### PR TITLE
Add integration tests, graceful shutdown, finalize v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [0.1.0] - 2026-02-05
 
 ### Added
 
-- Cargo workspace with 4 crates: zeph-core, zeph-llm, zeph-skills, zeph-memory
+#### M0: Workspace bootstrap
+- Cargo workspace with 5 crates: zeph-core, zeph-llm, zeph-skills, zeph-memory, zeph-channels
 - Binary entry point with version display
 - Default configuration file
 - Workspace-level dependency management and lints
+
+#### M1: LLM + CLI agent loop
 - LlmProvider trait with Message/Role types
 - Ollama backend using ollama-rs
 - Config loading from TOML with env var overrides
 - Interactive CLI agent loop with multi-turn conversation
+
+#### M2: Skills system
 - SKILL.md parser with YAML frontmatter and markdown body (zeph-skills)
 - Skill registry that scans directories for `*/SKILL.md` files
 - Prompt formatter with XML-like skill injection into system prompt
@@ -24,6 +29,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Multi-step execution loop with 3-iteration limit
 - 30-second timeout on shell commands
 - Context builder that combines base system prompt with skill instructions
+
+#### M3: Memory + Claude
 - SQLite conversation persistence with sqlx (zeph-memory)
 - Conversation history loading and message saving per session
 - Claude backend via Anthropic Messages API with 429 retry (zeph-llm)
@@ -33,6 +40,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - ZEPH_SQLITE_PATH env var override for database location
 - Provider factory in main.rs selecting Ollama or Claude from config
 - Memory integration into Agent with optional SqliteStore
+
+#### M4: Telegram channel
 - Channel trait abstraction for agent I/O (recv, send, send_typing)
 - CliChannel implementation reading stdin/stdout via tokio::task::spawn_blocking
 - TelegramChannel adapter using teloxide with mpsc-based message routing
@@ -43,9 +52,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - zeph-channels crate with teloxide 0.17 dependency
 - TelegramConfig in config.rs with TOML and env var support
 
+#### M5: Integration tests + release
+- Integration test suite: config, skills, memory, and agent end-to-end
+- MockProvider and MockChannel for agent testing without external dependencies
+- Graceful shutdown via tokio::sync::watch + tokio::signal (SIGINT/SIGTERM)
+- Ollama startup health check (warn-only, non-blocking)
+- README with installation, configuration, usage, and skills documentation
+
 ### Changed
 
 - Agent is now generic over both LlmProvider and Channel (`Agent<P, C>`)
 - Agent::new() accepts a Channel parameter instead of reading stdin directly
 - Agent::run() uses channel.recv()/send() instead of direct I/O
 - Agent calls channel.send_typing() before each LLM request
+- Agent::run() uses tokio::select! to race channel messages against shutdown signal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3738,6 +3738,7 @@ name = "zeph"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = "1.0"
 serde_yml = "0.0"
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite"] }
 teloxide = { version = "0.17", features = ["macros"] }
+tempfile = "3"
 thiserror = "2.0"
 tokio = { version = "1", features = ["full"] }
 toml = "0.9"
@@ -41,6 +42,13 @@ tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 zeph-channels = { path = "crates/zeph-channels" }
+zeph-core = { path = "crates/zeph-core" }
+zeph-llm = { path = "crates/zeph-llm" }
+zeph-memory = { path = "crates/zeph-memory" }
+zeph-skills = { path = "crates/zeph-skills" }
+
+[dev-dependencies]
+tempfile.workspace = true
 zeph-core = { path = "crates/zeph-core" }
 zeph-llm = { path = "crates/zeph-llm" }
 zeph-memory = { path = "crates/zeph-memory" }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,107 @@
 # Zeph
 
-Lightweight AI agent on Rust with hybrid inference, Telegram interface, and skills-first architecture.
+Lightweight AI agent in Rust with hybrid inference (Ollama / Claude), CLI and Telegram interfaces, and a skills-first architecture.
 
-> Work in progress
+## Features
+
+- **Hybrid LLM inference** -- local Ollama or cloud Claude via Anthropic API
+- **CLI and Telegram** -- interactive terminal by default, Telegram bot when token is set
+- **Skills system** -- drop `SKILL.md` files into `skills/` to extend agent capabilities
+- **Shell execution** -- agent extracts bash blocks from LLM responses and runs them
+- **SQLite memory** -- conversation persistence with configurable history limit
+- **Graceful shutdown** -- handles SIGINT/SIGTERM cleanly
+
+## Installation
+
+```bash
+cargo build --release
+```
+
+The binary is produced at `target/release/zeph`.
+
+## Configuration
+
+Zeph loads `config/default.toml` at startup and applies environment variable overrides.
+
+### Config file
+
+```toml
+[agent]
+name = "Zeph"
+
+[llm]
+provider = "ollama"
+base_url = "http://localhost:11434"
+model = "mistral:7b"
+
+[llm.cloud]
+model = "claude-sonnet-4-5-20250929"
+max_tokens = 4096
+
+[skills]
+paths = ["./skills"]
+
+[memory]
+sqlite_path = "./data/zeph.db"
+history_limit = 50
+```
+
+### Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `ZEPH_LLM_PROVIDER` | `ollama` or `claude` |
+| `ZEPH_LLM_BASE_URL` | Ollama API endpoint |
+| `ZEPH_LLM_MODEL` | Model name for Ollama |
+| `ZEPH_CLAUDE_API_KEY` | Anthropic API key (required for Claude) |
+| `ZEPH_TELEGRAM_TOKEN` | Telegram bot token (enables Telegram mode) |
+| `ZEPH_SQLITE_PATH` | SQLite database path |
+
+## Usage
+
+### CLI mode (default)
+
+```bash
+./target/release/zeph
+```
+
+Type messages at the `You:` prompt. Type `exit`, `quit`, or press Ctrl-D to stop.
+
+### Telegram mode
+
+Set `ZEPH_TELEGRAM_TOKEN` to your bot token:
+
+```bash
+ZEPH_TELEGRAM_TOKEN="123:ABC" ./target/release/zeph
+```
+
+Optionally restrict access via `telegram.allowed_users` in config.
+
+## Skills
+
+Create a directory under `skills/` with a `SKILL.md` file containing YAML frontmatter:
+
+```
+skills/
+  web-search/
+    SKILL.md
+  file-ops/
+    SKILL.md
+```
+
+`SKILL.md` format:
+
+```markdown
+---
+name: web-search
+description: Search the web for information.
+---
+# Instructions
+Use curl to fetch search results...
+```
+
+All loaded skills are injected into the system prompt.
+
+## License
+
+[MIT](LICENSE)

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -16,7 +16,7 @@ zeph-llm = { path = "../zeph-llm" }
 zeph-memory = { path = "../zeph-memory" }
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/zeph-llm/src/claude.rs
+++ b/crates/zeph-llm/src/claude.rs
@@ -196,7 +196,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore] // Requires ZEPH_CLAUDE_API_KEY env var
+    #[ignore = "requires ZEPH_CLAUDE_API_KEY env var"]
     async fn integration_claude_chat() {
         let api_key = std::env::var("ZEPH_CLAUDE_API_KEY")
             .expect("ZEPH_CLAUDE_API_KEY must be set");

--- a/crates/zeph-skills/Cargo.toml
+++ b/crates/zeph-skills/Cargo.toml
@@ -13,7 +13,7 @@ serde_yml.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,0 +1,262 @@
+use std::collections::VecDeque;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use zeph_core::agent::Agent;
+use zeph_core::channel::{Channel, ChannelMessage};
+use zeph_core::config::Config;
+use zeph_llm::provider::{LlmProvider, Message};
+use zeph_memory::sqlite::SqliteStore;
+use zeph_skills::loader::load_skill;
+use zeph_skills::registry::SkillRegistry;
+
+// -- Mock LLM Provider --
+
+struct MockProvider {
+    response: String,
+}
+
+impl MockProvider {
+    fn new(response: &str) -> Self {
+        Self {
+            response: response.to_string(),
+        }
+    }
+}
+
+impl LlmProvider for MockProvider {
+    async fn chat(&self, _messages: &[Message]) -> anyhow::Result<String> {
+        Ok(self.response.clone())
+    }
+
+    fn name(&self) -> &'static str {
+        "mock"
+    }
+}
+
+// -- Mock Channel --
+
+#[derive(Debug)]
+struct MockChannel {
+    inputs: VecDeque<String>,
+    outputs: Arc<Mutex<Vec<String>>>,
+}
+
+impl MockChannel {
+    fn new(inputs: Vec<&str>, outputs: Arc<Mutex<Vec<String>>>) -> Self {
+        Self {
+            inputs: inputs.into_iter().map(String::from).collect(),
+            outputs,
+        }
+    }
+}
+
+impl Channel for MockChannel {
+    async fn recv(&mut self) -> anyhow::Result<Option<ChannelMessage>> {
+        Ok(self
+            .inputs
+            .pop_front()
+            .map(|text| ChannelMessage { text }))
+    }
+
+    async fn send(&mut self, text: &str) -> anyhow::Result<()> {
+        self.outputs.lock().unwrap().push(text.to_string());
+        Ok(())
+    }
+}
+
+// -- Config tests --
+// Combined into one test to avoid env var races between parallel test threads.
+
+const ENV_KEYS: [&str; 5] = [
+    "ZEPH_LLM_PROVIDER",
+    "ZEPH_LLM_BASE_URL",
+    "ZEPH_LLM_MODEL",
+    "ZEPH_SQLITE_PATH",
+    "ZEPH_TELEGRAM_TOKEN",
+];
+
+fn clear_env() {
+    for key in ENV_KEYS {
+        unsafe { std::env::remove_var(key) };
+    }
+}
+
+#[test]
+fn config_defaults_and_env_overrides() {
+    clear_env();
+
+    let config = Config::load(Path::new("/nonexistent/config.toml")).unwrap();
+    assert_eq!(config.llm.provider, "ollama");
+    assert_eq!(config.llm.base_url, "http://localhost:11434");
+    assert_eq!(config.llm.model, "mistral:7b");
+    assert_eq!(config.agent.name, "Zeph");
+    assert_eq!(config.memory.history_limit, 50);
+
+    unsafe { std::env::set_var("ZEPH_LLM_MODEL", "test-model") };
+    let config = Config::load(Path::new("/nonexistent/config.toml")).unwrap();
+    unsafe { std::env::remove_var("ZEPH_LLM_MODEL") };
+    assert_eq!(config.llm.model, "test-model");
+}
+
+// -- Skills tests --
+
+#[test]
+fn skill_parse_valid() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("SKILL.md");
+    std::fs::write(
+        &path,
+        "---\nname: test-skill\ndescription: A test.\n---\n# Instructions\nDo stuff.",
+    )
+    .unwrap();
+
+    let skill = load_skill(&path).unwrap();
+    assert_eq!(skill.name, "test-skill");
+    assert_eq!(skill.description, "A test.");
+    assert!(skill.body.contains("Do stuff."));
+}
+
+#[test]
+fn skill_parse_invalid_no_frontmatter() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("SKILL.md");
+    std::fs::write(&path, "no frontmatter here").unwrap();
+    assert!(load_skill(&path).is_err());
+}
+
+#[test]
+fn skill_registry_scans_temp_dir() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let skill_dir = dir.path().join("alpha");
+    std::fs::create_dir(&skill_dir).unwrap();
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nname: alpha\ndescription: first\n---\nbody",
+    )
+    .unwrap();
+
+    let skill_dir2 = dir.path().join("beta");
+    std::fs::create_dir(&skill_dir2).unwrap();
+    std::fs::write(
+        skill_dir2.join("SKILL.md"),
+        "---\nname: beta\ndescription: second\n---\nbody",
+    )
+    .unwrap();
+
+    let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
+    assert_eq!(registry.all().len(), 2);
+}
+
+// -- Memory tests --
+
+#[tokio::test]
+async fn memory_save_load_roundtrip() {
+    let store = SqliteStore::new(":memory:").await.unwrap();
+    let cid = store.create_conversation().await.unwrap();
+
+    store.save_message(cid, "user", "hello").await.unwrap();
+    store
+        .save_message(cid, "assistant", "world")
+        .await
+        .unwrap();
+
+    let history = store.load_history(cid, 50).await.unwrap();
+    assert_eq!(history.len(), 2);
+    assert_eq!(history[0].content, "hello");
+    assert_eq!(history[1].content, "world");
+}
+
+#[tokio::test]
+async fn memory_history_limit() {
+    let store = SqliteStore::new(":memory:").await.unwrap();
+    let cid = store.create_conversation().await.unwrap();
+
+    for i in 0..20 {
+        store
+            .save_message(cid, "user", &format!("msg {i}"))
+            .await
+            .unwrap();
+    }
+
+    let history = store.load_history(cid, 5).await.unwrap();
+    assert_eq!(history.len(), 5);
+}
+
+#[tokio::test]
+async fn memory_conversation_isolation() {
+    let store = SqliteStore::new(":memory:").await.unwrap();
+    let cid1 = store.create_conversation().await.unwrap();
+    let cid2 = store.create_conversation().await.unwrap();
+
+    store.save_message(cid1, "user", "conv1").await.unwrap();
+    store.save_message(cid2, "user", "conv2").await.unwrap();
+
+    let h1 = store.load_history(cid1, 50).await.unwrap();
+    let h2 = store.load_history(cid2, 50).await.unwrap();
+
+    assert_eq!(h1.len(), 1);
+    assert_eq!(h1[0].content, "conv1");
+    assert_eq!(h2.len(), 1);
+    assert_eq!(h2[0].content, "conv2");
+}
+
+// -- Agent end-to-end tests --
+
+#[tokio::test]
+async fn agent_roundtrip_mock() {
+    let provider = MockProvider::new("mock response");
+    let outputs = Arc::new(Mutex::new(Vec::new()));
+    let channel = MockChannel::new(vec!["hello"], outputs.clone());
+
+    let mut agent = Agent::new(provider, channel, "");
+    agent.run().await.unwrap();
+
+    let collected = outputs.lock().unwrap();
+    assert_eq!(collected.len(), 1);
+    assert_eq!(collected[0], "mock response");
+}
+
+#[tokio::test]
+async fn agent_multiple_messages() {
+    let provider = MockProvider::new("reply");
+    let outputs = Arc::new(Mutex::new(Vec::new()));
+    let channel = MockChannel::new(vec!["first", "second", "third"], outputs.clone());
+
+    let mut agent = Agent::new(provider, channel, "");
+    agent.run().await.unwrap();
+
+    let collected = outputs.lock().unwrap();
+    assert_eq!(collected.len(), 3);
+    assert!(collected.iter().all(|o| o == "reply"));
+}
+
+#[tokio::test]
+async fn agent_with_memory() {
+    let provider = MockProvider::new("remembered");
+    let outputs = Arc::new(Mutex::new(Vec::new()));
+    let channel = MockChannel::new(vec!["save this"], outputs.clone());
+
+    let store = SqliteStore::new(":memory:").await.unwrap();
+    let cid = store.create_conversation().await.unwrap();
+
+    let mut agent = Agent::new(provider, channel, "")
+        .with_memory(store, cid, 50);
+    agent.run().await.unwrap();
+}
+
+#[tokio::test]
+async fn agent_shutdown_via_watch() {
+    let provider = MockProvider::new("should not appear");
+    let outputs = Arc::new(Mutex::new(Vec::new()));
+    let channel = MockChannel::new(vec![], outputs.clone());
+
+    let (tx, rx) = tokio::sync::watch::channel(false);
+
+    let mut agent = Agent::new(provider, channel, "").with_shutdown(rx);
+
+    let _ = tx.send(true);
+
+    agent.run().await.unwrap();
+}


### PR DESCRIPTION
## Summary

- 11 integration tests with MockProvider/MockChannel for end-to-end agent verification
- Graceful shutdown via `tokio::signal` + `watch` channel (SIGTERM/SIGINT)
- Ollama health check on startup (warn if unreachable)
- Complete README: installation, configuration, CLI/Telegram usage, skills
- CHANGELOG finalized as v0.1.0

## Test plan

- [x] 55 tests pass (`cargo test --workspace`)
- [x] Zero clippy warnings (`cargo clippy --workspace --tests -- -D warnings`)
- [x] Agent roundtrip with mock provider/channel verified
- [x] Shutdown via watch channel tested
- [x] README sections complete, no placeholders

Closes #23, closes #24