### PR TITLE
Move dependency features from workspace root to crate manifests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,15 +11,15 @@ repository = "https://github.com/bug-ops/zeph"
 [workspace.dependencies]
 anyhow = "1.0"
 ollama-rs = "0.3"
-reqwest = { version = "0.13", features = ["json"] }
-serde = { version = "1.0", features = ["derive"] }
+reqwest = "0.13"
+serde = "1.0"
 serde_json = "1.0"
 serde_yml = "0.0"
-sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite"] }
-teloxide = { version = "0.17", features = ["macros"] }
+sqlx = "0.8"
+teloxide = "0.17"
 tempfile = "3"
 thiserror = "2.0"
-tokio = { version = "1", features = ["full"] }
+tokio = "1"
 toml = "0.9"
 tracing = "0.1"
 tracing-subscriber = "0.3"
@@ -38,7 +38,7 @@ repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 zeph-channels = { path = "crates/zeph-channels" }

--- a/crates/zeph-channels/Cargo.toml
+++ b/crates/zeph-channels/Cargo.toml
@@ -8,8 +8,8 @@ repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-teloxide.workspace = true
-tokio.workspace = true
+teloxide = { workspace = true, features = ["macros"] }
+tokio = { workspace = true, features = ["sync", "rt"] }
 tracing.workspace = true
 zeph-core = { path = "../zeph-core" }
 

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -8,8 +8,8 @@ repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-serde.workspace = true
-tokio.workspace = true
+serde = { workspace = true, features = ["derive"] }
+tokio = { workspace = true, features = ["full"] }
 toml.workspace = true
 tracing.workspace = true
 zeph-llm = { path = "../zeph-llm" }

--- a/crates/zeph-llm/Cargo.toml
+++ b/crates/zeph-llm/Cargo.toml
@@ -9,10 +9,10 @@ repository.workspace = true
 [dependencies]
 anyhow.workspace = true
 ollama-rs.workspace = true
-reqwest.workspace = true
-serde.workspace = true
+reqwest = { workspace = true, features = ["json"] }
+serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt", "time"] }
 tracing.workspace = true
 
 [lints]

--- a/crates/zeph-memory/Cargo.toml
+++ b/crates/zeph-memory/Cargo.toml
@@ -8,8 +8,8 @@ repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-sqlx.workspace = true
-tokio.workspace = true
+sqlx = { workspace = true, features = ["runtime-tokio", "sqlite"] }
+tokio = { workspace = true, features = ["rt"] }
 tracing.workspace = true
 zeph-llm = { path = "../zeph-llm" }
 

--- a/crates/zeph-skills/Cargo.toml
+++ b/crates/zeph-skills/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-serde.workspace = true
+serde = { workspace = true, features = ["derive"] }
 serde_yml.workspace = true
 tracing.workspace = true
 


### PR DESCRIPTION
## Summary

- Workspace `[workspace.dependencies]` now declares version only (no features)
- Each crate specifies the exact features it needs in its own `Cargo.toml`
- Reduces implicit coupling: crates declare their own requirements

## Changes

| Dependency | Features | Moved to |
|-----------|----------|----------|
| `serde` | `derive` | zeph-core, zeph-llm, zeph-skills |
| `tokio` | `full` | zeph-core, root; `rt`+`time` for zeph-llm; `rt` for zeph-memory; `sync`+`rt` for zeph-channels |
| `reqwest` | `json` | zeph-llm |
| `sqlx` | `runtime-tokio`, `sqlite` | zeph-memory |
| `teloxide` | `macros` | zeph-channels |

## Test plan

- [x] 55 tests pass
- [x] Zero clippy warnings