### PR TITLE
M6 Phase 1: Add streaming trait extension (breaking changes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+
+#### M6 Phase 1: Streaming trait extension (Issue #35)
+- `LlmProvider::chat_stream()` method returning `Pin<Box<dyn Stream<Item = Result<String>> + Send>>`
+- `LlmProvider::supports_streaming()` capability query method
+- `Channel::send_chunk()` method for incremental response delivery
+- `Channel::flush_chunks()` method for buffered chunk flushing
+- `ChatStream` type alias for `Pin<Box<dyn Stream<Item = anyhow::Result<String>> + Send>>`
+- Streaming infrastructure in zeph-llm and zeph-core (dependencies: futures-core 0.3, tokio-stream 0.1)
+
+### Changed
+
+**BREAKING CHANGES** (pre-1.0.0):
+- `LlmProvider` trait now requires `chat_stream()` and `supports_streaming()` implementations (no default implementations per project policy)
+- `Channel` trait now requires `send_chunk()` and `flush_chunks()` implementations (no default implementations per project policy)
+- All existing providers (`OllamaProvider`, `ClaudeProvider`) updated with fallback implementations (Phase 1 non-streaming: calls `chat()` and wraps in single-item stream)
+- All existing channels (`CliChannel`, `TelegramChannel`) updated with no-op implementations (Phase 1: streaming not yet wired into agent loop)
+
 ## [0.1.0] - 2026-02-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3537,6 +3537,7 @@ dependencies = [
  "anyhow",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tracing-subscriber",
  "zeph-channels",
@@ -3576,11 +3577,13 @@ name = "zeph-llm"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "futures-core",
  "ollama-rs",
  "reqwest 0.13.1",
  "serde",
  "serde_json",
  "tokio",
+ "tokio-stream",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/bug-ops/zeph"
 
 [workspace.dependencies]
 anyhow = "1.0"
+futures-core = "0.3"
 ollama-rs = { version = "0.3", default-features = false, features = ["rustls"] }
 reqwest = { version = "0.13", default-features = false }
 serde = "1.0"
@@ -20,6 +21,7 @@ teloxide = { version = "0.17", default-features = false, features = ["rustls", "
 tempfile = "3"
 thiserror = "2.0"
 tokio = "1"
+tokio-stream = "0.1"
 toml = "0.9"
 tracing = "0.1"
 tracing-subscriber = "0.3"
@@ -49,6 +51,7 @@ zeph-skills = { path = "crates/zeph-skills" }
 
 [dev-dependencies]
 tempfile.workspace = true
+tokio-stream.workspace = true
 zeph-core = { path = "crates/zeph-core" }
 zeph-llm = { path = "crates/zeph-llm" }
 zeph-memory = { path = "crates/zeph-memory" }

--- a/crates/zeph-channels/src/telegram.rs
+++ b/crates/zeph-channels/src/telegram.rs
@@ -154,6 +154,14 @@ impl Channel for TelegramChannel {
         Ok(())
     }
 
+    async fn send_chunk(&mut self, _chunk: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn flush_chunks(&mut self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     async fn send_typing(&mut self) -> anyhow::Result<()> {
         let Some(chat_id) = self.chat_id else {
             return Ok(());

--- a/crates/zeph-llm/Cargo.toml
+++ b/crates/zeph-llm/Cargo.toml
@@ -8,12 +8,17 @@ repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+futures-core.workspace = true
 ollama-rs.workspace = true
 reqwest = { workspace = true, features = ["json", "rustls"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["rt", "time"] }
+tokio-stream.workspace = true
 tracing.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/crates/zeph-llm/src/any.rs
+++ b/crates/zeph-llm/src/any.rs
@@ -1,6 +1,6 @@
 use crate::claude::ClaudeProvider;
 use crate::ollama::OllamaProvider;
-use crate::provider::{LlmProvider, Message};
+use crate::provider::{ChatStream, LlmProvider, Message};
 
 #[derive(Debug)]
 pub enum AnyProvider {
@@ -13,6 +13,20 @@ impl LlmProvider for AnyProvider {
         match self {
             Self::Ollama(p) => p.chat(messages).await,
             Self::Claude(p) => p.chat(messages).await,
+        }
+    }
+
+    async fn chat_stream(&self, messages: &[Message]) -> anyhow::Result<ChatStream> {
+        match self {
+            Self::Ollama(p) => p.chat_stream(messages).await,
+            Self::Claude(p) => p.chat_stream(messages).await,
+        }
+    }
+
+    fn supports_streaming(&self) -> bool {
+        match self {
+            Self::Ollama(p) => p.supports_streaming(),
+            Self::Claude(p) => p.supports_streaming(),
         }
     }
 

--- a/crates/zeph-llm/src/claude.rs
+++ b/crates/zeph-llm/src/claude.rs
@@ -85,6 +85,18 @@ impl LlmProvider for ClaudeProvider {
         }
     }
 
+    async fn chat_stream(
+        &self,
+        messages: &[Message],
+    ) -> anyhow::Result<crate::provider::ChatStream> {
+        let response = self.chat(messages).await?;
+        Ok(Box::pin(tokio_stream::once(Ok(response))))
+    }
+
+    fn supports_streaming(&self) -> bool {
+        false
+    }
+
     fn name(&self) -> &'static str {
         "claude"
     }

--- a/crates/zeph-llm/src/ollama.rs
+++ b/crates/zeph-llm/src/ollama.rs
@@ -50,6 +50,18 @@ impl LlmProvider for OllamaProvider {
         Ok(response.message.content)
     }
 
+    async fn chat_stream(
+        &self,
+        messages: &[Message],
+    ) -> anyhow::Result<crate::provider::ChatStream> {
+        let response = self.chat(messages).await?;
+        Ok(Box::pin(tokio_stream::once(Ok(response))))
+    }
+
+    fn supports_streaming(&self) -> bool {
+        false
+    }
+
     fn name(&self) -> &'static str {
         "ollama"
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,20 @@ impl Channel for AnyChannel {
         }
     }
 
+    async fn send_chunk(&mut self, chunk: &str) -> anyhow::Result<()> {
+        match self {
+            Self::Cli(c) => c.send_chunk(chunk).await,
+            Self::Telegram(c) => c.send_chunk(chunk).await,
+        }
+    }
+
+    async fn flush_chunks(&mut self) -> anyhow::Result<()> {
+        match self {
+            Self::Cli(c) => c.flush_chunks().await,
+            Self::Telegram(c) => c.flush_chunks().await,
+        }
+    }
+
     async fn send_typing(&mut self) -> anyhow::Result<()> {
         match self {
             Self::Cli(c) => c.send_typing().await,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -29,6 +29,18 @@ impl LlmProvider for MockProvider {
         Ok(self.response.clone())
     }
 
+    async fn chat_stream(
+        &self,
+        messages: &[Message],
+    ) -> anyhow::Result<zeph_llm::provider::ChatStream> {
+        let response = self.chat(messages).await?;
+        Ok(Box::pin(tokio_stream::once(Ok(response))))
+    }
+
+    fn supports_streaming(&self) -> bool {
+        false
+    }
+
     fn name(&self) -> &'static str {
         "mock"
     }
@@ -58,6 +70,14 @@ impl Channel for MockChannel {
 
     async fn send(&mut self, text: &str) -> anyhow::Result<()> {
         self.outputs.lock().unwrap().push(text.to_string());
+        Ok(())
+    }
+
+    async fn send_chunk(&mut self, _chunk: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn flush_chunks(&mut self) -> anyhow::Result<()> {
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Extends `LlmProvider` and `Channel` traits with streaming support primitives for M6 Phase 1.

**BREAKING CHANGES**: Per project policy (pre-v1.0.0), no default implementations provided. All existing providers and channels updated with explicit implementations.

## Changes

### Traits

- **`LlmProvider::chat_stream()`**: Returns `ChatStream` (type alias for `Pin<Box<dyn Stream<Item = Result<String>> + Send>>`)
- **`LlmProvider::supports_streaming()`**: Capability query returning `bool`
- **`Channel::send_chunk()`**: Incremental chunk delivery
- **`Channel::flush_chunks()`**: Flush buffered chunks

### Implementations

All existing implementations updated:

- **`OllamaProvider`**: Fallback to `chat()`, wraps response in single-item stream (Phase 1 non-streaming)
- **`ClaudeProvider`**: Fallback to `chat()`, wraps response in single-item stream (Phase 1 non-streaming)
- **`CliChannel`**: No-op implementations (streaming not wired into agent loop yet)
- **`TelegramChannel`**: No-op implementations (streaming not wired into agent loop yet)

### Dependencies

- `futures-core` 0.3 (Stream trait)
- `tokio-stream` 0.1 (stream combinators)

Both were already transitive dependencies (zero build impact).

## Acceptance Criteria

- [x] `LlmProvider::chat_stream()` returns token stream
- [x] `Channel::send_chunk()` for incremental delivery
- [x] No default implementations (breaking changes per project policy)
- [x] Existing code updated (all providers/channels implement new methods)
- [x] All tests pass (11/11)
- [x] Clippy clean (zero warnings)
- [x] Formatting clean
- [x] Breaking changes documented in CHANGELOG.md

## Roadmap

Phase 1 provides **trait signatures only**. Native streaming will be implemented in subsequent phases:

- Phase 2 (Issue #36): Ollama streaming backend
- Phase 3 (Issue #37): Claude SSE streaming backend
- Phase 4 (Issue #38): Agent streaming integration

## Related

- Epic: #33 (M6: Streaming + Response Quality)
- Issue: #35 (Streaming trait extension)
- ADR-014: Use `Pin<Box<dyn Stream>>` for enum dispatch (in `.local/plan/architecture-v2.md`)