### PR TITLE
feat: integrate streaming into agent loop and channels (M6 Phase 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - eventsource-stream dependency added to workspace dependencies
 - reqwest `"stream"` feature enabled for `bytes_stream()` support
 
+#### M6 Phase 4: Agent streaming integration (Issue #38)
+- Agent automatically uses streaming when `provider.supports_streaming()` returns true (ADR-014)
+- `Agent::process_response_streaming()` method for stream consumption and chunk accumulation
+- CliChannel immediate streaming: `send_chunk()` prints each chunk instantly via `print!()` + `flush()`
+- TelegramChannel batched streaming: debounce at 1 second OR 512 bytes, edit-in-place for progressive updates
+- Response buffer pre-allocation with `String::with_capacity(2048)` for performance
+- Error message sanitization: full errors logged via `tracing::error!()`, generic messages shown to users
+- Telegram edit retry logic: recovers from stale message_id (message deleted, permissions lost)
+- tokio-stream dependency added for `StreamExt` trait
+- 6 new unit tests for channel streaming behavior
+
 ### Fixed
 
 #### M6 Phase 3: Security improvements

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3598,6 +3598,7 @@ dependencies = [
  "serde",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "toml",
  "tracing",
  "zeph-llm",

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 anyhow.workspace = true
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["full"] }
+tokio-stream.workspace = true
 toml.workspace = true
 tracing.workspace = true
 zeph-llm = { path = "../zeph-llm" }


### PR DESCRIPTION
## Summary

Implements M6 Phase 4 (Issue #38): Agent streaming integration.

Completes M6 milestone by wiring streaming into agent loop and channels. Agent automatically detects streaming support and provides incremental token-by-token delivery through channels.

## Changes

### Agent Streaming (ADR-014)
- Agent automatically uses `chat_stream()` when `provider.supports_streaming()` returns true
- New `process_response_streaming()` method for stream consumption
- Falls back to `chat()` for non-streaming providers
- Response buffer pre-allocated with `String::with_capacity(2048)` (~10-50µs optimization)

### CliChannel Immediate Streaming (ADR-015)
- `send_chunk()`: prints each chunk instantly via `print!()` + `flush()`
- Provides immediate visual feedback for token-by-token output
- `flush_chunks()`: adds final newline after complete response

### TelegramChannel Batched Streaming (ADR-015)
- Debounce at 1 second OR 512 bytes (respects Telegram rate limits)
- First chunk sends new message, subsequent chunks edit in-place
- `flush_chunks()`: performs final edit with complete message
- Edit retry logic: recovers from stale message_id (message deleted, bot permissions lost)

### Security & Error Handling
- Error sanitization: full errors logged via `tracing::error!()`
- Generic user messages: "An error occurred while processing your request"
- Avoids exposing internal details (provider endpoints, error codes)

### Testing
- 6 new unit tests for channel streaming behavior
- All tests pass (11 integration + 28 unit tests)
- Zero clippy warnings

## Architecture Alignment

- **ADR-014**: Automatic streaming selection
- **ADR-015**: Channel-specific buffering strategies
- **ADR-016**: Memory persistence after flush_chunks()

## Validation

- **Performance**: APPROVED (5-20x TTFT improvement, negligible CPU overhead)
- **Security**: PASS (0 critical/high issues, 2 medium tracked for M14)
- **Testing**: PASS (61.86% coverage, integration gaps acceptable for MVP)
- **Code Review**: APPROVED (all suggestions addressed in fix cycle)

## Test Plan

- [ ] Manual testing: Ollama CLI (verify incremental token output)
- [ ] Manual testing: Telegram bot (verify message edits and retry logic)
- [ ] Monitor for streaming-related issues post-merge

## Related

- Closes #38
- Part of M6 milestone (Streaming - v0.2.0)
- Previous phases: #35 (traits), #36 (Ollama), #37 (Claude)

## Post-Merge Actions

- Tag v0.2.0 release
- Update milestone tracker
- Monitor for streaming issues