### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-02-06
+
 ### Added
 
 #### M6 Phase 1: Streaming trait extension (Issue #35)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3564,7 +3564,7 @@ dependencies = [
 
 [[package]]
 name = "zeph"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -3581,7 +3581,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-channels"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "teloxide",
@@ -3592,7 +3592,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -3607,7 +3607,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-llm"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "eventsource-stream",
@@ -3623,7 +3623,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-memory"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "sqlx",
@@ -3634,7 +3634,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-skills"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ pedantic = "warn"
 
 [package]
 name = "zeph"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/zeph-channels/Cargo.toml
+++ b/crates/zeph-channels/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeph-channels"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeph-core"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/zeph-llm/Cargo.toml
+++ b/crates/zeph-llm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeph-llm"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/zeph-memory/Cargo.toml
+++ b/crates/zeph-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeph-memory"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/zeph-skills/Cargo.toml
+++ b/crates/zeph-skills/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeph-skills"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

Bump all workspace crates to version 0.2.0 after completing M6 streaming milestone.

## Changes

- Update root package version to 0.2.0
- Update all 5 crate versions (zeph-core, zeph-llm, zeph-skills, zeph-memory, zeph-channels) to 0.2.0
- Update CHANGELOG.md: mark [Unreleased] changes as [0.2.0] - 2026-02-06
- Update Cargo.lock with new versions

## Milestone

Closes #33 (M6: Streaming)

## Verification

- [ ] All manifests updated to 0.2.0
- [ ] CHANGELOG.md reflects release date
- [ ] Cargo.lock updated
- [ ] Build succeeds