### PR TITLE
M7 Phase 2: Command safety - whitelist/blacklist (#40)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3603,6 +3603,7 @@ dependencies = [
  "tracing",
  "zeph-llm",
  "zeph-memory",
+ "zeph-tools",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ zeph-core = { path = "crates/zeph-core", version = "0.2.0" }
 zeph-llm = { path = "crates/zeph-llm", version = "0.2.0" }
 zeph-memory = { path = "crates/zeph-memory", version = "0.2.0" }
 zeph-skills = { path = "crates/zeph-skills", version = "0.2.0" }
+zeph-tools = { path = "crates/zeph-tools", version = "0.2.0" }
 
 [workspace.lints.clippy]
 all = "warn"

--- a/config/default.toml
+++ b/config/default.toml
@@ -16,3 +16,10 @@ paths = ["./skills"]
 [memory]
 sqlite_path = "./data/zeph.db"
 history_limit = 50
+
+[tools]
+enabled = true
+
+[tools.shell]
+timeout = 30
+blocked_commands = []

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -15,6 +15,7 @@ toml.workspace = true
 tracing.workspace = true
 zeph-llm.workspace = true
 zeph-memory.workspace = true
+zeph-tools.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true


### PR DESCRIPTION
Part of #34 (M7: Tool Execution Framework)

## What's in this PR

**Phase 2**: Command filtering infrastructure in `zeph-tools`

### Changes

- **ShellExecutor blocking logic**: `DEFAULT_BLOCKED` const with 12 patterns
  - Destructive operations: `rm -rf /`, `sudo`, `mkfs`, `dd if=`
  - Network exfiltration: `curl`, `wget`, `nc `, `ncat`, `netcat`
  - System control: `shutdown`, `reboot`, `halt`
- **Case-insensitive matching**: `to_lowercase()` normalization prevents bypass
- **User config additive**: Custom blocked commands merge with defaults
- **Config integration**: `[tools]` and `[tools.shell]` sections in `config/default.toml`
- **zeph-core integration**: `tools: ToolsConfig` field with `ZEPH_TOOLS_TIMEOUT` env override

### Testing

- 5 new tests in `shell.rs`: network exfiltration, system control, nc trailing space, mixed-case dedup
- 41/41 zeph-tools tests pass
- 27/27 zeph-core tests pass
- Zero clippy warnings

### Validation

- **Performance**: APPROVED (blocking < 100ns)
- **Security**: 2 IMPORTANT issues fixed (DEFAULT_BLOCKED extended, user pattern normalization)
- **Testing**: 99.4% coverage

### Known Limitations

- **SEC-001**: ShellExecutor not yet wired into agent loop → **Phase 3 (Issue #41)** will integrate
- **SEC-003**: Shell metacharacter bypass (variable expansion, base64) → **M14** per ADR-015

## Closes

#40

## Related

- Epic: #34
- Architecture: ADR-015
- Next: #41 (M7 Phase 3: Agent integration)