### PR TITLE
Release v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3564,7 +3564,7 @@ dependencies = [
 
 [[package]]
 name = "zeph"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -3582,7 +3582,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-channels"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "teloxide",
@@ -3593,7 +3593,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -3609,7 +3609,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-llm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "eventsource-stream",
@@ -3625,7 +3625,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-memory"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "sqlx",
@@ -3636,7 +3636,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-skills"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -3645,7 +3645,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-tools"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 rust-version = "1.88"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["bug-ops"]
 license = "MIT"
 repository = "https://github.com/bug-ops/zeph"
@@ -27,12 +27,12 @@ tokio-stream = "0.1"
 toml = "0.9"
 tracing = "0.1"
 tracing-subscriber = "0.3"
-zeph-channels = { path = "crates/zeph-channels", version = "0.2.0" }
-zeph-core = { path = "crates/zeph-core", version = "0.2.0" }
-zeph-llm = { path = "crates/zeph-llm", version = "0.2.0" }
-zeph-memory = { path = "crates/zeph-memory", version = "0.2.0" }
-zeph-skills = { path = "crates/zeph-skills", version = "0.2.0" }
-zeph-tools = { path = "crates/zeph-tools", version = "0.2.0" }
+zeph-channels = { path = "crates/zeph-channels", version = "0.3.0" }
+zeph-core = { path = "crates/zeph-core", version = "0.3.0" }
+zeph-llm = { path = "crates/zeph-llm", version = "0.3.0" }
+zeph-memory = { path = "crates/zeph-memory", version = "0.3.0" }
+zeph-skills = { path = "crates/zeph-skills", version = "0.3.0" }
+zeph-tools = { path = "crates/zeph-tools", version = "0.3.0" }
 
 [workspace.lints.clippy]
 all = "warn"

--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ paths = ["./skills"]
 [memory]
 sqlite_path = "./data/zeph.db"
 history_limit = 50
+
+[tools]
+enabled = true
+
+[tools.shell]
+timeout = 30
+blocked_commands = []  # Additional patterns beyond defaults
 ```
 
 ### Environment variables
@@ -83,6 +90,10 @@ history_limit = 50
 | `ZEPH_CLAUDE_API_KEY` | Anthropic API key (required for Claude) |
 | `ZEPH_TELEGRAM_TOKEN` | Telegram bot token (enables Telegram mode) |
 | `ZEPH_SQLITE_PATH` | SQLite database path |
+| `ZEPH_TOOLS_TIMEOUT` | Shell command timeout in seconds (default: 30) |
+
+> [!IMPORTANT]
+> Shell commands are filtered for safety. Dangerous commands (`rm -rf /`, `sudo`, `mkfs`, `dd`, `curl`, `wget`, `nc`, `shutdown`) are blocked by default. Add custom patterns via `tools.shell.blocked_commands` in config.
 
 ## Skills
 


### PR DESCRIPTION
## Summary

Version bump to v0.3.0 for M7 Tool Execution Framework release.

## Changes

### Version Updates
- Workspace version: `0.2.0` → `0.3.0`
- All internal crate dependencies updated to `0.3.0`

### CHANGELOG.md
- Moved `[Unreleased]` content to `[0.3.0] - 2026-02-07`
- Added comprehensive M7 Phase 2 (command safety) documentation
- Documented all three M7 phases: ToolExecutor trait, command filtering, agent integration

### README.md
- Added `[tools]` configuration section
- Added `[tools.shell]` with `timeout` and `blocked_commands` fields
- Added `ZEPH_TOOLS_TIMEOUT` environment variable
- Added security callout for command filtering (dangerous patterns blocked by default)

### M7 Milestone Complete

Epic #34 closed with all acceptance criteria met:

**Phase 1**: zeph-tools crate with ToolExecutor trait (#39 → PR #47)
**Phase 2**: Command safety with DEFAULT_BLOCKED patterns (#40 → PR #48)  
**Phase 3**: Agent integration, SEC-001 CRITICAL fixed (#41 → PR #49)

All 24 tests passing, zero clippy warnings, release build successful.

## Checklist

- [x] Version updated in workspace Cargo.toml
- [x] All internal dependencies updated
- [x] CHANGELOG.md updated with release date
- [x] README.md reflects new features
- [x] All tests pass (24/24)
- [x] Clippy clean (zero warnings)
- [x] Release build successful