### PR TITLE
Release v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4466,7 +4466,7 @@ dependencies = [
 
 [[package]]
 name = "zeph"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-channels"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "teloxide",
@@ -4495,7 +4495,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -4511,7 +4511,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-llm"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "eventsource-stream",
@@ -4527,7 +4527,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-memory"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "qdrant-client",
@@ -4543,7 +4543,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-skills"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -4552,7 +4552,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-tools"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 rust-version = "1.88"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["bug-ops"]
 license = "MIT"
 repository = "https://github.com/bug-ops/zeph"
@@ -30,12 +30,12 @@ toml = "0.9"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 uuid = "1.20"
-zeph-channels = { path = "crates/zeph-channels", version = "0.3.0" }
-zeph-core = { path = "crates/zeph-core", version = "0.3.0" }
-zeph-llm = { path = "crates/zeph-llm", version = "0.3.0" }
-zeph-memory = { path = "crates/zeph-memory", version = "0.3.0" }
-zeph-skills = { path = "crates/zeph-skills", version = "0.3.0" }
-zeph-tools = { path = "crates/zeph-tools", version = "0.3.0" }
+zeph-channels = { path = "crates/zeph-channels", version = "0.4.0" }
+zeph-core = { path = "crates/zeph-core", version = "0.4.0" }
+zeph-llm = { path = "crates/zeph-llm", version = "0.4.0" }
+zeph-memory = { path = "crates/zeph-memory", version = "0.4.0" }
+zeph-skills = { path = "crates/zeph-skills", version = "0.4.0" }
+zeph-tools = { path = "crates/zeph-tools", version = "0.4.0" }
 
 [workspace.lints.clippy]
 all = "warn"


### PR DESCRIPTION
## Summary

Minor version release adding M9 Semantic Memory milestone with three phases: Qdrant vector storage integration, semantic memory orchestration, and conversation summarization with context budget management.

## Changes

### Version Update
- Bump workspace version from 0.3.0 to 0.4.0
- Update all zeph-* crate versions in workspace dependencies
- Regenerate Cargo.lock with updated versions

### M9 Phase 1: Qdrant Integration (Issue #60)
- New QdrantStore module for vector storage and similarity search
- SQLite migration 002_embeddings_metadata.sql for embedding tracking
- Docker Compose Qdrant service integration
- Integration and unit tests with 98% coverage

### M9 Phase 2: Semantic Memory Integration (Issue #61)
- SemanticMemory orchestrator coordinating SQLite, Qdrant, and LlmProvider
- Agent integration with semantic recall in context builder
- Graceful degradation when Qdrant unavailable
- Generic provider pattern for Edition 2024 async trait compatibility
- 18 new tests for semantic memory operations

### M9 Phase 3: Conversation Summarization and Context Budget (Issue #62)
- LLM-based conversation compression with automatic triggering
- SQLite migration 003_summaries.sql for summary storage
- ContextBudget for proportional token allocation (15% summaries, 25% recall, 60% recent)
- Configuration via TOML and environment variables
- 26 new unit tests, 4 ADRs (ADR-016 through ADR-019)

### Documentation
- Updated README with semantic memory setup instructions
- Added conversation summarization documentation
- Updated configuration examples and environment variables
- Updated architecture diagram with new capabilities
- Comprehensive CHANGELOG entries for all M9 phases

## Test Coverage
- 196 total tests (26 new in Phase 3, 18 in Phase 2, 12 in Phase 1)
- 75.31% overall coverage
- Zero clippy warnings with -D warnings
- All automated checks passing

## Breaking Changes

Pre-1.0.0 breaking changes documented in CHANGELOG:
- SqliteStore::save_message() returns Result<i64> instead of Result<()>
- SqliteStore::new() uses sqlx::migrate!() macro
- QdrantStore::store() requires model parameter
- OllamaProvider::new() accepts embedding_model parameter
- Config constant LLM_ENV_KEYS renamed to ENV_KEYS

## Review Notes
- All Phase 3 review issues resolved (re-review approved)
- DRY violation fixed: estimate_tokens() in single location
- Migration 004_fix_cascade.sql properly adds CASCADE constraints
- Foreign keys enabled in SqliteStore via SqliteConnectOptions

## Checklist
- [x] Version updated in all manifests
- [x] CHANGELOG.md updated with all M9 phases
- [x] README.md updated with new features
- [x] All tests passing (196 tests)
- [x] Zero clippy warnings
- [x] Cargo.lock regenerated
- [x] Documentation complete