### PR TITLE
Release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-02-08
+
+### Fixed
+- Auto-create Qdrant collection on first use. Previously, the `zeph_conversations` collection had to be manually created using curl commands. Now, `ensure_collection()` is called automatically before all Qdrant operations (remember, recall, summarize) to initialize the collection with correct vector dimensions (896 for qwen3-embedding) and Cosine distance metric on first access, similar to SQL migrations.
+
+### Changed
+- Docker Compose: Added environment variables for semantic memory configuration (`ZEPH_MEMORY_SEMANTIC_ENABLED`, `ZEPH_MEMORY_SEMANTIC_RECALL_LIMIT`) and Qdrant URL override (`ZEPH_QDRANT_URL`) to enable full semantic memory stack via `.env` file
+
 ## [0.4.0] - 2026-02-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4507,7 +4507,7 @@ dependencies = [
 
 [[package]]
 name = "zeph"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -4525,7 +4525,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-channels"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "teloxide",
@@ -4536,7 +4536,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "serde",
@@ -4553,7 +4553,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-llm"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "eventsource-stream",
@@ -4569,7 +4569,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-memory"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "qdrant-client",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-skills"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -4594,7 +4594,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-tools"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "serde",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 rust-version = "1.88"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["bug-ops"]
 license = "MIT"
 repository = "https://github.com/bug-ops/zeph"
@@ -31,12 +31,12 @@ toml = "0.9"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 uuid = "1.20"
-zeph-channels = { path = "crates/zeph-channels", version = "0.4.0" }
-zeph-core = { path = "crates/zeph-core", version = "0.4.0" }
-zeph-llm = { path = "crates/zeph-llm", version = "0.4.0" }
-zeph-memory = { path = "crates/zeph-memory", version = "0.4.0" }
-zeph-skills = { path = "crates/zeph-skills", version = "0.4.0" }
-zeph-tools = { path = "crates/zeph-tools", version = "0.4.0" }
+zeph-channels = { path = "crates/zeph-channels", version = "0.4.1" }
+zeph-core = { path = "crates/zeph-core", version = "0.4.1" }
+zeph-llm = { path = "crates/zeph-llm", version = "0.4.1" }
+zeph-memory = { path = "crates/zeph-memory", version = "0.4.1" }
+zeph-skills = { path = "crates/zeph-skills", version = "0.4.1" }
+zeph-tools = { path = "crates/zeph-tools", version = "0.4.1" }
 
 [workspace.lints.clippy]
 all = "warn"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ docker pull ghcr.io/bug-ops/zeph:latest
 Or use a specific version:
 
 ```bash
-docker pull ghcr.io/bug-ops/zeph:v0.4.0
+docker pull ghcr.io/bug-ops/zeph:v0.4.1
 ```
 
 **Security:** Images are scanned with [Trivy](https://trivy.dev/) and use Oracle Linux 9 Slim base with **0 HIGH/CRITICAL CVEs**. Multi-platform: linux/amd64, linux/arm64.
@@ -191,11 +191,13 @@ Zeph supports optional integration with [Qdrant](https://qdrant.tech/) for seman
    recall_limit = 5
    ```
 
-3. **Automatic embedding:** Messages are embedded asynchronously using the configured `embedding_model` and stored in Qdrant alongside SQLite.
+3. **Automatic setup:** Qdrant collection (`zeph_conversations`) is created automatically on first use with correct vector dimensions (896 for `qwen3-embedding`) and Cosine distance metric. No manual initialization required.
 
-4. **Semantic recall:** Context builder injects semantically relevant messages from full history, not just recent messages.
+4. **Automatic embedding:** Messages are embedded asynchronously using the configured `embedding_model` and stored in Qdrant alongside SQLite.
 
-5. **Graceful degradation:** If Qdrant is unavailable, Zeph falls back to SQLite-only mode (recency-based history).
+5. **Semantic recall:** Context builder injects semantically relevant messages from full history, not just recent messages.
+
+6. **Graceful degradation:** If Qdrant is unavailable, Zeph falls back to SQLite-only mode (recency-based history).
 
 </details>
 
@@ -230,7 +232,7 @@ context_budget_tokens = 8000  # Set to LLM context window size (0 = unlimited)
 
 ## Docker
 
-**Note:** Docker Compose automatically pulls the latest image from GitHub Container Registry. To use a specific version, set `ZEPH_IMAGE=ghcr.io/bug-ops/zeph:v0.4.0`.
+**Note:** Docker Compose automatically pulls the latest image from GitHub Container Registry. To use a specific version, set `ZEPH_IMAGE=ghcr.io/bug-ops/zeph:v0.4.1`.
 
 <details>
 <summary><b>🐳 Docker Deployment Options</b> (click to expand)</summary>
@@ -273,7 +275,7 @@ docker compose --profile gpu -f docker-compose.yml -f docker-compose.gpu.yml up
 
 ```bash
 # Use a specific release version
-ZEPH_IMAGE=ghcr.io/bug-ops/zeph:v0.4.0 docker compose up
+ZEPH_IMAGE=ghcr.io/bug-ops/zeph:v0.4.1 docker compose up
 
 # Always pull latest
 docker compose pull && docker compose up


### PR DESCRIPTION
## Summary

Patch release v0.4.1 with automatic Qdrant collection creation and Docker Compose improvements.

## Changes

- Automatic Qdrant collection initialization on first use (no manual curl commands required)
- Added semantic memory environment variables to Docker Compose
- Updated documentation to reflect v0.4.1 release

## Fixes

- Qdrant collection `zeph_conversations` now created automatically with correct vector dimensions (896) and Cosine distance metric
- Docker Compose now supports semantic memory configuration via `.env` file

## Testing

- [x] Compiled successfully with `cargo check`
- [x] Version updated to 0.4.1 in all manifests
- [x] CHANGELOG updated with patch notes
- [x] README updated with v0.4.1 references

## Closes

Fixes issue with manual Qdrant collection setup requirement.