### PR TITLE
chore: bump version to 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-02-08
+
+### Fixed
+- Telegram MarkdownV2 parsing errors (Issue #69). Replaced manual character-by-character escaping with AST-based event-driven rendering using pulldown-cmark 0.13.0
+- UTF-8 safe text chunking for messages exceeding Telegram's 4096-byte limit. Uses `str::is_char_boundary()` with newline preference to prevent splitting multi-byte characters (emoji, CJK)
+- Link URL over-escaping. Dedicated `escape_url()` method only escapes `)` and `\` per Telegram MarkdownV2 spec, fixing broken URLs like `https://example\.com`
+
+### Added
+- `TelegramRenderer` state machine for context-aware escaping: 19 special characters in text, only `\` and `` ` `` in code blocks
+- Markdown formatting support: bold, italic, strikethrough, headers, code blocks, links, lists, blockquotes
+- Comprehensive benchmark suite with criterion: 7 scenario groups measuring latency (2.83µs for 500 chars) and throughput (121-970 MiB/s)
+- Memory profiling test to measure escaping overhead (3-20% depending on content)
+- 30 markdown unit tests covering formatting, escaping, edge cases, and UTF-8 chunking (99.32% line coverage)
+
+### Changed
+- `crates/zeph-channels/src/markdown.rs`: Complete rewrite with pulldown-cmark event-driven parser (449 lines)
+- `crates/zeph-channels/src/telegram.rs`: Removed `has_unclosed_code_block()` pre-flight check (no longer needed with AST parsing), integrated UTF-8 safe chunking
+- Dependencies: Added pulldown-cmark 0.13.0 (MIT) and criterion 0.8.0 (Apache-2.0/MIT) for benchmarking
+
 ## [0.4.1] - 2026-02-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4774,7 +4774,7 @@ dependencies = [
 
 [[package]]
 name = "zeph"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -4792,7 +4792,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-channels"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "criterion",
@@ -4805,7 +4805,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "serde",
@@ -4822,7 +4822,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-llm"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "eventsource-stream",
@@ -4838,7 +4838,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-memory"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "qdrant-client",
@@ -4854,7 +4854,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-skills"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -4863,7 +4863,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-tools"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "serde",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 rust-version = "1.88"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["bug-ops"]
 license = "MIT"
 repository = "https://github.com/bug-ops/zeph"
@@ -33,12 +33,12 @@ toml = "0.9"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 uuid = "1.20"
-zeph-channels = { path = "crates/zeph-channels", version = "0.4.1" }
-zeph-core = { path = "crates/zeph-core", version = "0.4.1" }
-zeph-llm = { path = "crates/zeph-llm", version = "0.4.1" }
-zeph-memory = { path = "crates/zeph-memory", version = "0.4.1" }
-zeph-skills = { path = "crates/zeph-skills", version = "0.4.1" }
-zeph-tools = { path = "crates/zeph-tools", version = "0.4.1" }
+zeph-channels = { path = "crates/zeph-channels", version = "0.4.2" }
+zeph-core = { path = "crates/zeph-core", version = "0.4.2" }
+zeph-llm = { path = "crates/zeph-llm", version = "0.4.2" }
+zeph-memory = { path = "crates/zeph-memory", version = "0.4.2" }
+zeph-skills = { path = "crates/zeph-skills", version = "0.4.2" }
+zeph-tools = { path = "crates/zeph-tools", version = "0.4.2" }
 
 [workspace.lints.clippy]
 all = "warn"


### PR DESCRIPTION
## Summary

Version bump to 0.4.2 with enhanced security documentation.

## Changes

### Version Updates
- All workspace crates: 0.4.1 → 0.4.2
- Cargo.lock updated with new versions

### CHANGELOG.md
Added v0.4.2 entry documenting:
- Telegram MarkdownV2 parsing error fixes (Issue #69)
- UTF-8 safe text chunking for messages >4096 bytes
- Link URL over-escaping fix with dedicated `escape_url()` method
- `TelegramRenderer` state machine with context-aware escaping
- 30 markdown tests with 99.32% coverage
- Performance: 2.83µs (500 chars), 121-970 MiB/s throughput
- New dependencies: pulldown-cmark 0.13.0, criterion 0.8.0

### README.md Security Enhancements
- **New badges:** Trivy (0 CVEs), MSRV (1.88)
- **Expanded Security section:**
  - Detailed table of 12 blocked shell patterns with risk categories
  - Container security: Oracle Linux 9, Trivy scanning, non-root user
  - Code security: no unsafe blocks, cargo-deny, panic linting
  - Secrets management: environment variables, Vault integration planned
- **Updated Docker examples:** v0.4.1 → v0.4.2

## Quality

- ✅ All 221 tests pass
- ✅ Cargo.lock updated and validated
- ✅ Documentation reflects current release