### PR TITLE
fix(channels): guard against empty Telegram messages, add dev Docker setup

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,44 @@
+FROM rust:1.88-slim AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    pkg-config libssl-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Cache dependencies in a separate layer
+COPY Cargo.toml Cargo.lock ./
+COPY crates/zeph-core/Cargo.toml crates/zeph-core/Cargo.toml
+COPY crates/zeph-llm/Cargo.toml crates/zeph-llm/Cargo.toml
+COPY crates/zeph-skills/Cargo.toml crates/zeph-skills/Cargo.toml
+COPY crates/zeph-memory/Cargo.toml crates/zeph-memory/Cargo.toml
+COPY crates/zeph-channels/Cargo.toml crates/zeph-channels/Cargo.toml
+COPY crates/zeph-tools/Cargo.toml crates/zeph-tools/Cargo.toml
+RUN mkdir -p src && echo 'fn main() {}' > src/main.rs && \
+    for d in crates/*/; do mkdir -p "$d/src" && echo '' > "$d/src/lib.rs"; done && \
+    cargo build --release 2>/dev/null || true
+
+COPY . .
+RUN touch src/main.rs && \
+    for d in crates/*/src/lib.rs; do touch "$d"; done && \
+    cargo build --release
+
+FROM container-registry.oracle.com/os/oraclelinux:9-slim
+
+RUN microdnf install -y shadow-utils ca-certificates && \
+    microdnf clean all && \
+    useradd --system --no-create-home --shell /sbin/nologin zeph
+
+WORKDIR /app
+
+COPY --from=builder /build/target/release/zeph /app/zeph
+COPY config/ /app/config/
+COPY skills/ /app/skills/
+
+RUN mkdir -p /app/data && \
+    chown -R zeph:zeph /app && \
+    chmod +x /app/zeph
+
+USER zeph
+
+ENTRYPOINT ["/app/zeph"]

--- a/README.md
+++ b/README.md
@@ -298,11 +298,23 @@ ZEPH_IMAGE=ghcr.io/bug-ops/zeph:v0.4.2 docker compose up
 docker compose pull && docker compose up
 ```
 
-### Local Development (build from source)
+### Local Development
+
+Full stack with debug tracing (builds from source via `Dockerfile.dev`, uses host Ollama via `host.docker.internal`):
 
 ```bash
-# Build and run local changes
-ZEPH_IMAGE=zeph:local docker compose up --build
+# Build and start Qdrant + Zeph with debug logging
+docker compose -f docker-compose.dev.yml up --build
+```
+
+Dependencies only (run zeph natively on host):
+
+```bash
+# Start Qdrant
+docker compose -f docker-compose.deps.yml up
+
+# Run zeph natively with debug tracing
+RUST_LOG=zeph=debug,zeph_channels=trace cargo run
 ```
 
 </details>

--- a/crates/zeph-channels/src/telegram.rs
+++ b/crates/zeph-channels/src/telegram.rs
@@ -130,6 +130,11 @@ impl TelegramChannel {
 
         let formatted_text = markdown_to_telegram(text);
 
+        if formatted_text.is_empty() {
+            tracing::debug!("skipping send: formatted text is empty");
+            return Ok(());
+        }
+
         tracing::debug!("formatted_text (full): {}", formatted_text);
 
         match self.message_id {
@@ -237,6 +242,11 @@ impl Channel for TelegramChannel {
         };
 
         let formatted_text = markdown_to_telegram(text);
+
+        if formatted_text.is_empty() {
+            tracing::debug!("skipping send: formatted text is empty");
+            return Ok(());
+        }
 
         if formatted_text.len() <= MAX_MESSAGE_LEN {
             self.bot

--- a/docker-compose.deps.yml
+++ b/docker-compose.deps.yml
@@ -1,0 +1,13 @@
+services:
+  qdrant:
+    image: qdrant/qdrant:v1.16.3
+    ports:
+      - "6333:6333"
+      - "6334:6334"
+    volumes:
+      - qdrant_data:/qdrant/storage
+    environment:
+      - QDRANT__LOG_LEVEL=DEBUG
+
+volumes:
+  qdrant_data:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,38 @@
+services:
+  qdrant:
+    image: qdrant/qdrant:v1.16.3
+    ports:
+      - "6333:6333"
+      - "6334:6334"
+    volumes:
+      - qdrant_data:/qdrant/storage
+    environment:
+      - QDRANT__LOG_LEVEL=DEBUG
+
+  zeph:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    depends_on:
+      - qdrant
+    environment:
+      RUST_LOG: "zeph=debug,zeph_core=debug,zeph_llm=debug,zeph_channels=trace,zeph_memory=debug,zeph_tools=debug"
+      RUST_BACKTRACE: "1"
+      ZEPH_LLM_PROVIDER: ${ZEPH_LLM_PROVIDER:-ollama}
+      ZEPH_LLM_BASE_URL: ${ZEPH_LLM_BASE_URL:-http://host.docker.internal:11434}
+      ZEPH_LLM_MODEL: ${ZEPH_LLM_MODEL:-mistral:7b}
+      ZEPH_LLM_EMBEDDING_MODEL: ${ZEPH_LLM_EMBEDDING_MODEL:-qwen3-embedding}
+      ZEPH_CLAUDE_API_KEY: ${ZEPH_CLAUDE_API_KEY:-}
+      ZEPH_TELEGRAM_TOKEN: ${ZEPH_TELEGRAM_TOKEN:-}
+      ZEPH_SQLITE_PATH: /app/data/zeph.db
+      ZEPH_QDRANT_URL: http://qdrant:6334
+      ZEPH_MEMORY_SEMANTIC_ENABLED: ${ZEPH_MEMORY_SEMANTIC_ENABLED:-true}
+      ZEPH_MEMORY_SEMANTIC_RECALL_LIMIT: ${ZEPH_MEMORY_SEMANTIC_RECALL_LIMIT:-5}
+    volumes:
+      - zeph_data:/app/data
+    stdin_open: true
+    tty: true
+
+volumes:
+  qdrant_data:
+  zeph_data:


### PR DESCRIPTION
## Summary

- Guard against empty MarkdownV2 text in `send()` and `send_or_edit()` — when LLM returns whitespace-only content, `markdown_to_telegram` produces an empty string that Telegram API rejects with "Bad Request: text must be non-empty"
- Add local development Docker setup: `Dockerfile.dev` (multi-stage source build), `docker-compose.dev.yml` (full stack with debug tracing, host Ollama), `docker-compose.deps.yml` (Qdrant only for native execution)

## Test plan

- [x] `cargo clippy -p zeph-channels -- -D warnings` passes
- [x] `cargo nextest run -p zeph-channels` — 37/37 tests pass
- [ ] Manual: send message via Telegram, verify no "text must be non-empty" errors in logs
- [ ] Manual: `docker compose -f docker-compose.dev.yml up --build` starts successfully