### PR TITLE
chore: bump version to 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-02-08
+
+### Fixed
+- Telegram "Bad Request: text must be non-empty" error when LLM returns whitespace-only content. Added `is_empty()` guard after `markdown_to_telegram` conversion in both `send()` and `send_or_edit()` (Issue #73)
+
+### Added
+- `Dockerfile.dev`: multi-stage build from source with cargo registry/build cache layers for fast rebuilds
+- `docker-compose.dev.yml`: full dev stack (Qdrant + Zeph) with debug tracing (`RUST_LOG`, `RUST_BACKTRACE=1`), uses host Ollama via `host.docker.internal`
+- `docker-compose.deps.yml`: Qdrant-only compose for native zeph execution on macOS
+
 ## [0.4.2] - 2026-02-08
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 rust-version = "1.88"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["bug-ops"]
 license = "MIT"
 repository = "https://github.com/bug-ops/zeph"
@@ -33,12 +33,12 @@ toml = "0.9"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 uuid = "1.20"
-zeph-channels = { path = "crates/zeph-channels", version = "0.4.2" }
-zeph-core = { path = "crates/zeph-core", version = "0.4.2" }
-zeph-llm = { path = "crates/zeph-llm", version = "0.4.2" }
-zeph-memory = { path = "crates/zeph-memory", version = "0.4.2" }
-zeph-skills = { path = "crates/zeph-skills", version = "0.4.2" }
-zeph-tools = { path = "crates/zeph-tools", version = "0.4.2" }
+zeph-channels = { path = "crates/zeph-channels", version = "0.4.3" }
+zeph-core = { path = "crates/zeph-core", version = "0.4.3" }
+zeph-llm = { path = "crates/zeph-llm", version = "0.4.3" }
+zeph-memory = { path = "crates/zeph-memory", version = "0.4.3" }
+zeph-skills = { path = "crates/zeph-skills", version = "0.4.3" }
+zeph-tools = { path = "crates/zeph-tools", version = "0.4.3" }
 
 [workspace.lints.clippy]
 all = "warn"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ docker pull ghcr.io/bug-ops/zeph:latest
 Or use a specific version:
 
 ```bash
-docker pull ghcr.io/bug-ops/zeph:v0.4.2
+docker pull ghcr.io/bug-ops/zeph:v0.4.3
 ```
 
 **Security:** Images are scanned with [Trivy](https://trivy.dev/) in CI/CD and use Oracle Linux 9 Slim base with **0 HIGH/CRITICAL CVEs**. Multi-platform: linux/amd64, linux/arm64.
@@ -249,7 +249,7 @@ context_budget_tokens = 8000  # Set to LLM context window size (0 = unlimited)
 
 ## Docker
 
-**Note:** Docker Compose automatically pulls the latest image from GitHub Container Registry. To use a specific version, set `ZEPH_IMAGE=ghcr.io/bug-ops/zeph:v0.4.1`.
+**Note:** Docker Compose automatically pulls the latest image from GitHub Container Registry. To use a specific version, set `ZEPH_IMAGE=ghcr.io/bug-ops/zeph:v0.4.3`.
 
 <details>
 <summary><b>🐳 Docker Deployment Options</b> (click to expand)</summary>
@@ -292,7 +292,7 @@ docker compose --profile gpu -f docker-compose.yml -f docker-compose.gpu.yml up
 
 ```bash
 # Use a specific release version
-ZEPH_IMAGE=ghcr.io/bug-ops/zeph:v0.4.2 docker compose up
+ZEPH_IMAGE=ghcr.io/bug-ops/zeph:v0.4.3 docker compose up
 
 # Always pull latest
 docker compose pull && docker compose up


### PR DESCRIPTION
## Summary

- Bump workspace version 0.4.2 -> 0.4.3
- Update CHANGELOG.md with v0.4.3 entry: empty Telegram message fix (#73), dev Docker setup
- Update README.md Docker version references

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo nextest run --workspace` — 221 tests pass, 6 skipped