### PR TITLE
feat(tools): add allowed_commands to override default shell blocklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - Bundled `setup-guide` skill with configuration reference for all env vars, TOML keys, and operating modes
+- `allowed_commands` shell config to override default blocklist entries via `ZEPH_TOOLS_SHELL_ALLOWED_COMMANDS`
 
 ## [0.7.1] - 2026-02-09
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -63,6 +63,8 @@ enabled = true
 timeout = 30
 # Additional commands to block (case-insensitive, supports wildcards)
 blocked_commands = []
+# Commands to remove from the default blocklist (e.g., ["curl", "wget"])
+allowed_commands = []
 
 [tools.scrape]
 # HTTP request timeout in seconds

--- a/crates/zeph-tools/src/config.rs
+++ b/crates/zeph-tools/src/config.rs
@@ -19,13 +19,15 @@ pub struct ToolsConfig {
     pub scrape: ScrapeConfig,
 }
 
-/// Shell-specific configuration: timeout and command blocklist.
+/// Shell-specific configuration: timeout, command blocklist, and allowlist overrides.
 #[derive(Debug, Deserialize)]
 pub struct ShellConfig {
     #[serde(default = "default_timeout")]
     pub timeout: u64,
     #[serde(default)]
     pub blocked_commands: Vec<String>,
+    #[serde(default)]
+    pub allowed_commands: Vec<String>,
 }
 
 impl Default for ToolsConfig {
@@ -43,6 +45,7 @@ impl Default for ShellConfig {
         Self {
             timeout: default_timeout(),
             blocked_commands: Vec::new(),
+            allowed_commands: Vec::new(),
         }
     }
 }
@@ -159,5 +162,23 @@ mod tests {
         let config = ToolsConfig::default();
         assert_eq!(config.scrape.timeout, 15);
         assert_eq!(config.scrape.max_body_bytes, 1_048_576);
+    }
+
+    #[test]
+    fn deserialize_allowed_commands() {
+        let toml_str = r#"
+            [shell]
+            timeout = 30
+            allowed_commands = ["curl", "wget"]
+        "#;
+
+        let config: ToolsConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.shell.allowed_commands, vec!["curl", "wget"]);
+    }
+
+    #[test]
+    fn default_allowed_commands_empty() {
+        let config = ShellConfig::default();
+        assert!(config.allowed_commands.is_empty());
     }
 }

--- a/skills/setup-guide/SKILL.md
+++ b/skills/setup-guide/SKILL.md
@@ -94,8 +94,10 @@ Config: `tools.enabled` (default: true) — master toggle for all tool execution
 Shell:
 ```bash
 export ZEPH_TOOLS_TIMEOUT=30
+export ZEPH_TOOLS_SHELL_ALLOWED_COMMANDS=curl,wget
 ```
 Config: `tools.shell.blocked_commands` — additional command patterns to block.
+Config: `tools.shell.allowed_commands` — commands to remove from the default blocklist.
 
 Scrape:
 ```bash

--- a/tests/performance_agent_integration.rs
+++ b/tests/performance_agent_integration.rs
@@ -236,6 +236,7 @@ async fn agent_respects_configured_timeout() {
     let shell_config = ShellConfig {
         timeout: 1,
         blocked_commands: vec![],
+        allowed_commands: vec![],
     };
     let _executor = ShellExecutor::new(&shell_config);
 
@@ -256,6 +257,7 @@ async fn shell_executor_default_blocked_patterns() {
     let shell_config = ShellConfig {
         timeout: 30,
         blocked_commands: vec![],
+        allowed_commands: vec![],
     };
     let executor = ShellExecutor::new(&shell_config);
 
@@ -290,6 +292,7 @@ async fn shell_executor_allows_safe_commands() {
     let shell_config = ShellConfig {
         timeout: 5,
         blocked_commands: vec![],
+        allowed_commands: vec![],
     };
     let executor = ShellExecutor::new(&shell_config);
 
@@ -313,6 +316,7 @@ async fn shell_executor_case_insensitive_blocking() {
     let shell_config = ShellConfig {
         timeout: 30,
         blocked_commands: vec![],
+        allowed_commands: vec![],
     };
     let executor = ShellExecutor::new(&shell_config);
 
@@ -340,6 +344,7 @@ async fn integration_agent_tool_executor_types() {
     let shell_config = ShellConfig {
         timeout: 30,
         blocked_commands: vec![],
+        allowed_commands: vec![],
     };
     let executor = ShellExecutor::new(&shell_config);
 
@@ -398,6 +403,7 @@ async fn tool_executor_pattern_matching_overhead() {
             "custom2".to_string(),
             "custom3".to_string(),
         ],
+        allowed_commands: vec![],
     };
     let executor = ShellExecutor::new(&shell_config);
 
@@ -434,6 +440,7 @@ async fn agent_no_regression_in_error_handling() {
     let shell_config = ShellConfig {
         timeout: 30,
         blocked_commands: vec!["dangerous".to_string()],
+        allowed_commands: vec![],
     };
     let executor = ShellExecutor::new(&shell_config);
 
@@ -487,6 +494,7 @@ async fn agent_tool_executor_error_recovery() {
     let shell_config = ShellConfig {
         timeout: 30,
         blocked_commands: vec!["forbidden".to_string()],
+        allowed_commands: vec![],
     };
     let executor = ShellExecutor::new(&shell_config);
 


### PR DESCRIPTION
## Summary

- Add `tools.shell.allowed_commands` config to selectively remove commands from the hardcoded `DEFAULT_BLOCKED` list
- Add `ZEPH_TOOLS_SHELL_ALLOWED_COMMANDS` env var (comma-separated) for runtime override
- Explicit `blocked_commands` always takes precedence over `allowed_commands`

## Details

ShellExecutor has a hardcoded blocklist (`curl`, `wget`, `sudo`, etc.) that cannot be overridden via config. This adds an allowlist mechanism: commands listed in `allowed_commands` are removed from `DEFAULT_BLOCKED` before merging with user `blocked_commands`.

Conflict resolution: if a command appears in both `allowed_commands` and `blocked_commands`, it stays blocked (explicit block wins).

## Test plan

- [x] `allowed_commands_removes_from_default` — curl allowed, passes through
- [x] `allowed_commands_case_insensitive` — CURL matches curl
- [x] `allowed_does_not_override_explicit_block` — blocked_commands wins
- [x] `allowed_unknown_command_ignored` — no side effects
- [x] `empty_allowed_commands_changes_nothing` — default behavior preserved
- [x] `env_override_allowed_commands` — comma-separated parsing with trim
- [x] All 388 workspace tests pass