### PR TITLE
feat(skills): add persistent skill embeddings in Qdrant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - Bundled `setup-guide` skill with configuration reference for all env vars, TOML keys, and operating modes
 - `allowed_commands` shell config to override default blocklist entries via `ZEPH_TOOLS_SHELL_ALLOWED_COMMANDS`
+- `QdrantSkillMatcher`: persistent skill embeddings in Qdrant with BLAKE3 content-hash delta sync (Issue #104)
+- `SkillMatcherBackend` enum dispatching between `InMemory` and `Qdrant` skill matching (Issue #105)
+- `qdrant` feature flag on `zeph-skills` crate gating all Qdrant dependencies
+- Graceful fallback to in-memory matcher when Qdrant is unavailable
+
+### Changed
+- `Agent` field `matcher` type changed from `Option<SkillMatcher>` to `Option<SkillMatcherBackend>`
+- Skill matcher creation extracted to `create_skill_matcher()` in `main.rs`
+
+### Dependencies
+- Added `blake3` 1.8 to workspace
 
 ## [0.7.1] - 2026-02-09
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "astral-tokio-tar"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,6 +328,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "blake3"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -567,6 +593,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "core-foundation"
@@ -1292,6 +1324,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1659,6 +1704,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1866,6 +1917,12 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -2495,6 +2552,16 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro-error-attr2"
@@ -3432,6 +3499,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3941,12 +4014,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4537,6 +4610,7 @@ dependencies = [
  "getrandom 0.3.4",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 
@@ -4588,6 +4662,15 @@ name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -4658,6 +4741,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4681,6 +4786,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.10.0",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "semver",
 ]
 
 [[package]]
@@ -5141,6 +5258,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.10.0",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -5300,11 +5499,15 @@ name = "zeph-skills"
 version = "0.7.1"
 dependencies = [
  "anyhow",
+ "blake3",
  "notify",
  "notify-debouncer-mini",
+ "qdrant-client",
+ "serde_json",
  "tempfile",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/bug-ops/zeph"
 [workspace.dependencies]
 anyhow = "1.0"
 axum = "0.8"
+blake3 = "1.8"
 criterion = "0.8"
 futures = "0.3"
 eventsource-stream = "0.2"
@@ -77,7 +78,7 @@ zeph-channels.workspace = true
 zeph-core.workspace = true
 zeph-llm.workspace = true
 zeph-memory.workspace = true
-zeph-skills.workspace = true
+zeph-skills = { workspace = true, features = ["qdrant"] }
 zeph-tools.workspace = true
 
 [dev-dependencies]
@@ -86,7 +87,7 @@ tokio-stream.workspace = true
 zeph-core.workspace = true
 zeph-llm.workspace = true
 zeph-memory.workspace = true
-zeph-skills.workspace = true
+zeph-skills = { workspace = true, features = ["qdrant"] }
 
 [lints]
 workspace = true

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -15,7 +15,7 @@ toml.workspace = true
 tracing.workspace = true
 zeph-llm.workspace = true
 zeph-memory.workspace = true
-zeph-skills.workspace = true
+zeph-skills = { workspace = true, features = ["qdrant"] }
 zeph-tools.workspace = true
 
 [dev-dependencies]

--- a/crates/zeph-skills/Cargo.toml
+++ b/crates/zeph-skills/Cargo.toml
@@ -6,12 +6,20 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[features]
+default = []
+qdrant = ["dep:blake3", "dep:qdrant-client", "dep:serde_json", "dep:uuid"]
+
 [dependencies]
 anyhow.workspace = true
+blake3 = { workspace = true, optional = true }
 notify.workspace = true
 notify-debouncer-mini.workspace = true
+qdrant-client = { workspace = true, optional = true, features = ["serde"] }
+serde_json = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["sync", "rt"] }
 tracing.workspace = true
+uuid = { workspace = true, optional = true, features = ["v5"] }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/zeph-skills/src/lib.rs
+++ b/crates/zeph-skills/src/lib.rs
@@ -3,5 +3,7 @@
 pub mod loader;
 pub mod matcher;
 pub mod prompt;
+#[cfg(feature = "qdrant")]
+pub mod qdrant_matcher;
 pub mod registry;
 pub mod watcher;

--- a/crates/zeph-skills/src/qdrant_matcher.rs
+++ b/crates/zeph-skills/src/qdrant_matcher.rs
@@ -1,0 +1,391 @@
+use std::collections::HashMap;
+
+use anyhow::Context;
+use qdrant_client::Qdrant;
+use qdrant_client::qdrant::{
+    CreateCollectionBuilder, DeletePointsBuilder, Distance, PointStruct, PointsIdsList,
+    ScrollPointsBuilder, SearchPointsBuilder, UpsertPointsBuilder, VectorParamsBuilder,
+    value::Kind,
+};
+
+use crate::loader::Skill;
+use crate::matcher::EmbedFuture;
+
+const COLLECTION_NAME: &str = "zeph_skills";
+
+const SKILL_NAMESPACE: uuid::Uuid = uuid::Uuid::from_bytes([
+    0x7a, 0x65, 0x70, 0x68, // "zeph"
+    0x2d, 0x73, 0x6b, 0x69, // "-ski"
+    0x6c, 0x6c, 0x73, 0x00, // "lls\0"
+    0x00, 0x00, 0x00, 0x01, // version
+]);
+
+#[derive(Debug, Default)]
+pub struct SyncStats {
+    pub added: usize,
+    pub updated: usize,
+    pub removed: usize,
+    pub unchanged: usize,
+}
+
+pub struct QdrantSkillMatcher {
+    client: Qdrant,
+    collection: String,
+    hashes: HashMap<String, String>,
+}
+
+impl std::fmt::Debug for QdrantSkillMatcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("QdrantSkillMatcher")
+            .field("collection", &self.collection)
+            .finish_non_exhaustive()
+    }
+}
+
+fn content_hash(skill: &Skill) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(skill.name.as_bytes());
+    hasher.update(skill.description.as_bytes());
+    hasher.update(skill.body.as_bytes());
+    hasher.finalize().to_hex().to_string()
+}
+
+fn skill_point_id(skill_name: &str) -> String {
+    uuid::Uuid::new_v5(&SKILL_NAMESPACE, skill_name.as_bytes()).to_string()
+}
+
+impl QdrantSkillMatcher {
+    /// # Errors
+    ///
+    /// Returns an error if the Qdrant client cannot be created.
+    pub fn new(qdrant_url: &str) -> anyhow::Result<Self> {
+        let client = Qdrant::from_url(qdrant_url)
+            .build()
+            .context("failed to create Qdrant client")?;
+
+        Ok(Self {
+            client,
+            collection: COLLECTION_NAME.into(),
+            hashes: HashMap::new(),
+        })
+    }
+
+    /// Sync skill embeddings with Qdrant. Computes delta and upserts only changed skills.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if Qdrant communication fails.
+    pub async fn sync<F>(
+        &mut self,
+        skills: &[Skill],
+        embedding_model: &str,
+        embed_fn: F,
+    ) -> anyhow::Result<SyncStats>
+    where
+        F: Fn(&str) -> EmbedFuture,
+    {
+        let mut stats = SyncStats::default();
+
+        self.ensure_collection(&embed_fn).await?;
+
+        // Scroll all existing points (payload only, no vectors)
+        let existing = self.scroll_all().await?;
+
+        // Build current skill set: name -> (hash, skill_ref)
+        let mut current: HashMap<String, (String, &Skill)> = HashMap::with_capacity(skills.len());
+        for skill in skills {
+            current.insert(skill.name.clone(), (content_hash(skill), skill));
+        }
+
+        // Detect model change by checking first existing point's embedding_model
+        let model_changed = existing.values().any(|stored| {
+            stored
+                .get("embedding_model")
+                .is_some_and(|m| m != embedding_model)
+        });
+
+        if model_changed {
+            tracing::warn!("embedding model changed to '{embedding_model}', recreating collection");
+            self.recreate_collection(&embed_fn).await?;
+        }
+
+        // Collect changed skills into a batch
+        let mut points_to_upsert = Vec::new();
+        for (name, (hash, skill)) in &current {
+            let needs_update = if let Some(stored) = existing.get(name) {
+                model_changed || stored.get("content_hash").is_some_and(|h| h != hash)
+            } else {
+                true
+            };
+
+            if !needs_update {
+                stats.unchanged += 1;
+                self.hashes.insert(name.clone(), hash.clone());
+                continue;
+            }
+
+            let vector = match embed_fn(&skill.description).await {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!("failed to embed skill '{name}': {e:#}");
+                    continue;
+                }
+            };
+
+            let point_id = skill_point_id(name);
+            let payload: serde_json::Value = serde_json::json!({
+                "skill_name": name,
+                "description": skill.description,
+                "content_hash": hash,
+                "embedding_model": embedding_model,
+            });
+            let payload_map: HashMap<String, qdrant_client::qdrant::Value> =
+                serde_json::from_value(payload).context("failed to convert payload")?;
+
+            points_to_upsert.push(PointStruct::new(point_id, vector, payload_map));
+
+            if existing.contains_key(name) {
+                stats.updated += 1;
+            } else {
+                stats.added += 1;
+            }
+            self.hashes.insert(name.clone(), hash.clone());
+        }
+
+        if !points_to_upsert.is_empty() {
+            self.client
+                .upsert_points(UpsertPointsBuilder::new(&self.collection, points_to_upsert))
+                .await
+                .context("failed to upsert skill points")?;
+        }
+
+        // Remove orphan points (skills no longer in registry)
+        let orphan_ids: Vec<String> = existing
+            .keys()
+            .filter(|name| !current.contains_key(*name))
+            .map(|name| skill_point_id(name))
+            .collect();
+
+        if !orphan_ids.is_empty() {
+            stats.removed = orphan_ids.len();
+            let point_ids: Vec<qdrant_client::qdrant::PointId> = orphan_ids
+                .into_iter()
+                .map(|id| qdrant_client::qdrant::PointId::from(id.as_str()))
+                .collect();
+            self.client
+                .delete_points(
+                    DeletePointsBuilder::new(&self.collection)
+                        .points(PointsIdsList { ids: point_ids }),
+                )
+                .await
+                .context("failed to delete orphan points")?;
+        }
+
+        tracing::info!(
+            added = stats.added,
+            updated = stats.updated,
+            removed = stats.removed,
+            unchanged = stats.unchanged,
+            "skill embeddings synced"
+        );
+
+        Ok(stats)
+    }
+
+    /// Search for relevant skills using Qdrant native vector search.
+    pub async fn match_skills<'a, F>(
+        &self,
+        skills: &'a [Skill],
+        query: &str,
+        limit: usize,
+        embed_fn: F,
+    ) -> Vec<&'a Skill>
+    where
+        F: Fn(&str) -> EmbedFuture,
+    {
+        let query_vec = match embed_fn(query).await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!("failed to embed query: {e:#}");
+                return Vec::new();
+            }
+        };
+
+        let Ok(limit_u64) = u64::try_from(limit) else {
+            return Vec::new();
+        };
+
+        let results = match self
+            .client
+            .search_points(
+                SearchPointsBuilder::new(&self.collection, query_vec, limit_u64).with_payload(true),
+            )
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!("Qdrant search failed, returning empty: {e:#}");
+                return Vec::new();
+            }
+        };
+
+        results
+            .result
+            .into_iter()
+            .filter_map(|point| {
+                let name = point.payload.get("skill_name")?;
+                let name_str = match &name.kind {
+                    Some(Kind::StringValue(s)) => s.as_str(),
+                    _ => return None,
+                };
+                skills.iter().find(|s| s.name == name_str)
+            })
+            .collect()
+    }
+
+    async fn recreate_collection<F>(&self, embed_fn: &F) -> anyhow::Result<()>
+    where
+        F: Fn(&str) -> EmbedFuture,
+    {
+        if self.client.collection_exists(&self.collection).await? {
+            self.client
+                .delete_collection(&self.collection)
+                .await
+                .context("failed to delete collection for dimension change")?;
+            tracing::info!(
+                collection = &self.collection,
+                "deleted collection for recreation"
+            );
+        }
+        self.ensure_collection(embed_fn).await
+    }
+
+    async fn ensure_collection<F>(&self, embed_fn: &F) -> anyhow::Result<()>
+    where
+        F: Fn(&str) -> EmbedFuture,
+    {
+        if self.client.collection_exists(&self.collection).await? {
+            return Ok(());
+        }
+
+        // Probe vector dimensions by embedding a short test string
+        let probe = embed_fn("dimension probe")
+            .await
+            .context("failed to probe embedding dimensions")?;
+        let vector_size = u64::try_from(probe.len()).context("embedding dimension exceeds u64")?;
+
+        self.client
+            .create_collection(
+                CreateCollectionBuilder::new(&self.collection)
+                    .vectors_config(VectorParamsBuilder::new(vector_size, Distance::Cosine)),
+            )
+            .await
+            .context("failed to create skills collection")?;
+
+        tracing::info!(
+            collection = &self.collection,
+            dimensions = vector_size,
+            "created Qdrant collection for skill embeddings"
+        );
+
+        Ok(())
+    }
+
+    /// Scroll all points from the collection, returning `skill_name` -> payload fields.
+    async fn scroll_all(&self) -> anyhow::Result<HashMap<String, HashMap<String, String>>> {
+        let mut result = HashMap::new();
+        let mut offset: Option<qdrant_client::qdrant::PointId> = None;
+
+        loop {
+            let mut builder = ScrollPointsBuilder::new(&self.collection)
+                .with_payload(true)
+                .with_vectors(false)
+                .limit(100);
+
+            if let Some(ref off) = offset {
+                builder = builder.offset(off.clone());
+            }
+
+            let response = self
+                .client
+                .scroll(builder)
+                .await
+                .context("failed to scroll skill points")?;
+
+            for point in &response.result {
+                let Some(name_val) = point.payload.get("skill_name") else {
+                    continue;
+                };
+                let Some(Kind::StringValue(name)) = &name_val.kind else {
+                    continue;
+                };
+
+                let mut fields = HashMap::new();
+                for (key, val) in &point.payload {
+                    if let Some(Kind::StringValue(s)) = &val.kind {
+                        fields.insert(key.clone(), s.clone());
+                    }
+                }
+                result.insert(name.clone(), fields);
+            }
+
+            match response.next_page_offset {
+                Some(next) => offset = Some(next),
+                None => break,
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_skill(name: &str, description: &str, body: &str) -> Skill {
+        Skill {
+            name: name.into(),
+            description: description.into(),
+            body: body.into(),
+        }
+    }
+
+    #[test]
+    fn test_content_hash_deterministic() {
+        let skill = make_skill("test", "A test skill", "body content");
+        let h1 = content_hash(&skill);
+        let h2 = content_hash(&skill);
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn test_content_hash_changes_on_modification() {
+        let s1 = make_skill("test", "A test skill", "body v1");
+        let s2 = make_skill("test", "A test skill", "body v2");
+        assert_ne!(content_hash(&s1), content_hash(&s2));
+    }
+
+    #[test]
+    fn test_skill_point_id_deterministic() {
+        let id1 = skill_point_id("my-skill");
+        let id2 = skill_point_id("my-skill");
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn test_skill_point_id_different_names() {
+        let id1 = skill_point_id("skill-a");
+        let id2 = skill_point_id("skill-b");
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn test_sync_stats_default() {
+        let stats = SyncStats::default();
+        assert_eq!(stats.added, 0);
+        assert_eq!(stats.updated, 0);
+        assert_eq!(stats.removed, 0);
+        assert_eq!(stats.unchanged, 0);
+    }
+}

--- a/skills/setup-guide/SKILL.md
+++ b/skills/setup-guide/SKILL.md
@@ -56,6 +56,8 @@ Start Qdrant:
 docker compose up -d qdrant
 ```
 
+When semantic memory is enabled and Qdrant is reachable, skill embeddings are persisted in a `zeph_skills` collection. On startup, only changed skills are re-embedded (BLAKE3 content hash comparison). The Qdrant HNSW index is used for skill matching instead of in-memory cosine similarity. If Qdrant is unavailable, the agent falls back to in-memory matching.
+
 ## Summarization
 
 ```bash


### PR DESCRIPTION
## Summary

- Introduce `QdrantSkillMatcher` that persists skill embeddings in a dedicated `zeph_skills` Qdrant collection with BLAKE3 content-hash delta sync
- Add `SkillMatcherBackend` enum dispatching between `InMemory` and `Qdrant` variants with graceful fallback
- Batch upsert for changed skills, collection recreation on embedding model dimension change, orphan point cleanup

## Changes

| File | Change |
|------|--------|
| `crates/zeph-skills/src/qdrant_matcher.rs` | New `QdrantSkillMatcher` with `sync()`, `match_skills()`, BLAKE3 hashing, UUID v5 point IDs |
| `crates/zeph-skills/src/matcher.rs` | `SkillMatcherBackend` enum with `match_skills()` and `sync()` dispatch |
| `crates/zeph-skills/Cargo.toml` | `qdrant` feature flag with blake3, qdrant-client, serde_json, uuid optional deps |
| `crates/zeph-core/src/agent.rs` | `Agent.matcher` changed to `Option<SkillMatcherBackend>`, delta sync on hot-reload |
| `src/main.rs` | `create_skill_matcher()` with Qdrant/InMemory dispatch and fallback |
| `skills/README.md` | Matching backends documentation |
| `skills/setup-guide/SKILL.md` | Qdrant skill embeddings section |

## Test plan

- [x] `cargo build` (workspace) passes
- [x] `cargo build -p zeph-skills` without qdrant feature passes
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo nextest run` — 24 tests pass (including 5 new unit tests for hash/UUID determinism)
- [ ] Manual test with Qdrant running: verify `zeph_skills` collection created, delta sync on restart
- [ ] Manual test without Qdrant: verify fallback to in-memory matching

Closes #103, #104, #105, #106