### PR TITLE
feat(mcp): MCP client integration with unified tool matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `qdrant` feature flag on `zeph-skills` crate gating all Qdrant dependencies
 - Graceful fallback to in-memory matcher when Qdrant is unavailable
 - Skill matching tracing via `tracing::debug!` for diagnostics
+- New `zeph-mcp` crate: MCP client via rmcp 0.14 with stdio transport (Issue #117)
+- `McpClient` and `McpManager` for multi-server lifecycle management with concurrent connections
+- `McpToolExecutor` implementing `ToolExecutor` for `` ```mcp `` block execution (Issue #120)
+- `McpToolRegistry`: MCP tool embeddings in Qdrant `zeph_mcp_tools` collection with BLAKE3 delta sync (Issue #118)
+- Unified matching: skills + MCP tools injected into system prompt by relevance (Issue #119)
+- `mcp` feature flag on root binary and zeph-core gating all MCP functionality
+- Bundled `mcp-generate` skill with instructions for MCP-to-skill generation via mcp-execution (Issue #121)
+- `[[mcp.servers]]` TOML config section for MCP server connections
 
 ### Changed
 - `Agent` field `matcher` type changed from `Option<SkillMatcher>` to `Option<SkillMatcherBackend>`
@@ -22,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Dependencies
 - Added `blake3` 1.8 to workspace
+- Added `rmcp` 0.14 to workspace (MCP protocol SDK)
 
 ## [0.7.1] - 2026-02-09
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,8 +494,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -778,6 +780,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,6 +818,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,6 +848,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]
@@ -2099,6 +2135,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2363,6 +2411,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2591,6 +2645,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "process-wrap"
+version = "9.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd1395947e69c07400ef4d43db0051d6f773c21f647ad8b97382fc01f0204c60"
+dependencies = [
+ "futures",
+ "indexmap 2.13.0",
+ "nix",
+ "tokio",
+ "tracing",
+ "windows",
 ]
 
 [[package]]
@@ -3038,6 +3106,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a621b37a548ff6ab6292d57841eb25785a7f146d89391a19c9f199414bd13da"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "process-wrap",
+ "rmcp-macros",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b79ed92303f9262db79575aa8c3652581668e9d136be6fd0b9ededa78954c95"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3228,6 +3333,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
  "schemars_derive",
@@ -4892,6 +4998,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4902,6 +5029,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -4931,6 +5069,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -5065,6 +5213,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -5404,6 +5561,7 @@ dependencies = [
  "zeph-channels",
  "zeph-core",
  "zeph-llm",
+ "zeph-mcp",
  "zeph-memory",
  "zeph-skills",
  "zeph-tools",
@@ -5457,6 +5615,7 @@ dependencies = [
  "toml",
  "tracing",
  "zeph-llm",
+ "zeph-mcp",
  "zeph-memory",
  "zeph-skills",
  "zeph-tools",
@@ -5476,6 +5635,23 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+]
+
+[[package]]
+name = "zeph-mcp"
+version = "0.7.1"
+dependencies = [
+ "anyhow",
+ "blake3",
+ "qdrant-client",
+ "rmcp",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
+ "zeph-tools",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ ollama-rs = { version = "0.3", default-features = false, features = ["rustls", "
 pulldown-cmark = "0.13"
 qdrant-client = { version = "1.16", default-features = false }
 reqwest = { version = "0.13", default-features = false }
+rmcp = "0.14"
 scrape-core = "0.2.2"
 subtle = "2.6"
 serde = "1.0"
@@ -48,6 +49,7 @@ zeph-a2a = { path = "crates/zeph-a2a", version = "0.7.1" }
 zeph-channels = { path = "crates/zeph-channels", version = "0.7.1" }
 zeph-core = { path = "crates/zeph-core", version = "0.7.1" }
 zeph-llm = { path = "crates/zeph-llm", version = "0.7.1" }
+zeph-mcp = { path = "crates/zeph-mcp", version = "0.7.1" }
 zeph-memory = { path = "crates/zeph-memory", version = "0.7.1" }
 zeph-skills = { path = "crates/zeph-skills", version = "0.7.1" }
 zeph-tools = { path = "crates/zeph-tools", version = "0.7.1" }
@@ -67,6 +69,7 @@ repository.workspace = true
 [features]
 default = ["a2a"]
 a2a = ["dep:zeph-a2a", "zeph-a2a?/server"]
+mcp = ["dep:zeph-mcp", "zeph-mcp?/qdrant", "zeph-core/mcp"]
 
 [dependencies]
 anyhow.workspace = true
@@ -75,6 +78,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 zeph-a2a = { workspace = true, optional = true }
 zeph-channels.workspace = true
+zeph-mcp = { workspace = true, optional = true }
 zeph-core.workspace = true
 zeph-llm.workspace = true
 zeph-memory.workspace = true

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -6,6 +6,10 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[features]
+default = []
+mcp = ["dep:zeph-mcp"]
+
 [dependencies]
 anyhow.workspace = true
 serde = { workspace = true, features = ["derive"] }
@@ -14,6 +18,7 @@ tokio-stream.workspace = true
 toml.workspace = true
 tracing.workspace = true
 zeph-llm.workspace = true
+zeph-mcp = { workspace = true, optional = true, features = ["qdrant"] }
 zeph-memory.workspace = true
 zeph-skills = { workspace = true, features = ["qdrant"] }
 zeph-tools.workspace = true

--- a/crates/zeph-mcp/Cargo.toml
+++ b/crates/zeph-mcp/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "zeph-mcp"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[features]
+default = []
+qdrant = ["dep:blake3", "dep:qdrant-client", "dep:uuid"]
+
+[dependencies]
+anyhow.workspace = true
+blake3 = { workspace = true, optional = true }
+qdrant-client = { workspace = true, optional = true, features = ["serde"] }
+rmcp = { workspace = true, features = ["client", "transport-child-process"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["process", "sync", "time", "rt"] }
+tracing.workspace = true
+uuid = { workspace = true, optional = true, features = ["v5"] }
+zeph-tools.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[lints]
+workspace = true

--- a/crates/zeph-mcp/src/client.rs
+++ b/crates/zeph-mcp/src/client.rs
@@ -1,0 +1,148 @@
+use std::borrow::Cow;
+use std::sync::Arc;
+use std::time::Duration;
+
+use rmcp::ServiceExt;
+use rmcp::model::{CallToolRequestParams, CallToolResult};
+use rmcp::service::RunningService;
+use rmcp::transport::TokioChildProcess;
+use tokio::process::Command;
+
+use crate::error::McpError;
+use crate::tool::McpTool;
+
+type ClientService = RunningService<rmcp::RoleClient, ()>;
+
+pub struct McpClient {
+    server_id: String,
+    service: Arc<ClientService>,
+    timeout: Duration,
+}
+
+impl std::fmt::Debug for McpClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("McpClient")
+            .field("server_id", &self.server_id)
+            .field("timeout", &self.timeout)
+            .finish_non_exhaustive()
+    }
+}
+
+impl McpClient {
+    /// Spawn child process, perform MCP handshake.
+    ///
+    /// # Errors
+    ///
+    /// Returns `McpError::Connection` if the process cannot be spawned or handshake fails.
+    pub async fn connect(
+        server_id: &str,
+        command: &str,
+        args: &[String],
+        env: &std::collections::HashMap<String, String>,
+        timeout: Duration,
+    ) -> Result<Self, McpError> {
+        let mut cmd = Command::new(command);
+        cmd.args(args);
+        for (k, v) in env {
+            cmd.env(k, v);
+        }
+
+        let transport = TokioChildProcess::new(cmd).map_err(|e| McpError::Connection {
+            server_id: server_id.into(),
+            source: e.into(),
+        })?;
+
+        let service =
+            ().serve(transport)
+                .await
+                .map_err(|e| McpError::Connection {
+                    server_id: server_id.into(),
+                    source: anyhow::anyhow!("{e}"),
+                })?;
+
+        Ok(Self {
+            server_id: server_id.into(),
+            service: Arc::new(service),
+            timeout,
+        })
+    }
+
+    /// Call tools/list, convert to `McpTool` vec.
+    ///
+    /// # Errors
+    ///
+    /// Returns `McpError::ToolCall` if listing fails.
+    pub async fn list_tools(&self) -> Result<Vec<McpTool>, McpError> {
+        let tools = self
+            .service
+            .list_all_tools()
+            .await
+            .map_err(|e| McpError::ToolCall {
+                server_id: self.server_id.clone(),
+                tool_name: "tools/list".into(),
+                source: anyhow::anyhow!("{e}"),
+            })?;
+
+        Ok(tools
+            .into_iter()
+            .map(|t| McpTool {
+                server_id: self.server_id.clone(),
+                name: t.name.to_string(),
+                description: t.description.map_or_else(String::new, |d| d.to_string()),
+                input_schema: serde_json::to_value(&*t.input_schema).unwrap_or_default(),
+            })
+            .collect())
+    }
+
+    /// Call tools/call with JSON args, return the result.
+    ///
+    /// # Errors
+    ///
+    /// Returns `McpError::Timeout` or `McpError::ToolCall` on failure.
+    pub async fn call_tool(
+        &self,
+        name: &str,
+        args: serde_json::Value,
+    ) -> Result<CallToolResult, McpError> {
+        let arguments: Option<serde_json::Map<String, serde_json::Value>> = args
+            .as_object()
+            .map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect());
+
+        let params = CallToolRequestParams {
+            name: Cow::Owned(name.to_owned()),
+            arguments,
+            task: None,
+            meta: None,
+        };
+
+        let result = tokio::time::timeout(self.timeout, self.service.call_tool(params))
+            .await
+            .map_err(|_| McpError::Timeout {
+                server_id: self.server_id.clone(),
+                tool_name: name.into(),
+                timeout_secs: self.timeout.as_secs(),
+            })?
+            .map_err(|e| McpError::ToolCall {
+                server_id: self.server_id.clone(),
+                tool_name: name.into(),
+                source: anyhow::anyhow!("{e}"),
+            })?;
+
+        Ok(result)
+    }
+
+    /// Graceful shutdown.
+    pub async fn shutdown(self) {
+        match Arc::try_unwrap(self.service) {
+            Ok(service) => {
+                let _ = service.cancel().await;
+            }
+            Err(_arc) => {
+                tracing::warn!(
+                    server_id = self.server_id,
+                    "cannot shutdown: service has multiple references"
+                );
+            }
+        }
+    }
+}

--- a/crates/zeph-mcp/src/error.rs
+++ b/crates/zeph-mcp/src/error.rs
@@ -1,0 +1,85 @@
+#[derive(Debug, thiserror::Error)]
+pub enum McpError {
+    #[error("connection failed for server '{server_id}': {source}")]
+    Connection {
+        server_id: String,
+        source: anyhow::Error,
+    },
+
+    #[error("tool call failed: {server_id}/{tool_name}: {source}")]
+    ToolCall {
+        server_id: String,
+        tool_name: String,
+        source: anyhow::Error,
+    },
+
+    #[error("server '{server_id}' not found")]
+    ServerNotFound { server_id: String },
+
+    #[error("tool '{tool_name}' not found on server '{server_id}'")]
+    ToolNotFound {
+        server_id: String,
+        tool_name: String,
+    },
+
+    #[error("tool call timed out after {timeout_secs}s: {server_id}/{tool_name}")]
+    Timeout {
+        server_id: String,
+        tool_name: String,
+        timeout_secs: u64,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn connection_error_display() {
+        let err = McpError::Connection {
+            server_id: "github".into(),
+            source: anyhow::anyhow!("refused"),
+        };
+        assert_eq!(
+            err.to_string(),
+            "connection failed for server 'github': refused"
+        );
+    }
+
+    #[test]
+    fn tool_call_error_display() {
+        let err = McpError::ToolCall {
+            server_id: "fs".into(),
+            tool_name: "read_file".into(),
+            source: anyhow::anyhow!("not found"),
+        };
+        assert_eq!(err.to_string(), "tool call failed: fs/read_file: not found");
+    }
+
+    #[test]
+    fn server_not_found_display() {
+        let err = McpError::ServerNotFound {
+            server_id: "missing".into(),
+        };
+        assert_eq!(err.to_string(), "server 'missing' not found");
+    }
+
+    #[test]
+    fn tool_not_found_display() {
+        let err = McpError::ToolNotFound {
+            server_id: "fs".into(),
+            tool_name: "delete".into(),
+        };
+        assert_eq!(err.to_string(), "tool 'delete' not found on server 'fs'");
+    }
+
+    #[test]
+    fn timeout_error_display() {
+        let err = McpError::Timeout {
+            server_id: "slow".into(),
+            tool_name: "query".into(),
+            timeout_secs: 30,
+        };
+        assert_eq!(err.to_string(), "tool call timed out after 30s: slow/query");
+    }
+}

--- a/crates/zeph-mcp/src/executor.rs
+++ b/crates/zeph-mcp/src/executor.rs
@@ -1,0 +1,149 @@
+use std::sync::Arc;
+
+use zeph_tools::executor::{ToolError, ToolExecutor, ToolOutput, extract_fenced_blocks};
+
+use crate::manager::McpManager;
+
+#[derive(Debug, Clone)]
+pub struct McpToolExecutor {
+    manager: Arc<McpManager>,
+}
+
+impl McpToolExecutor {
+    #[must_use]
+    pub fn new(manager: Arc<McpManager>) -> Self {
+        Self { manager }
+    }
+}
+
+impl ToolExecutor for McpToolExecutor {
+    async fn execute(&self, response: &str) -> Result<Option<ToolOutput>, ToolError> {
+        let blocks = extract_fenced_blocks(response, "mcp");
+        if blocks.is_empty() {
+            return Ok(None);
+        }
+
+        let mut outputs = Vec::with_capacity(blocks.len());
+        #[allow(clippy::cast_possible_truncation)]
+        let blocks_executed = blocks.len() as u32;
+
+        for block in &blocks {
+            let instruction: McpInstruction =
+                serde_json::from_str(block).map_err(|e: serde_json::Error| {
+                    ToolError::Execution(std::io::Error::other(e.to_string()))
+                })?;
+
+            let result = self
+                .manager
+                .call_tool(&instruction.server, &instruction.tool, instruction.args)
+                .await
+                .map_err(|e| ToolError::Execution(std::io::Error::other(e.to_string())))?;
+
+            let text = result
+                .content
+                .iter()
+                .filter_map(|c| {
+                    if let rmcp::model::RawContent::Text(t) = &c.raw {
+                        Some(t.text.as_str())
+                    } else {
+                        tracing::debug!(
+                            server = instruction.server,
+                            tool = instruction.tool,
+                            "skipping non-text content from MCP tool"
+                        );
+                        None
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            outputs.push(format!(
+                "[mcp:{}:{}]\n{}",
+                instruction.server, instruction.tool, text,
+            ));
+        }
+
+        Ok(Some(ToolOutput {
+            summary: outputs.join("\n\n"),
+            blocks_executed,
+        }))
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct McpInstruction {
+    server: String,
+    tool: String,
+    #[serde(default = "default_args")]
+    args: serde_json::Value,
+}
+
+fn default_args() -> serde_json::Value {
+    serde_json::Value::Object(serde_json::Map::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_instruction_full() {
+        let json = r#"{"server": "github", "tool": "create_issue", "args": {"title": "bug"}}"#;
+        let instr: McpInstruction = serde_json::from_str(json).unwrap();
+        assert_eq!(instr.server, "github");
+        assert_eq!(instr.tool, "create_issue");
+        assert_eq!(instr.args["title"], "bug");
+    }
+
+    #[test]
+    fn parse_instruction_no_args() {
+        let json = r#"{"server": "fs", "tool": "list_dir"}"#;
+        let instr: McpInstruction = serde_json::from_str(json).unwrap();
+        assert_eq!(instr.server, "fs");
+        assert_eq!(instr.tool, "list_dir");
+        assert!(instr.args.is_object());
+    }
+
+    #[test]
+    fn parse_instruction_empty_args() {
+        let json = r#"{"server": "s", "tool": "t", "args": {}}"#;
+        let instr: McpInstruction = serde_json::from_str(json).unwrap();
+        assert!(instr.args.as_object().unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_instruction_missing_server_fails() {
+        let json = r#"{"tool": "t"}"#;
+        assert!(serde_json::from_str::<McpInstruction>(json).is_err());
+    }
+
+    #[test]
+    fn parse_instruction_missing_tool_fails() {
+        let json = r#"{"server": "s"}"#;
+        assert!(serde_json::from_str::<McpInstruction>(json).is_err());
+    }
+
+    #[test]
+    fn extract_mcp_blocks() {
+        let text = "Here:\n```mcp\n{\"server\":\"a\",\"tool\":\"b\"}\n```\nDone";
+        let blocks = extract_fenced_blocks(text, "mcp");
+        assert_eq!(blocks.len(), 1);
+        assert!(blocks[0].contains("\"server\""));
+    }
+
+    #[test]
+    fn no_mcp_blocks() {
+        let text = "```bash\necho hello\n```";
+        let blocks = extract_fenced_blocks(text, "mcp");
+        assert!(blocks.is_empty());
+    }
+
+    #[test]
+    fn multiple_mcp_blocks() {
+        let text = "```mcp\n{\"server\":\"a\",\"tool\":\"b\"}\n```\n\
+                    text\n\
+                    ```mcp\n{\"server\":\"c\",\"tool\":\"d\"}\n```";
+        let blocks = extract_fenced_blocks(text, "mcp");
+        assert_eq!(blocks.len(), 2);
+    }
+}

--- a/crates/zeph-mcp/src/lib.rs
+++ b/crates/zeph-mcp/src/lib.rs
@@ -1,0 +1,18 @@
+//! MCP client lifecycle, tool discovery, and execution.
+
+pub mod client;
+pub mod error;
+pub mod executor;
+pub mod manager;
+pub mod prompt;
+#[cfg(feature = "qdrant")]
+pub mod registry;
+pub mod tool;
+
+pub use error::McpError;
+pub use executor::McpToolExecutor;
+pub use manager::{McpManager, ServerEntry};
+pub use prompt::format_mcp_tools_prompt;
+#[cfg(feature = "qdrant")]
+pub use registry::McpToolRegistry;
+pub use tool::McpTool;

--- a/crates/zeph-mcp/src/manager.rs
+++ b/crates/zeph-mcp/src/manager.rs
@@ -1,0 +1,122 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use rmcp::model::CallToolResult;
+use tokio::sync::RwLock;
+use tokio::task::JoinSet;
+
+use crate::client::McpClient;
+use crate::error::McpError;
+use crate::tool::McpTool;
+
+/// Server connection parameters consumed by `McpManager`.
+#[derive(Debug, Clone)]
+pub struct ServerEntry {
+    pub id: String,
+    pub command: String,
+    pub args: Vec<String>,
+    pub env: HashMap<String, String>,
+    pub timeout: Duration,
+}
+
+pub struct McpManager {
+    configs: Vec<ServerEntry>,
+    clients: Arc<RwLock<HashMap<String, McpClient>>>,
+}
+
+impl std::fmt::Debug for McpManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("McpManager")
+            .field("server_count", &self.configs.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl McpManager {
+    #[must_use]
+    pub fn new(configs: Vec<ServerEntry>) -> Self {
+        Self {
+            configs,
+            clients: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Connect to all configured servers concurrently, return aggregated tool list.
+    /// Servers that fail to connect are logged and skipped.
+    pub async fn connect_all(&self) -> Vec<McpTool> {
+        let mut join_set = JoinSet::new();
+
+        for config in self.configs.clone() {
+            join_set.spawn(async move {
+                let result = McpClient::connect(
+                    &config.id,
+                    &config.command,
+                    &config.args,
+                    &config.env,
+                    config.timeout,
+                )
+                .await;
+                (config.id, result)
+            });
+        }
+
+        let mut all_tools = Vec::new();
+        let mut clients = self.clients.write().await;
+
+        while let Some(result) = join_set.join_next().await {
+            let Ok((server_id, connect_result)) = result else {
+                tracing::warn!("MCP connection task panicked");
+                continue;
+            };
+
+            match connect_result {
+                Ok(client) => match client.list_tools().await {
+                    Ok(tools) => {
+                        tracing::info!(server_id, tools = tools.len(), "connected to MCP server");
+                        all_tools.extend(tools);
+                        clients.insert(server_id, client);
+                    }
+                    Err(e) => {
+                        tracing::warn!(server_id, "failed to list tools: {e:#}");
+                    }
+                },
+                Err(e) => {
+                    tracing::warn!(server_id, "MCP server connection failed: {e:#}");
+                }
+            }
+        }
+
+        all_tools
+    }
+
+    /// Route tool call to the correct server's client.
+    ///
+    /// # Errors
+    ///
+    /// Returns `McpError::ServerNotFound` if the server is not connected.
+    pub async fn call_tool(
+        &self,
+        server_id: &str,
+        tool_name: &str,
+        args: serde_json::Value,
+    ) -> Result<CallToolResult, McpError> {
+        let clients = self.clients.read().await;
+        let client = clients
+            .get(server_id)
+            .ok_or_else(|| McpError::ServerNotFound {
+                server_id: server_id.into(),
+            })?;
+        client.call_tool(tool_name, args).await
+    }
+
+    /// Graceful shutdown of all connections.
+    pub async fn shutdown_all(self) {
+        let mut clients = self.clients.write().await;
+        let drained: Vec<(String, McpClient)> = clients.drain().collect();
+        for (id, client) in drained {
+            tracing::info!(server_id = id, "shutting down MCP client");
+            client.shutdown().await;
+        }
+    }
+}

--- a/crates/zeph-mcp/src/prompt.rs
+++ b/crates/zeph-mcp/src/prompt.rs
@@ -1,0 +1,84 @@
+use std::fmt::Write;
+
+use crate::tool::McpTool;
+
+#[must_use]
+pub fn format_mcp_tools_prompt(tools: &[McpTool]) -> String {
+    if tools.is_empty() {
+        return String::new();
+    }
+
+    let mut out = String::from("<available_tools>\n");
+    for tool in tools {
+        let _ = writeln!(
+            out,
+            "  <tool server=\"{server}\" name=\"{name}\">\n\
+             \x20   <description>{desc}</description>\n\
+             \x20   <parameters>{schema}</parameters>\n\
+             \x20   <invocation>\n\
+             ```mcp\n\
+             {{\"server\": \"{server}\", \"tool\": \"{name}\", \"args\": {{...}}}}\n\
+             ```\n\
+             \x20   </invocation>\n\
+             \x20 </tool>",
+            server = tool.server_id,
+            name = tool.name,
+            desc = tool.description,
+            schema = tool.input_schema,
+        );
+    }
+    out.push_str("</available_tools>");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_tool(server: &str, name: &str, desc: &str) -> McpTool {
+        McpTool {
+            server_id: server.into(),
+            name: name.into(),
+            description: desc.into(),
+            input_schema: serde_json::json!({"type": "object"}),
+        }
+    }
+
+    #[test]
+    fn empty_tools_returns_empty() {
+        assert!(format_mcp_tools_prompt(&[]).is_empty());
+    }
+
+    #[test]
+    fn single_tool_prompt() {
+        let tools = vec![make_tool("github", "create_issue", "Create issue")];
+        let prompt = format_mcp_tools_prompt(&tools);
+        assert!(prompt.starts_with("<available_tools>"));
+        assert!(prompt.ends_with("</available_tools>"));
+        assert!(prompt.contains("server=\"github\""));
+        assert!(prompt.contains("name=\"create_issue\""));
+        assert!(prompt.contains("<description>Create issue</description>"));
+        assert!(prompt.contains("```mcp"));
+        assert!(prompt.contains("\"server\": \"github\""));
+    }
+
+    #[test]
+    fn multiple_tools_prompt() {
+        let tools = vec![
+            make_tool("github", "create_issue", "Create issue"),
+            make_tool("fs", "read_file", "Read a file"),
+        ];
+        let prompt = format_mcp_tools_prompt(&tools);
+        assert!(prompt.contains("server=\"github\""));
+        assert!(prompt.contains("server=\"fs\""));
+        assert!(prompt.contains("name=\"read_file\""));
+    }
+
+    #[test]
+    fn prompt_contains_parameters() {
+        let tools = vec![make_tool("s", "t", "d")];
+        let prompt = format_mcp_tools_prompt(&tools);
+        assert!(prompt.contains("<parameters>"));
+        assert!(prompt.contains("\"type\":\"object\""));
+    }
+}

--- a/crates/zeph-mcp/src/registry.rs
+++ b/crates/zeph-mcp/src/registry.rs
@@ -1,0 +1,400 @@
+use std::collections::HashMap;
+
+use anyhow::Context;
+use qdrant_client::Qdrant;
+use qdrant_client::qdrant::{
+    CreateCollectionBuilder, DeletePointsBuilder, Distance, PointStruct, PointsIdsList,
+    ScrollPointsBuilder, SearchPointsBuilder, UpsertPointsBuilder, VectorParamsBuilder,
+    value::Kind,
+};
+
+use crate::tool::McpTool;
+
+pub type EmbedFuture =
+    std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<Vec<f32>>> + Send>>;
+
+const COLLECTION_NAME: &str = "zeph_mcp_tools";
+
+const MCP_NAMESPACE: uuid::Uuid = uuid::Uuid::from_bytes([
+    0x7a, 0x65, 0x70, 0x68, // "zeph"
+    0x2d, 0x6d, 0x63, 0x70, // "-mcp"
+    0x2d, 0x74, 0x6f, 0x6f, // "-too"
+    0x6c, 0x73, 0x00, 0x01, // "ls\0\x01"
+]);
+
+#[derive(Debug, Default)]
+pub struct SyncStats {
+    pub added: usize,
+    pub updated: usize,
+    pub removed: usize,
+    pub unchanged: usize,
+}
+
+pub struct McpToolRegistry {
+    client: Qdrant,
+    collection: String,
+    hashes: HashMap<String, String>,
+}
+
+impl std::fmt::Debug for McpToolRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("McpToolRegistry")
+            .field("collection", &self.collection)
+            .finish_non_exhaustive()
+    }
+}
+
+fn content_hash(tool: &McpTool) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(tool.server_id.as_bytes());
+    hasher.update(tool.name.as_bytes());
+    hasher.update(tool.description.as_bytes());
+    hasher.update(tool.input_schema.to_string().as_bytes());
+    hasher.finalize().to_hex().to_string()
+}
+
+fn tool_point_id(tool_key: &str) -> String {
+    uuid::Uuid::new_v5(&MCP_NAMESPACE, tool_key.as_bytes()).to_string()
+}
+
+impl McpToolRegistry {
+    /// # Errors
+    ///
+    /// Returns an error if the Qdrant client cannot be created.
+    pub fn new(qdrant_url: &str) -> anyhow::Result<Self> {
+        let client = Qdrant::from_url(qdrant_url)
+            .build()
+            .context("failed to create Qdrant client")?;
+
+        Ok(Self {
+            client,
+            collection: COLLECTION_NAME.into(),
+            hashes: HashMap::new(),
+        })
+    }
+
+    /// Sync MCP tool embeddings with Qdrant. Computes delta and upserts only changed tools.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if Qdrant communication fails.
+    pub async fn sync<F>(
+        &mut self,
+        tools: &[McpTool],
+        embedding_model: &str,
+        embed_fn: F,
+    ) -> anyhow::Result<SyncStats>
+    where
+        F: Fn(&str) -> EmbedFuture,
+    {
+        let mut stats = SyncStats::default();
+
+        self.ensure_collection(&embed_fn).await?;
+
+        let existing = self.scroll_all().await?;
+
+        let mut current: HashMap<String, (String, &McpTool)> = HashMap::with_capacity(tools.len());
+        for tool in tools {
+            let key = tool.qualified_name();
+            current.insert(key, (content_hash(tool), tool));
+        }
+
+        let model_changed = existing.values().any(|stored| {
+            stored
+                .get("embedding_model")
+                .is_some_and(|m| m != embedding_model)
+        });
+
+        if model_changed {
+            tracing::warn!("embedding model changed to '{embedding_model}', recreating collection");
+            self.recreate_collection(&embed_fn).await?;
+        }
+
+        let mut points_to_upsert = Vec::new();
+        for (key, (hash, tool)) in &current {
+            let needs_update = if let Some(stored) = existing.get(key) {
+                model_changed || stored.get("content_hash").is_some_and(|h| h != hash)
+            } else {
+                true
+            };
+
+            if !needs_update {
+                stats.unchanged += 1;
+                self.hashes.insert(key.clone(), hash.clone());
+                continue;
+            }
+
+            let vector = match embed_fn(&tool.description).await {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!("failed to embed tool '{key}': {e:#}");
+                    continue;
+                }
+            };
+
+            let point_id = tool_point_id(key);
+            let payload: serde_json::Value = serde_json::json!({
+                "tool_key": key,
+                "server_id": tool.server_id,
+                "tool_name": tool.name,
+                "description": tool.description,
+                "content_hash": hash,
+                "embedding_model": embedding_model,
+            });
+            let payload_map: HashMap<String, qdrant_client::qdrant::Value> =
+                serde_json::from_value(payload).context("failed to convert payload")?;
+
+            points_to_upsert.push(PointStruct::new(point_id, vector, payload_map));
+
+            if existing.contains_key(key) {
+                stats.updated += 1;
+            } else {
+                stats.added += 1;
+            }
+            self.hashes.insert(key.clone(), hash.clone());
+        }
+
+        if !points_to_upsert.is_empty() {
+            self.client
+                .upsert_points(UpsertPointsBuilder::new(&self.collection, points_to_upsert))
+                .await
+                .context("failed to upsert MCP tool points")?;
+        }
+
+        let orphan_ids: Vec<String> = existing
+            .keys()
+            .filter(|key| !current.contains_key(*key))
+            .map(|key| tool_point_id(key))
+            .collect();
+
+        if !orphan_ids.is_empty() {
+            stats.removed = orphan_ids.len();
+            let point_ids: Vec<qdrant_client::qdrant::PointId> = orphan_ids
+                .into_iter()
+                .map(|id| qdrant_client::qdrant::PointId::from(id.as_str()))
+                .collect();
+            self.client
+                .delete_points(
+                    DeletePointsBuilder::new(&self.collection)
+                        .points(PointsIdsList { ids: point_ids }),
+                )
+                .await
+                .context("failed to delete orphan MCP tool points")?;
+        }
+
+        tracing::info!(
+            added = stats.added,
+            updated = stats.updated,
+            removed = stats.removed,
+            unchanged = stats.unchanged,
+            "MCP tool embeddings synced"
+        );
+
+        Ok(stats)
+    }
+
+    /// Search for relevant MCP tools using Qdrant vector search.
+    pub async fn search<F>(&self, query: &str, limit: usize, embed_fn: F) -> Vec<McpTool>
+    where
+        F: Fn(&str) -> EmbedFuture,
+    {
+        let query_vec = match embed_fn(query).await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!("failed to embed query: {e:#}");
+                return Vec::new();
+            }
+        };
+
+        let Ok(limit_u64) = u64::try_from(limit) else {
+            return Vec::new();
+        };
+
+        let results = match self
+            .client
+            .search_points(
+                SearchPointsBuilder::new(&self.collection, query_vec, limit_u64).with_payload(true),
+            )
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!("Qdrant MCP tool search failed: {e:#}");
+                return Vec::new();
+            }
+        };
+
+        results
+            .result
+            .into_iter()
+            .filter_map(|point| {
+                let server_id = extract_string(&point.payload, "server_id")?;
+                let name = extract_string(&point.payload, "tool_name")?;
+                let description = extract_string(&point.payload, "description").unwrap_or_default();
+                Some(McpTool {
+                    server_id,
+                    name,
+                    description,
+                    input_schema: serde_json::Value::Object(serde_json::Map::new()),
+                })
+            })
+            .collect()
+    }
+
+    async fn recreate_collection<F>(&self, embed_fn: &F) -> anyhow::Result<()>
+    where
+        F: Fn(&str) -> EmbedFuture,
+    {
+        if self.client.collection_exists(&self.collection).await? {
+            self.client
+                .delete_collection(&self.collection)
+                .await
+                .context("failed to delete MCP tools collection for recreation")?;
+            tracing::info!(
+                collection = &self.collection,
+                "deleted MCP tools collection for recreation"
+            );
+        }
+        self.ensure_collection(embed_fn).await
+    }
+
+    async fn ensure_collection<F>(&self, embed_fn: &F) -> anyhow::Result<()>
+    where
+        F: Fn(&str) -> EmbedFuture,
+    {
+        if self.client.collection_exists(&self.collection).await? {
+            return Ok(());
+        }
+
+        let probe = embed_fn("dimension probe")
+            .await
+            .context("failed to probe embedding dimensions")?;
+        let vector_size = u64::try_from(probe.len()).context("embedding dimension exceeds u64")?;
+
+        self.client
+            .create_collection(
+                CreateCollectionBuilder::new(&self.collection)
+                    .vectors_config(VectorParamsBuilder::new(vector_size, Distance::Cosine)),
+            )
+            .await
+            .context("failed to create MCP tools collection")?;
+
+        tracing::info!(
+            collection = &self.collection,
+            dimensions = vector_size,
+            "created Qdrant collection for MCP tool embeddings"
+        );
+
+        Ok(())
+    }
+
+    async fn scroll_all(&self) -> anyhow::Result<HashMap<String, HashMap<String, String>>> {
+        let mut result = HashMap::new();
+        let mut offset: Option<qdrant_client::qdrant::PointId> = None;
+
+        loop {
+            let mut builder = ScrollPointsBuilder::new(&self.collection)
+                .with_payload(true)
+                .with_vectors(false)
+                .limit(100);
+
+            if let Some(ref off) = offset {
+                builder = builder.offset(off.clone());
+            }
+
+            let response = self
+                .client
+                .scroll(builder)
+                .await
+                .context("failed to scroll MCP tool points")?;
+
+            for point in &response.result {
+                let Some(key_val) = point.payload.get("tool_key") else {
+                    continue;
+                };
+                let Some(Kind::StringValue(key)) = &key_val.kind else {
+                    continue;
+                };
+
+                let mut fields = HashMap::new();
+                for (k, val) in &point.payload {
+                    if let Some(Kind::StringValue(s)) = &val.kind {
+                        fields.insert(k.clone(), s.clone());
+                    }
+                }
+                result.insert(key.clone(), fields);
+            }
+
+            match response.next_page_offset {
+                Some(next) => offset = Some(next),
+                None => break,
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+fn extract_string(
+    payload: &HashMap<String, qdrant_client::qdrant::Value>,
+    key: &str,
+) -> Option<String> {
+    let val = payload.get(key)?;
+    match &val.kind {
+        Some(Kind::StringValue(s)) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_tool(server: &str, name: &str) -> McpTool {
+        McpTool {
+            server_id: server.into(),
+            name: name.into(),
+            description: "test".into(),
+            input_schema: serde_json::json!({}),
+        }
+    }
+
+    #[test]
+    fn content_hash_deterministic() {
+        let tool = make_tool("github", "create_issue");
+        let h1 = content_hash(&tool);
+        let h2 = content_hash(&tool);
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn content_hash_changes_on_modification() {
+        let t1 = make_tool("github", "create_issue");
+        let mut t2 = make_tool("github", "create_issue");
+        t2.description = "modified".into();
+        assert_ne!(content_hash(&t1), content_hash(&t2));
+    }
+
+    #[test]
+    fn tool_point_id_deterministic() {
+        let id1 = tool_point_id("github:create_issue");
+        let id2 = tool_point_id("github:create_issue");
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn tool_point_id_different_keys() {
+        let id1 = tool_point_id("github:create_issue");
+        let id2 = tool_point_id("fs:read_file");
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn sync_stats_default() {
+        let stats = SyncStats::default();
+        assert_eq!(stats.added, 0);
+        assert_eq!(stats.updated, 0);
+        assert_eq!(stats.removed, 0);
+        assert_eq!(stats.unchanged, 0);
+    }
+}

--- a/crates/zeph-mcp/src/tool.rs
+++ b/crates/zeph-mcp/src/tool.rs
@@ -1,0 +1,53 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpTool {
+    pub server_id: String,
+    pub name: String,
+    pub description: String,
+    pub input_schema: serde_json::Value,
+}
+
+impl McpTool {
+    #[must_use]
+    pub fn qualified_name(&self) -> String {
+        format!("{}:{}", self.server_id, self.name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_tool(server: &str, name: &str) -> McpTool {
+        McpTool {
+            server_id: server.into(),
+            name: name.into(),
+            description: "test tool".into(),
+            input_schema: serde_json::json!({}),
+        }
+    }
+
+    #[test]
+    fn qualified_name_format() {
+        let tool = make_tool("github", "create_issue");
+        assert_eq!(tool.qualified_name(), "github:create_issue");
+    }
+
+    #[test]
+    fn tool_roundtrip_json() {
+        let tool = make_tool("fs", "read_file");
+        let json = serde_json::to_string(&tool).unwrap();
+        let parsed: McpTool = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.server_id, "fs");
+        assert_eq!(parsed.name, "read_file");
+        assert_eq!(parsed.description, "test tool");
+    }
+
+    #[test]
+    fn tool_clone() {
+        let tool = make_tool("a", "b");
+        let cloned = tool.clone();
+        assert_eq!(tool.qualified_name(), cloned.qualified_name());
+    }
+}

--- a/skills/mcp-generate/SKILL.md
+++ b/skills/mcp-generate/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: mcp-generate
+description: Generate MCP server configuration for Zeph. Use when the user asks about adding MCP servers, configuring MCP tools, or integrating external tool providers.
+---
+# MCP Server Configuration
+
+## Adding an MCP Server
+
+Add server entries to `config/default.toml`:
+
+```toml
+[[mcp.servers]]
+id = "github"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+timeout = 30
+
+[mcp.servers.env]
+GITHUB_PERSONAL_ACCESS_TOKEN = "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+```
+
+## Configuration Fields
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `id` | yes | — | Unique server identifier |
+| `command` | yes | — | Executable to spawn |
+| `args` | no | `[]` | Command arguments |
+| `env` | no | `{}` | Environment variables |
+| `timeout` | no | `30` | Tool call timeout in seconds |
+
+## Enabling MCP Feature
+
+Build with MCP support:
+```bash
+cargo build --features mcp
+```
+
+Or add to default features in `Cargo.toml`:
+```toml
+[features]
+default = ["a2a", "mcp"]
+```
+
+## Common MCP Servers
+
+### Filesystem
+```toml
+[[mcp.servers]]
+id = "filesystem"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "/path/to/allowed/dir"]
+```
+
+### GitHub
+```toml
+[[mcp.servers]]
+id = "github"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+
+[mcp.servers.env]
+GITHUB_PERSONAL_ACCESS_TOKEN = "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+```
+
+## How It Works
+
+1. On startup, Zeph connects to each configured MCP server via stdio
+2. Tools are discovered via the MCP `tools/list` protocol
+3. Tool descriptions are embedded into Qdrant for semantic matching
+4. When a user query matches an MCP tool, it appears in the system prompt
+5. The agent invokes tools via ` ```mcp ` fenced blocks with JSON payloads

--- a/skills/setup-guide/SKILL.md
+++ b/skills/setup-guide/SKILL.md
@@ -107,6 +107,24 @@ export ZEPH_TOOLS_SCRAPE_TIMEOUT=15
 export ZEPH_TOOLS_SCRAPE_MAX_BODY=1048576
 ```
 
+## MCP (Model Context Protocol)
+
+Build with `--features mcp` to enable MCP tool integration.
+
+Config in `config/default.toml`:
+```toml
+[[mcp.servers]]
+id = "github"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+timeout = 30
+
+[mcp.servers.env]
+GITHUB_PERSONAL_ACCESS_TOKEN = "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+```
+
+MCP tools are discovered at startup, embedded into Qdrant (`zeph_mcp_tools` collection), and matched per query alongside skills. Tool invocations use ` ```mcp ` fenced blocks with JSON payloads.
+
 ## Skills
 
 ```bash


### PR DESCRIPTION
## Summary

- New `zeph-mcp` crate: MCP client via rmcp 0.14 with stdio transport for connecting to external MCP servers
- `McpClient` and `McpManager` for multi-server lifecycle management with concurrent connections (JoinSet)
- `McpToolExecutor` implementing `ToolExecutor` trait — parses ` ```mcp` blocks from LLM responses and routes to MCP servers
- `McpToolRegistry`: MCP tool embeddings in Qdrant `zeph_mcp_tools` collection with BLAKE3 content-hash delta sync
- Unified matching in agent loop: skills + MCP tools injected into system prompt by embedding similarity
- Bundled `mcp-generate` skill for MCP-to-skill generation via mcp-execution-cli
- `[[mcp.servers]]` TOML config with per-server command, args, env, timeout
- Feature-gated behind `mcp` flag (off by default)
- Custom Debug impl on McpServerConfig redacting env values (API keys)
- 25 unit tests in zeph-mcp, all 24 existing workspace tests unaffected

## Architecture

```
MCP Server (stdio)          MCP Server (stdio)
      |                           |
   rmcp client               rmcp client
      |                           |
  McpManager --- tool registry --- Qdrant (zeph_mcp_tools)
      |                                    |
  Agent loop <- unified matcher ---------- system prompt
      |
  ```mcp block -> rmcp tools/call -> result -> LLM
```

Leaf crate: `zeph-mcp` depends only on `zeph-tools` (+ rmcp + optional Qdrant deps).

## Test plan

- [x] cargo build (with and without mcp feature)
- [x] cargo clippy -- -D warnings
- [x] cargo +nightly fmt --check
- [x] cargo nextest run (24 workspace tests pass)
- [x] cargo nextest run -p zeph-mcp --all-features (25 tests pass)
- [x] Feature-gate verification: both build modes clean
- [ ] Integration test with real MCP server (manual, requires npx)

Closes #116, #117, #118, #119, #120, #121.