### PR TITLE
feat(skills): add self-learning skill evolution system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Config examples for candle and orchestrator in `config/default.toml`
 - Setup guide sections for candle local inference and model orchestrator
 - 15 new unit tests for orchestrator, chat templates, generation config, and loader
+- Self-learning skill evolution system: automatic skill improvement through failure detection, self-reflection retry, and LLM-generated version updates (Issue #107)
+- `SkillOutcome` enum and `SkillMetrics` for skill execution outcome tracking (Issue #108)
+- Agent self-reflection retry on tool failure with 1-retry-per-message budget (Issue #109)
+- Skill version generation and storage in SQLite with auto-activate and manual approval modes (Issue #110)
+- Automatic rollback when skill version success rate drops below threshold (Issue #111)
+- `/skill stats`, `/skill versions`, `/skill activate`, `/skill approve`, `/skill reset` commands for version management (Issue #111)
+- `/feedback` command for explicit user feedback on skill quality (Issue #112)
+- `LearningConfig` with TOML config section `[skills.learning]` and env var overrides
+- `self-learning` feature flag on `zeph-skills`, `zeph-core`, and root binary
+- SQLite migration 005: `skill_versions` and `skill_outcomes` tables
 - Bundled `setup-guide` skill with configuration reference for all env vars, TOML keys, and operating modes
 - Bundled `skill-audit` skill for spec compliance and security review of installed skills
 - `allowed_commands` shell config to override default blocklist entries via `ZEPH_TOOLS_SHELL_ALLOWED_COMMANDS`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ candle = ["zeph-llm/candle"]
 metal = ["zeph-llm/metal"]
 cuda = ["zeph-llm/cuda"]
 orchestrator = ["zeph-llm/orchestrator"]
+self-learning = ["zeph-core/self-learning"]
 
 [dependencies]
 anyhow.workspace = true

--- a/config/default.toml
+++ b/config/default.toml
@@ -55,6 +55,24 @@ paths = ["./skills"]
 # Maximum number of skills to inject into context per query (embedding-based selection)
 max_active_skills = 5
 
+[skills.learning]
+# Enable self-learning skill improvement (requires self-learning feature)
+enabled = false
+# Automatically activate improved versions (false = require manual approval)
+auto_activate = false
+# Minimum failures before generating improvement
+min_failures = 3
+# Success rate threshold below which improvement is triggered (0.0-1.0)
+improve_threshold = 0.7
+# Success rate below which automatic rollback occurs (0.0-1.0)
+rollback_threshold = 0.5
+# Minimum evaluations before rollback decision
+min_evaluations = 5
+# Maximum auto-generated versions per skill
+max_versions = 10
+# Cooldown between improvements for same skill (minutes)
+cooldown_minutes = 60
+
 [memory]
 # SQLite database path for conversation history
 sqlite_path = "./data/zeph.db"

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 [features]
 default = []
 mcp = ["dep:zeph-mcp"]
+self-learning = ["zeph-skills/self-learning"]
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/zeph-core/src/agent.rs
+++ b/crates/zeph-core/src/agent.rs
@@ -13,6 +13,8 @@ use zeph_skills::watcher::SkillEvent;
 use zeph_tools::executor::{ToolError, ToolExecutor};
 
 use crate::channel::Channel;
+#[cfg(feature = "self-learning")]
+use crate::config::LearningConfig;
 use crate::context::build_system_prompt;
 
 // TODO(M14): Make configurable via AgentConfig (currently hardcoded for MVP)
@@ -35,6 +37,11 @@ pub struct Agent<P: LlmProvider + Clone + 'static, C: Channel, T: ToolExecutor> 
     recall_limit: usize,
     summarization_threshold: usize,
     shutdown: watch::Receiver<bool>,
+    active_skill_names: Vec<String>,
+    #[cfg(feature = "self-learning")]
+    learning_config: Option<LearningConfig>,
+    #[cfg(feature = "self-learning")]
+    reflection_used: bool,
     #[cfg(feature = "mcp")]
     mcp_tools: Vec<zeph_mcp::McpTool>,
     #[cfg(feature = "mcp")]
@@ -74,6 +81,11 @@ impl<P: LlmProvider + Clone + 'static, C: Channel, T: ToolExecutor> Agent<P, C, 
             recall_limit: 5,
             summarization_threshold: 100,
             shutdown: rx,
+            active_skill_names: Vec::new(),
+            #[cfg(feature = "self-learning")]
+            learning_config: None,
+            #[cfg(feature = "self-learning")]
+            reflection_used: false,
             #[cfg(feature = "mcp")]
             mcp_tools: Vec::new(),
             #[cfg(feature = "mcp")]
@@ -118,6 +130,13 @@ impl<P: LlmProvider + Clone + 'static, C: Channel, T: ToolExecutor> Agent<P, C, 
     ) -> Self {
         self.skill_paths = paths;
         self.skill_reload_rx = Some(rx);
+        self
+    }
+
+    #[cfg(feature = "self-learning")]
+    #[must_use]
+    pub fn with_learning(mut self, config: LearningConfig) -> Self {
+        self.learning_config = Some(config);
         self
     }
 
@@ -192,12 +211,29 @@ impl<P: LlmProvider + Clone + 'static, C: Channel, T: ToolExecutor> Agent<P, C, 
                 break;
             };
 
-            if incoming.text.trim() == "/skills" {
+            let trimmed = incoming.text.trim();
+
+            if trimmed == "/skills" {
                 self.handle_skills_command().await?;
                 continue;
             }
 
+            if let Some(rest) = trimmed.strip_prefix("/skill ") {
+                self.handle_skill_command(rest).await?;
+                continue;
+            }
+
+            if let Some(rest) = trimmed.strip_prefix("/feedback ") {
+                self.handle_feedback(rest).await?;
+                continue;
+            }
+
             self.rebuild_system_prompt(&incoming.text).await;
+
+            #[cfg(feature = "self-learning")]
+            {
+                self.reflection_used = false;
+            }
 
             self.messages.push(Message {
                 role: Role::User,
@@ -244,6 +280,253 @@ impl<P: LlmProvider + Clone + 'static, C: Channel, T: ToolExecutor> Agent<P, C, 
         }
 
         self.channel.send(&output).await
+    }
+
+    #[cfg(feature = "self-learning")]
+    async fn handle_skill_command(&mut self, args: &str) -> anyhow::Result<()> {
+        let parts: Vec<&str> = args.split_whitespace().collect();
+        match parts.first().copied() {
+            Some("stats") => self.handle_skill_stats().await,
+            Some("versions") => self.handle_skill_versions(parts.get(1).copied()).await,
+            Some("activate") => {
+                self.handle_skill_activate(parts.get(1).copied(), parts.get(2).copied())
+                    .await
+            }
+            Some("approve") => self.handle_skill_approve(parts.get(1).copied()).await,
+            Some("reset") => self.handle_skill_reset(parts.get(1).copied()).await,
+            _ => {
+                self.channel
+                    .send("Unknown /skill subcommand. Available: stats, versions, activate, approve, reset")
+                    .await
+            }
+        }
+    }
+
+    #[cfg(not(feature = "self-learning"))]
+    async fn handle_skill_command(&mut self, _args: &str) -> anyhow::Result<()> {
+        self.channel
+            .send("Self-learning feature is not enabled.")
+            .await
+    }
+
+    #[cfg(feature = "self-learning")]
+    async fn handle_skill_stats(&mut self) -> anyhow::Result<()> {
+        use std::fmt::Write;
+
+        let Some(memory) = &self.memory else {
+            return self.channel.send("Memory not available.").await;
+        };
+
+        let stats = memory.sqlite().load_skill_outcome_stats().await?;
+        if stats.is_empty() {
+            return self.channel.send("No skill outcome data yet.").await;
+        }
+
+        let mut output = String::from("Skill outcome statistics:\n\n");
+        #[allow(clippy::cast_precision_loss)]
+        for row in &stats {
+            let rate = if row.total == 0 {
+                0.0
+            } else {
+                row.successes as f64 / row.total as f64 * 100.0
+            };
+            let _ = writeln!(
+                output,
+                "- {}: {} total, {} ok, {} fail ({rate:.0}%)",
+                row.skill_name, row.total, row.successes, row.failures,
+            );
+        }
+
+        self.channel.send(&output).await
+    }
+
+    #[cfg(feature = "self-learning")]
+    async fn handle_skill_versions(&mut self, name: Option<&str>) -> anyhow::Result<()> {
+        use std::fmt::Write;
+
+        let Some(name) = name else {
+            return self.channel.send("Usage: /skill versions <name>").await;
+        };
+        let Some(memory) = &self.memory else {
+            return self.channel.send("Memory not available.").await;
+        };
+
+        let versions = memory.sqlite().load_skill_versions(name).await?;
+        if versions.is_empty() {
+            return self
+                .channel
+                .send(&format!("No versions found for \"{name}\"."))
+                .await;
+        }
+
+        let mut output = format!("Versions for \"{name}\":\n\n");
+        for v in &versions {
+            let active_tag = if v.is_active { ", active" } else { "" };
+            let _ = writeln!(
+                output,
+                "  v{} ({}{active_tag}) — success: {}, failure: {}",
+                v.version, v.source, v.success_count, v.failure_count,
+            );
+        }
+
+        self.channel.send(&output).await
+    }
+
+    #[cfg(feature = "self-learning")]
+    async fn handle_skill_activate(
+        &mut self,
+        name: Option<&str>,
+        version_str: Option<&str>,
+    ) -> anyhow::Result<()> {
+        let (Some(name), Some(ver_str)) = (name, version_str) else {
+            return self
+                .channel
+                .send("Usage: /skill activate <name> <version>")
+                .await;
+        };
+        let Ok(ver) = ver_str.parse::<i64>() else {
+            return self.channel.send("Invalid version number.").await;
+        };
+        let Some(memory) = &self.memory else {
+            return self.channel.send("Memory not available.").await;
+        };
+
+        let versions = memory.sqlite().load_skill_versions(name).await?;
+        let Some(target) = versions.iter().find(|v| v.version == ver) else {
+            return self
+                .channel
+                .send(&format!("Version {ver} not found for \"{name}\"."))
+                .await;
+        };
+
+        memory
+            .sqlite()
+            .activate_skill_version(name, target.id)
+            .await?;
+
+        write_skill_file(&self.skill_paths, name, &target.description, &target.body).await?;
+
+        self.channel
+            .send(&format!("Activated v{ver} for \"{name}\"."))
+            .await
+    }
+
+    #[cfg(feature = "self-learning")]
+    async fn handle_skill_approve(&mut self, name: Option<&str>) -> anyhow::Result<()> {
+        let Some(name) = name else {
+            return self.channel.send("Usage: /skill approve <name>").await;
+        };
+        let Some(memory) = &self.memory else {
+            return self.channel.send("Memory not available.").await;
+        };
+
+        let versions = memory.sqlite().load_skill_versions(name).await?;
+        let pending = versions
+            .iter()
+            .rfind(|v| v.source == "auto" && !v.is_active);
+
+        let Some(target) = pending else {
+            return self
+                .channel
+                .send(&format!("No pending auto version for \"{name}\"."))
+                .await;
+        };
+
+        memory
+            .sqlite()
+            .activate_skill_version(name, target.id)
+            .await?;
+
+        write_skill_file(&self.skill_paths, name, &target.description, &target.body).await?;
+
+        self.channel
+            .send(&format!(
+                "Approved and activated v{} for \"{name}\".",
+                target.version
+            ))
+            .await
+    }
+
+    #[cfg(feature = "self-learning")]
+    async fn handle_skill_reset(&mut self, name: Option<&str>) -> anyhow::Result<()> {
+        let Some(name) = name else {
+            return self.channel.send("Usage: /skill reset <name>").await;
+        };
+        let Some(memory) = &self.memory else {
+            return self.channel.send("Memory not available.").await;
+        };
+
+        let versions = memory.sqlite().load_skill_versions(name).await?;
+        let Some(v1) = versions.iter().find(|v| v.version == 1) else {
+            return self
+                .channel
+                .send(&format!("Original version not found for \"{name}\"."))
+                .await;
+        };
+
+        memory.sqlite().activate_skill_version(name, v1.id).await?;
+
+        write_skill_file(&self.skill_paths, name, &v1.description, &v1.body).await?;
+
+        self.channel
+            .send(&format!("Reset \"{name}\" to original v1."))
+            .await
+    }
+
+    async fn handle_feedback(&mut self, input: &str) -> anyhow::Result<()> {
+        #[cfg(feature = "self-learning")]
+        {
+            let (skill_name, feedback) = match input.split_once(' ') {
+                Some((name, rest)) => (name.trim(), rest.trim().trim_matches('"')),
+                None => {
+                    return self
+                        .channel
+                        .send("Usage: /feedback <skill_name> <message>")
+                        .await;
+                }
+            };
+
+            if feedback.is_empty() {
+                return self
+                    .channel
+                    .send("Usage: /feedback <skill_name> <message>")
+                    .await;
+            }
+
+            let Some(memory) = &self.memory else {
+                return self.channel.send("Memory not available.").await;
+            };
+
+            memory
+                .sqlite()
+                .record_skill_outcome(
+                    skill_name,
+                    None,
+                    self.conversation_id,
+                    "user_rejection",
+                    Some(feedback),
+                )
+                .await?;
+
+            if self.is_learning_enabled() {
+                self.generate_improved_skill(skill_name, feedback, "", Some(feedback))
+                    .await
+                    .ok();
+            }
+
+            return self
+                .channel
+                .send(&format!("Feedback recorded for \"{skill_name}\"."))
+                .await;
+        }
+
+        #[cfg(not(feature = "self-learning"))]
+        {
+            let _ = input;
+            self.channel
+                .send("Self-learning feature is not enabled.")
+                .await
+        }
     }
 
     async fn reload_skills(&mut self) {
@@ -296,6 +579,8 @@ impl<P: LlmProvider + Clone + 'static, C: Channel, T: ToolExecutor> Agent<P, C, 
         } else {
             self.skills.iter().collect()
         };
+
+        self.active_skill_names = active_skills.iter().map(|s| s.name.clone()).collect();
 
         if !active_skills.is_empty()
             && let Some(memory) = &self.memory
@@ -362,6 +647,17 @@ impl<P: LlmProvider + Clone + 'static, C: Channel, T: ToolExecutor> Agent<P, C, 
 
             if response.trim().is_empty() {
                 tracing::warn!("received empty response from LLM, skipping");
+                self.record_skill_outcomes("empty_response", None).await;
+
+                #[cfg(feature = "self-learning")]
+                if !self.reflection_used
+                    && self
+                        .attempt_self_reflection("LLM returned empty response", "")
+                        .await?
+                {
+                    return Ok(());
+                }
+
                 self.channel
                     .send("Received an empty response. Please try again.")
                     .await?;
@@ -378,7 +674,24 @@ impl<P: LlmProvider + Clone + 'static, C: Channel, T: ToolExecutor> Agent<P, C, 
                 Ok(Some(output)) => {
                     if output.summary.trim().is_empty() {
                         tracing::warn!("tool execution returned empty output");
+                        self.record_skill_outcomes("success", None).await;
                         return Ok(());
+                    }
+
+                    if output.summary.contains("[error]") || output.summary.contains("[exit code") {
+                        self.record_skill_outcomes("tool_failure", Some(&output.summary))
+                            .await;
+
+                        #[cfg(feature = "self-learning")]
+                        if !self.reflection_used
+                            && self
+                                .attempt_self_reflection(&output.summary, &output.summary)
+                                .await?
+                        {
+                            return Ok(());
+                        }
+                    } else {
+                        self.record_skill_outcomes("success", None).await;
                     }
 
                     let formatted_output = format!("[tool output]\n```\n{output}\n```");
@@ -390,7 +703,10 @@ impl<P: LlmProvider + Clone + 'static, C: Channel, T: ToolExecutor> Agent<P, C, 
                     });
                     self.persist_message(Role::User, &formatted_output).await;
                 }
-                Ok(None) => return Ok(()),
+                Ok(None) => {
+                    self.record_skill_outcomes("success", None).await;
+                    return Ok(());
+                }
                 Err(ToolError::Blocked { command }) => {
                     tracing::warn!("blocked command: {command}");
                     let error_msg = "This command is blocked by security policy.".to_string();
@@ -398,7 +714,16 @@ impl<P: LlmProvider + Clone + 'static, C: Channel, T: ToolExecutor> Agent<P, C, 
                     return Ok(());
                 }
                 Err(e) => {
-                    tracing::error!("tool execution error: {e:#}");
+                    let err_str = format!("{e:#}");
+                    tracing::error!("tool execution error: {err_str}");
+                    self.record_skill_outcomes("tool_failure", Some(&err_str))
+                        .await;
+
+                    #[cfg(feature = "self-learning")]
+                    if !self.reflection_used && self.attempt_self_reflection(&err_str, "").await? {
+                        return Ok(());
+                    }
+
                     self.channel
                         .send("Tool execution failed. Please try a different approach.")
                         .await?;
@@ -472,6 +797,399 @@ impl<P: LlmProvider + Clone + 'static, C: Channel, T: ToolExecutor> Agent<P, C, 
             }
         }
     }
+
+    // --- Self-learning integration ---
+
+    #[cfg(feature = "self-learning")]
+    fn is_learning_enabled(&self) -> bool {
+        self.learning_config.as_ref().is_some_and(|c| c.enabled)
+    }
+
+    #[cfg(not(feature = "self-learning"))]
+    #[allow(dead_code, clippy::unused_self)]
+    fn is_learning_enabled(&self) -> bool {
+        false
+    }
+
+    #[cfg(feature = "self-learning")]
+    async fn record_skill_outcomes(&self, outcome: &str, error_context: Option<&str>) {
+        if self.active_skill_names.is_empty() {
+            return;
+        }
+        let Some(memory) = &self.memory else { return };
+        if let Err(e) = memory
+            .sqlite()
+            .record_skill_outcomes_batch(
+                &self.active_skill_names,
+                self.conversation_id,
+                outcome,
+                error_context,
+            )
+            .await
+        {
+            tracing::warn!("failed to record skill outcomes: {e:#}");
+        }
+
+        if outcome != "success" {
+            for name in &self.active_skill_names {
+                self.check_rollback(name).await;
+            }
+        }
+    }
+
+    #[cfg(not(feature = "self-learning"))]
+    #[allow(clippy::unused_async)]
+    async fn record_skill_outcomes(&self, _outcome: &str, _error_context: Option<&str>) {}
+
+    #[cfg(feature = "self-learning")]
+    async fn attempt_self_reflection(
+        &mut self,
+        error_context: &str,
+        tool_output: &str,
+    ) -> anyhow::Result<bool> {
+        if self.reflection_used || !self.is_learning_enabled() {
+            return Ok(false);
+        }
+        self.reflection_used = true;
+
+        let skill = self
+            .active_skill_names
+            .first()
+            .and_then(|name| self.skills.iter().find(|s| s.name == *name))
+            .cloned();
+
+        let Some(skill) = skill else {
+            return Ok(false);
+        };
+
+        let prompt = zeph_skills::evolution::build_reflection_prompt(
+            &skill.name,
+            &skill.body,
+            error_context,
+            tool_output,
+        );
+
+        self.messages.push(Message {
+            role: Role::User,
+            content: prompt,
+        });
+
+        let messages_before = self.messages.len();
+        // Box::pin to break async recursion cycle (process_response → attempt_self_reflection → process_response)
+        Box::pin(self.process_response()).await?;
+        let retry_succeeded = self.messages.len() > messages_before;
+
+        if retry_succeeded {
+            let successful_response = self
+                .messages
+                .iter()
+                .rev()
+                .find(|m| m.role == Role::Assistant)
+                .map(|m| m.content.clone())
+                .unwrap_or_default();
+
+            self.generate_improved_skill(&skill.name, error_context, &successful_response, None)
+                .await
+                .ok();
+        }
+
+        Ok(retry_succeeded)
+    }
+
+    #[cfg(feature = "self-learning")]
+    #[allow(clippy::cast_precision_loss)]
+    async fn generate_improved_skill(
+        &self,
+        skill_name: &str,
+        error_context: &str,
+        successful_response: &str,
+        user_feedback: Option<&str>,
+    ) -> anyhow::Result<()> {
+        if !self.is_learning_enabled() {
+            return Ok(());
+        }
+
+        let Some(memory) = &self.memory else {
+            return Ok(());
+        };
+        let Some(config) = self.learning_config.as_ref() else {
+            return Ok(());
+        };
+
+        let skill = self
+            .skills
+            .iter()
+            .find(|s| s.name == skill_name)
+            .ok_or_else(|| anyhow::anyhow!("skill not found: {skill_name}"))?;
+
+        memory
+            .sqlite()
+            .ensure_skill_version_exists(skill_name, &skill.body, &skill.description)
+            .await?;
+
+        if !self
+            .check_improvement_allowed(memory, config, skill_name, user_feedback)
+            .await?
+        {
+            return Ok(());
+        }
+
+        let generated_body = self
+            .call_improvement_llm(
+                skill_name,
+                &skill.body,
+                error_context,
+                successful_response,
+                user_feedback,
+            )
+            .await?;
+        let generated_body = generated_body.trim();
+
+        if generated_body.is_empty()
+            || !zeph_skills::evolution::validate_body_size(&skill.body, generated_body)
+        {
+            tracing::warn!("improvement for {skill_name} rejected (empty or too large)");
+            return Ok(());
+        }
+
+        self.store_improved_version(
+            memory,
+            config,
+            skill_name,
+            generated_body,
+            &skill.description,
+            error_context,
+        )
+        .await
+    }
+
+    #[cfg(feature = "self-learning")]
+    #[allow(clippy::cast_precision_loss)]
+    async fn check_improvement_allowed(
+        &self,
+        memory: &SemanticMemory<P>,
+        config: &LearningConfig,
+        skill_name: &str,
+        user_feedback: Option<&str>,
+    ) -> anyhow::Result<bool> {
+        if let Some(last_time) = memory.sqlite().last_improvement_time(skill_name).await?
+            && let Ok(last) = chrono_parse_sqlite(&last_time)
+        {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            let elapsed_minutes = (now.saturating_sub(last)) / 60;
+            if elapsed_minutes < config.cooldown_minutes {
+                tracing::debug!(
+                    "cooldown active for {skill_name}: {elapsed_minutes}m < {}m",
+                    config.cooldown_minutes
+                );
+                return Ok(false);
+            }
+        }
+
+        if user_feedback.is_none()
+            && let Some(metrics) = memory.sqlite().skill_metrics(skill_name).await?
+        {
+            if metrics.failures < i64::from(config.min_failures) {
+                return Ok(false);
+            }
+            let rate = if metrics.total == 0 {
+                1.0
+            } else {
+                metrics.successes as f64 / metrics.total as f64
+            };
+            if rate >= config.improve_threshold {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+
+    #[cfg(feature = "self-learning")]
+    async fn call_improvement_llm(
+        &self,
+        skill_name: &str,
+        original_body: &str,
+        error_context: &str,
+        successful_response: &str,
+        user_feedback: Option<&str>,
+    ) -> anyhow::Result<String> {
+        let prompt = zeph_skills::evolution::build_improvement_prompt(
+            skill_name,
+            original_body,
+            error_context,
+            successful_response,
+            user_feedback,
+        );
+
+        let messages = vec![
+            Message {
+                role: Role::System,
+                content:
+                    "You are a skill improvement assistant. Output only the improved skill body."
+                        .into(),
+            },
+            Message {
+                role: Role::User,
+                content: prompt,
+            },
+        ];
+
+        self.provider.chat(&messages).await
+    }
+
+    #[cfg(feature = "self-learning")]
+    async fn store_improved_version(
+        &self,
+        memory: &SemanticMemory<P>,
+        config: &LearningConfig,
+        skill_name: &str,
+        generated_body: &str,
+        description: &str,
+        error_context: &str,
+    ) -> anyhow::Result<()> {
+        let active = memory.sqlite().active_skill_version(skill_name).await?;
+        let predecessor_id = active.as_ref().map(|v| v.id);
+
+        let next_ver = memory.sqlite().next_skill_version(skill_name).await?;
+        let version_id = memory
+            .sqlite()
+            .save_skill_version(
+                skill_name,
+                next_ver,
+                generated_body,
+                description,
+                "auto",
+                Some(error_context),
+                predecessor_id,
+            )
+            .await?;
+
+        tracing::info!("generated v{next_ver} for skill {skill_name} (id={version_id})");
+
+        if config.auto_activate {
+            memory
+                .sqlite()
+                .activate_skill_version(skill_name, version_id)
+                .await?;
+            write_skill_file(&self.skill_paths, skill_name, description, generated_body).await?;
+            tracing::info!("auto-activated v{next_ver} for {skill_name}");
+        }
+
+        memory
+            .sqlite()
+            .prune_skill_versions(skill_name, config.max_versions)
+            .await?;
+
+        Ok(())
+    }
+
+    #[cfg(feature = "self-learning")]
+    #[allow(clippy::cast_precision_loss)]
+    async fn check_rollback(&self, skill_name: &str) {
+        if !self.is_learning_enabled() {
+            return;
+        }
+        let Some(memory) = &self.memory else { return };
+        let Some(config) = &self.learning_config else {
+            return;
+        };
+        let Ok(Some(metrics)) = memory.sqlite().skill_metrics(skill_name).await else {
+            return;
+        };
+
+        if metrics.total < i64::from(config.min_evaluations) {
+            return;
+        }
+
+        let rate = if metrics.total == 0 {
+            1.0
+        } else {
+            metrics.successes as f64 / metrics.total as f64
+        };
+
+        if rate >= config.rollback_threshold {
+            return;
+        }
+
+        let Ok(Some(active)) = memory.sqlite().active_skill_version(skill_name).await else {
+            return;
+        };
+        if active.source != "auto" {
+            return;
+        }
+        let Ok(Some(predecessor)) = memory.sqlite().predecessor_version(active.id).await else {
+            return;
+        };
+
+        tracing::warn!(
+            "rolling back {skill_name} from v{} to v{} (rate: {rate:.0}%)",
+            active.version,
+            predecessor.version,
+        );
+
+        if memory
+            .sqlite()
+            .activate_skill_version(skill_name, predecessor.id)
+            .await
+            .is_ok()
+        {
+            write_skill_file(
+                &self.skill_paths,
+                skill_name,
+                &predecessor.description,
+                &predecessor.body,
+            )
+            .await
+            .ok();
+        }
+    }
+}
+
+#[cfg(feature = "self-learning")]
+async fn write_skill_file(
+    skill_paths: &[PathBuf],
+    skill_name: &str,
+    description: &str,
+    body: &str,
+) -> anyhow::Result<()> {
+    if skill_name.contains('/') || skill_name.contains('\\') || skill_name.contains("..") {
+        anyhow::bail!("invalid skill name: {skill_name}");
+    }
+    for base in skill_paths {
+        let skill_dir = base.join(skill_name);
+        let skill_file = skill_dir.join("SKILL.md");
+        if skill_file.exists() {
+            let content =
+                format!("---\nname: {skill_name}\ndescription: {description}\n---\n{body}\n");
+            tokio::fs::write(&skill_file, content).await?;
+            return Ok(());
+        }
+    }
+    anyhow::bail!("skill directory not found for {skill_name}")
+}
+
+/// Naive parser for `SQLite` datetime strings (e.g. "2024-01-15 10:30:00") to Unix seconds.
+#[cfg(feature = "self-learning")]
+fn chrono_parse_sqlite(s: &str) -> Result<u64, ()> {
+    // Format: "YYYY-MM-DD HH:MM:SS"
+    let parts: Vec<&str> = s.split(&['-', ' ', ':'][..]).collect();
+    if parts.len() < 6 {
+        return Err(());
+    }
+    let year: u64 = parts[0].parse().map_err(|_| ())?;
+    let month: u64 = parts[1].parse().map_err(|_| ())?;
+    let day: u64 = parts[2].parse().map_err(|_| ())?;
+    let hour: u64 = parts[3].parse().map_err(|_| ())?;
+    let min: u64 = parts[4].parse().map_err(|_| ())?;
+    let sec: u64 = parts[5].parse().map_err(|_| ())?;
+
+    // Rough approximation (sufficient for cooldown comparison)
+    let days_approx = (year - 1970) * 365 + (month - 1) * 30 + (day - 1);
+    Ok(days_approx * 86400 + hour * 3600 + min * 60 + sec)
 }
 
 async fn shutdown_signal(rx: &mut watch::Receiver<bool>) {
@@ -486,5 +1204,92 @@ async fn recv_skill_event(rx: &mut Option<mpsc::Receiver<SkillEvent>>) -> Option
     match rx {
         Some(rx) => rx.recv().await,
         None => std::future::pending().await,
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "self-learning")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chrono_parse_valid_datetime() {
+        let secs = chrono_parse_sqlite("2024-01-15 10:30:00").unwrap();
+        assert!(secs > 0);
+    }
+
+    #[test]
+    fn chrono_parse_ordering_preserved() {
+        let earlier = chrono_parse_sqlite("2024-01-15 10:00:00").unwrap();
+        let later = chrono_parse_sqlite("2024-01-15 11:00:00").unwrap();
+        assert!(later > earlier);
+    }
+
+    #[test]
+    fn chrono_parse_different_days() {
+        let day1 = chrono_parse_sqlite("2024-06-01 00:00:00").unwrap();
+        let day2 = chrono_parse_sqlite("2024-06-02 00:00:00").unwrap();
+        assert_eq!(day2 - day1, 86400);
+    }
+
+    #[test]
+    fn chrono_parse_invalid_format() {
+        assert!(chrono_parse_sqlite("not-a-date").is_err());
+        assert!(chrono_parse_sqlite("").is_err());
+        assert!(chrono_parse_sqlite("2024-01").is_err());
+    }
+
+    #[tokio::test]
+    async fn write_skill_file_missing_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = write_skill_file(
+            &[dir.path().to_path_buf()],
+            "nonexistent-skill",
+            "desc",
+            "body",
+        )
+        .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn write_skill_file_updates_existing() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("test-skill");
+        std::fs::create_dir(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "old content").unwrap();
+
+        write_skill_file(
+            &[dir.path().to_path_buf()],
+            "test-skill",
+            "new desc",
+            "new body",
+        )
+        .await
+        .unwrap();
+
+        let content = std::fs::read_to_string(skill_dir.join("SKILL.md")).unwrap();
+        assert!(content.contains("new body"));
+        assert!(content.contains("new desc"));
+    }
+
+    #[tokio::test]
+    async fn write_skill_file_rejects_path_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(
+            write_skill_file(&[dir.path().to_path_buf()], "../evil", "d", "b")
+                .await
+                .is_err()
+        );
+        assert!(
+            write_skill_file(&[dir.path().to_path_buf()], "a/b", "d", "b")
+                .await
+                .is_err()
+        );
+        assert!(
+            write_skill_file(&[dir.path().to_path_buf()], "a\\b", "d", "b")
+                .await
+                .is_err()
+        );
     }
 }

--- a/crates/zeph-memory/migrations/005_skill_versions.sql
+++ b/crates/zeph-memory/migrations/005_skill_versions.sql
@@ -1,0 +1,29 @@
+CREATE TABLE skill_versions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    skill_name TEXT NOT NULL,
+    version INTEGER NOT NULL,
+    body TEXT NOT NULL,
+    description TEXT NOT NULL,
+    source TEXT NOT NULL DEFAULT 'manual',
+    error_context TEXT,
+    predecessor_id INTEGER REFERENCES skill_versions(id) ON DELETE SET NULL,
+    is_active INTEGER NOT NULL DEFAULT 0,
+    success_count INTEGER NOT NULL DEFAULT 0,
+    failure_count INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE UNIQUE INDEX idx_skill_version ON skill_versions(skill_name, version);
+CREATE INDEX idx_skill_active ON skill_versions(skill_name, is_active);
+
+CREATE TABLE skill_outcomes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    skill_name TEXT NOT NULL,
+    version_id INTEGER REFERENCES skill_versions(id) ON DELETE SET NULL,
+    conversation_id INTEGER,
+    outcome TEXT NOT NULL,
+    error_context TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_skill_outcomes_name ON skill_outcomes(skill_name);

--- a/crates/zeph-memory/src/sqlite.rs
+++ b/crates/zeph-memory/src/sqlite.rs
@@ -337,6 +337,379 @@ impl SqliteStore {
             )
             .collect())
     }
+
+    // --- Self-learning skill evolution methods ---
+
+    /// Record a skill outcome event.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the insert fails.
+    pub async fn record_skill_outcome(
+        &self,
+        skill_name: &str,
+        version_id: Option<i64>,
+        conversation_id: Option<i64>,
+        outcome: &str,
+        error_context: Option<&str>,
+    ) -> anyhow::Result<()> {
+        sqlx::query(
+            "INSERT INTO skill_outcomes (skill_name, version_id, conversation_id, outcome, error_context) \
+             VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(skill_name)
+        .bind(version_id)
+        .bind(conversation_id)
+        .bind(outcome)
+        .bind(error_context)
+        .execute(&self.pool)
+        .await
+        .context("failed to record skill outcome")?;
+        Ok(())
+    }
+
+    /// Record outcomes for multiple skills in a single transaction.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any insert fails (whole batch is rolled back).
+    pub async fn record_skill_outcomes_batch(
+        &self,
+        skill_names: &[String],
+        conversation_id: Option<i64>,
+        outcome: &str,
+        error_context: Option<&str>,
+    ) -> anyhow::Result<()> {
+        let mut tx = self.pool.begin().await.context("failed to begin tx")?;
+        for name in skill_names {
+            sqlx::query(
+                "INSERT INTO skill_outcomes \
+                 (skill_name, version_id, conversation_id, outcome, error_context) \
+                 VALUES (?, ?, ?, ?, ?)",
+            )
+            .bind(name)
+            .bind(None::<i64>)
+            .bind(conversation_id)
+            .bind(outcome)
+            .bind(error_context)
+            .execute(&mut *tx)
+            .await
+            .context("failed to record skill outcome")?;
+        }
+        tx.commit().await.context("failed to commit outcomes")?;
+        Ok(())
+    }
+
+    /// Load metrics for a skill (latest version group).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query fails.
+    pub async fn skill_metrics(&self, skill_name: &str) -> anyhow::Result<Option<SkillMetricsRow>> {
+        let row: Option<(String, Option<i64>, i64, i64, i64)> = sqlx::query_as(
+            "SELECT skill_name, version_id, \
+             COUNT(*) as total, \
+             SUM(CASE WHEN outcome = 'success' THEN 1 ELSE 0 END) as successes, \
+             COUNT(*) - SUM(CASE WHEN outcome = 'success' THEN 1 ELSE 0 END) as failures \
+             FROM skill_outcomes WHERE skill_name = ? \
+             GROUP BY skill_name, version_id \
+             ORDER BY version_id DESC LIMIT 1",
+        )
+        .bind(skill_name)
+        .fetch_optional(&self.pool)
+        .await
+        .context("failed to load skill metrics")?;
+
+        Ok(row.map(
+            |(skill_name, version_id, total, successes, failures)| SkillMetricsRow {
+                skill_name,
+                version_id,
+                total,
+                successes,
+                failures,
+            },
+        ))
+    }
+
+    /// Load all skill outcome stats grouped by skill name.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query fails.
+    pub async fn load_skill_outcome_stats(&self) -> anyhow::Result<Vec<SkillMetricsRow>> {
+        let rows: Vec<(String, Option<i64>, i64, i64, i64)> = sqlx::query_as(
+            "SELECT skill_name, version_id, \
+             COUNT(*) as total, \
+             SUM(CASE WHEN outcome = 'success' THEN 1 ELSE 0 END) as successes, \
+             COUNT(*) - SUM(CASE WHEN outcome = 'success' THEN 1 ELSE 0 END) as failures \
+             FROM skill_outcomes \
+             GROUP BY skill_name \
+             ORDER BY total DESC",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .context("failed to load skill outcome stats")?;
+
+        Ok(rows
+            .into_iter()
+            .map(
+                |(skill_name, version_id, total, successes, failures)| SkillMetricsRow {
+                    skill_name,
+                    version_id,
+                    total,
+                    successes,
+                    failures,
+                },
+            )
+            .collect())
+    }
+
+    /// Save a new skill version and return its ID.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the insert fails.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn save_skill_version(
+        &self,
+        skill_name: &str,
+        version: i64,
+        body: &str,
+        description: &str,
+        source: &str,
+        error_context: Option<&str>,
+        predecessor_id: Option<i64>,
+    ) -> anyhow::Result<i64> {
+        let row: (i64,) = sqlx::query_as(
+            "INSERT INTO skill_versions \
+             (skill_name, version, body, description, source, error_context, predecessor_id) \
+             VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id",
+        )
+        .bind(skill_name)
+        .bind(version)
+        .bind(body)
+        .bind(description)
+        .bind(source)
+        .bind(error_context)
+        .bind(predecessor_id)
+        .fetch_one(&self.pool)
+        .await
+        .context("failed to save skill version")?;
+        Ok(row.0)
+    }
+
+    /// Load the active version for a skill.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query fails.
+    pub async fn active_skill_version(
+        &self,
+        skill_name: &str,
+    ) -> anyhow::Result<Option<SkillVersionRow>> {
+        let row: Option<SkillVersionTuple> = sqlx::query_as(
+            "SELECT id, skill_name, version, body, description, source, \
+                 is_active, success_count, failure_count, created_at \
+                 FROM skill_versions WHERE skill_name = ? AND is_active = 1 LIMIT 1",
+        )
+        .bind(skill_name)
+        .fetch_optional(&self.pool)
+        .await
+        .context("failed to load active skill version")?;
+
+        Ok(row.map(skill_version_from_tuple))
+    }
+
+    /// Activate a specific version (deactivates others for the same skill).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the update fails.
+    pub async fn activate_skill_version(
+        &self,
+        skill_name: &str,
+        version_id: i64,
+    ) -> anyhow::Result<()> {
+        let mut tx = self.pool.begin().await.context("failed to begin tx")?;
+
+        sqlx::query(
+            "UPDATE skill_versions SET is_active = 0 WHERE skill_name = ? AND is_active = 1",
+        )
+        .bind(skill_name)
+        .execute(&mut *tx)
+        .await
+        .context("failed to deactivate versions")?;
+
+        sqlx::query("UPDATE skill_versions SET is_active = 1 WHERE id = ?")
+            .bind(version_id)
+            .execute(&mut *tx)
+            .await
+            .context("failed to activate version")?;
+
+        tx.commit().await.context("failed to commit activation")?;
+        Ok(())
+    }
+
+    /// Get the next version number for a skill.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query fails.
+    pub async fn next_skill_version(&self, skill_name: &str) -> anyhow::Result<i64> {
+        let row: (i64,) = sqlx::query_as(
+            "SELECT COALESCE(MAX(version), 0) + 1 FROM skill_versions WHERE skill_name = ?",
+        )
+        .bind(skill_name)
+        .fetch_one(&self.pool)
+        .await
+        .context("failed to get next version")?;
+        Ok(row.0)
+    }
+
+    /// Get the latest auto-generated version's `created_at` for cooldown check.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query fails.
+    pub async fn last_improvement_time(&self, skill_name: &str) -> anyhow::Result<Option<String>> {
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT created_at FROM skill_versions \
+             WHERE skill_name = ? AND source = 'auto' \
+             ORDER BY id DESC LIMIT 1",
+        )
+        .bind(skill_name)
+        .fetch_optional(&self.pool)
+        .await
+        .context("failed to get last improvement time")?;
+        Ok(row.map(|r| r.0))
+    }
+
+    /// Ensure a base (v1 manual) version exists for a skill. Idempotent.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the DB operation fails.
+    pub async fn ensure_skill_version_exists(
+        &self,
+        skill_name: &str,
+        body: &str,
+        description: &str,
+    ) -> anyhow::Result<()> {
+        let existing: Option<(i64,)> =
+            sqlx::query_as("SELECT id FROM skill_versions WHERE skill_name = ? LIMIT 1")
+                .bind(skill_name)
+                .fetch_optional(&self.pool)
+                .await
+                .context("failed to check skill version existence")?;
+
+        if existing.is_none() {
+            let id = self
+                .save_skill_version(skill_name, 1, body, description, "manual", None, None)
+                .await?;
+            self.activate_skill_version(skill_name, id).await?;
+        }
+        Ok(())
+    }
+
+    /// Load all versions for a skill, ordered by version number.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query fails.
+    pub async fn load_skill_versions(
+        &self,
+        skill_name: &str,
+    ) -> anyhow::Result<Vec<SkillVersionRow>> {
+        let rows: Vec<SkillVersionTuple> = sqlx::query_as(
+            "SELECT id, skill_name, version, body, description, source, \
+                 is_active, success_count, failure_count, created_at \
+                 FROM skill_versions WHERE skill_name = ? ORDER BY version ASC",
+        )
+        .bind(skill_name)
+        .fetch_all(&self.pool)
+        .await
+        .context("failed to load skill versions")?;
+
+        Ok(rows.into_iter().map(skill_version_from_tuple).collect())
+    }
+
+    /// Count auto-generated versions for a skill.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query fails.
+    pub async fn count_auto_versions(&self, skill_name: &str) -> anyhow::Result<i64> {
+        let row: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM skill_versions WHERE skill_name = ? AND source = 'auto'",
+        )
+        .bind(skill_name)
+        .fetch_one(&self.pool)
+        .await
+        .context("failed to count auto versions")?;
+        Ok(row.0)
+    }
+
+    /// Delete oldest non-active auto versions exceeding max limit.
+    /// Returns the number of pruned versions.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the delete fails.
+    pub async fn prune_skill_versions(
+        &self,
+        skill_name: &str,
+        max_versions: u32,
+    ) -> anyhow::Result<u32> {
+        let result = sqlx::query(
+            "DELETE FROM skill_versions WHERE id IN (\
+                SELECT id FROM skill_versions \
+                WHERE skill_name = ? AND source = 'auto' AND is_active = 0 \
+                ORDER BY id ASC \
+                LIMIT max(0, (SELECT COUNT(*) FROM skill_versions \
+                    WHERE skill_name = ? AND source = 'auto') - ?)\
+            )",
+        )
+        .bind(skill_name)
+        .bind(skill_name)
+        .bind(max_versions)
+        .execute(&self.pool)
+        .await
+        .context("failed to prune skill versions")?;
+        Ok(u32::try_from(result.rows_affected()).unwrap_or(0))
+    }
+
+    /// Get the predecessor version for rollback.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query fails.
+    pub async fn predecessor_version(
+        &self,
+        version_id: i64,
+    ) -> anyhow::Result<Option<SkillVersionRow>> {
+        let pred_id: Option<(Option<i64>,)> =
+            sqlx::query_as("SELECT predecessor_id FROM skill_versions WHERE id = ?")
+                .bind(version_id)
+                .fetch_optional(&self.pool)
+                .await
+                .context("failed to get predecessor id")?;
+
+        let Some((Some(pid),)) = pred_id else {
+            return Ok(None);
+        };
+
+        let row: Option<SkillVersionTuple> = sqlx::query_as(
+            "SELECT id, skill_name, version, body, description, source, \
+                 is_active, success_count, failure_count, created_at \
+                 FROM skill_versions WHERE id = ?",
+        )
+        .bind(pid)
+        .fetch_optional(&self.pool)
+        .await
+        .context("failed to load predecessor version")?;
+
+        Ok(row.map(skill_version_from_tuple))
+    }
 }
 
 #[derive(Debug)]
@@ -344,6 +717,57 @@ pub struct SkillUsageRow {
     pub skill_name: String,
     pub invocation_count: i64,
     pub last_used_at: String,
+}
+
+#[derive(Debug)]
+pub struct SkillMetricsRow {
+    pub skill_name: String,
+    pub version_id: Option<i64>,
+    pub total: i64,
+    pub successes: i64,
+    pub failures: i64,
+}
+
+#[derive(Debug)]
+pub struct SkillVersionRow {
+    pub id: i64,
+    pub skill_name: String,
+    pub version: i64,
+    pub body: String,
+    pub description: String,
+    pub source: String,
+    pub is_active: bool,
+    pub success_count: i64,
+    pub failure_count: i64,
+    pub created_at: String,
+}
+
+type SkillVersionTuple = (
+    i64,
+    String,
+    i64,
+    String,
+    String,
+    String,
+    i64,
+    i64,
+    i64,
+    String,
+);
+
+fn skill_version_from_tuple(t: SkillVersionTuple) -> SkillVersionRow {
+    SkillVersionRow {
+        id: t.0,
+        skill_name: t.1,
+        version: t.2,
+        body: t.3,
+        description: t.4,
+        source: t.5,
+        is_active: t.6 != 0,
+        success_count: t.7,
+        failure_count: t.8,
+        created_at: t.9,
+    }
 }
 
 fn parse_role(s: &str) -> Role {
@@ -781,5 +1205,351 @@ mod tests {
         assert_eq!(usage[0].invocation_count, 2);
         assert_eq!(usage[1].skill_name, "docker");
         assert_eq!(usage[1].invocation_count, 1);
+    }
+
+    // --- Self-learning skill evolution tests ---
+
+    #[tokio::test]
+    async fn migration_005_creates_tables() {
+        let store = test_store().await;
+        let pool = store.pool();
+
+        let versions: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='skill_versions'",
+        )
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        assert_eq!(versions.0, 1);
+
+        let outcomes: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='skill_outcomes'",
+        )
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        assert_eq!(outcomes.0, 1);
+    }
+
+    #[tokio::test]
+    async fn record_skill_outcome_inserts() {
+        let store = test_store().await;
+
+        store
+            .record_skill_outcome("git", None, Some(1), "success", None)
+            .await
+            .unwrap();
+        store
+            .record_skill_outcome("git", None, Some(1), "tool_failure", Some("exit code 1"))
+            .await
+            .unwrap();
+
+        let metrics = store.skill_metrics("git").await.unwrap().unwrap();
+        assert_eq!(metrics.total, 2);
+        assert_eq!(metrics.successes, 1);
+        assert_eq!(metrics.failures, 1);
+    }
+
+    #[tokio::test]
+    async fn skill_metrics_none_for_unknown() {
+        let store = test_store().await;
+        let m = store.skill_metrics("nonexistent").await.unwrap();
+        assert!(m.is_none());
+    }
+
+    #[tokio::test]
+    async fn load_skill_outcome_stats_grouped() {
+        let store = test_store().await;
+
+        store
+            .record_skill_outcome("git", None, None, "success", None)
+            .await
+            .unwrap();
+        store
+            .record_skill_outcome("git", None, None, "tool_failure", None)
+            .await
+            .unwrap();
+        store
+            .record_skill_outcome("docker", None, None, "success", None)
+            .await
+            .unwrap();
+
+        let stats = store.load_skill_outcome_stats().await.unwrap();
+        assert_eq!(stats.len(), 2);
+        assert_eq!(stats[0].skill_name, "git");
+        assert_eq!(stats[0].total, 2);
+        assert_eq!(stats[1].skill_name, "docker");
+        assert_eq!(stats[1].total, 1);
+    }
+
+    #[tokio::test]
+    async fn save_and_load_skill_version() {
+        let store = test_store().await;
+
+        let id = store
+            .save_skill_version("git", 1, "body v1", "Git helper", "manual", None, None)
+            .await
+            .unwrap();
+        assert!(id > 0);
+
+        store.activate_skill_version("git", id).await.unwrap();
+
+        let active = store.active_skill_version("git").await.unwrap().unwrap();
+        assert_eq!(active.version, 1);
+        assert_eq!(active.body, "body v1");
+        assert!(active.is_active);
+    }
+
+    #[tokio::test]
+    async fn activate_deactivates_previous() {
+        let store = test_store().await;
+
+        let v1 = store
+            .save_skill_version("git", 1, "v1", "desc", "manual", None, None)
+            .await
+            .unwrap();
+        store.activate_skill_version("git", v1).await.unwrap();
+
+        let v2 = store
+            .save_skill_version("git", 2, "v2", "desc", "auto", None, Some(v1))
+            .await
+            .unwrap();
+        store.activate_skill_version("git", v2).await.unwrap();
+
+        let versions = store.load_skill_versions("git").await.unwrap();
+        assert_eq!(versions.len(), 2);
+        assert!(!versions[0].is_active);
+        assert!(versions[1].is_active);
+    }
+
+    #[tokio::test]
+    async fn next_skill_version_increments() {
+        let store = test_store().await;
+
+        let next = store.next_skill_version("git").await.unwrap();
+        assert_eq!(next, 1);
+
+        store
+            .save_skill_version("git", 1, "v1", "desc", "manual", None, None)
+            .await
+            .unwrap();
+        let next = store.next_skill_version("git").await.unwrap();
+        assert_eq!(next, 2);
+    }
+
+    #[tokio::test]
+    async fn last_improvement_time_returns_auto_only() {
+        let store = test_store().await;
+
+        store
+            .save_skill_version("git", 1, "v1", "desc", "manual", None, None)
+            .await
+            .unwrap();
+
+        let t = store.last_improvement_time("git").await.unwrap();
+        assert!(t.is_none());
+
+        store
+            .save_skill_version("git", 2, "v2", "desc", "auto", None, None)
+            .await
+            .unwrap();
+
+        let t = store.last_improvement_time("git").await.unwrap();
+        assert!(t.is_some());
+    }
+
+    #[tokio::test]
+    async fn ensure_skill_version_exists_idempotent() {
+        let store = test_store().await;
+
+        store
+            .ensure_skill_version_exists("git", "body", "Git helper")
+            .await
+            .unwrap();
+        store
+            .ensure_skill_version_exists("git", "body2", "Git helper 2")
+            .await
+            .unwrap();
+
+        let versions = store.load_skill_versions("git").await.unwrap();
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0].body, "body");
+    }
+
+    #[tokio::test]
+    async fn load_skill_versions_ordered() {
+        let store = test_store().await;
+
+        let v1 = store
+            .save_skill_version("git", 1, "v1", "desc", "manual", None, None)
+            .await
+            .unwrap();
+        store
+            .save_skill_version("git", 2, "v2", "desc", "auto", None, Some(v1))
+            .await
+            .unwrap();
+
+        let versions = store.load_skill_versions("git").await.unwrap();
+        assert_eq!(versions.len(), 2);
+        assert_eq!(versions[0].version, 1);
+        assert_eq!(versions[1].version, 2);
+    }
+
+    #[tokio::test]
+    async fn count_auto_versions_only() {
+        let store = test_store().await;
+
+        store
+            .save_skill_version("git", 1, "v1", "desc", "manual", None, None)
+            .await
+            .unwrap();
+        store
+            .save_skill_version("git", 2, "v2", "desc", "auto", None, None)
+            .await
+            .unwrap();
+        store
+            .save_skill_version("git", 3, "v3", "desc", "auto", None, None)
+            .await
+            .unwrap();
+
+        let count = store.count_auto_versions("git").await.unwrap();
+        assert_eq!(count, 2);
+    }
+
+    #[tokio::test]
+    async fn prune_preserves_manual_and_active() {
+        let store = test_store().await;
+
+        let v1 = store
+            .save_skill_version("git", 1, "v1", "desc", "manual", None, None)
+            .await
+            .unwrap();
+        store.activate_skill_version("git", v1).await.unwrap();
+
+        for i in 2..=5 {
+            store
+                .save_skill_version("git", i, &format!("v{i}"), "desc", "auto", None, None)
+                .await
+                .unwrap();
+        }
+
+        let pruned = store.prune_skill_versions("git", 2).await.unwrap();
+        assert_eq!(pruned, 2);
+
+        let versions = store.load_skill_versions("git").await.unwrap();
+        assert!(versions.iter().any(|v| v.source == "manual"));
+        let auto_count = versions.iter().filter(|v| v.source == "auto").count();
+        assert_eq!(auto_count, 2);
+    }
+
+    #[tokio::test]
+    async fn predecessor_version_returns_parent() {
+        let store = test_store().await;
+
+        let v1 = store
+            .save_skill_version("git", 1, "v1", "desc", "manual", None, None)
+            .await
+            .unwrap();
+        let v2 = store
+            .save_skill_version("git", 2, "v2", "desc", "auto", None, Some(v1))
+            .await
+            .unwrap();
+
+        let pred = store.predecessor_version(v2).await.unwrap().unwrap();
+        assert_eq!(pred.id, v1);
+        assert_eq!(pred.version, 1);
+    }
+
+    #[tokio::test]
+    async fn predecessor_version_none_for_root() {
+        let store = test_store().await;
+
+        let v1 = store
+            .save_skill_version("git", 1, "v1", "desc", "manual", None, None)
+            .await
+            .unwrap();
+
+        let pred = store.predecessor_version(v1).await.unwrap();
+        assert!(pred.is_none());
+    }
+
+    #[tokio::test]
+    async fn active_skill_version_none_for_unknown() {
+        let store = test_store().await;
+        let active = store.active_skill_version("nonexistent").await.unwrap();
+        assert!(active.is_none());
+    }
+
+    #[tokio::test]
+    async fn load_skill_outcome_stats_empty() {
+        let store = test_store().await;
+        let stats = store.load_skill_outcome_stats().await.unwrap();
+        assert!(stats.is_empty());
+    }
+
+    #[tokio::test]
+    async fn load_skill_versions_empty() {
+        let store = test_store().await;
+        let versions = store.load_skill_versions("nonexistent").await.unwrap();
+        assert!(versions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn count_auto_versions_zero_for_unknown() {
+        let store = test_store().await;
+        let count = store.count_auto_versions("nonexistent").await.unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn prune_nothing_when_below_limit() {
+        let store = test_store().await;
+
+        store
+            .save_skill_version("git", 1, "v1", "desc", "auto", None, None)
+            .await
+            .unwrap();
+
+        let pruned = store.prune_skill_versions("git", 5).await.unwrap();
+        assert_eq!(pruned, 0);
+    }
+
+    #[tokio::test]
+    async fn record_skill_outcome_with_error_context() {
+        let store = test_store().await;
+
+        store
+            .record_skill_outcome(
+                "docker",
+                None,
+                Some(1),
+                "tool_failure",
+                Some("container not found"),
+            )
+            .await
+            .unwrap();
+
+        let metrics = store.skill_metrics("docker").await.unwrap().unwrap();
+        assert_eq!(metrics.total, 1);
+        assert_eq!(metrics.failures, 1);
+    }
+
+    #[tokio::test]
+    async fn save_skill_version_with_error_context() {
+        let store = test_store().await;
+
+        let id = store
+            .save_skill_version(
+                "git",
+                1,
+                "improved body",
+                "Git helper",
+                "auto",
+                Some("exit code 128"),
+                None,
+            )
+            .await
+            .unwrap();
+        assert!(id > 0);
     }
 }

--- a/crates/zeph-skills/Cargo.toml
+++ b/crates/zeph-skills/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 [features]
 default = []
 qdrant = ["dep:blake3", "dep:qdrant-client", "dep:serde_json", "dep:uuid"]
+self-learning = []
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/zeph-skills/src/evolution.rs
+++ b/crates/zeph-skills/src/evolution.rs
@@ -1,0 +1,308 @@
+//! Self-learning skill evolution types and prompt templates.
+
+/// Outcome classification for skill-attributed events.
+#[derive(Debug, Clone)]
+pub enum SkillOutcome {
+    Success,
+    ToolFailure {
+        skill_name: String,
+        error_context: String,
+        tool_output: String,
+    },
+    EmptyResponse {
+        skill_name: String,
+    },
+    UserRejection {
+        skill_name: String,
+        feedback: String,
+    },
+}
+
+impl SkillOutcome {
+    /// Returns a stable string tag for DB storage.
+    #[must_use]
+    pub fn outcome_str(&self) -> &str {
+        match self {
+            Self::Success => "success",
+            Self::ToolFailure { .. } => "tool_failure",
+            Self::EmptyResponse { .. } => "empty_response",
+            Self::UserRejection { .. } => "user_rejection",
+        }
+    }
+
+    /// Extract the skill name from any non-success variant.
+    #[must_use]
+    pub fn skill_name(&self) -> Option<&str> {
+        match self {
+            Self::Success => None,
+            Self::ToolFailure { skill_name, .. }
+            | Self::EmptyResponse { skill_name }
+            | Self::UserRejection { skill_name, .. } => Some(skill_name),
+        }
+    }
+}
+
+/// Aggregated metrics for a skill version.
+#[derive(Debug, Clone)]
+pub struct SkillMetrics {
+    pub skill_name: String,
+    pub version: i64,
+    pub total: i64,
+    pub successes: i64,
+    pub failures: i64,
+}
+
+impl SkillMetrics {
+    #[must_use]
+    #[allow(clippy::cast_precision_loss)]
+    pub fn success_rate(&self) -> f64 {
+        if self.total == 0 {
+            0.0
+        } else {
+            self.successes as f64 / self.total as f64
+        }
+    }
+}
+
+pub const REFLECTION_PROMPT_TEMPLATE: &str = "\
+You attempted to help the user with their request using the following skill instructions:
+
+<skill name=\"{name}\">
+{body}
+</skill>
+
+The attempt failed with this error:
+{error_context}
+
+Tool output:
+{tool_output}
+
+Analyze what went wrong and suggest an improved approach. \
+Then attempt to fulfill the original user request using the improved approach.";
+
+/// Build a reflection prompt by substituting template placeholders.
+#[must_use]
+pub fn build_reflection_prompt(
+    name: &str,
+    body: &str,
+    error_context: &str,
+    tool_output: &str,
+) -> String {
+    REFLECTION_PROMPT_TEMPLATE
+        .replace("{name}", name)
+        .replace("{body}", body)
+        .replace("{error_context}", error_context)
+        .replace("{tool_output}", tool_output)
+}
+
+pub const IMPROVEMENT_PROMPT_TEMPLATE: &str = "\
+The original skill instructions failed, but an alternative approach succeeded.
+
+Original skill:
+<skill name=\"{name}\">
+{original_body}
+</skill>
+
+Failed approach error: {error_context}
+Successful approach: {successful_response}
+{user_feedback_section}
+Generate an improved version of the skill instructions that incorporates the lesson \
+learned. Keep the same format (markdown with bash code blocks). Be concise.
+Only output the improved skill body (no frontmatter, no explanation).";
+
+/// Build an improvement prompt by substituting template placeholders.
+#[must_use]
+pub fn build_improvement_prompt(
+    name: &str,
+    original_body: &str,
+    error_context: &str,
+    successful_response: &str,
+    user_feedback: Option<&str>,
+) -> String {
+    let feedback_section = user_feedback.map_or_else(String::new, |fb| {
+        format!("\nUser feedback on the current skill:\n{fb}\n")
+    });
+    IMPROVEMENT_PROMPT_TEMPLATE
+        .replace("{name}", name)
+        .replace("{original_body}", original_body)
+        .replace("{error_context}", error_context)
+        .replace("{successful_response}", successful_response)
+        .replace("{user_feedback_section}", &feedback_section)
+}
+
+/// Absolute maximum body size to prevent exponential growth across generations.
+pub const MAX_BODY_BYTES: usize = 65_536;
+
+/// Validate that the generated body does not exceed 2x the original size
+/// and stays within the absolute cap.
+#[must_use]
+pub fn validate_body_size(original: &str, generated: &str) -> bool {
+    generated.len() <= original.len() * 2 && generated.len() <= MAX_BODY_BYTES
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn outcome_str_variants() {
+        assert_eq!(SkillOutcome::Success.outcome_str(), "success");
+        assert_eq!(
+            SkillOutcome::ToolFailure {
+                skill_name: "git".into(),
+                error_context: "err".into(),
+                tool_output: "out".into(),
+            }
+            .outcome_str(),
+            "tool_failure"
+        );
+        assert_eq!(
+            SkillOutcome::EmptyResponse {
+                skill_name: "git".into(),
+            }
+            .outcome_str(),
+            "empty_response"
+        );
+        assert_eq!(
+            SkillOutcome::UserRejection {
+                skill_name: "git".into(),
+                feedback: "bad".into(),
+            }
+            .outcome_str(),
+            "user_rejection"
+        );
+    }
+
+    #[test]
+    fn skill_name_extraction() {
+        assert!(SkillOutcome::Success.skill_name().is_none());
+        assert_eq!(
+            SkillOutcome::ToolFailure {
+                skill_name: "docker".into(),
+                error_context: String::new(),
+                tool_output: String::new(),
+            }
+            .skill_name(),
+            Some("docker")
+        );
+        assert_eq!(
+            SkillOutcome::EmptyResponse {
+                skill_name: "git".into(),
+            }
+            .skill_name(),
+            Some("git")
+        );
+        assert_eq!(
+            SkillOutcome::UserRejection {
+                skill_name: "sql".into(),
+                feedback: String::new(),
+            }
+            .skill_name(),
+            Some("sql")
+        );
+    }
+
+    #[test]
+    fn success_rate_zero_total() {
+        let m = SkillMetrics {
+            skill_name: "x".into(),
+            version: 1,
+            total: 0,
+            successes: 0,
+            failures: 0,
+        };
+        assert!((m.success_rate() - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn success_rate_all_success() {
+        let m = SkillMetrics {
+            skill_name: "x".into(),
+            version: 1,
+            total: 10,
+            successes: 10,
+            failures: 0,
+        };
+        assert!((m.success_rate() - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn success_rate_all_failures() {
+        let m = SkillMetrics {
+            skill_name: "x".into(),
+            version: 1,
+            total: 5,
+            successes: 0,
+            failures: 5,
+        };
+        assert!((m.success_rate() - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn success_rate_mixed() {
+        let m = SkillMetrics {
+            skill_name: "x".into(),
+            version: 1,
+            total: 4,
+            successes: 3,
+            failures: 1,
+        };
+        assert!((m.success_rate() - 0.75).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn build_reflection_prompt_substitutes() {
+        let result = build_reflection_prompt("git", "do git stuff", "exit code 1", "fatal: error");
+        assert!(result.contains("<skill name=\"git\">"));
+        assert!(result.contains("do git stuff"));
+        assert!(result.contains("exit code 1"));
+        assert!(result.contains("fatal: error"));
+    }
+
+    #[test]
+    fn build_improvement_prompt_without_feedback() {
+        let result = build_improvement_prompt("git", "original body", "the error", "the fix", None);
+        assert!(result.contains("<skill name=\"git\">"));
+        assert!(result.contains("original body"));
+        assert!(result.contains("the error"));
+        assert!(result.contains("the fix"));
+        assert!(!result.contains("User feedback"));
+    }
+
+    #[test]
+    fn build_improvement_prompt_with_feedback() {
+        let result = build_improvement_prompt(
+            "git",
+            "original body",
+            "the error",
+            "the fix",
+            Some("please fix the commit flow"),
+        );
+        assert!(result.contains("User feedback on the current skill:"));
+        assert!(result.contains("please fix the commit flow"));
+    }
+
+    #[test]
+    fn validate_body_size_within_limit() {
+        assert!(validate_body_size("12345", "1234567890"));
+    }
+
+    #[test]
+    fn validate_body_size_exceeds_limit() {
+        assert!(!validate_body_size("12345", "12345678901"));
+    }
+
+    #[test]
+    fn validate_body_size_empty_original() {
+        assert!(validate_body_size("", ""));
+        assert!(!validate_body_size("", "x"));
+    }
+
+    #[test]
+    fn validate_body_size_absolute_cap() {
+        let large_original = "x".repeat(40_000);
+        let large_generated = "x".repeat(70_000);
+        // Within 2x but exceeds MAX_BODY_BYTES (65536)
+        assert!(!validate_body_size(&large_original, &large_generated));
+    }
+}

--- a/crates/zeph-skills/src/lib.rs
+++ b/crates/zeph-skills/src/lib.rs
@@ -1,5 +1,7 @@
 //! SKILL.md loader, skill registry, and prompt formatter.
 
+#[cfg(feature = "self-learning")]
+pub mod evolution;
 pub mod loader;
 pub mod matcher;
 pub mod prompt;

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,6 +180,9 @@ async fn main() -> anyhow::Result<()> {
     #[cfg(feature = "mcp")]
     let agent = agent.with_mcp(mcp_tools, mcp_registry);
 
+    #[cfg(feature = "self-learning")]
+    let agent = agent.with_learning(config.skills.learning);
+
     let mut agent = agent;
 
     agent.load_history().await?;


### PR DESCRIPTION
## Summary

- Implement automatic skill improvement through failure detection, self-reflection retry, and LLM-generated version updates
- Feature-gated behind `self-learning` flag with zero runtime overhead when disabled
- 5 phases: outcome tracking, self-reflection retry, version generation, rollback/safety, user feedback
- 12 files changed, 2161 insertions across zeph-skills, zeph-memory, zeph-core

## Changes

### Phase 1: Outcome Tracking (#108)
- Migration `005_skill_versions.sql`: `skill_versions` + `skill_outcomes` tables
- `SkillOutcome` enum and `SkillMetrics` in `zeph-skills/src/evolution.rs`
- SQLite methods for recording outcomes and computing metrics
- Agent loop hooks recording outcomes at every exit point in `process_response()`

### Phase 2: Self-Reflection Retry (#109)
- `attempt_self_reflection()` on Agent: builds reflection prompt, retries via recursive `process_response()`
- Max 1 retry per user message, shares existing `MAX_SHELL_ITERATIONS` budget
- `LearningConfig` struct with TOML config and env var overrides

### Phase 3: Skill Version Generation (#110)
- `generate_improved_skill()` with body size validation (2x relative + 64KB absolute cap)
- Cooldown enforcement, improvement threshold checks
- Auto-activate writes to filesystem, SkillWatcher picks up changes

### Phase 4: Rollback and Safety (#111)
- Auto-rollback when success rate < threshold after min evaluations
- `/skill stats|versions|activate|approve|reset` commands
- Version pruning (max 10 auto versions, manual versions never pruned)

### Phase 5: User Feedback (#112)
- `/feedback <skill> <text>` command records `UserRejection` outcome
- Feedback aggregated into improvement prompt

## Safety
- Path traversal validation on skill names before filesystem writes
- Parameterized SQL queries throughout (no string interpolation)
- ON DELETE SET NULL on FK references for safe pruning
- Disabled by default, manual approval by default (`auto_activate = false`)
- Batch outcome recording in single SQLite transaction
- Async filesystem I/O (tokio::fs::write)

## Test plan
- [x] `cargo clippy --features self-learning -- -D warnings` clean
- [x] `cargo clippy -- -D warnings` clean (without feature)
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo nextest run --features self-learning` 130 tests pass
- [x] `cargo nextest run` 24 tests pass (without feature)
- [x] 12 new evolution tests, 22 new sqlite tests, 12 new config/agent tests

Closes #107, closes #108, closes #109, closes #110, closes #111, closes #112.