### PR TITLE
release: v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-02-10
+
 ### Added
 - `VaultProvider` trait with pluggable secret backends, `Secret` newtype with redacted debug output, `EnvVaultProvider` for environment variable secrets (Issue #70)
 - `AgeVaultProvider`: age-encrypted JSON vault backend with x25519 identity key decryption (Issue #70)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7282,7 +7282,7 @@ dependencies = [
 
 [[package]]
 name = "zeph"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -7302,7 +7302,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-a2a"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "axum 0.8.8",
  "eventsource-stream",
@@ -7324,7 +7324,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-channels"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -7337,7 +7337,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-core"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "age",
  "anyhow",
@@ -7359,7 +7359,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-llm"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -7380,7 +7380,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-mcp"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -7397,7 +7397,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-memory"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "qdrant-client",
@@ -7413,7 +7413,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-skills"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -7429,7 +7429,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-tools"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "reqwest 0.13.2",
  "scrape-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 rust-version = "1.88"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["bug-ops"]
 license = "MIT"
 repository = "https://github.com/bug-ops/zeph"
@@ -51,14 +51,14 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 url = "2.5"
 uuid = "1.20"
-zeph-a2a = { path = "crates/zeph-a2a", version = "0.7.1" }
-zeph-channels = { path = "crates/zeph-channels", version = "0.7.1" }
-zeph-core = { path = "crates/zeph-core", version = "0.7.1" }
-zeph-llm = { path = "crates/zeph-llm", version = "0.7.1" }
-zeph-mcp = { path = "crates/zeph-mcp", version = "0.7.1" }
-zeph-memory = { path = "crates/zeph-memory", version = "0.7.1" }
-zeph-skills = { path = "crates/zeph-skills", version = "0.7.1" }
-zeph-tools = { path = "crates/zeph-tools", version = "0.7.1" }
+zeph-a2a = { path = "crates/zeph-a2a", version = "0.8.0" }
+zeph-channels = { path = "crates/zeph-channels", version = "0.8.0" }
+zeph-core = { path = "crates/zeph-core", version = "0.8.0" }
+zeph-llm = { path = "crates/zeph-llm", version = "0.8.0" }
+zeph-mcp = { path = "crates/zeph-mcp", version = "0.8.0" }
+zeph-memory = { path = "crates/zeph-memory", version = "0.8.0" }
+zeph-skills = { path = "crates/zeph-skills", version = "0.8.0" }
+zeph-tools = { path = "crates/zeph-tools", version = "0.8.0" }
 
 [workspace.lints.clippy]
 all = "warn"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ docker pull ghcr.io/bug-ops/zeph:latest
 Or use a specific version:
 
 ```bash
-docker pull ghcr.io/bug-ops/zeph:v0.7.1
+docker pull ghcr.io/bug-ops/zeph:v0.8.0
 ```
 
 **Security:** Images are scanned with [Trivy](https://trivy.dev/) in CI/CD and use Oracle Linux 9 Slim base with **0 HIGH/CRITICAL CVEs**. Multi-platform: linux/amd64, linux/arm64.
@@ -299,7 +299,7 @@ context_budget_tokens = 8000  # Set to LLM context window size (0 = unlimited)
 
 ## Docker
 
-**Note:** Docker Compose automatically pulls the latest image from GitHub Container Registry. To use a specific version, set `ZEPH_IMAGE=ghcr.io/bug-ops/zeph:v0.7.1`.
+**Note:** Docker Compose automatically pulls the latest image from GitHub Container Registry. To use a specific version, set `ZEPH_IMAGE=ghcr.io/bug-ops/zeph:v0.8.0`.
 
 <details>
 <summary><b>🐳 Docker Deployment Options</b> (click to expand)</summary>
@@ -359,7 +359,7 @@ ZEPH_VAULT_KEY=./my-key.txt ZEPH_VAULT_PATH=./my-secrets.age \
 
 ```bash
 # Use a specific release version
-ZEPH_IMAGE=ghcr.io/bug-ops/zeph:v0.7.1 docker compose up
+ZEPH_IMAGE=ghcr.io/bug-ops/zeph:v0.8.0 docker compose up
 
 # Always pull latest
 docker compose pull && docker compose up

--- a/crates/zeph-core/src/agent.rs
+++ b/crates/zeph-core/src/agent.rs
@@ -880,9 +880,8 @@ impl<P: LlmProvider + Clone + 'static, C: Channel, T: ToolExecutor> Agent<P, C, 
             return Ok(false);
         };
 
-        let skill = match self.registry.get_skill(&name) {
-            Ok(s) => s,
-            Err(_) => return Ok(false),
+        let Ok(skill) = self.registry.get_skill(&name) else {
+            return Ok(false);
         };
 
         let prompt = zeph_skills::evolution::build_reflection_prompt(


### PR DESCRIPTION
## Summary

- Bump version from 0.7.1 to 0.8.0
- Update CHANGELOG.md with release section for 2026-02-10
- Update README version references (Docker image tags)
- Fix clippy warnings for Rust 1.93 (inline format args, cast precision)

## Checklist

- [x] Version updated in all manifests
- [x] CHANGELOG.md has release section with date
- [x] README reflects new version
- [x] All CI checks pass locally (fmt, clippy, nextest)
- [ ] Ready for tagging after merge