### PR TITLE
fix: flush audit log after write to prevent data loss

### DIFF
--- a/crates/zeph-tools/src/audit.rs
+++ b/crates/zeph-tools/src/audit.rs
@@ -71,6 +71,8 @@ impl AuditLogger {
                 let line = format!("{json}\n");
                 if let Err(e) = f.write_all(line.as_bytes()).await {
                     tracing::error!("failed to write audit log: {e}");
+                } else if let Err(e) = f.flush().await {
+                    tracing::error!("failed to flush audit log: {e}");
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Add explicit `flush()` after `write_all()` in audit file logger
- Fixes flaky `audit_logger_file` test on CI where buffered data was not persisted before subsequent read

## Test plan
- [x] `audit_logger_file` passes locally
- [x] All 958 workspace tests pass