### PR TITLE
release: v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-02-12
+
 ### Added
 - ratatui-based TUI dashboard with real-time agent metrics (feature-gated `tui`, opt-in)
 - `TuiChannel` as new `Channel` implementation with bottom-up chat feed, input line, and status bar

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7959,7 +7959,7 @@ dependencies = [
 
 [[package]]
 name = "zeph"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -7980,7 +7980,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-a2a"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "axum 0.8.8",
  "eventsource-stream",
@@ -8003,7 +8003,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-channels"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8016,7 +8016,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-core"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "age",
  "anyhow",
@@ -8038,7 +8038,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-llm"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -8059,7 +8059,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-mcp"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -8076,7 +8076,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-memory"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "qdrant-client",
@@ -8092,7 +8092,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-skills"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -8108,7 +8108,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-tools"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "reqwest 0.13.2",
  "scrape-core",
@@ -8124,7 +8124,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-tui"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 rust-version = "1.88"
-version = "0.8.2"
+version = "0.9.0"
 authors = ["bug-ops"]
 license = "MIT"
 repository = "https://github.com/bug-ops/zeph"
@@ -54,15 +54,15 @@ tracing-subscriber = "0.3"
 unicode-width = "0.2"
 url = "2.5"
 uuid = "1.20"
-zeph-a2a = { path = "crates/zeph-a2a", version = "0.8.2" }
-zeph-channels = { path = "crates/zeph-channels", version = "0.8.2" }
-zeph-core = { path = "crates/zeph-core", version = "0.8.2" }
-zeph-llm = { path = "crates/zeph-llm", version = "0.8.2" }
-zeph-mcp = { path = "crates/zeph-mcp", version = "0.8.2" }
-zeph-memory = { path = "crates/zeph-memory", version = "0.8.2" }
-zeph-skills = { path = "crates/zeph-skills", version = "0.8.2" }
-zeph-tools = { path = "crates/zeph-tools", version = "0.8.2" }
-zeph-tui = { path = "crates/zeph-tui", version = "0.8.2" }
+zeph-a2a = { path = "crates/zeph-a2a", version = "0.9.0" }
+zeph-channels = { path = "crates/zeph-channels", version = "0.9.0" }
+zeph-core = { path = "crates/zeph-core", version = "0.9.0" }
+zeph-llm = { path = "crates/zeph-llm", version = "0.9.0" }
+zeph-mcp = { path = "crates/zeph-mcp", version = "0.9.0" }
+zeph-memory = { path = "crates/zeph-memory", version = "0.9.0" }
+zeph-skills = { path = "crates/zeph-skills", version = "0.9.0" }
+zeph-tools = { path = "crates/zeph-tools", version = "0.9.0" }
+zeph-tui = { path = "crates/zeph-tui", version = "0.9.0" }
 
 [workspace.lints.clippy]
 all = "warn"

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -33,7 +33,7 @@ docker pull ghcr.io/bug-ops/zeph:latest
 Or use a specific version:
 
 ```bash
-docker pull ghcr.io/bug-ops/zeph:v0.8.2
+docker pull ghcr.io/bug-ops/zeph:v0.9.0
 ```
 
 Images are scanned with [Trivy](https://trivy.dev/) in CI/CD and use Oracle Linux 9 Slim base with **0 HIGH/CRITICAL CVEs**. Multi-platform: linux/amd64, linux/arm64.

--- a/docs/src/guide/docker.md
+++ b/docs/src/guide/docker.md
@@ -1,6 +1,6 @@
 # Docker Deployment
 
-Docker Compose automatically pulls the latest image from GitHub Container Registry. To use a specific version, set `ZEPH_IMAGE=ghcr.io/bug-ops/zeph:v0.8.2`.
+Docker Compose automatically pulls the latest image from GitHub Container Registry. To use a specific version, set `ZEPH_IMAGE=ghcr.io/bug-ops/zeph:v0.9.0`.
 
 ## Quick Start (Ollama + Qdrant in containers)
 
@@ -56,7 +56,7 @@ ZEPH_VAULT_KEY=./my-key.txt ZEPH_VAULT_PATH=./my-secrets.age \
 
 ```bash
 # Use a specific release version
-ZEPH_IMAGE=ghcr.io/bug-ops/zeph:v0.8.2 docker compose up
+ZEPH_IMAGE=ghcr.io/bug-ops/zeph:v0.9.0 docker compose up
 
 # Always pull latest
 docker compose pull && docker compose up

--- a/docs/src/guide/tui.md
+++ b/docs/src/guide/tui.md
@@ -24,7 +24,7 @@ ZEPH_TUI=true zeph
 
 ```
 +-------------------------------------------------------------+
-| Zeph v0.8.2 | Provider: orchestrator | Model: claude-son... |
+| Zeph v0.9.0 | Provider: orchestrator | Model: claude-son... |
 +----------------------------------------+--------------------+
 |                                        | Skills (3/15)      |
 |                                        | - setup-guide      |


### PR DESCRIPTION
## Summary

- Bump version from 0.8.2 to 0.9.0
- Update CHANGELOG.md with release notes
- Update version references in docs

## Highlights

- **TUI Dashboard** (M17): ratatui-based terminal UI with live metrics, confirmation modal, scroll indicators, responsive layout, multiline input, bottom-up chat
- **OpenAI Provider** (M16): OpenAI-compatible LLM provider with chat, streaming, embeddings, and support for Together AI, Groq, Fireworks
- **MCP HTTP Transport**: Streamable HTTP transport for remote MCP servers, dynamic server management via `/mcp add|remove|list`

## Checklist

- [x] Version updated in all manifests
- [x] CHANGELOG.md has release section with date
- [x] Docs reflect new version
- [x] All CI checks pass (169/169 tests, clippy clean, fmt clean)
- [x] Ready for tagging after merge