### PR TITLE
feat(core): runtime context compaction for long sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Runtime context compaction for long sessions: automatic LLM-based summarization of middle messages when context usage exceeds configurable threshold (default 75%)
+- `with_context_budget()` builder method on Agent for wiring context budget and compaction settings
+- Config fields: `compaction_threshold` (f32), `compaction_preserve_tail` (usize) with env var overrides
+- `context_compactions` counter in MetricsSnapshot for observability
+
 ## [0.9.1] - 2026-02-12
 
 ### Added

--- a/config/default.toml
+++ b/config/default.toml
@@ -92,6 +92,10 @@ qdrant_url = "http://localhost:6334"
 summarization_threshold = 100
 # Total token budget for context window (0 = unlimited)
 context_budget_tokens = 0
+# Context compaction threshold (0.0-1.0): compact when usage exceeds this fraction
+compaction_threshold = 0.75
+# Number of recent messages to preserve during compaction
+compaction_preserve_tail = 4
 
 [memory.semantic]
 # Enable semantic memory with vector search

--- a/crates/zeph-core/src/context.rs
+++ b/crates/zeph-core/src/context.rs
@@ -38,6 +38,11 @@ impl ContextBudget {
     }
 
     #[must_use]
+    pub fn max_tokens(&self) -> usize {
+        self.max_tokens
+    }
+
+    #[must_use]
     #[allow(
         clippy::cast_precision_loss,
         clippy::cast_possible_truncation,
@@ -101,6 +106,12 @@ mod tests {
         assert_eq!(estimate_tokens("Hello world"), 2);
         assert_eq!(estimate_tokens(""), 0);
         assert_eq!(estimate_tokens("test"), 1);
+    }
+
+    #[test]
+    fn context_budget_max_tokens_accessor() {
+        let budget = ContextBudget::new(1000, 0.2);
+        assert_eq!(budget.max_tokens(), 1000);
     }
 
     #[test]

--- a/crates/zeph-core/src/metrics.rs
+++ b/crates/zeph-core/src/metrics.rs
@@ -19,6 +19,7 @@ pub struct MetricsSnapshot {
     pub provider_name: String,
     pub model_name: String,
     pub summaries_count: u64,
+    pub context_compactions: u64,
 }
 
 pub struct MetricsCollector {

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,6 +249,12 @@ async fn main() -> anyhow::Result<()> {
         config.memory.semantic.recall_limit,
         config.memory.summarization_threshold,
     )
+    .with_context_budget(
+        config.memory.context_budget_tokens,
+        0.20,
+        config.memory.compaction_threshold,
+        config.memory.compaction_preserve_tail,
+    )
     .with_shutdown(shutdown_rx)
     .with_security(config.security, config.timeouts);
 


### PR DESCRIPTION
## Summary

- Add automatic context compaction that triggers when message tokens exceed configurable threshold (default 75% of context window)
- Middle messages summarized via LLM into structured continuation note, preserving system prompt and last N messages
- Backward-compatible: disabled when `context_budget_tokens=0` (default)

Closes #166

## Changes

| File | Change |
|------|--------|
| `crates/zeph-core/src/agent.rs` | `context_budget` field, `with_context_budget()` builder, `should_compact()`, `compact_context()`, wiring in `run()`, 8 tests |
| `crates/zeph-core/src/config.rs` | `compaction_threshold`, `compaction_preserve_tail` fields + defaults + env overrides, 3 tests |
| `crates/zeph-core/src/context.rs` | `max_tokens()` getter + test |
| `crates/zeph-core/src/metrics.rs` | `context_compactions` counter |
| `src/main.rs` | `.with_context_budget()` in agent builder chain |
| `config/default.toml` | New config keys |

## Test plan

- [x] 183 zeph-core tests pass
- [x] 1102 workspace tests pass
- [x] cargo clippy --workspace -- -D warnings (zero warnings)
- [x] cargo +nightly fmt --check (clean)
- [x] Edge cases: budget disabled, below/above threshold, too few messages, metrics increment