### PR TITLE
feat(core): context engineering pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `with_context_budget()` builder method on Agent for wiring context budget and compaction settings
 - Config fields: `compaction_threshold` (f32), `compaction_preserve_tail` (usize) with env var overrides
 - `context_compactions` counter in MetricsSnapshot for observability
+- Context budget integration: `ContextBudget::allocate()` wired into agent loop via `prepare_context()` orchestrator
+- Semantic recall injection: `SemanticMemory::recall()` results injected as transient system messages with token budget control
+- Message history trimming: oldest non-system messages evicted when history exceeds budget allocation
+- Environment context injection: working directory, OS, git branch, and model name in system prompt via `<environment>` block
+- Extended BASE_PROMPT with structured Tool Use, Guidelines, and Security sections
+- Tool output truncation: head+tail split at 30K chars with UTF-8 safe boundaries
+- Progressive skill loading: matched skills get full body, remaining shown as description-only catalog via `<other_skills>`
+- ZEPH.md project config discovery: walk up directory tree, inject into system prompt as `<project_context>`
 
 ## [0.9.1] - 2026-02-12
 

--- a/crates/zeph-core/src/lib.rs
+++ b/crates/zeph-core/src/lib.rs
@@ -5,5 +5,6 @@ pub mod channel;
 pub mod config;
 pub mod context;
 pub mod metrics;
+pub mod project;
 pub mod redact;
 pub mod vault;

--- a/crates/zeph-core/src/project.rs
+++ b/crates/zeph-core/src/project.rs
@@ -1,0 +1,113 @@
+use std::fmt::Write;
+use std::path::{Path, PathBuf};
+
+const PROJECT_CONFIG_FILES: &[&str] = &["ZEPH.md", ".zeph/config.md"];
+
+/// Walk up from `start` to filesystem root, collecting all ZEPH.md files.
+/// Returns paths ordered from most general (ancestor) to most specific (cwd).
+#[must_use]
+pub fn discover_project_configs(start: &Path) -> Vec<PathBuf> {
+    let mut configs = Vec::new();
+    let mut current = start.to_path_buf();
+
+    loop {
+        for filename in PROJECT_CONFIG_FILES {
+            let candidate = current.join(filename);
+            if candidate.is_file() {
+                configs.push(candidate);
+            }
+        }
+        if !current.pop() {
+            break;
+        }
+    }
+
+    configs.reverse();
+    configs
+}
+
+/// Load and concatenate project configs into a prompt section.
+#[must_use]
+pub fn load_project_context(configs: &[PathBuf]) -> String {
+    if configs.is_empty() {
+        return String::new();
+    }
+
+    let mut out = String::from("<project_context>\n");
+    for path in configs {
+        if let Ok(content) = std::fs::read_to_string(path) {
+            let source = path.display();
+            let _ = write!(
+                out,
+                "  <config source=\"{source}\">\n{content}\n  </config>\n"
+            );
+        }
+    }
+    out.push_str("</project_context>");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discover_project_configs_empty_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let configs = discover_project_configs(dir.path());
+        assert!(configs.is_empty());
+    }
+
+    #[test]
+    fn discover_project_configs_finds_zeph_md() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("ZEPH.md"), "# Project").unwrap();
+        let configs = discover_project_configs(dir.path());
+        assert_eq!(configs.len(), 1);
+        assert!(configs[0].ends_with("ZEPH.md"));
+    }
+
+    #[test]
+    fn discover_project_configs_walks_up() {
+        let dir = tempfile::tempdir().unwrap();
+        let child = dir.path().join("sub");
+        std::fs::create_dir(&child).unwrap();
+        std::fs::write(dir.path().join("ZEPH.md"), "# Parent").unwrap();
+        std::fs::write(child.join("ZEPH.md"), "# Child").unwrap();
+
+        let configs = discover_project_configs(&child);
+        assert!(configs.len() >= 2);
+        // Parent should come before child (reversed order)
+        let parent_idx = configs
+            .iter()
+            .position(|p| p.parent().unwrap() == dir.path())
+            .unwrap();
+        let child_idx = configs
+            .iter()
+            .position(|p| p.parent().unwrap() == child)
+            .unwrap();
+        assert!(parent_idx < child_idx);
+    }
+
+    #[test]
+    fn load_project_context_empty() {
+        let result = load_project_context(&[]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn load_project_context_concatenates() {
+        let dir = tempfile::tempdir().unwrap();
+        let f1 = dir.path().join("ZEPH.md");
+        let f2 = dir.path().join("other.md");
+        std::fs::write(&f1, "config 1").unwrap();
+        std::fs::write(&f2, "config 2").unwrap();
+
+        let result = load_project_context(&[f1, f2]);
+        assert!(result.starts_with("<project_context>"));
+        assert!(result.ends_with("</project_context>"));
+        assert!(result.contains("config 1"));
+        assert!(result.contains("config 2"));
+        assert!(result.contains("<config source="));
+    }
+}

--- a/crates/zeph-skills/src/prompt.rs
+++ b/crates/zeph-skills/src/prompt.rs
@@ -54,6 +54,25 @@ pub fn format_skills_prompt(skills: &[Skill], os_family: &str) -> String {
     out
 }
 
+#[must_use]
+pub fn format_skills_catalog(skills: &[Skill]) -> String {
+    if skills.is_empty() {
+        return String::new();
+    }
+
+    let mut out = String::from("<other_skills>\n");
+    for skill in skills {
+        let _ = writeln!(
+            out,
+            "  <skill name=\"{}\" description=\"{}\" />",
+            skill.name(),
+            skill.description(),
+        );
+    }
+    out.push_str("</other_skills>");
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -178,5 +197,22 @@ mod tests {
         let output = format_skills_prompt(&skills, "macos");
         assert!(output.contains("skill body"));
         assert!(!output.contains("<reference"));
+    }
+
+    #[test]
+    fn format_skills_catalog_empty() {
+        let empty: &[Skill] = &[];
+        assert_eq!(format_skills_catalog(empty), "");
+    }
+
+    #[test]
+    fn format_skills_catalog_produces_other_skills_tag() {
+        let skills = vec![make_skill("test", "A test skill.", "body")];
+        let output = format_skills_catalog(&skills);
+        assert!(output.starts_with("<other_skills>"));
+        assert!(output.ends_with("</other_skills>"));
+        assert!(output.contains("name=\"test\""));
+        assert!(output.contains("description=\"A test skill.\""));
+        assert!(!output.contains("body"));
     }
 }

--- a/crates/zeph-tools/src/lib.rs
+++ b/crates/zeph-tools/src/lib.rs
@@ -10,6 +10,6 @@ pub mod shell;
 pub use audit::{AuditEntry, AuditLogger, AuditResult};
 pub use composite::CompositeExecutor;
 pub use config::{AuditConfig, ScrapeConfig, ShellConfig, ToolsConfig};
-pub use executor::{ToolError, ToolExecutor, ToolOutput};
+pub use executor::{ToolError, ToolExecutor, ToolOutput, truncate_tool_output};
 pub use scrape::WebScrapeExecutor;
 pub use shell::ShellExecutor;

--- a/src/main.rs
+++ b/src/main.rs
@@ -240,6 +240,7 @@ async fn main() -> anyhow::Result<()> {
         config.skills.max_active_skills,
         tool_executor,
     )
+    .with_model_name(config.llm.model.clone())
     .with_embedding_model(embed_model.clone())
     .with_skill_reload(skill_paths, reload_rx)
     .with_memory(


### PR DESCRIPTION
## Summary

Complete context engineering pipeline implementation (epic #167). Connects existing unused components and adds missing mechanisms for production-grade context management.

Closes #167, #168, #169, #170, #171, #172, #173, #175, #176

## Changes

### Batch 1 — Context budget integration (CRITICAL)
- Wire `ContextBudget::allocate()` into agent loop via `prepare_context()` orchestrator
- Inject `SemanticMemory::recall()` results as transient system messages with token budget
- Trim message history to fit `BudgetAllocation.recent_history` (oldest-first eviction)

### Batch 2 — Environment context (HIGH)
- `EnvironmentContext` struct gathering cwd, git branch, OS, model name per turn
- Extended `BASE_PROMPT` with Tool Use, Guidelines, and Security sections
- `build_system_prompt()` now accepts `env: Option<&EnvironmentContext>`

### Batch 3 — Tool output, skills, project config (MEDIUM)
- Tool output truncation at 30K chars with UTF-8 safe head+tail split
- Progressive skill loading: matched skills full body, rest description-only catalog
- ZEPH.md project config discovery via directory tree walk

### Files changed (9)

| File | Change |
|------|--------|
| `crates/zeph-core/src/agent.rs` | prepare_context, inject_semantic_recall, trim_messages_to_budget, model_name, skills catalog, project config |
| `crates/zeph-core/src/context.rs` | EnvironmentContext, extended BASE_PROMPT, build_system_prompt signature |
| `crates/zeph-core/src/project.rs` | New: discover_project_configs, load_project_context |
| `crates/zeph-core/src/lib.rs` | pub mod project |
| `crates/zeph-skills/src/prompt.rs` | format_skills_catalog() |
| `crates/zeph-tools/src/executor.rs` | truncate_tool_output() |
| `crates/zeph-tools/src/lib.rs` | Re-export truncate_tool_output |
| `src/main.rs` | .with_model_name() wiring |
| `CHANGELOG.md` | Unreleased section updated |

## Backward compatibility

`context_budget_tokens=0` (default) disables the entire pipeline — behavior identical to current.

## Test plan

- [x] 1125 workspace tests pass (23 new)
- [x] cargo clippy --workspace -- -D warnings (zero warnings)
- [x] cargo +nightly fmt (clean)
- [x] Security audit: 0 blocking issues
- [x] Performance audit: all per-turn costs <10ms (network I/O dominates)