### PR TITLE
release: v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-02-12
+
 ### Added
 - Runtime context compaction for long sessions: automatic LLM-based summarization of middle messages when context usage exceeds configurable threshold (default 75%)
 - `with_context_budget()` builder method on Agent for wiring context budget and compaction settings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7959,7 +7959,7 @@ dependencies = [
 
 [[package]]
 name = "zeph"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -7980,7 +7980,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-a2a"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "axum 0.8.8",
  "eventsource-stream",
@@ -8003,7 +8003,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-channels"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8016,7 +8016,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-core"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "age",
  "anyhow",
@@ -8038,7 +8038,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-llm"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -8059,7 +8059,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-mcp"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "blake3",
@@ -8076,7 +8076,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-memory"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "qdrant-client",
@@ -8092,7 +8092,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-skills"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "blake3",
@@ -8108,7 +8108,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-tools"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "reqwest 0.13.2",
  "scrape-core",
@@ -8124,7 +8124,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-tui"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 rust-version = "1.88"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["bug-ops"]
 license = "MIT"
 repository = "https://github.com/bug-ops/zeph"
@@ -54,15 +54,15 @@ tracing-subscriber = "0.3"
 unicode-width = "0.2"
 url = "2.5"
 uuid = "1.20"
-zeph-a2a = { path = "crates/zeph-a2a", version = "0.9.0" }
-zeph-channels = { path = "crates/zeph-channels", version = "0.9.0" }
-zeph-core = { path = "crates/zeph-core", version = "0.9.0" }
-zeph-llm = { path = "crates/zeph-llm", version = "0.9.0" }
-zeph-mcp = { path = "crates/zeph-mcp", version = "0.9.0" }
-zeph-memory = { path = "crates/zeph-memory", version = "0.9.0" }
-zeph-skills = { path = "crates/zeph-skills", version = "0.9.0" }
-zeph-tools = { path = "crates/zeph-tools", version = "0.9.0" }
-zeph-tui = { path = "crates/zeph-tui", version = "0.9.0" }
+zeph-a2a = { path = "crates/zeph-a2a", version = "0.9.2" }
+zeph-channels = { path = "crates/zeph-channels", version = "0.9.2" }
+zeph-core = { path = "crates/zeph-core", version = "0.9.2" }
+zeph-llm = { path = "crates/zeph-llm", version = "0.9.2" }
+zeph-mcp = { path = "crates/zeph-mcp", version = "0.9.2" }
+zeph-memory = { path = "crates/zeph-memory", version = "0.9.2" }
+zeph-skills = { path = "crates/zeph-skills", version = "0.9.2" }
+zeph-tools = { path = "crates/zeph-tools", version = "0.9.2" }
+zeph-tui = { path = "crates/zeph-tui", version = "0.9.2" }
 
 [workspace.lints.clippy]
 all = "warn"


### PR DESCRIPTION
## Summary

- Bump version from 0.9.1 to 0.9.2
- Update workspace dependency versions (0.9.0 -> 0.9.2)
- Finalize CHANGELOG.md with release notes for v0.9.2

## Checklist

- [x] Version updated in workspace manifest
- [x] Workspace dependency versions updated
- [x] CHANGELOG.md has release section with date
- [x] All CI checks pass (fmt, clippy, nextest 1136 passed)
- [x] Release build succeeds
- [ ] Ready for tagging after merge