### PR TITLE
fix(core): improve context management observability and summarization accuracy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- `context_tokens` metric in TUI Resources panel showing current prompt estimate (vs cumulative session totals)
+- `unsummarized_message_count` in `SemanticMemory` for precise summarization trigger
+- `count_messages_after` in `SqliteStore` for counting messages beyond a given ID
+- TUI status indicators for context compaction ("compacting context...") and summarization ("summarizing...")
+- Debug tracing in `should_compact()` for context budget diagnostics (token estimate, threshold, decision)
 - Config hot-reload: watch config file for changes via `notify_debouncer_mini` and apply runtime-safe fields (security, timeouts, memory limits, context budget, compaction, max_active_skills) without restart
 - `ConfigWatcher` in zeph-core with 500ms debounced filesystem monitoring
 - `with_config_reload()` builder method on Agent for wiring config file watcher
@@ -27,6 +32,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - TUI inline code rendered as blue with dark background glow instead of bright yellow
 - TUI header uses deep blue background (`Rgb(20, 40, 80)`) for improved contrast
 - System prompt includes explicit `bash` block example and bans invented formats (`tool_code`, `tool_call`) for small model compatibility
+
+### Changed
+- TUI Resources panel: replaced separate Prompt/Completion/Total with Context (current) and Session (cumulative) metrics
+- Summarization trigger uses unsummarized message count instead of total, avoiding repeated no-op checks
+- Empty `AgentEvent::Status` clears TUI spinner instead of showing blank throbber
+- Status label cleared after summarization and compaction complete
 
 ### Fixed
 - TUI chat line wrapping no longer eats 2 characters on word wrap (accent prefix width accounted for)

--- a/crates/zeph-core/src/metrics.rs
+++ b/crates/zeph-core/src/metrics.rs
@@ -5,6 +5,7 @@ pub struct MetricsSnapshot {
     pub prompt_tokens: u64,
     pub completion_tokens: u64,
     pub total_tokens: u64,
+    pub context_tokens: u64,
     pub api_calls: u64,
     pub active_skills: Vec<String>,
     pub total_skills: usize,

--- a/crates/zeph-tui/src/app.rs
+++ b/crates/zeph-tui/src/app.rs
@@ -274,7 +274,7 @@ impl App {
                 self.status_label = Some("thinking...".to_owned());
             }
             AgentEvent::Status(text) => {
-                self.status_label = Some(text);
+                self.status_label = if text.is_empty() { None } else { Some(text) };
                 self.scroll_offset = 0;
             }
             AgentEvent::ToolStart { tool_name, command } => {

--- a/crates/zeph-tui/src/widgets/resources.rs
+++ b/crates/zeph-tui/src/widgets/resources.rs
@@ -12,9 +12,8 @@ pub fn render(metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect) {
     let res_lines = vec![
         Line::from(format!("  Provider: {}", metrics.provider_name)),
         Line::from(format!("  Model: {}", metrics.model_name)),
-        Line::from(format!("  Prompt: {}", metrics.prompt_tokens)),
-        Line::from(format!("  Completion: {}", metrics.completion_tokens)),
-        Line::from(format!("  Total: {}", metrics.total_tokens)),
+        Line::from(format!("  Context: {}", metrics.context_tokens)),
+        Line::from(format!("  Session: {}", metrics.total_tokens)),
         Line::from(format!("  API calls: {}", metrics.api_calls)),
         Line::from(format!("  Latency: {}ms", metrics.last_llm_latency_ms)),
     ];


### PR DESCRIPTION
## Summary

- Summarization trigger uses `unsummarized_message_count` (messages after latest summary) instead of total SQLite count, eliminating repeated no-op LLM/DB calls when all messages are already covered by summaries
- TUI Resources panel shows **Context** (current prompt estimate) and **Session** (cumulative tokens) instead of separate Prompt/Completion/Total — Context can be compared directly against `context_budget_tokens`
- Status indicators for compaction ("compacting context...") and summarization ("summarizing...") with proper cleanup on completion
- Debug tracing in `should_compact()` logs token estimate, threshold, and decision for diagnostics
- Empty `AgentEvent::Status` clears TUI spinner instead of rendering blank throbber

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo nextest run --workspace --lib --bins` — 1206 tests pass (2 new)
- [ ] Manual: run with `RUST_LOG=debug` and Ollama, verify "context budget check" log lines
- [ ] Manual: verify Resources panel shows Context/Session labels
- [ ] Manual: trigger summarization threshold, verify spinner appears and clears