### PR TITLE
feat(core): summary injection and auto-budget context management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,24 +26,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - TUI: message separators and accent bars for visual structure
 - TUI: tool output restored as expandable messages from conversation history
 - TUI: collapsed tool output preview (3 lines) when restoring history
+- `LlmProvider::context_window()` trait method for model context window size detection
+- Ollama context window auto-detection via `/api/show` model info endpoint
+- Context window sizes for Claude (200K) and OpenAI (128K/16K/1M) provider models
+- `auto_budget` config field with `ZEPH_MEMORY_AUTO_BUDGET` env override for automatic context budget from model metadata
+- `inject_summaries()` in Agent: injects SQLite conversation summaries into context (newest-first, budget-aware, with deduplication)
 
 ### Changed
 - Agent error handler shows specific error context instead of generic message
 - TUI inline code rendered as blue with dark background glow instead of bright yellow
 - TUI header uses deep blue background (`Rgb(20, 40, 80)`) for improved contrast
 - System prompt includes explicit `bash` block example and bans invented formats (`tool_code`, `tool_call`) for small model compatibility
-
-### Changed
 - TUI Resources panel: replaced separate Prompt/Completion/Total with Context (current) and Session (cumulative) metrics
 - Summarization trigger uses unsummarized message count instead of total, avoiding repeated no-op checks
 - Empty `AgentEvent::Status` clears TUI spinner instead of showing blank throbber
 - Status label cleared after summarization and compaction complete
+- Default `summarization_threshold`: 100 → 50 messages
+- Default `compaction_threshold`: 0.75 → 0.80
+- Default `compaction_preserve_tail`: 4 → 6 messages
+- Default `semantic.enabled`: false → true
+- Default `summarize_output`: false → true
+- Default `context_budget_tokens`: 0 (auto-detect from model)
 
 ### Fixed
 - TUI chat line wrapping no longer eats 2 characters on word wrap (accent prefix width accounted for)
 - TUI activity indicator moved to dedicated layout row (no longer overlaps content)
 - Memory history loading now retrieves most recent messages instead of oldest
 - Persisted tool output format includes tool name (`[tool output: bash]`) for proper display on restore
+- `summarize_output` serde deserialization used `#[serde(default)]` yielding `false` instead of config default `true`
 
 ## [0.9.3] - 2026-02-12
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -89,17 +89,19 @@ history_limit = 50
 # Qdrant vector database URL for semantic memory
 qdrant_url = "http://localhost:6334"
 # Number of messages before triggering summarization (0 = disabled)
-summarization_threshold = 100
-# Total token budget for context window (0 = unlimited)
+summarization_threshold = 50
+# Total token budget for context window (0 = auto-detect from model)
 context_budget_tokens = 0
+# Auto-detect context budget from model's context window size
+auto_budget = true
 # Context compaction threshold (0.0-1.0): compact when usage exceeds this fraction
-compaction_threshold = 0.75
+compaction_threshold = 0.80
 # Number of recent messages to preserve during compaction
-compaction_preserve_tail = 4
+compaction_preserve_tail = 6
 
 [memory.semantic]
 # Enable semantic memory with vector search
-enabled = false
+enabled = true
 # Maximum number of semantically relevant messages to recall
 recall_limit = 5
 
@@ -148,7 +150,7 @@ max_body_size = 1048576
 # Enable tool execution (bash commands)
 enabled = true
 # Summarize long tool output via LLM instead of head+tail truncation
-summarize_output = false
+summarize_output = true
 
 [tools.shell]
 # Command timeout in seconds

--- a/crates/zeph-llm/src/provider.rs
+++ b/crates/zeph-llm/src/provider.rs
@@ -24,6 +24,13 @@ pub struct Message {
 }
 
 pub trait LlmProvider: Send + Sync {
+    /// Report the model's context window size in tokens.
+    ///
+    /// Returns `None` if unknown. Used for auto-budget calculation.
+    fn context_window(&self) -> Option<usize> {
+        None
+    }
+
     /// Send messages to the LLM and return the assistant response.
     ///
     /// # Errors
@@ -93,6 +100,14 @@ mod tests {
         fn name(&self) -> &'static str {
             "stub"
         }
+    }
+
+    #[test]
+    fn context_window_default_returns_none() {
+        let provider = StubProvider {
+            response: String::new(),
+        };
+        assert!(provider.context_window().is_none());
     }
 
     #[test]

--- a/crates/zeph-tools/src/config.rs
+++ b/crates/zeph-tools/src/config.rs
@@ -28,7 +28,7 @@ fn default_audit_destination() -> String {
 pub struct ToolsConfig {
     #[serde(default = "default_true")]
     pub enabled: bool,
-    #[serde(default)]
+    #[serde(default = "default_true")]
     pub summarize_output: bool,
     #[serde(default)]
     pub shell: ShellConfig,
@@ -68,7 +68,7 @@ impl Default for ToolsConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            summarize_output: false,
+            summarize_output: true,
             shell: ShellConfig::default(),
             scrape: ScrapeConfig::default(),
             audit: AuditConfig::default(),
@@ -163,16 +163,16 @@ mod tests {
     fn default_tools_config() {
         let config = ToolsConfig::default();
         assert!(config.enabled);
-        assert!(!config.summarize_output);
+        assert!(config.summarize_output);
         assert_eq!(config.shell.timeout, 30);
         assert!(config.shell.blocked_commands.is_empty());
         assert!(!config.audit.enabled);
     }
 
     #[test]
-    fn tools_summarize_output_default_false() {
+    fn tools_summarize_output_default_true() {
         let config = ToolsConfig::default();
-        assert!(!config.summarize_output);
+        assert!(config.summarize_output);
     }
 
     #[test]
@@ -207,6 +207,7 @@ mod tests {
         assert_eq!(config.scrape.max_body_bytes, 1_048_576);
         assert!(!config.audit.enabled);
         assert_eq!(config.audit.destination, "stdout");
+        assert!(config.summarize_output);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Phase 4**: `inject_summaries()` loads SQLite conversation summaries into context (newest-first, budget-aware, with deduplication), wired into `prepare_context()` before semantic recall
- **Phase 5**: `LlmProvider::context_window()` trait method with per-provider implementations (Ollama auto-detect via `/api/show`, Claude 200K, OpenAI model-based); auto-budget resolves `context_budget_tokens` from model metadata when `auto_budget=true`
- Updated smart defaults: `summarization_threshold` 50, `compaction_threshold` 0.80, `compaction_preserve_tail` 6, `semantic.enabled` true, `summarize_output` true
- Fixed `summarize_output` serde(default) mismatch (`#[serde(default)]` yielded `false` instead of config default `true`)

Closes #213, closes #214

## Changes

| File | Change |
|------|--------|
| `crates/zeph-llm/src/provider.rs` | `context_window()` default trait method |
| `crates/zeph-llm/src/ollama.rs` | `fetch_model_info()`, `parse_num_ctx()`, context window detection |
| `crates/zeph-llm/src/claude.rs` | Context window sizes for opus/sonnet/haiku (200K) |
| `crates/zeph-llm/src/openai.rs` | Context window sizes by model prefix |
| `crates/zeph-llm/src/any.rs` | `context_window()` delegation |
| `crates/zeph-llm/src/orchestrator.rs` | `context_window()` delegation to default provider |
| `crates/zeph-core/src/agent.rs` | `inject_summaries()`, summary dedup, updated defaults |
| `crates/zeph-core/src/config.rs` | `auto_budget` field, env override, updated defaults |
| `crates/zeph-tools/src/config.rs` | `serde(default = "default_true")` fix |
| `src/main.rs` | Auto-budget wiring, Ollama context window fetch |
| `config/default.toml` | Updated defaults |

## Test plan

- [x] 1229 unit tests pass (`cargo nextest run --workspace --lib --bins`)
- [x] Zero clippy warnings (`cargo clippy --workspace -- -D warnings`)
- [x] 23 new tests covering context_window(), inject_summaries(), auto_budget config, serde fix
- [x] Code review approved after fix cycle