### PR TITLE
fix(core): add missing #[serial] to auto_budget env tests

### DIFF
--- a/crates/zeph-core/src/config.rs
+++ b/crates/zeph-core/src/config.rs
@@ -2628,6 +2628,7 @@ compaction_preserve_tail = 6
     }
 
     #[test]
+    #[serial]
     fn auto_budget_default_true() {
         clear_env();
         let config = Config::default();
@@ -2635,6 +2636,7 @@ compaction_preserve_tail = 6
     }
 
     #[test]
+    #[serial]
     fn env_override_auto_budget() {
         clear_env();
         let mut config = Config::default();


### PR DESCRIPTION
## Summary

- Add `#[serial]` attribute to `auto_budget_default_true` and `env_override_auto_budget` tests that call `clear_env()` but were missing serialization, causing race conditions with parallel env tests in the coverage job

## Context

PR #217 introduced two new config tests that manipulate environment variables via `clear_env()` / `set_var()` without `#[serial]`, leading to flaky `env_override_a2a_public_url` failure in `cargo-llvm-cov` coverage run.

## Test plan

- [x] `cargo nextest run -p zeph-core -E 'test(auto_budget)'` passes
- [x] `cargo clippy -p zeph-core -- -D warnings` clean