### PR TITLE
feat(memory): add cross-session memory via compaction summaries

### DIFF
--- a/crates/zeph-llm/src/provider.rs
+++ b/crates/zeph-llm/src/provider.rs
@@ -38,6 +38,9 @@ pub enum MessagePart {
     Summary {
         text: String,
     },
+    CrossSession {
+        text: String,
+    },
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -88,7 +91,8 @@ impl Message {
                 MessagePart::Text { text }
                 | MessagePart::Recall { text }
                 | MessagePart::CodeContext { text }
-                | MessagePart::Summary { text } => out.push_str(text),
+                | MessagePart::Summary { text }
+                | MessagePart::CrossSession { text } => out.push_str(text),
                 MessagePart::ToolOutput {
                     tool_name,
                     body,


### PR DESCRIPTION
## Summary

- Store session summaries in dedicated Qdrant collection (`zeph_session_summaries`) on compaction events
- New conversations search past sessions for relevant context via semantic similarity
- Budget-aware injection (4% of available tokens) with conversation exclusion filter

## Changes

- Add generic multi-collection QdrantStore API (`ensure_named_collection`, `store_to_collection`, `search_collection`)
- Add `store_session_summary()` and `search_session_summaries()` to SemanticMemory
- Add `cross_session` field to BudgetAllocation (summaries 10%→8%, recall 10%→8%, cross_session 4%)
- Add `inject_cross_session_context()` wired into `prepare_context()` before semantic recall (broader context first)
- Add `CrossSession` MessagePart variant
- Hook `compact_context()` to store session summary (non-fatal, logged on failure)

## Test plan

- [x] `test_inject_cross_session_no_memory_noop` — early return without memory
- [x] `test_inject_cross_session_zero_budget_noop` — early return with zero budget
- [x] `test_remove_cross_session_messages` — cleanup of stale injections
- [x] `test_remove_cross_session_preserves_other_system` — preserves non-cross-session system messages
- [x] `test_store_session_summary_on_compaction` — storage trigger on compaction
- [x] `test_budget_allocation_cross_session` — 4% allocation correctness
- [x] Graceful degradation tests (no Qdrant, no embeddings)
- [x] All 1273 tests pass, zero clippy warnings

Closes #215