### PR TITLE
release: v0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.9.4] - 2026-02-14
+
 ### Added
 - Bounded FIFO message queue (max 10) in agent loop: users can submit messages during inference, queued messages are delivered sequentially when response cycle completes
 - Channel trait extended with `try_recv()` (non-blocking poll) and `send_queue_count()` with default no-op impls
@@ -53,6 +55,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - inject_semantic_recall, inject_code_context, inject_summaries now create typed MessagePart variants
 
 ### Changed
+- `index` feature enabled by default (Code RAG pipeline active out of the box)
 - Agent error handler shows specific error context instead of generic message
 - TUI inline code rendered as blue with dark background glow instead of bright yellow
 - TUI header uses deep blue background (`Rgb(20, 40, 80)`) for improved contrast

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8136,7 +8136,7 @@ dependencies = [
 
 [[package]]
 name = "zeph"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -8158,7 +8158,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-a2a"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "axum 0.8.8",
  "eventsource-stream",
@@ -8181,7 +8181,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-channels"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8194,7 +8194,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-core"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "age",
  "anyhow",
@@ -8219,7 +8219,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-index"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "blake3",
@@ -8248,7 +8248,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-llm"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -8269,7 +8269,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-mcp"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "blake3",
@@ -8286,7 +8286,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-memory"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "qdrant-client",
@@ -8302,7 +8302,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-skills"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "blake3",
@@ -8318,7 +8318,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-tools"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "reqwest 0.13.2",
  "scrape-core",
@@ -8334,7 +8334,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-tui"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 rust-version = "1.88"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["bug-ops"]
 license = "MIT"
 repository = "https://github.com/bug-ops/zeph"
@@ -56,16 +56,16 @@ tree-sitter = "0.26"
 unicode-width = "0.2"
 url = "2.5"
 uuid = "1.20"
-zeph-a2a = { path = "crates/zeph-a2a", version = "0.9.3" }
-zeph-channels = { path = "crates/zeph-channels", version = "0.9.3" }
-zeph-core = { path = "crates/zeph-core", version = "0.9.3" }
-zeph-index = { path = "crates/zeph-index", version = "0.9.3" }
-zeph-llm = { path = "crates/zeph-llm", version = "0.9.3" }
-zeph-mcp = { path = "crates/zeph-mcp", version = "0.9.3" }
-zeph-memory = { path = "crates/zeph-memory", version = "0.9.3" }
-zeph-skills = { path = "crates/zeph-skills", version = "0.9.3" }
-zeph-tools = { path = "crates/zeph-tools", version = "0.9.3" }
-zeph-tui = { path = "crates/zeph-tui", version = "0.9.3" }
+zeph-a2a = { path = "crates/zeph-a2a", version = "0.9.4" }
+zeph-channels = { path = "crates/zeph-channels", version = "0.9.4" }
+zeph-core = { path = "crates/zeph-core", version = "0.9.4" }
+zeph-index = { path = "crates/zeph-index", version = "0.9.4" }
+zeph-llm = { path = "crates/zeph-llm", version = "0.9.4" }
+zeph-mcp = { path = "crates/zeph-mcp", version = "0.9.4" }
+zeph-memory = { path = "crates/zeph-memory", version = "0.9.4" }
+zeph-skills = { path = "crates/zeph-skills", version = "0.9.4" }
+zeph-tools = { path = "crates/zeph-tools", version = "0.9.4" }
+zeph-tui = { path = "crates/zeph-tui", version = "0.9.4" }
 
 [workspace.lints.clippy]
 all = "warn"
@@ -80,7 +80,7 @@ license.workspace = true
 repository.workspace = true
 
 [features]
-default = ["a2a", "candle", "mcp", "openai", "orchestrator", "self-learning", "vault-age"]
+default = ["a2a", "candle", "index", "mcp", "openai", "orchestrator", "self-learning", "vault-age"]
 a2a = ["dep:zeph-a2a", "zeph-a2a?/server"]
 mcp = ["dep:zeph-mcp", "zeph-mcp?/qdrant", "zeph-core/mcp"]
 candle = ["zeph-llm/candle"]

--- a/docs/src/feature-flags.md
+++ b/docs/src/feature-flags.md
@@ -11,7 +11,7 @@ Zeph uses Cargo feature flags to control optional functionality. Default feature
 | `orchestrator` | Enabled | Multi-model routing with task-based classification and fallback chains |
 | `self-learning` | Enabled | Skill evolution via failure detection, self-reflection, and LLM-generated improvements |
 | `vault-age` | Enabled | Age-encrypted vault backend for file-based secret storage ([age](https://age-encryption.org/)) |
-| `index` | Disabled | AST-based code indexing and semantic retrieval via tree-sitter ([guide](guide/code-indexing.md)) |
+| `index` | Enabled | AST-based code indexing and semantic retrieval via tree-sitter ([guide](guide/code-indexing.md)) |
 | `tui` | Disabled | ratatui-based TUI dashboard with real-time agent metrics |
 | `metal` | Disabled | Metal GPU acceleration for candle on macOS (implies `candle`) |
 | `cuda` | Disabled | CUDA GPU acceleration for candle on Linux (implies `candle`) |
@@ -22,7 +22,6 @@ Zeph uses Cargo feature flags to control optional functionality. Default feature
 cargo build --release                                     # all default features
 cargo build --release --features metal                    # macOS with Metal GPU
 cargo build --release --features cuda                     # Linux with NVIDIA GPU
-cargo build --release --features index                    # with code indexing
 cargo build --release --features tui                      # with TUI dashboard
 cargo build --release --no-default-features               # minimal binary
 ```

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -35,7 +35,7 @@ docker pull ghcr.io/bug-ops/zeph:latest
 Or use a specific version:
 
 ```bash
-docker pull ghcr.io/bug-ops/zeph:v0.9.3
+docker pull ghcr.io/bug-ops/zeph:v0.9.4
 ```
 
 Images are scanned with [Trivy](https://trivy.dev/) in CI/CD and use Oracle Linux 9 Slim base with **0 HIGH/CRITICAL CVEs**. Multi-platform: linux/amd64, linux/arm64.

--- a/docs/src/guide/docker.md
+++ b/docs/src/guide/docker.md
@@ -1,6 +1,6 @@
 # Docker Deployment
 
-Docker Compose automatically pulls the latest image from GitHub Container Registry. To use a specific version, set `ZEPH_IMAGE=ghcr.io/bug-ops/zeph:v0.9.3`.
+Docker Compose automatically pulls the latest image from GitHub Container Registry. To use a specific version, set `ZEPH_IMAGE=ghcr.io/bug-ops/zeph:v0.9.4`.
 
 ## Quick Start (Ollama + Qdrant in containers)
 
@@ -56,7 +56,7 @@ ZEPH_VAULT_KEY=./my-key.txt ZEPH_VAULT_PATH=./my-secrets.age \
 
 ```bash
 # Use a specific release version
-ZEPH_IMAGE=ghcr.io/bug-ops/zeph:v0.9.3 docker compose up
+ZEPH_IMAGE=ghcr.io/bug-ops/zeph:v0.9.4 docker compose up
 
 # Always pull latest
 docker compose pull && docker compose up

--- a/docs/src/guide/tui.md
+++ b/docs/src/guide/tui.md
@@ -24,7 +24,7 @@ ZEPH_TUI=true zeph
 
 ```text
 +-------------------------------------------------------------+
-| Zeph v0.9.3 | Provider: orchestrator | Model: claude-son... |
+| Zeph v0.9.4 | Provider: orchestrator | Model: claude-son... |
 +----------------------------------------+--------------------+
 |                                        | Skills (3/15)      |
 |                                        | - setup-guide      |


### PR DESCRIPTION
## Summary

- Bump version from 0.9.3 to 0.9.4
- Enable `index` feature by default (Code RAG active out of the box)
- Update CHANGELOG.md with release notes (30 commits since v0.9.3)
- Update version references in documentation

## Highlights

- Two-tier context pruning (tool output prune + LLM compaction fallback)
- Part-based message architecture (MessagePart enum, SQLite migration 006)
- Message queue for user input during inference
- Code RAG pipeline wired into agent loop (zeph-index)
- Summary injection and auto-budget context management
- Config hot-reload on file change
- Deferred model warmup in TUI mode
- TUI: input history, side panel toggle, visual refinements

## Checklist

- [x] Version updated in all manifests (workspace.package.version)
- [x] CHANGELOG.md has release section with date
- [x] Documentation version references updated
- [x] `index` feature added to defaults
- [x] All CI checks pass (1260 tests, clippy, fmt, release build)