### PR TITLE
refactor: re-export hygiene, remove unused dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8356,7 +8356,6 @@ dependencies = [
  "thiserror 2.0.18",
  "throbber-widgets-tui",
  "tokio",
- "tracing",
  "unicode-width",
  "zeph-core",
 ]

--- a/crates/zeph-core/src/lib.rs
+++ b/crates/zeph-core/src/lib.rs
@@ -9,3 +9,7 @@ pub mod metrics;
 pub mod project;
 pub mod redact;
 pub mod vault;
+
+pub use agent::Agent;
+pub use channel::{Channel, ChannelMessage};
+pub use config::Config;

--- a/crates/zeph-llm/src/lib.rs
+++ b/crates/zeph-llm/src/lib.rs
@@ -13,3 +13,4 @@ pub mod orchestrator;
 pub mod provider;
 
 pub use error::LlmError;
+pub use provider::LlmProvider;

--- a/crates/zeph-tui/Cargo.toml
+++ b/crates/zeph-tui/Cargo.toml
@@ -14,7 +14,6 @@ ratatui.workspace = true
 thiserror.workspace = true
 throbber-widgets-tui = "0.10"
 tokio = { workspace = true, features = ["sync", "rt", "time"] }
-tracing.workspace = true
 unicode-width.workspace = true
 zeph-core.workspace = true
 


### PR DESCRIPTION
## Summary

- **R7.2**: Add `pub use` re-exports in zeph-core (`Agent`, `Channel`, `Config`) and zeph-llm (`LlmProvider`)
- **R9.1**: Remove unused `tracing` dependency from zeph-tui (confirmed by cargo-machete)
- **R3.3**: blake3 duplication audited — no shared crate, patterns differ, skip justified
- **R9.2**: Dead code audited — all pub fns used, clippy clean

## Test plan

- [x] `cargo nextest run --workspace --lib --bins` — 1351 passed
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] Code review: approved (0 blockers)

Phase 5 (final) of #268. Closes #275.