### PR TITLE
refactor: remove anyhow from channels, group agent fields, gate qdrant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8183,7 +8183,6 @@ dependencies = [
 name = "zeph-channels"
 version = "0.9.5"
 dependencies = [
- "anyhow",
  "criterion",
  "pulldown-cmark",
  "teloxide",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,9 +83,10 @@ license.workspace = true
 repository.workspace = true
 
 [features]
-default = ["a2a", "candle", "index", "mcp", "openai", "orchestrator", "self-learning", "vault-age"]
+default = ["a2a", "candle", "index", "mcp", "openai", "orchestrator", "qdrant", "self-learning", "vault-age"]
 a2a = ["dep:zeph-a2a", "zeph-a2a?/server"]
-mcp = ["dep:zeph-mcp", "zeph-mcp?/qdrant", "zeph-core/mcp"]
+mcp = ["dep:zeph-mcp", "zeph-core/mcp"]
+qdrant = ["zeph-skills/qdrant", "zeph-mcp?/qdrant"]
 candle = ["zeph-llm/candle"]
 metal = ["zeph-llm/metal"]
 cuda = ["zeph-llm/cuda"]
@@ -108,7 +109,7 @@ zeph-mcp = { workspace = true, optional = true }
 zeph-core.workspace = true
 zeph-llm.workspace = true
 zeph-memory.workspace = true
-zeph-skills = { workspace = true, features = ["qdrant"] }
+zeph-skills.workspace = true
 zeph-tools.workspace = true
 zeph-tui = { workspace = true, optional = true }
 
@@ -118,7 +119,7 @@ tokio-stream.workspace = true
 zeph-core.workspace = true
 zeph-llm.workspace = true
 zeph-memory.workspace = true
-zeph-skills = { workspace = true, features = ["qdrant"] }
+zeph-skills.workspace = true
 
 [lints]
 workspace = true

--- a/crates/zeph-channels/Cargo.toml
+++ b/crates/zeph-channels/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-anyhow.workspace = true
 pulldown-cmark.workspace = true
 teloxide.workspace = true
 thiserror.workspace = true

--- a/crates/zeph-core/src/agent/persistence.rs
+++ b/crates/zeph-core/src/agent/persistence.rs
@@ -13,13 +13,15 @@ impl<P: LlmProvider + Clone + 'static, C: Channel, T: ToolExecutor> Agent<P, C, 
     ///
     /// Returns an error if loading history from `SQLite` fails.
     pub async fn load_history(&mut self) -> anyhow::Result<()> {
-        let (Some(memory), Some(cid)) = (&self.memory, self.conversation_id) else {
+        let (Some(memory), Some(cid)) =
+            (&self.memory_state.memory, self.memory_state.conversation_id)
+        else {
             return Ok(());
         };
 
         let history = memory
             .sqlite()
-            .load_history(cid, self.history_limit)
+            .load_history(cid, self.memory_state.history_limit)
             .await?;
         if !history.is_empty() {
             let mut loaded = 0;
@@ -52,7 +54,9 @@ impl<P: LlmProvider + Clone + 'static, C: Channel, T: ToolExecutor> Agent<P, C, 
     }
 
     pub(crate) async fn persist_message(&mut self, role: Role, content: &str) {
-        let (Some(memory), Some(cid)) = (&self.memory, self.conversation_id) else {
+        let (Some(memory), Some(cid)) =
+            (&self.memory_state.memory, self.memory_state.conversation_id)
+        else {
             return;
         };
 
@@ -85,7 +89,9 @@ impl<P: LlmProvider + Clone + 'static, C: Channel, T: ToolExecutor> Agent<P, C, 
     }
 
     pub(crate) async fn check_summarization(&mut self) {
-        let (Some(memory), Some(cid)) = (&self.memory, self.conversation_id) else {
+        let (Some(memory), Some(cid)) =
+            (&self.memory_state.memory, self.memory_state.conversation_id)
+        else {
             return;
         };
 
@@ -105,9 +111,9 @@ impl<P: LlmProvider + Clone + 'static, C: Channel, T: ToolExecutor> Agent<P, C, 
             }
         };
 
-        if count_usize > self.summarization_threshold {
+        if count_usize > self.memory_state.summarization_threshold {
             let _ = self.channel.send_status("summarizing...").await;
-            let batch_size = self.summarization_threshold / 2;
+            let batch_size = self.memory_state.summarization_threshold / 2;
             match memory.summarize(cid, batch_size).await {
                 Ok(Some(summary_id)) => {
                     tracing::info!("created summary {summary_id} for conversation {cid}");

--- a/crates/zeph-core/src/agent/streaming.rs
+++ b/crates/zeph-core/src/agent/streaming.rs
@@ -16,7 +16,7 @@ impl<P: LlmProvider + Clone + 'static, C: Channel, T: ToolExecutor> Agent<P, C, 
             self.channel.send_typing().await?;
 
             // Context budget check at 80% threshold
-            if let Some(ref budget) = self.context_budget {
+            if let Some(ref budget) = self.context_state.budget {
                 let used: usize = self
                     .messages
                     .iter()

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ use zeph_llm::provider::LlmProvider;
 use zeph_memory::semantic::SemanticMemory;
 use zeph_skills::loader::SkillMeta;
 use zeph_skills::matcher::{SkillMatcher, SkillMatcherBackend};
+#[cfg(feature = "qdrant")]
 use zeph_skills::qdrant_matcher::QdrantSkillMatcher;
 use zeph_skills::registry::SkillRegistry;
 use zeph_skills::watcher::SkillWatcher;
@@ -661,6 +662,7 @@ async fn warmup_provider(provider: &AnyProvider) {
     }
 }
 
+#[allow(unused_variables)]
 async fn create_skill_matcher(
     config: &Config,
     provider: &AnyProvider,
@@ -675,6 +677,7 @@ async fn create_skill_matcher(
         Box::pin(async move { p.embed(&owned).await })
     };
 
+    #[cfg(feature = "qdrant")]
     if config.memory.semantic.enabled && memory.has_qdrant() {
         match QdrantSkillMatcher::new(&config.memory.qdrant_url) {
             Ok(mut qm) => match qm.sync(meta, embedding_model, &embed_fn).await {


### PR DESCRIPTION
## Summary

- Remove `anyhow` dependency from zeph-channels, replace with typed `ChannelError` mapping
- Group Agent struct 30+ flat fields into 5 inner structs: `MemoryState`, `SkillState`, `ContextState`, `McpState`, `IndexState`
- Add workspace-level `qdrant` feature flag to allow opting out of qdrant-client compilation

Closes #288, closes #289, closes #290
Part of #282

## Test plan

- [x] cargo build
- [x] cargo clippy --workspace -- -D warnings
- [x] cargo nextest run --workspace --lib --bins (1351 tests pass)
- [x] Performance review: no regression
- [x] Security audit: no issues, cargo-deny clean