### PR TITLE
clean up deny.toml license warnings

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -26,7 +26,6 @@ allow = [
     "BSD-3-Clause",
     "ISC",
     "Unicode-3.0",
-    "Unicode-DFS-2016",
     "Zlib",
     "MPL-2.0",
     "CC0-1.0",
@@ -39,6 +38,11 @@ allow = [
 name = "ring"
 expression = "MIT AND ISC AND OpenSSL"
 license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+[[licenses.clarify]]
+name = "ollama-rs"
+expression = "MIT"
+license-files = []
 
 [bans]
 multiple-versions = "warn"


### PR DESCRIPTION
## Summary
- Remove unused `Unicode-DFS-2016` from license allow list
- Add `licenses.clarify` entry for `ollama-rs` missing license field

Closes #310