### PR TITLE
implement TTL-based eviction for A2A rate limiter

### DIFF
--- a/crates/zeph-a2a/src/server/router.rs
+++ b/crates/zeph-a2a/src/server/router.rs
@@ -404,7 +404,10 @@ mod tests {
         let mut map = counters.lock().await;
         map.retain(|_, (_, ts)| now.duration_since(*ts) < RATE_WINDOW);
 
-        assert!(!map.contains_key(&stale_ip), "stale entry should be evicted");
+        assert!(
+            !map.contains_key(&stale_ip),
+            "stale entry should be evicted"
+        );
         assert!(map.contains_key(&fresh_ip), "fresh entry should remain");
     }
 }


### PR DESCRIPTION
## Summary
- Add periodic background task (every 60s) that evicts stale entries from rate limiter HashMap
- Add max entries cap (10,000) with full clear as defense-in-depth
- Add unit tests for eviction and cap behavior

## Test plan
- [x] `cargo nextest run -p zeph-a2a` — 71 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean

Closes #306