### PR TITLE
detect relative path traversal in shell sandbox

### DIFF
--- a/crates/zeph-tools/Cargo.toml
+++ b/crates/zeph-tools/Cargo.toml
@@ -17,7 +17,7 @@ scrape-core.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["fs", "io-util", "process", "rt", "sync", "time"] }
+tokio = { workspace = true, features = ["fs", "io-util", "macros", "process", "rt", "sync", "time"] }
 tracing.workspace = true
 url.workspace = true
 


### PR DESCRIPTION
## Summary

- Extend `validate_sandbox` to detect relative paths (`./`, `../`, `..`) in addition to absolute paths
- Reject any path containing `..` traversal segments before canonicalization to prevent sandbox escape
- Canonicalize relative paths against CWD for proper sandbox boundary checks
- Add `tokio/macros` to zeph-tools dependencies (fixes pre-existing build issue with `tokio::select!`)

## Test plan

- [x] Unit tests for `has_traversal` detection
- [x] Unit tests for `extract_paths` with relative path extraction
- [x] Sandbox rejection tests for `../`, `..`, `./` outside allowed paths
- [x] Sandbox rejection for absolute paths with embedded `..` traversal
- [x] All 240 zeph-tools tests pass
- [x] Workspace clippy clean

Closes #308