### PR TITLE
perf: replace tokio full features with explicit list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ vault-age = ["zeph-core/vault-age"]
 
 [dependencies]
 anyhow.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "sync"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 zeph-a2a = { workspace = true, optional = true }


### PR DESCRIPTION
## Summary
- Replace `tokio = { features = ["full"] }` with `["macros", "rt-multi-thread", "signal", "sync"]` in root binary
- Avoids compiling unused tokio features (io-util, fs, parking_lot, test-util, etc.)
- Expected 10-15% tokio compile time reduction on clean builds

Closes #314