### PR TITLE
perf: concurrent skill embedding with buffer_unordered

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8311,6 +8311,7 @@ version = "0.9.6"
 dependencies = [
  "anyhow",
  "blake3",
+ "futures",
  "notify",
  "notify-debouncer-mini",
  "qdrant-client",

--- a/crates/zeph-skills/Cargo.toml
+++ b/crates/zeph-skills/Cargo.toml
@@ -17,6 +17,7 @@ notify.workspace = true
 notify-debouncer-mini.workspace = true
 qdrant-client = { workspace = true, optional = true, features = ["serde"] }
 serde_json = { workspace = true, optional = true }
+futures.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["sync", "rt"] }
 tracing.workspace = true


### PR DESCRIPTION
## Summary
- Refactor `SkillMatcher::new()` from sequential embedding loop to `futures::stream::buffer_unordered(50)`
- Expected 10x speedup: 2.5s -> ~200ms for 50 skills on startup/hot-reload

Closes #315