### PR TITLE
fix: implement execute_tool_call for WebScrapeExecutor

### DIFF
--- a/crates/zeph-tools/src/scrape.rs
+++ b/crates/zeph-tools/src/scrape.rs
@@ -113,16 +113,18 @@ impl ToolExecutor for WebScrapeExecutor {
             return Ok(None);
         }
 
-        let instruction: ScrapeInstruction =
-            serde_json::from_value(serde_json::Value::Object(
-                call.params.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
+        let instruction: ScrapeInstruction = serde_json::from_value(serde_json::Value::Object(
+            call.params
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect(),
+        ))
+        .map_err(|e| {
+            ToolError::Execution(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                e.to_string(),
             ))
-            .map_err(|e| {
-                ToolError::Execution(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    e.to_string(),
-                ))
-            })?;
+        })?;
 
         let result = self.scrape_instruction(&instruction).await?;
 


### PR DESCRIPTION
## Summary
- WebScrapeExecutor only implemented legacy text-extraction `execute()`, returning `Ok(None)` for native `execute_tool_call()` — making `web_scrape` tool silently fail under native tool_use path
- Extract shared `scrape_instruction()` helper, wire into both `execute()` and `execute_tool_call()`

## Test plan
- [x] `cargo clippy -p zeph-tools -- -D warnings` passes
- [x] `cargo nextest run -p zeph-tools --lib` — 240 tests pass
- [ ] Manual verification: ask zeph to scrape a URL via Claude provider