### PR TITLE
feat: graceful shutdown on Ctrl-C with MCP cleanup

### DIFF
--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -500,6 +500,17 @@ impl<P: LlmProvider + Clone + 'static, C: Channel, T: ToolExecutor> Agent<P, C, 
         count
     }
 
+    pub async fn shutdown(&mut self) {
+        self.channel.send("Shutting down...").await.ok();
+
+        #[cfg(feature = "mcp")]
+        if let Some(ref manager) = self.mcp.manager {
+            manager.shutdown_all_shared().await;
+        }
+
+        tracing::info!("agent shutdown complete");
+    }
+
     /// Run the chat loop, receiving messages via the channel until EOF or shutdown.
     ///
     /// # Errors


### PR DESCRIPTION
## Summary
- Add `Agent::shutdown()` with farewell message and MCP server cleanup
- Cancel-aware LLM streaming via `tokio::select!` on shutdown signal
- Native tool loop checks shutdown flag each iteration
- `McpManager::shutdown_all_shared(&self)` with 5s per-client timeout
- Shutdown called in all exit paths (CLI, TUI agent, TUI task)

Closes #355, closes #356, closes #357, closes #358

## Test plan
- [x] `cargo nextest run --workspace --lib --bins` (1427 pass)
- [x] `cargo clippy --workspace -- -D warnings` (clean)
- [x] `cargo +nightly fmt --check` (clean)
- [ ] Manual: start long response, Ctrl-C — verify "Shutting down..." and clean exit