### PR TITLE
release: v0.9.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.9.8] - 2026-02-16
+
 ### Added
+- Graceful shutdown on Ctrl-C with farewell message and MCP server cleanup (#355)
+- Cancel-aware LLM streaming via tokio::select on shutdown signal (#358)
+- `McpManager::shutdown_all_shared()` with per-client 5s timeout (#356)
+- Indexer progress logging with file count and per-file stats
+- Skip code index for providers with native tool_use (#357)
 - OpenAI prompt caching: parse and report cached token usage (#348)
 - Syntax highlighting for TUI code blocks via tree-sitter-highlight (#345, #346, #347)
 - Anthropic prompt caching with structured system content blocks (#337)
@@ -19,6 +26,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `ToolUse`/`ToolResult` variants in `MessagePart` for structured tool flow (#255)
 - Dual-mode agent loop: native structured path alongside legacy text extraction (#258)
 - Dual system prompt: native tool_use instructions for capable providers, fenced-block instructions for legacy providers
+
+### Changed
+- Consolidate all SQLite migrations into root `migrations/` directory (#354)
 
 ## [0.9.7] - 2026-02-15
 
@@ -762,7 +772,8 @@ let agent = Agent::new(provider, channel, &skills_prompt, executor);
 - Agent calls channel.send_typing() before each LLM request
 - Agent::run() uses tokio::select! to race channel messages against shutdown signal
 
-[Unreleased]: https://github.com/bug-ops/zeph/compare/v0.9.7...HEAD
+[Unreleased]: https://github.com/bug-ops/zeph/compare/v0.9.8...HEAD
+[0.9.8]: https://github.com/bug-ops/zeph/compare/v0.9.7...v0.9.8
 [0.9.7]: https://github.com/bug-ops/zeph/compare/v0.9.6...v0.9.7
 [0.9.6]: https://github.com/bug-ops/zeph/compare/v0.9.5...v0.9.6
 [0.9.5]: https://github.com/bug-ops/zeph/compare/v0.9.4...v0.9.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8145,7 +8145,7 @@ dependencies = [
 
 [[package]]
 name = "zeph"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -8167,7 +8167,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-a2a"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "axum 0.8.8",
  "eventsource-stream",
@@ -8191,7 +8191,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-channels"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "criterion",
  "pulldown-cmark",
@@ -8204,7 +8204,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-core"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "age",
  "anyhow",
@@ -8230,7 +8230,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-index"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "blake3",
  "ignore",
@@ -8262,7 +8262,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-llm"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -8284,7 +8284,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-mcp"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "blake3",
  "qdrant-client",
@@ -8303,7 +8303,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-memory"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8321,7 +8321,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-skills"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "blake3",
@@ -8342,7 +8342,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-tools"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "dirs",
  "filetime",
@@ -8364,7 +8364,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-tui"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 rust-version = "1.88"
-version = "0.9.7"
+version = "0.9.8"
 authors = ["bug-ops"]
 license = "MIT"
 repository = "https://github.com/bug-ops/zeph"
@@ -70,16 +70,16 @@ tree-sitter-typescript = "0.23"
 unicode-width = "0.2"
 url = "2.5"
 uuid = "1.21"
-zeph-a2a = { path = "crates/zeph-a2a", version = "0.9.7" }
-zeph-channels = { path = "crates/zeph-channels", version = "0.9.7" }
-zeph-core = { path = "crates/zeph-core", version = "0.9.7" }
-zeph-index = { path = "crates/zeph-index", version = "0.9.7" }
-zeph-llm = { path = "crates/zeph-llm", version = "0.9.7" }
-zeph-mcp = { path = "crates/zeph-mcp", version = "0.9.7" }
-zeph-memory = { path = "crates/zeph-memory", version = "0.9.7" }
-zeph-skills = { path = "crates/zeph-skills", version = "0.9.7" }
-zeph-tools = { path = "crates/zeph-tools", version = "0.9.7" }
-zeph-tui = { path = "crates/zeph-tui", version = "0.9.7" }
+zeph-a2a = { path = "crates/zeph-a2a", version = "0.9.8" }
+zeph-channels = { path = "crates/zeph-channels", version = "0.9.8" }
+zeph-core = { path = "crates/zeph-core", version = "0.9.8" }
+zeph-index = { path = "crates/zeph-index", version = "0.9.8" }
+zeph-llm = { path = "crates/zeph-llm", version = "0.9.8" }
+zeph-mcp = { path = "crates/zeph-mcp", version = "0.9.8" }
+zeph-memory = { path = "crates/zeph-memory", version = "0.9.8" }
+zeph-skills = { path = "crates/zeph-skills", version = "0.9.8" }
+zeph-tools = { path = "crates/zeph-tools", version = "0.9.8" }
+zeph-tui = { path = "crates/zeph-tui", version = "0.9.8" }
 
 [workspace.lints.clippy]
 all = "warn"

--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ cargo build --release --features tui
 | **A2A Protocol** | Agent-to-agent communication via JSON-RPC 2.0 with SSE streaming, delegated task inference through agent pipeline | [A2A](https://bug-ops.github.io/zeph/guide/a2a.html) |
 | **Model Orchestrator** | Route tasks to different providers with fallback chains | [Orchestrator](https://bug-ops.github.io/zeph/guide/orchestrator.html) |
 | **Self-Learning** | Skills evolve via failure detection and LLM-generated improvements | [Self-Learning](https://bug-ops.github.io/zeph/guide/self-learning.html) |
-| **TUI Dashboard** | ratatui terminal UI with markdown rendering, deferred model warmup, scrollbar, mouse scroll, thinking blocks, conversation history, splash screen, live metrics, message queueing (max 10, FIFO with Ctrl+K clear) | [TUI](https://bug-ops.github.io/zeph/guide/tui.html) |
+| **Prompt Caching** | Automatic prompt caching for Anthropic and OpenAI providers, reducing latency and cost on repeated context | |
+| **Graceful Shutdown** | Ctrl-C triggers ordered teardown with MCP server cleanup and pending task draining | |
+| **TUI Dashboard** | ratatui terminal UI with tree-sitter syntax highlighting, markdown rendering, deferred model warmup, scrollbar, mouse scroll, thinking blocks, conversation history, splash screen, live metrics, message queueing (max 10, FIFO with Ctrl+K clear) | [TUI](https://bug-ops.github.io/zeph/guide/tui.html) |
 | **Multi-Channel I/O** | CLI, Telegram, and TUI with streaming support | [Channels](https://bug-ops.github.io/zeph/guide/channels.html) |
 | **Defense-in-Depth** | Shell sandbox with relative path traversal detection, file sandbox, command filter, secret redaction (Google/GitLab patterns), audit log, SSRF protection (agent + MCP), rate limiter TTL eviction, doom-loop detection | [Security](https://bug-ops.github.io/zeph/security.html) |
 

--- a/docs/src/architecture/overview.md
+++ b/docs/src/architecture/overview.md
@@ -59,3 +59,4 @@ Queued messages are processed sequentially with full context rebuilding between 
 - **Dependencies:** versions only in root `[workspace.dependencies]`; crates inherit via `workspace = true`
 - **Feature gates:** optional crates (`zeph-index`, `zeph-mcp`, `zeph-a2a`, `zeph-tui`) are feature-gated in the binary
 - **Context engineering:** proportional budget allocation, semantic recall injection, message trimming, runtime compaction, environment context injection, progressive skill loading, ZEPH.md project config discovery
+- **Graceful shutdown:** Ctrl-C triggers ordered teardown — the agent loop exits cleanly, MCP server connections are closed, and pending async tasks are drained before process exit

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -35,7 +35,7 @@ docker pull ghcr.io/bug-ops/zeph:latest
 Or use a specific version:
 
 ```bash
-docker pull ghcr.io/bug-ops/zeph:v0.9.5
+docker pull ghcr.io/bug-ops/zeph:v0.9.8
 ```
 
 Images are scanned with [Trivy](https://trivy.dev/) in CI/CD and use Oracle Linux 9 Slim base with **0 HIGH/CRITICAL CVEs**. Multi-platform: linux/amd64, linux/arm64.

--- a/docs/src/guide/docker.md
+++ b/docs/src/guide/docker.md
@@ -1,6 +1,6 @@
 # Docker Deployment
 
-Docker Compose automatically pulls the latest image from GitHub Container Registry. To use a specific version, set `ZEPH_IMAGE=ghcr.io/bug-ops/zeph:v0.9.5`.
+Docker Compose automatically pulls the latest image from GitHub Container Registry. To use a specific version, set `ZEPH_IMAGE=ghcr.io/bug-ops/zeph:v0.9.8`.
 
 ## Quick Start (Ollama + Qdrant in containers)
 
@@ -56,7 +56,7 @@ ZEPH_VAULT_KEY=./my-key.txt ZEPH_VAULT_PATH=./my-secrets.age \
 
 ```bash
 # Use a specific release version
-ZEPH_IMAGE=ghcr.io/bug-ops/zeph:v0.9.5 docker compose up
+ZEPH_IMAGE=ghcr.io/bug-ops/zeph:v0.9.8 docker compose up
 
 # Always pull latest
 docker compose pull && docker compose up

--- a/docs/src/guide/tools.md
+++ b/docs/src/guide/tools.md
@@ -42,6 +42,8 @@ The native path uses the same tool executors and permission checks as the legacy
 
 Types involved: `ToolDefinition` (name + description + JSON Schema), `ChatResponse` (Text or ToolUse), `ToolUseRequest` (id + name + input), and `ToolUse`/`ToolResult` variants in `MessagePart`.
 
+Prompt caching is enabled automatically for Anthropic and OpenAI providers, reducing latency and cost when the system prompt and tool definitions remain stable across turns.
+
 ## Legacy Text Extraction
 
 Providers without native tool support (Ollama, Candle) use text-based tool invocation, distinguished by `InvocationHint` on each `ToolDef`:

--- a/docs/src/guide/tui.md
+++ b/docs/src/guide/tui.md
@@ -24,7 +24,7 @@ ZEPH_TUI=true zeph
 
 ```text
 +-------------------------------------------------------------+
-| Zeph v0.9.5 | Provider: orchestrator | Model: claude-son... |
+| Zeph v0.9.8 | Provider: orchestrator | Model: claude-son... |
 +----------------------------------------+--------------------+
 |                                        | Skills (3/15)      |
 |                                        | - setup-guide      |
@@ -96,7 +96,7 @@ Chat messages are rendered with full markdown support via `pulldown-cmark`:
 | `**bold**` | Bold modifier |
 | `*italic*` | Italic modifier |
 | `` `inline code` `` | Blue text with dark background glow |
-| Code blocks | Green text with dimmed language tag |
+| Code blocks | Syntax-highlighted via tree-sitter (language-aware coloring) with dimmed language tag |
 | `# Heading` | Bold + underlined |
 | `- list item` | Green bullet (•) prefix |
 | `> blockquote` | Dimmed vertical bar (│) prefix |


### PR DESCRIPTION
## Summary

- Bump version from 0.9.7 to 0.9.8
- Update CHANGELOG.md with release notes
- Refresh README and mdBook documentation

## Checklist

- [x] Version updated in all manifests
- [x] CHANGELOG.md has release section with date
- [x] README reflects new features
- [x] Documentation updated (TUI, tools, docker, architecture)
- [x] All CI checks pass (fmt, clippy, 1427 tests)
- [ ] Ready for tagging after merge

After merge: `git tag v0.9.8 && git push origin v0.9.8`