### PR TITLE
feat: autonomy levels and channel allowlisting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- `AutonomyLevel` enum (ReadOnly/Supervised/Full) for controlling tool access (#370)
+- `autonomy_level` config key in `[security]` section (default: supervised)
+- Read-only mode restricts agent to file_read, file_glob, file_grep, web_scrape
+- Full mode allows all tools without confirmation prompts
+- Documented `[telegram].allowed_users` allowlist in default config (#371)
+
 ## [0.9.8] - 2026-02-16
 
 ### Added

--- a/config/default.toml
+++ b/config/default.toml
@@ -209,6 +209,13 @@ destination = "stdout"
 [security]
 # Redact secrets (API keys, tokens) from LLM responses before display
 redact_secrets = true
+# Tool access level: "readonly" (observe only), "supervised" (default, with confirmations), "full" (all tools, no confirmations)
+autonomy_level = "supervised"
+
+# [telegram]
+# token = "your-bot-token"
+# Allowed usernames (empty = allow all except for /start command)
+# allowed_users = ["username1", "username2"]
 
 [timeouts]
 # LLM chat completion timeout in seconds

--- a/crates/zeph-core/src/config/mod.rs
+++ b/crates/zeph-core/src/config/mod.rs
@@ -5,6 +5,7 @@ mod types;
 mod tests;
 
 pub use types::*;
+pub use zeph_tools::AutonomyLevel;
 
 use std::path::Path;
 

--- a/crates/zeph-core/src/config/tests.rs
+++ b/crates/zeph-core/src/config/tests.rs
@@ -2018,3 +2018,81 @@ fn index_config_env_override_invalid_ignored() {
     assert!(!config.index.enabled);
     assert_eq!(config.index.max_chunks, 12);
 }
+
+#[test]
+fn security_config_default_autonomy_supervised() {
+    let config = Config::default();
+    assert_eq!(config.security.autonomy_level, AutonomyLevel::Supervised);
+}
+
+#[test]
+#[serial]
+fn parse_toml_with_autonomy_readonly() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("autonomy_readonly.toml");
+    let mut f = std::fs::File::create(&path).unwrap();
+    write!(
+        f,
+        r#"
+[agent]
+name = "Zeph"
+
+[llm]
+provider = "ollama"
+base_url = "http://localhost:11434"
+model = "mistral:7b"
+
+[skills]
+paths = ["./skills"]
+
+[memory]
+sqlite_path = "./data/zeph.db"
+history_limit = 50
+
+[security]
+autonomy_level = "readonly"
+"#
+    )
+    .unwrap();
+
+    clear_env();
+
+    let config = Config::load(&path).unwrap();
+    assert_eq!(config.security.autonomy_level, AutonomyLevel::ReadOnly);
+}
+
+#[test]
+#[serial]
+fn parse_toml_with_autonomy_full() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("autonomy_full.toml");
+    let mut f = std::fs::File::create(&path).unwrap();
+    write!(
+        f,
+        r#"
+[agent]
+name = "Zeph"
+
+[llm]
+provider = "ollama"
+base_url = "http://localhost:11434"
+model = "mistral:7b"
+
+[skills]
+paths = ["./skills"]
+
+[memory]
+sqlite_path = "./data/zeph.db"
+history_limit = 50
+
+[security]
+autonomy_level = "full"
+"#
+    )
+    .unwrap();
+
+    clear_env();
+
+    let config = Config::load(&path).unwrap();
+    assert_eq!(config.security.autonomy_level, AutonomyLevel::Full);
+}

--- a/crates/zeph-core/src/config/types.rs
+++ b/crates/zeph-core/src/config/types.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use serde::Deserialize;
-use zeph_tools::ToolsConfig;
+use zeph_tools::{AutonomyLevel, ToolsConfig};
 
 use crate::vault::Secret;
 
@@ -503,12 +503,15 @@ fn default_a2a_timeout() -> u64 {
 pub struct SecurityConfig {
     #[serde(default = "default_true")]
     pub redact_secrets: bool,
+    #[serde(default)]
+    pub autonomy_level: AutonomyLevel,
 }
 
 impl Default for SecurityConfig {
     fn default() -> Self {
         Self {
             redact_secrets: true,
+            autonomy_level: AutonomyLevel::default(),
         }
     }
 }

--- a/crates/zeph-tools/src/lib.rs
+++ b/crates/zeph-tools/src/lib.rs
@@ -20,7 +20,9 @@ pub use executor::{
 };
 pub use file::FileExecutor;
 pub use overflow::{cleanup_overflow_files, save_overflow};
-pub use permissions::{PermissionAction, PermissionPolicy, PermissionRule, PermissionsConfig};
+pub use permissions::{
+    AutonomyLevel, PermissionAction, PermissionPolicy, PermissionRule, PermissionsConfig,
+};
 pub use registry::ToolRegistry;
 pub use scrape::WebScrapeExecutor;
 pub use shell::ShellExecutor;

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -67,6 +67,23 @@ Commands matching `confirm_patterns` trigger an interactive confirmation before 
 allowed_paths = ["/home/user/workspace"]  # Empty = cwd only
 ```
 
+## Autonomy Levels
+
+The `security.autonomy_level` setting controls the agent's tool access scope:
+
+| Level | Tools Available | Confirmations |
+|-------|----------------|---------------|
+| `readonly` | `file_read`, `file_glob`, `file_grep`, `web_scrape` | N/A (write tools hidden) |
+| `supervised` | All tools per permission policy | Yes, for destructive patterns |
+| `full` | All tools | No confirmations |
+
+Default is `supervised`. In `readonly` mode, write-capable tools are excluded from the LLM system prompt and rejected at execution time (defense-in-depth).
+
+```toml
+[security]
+autonomy_level = "supervised"  # readonly, supervised, full
+```
+
 ## Permission Policy
 
 The `[tools.permissions]` config section provides fine-grained, pattern-based access control for each tool. Rules are evaluated in order (first match wins) using case-insensitive glob patterns against the tool input. See [Tool System — Permissions](guide/tools.md#permissions) for configuration details.

--- a/src/main.rs
+++ b/src/main.rs
@@ -263,7 +263,9 @@ async fn main() -> anyhow::Result<()> {
         zeph_tools::cleanup_overflow_files(std::time::Duration::from_secs(86_400));
     });
 
-    let permission_policy = config.tools.permission_policy();
+    let permission_policy = config
+        .tools
+        .permission_policy(config.security.autonomy_level);
     let mut shell_executor =
         ShellExecutor::new(&config.tools.shell).with_permissions(permission_policy.clone());
     if config.tools.audit.enabled

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1217,6 +1217,7 @@ async fn agent_redaction_enabled() {
 
     let security = SecurityConfig {
         redact_secrets: true,
+        autonomy_level: Default::default(),
     };
 
     let mut agent = Agent::new(
@@ -1247,6 +1248,7 @@ async fn agent_redaction_disabled() {
 
     let security = SecurityConfig {
         redact_secrets: false,
+        autonomy_level: Default::default(),
     };
 
     let mut agent = Agent::new(
@@ -1415,6 +1417,7 @@ async fn agent_with_security_config() {
 
     let security = SecurityConfig {
         redact_secrets: true,
+        autonomy_level: Default::default(),
     };
     let timeouts = TimeoutConfig {
         llm_seconds: 60,
@@ -1679,6 +1682,7 @@ async fn agent_streaming_redaction() {
 
     let security = SecurityConfig {
         redact_secrets: true,
+        autonomy_level: Default::default(),
     };
 
     let mut agent = Agent::new(
@@ -1712,6 +1716,7 @@ async fn agent_redaction_in_tool_output() {
 
     let security = SecurityConfig {
         redact_secrets: true,
+        autonomy_level: Default::default(),
     };
 
     let mut agent = Agent::new(


### PR DESCRIPTION
## Summary

- Add `AutonomyLevel` enum (ReadOnly/Supervised/Full) to control tool access scope (#370)
- ReadOnly restricts agent to `file_read`, `file_glob`, `file_grep`, `web_scrape`
- Full mode allows all tools without confirmation prompts
- Supervised (default) preserves current permission policy behavior
- Document `[telegram].allowed_users` allowlist in default config (#371)

Closes #370, closes #371

## Changed files

- `crates/zeph-tools/src/permissions.rs` — `AutonomyLevel` enum, integration with `PermissionPolicy::check()`
- `crates/zeph-tools/src/config.rs` — `permission_policy()` accepts `AutonomyLevel` parameter
- `crates/zeph-core/src/config/types.rs` — `SecurityConfig.autonomy_level` field
- `config/default.toml` — `autonomy_level` key + telegram allowlist docs
- `docs/src/security.md` — Autonomy Levels section
- `src/main.rs` — Pass autonomy level to permission policy construction

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo nextest run --workspace --lib --bins` — 1437/1437 passed
- [x] New unit tests: autonomy level deserialization, readonly/full/supervised permission checks