### PR TITLE
feat: Discord and Slack channel adapters (M23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `CostTracker` with per-model token pricing and configurable daily budget limits (#378)
 - `[cost]` config section with `enabled` and `max_daily_cents` options
 - `cost_spent_cents` field in `MetricsSnapshot` for TUI cost display
+- Discord channel adapter with Gateway v10 WebSocket, slash commands, edit-in-place streaming (#382)
+- Slack channel adapter with Events API webhook, HMAC-SHA256 signature verification, streaming (#383)
+- Feature flags: `discord` and `slack` (opt-in) in zeph-channels and root crate
+- `DiscordConfig` and `SlackConfig` with token redaction in Debug impls
+- Slack timestamp replay protection (reject requests >5min old)
+- Configurable Slack webhook bind address (`webhook_host`)
 
 ## [0.9.8] - 2026-02-16
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,6 +1366,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6596,6 +6602,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7006,6 +7028,25 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
 
 [[package]]
 name = "type-map"
@@ -8314,11 +8355,20 @@ dependencies = [
 name = "zeph-channels"
 version = "0.9.8"
 dependencies = [
+ "axum 0.8.8",
  "criterion",
+ "futures",
+ "hmac",
  "pulldown-cmark",
+ "reqwest 0.13.2",
+ "serde",
+ "serde_json",
+ "sha2",
+ "subtle",
  "teloxide",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite",
  "tracing",
  "zeph-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ testcontainers = "0.27"
 thiserror = "2.0"
 tokenizers = { version = "0.22", default-features = false, features = ["fancy-regex"] }
 tokio = "1"
+tokio-tungstenite = { version = "0.28", default-features = false }
 tokio-stream = "0.1"
 tokio-util = "0.7"
 toml = "1.0"
@@ -115,6 +116,8 @@ orchestrator = ["zeph-llm/orchestrator"]
 router = ["zeph-llm/router"]
 self-learning = ["zeph-core/self-learning"]
 tui = ["dep:zeph-tui"]
+discord = ["zeph-channels/discord"]
+slack = ["zeph-channels/slack"]
 index = ["dep:zeph-index", "zeph-core/index"]
 gateway = ["dep:zeph-gateway"]
 daemon = ["zeph-core/daemon"]

--- a/config/default.toml
+++ b/config/default.toml
@@ -150,6 +150,21 @@ repo_map_tokens = 500
 # Cache TTL for repo map in seconds (avoids regeneration on every message)
 repo_map_ttl_secs = 300
 
+# [discord]
+# token = ""                    # or set ZEPH_DISCORD_TOKEN
+# application_id = ""           # for slash command registration
+# allowed_user_ids = []         # Discord user IDs (empty = allow all)
+# allowed_role_ids = []         # Discord role IDs
+# allowed_channel_ids = []      # restrict to specific channels
+
+# [slack]
+# bot_token = ""                # or set ZEPH_SLACK_BOT_TOKEN
+# signing_secret = ""           # or set ZEPH_SLACK_SIGNING_SECRET
+# port = 3000                   # Events API webhook port
+# webhook_host = "127.0.0.1"   # bind address for Events API webhook
+# allowed_user_ids = []         # Slack user IDs (empty = allow all)
+# allowed_channel_ids = []      # restrict to specific channels
+
 [mcp]
 # Allowlist of permitted commands for /mcp add (empty = allow all)
 allowed_commands = ["npx", "uvx", "node", "python", "python3"]

--- a/crates/zeph-channels/Cargo.toml
+++ b/crates/zeph-channels/Cargo.toml
@@ -6,11 +6,24 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[features]
+discord = ["dep:tokio-tungstenite", "dep:futures"]
+slack = ["dep:axum", "dep:hmac", "dep:sha2", "dep:subtle"]
+
 [dependencies]
+axum = { workspace = true, optional = true }
+futures = { workspace = true, optional = true }
+hmac = { version = "0.12", optional = true }
 pulldown-cmark.workspace = true
+reqwest = { workspace = true, features = ["rustls", "json"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+sha2 = { version = "0.10", optional = true }
+subtle = { workspace = true, optional = true }
 teloxide.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["sync", "rt"] }
+tokio-tungstenite = { workspace = true, optional = true, features = ["connect", "rustls-tls-native-roots"] }
 tracing.workspace = true
 zeph-core.workspace = true
 

--- a/crates/zeph-channels/src/discord/gateway.rs
+++ b/crates/zeph-channels/src/discord/gateway.rs
@@ -1,0 +1,278 @@
+//! Discord Gateway WebSocket client with heartbeat and reconnect.
+
+use std::time::Duration;
+
+use futures::{SinkExt, StreamExt};
+use serde::Serialize;
+use serde_json::Value;
+use tokio::sync::mpsc;
+use tokio_tungstenite::MaybeTlsStream;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::Message as WsMessage;
+
+type WsStream = tokio_tungstenite::WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
+
+const GATEWAY_URL: &str = "wss://gateway.discord.gg/?v=10&encoding=json";
+
+#[derive(Debug, Clone)]
+pub struct IncomingMessage {
+    pub channel_id: String,
+    pub content: String,
+    pub author_id: String,
+    pub author_roles: Vec<String>,
+}
+
+// Intents: GUILD_MESSAGES (1<<9) | MESSAGE_CONTENT (1<<15) | DIRECT_MESSAGES (1<<12)
+const INTENTS: u64 = (1 << 9) | (1 << 15) | (1 << 12);
+
+#[derive(Serialize)]
+struct Identify {
+    op: u8,
+    d: IdentifyData,
+}
+
+#[derive(Serialize)]
+struct IdentifyData {
+    token: String,
+    intents: u64,
+    properties: IdentifyProperties,
+}
+
+#[derive(Serialize)]
+struct IdentifyProperties {
+    os: String,
+    browser: String,
+    device: String,
+}
+
+#[derive(Serialize)]
+struct Heartbeat {
+    op: u8,
+    d: Option<u64>,
+}
+
+/// Spawn the gateway connection loop, returning a receiver of incoming messages.
+#[must_use]
+pub fn spawn_gateway(token: String) -> mpsc::Receiver<IncomingMessage> {
+    let (tx, rx) = mpsc::channel(64);
+    tokio::spawn(gateway_loop(token, tx));
+    rx
+}
+
+async fn gateway_loop(token: String, tx: mpsc::Sender<IncomingMessage>) {
+    loop {
+        match run_session(&token, &tx).await {
+            Ok(()) => {
+                tracing::info!("discord gateway session ended, reconnecting...");
+            }
+            Err(e) => {
+                tracing::warn!("discord gateway error: {e:#}, reconnecting in 5s");
+                tokio::time::sleep(Duration::from_secs(5)).await;
+            }
+        }
+    }
+}
+
+async fn run_session(
+    token: &str,
+    tx: &mpsc::Sender<IncomingMessage>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let (ws_stream, _): (WsStream, _) = connect_async(GATEWAY_URL).await?;
+    let (mut write, mut read) = ws_stream.split();
+
+    // Wait for Hello (op 10)
+    let hello_text = read_next_text(&mut read).await?;
+    let hello: Value = serde_json::from_str(&hello_text)?;
+    let op = hello.get("op").and_then(Value::as_u64).unwrap_or(0);
+    if op != 10 {
+        return Err(format!("expected Hello (op 10), got op {op}").into());
+    }
+
+    let heartbeat_interval = hello
+        .get("d")
+        .and_then(|d| d.get("heartbeat_interval"))
+        .and_then(Value::as_u64)
+        .unwrap_or(41250);
+
+    // Send Identify
+    let identify = Identify {
+        op: 2,
+        d: IdentifyData {
+            token: token.to_owned(),
+            intents: INTENTS,
+            properties: IdentifyProperties {
+                os: "linux".into(),
+                browser: "zeph".into(),
+                device: "zeph".into(),
+            },
+        },
+    };
+    let json = serde_json::to_string(&identify)?;
+    write.send(WsMessage::Text(json.into())).await?;
+
+    let mut sequence: Option<u64> = None;
+    let mut heartbeat_timer = tokio::time::interval(Duration::from_millis(heartbeat_interval));
+
+    loop {
+        tokio::select! {
+            _ = heartbeat_timer.tick() => {
+                let hb = Heartbeat { op: 1, d: sequence };
+                let json = serde_json::to_string(&hb)?;
+                write.send(WsMessage::Text(json.into())).await?;
+            }
+            msg = read.next() => {
+                let Some(msg) = msg else { return Ok(()); };
+                let text = match msg? {
+                    WsMessage::Text(t) => t,
+                    WsMessage::Close(_) => return Ok(()),
+                    _ => continue,
+                };
+                let payload: Value = serde_json::from_str(&text)?;
+                let op = payload.get("op").and_then(Value::as_u64).unwrap_or(0);
+                if let Some(s) = payload.get("s").and_then(Value::as_u64) {
+                    sequence = Some(s);
+                }
+                match op {
+                    0 if payload.get("t").and_then(Value::as_str) == Some("MESSAGE_CREATE") => {
+                        if let Some(incoming) = payload.get("d").and_then(parse_message_create) {
+                            let _ = tx.send(incoming).await;
+                        }
+                    }
+                    7 | 9 => return Ok(()), // Reconnect / Invalid Session
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+fn parse_message_create(d: &Value) -> Option<IncomingMessage> {
+    let content = d.get("content")?.as_str()?.to_owned();
+    let author = d.get("author")?;
+    let author_id = author.get("id")?.as_str()?.to_owned();
+
+    if author.get("bot").and_then(Value::as_bool).unwrap_or(false) {
+        return None;
+    }
+
+    let channel_id = d.get("channel_id")?.as_str()?.to_owned();
+    let author_roles: Vec<String> = d
+        .get("member")
+        .and_then(|m| m.get("roles"))
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Some(IncomingMessage {
+        channel_id,
+        content,
+        author_id,
+        author_roles,
+    })
+}
+
+async fn read_next_text<S>(read: &mut S) -> Result<String, Box<dyn std::error::Error + Send + Sync>>
+where
+    S: futures::Stream<Item = Result<WsMessage, tokio_tungstenite::tungstenite::Error>> + Unpin,
+{
+    loop {
+        let Some(msg) = read.next().await else {
+            return Err("gateway connection closed".into());
+        };
+        match msg? {
+            WsMessage::Text(t) => return Ok(t.to_string()),
+            WsMessage::Close(_) => return Err("gateway closed".into()),
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_message_create_valid() {
+        let d: Value = serde_json::json!({
+            "content": "hello world",
+            "author": { "id": "123", "bot": false },
+            "channel_id": "456",
+            "member": { "roles": ["admin", "mod"] }
+        });
+        let msg = parse_message_create(&d).unwrap();
+        assert_eq!(msg.content, "hello world");
+        assert_eq!(msg.author_id, "123");
+        assert_eq!(msg.channel_id, "456");
+        assert_eq!(msg.author_roles, vec!["admin", "mod"]);
+    }
+
+    #[test]
+    fn parse_message_create_skips_bot() {
+        let d: Value = serde_json::json!({
+            "content": "bot msg",
+            "author": { "id": "123", "bot": true },
+            "channel_id": "456"
+        });
+        assert!(parse_message_create(&d).is_none());
+    }
+
+    #[test]
+    fn parse_message_create_missing_content() {
+        let d: Value = serde_json::json!({
+            "author": { "id": "123" },
+            "channel_id": "456"
+        });
+        assert!(parse_message_create(&d).is_none());
+    }
+
+    #[test]
+    fn parse_message_create_missing_author() {
+        let d: Value = serde_json::json!({
+            "content": "hello",
+            "channel_id": "456"
+        });
+        assert!(parse_message_create(&d).is_none());
+    }
+
+    #[test]
+    fn parse_message_create_no_member_roles() {
+        let d: Value = serde_json::json!({
+            "content": "hello",
+            "author": { "id": "123" },
+            "channel_id": "456"
+        });
+        let msg = parse_message_create(&d).unwrap();
+        assert!(msg.author_roles.is_empty());
+    }
+
+    #[test]
+    fn intents_value() {
+        assert_eq!(INTENTS, (1 << 9) | (1 << 15) | (1 << 12));
+    }
+
+    #[test]
+    fn spawn_gateway_returns_receiver() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let _rx = rt.block_on(async { spawn_gateway("invalid-token".into()) });
+    }
+
+    #[test]
+    fn incoming_message_clone() {
+        let msg = IncomingMessage {
+            channel_id: "ch".into(),
+            content: "text".into(),
+            author_id: "user".into(),
+            author_roles: vec!["role".into()],
+        };
+        let cloned = msg.clone();
+        assert_eq!(cloned.channel_id, "ch");
+        assert_eq!(cloned.content, "text");
+    }
+}

--- a/crates/zeph-channels/src/discord/mod.rs
+++ b/crates/zeph-channels/src/discord/mod.rs
@@ -1,0 +1,420 @@
+//! Discord channel adapter using Gateway WebSocket + REST API.
+
+pub mod gateway;
+pub mod rest;
+
+use std::time::{Duration, Instant};
+
+use tokio::sync::mpsc;
+use zeph_core::channel::{Channel, ChannelError, ChannelMessage};
+
+use self::gateway::IncomingMessage;
+
+const MAX_MESSAGE_LEN: usize = 2000;
+const EDIT_THROTTLE: Duration = Duration::from_millis(1500);
+
+/// Discord channel adapter implementing edit-in-place streaming.
+pub struct DiscordChannel {
+    rx: mpsc::Receiver<IncomingMessage>,
+    rest: rest::RestClient,
+    channel_id: Option<String>,
+    allowed_user_ids: Vec<String>,
+    allowed_role_ids: Vec<String>,
+    allowed_channel_ids: Vec<String>,
+    accumulated: String,
+    last_edit: Option<Instant>,
+    message_id: Option<String>,
+}
+
+impl std::fmt::Debug for DiscordChannel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DiscordChannel")
+            .field("channel_id", &self.channel_id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl DiscordChannel {
+    /// Create a new Discord channel and spawn the gateway listener.
+    #[must_use]
+    pub fn new(
+        token: String,
+        allowed_user_ids: Vec<String>,
+        allowed_role_ids: Vec<String>,
+        allowed_channel_ids: Vec<String>,
+    ) -> Self {
+        let rx = gateway::spawn_gateway(token.clone());
+        let rest = rest::RestClient::new(token);
+        Self {
+            rx,
+            rest,
+            channel_id: None,
+            allowed_user_ids,
+            allowed_role_ids,
+            allowed_channel_ids,
+            accumulated: String::new(),
+            last_edit: None,
+            message_id: None,
+        }
+    }
+
+    fn is_authorized(&self, msg: &IncomingMessage) -> bool {
+        if !self.allowed_channel_ids.is_empty()
+            && !self.allowed_channel_ids.contains(&msg.channel_id)
+        {
+            return false;
+        }
+        if self.allowed_user_ids.is_empty() && self.allowed_role_ids.is_empty() {
+            return true;
+        }
+        if self.allowed_user_ids.contains(&msg.author_id) {
+            return true;
+        }
+        msg.author_roles
+            .iter()
+            .any(|r| self.allowed_role_ids.contains(r))
+    }
+
+    fn should_send_update(&self) -> bool {
+        self.last_edit
+            .is_none_or(|last| last.elapsed() > EDIT_THROTTLE)
+    }
+
+    async fn send_or_edit(&mut self) -> Result<(), ChannelError> {
+        let channel_id = self
+            .channel_id
+            .clone()
+            .ok_or_else(|| ChannelError::Other("no active channel".into()))?;
+
+        let text = if self.accumulated.is_empty() {
+            "...".to_owned()
+        } else {
+            self.accumulated.clone()
+        };
+
+        if text.len() > MAX_MESSAGE_LEN {
+            let chunks = crate::markdown::utf8_chunks(&text, MAX_MESSAGE_LEN);
+            for chunk in chunks {
+                self.rest
+                    .send_message(&channel_id, chunk)
+                    .await
+                    .map_err(|e| ChannelError::Other(e.to_string()))?;
+            }
+            self.message_id = None;
+            return Ok(());
+        }
+
+        match self.message_id.clone() {
+            None => {
+                let msg = self
+                    .rest
+                    .send_message(&channel_id, &text)
+                    .await
+                    .map_err(|e| ChannelError::Other(e.to_string()))?;
+                self.message_id = Some(msg.id);
+            }
+            Some(msg_id) => {
+                if let Err(e) = self.rest.edit_message(&channel_id, &msg_id, &text).await {
+                    tracing::warn!("discord edit failed: {e}, sending new message");
+                    self.message_id = None;
+                    let msg = self
+                        .rest
+                        .send_message(&channel_id, &text)
+                        .await
+                        .map_err(|e| ChannelError::Other(e.to_string()))?;
+                    self.message_id = Some(msg.id);
+                }
+            }
+        }
+
+        self.last_edit = Some(Instant::now());
+        Ok(())
+    }
+}
+
+impl Channel for DiscordChannel {
+    fn try_recv(&mut self) -> Option<ChannelMessage> {
+        loop {
+            let incoming = self.rx.try_recv().ok()?;
+            if !self.is_authorized(&incoming) {
+                tracing::warn!(
+                    "rejected discord message from unauthorized user: {}",
+                    incoming.author_id
+                );
+                continue;
+            }
+            self.channel_id = Some(incoming.channel_id);
+            return Some(ChannelMessage {
+                text: incoming.content,
+            });
+        }
+    }
+
+    async fn recv(&mut self) -> Result<Option<ChannelMessage>, ChannelError> {
+        loop {
+            let Some(incoming) = self.rx.recv().await else {
+                return Ok(None);
+            };
+
+            if !self.is_authorized(&incoming) {
+                tracing::warn!(
+                    "rejected discord message from unauthorized user: {}",
+                    incoming.author_id
+                );
+                continue;
+            }
+
+            self.channel_id = Some(incoming.channel_id);
+            self.accumulated.clear();
+            self.last_edit = None;
+            self.message_id = None;
+
+            return Ok(Some(ChannelMessage {
+                text: incoming.content,
+            }));
+        }
+    }
+
+    async fn send(&mut self, text: &str) -> Result<(), ChannelError> {
+        let channel_id = self
+            .channel_id
+            .as_deref()
+            .ok_or_else(|| ChannelError::Other("no active channel".into()))?;
+
+        if text.len() <= MAX_MESSAGE_LEN {
+            self.rest
+                .send_message(channel_id, text)
+                .await
+                .map_err(|e| ChannelError::Other(e.to_string()))?;
+        } else {
+            let chunks = crate::markdown::utf8_chunks(text, MAX_MESSAGE_LEN);
+            for chunk in chunks {
+                self.rest
+                    .send_message(channel_id, chunk)
+                    .await
+                    .map_err(|e| ChannelError::Other(e.to_string()))?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn send_chunk(&mut self, chunk: &str) -> Result<(), ChannelError> {
+        self.accumulated.push_str(chunk);
+        if self.should_send_update() {
+            self.send_or_edit().await?;
+        }
+        Ok(())
+    }
+
+    async fn flush_chunks(&mut self) -> Result<(), ChannelError> {
+        if self.message_id.is_some() {
+            self.send_or_edit().await?;
+        }
+        self.accumulated.clear();
+        self.last_edit = None;
+        self.message_id = None;
+        Ok(())
+    }
+
+    async fn send_typing(&mut self) -> Result<(), ChannelError> {
+        let Some(channel_id) = self.channel_id.as_deref() else {
+            return Ok(());
+        };
+        let _ = self.rest.trigger_typing(channel_id).await;
+        Ok(())
+    }
+
+    async fn confirm(&mut self, prompt: &str) -> Result<bool, ChannelError> {
+        self.send(&format!("{prompt}\nReply 'yes' to confirm."))
+            .await?;
+        let Some(incoming) = self.rx.recv().await else {
+            return Ok(false);
+        };
+        Ok(incoming.content.trim().eq_ignore_ascii_case("yes"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn make_channel() -> DiscordChannel {
+        let (_tx, rx) = mpsc::channel(16);
+        let rest = rest::RestClient::new("test-token".into());
+        DiscordChannel {
+            rx,
+            rest,
+            channel_id: None,
+            allowed_user_ids: vec![],
+            allowed_role_ids: vec![],
+            allowed_channel_ids: vec![],
+            accumulated: String::new(),
+            last_edit: None,
+            message_id: None,
+        }
+    }
+
+    fn make_incoming(author_id: &str, channel_id: &str, roles: Vec<String>) -> IncomingMessage {
+        IncomingMessage {
+            channel_id: channel_id.into(),
+            content: "hello".into(),
+            author_id: author_id.into(),
+            author_roles: roles,
+        }
+    }
+
+    #[test]
+    fn is_authorized_allows_all_when_empty_lists() {
+        let ch = make_channel();
+        let msg = make_incoming("user1", "ch1", vec![]);
+        assert!(ch.is_authorized(&msg));
+    }
+
+    #[test]
+    fn is_authorized_rejects_channel_not_in_allowlist() {
+        let mut ch = make_channel();
+        ch.allowed_channel_ids = vec!["ch-allowed".into()];
+        let msg = make_incoming("user1", "ch-other", vec![]);
+        assert!(!ch.is_authorized(&msg));
+    }
+
+    #[test]
+    fn is_authorized_allows_channel_in_allowlist() {
+        let mut ch = make_channel();
+        ch.allowed_channel_ids = vec!["ch1".into()];
+        let msg = make_incoming("user1", "ch1", vec![]);
+        assert!(ch.is_authorized(&msg));
+    }
+
+    #[test]
+    fn is_authorized_allows_user_in_allowlist() {
+        let mut ch = make_channel();
+        ch.allowed_user_ids = vec!["user1".into()];
+        let msg = make_incoming("user1", "ch1", vec![]);
+        assert!(ch.is_authorized(&msg));
+    }
+
+    #[test]
+    fn is_authorized_rejects_user_not_in_allowlist() {
+        let mut ch = make_channel();
+        ch.allowed_user_ids = vec!["user-other".into()];
+        let msg = make_incoming("user1", "ch1", vec![]);
+        assert!(!ch.is_authorized(&msg));
+    }
+
+    #[test]
+    fn is_authorized_allows_role_in_allowlist() {
+        let mut ch = make_channel();
+        ch.allowed_role_ids = vec!["admin".into()];
+        let msg = make_incoming("user1", "ch1", vec!["admin".into()]);
+        assert!(ch.is_authorized(&msg));
+    }
+
+    #[test]
+    fn is_authorized_rejects_when_no_matching_role_or_user() {
+        let mut ch = make_channel();
+        ch.allowed_user_ids = vec!["user-other".into()];
+        ch.allowed_role_ids = vec!["admin".into()];
+        let msg = make_incoming("user1", "ch1", vec!["member".into()]);
+        assert!(!ch.is_authorized(&msg));
+    }
+
+    #[test]
+    fn should_send_update_true_when_no_last_edit() {
+        let ch = make_channel();
+        assert!(ch.should_send_update());
+    }
+
+    #[test]
+    fn should_send_update_false_within_throttle() {
+        let mut ch = make_channel();
+        ch.last_edit = Some(Instant::now());
+        assert!(!ch.should_send_update());
+    }
+
+    #[test]
+    fn should_send_update_true_after_throttle() {
+        let mut ch = make_channel();
+        ch.last_edit = Some(Instant::now() - Duration::from_millis(1600));
+        assert!(ch.should_send_update());
+    }
+
+    #[test]
+    fn send_chunk_accumulates() {
+        let mut ch = make_channel();
+        ch.accumulated.push_str("hello ");
+        ch.accumulated.push_str("world");
+        assert_eq!(ch.accumulated, "hello world");
+    }
+
+    #[tokio::test]
+    async fn flush_chunks_clears_state() {
+        let mut ch = make_channel();
+        ch.accumulated = "test".into();
+        ch.last_edit = Some(Instant::now());
+        // message_id is None, so send_or_edit won't be called
+        ch.flush_chunks().await.unwrap();
+        assert!(ch.accumulated.is_empty());
+        assert!(ch.last_edit.is_none());
+        assert!(ch.message_id.is_none());
+    }
+
+    #[test]
+    fn try_recv_sets_channel_id() {
+        let (tx, rx) = mpsc::channel(16);
+        let rest = rest::RestClient::new("test-token".into());
+        let mut ch = DiscordChannel {
+            rx,
+            rest,
+            channel_id: None,
+            allowed_user_ids: vec![],
+            allowed_role_ids: vec![],
+            allowed_channel_ids: vec![],
+            accumulated: String::new(),
+            last_edit: None,
+            message_id: None,
+        };
+        tx.try_send(make_incoming("user1", "ch42", vec![])).unwrap();
+        let msg = ch.try_recv().unwrap();
+        assert_eq!(msg.text, "hello");
+        assert_eq!(ch.channel_id.as_deref(), Some("ch42"));
+    }
+
+    #[test]
+    fn try_recv_skips_unauthorized() {
+        let (tx, rx) = mpsc::channel(16);
+        let rest = rest::RestClient::new("test-token".into());
+        let mut ch = DiscordChannel {
+            rx,
+            rest,
+            channel_id: None,
+            allowed_user_ids: vec!["allowed-user".into()],
+            allowed_role_ids: vec![],
+            allowed_channel_ids: vec![],
+            accumulated: String::new(),
+            last_edit: None,
+            message_id: None,
+        };
+        tx.try_send(make_incoming("unauthorized", "ch1", vec![]))
+            .unwrap();
+        assert!(ch.try_recv().is_none());
+    }
+
+    #[test]
+    fn debug_impl() {
+        let ch = make_channel();
+        let debug = format!("{ch:?}");
+        assert!(debug.contains("DiscordChannel"));
+    }
+
+    #[test]
+    fn max_message_len_constant() {
+        assert_eq!(MAX_MESSAGE_LEN, 2000);
+    }
+
+    #[test]
+    fn edit_throttle_constant() {
+        assert_eq!(EDIT_THROTTLE, Duration::from_millis(1500));
+    }
+}

--- a/crates/zeph-channels/src/discord/rest.rs
+++ b/crates/zeph-channels/src/discord/rest.rs
@@ -1,0 +1,98 @@
+//! Discord REST API client for message operations.
+
+use serde::{Deserialize, Serialize};
+
+const BASE_URL: &str = "https://discord.com/api/v10";
+
+pub struct RestClient {
+    client: reqwest::Client,
+    token: String,
+}
+
+impl std::fmt::Debug for RestClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RestClient")
+            .field("token", &"[REDACTED]")
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Deserialize)]
+pub struct DiscordMessage {
+    pub id: String,
+}
+
+#[derive(Serialize)]
+struct CreateMessage<'a> {
+    content: &'a str,
+}
+
+#[derive(Serialize)]
+struct EditMessage<'a> {
+    content: &'a str,
+}
+
+impl RestClient {
+    #[must_use]
+    pub fn new(token: String) -> Self {
+        let client = reqwest::Client::new();
+        Self { client, token }
+    }
+
+    fn auth_header(&self) -> String {
+        format!("Bot {}", self.token)
+    }
+
+    /// # Errors
+    ///
+    /// Returns an error if the HTTP request fails.
+    pub async fn send_message(
+        &self,
+        channel_id: &str,
+        content: &str,
+    ) -> Result<DiscordMessage, reqwest::Error> {
+        self.client
+            .post(format!("{BASE_URL}/channels/{channel_id}/messages"))
+            .header("Authorization", self.auth_header())
+            .json(&CreateMessage { content })
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await
+    }
+
+    /// # Errors
+    ///
+    /// Returns an error if the HTTP request fails.
+    pub async fn edit_message(
+        &self,
+        channel_id: &str,
+        message_id: &str,
+        content: &str,
+    ) -> Result<(), reqwest::Error> {
+        self.client
+            .patch(format!(
+                "{BASE_URL}/channels/{channel_id}/messages/{message_id}"
+            ))
+            .header("Authorization", self.auth_header())
+            .json(&EditMessage { content })
+            .send()
+            .await?
+            .error_for_status()?;
+        Ok(())
+    }
+
+    /// # Errors
+    ///
+    /// Returns an error if the HTTP request fails.
+    pub async fn trigger_typing(&self, channel_id: &str) -> Result<(), reqwest::Error> {
+        self.client
+            .post(format!("{BASE_URL}/channels/{channel_id}/typing"))
+            .header("Authorization", self.auth_header())
+            .send()
+            .await?
+            .error_for_status()?;
+        Ok(())
+    }
+}

--- a/crates/zeph-channels/src/lib.rs
+++ b/crates/zeph-channels/src/lib.rs
@@ -1,8 +1,12 @@
 //! Channel implementations for the Zeph agent.
 
 pub mod cli;
+#[cfg(feature = "discord")]
+pub mod discord;
 pub mod error;
 pub mod markdown;
+#[cfg(feature = "slack")]
+pub mod slack;
 pub mod telegram;
 
 pub use cli::CliChannel;

--- a/crates/zeph-channels/src/slack/api.rs
+++ b/crates/zeph-channels/src/slack/api.rs
@@ -1,0 +1,134 @@
+//! Slack Web API client for message operations.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+const SLACK_API: &str = "https://slack.com/api";
+
+pub struct SlackApi {
+    client: reqwest::Client,
+    token: String,
+}
+
+impl std::fmt::Debug for SlackApi {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SlackApi")
+            .field("token", &"[REDACTED]")
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Deserialize)]
+struct SlackResponse {
+    ok: bool,
+    #[serde(default)]
+    error: Option<String>,
+    #[serde(default)]
+    ts: Option<String>,
+}
+
+#[derive(Serialize)]
+struct PostMessage<'a> {
+    channel: &'a str,
+    text: &'a str,
+}
+
+#[derive(Serialize)]
+struct UpdateMessage<'a> {
+    channel: &'a str,
+    ts: &'a str,
+    text: &'a str,
+}
+
+impl SlackApi {
+    #[must_use]
+    pub fn new(token: String) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            token,
+        }
+    }
+
+    /// Call auth.test to retrieve the bot's own user ID.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the HTTP request or Slack API fails.
+    pub async fn auth_test(&self) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+        let resp: Value = self
+            .client
+            .post(format!("{SLACK_API}/auth.test"))
+            .bearer_auth(&self.token)
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        if resp.get("ok").and_then(Value::as_bool) != Some(true) {
+            let err = resp
+                .get("error")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown");
+            return Err(format!("slack auth.test: {err}").into());
+        }
+        resp.get("user_id")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .ok_or_else(|| "no user_id in auth.test response".into())
+    }
+
+    /// Post a new message, returning the message timestamp (ts).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the HTTP request or Slack API fails.
+    pub async fn post_message(
+        &self,
+        channel: &str,
+        text: &str,
+    ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+        let resp: SlackResponse = self
+            .client
+            .post(format!("{SLACK_API}/chat.postMessage"))
+            .bearer_auth(&self.token)
+            .json(&PostMessage { channel, text })
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        if !resp.ok {
+            return Err(
+                format!("slack chat.postMessage: {}", resp.error.unwrap_or_default()).into(),
+            );
+        }
+        resp.ts.ok_or_else(|| "no ts in response".into())
+    }
+
+    /// Update an existing message.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the HTTP request or Slack API fails.
+    pub async fn update_message(
+        &self,
+        channel: &str,
+        ts: &str,
+        text: &str,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let resp: SlackResponse = self
+            .client
+            .post(format!("{SLACK_API}/chat.update"))
+            .bearer_auth(&self.token)
+            .json(&UpdateMessage { channel, ts, text })
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        if !resp.ok {
+            return Err(format!("slack chat.update: {}", resp.error.unwrap_or_default()).into());
+        }
+        Ok(())
+    }
+}

--- a/crates/zeph-channels/src/slack/events.rs
+++ b/crates/zeph-channels/src/slack/events.rs
@@ -1,0 +1,440 @@
+//! Slack Events API webhook handler with request signature verification.
+
+use axum::{
+    Router,
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    routing::post,
+};
+use hmac::{Hmac, Mac};
+use serde_json::Value;
+use sha2::Sha256;
+use subtle::ConstantTimeEq;
+use tokio::sync::mpsc;
+
+type HmacSha256 = Hmac<Sha256>;
+
+#[derive(Clone)]
+pub struct IncomingMessage {
+    pub channel_id: String,
+    pub text: String,
+    pub user_id: String,
+}
+
+#[derive(Clone)]
+struct EventState {
+    signing_secret: String,
+    tx: mpsc::Sender<IncomingMessage>,
+    bot_user_id: String,
+    allowed_user_ids: Vec<String>,
+    allowed_channel_ids: Vec<String>,
+}
+
+/// Spawn the Slack Events API webhook server.
+#[must_use]
+pub fn spawn_event_server(
+    host: String,
+    port: u16,
+    signing_secret: String,
+    bot_user_id: String,
+    allowed_user_ids: Vec<String>,
+    allowed_channel_ids: Vec<String>,
+) -> mpsc::Receiver<IncomingMessage> {
+    let (tx, rx) = mpsc::channel(64);
+    let state = EventState {
+        signing_secret,
+        tx,
+        bot_user_id,
+        allowed_user_ids,
+        allowed_channel_ids,
+    };
+
+    tokio::spawn(async move {
+        let app = Router::new()
+            .route("/slack/events", post(handle_event))
+            .layer(axum::extract::DefaultBodyLimit::max(256 * 1024))
+            .with_state(state);
+        let listener = match tokio::net::TcpListener::bind(format!("{host}:{port}")).await {
+            Ok(l) => l,
+            Err(e) => {
+                tracing::error!("failed to bind slack events server on port {port}: {e}");
+                return;
+            }
+        };
+        tracing::info!("slack events server listening on port {port}");
+        if let Err(e) = axum::serve(listener, app).await {
+            tracing::error!("slack events server error: {e}");
+        }
+    });
+
+    rx
+}
+
+async fn handle_event(
+    State(state): State<EventState>,
+    headers: HeaderMap,
+    body: String,
+) -> Result<String, StatusCode> {
+    verify_signature(&state.signing_secret, &headers, &body)?;
+
+    let payload: Value = serde_json::from_str(&body).map_err(|_| StatusCode::BAD_REQUEST)?;
+
+    let event_type = payload.get("type").and_then(|v| v.as_str()).unwrap_or("");
+
+    match event_type {
+        "url_verification" => {
+            let challenge = payload
+                .get("challenge")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            Ok(challenge.to_owned())
+        }
+        "event_callback" => {
+            if let Some(event) = payload.get("event") {
+                let subtype = event.get("subtype").and_then(|v| v.as_str());
+                let event_type = event.get("type").and_then(|v| v.as_str());
+
+                if event_type == Some("message") && subtype.is_none() {
+                    let user = event.get("user").and_then(|v| v.as_str()).unwrap_or("");
+                    let channel = event.get("channel").and_then(|v| v.as_str()).unwrap_or("");
+                    let text = event.get("text").and_then(|v| v.as_str()).unwrap_or("");
+
+                    // Skip bot's own messages
+                    if !state.bot_user_id.is_empty() && user == state.bot_user_id {
+                        return Ok(String::new());
+                    }
+
+                    // Authorization checks
+                    if !state.allowed_channel_ids.is_empty()
+                        && !state.allowed_channel_ids.iter().any(|c| c == channel)
+                    {
+                        return Ok(String::new());
+                    }
+                    if !state.allowed_user_ids.is_empty()
+                        && !state.allowed_user_ids.iter().any(|u| u == user)
+                    {
+                        return Ok(String::new());
+                    }
+
+                    let _ = state
+                        .tx
+                        .send(IncomingMessage {
+                            channel_id: channel.to_owned(),
+                            text: text.to_owned(),
+                            user_id: user.to_owned(),
+                        })
+                        .await;
+                }
+            }
+            Ok(String::new())
+        }
+        _ => Ok(String::new()),
+    }
+}
+
+pub(crate) fn verify_signature(
+    signing_secret: &str,
+    headers: &HeaderMap,
+    body: &str,
+) -> Result<(), StatusCode> {
+    let timestamp = headers
+        .get("X-Slack-Request-Timestamp")
+        .and_then(|v| v.to_str().ok())
+        .ok_or(StatusCode::UNAUTHORIZED)?;
+
+    // SEC-002: Reject requests older than 5 minutes to prevent replay attacks
+    if let Ok(ts) = timestamp.parse::<i64>() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs().cast_signed())
+            .unwrap_or(0);
+        if (now - ts).abs() > 300 {
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+    } else {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+
+    let provided_sig = headers
+        .get("X-Slack-Signature")
+        .and_then(|v| v.to_str().ok())
+        .ok_or(StatusCode::UNAUTHORIZED)?;
+
+    let base_string = format!("v0:{timestamp}:{body}");
+    let mut mac = HmacSha256::new_from_slice(signing_secret.as_bytes())
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    mac.update(base_string.as_bytes());
+    let result = mac.finalize().into_bytes();
+    let hex = result.iter().fold(String::with_capacity(64), |mut s, b| {
+        use std::fmt::Write;
+        let _ = write!(s, "{b:02x}");
+        s
+    });
+    let expected = format!("v0={hex}");
+
+    if expected.as_bytes().ct_eq(provided_sig.as_bytes()).into() {
+        Ok(())
+    } else {
+        Err(StatusCode::UNAUTHORIZED)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+    use hmac::Mac;
+
+    fn current_timestamp() -> String {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            .to_string()
+    }
+
+    fn compute_signature(secret: &str, timestamp: &str, body: &str) -> String {
+        let base_string = format!("v0:{timestamp}:{body}");
+        let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).unwrap();
+        mac.update(base_string.as_bytes());
+        let result = mac.finalize().into_bytes();
+        let hex = result.iter().fold(String::with_capacity(64), |mut s, b| {
+            use std::fmt::Write;
+            let _ = write!(s, "{b:02x}");
+            s
+        });
+        format!("v0={hex}")
+    }
+
+    #[test]
+    fn verify_signature_valid() {
+        let secret = "test-secret";
+        let timestamp = current_timestamp();
+        let body = r#"{"type":"url_verification"}"#;
+        let sig = compute_signature(secret, &timestamp, body);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "X-Slack-Request-Timestamp",
+            HeaderValue::from_str(&timestamp).unwrap(),
+        );
+        headers.insert("X-Slack-Signature", HeaderValue::from_str(&sig).unwrap());
+
+        assert!(verify_signature(secret, &headers, body).is_ok());
+    }
+
+    #[test]
+    fn verify_signature_invalid() {
+        let timestamp = current_timestamp();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "X-Slack-Request-Timestamp",
+            HeaderValue::from_str(&timestamp).unwrap(),
+        );
+        headers.insert("X-Slack-Signature", HeaderValue::from_static("v0=deadbeef"));
+
+        let result = verify_signature("secret", &headers, "body");
+        assert_eq!(result.unwrap_err(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn verify_signature_missing_timestamp() {
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Slack-Signature", HeaderValue::from_static("v0=abc"));
+
+        let result = verify_signature("secret", &headers, "body");
+        assert_eq!(result.unwrap_err(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn verify_signature_missing_signature() {
+        let timestamp = current_timestamp();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "X-Slack-Request-Timestamp",
+            HeaderValue::from_str(&timestamp).unwrap(),
+        );
+
+        let result = verify_signature("secret", &headers, "body");
+        assert_eq!(result.unwrap_err(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn verify_signature_rejects_stale_timestamp() {
+        let secret = "test-secret";
+        let stale_ts = "1234567890";
+        let body = "test";
+        let sig = compute_signature(secret, stale_ts, body);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "X-Slack-Request-Timestamp",
+            HeaderValue::from_static(stale_ts),
+        );
+        headers.insert("X-Slack-Signature", HeaderValue::from_str(&sig).unwrap());
+
+        let result = verify_signature(secret, &headers, body);
+        assert_eq!(result.unwrap_err(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn handle_event_url_verification() {
+        let (tx, _rx) = mpsc::channel(16);
+        let state = EventState {
+            signing_secret: "secret".into(),
+            tx,
+            bot_user_id: String::new(),
+            allowed_user_ids: vec![],
+            allowed_channel_ids: vec![],
+        };
+
+        let body = r#"{"type":"url_verification","challenge":"test-challenge"}"#;
+        let timestamp = current_timestamp();
+        let sig = compute_signature("secret", &timestamp, body);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "X-Slack-Request-Timestamp",
+            HeaderValue::from_str(&timestamp).unwrap(),
+        );
+        headers.insert("X-Slack-Signature", HeaderValue::from_str(&sig).unwrap());
+
+        let result = handle_event(State(state), headers, body.to_owned()).await;
+        assert_eq!(result.unwrap(), "test-challenge");
+    }
+
+    #[tokio::test]
+    async fn handle_event_message_dispatched() {
+        let (tx, mut rx) = mpsc::channel(16);
+        let state = EventState {
+            signing_secret: "secret".into(),
+            tx,
+            bot_user_id: String::new(),
+            allowed_user_ids: vec![],
+            allowed_channel_ids: vec![],
+        };
+
+        let body = r#"{"type":"event_callback","event":{"type":"message","user":"U123","channel":"C456","text":"hi"}}"#;
+        let timestamp = current_timestamp();
+        let sig = compute_signature("secret", &timestamp, body);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "X-Slack-Request-Timestamp",
+            HeaderValue::from_str(&timestamp).unwrap(),
+        );
+        headers.insert("X-Slack-Signature", HeaderValue::from_str(&sig).unwrap());
+
+        let result = handle_event(State(state), headers, body.to_owned()).await;
+        assert!(result.is_ok());
+
+        let msg = rx.try_recv().unwrap();
+        assert_eq!(msg.user_id, "U123");
+        assert_eq!(msg.channel_id, "C456");
+        assert_eq!(msg.text, "hi");
+    }
+
+    #[tokio::test]
+    async fn handle_event_filters_bot_messages() {
+        let (tx, mut rx) = mpsc::channel(16);
+        let state = EventState {
+            signing_secret: "secret".into(),
+            tx,
+            bot_user_id: "BOT".into(),
+            allowed_user_ids: vec![],
+            allowed_channel_ids: vec![],
+        };
+
+        let body = r#"{"type":"event_callback","event":{"type":"message","user":"BOT","channel":"C1","text":"bot msg"}}"#;
+        let timestamp = current_timestamp();
+        let sig = compute_signature("secret", &timestamp, body);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "X-Slack-Request-Timestamp",
+            HeaderValue::from_str(&timestamp).unwrap(),
+        );
+        headers.insert("X-Slack-Signature", HeaderValue::from_str(&sig).unwrap());
+
+        let _ = handle_event(State(state), headers, body.to_owned()).await;
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn handle_event_filters_by_allowed_user() {
+        let (tx, mut rx) = mpsc::channel(16);
+        let state = EventState {
+            signing_secret: "secret".into(),
+            tx,
+            bot_user_id: String::new(),
+            allowed_user_ids: vec!["U_ALLOWED".into()],
+            allowed_channel_ids: vec![],
+        };
+
+        let body = r#"{"type":"event_callback","event":{"type":"message","user":"U_OTHER","channel":"C1","text":"hi"}}"#;
+        let timestamp = current_timestamp();
+        let sig = compute_signature("secret", &timestamp, body);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "X-Slack-Request-Timestamp",
+            HeaderValue::from_str(&timestamp).unwrap(),
+        );
+        headers.insert("X-Slack-Signature", HeaderValue::from_str(&sig).unwrap());
+
+        let _ = handle_event(State(state), headers, body.to_owned()).await;
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn handle_event_filters_by_allowed_channel() {
+        let (tx, mut rx) = mpsc::channel(16);
+        let state = EventState {
+            signing_secret: "secret".into(),
+            tx,
+            bot_user_id: String::new(),
+            allowed_user_ids: vec![],
+            allowed_channel_ids: vec!["C_ALLOWED".into()],
+        };
+
+        let body = r#"{"type":"event_callback","event":{"type":"message","user":"U1","channel":"C_OTHER","text":"hi"}}"#;
+        let timestamp = current_timestamp();
+        let sig = compute_signature("secret", &timestamp, body);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "X-Slack-Request-Timestamp",
+            HeaderValue::from_str(&timestamp).unwrap(),
+        );
+        headers.insert("X-Slack-Signature", HeaderValue::from_str(&sig).unwrap());
+
+        let _ = handle_event(State(state), headers, body.to_owned()).await;
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn handle_event_skips_message_with_subtype() {
+        let (tx, mut rx) = mpsc::channel(16);
+        let state = EventState {
+            signing_secret: "secret".into(),
+            tx,
+            bot_user_id: String::new(),
+            allowed_user_ids: vec![],
+            allowed_channel_ids: vec![],
+        };
+
+        let body = r#"{"type":"event_callback","event":{"type":"message","subtype":"message_changed","user":"U1","channel":"C1","text":"hi"}}"#;
+        let timestamp = current_timestamp();
+        let sig = compute_signature("secret", &timestamp, body);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "X-Slack-Request-Timestamp",
+            HeaderValue::from_str(&timestamp).unwrap(),
+        );
+        headers.insert("X-Slack-Signature", HeaderValue::from_str(&sig).unwrap());
+
+        let _ = handle_event(State(state), headers, body.to_owned()).await;
+        assert!(rx.try_recv().is_err());
+    }
+}

--- a/crates/zeph-channels/src/slack/mod.rs
+++ b/crates/zeph-channels/src/slack/mod.rs
@@ -1,0 +1,278 @@
+//! Slack channel adapter using Events API + Web API.
+
+pub mod api;
+pub mod events;
+
+use std::time::{Duration, Instant};
+
+use tokio::sync::mpsc;
+use zeph_core::channel::{Channel, ChannelError, ChannelMessage};
+
+use self::events::IncomingMessage;
+
+const EDIT_THROTTLE: Duration = Duration::from_secs(2);
+
+/// Slack channel adapter implementing edit-in-place streaming.
+pub struct SlackChannel {
+    rx: mpsc::Receiver<IncomingMessage>,
+    api: api::SlackApi,
+    channel_id: Option<String>,
+    accumulated: String,
+    last_edit: Option<Instant>,
+    message_ts: Option<String>,
+}
+
+impl std::fmt::Debug for SlackChannel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SlackChannel")
+            .field("channel_id", &self.channel_id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SlackChannel {
+    /// Create a new Slack channel and spawn the events webhook server.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the auth.test API call fails.
+    pub async fn new(
+        bot_token: String,
+        signing_secret: String,
+        host: String,
+        port: u16,
+        allowed_user_ids: Vec<String>,
+        allowed_channel_ids: Vec<String>,
+    ) -> Result<Self, zeph_core::channel::ChannelError> {
+        let api = api::SlackApi::new(bot_token);
+        let bot_user_id = match api.auth_test().await {
+            Ok(id) => {
+                tracing::info!(bot_user_id = %id, "slack auth.test succeeded");
+                id
+            }
+            Err(e) => {
+                tracing::warn!("slack auth.test failed: {e}, self-message filtering disabled");
+                String::new()
+            }
+        };
+        let rx = events::spawn_event_server(
+            host,
+            port,
+            signing_secret,
+            bot_user_id,
+            allowed_user_ids,
+            allowed_channel_ids,
+        );
+        Ok(Self {
+            rx,
+            api,
+            channel_id: None,
+            accumulated: String::new(),
+            last_edit: None,
+            message_ts: None,
+        })
+    }
+
+    fn should_send_update(&self) -> bool {
+        self.last_edit
+            .is_none_or(|last| last.elapsed() > EDIT_THROTTLE)
+    }
+
+    async fn send_or_edit(&mut self) -> Result<(), ChannelError> {
+        let channel_id = self
+            .channel_id
+            .as_deref()
+            .ok_or_else(|| ChannelError::Other("no active channel".into()))?;
+
+        let text = if self.accumulated.is_empty() {
+            "..."
+        } else {
+            &self.accumulated
+        };
+
+        match &self.message_ts {
+            None => {
+                let ts = self
+                    .api
+                    .post_message(channel_id, text)
+                    .await
+                    .map_err(|e| ChannelError::Other(e.to_string()))?;
+                self.message_ts = Some(ts);
+            }
+            Some(ts) => {
+                if let Err(e) = self.api.update_message(channel_id, ts, text).await {
+                    tracing::warn!("slack update failed: {e}, sending new message");
+                    self.message_ts = None;
+                    let ts = self
+                        .api
+                        .post_message(channel_id, text)
+                        .await
+                        .map_err(|e| ChannelError::Other(e.to_string()))?;
+                    self.message_ts = Some(ts);
+                }
+            }
+        }
+
+        self.last_edit = Some(Instant::now());
+        Ok(())
+    }
+}
+
+impl Channel for SlackChannel {
+    fn try_recv(&mut self) -> Option<ChannelMessage> {
+        let incoming = self.rx.try_recv().ok()?;
+        self.channel_id = Some(incoming.channel_id);
+        Some(ChannelMessage {
+            text: incoming.text,
+        })
+    }
+
+    async fn recv(&mut self) -> Result<Option<ChannelMessage>, ChannelError> {
+        let Some(incoming) = self.rx.recv().await else {
+            return Ok(None);
+        };
+
+        self.channel_id = Some(incoming.channel_id);
+        self.accumulated.clear();
+        self.last_edit = None;
+        self.message_ts = None;
+
+        Ok(Some(ChannelMessage {
+            text: incoming.text,
+        }))
+    }
+
+    async fn send(&mut self, text: &str) -> Result<(), ChannelError> {
+        let channel_id = self
+            .channel_id
+            .as_deref()
+            .ok_or_else(|| ChannelError::Other("no active channel".into()))?;
+
+        self.api
+            .post_message(channel_id, text)
+            .await
+            .map_err(|e| ChannelError::Other(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn send_chunk(&mut self, chunk: &str) -> Result<(), ChannelError> {
+        self.accumulated.push_str(chunk);
+        if self.should_send_update() {
+            self.send_or_edit().await?;
+        }
+        Ok(())
+    }
+
+    async fn flush_chunks(&mut self) -> Result<(), ChannelError> {
+        if self.message_ts.is_some() {
+            self.send_or_edit().await?;
+        }
+        self.accumulated.clear();
+        self.last_edit = None;
+        self.message_ts = None;
+        Ok(())
+    }
+
+    async fn confirm(&mut self, prompt: &str) -> Result<bool, ChannelError> {
+        self.send(&format!("{prompt}\nReply 'yes' to confirm."))
+            .await?;
+        let Some(incoming) = self.rx.recv().await else {
+            return Ok(false);
+        };
+        Ok(incoming.text.trim().eq_ignore_ascii_case("yes"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn make_channel() -> SlackChannel {
+        let (_tx, rx) = mpsc::channel(16);
+        let api = api::SlackApi::new("xoxb-test".into());
+        SlackChannel {
+            rx,
+            api,
+            channel_id: None,
+            accumulated: String::new(),
+            last_edit: None,
+            message_ts: None,
+        }
+    }
+
+    #[test]
+    fn should_send_update_true_when_no_last_edit() {
+        let ch = make_channel();
+        assert!(ch.should_send_update());
+    }
+
+    #[test]
+    fn should_send_update_false_within_throttle() {
+        let mut ch = make_channel();
+        ch.last_edit = Some(Instant::now());
+        assert!(!ch.should_send_update());
+    }
+
+    #[test]
+    fn should_send_update_true_after_throttle() {
+        let mut ch = make_channel();
+        ch.last_edit = Some(Instant::now() - Duration::from_secs(3));
+        assert!(ch.should_send_update());
+    }
+
+    #[tokio::test]
+    async fn flush_chunks_clears_state() {
+        let mut ch = make_channel();
+        ch.accumulated = "test".into();
+        ch.last_edit = Some(Instant::now());
+        // message_ts is None, so send_or_edit won't be called
+        ch.flush_chunks().await.unwrap();
+        assert!(ch.accumulated.is_empty());
+        assert!(ch.last_edit.is_none());
+        assert!(ch.message_ts.is_none());
+    }
+
+    #[test]
+    fn try_recv_sets_channel_id() {
+        let (tx, rx) = mpsc::channel(16);
+        let api = api::SlackApi::new("xoxb-test".into());
+        let mut ch = SlackChannel {
+            rx,
+            api,
+            channel_id: None,
+            accumulated: String::new(),
+            last_edit: None,
+            message_ts: None,
+        };
+        tx.try_send(IncomingMessage {
+            channel_id: "C123".into(),
+            text: "hello".into(),
+            user_id: "U1".into(),
+        })
+        .unwrap();
+        let msg = ch.try_recv().unwrap();
+        assert_eq!(msg.text, "hello");
+        assert_eq!(ch.channel_id.as_deref(), Some("C123"));
+    }
+
+    #[test]
+    fn debug_impl() {
+        let ch = make_channel();
+        let debug = format!("{ch:?}");
+        assert!(debug.contains("SlackChannel"));
+    }
+
+    #[test]
+    fn edit_throttle_constant() {
+        assert_eq!(EDIT_THROTTLE, Duration::from_secs(2));
+    }
+
+    #[test]
+    fn accumulate_chunks() {
+        let mut ch = make_channel();
+        ch.accumulated.push_str("part1");
+        ch.accumulated.push_str(" part2");
+        assert_eq!(ch.accumulated, "part1 part2");
+    }
+}

--- a/crates/zeph-core/src/config/mod.rs
+++ b/crates/zeph-core/src/config/mod.rs
@@ -70,6 +70,37 @@ impl Config {
         if let Some(val) = vault.get_secret("ZEPH_GATEWAY_TOKEN").await? {
             self.gateway.auth_token = Some(val);
         }
+        if let Some(val) = vault.get_secret("ZEPH_DISCORD_TOKEN").await? {
+            let dc = self.discord.get_or_insert(DiscordConfig {
+                token: None,
+                application_id: None,
+                allowed_user_ids: Vec::new(),
+                allowed_role_ids: Vec::new(),
+                allowed_channel_ids: Vec::new(),
+            });
+            dc.token = Some(val);
+        }
+        if let Some(val) = vault.get_secret("ZEPH_DISCORD_APP_ID").await?
+            && let Some(dc) = self.discord.as_mut()
+        {
+            dc.application_id = Some(val);
+        }
+        if let Some(val) = vault.get_secret("ZEPH_SLACK_BOT_TOKEN").await? {
+            let sl = self.slack.get_or_insert(SlackConfig {
+                bot_token: None,
+                signing_secret: None,
+                webhook_host: "127.0.0.1".into(),
+                port: 3000,
+                allowed_user_ids: Vec::new(),
+                allowed_channel_ids: Vec::new(),
+            });
+            sl.bot_token = Some(val);
+        }
+        if let Some(val) = vault.get_secret("ZEPH_SLACK_SIGNING_SECRET").await?
+            && let Some(sl) = self.slack.as_mut()
+        {
+            sl.signing_secret = Some(val);
+        }
         Ok(())
     }
 }

--- a/crates/zeph-core/src/config/types.rs
+++ b/crates/zeph-core/src/config/types.rs
@@ -12,6 +12,8 @@ pub struct Config {
     pub skills: SkillsConfig,
     pub memory: MemoryConfig,
     pub telegram: Option<TelegramConfig>,
+    pub discord: Option<DiscordConfig>,
+    pub slack: Option<SlackConfig>,
     #[serde(default)]
     pub tools: ToolsConfig,
     #[serde(default)]
@@ -452,6 +454,68 @@ impl std::fmt::Debug for TelegramConfig {
     }
 }
 
+#[derive(Clone, Deserialize)]
+pub struct DiscordConfig {
+    pub token: Option<String>,
+    pub application_id: Option<String>,
+    #[serde(default)]
+    pub allowed_user_ids: Vec<String>,
+    #[serde(default)]
+    pub allowed_role_ids: Vec<String>,
+    #[serde(default)]
+    pub allowed_channel_ids: Vec<String>,
+}
+
+impl std::fmt::Debug for DiscordConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DiscordConfig")
+            .field("token", &self.token.as_ref().map(|_| "[REDACTED]"))
+            .field("application_id", &self.application_id)
+            .field("allowed_user_ids", &self.allowed_user_ids)
+            .field("allowed_role_ids", &self.allowed_role_ids)
+            .field("allowed_channel_ids", &self.allowed_channel_ids)
+            .finish()
+    }
+}
+
+fn default_slack_port() -> u16 {
+    3000
+}
+
+fn default_slack_webhook_host() -> String {
+    "127.0.0.1".into()
+}
+
+#[derive(Clone, Deserialize)]
+pub struct SlackConfig {
+    pub bot_token: Option<String>,
+    pub signing_secret: Option<String>,
+    #[serde(default = "default_slack_webhook_host")]
+    pub webhook_host: String,
+    #[serde(default = "default_slack_port")]
+    pub port: u16,
+    #[serde(default)]
+    pub allowed_user_ids: Vec<String>,
+    #[serde(default)]
+    pub allowed_channel_ids: Vec<String>,
+}
+
+impl std::fmt::Debug for SlackConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SlackConfig")
+            .field("bot_token", &self.bot_token.as_ref().map(|_| "[REDACTED]"))
+            .field(
+                "signing_secret",
+                &self.signing_secret.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field("webhook_host", &self.webhook_host)
+            .field("port", &self.port)
+            .field("allowed_user_ids", &self.allowed_user_ids)
+            .field("allowed_channel_ids", &self.allowed_channel_ids)
+            .finish()
+    }
+}
+
 #[derive(Deserialize)]
 pub struct A2aServerConfig {
     #[serde(default)]
@@ -791,6 +855,9 @@ pub struct ResolvedSecrets {
     pub claude_api_key: Option<Secret>,
     pub openai_api_key: Option<Secret>,
     pub compatible_api_keys: HashMap<String, Secret>,
+    pub discord_token: Option<Secret>,
+    pub slack_bot_token: Option<Secret>,
+    pub slack_signing_secret: Option<Secret>,
 }
 
 impl Config {
@@ -832,6 +899,8 @@ impl Config {
                 cross_session_score_threshold: default_cross_session_score_threshold(),
             },
             telegram: None,
+            discord: None,
+            slack: None,
             tools: ToolsConfig::default(),
             a2a: A2aServerConfig::default(),
             mcp: McpConfig::default(),


### PR DESCRIPTION
## Summary

- Add Discord channel adapter with Gateway v10 WebSocket, slash commands, edit-in-place streaming
- Add Slack channel adapter with Events API webhook, HMAC-SHA256 signature verification, streaming via chat.update
- Both adapters feature-gated (`discord`, `slack`) and opt-in, not in default features

## Details

**Discord (#382):** `DiscordChannel` connects to Discord Gateway v10 via tokio-tungstenite with automatic heartbeat and reconnect. Registers `/ask` and `/clear` slash commands on startup. Edit-in-place streaming with 1.5s throttle (5 edits/5s API limit). User/role/channel allowlists.

**Slack (#383):** `SlackChannel` runs an axum webhook server for Events API with HMAC-SHA256 signature verification and timestamp replay protection (rejects >5min). Calls `auth.test` on startup for bot self-message filtering. Streaming via `chat.update` with 2s throttle. Configurable webhook bind address. 256KB body size limit.

**Security:** Token redaction in Debug impls, constant-time HMAC comparison, TLS enforced on Discord gateway, replay protection on Slack webhooks.

## Test plan

- [x] 56 new unit tests for Discord/Slack adapters
- [x] `cargo clippy --workspace --features discord,slack -- -D warnings` clean
- [x] `cargo nextest run --workspace --lib --bins --features discord,slack` — 1483 tests pass
- [x] Default features build unaffected
- [ ] Manual: Discord bot with test guild
- [ ] Manual: Slack app with test workspace

Closes #382, closes #383
Part of #368