### PR TITLE
fix: resolve tui feature gate compilation errors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,9 +14,9 @@ use zeph_channels::telegram::TelegramChannel;
 use zeph_core::agent::Agent;
 #[cfg(feature = "mcp")]
 use zeph_core::bootstrap::create_mcp_registry;
-use zeph_core::bootstrap::{AppBuilder, warmup_provider};
 #[cfg(not(feature = "tui"))]
 use zeph_core::bootstrap::resolve_config_path;
+use zeph_core::bootstrap::{AppBuilder, warmup_provider};
 #[cfg(feature = "tui")]
 use zeph_core::channel::{Channel, ChannelError, ChannelMessage};
 use zeph_core::config::Config;
@@ -197,8 +197,7 @@ async fn main() -> anyhow::Result<()> {
                 .collect(),
         );
 
-        let mcp_manager =
-            std::sync::Arc::new(zeph_core::bootstrap::create_mcp_manager(config));
+        let mcp_manager = std::sync::Arc::new(zeph_core::bootstrap::create_mcp_manager(config));
         let mcp_tools = mcp_manager.connect_all().await;
         tracing::info!("discovered {} MCP tool(s)", mcp_tools.len());
 


### PR DESCRIPTION
## Summary

- Split `#[cfg(not(feature = "mcp"))]` tool executor block into two variants: `tui` and non-`tui`, so `shell_executor_for_tui` is properly defined and tool events are wired to TUI when building without `mcp`
- Narrow `AnyProvider` import cfg from `any(a2a, tui)` to `a2a` to match actual usage
- Gate `resolve_config_path` import with `#[cfg(not(feature = "tui"))]` to match call site

## Test plan

- [x] `cargo clippy --features tui -- -D warnings` passes
- [x] `cargo clippy -- -D warnings` passes (default features)
- [x] `cargo build --release --features tui` succeeds