### PR TITLE
refactor: remove 8 lightweight feature gates, make always-on (M26)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,19 +103,12 @@ license.workspace = true
 repository.workspace = true
 
 [features]
-default = ["compatible", "openai", "qdrant", "self-learning", "vault-age"]
-full = ["a2a", "compatible", "discord", "gateway", "index", "mcp", "openai", "orchestrator", "qdrant", "router", "self-learning", "slack", "tui", "vault-age"]
+default = []
+full = ["a2a", "discord", "gateway", "index", "slack", "tui"]
 a2a = ["dep:zeph-a2a", "zeph-a2a?/server"]
-compatible = ["zeph-llm/compatible", "zeph-core/compatible"]
-mcp = ["dep:zeph-mcp", "zeph-core/mcp"]
-qdrant = ["zeph-skills/qdrant", "zeph-mcp?/qdrant", "zeph-core/qdrant"]
 candle = ["zeph-llm/candle", "zeph-core/candle"]
 metal = ["zeph-llm/metal", "zeph-core/metal"]
 cuda = ["zeph-llm/cuda", "zeph-core/cuda"]
-openai = ["zeph-llm/openai", "zeph-core/openai"]
-orchestrator = ["zeph-llm/orchestrator", "zeph-core/orchestrator"]
-router = ["zeph-llm/router", "zeph-core/router"]
-self-learning = ["zeph-core/self-learning"]
 tui = ["dep:zeph-tui"]
 discord = ["zeph-channels/discord"]
 slack = ["zeph-channels/slack"]
@@ -123,7 +116,6 @@ index = ["dep:zeph-index", "zeph-core/index"]
 gateway = ["dep:zeph-gateway"]
 daemon = ["zeph-core/daemon"]
 scheduler = ["dep:zeph-scheduler"]
-vault-age = ["zeph-core/vault-age"]
 otel = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp", "dep:tracing-opentelemetry"]
 mock = ["zeph-llm/mock"]
 
@@ -139,7 +131,7 @@ tracing-opentelemetry = { workspace = true, optional = true }
 zeph-a2a = { workspace = true, optional = true }
 zeph-channels.workspace = true
 zeph-index = { workspace = true, optional = true }
-zeph-mcp = { workspace = true, optional = true }
+zeph-mcp.workspace = true
 zeph-core.workspace = true
 zeph-llm.workspace = true
 zeph-memory.workspace = true

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -9,21 +9,13 @@ repository.workspace = true
 [features]
 default = []
 candle = ["zeph-llm/candle"]
-compatible = ["zeph-llm/compatible"]
 cuda = ["zeph-llm/cuda"]
 daemon = []
 index = ["dep:zeph-index"]
-mcp = ["dep:zeph-mcp"]
 metal = ["zeph-llm/metal"]
-openai = ["zeph-llm/openai"]
-orchestrator = ["zeph-llm/orchestrator"]
-qdrant = ["zeph-skills/qdrant", "zeph-mcp?/qdrant"]
-router = ["zeph-llm/router"]
-self-learning = ["zeph-skills/self-learning"]
-vault-age = ["dep:age"]
 
 [dependencies]
-age = { workspace = true, optional = true }
+age.workspace = true
 anyhow.workspace = true
 notify.workspace = true
 notify-debouncer-mini.workspace = true
@@ -36,9 +28,9 @@ toml.workspace = true
 tracing.workspace = true
 zeph-index = { workspace = true, optional = true }
 zeph-llm.workspace = true
-zeph-mcp = { workspace = true, optional = true, features = ["qdrant"] }
+zeph-mcp.workspace = true
 zeph-memory.workspace = true
-zeph-skills = { workspace = true, features = ["qdrant"] }
+zeph-skills.workspace = true
 zeph-tools.workspace = true
 
 [[bench]]

--- a/crates/zeph-core/src/agent/context.rs
+++ b/crates/zeph-core/src/agent/context.rs
@@ -734,7 +734,6 @@ impl<C: Channel, T: ToolExecutor> Agent<C, T> {
         system_prompt.push_str("\n<!-- cache:stable -->");
         system_prompt.push_str("\n<!-- cache:volatile -->");
 
-        #[cfg(feature = "mcp")]
         self.append_mcp_prompt(query, &mut system_prompt).await;
 
         let cwd = std::env::current_dir().unwrap_or_default();

--- a/crates/zeph-core/src/agent/streaming.rs
+++ b/crates/zeph-core/src/agent/streaming.rs
@@ -58,7 +58,6 @@ impl<C: Channel, T: ToolExecutor> Agent<C, T> {
                 tracing::warn!("received empty response from LLM, skipping");
                 self.record_skill_outcomes("empty_response", None).await;
 
-                #[cfg(feature = "self-learning")]
                 if !self.reflection_used
                     && self
                         .attempt_self_reflection("LLM returned empty response", "")
@@ -269,7 +268,6 @@ impl<C: Channel, T: ToolExecutor> Agent<C, T> {
                     self.record_skill_outcomes("tool_failure", Some(&output.summary))
                         .await;
 
-                    #[cfg(feature = "self-learning")]
                     if !self.reflection_used
                         && self
                             .attempt_self_reflection(&output.summary, &output.summary)
@@ -344,7 +342,6 @@ impl<C: Channel, T: ToolExecutor> Agent<C, T> {
                 self.record_skill_outcomes("tool_failure", Some(&err_str))
                     .await;
 
-                #[cfg(feature = "self-learning")]
                 if !self.reflection_used && self.attempt_self_reflection(&err_str, "").await? {
                     return Ok(false);
                 }

--- a/crates/zeph-core/src/vault.rs
+++ b/crates/zeph-core/src/vault.rs
@@ -2,11 +2,10 @@ use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 
-#[cfg(feature = "vault-age")]
 use std::collections::HashMap;
-#[cfg(feature = "vault-age")]
+
 use std::io::Read as _;
-#[cfg(feature = "vault-age")]
+
 use std::path::Path;
 
 use serde::Deserialize;
@@ -60,7 +59,6 @@ impl VaultProvider for EnvVaultProvider {
     }
 }
 
-#[cfg(feature = "vault-age")]
 #[derive(Debug, thiserror::Error)]
 pub enum AgeVaultError {
     #[error("failed to read key file: {0}")]
@@ -77,12 +75,10 @@ pub enum AgeVaultError {
     Json(serde_json::Error),
 }
 
-#[cfg(feature = "vault-age")]
 pub struct AgeVaultProvider {
     secrets: HashMap<String, String>,
 }
 
-#[cfg(feature = "vault-age")]
 impl fmt::Debug for AgeVaultProvider {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("AgeVaultProvider")
@@ -91,7 +87,6 @@ impl fmt::Debug for AgeVaultProvider {
     }
 }
 
-#[cfg(feature = "vault-age")]
 impl AgeVaultProvider {
     /// Decrypt an age-encrypted JSON secrets file.
     ///
@@ -126,7 +121,6 @@ impl AgeVaultProvider {
     }
 }
 
-#[cfg(feature = "vault-age")]
 impl VaultProvider for AgeVaultProvider {
     fn get_secret(
         &self,
@@ -247,7 +241,7 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature = "vault-age"))]
+#[cfg(test)]
 mod age_tests {
     use std::io::Write as _;
 

--- a/crates/zeph-llm/Cargo.toml
+++ b/crates/zeph-llm/Cargo.toml
@@ -10,12 +10,8 @@ repository.workspace = true
 default = []
 mock = []
 candle = ["dep:candle-core", "dep:candle-nn", "dep:candle-transformers", "dep:hf-hub", "dep:tokenizers"]
-compatible = ["openai"]
 cuda = ["candle", "candle-core/cuda", "candle-nn/cuda", "candle-transformers/cuda"]
 metal = ["candle", "candle-core/metal", "candle-nn/metal", "candle-transformers/metal"]
-openai = []
-orchestrator = []
-router = []
 
 [dependencies]
 thiserror.workspace = true

--- a/crates/zeph-llm/src/any.rs
+++ b/crates/zeph-llm/src/any.rs
@@ -1,17 +1,13 @@
 #[cfg(feature = "candle")]
 use crate::candle_provider::CandleProvider;
 use crate::claude::ClaudeProvider;
-#[cfg(feature = "compatible")]
 use crate::compatible::CompatibleProvider;
 #[cfg(feature = "mock")]
 use crate::mock::MockProvider;
 use crate::ollama::OllamaProvider;
-#[cfg(feature = "openai")]
 use crate::openai::OpenAiProvider;
-#[cfg(feature = "orchestrator")]
 use crate::orchestrator::ModelOrchestrator;
 use crate::provider::{ChatResponse, ChatStream, LlmProvider, Message, StatusTx, ToolDefinition};
-#[cfg(feature = "router")]
 use crate::router::RouterProvider;
 
 /// Generates a match over all `AnyProvider` variants, binding the inner provider
@@ -21,15 +17,11 @@ macro_rules! delegate_provider {
         match $self {
             AnyProvider::Ollama($p) => $expr,
             AnyProvider::Claude($p) => $expr,
-            #[cfg(feature = "openai")]
             AnyProvider::OpenAi($p) => $expr,
             #[cfg(feature = "candle")]
             AnyProvider::Candle($p) => $expr,
-            #[cfg(feature = "compatible")]
             AnyProvider::Compatible($p) => $expr,
-            #[cfg(feature = "orchestrator")]
             AnyProvider::Orchestrator($p) => $expr,
-            #[cfg(feature = "router")]
             AnyProvider::Router($p) => $expr,
             #[cfg(feature = "mock")]
             AnyProvider::Mock($p) => $expr,
@@ -41,15 +33,11 @@ macro_rules! delegate_provider {
 pub enum AnyProvider {
     Ollama(OllamaProvider),
     Claude(ClaudeProvider),
-    #[cfg(feature = "openai")]
     OpenAi(OpenAiProvider),
     #[cfg(feature = "candle")]
     Candle(CandleProvider),
-    #[cfg(feature = "compatible")]
     Compatible(CompatibleProvider),
-    #[cfg(feature = "orchestrator")]
     Orchestrator(Box<ModelOrchestrator>),
-    #[cfg(feature = "router")]
     Router(Box<RouterProvider>),
     #[cfg(feature = "mock")]
     Mock(MockProvider),
@@ -72,19 +60,15 @@ impl AnyProvider {
             Self::Claude(p) => {
                 p.status_tx = Some(tx);
             }
-            #[cfg(feature = "openai")]
             Self::OpenAi(p) => {
                 p.status_tx = Some(tx);
             }
-            #[cfg(feature = "compatible")]
             Self::Compatible(p) => {
                 p.set_status_tx(tx);
             }
-            #[cfg(feature = "orchestrator")]
             Self::Orchestrator(p) => {
                 p.set_status_tx(tx);
             }
-            #[cfg(feature = "router")]
             Self::Router(p) => {
                 p.set_status_tx(tx);
             }
@@ -370,7 +354,6 @@ mod tests {
         assert!(format!("{claude:?}").contains("Claude"));
     }
 
-    #[cfg(feature = "openai")]
     #[test]
     fn any_openai_name() {
         let provider = AnyProvider::OpenAi(crate::openai::OpenAiProvider::new(
@@ -384,7 +367,6 @@ mod tests {
         assert_eq!(provider.name(), "openai");
     }
 
-    #[cfg(feature = "openai")]
     #[test]
     fn any_openai_supports_streaming() {
         let provider = AnyProvider::OpenAi(crate::openai::OpenAiProvider::new(
@@ -398,7 +380,6 @@ mod tests {
         assert!(provider.supports_streaming());
     }
 
-    #[cfg(feature = "openai")]
     #[test]
     fn any_openai_supports_embeddings() {
         let with_embed = AnyProvider::OpenAi(crate::openai::OpenAiProvider::new(
@@ -422,7 +403,6 @@ mod tests {
         assert!(!without_embed.supports_embeddings());
     }
 
-    #[cfg(feature = "openai")]
     #[test]
     fn any_openai_debug() {
         let provider = AnyProvider::OpenAi(crate::openai::OpenAiProvider::new(

--- a/crates/zeph-llm/src/lib.rs
+++ b/crates/zeph-llm/src/lib.rs
@@ -4,18 +4,14 @@ pub mod any;
 #[cfg(feature = "candle")]
 pub mod candle_provider;
 pub mod claude;
-#[cfg(feature = "compatible")]
 pub mod compatible;
 pub mod error;
 #[cfg(feature = "mock")]
 pub mod mock;
 pub mod ollama;
-#[cfg(feature = "openai")]
 pub mod openai;
-#[cfg(feature = "orchestrator")]
 pub mod orchestrator;
 pub mod provider;
-#[cfg(feature = "router")]
 pub mod router;
 
 pub use error::LlmError;

--- a/crates/zeph-llm/src/orchestrator/router.rs
+++ b/crates/zeph-llm/src/orchestrator/router.rs
@@ -4,7 +4,6 @@ use crate::error::LlmError;
 use crate::candle_provider::CandleProvider;
 use crate::claude::ClaudeProvider;
 use crate::ollama::OllamaProvider;
-#[cfg(feature = "openai")]
 use crate::openai::OpenAiProvider;
 use crate::provider::{ChatResponse, ChatStream, LlmProvider, Message, StatusTx, ToolDefinition};
 
@@ -13,7 +12,6 @@ use crate::provider::{ChatResponse, ChatStream, LlmProvider, Message, StatusTx, 
 pub enum SubProvider {
     Ollama(OllamaProvider),
     Claude(ClaudeProvider),
-    #[cfg(feature = "openai")]
     OpenAi(OpenAiProvider),
     #[cfg(feature = "candle")]
     Candle(CandleProvider),
@@ -25,7 +23,6 @@ impl SubProvider {
             Self::Claude(p) => {
                 p.status_tx = Some(tx);
             }
-            #[cfg(feature = "openai")]
             Self::OpenAi(p) => {
                 p.status_tx = Some(tx);
             }
@@ -41,7 +38,6 @@ impl LlmProvider for SubProvider {
         match self {
             Self::Ollama(p) => p.chat(messages).await,
             Self::Claude(p) => p.chat(messages).await,
-            #[cfg(feature = "openai")]
             Self::OpenAi(p) => p.chat(messages).await,
             #[cfg(feature = "candle")]
             Self::Candle(p) => p.chat(messages).await,
@@ -52,7 +48,6 @@ impl LlmProvider for SubProvider {
         match self {
             Self::Ollama(p) => p.chat_stream(messages).await,
             Self::Claude(p) => p.chat_stream(messages).await,
-            #[cfg(feature = "openai")]
             Self::OpenAi(p) => p.chat_stream(messages).await,
             #[cfg(feature = "candle")]
             Self::Candle(p) => p.chat_stream(messages).await,
@@ -63,7 +58,6 @@ impl LlmProvider for SubProvider {
         match self {
             Self::Ollama(p) => p.supports_streaming(),
             Self::Claude(p) => p.supports_streaming(),
-            #[cfg(feature = "openai")]
             Self::OpenAi(p) => p.supports_streaming(),
             #[cfg(feature = "candle")]
             Self::Candle(p) => p.supports_streaming(),
@@ -74,7 +68,6 @@ impl LlmProvider for SubProvider {
         match self {
             Self::Ollama(p) => p.embed(text).await,
             Self::Claude(p) => p.embed(text).await,
-            #[cfg(feature = "openai")]
             Self::OpenAi(p) => p.embed(text).await,
             #[cfg(feature = "candle")]
             Self::Candle(p) => p.embed(text).await,
@@ -85,7 +78,6 @@ impl LlmProvider for SubProvider {
         match self {
             Self::Ollama(p) => p.supports_embeddings(),
             Self::Claude(p) => p.supports_embeddings(),
-            #[cfg(feature = "openai")]
             Self::OpenAi(p) => p.supports_embeddings(),
             #[cfg(feature = "candle")]
             Self::Candle(p) => p.supports_embeddings(),
@@ -96,7 +88,6 @@ impl LlmProvider for SubProvider {
         match self {
             Self::Ollama(p) => p.supports_tool_use(),
             Self::Claude(p) => p.supports_tool_use(),
-            #[cfg(feature = "openai")]
             Self::OpenAi(p) => p.supports_tool_use(),
             #[cfg(feature = "candle")]
             Self::Candle(p) => p.supports_tool_use(),
@@ -111,7 +102,6 @@ impl LlmProvider for SubProvider {
         match self {
             Self::Ollama(p) => p.chat_with_tools(messages, tools).await,
             Self::Claude(p) => p.chat_with_tools(messages, tools).await,
-            #[cfg(feature = "openai")]
             Self::OpenAi(p) => p.chat_with_tools(messages, tools).await,
             #[cfg(feature = "candle")]
             Self::Candle(p) => p.chat_with_tools(messages, tools).await,
@@ -122,7 +112,6 @@ impl LlmProvider for SubProvider {
         match self {
             Self::Ollama(p) => p.last_cache_usage(),
             Self::Claude(p) => p.last_cache_usage(),
-            #[cfg(feature = "openai")]
             Self::OpenAi(p) => p.last_cache_usage(),
             #[cfg(feature = "candle")]
             Self::Candle(p) => p.last_cache_usage(),
@@ -133,7 +122,6 @@ impl LlmProvider for SubProvider {
         match self {
             Self::Ollama(p) => p.name(),
             Self::Claude(p) => p.name(),
-            #[cfg(feature = "openai")]
             Self::OpenAi(p) => p.name(),
             #[cfg(feature = "candle")]
             Self::Candle(p) => p.name(),

--- a/crates/zeph-mcp/Cargo.toml
+++ b/crates/zeph-mcp/Cargo.toml
@@ -8,11 +8,10 @@ repository.workspace = true
 
 [features]
 default = []
-qdrant = ["dep:blake3", "dep:qdrant-client", "dep:uuid", "dep:zeph-memory"]
 
 [dependencies]
-blake3 = { workspace = true, optional = true }
-qdrant-client = { workspace = true, optional = true, features = ["serde"] }
+blake3.workspace = true
+qdrant-client = { workspace = true, features = ["serde"] }
 rmcp = { workspace = true, features = ["client", "transport-child-process", "transport-streamable-http-client-reqwest"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
@@ -20,9 +19,9 @@ thiserror.workspace = true
 tokio = { workspace = true, features = ["process", "sync", "time", "rt"] }
 tracing.workspace = true
 url.workspace = true
-uuid = { workspace = true, optional = true, features = ["v5"] }
+uuid = { workspace = true, features = ["v5"] }
 zeph-llm.workspace = true
-zeph-memory = { workspace = true, optional = true }
+zeph-memory.workspace = true
 zeph-tools.workspace = true
 
 [dev-dependencies]

--- a/crates/zeph-mcp/src/error.rs
+++ b/crates/zeph-mcp/src/error.rs
@@ -29,7 +29,6 @@ pub enum McpError {
         timeout_secs: u64,
     },
 
-    #[cfg(feature = "qdrant")]
     #[error("Qdrant error: {0}")]
     Qdrant(#[from] Box<qdrant_client::QdrantError>),
 

--- a/crates/zeph-mcp/src/lib.rs
+++ b/crates/zeph-mcp/src/lib.rs
@@ -5,7 +5,6 @@ pub mod error;
 pub mod executor;
 pub mod manager;
 pub mod prompt;
-#[cfg(feature = "qdrant")]
 pub mod registry;
 pub mod tool;
 
@@ -13,6 +12,5 @@ pub use error::McpError;
 pub use executor::McpToolExecutor;
 pub use manager::{McpManager, McpTransport, ServerEntry};
 pub use prompt::format_mcp_tools_prompt;
-#[cfg(feature = "qdrant")]
 pub use registry::McpToolRegistry;
 pub use tool::McpTool;

--- a/crates/zeph-skills/Cargo.toml
+++ b/crates/zeph-skills/Cargo.toml
@@ -8,23 +8,21 @@ repository.workspace = true
 
 [features]
 default = []
-qdrant = ["dep:qdrant-client", "dep:uuid", "dep:zeph-memory"]
-self-learning = []
 
 [dependencies]
 blake3.workspace = true
 notify.workspace = true
 notify-debouncer-mini.workspace = true
-qdrant-client = { workspace = true, optional = true, features = ["serde"] }
+qdrant-client = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 futures.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["sync", "rt", "time"] }
 tracing.workspace = true
-uuid = { workspace = true, optional = true, features = ["v5"] }
+uuid = { workspace = true, features = ["v5"] }
 zeph-llm.workspace = true
-zeph-memory = { workspace = true, optional = true }
+zeph-memory.workspace = true
 
 [[bench]]
 name = "matcher"

--- a/crates/zeph-skills/src/error.rs
+++ b/crates/zeph-skills/src/error.rs
@@ -3,11 +3,9 @@ pub enum SkillError {
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 
-    #[cfg(feature = "qdrant")]
     #[error("Qdrant error: {0}")]
     Qdrant(#[from] Box<qdrant_client::QdrantError>),
 
-    #[cfg(feature = "qdrant")]
     #[error("JSON error: {0}")]
     Json(#[from] serde_json::Error),
 

--- a/crates/zeph-skills/src/lib.rs
+++ b/crates/zeph-skills/src/lib.rs
@@ -1,12 +1,10 @@
 //! SKILL.md loader, skill registry, and prompt formatter.
 
 pub mod error;
-#[cfg(feature = "self-learning")]
 pub mod evolution;
 pub mod loader;
 pub mod matcher;
 pub mod prompt;
-#[cfg(feature = "qdrant")]
 pub mod qdrant_matcher;
 pub mod registry;
 pub(crate) mod resource;

--- a/crates/zeph-skills/src/matcher.rs
+++ b/crates/zeph-skills/src/matcher.rs
@@ -92,7 +92,6 @@ impl SkillMatcher {
 #[derive(Debug)]
 pub enum SkillMatcherBackend {
     InMemory(SkillMatcher),
-    #[cfg(feature = "qdrant")]
     Qdrant(crate::qdrant_matcher::QdrantSkillMatcher),
 }
 
@@ -101,7 +100,6 @@ impl SkillMatcherBackend {
     pub fn is_qdrant(&self) -> bool {
         match self {
             Self::InMemory(_) => false,
-            #[cfg(feature = "qdrant")]
             Self::Qdrant(_) => true,
         }
     }
@@ -118,7 +116,6 @@ impl SkillMatcherBackend {
     {
         match self {
             Self::InMemory(m) => m.match_skills(meta.len(), query, limit, embed_fn).await,
-            #[cfg(feature = "qdrant")]
             Self::Qdrant(m) => m.match_skills(meta, query, limit, embed_fn).await,
         }
     }
@@ -143,7 +140,6 @@ impl SkillMatcherBackend {
                 let _ = (meta, embedding_model, &embed_fn);
                 Ok(())
             }
-            #[cfg(feature = "qdrant")]
             Self::Qdrant(m) => {
                 m.sync(meta, embedding_model, embed_fn).await?;
                 Ok(())

--- a/deny.toml
+++ b/deny.toml
@@ -5,7 +5,7 @@ targets = [
     "aarch64-apple-darwin",
 ]
 all-features = false
-features = ["candle", "orchestrator", "tui"]
+features = ["candle", "tui"]
 
 [advisories]
 db-path = "~/.cargo/advisory-db"

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1195,7 +1195,7 @@ async fn agent_skills_command_with_usage_stats() {
     assert!(skills_output.is_some());
 }
 
-// -- /skill command disabled (non-self-learning) --
+// -- /skill command --
 
 #[tokio::test]
 async fn agent_skill_command_disabled() {
@@ -1215,11 +1215,11 @@ async fn agent_skill_command_disabled() {
     agent.run().await.unwrap();
 
     let collected = outputs.lock().unwrap();
-    // In self-learning builds, this shows stats; in non-self-learning, it says "not enabled"
+    // Shows skill stats
     assert!(!collected.is_empty());
 }
 
-// -- /feedback command disabled (non-self-learning) --
+// -- /feedback command --
 
 #[tokio::test]
 async fn agent_feedback_disabled() {
@@ -2083,7 +2083,6 @@ async fn agent_no_tool_output_stops_loop() {
 
 // --- Self-learning agent tests ---
 
-#[cfg(feature = "self-learning")]
 mod self_learning {
     use std::collections::VecDeque;
     use std::sync::{Arc, Mutex};


### PR DESCRIPTION
## Summary

- Remove feature gates for `openai`, `compatible`, `orchestrator`, `router`, `self-learning`, `qdrant`, `vault-age`, `mcp` — make these always-on
- Collapse 3-way `tool_executor` construction in `main.rs` into a single block
- Remove duplicate `ToolExecutorBundleNoMcp` and `build_tool_executor` impl from `bootstrap.rs`
- Clean up ~90 `cfg` annotations across 5 crates (zeph-llm, zeph-skills, zeph-mcp, zeph-core, root)
- Update `deny.toml` to remove reference to deleted feature
- Remove dead `#[cfg(feature = "self-learning")]` from test module

22 files changed, 73 insertions(+), 346 deletions(-)

Default features reduced to `[]`. Remaining gated: `tui`, `candle`, `metal`, `cuda`, `discord`, `slack`, `a2a`, `index`, `gateway`, `daemon`, `scheduler`, `otel`, `mock`.

## Test plan

- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo clippy --workspace --features tui -- -D warnings`
- [x] `cargo nextest run --workspace --lib --bins` (1483 passed)
- [x] Security audit: no new attack surface (MCP is client-only, vault-age runtime-gated)
- [x] Performance: +3.1 MB binary (+12%), +11 crates, acceptable tradeoff

Closes #436