### PR TITLE
fix: periodic tick for TUI metrics refresh

### DIFF
--- a/crates/zeph-tui/src/lib.rs
+++ b/crates/zeph-tui/src/lib.rs
@@ -51,6 +51,9 @@ async fn tui_loop(
     event_rx: &mut mpsc::Receiver<AppEvent>,
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
 ) -> anyhow::Result<()> {
+    let mut tick = tokio::time::interval(std::time::Duration::from_millis(250));
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
     loop {
         app.poll_metrics();
         terminal.draw(|frame| app.draw(frame))?;
@@ -62,6 +65,7 @@ async fn tui_loop(
             Some(agent_event) = app.poll_agent_event() => {
                 app.handle_agent_event(agent_event);
             }
+            _ = tick.tick() => {}
         }
 
         if app.should_quit {


### PR DESCRIPTION
## Summary

- Add 250ms interval tick to `tui_loop` select! to ensure metrics polling and screen redraw regardless of user/agent event activity
- Fixes stale Context/Session/Resources display in TUI dashboard

## Root cause

The event loop blocked indefinitely in `tokio::select!` on UI and agent channels. Without incoming events, `poll_metrics()` and `terminal.draw()` never re-executed, leaving metrics frozen at their initial values.

## Test plan

- [ ] Run `cargo run -- --tui`, observe Resources panel updates during LLM calls
- [ ] Verify no CPU overhead from idle tick (250ms = ~4 Hz)

Closes #447