### PR TITLE
feat: compact/detailed tool output toggle in TUI chat

### DIFF
--- a/crates/zeph-tui/src/app.rs
+++ b/crates/zeph-tui/src/app.rs
@@ -56,6 +56,7 @@ pub struct App {
     metrics_rx: Option<watch::Receiver<MetricsSnapshot>>,
     active_panel: Panel,
     tool_expanded: bool,
+    compact_tools: bool,
     status_label: Option<String>,
     throbber_state: throbber_widgets_tui::ThrobberState,
     confirm_state: Option<ConfirmState>,
@@ -86,6 +87,7 @@ impl App {
             metrics_rx: None,
             active_panel: Panel::Chat,
             tool_expanded: false,
+            compact_tools: false,
             status_label: None,
             throbber_state: throbber_widgets_tui::ThrobberState::default(),
             confirm_state: None,
@@ -186,6 +188,11 @@ impl App {
     #[must_use]
     pub fn tool_expanded(&self) -> bool {
         self.tool_expanded
+    }
+
+    #[must_use]
+    pub fn compact_tools(&self) -> bool {
+        self.compact_tools
     }
 
     #[must_use]
@@ -465,6 +472,9 @@ impl App {
             }
             KeyCode::Char('e') => {
                 self.tool_expanded = !self.tool_expanded;
+            }
+            KeyCode::Char('c') => {
+                self.compact_tools = !self.compact_tools;
             }
             KeyCode::Tab => {
                 self.active_panel = match self.active_panel {

--- a/crates/zeph-tui/src/widgets/chat.rs
+++ b/crates/zeph-tui/src/widgets/chat.rs
@@ -268,30 +268,40 @@ fn render_tool_message(
 
     // Output lines (everything after the command)
     if content_lines.len() > 1 {
-        let output_lines = &content_lines[1..];
-
-        let mut wrapped: Vec<Line<'static>> = Vec::new();
-        for line in output_lines {
-            let spans = vec![
-                Span::styled(indent.clone(), Style::default()),
-                Span::styled((*line).to_string(), theme.code_block),
-            ];
-            wrapped.extend(wrap_spans(spans, wrap_width));
-        }
-
-        let total_visual = wrapped.len();
-        let show_all = app.tool_expanded() || total_visual <= TOOL_OUTPUT_COLLAPSED_LINES;
-
-        if show_all {
-            lines.extend(wrapped);
-        } else {
-            lines.extend(wrapped.into_iter().take(TOOL_OUTPUT_COLLAPSED_LINES));
-            let remaining = total_visual - TOOL_OUTPUT_COLLAPSED_LINES;
-            let hint = format!("{indent}... ({remaining} more lines, press 'e' to expand)");
+        if app.compact_tools() {
+            let line_count = content_lines.len() - 1;
+            let noun = if line_count == 1 { "line" } else { "lines" };
+            let summary = format!("{indent}-- {line_count} {noun}");
             lines.push(Line::from(Span::styled(
-                hint,
+                summary,
                 Style::default().add_modifier(Modifier::DIM),
             )));
+        } else {
+            let output_lines = &content_lines[1..];
+
+            let mut wrapped: Vec<Line<'static>> = Vec::new();
+            for line in output_lines {
+                let spans = vec![
+                    Span::styled(indent.clone(), Style::default()),
+                    Span::styled((*line).to_string(), theme.code_block),
+                ];
+                wrapped.extend(wrap_spans(spans, wrap_width));
+            }
+
+            let total_visual = wrapped.len();
+            let show_all = app.tool_expanded() || total_visual <= TOOL_OUTPUT_COLLAPSED_LINES;
+
+            if show_all {
+                lines.extend(wrapped);
+            } else {
+                lines.extend(wrapped.into_iter().take(TOOL_OUTPUT_COLLAPSED_LINES));
+                let remaining = total_visual - TOOL_OUTPUT_COLLAPSED_LINES;
+                let hint = format!("{indent}... ({remaining} more lines, press 'e' to expand)");
+                lines.push(Line::from(Span::styled(
+                    hint,
+                    Style::default().add_modifier(Modifier::DIM),
+                )));
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add `compact_tools` toggle to TUI App state (default: detailed)
- `c` keybinding in Normal mode switches between compact and detailed tool output
- Compact mode: single summary line per tool call (`-- N lines`) in DIM style
- Detailed mode: full output (current behavior preserved)
- Correct singular/plural grammar ("1 line" vs "N lines")

## Changes

- `app.rs` — `compact_tools` field, accessor, `'c'` keybinding handler
- `chat.rs` — conditional rendering in `render_tool_message`, compact summary with line count

## Test plan

- [x] 1560 tests pass, 0 failures
- [x] Clippy clean
- [x] Fmt clean
- [ ] Manual: run `--tui`, execute commands, press `c` to toggle

Closes #450