### PR TITLE
fix: propagate filter_stats to TUI metrics in native tool path

### DIFF
--- a/crates/zeph-core/src/agent/streaming.rs
+++ b/crates/zeph-core/src/agent/streaming.rs
@@ -620,8 +620,42 @@ impl<C: Channel, T: ToolExecutor> Agent<C, T> {
                 .await;
             let (output, is_error) = match tool_result {
                 Ok(Some(out)) => {
+                    if let Some(ref fs) = out.filter_stats {
+                        let saved = fs.estimated_tokens_saved() as u64;
+                        let raw = (fs.raw_chars / 4) as u64;
+                        let confidence = fs.confidence;
+                        let was_filtered = fs.filtered_chars < fs.raw_chars;
+                        self.update_metrics(|m| {
+                            m.filter_raw_tokens += raw;
+                            m.filter_saved_tokens += saved;
+                            m.filter_applications += 1;
+                            m.filter_total_commands += 1;
+                            if was_filtered {
+                                m.filter_filtered_commands += 1;
+                            }
+                            if let Some(c) = confidence {
+                                match c {
+                                    zeph_tools::FilterConfidence::Full => {
+                                        m.filter_confidence_full += 1;
+                                    }
+                                    zeph_tools::FilterConfidence::Partial => {
+                                        m.filter_confidence_partial += 1;
+                                    }
+                                    zeph_tools::FilterConfidence::Fallback => {
+                                        m.filter_confidence_fallback += 1;
+                                    }
+                                }
+                            }
+                        });
+                    }
                     if let Some(diff) = out.diff {
                         let _ = self.channel.send_diff(diff).await;
+                    }
+                    if let Some(ref fs) = out.filter_stats
+                        && fs.filtered_lines < fs.raw_lines
+                    {
+                        let stats_line = fs.format_inline(&tc.name);
+                        self.channel.send(&stats_line).await?;
                     }
                     (out.summary, false)
                 }

--- a/crates/zeph-tools/src/shell.rs
+++ b/crates/zeph-tools/src/shell.rs
@@ -207,17 +207,6 @@ impl ShellExecutor {
             };
             self.log_audit(block, result, duration_ms).await;
 
-            if let Some(ref tx) = self.tool_event_tx {
-                let _ = tx.send(ToolEvent::Completed {
-                    tool_name: "bash".to_owned(),
-                    command: (*block).to_owned(),
-                    output: out.clone(),
-                    success: !out.contains("[error]"),
-                    filter_stats: None,
-                    diff: None,
-                });
-            }
-
             let sanitized = sanitize_output(&out);
             let mut per_block_stats: Option<FilterStats> = None;
             let filtered = if let Some(ref registry) = self.output_filter_registry {


### PR DESCRIPTION
## Summary

- Fix filter metrics never appearing in TUI dashboard when using native tool_use providers (Claude, OpenAI)
- `handle_native_tool_calls` was silently discarding `ToolOutput.filter_stats`, keeping `filter_applications` at 0 and the TUI filter block permanently hidden
- Remove spurious duplicate `ToolEvent::Completed` emission in shell executor that sent `filter_stats: None` before filtering was applied

## Changes

- `zeph-core/agent/streaming.rs` — replicate `handle_tool_result` filter metrics logic in `handle_native_tool_calls`: update `MetricsSnapshot` counters (raw/saved tokens, applications, commands, confidence distribution) and send inline stats to channel
- `zeph-tools/shell.rs` — remove early `ToolEvent::Completed` with `filter_stats: None` emitted before filtering; keep only the post-filter event with correct stats

## Test plan

- [x] `cargo nextest run --workspace --lib --bins` — 1568 passed, 0 failed
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo +nightly fmt --check` — clean
- [ ] Manual: run `cargo run -- --tui`, execute shell commands via native tool_use provider, verify filter stats appear in Resources panel

Closes #448