### PR TITLE
fix: recognize native tool_result format in TUI history loader

### DIFF
--- a/crates/zeph-tui/src/app.rs
+++ b/crates/zeph-tui/src/app.rs
@@ -648,7 +648,7 @@ fn parse_tool_output(content: &str, suffix: &str) -> Option<(String, String)> {
     }
     // Native tool_use format: [tool_result: id]\ncontent
     if let Some(rest) = content.strip_prefix("[tool_result: ") {
-        let body = rest.find("]\n").map(|i| &rest[i + 2..]).unwrap_or("");
+        let body = rest.find("]\n").map_or("", |i| &rest[i + 2..]);
         let name = if body.contains("$ ") { "bash" } else { "tool" };
         return Some((name.to_owned(), body.to_owned()));
     }


### PR DESCRIPTION
## Summary
- TUI history loader now recognizes `[tool_result: id]` format used by native tool_use providers (Claude, OpenAI)
- Previously these messages were displayed as User role instead of Tool role on session restore
- Added test for the new format

## Test plan
- [x] Existing load_history tests pass
- [x] New test `load_history_recognizes_tool_result_format` added
- [ ] Manual: restart TUI session with history containing native tool calls, verify they render as Tool messages