### PR TITLE
feat(tui): add config option to hide message source labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Duplicate `ToolEvent::Completed` emission in shell executor before filtering was applied (#480)
 
 ### Added
+- TUI `[tui]` config section with `show_source_labels` option to hide `[user]`/`[zeph]`/`[tool]` prefixes (#488)
 - Syntax-highlighted diff view for write/edit tool output in TUI (#451)
   - Diff rendering with green/red backgrounds for added/removed lines
   - Word-level change highlighting within modified lines

--- a/config/default.toml
+++ b/config/default.toml
@@ -320,3 +320,7 @@ embedding_seconds = 30
 a2a_seconds = 30
 # Maximum number of tool calls to execute in parallel
 max_parallel_tools = 8
+
+[tui]
+# Show role prefix labels ([user], [zeph], etc.) in chat messages
+show_source_labels = false

--- a/crates/zeph-core/src/config/types.rs
+++ b/crates/zeph-core/src/config/types.rs
@@ -39,6 +39,8 @@ pub struct Config {
     pub daemon: DaemonConfig,
     #[serde(default)]
     pub scheduler: SchedulerConfig,
+    #[serde(default)]
+    pub tui: TuiConfig,
     #[serde(skip)]
     pub secrets: ResolvedSecrets,
 }
@@ -917,6 +919,12 @@ pub struct SchedulerConfig {
     pub tasks: Vec<ScheduledTaskConfig>,
 }
 
+#[derive(Debug, Clone, Copy, Default, Deserialize)]
+pub struct TuiConfig {
+    #[serde(default)]
+    pub show_source_labels: bool,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct ScheduledTaskConfig {
     pub name: String,
@@ -990,6 +998,7 @@ impl Config {
             gateway: GatewayConfig::default(),
             daemon: DaemonConfig::default(),
             scheduler: SchedulerConfig::default(),
+            tui: TuiConfig::default(),
             secrets: ResolvedSecrets::default(),
         }
     }

--- a/crates/zeph-tui/src/app.rs
+++ b/crates/zeph-tui/src/app.rs
@@ -58,6 +58,7 @@ pub struct App {
     active_panel: Panel,
     tool_expanded: bool,
     compact_tools: bool,
+    show_source_labels: bool,
     status_label: Option<String>,
     throbber_state: throbber_widgets_tui::ThrobberState,
     confirm_state: Option<ConfirmState>,
@@ -89,6 +90,7 @@ impl App {
             active_panel: Panel::Chat,
             tool_expanded: false,
             compact_tools: false,
+            show_source_labels: false,
             status_label: None,
             throbber_state: throbber_widgets_tui::ThrobberState::default(),
             confirm_state: None,
@@ -196,6 +198,15 @@ impl App {
     #[must_use]
     pub fn compact_tools(&self) -> bool {
         self.compact_tools
+    }
+
+    #[must_use]
+    pub fn show_source_labels(&self) -> bool {
+        self.show_source_labels
+    }
+
+    pub fn set_show_source_labels(&mut self, v: bool) {
+        self.show_source_labels = v;
     }
 
     #[must_use]

--- a/src/main.rs
+++ b/src/main.rs
@@ -399,6 +399,7 @@ async fn main() -> anyhow::Result<()> {
         std::thread::spawn(move || reader.run());
 
         let mut tui_app = App::new(tui_handle.user_tx, tui_handle.agent_rx);
+        tui_app.set_show_source_labels(config.tui.show_source_labels);
 
         let history: Vec<(&str, &str)> = agent
             .context_messages()


### PR DESCRIPTION
## Summary

- Add `[tui]` config section with `show_source_labels` option (default: `false`)
- When disabled, role prefixes (`[user]`, `[zeph]`, `[bash]`, `[mcp]`, etc.) are hidden in chat messages
- Message colors already distinguish roles, making labels redundant visual noise

## Changes

- `crates/zeph-core/src/config/types.rs` — new `TuiConfig` struct with serde defaults
- `config/default.toml` — new `[tui]` section
- `crates/zeph-tui/src/app.rs` — `show_source_labels` field with getter/setter
- `crates/zeph-tui/src/widgets/chat.rs` — conditional label rendering in chat and tool messages
- `src/main.rs` — thread config to TUI app

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo +nightly fmt --check` passes
- [x] `cargo nextest run --workspace --lib --bins` — 1585 tests pass
- [x] Config deserialization works with and without `[tui]` section (serde default)
- [x] Env override: `ZEPH_TUI__SHOW_SOURCE_LABELS=true`

Closes #488