### PR TITLE
feat(skills): add GitHub CLI skill

### DIFF
--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: github
+description: Interact with GitHub via the gh CLI. Use when the user asks about issues, pull requests, releases, repos, gists, workflows, or any GitHub operation.
+compatibility: Requires gh (GitHub CLI)
+---
+# GitHub CLI Operations
+
+All commands use `--json` fields and pipe through `head` to limit output and save tokens.
+
+## Authentication
+```bash
+gh auth status
+```
+
+## Issues
+```bash
+gh issue list --limit 10
+gh issue view NUMBER
+gh issue create --title "TITLE" --body "BODY"
+gh issue close NUMBER
+gh issue list --state open --label "LABEL" --limit 20
+gh issue comment NUMBER --body "COMMENT"
+```
+
+## Pull Requests
+```bash
+gh pr list --limit 10
+gh pr view NUMBER
+gh pr create --title "TITLE" --body "BODY" --base main
+gh pr merge NUMBER --squash --delete-branch
+gh pr checks NUMBER
+gh pr diff NUMBER | head -200
+gh pr review NUMBER --approve
+gh pr comment NUMBER --body "COMMENT"
+```
+
+## Repositories
+```bash
+gh repo view --json name,description,defaultBranchRef
+gh repo clone OWNER/REPO
+gh repo create NAME --public --source .
+gh repo list OWNER --limit 10
+```
+
+## Releases
+```bash
+gh release list --limit 5
+gh release view TAG
+gh release create TAG --title "TITLE" --notes "NOTES"
+```
+
+## Workflows (CI/CD)
+```bash
+gh run list --limit 10
+gh run view RUN_ID
+gh run watch RUN_ID
+gh workflow list
+gh workflow run WORKFLOW
+```
+
+## Search
+```bash
+gh search repos "QUERY" --limit 5
+gh search issues "QUERY" --limit 10
+gh search prs "QUERY" --limit 10
+```
+
+## API (raw)
+```bash
+gh api repos/OWNER/REPO --jq '.full_name'
+gh api repos/OWNER/REPO/pulls/NUMBER/comments --jq '.[].body' | head -50
+```
+
+## Token-saving patterns
+
+- Always use `--limit N` or `| head -N` to cap output
+- Use `--json FIELD1,FIELD2` to select only needed fields
+- Use `--jq 'EXPRESSION'` to filter JSON responses
+- Prefer `gh pr view NUMBER --json title,state,mergeable` over full view
+
+## Installation
+
+If `gh` is not installed, detect OS and follow `references/install.md`.

--- a/skills/github/references/install.md
+++ b/skills/github/references/install.md
@@ -1,0 +1,46 @@
+# GitHub CLI Installation
+
+## macOS
+```bash
+brew install gh
+```
+
+## Ubuntu / Debian
+```bash
+(type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
+  && sudo mkdir -p -m 755 /etc/apt/keyrings \
+  && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+  && cat $out | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+  && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+  && sudo apt update \
+  && sudo apt install gh -y
+```
+
+## Fedora / RHEL / CentOS
+```bash
+sudo dnf install 'dnf-command(config-manager)'
+sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+sudo dnf install gh -y
+```
+
+## Arch Linux
+```bash
+sudo pacman -S github-cli
+```
+
+## Windows (winget)
+```powershell
+winget install --id GitHub.cli
+```
+
+## Windows (scoop)
+```powershell
+scoop install gh
+```
+
+## Verify
+```bash
+gh --version
+gh auth login
+```


### PR DESCRIPTION
## Summary

- Add `skills/github/` skill for GitHub CLI (`gh`) operations
- All commands use `--limit`, `--json`, `--jq`, `| head` to minimize token usage
- Covers: issues, PRs, repos, releases, workflows, search, raw API
- Installation instructions for macOS, Ubuntu/Debian, Fedora/RHEL, Arch, Windows

## Test plan

- [x] SKILL.md follows existing skill YAML frontmatter + markdown pattern
- [x] References directory structure matches `system-info` skill convention