### PR TITLE
fix(tui): clear status spinner after warmup completes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -454,6 +454,10 @@ async fn main() -> anyhow::Result<()> {
                 .send(zeph_tui::AgentEvent::Status("model ready".into()))
                 .await;
             let _ = warmup_tx.send(true);
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            let _ = warmup_agent_tx
+                .send(zeph_tui::AgentEvent::Status(String::new()))
+                .await;
         });
 
         let mut agent = agent.with_warmup_ready(warmup_rx);


### PR DESCRIPTION
## Summary

- Clear the TUI status label and throbber 2 seconds after warmup finishes
- After `warmup_tx.send(true)`, sleep 2s then send `Status("")` to reset `status_label` to `None`
- Channel send failure is silently ignored (TUI may have exited during the delay)

Closes #504