### PR TITLE
release: v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-02-18
+
 ### Fixed
+- TUI status spinner not cleared after model warmup completes (#517)
+- Duplicate tool output rendering for shell-streamed tools in TUI (#516)
+- `send_tool_output` not forwarded through `AppChannel`/`AnyChannel` enum dispatch (#508)
+- Tool output and diff not sent atomically in native tool_use path (#498)
+- Parallel tool_use calls: results processed sequentially for correct ordering (#486)
+- Native `tool_result` format not recognized by TUI history loader (#484)
+- Inline filter stats threshold based on char savings instead of line count (#483)
+- Token metrics not propagated in native tool_use path (#482)
 - Filter metrics not appearing in TUI Resources panel when using native tool_use providers (#480)
 - Output filter matchers not matching compound shell commands like `cd /path && cargo test 2>&1 | tail` (#481)
 - Duplicate `ToolEvent::Completed` emission in shell executor before filtering was applied (#480)
+- TUI feature gate compilation errors (#435)
 
 ### Added
-- TUI `[tui]` config section with `show_source_labels` option to hide `[user]`/`[zeph]`/`[tool]` prefixes (#488)
-- Syntax-highlighted diff view for write/edit tool output in TUI (#451)
+- GitHub CLI skill with token-saving patterns (#507)
+- Parallel execution of native tool_use calls with configurable concurrency (#486)
+- TUI compact/detailed tool output toggle with 'e' key binding (#479)
+- TUI `[tui]` config section with `show_source_labels` option to hide `[user]`/`[zeph]`/`[tool]` prefixes (#505)
+- Syntax-highlighted diff view for write/edit tool output in TUI (#455)
   - Diff rendering with green/red backgrounds for added/removed lines
   - Word-level change highlighting within modified lines
   - Syntax highlighting via tree-sitter
@@ -51,6 +65,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `full` feature flag enabling all optional features
 
 ### Changed
+- Remove `P` generic from `Agent`, `SemanticMemory`, `CodeRetriever` — provider resolved at construction (#423)
+- Architecture improvements, performance optimizations, security hardening (M24) (#417)
 - Extract bootstrap logic from main.rs into `zeph-core::bootstrap::AppBuilder` (#393): main.rs reduced from 2313 to 978 lines
 - `SecurityConfig` and `TimeoutConfig` gain `Clone + Copy`
 - `AnyChannel` moved from main.rs to zeph-channels crate
@@ -868,7 +884,8 @@ let agent = Agent::new(provider, channel, &skills_prompt, executor);
 - Agent calls channel.send_typing() before each LLM request
 - Agent::run() uses tokio::select! to race channel messages against shutdown signal
 
-[Unreleased]: https://github.com/bug-ops/zeph/compare/v0.9.9...HEAD
+[Unreleased]: https://github.com/bug-ops/zeph/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/bug-ops/zeph/compare/v0.9.9...v0.10.0
 [0.9.9]: https://github.com/bug-ops/zeph/compare/v0.9.8...v0.9.9
 [0.9.8]: https://github.com/bug-ops/zeph/compare/v0.9.7...v0.9.8
 [0.9.7]: https://github.com/bug-ops/zeph/compare/v0.9.6...v0.9.7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8290,7 +8290,7 @@ dependencies = [
 
 [[package]]
 name = "zeph"
-version = "0.9.9"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "opentelemetry",
@@ -8318,7 +8318,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-a2a"
-version = "0.9.9"
+version = "0.10.0"
 dependencies = [
  "axum 0.8.8",
  "eventsource-stream",
@@ -8342,7 +8342,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-channels"
-version = "0.9.9"
+version = "0.10.0"
 dependencies = [
  "axum 0.8.8",
  "criterion",
@@ -8364,7 +8364,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-core"
-version = "0.9.9"
+version = "0.10.0"
 dependencies = [
  "age",
  "anyhow",
@@ -8391,7 +8391,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-gateway"
-version = "0.9.9"
+version = "0.10.0"
 dependencies = [
  "axum 0.8.8",
  "blake3",
@@ -8408,7 +8408,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-index"
-version = "0.9.9"
+version = "0.10.0"
 dependencies = [
  "blake3",
  "ignore",
@@ -8440,7 +8440,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-llm"
-version = "0.9.9"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -8462,7 +8462,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-mcp"
-version = "0.9.9"
+version = "0.10.0"
 dependencies = [
  "blake3",
  "qdrant-client",
@@ -8481,7 +8481,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-memory"
-version = "0.9.9"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8499,7 +8499,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-scheduler"
-version = "0.9.9"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "cron",
@@ -8514,7 +8514,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-skills"
-version = "0.9.9"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -8536,7 +8536,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-tools"
-version = "0.9.9"
+version = "0.10.0"
 dependencies = [
  "dirs",
  "filetime",
@@ -8559,7 +8559,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-tui"
-version = "0.9.9"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 rust-version = "1.88"
-version = "0.9.9"
+version = "0.10.0"
 authors = ["bug-ops"]
 license = "MIT"
 repository = "https://github.com/bug-ops/zeph"
@@ -78,18 +78,18 @@ unicode-width = "0.2"
 url = "2.5"
 uuid = "1.21"
 cron = "0.15"
-zeph-a2a = { path = "crates/zeph-a2a", version = "0.9.9" }
-zeph-channels = { path = "crates/zeph-channels", version = "0.9.9" }
-zeph-core = { path = "crates/zeph-core", version = "0.9.9" }
-zeph-index = { path = "crates/zeph-index", version = "0.9.9" }
-zeph-llm = { path = "crates/zeph-llm", version = "0.9.9" }
-zeph-mcp = { path = "crates/zeph-mcp", version = "0.9.9" }
-zeph-memory = { path = "crates/zeph-memory", version = "0.9.9" }
-zeph-skills = { path = "crates/zeph-skills", version = "0.9.9" }
-zeph-tools = { path = "crates/zeph-tools", version = "0.9.9" }
-zeph-gateway = { path = "crates/zeph-gateway", version = "0.9.9" }
-zeph-scheduler = { path = "crates/zeph-scheduler", version = "0.9.9" }
-zeph-tui = { path = "crates/zeph-tui", version = "0.9.9" }
+zeph-a2a = { path = "crates/zeph-a2a", version = "0.10.0" }
+zeph-channels = { path = "crates/zeph-channels", version = "0.10.0" }
+zeph-core = { path = "crates/zeph-core", version = "0.10.0" }
+zeph-index = { path = "crates/zeph-index", version = "0.10.0" }
+zeph-llm = { path = "crates/zeph-llm", version = "0.10.0" }
+zeph-mcp = { path = "crates/zeph-mcp", version = "0.10.0" }
+zeph-memory = { path = "crates/zeph-memory", version = "0.10.0" }
+zeph-skills = { path = "crates/zeph-skills", version = "0.10.0" }
+zeph-tools = { path = "crates/zeph-tools", version = "0.10.0" }
+zeph-gateway = { path = "crates/zeph-gateway", version = "0.10.0" }
+zeph-scheduler = { path = "crates/zeph-scheduler", version = "0.10.0" }
+zeph-tui = { path = "crates/zeph-tui", version = "0.10.0" }
 
 [workspace.lints.clippy]
 all = "warn"

--- a/README.md
+++ b/README.md
@@ -1,189 +1,210 @@
-# Zeph
-
-[![CI](https://img.shields.io/github/actions/workflow/status/bug-ops/zeph/ci.yml?branch=main&label=CI)](https://github.com/bug-ops/zeph/actions)
-[![codecov](https://codecov.io/gh/bug-ops/zeph/graph/badge.svg?token=S5O0GR9U6G)](https://codecov.io/gh/bug-ops/zeph)
-[![Trivy Scan](https://img.shields.io/badge/Trivy-0%20CVEs-success)](https://github.com/bug-ops/zeph/security)
-![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20Windows-blue)
-[![MSRV](https://img.shields.io/badge/MSRV-1.88-blue)](https://www.rust-lang.org)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-
-Lightweight AI agent that routes tasks across **Ollama, Claude, OpenAI, HuggingFace, and OpenAI-compatible endpoints** (Together AI, Groq, etc.) — with semantic skill matching, vector memory, MCP tooling, and agent-to-agent communication. Ships as a single binary for Linux, macOS, and Windows.
-
 <div align="center">
-  <img src="asset/zeph-logo.png" alt="Zeph" width="600">
+  <img src="asset/zeph-logo.png" alt="Zeph" width="480">
+
+  **AI agent that ships as a single binary. No Python. No containers. No dependency hell.**
+
+  Route tasks across Ollama, Claude, OpenAI, HuggingFace, and any OpenAI-compatible API —<br>
+  with semantic skills, vector memory, MCP tooling, and a built-in TUI dashboard.
+
+  [![CI](https://img.shields.io/github/actions/workflow/status/bug-ops/zeph/ci.yml?branch=main&label=CI)](https://github.com/bug-ops/zeph/actions)
+  [![codecov](https://codecov.io/gh/bug-ops/zeph/graph/badge.svg?token=S5O0GR9U6G)](https://codecov.io/gh/bug-ops/zeph)
+  [![Trivy](https://img.shields.io/badge/Trivy-0%20CVEs-success)](https://github.com/bug-ops/zeph/security)
+  [![MSRV](https://img.shields.io/badge/MSRV-1.88-blue)](https://www.rust-lang.org)
+  [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+  [Quick Start](#quick-start) · [Features](#what-makes-zeph-different) · [Docs](https://bug-ops.github.io/zeph/) · [Architecture](#architecture)
 </div>
 
-## Why Zeph
-
-**Token-efficient by design.** Most agent frameworks inject every tool and instruction into every prompt. Zeph embeds skills and MCP tools as vectors (with concurrent embedding via `buffer_unordered`), then selects only the top-K relevant ones per query via cosine similarity. Prompt size stays O(K) -- not O(N) -- regardless of how many capabilities are installed. Smart output filtering further reduces token consumption by 70-99% for common tool outputs (test results, git logs, clippy diagnostics, directory listings, log deduplication) — per-command filter stats are shown inline in CLI chat and aggregated in the TUI dashboard.
-
-**Intelligent context management.** Two-tier context pruning: Tier 1 selectively removes old tool outputs (clearing bodies from memory after persisting to SQLite) before falling back to Tier 2 LLM-based compaction, reducing unnecessary LLM calls. A token-based protection zone preserves recent context from pruning. Parallel context preparation via `try_join!` and optimized byte-length token estimation. Cross-session memory transfers knowledge between conversations with relevance filtering. Proportional budget allocation (8% summaries, 8% semantic recall, 4% cross-session, 30% code context, 50% recent history) keeps conversations efficient. Tool outputs are truncated at 30K chars with optional LLM-based summarization for large outputs. Doom-loop detection breaks runaway tool cycles after 3 identical consecutive outputs, with configurable iteration limits (default 10). ZEPH.md project config discovery walks up the directory tree and injects project-specific context when available. Config hot-reload applies runtime-safe fields (timeouts, security, memory limits) on file change without restart.
-
-**Run anywhere.** Local models via Ollama or Candle (GGUF with Metal/CUDA), cloud APIs (Claude, OpenAI), OpenAI-compatible endpoints (Together AI, Groq, Fireworks) via `CompatibleProvider`, or all of them at once through the multi-model orchestrator with automatic fallback chains and `RouterProvider` for prompt-based model selection.
-
-**Production-ready security.** Shell sandboxing with path restrictions and relative path traversal detection, pattern-based permission policy per tool, destructive command confirmation, file operation sandbox with path traversal protection, tool output overflow-to-file (with LLM-accessible paths), secret redaction (AWS, OpenAI, Anthropic, Google, GitLab), audit logging, SSRF protection (including MCP client), rate limiter with TTL-based eviction, and Trivy-scanned container images with 0 HIGH/CRITICAL CVEs.
-
-**Observable.** Optional OpenTelemetry OTLP export (feature-gated behind `otel`) for Prometheus/Grafana integration, with per-model cost tracking and configurable daily budget limits.
-
-**Self-improving.** Skills evolve through failure detection, self-reflection, and LLM-generated improvements — with optional manual approval before activation.
-
-## Installation
-
-### From source
-
-```bash
-git clone https://github.com/bug-ops/zeph
-cd zeph
-cargo build --release
-```
-
-### Pre-built binaries
-
-Download from [GitHub Releases](https://github.com/bug-ops/zeph/releases/latest) for Linux (x86_64, aarch64), macOS (x86_64, aarch64), and Windows (x86_64).
-
-### Docker
-
-```bash
-docker pull ghcr.io/bug-ops/zeph:latest
-```
-
-Multi-platform images (linux/amd64, linux/arm64) scanned with Trivy in CI. See [Docker deployment guide](https://bug-ops.github.io/zeph/guide/docker.html) for GPU, Compose, and vault options.
+---
 
 ## Quick Start
 
 ```bash
-# Pull models for Ollama
-ollama pull mistral:7b
-ollama pull qwen3-embedding
+# From source
+git clone https://github.com/bug-ops/zeph && cd zeph
+cargo build --release
 
-# Run
+# With local Ollama
+ollama pull mistral:7b && ollama pull qwen3-embedding
 ./target/release/zeph
-```
 
-For Telegram bot mode:
-
-```bash
-ZEPH_TELEGRAM_TOKEN="123:ABC" ./target/release/zeph
-```
-
-For cloud providers:
-
-```bash
-# Claude
+# With Claude
 ZEPH_LLM_PROVIDER=claude ZEPH_CLAUDE_API_KEY=sk-ant-... ./target/release/zeph
 
-# OpenAI
+# With OpenAI
 ZEPH_LLM_PROVIDER=openai ZEPH_OPENAI_API_KEY=sk-... ./target/release/zeph
 
-# OpenAI-compatible endpoint (Together AI, Groq, Fireworks, etc.)
+# With any OpenAI-compatible API (Together AI, Groq, Fireworks, etc.)
 ZEPH_LLM_PROVIDER=compatible ZEPH_COMPATIBLE_BASE_URL=https://api.together.xyz/v1 \
   ZEPH_COMPATIBLE_API_KEY=... ./target/release/zeph
 ```
 
-For Discord or Slack bot mode (requires respective feature):
+Pre-built binaries for Linux, macOS, and Windows: [GitHub Releases](https://github.com/bug-ops/zeph/releases/latest) · [Docker](https://bug-ops.github.io/zeph/guide/docker.html)
 
-```bash
-cargo build --release --features discord
-ZEPH_DISCORD_TOKEN="..." ZEPH_DISCORD_APP_ID="..." ./target/release/zeph
+## What Makes Zeph Different
 
-cargo build --release --features slack
-ZEPH_SLACK_BOT_TOKEN="xoxb-..." ZEPH_SLACK_SIGNING_SECRET="..." ./target/release/zeph
+### Compiled, Not Interpreted
+
+Written in Rust. Compiles to a single static binary. No runtime, no virtualenv, no `pip install` that breaks on every OS update. Deploy by copying one file.
+
+### Token-Efficient by Design
+
+Most agent frameworks inject every tool into every prompt — O(N) scaling. Zeph embeds skills and MCP tools as vectors, then selects only the **top-K relevant** per query via cosine similarity. Prompt size stays **O(K)** regardless of installed capabilities.
+
+Smart output filtering compresses tool output by **70-99%** before context injection — test results, git logs, clippy diagnostics, directory listings, log deduplication. Per-command stats shown inline:
+
+```
+[shell] `cargo test` 342 lines → 28 lines, 91.8% filtered
 ```
 
-For TUI dashboard (requires `tui` feature):
+### Hybrid Inference — Local, Cloud, or Both
+
+Run local models via **Ollama** or **Candle** (GGUF with Metal/CUDA acceleration), cloud APIs (**Claude**, **OpenAI**), or any **OpenAI-compatible** endpoint — Together AI, Groq, Fireworks, and more.
+
+The **orchestrator** routes tasks to different providers with automatic fallback chains. The **router** selects models based on prompt content. Use them together for cost-optimized inference that never drops requests.
+
+### Skills, Not Hardcoded Prompts
+
+Capabilities live in `SKILL.md` files — YAML frontmatter + markdown body. Drop a file into `skills/`, and the agent picks it up on the next query via semantic matching. No code changes. No redeployment.
+
+Skills **evolve**: failure detection triggers self-reflection, and the agent generates improved versions — with optional manual approval before activation.
+
+### Memory That Persists
+
+SQLite for conversation history. Qdrant for semantic vector search. Hybrid FTS5 + vector retrieval with configurable ranking weights. Cross-session memory transfers knowledge between conversations with relevance filtering.
+
+Two-tier context pruning: selective tool-output eviction before LLM-based compaction — so the agent calls the LLM less and remembers more.
+
+### Built-In TUI Dashboard
+
+A full terminal UI powered by ratatui — not a separate monitoring tool, but an integrated experience:
+
+- Tree-sitter syntax highlighting and markdown rendering
+- Syntax-highlighted diff view for file edits
+- Live metrics: token usage, filter savings, cost tracking
+- Conversation history with message queueing
+- Compact/expanded toggle for tool outputs
 
 ```bash
 cargo build --release --features tui
 ./target/release/zeph --tui
 ```
 
-> [!TIP]
-> Use `--config /path/to/config.toml` or `ZEPH_CONFIG=...` to override the default config path. Configure secret backends (env, age) via `vault.backend` in config or CLI flags (`--vault`, `--vault-key`, `--vault-path`). Full reference: [Configuration](https://bug-ops.github.io/zeph/getting-started/configuration.html)
+### Defense-in-Depth Security
 
-## Key Features
+Shell sandboxing with path restrictions · file operation sandbox · pattern-based tool permissions (allow/ask/deny) · destructive command confirmation · secret redaction (AWS, OpenAI, Anthropic, Google, GitLab) · SSRF protection (agent + MCP) · audit logging · rate limiting · doom-loop detection · skill trust quarantine with blake3 integrity verification · Trivy-scanned container images with 0 HIGH/CRITICAL CVEs.
 
-| Feature | Description | Docs |
-|---------|-------------|------|
-| **Native Tool Use** | Structured tool calling via Claude tool_use and OpenAI function calling APIs; automatic fallback to text extraction for local models | [Tools](https://bug-ops.github.io/zeph/guide/tools.html) |
-| **Hybrid Inference** | Ollama, Claude, OpenAI, Candle (GGUF), Compatible (any OpenAI-compatible API) — local, cloud, or both | [OpenAI](https://bug-ops.github.io/zeph/guide/openai.html) · [Candle](https://bug-ops.github.io/zeph/guide/candle.html) |
-| **Skills-First Architecture** | Embedding-based top-K matching, progressive loading, hot-reload | [Skills](https://bug-ops.github.io/zeph/guide/skills.html) |
-| **Code Indexing** | AST-based chunking (tree-sitter), semantic retrieval, repo map generation, incremental indexing | [Code Indexing](https://bug-ops.github.io/zeph/guide/code-indexing.html) |
-| **Context Engineering** | Two-tier context pruning (selective tool-output pruning before LLM compaction), semantic recall injection, proportional budget allocation, token-based protection zone for recent context, config hot-reload | [Context](https://bug-ops.github.io/zeph/guide/context.html) · [Configuration](https://bug-ops.github.io/zeph/getting-started/configuration.html) |
-| **Semantic Memory** | SQLite + Qdrant vector search for contextual recall | [Memory](https://bug-ops.github.io/zeph/guide/semantic-memory.html) |
-| **Tool Permissions** | Pattern-based permission policy (allow/ask/deny) with glob matching per tool, excluded denied tools from prompts | [Tools](https://bug-ops.github.io/zeph/guide/tools.html) |
-| **MCP Client** | Connect external tool servers (stdio + HTTP), unified matching, SSRF protection | [MCP](https://bug-ops.github.io/zeph/guide/mcp.html) |
-| **A2A Protocol** | Agent-to-agent communication via JSON-RPC 2.0 with SSE streaming, delegated task inference through agent pipeline | [A2A](https://bug-ops.github.io/zeph/guide/a2a.html) |
-| **Model Orchestrator** | Route tasks to different providers with fallback chains | [Orchestrator](https://bug-ops.github.io/zeph/guide/orchestrator.html) |
-| **Self-Learning** | Skills evolve via failure detection and LLM-generated improvements | [Self-Learning](https://bug-ops.github.io/zeph/guide/self-learning.html) |
-| **Skill Trust & Quarantine** | 4-tier trust model (Trusted/Verified/Quarantined/Blocked) with blake3 integrity verification, anomaly detection with automatic blocking, and restricted tool access for untrusted skills | |
-| **Prompt Caching** | Automatic prompt caching for Anthropic and OpenAI providers, reducing latency and cost on repeated context | |
-| **Graceful Shutdown** | Ctrl-C triggers ordered teardown with MCP server cleanup and pending task draining | |
-| **TUI Dashboard** | ratatui terminal UI with tree-sitter syntax highlighting, markdown rendering, syntax-highlighted diff view for write/edit tool output (compact/expanded toggle), deferred model warmup, scrollbar, mouse scroll, thinking blocks, conversation history, splash screen, live metrics (including filter savings), message queueing (max 10, FIFO with Ctrl+K clear) | [TUI](https://bug-ops.github.io/zeph/guide/tui.html) |
-| **Multi-Channel I/O** | CLI, Discord, Slack, Telegram, and TUI with streaming support | [Channels](https://bug-ops.github.io/zeph/guide/channels.html) |
-| **Defense-in-Depth** | Shell sandbox with relative path traversal detection, file sandbox, command filter, secret redaction (Google/GitLab patterns), audit log, SSRF protection (agent + MCP), rate limiter TTL eviction, doom-loop detection, skill trust quarantine | [Security](https://bug-ops.github.io/zeph/security.html) |
+### Connect Everything
+
+| Protocol | What It Does |
+|----------|-------------|
+| **MCP** | Connect external tool servers (stdio + HTTP) with SSRF protection |
+| **A2A** | Agent-to-agent communication via JSON-RPC 2.0 with SSE streaming |
+| **Channels** | CLI, Telegram, Discord, Slack, TUI — all with streaming support |
+| **Gateway** | HTTP webhook ingestion with bearer auth and rate limiting |
+| **Native tool_use** | Structured tool calling via Claude and OpenAI APIs; text fallback for local models |
 
 ## Architecture
 
+### Agent Loop
+
+```mermaid
+flowchart LR
+    User((User)) -->|query| Channel
+    Channel -->|message| Agent
+    Agent -->|context + skills| LLM
+    LLM -->|tool_use / text| Agent
+    Agent -->|execute| Tools
+    Tools -->|filtered output| Agent
+    Agent -->|recall| Memory[(Memory)]
+    Agent -->|response| Channel
+    Channel -->|stream| User
+
+    subgraph Providers
+        LLM
+    end
+
+    subgraph Execution
+        Tools
+        MCP[MCP Servers]
+        A2A[A2A Agents]
+        Tools -.-> MCP
+        Tools -.-> A2A
+    end
+
+    style User fill:#4a9eff,color:#fff
+    style Memory fill:#f5a623,color:#fff
+    style LLM fill:#7b61ff,color:#fff
 ```
-zeph (binary) — thin CLI/channel dispatch (anyhow for top-level errors)
-├── zeph-core       — bootstrap/AppBuilder, Agent split into 7 submodules (context, streaming,
-│                     persistence, learning, mcp, index), daemon supervisor, typed AgentError/ChannelError, config hot-reload
-├── zeph-llm        — LlmProvider: Ollama, Claude, OpenAI, Candle, Compatible, orchestrator,
-│                     RouterProvider, native tool_use (Claude/OpenAI), typed LlmError
-├── zeph-skills     — SKILL.md parser, embedding matcher, hot-reload, self-learning, typed SkillError
-├── zeph-memory     — SQLite + Qdrant, semantic recall, summarization, typed MemoryError
-├── zeph-index      — AST-based code indexing, semantic retrieval, repo map (optional)
-├── zeph-channels   — AnyChannel dispatch, Discord, Slack, Telegram adapters with streaming
-├── zeph-tools      — schemars-driven tool registry (shell, file ops, web scrape), composite dispatch
-├── zeph-mcp        — MCP client, multi-server lifecycle, unified tool matching
-├── zeph-a2a        — A2A client + server, agent discovery, JSON-RPC 2.0
-├── zeph-gateway    — HTTP gateway for webhook ingestion with bearer auth (optional)
-├── zeph-scheduler  — Cron-based periodic task scheduler with SQLite persistence (optional)
-└── zeph-tui        — ratatui TUI dashboard with live agent metrics (optional)
+
+### Crate Graph
+
+```mermaid
+graph TD
+    ZEPH[zeph binary] --> CORE[zeph-core]
+    ZEPH --> CHANNELS[zeph-channels]
+    ZEPH --> TUI[zeph-tui]
+
+    CORE --> LLM[zeph-llm]
+    CORE --> SKILLS[zeph-skills]
+    CORE --> MEMORY[zeph-memory]
+    CORE --> TOOLS[zeph-tools]
+    CORE --> MCP[zeph-mcp]
+    CORE --> INDEX[zeph-index]
+
+    CHANNELS --> CORE
+    TUI --> CORE
+
+    MCP --> TOOLS
+    CORE --> A2A[zeph-a2a]
+    ZEPH --> GATEWAY[zeph-gateway]
+    ZEPH --> SCHEDULER[zeph-scheduler]
+
+    SKILLS -.->|embeddings| LLM
+    MEMORY -.->|embeddings| LLM
+    INDEX -.->|embeddings| LLM
+
+    classDef always fill:#2d8cf0,color:#fff,stroke:none
+    classDef optional fill:#19be6b,color:#fff,stroke:none
+
+    class ZEPH,CORE,LLM,SKILLS,MEMORY,TOOLS,CHANNELS,MCP always
+    class TUI,A2A,INDEX,GATEWAY,SCHEDULER optional
 ```
 
-**Error handling:** Typed errors throughout all library crates -- `AgentError` (7 variants), `ChannelError` (4 variants), `LlmError`, `MemoryError`, `SkillError`. `anyhow` is used only in `main.rs` for top-level orchestration. Shared Qdrant operations consolidated via `QdrantOps` helper. `AnyProvider` dispatch deduplicated via `delegate_provider!` macro. `AnyChannel` enum dispatch lives in `zeph-channels` for reuse across binaries.
+<sub>Blue = always compiled &nbsp;·&nbsp; Green = feature-gated</sub>
 
-**Agent decomposition:** The agent module in `zeph-core` is split into 7 submodules (`mod.rs`, `context.rs`, `streaming.rs`, `persistence.rs`, `learning.rs`, `mcp.rs`, `index.rs`) with 5 inner field-grouping structs (`MemoryState`, `SkillState`, `ContextState`, `McpState`, `IndexState`).
-
-**MessageKind enum:** Replaces the previous `is_summary` boolean with an explicit variant-based message classification.
+12 crates. Typed errors throughout (`thiserror`). Native async traits (Edition 2024). `rustls` everywhere — no OpenSSL dependency.
 
 > [!IMPORTANT]
-> Requires Rust 1.88+ (Edition 2024). Native async traits — no `async-trait` crate dependency.
-
-Deep dive: [Architecture overview](https://bug-ops.github.io/zeph/architecture/overview.html) · [Crate reference](https://bug-ops.github.io/zeph/architecture/crates.html) · [Token efficiency](https://bug-ops.github.io/zeph/architecture/token-efficiency.html)
+> Requires Rust 1.88+. See the full [architecture overview](https://bug-ops.github.io/zeph/architecture/overview.html) and [crate reference](https://bug-ops.github.io/zeph/architecture/crates.html).
 
 ## Feature Flags
 
-The following features are always compiled in (no flag needed): `openai`, `compatible`, `orchestrator`, `router`, `self-learning`, `qdrant`, `vault-age`, `mcp`.
+Always compiled in: `openai`, `compatible`, `orchestrator`, `router`, `self-learning`, `qdrant`, `vault-age`, `mcp`.
 
-| Feature | Description |
-|---------|-------------|
-| `a2a` | A2A protocol client and server |
+| Flag | What It Adds |
+|------|-------------|
+| `tui` | Terminal dashboard with live metrics |
 | `candle` | Local HuggingFace inference (GGUF) |
-| `index` | AST-based code indexing and semantic retrieval |
-| `discord` | Discord bot with Gateway v10 WebSocket |
-| `slack` | Slack bot with Events API webhook |
-| `gateway` | HTTP gateway for webhook ingestion |
-| `daemon` | Daemon supervisor for component lifecycle |
-| `scheduler` | Cron-based periodic task scheduler |
-| `otel` | OpenTelemetry OTLP export for Prometheus/Grafana |
-| `metal` | Metal GPU acceleration (macOS) |
-| `tui` | ratatui TUI dashboard with real-time metrics |
-| `cuda` | CUDA GPU acceleration (Linux) |
+| `metal` / `cuda` | GPU acceleration (macOS / Linux) |
+| `discord` / `slack` | Bot adapters |
+| `a2a` | Agent-to-agent protocol |
+| `index` | AST-based code indexing |
+| `gateway` | HTTP webhook ingestion |
+| `daemon` | Component supervisor |
+| `scheduler` | Cron-based periodic tasks |
+| `otel` | OpenTelemetry OTLP export |
+| `full` | Everything above |
 
 ```bash
-cargo build --release                        # default build (all always-on features included)
-cargo build --release --features full        # all optional features
-cargo build --release --features metal       # macOS Metal GPU
-cargo build --release --features tui         # with TUI dashboard
+cargo build --release                     # default (always-on features)
+cargo build --release --features full     # everything
+cargo build --release --features tui      # with dashboard
 ```
-
-Full details: [Feature Flags](https://bug-ops.github.io/zeph/feature-flags.html)
 
 ## Documentation
 
-Full documentation is available at **[bug-ops.github.io/zeph](https://bug-ops.github.io/zeph/)**.
+**[bug-ops.github.io/zeph](https://bug-ops.github.io/zeph/)** — installation, configuration, guides, and API reference.
 
 ## Contributing
 
@@ -191,7 +212,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development workflow and guidelines.
 
 ## Security
 
-Found a vulnerability? Do not open a public issue. Use [GitHub Security Advisories](https://github.com/bug-ops/zeph/security/advisories/new) for responsible disclosure.
+Found a vulnerability? Please use [GitHub Security Advisories](https://github.com/bug-ops/zeph/security/advisories/new) for responsible disclosure.
 
 ## License
 

--- a/crates/zeph-a2a/README.md
+++ b/crates/zeph-a2a/README.md
@@ -1,0 +1,30 @@
+# zeph-a2a
+
+A2A protocol client and server for agent-to-agent communication.
+
+## Overview
+
+Implements the Agent-to-Agent (A2A) protocol over JSON-RPC 2.0, enabling Zeph to discover, communicate with, and delegate tasks to remote agents. Feature-gated behind `a2a`; the server component requires the `server` sub-feature.
+
+## Key Modules
+
+- **client** — `A2aClient` for sending tasks and messages to remote agents
+- **server** — `A2aServer` exposing an A2A-compliant endpoint (requires `server` feature)
+- **card** — `AgentCardBuilder` for constructing agent capability cards
+- **discovery** — `AgentRegistry` for agent lookup and registration
+- **jsonrpc** — JSON-RPC 2.0 request/response types
+- **types** — shared protocol types (Task, Message, Artifact, etc.)
+- **error** — `A2aError` error types
+
+## Usage
+
+```toml
+# Cargo.toml (workspace root)
+zeph-a2a = { path = "crates/zeph-a2a" }
+```
+
+Enabled via the `a2a` feature flag on the root `zeph` crate.
+
+## License
+
+MIT

--- a/crates/zeph-channels/README.md
+++ b/crates/zeph-channels/README.md
@@ -1,0 +1,32 @@
+# zeph-channels
+
+Channel implementations for the Zeph agent.
+
+## Overview
+
+Implements I/O channel adapters that connect the agent to different frontends. Ships with a CLI channel, Telegram adapter with streaming support, and optional Discord and Slack adapters. The `AnyChannel` enum provides unified dispatch across all channel variants.
+
+## Key modules
+
+| Module | Description |
+|--------|-------------|
+| `cli` | `CliChannel` — interactive terminal I/O |
+| `telegram` | Telegram adapter via teloxide with streaming |
+| `discord` | Discord adapter (optional feature) |
+| `slack` | Slack adapter (optional feature) |
+| `any` | `AnyChannel` — enum dispatch over all channels |
+| `markdown` | Markdown rendering helpers |
+| `error` | `ChannelError` — unified error type |
+
+**Re-exports:** `AnyChannel`, `CliChannel`, `ChannelError`
+
+## Usage
+
+```toml
+[dependencies]
+zeph-channels = { path = "../zeph-channels" }
+```
+
+## License
+
+MIT

--- a/crates/zeph-core/README.md
+++ b/crates/zeph-core/README.md
@@ -1,0 +1,37 @@
+# zeph-core
+
+Agent loop, configuration loading, and context builder.
+
+## Overview
+
+Core orchestration crate for the Zeph agent. Manages the main agent loop, bootstraps the application from TOML configuration with environment variable overrides, and assembles the LLM context from conversation history, skills, and memory. All other workspace crates are coordinated through `zeph-core`.
+
+## Key modules
+
+| Module | Description |
+|--------|-------------|
+| `agent` | `Agent` — main loop driving inference and tool execution |
+| `bootstrap` | `AppBuilder` — fluent builder for application startup |
+| `channel` | `Channel` trait defining I/O adapters |
+| `config` | TOML config with `ZEPH_*` env overrides |
+| `context` | LLM context assembly from history, skills, memory |
+| `cost` | Token cost tracking and budgeting |
+| `daemon` | Background daemon mode (optional feature) |
+| `metrics` | Runtime metrics collection |
+| `project` | Project-level context detection |
+| `redact` | Sensitive data redaction |
+| `vault` | Secret resolution via vault providers |
+| `diff` | Diff rendering utilities |
+
+**Re-exports:** `Agent`
+
+## Usage
+
+```toml
+[dependencies]
+zeph-core = { path = "../zeph-core" }
+```
+
+## License
+
+MIT

--- a/crates/zeph-gateway/README.md
+++ b/crates/zeph-gateway/README.md
@@ -1,0 +1,27 @@
+# zeph-gateway
+
+HTTP gateway for webhook ingestion with bearer auth and health endpoint.
+
+## Overview
+
+Exposes an axum 0.8 HTTP server that accepts incoming webhooks, validates bearer tokens, and forwards payloads into the agent loop. Includes a `/health` endpoint for liveness probes. Feature-gated behind `gateway`.
+
+## Key Modules
+
+- **server** — `GatewayServer` startup and graceful shutdown
+- **handlers** — request handlers for webhook and health routes
+- **router** — axum router construction with auth middleware
+- **error** — `GatewayError` error types
+
+## Usage
+
+```toml
+# Cargo.toml (workspace root)
+zeph-gateway = { path = "crates/zeph-gateway" }
+```
+
+Enabled via the `gateway` feature flag on the root `zeph` crate.
+
+## License
+
+MIT

--- a/crates/zeph-index/README.md
+++ b/crates/zeph-index/README.md
@@ -1,0 +1,29 @@
+# zeph-index
+
+AST-based code indexing, semantic retrieval, and repo map generation.
+
+## Overview
+
+Parses source files with tree-sitter to extract symbols, chunks them for embedding, and stores vectors in Qdrant for semantic code search. Generates concise repo maps that can be injected into the agent context. Feature-gated behind `index`.
+
+## Key Modules
+
+- **indexer** — orchestrates file discovery, parsing, and embedding pipeline
+- **retriever** — semantic search over indexed symbols and chunks
+- **store** — persistence layer backed by Qdrant
+- **repo_map** — generates tree-style repository summaries
+- **watcher** — filesystem watcher for incremental re-indexing
+- **error** — `IndexError` error types
+
+## Usage
+
+```toml
+# Cargo.toml (workspace root)
+zeph-index = { path = "crates/zeph-index" }
+```
+
+Enabled via the `index` feature flag on the root `zeph` crate.
+
+## License
+
+MIT

--- a/crates/zeph-llm/README.md
+++ b/crates/zeph-llm/README.md
@@ -1,0 +1,34 @@
+# zeph-llm
+
+LLM provider abstraction and backend implementations.
+
+## Overview
+
+Defines the `LlmProvider` trait and ships concrete backends for Ollama, Claude, OpenAI, and OpenAI-compatible endpoints. Includes an orchestrator for multi-model coordination, a router for model selection, and an optional Candle backend for local inference.
+
+## Key modules
+
+| Module | Description |
+|--------|-------------|
+| `provider` | `LlmProvider` trait — unified inference interface |
+| `ollama` | Ollama HTTP backend |
+| `claude` | Anthropic Claude backend |
+| `openai` | OpenAI backend |
+| `compatible` | Generic OpenAI-compatible endpoint backend |
+| `candle_provider` | Local inference via Candle (optional feature) |
+| `orchestrator` | Multi-model coordination and fallback |
+| `router` | Model selection and routing logic |
+| `error` | `LlmError` — unified error type |
+
+**Re-exports:** `LlmProvider`, `LlmError`
+
+## Usage
+
+```toml
+[dependencies]
+zeph-llm = { path = "../zeph-llm" }
+```
+
+## License
+
+MIT

--- a/crates/zeph-mcp/README.md
+++ b/crates/zeph-mcp/README.md
@@ -1,0 +1,28 @@
+# zeph-mcp
+
+MCP client lifecycle, tool discovery, and execution.
+
+## Overview
+
+Implements the Model Context Protocol client for Zeph, managing connections to multiple MCP servers, discovering their tools at startup, and routing tool calls through a unified executor. Built on rmcp 0.15.
+
+## Key Modules
+
+- **client** — low-level MCP transport and session handling
+- **manager** — `McpManager`, `McpTransport`, `ServerEntry` for multi-server lifecycle
+- **executor** — `McpToolExecutor` bridging MCP tools into the `ToolExecutor` trait
+- **registry** — `McpToolRegistry` for tool lookup and optional Qdrant-backed search
+- **tool** — `McpTool` wrapper with schema and metadata
+- **prompt** — MCP prompt template support
+- **error** — `McpError` error types
+
+## Usage
+
+```toml
+# Cargo.toml (workspace root)
+zeph-mcp = { path = "crates/zeph-mcp" }
+```
+
+## License
+
+MIT

--- a/crates/zeph-memory/README.md
+++ b/crates/zeph-memory/README.md
@@ -1,0 +1,31 @@
+# zeph-memory
+
+SQLite-backed conversation persistence with Qdrant vector search.
+
+## Overview
+
+Provides durable conversation storage via SQLite and semantic retrieval through Qdrant vector search. The `SemanticMemory` orchestrator combines both backends, enabling the agent to recall relevant context from past conversations using embedding similarity.
+
+## Key modules
+
+| Module | Description |
+|--------|-------------|
+| `sqlite` | SQLite storage for conversations and messages |
+| `qdrant` | Qdrant client for vector upsert and search |
+| `qdrant_ops` | `QdrantOps` — high-level Qdrant operations |
+| `semantic` | `SemanticMemory` — orchestrates SQLite + Qdrant |
+| `types` | `ConversationId`, `MessageId`, shared types |
+| `error` | `MemoryError` — unified error type |
+
+**Re-exports:** `MemoryError`, `QdrantOps`, `ConversationId`, `MessageId`
+
+## Usage
+
+```toml
+[dependencies]
+zeph-memory = { path = "../zeph-memory" }
+```
+
+## License
+
+MIT

--- a/crates/zeph-scheduler/README.md
+++ b/crates/zeph-scheduler/README.md
@@ -1,0 +1,33 @@
+# zeph-scheduler
+
+Cron-based periodic task scheduler with SQLite persistence.
+
+## Overview
+
+Runs recurring tasks on cron schedules, persisting job state and last-run timestamps in SQLite. Ships with built-in tasks for memory cleanup, skill refresh, and health checks. Feature-gated behind `scheduler`.
+
+## Key Modules
+
+- **scheduler** — `Scheduler` event loop managing job evaluation and dispatch
+- **store** — `JobStore` for SQLite-backed job persistence
+- **task** — `ScheduledTask`, `TaskHandler`, `TaskKind` defining task types and execution
+- **error** — `SchedulerError` error types
+
+## Built-in Tasks
+
+- `memory_cleanup` — prune expired memory entries
+- `skill_refresh` — hot-reload changed skill files
+- `health_check` — periodic self-diagnostics
+
+## Usage
+
+```toml
+# Cargo.toml (workspace root)
+zeph-scheduler = { path = "crates/zeph-scheduler" }
+```
+
+Enabled via the `scheduler` feature flag on the root `zeph` crate.
+
+## License
+
+MIT

--- a/crates/zeph-skills/README.md
+++ b/crates/zeph-skills/README.md
@@ -1,0 +1,33 @@
+# zeph-skills
+
+SKILL.md loader, skill registry, and prompt formatter.
+
+## Overview
+
+Parses SKILL.md files (YAML frontmatter + markdown body) from the `skills/` directory, maintains an in-memory registry with hot-reload support, and formats selected skills into LLM system prompts. Supports semantic matching via Qdrant embeddings and self-learning skill evolution with trust scoring.
+
+## Key modules
+
+| Module | Description |
+|--------|-------------|
+| `loader` | SKILL.md parser (YAML frontmatter + markdown) |
+| `registry` | In-memory skill registry with hot-reload |
+| `matcher` | Keyword-based skill matching |
+| `qdrant_matcher` | Semantic skill matching via Qdrant |
+| `evolution` | Self-learning skill generation and refinement |
+| `trust` | `SkillTrust`, `TrustLevel` — skill trust scoring |
+| `watcher` | Filesystem watcher for skill hot-reload |
+| `prompt` | Skill-to-prompt formatting |
+
+**Re-exports:** `SkillError`, `SkillTrust`, `TrustLevel`, `compute_skill_hash`
+
+## Usage
+
+```toml
+[dependencies]
+zeph-skills = { path = "../zeph-skills" }
+```
+
+## License
+
+MIT

--- a/crates/zeph-tools/README.md
+++ b/crates/zeph-tools/README.md
@@ -1,0 +1,38 @@
+# zeph-tools
+
+Tool execution abstraction and shell backend.
+
+## Overview
+
+Defines the `ToolExecutor` trait for sandboxed tool invocation and ships concrete executors for shell commands, file operations, and web scraping. The `CompositeExecutor` chains multiple backends with output filtering, permission checks, trust gating, anomaly detection, and audit logging.
+
+## Key modules
+
+| Module | Description |
+|--------|-------------|
+| `executor` | `ToolExecutor` trait, `ToolOutput`, `ToolCall` |
+| `shell` | Shell command executor |
+| `file` | File operation executor |
+| `scrape` | Web scraping executor |
+| `composite` | `CompositeExecutor` — chains executors with middleware |
+| `filter` | Output filtering pipeline |
+| `permissions` | Permission checks for tool invocation |
+| `audit` | `AuditLogger` — tool execution audit trail |
+| `registry` | Tool registry and discovery |
+| `trust_gate` | Trust-based tool access control |
+| `anomaly` | `AnomalyDetector` — unusual execution pattern detection |
+| `overflow` | Output overflow handling |
+| `config` | Per-tool TOML configuration |
+
+**Re-exports:** `CompositeExecutor`, `AuditLogger`, `AnomalyDetector`
+
+## Usage
+
+```toml
+[dependencies]
+zeph-tools = { path = "../zeph-tools" }
+```
+
+## License
+
+MIT

--- a/crates/zeph-tui/README.md
+++ b/crates/zeph-tui/README.md
@@ -1,0 +1,31 @@
+# zeph-tui
+
+ratatui-based TUI dashboard with real-time agent metrics.
+
+## Overview
+
+Provides a terminal UI for monitoring the Zeph agent in real time. Built on ratatui and crossterm, it renders live token usage, latency histograms, conversation history, and skill activity. Feature-gated behind `tui`.
+
+## Key Modules
+
+- **app** — `App` state machine driving the render/event loop
+- **channel** — `TuiChannel` implementing the `Channel` trait for agent I/O
+- **event** — `AgentEvent`, `AppEvent`, `EventReader` for async event dispatch
+- **highlight** — syntax highlighting for code blocks
+- **layout** — panel arrangement and responsive grid
+- **metrics** — `MetricsCollector`, `MetricsSnapshot` for live telemetry
+- **theme** — color palette and style definitions
+- **widgets** — reusable ratatui widget components
+
+## Usage
+
+```toml
+# Cargo.toml (workspace root)
+zeph-tui = { path = "crates/zeph-tui" }
+```
+
+Enabled via the `tui` feature flag on the root `zeph` crate.
+
+## License
+
+MIT

--- a/docs/src/architecture/crates.md
+++ b/docs/src/architecture/crates.md
@@ -7,7 +7,7 @@ Each workspace crate has a focused responsibility. All leaf crates are independe
 Agent loop, bootstrap orchestration, configuration loading, and context builder.
 
 - `AppBuilder` — bootstrap orchestrator in `zeph-core::bootstrap`: `from_env()` config/vault resolution, `build_provider()` with health check, `build_memory()`, `build_skill_matcher()`, `build_registry()`, `build_tool_executor()`, `build_watchers()`, `build_shutdown()`, `build_summary_provider()`
-- `Agent<P, C, T>` — main agent loop with streaming support, message queue drain, configurable `max_tool_iterations` (default 10), doom-loop detection, and context budget check (stops at 80% threshold). Internal state is grouped into five domain structs (`MemoryState`, `SkillState`, `ContextState`, `McpState`, `IndexState`); logic is decomposed into `streaming.rs` and `persistence.rs` submodules
+- `Agent<C, T>` — main agent loop with streaming support, message queue drain, configurable `max_tool_iterations` (default 10), doom-loop detection, and context budget check (stops at 80% threshold). Provider is resolved at construction time (no `P` generic). Internal state is grouped into five domain structs (`MemoryState`, `SkillState`, `ContextState`, `McpState`, `IndexState`); logic is decomposed into `streaming.rs` and `persistence.rs` submodules
 - `AgentError` — typed error enum covering LLM, memory, channel, tool, context, and I/O failures (replaces prior `anyhow` usage)
 - `Config` — TOML config loading with env var overrides
 - `Channel` trait — abstraction for I/O (CLI, Telegram, TUI) with `recv()`, `try_recv()`, `send_queue_count()` for queue management. Returns `Result<_, ChannelError>` with typed variants (`Io`, `ChannelClosed`, `ConfirmationCancelled`)

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -5,3 +5,84 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 See the full [CHANGELOG.md](https://github.com/bug-ops/zeph/blob/main/CHANGELOG.md) in the repository for the complete version history.
+
+## [Unreleased]
+
+## [0.10.0] - 2026-02-18
+
+### Fixed
+- TUI status spinner not cleared after model warmup completes (#517)
+- Duplicate tool output rendering for shell-streamed tools in TUI (#516)
+- `send_tool_output` not forwarded through `AppChannel`/`AnyChannel` enum dispatch (#508)
+- Tool output and diff not sent atomically in native tool_use path (#498)
+- Parallel tool_use calls: results processed sequentially for correct ordering (#486)
+- Native `tool_result` format not recognized by TUI history loader (#484)
+- Inline filter stats threshold based on char savings instead of line count (#483)
+- Token metrics not propagated in native tool_use path (#482)
+- Filter metrics not appearing in TUI Resources panel when using native tool_use providers (#480)
+- Output filter matchers not matching compound shell commands like `cd /path && cargo test 2>&1 | tail` (#481)
+- Duplicate `ToolEvent::Completed` emission in shell executor before filtering was applied (#480)
+- TUI feature gate compilation errors (#435)
+
+### Added
+- GitHub CLI skill with token-saving patterns (#507)
+- Parallel execution of native tool_use calls with configurable concurrency (#486)
+- TUI compact/detailed tool output toggle with 'e' key binding (#479)
+- TUI `[tui]` config section with `show_source_labels` option to hide `[user]`/`[zeph]`/`[tool]` prefixes (#505)
+- Syntax-highlighted diff view for write/edit tool output in TUI (#455)
+  - Diff rendering with green/red backgrounds for added/removed lines
+  - Word-level change highlighting within modified lines
+  - Syntax highlighting via tree-sitter
+  - Compact/expanded toggle with existing 'e' key binding
+  - New dependency: `similar` 2.7.0
+- Per-tool inline filter stats in CLI chat: `[shell] cargo test (342 lines -> 28 lines, 91.8% filtered)` (#449)
+- Filter metrics in TUI Resources panel: confidence distribution, command hit rate, token savings (#448)
+- Periodic 250ms tick in TUI event loop for real-time metrics refresh (#447)
+- Output filter architecture improvements (M26.1): `CommandMatcher` enum, `FilterConfidence`, `FilterPipeline`, `SecurityPatterns`, per-filter TOML config (#452)
+- Token savings tracking and metrics for output filtering (#445)
+- Smart tool output filtering: command-aware filters that compress tool output before context insertion
+- `OutputFilter` trait and `OutputFilterRegistry` with first-match-wins dispatch
+- `sanitize_output()` ANSI escape and progress bar stripping (runs on all tool output)
+- Test output filter: cargo test/nextest failures-only mode (94-99% token savings on green suites)
+- Git output filter: compact status/diff/log/push compression (80-99% savings)
+- Clippy output filter: group warnings by lint rule (70-90% savings)
+- Directory listing filter: hide noise directories (target, node_modules, .git)
+- Log deduplication filter: normalize timestamps/UUIDs, count repeated patterns (70-85% savings)
+- `[tools.filters]` config section with `enabled` toggle
+- Skill trust levels: 4-tier model (Trusted, Verified, Quarantined, Blocked) with per-turn enforcement
+- `TrustGateExecutor` wrapping tool execution with trust-level permission checks
+- `AnomalyDetector` with sliding-window threshold counters for quarantined skill monitoring
+- blake3 content hashing for skill integrity verification on load and hot-reload
+- Quarantine prompt wrapping for structural isolation of untrusted skill bodies
+- Self-learning gate: skills with trust < Verified skip auto-improvement
+- `skill_trust` SQLite table with migration 009
+- CLI commands: `/skill trust`, `/skill block`, `/skill unblock`
+- `[skills.trust]` config section (default_level, local_level, hash_mismatch_level)
+- `ProviderKind` enum for type-safe provider selection in config
+- `RuntimeConfig` struct grouping agent runtime fields
+- `AnyProvider::embed_fn()` shared embedding closure helper
+- `Config::validate()` with bounds checking for critical config values
+- `sanitize_paths()` for stripping absolute paths from error messages
+- 10-second timeout wrapper for embedding API calls
+- `full` feature flag enabling all optional features
+
+### Changed
+- Remove `P` generic from `Agent`, `SemanticMemory`, `CodeRetriever` — provider resolved at construction (#423)
+- Architecture improvements, performance optimizations, security hardening (M24) (#417)
+- Extract bootstrap logic from main.rs into `zeph-core::bootstrap::AppBuilder` (#393): main.rs reduced from 2313 to 978 lines
+- `SecurityConfig` and `TimeoutConfig` gain `Clone + Copy`
+- `AnyChannel` moved from main.rs to zeph-channels crate
+- Remove 8 lightweight feature gates, make always-on: openai, compatible, orchestrator, router, self-learning, qdrant, vault-age, mcp (#438)
+- Default features reduced to minimal set (empty after M26)
+- Skill matcher concurrency reduced from 50 to 20
+- `String::with_capacity` in context building loops
+- CI updated to use `--features full`
+
+### Breaking
+- `LlmConfig.provider` changed from `String` to `ProviderKind` enum
+- Default features reduced -- users needing a2a, candle, mcp, openai, orchestrator, router, tui must enable explicitly or use `--features full`
+- Telegram channel rejects empty `allowed_users` at startup
+- Config with extreme values now rejected by `Config::validate()`
+
+### Deprecated
+- `ToolExecutor::execute()` string-based dispatch (use `execute_tool_call()` instead)

--- a/docs/src/guide/tui.md
+++ b/docs/src/guide/tui.md
@@ -245,6 +245,15 @@ The TUI runs as three concurrent loops:
 
 `TuiChannel` implements the `Channel` trait, so it plugs into the agent with zero changes to the generic signature. `MetricsSnapshot` and `MetricsCollector` live in `zeph-core` to avoid circular dependencies — `zeph-tui` re-exports them.
 
+## Configuration
+
+```toml
+[tui]
+show_source_labels = true   # Show [user]/[zeph]/[tool] prefixes on messages (default: true)
+```
+
+Set `show_source_labels = false` to hide the source label prefixes from chat messages for a cleaner look. Environment variable: `ZEPH_TUI_SHOW_SOURCE_LABELS`.
+
 ## Tracing
 
 When TUI is active, tracing output is redirected to `zeph.log` to avoid corrupting the terminal display.


### PR DESCRIPTION
## Summary

- Bump workspace version from 0.9.9 to 0.10.0
- Finalize CHANGELOG.md with release notes for all 25 commits since v0.9.9
- Add README.md to all 12 workspace crates
- Update mdbook documentation (changelog, crate architecture, TUI config)

## Highlights

- Parallel execution of native tool_use calls
- Smart output filtering (70-99% token savings)
- Skill trust levels and quarantine system
- Syntax-highlighted diff view in TUI
- Gateway, daemon, scheduler crates
- Discord and Slack channel adapters
- OpenTelemetry OTLP export with cost tracking

## Checklist

- [x] Version updated in workspace manifest
- [x] Cargo.lock regenerated
- [x] CHANGELOG.md has [0.10.0] section with date
- [x] README.md for all 12 crates created
- [x] mdbook docs updated
- [x] cargo fmt, clippy, nextest pass
- [x] Release build succeeds

## After merge

```
git tag v0.10.0 && git push origin v0.10.0
```