### PR TITLE
fix(core): strip schema metadata and fix doom loop detection for native tool calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8372,6 +8372,7 @@ dependencies = [
  "futures",
  "notify",
  "notify-debouncer-mini",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "serial_test",

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -40,6 +40,7 @@ harness = false
 
 [dev-dependencies]
 criterion.workspace = true
+schemars.workspace = true
 serial_test.workspace = true
 tempfile.workspace = true
 zeph-llm = { workspace = true, features = ["mock"] }


### PR DESCRIPTION
## Summary

- Strip `$schema` and `title` fields from schemars-generated JSON before passing tool definitions to Claude API, preventing schema metadata from confusing the model into omitting required parameters
- Fix doom loop detection for native tool_use path by normalizing volatile `tool_use_id` values before comparing consecutive messages
- Add unit tests for schema stripping, ID normalization, and mixed tag ordering

## Test plan

- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo nextest run --workspace --lib --bins` — 1596 passed, 0 failed
- [x] New tests: `tool_def_strips_schema_and_title`, `normalize_strips_tool_result_ids`, `normalize_strips_tool_use_ids`, `normalize_preserves_plain_text`, `normalize_handles_mixed_tag_order`

Closes #506