### PR TITLE
feat(tui): edit queued messages before LLM processing

### DIFF
--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -513,6 +513,10 @@ impl<C: Channel, T: ToolExecutor> Agent<C, T> {
             let Some(msg) = self.channel.try_recv() else {
                 break;
             };
+            if msg.text.trim() == "/drop-last-queued" {
+                self.message_queue.pop_back();
+                continue;
+            }
             self.enqueue_or_merge(msg.text);
         }
     }

--- a/crates/zeph-tui/src/widgets/input.rs
+++ b/crates/zeph-tui/src/widgets/input.rs
@@ -25,6 +25,10 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect) {
         block = block.title_bottom(Span::styled(badge, theme.highlight));
     }
 
+    if app.editing_queued() {
+        block = block.title_bottom(Span::styled(" [editing queued] ", theme.highlight));
+    }
+
     let paragraph = Paragraph::new(app.input())
         .block(block)
         .style(theme.input_cursor)


### PR DESCRIPTION
## Summary

- Add `/edit-last-queued` command that pops last queued message and returns it to TUI input buffer
- Up arrow in Insert mode with empty input and non-empty queue recalls last queued message
- Visual `[editing queued]` badge shown while editing a recalled message
- New `send_edit_queued` Channel trait method with default no-op (only TUI implements it)

## Test plan

- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes (0 warnings)
- [x] `cargo nextest run --workspace --lib --bins` passes (1596 tests)
- [x] Manual: open TUI, queue multiple messages, press Up with empty input — last message recalled
- [x] Manual: verify queue count decrements and `[editing queued]` badge appears
- [x] Manual: press Enter to re-submit, verify badge disappears

Closes #503