### PR TITLE
refactor(tools): typed deserialization for tool call params

### DIFF
--- a/crates/zeph-tools/src/scrape.rs
+++ b/crates/zeph-tools/src/scrape.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 use url::Url;
 
 use crate::config::ScrapeConfig;
-use crate::executor::{ToolCall, ToolError, ToolExecutor, ToolOutput};
+use crate::executor::{ToolCall, ToolError, ToolExecutor, ToolOutput, deserialize_params};
 
 #[derive(Debug, Deserialize, JsonSchema)]
 struct ScrapeInstruction {
@@ -116,18 +116,7 @@ impl ToolExecutor for WebScrapeExecutor {
             return Ok(None);
         }
 
-        let instruction: ScrapeInstruction = serde_json::from_value(serde_json::Value::Object(
-            call.params
-                .iter()
-                .map(|(k, v)| (k.clone(), v.clone()))
-                .collect(),
-        ))
-        .map_err(|e| {
-            ToolError::Execution(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                e.to_string(),
-            ))
-        })?;
+        let instruction: ScrapeInstruction = deserialize_params(&call.params)?;
 
         let result = self.scrape_instruction(&instruction).await?;
 


### PR DESCRIPTION
## Summary

- Add generic `deserialize_params<T>` helper that wraps `serde_json::from_value` with `ToolError::InvalidParams` mapping
- Derive `Deserialize` on all param structs (`BashParams`, `ReadParams`, `WriteParams`, `EditParams`, `GlobParams`, `GrepParams`), remove `#[allow(dead_code)]`
- Migrate `ShellExecutor`, `FileExecutor`, `WebScrapeExecutor` from manual `HashMap` extraction to typed deserialization
- Remove dead helpers (`param_str`, `param_usize`)
- Add 10 new tests covering deserialization edge cases

Closes #460, closes #461, closes #475

## Test plan

- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` — 0 warnings
- [x] `cargo nextest run --workspace --lib --bins` — 1635 passed, 9 skipped