### PR TITLE
fix(tui): prevent event reader thread termination on mouse events

### DIFF
--- a/crates/zeph-tui/src/event.rs
+++ b/crates/zeph-tui/src/event.rs
@@ -27,9 +27,9 @@ impl EventSource for CrosstermEventSource {
                 Ok(CrosstermEvent::Mouse(mouse)) => match mouse.kind {
                     MouseEventKind::ScrollUp => Some(AppEvent::MouseScroll(1)),
                     MouseEventKind::ScrollDown => Some(AppEvent::MouseScroll(-1)),
-                    _ => None,
+                    _ => Some(AppEvent::Tick),
                 },
-                _ => None,
+                _ => Some(AppEvent::Tick),
             }
         } else {
             Some(AppEvent::Tick)


### PR DESCRIPTION
## Summary

- Fix TUI freeze caused by mouse click/drag/move events killing the event reader thread
- `CrosstermEventSource::next_event()` returned `None` for non-scroll mouse events and unhandled crossterm events (FocusGained/FocusLost/Paste), which terminated the `EventReader::run_with_source()` loop
- Replace `None` with `AppEvent::Tick` to keep the reader thread alive

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --lib --bins` (2014 passed)
- [x] Manual verification: TUI remains responsive after mouse clicks