### PR TITLE
refactor(channels): replace rustyline with crossterm for CLI input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,15 +963,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
-name = "clipboard-win"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
-dependencies = [
- "error-code",
-]
-
-[[package]]
 name = "cmake"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1799,12 +1790,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "error-code"
-version = "3.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "esaxx-rs"
@@ -3755,18 +3740,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
-name = "nix"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225e7cfe711e0ba79a68baeddb2982723e4235247aefce1482f2f16c27865b66"
@@ -5595,25 +5568,6 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
-]
-
-[[package]]
-name = "rustyline"
-version = "17.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e902948a25149d50edc1a8e0141aad50f54e22ba83ff988cf8f7c9ef07f50564"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "clipboard-win",
- "libc",
- "log",
- "memchr",
- "nix 0.30.1",
- "unicode-segmentation",
- "unicode-width",
- "utf8parse",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8951,15 +8905,14 @@ version = "0.11.1"
 dependencies = [
  "axum 0.8.8",
  "criterion",
+ "crossterm",
  "futures",
  "hmac",
  "pulldown-cmark",
  "reqwest 0.13.2",
- "rustyline",
  "serde",
  "serde_json",
  "sha2",
- "sqlx",
  "subtle",
  "teloxide",
  "tempfile",
@@ -8967,6 +8920,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tracing",
+ "unicode-width",
  "zeph-core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ ratatui = "0.30"
 regex = "1.12"
 reqwest = { version = "0.13", default-features = false }
 rmcp = "0.15"
-rustyline = { version = "17.0", default-features = false }
 semver = "1.0.27"
 scrape-core = "0.2.2"
 subtle = "2.6"

--- a/crates/zeph-channels/Cargo.toml
+++ b/crates/zeph-channels/Cargo.toml
@@ -16,8 +16,8 @@ futures = { workspace = true, optional = true }
 hmac = { version = "0.12", optional = true }
 pulldown-cmark.workspace = true
 reqwest = { workspace = true, features = ["rustls", "json"] }
-rustyline.workspace = true
-sqlx = { workspace = true, features = ["runtime-tokio", "sqlite"] }
+crossterm.workspace = true
+unicode-width.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 sha2 = { version = "0.10", optional = true }

--- a/crates/zeph-channels/src/cli.rs
+++ b/crates/zeph-channels/src/cli.rs
@@ -1,219 +1,50 @@
-use std::borrow::Cow;
 use std::collections::VecDeque;
-use std::path::Path;
-use std::sync::{Arc, Mutex};
 
-use rustyline::Editor;
-use rustyline::error::ReadlineError;
-use rustyline::history::{History, SearchDirection, SearchResult};
-use sqlx::SqlitePool;
 use zeph_core::channel::{Attachment, AttachmentKind, Channel, ChannelError, ChannelMessage};
 
-struct SqliteHistory {
+use crate::line_editor::{self, ReadLineResult};
+
+type PersistFn = Box<dyn Fn(&str) + Send>;
+
+struct InputHistory {
     entries: VecDeque<String>,
-    pool: SqlitePool,
+    persist_fn: PersistFn,
     max_len: usize,
-    ignore_dups: bool,
-    ignore_space: bool,
 }
 
-impl SqliteHistory {
-    fn new(entries: Vec<String>, pool: SqlitePool) -> Self {
+impl InputHistory {
+    fn new(entries: Vec<String>, persist_fn: PersistFn) -> Self {
         Self {
             entries: VecDeque::from(entries),
-            pool,
+            persist_fn,
             max_len: 1000,
-            ignore_dups: true,
-            ignore_space: true,
         }
     }
 
-    fn should_ignore(&self, line: &str) -> bool {
-        if self.max_len == 0 || line.is_empty() {
-            return true;
-        }
-        if self.ignore_space && line.starts_with(char::is_whitespace) {
-            return true;
-        }
-        if self.ignore_dups
-            && let Some(last) = self.entries.back()
-            && last == line
-        {
-            return true;
-        }
-        false
+    fn entries(&self) -> &VecDeque<String> {
+        &self.entries
     }
 
-    fn insert(&mut self, line: String) {
+    fn add(&mut self, line: &str) {
+        if line.is_empty() {
+            return;
+        }
+        if self.entries.back().is_some_and(|last| last == line) {
+            return;
+        }
         if self.entries.len() == self.max_len {
             self.entries.pop_front();
         }
-        self.entries.push_back(line);
-    }
-
-    fn search_match<F>(
-        &self,
-        term: &str,
-        start: usize,
-        dir: SearchDirection,
-        test: F,
-    ) -> Option<SearchResult<'_>>
-    where
-        F: Fn(&str) -> Option<usize>,
-    {
-        if term.is_empty() || start >= self.len() {
-            return None;
-        }
-        match dir {
-            SearchDirection::Reverse => {
-                for (idx, entry) in self
-                    .entries
-                    .iter()
-                    .rev()
-                    .skip(self.len() - 1 - start)
-                    .enumerate()
-                {
-                    if let Some(cursor) = test(entry) {
-                        return Some(SearchResult {
-                            idx: start - idx,
-                            entry: Cow::Borrowed(entry),
-                            pos: cursor,
-                        });
-                    }
-                }
-                None
-            }
-            SearchDirection::Forward => {
-                for (idx, entry) in self.entries.iter().skip(start).enumerate() {
-                    if let Some(cursor) = test(entry) {
-                        return Some(SearchResult {
-                            idx: idx + start,
-                            entry: Cow::Borrowed(entry),
-                            pos: cursor,
-                        });
-                    }
-                }
-                None
-            }
-        }
+        self.entries.push_back(line.to_owned());
+        (self.persist_fn)(line);
     }
 }
 
-impl History for SqliteHistory {
-    fn get(
-        &self,
-        index: usize,
-        _dir: SearchDirection,
-    ) -> rustyline::Result<Option<SearchResult<'_>>> {
-        Ok(self.entries.get(index).map(|entry| SearchResult {
-            entry: Cow::Borrowed(entry.as_str()),
-            idx: index,
-            pos: 0,
-        }))
-    }
-
-    fn add(&mut self, line: &str) -> rustyline::Result<bool> {
-        if self.should_ignore(line) {
-            return Ok(false);
-        }
-        let line_owned = line.to_owned();
-        self.insert(line_owned.clone());
-
-        // Safe: add() is always called inside spawn_blocking
-        if let Ok(handle) = tokio::runtime::Handle::try_current() {
-            let pool = self.pool.clone();
-            if let Err(e) = handle.block_on(async move {
-                sqlx::query("INSERT INTO input_history (input) VALUES (?)")
-                    .bind(&line_owned)
-                    .execute(&pool)
-                    .await
-            }) {
-                tracing::warn!("failed to persist input history entry: {e}");
-            }
-        }
-        Ok(true)
-    }
-
-    fn add_owned(&mut self, line: String) -> rustyline::Result<bool> {
-        self.add(&line)
-    }
-
-    fn len(&self) -> usize {
-        self.entries.len()
-    }
-
-    fn is_empty(&self) -> bool {
-        self.entries.is_empty()
-    }
-
-    fn set_max_len(&mut self, len: usize) -> rustyline::Result<()> {
-        self.max_len = len;
-        if self.len() > len {
-            self.entries.drain(..self.len() - len);
-        }
-        Ok(())
-    }
-
-    fn ignore_dups(&mut self, yes: bool) -> rustyline::Result<()> {
-        self.ignore_dups = yes;
-        Ok(())
-    }
-
-    fn ignore_space(&mut self, yes: bool) {
-        self.ignore_space = yes;
-    }
-
-    fn save(&mut self, _path: &Path) -> rustyline::Result<()> {
-        Ok(())
-    }
-
-    fn append(&mut self, _path: &Path) -> rustyline::Result<()> {
-        Ok(())
-    }
-
-    fn load(&mut self, _path: &Path) -> rustyline::Result<()> {
-        Ok(())
-    }
-
-    fn clear(&mut self) -> rustyline::Result<()> {
-        self.entries.clear();
-        if let Ok(handle) = tokio::runtime::Handle::try_current() {
-            let pool = self.pool.clone();
-            if let Err(e) = handle.block_on(async move {
-                sqlx::query("DELETE FROM input_history")
-                    .execute(&pool)
-                    .await
-            }) {
-                tracing::warn!("failed to clear input history: {e}");
-            }
-        }
-        Ok(())
-    }
-
-    fn search(
-        &self,
-        term: &str,
-        start: usize,
-        dir: SearchDirection,
-    ) -> rustyline::Result<Option<SearchResult<'_>>> {
-        let test = |entry: &str| entry.find(term);
-        Ok(self.search_match(term, start, dir, test))
-    }
-
-    fn starts_with(
-        &self,
-        term: &str,
-        start: usize,
-        dir: SearchDirection,
-    ) -> rustyline::Result<Option<SearchResult<'_>>> {
-        let test = |entry: &str| {
-            if entry.starts_with(term) {
-                Some(0)
-            } else {
-                None
-            }
-        };
-        Ok(self.search_match(term, start, dir, test))
+impl std::fmt::Debug for InputHistory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InputHistory")
+            .field("entries_len", &self.entries.len())
+            .finish_non_exhaustive()
     }
 }
 
@@ -221,18 +52,7 @@ impl History for SqliteHistory {
 #[derive(Debug)]
 pub struct CliChannel {
     accumulated: String,
-    editor: Option<Arc<Mutex<Editor<(), SqliteHistory>>>>,
-}
-
-impl std::fmt::Debug for SqliteHistory {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SqliteHistory")
-            .field("entries_len", &self.entries.len())
-            .field("max_len", &self.max_len)
-            .field("ignore_dups", &self.ignore_dups)
-            .field("ignore_space", &self.ignore_space)
-            .finish_non_exhaustive()
-    }
+    history: Option<InputHistory>,
 }
 
 impl CliChannel {
@@ -240,25 +60,20 @@ impl CliChannel {
     pub fn new() -> Self {
         Self {
             accumulated: String::new(),
-            editor: None,
+            history: None,
         }
     }
 
-    /// Create a CLI channel with persistent history backed by `SqlitePool`.
+    /// Create a CLI channel with persistent history.
     ///
-    /// `entries` should be pre-loaded from the database by the caller.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the editor cannot be created.
-    pub fn with_history(pool: SqlitePool, entries: Vec<String>) -> Result<Self, ChannelError> {
-        let history = SqliteHistory::new(entries, pool);
-        let editor = Editor::with_history(rustyline::Config::default(), history)
-            .map_err(|e| ChannelError::Other(e.to_string()))?;
-        Ok(Self {
+    /// `entries` should be pre-loaded by the caller. `persist_fn` is called
+    /// for each new entry to persist it (e.g. via `SqliteStore::save_input_entry`).
+    #[must_use]
+    pub fn with_history(entries: Vec<String>, persist_fn: impl Fn(&str) + Send + 'static) -> Self {
+        Self {
             accumulated: String::new(),
-            editor: Some(Arc::new(Mutex::new(editor))),
-        })
+            history: Some(InputHistory::new(entries, Box::new(persist_fn))),
+        }
     }
 }
 
@@ -270,54 +85,33 @@ impl Default for CliChannel {
 
 impl Channel for CliChannel {
     async fn recv(&mut self) -> Result<Option<ChannelMessage>, ChannelError> {
-        let raw = if let Some(editor) = &self.editor {
-            let editor = editor.clone();
-            let result = tokio::task::spawn_blocking(move || {
-                let mut ed = editor.lock().expect("editor mutex poisoned");
-                ed.readline("You: ")
-            })
+        let entries: Vec<String> = self
+            .history
+            .as_ref()
+            .map(|h| h.entries().iter().cloned().collect())
+            .unwrap_or_default();
+
+        let result = tokio::task::spawn_blocking(move || line_editor::read_line("You: ", &entries))
             .await
-            .map_err(|e| ChannelError::Other(e.to_string()))?;
+            .map_err(|e| ChannelError::Other(e.to_string()))?
+            .map_err(ChannelError::Io)?;
 
-            match result {
-                Ok(line) => line,
-                Err(ReadlineError::Eof | ReadlineError::Interrupted) => return Ok(None),
-                Err(e) => return Err(ChannelError::Other(e.to_string())),
-            }
-        } else {
-            use std::io::{BufRead, Write};
-            let line = tokio::task::spawn_blocking(|| {
-                let stdin = std::io::stdin();
-                let mut reader = stdin.lock();
-                let mut buf = String::new();
-
-                print!("You: ");
-                std::io::stdout().flush()?;
-
-                match reader.read_line(&mut buf) {
-                    Ok(0) => Ok(None),
-                    Ok(_) => Ok(Some(buf)),
-                    Err(e) => Err(e),
-                }
-            })
-            .await
-            .map_err(|e| ChannelError::Other(e.to_string()))??;
-
-            match line {
-                Some(l) => l,
-                None => return Ok(None),
-            }
+        let line = match result {
+            ReadLineResult::Interrupted | ReadLineResult::Eof => return Ok(None),
+            ReadLineResult::Line(l) => l,
         };
 
-        let trimmed = raw.trim();
+        let trimmed = line.trim();
         if trimmed.is_empty() || trimmed == "exit" || trimmed == "quit" {
             return Ok(None);
         }
 
-        // Reset accumulated for new response
+        if let Some(h) = &mut self.history {
+            h.add(trimmed);
+        }
+
         self.accumulated.clear();
 
-        // Handle /image <path> command by reading the file into an attachment
         if let Some(path) = trimmed.strip_prefix("/image").map(str::trim) {
             if path.is_empty() {
                 println!("Usage: /image <path>");
@@ -369,32 +163,15 @@ impl Channel for CliChannel {
     }
 
     async fn confirm(&mut self, prompt: &str) -> Result<bool, ChannelError> {
-        let prompt = prompt.to_owned();
-        if let Some(editor) = &self.editor {
-            let editor = editor.clone();
-            let result = tokio::task::spawn_blocking(move || {
-                let mut ed = editor.lock().expect("editor mutex poisoned");
-                ed.readline(&format!("{prompt} [y/N]: "))
-            })
-            .await
-            .map_err(|e| ChannelError::Other(e.to_string()))?;
-
-            match result {
-                Ok(line) => Ok(line.trim().eq_ignore_ascii_case("y")),
-                Err(ReadlineError::Eof | ReadlineError::Interrupted) => Ok(false),
-                Err(e) => Err(ChannelError::Other(e.to_string())),
-            }
-        } else {
-            tokio::task::spawn_blocking(move || {
-                use std::io::{BufRead, Write};
-                print!("{prompt} [y/N]: ");
-                std::io::stdout().flush()?;
-                let mut buf = String::new();
-                std::io::stdin().lock().read_line(&mut buf)?;
-                Ok(buf.trim().eq_ignore_ascii_case("y"))
-            })
+        let prompt = format!("{prompt} [y/N]: ");
+        let result = tokio::task::spawn_blocking(move || line_editor::read_line(&prompt, &[]))
             .await
             .map_err(|e| ChannelError::Other(e.to_string()))?
+            .map_err(ChannelError::Io)?;
+
+        match result {
+            ReadLineResult::Line(line) => Ok(line.trim().eq_ignore_ascii_case("y")),
+            ReadLineResult::Interrupted | ReadLineResult::Eof => Ok(false),
         }
     }
 }
@@ -462,7 +239,6 @@ mod tests {
         let path = tmp.path().to_str().unwrap().to_owned();
         let filename = tmp.path().file_name().unwrap().to_str().unwrap().to_owned();
 
-        // Simulate /image <path> parsing: strip prefix and read file
         let trimmed = format!("/image {path}");
         let arg = trimmed.strip_prefix("/image").map(str::trim).unwrap();
         assert!(!arg.is_empty());
@@ -489,19 +265,16 @@ mod tests {
     async fn image_command_missing_file_returns_io_error() {
         let result = tokio::fs::read("/nonexistent/path/image.png").await;
         assert!(result.is_err());
-        // Verify it maps to ChannelError::Io correctly
         let err = ChannelError::Io(result.unwrap_err());
         assert!(matches!(err, ChannelError::Io(_)));
     }
 
     #[test]
     fn image_command_empty_args_detected() {
-        // "/image " with only whitespace after stripping prefix yields empty arg
         let trimmed = "/image";
         let arg = trimmed.strip_prefix("/image").map(str::trim).unwrap_or("");
         assert!(arg.is_empty());
 
-        // "/image " (with trailing space)
         let trimmed_space = "/image   ";
         let arg_space = trimmed_space
             .strip_prefix("/image")
@@ -511,115 +284,30 @@ mod tests {
     }
 
     #[test]
-    fn sqlite_history_add_and_get() {
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        let pool = rt.block_on(async {
-            sqlx::sqlite::SqlitePoolOptions::new()
-                .connect("sqlite::memory:")
-                .await
-                .unwrap()
-        });
+    fn input_history_add_and_dedup() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
 
-        let mut history = SqliteHistory::new(vec!["hello".to_owned(), "world".to_owned()], pool);
-        assert_eq!(history.len(), 2);
-
-        let result = rt.block_on(async {
-            // run in spawn_blocking context to satisfy Handle::try_current
-            tokio::task::spawn_blocking(move || {
-                history.add("rust").unwrap();
-                history.len()
-            })
-            .await
-            .unwrap()
-        });
-        assert_eq!(result, 3);
-    }
-
-    #[test]
-    fn sqlite_history_ignore_dups() {
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        let pool = rt.block_on(async {
-            sqlx::sqlite::SqlitePoolOptions::new()
-                .connect("sqlite::memory:")
-                .await
-                .unwrap()
-        });
-
-        let result = rt.block_on(async {
-            tokio::task::spawn_blocking(move || {
-                let mut history = SqliteHistory::new(vec![], pool);
-                history.add("hello").unwrap();
-                history.add("hello").unwrap(); // duplicate — ignored
-                history.len()
-            })
-            .await
-            .unwrap()
-        });
-        assert_eq!(result, 1);
-    }
-
-    #[test]
-    fn sqlite_history_search_finds_entry() {
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        let pool = rt.block_on(async {
-            sqlx::sqlite::SqlitePoolOptions::new()
-                .connect("sqlite::memory:")
-                .await
-                .unwrap()
-        });
-
-        let history = SqliteHistory::new(
-            vec!["cargo build".to_owned(), "cargo test".to_owned()],
-            pool,
+        let persisted = Arc::new(AtomicUsize::new(0));
+        let p = persisted.clone();
+        let mut history = InputHistory::new(
+            vec![],
+            Box::new(move |_| {
+                p.fetch_add(1, Ordering::Relaxed);
+            }),
         );
-
-        let result = history.search("test", 0, SearchDirection::Forward).unwrap();
-        assert!(result.is_some());
-        let sr = result.unwrap();
-        assert_eq!(sr.idx, 1);
+        history.add("hello");
+        history.add("hello"); // duplicate
+        history.add("world");
+        assert_eq!(history.entries().len(), 2);
+        assert_eq!(history.entries()[0], "hello");
+        assert_eq!(persisted.load(Ordering::Relaxed), 2);
     }
 
     #[test]
-    fn sqlite_history_starts_with() {
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        let pool = rt.block_on(async {
-            sqlx::sqlite::SqlitePoolOptions::new()
-                .connect("sqlite::memory:")
-                .await
-                .unwrap()
-        });
-
-        let history = SqliteHistory::new(
-            vec!["cargo build".to_owned(), "cargo test".to_owned()],
-            pool,
-        );
-
-        let result = history
-            .starts_with("cargo", 0, SearchDirection::Forward)
-            .unwrap();
-        assert!(result.is_some());
-        assert_eq!(result.unwrap().idx, 0);
-    }
-
-    #[test]
-    fn sqlite_history_clear() {
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        let pool = rt.block_on(async {
-            sqlx::sqlite::SqlitePoolOptions::new()
-                .connect("sqlite::memory:")
-                .await
-                .unwrap()
-        });
-
-        let result = rt.block_on(async {
-            tokio::task::spawn_blocking(move || {
-                let mut history = SqliteHistory::new(vec!["a".to_owned(), "b".to_owned()], pool);
-                history.clear().unwrap();
-                history.len()
-            })
-            .await
-            .unwrap()
-        });
-        assert_eq!(result, 0);
+    fn input_history_ignores_empty() {
+        let mut history = InputHistory::new(vec![], Box::new(|_| {}));
+        history.add("");
+        assert_eq!(history.entries().len(), 0);
     }
 }

--- a/crates/zeph-channels/src/lib.rs
+++ b/crates/zeph-channels/src/lib.rs
@@ -5,6 +5,7 @@ pub mod cli;
 #[cfg(feature = "discord")]
 pub mod discord;
 pub mod error;
+mod line_editor;
 pub mod markdown;
 #[cfg(feature = "slack")]
 pub mod slack;

--- a/crates/zeph-channels/src/line_editor.rs
+++ b/crates/zeph-channels/src/line_editor.rs
@@ -1,0 +1,230 @@
+use std::io::{self, Write, stdout};
+
+use crossterm::{
+    cursor,
+    event::{self, Event, KeyCode, KeyModifiers},
+    terminal::{self, ClearType},
+};
+
+pub enum ReadLineResult {
+    Line(String),
+    Interrupted,
+    Eof,
+}
+
+struct RawModeGuard;
+
+impl RawModeGuard {
+    fn enter() -> io::Result<Self> {
+        terminal::enable_raw_mode()?;
+        Ok(Self)
+    }
+}
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        let _ = terminal::disable_raw_mode();
+    }
+}
+
+pub fn read_line(prompt: &str, history: &[String]) -> io::Result<ReadLineResult> {
+    let _guard = RawModeGuard::enter()?;
+
+    let mut input = String::new();
+    let mut cursor_pos: usize = 0;
+    let mut history_index: Option<usize> = None;
+    let mut draft = String::new();
+
+    render(prompt, &input, cursor_pos)?;
+
+    loop {
+        let Event::Key(key) = event::read()? else {
+            continue;
+        };
+        // Ignore release/repeat events on platforms that send them
+        if key.kind != event::KeyEventKind::Press {
+            continue;
+        }
+
+        match (key.modifiers, key.code) {
+            (KeyModifiers::CONTROL, KeyCode::Char('c')) => {
+                write!(stdout(), "\r\n")?;
+                stdout().flush()?;
+                return Ok(ReadLineResult::Interrupted);
+            }
+            (KeyModifiers::CONTROL, KeyCode::Char('d')) => {
+                if input.is_empty() {
+                    write!(stdout(), "\r\n")?;
+                    stdout().flush()?;
+                    return Ok(ReadLineResult::Eof);
+                }
+            }
+            (_, KeyCode::Enter) => {
+                write!(stdout(), "\r\n")?;
+                stdout().flush()?;
+                return Ok(ReadLineResult::Line(input));
+            }
+            (KeyModifiers::CONTROL, KeyCode::Char('a')) | (_, KeyCode::Home) => {
+                cursor_pos = 0;
+            }
+            (KeyModifiers::CONTROL, KeyCode::Char('e')) | (_, KeyCode::End) => {
+                cursor_pos = char_count(&input);
+            }
+            (KeyModifiers::CONTROL, KeyCode::Char('u')) => {
+                input.clear();
+                cursor_pos = 0;
+            }
+            (KeyModifiers::ALT, KeyCode::Backspace) => {
+                let boundary = prev_word_boundary(&input, cursor_pos);
+                let start = byte_offset(&input, boundary);
+                let end = byte_offset(&input, cursor_pos);
+                input.drain(start..end);
+                cursor_pos = boundary;
+            }
+            (_, KeyCode::Backspace) => {
+                if cursor_pos > 0 {
+                    let off = byte_offset(&input, cursor_pos - 1);
+                    input.remove(off);
+                    cursor_pos -= 1;
+                }
+            }
+            (_, KeyCode::Delete) => {
+                if cursor_pos < char_count(&input) {
+                    let off = byte_offset(&input, cursor_pos);
+                    input.remove(off);
+                }
+            }
+            (_, KeyCode::Left) => {
+                cursor_pos = cursor_pos.saturating_sub(1);
+            }
+            (_, KeyCode::Right) => {
+                if cursor_pos < char_count(&input) {
+                    cursor_pos += 1;
+                }
+            }
+            (_, KeyCode::Up) => {
+                navigate_history_up(
+                    history,
+                    &mut input,
+                    &mut cursor_pos,
+                    &mut history_index,
+                    &mut draft,
+                );
+            }
+            (_, KeyCode::Down) => {
+                navigate_history_down(
+                    history,
+                    &mut input,
+                    &mut cursor_pos,
+                    &mut history_index,
+                    &mut draft,
+                );
+            }
+            (_, KeyCode::Char(c)) => {
+                let off = byte_offset(&input, cursor_pos);
+                input.insert(off, c);
+                cursor_pos += 1;
+            }
+            _ => {}
+        }
+
+        render(prompt, &input, cursor_pos)?;
+    }
+}
+
+fn navigate_history_up(
+    history: &[String],
+    input: &mut String,
+    cursor_pos: &mut usize,
+    history_index: &mut Option<usize>,
+    draft: &mut String,
+) {
+    match *history_index {
+        None => {
+            if history.is_empty() {
+                return;
+            }
+            draft.clone_from(input);
+            let prefix = &*draft;
+            let found = history
+                .iter()
+                .rposition(|e| prefix.is_empty() || e.starts_with(prefix));
+            let Some(idx) = found else { return };
+            *history_index = Some(idx);
+            input.clone_from(&history[idx]);
+        }
+        Some(i) => {
+            let prefix = &*draft;
+            let found = history[..i]
+                .iter()
+                .rposition(|e| prefix.is_empty() || e.starts_with(prefix));
+            let Some(idx) = found else { return };
+            *history_index = Some(idx);
+            input.clone_from(&history[idx]);
+        }
+    }
+    *cursor_pos = char_count(input);
+}
+
+fn navigate_history_down(
+    history: &[String],
+    input: &mut String,
+    cursor_pos: &mut usize,
+    history_index: &mut Option<usize>,
+    draft: &mut String,
+) {
+    let Some(i) = *history_index else { return };
+    let prefix = &*draft;
+    let found = history[i + 1..]
+        .iter()
+        .position(|e| prefix.is_empty() || e.starts_with(prefix))
+        .map(|offset| i + 1 + offset);
+    if let Some(idx) = found {
+        *history_index = Some(idx);
+        input.clone_from(&history[idx]);
+    } else {
+        *history_index = None;
+        *input = std::mem::take(draft);
+    }
+    *cursor_pos = char_count(input);
+}
+
+fn render(prompt: &str, input: &str, cursor_pos: usize) -> io::Result<()> {
+    let mut out = stdout();
+    let prefix: String = input.chars().take(cursor_pos).collect();
+    let cursor_col = prompt.len() + unicode_display_width(&prefix);
+    write!(
+        out,
+        "\r{}{}{}{}",
+        terminal::Clear(ClearType::CurrentLine),
+        prompt,
+        input,
+        cursor::MoveToColumn(u16::try_from(cursor_col).unwrap_or(u16::MAX)),
+    )?;
+    out.flush()
+}
+
+fn char_count(s: &str) -> usize {
+    s.chars().count()
+}
+
+fn byte_offset(s: &str, char_idx: usize) -> usize {
+    s.char_indices().nth(char_idx).map_or(s.len(), |(i, _)| i)
+}
+
+fn prev_word_boundary(s: &str, cursor: usize) -> usize {
+    let chars: Vec<char> = s.chars().collect();
+    let mut i = cursor;
+    while i > 0 && !chars[i - 1].is_alphanumeric() {
+        i -= 1;
+    }
+    while i > 0 && chars[i - 1].is_alphanumeric() {
+        i -= 1;
+    }
+    i
+}
+
+fn unicode_display_width(s: &str) -> usize {
+    use unicode_width::UnicodeWidthStr;
+    UnicodeWidthStr::width(s)
+}

--- a/crates/zeph-memory/src/sqlite/mod.rs
+++ b/crates/zeph-memory/src/sqlite/mod.rs
@@ -14,7 +14,7 @@ pub use messages::role_str;
 pub use skills::{SkillMetricsRow, SkillUsageRow, SkillVersionRow};
 pub use trust::SkillTrustRow;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SqliteStore {
     pool: SqlitePool,
 }


### PR DESCRIPTION
## Summary

- Replace rustyline with crossterm raw-mode line editor for CLI input
- Add prefix-based history search (Up/Down filters by typed prefix) to both CLI and TUI
- Remove rustyline and sqlx dependencies from zeph-channels, using persist callback pattern instead
- Derive Clone on SqliteStore for shared ownership in closures
- Populate TUI input_history on load_history for arrow-key navigation

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` (2011 passed)
- [ ] Manual: `cargo run`, verify line editing (Left/Right, Home/End, Backspace, Ctrl+A/E/U)
- [ ] Manual: verify Up/Down history navigation and prefix filtering
- [ ] Manual: `cargo run -- --tui`, verify TUI history navigation with prefix search