### PR TITLE
feat(stt): add base_url and language support for local whisper servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- `base_url` and `language` fields in `[llm.stt]` config for OpenAI-compatible local whisper servers (e.g. whisper.cpp)
+- `ZEPH_STT_BASE_URL` and `ZEPH_STT_LANGUAGE` environment variable overrides
+- Whisper API provider now passes `language` parameter for accurate non-English transcription
+- Documentation for whisper.cpp server setup with Metal acceleration on macOS
 - Per-sub-provider `base_url` and `embedding_model` overrides in orchestrator config
 - Full orchestrator example with cloud + local + STT in default.toml
 - All previously undocumented config keys in default.toml (`agent.auto_update_check`, `llm.stt`, `llm.vision_model`, `skills.disambiguation_threshold`, `tools.filters.*`, `tools.permissions`, `a2a.auth_token`, `mcp.servers.env`)
@@ -17,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Vault age backend now falls back to default directory for key/path when `--vault-key`/`--vault-path` are not provided, matching `zeph vault init` behavior (#613)
 
 ### Changed
+- Whisper STT provider no longer requires OpenAI API key when `base_url` points to a local server
 - Orchestrator sub-providers now resolve `base_url` and `embedding_model` via fallback chain: per-provider, parent section, global default
 
 ## [0.11.1] - 2026-02-19

--- a/crates/zeph-core/src/bootstrap.rs
+++ b/crates/zeph-core/src/bootstrap.rs
@@ -555,7 +555,8 @@ pub fn create_provider(config: &Config) -> anyhow::Result<AnyProvider> {
                 providers,
             ))))
         }
-        other => bail!("LLM provider {other} not available"),
+        #[cfg(not(feature = "candle"))]
+        ProviderKind::Candle => bail!("candle feature is not enabled"),
     }
 }
 

--- a/crates/zeph-core/src/config/env.rs
+++ b/crates/zeph-core/src/config/env.rs
@@ -1,4 +1,4 @@
-use super::{Config, SttConfig, default_stt_model, default_stt_provider};
+use super::{Config, SttConfig, default_stt_language, default_stt_model, default_stt_provider};
 
 impl Config {
     pub(crate) fn apply_env_overrides(&mut self) {
@@ -141,6 +141,8 @@ impl Config {
             let stt = self.llm.stt.get_or_insert_with(|| SttConfig {
                 provider: default_stt_provider(),
                 model: default_stt_model(),
+                language: default_stt_language(),
+                base_url: None,
             });
             stt.provider = v;
         }
@@ -148,8 +150,28 @@ impl Config {
             let stt = self.llm.stt.get_or_insert_with(|| SttConfig {
                 provider: default_stt_provider(),
                 model: default_stt_model(),
+                language: default_stt_language(),
+                base_url: None,
             });
             stt.model = v;
+        }
+        if let Ok(v) = std::env::var("ZEPH_STT_LANGUAGE") {
+            let stt = self.llm.stt.get_or_insert_with(|| SttConfig {
+                provider: default_stt_provider(),
+                model: default_stt_model(),
+                language: default_stt_language(),
+                base_url: None,
+            });
+            stt.language = v;
+        }
+        if let Ok(v) = std::env::var("ZEPH_STT_BASE_URL") {
+            let stt = self.llm.stt.get_or_insert_with(|| SttConfig {
+                provider: default_stt_provider(),
+                model: default_stt_model(),
+                language: default_stt_language(),
+                base_url: None,
+            });
+            stt.base_url = Some(v);
         }
         if let Ok(v) = std::env::var("ZEPH_AUTO_UPDATE_CHECK")
             && let Ok(enabled) = v.parse::<bool>()

--- a/crates/zeph-core/src/config/types.rs
+++ b/crates/zeph-core/src/config/types.rs
@@ -135,6 +135,10 @@ pub struct SttConfig {
     pub provider: String,
     #[serde(default = "default_stt_model")]
     pub model: String,
+    #[serde(default = "default_stt_language")]
+    pub language: String,
+    #[serde(default)]
+    pub base_url: Option<String>,
 }
 
 pub(crate) fn default_stt_provider() -> String {
@@ -143,6 +147,10 @@ pub(crate) fn default_stt_provider() -> String {
 
 pub(crate) fn default_stt_model() -> String {
     "whisper-1".into()
+}
+
+pub(crate) fn default_stt_language() -> String {
+    "auto".into()
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/docs/src/advanced/multimodal.md
+++ b/docs/src/advanced/multimodal.md
@@ -20,14 +20,55 @@ provider = "whisper"
 model = "whisper-1"
 ```
 
-The Whisper provider inherits the OpenAI API key from `[llm.openai]` or `ZEPH_OPENAI_API_KEY`. Environment variable overrides: `ZEPH_STT_PROVIDER`, `ZEPH_STT_MODEL`.
+When `base_url` is omitted, the provider uses the OpenAI API key from `[llm.openai]` or `ZEPH_OPENAI_API_KEY`. Set `base_url` to point at any OpenAI-compatible server (no API key required for local servers). The `language` field accepts an [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) code (e.g. `ru`, `en`, `de`) or `auto` for automatic detection.
+
+Environment variable overrides: `ZEPH_STT_PROVIDER`, `ZEPH_STT_MODEL`, `ZEPH_STT_LANGUAGE`, `ZEPH_STT_BASE_URL`.
 
 ### Backends
 
 | Backend | Provider | Feature | Description |
 |---------|----------|---------|-------------|
 | OpenAI Whisper API | `whisper` | `stt` | Cloud-based transcription |
+| OpenAI-compatible server | `whisper` | `stt` | Any local server with `/v1/audio/transcriptions` |
 | Local Whisper | `candle-whisper` | `candle` | Fully offline via candle |
+
+### Local Whisper Server (whisper.cpp)
+
+The recommended setup for local speech-to-text. Uses Metal acceleration on Apple Silicon and handles all audio formats (including Telegram OGG/Opus) server-side.
+
+**Install and run:**
+
+```bash
+brew install whisper-cpp
+
+# Download a model
+curl -L -o ~/.cache/whisper/ggml-large-v3.bin \
+  https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3.bin
+
+# Start the server
+whisper-server \
+  --model ~/.cache/whisper/ggml-large-v3.bin \
+  --host 127.0.0.1 --port 8080 \
+  --inference-path "/v1/audio/transcriptions" \
+  --convert
+```
+
+**Configure Zeph:**
+
+```toml
+[llm.stt]
+provider = "whisper"
+model = "large-v3"
+base_url = "http://127.0.0.1:8080/v1"
+language = "en"   # ISO-639-1 code or "auto"
+```
+
+| Model | Parameters | Disk | Notes |
+|-------|------------|------|-------|
+| `ggml-tiny` | 39M | ~75 MB | Fastest, lower accuracy |
+| `ggml-base` | 74M | ~142 MB | Good balance |
+| `ggml-small` | 244M | ~466 MB | Better accuracy |
+| `ggml-large-v3` | 1.5B | ~2.9 GB | Best accuracy |
 
 ### Local Whisper (Candle)
 

--- a/docs/src/reference/configuration.md
+++ b/docs/src/reference/configuration.md
@@ -78,7 +78,10 @@ max_tokens = 4096
 [llm.stt]
 provider = "whisper"
 model = "whisper-1"
-# Requires `stt` feature. Uses the OpenAI API key from [llm.openai] or ZEPH_OPENAI_API_KEY.
+# base_url = "http://127.0.0.1:8080/v1"  # optional: OpenAI-compatible server
+# language = "en"                          # optional: ISO-639-1 code or "auto"
+# Requires `stt` feature. When base_url is set, targets a local server (no API key needed).
+# When omitted, uses the OpenAI API key from [llm.openai] or ZEPH_OPENAI_API_KEY.
 
 [skills]
 paths = ["./skills"]
@@ -270,6 +273,8 @@ Field resolution: per-provider value → parent section (`[llm]`, `[llm.cloud]`)
 | `ZEPH_COST_MAX_DAILY_CENTS` | Daily spending limit in cents (default: 500) |
 | `ZEPH_STT_PROVIDER` | STT provider: `whisper` or `candle-whisper` (default: `whisper`, requires `stt` feature) |
 | `ZEPH_STT_MODEL` | STT model name (default: `whisper-1`) |
+| `ZEPH_STT_BASE_URL` | STT server base URL (e.g. `http://127.0.0.1:8080/v1` for local whisper.cpp) |
+| `ZEPH_STT_LANGUAGE` | STT language: ISO-639-1 code or `auto` (default: `auto`) |
 | `ZEPH_CONFIG` | Path to config file (default: `config/default.toml`) |
 | `ZEPH_TUI` | Enable TUI dashboard: `true` or `1` (requires `tui` feature) |
 | `ZEPH_AUTO_UPDATE_CHECK` | Enable automatic update checks: `true` or `false` (default: `true`) |


### PR DESCRIPTION
## Summary

- Add `base_url` and `language` fields to `[llm.stt]` config, enabling OpenAI-compatible local whisper servers (e.g. whisper.cpp) without requiring an OpenAI API key
- Pass `language` parameter in Whisper API transcription requests for accurate non-English speech recognition
- Preserve voice message attachments through `drain_channel` buffering so audio arriving during warmup is not lost
- Add configurable language support for the candle-whisper backend
- Document whisper.cpp server setup with Metal acceleration on macOS

## Test plan

- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo nextest run --workspace --lib --bins` passes (2011 tests)
- [x] Manual test: Telegram voice message -> whisper.cpp server -> transcribed text -> agent response
- [x] Verified language parameter produces correct non-English transcription