### PR TITLE
feat(tools): harden shell command detection against bypass vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- Shell command detection rewritten from substring matching to tokenizer-based pipeline with escape normalization, eliminating bypass vectors via backslash insertion, hex/octal escapes, quote splitting, and pipe chains
+- Shell sandbox path validation now uses `std::path::absolute()` as fallback when `canonicalize()` fails on non-existent paths
+- Blocked command matching extracts basename from absolute paths (`/usr/bin/sudo` now correctly blocked)
+- Transparent wrapper commands (`env`, `command`, `exec`, `nice`, `nohup`, `time`, `xargs`) are skipped to detect the actual command
+- Default confirm patterns now include `$(` and backtick subshell expressions
+
+### Fixed
+- False positive: "sudoku" no longer matched by "sudo" blocked pattern (word-boundary matching)
+
 ## [0.11.2] - 2026-02-19
 
 ### Added

--- a/crates/zeph-tools/src/config.rs
+++ b/crates/zeph-tools/src/config.rs
@@ -18,6 +18,8 @@ fn default_confirm_patterns() -> Vec<String> {
         "drop table".into(),
         "drop database".into(),
         "truncate ".into(),
+        "$(".into(),
+        "`".into(),
     ]
 }
 


### PR DESCRIPTION
## Summary

- Replace substring-based blocked command matching with tokenizer pipeline that normalizes shell escape sequences (backslash, hex `$'\xNN'`, octal `$'\NNN'`, quote splitting) and splits on shell operators before word-boundary matching
- Extract basename from absolute paths so `/usr/bin/sudo` is correctly blocked
- Skip transparent wrapper prefixes (`env`, `command`, `exec`, `nice`, `nohup`, `time`, `xargs`) to detect actual command
- Use `std::path::absolute()` as fallback when `canonicalize()` fails on non-existent paths in sandbox validation
- Add `$(` and backtick subshell expressions to default confirm patterns
- Fix false positive: "sudoku" no longer matched by "sudo" pattern

## Test plan

- [x] 382/382 unit tests pass (`cargo nextest run -p zeph-tools --lib`)
- [x] Bypass vectors validated: backslash insertion, hex/octal escapes, quote splitting, pipe chains, absolute paths, transparent wrappers
- [x] No regressions in sandbox validation or existing blocked command tests
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] Security audit passed (AUDIT-01, AUDIT-02, AUDIT-03 addressed)

Closes #618,Closes #628,Closes #629