### PR TITLE
refactor(llm): clean up provider layer — fix leak, deduplicate, optimize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Replace doom-loop string history with content hash comparison (#645)
 - Return &'static str from detect_image_mime with case-insensitive matching (#646)
 - Replace block_on in history persist with fire-and-forget async spawn (#647)
+- Change `LlmProvider::name()` from `&'static str` to `&str`, eliminating `Box::leak` memory leak in CompatibleProvider (#633)
+- Extract rate-limit retry helper `send_with_retry()` in zeph-llm, deduplicating 3 retry loops (#634)
+- Extract `sse_to_chat_stream()` helpers shared by Claude and OpenAI providers (#635)
+- Replace double `AnyProvider::clone()` in `embed_fn()` with single `Arc` clone (#636)
+- Add `with_client()` builder to ClaudeProvider and OpenAiProvider for shared `reqwest::Client` (#637)
+- Cache `JsonSchema` per `TypeId` in `chat_typed` to avoid per-call schema generation (#638)
 
 ### Fixed
 - False positive: "sudoku" no longer matched by "sudo" blocked pattern (word-boundary matching)

--- a/crates/zeph-llm/src/candle_provider/mod.rs
+++ b/crates/zeph-llm/src/candle_provider/mod.rs
@@ -163,7 +163,9 @@ impl LlmProvider for CandleProvider {
 
     async fn embed(&self, text: &str) -> Result<Vec<f32>, LlmError> {
         let Some(ref embed_model) = self.embed_model else {
-            return Err(LlmError::EmbedUnsupported { provider: "candle" });
+            return Err(LlmError::EmbedUnsupported {
+                provider: "candle".into(),
+            });
         };
         let model = embed_model.clone();
         let text = text.to_owned();
@@ -176,7 +178,7 @@ impl LlmProvider for CandleProvider {
         self.embed_model.is_some()
     }
 
-    fn name(&self) -> &'static str {
+    fn name(&self) -> &str {
         "candle"
     }
 }

--- a/crates/zeph-llm/src/error.rs
+++ b/crates/zeph-llm/src/error.rs
@@ -13,13 +13,13 @@ pub enum LlmError {
     Unavailable,
 
     #[error("empty response from {provider}")]
-    EmptyResponse { provider: &'static str },
+    EmptyResponse { provider: String },
 
     #[error("SSE parse error: {0}")]
     SseParse(String),
 
     #[error("embedding not supported by {provider}")]
-    EmbedUnsupported { provider: &'static str },
+    EmbedUnsupported { provider: String },
 
     #[error("model loading failed: {0}")]
     ModelLoad(String),

--- a/crates/zeph-llm/src/extractor.rs
+++ b/crates/zeph-llm/src/extractor.rs
@@ -28,7 +28,7 @@ impl<'a, P: LlmProvider> Extractor<'a, P> {
     /// Returns an error if the provider fails or the response cannot be parsed.
     pub async fn extract<T>(&self, input: &str) -> Result<T, LlmError>
     where
-        T: DeserializeOwned + JsonSchema,
+        T: DeserializeOwned + JsonSchema + 'static,
     {
         let mut messages = Vec::new();
         if let Some(ref preamble) = self.preamble {
@@ -63,14 +63,16 @@ mod tests {
         }
 
         async fn embed(&self, _text: &str) -> Result<Vec<f32>, LlmError> {
-            Err(LlmError::EmbedUnsupported { provider: "stub" })
+            Err(LlmError::EmbedUnsupported {
+                provider: "stub".into(),
+            })
         }
 
         fn supports_embeddings(&self) -> bool {
             false
         }
 
-        fn name(&self) -> &'static str {
+        fn name(&self) -> &str {
             "stub"
         }
     }
@@ -135,7 +137,7 @@ mod tests {
                 false
             }
 
-            fn name(&self) -> &'static str {
+            fn name(&self) -> &str {
                 "fail"
             }
         }

--- a/crates/zeph-llm/src/lib.rs
+++ b/crates/zeph-llm/src/lib.rs
@@ -15,7 +15,9 @@ pub mod ollama;
 pub mod openai;
 pub mod orchestrator;
 pub mod provider;
+pub(crate) mod retry;
 pub mod router;
+pub(crate) mod sse;
 pub mod stt;
 #[cfg(feature = "stt")]
 pub mod whisper;

--- a/crates/zeph-llm/src/mock.rs
+++ b/crates/zeph-llm/src/mock.rs
@@ -61,7 +61,8 @@ impl MockProvider {
 }
 
 impl LlmProvider for MockProvider {
-    fn name(&self) -> &'static str {
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn name(&self) -> &str {
         "mock"
     }
 
@@ -94,7 +95,9 @@ impl LlmProvider for MockProvider {
         if self.supports_embeddings {
             Ok(self.embedding.clone())
         } else {
-            Err(crate::LlmError::EmbedUnsupported { provider: "mock" })
+            Err(crate::LlmError::EmbedUnsupported {
+                provider: "mock".into(),
+            })
         }
     }
 

--- a/crates/zeph-llm/src/ollama.rs
+++ b/crates/zeph-llm/src/ollama.rs
@@ -187,14 +187,17 @@ impl LlmProvider for OllamaProvider {
             .embeddings
             .into_iter()
             .next()
-            .ok_or(LlmError::EmptyResponse { provider: "ollama" })
+            .ok_or(LlmError::EmptyResponse {
+                provider: "ollama".into(),
+            })
     }
 
     fn supports_embeddings(&self) -> bool {
         true
     }
 
-    fn name(&self) -> &'static str {
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn name(&self) -> &str {
         "ollama"
     }
 }

--- a/crates/zeph-llm/src/orchestrator/mod.rs
+++ b/crates/zeph-llm/src/orchestrator/mod.rs
@@ -312,7 +312,8 @@ impl LlmProvider for ModelOrchestrator {
             .and_then(LlmProvider::last_cache_usage)
     }
 
-    fn name(&self) -> &'static str {
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn name(&self) -> &str {
         "orchestrator"
     }
 }

--- a/crates/zeph-llm/src/orchestrator/router.rs
+++ b/crates/zeph-llm/src/orchestrator/router.rs
@@ -118,7 +118,8 @@ impl LlmProvider for SubProvider {
         }
     }
 
-    fn name(&self) -> &'static str {
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn name(&self) -> &str {
         match self {
             Self::Ollama(p) => p.name(),
             Self::Claude(p) => p.name(),

--- a/crates/zeph-llm/src/retry.rs
+++ b/crates/zeph-llm/src/retry.rs
@@ -1,0 +1,80 @@
+use std::future::Future;
+use std::time::Duration;
+
+use crate::error::LlmError;
+use crate::provider::StatusTx;
+
+const BASE_BACKOFF_SECS: u64 = 1;
+
+/// Parse the `Retry-After` header value as seconds, falling back to exponential backoff.
+pub(crate) fn retry_delay(response: &reqwest::Response, attempt: u32) -> Duration {
+    if let Some(val) = response.headers().get("retry-after")
+        && let Ok(s) = val.to_str()
+        && let Ok(secs) = s.parse::<u64>()
+    {
+        return Duration::from_secs(secs);
+    }
+    Duration::from_secs(BASE_BACKOFF_SECS << attempt)
+}
+
+/// Send an HTTP request, retrying up to `max_retries` times on 429 responses.
+///
+/// `f` must return a `reqwest::Response`. On each rate-limited attempt, emits a status
+/// message and waits before retrying. Returns the successful `Response` for further
+/// processing by the caller, or an error.
+///
+/// # Errors
+///
+/// Returns `LlmError::RateLimited` if all attempts are exhausted, or the underlying
+/// `reqwest::Error` wrapped as `LlmError::Http` for other failures.
+pub(crate) async fn send_with_retry<F, Fut>(
+    provider_name: &str,
+    max_retries: u32,
+    status_tx: Option<&StatusTx>,
+    mut f: F,
+) -> Result<reqwest::Response, LlmError>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<reqwest::Response, reqwest::Error>>,
+{
+    for attempt in 0..=max_retries {
+        let response = f().await.map_err(LlmError::Http)?;
+        let status = response.status();
+
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            if attempt == max_retries {
+                return Err(LlmError::RateLimited);
+            }
+            let delay = retry_delay(&response, attempt);
+            let msg = format!(
+                "{provider_name} rate limited, retrying in {}s ({}/{})",
+                delay.as_secs(),
+                attempt + 1,
+                max_retries
+            );
+            if let Some(tx) = status_tx {
+                let _ = tx.send(msg.clone());
+            }
+            tracing::warn!("{msg}");
+            tokio::time::sleep(delay).await;
+            continue;
+        }
+
+        return Ok(response);
+    }
+
+    Err(LlmError::RateLimited)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retry_delay_exponential_backoff() {
+        // Without a response, we can't test header parsing, but verify the math
+        assert_eq!(BASE_BACKOFF_SECS << 0, 1);
+        assert_eq!(BASE_BACKOFF_SECS << 1, 2);
+        assert_eq!(BASE_BACKOFF_SECS << 2, 4);
+    }
+}

--- a/crates/zeph-llm/src/router.rs
+++ b/crates/zeph-llm/src/router.rs
@@ -111,7 +111,8 @@ impl LlmProvider for RouterProvider {
         self.providers.iter().any(LlmProvider::supports_embeddings)
     }
 
-    fn name(&self) -> &'static str {
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn name(&self) -> &str {
         "router"
     }
 

--- a/crates/zeph-llm/src/sse.rs
+++ b/crates/zeph-llm/src/sse.rs
@@ -1,0 +1,188 @@
+use eventsource_stream::Eventsource;
+use serde::Deserialize;
+use tokio_stream::StreamExt;
+
+use crate::error::LlmError;
+use crate::provider::ChatStream;
+
+/// Convert a Claude streaming response into a `ChatStream`.
+pub(crate) fn claude_sse_to_stream(response: reqwest::Response) -> ChatStream {
+    let event_stream = response.bytes_stream().eventsource();
+    let mapped = event_stream.filter_map(|event| match event {
+        Ok(event) => parse_claude_sse_event(&event.data, &event.event),
+        Err(e) => Some(Err(LlmError::SseParse(e.to_string()))),
+    });
+    Box::pin(mapped)
+}
+
+/// Convert an `OpenAI` streaming response into a `ChatStream`.
+pub(crate) fn openai_sse_to_stream(response: reqwest::Response) -> ChatStream {
+    let event_stream = response.bytes_stream().eventsource();
+    let mapped = event_stream.filter_map(|event| match event {
+        Ok(event) => parse_openai_sse_event(&event.data),
+        Err(e) => Some(Err(LlmError::SseParse(e.to_string()))),
+    });
+    Box::pin(mapped)
+}
+
+fn parse_claude_sse_event(data: &str, event_type: &str) -> Option<Result<String, LlmError>> {
+    match event_type {
+        "content_block_delta" => match serde_json::from_str::<ClaudeStreamEvent>(data) {
+            Ok(event) => {
+                if let Some(delta) = event.delta
+                    && delta.delta_type == "text_delta"
+                    && !delta.text.is_empty()
+                {
+                    return Some(Ok(delta.text));
+                }
+                None
+            }
+            Err(e) => Some(Err(LlmError::SseParse(format!(
+                "failed to parse SSE data: {e}"
+            )))),
+        },
+        "error" => match serde_json::from_str::<ClaudeStreamEvent>(data) {
+            Ok(event) => {
+                if let Some(err) = event.error {
+                    Some(Err(LlmError::SseParse(format!(
+                        "Claude stream error ({}): {}",
+                        err.error_type, err.message
+                    ))))
+                } else {
+                    Some(Err(LlmError::SseParse(format!(
+                        "Claude stream error: {data}"
+                    ))))
+                }
+            }
+            Err(_) => Some(Err(LlmError::SseParse(format!(
+                "Claude stream error: {data}"
+            )))),
+        },
+        _ => None,
+    }
+}
+
+fn parse_openai_sse_event(data: &str) -> Option<Result<String, LlmError>> {
+    if data == "[DONE]" {
+        return None;
+    }
+
+    match serde_json::from_str::<OpenAiStreamChunk>(data) {
+        Ok(chunk) => {
+            let content = chunk
+                .choices
+                .first()
+                .and_then(|c| c.delta.content.as_deref())
+                .unwrap_or_default();
+
+            if content.is_empty() {
+                None
+            } else {
+                Some(Ok(content.to_owned()))
+            }
+        }
+        Err(e) => Some(Err(LlmError::SseParse(format!(
+            "failed to parse SSE data: {e}"
+        )))),
+    }
+}
+
+#[derive(Deserialize)]
+struct ClaudeStreamEvent {
+    #[serde(default)]
+    delta: Option<ClaudeDelta>,
+    #[serde(default)]
+    error: Option<ClaudeStreamError>,
+}
+
+#[derive(Deserialize)]
+struct ClaudeDelta {
+    #[serde(rename = "type")]
+    delta_type: String,
+    #[serde(default)]
+    text: String,
+}
+
+#[derive(Deserialize)]
+struct ClaudeStreamError {
+    #[serde(rename = "type")]
+    error_type: String,
+    message: String,
+}
+
+#[derive(Deserialize)]
+struct OpenAiStreamChunk {
+    choices: Vec<OpenAiStreamChoice>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiStreamChoice {
+    delta: OpenAiStreamDelta,
+}
+
+#[derive(Deserialize)]
+struct OpenAiStreamDelta {
+    #[serde(default)]
+    content: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claude_parse_text_delta() {
+        let data = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#;
+        let result = parse_claude_sse_event(data, "content_block_delta");
+        assert_eq!(result.unwrap().unwrap(), "Hello");
+    }
+
+    #[test]
+    fn claude_parse_empty_text_delta() {
+        let data =
+            r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":""}}"#;
+        let result = parse_claude_sse_event(data, "content_block_delta");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn claude_parse_error_event() {
+        let data = r#"{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}"#;
+        let result = parse_claude_sse_event(data, "error");
+        let err = result.unwrap().unwrap_err();
+        assert!(err.to_string().contains("overloaded_error"));
+    }
+
+    #[test]
+    fn claude_parse_unknown_event_skipped() {
+        let result = parse_claude_sse_event("{}", "ping");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn openai_parse_text_chunk() {
+        let data = r#"{"choices":[{"delta":{"content":"hi"},"finish_reason":null}]}"#;
+        let result = parse_openai_sse_event(data);
+        assert_eq!(result.unwrap().unwrap(), "hi");
+    }
+
+    #[test]
+    fn openai_parse_done_signal() {
+        let result = parse_openai_sse_event("[DONE]");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn openai_parse_empty_content() {
+        let data = r#"{"choices":[{"delta":{},"finish_reason":"stop"}]}"#;
+        let result = parse_openai_sse_event(data);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn openai_parse_invalid_json() {
+        let result = parse_openai_sse_event("not json");
+        let err = result.unwrap().unwrap_err();
+        assert!(err.to_string().contains("failed to parse SSE data"));
+    }
+}


### PR DESCRIPTION
## Summary

- Change `LlmProvider::name()` from `&'static str` to `&str`, eliminating `Box::leak` memory leak in CompatibleProvider (#633)
- Extract `send_with_retry()` rate-limit retry helper, deduplicating 3 retry loops in Claude provider (#634)
- Extract `sse_to_chat_stream()` helpers shared by Claude and OpenAI SSE parsing (#635)
- Replace double `AnyProvider::clone()` in `embed_fn()` with single `Arc` clone (#636)
- Add `with_client()` builder to Claude/OpenAI providers for shared `reqwest::Client` (#637)
- Cache `JsonSchema` per `TypeId` in `chat_typed` to avoid per-call generation (#638)

Net: 14 files changed, +466 -527 lines (all within `zeph-llm` crate).

Closes #620, #633, #634, #635, #636, #637, #638

## Test plan

- [x] `cargo +nightly fmt --check` — pass
- [x] `cargo clippy --workspace -- -D warnings` — 0 warnings
- [x] `cargo nextest run --workspace --lib --bins` — 2016 passed, 9 skipped