### PR TITLE
feat(security): mitigate SSRF and information leakage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Replace double `AnyProvider::clone()` in `embed_fn()` with single `Arc` clone (#636)
 - Add `with_client()` builder to ClaudeProvider and OpenAiProvider for shared `reqwest::Client` (#637)
 - Cache `JsonSchema` per `TypeId` in `chat_typed` to avoid per-call schema generation (#638)
+- Scrape executor performs post-DNS resolution validation against private/loopback IPs with pinned address client to prevent SSRF via DNS rebinding
+- Private host detection expanded to block `*.localhost`, `*.internal`, `*.local` domains
+- A2A error responses sanitized: serde details and method names no longer exposed to clients
+- Rate limiter rejects new clients with 429 when entry map is at capacity after stale eviction
+- Secret redaction regex-based pattern matching replaces whitespace tokenizer, detecting secrets in URLs, JSON, and quoted strings
+- Added `hf_`, `npm_`, `dckr_pat_` to secret redaction prefixes
+- A2A client stream errors truncate upstream body to 256 bytes
 
 ### Fixed
 - False positive: "sudoku" no longer matched by "sudo" blocked pattern (word-boundary matching)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8935,6 +8935,7 @@ dependencies = [
  "notify",
  "notify-debouncer-mini",
  "proptest",
+ "regex",
  "schemars 1.2.1",
  "serde",
  "serde_json",

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -20,6 +20,7 @@ anyhow.workspace = true
 futures.workspace = true
 notify.workspace = true
 notify-debouncer-mini.workspace = true
+regex.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true


### PR DESCRIPTION
## Summary

- Scrape executor validates resolved IPs against private/loopback ranges and pins reqwest client to validated addresses, eliminating DNS rebinding TOCTOU
- Private host blocklist expanded to `*.localhost`, `*.internal`, `*.local` domains
- A2A error responses sanitized: serde parse details and method names no longer exposed to clients
- Rate limiter enforces entry cap with 429 rejection when map is full after stale eviction
- Secret redaction rewritten with regex-based pattern matching, detecting secrets inside URLs, JSON, and quoted strings
- Added `hf_`, `npm_`, `dckr_pat_` to redaction prefixes
- A2A client stream errors truncate upstream body to 256 bytes

## Test plan

- [x] 2041/2041 tests pass (`cargo nextest run --workspace --lib --bins`)
- [x] SSRF: resolve_and_validate rejects 127.0.0.1, 10.x, 192.168.x, ::1
- [x] Private host: *.localhost, *.internal, *.local blocked
- [x] A2A error sanitization: 4 handler tests verify no serde/method leakage
- [x] Rate limiter: cap enforcement tested with fresh and stale entries
- [x] Redaction: secrets in URLs, JSON, quoted strings detected
- [x] Security audit passed (AUD-01 through AUD-04 addressed)
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean

Closes #624