### PR TITLE
refactor(memory): extract generic EmbeddingRegistry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- `Embeddable` trait and `EmbeddingRegistry<T>` in zeph-memory — generic Qdrant sync/search extracted from duplicated code in QdrantSkillMatcher and McpToolRegistry (~350 lines removed)
 - MCP server command allowlist validation — only permitted commands (npx, uvx, node, python3, python, docker, deno, bun) can spawn child processes; configurable via `mcp.allowed_commands`
 - MCP env var blocklist — blocks 21 dangerous variables (LD_PRELOAD, DYLD_*, NODE_OPTIONS, PYTHONPATH, JAVA_TOOL_OPTIONS, etc.) and BASH_FUNC_* prefix from MCP server processes
 - Path separator rejection in MCP command validation to prevent symlink-based bypasses

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9055,6 +9055,7 @@ name = "zeph-memory"
 version = "0.11.2"
 dependencies = [
  "anyhow",
+ "blake3",
  "criterion",
  "pdf-extract",
  "proptest",

--- a/crates/zeph-mcp/src/registry.rs
+++ b/crates/zeph-mcp/src/registry.rs
@@ -1,12 +1,10 @@
-use std::collections::HashMap;
+pub use zeph_memory::SyncStats;
+use zeph_memory::{Embeddable, EmbeddingRegistry, QdrantOps};
 
-use qdrant_client::qdrant::{PointStruct, value::Kind};
-use zeph_memory::QdrantOps;
+pub use zeph_llm::provider::EmbedFuture;
 
 use crate::error::McpError;
 use crate::tool::McpTool;
-
-pub use zeph_llm::provider::EmbedFuture;
 
 const COLLECTION_NAME: &str = "zeph_mcp_tools";
 
@@ -17,29 +15,49 @@ const MCP_NAMESPACE: uuid::Uuid = uuid::Uuid::from_bytes([
     0x6c, 0x73, 0x00, 0x01, // "ls\0\x01"
 ]);
 
-#[derive(Debug, Default)]
-pub struct SyncStats {
-    pub added: usize,
-    pub updated: usize,
-    pub removed: usize,
-    pub unchanged: usize,
+/// Wrapper that caches the qualified name so [`Embeddable::key`] can return `&str`.
+struct McpToolRef<'a> {
+    tool: &'a McpTool,
+    qualified: String,
+    hash: String,
 }
 
-pub struct McpToolRegistry {
-    ops: QdrantOps,
-    collection: String,
-    hashes: HashMap<String, String>,
-}
-
-impl std::fmt::Debug for McpToolRegistry {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("McpToolRegistry")
-            .field("collection", &self.collection)
-            .finish_non_exhaustive()
+impl<'a> McpToolRef<'a> {
+    fn new(tool: &'a McpTool) -> Self {
+        let qualified = tool.qualified_name();
+        let hash = compute_hash(tool);
+        Self {
+            tool,
+            qualified,
+            hash,
+        }
     }
 }
 
-fn content_hash(tool: &McpTool) -> String {
+impl Embeddable for McpToolRef<'_> {
+    fn key(&self) -> &str {
+        &self.qualified
+    }
+
+    fn content_hash(&self) -> String {
+        self.hash.clone()
+    }
+
+    fn embed_text(&self) -> &str {
+        &self.tool.description
+    }
+
+    fn to_payload(&self) -> serde_json::Value {
+        serde_json::json!({
+            "key": self.qualified,
+            "server_id": self.tool.server_id,
+            "tool_name": self.tool.name,
+            "description": self.tool.description,
+        })
+    }
+}
+
+fn compute_hash(tool: &McpTool) -> String {
     let mut hasher = blake3::Hasher::new();
     hasher.update(tool.server_id.as_bytes());
     hasher.update(tool.name.as_bytes());
@@ -48,8 +66,16 @@ fn content_hash(tool: &McpTool) -> String {
     hasher.finalize().to_hex().to_string()
 }
 
-fn tool_point_id(tool_key: &str) -> String {
-    uuid::Uuid::new_v5(&MCP_NAMESPACE, tool_key.as_bytes()).to_string()
+pub struct McpToolRegistry {
+    registry: EmbeddingRegistry,
+}
+
+impl std::fmt::Debug for McpToolRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("McpToolRegistry")
+            .field("collection", &COLLECTION_NAME)
+            .finish_non_exhaustive()
+    }
 }
 
 impl McpToolRegistry {
@@ -58,11 +84,8 @@ impl McpToolRegistry {
     /// Returns an error if the Qdrant client cannot be created.
     pub fn new(qdrant_url: &str) -> Result<Self, McpError> {
         let ops = QdrantOps::new(qdrant_url)?;
-
         Ok(Self {
-            ops,
-            collection: COLLECTION_NAME.into(),
-            hashes: HashMap::new(),
+            registry: EmbeddingRegistry::new(ops, COLLECTION_NAME, MCP_NAMESPACE),
         })
     }
 
@@ -80,87 +103,18 @@ impl McpToolRegistry {
     where
         F: Fn(&str) -> EmbedFuture,
     {
-        let mut stats = SyncStats::default();
-
-        self.ensure_collection(&embed_fn).await?;
-
-        let existing = self.ops.scroll_all(&self.collection, "tool_key").await?;
-
-        let mut current: HashMap<String, (String, &McpTool)> = HashMap::with_capacity(tools.len());
-        for tool in tools {
-            let key = tool.qualified_name();
-            current.insert(key, (content_hash(tool), tool));
-        }
-
-        let model_changed = existing.values().any(|stored| {
-            stored
-                .get("embedding_model")
-                .is_some_and(|m| m != embedding_model)
-        });
-
-        if model_changed {
-            tracing::warn!("embedding model changed to '{embedding_model}', recreating collection");
-            self.recreate_collection(&embed_fn).await?;
-        }
-
-        let mut points_to_upsert = Vec::new();
-        for (key, (hash, tool)) in &current {
-            let needs_update = if let Some(stored) = existing.get(key) {
-                model_changed || stored.get("content_hash").is_some_and(|h| h != hash)
-            } else {
-                true
-            };
-
-            if !needs_update {
-                stats.unchanged += 1;
-                self.hashes.insert(key.clone(), hash.clone());
-                continue;
-            }
-
-            let vector = match embed_fn(&tool.description).await {
-                Ok(v) => v,
-                Err(e) => {
-                    tracing::warn!("failed to embed tool '{key}': {e:#}");
-                    continue;
-                }
-            };
-
-            let point_id = tool_point_id(key);
-            let payload = serde_json::json!({
-                "tool_key": key,
-                "server_id": tool.server_id,
-                "tool_name": tool.name,
-                "description": tool.description,
-                "content_hash": hash,
-                "embedding_model": embedding_model,
-            });
-            let payload_map = QdrantOps::json_to_payload(payload)?;
-
-            points_to_upsert.push(PointStruct::new(point_id, vector, payload_map));
-
-            if existing.contains_key(key) {
-                stats.updated += 1;
-            } else {
-                stats.added += 1;
-            }
-            self.hashes.insert(key.clone(), hash.clone());
-        }
-
-        if !points_to_upsert.is_empty() {
-            self.ops.upsert(&self.collection, points_to_upsert).await?;
-        }
-
-        let orphan_ids: Vec<qdrant_client::qdrant::PointId> = existing
-            .keys()
-            .filter(|key| !current.contains_key(*key))
-            .map(|key| qdrant_client::qdrant::PointId::from(tool_point_id(key).as_str()))
-            .collect();
-
-        if !orphan_ids.is_empty() {
-            stats.removed = orphan_ids.len();
-            self.ops.delete_by_ids(&self.collection, orphan_ids).await?;
-        }
-
+        let refs: Vec<McpToolRef<'_>> = tools.iter().map(McpToolRef::new).collect();
+        let stats = self
+            .registry
+            .sync(&refs, embedding_model, |text| {
+                let fut = embed_fn(text);
+                Box::pin(async move {
+                    fut.await
+                        .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
+                }) as zeph_memory::EmbedFuture
+            })
+            .await
+            .map_err(|e| McpError::Embedding(e.to_string()))?;
         tracing::info!(
             added = stats.added,
             updated = stats.updated,
@@ -168,7 +122,6 @@ impl McpToolRegistry {
             unchanged = stats.unchanged,
             "MCP tool embeddings synced"
         );
-
         Ok(stats)
     }
 
@@ -177,21 +130,15 @@ impl McpToolRegistry {
     where
         F: Fn(&str) -> EmbedFuture,
     {
-        let query_vec = match embed_fn(query).await {
-            Ok(v) => v,
-            Err(e) => {
-                tracing::warn!("failed to embed query: {e:#}");
-                return Vec::new();
-            }
-        };
-
-        let Ok(limit_u64) = u64::try_from(limit) else {
-            return Vec::new();
-        };
-
         let results = match self
-            .ops
-            .search(&self.collection, query_vec, limit_u64, None)
+            .registry
+            .search_raw(query, limit, |text| {
+                let fut = embed_fn(text);
+                Box::pin(async move {
+                    fut.await
+                        .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
+                }) as zeph_memory::EmbedFuture
+            })
             .await
         {
             Ok(r) => r,
@@ -204,9 +151,14 @@ impl McpToolRegistry {
         results
             .into_iter()
             .filter_map(|point| {
-                let server_id = extract_string(&point.payload, "server_id")?;
-                let name = extract_string(&point.payload, "tool_name")?;
-                let description = extract_string(&point.payload, "description").unwrap_or_default();
+                let server_id = point.payload.get("server_id")?.as_str()?.to_owned();
+                let name = point.payload.get("tool_name")?.as_str()?.to_owned();
+                let description = point
+                    .payload
+                    .get("description")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_owned();
                 Some(McpTool {
                     server_id,
                     name,
@@ -215,57 +167,6 @@ impl McpToolRegistry {
                 })
             })
             .collect()
-    }
-
-    async fn recreate_collection<F>(&self, embed_fn: &F) -> Result<(), McpError>
-    where
-        F: Fn(&str) -> EmbedFuture,
-    {
-        if self.ops.collection_exists(&self.collection).await? {
-            self.ops.delete_collection(&self.collection).await?;
-            tracing::info!(
-                collection = &self.collection,
-                "deleted MCP tools collection for recreation"
-            );
-        }
-        self.ensure_collection(embed_fn).await
-    }
-
-    async fn ensure_collection<F>(&self, embed_fn: &F) -> Result<(), McpError>
-    where
-        F: Fn(&str) -> EmbedFuture,
-    {
-        if self.ops.collection_exists(&self.collection).await? {
-            return Ok(());
-        }
-
-        let probe = embed_fn("dimension probe")
-            .await
-            .map_err(|e| McpError::Embedding(e.to_string()))?;
-        let vector_size = u64::try_from(probe.len())?;
-
-        self.ops
-            .ensure_collection(&self.collection, vector_size)
-            .await?;
-
-        tracing::info!(
-            collection = &self.collection,
-            dimensions = vector_size,
-            "created Qdrant collection for MCP tool embeddings"
-        );
-
-        Ok(())
-    }
-}
-
-fn extract_string(
-    payload: &HashMap<String, qdrant_client::qdrant::Value>,
-    key: &str,
-) -> Option<String> {
-    let val = payload.get(key)?;
-    match &val.kind {
-        Some(Kind::StringValue(s)) => Some(s.clone()),
-        _ => None,
     }
 }
 
@@ -283,10 +184,32 @@ mod tests {
     }
 
     #[test]
+    fn mcp_tool_ref_key() {
+        let tool = make_tool("github", "create_issue");
+        let r = McpToolRef::new(&tool);
+        assert_eq!(r.key(), "github:create_issue");
+    }
+
+    #[test]
+    fn mcp_tool_ref_embed_text() {
+        let tool = make_tool("s", "t");
+        let r = McpToolRef::new(&tool);
+        assert_eq!(r.embed_text(), "test");
+    }
+
+    #[test]
+    fn mcp_tool_ref_payload_has_key() {
+        let tool = make_tool("github", "create_issue");
+        let r = McpToolRef::new(&tool);
+        let payload = r.to_payload();
+        assert_eq!(payload["key"], "github:create_issue");
+    }
+
+    #[test]
     fn content_hash_deterministic() {
         let tool = make_tool("github", "create_issue");
-        let h1 = content_hash(&tool);
-        let h2 = content_hash(&tool);
+        let h1 = compute_hash(&tool);
+        let h2 = compute_hash(&tool);
         assert_eq!(h1, h2);
     }
 
@@ -295,30 +218,38 @@ mod tests {
         let t1 = make_tool("github", "create_issue");
         let mut t2 = make_tool("github", "create_issue");
         t2.description = "modified".into();
-        assert_ne!(content_hash(&t1), content_hash(&t2));
+        assert_ne!(compute_hash(&t1), compute_hash(&t2));
     }
 
     #[test]
-    fn tool_point_id_deterministic() {
-        let id1 = tool_point_id("github:create_issue");
-        let id2 = tool_point_id("github:create_issue");
-        assert_eq!(id1, id2);
+    fn content_hash_different_server_same_name() {
+        let t1 = McpTool {
+            server_id: "server-a".into(),
+            name: "tool".into(),
+            description: "test".into(),
+            input_schema: serde_json::json!({}),
+        };
+        let t2 = McpTool {
+            server_id: "server-b".into(),
+            name: "tool".into(),
+            description: "test".into(),
+            input_schema: serde_json::json!({}),
+        };
+        assert_ne!(compute_hash(&t1), compute_hash(&t2));
     }
 
     #[test]
-    fn tool_point_id_different_keys() {
-        let id1 = tool_point_id("github:create_issue");
-        let id2 = tool_point_id("fs:read_file");
-        assert_ne!(id1, id2);
+    fn content_hash_different_schema() {
+        let t1 = make_tool("s", "t");
+        let mut t2 = make_tool("s", "t");
+        t2.input_schema = serde_json::json!({"type": "object"});
+        assert_ne!(compute_hash(&t1), compute_hash(&t2));
     }
 
     #[test]
     fn sync_stats_default() {
         let stats = SyncStats::default();
         assert_eq!(stats.added, 0);
-        assert_eq!(stats.updated, 0);
-        assert_eq!(stats.removed, 0);
-        assert_eq!(stats.unchanged, 0);
     }
 
     #[test]
@@ -349,34 +280,9 @@ mod tests {
     }
 
     #[test]
-    fn content_hash_different_server_same_name() {
-        let t1 = McpTool {
-            server_id: "server-a".into(),
-            name: "tool".into(),
-            description: "test".into(),
-            input_schema: serde_json::json!({}),
-        };
-        let t2 = McpTool {
-            server_id: "server-b".into(),
-            name: "tool".into(),
-            description: "test".into(),
-            input_schema: serde_json::json!({}),
-        };
-        assert_ne!(content_hash(&t1), content_hash(&t2));
-    }
-
-    #[test]
-    fn content_hash_different_schema() {
-        let t1 = make_tool("s", "t");
-        let mut t2 = make_tool("s", "t");
-        t2.input_schema = serde_json::json!({"type": "object"});
-        assert_ne!(content_hash(&t1), content_hash(&t2));
-    }
-
-    #[test]
-    fn tool_point_id_is_valid_uuid() {
-        let id = tool_point_id("test:tool");
-        assert!(uuid::Uuid::parse_str(&id).is_ok());
+    fn registry_new_with_invalid_url_fails() {
+        let result = McpToolRegistry::new("not a valid url");
+        assert!(result.is_err());
     }
 
     #[test]
@@ -385,62 +291,9 @@ mod tests {
     }
 
     #[test]
-    fn extract_string_present() {
-        let mut payload = HashMap::new();
-        payload.insert(
-            "key".into(),
-            qdrant_client::qdrant::Value {
-                kind: Some(Kind::StringValue("hello".into())),
-            },
-        );
-        assert_eq!(extract_string(&payload, "key"), Some("hello".into()));
-    }
-
-    #[test]
-    fn extract_string_missing_key() {
-        let payload: HashMap<String, qdrant_client::qdrant::Value> = HashMap::new();
-        assert_eq!(extract_string(&payload, "missing"), None);
-    }
-
-    #[test]
-    fn extract_string_non_string_value() {
-        let mut payload = HashMap::new();
-        payload.insert(
-            "key".into(),
-            qdrant_client::qdrant::Value {
-                kind: Some(Kind::IntegerValue(42)),
-            },
-        );
-        assert_eq!(extract_string(&payload, "key"), None);
-    }
-
-    #[test]
-    fn extract_string_none_kind() {
-        let mut payload = HashMap::new();
-        payload.insert("key".into(), qdrant_client::qdrant::Value { kind: None });
-        assert_eq!(extract_string(&payload, "key"), None);
-    }
-
-    #[tokio::test]
-    async fn search_empty_registry_returns_empty() {
-        let registry = McpToolRegistry::new("http://localhost:6334").unwrap();
-        let embed_fn = |_: &str| -> crate::registry::EmbedFuture {
-            Box::pin(async { Err(zeph_llm::LlmError::Other("no qdrant".into())) })
-        };
-        let results = registry.search("test query", 5, embed_fn).await;
-        assert!(results.is_empty());
-    }
-
-    #[test]
-    fn registry_new_with_invalid_url_fails() {
-        let result = McpToolRegistry::new("not a valid url");
-        assert!(result.is_err());
-    }
-
-    #[test]
     fn content_hash_length_is_blake3_hex() {
         let tool = make_tool("server", "tool");
-        let hash = content_hash(&tool);
+        let hash = compute_hash(&tool);
         assert_eq!(hash.len(), 64);
     }
 
@@ -458,30 +311,14 @@ mod tests {
             description: "desc".into(),
             input_schema: serde_json::json!({"type": "string"}),
         };
-        assert_eq!(content_hash(&t1), content_hash(&t2));
+        assert_eq!(compute_hash(&t1), compute_hash(&t2));
     }
 
     #[test]
     fn content_hash_different_name_different_hash() {
         let t1 = make_tool("s", "tool_a");
         let t2 = make_tool("s", "tool_b");
-        assert_ne!(content_hash(&t1), content_hash(&t2));
-    }
-
-    #[test]
-    fn tool_point_id_format_uuid_v5() {
-        let id = tool_point_id("github:create_issue");
-        let parsed = uuid::Uuid::parse_str(&id).unwrap();
-        assert_eq!(parsed.get_version_num(), 5);
-    }
-
-    #[test]
-    fn tool_point_id_consistent_across_calls() {
-        let key = "server:tool_name";
-        let ids: Vec<String> = (0..10).map(|_| tool_point_id(key)).collect();
-        for id in &ids {
-            assert_eq!(id, &ids[0]);
-        }
+        assert_ne!(compute_hash(&t1), compute_hash(&t2));
     }
 
     #[test]
@@ -490,9 +327,19 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn search_empty_registry_returns_empty() {
+        let registry = McpToolRegistry::new("http://localhost:6334").unwrap();
+        let embed_fn = |_: &str| -> EmbedFuture {
+            Box::pin(async { Err(zeph_llm::LlmError::Other("no qdrant".into())) })
+        };
+        let results = registry.search("test query", 5, embed_fn).await;
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test]
     async fn search_with_embedding_failure_returns_empty() {
         let registry = McpToolRegistry::new("http://localhost:6334").unwrap();
-        let embed_fn = |_: &str| -> crate::registry::EmbedFuture {
+        let embed_fn = |_: &str| -> EmbedFuture {
             Box::pin(async {
                 Err(zeph_llm::LlmError::Other(
                     "embedding model not loaded".into(),
@@ -506,9 +353,7 @@ mod tests {
     #[tokio::test]
     async fn search_with_zero_limit() {
         let registry = McpToolRegistry::new("http://localhost:6334").unwrap();
-        let embed_fn = |_: &str| -> crate::registry::EmbedFuture {
-            Box::pin(async { Ok(vec![0.1, 0.2, 0.3]) })
-        };
+        let embed_fn = |_: &str| -> EmbedFuture { Box::pin(async { Ok(vec![0.1, 0.2, 0.3]) }) };
         let results = registry.search("query", 0, embed_fn).await;
         assert!(results.is_empty());
     }
@@ -517,9 +362,7 @@ mod tests {
     async fn sync_with_unreachable_qdrant_fails() {
         let mut registry = McpToolRegistry::new("http://127.0.0.1:1").unwrap();
         let tools = vec![make_tool("server", "tool")];
-        let embed_fn = |_: &str| -> crate::registry::EmbedFuture {
-            Box::pin(async { Ok(vec![0.1, 0.2, 0.3]) })
-        };
+        let embed_fn = |_: &str| -> EmbedFuture { Box::pin(async { Ok(vec![0.1, 0.2, 0.3]) }) };
         let result = registry.sync(&tools, "test-model", embed_fn).await;
         assert!(result.is_err());
     }
@@ -527,66 +370,8 @@ mod tests {
     #[tokio::test]
     async fn sync_with_empty_tools_and_unreachable_qdrant_fails() {
         let mut registry = McpToolRegistry::new("http://127.0.0.1:1").unwrap();
-        let embed_fn = |_: &str| -> crate::registry::EmbedFuture {
-            Box::pin(async { Ok(vec![0.1, 0.2, 0.3]) })
-        };
+        let embed_fn = |_: &str| -> EmbedFuture { Box::pin(async { Ok(vec![0.1, 0.2, 0.3]) }) };
         let result = registry.sync(&[], "test-model", embed_fn).await;
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn extract_string_from_double_value_returns_none() {
-        let mut payload = HashMap::new();
-        payload.insert(
-            "key".into(),
-            qdrant_client::qdrant::Value {
-                kind: Some(Kind::DoubleValue(3.14)),
-            },
-        );
-        assert_eq!(extract_string(&payload, "key"), None);
-    }
-
-    #[test]
-    fn extract_string_from_bool_value_returns_none() {
-        let mut payload = HashMap::new();
-        payload.insert(
-            "key".into(),
-            qdrant_client::qdrant::Value {
-                kind: Some(Kind::BoolValue(true)),
-            },
-        );
-        assert_eq!(extract_string(&payload, "key"), None);
-    }
-
-    #[test]
-    fn content_hash_empty_description() {
-        let tool = McpTool {
-            server_id: "s".into(),
-            name: "t".into(),
-            description: String::new(),
-            input_schema: serde_json::json!({}),
-        };
-        let hash = content_hash(&tool);
-        assert!(!hash.is_empty());
-    }
-
-    #[test]
-    fn tool_point_id_empty_key() {
-        let id = tool_point_id("");
-        assert!(uuid::Uuid::parse_str(&id).is_ok());
-    }
-
-    #[test]
-    fn sync_stats_all_fields_settable() {
-        let stats = SyncStats {
-            added: 10,
-            updated: 20,
-            removed: 5,
-            unchanged: 100,
-        };
-        assert_eq!(stats.added, 10);
-        assert_eq!(stats.updated, 20);
-        assert_eq!(stats.removed, 5);
-        assert_eq!(stats.unchanged, 100);
     }
 }

--- a/crates/zeph-memory/Cargo.toml
+++ b/crates/zeph-memory/Cargo.toml
@@ -16,7 +16,8 @@ sqlx = { workspace = true, features = ["runtime-tokio", "sqlite", "migrate"] }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt"] }
 tracing.workspace = true
-uuid = { workspace = true, features = ["v4"] }
+uuid = { workspace = true, features = ["v4", "v5"] }
+blake3.workspace = true
 zeph-llm.workspace = true
 
 [features]

--- a/crates/zeph-memory/src/embedding_registry.rs
+++ b/crates/zeph-memory/src/embedding_registry.rs
@@ -1,0 +1,480 @@
+//! Generic embedding registry backed by Qdrant.
+//!
+//! Provides deduplication through content-hash delta tracking and collection-level
+//! embedding-model change detection.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+
+use qdrant_client::qdrant::{PointStruct, value::Kind};
+
+use crate::QdrantOps;
+use crate::vector_store::VectorStoreError;
+
+/// Boxed future returned by an embedding function.
+pub type EmbedFuture = Pin<
+    Box<dyn Future<Output = Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>>> + Send>,
+>;
+
+/// Trait implemented by domain types that can be stored in an [`EmbeddingRegistry`].
+pub trait Embeddable: Send + Sync {
+    /// Unique string key used for point-ID generation and delta tracking.
+    fn key(&self) -> &str;
+
+    /// blake3 hex hash of all semantically relevant fields.
+    fn content_hash(&self) -> String;
+
+    /// Text that will be embedded (e.g. description).
+    fn embed_text(&self) -> &str;
+
+    /// Full JSON payload to store in Qdrant. **Must** include a `"key"` field
+    /// equal to [`Self::key()`] so [`EmbeddingRegistry`] can recover it on scroll.
+    fn to_payload(&self) -> serde_json::Value;
+}
+
+/// Counters returned by [`EmbeddingRegistry::sync`].
+#[derive(Debug, Default, Clone)]
+pub struct SyncStats {
+    pub added: usize,
+    pub updated: usize,
+    pub removed: usize,
+    pub unchanged: usize,
+}
+
+/// Errors produced by [`EmbeddingRegistry`].
+#[derive(Debug, thiserror::Error)]
+pub enum EmbeddingRegistryError {
+    #[error("vector store error: {0}")]
+    VectorStore(#[from] VectorStoreError),
+
+    #[error("embedding error: {0}")]
+    Embedding(String),
+
+    #[error("serialization error: {0}")]
+    Serialization(String),
+
+    #[error("dimension probe failed: {0}")]
+    DimensionProbe(String),
+}
+
+impl From<Box<qdrant_client::QdrantError>> for EmbeddingRegistryError {
+    fn from(e: Box<qdrant_client::QdrantError>) -> Self {
+        Self::VectorStore(VectorStoreError::Collection(e.to_string()))
+    }
+}
+
+impl From<serde_json::Error> for EmbeddingRegistryError {
+    fn from(e: serde_json::Error) -> Self {
+        Self::Serialization(e.to_string())
+    }
+}
+
+impl From<std::num::TryFromIntError> for EmbeddingRegistryError {
+    fn from(e: std::num::TryFromIntError) -> Self {
+        Self::DimensionProbe(e.to_string())
+    }
+}
+
+/// Generic Qdrant-backed embedding registry.
+///
+/// Owns a [`QdrantOps`] instance, a collection name and a UUID namespace for
+/// deterministic point IDs (uuid v5).  The in-memory `hashes` map enables
+/// O(1) delta detection between syncs.
+pub struct EmbeddingRegistry {
+    ops: QdrantOps,
+    collection: String,
+    namespace: uuid::Uuid,
+    hashes: HashMap<String, String>,
+}
+
+impl std::fmt::Debug for EmbeddingRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EmbeddingRegistry")
+            .field("collection", &self.collection)
+            .finish_non_exhaustive()
+    }
+}
+
+impl EmbeddingRegistry {
+    /// Create a registry wrapping an existing [`QdrantOps`] connection.
+    #[must_use]
+    pub fn new(ops: QdrantOps, collection: impl Into<String>, namespace: uuid::Uuid) -> Self {
+        Self {
+            ops,
+            collection: collection.into(),
+            namespace,
+            hashes: HashMap::new(),
+        }
+    }
+
+    /// Sync `items` into Qdrant, computing a content-hash delta to avoid
+    /// unnecessary re-embedding.  Re-creates the collection when the embedding
+    /// model changes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EmbeddingRegistryError`] on Qdrant or embedding failures.
+    pub async fn sync<T: Embeddable>(
+        &mut self,
+        items: &[T],
+        embedding_model: &str,
+        embed_fn: impl Fn(&str) -> EmbedFuture,
+    ) -> Result<SyncStats, EmbeddingRegistryError> {
+        let mut stats = SyncStats::default();
+
+        self.ensure_collection(&embed_fn).await?;
+
+        let existing = self
+            .ops
+            .scroll_all(&self.collection, "key")
+            .await
+            .map_err(|e| {
+                EmbeddingRegistryError::VectorStore(VectorStoreError::Scroll(e.to_string()))
+            })?;
+
+        let mut current: HashMap<String, (String, &T)> = HashMap::with_capacity(items.len());
+        for item in items {
+            current.insert(item.key().to_owned(), (item.content_hash(), item));
+        }
+
+        let model_changed = existing.values().any(|stored| {
+            stored
+                .get("embedding_model")
+                .is_some_and(|m| m != embedding_model)
+        });
+
+        if model_changed {
+            tracing::warn!("embedding model changed to '{embedding_model}', recreating collection");
+            self.recreate_collection(&embed_fn).await?;
+        }
+
+        let mut points_to_upsert = Vec::new();
+        for (key, (hash, item)) in &current {
+            let needs_update = if let Some(stored) = existing.get(key) {
+                model_changed || stored.get("content_hash").is_some_and(|h| h != hash)
+            } else {
+                true
+            };
+
+            if !needs_update {
+                stats.unchanged += 1;
+                self.hashes.insert(key.clone(), hash.clone());
+                continue;
+            }
+
+            let vector = match embed_fn(item.embed_text()).await {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!("failed to embed item '{key}': {e:#}");
+                    continue;
+                }
+            };
+
+            let point_id = self.point_id(key);
+            let mut payload = item.to_payload();
+            if let Some(obj) = payload.as_object_mut() {
+                obj.insert(
+                    "content_hash".into(),
+                    serde_json::Value::String(hash.clone()),
+                );
+                obj.insert(
+                    "embedding_model".into(),
+                    serde_json::Value::String(embedding_model.to_owned()),
+                );
+            }
+            let payload_map = QdrantOps::json_to_payload(payload)?;
+
+            points_to_upsert.push(PointStruct::new(point_id, vector, payload_map));
+
+            if existing.contains_key(key) {
+                stats.updated += 1;
+            } else {
+                stats.added += 1;
+            }
+            self.hashes.insert(key.clone(), hash.clone());
+        }
+
+        if !points_to_upsert.is_empty() {
+            self.ops
+                .upsert(&self.collection, points_to_upsert)
+                .await
+                .map_err(|e| {
+                    EmbeddingRegistryError::VectorStore(VectorStoreError::Upsert(e.to_string()))
+                })?;
+        }
+
+        let orphan_ids: Vec<qdrant_client::qdrant::PointId> = existing
+            .keys()
+            .filter(|key| !current.contains_key(*key))
+            .map(|key| qdrant_client::qdrant::PointId::from(self.point_id(key).as_str()))
+            .collect();
+
+        if !orphan_ids.is_empty() {
+            stats.removed = orphan_ids.len();
+            self.ops
+                .delete_by_ids(&self.collection, orphan_ids)
+                .await
+                .map_err(|e| {
+                    EmbeddingRegistryError::VectorStore(VectorStoreError::Delete(e.to_string()))
+                })?;
+        }
+
+        tracing::info!(
+            added = stats.added,
+            updated = stats.updated,
+            removed = stats.removed,
+            unchanged = stats.unchanged,
+            collection = &self.collection,
+            "embeddings synced"
+        );
+
+        Ok(stats)
+    }
+
+    /// Search the collection, returning raw scored Qdrant points.
+    ///
+    /// Consumers map the payloads to their domain types.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EmbeddingRegistryError`] if embedding or Qdrant search fails.
+    pub async fn search_raw(
+        &self,
+        query: &str,
+        limit: usize,
+        embed_fn: impl Fn(&str) -> EmbedFuture,
+    ) -> Result<Vec<crate::ScoredVectorPoint>, EmbeddingRegistryError> {
+        let query_vec = embed_fn(query)
+            .await
+            .map_err(|e| EmbeddingRegistryError::Embedding(e.to_string()))?;
+
+        let Ok(limit_u64) = u64::try_from(limit) else {
+            return Ok(Vec::new());
+        };
+
+        let results = self
+            .ops
+            .search(&self.collection, query_vec, limit_u64, None)
+            .await
+            .map_err(|e| {
+                EmbeddingRegistryError::VectorStore(VectorStoreError::Search(e.to_string()))
+            })?;
+
+        let scored: Vec<crate::ScoredVectorPoint> = results
+            .into_iter()
+            .map(|point| {
+                let payload: HashMap<String, serde_json::Value> = point
+                    .payload
+                    .into_iter()
+                    .filter_map(|(k, v)| {
+                        let json_val = match v.kind? {
+                            Kind::StringValue(s) => serde_json::Value::String(s),
+                            Kind::IntegerValue(i) => serde_json::Value::Number(i.into()),
+                            Kind::BoolValue(b) => serde_json::Value::Bool(b),
+                            Kind::DoubleValue(d) => {
+                                serde_json::Number::from_f64(d).map(serde_json::Value::Number)?
+                            }
+                            _ => return None,
+                        };
+                        Some((k, json_val))
+                    })
+                    .collect();
+
+                let id = match point.id.and_then(|pid| pid.point_id_options) {
+                    Some(qdrant_client::qdrant::point_id::PointIdOptions::Uuid(u)) => u,
+                    Some(qdrant_client::qdrant::point_id::PointIdOptions::Num(n)) => n.to_string(),
+                    None => String::new(),
+                };
+
+                crate::ScoredVectorPoint {
+                    id,
+                    score: point.score,
+                    payload,
+                }
+            })
+            .collect();
+
+        Ok(scored)
+    }
+
+    fn point_id(&self, key: &str) -> String {
+        uuid::Uuid::new_v5(&self.namespace, key.as_bytes()).to_string()
+    }
+
+    async fn ensure_collection(
+        &self,
+        embed_fn: &impl Fn(&str) -> EmbedFuture,
+    ) -> Result<(), EmbeddingRegistryError> {
+        if self
+            .ops
+            .collection_exists(&self.collection)
+            .await
+            .map_err(|e| {
+                EmbeddingRegistryError::VectorStore(VectorStoreError::Collection(e.to_string()))
+            })?
+        {
+            return Ok(());
+        }
+
+        let probe = embed_fn("dimension probe")
+            .await
+            .map_err(|e| EmbeddingRegistryError::DimensionProbe(e.to_string()))?;
+        let vector_size = u64::try_from(probe.len())?;
+
+        self.ops
+            .ensure_collection(&self.collection, vector_size)
+            .await
+            .map_err(|e| {
+                EmbeddingRegistryError::VectorStore(VectorStoreError::Collection(e.to_string()))
+            })?;
+
+        tracing::info!(
+            collection = &self.collection,
+            dimensions = vector_size,
+            "created Qdrant collection"
+        );
+
+        Ok(())
+    }
+
+    async fn recreate_collection(
+        &self,
+        embed_fn: &impl Fn(&str) -> EmbedFuture,
+    ) -> Result<(), EmbeddingRegistryError> {
+        if self
+            .ops
+            .collection_exists(&self.collection)
+            .await
+            .map_err(|e| {
+                EmbeddingRegistryError::VectorStore(VectorStoreError::Collection(e.to_string()))
+            })?
+        {
+            self.ops
+                .delete_collection(&self.collection)
+                .await
+                .map_err(|e| {
+                    EmbeddingRegistryError::VectorStore(VectorStoreError::Collection(e.to_string()))
+                })?;
+            tracing::info!(
+                collection = &self.collection,
+                "deleted collection for recreation"
+            );
+        }
+        self.ensure_collection(embed_fn).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestItem {
+        k: String,
+        text: String,
+    }
+
+    impl Embeddable for TestItem {
+        fn key(&self) -> &str {
+            &self.k
+        }
+
+        fn content_hash(&self) -> String {
+            let mut hasher = blake3::Hasher::new();
+            hasher.update(self.text.as_bytes());
+            hasher.finalize().to_hex().to_string()
+        }
+
+        fn embed_text(&self) -> &str {
+            &self.text
+        }
+
+        fn to_payload(&self) -> serde_json::Value {
+            serde_json::json!({"key": self.k, "text": self.text})
+        }
+    }
+
+    fn make_item(k: &str, text: &str) -> TestItem {
+        TestItem {
+            k: k.into(),
+            text: text.into(),
+        }
+    }
+
+    #[test]
+    fn registry_new_valid_url() {
+        let ops = QdrantOps::new("http://localhost:6334").unwrap();
+        let ns = uuid::Uuid::from_bytes([0u8; 16]);
+        let reg = EmbeddingRegistry::new(ops, "test_col", ns);
+        let dbg = format!("{reg:?}");
+        assert!(dbg.contains("EmbeddingRegistry"));
+        assert!(dbg.contains("test_col"));
+    }
+
+    #[test]
+    fn embeddable_content_hash_deterministic() {
+        let item = make_item("key", "some text");
+        assert_eq!(item.content_hash(), item.content_hash());
+    }
+
+    #[test]
+    fn embeddable_content_hash_changes() {
+        let a = make_item("key", "text a");
+        let b = make_item("key", "text b");
+        assert_ne!(a.content_hash(), b.content_hash());
+    }
+
+    #[test]
+    fn embeddable_payload_contains_key() {
+        let item = make_item("my-key", "desc");
+        let payload = item.to_payload();
+        assert_eq!(payload["key"], "my-key");
+    }
+
+    #[test]
+    fn sync_stats_default() {
+        let s = SyncStats::default();
+        assert_eq!(s.added, 0);
+        assert_eq!(s.updated, 0);
+        assert_eq!(s.removed, 0);
+        assert_eq!(s.unchanged, 0);
+    }
+
+    #[test]
+    fn sync_stats_debug() {
+        let s = SyncStats {
+            added: 1,
+            updated: 2,
+            removed: 3,
+            unchanged: 4,
+        };
+        let dbg = format!("{s:?}");
+        assert!(dbg.contains("added"));
+    }
+
+    #[tokio::test]
+    async fn search_raw_embed_fail_returns_error() {
+        let ops = QdrantOps::new("http://localhost:6334").unwrap();
+        let ns = uuid::Uuid::from_bytes([0u8; 16]);
+        let reg = EmbeddingRegistry::new(ops, "test", ns);
+        let embed_fn = |_: &str| -> EmbedFuture {
+            Box::pin(async {
+                Err(Box::new(std::io::Error::other("fail"))
+                    as Box<dyn std::error::Error + Send + Sync>)
+            })
+        };
+        let result = reg.search_raw("query", 5, embed_fn).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn sync_with_unreachable_qdrant_fails() {
+        let ops = QdrantOps::new("http://127.0.0.1:1").unwrap();
+        let ns = uuid::Uuid::from_bytes([0u8; 16]);
+        let mut reg = EmbeddingRegistry::new(ops, "test", ns);
+        let items = vec![make_item("k", "text")];
+        let embed_fn = |_: &str| -> EmbedFuture { Box::pin(async { Ok(vec![0.1_f32, 0.2]) }) };
+        let result = reg.sync(&items, "model", embed_fn).await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/zeph-memory/src/lib.rs
+++ b/crates/zeph-memory/src/lib.rs
@@ -1,6 +1,7 @@
 //! SQLite-backed conversation persistence with Qdrant vector search.
 
 pub mod document;
+pub mod embedding_registry;
 pub mod embedding_store;
 pub mod error;
 #[cfg(feature = "mock")]
@@ -16,6 +17,9 @@ pub use document::PdfLoader;
 pub use document::{
     Chunk, Document, DocumentError, DocumentLoader, DocumentMetadata, IngestionPipeline,
     SplitterConfig, TextLoader, TextSplitter,
+};
+pub use embedding_registry::{
+    EmbedFuture, Embeddable, EmbeddingRegistry, EmbeddingRegistryError, SyncStats,
 };
 pub use embedding_store::ensure_qdrant_collection;
 pub use error::MemoryError;


### PR DESCRIPTION
## Summary

- Extract `Embeddable` trait and `EmbeddingRegistry<T>` in zeph-memory — generic Qdrant collection management, content hashing, delta sync, and vector search
- Refactor `QdrantSkillMatcher` to delegate to `EmbeddingRegistry` (thin wrapper)
- Refactor `McpToolRegistry` to delegate to `EmbeddingRegistry` (thin wrapper)
- Move `SyncStats` to zeph-memory (single source of truth)
- Net reduction: ~350 lines removed across both consumers

Closes #619, closes #630, closes #631, closes #632

## Changes

- New `crates/zeph-memory/src/embedding_registry.rs` with `Embeddable`, `EmbeddingRegistry<T>`, `SyncStats`, `EmbeddingRegistryError`, `EmbedFuture`
- `crates/zeph-skills/src/qdrant_matcher.rs` — `impl Embeddable for &SkillMeta`, thin wrapper
- `crates/zeph-mcp/src/registry.rs` — `McpToolRef` wrapper, `impl Embeddable`, thin wrapper

## Test plan

- [x] 2046 workspace tests pass, 0 failures
- [x] clippy zero warnings, fmt clean
- [x] Performance verified: no regressions vs original (Embeddable for &SkillMeta avoids clone)
- [x] Public APIs unchanged — backward compatible