### PR TITLE
refactor(core): decompose agent module into focused submodules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - A2A client stream errors truncate upstream body to 256 bytes
 - Add `default_client()` HTTP helper with standard timeouts and user-agent in zeph-core and zeph-llm (#666)
 - Replace 5 production `Client::new()` calls with `default_client()` for consistent HTTP config (#667)
+- Decompose agent/mod.rs (2602→459 lines) into tool_execution, message_queue, builder, commands, and utils modules (#648, #649, #650)
 
 ### Fixed
 - False positive: "sudoku" no longer matched by "sudo" blocked pattern (word-boundary matching)

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1,0 +1,246 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tokio::sync::{Notify, mpsc, watch};
+use zeph_llm::any::AnyProvider;
+use zeph_llm::provider::LlmProvider;
+
+use crate::channel::Channel;
+use crate::config::{LearningConfig, SecurityConfig, TimeoutConfig};
+use crate::config_watcher::ConfigEvent;
+use crate::context::ContextBudget;
+use crate::cost::CostTracker;
+use crate::metrics::MetricsSnapshot;
+use zeph_memory::semantic::SemanticMemory;
+use zeph_skills::watcher::SkillEvent;
+use zeph_tools::executor::ToolExecutor;
+
+use super::Agent;
+
+impl<C: Channel, T: ToolExecutor> Agent<C, T> {
+    #[must_use]
+    pub fn with_stt(mut self, stt: Box<dyn zeph_llm::stt::SpeechToText>) -> Self {
+        self.stt = Some(stt);
+        self
+    }
+
+    #[must_use]
+    pub fn with_update_notifications(mut self, rx: mpsc::Receiver<String>) -> Self {
+        self.update_notify_rx = Some(rx);
+        self
+    }
+
+    #[must_use]
+    pub fn with_max_tool_iterations(mut self, max: usize) -> Self {
+        self.runtime.max_tool_iterations = max;
+        self
+    }
+
+    #[must_use]
+    pub fn with_memory(
+        mut self,
+        memory: SemanticMemory,
+        conversation_id: zeph_memory::ConversationId,
+        history_limit: u32,
+        recall_limit: usize,
+        summarization_threshold: usize,
+    ) -> Self {
+        let has_qdrant = memory.has_qdrant();
+        self.memory_state.memory = Some(memory);
+        self.memory_state.conversation_id = Some(conversation_id);
+        self.memory_state.history_limit = history_limit;
+        self.memory_state.recall_limit = recall_limit;
+        self.memory_state.summarization_threshold = summarization_threshold;
+        self.update_metrics(|m| {
+            m.qdrant_available = has_qdrant;
+            m.sqlite_conversation_id = Some(conversation_id);
+        });
+        self
+    }
+
+    #[must_use]
+    pub fn with_embedding_model(mut self, model: String) -> Self {
+        self.skill_state.embedding_model = model;
+        self
+    }
+
+    #[must_use]
+    pub fn with_disambiguation_threshold(mut self, threshold: f32) -> Self {
+        self.skill_state.disambiguation_threshold = threshold;
+        self
+    }
+
+    #[must_use]
+    pub fn with_shutdown(mut self, rx: watch::Receiver<bool>) -> Self {
+        self.shutdown = rx;
+        self
+    }
+
+    #[must_use]
+    pub fn with_skill_reload(
+        mut self,
+        paths: Vec<PathBuf>,
+        rx: mpsc::Receiver<SkillEvent>,
+    ) -> Self {
+        self.skill_state.skill_paths = paths;
+        self.skill_state.skill_reload_rx = Some(rx);
+        self
+    }
+
+    #[must_use]
+    pub fn with_config_reload(mut self, path: PathBuf, rx: mpsc::Receiver<ConfigEvent>) -> Self {
+        self.config_path = Some(path);
+        self.config_reload_rx = Some(rx);
+        self
+    }
+
+    #[must_use]
+    pub fn with_learning(mut self, config: LearningConfig) -> Self {
+        self.learning_config = Some(config);
+        self
+    }
+
+    #[must_use]
+    pub fn with_mcp(
+        mut self,
+        tools: Vec<zeph_mcp::McpTool>,
+        registry: Option<zeph_mcp::McpToolRegistry>,
+        manager: Option<std::sync::Arc<zeph_mcp::McpManager>>,
+        mcp_config: &crate::config::McpConfig,
+    ) -> Self {
+        self.mcp.tools = tools;
+        self.mcp.registry = registry;
+        self.mcp.manager = manager;
+        self.mcp
+            .allowed_commands
+            .clone_from(&mcp_config.allowed_commands);
+        self.mcp.max_dynamic = mcp_config.max_dynamic_servers;
+        self
+    }
+
+    #[must_use]
+    pub fn with_security(mut self, security: SecurityConfig, timeouts: TimeoutConfig) -> Self {
+        self.runtime.security = security;
+        self.runtime.timeouts = timeouts;
+        self
+    }
+
+    #[must_use]
+    pub fn with_tool_summarization(mut self, enabled: bool) -> Self {
+        self.runtime.summarize_tool_output_enabled = enabled;
+        self
+    }
+
+    #[must_use]
+    pub fn with_summary_provider(mut self, provider: AnyProvider) -> Self {
+        self.summary_provider = Some(provider);
+        self
+    }
+
+    pub(super) fn summary_or_primary_provider(&self) -> &AnyProvider {
+        self.summary_provider.as_ref().unwrap_or(&self.provider)
+    }
+
+    #[must_use]
+    pub fn with_permission_policy(mut self, policy: zeph_tools::PermissionPolicy) -> Self {
+        self.runtime.permission_policy = policy;
+        self
+    }
+
+    #[must_use]
+    pub fn with_context_budget(
+        mut self,
+        budget_tokens: usize,
+        reserve_ratio: f32,
+        compaction_threshold: f32,
+        compaction_preserve_tail: usize,
+        prune_protect_tokens: usize,
+    ) -> Self {
+        if budget_tokens > 0 {
+            self.context_state.budget = Some(ContextBudget::new(budget_tokens, reserve_ratio));
+        }
+        self.context_state.compaction_threshold = compaction_threshold;
+        self.context_state.compaction_preserve_tail = compaction_preserve_tail;
+        self.context_state.prune_protect_tokens = prune_protect_tokens;
+        self
+    }
+
+    #[must_use]
+    pub fn with_model_name(mut self, name: impl Into<String>) -> Self {
+        self.runtime.model_name = name.into();
+        self
+    }
+
+    #[must_use]
+    pub fn with_warmup_ready(mut self, rx: watch::Receiver<bool>) -> Self {
+        self.warmup_ready = Some(rx);
+        self
+    }
+
+    #[must_use]
+    pub fn with_cost_tracker(mut self, tracker: CostTracker) -> Self {
+        self.cost_tracker = Some(tracker);
+        self
+    }
+
+    #[cfg(feature = "index")]
+    #[must_use]
+    pub fn with_code_retriever(
+        mut self,
+        retriever: std::sync::Arc<zeph_index::retriever::CodeRetriever>,
+        repo_map_tokens: usize,
+        repo_map_ttl_secs: u64,
+    ) -> Self {
+        self.index.retriever = Some(retriever);
+        self.index.repo_map_tokens = repo_map_tokens;
+        self.index.repo_map_ttl = std::time::Duration::from_secs(repo_map_ttl_secs);
+        self
+    }
+
+    #[must_use]
+    pub fn with_metrics(mut self, tx: watch::Sender<MetricsSnapshot>) -> Self {
+        let provider_name = self.provider.name().to_string();
+        let model_name = self.runtime.model_name.clone();
+        let total_skills = self.skill_state.registry.all_meta().len();
+        let qdrant_available = self
+            .memory_state
+            .memory
+            .as_ref()
+            .is_some_and(zeph_memory::semantic::SemanticMemory::has_qdrant);
+        let conversation_id = self.memory_state.conversation_id;
+        let prompt_estimate = self
+            .messages
+            .first()
+            .map_or(0, |m| u64::try_from(m.content.len()).unwrap_or(0) / 4);
+        let mcp_tool_count = self.mcp.tools.len();
+        let mcp_server_count = self
+            .mcp
+            .tools
+            .iter()
+            .map(|t| &t.server_id)
+            .collect::<std::collections::HashSet<_>>()
+            .len();
+        tx.send_modify(|m| {
+            m.provider_name = provider_name;
+            m.model_name = model_name;
+            m.total_skills = total_skills;
+            m.qdrant_available = qdrant_available;
+            m.sqlite_conversation_id = conversation_id;
+            m.context_tokens = prompt_estimate;
+            m.prompt_tokens = prompt_estimate;
+            m.total_tokens = prompt_estimate;
+            m.mcp_tool_count = mcp_tool_count;
+            m.mcp_server_count = mcp_server_count;
+        });
+        self.metrics_tx = Some(tx);
+        self
+    }
+
+    /// Returns a handle that can cancel the current in-flight operation.
+    /// The returned `Notify` is stable across messages — callers invoke
+    /// `notify_waiters()` to cancel whatever operation is running.
+    #[must_use]
+    pub fn cancel_signal(&self) -> Arc<Notify> {
+        Arc::clone(&self.cancel_signal)
+    }
+}

--- a/crates/zeph-core/src/agent/commands.rs
+++ b/crates/zeph-core/src/agent/commands.rs
@@ -1,0 +1,198 @@
+use zeph_llm::provider::LlmProvider;
+use zeph_skills::loader::Skill;
+use zeph_skills::matcher::{SkillMatcher, SkillMatcherBackend};
+use zeph_skills::prompt::format_skills_prompt;
+use zeph_skills::registry::SkillRegistry;
+
+use crate::channel::Channel;
+use crate::config::Config;
+use crate::context::{ContextBudget, build_system_prompt};
+use zeph_tools::executor::ToolExecutor;
+
+use super::{Agent, error};
+
+impl<C: Channel, T: ToolExecutor> Agent<C, T> {
+    pub(super) async fn handle_skills_command(&mut self) -> Result<(), error::AgentError> {
+        use std::fmt::Write;
+
+        let mut output = String::from("Available skills:\n\n");
+
+        for meta in self.skill_state.registry.all_meta() {
+            let trust_info = if let Some(memory) = &self.memory_state.memory {
+                memory
+                    .sqlite()
+                    .load_skill_trust(&meta.name)
+                    .await
+                    .ok()
+                    .flatten()
+                    .map_or_else(String::new, |r| format!(" [{}]", r.trust_level))
+            } else {
+                String::new()
+            };
+            let _ = writeln!(output, "- {} — {}{trust_info}", meta.name, meta.description);
+        }
+
+        if let Some(memory) = &self.memory_state.memory {
+            match memory.sqlite().load_skill_usage().await {
+                Ok(usage) if !usage.is_empty() => {
+                    output.push_str("\nUsage statistics:\n\n");
+                    for row in &usage {
+                        let _ = writeln!(
+                            output,
+                            "- {}: {} invocations (last: {})",
+                            row.skill_name, row.invocation_count, row.last_used_at,
+                        );
+                    }
+                }
+                Ok(_) => {}
+                Err(e) => tracing::warn!("failed to load skill usage: {e:#}"),
+            }
+        }
+
+        self.channel.send(&output).await?;
+        Ok(())
+    }
+
+    pub(super) async fn handle_feedback(&mut self, input: &str) -> Result<(), error::AgentError> {
+        let Some((name, rest)) = input.split_once(' ') else {
+            self.channel
+                .send("Usage: /feedback <skill_name> <message>")
+                .await?;
+            return Ok(());
+        };
+        let (skill_name, feedback) = (name.trim(), rest.trim().trim_matches('"'));
+
+        if feedback.is_empty() {
+            self.channel
+                .send("Usage: /feedback <skill_name> <message>")
+                .await?;
+            return Ok(());
+        }
+
+        let Some(memory) = &self.memory_state.memory else {
+            self.channel.send("Memory not available.").await?;
+            return Ok(());
+        };
+
+        memory
+            .sqlite()
+            .record_skill_outcome(
+                skill_name,
+                None,
+                self.memory_state.conversation_id,
+                "user_rejection",
+                Some(feedback),
+            )
+            .await?;
+
+        if self.is_learning_enabled() {
+            self.generate_improved_skill(skill_name, feedback, "", Some(feedback))
+                .await
+                .ok();
+        }
+
+        self.channel
+            .send(&format!("Feedback recorded for \"{skill_name}\"."))
+            .await?;
+        Ok(())
+    }
+
+    pub(super) async fn reload_skills(&mut self) {
+        let new_registry = SkillRegistry::load(&self.skill_state.skill_paths);
+        if new_registry.fingerprint() == self.skill_state.registry.fingerprint() {
+            return;
+        }
+        self.skill_state.registry = new_registry;
+
+        let all_meta = self.skill_state.registry.all_meta();
+        let provider = self.provider.clone();
+        let embed_fn = |text: &str| -> zeph_skills::matcher::EmbedFuture {
+            let owned = text.to_owned();
+            let p = provider.clone();
+            Box::pin(async move { p.embed(&owned).await })
+        };
+
+        let needs_inmemory_rebuild = !self
+            .skill_state
+            .matcher
+            .as_ref()
+            .is_some_and(SkillMatcherBackend::is_qdrant);
+
+        if needs_inmemory_rebuild {
+            self.skill_state.matcher = SkillMatcher::new(&all_meta, embed_fn)
+                .await
+                .map(SkillMatcherBackend::InMemory);
+        } else if let Some(ref mut backend) = self.skill_state.matcher
+            && let Err(e) = backend
+                .sync(&all_meta, &self.skill_state.embedding_model, embed_fn)
+                .await
+        {
+            tracing::warn!("failed to sync skill embeddings: {e:#}");
+        }
+
+        let all_skills: Vec<Skill> = self
+            .skill_state
+            .registry
+            .all_meta()
+            .iter()
+            .filter_map(|m| self.skill_state.registry.get_skill(&m.name).ok())
+            .collect();
+        let trust_map = self.build_skill_trust_map().await;
+        let skills_prompt = format_skills_prompt(&all_skills, std::env::consts::OS, &trust_map);
+        self.skill_state
+            .last_skills_prompt
+            .clone_from(&skills_prompt);
+        let system_prompt = build_system_prompt(&skills_prompt, None, None, false);
+        if let Some(msg) = self.messages.first_mut() {
+            msg.content = system_prompt;
+        }
+
+        tracing::info!(
+            "reloaded {} skill(s)",
+            self.skill_state.registry.all_meta().len()
+        );
+    }
+
+    pub(super) fn reload_config(&mut self) {
+        let Some(ref path) = self.config_path else {
+            return;
+        };
+        let config = match Config::load(path) {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!("config reload failed: {e:#}");
+                return;
+            }
+        };
+
+        self.runtime.security = config.security;
+        self.runtime.timeouts = config.timeouts;
+        self.memory_state.history_limit = config.memory.history_limit;
+        self.memory_state.recall_limit = config.memory.semantic.recall_limit;
+        self.memory_state.summarization_threshold = config.memory.summarization_threshold;
+        self.skill_state.max_active_skills = config.skills.max_active_skills;
+        self.skill_state.disambiguation_threshold = config.skills.disambiguation_threshold;
+
+        if config.memory.context_budget_tokens > 0 {
+            self.context_state.budget = Some(ContextBudget::new(
+                config.memory.context_budget_tokens,
+                0.20,
+            ));
+        } else {
+            self.context_state.budget = None;
+        }
+        self.context_state.compaction_threshold = config.memory.compaction_threshold;
+        self.context_state.compaction_preserve_tail = config.memory.compaction_preserve_tail;
+        self.context_state.prune_protect_tokens = config.memory.prune_protect_tokens;
+        self.memory_state.cross_session_score_threshold =
+            config.memory.cross_session_score_threshold;
+
+        #[cfg(feature = "index")]
+        {
+            self.index.repo_map_ttl =
+                std::time::Duration::from_secs(config.index.repo_map_ttl_secs);
+        }
+
+        tracing::info!("config reloaded");
+    }
+}

--- a/crates/zeph-core/src/agent/message_queue.rs
+++ b/crates/zeph-core/src/agent/message_queue.rs
@@ -1,0 +1,696 @@
+use std::time::{Duration, Instant};
+
+use crate::channel::Channel;
+use zeph_tools::executor::ToolExecutor;
+
+use super::Agent;
+
+pub(super) const MAX_QUEUE_SIZE: usize = 10;
+pub(super) const MESSAGE_MERGE_WINDOW: Duration = Duration::from_millis(500);
+pub(super) const MAX_AUDIO_BYTES: usize = 25 * 1024 * 1024;
+pub(super) const MAX_IMAGE_BYTES: usize = 20 * 1024 * 1024;
+
+pub(super) struct QueuedMessage {
+    pub(super) text: String,
+    pub(super) received_at: Instant,
+    pub(super) image_parts: Vec<zeph_llm::provider::MessagePart>,
+    pub(super) raw_attachments: Vec<crate::channel::Attachment>,
+}
+
+pub(super) fn detect_image_mime(filename: Option<&str>) -> &'static str {
+    let ext = filename
+        .and_then(|f| std::path::Path::new(f).extension())
+        .and_then(|e| e.to_str())
+        .unwrap_or("");
+    if ext.eq_ignore_ascii_case("jpg") || ext.eq_ignore_ascii_case("jpeg") {
+        "image/jpeg"
+    } else if ext.eq_ignore_ascii_case("gif") {
+        "image/gif"
+    } else if ext.eq_ignore_ascii_case("webp") {
+        "image/webp"
+    } else {
+        "image/png"
+    }
+}
+
+impl<C: Channel, T: ToolExecutor> Agent<C, T> {
+    pub(super) fn drain_channel(&mut self) {
+        while self.message_queue.len() < MAX_QUEUE_SIZE {
+            let Some(msg) = self.channel.try_recv() else {
+                break;
+            };
+            if msg.text.trim() == "/drop-last-queued" {
+                self.message_queue.pop_back();
+                continue;
+            }
+            self.enqueue_or_merge(msg.text, vec![], msg.attachments);
+        }
+    }
+
+    pub(super) fn enqueue_or_merge(
+        &mut self,
+        text: String,
+        image_parts: Vec<zeph_llm::provider::MessagePart>,
+        raw_attachments: Vec<crate::channel::Attachment>,
+    ) {
+        let now = Instant::now();
+        if let Some(last) = self.message_queue.back_mut()
+            && now.duration_since(last.received_at) < MESSAGE_MERGE_WINDOW
+            && last.image_parts.is_empty()
+            && image_parts.is_empty()
+            && last.raw_attachments.is_empty()
+            && raw_attachments.is_empty()
+        {
+            last.text.push('\n');
+            last.text.push_str(&text);
+            return;
+        }
+        if self.message_queue.len() < MAX_QUEUE_SIZE {
+            self.message_queue.push_back(QueuedMessage {
+                text,
+                received_at: now,
+                image_parts,
+                raw_attachments,
+            });
+        } else {
+            tracing::warn!("message queue full, dropping message");
+        }
+    }
+
+    pub(super) async fn notify_queue_count(&mut self) {
+        let count = self.message_queue.len();
+        let _ = self.channel.send_queue_count(count).await;
+    }
+
+    pub(super) fn clear_queue(&mut self) -> usize {
+        let count = self.message_queue.len();
+        self.message_queue.clear();
+        count
+    }
+
+    pub(super) async fn resolve_message(
+        &self,
+        msg: crate::channel::ChannelMessage,
+    ) -> (String, Vec<zeph_llm::provider::MessagePart>) {
+        use crate::channel::{Attachment, AttachmentKind};
+        use zeph_llm::provider::MessagePart;
+
+        let text_base = msg.text.clone();
+
+        let (audio_attachments, image_attachments): (Vec<Attachment>, Vec<Attachment>) = msg
+            .attachments
+            .into_iter()
+            .partition(|a| a.kind == AttachmentKind::Audio);
+
+        tracing::debug!(
+            audio = audio_attachments.len(),
+            has_stt = self.stt.is_some(),
+            "resolve_message attachments"
+        );
+
+        let text = if !audio_attachments.is_empty()
+            && let Some(stt) = self.stt.as_ref()
+        {
+            let mut transcribed_parts = Vec::new();
+            for attachment in &audio_attachments {
+                if attachment.data.len() > MAX_AUDIO_BYTES {
+                    tracing::warn!(
+                        size = attachment.data.len(),
+                        max = MAX_AUDIO_BYTES,
+                        "audio attachment exceeds size limit, skipping"
+                    );
+                    continue;
+                }
+                match stt
+                    .transcribe(&attachment.data, attachment.filename.as_deref())
+                    .await
+                {
+                    Ok(result) => {
+                        tracing::info!(
+                            len = result.text.len(),
+                            language = ?result.language,
+                            "audio transcribed"
+                        );
+                        transcribed_parts.push(result.text);
+                    }
+                    Err(e) => {
+                        tracing::error!(error = %e, "audio transcription failed");
+                    }
+                }
+            }
+            if transcribed_parts.is_empty() {
+                text_base
+            } else {
+                let transcribed = transcribed_parts.join("\n");
+                if text_base.is_empty() {
+                    transcribed
+                } else {
+                    format!("[transcribed audio]\n{transcribed}\n\n{text_base}")
+                }
+            }
+        } else {
+            if !audio_attachments.is_empty() {
+                tracing::warn!(
+                    count = audio_attachments.len(),
+                    "audio attachments received but no STT provider configured, dropping"
+                );
+            }
+            text_base
+        };
+
+        let mut image_parts = Vec::new();
+        for attachment in image_attachments {
+            if attachment.data.len() > MAX_IMAGE_BYTES {
+                tracing::warn!(
+                    size = attachment.data.len(),
+                    max = MAX_IMAGE_BYTES,
+                    "image attachment exceeds size limit, skipping"
+                );
+                continue;
+            }
+            let mime_type = detect_image_mime(attachment.filename.as_deref()).to_string();
+            image_parts.push(MessagePart::Image {
+                data: attachment.data,
+                mime_type,
+            });
+        }
+
+        (text, image_parts)
+    }
+
+    pub(super) async fn handle_image_command(
+        &mut self,
+        path: &str,
+        extra_parts: &mut Vec<zeph_llm::provider::MessagePart>,
+    ) -> Result<(), super::error::AgentError> {
+        use std::path::Component;
+        use zeph_llm::provider::MessagePart;
+
+        // Reject paths that traverse outside the current directory.
+        let has_parent_dir = std::path::Path::new(path)
+            .components()
+            .any(|c| c == Component::ParentDir);
+        if has_parent_dir {
+            self.channel
+                .send("Invalid image path: path traversal not allowed")
+                .await?;
+            return Ok(());
+        }
+
+        let data = match std::fs::read(path) {
+            Ok(d) => d,
+            Err(e) => {
+                self.channel
+                    .send(&format!("Cannot read image {path}: {e}"))
+                    .await?;
+                return Ok(());
+            }
+        };
+        if data.len() > MAX_IMAGE_BYTES {
+            self.channel
+                .send(&format!(
+                    "Image {path} exceeds size limit ({} MB), skipping",
+                    MAX_IMAGE_BYTES / 1024 / 1024
+                ))
+                .await?;
+            return Ok(());
+        }
+        let mime_type = detect_image_mime(Some(path)).to_string();
+        extra_parts.push(MessagePart::Image { data, mime_type });
+        self.channel
+            .send(&format!("Image loaded: {path}. Send your message."))
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::agent_tests::{
+        MockChannel, MockToolExecutor, create_test_registry, mock_provider,
+    };
+    use super::*;
+
+    #[test]
+    fn enqueue_or_merge_adds_new_message() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+        agent.enqueue_or_merge("hello".into(), vec![], vec![]);
+        assert_eq!(agent.message_queue.len(), 1);
+        assert_eq!(agent.message_queue[0].text, "hello");
+    }
+
+    #[test]
+    fn enqueue_or_merge_merges_within_window() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+        agent.enqueue_or_merge("first".into(), vec![], vec![]);
+        agent.enqueue_or_merge("second".into(), vec![], vec![]);
+        assert_eq!(agent.message_queue.len(), 1);
+        assert_eq!(agent.message_queue[0].text, "first\nsecond");
+    }
+
+    #[test]
+    fn enqueue_or_merge_no_merge_after_window() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+        agent.message_queue.push_back(QueuedMessage {
+            text: "old".into(),
+            received_at: Instant::now() - Duration::from_secs(2),
+            image_parts: vec![],
+            raw_attachments: vec![],
+        });
+        agent.enqueue_or_merge("new".into(), vec![], vec![]);
+        assert_eq!(agent.message_queue.len(), 2);
+        assert_eq!(agent.message_queue[0].text, "old");
+        assert_eq!(agent.message_queue[1].text, "new");
+    }
+
+    #[test]
+    fn enqueue_or_merge_respects_max_queue_size() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+        for i in 0..MAX_QUEUE_SIZE {
+            agent.message_queue.push_back(QueuedMessage {
+                text: format!("msg{i}"),
+                received_at: Instant::now() - Duration::from_secs(2),
+                image_parts: vec![],
+                raw_attachments: vec![],
+            });
+        }
+        agent.enqueue_or_merge("overflow".into(), vec![], vec![]);
+        assert_eq!(agent.message_queue.len(), MAX_QUEUE_SIZE);
+    }
+
+    #[test]
+    fn clear_queue_returns_count_and_empties() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+        agent.enqueue_or_merge("a".into(), vec![], vec![]);
+        // Wait past merge window
+        agent.message_queue.back_mut().unwrap().received_at =
+            Instant::now() - Duration::from_secs(1);
+        agent.enqueue_or_merge("b".into(), vec![], vec![]);
+        assert_eq!(agent.message_queue.len(), 2);
+
+        let count = agent.clear_queue();
+        assert_eq!(count, 2);
+        assert!(agent.message_queue.is_empty());
+    }
+
+    #[test]
+    fn drain_channel_fills_queue() {
+        let messages: Vec<String> = (0..5).map(|i| format!("msg{i}")).collect();
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(messages);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+        agent.drain_channel();
+        // All 5 messages arrive within the merge window, so they merge into 1
+        assert_eq!(agent.message_queue.len(), 1);
+        assert!(agent.message_queue[0].text.contains("msg0"));
+        assert!(agent.message_queue[0].text.contains("msg4"));
+    }
+
+    #[test]
+    fn drain_channel_stops_at_max_queue_size() {
+        let messages: Vec<String> = (0..15).map(|i| format!("msg{i}")).collect();
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(messages);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+        // Pre-fill queue to near capacity with old timestamps (outside merge window)
+        for i in 0..MAX_QUEUE_SIZE - 1 {
+            agent.message_queue.push_back(QueuedMessage {
+                text: format!("pre{i}"),
+                received_at: Instant::now() - Duration::from_secs(2),
+                image_parts: vec![],
+                raw_attachments: vec![],
+            });
+        }
+        agent.drain_channel();
+        // One more slot was available; all 15 messages merge into it
+        assert_eq!(agent.message_queue.len(), MAX_QUEUE_SIZE);
+    }
+
+    #[test]
+    fn queue_fifo_order() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+        for i in 0..3 {
+            agent.message_queue.push_back(QueuedMessage {
+                text: format!("msg{i}"),
+                received_at: Instant::now() - Duration::from_secs(2),
+                image_parts: vec![],
+                raw_attachments: vec![],
+            });
+        }
+
+        assert_eq!(agent.message_queue.pop_front().unwrap().text, "msg0");
+        assert_eq!(agent.message_queue.pop_front().unwrap().text, "msg1");
+        assert_eq!(agent.message_queue.pop_front().unwrap().text, "msg2");
+    }
+
+    #[test]
+    fn detect_image_mime_standard() {
+        assert_eq!(detect_image_mime(Some("photo.jpg")), "image/jpeg");
+        assert_eq!(detect_image_mime(Some("photo.jpeg")), "image/jpeg");
+        assert_eq!(detect_image_mime(Some("anim.gif")), "image/gif");
+        assert_eq!(detect_image_mime(Some("img.webp")), "image/webp");
+        assert_eq!(detect_image_mime(Some("img.png")), "image/png");
+        assert_eq!(detect_image_mime(None), "image/png");
+    }
+
+    #[test]
+    fn detect_image_mime_uppercase() {
+        assert_eq!(detect_image_mime(Some("photo.JPG")), "image/jpeg");
+        assert_eq!(detect_image_mime(Some("photo.JPEG")), "image/jpeg");
+        assert_eq!(detect_image_mime(Some("anim.GIF")), "image/gif");
+        assert_eq!(detect_image_mime(Some("img.WEBP")), "image/webp");
+    }
+
+    #[test]
+    fn detect_image_mime_mixed_case() {
+        assert_eq!(detect_image_mime(Some("photo.Jpg")), "image/jpeg");
+        assert_eq!(detect_image_mime(Some("photo.JpEg")), "image/jpeg");
+        assert_eq!(detect_image_mime(Some("anim.Gif")), "image/gif");
+        assert_eq!(detect_image_mime(Some("img.WebP")), "image/webp");
+    }
+
+    #[test]
+    fn detect_image_mime_jpeg() {
+        assert_eq!(detect_image_mime(Some("photo.jpg")), "image/jpeg");
+        assert_eq!(detect_image_mime(Some("photo.jpeg")), "image/jpeg");
+    }
+
+    #[test]
+    fn detect_image_mime_gif() {
+        assert_eq!(detect_image_mime(Some("anim.gif")), "image/gif");
+    }
+
+    #[test]
+    fn detect_image_mime_webp() {
+        assert_eq!(detect_image_mime(Some("img.webp")), "image/webp");
+    }
+
+    #[test]
+    fn detect_image_mime_unknown_defaults_png() {
+        assert_eq!(detect_image_mime(Some("file.bmp")), "image/png");
+        assert_eq!(detect_image_mime(None), "image/png");
+    }
+
+    #[tokio::test]
+    async fn resolve_message_extracts_image_attachment() {
+        use crate::channel::{Attachment, AttachmentKind, ChannelMessage};
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+        let msg = ChannelMessage {
+            text: "look at this".into(),
+            attachments: vec![Attachment {
+                kind: AttachmentKind::Image,
+                data: vec![0u8; 16],
+                filename: Some("test.jpg".into()),
+            }],
+        };
+        let (text, parts) = agent.resolve_message(msg).await;
+        assert_eq!(text, "look at this");
+        assert_eq!(parts.len(), 1);
+        match &parts[0] {
+            zeph_llm::provider::MessagePart::Image { mime_type, data } => {
+                assert_eq!(mime_type, "image/jpeg");
+                assert_eq!(data.len(), 16);
+            }
+            _ => panic!("expected Image part"),
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_message_drops_oversized_image() {
+        use crate::channel::{Attachment, AttachmentKind, ChannelMessage};
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+        let msg = ChannelMessage {
+            text: "big image".into(),
+            attachments: vec![Attachment {
+                kind: AttachmentKind::Image,
+                data: vec![0u8; MAX_IMAGE_BYTES + 1],
+                filename: Some("huge.png".into()),
+            }],
+        };
+        let (text, parts) = agent.resolve_message(msg).await;
+        assert_eq!(text, "big image");
+        assert!(parts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn handle_image_command_rejects_path_traversal() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+        let mut parts = Vec::new();
+        let result = agent
+            .handle_image_command("../../etc/passwd", &mut parts)
+            .await;
+        assert!(result.is_ok());
+        assert!(parts.is_empty());
+        let sent = agent.channel.sent_messages();
+        assert!(sent.iter().any(|m| m.contains("traversal")));
+    }
+
+    #[tokio::test]
+    async fn handle_image_command_missing_file_sends_error() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+        let mut parts = Vec::new();
+        let result = agent
+            .handle_image_command("/nonexistent/image.png", &mut parts)
+            .await;
+        assert!(result.is_ok());
+        assert!(parts.is_empty());
+        let sent = agent.channel.sent_messages();
+        assert!(sent.iter().any(|m| m.contains("Cannot read image")));
+    }
+
+    #[tokio::test]
+    async fn handle_image_command_loads_valid_file() {
+        use std::io::Write;
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+        let mut tmp = tempfile::NamedTempFile::with_suffix(".jpg").unwrap();
+        let data = vec![0xFFu8, 0xD8, 0xFF, 0xE0];
+        tmp.write_all(&data).unwrap();
+        let path = tmp.path().to_str().unwrap().to_owned();
+
+        let mut parts = Vec::new();
+        let result = agent.handle_image_command(&path, &mut parts).await;
+        assert!(result.is_ok());
+        assert_eq!(parts.len(), 1);
+        match &parts[0] {
+            zeph_llm::provider::MessagePart::Image {
+                data: img_data,
+                mime_type,
+            } => {
+                assert_eq!(img_data, &data);
+                assert_eq!(mime_type, "image/jpeg");
+            }
+            _ => panic!("expected Image part"),
+        }
+        let sent = agent.channel.sent_messages();
+        assert!(sent.iter().any(|m| m.contains("Image loaded")));
+    }
+
+    mod resolve_message_tests {
+        use super::super::super::agent_tests::{MockChannel, MockToolExecutor, mock_provider};
+        use super::*;
+        use crate::channel::{Attachment, AttachmentKind, ChannelMessage};
+        use std::future::Future;
+        use std::pin::Pin;
+        use zeph_llm::error::LlmError;
+        use zeph_llm::stt::{SpeechToText, Transcription};
+
+        struct MockStt {
+            text: Option<String>,
+        }
+
+        impl MockStt {
+            fn ok(text: &str) -> Self {
+                Self {
+                    text: Some(text.to_string()),
+                }
+            }
+
+            fn failing() -> Self {
+                Self { text: None }
+            }
+        }
+
+        impl SpeechToText for MockStt {
+            fn transcribe(
+                &self,
+                _audio: &[u8],
+                _filename: Option<&str>,
+            ) -> Pin<Box<dyn Future<Output = Result<Transcription, LlmError>> + Send + '_>>
+            {
+                let result = match &self.text {
+                    Some(t) => Ok(Transcription {
+                        text: t.clone(),
+                        language: None,
+                        duration_secs: None,
+                    }),
+                    None => Err(LlmError::TranscriptionFailed("mock error".into())),
+                };
+                Box::pin(async move { result })
+            }
+        }
+
+        fn make_agent(stt: Option<Box<dyn SpeechToText>>) -> Agent<MockChannel, MockToolExecutor> {
+            let provider = mock_provider(vec!["ok".into()]);
+            let empty: Vec<String> = vec![];
+            let registry = zeph_skills::registry::SkillRegistry::load(&empty);
+            let channel = MockChannel::new(vec![]);
+            let executor = MockToolExecutor::no_tools();
+            let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+            agent.stt = stt;
+            agent
+        }
+
+        fn audio_attachment(data: &[u8]) -> Attachment {
+            Attachment {
+                kind: AttachmentKind::Audio,
+                data: data.to_vec(),
+                filename: Some("test.wav".into()),
+            }
+        }
+
+        #[tokio::test]
+        async fn no_audio_attachments_returns_text() {
+            let agent = make_agent(None);
+            let msg = ChannelMessage {
+                text: "hello".into(),
+                attachments: vec![],
+            };
+            assert_eq!(agent.resolve_message(msg).await.0, "hello");
+        }
+
+        #[tokio::test]
+        async fn audio_without_stt_returns_original_text() {
+            let agent = make_agent(None);
+            let msg = ChannelMessage {
+                text: "hello".into(),
+                attachments: vec![audio_attachment(b"audio-data")],
+            };
+            assert_eq!(agent.resolve_message(msg).await.0, "hello");
+        }
+
+        #[tokio::test]
+        async fn audio_with_stt_prepends_transcription() {
+            let agent = make_agent(Some(Box::new(MockStt::ok("transcribed text"))));
+            let msg = ChannelMessage {
+                text: "original".into(),
+                attachments: vec![audio_attachment(b"audio-data")],
+            };
+            let (result, _) = agent.resolve_message(msg).await;
+            assert!(result.contains("[transcribed audio]"));
+            assert!(result.contains("transcribed text"));
+            assert!(result.contains("original"));
+        }
+
+        #[tokio::test]
+        async fn audio_with_stt_no_original_text() {
+            let agent = make_agent(Some(Box::new(MockStt::ok("transcribed text"))));
+            let msg = ChannelMessage {
+                text: String::new(),
+                attachments: vec![audio_attachment(b"audio-data")],
+            };
+            let (result, _) = agent.resolve_message(msg).await;
+            assert_eq!(result, "transcribed text");
+        }
+
+        #[tokio::test]
+        async fn all_transcriptions_fail_returns_original() {
+            let agent = make_agent(Some(Box::new(MockStt::failing())));
+            let msg = ChannelMessage {
+                text: "original".into(),
+                attachments: vec![audio_attachment(b"audio-data")],
+            };
+            assert_eq!(agent.resolve_message(msg).await.0, "original");
+        }
+
+        #[tokio::test]
+        async fn multiple_audio_attachments_joined() {
+            let agent = make_agent(Some(Box::new(MockStt::ok("chunk"))));
+            let msg = ChannelMessage {
+                text: String::new(),
+                attachments: vec![
+                    audio_attachment(b"a1"),
+                    audio_attachment(b"a2"),
+                    audio_attachment(b"a3"),
+                ],
+            };
+            let (result, _) = agent.resolve_message(msg).await;
+            assert_eq!(result, "chunk\nchunk\nchunk");
+        }
+
+        #[tokio::test]
+        async fn oversized_audio_skipped() {
+            let agent = make_agent(Some(Box::new(MockStt::ok("should not appear"))));
+            let big = vec![0u8; MAX_AUDIO_BYTES + 1];
+            let msg = ChannelMessage {
+                text: "original".into(),
+                attachments: vec![Attachment {
+                    kind: AttachmentKind::Audio,
+                    data: big,
+                    filename: None,
+                }],
+            };
+            assert_eq!(agent.resolve_message(msg).await.0, "original");
+        }
+    }
+}

--- a/crates/zeph-core/src/agent/tool_execution.rs
+++ b/crates/zeph-core/src/agent/tool_execution.rs
@@ -69,7 +69,7 @@ fn handle_tool_use(out: &mut String, rest: &mut &str, start: usize) {
 }
 
 impl<C: Channel, T: ToolExecutor> Agent<C, T> {
-    pub(crate) async fn process_response(&mut self) -> Result<(), super::error::AgentError> {
+    pub(super) async fn process_response(&mut self) -> Result<(), super::error::AgentError> {
         if self.provider.supports_tool_use() {
             tracing::debug!(
                 provider = self.provider.name(),
@@ -175,7 +175,7 @@ impl<C: Channel, T: ToolExecutor> Agent<C, T> {
         Ok(())
     }
 
-    pub(crate) async fn call_llm_with_timeout(
+    pub(super) async fn call_llm_with_timeout(
         &mut self,
     ) -> Result<Option<String>, super::error::AgentError> {
         if self.cancel_token.is_cancelled() {
@@ -275,7 +275,7 @@ impl<C: Channel, T: ToolExecutor> Agent<C, T> {
         }
     }
 
-    pub(crate) fn last_user_query(&self) -> &str {
+    pub(super) fn last_user_query(&self) -> &str {
         self.messages
             .iter()
             .rev()
@@ -283,7 +283,7 @@ impl<C: Channel, T: ToolExecutor> Agent<C, T> {
             .map_or("", |m| m.content.as_str())
     }
 
-    pub(crate) async fn summarize_tool_output(&self, output: &str) -> String {
+    pub(super) async fn summarize_tool_output(&self, output: &str) -> String {
         let truncated = zeph_tools::truncate_tool_output(output);
         let query = self.last_user_query();
         let prompt = format!(
@@ -312,7 +312,7 @@ impl<C: Channel, T: ToolExecutor> Agent<C, T> {
         }
     }
 
-    pub(crate) async fn maybe_summarize_tool_output(&self, output: &str) -> String {
+    pub(super) async fn maybe_summarize_tool_output(&self, output: &str) -> String {
         if output.len() <= zeph_tools::MAX_TOOL_OUTPUT_CHARS {
             return output.to_string();
         }
@@ -334,7 +334,7 @@ impl<C: Channel, T: ToolExecutor> Agent<C, T> {
 
     /// Returns `true` if the tool loop should continue.
     #[allow(clippy::too_many_lines)]
-    pub(crate) async fn handle_tool_result(
+    pub(super) async fn handle_tool_result(
         &mut self,
         response: &str,
         result: Result<Option<ToolOutput>, ToolError>,
@@ -478,7 +478,7 @@ impl<C: Channel, T: ToolExecutor> Agent<C, T> {
         }
     }
 
-    pub(crate) async fn process_response_streaming(
+    pub(super) async fn process_response_streaming(
         &mut self,
     ) -> Result<String, super::error::AgentError> {
         let mut stream = self.provider.chat_stream(&self.messages).await?;
@@ -515,7 +515,7 @@ impl<C: Channel, T: ToolExecutor> Agent<C, T> {
         Ok(response)
     }
 
-    pub(crate) fn maybe_redact<'a>(&self, text: &'a str) -> std::borrow::Cow<'a, str> {
+    pub(super) fn maybe_redact<'a>(&self, text: &'a str) -> std::borrow::Cow<'a, str> {
         if self.runtime.security.redact_secrets {
             let redacted = redact_secrets(text);
             let sanitized = crate::redact::sanitize_paths(&redacted);

--- a/crates/zeph-core/src/agent/utils.rs
+++ b/crates/zeph-core/src/agent/utils.rs
@@ -1,0 +1,76 @@
+use zeph_llm::provider::{LlmProvider, Message, MessagePart, Role};
+
+use crate::channel::Channel;
+use crate::metrics::MetricsSnapshot;
+use zeph_tools::executor::ToolExecutor;
+
+use super::{Agent, CODE_CONTEXT_PREFIX};
+
+impl<C: Channel, T: ToolExecutor> Agent<C, T> {
+    pub(super) fn update_metrics(&self, f: impl FnOnce(&mut MetricsSnapshot)) {
+        if let Some(ref tx) = self.metrics_tx {
+            let elapsed = self.start_time.elapsed().as_secs();
+            tx.send_modify(|m| {
+                m.uptime_seconds = elapsed;
+                f(m);
+            });
+        }
+    }
+
+    pub(super) fn estimate_tokens(content: &str) -> u64 {
+        u64::try_from(content.len()).unwrap_or(0) / 4
+    }
+
+    pub(super) fn recompute_prompt_tokens(&mut self) {
+        self.cached_prompt_tokens = self
+            .messages
+            .iter()
+            .map(|m| Self::estimate_tokens(&m.content))
+            .sum();
+    }
+
+    pub(super) fn push_message(&mut self, msg: Message) {
+        self.cached_prompt_tokens += Self::estimate_tokens(&msg.content);
+        self.messages.push(msg);
+    }
+
+    pub(crate) fn record_cost(&self, prompt_tokens: u64, completion_tokens: u64) {
+        if let Some(ref tracker) = self.cost_tracker {
+            tracker.record_usage(&self.runtime.model_name, prompt_tokens, completion_tokens);
+            self.update_metrics(|m| {
+                m.cost_spent_cents = tracker.current_spend();
+            });
+        }
+    }
+
+    pub(crate) fn record_cache_usage(&self) {
+        if let Some((creation, read)) = self.provider.last_cache_usage() {
+            self.update_metrics(|m| {
+                m.cache_creation_tokens += creation;
+                m.cache_read_tokens += read;
+            });
+        }
+    }
+
+    /// Inject pre-formatted code context into the message list.
+    /// The caller is responsible for retrieving and formatting the text.
+    pub fn inject_code_context(&mut self, text: &str) {
+        self.remove_code_context_messages();
+        if text.is_empty() || self.messages.len() <= 1 {
+            return;
+        }
+        let content = format!("{CODE_CONTEXT_PREFIX}{text}");
+        self.messages.insert(
+            1,
+            Message::from_parts(
+                Role::System,
+                vec![MessagePart::CodeContext { text: content }],
+            ),
+        );
+    }
+
+    #[must_use]
+    pub fn context_messages(&self) -> &[Message] {
+        &self.messages
+    }
+}


### PR DESCRIPTION
## Summary

Resolves #622 — decompose the monolithic `agent/mod.rs` (2602 lines, 142 functions) into focused submodules.

- Rename `streaming.rs` → `tool_execution.rs` for clarity (#648)
- Extract message queue logic (QueuedMessage, drain/enqueue/resolve, image handling) to `message_queue.rs` (#649)
- Extract builder methods to `builder.rs`
- Extract slash command handlers to `commands.rs`
- Extract utility helpers (metrics, tokens, cost) to `utils.rs`
- `mod.rs` reduced from 2602 → 459 non-test lines (#650)

No public API changes. No logic changes — pure code movement.

7 files changed, +1270 -1190, 2033 tests passing.

## Test plan

- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo clippy --workspace --features full -- -D warnings` passes
- [x] `cargo nextest run --workspace --lib --bins` — 2033 passed, 9 skipped
- [x] No public API changes verified
- [x] Performance analysis confirms zero regression