### PR TITLE
refactor: replace anyhow with typed errors in library crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Add `default_client()` HTTP helper with standard timeouts and user-agent in zeph-core and zeph-llm (#666)
 - Replace 5 production `Client::new()` calls with `default_client()` for consistent HTTP config (#667)
 - Decompose agent/mod.rs (2602→459 lines) into tool_execution, message_queue, builder, commands, and utils modules (#648, #649, #650)
+- Replace `anyhow` in `zeph-core::config` with typed `ConfigError` enum (Io, Parse, Validation, Vault)
+- Replace `anyhow` in `zeph-tui` with typed `TuiError` enum (Io, Channel); simplify `handle_event()` return to `()`
+- Sort `[workspace.dependencies]` alphabetically in root Cargo.toml
 
 ### Fixed
 - False positive: "sudoku" no longer matched by "sudo" blocked pattern (word-boundary matching)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9145,7 +9145,6 @@ dependencies = [
 name = "zeph-tui"
 version = "0.11.2"
 dependencies = [
- "anyhow",
  "crossterm",
  "expectrl",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,29 +12,33 @@ repository = "https://github.com/bug-ops/zeph"
 
 [workspace.dependencies]
 age = { version = "0.11.2", default-features = false }
-clap = { version = "4.5", features = ["derive"] }
-dialoguer = "0.11"
 anyhow = "1.0"
+axum = "0.8"
 base64 = "0.22"
+blake3 = "1.8"
 candle-core = { version = "0.9", default-features = false }
 candle-nn = { version = "0.9", default-features = false }
 candle-transformers = { version = "0.9", default-features = false }
 chrono = { version = "0.4", default-features = false, features = ["std"] }
-crossterm = "0.29"
-axum = "0.8"
-blake3 = "1.8"
+clap = { version = "4.5", features = ["derive"] }
 criterion = "0.8"
-glob = "0.3.3"
-futures = "0.3"
-ignore = "0.4"
-hf-hub = { version = "0.4", default-features = false, features = ["tokio", "rustls-tls", "ureq"] }
+cron = "0.15"
+crossterm = "0.29"
+dialoguer = "0.11"
 eventsource-stream = "0.2"
-http-body-util = "0.1"
+futures = "0.3"
 futures-core = "0.3"
+glob = "0.3.3"
+hf-hub = { version = "0.4", default-features = false, features = ["tokio", "rustls-tls", "ureq"] }
+http-body-util = "0.1"
+ignore = "0.4"
 notify = "8"
-nucleo-matcher = "0.3.1"
 notify-debouncer-mini = "0.7"
+nucleo-matcher = "0.3.1"
 ollama-rs = { version = "0.3", default-features = false, features = ["rustls", "stream"] }
+opentelemetry = "0.31"
+opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic"] }
+opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
 pdf-extract = "0.7"
 proptest = "1.6"
 pulldown-cmark = "0.13"
@@ -43,33 +47,29 @@ ratatui = "0.30"
 regex = "1.12"
 reqwest = { version = "0.13", default-features = false }
 rmcp = "0.15"
-semver = "1.0.27"
-scrape-core = "0.2.2"
-subtle = "2.6"
 rubato = "0.16"
 schemars = "1.2"
-similar = "2.7"
+scrape-core = "0.2.2"
+semver = "1.0.27"
 serde = "1.0"
 serde_json = "1.0"
 serial_test = "3.3"
-symphonia = { version = "0.5.5", default-features = false, features = ["mp3", "ogg", "wav", "flac", "pcm"] }
+similar = "2.7"
 sqlx = { version = "0.8", default-features = false, features = ["macros"] }
+subtle = "2.6"
+symphonia = { version = "0.5.5", default-features = false, features = ["mp3", "ogg", "wav", "flac", "pcm"] }
 teloxide = { version = "0.17", default-features = false, features = ["rustls", "ctrlc_handler", "macros"] }
 tempfile = "3"
 testcontainers = "0.27"
-wiremock = "0.6.5"
 thiserror = "2.0"
 tokenizers = { version = "0.22", default-features = false, features = ["fancy-regex"] }
 tokio = "1"
-tokio-tungstenite = { version = "0.28", default-features = false }
 tokio-stream = "0.1"
+tokio-tungstenite = { version = "0.28", default-features = false }
 tokio-util = "0.7"
 toml = "1.0"
 tower = "0.5"
 tower-http = "0.6"
-opentelemetry = "0.31"
-opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic"] }
 tracing = "0.1"
 tracing-opentelemetry = "0.32"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
@@ -87,18 +87,18 @@ tree-sitter-typescript = "0.23"
 unicode-width = "0.2"
 url = "2.5"
 uuid = "1.21"
-cron = "0.15"
+wiremock = "0.6.5"
 zeph-a2a = { path = "crates/zeph-a2a", version = "0.11.2" }
 zeph-channels = { path = "crates/zeph-channels", version = "0.11.2" }
 zeph-core = { path = "crates/zeph-core", version = "0.11.2" }
+zeph-gateway = { path = "crates/zeph-gateway", version = "0.11.2" }
 zeph-index = { path = "crates/zeph-index", version = "0.11.2" }
 zeph-llm = { path = "crates/zeph-llm", version = "0.11.2" }
 zeph-mcp = { path = "crates/zeph-mcp", version = "0.11.2" }
 zeph-memory = { path = "crates/zeph-memory", version = "0.11.2" }
+zeph-scheduler = { path = "crates/zeph-scheduler", version = "0.11.2" }
 zeph-skills = { path = "crates/zeph-skills", version = "0.11.2" }
 zeph-tools = { path = "crates/zeph-tools", version = "0.11.2" }
-zeph-gateway = { path = "crates/zeph-gateway", version = "0.11.2" }
-zeph-scheduler = { path = "crates/zeph-scheduler", version = "0.11.2" }
 zeph-tui = { path = "crates/zeph-tui", version = "0.11.2" }
 
 [workspace.lints.clippy]

--- a/crates/zeph-core/src/lib.rs
+++ b/crates/zeph-core/src/lib.rs
@@ -22,5 +22,5 @@ pub mod http;
 pub use agent::Agent;
 pub use agent::error::AgentError;
 pub use channel::{Attachment, AttachmentKind, Channel, ChannelError, ChannelMessage};
-pub use config::Config;
+pub use config::{Config, ConfigError};
 pub use diff::DiffData;

--- a/crates/zeph-tui/Cargo.toml
+++ b/crates/zeph-tui/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-anyhow.workspace = true
 ignore.workspace = true
 nucleo-matcher.workspace = true
 crossterm.workspace = true

--- a/crates/zeph-tui/src/app.rs
+++ b/crates/zeph-tui/src/app.rs
@@ -367,10 +367,7 @@ impl App {
         &mut self.throbber_state
     }
 
-    /// # Errors
-    ///
-    /// Returns an error if event handling fails.
-    pub fn handle_event(&mut self, event: AppEvent) -> anyhow::Result<()> {
+    pub fn handle_event(&mut self, event: AppEvent) {
         match event {
             AppEvent::Key(key) => self.handle_key(key),
             AppEvent::Tick => {
@@ -390,7 +387,6 @@ impl App {
             }
             AppEvent::Agent(agent_event) => self.handle_agent_event(agent_event),
         }
-        Ok(())
     }
 
     pub fn poll_agent_event(&mut self) -> impl Future<Output = Option<AgentEvent>> + use<'_> {
@@ -1183,7 +1179,7 @@ mod tests {
     fn ctrl_c_quits() {
         let (mut app, _rx, _tx) = make_app();
         let key = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert!(app.should_quit);
     }
 
@@ -1192,7 +1188,7 @@ mod tests {
         let (mut app, _rx, _tx) = make_app();
         app.input_mode = InputMode::Insert;
         let key = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert_eq!(app.input(), "a");
         assert_eq!(app.cursor_position(), 1);
     }
@@ -1202,7 +1198,7 @@ mod tests {
         let (mut app, _rx, _tx) = make_app();
         app.input_mode = InputMode::Insert;
         let key = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert_eq!(app.input_mode(), InputMode::Normal);
     }
 
@@ -1211,7 +1207,7 @@ mod tests {
         let (mut app, _rx, _tx) = make_app();
         app.input_mode = InputMode::Normal;
         let key = KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert_eq!(app.input_mode(), InputMode::Insert);
     }
 
@@ -1220,7 +1216,7 @@ mod tests {
         let (mut app, _rx, _tx) = make_app();
         app.input_mode = InputMode::Normal;
         let key = KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert!(app.should_quit);
     }
 
@@ -1231,7 +1227,7 @@ mod tests {
         app.input = "ab".into();
         app.cursor_position = 2;
         let key = KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert_eq!(app.input(), "a");
         assert_eq!(app.cursor_position(), 1);
     }
@@ -1243,7 +1239,7 @@ mod tests {
         app.input = "hello".into();
         app.cursor_position = 5;
         let key = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert!(app.input().is_empty());
         assert_eq!(app.messages().len(), 1);
         assert_eq!(app.messages()[0].content, "hello");
@@ -1257,7 +1253,7 @@ mod tests {
         let (mut app, mut rx, _tx) = make_app();
         app.input_mode = InputMode::Insert;
         let key = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert!(app.messages().is_empty());
         assert!(rx.try_recv().is_err());
     }
@@ -1307,11 +1303,11 @@ mod tests {
         let (mut app, _rx, _tx) = make_app();
         app.input_mode = InputMode::Normal;
         let up = KeyEvent::new(KeyCode::Up, KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(up)).unwrap();
+        app.handle_event(AppEvent::Key(up));
         assert_eq!(app.scroll_offset(), 1);
 
         let down = KeyEvent::new(KeyCode::Down, KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(down)).unwrap();
+        app.handle_event(AppEvent::Key(down));
         assert_eq!(app.scroll_offset(), 0);
     }
 
@@ -1322,16 +1318,16 @@ mod tests {
         assert_eq!(app.active_panel, Panel::Chat);
 
         let tab = KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(tab)).unwrap();
+        app.handle_event(AppEvent::Key(tab));
         assert_eq!(app.active_panel, Panel::Skills);
 
-        app.handle_event(AppEvent::Key(tab)).unwrap();
+        app.handle_event(AppEvent::Key(tab));
         assert_eq!(app.active_panel, Panel::Memory);
 
-        app.handle_event(AppEvent::Key(tab)).unwrap();
+        app.handle_event(AppEvent::Key(tab));
         assert_eq!(app.active_panel, Panel::Resources);
 
-        app.handle_event(AppEvent::Key(tab)).unwrap();
+        app.handle_event(AppEvent::Key(tab));
         assert_eq!(app.active_panel, Panel::Chat);
     }
 
@@ -1342,7 +1338,7 @@ mod tests {
         app.input = "some text".into();
         app.cursor_position = 9;
         let key = KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert!(app.input().is_empty());
         assert_eq!(app.cursor_position(), 0);
     }
@@ -1355,23 +1351,23 @@ mod tests {
         app.cursor_position = 1;
 
         let left = KeyEvent::new(KeyCode::Left, KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(left)).unwrap();
+        app.handle_event(AppEvent::Key(left));
         assert_eq!(app.cursor_position(), 0);
 
         // left at 0 stays at 0
-        app.handle_event(AppEvent::Key(left)).unwrap();
+        app.handle_event(AppEvent::Key(left));
         assert_eq!(app.cursor_position(), 0);
 
         let right = KeyEvent::new(KeyCode::Right, KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(right)).unwrap();
+        app.handle_event(AppEvent::Key(right));
         assert_eq!(app.cursor_position(), 1);
 
         let home = KeyEvent::new(KeyCode::Home, KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(home)).unwrap();
+        app.handle_event(AppEvent::Key(home));
         assert_eq!(app.cursor_position(), 0);
 
         let end = KeyEvent::new(KeyCode::End, KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(end)).unwrap();
+        app.handle_event(AppEvent::Key(end));
         assert_eq!(app.cursor_position(), 3);
     }
 
@@ -1382,7 +1378,7 @@ mod tests {
         app.input = "abc".into();
         app.cursor_position = 1;
         let key = KeyEvent::new(KeyCode::Delete, KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert_eq!(app.input(), "ac");
         assert_eq!(app.cursor_position(), 1);
     }
@@ -1395,30 +1391,30 @@ mod tests {
         // Type multi-byte chars
         for c in "\u{00e9}a\u{1f600}".chars() {
             let key = KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE);
-            app.handle_event(AppEvent::Key(key)).unwrap();
+            app.handle_event(AppEvent::Key(key));
         }
         assert_eq!(app.input(), "\u{00e9}a\u{1f600}");
         assert_eq!(app.cursor_position(), 3);
 
         // Backspace removes the emoji (last char)
         let bs = KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(bs)).unwrap();
+        app.handle_event(AppEvent::Key(bs));
         assert_eq!(app.input(), "\u{00e9}a");
         assert_eq!(app.cursor_position(), 2);
 
         // Move cursor left and delete 'a'
         let left = KeyEvent::new(KeyCode::Left, KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(left)).unwrap();
+        app.handle_event(AppEvent::Key(left));
         assert_eq!(app.cursor_position(), 1);
 
         let del = KeyEvent::new(KeyCode::Delete, KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(del)).unwrap();
+        app.handle_event(AppEvent::Key(del));
         assert_eq!(app.input(), "\u{00e9}");
         assert_eq!(app.cursor_position(), 1);
 
         // End key uses char count, not byte count
         let end = KeyEvent::new(KeyCode::End, KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(end)).unwrap();
+        app.handle_event(AppEvent::Key(end));
         assert_eq!(app.cursor_position(), 1);
     }
 
@@ -1443,7 +1439,7 @@ mod tests {
             response_tx: Some(tx),
         });
         let key = KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert!(app.confirm_state.is_none());
         assert!(rx.try_recv().unwrap());
     }
@@ -1457,7 +1453,7 @@ mod tests {
             response_tx: Some(tx),
         });
         let key = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert!(app.confirm_state.is_none());
         assert!(rx.try_recv().unwrap());
     }
@@ -1471,7 +1467,7 @@ mod tests {
             response_tx: Some(tx),
         });
         let key = KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert!(app.confirm_state.is_none());
         assert!(!rx.try_recv().unwrap());
     }
@@ -1485,7 +1481,7 @@ mod tests {
             response_tx: Some(tx),
         });
         let key = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert!(app.confirm_state.is_none());
         assert!(!rx.try_recv().unwrap());
     }
@@ -1500,7 +1496,7 @@ mod tests {
             response_tx: Some(tx),
         });
         let key = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert!(app.input().is_empty());
         assert!(app.confirm_state.is_some());
     }
@@ -1512,7 +1508,7 @@ mod tests {
         app.input = "hello".into();
         app.cursor_position = 5;
         let key = KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert_eq!(app.input(), "hello\n");
         assert_eq!(app.cursor_position(), 6);
         assert!(app.messages().is_empty());
@@ -1526,7 +1522,7 @@ mod tests {
         app.input = "ab".into();
         app.cursor_position = 1;
         let key = KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert_eq!(app.input(), "a\nb");
         assert_eq!(app.cursor_position(), 2);
     }
@@ -1538,10 +1534,10 @@ mod tests {
         assert!(app.show_side_panels());
 
         let key = KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert!(!app.show_side_panels());
 
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert!(app.show_side_panels());
     }
 
@@ -1549,9 +1545,9 @@ mod tests {
     fn mouse_scroll_up() {
         let (mut app, _rx, _tx) = make_app();
         assert_eq!(app.scroll_offset(), 0);
-        app.handle_event(AppEvent::MouseScroll(1)).unwrap();
+        app.handle_event(AppEvent::MouseScroll(1));
         assert_eq!(app.scroll_offset(), 1);
-        app.handle_event(AppEvent::MouseScroll(1)).unwrap();
+        app.handle_event(AppEvent::MouseScroll(1));
         assert_eq!(app.scroll_offset(), 2);
     }
 
@@ -1559,9 +1555,9 @@ mod tests {
     fn mouse_scroll_down() {
         let (mut app, _rx, _tx) = make_app();
         app.scroll_offset = 5;
-        app.handle_event(AppEvent::MouseScroll(-1)).unwrap();
+        app.handle_event(AppEvent::MouseScroll(-1));
         assert_eq!(app.scroll_offset(), 4);
-        app.handle_event(AppEvent::MouseScroll(-1)).unwrap();
+        app.handle_event(AppEvent::MouseScroll(-1));
         assert_eq!(app.scroll_offset(), 3);
     }
 
@@ -1569,9 +1565,9 @@ mod tests {
     fn mouse_scroll_down_saturates_at_zero() {
         let (mut app, _rx, _tx) = make_app();
         app.scroll_offset = 1;
-        app.handle_event(AppEvent::MouseScroll(-1)).unwrap();
+        app.handle_event(AppEvent::MouseScroll(-1));
         assert_eq!(app.scroll_offset(), 0);
-        app.handle_event(AppEvent::MouseScroll(-1)).unwrap();
+        app.handle_event(AppEvent::MouseScroll(-1));
         assert_eq!(app.scroll_offset(), 0);
     }
 
@@ -1584,9 +1580,9 @@ mod tests {
             response_tx: Some(tx),
         });
         app.scroll_offset = 5;
-        app.handle_event(AppEvent::MouseScroll(1)).unwrap();
+        app.handle_event(AppEvent::MouseScroll(1));
         assert_eq!(app.scroll_offset(), 5);
-        app.handle_event(AppEvent::MouseScroll(-1)).unwrap();
+        app.handle_event(AppEvent::MouseScroll(-1));
         assert_eq!(app.scroll_offset(), 5);
     }
 
@@ -1691,7 +1687,7 @@ mod tests {
         let (mut app, _rx, _tx) = make_app();
         app.input_mode = InputMode::Normal;
         let key = KeyEvent::new(KeyCode::Char('?'), KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert!(app.show_help);
     }
 
@@ -1700,7 +1696,7 @@ mod tests {
         let (mut app, _rx, _tx) = make_app();
         app.show_help = true;
         let key = KeyEvent::new(KeyCode::Char('?'), KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert!(!app.show_help);
     }
 
@@ -1709,7 +1705,7 @@ mod tests {
         let (mut app, _rx, _tx) = make_app();
         app.show_help = true;
         let key = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert!(!app.show_help);
     }
 
@@ -1721,13 +1717,13 @@ mod tests {
 
         // Typing a character should not modify input
         let key = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert!(app.input().is_empty());
         assert!(app.show_help);
 
         // Enter should not submit
         let key = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert!(app.messages().is_empty());
         assert!(app.show_help);
     }
@@ -1737,7 +1733,7 @@ mod tests {
         let (mut app, _rx, _tx) = make_app();
         app.show_help = true;
         let key = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert!(app.should_quit);
     }
 
@@ -1746,7 +1742,7 @@ mod tests {
         let (mut app, _rx, _tx) = make_app();
         app.input_mode = InputMode::Insert;
         let key = KeyEvent::new(KeyCode::Char('?'), KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert!(!app.show_help);
         assert_eq!(app.input(), "?");
     }
@@ -1768,7 +1764,7 @@ mod tests {
         assert!(app.is_agent_busy());
 
         let key = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         let result = tokio::time::timeout(std::time::Duration::from_millis(100), handle).await;
         assert!(result.is_ok(), "notify should have been triggered");
     }
@@ -1782,7 +1778,7 @@ mod tests {
         assert!(!app.is_agent_busy());
 
         let key = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         // No way to assert "not notified" directly, but we verify no panic
     }
 
@@ -1802,7 +1798,7 @@ mod tests {
         });
 
         let key = KeyEvent::new(KeyCode::Up, KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
 
         assert_eq!(app.input(), "queued msg");
         assert_eq!(app.cursor_position(), 10);
@@ -1824,7 +1820,7 @@ mod tests {
         app.input_history.push("hello world".into());
 
         let key = KeyEvent::new(KeyCode::Up, KeyModifiers::NONE);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
 
         assert!(rx.try_recv().is_err());
         assert_eq!(app.input(), "hello world");
@@ -1865,7 +1861,7 @@ mod tests {
             app.input = "hello world".into();
             app.cursor_position = 11;
             let enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
-            app.handle_event(AppEvent::Key(enter)).unwrap();
+            app.handle_event(AppEvent::Key(enter));
 
             let output = draw_app(&mut app, 80, 24);
             assert!(output.contains("hello world"));
@@ -1876,7 +1872,7 @@ mod tests {
             let (mut app, _rx, _tx) = make_app();
             app.input_mode = InputMode::Normal;
             let key = KeyEvent::new(KeyCode::Char('?'), KeyModifiers::NONE);
-            app.handle_event(AppEvent::Key(key)).unwrap();
+            app.handle_event(AppEvent::Key(key));
 
             let output = draw_app(&mut app, 80, 30);
             assert!(output.contains("Help"));
@@ -1888,9 +1884,9 @@ mod tests {
             let (mut app, _rx, _tx) = make_app();
             app.input_mode = InputMode::Normal;
             let open = KeyEvent::new(KeyCode::Char('?'), KeyModifiers::NONE);
-            app.handle_event(AppEvent::Key(open)).unwrap();
+            app.handle_event(AppEvent::Key(open));
             let close = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
-            app.handle_event(AppEvent::Key(close)).unwrap();
+            app.handle_event(AppEvent::Key(close));
 
             let output = draw_app(&mut app, 80, 30);
             assert!(!output.contains("Help — press"));
@@ -1920,7 +1916,7 @@ mod tests {
                 response_tx: Some(tx),
             });
             let key = KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE);
-            app.handle_event(AppEvent::Key(key)).unwrap();
+            app.handle_event(AppEvent::Key(key));
 
             let output = draw_app(&mut app, 60, 20);
             assert!(!output.contains("[Y]es / [N]o"));
@@ -1936,7 +1932,7 @@ mod tests {
             assert!(before.contains("Memory"));
 
             let key = KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE);
-            app.handle_event(AppEvent::Key(key)).unwrap();
+            app.handle_event(AppEvent::Key(key));
 
             let after = draw_app(&mut app, 120, 40);
             assert!(!after.contains("Skills ("));
@@ -1956,7 +1952,7 @@ mod tests {
             app.input = "hi".into();
             app.cursor_position = 2;
             let enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
-            app.handle_event(AppEvent::Key(enter)).unwrap();
+            app.handle_event(AppEvent::Key(enter));
 
             let output = draw_app(&mut app, 80, 24);
             assert!(!output.contains("Type a message"));
@@ -2080,7 +2076,7 @@ mod tests {
         app.input = "hello world".into();
         app.cursor_position = 8;
         let key = KeyEvent::new(KeyCode::Left, KeyModifiers::ALT);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert_eq!(app.cursor_position(), 6);
     }
 
@@ -2091,7 +2087,7 @@ mod tests {
         app.input = "hello world".into();
         app.cursor_position = 2;
         let key = KeyEvent::new(KeyCode::Right, KeyModifiers::ALT);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert_eq!(app.cursor_position(), 6);
     }
 
@@ -2102,7 +2098,7 @@ mod tests {
         app.input = "hello world".into();
         app.cursor_position = 7;
         let key = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::CONTROL);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert_eq!(app.cursor_position(), 0);
     }
 
@@ -2113,7 +2109,7 @@ mod tests {
         app.input = "hello world".into();
         app.cursor_position = 3;
         let key = KeyEvent::new(KeyCode::Char('e'), KeyModifiers::CONTROL);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert_eq!(app.cursor_position(), 11);
     }
 
@@ -2124,7 +2120,7 @@ mod tests {
         app.input = "hello world".into();
         app.cursor_position = 11;
         let key = KeyEvent::new(KeyCode::Backspace, KeyModifiers::ALT);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert_eq!(app.input(), "hello ");
         assert_eq!(app.cursor_position(), 6);
     }
@@ -2136,7 +2132,7 @@ mod tests {
         app.input = "hello world".into();
         app.cursor_position = 6;
         let key = KeyEvent::new(KeyCode::Backspace, KeyModifiers::ALT);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert_eq!(app.input(), "world");
         assert_eq!(app.cursor_position(), 0);
     }
@@ -2148,7 +2144,7 @@ mod tests {
         app.input = "hello".into();
         app.cursor_position = 0;
         let key = KeyEvent::new(KeyCode::Backspace, KeyModifiers::ALT);
-        app.handle_event(AppEvent::Key(key)).unwrap();
+        app.handle_event(AppEvent::Key(key));
         assert_eq!(app.input(), "hello");
         assert_eq!(app.cursor_position(), 0);
     }
@@ -2190,7 +2186,7 @@ mod tests {
                 app.cursor_position = cursor.min(len);
 
                 let key = KeyEvent::new(KeyCode::Backspace, KeyModifiers::ALT);
-                app.handle_event(AppEvent::Key(key)).unwrap();
+                app.handle_event(AppEvent::Key(key));
 
                 prop_assert!(app.cursor_position() <= app.char_count());
             }
@@ -2330,7 +2326,7 @@ mod tests {
             assert!(app.command_palette.is_none());
 
             let key = KeyEvent::new(KeyCode::Char(':'), KeyModifiers::NONE);
-            app.handle_event(AppEvent::Key(key)).unwrap();
+            app.handle_event(AppEvent::Key(key));
             assert!(app.command_palette.is_some());
         }
 
@@ -2341,7 +2337,7 @@ mod tests {
             app.command_palette = Some(crate::widgets::command_palette::CommandPaletteState::new());
 
             let key = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
-            app.handle_event(AppEvent::Key(key)).unwrap();
+            app.handle_event(AppEvent::Key(key));
             assert!(app.command_palette.is_none());
         }
 
@@ -2353,7 +2349,7 @@ mod tests {
 
             // Typing a char goes to palette, not to input field
             let key = KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE);
-            app.handle_event(AppEvent::Key(key)).unwrap();
+            app.handle_event(AppEvent::Key(key));
             assert!(app.input().is_empty());
             let palette = app.command_palette.as_ref().unwrap();
             assert_eq!(palette.query, "s");
@@ -2365,12 +2361,12 @@ mod tests {
             app.input_mode = InputMode::Normal;
             // Open palette
             let colon = KeyEvent::new(KeyCode::Char(':'), KeyModifiers::NONE);
-            app.handle_event(AppEvent::Key(colon)).unwrap();
+            app.handle_event(AppEvent::Key(colon));
             assert!(app.command_palette.is_some());
 
             // Enter on first command (skill:list)
             let enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
-            app.handle_event(AppEvent::Key(enter)).unwrap();
+            app.handle_event(AppEvent::Key(enter));
             assert!(app.command_palette.is_none());
             // Should have added a system message
             assert!(!app.messages().is_empty());
@@ -2385,9 +2381,9 @@ mod tests {
             let m = KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE);
             let c = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE);
             let p = KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE);
-            app.handle_event(AppEvent::Key(m)).unwrap();
-            app.handle_event(AppEvent::Key(c)).unwrap();
-            app.handle_event(AppEvent::Key(p)).unwrap();
+            app.handle_event(AppEvent::Key(m));
+            app.handle_event(AppEvent::Key(c));
+            app.handle_event(AppEvent::Key(p));
 
             let palette = app.command_palette.as_ref().unwrap();
             assert_eq!(palette.query, "mcp");
@@ -2401,11 +2397,11 @@ mod tests {
             app.command_palette = Some(crate::widgets::command_palette::CommandPaletteState::new());
 
             let s = KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE);
-            app.handle_event(AppEvent::Key(s)).unwrap();
+            app.handle_event(AppEvent::Key(s));
             assert_eq!(app.command_palette.as_ref().unwrap().query, "s");
 
             let bs = KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE);
-            app.handle_event(AppEvent::Key(bs)).unwrap();
+            app.handle_event(AppEvent::Key(bs));
             assert!(app.command_palette.as_ref().unwrap().query.is_empty());
         }
 
@@ -2438,7 +2434,7 @@ mod tests {
             let (mut app, _rx, _tx) = make_app();
             app.input_mode = InputMode::Insert;
             let key = KeyEvent::new(KeyCode::Char(':'), KeyModifiers::NONE);
-            app.handle_event(AppEvent::Key(key)).unwrap();
+            app.handle_event(AppEvent::Key(key));
             assert!(app.command_palette.is_none());
             assert_eq!(app.input(), ":");
         }
@@ -2455,7 +2451,7 @@ mod tests {
             app.command_palette = Some(palette);
 
             let enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
-            app.handle_event(AppEvent::Key(enter)).unwrap();
+            app.handle_event(AppEvent::Key(enter));
             // palette should close without crashing, no message added
             assert!(app.command_palette.is_none());
         }
@@ -2542,7 +2538,7 @@ mod tests {
             let (mut app, _rx, _tx) = make_app_with_index();
             app.input_mode = InputMode::Insert;
             let key = KeyEvent::new(KeyCode::Char('@'), KeyModifiers::NONE);
-            app.handle_event(AppEvent::Key(key)).unwrap();
+            app.handle_event(AppEvent::Key(key));
             assert!(
                 !app.input.contains('@'),
                 "@ should not be in input after opening picker"
@@ -2561,7 +2557,7 @@ mod tests {
             assert!(app.file_picker_state.is_some());
 
             let key = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
-            app.handle_event(AppEvent::Key(key)).unwrap();
+            app.handle_event(AppEvent::Key(key));
             assert!(app.file_picker_state.is_none());
             assert!(app.input.is_empty());
         }
@@ -2581,7 +2577,7 @@ mod tests {
                 .unwrap();
 
             let key = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
-            app.handle_event(AppEvent::Key(key)).unwrap();
+            app.handle_event(AppEvent::Key(key));
 
             assert!(app.file_picker_state.is_none());
             assert!(
@@ -2606,7 +2602,7 @@ mod tests {
                 .unwrap();
 
             let key = KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE);
-            app.handle_event(AppEvent::Key(key)).unwrap();
+            app.handle_event(AppEvent::Key(key));
 
             assert!(app.file_picker_state.is_none());
             assert!(app.input.contains(&selected));
@@ -2624,7 +2620,7 @@ mod tests {
             assert!(app.file_picker_state.as_ref().unwrap().matches().is_empty());
 
             let key = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
-            app.handle_event(AppEvent::Key(key)).unwrap();
+            app.handle_event(AppEvent::Key(key));
 
             assert!(app.file_picker_state.is_none());
             assert!(app.input.is_empty(), "input must be unchanged");
@@ -2639,7 +2635,7 @@ mod tests {
             assert_eq!(app.file_picker_state.as_ref().unwrap().selected, 0);
 
             let key = KeyEvent::new(KeyCode::Down, KeyModifiers::NONE);
-            app.handle_event(AppEvent::Key(key)).unwrap();
+            app.handle_event(AppEvent::Key(key));
             assert_eq!(app.file_picker_state.as_ref().unwrap().selected, 1);
         }
 
@@ -2650,7 +2646,7 @@ mod tests {
             open_picker_with_index(&mut app, &idx);
 
             let key = KeyEvent::new(KeyCode::Up, KeyModifiers::NONE);
-            app.handle_event(AppEvent::Key(key)).unwrap();
+            app.handle_event(AppEvent::Key(key));
             let state = app.file_picker_state.as_ref().unwrap();
             assert_eq!(state.selected, state.matches().len() - 1);
         }
@@ -2664,7 +2660,7 @@ mod tests {
             let initial_count = app.file_picker_state.as_ref().unwrap().matches().len();
 
             let key = KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE);
-            app.handle_event(AppEvent::Key(key)).unwrap();
+            app.handle_event(AppEvent::Key(key));
 
             let filtered_count = app.file_picker_state.as_ref().unwrap().matches().len();
             assert!(filtered_count <= initial_count);
@@ -2680,7 +2676,7 @@ mod tests {
             app.file_picker_state.as_mut().unwrap().update_query("ma");
 
             let key = KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE);
-            app.handle_event(AppEvent::Key(key)).unwrap();
+            app.handle_event(AppEvent::Key(key));
 
             assert!(app.file_picker_state.is_some());
             assert_eq!(app.file_picker_state.as_ref().unwrap().query, "m");
@@ -2695,7 +2691,7 @@ mod tests {
             assert!(app.file_picker_state.as_ref().unwrap().query.is_empty());
 
             let key = KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE);
-            app.handle_event(AppEvent::Key(key)).unwrap();
+            app.handle_event(AppEvent::Key(key));
 
             assert!(app.file_picker_state.is_none());
         }
@@ -2709,7 +2705,7 @@ mod tests {
             app.input = "hello".into();
             app.cursor_position = 5;
             let key = KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL);
-            app.handle_event(AppEvent::Key(key)).unwrap();
+            app.handle_event(AppEvent::Key(key));
             assert_eq!(
                 app.input, "hello",
                 "input should be unchanged while picker is open"
@@ -2734,7 +2730,7 @@ mod tests {
                 .unwrap();
 
             let key = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
-            app.handle_event(AppEvent::Key(key)).unwrap();
+            app.handle_event(AppEvent::Key(key));
 
             assert!(app.input.contains(&selected));
             assert!(app.input.starts_with('a'));

--- a/crates/zeph-tui/src/error.rs
+++ b/crates/zeph-tui/src/error.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, thiserror::Error)]
+pub enum TuiError {
+    #[error("terminal I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("channel error: {0}")]
+    Channel(#[from] zeph_core::channel::ChannelError),
+}

--- a/crates/zeph-tui/src/lib.rs
+++ b/crates/zeph-tui/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod app;
 pub mod channel;
 pub mod command;
+pub mod error;
 pub mod event;
 pub mod file_picker;
 pub mod highlight;
@@ -14,21 +15,20 @@ pub mod widgets;
 
 use std::io;
 
-use ratatui::Terminal;
-use ratatui::backend::CrosstermBackend;
-use tokio::sync::mpsc;
-use zeph_core::channel::ChannelError;
-
 pub use app::App;
 pub use channel::TuiChannel;
 pub use command::TuiCommand;
+pub use error::TuiError;
 pub use event::{AgentEvent, AppEvent, CrosstermEventSource, EventReader, EventSource};
 pub use metrics::{MetricsCollector, MetricsSnapshot};
+use ratatui::Terminal;
+use ratatui::backend::CrosstermBackend;
+use tokio::sync::mpsc;
 
 /// # Errors
 ///
 /// Returns an error if terminal init/restore or rendering fails.
-pub async fn run_tui(mut app: App, mut event_rx: mpsc::Receiver<AppEvent>) -> anyhow::Result<()> {
+pub async fn run_tui(mut app: App, mut event_rx: mpsc::Receiver<AppEvent>) -> Result<(), TuiError> {
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
         let _ = crossterm::terminal::disable_raw_mode();
@@ -56,7 +56,7 @@ async fn tui_loop(
     app: &mut App,
     event_rx: &mut mpsc::Receiver<AppEvent>,
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
-) -> anyhow::Result<()> {
+) -> Result<(), TuiError> {
     let mut tick = tokio::time::interval(std::time::Duration::from_millis(250));
     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
@@ -72,7 +72,7 @@ async fn tui_loop(
         tokio::select! {
             biased;
             Some(event) = event_rx.recv() => {
-                app.handle_event(event)?;
+                app.handle_event(event);
             }
             Some(agent_event) = app.poll_agent_event() => {
                 app.handle_agent_event(agent_event);
@@ -90,7 +90,7 @@ async fn tui_loop(
     Ok(())
 }
 
-fn init_terminal() -> Result<Terminal<CrosstermBackend<io::Stdout>>, ChannelError> {
+fn init_terminal() -> Result<Terminal<CrosstermBackend<io::Stdout>>, TuiError> {
     crossterm::terminal::enable_raw_mode()?;
     let mut stdout = io::stdout();
     crossterm::execute!(
@@ -102,9 +102,7 @@ fn init_terminal() -> Result<Terminal<CrosstermBackend<io::Stdout>>, ChannelErro
     Ok(Terminal::new(backend)?)
 }
 
-fn restore_terminal(
-    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
-) -> Result<(), ChannelError> {
+fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<(), TuiError> {
     crossterm::terminal::disable_raw_mode()?;
     crossterm::execute!(
         terminal.backend_mut(),

--- a/crates/zeph-tui/src/widgets/input.rs
+++ b/crates/zeph-tui/src/widgets/input.rs
@@ -79,8 +79,7 @@ mod tests {
                 crossterm::event::KeyCode::Esc,
                 crossterm::event::KeyModifiers::NONE,
             ),
-        ))
-        .unwrap();
+        ));
         let output = render_to_string(40, 5, |frame, area| {
             super::render(&app, frame, area);
         });

--- a/src/main.rs
+++ b/src/main.rs
@@ -683,7 +683,8 @@ async fn main() -> anyhow::Result<()> {
         tokio::select! {
             result = tui_task => {
                 agent.shutdown().await;
-                return result?;
+                result??;
+                return Ok(());
             }
             result = agent_future => {
                 agent.shutdown().await;


### PR DESCRIPTION
## Summary

- Replace `anyhow` in `zeph-core::config` with typed `ConfigError` enum (Io, Parse, Validation, Vault) via thiserror
- Replace `anyhow` in `zeph-tui` with typed `TuiError` enum (Io, Channel); simplify `handle_event()` return to `()`
- Sort `[workspace.dependencies]` alphabetically in root Cargo.toml
- Issues 9.4 (LlmProvider) and 9.5 (VectorStore) skipped: LlmProvider already uses RPITIT; VectorStore used as `dyn` requiring BoxFuture

## Test plan

- [x] 2048/2048 tests pass (`cargo nextest run --workspace --lib --bins`)
- [x] No `anyhow` in zeph-core::config or zeph-tui
- [x] ConfigError covers all config error paths (Io, Parse, Validation, Vault)
- [x] TuiError covers all TUI error paths (Io, Channel)
- [x] Workspace deps sorted alphabetically
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean

Closes #626