### PR TITLE
feat(zeph-skills): align SKILL.md parser with agentskills.io spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- `allowed-tools` SKILL.md field now uses space-separated values per agentskills.io spec (was comma-separated) — **breaking change** for skills using comma-delimited allowed-tools (#686)
+
 ### Added
+- Nested `metadata:` block support in SKILL.md frontmatter: indented key-value pairs under `metadata:` are parsed as structured metadata (#686)
+- Field length validation in SKILL.md loader: `description` capped at 1024 characters, `compatibility` capped at 500 characters (#686)
+- Warning log in `load_skill_body()` when body exceeds 20,000 bytes (~5000 tokens) per spec recommendation (#686)
+- Empty value normalization for `compatibility` and `license` frontmatter fields: bare `compatibility:` now produces `None` instead of `Some("")` (#686)
 - `SkillManager` in zeph-skills — install skills from git URLs or local paths, remove, verify blake3 integrity, list with trust metadata
 - CLI subcommands: `zeph skill {install, remove, list, verify, trust, block, unblock}` — runs without agent loop
 - In-session `/skill install <url|path>` and `/skill remove <name>` with hot reload

--- a/docs/src/guides/custom-skills.md
+++ b/docs/src/guides/custom-skills.md
@@ -32,7 +32,7 @@ into the LLM context when the skill is matched.
 | `name` | Yes | Unique identifier (1-64 chars, lowercase, hyphens allowed) |
 | `description` | Yes | Used for embedding-based matching against user queries |
 | `compatibility` | No | Runtime requirements (e.g., "requires curl") |
-| `allowed-tools` | No | Comma-separated tool names this skill can use |
+| `allowed-tools` | No | Space-separated tool names this skill can use |
 | `requires-secrets` | No | Comma-separated secret names the skill needs (see below) |
 
 ### Secret-Gated Skills


### PR DESCRIPTION
## Summary

Aligns the SKILL.md frontmatter parser (`crates/zeph-skills/src/loader.rs`) with the [Agent Skills specification](https://agentskills.io/specification.md).

- `allowed-tools` field now uses space-separated values per spec (was comma-separated)
- Nested `metadata:` block parsing with indentation-aware key-value extraction
- `description` capped at 1024 chars, `compatibility` capped at 500 chars per spec
- Body size warning when SKILL.md body exceeds 20KB (~5000 tokens recommended)
- `compatibility`/`license` empty values normalized to `None`
- 13 new tests, 1 updated test

Closes #686

## Breaking changes

- `allowed-tools` delimiter changed from comma to space. Existing skills using commas need updating.

## Test plan

- [x] `cargo nextest run -p zeph-skills` — 56 tests pass
- [x] `cargo nextest run --workspace --lib --bins` — 2227 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo +nightly fmt --check` — clean

## Follow-up issues

- #687 — Lazy resource loading (progressive disclosure)
- #688 — Vendor prefix for `requires-secrets` extension
- #689 — File reference validation and body sanitization