### PR TITLE
refactor(zeph-skills): lazy resource loading per progressive disclosure spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - `requires-secrets` SKILL.md frontmatter field renamed to `x-requires-secrets` to follow JSON Schema vendor extension convention and avoid future spec collisions — **breaking change**: update skill frontmatter to use `x-requires-secrets`; the old `requires-secrets` form is still parsed with a deprecation warning (#688)
 - `allowed-tools` SKILL.md field now uses space-separated values per agentskills.io spec (was comma-separated) — **breaking change** for skills using comma-delimited allowed-tools (#686)
+- Skill resource files (references, scripts, assets) are no longer eagerly injected into the system prompt on skill activation; only filenames are listed as available resources — **breaking change** for skills relying on auto-injected reference content (#687)
 
 ### Added
+- `load_skill_resource(skill_dir, relative_path)` public function in `zeph-skills::resource` for on-demand loading of skill resource files with path traversal protection (#687)
 - Nested `metadata:` block support in SKILL.md frontmatter: indented key-value pairs under `metadata:` are parsed as structured metadata (#686)
 - Field length validation in SKILL.md loader: `description` capped at 1024 characters, `compatibility` capped at 500 characters (#686)
 - Warning log in `load_skill_body()` when body exceeds 20,000 bytes (~5000 tokens) per spec recommendation (#686)

--- a/crates/zeph-core/src/agent/context.rs
+++ b/crates/zeph-core/src/agent/context.rs
@@ -795,7 +795,7 @@ impl<C: Channel> Agent<C> {
             .collect();
 
         let trust_map = self.build_skill_trust_map().await;
-        let skills_prompt = format_skills_prompt(&active_skills, std::env::consts::OS, &trust_map);
+        let skills_prompt = format_skills_prompt(&active_skills, &trust_map);
         let catalog_prompt = format_skills_catalog(&remaining_skills);
         self.skill_state
             .last_skills_prompt

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -171,7 +171,7 @@ impl<C: Channel> Agent<C> {
             .filter_map(|m| registry.get_skill(&m.name).ok())
             .collect();
         let empty_trust = HashMap::new();
-        let skills_prompt = format_skills_prompt(&all_skills, std::env::consts::OS, &empty_trust);
+        let skills_prompt = format_skills_prompt(&all_skills, &empty_trust);
         let system_prompt = build_system_prompt(&skills_prompt, None, None, false);
         tracing::debug!(len = system_prompt.len(), "initial system prompt built");
         tracing::trace!(prompt = %system_prompt, "full system prompt");
@@ -702,7 +702,7 @@ impl<C: Channel> Agent<C> {
             .filter_map(|m| self.skill_state.registry.get_skill(&m.name).ok())
             .collect();
         let trust_map = self.build_skill_trust_map().await;
-        let skills_prompt = format_skills_prompt(&all_skills, std::env::consts::OS, &trust_map);
+        let skills_prompt = format_skills_prompt(&all_skills, &trust_map);
         self.skill_state
             .last_skills_prompt
             .clone_from(&skills_prompt);

--- a/crates/zeph-skills/src/lib.rs
+++ b/crates/zeph-skills/src/lib.rs
@@ -8,7 +8,7 @@ pub mod matcher;
 pub mod prompt;
 pub mod qdrant_matcher;
 pub mod registry;
-pub(crate) mod resource;
+pub mod resource;
 pub mod trust;
 pub mod watcher;
 


### PR DESCRIPTION
## Summary

- Remove eager reference/script/asset injection from `format_skills_prompt()`
- Skill activation now lists available resource filenames without loading content
- Add public `load_skill_resource()` in resource.rs for on-demand loading with path traversal protection
- Remove unused `os_family` parameter from `format_skills_prompt()`

Closes #687

## Test plan

- [x] `cargo nextest run --workspace --lib --bins` — 2227 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo +nightly fmt --check` — clean