### PR TITLE
Add crates.io publishing metadata to all workspace crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ version = "0.11.3"
 authors = ["bug-ops"]
 license = "MIT"
 repository = "https://github.com/bug-ops/zeph"
+homepage = "https://github.com/bug-ops/zeph"
+documentation = "https://docs.rs/zeph"
+keywords = ["ai", "agent", "llm", "inference", "skills"]
+categories = ["command-line-utilities", "science"]
 
 [workspace.dependencies]
 age = { version = "0.11.2", default-features = false }
@@ -113,6 +117,12 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Lightweight AI agent with hybrid inference, skills-first architecture, and multi-channel I/O"
+readme = "README.md"
 
 [features]
 default = []

--- a/crates/zeph-a2a/Cargo.toml
+++ b/crates/zeph-a2a/Cargo.toml
@@ -5,6 +5,12 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/zeph-a2a"
+keywords.workspace = true
+categories.workspace = true
+description = "A2A protocol client and server with agent discovery for Zeph"
+readme = "README.md"
 
 [features]
 server = ["dep:axum", "dep:subtle", "dep:tower", "dep:tower-http"]

--- a/crates/zeph-channels/Cargo.toml
+++ b/crates/zeph-channels/Cargo.toml
@@ -5,6 +5,12 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/zeph-channels"
+keywords.workspace = true
+categories.workspace = true
+description = "Multi-channel I/O adapters (CLI, Telegram, Discord, Slack) for Zeph"
+readme = "README.md"
 
 [features]
 discord = ["dep:tokio-tungstenite", "dep:futures"]

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -5,6 +5,12 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/zeph-core"
+keywords.workspace = true
+categories.workspace = true
+description = "Core agent loop, configuration, context builder, metrics, and vault for Zeph"
+readme = "README.md"
 
 [features]
 default = []

--- a/crates/zeph-gateway/Cargo.toml
+++ b/crates/zeph-gateway/Cargo.toml
@@ -5,6 +5,12 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/zeph-gateway"
+keywords.workspace = true
+categories.workspace = true
+description = "HTTP gateway for webhook ingestion with bearer auth for Zeph"
+readme = "README.md"
 
 [dependencies]
 axum.workspace = true

--- a/crates/zeph-index/Cargo.toml
+++ b/crates/zeph-index/Cargo.toml
@@ -5,6 +5,12 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/zeph-index"
+keywords.workspace = true
+categories.workspace = true
+description = "AST-based code indexing and semantic retrieval for Zeph"
+readme = "README.md"
 
 [features]
 default = ["lang-rust", "lang-python", "lang-js", "lang-go", "lang-config"]

--- a/crates/zeph-llm/Cargo.toml
+++ b/crates/zeph-llm/Cargo.toml
@@ -5,6 +5,12 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/zeph-llm"
+keywords.workspace = true
+categories.workspace = true
+description = "LLM provider abstraction with Ollama, Claude, OpenAI, and Candle backends"
+readme = "README.md"
 
 [features]
 default = []

--- a/crates/zeph-mcp/Cargo.toml
+++ b/crates/zeph-mcp/Cargo.toml
@@ -5,6 +5,12 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/zeph-mcp"
+keywords.workspace = true
+categories.workspace = true
+description = "MCP client with multi-server lifecycle and Qdrant tool registry for Zeph"
+readme = "README.md"
 
 [features]
 default = []

--- a/crates/zeph-memory/Cargo.toml
+++ b/crates/zeph-memory/Cargo.toml
@@ -5,6 +5,12 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/zeph-memory"
+keywords.workspace = true
+categories.workspace = true
+description = "Semantic memory with SQLite and Qdrant for Zeph agent"
+readme = "README.md"
 
 [dependencies]
 pdf-extract = { workspace = true, optional = true }

--- a/crates/zeph-scheduler/Cargo.toml
+++ b/crates/zeph-scheduler/Cargo.toml
@@ -5,6 +5,12 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/zeph-scheduler"
+keywords.workspace = true
+categories.workspace = true
+description = "Cron-based periodic task scheduler with SQLite persistence for Zeph"
+readme = "README.md"
 
 [dependencies]
 chrono.workspace = true

--- a/crates/zeph-skills/Cargo.toml
+++ b/crates/zeph-skills/Cargo.toml
@@ -5,6 +5,12 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/zeph-skills"
+keywords.workspace = true
+categories.workspace = true
+description = "SKILL.md parser, registry, embedding matcher, and hot-reload for Zeph"
+readme = "README.md"
 
 [features]
 default = []

--- a/crates/zeph-tools/Cargo.toml
+++ b/crates/zeph-tools/Cargo.toml
@@ -5,6 +5,12 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/zeph-tools"
+keywords.workspace = true
+categories.workspace = true
+description = "Tool executor trait with shell, web scrape, and composite executors for Zeph"
+readme = "README.md"
 
 [dependencies]
 dirs = "6.0"

--- a/crates/zeph-tui/Cargo.toml
+++ b/crates/zeph-tui/Cargo.toml
@@ -5,6 +5,12 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/zeph-tui"
+keywords.workspace = true
+categories.workspace = true
+description = "Ratatui-based TUI dashboard with real-time metrics for Zeph"
+readme = "README.md"
 
 [dependencies]
 ignore.workspace = true


### PR DESCRIPTION
## Summary

- Add required `description` and `readme` fields to all 13 crates (unique per crate)
- Add `homepage`, `keywords`, `categories` at workspace level
- Add per-crate `documentation` pointing to docs.rs

## Test plan

- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo nextest run --workspace --lib --bins` — 2241 passed, 9 skipped
- [ ] Verify with `cargo publish -p zeph-llm --dry-run`