### PR TITLE
docs: add crates.io installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Zeph takes the opposite approach: **automated context engineering**. Only releva
 <summary>Other installation methods</summary>
 
 ```bash
+# From crates.io
+cargo install zeph
+
 # From source
 cargo install --git https://github.com/bug-ops/zeph
 

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -28,6 +28,18 @@ After installation, run the configuration wizard:
 zeph init
 ```
 
+## From crates.io
+
+```bash
+cargo install zeph
+```
+
+With optional features:
+
+```bash
+cargo install zeph --features tui,a2a
+```
+
 ## From Source
 
 ```bash


### PR DESCRIPTION
## Summary

- Add `cargo install zeph` to root README installation methods
- Add dedicated "From crates.io" section to mdBook installation guide with feature flags example

## Test plan

- [x] All checks pass
- [x] Verified `cargo install zeph` works from crates.io