### PR TITLE
ci: add automated crates.io publishing to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,14 +103,18 @@ jobs:
             zeph-${{ matrix.target }}.zip.sha256
           retention-days: 3
 
-  create-release:
-    name: Create GitHub Release
+  publish-crates:
+    name: Publish to crates.io
     needs: [build-binaries]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: release
     permissions:
-      contents: write
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
       - name: Verify version matches tag
         run: |
           TAG_VERSION="${GITHUB_REF#refs/tags/v}"
@@ -119,6 +123,24 @@ jobs:
             echo "Tag version ($TAG_VERSION) does not match Cargo.toml version ($CARGO_VERSION)"
             exit 1
           fi
+      - name: Authenticate with crates.io (OIDC)
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      - name: Publish crates to crates.io
+        uses: katyo/publish-crates@v2
+        with:
+          registry-token: ${{ steps.auth.outputs.token }}
+          ignore-unpublished-changes: true
+          publish-delay: 15000
+
+  create-release:
+    name: Create GitHub Release
+    needs: [build-binaries, publish-crates]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
       - name: Download all artifacts
         uses: actions/download-artifact@v7
         with:


### PR DESCRIPTION
## Summary

- Add `publish-crates` job to release workflow triggered on `v*` tags
- OIDC trusted publishing via `rust-lang/crates-io-auth-action` (no manual API token)
- `katyo/publish-crates` handles workspace topological ordering with 15s inter-crate delay
- Version tag verification before publishing
- Job dependency: `build-binaries` -> `publish-crates` -> `create-release`

## Setup required

Configure [trusted publishers](https://blog.rust-lang.org/2023/11/09/crates-io-trusted-publishing.html) on crates.io for each workspace crate:
- Repository: `bug-ops/zeph`
- Workflow: `release.yml`
- Environment: `release`

Create a `release` environment in GitHub repo settings (Settings > Environments).

## Test plan

- [ ] Push a tag to verify the workflow runs correctly
- [x] YAML syntax validated