### PR TITLE
feat: add sub-agent orchestration with zero-trust permission model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - ReDoS protection: RegexBuilder with size_limit, 512-char pattern cap, 1 MiB file size limit
 - Dedup strategy with configurable normalization patterns and HashMap pre-allocation
 - NormalizeEntry replacement validation (rejects unescaped `$` capture group refs)
+- Sub-agent orchestration system with A2A protocol integration (#709)
+- Sub-agent definition format with TOML frontmatter parser (#710)
+- `SubAgentManager` with spawn/cancel/collect lifecycle (#711)
+- Tool filtering (AllowList/DenyList/InheritAll) and skill filtering with glob patterns (#712)
+- Zero-trust permission model with TTL-based grants and automatic revocation (#713)
+- In-process A2A channels for orchestrator-to-sub-agent communication
+- `PermissionGrants` with audit trail via tracing
 
 ### Changed
 - Migrated all 6 hardcoded filters (cargo_build, test_output, clippy, git, dir_listing, log_dedup) into the declarative TOML engine

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9155,6 +9155,8 @@ dependencies = [
  "tokio-util",
  "toml 1.0.3+spec-1.1.0",
  "tracing",
+ "uuid",
+ "zeph-a2a",
  "zeph-index",
  "zeph-llm",
  "zeph-mcp",

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ flowchart TD
 | **Rate limiter** | TTL-based eviction, per-IP limits on gateway |
 | **Doom-loop detection** | Runaway tool cycles (3 identical outputs = break) |
 | **Skill trust quarantine** | 4-tier model (Trusted/Verified/Quarantined/Blocked) with blake3 integrity |
+| **Sub-agent sandboxing** | Zero-trust permission grants: each sub-agent receives only explicitly delegated tools, skills, and secrets |
 | **Container scanning** | Trivy in CI — 0 HIGH/CRITICAL CVEs |
 
 [Security model →](https://bug-ops.github.io/zeph/reference/security.html) · [MCP security →](https://bug-ops.github.io/zeph/reference/security/mcp.html)
@@ -288,6 +289,7 @@ Skills can declare **required secrets** via the `x-requires-secrets` frontmatter
 |----------|-------------|
 | **MCP** | Connect external tool servers (stdio + HTTP) with SSRF protection, command allowlist, and env var blocklist |
 | **A2A** | Agent-to-agent communication via JSON-RPC 2.0 with SSE streaming |
+| **Sub-agent orchestration** | Spawn scoped sub-agents with zero-trust permissions, filtered tools/skills, and A2A-based in-process channels |
 | **Audio input** | Speech-to-text via OpenAI Whisper API or local Candle Whisper (offline, feature-gated); Telegram and Slack audio files transcribed automatically |
 | **Vision** | Image input via CLI (`/image`), TUI (`/image`), and Telegram photo messages; supported by Claude, OpenAI, and Ollama providers (20 MB max, automatic MIME detection) |
 | **Channels** | CLI (with persistent input history), Telegram (text + voice), Discord, Slack, TUI — all with streaming support |

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -36,6 +36,8 @@ tokio-util.workspace = true
 tokio-stream.workspace = true
 toml.workspace = true
 tracing.workspace = true
+uuid = { workspace = true, features = ["v4"] }
+zeph-a2a.workspace = true
 zeph-index = { workspace = true, optional = true }
 zeph-llm.workspace = true
 zeph-mcp.workspace = true

--- a/crates/zeph-core/README.md
+++ b/crates/zeph-core/README.md
@@ -5,11 +5,11 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](../../LICENSE)
 [![MSRV](https://img.shields.io/badge/MSRV-1.88-blue)](https://www.rust-lang.org)
 
-Core agent loop, configuration, context builder, metrics, and vault for Zeph.
+Core agent loop, configuration, context builder, metrics, vault, and sub-agent orchestration for Zeph.
 
 ## Overview
 
-Core orchestration crate for the Zeph agent. Manages the main agent loop, bootstraps the application from TOML configuration with environment variable overrides, and assembles the LLM context from conversation history, skills, and memory. All other workspace crates are coordinated through `zeph-core`.
+Core orchestration crate for the Zeph agent. Manages the main agent loop, bootstraps the application from TOML configuration with environment variable overrides, and assembles the LLM context from conversation history, skills, and memory. Includes sub-agent orchestration with zero-trust permission grants, filtered tool/skill access, and A2A-based in-process communication channels. All other workspace crates are coordinated through `zeph-core`.
 
 ## Key modules
 
@@ -33,6 +33,7 @@ Core orchestration crate for the Zeph agent. Manages the main agent loop, bootst
 | `vault` | Secret storage and resolution via vault providers (age-encrypted read/write); scans `ZEPH_SECRET_*` keys to build the custom-secrets map used by skill env injection |
 | `diff` | Diff rendering utilities |
 | `pipeline` | Composable, type-safe step chains for multi-stage workflows |
+| `subagent` | Sub-agent orchestration: `SubAgentManager` lifecycle, `SubAgentDef` TOML definitions, `PermissionGrants` zero-trust delegation, `FilteredToolExecutor` scoped tool access, A2A in-process channels |
 
 **Re-exports:** `Agent`
 

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -153,6 +153,8 @@ pub struct Agent<C: Channel> {
     cached_prompt_tokens: u64,
     stt: Option<Box<dyn SpeechToText>>,
     update_notify_rx: Option<mpsc::Receiver<String>>,
+    #[allow(dead_code)]
+    pub(crate) subagent_manager: Option<crate::subagent::SubAgentManager>,
 }
 
 impl<C: Channel> Agent<C> {
@@ -253,6 +255,7 @@ impl<C: Channel> Agent<C> {
             cached_prompt_tokens: initial_prompt_tokens,
             stt: None,
             update_notify_rx: None,
+            subagent_manager: None,
         }
     }
 

--- a/crates/zeph-core/src/lib.rs
+++ b/crates/zeph-core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod vault;
 
 pub mod diff;
 pub mod http;
+pub mod subagent;
 
 pub use agent::Agent;
 pub use agent::error::AgentError;

--- a/crates/zeph-core/src/subagent/channel.rs
+++ b/crates/zeph-core/src/subagent/channel.rs
@@ -1,0 +1,84 @@
+use tokio::sync::mpsc;
+use zeph_a2a::types::{Message, TaskArtifactUpdateEvent, TaskStatusUpdateEvent};
+
+/// Messages exchanged between the orchestrator and a sub-agent over the in-process channel.
+#[derive(Debug)]
+pub enum A2aMessage {
+    SendMessage(Message),
+    StatusUpdate(TaskStatusUpdateEvent),
+    ArtifactUpdate(TaskArtifactUpdateEvent),
+    Cancel,
+}
+
+/// Orchestrator-side half of the sub-agent channel.
+pub struct OrchestratorHalf {
+    pub tx: mpsc::Sender<A2aMessage>,
+    pub rx: mpsc::Receiver<A2aMessage>,
+}
+
+/// Sub-agent-side half of the in-process A2A channel.
+pub struct AgentHalf {
+    pub tx: mpsc::Sender<A2aMessage>,
+    pub rx: mpsc::Receiver<A2aMessage>,
+}
+
+/// Create a bidirectional in-process channel between orchestrator and sub-agent.
+#[must_use]
+pub fn new_channel(buffer: usize) -> (OrchestratorHalf, AgentHalf) {
+    let (orch_tx, agent_rx) = mpsc::channel::<A2aMessage>(buffer);
+    let (agent_tx, orch_rx) = mpsc::channel::<A2aMessage>(buffer);
+    (
+        OrchestratorHalf {
+            tx: orch_tx,
+            rx: orch_rx,
+        },
+        AgentHalf {
+            tx: agent_tx,
+            rx: agent_rx,
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use zeph_a2a::types::{Message, Part, Role, TaskState, TaskStatus, TaskStatusUpdateEvent};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn send_receive_round_trip() {
+        let (mut orch, mut agent) = new_channel(8);
+
+        let msg = A2aMessage::StatusUpdate(TaskStatusUpdateEvent {
+            kind: "status-update".into(),
+            task_id: "task-1".into(),
+            context_id: None,
+            status: TaskStatus {
+                state: TaskState::Working,
+                timestamp: "2026-01-01T00:00:00Z".into(),
+                message: None,
+            },
+            is_final: false,
+        });
+        orch.tx.send(msg).await.unwrap();
+
+        let received = agent.rx.recv().await.unwrap();
+        assert!(matches!(received, A2aMessage::StatusUpdate(_)));
+
+        let reply = A2aMessage::SendMessage(Message {
+            role: Role::Agent,
+            parts: vec![Part::Text {
+                text: "hello".into(),
+                metadata: None,
+            }],
+            message_id: None,
+            task_id: None,
+            context_id: None,
+            metadata: None,
+        });
+        agent.tx.send(reply).await.unwrap();
+
+        let back = orch.rx.recv().await.unwrap();
+        assert!(matches!(back, A2aMessage::SendMessage(_)));
+    }
+}

--- a/crates/zeph-core/src/subagent/def.rs
+++ b/crates/zeph-core/src/subagent/def.rs
@@ -1,0 +1,459 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use super::error::SubAgentError;
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubAgentDef {
+    pub name: String,
+    pub description: String,
+    pub model: Option<String>,
+    pub tools: ToolPolicy,
+    pub permissions: SubAgentPermissions,
+    pub skills: SkillFilter,
+    pub system_prompt: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolPolicy {
+    AllowList(Vec<String>),
+    DenyList(Vec<String>),
+    InheritAll,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubAgentPermissions {
+    pub secrets: Vec<String>,
+    pub max_turns: u32,
+    pub background: bool,
+    pub timeout_secs: u64,
+    pub ttl_secs: u64,
+}
+
+impl Default for SubAgentPermissions {
+    fn default() -> Self {
+        Self {
+            secrets: Vec::new(),
+            max_turns: 20,
+            background: false,
+            timeout_secs: 600,
+            ttl_secs: 300,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SkillFilter {
+    pub include: Vec<String>,
+    pub exclude: Vec<String>,
+}
+
+// ── Raw TOML deserialization structs ─────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct RawSubAgentDef {
+    name: String,
+    description: String,
+    model: Option<String>,
+    #[serde(default)]
+    tools: RawToolPolicy,
+    #[serde(default)]
+    permissions: RawPermissions,
+    #[serde(default)]
+    skills: RawSkillFilter,
+}
+
+#[derive(Default, Deserialize)]
+struct RawToolPolicy {
+    allow: Option<Vec<String>>,
+    deny: Option<Vec<String>>,
+}
+
+#[derive(Deserialize)]
+struct RawPermissions {
+    #[serde(default)]
+    secrets: Vec<String>,
+    #[serde(default = "default_max_turns")]
+    max_turns: u32,
+    #[serde(default)]
+    background: bool,
+    #[serde(default = "default_timeout")]
+    timeout_secs: u64,
+    #[serde(default = "default_ttl")]
+    ttl_secs: u64,
+}
+
+impl Default for RawPermissions {
+    fn default() -> Self {
+        Self {
+            secrets: Vec::new(),
+            max_turns: default_max_turns(),
+            background: false,
+            timeout_secs: default_timeout(),
+            ttl_secs: default_ttl(),
+        }
+    }
+}
+
+#[derive(Default, Deserialize)]
+struct RawSkillFilter {
+    #[serde(default)]
+    include: Vec<String>,
+    #[serde(default)]
+    exclude: Vec<String>,
+}
+
+fn default_max_turns() -> u32 {
+    20
+}
+fn default_timeout() -> u64 {
+    600
+}
+fn default_ttl() -> u64 {
+    300
+}
+
+// ── Parser ────────────────────────────────────────────────────────────────────
+
+/// Split TOML frontmatter from markdown body.
+///
+/// Expected format:
+/// ```text
+/// +++
+/// <toml content>
+/// +++
+///
+/// <body>
+/// ```
+fn split_toml_frontmatter<'a>(
+    content: &'a str,
+    path: &str,
+) -> Result<(&'a str, &'a str), SubAgentError> {
+    let make_err = |reason: &str| SubAgentError::Parse {
+        path: path.to_owned(),
+        reason: reason.to_owned(),
+    };
+
+    let rest = content
+        .strip_prefix("+++")
+        .and_then(|s| s.strip_prefix('\n').or_else(|| s.strip_prefix("\r\n")))
+        .ok_or_else(|| make_err("missing opening `+++` delimiter"))?;
+
+    let (toml_str, after) = rest
+        .split_once("\n+++")
+        .ok_or_else(|| make_err("missing closing `+++` delimiter"))?;
+
+    // body starts after optional newline following the closing +++
+    let body = after
+        .strip_prefix('\n')
+        .or_else(|| after.strip_prefix("\r\n"))
+        .unwrap_or(after);
+
+    Ok((toml_str, body))
+}
+
+impl SubAgentDef {
+    /// Parse a sub-agent definition from its markdown+TOML frontmatter content.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SubAgentError::Parse`] if the frontmatter delimiters are missing or the
+    /// TOML is malformed, and [`SubAgentError::Invalid`] if required fields are empty or
+    /// `tools.allow` and `tools.deny` are both specified.
+    pub fn parse(content: &str) -> Result<Self, SubAgentError> {
+        Self::parse_with_path(content, "<unknown>")
+    }
+
+    fn parse_with_path(content: &str, path: &str) -> Result<Self, SubAgentError> {
+        let (toml_str, body) = split_toml_frontmatter(content, path)?;
+
+        let raw: RawSubAgentDef = toml::from_str(toml_str).map_err(|e| SubAgentError::Parse {
+            path: path.to_owned(),
+            reason: e.to_string(),
+        })?;
+
+        if raw.name.trim().is_empty() {
+            return Err(SubAgentError::Invalid("name must not be empty".into()));
+        }
+        if raw.description.trim().is_empty() {
+            return Err(SubAgentError::Invalid(
+                "description must not be empty".into(),
+            ));
+        }
+
+        let tools = match (raw.tools.allow, raw.tools.deny) {
+            (None, None) => ToolPolicy::InheritAll,
+            (Some(list), None) => ToolPolicy::AllowList(list),
+            (None, Some(list)) => ToolPolicy::DenyList(list),
+            (Some(_), Some(_)) => {
+                return Err(SubAgentError::Invalid(
+                    "tools.allow and tools.deny are mutually exclusive".into(),
+                ));
+            }
+        };
+
+        let p = raw.permissions;
+        Ok(Self {
+            name: raw.name,
+            description: raw.description,
+            model: raw.model,
+            tools,
+            permissions: SubAgentPermissions {
+                secrets: p.secrets,
+                max_turns: p.max_turns,
+                background: p.background,
+                timeout_secs: p.timeout_secs,
+                ttl_secs: p.ttl_secs,
+            },
+            skills: SkillFilter {
+                include: raw.skills.include,
+                exclude: raw.skills.exclude,
+            },
+            system_prompt: body.trim().to_owned(),
+        })
+    }
+
+    /// Load a single definition from a `.md` file.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SubAgentError::Parse`] if the file cannot be read or parsed.
+    pub fn load(path: &Path) -> Result<Self, SubAgentError> {
+        let content = std::fs::read_to_string(path).map_err(|e| SubAgentError::Parse {
+            path: path.display().to_string(),
+            reason: e.to_string(),
+        })?;
+        Self::parse_with_path(&content, &path.display().to_string())
+    }
+
+    /// Load all definitions from a list of directories.
+    ///
+    /// Directories are processed in order; when two files share the same agent
+    /// `name`, the first one wins (higher-priority path takes precedence).
+    /// Non-existent directories are silently skipped.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SubAgentError`] if any `.md` file fails to parse.
+    pub fn load_all(dirs: &[PathBuf]) -> Result<Vec<Self>, SubAgentError> {
+        let mut seen: HashSet<String> = HashSet::new();
+        let mut result = Vec::new();
+
+        for dir in dirs {
+            let Ok(read_dir) = std::fs::read_dir(dir) else {
+                continue; // directory doesn't exist — skip silently
+            };
+
+            let mut entries: Vec<PathBuf> = read_dir
+                .filter_map(std::result::Result::ok)
+                .map(|e| e.path())
+                .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("md"))
+                .collect();
+
+            entries.sort(); // deterministic order within a directory
+
+            for path in entries {
+                let def = Self::load(&path)?;
+                if seen.contains(&def.name) {
+                    tracing::debug!(
+                        name = %def.name,
+                        path = %path.display(),
+                        "skipping duplicate sub-agent definition (shadowed by higher-priority path)"
+                    );
+                    continue;
+                }
+                seen.insert(def.name.clone());
+                result.push(def);
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FULL_DEF: &str = r#"+++
+name = "code-reviewer"
+description = "Reviews code changes for correctness and style"
+model = "claude-sonnet-4-20250514"
+
+[tools]
+allow = ["shell", "web_scrape"]
+
+[permissions]
+secrets = ["github-token"]
+max_turns = 10
+background = false
+timeout_secs = 300
+ttl_secs = 120
+
+[skills]
+include = ["git-*", "rust-*"]
+exclude = ["deploy-*"]
++++
+
+You are a code reviewer. Report findings with severity.
+"#;
+
+    const MINIMAL_DEF: &str = "+++\nname = \"bot\"\ndescription = \"A bot\"\n+++\n\nDo things.\n";
+
+    #[test]
+    fn parse_full_definition() {
+        let def = SubAgentDef::parse(FULL_DEF).unwrap();
+        assert_eq!(def.name, "code-reviewer");
+        assert_eq!(
+            def.description,
+            "Reviews code changes for correctness and style"
+        );
+        assert_eq!(def.model.as_deref(), Some("claude-sonnet-4-20250514"));
+        assert!(matches!(def.tools, ToolPolicy::AllowList(ref v) if v == &["shell", "web_scrape"]));
+        assert_eq!(def.permissions.max_turns, 10);
+        assert_eq!(def.permissions.secrets, ["github-token"]);
+        assert_eq!(def.skills.include, ["git-*", "rust-*"]);
+        assert_eq!(def.skills.exclude, ["deploy-*"]);
+        assert!(def.system_prompt.contains("code reviewer"));
+    }
+
+    #[test]
+    fn parse_minimal_definition() {
+        let def = SubAgentDef::parse(MINIMAL_DEF).unwrap();
+        assert_eq!(def.name, "bot");
+        assert_eq!(def.description, "A bot");
+        assert!(def.model.is_none());
+        assert!(matches!(def.tools, ToolPolicy::InheritAll));
+        assert_eq!(def.permissions.max_turns, 20);
+        assert_eq!(def.permissions.timeout_secs, 600);
+        assert_eq!(def.permissions.ttl_secs, 300);
+        assert!(!def.permissions.background);
+        assert_eq!(def.system_prompt, "Do things.");
+    }
+
+    #[test]
+    fn tool_policy_deny_list() {
+        let content =
+            "+++\nname = \"a\"\ndescription = \"b\"\n[tools]\ndeny = [\"shell\"]\n+++\n\nbody\n";
+        let def = SubAgentDef::parse(content).unwrap();
+        assert!(matches!(def.tools, ToolPolicy::DenyList(ref v) if v == &["shell"]));
+    }
+
+    #[test]
+    fn tool_policy_inherit_all() {
+        let def = SubAgentDef::parse(MINIMAL_DEF).unwrap();
+        assert!(matches!(def.tools, ToolPolicy::InheritAll));
+    }
+
+    #[test]
+    fn tool_policy_both_specified_is_error() {
+        let content = "+++\nname = \"a\"\ndescription = \"b\"\n[tools]\nallow = [\"x\"]\ndeny = [\"y\"]\n+++\n\nbody\n";
+        let err = SubAgentDef::parse(content).unwrap_err();
+        assert!(matches!(err, SubAgentError::Invalid(_)));
+    }
+
+    #[test]
+    fn missing_opening_delimiter() {
+        let err = SubAgentDef::parse("name = \"a\"\n+++\nbody\n").unwrap_err();
+        assert!(matches!(err, SubAgentError::Parse { .. }));
+    }
+
+    #[test]
+    fn missing_closing_delimiter() {
+        let err = SubAgentDef::parse("+++\nname = \"a\"\ndescription = \"b\"\n").unwrap_err();
+        assert!(matches!(err, SubAgentError::Parse { .. }));
+    }
+
+    #[test]
+    fn missing_required_field_name() {
+        let content = "+++\ndescription = \"b\"\n+++\n\nbody\n";
+        let err = SubAgentDef::parse(content).unwrap_err();
+        assert!(matches!(err, SubAgentError::Parse { .. }));
+    }
+
+    #[test]
+    fn missing_required_field_description() {
+        let content = "+++\nname = \"a\"\n+++\n\nbody\n";
+        let err = SubAgentDef::parse(content).unwrap_err();
+        assert!(matches!(err, SubAgentError::Parse { .. }));
+    }
+
+    #[test]
+    fn empty_name_is_invalid() {
+        let content = "+++\nname = \"\"\ndescription = \"b\"\n+++\n\nbody\n";
+        let err = SubAgentDef::parse(content).unwrap_err();
+        assert!(matches!(err, SubAgentError::Invalid(_)));
+    }
+
+    #[test]
+    fn load_all_deduplication_by_name() {
+        use std::io::Write as _;
+        let dir1 = tempfile::tempdir().unwrap();
+        let dir2 = tempfile::tempdir().unwrap();
+
+        // Same name "bot" in both dirs — dir1 wins (higher priority)
+        let content1 = "+++\nname = \"bot\"\ndescription = \"from dir1\"\n+++\n\ndir1 prompt\n";
+        let content2 = "+++\nname = \"bot\"\ndescription = \"from dir2\"\n+++\n\ndir2 prompt\n";
+
+        let mut f1 = std::fs::File::create(dir1.path().join("bot.md")).unwrap();
+        f1.write_all(content1.as_bytes()).unwrap();
+
+        let mut f2 = std::fs::File::create(dir2.path().join("bot.md")).unwrap();
+        f2.write_all(content2.as_bytes()).unwrap();
+
+        let dirs = vec![dir1.path().to_path_buf(), dir2.path().to_path_buf()];
+        let defs = SubAgentDef::load_all(&dirs).unwrap();
+
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].description, "from dir1");
+    }
+
+    #[test]
+    fn default_permissions_values() {
+        let p = SubAgentPermissions::default();
+        assert_eq!(p.max_turns, 20);
+        assert_eq!(p.timeout_secs, 600);
+        assert_eq!(p.ttl_secs, 300);
+        assert!(!p.background);
+        assert!(p.secrets.is_empty());
+    }
+
+    #[test]
+    fn whitespace_only_description_is_invalid() {
+        let content = "+++\nname = \"a\"\ndescription = \"   \"\n+++\n\nbody\n";
+        let err = SubAgentDef::parse(content).unwrap_err();
+        assert!(matches!(err, SubAgentError::Invalid(_)));
+    }
+
+    #[test]
+    fn load_nonexistent_file_returns_parse_error() {
+        let err =
+            SubAgentDef::load(std::path::Path::new("/tmp/does-not-exist-zeph.md")).unwrap_err();
+        assert!(matches!(err, SubAgentError::Parse { .. }));
+    }
+
+    #[test]
+    fn load_all_stops_on_parse_error_mid_scan() {
+        use std::io::Write as _;
+        let dir = tempfile::tempdir().unwrap();
+
+        let valid = "+++\nname = \"good\"\ndescription = \"ok\"\n+++\n\nbody\n";
+        let invalid = "this is not valid frontmatter";
+
+        let mut f1 = std::fs::File::create(dir.path().join("a_good.md")).unwrap();
+        f1.write_all(valid.as_bytes()).unwrap();
+
+        let mut f2 = std::fs::File::create(dir.path().join("b_bad.md")).unwrap();
+        f2.write_all(invalid.as_bytes()).unwrap();
+
+        let err = SubAgentDef::load_all(&[dir.path().to_path_buf()]).unwrap_err();
+        assert!(matches!(err, SubAgentError::Parse { .. }));
+    }
+}

--- a/crates/zeph-core/src/subagent/error.rs
+++ b/crates/zeph-core/src/subagent/error.rs
@@ -1,0 +1,20 @@
+#[derive(Debug, thiserror::Error)]
+pub enum SubAgentError {
+    #[error("parse error in {path}: {reason}")]
+    Parse { path: String, reason: String },
+
+    #[error("invalid definition: {0}")]
+    Invalid(String),
+
+    #[error("agent not found: {0}")]
+    NotFound(String),
+
+    #[error("spawn failed: {0}")]
+    Spawn(String),
+
+    #[error("cancelled")]
+    Cancelled,
+
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}

--- a/crates/zeph-core/src/subagent/filter.rs
+++ b/crates/zeph-core/src/subagent/filter.rs
@@ -1,0 +1,454 @@
+use std::collections::HashMap;
+use std::pin::Pin;
+
+use zeph_skills::loader::Skill;
+use zeph_skills::registry::SkillRegistry;
+use zeph_tools::ToolCall;
+use zeph_tools::executor::{ErasedToolExecutor, ToolError, ToolOutput};
+use zeph_tools::registry::ToolDef;
+
+use super::def::{SkillFilter, ToolPolicy};
+use super::error::SubAgentError;
+
+// ── Tool filtering ────────────────────────────────────────────────────────────
+
+/// Wraps an [`ErasedToolExecutor`] and enforces a [`ToolPolicy`].
+///
+/// All calls are checked against the policy before being forwarded to the inner
+/// executor. Rejected calls return a descriptive [`ToolError`].
+pub struct FilteredToolExecutor {
+    inner: Box<dyn ErasedToolExecutor>,
+    policy: ToolPolicy,
+}
+
+impl FilteredToolExecutor {
+    /// Create a new filtered executor.
+    #[must_use]
+    pub fn new(inner: Box<dyn ErasedToolExecutor>, policy: ToolPolicy) -> Self {
+        Self { inner, policy }
+    }
+
+    fn is_allowed(&self, tool_id: &str) -> bool {
+        match &self.policy {
+            ToolPolicy::InheritAll => true,
+            ToolPolicy::AllowList(list) => list.iter().any(|t| t == tool_id),
+            ToolPolicy::DenyList(list) => !list.iter().any(|t| t == tool_id),
+        }
+    }
+}
+
+impl ErasedToolExecutor for FilteredToolExecutor {
+    fn execute_erased<'a>(
+        &'a self,
+        _response: &'a str,
+    ) -> Pin<Box<dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a>>
+    {
+        // Fenced-block (markdown code block) invocation cannot have the tool name
+        // extracted before execution, so it cannot be checked against ToolPolicy.
+        // Sub-agents must use structured tool calls (execute_tool_call_erased).
+        // Fenced-block execution is disabled entirely for sub-agents to prevent
+        // policy bypass (SEC-03).
+        tracing::warn!("sub-agent attempted fenced-block tool invocation — blocked by policy");
+        Box::pin(std::future::ready(Err(ToolError::Blocked {
+            command: "fenced-block".into(),
+        })))
+    }
+
+    fn execute_confirmed_erased<'a>(
+        &'a self,
+        _response: &'a str,
+    ) -> Pin<Box<dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a>>
+    {
+        // Same as execute_erased: fenced-block is disabled for sub-agents.
+        Box::pin(std::future::ready(Err(ToolError::Blocked {
+            command: "fenced-block".into(),
+        })))
+    }
+
+    fn tool_definitions_erased(&self) -> Vec<ToolDef> {
+        // Filter the visible tool definitions according to the policy.
+        self.inner
+            .tool_definitions_erased()
+            .into_iter()
+            .filter(|def| self.is_allowed(def.id))
+            .collect()
+    }
+
+    fn execute_tool_call_erased<'a>(
+        &'a self,
+        call: &'a ToolCall,
+    ) -> Pin<Box<dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a>>
+    {
+        if !self.is_allowed(&call.tool_id) {
+            tracing::warn!(
+                tool_id = %call.tool_id,
+                "sub-agent tool call rejected by policy"
+            );
+            return Box::pin(std::future::ready(Err(ToolError::Blocked {
+                command: call.tool_id.clone(),
+            })));
+        }
+        Box::pin(self.inner.execute_tool_call_erased(call))
+    }
+
+    fn set_skill_env(&self, env: Option<HashMap<String, String>>) {
+        self.inner.set_skill_env(env);
+    }
+}
+
+// ── Skill filtering ───────────────────────────────────────────────────────────
+
+/// Filter skills from a registry according to a [`SkillFilter`].
+///
+/// Include patterns are glob-matched against skill names. If `include` is empty,
+/// all skills pass (unless excluded). Exclude patterns always take precedence.
+///
+/// # Errors
+///
+/// Returns [`SubAgentError::Invalid`] if any glob pattern is syntactically invalid.
+pub fn filter_skills(
+    registry: &SkillRegistry,
+    filter: &SkillFilter,
+) -> Result<Vec<Skill>, SubAgentError> {
+    let compiled_include = compile_globs(&filter.include)?;
+    let compiled_exclude = compile_globs(&filter.exclude)?;
+
+    let all: Vec<Skill> = registry
+        .all_meta()
+        .into_iter()
+        .filter(|meta| {
+            let name = &meta.name;
+            let included =
+                compiled_include.is_empty() || compiled_include.iter().any(|p| glob_match(p, name));
+            let excluded = compiled_exclude.iter().any(|p| glob_match(p, name));
+            included && !excluded
+        })
+        .filter_map(|meta| registry.get_skill(&meta.name).ok())
+        .collect();
+
+    Ok(all)
+}
+
+/// Compiled glob pattern: literal prefix + optional `*` wildcard suffix.
+struct GlobPattern {
+    raw: String,
+    prefix: String,
+    suffix: Option<String>,
+    is_star: bool,
+}
+
+fn compile_globs(patterns: &[String]) -> Result<Vec<GlobPattern>, SubAgentError> {
+    patterns.iter().map(|p| compile_glob(p)).collect()
+}
+
+fn compile_glob(pattern: &str) -> Result<GlobPattern, SubAgentError> {
+    // Simple glob: supports `*` as a wildcard anywhere in the string.
+    // For MVP we only need prefix-star patterns like "git-*" or "*".
+    if pattern.contains("**") {
+        return Err(SubAgentError::Invalid(format!(
+            "glob pattern '{pattern}' uses '**' which is not supported"
+        )));
+    }
+
+    let is_star = pattern == "*";
+
+    let (prefix, suffix) = if let Some(pos) = pattern.find('*') {
+        let before = pattern[..pos].to_owned();
+        let after = pattern[pos + 1..].to_owned();
+        (before, Some(after))
+    } else {
+        (pattern.to_owned(), None)
+    };
+
+    Ok(GlobPattern {
+        raw: pattern.to_owned(),
+        prefix,
+        suffix,
+        is_star,
+    })
+}
+
+fn glob_match(pattern: &GlobPattern, name: &str) -> bool {
+    if pattern.is_star {
+        return true;
+    }
+
+    match &pattern.suffix {
+        None => name == pattern.raw,
+        Some(suf) => {
+            name.starts_with(&pattern.prefix) && name.ends_with(suf.as_str()) && {
+                // Ensure the wildcard section isn't negative-length.
+                name.len() >= pattern.prefix.len() + suf.len()
+            }
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::subagent::def::ToolPolicy;
+
+    // ── FilteredToolExecutor tests ─────────────────────────────────────────
+
+    struct StubExecutor {
+        tools: Vec<&'static str>,
+    }
+
+    impl ErasedToolExecutor for StubExecutor {
+        fn execute_erased<'a>(
+            &'a self,
+            _response: &'a str,
+        ) -> Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a,
+            >,
+        > {
+            Box::pin(std::future::ready(Ok(None)))
+        }
+
+        fn execute_confirmed_erased<'a>(
+            &'a self,
+            _response: &'a str,
+        ) -> Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a,
+            >,
+        > {
+            Box::pin(std::future::ready(Ok(None)))
+        }
+
+        fn tool_definitions_erased(&self) -> Vec<ToolDef> {
+            // Return stub definitions for each tool name.
+            use zeph_tools::registry::InvocationHint;
+            self.tools
+                .iter()
+                .map(|id| ToolDef {
+                    id,
+                    description: "stub",
+                    schema: schemars::Schema::default(),
+                    invocation: InvocationHint::ToolCall,
+                })
+                .collect()
+        }
+
+        fn execute_tool_call_erased<'a>(
+            &'a self,
+            call: &'a ToolCall,
+        ) -> Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a,
+            >,
+        > {
+            let result = Ok(Some(ToolOutput {
+                tool_name: call.tool_id.clone(),
+                summary: "ok".into(),
+                blocks_executed: 1,
+                filter_stats: None,
+                diff: None,
+                streamed: false,
+            }));
+            Box::pin(std::future::ready(result))
+        }
+    }
+
+    fn stub_box(tools: &[&'static str]) -> Box<dyn ErasedToolExecutor> {
+        Box::new(StubExecutor {
+            tools: tools.to_vec(),
+        })
+    }
+
+    #[tokio::test]
+    async fn allow_list_permits_listed_tool() {
+        let exec = FilteredToolExecutor::new(
+            stub_box(&["shell", "web"]),
+            ToolPolicy::AllowList(vec!["shell".into()]),
+        );
+        let call = ToolCall {
+            tool_id: "shell".into(),
+            params: Default::default(),
+        };
+        let res = exec.execute_tool_call_erased(&call).await.unwrap();
+        assert!(res.is_some());
+    }
+
+    #[tokio::test]
+    async fn allow_list_blocks_unlisted_tool() {
+        let exec = FilteredToolExecutor::new(
+            stub_box(&["shell", "web"]),
+            ToolPolicy::AllowList(vec!["shell".into()]),
+        );
+        let call = ToolCall {
+            tool_id: "web".into(),
+            params: Default::default(),
+        };
+        let res = exec.execute_tool_call_erased(&call).await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn deny_list_blocks_listed_tool() {
+        let exec = FilteredToolExecutor::new(
+            stub_box(&["shell", "web"]),
+            ToolPolicy::DenyList(vec!["shell".into()]),
+        );
+        let call = ToolCall {
+            tool_id: "shell".into(),
+            params: Default::default(),
+        };
+        let res = exec.execute_tool_call_erased(&call).await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn inherit_all_permits_any_tool() {
+        let exec = FilteredToolExecutor::new(stub_box(&["shell"]), ToolPolicy::InheritAll);
+        let call = ToolCall {
+            tool_id: "shell".into(),
+            params: Default::default(),
+        };
+        let res = exec.execute_tool_call_erased(&call).await.unwrap();
+        assert!(res.is_some());
+    }
+
+    #[test]
+    fn tool_definitions_filtered_by_allow_list() {
+        let exec = FilteredToolExecutor::new(
+            stub_box(&["shell", "web"]),
+            ToolPolicy::AllowList(vec!["shell".into()]),
+        );
+        let defs = exec.tool_definitions_erased();
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].id, "shell");
+    }
+
+    // ── glob_match tests ───────────────────────────────────────────────────
+
+    fn matches(pattern: &str, name: &str) -> bool {
+        let p = compile_glob(pattern).unwrap();
+        glob_match(&p, name)
+    }
+
+    #[test]
+    fn glob_star_matches_all() {
+        assert!(matches("*", "anything"));
+        assert!(matches("*", ""));
+    }
+
+    #[test]
+    fn glob_prefix_star() {
+        assert!(matches("git-*", "git-commit"));
+        assert!(matches("git-*", "git-status"));
+        assert!(!matches("git-*", "rust-fmt"));
+    }
+
+    #[test]
+    fn glob_literal_exact_match() {
+        assert!(matches("shell", "shell"));
+        assert!(!matches("shell", "shell-extra"));
+    }
+
+    #[test]
+    fn glob_star_suffix() {
+        assert!(matches("*-review", "code-review"));
+        assert!(!matches("*-review", "code-reviewer"));
+    }
+
+    #[test]
+    fn glob_double_star_is_error() {
+        assert!(compile_glob("**").is_err());
+    }
+
+    #[test]
+    fn glob_mid_string_wildcard() {
+        // "a*b" — prefix="a", suffix=Some("b")
+        assert!(matches("a*b", "axb"));
+        assert!(matches("a*b", "aXYZb"));
+        assert!(!matches("a*b", "ab-extra"));
+        assert!(!matches("a*b", "xab"));
+    }
+
+    // ── FilteredToolExecutor additional tests ──────────────────────────────
+
+    #[tokio::test]
+    async fn deny_list_permits_unlisted_tool() {
+        let exec = FilteredToolExecutor::new(
+            stub_box(&["shell", "web"]),
+            ToolPolicy::DenyList(vec!["shell".into()]),
+        );
+        let call = ToolCall {
+            tool_id: "web".into(), // not in deny list → allowed
+            params: Default::default(),
+        };
+        let res = exec.execute_tool_call_erased(&call).await.unwrap();
+        assert!(res.is_some());
+    }
+
+    #[test]
+    fn tool_definitions_filtered_by_deny_list() {
+        let exec = FilteredToolExecutor::new(
+            stub_box(&["shell", "web"]),
+            ToolPolicy::DenyList(vec!["shell".into()]),
+        );
+        let defs = exec.tool_definitions_erased();
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].id, "web");
+    }
+
+    #[test]
+    fn tool_definitions_inherit_all_returns_all() {
+        let exec = FilteredToolExecutor::new(stub_box(&["shell", "web"]), ToolPolicy::InheritAll);
+        let defs = exec.tool_definitions_erased();
+        assert_eq!(defs.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn fenced_block_execute_is_blocked() {
+        let exec = FilteredToolExecutor::new(stub_box(&["shell"]), ToolPolicy::InheritAll);
+        let res = exec.execute_erased("```shell\nls\n```").await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn fenced_block_execute_confirmed_is_blocked() {
+        let exec = FilteredToolExecutor::new(stub_box(&["shell"]), ToolPolicy::InheritAll);
+        let res = exec.execute_confirmed_erased("```shell\nls\n```").await;
+        assert!(res.is_err());
+    }
+
+    // ── filter_skills tests ────────────────────────────────────────────────
+
+    #[test]
+    fn filter_skills_empty_registry_returns_empty() {
+        let registry = zeph_skills::registry::SkillRegistry::load(&[] as &[&str]);
+        let filter = SkillFilter::default();
+        let result = filter_skills(&registry, &filter).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn filter_skills_empty_include_passes_all() {
+        // Empty include list means "include everything".
+        // With an empty registry, result is still empty — logic is correct.
+        let registry = zeph_skills::registry::SkillRegistry::load(&[] as &[&str]);
+        let filter = SkillFilter {
+            include: vec![],
+            exclude: vec![],
+        };
+        let result = filter_skills(&registry, &filter).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn filter_skills_double_star_pattern_is_error() {
+        let registry = zeph_skills::registry::SkillRegistry::load(&[] as &[&str]);
+        let filter = SkillFilter {
+            include: vec!["**".into()],
+            exclude: vec![],
+        };
+        let err = filter_skills(&registry, &filter).unwrap_err();
+        assert!(matches!(err, SubAgentError::Invalid(_)));
+    }
+}

--- a/crates/zeph-core/src/subagent/grants.rs
+++ b/crates/zeph-core/src/subagent/grants.rs
@@ -1,0 +1,207 @@
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+
+/// Metadata sent by a sub-agent when it needs a secret from the vault.
+///
+/// Carried in an `InputRequired` A2A status update as structured metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SecretRequest {
+    /// The vault key name the sub-agent is requesting.
+    pub secret_key: String,
+    /// Human-readable reason (shown to the user in the approval prompt).
+    pub reason: Option<String>,
+}
+
+/// Identifies the kind of permission that was granted to a sub-agent.
+///
+/// `GrantKind` is intentionally NOT serializable — grant metadata should never
+/// leave the in-memory security boundary. Key names are logged only at DEBUG
+/// level to avoid leaking grant enumeration to centralized log systems.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GrantKind {
+    /// A vault secret key granted for in-memory access.
+    Secret(String),
+    /// A tool name granted at runtime beyond the definition's static policy.
+    Tool(String),
+}
+
+impl std::fmt::Display for GrantKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Secret(_) => write!(f, "Secret(<redacted>)"),
+            Self::Tool(name) => write!(f, "Tool({name})"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Grant {
+    pub(crate) kind: GrantKind,
+    pub(crate) granted_at: Instant,
+    pub(crate) ttl: Duration,
+}
+
+impl Grant {
+    #[must_use]
+    pub fn new(kind: GrantKind, ttl: Duration) -> Self {
+        Self {
+            kind,
+            granted_at: Instant::now(),
+            ttl,
+        }
+    }
+
+    #[must_use]
+    pub fn is_expired(&self) -> bool {
+        self.granted_at.elapsed() >= self.ttl
+    }
+}
+
+/// Tracks active zero-trust permission grants for a sub-agent.
+///
+/// All grants are TTL-bounded. [`is_active`](Self::is_active) automatically
+/// sweeps expired grants before checking, so callers do not need to call
+/// [`sweep_expired`](Self::sweep_expired) manually.
+#[derive(Debug, Default)]
+pub struct PermissionGrants {
+    grants: Vec<Grant>,
+}
+
+impl Drop for PermissionGrants {
+    fn drop(&mut self) {
+        // Defense-in-depth: revoke all grants on drop even if revoke_all()
+        // was not explicitly called (e.g., on panic or early return).
+        if !self.grants.is_empty() {
+            tracing::warn!(
+                count = self.grants.len(),
+                "PermissionGrants dropped with active grants — revoking"
+            );
+            self.grants.clear();
+        }
+    }
+}
+
+impl PermissionGrants {
+    /// Add a new grant.
+    pub fn add(&mut self, kind: GrantKind, ttl: Duration) {
+        // Log tool grants at DEBUG; for secrets log only the redacted display form.
+        tracing::debug!(kind = %kind, ?ttl, "permission grant added");
+        self.grants.push(Grant::new(kind, ttl));
+    }
+
+    /// Remove all expired grants.
+    pub fn sweep_expired(&mut self) {
+        let before = self.grants.len();
+        self.grants.retain(|g| {
+            let expired = g.is_expired();
+            if expired {
+                tracing::debug!(kind = %g.kind, "permission grant expired and revoked");
+            }
+            !expired
+        });
+        let removed = before - self.grants.len();
+        if removed > 0 {
+            tracing::debug!(removed, "swept expired grants");
+        }
+    }
+
+    /// Check if a specific grant is still active (not expired).
+    ///
+    /// Automatically sweeps expired grants before checking.
+    #[must_use]
+    pub fn is_active(&mut self, kind: &GrantKind) -> bool {
+        self.sweep_expired();
+        self.grants.iter().any(|g| &g.kind == kind)
+    }
+
+    /// Grant access to a vault secret with the given TTL.
+    ///
+    /// Sweeps expired grants first. Logs an audit event at DEBUG (key is redacted
+    /// in the log output to avoid leaking grant enumeration to log aggregators).
+    pub fn grant_secret(&mut self, key: impl Into<String>, ttl: Duration) {
+        self.sweep_expired();
+        let key = key.into();
+        tracing::debug!("vault secret granted to sub-agent (key redacted), ttl={ttl:?}");
+        self.add(GrantKind::Secret(key), ttl);
+    }
+
+    /// Returns `true` if there are any grants currently tracked (expired or not).
+    ///
+    /// Used by [`Drop`] to emit a warning when handles are dropped without cleanup.
+    #[must_use]
+    pub fn is_empty_grants(&self) -> bool {
+        self.grants.is_empty()
+    }
+
+    /// Revoke all grants immediately (called on sub-agent completion or cancellation).
+    pub fn revoke_all(&mut self) {
+        let count = self.grants.len();
+        self.grants.clear();
+        if count > 0 {
+            tracing::debug!(count, "all permission grants revoked");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grant_is_active_before_expiry() {
+        let mut pg = PermissionGrants::default();
+        pg.add(
+            GrantKind::Secret("api-key".into()),
+            Duration::from_secs(300),
+        );
+        assert!(pg.is_active(&GrantKind::Secret("api-key".into())));
+    }
+
+    #[test]
+    fn sweep_expired_removes_instant_ttl() {
+        let mut pg = PermissionGrants::default();
+        pg.grants.push(Grant {
+            kind: GrantKind::Tool("shell".into()),
+            granted_at: Instant::now() - Duration::from_secs(10),
+            ttl: Duration::from_secs(1), // already expired
+        });
+        // is_active internally sweeps
+        assert!(!pg.is_active(&GrantKind::Tool("shell".into())));
+        assert!(pg.grants.is_empty());
+    }
+
+    #[test]
+    fn revoke_all_clears_all_grants() {
+        let mut pg = PermissionGrants::default();
+        pg.add(GrantKind::Secret("token".into()), Duration::from_secs(60));
+        pg.add(GrantKind::Tool("web".into()), Duration::from_secs(60));
+        pg.revoke_all();
+        assert!(pg.grants.is_empty());
+    }
+
+    #[test]
+    fn grant_secret_is_active() {
+        let mut pg = PermissionGrants::default();
+        pg.grant_secret("db-password", Duration::from_secs(120));
+        assert!(pg.is_active(&GrantKind::Secret("db-password".into())));
+    }
+
+    #[test]
+    fn whitespace_description_invalid() {
+        // Verify grant kind display redacts secrets
+        let k = GrantKind::Secret("my-secret-key".into());
+        let display = k.to_string();
+        assert!(
+            !display.contains("my-secret-key"),
+            "secret key must be redacted in Display"
+        );
+        assert!(display.contains("redacted"));
+    }
+
+    #[test]
+    fn tool_grant_display_shows_name() {
+        let k = GrantKind::Tool("shell".into());
+        assert_eq!(k.to_string(), "Tool(shell)");
+    }
+}

--- a/crates/zeph-core/src/subagent/manager.rs
+++ b/crates/zeph-core/src/subagent/manager.rs
@@ -1,0 +1,463 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Instant;
+
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+use zeph_a2a::types::TaskState;
+
+use super::channel::{AgentHalf, OrchestratorHalf, new_channel};
+use super::def::SubAgentDef;
+use super::error::SubAgentError;
+use super::grants::PermissionGrants;
+
+const CHANNEL_BUFFER: usize = 32;
+
+/// Live status of a running sub-agent.
+#[derive(Debug, Clone)]
+pub struct SubAgentStatus {
+    pub state: TaskState,
+    pub last_message: Option<String>,
+    pub turns_used: u32,
+    pub started_at: Instant,
+}
+
+/// Handle to a spawned sub-agent task.
+///
+/// Fields are `pub(crate)` to prevent external code from bypassing the manager's
+/// audit trail by mutating grants or cancellation state directly.
+pub struct SubAgentHandle {
+    pub(crate) id: String,
+    pub(crate) def: SubAgentDef,
+    /// A2A task ID — currently the same UUID as `id`; separated for future
+    /// compatibility when sub-agents may have distinct internal/external IDs.
+    pub(crate) task_id: String,
+    pub(crate) state: TaskState,
+    pub(crate) join_handle: Option<JoinHandle<anyhow::Result<String>>>,
+    pub(crate) cancel: CancellationToken,
+    pub(crate) status_rx: watch::Receiver<SubAgentStatus>,
+    pub(crate) grants: PermissionGrants,
+    /// Orchestrator-side channel half for communicating with the sub-agent.
+    #[allow(dead_code)]
+    pub(crate) channel: OrchestratorHalf,
+}
+
+impl std::fmt::Debug for SubAgentHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SubAgentHandle")
+            .field("id", &self.id)
+            .field("task_id", &self.task_id)
+            .field("state", &self.state)
+            .field("def_name", &self.def.name)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for SubAgentHandle {
+    fn drop(&mut self) {
+        // Defense-in-depth: cancel the task and revoke grants on drop even if
+        // cancel() or collect() was not called (e.g., on panic or early return).
+        self.cancel.cancel();
+        if !self.grants.is_empty_grants() {
+            tracing::warn!(
+                id = %self.id,
+                "SubAgentHandle dropped without explicit cleanup — revoking grants"
+            );
+        }
+        self.grants.revoke_all();
+    }
+}
+
+/// Manages sub-agent lifecycle: definitions, spawning, cancellation, and result collection.
+pub struct SubAgentManager {
+    definitions: Vec<SubAgentDef>,
+    agents: HashMap<String, SubAgentHandle>,
+    max_concurrent: usize,
+}
+
+impl std::fmt::Debug for SubAgentManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SubAgentManager")
+            .field("definitions_count", &self.definitions.len())
+            .field("active_agents", &self.agents.len())
+            .field("max_concurrent", &self.max_concurrent)
+            .finish()
+    }
+}
+
+impl SubAgentManager {
+    /// Create a new manager with the given concurrency limit.
+    #[must_use]
+    pub fn new(max_concurrent: usize) -> Self {
+        Self {
+            definitions: Vec::new(),
+            agents: HashMap::new(),
+            max_concurrent,
+        }
+    }
+
+    /// Load sub-agent definitions from the given directories.
+    ///
+    /// Higher-priority directories should appear first. Name conflicts are resolved
+    /// by keeping the first occurrence. Non-existent directories are silently skipped.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SubAgentError`] if any definition file fails to parse.
+    pub fn load_definitions(&mut self, dirs: &[PathBuf]) -> Result<(), SubAgentError> {
+        self.definitions = SubAgentDef::load_all(dirs)?;
+        tracing::info!(
+            count = self.definitions.len(),
+            "sub-agent definitions loaded"
+        );
+        Ok(())
+    }
+
+    /// Return all loaded definitions.
+    #[must_use]
+    pub fn definitions(&self) -> &[SubAgentDef] {
+        &self.definitions
+    }
+
+    /// Spawn a sub-agent by definition name.
+    ///
+    /// Returns the `task_id` (UUID string) that can be used with [`cancel`](Self::cancel)
+    /// and [`collect`](Self::collect).
+    ///
+    /// # Note
+    ///
+    /// The actual agent execution loop is a stub that waits for cancellation.
+    /// It will be wired to the real provider + tools in a future phase (M28-E).
+    /// The intended signature at that point is:
+    /// `spawn(&mut self, def_name, task_prompt, provider: AnyProvider, tools: Box<dyn ErasedToolExecutor>)`
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SubAgentError::NotFound`] if no definition with the given name exists,
+    /// [`SubAgentError::Spawn`] if the concurrency limit is exceeded.
+    pub fn spawn(&mut self, def_name: &str, _task_prompt: &str) -> Result<String, SubAgentError> {
+        let def = self
+            .definitions
+            .iter()
+            .find(|d| d.name == def_name)
+            .cloned()
+            .ok_or_else(|| SubAgentError::NotFound(def_name.to_owned()))?;
+
+        let active = self
+            .agents
+            .values()
+            .filter(|h| matches!(h.state, TaskState::Working | TaskState::Submitted))
+            .count();
+
+        if active >= self.max_concurrent {
+            return Err(SubAgentError::Spawn(format!(
+                "concurrency limit {max} reached",
+                max = self.max_concurrent
+            )));
+        }
+
+        let task_id = Uuid::new_v4().to_string();
+        let cancel = CancellationToken::new();
+        let (orch_half, agent_half): (OrchestratorHalf, AgentHalf) = new_channel(CHANNEL_BUFFER);
+
+        let started_at = Instant::now();
+        let initial_status = SubAgentStatus {
+            state: TaskState::Submitted,
+            last_message: None,
+            turns_used: 0,
+            started_at,
+        };
+        let (status_tx, status_rx) = watch::channel(initial_status);
+
+        // Stub execution task — real agent loop wired in future phase.
+        // `agent_half` is passed into the closure so it is available when the
+        // real loop is implemented; dropping it here would silently break comms.
+        let cancel_clone = cancel.clone();
+        let join_handle: JoinHandle<anyhow::Result<String>> = tokio::spawn(async move {
+            // Keep agent_half alive for the duration of the task.
+            let _agent_channel = agent_half;
+            let _ = status_tx.send(SubAgentStatus {
+                state: TaskState::Working,
+                last_message: None,
+                turns_used: 0,
+                started_at, // reuse the original started_at — no drift
+            });
+            cancel_clone.cancelled().await;
+            Ok(String::new())
+        });
+
+        let handle = SubAgentHandle {
+            id: task_id.clone(),
+            def,
+            task_id: task_id.clone(),
+            state: TaskState::Submitted,
+            join_handle: Some(join_handle),
+            cancel,
+            status_rx,
+            grants: PermissionGrants::default(),
+            channel: orch_half,
+        };
+
+        self.agents.insert(task_id.clone(), handle);
+        tracing::info!(task_id, def_name, "sub-agent spawned");
+        Ok(task_id)
+    }
+
+    /// Cancel a running sub-agent by task ID.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SubAgentError::NotFound`] if the task ID is unknown.
+    pub fn cancel(&mut self, task_id: &str) -> Result<(), SubAgentError> {
+        let handle = self
+            .agents
+            .get_mut(task_id)
+            .ok_or_else(|| SubAgentError::NotFound(task_id.to_owned()))?;
+        handle.cancel.cancel();
+        handle.state = TaskState::Canceled;
+        handle.grants.revoke_all();
+        tracing::info!(task_id, "sub-agent cancelled");
+        Ok(())
+    }
+
+    /// Approve a secret request for a running sub-agent.
+    ///
+    /// Called after the user approves a vault secret access prompt. The secret
+    /// key must appear in the sub-agent definition's allowed `secrets` list;
+    /// otherwise the request is auto-denied.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SubAgentError::NotFound`] if the task ID is unknown,
+    /// [`SubAgentError::Invalid`] if the key is not in the definition's allowed list.
+    pub fn approve_secret(
+        &mut self,
+        task_id: &str,
+        secret_key: &str,
+        ttl: std::time::Duration,
+    ) -> Result<(), SubAgentError> {
+        let handle = self
+            .agents
+            .get_mut(task_id)
+            .ok_or_else(|| SubAgentError::NotFound(task_id.to_owned()))?;
+
+        // Sweep stale grants before adding a new one for consistent housekeeping.
+        handle.grants.sweep_expired();
+
+        if !handle
+            .def
+            .permissions
+            .secrets
+            .iter()
+            .any(|k| k == secret_key)
+        {
+            // Do not log the key name at warn level — only log that a request was denied.
+            tracing::warn!(task_id, "secret request denied: key not in allowed list");
+            return Err(SubAgentError::Invalid(format!(
+                "secret is not in the allowed secrets list for '{}'",
+                handle.def.name
+            )));
+        }
+
+        handle.grants.grant_secret(secret_key, ttl);
+        Ok(())
+    }
+
+    /// Collect the result from a completed sub-agent, removing it from the active set.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SubAgentError::NotFound`] if the task ID is unknown,
+    /// [`SubAgentError::Spawn`] if the task panicked.
+    pub async fn collect(&mut self, task_id: &str) -> Result<String, SubAgentError> {
+        let mut handle = self
+            .agents
+            .remove(task_id)
+            .ok_or_else(|| SubAgentError::NotFound(task_id.to_owned()))?;
+
+        handle.grants.revoke_all();
+
+        if let Some(jh) = handle.join_handle.take() {
+            let result = jh.await.map_err(|e| SubAgentError::Spawn(e.to_string()))?;
+            result.map_err(|e| SubAgentError::Spawn(e.to_string()))
+        } else {
+            Ok(String::new())
+        }
+    }
+
+    /// Return a snapshot of all active sub-agent statuses.
+    #[must_use]
+    pub fn statuses(&self) -> Vec<(String, SubAgentStatus)> {
+        self.agents
+            .values()
+            .map(|h| (h.task_id.clone(), h.status_rx.borrow().clone()))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_manager() -> SubAgentManager {
+        SubAgentManager::new(4)
+    }
+
+    fn sample_def() -> SubAgentDef {
+        SubAgentDef::parse("+++\nname = \"bot\"\ndescription = \"A bot\"\n+++\n\nDo things.\n")
+            .unwrap()
+    }
+
+    fn def_with_secrets() -> SubAgentDef {
+        SubAgentDef::parse(
+            "+++\nname = \"bot\"\ndescription = \"A bot\"\n[permissions]\nsecrets = [\"api-key\"]\n+++\n\nDo things.\n",
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn load_definitions_populates_vec() {
+        use std::io::Write as _;
+        let dir = tempfile::tempdir().unwrap();
+        let content = "+++\nname = \"helper\"\ndescription = \"A helper\"\n+++\n\nHelp.\n";
+        let mut f = std::fs::File::create(dir.path().join("helper.md")).unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+
+        let mut mgr = make_manager();
+        mgr.load_definitions(&[dir.path().to_path_buf()]).unwrap();
+        assert_eq!(mgr.definitions().len(), 1);
+        assert_eq!(mgr.definitions()[0].name, "helper");
+    }
+
+    #[test]
+    fn spawn_not_found_error() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let _guard = rt.enter();
+        let mut mgr = make_manager();
+        let err = mgr.spawn("nonexistent", "prompt").unwrap_err();
+        assert!(matches!(err, SubAgentError::NotFound(_)));
+    }
+
+    #[test]
+    fn spawn_and_cancel() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let _guard = rt.enter();
+        let mut mgr = make_manager();
+        mgr.definitions.push(sample_def());
+
+        let task_id = mgr.spawn("bot", "do stuff").unwrap();
+        assert!(!task_id.is_empty());
+
+        mgr.cancel(&task_id).unwrap();
+        assert_eq!(mgr.agents[&task_id].state, TaskState::Canceled);
+    }
+
+    #[test]
+    fn cancel_unknown_task_id_returns_not_found() {
+        let mut mgr = make_manager();
+        let err = mgr.cancel("unknown-id").unwrap_err();
+        assert!(matches!(err, SubAgentError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn collect_removes_agent() {
+        let mut mgr = make_manager();
+        mgr.definitions.push(sample_def());
+
+        let task_id = mgr.spawn("bot", "do stuff").unwrap();
+        mgr.cancel(&task_id).unwrap();
+
+        let result = mgr.collect(&task_id).await.unwrap();
+        assert!(result.is_empty());
+        assert!(!mgr.agents.contains_key(&task_id));
+    }
+
+    #[tokio::test]
+    async fn collect_unknown_task_id_returns_not_found() {
+        let mut mgr = make_manager();
+        let err = mgr.collect("unknown-id").await.unwrap_err();
+        assert!(matches!(err, SubAgentError::NotFound(_)));
+    }
+
+    #[test]
+    fn approve_secret_grants_access() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let _guard = rt.enter();
+        let mut mgr = make_manager();
+        mgr.definitions.push(def_with_secrets());
+
+        let task_id = mgr.spawn("bot", "work").unwrap();
+        mgr.approve_secret(&task_id, "api-key", std::time::Duration::from_secs(60))
+            .unwrap();
+
+        let handle = mgr.agents.get_mut(&task_id).unwrap();
+        assert!(
+            handle
+                .grants
+                .is_active(&crate::subagent::GrantKind::Secret("api-key".into()))
+        );
+    }
+
+    #[test]
+    fn approve_secret_denied_for_unlisted_key() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let _guard = rt.enter();
+        let mut mgr = make_manager();
+        mgr.definitions.push(sample_def()); // no secrets in allowed list
+
+        let task_id = mgr.spawn("bot", "work").unwrap();
+        let err = mgr
+            .approve_secret(&task_id, "not-allowed", std::time::Duration::from_secs(60))
+            .unwrap_err();
+        assert!(matches!(err, SubAgentError::Invalid(_)));
+    }
+
+    #[test]
+    fn approve_secret_unknown_task_id_returns_not_found() {
+        let mut mgr = make_manager();
+        let err = mgr
+            .approve_secret("unknown", "key", std::time::Duration::from_secs(60))
+            .unwrap_err();
+        assert!(matches!(err, SubAgentError::NotFound(_)));
+    }
+
+    #[test]
+    fn statuses_returns_active_agents() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let _guard = rt.enter();
+        let mut mgr = make_manager();
+        mgr.definitions.push(sample_def());
+
+        let task_id = mgr.spawn("bot", "work").unwrap();
+        let statuses = mgr.statuses();
+        assert_eq!(statuses.len(), 1);
+        assert_eq!(statuses[0].0, task_id);
+    }
+
+    #[test]
+    fn concurrency_limit_enforced() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let _guard = rt.enter();
+        let mut mgr = SubAgentManager::new(1);
+        mgr.definitions.push(sample_def());
+
+        let _first = mgr.spawn("bot", "first").unwrap();
+        let err = mgr.spawn("bot", "second").unwrap_err();
+        assert!(matches!(err, SubAgentError::Spawn(_)));
+    }
+
+    #[test]
+    fn debug_impl_does_not_expose_sensitive_fields() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let _guard = rt.enter();
+        let mut mgr = make_manager();
+        mgr.definitions.push(def_with_secrets());
+        let task_id = mgr.spawn("bot", "work").unwrap();
+        let handle = &mgr.agents[&task_id];
+        let debug_str = format!("{handle:?}");
+        // SubAgentHandle Debug must not expose grant contents or secrets
+        assert!(!debug_str.contains("api-key"));
+    }
+}

--- a/crates/zeph-core/src/subagent/mod.rs
+++ b/crates/zeph-core/src/subagent/mod.rs
@@ -1,0 +1,13 @@
+pub mod channel;
+pub mod def;
+pub mod error;
+pub mod filter;
+pub mod grants;
+pub mod manager;
+
+pub use channel::{A2aMessage, AgentHalf, OrchestratorHalf, new_channel};
+pub use def::{SkillFilter, SubAgentDef, SubAgentPermissions, ToolPolicy};
+pub use error::SubAgentError;
+pub use filter::{FilteredToolExecutor, filter_skills};
+pub use grants::{Grant, GrantKind, PermissionGrants, SecretRequest};
+pub use manager::{SubAgentHandle, SubAgentManager, SubAgentStatus};

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -31,6 +31,7 @@
 - [Model Orchestrator](advanced/orchestrator.md)
 - [Self-Learning Skills](advanced/self-learning.md)
 - [Skill Trust & Security](advanced/skill-trust.md)
+- [Sub-Agent Orchestration](advanced/sub-agents.md)
 - [A2A Protocol](advanced/a2a.md)
 - [Code Indexing](advanced/code-indexing.md)
 - [Pipeline API](advanced/pipeline.md)

--- a/docs/src/advanced/sub-agents.md
+++ b/docs/src/advanced/sub-agents.md
@@ -1,0 +1,263 @@
+# Sub-Agent Orchestration
+
+Zeph supports delegating tasks to specialized sub-agents that run in isolated contexts with controlled permissions. Sub-agents are defined as markdown files with TOML frontmatter and communicate with the main agent via the A2A protocol over in-process channels.
+
+## Concepts
+
+A sub-agent is a lightweight, disposable agent instance that:
+
+- Has its own system prompt, message history, and LLM model
+- Receives a filtered subset of tools and skills from the main agent
+- Starts with zero permissions (zero-trust model)
+- Communicates with the main agent via A2A protocol messages
+- Cannot spawn other sub-agents (no nesting)
+- Is automatically cleaned up on completion, cancellation, timeout, or crash
+
+The main agent remains the single user-facing interface. Sub-agents are invisible to the user except through status updates and approval prompts.
+
+## Architecture
+
+```
+User
+  |
+  v
++---------------------------+
+|  Main Agent               |
+|  - user channel           |
+|  - SubAgentManager        |
+|  - VaultProvider          |
+|  - SkillRegistry          |
++-----|---------------------+
+      |
+      | A2A (in-process mpsc channels)
+      |
+  +---+---+---+
+  |   |   |   |
+  v   v   v   v
+ SA1 SA2 SA3 SA4   (sub-agent instances)
+```
+
+Each sub-agent has:
+- Own message history and system prompt
+- Filtered tool access via `FilteredToolExecutor`
+- Filtered skill access via glob patterns
+- No vault access unless explicitly granted with TTL
+
+## Definition Format
+
+Sub-agent definitions are markdown files with `+++`-delimited TOML frontmatter, stored in:
+
+- `.zeph/agents/` (project scope, higher priority)
+- `~/.config/zeph/agents/` (user scope)
+
+When both directories contain a definition with the same `name`, the project-scope file takes precedence.
+
+### Example
+
+```markdown
++++
+name = "code-reviewer"
+description = "Reviews code changes for correctness and style"
+model = "claude-sonnet-4-20250514"
+
+[tools]
+allow = ["shell", "web_scrape"]
+
+[permissions]
+secrets = ["github-token"]
+max_turns = 10
+background = false
+timeout_secs = 300
+ttl_secs = 120
+
+[skills]
+include = ["git-*", "rust-*"]
+exclude = ["deploy-*"]
++++
+
+You are a code reviewer. Analyze the provided code for:
+- Correctness bugs
+- Performance issues
+- Idiomatic Rust style
+
+Report findings as a structured list with severity (critical/warning/info).
+```
+
+### Frontmatter Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | string | required | Unique identifier for the sub-agent |
+| `description` | string | required | Human-readable description |
+| `model` | string | inherited | LLM model override (uses main agent model if omitted) |
+| `tools.allow` | string[] | - | Allowlist of tool IDs (mutually exclusive with `deny`) |
+| `tools.deny` | string[] | - | Denylist of tool IDs (mutually exclusive with `allow`) |
+| `permissions.secrets` | string[] | `[]` | Vault keys this agent MAY request (not granted by default) |
+| `permissions.max_turns` | u32 | `20` | Maximum LLM turns before forced stop |
+| `permissions.background` | bool | `false` | Run in background (non-blocking) |
+| `permissions.timeout_secs` | u64 | `600` | Hard kill deadline in seconds |
+| `permissions.ttl_secs` | u64 | `300` | TTL for granted permissions and secrets |
+| `skills.include` | string[] | `[]` (all) | Glob patterns for skill names to include |
+| `skills.exclude` | string[] | `[]` | Glob patterns for skill names to exclude |
+
+If neither `tools.allow` nor `tools.deny` is specified, the sub-agent inherits all tools from the main agent.
+
+The body after the closing `+++` becomes the sub-agent's system prompt.
+
+## SubAgentManager API
+
+`SubAgentManager` lives in `zeph-core` and manages the full sub-agent lifecycle:
+
+```rust
+let mut manager = SubAgentManager::new(/* max_concurrent */ 4);
+
+// Load definitions from project and user directories
+manager.load_definitions(&[
+    project_dir.join(".zeph/agents"),
+    dirs::config_dir().unwrap().join("zeph/agents"),
+])?;
+
+// Spawn a sub-agent by definition name
+let task_id = manager.spawn("code-reviewer", "Review src/main.rs")?;
+
+// Check status
+let statuses = manager.statuses();
+
+// Cancel if needed
+manager.cancel(&task_id)?;
+
+// Collect result (removes from active set)
+let result = manager.collect(&task_id).await?;
+```
+
+Key operations:
+
+| Method | Description |
+|--------|-------------|
+| `load_definitions(&[PathBuf])` | Load `.md` definitions from directories (first-wins deduplication) |
+| `spawn(name, prompt)` | Spawn a sub-agent, returns task ID |
+| `cancel(task_id)` | Cancel and revoke all grants |
+| `collect(task_id)` | Await result and remove from active set |
+| `statuses()` | Snapshot of all active sub-agent states |
+| `approve_secret(task_id, key, ttl)` | Grant a vault secret after user approval |
+
+Concurrency is enforced: `spawn` returns an error if the active agent count reaches `max_concurrent`.
+
+## Zero-Trust Security Model
+
+Every sub-agent starts with zero permissions. Access is never implicit.
+
+### Core Rules
+
+1. **No default trust** -- the definition declares what a sub-agent MAY request, not what it has
+2. **Explicit user approval** -- every secret requires user consent at runtime
+3. **TTL on all grants** -- secrets and runtime permissions expire after `ttl_secs`
+4. **Automatic revocation** -- all grants revoked on completion, cancellation, or crash
+5. **No persistence** -- secrets exist only in memory, never written to disk or message history
+6. **Audit trail** -- every grant, revoke, and expiry event logged via `tracing`
+7. **Sweep before access** -- `PermissionGrants::sweep_expired()` called before every tool execution and secret read
+
+### Grant Lifecycle
+
+```
+Request -> User Approval -> Grant (with TTL) -> Active -> Expired/Revoked
+                |                                            |
+              Denied                                 Cleared from memory
+```
+
+### PermissionGrants
+
+`PermissionGrants` tracks active grants and enforces TTL:
+
+- `add(kind, ttl)` -- add a new time-bounded grant
+- `is_active(kind)` -- check if a grant is still valid (auto-sweeps expired)
+- `sweep_expired()` -- remove all expired grants
+- `revoke_all()` -- immediately revoke all grants
+- `Drop` impl revokes remaining grants as defense-in-depth
+
+Grant kinds:
+- `GrantKind::Secret(key)` -- vault secret access (redacted in logs and `Display`)
+- `GrantKind::Tool(name)` -- runtime tool access beyond static policy
+
+### Secret Delivery Protocol
+
+1. Sub-agent sends `InputRequired` status with `SecretRequest { secret_key, reason }`
+2. Main agent validates: is the key in the definition's allowed `secrets` list?
+3. If not in allowed list, auto-deny (no user prompt)
+4. If allowed, prompt user: agent name, key name, TTL
+5. User approves: vault read, in-memory grant with TTL via `approve_secret()`
+6. Sub-agent accesses secret via `PermissionGrants` (not via message channel)
+7. On TTL expiry or sub-agent end: grant swept, secret cleared from memory
+
+Secrets are never serialized into A2A messages, message history, or logs.
+
+## Tool Filtering
+
+`FilteredToolExecutor` wraps the main agent's tool executor and enforces the sub-agent's `ToolPolicy`:
+
+- **AllowList** -- only listed tools are permitted
+- **DenyList** -- all tools except listed ones are permitted
+- **InheritAll** -- all parent tools are available
+
+Enforcement happens at the executor level (not prompt level). Rejected tool calls return a `ToolError::Blocked`. Tool definitions exposed to the sub-agent's LLM are also filtered, so the model only sees tools it can actually use.
+
+## Skill Filtering
+
+Skills are filtered from the main agent's `SkillRegistry` using glob patterns:
+
+- `include = ["git-*", "rust-*"]` -- only skills matching these patterns
+- `exclude = ["deploy-*"]` -- remove skills matching these patterns
+- Empty `include` means all skills pass (unless excluded)
+- Exclude patterns always take precedence over include
+
+Supported glob syntax: `*` wildcard (e.g., `git-*`, `*-review`). Double-star `**` is not supported.
+
+Filtered skills are injected into the sub-agent's system prompt at spawn time.
+
+## A2A Channel Communication
+
+Sub-agents communicate with the main agent via in-process bidirectional channels (`tokio::sync::mpsc`) that carry A2A protocol messages:
+
+```
+Main Agent                          Sub-Agent
+    |                                   |
+    |--- SendMessage(task prompt) ----->|
+    |                                   |
+    |<-- StatusUpdate(working) ---------|
+    |<-- StatusUpdate(working, msg) ----|  (progress)
+    |                                   |
+    |<-- StatusUpdate(input-required) --|  (needs permission)
+    |--- SendMessage(approval) -------->|
+    |                                   |
+    |<-- ArtifactUpdate(result) --------|
+    |<-- StatusUpdate(completed) -------|
+```
+
+Message types (`A2aMessage` enum):
+- `SendMessage` -- carries an A2A `Message`
+- `StatusUpdate` -- carries a `TaskStatusUpdateEvent`
+- `ArtifactUpdate` -- carries a `TaskArtifactUpdateEvent`
+- `Cancel` -- signals cancellation
+
+The channel reuses A2A types from `zeph-a2a` directly. This means upgrading to HTTP-based A2A (remote sub-agents) in the future requires zero protocol changes.
+
+## Error Handling
+
+Sub-agent operations return `SubAgentError`:
+
+| Variant | When |
+|---------|------|
+| `Parse` | Definition file has invalid frontmatter or TOML |
+| `Invalid` | Validation failure (empty name, mutual exclusion, unauthorized secret) |
+| `NotFound` | Unknown definition name or task ID |
+| `Spawn` | Concurrency limit reached or task panic |
+| `Cancelled` | Sub-agent was cancelled |
+
+## Safety Guarantees
+
+- `SubAgentHandle::Drop` cancels the task and revokes all grants
+- `PermissionGrants::Drop` revokes remaining grants with a warning log
+- Concurrency limit prevents resource exhaustion
+- `timeout_secs` provides a hard kill deadline
+- `max_turns` prevents runaway LLM loops
+- Secret key names are redacted in `Display` and log output


### PR DESCRIPTION
## Summary

- Sub-agent orchestration system enabling the main agent to delegate tasks to specialized child agents
- Zero-trust security model: all permissions TTL-bounded, auto-revoked, secrets never persisted
- In-process A2A channels (mpsc) reusing zeph-a2a types, upgradable to HTTP later
- Tool filtering (AllowList/DenyList/InheritAll) and skill filtering with glob patterns
- 55+ unit tests covering parsing, grants, filtering, manager lifecycle

## New module: `zeph-core::subagent`

| File | Purpose |
|------|---------|
| `def.rs` | SubAgentDef, TOML frontmatter parser, definition loader |
| `manager.rs` | SubAgentManager (spawn/cancel/collect/approve_secret) |
| `channel.rs` | In-process A2A channels (OrchestratorHalf/AgentHalf) |
| `grants.rs` | PermissionGrants with TTL, audit trail, Drop revocation |
| `filter.rs` | FilteredToolExecutor, SkillFilter with glob matching |
| `error.rs` | SubAgentError |

## Zero-trust security model

- Sub-agents start with zero permissions
- Secrets delivered via in-memory grants only (never serialized)
- All grants have TTL with automatic expiry sweep
- Drop impls revoke all grants on sub-agent termination
- Audit trail via tracing for grant/revoke/expire events
- Fenced-block tool calls blocked for sub-agents (SEC-03 fix)

## Test plan

- [x] cargo +nightly fmt --check
- [x] cargo clippy --workspace -- -D warnings
- [x] cargo nextest run --workspace --lib --bins (2294 passed)
- [x] Security audit: 0 critical, 0 high remaining
- [x] Code review: APPROVED

Closes #709, #710, #711, #712, #713