### PR TITLE
feat(tui): improve chat UX with cleaner visual design

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9351,6 +9351,7 @@ dependencies = [
 name = "zeph-tui"
 version = "0.11.4"
 dependencies = [
+ "chrono",
  "crossterm",
  "expectrl",
  "ignore",

--- a/crates/zeph-tui/Cargo.toml
+++ b/crates/zeph-tui/Cargo.toml
@@ -15,6 +15,7 @@ readme = "README.md"
 [dependencies]
 ignore.workspace = true
 nucleo-matcher.workspace = true
+chrono = { workspace = true, features = ["clock"] }
 crossterm.workspace = true
 pulldown-cmark.workspace = true
 ratatui.workspace = true

--- a/crates/zeph-tui/src/app.rs
+++ b/crates/zeph-tui/src/app.rs
@@ -105,6 +105,33 @@ pub struct ChatMessage {
     pub tool_name: Option<String>,
     pub diff_data: Option<zeph_core::DiffData>,
     pub filter_stats: Option<String>,
+    pub timestamp: String,
+}
+
+impl ChatMessage {
+    pub fn new(role: MessageRole, content: impl Into<String>) -> Self {
+        Self {
+            role,
+            content: content.into(),
+            streaming: false,
+            tool_name: None,
+            diff_data: None,
+            filter_stats: None,
+            timestamp: format_local_time(),
+        }
+    }
+
+    #[must_use]
+    pub fn streaming(mut self) -> Self {
+        self.streaming = true;
+        self
+    }
+
+    #[must_use]
+    pub fn with_tool(mut self, name: String) -> Self {
+        self.tool_name = Some(name);
+        self
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -217,14 +244,8 @@ impl App {
             if role_str == "user"
                 && let Some((tool_name, body)) = parse_tool_output(content, TOOL_SUFFIX)
             {
-                self.messages.push(ChatMessage {
-                    role: MessageRole::Tool,
-                    content: body,
-                    streaming: false,
-                    tool_name: Some(tool_name),
-                    diff_data: None,
-                    filter_stats: None,
-                });
+                self.messages
+                    .push(ChatMessage::new(MessageRole::Tool, body).with_tool(tool_name));
                 continue;
             }
 
@@ -236,14 +257,7 @@ impl App {
             if role == MessageRole::User {
                 self.input_history.push(content.to_owned());
             }
-            self.messages.push(ChatMessage {
-                role,
-                content: content.to_owned(),
-                streaming: false,
-                tool_name: None,
-                diff_data: None,
-                filter_stats: None,
-            });
+            self.messages.push(ChatMessage::new(role, content));
         }
         if !self.messages.is_empty() {
             self.show_splash = false;
@@ -299,6 +313,13 @@ impl App {
     #[must_use]
     pub fn scroll_offset(&self) -> usize {
         self.scroll_offset
+    }
+
+    /// Scroll to bottom only if already at (or near) the bottom.
+    fn auto_scroll(&mut self) {
+        if self.scroll_offset <= 1 {
+            self.scroll_offset = 0;
+        }
     }
 
     #[must_use]
@@ -412,32 +433,20 @@ impl App {
                 {
                     last.content.push_str(&text);
                 } else {
-                    self.messages.push(ChatMessage {
-                        role: MessageRole::Assistant,
-                        content: text,
-                        streaming: true,
-                        tool_name: None,
-                        diff_data: None,
-                        filter_stats: None,
-                    });
+                    self.messages
+                        .push(ChatMessage::new(MessageRole::Assistant, text).streaming());
                 }
                 let last_idx = self.messages.len().saturating_sub(1);
                 self.render_cache.invalidate(last_idx);
-                self.scroll_offset = 0;
+                self.auto_scroll();
             }
             AgentEvent::FullMessage(text) => {
                 self.status_label = None;
                 if !text.starts_with("[tool output") {
-                    self.messages.push(ChatMessage {
-                        role: MessageRole::Assistant,
-                        content: text,
-                        streaming: false,
-                        tool_name: None,
-                        diff_data: None,
-                        filter_stats: None,
-                    });
+                    self.messages
+                        .push(ChatMessage::new(MessageRole::Assistant, text));
                 }
-                self.scroll_offset = 0;
+                self.auto_scroll();
             }
             AgentEvent::Flush => {
                 if let Some(last) = self.messages.last_mut()
@@ -454,19 +463,16 @@ impl App {
             }
             AgentEvent::Status(text) => {
                 self.status_label = if text.is_empty() { None } else { Some(text) };
-                self.scroll_offset = 0;
+                self.auto_scroll();
             }
             AgentEvent::ToolStart { tool_name, command } => {
                 self.status_label = None;
-                self.messages.push(ChatMessage {
-                    role: MessageRole::Tool,
-                    content: format!("$ {command}\n"),
-                    streaming: true,
-                    tool_name: Some(tool_name),
-                    diff_data: None,
-                    filter_stats: None,
-                });
-                self.scroll_offset = 0;
+                self.messages.push(
+                    ChatMessage::new(MessageRole::Tool, format!("$ {command}\n"))
+                        .streaming()
+                        .with_tool(tool_name),
+                );
+                self.auto_scroll();
             }
             AgentEvent::ToolOutputChunk { chunk, .. } => {
                 if let Some(pos) = self
@@ -477,7 +483,7 @@ impl App {
                     self.messages[pos].content.push_str(&chunk);
                     self.render_cache.invalidate(pos);
                 }
-                self.scroll_offset = 0;
+                self.auto_scroll();
             }
             AgentEvent::ToolOutput {
                 tool_name,
@@ -507,14 +513,10 @@ impl App {
                 } else if diff.is_some() || filter_stats.is_some() {
                     // Native tool_use path: no prior ToolStart, create the message now.
                     debug!("creating new Tool message with diff (native path)");
-                    self.messages.push(ChatMessage {
-                        role: MessageRole::Tool,
-                        content: output,
-                        streaming: false,
-                        tool_name: Some(tool_name),
-                        diff_data: diff,
-                        filter_stats,
-                    });
+                    let mut msg = ChatMessage::new(MessageRole::Tool, output).with_tool(tool_name);
+                    msg.diff_data = diff;
+                    msg.filter_stats = filter_stats;
+                    self.messages.push(msg);
                 } else if let Some(msg) = self
                     .messages
                     .iter_mut()
@@ -523,7 +525,7 @@ impl App {
                 {
                     msg.filter_stats = filter_stats;
                 }
-                self.scroll_offset = 0;
+                self.auto_scroll();
             }
             AgentEvent::ConfirmRequest {
                 prompt,
@@ -550,15 +552,9 @@ impl App {
             }
             AgentEvent::CommandResult { output, .. } => {
                 self.command_palette = None;
-                self.messages.push(ChatMessage {
-                    role: MessageRole::System,
-                    content: output,
-                    streaming: false,
-                    tool_name: None,
-                    diff_data: None,
-                    filter_stats: None,
-                });
-                self.scroll_offset = 0;
+                self.messages
+                    .push(ChatMessage::new(MessageRole::System, output));
+                self.auto_scroll();
             }
         }
     }
@@ -828,14 +824,8 @@ impl App {
 
     fn push_system_message(&mut self, content: String) {
         self.show_splash = false;
-        self.messages.push(ChatMessage {
-            role: MessageRole::System,
-            content,
-            streaming: false,
-            tool_name: None,
-            diff_data: None,
-            filter_stats: None,
-        });
+        self.messages
+            .push(ChatMessage::new(MessageRole::System, content));
         self.scroll_offset = 0;
     }
 
@@ -887,6 +877,11 @@ impl App {
                     Panel::Memory => Panel::Resources,
                     Panel::Resources => Panel::Chat,
                 };
+            }
+            KeyCode::Char('l') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.messages.clear();
+                self.render_cache.clear();
+                self.scroll_offset = 0;
             }
             KeyCode::Char('?') => {
                 self.show_help = true;
@@ -1123,14 +1118,8 @@ impl App {
         self.input_history.push(text.clone());
         self.history_index = None;
         self.draft_input.clear();
-        self.messages.push(ChatMessage {
-            role: MessageRole::User,
-            content: text.clone(),
-            streaming: false,
-            tool_name: None,
-            diff_data: None,
-            filter_stats: None,
-        });
+        self.messages
+            .push(ChatMessage::new(MessageRole::User, text.clone()));
         self.input.clear();
         self.cursor_position = 0;
         self.scroll_offset = 0;
@@ -1141,6 +1130,10 @@ impl App {
         // Message is visible in chat but not processed; acceptable for interactive TUI.
         let _ = self.user_input_tx.try_send(text);
     }
+}
+
+fn format_local_time() -> String {
+    chrono::Local::now().format("%H:%M").to_string()
 }
 
 fn parse_tool_output(content: &str, suffix: &str) -> Option<(String, String)> {
@@ -1808,14 +1801,8 @@ mod tests {
         app.input_mode = InputMode::Insert;
         app.pending_count = 2;
         app.input_history.push("queued msg".into());
-        app.messages.push(ChatMessage {
-            role: MessageRole::User,
-            content: "queued msg".into(),
-            streaming: false,
-            tool_name: None,
-            diff_data: None,
-            filter_stats: None,
-        });
+        app.messages
+            .push(ChatMessage::new(MessageRole::User, "queued msg"));
 
         let key = KeyEvent::new(KeyCode::Up, KeyModifiers::NONE);
         app.handle_event(AppEvent::Key(key));
@@ -1974,22 +1961,17 @@ mod tests {
             let enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
             app.handle_event(AppEvent::Key(enter));
 
-            let output = draw_app(&mut app, 80, 24);
-            assert!(!output.contains("Type a message"));
+            assert!(!app.show_splash, "splash should be hidden after submit");
         }
 
         #[test]
         fn markdown_link_produces_hyperlink_span() {
             let (mut app, _rx, _tx) = make_app();
             app.show_splash = false;
-            app.messages.push(ChatMessage {
-                role: MessageRole::Assistant,
-                content: "See [docs](https://docs.rs) for details".into(),
-                streaming: false,
-                tool_name: None,
-                diff_data: None,
-                filter_stats: None,
-            });
+            app.messages.push(ChatMessage::new(
+                MessageRole::Assistant,
+                "See [docs](https://docs.rs) for details",
+            ));
 
             let _ = draw_app(&mut app, 80, 24);
             let links = app.take_hyperlinks();
@@ -2004,14 +1986,10 @@ mod tests {
         fn bare_url_still_produces_hyperlink_span() {
             let (mut app, _rx, _tx) = make_app();
             app.show_splash = false;
-            app.messages.push(ChatMessage {
-                role: MessageRole::Assistant,
-                content: "Visit https://example.com today".into(),
-                streaming: false,
-                tool_name: None,
-                diff_data: None,
-                filter_stats: None,
-            });
+            app.messages.push(ChatMessage::new(
+                MessageRole::Assistant,
+                "Visit https://example.com today",
+            ));
 
             let _ = draw_app(&mut app, 80, 24);
             let links = app.take_hyperlinks();

--- a/crates/zeph-tui/src/theme.rs
+++ b/crates/zeph-tui/src/theme.rs
@@ -19,6 +19,7 @@ pub struct Theme {
     pub user_message: Style,
     pub assistant_message: Style,
     pub system_message: Style,
+    pub input_text: Style,
     pub input_cursor: Style,
     pub status_bar: Style,
     pub header: Style,
@@ -47,8 +48,9 @@ impl Default for Theme {
     fn default() -> Self {
         Self {
             user_message: Style::default().fg(Color::Cyan),
-            assistant_message: Style::default().fg(Color::White),
+            assistant_message: Style::default().fg(Color::Rgb(200, 200, 210)),
             system_message: Style::default().fg(Color::DarkGray),
+            input_text: Style::default().fg(Color::Cyan),
             input_cursor: Style::default()
                 .fg(Color::Yellow)
                 .add_modifier(Modifier::BOLD),
@@ -69,9 +71,7 @@ impl Default for Theme {
                 .bg(Color::Rgb(15, 30, 55))
                 .add_modifier(Modifier::BOLD),
             code_block: Style::default().fg(Color::Rgb(190, 175, 145)),
-            streaming_cursor: Style::default()
-                .fg(Color::Yellow)
-                .add_modifier(Modifier::SLOW_BLINK),
+            streaming_cursor: Style::default().fg(Color::DarkGray),
             tool_command: Style::default()
                 .fg(Color::Yellow)
                 .add_modifier(Modifier::BOLD),

--- a/crates/zeph-tui/src/widgets/chat.rs
+++ b/crates/zeph-tui/src/widgets/chat.rs
@@ -55,8 +55,7 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, cache: &mut RenderCa
         };
 
         if idx > 0 {
-            let sep = "\u{2500}".repeat(wrap_width);
-            lines.push(Line::from(Span::styled(sep, theme.system_message)));
+            lines.push(Line::default());
         }
 
         let cache_key = RenderCacheKey {
@@ -96,8 +95,25 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, cache: &mut RenderCa
 
         all_md_links.extend(msg_md_links);
 
-        for mut line in msg_lines {
-            line.spans.insert(0, Span::styled("\u{258e} ", accent));
+        let time_str = &msg.timestamp;
+        for (i, mut line) in msg_lines.into_iter().enumerate() {
+            if msg.role == MessageRole::User {
+                line.spans.insert(0, Span::styled("\u{258e} ", accent));
+            } else {
+                line.spans.insert(0, Span::raw("  "));
+            }
+            if i == 0 {
+                let content_width: usize =
+                    line.spans.iter().map(|s| s.content.chars().count()).sum();
+                let pad = wrap_width
+                    .saturating_sub(content_width)
+                    .saturating_sub(time_str.len());
+                if pad > 0 {
+                    line.spans.push(Span::raw(" ".repeat(pad)));
+                    line.spans
+                        .push(Span::styled(time_str.clone(), theme.system_message));
+                }
+            }
             lines.push(line);
         }
     }
@@ -198,24 +214,16 @@ fn render_chat_message(
     msg: &crate::app::ChatMessage,
     theme: &Theme,
     wrap_width: usize,
-    show_labels: bool,
+    _show_labels: bool,
     lines: &mut Vec<Line<'static>>,
 ) -> Vec<MdLink> {
-    let (prefix, base_style) = if show_labels {
-        match msg.role {
-            MessageRole::User => ("[user] ", theme.user_message),
-            MessageRole::Assistant => ("[zeph] ", theme.assistant_message),
-            MessageRole::System => ("[system] ", theme.system_message),
-            MessageRole::Tool => unreachable!(),
-        }
-    } else {
-        match msg.role {
-            MessageRole::User => ("", theme.user_message),
-            MessageRole::Assistant => ("", theme.assistant_message),
-            MessageRole::System => ("", theme.system_message),
-            MessageRole::Tool => unreachable!(),
-        }
+    let base_style = match msg.role {
+        MessageRole::User => theme.user_message,
+        MessageRole::Assistant => theme.assistant_message,
+        MessageRole::System => theme.system_message,
+        MessageRole::Tool => unreachable!(),
     };
+    let prefix = "";
 
     let indent = " ".repeat(prefix.len());
     let is_assistant = msg.role == MessageRole::Assistant;
@@ -243,7 +251,7 @@ fn render_chat_message(
 
         let is_last_line = i == styled_lines.len() - 1;
         if msg.streaming && is_last_line {
-            line_spans.push(Span::styled("\u{258c}".to_string(), theme.streaming_cursor));
+            line_spans.push(Span::styled("\u{2502}".to_string(), theme.streaming_cursor));
         }
 
         lines.extend(wrap_spans(line_spans, wrap_width));
@@ -252,7 +260,7 @@ fn render_chat_message(
     if styled_lines.is_empty() {
         let mut pfx_spans = vec![Span::styled(prefix.to_string(), base_style)];
         if msg.streaming {
-            pfx_spans.push(Span::styled("\u{258c}".to_string(), theme.streaming_cursor));
+            pfx_spans.push(Span::styled("\u{2502}".to_string(), theme.streaming_cursor));
         }
         lines.extend(wrap_spans(pfx_spans, wrap_width));
     }
@@ -266,48 +274,33 @@ fn render_scrollbar(
     inner_height: usize,
     total: usize,
     scroll: usize,
-    effective_offset: usize,
+    _effective_offset: usize,
     max_scroll: usize,
 ) {
-    let indicator_x = area.x + area.width.saturating_sub(2);
-    if scroll > 0 {
-        let y = area.y + 1;
+    let track_height = inner_height;
+    if track_height == 0 {
+        return;
+    }
+    let thumb_size = (inner_height * track_height)
+        .checked_div(total)
+        .unwrap_or(track_height)
+        .clamp(1, track_height);
+    let thumb_pos = ((track_height - thumb_size) * scroll)
+        .checked_div(max_scroll)
+        .unwrap_or(0);
+    let track_top = area.y + 1;
+    let bar_x = area.x + area.width.saturating_sub(1);
+    let dim = Style::default().fg(ratatui::style::Color::DarkGray);
+    for row in 0..track_height {
+        let ch = if row >= thumb_pos && row < thumb_pos + thumb_size {
+            "\u{2502}"
+        } else {
+            " "
+        };
+        let row_y = u16::try_from(row).unwrap_or(u16::MAX);
         frame
             .buffer_mut()
-            .set_string(indicator_x, y, "\u{25b2}", Style::default());
-    }
-    if effective_offset > 0 {
-        let y = area.y + area.height.saturating_sub(2);
-        frame
-            .buffer_mut()
-            .set_string(indicator_x, y, "\u{25bc}", Style::default());
-    }
-
-    let track_height = inner_height.saturating_sub(2);
-    if track_height > 0 {
-        let thumb_size = (inner_height * track_height)
-            .checked_div(total)
-            .unwrap_or(track_height)
-            .clamp(1, track_height);
-        let thumb_pos = ((track_height - thumb_size) * scroll)
-            .checked_div(max_scroll)
-            .unwrap_or(0);
-        let track_top = area.y + 2;
-        let bar_x = area.x + area.width.saturating_sub(1);
-        for row in 0..track_height {
-            let ch = if row >= thumb_pos && row < thumb_pos + thumb_size {
-                "\u{2588}"
-            } else {
-                "\u{2591}"
-            };
-            let row_y = u16::try_from(row).unwrap_or(u16::MAX);
-            frame.buffer_mut().set_string(
-                bar_x,
-                track_top + row_y,
-                ch,
-                Style::default().fg(ratatui::style::Color::DarkGray),
-            );
-        }
+            .set_string(bar_x, track_top + row_y, ch, dim);
     }
 }
 
@@ -321,32 +314,27 @@ fn render_tool_message(
     throbber_idx: usize,
     theme: &Theme,
     wrap_width: usize,
-    show_labels: bool,
+    _show_labels: bool,
     lines: &mut Vec<Line<'static>>,
 ) {
-    let prefix = if show_labels {
-        let name = msg.tool_name.as_deref().unwrap_or("tool");
-        format!("[{name}] ")
-    } else {
-        String::new()
-    };
+    let name = msg.tool_name.as_deref().unwrap_or("tool");
     let content_lines: Vec<&str> = msg.content.lines().collect();
-
-    // First line is always the command ($ ...)
     let cmd_line = content_lines.first().copied().unwrap_or("");
+    let dim = Style::default().add_modifier(Modifier::DIM);
+
     let status_span = if msg.streaming {
         let symbol = BRAILLE_SIX.symbols[throbber_idx];
         Span::styled(format!("{symbol} "), theme.streaming_cursor)
     } else {
-        Span::styled("\u{2714} ".to_string(), theme.highlight)
+        Span::styled("\u{2714} ", dim)
     };
-    let indent = " ".repeat(prefix.len());
     let cmd_spans: Vec<Span<'static>> = vec![
-        Span::styled(prefix, theme.highlight),
         status_span,
-        Span::styled(cmd_line.to_string(), theme.tool_command),
+        Span::styled(format!("{name} "), dim),
+        Span::styled(cmd_line.to_string(), dim),
     ];
     lines.extend(wrap_spans(cmd_spans, wrap_width));
+    let indent = "  ";
 
     // Diff rendering for write/edit tools
     if let Some(ref diff_data) = msg.diff_data {
@@ -354,7 +342,7 @@ fn render_tool_message(
         let rendered = super::diff::render_diff_lines(&diff_lines, &diff_data.file_path, theme);
         let mut wrapped: Vec<Line<'static>> = Vec::new();
         for line in rendered {
-            let mut prefixed_spans = vec![Span::styled(indent.clone(), Style::default())];
+            let mut prefixed_spans = vec![Span::styled(indent.to_string(), Style::default())];
             prefixed_spans.extend(line.spans);
             wrapped.push(Line::from(prefixed_spans));
         }
@@ -392,7 +380,7 @@ fn render_tool_message(
             let mut wrapped: Vec<Line<'static>> = Vec::new();
             for line in output_lines {
                 let spans = vec![
-                    Span::styled(indent.clone(), Style::default()),
+                    Span::styled(indent.to_string(), Style::default()),
                     Span::styled((*line).to_string(), theme.code_block),
                 ];
                 wrapped.extend(wrap_spans(spans, wrap_width));

--- a/crates/zeph-tui/src/widgets/input.rs
+++ b/crates/zeph-tui/src/widgets/input.rs
@@ -29,10 +29,17 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect) {
         block = block.title_bottom(Span::styled(" [editing queued] ", theme.highlight));
     }
 
-    let paragraph = Paragraph::new(app.input())
-        .block(block)
-        .style(theme.input_cursor)
-        .wrap(Wrap { trim: false });
+    let paragraph = if app.input().is_empty() && matches!(app.input_mode(), InputMode::Insert) {
+        Paragraph::new("Type a message, / for commands, @ to mention")
+            .block(block)
+            .style(theme.system_message)
+            .wrap(Wrap { trim: false })
+    } else {
+        Paragraph::new(app.input())
+            .block(block)
+            .style(theme.input_text)
+            .wrap(Wrap { trim: false })
+    };
 
     frame.render_widget(paragraph, area);
 

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__input__tests__input_insert_mode.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__input__tests__input_insert_mode.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/zeph-tui/src/widgets/input.rs
+assertion_line: 78
 expression: output
 ---
 ┌ Input (Esc to cancel) ───────────────┐
-│                                      │
-│                                      │
+│Type a message, / for commands, @ to  │
+│mention                               │
 │                                      │
 └──────────────────────────────────────┘


### PR DESCRIPTION
## Summary

- Remove message labels, separator lines, and scrollbar arrows for minimal design
- Vertical bar prefix only for user messages, simplified tool output rendering
- Static HH:MM timestamps, input placeholder hint, Cyan input color matching chat
- Auto-scroll respects manual scroll position, Ctrl+L clears chat
- Refactor ChatMessage to builder pattern (`new`/`streaming`/`with_tool`)

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo nextest run --workspace --lib --bins` — 2359 tests pass
- [ ] Manual verification of TUI rendering