### PR TITLE
fix(memory): auto-create parent directories for sqlite_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Auto-create parent directories for `sqlite_path` on startup (#756)
+
 ### Added
 - `autosave_assistant` and `autosave_min_length` config fields in `MemoryConfig` — assistant responses skip embedding when disabled (#748)
 - `SemanticMemory::save_only()` — persist message to SQLite without generating a vector embedding (#748)

--- a/crates/zeph-memory/src/error.rs
+++ b/crates/zeph-memory/src/error.rs
@@ -24,6 +24,9 @@ pub enum MemoryError {
     #[error("snapshot error: {0}")]
     Snapshot(String),
 
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
     #[error("{0}")]
     Other(String),
 }

--- a/crates/zeph-memory/src/sqlite/mod.rs
+++ b/crates/zeph-memory/src/sqlite/mod.rs
@@ -32,6 +32,11 @@ impl SqliteStore {
         let url = if path == ":memory:" {
             "sqlite::memory:".to_string()
         } else {
+            if let Some(parent) = std::path::Path::new(path).parent()
+                && !parent.as_os_str().is_empty()
+            {
+                std::fs::create_dir_all(parent)?;
+            }
             format!("sqlite:{path}?mode=rwc")
         };
 
@@ -86,5 +91,14 @@ mod tests {
             .expect("PRAGMA query");
 
         assert_eq!(mode, "wal", "expected WAL journal mode, got: {mode}");
+    }
+
+    #[tokio::test]
+    async fn creates_parent_dirs() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let deep = dir.path().join("a/b/c/zeph.db");
+        let path = deep.to_str().expect("valid path");
+        let _store = SqliteStore::new(path).await.expect("SqliteStore::new");
+        assert!(deep.exists(), "database file should exist");
     }
 }


### PR DESCRIPTION
## Summary
- `SqliteStore::new()` now calls `create_dir_all` on the parent directory before opening the SQLite connection
- Added `Io` variant to `MemoryError` for `std::io::Error` propagation
- Prevents startup crash when `data/` directory does not exist (default config uses `./data/zeph.db`)

## Test plan
- [x] New `creates_parent_dirs` test — verifies nested directory creation
- [x] `cargo +nightly fmt --check` — pass
- [x] `cargo clippy --workspace -- -D warnings` — pass
- [x] `cargo nextest run -p zeph-memory --lib --features mock` — 253/253 pass

Closes #756