### PR TITLE
fix(acp): preserve session on cancel, filter tool_use markers

### DIFF
--- a/crates/zeph-acp/src/agent.rs
+++ b/crates/zeph-acp/src/agent.rs
@@ -230,7 +230,8 @@ impl acp::Agent for ZephAcpAgent {
 
     async fn cancel(&self, args: acp::CancelNotification) -> acp::Result<()> {
         tracing::debug!(session_id = %args.session_id, "ACP cancel");
-        self.sessions.borrow_mut().remove(&args.session_id);
+        // Keep the session alive — the IDE may send another prompt on the same session_id.
+        // The current prompt() drain loop will finish naturally when the agent completes its turn.
         Ok(())
     }
 
@@ -246,9 +247,20 @@ impl acp::Agent for ZephAcpAgent {
     }
 }
 
+/// Returns `true` if `text` looks like a raw tool-use marker that should not be
+/// forwarded to the IDE (e.g. `[tool_use: bash (toolu_abc123)]`).
+fn is_tool_use_marker(text: &str) -> bool {
+    let trimmed = text.trim();
+    trimmed.starts_with("[tool_use:") && trimmed.ends_with(']')
+}
+
 fn loopback_event_to_update(event: LoopbackEvent) -> Option<acp::SessionUpdate> {
     match event {
-        LoopbackEvent::Chunk(text) | LoopbackEvent::FullMessage(text) if text.is_empty() => None,
+        LoopbackEvent::Chunk(text) | LoopbackEvent::FullMessage(text)
+            if text.is_empty() || is_tool_use_marker(&text) =>
+        {
+            None
+        }
         LoopbackEvent::Chunk(text) | LoopbackEvent::FullMessage(text) => Some(
             acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(text.into())),
         ),
@@ -319,7 +331,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cancel_removes_session() {
+    async fn cancel_keeps_session() {
         let local = tokio::task::LocalSet::new();
         local
             .run_until(async {
@@ -334,7 +346,8 @@ mod tests {
                     .cancel(acp::CancelNotification::new(sid.clone()))
                     .await
                     .unwrap();
-                assert!(!agent.sessions.borrow().contains_key(&sid));
+                // Cancel keeps the session alive for subsequent prompts.
+                assert!(agent.sessions.borrow().contains_key(&sid));
             })
             .await;
     }
@@ -473,5 +486,19 @@ mod tests {
                 assert!(agent.prompt(req).await.is_err());
             })
             .await;
+    }
+
+    #[test]
+    fn tool_use_marker_filtered() {
+        let event =
+            LoopbackEvent::Chunk("[tool_use: bash (toolu_01VzP6Q9b6JQY6ZP5r6qY9Wm)]".into());
+        assert!(loopback_event_to_update(event).is_none());
+
+        let event = LoopbackEvent::FullMessage("[tool_use: read (toolu_abc)]".into());
+        assert!(loopback_event_to_update(event).is_none());
+
+        // Normal text should pass through.
+        let event = LoopbackEvent::Chunk("hello [tool_use: not a marker".into());
+        assert!(loopback_event_to_update(event).is_some());
     }
 }


### PR DESCRIPTION
## Summary

- Cancel no longer removes the session entry — the IDE reuses the same session_id for subsequent prompts, preventing "session not found" errors after cancellation
- Filter raw `[tool_use: ...]` markers from streaming chunks so LLM tool call metadata is not rendered as plain text in the IDE conversation panel

## Test plan

- [x] `cargo +nightly fmt --check` — pass
- [x] `cargo clippy --workspace -- -D warnings` — pass
- [x] `cargo nextest run --workspace --lib --bins` — 2555 passed
- [x] Manually tested in Zed: cancel mid-response then send new prompt — no error