### PR TITLE
feat(acp): wire AcpContext into agent loop, cancellation, spec compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Wire `AcpContext` (IDE-proxied FS, shell, permissions) through `AgentSpawner` into agent tool chain via `CompositeExecutor` — ACP executors take priority with automatic local fallback (#779)
+- `DynExecutor` newtype in `zeph-tools` for object-safe `ToolExecutor` composition in `CompositeExecutor` (#779)
+- `cancel_signal: Arc<Notify>` on `LoopbackHandle` for cooperative cancellation between ACP sessions and agent loop (#780)
+- `with_cancel_signal()` builder method on `Agent` to inject external cancellation signal (#780)
 - `zeph-acp` crate — ACP (Agent Client Protocol) server for IDE embedding (Zed, JetBrains, Neovim) (#763-#766)
 - `--acp` CLI flag to launch Zeph as an ACP stdio server (requires `acp` feature)
 - `acp` feature gate in root `Cargo.toml`; included in `full` feature set
@@ -27,6 +31,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `AcpServerConfig` passed through `serve_stdio`/`serve_connection` to configure agent identity from config values (#770)
 - ACP section in `--init` wizard — prompts for `enabled`, `agent_name`, `agent_version` (#771)
 - Integration tests for ACP transport using `tokio::io::duplex` — `initialize_handshake`, `new_session_and_cancel` (#773)
+
+### Fixed
+- Permission cache key collision on anonymous tools — uses `tool_call_id` as fallback when title is absent (#779)
 
 ## [0.11.6] - 2026-02-23
 

--- a/crates/zeph-acp/README.md
+++ b/crates/zeph-acp/README.md
@@ -1,0 +1,65 @@
+# zeph-acp
+
+[![Crates.io](https://img.shields.io/crates/v/zeph-acp)](https://crates.io/crates/zeph-acp)
+[![docs.rs](https://img.shields.io/docsrs/zeph-acp)](https://docs.rs/zeph-acp)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](../../LICENSE)
+[![MSRV](https://img.shields.io/badge/MSRV-1.88-blue)](https://www.rust-lang.org)
+
+ACP (Agent Client Protocol) server adapter for embedding Zeph in IDE environments.
+
+## Overview
+
+Implements the [Agent Client Protocol](https://agentclientprotocol.org) server side, allowing IDEs and editors to drive the Zeph agent loop over stdio or HTTP transports. The crate wires IDE-proxied capabilities — file system access, terminal execution, and permission gates — into the agent loop via `AcpContext`, and exposes `AgentSpawner` as the integration point for the host application.
+
+## Key modules
+
+| Module | Description |
+|--------|-------------|
+| `agent` | `AcpContext` — IDE-proxied capabilities (file executor, shell executor, permission gate, cancel signal) wired into the agent loop per session; `AgentSpawner` factory type; `ZephAcpAgent` ACP protocol handler |
+| `transport` | `serve_stdio` / `serve_connection` — ACP server transports; `AcpServerConfig` |
+| `fs` | `AcpFileExecutor` — file system executor backed by IDE-proxied ACP file operations |
+| `terminal` | `AcpShellExecutor` — shell executor backed by IDE-proxied ACP terminal |
+| `permission` | `AcpPermissionGate` — forwards tool permission requests to the IDE for user approval |
+| `mcp_bridge` | `acp_mcp_servers_to_entries` — converts ACP-advertised MCP servers into `McpServerEntry` configs |
+| `error` | `AcpError` typed error enum |
+
+**Re-exports:** `AcpContext`, `AgentSpawner`, `AcpError`, `AcpFileExecutor`, `AcpPermissionGate`, `AcpShellExecutor`, `AcpServerConfig`, `serve_connection`, `serve_stdio`, `acp_mcp_servers_to_entries`
+
+## AcpContext
+
+`AcpContext` carries per-session IDE capabilities into the agent loop. Each field is `None` when the IDE did not advertise the corresponding capability:
+
+```rust
+pub struct AcpContext {
+    pub file_executor: Option<AcpFileExecutor>,
+    pub shell_executor: Option<AcpShellExecutor>,
+    pub permission_gate: Option<AcpPermissionGate>,
+    /// Notify to interrupt the running agent operation.
+    pub cancel_signal: Arc<Notify>,
+}
+```
+
+The `cancel_signal` is shared with the agent's `LoopbackHandle` so that an IDE cancel request immediately interrupts the running inference loop.
+
+## AgentSpawner
+
+`AgentSpawner` is the integration contract between `zeph-acp` and the host application:
+
+```rust
+pub type AgentSpawner = Arc<
+    dyn Fn(LoopbackChannel, Option<AcpContext>) -> Pin<Box<dyn Future<Output = ()> + 'static>>
+        + 'static,
+>;
+```
+
+The host constructs an `AgentSpawner` closure that wires `AcpContext` capabilities into `Agent` via `with_cancel_signal()` on the builder, then passes the closure to `serve_stdio` or `serve_connection`.
+
+## Installation
+
+```bash
+cargo add zeph-acp
+```
+
+## License
+
+MIT

--- a/crates/zeph-acp/src/agent.rs
+++ b/crates/zeph-acp/src/agent.rs
@@ -215,9 +215,27 @@ impl acp::Agent for ZephAcpAgent {
             .await
             .map_err(|_| acp::Error::internal_error().data("agent channel closed"))?;
 
+        // Grab the cancel_signal so we can detect cancellation during the drain loop.
+        let cancel_signal = self
+            .sessions
+            .borrow()
+            .get(&args.session_id)
+            .map(|e| std::sync::Arc::clone(&e.cancel_signal));
+
         // Block until the agent finishes this turn (signals via Flush or channel close).
         let mut rx = output_rx;
-        while let Some(event) = rx.recv().await {
+        let mut cancelled = false;
+        loop {
+            let event = if let Some(ref signal) = cancel_signal {
+                tokio::select! {
+                    biased;
+                    () = signal.notified() => { cancelled = true; break; }
+                    ev = rx.recv() => ev,
+                }
+            } else {
+                rx.recv().await
+            };
+            let Some(event) = event else { break };
             let is_flush = matches!(event, LoopbackEvent::Flush);
             if let Some(update) = loopback_event_to_update(event) {
                 let notification = acp::SessionNotification::new(args.session_id.clone(), update);
@@ -236,7 +254,12 @@ impl acp::Agent for ZephAcpAgent {
             *entry.output_rx.borrow_mut() = Some(rx);
         }
 
-        Ok(acp::PromptResponse::new(acp::StopReason::EndTurn))
+        let stop_reason = if cancelled {
+            acp::StopReason::Cancelled
+        } else {
+            acp::StopReason::EndTurn
+        };
+        Ok(acp::PromptResponse::new(stop_reason))
     }
 
     async fn cancel(&self, args: acp::CancelNotification) -> acp::Result<()> {
@@ -268,6 +291,17 @@ fn is_tool_use_marker(text: &str) -> bool {
     trimmed.starts_with("[tool_use:") && trimmed.ends_with(']')
 }
 
+fn tool_kind_from_name(name: &str) -> acp::ToolKind {
+    match name {
+        "bash" | "shell" => acp::ToolKind::Execute,
+        "read_file" => acp::ToolKind::Read,
+        "write_file" => acp::ToolKind::Edit,
+        "search" | "grep" | "find" => acp::ToolKind::Search,
+        "web_scrape" | "fetch" => acp::ToolKind::Fetch,
+        _ => acp::ToolKind::Other,
+    }
+}
+
 fn loopback_event_to_update(event: LoopbackEvent) -> Option<acp::SessionUpdate> {
     match event {
         LoopbackEvent::Chunk(text) | LoopbackEvent::FullMessage(text)
@@ -285,10 +319,14 @@ fn loopback_event_to_update(event: LoopbackEvent) -> Option<acp::SessionUpdate> 
         LoopbackEvent::ToolOutput {
             tool_name, display, ..
         } => {
-            let text = format!("[{tool_name}] {display}");
-            Some(acp::SessionUpdate::AgentMessageChunk(
-                acp::ContentChunk::new(text.into()),
-            ))
+            let tool_call_id = uuid::Uuid::new_v4().to_string();
+            let tool_call = acp::ToolCall::new(tool_call_id, &tool_name)
+                .kind(tool_kind_from_name(&tool_name))
+                .status(acp::ToolCallStatus::Completed)
+                .content(vec![acp::ToolCallContent::from(
+                    acp::ContentBlock::Text(acp::TextContent::new(display)),
+                )]);
+            Some(acp::SessionUpdate::ToolCall(tool_call))
         }
         LoopbackEvent::Flush => None,
     }
@@ -448,7 +486,7 @@ mod tests {
     }
 
     #[test]
-    fn loopback_tool_output_maps_to_agent_message() {
+    fn loopback_tool_output_maps_to_tool_call() {
         let event = LoopbackEvent::ToolOutput {
             tool_name: "bash".to_owned(),
             display: "done".to_owned(),
@@ -456,10 +494,25 @@ mod tests {
             filter_stats: None,
             kept_lines: None,
         };
-        assert!(matches!(
-            loopback_event_to_update(event),
-            Some(acp::SessionUpdate::AgentMessageChunk(_))
-        ));
+        let update = loopback_event_to_update(event);
+        match update {
+            Some(acp::SessionUpdate::ToolCall(tc)) => {
+                assert_eq!(tc.title, "bash");
+                assert_eq!(tc.status, acp::ToolCallStatus::Completed);
+                assert_eq!(tc.kind, acp::ToolKind::Execute);
+            }
+            other => panic!("expected ToolCall, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tool_kind_from_name_maps_correctly() {
+        assert_eq!(tool_kind_from_name("bash"), acp::ToolKind::Execute);
+        assert_eq!(tool_kind_from_name("read_file"), acp::ToolKind::Read);
+        assert_eq!(tool_kind_from_name("write_file"), acp::ToolKind::Edit);
+        assert_eq!(tool_kind_from_name("search"), acp::ToolKind::Search);
+        assert_eq!(tool_kind_from_name("web_scrape"), acp::ToolKind::Fetch);
+        assert_eq!(tool_kind_from_name("unknown"), acp::ToolKind::Other);
     }
 
     #[tokio::test]

--- a/crates/zeph-acp/src/agent.rs
+++ b/crates/zeph-acp/src/agent.rs
@@ -323,9 +323,9 @@ fn loopback_event_to_update(event: LoopbackEvent) -> Option<acp::SessionUpdate> 
             let tool_call = acp::ToolCall::new(tool_call_id, &tool_name)
                 .kind(tool_kind_from_name(&tool_name))
                 .status(acp::ToolCallStatus::Completed)
-                .content(vec![acp::ToolCallContent::from(
-                    acp::ContentBlock::Text(acp::TextContent::new(display)),
-                )]);
+                .content(vec![acp::ToolCallContent::from(acp::ContentBlock::Text(
+                    acp::TextContent::new(display),
+                ))]);
             Some(acp::SessionUpdate::ToolCall(tool_call))
         }
         LoopbackEvent::Flush => None,

--- a/crates/zeph-acp/src/agent.rs
+++ b/crates/zeph-acp/src/agent.rs
@@ -24,6 +24,8 @@ pub struct AcpContext {
     pub file_executor: Option<AcpFileExecutor>,
     pub shell_executor: Option<AcpShellExecutor>,
     pub permission_gate: Option<AcpPermissionGate>,
+    /// Shared cancellation signal: notify to interrupt the running agent operation.
+    pub cancel_signal: std::sync::Arc<tokio::sync::Notify>,
 }
 
 /// Factory: receives a [`LoopbackChannel`] and optional [`AcpContext`], runs the agent loop.
@@ -44,6 +46,7 @@ struct SessionEntry {
     // Receiver is owned solely by the prompt() handler; RefCell avoids Arc<Mutex> overhead
     // since MAX_SESSIONS=1 and prompt() is never called concurrently for the same session.
     output_rx: RefCell<Option<mpsc::Receiver<LoopbackEvent>>>,
+    cancel_signal: std::sync::Arc<tokio::sync::Notify>,
 }
 
 pub struct ZephAcpAgent {
@@ -77,7 +80,11 @@ impl ZephAcpAgent {
         self
     }
 
-    fn build_acp_context(&self, session_id: &acp::SessionId) -> Option<AcpContext> {
+    fn build_acp_context(
+        &self,
+        session_id: &acp::SessionId,
+        cancel_signal: std::sync::Arc<tokio::sync::Notify>,
+    ) -> Option<AcpContext> {
         let conn_guard = self.conn_slot.borrow();
         let conn = conn_guard.as_ref()?;
 
@@ -102,6 +109,7 @@ impl ZephAcpAgent {
             file_executor: Some(fs_exec),
             shell_executor: Some(shell_exec),
             permission_gate: Some(perm_gate),
+            cancel_signal,
         })
     }
 
@@ -151,14 +159,17 @@ impl acp::Agent for ZephAcpAgent {
         tracing::debug!(%session_id, "new ACP session");
 
         let (channel, handle) = LoopbackChannel::pair(LOOPBACK_CHANNEL_CAPACITY);
+        // Clone once for build_acp_context; ownership of the original moves into SessionEntry.
+        let cancel_signal = std::sync::Arc::clone(&handle.cancel_signal);
 
         let entry = SessionEntry {
             input_tx: handle.input_tx,
             output_rx: RefCell::new(Some(handle.output_rx)),
+            cancel_signal: handle.cancel_signal,
         };
         self.sessions.borrow_mut().insert(session_id.clone(), entry);
 
-        let acp_ctx = self.build_acp_context(&session_id);
+        let acp_ctx = self.build_acp_context(&session_id, cancel_signal);
         let spawner = Arc::clone(&self.spawner);
         tokio::task::spawn_local(async move {
             (spawner)(channel, acp_ctx).await;
@@ -230,6 +241,9 @@ impl acp::Agent for ZephAcpAgent {
 
     async fn cancel(&self, args: acp::CancelNotification) -> acp::Result<()> {
         tracing::debug!(session_id = %args.session_id, "ACP cancel");
+        if let Some(entry) = self.sessions.borrow().get(&args.session_id) {
+            entry.cancel_signal.notify_one();
+        }
         self.sessions.borrow_mut().remove(&args.session_id);
         Ok(())
     }
@@ -335,6 +349,40 @@ mod tests {
                     .await
                     .unwrap();
                 assert!(!agent.sessions.borrow().contains_key(&sid));
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn cancel_triggers_notify_one() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let (agent, _rx) = make_agent();
+                use acp::Agent as _;
+                let resp = agent
+                    .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
+                    .await
+                    .unwrap();
+                let sid = resp.session_id.clone();
+
+                // Capture the cancel_signal before cancel() removes the entry.
+                let signal = std::sync::Arc::clone(
+                    &agent.sessions.borrow().get(&sid).unwrap().cancel_signal,
+                );
+
+                // Set up a notified future before calling cancel().
+                let notified = signal.notified();
+
+                agent
+                    .cancel(acp::CancelNotification::new(sid))
+                    .await
+                    .unwrap();
+
+                // Should resolve immediately since cancel() called notify_one().
+                tokio::time::timeout(std::time::Duration::from_millis(100), notified)
+                    .await
+                    .expect("cancel_signal was not notified within timeout");
             })
             .await;
     }

--- a/crates/zeph-acp/src/permission.rs
+++ b/crates/zeph-acp/src/permission.rs
@@ -66,12 +66,15 @@ impl AcpPermissionGate {
         session_id: acp::SessionId,
         tool_call: acp::ToolCallUpdate,
     ) -> Result<bool, AcpError> {
-        // Key on session + tool title (binary name) for AllowAlways/RejectAlways caching.
-        // Granularity is intentionally per-binary, per-session: the user approves "bash" once
-        // per session rather than per-invocation, matching IDE UX expectations.
-        // Trade-off: two distinct tools with the same title share one cache entry.
-        // This is acceptable since title is the user-visible identifier shown in the IDE prompt.
-        let tool_name = tool_call.fields.title.as_deref().unwrap_or("");
+        // Key on session + tool title for AllowAlways/RejectAlways caching. When title is absent,
+        // fall back to tool_call_id so distinct untitled tools never share the same cache entry.
+        let fallback = tool_call.tool_call_id.to_string();
+        let tool_name = tool_call
+            .fields
+            .title
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .unwrap_or(&fallback);
         let cache_key = format!("{session_id}:{tool_name}");
 
         // Fast path: cached decision.
@@ -127,12 +130,14 @@ async fn run_permission_handler<C>(
             ),
         ];
 
+        let fallback = req.tool_call.tool_call_id.to_string();
         let tool_name = req
             .tool_call
             .fields
             .title
             .as_deref()
-            .unwrap_or("")
+            .filter(|s| !s.is_empty())
+            .unwrap_or(&fallback)
             .to_owned();
         let session_id = &req.session_id;
         let cache_key = format!("{session_id}:{tool_name}");
@@ -328,10 +333,10 @@ mod tests {
                 // Second call — served from cache without IDE round-trip.
                 let second = gate.check_permission(sid, tc).await.unwrap();
                 assert!(second);
-                // Verify cache entry uses "session_id:tool_name" key.
+                // Verify cache entry uses "session_id:tool_call_id" key (title is absent).
                 let guard = gate.cache.read().unwrap();
                 assert!(matches!(
-                    guard.get("s1:"),
+                    guard.get("s1:tc-aa"),
                     Some(PermissionDecision::AllowAlways)
                 ));
             })
@@ -358,7 +363,7 @@ mod tests {
                 assert!(!second);
                 let guard = gate.cache.read().unwrap();
                 assert!(matches!(
-                    guard.get("s1:"),
+                    guard.get("s1:tc-ra"),
                     Some(PermissionDecision::RejectAlways)
                 ));
             })

--- a/crates/zeph-core/README.md
+++ b/crates/zeph-core/README.md
@@ -15,14 +15,14 @@ Core orchestration crate for the Zeph agent. Manages the main agent loop, bootst
 
 | Module | Description |
 |--------|-------------|
-| `agent` | `Agent<C>` — main loop driving inference and tool execution; ToolExecutor erased via `Box<dyn ErasedToolExecutor>` |
+| `agent` | `Agent<C>` — main loop driving inference and tool execution; ToolExecutor erased via `Box<dyn ErasedToolExecutor>`; supports external cancellation via `with_cancel_signal()` |
 | `agent::tool_execution` | Tool call handling, redaction, and result processing |
 | `agent::message_queue` | Message queue management |
 | `agent::builder` | Agent builder API |
 | `agent::commands` | Chat command dispatch (skills, feedback, skill management via `/skill install` and `/skill remove`, sub-agent management via `/agent`, etc.) |
 | `agent::utils` | Shared agent utilities |
 | `bootstrap` | `AppBuilder` — fluent builder for application startup |
-| `channel` | `Channel` trait defining I/O adapters; `LoopbackChannel` / `LoopbackHandle` for headless daemon I/O; `Attachment` / `AttachmentKind` for multimodal inputs |
+| `channel` | `Channel` trait defining I/O adapters; `LoopbackChannel` / `LoopbackHandle` for headless daemon I/O (`LoopbackHandle` exposes `cancel_signal: Arc<Notify>` for session cancellation); `Attachment` / `AttachmentKind` for multimodal inputs |
 | `config` | TOML config with `ZEPH_*` env overrides; typed `ConfigError` (Io, Parse, Validation, Vault) |
 | `context` | LLM context assembly from history, skills, memory; adaptive chunked compaction with parallel summarization |
 | `cost` | Token cost tracking and budgeting |

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -285,6 +285,14 @@ impl<C: Channel> Agent<C> {
     pub fn cancel_signal(&self) -> Arc<Notify> {
         Arc::clone(&self.cancel_signal)
     }
+
+    /// Inject a shared cancel signal so an external caller (e.g. ACP session) can
+    /// interrupt the agent loop by calling `notify_one()`.
+    #[must_use]
+    pub fn with_cancel_signal(mut self, signal: Arc<Notify>) -> Self {
+        self.cancel_signal = signal;
+        self
+    }
 }
 
 #[cfg(test)]
@@ -293,6 +301,24 @@ mod tests {
         MockChannel, MockToolExecutor, create_test_registry, mock_provider,
     };
     use super::*;
+
+    #[test]
+    fn with_cancel_signal_replaces_internal_signal() {
+        let agent = Agent::new(
+            mock_provider(vec![]),
+            MockChannel::new(vec![]),
+            create_test_registry(),
+            None,
+            5,
+            MockToolExecutor::no_tools(),
+        );
+
+        let shared = Arc::new(Notify::new());
+        let agent = agent.with_cancel_signal(Arc::clone(&shared));
+
+        // The injected signal and the agent's internal signal must be the same Arc.
+        assert!(Arc::ptr_eq(&shared, &agent.cancel_signal()));
+    }
 
     /// Verify that with_managed_skills_dir enables the install/remove commands.
     /// Without a managed dir, `/skill install` sends a "not configured" message.

--- a/crates/zeph-core/src/channel.rs
+++ b/crates/zeph-core/src/channel.rs
@@ -177,6 +177,8 @@ pub enum LoopbackEvent {
 pub struct LoopbackHandle {
     pub input_tx: tokio::sync::mpsc::Sender<ChannelMessage>,
     pub output_rx: tokio::sync::mpsc::Receiver<LoopbackEvent>,
+    /// Shared cancel signal: notify to interrupt the agent's current operation.
+    pub cancel_signal: std::sync::Arc<tokio::sync::Notify>,
 }
 
 /// Headless channel bridging an A2A `TaskProcessor` with the agent loop.
@@ -191,6 +193,7 @@ impl LoopbackChannel {
     pub fn pair(buffer: usize) -> (Self, LoopbackHandle) {
         let (input_tx, input_rx) = tokio::sync::mpsc::channel(buffer);
         let (output_tx, output_rx) = tokio::sync::mpsc::channel(buffer);
+        let cancel_signal = std::sync::Arc::new(tokio::sync::Notify::new());
         (
             Self {
                 input_rx,
@@ -199,6 +202,7 @@ impl LoopbackChannel {
             LoopbackHandle {
                 input_tx,
                 output_rx,
+                cancel_signal,
             },
         )
     }
@@ -406,6 +410,26 @@ mod tests {
         // Both sides exist and channels are connected via their sender capacity
         drop(channel);
         drop(handle);
+    }
+
+    #[tokio::test]
+    async fn loopback_cancel_signal_can_be_notified_and_awaited() {
+        let (_channel, handle) = LoopbackChannel::pair(8);
+        let signal = std::sync::Arc::clone(&handle.cancel_signal);
+        // Notify from one side, await on the other.
+        let notified = signal.notified();
+        handle.cancel_signal.notify_one();
+        notified.await; // resolves immediately after notify_one()
+    }
+
+    #[tokio::test]
+    async fn loopback_cancel_signal_shared_across_clones() {
+        let (_channel, handle) = LoopbackChannel::pair(8);
+        let signal_a = std::sync::Arc::clone(&handle.cancel_signal);
+        let signal_b = std::sync::Arc::clone(&handle.cancel_signal);
+        let notified = signal_b.notified();
+        signal_a.notify_one();
+        notified.await;
     }
 
     #[tokio::test]

--- a/crates/zeph-tools/README.md
+++ b/crates/zeph-tools/README.md
@@ -15,7 +15,7 @@ Defines the `ToolExecutor` trait for sandboxed tool invocation and ships concret
 
 | Module | Description |
 |--------|-------------|
-| `executor` | `ToolExecutor` trait, `ToolOutput`, `ToolCall` |
+| `executor` | `ToolExecutor` trait, `ToolOutput`, `ToolCall`; `DynExecutor` newtype wrapping `Arc<dyn ErasedToolExecutor>` for object-safe executor composition |
 | `shell` | Shell command executor with tokenizer-based command detection, escape normalization, and transparent wrapper skipping; receives skill-scoped env vars injected by the agent for active skills that declare `x-requires-secrets` |
 | `file` | File operation executor |
 | `scrape` | Web scraping executor with SSRF protection (post-DNS private IP validation, pinned address client) |

--- a/crates/zeph-tools/src/executor.rs
+++ b/crates/zeph-tools/src/executor.rs
@@ -263,6 +263,49 @@ impl<T: ToolExecutor> ErasedToolExecutor for T {
     }
 }
 
+/// Wraps `Arc<dyn ErasedToolExecutor>` so it can be used as a concrete `ToolExecutor`.
+///
+/// Enables dynamic composition of tool executors at runtime without static type chains.
+pub struct DynExecutor(pub std::sync::Arc<dyn ErasedToolExecutor>);
+
+impl ToolExecutor for DynExecutor {
+    fn execute(
+        &self,
+        response: &str,
+    ) -> impl Future<Output = Result<Option<ToolOutput>, ToolError>> + Send {
+        // Clone data to satisfy the 'static-ish bound: erased futures must not borrow self.
+        let inner = std::sync::Arc::clone(&self.0);
+        let response = response.to_owned();
+        async move { inner.execute_erased(&response).await }
+    }
+
+    fn execute_confirmed(
+        &self,
+        response: &str,
+    ) -> impl Future<Output = Result<Option<ToolOutput>, ToolError>> + Send {
+        let inner = std::sync::Arc::clone(&self.0);
+        let response = response.to_owned();
+        async move { inner.execute_confirmed_erased(&response).await }
+    }
+
+    fn tool_definitions(&self) -> Vec<crate::registry::ToolDef> {
+        self.0.tool_definitions_erased()
+    }
+
+    fn execute_tool_call(
+        &self,
+        call: &ToolCall,
+    ) -> impl Future<Output = Result<Option<ToolOutput>, ToolError>> + Send {
+        let inner = std::sync::Arc::clone(&self.0);
+        let call = call.clone();
+        async move { inner.execute_tool_call_erased(&call).await }
+    }
+
+    fn set_skill_env(&self, env: Option<std::collections::HashMap<String, String>>) {
+        ErasedToolExecutor::set_skill_env(self.0.as_ref(), env);
+    }
+}
+
 /// Extract fenced code blocks with the given language marker from text.
 ///
 /// Searches for `` ```{lang} `` … `` ``` `` pairs, returning trimmed content.
@@ -520,5 +563,95 @@ mod tests {
         let fs = FilterStats::default();
         let line = fs.format_inline("bash");
         assert_eq!(line, "[bash] 0 lines \u{2192} 0 lines, 0.0% filtered");
+    }
+
+    // DynExecutor tests
+
+    struct FixedExecutor {
+        tool_id: &'static str,
+        output: &'static str,
+    }
+
+    impl ToolExecutor for FixedExecutor {
+        async fn execute(&self, _response: &str) -> Result<Option<ToolOutput>, ToolError> {
+            Ok(Some(ToolOutput {
+                tool_name: self.tool_id.to_owned(),
+                summary: self.output.to_owned(),
+                blocks_executed: 1,
+                filter_stats: None,
+                diff: None,
+                streamed: false,
+            }))
+        }
+
+        fn tool_definitions(&self) -> Vec<crate::registry::ToolDef> {
+            vec![]
+        }
+
+        async fn execute_tool_call(
+            &self,
+            _call: &ToolCall,
+        ) -> Result<Option<ToolOutput>, ToolError> {
+            Ok(Some(ToolOutput {
+                tool_name: self.tool_id.to_owned(),
+                summary: self.output.to_owned(),
+                blocks_executed: 1,
+                filter_stats: None,
+                diff: None,
+                streamed: false,
+            }))
+        }
+    }
+
+    #[tokio::test]
+    async fn dyn_executor_execute_delegates() {
+        let inner = std::sync::Arc::new(FixedExecutor {
+            tool_id: "bash",
+            output: "hello",
+        });
+        let exec = DynExecutor(inner);
+        let result = exec.execute("```bash\necho hello\n```").await.unwrap();
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().summary, "hello");
+    }
+
+    #[tokio::test]
+    async fn dyn_executor_execute_confirmed_delegates() {
+        let inner = std::sync::Arc::new(FixedExecutor {
+            tool_id: "bash",
+            output: "confirmed",
+        });
+        let exec = DynExecutor(inner);
+        let result = exec.execute_confirmed("...").await.unwrap();
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().summary, "confirmed");
+    }
+
+    #[test]
+    fn dyn_executor_tool_definitions_delegates() {
+        let inner = std::sync::Arc::new(FixedExecutor {
+            tool_id: "my_tool",
+            output: "",
+        });
+        let exec = DynExecutor(inner);
+        // FixedExecutor returns empty definitions; verify delegation occurs without panic.
+        let defs = exec.tool_definitions();
+        assert!(defs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn dyn_executor_execute_tool_call_delegates() {
+        let inner = std::sync::Arc::new(FixedExecutor {
+            tool_id: "bash",
+            output: "tool_call_result",
+        });
+        let exec = DynExecutor(inner);
+        let call = ToolCall {
+            tool_id: "bash".to_owned(),
+            params: serde_json::Map::new(),
+        };
+        let result = exec.execute_tool_call(&call).await.unwrap();
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().summary, "tool_call_result");
     }
 }

--- a/crates/zeph-tools/src/lib.rs
+++ b/crates/zeph-tools/src/lib.rs
@@ -19,8 +19,8 @@ pub use audit::{AuditEntry, AuditLogger, AuditResult};
 pub use composite::CompositeExecutor;
 pub use config::{AuditConfig, ScrapeConfig, ShellConfig, ToolsConfig};
 pub use executor::{
-    DiffData, ErasedToolExecutor, FilterStats, MAX_TOOL_OUTPUT_CHARS, ToolCall, ToolError,
-    ToolEvent, ToolEventTx, ToolExecutor, ToolOutput, truncate_tool_output,
+    DiffData, DynExecutor, ErasedToolExecutor, FilterStats, MAX_TOOL_OUTPUT_CHARS, ToolCall,
+    ToolError, ToolEvent, ToolEventTx, ToolExecutor, ToolOutput, truncate_tool_output,
 };
 pub use file::FileExecutor;
 pub use filter::{

--- a/docs/src/advanced/channels.md
+++ b/docs/src/advanced/channels.md
@@ -79,7 +79,13 @@ zeph --tui
 
 ## Loopback Channel
 
-Internal headless channel used by daemon mode. `LoopbackChannel` bridges the A2A `TaskProcessor` with the agent loop via two linked tokio mpsc pairs. The handle side (`LoopbackHandle`) exposes `input_tx` for sending user messages and `output_rx` for receiving `LoopbackEvent` variants (`Chunk`, `Flush`, `FullMessage`, `Status`, `ToolOutput`). Confirmations are auto-approved.
+Internal headless channel used by daemon mode and ACP sessions. `LoopbackChannel` bridges the caller with the agent loop via two linked tokio mpsc pairs. The handle side (`LoopbackHandle`) exposes:
+
+- `input_tx` — send user messages into the agent loop
+- `output_rx` — receive `LoopbackEvent` variants (`Chunk`, `Flush`, `FullMessage`, `Status`, `ToolOutput`)
+- `cancel_signal: Arc<Notify>` — fire `notify_one()` to interrupt the running agent turn; shared with `AcpContext` so an IDE `cancel` call propagates directly to the agent
+
+Confirmations are auto-approved.
 
 See [Daemon Mode](../guides/daemon-mode.md) for usage.
 

--- a/docs/src/advanced/tools.md
+++ b/docs/src/advanced/tools.md
@@ -53,6 +53,18 @@ Providers without native tool support (Ollama, Candle) use text-based tool invoc
 
 Both modes coexist in the same iteration. The system prompt includes invocation instructions per tool so the LLM knows exactly which format to use.
 
+## DynExecutor
+
+`DynExecutor` is a newtype wrapping `Arc<dyn ErasedToolExecutor>`. It implements `ToolExecutor` by delegating all methods through the erased trait, enabling a heap-allocated executor to be used wherever a concrete `ToolExecutor` is expected.
+
+This is the mechanism that allows ACP sessions to supply IDE-proxied executors at runtime. The main binary wraps an ACP-aware composite in a `DynExecutor` and passes it to `AgentBuilder` — no changes to `Agent<C>` are needed for different tool backends.
+
+```rust
+let acp_composite = CompositeExecutor::new(acp_exec, local_exec);
+let dyn_exec = DynExecutor(Arc::new(acp_composite));
+agent_builder.with_tool_executor(dyn_exec);
+```
+
 ## Iteration Control
 
 The agent loop iterates tool execution until the LLM produces a response with no tool invocations, or one of the safety limits is hit.

--- a/docs/src/architecture/crates.md
+++ b/docs/src/architecture/crates.md
@@ -19,6 +19,7 @@ Agent loop, bootstrap orchestration, configuration loading, and context builder.
 - `MetricsSnapshot` / `MetricsCollector` — real-time metrics via `tokio::sync::watch` for TUI dashboard
 - `DaemonSupervisor` — component lifecycle monitor with health polling, PID file management, restart tracking (feature-gated: `daemon`)
 - `LoopbackChannel` / `LoopbackHandle` / `LoopbackEvent` — headless channel for daemon mode using paired tokio mpsc channels; auto-approves confirmations
+- `LoopbackHandle::cancel_signal` — `Arc<Notify>` shared between the ACP session and the agent loop; calling `notify_one()` interrupts the running agent turn
 
 ## zeph-llm
 
@@ -87,7 +88,8 @@ Tool execution abstraction and shell backend.
 - `FileExecutor` — sandboxed file operations (read, write, edit, glob, grep) with ancestor-walk path canonicalization
 - `ShellExecutor` — bash block parser, command safety filter, sandbox validation
 - `WebScrapeExecutor` — HTML scraping with CSS selectors, SSRF protection
-- `CompositeExecutor<A, B>` — generic chaining with first-match-wins dispatch, routes structured tool calls by `tool_id` to the appropriate backend
+- `CompositeExecutor<A, B>` — generic chaining with first-match-wins dispatch, routes structured tool calls by `tool_id` to the appropriate backend; used to place ACP executors ahead of local tools so IDE-proxied operations take priority
+- `DynExecutor` — newtype wrapping `Arc<dyn ErasedToolExecutor>` so a heap-allocated erased executor can be used anywhere a concrete `ToolExecutor` is required; enables runtime composition without static type chains
 - `AuditLogger` — structured JSON audit trail for all executions
 - `truncate_tool_output()` — head+tail split at 30K chars with UTF-8 safe boundaries
 
@@ -146,6 +148,34 @@ A2A protocol client and server (optional, feature-gated).
 - A2A Server — axum-based HTTP server with bearer auth, rate limiting with TTL-based eviction (60s sweep, 10K max entries), body size limits
 - `TaskManager` — in-memory task lifecycle management
 - `ProcessorEvent` — streaming event enum (`StatusUpdate`, `ArtifactChunk`) for per-token SSE delivery; `TaskProcessor::process` accepts `mpsc::Sender<ProcessorEvent>`
+
+## zeph-acp
+
+Agent Client Protocol server — IDE integration via ACP (optional, feature-gated).
+
+- `ZephAcpAgent` — `acp::Agent` implementation; manages sessions, forwards prompts to the agent loop, and emits `SessionNotification` updates back to the IDE
+- `AcpContext` — per-session bundle of IDE-proxied capabilities passed to `AgentSpawner`:
+  - `file_executor: Option<AcpFileExecutor>` — reads/writes routed to the IDE filesystem proxy
+  - `shell_executor: Option<AcpShellExecutor>` — shell commands routed through the IDE terminal proxy
+  - `permission_gate: Option<AcpPermissionGate>` — confirmation requests forwarded to the IDE UI
+  - `cancel_signal: Arc<Notify>` — shared with `LoopbackHandle`; firing it interrupts the running agent turn
+- `AgentSpawner` — `Arc<dyn Fn(LoopbackChannel, Option<AcpContext>) -> ...>` factory that the main binary supplies; wires `AcpContext` into `CompositeExecutor` before starting the agent loop
+- `AcpPermissionGate` — permission gate backed by `acp::Connection`; cache key uses `tool_call_id` as fallback when `title` is `None` to prevent distinct untitled tools from sharing a cached decision
+- `AcpFileExecutor` / `AcpShellExecutor` — IDE-proxied file and shell backends; each spawns a local task for the connection handler
+
+### AcpContext wiring
+
+When a new ACP session starts, `ZephAcpAgent::new_session` calls `build_acp_context`, which constructs the three proxied executors from the IDE capabilities advertised during `initialize`. The context is passed to `AgentSpawner` alongside the `LoopbackChannel`. The spawner builds a `CompositeExecutor` with ACP executors as the primary layer and local `ShellExecutor`/`FileExecutor` as fallback:
+
+```text
+CompositeExecutor
+├── primary:  AcpShellExecutor / AcpFileExecutor  (IDE-proxied, used when AcpContext present)
+└── fallback: ShellExecutor / FileExecutor        (local, used in non-ACP sessions)
+```
+
+### Cancellation
+
+`LoopbackHandle::cancel_signal` (`Arc<Notify>`) is cloned into `AcpContext` at session creation. When the IDE calls `cancel`, `ZephAcpAgent::cancel` fires `notify_one()` on the signal and removes the session. The agent loop polls this notifier and aborts the current turn. `AgentBuilder::with_cancel_signal()` wires the signal into the agent so a new `Notify` is not created internally.
 
 ## zeph-tui
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2199,15 +2199,48 @@ async fn build_acp_deps(
 }
 
 /// Spawn an `Agent` from pre-built deps and run its loop on the given channel.
+///
+/// When `acp_ctx` is `Some`, ACP executors are composed on top of the local tool executor
+/// (ACP-first, local fallback). When `None`, local tools handle everything.
 #[cfg(feature = "acp")]
-async fn spawn_acp_agent(d: AgentDeps, channel: zeph_core::channel::LoopbackChannel) {
+async fn spawn_acp_agent(
+    d: AgentDeps,
+    channel: zeph_core::channel::LoopbackChannel,
+    acp_ctx: Option<zeph_acp::AcpContext>,
+) {
+    use std::sync::Arc;
+    use zeph_tools::ErasedToolExecutor;
+
+    // Build tool executor: ACP executors take priority via CompositeExecutor (first-match-wins).
+    // DynExecutor wraps Arc<dyn ErasedToolExecutor> so it satisfies Agent::new's ToolExecutor bound.
+    let (tool_executor, cancel_signal) = match acp_ctx {
+        Some(ctx) => {
+            let cancel_signal = Arc::clone(&ctx.cancel_signal);
+            let mut base: Arc<dyn ErasedToolExecutor> = Arc::new(d.tool_executor);
+            if let Some(fs) = ctx.file_executor {
+                base = Arc::new(zeph_tools::CompositeExecutor::new(
+                    fs,
+                    zeph_tools::DynExecutor(base),
+                ));
+            }
+            if let Some(shell) = ctx.shell_executor {
+                base = Arc::new(zeph_tools::CompositeExecutor::new(
+                    shell,
+                    zeph_tools::DynExecutor(base),
+                ));
+            }
+            (zeph_tools::DynExecutor(base), Some(cancel_signal))
+        }
+        None => (zeph_tools::DynExecutor(Arc::new(d.tool_executor)), None),
+    };
+
     let mut agent = Agent::new(
         d.provider,
         channel,
         d.registry,
         d.matcher,
         d.max_active_skills,
-        d.tool_executor,
+        tool_executor,
     )
     .with_max_tool_iterations(d.max_tool_iterations)
     .with_model_name(d.model_name)
@@ -2242,6 +2275,10 @@ async fn spawn_acp_agent(d: AgentDeps, channel: zeph_core::channel::LoopbackChan
     )
     .with_learning(d.learning)
     .with_available_secrets(d.secrets.iter().map(|(k, v)| (k.clone(), v.clone())));
+
+    if let Some(signal) = cancel_signal {
+        agent = agent.with_cancel_signal(signal);
+    }
 
     if let Some(sp) = d.summary_provider {
         agent = agent.with_summary_provider(sp);
@@ -2283,7 +2320,7 @@ async fn run_acp_server(
 
     let deps = Arc::new(Mutex::new(Some(deps)));
 
-    let spawner: zeph_acp::AgentSpawner = Arc::new(move |channel, _acp_ctx| {
+    let spawner: zeph_acp::AgentSpawner = Arc::new(move |channel, acp_ctx| {
         let deps = Arc::clone(&deps);
         Box::pin(async move {
             let Some(d) = deps.lock().await.take() else {
@@ -2292,7 +2329,7 @@ async fn run_acp_server(
                 );
                 return;
             };
-            Box::pin(spawn_acp_agent(d, channel)).await;
+            Box::pin(spawn_acp_agent(d, channel, acp_ctx)).await;
         })
     });
 


### PR DESCRIPTION
## Summary

- Wire AcpContext (IDE-proxied FS, shell, permissions) through AgentSpawner into agent tool chain via CompositeExecutor (ACP-first, local fallback)
- Add `cancel_signal: Arc<Notify>` to LoopbackHandle for cooperative cancellation between ACP sessions and agent loop
- Fix permission cache key collision on anonymous tools (use tool_call_id fallback)
- Return `StopReason::Cancelled` when IDE sends `session/cancel` (ACP spec compliance)
- Map `ToolOutput` to structured `SessionUpdate::ToolCall` with proper `ToolKind` and `Completed` status instead of generic `AgentMessageChunk` (ACP spec compliance)

## Changes

| File | Change |
|------|--------|
| `src/main.rs` | `spawn_acp_agent` accepts `Option<AcpContext>`, composes ACP executors |
| `crates/zeph-tools/src/executor.rs` | `DynExecutor` newtype for object-safe ToolExecutor composition |
| `crates/zeph-tools/src/lib.rs` | Re-export `DynExecutor` |
| `crates/zeph-core/src/channel.rs` | `cancel_signal: Arc<Notify>` on `LoopbackHandle` |
| `crates/zeph-core/src/agent/builder.rs` | `with_cancel_signal()` builder method |
| `crates/zeph-acp/src/agent.rs` | Cancel signal in SessionEntry, `StopReason::Cancelled`, structured `ToolCall` notifications, `tool_kind_from_name()` |
| `crates/zeph-acp/src/permission.rs` | Cache key fallback to tool_call_id when title is None |

## ACP spec compliance fixes

- **NC-1**: `prompt()` uses `tokio::select!` to detect `cancel_signal` during drain loop, returns `StopReason::Cancelled` per [spec requirement](https://agentclientprotocol.com/protocol/prompt-turn#cancellation)
- **NC-2**: Tool output maps to `SessionUpdate::ToolCall` with `Completed` status and `ToolKind` per [tool-calls spec](https://agentclientprotocol.com/protocol/tool-calls), enabling IDE structured tool UX

## Test plan

- [x] 2564 tests passed, 0 failed (+10 new tests)
- [x] `cargo clippy --workspace -- -D warnings`: 0 warnings
- [x] `cargo +nightly fmt --check`: clean
- [x] DynExecutor delegation tests (4 tests)
- [x] with_cancel_signal() pointer identity test
- [x] cancel_signal notify/await tests (2 tests)
- [x] Permission cache key fallback test
- [x] ToolOutput maps to ToolCall with correct kind/status
- [x] tool_kind_from_name mapping coverage

Closes #779, closes #780
Part of Epic #777