### PR TITLE
feat(tools): configurable tool response offload (#791)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Configurable tool response offload — `OverflowConfig` with threshold (default 50k chars), retention (7 days), optional custom dir (#791)
+- `[tools.overflow]` section in `config.toml` for offload configuration
+- Security hardening: path canonicalization, symlink-safe cleanup, 0o600 file permissions on Unix
 - Wire `AcpContext` (IDE-proxied FS, shell, permissions) through `AgentSpawner` into agent tool chain via `CompositeExecutor` — ACP executors take priority with automatic local fallback (#779)
 - `DynExecutor` newtype in `zeph-tools` for object-safe `ToolExecutor` composition in `CompositeExecutor` (#779)
 - `cancel_signal: Arc<Notify>` on `LoopbackHandle` for cooperative cancellation between ACP sessions and agent loop (#780)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 Most AI agent frameworks dump every tool description, skill, and raw output into the context window — and bill you for it. Zeph takes the opposite approach: **automated context engineering**. Only relevant data enters the context. The result — lower costs, faster responses, and an agent that runs on hardware you already have.
 
 - **Semantic skill selection** — embeds skills as vectors, retrieves only top-K relevant per query instead of injecting all
-- **Smart output filtering** — command-aware filters strip 70-99% of noise before context injection
+- **Smart output filtering** — command-aware filters strip 70-99% of noise before context injection; oversized responses offloaded to filesystem
 - **Two-tier context pruning** — selective eviction + adaptive chunked compaction with parallel summarization keeps the window clean
 - **Proportional budget allocation** — context space distributed by purpose, not arrival order
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -365,6 +365,15 @@ enabled = true
 # [tools.permissions]
 # shell = [{ pattern = "/tmp/*", action = "allow" }, { pattern = "/etc/*", action = "deny" }]
 
+[tools.overflow]
+# Offload large tool responses to filesystem instead of truncating in-memory.
+# Characters threshold above which output is saved to a file (default: 50000)
+threshold = 50000
+# Days to retain offloaded files before cleanup on next startup (default: 7)
+retention_days = 7
+# Optional custom directory for overflow files (default: ~/.zeph/data/tool-output)
+# dir = "/custom/path/to/overflow"
+
 [tools.audit]
 # Enable audit logging for tool executions
 enabled = false

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -178,6 +178,12 @@ impl<C: Channel> Agent<C> {
     }
 
     #[must_use]
+    pub fn with_overflow_config(mut self, config: zeph_tools::OverflowConfig) -> Self {
+        self.runtime.overflow_config = config;
+        self
+    }
+
+    #[must_use]
     pub fn with_summary_provider(mut self, provider: AnyProvider) -> Self {
         self.summary_provider = Some(provider);
         self

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -127,6 +127,7 @@ pub(super) struct RuntimeConfig {
     pub(super) permission_policy: zeph_tools::PermissionPolicy,
     pub(super) redact_credentials: bool,
     pub(super) token_safety_margin: f32,
+    pub(super) overflow_config: zeph_tools::OverflowConfig,
 }
 
 pub struct Agent<C: Channel> {
@@ -238,6 +239,7 @@ impl<C: Channel> Agent<C> {
                 permission_policy: zeph_tools::PermissionPolicy::default(),
                 redact_credentials: true,
                 token_safety_margin: 1.0,
+                overflow_config: zeph_tools::OverflowConfig::default(),
             },
             learning_config: None,
             reflection_used: false,
@@ -1861,6 +1863,32 @@ pub(super) mod agent_tests {
     }
 
     #[tokio::test]
+    async fn test_overflow_notice_contains_filename() {
+        let dir = tempfile::tempdir().unwrap();
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+
+        let agent = Agent::new(provider, channel, registry, None, 5, executor)
+            .with_tool_summarization(false)
+            .with_overflow_config(zeph_tools::OverflowConfig {
+                threshold: 100,
+                retention_days: 7,
+                dir: Some(dir.path().to_path_buf()),
+            });
+
+        let long = "x".repeat(zeph_tools::MAX_TOOL_OUTPUT_CHARS + 1000);
+        let result = agent.maybe_summarize_tool_output(&long).await;
+        assert!(result.contains("full output saved to"));
+        // Notice must contain only filename (UUID.txt), not a full path
+        let notice_start = result.find("full output saved to").unwrap();
+        let notice_part = &result[notice_start..];
+        assert!(notice_part.contains(".txt"));
+        assert!(!notice_part.contains('/'));
+    }
+
+    #[tokio::test]
     async fn test_maybe_summarize_long_output_disabled_truncates() {
         let provider = mock_provider(vec![]);
         let channel = MockChannel::new(vec![]);
@@ -1868,8 +1896,15 @@ pub(super) mod agent_tests {
         let executor = MockToolExecutor::no_tools();
 
         let agent = Agent::new(provider, channel, registry, None, 5, executor)
-            .with_tool_summarization(false);
+            .with_tool_summarization(false)
+            .with_overflow_config(zeph_tools::OverflowConfig {
+                threshold: 1000,
+                retention_days: 7,
+                dir: None,
+            });
 
+        // Must exceed both overflow threshold (1000) and MAX_TOOL_OUTPUT_CHARS (30_000)
+        // so that truncate_tool_output produces the "truncated" marker.
         let long = "x".repeat(zeph_tools::MAX_TOOL_OUTPUT_CHARS + 1000);
         let result = agent.maybe_summarize_tool_output(&long).await;
         assert!(result.contains("truncated"));
@@ -1883,7 +1918,12 @@ pub(super) mod agent_tests {
         let executor = MockToolExecutor::no_tools();
 
         let agent = Agent::new(provider, channel, registry, None, 5, executor)
-            .with_tool_summarization(true);
+            .with_tool_summarization(true)
+            .with_overflow_config(zeph_tools::OverflowConfig {
+                threshold: 1000,
+                retention_days: 7,
+                dir: None,
+            });
 
         let long = "x".repeat(zeph_tools::MAX_TOOL_OUTPUT_CHARS + 1000);
         let result = agent.maybe_summarize_tool_output(&long).await;
@@ -1900,7 +1940,12 @@ pub(super) mod agent_tests {
         let executor = MockToolExecutor::no_tools();
 
         let agent = Agent::new(provider, channel, registry, None, 5, executor)
-            .with_tool_summarization(true);
+            .with_tool_summarization(true)
+            .with_overflow_config(zeph_tools::OverflowConfig {
+                threshold: 1000,
+                retention_days: 7,
+                dir: None,
+            });
 
         let long = "x".repeat(zeph_tools::MAX_TOOL_OUTPUT_CHARS + 1000);
         let result = agent.maybe_summarize_tool_output(&long).await;

--- a/crates/zeph-core/src/agent/tool_execution.rs
+++ b/crates/zeph-core/src/agent/tool_execution.rs
@@ -324,14 +324,13 @@ impl<C: Channel> Agent<C> {
     }
 
     pub(super) async fn maybe_summarize_tool_output(&self, output: &str) -> String {
-        if output.len() <= zeph_tools::MAX_TOOL_OUTPUT_CHARS {
+        if output.len() <= self.runtime.overflow_config.threshold {
             return output.to_string();
         }
-        let overflow_notice = if let Some(path) = zeph_tools::save_overflow(output) {
-            format!(
-                "\n[full output saved to {}, use read tool to access]",
-                path.display()
-            )
+        let overflow_notice = if let Some(filename) =
+            zeph_tools::save_overflow(output, &self.runtime.overflow_config)
+        {
+            format!("\n[full output saved to {filename}, use read tool to access]")
         } else {
             String::new()
         };

--- a/crates/zeph-core/src/config/snapshots/zeph_core__config__types__tests__config_default_snapshot.snap
+++ b/crates/zeph-core/src/config/snapshots/zeph_core__config__types__tests__config_default_snapshot.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/zeph-core/src/config/types.rs
+assertion_line: 1207
 expression: toml_str
 ---
 [agent]
@@ -98,6 +99,10 @@ enabled = true
 [tools.filters.security]
 enabled = true
 extra_patterns = []
+
+[tools.overflow]
+threshold = 50000
+retention_days = 7
 
 [a2a]
 enabled = false

--- a/crates/zeph-tools/README.md
+++ b/crates/zeph-tools/README.md
@@ -26,8 +26,8 @@ Defines the `ToolExecutor` trait for sandboxed tool invocation and ships concret
 | `registry` | Tool registry and discovery |
 | `trust_gate` | Trust-based tool access control |
 | `anomaly` | `AnomalyDetector` — unusual execution pattern detection |
-| `overflow` | Output overflow handling |
-| `config` | Per-tool TOML configuration |
+| `overflow` | Large output offload to filesystem — configurable threshold (default 50K chars), retention-based cleanup with symlink-safe deletion, 0o600 file permissions on Unix, path canonicalization |
+| `config` | Per-tool TOML configuration; `OverflowConfig` for `[tools.overflow]` section (threshold, retention_days, optional custom dir) |
 
 **Re-exports:** `CompositeExecutor`, `AuditLogger`, `AnomalyDetector`
 

--- a/crates/zeph-tools/src/config.rs
+++ b/crates/zeph-tools/src/config.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use serde::{Deserialize, Serialize};
 
 use crate::permissions::{AutonomyLevel, PermissionPolicy, PermissionsConfig};
@@ -27,6 +29,35 @@ fn default_audit_destination() -> String {
     "stdout".into()
 }
 
+fn default_overflow_threshold() -> usize {
+    50_000
+}
+
+fn default_retention_days() -> u64 {
+    7
+}
+
+/// Configuration for large tool response offload to filesystem.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct OverflowConfig {
+    #[serde(default = "default_overflow_threshold")]
+    pub threshold: usize,
+    #[serde(default = "default_retention_days")]
+    pub retention_days: u64,
+    #[serde(default)]
+    pub dir: Option<PathBuf>,
+}
+
+impl Default for OverflowConfig {
+    fn default() -> Self {
+        Self {
+            threshold: default_overflow_threshold(),
+            retention_days: default_retention_days(),
+            dir: None,
+        }
+    }
+}
+
 /// Top-level configuration for tool execution.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ToolsConfig {
@@ -44,6 +75,8 @@ pub struct ToolsConfig {
     pub permissions: Option<PermissionsConfig>,
     #[serde(default)]
     pub filters: crate::filter::FilterConfig,
+    #[serde(default)]
+    pub overflow: OverflowConfig,
 }
 
 impl ToolsConfig {
@@ -98,6 +131,7 @@ impl Default for ToolsConfig {
             audit: AuditConfig::default(),
             permissions: None,
             filters: crate::filter::FilterConfig::default(),
+            overflow: OverflowConfig::default(),
         }
     }
 }
@@ -361,5 +395,42 @@ mod tests {
         // Default ShellConfig has confirm_patterns, so legacy rules are generated
         assert!(!config.shell.confirm_patterns.is_empty());
         assert!(policy.rules().contains_key("bash"));
+    }
+
+    #[test]
+    fn deserialize_overflow_config_full() {
+        let toml_str = r#"
+            [overflow]
+            threshold = 100000
+            retention_days = 14
+            dir = "/tmp/overflow"
+        "#;
+        let config: ToolsConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.overflow.threshold, 100_000);
+        assert_eq!(config.overflow.retention_days, 14);
+        assert_eq!(
+            config.overflow.dir.unwrap().to_str().unwrap(),
+            "/tmp/overflow"
+        );
+    }
+
+    #[test]
+    fn deserialize_overflow_config_partial_uses_defaults() {
+        let toml_str = r#"
+            [overflow]
+            threshold = 75000
+        "#;
+        let config: ToolsConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.overflow.threshold, 75_000);
+        assert_eq!(config.overflow.retention_days, 7);
+        assert!(config.overflow.dir.is_none());
+    }
+
+    #[test]
+    fn deserialize_overflow_config_omitted_uses_defaults() {
+        let config: ToolsConfig = toml::from_str("").unwrap();
+        assert_eq!(config.overflow.threshold, 50_000);
+        assert_eq!(config.overflow.retention_days, 7);
+        assert!(config.overflow.dir.is_none());
     }
 }

--- a/crates/zeph-tools/src/lib.rs
+++ b/crates/zeph-tools/src/lib.rs
@@ -17,7 +17,7 @@ pub mod trust_gate;
 pub use anomaly::{AnomalyDetector, AnomalySeverity};
 pub use audit::{AuditEntry, AuditLogger, AuditResult};
 pub use composite::CompositeExecutor;
-pub use config::{AuditConfig, ScrapeConfig, ShellConfig, ToolsConfig};
+pub use config::{AuditConfig, OverflowConfig, ScrapeConfig, ShellConfig, ToolsConfig};
 pub use executor::{
     DiffData, DynExecutor, ErasedToolExecutor, FilterStats, MAX_TOOL_OUTPUT_CHARS, ToolCall,
     ToolError, ToolEvent, ToolEventTx, ToolExecutor, ToolOutput, truncate_tool_output,

--- a/crates/zeph-tools/src/overflow.rs
+++ b/crates/zeph-tools/src/overflow.rs
@@ -1,38 +1,72 @@
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
-use crate::executor::MAX_TOOL_OUTPUT_CHARS;
+use crate::config::OverflowConfig;
 
-/// Default overflow directory under user home.
-fn overflow_dir() -> PathBuf {
+fn overflow_dir(custom: Option<&Path>) -> PathBuf {
+    if let Some(p) = custom {
+        return p.to_path_buf();
+    }
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".zeph/data/tool-output")
 }
 
-/// Save full output to overflow file if it exceeds `MAX_TOOL_OUTPUT_CHARS`.
-/// Returns the path to the saved file, or `None` if output fits.
-pub fn save_overflow(output: &str) -> Option<PathBuf> {
-    if output.len() <= MAX_TOOL_OUTPUT_CHARS {
+/// Save full output to overflow file if it exceeds `config.threshold`.
+/// Returns the filename (UUID.txt) of the saved file, or `None` if output fits.
+pub fn save_overflow(output: &str, config: &OverflowConfig) -> Option<String> {
+    if output.len() <= config.threshold {
         return None;
     }
-    let dir = overflow_dir();
+    let dir = overflow_dir(config.dir.as_deref());
     if let Err(e) = std::fs::create_dir_all(&dir) {
         tracing::warn!("failed to create overflow dir: {e}");
         return None;
     }
-    let id = uuid::Uuid::new_v4();
-    let path = dir.join(format!("{id}.txt"));
-    if let Err(e) = std::fs::write(&path, output) {
-        tracing::warn!("failed to write overflow file: {e}");
-        return None;
+    let canonical_dir = match std::fs::canonicalize(&dir) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!("failed to canonicalize overflow dir: {e}");
+            return None;
+        }
+    };
+    let filename = format!("{}.txt", uuid::Uuid::new_v4());
+    let path = canonical_dir.join(&filename);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&path)
+            .and_then(|mut f| {
+                use std::io::Write;
+                f.write_all(output.as_bytes())
+            }) {
+            Ok(()) => {}
+            Err(e) => {
+                tracing::warn!("failed to write overflow file: {e}");
+                return None;
+            }
+        }
     }
-    Some(path)
+    #[cfg(not(unix))]
+    {
+        if let Err(e) = std::fs::write(&path, output) {
+            tracing::warn!("failed to write overflow file: {e}");
+            return None;
+        }
+    }
+
+    Some(filename)
 }
 
-/// Remove overflow files older than `max_age`. Creates directory if missing.
-pub fn cleanup_overflow_files(max_age: Duration) {
-    let dir = overflow_dir();
+/// Remove overflow files older than `config.retention_days`. Creates directory if missing.
+pub fn cleanup_overflow_files(config: &OverflowConfig) {
+    let dir = overflow_dir(config.dir.as_deref());
+    let max_age = Duration::from_secs(config.retention_days * 86_400);
     cleanup_overflow_files_in(&dir, max_age);
 }
 
@@ -48,14 +82,21 @@ fn cleanup_overflow_files_in(dir: &Path, max_age: Duration) {
             return;
         }
     };
+    let now = SystemTime::now();
     for entry in entries.flatten() {
-        let Ok(meta) = entry.metadata() else {
+        // Use symlink_metadata to avoid following symlinks — we only remove regular files.
+        let Ok(meta) = std::fs::symlink_metadata(entry.path()) else {
             continue;
         };
+        if !meta.file_type().is_file() {
+            continue;
+        }
         let Ok(modified) = meta.modified() else {
             continue;
         };
-        if modified.elapsed().unwrap_or_default() > max_age
+        // TOCTOU race between metadata check and remove_file is benign here:
+        // the worst case is a spurious warning if another process removes the file first.
+        if now.duration_since(modified).unwrap_or_default() > max_age
             && let Err(e) = std::fs::remove_file(entry.path())
         {
             tracing::warn!("failed to remove stale overflow file: {e}");
@@ -67,21 +108,78 @@ fn cleanup_overflow_files_in(dir: &Path, max_age: Duration) {
 mod tests {
     use super::*;
 
+    fn cfg(threshold: usize) -> OverflowConfig {
+        OverflowConfig {
+            threshold,
+            retention_days: 7,
+            dir: None,
+        }
+    }
+
     #[test]
     fn small_output_no_overflow() {
-        assert!(save_overflow("short").is_none());
+        assert!(save_overflow("short", &cfg(50_000)).is_none());
     }
 
     #[test]
     fn overflow_creates_file() {
-        let long = "x".repeat(MAX_TOOL_OUTPUT_CHARS + 100);
-        let path = save_overflow(&long);
-        assert!(path.is_some());
-        let p = path.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let config = OverflowConfig {
+            threshold: 50_000,
+            retention_days: 7,
+            dir: Some(dir.path().to_path_buf()),
+        };
+        let long = "x".repeat(50_001);
+        let filename = save_overflow(&long, &config);
+        assert!(filename.is_some());
+        let name = filename.unwrap();
+        let p = dir.path().join(&name);
         assert!(p.exists());
         let contents = std::fs::read_to_string(&p).unwrap();
         assert_eq!(contents.len(), long.len());
-        std::fs::remove_file(p).ok();
+    }
+
+    #[test]
+    fn custom_threshold_respected() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = "x".repeat(1_001);
+
+        let config_low = OverflowConfig {
+            threshold: 1_000,
+            retention_days: 7,
+            dir: Some(dir.path().to_path_buf()),
+        };
+        assert!(save_overflow(&output, &config_low).is_some());
+
+        assert!(save_overflow(&output, &cfg(2_000)).is_none());
+    }
+
+    #[test]
+    fn save_returns_filename_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = OverflowConfig {
+            threshold: 0,
+            retention_days: 7,
+            dir: Some(dir.path().to_path_buf()),
+        };
+        let filename = save_overflow("any", &config).unwrap();
+        // Must be just "UUID.txt", not a full path
+        assert!(!filename.contains('/'));
+        assert!(filename.ends_with(".txt"));
+    }
+
+    #[test]
+    fn custom_dir_used() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = OverflowConfig {
+            threshold: 0,
+            retention_days: 7,
+            dir: Some(dir.path().to_path_buf()),
+        };
+        let filename = save_overflow("any", &config);
+        assert!(filename.is_some());
+        let p = dir.path().join(filename.unwrap());
+        assert!(p.exists());
     }
 
     #[test]
@@ -89,8 +187,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("old.txt");
         std::fs::write(&file, "data").unwrap();
-        // Set mtime to past by using filetime
-        let old_time = std::time::SystemTime::now() - Duration::from_secs(86_500);
+        let old_time = SystemTime::now() - Duration::from_secs(86_500);
         let ft = filetime::FileTime::from_system_time(old_time);
         filetime::set_file_mtime(&file, ft).unwrap();
         cleanup_overflow_files_in(dir.path(), Duration::from_secs(86_400));
@@ -112,5 +209,57 @@ mod tests {
         let sub = dir.path().join("sub/dir");
         cleanup_overflow_files_in(&sub, Duration::from_secs(86_400));
         assert!(sub.exists());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn cleanup_skips_symlinks() {
+        let dir = tempfile::tempdir().unwrap();
+        // Create a regular file outside the overflow dir that the symlink points to
+        let outside_dir = tempfile::tempdir().unwrap();
+        let target = outside_dir.path().join("target.txt");
+        std::fs::write(&target, "data").unwrap();
+
+        // Create a symlink inside the overflow dir pointing to the external file
+        let link = dir.path().join("link.txt");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        // Age the symlink mtime (not the target)
+        let old_time = SystemTime::now() - Duration::from_secs(86_500);
+        let ft = filetime::FileTime::from_system_time(old_time);
+        filetime::set_file_mtime(&link, ft).unwrap();
+
+        cleanup_overflow_files_in(dir.path(), Duration::from_secs(86_400));
+
+        // The symlink is not a regular file — cleanup must not remove it
+        assert!(link.exists(), "symlink should not be removed by cleanup");
+        // The external target must also be untouched
+        assert!(target.exists(), "symlink target must not be removed");
+    }
+
+    #[test]
+    fn cleanup_uses_retention_days() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("stale.txt");
+        std::fs::write(&file, "data").unwrap();
+        let old_time = SystemTime::now() - Duration::from_secs(7 * 86_400 + 100);
+        let ft = filetime::FileTime::from_system_time(old_time);
+        filetime::set_file_mtime(&file, ft).unwrap();
+
+        let config = OverflowConfig {
+            threshold: 50_000,
+            retention_days: 7,
+            dir: Some(dir.path().to_path_buf()),
+        };
+        cleanup_overflow_files(&config);
+        assert!(!file.exists());
+    }
+
+    #[test]
+    fn default_config_values() {
+        let config = OverflowConfig::default();
+        assert_eq!(config.threshold, 50_000);
+        assert_eq!(config.retention_days, 7);
+        assert!(config.dir.is_none());
     }
 }

--- a/docs/src/advanced/tools.md
+++ b/docs/src/advanced/tools.md
@@ -119,9 +119,27 @@ When `[tools.permissions]` is absent, legacy `blocked_commands` and `confirm_pat
 
 ## Output Overflow
 
-Tool output exceeding 30 000 characters is truncated (head + tail split) before being sent to the LLM. The full untruncated output is saved to `~/.zeph/data/tool-output/{uuid}.txt`, and the truncated message includes the file path so the LLM can read the complete output if needed.
+When tool output exceeds a configurable character threshold, the full response is offloaded to a file and the LLM receives a truncated version (head + tail split) with a pointer to the saved file. This prevents large outputs from consuming the entire context window while preserving access to the complete data.
 
-Stale overflow files older than 24 hours are cleaned up automatically on startup.
+Overflow files are written to `~/.zeph/data/tool-output/` by default. The pointer returned to the LLM contains only the filename (`{uuid}.txt`), not the full path, to avoid leaking the home directory.
+
+Stale overflow files are cleaned up automatically on startup based on `retention_days`.
+
+### Configuration
+
+```toml
+[tools.overflow]
+threshold = 50000       # Character count above which output is offloaded (default: 50000)
+retention_days = 7      # Days to retain overflow files before cleanup (default: 7)
+# dir = "/custom/path"  # Custom overflow directory (default: ~/.zeph/data/tool-output)
+```
+
+### Security
+
+- Overflow directory is canonicalized after creation to prevent symlink-based path traversal.
+- Files are created with `0o600` permissions on Unix (owner read/write only).
+- Cleanup uses `symlink_metadata` and skips non-regular files (symlinks, directories) to prevent symlink attacks.
+- The returned pointer is a bare filename, never an absolute path.
 
 ## Output Filter Pipeline
 

--- a/docs/src/reference/configuration.md
+++ b/docs/src/reference/configuration.md
@@ -174,6 +174,11 @@ enabled = true              # Enable smart output filtering for tool results
 #   { pattern = "*", action = "ask" },
 # ]
 
+[tools.overflow]
+threshold = 50000           # Offload output larger than N chars to file (default: 50000)
+retention_days = 7          # Days to retain overflow files before cleanup (default: 7)
+# dir = "/custom/path"     # Custom overflow directory (default: ~/.zeph/data/tool-output)
+
 [tools.audit]
 enabled = false             # Structured JSON audit log for tool executions
 destination = "stdout"      # "stdout" or file path

--- a/src/main.rs
+++ b/src/main.rs
@@ -439,11 +439,15 @@ async fn main() -> anyhow::Result<()> {
 
     let (shutdown_tx, shutdown_rx) = AppBuilder::build_shutdown();
 
-    tokio::task::spawn_blocking(|| {
-        zeph_tools::cleanup_overflow_files(std::time::Duration::from_secs(86_400));
-    });
-
     let config = app.config();
+
+    {
+        let overflow_cfg = config.tools.overflow.clone();
+        tokio::task::spawn_blocking(move || {
+            zeph_tools::cleanup_overflow_files(&overflow_cfg);
+        });
+    }
+
     let permission_policy = config
         .tools
         .permission_policy(config.security.autonomy_level);
@@ -558,6 +562,7 @@ async fn main() -> anyhow::Result<()> {
     .with_security(config.security, config.timeouts)
     .with_redact_credentials(config.memory.redact_credentials)
     .with_tool_summarization(config.tools.summarize_output)
+    .with_overflow_config(config.tools.overflow.clone())
     .with_permission_policy(permission_policy.clone())
     .with_config_reload(config_path, config_reload_rx)
     .with_available_secrets(
@@ -1626,6 +1631,7 @@ async fn run_daemon(
     .with_security(config.security, config.timeouts)
     .with_redact_credentials(config.memory.redact_credentials)
     .with_tool_summarization(config.tools.summarize_output)
+    .with_overflow_config(config.tools.overflow.clone())
     .with_permission_policy(permission_policy)
     .with_config_reload(config_path_owned, config_reload_rx)
     .with_mcp(mcp_tools, mcp_registry, Some(mcp_manager), &config.mcp)
@@ -2073,6 +2079,7 @@ struct AgentDeps {
     timeouts: zeph_core::config::TimeoutConfig,
     redact_credentials: bool,
     tool_summarization: bool,
+    overflow_config: zeph_tools::OverflowConfig,
     permission_policy: zeph_tools::PermissionPolicy,
     config_path: PathBuf,
     config_reload_rx: tokio::sync::mpsc::Receiver<zeph_core::config_watcher::ConfigEvent>,
@@ -2178,6 +2185,7 @@ async fn build_acp_deps(
         timeouts: config.timeouts,
         redact_credentials: config.memory.redact_credentials,
         tool_summarization: config.tools.summarize_output,
+        overflow_config: config.tools.overflow.clone(),
         permission_policy: config
             .tools
             .permission_policy(config.security.autonomy_level),
@@ -2265,6 +2273,7 @@ async fn spawn_acp_agent(
     .with_security(d.security, d.timeouts)
     .with_redact_credentials(d.redact_credentials)
     .with_tool_summarization(d.tool_summarization)
+    .with_overflow_config(d.overflow_config)
     .with_permission_policy(d.permission_policy)
     .with_config_reload(d.config_path, d.config_reload_rx)
     .with_mcp(


### PR DESCRIPTION
## Summary
- Add `OverflowConfig` to `ToolsConfig` with configurable threshold (default 50k chars), retention (7 days), and optional custom directory
- Refactor `save_overflow` and `cleanup_overflow_files` in `overflow.rs` to accept `&OverflowConfig` instead of hardcoded values
- Security hardening: path canonicalization, symlink-safe cleanup (`symlink_metadata`), `0o600` file permissions on Unix, filename-only pointers in LLM context

## Test plan
- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo nextest run --workspace --lib --bins` — 2565/2565 pass
- [x] New tests: custom threshold, custom dir, retention days, symlink skip, TOML deserialization, notice format
- [x] Security review: path traversal, symlink attack, file permissions, path leak — all addressed
- [x] Performance review: SystemTime snapshot before cleanup loop

Closes #791