### PR TITLE
feat(acp): multi-session support with LRU eviction and session persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Multi-session ACP support with configurable `max_sessions` (default 4) and LRU eviction of idle sessions (#781)
+- `session_idle_timeout_secs` config for automatic session cleanup (default 30 min) with background reaper task (#781)
+- `ZEPH_ACP_MAX_SESSIONS` and `ZEPH_ACP_SESSION_IDLE_TIMEOUT_SECS` env overrides (#781)
+- ACP session persistence to `SQLite` — `acp_sessions` and `acp_session_events` tables with conversation replay on `load_session` per ACP spec (#782)
+- `SqliteStore` methods for ACP session lifecycle: `create_acp_session`, `save_acp_event`, `load_acp_events`, `delete_acp_session`, `acp_session_exists` (#782)
 - Wire `AcpContext` (IDE-proxied FS, shell, permissions) through `AgentSpawner` into agent tool chain via `CompositeExecutor` — ACP executors take priority with automatic local fallback (#779)
 - `DynExecutor` newtype in `zeph-tools` for object-safe `ToolExecutor` composition in `CompositeExecutor` (#779)
 - `cancel_signal: Arc<Notify>` on `LoopbackHandle` for cooperative cancellation between ACP sessions and agent loop (#780)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9178,6 +9178,7 @@ dependencies = [
  "uuid",
  "zeph-core",
  "zeph-mcp",
+ "zeph-memory",
  "zeph-tools",
 ]
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ zeph --tui         # run with TUI dashboard
 | **Skills-first architecture** | YAML+Markdown skill files with semantic matching, self-learning evolution, 4-tier trust model, and compact prompt mode for small-context models |
 | **Semantic memory** | SQLite + Qdrant (or embedded SQLite vector search) with MMR re-ranking, temporal decay scoring, adaptive chunked compaction, credential scrubbing, cross-session recall, vector retrieval, autosave assistant responses, and snapshot export/import |
 | **Multi-channel I/O** | CLI, Telegram, Discord, Slack, TUI — all with streaming. Vision and speech-to-text input |
-| **Protocols** | MCP client (stdio + HTTP), A2A agent-to-agent communication, sub-agent orchestration |
+| **Protocols** | MCP client (stdio + HTTP), A2A agent-to-agent communication, ACP server for IDE integration (multi-session, persistence, idle reaper), sub-agent orchestration |
 | **Defense-in-depth** | Shell sandbox, tool permissions, secret redaction, SSRF protection, skill trust quarantine, audit logging |
 | **TUI dashboard** | ratatui-based with syntax highlighting, live metrics, file picker, command palette, daemon mode |
 | **Single binary** | ~15 MB, no runtime dependencies, ~50ms startup, ~20 MB idle memory |

--- a/crates/zeph-acp/Cargo.toml
+++ b/crates/zeph-acp/Cargo.toml
@@ -25,6 +25,7 @@ tokio-util = { workspace = true, features = ["compat"] }
 tracing.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 zeph-core.workspace = true
+zeph-memory.workspace = true
 zeph-mcp.workspace = true
 zeph-tools.workspace = true
 

--- a/crates/zeph-acp/README.md
+++ b/crates/zeph-acp/README.md
@@ -15,7 +15,7 @@ Implements the [Agent Client Protocol](https://agentclientprotocol.org) server s
 
 | Module | Description |
 |--------|-------------|
-| `agent` | `AcpContext` — IDE-proxied capabilities (file executor, shell executor, permission gate, cancel signal) wired into the agent loop per session; `AgentSpawner` factory type; `ZephAcpAgent` ACP protocol handler |
+| `agent` | `AcpContext` — IDE-proxied capabilities (file executor, shell executor, permission gate, cancel signal) wired into the agent loop per session; `AgentSpawner` factory type; `ZephAcpAgent` ACP protocol handler with multi-session support, LRU eviction, idle reaper, and SQLite persistence |
 | `transport` | `serve_stdio` / `serve_connection` — ACP server transports; `AcpServerConfig` |
 | `fs` | `AcpFileExecutor` — file system executor backed by IDE-proxied ACP file operations |
 | `terminal` | `AcpShellExecutor` — shell executor backed by IDE-proxied ACP terminal |
@@ -40,6 +40,22 @@ pub struct AcpContext {
 ```
 
 The `cancel_signal` is shared with the agent's `LoopbackHandle` so that an IDE cancel request immediately interrupts the running inference loop.
+
+## Session lifecycle
+
+`ZephAcpAgent` manages multiple concurrent sessions with the following capabilities:
+
+- **LRU eviction** — when the number of active sessions reaches `max_sessions`, the least-recently-used session is evicted to free resources.
+- **SQLite persistence** — session events are persisted to `acp_sessions` and `acp_session_events` tables (migration 013) via `zeph-memory`. This enables session resume across process restarts.
+- **Session resume** — `load_session` replays persisted history as `session/update` events, restoring the conversation state.
+- **Idle reaper** — a background task periodically removes sessions that have been idle longer than `session_idle_timeout_secs`.
+
+### Configuration
+
+| Config field | Type | Default | Env override |
+|-------------|------|---------|--------------|
+| `acp.max_sessions` | usize | `16` | `ZEPH_ACP_MAX_SESSIONS` |
+| `acp.session_idle_timeout_secs` | u64 | `1800` | `ZEPH_ACP_SESSION_IDLE_TIMEOUT_SECS` |
 
 ## AgentSpawner
 

--- a/crates/zeph-acp/src/agent.rs
+++ b/crates/zeph-acp/src/agent.rs
@@ -7,6 +7,7 @@ use agent_client_protocol as acp;
 use tokio::sync::{mpsc, oneshot};
 use zeph_core::LoopbackEvent;
 use zeph_core::channel::{ChannelMessage, LoopbackChannel};
+use zeph_memory::sqlite::SqliteStore;
 
 use crate::fs::AcpFileExecutor;
 use crate::permission::AcpPermissionGate;
@@ -14,7 +15,6 @@ use crate::terminal::AcpShellExecutor;
 use crate::transport::ConnSlot;
 
 const MAX_PROMPT_BYTES: usize = 1_048_576; // 1 MiB
-const MAX_SESSIONS: usize = 1;
 const LOOPBACK_CHANNEL_CAPACITY: usize = 64;
 
 /// IDE-proxied capabilities passed to the agent loop per session.
@@ -43,34 +43,55 @@ pub(crate) type NotifySender =
 
 struct SessionEntry {
     input_tx: mpsc::Sender<ChannelMessage>,
-    // Receiver is owned solely by the prompt() handler; RefCell avoids Arc<Mutex> overhead
-    // since MAX_SESSIONS=1 and prompt() is never called concurrently for the same session.
+    // Receiver is owned solely by the prompt() handler; RefCell avoids Arc<Mutex> overhead.
+    // prompt() is not called concurrently for the same session.
     output_rx: RefCell<Option<mpsc::Receiver<LoopbackEvent>>>,
     cancel_signal: std::sync::Arc<tokio::sync::Notify>,
+    last_active: std::cell::Cell<std::time::Instant>,
 }
+
+type SessionMap = Rc<RefCell<std::collections::HashMap<acp::SessionId, SessionEntry>>>;
 
 pub struct ZephAcpAgent {
     notify_tx: NotifySender,
     spawner: AgentSpawner,
-    sessions: RefCell<std::collections::HashMap<acp::SessionId, SessionEntry>>,
+    sessions: SessionMap,
     conn_slot: ConnSlot,
     agent_name: String,
     agent_version: String,
+    max_sessions: usize,
+    idle_timeout: std::time::Duration,
+    store: Option<SqliteStore>,
     // IDE capabilities received during initialize(); used by build_acp_context.
     client_caps: RefCell<acp::ClientCapabilities>,
 }
 
 impl ZephAcpAgent {
-    pub fn new(spawner: AgentSpawner, notify_tx: NotifySender, conn_slot: ConnSlot) -> Self {
+    pub fn new(
+        spawner: AgentSpawner,
+        notify_tx: NotifySender,
+        conn_slot: ConnSlot,
+        max_sessions: usize,
+        session_idle_timeout_secs: u64,
+    ) -> Self {
         Self {
             notify_tx,
             spawner,
-            sessions: RefCell::new(std::collections::HashMap::new()),
+            sessions: Rc::new(RefCell::new(std::collections::HashMap::new())),
             conn_slot,
             agent_name: "zeph".to_owned(),
             agent_version: env!("CARGO_PKG_VERSION").to_owned(),
+            max_sessions,
+            idle_timeout: std::time::Duration::from_secs(session_idle_timeout_secs),
+            store: None,
             client_caps: RefCell::new(acp::ClientCapabilities::default()),
         }
+    }
+
+    #[must_use]
+    pub fn with_store(mut self, store: SqliteStore) -> Self {
+        self.store = Some(store);
+        self
     }
 
     #[must_use]
@@ -78,6 +99,38 @@ impl ZephAcpAgent {
         self.agent_name = name.into();
         self.agent_version = version.into();
         self
+    }
+
+    /// Spawn a background task that periodically evicts idle sessions.
+    ///
+    /// Must be called from within a `LocalSet` context.
+    pub fn start_idle_reaper(&self) {
+        let sessions = Rc::clone(&self.sessions);
+        let idle_timeout = self.idle_timeout;
+        tokio::task::spawn_local(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+            interval.tick().await; // skip first tick
+            loop {
+                interval.tick().await;
+                let now = std::time::Instant::now();
+                let expired: Vec<acp::SessionId> = sessions
+                    .borrow()
+                    .iter()
+                    .filter(|(_, e)| {
+                        // Only evict idle sessions (output_rx is Some = not busy).
+                        e.output_rx.borrow().is_some()
+                            && now.duration_since(e.last_active.get()) > idle_timeout
+                    })
+                    .map(|(id, _)| id.clone())
+                    .collect();
+                for id in expired {
+                    if let Some(entry) = sessions.borrow_mut().remove(&id) {
+                        entry.cancel_signal.notify_one();
+                        tracing::debug!(session_id = %id, "evicted idle ACP session (timeout)");
+                    }
+                }
+            }
+        });
     }
 
     fn build_acp_context(
@@ -151,8 +204,27 @@ impl acp::Agent for ZephAcpAgent {
         &self,
         _args: acp::NewSessionRequest,
     ) -> acp::Result<acp::NewSessionResponse> {
-        if self.sessions.borrow().len() >= MAX_SESSIONS {
-            return Err(acp::Error::internal_error().data("session limit reached"));
+        // LRU eviction: find and remove the oldest idle (non-busy) session when at limit.
+        if self.sessions.borrow().len() >= self.max_sessions {
+            let evict_id = {
+                let sessions = self.sessions.borrow();
+                sessions
+                    .iter()
+                    .filter(|(_, e)| e.output_rx.borrow().is_some())
+                    .min_by_key(|(_, e)| e.last_active.get())
+                    .map(|(id, _)| id.clone())
+            };
+            match evict_id {
+                Some(id) => {
+                    if let Some(entry) = self.sessions.borrow_mut().remove(&id) {
+                        entry.cancel_signal.notify_one();
+                        tracing::debug!(session_id = %id, "evicted idle ACP session (LRU)");
+                    }
+                }
+                None => {
+                    return Err(acp::Error::internal_error().data("session limit reached"));
+                }
+            }
         }
 
         let session_id = acp::SessionId::new(uuid::Uuid::new_v4().to_string());
@@ -166,8 +238,19 @@ impl acp::Agent for ZephAcpAgent {
             input_tx: handle.input_tx,
             output_rx: RefCell::new(Some(handle.output_rx)),
             cancel_signal: handle.cancel_signal,
+            last_active: std::cell::Cell::new(std::time::Instant::now()),
         };
         self.sessions.borrow_mut().insert(session_id.clone(), entry);
+
+        if let Some(ref store) = self.store {
+            let sid = session_id.to_string();
+            let store = store.clone();
+            tokio::task::spawn_local(async move {
+                if let Err(e) = store.create_acp_session(&sid).await {
+                    tracing::warn!(error = %e, "failed to persist ACP session");
+                }
+            });
+        }
 
         let acp_ctx = self.build_acp_context(&session_id, cancel_signal);
         let spawner = Arc::clone(&self.spawner);
@@ -204,8 +287,21 @@ impl acp::Agent for ZephAcpAgent {
                 entry.output_rx.borrow_mut().take().ok_or_else(|| {
                     acp::Error::internal_error().data("prompt already in progress")
                 })?;
+            entry.last_active.set(std::time::Instant::now());
             (entry.input_tx.clone(), rx)
         };
+
+        // Persist user message before sending to agent.
+        if let Some(ref store) = self.store {
+            let sid = args.session_id.to_string();
+            let payload = text.clone();
+            let store = store.clone();
+            tokio::task::spawn_local(async move {
+                if let Err(e) = store.save_acp_event(&sid, "user_message", &payload).await {
+                    tracing::warn!(error = %e, "failed to persist user message");
+                }
+            });
+        }
 
         input_tx
             .send(ChannelMessage {
@@ -238,6 +334,17 @@ impl acp::Agent for ZephAcpAgent {
             let Some(event) = event else { break };
             let is_flush = matches!(event, LoopbackEvent::Flush);
             if let Some(update) = loopback_event_to_update(event) {
+                // Persist event before sending notification (best-effort).
+                if let Some(ref store) = self.store {
+                    let sid = args.session_id.to_string();
+                    let (event_type, payload) = session_update_to_event(&update);
+                    let store = store.clone();
+                    tokio::task::spawn_local(async move {
+                        if let Err(e) = store.save_acp_event(&sid, event_type, &payload).await {
+                            tracing::warn!(error = %e, "failed to persist session event");
+                        }
+                    });
+                }
                 let notification = acp::SessionNotification::new(args.session_id.clone(), update);
                 if let Err(e) = self.send_notification(notification).await {
                     tracing::warn!(error = %e, "failed to send notification");
@@ -276,11 +383,112 @@ impl acp::Agent for ZephAcpAgent {
         &self,
         args: acp::LoadSessionRequest,
     ) -> acp::Result<acp::LoadSessionResponse> {
+        // Session already in memory — nothing to restore.
         if self.sessions.borrow().contains_key(&args.session_id) {
-            Ok(acp::LoadSessionResponse::new())
-        } else {
-            Err(acp::Error::internal_error().data("session not found"))
+            return Ok(acp::LoadSessionResponse::new());
         }
+
+        // Try to restore from SQLite persistence.
+        let Some(ref store) = self.store else {
+            return Err(acp::Error::internal_error().data("session not found"));
+        };
+
+        let exists = store
+            .acp_session_exists(&args.session_id.to_string())
+            .await
+            .map_err(|e| {
+                tracing::warn!(error = %e, session_id = %args.session_id, "failed to check ACP session existence");
+                acp::Error::internal_error().data("internal error")
+            })?;
+
+        if !exists {
+            return Err(acp::Error::internal_error().data("session not found"));
+        }
+
+        // Load events BEFORE spawning the agent loop to avoid orphaned sessions on error.
+        let events = store
+            .load_acp_events(&args.session_id.to_string())
+            .await
+            .map_err(|e| {
+                tracing::warn!(error = %e, session_id = %args.session_id, "failed to load ACP session events");
+                acp::Error::internal_error().data("internal error")
+            })?;
+
+        // Rebuild agent loop for the restored session.
+        let (channel, handle) = LoopbackChannel::pair(LOOPBACK_CHANNEL_CAPACITY);
+        let cancel_signal = std::sync::Arc::clone(&handle.cancel_signal);
+        let entry = SessionEntry {
+            input_tx: handle.input_tx,
+            output_rx: RefCell::new(Some(handle.output_rx)),
+            cancel_signal: handle.cancel_signal,
+            last_active: std::cell::Cell::new(std::time::Instant::now()),
+        };
+        self.sessions
+            .borrow_mut()
+            .insert(args.session_id.clone(), entry);
+
+        let acp_ctx = self.build_acp_context(&args.session_id, cancel_signal);
+        let spawner = Arc::clone(&self.spawner);
+        tokio::task::spawn_local(async move {
+            (spawner)(channel, acp_ctx).await;
+        });
+
+        // Replay stored events as session/update notifications per ACP spec.
+
+        for ev in events {
+            let update = match ev.event_type.as_str() {
+                "user_message" => {
+                    acp::SessionUpdate::UserMessageChunk(acp::ContentChunk::new(ev.payload.into()))
+                }
+                "agent_message" => {
+                    acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(ev.payload.into()))
+                }
+                "agent_thought" => {
+                    acp::SessionUpdate::AgentThoughtChunk(acp::ContentChunk::new(ev.payload.into()))
+                }
+                "tool_call" => match serde_json::from_str::<acp::ToolCall>(&ev.payload) {
+                    Ok(tc) => acp::SessionUpdate::ToolCall(tc),
+                    Err(e) => {
+                        tracing::warn!(error = %e, "failed to deserialize tool call event during replay");
+                        continue;
+                    }
+                },
+                other => {
+                    tracing::debug!(
+                        event_type = other,
+                        "skipping unknown event type during replay"
+                    );
+                    continue;
+                }
+            };
+            let notification = acp::SessionNotification::new(args.session_id.clone(), update);
+            if let Err(e) = self.send_notification(notification).await {
+                tracing::warn!(error = %e, "failed to replay notification");
+                break;
+            }
+        }
+
+        Ok(acp::LoadSessionResponse::new())
+    }
+}
+
+/// Map a `SessionUpdate` to a `(event_type, payload)` pair for `SQLite` persistence.
+fn content_chunk_text(chunk: &acp::ContentChunk) -> String {
+    match &chunk.content {
+        acp::ContentBlock::Text(t) => t.text.clone(),
+        _ => String::new(),
+    }
+}
+
+fn session_update_to_event(update: &acp::SessionUpdate) -> (&'static str, String) {
+    match update {
+        acp::SessionUpdate::UserMessageChunk(c) => ("user_message", content_chunk_text(c)),
+        acp::SessionUpdate::AgentMessageChunk(c) => ("agent_message", content_chunk_text(c)),
+        acp::SessionUpdate::AgentThoughtChunk(c) => ("agent_thought", content_chunk_text(c)),
+        acp::SessionUpdate::ToolCall(tc) => {
+            ("tool_call", serde_json::to_string(tc).unwrap_or_default())
+        }
+        _ => ("unknown", String::new()),
     }
 }
 
@@ -344,9 +552,21 @@ mod tests {
         ZephAcpAgent,
         mpsc::UnboundedReceiver<(acp::SessionNotification, oneshot::Sender<()>)>,
     ) {
+        make_agent_with_max(4)
+    }
+
+    fn make_agent_with_max(
+        max_sessions: usize,
+    ) -> (
+        ZephAcpAgent,
+        mpsc::UnboundedReceiver<(acp::SessionNotification, oneshot::Sender<()>)>,
+    ) {
         let (tx, rx) = mpsc::unbounded_channel();
         let conn_slot = std::rc::Rc::new(std::cell::RefCell::new(None));
-        (ZephAcpAgent::new(make_spawner(), tx, conn_slot), rx)
+        (
+            ZephAcpAgent::new(make_spawner(), tx, conn_slot, max_sessions, 1800),
+            rx,
+        )
     }
 
     #[tokio::test]
@@ -520,18 +740,76 @@ mod tests {
         let local = tokio::task::LocalSet::new();
         local
             .run_until(async {
-                let (agent, _rx) = make_agent();
+                let (agent, _rx) = make_agent_with_max(1);
                 use acp::Agent as _;
                 // fill the limit
                 agent
                     .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                     .await
                     .unwrap();
-                // second session should fail
+                // LRU evicts the only idle session, so second succeeds
+                let res = agent
+                    .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
+                    .await;
+                assert!(res.is_ok());
+                // Now there's 1 session again (evicted + new)
+                assert_eq!(agent.sessions.borrow().len(), 1);
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn new_session_rejects_when_all_busy() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let (agent, _rx) = make_agent_with_max(1);
+                use acp::Agent as _;
+                let resp = agent
+                    .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
+                    .await
+                    .unwrap();
+                // Mark the session as busy by taking output_rx
+                agent
+                    .sessions
+                    .borrow()
+                    .get(&resp.session_id)
+                    .unwrap()
+                    .output_rx
+                    .borrow_mut()
+                    .take();
+                // No idle sessions to evict — should fail
                 let res = agent
                     .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                     .await;
                 assert!(res.is_err());
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn new_session_respects_configurable_limit() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let (agent, _rx) = make_agent_with_max(2);
+                use acp::Agent as _;
+                let r1 = agent
+                    .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
+                    .await
+                    .unwrap();
+                let _r2 = agent
+                    .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
+                    .await
+                    .unwrap();
+                // Third session triggers LRU eviction (evicts r1 as oldest idle)
+                let r3 = agent
+                    .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
+                    .await
+                    .unwrap();
+                assert_eq!(agent.sessions.borrow().len(), 2);
+                assert!(!agent.sessions.borrow().contains_key(&r1.session_id));
+                assert!(agent.sessions.borrow().contains_key(&r3.session_id));
             })
             .await;
     }

--- a/crates/zeph-acp/src/transport.rs
+++ b/crates/zeph-acp/src/transport.rs
@@ -14,11 +14,24 @@ use crate::error::AcpError;
 /// the connection to build ACP tool adapters.
 pub(crate) type ConnSlot = Rc<RefCell<Option<Rc<acp::AgentSideConnection>>>>;
 
-/// Configuration for the ACP server identity advertised during `initialize`.
-#[derive(Debug, Clone, Default)]
+/// Configuration for the ACP server passed through to the agent.
+#[derive(Debug, Clone)]
 pub struct AcpServerConfig {
     pub agent_name: String,
     pub agent_version: String,
+    pub max_sessions: usize,
+    pub session_idle_timeout_secs: u64,
+}
+
+impl Default for AcpServerConfig {
+    fn default() -> Self {
+        Self {
+            agent_name: String::new(),
+            agent_version: String::new(),
+            max_sessions: 4,
+            session_idle_timeout_secs: 1800,
+        }
+    }
 }
 
 /// Run the ACP server over stdin/stdout until the connection closes.
@@ -60,8 +73,15 @@ where
             let conn_slot: ConnSlot = Rc::new(RefCell::new(None));
 
             let (tx, mut rx) = mpsc::unbounded_channel();
-            let agent = ZephAcpAgent::new(spawner, tx, Rc::clone(&conn_slot))
-                .with_agent_info(server_config.agent_name, server_config.agent_version);
+            let agent = ZephAcpAgent::new(
+                spawner,
+                tx,
+                Rc::clone(&conn_slot),
+                server_config.max_sessions,
+                server_config.session_idle_timeout_secs,
+            )
+            .with_agent_info(server_config.agent_name, server_config.agent_version);
+            agent.start_idle_reaper();
 
             let (conn, io_fut) = acp::AgentSideConnection::new(agent, writer, reader, |fut| {
                 tokio::task::spawn_local(fut);

--- a/crates/zeph-acp/tests/integration.rs
+++ b/crates/zeph-acp/tests/integration.rs
@@ -35,6 +35,8 @@ fn make_server_config() -> AcpServerConfig {
     AcpServerConfig {
         agent_name: "test-agent".to_owned(),
         agent_version: "0.0.1".to_owned(),
+        max_sessions: 4,
+        session_idle_timeout_secs: 1800,
     }
 }
 

--- a/crates/zeph-core/src/config/env.rs
+++ b/crates/zeph-core/src/config/env.rs
@@ -274,6 +274,16 @@ impl Config {
         if let Ok(v) = std::env::var("ZEPH_ACP_AGENT_VERSION") {
             self.acp.agent_version = v;
         }
+        if let Ok(v) = std::env::var("ZEPH_ACP_MAX_SESSIONS")
+            && let Ok(n) = v.parse::<usize>()
+        {
+            self.acp.max_sessions = n;
+        }
+        if let Ok(v) = std::env::var("ZEPH_ACP_SESSION_IDLE_TIMEOUT_SECS")
+            && let Ok(secs) = v.parse::<u64>()
+        {
+            self.acp.session_idle_timeout_secs = secs;
+        }
     }
 
     fn apply_env_overrides_security(&mut self) {

--- a/crates/zeph-core/src/config/snapshots/zeph_core__config__types__tests__config_default_snapshot.snap
+++ b/crates/zeph-core/src/config/snapshots/zeph_core__config__types__tests__config_default_snapshot.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/zeph-core/src/config/types.rs
+assertion_line: 1221
 expression: toml_str
 ---
 [agent]
@@ -168,3 +169,5 @@ show_source_labels = false
 enabled = false
 agent_name = "zeph"
 agent_version = "0.11.6"
+max_sessions = 4
+session_idle_timeout_secs = 1800

--- a/crates/zeph-core/src/config/types.rs
+++ b/crates/zeph-core/src/config/types.rs
@@ -1067,6 +1067,14 @@ fn default_acp_agent_version() -> String {
     env!("CARGO_PKG_VERSION").to_owned()
 }
 
+fn default_acp_max_sessions() -> usize {
+    4
+}
+
+fn default_acp_session_idle_timeout_secs() -> u64 {
+    1800
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AcpConfig {
     #[serde(default)]
@@ -1075,6 +1083,10 @@ pub struct AcpConfig {
     pub agent_name: String,
     #[serde(default = "default_acp_agent_version")]
     pub agent_version: String,
+    #[serde(default = "default_acp_max_sessions")]
+    pub max_sessions: usize,
+    #[serde(default = "default_acp_session_idle_timeout_secs")]
+    pub session_idle_timeout_secs: u64,
 }
 
 impl Default for AcpConfig {
@@ -1083,6 +1095,8 @@ impl Default for AcpConfig {
             enabled: false,
             agent_name: default_acp_agent_name(),
             agent_version: default_acp_agent_version(),
+            max_sessions: default_acp_max_sessions(),
+            session_idle_timeout_secs: default_acp_session_idle_timeout_secs(),
         }
     }
 }

--- a/crates/zeph-memory/README.md
+++ b/crates/zeph-memory/README.md
@@ -21,6 +21,7 @@ Includes a document ingestion subsystem for loading, chunking, and storing user 
 |--------|-------------|
 | `sqlite` | SQLite storage for conversations and messages |
 | `sqlite::history` | Input history persistence for CLI channel |
+| `sqlite::acp_sessions` | ACP session and event persistence for session resume and lifecycle tracking |
 | `qdrant` | Qdrant client for vector upsert and search |
 | `qdrant_ops` | `QdrantOps` — high-level Qdrant operations |
 | `semantic` | `SemanticMemory` — orchestrates SQLite + Qdrant |

--- a/crates/zeph-memory/migrations/013_acp_sessions.sql
+++ b/crates/zeph-memory/migrations/013_acp_sessions.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS acp_sessions (
+    id TEXT PRIMARY KEY,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS acp_session_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL REFERENCES acp_sessions(id) ON DELETE CASCADE,
+    event_type TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_acp_session_events_session ON acp_session_events(session_id, id);

--- a/crates/zeph-memory/src/sqlite/acp_sessions.rs
+++ b/crates/zeph-memory/src/sqlite/acp_sessions.rs
@@ -1,0 +1,157 @@
+use crate::error::MemoryError;
+use crate::sqlite::SqliteStore;
+
+pub struct AcpSessionEvent {
+    pub event_type: String,
+    pub payload: String,
+}
+
+impl SqliteStore {
+    /// Create a new ACP session record.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database write fails.
+    pub async fn create_acp_session(&self, session_id: &str) -> Result<(), MemoryError> {
+        sqlx::query("INSERT OR IGNORE INTO acp_sessions (id) VALUES (?)")
+            .bind(session_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Persist a single ACP session event.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database write fails.
+    pub async fn save_acp_event(
+        &self,
+        session_id: &str,
+        event_type: &str,
+        payload: &str,
+    ) -> Result<(), MemoryError> {
+        sqlx::query(
+            "INSERT INTO acp_session_events (session_id, event_type, payload) VALUES (?, ?, ?)",
+        )
+        .bind(session_id)
+        .bind(event_type)
+        .bind(payload)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Load all events for an ACP session in insertion order.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database query fails.
+    pub async fn load_acp_events(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<AcpSessionEvent>, MemoryError> {
+        let rows = sqlx::query_as::<_, (String, String)>(
+            "SELECT event_type, payload FROM acp_session_events WHERE session_id = ? ORDER BY id",
+        )
+        .bind(session_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|(event_type, payload)| AcpSessionEvent {
+                event_type,
+                payload,
+            })
+            .collect())
+    }
+
+    /// Delete an ACP session and its events (cascade).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database write fails.
+    pub async fn delete_acp_session(&self, session_id: &str) -> Result<(), MemoryError> {
+        sqlx::query("DELETE FROM acp_sessions WHERE id = ?")
+            .bind(session_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Check whether an ACP session record exists.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database query fails.
+    pub async fn acp_session_exists(&self, session_id: &str) -> Result<bool, MemoryError> {
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM acp_sessions WHERE id = ?")
+            .bind(session_id)
+            .fetch_one(&self.pool)
+            .await?;
+        Ok(count > 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn make_store() -> SqliteStore {
+        SqliteStore::new(":memory:")
+            .await
+            .expect("SqliteStore::new")
+    }
+
+    #[tokio::test]
+    async fn create_and_exists() {
+        let store = make_store().await;
+        store.create_acp_session("sess-1").await.unwrap();
+        assert!(store.acp_session_exists("sess-1").await.unwrap());
+        assert!(!store.acp_session_exists("sess-2").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn save_and_load_events() {
+        let store = make_store().await;
+        store.create_acp_session("sess-1").await.unwrap();
+        store
+            .save_acp_event("sess-1", "user_message", "hello")
+            .await
+            .unwrap();
+        store
+            .save_acp_event("sess-1", "agent_message", "world")
+            .await
+            .unwrap();
+
+        let events = store.load_acp_events("sess-1").await.unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].event_type, "user_message");
+        assert_eq!(events[0].payload, "hello");
+        assert_eq!(events[1].event_type, "agent_message");
+        assert_eq!(events[1].payload, "world");
+    }
+
+    #[tokio::test]
+    async fn delete_cascades_events() {
+        let store = make_store().await;
+        store.create_acp_session("sess-1").await.unwrap();
+        store
+            .save_acp_event("sess-1", "user_message", "hello")
+            .await
+            .unwrap();
+        store.delete_acp_session("sess-1").await.unwrap();
+
+        assert!(!store.acp_session_exists("sess-1").await.unwrap());
+        let events = store.load_acp_events("sess-1").await.unwrap();
+        assert!(events.is_empty());
+    }
+
+    #[tokio::test]
+    async fn load_events_empty_for_unknown() {
+        let store = make_store().await;
+        let events = store.load_acp_events("no-such").await.unwrap();
+        assert!(events.is_empty());
+    }
+}

--- a/crates/zeph-memory/src/sqlite/mod.rs
+++ b/crates/zeph-memory/src/sqlite/mod.rs
@@ -1,3 +1,4 @@
+mod acp_sessions;
 mod history;
 mod messages;
 mod skills;
@@ -10,6 +11,7 @@ use std::str::FromStr;
 
 use crate::error::MemoryError;
 
+pub use acp_sessions::AcpSessionEvent;
 pub use messages::role_str;
 pub use skills::{SkillMetricsRow, SkillUsageRow, SkillVersionRow};
 pub use trust::SkillTrustRow;

--- a/docs/src/architecture/crates.md
+++ b/docs/src/architecture/crates.md
@@ -56,7 +56,7 @@ SKILL.md loader, skill registry, and prompt formatter.
 
 SQLite-backed conversation persistence with Qdrant vector search.
 
-- `SqliteStore` — conversations, messages, summaries, skill usage, skill versions
+- `SqliteStore` — conversations, messages, summaries, skill usage, skill versions, ACP session persistence (`acp_sessions.rs`)
 - `QdrantOps` — shared helper consolidating common Qdrant operations (ensure_collection, upsert, search, delete, scroll), used by `QdrantStore`, `CodeStore`, `QdrantSkillMatcher`, and `McpToolRegistry`
 - `QdrantStore` — vector storage and cosine similarity search with `MessageKind` enum (`Regular` | `Summary`) for payload classification
 - `SemanticMemory<P>` — orchestrator coordinating SQLite + Qdrant + LlmProvider
@@ -153,7 +153,7 @@ A2A protocol client and server (optional, feature-gated).
 
 Agent Client Protocol server — IDE integration via ACP (optional, feature-gated).
 
-- `ZephAcpAgent` — `acp::Agent` implementation; manages sessions, forwards prompts to the agent loop, and emits `SessionNotification` updates back to the IDE
+- `ZephAcpAgent` — `acp::Agent` implementation; manages concurrent sessions with LRU eviction (`max_sessions`, default 4), forwards prompts to the agent loop, and emits `SessionNotification` updates back to the IDE
 - `AcpContext` — per-session bundle of IDE-proxied capabilities passed to `AgentSpawner`:
   - `file_executor: Option<AcpFileExecutor>` — reads/writes routed to the IDE filesystem proxy
   - `shell_executor: Option<AcpShellExecutor>` — shell commands routed through the IDE terminal proxy
@@ -162,6 +162,14 @@ Agent Client Protocol server — IDE integration via ACP (optional, feature-gate
 - `AgentSpawner` — `Arc<dyn Fn(LoopbackChannel, Option<AcpContext>) -> ...>` factory that the main binary supplies; wires `AcpContext` into `CompositeExecutor` before starting the agent loop
 - `AcpPermissionGate` — permission gate backed by `acp::Connection`; cache key uses `tool_call_id` as fallback when `title` is `None` to prevent distinct untitled tools from sharing a cached decision
 - `AcpFileExecutor` / `AcpShellExecutor` — IDE-proxied file and shell backends; each spawns a local task for the connection handler
+
+### Session Lifecycle
+
+`ZephAcpAgent` supports multi-session concurrency with configurable `max_sessions` (default 4). Sessions are tracked in an LRU map; when the limit is reached, the least-recently-used session is evicted and its agent task cancelled.
+
+- **Persistence** — session state and events are persisted to SQLite via `acp_sessions` and `acp_session_events` tables (migration 013 in `zeph-memory`). On `load_session`, stored history is replayed as `session/update` notifications per ACP spec.
+- **Idle reaper** — a background task periodically scans sessions and removes those idle longer than `session_idle_timeout_secs` (default 1800).
+- **Configuration** — `AcpConfig` exposes `max_sessions` and `session_idle_timeout_secs`, with env overrides `ZEPH_ACP_MAX_SESSIONS` and `ZEPH_ACP_SESSION_IDLE_TIMEOUT_SECS`.
 
 ### AcpContext wiring
 

--- a/docs/src/reference/configuration.md
+++ b/docs/src/reference/configuration.md
@@ -30,6 +30,8 @@ Priority: `--config` > `ZEPH_CONFIG` > `config/default.toml`.
 | `memory.token_safety_margin` | > 0.0 |
 | `agent.max_tool_iterations` | <= 100 |
 | `a2a.rate_limit` | > 0 |
+| `acp.max_sessions` | > 0 |
+| `acp.session_idle_timeout_secs` | > 0 |
 | `gateway.rate_limit` | > 0 |
 
 ## Hot-Reload
@@ -48,7 +50,7 @@ Zeph watches the config file for changes and applies runtime-safe fields without
 | `[agent]` | `max_tool_iterations` |
 | `[skills]` | `max_active_skills` |
 
-**Not reloadable** (require restart): LLM provider/model, SQLite path, Qdrant URL, vector backend, Telegram token, MCP servers, A2A config, skill paths.
+**Not reloadable** (require restart): LLM provider/model, SQLite path, Qdrant URL, vector backend, Telegram token, MCP servers, A2A config, ACP config, skill paths.
 
 ## Configuration File
 
@@ -205,6 +207,10 @@ port = 8080
 # auth_token = "secret"     # Bearer token for A2A authentication (from vault ZEPH_A2A_AUTH_TOKEN)
 rate_limit = 60
 
+[acp]
+max_sessions = 4                   # Max concurrent ACP sessions; LRU eviction when exceeded (default: 4)
+session_idle_timeout_secs = 1800   # Idle session reaper timeout in seconds (default: 1800)
+
 [mcp]
 allowed_commands = ["npx", "uvx", "node", "python", "python3"]
 max_dynamic_servers = 10
@@ -273,6 +279,8 @@ Field resolution: per-provider value → parent section (`[llm]`, `[llm.cloud]`)
 | `ZEPH_TOOLS_TIMEOUT` | Shell command timeout in seconds (default: 30) |
 | `ZEPH_TOOLS_SCRAPE_TIMEOUT` | Web scrape request timeout in seconds (default: 15) |
 | `ZEPH_TOOLS_SCRAPE_MAX_BODY` | Max response body size in bytes (default: 1048576) |
+| `ZEPH_ACP_MAX_SESSIONS` | Max concurrent ACP sessions (default: 4) |
+| `ZEPH_ACP_SESSION_IDLE_TIMEOUT_SECS` | Idle session reaper timeout in seconds (default: 1800) |
 | `ZEPH_A2A_ENABLED` | Enable A2A server (default: false) |
 | `ZEPH_A2A_HOST` | A2A server bind address (default: `0.0.0.0`) |
 | `ZEPH_A2A_PORT` | A2A server port (default: `8080`) |

--- a/src/init.rs
+++ b/src/init.rs
@@ -534,6 +534,7 @@ fn apply_acp_config(config: &mut Config, state: &WizardState) {
             enabled: true,
             agent_name: state.acp_agent_name.clone(),
             agent_version: state.acp_agent_version.clone(),
+            ..AcpConfig::default()
         };
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2098,6 +2098,7 @@ struct AgentDeps {
 
 /// Build all agent dependencies from config for the ACP server.
 #[cfg(feature = "acp")]
+#[allow(clippy::too_many_lines)]
 async fn build_acp_deps(
     config_path: Option<&std::path::Path>,
     vault_backend: Option<&str>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2085,6 +2085,8 @@ struct AgentDeps {
     summary_provider: Option<zeph_llm::any::AnyProvider>,
     acp_agent_name: String,
     acp_agent_version: String,
+    acp_max_sessions: usize,
+    acp_session_idle_timeout_secs: u64,
 }
 
 /// Build all agent dependencies from config for the ACP server.
@@ -2192,6 +2194,8 @@ async fn build_acp_deps(
         summary_provider,
         acp_agent_name: config.acp.agent_name.clone(),
         acp_agent_version: config.acp.agent_version.clone(),
+        acp_max_sessions: config.acp.max_sessions,
+        acp_session_idle_timeout_secs: config.acp.session_idle_timeout_secs,
     };
 
     let keepalive: Box<dyn std::any::Any> = Box::new((skill_watcher, config_watcher));
@@ -2316,6 +2320,8 @@ async fn run_acp_server(
     let server_config = zeph_acp::AcpServerConfig {
         agent_name: deps.acp_agent_name.clone(),
         agent_version: deps.acp_agent_version.clone(),
+        max_sessions: deps.acp_max_sessions,
+        session_idle_timeout_secs: deps.acp_session_idle_timeout_secs,
     };
 
     let deps = Arc::new(Mutex::new(Some(deps)));


### PR DESCRIPTION
## Summary

- Configurable `max_sessions` (default 4) with LRU eviction of idle sessions
- Background idle reaper task (60s tick) removes sessions past `session_idle_timeout_secs` (default 30 min)
- Session persistence to SQLite (`acp_sessions` + `acp_session_events` tables)
- `load_session` replays conversation history as `session/update` notifications per ACP spec
- Evicted sessions remain loadable from SQLite
- Database errors not leaked to ACP clients

## Changes

| File | Change |
|------|--------|
| `crates/zeph-core/src/config/types.rs` | `max_sessions`, `session_idle_timeout_secs` in AcpConfig |
| `crates/zeph-core/src/config/env.rs` | `ZEPH_ACP_MAX_SESSIONS`, `ZEPH_ACP_SESSION_IDLE_TIMEOUT_SECS` |
| `crates/zeph-acp/src/agent.rs` | LRU eviction, idle reaper, persistence, load_session replay |
| `crates/zeph-acp/src/transport.rs` | Config wiring through AcpServerConfig |
| `crates/zeph-acp/Cargo.toml` | zeph-memory dependency |
| `crates/zeph-memory/migrations/013_acp_sessions.sql` | New tables |
| `crates/zeph-memory/src/sqlite/acp_sessions.rs` | CRUD methods for ACP sessions |
| `src/main.rs`, `src/init.rs` | Wire store and config |

## Test plan

- [x] 2570 tests passed, 0 failed (+16 new)
- [x] `cargo clippy --workspace -- -D warnings`: 0 warnings
- [x] `cargo +nightly fmt --check`: clean
- [x] LRU eviction tests (oldest idle evicted, all-busy rejects)
- [x] SQLite CRUD tests (create, save events, load, delete, exists)
- [x] Config snapshot updated with new fields

## Deferred items (tracked)

- Session ownership check for load_session (SEC-01) — N/A until HTTP transport
- Rate limiting on new_session (SEC-02) — low risk on stdio
- SQLite growth cap (SEC-03) — acceptable at max_sessions=4
- Batch event persistence (PERF-01) — post-MVP optimization

Closes #781, closes #782
Part of Epic #778