### PR TITLE
fix(acp): deduplicate tool definitions and flush after native tool loop

### DIFF
--- a/crates/zeph-core/src/agent/tool_execution.rs
+++ b/crates/zeph-core/src/agent/tool_execution.rs
@@ -694,6 +694,7 @@ impl<C: Channel> Agent<C> {
                 self.messages
                     .push(Message::from_legacy(Role::Assistant, text.as_str()));
                 self.persist_message(Role::Assistant, text).await;
+                self.channel.flush_chunks().await?;
                 return Ok(());
             }
 
@@ -713,6 +714,7 @@ impl<C: Channel> Agent<C> {
             }
         }
 
+        self.channel.flush_chunks().await?;
         Ok(())
     }
 

--- a/crates/zeph-tools/src/composite.rs
+++ b/crates/zeph-tools/src/composite.rs
@@ -38,7 +38,12 @@ impl<A: ToolExecutor, B: ToolExecutor> ToolExecutor for CompositeExecutor<A, B> 
 
     fn tool_definitions(&self) -> Vec<ToolDef> {
         let mut defs = self.first.tool_definitions();
-        defs.extend(self.second.tool_definitions());
+        let seen: std::collections::HashSet<&str> = defs.iter().map(|d| d.id).collect();
+        for def in self.second.tool_definitions() {
+            if !seen.contains(def.id) {
+                defs.push(def);
+            }
+        }
         defs
     }
 


### PR DESCRIPTION
## Summary

- **CompositeExecutor.tool_definitions()** now deduplicates tools by id (first executor wins), fixing Claude API 400 "Tool names must be unique" when ACP wires duplicate `bash` executors
- **process_response_native_tools()** now calls `flush_chunks()` on all exit paths (Text response and loop break), so the ACP session correctly emits a `Flush` event and transitions back to idle — fixing "prompt already in progress" on subsequent requests

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo nextest run --workspace --lib --bins` — 2691 passed
- [ ] Manual: send prompt via ACP, verify session accepts follow-up prompt after response