### PR TITLE
ci: run build-tests in parallel with lint jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,6 @@ jobs:
 
   build-tests:
     name: Build Tests (${{ matrix.os }})
-    needs: [lint-fmt, lint-clippy]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
     strategy:
@@ -130,7 +129,7 @@ jobs:
 
   test:
     name: Test (${{ matrix.os }})
-    needs: build-tests
+    needs: [lint-fmt, lint-clippy, build-tests]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:


### PR DESCRIPTION
## Summary

- Remove `needs: [lint-fmt, lint-clippy]` from `build-tests` so it starts immediately
- Add `needs: [lint-fmt, lint-clippy, build-tests]` to `test` job
- Net effect: build-tests runs in parallel with lint, test waits for all three

Before:
```
lint-fmt + lint-clippy → build-tests → test
```

After:
```
lint-fmt ──────────┐
lint-clippy ───────┼── test
build-tests ───────┘
```

## Test plan

- [x] CI workflow syntax valid
- [ ] Verify parallel execution in CI run