### PR TITLE
fix: sync workspace.dependencies versions to 0.12.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,19 +101,19 @@ url = "2.5"
 uuid = "1.21"
 wiremock = "0.6.5"
 zeroize = { version = "1", features = ["derive", "serde"] }
-zeph-a2a = { path = "crates/zeph-a2a", version = "0.12.0" }
-zeph-acp = { path = "crates/zeph-acp", version = "0.12.0" }
-zeph-channels = { path = "crates/zeph-channels", version = "0.12.0" }
-zeph-core = { path = "crates/zeph-core", version = "0.12.0" }
-zeph-gateway = { path = "crates/zeph-gateway", version = "0.12.0" }
-zeph-index = { path = "crates/zeph-index", version = "0.12.0" }
-zeph-llm = { path = "crates/zeph-llm", version = "0.12.0" }
-zeph-mcp = { path = "crates/zeph-mcp", version = "0.12.0" }
-zeph-memory = { path = "crates/zeph-memory", version = "0.12.0" }
-zeph-scheduler = { path = "crates/zeph-scheduler", version = "0.12.0" }
-zeph-skills = { path = "crates/zeph-skills", version = "0.12.0" }
-zeph-tools = { path = "crates/zeph-tools", version = "0.12.0" }
-zeph-tui = { path = "crates/zeph-tui", version = "0.12.0" }
+zeph-a2a = { path = "crates/zeph-a2a", version = "0.12.1" }
+zeph-acp = { path = "crates/zeph-acp", version = "0.12.1" }
+zeph-channels = { path = "crates/zeph-channels", version = "0.12.1" }
+zeph-core = { path = "crates/zeph-core", version = "0.12.1" }
+zeph-gateway = { path = "crates/zeph-gateway", version = "0.12.1" }
+zeph-index = { path = "crates/zeph-index", version = "0.12.1" }
+zeph-llm = { path = "crates/zeph-llm", version = "0.12.1" }
+zeph-mcp = { path = "crates/zeph-mcp", version = "0.12.1" }
+zeph-memory = { path = "crates/zeph-memory", version = "0.12.1" }
+zeph-scheduler = { path = "crates/zeph-scheduler", version = "0.12.1" }
+zeph-skills = { path = "crates/zeph-skills", version = "0.12.1" }
+zeph-tools = { path = "crates/zeph-tools", version = "0.12.1" }
+zeph-tui = { path = "crates/zeph-tui", version = "0.12.1" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"


### PR DESCRIPTION
## Summary

- Bump all 13 internal crate version constraints in `[workspace.dependencies]` from `0.12.0` to `0.12.1`
- Fixes regression introduced in `2c3ffa3` (release: prepare v0.12.1) where only `[workspace.package].version` was updated but `[workspace.dependencies]` entries were left at `0.12.0`

## Test plan

- [x] `cargo +nightly fmt --check` — pass
- [x] `cargo clippy --workspace -- -D warnings` — pass
- [x] `cargo nextest run --workspace --lib --bins` — 2894 tests passed