### PR TITLE
release: v0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.12.2] - 2026-02-26
+
 ### Added
 - `MemoryToolExecutor` in `zeph-core` exposes `memory_search` and `memory_save` as native tools the model can invoke explicitly
 - `memory_search` queries SemanticMemory recall, key facts, and session summaries; `memory_save` persists content to long-term memory
@@ -1346,7 +1348,8 @@ let agent = Agent::new(provider, channel, &skills_prompt, executor);
 - Agent calls channel.send_typing() before each LLM request
 - Agent::run() uses tokio::select! to race channel messages against shutdown signal
 
-[Unreleased]: https://github.com/bug-ops/zeph/compare/v0.12.1...HEAD
+[Unreleased]: https://github.com/bug-ops/zeph/compare/v0.12.2...HEAD
+[0.12.2]: https://github.com/bug-ops/zeph/compare/v0.12.1...v0.12.2
 [0.12.1]: https://github.com/bug-ops/zeph/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/bug-ops/zeph/compare/v0.11.6...v0.12.0
 [0.11.6]: https://github.com/bug-ops/zeph/compare/v0.11.5...v0.11.6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9154,7 +9154,7 @@ dependencies = [
 
 [[package]]
 name = "zeph"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -9191,7 +9191,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-a2a"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "axum 0.8.8",
  "eventsource-stream",
@@ -9214,7 +9214,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-acp"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "agent-client-protocol",
  "async-stream",
@@ -9248,7 +9248,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-channels"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "axum 0.8.8",
  "criterion",
@@ -9273,7 +9273,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-core"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "age",
  "anyhow",
@@ -9309,7 +9309,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-gateway"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "axum 0.8.8",
  "blake3",
@@ -9326,7 +9326,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-index"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "blake3",
  "ignore",
@@ -9356,7 +9356,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-llm"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "base64 0.22.1",
  "candle-core",
@@ -9383,7 +9383,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-mcp"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "blake3",
  "qdrant-client",
@@ -9403,7 +9403,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-memory"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "blake3",
  "bytemuck",
@@ -9428,7 +9428,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-scheduler"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "chrono",
  "cron",
@@ -9445,7 +9445,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-skills"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "blake3",
  "criterion",
@@ -9469,7 +9469,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-tools"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "dirs",
  "filetime",
@@ -9495,7 +9495,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-tui"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "chrono",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 rust-version = "1.88"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["bug-ops"]
 license = "MIT"
 repository = "https://github.com/bug-ops/zeph"
@@ -101,19 +101,19 @@ url = "2.5"
 uuid = "1.21"
 wiremock = "0.6.5"
 zeroize = { version = "1", features = ["derive", "serde"] }
-zeph-a2a = { path = "crates/zeph-a2a", version = "0.12.1" }
-zeph-acp = { path = "crates/zeph-acp", version = "0.12.1" }
-zeph-channels = { path = "crates/zeph-channels", version = "0.12.1" }
-zeph-core = { path = "crates/zeph-core", version = "0.12.1" }
-zeph-gateway = { path = "crates/zeph-gateway", version = "0.12.1" }
-zeph-index = { path = "crates/zeph-index", version = "0.12.1" }
-zeph-llm = { path = "crates/zeph-llm", version = "0.12.1" }
-zeph-mcp = { path = "crates/zeph-mcp", version = "0.12.1" }
-zeph-memory = { path = "crates/zeph-memory", version = "0.12.1" }
-zeph-scheduler = { path = "crates/zeph-scheduler", version = "0.12.1" }
-zeph-skills = { path = "crates/zeph-skills", version = "0.12.1" }
-zeph-tools = { path = "crates/zeph-tools", version = "0.12.1" }
-zeph-tui = { path = "crates/zeph-tui", version = "0.12.1" }
+zeph-a2a = { path = "crates/zeph-a2a", version = "0.12.2" }
+zeph-acp = { path = "crates/zeph-acp", version = "0.12.2" }
+zeph-channels = { path = "crates/zeph-channels", version = "0.12.2" }
+zeph-core = { path = "crates/zeph-core", version = "0.12.2" }
+zeph-gateway = { path = "crates/zeph-gateway", version = "0.12.2" }
+zeph-index = { path = "crates/zeph-index", version = "0.12.2" }
+zeph-llm = { path = "crates/zeph-llm", version = "0.12.2" }
+zeph-mcp = { path = "crates/zeph-mcp", version = "0.12.2" }
+zeph-memory = { path = "crates/zeph-memory", version = "0.12.2" }
+zeph-scheduler = { path = "crates/zeph-scheduler", version = "0.12.2" }
+zeph-skills = { path = "crates/zeph-skills", version = "0.12.2" }
+zeph-tools = { path = "crates/zeph-tools", version = "0.12.2" }
+zeph-tui = { path = "crates/zeph-tui", version = "0.12.2" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/crates/zeph-core/src/config/snapshots/zeph_core__config__types__tests__config_default_snapshot.snap
+++ b/crates/zeph-core/src/config/snapshots/zeph_core__config__types__tests__config_default_snapshot.snap
@@ -178,7 +178,7 @@ show_source_labels = false
 [acp]
 enabled = false
 agent_name = "zeph"
-agent_version = "0.12.1"
+agent_version = "0.12.2"
 max_sessions = 4
 session_idle_timeout_secs = 1800
 available_models = []

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__splash__tests__splash_default.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__splash__tests__splash_default.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/zeph-tui/src/widgets/splash.rs
-assertion_line: 79
 expression: output
 ---
 ┌──────────────────────────────────────────────────────────┐
@@ -15,7 +14,7 @@ expression: output
 │              ███████╗███████╗██║     ██║  ██║            │
 │              ╚══════╝╚══════╝╚═╝     ╚═╝  ╚═╝            │
 │                                                          │
-│                          v0.12.1                         │
+│                          v0.12.2                         │
 │                                                          │
 │                  Type a message to start.                │
 │                                                          │


### PR DESCRIPTION
## Summary

- Bump version from 0.12.1 to 0.12.2 across all workspace manifests
- Update CHANGELOG.md with release section dated 2026-02-26
- Update insta snapshots to reflect new version string

## Checklist

- [x] Version updated in all manifests (`[workspace.package]` + 13 internal dep references)
- [x] CHANGELOG.md has release section with date
- [x] Insta snapshots updated (config_default_snapshot, splash_default)
- [x] `cargo +nightly fmt --check` passed
- [x] `cargo clippy --workspace -- -D warnings` passed
- [x] `cargo nextest run --workspace --lib --bins` — 2894/2894 passed
- [ ] Ready for tagging after merge