### PR TITLE
fix(acp): replace direct send with send_tool_output in skill streaming paths

### DIFF
--- a/crates/zeph-core/src/agent/tool_execution.rs
+++ b/crates/zeph-core/src/agent/tool_execution.rs
@@ -519,9 +519,22 @@ impl<C: Channel> Agent<C> {
                 } else {
                     processed.clone()
                 };
+                let filter_stats_inline = output.filter_stats.as_ref().and_then(|fs| {
+                    (fs.filtered_chars < fs.raw_chars).then(|| fs.format_inline(&output.tool_name))
+                });
                 let formatted_output = format_tool_output(&output.tool_name, &body);
                 let display = self.maybe_redact(&formatted_output);
-                self.channel.send(&display).await?;
+                self.channel
+                    .send_tool_output(
+                        &output.tool_name,
+                        &display,
+                        None,
+                        filter_stats_inline,
+                        None,
+                        "",
+                        false,
+                    )
+                    .await?;
 
                 self.push_message(Message::from_parts(
                     Role::User,
@@ -554,7 +567,9 @@ impl<C: Channel> Agent<C> {
                         let processed = self.maybe_summarize_tool_output(&out.summary).await;
                         let formatted = format_tool_output(&out.tool_name, &processed);
                         let display = self.maybe_redact(&formatted);
-                        self.channel.send(&display).await?;
+                        self.channel
+                            .send_tool_output(&out.tool_name, &display, None, None, None, "", false)
+                            .await?;
                         self.push_message(Message::from_parts(
                             Role::User,
                             vec![MessagePart::ToolOutput {


### PR DESCRIPTION
## Summary

- Skill direct-output path (~line 522) and confirmation-required path (~line 555) in `tool_execution.rs` were calling `channel.send(format_tool_output(...))` directly
- Both paths now call `channel.send_tool_output(...)`, emitting a structured `LoopbackEvent::ToolOutput` with separate `tool_name` and `display` fields
- `filter_stats_inline` is forwarded as a structured field in the direct-output path

## Test plan

- [ ] `cargo clippy -p zeph-core -- -D warnings` passes with zero warnings
- [ ] `cargo nextest run -p zeph-core --lib` — all 766 tests pass
- [ ] Manual: verify ACP/Zed renders a tool card instead of plain text with embedded `[tool output: name]` header

Fixes #985.