### PR TITLE
fix(acp): use tool id as permission cache key instead of command string

### DIFF
--- a/crates/zeph-acp/src/terminal.rs
+++ b/crates/zeph-acp/src/terminal.rs
@@ -142,7 +142,9 @@ impl zeph_tools::ToolExecutor for AcpShellExecutor {
         let cwd = params.cwd.map(PathBuf::from);
 
         if let Some(gate) = &self.permission_gate {
-            let fields = acp::ToolCallUpdateFields::new().title(params.command.clone());
+            let fields = acp::ToolCallUpdateFields::new()
+                .title(call.tool_id.clone())
+                .raw_input(serde_json::json!({ "command": params.command }));
             let tool_call = acp::ToolCallUpdate::new(call.tool_id.clone(), fields);
             let allowed = gate
                 .check_permission(self.session_id.clone(), tool_call)


### PR DESCRIPTION
## Problem

`Allow always` for bash tool calls had no effect — every distinct command
triggered a new permission prompt regardless of prior decisions.

## Root Cause

`terminal.rs` set `ToolCallUpdateFields::title` to the full command string
(`gh api repos/.../contents/docs --jq '...'`). The permission cache in
`AcpPermissionGate` keys on `title`, so each unique command was a separate
cache entry. Selecting `Allow always` saved one specific command string but
never matched subsequent calls.

## Fix

- `title` is now set to the stable tool id (`"bash"`)
- The full command moves to `raw_input` and remains visible in the IDE's
  "View Raw Input" panel
- A single `Allow always` for `bash` now covers all shell invocations

## Test plan

- [x] `cargo clippy -p zeph-acp -- -D warnings` passes
- [x] All 133 unit tests in `zeph-acp` pass
- [ ] Manual: allow bash once, trigger another bash call — no prompt
- [ ] Manual: allow bash always, restart session — no prompts for any command