### PR TITLE
fix(acp): populate ToolCall title and raw_input from tool params

### DIFF
--- a/crates/zeph-acp/src/agent.rs
+++ b/crates/zeph-acp/src/agent.rs
@@ -1564,7 +1564,11 @@ fn loopback_event_to_updates(event: LoopbackEvent) -> Vec<acp::SessionUpdate> {
             // For bash: use the command string (truncated). For others: fall back to tool_name.
             let title = params
                 .as_ref()
-                .and_then(|p| p.get("command").or_else(|| p.get("path")).or_else(|| p.get("url")))
+                .and_then(|p| {
+                    p.get("command")
+                        .or_else(|| p.get("path"))
+                        .or_else(|| p.get("url"))
+                })
                 .and_then(|v| v.as_str())
                 .map_or_else(
                     || tool_name.clone(),

--- a/crates/zeph-acp/src/terminal.rs
+++ b/crates/zeph-acp/src/terminal.rs
@@ -532,7 +532,9 @@ mod tests {
             .run_until(async {
                 let perm_conn = Rc::new(RejectPermissionClient);
                 let sid = acp::SessionId::new("s1");
-                let (gate, perm_handler) = AcpPermissionGate::new(perm_conn, None);
+                let tmp_dir = tempfile::tempdir().unwrap();
+                let perm_file = tmp_dir.path().join("perms.toml");
+                let (gate, perm_handler) = AcpPermissionGate::new(perm_conn, Some(perm_file));
                 tokio::task::spawn_local(perm_handler);
 
                 let term_conn = Rc::new(FakeTerminalClient);

--- a/crates/zeph-core/src/agent/tool_execution.rs
+++ b/crates/zeph-core/src/agent/tool_execution.rs
@@ -920,7 +920,10 @@ impl<C: Channel> Agent<C> {
             .map(|_| uuid::Uuid::new_v4().to_string())
             .collect();
         for (tc, tool_call_id) in tool_calls.iter().zip(tool_call_ids.iter()) {
-            self.channel.send_tool_start(&tc.name, tool_call_id).await?;
+            let raw_params = tc.input.clone();
+            self.channel
+                .send_tool_start(&tc.name, tool_call_id, Some(raw_params))
+                .await?;
         }
 
         // Inject active skill secrets before tool execution

--- a/crates/zeph-core/src/channel.rs
+++ b/crates/zeph-core/src/channel.rs
@@ -153,6 +153,7 @@ pub trait Channel: Send {
         &mut self,
         _tool_name: &str,
         _tool_call_id: &str,
+        _params: Option<serde_json::Value>,
     ) -> impl Future<Output = Result<(), ChannelError>> + Send {
         async { Ok(()) }
     }
@@ -207,6 +208,8 @@ pub enum LoopbackEvent {
     ToolStart {
         tool_name: String,
         tool_call_id: String,
+        /// Raw input parameters passed to the tool (e.g. `{"command": "..."}` for bash).
+        params: Option<serde_json::Value>,
     },
     ToolOutput {
         tool_name: String,
@@ -312,11 +315,13 @@ impl Channel for LoopbackChannel {
         &mut self,
         tool_name: &str,
         tool_call_id: &str,
+        params: Option<serde_json::Value>,
     ) -> Result<(), ChannelError> {
         self.output_tx
             .send(LoopbackEvent::ToolStart {
                 tool_name: tool_name.to_owned(),
                 tool_call_id: tool_call_id.to_owned(),
+                params,
             })
             .await
             .map_err(|_| ChannelError::ChannelClosed)


### PR DESCRIPTION
## Problem

All bash tool calls in the Zed ACP chat showed only `bash` as the title,
making it impossible to see which command was being executed without
expanding "View Raw Input".

## Root Cause

`LoopbackEvent::ToolStart` carried only `tool_name` and `tool_call_id`.
In `loopback_event_to_updates` the title was set to `tool_name` ("bash")
with no command information attached.

## Changes

- `LoopbackEvent::ToolStart` — new `params: Option<serde_json::Value>` field
- `send_tool_start` trait method and `LoopbackChannel` implementation updated
- `tool_execution.rs` — passes `tc.input` as params at the call site
- `loopback_event_to_updates` — derives `ToolCall.title` from `command` /
  `path` / `url` keys in params (truncated to 120 chars with `…` suffix);
  attaches params as `raw_input` for "View Raw Input"
- `permission_denied_returns_blocked_error` test — uses isolated temp file
  to prevent cache pollution from `bash = "allow"` in the default config

## Result

Zed now shows the actual command in the tool call bubble:

```
Run Command
gh api repos/agentclientprotocol/…/contents/docs --jq '.[] | …'
```

Commands longer than 120 characters are truncated with `…`.

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] All 2921 tests pass