### PR TITLE
fix(agent): restore skill matching and context population on TUI queries

### DIFF
--- a/crates/zeph-core/src/agent/context.rs
+++ b/crates/zeph-core/src/agent/context.rs
@@ -1256,7 +1256,12 @@ impl<C: Channel> Agent<C> {
                 )
                 .await;
 
-            let indices: Vec<usize> = if scored.len() >= 2
+            let indices: Vec<usize> = if scored.is_empty() {
+                // Embed or Qdrant failure: fall back to all skills so the agent
+                // remains functional rather than running with an empty skill set.
+                tracing::warn!("skill matcher returned no results, falling back to all skills");
+                (0..all_meta.len()).collect()
+            } else if scored.len() >= 2
                 && (scored[0].score - scored[1].score) < self.skill_state.disambiguation_threshold
             {
                 match self.disambiguate_skills(query, &all_meta, &scored).await {

--- a/crates/zeph-core/src/bootstrap/mod.rs
+++ b/crates/zeph-core/src/bootstrap/mod.rs
@@ -136,6 +136,15 @@ impl AppBuilder {
             tracing::info!(context_window = ctx, "detected Ollama model context window");
         }
 
+        if let AnyProvider::Orchestrator(ref mut orch) = provider {
+            orch.auto_detect_context_window().await;
+        }
+        if let Some(ctx) = provider.context_window()
+            && !matches!(provider, AnyProvider::Ollama(_))
+        {
+            tracing::info!(context_window = ctx, "detected orchestrator context window");
+        }
+
         Ok((provider, status_rx))
     }
 

--- a/crates/zeph-llm/src/orchestrator/mod.rs
+++ b/crates/zeph-llm/src/orchestrator/mod.rs
@@ -67,6 +67,16 @@ impl ModelOrchestrator {
         self.status_tx = Some(tx);
     }
 
+    /// Detect and apply the context window size from the default sub-provider.
+    ///
+    /// Currently supported for Ollama sub-providers via `show` API.
+    /// Other sub-providers are skipped silently.
+    pub async fn auto_detect_context_window(&mut self) {
+        if let Some(provider) = self.providers.get_mut(&self.default_provider) {
+            provider.auto_detect_context_window().await;
+        }
+    }
+
     /// Aggregate model lists from all sub-providers, deduplicating by id.
     ///
     /// Individual sub-provider errors are logged as warnings and skipped.

--- a/crates/zeph-llm/src/orchestrator/router.rs
+++ b/crates/zeph-llm/src/orchestrator/router.rs
@@ -21,6 +21,16 @@ pub enum SubProvider {
 }
 
 impl SubProvider {
+    /// Detect and set the context window size from the underlying provider where supported.
+    pub async fn auto_detect_context_window(&mut self) {
+        if let Self::Ollama(p) = self
+            && let Ok(info) = p.fetch_model_info().await
+            && let Some(ctx) = info.context_length
+        {
+            p.set_context_window(ctx);
+        }
+    }
+
     pub fn set_status_tx(&mut self, tx: StatusTx) {
         match self {
             Self::Claude(p) => {


### PR DESCRIPTION
## Summary

- When `QdrantSkillMatcher` returns an empty result set (embed error or Qdrant unavailable), `rebuild_system_prompt` now falls back to all registered skills instead of running with an empty active-skill list
- Added `auto_detect_context_window` to `SubProvider` and `ModelOrchestrator`; `build_provider` now calls it for `AnyProvider::Orchestrator` so that `auto_budget_tokens` returns a non-zero value and `prepare_context` injects semantic recall, summaries, and cross-session memories

## Root causes

1. **Skill matching**: empty `scored` vec passed through unchanged → zero active skills, no fallback
2. **Context budget**: only `AnyProvider::Ollama` was interrogated for context window size; orchestrator was silently skipped → `context_budget = None` → `prepare_context` returned early on every query

## Test plan

- [ ] `cargo clippy --workspace -- -D warnings` passes with zero warnings
- [ ] `cargo nextest run --workspace --lib --bins` — 2963 tests pass
- [ ] TUI: enter query with Qdrant unavailable → skills panel shows all registered skills
- [ ] TUI: enter query with orchestrator provider → context panel shows memory/summary entries