### PR TITLE
fix(acp): preserve newlines in tool output for IDE terminal widget

### DIFF
--- a/crates/zeph-acp/src/agent.rs
+++ b/crates/zeph-acp/src/agent.rs
@@ -3585,6 +3585,72 @@ mod tests {
         ));
     }
 
+    // Regression test for #1033: multiline tool output must preserve newlines in
+    // terminal_output.data and raw_output. Before the fix, the markdown-wrapped display string
+    // was used, causing IDEs to receive fenced code block text rather than raw output.
+    #[test]
+    fn loopback_tool_output_multiline_preserves_newlines_in_terminal_data() {
+        let raw = "file1.rs\nfile2.rs\nfile3.rs".to_owned();
+        let event = LoopbackEvent::ToolOutput {
+            tool_name: "bash".to_owned(),
+            display: raw.clone(),
+            diff: None,
+            filter_stats: None,
+            kept_lines: None,
+            locations: None,
+            tool_call_id: "tc-multi".to_owned(),
+            is_error: false,
+            terminal_id: Some("term-multi".to_owned()),
+            parent_tool_use_id: None,
+        };
+        let updates = loopback_event_to_updates(event);
+        assert_eq!(updates.len(), 2, "expected intermediate + final update");
+
+        // Intermediate update carries terminal_output meta.
+        match &updates[0] {
+            acp::SessionUpdate::ToolCallUpdate(tcu) => {
+                let meta = tcu.meta.as_ref().expect("intermediate must have _meta");
+                let output = &meta["terminal_output"];
+                let data = output["data"]
+                    .as_str()
+                    .expect("terminal_output.data must be string");
+                // Must be raw text — no markdown fences.
+                assert!(
+                    !data.contains("```"),
+                    "terminal_output.data must not contain markdown fences; got: {data:?}"
+                );
+                assert!(
+                    data.contains('\n'),
+                    "terminal_output.data must preserve newlines; got: {data:?}"
+                );
+                assert_eq!(data, raw, "terminal_output.data must equal raw body");
+            }
+            other => panic!("expected intermediate ToolCallUpdate, got {other:?}"),
+        }
+
+        // Final update carries raw_output.
+        match &updates[1] {
+            acp::SessionUpdate::ToolCallUpdate(tcu) => {
+                let raw_out = tcu
+                    .fields
+                    .raw_output
+                    .as_ref()
+                    .and_then(|v| v.as_str())
+                    .expect("raw_output must be string");
+                assert!(
+                    !raw_out.contains("```"),
+                    "raw_output must not contain markdown fences; got: {raw_out:?}"
+                );
+                assert!(
+                    raw_out.contains('\n'),
+                    "raw_output must preserve newlines; got: {raw_out:?}"
+                );
+                assert_eq!(raw_out, raw, "raw_output must equal raw body");
+            }
+            other => panic!("expected final ToolCallUpdate, got {other:?}"),
+        }
+    }
+
     // --- #958 SetSessionModel ---
 
     #[cfg(feature = "unstable-session-model")]

--- a/crates/zeph-core/src/agent/tool_execution.rs
+++ b/crates/zeph-core/src/agent/tool_execution.rs
@@ -2409,4 +2409,70 @@ mod tests {
             "locations from ToolOutput must be forwarded to LoopbackEvent::ToolOutput"
         );
     }
+
+    // Regression test for #1033: send_tool_output must receive raw body, not markdown-wrapped text.
+    // Before the fix, `format_tool_output` output (with fenced code block) was passed to
+    // `send_tool_output`, which caused newlines inside the output to be lost in ACP consumers
+    // that read `terminal_output.data` or `raw_output` as plain text.
+    #[tokio::test]
+    async fn handle_tool_result_display_is_raw_body_not_markdown_wrapped() {
+        use super::super::agent_tests::{MockToolExecutor, create_test_registry, mock_provider};
+        use crate::channel::{LoopbackChannel, LoopbackEvent};
+        use zeph_tools::executor::ToolOutput;
+
+        let (loopback, mut handle) = LoopbackChannel::pair(32);
+        let provider = mock_provider(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = super::super::Agent::new(provider, loopback, registry, None, 5, executor);
+
+        let output = ToolOutput {
+            tool_name: "bash".into(),
+            summary: "line1\nline2\nline3".into(),
+            blocks_executed: 1,
+            diff: None,
+            filter_stats: None,
+            streamed: false,
+            terminal_id: None,
+            locations: None,
+        };
+        agent
+            .handle_tool_result("response", Ok(Some(output)))
+            .await
+            .unwrap();
+        drop(agent);
+
+        let mut events = Vec::new();
+        while let Ok(ev) = handle.output_rx.try_recv() {
+            events.push(ev);
+        }
+
+        let display = events.iter().find_map(|e| {
+            if let LoopbackEvent::ToolOutput { display, .. } = e {
+                Some(display.clone())
+            } else {
+                None
+            }
+        });
+
+        let display = display.expect("LoopbackEvent::ToolOutput must be emitted");
+        // Raw body must be passed — no markdown fence markers.
+        assert!(
+            !display.contains("```"),
+            "display must not contain markdown fences; got: {display:?}"
+        );
+        assert!(
+            !display.contains("[tool output:"),
+            "display must not contain markdown header; got: {display:?}"
+        );
+        // Newlines from the original output must be preserved.
+        assert!(
+            display.contains('\n'),
+            "display must preserve newlines from raw body; got: {display:?}"
+        );
+        assert!(
+            display.contains("line1") && display.contains("line2") && display.contains("line3"),
+            "display must contain all lines from raw body; got: {display:?}"
+        );
+    }
 }


### PR DESCRIPTION
Closes #1033

## Problem

Tool output in the ACP session panel lost all newlines — multi-line output
from shell commands (`ls`, `find`, etc.) appeared as a single merged line.

## Root cause

`tool_execution.rs` was passing the markdown-wrapped string from
`format_tool_output()` (`` [tool output: bash]\n```\n{body}\n``` ``) to
`send_tool_output()`, violating the Channel trait's documented contract:
> "body is the raw tool output content, no header"

`LoopbackChannel` stored this as `display`, which ACP then used directly for
`terminal_output.data` and `raw_output` — IDE terminal widgets expect raw
text, not Markdown, so newlines were lost in rendering.

The default `Channel::send_tool_output` implementation already calls
`format_tool_output()` internally, so CLI and Telegram channels were
unaffected; only `LoopbackChannel` (ACP path) was broken.

## Fix

Pass raw (pre-formatted) body to `send_tool_output()` at both call sites in
`tool_execution.rs`. No changes to `channel.rs` or `zeph-acp/src/agent.rs`.

## Tests

Added two regression tests:
- `handle_tool_result_display_is_raw_body_not_markdown_wrapped` — verifies
  `LoopbackEvent::ToolOutput.display` has no markdown fences and preserves newlines
- `loopback_tool_output_multiline_preserves_newlines_in_terminal_data` — verifies
  `terminal_output.data` and `raw_output` in ACP meta contain raw multiline text