### PR TITLE
fix(ci): add repository and gitAuthor to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "repositories": ["bug-ops/zeph"],
+  "gitAuthor": "Andrei G <andrei.g@my.com>",
   "schedule": ["before 9am on monday"],
   "timezone": "UTC",
   "prHourlyLimit": 5,


### PR DESCRIPTION
## Summary

Fix two warnings from first Renovate run:

- Add `repositories: ["bug-ops/zeph"]` — Renovate was reporting "No repositories found"
- Add `gitAuthor` — eliminates warning about default Mend/WhiteSource email on commits