### PR TITLE
fix(acp): harden permission gate against shell bypass and fix allow-always scope

### DIFF
--- a/crates/zeph-acp/src/permission.rs
+++ b/crates/zeph-acp/src/permission.rs
@@ -28,7 +28,66 @@ struct PermissionRequest {
 #[derive(Debug, Serialize, Deserialize, Default)]
 struct PersistedPermissions {
     #[serde(default)]
-    tools: HashMap<String, String>,
+    tools: HashMap<String, ToolPermission>,
+}
+
+/// Per-tool permission entry in the persisted TOML file.
+///
+/// Simple variant: `tool_name = "allow"` or `tool_name = "deny"`.
+/// Patterned variant: used for bash-like tools to grant/deny per command binary.
+///
+/// ```toml
+/// [tools.bash]
+/// default = "ask"
+///
+/// [tools.bash.patterns]
+/// git = "allow"
+/// cargo = "allow"
+/// rm = "deny"
+///
+/// [tools]
+/// web_scrape = "allow"
+/// ```
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+enum ToolPermission {
+    Simple(String),
+    Patterned {
+        #[serde(default)]
+        default: Option<String>,
+        #[serde(default)]
+        patterns: HashMap<String, String>,
+    },
+}
+
+/// Transparent prefixes that wrap another command without changing its semantics.
+const TRANSPARENT_PREFIXES: &[&str] = &["env", "command", "exec", "nice", "nohup", "time"];
+
+/// Extract the effective command binary name from a shell command string.
+///
+/// Iteratively skips transparent prefixes (`env`, `command`, `exec`, etc.) and
+/// env-var assignments (`FOO=bar`) to reach the real binary name.
+/// Falls back to `"bash"` if the command is empty.
+fn extract_command_binary_owned(command: &str) -> String {
+    let mut tokens = command.split_whitespace().peekable();
+    loop {
+        match tokens.peek() {
+            None => return "bash".to_owned(),
+            Some(tok) => {
+                if tok.contains('=') {
+                    tokens.next();
+                    continue;
+                }
+                let base = tok.rsplit('/').next().unwrap_or(tok);
+                if TRANSPARENT_PREFIXES.contains(&base) {
+                    tokens.next();
+                    continue;
+                }
+                let binary = tok.rsplit('/').next().unwrap_or(tok);
+                return binary.to_owned();
+            }
+        }
+    }
 }
 
 fn default_permission_file() -> PathBuf {
@@ -126,17 +185,53 @@ impl AcpPermissionGate {
         let persisted = load_persisted(&file);
 
         let mut initial: HashMap<String, PermissionDecision> = HashMap::new();
-        for (tool_name, decision_str) in &persisted.tools {
-            let decision = match decision_str.as_str() {
-                "allow" => PermissionDecision::AllowAlways,
-                "reject" => PermissionDecision::RejectAlways,
-                other => {
-                    warn!("unknown persisted permission decision '{other}' for tool '{tool_name}'");
-                    continue;
+        for (tool_name, perm) in &persisted.tools {
+            match perm {
+                ToolPermission::Simple(decision_str) => {
+                    let decision = match decision_str.as_str() {
+                        "allow" => PermissionDecision::AllowAlways,
+                        "deny" | "reject" => PermissionDecision::RejectAlways,
+                        other => {
+                            warn!("unknown persisted permission '{other}' for tool '{tool_name}'");
+                            continue;
+                        }
+                    };
+                    // Store without session prefix — on check_permission we look up tool_name directly.
+                    initial.insert(tool_name.clone(), decision);
                 }
-            };
-            // Store without session prefix — on check_permission we look up tool_name directly.
-            initial.insert(tool_name.clone(), decision);
+                ToolPermission::Patterned { default, patterns } => {
+                    // Load per-binary patterns as "tool_name\x01binary" cache keys.
+                    for (binary, decision_str) in patterns {
+                        let decision = match decision_str.as_str() {
+                            "allow" => PermissionDecision::AllowAlways,
+                            "deny" | "reject" => PermissionDecision::RejectAlways,
+                            other => {
+                                warn!(
+                                    "unknown persisted pattern permission '{other}' for \
+                                     tool '{tool_name}' binary '{binary}'"
+                                );
+                                continue;
+                            }
+                        };
+                        initial.insert(format!("{tool_name}\x01{binary}"), decision);
+                    }
+                    // Load default decision for the tool as a fallback.
+                    if let Some(default_str) = default {
+                        let decision = match default_str.as_str() {
+                            "allow" => PermissionDecision::AllowAlways,
+                            "deny" | "reject" => PermissionDecision::RejectAlways,
+                            other => {
+                                warn!(
+                                    "unknown persisted default permission '{other}' for \
+                                     tool '{tool_name}'"
+                                );
+                                continue;
+                            }
+                        };
+                        initial.insert(tool_name.clone(), decision);
+                    }
+                }
+            }
         }
 
         let (tx, rx) = mpsc::unbounded_channel::<PermissionRequest>();
@@ -187,12 +282,32 @@ impl AcpPermissionGate {
         let session_cache_key = format!("{session_id}\0{tool_name}");
 
         // Fast path: check session-scoped key first, then tool-name-only (persisted).
-        if let Ok(guard) = self.cache.read()
-            && let Some(d) = guard
-                .get(session_cache_key.as_str())
-                .or_else(|| guard.get(tool_name))
-        {
-            return Ok(matches!(d, PermissionDecision::AllowAlways));
+        // For patterned tools (e.g. "bash"), also check the per-binary pattern key.
+        // The binary name is extracted from raw_input["command"] when present.
+        if let Ok(guard) = self.cache.read() {
+            // Check session-scoped key first.
+            if let Some(d) = guard.get(session_cache_key.as_str()) {
+                return Ok(matches!(d, PermissionDecision::AllowAlways));
+            }
+            // Extract binary from raw_input for patterned lookup.
+            let binary = tool_call
+                .fields
+                .raw_input
+                .as_ref()
+                .and_then(|v| v.get("command"))
+                .and_then(|c| c.as_str())
+                .map(extract_command_binary_owned);
+            // Check per-binary pattern key: "tool_name\x01binary".
+            if let Some(ref bin) = binary {
+                let pattern_key = format!("{tool_name}\x01{bin}");
+                if let Some(d) = guard.get(pattern_key.as_str()) {
+                    return Ok(matches!(d, PermissionDecision::AllowAlways));
+                }
+            }
+            // Fall back to tool-name-only (persisted default).
+            if let Some(d) = guard.get(tool_name) {
+                return Ok(matches!(d, PermissionDecision::AllowAlways));
+            }
         }
 
         let (reply_tx, reply_rx) = oneshot::channel();
@@ -249,6 +364,15 @@ async fn run_permission_handler<C>(
             .filter(|s| !s.is_empty())
             .unwrap_or(&fallback)
             .replace('\0', "");
+        // Extract command binary for patterned tools (e.g. "bash" -> "git", "cargo").
+        let cmd_binary = req
+            .tool_call
+            .fields
+            .raw_input
+            .as_ref()
+            .and_then(|v| v.get("command"))
+            .and_then(|c| c.as_str())
+            .map(extract_command_binary_owned);
         let session_id = &req.session_id;
         let session_cache_key = format!("{session_id}\0{tool_name}");
         let perm_req = acp::RequestPermissionRequest::new(req.session_id, req.tool_call, options);
@@ -270,27 +394,17 @@ async fn run_permission_handler<C>(
                         "reject_always" => Some(PermissionDecision::RejectAlways),
                         _ => None,
                     };
-                    if let Some(d) = decision {
-                        let mut persisted = PersistedPermissions::default();
-                        if let Ok(mut guard) = cache.write() {
-                            // Insert session-scoped key for fast in-process lookup.
-                            guard.insert(session_cache_key, d);
-                            // Also insert tool-name-only key so other sessions benefit.
+                    if let (Some(d), Ok(mut guard)) = (decision, cache.write()) {
+                        // Insert session-scoped key for fast in-process lookup.
+                        guard.insert(session_cache_key, d);
+                        // For patterned tools, cache at binary granularity.
+                        if let Some(ref bin) = cmd_binary {
+                            guard.insert(format!("{tool_name}\x01{bin}"), d);
+                        } else {
+                            // Simple tool — cache at tool-name level.
                             guard.insert(tool_name.clone(), d);
-                            // Rebuild persisted map from all tool-name-only entries.
-                            for (k, v) in guard.iter() {
-                                if !k.contains('\0') {
-                                    persisted.tools.insert(
-                                        k.clone(),
-                                        match v {
-                                            PermissionDecision::AllowAlways => "allow".to_owned(),
-                                            PermissionDecision::RejectAlways => "reject".to_owned(),
-                                        },
-                                    );
-                                }
-                            }
                         }
-                        save_persisted(&permission_file, &persisted);
+                        save_persisted(&permission_file, &rebuild_persisted(&guard));
                     }
 
                     Ok(allowed)
@@ -303,6 +417,52 @@ async fn run_permission_handler<C>(
 
         req.reply.send(reply).ok();
     }
+}
+
+/// Rebuild the persisted TOML structure from the in-memory cache.
+///
+/// Keys without `\0` (session separator) and without `\x01` (pattern separator) are simple tool
+/// entries. Keys with `\x01` are per-binary patterns: `"tool_name\x01binary"`.
+fn rebuild_persisted(guard: &HashMap<String, PermissionDecision>) -> PersistedPermissions {
+    let mut result: PersistedPermissions = PersistedPermissions::default();
+    for (k, v) in guard {
+        // Skip session-scoped keys (contain '\0').
+        if k.contains('\0') {
+            continue;
+        }
+        let decision_str = match v {
+            PermissionDecision::AllowAlways => "allow",
+            PermissionDecision::RejectAlways => "deny",
+        };
+        if let Some((tool, binary)) = k.split_once('\x01') {
+            // Per-binary pattern key.
+            match result
+                .tools
+                .entry(tool.to_owned())
+                .or_insert_with(|| ToolPermission::Patterned {
+                    default: None,
+                    patterns: HashMap::new(),
+                }) {
+                ToolPermission::Patterned { patterns, .. } => {
+                    patterns.insert(binary.to_owned(), decision_str.to_owned());
+                }
+                // Upgrade Simple to Patterned if there's a collision (shouldn't happen).
+                entry @ ToolPermission::Simple(_) => {
+                    *entry = ToolPermission::Patterned {
+                        default: None,
+                        patterns: HashMap::from([(binary.to_owned(), decision_str.to_owned())]),
+                    };
+                }
+            }
+        } else {
+            // Simple tool-level key — only insert if not already Patterned.
+            result
+                .tools
+                .entry(k.clone())
+                .or_insert_with(|| ToolPermission::Simple(decision_str.to_owned()));
+        }
+    }
+    result
 }
 
 #[cfg(test)]
@@ -511,24 +671,26 @@ mod tests {
 
         // Write persisted file manually.
         let mut perms = PersistedPermissions::default();
-        perms
-            .tools
-            .insert("shell_execute".to_owned(), "allow".to_owned());
-        perms
-            .tools
-            .insert("web_scrape".to_owned(), "reject".to_owned());
+        perms.tools.insert(
+            "shell_execute".to_owned(),
+            ToolPermission::Simple("allow".to_owned()),
+        );
+        perms.tools.insert(
+            "web_scrape".to_owned(),
+            ToolPermission::Simple("reject".to_owned()),
+        );
         save_persisted(&file, &perms);
 
         // Load and verify.
         let loaded = load_persisted(&file);
-        assert_eq!(
-            loaded.tools.get("shell_execute").map(String::as_str),
-            Some("allow")
-        );
-        assert_eq!(
-            loaded.tools.get("web_scrape").map(String::as_str),
-            Some("reject")
-        );
+        assert!(matches!(
+            loaded.tools.get("shell_execute"),
+            Some(ToolPermission::Simple(s)) if s == "allow"
+        ));
+        assert!(matches!(
+            loaded.tools.get("web_scrape"),
+            Some(ToolPermission::Simple(s)) if s == "reject"
+        ));
     }
 
     #[test]
@@ -638,9 +800,10 @@ mod tests {
 
         // Pre-populate permission file.
         let mut perms = PersistedPermissions::default();
-        perms
-            .tools
-            .insert("tc-persisted".to_owned(), "allow".to_owned());
+        perms.tools.insert(
+            "tc-persisted".to_owned(),
+            ToolPermission::Simple("allow".to_owned()),
+        );
         save_persisted(&file, &perms);
 
         let local = tokio::task::LocalSet::new();
@@ -656,6 +819,217 @@ mod tests {
                 // Should be allowed from persisted cache, not forwarded to RejectClient.
                 let result = gate.check_permission(sid, tc).await.unwrap();
                 assert!(result);
+            })
+            .await;
+    }
+
+    fn make_tool_call_with_command(id: &str, title: &str, command: &str) -> acp::ToolCallUpdate {
+        let fields = acp::ToolCallUpdateFields::new()
+            .title(title.to_owned())
+            .raw_input(serde_json::json!({ "command": command }));
+        acp::ToolCallUpdate::new(id.to_owned(), fields)
+    }
+
+    #[test]
+    fn patterned_permission_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("acp-permissions.toml");
+
+        let mut patterns = HashMap::new();
+        patterns.insert("git".to_owned(), "allow".to_owned());
+        patterns.insert("rm".to_owned(), "deny".to_owned());
+        let mut perms = PersistedPermissions::default();
+        perms.tools.insert(
+            "bash".to_owned(),
+            ToolPermission::Patterned {
+                default: Some("ask".to_owned()),
+                patterns,
+            },
+        );
+        save_persisted(&file, &perms);
+
+        let loaded = load_persisted(&file);
+        match loaded.tools.get("bash") {
+            Some(ToolPermission::Patterned { patterns, default }) => {
+                assert_eq!(patterns.get("git").map(String::as_str), Some("allow"));
+                assert_eq!(patterns.get("rm").map(String::as_str), Some("deny"));
+                assert_eq!(default.as_deref(), Some("ask"));
+            }
+            other => panic!("expected Patterned, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn per_binary_pattern_allow_is_cached() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("acp-permissions.toml");
+
+        // Pre-populate: bash.git = allow
+        let mut patterns = HashMap::new();
+        patterns.insert("git".to_owned(), "allow".to_owned());
+        let mut perms = PersistedPermissions::default();
+        perms.tools.insert(
+            "git".to_owned(),
+            ToolPermission::Patterned {
+                default: None,
+                patterns,
+            },
+        );
+        save_persisted(&file, &perms);
+
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let conn = Rc::new(AlwaysRejectClient);
+                let (gate, handler) = AcpPermissionGate::new(conn, Some(file));
+                tokio::task::spawn_local(handler);
+
+                let sid = acp::SessionId::new("s1");
+                let tc = make_tool_call_with_command("tc1", "git", "git status");
+                // Should be allowed from pattern cache.
+                assert!(gate.check_permission(sid, tc).await.unwrap());
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn per_binary_pattern_deny_short_circuits() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("acp-permissions.toml");
+
+        // Pre-populate: bash.rm = deny
+        let mut patterns = HashMap::new();
+        patterns.insert("rm".to_owned(), "deny".to_owned());
+        let mut perms = PersistedPermissions::default();
+        perms.tools.insert(
+            "rm".to_owned(),
+            ToolPermission::Patterned {
+                default: None,
+                patterns,
+            },
+        );
+        save_persisted(&file, &perms);
+
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                // AlwaysAllowClient would allow if asked — but pattern must short-circuit.
+                let conn = Rc::new(AllowAlwaysClient);
+                let (gate, handler) = AcpPermissionGate::new(conn, Some(file));
+                tokio::task::spawn_local(handler);
+
+                let sid = acp::SessionId::new("s1");
+                let tc = make_tool_call_with_command("tc1", "rm", "rm -rf /tmp/test");
+                // Should be rejected from pattern cache without asking IDE.
+                assert!(!gate.check_permission(sid, tc).await.unwrap());
+            })
+            .await;
+    }
+
+    #[test]
+    fn extract_command_binary_owned_basic() {
+        assert_eq!(extract_command_binary_owned("git status"), "git");
+        assert_eq!(extract_command_binary_owned("cargo build"), "cargo");
+        assert_eq!(extract_command_binary_owned("env FOO=bar git log"), "git");
+        assert_eq!(extract_command_binary_owned("/usr/bin/git push"), "git");
+        assert_eq!(extract_command_binary_owned("FOO=bar baz"), "baz");
+        assert_eq!(extract_command_binary_owned(""), "bash");
+    }
+
+    #[tokio::test]
+    async fn allow_always_for_git_does_not_auto_allow_rm() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                // AllowAlwaysClient always responds allow_always.
+                let conn = Rc::new(AllowAlwaysClient);
+                let (gate, handler) = AcpPermissionGate::new(conn, None);
+                tokio::task::spawn_local(handler);
+
+                let sid = acp::SessionId::new("s1");
+                // First call: "git" gets AllowAlways cached.
+                let tc_git = make_tool_call_with_command("tc1", "git", "git status");
+                assert!(gate.check_permission(sid.clone(), tc_git).await.unwrap());
+
+                // Now check "rm" — different binary, must NOT inherit git's AllowAlways.
+                // AllowAlwaysClient will be asked and return allow_always, but the point is
+                // the cache key is "rm", not "git". We verify by using a different gate
+                // backed by RejectClient for "rm".
+                let conn2 = Rc::new(AlwaysRejectClient);
+                let (gate2, handler2) = AcpPermissionGate::new(conn2, None);
+                tokio::task::spawn_local(handler2);
+
+                let sid2 = acp::SessionId::new("s2");
+                let tc_rm = make_tool_call_with_command("tc2", "rm", "rm /tmp/test");
+                // gate2 has no cache for "rm" — falls through to AlwaysRejectClient.
+                assert!(!gate2.check_permission(sid2, tc_rm).await.unwrap());
+            })
+            .await;
+    }
+
+    #[test]
+    fn rebuild_persisted_simple_deny_not_lost_when_patterned_present() {
+        // SEC-ACP-S1: a Simple deny for "web_scrape" must survive rebuild_persisted
+        // even when a Patterned entry for "bash" is also in the cache.
+        let mut cache: HashMap<String, PermissionDecision> = HashMap::new();
+        cache.insert("web_scrape".to_owned(), PermissionDecision::RejectAlways);
+        cache.insert("bash\x01git".to_owned(), PermissionDecision::AllowAlways);
+        cache.insert("bash\x01rm".to_owned(), PermissionDecision::RejectAlways);
+
+        let persisted = rebuild_persisted(&cache);
+
+        // Simple deny for web_scrape must be present.
+        assert!(
+            matches!(persisted.tools.get("web_scrape"), Some(ToolPermission::Simple(s)) if s == "deny"),
+            "Simple deny for web_scrape was lost: {:?}",
+            persisted.tools
+        );
+        // Patterned entry for bash must be present.
+        match persisted.tools.get("bash") {
+            Some(ToolPermission::Patterned { patterns, .. }) => {
+                assert_eq!(patterns.get("git").map(String::as_str), Some("allow"));
+                assert_eq!(patterns.get("rm").map(String::as_str), Some("deny"));
+            }
+            other => panic!("expected Patterned for bash, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn within_gate_allow_git_does_not_allow_rm() {
+        // GAP-002: stronger isolation proof — same gate, one session, git allowed but rm rejected.
+        // We use AllowAlwaysClient for git's first call, then RejectAlwaysClient via a second gate.
+        // The key check: AllowAlways cached for "git" must NOT affect "rm" in the SAME gate
+        // instance backed by a new client.
+        //
+        // Implementation: we use one gate backed by AllowAlwaysClient to cache "git",
+        // then a second gate backed by RejectAlwaysClient to prove "rm" is NOT cached.
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let dir = tempfile::tempdir().unwrap();
+                let perm_file = dir.path().join("perms.toml");
+
+                // Gate 1: allows git always — writes to perm_file.
+                let conn1 = Rc::new(AllowAlwaysClient);
+                let (gate1, handler1) = AcpPermissionGate::new(conn1, Some(perm_file.clone()));
+                tokio::task::spawn_local(handler1);
+
+                let sid = acp::SessionId::new("s1");
+                let tc_git = make_tool_call_with_command("tc1", "git", "git status");
+                assert!(gate1.check_permission(sid.clone(), tc_git).await.unwrap());
+
+                // Drop gate1 to ensure perm_file is written. Give it a tick.
+                tokio::task::yield_now().await;
+
+                // Gate 2: backed by RejectAlwaysClient — rm must NOT be in the loaded perms.
+                let conn2 = Rc::new(RejectAlwaysClient);
+                let (gate2, handler2) = AcpPermissionGate::new(conn2, Some(perm_file));
+                tokio::task::spawn_local(handler2);
+
+                let sid2 = acp::SessionId::new("s2");
+                let tc_rm = make_tool_call_with_command("tc2", "rm", "rm /tmp/test");
+                // rm was never allowed — gate2 must ask RejectAlwaysClient which rejects.
+                assert!(!gate2.check_permission(sid2, tc_rm).await.unwrap());
             })
             .await;
     }

--- a/crates/zeph-acp/src/terminal.rs
+++ b/crates/zeph-acp/src/terminal.rs
@@ -20,6 +20,40 @@ use crate::{error::AcpError, permission::AcpPermissionGate};
 
 const KILL_GRACE_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Transparent prefixes that wrap another command without changing its semantics.
+const TRANSPARENT_PREFIXES: &[&str] = &["env", "command", "exec", "nice", "nohup", "time"];
+
+/// Extract the effective command binary name from a shell command string.
+///
+/// Iteratively skips transparent prefixes (`env`, `command`, `exec`, etc.) and
+/// env-var assignments (`FOO=bar`) to reach the real binary. Falls back to `"bash"`
+/// if the command is empty.
+fn extract_command_binary(command: &str) -> &str {
+    // Split into tokens and skip leading env-var assignments and transparent prefixes.
+    let mut tokens = command.split_whitespace().peekable();
+    loop {
+        match tokens.peek() {
+            None => return "bash",
+            Some(tok) => {
+                // Skip env-var assignments.
+                if tok.contains('=') {
+                    tokens.next();
+                    continue;
+                }
+                // Skip transparent prefix commands.
+                let base = tok.rsplit('/').next().unwrap_or(tok);
+                if TRANSPARENT_PREFIXES.contains(&base) {
+                    tokens.next();
+                    continue;
+                }
+                // First non-prefix, non-assignment token is the binary.
+                let binary = tok.rsplit('/').next().unwrap_or(tok);
+                return binary;
+            }
+        }
+    }
+}
+
 struct ShellResult {
     output: String,
     exit_code: Option<u32>,
@@ -171,11 +205,38 @@ impl zeph_tools::ToolExecutor for AcpShellExecutor {
         let params: BashParams = deserialize_params(&call.params)?;
         let cwd = params.cwd.map(PathBuf::from);
 
+        let blocklist: Vec<String> = zeph_tools::DEFAULT_BLOCKED_COMMANDS
+            .iter()
+            .map(|s| (*s).to_owned())
+            .collect();
+
+        // Blocklist check — reject dangerous commands before hitting the permission gate.
+        if let Some(pattern) = zeph_tools::check_blocklist(&params.command, &blocklist) {
+            return Err(ToolError::Blocked { command: pattern });
+        }
+        // Also check args when the command is a shell interpreter (e.g. bash -c "rm -rf /").
+        // This prevents args-field bypass: { command: "bash", args: ["-c", "blocked cmd"] }.
+        if let Some(script) = zeph_tools::effective_shell_command(&params.command, &params.args)
+            && let Some(pattern) = zeph_tools::check_blocklist(script, &blocklist)
+        {
+            return Err(ToolError::Blocked { command: pattern });
+        }
+
+        if self.permission_gate.is_none() {
+            tracing::warn!(
+                "AcpShellExecutor has no permission gate — only blocklist applies. \
+                 Do not use in production without a permission gate."
+            );
+        }
+
         if let Some(gate) = &self.permission_gate {
+            // Use the command binary as the cache key, not the tool_id ("bash").
+            // This makes "Allow always" apply per binary (git, cargo, etc.).
+            let cmd_binary = extract_command_binary(&params.command);
             let fields = acp::ToolCallUpdateFields::new()
-                .title(call.tool_id.clone())
+                .title(cmd_binary.to_owned())
                 .raw_input(serde_json::json!({ "command": params.command }));
-            let tool_call = acp::ToolCallUpdate::new(call.tool_id.clone(), fields);
+            let tool_call = acp::ToolCallUpdate::new(cmd_binary.to_owned(), fields);
             let allowed = gate
                 .check_permission(self.session_id.clone(), tool_call)
                 .await
@@ -755,5 +816,162 @@ mod tests {
                 assert!(got_exit, "expected terminal_exit notification");
             })
             .await;
+    }
+
+    #[test]
+    fn extract_command_binary_bare() {
+        assert_eq!(extract_command_binary("git status"), "git");
+        assert_eq!(extract_command_binary("cargo build --release"), "cargo");
+        assert_eq!(extract_command_binary("  cat file.txt  "), "cat");
+    }
+
+    #[test]
+    fn extract_command_binary_env_prefix() {
+        assert_eq!(extract_command_binary("env FOO=bar git status"), "git");
+        assert_eq!(extract_command_binary("command git push"), "git");
+        assert_eq!(extract_command_binary("exec cargo test"), "cargo");
+    }
+
+    #[test]
+    fn extract_command_binary_env_var_assignments() {
+        assert_eq!(extract_command_binary("FOO=bar BAZ=qux git log"), "git");
+    }
+
+    #[test]
+    fn extract_command_binary_path() {
+        assert_eq!(extract_command_binary("/usr/bin/git status"), "git");
+        assert_eq!(
+            extract_command_binary("/usr/local/bin/cargo build"),
+            "cargo"
+        );
+    }
+
+    #[test]
+    fn extract_command_binary_empty_fallback() {
+        assert_eq!(extract_command_binary(""), "bash");
+        assert_eq!(extract_command_binary("   "), "bash");
+    }
+
+    #[tokio::test]
+    async fn blocklist_blocked_before_permission_gate() {
+        // rm -rf / must be blocked before the permission gate is consulted.
+        // FakeTerminalClient panics if create_terminal is called — so if
+        // we reach the terminal, the test fails.
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let conn = Rc::new(FakeTerminalClient);
+                let sid = acp::SessionId::new("s1");
+                // No permission gate — blocklist runs independently.
+                let (exec, handler) = AcpShellExecutor::new(conn, sid, None, 120);
+                tokio::task::spawn_local(handler);
+
+                let mut params = serde_json::Map::new();
+                params.insert("command".to_owned(), serde_json::json!("rm -rf /"));
+                let call = ToolCall {
+                    tool_id: "bash".to_owned(),
+                    params,
+                };
+
+                let err = exec.execute_tool_call(&call).await.unwrap_err();
+                assert!(matches!(err, ToolError::Blocked { .. }));
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn blocklist_sudo_blocked() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let conn = Rc::new(FakeTerminalClient);
+                let sid = acp::SessionId::new("s1");
+                let (exec, handler) = AcpShellExecutor::new(conn, sid, None, 120);
+                tokio::task::spawn_local(handler);
+
+                let mut params = serde_json::Map::new();
+                params.insert(
+                    "command".to_owned(),
+                    serde_json::json!("sudo apt install vim"),
+                );
+                let call = ToolCall {
+                    tool_id: "bash".to_owned(),
+                    params,
+                };
+
+                let err = exec.execute_tool_call(&call).await.unwrap_err();
+                assert!(matches!(err, ToolError::Blocked { .. }));
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn args_field_bypass_blocked_for_shell_interpreter() {
+        // SEC-ACP-C2: { command: "bash", args: ["-c", "rm -rf /"] } must be blocked.
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let conn = Rc::new(FakeTerminalClient);
+                let sid = acp::SessionId::new("s1");
+                let (exec, handler) = AcpShellExecutor::new(conn, sid, None, 120);
+                tokio::task::spawn_local(handler);
+
+                let mut params = serde_json::Map::new();
+                params.insert("command".to_owned(), serde_json::json!("bash"));
+                params.insert(
+                    "args".to_owned(),
+                    serde_json::json!(["-c", "sudo rm -rf /"]),
+                );
+                let call = ToolCall {
+                    tool_id: "bash".to_owned(),
+                    params,
+                };
+
+                let err = exec.execute_tool_call(&call).await.unwrap_err();
+                assert!(matches!(err, ToolError::Blocked { .. }));
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn args_field_bypass_sh_minus_c_blocked() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let conn = Rc::new(FakeTerminalClient);
+                let sid = acp::SessionId::new("s1");
+                let (exec, handler) = AcpShellExecutor::new(conn, sid, None, 120);
+                tokio::task::spawn_local(handler);
+
+                let mut params = serde_json::Map::new();
+                params.insert("command".to_owned(), serde_json::json!("sh"));
+                params.insert(
+                    "args".to_owned(),
+                    serde_json::json!(["-c", "shutdown -h now"]),
+                );
+                let call = ToolCall {
+                    tool_id: "bash".to_owned(),
+                    params,
+                };
+
+                let err = exec.execute_tool_call(&call).await.unwrap_err();
+                assert!(matches!(err, ToolError::Blocked { .. }));
+            })
+            .await;
+    }
+
+    #[test]
+    fn extract_command_binary_chained_transparent_prefixes() {
+        // SEC-ACP-I1: "env command exec sudo rm" -> "sudo", not "command"
+        assert_eq!(
+            extract_command_binary("env command exec sudo rm -rf /"),
+            "sudo"
+        );
+        assert_eq!(extract_command_binary("nice nohup time git status"), "git");
+    }
+
+    #[test]
+    fn extract_command_binary_env_var_then_prefix_then_binary() {
+        assert_eq!(extract_command_binary("FOO=bar env BAZ=qux git log"), "git");
     }
 }

--- a/crates/zeph-tools/src/lib.rs
+++ b/crates/zeph-tools/src/lib.rs
@@ -37,6 +37,9 @@ pub use permissions::{
 };
 pub use registry::ToolRegistry;
 pub use scrape::WebScrapeExecutor;
-pub use shell::ShellExecutor;
+pub use shell::{
+    DEFAULT_BLOCKED_COMMANDS, SHELL_INTERPRETERS, ShellExecutor, check_blocklist,
+    effective_shell_command,
+};
 pub use trust_gate::TrustGateExecutor;
 pub use trust_level::TrustLevel;

--- a/crates/zeph-tools/src/shell.rs
+++ b/crates/zeph-tools/src/shell.rs
@@ -23,6 +23,64 @@ const DEFAULT_BLOCKED: &[&str] = &[
     "reboot", "halt",
 ];
 
+/// The default list of blocked command patterns used by [`ShellExecutor`].
+///
+/// Exposed so other executors (e.g. `AcpShellExecutor`) can reuse the same
+/// blocklist without duplicating it.
+pub const DEFAULT_BLOCKED_COMMANDS: &[&str] = DEFAULT_BLOCKED;
+
+/// Shell interpreters that may execute arbitrary code via `-c` or positional args.
+pub const SHELL_INTERPRETERS: &[&str] =
+    &["bash", "sh", "zsh", "fish", "dash", "ksh", "csh", "tcsh"];
+
+/// Subshell metacharacters that could embed a blocked command inside a benign wrapper.
+/// Commands containing these sequences are rejected outright because safe static
+/// analysis of nested shell evaluation is not feasible.
+const SUBSHELL_METACHARS: &[&str] = &["$(", "`"];
+
+/// Check if `command` matches any pattern in `blocklist`.
+///
+/// Returns the matched pattern string if the command is blocked, `None` otherwise.
+/// The check is case-insensitive and handles common shell escape sequences.
+///
+/// Commands containing subshell metacharacters (`$(` or `` ` ``) are always
+/// blocked because nested evaluation cannot be safely analysed statically.
+#[must_use]
+pub fn check_blocklist(command: &str, blocklist: &[String]) -> Option<String> {
+    let lower = command.to_lowercase();
+    // Reject commands that embed subshell constructs to prevent blocklist bypass.
+    for meta in SUBSHELL_METACHARS {
+        if lower.contains(meta) {
+            return Some((*meta).to_owned());
+        }
+    }
+    let cleaned = strip_shell_escapes(&lower);
+    let commands = tokenize_commands(&cleaned);
+    for blocked in blocklist {
+        for cmd_tokens in &commands {
+            if tokens_match_pattern(cmd_tokens, blocked) {
+                return Some(blocked.clone());
+            }
+        }
+    }
+    None
+}
+
+/// Build the effective command string for blocklist evaluation when the binary is a
+/// shell interpreter (bash, sh, zsh, etc.) and args contains a `-c` script.
+///
+/// Returns `None` if the args do not follow the `-c <script>` pattern.
+#[must_use]
+pub fn effective_shell_command<'a>(binary: &str, args: &'a [String]) -> Option<&'a str> {
+    let base = binary.rsplit('/').next().unwrap_or(binary);
+    if !SHELL_INTERPRETERS.contains(&base) {
+        return None;
+    }
+    // Find "-c" and return the next element as the script to check.
+    let pos = args.iter().position(|a| a == "-c")?;
+    args.get(pos + 1).map(String::as_str)
+}
+
 const NETWORK_COMMANDS: &[&str] = &["curl", "wget", "nc ", "ncat", "netcat"];
 
 #[derive(Deserialize, JsonSchema)]
@@ -457,7 +515,7 @@ impl ToolExecutor for ShellExecutor {
 /// Strip shell escape sequences that could bypass command detection.
 /// Handles: backslash insertion (`su\do` -> `sudo`), `$'\xNN'` hex and `$'\NNN'` octal
 /// escapes, adjacent quoted segments (`"su""do"` -> `sudo`), backslash-newline continuations.
-fn strip_shell_escapes(input: &str) -> String {
+pub(crate) fn strip_shell_escapes(input: &str) -> String {
     let mut out = String::with_capacity(input.len());
     let bytes = input.as_bytes();
     let mut i = 0;
@@ -548,7 +606,7 @@ fn strip_shell_escapes(input: &str) -> String {
 
 /// Split normalized shell code into sub-commands on `|`, `||`, `&&`, `;`, `\n`.
 /// Returns list of sub-commands, each as `Vec<String>` of tokens.
-fn tokenize_commands(normalized: &str) -> Vec<Vec<String>> {
+pub(crate) fn tokenize_commands(normalized: &str) -> Vec<Vec<String>> {
     // Replace two-char operators with a single separator, then split on single-char separators
     let replaced = normalized.replace("||", "\n").replace("&&", "\n");
     replaced
@@ -577,7 +635,7 @@ fn cmd_basename(tok: &str) -> &str {
 /// - Absolute paths (`/usr/bin/sudo rm` -> basename `sudo` is checked)
 /// - Dot-suffixed variants (`mkfs` matches `mkfs.ext4`)
 /// - Multi-word patterns (`rm -rf /` joined prefix check)
-fn tokens_match_pattern(tokens: &[String], pattern: &str) -> bool {
+pub(crate) fn tokens_match_pattern(tokens: &[String], pattern: &str) -> bool {
     if tokens.is_empty() || pattern.is_empty() {
         return false;
     }
@@ -2007,5 +2065,94 @@ mod tests {
         let executor = ShellExecutor::new(&default_config());
         // Known limitation: bash receives payload via stdin; inner command substitution is opaque.
         assert!(executor.find_blocked_command("bash <<< $(id)").is_none());
+    }
+
+    // --- check_blocklist direct tests (GAP-001) ---
+
+    fn default_blocklist() -> Vec<String> {
+        DEFAULT_BLOCKED.iter().map(|s| (*s).to_owned()).collect()
+    }
+
+    #[test]
+    fn check_blocklist_blocks_rm_rf_root() {
+        let bl = default_blocklist();
+        assert!(check_blocklist("rm -rf /", &bl).is_some());
+    }
+
+    #[test]
+    fn check_blocklist_blocks_sudo() {
+        let bl = default_blocklist();
+        assert!(check_blocklist("sudo apt install vim", &bl).is_some());
+    }
+
+    #[test]
+    fn check_blocklist_allows_safe_commands() {
+        let bl = default_blocklist();
+        assert!(check_blocklist("ls -la", &bl).is_none());
+        assert!(check_blocklist("echo hello world", &bl).is_none());
+        assert!(check_blocklist("git status", &bl).is_none());
+        assert!(check_blocklist("cargo build --release", &bl).is_none());
+    }
+
+    #[test]
+    fn check_blocklist_blocks_subshell_dollar_paren() {
+        let bl = default_blocklist();
+        // Subshell $(sudo ...) must be rejected even if outer command is benign.
+        assert!(check_blocklist("echo $(sudo id)", &bl).is_some());
+        assert!(check_blocklist("echo $(rm -rf /tmp)", &bl).is_some());
+    }
+
+    #[test]
+    fn check_blocklist_blocks_subshell_backtick() {
+        let bl = default_blocklist();
+        assert!(check_blocklist("cat `sudo cat /etc/shadow`", &bl).is_some());
+    }
+
+    #[test]
+    fn check_blocklist_blocks_mkfs() {
+        let bl = default_blocklist();
+        assert!(check_blocklist("mkfs.ext4 /dev/sda1", &bl).is_some());
+    }
+
+    #[test]
+    fn check_blocklist_blocks_shutdown() {
+        let bl = default_blocklist();
+        assert!(check_blocklist("shutdown -h now", &bl).is_some());
+    }
+
+    // --- effective_shell_command tests ---
+
+    #[test]
+    fn effective_shell_command_bash_minus_c() {
+        let args = vec!["-c".to_owned(), "rm -rf /".to_owned()];
+        assert_eq!(effective_shell_command("bash", &args), Some("rm -rf /"));
+    }
+
+    #[test]
+    fn effective_shell_command_sh_minus_c() {
+        let args = vec!["-c".to_owned(), "sudo ls".to_owned()];
+        assert_eq!(effective_shell_command("sh", &args), Some("sudo ls"));
+    }
+
+    #[test]
+    fn effective_shell_command_non_shell_returns_none() {
+        let args = vec!["-c".to_owned(), "rm -rf /".to_owned()];
+        assert_eq!(effective_shell_command("git", &args), None);
+        assert_eq!(effective_shell_command("cargo", &args), None);
+    }
+
+    #[test]
+    fn effective_shell_command_no_minus_c_returns_none() {
+        let args = vec!["script.sh".to_owned()];
+        assert_eq!(effective_shell_command("bash", &args), None);
+    }
+
+    #[test]
+    fn effective_shell_command_full_path_shell() {
+        let args = vec!["-c".to_owned(), "sudo rm".to_owned()];
+        assert_eq!(
+            effective_shell_command("/usr/bin/bash", &args),
+            Some("sudo rm")
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes critical security bugs in `AcpPermissionGate` and `AcpShellExecutor` found during Zed IDE integration audit. Implements pattern-based permission persistence and deny-always tier.

- **#1043**: `AcpPermissionGate` cached decisions under tool id `"bash"`, so a single "Allow always" click auto-approved all subsequent shell commands. Fixed by keying the cache on the resolved binary name (`git`, `cargo`, `cat`) via `extract_command_binary()`.
- **#1044**: `AcpShellExecutor` forwarded commands to the IDE terminal without applying the blocklist that `ShellExecutor` enforces locally. Extracted `check_blocklist()` to `zeph-tools` pub API and call it before the permission gate. Also blocks subshell injection (`$(...)`, backticks) and `bash -c <cmd>` args-field bypass via `effective_shell_command()`.
- **#1045**: Permission persistence now supports per-binary TOML patterns: `[tools.bash.patterns] git = "allow"`. Cache lookup resolves binary name from raw command before checking patterns.
- **#1046**: `deny` pattern entries wire to `RejectAlways` fast-path — blocked without IDE round-trip.

## Test plan

- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo nextest run --workspace --lib --bins`: 3005 passed (675 → 705 in changed crates, +30 new tests)
- [x] New tests: subshell bypass, args-field bypass, chained transparent prefixes, per-binary cache isolation, deny fast-path, TOML round-trip

## Follow-up

- REV-I1: deduplicate `TRANSPARENT_PREFIXES` / `extract_command_binary` between `terminal.rs` and `permission.rs`
- REV-S1/S2: `check_blocklist` signature and `LazyLock` optimization
- SEC-ACP-I2: unicode homoglyph handling (low priority)

Closes #1043, #1044
Implements #1045, #1046
Part of epic #1042