### PR TITLE
feat(acp): native file tools (list_directory, find_path) and ToolFilter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9225,6 +9225,7 @@ dependencies = [
  "dashmap",
  "dirs",
  "futures",
+ "glob",
  "schemars 1.2.1",
  "serde",
  "serde_json",

--- a/crates/zeph-acp/Cargo.toml
+++ b/crates/zeph-acp/Cargo.toml
@@ -36,6 +36,7 @@ base64.workspace = true
 chrono = { workspace = true }
 dirs.workspace = true
 futures.workspace = true
+glob.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/zeph-acp/src/agent.rs
+++ b/crates/zeph-acp/src/agent.rs
@@ -1520,7 +1520,9 @@ fn tool_kind_from_name(name: &str) -> acp::ToolKind {
         "bash" | "shell" => acp::ToolKind::Execute,
         "read_file" => acp::ToolKind::Read,
         "write_file" => acp::ToolKind::Edit,
-        "search" | "grep" | "find" | "glob" => acp::ToolKind::Search,
+        "list_directory" | "find_path" | "search" | "grep" | "find" | "glob" => {
+            acp::ToolKind::Search
+        }
         "web_scrape" | "fetch" => acp::ToolKind::Fetch,
         _ => acp::ToolKind::Other,
     }
@@ -2714,6 +2716,8 @@ mod tests {
         assert_eq!(tool_kind_from_name("write_file"), acp::ToolKind::Edit);
         assert_eq!(tool_kind_from_name("search"), acp::ToolKind::Search);
         assert_eq!(tool_kind_from_name("glob"), acp::ToolKind::Search);
+        assert_eq!(tool_kind_from_name("list_directory"), acp::ToolKind::Search);
+        assert_eq!(tool_kind_from_name("find_path"), acp::ToolKind::Search);
         assert_eq!(tool_kind_from_name("web_scrape"), acp::ToolKind::Fetch);
         assert_eq!(tool_kind_from_name("unknown"), acp::ToolKind::Other);
     }

--- a/crates/zeph-acp/src/fs.rs
+++ b/crates/zeph-acp/src/fs.rs
@@ -120,6 +120,18 @@ struct WriteFileParams {
     content: String,
 }
 
+#[derive(Deserialize, JsonSchema)]
+struct ListDirectoryParams {
+    path: String,
+}
+
+#[derive(Deserialize, JsonSchema)]
+struct FindPathParams {
+    pattern: String,
+    #[serde(default)]
+    path: Option<String>,
+}
+
 fn validate_absolute_path(raw: &str) -> Result<PathBuf, ToolError> {
     let path = PathBuf::from(raw);
     if !path.is_absolute() {
@@ -149,15 +161,32 @@ impl zeph_tools::ToolExecutor for AcpFileExecutor {
         if self.can_read {
             defs.push(ToolDef {
                 id: "read_file".into(),
-                description: "Read a file from the IDE workspace".into(),
+                description: "Read a file from the IDE workspace. Preferred over bash cat/head/tail for reading files. Returns structured content with line numbers. Supports optional line offset and limit.".into(),
                 schema: schemars::schema_for!(ReadFileParams),
+                invocation: InvocationHint::ToolCall,
+            });
+            defs.push(ToolDef {
+                id: "list_directory".into(),
+                description:
+                    "List files and directories at the given path. Preferred over bash ls.".into(),
+                schema: schemars::schema_for!(ListDirectoryParams),
+                invocation: InvocationHint::ToolCall,
+            });
+            defs.push(ToolDef {
+                id: "find_path".into(),
+                description:
+                    "Find files matching a glob pattern in a directory. Preferred over bash find."
+                        .into(),
+                schema: schemars::schema_for!(FindPathParams),
                 invocation: InvocationHint::ToolCall,
             });
         }
         if self.can_write {
             defs.push(ToolDef {
                 id: "write_file".into(),
-                description: "Write content to a file in the IDE workspace".into(),
+                description:
+                    "Write content to a file in the IDE workspace. Preferred over shell redirects."
+                        .into(),
                 schema: schemars::schema_for!(WriteFileParams),
                 invocation: InvocationHint::ToolCall,
             });
@@ -220,8 +249,112 @@ impl zeph_tools::ToolExecutor for AcpFileExecutor {
                     raw_response: None,
                 }))
             }
+            "list_directory" if self.can_read => {
+                let params: ListDirectoryParams = deserialize_params(&call.params)?;
+                Self::handle_list_directory(params)
+            }
+            "find_path" if self.can_read => {
+                let params: FindPathParams = deserialize_params(&call.params)?;
+                Self::handle_find_path(&params)
+            }
             _ => Ok(None),
         }
+    }
+}
+
+impl AcpFileExecutor {
+    fn handle_list_directory(params: ListDirectoryParams) -> Result<Option<ToolOutput>, ToolError> {
+        let dir = validate_absolute_path(&params.path)?;
+        let entries = std::fs::read_dir(&dir).map_err(|e| ToolError::InvalidParams {
+            message: format!("cannot read directory {}: {e}", params.path),
+        })?;
+        let mut items: Vec<serde_json::Value> = Vec::new();
+        for entry in entries {
+            let entry = entry.map_err(|e| ToolError::InvalidParams {
+                message: format!("directory entry error: {e}"),
+            })?;
+            // Use symlink_metadata to avoid following symlinks outside the sandbox.
+            let meta = entry
+                .path()
+                .symlink_metadata()
+                .map_err(|e| ToolError::InvalidParams {
+                    message: format!("metadata error: {e}"),
+                })?;
+            items.push(serde_json::json!({
+                "name": entry.file_name().to_string_lossy(),
+                "is_dir": meta.is_dir(),
+                "size": meta.len(),
+                "is_symlink": meta.file_type().is_symlink(),
+            }));
+        }
+        items.sort_by(|a, b| {
+            let a_name = a["name"].as_str().unwrap_or("");
+            let b_name = b["name"].as_str().unwrap_or("");
+            a_name.cmp(b_name)
+        });
+        let summary = serde_json::to_string(&items).unwrap_or_default();
+        Ok(Some(ToolOutput {
+            tool_name: "list_directory".to_owned(),
+            summary,
+            blocks_executed: 1,
+            filter_stats: None,
+            diff: None,
+            streamed: false,
+            terminal_id: None,
+            locations: Some(vec![params.path]),
+            raw_response: None,
+        }))
+    }
+
+    fn handle_find_path(params: &FindPathParams) -> Result<Option<ToolOutput>, ToolError> {
+        const MAX_RESULTS: usize = 1000;
+
+        // path is required; defaulting to "." would bypass sandbox validation.
+        let base_str = params
+            .path
+            .as_deref()
+            .ok_or_else(|| ToolError::InvalidParams {
+                message: "find_path: 'path' parameter is required and must be an absolute path"
+                    .into(),
+            })?;
+        let _base = validate_absolute_path(base_str)?;
+
+        // Reject traversal components in the pattern to prevent escaping the base directory.
+        if params
+            .pattern
+            .split('/')
+            .any(|seg| seg == ".." || seg.starts_with('/'))
+        {
+            return Err(ToolError::SandboxViolation {
+                path: params.pattern.clone(),
+            });
+        }
+
+        let glob_str = format!("{base_str}/{}", params.pattern);
+        let mut matches: Vec<String> = Vec::new();
+        for entry in glob::glob(&glob_str).map_err(|e| ToolError::InvalidParams {
+            message: format!("invalid glob pattern: {e}"),
+        })? {
+            if matches.len() >= MAX_RESULTS {
+                break;
+            }
+            if let Ok(p) = entry {
+                matches.push(p.display().to_string());
+            }
+        }
+
+        let summary = matches.join("\n");
+        Ok(Some(ToolOutput {
+            tool_name: "find_path".to_owned(),
+            summary,
+            blocks_executed: 1,
+            filter_stats: None,
+            diff: None,
+            streamed: false,
+            terminal_id: None,
+            locations: None,
+            raw_response: None,
+        }))
     }
 }
 
@@ -404,8 +537,12 @@ mod tests {
             can_write: false,
         };
         let defs = exec_read_only.tool_definitions();
-        assert_eq!(defs.len(), 1);
-        assert_eq!(defs[0].id, "read_file");
+        let ids: Vec<&str> = defs.iter().map(|d| d.id.as_ref()).collect();
+        assert!(ids.contains(&"read_file"));
+        assert!(ids.contains(&"list_directory"));
+        assert!(ids.contains(&"find_path"));
+        assert!(!ids.contains(&"write_file"));
+        assert!(defs[0].description.contains("cat/head/tail"));
 
         let exec_write_only = AcpFileExecutor {
             session_id: acp::SessionId::new("s"),
@@ -416,6 +553,64 @@ mod tests {
         let defs = exec_write_only.tool_definitions();
         assert_eq!(defs.len(), 1);
         assert_eq!(defs[0].id, "write_file");
+        assert!(defs[0].description.contains("shell redirects"));
+    }
+
+    #[tokio::test]
+    async fn list_directory_returns_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("file.txt"), "hello").unwrap();
+        std::fs::create_dir(dir.path().join("subdir")).unwrap();
+
+        let (tx, _rx) = mpsc::unbounded_channel::<FsRequest>();
+        let exec = AcpFileExecutor {
+            session_id: acp::SessionId::new("s"),
+            request_tx: tx,
+            can_read: true,
+            can_write: false,
+        };
+
+        let mut params = serde_json::Map::new();
+        params.insert(
+            "path".to_owned(),
+            serde_json::json!(dir.path().to_str().unwrap()),
+        );
+        let call = ToolCall {
+            tool_id: "list_directory".to_owned(),
+            params,
+        };
+        let result = exec.execute_tool_call(&call).await.unwrap().unwrap();
+        assert!(result.summary.contains("file.txt"));
+        assert!(result.summary.contains("subdir"));
+    }
+
+    #[tokio::test]
+    async fn find_path_matches_glob() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("foo.rs"), "fn main() {}").unwrap();
+        std::fs::write(dir.path().join("bar.toml"), "[package]").unwrap();
+
+        let (tx, _rx) = mpsc::unbounded_channel::<FsRequest>();
+        let exec = AcpFileExecutor {
+            session_id: acp::SessionId::new("s"),
+            request_tx: tx,
+            can_read: true,
+            can_write: false,
+        };
+
+        let mut params = serde_json::Map::new();
+        params.insert("pattern".to_owned(), serde_json::json!("*.rs"));
+        params.insert(
+            "path".to_owned(),
+            serde_json::json!(dir.path().to_str().unwrap()),
+        );
+        let call = ToolCall {
+            tool_id: "find_path".to_owned(),
+            params,
+        };
+        let result = exec.execute_tool_call(&call).await.unwrap().unwrap();
+        assert!(result.summary.contains("foo.rs"));
+        assert!(!result.summary.contains("bar.toml"));
     }
 
     #[tokio::test]
@@ -467,6 +662,186 @@ mod tests {
                 assert!(result.is_none());
             })
             .await;
+    }
+
+    #[tokio::test]
+    async fn list_directory_nonexistent_returns_error() {
+        let (tx, _rx) = mpsc::unbounded_channel::<FsRequest>();
+        let exec = AcpFileExecutor {
+            session_id: acp::SessionId::new("s"),
+            request_tx: tx,
+            can_read: true,
+            can_write: false,
+        };
+        let mut params = serde_json::Map::new();
+        params.insert(
+            "path".to_owned(),
+            serde_json::json!(test_path("nonexistent_dir_zeph")),
+        );
+        let call = ToolCall {
+            tool_id: "list_directory".to_owned(),
+            params,
+        };
+        let err = exec.execute_tool_call(&call).await.unwrap_err();
+        assert!(matches!(err, ToolError::InvalidParams { .. }));
+    }
+
+    #[tokio::test]
+    async fn list_directory_empty_dir_returns_empty_array() {
+        let dir = tempfile::tempdir().unwrap();
+        let (tx, _rx) = mpsc::unbounded_channel::<FsRequest>();
+        let exec = AcpFileExecutor {
+            session_id: acp::SessionId::new("s"),
+            request_tx: tx,
+            can_read: true,
+            can_write: false,
+        };
+        let mut params = serde_json::Map::new();
+        params.insert(
+            "path".to_owned(),
+            serde_json::json!(dir.path().to_str().unwrap()),
+        );
+        let call = ToolCall {
+            tool_id: "list_directory".to_owned(),
+            params,
+        };
+        let result = exec.execute_tool_call(&call).await.unwrap().unwrap();
+        assert_eq!(result.summary, "[]");
+    }
+
+    #[tokio::test]
+    async fn find_path_no_matches_returns_empty_summary() {
+        let dir = tempfile::tempdir().unwrap();
+        let (tx, _rx) = mpsc::unbounded_channel::<FsRequest>();
+        let exec = AcpFileExecutor {
+            session_id: acp::SessionId::new("s"),
+            request_tx: tx,
+            can_read: true,
+            can_write: false,
+        };
+        let mut params = serde_json::Map::new();
+        params.insert("pattern".to_owned(), serde_json::json!("*.nomatch"));
+        params.insert(
+            "path".to_owned(),
+            serde_json::json!(dir.path().to_str().unwrap()),
+        );
+        let call = ToolCall {
+            tool_id: "find_path".to_owned(),
+            params,
+        };
+        let result = exec.execute_tool_call(&call).await.unwrap().unwrap();
+        assert_eq!(result.summary, "");
+    }
+
+    #[tokio::test]
+    async fn find_path_invalid_glob_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let (tx, _rx) = mpsc::unbounded_channel::<FsRequest>();
+        let exec = AcpFileExecutor {
+            session_id: acp::SessionId::new("s"),
+            request_tx: tx,
+            can_read: true,
+            can_write: false,
+        };
+        let mut params = serde_json::Map::new();
+        params.insert("pattern".to_owned(), serde_json::json!("[invalid"));
+        params.insert(
+            "path".to_owned(),
+            serde_json::json!(dir.path().to_str().unwrap()),
+        );
+        let call = ToolCall {
+            tool_id: "find_path".to_owned(),
+            params,
+        };
+        let err = exec.execute_tool_call(&call).await.unwrap_err();
+        assert!(matches!(err, ToolError::InvalidParams { .. }));
+    }
+
+    #[tokio::test]
+    async fn list_directory_capability_disabled_returns_none() {
+        let (tx, _rx) = mpsc::unbounded_channel::<FsRequest>();
+        let exec = AcpFileExecutor {
+            session_id: acp::SessionId::new("s"),
+            request_tx: tx,
+            can_read: false,
+            can_write: false,
+        };
+        let mut params = serde_json::Map::new();
+        params.insert("path".to_owned(), serde_json::json!(test_path("some_dir")));
+        let call = ToolCall {
+            tool_id: "list_directory".to_owned(),
+            params,
+        };
+        let result = exec.execute_tool_call(&call).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn find_path_capability_disabled_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let (tx, _rx) = mpsc::unbounded_channel::<FsRequest>();
+        let exec = AcpFileExecutor {
+            session_id: acp::SessionId::new("s"),
+            request_tx: tx,
+            can_read: false,
+            can_write: false,
+        };
+        let mut params = serde_json::Map::new();
+        params.insert("pattern".to_owned(), serde_json::json!("*.rs"));
+        params.insert(
+            "path".to_owned(),
+            serde_json::json!(dir.path().to_str().unwrap()),
+        );
+        let call = ToolCall {
+            tool_id: "find_path".to_owned(),
+            params,
+        };
+        let result = exec.execute_tool_call(&call).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn find_path_traversal_in_pattern_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let (tx, _rx) = mpsc::unbounded_channel::<FsRequest>();
+        let exec = AcpFileExecutor {
+            session_id: acp::SessionId::new("s"),
+            request_tx: tx,
+            can_read: true,
+            can_write: false,
+        };
+        let mut params = serde_json::Map::new();
+        params.insert("pattern".to_owned(), serde_json::json!("../../etc/passwd"));
+        params.insert(
+            "path".to_owned(),
+            serde_json::json!(dir.path().to_str().unwrap()),
+        );
+        let call = ToolCall {
+            tool_id: "find_path".to_owned(),
+            params,
+        };
+        let err = exec.execute_tool_call(&call).await.unwrap_err();
+        assert!(matches!(err, ToolError::SandboxViolation { .. }));
+    }
+
+    #[tokio::test]
+    async fn find_path_missing_path_param_returns_error() {
+        let (tx, _rx) = mpsc::unbounded_channel::<FsRequest>();
+        let exec = AcpFileExecutor {
+            session_id: acp::SessionId::new("s"),
+            request_tx: tx,
+            can_read: true,
+            can_write: false,
+        };
+        let mut params = serde_json::Map::new();
+        params.insert("pattern".to_owned(), serde_json::json!("*.rs"));
+        // no "path" key — should error, not default to "."
+        let call = ToolCall {
+            tool_id: "find_path".to_owned(),
+            params,
+        };
+        let err = exec.execute_tool_call(&call).await.unwrap_err();
+        assert!(matches!(err, ToolError::InvalidParams { .. }));
     }
 
     #[test]

--- a/crates/zeph-core/src/context.rs
+++ b/crates/zeph-core/src/context.rs
@@ -25,7 +25,13 @@ const TOOL_USE_NATIVE: &str = "\
 \n\n## Tool Use\n\
 You have access to tools via the API. Use them by calling the appropriate tool \
 with the required parameters. Do NOT write fenced code blocks to invoke tools; \
-use the structured tool_use mechanism instead.";
+use the structured tool_use mechanism instead.\n\
+\n\
+When `read_file` is available, always prefer it over bash alternatives like \
+`cat`, `head`, `tail`, or `sed` for reading files. `read_file` returns \
+structured output with line numbers and metadata. Similarly prefer `write_file` \
+over shell redirects, and `list_directory` / `find_path` over `ls` / `find` \
+when available.";
 
 const BASE_PROMPT_TAIL: &str = "\
 \n\n## Skills\n\

--- a/crates/zeph-tools/src/lib.rs
+++ b/crates/zeph-tools/src/lib.rs
@@ -15,6 +15,7 @@ pub mod permissions;
 pub mod registry;
 pub mod scrape;
 pub mod shell;
+pub mod tool_filter;
 pub mod trust_gate;
 pub mod trust_level;
 
@@ -41,5 +42,6 @@ pub use shell::{
     DEFAULT_BLOCKED_COMMANDS, SHELL_INTERPRETERS, ShellExecutor, check_blocklist,
     effective_shell_command,
 };
+pub use tool_filter::ToolFilter;
 pub use trust_gate::TrustGateExecutor;
 pub use trust_level::TrustLevel;

--- a/crates/zeph-tools/src/tool_filter.rs
+++ b/crates/zeph-tools/src/tool_filter.rs
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::executor::{ToolCall, ToolError, ToolExecutor, ToolOutput};
+use crate::registry::ToolDef;
+
+/// Wraps a `ToolExecutor` and suppresses specified tool ids from both
+/// `tool_definitions` and `execute_tool_call`.
+///
+/// Used to hide `FileExecutor` tools (e.g. `read`, `glob`) when
+/// `AcpFileExecutor` provides equivalent IDE-proxied alternatives.
+#[derive(Debug)]
+pub struct ToolFilter<E: ToolExecutor> {
+    inner: E,
+    suppressed: &'static [&'static str],
+}
+
+impl<E: ToolExecutor> ToolFilter<E> {
+    #[must_use]
+    pub fn new(inner: E, suppressed: &'static [&'static str]) -> Self {
+        Self { inner, suppressed }
+    }
+}
+
+impl<E: ToolExecutor> ToolExecutor for ToolFilter<E> {
+    async fn execute(&self, response: &str) -> Result<Option<ToolOutput>, ToolError> {
+        self.inner.execute(response).await
+    }
+
+    async fn execute_confirmed(&self, response: &str) -> Result<Option<ToolOutput>, ToolError> {
+        self.inner.execute_confirmed(response).await
+    }
+
+    fn tool_definitions(&self) -> Vec<ToolDef> {
+        self.inner
+            .tool_definitions()
+            .into_iter()
+            .filter(|d| !self.suppressed.contains(&d.id.as_ref()))
+            .collect()
+    }
+
+    async fn execute_tool_call(&self, call: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
+        if self.suppressed.contains(&call.tool_id.as_str()) {
+            return Ok(None);
+        }
+        self.inner.execute_tool_call(call).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug)]
+    struct StubExecutor;
+    impl ToolExecutor for StubExecutor {
+        async fn execute(&self, _: &str) -> Result<Option<ToolOutput>, ToolError> {
+            Ok(None)
+        }
+        fn tool_definitions(&self) -> Vec<ToolDef> {
+            vec![
+                ToolDef {
+                    id: "read".into(),
+                    description: "read a file".into(),
+                    schema: schemars::schema_for!(String),
+                    invocation: crate::registry::InvocationHint::ToolCall,
+                },
+                ToolDef {
+                    id: "glob".into(),
+                    description: "find files".into(),
+                    schema: schemars::schema_for!(String),
+                    invocation: crate::registry::InvocationHint::ToolCall,
+                },
+                ToolDef {
+                    id: "edit".into(),
+                    description: "edit a file".into(),
+                    schema: schemars::schema_for!(String),
+                    invocation: crate::registry::InvocationHint::ToolCall,
+                },
+            ]
+        }
+        async fn execute_tool_call(
+            &self,
+            call: &ToolCall,
+        ) -> Result<Option<ToolOutput>, ToolError> {
+            Ok(Some(ToolOutput {
+                tool_name: call.tool_id.clone(),
+                summary: "stub".to_owned(),
+                blocks_executed: 1,
+                filter_stats: None,
+                diff: None,
+                streamed: false,
+                terminal_id: None,
+                locations: None,
+                raw_response: None,
+            }))
+        }
+    }
+
+    #[test]
+    fn suppressed_tools_hidden_from_definitions() {
+        let filter = ToolFilter::new(StubExecutor, &["read", "glob"]);
+        let defs = filter.tool_definitions();
+        let ids: Vec<&str> = defs.iter().map(|d| d.id.as_ref()).collect();
+        assert!(!ids.contains(&"read"));
+        assert!(!ids.contains(&"glob"));
+        assert!(ids.contains(&"edit"));
+    }
+
+    #[tokio::test]
+    async fn suppressed_tool_call_returns_none() {
+        let filter = ToolFilter::new(StubExecutor, &["read", "glob"]);
+        let call = ToolCall {
+            tool_id: "read".to_owned(),
+            params: serde_json::Map::new(),
+        };
+        let result = filter.execute_tool_call(&call).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn allowed_tool_call_passes_through() {
+        let filter = ToolFilter::new(StubExecutor, &["read", "glob"]);
+        let call = ToolCall {
+            tool_id: "edit".to_owned(),
+            params: serde_json::Map::new(),
+        };
+        let result = filter.execute_tool_call(&call).await.unwrap();
+        assert!(result.is_some());
+    }
+}

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -244,10 +244,13 @@ async fn spawn_acp_agent(
             let parent_tool_use_id = ctx.parent_tool_use_id.clone();
             let mut base: Arc<dyn ErasedToolExecutor> = Arc::new(d.tool_executor);
             if let Some(fs) = ctx.file_executor {
-                base = Arc::new(zeph_tools::CompositeExecutor::new(
-                    fs,
+                // Suppress FileExecutor's read/write/glob when AcpFileExecutor is active.
+                // edit and grep remain available from FileExecutor (no ACP equivalents yet).
+                let filtered = zeph_tools::ToolFilter::new(
                     zeph_tools::DynExecutor(base),
-                ));
+                    &["read", "write", "glob"],
+                );
+                base = Arc::new(zeph_tools::CompositeExecutor::new(fs, filtered));
             }
             if let Some(shell) = ctx.shell_executor {
                 base = Arc::new(zeph_tools::CompositeExecutor::new(


### PR DESCRIPTION
## Summary

- Add `list_directory` and `find_path` tools to `AcpFileExecutor` for local filesystem access when the IDE advertises `fs.readTextFile` capability
- Add `ToolFilter` wrapper in `zeph-tools` to suppress `FileExecutor` tools (`read`, `write`, `glob`) when ACP equivalents are active
- Update `TOOL_USE_NATIVE` system prompt to guide LLM toward native file tools over bash alternatives
- Map new tools to `ToolKind::Search` in `tool_kind_from_name`

## Security

- `find_path`: requires explicit absolute `path` parameter (no cwd fallback), validates glob pattern against `..` traversal segments, caps results at 1000
- `list_directory`: uses `symlink_metadata()` to prevent symlink escape, exposes `is_symlink` field
- Both tools gated behind `can_read` capability flag

## Test plan

- [x] 8 new unit tests covering edge cases and security regressions
- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes (0 warnings)
- [x] `cargo nextest run --workspace --lib --bins` passes (3099 tests, 0 failures)

Closes #1047