### PR TITLE
fix(security): replace variable-length ct_eq with blake3 hash comparison in bearer auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9194,6 +9194,7 @@ name = "zeph-a2a"
 version = "0.12.3"
 dependencies = [
  "axum 0.8.8",
+ "blake3",
  "eventsource-stream",
  "futures",
  "futures-core",
@@ -9221,6 +9222,7 @@ dependencies = [
  "async-trait",
  "axum 0.8.8",
  "base64 0.22.1",
+ "blake3",
  "chrono",
  "dashmap",
  "dirs",

--- a/crates/zeph-a2a/Cargo.toml
+++ b/crates/zeph-a2a/Cargo.toml
@@ -13,10 +13,11 @@ description = "A2A protocol client and server with agent discovery for Zeph"
 readme = "README.md"
 
 [features]
-server = ["dep:axum", "dep:subtle", "dep:tower", "dep:tower-http"]
+server = ["dep:axum", "dep:blake3", "dep:subtle", "dep:tower", "dep:tower-http"]
 
 [dependencies]
 axum = { workspace = true, optional = true }
+blake3 = { workspace = true, optional = true }
 eventsource-stream.workspace = true
 futures.workspace = true
 futures-core.workspace = true

--- a/crates/zeph-a2a/src/server/router.rs
+++ b/crates/zeph-a2a/src/server/router.rs
@@ -107,8 +107,11 @@ async fn auth_middleware(
             .and_then(|v| v.strip_prefix("Bearer "))
             .unwrap_or("");
 
-        if token.len() != expected.len() || !bool::from(token.as_bytes().ct_eq(expected.as_bytes()))
-        {
+        // Hash both sides so ct_eq compares fixed-length digests, avoiding the
+        // length side-channel that an explicit len() check or direct ct_eq would expose.
+        let h_token = blake3::hash(token.as_bytes());
+        let h_expected = blake3::hash(expected.as_bytes());
+        if !bool::from(h_token.as_bytes().ct_eq(h_expected.as_bytes())) {
             return StatusCode::UNAUTHORIZED.into_response();
         }
     }

--- a/crates/zeph-acp/Cargo.toml
+++ b/crates/zeph-acp/Cargo.toml
@@ -21,7 +21,7 @@ default = [
     "unstable-session-model",
     "unstable-session-info-update",
 ]
-acp-http = ["dep:axum", "dep:dashmap", "dep:async-stream", "dep:tower-http", "dep:subtle", "dep:tower"]
+acp-http = ["dep:axum", "dep:blake3", "dep:dashmap", "dep:async-stream", "dep:tower-http", "dep:subtle", "dep:tower"]
 unstable-session-list = ["agent-client-protocol/unstable_session_list"]
 unstable-session-fork = ["agent-client-protocol/unstable_session_fork"]
 unstable-session-resume = ["agent-client-protocol/unstable_session_resume"]
@@ -54,6 +54,7 @@ zeph-tools.workspace = true
 axum = { workspace = true, features = ["ws"], optional = true }
 async-stream = { version = "0.3", optional = true }
 dashmap = { workspace = true, optional = true }
+blake3 = { workspace = true, optional = true }
 subtle = { workspace = true, optional = true }
 tower = { workspace = true, features = ["util"], optional = true }
 tower-http = { workspace = true, features = ["cors", "limit"], optional = true }

--- a/crates/zeph-acp/src/transport/auth.rs
+++ b/crates/zeph-acp/src/transport/auth.rs
@@ -66,8 +66,13 @@ where
             .get(header::AUTHORIZATION)
             .and_then(|v| v.to_str().ok())
             .and_then(|v| v.strip_prefix("Bearer "))
-            // Constant-time comparison to prevent timing attacks.
-            .is_some_and(|provided| provided.as_bytes().ct_eq(expected.as_bytes()).into());
+            // Hash both sides first so ct_eq operates on fixed-length digests,
+            // eliminating the length side-channel present in direct byte comparison.
+            .is_some_and(|provided| {
+                let h_provided = blake3::hash(provided.as_bytes());
+                let h_expected = blake3::hash(expected.as_bytes());
+                h_provided.as_bytes().ct_eq(h_expected.as_bytes()).into()
+            });
 
         if authorized {
             let fut = self.inner.call(req);
@@ -75,5 +80,59 @@ where
         } else {
             Box::pin(async move { Ok(StatusCode::UNAUTHORIZED.into_response()) })
         }
+    }
+}
+
+#[cfg(all(test, feature = "acp-http"))]
+mod tests {
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::routing::get;
+    use tower::ServiceExt as _;
+
+    use super::*;
+
+    fn ok_handler() -> axum::Router {
+        axum::Router::new().route("/", get(|| async { StatusCode::OK }))
+    }
+
+    fn app_with_token(token: &str) -> axum::Router {
+        ok_handler().layer(BearerAuthLayer::new(token))
+    }
+
+    async fn send(app: axum::Router, auth: Option<&str>) -> StatusCode {
+        let mut builder = Request::builder().method("GET").uri("/");
+        if let Some(v) = auth {
+            builder = builder.header("authorization", v);
+        }
+        let req = builder.body(Body::empty()).unwrap();
+        app.oneshot(req).await.unwrap().status()
+    }
+
+    #[tokio::test]
+    async fn correct_token_accepted() {
+        let app = app_with_token("my-secret");
+        assert_eq!(send(app, Some("Bearer my-secret")).await, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn wrong_token_rejected() {
+        let app = app_with_token("my-secret");
+        assert_eq!(
+            send(app, Some("Bearer wrong")).await,
+            StatusCode::UNAUTHORIZED
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_token_rejected() {
+        let app = app_with_token("my-secret");
+        assert_eq!(send(app, Some("Bearer ")).await, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn missing_header_rejected() {
+        let app = app_with_token("my-secret");
+        assert_eq!(send(app, None).await, StatusCode::UNAUTHORIZED);
     }
 }


### PR DESCRIPTION
Fixes #1025

## Problem

Bearer token validation in `zeph-acp` and `zeph-a2a` used `subtle::ConstantTimeEq` directly on raw byte slices. When slice lengths differ, `ct_eq` returns `0` immediately — an attacker can probe the expected token's length by sending tokens of increasing length and measuring response times. The `zeph-a2a` path made this worse with an explicit `token.len() != expected.len()` short-circuit that bypassed constant-time comparison entirely.

## Fix

Hash both provided and expected tokens with `blake3` before comparison. `blake3` always produces a 32-byte digest regardless of input length, so `ct_eq` operates on equal-length slices with no early exit. Pattern adopted from `zeph-gateway` which already used this approach correctly.

## Changes

- `zeph-acp/src/transport/auth.rs` — `BearerAuthMiddleware::call`: blake3 hash both sides, then `ct_eq` on digests
- `zeph-a2a/src/server/router.rs` — `bearer_auth_middleware`: remove `len()` check, blake3 hash comparison
- `zeph-acp/Cargo.toml`, `zeph-a2a/Cargo.toml` — add `blake3` under feature gates (`acp-http`, `server`)

## Validation

- `cargo +nightly fmt --check`: pass
- `cargo clippy --workspace -- -D warnings`: pass (0 warnings)
- `cargo nextest run --workspace --lib --bins`: pass
- `cargo nextest run -p zeph-acp --features acp-http`: 223 passed, +4 new auth tests
- `cargo nextest run -p zeph-a2a --features server`: 119 passed, all 8 auth tests pass
- Security review: blake3 eliminates length oracle, no remaining `==` on token strings