### PR TITLE
feat(llm): Claude API prompt caching compliance (epic #1082)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `CacheType` enum (`Ephemeral` variant) replaces bare `String` in `CacheControl` — compile-time safety for cache type construction (#1082, #1088)
+- Tool definitions now carry `cache_control: ephemeral` on the last tool entry, enabling tools to be cached independently of the system prompt (#1084)
+- Top-level `cache_control` added to all Claude request body structs; activated automatically for multi-turn sessions (`messages.len() > 1`) (#1086)
+- Message-level `cache_control` breakpoint placed on user message at position `max(0, total - 20)` to cover the 20-block lookback window (#1087)
+
 ### Fixed
 
+- Block 1 of system prompt now includes skills prompt, tool catalog, and catalog prompt so its token count exceeds the model-aware minimum threshold (Sonnet 4.6: 2048 tokens, Opus/Haiku: 4096 tokens) — previously ~377 tokens caused caching to be silently skipped (#1083)
+- Removed outdated `anthropic-beta: prompt-caching-2024-07-31` request header; prompt caching is GA and no longer requires the beta header (#1085)
+- Model-aware `cache_min_tokens` check added to `split_system_into_blocks` to prevent `cache_control` from being attached to blocks below the minimum cacheable threshold (#1083)
 - Restructured `rebuild_system_prompt` block ordering so cache markers align with content stability: Block 1 (base prompt) is stable across all turns, Block 2 (skill catalog, MCP, project context) is semi-stable per session, Block 3 (env, tools, active skills) is volatile per turn — fixes near-zero cache hit rate in multi-turn Claude sessions (#1079)
 - TUI Skills panel now shows Wilson score confidence bars immediately after skill match, not only after the first LLM outcome is recorded (`context.rs`: call `update_skill_confidence_metrics()` at skill resolution time) (#1077)
 - TUI event loop redraws on every tick unconditionally; previously the dirty-flag was never set by the tick arm, causing confidence bars to stay stale between user keypresses (#1077)

--- a/crates/zeph-core/src/agent/context.rs
+++ b/crates/zeph-core/src/agent/context.rs
@@ -1582,7 +1582,6 @@ impl<C: Channel> Agent<C> {
         self.env_context
             .model_name
             .clone_from(&self.runtime.model_name);
-        let env_formatted = self.env_context.format();
         let tool_catalog = if self.provider.supports_tool_use() {
             // Native tool_use: tools are passed via API, skip prompt-based instructions
             None
@@ -1595,17 +1594,22 @@ impl<C: Channel> Agent<C> {
                 Some(reg.format_for_prompt_filtered(&self.runtime.permission_policy))
             }
         };
-        // BLOCK 1: stable across all turns — base prompt only, no dynamic content
+        // BLOCK 1: stable within a session — base prompt + skills + tool catalog
         #[allow(unused_mut)]
-        let mut system_prompt =
-            build_system_prompt("", None, None, self.provider.supports_tool_use());
-        system_prompt.push_str("\n<!-- cache:stable -->");
+        let mut system_prompt = build_system_prompt(
+            &skills_prompt,
+            Some(&self.env_context),
+            tool_catalog.as_deref(),
+            self.provider.supports_tool_use(),
+        );
 
         // BLOCK 2: semi-stable within a session — skills catalog, MCP, project context, repo map
         if !catalog_prompt.is_empty() {
             system_prompt.push_str("\n\n");
             system_prompt.push_str(&catalog_prompt);
         }
+
+        system_prompt.push_str("\n<!-- cache:stable -->");
 
         self.append_mcp_prompt(query, &mut system_prompt).await;
 
@@ -1642,21 +1646,6 @@ impl<C: Channel> Agent<C> {
 
         // BLOCK 3: volatile — dynamic per-turn content, never cached
         system_prompt.push_str("\n<!-- cache:volatile -->");
-
-        if !env_formatted.is_empty() {
-            system_prompt.push_str("\n\n");
-            system_prompt.push_str(&env_formatted);
-        }
-
-        if let Some(ref catalog) = tool_catalog {
-            system_prompt.push_str("\n\n");
-            system_prompt.push_str(catalog);
-        }
-
-        if !skills_prompt.is_empty() {
-            system_prompt.push_str("\n\n");
-            system_prompt.push_str(&skills_prompt);
-        }
 
         tracing::debug!(
             len = system_prompt.len(),

--- a/crates/zeph-llm/src/claude.rs
+++ b/crates/zeph-llm/src/claude.rs
@@ -16,7 +16,6 @@ use crate::sse::claude_sse_to_stream;
 
 const API_URL: &str = "https://api.anthropic.com/v1/messages";
 const ANTHROPIC_VERSION: &str = "2023-06-01";
-const ANTHROPIC_BETA: &str = "prompt-caching-2024-07-31";
 const MAX_RETRIES: u32 = 3;
 
 const CACHE_MARKER_STABLE: &str = "<!-- cache:stable -->";
@@ -214,7 +213,7 @@ impl ClaudeProvider {
         {
             return cached_values.clone();
         }
-        let serialized: Vec<serde_json::Value> = tools
+        let mut serialized: Vec<serde_json::Value> = tools
             .iter()
             .map(|t| {
                 serde_json::json!({
@@ -224,6 +223,12 @@ impl ClaudeProvider {
                 })
             })
             .collect();
+        if let Some(Some(obj)) = serialized.last_mut().map(serde_json::Value::as_object_mut) {
+            obj.insert(
+                "cache_control".into(),
+                serde_json::json!({"type": "ephemeral"}),
+            );
+        }
         *guard = Some((names, serialized.clone()));
         serialized
     }
@@ -247,28 +252,36 @@ impl ClaudeProvider {
     }
 
     fn build_request(&self, messages: &[Message], stream: bool) -> reqwest::RequestBuilder {
+        let auto_cache = if messages.len() > 1 {
+            Some(CacheControl {
+                cache_type: CacheType::Ephemeral,
+            })
+        } else {
+            None
+        };
+
         if Self::has_image_parts(messages) {
             let (system, chat_messages) = split_messages_structured(messages);
-            let system_blocks = system.map(|s| split_system_into_blocks(&s));
+            let system_blocks = system.map(|s| split_system_into_blocks(&s, &self.model));
             let body = VisionRequestBody {
                 model: &self.model,
                 max_tokens: self.max_tokens,
                 system: system_blocks,
                 messages: &chat_messages,
                 stream,
+                cache_control: auto_cache,
             };
             return self
                 .client
                 .post(API_URL)
                 .header("x-api-key", &self.api_key)
                 .header("anthropic-version", ANTHROPIC_VERSION)
-                .header("anthropic-beta", ANTHROPIC_BETA)
                 .header("content-type", "application/json")
                 .json(&body);
         }
 
         let (system, chat_messages) = split_messages(messages);
-        let system_blocks = system.map(|s| split_system_into_blocks(&s));
+        let system_blocks = system.map(|s| split_system_into_blocks(&s, &self.model));
 
         let body = RequestBody {
             model: &self.model,
@@ -276,13 +289,13 @@ impl ClaudeProvider {
             system: system_blocks,
             messages: &chat_messages,
             stream,
+            cache_control: auto_cache,
         };
 
         self.client
             .post(API_URL)
             .header("x-api-key", &self.api_key)
             .header("anthropic-version", ANTHROPIC_VERSION)
-            .header("anthropic-beta", ANTHROPIC_BETA)
             .header("content-type", "application/json")
             .json(&body)
     }
@@ -310,7 +323,7 @@ impl ClaudeProvider {
                 self.store_cache_usage(usage);
             }
             let extracted = resp.content.into_iter().find_map(|b| {
-                if let AnthropicContentBlock::Text { text } = b {
+                if let AnthropicContentBlock::Text { text, .. } = b {
                     Some(text)
                 } else {
                     None
@@ -428,7 +441,14 @@ impl LlmProvider for ClaudeProvider {
             input_schema: &tool.parameters,
         };
 
-        let system_blocks = system.map(|s| split_system_into_blocks(&s));
+        let system_blocks = system.map(|s| split_system_into_blocks(&s, &self.model));
+        let auto_cache = if messages.len() > 1 {
+            Some(CacheControl {
+                cache_type: CacheType::Ephemeral,
+            })
+        } else {
+            None
+        };
         let body = TypedToolRequestBody {
             model: &self.model,
             max_tokens: self.max_tokens,
@@ -439,6 +459,7 @@ impl LlmProvider for ClaudeProvider {
                 r#type: "tool",
                 name: &tool_name,
             },
+            cache_control: auto_cache,
         };
 
         let response = self
@@ -446,7 +467,6 @@ impl LlmProvider for ClaudeProvider {
             .post(API_URL)
             .header("x-api-key", &self.api_key)
             .header("anthropic-version", ANTHROPIC_VERSION)
-            .header("anthropic-beta", ANTHROPIC_BETA)
             .header("content-type", "application/json")
             .json(&body)
             .send()
@@ -499,13 +519,21 @@ impl LlmProvider for ClaudeProvider {
         let (system, chat_messages) = split_messages_structured(messages);
         let api_tools = self.get_or_build_api_tools(tools);
 
-        let system_blocks = system.map(|s| split_system_into_blocks(&s));
+        let system_blocks = system.map(|s| split_system_into_blocks(&s, &self.model));
+        let auto_cache = if messages.len() > 1 {
+            Some(CacheControl {
+                cache_type: CacheType::Ephemeral,
+            })
+        } else {
+            None
+        };
         let body = ToolRequestBody {
             model: &self.model,
             max_tokens: self.max_tokens,
             system: system_blocks,
             messages: &chat_messages,
             tools: &api_tools,
+            cache_control: auto_cache,
         };
 
         let response = send_with_retry("Claude", MAX_RETRIES, self.status_tx.as_ref(), || {
@@ -513,7 +541,6 @@ impl LlmProvider for ClaudeProvider {
                 .post(API_URL)
                 .header("x-api-key", &self.api_key)
                 .header("anthropic-version", ANTHROPIC_VERSION)
-                .header("anthropic-beta", ANTHROPIC_BETA)
                 .header("content-type", "application/json")
                 .json(&body)
                 .send()
@@ -595,13 +622,25 @@ struct SystemContentBlock {
     cache_control: Option<CacheControl>,
 }
 
-#[derive(Serialize, Clone, Debug)]
-struct CacheControl {
-    #[serde(rename = "type")]
-    cache_type: &'static str,
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "snake_case")]
+enum CacheType {
+    Ephemeral,
 }
 
-fn split_system_into_blocks(system: &str) -> Vec<SystemContentBlock> {
+#[derive(Serialize, Deserialize, Clone, Debug)]
+struct CacheControl {
+    #[serde(rename = "type")]
+    cache_type: CacheType,
+}
+
+/// Returns the minimum token count required for caching to activate for the given model.
+/// Uses `byte_len / 4` as a conservative token estimate (1 token ≈ 4 chars for English).
+fn cache_min_tokens(model: &str) -> usize {
+    if model.contains("sonnet") { 2048 } else { 4096 }
+}
+
+fn split_system_into_blocks(system: &str, model: &str) -> Vec<SystemContentBlock> {
     // Split on volatile marker first: everything before is cacheable
     let (cacheable_part, volatile_part) = if let Some(pos) = system.find(CACHE_MARKER_VOLATILE) {
         (
@@ -615,17 +654,30 @@ fn split_system_into_blocks(system: &str) -> Vec<SystemContentBlock> {
     let mut blocks = Vec::new();
     let cache_markers = [CACHE_MARKER_STABLE, CACHE_MARKER_TOOLS];
     let mut remaining = cacheable_part;
+    let min_tokens = cache_min_tokens(model);
 
     for marker in &cache_markers {
         if let Some(pos) = remaining.find(marker) {
             let before = remaining[..pos].trim();
             if !before.is_empty() {
+                let estimated_tokens = before.len() / 4;
+                let cc = if estimated_tokens >= min_tokens {
+                    Some(CacheControl {
+                        cache_type: CacheType::Ephemeral,
+                    })
+                } else {
+                    tracing::debug!(
+                        estimated_tokens,
+                        min_tokens,
+                        model,
+                        "system block below cache threshold, skipping cache_control"
+                    );
+                    None
+                };
                 blocks.push(SystemContentBlock {
                     block_type: "text",
                     text: before.to_owned(),
-                    cache_control: Some(CacheControl {
-                        cache_type: "ephemeral",
-                    }),
+                    cache_control: cc,
                 });
             }
             remaining = &remaining[pos + marker.len()..];
@@ -638,7 +690,7 @@ fn split_system_into_blocks(system: &str) -> Vec<SystemContentBlock> {
             block_type: "text",
             text: remaining.to_owned(),
             cache_control: Some(CacheControl {
-                cache_type: "ephemeral",
+                cache_type: CacheType::Ephemeral,
             }),
         });
     }
@@ -660,7 +712,7 @@ fn split_system_into_blocks(system: &str) -> Vec<SystemContentBlock> {
             block_type: "text",
             text: system.to_owned(),
             cache_control: Some(CacheControl {
-                cache_type: "ephemeral",
+                cache_type: CacheType::Ephemeral,
             }),
         });
     }
@@ -678,6 +730,8 @@ struct TypedToolRequestBody<'a> {
     messages: &'a [StructuredApiMessage],
     tools: &'a [AnthropicTool<'a>],
     tool_choice: ToolChoice<'a>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cache_control: Option<CacheControl>,
 }
 
 #[cfg(feature = "schema")]
@@ -702,6 +756,8 @@ struct ToolRequestBody<'a> {
     system: Option<Vec<SystemContentBlock>>,
     messages: &'a [StructuredApiMessage],
     tools: &'a [serde_json::Value],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cache_control: Option<CacheControl>,
 }
 
 #[derive(Serialize)]
@@ -722,6 +778,8 @@ enum StructuredContent {
 enum AnthropicContentBlock {
     Text {
         text: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
     },
     ToolUse {
         id: String,
@@ -733,6 +791,8 @@ enum AnthropicContentBlock {
         content: String,
         #[serde(default, skip_serializing_if = "std::ops::Not::not")]
         is_error: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
     },
     Image {
         source: ImageSource,
@@ -763,7 +823,7 @@ fn parse_tool_response(resp: ToolApiResponse) -> ChatResponse {
 
     for block in resp.content {
         match block {
-            AnthropicContentBlock::Text { text } => text_parts.push(text),
+            AnthropicContentBlock::Text { text, .. } => text_parts.push(text),
             AnthropicContentBlock::ToolUse { id, name, input } => {
                 tool_calls.push(ToolUseRequest { id, name, input });
             }
@@ -838,7 +898,10 @@ fn split_messages_structured(messages: &[Message]) -> (Option<String>, Vec<Struc
                             | MessagePart::Summary { text }
                             | MessagePart::CrossSession { text } => {
                                 if !text.trim().is_empty() {
-                                    blocks.push(AnthropicContentBlock::Text { text: text.clone() });
+                                    blocks.push(AnthropicContentBlock::Text {
+                                        text: text.clone(),
+                                        cache_control: None,
+                                    });
                                 }
                             }
                             MessagePart::ToolOutput {
@@ -846,6 +909,7 @@ fn split_messages_structured(messages: &[Message]) -> (Option<String>, Vec<Struc
                             } => {
                                 blocks.push(AnthropicContentBlock::Text {
                                     text: format!("[tool output: {tool_name}]\n{body}"),
+                                    cache_control: None,
                                 });
                             }
                             MessagePart::ToolUse { id, name, input } if is_assistant => {
@@ -858,6 +922,7 @@ fn split_messages_structured(messages: &[Message]) -> (Option<String>, Vec<Struc
                             MessagePart::ToolUse { name, input, .. } => {
                                 blocks.push(AnthropicContentBlock::Text {
                                     text: format!("[tool_use: {name}] {input}"),
+                                    cache_control: None,
                                 });
                             }
                             MessagePart::ToolResult {
@@ -869,12 +934,14 @@ fn split_messages_structured(messages: &[Message]) -> (Option<String>, Vec<Struc
                                     tool_use_id: tool_use_id.clone(),
                                     content: content.clone(),
                                     is_error: *is_error,
+                                    cache_control: None,
                                 });
                             }
                             MessagePart::ToolResult { content, .. } => {
                                 if !content.trim().is_empty() {
                                     blocks.push(AnthropicContentBlock::Text {
                                         text: content.clone(),
+                                        cache_control: None,
                                     });
                                 }
                             }
@@ -906,6 +973,38 @@ fn split_messages_structured(messages: &[Message]) -> (Option<String>, Vec<Struc
         }
     }
 
+    // Place 1 message-level cache breakpoint at the user message closest to position
+    // (total - 20) to maximize the 20-block lookback window coverage.
+    if chat.len() > 1 {
+        let target = chat.len().saturating_sub(20);
+        let breakpoint_idx = (target..chat.len())
+            .find(|&i| chat[i].role == "user")
+            .unwrap_or(0);
+        let msg = &mut chat[breakpoint_idx];
+        match &mut msg.content {
+            StructuredContent::Blocks(blocks) => {
+                if let Some(
+                    AnthropicContentBlock::Text { cache_control, .. }
+                    | AnthropicContentBlock::ToolResult { cache_control, .. },
+                ) = blocks.last_mut()
+                {
+                    *cache_control = Some(CacheControl {
+                        cache_type: CacheType::Ephemeral,
+                    });
+                }
+            }
+            StructuredContent::Text(text) => {
+                let owned = std::mem::take(text);
+                msg.content = StructuredContent::Blocks(vec![AnthropicContentBlock::Text {
+                    text: owned,
+                    cache_control: Some(CacheControl {
+                        cache_type: CacheType::Ephemeral,
+                    }),
+                }]);
+            }
+        }
+    }
+
     let system = if system_parts.is_empty() {
         None
     } else {
@@ -924,6 +1023,8 @@ struct RequestBody<'a> {
     messages: &'a [ApiMessage<'a>],
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     stream: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cache_control: Option<CacheControl>,
 }
 
 #[derive(Serialize)]
@@ -935,6 +1036,8 @@ struct VisionRequestBody<'a> {
     messages: &'a [StructuredApiMessage],
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     stream: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cache_control: Option<CacheControl>,
 }
 
 #[derive(Serialize)]
@@ -1144,6 +1247,7 @@ mod tests {
                 content: "hello",
             }],
             stream: false,
+            cache_control: None,
         };
         let json = serde_json::to_string(&body).unwrap();
         assert!(!json.contains("system"));
@@ -1161,11 +1265,12 @@ mod tests {
                 block_type: "text",
                 text: "You are helpful.".into(),
                 cache_control: Some(CacheControl {
-                    cache_type: "ephemeral",
+                    cache_type: CacheType::Ephemeral,
                 }),
             }]),
             messages: &[],
             stream: false,
+            cache_control: None,
         };
         let json = serde_json::to_string(&body).unwrap();
         assert!(json.contains("\"system\""));
@@ -1181,6 +1286,7 @@ mod tests {
             system: None,
             messages: &[],
             stream: true,
+            cache_control: None,
         };
         let json = serde_json::to_string(&body).unwrap();
         assert!(json.contains("\"stream\":true"));
@@ -1347,6 +1453,7 @@ mod tests {
             system: None,
             messages: &[],
             stream: false,
+            cache_control: None,
         };
         let json = serde_json::to_string(&body).unwrap();
         assert!(!json.contains("stream"));
@@ -1354,7 +1461,8 @@ mod tests {
 
     #[test]
     fn split_system_no_markers_caches_entire_block() {
-        let blocks = split_system_into_blocks("You are Zeph, an AI assistant.");
+        let blocks =
+            split_system_into_blocks("You are Zeph, an AI assistant.", "claude-sonnet-4-6");
         assert_eq!(blocks.len(), 1);
         assert!(blocks[0].cache_control.is_some());
         assert!(blocks[0].text.contains("Zeph"));
@@ -1362,12 +1470,14 @@ mod tests {
 
     #[test]
     fn split_system_with_all_markers() {
+        // Each block must exceed 2048 tokens (≈ 8192 chars) for sonnet threshold
+        let padding = "x".repeat(8200);
         let system = format!(
-            "base prompt\n{CACHE_MARKER_STABLE}\nskills here\n\
-             {CACHE_MARKER_TOOLS}\ntool catalog\n\
+            "base prompt {padding}\n{CACHE_MARKER_STABLE}\nskills here {padding}\n\
+             {CACHE_MARKER_TOOLS}\ntool catalog {padding}\n\
              {CACHE_MARKER_VOLATILE}\nvolatile stuff"
         );
-        let blocks = split_system_into_blocks(&system);
+        let blocks = split_system_into_blocks(&system, "claude-sonnet-4-6");
         assert_eq!(blocks.len(), 4);
         assert!(blocks[0].cache_control.is_some());
         assert!(blocks[0].text.contains("base prompt"));
@@ -1381,11 +1491,21 @@ mod tests {
 
     #[test]
     fn split_system_partial_markers() {
-        let system = format!("base prompt\n{CACHE_MARKER_VOLATILE}\nvolatile only");
-        let blocks = split_system_into_blocks(&system);
+        let padding = "x".repeat(8200);
+        let system = format!("base prompt {padding}\n{CACHE_MARKER_VOLATILE}\nvolatile only");
+        let blocks = split_system_into_blocks(&system, "claude-sonnet-4-6");
         assert_eq!(blocks.len(), 2);
         assert!(blocks[0].cache_control.is_some());
         assert!(blocks[1].cache_control.is_none());
+    }
+
+    #[test]
+    fn split_system_block_below_threshold_skips_cache_control() {
+        // "short text" is well below 2048 tokens — cache_control must be None for Block 1
+        let system = format!("short text\n{CACHE_MARKER_STABLE}\nmore content");
+        let blocks = split_system_into_blocks(&system, "claude-sonnet-4-6");
+        // Block 1 ("short text") is below threshold
+        assert!(blocks[0].cache_control.is_none());
     }
 
     #[test]
@@ -1519,6 +1639,7 @@ mod tests {
         let resp = ToolApiResponse {
             content: vec![AnthropicContentBlock::Text {
                 text: "Hello".into(),
+                cache_control: None,
             }],
             stop_reason: None,
             usage: None,
@@ -1533,6 +1654,7 @@ mod tests {
             content: vec![
                 AnthropicContentBlock::Text {
                     text: "I'll run that".into(),
+                    cache_control: None,
                 },
                 AnthropicContentBlock::ToolUse {
                     id: "toolu_123".into(),
@@ -1667,7 +1789,7 @@ mod tests {
             StructuredContent::Blocks(blocks) => {
                 assert_eq!(blocks.len(), 2);
                 match &blocks[0] {
-                    AnthropicContentBlock::Text { text } => assert_eq!(text, "look at this"),
+                    AnthropicContentBlock::Text { text, .. } => assert_eq!(text, "look at this"),
                     _ => panic!("expected Text block first"),
                 }
                 match &blocks[1] {
@@ -2016,5 +2138,261 @@ mod tests {
             .unwrap_or(&id)
             .to_string();
         assert_eq!(display_name, "claude-x");
+    }
+
+    // ── #1085: anthropic-beta header removed ──────────────────────────────────
+
+    #[test]
+    fn build_request_does_not_include_anthropic_beta_header() {
+        let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 256);
+        let messages = vec![Message {
+            role: Role::User,
+            content: "hi".into(),
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        }];
+        let req = provider.build_request(&messages, false).build().unwrap();
+        assert!(
+            req.headers().get("anthropic-beta").is_none(),
+            "anthropic-beta header must not be present"
+        );
+        assert!(req.headers().get("anthropic-version").is_some());
+        assert!(req.headers().get("x-api-key").is_some());
+    }
+
+    // ── #1084: cache_control only on last tool ────────────────────────────────
+
+    #[test]
+    fn get_or_build_api_tools_only_last_tool_has_cache_control() {
+        use crate::provider::ToolDefinition;
+        let provider = ClaudeProvider::new("key".into(), "model".into(), 512);
+        let tools = vec![
+            ToolDefinition {
+                name: "alpha".into(),
+                description: "First".into(),
+                parameters: serde_json::json!({"type": "object", "properties": {}}),
+            },
+            ToolDefinition {
+                name: "beta".into(),
+                description: "Second".into(),
+                parameters: serde_json::json!({"type": "object", "properties": {}}),
+            },
+            ToolDefinition {
+                name: "gamma".into(),
+                description: "Third".into(),
+                parameters: serde_json::json!({"type": "object", "properties": {}}),
+            },
+        ];
+        let result = provider.get_or_build_api_tools(&tools);
+        assert_eq!(result.len(), 3);
+        assert!(
+            result[0].get("cache_control").is_none(),
+            "first tool must not have cache_control"
+        );
+        assert!(
+            result[1].get("cache_control").is_none(),
+            "middle tool must not have cache_control"
+        );
+        assert!(
+            result[2].get("cache_control").is_some(),
+            "last tool must have cache_control"
+        );
+        assert_eq!(result[2]["cache_control"]["type"], "ephemeral");
+    }
+
+    #[test]
+    fn get_or_build_api_tools_single_tool_has_cache_control() {
+        use crate::provider::ToolDefinition;
+        let provider = ClaudeProvider::new("key".into(), "model".into(), 512);
+        let tools = vec![ToolDefinition {
+            name: "only".into(),
+            description: "Only tool".into(),
+            parameters: serde_json::json!({"type": "object", "properties": {}}),
+        }];
+        let result = provider.get_or_build_api_tools(&tools);
+        assert_eq!(result.len(), 1);
+        assert!(result[0].get("cache_control").is_some());
+        assert_eq!(result[0]["cache_control"]["type"], "ephemeral");
+    }
+
+    // ── #1083: model-aware token threshold ───────────────────────────────────
+
+    #[test]
+    fn cache_min_tokens_sonnet_returns_2048() {
+        assert_eq!(cache_min_tokens("claude-sonnet-4-6"), 2048);
+        assert_eq!(cache_min_tokens("claude-sonnet-4-5-20250929"), 2048);
+    }
+
+    #[test]
+    fn cache_min_tokens_non_sonnet_returns_4096() {
+        assert_eq!(cache_min_tokens("claude-opus-4-6"), 4096);
+        assert_eq!(cache_min_tokens("claude-haiku-4-5"), 4096);
+        assert_eq!(cache_min_tokens("unknown-model"), 4096);
+    }
+
+    #[test]
+    fn split_system_opus_block_above_threshold_gets_cache_control() {
+        // opus threshold = 4096 tokens = 16384 chars
+        let padding = "x".repeat(16400);
+        let system = format!("{padding}\n{CACHE_MARKER_STABLE}\nmore");
+        let blocks = split_system_into_blocks(&system, "claude-opus-4-6");
+        assert!(
+            blocks[0].cache_control.is_some(),
+            "block above opus threshold must be cached"
+        );
+    }
+
+    #[test]
+    fn split_system_opus_block_below_threshold_skips_cache_control() {
+        // text under 16384 chars is below opus threshold (4096 tokens)
+        let system = format!("short\n{CACHE_MARKER_STABLE}\nmore content");
+        let blocks = split_system_into_blocks(&system, "claude-opus-4-6");
+        assert!(
+            blocks[0].cache_control.is_none(),
+            "block below opus threshold must not be cached"
+        );
+    }
+
+    // ── #1086: top-level cache_control for multi-turn ─────────────────────────
+
+    #[test]
+    fn build_request_single_message_no_top_level_cache_control() {
+        let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 256);
+        let messages = vec![Message {
+            role: Role::User,
+            content: "hello".into(),
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        }];
+        let req = provider.build_request(&messages, false).build().unwrap();
+        let body: serde_json::Value =
+            serde_json::from_slice(req.body().and_then(|b| b.as_bytes()).unwrap()).unwrap();
+        assert!(
+            body.get("cache_control").is_none(),
+            "single-turn request must not have top-level cache_control"
+        );
+    }
+
+    #[test]
+    fn build_request_multi_turn_has_top_level_cache_control() {
+        let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 256);
+        let messages = vec![
+            Message {
+                role: Role::User,
+                content: "first".into(),
+                parts: vec![],
+                metadata: MessageMetadata::default(),
+            },
+            Message {
+                role: Role::Assistant,
+                content: "reply".into(),
+                parts: vec![],
+                metadata: MessageMetadata::default(),
+            },
+            Message {
+                role: Role::User,
+                content: "second".into(),
+                parts: vec![],
+                metadata: MessageMetadata::default(),
+            },
+        ];
+        let req = provider.build_request(&messages, false).build().unwrap();
+        let body: serde_json::Value =
+            serde_json::from_slice(req.body().and_then(|b| b.as_bytes()).unwrap()).unwrap();
+        assert_eq!(
+            body["cache_control"]["type"], "ephemeral",
+            "multi-turn request must have top-level cache_control"
+        );
+    }
+
+    // ── #1087: message-level breakpoint at position max(0, total-20) ──────────
+
+    #[test]
+    fn split_messages_structured_single_message_no_cache_breakpoint() {
+        let messages = vec![Message {
+            role: Role::User,
+            content: "only message".into(),
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        }];
+        let (_, chat) = split_messages_structured(&messages);
+        assert_eq!(chat.len(), 1);
+        // With only 1 message, no breakpoint is placed
+        let json = serde_json::to_value(&chat[0]).unwrap();
+        let has_cache = json.to_string().contains("cache_control");
+        assert!(
+            !has_cache,
+            "single message must not have cache_control breakpoint"
+        );
+    }
+
+    #[test]
+    fn split_messages_structured_two_messages_places_breakpoint_on_user() {
+        let messages = vec![
+            Message {
+                role: Role::User,
+                content: "first user".into(),
+                parts: vec![],
+                metadata: MessageMetadata::default(),
+            },
+            Message {
+                role: Role::Assistant,
+                content: "assistant reply".into(),
+                parts: vec![],
+                metadata: MessageMetadata::default(),
+            },
+        ];
+        let (_, chat) = split_messages_structured(&messages);
+        assert_eq!(chat.len(), 2);
+        // Breakpoint must be on the user message at index 0 (only user in range)
+        let user_json = serde_json::to_value(&chat[0]).unwrap();
+        assert!(
+            user_json.to_string().contains("cache_control"),
+            "user message must carry cache_control breakpoint"
+        );
+        let assistant_json = serde_json::to_value(&chat[1]).unwrap();
+        assert!(
+            !assistant_json.to_string().contains("cache_control"),
+            "assistant message must not have cache_control"
+        );
+    }
+
+    #[test]
+    fn split_messages_structured_breakpoint_targets_last_minus_20_position() {
+        // Build 25 messages: user/assistant alternating, user first
+        let mut messages = Vec::new();
+        for i in 0..25u32 {
+            let role = if i % 2 == 0 {
+                Role::User
+            } else {
+                Role::Assistant
+            };
+            let content = format!("message {i}");
+            messages.push(Message {
+                role,
+                content,
+                parts: vec![],
+                metadata: MessageMetadata::default(),
+            });
+        }
+        let (_, chat) = split_messages_structured(&messages);
+        assert_eq!(chat.len(), 25);
+        // target = 25 - 20 = 5; first user at or after index 5 is index 6 (even indices are user)
+        // Actually index 5 is assistant (odd), so search finds index 6 (user)
+        let mut breakpoint_idx = None;
+        for (i, msg) in chat.iter().enumerate() {
+            let json = serde_json::to_value(msg).unwrap();
+            if json.to_string().contains("cache_control") {
+                breakpoint_idx = Some(i);
+                break;
+            }
+        }
+        let idx = breakpoint_idx.expect("must have a breakpoint somewhere");
+        assert_eq!(
+            chat[idx].role, "user",
+            "breakpoint must be on a user message"
+        );
+        // Breakpoint index must be >= max(0, total-20) = 5
+        assert!(idx >= 5, "breakpoint must be at or after position total-20");
     }
 }

--- a/crates/zeph-llm/src/snapshots/zeph_llm__claude__tests__tool_cache_serialized_shape_snapshot.snap
+++ b/crates/zeph-llm/src/snapshots/zeph_llm__claude__tests__tool_cache_serialized_shape_snapshot.snap
@@ -18,6 +18,9 @@ expression: pretty
       "required": [
         "command"
       ]
+    },
+    "cache_control": {
+      "type": "ephemeral"
     }
   }
 ]


### PR DESCRIPTION
## Summary

Fixes five compliance gaps in `ClaudeProvider` identified by auditing against the current Anthropic prompt caching documentation.

| Issue | Severity | Fix |
|-------|----------|-----|
| #1085 | safe | Remove outdated `anthropic-beta: prompt-caching-2024-07-31` header (GA, no longer needed) |
| #1083 | high | Move skills/catalog into Block 1; add model-aware `cache_min_tokens` threshold check |
| #1084 | medium | Add `cache_control: ephemeral` to last tool entry in `get_or_build_api_tools` |
| #1086 | medium | Top-level `cache_control` on request structs for multi-turn auto caching |
| #1087 | low | Message-level `cache_control` at `max(0, total - 20)` for 20-block lookback |

Also replaces `CacheControl.cache_type: String` with `enum CacheType { Ephemeral }` for compile-time safety.

**Cache breakpoint budget**: `tools(1) + system(2) + messages(1) = 4` (at limit, none wasted).

## Changes

- `crates/zeph-llm/src/claude.rs` — all caching logic, `CacheType` enum, `CacheControl` struct, tool/message/request-level cache_control, threshold guard
- `crates/zeph-core/src/agent/context.rs` — `<!-- cache:stable -->` marker moved after skills + catalog (Block 1 now exceeds minimum token threshold)
- Snapshot updated for tool serialization shape

## Tests

12 new unit tests added in `zeph-llm` covering:
- `anthropic-beta` header absence (#1085)
- Only last tool carries `cache_control` (#1084, 2 tests)
- `cache_min_tokens` per model: sonnet/opus/haiku, boundary (#1083, 4 tests)
- Top-level `cache_control` conditional on `messages.len() > 1` (#1086, 2 tests)
- Message breakpoint at `max(0, total - 20)` (#1087, 3 tests)

Total: 3211 tests pass (was 3183 before epic).

## Follow-up issues

- #1093 — `cache_user_messages` config toggle for PII opt-out
- #1094 — include schema hash in tool cache invalidation key
- #1095 — tracing for auto_cache activation
- #1096 — apply threshold check to no-markers fallback path

Closes #1083, #1084, #1085, #1086, #1087