### PR TITLE
fix(memory): sanitize FTS5 query to prevent syntax errors on special chars

### DIFF
--- a/crates/zeph-memory/src/sqlite/messages.rs
+++ b/crates/zeph-memory/src/sqlite/messages.rs
@@ -7,6 +7,19 @@ use super::SqliteStore;
 use crate::error::MemoryError;
 use crate::types::{ConversationId, MessageId};
 
+/// Sanitize an arbitrary string into a valid FTS5 query.
+///
+/// Extracts alphanumeric tokens and joins them with spaces. FTS5 special
+/// characters (`,`, `"`, `*`, `(`, `)`, `^`, `-`, `+`) are stripped to avoid
+/// syntax errors in the `MATCH` clause.
+fn sanitize_fts5_query(query: &str) -> String {
+    query
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|t| !t.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 fn parse_role(s: &str) -> Role {
     match s {
         "assistant" => Role::Assistant,
@@ -457,6 +470,10 @@ impl SqliteStore {
         conversation_id: Option<ConversationId>,
     ) -> Result<Vec<(MessageId, f64)>, MemoryError> {
         let effective_limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let safe_query = sanitize_fts5_query(query);
+        if safe_query.is_empty() {
+            return Ok(Vec::new());
+        }
 
         let rows: Vec<(MessageId, f64)> = if let Some(cid) = conversation_id {
             sqlx::query_as(
@@ -467,7 +484,7 @@ impl SqliteStore {
                  ORDER BY rank \
                  LIMIT ?",
             )
-            .bind(query)
+            .bind(&safe_query)
             .bind(cid)
             .bind(effective_limit)
             .fetch_all(&self.pool)
@@ -481,7 +498,7 @@ impl SqliteStore {
                  ORDER BY rank \
                  LIMIT ?",
             )
-            .bind(query)
+            .bind(&safe_query)
             .bind(effective_limit)
             .fetch_all(&self.pool)
             .await?
@@ -942,6 +959,31 @@ mod tests {
 
         let results = store.keyword_search("test", 3, None).await.unwrap();
         assert_eq!(results.len(), 3);
+    }
+
+    #[test]
+    fn sanitize_fts5_query_strips_special_chars() {
+        assert_eq!(sanitize_fts5_query("skill-audit"), "skill audit");
+        assert_eq!(sanitize_fts5_query("hello, world"), "hello world");
+        assert_eq!(sanitize_fts5_query("a+b*c^d"), "a b c d");
+        assert_eq!(sanitize_fts5_query("  "), "");
+        assert_eq!(sanitize_fts5_query("rust programming"), "rust programming");
+    }
+
+    #[tokio::test]
+    async fn keyword_search_with_special_chars_does_not_error() {
+        let store = test_store().await;
+        let cid = store.create_conversation().await.unwrap();
+        store
+            .save_message(cid, "user", "skill audit info")
+            .await
+            .unwrap();
+        // query with comma and special chars — previously caused FTS5 syntax error
+        // result may be empty; important is that no error is returned
+        store
+            .keyword_search("skill-audit, confidence=0.1", 10, None)
+            .await
+            .unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

Queries containing FTS5 operator characters (`,`, `-`, `*`, `^`, etc.) caused a
runtime warning and silently degraded memory recall:

```
WARN zeph_memory::semantic: FTS5 keyword search failed: fts5: syntax error near ","
```

Reproduced when a skill name like `skill-audit` or a query fragment with a comma
was passed directly as the `MATCH` argument.

## Solution

- Add `sanitize_fts5_query()` in `sqlite/messages.rs` that extracts only
  alphanumeric tokens, dropping all FTS5 operator characters.
- Return an empty `Vec` immediately when the sanitized query is empty (avoids a
  no-op DB round-trip).
- Apply sanitization in both branches of `keyword_search` (with and without
  conversation filter).

## Tests

- Unit test `sanitize_fts5_query_strips_special_chars` — verifies edge cases
  (hyphens, commas, operators, whitespace-only input, plain words).
- Integration test `keyword_search_with_special_chars_does_not_error` — verifies
  no error is returned for the exact query pattern from the production log.