### PR TITLE
fix(scrape): raise default max_body_bytes from 1 MiB to 4 MiB

### DIFF
--- a/crates/zeph-core/src/config/snapshots/zeph_core__config__types__tests__config_default_snapshot.snap
+++ b/crates/zeph-core/src/config/snapshots/zeph_core__config__types__tests__config_default_snapshot.snap
@@ -118,7 +118,7 @@ confirm_patterns = [
 
 [tools.scrape]
 timeout = 15
-max_body_bytes = 1048576
+max_body_bytes = 4194304
 
 [tools.audit]
 enabled = false

--- a/crates/zeph-tools/src/config.rs
+++ b/crates/zeph-tools/src/config.rs
@@ -209,7 +209,7 @@ fn default_scrape_timeout() -> u64 {
 }
 
 fn default_max_body_bytes() -> usize {
-    1_048_576
+    4_194_304
 }
 
 /// Configuration for the web scrape tool.
@@ -310,7 +310,7 @@ mod tests {
         assert!(config.shell.allow_network);
         assert!(!config.shell.confirm_patterns.is_empty());
         assert_eq!(config.scrape.timeout, 15);
-        assert_eq!(config.scrape.max_body_bytes, 1_048_576);
+        assert_eq!(config.scrape.max_body_bytes, 4_194_304);
         assert!(!config.audit.enabled);
         assert_eq!(config.audit.destination, "stdout");
         assert!(config.summarize_output);
@@ -320,7 +320,7 @@ mod tests {
     fn default_scrape_config() {
         let config = ScrapeConfig::default();
         assert_eq!(config.timeout, 15);
-        assert_eq!(config.max_body_bytes, 1_048_576);
+        assert_eq!(config.max_body_bytes, 4_194_304);
     }
 
     #[test]
@@ -340,7 +340,7 @@ mod tests {
     fn tools_config_default_includes_scrape() {
         let config = ToolsConfig::default();
         assert_eq!(config.scrape.timeout, 15);
-        assert_eq!(config.scrape.max_body_bytes, 1_048_576);
+        assert_eq!(config.scrape.max_body_bytes, 4_194_304);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Raises `default_max_body_bytes` from 1 048 576 (1 MiB) to 4 194 304 (4 MiB) in `ScrapeConfig`
- Fixes "response too large" errors when scraping documentation pages that exceed 1 MiB of raw HTML
- Updates insta snapshot (`config_default_snapshot`) and all affected unit test assertions

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` — all 3374 tests pass
- [ ] `cargo clippy --workspace -- -D warnings` — zero warnings
- [ ] `cargo +nightly fmt --check` — clean