### PR TITLE
fix(scheduler): enable scheduler by default

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -439,7 +439,7 @@ max_restart_backoff_secs = 60
 
 [scheduler]
 # Enable cron scheduler (feature-gated: --features scheduler)
-enabled = false
+enabled = true
 # Example task definitions:
 # [[scheduler.tasks]]
 # name = "memory_cleanup"

--- a/crates/zeph-core/src/config/snapshots/zeph_core__config__types__tests__config_default_snapshot.snap
+++ b/crates/zeph-core/src/config/snapshots/zeph_core__config__types__tests__config_default_snapshot.snap
@@ -201,7 +201,7 @@ health_interval_secs = 30
 max_restart_backoff_secs = 60
 
 [scheduler]
-enabled = false
+enabled = true
 tick_interval_secs = 60
 max_tasks = 100
 tasks = []

--- a/crates/zeph-core/src/config/types.rs
+++ b/crates/zeph-core/src/config/types.rs
@@ -1296,7 +1296,7 @@ pub struct SchedulerConfig {
 impl Default for SchedulerConfig {
     fn default() -> Self {
         Self {
-            enabled: false,
+            enabled: true,
             tick_interval_secs: default_scheduler_tick_interval(),
             max_tasks: default_scheduler_max_tasks(),
             tasks: Vec::new(),
@@ -1692,7 +1692,7 @@ mod tests {
     #[test]
     fn scheduler_config_defaults() {
         let cfg = SchedulerConfig::default();
-        assert!(!cfg.enabled);
+        assert!(cfg.enabled);
         assert_eq!(cfg.tick_interval_secs, 60);
         assert_eq!(cfg.max_tasks, 100);
         assert!(cfg.tasks.is_empty());


### PR DESCRIPTION
## Summary

- `SchedulerConfig::default().enabled` changed from `false` to `true`
- `config/default.toml` updated accordingly
- Config snapshot and unit test updated to match new default

Without this change, the scheduler skill was selected by the LLM but
`schedule_periodic` / `schedule_deferred` / `cancel_task` tools were
never registered — `bootstrap_scheduler` returned `None` because
`config.scheduler.enabled` defaulted to `false`.