### PR TITLE
feat(subagents): migrate definition format from TOML to YAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Sub-agent definition format migrated from `+++` TOML frontmatter to `---` YAML frontmatter (Claude Code spec compatible); `+++` TOML remains supported as a deprecated fallback with a `tracing::warn!` log (#1146)
+
+### Added
+
+- `serde_norway = "0.9.42"` dependency for YAML parsing in sub-agent definitions (replaces TOML-only parsing)
+- `FrontmatterFormat` enum in `zeph-core` routes sub-agent definitions to the correct deserializer based on detected delimiter
+- 256 KiB file size cap in `SubAgentDef::load()` to prevent DoS via oversized definition files
+- Control character validation (ASCII < 0x20 excluding tab, plus DEL 0x7F) for `name` and `description` fields in sub-agent definitions
+
 ## [0.12.6] - 2026-03-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6108,6 +6108,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_norway"
+version = "0.9.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
+dependencies = [
+ "indexmap 2.13.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml-norway",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8040,6 +8053,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9303,6 +9322,7 @@ dependencies = [
  "criterion",
  "dirs",
  "futures",
+ "indoc",
  "insta",
  "notify",
  "notify-debouncer-mini",
@@ -9312,6 +9332,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "serde_norway",
  "serial_test",
  "tempfile",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ glob = "0.3.3"
 hf-hub = { version = "0.5", default-features = false, features = ["tokio", "rustls-tls", "ureq"] }
 http-body-util = "0.1"
 ignore = "0.4"
+indoc = "2"
 insta = { version = "1.46.3", features = ["toml", "filters"] }
 notify = "8"
 notify-debouncer-mini = "0.7"
@@ -71,6 +72,7 @@ scrape-core = "0.2"
 semver = "1.0.27"
 serde = "1.0"
 serde_json = "1.0"
+serde_norway = "0.9.42"
 serial_test = "3.4"
 similar = "2.7"
 sqlx = { version = "0.8", default-features = false, features = ["macros"] }

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -34,6 +34,7 @@ schemars.workspace = true
 dirs.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+serde_norway.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["fs", "macros", "rt-multi-thread", "sync", "time"] }
 tokio-util.workspace = true
@@ -56,6 +57,7 @@ harness = false
 
 [dev-dependencies]
 criterion.workspace = true
+indoc.workspace = true
 insta.workspace = true
 proptest.workspace = true
 schemars.workspace = true

--- a/crates/zeph-core/src/subagent/def.rs
+++ b/crates/zeph-core/src/subagent/def.rs
@@ -8,6 +8,11 @@ use serde::{Deserialize, Serialize};
 
 use super::error::SubAgentError;
 
+/// Maximum allowed size for a sub-agent definition file (256 KiB).
+///
+/// Files larger than this are rejected before parsing to cap memory usage.
+const MAX_DEF_SIZE: usize = 256 * 1024;
+
 // ── Public types ──────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -56,7 +61,9 @@ pub struct SkillFilter {
     pub exclude: Vec<String>,
 }
 
-// ── Raw TOML deserialization structs ─────────────────────────────────────────
+// ── Raw deserialization structs ───────────────────────────────────────────────
+// These work for both YAML and TOML deserializers — only the deserializer call
+// differs based on detected frontmatter format.
 
 #[derive(Deserialize)]
 struct RawSubAgentDef {
@@ -121,11 +128,26 @@ fn default_ttl() -> u64 {
     300
 }
 
-// ── Parser ────────────────────────────────────────────────────────────────────
+// ── Frontmatter format detection ──────────────────────────────────────────────
 
-/// Split TOML frontmatter from markdown body.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FrontmatterFormat {
+    Yaml,
+    Toml,
+}
+
+/// Split frontmatter from markdown body, detecting format from opening delimiter.
 ///
-/// Expected format:
+/// YAML frontmatter (primary):
+/// ```text
+/// ---
+/// <yaml content>
+/// ---
+///
+/// <body>
+/// ```
+///
+/// TOML frontmatter (deprecated):
 /// ```text
 /// +++
 /// <toml content>
@@ -133,60 +155,125 @@ fn default_ttl() -> u64 {
 ///
 /// <body>
 /// ```
-fn split_toml_frontmatter<'a>(
+fn split_frontmatter<'a>(
     content: &'a str,
     path: &str,
-) -> Result<(&'a str, &'a str), SubAgentError> {
+) -> Result<(&'a str, &'a str, FrontmatterFormat), SubAgentError> {
     let make_err = |reason: &str| SubAgentError::Parse {
         path: path.to_owned(),
         reason: reason.to_owned(),
     };
 
-    let rest = content
+    if let Some(rest) = content
+        .strip_prefix("---")
+        .and_then(|s| s.strip_prefix('\n').or_else(|| s.strip_prefix("\r\n")))
+    {
+        // YAML: closing delimiter is \n---\n or \n--- at EOF.
+        // Note: `split_once("\n---")` matches `\r\n---` because `\r\n` contains `\n`.
+        // The leading `\r` is left in `yaml_str` but removed by CRLF normalization in
+        // `parse_with_path`. Do not remove that normalization without updating this search.
+        let (yaml_str, after) = rest
+            .split_once("\n---")
+            .ok_or_else(|| make_err("missing closing `---` delimiter for YAML frontmatter"))?;
+        let body = after
+            .strip_prefix('\n')
+            .or_else(|| after.strip_prefix("\r\n"))
+            .unwrap_or(after);
+        return Ok((yaml_str, body, FrontmatterFormat::Yaml));
+    }
+
+    if let Some(rest) = content
         .strip_prefix("+++")
         .and_then(|s| s.strip_prefix('\n').or_else(|| s.strip_prefix("\r\n")))
-        .ok_or_else(|| make_err("missing opening `+++` delimiter"))?;
+    {
+        // Same CRLF note as YAML branch above: trailing `\r` is cleaned by normalization.
+        let (toml_str, after) = rest
+            .split_once("\n+++")
+            .ok_or_else(|| make_err("missing closing `+++` delimiter for TOML frontmatter"))?;
+        let body = after
+            .strip_prefix('\n')
+            .or_else(|| after.strip_prefix("\r\n"))
+            .unwrap_or(after);
+        return Ok((toml_str, body, FrontmatterFormat::Toml));
+    }
 
-    let (toml_str, after) = rest
-        .split_once("\n+++")
-        .ok_or_else(|| make_err("missing closing `+++` delimiter"))?;
-
-    // body starts after optional newline following the closing +++
-    let body = after
-        .strip_prefix('\n')
-        .or_else(|| after.strip_prefix("\r\n"))
-        .unwrap_or(after);
-
-    Ok((toml_str, body))
+    Err(make_err(
+        "missing frontmatter delimiters: expected `---` (YAML) or `+++` (TOML, deprecated)",
+    ))
 }
 
 impl SubAgentDef {
-    /// Parse a sub-agent definition from its markdown+TOML frontmatter content.
+    /// Parse a sub-agent definition from its frontmatter+markdown content.
+    ///
+    /// The primary format uses YAML frontmatter delimited by `---`:
+    ///
+    /// ```text
+    /// ---
+    /// name: my-agent
+    /// description: Does something useful
+    /// model: claude-sonnet-4-20250514
+    /// tools:
+    ///   allow:
+    ///     - shell
+    /// permissions:
+    ///   max_turns: 10
+    /// skills:
+    ///   include:
+    ///     - "git-*"
+    /// ---
+    ///
+    /// You are a helpful agent.
+    /// ```
+    ///
+    /// TOML frontmatter (`+++`) is supported as a deprecated fallback and will emit a
+    /// `tracing::warn!` message. It will be removed in v1.0.0.
     ///
     /// # Errors
     ///
     /// Returns [`SubAgentError::Parse`] if the frontmatter delimiters are missing or the
-    /// TOML is malformed, and [`SubAgentError::Invalid`] if required fields are empty or
+    /// content is malformed, and [`SubAgentError::Invalid`] if required fields are empty or
     /// `tools.allow` and `tools.deny` are both specified.
     pub fn parse(content: &str) -> Result<Self, SubAgentError> {
         Self::parse_with_path(content, "<unknown>")
     }
 
     fn parse_with_path(content: &str, path: &str) -> Result<Self, SubAgentError> {
-        let (toml_str, body) = split_toml_frontmatter(content, path)?;
+        let (frontmatter_str, body, format) = split_frontmatter(content, path)?;
 
-        // Normalize CRLF in the TOML block — the `toml` crate rejects bare `\r`.
-        let toml_normalized;
-        let toml_str = if toml_str.contains('\r') {
-            toml_normalized = toml_str.replace("\r\n", "\n").replace('\r', "\n");
-            &toml_normalized
-        } else {
-            toml_str
+        let raw: RawSubAgentDef = match format {
+            FrontmatterFormat::Yaml => {
+                // Normalize CRLF so numeric/bool fields parse correctly on Windows line endings.
+                let yaml_normalized;
+                let yaml_str = if frontmatter_str.contains('\r') {
+                    yaml_normalized = frontmatter_str.replace("\r\n", "\n").replace('\r', "\n");
+                    &yaml_normalized
+                } else {
+                    frontmatter_str
+                };
+                serde_norway::from_str(yaml_str).map_err(|e| SubAgentError::Parse {
+                    path: path.to_owned(),
+                    reason: e.to_string(),
+                })?
+            }
+            FrontmatterFormat::Toml => {
+                tracing::warn!(
+                    path,
+                    "sub-agent definition uses deprecated +++ TOML frontmatter, migrate to --- YAML"
+                );
+                // Normalize CRLF — the `toml` crate rejects bare `\r`.
+                let toml_normalized;
+                let toml_str = if frontmatter_str.contains('\r') {
+                    toml_normalized = frontmatter_str.replace("\r\n", "\n").replace('\r', "\n");
+                    &toml_normalized
+                } else {
+                    frontmatter_str
+                };
+                toml::from_str(toml_str).map_err(|e| SubAgentError::Parse {
+                    path: path.to_owned(),
+                    reason: e.to_string(),
+                })?
+            }
         };
-        let raw: RawSubAgentDef = toml::from_str(toml_str).map_err(|e| SubAgentError::Parse {
-            path: path.to_owned(),
-            reason: e.to_string(),
-        })?;
 
         if raw.name.trim().is_empty() {
             return Err(SubAgentError::Invalid("name must not be empty".into()));
@@ -194,6 +281,24 @@ impl SubAgentDef {
         if raw.description.trim().is_empty() {
             return Err(SubAgentError::Invalid(
                 "description must not be empty".into(),
+            ));
+        }
+        if raw
+            .name
+            .chars()
+            .any(|c| (c < '\x20' && c != '\t') || c == '\x7F')
+        {
+            return Err(SubAgentError::Invalid(
+                "name must not contain control characters".into(),
+            ));
+        }
+        if raw
+            .description
+            .chars()
+            .any(|c| (c < '\x20' && c != '\t') || c == '\x7F')
+        {
+            return Err(SubAgentError::Invalid(
+                "description must not contain control characters".into(),
             ));
         }
 
@@ -233,13 +338,24 @@ impl SubAgentDef {
     ///
     /// # Errors
     ///
-    /// Returns [`SubAgentError::Parse`] if the file cannot be read or parsed.
+    /// Returns [`SubAgentError::Parse`] if the file cannot be read, exceeds 256 KiB, or fails
+    /// to parse.
     pub fn load(path: &Path) -> Result<Self, SubAgentError> {
+        let path_str = path.display().to_string();
         let content = std::fs::read_to_string(path).map_err(|e| SubAgentError::Parse {
-            path: path.display().to_string(),
+            path: path_str.clone(),
             reason: e.to_string(),
         })?;
-        Self::parse_with_path(&content, &path.display().to_string())
+        if content.len() > MAX_DEF_SIZE {
+            return Err(SubAgentError::Parse {
+                path: path_str.clone(),
+                reason: format!(
+                    "definition file exceeds maximum size of {} KiB",
+                    MAX_DEF_SIZE / 1024
+                ),
+            });
+        }
+        Self::parse_with_path(&content, &path_str)
     }
 
     /// Load all definitions from a list of directories.
@@ -291,36 +407,211 @@ impl SubAgentDef {
 
 #[cfg(test)]
 mod tests {
+    use indoc::indoc;
+
     use super::*;
 
-    const FULL_DEF: &str = r#"+++
-name = "code-reviewer"
-description = "Reviews code changes for correctness and style"
-model = "claude-sonnet-4-20250514"
+    // ── YAML fixtures (primary format) ─────────────────────────────────────────
 
-[tools]
-allow = ["shell", "web_scrape"]
+    const FULL_DEF_YAML: &str = indoc! {"
+        ---
+        name: code-reviewer
+        description: Reviews code changes for correctness and style
+        model: claude-sonnet-4-20250514
+        tools:
+          allow:
+            - shell
+            - web_scrape
+        permissions:
+          secrets:
+            - github-token
+          max_turns: 10
+          background: false
+          timeout_secs: 300
+          ttl_secs: 120
+        skills:
+          include:
+            - \"git-*\"
+            - \"rust-*\"
+          exclude:
+            - \"deploy-*\"
+        ---
 
-[permissions]
-secrets = ["github-token"]
-max_turns = 10
-background = false
-timeout_secs = 300
-ttl_secs = 120
+        You are a code reviewer. Report findings with severity.
+    "};
 
-[skills]
-include = ["git-*", "rust-*"]
-exclude = ["deploy-*"]
-+++
+    const MINIMAL_DEF_YAML: &str = indoc! {"
+        ---
+        name: bot
+        description: A bot
+        ---
 
-You are a code reviewer. Report findings with severity.
-"#;
+        Do things.
+    "};
 
-    const MINIMAL_DEF: &str = "+++\nname = \"bot\"\ndescription = \"A bot\"\n+++\n\nDo things.\n";
+    // ── TOML fixtures (deprecated fallback) ────────────────────────────────────
+
+    const FULL_DEF_TOML: &str = indoc! {"
+        +++
+        name = \"code-reviewer\"
+        description = \"Reviews code changes for correctness and style\"
+        model = \"claude-sonnet-4-20250514\"
+
+        [tools]
+        allow = [\"shell\", \"web_scrape\"]
+
+        [permissions]
+        secrets = [\"github-token\"]
+        max_turns = 10
+        background = false
+        timeout_secs = 300
+        ttl_secs = 120
+
+        [skills]
+        include = [\"git-*\", \"rust-*\"]
+        exclude = [\"deploy-*\"]
+        +++
+
+        You are a code reviewer. Report findings with severity.
+    "};
+
+    const MINIMAL_DEF_TOML: &str = indoc! {"
+        +++
+        name = \"bot\"
+        description = \"A bot\"
+        +++
+
+        Do things.
+    "};
+
+    // ── YAML tests ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_yaml_full_definition() {
+        let def = SubAgentDef::parse(FULL_DEF_YAML).unwrap();
+        assert_eq!(def.name, "code-reviewer");
+        assert_eq!(
+            def.description,
+            "Reviews code changes for correctness and style"
+        );
+        assert_eq!(def.model.as_deref(), Some("claude-sonnet-4-20250514"));
+        assert!(matches!(def.tools, ToolPolicy::AllowList(ref v) if v == &["shell", "web_scrape"]));
+        assert_eq!(def.permissions.max_turns, 10);
+        assert_eq!(def.permissions.secrets, ["github-token"]);
+        assert_eq!(def.skills.include, ["git-*", "rust-*"]);
+        assert_eq!(def.skills.exclude, ["deploy-*"]);
+        assert!(def.system_prompt.contains("code reviewer"));
+    }
+
+    #[test]
+    fn parse_yaml_minimal_definition() {
+        let def = SubAgentDef::parse(MINIMAL_DEF_YAML).unwrap();
+        assert_eq!(def.name, "bot");
+        assert_eq!(def.description, "A bot");
+        assert!(def.model.is_none());
+        assert!(matches!(def.tools, ToolPolicy::InheritAll));
+        assert_eq!(def.permissions.max_turns, 20);
+        assert_eq!(def.permissions.timeout_secs, 600);
+        assert_eq!(def.permissions.ttl_secs, 300);
+        assert!(!def.permissions.background);
+        assert_eq!(def.system_prompt, "Do things.");
+    }
+
+    #[test]
+    fn parse_yaml_with_dashes_in_body() {
+        // --- in the body after the closing --- delimiter must not break the parser
+        let content = "---\nname: agent\ndescription: desc\n---\n\nSome text\n---\nMore text\n";
+        let def = SubAgentDef::parse(content).unwrap();
+        assert_eq!(def.name, "agent");
+        assert!(def.system_prompt.contains("Some text"));
+        assert!(def.system_prompt.contains("More text"));
+    }
+
+    #[test]
+    fn parse_yaml_tool_deny_list() {
+        let content = "---\nname: a\ndescription: b\ntools:\n  deny:\n    - shell\n---\n\nbody\n";
+        let def = SubAgentDef::parse(content).unwrap();
+        assert!(matches!(def.tools, ToolPolicy::DenyList(ref v) if v == &["shell"]));
+    }
+
+    #[test]
+    fn parse_yaml_tool_inherit_all() {
+        // Explicit tools section with neither allow nor deny also yields InheritAll.
+        let content = "---\nname: a\ndescription: b\ntools: {}\n---\n\nbody\n";
+        let def = SubAgentDef::parse(content).unwrap();
+        assert!(matches!(def.tools, ToolPolicy::InheritAll));
+    }
+
+    #[test]
+    fn parse_yaml_tool_both_specified_is_error() {
+        let content = "---\nname: a\ndescription: b\ntools:\n  allow:\n    - x\n  deny:\n    - y\n---\n\nbody\n";
+        let err = SubAgentDef::parse(content).unwrap_err();
+        assert!(matches!(err, SubAgentError::Invalid(_)));
+    }
+
+    #[test]
+    fn parse_yaml_missing_closing_delimiter() {
+        let err = SubAgentDef::parse("---\nname: a\ndescription: b\n").unwrap_err();
+        assert!(matches!(err, SubAgentError::Parse { .. }));
+    }
+
+    #[test]
+    fn parse_yaml_crlf_line_endings() {
+        let content = "---\r\nname: bot\r\ndescription: A bot\r\n---\r\n\r\nDo things.\r\n";
+        let def = SubAgentDef::parse(content).unwrap();
+        assert_eq!(def.name, "bot");
+        assert_eq!(def.description, "A bot");
+        assert!(!def.system_prompt.is_empty());
+    }
+
+    #[test]
+    fn parse_yaml_missing_required_field_name() {
+        let content = "---\ndescription: b\n---\n\nbody\n";
+        let err = SubAgentDef::parse(content).unwrap_err();
+        assert!(matches!(err, SubAgentError::Parse { .. }));
+    }
+
+    #[test]
+    fn parse_yaml_missing_required_field_description() {
+        let content = "---\nname: a\n---\n\nbody\n";
+        let err = SubAgentDef::parse(content).unwrap_err();
+        assert!(matches!(err, SubAgentError::Parse { .. }));
+    }
+
+    #[test]
+    fn parse_yaml_empty_name_is_invalid() {
+        let content = "---\nname: \"\"\ndescription: b\n---\n\nbody\n";
+        let err = SubAgentDef::parse(content).unwrap_err();
+        assert!(matches!(err, SubAgentError::Invalid(_)));
+    }
+
+    #[test]
+    fn parse_yaml_whitespace_only_description_is_invalid() {
+        let content = "---\nname: a\ndescription: \"   \"\n---\n\nbody\n";
+        let err = SubAgentDef::parse(content).unwrap_err();
+        assert!(matches!(err, SubAgentError::Invalid(_)));
+    }
+
+    #[test]
+    fn parse_yaml_crlf_with_numeric_fields() {
+        let content = "---\r\nname: bot\r\ndescription: A bot\r\npermissions:\r\n  max_turns: 5\r\n  timeout_secs: 120\r\n---\r\n\r\nDo things.\r\n";
+        let def = SubAgentDef::parse(content).unwrap();
+        assert_eq!(def.permissions.max_turns, 5);
+        assert_eq!(def.permissions.timeout_secs, 120);
+    }
+
+    #[test]
+    fn parse_yaml_no_trailing_newline() {
+        let content = "---\nname: a\ndescription: b\n---";
+        let def = SubAgentDef::parse(content).unwrap();
+        assert_eq!(def.system_prompt, "");
+    }
+
+    // ── TOML deprecated fallback tests ─────────────────────────────────────────
 
     #[test]
     fn parse_full_definition() {
-        let def = SubAgentDef::parse(FULL_DEF).unwrap();
+        let def = SubAgentDef::parse(FULL_DEF_TOML).unwrap();
         assert_eq!(def.name, "code-reviewer");
         assert_eq!(
             def.description,
@@ -337,7 +628,7 @@ You are a code reviewer. Report findings with severity.
 
     #[test]
     fn parse_minimal_definition() {
-        let def = SubAgentDef::parse(MINIMAL_DEF).unwrap();
+        let def = SubAgentDef::parse(MINIMAL_DEF_TOML).unwrap();
         assert_eq!(def.name, "bot");
         assert_eq!(def.description, "A bot");
         assert!(def.model.is_none());
@@ -359,7 +650,7 @@ You are a code reviewer. Report findings with severity.
 
     #[test]
     fn tool_policy_inherit_all() {
-        let def = SubAgentDef::parse(MINIMAL_DEF).unwrap();
+        let def = SubAgentDef::parse(MINIMAL_DEF_TOML).unwrap();
         assert!(matches!(def.tools, ToolPolicy::InheritAll));
     }
 
@@ -409,9 +700,8 @@ You are a code reviewer. Report findings with severity.
         let dir1 = tempfile::tempdir().unwrap();
         let dir2 = tempfile::tempdir().unwrap();
 
-        // Same name "bot" in both dirs — dir1 wins (higher priority)
-        let content1 = "+++\nname = \"bot\"\ndescription = \"from dir1\"\n+++\n\ndir1 prompt\n";
-        let content2 = "+++\nname = \"bot\"\ndescription = \"from dir2\"\n+++\n\ndir2 prompt\n";
+        let content1 = "---\nname: bot\ndescription: from dir1\n---\n\ndir1 prompt\n";
+        let content2 = "---\nname: bot\ndescription: from dir2\n---\n\ndir2 prompt\n";
 
         let mut f1 = std::fs::File::create(dir1.path().join("bot.md")).unwrap();
         f1.write_all(content1.as_bytes()).unwrap();
@@ -452,7 +742,6 @@ You are a code reviewer. Report findings with severity.
 
     #[test]
     fn parse_crlf_line_endings() {
-        // Windows-style CRLF line endings must be accepted without error.
         let content =
             "+++\r\nname = \"bot\"\r\ndescription = \"A bot\"\r\n+++\r\n\r\nDo things.\r\n";
         let def = SubAgentDef::parse(content).unwrap();
@@ -463,7 +752,6 @@ You are a code reviewer. Report findings with severity.
 
     #[test]
     fn parse_crlf_closing_delimiter() {
-        // Verify that \r\n after the closing +++ is stripped correctly.
         let content = "+++\r\nname = \"bot\"\r\ndescription = \"A bot\"\r\n+++\r\nPrompt here.\r\n";
         let def = SubAgentDef::parse(content).unwrap();
         assert!(def.system_prompt.contains("Prompt here"));
@@ -474,7 +762,7 @@ You are a code reviewer. Report findings with severity.
         use std::io::Write as _;
         let dir = tempfile::tempdir().unwrap();
 
-        let valid = "+++\nname = \"good\"\ndescription = \"ok\"\n+++\n\nbody\n";
+        let valid = "---\nname: good\ndescription: ok\n---\n\nbody\n";
         let invalid = "this is not valid frontmatter";
 
         let mut f1 = std::fs::File::create(dir.path().join("a_good.md")).unwrap();

--- a/crates/zeph-core/src/subagent/manager.rs
+++ b/crates/zeph-core/src/subagent/manager.rs
@@ -568,6 +568,7 @@ impl SubAgentManager {
 mod tests {
     use std::pin::Pin;
 
+    use indoc::indoc;
     use zeph_llm::any::AnyProvider;
     use zeph_llm::mock::MockProvider;
     use zeph_tools::ToolCall;
@@ -581,13 +582,12 @@ mod tests {
     }
 
     fn sample_def() -> SubAgentDef {
-        SubAgentDef::parse("+++\nname = \"bot\"\ndescription = \"A bot\"\n+++\n\nDo things.\n")
-            .unwrap()
+        SubAgentDef::parse("---\nname: bot\ndescription: A bot\n---\n\nDo things.\n").unwrap()
     }
 
     fn def_with_secrets() -> SubAgentDef {
         SubAgentDef::parse(
-            "+++\nname = \"bot\"\ndescription = \"A bot\"\n[permissions]\nsecrets = [\"api-key\"]\n+++\n\nDo things.\n",
+            "---\nname: bot\ndescription: A bot\npermissions:\n  secrets:\n    - api-key\n---\n\nDo things.\n",
         )
         .unwrap()
     }
@@ -661,7 +661,7 @@ mod tests {
     fn load_definitions_populates_vec() {
         use std::io::Write as _;
         let dir = tempfile::tempdir().unwrap();
-        let content = "+++\nname = \"helper\"\ndescription = \"A helper\"\n+++\n\nHelp.\n";
+        let content = "---\nname: helper\ndescription: A helper\n---\n\nHelp.\n";
         let mut f = std::fs::File::create(dir.path().join("helper.md")).unwrap();
         f.write_all(content.as_bytes()).unwrap();
 
@@ -811,9 +811,16 @@ mod tests {
     async fn max_turns_terminates_agent_loop() {
         let mut mgr = make_manager();
         // max_turns = 1, mock returns empty (no tool call), so loop ends after 1 turn
-        let def = SubAgentDef::parse(
-            "+++\nname = \"limited\"\ndescription = \"A bot\"\n[permissions]\nmax_turns = 1\n+++\n\nDo one thing.\n",
-        )
+        let def = SubAgentDef::parse(indoc! {"
+            ---
+            name: limited
+            description: A bot
+            permissions:
+              max_turns: 1
+            ---
+
+            Do one thing.
+        "})
         .unwrap();
         mgr.definitions.push(def);
 

--- a/docs/src/advanced/sub-agents.md
+++ b/docs/src/advanced/sub-agents.md
@@ -7,10 +7,10 @@ Sub-agents let you delegate tasks to specialized helpers that work in the backgr
 1. Create a definition file:
 
 ```markdown
-+++
-name = "code-reviewer"
-description = "Reviews code for correctness and style"
-+++
+---
+name: code-reviewer
+description: Reviews code for correctness and style
+---
 
 You are a code reviewer. Analyze the provided code for bugs, performance issues, and idiomatic style.
 ```
@@ -65,17 +65,19 @@ Cancelled sub-agent a1b2c3d4-...
 
 ## Writing Definitions
 
-A definition is a markdown file with TOML frontmatter between `+++` delimiters. The body after the closing `+++` becomes the sub-agent's system prompt.
+A definition is a markdown file with YAML frontmatter between `---` delimiters. The body after the closing `---` becomes the sub-agent's system prompt.
+
+> **Note:** Prior to v0.13, definitions used TOML frontmatter (`+++`). That format is still accepted but deprecated and will be removed in v1.0.0. Migrate by replacing `+++` delimiters with `---` and converting the body to YAML syntax.
 
 ### Minimal Definition
 
 Only `name` and `description` are required. Everything else has sensible defaults:
 
 ```markdown
-+++
-name = "helper"
-description = "General-purpose helper"
-+++
+---
+name: helper
+description: General-purpose helper
+---
 
 You are a helpful assistant. Complete the given task concisely.
 ```
@@ -83,24 +85,27 @@ You are a helpful assistant. Complete the given task concisely.
 ### Full Definition
 
 ```markdown
-+++
-name = "code-reviewer"
-description = "Reviews code changes for correctness and style"
-model = "claude-sonnet-4-20250514"
-
-[tools]
-allow = ["shell", "web_scrape"]
-
-[permissions]
-secrets = ["github-token"]
-max_turns = 10
-timeout_secs = 300
-ttl_secs = 120
-
-[skills]
-include = ["git-*", "rust-*"]
-exclude = ["deploy-*"]
-+++
+---
+name: code-reviewer
+description: Reviews code changes for correctness and style
+model: claude-sonnet-4-20250514
+tools:
+  allow:
+    - shell
+    - web_scrape
+permissions:
+  secrets:
+    - github-token
+  max_turns: 10
+  timeout_secs: 300
+  ttl_secs: 120
+skills:
+  include:
+    - "git-*"
+    - "rust-*"
+  exclude:
+    - "deploy-*"
+---
 
 You are a code reviewer. Analyze the provided code for:
 - Correctness bugs
@@ -142,8 +147,19 @@ If neither `tools.allow` nor `tools.deny` is specified, the sub-agent inherits a
 
 Control which tools a sub-agent can use:
 
-- **Allow list** — only listed tools are available: `allow = ["shell", "web_scrape"]`
-- **Deny list** — all tools except listed: `deny = ["shell"]`
+- **Allow list** — only listed tools are available:
+  ```yaml
+  tools:
+    allow:
+      - shell
+      - web_scrape
+  ```
+- **Deny list** — all tools except listed:
+  ```yaml
+  tools:
+    deny:
+      - shell
+  ```
 - **Inherit all** — omit both `allow` and `deny`
 
 Filtering is enforced at the executor level. The sub-agent's LLM only sees tool definitions it can actually call. Blocked tool calls return an error.
@@ -152,10 +168,13 @@ Filtering is enforced at the executor level. The sub-agent's LLM only sees tool 
 
 Skills are filtered by glob patterns with `*` wildcard:
 
-```toml
-[skills]
-include = ["git-*", "rust-*"]   # only matching skills
-exclude = ["deploy-*"]          # always excluded
+```yaml
+skills:
+  include:
+    - "git-*"
+    - "rust-*"
+  exclude:
+    - "deploy-*"
 ```
 
 - Empty `include` = all skills pass (unless excluded)
@@ -167,7 +186,7 @@ Sub-agents follow a zero-trust principle: they start with **zero permissions** a
 
 ### How It Works
 
-1. **Definitions declare capabilities, not permissions.** Writing `secrets = ["github-token"]` means the agent _may request_ that secret — it doesn't get it automatically.
+1. **Definitions declare capabilities, not permissions.** Writing `secrets: [github-token]` means the agent _may request_ that secret — it doesn't get it automatically.
 
 2. **Secrets require your approval.** When a sub-agent needs a secret, Zeph prompts you:
 
@@ -259,7 +278,7 @@ manager.load_definitions(&[
     dirs::config_dir().unwrap().join("zeph/agents"),
 ])?;
 
-let task_id = manager.spawn("code-reviewer", "Review src/main.rs", provider, executor)?;
+let task_id = manager.spawn("code-reviewer", "Review src/main.rs", provider, executor, None)?;
 let statuses = manager.statuses();
 manager.cancel(&task_id)?;
 let result = manager.collect(&task_id).await?;
@@ -268,7 +287,7 @@ let result = manager.collect(&task_id).await?;
 | Method | Description |
 |--------|-------------|
 | `load_definitions(&[PathBuf])` | Load `.md` definitions (first-wins deduplication) |
-| `spawn(name, prompt, provider, executor)` | Spawn a sub-agent, returns task ID |
+| `spawn(name, prompt, provider, executor, skills)` | Spawn a sub-agent, returns task ID |
 | `cancel(task_id)` | Cancel and revoke all grants |
 | `collect(task_id)` | Await result and remove from active set |
 | `statuses()` | Snapshot of all active sub-agent states |
@@ -279,7 +298,7 @@ let result = manager.collect(&task_id).await?;
 
 | Variant | When |
 |---------|------|
-| `Parse` | Invalid frontmatter or TOML |
+| `Parse` | Invalid frontmatter or YAML/TOML |
 | `Invalid` | Validation failure (empty name, mutual exclusion) |
 | `NotFound` | Unknown definition name or task ID |
 | `Spawn` | Concurrency limit reached or task panic |


### PR DESCRIPTION
## Summary

- Migrates sub-agent definition frontmatter from non-standard `+++` TOML to `---` YAML (Claude Code spec format), closes #1146
- `+++` TOML remains supported as deprecated fallback with `tracing::warn!` log
- Adds 256 KiB file size cap and control character validation for `name`/`description` fields

## Changes

- `serde_norway = "0.9.42"` — YAML deserializer (no known advisories, uses safe `unsafe-libyaml-norway`)
- `split_frontmatter`: dual-delimiter detection with CRLF normalization in both branches
- `FrontmatterFormat` enum routes to `serde_norway::from_str` (YAML) or `toml::from_str` (TOML)
- 13 new tests (YAML format, validation, CRLF, EOF); 17 existing TOML tests preserved
- `manager.rs` test helpers migrated to YAML
- `docs/src/advanced/sub-agents.md` updated with YAML examples and migration note

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — 0 warnings
- [x] `cargo nextest run --workspace --lib --bins` — 3422/3422 passed
- [x] All YAML fixtures validated with `fy`

Part of #1145