### PR TITLE
feat(subagents): follow-up fixes #1180-#1185 — spawn defaults, bypass gate, deny_unknown_fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `PlanModeExecutor` in `zeph-core`: wraps the real executor to expose tool catalog but block all execution; used when `permission_mode: plan`
 - `FilteredToolExecutor::with_disallowed()` constructor: accepts an extra denylist alongside the base `ToolPolicy`
 - `background` agents now auto-deny secret requests without blocking on the parent channel (CRIT-01 fix)
-- `SubAgentConfig.default_permission_mode` and `SubAgentConfig.default_disallowed_tools` global defaults in `[agents]` config section
+- `SubAgentConfig.default_permission_mode` and `SubAgentConfig.default_disallowed_tools` global defaults in `[agents]` config section; both are now applied at spawn time — `default_permission_mode` overrides `Default` mode agents, `default_disallowed_tools` is merged into per-agent denylist (#1180)
+- `SubAgentConfig.allow_bypass_permissions: bool` (default: `false`) config gate — spawning a sub-agent with `permission_mode: bypass_permissions` is rejected with an error unless explicitly enabled (#1182)
+- `#[serde(deny_unknown_fields)]` on `RawSubAgentDef`: YAML frontmatter typos (e.g. `permisions:`) are now rejected with a clear parse error instead of being silently ignored (#1183)
+- Doc comment on `FilteredToolExecutor::is_allowed()` clarifying that tool ID matching is exact string equality and MCP compound IDs (e.g. `mcp__server__tool`) must be listed in full in `tools.except` (#1181)
 - `PermissionMode` re-exported from `zeph-core::subagent` public API
 
 - `serde_norway = "0.9.42"` dependency for YAML parsing in sub-agent definitions (replaces TOML-only parsing)

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -413,6 +413,12 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    #[must_use]
+    pub fn with_subagent_config(mut self, config: crate::config::SubAgentConfig) -> Self {
+        self.subagent_config = config;
+        self
+    }
+
     /// Inject a shared provider override slot for runtime model switching (e.g. via ACP
     /// `set_session_config_option`). The agent checks and swaps the provider before each turn.
     #[must_use]

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -177,6 +177,7 @@ pub struct Agent<C: Channel> {
     /// dispatched to in the current agent loop iteration; retained for
     /// forward-compatible multi-agent orchestration.
     pub(crate) subagent_manager: Option<crate::subagent::SubAgentManager>,
+    pub(crate) subagent_config: crate::config::SubAgentConfig,
     pub(super) response_cache: Option<std::sync::Arc<zeph_memory::ResponseCache>>,
     /// Parent tool call ID when this agent runs as a subagent inside another agent session.
     /// Propagated into every `LoopbackEvent::ToolStart` / `ToolOutput` so the IDE can build
@@ -329,6 +330,7 @@ impl<C: Channel> Agent<C> {
             update_notify_rx: None,
             custom_task_rx: None,
             subagent_manager: None,
+            subagent_config: crate::config::SubAgentConfig::default(),
             response_cache: None,
             parent_tool_use_id: None,
             anomaly_detector: None,
@@ -1109,7 +1111,8 @@ impl<C: Channel> Agent<C> {
                 let tool_executor = Arc::clone(&self.tool_executor);
                 let skills = self.filtered_skills_for(&name);
                 let mgr = self.subagent_manager.as_mut()?;
-                match mgr.spawn(&name, &prompt, provider, tool_executor, skills) {
+                let cfg = self.subagent_config.clone();
+                match mgr.spawn(&name, &prompt, provider, tool_executor, skills, &cfg) {
                     Ok(id) => Some(format!(
                         "Sub-agent '{name}' started in background (id: {short})",
                         short = &id[..8.min(id.len())]
@@ -1127,7 +1130,9 @@ impl<C: Channel> Agent<C> {
                 let tool_executor = Arc::clone(&self.tool_executor);
                 let skills = self.filtered_skills_for(&name);
                 let mgr = self.subagent_manager.as_mut()?;
-                let task_id = match mgr.spawn(&name, &prompt, provider, tool_executor, skills) {
+                let cfg = self.subagent_config.clone();
+                let task_id = match mgr.spawn(&name, &prompt, provider, tool_executor, skills, &cfg)
+                {
                     Ok(id) => id,
                     Err(e) => return Some(format!("Failed to spawn sub-agent: {e}")),
                 };

--- a/crates/zeph-core/src/config/snapshots/zeph_core__config__types__tests__config_default_snapshot.snap
+++ b/crates/zeph-core/src/config/snapshots/zeph_core__config__types__tests__config_default_snapshot.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/zeph-core/src/config/types.rs
-assertion_line: 1585
 expression: toml_str
 ---
 [agent]
@@ -226,3 +225,4 @@ enabled = false
 max_concurrent = 1
 extra_dirs = []
 default_disallowed_tools = []
+allow_bypass_permissions = false

--- a/crates/zeph-core/src/config/types.rs
+++ b/crates/zeph-core/src/config/types.rs
@@ -67,10 +67,22 @@ pub struct SubAgentConfig {
     pub max_concurrent: usize,
     pub extra_dirs: Vec<PathBuf>,
     /// Default permission mode applied to sub-agents that do not specify one.
+    ///
+    /// Only takes effect when the sub-agent definition leaves `permission_mode` at its
+    /// default value (`Default`). If the definition sets an explicit mode, this field is
+    /// ignored. `Some(PermissionMode::Default)` behaves identically to `None` — both
+    /// result in `Default` mode. Prefer omitting the field over explicitly setting
+    /// `default_permission_mode = "default"` in config.
     pub default_permission_mode: Option<PermissionMode>,
     /// Global denylist applied to all sub-agents in addition to per-agent `tools.except`.
     #[serde(default)]
     pub default_disallowed_tools: Vec<String>,
+    /// Allow sub-agents to use `bypass_permissions` mode.
+    ///
+    /// When `false` (default), spawning a sub-agent with `permission_mode: bypass_permissions`
+    /// is rejected with an error. Set to `true` only in trusted, controlled environments.
+    #[serde(default)]
+    pub allow_bypass_permissions: bool,
 }
 
 impl Default for SubAgentConfig {
@@ -81,6 +93,7 @@ impl Default for SubAgentConfig {
             extra_dirs: Vec::new(),
             default_permission_mode: None,
             default_disallowed_tools: Vec::new(),
+            allow_bypass_permissions: false,
         }
     }
 }

--- a/crates/zeph-core/src/subagent/def.rs
+++ b/crates/zeph-core/src/subagent/def.rs
@@ -104,6 +104,7 @@ pub struct SkillFilter {
 // differs based on detected frontmatter format.
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 struct RawSubAgentDef {
     name: String,
     description: String,
@@ -116,6 +117,12 @@ struct RawSubAgentDef {
     skills: RawSkillFilter,
 }
 
+// Note: `RawToolPolicy` and `RawPermissions` intentionally do not carry
+// `#[serde(deny_unknown_fields)]`. They are nested under `RawSubAgentDef` (which does have
+// `deny_unknown_fields`), but serde does not propagate that attribute into nested structs.
+// Adding it here would reject currently-valid frontmatter that omits optional fields via
+// serde's default mechanism. A follow-up issue should evaluate whether strict rejection of
+// unknown nested keys is desirable before adding it.
 #[derive(Default, Deserialize)]
 struct RawToolPolicy {
     allow: Option<Vec<String>>,
@@ -917,5 +924,60 @@ mod tests {
     fn default_permissions_includes_permission_mode_default() {
         let p = SubAgentPermissions::default();
         assert_eq!(p.permission_mode, PermissionMode::Default);
+    }
+
+    // ── #1185: additional test gaps ────────────────────────────────────────
+
+    #[test]
+    fn parse_yaml_unknown_permission_mode_variant_is_error() {
+        // Unknown variant (e.g. "banana_mode") must fail with a parse error.
+        let content = "---\nname: a\ndescription: b\npermissions:\n  permission_mode: banana_mode\n---\n\nbody\n";
+        let err = SubAgentDef::parse(content).unwrap_err();
+        assert!(matches!(err, SubAgentError::Parse { .. }));
+    }
+
+    #[test]
+    fn parse_yaml_permission_mode_case_sensitive_camel_is_error() {
+        // "DontAsk" (camelCase) must not parse — only snake_case is accepted.
+        let content =
+            "---\nname: a\ndescription: b\npermissions:\n  permission_mode: DontAsk\n---\n\nbody\n";
+        let err = SubAgentDef::parse(content).unwrap_err();
+        assert!(matches!(err, SubAgentError::Parse { .. }));
+    }
+
+    #[test]
+    fn parse_yaml_explicit_empty_except_gives_empty_disallowed_tools() {
+        let content = "---\nname: a\ndescription: b\ntools:\n  allow:\n    - shell\n  except: []\n---\n\nbody\n";
+        let def = SubAgentDef::parse(content).unwrap();
+        assert!(def.disallowed_tools.is_empty());
+    }
+
+    #[test]
+    fn parse_yaml_disallowed_tools_with_deny_list_deny_wins() {
+        // disallowed_tools (tools.except) blocks a tool even when DenyList base policy
+        // would otherwise allow it (deny wins).
+        let content = "---\nname: a\ndescription: b\ntools:\n  deny:\n    - dangerous\n  except:\n    - web\n---\n\nbody\n";
+        let def = SubAgentDef::parse(content).unwrap();
+        // base policy: DenyList blocks "dangerous", allows everything else
+        assert!(matches!(def.tools, ToolPolicy::DenyList(ref v) if v == &["dangerous"]));
+        // disallowed_tools: "web" is additionally blocked by except
+        assert!(def.disallowed_tools.contains(&"web".to_owned()));
+    }
+
+    #[test]
+    fn parse_toml_background_true_frontmatter() {
+        // background: true via TOML (+++) frontmatter must parse correctly.
+        let content = "+++\nname = \"bg-agent\"\ndescription = \"Runs in background\"\n[permissions]\nbackground = true\n+++\n\nSystem prompt.\n";
+        let def = SubAgentDef::parse(content).unwrap();
+        assert!(def.permissions.background);
+        assert_eq!(def.name, "bg-agent");
+    }
+
+    #[test]
+    fn parse_yaml_unknown_top_level_field_is_error() {
+        // deny_unknown_fields on RawSubAgentDef: typos like "permisions:" must be rejected.
+        let content = "---\nname: a\ndescription: b\npermisions:\n  max_turns: 5\n---\n\nbody\n";
+        let err = SubAgentDef::parse(content).unwrap_err();
+        assert!(matches!(err, SubAgentError::Parse { .. }));
     }
 }

--- a/crates/zeph-core/src/subagent/filter.rs
+++ b/crates/zeph-core/src/subagent/filter.rs
@@ -57,6 +57,10 @@ impl FilteredToolExecutor {
         }
     }
 
+    /// Check whether `tool_id` is allowed under the current policy and denylist.
+    ///
+    /// Matching is exact string equality. MCP compound tool IDs (e.g. `mcp__server__tool`)
+    /// must be listed in full in `tools.except` — partial names or prefixes are not matched.
     fn is_allowed(&self, tool_id: &str) -> bool {
         if self.disallowed.iter().any(|t| t == tool_id) {
             return false;
@@ -573,6 +577,29 @@ mod tests {
         let defs = exec.tool_definitions_erased();
         assert_eq!(defs.len(), 2);
         assert!(!defs.iter().any(|d| d.id == "dangerous"));
+    }
+
+    // ── #1184: PlanModeExecutor + disallowed_tools catalog test ───────────
+
+    #[test]
+    fn plan_mode_with_disallowed_excludes_from_catalog() {
+        // FilteredToolExecutor wrapping PlanModeExecutor must exclude disallowed tools from
+        // tool_definitions_erased(), verifying that deny-list is enforced in plan mode catalog.
+        let inner = Arc::new(PlanModeExecutor::new(stub_box(&["shell", "web"])));
+        let exec = FilteredToolExecutor::with_disallowed(
+            inner,
+            ToolPolicy::InheritAll,
+            vec!["shell".into()],
+        );
+        let defs = exec.tool_definitions_erased();
+        assert!(
+            !defs.iter().any(|d| d.id == "shell"),
+            "shell must be excluded from catalog"
+        );
+        assert!(
+            defs.iter().any(|d| d.id == "web"),
+            "web must remain in catalog"
+        );
     }
 
     // ── PlanModeExecutor tests ─────────────────────────────────────────────

--- a/crates/zeph-core/src/subagent/manager.rs
+++ b/crates/zeph-core/src/subagent/manager.rs
@@ -14,6 +14,8 @@ use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::{LlmProvider, Message, MessageMetadata, Role};
 use zeph_tools::executor::ErasedToolExecutor;
 
+use crate::config::SubAgentConfig;
+
 use super::def::{PermissionMode, SubAgentDef};
 use super::error::SubAgentError;
 use super::filter::{FilteredToolExecutor, PlanModeExecutor};
@@ -345,7 +347,10 @@ impl SubAgentManager {
     /// # Errors
     ///
     /// Returns [`SubAgentError::NotFound`] if no definition with the given name exists,
-    /// [`SubAgentError::Spawn`] if the concurrency limit is exceeded.
+    /// [`SubAgentError::Spawn`] if the concurrency limit is exceeded, or
+    /// [`SubAgentError::Invalid`] if the agent requests `bypass_permissions` but the config
+    /// does not allow it (`allow_bypass_permissions: false`).
+    #[allow(clippy::too_many_lines)]
     pub fn spawn(
         &mut self,
         def_name: &str,
@@ -353,13 +358,44 @@ impl SubAgentManager {
         provider: AnyProvider,
         tool_executor: Arc<dyn ErasedToolExecutor>,
         skills: Option<Vec<String>>,
+        config: &SubAgentConfig,
     ) -> Result<String, SubAgentError> {
-        let def = self
+        let mut def = self
             .definitions
             .iter()
             .find(|d| d.name == def_name)
             .cloned()
             .ok_or_else(|| SubAgentError::NotFound(def_name.to_owned()))?;
+
+        // Apply config-level defaults: if agent has Default permission mode, use the
+        // config default_permission_mode if set.
+        if def.permissions.permission_mode == PermissionMode::Default
+            && let Some(default_mode) = config.default_permission_mode
+        {
+            def.permissions.permission_mode = default_mode;
+        }
+
+        // Merge global disallowed_tools into per-agent disallowed_tools (deny wins).
+        if !config.default_disallowed_tools.is_empty() {
+            let mut merged = def.disallowed_tools.clone();
+            for tool in &config.default_disallowed_tools {
+                if !merged.contains(tool) {
+                    merged.push(tool.clone());
+                }
+            }
+            def.disallowed_tools = merged;
+        }
+
+        // Guard: bypass_permissions requires explicit opt-in at config level.
+        if def.permissions.permission_mode == PermissionMode::BypassPermissions
+            && !config.allow_bypass_permissions
+        {
+            return Err(SubAgentError::Invalid(format!(
+                "sub-agent '{}' requests bypass_permissions mode but it is not allowed by config \
+                 (set agents.allow_bypass_permissions = true to enable)",
+                def.name
+            )));
+        }
 
         let active = self
             .agents
@@ -624,6 +660,8 @@ mod tests {
     use zeph_tools::executor::{ErasedToolExecutor, ToolError, ToolOutput};
     use zeph_tools::registry::ToolDef;
 
+    use crate::config::SubAgentConfig;
+
     use super::*;
 
     fn make_manager() -> SubAgentManager {
@@ -703,6 +741,7 @@ mod tests {
             mock_provider(vec!["done"]),
             noop_executor(),
             None,
+            &SubAgentConfig::default(),
         )
     }
 
@@ -880,6 +919,7 @@ mod tests {
                 mock_provider(vec!["final answer"]),
                 noop_executor(),
                 None,
+                &SubAgentConfig::default(),
             )
             .unwrap();
 
@@ -949,7 +989,14 @@ mod tests {
 
         let failing = AnyProvider::Mock(MockProvider::failing());
         let task_id = mgr
-            .spawn("bot", "do work", failing, noop_executor(), None)
+            .spawn(
+                "bot",
+                "do work",
+                failing,
+                noop_executor(),
+                None,
+                &SubAgentConfig::default(),
+            )
             .unwrap();
 
         // Wait for the background task to complete.
@@ -1051,7 +1098,14 @@ mod tests {
         });
 
         let task_id = mgr
-            .spawn("bot", "run two turns", provider, executor, None)
+            .spawn(
+                "bot",
+                "run two turns",
+                provider,
+                executor,
+                None,
+                &SubAgentConfig::default(),
+            )
             .unwrap();
 
         // Wait for background loop to finish.
@@ -1119,7 +1173,14 @@ mod tests {
 
         let skill_bodies = vec!["# skill-one\nDo something useful.".to_owned()];
         let task_id = mgr
-            .spawn("bot", "task", provider, noop_executor(), Some(skill_bodies))
+            .spawn(
+                "bot",
+                "task",
+                provider,
+                noop_executor(),
+                Some(skill_bodies),
+                &SubAgentConfig::default(),
+            )
             .unwrap();
 
         // Wait for the loop to call the provider at least once.
@@ -1153,7 +1214,14 @@ mod tests {
         mgr.definitions.push(sample_def());
 
         let task_id = mgr
-            .spawn("bot", "task", provider, noop_executor(), None)
+            .spawn(
+                "bot",
+                "task",
+                provider,
+                noop_executor(),
+                None,
+                &SubAgentConfig::default(),
+            )
             .unwrap();
 
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
@@ -1215,7 +1283,14 @@ mod tests {
         mgr.definitions.push(def);
 
         let task_id = mgr
-            .spawn("bg-bot", "task", provider, noop_executor(), None)
+            .spawn(
+                "bg-bot",
+                "task",
+                provider,
+                noop_executor(),
+                None,
+                &SubAgentConfig::default(),
+            )
             .unwrap();
 
         // Should complete without blocking — background auto-denies the secret.
@@ -1280,6 +1355,179 @@ mod tests {
         mgr.definitions.push(def);
 
         let task_id = do_spawn(&mut mgr, "safe-bot", "task").unwrap();
+        assert!(!task_id.is_empty());
+        mgr.cancel(&task_id).unwrap();
+    }
+
+    // ── #1180: default_permission_mode / default_disallowed_tools applied at spawn ──
+
+    #[test]
+    fn spawn_applies_default_permission_mode_from_config() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let _guard = rt.enter();
+
+        // Agent has Default permission mode — config sets Plan as default.
+        let def =
+            SubAgentDef::parse("---\nname: bot\ndescription: A bot\n---\n\nDo things.\n").unwrap();
+        assert_eq!(def.permissions.permission_mode, PermissionMode::Default);
+
+        let mut mgr = make_manager();
+        mgr.definitions.push(def);
+
+        let mut cfg = SubAgentConfig::default();
+        cfg.default_permission_mode = Some(PermissionMode::Plan);
+
+        let task_id = mgr
+            .spawn(
+                "bot",
+                "prompt",
+                mock_provider(vec!["done"]),
+                noop_executor(),
+                None,
+                &cfg,
+            )
+            .unwrap();
+        assert!(!task_id.is_empty());
+        mgr.cancel(&task_id).unwrap();
+    }
+
+    #[test]
+    fn spawn_does_not_override_explicit_permission_mode() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let _guard = rt.enter();
+
+        // Agent explicitly sets DontAsk — config default must not override it.
+        let def = SubAgentDef::parse(indoc! {"
+            ---
+            name: bot
+            description: A bot
+            permissions:
+              permission_mode: dont_ask
+            ---
+
+            Do things.
+        "})
+        .unwrap();
+        assert_eq!(def.permissions.permission_mode, PermissionMode::DontAsk);
+
+        let mut mgr = make_manager();
+        mgr.definitions.push(def);
+
+        let mut cfg = SubAgentConfig::default();
+        cfg.default_permission_mode = Some(PermissionMode::Plan);
+
+        let task_id = mgr
+            .spawn(
+                "bot",
+                "prompt",
+                mock_provider(vec!["done"]),
+                noop_executor(),
+                None,
+                &cfg,
+            )
+            .unwrap();
+        assert!(!task_id.is_empty());
+        mgr.cancel(&task_id).unwrap();
+    }
+
+    #[test]
+    fn spawn_merges_global_disallowed_tools() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let _guard = rt.enter();
+
+        let def =
+            SubAgentDef::parse("---\nname: bot\ndescription: A bot\n---\n\nDo things.\n").unwrap();
+
+        let mut mgr = make_manager();
+        mgr.definitions.push(def);
+
+        let mut cfg = SubAgentConfig::default();
+        cfg.default_disallowed_tools = vec!["dangerous".into()];
+
+        let task_id = mgr
+            .spawn(
+                "bot",
+                "prompt",
+                mock_provider(vec!["done"]),
+                noop_executor(),
+                None,
+                &cfg,
+            )
+            .unwrap();
+        assert!(!task_id.is_empty());
+        mgr.cancel(&task_id).unwrap();
+    }
+
+    // ── #1182: bypass_permissions blocked without config gate ─────────────
+
+    #[test]
+    fn spawn_bypass_permissions_without_config_gate_is_error() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let _guard = rt.enter();
+
+        let def = SubAgentDef::parse(indoc! {"
+            ---
+            name: bypass-bot
+            description: A bot with bypass mode
+            permissions:
+              permission_mode: bypass_permissions
+            ---
+
+            Unrestricted.
+        "})
+        .unwrap();
+
+        let mut mgr = make_manager();
+        mgr.definitions.push(def);
+
+        // Default config: allow_bypass_permissions = false
+        let cfg = SubAgentConfig::default();
+        let err = mgr
+            .spawn(
+                "bypass-bot",
+                "prompt",
+                mock_provider(vec!["done"]),
+                noop_executor(),
+                None,
+                &cfg,
+            )
+            .unwrap_err();
+        assert!(matches!(err, SubAgentError::Invalid(_)));
+    }
+
+    #[test]
+    fn spawn_bypass_permissions_with_config_gate_succeeds() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let _guard = rt.enter();
+
+        let def = SubAgentDef::parse(indoc! {"
+            ---
+            name: bypass-bot
+            description: A bot with bypass mode
+            permissions:
+              permission_mode: bypass_permissions
+            ---
+
+            Unrestricted.
+        "})
+        .unwrap();
+
+        let mut mgr = make_manager();
+        mgr.definitions.push(def);
+
+        let mut cfg = SubAgentConfig::default();
+        cfg.allow_bypass_permissions = true;
+
+        let task_id = mgr
+            .spawn(
+                "bypass-bot",
+                "prompt",
+                mock_provider(vec!["done"]),
+                noop_executor(),
+                None,
+                &cfg,
+            )
+            .unwrap();
         assert!(!task_id.is_empty());
         mgr.cancel(&task_id).unwrap();
     }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -494,7 +494,9 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         if let Err(e) = mgr.load_definitions(&agent_dirs) {
             tracing::warn!("sub-agent definition loading failed: {e:#}");
         }
-        agent.with_subagent_manager(mgr)
+        agent
+            .with_subagent_manager(mgr)
+            .with_subagent_config(config.agents.clone())
     };
 
     #[cfg(all(feature = "scheduler", feature = "tui"))]


### PR DESCRIPTION
Closes #1180, #1181, #1183, #1184, #1185. Partially closes #1186.
Addresses #1182.

## Summary

- Apply `default_permission_mode` and `default_disallowed_tools` from `SubAgentConfig` at spawn time; per-agent settings take precedence over config defaults (#1180)
- Add `allow_bypass_permissions: bool` (default: false) to `SubAgentConfig`; spawning an agent with `bypass_permissions` mode is rejected with an error unless the gate is enabled (#1182)
- Add `#[serde(deny_unknown_fields)]` to `RawSubAgentDef`; YAML typos in top-level keys now return a parse error instead of being silently ignored (#1183)
- Doc comment on `filter.rs` explaining exact-string tool ID matching and MCP compound IDs (#1181)
- Test: `disallowed_tools` filtered from `PlanModeExecutor` tool catalog (#1184)
- 6 test gaps from Phase 2: unknown variant, camelCase mode, empty except, disallowed+DenyList, TOML background=true, bypass warn (#1185)

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --lib --bins` — 3459/3459 passed (+12 tests)