### PR TITLE
feat(security): source-specific sanitization boundaries (Phase 2, #1195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Add system prompt security note in `BASE_PROMPT_TAIL` instructing the LLM to treat `<tool-output>` and `<external-data>` content as untrusted data, not instructions (#1199)
 - Add `[security.content_isolation]` TOML config section: `enabled`, `max_content_size` (64 KiB default), `flag_injection_patterns`, `spotlight_untrusted` (#1198)
 - Add `sanitizer_runs`, `sanitizer_injection_flags`, `sanitizer_truncations` counters to `MetricsSnapshot` (#1197)
+- Differentiate `ContentSourceKind` in `sanitize_tool_output`: MCP tools use `McpResponse` (ExternalUntrusted), web-scrape/fetch use `WebScrape` (ExternalUntrusted), others remain `ToolResult` (LocalUntrusted) (#1200, #1201)
+- Sanitize A2A inbound messages as `ExternalUntrusted` in `AgentTaskProcessor` before they enter the agent loop; add `all_text_content()` to collect all `Part::Text` entries (#1202)
+- Sanitize code RAG text from `zeph-index` before injection into context with metrics tracking and injection flag logging (#1203)
+- Sanitize tool error messages before `self_reflection` context using `ExternalUntrusted` as conservative default (#1200)
 
 ## [0.13.0] - 2026-03-05
 

--- a/crates/zeph-a2a/src/types.rs
+++ b/crates/zeph-a2a/src/types.rs
@@ -232,6 +232,24 @@ impl Message {
             _ => None,
         })
     }
+
+    /// Collect and concatenate all `Part::Text` entries in order.
+    ///
+    /// Unlike [`text_content`] which returns only the first text part, this method
+    /// preserves the full message when an agent sends multiple text parts.
+    /// Returns an empty string if the message contains no text parts.
+    #[must_use]
+    pub fn all_text_content(&self) -> String {
+        let parts: Vec<&str> = self
+            .parts
+            .iter()
+            .filter_map(|p| match p {
+                Part::Text { text, .. } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+        parts.join("\n\n")
+    }
 }
 
 #[cfg(test)]
@@ -476,6 +494,61 @@ mod tests {
         assert!(!json.contains("fileWithUri"));
         let back: FileContent = serde_json::from_str(&json).unwrap();
         assert_eq!(back.name.as_deref(), Some("doc.pdf"));
+    }
+
+    #[test]
+    fn all_text_content_single_part() {
+        let msg = Message::user_text("hello world");
+        assert_eq!(msg.all_text_content(), "hello world");
+    }
+
+    #[test]
+    fn all_text_content_multiple_parts_joined() {
+        let msg = Message {
+            role: Role::User,
+            parts: vec![
+                Part::text("first"),
+                Part::text("second"),
+                Part::text("third"),
+            ],
+            message_id: None,
+            task_id: None,
+            context_id: None,
+            metadata: None,
+        };
+        assert_eq!(msg.all_text_content(), "first\n\nsecond\n\nthird");
+    }
+
+    #[test]
+    fn all_text_content_no_text_parts_returns_empty() {
+        let msg = Message {
+            role: Role::User,
+            parts: vec![],
+            message_id: None,
+            task_id: None,
+            context_id: None,
+            metadata: None,
+        };
+        assert_eq!(msg.all_text_content(), "");
+    }
+
+    #[test]
+    fn all_text_content_skips_non_text_parts() {
+        let msg = Message {
+            role: Role::User,
+            parts: vec![
+                Part::text("text-only"),
+                Part::Data {
+                    data: serde_json::json!({"key": "val"}),
+                    metadata: None,
+                },
+            ],
+            message_id: None,
+            task_id: None,
+            context_id: None,
+            metadata: None,
+        };
+        assert_eq!(msg.all_text_content(), "text-only");
     }
 
     trait Not {

--- a/crates/zeph-core/src/agent/context.rs
+++ b/crates/zeph-core/src/agent/context.rs
@@ -1535,7 +1535,26 @@ impl<C: Channel> Agent<C> {
 
         #[cfg(feature = "index")]
         if let Some(text) = code_rag_text {
-            self.inject_code_context(&text);
+            // Sanitize before injection: indexed repo files can contain injection patterns
+            // embedded in comments, docstrings, or string literals (ContentSourceKind::ToolResult
+            // / LocalUntrusted — local repo, not external).
+            let sanitized = self
+                .sanitizer
+                .sanitize(&text, ContentSource::new(ContentSourceKind::ToolResult));
+            self.update_metrics(|m| m.sanitizer_runs += 1);
+            if !sanitized.injection_flags.is_empty() {
+                tracing::warn!(
+                    flags = sanitized.injection_flags.len(),
+                    "injection patterns detected in code RAG context"
+                );
+                self.update_metrics(|m| {
+                    m.sanitizer_injection_flags += sanitized.injection_flags.len() as u64;
+                });
+            }
+            if sanitized.was_truncated {
+                self.update_metrics(|m| m.sanitizer_truncations += 1);
+            }
+            self.inject_code_context(&sanitized.body);
         }
 
         self.trim_messages_to_budget(alloc.recent_history);
@@ -1557,6 +1576,10 @@ impl<C: Channel> Agent<C> {
     /// Apply spotlighting sanitization to a memory retrieval message before inserting it
     /// into the context. Memory content is `ExternalUntrusted` because prior sessions may
     /// have stored poisoned content retrieved from web scraping or MCP responses.
+    ///
+    /// This is the SOLE sanitization point for the 5 memory retrieval paths (`doc_rag`,
+    /// corrections, recall, `cross_session`, summaries). Do not add redundant sanitization
+    /// in zeph-memory or at other call sites.
     fn sanitize_memory_message(&self, mut msg: Message) -> Message {
         let source = ContentSource::new(ContentSourceKind::MemoryRetrieval);
         let sanitized = self.sanitizer.sanitize(&msg.content, source);

--- a/crates/zeph-core/src/agent/tool_execution.rs
+++ b/crates/zeph-core/src/agent/tool_execution.rs
@@ -702,12 +702,21 @@ impl<C: Channel> Agent<C> {
                 let err_str = format!("{e:#}");
                 tracing::error!("tool execution error: {err_str}");
                 let kind = FailureKind::from_error(&err_str);
+                // Sanitize before passing to self_reflection: error messages from MCP servers
+                // and web endpoints can contain untrusted content with injection patterns.
+                // Use McpResponse (ExternalUntrusted) as conservative default — tool_name is
+                // not available in this error branch, and over-spotlighting local errors is
+                // harmless while under-spotlighting external errors is a risk.
+                let sanitized_err = self
+                    .sanitizer
+                    .sanitize(&err_str, ContentSource::new(ContentSourceKind::McpResponse))
+                    .body;
                 self.record_skill_outcomes("tool_failure", Some(&err_str), Some(kind.as_str()))
                     .await;
                 self.record_anomaly_outcome(AnomalyOutcome::Error).await?;
 
                 if !self.learning_engine.was_reflection_used()
-                    && self.attempt_self_reflection(&err_str, "").await?
+                    && self.attempt_self_reflection(&sanitized_err, "").await?
                 {
                     return Ok(false);
                 }
@@ -724,8 +733,21 @@ impl<C: Channel> Agent<C> {
     ///
     /// Channel display (`send_tool_output`) still receives the raw body so the user
     /// sees unmodified output; spotlighting delimiters are added only for the LLM.
+    ///
+    /// This is the SOLE sanitization point for tool output data flows. Do not add
+    /// redundant sanitization in leaf crates (zeph-tools, zeph-mcp).
     fn sanitize_tool_output(&self, body: &str, tool_name: &str) -> String {
-        let source = ContentSource::new(ContentSourceKind::ToolResult).with_identifier(tool_name);
+        // MCP tools use "server:tool" format (contains ':') or legacy "mcp" name.
+        // Web scrape tools use "web-scrape" (hyphenated) or "fetch".
+        // Everything else is local shell/file output.
+        let kind = if tool_name.contains(':') || tool_name == "mcp" {
+            ContentSourceKind::McpResponse
+        } else if tool_name == "web-scrape" || tool_name == "web_scrape" || tool_name == "fetch" {
+            ContentSourceKind::WebScrape
+        } else {
+            ContentSourceKind::ToolResult
+        };
+        let source = ContentSource::new(kind).with_identifier(tool_name);
         let sanitized = self.sanitizer.sanitize(body, source);
         if !sanitized.injection_flags.is_empty() {
             tracing::warn!(
@@ -2821,5 +2843,159 @@ mod tests {
     #[test]
     fn first_tool_name_empty_input_falls_back_to_tool() {
         assert_eq!(first_tool_name(""), "tool");
+    }
+
+    // --- sanitize_tool_output source kind differentiation ---
+
+    macro_rules! assert_external_data {
+        ($tool:literal, $body:literal) => {{
+            use super::super::agent_tests::{
+                MockChannel, MockToolExecutor, create_test_registry, mock_provider,
+            };
+            let provider = mock_provider(vec![]);
+            let channel = MockChannel::new(vec![]);
+            let registry = create_test_registry();
+            let executor = MockToolExecutor::no_tools();
+            let mut agent =
+                super::super::Agent::new(provider, channel, registry, None, 5, executor);
+            let cfg = crate::sanitizer::ContentIsolationConfig {
+                enabled: true,
+                spotlight_untrusted: true,
+                flag_injection_patterns: false,
+                ..Default::default()
+            };
+            agent.sanitizer = crate::sanitizer::ContentSanitizer::new(&cfg);
+            let result = agent.sanitize_tool_output($body, $tool);
+            assert!(
+                result.contains("<external-data"),
+                "tool '{}' should produce ExternalUntrusted (<external-data>) spotlighting, got: {}",
+                $tool,
+                &result[..result.len().min(200)]
+            );
+            assert!(
+                result.contains($body),
+                "tool '{}' result should preserve body text '{}' inside wrapper",
+                $tool,
+                $body
+            );
+        }};
+    }
+
+    macro_rules! assert_tool_output {
+        ($tool:literal, $body:literal) => {{
+            use super::super::agent_tests::{
+                MockChannel, MockToolExecutor, create_test_registry, mock_provider,
+            };
+            let provider = mock_provider(vec![]);
+            let channel = MockChannel::new(vec![]);
+            let registry = create_test_registry();
+            let executor = MockToolExecutor::no_tools();
+            let mut agent =
+                super::super::Agent::new(provider, channel, registry, None, 5, executor);
+            let cfg = crate::sanitizer::ContentIsolationConfig {
+                enabled: true,
+                spotlight_untrusted: true,
+                flag_injection_patterns: false,
+                ..Default::default()
+            };
+            agent.sanitizer = crate::sanitizer::ContentSanitizer::new(&cfg);
+            let result = agent.sanitize_tool_output($body, $tool);
+            assert!(
+                result.contains("<tool-output"),
+                "tool '{}' should produce LocalUntrusted (<tool-output>) spotlighting",
+                $tool
+            );
+            assert!(!result.contains("<external-data"));
+            assert!(
+                result.contains($body),
+                "tool '{}' result should preserve body text '{}' inside wrapper",
+                $tool,
+                $body
+            );
+        }};
+    }
+
+    #[test]
+    fn sanitize_tool_output_mcp_colon_uses_external_data_wrapper() {
+        assert_external_data!("gh:create_issue", "hello from mcp");
+    }
+
+    #[test]
+    fn sanitize_tool_output_legacy_mcp_uses_external_data_wrapper() {
+        assert_external_data!("mcp", "mcp output");
+    }
+
+    #[test]
+    fn sanitize_tool_output_web_scrape_hyphen_uses_external_data_wrapper() {
+        assert_external_data!("web-scrape", "scraped page");
+    }
+
+    #[test]
+    fn sanitize_tool_output_web_scrape_underscore_uses_external_data_wrapper() {
+        assert_external_data!("web_scrape", "scraped page");
+    }
+
+    #[test]
+    fn sanitize_tool_output_fetch_uses_external_data_wrapper() {
+        assert_external_data!("fetch", "fetched content");
+    }
+
+    #[test]
+    fn sanitize_tool_output_shell_uses_tool_output_wrapper() {
+        assert_tool_output!("shell", "ls output");
+    }
+
+    #[test]
+    fn sanitize_tool_output_bash_uses_tool_output_wrapper() {
+        assert_tool_output!("bash", "command output");
+    }
+
+    // R-06: disabled sanitizer returns raw body unchanged
+    #[test]
+    fn sanitize_tool_output_disabled_returns_raw_body() {
+        use super::super::agent_tests::{
+            MockChannel, MockToolExecutor, create_test_registry, mock_provider,
+        };
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = super::super::Agent::new(provider, channel, registry, None, 5, executor);
+        let cfg = crate::sanitizer::ContentIsolationConfig {
+            enabled: false,
+            ..Default::default()
+        };
+        agent.sanitizer = crate::sanitizer::ContentSanitizer::new(&cfg);
+        let body = "raw mcp output";
+        let result = agent.sanitize_tool_output(body, "gh:create_issue");
+        assert_eq!(
+            result, body,
+            "disabled sanitizer must return body unchanged",
+        );
+    }
+
+    // R-07: error path sanitization — FailureKind uses raw err_str, self_reflection gets sanitized
+    #[test]
+    fn sanitize_error_str_strips_injection_patterns() {
+        // Verify that the sanitizer correctly processes content that would be passed
+        // to self_reflection in the Err(e) branch. We test this by calling the sanitizer
+        // directly with McpResponse kind (as the error path does) and confirming that
+        // spotlighting is applied while body content is preserved.
+        let cfg = crate::sanitizer::ContentIsolationConfig {
+            enabled: true,
+            spotlight_untrusted: true,
+            flag_injection_patterns: true,
+            ..Default::default()
+        };
+        let sanitizer = crate::sanitizer::ContentSanitizer::new(&cfg);
+        let err_msg = "HTTP 500: server error body";
+        let result = sanitizer.sanitize(
+            err_msg,
+            crate::sanitizer::ContentSource::new(crate::sanitizer::ContentSourceKind::McpResponse),
+        );
+        // ExternalUntrusted wraps in <external-data>
+        assert!(result.body.contains("<external-data"));
+        // Body content is preserved
+        assert!(result.body.contains(err_msg));
     }
 }

--- a/crates/zeph-core/src/sanitizer.rs
+++ b/crates/zeph-core/src/sanitizer.rs
@@ -265,6 +265,7 @@ static INJECTION_PATTERNS: LazyLock<Vec<CompiledPattern>> = LazyLock::new(|| {
 ///
 /// Constructed once at `Agent` startup from [`ContentIsolationConfig`] and held as a
 /// field on the agent. All calls are synchronous.
+#[derive(Clone)]
 pub struct ContentSanitizer {
     max_content_size: usize,
     flag_injections: bool,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -17,6 +17,7 @@ fn spawn_a2a_server(
     config: &Config,
     shutdown_rx: watch::Receiver<bool>,
     loopback_handle: zeph_core::LoopbackHandle,
+    sanitizer: zeph_core::ContentSanitizer,
 ) {
     let public_url = if config.a2a.public_url.is_empty() {
         format!("http://{}:{}", config.a2a.host, config.a2a.port)
@@ -33,6 +34,7 @@ fn spawn_a2a_server(
     let processor: std::sync::Arc<dyn zeph_a2a::TaskProcessor> =
         std::sync::Arc::new(AgentTaskProcessor {
             loopback_handle: std::sync::Arc::new(tokio::sync::Mutex::new(loopback_handle)),
+            sanitizer,
         });
     let a2a_server = zeph_a2a::A2aServer::new(
         card,
@@ -60,6 +62,7 @@ fn spawn_a2a_server(
 
 pub(crate) struct AgentTaskProcessor {
     pub(crate) loopback_handle: std::sync::Arc<tokio::sync::Mutex<zeph_core::LoopbackHandle>>,
+    pub(crate) sanitizer: zeph_core::ContentSanitizer,
 }
 
 impl zeph_a2a::TaskProcessor for AgentTaskProcessor {
@@ -71,9 +74,20 @@ impl zeph_a2a::TaskProcessor for AgentTaskProcessor {
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), zeph_a2a::A2aError>> + Send>>
     {
         let handle = self.loopback_handle.clone();
+        let sanitizer = self.sanitizer.clone();
 
         Box::pin(async move {
-            let user_text = message.text_content().unwrap_or("").to_owned();
+            // Inbound A2A messages come from external agents and are treated as
+            // ExternalUntrusted — sanitize before forwarding to the agent loop.
+            // Use all_text_content() to concatenate ALL Part::Text entries; text_content()
+            // returns only the first part and would silently drop subsequent text.
+            let raw_text = message.all_text_content();
+            let user_text = sanitizer
+                .sanitize(
+                    &raw_text,
+                    zeph_core::ContentSource::new(zeph_core::ContentSourceKind::A2aMessage),
+                )
+                .body;
             let mut handle = handle.lock().await;
 
             handle
@@ -335,7 +349,8 @@ pub(crate) async fn run_daemon(
         .check_vector_store_health(config.memory.vector_backend.as_str())
         .await;
 
-    spawn_a2a_server(config, shutdown_rx.clone(), loopback_handle);
+    let a2a_sanitizer = zeph_core::ContentSanitizer::new(&config.security.content_isolation);
+    spawn_a2a_server(config, shutdown_rx.clone(), loopback_handle, a2a_sanitizer);
 
     #[cfg(feature = "gateway")]
     if config.gateway.enabled {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -352,8 +352,10 @@ fn agent_task_processor_construction() {
     use crate::daemon::AgentTaskProcessor;
 
     let (_, handle) = zeph_core::LoopbackChannel::pair(8);
+    let sanitizer = zeph_core::ContentSanitizer::new(&zeph_core::ContentIsolationConfig::default());
     let processor = AgentTaskProcessor {
         loopback_handle: std::sync::Arc::new(tokio::sync::Mutex::new(handle)),
+        sanitizer,
     };
     assert!(std::sync::Arc::strong_count(&processor.loopback_handle) == 1);
 }


### PR DESCRIPTION
## Summary

Phase 2 of Untrusted Content Isolation epic (#1195). Refines `ContentSanitizer` integration to differentiate trust levels at each untrusted data boundary.

- **Tool results (#1200, #1201)**: MCP tools (`contains(':')`) use `McpResponse` (ExternalUntrusted), web-scrape/fetch use `WebScrape` (ExternalUntrusted), others remain `ToolResult` (LocalUntrusted)
- **A2A inbound (#1202)**: Sanitize external agent messages in `AgentTaskProcessor` with `A2aMessage` (ExternalUntrusted) before entering agent loop; add `Message::all_text_content()` for multi-part message support
- **Code RAG (#1203)**: Sanitize indexed code text before context injection with metrics tracking and injection flag logging
- **Error paths**: Sanitize tool error messages before `self_reflection` context as ExternalUntrusted (conservative default)

**Files changed** (6 files, +299/-5):
- `crates/zeph-a2a/src/types.rs` — `all_text_content()` + 4 tests
- `crates/zeph-core/src/agent/context.rs` — code RAG sanitization with metrics
- `crates/zeph-core/src/agent/tool_execution.rs` — source kind differentiation + error sanitization + 7 tests
- `crates/zeph-core/src/sanitizer.rs` — `#[derive(Clone)]`
- `src/daemon.rs` — A2A inbound sanitization in `AgentTaskProcessor`
- `src/tests.rs` — fix `sanitizer` field in daemon test struct

**Tests**: 3795 passed (+13 from Phase 1 baseline of 3782)

Closes #1200, closes #1201, closes #1202, closes #1203

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --lib --bins` (3795 pass)
- [x] `cargo check --features "daemon,a2a"`
- [ ] CI gate job (full matrix)