### PR TITLE
feat(memory): LLM-powered entity and relation extraction pipeline (#1225)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Add `GraphExtractor` with LLM-powered entity/relation extraction via `chat_typed_erased`, system prompt with 10 extraction rules, truncation guards, and graceful parse-failure degradation (#1225)
+- Add `EntityResolver` with exact name+type entity resolution (`resolve`) and edge deduplication/supersession (`resolve_edge`), case-insensitive entity matching, unknown-type coercion to `Concept` (#1225)
+- Add `ExtractionResult`, `ExtractedEntity`, `ExtractedEdge` types with `JsonSchema` derivation for structured LLM output (#1225)
+- Add `GraphStore::edges_exact` for unidirectional edge queries (performance optimization) (#1225)
+- Add entity name sanitization: control-character stripping (ASCII controls + BiDi overrides), 512-byte length cap, empty-name rejection (#1225)
+- Add relation/fact string sanitization: control-character stripping, length caps (256/2048 bytes) (#1225)
 - Add graph memory schema with SQLite tables (`graph_entities`, `graph_edges`, `graph_communities`, `graph_metadata`) and `messages.graph_processed` flag (migration 021) (#1224)
 - Add `GraphStore` CRUD with 18 methods: entity/edge/community upsert, BFS traversal with cycle-safe iterative algorithm, metadata persistence (#1224)
 - Add `EntityType` enum (8 variants), `Entity`, `Edge`, `Community`, `GraphFact` types in `zeph-memory::graph` module (#1224)

--- a/crates/zeph-memory/Cargo.toml
+++ b/crates/zeph-memory/Cargo.toml
@@ -33,7 +33,7 @@ zeph-llm.workspace = true
 
 [features]
 default = []
-graph-memory = []
+graph-memory = ["zeph-llm/schema"]
 mock = []
 pdf = ["dep:pdf-extract"]
 

--- a/crates/zeph-memory/src/graph/extractor.rs
+++ b/crates/zeph-memory/src/graph/extractor.rs
@@ -1,0 +1,323 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use zeph_llm::LlmError;
+use zeph_llm::any::AnyProvider;
+use zeph_llm::provider::{Message, Role};
+
+use crate::error::MemoryError;
+
+const SYSTEM_PROMPT: &str = "\
+You are an entity and relationship extractor. Given a conversation message and \
+its recent context, extract structured knowledge as JSON.
+
+Rules:
+1. Extract entities mentioned or implied in the current message.
+2. Extract relationships between entities.
+3. Entity types must be one of: person, tool, concept, project, language, file, config, organization.
+4. Relations should be short verb phrases: \"prefers\", \"uses\", \"works_on\", \"knows\", \"created\", \"depends_on\", \"replaces\", \"configured_with\".
+5. The \"fact\" field is a human-readable sentence summarizing the relationship.
+6. If a message contains a temporal change (e.g., \"switched from X to Y\"), include a temporal_hint like \"replaced X\" or \"since January 2026\".
+7. Do not extract entities from greetings, filler, or meta-conversation (\"hi\", \"thanks\", \"ok\").
+8. Do not extract personal identifiable information as entity names: email addresses, phone numbers, physical addresses, SSNs, or API keys. Use generic references instead (e.g., \"User\" instead of \"Alice Smith\").
+9. Always output entity names and relation verbs in English, even if the conversation is in another language. Translate entity names if needed.
+10. Return empty arrays if no entities or relationships are present.
+
+Output JSON schema:
+{
+  \"entities\": [
+    {\"name\": \"string\", \"type\": \"person|tool|concept|project|language|file|config|organization\", \"summary\": \"optional string\"}
+  ],
+  \"edges\": [
+    {\"source\": \"entity name\", \"target\": \"entity name\", \"relation\": \"verb phrase\", \"fact\": \"human-readable sentence\", \"temporal_hint\": \"optional string\"}
+  ]
+}";
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct ExtractionResult {
+    pub entities: Vec<ExtractedEntity>,
+    pub edges: Vec<ExtractedEdge>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct ExtractedEntity {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub entity_type: String,
+    pub summary: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct ExtractedEdge {
+    pub source: String,
+    pub target: String,
+    pub relation: String,
+    pub fact: String,
+    pub temporal_hint: Option<String>,
+}
+
+pub struct GraphExtractor {
+    provider: AnyProvider,
+    max_entities: usize,
+    max_edges: usize,
+}
+
+impl GraphExtractor {
+    #[must_use]
+    pub fn new(provider: AnyProvider, max_entities: usize, max_edges: usize) -> Self {
+        Self {
+            provider,
+            max_entities,
+            max_edges,
+        }
+    }
+
+    /// Extract entities and relations from a message with surrounding context.
+    ///
+    /// Returns `None` if the message is empty, extraction fails, or the LLM returns
+    /// unparseable output. Callers should treat `None` as a graceful degradation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error only for transport-level failures (network, auth).
+    /// JSON parse failures are logged and return `Ok(None)`.
+    pub async fn extract(
+        &self,
+        message: &str,
+        context_messages: &[&str],
+    ) -> Result<Option<ExtractionResult>, MemoryError> {
+        if message.trim().is_empty() {
+            return Ok(None);
+        }
+
+        let user_prompt = build_user_prompt(message, context_messages);
+        let messages = [
+            Message::from_legacy(Role::System, SYSTEM_PROMPT),
+            Message::from_legacy(Role::User, user_prompt),
+        ];
+
+        match self
+            .provider
+            .chat_typed_erased::<ExtractionResult>(&messages)
+            .await
+        {
+            Ok(mut result) => {
+                result.entities.truncate(self.max_entities);
+                result.edges.truncate(self.max_edges);
+                Ok(Some(result))
+            }
+            Err(LlmError::StructuredParse(msg)) => {
+                tracing::warn!(
+                    "graph extraction: LLM returned unparseable output (len={}): {:.200}",
+                    msg.len(),
+                    msg
+                );
+                Ok(None)
+            }
+            Err(other) => Err(MemoryError::Llm(other)),
+        }
+    }
+}
+
+fn build_user_prompt(message: &str, context_messages: &[&str]) -> String {
+    if context_messages.is_empty() {
+        format!("Current message:\n{message}\n\nExtract entities and relationships as JSON.")
+    } else {
+        let n = context_messages.len();
+        let context = context_messages.join("\n");
+        format!(
+            "Context (last {n} messages):\n{context}\n\nCurrent message:\n{message}\n\nExtract entities and relationships as JSON."
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_entity(name: &str, entity_type: &str, summary: Option<&str>) -> ExtractedEntity {
+        ExtractedEntity {
+            name: name.into(),
+            entity_type: entity_type.into(),
+            summary: summary.map(Into::into),
+        }
+    }
+
+    fn make_edge(
+        source: &str,
+        target: &str,
+        relation: &str,
+        fact: &str,
+        temporal_hint: Option<&str>,
+    ) -> ExtractedEdge {
+        ExtractedEdge {
+            source: source.into(),
+            target: target.into(),
+            relation: relation.into(),
+            fact: fact.into(),
+            temporal_hint: temporal_hint.map(Into::into),
+        }
+    }
+
+    #[test]
+    fn extraction_result_deserialize_valid_json() {
+        let json = r#"{"entities":[{"name":"Rust","type":"language","summary":"A systems language"}],"edges":[]}"#;
+        let result: ExtractionResult = serde_json::from_str(json).unwrap();
+        assert_eq!(result.entities.len(), 1);
+        assert_eq!(result.entities[0].name, "Rust");
+        assert_eq!(result.entities[0].entity_type, "language");
+        assert_eq!(
+            result.entities[0].summary.as_deref(),
+            Some("A systems language")
+        );
+        assert!(result.edges.is_empty());
+    }
+
+    #[test]
+    fn extraction_result_deserialize_empty_arrays() {
+        let json = r#"{"entities":[],"edges":[]}"#;
+        let result: ExtractionResult = serde_json::from_str(json).unwrap();
+        assert!(result.entities.is_empty());
+        assert!(result.edges.is_empty());
+    }
+
+    #[test]
+    fn extraction_result_deserialize_missing_optional_fields() {
+        let json = r#"{"entities":[{"name":"Alice","type":"person","summary":null}],"edges":[{"source":"Alice","target":"Rust","relation":"uses","fact":"Alice uses Rust","temporal_hint":null}]}"#;
+        let result: ExtractionResult = serde_json::from_str(json).unwrap();
+        assert_eq!(result.entities[0].summary, None);
+        assert_eq!(result.edges[0].temporal_hint, None);
+    }
+
+    #[test]
+    fn extracted_entity_type_field_rename() {
+        let json = r#"{"name":"cargo","type":"tool","summary":null}"#;
+        let entity: ExtractedEntity = serde_json::from_str(json).unwrap();
+        assert_eq!(entity.entity_type, "tool");
+
+        let serialized = serde_json::to_string(&entity).unwrap();
+        assert!(serialized.contains("\"type\""));
+        assert!(!serialized.contains("\"entity_type\""));
+    }
+
+    #[test]
+    fn extraction_result_roundtrip() {
+        let original = ExtractionResult {
+            entities: vec![make_entity("Rust", "language", Some("A systems language"))],
+            edges: vec![make_edge("Alice", "Rust", "uses", "Alice uses Rust", None)],
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let restored: ExtractionResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, restored);
+    }
+
+    #[test]
+    fn extraction_result_json_schema() {
+        let schema = schemars::schema_for!(ExtractionResult);
+        let value = serde_json::to_value(&schema).unwrap();
+        let schema_obj = value.as_object().unwrap();
+        assert!(
+            schema_obj.contains_key("title") || schema_obj.contains_key("properties"),
+            "schema should have top-level keys"
+        );
+        let json_str = serde_json::to_string(&schema).unwrap();
+        assert!(
+            json_str.contains("entities"),
+            "schema should contain 'entities'"
+        );
+        assert!(json_str.contains("edges"), "schema should contain 'edges'");
+    }
+
+    #[test]
+    fn build_user_prompt_with_context() {
+        let prompt = build_user_prompt("Hello Rust", &["prev message 1", "prev message 2"]);
+        assert!(prompt.contains("Context (last 2 messages):"));
+        assert!(prompt.contains("prev message 1\nprev message 2"));
+        assert!(prompt.contains("Current message:\nHello Rust"));
+        assert!(prompt.contains("Extract entities and relationships as JSON."));
+    }
+
+    #[test]
+    fn build_user_prompt_without_context() {
+        let prompt = build_user_prompt("Hello Rust", &[]);
+        assert!(!prompt.contains("Context"));
+        assert!(prompt.contains("Current message:\nHello Rust"));
+        assert!(prompt.contains("Extract entities and relationships as JSON."));
+    }
+
+    #[cfg(feature = "mock")]
+    mod mock_tests {
+        use super::*;
+        use zeph_llm::mock::MockProvider;
+
+        fn make_entities_json(count: usize) -> String {
+            let entities: Vec<String> = (0..count)
+                .map(|i| format!(r#"{{"name":"entity{i}","type":"concept","summary":null}}"#))
+                .collect();
+            format!(r#"{{"entities":[{}],"edges":[]}}"#, entities.join(","))
+        }
+
+        fn make_edges_json(count: usize) -> String {
+            let edges: Vec<String> = (0..count)
+                .map(|i| {
+                    format!(
+                        r#"{{"source":"A","target":"B{i}","relation":"uses","fact":"A uses B{i}","temporal_hint":null}}"#
+                    )
+                })
+                .collect();
+            format!(r#"{{"entities":[],"edges":[{}]}}"#, edges.join(","))
+        }
+
+        #[tokio::test]
+        async fn extract_truncates_to_max_entities() {
+            let json = make_entities_json(20);
+            let mock = MockProvider::with_responses(vec![json]);
+            let extractor = GraphExtractor::new(zeph_llm::any::AnyProvider::Mock(mock), 5, 100);
+            let result = extractor.extract("test message", &[]).await.unwrap();
+            let result = result.unwrap();
+            assert_eq!(result.entities.len(), 5);
+        }
+
+        #[tokio::test]
+        async fn extract_truncates_to_max_edges() {
+            let json = make_edges_json(15);
+            let mock = MockProvider::with_responses(vec![json]);
+            let extractor = GraphExtractor::new(zeph_llm::any::AnyProvider::Mock(mock), 100, 3);
+            let result = extractor.extract("test message", &[]).await.unwrap();
+            let result = result.unwrap();
+            assert_eq!(result.edges.len(), 3);
+        }
+
+        #[tokio::test]
+        async fn extract_returns_none_on_parse_failure() {
+            let mock = MockProvider::with_responses(vec!["not valid json at all".into()]);
+            let extractor = GraphExtractor::new(zeph_llm::any::AnyProvider::Mock(mock), 10, 10);
+            let result = extractor.extract("test message", &[]).await.unwrap();
+            assert!(result.is_none());
+        }
+
+        #[tokio::test]
+        async fn extract_returns_err_on_transport_failure() {
+            let mock = MockProvider::default()
+                .with_errors(vec![zeph_llm::LlmError::Other("connection refused".into())]);
+            let extractor = GraphExtractor::new(zeph_llm::any::AnyProvider::Mock(mock), 10, 10);
+            let result = extractor.extract("test message", &[]).await;
+            assert!(result.is_err());
+            assert!(matches!(result.unwrap_err(), MemoryError::Llm(_)));
+        }
+
+        #[tokio::test]
+        async fn extract_returns_none_on_empty_message() {
+            let mock = MockProvider::with_responses(vec!["should not be called".into()]);
+            let extractor = GraphExtractor::new(zeph_llm::any::AnyProvider::Mock(mock), 10, 10);
+
+            let result_empty = extractor.extract("", &[]).await.unwrap();
+            assert!(result_empty.is_none());
+
+            let result_whitespace = extractor.extract("   \t\n  ", &[]).await.unwrap();
+            assert!(result_whitespace.is_none());
+        }
+    }
+}

--- a/crates/zeph-memory/src/graph/mod.rs
+++ b/crates/zeph-memory/src/graph/mod.rs
@@ -4,5 +4,15 @@
 pub mod store;
 pub mod types;
 
+#[cfg(feature = "graph-memory")]
+pub mod extractor;
+#[cfg(feature = "graph-memory")]
+pub mod resolver;
+
 pub use store::GraphStore;
 pub use types::{Community, Edge, Entity, EntityType, GraphFact};
+
+#[cfg(feature = "graph-memory")]
+pub use extractor::{ExtractedEdge, ExtractedEntity, ExtractionResult, GraphExtractor};
+#[cfg(feature = "graph-memory")]
+pub use resolver::EntityResolver;

--- a/crates/zeph-memory/src/graph/resolver.rs
+++ b/crates/zeph-memory/src/graph/resolver.rs
@@ -1,0 +1,520 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use super::store::GraphStore;
+use super::types::EntityType;
+use crate::error::MemoryError;
+use crate::types::MessageId;
+
+/// Maximum byte length for entity names stored in the graph.
+const MAX_ENTITY_NAME_BYTES: usize = 512;
+/// Maximum byte length for relation strings.
+const MAX_RELATION_BYTES: usize = 256;
+/// Maximum byte length for fact strings.
+const MAX_FACT_BYTES: usize = 2048;
+
+/// Strip ASCII control characters and Unicode `BiDi` override codepoints.
+fn strip_control_chars(s: &str) -> String {
+    s.chars()
+        .filter(|c| !c.is_control() && !matches!(*c as u32, 0x202A..=0x202E | 0x2066..=0x2069))
+        .collect()
+}
+
+/// Truncate a string to at most `max_bytes` bytes at a valid UTF-8 char boundary.
+fn truncate_to_bytes(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut boundary = max_bytes;
+    while !s.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    &s[..boundary]
+}
+
+pub struct EntityResolver<'a> {
+    store: &'a GraphStore,
+}
+
+impl<'a> EntityResolver<'a> {
+    #[must_use]
+    pub fn new(store: &'a GraphStore) -> Self {
+        Self { store }
+    }
+
+    /// Resolve an extracted entity: normalize name, parse entity type, and upsert into the store.
+    ///
+    /// Entity names are:
+    /// - Trimmed and lowercased (case-insensitive deduplication)
+    /// - Stripped of control characters and `BiDi` overrides
+    /// - Truncated to 512 bytes at a `UTF-8` char boundary
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the entity name is empty after normalization, or if the DB operation fails.
+    pub async fn resolve(
+        &self,
+        name: &str,
+        entity_type: &str,
+        summary: Option<&str>,
+    ) -> Result<i64, MemoryError> {
+        let lowered = name.trim().to_lowercase();
+        let cleaned = strip_control_chars(&lowered);
+        let normalized = truncate_to_bytes(&cleaned, MAX_ENTITY_NAME_BYTES).to_owned();
+
+        if normalized.is_empty() {
+            return Err(MemoryError::GraphStore("empty entity name".into()));
+        }
+
+        if normalized.len() < cleaned.len() {
+            tracing::debug!(
+                "graph resolver: entity name truncated to {} bytes",
+                MAX_ENTITY_NAME_BYTES
+            );
+        }
+
+        let entity_type_parsed = entity_type
+            .trim()
+            .to_lowercase()
+            .parse::<EntityType>()
+            .unwrap_or_else(|_| {
+                tracing::debug!(
+                    "graph resolver: unknown entity type {:?}, falling back to Concept",
+                    entity_type
+                );
+                EntityType::Concept
+            });
+
+        self.store
+            .upsert_entity(&normalized, entity_type_parsed, summary)
+            .await
+    }
+
+    /// Resolve an extracted edge: deduplicate or supersede existing edges.
+    ///
+    /// - If an active edge with the same direction and relation exists with an identical fact,
+    ///   returns `None` (deduplicated).
+    /// - If an active edge with the same direction and relation exists with a different fact,
+    ///   invalidates the old edge and inserts the new one, returning `Some(new_id)`.
+    /// - If no matching edge exists, inserts a new edge and returns `Some(new_id)`.
+    ///
+    /// Relation and fact strings are sanitized (control chars stripped, length-capped).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any database operation fails.
+    pub async fn resolve_edge(
+        &self,
+        source_id: i64,
+        target_id: i64,
+        relation: &str,
+        fact: &str,
+        confidence: f32,
+        episode_id: Option<MessageId>,
+    ) -> Result<Option<i64>, MemoryError> {
+        let relation_clean = strip_control_chars(&relation.trim().to_lowercase());
+        let normalized_relation = truncate_to_bytes(&relation_clean, MAX_RELATION_BYTES).to_owned();
+
+        let fact_clean = strip_control_chars(fact.trim());
+        let normalized_fact = truncate_to_bytes(&fact_clean, MAX_FACT_BYTES).to_owned();
+
+        // Fetch only exact-direction edges — no reverse edges to filter out
+        let existing_edges = self.store.edges_exact(source_id, target_id).await?;
+
+        let matching = existing_edges
+            .iter()
+            .find(|e| e.relation == normalized_relation);
+
+        if let Some(old) = matching {
+            if old.fact == normalized_fact {
+                // Exact duplicate — skip
+                return Ok(None);
+            }
+            // Same relation, different fact — supersede
+            self.store.invalidate_edge(old.id).await?;
+        }
+
+        let new_id = self
+            .store
+            .insert_edge(
+                source_id,
+                target_id,
+                &normalized_relation,
+                &normalized_fact,
+                confidence,
+                episode_id,
+            )
+            .await?;
+        Ok(Some(new_id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sqlite::SqliteStore;
+
+    async fn setup() -> GraphStore {
+        let store = SqliteStore::new(":memory:").await.unwrap();
+        GraphStore::new(store.pool().clone())
+    }
+
+    #[tokio::test]
+    async fn resolve_creates_new_entity() {
+        let gs = setup().await;
+        let resolver = EntityResolver::new(&gs);
+        let id = resolver
+            .resolve("alice", "person", Some("a person"))
+            .await
+            .unwrap();
+        assert!(id > 0);
+    }
+
+    #[tokio::test]
+    async fn resolve_updates_existing_entity() {
+        let gs = setup().await;
+        let resolver = EntityResolver::new(&gs);
+        let id1 = resolver.resolve("alice", "person", None).await.unwrap();
+        let id2 = resolver
+            .resolve("alice", "person", Some("updated summary"))
+            .await
+            .unwrap();
+        assert_eq!(id1, id2);
+
+        let entity = gs
+            .find_entity("alice", EntityType::Person)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(entity.summary.as_deref(), Some("updated summary"));
+    }
+
+    #[tokio::test]
+    async fn resolve_unknown_type_falls_back_to_concept() {
+        let gs = setup().await;
+        let resolver = EntityResolver::new(&gs);
+        let id = resolver
+            .resolve("my_thing", "unknown_type", None)
+            .await
+            .unwrap();
+        assert!(id > 0);
+
+        // Verify it was stored as Concept
+        let entity = gs
+            .find_entity("my_thing", EntityType::Concept)
+            .await
+            .unwrap();
+        assert!(entity.is_some());
+    }
+
+    #[tokio::test]
+    async fn resolve_empty_name_returns_error() {
+        let gs = setup().await;
+        let resolver = EntityResolver::new(&gs);
+
+        let result_empty = resolver.resolve("", "concept", None).await;
+        assert!(result_empty.is_err());
+        assert!(matches!(
+            result_empty.unwrap_err(),
+            MemoryError::GraphStore(_)
+        ));
+
+        let result_whitespace = resolver.resolve("   ", "concept", None).await;
+        assert!(result_whitespace.is_err());
+    }
+
+    #[tokio::test]
+    async fn resolve_case_insensitive() {
+        let gs = setup().await;
+        let resolver = EntityResolver::new(&gs);
+
+        let id1 = resolver.resolve("Rust", "language", None).await.unwrap();
+        let id2 = resolver.resolve("rust", "language", None).await.unwrap();
+        assert_eq!(
+            id1, id2,
+            "'Rust' and 'rust' should resolve to the same entity"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_edge_inserts_new() {
+        let gs = setup().await;
+        let resolver = EntityResolver::new(&gs);
+
+        let src = gs
+            .upsert_entity("src", EntityType::Concept, None)
+            .await
+            .unwrap();
+        let tgt = gs
+            .upsert_entity("tgt", EntityType::Concept, None)
+            .await
+            .unwrap();
+
+        let result = resolver
+            .resolve_edge(src, tgt, "uses", "src uses tgt", 0.9, None)
+            .await
+            .unwrap();
+        assert!(result.is_some());
+        assert!(result.unwrap() > 0);
+    }
+
+    #[tokio::test]
+    async fn resolve_edge_deduplicates_identical() {
+        let gs = setup().await;
+        let resolver = EntityResolver::new(&gs);
+
+        let src = gs
+            .upsert_entity("a", EntityType::Concept, None)
+            .await
+            .unwrap();
+        let tgt = gs
+            .upsert_entity("b", EntityType::Concept, None)
+            .await
+            .unwrap();
+
+        let first = resolver
+            .resolve_edge(src, tgt, "uses", "a uses b", 0.9, None)
+            .await
+            .unwrap();
+        assert!(first.is_some());
+
+        let second = resolver
+            .resolve_edge(src, tgt, "uses", "a uses b", 0.9, None)
+            .await
+            .unwrap();
+        assert!(second.is_none(), "identical edge should be deduplicated");
+    }
+
+    #[tokio::test]
+    async fn resolve_edge_supersedes_contradictory() {
+        let gs = setup().await;
+        let resolver = EntityResolver::new(&gs);
+
+        let src = gs
+            .upsert_entity("x", EntityType::Concept, None)
+            .await
+            .unwrap();
+        let tgt = gs
+            .upsert_entity("y", EntityType::Concept, None)
+            .await
+            .unwrap();
+
+        let first_id = resolver
+            .resolve_edge(src, tgt, "prefers", "x prefers y (old)", 0.8, None)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let second_id = resolver
+            .resolve_edge(src, tgt, "prefers", "x prefers y (new)", 0.9, None)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_ne!(first_id, second_id, "superseded edge should have a new ID");
+
+        // Old edge should be invalidated
+        let active_count = gs.active_edge_count().await.unwrap();
+        assert_eq!(active_count, 1, "only new edge should be active");
+    }
+
+    #[tokio::test]
+    async fn resolve_edge_direction_sensitive() {
+        // A->B "uses" should not interfere with B->A "uses" dedup
+        let gs = setup().await;
+        let resolver = EntityResolver::new(&gs);
+
+        let a = gs
+            .upsert_entity("node_a", EntityType::Concept, None)
+            .await
+            .unwrap();
+        let b = gs
+            .upsert_entity("node_b", EntityType::Concept, None)
+            .await
+            .unwrap();
+
+        // Insert A->B
+        let id1 = resolver
+            .resolve_edge(a, b, "uses", "A uses B", 0.9, None)
+            .await
+            .unwrap();
+        assert!(id1.is_some());
+
+        // Insert B->A with different fact — should NOT invalidate A->B (different direction)
+        let id2 = resolver
+            .resolve_edge(b, a, "uses", "B uses A (different direction)", 0.9, None)
+            .await
+            .unwrap();
+        assert!(id2.is_some());
+
+        // Both edges should still be active
+        let active_count = gs.active_edge_count().await.unwrap();
+        assert_eq!(active_count, 2, "both directional edges should be active");
+    }
+
+    #[tokio::test]
+    async fn resolve_edge_normalizes_relation_case() {
+        let gs = setup().await;
+        let resolver = EntityResolver::new(&gs);
+
+        let src = gs
+            .upsert_entity("p", EntityType::Concept, None)
+            .await
+            .unwrap();
+        let tgt = gs
+            .upsert_entity("q", EntityType::Concept, None)
+            .await
+            .unwrap();
+
+        // Insert with uppercase relation
+        let id1 = resolver
+            .resolve_edge(src, tgt, "Uses", "p uses q", 0.9, None)
+            .await
+            .unwrap();
+        assert!(id1.is_some());
+
+        // Insert with lowercase relation — same normalized relation, same fact → deduplicate
+        let id2 = resolver
+            .resolve_edge(src, tgt, "uses", "p uses q", 0.9, None)
+            .await
+            .unwrap();
+        assert!(id2.is_none(), "normalized relations should deduplicate");
+    }
+
+    // ── IC-01: entity_type lowercased before parse ────────────────────────────
+
+    #[tokio::test]
+    async fn resolve_entity_type_uppercase_parsed_correctly() {
+        let gs = setup().await;
+        let resolver = EntityResolver::new(&gs);
+
+        // "Person" (title case from LLM) should parse as EntityType::Person, not fall back to Concept
+        let id = resolver
+            .resolve("test_entity", "Person", None)
+            .await
+            .unwrap();
+        assert!(id > 0);
+
+        let entity = gs
+            .find_entity("test_entity", EntityType::Person)
+            .await
+            .unwrap();
+        assert!(entity.is_some(), "entity should be stored as Person type");
+    }
+
+    #[tokio::test]
+    async fn resolve_entity_type_all_caps_parsed_correctly() {
+        let gs = setup().await;
+        let resolver = EntityResolver::new(&gs);
+
+        let id = resolver.resolve("my_lang", "LANGUAGE", None).await.unwrap();
+        assert!(id > 0);
+
+        let entity = gs
+            .find_entity("my_lang", EntityType::Language)
+            .await
+            .unwrap();
+        assert!(entity.is_some(), "entity should be stored as Language type");
+    }
+
+    // ── SEC-GRAPH-01: entity name length cap ──────────────────────────────────
+
+    #[tokio::test]
+    async fn resolve_truncates_long_entity_name() {
+        let gs = setup().await;
+        let resolver = EntityResolver::new(&gs);
+
+        let long_name = "a".repeat(1024);
+        let id = resolver.resolve(&long_name, "concept", None).await.unwrap();
+        assert!(id > 0);
+
+        // Entity should exist with a truncated name (512 bytes)
+        let entity = gs
+            .find_entity(&"a".repeat(512), EntityType::Concept)
+            .await
+            .unwrap();
+        assert!(entity.is_some(), "truncated name should be stored");
+    }
+
+    // ── SEC-GRAPH-02: control character stripping ─────────────────────────────
+
+    #[tokio::test]
+    async fn resolve_strips_control_chars_from_name() {
+        let gs = setup().await;
+        let resolver = EntityResolver::new(&gs);
+
+        // Name with null byte and a BiDi override
+        let name_with_ctrl = "rust\x00lang";
+        let id = resolver
+            .resolve(name_with_ctrl, "language", None)
+            .await
+            .unwrap();
+        assert!(id > 0);
+
+        // Stored name should have control chars removed
+        let entity = gs
+            .find_entity("rustlang", EntityType::Language)
+            .await
+            .unwrap();
+        assert!(
+            entity.is_some(),
+            "control chars should be stripped from stored name"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_strips_bidi_overrides_from_name() {
+        let gs = setup().await;
+        let resolver = EntityResolver::new(&gs);
+
+        // U+202E is RIGHT-TO-LEFT OVERRIDE — a BiDi spoof character
+        let name_with_bidi = "rust\u{202E}lang";
+        let id = resolver
+            .resolve(name_with_bidi, "language", None)
+            .await
+            .unwrap();
+        assert!(id > 0);
+
+        let entity = gs
+            .find_entity("rustlang", EntityType::Language)
+            .await
+            .unwrap();
+        assert!(entity.is_some(), "BiDi override chars should be stripped");
+    }
+
+    // ── Helper unit tests for sanitization functions ──────────────────────────
+
+    #[test]
+    fn strip_control_chars_removes_ascii_controls() {
+        assert_eq!(strip_control_chars("hello\x00world"), "helloworld");
+        assert_eq!(strip_control_chars("tab\there"), "tabhere");
+        assert_eq!(strip_control_chars("new\nline"), "newline");
+    }
+
+    #[test]
+    fn strip_control_chars_removes_bidi() {
+        let bidi = "\u{202E}spoof";
+        assert_eq!(strip_control_chars(bidi), "spoof");
+    }
+
+    #[test]
+    fn strip_control_chars_preserves_normal_unicode() {
+        assert_eq!(strip_control_chars("привет мир"), "привет мир");
+        assert_eq!(strip_control_chars("日本語"), "日本語");
+    }
+
+    #[test]
+    fn truncate_to_bytes_exact_boundary() {
+        let s = "hello";
+        assert_eq!(truncate_to_bytes(s, 5), "hello");
+        assert_eq!(truncate_to_bytes(s, 3), "hel");
+    }
+
+    #[test]
+    fn truncate_to_bytes_respects_utf8_boundary() {
+        // "é" is 2 bytes in UTF-8 — truncating at 1 byte should give ""
+        let s = "élan";
+        let truncated = truncate_to_bytes(s, 1);
+        assert!(s.is_char_boundary(truncated.len()));
+    }
+}

--- a/crates/zeph-memory/src/graph/store.rs
+++ b/crates/zeph-memory/src/graph/store.rs
@@ -240,6 +240,31 @@ impl GraphStore {
         Ok(rows.into_iter().map(edge_from_row).collect())
     }
 
+    /// Get active edges from `source` to `target` in the exact direction (no reverse).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database query fails.
+    pub async fn edges_exact(
+        &self,
+        source_entity_id: i64,
+        target_entity_id: i64,
+    ) -> Result<Vec<Edge>, MemoryError> {
+        let rows: Vec<EdgeRow> = sqlx::query_as(
+            "SELECT id, source_entity_id, target_entity_id, relation, fact, confidence,
+                    valid_from, valid_to, created_at, expired_at, episode_id, qdrant_point_id
+             FROM graph_edges
+             WHERE valid_to IS NULL
+               AND source_entity_id = ?1
+               AND target_entity_id = ?2",
+        )
+        .bind(source_entity_id)
+        .bind(target_entity_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.into_iter().map(edge_from_row).collect())
+    }
+
     /// Count active (non-invalidated) edges.
     ///
     /// # Errors


### PR DESCRIPTION
## Summary

- Add `GraphExtractor` with LLM-powered entity/relation extraction via `chat_typed_erased`, 10-rule system prompt, truncation guards, and graceful parse-failure degradation (`Ok(None)`)
- Add `EntityResolver` with case-insensitive entity resolution (exact name+type match, unknown types coerced to `Concept`), edge deduplication, and temporal supersession of contradictory edges
- Add entity/relation/fact sanitization: control-character stripping (ASCII controls + BiDi overrides), length caps (512/256/2048 bytes), empty-name rejection
- Add `GraphStore::edges_exact()` for unidirectional edge queries (PERF-01 fix)
- Feature-gated behind `graph-memory` with explicit `zeph-llm/schema` dependency

**Test delta**: 4084 → 4094 (+33 new tests, 10 from security/perf fixes)

## Test plan

- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --workspace --features full -- -D warnings` passes (zero warnings)
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features full --lib --bins` passes (4094/4094)
- [x] All 7 acceptance criteria from #1225 verified by testing engineer
- [x] Security audit: all 3 medium findings (SEC-GRAPH-01/02/03) fixed
- [x] Performance review: PERF-01 (edges_exact) fixed
- [x] Implementation critique: IC-01 (entity_type lowercase) fixed

Closes #1225