### PR TITLE
fix(core): token counting uses parts structure for accurate budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - Fix `persist_message` saving parts from wrong message — `self.messages.last()` returned the previous message's parts instead of the current one, causing 100% parts corruption in SQLite for all tool interactions; now takes explicit `parts` parameter (#1279)
+- Fix token counting using flattened `content` instead of structured `parts` — add `count_message_tokens` to `TokenCounter` that estimates tokens per `MessagePart` variant matching API payload structure, update 6 call sites in context budget tracking (#1280)
 
 ## [0.14.0] - 2026-03-06
 

--- a/crates/zeph-core/src/agent/context.rs
+++ b/crates/zeph-core/src/agent/context.rs
@@ -35,7 +35,7 @@ fn chunk_messages(
     let mut current_tokens = 0usize;
 
     for msg in messages {
-        let msg_tokens = tc.count_tokens(&msg.content);
+        let msg_tokens = tc.count_message_tokens(msg);
 
         if msg_tokens >= oversized {
             // Oversized message gets its own chunk
@@ -545,7 +545,7 @@ impl<C: Channel> Agent<C> {
         let mut protection_boundary = self.messages.len();
         if protect > 0 {
             for (i, msg) in self.messages.iter().enumerate().rev() {
-                tail_tokens += self.token_counter.count_tokens(&msg.content);
+                tail_tokens += self.token_counter.count_message_tokens(msg);
                 if tail_tokens >= protect {
                     protection_boundary = i;
                     break;
@@ -804,7 +804,7 @@ impl<C: Channel> Agent<C> {
         let total_tokens: usize = self
             .messages
             .iter()
-            .map(|m| self.token_counter.count_tokens(&m.content))
+            .map(|m| self.token_counter.count_message_tokens(m))
             .sum();
         let threshold = (budget as f32 * self.context_manager.compaction_threshold) as usize;
         let min_to_free = total_tokens.saturating_sub(threshold);
@@ -1460,7 +1460,7 @@ impl<C: Channel> Agent<C> {
         let mut keep_from = self.messages.len();
 
         for i in (history_start..self.messages.len()).rev() {
-            let msg_tokens = self.token_counter.count_tokens(&self.messages[i].content);
+            let msg_tokens = self.token_counter.count_message_tokens(&self.messages[i]);
             if total + msg_tokens > token_budget {
                 break;
             }

--- a/crates/zeph-core/src/agent/utils.rs
+++ b/crates/zeph-core/src/agent/utils.rs
@@ -99,12 +99,12 @@ impl<C: Channel> Agent<C> {
         self.cached_prompt_tokens = self
             .messages
             .iter()
-            .map(|m| self.token_counter.count_tokens(&m.content) as u64)
+            .map(|m| self.token_counter.count_message_tokens(m) as u64)
             .sum();
     }
 
     pub(super) fn push_message(&mut self, msg: Message) {
-        self.cached_prompt_tokens += self.token_counter.count_tokens(&msg.content) as u64;
+        self.cached_prompt_tokens += self.token_counter.count_message_tokens(&msg) as u64;
         self.messages.push(msg);
     }
 
@@ -166,13 +166,14 @@ mod tests {
         let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
 
         let before = agent.cached_prompt_tokens;
-        agent.push_message(Message {
+        let msg = Message {
             role: Role::User,
             content: "hello world!!".to_string(),
             parts: vec![],
             metadata: MessageMetadata::default(),
-        });
-        let expected_delta = agent.token_counter.count_tokens("hello world!!") as u64;
+        };
+        let expected_delta = agent.token_counter.count_message_tokens(&msg) as u64;
+        agent.push_message(msg);
         assert_eq!(agent.cached_prompt_tokens, before + expected_delta);
     }
 
@@ -202,7 +203,7 @@ mod tests {
         let expected: u64 = agent
             .messages
             .iter()
-            .map(|m| agent.token_counter.count_tokens(&m.content) as u64)
+            .map(|m| agent.token_counter.count_message_tokens(m) as u64)
             .sum();
         assert_eq!(agent.cached_prompt_tokens, expected);
     }

--- a/crates/zeph-memory/src/token_counter.rs
+++ b/crates/zeph-memory/src/token_counter.rs
@@ -6,6 +6,7 @@ use std::hash::{Hash, Hasher};
 
 use dashmap::DashMap;
 use tiktoken_rs::CoreBPE;
+use zeph_llm::provider::{Message, MessagePart};
 
 const CACHE_CAP: usize = 10_000;
 /// Inputs larger than this limit bypass BPE encoding and use the chars/4 fallback.
@@ -19,6 +20,20 @@ const PROP_KEY: usize = 3;
 const ENUM_INIT: isize = -3;
 const ENUM_ITEM: usize = 3;
 const FUNC_END: usize = 12;
+
+// Structural overhead per part type (approximate token counts for JSON framing)
+/// `{"type":"tool_use","id":"","name":"","input":}`
+const TOOL_USE_OVERHEAD: usize = 20;
+/// `{"type":"tool_result","tool_use_id":"","content":""}`
+const TOOL_RESULT_OVERHEAD: usize = 15;
+/// `[tool output: <name>]\n` wrapping
+const TOOL_OUTPUT_OVERHEAD: usize = 8;
+/// Image block JSON structure overhead (dimension-based counting unavailable)
+const IMAGE_OVERHEAD: usize = 50;
+/// Default token estimate for a typical image (dimensions not available in `ImageData`)
+const IMAGE_DEFAULT_TOKENS: usize = 1000;
+/// Thinking/redacted block framing
+const THINKING_OVERHEAD: usize = 10;
 
 pub struct TokenCounter {
     bpe: Option<CoreBPE>,
@@ -82,6 +97,70 @@ impl TokenCounter {
         count
     }
 
+    /// Estimate token count for a message the way the LLM API will see it.
+    ///
+    /// When structured parts exist, counts from parts matching the API payload
+    /// structure. Falls back to `content` (flattened text) when parts is empty.
+    #[must_use]
+    pub fn count_message_tokens(&self, msg: &Message) -> usize {
+        if msg.parts.is_empty() {
+            return self.count_tokens(&msg.content);
+        }
+        msg.parts.iter().map(|p| self.count_part_tokens(p)).sum()
+    }
+
+    /// Estimate tokens for a single [`MessagePart`] matching the API payload structure.
+    #[must_use]
+    fn count_part_tokens(&self, part: &MessagePart) -> usize {
+        match part {
+            MessagePart::Text { text }
+            | MessagePart::Recall { text }
+            | MessagePart::CodeContext { text }
+            | MessagePart::Summary { text }
+            | MessagePart::CrossSession { text } => {
+                if text.trim().is_empty() {
+                    return 0;
+                }
+                self.count_tokens(text)
+            }
+
+            // API always emits `[tool output: {name}]\n{body}` regardless of compacted_at.
+            // When body is emptied by compaction, count_tokens(body) returns 0 naturally.
+            MessagePart::ToolOutput {
+                tool_name, body, ..
+            } => TOOL_OUTPUT_OVERHEAD + self.count_tokens(tool_name) + self.count_tokens(body),
+
+            // API sends structured JSON block: `{"type":"tool_use","id":"...","name":"...","input":...}`
+            MessagePart::ToolUse { id, name, input } => {
+                TOOL_USE_OVERHEAD
+                    + self.count_tokens(id)
+                    + self.count_tokens(name)
+                    + self.count_tokens(&input.to_string())
+            }
+
+            // API sends structured block: `{"type":"tool_result","tool_use_id":"...","content":"..."}`
+            MessagePart::ToolResult {
+                tool_use_id,
+                content,
+                ..
+            } => TOOL_RESULT_OVERHEAD + self.count_tokens(tool_use_id) + self.count_tokens(content),
+
+            // Image token count depends on pixel dimensions, which are unavailable in ImageData.
+            // Using a fixed constant is more accurate than bytes-based formula because
+            // Claude's actual formula is width*height based, not payload-size based.
+            MessagePart::Image(_) => IMAGE_OVERHEAD + IMAGE_DEFAULT_TOKENS,
+
+            // ThinkingBlock is preserved verbatim in multi-turn requests.
+            MessagePart::ThinkingBlock {
+                thinking,
+                signature,
+            } => THINKING_OVERHEAD + self.count_tokens(thinking) + self.count_tokens(signature),
+
+            // RedactedThinkingBlock is an opaque base64 blob — BPE is not meaningful here.
+            MessagePart::RedactedThinkingBlock { data } => THINKING_OVERHEAD + data.len() / 4,
+        }
+    }
+
     /// Count tokens for an `OpenAI` tool/function schema `JSON` value.
     #[must_use]
     pub fn count_tool_schema_tokens(&self, schema: &serde_json::Value) -> usize {
@@ -129,6 +208,187 @@ fn count_schema_value(counter: &TokenCounter, value: &serde_json::Value) -> usiz
 #[cfg(test)]
 mod tests {
     use super::*;
+    use zeph_llm::provider::{ImageData, Message, MessageMetadata, MessagePart, Role};
+
+    fn make_msg(parts: Vec<MessagePart>) -> Message {
+        Message::from_parts(Role::User, parts)
+    }
+
+    fn make_msg_no_parts(content: &str) -> Message {
+        Message {
+            role: Role::User,
+            content: content.to_string(),
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        }
+    }
+
+    #[test]
+    fn count_message_tokens_empty_parts_falls_back_to_content() {
+        let counter = TokenCounter::new();
+        let msg = make_msg_no_parts("hello world");
+        assert_eq!(
+            counter.count_message_tokens(&msg),
+            counter.count_tokens("hello world")
+        );
+    }
+
+    #[test]
+    fn count_message_tokens_text_part_matches_count_tokens() {
+        let counter = TokenCounter::new();
+        let text = "the quick brown fox jumps over the lazy dog";
+        let msg = make_msg(vec![MessagePart::Text {
+            text: text.to_string(),
+        }]);
+        assert_eq!(
+            counter.count_message_tokens(&msg),
+            counter.count_tokens(text)
+        );
+    }
+
+    #[test]
+    fn count_message_tokens_tool_use_exceeds_flattened_content() {
+        let counter = TokenCounter::new();
+        // Large JSON input: structured counting should be higher than flattened "[tool_use: bash(id)]"
+        let input = serde_json::json!({"command": "find /home -name '*.rs' -type f | head -100"});
+        let msg = make_msg(vec![MessagePart::ToolUse {
+            id: "toolu_abc".into(),
+            name: "bash".into(),
+            input,
+        }]);
+        let structured = counter.count_message_tokens(&msg);
+        let flattened = counter.count_tokens(&msg.content);
+        assert!(
+            structured > flattened,
+            "structured={structured} should exceed flattened={flattened}"
+        );
+    }
+
+    #[test]
+    fn count_message_tokens_compacted_tool_output_is_small() {
+        let counter = TokenCounter::new();
+        // Compacted ToolOutput has empty body — should count close to overhead only
+        let msg = make_msg(vec![MessagePart::ToolOutput {
+            tool_name: "bash".into(),
+            body: String::new(),
+            compacted_at: Some(1_700_000_000),
+        }]);
+        let tokens = counter.count_message_tokens(&msg);
+        // Should be small: TOOL_OUTPUT_OVERHEAD + count_tokens("bash") + 0
+        assert!(
+            tokens <= 15,
+            "compacted tool output should be small, got {tokens}"
+        );
+    }
+
+    #[test]
+    fn count_message_tokens_image_returns_constant() {
+        let counter = TokenCounter::new();
+        let msg = make_msg(vec![MessagePart::Image(Box::new(ImageData {
+            data: vec![0u8; 1000],
+            mime_type: "image/jpeg".into(),
+        }))]);
+        assert_eq!(
+            counter.count_message_tokens(&msg),
+            IMAGE_OVERHEAD + IMAGE_DEFAULT_TOKENS
+        );
+    }
+
+    #[test]
+    fn count_message_tokens_thinking_block_counts_text() {
+        let counter = TokenCounter::new();
+        let thinking = "step by step reasoning about the problem";
+        let signature = "sig";
+        let msg = make_msg(vec![MessagePart::ThinkingBlock {
+            thinking: thinking.to_string(),
+            signature: signature.to_string(),
+        }]);
+        let expected =
+            THINKING_OVERHEAD + counter.count_tokens(thinking) + counter.count_tokens(signature);
+        assert_eq!(counter.count_message_tokens(&msg), expected);
+    }
+
+    #[test]
+    fn count_part_tokens_empty_text_returns_zero() {
+        let counter = TokenCounter::new();
+        assert_eq!(
+            counter.count_part_tokens(&MessagePart::Text {
+                text: String::new()
+            }),
+            0
+        );
+        assert_eq!(
+            counter.count_part_tokens(&MessagePart::Text {
+                text: "   ".to_string()
+            }),
+            0
+        );
+        assert_eq!(
+            counter.count_part_tokens(&MessagePart::Recall {
+                text: "\n\t".to_string()
+            }),
+            0
+        );
+    }
+
+    #[test]
+    fn count_message_tokens_push_recompute_consistency() {
+        // Verify that sum of count_message_tokens per part equals recompute result
+        let counter = TokenCounter::new();
+        let parts = vec![
+            MessagePart::Text {
+                text: "hello".into(),
+            },
+            MessagePart::ToolOutput {
+                tool_name: "bash".into(),
+                body: "output data".into(),
+                compacted_at: None,
+            },
+        ];
+        let msg = make_msg(parts);
+        let total = counter.count_message_tokens(&msg);
+        let sum: usize = msg.parts.iter().map(|p| counter.count_part_tokens(p)).sum();
+        assert_eq!(total, sum);
+    }
+
+    #[test]
+    fn count_message_tokens_parts_take_priority_over_content() {
+        // R-2: primary regression guard — when parts is non-empty, content is ignored.
+        let counter = TokenCounter::new();
+        let parts_text = "hello from parts";
+        let msg = Message {
+            role: Role::User,
+            content: "completely different content that should be ignored".to_string(),
+            parts: vec![MessagePart::Text {
+                text: parts_text.to_string(),
+            }],
+            metadata: MessageMetadata::default(),
+        };
+        let parts_based = counter.count_tokens(parts_text);
+        let content_based = counter.count_tokens(&msg.content);
+        assert_ne!(
+            parts_based, content_based,
+            "test setup: parts and content must differ"
+        );
+        assert_eq!(counter.count_message_tokens(&msg), parts_based);
+    }
+
+    #[test]
+    fn count_part_tokens_tool_result() {
+        // R-3: verify ToolResult arm counting
+        let counter = TokenCounter::new();
+        let tool_use_id = "toolu_xyz";
+        let content = "result text";
+        let part = MessagePart::ToolResult {
+            tool_use_id: tool_use_id.to_string(),
+            content: content.to_string(),
+            is_error: false,
+        };
+        let expected = TOOL_RESULT_OVERHEAD
+            + counter.count_tokens(tool_use_id)
+            + counter.count_tokens(content);
+        assert_eq!(counter.count_part_tokens(&part), expected);
+    }
 
     #[test]
     fn count_tokens_empty() {


### PR DESCRIPTION
## Summary

- Add `count_message_tokens`/`count_part_tokens` to `TokenCounter` — estimates tokens per `MessagePart` variant matching actual API payload structure
- Update 6 call sites in `utils.rs` and `context.rs` from `count_tokens(&msg.content)` to `count_message_tokens(msg)`
- Falls back to `content` for plain text messages without parts
- 10 new unit tests (+14 total delta from base)

Closes #1280

## Test plan

- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --workspace --features full -- -D warnings` — 0 warnings
- [x] `cargo nextest run --workspace --features full --lib --bins` — 4413 passed, 11 skipped
- [x] Key invariant test: structured ToolUse token count > flattened content count
- [x] Regression guard: parts take priority over content when both present