### PR TITLE
fix(memory): correction embedding FK constraint failure on clean DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Correction embedding storage fails with FOREIGN KEY constraint error (SQLite code 787) on a clean database. Add missing `ensure_named_collection()` call before vector store operations in `store_correction_embedding()` and `retrieve_similar_corrections()` (#1348)
 - Router provider no longer eagerly initializes all providers in chain at startup. Providers that fail to initialize (e.g. missing API keys) are skipped with a warning instead of aborting the entire chain (#1345)
 - Compatible provider API key is now optional for local endpoints (localhost, private networks). Add `api_key` field to `[[llm.compatible]]` config as an alternative to vault secrets (#1345)
 

--- a/crates/zeph-memory/src/semantic.rs
+++ b/crates/zeph-memory/src/semantic.rs
@@ -1326,6 +1326,10 @@ impl SemanticMemory {
             .embed(correction_text)
             .await
             .map_err(|e| MemoryError::Other(e.to_string()))?;
+        let vector_size = u64::try_from(embedding.len()).unwrap_or(896);
+        store
+            .ensure_named_collection(CORRECTIONS_COLLECTION, vector_size)
+            .await?;
         let payload = serde_json::json!({ "correction_id": correction_id });
         store
             .store_to_collection(CORRECTIONS_COLLECTION, payload, embedding)
@@ -1358,6 +1362,10 @@ impl SemanticMemory {
             .embed(query)
             .await
             .map_err(|e| MemoryError::Other(e.to_string()))?;
+        let vector_size = u64::try_from(embedding.len()).unwrap_or(896);
+        store
+            .ensure_named_collection(CORRECTIONS_COLLECTION, vector_size)
+            .await?;
         let scored = store
             .search_collection(CORRECTIONS_COLLECTION, &embedding, limit, None)
             .await
@@ -2361,6 +2369,85 @@ mod tests {
         let memory = test_semantic_memory(false).await;
         let results = memory
             .search_session_summaries("query", 5, Some(ConversationId(1)))
+            .await
+            .unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn store_correction_embedding_no_qdrant_noop() {
+        let memory = test_semantic_memory(true).await;
+        let result = memory.store_correction_embedding(1, "bad response").await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn store_correction_embedding_no_embeddings_noop() {
+        let memory = test_semantic_memory(false).await;
+        let result = memory.store_correction_embedding(1, "bad response").await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn retrieve_similar_corrections_no_qdrant_empty() {
+        let memory = test_semantic_memory(true).await;
+        let results = memory
+            .retrieve_similar_corrections("query", 5, 0.0)
+            .await
+            .unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn retrieve_similar_corrections_no_embeddings_empty() {
+        let memory = test_semantic_memory(false).await;
+        let results = memory
+            .retrieve_similar_corrections("query", 5, 0.0)
+            .await
+            .unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn store_correction_embedding_sqlite_clean_db_roundtrip() {
+        let mut mock = MockProvider::default();
+        mock.supports_embeddings = true;
+        let provider = AnyProvider::Mock(mock);
+
+        let sqlite = SqliteStore::new(":memory:").await.unwrap();
+        let pool = sqlite.pool().clone();
+        let qdrant = Some(Arc::new(
+            crate::embedding_store::EmbeddingStore::new_sqlite(pool),
+        ));
+
+        let memory = SemanticMemory {
+            sqlite,
+            qdrant,
+            provider,
+            embedding_model: "test-model".into(),
+            vector_weight: 0.7,
+            keyword_weight: 0.3,
+            temporal_decay_enabled: false,
+            temporal_decay_half_life_days: 30,
+            mmr_enabled: false,
+            mmr_lambda: 0.7,
+            token_counter: Arc::new(TokenCounter::new()),
+            graph_store: None,
+            community_detection_failures: Arc::new(AtomicU64::new(0)),
+            graph_extraction_count: Arc::new(AtomicU64::new(0)),
+            graph_extraction_failures: Arc::new(AtomicU64::new(0)),
+        };
+
+        // Regression test: on a clean DB, store_correction_embedding() must NOT fail with
+        // SQLite FK constraint error (error 787). ensure_named_collection() must be called first.
+        memory
+            .store_correction_embedding(1, "bad response")
+            .await
+            .unwrap();
+
+        // retrieve must succeed too (no UserCorrectionRow in SQLite yet → empty results)
+        let results = memory
+            .retrieve_similar_corrections("bad", 5, 0.0)
             .await
             .unwrap();
         assert!(results.is_empty());


### PR DESCRIPTION
## Summary

- Fix FOREIGN KEY constraint failure (SQLite error 787) when storing correction embeddings on a clean database by adding missing `ensure_named_collection()` calls before vector store operations in `store_correction_embedding()` and `retrieve_similar_corrections()`
- Add 5 unit tests including a clean-DB regression test that exercises the exact failure scenario

Closes #1348

## Root Cause

`store_correction_embedding()` and `retrieve_similar_corrections()` in `crates/zeph-memory/src/semantic.rs` called `store_to_collection()` / `search_collection()` without first ensuring the `"zeph_corrections"` collection exists in the `vector_collections` table. Other collections (`session_summaries`, `key_facts`) correctly call `ensure_named_collection()` first — corrections was the only one missing this call.

## Changes

- `crates/zeph-memory/src/semantic.rs`: add `ensure_named_collection(CORRECTIONS_COLLECTION, vector_size)` before `store_to_collection()` and `search_collection()`
- `crates/zeph-memory/src/semantic.rs`: add 5 tests (`store_correction_embedding_no_qdrant_noop`, `store_correction_embedding_no_embeddings_noop`, `retrieve_similar_corrections_no_qdrant_empty`, `retrieve_similar_corrections_no_embeddings_empty`, `store_correction_embedding_sqlite_clean_db_roundtrip`)

## Test plan

- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --workspace --features full -- -D warnings` passes (zero warnings)
- [x] `cargo nextest run --workspace --features full --lib --bins` — 4688 passed, 11 skipped
- [x] New regression test `store_correction_embedding_sqlite_clean_db_roundtrip` exercises the exact clean-DB FK scenario