### PR TITLE
feat(core): add /help, /exit, /status slash commands with discoverability

### DIFF
--- a/crates/zeph-channels/src/any.rs
+++ b/crates/zeph-channels/src/any.rs
@@ -70,6 +70,17 @@ impl Channel for AnyChannel {
         }
     }
 
+    fn supports_exit(&self) -> bool {
+        match self {
+            Self::Cli(c) => c.supports_exit(),
+            Self::Telegram(c) => c.supports_exit(),
+            #[cfg(feature = "discord")]
+            Self::Discord(c) => c.supports_exit(),
+            #[cfg(feature = "slack")]
+            Self::Slack(c) => c.supports_exit(),
+        }
+    }
+
     async fn send_status(&mut self, text: &str) -> Result<(), ChannelError> {
         dispatch_channel!(self, send_status, text)
     }

--- a/crates/zeph-channels/src/cli.rs
+++ b/crates/zeph-channels/src/cli.rs
@@ -120,7 +120,11 @@ impl Channel for CliChannel {
                 ReadLineResult::Interrupted | ReadLineResult::Eof => return Ok(None),
                 ReadLineResult::Line(l) => {
                     let trimmed = l.trim();
-                    if trimmed == "exit" || trimmed == "quit" {
+                    if trimmed == "exit"
+                        || trimmed == "quit"
+                        || trimmed == "/exit"
+                        || trimmed == "/quit"
+                    {
                         return Ok(None);
                     }
                     // In pipe mode, skip empty lines (formatting) and read the next one.

--- a/crates/zeph-channels/src/discord/mod.rs
+++ b/crates/zeph-channels/src/discord/mod.rs
@@ -136,6 +136,10 @@ impl DiscordChannel {
 }
 
 impl Channel for DiscordChannel {
+    fn supports_exit(&self) -> bool {
+        false
+    }
+
     fn try_recv(&mut self) -> Option<ChannelMessage> {
         loop {
             let incoming = self.rx.try_recv().ok()?;

--- a/crates/zeph-channels/src/slack/mod.rs
+++ b/crates/zeph-channels/src/slack/mod.rs
@@ -122,6 +122,10 @@ impl SlackChannel {
 }
 
 impl Channel for SlackChannel {
+    fn supports_exit(&self) -> bool {
+        false
+    }
+
     fn try_recv(&mut self) -> Option<ChannelMessage> {
         let incoming = self.rx.try_recv().ok()?;
         self.channel_id = Some(incoming.channel_id);

--- a/crates/zeph-channels/src/telegram.rs
+++ b/crates/zeph-channels/src/telegram.rs
@@ -292,6 +292,10 @@ async fn download_file(bot: &Bot, file_id: String, capacity: u32) -> Result<Vec<
 }
 
 impl Channel for TelegramChannel {
+    fn supports_exit(&self) -> bool {
+        false
+    }
+
     fn try_recv(&mut self) -> Option<ChannelMessage> {
         self.rx.try_recv().ok().map(|incoming| {
             self.chat_id = Some(incoming.chat_id);

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -20,6 +20,7 @@ mod mcp;
 mod message_queue;
 mod persistence;
 mod skill_management;
+pub mod slash_commands;
 mod tool_execution;
 pub(crate) mod tool_orchestrator;
 mod trust_commands;
@@ -1009,6 +1010,17 @@ impl<C: Channel> Agent<C> {
                 continue;
             }
 
+            if trimmed == "/exit" || trimmed == "/quit" {
+                if self.channel.supports_exit() {
+                    break;
+                }
+                let _ = self
+                    .channel
+                    .send("/exit is not supported in this channel.")
+                    .await;
+                continue;
+            }
+
             self.process_user_message(text, image_parts).await?;
         }
 
@@ -1270,6 +1282,16 @@ impl<C: Channel> Agent<C> {
             token.cancel();
         });
         let trimmed = text.trim();
+
+        if trimmed == "/help" {
+            self.handle_help_command().await?;
+            return Ok(());
+        }
+
+        if trimmed == "/status" {
+            self.handle_status_command().await?;
+            return Ok(());
+        }
 
         if trimmed == "/skills" {
             self.handle_skills_command().await?;
@@ -1650,6 +1672,101 @@ impl<C: Channel> Agent<C> {
         self.channel
             .send(&format!("Image loaded: {path}. Send your message."))
             .await?;
+        Ok(())
+    }
+
+    async fn handle_help_command(&mut self) -> Result<(), error::AgentError> {
+        use std::fmt::Write;
+
+        let mut out = String::from("Slash commands:\n\n");
+
+        let categories = [
+            slash_commands::SlashCategory::Info,
+            slash_commands::SlashCategory::Session,
+            slash_commands::SlashCategory::Model,
+            slash_commands::SlashCategory::Memory,
+            slash_commands::SlashCategory::Tools,
+            slash_commands::SlashCategory::Planning,
+            slash_commands::SlashCategory::Debug,
+            slash_commands::SlashCategory::Advanced,
+        ];
+
+        for cat in &categories {
+            let entries: Vec<_> = slash_commands::COMMANDS
+                .iter()
+                .filter(|c| &c.category == cat)
+                .collect();
+            if entries.is_empty() {
+                continue;
+            }
+            let _ = writeln!(out, "{}:", cat.as_str());
+            for cmd in entries {
+                if cmd.args.is_empty() {
+                    let _ = write!(out, "  {}", cmd.name);
+                } else {
+                    let _ = write!(out, "  {} {}", cmd.name, cmd.args);
+                }
+                let _ = write!(out, "  — {}", cmd.description);
+                if let Some(feat) = cmd.feature_gate {
+                    let _ = write!(out, " [requires: {feat}]");
+                }
+                let _ = writeln!(out);
+            }
+            let _ = writeln!(out);
+        }
+
+        self.channel.send(out.trim_end()).await?;
+        Ok(())
+    }
+
+    async fn handle_status_command(&mut self) -> Result<(), error::AgentError> {
+        use std::fmt::Write;
+
+        let uptime = self.start_time.elapsed().as_secs();
+        let msg_count = self
+            .messages
+            .iter()
+            .filter(|m| m.role == Role::User)
+            .count();
+
+        let (api_calls, prompt_tokens, completion_tokens, cost_cents, mcp_servers) =
+            if let Some(ref tx) = self.metrics_tx {
+                let m = tx.borrow();
+                (
+                    m.api_calls,
+                    m.prompt_tokens,
+                    m.completion_tokens,
+                    m.cost_spent_cents,
+                    m.mcp_server_count,
+                )
+            } else {
+                (0, 0, 0, 0.0, 0)
+            };
+
+        let skill_count = self
+            .skill_state
+            .registry
+            .read()
+            .map(|r| r.all_meta().len())
+            .unwrap_or(0);
+
+        let mut out = String::from("Session status:\n\n");
+        let _ = writeln!(out, "Provider:  {}", self.provider.name());
+        let _ = writeln!(out, "Model:     {}", self.runtime.model_name);
+        let _ = writeln!(out, "Uptime:    {uptime}s");
+        let _ = writeln!(out, "Turns:     {msg_count}");
+        let _ = writeln!(out, "API calls: {api_calls}");
+        let _ = writeln!(
+            out,
+            "Tokens:    {prompt_tokens} prompt / {completion_tokens} completion"
+        );
+        let _ = writeln!(out, "Skills:    {skill_count}");
+        let _ = writeln!(out, "MCP:       {mcp_servers} server(s)");
+        if cost_cents > 0.0 {
+            let _ = writeln!(out, "Cost:      ${:.4}", cost_cents / 100.0);
+        }
+
+        self.channel.send(out.trim_end()).await?;
         Ok(())
     }
 
@@ -2358,6 +2475,7 @@ pub(super) mod agent_tests {
         chunks: Arc<Mutex<Vec<String>>>,
         confirmations: Arc<Mutex<Vec<bool>>>,
         pub(crate) statuses: Arc<Mutex<Vec<String>>>,
+        exit_supported: bool,
     }
 
     impl MockChannel {
@@ -2368,7 +2486,13 @@ pub(super) mod agent_tests {
                 chunks: Arc::new(Mutex::new(Vec::new())),
                 confirmations: Arc::new(Mutex::new(Vec::new())),
                 statuses: Arc::new(Mutex::new(Vec::new())),
+                exit_supported: true,
             }
+        }
+
+        pub(crate) fn without_exit_support(mut self) -> Self {
+            self.exit_supported = false;
+            self
         }
 
         pub(crate) fn with_confirmations(mut self, confirmations: Vec<bool>) -> Self {
@@ -2436,6 +2560,10 @@ pub(super) mod agent_tests {
             } else {
                 confs.remove(0)
             })
+        }
+
+        fn supports_exit(&self) -> bool {
+            self.exit_supported
         }
     }
 
@@ -3928,6 +4056,147 @@ pub(super) mod agent_tests {
             messages.iter().any(|m| m.contains("Fetched")),
             "expected fetch confirmation, got: {messages:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn help_command_lists_commands() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec!["/help".to_string()]);
+        let sent = channel.sent.clone();
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+        let result = agent.run().await;
+        assert!(result.is_ok());
+
+        let messages = sent.lock().unwrap();
+        assert!(!messages.is_empty(), "expected /help output");
+        let output = messages.join("\n");
+        assert!(output.contains("/help"), "expected /help in output");
+        assert!(output.contains("/exit"), "expected /exit in output");
+        assert!(output.contains("/status"), "expected /status in output");
+        assert!(output.contains("/skills"), "expected /skills in output");
+        assert!(output.contains("/model"), "expected /model in output");
+    }
+
+    #[tokio::test]
+    async fn help_command_does_not_include_unknown_commands() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec!["/help".to_string()]);
+        let sent = channel.sent.clone();
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+        let result = agent.run().await;
+        assert!(result.is_ok());
+
+        let messages = sent.lock().unwrap();
+        let output = messages.join("\n");
+        // /ingest does not exist in the codebase — must not appear
+        assert!(
+            !output.contains("/ingest"),
+            "unexpected /ingest in /help output"
+        );
+    }
+
+    #[tokio::test]
+    async fn status_command_includes_provider_and_model() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec!["/status".to_string()]);
+        let sent = channel.sent.clone();
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+        let result = agent.run().await;
+        assert!(result.is_ok());
+
+        let messages = sent.lock().unwrap();
+        assert!(!messages.is_empty(), "expected /status output");
+        let output = messages.join("\n");
+        assert!(output.contains("Provider:"), "expected Provider: field");
+        assert!(output.contains("Model:"), "expected Model: field");
+        assert!(output.contains("Uptime:"), "expected Uptime: field");
+        assert!(output.contains("Tokens:"), "expected Tokens: field");
+    }
+
+    #[tokio::test]
+    async fn exit_command_breaks_run_loop() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec!["/exit".to_string()]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+        let result = agent.run().await;
+        assert!(result.is_ok());
+        // /exit should not produce any LLM message — only system message in history
+        assert_eq!(agent.messages.len(), 1, "expected only system message");
+    }
+
+    #[tokio::test]
+    async fn quit_command_breaks_run_loop() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec!["/quit".to_string()]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+        let result = agent.run().await;
+        assert!(result.is_ok());
+        assert_eq!(agent.messages.len(), 1, "expected only system message");
+    }
+
+    #[tokio::test]
+    async fn exit_command_sends_info_and_continues_when_not_supported() {
+        let provider = mock_provider(vec![]);
+        // Channel that does not support exit: /exit should NOT break the loop,
+        // it should send an info message and then yield the next message.
+        let channel = MockChannel::new(vec![
+            "/exit".to_string(),
+            // second message is empty → causes recv() to return None → loop exits naturally
+        ])
+        .without_exit_support();
+        let sent = channel.sent.clone();
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+        let result = agent.run().await;
+        assert!(result.is_ok());
+
+        let messages = sent.lock().unwrap();
+        assert!(
+            messages
+                .iter()
+                .any(|m| m.contains("/exit is not supported")),
+            "expected info message, got: {messages:?}"
+        );
+    }
+
+    #[test]
+    fn slash_commands_registry_has_no_ingest() {
+        use super::slash_commands::COMMANDS;
+        assert!(
+            !COMMANDS.iter().any(|c| c.name == "/ingest"),
+            "/ingest is not implemented and must not appear in COMMANDS"
+        );
+    }
+
+    #[test]
+    fn slash_commands_graph_and_plan_have_no_feature_gate() {
+        use super::slash_commands::COMMANDS;
+        for cmd in COMMANDS {
+            if cmd.name == "/graph" || cmd.name == "/plan" {
+                assert!(
+                    cmd.feature_gate.is_none(),
+                    "{} should have feature_gate: None",
+                    cmd.name
+                );
+            }
+        }
     }
 }
 

--- a/crates/zeph-core/src/agent/slash_commands.rs
+++ b/crates/zeph-core/src/agent/slash_commands.rs
@@ -1,0 +1,197 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Static registry of all slash commands available in the agent loop.
+//!
+//! Used by `/help` to enumerate and display commands grouped by category.
+
+/// Broad grouping for displaying commands in `/help` output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SlashCategory {
+    Session,
+    Model,
+    Info,
+    Memory,
+    Tools,
+    Debug,
+    Planning,
+    Advanced,
+}
+
+impl SlashCategory {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Session => "Session",
+            Self::Model => "Model",
+            Self::Info => "Info",
+            Self::Memory => "Memory",
+            Self::Tools => "Tools",
+            Self::Debug => "Debug",
+            Self::Planning => "Planning",
+            Self::Advanced => "Advanced",
+        }
+    }
+}
+
+/// Metadata for a single slash command displayed by `/help`.
+pub struct SlashCommandInfo {
+    pub name: &'static str,
+    /// Argument hint shown after the command name, e.g. `[path]` or `<name>`.
+    pub args: &'static str,
+    pub description: &'static str,
+    pub category: SlashCategory,
+    /// When `Some`, this entry was compiled in only for that feature.
+    /// Shown in the help output as `[requires: <feature>]`.
+    pub feature_gate: Option<&'static str>,
+}
+
+/// All slash commands recognised by the agent loop, in display order.
+///
+/// Feature-gated entries are wrapped in `#[cfg(feature = "...")]` so that
+/// only commands compiled into the binary appear in `/help`.
+pub const COMMANDS: &[SlashCommandInfo] = &[
+    // --- Info ---
+    SlashCommandInfo {
+        name: "/help",
+        args: "",
+        description: "Show this help message",
+        category: SlashCategory::Info,
+        feature_gate: None,
+    },
+    SlashCommandInfo {
+        name: "/status",
+        args: "",
+        description: "Show current session status (provider, model, tokens, uptime)",
+        category: SlashCategory::Info,
+        feature_gate: None,
+    },
+    SlashCommandInfo {
+        name: "/skills",
+        args: "",
+        description: "List loaded skills",
+        category: SlashCategory::Info,
+        feature_gate: None,
+    },
+    SlashCommandInfo {
+        name: "/log",
+        args: "",
+        description: "Toggle verbose log output",
+        category: SlashCategory::Info,
+        feature_gate: None,
+    },
+    // --- Session ---
+    SlashCommandInfo {
+        name: "/exit",
+        args: "",
+        description: "Exit the agent (also: /quit)",
+        category: SlashCategory::Session,
+        feature_gate: None,
+    },
+    SlashCommandInfo {
+        name: "/clear",
+        args: "",
+        description: "Clear conversation history",
+        category: SlashCategory::Session,
+        feature_gate: None,
+    },
+    SlashCommandInfo {
+        name: "/clear-queue",
+        args: "",
+        description: "Discard queued messages",
+        category: SlashCategory::Session,
+        feature_gate: None,
+    },
+    SlashCommandInfo {
+        name: "/compact",
+        args: "",
+        description: "Compact the context window",
+        category: SlashCategory::Session,
+        feature_gate: None,
+    },
+    // --- Model ---
+    SlashCommandInfo {
+        name: "/model",
+        args: "[id|refresh]",
+        description: "Show or switch the active model",
+        category: SlashCategory::Model,
+        feature_gate: None,
+    },
+    // --- Memory ---
+    SlashCommandInfo {
+        name: "/feedback",
+        args: "<skill> <message>",
+        description: "Submit feedback for a skill",
+        category: SlashCategory::Memory,
+        feature_gate: None,
+    },
+    SlashCommandInfo {
+        name: "/graph",
+        args: "[subcommand]",
+        description: "Query or manage the knowledge graph",
+        category: SlashCategory::Memory,
+        feature_gate: None,
+    },
+    // --- Tools ---
+    SlashCommandInfo {
+        name: "/skill",
+        args: "<name>",
+        description: "Load and display a skill body",
+        category: SlashCategory::Tools,
+        feature_gate: None,
+    },
+    SlashCommandInfo {
+        name: "/mcp",
+        args: "[add|list|tools|remove]",
+        description: "Manage MCP servers",
+        category: SlashCategory::Tools,
+        feature_gate: None,
+    },
+    SlashCommandInfo {
+        name: "/image",
+        args: "<path>",
+        description: "Attach an image to the next message",
+        category: SlashCategory::Tools,
+        feature_gate: None,
+    },
+    SlashCommandInfo {
+        name: "/agent",
+        args: "[subcommand]",
+        description: "Manage sub-agents",
+        category: SlashCategory::Tools,
+        feature_gate: None,
+    },
+    // --- Planning ---
+    SlashCommandInfo {
+        name: "/plan",
+        args: "[goal|confirm|cancel|status|list|resume|retry]",
+        description: "Create or manage execution plans",
+        category: SlashCategory::Planning,
+        feature_gate: None,
+    },
+    // --- Debug ---
+    SlashCommandInfo {
+        name: "/debug-dump",
+        args: "[path]",
+        description: "Enable or toggle debug dump output",
+        category: SlashCategory::Debug,
+        feature_gate: None,
+    },
+    // --- Advanced (feature-gated) ---
+    #[cfg(feature = "experiments")]
+    SlashCommandInfo {
+        name: "/experiment",
+        args: "[subcommand]",
+        description: "Experimental features",
+        category: SlashCategory::Advanced,
+        feature_gate: Some("experiments"),
+    },
+    #[cfg(feature = "lsp-context")]
+    SlashCommandInfo {
+        name: "/lsp",
+        args: "",
+        description: "Show LSP context status",
+        category: SlashCategory::Advanced,
+        feature_gate: Some("lsp-context"),
+    },
+];

--- a/crates/zeph-core/src/channel.rs
+++ b/crates/zeph-core/src/channel.rs
@@ -60,6 +60,14 @@ pub trait Channel: Send {
         None
     }
 
+    /// Whether `/exit` and `/quit` commands should terminate the agent loop.
+    ///
+    /// Returns `false` for persistent server-side channels (e.g. Telegram) where
+    /// breaking the loop would not meaningfully exit from the user's perspective.
+    fn supports_exit(&self) -> bool {
+        true
+    }
+
     /// Send a text response.
     ///
     /// # Errors
@@ -340,6 +348,10 @@ impl LoopbackChannel {
 }
 
 impl Channel for LoopbackChannel {
+    fn supports_exit(&self) -> bool {
+        false
+    }
+
     async fn recv(&mut self) -> Result<Option<ChannelMessage>, ChannelError> {
         Ok(self.input_rx.recv().await)
     }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -59,6 +59,13 @@ impl Channel for AppChannel {
             Self::Tui(c) => c.try_recv(),
         }
     }
+
+    fn supports_exit(&self) -> bool {
+        match self {
+            Self::Standard(c) => c.supports_exit(),
+            Self::Tui(c) => c.supports_exit(),
+        }
+    }
     async fn send_status(&mut self, text: &str) -> Result<(), ChannelError> {
         dispatch_app_channel!(self, send_status, text)
     }


### PR DESCRIPTION
Fixes #1379.

## Summary

- Add `/help` command listing all available slash commands, grouped by category
- Add `/exit` (and `/quit`) as explicit slash commands that terminate the CLI session; CliChannel also accepts them as early-exit aliases alongside bare `exit`/`quit`
- Add `/status` command showing provider, model, uptime, message count, token usage and cost
- Add `supports_exit()` to the `Channel` trait (default `true`) so server-side channels (Telegram, Discord, Slack, ACP/A2A LoopbackChannel) safely return an info message instead of breaking the run loop

## Changes

- `crates/zeph-core/src/agent/slash_commands.rs` (new) — static `COMMANDS` registry with `SlashCommandInfo`; feature-gated entries use `#[cfg(feature)]` at compile time
- `crates/zeph-core/src/agent/mod.rs` — dispatch for `/help`, `/exit`, `/quit`, `/status`; `handle_help_command()`, `handle_status_command()`
- `crates/zeph-core/src/channel.rs` — `supports_exit()` trait method with default `true`
- `crates/zeph-channels/src/any.rs` — `AnyChannel` delegates `supports_exit()` to inner channel
- `crates/zeph-channels/src/{cli,telegram,discord/mod,slack/mod}.rs` — appropriate overrides
- `src/channel.rs` — `AppChannel` delegates `supports_exit()` to inner channel

## Test plan

- [ ] `cargo +nightly fmt --check` passes
- [ ] `cargo clippy --workspace --features full -- -D warnings` passes
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --features full --lib --bins` — 4769 passed (+332 vs baseline 4437)
- [ ] `/help` in CLI shows grouped command list
- [ ] `/exit` terminates CLI session
- [ ] `/status` shows provider/model/uptime/tokens
- [ ] Telegram `/exit` returns info message, does not break loop