### PR TITLE
fix(cli): allow --log-file bare flag to disable file logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `--log-file` now accepts bare flag (without value) to disable file logging, overriding config (#1378)
 - Response cache bypassed in native `tool_use` path: `process_response_native_tools()` never called `check_response_cache()` or `store_response_in_cache()`, so cache lookups and stores only worked in the legacy non-tool path. Add cache check before the tool loop and cache store after `ChatResponse::Text` responses (#1377)
 - `[memory.compression]` and `[memory.routing]` config sections silently ignored on startup; only applied after config hot-reload. Add `with_compression()` and `with_routing()` builder methods and wire them in agent construction (#1374)
 - Add partial index `idx_graph_edges_expired` on `graph_edges(expired_at) WHERE expired_at IS NOT NULL` (migration 027) to accelerate `delete_expired_edges` eviction query, which previously required a full table scan (#1264)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -89,10 +89,11 @@ pub(crate) struct Cli {
     #[arg(long)]
     pub(crate) lsp_context: bool,
 
-    /// Override log file path (set to empty string to disable file logging).
-    /// When omitted, uses the value from [logging] config section (default: .zeph/logs/zeph.log).
-    #[arg(long, value_name = "PATH")]
-    pub(crate) log_file: Option<PathBuf>,
+    /// Override log file path. Use bare `--log-file` (without a value) to disable file
+    /// logging, overriding any config value. When omitted, uses the value from [logging]
+    /// config section (default: .zeph/logs/zeph.log).
+    #[arg(long, value_name = "PATH", num_args = 0..=1, default_missing_value = "")]
+    pub(crate) log_file: Option<String>,
 
     /// Enable debug dump: write LLM requests/responses and raw tool output to files.
     /// Omit PATH to use the default directory from config (default: .zeph/debug).
@@ -372,15 +373,18 @@ mod tests {
     #[test]
     fn cli_parses_log_file_flag() {
         let cli = Cli::try_parse_from(["zeph", "--log-file", "/tmp/test.log"]).unwrap();
-        assert_eq!(
-            cli.log_file.as_deref(),
-            Some(std::path::Path::new("/tmp/test.log"))
-        );
+        assert_eq!(cli.log_file.as_deref(), Some("/tmp/test.log"));
     }
 
     #[test]
     fn cli_log_file_defaults_to_none() {
         let cli = Cli::try_parse_from(["zeph"]).unwrap();
         assert!(cli.log_file.is_none());
+    }
+
+    #[test]
+    fn cli_log_file_bare_flag_disables_logging() {
+        let cli = Cli::try_parse_from(["zeph", "--log-file"]).unwrap();
+        assert_eq!(cli.log_file.as_deref(), Some(""));
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -80,11 +80,11 @@ fn check_legacy_artifact_paths(config: &Config) {
 /// Priority: CLI flag > config file > built-in defaults.
 fn resolve_logging_config(
     config_logging: zeph_core::config::LoggingConfig,
-    cli_log_file: Option<&std::path::Path>,
+    cli_log_file: Option<&str>,
 ) -> zeph_core::config::LoggingConfig {
     let mut logging = config_logging;
     if let Some(p) = cli_log_file {
-        logging.file = p.to_string_lossy().into_owned();
+        p.clone_into(&mut logging.file);
     }
     logging
 }
@@ -991,7 +991,7 @@ mod tests {
     fn resolve_logging_config_cli_empty_str_disables_logging() {
         let mut base = zeph_core::config::LoggingConfig::default();
         base.file = "/var/log/zeph.log".into();
-        let result = resolve_logging_config(base, Some(std::path::Path::new("")));
+        let result = resolve_logging_config(base, Some(""));
         assert_eq!(result.file, "");
     }
 
@@ -999,7 +999,7 @@ mod tests {
     fn resolve_logging_config_cli_path_overrides_config() {
         let mut base = zeph_core::config::LoggingConfig::default();
         base.file = "/var/log/zeph.log".into();
-        let result = resolve_logging_config(base, Some(std::path::Path::new("/tmp/custom.log")));
+        let result = resolve_logging_config(base, Some("/tmp/custom.log"));
         assert_eq!(result.file, "/tmp/custom.log");
     }
 


### PR DESCRIPTION
## Summary

- Change `log_file` field type from `Option<PathBuf>` to `Option<String>` with `num_args = 0..=1, default_missing_value = ""`
- Bare `--log-file` (no value) now sets empty string, disabling file logging even when config has a path
- Update `resolve_logging_config` signature in `runner.rs` to accept `Option<&str>`

Closes #1378

## Test plan

- [ ] `cargo nextest run` passes (4807 tests)
- [ ] `cli_log_file_bare_flag_disables_logging` — bare `--log-file` parses to `Some("")`
- [ ] `cli_parses_log_file_flag` — path value works as before
- [ ] `cli_log_file_defaults_to_none` — omitted flag remains `None`
- [ ] `resolve_logging_config_cli_empty_str_disables_logging` — empty string overrides config