### PR TITLE
fix(memory): start eviction loop during agent bootstrap

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -327,6 +327,23 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         });
     }
 
+    let _eviction_handle = {
+        let eviction_cancel = zeph_memory::CancellationToken::new();
+        let eviction_cancel_clone = eviction_cancel.clone();
+        let mut shutdown_for_eviction = shutdown_rx.clone();
+        tokio::spawn(async move {
+            let _ = shutdown_for_eviction.changed().await;
+            eviction_cancel_clone.cancel();
+        });
+        let sqlite_store = std::sync::Arc::new(memory.sqlite().clone());
+        zeph_memory::start_eviction_loop(
+            sqlite_store,
+            &config.memory.eviction,
+            std::sync::Arc::new(zeph_memory::EbbinghausPolicy::default()),
+            eviction_cancel,
+        )
+    };
+
     let skill_paths = app.skill_paths();
 
     let memory_executor = zeph_core::memory_tools::MemoryToolExecutor::new(


### PR DESCRIPTION
## Summary

- `start_eviction_loop()` was exported from `zeph-memory` but never called, making Ebbinghaus eviction silently non-functional regardless of `[memory.eviction]` config
- Wire it up in `src/runner.rs` after `build_memory()`, bridging the existing `shutdown_rx` watch channel to a `CancellationToken` for graceful teardown
- `_eviction_handle` is kept alive for the duration of `run()`, consistent with `_skill_watcher` and `_instruction_watcher`

## Test plan

- [ ] `cargo build --workspace --features full` passes
- [ ] `cargo clippy --workspace --features full -- -D warnings` passes (0 warnings)
- [ ] `cargo +nightly fmt --check` passes
- [ ] 4818 tests pass, 0 regressions
- [ ] Manual: set `[memory.eviction] max_entries = 5, sweep_interval_secs = 15`, send >5 messages, verify soft-deletes appear in DB after sweep

Closes #1395