### PR TITLE
fix(subagent): create transcript directory on first sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Sub-agent transcript sweep no longer logs a spurious `transcript sweep failed` warning on first run when the transcript directory does not exist yet; the directory is now created automatically (#1397)
+
 ### Performance
 
 - Parallelize LLM summarization calls across communities in `detect_communities` using `tokio::task::JoinSet` bounded by `Arc<Semaphore>`. New `GraphConfig.community_summary_concurrency` field (default: 4) controls the concurrency limit; `concurrency=1` provides sequential fallback (#1260)

--- a/crates/zeph-core/src/subagent/transcript.rs
+++ b/crates/zeph-core/src/subagent/transcript.rs
@@ -241,6 +241,12 @@ pub fn sweep_old_transcripts(dir: &Path, max_files: usize) -> io::Result<usize> 
         return Ok(0);
     }
 
+    // Create the directory if it does not exist yet (first run).
+    if !dir.exists() {
+        fs::create_dir_all(dir)?;
+        return Ok(0);
+    }
+
     let mut jsonl_files: Vec<(PathBuf, std::time::SystemTime)> = Vec::new();
     for entry in fs::read_dir(dir)? {
         let entry = entry?;


### PR DESCRIPTION
## Summary

- `sweep_old_transcripts` called `fs::read_dir` on a directory that did not exist yet, producing a spurious `WARN zeph_core::subagent::manager: transcript sweep failed` on first agent spawn
- Fix: check `dir.exists()` at the start of the sweep; create via `create_dir_all` and return early (no files to sweep yet)

Closes #1397

## Test plan

- [ ] Existing unit tests pass (`cargo nextest run --workspace --features full --lib --bins`: 4854 passed)
- [ ] Start agent with no prior `.zeph/subagents/` directory and spawn a sub-agent — no `transcript sweep failed` warning appears in logs