### PR TITLE
release: v0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - `/experiment status` now shows the last completed session (session ID, experiment count, accepted count, best delta) when an experiment is not running. Previously it always showed "idle" with no history, making scheduled experiment results invisible (#1425)
-
-## [0.14.2] - 2026-03-09
-
-### Fixed
-
 - Shell timeouts in `ShellExecutor` now return `Err(ToolError::Timeout { timeout_secs })` instead of `Ok(ToolOutput)` with an error string. Fixes dead `ToolError::Timeout` code path and enables `max_tool_retries` retry-with-backoff for timed-out shell commands (#1420)
 - `/model <id>` now validates the provided model name against the cached model list before switching. If the model is not found in a non-empty list, an error is returned with the list of available models. If the model list is unavailable (cold start or provider does not support listing), a warning is shown and the switch proceeds (#1417)
 - `/status` command now shows real API call count, token usage, and cost in CLI mode (non-TUI). `MetricsCollector` watch channel is always initialized in `runner.rs`; in CLI mode the receiver is dropped immediately, in TUI mode it flows to the TUI widget as before (#1415)


### PR DESCRIPTION
## Summary

- Finalize CHANGELOG.md for v0.14.2 release
- Includes all fixes merged after initial release preparation:
  - fix(core): validate model name in /model command against provider list (#1445)
  - fix(tools): return Err(ToolError::Timeout) from ShellExecutor on timeout (#1446)
  - fix(experiments): show last session in /experiment status (#1448)
  - fix(daemon): gate SIGTERM handler behind #[cfg(unix)] for Windows build

## Checklist

- [x] CHANGELOG.md has release section with date
- [x] Windows build fix included (tokio::signal::unix cfg guard)
- [x] All CI checks pass