### PR TITLE
fix(skills): record tool call outcomes in native tool path

### DIFF
--- a/crates/zeph-core/src/config/snapshots/zeph_core__config__types__tests__config_default_snapshot.snap
+++ b/crates/zeph-core/src/config/snapshots/zeph_core__config__types__tests__config_default_snapshot.snap
@@ -334,3 +334,18 @@ file = ".zeph/logs/zeph.log"
 level = "info"
 rotation = "daily"
 max_files = 7
+
+[lsp]
+enabled = false
+mcp_server_id = "mcpls"
+token_budget = 2000
+call_timeout_secs = 5
+
+[lsp.diagnostics]
+enabled = true
+max_per_file = 20
+min_severity = "error"
+
+[lsp.hover]
+enabled = false
+max_symbols = 10


### PR DESCRIPTION
## Problem

`handle_native_tool_calls` never called `record_skill_outcomes()`, so Wilson score re-ranking received zero signal from actual tool execution when using providers with native `tool_use` support (Claude, OpenAI, OpenAI-compatible).

Only the legacy text-extraction path called `record_skill_outcomes` (via `handle_tool_result`), meaning skill rankings were based solely on explicit user feedback corrections — never on whether tool calls actually succeeded or failed.

## Root Cause

`handle_native_tool_calls` (tool_execution.rs) processes tool results and sends outputs back to the LLM, but contained no calls to `record_skill_outcomes`. The legacy `handle_tool_result` path had these calls at lines ~638, 644, 659, 736.

## Fix

Added `record_skill_outcomes` calls in the results loop of `handle_native_tool_calls`, after the `match tool_result` block, mirroring legacy behavior:

| Result | Outcome |
|--------|---------|
| `Ok(Some(out))` — success output | `"success"` |
| `Ok(Some(out))` — `[error]`/`[exit code` | `"tool_failure"` + `attempt_self_reflection` |
| `Ok(Some(out))` — empty output | `"success"` |
| `Ok(None)` | `"success"` (via `"(no output)"` → else branch) |
| `Err(e)` | `"tool_failure"` |

`attempt_self_reflection` is included on the native failure path (matching legacy) — at the insertion point `persist_message`/`push_message` have not yet been called, so `return Ok(())` is safe.

## Tests

5 regression tests added covering all branches:
- `native_tool_success_outcome_does_not_panic`
- `native_tool_error_output_does_not_panic`
- `native_tool_exit_code_output_does_not_panic`
- `native_tool_executor_error_does_not_panic`
- `native_tool_no_active_skills_does_not_panic`

Fixes #1436