### PR TITLE
fix(metrics): use API-reported output_tokens instead of byte-length estimate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Completion token count in metrics now uses API-reported `output_tokens` from OpenAI, Ollama, and Compatible providers instead of the `response.len() / 4` byte-length heuristic. Streaming paths retain the heuristic as a fallback when the provider returns no usage data. `chat_typed()` now stores usage so `eval_budget_tokens` enforcement reflects real token counts in structured-output calls ([#1449](https://github.com/bug-ops/zeph/issues/1449))
 - Secret requests from sub-agents are now always processed before the plan scheduler terminates, even when the sole task completes on the first tick (instant completion). Previously, `process_pending_secret_requests()` was skipped when `Done` was emitted before the first `wait_event()` (#1454)
 - Anomaly detector now classifies `[stderr]` tool output as `AnomalyOutcome::Error`. Previously the condition checked for dead-code pattern `[exit code` (never emitted by `ShellExecutor`), causing all shell stderr output to be silently classified as `Success` (#1453)
 - Shell audit logger (`ShellExecutor`) now classifies `[stderr]` output as `AuditResult::Error`, matching the anomaly detector fix (#1453)

--- a/crates/zeph-core/src/agent/tool_execution.rs
+++ b/crates/zeph-core/src/agent/tool_execution.rs
@@ -366,18 +366,34 @@ impl<C: Channel> Agent<C> {
             };
             if let Ok(r) = result {
                 let latency = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
-                let completion_estimate_for_cost = r
-                    .as_ref()
-                    .map_or(0, |s| u64::try_from(s.len()).unwrap_or(0) / 4);
+                // completion_tokens was set by process_response_streaming via heuristic;
+                // override with API-reported counts when available (non-streaming providers).
+                let (final_prompt, final_completion_opt) = self
+                    .provider
+                    .last_usage()
+                    .map_or((prompt_estimate, None), |(p, c)| (p, Some(c)));
                 self.update_metrics(|m| {
                     m.api_calls += 1;
                     m.last_llm_latency_ms = latency;
-                    m.context_tokens = prompt_estimate;
-                    m.prompt_tokens += prompt_estimate;
+                    m.context_tokens = final_prompt;
+                    m.prompt_tokens += final_prompt;
+                    if let Some(final_completion) = final_completion_opt {
+                        m.completion_tokens = m
+                            .completion_tokens
+                            .saturating_sub(
+                                r.as_ref()
+                                    .map_or(0, |s| u64::try_from(s.len()).unwrap_or(0) / 4),
+                            )
+                            .saturating_add(final_completion);
+                    }
                     m.total_tokens = m.prompt_tokens + m.completion_tokens;
                 });
                 self.record_cache_usage();
-                self.record_cost(prompt_estimate, completion_estimate_for_cost);
+                let cost_completion = final_completion_opt.unwrap_or_else(|| {
+                    r.as_ref()
+                        .map_or(0, |s| u64::try_from(s.len()).unwrap_or(0) / 4)
+                });
+                self.record_cost(final_prompt, cost_completion);
                 let raw = r?;
                 if let (Some(d), Some(id)) = (self.debug_dumper.as_ref(), dump_id) {
                     d.dump_response(id, &raw);
@@ -411,17 +427,21 @@ impl<C: Channel> Agent<C> {
             match result {
                 Ok(Ok(resp)) => {
                     let latency = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
-                    let completion_estimate = u64::try_from(resp.len()).unwrap_or(0) / 4;
+                    let completion_heuristic = u64::try_from(resp.len()).unwrap_or(0) / 4;
+                    let (final_prompt, final_completion) = self
+                        .provider
+                        .last_usage()
+                        .unwrap_or((prompt_estimate, completion_heuristic));
                     self.update_metrics(|m| {
                         m.api_calls += 1;
                         m.last_llm_latency_ms = latency;
-                        m.context_tokens = prompt_estimate;
-                        m.prompt_tokens += prompt_estimate;
-                        m.completion_tokens += completion_estimate;
+                        m.context_tokens = final_prompt;
+                        m.prompt_tokens += final_prompt;
+                        m.completion_tokens += final_completion;
                         m.total_tokens = m.prompt_tokens + m.completion_tokens;
                     });
                     self.record_cache_usage();
-                    self.record_cost(prompt_estimate, completion_estimate);
+                    self.record_cost(final_prompt, final_completion);
                     // S2: scan for markdown image exfiltration in non-streaming path.
                     let cleaned = self.scan_output_and_warn(&resp);
                     if let (Some(d), Some(id)) = (self.debug_dumper.as_ref(), dump_id) {
@@ -984,9 +1004,15 @@ impl<C: Channel> Agent<C> {
 
         self.channel.flush_chunks().await?;
 
-        let completion_estimate = u64::try_from(response.len()).unwrap_or(0) / 4;
+        // For streaming paths, last_usage() is None (providers don't return usage in streams),
+        // so the heuristic is the fallback. For non-streaming via this path, use real counts.
+        let completion_heuristic = u64::try_from(response.len()).unwrap_or(0) / 4;
+        let completion_tokens = self
+            .provider
+            .last_usage()
+            .map_or(completion_heuristic, |(_, out)| out);
         self.update_metrics(|m| {
-            m.completion_tokens += completion_estimate;
+            m.completion_tokens += completion_tokens;
             m.total_tokens = m.prompt_tokens + m.completion_tokens;
         });
 
@@ -1234,6 +1260,7 @@ impl<C: Channel> Agent<C> {
         Ok(())
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn call_chat_with_tools(
         &mut self,
         tool_defs: &[ToolDefinition],
@@ -1287,7 +1314,7 @@ impl<C: Channel> Agent<C> {
 
         let latency = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
         let prompt_estimate = self.cached_prompt_tokens;
-        let completion_estimate = match &result {
+        let completion_heuristic = match &result {
             ChatResponse::Text(t) => u64::try_from(t.len()).unwrap_or(0) / 4,
             ChatResponse::ToolUse {
                 text, tool_calls, ..
@@ -1300,20 +1327,24 @@ impl<C: Channel> Agent<C> {
                 u64::try_from(text_len + calls_len).unwrap_or(0) / 4
             }
         };
+        let (final_prompt, final_completion) = self
+            .provider
+            .last_usage()
+            .unwrap_or((prompt_estimate, completion_heuristic));
         let router_stats = self.provider.router_thompson_stats();
         self.update_metrics(|m| {
             m.api_calls += 1;
             m.last_llm_latency_ms = latency;
-            m.context_tokens = prompt_estimate;
-            m.prompt_tokens += prompt_estimate;
-            m.completion_tokens += completion_estimate;
+            m.context_tokens = final_prompt;
+            m.prompt_tokens += final_prompt;
+            m.completion_tokens += final_completion;
             m.total_tokens = m.prompt_tokens + m.completion_tokens;
             if !router_stats.is_empty() {
                 m.router_thompson_stats = router_stats;
             }
         });
         self.record_cache_usage();
-        self.record_cost(prompt_estimate, completion_estimate);
+        self.record_cost(final_prompt, final_completion);
 
         if let Some((input_tokens, output_tokens)) = self.provider.last_usage() {
             let context_window =

--- a/crates/zeph-llm/src/compatible.rs
+++ b/crates/zeph-llm/src/compatible.rs
@@ -137,6 +137,10 @@ impl LlmProvider for CompatibleProvider {
     fn last_cache_usage(&self) -> Option<(u64, u64)> {
         self.inner.last_cache_usage()
     }
+
+    fn last_usage(&self) -> Option<(u64, u64)> {
+        self.inner.last_usage()
+    }
 }
 
 #[cfg(test)]
@@ -226,5 +230,10 @@ mod tests {
         let p = test_provider();
         let result = p.embed("test").await;
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn last_usage_initially_none() {
+        assert!(test_provider().last_usage().is_none());
     }
 }

--- a/crates/zeph-llm/src/ollama.rs
+++ b/crates/zeph-llm/src/ollama.rs
@@ -23,7 +23,7 @@ pub struct ModelInfo {
     pub context_length: Option<usize>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct OllamaProvider {
     client: Ollama,
     model: String,
@@ -32,6 +32,22 @@ pub struct OllamaProvider {
     vision_model: Option<String>,
     tool_use: bool,
     generation_overrides: Option<GenerationOverrides>,
+    last_usage: std::sync::Mutex<Option<(u64, u64)>>,
+}
+
+impl Clone for OllamaProvider {
+    fn clone(&self) -> Self {
+        Self {
+            client: self.client.clone(),
+            model: self.model.clone(),
+            embedding_model: self.embedding_model.clone(),
+            context_window_size: self.context_window_size,
+            vision_model: self.vision_model.clone(),
+            tool_use: self.tool_use,
+            generation_overrides: self.generation_overrides.clone(),
+            last_usage: std::sync::Mutex::new(None),
+        }
+    }
 }
 
 #[allow(clippy::cast_possible_truncation)]
@@ -68,6 +84,7 @@ impl OllamaProvider {
             vision_model: None,
             tool_use: false,
             generation_overrides: None,
+            last_usage: std::sync::Mutex::new(None),
         }
     }
 
@@ -214,6 +231,12 @@ impl LlmProvider for OllamaProvider {
             .await
             .map_err(|e| LlmError::Other(format!("Ollama chat request failed: {e}")))?;
 
+        if let Some(ref fd) = response.final_data
+            && let Ok(mut guard) = self.last_usage.lock()
+        {
+            *guard = Some((fd.prompt_eval_count, fd.eval_count));
+        }
+
         Ok(response.message.content)
     }
 
@@ -287,6 +310,12 @@ impl LlmProvider for OllamaProvider {
                 LlmError::Other(format!("Ollama chat_with_tools request failed: {e}"))
             })?;
 
+        if let Some(ref fd) = response.final_data
+            && let Ok(mut guard) = self.last_usage.lock()
+        {
+            *guard = Some((fd.prompt_eval_count, fd.eval_count));
+        }
+
         if response.message.tool_calls.is_empty() {
             return Ok(ChatResponse::Text(response.message.content));
         }
@@ -344,6 +373,10 @@ impl LlmProvider for OllamaProvider {
     #[allow(clippy::unnecessary_literal_bound)]
     fn name(&self) -> &str {
         "ollama"
+    }
+
+    fn last_usage(&self) -> Option<(u64, u64)> {
+        self.last_usage.lock().ok().and_then(|g| *g)
     }
 }
 
@@ -479,6 +512,23 @@ mod tests {
         };
         let cm = convert_message(&msg);
         assert_eq!(cm.content, "hello");
+    }
+
+    #[test]
+    fn last_usage_initially_none() {
+        let provider =
+            OllamaProvider::new("http://localhost:11434", "test".into(), "test-embed".into());
+        assert!(provider.last_usage().is_none());
+    }
+
+    #[test]
+    fn clone_resets_last_usage() {
+        let provider =
+            OllamaProvider::new("http://localhost:11434", "test".into(), "test-embed".into());
+        *provider.last_usage.lock().unwrap() = Some((100, 50));
+        assert!(provider.last_usage().is_some());
+        let cloned = provider.clone();
+        assert!(cloned.last_usage().is_none());
     }
 
     #[test]

--- a/crates/zeph-llm/src/openai.rs
+++ b/crates/zeph-llm/src/openai.rs
@@ -24,6 +24,7 @@ pub struct OpenAiProvider {
     reasoning_effort: Option<String>,
     pub(crate) status_tx: Option<StatusTx>,
     last_cache: std::sync::Mutex<Option<(u64, u64)>>,
+    last_usage: std::sync::Mutex<Option<(u64, u64)>>,
     generation_overrides: Option<GenerationOverrides>,
 }
 
@@ -39,6 +40,7 @@ impl fmt::Debug for OpenAiProvider {
             .field("reasoning_effort", &self.reasoning_effort)
             .field("status_tx", &self.status_tx.is_some())
             .field("last_cache", &self.last_cache.lock().ok())
+            .field("last_usage", &self.last_usage.lock().ok())
             .field("generation_overrides", &self.generation_overrides)
             .finish()
     }
@@ -56,6 +58,7 @@ impl Clone for OpenAiProvider {
             reasoning_effort: self.reasoning_effort.clone(),
             status_tx: self.status_tx.clone(),
             last_cache: std::sync::Mutex::new(None),
+            last_usage: std::sync::Mutex::new(None),
             generation_overrides: self.generation_overrides.clone(),
         }
     }
@@ -84,6 +87,7 @@ impl OpenAiProvider {
             reasoning_effort,
             status_tx: None,
             last_cache: std::sync::Mutex::new(None),
+            last_usage: std::sync::Mutex::new(None),
             generation_overrides: None,
         }
     }
@@ -186,21 +190,24 @@ impl OpenAiProvider {
     }
 
     fn store_cache_usage(&self, usage: &OpenAiUsage) {
+        if let Ok(mut guard) = self.last_usage.lock() {
+            *guard = Some((usage.prompt_tokens, usage.completion_tokens));
+        }
         let cached = usage
             .prompt_tokens_details
             .as_ref()
             .map_or(0, |d| d.cached_tokens);
-        if cached > 0 {
-            if let Ok(mut guard) = self.last_cache.lock() {
-                *guard = Some((0, cached));
-            }
-            tracing::debug!(
-                prompt_tokens = usage.prompt_tokens,
-                cached_tokens = cached,
-                completion_tokens = usage.completion_tokens,
-                "OpenAI API usage"
-            );
+        if cached > 0
+            && let Ok(mut guard) = self.last_cache.lock()
+        {
+            *guard = Some((0, cached));
         }
+        tracing::debug!(
+            prompt_tokens = usage.prompt_tokens,
+            cached_tokens = cached,
+            completion_tokens = usage.completion_tokens,
+            "OpenAI API usage"
+        );
     }
 
     fn emit_status(&self, msg: impl Into<String>) {
@@ -459,6 +466,10 @@ impl LlmProvider for OpenAiProvider {
         self.last_cache.lock().ok().and_then(|g| *g)
     }
 
+    fn last_usage(&self) -> Option<(u64, u64)> {
+        self.last_usage.lock().ok().and_then(|g| *g)
+    }
+
     fn supports_structured_output(&self) -> bool {
         true
     }
@@ -509,6 +520,11 @@ impl LlmProvider for OpenAiProvider {
         }
 
         let resp: OpenAiChatResponse = serde_json::from_str(&text)?;
+
+        if let Some(ref usage) = resp.usage {
+            self.store_cache_usage(usage);
+        }
+
         let content = resp
             .choices
             .first()
@@ -1670,6 +1686,40 @@ mod tests {
     fn last_cache_usage_initially_none() {
         let p = test_provider();
         assert!(p.last_cache_usage().is_none());
+    }
+
+    #[test]
+    fn last_usage_initially_none() {
+        let p = test_provider();
+        assert!(p.last_usage().is_none());
+    }
+
+    #[test]
+    fn store_cache_usage_stores_token_counts() {
+        let p = test_provider();
+        let usage = OpenAiUsage {
+            prompt_tokens: 1000,
+            completion_tokens: 200,
+            prompt_tokens_details: None,
+        };
+        p.store_cache_usage(&usage);
+        let (prompt, completion) = p.last_usage().unwrap();
+        assert_eq!(prompt, 1000);
+        assert_eq!(completion, 200);
+    }
+
+    #[test]
+    fn clone_resets_last_usage() {
+        let p = test_provider();
+        let usage = OpenAiUsage {
+            prompt_tokens: 500,
+            completion_tokens: 100,
+            prompt_tokens_details: None,
+        };
+        p.store_cache_usage(&usage);
+        assert!(p.last_usage().is_some());
+        let cloned = p.clone();
+        assert!(cloned.last_usage().is_none());
     }
 
     #[test]

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -864,7 +864,7 @@ pub(crate) async fn run_acp_server(
     let spawner: zeph_acp::AgentSpawner = Arc::new(move |channel, acp_ctx, session_ctx| {
         let shared = Arc::clone(&shared);
         Box::pin(async move {
-            spawn_acp_agent(shared, channel, acp_ctx, session_ctx).await;
+            Box::pin(spawn_acp_agent(shared, channel, acp_ctx, session_ctx)).await;
         })
     });
 
@@ -924,7 +924,7 @@ pub(crate) async fn run_acp_http_server(
     let spawner: zeph_acp::SendAgentSpawner = Arc::new(move |channel, acp_ctx, session_ctx| {
         let shared = Arc::clone(&shared);
         Box::pin(async move {
-            spawn_acp_agent(shared, channel, acp_ctx, session_ctx).await;
+            Box::pin(spawn_acp_agent(shared, channel, acp_ctx, session_ctx)).await;
         })
     });
 


### PR DESCRIPTION
## Summary

- Replace the `response.len() / 4` heuristic at all four metric recording sites in `tool_execution.rs` with actual completion token counts from `provider.last_usage()`
- Streaming paths retain the heuristic as a fallback when the API returns no usage data
- `chat_typed()` callers (LlmPlanner, LlmAggregator, EntityResolver) now also report accurate counts for `eval_budget_tokens` enforcement

## Changes

- **`crates/zeph-llm/src/openai.rs`**: add `last_usage: Mutex<Option<(u64, u64)>>` field; `store_cache_usage()` now records both cache metadata and token counts; `chat_typed()` now calls `store_cache_usage()`
- **`crates/zeph-llm/src/ollama.rs`**: add `last_usage` field with manual `Clone` impl; read from `ChatMessageFinalResponseData` in `chat()` and `chat_with_tools()`
- **`crates/zeph-llm/src/compatible.rs`**: delegate `last_usage()` to inner `OpenAiProvider`
- **`crates/zeph-core/src/agent/tool_execution.rs`**: prefer `provider.last_usage()` at all four metric sites, fall back to `len/4` only when provider returns `None`
- **`src/acp.rs`**: wrap large futures with `Box::pin()` to satisfy clippy `large_futures` lint

## Test plan

- [ ] `cargo +nightly fmt --check` passes
- [ ] `cargo clippy --workspace --features full -- -D warnings` passes
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --features full --lib --bins` — 4905 tests pass
- [ ] Unit tests for `last_usage()` initial state, value after call, and `Clone` reset added to OpenAI, Ollama, and Compatible providers

Closes #1449