### PR TITLE
fix(orchestration): defer task to Ready on concurrency-limit spawn failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `DagScheduler::record_spawn_failure` now detects transient concurrency-limit rejections (error contains `"concurrency limit"`) and reverts the task to `TaskStatus::Ready` instead of marking it `Failed`. This prevents spurious graph failure cascades when `SubAgentManager` refuses a spawn because all concurrency slots are occupied by other agents (#1513)
 - ACP stdio transport: tracing subscriber now explicitly writes to stderr via `.with_writer(std::io::stderr)`, preventing WARN/ERROR log lines from polluting stdout and breaking NDJSON parsing in IDE clients (Zed, VS Code, Helix) (#1503)
 - `persist_message` now receives the correct `has_injection_flags` value derived from `sanitize_tool_output` injection pattern detection, not just URL extraction. Pure text injections (without URLs) now correctly activate `guard_memory_writes` in both legacy and native tool paths (#1491)
 - `handle_native_tool_calls()` now routes tool output through `sanitize_tool_output()` before placing it in `MessagePart::ToolResult`. Previously, the native tool-use path (Claude provider) bypassed `ContentSanitizer` entirely: injection detection, exfiltration URL extraction, quarantine summarizer, and security metrics were all silently skipped. `flagged_urls` was never populated, so `validate_tool_call()` and memory-write guarding (`persist_message`) were also effectively disabled for this path (#1490)

--- a/crates/zeph-core/src/orchestration/scheduler.rs
+++ b/crates/zeph-core/src/orchestration/scheduler.rs
@@ -467,13 +467,26 @@ impl DagScheduler {
 
     /// Handle a failed spawn attempt.
     ///
-    /// Reverts the task from Running to Failed and propagates failure.
+    /// If the error is a transient concurrency-limit rejection, reverts the task from
+    /// Running back to `Ready` so the next [`tick`] can retry the spawn when a slot opens.
+    /// Otherwise, marks the task as `Failed` and propagates failure.
     /// Returns any cancel actions needed.
     ///
     /// # Errors (via returned actions)
     ///
     /// Propagates failure per the task's effective `FailureStrategy`.
     pub fn record_spawn_failure(&mut self, task_id: TaskId, error: &str) -> Vec<SchedulerAction> {
+        // Transient condition: the SubAgentManager rejected the spawn because all
+        // concurrency slots are occupied. Revert to Ready so the next tick retries.
+        if error.contains("concurrency limit") {
+            tracing::info!(
+                task_id = %task_id,
+                "concurrency limit reached, deferring task to next tick"
+            );
+            self.graph.tasks[task_id.index()].status = TaskStatus::Ready;
+            return Vec::new();
+        }
+
         // SEC-ORCH-04: truncate error to avoid logging sensitive internal details.
         let error_excerpt: String = error.chars().take(512).collect();
         tracing::warn!(
@@ -1255,6 +1268,44 @@ mod tests {
                 .iter()
                 .any(|a| matches!(a, SchedulerAction::Done { .. }))
         );
+    }
+
+    #[test]
+    fn test_record_spawn_failure_concurrency_limit_reverts_to_ready() {
+        let graph = graph_from_nodes(vec![make_node(0, &[])]);
+        let mut scheduler = make_scheduler(graph);
+
+        // Simulate tick() optimistically marking the task Running before spawn.
+        scheduler.graph.tasks[0].status = TaskStatus::Running;
+
+        // Concurrency limit hit — transient, should not fail the task.
+        let actions = scheduler.record_spawn_failure(TaskId(0), "concurrency limit 4 reached");
+        assert_eq!(
+            scheduler.graph.tasks[0].status,
+            TaskStatus::Ready,
+            "task must revert to Ready so the next tick can retry"
+        );
+        assert_eq!(
+            scheduler.graph.status,
+            GraphStatus::Running,
+            "graph must stay Running, not transition to Failed"
+        );
+        assert!(
+            actions.is_empty(),
+            "no cancel or done actions expected for a transient deferral"
+        );
+    }
+
+    #[test]
+    fn test_record_spawn_failure_concurrency_limit_variant_spawn_for_task() {
+        // spawn_for_task() uses a slightly different format string — verify both are handled.
+        let graph = graph_from_nodes(vec![make_node(0, &[])]);
+        let mut scheduler = make_scheduler(graph);
+        scheduler.graph.tasks[0].status = TaskStatus::Running;
+
+        let actions = scheduler.record_spawn_failure(TaskId(0), "concurrency limit reached");
+        assert_eq!(scheduler.graph.tasks[0].status, TaskStatus::Ready);
+        assert!(actions.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `DagScheduler::record_spawn_failure()` now detects transient concurrency-limit rejections and reverts the task to `TaskStatus::Ready` instead of `Failed`
- This prevents spurious graph failure cascades when `SubAgentManager` refuses a spawn because all concurrency slots are occupied (e.g., `max_concurrent=1`)
- Permanent spawn failures (invalid agent definition, config error) continue to mark the task `Failed` as before
- 2 unit tests added covering both error string variants produced by `SubAgentManager`

## Root cause

`DagScheduler.tick()` optimistically marks tasks as `Running` before calling `SubAgentManager::spawn()`. When the manager rejects the spawn with `"concurrency limit N reached"`, the old code called `record_spawn_failure()` which unconditionally set the task to `Failed` and cascaded failure to all dependents — aborting the entire plan.

## Test plan

- [x] `cargo +nightly fmt --check` — pass
- [x] `cargo clippy --workspace --features full -- -D warnings` — pass
- [x] `cargo nextest run --workspace --features full --lib --bins` — 4986 passed (+2 new tests), 11 skipped

## Follow-up

- Typed `SubAgentError::ConcurrencyLimit` variant to replace string matching (filed separately)
- Additional edge-case tests: multi-task deferral, `max_concurrent=0`, deadlock detection

Closes #1513