### PR TITLE
fix(lsp): use file_path parameter for mcpls 0.3.4 compatibility

### DIFF
--- a/crates/zeph-core/src/lsp_hooks/diagnostics.rs
+++ b/crates/zeph-core/src/lsp_hooks/diagnostics.rs
@@ -66,7 +66,7 @@ pub(super) async fn fetch_diagnostics(
     sanitizer: &ContentSanitizer,
 ) -> Option<LspNote> {
     let timeout = std::time::Duration::from_secs(config.call_timeout_secs);
-    let args = serde_json::json!({ "path": file_path });
+    let args = serde_json::json!({ "file_path": file_path });
 
     let call_result = match tokio::time::timeout(
         timeout,

--- a/crates/zeph-core/src/lsp_hooks/hover.rs
+++ b/crates/zeph-core/src/lsp_hooks/hover.rs
@@ -79,7 +79,7 @@ pub(super) async fn fetch_hover(
     let mut entries: Vec<String> =
         futures::stream::iter(positions.iter().map(|(line, character)| {
             let args = serde_json::json!({
-                "path": file_path,
+                "file_path": file_path,
                 "line": line,
                 "character": character,
             });


### PR DESCRIPTION
Fixes #1531.

## Summary

- `crates/zeph-core/src/lsp_hooks/diagnostics.rs` — rename `path` → `file_path` in `get_diagnostics` MCP call args
- `crates/zeph-core/src/lsp_hooks/hover.rs` — rename `path` → `file_path` in `get_hover` MCP call args

Both `get_diagnostics` and `get_hover` tools in mcpls 0.3.4 require `file_path` as the parameter name. The previous code sent `path`, causing `ErrorCode(-32602)` ("missing field `file_path`") on every diagnostics-on-save and hover fetch, making the LSP context injection feature entirely non-functional.

Note: remaining `tool_params.get("path")` usages in `hover.rs` and `mod.rs` are intentional — they read the native `read`/`write` tool parameters (which use `path`), not MCP call arguments.

## Test plan

- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --workspace --features full -- -D warnings` passes (0 warnings)
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features full --lib --bins` — 5047 passed, 11 skipped