### PR TITLE
chore(deps): document upstream blocker for RUSTSEC-2025-0134

### DIFF
--- a/.github/deny.toml
+++ b/.github/deny.toml
@@ -10,8 +10,8 @@ features = ["candle", "tui"]
 [advisories]
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
-# rustls-pemfile unmaintained (via qdrant-client -> tonic)
-# Cannot fix directly, monitoring upstream
+# rustls-pemfile unmaintained (RUSTSEC-2025-0134, via qdrant-client -> tonic 0.12)
+# Blocked on qdrant/rust-client#255 (tonic 0.14 upgrade removes rustls-pemfile)
 # number_prefix unmaintained (via indicatif -> hf-hub, candle transitive dep)
 ignore = ["RUSTSEC-2025-0134", "RUSTSEC-2024-0436"]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `McpLspProvider` was sending `"uri"` as the parameter key to all mcpls tool calls, but mcpls 0.3.4 expects `"file_path"`. All six methods (`hover`, `definition`, `references`, `diagnostics`, `document_symbols`, `code_actions`) are fixed. `code_actions` additionally now sends flat `start_line`/`start_character`/`end_line`/`end_character` fields instead of a nested `range` object, matching the mcpls `get_code_actions` schema. Fixes #1533.
 - `--init` wizard generated unsupported `--workspace-root` flag for mcpls. The wizard now writes `.zeph/mcpls.toml` (with workspace roots, language extensions, and rust-analyzer LSP server config) and passes `--config .zeph/mcpls.toml` to mcpls instead. Fixes broken LSP setup for all users who configured mcpls via `zeph init`. (#1534)
+- Update `deny.toml` suppression comment for RUSTSEC-2025-0134 (`rustls-pemfile` unmaintained) to reference upstream tracking issue qdrant/rust-client#255 (tonic 0.14 upgrade that removes the dependency); no code change possible until upstream ships a release.
 - Shell command blocklist (`blocked_commands`, `DEFAULT_BLOCKED`, `allow_network = false`) was silently skipped whenever a `PermissionPolicy` was attached to `ShellExecutor` (i.e., in all normal operation with `autonomy_level` set). `find_blocked_command()` now runs unconditionally before the policy check, making it a hard security boundary that cannot be bypassed by any autonomy level or permission policy configuration.
 
 ### Added


### PR DESCRIPTION
## Summary

- Update `.github/deny.toml` suppression comment for RUSTSEC-2025-0134 (`rustls-pemfile` unmaintained) to reference the upstream tracking issue qdrant/rust-client 255
- `rustls-pemfile` is a transitive dep via `qdrant-client 1.17.0 → tonic 0.12.3`; no direct fix is possible until qdrant-client ships a release with tonic 0.14
- `cargo deny check advisories` continues to pass with the existing ignore entry

Closes #1468

## Test plan

- [x] `cargo deny check advisories --config .github/deny.toml` passes
- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --workspace --features full -- -D warnings` passes
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features full --lib --bins` — 5047 passed