### PR TITLE
fix(tools): SEC-001..004 tool execution hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Security
+
+- SEC-001: Replace `DefaultHasher` with a process-scoped `RandomState`-seeded SipHash-1-3 in `tool_args_hash()` to prevent adversarial hash collision bypasses of the repeat-detection window (#1399)
+- SEC-002: Replace `SystemTime::now().subsec_nanos()` jitter with `rand::rng().random_range()` in `retry_backoff_ms()` to eliminate predictable retry timing that could be exploited by an adversary (#1400)
+- SEC-003: Truncate tool names to 256 bytes at UTF-8 boundaries before storing in the `recent_tool_calls` sliding window to prevent unbounded memory growth from adversarially long names (#1401)
+- SEC-004: Add `max_retry_duration_secs` (default 30) wall-clock retry budget to `AgentConfig`; the retry loop in `handle_native_tool_calls()` breaks when the budget is exhausted even if attempts remain, preventing indefinite retry loops (#1402)
+
 ### Fixed
 
 - `McpLspProvider` was sending `"uri"` as the parameter key to all mcpls tool calls, but mcpls 0.3.4 expects `"file_path"`. All six methods (`hover`, `definition`, `references`, `diagnostics`, `document_symbols`, `code_actions`) are fixed. `code_actions` additionally now sends flat `start_line`/`start_character`/`end_line`/`end_character` fields instead of a nested `range` object, matching the mcpls `get_code_actions` schema. Fixes #1533.

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 default = []
 candle = ["zeph-llm/candle"]
 cuda = ["zeph-llm/cuda"]
-experiments = ["dep:ordered-float", "dep:rand", "zeph-memory/experiments"]
+experiments = ["dep:ordered-float", "zeph-memory/experiments"]
 index = ["dep:zeph-index"]
 metal = ["zeph-llm/metal"]
 lsp-context = []
@@ -30,7 +30,7 @@ futures.workspace = true
 notify.workspace = true
 notify-debouncer-mini.workspace = true
 ordered-float = { workspace = true, optional = true }
-rand = { workspace = true, optional = true }
+rand.workspace = true
 regex.workspace = true
 schemars.workspace = true
 dirs.workspace = true

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -114,6 +114,13 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Set the maximum wall-clock budget (seconds) for retries per tool call (0 = unlimited).
+    #[must_use]
+    pub fn with_max_retry_duration_secs(mut self, secs: u64) -> Self {
+        self.tool_orchestrator.max_retry_duration_secs = secs;
+        self
+    }
+
     /// Set the repeat-detection threshold (0 = disabled).
     /// Window size is `2 * threshold`.
     #[must_use]

--- a/crates/zeph-core/src/agent/tool_execution/mod.rs
+++ b/crates/zeph-core/src/agent/tool_execution/mod.rs
@@ -472,14 +472,24 @@ impl<C: Channel> Agent<C> {
     }
 }
 
+/// Process-wide randomized `BuildHasher` for `tool_args_hash`.
+///
+/// Initialized once at first use. Consistent within a session (repeat-detection
+/// works correctly) but unpredictable across sessions (prevents adversarial
+/// hash collision bypasses).
+static TOOL_ARGS_HASHER: std::sync::OnceLock<std::collections::hash_map::RandomState> =
+    std::sync::OnceLock::new();
+
 /// Compute a stable hash for tool arguments for repeat-detection.
 ///
 /// Keys are sorted before hashing to normalize key ordering differences between
-/// LLM tool calls that have the same logical parameters. Uses `DefaultHasher`
-/// (not stable across Rust versions) — used only for within-session comparison.
+/// LLM tool calls that have the same logical parameters. Uses a process-scoped
+/// randomized `RandomState` (seeded once at startup) to prevent adversarial hash
+/// collision bypasses of the repeat-detection window.
 fn tool_args_hash(params: &serde_json::Map<String, serde_json::Value>) -> u64 {
-    use std::hash::{DefaultHasher, Hash, Hasher};
-    let mut hasher = DefaultHasher::new();
+    use std::hash::{BuildHasher, Hash, Hasher};
+    let state = TOOL_ARGS_HASHER.get_or_init(std::collections::hash_map::RandomState::new);
+    let mut hasher = state.build_hasher();
     let mut keys: Vec<&String> = params.keys().collect();
     keys.sort_unstable();
     for k in keys {
@@ -492,22 +502,16 @@ fn tool_args_hash(params: &serde_json::Map<String, serde_json::Value>) -> u64 {
 /// Compute exponential backoff delay for retry attempt (0-indexed).
 ///
 /// Formula: `base_ms * 2^attempt`, nominally capped at 5000ms.
-/// Jitter of +-12.5% is applied using system time nanos as entropy, so the
-/// actual output range is `[cap * 0.875, cap * 1.125]` (up to ~5625ms at cap).
+/// Full jitter in `[0, cap]` is applied using `rand` for cryptographically
+/// seeded randomness — avoids predictable timing that an adversary could exploit
+/// to align retry windows.
 fn retry_backoff_ms(attempt: usize) -> u64 {
+    use rand::Rng as _;
     const BASE_MS: u64 = 500;
     const MAX_MS: u64 = 5000;
     let base = BASE_MS.saturating_mul(1_u64 << attempt.min(10));
     let capped = base.min(MAX_MS);
-    // Simple jitter: +-12.5% using current time nanos as entropy
-    let nanos = u64::from(
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map_or(0, |d| d.subsec_nanos()),
-    );
-    let jitter_range = capped / 8; // 12.5%
-    let jitter = nanos % (jitter_range * 2 + 1);
-    capped.saturating_sub(jitter_range).saturating_add(jitter)
+    rand::rng().random_range(0..=capped)
 }
 
 pub(crate) fn tool_def_to_definition(def: &zeph_tools::registry::ToolDef) -> ToolDefinition {
@@ -3014,36 +3018,55 @@ mod tests {
 
     #[test]
     fn retry_backoff_ms_attempt0_within_range() {
-        // attempt=0 → base = 500ms, capped = 500ms, jitter ±62ms → [438, 562]
+        // attempt=0 → cap = 500ms, full jitter [0, 500]
         let delay = retry_backoff_ms(0);
-        assert!(delay >= 500 / 8 * 7, "attempt 0 delay too low: {delay}");
-        assert!(delay <= 562, "attempt 0 delay too high: {delay}");
+        assert!(delay <= 500, "attempt 0 delay too high: {delay}");
     }
 
     #[test]
     fn retry_backoff_ms_attempt1_within_range() {
-        // attempt=1 → base = 1000ms, capped = 1000ms, jitter ±125ms → [875, 1125]
+        // attempt=1 → cap = 1000ms, full jitter [0, 1000]
         let delay = retry_backoff_ms(1);
-        assert!(delay >= 875, "attempt 1 delay too low: {delay}");
-        assert!(delay <= 1125, "attempt 1 delay too high: {delay}");
+        assert!(delay <= 1000, "attempt 1 delay too high: {delay}");
     }
 
     #[test]
     fn retry_backoff_ms_cap_at_5000() {
-        // attempt=4 → base = 8000ms → capped to 5000ms; jitter ±625ms → [4375, 5625]
-        // but capped.saturating_sub(jitter_range).saturating_add(jitter) is bounded by ±jitter_range
-        // so max is 5000 - 625 + (625*2) = 5625, but the actual formula clamps via saturating_add.
-        // In practice the cap keeps it in [4375, 5625].
+        // attempt=4 → base = 8000ms → capped to 5000ms; full jitter [0, 5000]
         let delay = retry_backoff_ms(4);
-        assert!(delay >= 4375, "capped attempt 4 delay too low: {delay}");
-        assert!(delay <= 5625, "capped attempt 4 delay too high: {delay}");
+        assert!(delay <= 5000, "capped attempt 4 delay too high: {delay}");
     }
 
     #[test]
     fn retry_backoff_ms_large_attempt_still_capped() {
-        // Very large attempt: bit-shift is capped at 10, so base = 500 * 1024 >> saturate to MAX_MS.
+        // Very large attempt: bit-shift is capped at 10, so base = 500 * 1024 → capped at 5000ms.
         let delay = retry_backoff_ms(100);
-        assert!(delay <= 5625, "large attempt delay exceeds cap: {delay}");
+        assert!(delay <= 5000, "large attempt delay exceeds cap: {delay}");
+    }
+
+    #[test]
+    fn retry_backoff_ms_all_attempts_within_cap() {
+        // SEC-002: full jitter is in [0, cap]. Verify no attempt returns a value above 5000ms.
+        for attempt in 0..5 {
+            let delay = retry_backoff_ms(attempt);
+            assert!(
+                delay <= 5000,
+                "attempt {attempt} delay out of range: {delay}"
+            );
+        }
+    }
+
+    #[test]
+    fn retry_backoff_ms_is_non_deterministic() {
+        // SEC-002: full jitter uses rand — successive calls for the same attempt must not
+        // all return the same value (probability of 100 identical draws from [0, 500] is
+        // effectively zero for a properly seeded PRNG).
+        let samples: Vec<u64> = (0..100).map(|_| retry_backoff_ms(0)).collect();
+        let all_same = samples.windows(2).all(|w| w[0] == w[1]);
+        assert!(
+            !all_same,
+            "retry_backoff_ms returned identical values 100 times — jitter not applied"
+        );
     }
 
     // ── record_skill_outcomes in native tool path (issue #1436) ───────────────

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -525,6 +525,8 @@ impl<C: Channel> Agent<C> {
 
             // Execute with retry for transient errors.
             let mut attempt = 0_usize;
+            let retry_start = std::time::Instant::now();
+            let max_retry_duration_secs = self.tool_orchestrator.max_retry_duration_secs;
             let result = loop {
                 let exec_result = tokio::select! {
                     r = self.tool_executor.execute_tool_call_erased(call).instrument(
@@ -547,6 +549,16 @@ impl<C: Channel> Agent<C> {
                         if e.kind() == zeph_tools::ErrorKind::Transient
                             && attempt < max_retries =>
                     {
+                        let elapsed_secs = retry_start.elapsed().as_secs();
+                        if max_retry_duration_secs > 0 && elapsed_secs >= max_retry_duration_secs {
+                            tracing::warn!(
+                                tool = %tc.name,
+                                elapsed_secs,
+                                max_retry_duration_secs,
+                                "tool retry budget exceeded, aborting retries"
+                            );
+                            break exec_result;
+                        }
                         attempt += 1;
                         let delay_ms = retry_backoff_ms(attempt - 1);
                         tracing::warn!(

--- a/crates/zeph-core/src/agent/tool_orchestrator.rs
+++ b/crates/zeph-core/src/agent/tool_orchestrator.rs
@@ -21,6 +21,25 @@ pub(crate) struct ToolOrchestrator {
     pub(super) repeat_threshold: usize,
     /// Max retries for transient errors per tool call. 0 = disabled.
     pub(super) max_tool_retries: usize,
+    /// Maximum wall-clock time (seconds) to spend on retries for a single tool call.
+    /// 0 = no wall-clock budget (only `max_tool_retries` applies).
+    pub(super) max_retry_duration_secs: u64,
+}
+
+/// Truncate a tool name to at most 256 bytes, respecting UTF-8 char boundaries.
+///
+/// Used by both `push_tool_call` and `is_repeat` to ensure stored and queried
+/// names always match when the original name exceeds the limit.
+fn truncate_tool_name(name: &str) -> &str {
+    const MAX_TOOL_NAME_BYTES: usize = 256;
+    if name.len() <= MAX_TOOL_NAME_BYTES {
+        return name;
+    }
+    let mut idx = MAX_TOOL_NAME_BYTES;
+    while !name.is_char_boundary(idx) {
+        idx -= 1;
+    }
+    &name[..idx]
 }
 
 impl ToolOrchestrator {
@@ -35,6 +54,7 @@ impl ToolOrchestrator {
             recent_tool_calls: VecDeque::with_capacity(2 * repeat_threshold),
             repeat_threshold,
             max_tool_retries: 2,
+            max_retry_duration_secs: 30,
         }
     }
 
@@ -63,6 +83,8 @@ impl ToolOrchestrator {
     /// Record a tool call (LLM-initiated only — not retry re-executions).
     ///
     /// Maintains a sliding window of size `2 * repeat_threshold`.
+    /// Tool names are truncated to 256 bytes to prevent unbounded memory growth
+    /// from adversarially long names.
     pub(super) fn push_tool_call(&mut self, name: &str, args_hash: u64) {
         if self.repeat_threshold == 0 {
             return;
@@ -72,15 +94,19 @@ impl ToolOrchestrator {
             self.recent_tool_calls.pop_front();
         }
         self.recent_tool_calls
-            .push_back((name.to_owned(), args_hash));
+            .push_back((truncate_tool_name(name).to_owned(), args_hash));
     }
 
     /// Returns `true` if the same `(name, args_hash)` pair appears `>= repeat_threshold`
     /// times in the current window.
+    ///
+    /// Applies the same 256-byte name truncation as `push_tool_call` so that long names
+    /// are correctly matched against stored (truncated) entries.
     pub(super) fn is_repeat(&self, name: &str, args_hash: u64) -> bool {
         if self.repeat_threshold == 0 {
             return false;
         }
+        let name = truncate_tool_name(name);
         let count = self
             .recent_tool_calls
             .iter()
@@ -103,6 +129,7 @@ mod tests {
         assert!(o.recent_tool_calls.is_empty());
         assert_eq!(o.repeat_threshold, 2);
         assert_eq!(o.max_tool_retries, 2);
+        assert_eq!(o.max_retry_duration_secs, 30);
     }
 
     #[test]
@@ -214,5 +241,100 @@ mod tests {
         o.push_tool_call("bash", 42);
         // Threshold 0 means disabled
         assert!(!o.is_repeat("bash", 42));
+    }
+
+    // ── SEC-003: tool name truncation ─────────────────────────────────────────
+
+    #[test]
+    fn push_tool_call_long_name_truncated_to_256_bytes() {
+        let mut o = ToolOrchestrator::new();
+        // Name well above 256 bytes
+        let long_name = "a".repeat(512);
+        o.push_tool_call(&long_name, 99);
+        let stored = &o.recent_tool_calls[0].0;
+        assert_eq!(stored.len(), 256, "stored name must be exactly 256 bytes");
+        assert!(
+            stored.is_char_boundary(stored.len()),
+            "truncation must land on char boundary"
+        );
+    }
+
+    #[test]
+    fn push_tool_call_unicode_name_truncated_at_char_boundary() {
+        let mut o = ToolOrchestrator::new();
+        // Each '日' is 3 bytes. 256 / 3 = 85 full chars = 255 bytes.
+        // Appending one more gives 258 bytes total — must truncate to 255.
+        let base: String = "日".repeat(85); // 255 bytes
+        let long_name = format!("{base}日"); // 258 bytes — crosses 256-byte boundary
+        o.push_tool_call(&long_name, 1);
+        let stored = &o.recent_tool_calls[0].0;
+        assert!(stored.len() <= 256, "stored name must not exceed 256 bytes");
+        assert!(
+            stored.is_char_boundary(stored.len()),
+            "must be valid UTF-8 boundary"
+        );
+    }
+
+    #[test]
+    fn push_tool_call_short_name_not_truncated() {
+        let mut o = ToolOrchestrator::new();
+        let short_name = "shell";
+        o.push_tool_call(short_name, 7);
+        assert_eq!(o.recent_tool_calls[0].0, short_name);
+    }
+
+    #[test]
+    fn push_tool_call_300_byte_name_truncated_to_at_most_256() {
+        // SEC-003: specifically test with 300-byte name as the boundary case
+        let mut o = ToolOrchestrator::new();
+        let name_300 = "x".repeat(300);
+        o.push_tool_call(&name_300, 42);
+        let stored = &o.recent_tool_calls[0].0;
+        assert!(
+            stored.len() <= 256,
+            "300-byte name must be stored as ≤256 bytes, got {}",
+            stored.len()
+        );
+        assert!(stored.is_char_boundary(stored.len()));
+    }
+
+    // ── SEC-004: retry budget field and logic ─────────────────────────────────
+
+    #[test]
+    fn max_retry_duration_secs_default_is_30() {
+        // SEC-004: verify the budget field is set at construction time
+        let o = ToolOrchestrator::new();
+        assert_eq!(o.max_retry_duration_secs, 30);
+    }
+
+    #[test]
+    fn retry_budget_condition_zero_disables_check() {
+        // SEC-004: when max_retry_duration_secs == 0, the budget check must be skipped.
+        // This mirrors the `if max_retry_duration_secs > 0` guard in native.rs.
+        let budget_secs: u64 = 0;
+        // Simulate that 60 seconds have elapsed — budget check is disabled.
+        let elapsed_secs: u64 = 60;
+        let budget_exceeded = budget_secs > 0 && elapsed_secs >= budget_secs;
+        assert!(
+            !budget_exceeded,
+            "budget=0 must disable the wall-clock check"
+        );
+    }
+
+    #[test]
+    fn retry_budget_condition_exceeded_triggers_break() {
+        // SEC-004: simulate elapsed > budget with a real Instant to confirm the
+        // condition that native.rs evaluates before breaking the retry loop.
+        let budget_secs: u64 = 1;
+        // Subtract 2 seconds to ensure elapsed >= budget without sleeping.
+        let retry_start = std::time::Instant::now()
+            .checked_sub(std::time::Duration::from_secs(2))
+            .unwrap();
+        let elapsed_secs = retry_start.elapsed().as_secs();
+        let budget_exceeded = budget_secs > 0 && elapsed_secs >= budget_secs;
+        assert!(
+            budget_exceeded,
+            "elapsed {elapsed_secs}s should exceed budget {budget_secs}s"
+        );
     }
 }

--- a/crates/zeph-core/src/config/snapshots/zeph_core__config__types__tests__config_default_snapshot.snap
+++ b/crates/zeph-core/src/config/snapshots/zeph_core__config__types__tests__config_default_snapshot.snap
@@ -10,6 +10,7 @@ instruction_files = []
 instruction_auto_detect = true
 max_tool_retries = 2
 tool_repeat_threshold = 2
+max_retry_duration_secs = 30
 
 [llm]
 provider = "ollama"

--- a/crates/zeph-core/src/config/types.rs
+++ b/crates/zeph-core/src/config/types.rs
@@ -249,6 +249,10 @@ fn default_max_tool_retries() -> usize {
     2
 }
 
+fn default_max_retry_duration_secs() -> u64 {
+    30
+}
+
 fn default_tool_repeat_threshold() -> usize {
     2
 }
@@ -275,6 +279,11 @@ pub struct AgentConfig {
     /// abort (0 to disable). Window size is `2 * tool_repeat_threshold`.
     #[serde(default = "default_tool_repeat_threshold")]
     pub tool_repeat_threshold: usize,
+    /// Maximum total wall-clock time (seconds) to spend on retries for a single tool call.
+    /// When the budget is exhausted the retry loop breaks even if attempts remain.
+    /// 0 = no wall-clock budget (only `max_tool_retries` applies).
+    #[serde(default = "default_max_retry_duration_secs")]
+    pub max_retry_duration_secs: u64,
 }
 
 fn default_instruction_auto_detect() -> bool {
@@ -1840,6 +1849,7 @@ impl Default for Config {
                 instruction_auto_detect: default_instruction_auto_detect(),
                 max_tool_retries: default_max_tool_retries(),
                 tool_repeat_threshold: default_tool_repeat_threshold(),
+                max_retry_duration_secs: default_max_retry_duration_secs(),
             },
             llm: LlmConfig {
                 provider: ProviderKind::Ollama,

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -35,6 +35,7 @@ struct SharedAgentDeps {
     tool_executor: std::sync::Arc<dyn zeph_tools::ErasedToolExecutor>,
     max_tool_iterations: usize,
     max_tool_retries: usize,
+    max_retry_duration_secs: u64,
     tool_repeat_threshold: usize,
     model_name: String,
     embed_model: String,
@@ -255,6 +256,7 @@ async fn build_acp_deps(
         tool_executor,
         max_tool_iterations: config.agent.max_tool_iterations,
         max_tool_retries: config.agent.max_tool_retries,
+        max_retry_duration_secs: config.agent.max_retry_duration_secs,
         tool_repeat_threshold: config.agent.tool_repeat_threshold,
         model_name: config.llm.model.clone(),
         embed_model,
@@ -421,6 +423,7 @@ async fn spawn_acp_agent(
     )
     .with_max_tool_iterations(d.max_tool_iterations)
     .with_max_tool_retries(d.max_tool_retries)
+    .with_max_retry_duration_secs(d.max_retry_duration_secs)
     .with_tool_repeat_threshold(d.tool_repeat_threshold)
     .with_model_name(d.model_name.clone())
     .with_embedding_model(d.embed_model.clone())

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -281,6 +281,7 @@ pub(crate) async fn run_daemon(
     )
     .with_max_tool_iterations(config.agent.max_tool_iterations)
     .with_max_tool_retries(config.agent.max_tool_retries)
+    .with_max_retry_duration_secs(config.agent.max_retry_duration_secs)
     .with_tool_repeat_threshold(config.agent.tool_repeat_threshold)
     .with_model_name(config.llm.model.clone())
     .with_embedding_model(embed_model)

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -479,6 +479,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     )
     .with_max_tool_iterations(config.agent.max_tool_iterations)
     .with_max_tool_retries(config.agent.max_tool_retries)
+    .with_max_retry_duration_secs(config.agent.max_retry_duration_secs)
     .with_tool_repeat_threshold(config.agent.tool_repeat_threshold)
     .with_model_name(config.llm.model.clone())
     .with_embedding_model(embed_model.clone())


### PR DESCRIPTION
## Summary

Four security hardening fixes in `zeph-core` tool execution layer, addressing low-severity issues found during continuous improvement testing.

- **SEC-001 (#1399)**: Replace `DefaultHasher` with `OnceLock<RandomState>` in `tool_args_hash()`. Hashes are stable within a session (repeat-detection works) but unpredictable across processes, preventing adversarial hash collision bypass of the repeat-detection sliding window.
- **SEC-002 (#1400)**: Replace `SystemTime::now().subsec_nanos()` jitter in `retry_backoff_ms()` with `rand::rng().random_range()` full jitter (AWS-style `[0, cap]`). Promotes `rand 0.9` from optional `experiments` feature to unconditional dependency in `zeph-core`.
- **SEC-003 (#1401)**: Extract `truncate_tool_name()` helper that enforces a 256-byte UTF-8-safe cap, called in both `push_tool_call()` and `is_repeat()`. Prevents unbounded memory growth from crafted tool names and a repeat-detection bypass where full names would never match stored truncated names.
- **SEC-004 (#1402)**: Add `max_retry_duration_secs: u64` (default 30) to `AgentConfig`/`ToolOrchestrator`. A wall-clock budget is checked before each retry sleep in `handle_native_tool_calls()`; `0` disables the check. Wired through builder, runner, daemon, and acp entry points.

## Test plan

- [ ] `cargo +nightly fmt --check` — passes
- [ ] `cargo clippy --workspace --features full -- -D warnings` — passes (zero warnings)
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --features full --lib --bins` — 5062/5062 pass (9 new tests added for SEC-002/003/004)
- [ ] Security audit: all 4 fixes verified correct; SEC-003-I1 (`is_repeat` truncation mismatch) found and fixed during audit
- [ ] Branch synced with `origin/main` (includes PR #1541 hover.rs fix)

Closes #1399, #1400, #1401, #1402.