### PR TITLE
feat(memory): share single QdrantOps instance across all subsystems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Share a single `QdrantOps` instance (one gRPC channel) across all subsystems at startup: `AppBuilder::new()` constructs `QdrantOps` once when `vector_backend = "qdrant"` and propagates it via clone (O(1) `Arc` bump) to `SemanticMemory`, `QdrantSkillMatcher`, `McpToolRegistry`, and `CodeStore`. Previously 4+ independent gRPC channels were created. Invalid `qdrant_url` when `vector_backend = "qdrant"` is now a hard startup error instead of a silent `None`. URL-based constructors (`QdrantSkillMatcher::new`, `McpToolRegistry::new`, `CodeStore::new`) are replaced by `::with_ops(ops)` variants. (#1337)
 - Consolidate `is_private_ip` (SSRF IP check) into `zeph-tools::net::is_private_ip` (canonical superset with CGNAT `100.64.0.0/10`); update `zeph-mcp`, `zeph-acp`, `zeph-tools/scrape` to use it; upgrade A2A's own copy with CGNAT range (DEDUP-01)
 - Consolidate `cosine_similarity` into `zeph-memory::math::cosine_similarity` (single-pass loop, length guard); update all callers in `zeph-memory` and `zeph-skills` (DEDUP-02)
 - Add `text::truncate_chars(&str, usize) -> &str` to `zeph-core::text`; replace `context/mod.rs::truncate_chars` with a re-export of the canonical version (DEDUP-03)

--- a/crates/zeph-core/src/bootstrap/mcp.rs
+++ b/crates/zeph-core/src/bootstrap/mcp.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use zeph_llm::any::AnyProvider;
+use zeph_memory::QdrantOps;
 
 use crate::config::Config;
 
@@ -43,21 +44,19 @@ pub async fn create_mcp_registry(
     provider: &AnyProvider,
     mcp_tools: &[zeph_mcp::McpTool],
     embedding_model: &str,
+    qdrant_ops: Option<&QdrantOps>,
 ) -> Option<zeph_mcp::McpToolRegistry> {
     if !config.memory.semantic.enabled {
         return None;
     }
-    match zeph_mcp::McpToolRegistry::new(&config.memory.qdrant_url) {
-        Ok(mut reg) => {
-            let embed_fn = provider.embed_fn();
-            if let Err(e) = reg.sync(mcp_tools, embedding_model, &embed_fn).await {
-                tracing::warn!("MCP tool embedding sync failed: {e:#}");
-            }
-            Some(reg)
-        }
-        Err(e) => {
-            tracing::warn!("MCP tool registry unavailable: {e:#}");
-            None
-        }
+    let Some(ops) = qdrant_ops else {
+        tracing::debug!("MCP tool registry skipped: no Qdrant backend configured");
+        return None;
+    };
+    let mut reg = zeph_mcp::McpToolRegistry::with_ops(ops.clone());
+    let embed_fn = provider.embed_fn();
+    if let Err(e) = reg.sync(mcp_tools, embedding_model, &embed_fn).await {
+        tracing::warn!("MCP tool embedding sync failed: {e:#}");
     }
+    Some(reg)
 }

--- a/crates/zeph-core/src/bootstrap/mod.rs
+++ b/crates/zeph-core/src/bootstrap/mod.rs
@@ -28,6 +28,7 @@ use tokio::sync::{mpsc, watch};
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::LlmProvider;
 use zeph_memory::GraphStore;
+use zeph_memory::QdrantOps;
 use zeph_memory::semantic::SemanticMemory;
 use zeph_skills::loader::SkillMeta;
 use zeph_skills::matcher::SkillMatcherBackend;
@@ -43,6 +44,7 @@ pub struct AppBuilder {
     config: Config,
     config_path: PathBuf,
     vault: Box<dyn VaultProvider>,
+    qdrant_ops: Option<QdrantOps>,
 }
 
 pub struct VaultArgs {
@@ -94,11 +96,26 @@ impl AppBuilder {
 
         config.resolve_secrets(vault.as_ref()).await?;
 
+        let qdrant_ops = match config.memory.vector_backend {
+            crate::config::VectorBackend::Qdrant => {
+                let ops = QdrantOps::new(&config.memory.qdrant_url).map_err(|e| {
+                    anyhow::anyhow!("invalid qdrant_url '{}': {e}", config.memory.qdrant_url)
+                })?;
+                Some(ops)
+            }
+            crate::config::VectorBackend::Sqlite => None,
+        };
+
         Ok(Self {
             config,
             config_path,
             vault,
+            qdrant_ops,
         })
+    }
+
+    pub fn qdrant_ops(&self) -> Option<&QdrantOps> {
+        self.qdrant_ops.as_ref()
     }
 
     pub fn config(&self) -> &Config {
@@ -164,6 +181,11 @@ impl AppBuilder {
         }
     }
 
+    /// # Errors
+    ///
+    /// Returns an error if `SQLite` cannot be initialized or if `vector_backend = Qdrant`
+    /// but `qdrant_ops` is `None` (invariant violation — should not happen if `AppBuilder::new`
+    /// succeeded).
     pub async fn build_memory(&self, provider: &AnyProvider) -> anyhow::Result<SemanticMemory> {
         let embed_model = self.embedding_model();
         let mut memory = match self.config.memory.vector_backend {
@@ -179,9 +201,14 @@ impl AppBuilder {
                 .await?
             }
             crate::config::VectorBackend::Qdrant => {
-                SemanticMemory::with_weights_and_pool_size(
+                let ops = self
+                    .qdrant_ops
+                    .as_ref()
+                    .context("qdrant_ops must be Some when vector_backend = Qdrant")?
+                    .clone();
+                SemanticMemory::with_qdrant_ops(
                     &self.config.memory.sqlite_path,
-                    &self.config.memory.qdrant_url,
+                    ops,
                     provider.clone(),
                     &embed_model,
                     self.config.memory.semantic.vector_weight,
@@ -218,7 +245,15 @@ impl AppBuilder {
         memory: &SemanticMemory,
     ) -> Option<SkillMatcherBackend> {
         let embed_model = self.embedding_model();
-        create_skill_matcher(&self.config, provider, meta, memory, &embed_model).await
+        create_skill_matcher(
+            &self.config,
+            provider,
+            meta,
+            memory,
+            &embed_model,
+            self.qdrant_ops.as_ref(),
+        )
+        .await
     }
 
     pub fn build_registry(&self) -> SkillRegistry {

--- a/crates/zeph-core/src/bootstrap/skills.rs
+++ b/crates/zeph-core/src/bootstrap/skills.rs
@@ -3,6 +3,7 @@
 
 use std::path::PathBuf;
 use zeph_llm::any::AnyProvider;
+use zeph_memory::QdrantOps;
 use zeph_memory::semantic::SemanticMemory;
 use zeph_skills::loader::SkillMeta;
 use zeph_skills::matcher::{SkillMatcher, SkillMatcherBackend};
@@ -17,19 +18,19 @@ pub async fn create_skill_matcher(
     meta: &[&SkillMeta],
     memory: &SemanticMemory,
     embedding_model: &str,
+    qdrant_ops: Option<&QdrantOps>,
 ) -> Option<SkillMatcherBackend> {
     let embed_fn = provider.embed_fn();
 
-    if config.memory.semantic.enabled && memory.is_vector_store_connected().await {
-        match QdrantSkillMatcher::new(&config.memory.qdrant_url) {
-            Ok(mut qm) => match qm.sync(meta, embedding_model, &embed_fn).await {
-                Ok(_) => return Some(SkillMatcherBackend::Qdrant(qm)),
-                Err(e) => {
-                    tracing::warn!("Qdrant skill sync failed, falling back to in-memory: {e:#}");
-                }
-            },
+    if config.memory.semantic.enabled
+        && memory.is_vector_store_connected().await
+        && let Some(ops) = qdrant_ops
+    {
+        let mut qm = QdrantSkillMatcher::with_ops(ops.clone());
+        match qm.sync(meta, embedding_model, &embed_fn).await {
+            Ok(_) => return Some(SkillMatcherBackend::Qdrant(qm)),
             Err(e) => {
-                tracing::warn!("Qdrant client creation failed, falling back to in-memory: {e:#}");
+                tracing::warn!("Qdrant skill sync failed, falling back to in-memory: {e:#}");
             }
         }
     }

--- a/crates/zeph-core/src/bootstrap/tests.rs
+++ b/crates/zeph-core/src/bootstrap/tests.rs
@@ -818,7 +818,7 @@ async fn create_mcp_registry_when_semantic_disabled() {
     ));
 
     let mcp_tools = vec![];
-    let registry = create_mcp_registry(&config, &provider, &mcp_tools, "test-model").await;
+    let registry = create_mcp_registry(&config, &provider, &mcp_tools, "test-model", None).await;
     assert!(registry.is_none());
 }
 
@@ -843,6 +843,7 @@ fn skill_paths_includes_managed_dir() {
         config,
         config_path: PathBuf::from("/nonexistent/config.toml"),
         vault: Box::new(EnvVaultProvider),
+        qdrant_ops: None,
     };
     let paths = builder.skill_paths();
     let managed = managed_skills_dir();
@@ -861,6 +862,7 @@ fn skill_paths_does_not_duplicate_managed_dir() {
         config,
         config_path: PathBuf::from("/nonexistent/config.toml"),
         vault: Box::new(EnvVaultProvider),
+        qdrant_ops: None,
     };
     let paths = builder.skill_paths();
     let count = paths.iter().filter(|p| p == &&managed).count();
@@ -886,18 +888,44 @@ async fn create_skill_matcher_when_semantic_disabled() {
         "embed".into(),
     ));
 
-    let memory = SemanticMemory::new(
+    let memory = SemanticMemory::with_sqlite_backend_and_pool_size(
         &tmp_path,
-        &config.memory.qdrant_url,
         provider.clone(),
         &config.llm.embedding_model,
+        config.memory.semantic.vector_weight,
+        config.memory.semantic.keyword_weight,
+        1,
     )
     .await
     .unwrap();
 
     let meta: Vec<&SkillMeta> = vec![];
-    let result = create_skill_matcher(&config, &provider, &meta, &memory, "test-model").await;
+    let result = create_skill_matcher(&config, &provider, &meta, &memory, "test-model", None).await;
     assert!(result.is_none());
 
     let _ = std::fs::remove_file(&tmp);
+}
+
+#[test]
+fn appbuilder_qdrant_ops_invalid_url_returns_err() {
+    // Verify the CRIT-04 hard-error path: VectorBackend::Qdrant with an invalid URL
+    // must produce an error, not silently yield None.
+    // This mirrors the logic inside AppBuilder::new() without the vault/config-file overhead.
+    let mut config = Config::load(Path::new("/nonexistent")).unwrap();
+    config.memory.vector_backend = crate::config::VectorBackend::Qdrant;
+    config.memory.qdrant_url = "not a valid url".into();
+
+    let result = zeph_memory::QdrantOps::new(&config.memory.qdrant_url);
+    assert!(
+        result.is_err(),
+        "QdrantOps::new with invalid URL must fail (CRIT-04)"
+    );
+}
+
+#[test]
+fn appbuilder_qdrant_ops_valid_url_succeeds() {
+    // Complement: a well-formed URL must succeed even without a live server
+    // (connection is lazy — only established on first RPC).
+    let result = zeph_memory::QdrantOps::new("http://localhost:6334");
+    assert!(result.is_ok(), "QdrantOps::new with valid URL must succeed");
 }

--- a/crates/zeph-index/src/store.rs
+++ b/crates/zeph-index/src/store.rs
@@ -43,17 +43,14 @@ pub struct SearchHit {
 }
 
 impl CodeStore {
-    /// # Errors
-    ///
-    /// Returns an error if the `Qdrant` client fails to connect.
-    pub fn new(qdrant_url: &str, pool: sqlx::SqlitePool) -> Result<Self> {
-        let ops = QdrantOps::new(qdrant_url)
-            .map_err(|e| crate::error::IndexError::Other(e.to_string()))?;
-        Ok(Self {
+    /// Create a `CodeStore` from a pre-built `QdrantOps` instance.
+    #[must_use]
+    pub fn with_ops(ops: QdrantOps, pool: sqlx::SqlitePool) -> Self {
+        Self {
             ops,
             collection: CODE_COLLECTION.into(),
             pool,
-        })
+        }
     }
 
     /// Create collection with INT8 scalar quantization if it doesn't exist.

--- a/crates/zeph-index/src/watcher.rs
+++ b/crates/zeph-index/src/watcher.rs
@@ -74,14 +74,15 @@ mod tests {
 
     use zeph_llm::any::AnyProvider;
     use zeph_llm::ollama::OllamaProvider;
+    use zeph_memory::QdrantOps;
 
     async fn create_test_pool() -> sqlx::SqlitePool {
         sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap()
     }
 
     async fn create_test_indexer() -> Arc<CodeIndexer> {
-        let store = crate::store::CodeStore::new("http://localhost:6334", create_test_pool().await)
-            .unwrap();
+        let ops = QdrantOps::new("http://localhost:6334").unwrap();
+        let store = crate::store::CodeStore::with_ops(ops, create_test_pool().await);
         let provider = AnyProvider::Ollama(OllamaProvider::new(
             "http://127.0.0.1:1",
             "test".into(),

--- a/crates/zeph-mcp/src/registry.rs
+++ b/crates/zeph-mcp/src/registry.rs
@@ -83,14 +83,12 @@ impl std::fmt::Debug for McpToolRegistry {
 }
 
 impl McpToolRegistry {
-    /// # Errors
-    ///
-    /// Returns an error if the Qdrant client cannot be created.
-    pub fn new(qdrant_url: &str) -> Result<Self, McpError> {
-        let ops = QdrantOps::new(qdrant_url)?;
-        Ok(Self {
+    /// Create a `McpToolRegistry` from a pre-built `QdrantOps` instance.
+    #[must_use]
+    pub fn with_ops(ops: QdrantOps) -> Self {
+        Self {
             registry: EmbeddingRegistry::new(ops, COLLECTION_NAME, MCP_NAMESPACE),
-        })
+        }
     }
 
     /// Sync MCP tool embeddings with Qdrant. Computes delta and upserts only changed tools.
@@ -269,24 +267,22 @@ mod tests {
         assert!(dbg.contains("1"));
     }
 
+    fn make_registry(url: &str) -> McpToolRegistry {
+        let ops = QdrantOps::new(url).unwrap();
+        McpToolRegistry::with_ops(ops)
+    }
+
     #[test]
-    fn registry_new_valid_url() {
-        let result = McpToolRegistry::new("http://localhost:6334");
-        assert!(result.is_ok());
+    fn registry_construction_with_ops() {
+        let _registry = make_registry("http://localhost:6334");
     }
 
     #[test]
     fn registry_debug() {
-        let registry = McpToolRegistry::new("http://localhost:6334").unwrap();
+        let registry = make_registry("http://localhost:6334");
         let dbg = format!("{registry:?}");
         assert!(dbg.contains("McpToolRegistry"));
         assert!(dbg.contains("zeph_mcp_tools"));
-    }
-
-    #[test]
-    fn registry_new_with_invalid_url_fails() {
-        let result = McpToolRegistry::new("not a valid url");
-        assert!(result.is_err());
     }
 
     #[test]
@@ -332,7 +328,7 @@ mod tests {
 
     #[tokio::test]
     async fn search_empty_registry_returns_empty() {
-        let registry = McpToolRegistry::new("http://localhost:6334").unwrap();
+        let registry = make_registry("http://localhost:6334");
         let embed_fn = |_: &str| -> EmbedFuture {
             Box::pin(async { Err(zeph_llm::LlmError::Other("no qdrant".into())) })
         };
@@ -342,7 +338,7 @@ mod tests {
 
     #[tokio::test]
     async fn search_with_embedding_failure_returns_empty() {
-        let registry = McpToolRegistry::new("http://localhost:6334").unwrap();
+        let registry = make_registry("http://localhost:6334");
         let embed_fn = |_: &str| -> EmbedFuture {
             Box::pin(async {
                 Err(zeph_llm::LlmError::Other(
@@ -356,7 +352,7 @@ mod tests {
 
     #[tokio::test]
     async fn search_with_zero_limit() {
-        let registry = McpToolRegistry::new("http://localhost:6334").unwrap();
+        let registry = make_registry("http://localhost:6334");
         let embed_fn = |_: &str| -> EmbedFuture { Box::pin(async { Ok(vec![0.1, 0.2, 0.3]) }) };
         let results = registry.search("query", 0, embed_fn).await;
         assert!(results.is_empty());
@@ -364,7 +360,7 @@ mod tests {
 
     #[tokio::test]
     async fn sync_with_unreachable_qdrant_fails() {
-        let mut registry = McpToolRegistry::new("http://127.0.0.1:1").unwrap();
+        let mut registry = make_registry("http://127.0.0.1:1");
         let tools = vec![make_tool("server", "tool")];
         let embed_fn = |_: &str| -> EmbedFuture { Box::pin(async { Ok(vec![0.1, 0.2, 0.3]) }) };
         let result = registry.sync(&tools, "test-model", embed_fn).await;
@@ -373,7 +369,7 @@ mod tests {
 
     #[tokio::test]
     async fn sync_with_empty_tools_and_unreachable_qdrant_fails() {
-        let mut registry = McpToolRegistry::new("http://127.0.0.1:1").unwrap();
+        let mut registry = make_registry("http://127.0.0.1:1");
         let embed_fn = |_: &str| -> EmbedFuture { Box::pin(async { Ok(vec![0.1, 0.2, 0.3]) }) };
         let result = registry.sync(&[], "test-model", embed_fn).await;
         assert!(result.is_err());

--- a/crates/zeph-memory/src/semantic.rs
+++ b/crates/zeph-memory/src/semantic.rs
@@ -167,6 +167,9 @@ impl SemanticMemory {
     ///
     /// Qdrant connection is best-effort: if unavailable, semantic search is disabled.
     ///
+    /// For `AppBuilder` bootstrap, prefer [`SemanticMemory::with_qdrant_ops`] to share
+    /// a single gRPC channel across all subsystems.
+    ///
     /// # Errors
     ///
     /// Returns an error if `SQLite` cannot be initialized.
@@ -180,6 +183,9 @@ impl SemanticMemory {
     }
 
     /// Create a new `SemanticMemory` with custom vector/keyword weights for hybrid search.
+    ///
+    /// For `AppBuilder` bootstrap, prefer [`SemanticMemory::with_qdrant_ops`] to share
+    /// a single gRPC channel across all subsystems.
     ///
     /// # Errors
     ///
@@ -205,6 +211,9 @@ impl SemanticMemory {
     }
 
     /// Create a new `SemanticMemory` with custom weights and configurable pool size.
+    ///
+    /// For `AppBuilder` bootstrap, prefer [`SemanticMemory::with_qdrant_ops`] to share
+    /// a single gRPC channel across all subsystems.
     ///
     /// # Errors
     ///
@@ -232,6 +241,46 @@ impl SemanticMemory {
         Ok(Self {
             sqlite,
             qdrant,
+            provider,
+            embedding_model: embedding_model.into(),
+            vector_weight,
+            keyword_weight,
+            temporal_decay_enabled: false,
+            temporal_decay_half_life_days: 30,
+            mmr_enabled: false,
+            mmr_lambda: 0.7,
+            token_counter: Arc::new(TokenCounter::new()),
+            graph_store: None,
+            community_detection_failures: Arc::new(AtomicU64::new(0)),
+            graph_extraction_count: Arc::new(AtomicU64::new(0)),
+            graph_extraction_failures: Arc::new(AtomicU64::new(0)),
+        })
+    }
+
+    /// Create a `SemanticMemory` from a pre-built `QdrantOps` instance.
+    ///
+    /// Use this at bootstrap to share one `QdrantOps` (and thus one gRPC channel)
+    /// across all subsystems. The `ops` is consumed and wrapped inside `EmbeddingStore`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `SQLite` cannot be initialized.
+    pub async fn with_qdrant_ops(
+        sqlite_path: &str,
+        ops: crate::QdrantOps,
+        provider: AnyProvider,
+        embedding_model: &str,
+        vector_weight: f64,
+        keyword_weight: f64,
+        pool_size: u32,
+    ) -> Result<Self, MemoryError> {
+        let sqlite = SqliteStore::with_pool_size(sqlite_path, pool_size).await?;
+        let pool = sqlite.pool().clone();
+        let store = EmbeddingStore::with_store(Box::new(ops), pool);
+
+        Ok(Self {
+            sqlite,
+            qdrant: Some(Arc::new(store)),
             provider,
             embedding_model: embedding_model.into(),
             vector_weight,
@@ -1632,6 +1681,19 @@ mod tests {
             graph_extraction_count: Arc::new(AtomicU64::new(0)),
             graph_extraction_failures: Arc::new(AtomicU64::new(0)),
         }
+    }
+
+    #[tokio::test]
+    async fn with_qdrant_ops_constructs_successfully() {
+        let ops = crate::QdrantOps::new("http://127.0.0.1:1").unwrap();
+        let provider = test_provider();
+        let result =
+            SemanticMemory::with_qdrant_ops(":memory:", ops, provider, "test-model", 0.7, 0.3, 1)
+                .await;
+        assert!(
+            result.is_ok(),
+            "with_qdrant_ops must succeed (lazy TCP connect)"
+        );
     }
 
     #[tokio::test]

--- a/crates/zeph-skills/src/qdrant_matcher.rs
+++ b/crates/zeph-skills/src/qdrant_matcher.rs
@@ -55,14 +55,12 @@ impl std::fmt::Debug for QdrantSkillMatcher {
 }
 
 impl QdrantSkillMatcher {
-    /// # Errors
-    ///
-    /// Returns an error if the Qdrant client cannot be created.
-    pub fn new(qdrant_url: &str) -> Result<Self, SkillError> {
-        let ops = QdrantOps::new(qdrant_url)?;
-        Ok(Self {
+    /// Create a `QdrantSkillMatcher` from a pre-built `QdrantOps` instance.
+    #[must_use]
+    pub fn with_ops(ops: QdrantOps) -> Self {
+        Self {
             registry: EmbeddingRegistry::new(ops, COLLECTION_NAME, SKILL_NAMESPACE),
-        })
+        }
     }
 
     /// Sync skill embeddings with Qdrant. Computes delta and upserts only changed skills.
@@ -194,15 +192,19 @@ mod tests {
         assert_eq!(payload["key"], "my-skill");
     }
 
+    fn make_matcher() -> QdrantSkillMatcher {
+        let ops = QdrantOps::new("http://localhost:6334").unwrap();
+        QdrantSkillMatcher::with_ops(ops)
+    }
+
     #[test]
-    fn construction_valid_url() {
-        let result = QdrantSkillMatcher::new("http://localhost:6334");
-        assert!(result.is_ok());
+    fn construction_with_ops() {
+        let _matcher = make_matcher();
     }
 
     #[test]
     fn debug_format() {
-        let matcher = QdrantSkillMatcher::new("http://localhost:6334").unwrap();
+        let matcher = make_matcher();
         let dbg = format!("{matcher:?}");
         assert!(dbg.contains("QdrantSkillMatcher"));
         assert!(dbg.contains("zeph_skills"));
@@ -229,7 +231,7 @@ mod tests {
 
     #[tokio::test]
     async fn match_skills_embed_fail_returns_empty() {
-        let matcher = QdrantSkillMatcher::new("http://localhost:6334").unwrap();
+        let matcher = make_matcher();
         let metas = vec![make_meta("s", "desc")];
         let refs: Vec<&SkillMeta> = metas.iter().collect();
         let embed_fn = |_: &str| -> EmbedFuture {

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -207,7 +207,14 @@ async fn build_acp_deps(
         zeph_tools::CompositeExecutor::new(base_executor, mcp_executor),
     );
 
-    let mcp_registry = create_mcp_registry(config, &provider, &mcp_tools, &embed_model).await;
+    let mcp_registry = create_mcp_registry(
+        config,
+        &provider,
+        &mcp_tools,
+        &embed_model,
+        app.qdrant_ops(),
+    )
+    .await;
     let summary_provider = app.build_summary_provider();
     let skill_paths = app.skill_paths();
     let acp_project_rules = collect_project_rules(&skill_paths);

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -95,6 +95,8 @@ use zeph_index::{
     store::CodeStore,
     watcher::IndexWatcher,
 };
+#[cfg(feature = "index")]
+use zeph_memory::QdrantOps;
 
 pub(crate) fn spawn_ctrl_c_handler(
     cancel_signal: std::sync::Arc<tokio::sync::Notify>,
@@ -188,7 +190,7 @@ pub(crate) fn apply_quarantine_provider<C: Channel>(
 pub(crate) async fn apply_code_index<C: Channel>(
     agent: Agent<C>,
     config: &IndexConfig,
-    qdrant_url: &str,
+    qdrant_ops: Option<QdrantOps>,
     provider: zeph_llm::any::AnyProvider,
     pool: sqlx::SqlitePool,
     provider_has_tools: bool,
@@ -201,7 +203,10 @@ pub(crate) async fn apply_code_index<C: Channel>(
     }
 
     let init = async {
-        let store = CodeStore::new(qdrant_url, pool)?;
+        let ops = qdrant_ops.ok_or_else(|| {
+            anyhow::anyhow!("code index requires Qdrant backend (vector_backend = \"qdrant\")")
+        })?;
+        let store = CodeStore::with_ops(ops, pool);
         let provider_arc = std::sync::Arc::new(provider);
         let retrieval_config = RetrievalConfig {
             max_chunks: config.max_chunks,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -256,7 +256,14 @@ pub(crate) async fn run_daemon(
             zeph_tools::CompositeExecutor::new(memory_executor, zeph_tools::DynExecutor(base_tool)),
         )));
 
-    let mcp_registry = create_mcp_registry(config, &provider, &mcp_tools, &embed_model).await;
+    let mcp_registry = create_mcp_registry(
+        config,
+        &provider,
+        &mcp_tools,
+        &embed_model,
+        app.qdrant_ops(),
+    )
+    .await;
 
     let watchers = app.build_watchers();
     let _skill_watcher = watchers.skill_watcher;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -448,7 +448,14 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     let _config_watcher = watchers.config_watcher;
     let config_reload_rx = watchers.config_reload_rx;
 
-    let mcp_registry = create_mcp_registry(config, &provider, &mcp_tools, &embed_model).await;
+    let mcp_registry = create_mcp_registry(
+        config,
+        &provider,
+        &mcp_tools,
+        &embed_model,
+        app.qdrant_ops(),
+    )
+    .await;
 
     #[cfg(feature = "index")]
     let index_pool = memory.sqlite().pool().clone();
@@ -456,6 +463,8 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     let index_provider = provider.clone();
     #[cfg(feature = "index")]
     let provider_has_tools = provider.supports_tool_use();
+    #[cfg(feature = "index")]
+    let index_qdrant_ops = app.qdrant_ops().cloned();
     let config_path = app.config_path().to_owned();
     let cache_pool = memory.sqlite().pool().clone();
 
@@ -642,7 +651,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     let (agent, _index_watcher) = agent_setup::apply_code_index(
         agent,
         &config.index,
-        &config.memory.qdrant_url,
+        index_qdrant_ops,
         index_provider,
         index_pool,
         provider_has_tools,


### PR DESCRIPTION
Closes #1337

## Summary

- Constructs `QdrantOps` once in `AppBuilder::new()`, cloned (O(1) Arc bump via tonic `Arc<ChannelPool>`) into all Qdrant consumers
- Reduces startup gRPC connection count from 4 to 1 with no behavioral change
- Adds hard error at startup when `vector_backend = "qdrant"` and `qdrant_url` is invalid (previously silent `None`)
- Adds debug log when MCP tool registry is skipped due to no Qdrant backend

## Changes

- New `with_ops(ops: QdrantOps)` constructors: `QdrantSkillMatcher`, `McpToolRegistry`, `CodeStore`
- New `SemanticMemory::with_qdrant_ops(sqlite_path, ops, ...)` constructor
- `AppBuilder` builds `QdrantOps` once; all bootstrap call sites receive `app.qdrant_ops()` clone
- Old URL-only constructors removed from all bootstrap paths (pre-v1.0, no compat wrappers)
- Unit tests added for CRIT-04 hard error path and `SemanticMemory::with_qdrant_ops`

## Test plan

- [ ] `cargo +nightly fmt --check` — pass
- [ ] `cargo clippy --workspace --features full -- -D warnings` — pass
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --features full --lib --bins` — 5063 passed (+2 new tests)