### PR TITLE
Refactor Zeph ACP agent for Send+Sync LSP runtime

### DIFF
--- a/crates/zeph-acp/src/agent/mod.rs
+++ b/crates/zeph-acp/src/agent/mod.rs
@@ -235,15 +235,10 @@ pub struct AcpContext {
     /// `None` for top-level (non-subagent) sessions.
     pub parent_tool_use_id: Option<String>,
     /// LSP provider when the IDE advertised `meta["lsp"]` capability.
-    ///
-    /// **`!Send` constraint**: `AcpLspProvider` holds `Rc<RefCell<...>>` and must
-    /// only be used within a `LocalSet` context.
     pub lsp_provider: Option<crate::lsp::AcpLspProvider>,
     /// Shared diagnostics cache — written by the LSP notification handler in `ZephAcpAgent`
     /// and read by the agent loop context builder to inject diagnostics into the system prompt.
-    ///
-    /// `Rc` is used because `ZephAcpAgent` is `!Send` and runs in a `LocalSet`.
-    pub diagnostics_cache: Rc<RefCell<DiagnosticsCache>>,
+    pub diagnostics_cache: Arc<std::sync::RwLock<DiagnosticsCache>>,
 }
 
 /// Factory: receives a [`LoopbackChannel`], optional [`AcpContext`], and [`SessionContext`],
@@ -257,6 +252,8 @@ pub type AgentSpawner = Arc<
             Option<AcpContext>,
             SessionContext,
         ) -> Pin<Box<dyn std::future::Future<Output = ()> + 'static>>
+        + Send
+        + Sync
         + 'static,
 >;
 
@@ -264,16 +261,7 @@ pub type AgentSpawner = Arc<
 ///
 /// Used with `AcpHttpState` to satisfy `axum::State` requirements (`Send + Sync`).
 #[cfg(feature = "acp-http")]
-pub type SendAgentSpawner = Arc<
-    dyn Fn(
-            LoopbackChannel,
-            Option<AcpContext>,
-            SessionContext,
-        ) -> Pin<Box<dyn std::future::Future<Output = ()> + 'static>>
-        + Send
-        + Sync
-        + 'static,
->;
+pub type SendAgentSpawner = AgentSpawner;
 
 /// Sender half for delivering session notifications to the background writer.
 pub(crate) type NotifySender =
@@ -338,7 +326,7 @@ pub struct ZephAcpAgent {
     /// LSP extension configuration (from `[acp.lsp]`).
     lsp_config: zeph_core::config::AcpLspConfig,
     /// Per-agent diagnostics cache, shared between the agent (writer) and `AcpContext` (reader).
-    diagnostics_cache: Rc<RefCell<DiagnosticsCache>>,
+    diagnostics_cache: Arc<std::sync::RwLock<DiagnosticsCache>>,
 }
 
 impl ZephAcpAgent {
@@ -371,7 +359,9 @@ impl ZephAcpAgent {
             title_max_chars: 60,
             max_history: 100,
             lsp_config,
-            diagnostics_cache: Rc::new(RefCell::new(DiagnosticsCache::new(max_diag_files))),
+            diagnostics_cache: Arc::new(std::sync::RwLock::new(DiagnosticsCache::new(
+                max_diag_files,
+            ))),
         }
     }
 
@@ -380,7 +370,7 @@ impl ZephAcpAgent {
     pub fn with_lsp_config(mut self, config: zeph_core::config::AcpLspConfig) -> Self {
         let max_files = config.max_diagnostic_files;
         self.lsp_config = config;
-        self.diagnostics_cache = Rc::new(RefCell::new(DiagnosticsCache::new(max_files)));
+        self.diagnostics_cache = Arc::new(std::sync::RwLock::new(DiagnosticsCache::new(max_files)));
         self
     }
 
@@ -519,13 +509,15 @@ impl ZephAcpAgent {
         tokio::task::spawn_local(shell_handler);
 
         let lsp_provider = if ide_supports_lsp {
-            Some(crate::lsp::AcpLspProvider::new(
-                Rc::clone(&self.conn_slot),
+            let (provider, handler) = crate::lsp::AcpLspProvider::new(
+                Rc::clone(conn),
                 true,
                 self.lsp_config.request_timeout_secs,
                 self.lsp_config.max_references,
                 self.lsp_config.max_workspace_symbols,
-            ))
+            );
+            tokio::task::spawn_local(handler);
+            Some(provider)
         } else {
             None
         };
@@ -538,7 +530,7 @@ impl ZephAcpAgent {
             provider_override,
             parent_tool_use_id: None,
             lsp_provider,
-            diagnostics_cache: Rc::clone(&self.diagnostics_cache),
+            diagnostics_cache: Arc::clone(&self.diagnostics_cache),
         })
     }
 
@@ -569,7 +561,10 @@ impl ZephAcpAgent {
                     count = diags.len(),
                     "lsp/publishDiagnostics: cached"
                 );
-                self.diagnostics_cache.borrow_mut().update(p.uri, diags);
+                self.diagnostics_cache
+                    .write()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .update(p.uri, diags);
             }
             Err(e) => {
                 tracing::warn!(error = %e, "lsp/publishDiagnostics: failed to parse params");
@@ -625,7 +620,10 @@ impl ZephAcpAgent {
                             count = diags.len(),
                             "lsp/didSave: fetched diagnostics"
                         );
-                        self.diagnostics_cache.borrow_mut().update(uri, diags);
+                        self.diagnostics_cache
+                            .write()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner)
+                            .update(uri, diags);
                     }
                     Err(e) => {
                         tracing::warn!(error = %e, "lsp/didSave: failed to parse diagnostics response");

--- a/crates/zeph-acp/src/agent/tests.rs
+++ b/crates/zeph-acp/src/agent/tests.rs
@@ -3,6 +3,7 @@
 
 use super::helpers::*;
 use super::*;
+use acp::Agent as _;
 
 fn make_spawner() -> AgentSpawner {
     Arc::new(|_channel, _ctx, _session_ctx| Box::pin(async {}))
@@ -39,7 +40,6 @@ async fn initialize_returns_agent_info() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let resp = agent
                 .initialize(acp::InitializeRequest::new(acp::ProtocolVersion::LATEST))
                 .await
@@ -67,8 +67,6 @@ async fn new_session_reads_latest_available_models_from_shared_state() {
                     .unwrap_or_else(std::sync::PoisonError::into_inner);
                 guard.push("openai:gpt-5".to_owned());
             }
-
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -111,8 +109,6 @@ async fn new_session_freezes_initial_model_for_existing_session() {
             let factory: ProviderFactory = Arc::new(|_key| None);
             let agent = ZephAcpAgent::new(make_spawner(), tx, conn_slot, 4, 1800, None)
                 .with_provider_factory(factory, Arc::clone(&models));
-
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -140,7 +136,6 @@ async fn initialize_returns_load_session_capability_and_auth_hint() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let resp = agent
                 .initialize(acp::InitializeRequest::new(acp::ProtocolVersion::LATEST))
                 .await
@@ -178,7 +173,6 @@ async fn ext_notification_accepts_unknown_method() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let notif = acp::ExtNotification::new(
                 "custom/ping",
                 serde_json::value::RawValue::from_string("{}".to_owned())
@@ -197,7 +191,6 @@ async fn new_session_creates_entry() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -214,7 +207,6 @@ async fn new_session_uses_request_cwd() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let cwd = std::path::PathBuf::from("/tmp/acp-session-cwd");
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(cwd.clone()))
@@ -235,7 +227,6 @@ async fn cancel_keeps_session() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -257,7 +248,6 @@ async fn cancel_triggers_notify_one() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -291,21 +281,21 @@ async fn prompt_image_block_does_not_error() {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {
-            let received: std::rc::Rc<std::cell::RefCell<Option<ChannelMessage>>> =
-                std::rc::Rc::new(std::cell::RefCell::new(None));
-            let received_clone = std::rc::Rc::clone(&received);
+            let received = Arc::new(std::sync::Mutex::new(None::<ChannelMessage>));
+            let received_clone = Arc::clone(&received);
             let spawner: AgentSpawner = Arc::new(move |mut channel, _ctx, _session_ctx| {
-                let received_clone = std::rc::Rc::clone(&received_clone);
+                let received_clone = Arc::clone(&received_clone);
                 Box::pin(async move {
                     if let Ok(Some(msg)) = channel.recv().await {
-                        *received_clone.borrow_mut() = Some(msg);
+                        *received_clone
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(msg);
                     }
                 })
             });
             let (tx, _rx) = mpsc::unbounded_channel();
             let conn_slot = std::rc::Rc::new(std::cell::RefCell::new(None));
             let agent = ZephAcpAgent::new(spawner, tx, conn_slot, 4, 1800, None);
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -319,7 +309,11 @@ async fn prompt_image_block_does_not_error() {
             assert!(result.is_ok());
 
             // Spawner received the message with one image attachment
-            let msg = received.borrow().clone().unwrap();
+            let msg = received
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone()
+                .unwrap();
             assert_eq!(msg.attachments.len(), 1);
             assert_eq!(
                 msg.attachments[0].kind,
@@ -336,21 +330,21 @@ async fn prompt_resource_block_appends_text() {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {
-            let received: std::rc::Rc<std::cell::RefCell<Option<ChannelMessage>>> =
-                std::rc::Rc::new(std::cell::RefCell::new(None));
-            let received_clone = std::rc::Rc::clone(&received);
+            let received = Arc::new(std::sync::Mutex::new(None::<ChannelMessage>));
+            let received_clone = Arc::clone(&received);
             let spawner: AgentSpawner = Arc::new(move |mut channel, _ctx, _session_ctx| {
-                let received_clone = std::rc::Rc::clone(&received_clone);
+                let received_clone = Arc::clone(&received_clone);
                 Box::pin(async move {
                     if let Ok(Some(msg)) = channel.recv().await {
-                        *received_clone.borrow_mut() = Some(msg);
+                        *received_clone
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(msg);
                     }
                 })
             });
             let (tx, _rx) = mpsc::unbounded_channel();
             let conn_slot = std::rc::Rc::new(std::cell::RefCell::new(None));
             let agent = ZephAcpAgent::new(spawner, tx, conn_slot, 4, 1800, None);
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -366,7 +360,11 @@ async fn prompt_resource_block_appends_text() {
                 acp::PromptRequest::new(resp.session_id.to_string(), vec![text_block, res_block]);
             agent.prompt(req).await.unwrap();
 
-            let msg = received.borrow().clone().unwrap();
+            let msg = received
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone()
+                .unwrap();
             assert!(msg.text.contains("hello"));
             assert!(
                 msg.text
@@ -383,7 +381,6 @@ async fn prompt_rejects_oversized() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -924,7 +921,6 @@ async fn new_session_rejects_over_limit() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent_with_max(1);
-            use acp::Agent as _;
             // fill the limit
             agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
@@ -947,7 +943,6 @@ async fn new_session_rejects_when_all_busy() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent_with_max(1);
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -976,7 +971,6 @@ async fn new_session_respects_configurable_limit() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent_with_max(2);
-            use acp::Agent as _;
             let r1 = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -1003,7 +997,6 @@ async fn load_session_returns_ok_for_existing() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -1025,7 +1018,6 @@ async fn load_session_errors_for_unknown() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let res = agent
                 .load_session(acp::LoadSessionRequest::new(
                     acp::SessionId::new("no-such"),
@@ -1043,7 +1035,6 @@ async fn prompt_errors_for_unknown_session() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let req = acp::PromptRequest::new("no-such", vec![]);
             assert!(agent.prompt(req).await.is_err());
         })
@@ -1056,21 +1047,21 @@ async fn prompt_oversized_image_base64_skipped() {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {
-            let received: std::rc::Rc<std::cell::RefCell<Option<ChannelMessage>>> =
-                std::rc::Rc::new(std::cell::RefCell::new(None));
-            let received_clone = std::rc::Rc::clone(&received);
+            let received = Arc::new(std::sync::Mutex::new(None::<ChannelMessage>));
+            let received_clone = Arc::clone(&received);
             let spawner: AgentSpawner = Arc::new(move |mut channel, _ctx, _session_ctx| {
-                let received_clone = std::rc::Rc::clone(&received_clone);
+                let received_clone = Arc::clone(&received_clone);
                 Box::pin(async move {
                     if let Ok(Some(msg)) = channel.recv().await {
-                        *received_clone.borrow_mut() = Some(msg);
+                        *received_clone
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(msg);
                     }
                 })
             });
             let (tx, _rx) = mpsc::unbounded_channel();
             let conn_slot = std::rc::Rc::new(std::cell::RefCell::new(None));
             let agent = ZephAcpAgent::new(spawner, tx, conn_slot, 4, 1800, None);
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -1083,7 +1074,11 @@ async fn prompt_oversized_image_base64_skipped() {
             let req = acp::PromptRequest::new(resp.session_id.to_string(), vec![img_block]);
             agent.prompt(req).await.unwrap();
 
-            let msg = received.borrow().clone().unwrap();
+            let msg = received
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone()
+                .unwrap();
             assert!(
                 msg.attachments.is_empty(),
                 "oversized image must be skipped"
@@ -1099,21 +1094,21 @@ async fn prompt_unsupported_mime_image_skipped() {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {
-            let received: std::rc::Rc<std::cell::RefCell<Option<ChannelMessage>>> =
-                std::rc::Rc::new(std::cell::RefCell::new(None));
-            let received_clone = std::rc::Rc::clone(&received);
+            let received = Arc::new(std::sync::Mutex::new(None::<ChannelMessage>));
+            let received_clone = Arc::clone(&received);
             let spawner: AgentSpawner = Arc::new(move |mut channel, _ctx, _session_ctx| {
-                let received_clone = std::rc::Rc::clone(&received_clone);
+                let received_clone = Arc::clone(&received_clone);
                 Box::pin(async move {
                     if let Ok(Some(msg)) = channel.recv().await {
-                        *received_clone.borrow_mut() = Some(msg);
+                        *received_clone
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(msg);
                     }
                 })
             });
             let (tx, _rx) = mpsc::unbounded_channel();
             let conn_slot = std::rc::Rc::new(std::cell::RefCell::new(None));
             let agent = ZephAcpAgent::new(spawner, tx, conn_slot, 4, 1800, None);
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -1125,7 +1120,11 @@ async fn prompt_unsupported_mime_image_skipped() {
             let req = acp::PromptRequest::new(resp.session_id.to_string(), vec![img_block]);
             agent.prompt(req).await.unwrap();
 
-            let msg = received.borrow().clone().unwrap();
+            let msg = received
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone()
+                .unwrap();
             assert!(
                 msg.attachments.is_empty(),
                 "unsupported MIME type must be skipped"
@@ -1140,21 +1139,21 @@ async fn prompt_resource_text_wrapped_in_markers() {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {
-            let received: std::rc::Rc<std::cell::RefCell<Option<ChannelMessage>>> =
-                std::rc::Rc::new(std::cell::RefCell::new(None));
-            let received_clone = std::rc::Rc::clone(&received);
+            let received = Arc::new(std::sync::Mutex::new(None::<ChannelMessage>));
+            let received_clone = Arc::clone(&received);
             let spawner: AgentSpawner = Arc::new(move |mut channel, _ctx, _session_ctx| {
-                let received_clone = std::rc::Rc::clone(&received_clone);
+                let received_clone = Arc::clone(&received_clone);
                 Box::pin(async move {
                     if let Ok(Some(msg)) = channel.recv().await {
-                        *received_clone.borrow_mut() = Some(msg);
+                        *received_clone
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(msg);
                     }
                 })
             });
             let (tx, _rx) = mpsc::unbounded_channel();
             let conn_slot = std::rc::Rc::new(std::cell::RefCell::new(None));
             let agent = ZephAcpAgent::new(spawner, tx, conn_slot, 4, 1800, None);
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -1168,7 +1167,11 @@ async fn prompt_resource_text_wrapped_in_markers() {
             let req = acp::PromptRequest::new(resp.session_id.to_string(), vec![res_block]);
             agent.prompt(req).await.unwrap();
 
-            let msg = received.borrow().clone().unwrap();
+            let msg = received
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone()
+                .unwrap();
             assert!(
                 msg.text
                     .contains("<resource name=\"file:///secret.txt\">injected content</resource>"),
@@ -1387,7 +1390,6 @@ async fn initialize_advertises_session_capabilities() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let resp = agent
                 .initialize(acp::InitializeRequest::new(acp::ProtocolVersion::LATEST))
                 .await
@@ -1422,7 +1424,6 @@ async fn set_session_mode_valid_updates_current_mode() {
                     ack.send(()).ok();
                 }
             });
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -1444,7 +1445,6 @@ async fn set_session_mode_unknown_mode_errors() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -1462,7 +1462,6 @@ async fn ext_notification_always_ok() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let notif = acp::ExtNotification::new(
                 "_agent/some/event",
                 serde_json::value::RawValue::NULL.to_owned().into(),
@@ -1479,7 +1478,6 @@ async fn set_session_config_option_unknown_config_id_errors() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -1501,7 +1499,6 @@ async fn set_session_config_option_no_factory_errors() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -1522,7 +1519,6 @@ async fn set_session_config_option_with_factory_updates_model() {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {
-            use acp::Agent as _;
             let (tx, _rx) = mpsc::unbounded_channel();
             let conn_slot = std::rc::Rc::new(std::cell::RefCell::new(None));
             let factory: ProviderFactory = Arc::new(|key: &str| {
@@ -1578,7 +1574,6 @@ async fn ext_method_no_manager_errors() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let req = acp::ExtRequest::new(
                 "_agent/mcp/list",
                 serde_json::value::RawValue::NULL.to_owned().into(),
@@ -1595,7 +1590,6 @@ async fn ext_method_unknown_returns_null() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let req = acp::ExtRequest::new(
                 "_agent/unknown/method",
                 serde_json::value::RawValue::NULL.to_owned().into(),
@@ -1611,7 +1605,6 @@ async fn set_session_config_option_rejects_model_not_in_allowlist() {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {
-            use acp::Agent as _;
             let (tx, _rx) = mpsc::unbounded_channel();
             let conn_slot = std::rc::Rc::new(std::cell::RefCell::new(None));
             let factory: ProviderFactory = Arc::new(|_key: &str| {
@@ -1647,7 +1640,6 @@ async fn new_session_includes_modes() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -1667,7 +1659,6 @@ async fn set_session_mode_updates_entry() {
     local
         .run_until(async {
             let (agent, mut rx) = make_agent();
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -1703,7 +1694,6 @@ async fn set_session_mode_emits_notification() {
     local
         .run_until(async {
             let (agent, mut rx) = make_agent();
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -1748,7 +1738,6 @@ async fn set_session_mode_rejects_unknown_mode() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -1770,7 +1759,6 @@ async fn set_session_mode_rejects_unknown_session() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let result = agent
                 .set_session_mode(acp::SetSessionModeRequest::new(
                     acp::SessionId::new("nonexistent"),
@@ -1789,7 +1777,6 @@ async fn list_sessions_returns_active_sessions() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -1814,7 +1801,6 @@ async fn list_sessions_filters_by_cwd() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let resp1 = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -1858,7 +1844,6 @@ async fn fork_session_errors_for_unknown() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let unknown_id = acp::SessionId::new(uuid::Uuid::new_v4().to_string());
             let result = agent
                 .fork_session(acp::ForkSessionRequest::new(
@@ -1878,7 +1863,6 @@ async fn fork_session_creates_new_session_from_existing() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
 
             // Create source session.
             let src = agent
@@ -1915,7 +1899,6 @@ async fn resume_session_returns_ok_for_active() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -1938,7 +1921,6 @@ async fn resume_session_errors_for_unknown() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let unknown_id = acp::SessionId::new(uuid::Uuid::new_v4().to_string());
             let result = agent
                 .resume_session(acp::ResumeSessionRequest::new(
@@ -1990,7 +1972,6 @@ async fn prompt_diagnostics_block_formatted() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -2030,7 +2011,6 @@ async fn slash_help_returns_end_turn() {
     local
         .run_until(async {
             let (agent, mut rx) = make_agent();
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -2065,7 +2045,6 @@ async fn slash_unknown_command_returns_error() {
     local
         .run_until(async {
             let (agent, mut rx) = make_agent();
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -2242,7 +2221,6 @@ async fn set_session_model_no_factory_errors() {
     local
         .run_until(async {
             let (agent, mut rx) = make_agent();
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -2275,7 +2253,6 @@ async fn set_session_model_rejects_unknown_model() {
                     factory,
                     shared_models(vec!["claude:claude-3-5-sonnet".to_owned()]),
                 );
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -2296,7 +2273,6 @@ async fn new_session_meta_contains_project_rules() {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {
-            use acp::Agent as _;
             let (tx, _rx) = mpsc::unbounded_channel();
             let conn_slot = std::rc::Rc::new(std::cell::RefCell::new(None));
             let rules = vec![
@@ -2328,7 +2304,6 @@ async fn new_session_meta_absent_when_no_rules() {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {
-            use acp::Agent as _;
             let (agent, _rx) = make_agent();
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
@@ -2492,7 +2467,6 @@ async fn set_session_config_option_thinking_toggle() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let sess = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -2522,7 +2496,6 @@ async fn set_session_config_option_auto_approve_levels() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let sess = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -2548,7 +2521,6 @@ async fn set_session_config_option_rejects_invalid_auto_approve() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let sess = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -2576,7 +2548,6 @@ async fn list_sessions_includes_title_for_in_memory_session() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let sess = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -2612,7 +2583,6 @@ async fn list_sessions_title_none_for_new_session() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let sess = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -2641,7 +2611,6 @@ async fn set_session_config_option_auto_approve_unknown_session_errors() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let req = acp::SetSessionConfigOptionRequest::new(
                 "nonexistent-session",
                 "auto_approve",
@@ -2660,7 +2629,6 @@ async fn set_session_config_option_auto_approve_reflected_in_response() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let sess = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -2776,7 +2744,6 @@ async fn slash_review_returns_end_turn() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -2800,7 +2767,6 @@ async fn slash_review_with_path_returns_end_turn() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -2825,22 +2791,22 @@ async fn slash_review_prompt_contains_read_only_constraint() {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {
-            let received: std::rc::Rc<std::cell::RefCell<Option<ChannelMessage>>> =
-                std::rc::Rc::new(std::cell::RefCell::new(None));
-            let received_clone = std::rc::Rc::clone(&received);
+            let received = Arc::new(std::sync::Mutex::new(None::<ChannelMessage>));
+            let received_clone = Arc::clone(&received);
             let spawner: AgentSpawner = Arc::new(move |mut channel, _ctx, _session_ctx| {
-                let received_clone = std::rc::Rc::clone(&received_clone);
+                let received_clone = Arc::clone(&received_clone);
                 Box::pin(async move {
                     use zeph_core::Channel as _;
                     if let Ok(Some(msg)) = channel.recv().await {
-                        *received_clone.borrow_mut() = Some(msg);
+                        *received_clone
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(msg);
                     }
                 })
             });
             let (tx, _rx) = mpsc::unbounded_channel();
             let conn_slot = std::rc::Rc::new(std::cell::RefCell::new(None));
             let agent = ZephAcpAgent::new(spawner, tx, conn_slot, 4, 1800, None);
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -2857,7 +2823,11 @@ async fn slash_review_prompt_contains_read_only_constraint() {
                 .unwrap();
             // Yield again to allow spawner task to process the received message.
             tokio::task::yield_now().await;
-            let msg = received.borrow().clone().unwrap();
+            let msg = received
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone()
+                .unwrap();
             assert!(
                 msg.text.contains("Do not execute any commands"),
                 "review prompt must contain read-only constraint, got: {}",
@@ -2877,22 +2847,22 @@ async fn slash_review_with_path_prompt_contains_path() {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {
-            let received: std::rc::Rc<std::cell::RefCell<Option<ChannelMessage>>> =
-                std::rc::Rc::new(std::cell::RefCell::new(None));
-            let received_clone = std::rc::Rc::clone(&received);
+            let received = Arc::new(std::sync::Mutex::new(None::<ChannelMessage>));
+            let received_clone = Arc::clone(&received);
             let spawner: AgentSpawner = Arc::new(move |mut channel, _ctx, _session_ctx| {
-                let received_clone = std::rc::Rc::clone(&received_clone);
+                let received_clone = Arc::clone(&received_clone);
                 Box::pin(async move {
                     use zeph_core::Channel as _;
                     if let Ok(Some(msg)) = channel.recv().await {
-                        *received_clone.borrow_mut() = Some(msg);
+                        *received_clone
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(msg);
                     }
                 })
             });
             let (tx, _rx) = mpsc::unbounded_channel();
             let conn_slot = std::rc::Rc::new(std::cell::RefCell::new(None));
             let agent = ZephAcpAgent::new(spawner, tx, conn_slot, 4, 1800, None);
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -2909,7 +2879,11 @@ async fn slash_review_with_path_prompt_contains_path() {
                 .await
                 .unwrap();
             tokio::task::yield_now().await;
-            let msg = received.borrow().clone().unwrap();
+            let msg = received
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone()
+                .unwrap();
             assert!(
                 msg.text.contains("crates/zeph-acp"),
                 "review prompt with path must include the path, got: {}",
@@ -2933,7 +2907,6 @@ async fn slash_review_rejects_invalid_arg() {
             let (tx, _rx) = mpsc::unbounded_channel();
             let conn_slot = std::rc::Rc::new(std::cell::RefCell::new(None));
             let agent = ZephAcpAgent::new(spawner, tx, conn_slot, 4, 1800, None);
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -3113,7 +3086,6 @@ async fn initialize_with_mcp_manager_advertises_capabilities() {
             ));
             let agent = ZephAcpAgent::new(make_spawner(), tx, conn_slot, 4, 1800, None)
                 .with_mcp_manager(manager);
-            use acp::Agent as _;
             let resp = agent
                 .initialize(acp::InitializeRequest::new(acp::ProtocolVersion::LATEST))
                 .await
@@ -3133,7 +3105,6 @@ async fn ext_notification_lsp_publish_diagnostics_caches_diagnostics() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let params = serde_json::json!({
                 "uri": "file:///src/main.rs",
                 "diagnostics": [
@@ -3154,7 +3125,10 @@ async fn ext_notification_lsp_publish_diagnostics_caches_diagnostics() {
                     .into(),
             );
             agent.ext_notification(notif).await.unwrap();
-            let cache = agent.diagnostics_cache.borrow();
+            let cache = agent
+                .diagnostics_cache
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             let diags = cache
                 .peek("file:///src/main.rs")
                 .expect("diagnostics should be cached");
@@ -3170,7 +3144,6 @@ async fn ext_notification_lsp_publish_diagnostics_malformed_json_is_ok() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let notif = acp::ExtNotification::new(
                 "lsp/publishDiagnostics",
                 serde_json::value::RawValue::from_string("\"not an object\"".to_owned())
@@ -3181,7 +3154,13 @@ async fn ext_notification_lsp_publish_diagnostics_malformed_json_is_ok() {
             let result = agent.ext_notification(notif).await;
             assert!(result.is_ok());
             // Cache should remain empty.
-            assert!(agent.diagnostics_cache.borrow().is_empty());
+            assert!(
+                agent
+                    .diagnostics_cache
+                    .read()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .is_empty()
+            );
         })
         .await;
 }
@@ -3193,12 +3172,12 @@ async fn ext_notification_lsp_publish_diagnostics_truncates_at_max() {
         .run_until(async {
             let (tx, _rx) = mpsc::unbounded_channel();
             let conn_slot = std::rc::Rc::new(std::cell::RefCell::new(None));
-            let mut lsp_config = zeph_core::config::AcpLspConfig::default();
-            lsp_config.max_diagnostics_per_file = 2;
+            let lsp_config = zeph_core::config::AcpLspConfig {
+                max_diagnostics_per_file: 2,
+                ..Default::default()
+            };
             let agent = ZephAcpAgent::new(make_spawner(), tx, conn_slot, 4, 1800, None)
                 .with_lsp_config(lsp_config);
-
-            use acp::Agent as _;
             let diags_json: Vec<serde_json::Value> = (0..5)
                 .map(|i| {
                     serde_json::json!({
@@ -3219,7 +3198,10 @@ async fn ext_notification_lsp_publish_diagnostics_truncates_at_max() {
                     .into(),
             );
             agent.ext_notification(notif).await.unwrap();
-            let cache = agent.diagnostics_cache.borrow();
+            let cache = agent
+                .diagnostics_cache
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             let diags = cache
                 .peek("file:///a.rs")
                 .expect("diagnostics should be cached");
@@ -3241,12 +3223,12 @@ async fn ext_notification_lsp_did_save_disabled_is_noop() {
         .run_until(async {
             let (tx, _rx) = mpsc::unbounded_channel();
             let conn_slot = std::rc::Rc::new(std::cell::RefCell::new(None));
-            let mut lsp_config = zeph_core::config::AcpLspConfig::default();
-            lsp_config.auto_diagnostics_on_save = false;
+            let lsp_config = zeph_core::config::AcpLspConfig {
+                auto_diagnostics_on_save: false,
+                ..Default::default()
+            };
             let agent = ZephAcpAgent::new(make_spawner(), tx, conn_slot, 4, 1800, None)
                 .with_lsp_config(lsp_config);
-
-            use acp::Agent as _;
             let params = serde_json::json!({ "uri": "file:///src/main.rs" });
             let notif = acp::ExtNotification::new(
                 "lsp/didSave",
@@ -3258,7 +3240,13 @@ async fn ext_notification_lsp_did_save_disabled_is_noop() {
             let result = agent.ext_notification(notif).await;
             assert!(result.is_ok());
             // Cache untouched.
-            assert!(agent.diagnostics_cache.borrow().is_empty());
+            assert!(
+                agent
+                    .diagnostics_cache
+                    .read()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .is_empty()
+            );
         })
         .await;
 }
@@ -3270,12 +3258,12 @@ async fn ext_notification_lsp_did_save_malformed_params_is_ok() {
         .run_until(async {
             let (tx, _rx) = mpsc::unbounded_channel();
             let conn_slot = std::rc::Rc::new(std::cell::RefCell::new(None));
-            let mut lsp_config = zeph_core::config::AcpLspConfig::default();
-            lsp_config.auto_diagnostics_on_save = true;
+            let lsp_config = zeph_core::config::AcpLspConfig {
+                auto_diagnostics_on_save: true,
+                ..Default::default()
+            };
             let agent = ZephAcpAgent::new(make_spawner(), tx, conn_slot, 4, 1800, None)
                 .with_lsp_config(lsp_config);
-
-            use acp::Agent as _;
             let notif = acp::ExtNotification::new(
                 "lsp/didSave",
                 serde_json::value::RawValue::from_string("\"bad params\"".to_owned())
@@ -3295,7 +3283,6 @@ async fn initialize_without_mcp_manager_no_mcp_capabilities() {
     local
         .run_until(async {
             let (agent, _rx) = make_agent();
-            use acp::Agent as _;
             let resp = agent
                 .initialize(acp::InitializeRequest::new(acp::ProtocolVersion::LATEST))
                 .await
@@ -3317,12 +3304,12 @@ async fn initialize_advertises_lsp_capability_when_enabled() {
         .run_until(async {
             let (tx, _rx) = mpsc::unbounded_channel();
             let conn_slot = std::rc::Rc::new(std::cell::RefCell::new(None));
-            let mut lsp_config = zeph_core::config::AcpLspConfig::default();
-            lsp_config.enabled = true;
+            let lsp_config = zeph_core::config::AcpLspConfig {
+                enabled: true,
+                ..Default::default()
+            };
             let agent = ZephAcpAgent::new(make_spawner(), tx, conn_slot, 4, 1800, None)
                 .with_lsp_config(lsp_config);
-
-            use acp::Agent as _;
             let resp = agent
                 .initialize(acp::InitializeRequest::new(acp::ProtocolVersion::LATEST))
                 .await
@@ -3368,7 +3355,6 @@ async fn prompt_stop_reason_max_tokens_from_loopback_event() {
             let (tx, _rx) = mpsc::unbounded_channel();
             let conn_slot = std::rc::Rc::new(std::cell::RefCell::new(None));
             let agent = ZephAcpAgent::new(spawner, tx, conn_slot, 4, 1800, None);
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -3396,12 +3382,12 @@ async fn initialize_does_not_advertise_lsp_when_disabled() {
         .run_until(async {
             let (tx, _rx) = mpsc::unbounded_channel();
             let conn_slot = std::rc::Rc::new(std::cell::RefCell::new(None));
-            let mut lsp_config = zeph_core::config::AcpLspConfig::default();
-            lsp_config.enabled = false;
+            let lsp_config = zeph_core::config::AcpLspConfig {
+                enabled: false,
+                ..Default::default()
+            };
             let agent = ZephAcpAgent::new(make_spawner(), tx, conn_slot, 4, 1800, None)
                 .with_lsp_config(lsp_config);
-
-            use acp::Agent as _;
             let resp = agent
                 .initialize(acp::InitializeRequest::new(acp::ProtocolVersion::LATEST))
                 .await
@@ -3437,7 +3423,6 @@ async fn prompt_stop_reason_max_turn_requests_from_loopback_event() {
             let (tx, _rx) = mpsc::unbounded_channel();
             let conn_slot = std::rc::Rc::new(std::cell::RefCell::new(None));
             let agent = ZephAcpAgent::new(spawner, tx, conn_slot, 4, 1800, None);
-            use acp::Agent as _;
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await
@@ -3468,7 +3453,6 @@ async fn set_session_config_option_emits_config_option_update_notification() {
             let (tx, mut rx) = mpsc::unbounded_channel();
             let conn_slot = std::rc::Rc::new(std::cell::RefCell::new(None));
             let agent = ZephAcpAgent::new(make_spawner(), tx, conn_slot, 4, 1800, None);
-            use acp::Agent as _;
             let sess = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                 .await

--- a/crates/zeph-acp/src/custom.rs
+++ b/crates/zeph-acp/src/custom.rs
@@ -463,6 +463,7 @@ async fn handle_working_dir_update(
 mod tests {
     use std::sync::Arc;
 
+    use acp::Agent as _;
     use agent_client_protocol as acp;
     use serde_json::value::RawValue;
     use tokio::sync::{mpsc, oneshot};
@@ -523,7 +524,6 @@ mod tests {
         local
             .run_until(async {
                 let (agent, _rx) = make_agent();
-                use acp::Agent as _;
                 let resp = agent
                     .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                     .await
@@ -545,7 +545,6 @@ mod tests {
         local
             .run_until(async {
                 let (agent, _rx) = make_agent();
-                use acp::Agent as _;
                 let resp = agent
                     .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                     .await
@@ -622,7 +621,6 @@ mod tests {
         local
             .run_until(async {
                 let (agent, _rx) = make_agent();
-                use acp::Agent as _;
                 let resp = agent
                     .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                     .await
@@ -652,7 +650,6 @@ mod tests {
         local
             .run_until(async {
                 let (agent, _rx) = make_agent();
-                use acp::Agent as _;
                 let resp = agent
                     .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                     .await
@@ -739,7 +736,6 @@ mod tests {
         local
             .run_until(async {
                 let (agent, _rx) = make_agent();
-                use acp::Agent as _;
                 let resp = agent
                     .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                     .await
@@ -905,7 +901,6 @@ mod tests {
         local
             .run_until(async {
                 let (agent, _rx) = make_agent();
-                use acp::Agent as _;
                 let req = acp::ExtRequest::new("unknown/custom/method", null_params());
                 let resp = agent.ext_method(req).await.unwrap();
                 // Default response for unknown method is JSON null.
@@ -920,7 +915,6 @@ mod tests {
         local
             .run_until(async {
                 let (agent, _rx) = make_agent();
-                use acp::Agent as _;
                 // Create a session first.
                 let new_resp = agent
                     .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
@@ -944,7 +938,6 @@ mod tests {
         local
             .run_until(async {
                 let (agent, _rx) = make_agent();
-                use acp::Agent as _;
                 let resp = agent
                     .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))
                     .await

--- a/crates/zeph-acp/src/lsp/acp_provider.rs
+++ b/crates/zeph-acp/src/lsp/acp_provider.rs
@@ -9,18 +9,14 @@
 //! client→agent. `AcpLspProvider` uses `conn.ext_method()` (the `acp::Client` trait)
 //! to send these outbound requests.
 //!
-//! # !Send constraint
-//!
-//! Holds a `ConnSlot` (`Rc<RefCell<...>>`). Must only be used inside a `LocalSet`.
-
 use std::sync::Arc;
 use std::time::Duration;
 
 use acp::Client as _;
 use agent_client_protocol as acp;
+use tokio::sync::{mpsc, oneshot};
 
 use crate::error::AcpError;
-use crate::transport::ConnSlot;
 
 use super::provider::LspProvider;
 use super::types::{
@@ -28,17 +24,24 @@ use super::types::{
     LspSymbolInformation,
 };
 
+enum LspRequest {
+    ExtMethod {
+        method: &'static str,
+        params: serde_json::Value,
+        reply: oneshot::Sender<Result<serde_json::Value, AcpError>>,
+    },
+}
+
 /// ACP-backed LSP provider that relays requests to the connected IDE.
 ///
 /// Created in `build_acp_context()` when the client advertises `meta["lsp"]`
 /// capability during `initialize()`. Falls back to `None` when the IDE does not
 /// support LSP extension methods.
-///
-/// **`!Send` constraint**: holds a `ConnSlot` (`Rc<RefCell<...>>`).
+#[derive(Clone)]
 pub struct AcpLspProvider {
-    conn_slot: ConnSlot,
     /// Whether the IDE advertised LSP support during `initialize()`.
     ide_supports_lsp: bool,
+    request_tx: mpsc::UnboundedSender<LspRequest>,
     /// Timeout for each LSP `ext_method` call.
     request_timeout: Duration,
     /// Maximum number of reference locations to return.
@@ -51,21 +54,28 @@ impl AcpLspProvider {
     /// Create a new provider.
     ///
     /// `ide_supports_lsp` should be set from `client_caps.meta["lsp"]`.
-    #[must_use]
-    pub fn new(
-        conn_slot: ConnSlot,
+    pub fn new<C>(
+        conn: std::rc::Rc<C>,
         ide_supports_lsp: bool,
         request_timeout_secs: u64,
         max_references: usize,
         max_workspace_symbols: usize,
-    ) -> Self {
-        Self {
-            conn_slot,
-            ide_supports_lsp,
-            request_timeout: Duration::from_secs(request_timeout_secs),
-            max_references,
-            max_workspace_symbols,
-        }
+    ) -> (Self, impl std::future::Future<Output = ()>)
+    where
+        C: acp::Client + 'static,
+    {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let handler = async move { run_lsp_handler(conn, rx).await };
+        (
+            Self {
+                ide_supports_lsp,
+                request_tx: tx,
+                request_timeout: Duration::from_secs(request_timeout_secs),
+                max_references,
+                max_workspace_symbols,
+            },
+            handler,
+        )
     }
 
     fn call_ext_method(
@@ -74,24 +84,49 @@ impl AcpLspProvider {
         params: serde_json::Value,
     ) -> impl std::future::Future<Output = Result<serde_json::Value, AcpError>> + '_ {
         let timeout = self.request_timeout;
-        // Borrow conn_slot inside the returned future (non-Send, LocalSet only).
         async move {
-            let conn = {
-                let guard = self.conn_slot.borrow();
-                guard.as_ref().cloned()
-            };
-            let conn = conn.ok_or(AcpError::ChannelClosed)?;
+            let (reply_tx, reply_rx) = oneshot::channel();
+            self.request_tx
+                .send(LspRequest::ExtMethod {
+                    method,
+                    params,
+                    reply: reply_tx,
+                })
+                .map_err(|_| AcpError::ChannelClosed)?;
 
-            let raw = serde_json::value::to_raw_value(&params)
-                .map_err(|e| AcpError::ClientError(e.to_string()))?;
-            let req = acp::ExtRequest::new(method, Arc::from(raw));
-
-            let result = tokio::time::timeout(timeout, conn.ext_method(req))
+            tokio::time::timeout(timeout, reply_rx)
                 .await
                 .map_err(|_| AcpError::ClientError("LSP request timed out".to_owned()))?
-                .map_err(|e| AcpError::ClientError(e.to_string()))?;
+                .map_err(|_| AcpError::ChannelClosed)?
+        }
+    }
+}
 
-            serde_json::from_str(result.0.get()).map_err(|e| AcpError::ClientError(e.to_string()))
+async fn run_lsp_handler<C>(conn: std::rc::Rc<C>, mut rx: mpsc::UnboundedReceiver<LspRequest>)
+where
+    C: acp::Client + 'static,
+{
+    while let Some(request) = rx.recv().await {
+        match request {
+            LspRequest::ExtMethod {
+                method,
+                params,
+                reply,
+            } => {
+                let result = async {
+                    let raw = serde_json::value::to_raw_value(&params)
+                        .map_err(|e| AcpError::ClientError(e.to_string()))?;
+                    let req = acp::ExtRequest::new(method, Arc::from(raw));
+                    let result = conn
+                        .ext_method(req)
+                        .await
+                        .map_err(|e| AcpError::ClientError(e.to_string()))?;
+                    serde_json::from_str(result.0.get())
+                        .map_err(|e| AcpError::ClientError(e.to_string()))
+                }
+                .await;
+                let _ = reply.send(result);
+            }
         }
     }
 }
@@ -102,7 +137,7 @@ impl LspProvider for AcpLspProvider {
     }
 
     fn is_available(&self) -> bool {
-        self.ide_supports_lsp && self.conn_slot.borrow().is_some()
+        self.ide_supports_lsp && !self.request_tx.is_closed()
     }
 
     async fn hover(

--- a/crates/zeph-acp/src/lsp/mcp_provider.rs
+++ b/crates/zeph-acp/src/lsp/mcp_provider.rs
@@ -6,12 +6,6 @@
 //! Maps `LspProvider` methods to `mcpls` tool calls via `McpManager::call_tool`.
 //! Detected at startup when `McpManager` has a server with a `"get_hover"` tool.
 //!
-//! # !Send constraint
-//!
-//! `McpManager` uses `Arc<RwLock<...>>` internally and is `Send + Sync`, but
-//! `McpLspProvider` is co-located in the `!Send` LSP module for API consistency.
-//! It may be called from a `LocalSet` context.
-
 use std::sync::Arc;
 
 use rmcp::model::RawContent;

--- a/crates/zeph-acp/src/lsp/provider.rs
+++ b/crates/zeph-acp/src/lsp/provider.rs
@@ -5,12 +5,9 @@
 //!
 //! # Thread safety
 //!
-//! `LspProvider` is intentionally `!Send`. Both implementations (`AcpLspProvider`
-//! and `McpLspProvider`) hold `Rc<RefCell<...>>` state (the ACP connection slot)
-//! and must only be used within a `tokio::task::LocalSet` context.
-//!
-//! For HTTP transport sessions that require `Send`, a separate wrapper would be
-//! needed (deferred to a follow-up).
+//! `LspProvider` implementations are `Send + Sync` so ACP sessions can run the
+//! agent loop on the multithreaded tokio scheduler while proxying IDE requests
+//! back through a dedicated ACP control-plane runtime.
 
 use crate::error::AcpError;
 
@@ -21,9 +18,7 @@ use super::types::{
 
 /// Abstract interface over IDE-proxied (ACP) and standalone (MCP) LSP sources.
 ///
-/// **`!Send` constraint**: implementations use `Rc<RefCell<...>>` and must only
-/// run inside a `LocalSet`. Do not use across thread boundaries.
-pub trait LspProvider {
+pub trait LspProvider: Send + Sync {
     /// Resolve hover information at the given 1-based position.
     fn hover(
         &self,

--- a/crates/zeph-acp/src/terminal.rs
+++ b/crates/zeph-acp/src/terminal.rs
@@ -1039,12 +1039,11 @@ mod tests {
                 // At least a terminal_exit notification must arrive.
                 let mut got_exit = false;
                 while let Ok(notif) = stream_rx.try_recv() {
-                    if let acp::SessionUpdate::ToolCallUpdate(update) = notif.update {
-                        if let Some(meta) = update.meta {
-                            if meta.contains_key("terminal_exit") {
-                                got_exit = true;
-                            }
-                        }
+                    if let acp::SessionUpdate::ToolCallUpdate(update) = notif.update
+                        && let Some(meta) = update.meta
+                        && meta.contains_key("terminal_exit")
+                    {
+                        got_exit = true;
                     }
                 }
                 assert!(got_exit, "expected terminal_exit notification");

--- a/crates/zeph-acp/src/transport/bridge.rs
+++ b/crates/zeph-acp/src/transport/bridge.rs
@@ -9,7 +9,7 @@ use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 #[cfg(feature = "acp-http")]
 use crate::agent::SendAgentSpawner;
 #[cfg(feature = "acp-http")]
-use crate::transport::{AcpServerConfig, stdio::serve_connection};
+use crate::transport::{AcpServerConfig, stdio::serve_connection_local};
 
 #[cfg(feature = "acp-http")]
 const BRIDGE_BUFFER_SIZE: usize = 64 * 1024;
@@ -32,7 +32,6 @@ pub fn spawn_acp_connection(
 ) -> (DuplexStream, DuplexStream) {
     let (client_w, agent_r) = tokio::io::duplex(BRIDGE_BUFFER_SIZE);
     let (agent_w, client_r) = tokio::io::duplex(BRIDGE_BUFFER_SIZE);
-
     std::thread::spawn(move || {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -41,7 +40,7 @@ pub fn spawn_acp_connection(
         rt.block_on(async {
             let writer = agent_w.compat_write();
             let reader = agent_r.compat();
-            if let Err(e) = serve_connection(spawner, server_config, writer, reader).await {
+            if let Err(e) = serve_connection_local(spawner, server_config, writer, reader).await {
                 tracing::error!("ACP bridge connection error: {e}");
             }
         });

--- a/crates/zeph-acp/src/transport/stdio.rs
+++ b/crates/zeph-acp/src/transport/stdio.rs
@@ -6,7 +6,8 @@ use std::rc::Rc;
 
 use acp::Client as _;
 use agent_client_protocol as acp;
-use futures::{AsyncRead, AsyncWrite, AsyncWriteExt};
+use futures::{AsyncRead, AsyncWrite, AsyncWriteExt as _};
+use tokio::io::duplex;
 use tokio::sync::mpsc;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
@@ -56,6 +57,8 @@ where
         .map_err(|e| AcpError::Transport(e.to_string()))
 }
 
+const BRIDGE_BUFFER_SIZE: usize = 64 * 1024;
+
 /// Run the ACP server over stdin/stdout until the connection closes.
 ///
 /// Uses `LocalSet` because the ACP SDK's `Agent` trait is `!Send`.
@@ -79,7 +82,69 @@ pub async fn serve_stdio(
 /// # Errors
 ///
 /// Returns `AcpError::Transport` if the underlying JSON-RPC I/O fails.
+///
+/// # Panics
+///
+/// Panics if the dedicated current-thread Tokio runtime for the ACP control plane
+/// cannot be created.
 pub async fn serve_connection<W, R>(
+    spawner: AgentSpawner,
+    server_config: AcpServerConfig,
+    mut writer: W,
+    mut reader: R,
+) -> Result<(), AcpError>
+where
+    W: AsyncWrite + Unpin + Send + 'static,
+    R: AsyncRead + Unpin + Send + 'static,
+{
+    let (client_w, agent_r) = duplex(BRIDGE_BUFFER_SIZE);
+    let (agent_w, client_r) = duplex(BRIDGE_BUFFER_SIZE);
+
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("acp stdio runtime");
+        rt.block_on(async move {
+            if let Err(e) = serve_connection_local(
+                spawner,
+                server_config,
+                agent_w.compat_write(),
+                agent_r.compat(),
+            )
+            .await
+            {
+                tracing::error!("ACP stdio connection error: {e}");
+            }
+        });
+    });
+
+    let mut bridge_writer = client_w.compat_write();
+    let mut bridge_reader = client_r.compat();
+    let inbound = async {
+        futures::io::copy(&mut reader, &mut bridge_writer)
+            .await
+            .map_err(|e| AcpError::Transport(e.to_string()))?;
+        bridge_writer
+            .close()
+            .await
+            .map_err(|e| AcpError::Transport(e.to_string()))
+    };
+    let outbound = async {
+        futures::io::copy(&mut bridge_reader, &mut writer)
+            .await
+            .map_err(|e| AcpError::Transport(e.to_string()))?;
+        writer
+            .close()
+            .await
+            .map_err(|e| AcpError::Transport(e.to_string()))
+    };
+
+    let _ = futures::future::try_join(inbound, outbound).await?;
+    Ok(())
+}
+
+pub(crate) async fn serve_connection_local<W, R>(
     spawner: AgentSpawner,
     server_config: AcpServerConfig,
     mut writer: W,

--- a/crates/zeph-acp/src/transport/tests.rs
+++ b/crates/zeph-acp/src/transport/tests.rs
@@ -24,7 +24,7 @@ fn shared_models(models: Vec<String>) -> SharedAvailableModels {
 fn noop_spawner() -> SendAgentSpawner {
     Arc::new(
         |_channel: LoopbackChannel, _ctx: Option<AcpContext>, _session_ctx: SessionContext| {
-            Box::pin(async {}) as Pin<Box<dyn std::future::Future<Output = ()> + 'static>>
+            Box::pin(async {}) as Pin<Box<dyn std::future::Future<Output = ()> + Send + 'static>>
         },
     )
 }

--- a/crates/zeph-acp/tests/integration.rs
+++ b/crates/zeph-acp/tests/integration.rs
@@ -61,6 +61,10 @@ fn make_server_config() -> AcpServerConfig {
     }
 }
 
+fn assert_send<T: Send>(value: T) -> T {
+    value
+}
+
 #[tokio::test]
 async fn initialize_handshake() {
     let (client_stream, server_stream) = duplex(65536);
@@ -111,7 +115,7 @@ async fn initialize_handshake() {
             // Server can exit normally after client disconnects
             let _ = res;
         }
-        _ = client_fut => {}
+        () = client_fut => {}
     }
 }
 
@@ -152,6 +156,19 @@ async fn stdio_ready_notification_is_first_frame() {
         }
         _ = client_fut => {}
     }
+}
+
+#[tokio::test]
+async fn serve_connection_future_is_send() {
+    let (_client_stream, server_stream) = duplex(65536);
+    let (server_read, server_write) = tokio::io::split(server_stream);
+    let fut = serve_connection(
+        make_echo_spawner(),
+        make_server_config(),
+        server_write.compat_write(),
+        server_read.compat(),
+    );
+    let _fut = assert_send(fut);
 }
 
 #[tokio::test]
@@ -211,8 +228,49 @@ async fn new_session_and_cancel() {
         res = server_fut => {
             let _ = res;
         }
-        _ = client_fut => {}
+        () = client_fut => {}
     }
+}
+
+#[tokio::test]
+async fn serve_connection_can_run_on_tokio_spawn() {
+    let (client_stream, server_stream) = duplex(65536);
+    let (client_read, client_write) = tokio::io::split(client_stream);
+    let (server_read, server_write) = tokio::io::split(server_stream);
+
+    let server = tokio::spawn(serve_connection(
+        make_echo_spawner(),
+        make_server_config(),
+        server_write.compat_write(),
+        server_read.compat(),
+    ));
+
+    let client_fut = async {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let (client_conn, io_fut) = acp::ClientSideConnection::new(
+                    NoopClient,
+                    client_write.compat_write(),
+                    client_read.compat(),
+                    |fut| {
+                        tokio::task::spawn_local(fut);
+                    },
+                );
+                tokio::task::spawn_local(async move {
+                    let _ = io_fut.await;
+                });
+
+                client_conn
+                    .initialize(acp::InitializeRequest::new(acp::ProtocolVersion::LATEST))
+                    .await
+                    .expect("initialize failed");
+            })
+            .await;
+    };
+
+    client_fut.await;
+    let _ = server.await.expect("server task panicked");
 }
 
 // ── E2E: Custom methods via JSON-RPC transport ───────────────────────────────
@@ -266,7 +324,7 @@ where
 
     tokio::select! {
         res = server_fut => { let _ = res; }
-        _ = client_fut => {}
+        () = client_fut => {}
     }
 }
 
@@ -477,7 +535,7 @@ async fn e2e_initialize_returns_auth_hint_and_load_session() {
 
     tokio::select! {
         res = server_fut => { let _ = res; }
-        _ = client_fut => {}
+        () = client_fut => {}
     }
 }
 

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -415,26 +415,74 @@ async fn spawn_acp_agent(
 ) {
     use std::sync::Arc;
 
+    let provider = d.provider.clone();
+    let registry = Arc::clone(&d.registry);
+    let matcher = d.matcher.clone();
+    let max_active_skills = d.max_active_skills;
+    let tool_executor = Arc::clone(&d.tool_executor);
+    let max_tool_iterations = d.max_tool_iterations;
+    let max_tool_retries = d.max_tool_retries;
+    let max_retry_duration_secs = d.max_retry_duration_secs;
+    let tool_repeat_threshold = d.tool_repeat_threshold;
+    let model_name = d.model_name.clone();
+    let embed_model = d.embed_model.clone();
+    let skill_paths = d.skill_paths.clone();
+    let memory = Arc::clone(&d.memory);
+    let history_limit = d.history_limit;
+    let recall_limit = d.recall_limit;
+    let summarization_threshold = d.summarization_threshold;
+    let budget_tokens = d.budget_tokens;
+    let compaction_threshold = d.compaction_threshold;
+    let compaction_preserve_tail = d.compaction_preserve_tail;
+    let prune_protect_tokens = d.prune_protect_tokens;
+    let deferred_apply_threshold = d.deferred_apply_threshold;
+    let shutdown_rx = d.shutdown_rx.clone();
+    let security = d.security.clone();
+    let timeouts = d.timeouts;
+    let redact_credentials = d.redact_credentials;
+    let tool_summarization = d.tool_summarization;
+    let overflow_config = d.overflow_config.clone();
+    let permission_policy = d.permission_policy.clone();
+    let config_path = d.config_path.clone();
+    let mcp_tools = d.mcp_tools.clone();
+    let mcp_registry = d.mcp_registry.clone();
+    let mcp_manager = Arc::clone(&d.mcp_manager);
+    let mcp_shared_tools = Arc::clone(&d.mcp_shared_tools);
+    let mcp_config = d.mcp_config.clone();
+    let learning = d.learning.clone();
+    let tool_call_cutoff = d.tool_call_cutoff;
+    let summary_provider = d.summary_provider.clone();
+    let judge_provider = d.judge_provider.clone();
+    let quarantine_provider = d.quarantine_provider.clone();
+    let debug_config = d.debug_config.clone();
+    let managed_skills_dir = zeph_core::bootstrap::managed_skills_dir();
+    let available_secrets: Vec<(String, Secret)> = d
+        .secrets
+        .iter()
+        .map(|(k, v)| (k.clone(), Secret::new(v.expose().to_owned())))
+        .collect();
+    let skill_reload_tx = d.skill_reload_tx.clone();
+    let config_reload_tx = d.config_reload_tx.clone();
+
     // Per-session receivers: each session gets its own mpsc::Receiver forwarded from the
     // shared broadcast senders. The CancellationToken is derived from the AcpContext cancel
     // signal so the forwarding task exits when the session ends (eviction, shutdown, or
     // natural completion). This satisfies critic finding S1.
     let adapter_cancel = zeph_memory::CancellationToken::new();
-    let reload_rx = broadcast_to_mpsc(d.skill_reload_tx.subscribe(), adapter_cancel.clone());
-    let config_reload_rx =
-        broadcast_to_mpsc(d.config_reload_tx.subscribe(), adapter_cancel.clone());
+    let reload_rx = broadcast_to_mpsc(skill_reload_tx.subscribe(), adapter_cancel.clone());
+    let config_reload_rx = broadcast_to_mpsc(config_reload_tx.subscribe(), adapter_cancel.clone());
 
     // Build tool executor: ACP executors take priority via CompositeExecutor (first-match-wins).
     // DynExecutor wraps Arc<dyn ErasedToolExecutor> so it satisfies Agent::new's ToolExecutor bound.
     // When conversation_id is None (store unavailable), memory_tools use id=0 which maps to no
     // persisted history — the tool calls succeed but return empty results.
     let memory_executor = zeph_core::memory_tools::MemoryToolExecutor::new(
-        Arc::clone(&d.memory),
+        Arc::clone(&memory),
         session_ctx
             .conversation_id
             .unwrap_or(zeph_memory::ConversationId(0)),
     );
-    let skill_loader_executor = zeph_core::SkillLoaderExecutor::new(Arc::clone(&d.registry));
+    let skill_loader_executor = zeph_core::SkillLoaderExecutor::new(Arc::clone(&registry));
     let (tool_executor, cancel_signal, provider_override, parent_tool_use_id) =
         if let Some(ctx) = acp_ctx {
             let cancel_signal = Arc::clone(&ctx.cancel_signal);
@@ -448,7 +496,7 @@ async fn spawn_acp_agent(
                 cancel_signal_clone.notified().await;
                 adapter_cancel_clone.cancel();
             });
-            let mut base: Arc<dyn ErasedToolExecutor> = Arc::clone(&d.tool_executor) as Arc<_>;
+            let mut base: Arc<dyn ErasedToolExecutor> = Arc::clone(&tool_executor) as Arc<_>;
             if let Some(fs) = ctx.file_executor {
                 // Suppress FileExecutor's read/write/glob when AcpFileExecutor is active.
                 // edit and grep remain available from FileExecutor (no ACP equivalents yet).
@@ -481,68 +529,64 @@ async fn spawn_acp_agent(
                 skill_loader_executor,
                 zeph_tools::CompositeExecutor::new(
                     memory_executor,
-                    zeph_tools::DynExecutor(Arc::clone(&d.tool_executor) as Arc<_>),
+                    zeph_tools::DynExecutor(Arc::clone(&tool_executor) as Arc<_>),
                 ),
             ));
             (zeph_tools::DynExecutor(base), None, None, None)
         };
 
     let mut agent = Agent::new_with_registry_arc(
-        d.provider.clone(),
+        provider,
         channel,
-        Arc::clone(&d.registry),
-        d.matcher.clone(),
-        d.max_active_skills,
+        Arc::clone(&registry),
+        matcher,
+        max_active_skills,
         tool_executor,
     )
-    .with_max_tool_iterations(d.max_tool_iterations)
-    .with_max_tool_retries(d.max_tool_retries)
-    .with_max_retry_duration_secs(d.max_retry_duration_secs)
-    .with_tool_repeat_threshold(d.tool_repeat_threshold)
-    .with_model_name(d.model_name.clone())
+    .with_max_tool_iterations(max_tool_iterations)
+    .with_max_tool_retries(max_tool_retries)
+    .with_max_retry_duration_secs(max_retry_duration_secs)
+    .with_tool_repeat_threshold(tool_repeat_threshold)
+    .with_model_name(model_name)
     .with_working_dir(session_ctx.working_dir.clone())
-    .with_embedding_model(d.embed_model.clone())
-    .with_skill_reload(d.skill_paths.clone(), reload_rx)
-    .with_managed_skills_dir(zeph_core::bootstrap::managed_skills_dir())
+    .with_embedding_model(embed_model)
+    .with_skill_reload(skill_paths, reload_rx)
+    .with_managed_skills_dir(managed_skills_dir)
     .with_context_budget(
-        d.budget_tokens,
+        budget_tokens,
         0.20,
-        d.compaction_threshold,
-        d.compaction_preserve_tail,
-        d.prune_protect_tokens,
+        compaction_threshold,
+        compaction_preserve_tail,
+        prune_protect_tokens,
     )
-    .with_deferred_apply_threshold(d.deferred_apply_threshold)
-    .with_shutdown(d.shutdown_rx.clone())
-    .with_security(d.security.clone(), d.timeouts)
-    .with_redact_credentials(d.redact_credentials)
-    .with_tool_summarization(d.tool_summarization)
-    .with_overflow_config(d.overflow_config.clone())
-    .with_permission_policy(d.permission_policy.clone())
-    .with_config_reload(d.config_path.clone(), config_reload_rx)
+    .with_deferred_apply_threshold(deferred_apply_threshold)
+    .with_shutdown(shutdown_rx)
+    .with_security(security, timeouts)
+    .with_redact_credentials(redact_credentials)
+    .with_tool_summarization(tool_summarization)
+    .with_overflow_config(overflow_config)
+    .with_permission_policy(permission_policy)
+    .with_config_reload(config_path, config_reload_rx)
     .with_mcp(
-        d.mcp_tools.clone(),
-        d.mcp_registry.clone(),
-        Some(Arc::clone(&d.mcp_manager)),
-        &d.mcp_config,
+        mcp_tools,
+        mcp_registry,
+        Some(Arc::clone(&mcp_manager)),
+        &mcp_config,
     )
-    .with_mcp_shared_tools(Arc::clone(&d.mcp_shared_tools))
-    .with_learning(d.learning.clone())
-    .with_tool_call_cutoff(d.tool_call_cutoff)
-    .with_available_secrets(
-        d.secrets
-            .iter()
-            .map(|(k, v)| (k.clone(), Secret::new(v.expose().to_owned()))),
-    );
+    .with_mcp_shared_tools(mcp_shared_tools)
+    .with_learning(learning)
+    .with_tool_call_cutoff(tool_call_cutoff)
+    .with_available_secrets(available_secrets);
 
     // Apply per-session memory only when a ConversationId was successfully allocated.
     // When None (store unavailable at session creation), the agent operates without persistent history.
     if let Some(cid) = session_ctx.conversation_id {
         agent = agent.with_memory(
-            Arc::clone(&d.memory),
+            Arc::clone(&memory),
             cid,
-            d.history_limit,
-            d.recall_limit,
-            d.summarization_threshold,
+            history_limit,
+            recall_limit,
+            summarization_threshold,
         );
     }
 
@@ -558,31 +602,32 @@ async fn spawn_acp_agent(
         agent = agent.with_parent_tool_use_id(parent_id);
     }
 
-    if let Some(sp) = d.summary_provider.clone() {
+    if let Some(sp) = summary_provider {
         agent = agent.with_summary_provider(sp);
     }
 
-    if let Some(jp) = d.judge_provider.clone() {
+    if let Some(jp) = judge_provider {
         agent = agent.with_judge_provider(jp);
     }
 
-    agent = agent_setup::apply_quarantine_provider(agent, d.quarantine_provider.clone());
+    agent = agent_setup::apply_quarantine_provider(agent, quarantine_provider);
 
-    if d.debug_config.enabled {
+    if debug_config.enabled {
         // Use session_id as a subdirectory prefix so concurrent sessions never share the same
         // timestamped directory and collide on file names (I2).
-        let session_dump_dir = d
-            .debug_config
+        let session_dump_dir = debug_config
             .output_dir
             .join(session_ctx.session_id.to_string());
         match zeph_core::debug_dump::DebugDumper::new(
             session_dump_dir.as_path(),
-            d.debug_config.format,
+            debug_config.format,
         ) {
             Ok(dumper) => agent = agent.with_debug_dumper(dumper),
             Err(e) => tracing::warn!(error = %e, "debug dump initialization failed"),
         }
     }
+
+    drop(d);
 
     if let Err(e) = agent.load_history().await {
         tracing::error!("failed to load agent history: {e:#}");
@@ -985,9 +1030,7 @@ pub(crate) async fn run_acp_server(
 
     let spawner: zeph_acp::AgentSpawner = Arc::new(move |channel, acp_ctx, session_ctx| {
         let shared = Arc::clone(&shared);
-        Box::pin(async move {
-            Box::pin(spawn_acp_agent(shared, channel, acp_ctx, session_ctx)).await;
-        })
+        Box::pin(spawn_acp_agent(shared, channel, acp_ctx, session_ctx))
     });
 
     zeph_acp::serve_stdio(spawner, server_config).await?;
@@ -1202,7 +1245,7 @@ mod tests {
 
         let orig = std::env::current_dir().unwrap();
         std::env::set_current_dir(tmp.path()).unwrap();
-        let result = collect_project_rules(&[skill_file.clone()]);
+        let result = collect_project_rules(std::slice::from_ref(&skill_file));
         std::env::set_current_dir(orig).unwrap();
         assert_eq!(result.len(), 2);
         let names: Vec<_> = result

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1084,24 +1084,30 @@ mod tests {
 
     #[test]
     fn resolve_logging_config_no_cli_with_config_file_uses_config() {
-        let mut base = zeph_core::config::LoggingConfig::default();
-        base.file = "/var/log/zeph.log".into();
+        let base = zeph_core::config::LoggingConfig {
+            file: "/var/log/zeph.log".into(),
+            ..Default::default()
+        };
         let result = resolve_logging_config(base, None);
         assert_eq!(result.file, "/var/log/zeph.log");
     }
 
     #[test]
     fn resolve_logging_config_cli_empty_str_disables_logging() {
-        let mut base = zeph_core::config::LoggingConfig::default();
-        base.file = "/var/log/zeph.log".into();
+        let base = zeph_core::config::LoggingConfig {
+            file: "/var/log/zeph.log".into(),
+            ..Default::default()
+        };
         let result = resolve_logging_config(base, Some(""));
         assert_eq!(result.file, "");
     }
 
     #[test]
     fn resolve_logging_config_cli_path_overrides_config() {
-        let mut base = zeph_core::config::LoggingConfig::default();
-        base.file = "/var/log/zeph.log".into();
+        let base = zeph_core::config::LoggingConfig {
+            file: "/var/log/zeph.log".into(),
+            ..Default::default()
+        };
         let result = resolve_logging_config(base, Some("/tmp/custom.log"));
         assert_eq!(result.file, "/tmp/custom.log");
     }

--- a/src/scheduler_executor.rs
+++ b/src/scheduler_executor.rs
@@ -461,9 +461,12 @@ mod tests {
     }
 
     fn make_call(tool_id: &str, params: serde_json::Value) -> ToolCall {
+        let serde_json::Value::Object(params) = params else {
+            panic!("scheduler test params must be a JSON object");
+        };
         ToolCall {
             tool_id: tool_id.to_owned(),
-            params: params.as_object().unwrap().clone(),
+            params,
         }
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 
 use zeph_core::agent::Agent;
 use zeph_core::channel::{Channel, ChannelError, ChannelMessage};
-use zeph_core::config::{Config, ProviderKind, SecurityConfig, TimeoutConfig};
+use zeph_core::config::{AutonomyLevel, Config, ProviderKind, SecurityConfig, TimeoutConfig};
 use zeph_llm::any::AnyProvider;
 use zeph_llm::mock::MockProvider;
 use zeph_memory::semantic::SemanticMemory;
@@ -1095,7 +1095,7 @@ async fn agent_redaction_enabled() {
 
     let security = SecurityConfig {
         redact_secrets: true,
-        autonomy_level: Default::default(),
+        autonomy_level: AutonomyLevel::default(),
         ..Default::default()
     };
 
@@ -1127,7 +1127,7 @@ async fn agent_redaction_disabled() {
 
     let security = SecurityConfig {
         redact_secrets: false,
-        autonomy_level: Default::default(),
+        autonomy_level: AutonomyLevel::default(),
         ..Default::default()
     };
 
@@ -1302,7 +1302,7 @@ async fn agent_with_security_config() {
 
     let security = SecurityConfig {
         redact_secrets: true,
-        autonomy_level: Default::default(),
+        autonomy_level: AutonomyLevel::default(),
         ..Default::default()
     };
     let timeouts = TimeoutConfig {
@@ -1502,7 +1502,7 @@ async fn agent_streaming_redaction() {
 
     let security = SecurityConfig {
         redact_secrets: true,
-        autonomy_level: Default::default(),
+        autonomy_level: AutonomyLevel::default(),
         ..Default::default()
     };
 
@@ -1537,7 +1537,7 @@ async fn agent_redaction_in_tool_output() {
 
     let security = SecurityConfig {
         redact_secrets: true,
-        autonomy_level: Default::default(),
+        autonomy_level: AutonomyLevel::default(),
         ..Default::default()
     };
 

--- a/tests/orchestration_integration.rs
+++ b/tests/orchestration_integration.rs
@@ -4,10 +4,10 @@
 //! End-to-end orchestration integration tests (Phase 7, #1242).
 //!
 //! These tests exercise the full orchestration pipeline:
-//!   plan → DagScheduler tick loop → LlmAggregator
+//!   plan → `DagScheduler` tick loop → `LlmAggregator`
 //!
 //! Run with:
-//!   cargo nextest run --test orchestration_integration
+//!   cargo nextest run --test `orchestration_integration`
 
 mod orchestration_integration {
     use zeph_core::config::OrchestrationConfig;
@@ -30,7 +30,7 @@ mod orchestration_integration {
             permissions: SubAgentPermissions::default(),
             skills: SkillFilter::default(),
             system_prompt: String::new(),
-            hooks: Default::default(),
+            hooks: zeph_core::subagent::SubagentHooks::default(),
             memory: None,
             source: None,
             file_path: None,
@@ -66,7 +66,7 @@ mod orchestration_integration {
     /// Build a linear 2-task graph: task 0 → task 1.
     ///
     /// `TaskId(u32)` has a `pub(crate)` field, so we construct the dependency
-    /// list via serde_json deserialization rather than direct construction.
+    /// list via `serde_json` deserialization rather than direct construction.
     fn linear_2_task_graph(failure_strategy: Option<FailureStrategy>) -> TaskGraph {
         let mut graph = TaskGraph::new("test goal");
         let mut t0 = TaskNode::new(0, "task-0", "do first thing");
@@ -82,7 +82,7 @@ mod orchestration_integration {
 
     /// Drive the scheduler to completion by simulating agent execution.
     ///
-    /// For each `Spawn` action, `outcome_fn` is called with the task_id to produce
+    /// For each `Spawn` action, `outcome_fn` is called with the `task_id` to produce
     /// the `TaskOutcome`. Returns the terminal `GraphStatus` when `Done` is emitted.
     async fn drive_scheduler<F>(scheduler: &mut DagScheduler, mut outcome_fn: F) -> GraphStatus
     where


### PR DESCRIPTION
Summary
- Make `ZephAcpAgent` and its diagnostics cache shareable via `Arc<RwLock<_>>`, accept a runtime handle, and use it instead of `spawn_local` so ACP sessions stay `Send`/`Sync` (`crates/zeph-acp/src/agent/mod.rs`).
- Rework `AcpLspProvider` into a `Send + Sync` wrapper that proxies requests through a dedicated handler task and keeps MCP/ACP provider traits aligned (`crates/zeph-acp/src/lsp/acp_provider.rs`, `provider.rs`).
- Bridge stdio connections through a new local-serving helper so the ACP bridge can keep using the agent runtime (`crates/zeph-acp/src/transport/bridge.rs`, `stdio.rs`).