### PR TITLE
fix(scheduler): initialize scheduler in ACP mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Scheduler not initialized in ACP mode — tick loop and scheduler tool now available in ACP sessions (#1599)
 - `TrustGateExecutor::check_trust()` was calling `policy.check()` for all tool IDs in Supervised mode, causing `ConfirmationRequired` for any MCP/LSP tool without explicit permission rules (since `PermissionPolicy::from_legacy()` only populates rules for `"bash"`). Non-system tools without explicit rules now return `Allow` by default; system tools (`bash`) always go through `policy.check()` via the new `POLICY_ENFORCED_TOOLS` constant. Fixes #1544.
 - `process_response_native_tools()` did not handle `ToolError::ConfirmationRequired` — the error was collapsed into `[error] command requires confirmation: …` and returned to the LLM. The native tool execution loop now calls `channel.confirm()` on `ConfirmationRequired`, re-executes via `execute_tool_call_confirmed_erased()` on approval, and returns `[cancelled by user]` (not an error) on denial. Added `execute_tool_call_confirmed` to `ToolExecutor` and `ErasedToolExecutor` traits; `TrustGateExecutor` overrides it to bypass the permission check while still enforcing `Blocked`/`Quarantined` trust levels. Fixes #1545.
 

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -149,6 +149,15 @@ struct SharedAgentDeps {
     acp_project_rules: Vec<PathBuf>,
     /// Debug dump configuration from `[debug]` config section.
     debug_config: zeph_core::config::DebugConfig,
+    /// Scheduler executor shared across sessions. Initialized once at startup.
+    #[cfg(feature = "scheduler")]
+    scheduler_executor: Option<std::sync::Arc<crate::scheduler_executor::SchedulerExecutor>>,
+    /// Broadcast sender for scheduler update notifications (`auto_update_check`).
+    #[cfg(feature = "scheduler")]
+    scheduler_update_tx: Option<tokio::sync::broadcast::Sender<String>>,
+    /// Broadcast sender for custom task notifications.
+    #[cfg(feature = "scheduler")]
+    scheduler_custom_tx: Option<tokio::sync::broadcast::Sender<String>>,
 }
 
 /// Forward events from a `broadcast::Receiver` to an `mpsc::Receiver`.
@@ -326,6 +335,54 @@ async fn build_acp_deps(
         });
     }
 
+    #[cfg(feature = "scheduler")]
+    let (scheduler_executor, scheduler_update_tx, scheduler_custom_tx) = {
+        #[cfg(feature = "experiments")]
+        let exp_deps = {
+            use std::sync::Arc;
+            if config.experiments.enabled && config.experiments.schedule.enabled {
+                let p = provider.clone();
+                Some((Arc::new(p), Some(Arc::clone(&memory))))
+            } else {
+                None
+            }
+        };
+        #[cfg(not(feature = "experiments"))]
+        let exp_deps: Option<(
+            std::sync::Arc<zeph_llm::any::AnyProvider>,
+            Option<std::sync::Arc<zeph_memory::semantic::SemanticMemory>>,
+        )> = None;
+
+        match crate::scheduler::init_scheduler(config, shutdown_rx.clone(), exp_deps).await {
+            Some(result) => {
+                let exec = std::sync::Arc::new(result.executor);
+                let mut custom_rx = result.custom_rx;
+                let (ctx, _) = tokio::sync::broadcast::channel::<String>(broadcast_cap);
+                let ctx_clone = ctx.clone();
+                tokio::spawn(async move {
+                    while let Some(ev) = custom_rx.recv().await {
+                        let _ = ctx_clone.send(ev);
+                    }
+                });
+                let update_tx = if let Some(mut update_rx) = result.update_rx {
+                    let (utx, _) = tokio::sync::broadcast::channel::<String>(broadcast_cap);
+                    let utx_clone = utx.clone();
+                    tokio::spawn(async move {
+                        while let Some(ev) = update_rx.recv().await {
+                            let _ = utx_clone.send(ev);
+                        }
+                    });
+                    Some(utx)
+                } else {
+                    None
+                };
+                let (update_tx, custom_tx) = (update_tx, Some(ctx));
+                (Some(exec), update_tx, custom_tx)
+            }
+            None => (None, None, None),
+        }
+    };
+
     let deps = SharedAgentDeps {
         provider,
         registry,
@@ -406,6 +463,12 @@ async fn build_acp_deps(
         acp_provider_factory: Some(build_acp_provider_factory(config)),
         acp_project_rules,
         debug_config: config.debug.clone(),
+        #[cfg(feature = "scheduler")]
+        scheduler_executor,
+        #[cfg(feature = "scheduler")]
+        scheduler_update_tx,
+        #[cfg(feature = "scheduler")]
+        scheduler_custom_tx,
     };
 
     let keepalive: Box<dyn std::any::Any> = Box::new((skill_watcher, config_watcher));
@@ -479,6 +542,12 @@ async fn spawn_acp_agent(
         .collect();
     let skill_reload_tx = d.skill_reload_tx.clone();
     let config_reload_tx = d.config_reload_tx.clone();
+    #[cfg(feature = "scheduler")]
+    let scheduler_executor = d.scheduler_executor.as_ref().map(std::sync::Arc::clone);
+    #[cfg(feature = "scheduler")]
+    let scheduler_update_tx = d.scheduler_update_tx.clone();
+    #[cfg(feature = "scheduler")]
+    let scheduler_custom_tx = d.scheduler_custom_tx.clone();
 
     // Per-session receivers: each session gets its own mpsc::Receiver forwarded from the
     // shared broadcast senders. The CancellationToken is derived from the AcpContext cancel
@@ -487,6 +556,14 @@ async fn spawn_acp_agent(
     let adapter_cancel = zeph_memory::CancellationToken::new();
     let reload_rx = broadcast_to_mpsc(skill_reload_tx.subscribe(), adapter_cancel.clone());
     let config_reload_rx = broadcast_to_mpsc(config_reload_tx.subscribe(), adapter_cancel.clone());
+    #[cfg(feature = "scheduler")]
+    let scheduler_update_rx = scheduler_update_tx
+        .as_ref()
+        .map(|tx| broadcast_to_mpsc(tx.subscribe(), adapter_cancel.clone()));
+    #[cfg(feature = "scheduler")]
+    let scheduler_custom_rx = scheduler_custom_tx
+        .as_ref()
+        .map(|tx| broadcast_to_mpsc(tx.subscribe(), adapter_cancel.clone()));
 
     // Build tool executor: ACP executors take priority via CompositeExecutor (first-match-wins).
     // DynExecutor wraps Arc<dyn ErasedToolExecutor> so it satisfies Agent::new's ToolExecutor bound.
@@ -539,8 +616,9 @@ async fn spawn_acp_agent(
                 parent_tool_use_id,
             )
         } else {
-            // No AcpContext: the adapter forwarding tasks run until adapter_cancel.cancel() is
-            // called explicitly at function end (line below), or until the mpsc sender is dropped.
+            // No AcpContext: the adapter forwarding tasks (skill reload, config reload, and
+            // scheduler receivers) run until adapter_cancel.cancel() is called explicitly at
+            // function end (line below), or until the mpsc sender is dropped.
             let base: Arc<dyn ErasedToolExecutor> = Arc::new(zeph_tools::CompositeExecutor::new(
                 skill_loader_executor,
                 zeph_tools::CompositeExecutor::new(
@@ -593,6 +671,21 @@ async fn spawn_acp_agent(
     .with_learning(learning)
     .with_tool_call_cutoff(tool_call_cutoff)
     .with_available_secrets(available_secrets);
+
+    // Wire scheduler per session: apply update/custom receivers and add executor.
+    #[cfg(feature = "scheduler")]
+    {
+        if let Some(rx) = scheduler_update_rx {
+            agent = agent.with_update_notifications(rx);
+        }
+        if let Some(rx) = scheduler_custom_rx {
+            agent = agent.with_custom_task_rx(rx);
+        }
+        if let Some(sched_exec) = scheduler_executor {
+            agent = agent
+                .add_tool_executor(crate::scheduler_executor::DynSchedulerExecutor(sched_exec));
+        }
+    }
 
     // Apply per-session memory only when a ConversationId was successfully allocated.
     // When None (store unavailable at session creation), the agent operates without persistent history.

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -252,34 +252,35 @@ fn load_config_tasks(
     }
 }
 
+/// Scheduler init result: executor plus optional channel receivers for agent wiring.
+#[cfg(feature = "scheduler")]
+pub(crate) struct SchedulerInitResult {
+    pub(crate) executor: SchedulerExecutor,
+    /// Present when `auto_update_check` is enabled.
+    pub(crate) update_rx: Option<mpsc::Receiver<String>>,
+    pub(crate) custom_rx: mpsc::Receiver<String>,
+}
+
+/// Initialize the scheduler: open stores, build executor, spawn tick loop.
+///
+/// Does NOT touch any `Agent` — returns raw channel receivers so callers can apply them to
+/// whichever `Agent<C>` they control. Returns `None` when the scheduler is disabled.
 #[cfg(feature = "scheduler")]
 #[allow(clippy::too_many_lines)]
-pub(crate) async fn bootstrap_scheduler<C>(
-    agent: zeph_core::agent::Agent<C>,
+pub(crate) async fn init_scheduler(
     config: &Config,
     shutdown_rx: watch::Receiver<bool>,
     experiment_deps: Option<(Arc<AnyProvider>, Option<Arc<SemanticMemory>>)>,
-) -> (zeph_core::agent::Agent<C>, Option<SchedulerExecutor>)
-where
-    C: zeph_core::channel::Channel,
-{
+) -> Option<SchedulerInitResult> {
     if !config.scheduler.enabled {
-        if config.agent.auto_update_check {
-            let (tx, rx) = tokio::sync::mpsc::channel(1);
-            let handler = UpdateCheckHandler::new(env!("CARGO_PKG_VERSION"), tx);
-            tokio::spawn(async move {
-                let _ = handler.execute(&serde_json::Value::Null).await;
-            });
-            return (agent.with_update_notifications(rx), None);
-        }
-        return (agent, None);
+        return None;
     }
 
     let store = match JobStore::open(&config.memory.sqlite_path).await {
         Ok(s) => s,
         Err(e) => {
             tracing::warn!("scheduler: failed to open store: {e}");
-            return (agent, None);
+            return None;
         }
     };
 
@@ -288,7 +289,7 @@ where
         Ok(s) => s,
         Err(e) => {
             tracing::warn!("scheduler: failed to open second store handle: {e}");
-            return (agent, None);
+            return None;
         }
     };
 
@@ -337,7 +338,7 @@ where
     #[cfg(not(feature = "experiments"))]
     let _ = experiment_deps;
 
-    if config.agent.auto_update_check {
+    let update_rx = if config.agent.auto_update_check {
         let (update_tx, update_rx) = tokio::sync::mpsc::channel(4);
         let update_task = match ScheduledTask::new(
             "update_check",
@@ -348,7 +349,7 @@ where
             Ok(t) => t,
             Err(e) => {
                 tracing::warn!("scheduler: invalid update_check cron: {e}");
-                return (agent, None);
+                return None;
             }
         };
         scheduler.add_task(update_task);
@@ -356,31 +357,13 @@ where
             &TaskKind::UpdateCheck,
             Box::new(UpdateCheckHandler::new(
                 env!("CARGO_PKG_VERSION"),
-                update_tx.clone(),
+                update_tx,
             )),
         );
-        scheduler.register_handler(
-            &TaskKind::Custom("custom".to_owned()),
-            Box::new(CustomTaskHandler::new(custom_tx)),
-        );
-
-        if let Err(e) = scheduler.init().await {
-            tracing::warn!("scheduler init failed: {e}");
-            return (agent, None);
-        }
-
-        let tick_secs = config.scheduler.tick_interval_secs;
-        tokio::spawn(async move { scheduler.run_with_interval(tick_secs).await });
-        tracing::info!("scheduler started");
-
-        let executor = SchedulerExecutor::new(task_tx, store_arc);
-        return (
-            agent
-                .with_update_notifications(update_rx)
-                .with_custom_task_rx(custom_rx),
-            Some(executor),
-        );
-    }
+        Some(update_rx)
+    } else {
+        None
+    };
 
     scheduler.register_handler(
         &TaskKind::Custom("custom".to_owned()),
@@ -389,7 +372,7 @@ where
 
     if let Err(e) = scheduler.init().await {
         tracing::warn!("scheduler init failed: {e}");
-        return (agent, None);
+        return None;
     }
 
     let tick_secs = config.scheduler.tick_interval_secs;
@@ -397,7 +380,49 @@ where
     tracing::info!("scheduler started");
 
     let executor = SchedulerExecutor::new(task_tx, store_arc);
-    (agent.with_custom_task_rx(custom_rx), Some(executor))
+    Some(SchedulerInitResult {
+        executor,
+        update_rx,
+        custom_rx,
+    })
+}
+
+#[cfg(feature = "scheduler")]
+#[allow(clippy::too_many_lines)]
+pub(crate) async fn bootstrap_scheduler<C>(
+    agent: zeph_core::agent::Agent<C>,
+    config: &Config,
+    shutdown_rx: watch::Receiver<bool>,
+    experiment_deps: Option<(Arc<AnyProvider>, Option<Arc<SemanticMemory>>)>,
+) -> (zeph_core::agent::Agent<C>, Option<SchedulerExecutor>)
+where
+    C: zeph_core::channel::Channel,
+{
+    if !config.scheduler.enabled {
+        if config.agent.auto_update_check {
+            let (tx, rx) = tokio::sync::mpsc::channel(1);
+            let handler = UpdateCheckHandler::new(env!("CARGO_PKG_VERSION"), tx);
+            tokio::spawn(async move {
+                let _ = handler.execute(&serde_json::Value::Null).await;
+            });
+            return (agent.with_update_notifications(rx), None);
+        }
+        return (agent, None);
+    }
+
+    let Some(result) = init_scheduler(config, shutdown_rx, experiment_deps).await else {
+        return (agent, None);
+    };
+
+    let agent = if let Some(rx) = result.update_rx {
+        agent
+            .with_update_notifications(rx)
+            .with_custom_task_rx(result.custom_rx)
+    } else {
+        agent.with_custom_task_rx(result.custom_rx)
+    };
+
+    (agent, Some(result.executor))
 }
 
 #[cfg(all(test, feature = "scheduler"))]

--- a/src/scheduler_executor.rs
+++ b/src/scheduler_executor.rs
@@ -440,6 +440,23 @@ impl ToolExecutor for SchedulerExecutor {
     }
 }
 
+/// `Arc`-wrapper so `SchedulerExecutor` can be shared across ACP sessions without `Clone`.
+pub(crate) struct DynSchedulerExecutor(pub(crate) std::sync::Arc<SchedulerExecutor>);
+
+impl ToolExecutor for DynSchedulerExecutor {
+    async fn execute(&self, response: &str) -> Result<Option<ToolOutput>, ToolError> {
+        self.0.execute(response).await
+    }
+
+    fn tool_definitions(&self) -> Vec<ToolDef> {
+        self.0.tool_definitions()
+    }
+
+    async fn execute_tool_call(&self, call: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
+        self.0.execute_tool_call(call).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;


### PR DESCRIPTION
## Summary

- Wire `bootstrap_scheduler` into the ACP code path so that the scheduler tick loop starts and the `scheduler` tool is available in ACP sessions (Zed, Helix, VS Code)
- Extract `init_scheduler()` from `bootstrap_scheduler` to separate tick-loop/executor startup from Agent wiring; `runner.rs` is unchanged
- Add `DynSchedulerExecutor` wrapper for `Arc`-based sharing across ACP sessions
- Distribute per-session scheduler receivers via existing `broadcast_to_mpsc` pattern (same as skill/config reload)

Closes #1599

## Test plan

- [ ] `cargo +nightly fmt --check` passes
- [ ] `cargo clippy --workspace --features full -- -D warnings` passes (0 warnings)
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --features full --lib --bins` — 5136 passed
- [ ] ACP session: `scheduler` tool present in tool list
- [ ] ACP session: periodic task created via `scheduler` skill fires on schedule