### PR TITLE
refactor(orchestrator): downgrade noisy fallback log to debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `ModelOrchestrator` no longer logs `INFO falling back to default provider` on every request when no router chain is configured (the normal orchestrator path). The message is now `DEBUG` when no chain providers were attempted; `INFO` is kept only when a chain was configured but all providers failed — the genuine fallback case. Closes #1484.
+
 - `DagScheduler::wait_event()` busy-spun at 250ms when `SubAgentManager` was saturated. Replaced the fixed `deferral_backoff` sleep with exponential backoff (250ms → 500ms → 1s → 2s → 4s, capped at 5s) that resets on the first successful spawn. Eliminates log flood and CPU waste when the concurrency limit is reached during plan execution (#1618).
 - HTTP 503 (`SERVICE_UNAVAILABLE`) responses are now retried by `send_with_retry()` alongside 429, benefiting all LLM providers (#1593)
 

--- a/crates/zeph-llm/src/orchestrator/mod.rs
+++ b/crates/zeph-llm/src/orchestrator/mod.rs
@@ -246,7 +246,17 @@ impl ModelOrchestrator {
                 "Falling back to default provider {}",
                 self.default_provider
             ));
-            tracing::info!("falling back to default provider {}", self.default_provider);
+            if tried.is_empty() {
+                tracing::debug!(
+                    "no chain configured, routing to default provider {}",
+                    self.default_provider
+                );
+            } else {
+                tracing::info!(
+                    "all chain providers failed, falling back to default provider {}",
+                    self.default_provider
+                );
+            }
             match provider.chat(messages).await {
                 Ok(response) => {
                     *self.last_used_provider.lock().unwrap() = Some(self.default_provider.clone());
@@ -388,10 +398,17 @@ impl ModelOrchestrator {
                 "Falling back to default provider {}",
                 self.default_provider
             ));
-            tracing::info!(
-                "falling back to default provider {} for stream",
-                self.default_provider
-            );
+            if tried.is_empty() {
+                tracing::debug!(
+                    "no chain configured, routing to default provider {} for stream",
+                    self.default_provider
+                );
+            } else {
+                tracing::info!(
+                    "all chain providers failed, falling back to default provider {} for stream",
+                    self.default_provider
+                );
+            }
             match provider.chat_stream(messages).await {
                 Ok(stream) => {
                     *self.last_used_provider.lock().unwrap() = Some(self.default_provider.clone());


### PR DESCRIPTION
## Summary

- When `provider = "orchestrator"` with no router chain, routing to the default provider is the normal code path. The `INFO falling back to default provider` log fired on every request, obscuring real fallback events in logs.
- `tracing::info!` is now `tracing::debug!` when `tried.is_empty()` (no chain providers were attempted).
- `tracing::info!` is preserved when a chain was configured but all providers failed — the actual fallback scenario.
- Applied to both the `chat_with_fallback` and `chat_stream_with_fallback` code paths (mod.rs lines 249 and 391).

## Test plan

- [ ] `cargo clippy --workspace --features full -- -D warnings` passes
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --features full --lib --bins` — 5181 tests passed
- [ ] With `provider = "orchestrator"` and no chain, DEBUG-level log appears instead of INFO
- [ ] With a chain configured and all providers failing, INFO-level log is preserved

Closes #1484