### PR TITLE
feat(scheduler): accept standard 5-field cron expressions

### DIFF
--- a/.zeph/skills/scheduler/SKILL.md
+++ b/.zeph/skills/scheduler/SKILL.md
@@ -57,7 +57,8 @@ tasks at a specific future time, and `cancel_task` to remove a scheduled task.
 
 ## Cron format
 
-`sec min hour day month weekday` (6 fields, uses the `cron` crate).
+Both standard 5-field (`min hour day month weekday`) and 6-field (`sec min hour day month weekday`)
+expressions are accepted. When 5 fields are given, seconds default to 0.
 
 Built-in kinds: `memory_cleanup`, `skill_refresh`, `health_check`, `update_check`, `custom`.
 
@@ -98,5 +99,5 @@ If the user says "do X at time", use pattern 2 (`X`).
 ## Validation rules
 
 - `run_at` must resolve to a future time.
-- `cron` must be a valid 6-field cron expression.
+- `cron` must be a valid 5 or 6-field cron expression.
 - Task names must be unique. Scheduling with an existing name updates the task.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **5-field cron expression support in scheduler**: `normalize_cron_expr()` now accepts standard 5-field cron expressions (e.g. `*/5 * * * *`) by auto-prepending `0` for the seconds field. All three parse sites (`ScheduledTask::periodic`, `SchedulerExecutor::schedule_periodic`, `load_config_tasks`) and the DB persistence path now use the normalized 6-field form. Closes #1422.
+
 - **Chunked edge loading in community detection**: `detect_communities` now loads edges in configurable chunks (keyset pagination via `WHERE id > ?1 LIMIT ?2`) instead of loading all edges at once, reducing peak memory proportional to chunk size on large graphs. Configurable via `GraphConfig.lpa_edge_chunk_size` (default 10,000); `chunk_size = 0` falls back to the legacy full-stream path. Closes #1259.
 
 - **Gemini provider** (Phase 2): SSE streaming via `streamGenerateContent?alt=sse`. `chat_stream()` now produces `StreamChunk::Content` chunks; Gemini 2.5 thinking parts (`thought: true`) are emitted as `StreamChunk::Thinking`. `supports_streaming()` returns `true`. `GeminiProvider` gains `status_tx: Option<StatusTx>` field with `with_status_tx()`/`set_status_tx()` builders; `AnyProvider::set_status_tx()` now propagates the sender to the Gemini arm. Both streaming and non-streaming paths use `status_tx` for retry notifications. API key stays in the `x-goog-api-key` header (never in URL query params). Part of epic #1592, closes #1594.

--- a/crates/zeph-scheduler/README.md
+++ b/crates/zeph-scheduler/README.md
@@ -27,7 +27,7 @@ Manages recurring and deferred background tasks. Periodic tasks run on a cron sc
 
 | Variant | Trigger | Persistence |
 |---------|---------|-------------|
-| `TaskMode::Periodic { schedule }` | Cron expression; fires every matching occurrence | `cron_expr` + `next_run` columns |
+| `TaskMode::Periodic { schedule }` | 5 or 6-field cron expression; fires every matching occurrence | `cron_expr` + `next_run` columns |
 | `TaskMode::OneShot { run_at }` | Single ISO 8601 UTC timestamp | `run_at` column; removed from memory after execution |
 
 > [!NOTE]

--- a/crates/zeph-scheduler/src/lib.rs
+++ b/crates/zeph-scheduler/src/lib.rs
@@ -16,5 +16,7 @@ pub use handlers::CustomTaskHandler;
 pub use sanitize::sanitize_task_prompt;
 pub use scheduler::{Scheduler, SchedulerMessage};
 pub use store::JobStore;
-pub use task::{ScheduledTask, TaskDescriptor, TaskHandler, TaskKind, TaskMode};
+pub use task::{
+    ScheduledTask, TaskDescriptor, TaskHandler, TaskKind, TaskMode, normalize_cron_expr,
+};
 pub use update_check::UpdateCheckHandler;

--- a/crates/zeph-scheduler/src/task.rs
+++ b/crates/zeph-scheduler/src/task.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::borrow::Cow;
 use std::future::Future;
 use std::pin::Pin;
 use std::str::FromStr;
@@ -9,6 +10,20 @@ use chrono::{DateTime, Utc};
 use cron::Schedule as CronSchedule;
 
 use crate::error::SchedulerError;
+
+/// Normalize a cron expression to the 6-field format required by the `cron` crate.
+///
+/// Standard 5-field expressions (`min hour day month weekday`) are prepended with `"0 "` to
+/// default seconds to zero. 6-field expressions are passed through unchanged. Any other field
+/// count is also passed through and will produce an error from the `cron` crate at parse time.
+#[must_use]
+pub fn normalize_cron_expr(expr: &str) -> Cow<'_, str> {
+    if expr.split_whitespace().count() == 5 {
+        Cow::Owned(format!("0 {expr}"))
+    } else {
+        Cow::Borrowed(expr)
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TaskKind {
@@ -93,7 +108,8 @@ impl ScheduledTask {
         kind: TaskKind,
         config: serde_json::Value,
     ) -> Result<Self, SchedulerError> {
-        let schedule = CronSchedule::from_str(cron_expr)
+        let normalized = normalize_cron_expr(cron_expr);
+        let schedule = CronSchedule::from_str(&normalized)
             .map_err(|e| SchedulerError::InvalidCron(format!("{cron_expr}: {e}")))?;
         Ok(Self {
             name: name.into(),
@@ -200,6 +216,34 @@ mod tests {
     }
 
     #[test]
+    fn normalize_five_field_prepends_zero() {
+        assert_eq!(normalize_cron_expr("*/5 * * * *"), "0 */5 * * * *");
+        assert_eq!(normalize_cron_expr("0 3 * * *"), "0 0 3 * * *");
+    }
+
+    #[test]
+    fn normalize_six_field_passthrough() {
+        assert_eq!(normalize_cron_expr("0 0 3 * * *"), "0 0 3 * * *");
+        assert_eq!(normalize_cron_expr("* * * * * *"), "* * * * * *");
+    }
+
+    #[test]
+    fn normalize_other_field_count_passthrough() {
+        assert_eq!(normalize_cron_expr("not_cron"), "not_cron");
+        assert_eq!(normalize_cron_expr("0 0 0 0"), "0 0 0 0");
+    }
+
+    #[test]
+    fn normalize_empty_string_passthrough() {
+        assert_eq!(normalize_cron_expr(""), "");
+    }
+
+    #[test]
+    fn normalize_whitespace_only_passthrough() {
+        assert_eq!(normalize_cron_expr("   "), "   ");
+    }
+
+    #[test]
     fn valid_cron_creates_task() {
         let task = ScheduledTask::new(
             "test",
@@ -208,6 +252,17 @@ mod tests {
             serde_json::Value::Null,
         );
         assert!(task.is_ok());
+    }
+
+    #[test]
+    fn five_field_cron_creates_task() {
+        let task = ScheduledTask::new(
+            "five-field",
+            "*/5 * * * *",
+            TaskKind::HealthCheck,
+            serde_json::Value::Null,
+        );
+        assert!(task.is_ok(), "5-field cron must be accepted");
     }
 
     #[test]

--- a/docs/src/architecture/crates.md
+++ b/docs/src/architecture/crates.md
@@ -159,7 +159,7 @@ HTTP gateway for webhook ingestion (optional, feature-gated).
 Cron-based periodic task scheduler with SQLite persistence (optional, feature-gated).
 
 - `Scheduler` -- tick loop checking due tasks every 60 seconds
-- `ScheduledTask` -- task definition with 6-field cron expression (via `cron` crate)
+- `ScheduledTask` -- task definition with 5 or 6-field cron expression (via `cron` crate; 5-field seconds default to 0)
 - `TaskKind` -- built-in kinds (`memory_cleanup`, `skill_refresh`, `health_check`, `update_check`) and `Custom(String)`
 - `TaskHandler` trait -- async execution interface receiving `serde_json::Value` config
 - `JobStore` -- SQLite-backed persistence tracking `last_run` timestamps and status

--- a/docs/src/concepts/scheduler.md
+++ b/docs/src/concepts/scheduler.md
@@ -18,7 +18,7 @@ Every task has one of two execution modes:
 
 | Mode | Struct variant | Trigger |
 |------|---------------|---------|
-| `Periodic` | `TaskMode::Periodic { schedule }` | Fires repeatedly on a 6-field cron expression |
+| `Periodic` | `TaskMode::Periodic { schedule }` | Fires repeatedly on a 5 or 6-field cron expression |
 | `OneShot` | `TaskMode::OneShot { run_at }` | Fires once at the given UTC timestamp, then is removed |
 
 The scheduler ticks every 60 seconds by default. `run_with_interval(secs)` accepts a custom interval (minimum 1 second).
@@ -40,13 +40,18 @@ Unknown kinds are accepted at runtime and stored as `Custom`. If no handler is r
 
 ## Cron Expression Format
 
-The scheduler uses 6-field cron expressions: `sec min hour day month weekday`.
+The scheduler accepts both standard 5-field cron expressions (`min hour day month weekday`) and
+6-field expressions with an explicit seconds field (`sec min hour day month weekday`). When a
+5-field expression is provided, seconds default to `0`.
 
 ```
-0 0 3 * * *       # daily at 03:00 UTC
-0 0 2 * * SUN     # Sundays at 02:00 UTC
-0 */15 * * * *    # every 15 minutes
-* * * * * *       # every second (testing only)
+0 3 * * *         # daily at 03:00 UTC (5-field, standard)
+0 2 * * SUN       # Sundays at 02:00 UTC (5-field, standard)
+*/15 * * * *      # every 15 minutes (5-field, standard)
+0 0 3 * * *       # daily at 03:00 UTC (6-field, with seconds)
+0 0 2 * * SUN     # Sundays at 02:00 UTC (6-field, with seconds)
+0 */15 * * * *    # every 15 minutes (6-field, with seconds)
+* * * * * *       # every second (6-field, testing only)
 ```
 
 Expressions are parsed by the [`cron`](https://docs.rs/cron) crate. An invalid expression is rejected immediately with `SchedulerError::InvalidCron`.
@@ -71,7 +76,7 @@ Schedule a recurring task using a cron expression.
 | Parameter | Type | Constraints |
 |-----------|------|-------------|
 | `name` | string | Max 128 characters; unique — scheduling with an existing name **updates** the task |
-| `cron` | string | Max 64 characters; must be a valid 6-field expression |
+| `cron` | string | Max 64 characters; must be a valid 5 or 6-field cron expression |
 | `kind` | string | Max 64 characters; see Task Kinds above |
 | `config` | JSON object | Optional. Passed verbatim to the handler as `serde_json::Value` |
 

--- a/docs/src/concepts/tools.md
+++ b/docs/src/concepts/tools.md
@@ -94,7 +94,7 @@ When the `scheduler` feature is enabled, three tools are injected into the LLM t
 
 | Tool | Description |
 |------|-------------|
-| `schedule_periodic` | Register a recurring task with a 6-field cron expression |
+| `schedule_periodic` | Register a recurring task with a 5 or 6-field cron expression |
 | `schedule_deferred` | Register a one-shot task to fire at a specific ISO 8601 UTC time |
 | `cancel_task` | Cancel a scheduled task by name |
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -23,7 +23,7 @@ use zeph_memory::semantic::SemanticMemory;
 #[cfg(feature = "scheduler")]
 use zeph_scheduler::{
     CustomTaskHandler, JobStore, ScheduledTask, Scheduler, SchedulerMessage, TaskDescriptor,
-    TaskHandler, TaskKind, TaskMode, UpdateCheckHandler,
+    TaskHandler, TaskKind, TaskMode, UpdateCheckHandler, normalize_cron_expr,
 };
 
 #[cfg(feature = "scheduler")]
@@ -209,7 +209,8 @@ fn load_config_tasks(
         };
 
         let mode = if let Some(cron_expr) = &task.cron {
-            match cron::Schedule::from_str(cron_expr) {
+            let normalized = normalize_cron_expr(cron_expr);
+            match cron::Schedule::from_str(&normalized) {
                 Ok(s) => TaskMode::Periodic {
                     schedule: Box::new(s),
                 },

--- a/src/scheduler_executor.rs
+++ b/src/scheduler_executor.rs
@@ -10,7 +10,8 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use tokio::sync::mpsc;
 use zeph_scheduler::{
-    JobStore, SchedulerMessage, TaskDescriptor, TaskKind, TaskMode, sanitize_task_prompt,
+    JobStore, SchedulerMessage, TaskDescriptor, TaskKind, TaskMode, normalize_cron_expr,
+    sanitize_task_prompt,
 };
 use zeph_tools::executor::{
     ToolCall, ToolError, ToolExecutor, ToolOutput, deserialize_params, truncate_tool_output,
@@ -203,8 +204,9 @@ impl SchedulerExecutor {
             });
         }
 
+        let normalized_cron = normalize_cron_expr(&params.cron);
         let schedule =
-            CronSchedule::from_str(&params.cron).map_err(|e| ToolError::InvalidParams {
+            CronSchedule::from_str(&normalized_cron).map_err(|e| ToolError::InvalidParams {
                 message: format!("invalid cron expression: {e}"),
             })?;
 
@@ -234,7 +236,7 @@ impl SchedulerExecutor {
         };
 
         self.store
-            .upsert_job(&params.name, &params.cron, &params.kind)
+            .upsert_job(&params.name, &normalized_cron, &params.kind)
             .await
             .map_err(|e| ToolError::InvalidParams {
                 message: format!("store error: {e}"),
@@ -498,6 +500,29 @@ mod tests {
         let result = exec.execute_tool_call(&call).await.unwrap().unwrap();
         assert!(result.summary.contains("Created"));
         assert!(result.summary.contains("daily"));
+        assert!(rx.recv().await.is_some());
+    }
+
+    #[tokio::test]
+    async fn schedule_periodic_valid_5field() {
+        let (exec, mut rx) = make_executor().await;
+        let call = make_call(
+            "schedule_periodic",
+            serde_json::json!({"name": "every5m", "cron": "*/5 * * * *", "kind": "health_check"}),
+        );
+        let result = exec.execute_tool_call(&call).await.unwrap().unwrap();
+        assert!(result.summary.contains("Created"));
+        assert!(result.summary.contains("every5m"));
+        // Verify normalized cron is persisted to DB (must be 6-field, not raw 5-field)
+        let row: (String,) =
+            sqlx::query_as("SELECT cron_expr FROM scheduled_jobs WHERE name = 'every5m'")
+                .fetch_one(exec.store.pool())
+                .await
+                .unwrap();
+        assert_eq!(
+            row.0, "0 */5 * * * *",
+            "DB must store normalized 6-field cron"
+        );
         assert!(rx.recv().await.is_some());
     }
 


### PR DESCRIPTION
## Summary

- Adds `normalize_cron_expr()` that auto-prepends `0` (seconds) when a standard 5-field cron expression is provided
- Patches all three parse sites: `ScheduledTask::periodic`, `SchedulerExecutor::schedule_periodic`, `load_config_tasks`
- DB persistence now stores the normalized 6-field form
- Docs updated in scheduler.md, tools.md, crates.md, SKILL.md, README

## Test plan

- [ ] `normalize_cron_expr` unit tests: 5-field, 6-field passthrough, invalid, empty, whitespace
- [ ] `ScheduledTask::periodic` test with 5-field expression
- [ ] `schedule_periodic_valid_5field` executor test verifying DB stores normalized `"0 */5 * * * *"`
- [ ] Full suite: 5194 passed, 0 failed (`--features full`)

Closes #1422