### PR TITLE
feat(gemini): document parse_tool_response single-candidate limitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Gemini `parse_tool_response` single-candidate limitation documented**: added code comment and `debug!` log in `parse_tool_response()` noting that only `candidates[0]` is processed. Zeph never requests `candidateCount > 1`, so this path is unreachable in normal operation. Closes #1640.
 - **ACP graph memory extraction silently disabled**: `spawn_acp_agent` in `src/acp.rs` now calls `agent.with_graph_config()` with the `[memory.graph]` config section. Previously the `graph_config` field in `MemoryState` defaulted to `GraphConfig { enabled: false }`, causing `maybe_spawn_graph_extraction()` to return early for every ACP session regardless of user configuration. Closes #1633.
 
 ### Tests

--- a/crates/zeph-llm/src/gemini.rs
+++ b/crates/zeph-llm/src/gemini.rs
@@ -320,6 +320,15 @@ fn parse_gemini_error(body: &str, status: reqwest::StatusCode) -> LlmError {
 // ---------------------------------------------------------------------------
 
 fn parse_tool_response(resp: GenerateContentResponse) -> Result<ChatResponse, LlmError> {
+    // Known limitation: only the first candidate is processed (issue #1640).
+    // Gemini supports `candidateCount > 1`, but Zeph never requests multiple
+    // candidates, so the remaining entries are unreachable in normal operation.
+    if resp.candidates.len() > 1 {
+        tracing::debug!(
+            count = resp.candidates.len(),
+            "Gemini returned multiple candidates; only the first will be used"
+        );
+    }
     let candidate = resp
         .candidates
         .into_iter()


### PR DESCRIPTION
## Summary

- Documents the known limitation in `parse_tool_response()` that only `candidates[0]` is processed
- Adds a `debug!` log when Gemini unexpectedly returns multiple candidates, making it observable
- No behavioral change — Zeph never requests `candidateCount > 1`, so the additional candidates path is unreachable in normal operation

## Test plan

- [ ] All 5236 existing tests pass (`cargo nextest run --workspace --features full --lib --bins`)
- [ ] `cargo clippy --workspace --features full -- -D warnings` passes with zero warnings
- [ ] `cargo +nightly fmt --check` passes

Closes #1640. Part of #1592.