### PR TITLE
chore(llm): replace retired Claude 3 model IDs and add deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Claude 3 model ID retirement** (#1625): replaced retired Claude 3 model IDs (`claude-3-opus`, `claude-3`, `claude:claude-3-5-sonnet`) with `claude-sonnet-4-6` in test files. `ClaudeProvider::new()` now emits a `tracing::warn!` when the configured model starts with `claude-3`, alerting users with stale configs before the first API call fails.
+
 ### Added
 
 - **Gemini SSE TODO for Phase 4 (streaming tool use)**: added a TODO comment in `parse_gemini_sse_event()` documenting that `GeminiStreamPart` lacks a `function_call` field and that `functionCall` SSE chunks are silently dropped. `chat_with_tools()` uses the non-streaming endpoint today, so this is safe; the TODO tracks Phase 4 work (extend `GeminiStreamPart` and handle `functionCall` parts in the SSE loop). Closes #1639.

--- a/crates/zeph-acp/src/agent/tests.rs
+++ b/crates/zeph-acp/src/agent/tests.rs
@@ -2257,7 +2257,7 @@ async fn set_session_model_rejects_unknown_model() {
             let agent = ZephAcpAgent::new(make_spawner(), tx, conn_slot, 4, 1800, None)
                 .with_provider_factory(
                     factory,
-                    shared_models(vec!["claude:claude-3-5-sonnet".to_owned()]),
+                    shared_models(vec!["claude:claude-sonnet-4-6".to_owned()]),
                 );
             let resp = agent
                 .new_session(acp::NewSessionRequest::new(std::path::PathBuf::from(".")))

--- a/crates/zeph-core/src/bootstrap/tests.rs
+++ b/crates/zeph-core/src/bootstrap/tests.rs
@@ -135,7 +135,7 @@ fn create_provider_claude_without_api_key_errors() {
     let mut config = Config::load(Path::new("/nonexistent")).unwrap();
     config.llm.provider = ProviderKind::Claude;
     config.llm.cloud = Some(crate::config::CloudLlmConfig {
-        model: "claude-3-opus".into(),
+        model: "claude-sonnet-4-6".into(),
         max_tokens: 4096,
         thinking: None,
     });
@@ -398,7 +398,7 @@ fn build_orchestrator_claude_sub_without_api_key_errors() {
     let mut config = Config::load(Path::new("/nonexistent")).unwrap();
     config.llm.provider = ProviderKind::Orchestrator;
     config.llm.cloud = Some(crate::config::CloudLlmConfig {
-        model: "claude-3".into(),
+        model: "claude-sonnet-4-6".into(),
         max_tokens: 4096,
         thinking: None,
     });

--- a/crates/zeph-llm/src/claude.rs
+++ b/crates/zeph-llm/src/claude.rs
@@ -422,6 +422,13 @@ impl ClaudeProvider {
 
     #[must_use]
     pub fn new(api_key: String, model: String, max_tokens: u32) -> Self {
+        if model.starts_with("claude-3") {
+            tracing::warn!(
+                model = %model,
+                "configured model is a retired Claude 3 identifier and may cause API errors; \
+                consider upgrading to claude-sonnet-4-6 or claude-haiku-4-5-20251001",
+            );
+        }
         Self {
             client: crate::http::llm_client(600),
             api_key,


### PR DESCRIPTION
## Summary

- Replace `claude-3-opus`, `claude-3`, and `claude:claude-3-5-sonnet` test fixtures with `claude-sonnet-4-6` (all were error-path tests where the model string is an arbitrary placeholder)
- Add `tracing::warn!` in `ClaudeProvider::new()` when the configured model matches the `claude-3` prefix, covering all retired identifiers that return API errors since Feb 19 2026

## Test plan

- [ ] All 5261 tests pass (`cargo nextest run --workspace --features full --lib --bins`)
- [ ] `cargo clippy --workspace --features full -- -D warnings` clean
- [ ] `cargo +nightly fmt --check` clean

Closes #1625