### PR TITLE
fix(memory): wire ranking options in build_memory to enable MMR for all backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **MMR re-ranking silently disabled for all backends** (#1666): `build_memory()` in `AppBuilder` never called `with_ranking_options()`, so `mmr_enabled` was always `false` at runtime regardless of `[memory.semantic] mmr_enabled = true` in config. Fixed by wiring `mmr_enabled`, `mmr_lambda`, `temporal_decay_enabled`, and `temporal_decay_half_life_days` from config into the `SemanticMemory` builder after construction. Also adds a `tracing::warn!` when `get_vectors()` returns an empty map while MMR is enabled, making the silent fallback to score-based truncation observable in logs.
+
 - **Graph extraction 400 Bad Request with OpenAI strict mode**: `chat_typed` in `zeph-llm` now normalizes the `schemars`-generated JSON Schema before sending it to OpenAI structured output with `strict: true`. Normalization inlines `$ref`/`$defs` references (depth 8) and adds `additionalProperties: false` plus a complete `required` array on every object schema (depth 16). `Option<T>` fields are preserved via `anyOf` and made required as per OpenAI strict mode rules. Closes #1656.
 - **Gemini `inline_refs_inner` depth counter**: the depth limit was decremented on every structural recursion step (object key visit, array element visit), not only on `$ref` resolution. Schemas with 9+ levels of plain nesting (no `$ref`s) would hit the depth-8 cap prematurely and corrupt deeply nested schemas. Fixed by decrementing depth only when resolving a `$ref`, leaving structural recursion depth-neutral. Closes #1638.
 

--- a/crates/zeph-core/src/bootstrap/mod.rs
+++ b/crates/zeph-core/src/bootstrap/mod.rs
@@ -219,6 +219,13 @@ impl AppBuilder {
             }
         };
 
+        memory = memory.with_ranking_options(
+            self.config.memory.semantic.temporal_decay_enabled,
+            self.config.memory.semantic.temporal_decay_half_life_days,
+            self.config.memory.semantic.mmr_enabled,
+            self.config.memory.semantic.mmr_lambda,
+        );
+
         if self.config.memory.semantic.enabled && memory.is_vector_store_connected().await {
             tracing::info!("semantic memory enabled, vector store connected");
             match memory.embed_missing().await {

--- a/crates/zeph-memory/src/semantic.rs
+++ b/crates/zeph-memory/src/semantic.rs
@@ -765,6 +765,10 @@ impl SemanticMemory {
                         );
                     }
                     Ok(_) => {
+                        tracing::warn!(
+                            "mmr: no vectors available for recalled messages, \
+                             falling back to score-based truncation"
+                        );
                         ranked.truncate(limit);
                     }
                     Err(e) => {
@@ -3319,6 +3323,79 @@ mod tests {
             // No assertion on count: with 0s timeout the task may or may not complete.
             // The test verifies there is no panic.
         }
+    }
+
+    // MMR end-to-end regression: verifies that with_ranking_options() actually enables MMR
+    // and that the SQLite vector backend provides vectors for re-ranking.
+    #[tokio::test]
+    async fn mmr_enabled_with_sqlite_backend_produces_diverse_recall() {
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+
+        // MockProvider returns vec![1.0, 0.0] for every embed() call.
+        let mut mock = MockProvider::default();
+        mock.supports_embeddings = true;
+        mock.embedding = vec![1.0_f32, 0.0];
+        let provider = AnyProvider::Mock(mock);
+
+        let mut memory = SemanticMemory::with_sqlite_backend_and_pool_size(
+            ":memory:", provider, "m", 0.7, 0.3, 1,
+        )
+        .await
+        .unwrap();
+
+        // Enable MMR via with_ranking_options (lambda=0.5 → equal diversity/relevance weight).
+        memory = memory.with_ranking_options(false, 30, true, 0.5);
+
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+
+        // Save three messages to SQLite.
+        let id1 = memory.remember(cid, "user", "alpha topic").await.unwrap();
+        let id2 = memory.remember(cid, "user", "beta topic").await.unwrap();
+        let id3 = memory
+            .remember(cid, "user", "alpha topic again")
+            .await
+            .unwrap();
+
+        // Manually store controlled vectors so MMR has real data to work with.
+        // id1 and id3: [1.0, 0.0] — same direction as query, redundant pair.
+        // id2: [0.0, 1.0] — orthogonal, diverse.
+        let qdrant = memory.qdrant.as_ref().unwrap();
+        qdrant.ensure_collection(2).await.unwrap();
+        qdrant
+            .store(id1, cid, "user", vec![1.0, 0.0], MessageKind::Regular, "m")
+            .await
+            .unwrap();
+        qdrant
+            .store(id2, cid, "user", vec![0.0, 1.0], MessageKind::Regular, "m")
+            .await
+            .unwrap();
+        qdrant
+            .store(id3, cid, "user", vec![1.0, 0.0], MessageKind::Regular, "m")
+            .await
+            .unwrap();
+
+        // recall() with limit=2 — without MMR both slots would go to the most similar pair
+        // (id1+id3), with MMR the diverse id2 should appear instead of id3.
+        let recalled = memory.recall("alpha", 2, None).await.unwrap();
+
+        assert!(
+            !recalled.is_empty(),
+            "recall must return results with SQLite vector backend"
+        );
+
+        let contents: Vec<&str> = recalled
+            .iter()
+            .map(|r| r.message.content.as_str())
+            .collect();
+
+        // "beta topic" (id2, vector [0,1]) must be present: MMR penalizes the redundant
+        // [1,0] pair (id1+id3) and promotes the orthogonal id2 for diversity.
+        assert!(
+            contents.contains(&"beta topic"),
+            "MMR must select diverse 'beta topic' over redundant 'alpha topic again'; \
+             got: {contents:?}"
+        );
     }
 
     // Priority 3: proptest


### PR DESCRIPTION
## Summary

Fixes #1666.

Two bugs caused MMR re-ranking to be silently disabled:

1. **Root cause (all backends)**: `build_memory()` in `zeph-core/src/bootstrap/mod.rs` never called `with_ranking_options()`, so `mmr_enabled` was always `false` at runtime regardless of config. Fixed by wiring `mmr_enabled`, `mmr_lambda`, `temporal_decay_enabled`, and `temporal_decay_half_life_days` from config.

2. **Secondary (Qdrant backend)**: When MMR is enabled but no raw vectors are available (e.g. Qdrant stores vectors externally), the fallback to score-based truncation was silent. Fixed by adding a `tracing::warn!` so operators know MMR is inactive.

## Changes

- `crates/zeph-core/src/bootstrap/mod.rs` — add `with_ranking_options()` call in `build_memory()`
- `crates/zeph-memory/src/semantic.rs` — add warning when vectors unavailable; add regression test
- `CHANGELOG.md` — document the fix under `[Unreleased]`

## Test plan

- [ ] New regression test `mmr_enabled_with_sqlite_backend_produces_diverse_recall` — stores 3 messages with controlled vectors, enables MMR, asserts the orthogonal message is ranked over the redundant duplicate
- [ ] All 5267 tests pass (`cargo nextest run --workspace --features full --lib --bins`)
- [ ] `cargo +nightly fmt --check` and `cargo clippy --workspace --features full -- -D warnings` pass