### PR TITLE
test(agent): add COV-03 scheduler-loop integration test for non-cancel message queuing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **COV-03 scheduler-loop integration test** (#1611): adds `scheduler_loop_queues_non_cancel_message` to `agent/tests.rs`, verifying end-to-end that a non-cancel message delivered via `channel.recv()` during `run_scheduler_loop` is passed to `enqueue_or_merge()` and appears in `agent.message_queue` after the loop exits. Complements the `enqueue_or_merge` unit tests in `message_queue.rs`.
+
 - **Claude 1M extended context window** (#1649): adds `enable_extended_context: bool` to `CloudLlmConfig` (default `false`). When enabled, `ClaudeProvider` injects `anthropic-beta: context-1m-2025-08-07` into all API requests, unlocking the 1M token context window for Opus 4.6 and Sonnet 4.6. `context_window()` now returns `1_000_000` instead of `200_000` when the flag is set, so the auto-budget correctly scales to 1M. All four Claude construction sites in `bootstrap/provider.rs` wire the flag (summary provider intentionally skips it — summaries are capped at 4096 tokens). `--init` wizard adds a Confirm prompt after the thinking mode question. An INFO log is emitted at provider construction when extended context is active.
 
 - **Gemini SSE TODO for Phase 4 (streaming tool use)**: added a TODO comment in `parse_gemini_sse_event()` documenting that `GeminiStreamPart` lacks a `function_call` field and that `functionCall` SSE chunks are silently dropped. `chat_with_tools()` uses the non-streaming endpoint today, so this is safe; the TODO tracks Phase 4 work (extend `GeminiStreamPart` and handle `functionCall` parts in the SSE loop). Closes #1639.

--- a/crates/zeph-core/src/agent/tests.rs
+++ b/crates/zeph-core/src/agent/tests.rs
@@ -2962,9 +2962,66 @@ mod compaction_e2e {
         );
     }
 
-    /// COV-03 (non-cancel message queuing): tested via enqueue_or_merge unit tests in
-    /// message_queue.rs. A dedicated scheduler-loop integration test is deferred to
-    /// GitHub issue #1605.
+    /// COV-03: a non-cancel message received via the channel during `run_scheduler_loop`
+    /// is queued in `message_queue` for processing after the plan completes.
+    ///
+    /// Verifies the `tokio::select!` path added in #1603: when the channel delivers a
+    /// non-cancel message while the loop is waiting for a scheduler event, the message
+    /// is passed to `enqueue_or_merge()` and appears in `agent.message_queue` after
+    /// `run_scheduler_loop` returns.
+    #[tokio::test]
+    async fn scheduler_loop_queues_non_cancel_message() {
+        use crate::orchestration::{DagScheduler, OrchestrationConfig, RuleBasedRouter};
+        use crate::subagent::SubAgentManager;
+
+        // Channel pre-loaded with one non-cancel message; second recv() returns None,
+        // which terminates the loop with GraphStatus::Failed — acceptable for this test
+        // since we only verify queuing, not plan completion status.
+        let channel = MockChannel::new(vec!["hello".to_owned()]);
+        let provider = mock_provider(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+        agent.orchestration_config.enabled = true;
+        agent.subagent_manager = Some(SubAgentManager::new(4));
+
+        // Graph in Running status with one task in Running state: tick() emits no actions
+        // (no Ready tasks, running_in_graph_now > 0 suppresses Done), so the loop reaches
+        // the select! where channel.recv() delivers "hello" before the loop exits.
+        let mut graph = TaskGraph::new("queue test goal");
+        let mut node = TaskNode::new(0, "task-0", "long running task");
+        node.status = TaskStatus::Running;
+        graph.tasks.push(node);
+        graph.status = GraphStatus::Running;
+
+        let config = OrchestrationConfig {
+            enabled: true,
+            ..OrchestrationConfig::default()
+        };
+        let mut scheduler =
+            DagScheduler::resume_from(graph, &config, Box::new(RuleBasedRouter), vec![]).unwrap();
+
+        let token = tokio_util::sync::CancellationToken::new();
+        let _ = agent
+            .run_scheduler_loop(&mut scheduler, 1, token)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            agent.message_queue.len(),
+            1,
+            "non-cancel message must be queued in message_queue; got: {:?}",
+            agent
+                .message_queue
+                .iter()
+                .map(|m| &m.text)
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            agent.message_queue[0].text, "hello",
+            "queued message text must match the received message"
+        );
+    }
 
     /// GAP-9: `handle_plan_status` shows the correct message for each graph status.
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Adds `scheduler_loop_queues_non_cancel_message` to `agent/tests.rs`, providing an end-to-end integration test for the `tokio::select!` message-queuing path added in #1603
- Verifies that a non-cancel message received via `channel.recv()` during `run_scheduler_loop` is passed to `enqueue_or_merge()` and appears in `agent.message_queue` after the loop exits
- Replaces the placeholder COV-03 comment that previously deferred this test to a future issue

## Test design

The test uses:
1. A `MockChannel` pre-loaded with a `"hello"` message (non-cancel)
2. A `DagScheduler` backed by a graph in `Running` status with one task in `TaskStatus::Running` — `tick()` returns no actions on the first call (no Ready tasks, `running_in_graph_now > 0` suppresses the Done check), so the loop reaches the `select!` where `channel.recv()` delivers the message
3. Channel exhaustion (`recv()` returning `None` on the second call) terminates the loop with `GraphStatus::Failed` — acceptable since the test verifies queuing behavior, not completion status

Closes #1611

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --features full -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features full --lib --bins` — 5301 passed
- [x] New test passes: `scheduler_loop_queues_non_cancel_message`