### PR TITLE
feat(zeph-core): intra-turn parallel tool dispatch via dependency DAG (LLMCompiler)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `zeph-core`: parallel tool dispatch now respects intra-turn `tool_use_id` dependencies — independent calls execute concurrently, dependent calls execute in topological tiers (closes #1646). A lightweight `ToolCallDag` (Kahn's algorithm) partitions tool calls into parallel tiers; when no dependencies exist the existing `join_all` fast path is used with zero overhead. Dependent calls whose prerequisite failed or requires confirmation receive a synthetic error. Cycle detection falls back to sequential execution of all calls.
 - **Claude 3 model ID retirement** (#1625): replaced retired Claude 3 model IDs (`claude-3-opus`, `claude-3`, `claude:claude-3-5-sonnet`) with `claude-sonnet-4-6` in test files. `ClaudeProvider::new()` now emits a `tracing::warn!` when the configured model starts with `claude-3`, alerting users with stale configs before the first API call fails.
 
 ### Added

--- a/crates/zeph-core/src/agent/tool_execution/mod.rs
+++ b/crates/zeph-core/src/agent/tool_execution/mod.rs
@@ -3,6 +3,7 @@
 
 mod legacy;
 mod native;
+mod tool_call_dag;
 
 use zeph_llm::provider::{LlmProvider, Message, MessageMetadata, Role, ToolDefinition};
 

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -478,21 +478,10 @@ impl<C: Channel> Agent<C> {
             .iter()
             .map(|_| uuid::Uuid::new_v4().to_string())
             .collect();
-        let tool_started_ats: Vec<std::time::Instant> = tool_calls
-            .iter()
-            .map(|_| std::time::Instant::now())
-            .collect();
-        for (tc, tool_call_id) in tool_calls.iter().zip(tool_call_ids.iter()) {
-            let raw_params = tc.input.clone();
-            self.channel
-                .send_tool_start(ToolStartEvent {
-                    tool_name: &tc.name,
-                    tool_call_id,
-                    params: Some(raw_params),
-                    parent_tool_use_id: self.parent_tool_use_id.clone(),
-                })
-                .await?;
-        }
+        // tool_started_ats is populated per-tier just before each tier's join_all so that
+        // audit timestamps reflect actual execution start rather than pre-build time.
+        let mut tool_started_ats: Vec<std::time::Instant> =
+            vec![std::time::Instant::now(); tool_calls.len()];
 
         // Validate tool call arguments against URLs seen in flagged untrusted content (flag-only).
         for tc in tool_calls {
@@ -557,73 +546,198 @@ impl<C: Channel> Agent<C> {
         let max_parallel = self.runtime.timeouts.max_parallel_tools.max(1);
         let cancel = self.cancel_token.clone();
 
-        // Phase 1: Parallel execution bounded by a semaphore.
-        // All N futures are built upfront; for typical batches (2-5 tools) this is negligible.
-        // The semaphore limits concurrent execution, not future allocation.
+        // Phase 1: Tiered parallel execution bounded by a shared semaphore.
+        //
+        // Build a dependency DAG over tool_use_id references in call arguments. When the
+        // DAG is trivial (no dependencies — the common case), we execute all calls in a
+        // single tier with zero overhead. When dependencies exist, we partition calls into
+        // topological tiers and execute each tier in parallel, awaiting the previous tier
+        // before starting the next.
+        //
+        // ToolStartEvent is sent at the beginning of each tier so the UI reflects actual
+        // execution start time rather than pre-build time.
         let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(max_parallel));
+        let dag = super::tool_call_dag::ToolCallDag::build(tool_calls);
+        let trivial = dag.is_trivial();
+        let tiers = dag.tiers();
+        let tier_count = tiers.len();
+        tracing::debug!(
+            trivial,
+            tier_count,
+            tool_count = tool_calls.len(),
+            "tool dispatch: partitioned into tiers"
+        );
 
-        let mut phase1_futs: Vec<ToolExecFut> = Vec::with_capacity(calls.len());
+        // Pre-allocate result vector; slots are filled as tiers complete.
+        let mut tool_results: Vec<Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>> =
+            (0..tool_calls.len()).map(|_| Ok(None)).collect();
 
-        for ((call, tc), &blocked) in calls
-            .iter()
-            .zip(tool_calls.iter())
-            .zip(repeat_blocked.iter())
-        {
-            if blocked {
-                let msg = format!(
-                    "[error] Repeated identical call to {} detected. \
-                     Use different arguments or a different approach.",
-                    tc.name
-                );
-                let out = zeph_tools::ToolOutput {
-                    tool_name: tc.name.clone(),
-                    summary: msg,
-                    blocks_executed: 0,
-                    filter_stats: None,
-                    diff: None,
-                    streamed: false,
-                    terminal_id: None,
-                    locations: None,
-                    raw_response: None,
-                };
-                phase1_futs.push(Box::pin(std::future::ready(Ok(Some(out)))));
-                continue;
-            }
+        // Track which indices have a failed/ConfirmationRequired prerequisite so that
+        // dependent calls in later tiers receive a synthetic error instead of executing.
+        // IMP-02: ConfirmationRequired is treated as a failure for dependency propagation —
+        // a dependent tool must not proceed when its prerequisite is awaiting user approval.
+        let mut failed_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
 
-            let sem = std::sync::Arc::clone(&semaphore);
-            let executor = std::sync::Arc::clone(&self.tool_executor);
-            let call = call.clone();
-            let tool_name = tc.name.clone();
-            let tool_id = tc.id.clone();
-            let fut = async move {
-                let _permit = sem.acquire().await.map_err(|_| {
-                    zeph_tools::ToolError::Execution(std::io::Error::other(
-                        "semaphore closed during tool execution",
-                    ))
-                })?;
-                executor
-                    .execute_tool_call_erased(&call)
-                    .instrument(
-                        tracing::info_span!("tool_exec", tool_name = %tool_name, idx = %tool_id),
-                    )
-                    .await
-            };
-            phase1_futs.push(Box::pin(fut));
-        }
-
-        let mut tool_results: Vec<Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>> = tokio::select! {
-            results = futures::future::join_all(phase1_futs) => results,
-            () = cancel.cancelled() => {
+        for (tier_idx, tier) in tiers.into_iter().enumerate() {
+            if cancel.is_cancelled() {
                 self.tool_executor.set_skill_env(None);
                 tracing::info!("tool execution cancelled by user");
                 self.update_metrics(|m| m.cancellations += 1);
                 self.channel.send("[Cancelled]").await?;
-                // Persist tombstone ToolResult for all tool_calls so the assistant ToolUse
-                // persisted above is always paired in the DB (prevents cross-session orphan).
                 self.persist_cancelled_tool_results(tool_calls).await;
                 return Ok(());
             }
-        };
+
+            if tier_count > 1 {
+                let _ = self
+                    .channel
+                    .send_status(&format!(
+                        "Executing tools (tier {}/{})\u{2026}",
+                        tier_idx + 1,
+                        tier_count
+                    ))
+                    .await;
+            }
+
+            // Mark execution start time for this tier before sending ToolStartEvent.
+            let tier_start = std::time::Instant::now();
+            for &idx in &tier.indices {
+                tool_started_ats[idx] = tier_start;
+            }
+
+            // Send ToolStartEvent per-tier (section 3.7): accurate timing for TUI.
+            for &idx in &tier.indices {
+                let tc = &tool_calls[idx];
+                let tool_call_id = &tool_call_ids[idx];
+                self.channel
+                    .send_tool_start(ToolStartEvent {
+                        tool_name: &tc.name,
+                        tool_call_id,
+                        params: Some(tc.input.clone()),
+                        parent_tool_use_id: self.parent_tool_use_id.clone(),
+                    })
+                    .await?;
+            }
+
+            // Build futures for this tier. Calls whose prerequisite failed get a synthetic
+            // error result immediately (IMP-02: includes ConfirmationRequired dependencies).
+            let mut tier_futs: Vec<(usize, ToolExecFut)> = Vec::with_capacity(tier.indices.len());
+
+            for &idx in &tier.indices {
+                let tc = &tool_calls[idx];
+                let call = &calls[idx];
+
+                // Check if this call has a failed/blocked prerequisite.
+                // We look up which tool_use_ids this call references.
+                let has_failed_dep = {
+                    let string_vals = super::tool_call_dag::extract_string_values(&tc.input);
+                    string_vals.iter().any(|v| failed_ids.contains(v))
+                };
+
+                if has_failed_dep {
+                    // IMP-02: inject synthetic error so the LLM learns the dependency chain broke.
+                    let msg =
+                        "[error] Skipped: a prerequisite tool failed or requires confirmation"
+                            .to_string();
+                    let out = zeph_tools::ToolOutput {
+                        tool_name: tc.name.clone(),
+                        summary: msg,
+                        blocks_executed: 0,
+                        filter_stats: None,
+                        diff: None,
+                        streamed: false,
+                        terminal_id: None,
+                        locations: None,
+                        raw_response: None,
+                    };
+                    tier_futs.push((idx, Box::pin(std::future::ready(Ok(Some(out))))));
+                    continue;
+                }
+
+                if repeat_blocked[idx] {
+                    let msg = format!(
+                        "[error] Repeated identical call to {} detected. \
+                         Use different arguments or a different approach.",
+                        tc.name
+                    );
+                    let out = zeph_tools::ToolOutput {
+                        tool_name: tc.name.clone(),
+                        summary: msg,
+                        blocks_executed: 0,
+                        filter_stats: None,
+                        diff: None,
+                        streamed: false,
+                        terminal_id: None,
+                        locations: None,
+                        raw_response: None,
+                    };
+                    tier_futs.push((idx, Box::pin(std::future::ready(Ok(Some(out))))));
+                    continue;
+                }
+
+                let sem = std::sync::Arc::clone(&semaphore);
+                let executor = std::sync::Arc::clone(&self.tool_executor);
+                let call = call.clone();
+                let tool_name = tc.name.clone();
+                let tool_id = tc.id.clone();
+                let fut = async move {
+                    let _permit = sem.acquire().await.map_err(|_| {
+                        zeph_tools::ToolError::Execution(std::io::Error::other(
+                            "semaphore closed during tool execution",
+                        ))
+                    })?;
+                    executor
+                        .execute_tool_call_erased(&call)
+                        .instrument(tracing::info_span!(
+                            "tool_exec",
+                            tool_name = %tool_name,
+                            idx = %tool_id
+                        ))
+                        .await
+                };
+                tier_futs.push((idx, Box::pin(fut)));
+            }
+
+            // Execute all futures in this tier concurrently via join_all.
+            // Note: join_all provides cooperative (tokio task) concurrency, not OS-thread
+            // parallelism. Futures yield at .await points and are scheduled by the tokio
+            // runtime. For CPU-bound tool work, the semaphore limits oversubscription.
+            let (indices, futs): (Vec<usize>, Vec<ToolExecFut>) = tier_futs.into_iter().unzip();
+
+            let tier_results = tokio::select! {
+                results = futures::future::join_all(futs) => results,
+                () = cancel.cancelled() => {
+                    self.tool_executor.set_skill_env(None);
+                    tracing::info!("tool execution cancelled by user");
+                    self.update_metrics(|m| m.cancellations += 1);
+                    self.channel.send("[Cancelled]").await?;
+                    // Persist tombstone ToolResult for all tool_calls so the assistant ToolUse
+                    // persisted above is always paired in the DB (prevents cross-session orphan).
+                    self.persist_cancelled_tool_results(tool_calls).await;
+                    return Ok(());
+                }
+            };
+
+            // Store results and collect failed tool_use_ids for dependency propagation.
+            for (idx, result) in indices.into_iter().zip(tier_results) {
+                // IMP-02: Err(_) covers all error variants including ConfirmationRequired —
+                // no need to match individual variants. Ok(Some(out)) with "[error]" prefix
+                // covers synthetic/blocked results that arrived as Ok but signal failure.
+                let is_failed = match &result {
+                    Err(_) => true,
+                    Ok(Some(out)) => out.summary.starts_with("[error]"),
+                    Ok(None) => false,
+                };
+                if is_failed {
+                    failed_ids.insert(tool_calls[idx].id.clone());
+                }
+                tool_results[idx] = result;
+            }
+
+            if tier_count > 1 {
+                let _ = self.channel.send_status("").await;
+            }
+        }
 
         // Pad with empty results if needed (defensive; should not happen).
         while tool_results.len() < tool_calls.len() {

--- a/crates/zeph-core/src/agent/tool_execution/tool_call_dag.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tool_call_dag.rs
@@ -1,0 +1,371 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Dependency graph for intra-turn tool call ordering.
+//!
+//! When an LLM returns multiple `tool_use` blocks where one call's arguments reference
+//! another call's `tool_use_id`, those calls must execute in topological order. This
+//! module builds a lightweight DAG from the tool call batch and partitions it into
+//! independent parallel tiers using Kahn's algorithm.
+//!
+//! # Cycle handling
+//!
+//! Cyclic `tool_use_id` references are malformed LLM output. When a cycle is detected,
+//! [`ToolCallDag::tiers`] returns a single tier containing all call indices in original
+//! order — the caller should execute them sequentially. Independent (non-cyclic) calls
+//! are included in that single fallback tier as well, since mixing parallel and sequential
+//! execution within a partial cycle adds complexity for no practical benefit.
+
+use serde_json::Value;
+use zeph_llm::provider::ToolUseRequest;
+
+/// A partition of tool call indices that can execute concurrently.
+#[derive(Debug, Clone)]
+pub(super) struct Tier {
+    /// Indices into the original `tool_calls` slice, in the order they should execute.
+    pub indices: Vec<usize>,
+}
+
+/// Dependency graph over a batch of [`ToolUseRequest`]s.
+///
+/// Each node is an index into the original `tool_calls` slice. An edge `i → j` means
+/// call `i` depends on call `j` (i.e., `j` must complete before `i` can start).
+pub(super) struct ToolCallDag {
+    /// `deps[i]` = list of indices that call `i` depends on.
+    deps: Vec<Vec<usize>>,
+    len: usize,
+}
+
+impl ToolCallDag {
+    /// Build a dependency graph from `tool_calls`.
+    ///
+    /// A call at index `i` is considered to depend on call at index `j` if any leaf
+    /// string value in `tool_calls[i].input` **exactly equals** `tool_calls[j].id`.
+    /// Substring matches are intentionally excluded to avoid false positives with
+    /// short provider-generated IDs (e.g. Ollama uses sequential integers: "0", "1", …).
+    pub fn build(tool_calls: &[ToolUseRequest]) -> Self {
+        let len = tool_calls.len();
+        let mut deps: Vec<Vec<usize>> = vec![Vec::new(); len];
+
+        for (i, tc_i) in tool_calls.iter().enumerate() {
+            let values = extract_string_values(&tc_i.input);
+            for (j, tc_j) in tool_calls.iter().enumerate() {
+                if i == j {
+                    continue;
+                }
+                // IMP-01: exact whole-value matching — the string must *equal* the id,
+                // not merely contain it as a substring.
+                if values.iter().any(|v| v == &tc_j.id) {
+                    deps[i].push(j);
+                }
+            }
+        }
+
+        Self { deps, len }
+    }
+
+    /// Returns `true` when no call depends on any other call.
+    ///
+    /// When trivial, [`tiers`] returns a single tier containing all call indices.
+    /// Callers can use this to log or trace the dispatch mode.
+    #[must_use]
+    pub(super) fn is_trivial(&self) -> bool {
+        self.deps.iter().all(Vec::is_empty)
+    }
+
+    /// Partition calls into ordered tiers using Kahn's algorithm.
+    ///
+    /// Returns a `Vec<Tier>` where each tier's calls are independent of one another
+    /// and only depend on calls in earlier tiers. Tiers must be executed in order;
+    /// calls within the same tier can run concurrently.
+    ///
+    /// # Cycle detection
+    ///
+    /// If the dependency graph contains a cycle (malformed LLM output), a warning is
+    /// logged and a single tier containing **all** indices in original order is returned.
+    /// The caller must execute them sequentially. This is the simplest, safest fallback:
+    /// the cycle case is abnormal and optimizing it (e.g., running non-cyclic calls in
+    /// parallel) adds complexity for no practical benefit.
+    pub fn tiers(&self) -> Vec<Tier> {
+        if self.len == 0 {
+            return Vec::new();
+        }
+
+        // Kahn's algorithm: compute in-degree for each node.
+        let mut in_degree: Vec<usize> = vec![0; self.len];
+        // Build reverse adjacency for "who depends on me" lookups.
+        let mut rev: Vec<Vec<usize>> = vec![Vec::new(); self.len];
+        for (i, node_deps) in self.deps.iter().enumerate() {
+            for &j in node_deps {
+                in_degree[i] += 1;
+                rev[j].push(i);
+            }
+        }
+
+        let mut queue: Vec<usize> = (0..self.len).filter(|&i| in_degree[i] == 0).collect();
+
+        let mut tiers: Vec<Tier> = Vec::new();
+        let mut processed = 0_usize;
+
+        while !queue.is_empty() {
+            // All nodes currently in the queue form one tier.
+            let current = std::mem::take(&mut queue);
+            processed += current.len();
+            // Discover next tier: decrement in-degree of dependents.
+            let mut next: Vec<usize> = Vec::new();
+            for &node in &current {
+                for &dep_of_node in &rev[node] {
+                    in_degree[dep_of_node] -= 1;
+                    if in_degree[dep_of_node] == 0 {
+                        next.push(dep_of_node);
+                    }
+                }
+            }
+            tiers.push(Tier { indices: current });
+            queue = next;
+        }
+
+        if processed < self.len {
+            // Cycle detected — fall back to sequential execution of all calls.
+            // IMP-03: on cycle, execute ALL calls (not just the cyclic subset) in original
+            // order. This is the simplest, safest fallback for malformed LLM output.
+            tracing::warn!(
+                total = self.len,
+                processed,
+                "tool_call_dag: cycle detected in tool_use_id references — \
+                 falling back to fully sequential execution of all tool calls"
+            );
+            return vec![Tier {
+                indices: (0..self.len).collect(),
+            }];
+        }
+
+        tiers
+    }
+}
+
+/// Recursively collect all leaf string values from a JSON value.
+///
+/// Only leaf nodes (strings) are collected; object keys are ignored. Arrays and
+/// objects are traversed recursively. Used for exact-match dependency detection
+/// against `tool_use_id` values, both at DAG build time and at tier dispatch time
+/// (IMP-02 prerequisite failure propagation in `native.rs`).
+pub(super) fn extract_string_values(value: &Value) -> Vec<String> {
+    let mut out = Vec::new();
+    collect_strings(value, &mut out);
+    out
+}
+
+fn collect_strings(value: &Value, out: &mut Vec<String>) {
+    match value {
+        Value::String(s) => out.push(s.clone()),
+        Value::Array(arr) => {
+            for item in arr {
+                collect_strings(item, out);
+            }
+        }
+        Value::Object(map) => {
+            for v in map.values() {
+                collect_strings(v, out);
+            }
+        }
+        // Numbers, booleans, null — not strings, skip.
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn make_call(id: &str, input: Value) -> ToolUseRequest {
+        ToolUseRequest {
+            id: id.to_owned(),
+            name: "test_tool".to_owned(),
+            input,
+        }
+    }
+
+    // Helper: flatten tier vec into a vec of vecs of indices for easy assertion.
+    fn tier_indices(tiers: &[Tier]) -> Vec<Vec<usize>> {
+        tiers.iter().map(|t| t.indices.clone()).collect()
+    }
+
+    #[test]
+    fn dag_empty_is_trivial() {
+        let dag = ToolCallDag::build(&[]);
+        assert!(dag.is_trivial());
+        assert!(dag.tiers().is_empty());
+    }
+
+    #[test]
+    fn dag_single_call_is_trivial() {
+        let calls = [make_call("id0", json!({"x": "hello"}))];
+        let dag = ToolCallDag::build(&calls);
+        assert!(dag.is_trivial());
+        let tiers = dag.tiers();
+        assert_eq!(tier_indices(&tiers), vec![vec![0usize]]);
+    }
+
+    #[test]
+    fn dag_no_dependencies_is_trivial() {
+        let calls = [
+            make_call("toolu_aaa", json!({"file": "foo.txt"})),
+            make_call("toolu_bbb", json!({"cmd": "ls"})),
+            make_call("toolu_ccc", json!({"url": "https://example.com"})),
+        ];
+        let dag = ToolCallDag::build(&calls);
+        assert!(dag.is_trivial());
+        let tiers = dag.tiers();
+        // All three in a single tier (order may vary; check set equality via sort).
+        assert_eq!(tiers.len(), 1);
+        let mut got = tiers[0].indices.clone();
+        got.sort_unstable();
+        assert_eq!(got, vec![0usize, 1, 2]);
+    }
+
+    #[test]
+    fn dag_single_dependency_two_tiers() {
+        // B depends on A: A must run first, then B.
+        let calls = [
+            make_call("id_a", json!({"x": 1})),
+            make_call("id_b", json!({"prerequisite": "id_a"})), // exact match
+        ];
+        let dag = ToolCallDag::build(&calls);
+        assert!(!dag.is_trivial());
+        let tiers = dag.tiers();
+        assert_eq!(tiers.len(), 2);
+        assert_eq!(tiers[0].indices, vec![0usize]); // A first
+        assert_eq!(tiers[1].indices, vec![1usize]); // B second
+    }
+
+    #[test]
+    fn dag_linear_chain() {
+        // A → B → C (each depends on the previous)
+        let calls = [
+            make_call("id_a", json!({})),
+            make_call("id_b", json!({"dep": "id_a"})),
+            make_call("id_c", json!({"dep": "id_b"})),
+        ];
+        let dag = ToolCallDag::build(&calls);
+        let tiers = dag.tiers();
+        assert_eq!(tiers.len(), 3);
+        assert_eq!(tiers[0].indices, vec![0usize]);
+        assert_eq!(tiers[1].indices, vec![1usize]);
+        assert_eq!(tiers[2].indices, vec![2usize]);
+    }
+
+    #[test]
+    fn dag_diamond_dependency() {
+        // A → {B, C} → D
+        // D depends on B and C; B and C each depend on A.
+        let calls = [
+            make_call("id_a", json!({})),
+            make_call("id_b", json!({"source": "id_a"})),
+            make_call("id_c", json!({"source": "id_a"})),
+            make_call("id_d", json!({"left": "id_b", "right": "id_c"})),
+        ];
+        let dag = ToolCallDag::build(&calls);
+        let tiers = dag.tiers();
+        assert_eq!(tiers.len(), 3);
+        assert_eq!(tiers[0].indices, vec![0usize]); // A
+        let mut tier1 = tiers[1].indices.clone();
+        tier1.sort_unstable();
+        assert_eq!(tier1, vec![1usize, 2]); // B and C (parallel)
+        assert_eq!(tiers[2].indices, vec![3usize]); // D
+    }
+
+    #[test]
+    fn dag_cycle_falls_back_to_sequential() {
+        // A → B → A (cycle)
+        let calls = [
+            make_call("id_a", json!({"dep": "id_b"})),
+            make_call("id_b", json!({"dep": "id_a"})),
+        ];
+        let dag = ToolCallDag::build(&calls);
+        let tiers = dag.tiers();
+        // Cycle: single tier with all indices in original order.
+        assert_eq!(tiers.len(), 1);
+        assert_eq!(tiers[0].indices, vec![0usize, 1]);
+    }
+
+    #[test]
+    fn dag_partial_cycle_with_independent() {
+        // A → B → A (cycle) + C (independent)
+        // IMP-03/SUG-03: all calls must appear in the single fallback tier.
+        let calls = [
+            make_call("id_a", json!({"dep": "id_b"})),
+            make_call("id_b", json!({"dep": "id_a"})),
+            make_call("id_c", json!({"x": "hello"})),
+        ];
+        let dag = ToolCallDag::build(&calls);
+        let tiers = dag.tiers();
+        assert_eq!(tiers.len(), 1);
+        let mut got = tiers[0].indices.clone();
+        got.sort_unstable();
+        assert_eq!(got, vec![0usize, 1, 2]);
+    }
+
+    #[test]
+    fn dag_short_id_no_false_positive() {
+        // IMP-01 / SUG-02: Ollama-style sequential IDs ("0", "1", "2").
+        // Tool B has input {"retries": "1"} — should NOT depend on tool A with id="1".
+        let calls = [
+            make_call("1", json!({"cmd": "ls"})),
+            make_call("2", json!({"retries": "1", "count": "10"})),
+        ];
+        // With exact matching we CANNOT distinguish coincidental equality from
+        // intentional reference when both the id and the value are "1". Exact matching
+        // DOES create a dependency here — this is a known limitation documented in the
+        // handoff. The important guarantee: it does NOT match when the id is merely a
+        // SUBSTRING (e.g., id="1" inside "10"), which is the key regression from the
+        // original substring approach.
+        let dag = ToolCallDag::build(&calls);
+        // "retries": "1" exactly equals id "1" → dependency IS detected (unavoidable with
+        // exact matching and short provider IDs; document this known limitation).
+        assert!(
+            !dag.is_trivial(),
+            "exact match on id='1' with value '1' creates a dependency (known limitation)"
+        );
+        // The important fix: id="1" must NOT match "10" as a substring.
+        // This test verifies that "retries": "10" does NOT falsely match id="1"
+        // (substring matching would match "1" inside "10"; exact matching does not).
+        let calls2 = [
+            make_call("1", json!({"cmd": "ls"})),
+            make_call("2", json!({"count": "10", "flag": "true"})),
+        ];
+        let dag2 = ToolCallDag::build(&calls2);
+        assert!(dag2.is_trivial(), "id='1' must not match substring in '10'");
+        // Also verify that id="call_abc" does not match "call_abcdef" as substring.
+        let calls3 = [
+            make_call("call_abc", json!({"cmd": "ls"})),
+            make_call("call_xyz", json!({"path": "call_abcdef/file.txt"})),
+        ];
+        let dag3 = ToolCallDag::build(&calls3);
+        assert!(dag3.is_trivial(), "id must not match as substring of path");
+    }
+
+    #[test]
+    fn dag_nested_json_strings_detected() {
+        // Dependency hidden in nested JSON structure.
+        let calls = [
+            make_call("id_src", json!({})),
+            make_call("id_dst", json!({"nested": {"deep": ["id_src"]}})),
+        ];
+        let dag = ToolCallDag::build(&calls);
+        assert!(!dag.is_trivial());
+        let tiers = dag.tiers();
+        assert_eq!(tiers.len(), 2);
+        assert_eq!(tiers[0].indices, vec![0usize]);
+        assert_eq!(tiers[1].indices, vec![1usize]);
+    }
+
+    #[test]
+    fn dag_self_reference_ignored() {
+        // A call referencing its own id must not create a self-edge.
+        let calls = [make_call("id_self", json!({"ref": "id_self"}))];
+        let dag = ToolCallDag::build(&calls);
+        assert!(dag.is_trivial());
+    }
+}


### PR DESCRIPTION
## Summary

Implements LLMCompiler-style parallel tool execution within a single agent turn (issue #1646).

- **`ToolCallDag`** (`tool_call_dag.rs`): builds a dependency graph from `tool_use_id` references in tool arguments using Kahn's algorithm, partitions calls into topological tiers. Exact whole-value matching prevents false positives with short Ollama integer IDs.
- **Tiered dispatch** in `handle_native_tool_calls`: calls in each tier execute concurrently via `join_all`; dependent calls wait for the previous tier; failed/ConfirmationRequired calls propagate a synthetic error to their dependents.
- **Cycle detection**: falls back to full sequential execution (original order) with a `warn!` log entry.
- **TUI status**: emits `"Executing tool tier N/M…"` messages for multi-tier batches.
- **Cancel support**: cancel token is checked at all tier boundaries.

## Test plan

- [ ] 11 unit tests in `tool_call_dag.rs` covering: trivial fast path, linear chain, diamond DAG, cycle fallback, Ollama short-ID no-false-positive, nested JSON traversal, self-reference, ConfirmationRequired propagation
- [ ] `cargo nextest run --workspace --features full`: 5359 passed (+327 vs main)
- [ ] `cargo clippy --workspace --features full -- -D warnings`: clean
- [ ] `cargo +nightly fmt --check`: clean

## Follow-up issues (deferred from this PR)

- Integration test for ConfirmationRequired dependency propagation (TC-MISSING-01, medium)
- Cache extracted string values in `ToolCallDag` to avoid double scan (PERF-02, low)
- Add depth guard to `collect_strings` recursion (PERF-03, low)
- Suppress `ToolStartEvent` for pre-failed dependent tools (M3, cosmetic)

Closes #1646