### PR TITLE
fix(llm): extend is_compact_beta_rejection() to catch context_management 400s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- llm: extend `is_compact_beta_rejection()` to catch `invalid_request_error` 400s mentioning `context_management` (fixes #1706)
 - **`ContextManagement` serialization for Claude server compaction API** (closes #1705): `ContextManagement` struct now serializes to `{ "type": "auto_truncate", "trigger": { "type": "input_tokens", "value": N }, "pause_after_compaction": false }` matching the Claude API spec. Previously serialized as `{ "type": "enabled", "trigger_tokens": N }` which caused a `400 invalid_request_error: context_management.type: Extra inputs are not permitted`, making `--server-compaction` completely non-functional.
 
 - **Skill embedding log noise** (#1387): `SkillMatcher::new()` no longer emits one `WARN` per skill when the provider does not support embeddings. All `EmbedUnsupported` errors are now collected and summarised into a single info-level log message (e.g. `skill embeddings skipped: embedding not supported by claude (14 skills affected)`). Timeout and other per-skill errors are still logged individually.

--- a/crates/zeph-llm/src/claude.rs
+++ b/crates/zeph-llm/src/claude.rs
@@ -557,7 +557,8 @@ impl ClaudeProvider {
         status == reqwest::StatusCode::BAD_REQUEST
             && (body.contains(ANTHROPIC_BETA_COMPACT)
                 || body.contains("unknown beta")
-                || body.contains("invalid beta"))
+                || body.contains("invalid beta")
+                || body.contains("context_management"))
     }
 
     #[must_use]
@@ -4993,6 +4994,30 @@ mod tests {
         assert!(!ClaudeProvider::is_compact_beta_rejection(
             reqwest::StatusCode::BAD_REQUEST,
             r#"{"error":{"message":"invalid parameter: model"}}"#
+        ));
+    }
+
+    #[test]
+    fn is_compact_beta_rejection_detects_context_management_extra_inputs() {
+        assert!(ClaudeProvider::is_compact_beta_rejection(
+            reqwest::StatusCode::BAD_REQUEST,
+            r#"{"type":"error","error":{"type":"invalid_request_error","message":"context_management.type: Extra inputs are not permitted"}}"#
+        ));
+    }
+
+    #[test]
+    fn is_compact_beta_rejection_detects_context_management_generic() {
+        assert!(ClaudeProvider::is_compact_beta_rejection(
+            reqwest::StatusCode::BAD_REQUEST,
+            r#"{"type":"error","error":{"type":"invalid_request_error","message":"context_management: field not allowed"}}"#
+        ));
+    }
+
+    #[test]
+    fn is_compact_beta_rejection_ignores_unrelated_no_context_management() {
+        assert!(!ClaudeProvider::is_compact_beta_rejection(
+            reqwest::StatusCode::BAD_REQUEST,
+            r#"{"type":"error","error":{"type":"invalid_request_error","message":"max_tokens: field required"}}"#
         ));
     }
 


### PR DESCRIPTION
## Summary

- Extends `is_compact_beta_rejection()` in `crates/zeph-llm/src/claude.rs` with `|| body.contains("context_management")` to catch HTTP 400 responses where `error.type = "invalid_request_error"` and the message references the `context_management` field
- Adds 3 unit tests: exact error body from the issue, generic variant, and negative case (unrelated 400)

## Test plan

- [ ] `cargo +nightly fmt --check` — OK
- [ ] `cargo clippy --workspace --features full -- -D warnings` — OK
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --features full --lib --bins` — 5351 passed

Closes #1706