### PR TITLE
fix(llm): disable server_compaction for Haiku models with WARN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- llm: `with_server_compaction(true)` on Haiku models now emits a `WARN` and keeps the flag disabled — the `compact-2026-01-12` beta is not supported for Haiku
 - llm: extend `is_compact_beta_rejection()` to catch `invalid_request_error` 400s mentioning `context_management` (fixes #1706)
 - **`ContextManagement` serialization for Claude server compaction API** (closes #1705): `ContextManagement` struct now serializes to `{ "type": "auto_truncate", "trigger": { "type": "input_tokens", "value": N }, "pause_after_compaction": false }` matching the Claude API spec. Previously serialized as `{ "type": "enabled", "trigger_tokens": N }` which caused a `400 invalid_request_error: context_management.type: Extra inputs are not permitted`, making `--server-compaction` completely non-functional.
 

--- a/crates/zeph-llm/src/claude.rs
+++ b/crates/zeph-llm/src/claude.rs
@@ -525,6 +525,15 @@ impl ClaudeProvider {
     /// this is active.
     #[must_use]
     pub fn with_server_compaction(mut self, enabled: bool) -> Self {
+        if enabled && self.model.contains("haiku") {
+            tracing::warn!(
+                model = %self.model,
+                "server-side compaction (compact-2026-01-12) not supported for Haiku models — \
+                disabling"
+            );
+            self.server_compaction = false;
+            return self;
+        }
         self.server_compaction = enabled;
         self
     }
@@ -4848,6 +4857,14 @@ mod tests {
         let provider = ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 1024)
             .with_server_compaction(true);
         assert!(provider.server_compaction_enabled());
+    }
+
+    #[test]
+    fn with_server_compaction_haiku_stays_disabled() {
+        // Haiku does not support the compact-2026-01-12 beta; flag must be ignored.
+        let provider = ClaudeProvider::new("key".into(), "claude-haiku-4-5-20251001".into(), 1024)
+            .with_server_compaction(true);
+        assert!(!provider.server_compaction_enabled());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Closes #1707
- Adds Haiku model guard in `ClaudeProvider::with_server_compaction()`: when `enabled == true` and the model contains `"haiku"`, emits a `WARN` and returns early with the flag kept `false`
- Follows the existing `enable_extended_context` Haiku guard pattern exactly
- Adds unit test `with_server_compaction_haiku_stays_disabled`

## Test plan

- [ ] `cargo +nightly fmt --check` passes
- [ ] `cargo clippy --workspace --features full -- -D warnings` passes
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --features full --lib --bins` — 5382 passed, 0 failed
- [ ] New test `with_server_compaction_haiku_stays_disabled` verifies guard behavior