### PR TITLE
fix(llm): remove top-level type field from ContextManagement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **`ContextManagement` top-level `type` field removed** (closes #1715): the `ContextManagement` struct no longer serializes a `"type": "auto_truncate"` discriminator at the top level. The Claude API rejects requests with `context_management.type: Extra inputs are not permitted` — the correct format contains only `trigger` and `pause_after_compaction`. `--server-compaction` was still non-functional after PR #1709 due to this field.
 - llm: `with_server_compaction(true)` on Haiku models now emits a `WARN` and keeps the flag disabled — the `compact-2026-01-12` beta is not supported for Haiku
 - llm: extend `is_compact_beta_rejection()` to catch `invalid_request_error` 400s mentioning `context_management` (fixes #1706)
 - **`ContextManagement` serialization for Claude server compaction API** (closes #1705): `ContextManagement` struct now serializes to `{ "type": "auto_truncate", "trigger": { "type": "input_tokens", "value": N }, "pause_after_compaction": false }` matching the Claude API spec. Previously serialized as `{ "type": "enabled", "trigger_tokens": N }` which caused a `400 invalid_request_error: context_management.type: Extra inputs are not permitted`, making `--server-compaction` completely non-functional.

--- a/crates/zeph-llm/src/claude.rs
+++ b/crates/zeph-llm/src/claude.rs
@@ -25,10 +25,11 @@ const MAX_RETRIES: u32 = 3;
 const MIN_MAX_TOKENS_WITH_THINKING: u32 = 16_000;
 
 /// Request field for Claude server-side context management (compact-2026-01-12 beta).
+///
+/// Note: the API does not accept a top-level `"type"` discriminator on this object — only
+/// `trigger` and `pause_after_compaction` are allowed.
 #[derive(Serialize, Clone, Debug)]
 struct ContextManagement {
-    #[serde(rename = "type")]
-    kind: &'static str,
     trigger: ContextManagementTrigger,
     pause_after_compaction: bool,
 }
@@ -804,7 +805,6 @@ impl ClaudeProvider {
         // Multiply before dividing to preserve precision (avoid losing up to 99 tokens).
         let trigger_tokens = context_window * 80 / 100;
         Some(ContextManagement {
-            kind: "auto_truncate",
             trigger: ContextManagementTrigger {
                 kind: "input_tokens",
                 value: trigger_tokens,
@@ -4901,7 +4901,6 @@ mod tests {
     #[test]
     fn context_management_serializes_correctly() {
         let cm = ContextManagement {
-            kind: "auto_truncate",
             trigger: ContextManagementTrigger {
                 kind: "input_tokens",
                 value: 160_000,
@@ -4909,7 +4908,11 @@ mod tests {
             pause_after_compaction: false,
         };
         let json = serde_json::to_value(&cm).unwrap();
-        assert_eq!(json["type"], "auto_truncate");
+        // The API rejects a top-level "type" field on context_management.
+        assert!(
+            json.get("type").is_none(),
+            "context_management must not have a top-level 'type' field"
+        );
         assert_eq!(json["trigger"]["type"], "input_tokens");
         assert_eq!(json["trigger"]["value"], 160_000);
         assert_eq!(json["pause_after_compaction"], false);


### PR DESCRIPTION
## Summary

- Removes `"type": "auto_truncate"` top-level discriminator from `ContextManagement` struct serialization
- The Claude API rejects requests with `context_management.type: Extra inputs are not permitted`
- Only `trigger` and `pause_after_compaction` are valid fields at the top level of `context_management`
- Updates serialization test to assert the `"type"` key is absent at the top level

## Test plan

- [ ] `cargo nextest run -p zeph-llm` — all `server_compaction` / `context_management` tests pass
- [ ] `context_management_serializes_correctly` asserts no top-level `"type"` key
- [ ] Full suite: `cargo nextest run --config-file .github/nextest.toml --workspace --features full --lib --bins` — 5386 tests pass

Closes #1715