### PR TITLE
fix(tui): skip ACP stdio autostart and suppress MCP child stderr in TUI mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(tui): skip ACP stdio/both autostart when `--tui` is active; stdio and TUI are mutually exclusive (both own stdin/stdout); HTTP transport is still allowed alongside TUI when `acp-http` feature is enabled (#1729)
+- fix(mcp): suppress MCP child process stderr in TUI mode to prevent ratatui display corruption; `McpManager` gains `with_suppress_stderr` builder method (#1729)
+
 ## [0.15.0] - 2026-03-14
 
 ### Changed

--- a/crates/zeph-core/src/bootstrap/mcp.rs
+++ b/crates/zeph-core/src/bootstrap/mcp.rs
@@ -6,7 +6,7 @@ use zeph_memory::QdrantOps;
 
 use crate::config::Config;
 
-pub fn create_mcp_manager(config: &Config) -> zeph_mcp::McpManager {
+pub fn create_mcp_manager(config: &Config, suppress_stderr: bool) -> zeph_mcp::McpManager {
     let entries: Vec<zeph_mcp::ServerEntry> = config
         .mcp
         .servers
@@ -37,6 +37,7 @@ pub fn create_mcp_manager(config: &Config) -> zeph_mcp::McpManager {
         .collect();
     let enforcer = zeph_mcp::PolicyEnforcer::new(policy_entries);
     zeph_mcp::McpManager::new(entries, config.mcp.allowed_commands.clone(), enforcer)
+        .with_suppress_stderr(suppress_stderr)
 }
 
 pub async fn create_mcp_registry(

--- a/crates/zeph-core/src/bootstrap/tests.rs
+++ b/crates/zeph-core/src/bootstrap/tests.rs
@@ -775,7 +775,7 @@ fn create_mcp_manager_with_http_transport() {
         policy: Default::default(),
     }];
 
-    let manager = create_mcp_manager(&config);
+    let manager = create_mcp_manager(&config, false);
     let debug = format!("{manager:?}");
     assert!(debug.contains("server_count: 1"));
 }
@@ -795,7 +795,7 @@ fn create_mcp_manager_with_stdio_transport() {
         policy: Default::default(),
     }];
 
-    let manager = create_mcp_manager(&config);
+    let manager = create_mcp_manager(&config, false);
     let debug = format!("{manager:?}");
     assert!(debug.contains("server_count: 1"));
 }
@@ -805,7 +805,7 @@ fn create_mcp_manager_empty_servers() {
     let mut config = Config::load(Path::new("/nonexistent")).unwrap();
     config.mcp.servers = vec![];
 
-    let manager = create_mcp_manager(&config);
+    let manager = create_mcp_manager(&config, false);
     let debug = format!("{manager:?}");
     assert!(debug.contains("server_count: 0"));
 }

--- a/crates/zeph-mcp/src/client.rs
+++ b/crates/zeph-mcp/src/client.rs
@@ -48,6 +48,7 @@ impl McpClient {
         env: &std::collections::HashMap<String, String>,
         allowed_commands: &[String],
         timeout: Duration,
+        suppress_stderr: bool,
     ) -> Result<Self, McpError> {
         crate::security::validate_command(command, allowed_commands)?;
         crate::security::validate_env(env)?;
@@ -58,10 +59,21 @@ impl McpClient {
             cmd.env(k, v);
         }
 
-        let transport = TokioChildProcess::new(cmd).map_err(|e| McpError::Connection {
-            server_id: server_id.into(),
-            message: e.to_string(),
-        })?;
+        let transport = if suppress_stderr {
+            let (proc, _stderr) = TokioChildProcess::builder(cmd)
+                .stderr(std::process::Stdio::null())
+                .spawn()
+                .map_err(|e| McpError::Connection {
+                    server_id: server_id.into(),
+                    message: e.to_string(),
+                })?;
+            proc
+        } else {
+            TokioChildProcess::new(cmd).map_err(|e| McpError::Connection {
+                server_id: server_id.into(),
+                message: e.to_string(),
+            })?
+        };
 
         let service =
             ().serve(transport)

--- a/crates/zeph-mcp/src/manager.rs
+++ b/crates/zeph-mcp/src/manager.rs
@@ -45,6 +45,7 @@ pub struct McpManager {
     clients: Arc<RwLock<HashMap<String, McpClient>>>,
     connected_server_ids: std::sync::RwLock<HashSet<String>>,
     enforcer: Arc<PolicyEnforcer>,
+    suppress_stderr: bool,
 }
 
 impl std::fmt::Debug for McpManager {
@@ -68,7 +69,17 @@ impl McpManager {
             clients: Arc::new(RwLock::new(HashMap::new())),
             connected_server_ids: std::sync::RwLock::new(HashSet::new()),
             enforcer: Arc::new(enforcer),
+            suppress_stderr: false,
         }
+    }
+
+    /// When `true`, stderr of spawned MCP child processes is suppressed (`Stdio::null()`).
+    ///
+    /// Use in TUI mode to prevent child stderr from corrupting the terminal.
+    #[must_use]
+    pub fn with_suppress_stderr(mut self, suppress: bool) -> Self {
+        self.suppress_stderr = suppress;
+        self
     }
 
     /// Connect to all configured servers concurrently, return aggregated tool list.
@@ -81,10 +92,11 @@ impl McpManager {
         let mut join_set = JoinSet::new();
 
         let allowed = self.allowed_commands.clone();
+        let suppress = self.suppress_stderr;
         for config in self.configs.clone() {
             let allowed = allowed.clone();
             join_set.spawn(async move {
-                let result = connect_entry(&config, &allowed).await;
+                let result = connect_entry(&config, &allowed, suppress).await;
                 (config.id, result)
             });
         }
@@ -168,7 +180,7 @@ impl McpManager {
             }
         }
 
-        let client = connect_entry(entry, &self.allowed_commands).await?;
+        let client = connect_entry(entry, &self.allowed_commands, self.suppress_stderr).await?;
         let tools = match client.list_tools().await {
             Ok(tools) => tools,
             Err(e) => {
@@ -284,6 +296,7 @@ impl McpManager {
 async fn connect_entry(
     entry: &ServerEntry,
     allowed_commands: &[String],
+    suppress_stderr: bool,
 ) -> Result<McpClient, McpError> {
     match &entry.transport {
         McpTransport::Stdio { command, args, env } => {
@@ -294,6 +307,7 @@ async fn connect_entry(
                 env,
                 allowed_commands,
                 entry.timeout,
+                suppress_stderr,
             )
             .await
         }
@@ -571,6 +585,14 @@ mod tests {
         let tools = mgr.connect_all().await;
         assert!(tools.is_empty());
         assert!(mgr.list_servers().await.is_empty());
+    }
+
+    #[test]
+    fn with_suppress_stderr_builder() {
+        let mgr =
+            McpManager::new(vec![], vec![], PolicyEnforcer::new(vec![])).with_suppress_stderr(true);
+        let dbg = format!("{mgr:?}");
+        assert!(dbg.contains("McpManager"));
     }
 
     impl McpManager {

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -269,8 +269,9 @@ async fn build_acp_deps(
             .map(PathBuf::from)
             .collect(),
     );
-    let mcp_manager = prebuilt_mcp_manager
-        .unwrap_or_else(|| std::sync::Arc::new(zeph_core::bootstrap::create_mcp_manager(config)));
+    let mcp_manager = prebuilt_mcp_manager.unwrap_or_else(|| {
+        std::sync::Arc::new(zeph_core::bootstrap::create_mcp_manager(config, false))
+    });
     let mcp_tools = mcp_manager.connect_all().await;
     let mcp_shared_tools = std::sync::Arc::new(std::sync::RwLock::new(mcp_tools.clone()));
     let mcp_executor =
@@ -1214,7 +1215,10 @@ pub(crate) async fn run_acp_http_server(
 
     // CLI flag overrides config/env values for auth token.
     let auth_bearer_token = auth_token_override.or(app.config().acp.auth_token.clone());
-    let mcp_manager_for_acp = Arc::new(zeph_core::bootstrap::create_mcp_manager(app.config()));
+    let mcp_manager_for_acp = Arc::new(zeph_core::bootstrap::create_mcp_manager(
+        app.config(),
+        false,
+    ));
     let server_config = zeph_acp::AcpServerConfig {
         agent_name: app.config().acp.agent_name.clone(),
         agent_version: app.config().acp.agent_version.clone(),

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -264,6 +264,7 @@ pub(crate) async fn build_tool_setup(
     config: &Config,
     permission_policy: zeph_tools::PermissionPolicy,
     with_tool_events: bool,
+    suppress_stderr: bool,
 ) -> ToolSetup {
     let filter_registry = if config.tools.filters.enabled {
         zeph_tools::OutputFilterRegistry::default_filters(&config.tools.filters)
@@ -299,7 +300,10 @@ pub(crate) async fn build_tool_setup(
             .collect(),
     );
 
-    let mcp_manager = Arc::new(zeph_core::bootstrap::create_mcp_manager(config));
+    let mcp_manager = Arc::new(zeph_core::bootstrap::create_mcp_manager(
+        config,
+        suppress_stderr,
+    ));
     let mcp_tools = mcp_manager.connect_all().await;
     tracing::info!("discovered {} MCP tool(s)", mcp_tools.len());
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -232,7 +232,7 @@ pub(crate) async fn run_daemon(
             .map(PathBuf::from)
             .collect(),
     );
-    let mcp_manager = std::sync::Arc::new(zeph_core::bootstrap::create_mcp_manager(config));
+    let mcp_manager = std::sync::Arc::new(zeph_core::bootstrap::create_mcp_manager(config, false));
     let mcp_tools = mcp_manager.connect_all().await;
     let mcp_shared_tools = std::sync::Arc::new(std::sync::RwLock::new(mcp_tools.clone()));
     let mcp_executor =

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -110,11 +110,30 @@ fn cli_requested_any_acp_mode(cli: &Cli) -> bool {
 
 #[cfg(feature = "acp")]
 fn configured_acp_autostart_transport(config: &Config, cli: &Cli) -> Option<AcpTransport> {
-    if config.acp.enabled && !cli_requested_any_acp_mode(cli) {
-        Some(config.acp.transport.clone())
-    } else {
-        None
+    if !config.acp.enabled || cli_requested_any_acp_mode(cli) {
+        return None;
     }
+
+    #[cfg(feature = "tui")]
+    if cli.tui {
+        // TUI owns stdin/stdout — stdio ACP transport is incompatible.
+        // Allow HTTP transport only when the acp-http feature is enabled;
+        // otherwise Http would silently fall back to stdio (which is also incompatible).
+        return match &config.acp.transport {
+            #[cfg(feature = "acp-http")]
+            AcpTransport::Http => Some(AcpTransport::Http),
+            _ => {
+                tracing::warn!(
+                    "ACP autostart skipped in TUI mode: \
+                     stdio and both transports are incompatible with TUI (both own stdin/stdout); \
+                     set [acp] transport = \"http\" to run ACP alongside TUI"
+                );
+                None
+            }
+        };
+    }
+
+    Some(config.acp.transport.clone())
 }
 
 #[cfg(feature = "acp")]
@@ -420,9 +439,19 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         Some(tokio::spawn(async move { warmup_provider(&p).await }))
     };
 
+    #[cfg(feature = "tui")]
+    let suppress_mcp_stderr = tui_active;
+    #[cfg(not(feature = "tui"))]
+    let suppress_mcp_stderr = false;
+
     let (memory_result, tool_setup) = tokio::join!(
         app.build_memory(&provider),
-        agent_setup::build_tool_setup(config, permission_policy.clone(), with_tool_events),
+        agent_setup::build_tool_setup(
+            config,
+            permission_policy.clone(),
+            with_tool_events,
+            suppress_mcp_stderr
+        ),
     );
     let memory = std::sync::Arc::new(memory_result?);
 
@@ -1415,6 +1444,49 @@ mod tests {
         let cli = Cli::parse_from(["zeph", "--acp-http"]);
         let mut config = Config::default();
         config.acp.enabled = true;
+        assert!(configured_acp_autostart_transport(&config, &cli).is_none());
+    }
+
+    #[cfg(all(feature = "acp", feature = "tui"))]
+    #[test]
+    fn configured_acp_autostart_transport_suppresses_stdio_in_tui_mode() {
+        let cli = Cli::parse_from(["zeph", "--tui"]);
+        let mut config = Config::default();
+        config.acp.enabled = true;
+        config.acp.transport = AcpTransport::Stdio;
+        assert!(configured_acp_autostart_transport(&config, &cli).is_none());
+    }
+
+    #[cfg(all(feature = "acp", feature = "tui"))]
+    #[test]
+    fn configured_acp_autostart_transport_suppresses_both_in_tui_mode() {
+        let cli = Cli::parse_from(["zeph", "--tui"]);
+        let mut config = Config::default();
+        config.acp.enabled = true;
+        config.acp.transport = AcpTransport::Both;
+        assert!(configured_acp_autostart_transport(&config, &cli).is_none());
+    }
+
+    #[cfg(all(feature = "acp", feature = "tui", feature = "acp-http"))]
+    #[test]
+    fn configured_acp_autostart_transport_allows_http_in_tui_mode_with_acp_http() {
+        let cli = Cli::parse_from(["zeph", "--tui"]);
+        let mut config = Config::default();
+        config.acp.enabled = true;
+        config.acp.transport = AcpTransport::Http;
+        assert!(matches!(
+            configured_acp_autostart_transport(&config, &cli),
+            Some(AcpTransport::Http)
+        ));
+    }
+
+    #[cfg(all(feature = "acp", feature = "tui", not(feature = "acp-http")))]
+    #[test]
+    fn configured_acp_autostart_transport_suppresses_http_in_tui_mode_without_acp_http() {
+        let cli = Cli::parse_from(["zeph", "--tui"]);
+        let mut config = Config::default();
+        config.acp.enabled = true;
+        config.acp.transport = AcpTransport::Http;
         assert!(configured_acp_autostart_transport(&config, &cli).is_none());
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1729 — running `zeph --tui` with `[acp] enabled = true` (default transport = `stdio`) caused the TUI to never open.

Two bugs fixed:

- **ACP stdio/TUI conflict**: `configured_acp_autostart_transport` now returns `None` when `--tui` is active and transport is `stdio` or `both`. HTTP transport is still allowed alongside TUI when the `acp-http` feature is enabled. A warning is logged when autostart is suppressed.
- **MCP child stderr corruption**: `McpManager` gains a `suppress_stderr` flag (default `false`) that switches MCP child processes to `Stdio::null()` in TUI mode, preventing subprocess logs from bleeding through ratatui's alternate screen.

## Changes

- `src/runner.rs` — TUI guard in `configured_acp_autostart_transport`; passes `tui_active` as `suppress_mcp_stderr` to `build_tool_setup`
- `crates/zeph-mcp/src/client.rs` — `McpClient::connect` accepts `suppress_stderr: bool`; uses `TokioChildProcess::builder().stderr()`
- `crates/zeph-mcp/src/manager.rs` — `McpManager` gains `suppress_stderr` field and `with_suppress_stderr` builder
- `crates/zeph-core/src/bootstrap/mcp.rs` — `create_mcp_manager` accepts `suppress_stderr: bool`
- `src/agent_setup.rs` — `build_tool_setup` accepts `suppress_stderr: bool`
- `src/daemon.rs`, `src/acp.rs` — pass `false` to `create_mcp_manager`
- `crates/zeph-core/src/bootstrap/tests.rs` — updated call sites

## Test plan

- [ ] 5 new unit tests added: stdio suppressed in TUI, both suppressed in TUI, http allowed (acp-http), http suppressed (no acp-http), `with_suppress_stderr` builder
- [ ] `cargo nextest run --workspace --features full --lib --bins`: 5427 passed, 12 skipped
- [ ] `cargo clippy --workspace --features full -- -D warnings`: clean
- [ ] `cargo +nightly fmt --check`: clean