### PR TITLE
refactor(zeph-core): decompose Agent struct and remove anyhow (#1731, #1732)

### DIFF
--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -58,7 +58,7 @@ impl<C: Channel> Agent<C> {
 
     #[must_use]
     pub fn with_stt(mut self, stt: Box<dyn zeph_llm::stt::SpeechToText>) -> Self {
-        self.stt = Some(stt);
+        self.providers.stt = Some(stt);
         self
     }
 
@@ -79,13 +79,13 @@ impl<C: Channel> Agent<C> {
 
     #[must_use]
     pub fn with_update_notifications(mut self, rx: mpsc::Receiver<String>) -> Self {
-        self.update_notify_rx = Some(rx);
+        self.lifecycle.update_notify_rx = Some(rx);
         self
     }
 
     #[must_use]
     pub fn with_custom_task_rx(mut self, rx: mpsc::Receiver<String>) -> Self {
-        self.custom_task_rx = Some(rx);
+        self.lifecycle.custom_task_rx = Some(rx);
         self
     }
 
@@ -217,7 +217,7 @@ impl<C: Channel> Agent<C> {
 
     #[must_use]
     pub fn with_shutdown(mut self, rx: watch::Receiver<bool>) -> Self {
-        self.shutdown = rx;
+        self.lifecycle.shutdown = rx;
         self
     }
 
@@ -246,8 +246,8 @@ impl<C: Channel> Agent<C> {
 
     #[must_use]
     pub fn with_config_reload(mut self, path: PathBuf, rx: mpsc::Receiver<ConfigEvent>) -> Self {
-        self.config_path = Some(path);
-        self.config_reload_rx = Some(rx);
+        self.lifecycle.config_path = Some(path);
+        self.lifecycle.config_reload_rx = Some(rx);
         self
     }
 
@@ -304,7 +304,7 @@ impl<C: Channel> Agent<C> {
 
     #[must_use]
     pub fn with_judge_provider(mut self, provider: AnyProvider) -> Self {
-        self.judge_provider = Some(provider);
+        self.providers.judge_provider = Some(provider);
         self
     }
 
@@ -313,7 +313,7 @@ impl<C: Channel> Agent<C> {
     /// When active, client-side reactive and proactive compaction are skipped.
     #[must_use]
     pub fn with_server_compaction(mut self, enabled: bool) -> Self {
-        self.server_compaction_active = enabled;
+        self.providers.server_compaction_active = enabled;
         self
     }
 
@@ -376,7 +376,7 @@ impl<C: Channel> Agent<C> {
 
     #[must_use]
     pub fn with_summary_provider(mut self, provider: AnyProvider) -> Self {
-        self.summary_provider = Some(provider);
+        self.providers.summary_provider = Some(provider);
         self
     }
 
@@ -390,7 +390,10 @@ impl<C: Channel> Agent<C> {
     }
 
     pub(super) fn summary_or_primary_provider(&self) -> &AnyProvider {
-        self.summary_provider.as_ref().unwrap_or(&self.provider)
+        self.providers
+            .summary_provider
+            .as_ref()
+            .unwrap_or(&self.provider)
     }
 
     /// Extract the last assistant message, truncated to 500 chars, for the judge prompt.
@@ -471,13 +474,13 @@ impl<C: Channel> Agent<C> {
 
     #[must_use]
     pub fn with_warmup_ready(mut self, rx: watch::Receiver<bool>) -> Self {
-        self.warmup_ready = Some(rx);
+        self.lifecycle.warmup_ready = Some(rx);
         self
     }
 
     #[must_use]
     pub fn with_cost_tracker(mut self, tracker: CostTracker) -> Self {
-        self.cost_tracker = Some(tracker);
+        self.metrics.cost_tracker = Some(tracker);
         self
     }
 
@@ -537,7 +540,7 @@ impl<C: Channel> Agent<C> {
             m.mcp_tool_count = mcp_tool_count;
             m.mcp_server_count = mcp_server_count;
         });
-        self.metrics_tx = Some(tx);
+        self.metrics.metrics_tx = Some(tx);
         self
     }
 
@@ -546,32 +549,32 @@ impl<C: Channel> Agent<C> {
     /// `notify_waiters()` to cancel whatever operation is running.
     #[must_use]
     pub fn cancel_signal(&self) -> Arc<Notify> {
-        Arc::clone(&self.cancel_signal)
+        Arc::clone(&self.lifecycle.cancel_signal)
     }
 
     /// Inject a shared cancel signal so an external caller (e.g. ACP session) can
     /// interrupt the agent loop by calling `notify_one()`.
     #[must_use]
     pub fn with_cancel_signal(mut self, signal: Arc<Notify>) -> Self {
-        self.cancel_signal = signal;
+        self.lifecycle.cancel_signal = signal;
         self
     }
 
     #[must_use]
     pub fn with_subagent_manager(mut self, manager: crate::subagent::SubAgentManager) -> Self {
-        self.subagent_manager = Some(manager);
+        self.orchestration.subagent_manager = Some(manager);
         self
     }
 
     #[must_use]
     pub fn with_subagent_config(mut self, config: crate::config::SubAgentConfig) -> Self {
-        self.subagent_config = config;
+        self.orchestration.subagent_config = config;
         self
     }
 
     #[must_use]
     pub fn with_orchestration_config(mut self, config: crate::config::OrchestrationConfig) -> Self {
-        self.orchestration_config = config;
+        self.orchestration.orchestration_config = config;
         self
     }
 
@@ -605,7 +608,7 @@ impl<C: Channel> Agent<C> {
         mut self,
         slot: Arc<std::sync::RwLock<Option<AnyProvider>>>,
     ) -> Self {
-        self.provider_override = Some(slot);
+        self.providers.provider_override = Some(slot);
         self
     }
 }

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -169,7 +169,7 @@ impl<C: Channel> Agent<C> {
             &self.memory_state,
             query,
             token_budget,
-            &self.token_counter,
+            &self.metrics.token_counter,
             None,
         )
         .await?
@@ -350,9 +350,13 @@ impl<C: Channel> Agent<C> {
     ) -> Result<(), super::super::error::AgentError> {
         self.remove_cross_session_messages();
 
-        if let Some(msg) =
-            Self::fetch_cross_session(&self.memory_state, query, token_budget, &self.token_counter)
-                .await?
+        if let Some(msg) = Self::fetch_cross_session(
+            &self.memory_state,
+            query,
+            token_budget,
+            &self.metrics.token_counter,
+        )
+        .await?
             && self.messages.len() > 1
         {
             self.messages.insert(1, msg);
@@ -416,8 +420,12 @@ impl<C: Channel> Agent<C> {
     ) -> Result<(), super::super::error::AgentError> {
         self.remove_summary_messages();
 
-        if let Some(msg) =
-            Self::fetch_summaries(&self.memory_state, token_budget, &self.token_counter).await?
+        if let Some(msg) = Self::fetch_summaries(
+            &self.memory_state,
+            token_budget,
+            &self.metrics.token_counter,
+        )
+        .await?
             && self.messages.len() > 1
         {
             self.messages.insert(1, msg);
@@ -489,7 +497,10 @@ impl<C: Channel> Agent<C> {
         let mut keep_from = self.messages.len();
 
         for i in (history_start..self.messages.len()).rev() {
-            let msg_tokens = self.token_counter.count_message_tokens(&self.messages[i]);
+            let msg_tokens = self
+                .metrics
+                .token_counter
+                .count_message_tokens(&self.messages[i]);
             if total + msg_tokens > token_budget {
                 break;
             }
@@ -526,7 +537,7 @@ impl<C: Channel> Agent<C> {
         let alloc = budget.allocate(
             system_prompt,
             &self.skill_state.last_skills_prompt,
-            &self.token_counter,
+            &self.metrics.token_counter,
             graph_enabled,
         );
 
@@ -574,7 +585,7 @@ impl<C: Channel> Agent<C> {
                 >,
             >;
 
-            let tc = self.token_counter.clone();
+            let tc = self.metrics.token_counter.clone();
             let router = self.context_manager.build_router();
             let memory_state = &self.memory_state;
             let index = &self.index;
@@ -1175,7 +1186,7 @@ impl<C: Channel> Agent<C> {
             } else {
                 let cwd2 = cwd.clone();
                 let token_budget = self.index.repo_map_tokens;
-                let tc = Arc::clone(&self.token_counter);
+                let tc = Arc::clone(&self.metrics.token_counter);
                 let fresh = tokio::task::spawn_blocking(move || {
                     zeph_index::repo_map::generate_repo_map(&cwd2, token_budget, &tc)
                 })

--- a/crates/zeph-core/src/agent/context/mod.rs
+++ b/crates/zeph-core/src/agent/context/mod.rs
@@ -86,7 +86,7 @@ pub(super) enum ContextSlot {
 impl<C: Channel> Agent<C> {
     pub(super) fn compaction_tier(&self) -> super::context_manager::CompactionTier {
         self.context_manager
-            .compaction_tier(self.cached_prompt_tokens)
+            .compaction_tier(self.providers.cached_prompt_tokens)
     }
 }
 
@@ -1465,7 +1465,7 @@ mod tests {
         let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
             .with_context_budget(1000, 0.20, 0.75, 4, 0)
             .with_soft_compaction_threshold(0.50);
-        agent.cached_prompt_tokens = 900;
+        agent.providers.cached_prompt_tokens = 900;
 
         assert_eq!(
             agent.compaction_tier(),
@@ -1485,7 +1485,7 @@ mod tests {
         let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
             .with_context_budget(1000, 0.20, 0.75, 4, 0)
             .with_soft_compaction_threshold(0.50);
-        agent.cached_prompt_tokens = 100;
+        agent.providers.cached_prompt_tokens = 100;
 
         assert_eq!(
             agent.compaction_tier(),
@@ -2681,7 +2681,7 @@ mod tests {
         let executor = MockToolExecutor::no_tools();
 
         let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
-        agent.cached_prompt_tokens = 200_000; // very high token count
+        agent.providers.cached_prompt_tokens = 200_000; // very high token count
 
         // should_proactively_compress returns None for Reactive → no compression
         let result = agent.maybe_proactive_compress().await;
@@ -3253,7 +3253,7 @@ mod tests {
 
         agent.messages[2].metadata.deferred_summary = Some("s".into());
         // Simulate token usage above 70% soft threshold
-        agent.cached_prompt_tokens = 75_000;
+        agent.providers.cached_prompt_tokens = 75_000;
 
         assert!(!agent.context_manager.compacted_this_turn);
         agent.maybe_apply_deferred_summaries();
@@ -3290,7 +3290,7 @@ mod tests {
         agent.messages[12].metadata.deferred_summary = Some("s_f".into());
 
         // Token count well below budget threshold (simulates post-pruning state)
-        agent.cached_prompt_tokens = 5_000;
+        agent.providers.cached_prompt_tokens = 5_000;
 
         agent.maybe_apply_deferred_summaries();
 
@@ -3505,7 +3505,7 @@ mod tests {
         // Seed cached_prompt_tokens above threshold so maybe_compact proceeds past Guard 1.
         // Messages were pushed directly (bypassing push_message), so we set this explicitly.
         // Use a large value so freed_tokens > 0 after compact_context() recomputes.
-        agent.cached_prompt_tokens = 10_000;
+        agent.providers.cached_prompt_tokens = 10_000;
 
         agent.maybe_compact().await.unwrap();
 

--- a/crates/zeph-core/src/agent/context/summarization.rs
+++ b/crates/zeph-core/src/agent/context/summarization.rs
@@ -106,7 +106,7 @@ impl<C: Channel> Agent<C> {
             messages,
             CHUNK_TOKEN_BUDGET,
             OVERSIZED_THRESHOLD,
-            &self.token_counter,
+            &self.metrics.token_counter,
         );
 
         let llm_timeout = std::time::Duration::from_secs(self.runtime.timeouts.llm_seconds);
@@ -389,7 +389,7 @@ impl<C: Channel> Agent<C> {
 
         tracing::info!(
             compacted_count,
-            summary_tokens = self.token_counter.count_tokens(&summary),
+            summary_tokens = self.metrics.token_counter.count_tokens(&summary),
             "compacted context"
         );
 
@@ -451,7 +451,7 @@ impl<C: Channel> Agent<C> {
         let mut protection_boundary = self.messages.len();
         if protect > 0 {
             for (i, msg) in self.messages.iter().enumerate().rev() {
-                tail_tokens += self.token_counter.count_message_tokens(msg);
+                tail_tokens += self.metrics.token_counter.count_message_tokens(msg);
                 if tail_tokens >= protect {
                     protection_boundary = i;
                     break;
@@ -482,7 +482,7 @@ impl<C: Channel> Agent<C> {
                     && compacted_at.is_none()
                     && !body.is_empty()
                 {
-                    freed += self.token_counter.count_tokens(body);
+                    freed += self.metrics.token_counter.count_tokens(body);
                     *compacted_at = Some(now);
                     *body = String::new();
                     modified = true;
@@ -531,13 +531,13 @@ impl<C: Channel> Agent<C> {
                     MessagePart::ToolOutput {
                         body, compacted_at, ..
                     } if compacted_at.is_none() && !body.is_empty() => {
-                        freed += self.token_counter.count_tokens(body);
+                        freed += self.metrics.token_counter.count_tokens(body);
                         *compacted_at = Some(now);
                         *body = String::new();
                         modified = true;
                     }
                     MessagePart::ToolResult { content, .. } => {
-                        let tokens = self.token_counter.count_tokens(content);
+                        let tokens = self.metrics.token_counter.count_tokens(content);
                         if tokens > 20 {
                             freed += tokens;
                             "[pruned]".clone_into(content);
@@ -866,7 +866,7 @@ impl<C: Channel> Agent<C> {
 
         // S1: skip client-side compaction when server compaction is active — unless context
         // has grown past 95% of the budget without a server compaction event (safety fallback).
-        if self.server_compaction_active {
+        if self.providers.server_compaction_active {
             let budget = self
                 .context_manager
                 .budget
@@ -876,7 +876,7 @@ impl<C: Channel> Agent<C> {
                 let total_tokens: usize = self
                     .messages
                     .iter()
-                    .map(|m| self.token_counter.count_message_tokens(m))
+                    .map(|m| self.metrics.token_counter.count_message_tokens(m))
                     .sum();
                 let fallback_threshold = budget * 95 / 100;
                 if total_tokens < fallback_threshold {
@@ -918,7 +918,8 @@ impl<C: Channel> Agent<C> {
                     .map_or(0, ContextBudget::max_tokens);
                 let soft_threshold =
                     (budget as f32 * self.context_manager.soft_compaction_threshold) as usize;
-                let cached = usize::try_from(self.cached_prompt_tokens).unwrap_or(usize::MAX);
+                let cached =
+                    usize::try_from(self.providers.cached_prompt_tokens).unwrap_or(usize::MAX);
                 let min_to_free = cached.saturating_sub(soft_threshold);
                 if min_to_free > 0 {
                     self.prune_tool_outputs(min_to_free);
@@ -926,7 +927,7 @@ impl<C: Channel> Agent<C> {
 
                 let _ = self.channel.send_status("").await;
                 tracing::info!(
-                    cached_tokens = self.cached_prompt_tokens,
+                    cached_tokens = self.providers.cached_prompt_tokens,
                     soft_threshold,
                     "soft compaction complete"
                 );
@@ -951,7 +952,8 @@ impl<C: Channel> Agent<C> {
                     .map_or(0, ContextBudget::max_tokens);
                 let hard_threshold =
                     (budget as f32 * self.context_manager.hard_compaction_threshold) as usize;
-                let cached = usize::try_from(self.cached_prompt_tokens).unwrap_or(usize::MAX);
+                let cached =
+                    usize::try_from(self.providers.cached_prompt_tokens).unwrap_or(usize::MAX);
                 let min_to_free = cached.saturating_sub(hard_threshold);
 
                 let _ = self.channel.send_status("compacting context...").await;
@@ -990,12 +992,13 @@ impl<C: Channel> Agent<C> {
                     min_to_free,
                     "hard compaction: pruning insufficient, falling back to LLM summarization"
                 );
-                let tokens_before = self.cached_prompt_tokens;
+                let tokens_before = self.providers.cached_prompt_tokens;
                 let result = self.compact_context().await;
                 if result.is_ok() {
                     // Guard 2 — Counterproductive: net freed tokens is zero (summary ate all
                     // freed space — no net reduction).
-                    let freed_tokens = tokens_before.saturating_sub(self.cached_prompt_tokens);
+                    let freed_tokens =
+                        tokens_before.saturating_sub(self.providers.cached_prompt_tokens);
                     if freed_tokens == 0 {
                         tracing::warn!(
                             "hard compaction: summary consumed all freed tokens — no net \
@@ -1035,7 +1038,7 @@ impl<C: Channel> Agent<C> {
     ) -> Result<(), super::super::error::AgentError> {
         // S1: skip proactive compression when server compaction is active — unless context
         // has grown past 95% of the budget without a server compaction event (safety fallback).
-        if self.server_compaction_active {
+        if self.providers.server_compaction_active {
             let budget = self
                 .context_manager
                 .budget
@@ -1043,11 +1046,11 @@ impl<C: Channel> Agent<C> {
                 .map_or(0, ContextBudget::max_tokens);
             if budget > 0 {
                 let fallback_threshold = (budget * 95 / 100) as u64;
-                if self.cached_prompt_tokens <= fallback_threshold {
+                if self.providers.cached_prompt_tokens <= fallback_threshold {
                     return Ok(());
                 }
                 tracing::warn!(
-                    cached_prompt_tokens = self.cached_prompt_tokens,
+                    cached_prompt_tokens = self.providers.cached_prompt_tokens,
                     fallback_threshold,
                     "server compaction active but context at 95%+ — falling back to client-side proactive"
                 );
@@ -1057,12 +1060,12 @@ impl<C: Channel> Agent<C> {
         }
         let Some((_threshold, max_summary_tokens)) = self
             .context_manager
-            .should_proactively_compress(self.cached_prompt_tokens)
+            .should_proactively_compress(self.providers.cached_prompt_tokens)
         else {
             return Ok(());
         };
 
-        let tokens_before = self.cached_prompt_tokens;
+        let tokens_before = self.providers.cached_prompt_tokens;
         let _ = self.channel.send_status("compressing context...").await;
         tracing::info!(
             max_summary_tokens,
@@ -1076,7 +1079,7 @@ impl<C: Channel> Agent<C> {
 
         if result.is_ok() {
             self.context_manager.compacted_this_turn = true;
-            let tokens_saved = tokens_before.saturating_sub(self.cached_prompt_tokens);
+            let tokens_saved = tokens_before.saturating_sub(self.providers.cached_prompt_tokens);
             self.update_metrics(|m| {
                 m.compression_events += 1;
                 m.compression_tokens_saved += tokens_saved;
@@ -1130,7 +1133,7 @@ impl<C: Channel> Agent<C> {
 
         tracing::info!(
             compacted_count,
-            summary_tokens = self.token_counter.count_tokens(&summary),
+            summary_tokens = self.metrics.token_counter.count_tokens(&summary),
             "compacted context (with budget)"
         );
 
@@ -1192,7 +1195,7 @@ impl<C: Channel> Agent<C> {
             messages,
             chunk_token_budget,
             oversized_threshold,
-            &self.token_counter,
+            &self.metrics.token_counter,
         );
 
         let llm_timeout = std::time::Duration::from_secs(self.runtime.timeouts.llm_seconds);

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -191,6 +191,58 @@ pub(super) struct DebugState {
     pub(super) logging_config: crate::config::LoggingConfig,
 }
 
+/// Groups agent lifecycle state: shutdown signaling, timing, and I/O notification channels.
+pub(super) struct LifecycleState {
+    pub(super) shutdown: watch::Receiver<bool>,
+    pub(super) start_time: Instant,
+    pub(super) cancel_signal: Arc<Notify>,
+    pub(super) cancel_token: CancellationToken,
+    pub(super) config_path: Option<PathBuf>,
+    pub(super) config_reload_rx: Option<mpsc::Receiver<ConfigEvent>>,
+    pub(super) warmup_ready: Option<watch::Receiver<bool>>,
+    pub(super) update_notify_rx: Option<mpsc::Receiver<String>>,
+    pub(super) custom_task_rx: Option<mpsc::Receiver<String>>,
+}
+
+/// Groups provider-related state: alternate providers, runtime switching, and compaction flags.
+pub(super) struct ProviderState {
+    pub(super) summary_provider: Option<AnyProvider>,
+    /// Shared slot for runtime model switching; set by external caller (e.g. ACP).
+    pub(super) provider_override: Option<Arc<std::sync::RwLock<Option<AnyProvider>>>>,
+    pub(super) judge_provider: Option<AnyProvider>,
+    pub(super) cached_prompt_tokens: u64,
+    /// Whether the active provider has server-side compaction enabled (Claude compact-2026-01-12).
+    /// When true, client-side compaction is skipped.
+    pub(super) server_compaction_active: bool,
+    pub(super) stt: Option<Box<dyn SpeechToText>>,
+}
+
+/// Groups metrics and cost tracking state.
+pub(super) struct MetricsState {
+    pub(super) metrics_tx: Option<watch::Sender<MetricsSnapshot>>,
+    pub(super) cost_tracker: Option<CostTracker>,
+    pub(super) token_counter: Arc<TokenCounter>,
+}
+
+/// Groups task orchestration and subagent state.
+pub(super) struct OrchestrationState {
+    /// Graph waiting for `/plan confirm` before execution starts.
+    pub(super) pending_graph: Option<crate::orchestration::TaskGraph>,
+    /// Cancellation token for the currently executing plan. `None` when no plan is running.
+    /// Created fresh in `handle_plan_confirm()`, cancelled in `handle_plan_cancel()`.
+    ///
+    /// # Known limitation
+    ///
+    /// Token plumbing is ready; the delivery path requires the agent message loop to be
+    /// restructured so `/plan cancel` can be received while `run_scheduler_loop` holds
+    /// `&mut self`. See follow-up issue #1603 (SEC-M34-002).
+    pub(super) plan_cancel_token: Option<CancellationToken>,
+    /// Manages spawned sub-agents.
+    pub(super) subagent_manager: Option<crate::subagent::SubAgentManager>,
+    pub(super) subagent_config: crate::config::SubAgentConfig,
+    pub(super) orchestration_config: crate::config::OrchestrationConfig,
+}
+
 pub struct Agent<C: Channel> {
     provider: AnyProvider,
     channel: C,
@@ -203,37 +255,11 @@ pub struct Agent<C: Channel> {
     pub(super) learning_engine: learning_engine::LearningEngine,
     pub(super) feedback_detector: feedback_detector::FeedbackDetector,
     pub(super) judge_detector: Option<feedback_detector::JudgeDetector>,
-    pub(super) judge_provider: Option<AnyProvider>,
-    config_path: Option<PathBuf>,
-    config_reload_rx: Option<mpsc::Receiver<ConfigEvent>>,
-    shutdown: watch::Receiver<bool>,
-    metrics_tx: Option<watch::Sender<MetricsSnapshot>>,
     pub(super) runtime: RuntimeConfig,
     pub(super) mcp: McpState,
     pub(super) index: IndexState,
-    cancel_signal: Arc<Notify>,
-    cancel_token: CancellationToken,
-    start_time: Instant,
     message_queue: VecDeque<QueuedMessage>,
-    summary_provider: Option<AnyProvider>,
-    /// Shared slot for runtime model switching; set by external caller (e.g. ACP).
-    provider_override: Option<Arc<std::sync::RwLock<Option<AnyProvider>>>>,
-    warmup_ready: Option<watch::Receiver<bool>>,
-    cost_tracker: Option<CostTracker>,
-    cached_prompt_tokens: u64,
     env_context: EnvironmentContext,
-    pub(crate) token_counter: Arc<TokenCounter>,
-    stt: Option<Box<dyn SpeechToText>>,
-    update_notify_rx: Option<mpsc::Receiver<String>>,
-    custom_task_rx: Option<mpsc::Receiver<String>>,
-    /// Manages spawned sub-agents. Wired up during construction but not yet
-    /// dispatched to in the current agent loop iteration; retained for
-    /// forward-compatible multi-agent orchestration.
-    pub(crate) subagent_manager: Option<crate::subagent::SubAgentManager>,
-    pub(crate) subagent_config: crate::config::SubAgentConfig,
-    pub(crate) orchestration_config: crate::config::OrchestrationConfig,
-    #[cfg(feature = "experiments")]
-    pub(super) experiment_config: crate::config::ExperimentConfig,
     pub(super) response_cache: Option<std::sync::Arc<zeph_memory::ResponseCache>>,
     /// Parent tool call ID when this agent runs as a subagent inside another agent session.
     /// Propagated into every `LoopbackEvent::ToolStart` / `ToolOutput` so the IDE can build
@@ -247,22 +273,8 @@ pub struct Agent<C: Channel> {
     pub(super) security: SecurityState,
     /// Image parts staged by `/image` commands, attached to the next user message.
     pending_image_parts: Vec<zeph_llm::provider::MessagePart>,
-    /// Graph waiting for `/plan confirm` before execution starts.
-    pub(super) pending_graph: Option<crate::orchestration::TaskGraph>,
-    /// Cancellation token for the currently executing plan. `None` when no plan is running.
-    /// Created fresh in `handle_plan_confirm()`, cancelled in `handle_plan_cancel()`.
-    ///
-    /// # Known limitation
-    ///
-    /// Token plumbing is ready; the delivery path requires the agent message loop to be
-    /// restructured so `/plan cancel` can be received while `run_scheduler_loop` holds
-    /// `&mut self`. See follow-up issue #1603 (SEC-M34-002).
-    plan_cancel_token: Option<CancellationToken>,
-
-    /// LSP context injection hooks. Fires after native tool execution, injects
-    /// diagnostics/hover notes as `Role::System` messages before the next LLM call.
-    #[cfg(feature = "lsp-context")]
-    pub(super) lsp_hooks: Option<crate::lsp_hooks::LspHookRunner>,
+    #[cfg(feature = "experiments")]
+    pub(super) experiment_config: crate::config::ExperimentConfig,
     /// Cancellation token for a running experiment session. `Some` means an experiment is active.
     #[cfg(feature = "experiments")]
     pub(super) experiment_cancel: Option<tokio_util::sync::CancellationToken>,
@@ -279,9 +291,15 @@ pub struct Agent<C: Channel> {
     /// Feature-gated because it is only used in `experiment_cmd.rs`.
     #[cfg(feature = "experiments")]
     pub(super) experiment_notify_tx: tokio::sync::mpsc::Sender<String>,
-    /// Whether the active provider has server-side compaction enabled (Claude compact-2026-01-12).
-    /// When true, client-side compaction is skipped.
-    pub(super) server_compaction_active: bool,
+    /// LSP context injection hooks. Fires after native tool execution, injects
+    /// diagnostics/hover notes as `Role::System` messages before the next LLM call.
+    #[cfg(feature = "lsp-context")]
+    pub(super) lsp_hooks: Option<crate::lsp_hooks::LspHookRunner>,
+    // --- New sub-structs ---
+    pub(super) lifecycle: LifecycleState,
+    pub(super) providers: ProviderState,
+    pub(super) metrics: MetricsState,
+    pub(super) orchestration: OrchestrationState,
 }
 
 impl<C: Channel> Agent<C> {
@@ -393,17 +411,12 @@ impl<C: Channel> Agent<C> {
             learning_engine: learning_engine::LearningEngine::new(),
             feedback_detector: feedback_detector::FeedbackDetector::new(0.6),
             judge_detector: None,
-            judge_provider: None,
-            config_path: None,
             debug_state: DebugState {
                 debug_dumper: None,
                 dump_format: crate::debug_dump::DumpFormat::default(),
                 anomaly_detector: None,
                 logging_config: crate::config::LoggingConfig::default(),
             },
-            config_reload_rx: None,
-            shutdown: rx,
-            metrics_tx: None,
             runtime: RuntimeConfig {
                 security: SecurityConfig::default(),
                 timeouts: TimeoutConfig::default(),
@@ -425,30 +438,8 @@ impl<C: Channel> Agent<C> {
                 cached_repo_map: None,
                 repo_map_ttl: std::time::Duration::from_secs(300),
             },
-            cancel_signal: Arc::new(Notify::new()),
-            cancel_token: CancellationToken::new(),
-            start_time: Instant::now(),
             message_queue: VecDeque::new(),
-            summary_provider: None,
-            provider_override: None,
-            warmup_ready: None,
-            cost_tracker: None,
-            cached_prompt_tokens: initial_prompt_tokens,
             env_context: EnvironmentContext::gather(""),
-            token_counter,
-            stt: None,
-            update_notify_rx: None,
-            custom_task_rx: None,
-            subagent_manager: None,
-            subagent_config: crate::config::SubAgentConfig::default(),
-            orchestration_config: crate::config::OrchestrationConfig::default(),
-            #[cfg(feature = "experiments")]
-            experiment_config: crate::config::ExperimentConfig::default(),
-            #[cfg(feature = "experiments")]
-            experiment_baseline: crate::experiments::ConfigSnapshot::default(),
-            experiment_notify_rx: Some(exp_notify_rx),
-            #[cfg(feature = "experiments")]
-            experiment_notify_tx: exp_notify_tx,
             response_cache: None,
             parent_tool_use_id: None,
             instruction_blocks: Vec::new(),
@@ -465,14 +456,49 @@ impl<C: Channel> Agent<C> {
                 flagged_urls: std::collections::HashSet::new(),
             },
             pending_image_parts: Vec::new(),
-            pending_graph: None,
-            plan_cancel_token: None,
-
+            #[cfg(feature = "experiments")]
+            experiment_config: crate::config::ExperimentConfig::default(),
+            #[cfg(feature = "experiments")]
+            experiment_baseline: crate::experiments::ConfigSnapshot::default(),
+            experiment_notify_rx: Some(exp_notify_rx),
+            #[cfg(feature = "experiments")]
+            experiment_notify_tx: exp_notify_tx,
             #[cfg(feature = "lsp-context")]
             lsp_hooks: None,
             #[cfg(feature = "experiments")]
             experiment_cancel: None,
-            server_compaction_active: false,
+            // --- New sub-structs ---
+            lifecycle: LifecycleState {
+                shutdown: rx,
+                start_time: Instant::now(),
+                cancel_signal: Arc::new(Notify::new()),
+                cancel_token: CancellationToken::new(),
+                config_path: None,
+                config_reload_rx: None,
+                warmup_ready: None,
+                update_notify_rx: None,
+                custom_task_rx: None,
+            },
+            providers: ProviderState {
+                summary_provider: None,
+                provider_override: None,
+                judge_provider: None,
+                cached_prompt_tokens: initial_prompt_tokens,
+                server_compaction_active: false,
+                stt: None,
+            },
+            metrics: MetricsState {
+                metrics_tx: None,
+                cost_tracker: None,
+                token_counter,
+            },
+            orchestration: OrchestrationState {
+                pending_graph: None,
+                plan_cancel_token: None,
+                subagent_manager: None,
+                subagent_config: crate::config::SubAgentConfig::default(),
+                orchestration_config: crate::config::OrchestrationConfig::default(),
+            },
         }
     }
 
@@ -481,7 +507,7 @@ impl<C: Channel> Agent<C> {
     /// Non-blocking: returns immediately with a list of `(task_id, result)` pairs
     /// for agents that have finished. Each completed agent is removed from the manager.
     pub async fn poll_subagents(&mut self) -> Vec<(String, String)> {
-        let Some(mgr) = &mut self.subagent_manager else {
+        let Some(mgr) = &mut self.orchestration.subagent_manager else {
             return vec![];
         };
 
@@ -541,13 +567,13 @@ impl<C: Channel> Agent<C> {
     }
 
     fn config_for_orchestration(&self) -> &crate::config::OrchestrationConfig {
-        &self.orchestration_config
+        &self.orchestration.orchestration_config
     }
 
     async fn handle_plan_goal(&mut self, goal: &str) -> Result<(), error::AgentError> {
         use crate::orchestration::{LlmPlanner, Planner};
 
-        if self.pending_graph.is_some() {
+        if self.orchestration.pending_graph.is_some() {
             self.channel
                 .send(
                     "A plan is already pending confirmation. \
@@ -560,16 +586,23 @@ impl<C: Channel> Agent<C> {
         self.channel.send("Planning task decomposition...").await?;
 
         let available_agents = self
+            .orchestration
             .subagent_manager
             .as_ref()
             .map(|m| m.definitions().to_vec())
             .unwrap_or_default();
 
-        let confirm_before_execute = self.orchestration_config.confirm_before_execute;
-        let graph = LlmPlanner::new(self.provider.clone(), &self.orchestration_config)
-            .plan(goal, &available_agents)
-            .await
-            .map_err(|e| error::AgentError::Other(e.to_string()))?;
+        let confirm_before_execute = self
+            .orchestration
+            .orchestration_config
+            .confirm_before_execute;
+        let graph = LlmPlanner::new(
+            self.provider.clone(),
+            &self.orchestration.orchestration_config,
+        )
+        .plan(goal, &available_agents)
+        .await
+        .map_err(|e| error::AgentError::Other(e.to_string()))?;
 
         let task_count = graph.tasks.len() as u64;
         let snapshot = crate::metrics::TaskGraphSnapshot::from(&graph);
@@ -585,7 +618,7 @@ impl<C: Channel> Agent<C> {
             self.channel
                 .send("Type `/plan confirm` to execute, or `/plan cancel` to abort.")
                 .await?;
-            self.pending_graph = Some(graph);
+            self.orchestration.pending_graph = Some(graph);
         } else {
             // confirm_before_execute = false: display and proceed (Phase 5 will run scheduler).
             // TODO(#1241): wire DagScheduler tick updates for Running task state
@@ -611,7 +644,7 @@ impl<C: Channel> Agent<C> {
     async fn handle_plan_confirm(&mut self) -> Result<(), error::AgentError> {
         use crate::orchestration::{DagScheduler, GraphStatus, RuleBasedRouter};
 
-        let Some(graph) = self.pending_graph.take() else {
+        let Some(graph) = self.orchestration.pending_graph.take() else {
             self.channel
                 .send("No pending plan to confirm. Use `/plan <goal>` to create one.")
                 .await?;
@@ -619,14 +652,14 @@ impl<C: Channel> Agent<C> {
         };
 
         // When subagent manager is not configured, restore graph and inform the user.
-        if self.subagent_manager.is_none() {
+        if self.orchestration.subagent_manager.is_none() {
             self.channel
                 .send(
                     "No sub-agents configured. Add sub-agent definitions to config \
                      to enable plan execution.",
                 )
                 .await?;
-            self.pending_graph = Some(graph);
+            self.orchestration.pending_graph = Some(graph);
             return Ok(());
         }
 
@@ -634,7 +667,7 @@ impl<C: Channel> Agent<C> {
         // restore it to pending_graph on failure.
         if graph.tasks.is_empty() {
             self.channel.send("Plan has no tasks.").await?;
-            self.pending_graph = Some(graph);
+            self.orchestration.pending_graph = Some(graph);
             return Ok(());
         }
         // resume_from() rejects Completed and Canceled — guard those here too.
@@ -645,11 +678,12 @@ impl<C: Channel> Agent<C> {
                     graph.status
                 ))
                 .await?;
-            self.pending_graph = Some(graph);
+            self.orchestration.pending_graph = Some(graph);
             return Ok(());
         }
 
         let available_agents = self
+            .orchestration
             .subagent_manager
             .as_ref()
             .map(|m| m.definitions().to_vec())
@@ -658,8 +692,8 @@ impl<C: Channel> Agent<C> {
         // Warn when max_concurrent is too low to support the configured parallelism.
         // This is the main cause of DagScheduler deadlocks (#1619): a planning-phase
         // sub-agent occupies the only slot while orchestration tasks are waiting.
-        let max_concurrent = self.subagent_config.max_concurrent;
-        let max_parallel = self.orchestration_config.max_parallel as usize;
+        let max_concurrent = self.orchestration.subagent_config.max_concurrent;
+        let max_parallel = self.orchestration.orchestration_config.max_parallel as usize;
         if max_concurrent < max_parallel + 1 {
             tracing::warn!(
                 max_concurrent,
@@ -673,7 +707,7 @@ impl<C: Channel> Agent<C> {
         // Reserve slots equal to max_parallel so the scheduler is guaranteed capacity
         // even if a planning-phase sub-agent is occupying a slot (#1619).
         let reserved = max_parallel.min(max_concurrent.saturating_sub(1));
-        if let Some(mgr) = self.subagent_manager.as_mut() {
+        if let Some(mgr) = self.orchestration.subagent_manager.as_mut() {
             mgr.reserve_slots(reserved);
         }
 
@@ -682,21 +716,21 @@ impl<C: Channel> Agent<C> {
         let mut scheduler = if graph.status == GraphStatus::Created {
             DagScheduler::new(
                 graph,
-                &self.orchestration_config,
+                &self.orchestration.orchestration_config,
                 Box::new(RuleBasedRouter),
                 available_agents,
             )
         } else {
             DagScheduler::resume_from(
                 graph,
-                &self.orchestration_config,
+                &self.orchestration.orchestration_config,
                 Box::new(RuleBasedRouter),
                 available_agents,
             )
         }
         .map_err(|e| {
             // Release reservation before propagating error.
-            if let Some(mgr) = self.subagent_manager.as_mut() {
+            if let Some(mgr) = self.orchestration.subagent_manager.as_mut() {
                 mgr.release_reservation(reserved);
             }
             error::AgentError::Other(e.to_string())
@@ -710,16 +744,16 @@ impl<C: Channel> Agent<C> {
             .await?;
 
         let plan_token = CancellationToken::new();
-        self.plan_cancel_token = Some(plan_token.clone());
+        self.orchestration.plan_cancel_token = Some(plan_token.clone());
 
         // Use match instead of ? so plan_cancel_token is always cleared (CRIT-07).
         let scheduler_result = self
             .run_scheduler_loop(&mut scheduler, task_count, plan_token)
             .await;
-        self.plan_cancel_token = None;
+        self.orchestration.plan_cancel_token = None;
 
         // Always release the reservation, regardless of scheduler outcome.
-        if let Some(mgr) = self.subagent_manager.as_mut() {
+        if let Some(mgr) = self.orchestration.subagent_manager.as_mut() {
             mgr.release_reservation(reserved);
         }
 
@@ -805,10 +839,11 @@ impl<C: Channel> Agent<C> {
                         let provider = self.provider.clone();
                         let tool_executor = Arc::clone(&self.tool_executor);
                         let skills = self.filtered_skills_for(&agent_def_name);
-                        let cfg = self.subagent_config.clone();
+                        let cfg = self.orchestration.subagent_config.clone();
                         let event_tx = scheduler.event_sender();
 
                         let mgr = self
+                            .orchestration
                             .subagent_manager
                             .as_mut()
                             .expect("subagent_manager checked above");
@@ -845,7 +880,9 @@ impl<C: Channel> Agent<C> {
                                 for a in extra {
                                     match a {
                                         SchedulerAction::Cancel { agent_handle_id } => {
-                                            if let Some(m) = self.subagent_manager.as_mut() {
+                                            if let Some(m) =
+                                                self.orchestration.subagent_manager.as_mut()
+                                            {
                                                 // benign race: agent may have already finished
                                                 let _ =
                                                     m.cancel(&agent_handle_id).inspect_err(|err| {
@@ -867,7 +904,7 @@ impl<C: Channel> Agent<C> {
                         }
                     }
                     SchedulerAction::Cancel { agent_handle_id } => {
-                        if let Some(mgr) = self.subagent_manager.as_mut() {
+                        if let Some(mgr) = self.orchestration.subagent_manager.as_mut() {
                             // benign race: agent may have already finished
                             let _ = mgr.cancel(&agent_handle_id).inspect_err(|e| {
                                 tracing::trace!(error = %e, "cancel: agent already gone");
@@ -985,7 +1022,7 @@ impl<C: Channel> Agent<C> {
                     for action in cancel_actions {
                         match action {
                             SchedulerAction::Cancel { agent_handle_id } => {
-                                if let Some(mgr) = self.subagent_manager.as_mut() {
+                                if let Some(mgr) = self.orchestration.subagent_manager.as_mut() {
                                     let _ = mgr.cancel(&agent_handle_id).inspect_err(|e| {
                                         tracing::trace!(
                                             error = %e,
@@ -1013,7 +1050,7 @@ impl<C: Channel> Agent<C> {
                             for ca in cancel_actions {
                                 match ca {
                                     SchedulerAction::Cancel { agent_handle_id } => {
-                                        if let Some(mgr) = self.subagent_manager.as_mut() {
+                                        if let Some(mgr) = self.orchestration.subagent_manager.as_mut() {
                                             // benign race: agent may have already finished
                                             let _ = mgr.cancel(&agent_handle_id).inspect_err(|e| {
                                                 tracing::trace!(error = %e, "cancel on user request: agent already gone");
@@ -1043,7 +1080,7 @@ impl<C: Channel> Agent<C> {
                         for action in cancel_actions {
                             match action {
                                 SchedulerAction::Cancel { agent_handle_id } => {
-                                    if let Some(mgr) = self.subagent_manager.as_mut() {
+                                    if let Some(mgr) = self.orchestration.subagent_manager.as_mut() {
                                         let _ = mgr.cancel(&agent_handle_id).inspect_err(|e| {
                                             tracing::trace!(
                                                 error = %e,
@@ -1064,7 +1101,7 @@ impl<C: Channel> Agent<C> {
                     }
                 }
                 // Shutdown signal received — cancel running sub-agents and exit cleanly.
-                () = shutdown_signal(&mut self.shutdown) => {
+                () = shutdown_signal(&mut self.lifecycle.shutdown) => {
                     let cancel_actions = scheduler.cancel_all();
                     let n = cancel_actions
                         .iter()
@@ -1074,7 +1111,7 @@ impl<C: Channel> Agent<C> {
                     for action in cancel_actions {
                         match action {
                             SchedulerAction::Cancel { agent_handle_id } => {
-                                if let Some(mgr) = self.subagent_manager.as_mut() {
+                                if let Some(mgr) = self.orchestration.subagent_manager.as_mut() {
                                     let _ = mgr.cancel(&agent_handle_id).inspect_err(|e| {
                                         tracing::trace!(
                                             error = %e,
@@ -1221,6 +1258,7 @@ impl<C: Channel> Agent<C> {
     ) {
         loop {
             let pending = self
+                .orchestration
                 .subagent_manager
                 .as_mut()
                 .and_then(crate::subagent::SubAgentManager::try_recv_secret_request);
@@ -1234,7 +1272,7 @@ impl<C: Channel> Agent<C> {
                     secret_key = %req.secret_key,
                     "skipping duplicate secret prompt for already-denied key"
                 );
-                if let Some(mgr) = self.subagent_manager.as_mut() {
+                if let Some(mgr) = self.orchestration.subagent_manager.as_mut() {
                     let _ = mgr.deny_secret(&req_handle_id);
                 }
                 continue;
@@ -1255,7 +1293,7 @@ impl<C: Channel> Agent<C> {
                     false
                 }
             };
-            if let Some(mgr) = self.subagent_manager.as_mut() {
+            if let Some(mgr) = self.orchestration.subagent_manager.as_mut() {
                 if approved {
                     let ttl = std::time::Duration::from_secs(300);
                     let key = req.secret_key.clone();
@@ -1290,8 +1328,10 @@ impl<C: Channel> Agent<C> {
                     .count() as u64;
                 self.update_metrics(|m| m.orchestration.tasks_completed += completed_count);
 
-                let aggregator =
-                    LlmAggregator::new(self.provider.clone(), &self.orchestration_config);
+                let aggregator = LlmAggregator::new(
+                    self.provider.clone(),
+                    &self.orchestration.orchestration_config,
+                );
                 match aggregator.aggregate(&completed_graph).await {
                     Ok(synthesis) => {
                         self.channel.send(&synthesis).await?;
@@ -1337,7 +1377,7 @@ impl<C: Channel> Agent<C> {
                 msg.push_str("\nUse `/plan retry` to retry failed tasks.");
                 self.channel.send(&msg).await?;
                 // Store graph back so /plan retry and /plan resume work.
-                self.pending_graph = Some(completed_graph);
+                self.orchestration.pending_graph = Some(completed_graph);
                 "failed"
             }
             GraphStatus::Paused => {
@@ -1347,7 +1387,7 @@ impl<C: Channel> Agent<C> {
                          Use `/plan resume` to continue or `/plan retry` to retry failed tasks.",
                     )
                     .await?;
-                self.pending_graph = Some(completed_graph);
+                self.orchestration.pending_graph = Some(completed_graph);
                 "paused"
             }
             GraphStatus::Canceled => {
@@ -1383,7 +1423,7 @@ impl<C: Channel> Agent<C> {
         _graph_id: Option<&str>,
     ) -> Result<(), error::AgentError> {
         use crate::orchestration::GraphStatus;
-        let Some(ref graph) = self.pending_graph else {
+        let Some(ref graph) = self.orchestration.pending_graph else {
             self.channel.send("No active plan.").await?;
             return Ok(());
         };
@@ -1406,7 +1446,7 @@ impl<C: Channel> Agent<C> {
     }
 
     async fn handle_plan_list(&mut self) -> Result<(), error::AgentError> {
-        if let Some(ref graph) = self.pending_graph {
+        if let Some(ref graph) = self.orchestration.pending_graph {
             let summary = format_plan_summary(graph);
             let status_label = match graph.status {
                 crate::orchestration::GraphStatus::Created => "awaiting confirmation",
@@ -1428,7 +1468,7 @@ impl<C: Channel> Agent<C> {
         &mut self,
         _graph_id: Option<&str>,
     ) -> Result<(), error::AgentError> {
-        if let Some(token) = self.plan_cancel_token.take() {
+        if let Some(token) = self.orchestration.plan_cancel_token.take() {
             // In-flight plan: signal cancellation. The scheduler loop will pick this up
             // in the next tokio::select! iteration at wait_event().
             // NOTE: Due to &mut self being held by run_scheduler_loop, this branch is only
@@ -1437,7 +1477,7 @@ impl<C: Channel> Agent<C> {
             // (see #1603, SEC-M34-002).
             token.cancel();
             self.channel.send("Canceling plan execution...").await?;
-        } else if self.pending_graph.take().is_some() {
+        } else if self.orchestration.pending_graph.take().is_some() {
             let now = std::time::Instant::now();
             self.update_metrics(|m| {
                 if let Some(ref mut s) = m.orchestration_graph {
@@ -1462,7 +1502,7 @@ impl<C: Channel> Agent<C> {
     ) -> Result<(), error::AgentError> {
         use crate::orchestration::GraphStatus;
 
-        let Some(ref graph) = self.pending_graph else {
+        let Some(ref graph) = self.orchestration.pending_graph else {
             self.channel
                 .send("No paused plan to resume. Use `/plan status` to check the current state.")
                 .await?;
@@ -1494,7 +1534,7 @@ impl<C: Channel> Agent<C> {
             return Ok(());
         }
 
-        let graph = self.pending_graph.take().unwrap();
+        let graph = self.orchestration.pending_graph.take().unwrap();
 
         tracing::info!(
             graph_id = %graph.id,
@@ -1509,7 +1549,7 @@ impl<C: Channel> Agent<C> {
             .await?;
 
         // Store resumed graph back as pending. resume_from() will set status=Running in confirm.
-        self.pending_graph = Some(graph);
+        self.orchestration.pending_graph = Some(graph);
         Ok(())
     }
 
@@ -1521,7 +1561,7 @@ impl<C: Channel> Agent<C> {
     async fn handle_plan_retry(&mut self, graph_id: Option<&str>) -> Result<(), error::AgentError> {
         use crate::orchestration::{GraphStatus, dag};
 
-        let Some(ref graph) = self.pending_graph else {
+        let Some(ref graph) = self.orchestration.pending_graph else {
             self.channel
                 .send("No active plan to retry. Use `/plan status` to check the current state.")
                 .await?;
@@ -1552,7 +1592,7 @@ impl<C: Channel> Agent<C> {
             return Ok(());
         }
 
-        let mut graph = self.pending_graph.take().unwrap();
+        let mut graph = self.orchestration.pending_graph.take().unwrap();
 
         // IC3: count before reset so the message reflects actual failed tasks, not Ready count.
         let failed_count = graph
@@ -1589,7 +1629,7 @@ impl<C: Channel> Agent<C> {
             .await?;
 
         // Store retried graph back for re-execution via /plan confirm.
-        self.pending_graph = Some(graph);
+        self.orchestration.pending_graph = Some(graph);
         Ok(())
     }
 
@@ -1599,7 +1639,7 @@ impl<C: Channel> Agent<C> {
         // CRIT-1: persist Thompson state accumulated during this session.
         self.provider.save_router_state();
 
-        if let Some(ref mut mgr) = self.subagent_manager {
+        if let Some(ref mut mgr) = self.orchestration.subagent_manager {
             mgr.shutdown_all();
         }
 
@@ -1607,7 +1647,7 @@ impl<C: Channel> Agent<C> {
             manager.shutdown_all_shared().await;
         }
 
-        if let Some(ref tx) = self.metrics_tx {
+        if let Some(ref tx) = self.metrics.metrics_tx {
             let m = tx.borrow();
             if m.filter_applications > 0 {
                 #[allow(clippy::cast_precision_loss)]
@@ -1635,7 +1675,7 @@ impl<C: Channel> Agent<C> {
     /// Returns an error if channel I/O or LLM communication fails.
     #[allow(clippy::too_many_lines)]
     pub async fn run(&mut self) -> Result<(), error::AgentError> {
-        if let Some(mut rx) = self.warmup_ready.take()
+        if let Some(mut rx) = self.lifecycle.warmup_ready.take()
             && !*rx.borrow()
         {
             let _ = rx.changed().await;
@@ -1646,7 +1686,7 @@ impl<C: Channel> Agent<C> {
 
         loop {
             // Apply any pending provider override (from ACP set_session_config_option).
-            if let Some(ref slot) = self.provider_override
+            if let Some(ref slot) = self.providers.provider_override
                 && let Some(new_provider) = slot
                     .write()
                     .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -1657,7 +1697,7 @@ impl<C: Channel> Agent<C> {
             }
 
             // Refresh sub-agent status in metrics before polling.
-            if let Some(ref mgr) = self.subagent_manager {
+            if let Some(ref mgr) = self.orchestration.subagent_manager {
                 let sub_agent_metrics: Vec<crate::metrics::SubAgentMetrics> = mgr
                     .statuses()
                     .into_iter()
@@ -1721,7 +1761,7 @@ impl<C: Channel> Agent<C> {
             } else {
                 let incoming = tokio::select! {
                     result = self.channel.recv() => result?,
-                    () = shutdown_signal(&mut self.shutdown) => {
+                    () = shutdown_signal(&mut self.lifecycle.shutdown) => {
                         tracing::info!("shutting down");
                         break;
                     }
@@ -1733,11 +1773,11 @@ impl<C: Channel> Agent<C> {
                         self.reload_instructions();
                         continue;
                     }
-                    Some(_) = recv_optional(&mut self.config_reload_rx) => {
+                    Some(_) = recv_optional(&mut self.lifecycle.config_reload_rx) => {
                         self.reload_config();
                         continue;
                     }
-                    Some(msg) = recv_optional(&mut self.update_notify_rx) => {
+                    Some(msg) = recv_optional(&mut self.lifecycle.update_notify_rx) => {
                         if let Err(e) = self.channel.send(&msg).await {
                             tracing::warn!("failed to send update notification: {e}");
                         }
@@ -1753,7 +1793,7 @@ impl<C: Channel> Agent<C> {
                         }
                         continue;
                     }
-                    Some(prompt) = recv_optional(&mut self.custom_task_rx) => {
+                    Some(prompt) = recv_optional(&mut self.lifecycle.custom_task_rx) => {
                         tracing::info!("scheduler: injecting custom task as agent turn");
                         let text = format!("[Scheduled task] {prompt}");
                         Some(crate::channel::ChannelMessage { text, attachments: Vec::new() })
@@ -2027,12 +2067,12 @@ impl<C: Channel> Agent<C> {
 
         tracing::debug!(
             audio = audio_attachments.len(),
-            has_stt = self.stt.is_some(),
+            has_stt = self.providers.stt.is_some(),
             "resolve_message attachments"
         );
 
         let text = if !audio_attachments.is_empty()
-            && let Some(stt) = self.stt.as_ref()
+            && let Some(stt) = self.providers.stt.as_ref()
         {
             let mut transcribed_parts = Vec::new();
             for attachment in &audio_attachments {
@@ -2107,9 +2147,9 @@ impl<C: Channel> Agent<C> {
         text: String,
         image_parts: Vec<zeph_llm::provider::MessagePart>,
     ) -> Result<(), error::AgentError> {
-        self.cancel_token = CancellationToken::new();
-        let signal = Arc::clone(&self.cancel_signal);
-        let token = self.cancel_token.clone();
+        self.lifecycle.cancel_token = CancellationToken::new();
+        let signal = Arc::clone(&self.lifecycle.cancel_signal);
+        let token = self.lifecycle.cancel_token.clone();
         tokio::spawn(async move {
             signal.notified().await;
             token.cancel();
@@ -2217,6 +2257,7 @@ impl<C: Channel> Agent<C> {
 
         if trimmed.starts_with("/agent") || trimmed.starts_with('@') {
             let known: Vec<String> = self
+                .orchestration
                 .subagent_manager
                 .as_ref()
                 .map(|m| m.definitions().iter().map(|d| d.name.clone()).collect())
@@ -2286,6 +2327,7 @@ impl<C: Channel> Agent<C> {
 
             let signal = if judge_should_run {
                 let judge_provider = self
+                    .providers
                     .judge_provider
                     .clone()
                     .unwrap_or_else(|| self.provider.clone());
@@ -2589,7 +2631,7 @@ impl<C: Channel> Agent<C> {
     async fn handle_status_command(&mut self) -> Result<(), error::AgentError> {
         use std::fmt::Write;
 
-        let uptime = self.start_time.elapsed().as_secs();
+        let uptime = self.lifecycle.start_time.elapsed().as_secs();
         let msg_count = self
             .messages
             .iter()
@@ -2597,7 +2639,7 @@ impl<C: Channel> Agent<C> {
             .count();
 
         let (api_calls, prompt_tokens, completion_tokens, cost_cents, mcp_servers) =
-            if let Some(ref tx) = self.metrics_tx {
+            if let Some(ref tx) = self.metrics.metrics_tx {
                 let m = tx.borrow();
                 (
                     m.api_calls,
@@ -2746,7 +2788,7 @@ impl<C: Channel> Agent<C> {
 
         match cmd {
             AgentCommand::List => {
-                let mgr = self.subagent_manager.as_ref()?;
+                let mgr = self.orchestration.subagent_manager.as_ref()?;
                 let defs = mgr.definitions();
                 if defs.is_empty() {
                     return Some("No sub-agent definitions found.".into());
@@ -2775,8 +2817,8 @@ impl<C: Channel> Agent<C> {
                 let provider = self.provider.clone();
                 let tool_executor = Arc::clone(&self.tool_executor);
                 let skills = self.filtered_skills_for(&name);
-                let mgr = self.subagent_manager.as_mut()?;
-                let cfg = self.subagent_config.clone();
+                let mgr = self.orchestration.subagent_manager.as_mut()?;
+                let cfg = self.orchestration.subagent_config.clone();
                 match mgr.spawn(&name, &prompt, provider, tool_executor, skills, &cfg) {
                     Ok(id) => Some(format!(
                         "Sub-agent '{name}' started in background (id: {short})",
@@ -2794,8 +2836,8 @@ impl<C: Channel> Agent<C> {
                 let provider = self.provider.clone();
                 let tool_executor = Arc::clone(&self.tool_executor);
                 let skills = self.filtered_skills_for(&name);
-                let mgr = self.subagent_manager.as_mut()?;
-                let cfg = self.subagent_config.clone();
+                let mgr = self.orchestration.subagent_manager.as_mut()?;
+                let cfg = self.orchestration.subagent_config.clone();
                 let task_id = match mgr.spawn(&name, &prompt, provider, tool_executor, skills, &cfg)
                 {
                     Ok(id) => id,
@@ -2815,6 +2857,7 @@ impl<C: Channel> Agent<C> {
                     // calling channel.confirm() (which requires &mut self).
                     #[allow(clippy::redundant_closure_for_method_calls)]
                     let pending = self
+                        .orchestration
                         .subagent_manager
                         .as_mut()
                         .and_then(|m| m.try_recv_secret_request());
@@ -2831,7 +2874,7 @@ impl<C: Channel> Agent<C> {
                             crate::text::truncate_to_chars(&req.secret_key, 100)
                         );
                         let approved = self.channel.confirm(&prompt).await.unwrap_or(false);
-                        if let Some(mgr) = self.subagent_manager.as_mut() {
+                        if let Some(mgr) = self.orchestration.subagent_manager.as_mut() {
                             if approved {
                                 let ttl = std::time::Duration::from_secs(300);
                                 let key = req.secret_key.clone();
@@ -2844,7 +2887,7 @@ impl<C: Channel> Agent<C> {
                         }
                     }
 
-                    let mgr = self.subagent_manager.as_ref()?;
+                    let mgr = self.orchestration.subagent_manager.as_ref()?;
                     let statuses = mgr.statuses();
                     let Some((_, status)) = statuses.iter().find(|(id, _)| id == &task_id) else {
                         break "Sub-agent completed (no status available).".to_owned();
@@ -2870,7 +2913,8 @@ impl<C: Channel> Agent<C> {
                                 .send_status(&format!(
                                     "sub-agent '{name}': turn {}/{}",
                                     status.turns_used,
-                                    self.subagent_manager
+                                    self.orchestration
+                                        .subagent_manager
                                         .as_ref()
                                         .and_then(|m| m.agents_def(&task_id))
                                         .map_or(20, |d| d.permissions.max_turns)
@@ -2882,7 +2926,7 @@ impl<C: Channel> Agent<C> {
                 Some(result)
             }
             AgentCommand::Status => {
-                let mgr = self.subagent_manager.as_ref()?;
+                let mgr = self.orchestration.subagent_manager.as_ref()?;
                 let statuses = mgr.statuses();
                 if statuses.is_empty() {
                     return Some("No active sub-agents.".into());
@@ -2910,7 +2954,7 @@ impl<C: Channel> Agent<C> {
                 Some(out)
             }
             AgentCommand::Cancel { id } => {
-                let mgr = self.subagent_manager.as_mut()?;
+                let mgr = self.orchestration.subagent_manager.as_mut()?;
                 // Accept prefix match on task_id.
                 let ids: Vec<String> = mgr
                     .statuses()
@@ -2935,7 +2979,7 @@ impl<C: Channel> Agent<C> {
             }
             AgentCommand::Approve { id } => {
                 // Look up pending secret request for the given task_id prefix.
-                let mgr = self.subagent_manager.as_mut()?;
+                let mgr = self.orchestration.subagent_manager.as_mut()?;
                 let full_ids: Vec<String> = mgr
                     .statuses()
                     .into_iter()
@@ -2970,7 +3014,7 @@ impl<C: Channel> Agent<C> {
                 ))
             }
             AgentCommand::Deny { id } => {
-                let mgr = self.subagent_manager.as_mut()?;
+                let mgr = self.orchestration.subagent_manager.as_mut()?;
                 let full_ids: Vec<String> = mgr
                     .statuses()
                     .into_iter()
@@ -2993,11 +3037,11 @@ impl<C: Channel> Agent<C> {
                 }
             }
             AgentCommand::Resume { id, prompt } => {
-                let cfg = self.subagent_config.clone();
+                let cfg = self.orchestration.subagent_config.clone();
                 // Resolve definition name from transcript meta before spawning so we can
                 // look up skills by definition name rather than the UUID prefix (S1 fix).
                 let def_name = {
-                    let mgr = self.subagent_manager.as_ref()?;
+                    let mgr = self.orchestration.subagent_manager.as_ref()?;
                     match mgr.def_name_for_resume(&id, &cfg) {
                         Ok(name) => name,
                         Err(e) => return Some(format!("Failed to resume sub-agent: {e}")),
@@ -3006,7 +3050,7 @@ impl<C: Channel> Agent<C> {
                 let skills = self.filtered_skills_for(&def_name);
                 let provider = self.provider.clone();
                 let tool_executor = Arc::clone(&self.tool_executor);
-                let mgr = self.subagent_manager.as_mut()?;
+                let mgr = self.orchestration.subagent_manager.as_mut()?;
                 let (task_id, _) =
                     match mgr.resume(&id, &prompt, provider, tool_executor, skills, &cfg) {
                         Ok(pair) => pair,
@@ -3023,6 +3067,7 @@ impl<C: Channel> Agent<C> {
 
                     #[allow(clippy::redundant_closure_for_method_calls)]
                     let pending = self
+                        .orchestration
                         .subagent_manager
                         .as_mut()
                         .and_then(|m| m.try_recv_secret_request());
@@ -3032,7 +3077,7 @@ impl<C: Channel> Agent<C> {
                             crate::text::truncate_to_chars(&req.secret_key, 100)
                         );
                         let approved = self.channel.confirm(&confirm_prompt).await.unwrap_or(false);
-                        if let Some(mgr) = self.subagent_manager.as_mut() {
+                        if let Some(mgr) = self.orchestration.subagent_manager.as_mut() {
                             if approved {
                                 let ttl = std::time::Duration::from_secs(300);
                                 let key = req.secret_key.clone();
@@ -3045,7 +3090,7 @@ impl<C: Channel> Agent<C> {
                         }
                     }
 
-                    let mgr = self.subagent_manager.as_ref()?;
+                    let mgr = self.orchestration.subagent_manager.as_ref()?;
                     let statuses = mgr.statuses();
                     let Some((_, status)) = statuses.iter().find(|(tid, _)| tid == &task_id) else {
                         break "Sub-agent resume completed (no status available).".to_owned();
@@ -3071,7 +3116,8 @@ impl<C: Channel> Agent<C> {
                                 .send_status(&format!(
                                     "resumed sub-agent: turn {}/{}",
                                     status.turns_used,
-                                    self.subagent_manager
+                                    self.orchestration
+                                        .subagent_manager
                                         .as_ref()
                                         .and_then(|m| m.agents_def(&task_id))
                                         .map_or(20, |d| d.permissions.max_turns)
@@ -3086,7 +3132,7 @@ impl<C: Channel> Agent<C> {
     }
 
     fn filtered_skills_for(&self, agent_name: &str) -> Option<Vec<String>> {
-        let mgr = self.subagent_manager.as_ref()?;
+        let mgr = self.orchestration.subagent_manager.as_ref()?;
         let def = mgr.definitions().iter().find(|d| d.name == agent_name)?;
         let reg = self
             .skill_state
@@ -3298,7 +3344,7 @@ impl<C: Channel> Agent<C> {
     }
 
     fn reload_config(&mut self) {
-        let Some(ref path) = self.config_path else {
+        let Some(ref path) = self.lifecycle.config_path else {
             return;
         };
         let config = match Config::load(path) {

--- a/crates/zeph-core/src/agent/tests.rs
+++ b/crates/zeph-core/src/agent/tests.rs
@@ -1219,7 +1219,7 @@ pub mod agent_tests {
             let channel = MockChannel::new(vec![]);
             let executor = MockToolExecutor::no_tools();
             let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
-            agent.stt = stt;
+            agent.providers.stt = stt;
             agent
         }
 
@@ -1477,7 +1477,7 @@ pub mod agent_tests {
             source: None,
             file_path: None,
         });
-        agent.subagent_manager = Some(mgr);
+        agent.orchestration.subagent_manager = Some(mgr);
         agent
     }
 
@@ -2265,7 +2265,7 @@ mod compaction_e2e {
             source: None,
             file_path: None,
         });
-        agent.subagent_manager = Some(mgr);
+        agent.orchestration.subagent_manager = Some(mgr);
 
         // Spawn the sub-agent in background — returns immediately with the task id.
         let spawn_resp = agent
@@ -2297,7 +2297,7 @@ mod compaction_e2e {
         // Poll until the sub-agent reaches a terminal state (max 5s).
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
         let full_id = loop {
-            let mgr = agent.subagent_manager.as_ref().unwrap();
+            let mgr = agent.orchestration.subagent_manager.as_ref().unwrap();
             let statuses = mgr.statuses();
             let found = statuses.iter().find(|(id, _)| id.starts_with(&short_id));
             if let Some((id, status)) = found {
@@ -2321,6 +2321,7 @@ mod compaction_e2e {
 
         // Collect result and verify output.
         let result = agent
+            .orchestration
             .subagent_manager
             .as_mut()
             .unwrap()
@@ -2379,7 +2380,7 @@ mod compaction_e2e {
             source: None,
             file_path: None,
         });
-        agent.subagent_manager = Some(mgr);
+        agent.orchestration.subagent_manager = Some(mgr);
 
         // Foreground spawn — blocks until sub-agent completes.
         let resp: String = agent
@@ -2417,7 +2418,7 @@ mod compaction_e2e {
         let registry = create_test_registry();
         let executor = MockToolExecutor::no_tools();
         let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
-        agent.orchestration_config.enabled = true;
+        agent.orchestration.orchestration_config.enabled = true;
         agent
     }
 
@@ -2453,7 +2454,7 @@ mod compaction_e2e {
         let mut agent = agent_with_orchestration();
 
         let graph = make_simple_graph(GraphStatus::Created);
-        agent.pending_graph = Some(graph);
+        agent.orchestration.pending_graph = Some(graph);
 
         // No subagent_manager set.
         agent
@@ -2463,7 +2464,7 @@ mod compaction_e2e {
 
         // Graph must be restored.
         assert!(
-            agent.pending_graph.is_some(),
+            agent.orchestration.pending_graph.is_some(),
             "graph must be restored when no manager configured"
         );
         let msgs = agent.channel.sent_messages();
@@ -2505,7 +2506,7 @@ mod compaction_e2e {
         let registry = create_test_registry();
         let executor = MockToolExecutor::no_tools();
         let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
-        agent.orchestration_config.enabled = true;
+        agent.orchestration.orchestration_config.enabled = true;
 
         let mut mgr = SubAgentManager::new(4);
         mgr.definitions_mut().push(SubAgentDef {
@@ -2522,7 +2523,7 @@ mod compaction_e2e {
             source: None,
             file_path: None,
         });
-        agent.subagent_manager = Some(mgr);
+        agent.orchestration.subagent_manager = Some(mgr);
 
         // Graph with one already-Completed task in Running status: resume_from() accepts it,
         // and the first tick() will find no running/ready tasks → Done{Completed}.
@@ -2538,7 +2539,7 @@ mod compaction_e2e {
         });
         graph.tasks.push(node);
         graph.status = GraphStatus::Running;
-        agent.pending_graph = Some(graph);
+        agent.orchestration.pending_graph = Some(graph);
 
         agent
             .handle_plan_command(PlanCommand::Confirm)
@@ -2553,7 +2554,7 @@ mod compaction_e2e {
         );
         // Graph must be cleared after successful completion.
         assert!(
-            agent.pending_graph.is_none(),
+            agent.orchestration.pending_graph.is_none(),
             "pending_graph must be cleared after Completed"
         );
     }
@@ -2574,10 +2575,10 @@ mod compaction_e2e {
         let registry = create_test_registry();
         let executor = MockToolExecutor::no_tools();
         let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
-        agent.orchestration_config.enabled = true;
+        agent.orchestration.orchestration_config.enabled = true;
 
         // Manager with no defined agents → route() returns None → RunInline.
-        agent.subagent_manager = Some(SubAgentManager::new(4));
+        agent.orchestration.subagent_manager = Some(SubAgentManager::new(4));
 
         // Graph in Created status with one task; scheduler emits RunInline,
         // provider fails → TaskOutcome::Failed → graph Failed.
@@ -2585,7 +2586,7 @@ mod compaction_e2e {
         let node = TaskNode::new(0, "task-0", "will fail inline");
         graph.tasks.push(node);
         graph.status = GraphStatus::Created;
-        agent.pending_graph = Some(graph);
+        agent.orchestration.pending_graph = Some(graph);
 
         agent
             .handle_plan_command(PlanCommand::Confirm)
@@ -2605,7 +2606,7 @@ mod compaction_e2e {
     async fn plan_list_with_pending_graph_shows_summary() {
         let mut agent = agent_with_orchestration();
 
-        agent.pending_graph = Some(make_simple_graph(GraphStatus::Created));
+        agent.orchestration.pending_graph = Some(make_simple_graph(GraphStatus::Created));
 
         agent.handle_plan_command(PlanCommand::List).await.unwrap();
 
@@ -2644,7 +2645,7 @@ mod compaction_e2e {
         graph.tasks.push(failed);
         graph.tasks.push(stale_running);
         graph.status = GraphStatus::Failed;
-        agent.pending_graph = Some(graph);
+        agent.orchestration.pending_graph = Some(graph);
 
         agent
             .handle_plan_command(PlanCommand::Retry(None))
@@ -2652,6 +2653,7 @@ mod compaction_e2e {
             .unwrap();
 
         let g = agent
+            .orchestration
             .pending_graph
             .as_ref()
             .expect("graph must be present after retry");
@@ -2705,7 +2707,7 @@ mod compaction_e2e {
         let registry = create_test_registry();
         let executor = MockToolExecutor::no_tools();
         let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
-        agent.orchestration_config.enabled = true;
+        agent.orchestration.orchestration_config.enabled = true;
 
         // Build a manager with one agent definition (needed by finalize_plan_execution).
         let mut mgr = SubAgentManager::new(4);
@@ -2765,7 +2767,7 @@ mod compaction_e2e {
                 transcript_dir: None,
             },
         );
-        agent.subagent_manager = Some(mgr);
+        agent.orchestration.subagent_manager = Some(mgr);
 
         // Graph with one already-Completed task in Running status: the first tick() finds no
         // Running/Ready tasks and emits Done{Completed} immediately (instant completion).
@@ -2781,7 +2783,7 @@ mod compaction_e2e {
         });
         graph.tasks.push(node);
         graph.status = GraphStatus::Running;
-        agent.pending_graph = Some(graph);
+        agent.orchestration.pending_graph = Some(graph);
 
         // Run the plan loop — the fix adds a post-loop drain call.
         agent
@@ -2792,6 +2794,7 @@ mod compaction_e2e {
         // After plan completion, the secret request must have been drained.
         // If the drain was NOT called, try_recv_secret_request() would return Some(_).
         let leftover = agent
+            .orchestration
             .subagent_manager
             .as_mut()
             .and_then(SubAgentManager::try_recv_secret_request);
@@ -2815,17 +2818,17 @@ mod compaction_e2e {
         let registry = create_test_registry();
         let executor = MockToolExecutor::no_tools();
         let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
-        agent.orchestration_config.enabled = true;
+        agent.orchestration.orchestration_config.enabled = true;
 
         // SubAgentManager with no definitions → route() returns None → RunInline.
-        agent.subagent_manager = Some(SubAgentManager::new(4));
+        agent.orchestration.subagent_manager = Some(SubAgentManager::new(4));
 
         // Simple single-task graph.
         let mut graph = TaskGraph::new("inline goal");
         let node = TaskNode::new(0, "task-0", "do something inline");
         graph.tasks.push(node);
         graph.status = GraphStatus::Created;
-        agent.pending_graph = Some(graph);
+        agent.orchestration.pending_graph = Some(graph);
 
         agent
             .handle_plan_command(PlanCommand::Confirm)
@@ -2834,7 +2837,7 @@ mod compaction_e2e {
 
         // Graph must be cleared after successful execution.
         assert!(
-            agent.pending_graph.is_none(),
+            agent.orchestration.pending_graph.is_none(),
             "pending_graph must be cleared after inline plan completion"
         );
         let msgs = agent.channel.sent_messages();
@@ -2860,8 +2863,8 @@ mod compaction_e2e {
         let registry = create_test_registry();
         let executor = MockToolExecutor::no_tools();
         let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
-        agent.orchestration_config.enabled = true;
-        agent.subagent_manager = Some(SubAgentManager::new(4));
+        agent.orchestration.orchestration_config.enabled = true;
+        agent.orchestration.subagent_manager = Some(SubAgentManager::new(4));
 
         // Graph in Running status with one task in Running state: tick() will not emit
         // any actions (no Ready tasks, no timed-out running tasks), so the loop reaches
@@ -2916,8 +2919,8 @@ mod compaction_e2e {
         let (metrics_tx, metrics_rx) = watch::channel(MetricsSnapshot::default());
         let mut agent =
             Agent::new(provider, channel, registry, None, 5, executor).with_metrics(metrics_tx);
-        agent.orchestration_config.enabled = true;
-        agent.subagent_manager = Some(SubAgentManager::new(4));
+        agent.orchestration.orchestration_config.enabled = true;
+        agent.orchestration.subagent_manager = Some(SubAgentManager::new(4));
 
         // Graph with one completed task and one canceled task — typical mid-cancel state.
         let mut graph = TaskGraph::new("cancel finalize test");
@@ -2952,7 +2955,7 @@ mod compaction_e2e {
             "must report completed task count (1/2); got: {msgs:?}"
         );
         assert!(
-            agent.pending_graph.is_none(),
+            agent.orchestration.pending_graph.is_none(),
             "canceled plan must NOT be stored in pending_graph"
         );
         let snapshot = metrics_rx.borrow().clone();
@@ -2982,8 +2985,8 @@ mod compaction_e2e {
         let registry = create_test_registry();
         let executor = MockToolExecutor::no_tools();
         let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
-        agent.orchestration_config.enabled = true;
-        agent.subagent_manager = Some(SubAgentManager::new(4));
+        agent.orchestration.orchestration_config.enabled = true;
+        agent.orchestration.subagent_manager = Some(SubAgentManager::new(4));
 
         // Graph in Running status with one task in Running state: tick() emits no actions
         // (no Ready tasks, running_in_graph_now > 0 suppresses Done), so the loop reaches
@@ -3040,7 +3043,7 @@ mod compaction_e2e {
 
         // GraphStatus::Created → awaiting confirmation.
         let mut agent = agent_with_orchestration();
-        agent.pending_graph = Some(make_simple_graph(GraphStatus::Created));
+        agent.orchestration.pending_graph = Some(make_simple_graph(GraphStatus::Created));
         agent
             .handle_plan_command(PlanCommand::Status(None))
             .await
@@ -3055,7 +3058,7 @@ mod compaction_e2e {
         let mut agent = agent_with_orchestration();
         let mut failed_graph = make_simple_graph(GraphStatus::Created);
         failed_graph.status = GraphStatus::Failed;
-        agent.pending_graph = Some(failed_graph);
+        agent.orchestration.pending_graph = Some(failed_graph);
         agent
             .handle_plan_command(PlanCommand::Status(None))
             .await
@@ -3071,7 +3074,7 @@ mod compaction_e2e {
         let mut agent = agent_with_orchestration();
         let mut paused_graph = make_simple_graph(GraphStatus::Created);
         paused_graph.status = GraphStatus::Paused;
-        agent.pending_graph = Some(paused_graph);
+        agent.orchestration.pending_graph = Some(paused_graph);
         agent
             .handle_plan_command(PlanCommand::Status(None))
             .await
@@ -3087,7 +3090,7 @@ mod compaction_e2e {
         let mut agent = agent_with_orchestration();
         let mut completed_graph = make_simple_graph(GraphStatus::Created);
         completed_graph.status = GraphStatus::Completed;
-        agent.pending_graph = Some(completed_graph);
+        agent.orchestration.pending_graph = Some(completed_graph);
         agent
             .handle_plan_command(PlanCommand::Status(None))
             .await

--- a/crates/zeph-core/src/agent/tool_execution/legacy.rs
+++ b/crates/zeph-core/src/agent/tool_execution/legacy.rs
@@ -37,7 +37,7 @@ impl<C: Channel> Agent<C> {
         self.tool_orchestrator.clear_recent_tool_calls();
 
         for iteration in 0..self.tool_orchestrator.max_iterations {
-            if self.cancel_token.is_cancelled() {
+            if self.lifecycle.cancel_token.is_cancelled() {
                 tracing::info!("tool loop cancelled by user");
                 break;
             }
@@ -46,7 +46,8 @@ impl<C: Channel> Agent<C> {
 
             // Context budget check at 80% threshold
             if let Some(ref budget) = self.context_manager.budget {
-                let used = usize::try_from(self.cached_prompt_tokens).unwrap_or(usize::MAX);
+                let used =
+                    usize::try_from(self.providers.cached_prompt_tokens).unwrap_or(usize::MAX);
                 let threshold = budget.max_tokens() * 4 / 5;
                 if used >= threshold {
                     tracing::warn!(
@@ -199,11 +200,11 @@ impl<C: Channel> Agent<C> {
     pub(super) async fn call_llm_with_timeout(
         &mut self,
     ) -> Result<Option<String>, super::super::error::AgentError> {
-        if self.cancel_token.is_cancelled() {
+        if self.lifecycle.cancel_token.is_cancelled() {
             return Ok(None);
         }
 
-        if let Some(ref tracker) = self.cost_tracker
+        if let Some(ref tracker) = self.metrics.cost_tracker
             && let Err(e) = tracker.check_budget()
         {
             self.channel
@@ -218,7 +219,7 @@ impl<C: Channel> Agent<C> {
 
         let llm_timeout = std::time::Duration::from_secs(self.runtime.timeouts.llm_seconds);
         let start = std::time::Instant::now();
-        let prompt_estimate = self.cached_prompt_tokens;
+        let prompt_estimate = self.providers.cached_prompt_tokens;
 
         let dump_id =
             self.debug_state
@@ -239,7 +240,7 @@ impl<C: Channel> Agent<C> {
 
         let llm_span = tracing::info_span!("llm_call", model = %self.runtime.model_name);
         if self.provider.supports_streaming() {
-            let cancel = self.cancel_token.clone();
+            let cancel = self.lifecycle.cancel_token.clone();
             let streaming_fut = self.process_response_streaming().instrument(llm_span);
             let result = tokio::select! {
                 r = tokio::time::timeout(llm_timeout, streaming_fut) => r,
@@ -299,7 +300,7 @@ impl<C: Channel> Agent<C> {
                 Ok(None)
             }
         } else {
-            let cancel = self.cancel_token.clone();
+            let cancel = self.lifecycle.cancel_token.clone();
             let chat_fut = self.provider.chat(&self.messages).instrument(llm_span);
             let result = tokio::select! {
                 r = tokio::time::timeout(llm_timeout, chat_fut) => r,
@@ -647,11 +648,11 @@ impl<C: Channel> Agent<C> {
                     Some(r) => r,
                     None => break,
                 },
-                () = super::super::shutdown_signal(&mut self.shutdown) => {
+                () = super::super::shutdown_signal(&mut self.lifecycle.shutdown) => {
                     tracing::info!("streaming interrupted by shutdown");
                     break;
                 }
-                () = self.cancel_token.cancelled() => {
+                () = self.lifecycle.cancel_token.cancelled() => {
                     tracing::info!("streaming interrupted by cancellation");
                     break;
                 }

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -50,7 +50,7 @@ impl<C: Channel> Agent<C> {
                         "server compaction beta header rejected; \
                         falling back to client-side compaction and retrying"
                     );
-                    self.server_compaction_active = false;
+                    self.providers.server_compaction_active = false;
                     let _ = self
                         .channel
                         .send_status(
@@ -98,11 +98,11 @@ impl<C: Channel> Agent<C> {
         }
 
         for iteration in 0..self.tool_orchestrator.max_iterations {
-            if *self.shutdown.borrow() {
+            if *self.lifecycle.shutdown.borrow() {
                 tracing::info!("native tool loop interrupted by shutdown");
                 break;
             }
-            if self.cancel_token.is_cancelled() {
+            if self.lifecycle.cancel_token.is_cancelled() {
                 tracing::info!("native tool loop cancelled by user");
                 break;
             }
@@ -117,7 +117,7 @@ impl<C: Channel> Agent<C> {
             if self.lsp_hooks.is_some() {
                 // Clear stale notes before borrowing lsp_hooks mutably (borrow checker).
                 self.remove_lsp_messages();
-                let tc = std::sync::Arc::clone(&self.token_counter);
+                let tc = std::sync::Arc::clone(&self.metrics.token_counter);
                 if let Some(ref mut lsp) = self.lsp_hooks
                     && let Some(note_text) = lsp.drain_notes(&tc)
                 {
@@ -130,7 +130,8 @@ impl<C: Channel> Agent<C> {
             }
 
             if let Some(ref budget) = self.context_manager.budget {
-                let used = usize::try_from(self.cached_prompt_tokens).unwrap_or(usize::MAX);
+                let used =
+                    usize::try_from(self.providers.cached_prompt_tokens).unwrap_or(usize::MAX);
                 let threshold = budget.max_tokens() * 4 / 5;
                 if used >= threshold {
                     tracing::warn!(
@@ -218,7 +219,7 @@ impl<C: Channel> Agent<C> {
         &mut self,
         tool_defs: &[ToolDefinition],
     ) -> Result<Option<ChatResponse>, super::super::error::AgentError> {
-        if let Some(ref tracker) = self.cost_tracker
+        if let Some(ref tracker) = self.metrics.cost_tracker
             && let Err(e) = tracker.check_budget()
         {
             self.channel
@@ -261,7 +262,7 @@ impl<C: Channel> Agent<C> {
         );
         let timeout_result = tokio::select! {
             r = chat_fut => r,
-            () = self.cancel_token.cancelled() => {
+            () = self.lifecycle.cancel_token.cancelled() => {
                 tracing::info!("chat_with_tools cancelled by user");
                 self.update_metrics(|m| m.cancellations += 1);
                 self.channel.send("[Cancelled]").await?;
@@ -278,7 +279,7 @@ impl<C: Channel> Agent<C> {
         };
 
         let latency = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
-        let prompt_estimate = self.cached_prompt_tokens;
+        let prompt_estimate = self.providers.cached_prompt_tokens;
         let completion_heuristic = match &result {
             ChatResponse::Text(t) => u64::try_from(t.len()).unwrap_or(0) / 4,
             ChatResponse::ToolUse {
@@ -544,7 +545,7 @@ impl<C: Channel> Agent<C> {
         let max_retries = self.tool_orchestrator.max_tool_retries;
         // Clamp to 1 to prevent Semaphore(0) deadlock when config is set to 0.
         let max_parallel = self.runtime.timeouts.max_parallel_tools.max(1);
-        let cancel = self.cancel_token.clone();
+        let cancel = self.lifecycle.cancel_token.clone();
 
         // Phase 1: Tiered parallel execution bounded by a shared semaphore.
         //
@@ -1216,7 +1217,7 @@ impl<C: Channel> Agent<C> {
         // `&mut self.lsp_hooks` without conflicting borrows.
         #[cfg(feature = "lsp-context")]
         if self.lsp_hooks.is_some() {
-            let tc_arc = std::sync::Arc::clone(&self.token_counter);
+            let tc_arc = std::sync::Arc::clone(&self.metrics.token_counter);
             let sanitizer = self.security.sanitizer.clone();
             for (name, input, output) in lsp_tool_calls {
                 if let Some(ref mut lsp) = self.lsp_hooks {

--- a/crates/zeph-core/src/agent/utils.rs
+++ b/crates/zeph-core/src/agent/utils.rs
@@ -64,8 +64,8 @@ impl<C: Channel> Agent<C> {
     }
 
     pub(super) fn update_metrics(&self, f: impl FnOnce(&mut MetricsSnapshot)) {
-        if let Some(ref tx) = self.metrics_tx {
-            let elapsed = self.start_time.elapsed().as_secs();
+        if let Some(ref tx) = self.metrics.metrics_tx {
+            let elapsed = self.lifecycle.start_time.elapsed().as_secs();
             tx.send_modify(|m| {
                 m.uptime_seconds = elapsed;
                 f(m);
@@ -79,9 +79,9 @@ impl<C: Channel> Agent<C> {
         source: &str,
         detail: impl Into<String>,
     ) {
-        if let Some(ref tx) = self.metrics_tx {
+        if let Some(ref tx) = self.metrics.metrics_tx {
             let event = SecurityEvent::new(category, source, detail);
-            let elapsed = self.start_time.elapsed().as_secs();
+            let elapsed = self.lifecycle.start_time.elapsed().as_secs();
             tx.send_modify(|m| {
                 m.uptime_seconds = elapsed;
                 if m.security_events.len() >= SECURITY_EVENT_CAP {
@@ -93,20 +93,21 @@ impl<C: Channel> Agent<C> {
     }
 
     pub(super) fn recompute_prompt_tokens(&mut self) {
-        self.cached_prompt_tokens = self
+        self.providers.cached_prompt_tokens = self
             .messages
             .iter()
-            .map(|m| self.token_counter.count_message_tokens(m) as u64)
+            .map(|m| self.metrics.token_counter.count_message_tokens(m) as u64)
             .sum();
     }
 
     pub(super) fn push_message(&mut self, msg: Message) {
-        self.cached_prompt_tokens += self.token_counter.count_message_tokens(&msg) as u64;
+        self.providers.cached_prompt_tokens +=
+            self.metrics.token_counter.count_message_tokens(&msg) as u64;
         self.messages.push(msg);
     }
 
     pub(crate) fn record_cost(&self, prompt_tokens: u64, completion_tokens: u64) {
-        if let Some(ref tracker) = self.cost_tracker {
+        if let Some(ref tracker) = self.metrics.cost_tracker {
             tracker.record_usage(&self.runtime.model_name, prompt_tokens, completion_tokens);
             self.update_metrics(|m| {
                 m.cost_spent_cents = tracker.current_spend();
@@ -162,16 +163,19 @@ mod tests {
         let executor = MockToolExecutor::no_tools();
         let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
 
-        let before = agent.cached_prompt_tokens;
+        let before = agent.providers.cached_prompt_tokens;
         let msg = Message {
             role: Role::User,
             content: "hello world!!".to_string(),
             parts: vec![],
             metadata: MessageMetadata::default(),
         };
-        let expected_delta = agent.token_counter.count_message_tokens(&msg) as u64;
+        let expected_delta = agent.metrics.token_counter.count_message_tokens(&msg) as u64;
         agent.push_message(msg);
-        assert_eq!(agent.cached_prompt_tokens, before + expected_delta);
+        assert_eq!(
+            agent.providers.cached_prompt_tokens,
+            before + expected_delta
+        );
     }
 
     #[test]
@@ -200,9 +204,9 @@ mod tests {
         let expected: u64 = agent
             .messages
             .iter()
-            .map(|m| agent.token_counter.count_message_tokens(m) as u64)
+            .map(|m| agent.metrics.token_counter.count_message_tokens(m) as u64)
             .sum();
-        assert_eq!(agent.cached_prompt_tokens, expected);
+        assert_eq!(agent.providers.cached_prompt_tokens, expected);
     }
 
     #[test]

--- a/crates/zeph-core/src/bootstrap/mod.rs
+++ b/crates/zeph-core/src/bootstrap/mod.rs
@@ -15,15 +15,14 @@ pub use mcp::{create_mcp_manager, create_mcp_registry};
 #[cfg(feature = "candle")]
 pub use provider::select_device;
 pub use provider::{
-    build_orchestrator, create_named_provider, create_provider, create_provider_from_config,
-    create_summary_provider,
+    BootstrapError, build_orchestrator, create_named_provider, create_provider,
+    create_provider_from_config, create_summary_provider,
 };
 pub use skills::{create_skill_matcher, effective_embedding_model, managed_skills_dir};
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use anyhow::{Context, bail};
 use tokio::sync::{mpsc, watch};
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::LlmProvider;
@@ -64,12 +63,17 @@ impl AppBuilder {
     /// Resolve config, load it, create vault, resolve secrets.
     ///
     /// CLI-provided overrides take priority over environment variables and config.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BootstrapError`] if config loading, validation, vault construction,
+    /// secret resolution, or Qdrant URL parsing fails.
     pub async fn new(
         config_override: Option<&Path>,
         vault_override: Option<&str>,
         vault_key_override: Option<&Path>,
         vault_path_override: Option<&Path>,
-    ) -> anyhow::Result<Self> {
+    ) -> Result<Self, BootstrapError> {
         let config_path = resolve_config_path(config_override);
         let mut config = Config::load(&config_path)?;
         config.validate()?;
@@ -83,15 +87,22 @@ impl AppBuilder {
         let vault: Box<dyn VaultProvider> = match vault_args.backend.as_str() {
             "env" => Box::new(EnvVaultProvider),
             "age" => {
-                let key = vault_args
-                    .key_path
-                    .context("--vault-key required for age backend")?;
-                let path = vault_args
-                    .vault_path
-                    .context("--vault-path required for age backend")?;
-                Box::new(AgeVaultProvider::new(Path::new(&key), Path::new(&path))?)
+                let key = vault_args.key_path.ok_or_else(|| {
+                    BootstrapError::Provider("--vault-key required for age backend".into())
+                })?;
+                let path = vault_args.vault_path.ok_or_else(|| {
+                    BootstrapError::Provider("--vault-path required for age backend".into())
+                })?;
+                Box::new(
+                    AgeVaultProvider::new(Path::new(&key), Path::new(&path))
+                        .map_err(BootstrapError::VaultInit)?,
+                )
             }
-            other => bail!("unknown vault backend: {other}"),
+            other => {
+                return Err(BootstrapError::Provider(format!(
+                    "unknown vault backend: {other}"
+                )));
+            }
         };
 
         config.resolve_secrets(vault.as_ref()).await?;
@@ -99,7 +110,10 @@ impl AppBuilder {
         let qdrant_ops = match config.memory.vector_backend {
             crate::config::VectorBackend::Qdrant => {
                 let ops = QdrantOps::new(&config.memory.qdrant_url).map_err(|e| {
-                    anyhow::anyhow!("invalid qdrant_url '{}': {e}", config.memory.qdrant_url)
+                    BootstrapError::Provider(format!(
+                        "invalid qdrant_url '{}': {e}",
+                        config.memory.qdrant_url
+                    ))
                 })?;
                 Some(ops)
             }
@@ -138,9 +152,12 @@ impl AppBuilder {
         self.vault.as_ref()
     }
 
+    /// # Errors
+    ///
+    /// Returns [`BootstrapError`] if provider creation or health check fails.
     pub async fn build_provider(
         &self,
-    ) -> anyhow::Result<(AnyProvider, tokio::sync::mpsc::UnboundedReceiver<String>)> {
+    ) -> Result<(AnyProvider, tokio::sync::mpsc::UnboundedReceiver<String>), BootstrapError> {
         let mut provider = create_provider(&self.config)?;
 
         let (status_tx, status_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
@@ -183,10 +200,13 @@ impl AppBuilder {
 
     /// # Errors
     ///
-    /// Returns an error if `SQLite` cannot be initialized or if `vector_backend = Qdrant`
+    /// Returns [`BootstrapError`] if `SQLite` cannot be initialized or if `vector_backend = "Qdrant"`
     /// but `qdrant_ops` is `None` (invariant violation — should not happen if `AppBuilder::new`
     /// succeeded).
-    pub async fn build_memory(&self, provider: &AnyProvider) -> anyhow::Result<SemanticMemory> {
+    pub async fn build_memory(
+        &self,
+        provider: &AnyProvider,
+    ) -> Result<SemanticMemory, BootstrapError> {
         let embed_model = self.embedding_model();
         let mut memory = match self.config.memory.vector_backend {
             crate::config::VectorBackend::Sqlite => {
@@ -198,13 +218,18 @@ impl AppBuilder {
                     self.config.memory.semantic.keyword_weight,
                     self.config.memory.sqlite_pool_size,
                 )
-                .await?
+                .await
+                .map_err(|e| BootstrapError::Memory(e.to_string()))?
             }
             crate::config::VectorBackend::Qdrant => {
                 let ops = self
                     .qdrant_ops
                     .as_ref()
-                    .context("qdrant_ops must be Some when vector_backend = Qdrant")?
+                    .ok_or_else(|| {
+                        BootstrapError::Memory(
+                            "qdrant_ops must be Some when vector_backend = Qdrant".into(),
+                        )
+                    })?
                     .clone();
                 SemanticMemory::with_qdrant_ops(
                     &self.config.memory.sqlite_path,
@@ -215,7 +240,8 @@ impl AppBuilder {
                     self.config.memory.semantic.keyword_weight,
                     self.config.memory.sqlite_pool_size,
                 )
-                .await?
+                .await
+                .map_err(|e| BootstrapError::Memory(e.to_string()))?
             }
         };
 

--- a/crates/zeph-core/src/bootstrap/provider.rs
+++ b/crates/zeph-core/src/bootstrap/provider.rs
@@ -1,8 +1,27 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use anyhow::{Context, bail};
 use zeph_llm::any::AnyProvider;
+
+/// Error type for bootstrap / provider construction failures.
+///
+/// String-based variants flatten the error chain intentionally: bootstrap errors are
+/// terminal (the application exits), so downcasting is not needed at this stage.
+/// If a future phase requires programmatic retry on specific failures, expand these
+/// variants into typed sub-errors.
+#[derive(Debug, thiserror::Error)]
+pub enum BootstrapError {
+    #[error("config error: {0}")]
+    Config(#[from] crate::config::ConfigError),
+    #[error("provider error: {0}")]
+    Provider(String),
+    #[error("memory error: {0}")]
+    Memory(String),
+    #[error("vault init error: {0}")]
+    VaultInit(crate::vault::AgeVaultError),
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+}
 use zeph_llm::claude::ClaudeProvider;
 use zeph_llm::compatible::CompatibleProvider;
 use zeph_llm::gemini::GeminiProvider;
@@ -15,7 +34,7 @@ use zeph_llm::router::{CascadeRouterConfig, RouterProvider};
 use crate::config::{Config, ProviderKind};
 
 #[allow(clippy::too_many_lines)]
-pub fn create_provider(config: &Config) -> anyhow::Result<AnyProvider> {
+pub fn create_provider(config: &Config) -> Result<AnyProvider, BootstrapError> {
     match config.llm.provider {
         ProviderKind::Ollama | ProviderKind::Claude => {
             create_named_provider(config.llm.provider.as_str(), config)
@@ -25,11 +44,11 @@ pub fn create_provider(config: &Config) -> anyhow::Result<AnyProvider> {
         ProviderKind::Compatible => create_named_provider("compatible", config),
         #[cfg(feature = "candle")]
         ProviderKind::Candle => {
-            let candle_cfg = config
-                .llm
-                .candle
-                .as_ref()
-                .context("llm.candle config section required for candle provider")?;
+            let candle_cfg = config.llm.candle.as_ref().ok_or_else(|| {
+                BootstrapError::Provider(
+                    "llm.candle config section required for candle provider".into(),
+                )
+            })?;
 
             let source = match candle_cfg.source.as_str() {
                 "local" => zeph_llm::candle_provider::loader::ModelSource::Local {
@@ -62,7 +81,8 @@ pub fn create_provider(config: &Config) -> anyhow::Result<AnyProvider> {
                 gen_config,
                 candle_cfg.embedding_repo.as_deref(),
                 device,
-            )?;
+            )
+            .map_err(|e| BootstrapError::Provider(e.to_string()))?;
             Ok(AnyProvider::Candle(provider))
         }
         ProviderKind::Orchestrator => {
@@ -70,11 +90,11 @@ pub fn create_provider(config: &Config) -> anyhow::Result<AnyProvider> {
             Ok(AnyProvider::Orchestrator(Box::new(orch)))
         }
         ProviderKind::Router => {
-            let router_cfg = config
-                .llm
-                .router
-                .as_ref()
-                .context("llm.router config section required for router provider")?;
+            let router_cfg = config.llm.router.as_ref().ok_or_else(|| {
+                BootstrapError::Provider(
+                    "llm.router config section required for router provider".into(),
+                )
+            })?;
 
             let mut providers = Vec::new();
             for name in &router_cfg.chain {
@@ -90,10 +110,10 @@ pub fn create_provider(config: &Config) -> anyhow::Result<AnyProvider> {
                 }
             }
             if providers.is_empty() {
-                bail!(
+                return Err(BootstrapError::Provider(format!(
                     "router chain is empty: none of [{}] could be initialized",
                     router_cfg.chain.join(", ")
-                );
+                )));
             }
             let router = if router_cfg.strategy == crate::config::RouterStrategyConfig::Thompson {
                 let state_path = router_cfg
@@ -158,12 +178,14 @@ pub fn create_provider(config: &Config) -> anyhow::Result<AnyProvider> {
             Ok(AnyProvider::Router(Box::new(router)))
         }
         #[cfg(not(feature = "candle"))]
-        ProviderKind::Candle => bail!("candle feature is not enabled"),
+        ProviderKind::Candle => Err(BootstrapError::Provider(
+            "candle feature is not enabled".into(),
+        )),
     }
 }
 
 #[allow(clippy::too_many_lines)]
-pub fn create_named_provider(name: &str, config: &Config) -> anyhow::Result<AnyProvider> {
+pub fn create_named_provider(name: &str, config: &Config) -> Result<AnyProvider, BootstrapError> {
     match name {
         "ollama" => {
             let tool_use = config.llm.ollama.as_ref().is_some_and(|c| c.tool_use);
@@ -179,37 +201,41 @@ pub fn create_named_provider(name: &str, config: &Config) -> anyhow::Result<AnyP
             Ok(AnyProvider::Ollama(provider))
         }
         "claude" => {
-            let cloud = config
-                .llm
-                .cloud
-                .as_ref()
-                .context("llm.cloud config section required for Claude provider")?;
+            let cloud = config.llm.cloud.as_ref().ok_or_else(|| {
+                BootstrapError::Provider(
+                    "llm.cloud config section required for Claude provider".into(),
+                )
+            })?;
             let api_key = config
                 .secrets
                 .claude_api_key
                 .as_ref()
-                .context("ZEPH_CLAUDE_API_KEY not found in vault")?
+                .ok_or_else(|| {
+                    BootstrapError::Provider("ZEPH_CLAUDE_API_KEY not found in vault".into())
+                })?
                 .expose()
                 .to_owned();
             let provider = ClaudeProvider::new(api_key, cloud.model.clone(), cloud.max_tokens)
                 .with_client(llm_client(config.timeouts.llm_request_timeout_secs))
                 .with_extended_context(cloud.enable_extended_context)
                 .with_thinking_opt(cloud.thinking.clone())
-                .map_err(|e| anyhow::anyhow!("invalid thinking config: {e}"))?
+                .map_err(|e| BootstrapError::Provider(format!("invalid thinking config: {e}")))?
                 .with_server_compaction(cloud.server_compaction);
             Ok(AnyProvider::Claude(provider))
         }
         "openai" => {
-            let openai_cfg = config
-                .llm
-                .openai
-                .as_ref()
-                .context("llm.openai config section required for OpenAI provider")?;
+            let openai_cfg = config.llm.openai.as_ref().ok_or_else(|| {
+                BootstrapError::Provider(
+                    "llm.openai config section required for OpenAI provider".into(),
+                )
+            })?;
             let api_key = config
                 .secrets
                 .openai_api_key
                 .as_ref()
-                .context("ZEPH_OPENAI_API_KEY not found in vault")?
+                .ok_or_else(|| {
+                    BootstrapError::Provider("ZEPH_OPENAI_API_KEY not found in vault".into())
+                })?
                 .expose()
                 .to_owned();
             Ok(AnyProvider::OpenAi(
@@ -225,16 +251,18 @@ pub fn create_named_provider(name: &str, config: &Config) -> anyhow::Result<AnyP
             ))
         }
         "gemini" => {
-            let gemini_cfg = config
-                .llm
-                .gemini
-                .as_ref()
-                .context("llm.gemini config section required for Gemini provider")?;
+            let gemini_cfg = config.llm.gemini.as_ref().ok_or_else(|| {
+                BootstrapError::Provider(
+                    "llm.gemini config section required for Gemini provider".into(),
+                )
+            })?;
             let api_key = config
                 .secrets
                 .gemini_api_key
                 .as_ref()
-                .context("ZEPH_GEMINI_API_KEY not found in vault")?
+                .ok_or_else(|| {
+                    BootstrapError::Provider("ZEPH_GEMINI_API_KEY not found in vault".into())
+                })?
                 .expose()
                 .to_owned();
             let mut provider =
@@ -248,7 +276,9 @@ pub fn create_named_provider(name: &str, config: &Config) -> anyhow::Result<AnyP
                 provider = provider.with_thinking_level(level);
             }
             if let Some(budget) = gemini_cfg.thinking_budget {
-                provider = provider.with_thinking_budget(budget)?;
+                provider = provider
+                    .with_thinking_budget(budget)
+                    .map_err(|e| BootstrapError::Provider(e.to_string()))?;
             }
             if let Some(include) = gemini_cfg.include_thoughts {
                 provider = provider.with_include_thoughts(include);
@@ -267,12 +297,12 @@ pub fn create_named_provider(name: &str, config: &Config) -> anyhow::Result<AnyP
                         || config.secrets.compatible_api_keys.contains_key(&entry.name)
                         || is_local_endpoint(&entry.base_url);
                     if !has_key {
-                        bail!(
+                        return Err(BootstrapError::Provider(format!(
                             "ZEPH_COMPATIBLE_{}_API_KEY required for '{}' \
                              (set api_key in config, vault secret, or use a local endpoint)",
                             entry.name.to_uppercase(),
                             entry.name
-                        );
+                        )));
                     }
                     // Resolve key: config field > vault secret > empty for local.
                     let api_key = entry.api_key.clone().unwrap_or_else(|| {
@@ -293,7 +323,9 @@ pub fn create_named_provider(name: &str, config: &Config) -> anyhow::Result<AnyP
                     )));
                 }
             }
-            bail!("unknown provider: {other}")
+            Err(BootstrapError::Provider(format!(
+                "unknown provider: {other}"
+            )))
         }
     }
 }
@@ -307,7 +339,10 @@ pub fn create_named_provider(name: &str, config: &Config) -> anyhow::Result<AnyP
 /// - `compatible/<name>` — named entry from `[[llm.compatible]]`
 /// - `candle` — local candle model (requires `[llm.candle]` config; feature-gated)
 #[allow(clippy::too_many_lines)]
-pub fn create_summary_provider(model_spec: &str, config: &Config) -> anyhow::Result<AnyProvider> {
+pub fn create_summary_provider(
+    model_spec: &str,
+    config: &Config,
+) -> Result<AnyProvider, BootstrapError> {
     let (backend, model_override) = if let Some((b, m)) = model_spec.split_once('/') {
         (b, Some(m))
     } else {
@@ -316,8 +351,11 @@ pub fn create_summary_provider(model_spec: &str, config: &Config) -> anyhow::Res
 
     match backend {
         "ollama" => {
-            let model =
-                model_override.context("ollama summary_model requires format 'ollama/<model>'")?;
+            let model = model_override.ok_or_else(|| {
+                BootstrapError::Provider(
+                    "ollama summary_model requires format 'ollama/<model>'".into(),
+                )
+            })?;
             Ok(AnyProvider::Ollama(OllamaProvider::new(
                 &config.llm.base_url,
                 model.to_owned(),
@@ -329,7 +367,11 @@ pub fn create_summary_provider(model_spec: &str, config: &Config) -> anyhow::Res
                 .secrets
                 .claude_api_key
                 .as_ref()
-                .context("ZEPH_CLAUDE_API_KEY required for claude summary provider")?
+                .ok_or_else(|| {
+                    BootstrapError::Provider(
+                        "ZEPH_CLAUDE_API_KEY required for claude summary provider".into(),
+                    )
+                })?
                 .expose()
                 .to_owned();
             let cloud = config.llm.cloud.as_ref();
@@ -350,7 +392,11 @@ pub fn create_summary_provider(model_spec: &str, config: &Config) -> anyhow::Res
                 .secrets
                 .openai_api_key
                 .as_ref()
-                .context("ZEPH_OPENAI_API_KEY required for openai summary provider")?
+                .ok_or_else(|| {
+                    BootstrapError::Provider(
+                        "ZEPH_OPENAI_API_KEY required for openai summary provider".into(),
+                    )
+                })?
                 .expose()
                 .to_owned();
             let openai_cfg = config.llm.openai.as_ref();
@@ -373,7 +419,11 @@ pub fn create_summary_provider(model_spec: &str, config: &Config) -> anyhow::Res
                 .secrets
                 .gemini_api_key
                 .as_ref()
-                .context("ZEPH_GEMINI_API_KEY required for gemini summary provider")?
+                .ok_or_else(|| {
+                    BootstrapError::Provider(
+                        "ZEPH_GEMINI_API_KEY required for gemini summary provider".into(),
+                    )
+                })?
                 .expose()
                 .to_owned();
             let gemini_cfg = config.llm.gemini.as_ref();
@@ -395,18 +445,21 @@ pub fn create_summary_provider(model_spec: &str, config: &Config) -> anyhow::Res
             ))
         }
         "compatible" => {
-            let name = model_override
-                .context("compatible summary_model requires format 'compatible/<name>'")?;
+            let name = model_override.ok_or_else(|| {
+                BootstrapError::Provider(
+                    "compatible summary_model requires format 'compatible/<name>'".into(),
+                )
+            })?;
             // Delegate to create_named_provider which resolves the entry by name.
             create_named_provider(name, config)
         }
         #[cfg(feature = "candle")]
         "candle" => {
-            let candle_cfg = config
-                .llm
-                .candle
-                .as_ref()
-                .context("llm.candle config section required for candle summary provider")?;
+            let candle_cfg = config.llm.candle.as_ref().ok_or_else(|| {
+                BootstrapError::Provider(
+                    "llm.candle config section required for candle summary provider".into(),
+                )
+            })?;
             let source = match candle_cfg.source.as_str() {
                 "local" => zeph_llm::candle_provider::loader::ModelSource::Local {
                     path: std::path::PathBuf::from(&candle_cfg.local_path),
@@ -435,10 +488,11 @@ pub fn create_summary_provider(model_spec: &str, config: &Config) -> anyhow::Res
                 gen_config,
                 candle_cfg.embedding_repo.as_deref(),
                 device,
-            )?;
+            )
+            .map_err(|e| BootstrapError::Provider(e.to_string()))?;
             Ok(AnyProvider::Candle(provider))
         }
-        _ => bail!(
+        _ => Err(BootstrapError::Provider(format!(
             "unsupported summary_model format: '{model_spec}'. \
              Supported: ollama/<model>, claude[/<model>], openai[/<model>], \
              compatible/<name>{candle}",
@@ -447,24 +501,32 @@ pub fn create_summary_provider(model_spec: &str, config: &Config) -> anyhow::Res
             } else {
                 ""
             }
-        ),
+        ))),
     }
 }
 
 #[cfg(feature = "candle")]
-pub fn select_device(preference: &str) -> anyhow::Result<zeph_llm::candle_provider::Device> {
+pub fn select_device(
+    preference: &str,
+) -> Result<zeph_llm::candle_provider::Device, BootstrapError> {
     match preference {
         "metal" => {
             #[cfg(feature = "metal")]
-            return Ok(zeph_llm::candle_provider::Device::new_metal(0)?);
+            return zeph_llm::candle_provider::Device::new_metal(0)
+                .map_err(|e| BootstrapError::Provider(e.to_string()));
             #[cfg(not(feature = "metal"))]
-            bail!("candle compiled without metal feature");
+            return Err(BootstrapError::Provider(
+                "candle compiled without metal feature".into(),
+            ));
         }
         "cuda" => {
             #[cfg(feature = "cuda")]
-            return Ok(zeph_llm::candle_provider::Device::new_cuda(0)?);
+            return zeph_llm::candle_provider::Device::new_cuda(0)
+                .map_err(|e| BootstrapError::Provider(e.to_string()));
             #[cfg(not(feature = "cuda"))]
-            bail!("candle compiled without cuda feature");
+            return Err(BootstrapError::Provider(
+                "candle compiled without cuda feature".into(),
+            ));
         }
         "auto" => {
             #[cfg(feature = "metal")]
@@ -489,7 +551,7 @@ pub fn select_device(preference: &str) -> anyhow::Result<zeph_llm::candle_provid
 pub fn create_provider_from_config(
     pcfg: &crate::config::OrchestratorProviderConfig,
     config: &Config,
-) -> anyhow::Result<AnyProvider> {
+) -> Result<AnyProvider, BootstrapError> {
     match pcfg.provider_type.as_str() {
         "ollama" => {
             let base_url = pcfg.base_url.as_deref().unwrap_or(&config.llm.base_url);
@@ -509,7 +571,11 @@ pub fn create_provider_from_config(
                 .secrets
                 .claude_api_key
                 .as_ref()
-                .context("ZEPH_CLAUDE_API_KEY required for claude provider")?
+                .ok_or_else(|| {
+                    BootstrapError::Provider(
+                        "ZEPH_CLAUDE_API_KEY required for claude provider".into(),
+                    )
+                })?
                 .expose()
                 .to_owned();
             let cloud = config.llm.cloud.as_ref();
@@ -530,7 +596,11 @@ pub fn create_provider_from_config(
                 .secrets
                 .openai_api_key
                 .as_ref()
-                .context("ZEPH_OPENAI_API_KEY required for openai provider")?
+                .ok_or_else(|| {
+                    BootstrapError::Provider(
+                        "ZEPH_OPENAI_API_KEY required for openai provider".into(),
+                    )
+                })?
                 .expose()
                 .to_owned();
             let openai_cfg = config.llm.openai.as_ref();
@@ -559,7 +629,11 @@ pub fn create_provider_from_config(
                 .secrets
                 .gemini_api_key
                 .as_ref()
-                .context("ZEPH_GEMINI_API_KEY required for gemini provider")?
+                .ok_or_else(|| {
+                    BootstrapError::Provider(
+                        "ZEPH_GEMINI_API_KEY required for gemini provider".into(),
+                    )
+                })?
                 .expose()
                 .to_owned();
             let gemini_cfg = config.llm.gemini.as_ref();
@@ -583,7 +657,9 @@ pub fn create_provider_from_config(
                 provider = provider.with_thinking_level(level);
             }
             if let Some(budget) = gemini_cfg.and_then(|c| c.thinking_budget) {
-                provider = provider.with_thinking_budget(budget)?;
+                provider = provider
+                    .with_thinking_budget(budget)
+                    .map_err(|e| BootstrapError::Provider(e.to_string()))?;
             }
             if let Some(include) = gemini_cfg.and_then(|c| c.include_thoughts) {
                 provider = provider.with_include_thoughts(include);
@@ -591,19 +667,20 @@ pub fn create_provider_from_config(
             Ok(AnyProvider::Gemini(provider))
         }
         "compatible" => {
-            let name = pcfg
-                .model
-                .as_deref()
-                .context("compatible provider requires 'model' set to the entry name")?;
+            let name = pcfg.model.as_deref().ok_or_else(|| {
+                BootstrapError::Provider(
+                    "compatible provider requires 'model' set to the entry name".into(),
+                )
+            })?;
             create_named_provider(name, config)
         }
         #[cfg(feature = "candle")]
         "candle" => {
-            let candle_cfg = config
-                .llm
-                .candle
-                .as_ref()
-                .context("llm.candle config section required for candle provider")?;
+            let candle_cfg = config.llm.candle.as_ref().ok_or_else(|| {
+                BootstrapError::Provider(
+                    "llm.candle config section required for candle provider".into(),
+                )
+            })?;
             let source = match candle_cfg.source.as_str() {
                 "local" => zeph_llm::candle_provider::loader::ModelSource::Local {
                     path: std::path::PathBuf::from(&candle_cfg.local_path),
@@ -636,25 +713,28 @@ pub fn create_provider_from_config(
                 gen_config,
                 candle_cfg.embedding_repo.as_deref(),
                 device,
-            )?;
+            )
+            .map_err(|e| BootstrapError::Provider(e.to_string()))?;
             Ok(AnyProvider::Candle(provider))
         }
-        other => bail!("unknown provider type: '{other}'"),
+        other => Err(BootstrapError::Provider(format!(
+            "unknown provider type: '{other}'"
+        ))),
     }
 }
 
 #[allow(clippy::too_many_lines)]
 pub fn build_orchestrator(
     config: &Config,
-) -> anyhow::Result<zeph_llm::orchestrator::ModelOrchestrator> {
+) -> Result<zeph_llm::orchestrator::ModelOrchestrator, BootstrapError> {
     use std::collections::HashMap;
     use zeph_llm::orchestrator::{ModelOrchestrator, SubProvider, TaskType};
 
-    let orch_cfg = config
-        .llm
-        .orchestrator
-        .as_ref()
-        .context("llm.orchestrator config section required for orchestrator provider")?;
+    let orch_cfg = config.llm.orchestrator.as_ref().ok_or_else(|| {
+        BootstrapError::Provider(
+            "llm.orchestrator config section required for orchestrator provider".into(),
+        )
+    })?;
 
     let mut providers = HashMap::new();
     for (name, pcfg) in &orch_cfg.providers {
@@ -669,16 +749,20 @@ pub fn build_orchestrator(
                 SubProvider::Ollama(OllamaProvider::new(base_url, model.to_owned(), embed))
             }
             "claude" => {
-                let cloud = config
-                    .llm
-                    .cloud
-                    .as_ref()
-                    .context("llm.cloud config required for claude sub-provider")?;
+                let cloud = config.llm.cloud.as_ref().ok_or_else(|| {
+                    BootstrapError::Provider(
+                        "llm.cloud config required for claude sub-provider".into(),
+                    )
+                })?;
                 let api_key = config
                     .secrets
                     .claude_api_key
                     .as_ref()
-                    .context("ZEPH_CLAUDE_API_KEY required for claude sub-provider")?
+                    .ok_or_else(|| {
+                        BootstrapError::Provider(
+                            "ZEPH_CLAUDE_API_KEY required for claude sub-provider".into(),
+                        )
+                    })?
                     .expose()
                     .to_owned();
                 let model = pcfg.model.as_deref().unwrap_or(&cloud.model);
@@ -686,21 +770,25 @@ pub fn build_orchestrator(
                     .with_client(llm_client(config.timeouts.llm_request_timeout_secs))
                     .with_extended_context(cloud.enable_extended_context)
                     .with_thinking_opt(cloud.thinking.clone())
-                    .map_err(|e| anyhow::anyhow!("invalid thinking config: {e}"))?
+                    .map_err(|e| BootstrapError::Provider(format!("invalid thinking config: {e}")))?
                     .with_server_compaction(cloud.server_compaction);
                 SubProvider::Claude(sub)
             }
             "openai" => {
-                let openai_cfg = config
-                    .llm
-                    .openai
-                    .as_ref()
-                    .context("llm.openai config required for openai sub-provider")?;
+                let openai_cfg = config.llm.openai.as_ref().ok_or_else(|| {
+                    BootstrapError::Provider(
+                        "llm.openai config required for openai sub-provider".into(),
+                    )
+                })?;
                 let api_key = config
                     .secrets
                     .openai_api_key
                     .as_ref()
-                    .context("ZEPH_OPENAI_API_KEY required for openai sub-provider")?
+                    .ok_or_else(|| {
+                        BootstrapError::Provider(
+                            "ZEPH_OPENAI_API_KEY required for openai sub-provider".into(),
+                        )
+                    })?
                     .expose()
                     .to_owned();
                 let base_url = pcfg
@@ -729,7 +817,11 @@ pub fn build_orchestrator(
                     .secrets
                     .gemini_api_key
                     .as_ref()
-                    .context("ZEPH_GEMINI_API_KEY required for gemini sub-provider")?
+                    .ok_or_else(|| {
+                        BootstrapError::Provider(
+                            "ZEPH_GEMINI_API_KEY required for gemini sub-provider".into(),
+                        )
+                    })?
                     .expose()
                     .to_owned();
                 let gemini_cfg = config.llm.gemini.as_ref();
@@ -750,9 +842,9 @@ pub fn build_orchestrator(
                     provider = provider.with_thinking_level(level);
                 }
                 if let Some(budget) = gemini_cfg.and_then(|c| c.thinking_budget) {
-                    provider = provider
-                        .with_thinking_budget(budget)
-                        .map_err(|e| anyhow::anyhow!("invalid thinking_budget: {e}"))?;
+                    provider = provider.with_thinking_budget(budget).map_err(|e| {
+                        BootstrapError::Provider(format!("invalid thinking_budget: {e}"))
+                    })?;
                 }
                 if let Some(include) = gemini_cfg.and_then(|c| c.include_thoughts) {
                     provider = provider.with_include_thoughts(include);
@@ -761,11 +853,11 @@ pub fn build_orchestrator(
             }
             #[cfg(feature = "candle")]
             "candle" => {
-                let candle_cfg = config
-                    .llm
-                    .candle
-                    .as_ref()
-                    .context("llm.candle config required for candle sub-provider")?;
+                let candle_cfg = config.llm.candle.as_ref().ok_or_else(|| {
+                    BootstrapError::Provider(
+                        "llm.candle config required for candle sub-provider".into(),
+                    )
+                })?;
                 let source = match candle_cfg.source.as_str() {
                     "local" => zeph_llm::candle_provider::loader::ModelSource::Local {
                         path: std::path::PathBuf::from(&candle_cfg.local_path),
@@ -798,10 +890,15 @@ pub fn build_orchestrator(
                     gen_config,
                     candle_cfg.embedding_repo.as_deref(),
                     device,
-                )?;
+                )
+                .map_err(|e| BootstrapError::Provider(e.to_string()))?;
                 SubProvider::Candle(candle_provider)
             }
-            other => bail!("unknown orchestrator sub-provider type: {other}"),
+            other => {
+                return Err(BootstrapError::Provider(format!(
+                    "unknown orchestrator sub-provider type: {other}"
+                )));
+            }
         };
         providers.insert(name.clone(), provider);
     }
@@ -812,12 +909,13 @@ pub fn build_orchestrator(
         routes.insert(task, chain.clone());
     }
 
-    Ok(ModelOrchestrator::new(
+    ModelOrchestrator::new(
         routes,
         providers,
         orch_cfg.default.clone(),
         orch_cfg.embed.clone(),
-    )?)
+    )
+    .map_err(|e| BootstrapError::Provider(e.to_string()))
 }
 
 /// Returns `true` if `base_url` points to a local or private-network endpoint

--- a/crates/zeph-core/src/config/mod.rs
+++ b/crates/zeph-core/src/config/mod.rs
@@ -24,7 +24,7 @@ pub enum ConfigError {
     #[error("config validation failed: {0}")]
     Validation(String),
     #[error("vault error: {0}")]
-    Vault(#[from] anyhow::Error),
+    Vault(#[from] crate::vault::VaultError),
 }
 
 impl Config {

--- a/crates/zeph-core/src/daemon.rs
+++ b/crates/zeph-core/src/daemon.rs
@@ -17,16 +17,25 @@ pub enum ComponentStatus {
     Stopped,
 }
 
+/// Error type for daemon component task failures.
+#[derive(Debug, thiserror::Error)]
+pub enum DaemonError {
+    #[error("task error: {0}")]
+    Task(String),
+    #[error("shutdown error: {0}")]
+    Shutdown(String),
+}
+
 pub struct ComponentHandle {
     pub name: String,
-    handle: JoinHandle<anyhow::Result<()>>,
+    handle: JoinHandle<Result<(), DaemonError>>,
     pub status: ComponentStatus,
     pub restart_count: u32,
 }
 
 impl ComponentHandle {
     #[must_use]
-    pub fn new(name: impl Into<String>, handle: JoinHandle<anyhow::Result<()>>) -> Self {
+    pub fn new(name: impl Into<String>, handle: JoinHandle<Result<(), DaemonError>>) -> Self {
         Self {
             name: name.into(),
             handle,
@@ -215,7 +224,7 @@ mod tests {
         let (_tx, rx) = watch::channel(false);
         let mut supervisor = DaemonSupervisor::new(&config, rx);
 
-        let handle = tokio::spawn(async { Ok(()) });
+        let handle = tokio::spawn(async { Ok::<(), DaemonError>(()) });
         supervisor.add_component(ComponentHandle::new("test", handle));
         assert_eq!(supervisor.component_count(), 1);
     }
@@ -226,7 +235,7 @@ mod tests {
         let (_tx, rx) = watch::channel(false);
         let mut supervisor = DaemonSupervisor::new(&config, rx);
 
-        let handle = tokio::spawn(async { Ok(()) });
+        let handle = tokio::spawn(async { Ok::<(), DaemonError>(()) });
         tokio::time::sleep(Duration::from_millis(10)).await;
         supervisor.add_component(ComponentHandle::new("finished", handle));
         supervisor.check_health();

--- a/crates/zeph-core/src/vault.rs
+++ b/crates/zeph-core/src/vault.rs
@@ -55,12 +55,34 @@ impl fmt::Display for Secret {
     }
 }
 
+/// Error type for vault operations.
+///
+/// Returned by [`VaultProvider::get_secret`] on failure.
+///
+/// The `Backend(String)` variant is the escape hatch for third-party vault implementations:
+/// format the underlying error into the `String` when no more specific variant applies.
+#[derive(Debug, thiserror::Error)]
+pub enum VaultError {
+    #[error("secret not found: {0}")]
+    NotFound(String),
+    /// Generic backend failure. Third-party vault implementors should use this variant
+    /// to surface errors that do not fit `NotFound` or `Io`.
+    #[error("vault backend error: {0}")]
+    Backend(String),
+    #[error("vault I/O error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
 /// Pluggable secret retrieval backend.
 pub trait VaultProvider: Send + Sync {
+    /// Retrieve a secret by key.
+    ///
+    /// Returns `Ok(None)` when the key does not exist. Returns `Err(VaultError)` on
+    /// backend failures (I/O, decryption, network, etc.).
     fn get_secret(
         &self,
         key: &str,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<Option<String>>> + Send + '_>>;
+    ) -> Pin<Box<dyn Future<Output = Result<Option<String>, VaultError>> + Send + '_>>;
 
     /// Return all known secret keys. Used for scanning `ZEPH_SECRET_*` prefixes.
     fn list_keys(&self) -> Vec<String> {
@@ -318,7 +340,7 @@ impl VaultProvider for AgeVaultProvider {
     fn get_secret(
         &self,
         key: &str,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<Option<String>>> + Send + '_>> {
+    ) -> Pin<Box<dyn Future<Output = Result<Option<String>, VaultError>> + Send + '_>> {
         let result = self.secrets.get(key).map(|v| (**v).clone());
         Box::pin(async move { Ok(result) })
     }
@@ -334,7 +356,7 @@ impl VaultProvider for EnvVaultProvider {
     fn get_secret(
         &self,
         key: &str,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<Option<String>>> + Send + '_>> {
+    ) -> Pin<Box<dyn Future<Output = Result<Option<String>, VaultError>> + Send + '_>> {
         let key = key.to_owned();
         Box::pin(async move { Ok(std::env::var(&key).ok()) })
     }
@@ -385,7 +407,7 @@ impl VaultProvider for MockVaultProvider {
     fn get_secret(
         &self,
         key: &str,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<Option<String>>> + Send + '_>> {
+    ) -> Pin<Box<dyn Future<Output = Result<Option<String>, VaultError>> + Send + '_>> {
         let result = self.secrets.get(key).cloned();
         Box::pin(async move { Ok(result) })
     }


### PR DESCRIPTION
## Summary

Phase 1 of epic #1741 (arch: codebase architecture improvements).

- Decomposes the 50-field `Agent` god object into 4 focused sub-structs (#1731)
- Removes `anyhow` from core library modules, replacing with typed errors (#1732)

## Changes

### Agent struct decomposition (#1731)

`Agent<C>` retains core identity fields. Loose fields moved to named sub-structs:

| Sub-struct | Fields | Concern |
|---|---|---|
| `LifecycleState` | shutdown, cancel_token, warmup_ready, config_path, watchers | Lifecycle management |
| `ProviderState` | summary_provider, judge_provider, cached_prompt_tokens, stt | Provider state |
| `MetricsState` | metrics_tx, cost_tracker, token_counter | Metrics collection |
| `OrchestrationState` | pending_graph, plan_cancel_token, subagent_manager | Multi-agent orchestration |

### anyhow removal (#1732)

| New type | Location | Replaces |
|---|---|---|
| `VaultError` | `vault.rs` | `anyhow::Error` in `VaultProvider` trait |
| `BootstrapError` | `bootstrap/provider.rs` | `anyhow::Result` in all bootstrap functions |
| `DaemonError` | `daemon.rs` | `anyhow::Result` in `ComponentHandle` |

Remaining `anyhow` usage in `subagent/` and `config_watcher.rs` tracked in #1742.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --features full -- -D warnings` — clean
- [x] `cargo nextest run --workspace --features full --lib --bins` — 5423 passed, 12 skipped
- [x] Architecture reviewed, adversarially critiqued, performance/security/testing validated
- [x] Code review approved after fixes (R-I1: removed dead `BootstrapError::Vault`, R-I2: tightened visibility to `pub(super)`, R-I3: created follow-up #1742)

## Related

- Epic: #1741
- Closes #1731
- Partially closes #1732 (remaining: #1742)