### PR TITLE
feat(core): JIT tool reference injection after pruning (#1740)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - feat(llm): `cost_tiers` config field for `[llm.router.cascade]` — explicit cheapest-first provider ordering independent of chain order; providers are sorted once at construction time (zero per-request cost); unknown names are silently ignored; empty list is equivalent to `None` (#1724)
 - feat(cost): add gpt-5 and gpt-5-mini to default pricing table (closes #1744)
 - feat(init): add `hard_compaction_threshold` prompt to `--init` wizard (#1719); prompts for both soft and hard compaction thresholds in sequence with cross-field validation (hard > soft) and `is_finite()` guards
+- feat(core): when pruning a tool output that has an overflow file, emit `[tool output pruned; full content at {path}]` instead of clearing the body, preserving the reference across hard compaction, `prune_tool_outputs`, and `prune_stale_tool_outputs` (#1740)
 
 ### Changed
 

--- a/crates/zeph-core/src/agent/context/mod.rs
+++ b/crates/zeph-core/src/agent/context/mod.rs
@@ -933,6 +933,140 @@ mod tests {
         }
     }
 
+    #[test]
+    fn prune_tool_outputs_preserves_overflow_reference() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let (tx, _rx) = watch::channel(crate::metrics::MetricsSnapshot::default());
+
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
+            .with_context_budget(1000, 0.20, 0.75, 4, 0)
+            .with_metrics(tx);
+
+        let path = "/tmp/overflow/big.txt";
+        let body = format!(
+            "truncated output\n[full output saved to {path} \u{2014} 99999 bytes, use read tool to access]"
+        );
+        agent.messages.push(Message::from_parts(
+            Role::User,
+            vec![MessagePart::ToolOutput {
+                tool_name: "bash".into(),
+                body,
+                compacted_at: None,
+            }],
+        ));
+
+        let freed = agent.prune_tool_outputs(10);
+        assert!(freed > 0);
+
+        if let MessagePart::ToolOutput {
+            body, compacted_at, ..
+        } = &agent.messages[1].parts[0]
+        {
+            assert!(compacted_at.is_some());
+            assert_eq!(
+                body,
+                &format!("[tool output pruned; full content at {path}]")
+            );
+        } else {
+            panic!("expected ToolOutput");
+        }
+    }
+
+    #[test]
+    fn prune_stale_tool_outputs_preserves_overflow_reference_in_tool_output() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+        let path = "/tmp/overflow/big.txt";
+        let body = format!(
+            "truncated output\n[full output saved to {path} \u{2014} 99999 bytes, use read tool to access]"
+        );
+        agent.messages.push(Message::from_parts(
+            Role::User,
+            vec![MessagePart::ToolOutput {
+                tool_name: "bash".into(),
+                body,
+                compacted_at: None,
+            }],
+        ));
+        for _ in 0..4 {
+            agent.messages.push(Message {
+                role: Role::User,
+                content: "recent".into(),
+                parts: vec![],
+                metadata: MessageMetadata::default(),
+            });
+        }
+
+        let freed = agent.prune_stale_tool_outputs(4);
+        assert!(freed > 0);
+
+        if let MessagePart::ToolOutput {
+            body, compacted_at, ..
+        } = &agent.messages[1].parts[0]
+        {
+            assert!(compacted_at.is_some());
+            assert_eq!(
+                body,
+                &format!("[tool output pruned; full content at {path}]")
+            );
+        } else {
+            panic!("expected ToolOutput");
+        }
+    }
+
+    #[test]
+    fn prune_stale_tool_outputs_preserves_overflow_reference_in_tool_result() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+        let path = "/tmp/overflow/big.txt";
+        // Content large enough to exceed the 20-token threshold
+        let content = format!(
+            "{}\n[full output saved to {path} \u{2014} 99999 bytes, use read tool to access]",
+            "x".repeat(200)
+        );
+        agent.messages.push(Message::from_parts(
+            Role::User,
+            vec![MessagePart::ToolResult {
+                tool_use_id: "t1".into(),
+                content,
+                is_error: false,
+            }],
+        ));
+        for _ in 0..4 {
+            agent.messages.push(Message {
+                role: Role::User,
+                content: "recent".into(),
+                parts: vec![],
+                metadata: MessageMetadata::default(),
+            });
+        }
+
+        let freed = agent.prune_stale_tool_outputs(4);
+        assert!(freed > 0);
+
+        if let MessagePart::ToolResult { content, .. } = &agent.messages[1].parts[0] {
+            assert_eq!(
+                content,
+                &format!("[tool output pruned; full content at {path}]")
+            );
+        } else {
+            panic!("expected ToolResult");
+        }
+    }
+
     #[tokio::test]
     async fn test_tier2_after_insufficient_prune() {
         let provider = mock_provider(vec!["summary".to_string()]);

--- a/crates/zeph-core/src/agent/context/summarization.rs
+++ b/crates/zeph-core/src/agent/context/summarization.rs
@@ -8,8 +8,51 @@ use zeph_llm::provider::{LlmProvider, Message, MessageMetadata, MessagePart, Rol
 
 use super::super::Agent;
 use super::super::context_manager::CompactionTier;
+use super::super::tool_execution::OVERFLOW_NOTICE_PREFIX;
 use crate::channel::Channel;
 use crate::context::ContextBudget;
+
+/// Extract the overflow file path from a tool output body, if present.
+///
+/// The overflow notice has the format:
+/// `\n[full output saved to {path} — {bytes} bytes, use read tool to access]`
+///
+/// Returns the path substring on success, or `None` if the notice is absent.
+fn extract_overflow_ref(body: &str) -> Option<&str> {
+    let start = body.find(OVERFLOW_NOTICE_PREFIX)?;
+    let rest = &body[start + OVERFLOW_NOTICE_PREFIX.len()..];
+    let end = rest.find(" \u{2014} ")?;
+    Some(&rest[..end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_overflow_ref_returns_path_when_present() {
+        let body = "some output\n[full output saved to /tmp/overflow/abc.txt \u{2014} 12345 bytes, use read tool to access]";
+        assert_eq!(extract_overflow_ref(body), Some("/tmp/overflow/abc.txt"));
+    }
+
+    #[test]
+    fn extract_overflow_ref_returns_none_when_absent() {
+        let body = "normal small output without overflow notice";
+        assert_eq!(extract_overflow_ref(body), None);
+    }
+
+    #[test]
+    fn extract_overflow_ref_returns_none_for_empty_body() {
+        assert_eq!(extract_overflow_ref(""), None);
+    }
+
+    #[test]
+    fn extract_overflow_ref_handles_prefix_at_start() {
+        let body =
+            "[full output saved to /var/tmp/out.txt \u{2014} 9999 bytes, use read tool to access]";
+        assert_eq!(extract_overflow_ref(body), Some("/var/tmp/out.txt"));
+    }
+}
 
 impl<C: Channel> Agent<C> {
     pub(super) fn build_chunk_prompt(messages: &[Message]) -> String {
@@ -287,13 +330,20 @@ impl<C: Channel> Agent<C> {
             for part in &mut msg.parts {
                 match part {
                     MessagePart::ToolResult { content, .. } => {
-                        "[compacted]".clone_into(content);
+                        let ref_notice = extract_overflow_ref(content).map_or_else(
+                            || String::from("[compacted]"),
+                            |p| format!("[tool output pruned; full content at {p}]"),
+                        );
+                        *content = ref_notice;
                     }
                     MessagePart::ToolOutput {
                         body, compacted_at, ..
                     } => {
                         if compacted_at.is_none() {
-                            *body = String::new();
+                            let ref_notice = extract_overflow_ref(body)
+                                .map(|p| format!("[tool output pruned; full content at {p}]"))
+                                .unwrap_or_default();
+                            *body = ref_notice;
                             *compacted_at = Some(
                                 std::time::SystemTime::now()
                                     .duration_since(std::time::UNIX_EPOCH)
@@ -483,8 +533,12 @@ impl<C: Channel> Agent<C> {
                     && !body.is_empty()
                 {
                     freed += self.metrics.token_counter.count_tokens(body);
+                    let ref_notice = extract_overflow_ref(body)
+                        .map(|p| format!("[tool output pruned; full content at {p}]"))
+                        .unwrap_or_default();
+                    freed -= self.metrics.token_counter.count_tokens(&ref_notice);
                     *compacted_at = Some(now);
-                    *body = String::new();
+                    *body = ref_notice;
                     modified = true;
                 }
             }
@@ -532,16 +586,24 @@ impl<C: Channel> Agent<C> {
                         body, compacted_at, ..
                     } if compacted_at.is_none() && !body.is_empty() => {
                         freed += self.metrics.token_counter.count_tokens(body);
+                        let ref_notice = extract_overflow_ref(body)
+                            .map(|p| format!("[tool output pruned; full content at {p}]"))
+                            .unwrap_or_default();
+                        freed -= self.metrics.token_counter.count_tokens(&ref_notice);
                         *compacted_at = Some(now);
-                        *body = String::new();
+                        *body = ref_notice;
                         modified = true;
                     }
                     MessagePart::ToolResult { content, .. } => {
                         let tokens = self.metrics.token_counter.count_tokens(content);
                         if tokens > 20 {
                             freed += tokens;
-                            "[pruned]".clone_into(content);
-                            freed -= 1;
+                            let ref_notice = extract_overflow_ref(content).map_or_else(
+                                || String::from("[pruned]"),
+                                |p| format!("[tool output pruned; full content at {p}]"),
+                            );
+                            freed -= self.metrics.token_counter.count_tokens(&ref_notice);
+                            *content = ref_notice;
                             modified = true;
                         }
                     }

--- a/crates/zeph-core/src/agent/tool_execution/mod.rs
+++ b/crates/zeph-core/src/agent/tool_execution/mod.rs
@@ -13,6 +13,10 @@ use crate::redact::redact_secrets;
 use crate::sanitizer::{ContentSource, ContentSourceKind};
 use zeph_skills::loader::Skill;
 
+/// Prefix used in the overflow notice appended to tool outputs that exceed the size threshold.
+/// Shared with the pruning logic so both sides stay in sync if the format changes.
+pub(crate) const OVERFLOW_NOTICE_PREFIX: &str = "[full output saved to ";
+
 enum AnomalyOutcome {
     Success,
     Error,

--- a/crates/zeph-core/src/debug_dump.rs
+++ b/crates/zeph-core/src/debug_dump.rs
@@ -292,7 +292,11 @@ fn part_to_block(part: &MessagePart, is_assistant: bool) -> Option<serde_json::V
             compacted_at,
         } => {
             let text = if compacted_at.is_some() {
-                format!("[tool output: {tool_name}] (pruned)")
+                if body.is_empty() {
+                    format!("[tool output: {tool_name}] (pruned)")
+                } else {
+                    format!("[tool output: {tool_name}] {body}")
+                }
             } else {
                 format!("[tool output: {tool_name}]\n{body}")
             };

--- a/crates/zeph-llm/src/provider.rs
+++ b/crates/zeph-llm/src/provider.rs
@@ -352,7 +352,11 @@ impl Message {
                     compacted_at,
                 } => {
                     if compacted_at.is_some() {
-                        let _ = write!(out, "[tool output: {tool_name}] (pruned)");
+                        if body.is_empty() {
+                            let _ = write!(out, "[tool output: {tool_name}] (pruned)");
+                        } else {
+                            let _ = write!(out, "[tool output: {tool_name}] {body}");
+                        }
                     } else {
                         let _ = write!(out, "[tool output: {tool_name}]\n```\n{body}\n```");
                     }
@@ -857,7 +861,8 @@ mod tests {
     }
 
     #[test]
-    fn flatten_skips_compacted_tool_output() {
+    fn flatten_skips_compacted_tool_output_empty_body() {
+        // When compacted_at is set and body is empty, renders "(pruned)".
         let msg = Message::from_parts(
             Role::User,
             vec![
@@ -866,7 +871,7 @@ mod tests {
                 },
                 MessagePart::ToolOutput {
                     tool_name: "bash".into(),
-                    body: "big output".into(),
+                    body: String::new(),
                     compacted_at: Some(1234),
                 },
                 MessagePart::Text {
@@ -875,9 +880,24 @@ mod tests {
             ],
         );
         assert!(msg.content.contains("(pruned)"));
-        assert!(!msg.content.contains("big output"));
         assert!(msg.content.contains("prefix "));
         assert!(msg.content.contains(" suffix"));
+    }
+
+    #[test]
+    fn flatten_compacted_tool_output_with_reference_renders_body() {
+        // When compacted_at is set and body contains a reference notice, renders the body.
+        let ref_notice = "[tool output pruned; full content at /tmp/overflow/big.txt]";
+        let msg = Message::from_parts(
+            Role::User,
+            vec![MessagePart::ToolOutput {
+                tool_name: "bash".into(),
+                body: ref_notice.into(),
+                compacted_at: Some(1234),
+            }],
+        );
+        assert!(msg.content.contains(ref_notice));
+        assert!(!msg.content.contains("(pruned)"));
     }
 
     #[test]
@@ -894,10 +914,12 @@ mod tests {
 
         if let MessagePart::ToolOutput {
             ref mut compacted_at,
+            ref mut body,
             ..
         } = msg.parts[0]
         {
             *compacted_at = Some(999);
+            body.clear(); // simulate pruning: body cleared, no overflow notice
         }
         msg.rebuild_content();
 


### PR DESCRIPTION
## Summary

Implements the just-in-time tool result retrieval pattern from Manus / Anthropic context engineering research (#1740).

When soft compaction prunes a stale tool output that already has an overflow file on disk, instead of silently clearing the body, the reference is preserved:

```
[tool output pruned; full content at {path}]
```

This allows the agent to re-fetch the content via the `read` tool if needed, rather than repeating the original tool call blindly.

## Changes

- **`tool_execution/mod.rs`**: Add `OVERFLOW_NOTICE_PREFIX` constant shared between the overflow writer and the new extractor — eliminates magic string coupling
- **`context/summarization.rs`**: Add `extract_overflow_ref()` helper; apply JIT reference in all three pruning paths: hard compaction loop, `prune_tool_outputs`, `prune_stale_tool_outputs`
- **`provider.rs`**: Update `flatten_parts()` to render body-as-reference when body is non-empty on a compacted `ToolOutput`
- **`debug_dump.rs`**: Same body-aware rendering for consistency

## Test plan

- [ ] `extract_overflow_ref()` unit tests: happy path, absent notice, empty body, prefix-at-start
- [ ] Pruning path tests in `context/mod.rs`: all three paths produce `[tool output pruned; full content at {path}]` when overflow file present
- [ ] Backward-compat: no-overflow case still produces `[pruned]` / empty body
- [ ] `flatten_parts()` rendering test: non-empty body on compacted `ToolOutput` renders reference
- [ ] `cargo +nightly fmt --check` ✓
- [ ] `cargo clippy --workspace --features full -- -D warnings` ✓
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --features full --lib --bins` ✓ (5551 tests, +8 new)

## Follow-up issues

- `debug_dump.rs` `part_to_json_value()` ToolOutput branch is untested — needs dedicated test
- `extract_overflow_ref()` edge case: prefix present but EM-DASH delimiter absent — missing test
- SEC-JIT-04: use `rfind` over `find` in `extract_overflow_ref` for hardening against crafted tool output

Closes #1740