### PR TITLE
fix(memory): add edge_history_limit config field to prevent unbounded results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- fix(memory): add `edge_history_limit` config field to `[memory.graph]` (default 100); `GraphStore::edge_history()` already accepted a `limit` parameter but callers had no config-driven default — future TUI/API call sites must read `config.memory.graph.edge_history_limit` instead of hardcoding a value (closes #1778)
 - fix(llm): `cascade_chat` and `cascade_chat_stream` no longer store an empty-string provider response as `best_seen`; a provider returning `""` is now skipped for best-seen tracking so the caller receives an explicit error instead of a silent empty response on all-fail fallback (#1754)
 - fix(tui): skip ACP stdio/both autostart when `--tui` is active; stdio and TUI are mutually exclusive (both own stdin/stdout); HTTP transport is still allowed alongside TUI when `acp-http` feature is enabled (#1729)
 - fix(mcp): suppress MCP child process stderr in TUI mode to prevent ratatui display corruption; `McpManager` gains `with_suppress_stderr` builder method (#1729)

--- a/crates/zeph-core/src/config/types/memory.rs
+++ b/crates/zeph-core/src/config/types/memory.rs
@@ -165,6 +165,10 @@ fn default_graph_temporal_decay_rate() -> f64 {
     0.0
 }
 
+fn default_graph_edge_history_limit() -> usize {
+    100
+}
+
 /// Vector backend selector for embedding storage.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -427,6 +431,13 @@ pub struct GraphConfig {
     /// composite score. Default 0.0 preserves existing scoring behavior exactly.
     #[serde(default = "default_graph_temporal_decay_rate")]
     pub temporal_decay_rate: f64,
+    /// Maximum number of historical edge versions returned by `edge_history()`. Default: 100.
+    ///
+    /// Caps the result set returned for a given source entity + predicate pair. Prevents
+    /// unbounded memory usage for high-churn predicates when this method is exposed via TUI
+    /// or API endpoints.
+    #[serde(default = "default_graph_edge_history_limit")]
+    pub edge_history_limit: usize,
 }
 
 impl Default for GraphConfig {
@@ -449,6 +460,7 @@ impl Default for GraphConfig {
             community_summary_concurrency: default_graph_community_summary_concurrency(),
             lpa_edge_chunk_size: default_lpa_edge_chunk_size(),
             temporal_decay_rate: default_graph_temporal_decay_rate(),
+            edge_history_limit: default_graph_edge_history_limit(),
         }
     }
 }

--- a/crates/zeph-core/src/config/types/tests/memory.rs
+++ b/crates/zeph-core/src/config/types/tests/memory.rs
@@ -110,6 +110,7 @@ fn graph_config_defaults() {
     assert_eq!(cfg.community_summary_max_prompt_bytes, 8192);
     assert_eq!(cfg.community_summary_concurrency, 4);
     assert_eq!(cfg.lpa_edge_chunk_size, 10_000);
+    assert_eq!(cfg.edge_history_limit, 100);
 }
 
 #[test]

--- a/crates/zeph-core/src/config/types/tests/snapshots/zeph_core__config__types__tests__config_default_snapshot.snap
+++ b/crates/zeph-core/src/config/types/tests/snapshots/zeph_core__config__types__tests__config_default_snapshot.snap
@@ -130,6 +130,7 @@ community_summary_max_prompt_bytes = 8192
 community_summary_concurrency = 4
 lpa_edge_chunk_size = 10000
 temporal_decay_rate = 0.0
+edge_history_limit = 100
 
 [tools]
 enabled = true


### PR DESCRIPTION
## Summary

- Adds `edge_history_limit: usize` (default 100) to `GraphConfig` / `[memory.graph]` TOML section
- `GraphStore::edge_history()` already accepted a `limit: usize` parameter and had SQL `LIMIT` clauses, but callers had no config-driven default and were forced to hardcode values
- Future TUI/API call sites must read `config.memory.graph.edge_history_limit` instead of hardcoding, preventing unbounded result sets for high-churn predicates

## Test plan

- [ ] `graph_config_defaults` test asserts `edge_history_limit == 100`
- [ ] `graph_config_toml_round_trip` snapshot updated to include the new field
- [ ] All 5577 unit tests pass: `cargo nextest run --config-file .github/nextest.toml --workspace --features full --lib --bins`
- [ ] `cargo clippy --workspace --features full -- -D warnings` passes with zero warnings

Closes #1778