### PR TITLE
feat(memory): validate temporal_decay_rate on deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - feat(cost): add gpt-5 and gpt-5-mini to default pricing table (closes #1744)
 - feat(init): add `hard_compaction_threshold` prompt to `--init` wizard (#1719); prompts for both soft and hard compaction thresholds in sequence with cross-field validation (hard > soft) and `is_finite()` guards
 - feat(core): when pruning a tool output that has an overflow file, emit `[tool output pruned; full content at {path}]` instead of clearing the body, preserving the reference across hard compaction, `prune_tool_outputs`, and `prune_stale_tool_outputs` (#1740)
+- feat(memory): validate `temporal_decay_rate` in `[memory.graph]` on deserialization — rejects NaN, Inf, negative values, and values outside `[0.0, 10.0]`; invalid configs produce a descriptive error at startup instead of silently producing NaN scores (closes #1777)
 
 ### Changed
 

--- a/crates/zeph-core/src/config/types/memory.rs
+++ b/crates/zeph-core/src/config/types/memory.rs
@@ -169,6 +169,24 @@ fn default_graph_edge_history_limit() -> usize {
     100
 }
 
+fn validate_temporal_decay_rate<'de, D>(deserializer: D) -> Result<f64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = <f64 as serde::Deserialize>::deserialize(deserializer)?;
+    if value.is_nan() || value.is_infinite() {
+        return Err(serde::de::Error::custom(
+            "temporal_decay_rate must be a finite number",
+        ));
+    }
+    if !(0.0..=10.0).contains(&value) {
+        return Err(serde::de::Error::custom(
+            "temporal_decay_rate must be in [0.0, 10.0]",
+        ));
+    }
+    Ok(value)
+}
+
 /// Vector backend selector for embedding storage.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -429,7 +447,10 @@ pub struct GraphConfig {
     /// When > 0, recent edges receive a small additive score boost over older edges.
     /// The boost formula is `1 / (1 + age_days * rate)`, blended additively with the base
     /// composite score. Default 0.0 preserves existing scoring behavior exactly.
-    #[serde(default = "default_graph_temporal_decay_rate")]
+    #[serde(
+        default = "default_graph_temporal_decay_rate",
+        deserialize_with = "validate_temporal_decay_rate"
+    )]
     pub temporal_decay_rate: f64,
     /// Maximum number of historical edge versions returned by `edge_history()`. Default: 100.
     ///

--- a/crates/zeph-core/src/config/types/tests/memory.rs
+++ b/crates/zeph-core/src/config/types/tests/memory.rs
@@ -111,6 +111,70 @@ fn graph_config_defaults() {
     assert_eq!(cfg.community_summary_concurrency, 4);
     assert_eq!(cfg.lpa_edge_chunk_size, 10_000);
     assert_eq!(cfg.edge_history_limit, 100);
+    assert!((cfg.temporal_decay_rate - 0.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn graph_config_temporal_decay_rate_valid_zero() {
+    let toml = r#"temporal_decay_rate = 0.0"#;
+    let cfg: GraphConfig = toml::from_str(toml).unwrap();
+    assert!((cfg.temporal_decay_rate - 0.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn graph_config_temporal_decay_rate_valid_mid() {
+    let toml = r#"temporal_decay_rate = 5.0"#;
+    let cfg: GraphConfig = toml::from_str(toml).unwrap();
+    assert!((cfg.temporal_decay_rate - 5.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn graph_config_temporal_decay_rate_valid_max() {
+    let toml = r#"temporal_decay_rate = 10.0"#;
+    let cfg: GraphConfig = toml::from_str(toml).unwrap();
+    assert!((cfg.temporal_decay_rate - 10.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn graph_config_temporal_decay_rate_negative_rejected() {
+    let toml = r#"temporal_decay_rate = -0.1"#;
+    assert!(
+        toml::from_str::<GraphConfig>(toml).is_err(),
+        "negative temporal_decay_rate must be rejected"
+    );
+}
+
+#[test]
+fn graph_config_temporal_decay_rate_above_max_rejected() {
+    let toml = r#"temporal_decay_rate = 10.1"#;
+    assert!(
+        toml::from_str::<GraphConfig>(toml).is_err(),
+        "temporal_decay_rate > 10.0 must be rejected"
+    );
+}
+
+// NaN cannot be expressed in TOML or JSON; the is_nan() guard in validate_temporal_decay_rate
+// is a defense-in-depth check against programmatic misuse (e.g. direct struct construction),
+// not reachable through normal deserialization paths.
+
+#[test]
+fn graph_config_temporal_decay_rate_inf_rejected() {
+    // TOML does not support Inf literals; test via a sufficiently large JSON float that
+    // overflows to f64::INFINITY when parsed by serde_json.
+    let json = r#"{"temporal_decay_rate": 1e309}"#;
+    assert!(
+        serde_json::from_str::<GraphConfig>(json).is_err(),
+        "+Inf temporal_decay_rate must be rejected"
+    );
+}
+
+#[test]
+fn graph_config_temporal_decay_rate_neg_inf_rejected() {
+    let json = r#"{"temporal_decay_rate": -1e309}"#;
+    assert!(
+        serde_json::from_str::<GraphConfig>(json).is_err(),
+        "-Inf temporal_decay_rate must be rejected"
+    );
 }
 
 #[test]
@@ -121,4 +185,5 @@ fn graph_config_toml_round_trip() {
     assert_eq!(back.enabled, original.enabled);
     assert_eq!(back.max_hops, original.max_hops);
     assert_eq!(back.recall_limit, original.recall_limit);
+    assert_eq!(back.temporal_decay_rate, original.temporal_decay_rate);
 }


### PR DESCRIPTION
## Summary

- Add `validate_temporal_decay_rate` custom serde deserializer in `GraphConfig`
- Rejects NaN, Inf, negative values, and values outside `[0.0, 10.0]` with a descriptive error
- Invalid configs now fail at startup instead of silently producing NaN scores during graph recall scoring

Closes #1777

## Test plan

- `graph_config_temporal_decay_rate_negative_rejected` — `-0.1` via TOML fails
- `graph_config_temporal_decay_rate_above_max_rejected` — `10.1` via TOML fails
- `graph_config_temporal_decay_rate_inf_rejected` — `+Inf` via JSON overflow fails
- `graph_config_temporal_decay_rate_neg_inf_rejected` — `-Inf` via JSON overflow fails
- `graph_config_temporal_decay_rate_valid_zero` — `0.0` passes
- `graph_config_temporal_decay_rate_valid_mid` — `5.0` passes
- `graph_config_temporal_decay_rate_valid_max` — `10.0` passes
- `graph_config_defaults` — asserts `temporal_decay_rate == 0.0`
- `graph_config_toml_round_trip` — asserts `temporal_decay_rate` survives round-trip