### PR TITLE
feat(memory): track trajectory elongation from hard compaction (#1739)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - feat(init): add `hard_compaction_threshold` prompt to `--init` wizard (#1719); prompts for both soft and hard compaction thresholds in sequence with cross-field validation (hard > soft) and `is_finite()` guards
 - feat(core): when pruning a tool output that has an overflow file, emit `[tool output pruned; full content at {path}]` instead of clearing the body, preserving the reference across hard compaction, `prune_tool_outputs`, and `prune_stale_tool_outputs` (#1740)
 - feat(memory): validate `temporal_decay_rate` in `[memory.graph]` on deserialization — rejects NaN, Inf, negative values, and values outside `[0.0, 10.0]`; invalid configs produce a descriptive error at startup instead of silently producing NaN scores (closes #1777)
+- feat(core): hard compaction trajectory-elongation metrics (closes #1739) — `compaction_hard_count` and `compaction_turns_after_hard` added to `MetricsSnapshot`; tracks how many user-message turns elapsed between consecutive hard compaction events; turn counter increments before all early-return guards (exhaustion, server compaction, `compacted_this_turn`) to ensure no turns are silently dropped; last open segment is finalized at `shutdown()` and both fields are logged via `tracing::info!` when at least one hard compaction occurred
 
 ### Changed
 

--- a/crates/zeph-core/src/agent/context/mod.rs
+++ b/crates/zeph-core/src/agent/context/mod.rs
@@ -3812,4 +3812,98 @@ mod tests {
 
         assert_eq!(agent.context_manager.compaction_cooldown_turns, 5);
     }
+
+    #[test]
+    fn compaction_hard_count_zero_by_default() {
+        let snapshot = crate::metrics::MetricsSnapshot::default();
+        assert_eq!(snapshot.compaction_hard_count, 0);
+        assert!(snapshot.compaction_turns_after_hard.is_empty());
+    }
+
+    #[tokio::test]
+    async fn compaction_hard_count_increments_on_hard_tier() {
+        let provider = mock_provider(vec!["summary".to_string()]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let (tx, rx) = watch::channel(crate::metrics::MetricsSnapshot::default());
+
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
+            .with_context_budget(1000, 0.20, 0.75, 4, 0)
+            .with_metrics(tx);
+
+        // Drive cached_prompt_tokens above the hard threshold (75% of 1000 = 750).
+        agent.providers.cached_prompt_tokens = 900;
+
+        agent.maybe_compact().await.unwrap();
+
+        assert_eq!(rx.borrow().compaction_hard_count, 1);
+    }
+
+    #[tokio::test]
+    async fn compaction_turns_after_hard_tracks_segments() {
+        let provider = mock_provider(vec!["summary".to_string()]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let (tx, rx) = watch::channel(crate::metrics::MetricsSnapshot::default());
+
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
+            .with_context_budget(1000, 0.20, 0.75, 4, 0)
+            .with_compaction_cooldown(0)
+            .with_metrics(tx);
+
+        // Simulate first hard compaction by driving cached tokens above threshold.
+        agent.providers.cached_prompt_tokens = 900;
+        agent.maybe_compact().await.unwrap();
+        assert_eq!(rx.borrow().compaction_hard_count, 1);
+        // turns_since_last_hard_compaction is now Some(0).
+
+        // Simulate 3 turns where context is below threshold.
+        // Reset per-turn guard (done by handle_message at the start of each turn).
+        agent.providers.cached_prompt_tokens = 0;
+        for _ in 0..3 {
+            agent.context_manager.compacted_this_turn = false;
+            agent.maybe_compact().await.unwrap();
+        }
+        // turns_since_last_hard_compaction is now Some(3).
+
+        // Directly trigger the Hard tier accounting without a real LLM call
+        // by simulating what maybe_compact does in the Hard branch.
+        // This tests that the Vec accumulates the segment correctly.
+        if let Some(turns) = agent.context_manager.turns_since_last_hard_compaction {
+            agent.update_metrics(|m| {
+                m.compaction_turns_after_hard.push(turns);
+                m.compaction_hard_count += 1;
+            });
+            agent.context_manager.turns_since_last_hard_compaction = Some(0);
+        }
+
+        assert_eq!(rx.borrow().compaction_hard_count, 2);
+        assert_eq!(rx.borrow().compaction_turns_after_hard, vec![3]);
+    }
+
+    #[tokio::test]
+    async fn compaction_turn_counter_increments_before_exhaustion_guard() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
+            .with_context_budget(1000, 0.20, 0.75, 4, 0);
+
+        // Manually set tracking active and exhaust compaction.
+        agent.context_manager.turns_since_last_hard_compaction = Some(0);
+        agent.context_manager.compaction_exhausted = true;
+
+        // Call maybe_compact — early return via exhaustion guard.
+        agent.maybe_compact().await.unwrap();
+
+        // Turn counter must still have been incremented (S1/S2 fix).
+        assert_eq!(
+            agent.context_manager.turns_since_last_hard_compaction,
+            Some(1)
+        );
+    }
 }

--- a/crates/zeph-core/src/agent/context/summarization.rs
+++ b/crates/zeph-core/src/agent/context/summarization.rs
@@ -893,6 +893,12 @@ impl<C: Channel> Agent<C> {
     pub(in crate::agent) async fn maybe_compact(
         &mut self,
     ) -> Result<(), super::super::error::AgentError> {
+        // Increment the turn counter unconditionally so every user-message turn is counted
+        // regardless of early-return guards (exhaustion, server compaction, cooldown).
+        if let Some(ref mut count) = self.context_manager.turns_since_last_hard_compaction {
+            *count += 1;
+        }
+
         // Guard 3 — Exhaustion: stop compaction permanently when it cannot reduce context.
         if self.context_manager.compaction_exhausted {
             if !self.context_manager.exhaustion_warned {
@@ -982,6 +988,20 @@ impl<C: Channel> Agent<C> {
                 Ok(())
             }
             CompactionTier::Hard => {
+                // Track hard compaction event: finalize the previous segment's turn count
+                // and start a new one. Counted regardless of cooldown — captures pressure,
+                // not just action. When compaction_hard_count == 0, compaction_turns_after_hard
+                // is expected to be empty.
+                if let Some(turns) = self.context_manager.turns_since_last_hard_compaction {
+                    self.update_metrics(|m| {
+                        m.compaction_turns_after_hard.push(turns);
+                    });
+                }
+                self.context_manager.turns_since_last_hard_compaction = Some(0);
+                self.update_metrics(|m| {
+                    m.compaction_hard_count += 1;
+                });
+
                 // Cooldown guard: skip LLM summarization while cooling down.
                 if in_cooldown {
                     tracing::debug!(

--- a/crates/zeph-core/src/agent/context_manager.rs
+++ b/crates/zeph-core/src/agent/context_manager.rs
@@ -40,6 +40,10 @@ pub(crate) struct ContextManager {
     pub(super) compaction_exhausted: bool,
     /// Tracks whether the exhaustion warning message has been sent to the user.
     pub(super) exhaustion_warned: bool,
+    /// Counts user-message turns since the last hard compaction event.
+    /// `None` = no hard compaction has occurred yet in this session.
+    /// `Some(n)` = n turns have elapsed since the last hard compaction.
+    pub(super) turns_since_last_hard_compaction: Option<u64>,
 }
 
 impl ContextManager {
@@ -58,6 +62,7 @@ impl ContextManager {
             compaction_turns_since: 0,
             compaction_exhausted: false,
             exhaustion_warned: false,
+            turns_since_last_hard_compaction: None,
         }
     }
 

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -1727,6 +1727,16 @@ impl<C: Channel> Agent<C> {
             manager.shutdown_all_shared().await;
         }
 
+        // Finalize compaction trajectory: push the last open segment into the Vec.
+        // This segment would otherwise only be pushed when the next hard compaction fires,
+        // which never happens at session end.
+        if let Some(turns) = self.context_manager.turns_since_last_hard_compaction {
+            self.update_metrics(|m| {
+                m.compaction_turns_after_hard.push(turns);
+            });
+            self.context_manager.turns_since_last_hard_compaction = None;
+        }
+
         if let Some(ref tx) = self.metrics.metrics_tx {
             let m = tx.borrow();
             if m.filter_applications > 0 {
@@ -1742,6 +1752,13 @@ impl<C: Channel> Agent<C> {
                     applications = m.filter_applications,
                     "tool output filtering saved ~{} tokens ({pct:.0}%)",
                     m.filter_saved_tokens,
+                );
+            }
+            if m.compaction_hard_count > 0 {
+                tracing::info!(
+                    hard_compactions = m.compaction_hard_count,
+                    turns_after_hard = ?m.compaction_turns_after_hard,
+                    "hard compaction trajectory"
                 );
             }
         }

--- a/crates/zeph-core/src/metrics.rs
+++ b/crates/zeph-core/src/metrics.rs
@@ -170,6 +170,13 @@ pub struct MetricsSnapshot {
     pub model_name: String,
     pub summaries_count: u64,
     pub context_compactions: u64,
+    /// Number of times the agent entered the Hard compaction tier, including cooldown-skipped
+    /// turns. Not equal to the actual LLM summarization count — reflects pressure, not action.
+    pub compaction_hard_count: u64,
+    /// User-message turns elapsed after each hard compaction event.
+    /// Entry i = turns between hard compaction i and hard compaction i+1 (or session end).
+    /// Empty when no hard compaction occurred during the session.
+    pub compaction_turns_after_hard: Vec<u64>,
     pub compression_events: u64,
     pub compression_tokens_saved: u64,
     pub tool_output_prunes: u64,


### PR DESCRIPTION
## Summary

- Add `compaction_hard_count: u64` and `turns_after_hard_compaction: Vec<u64>` to `MetricsSnapshot`
- Increment hard compaction counter and push per-segment turn count at each `CompactionTier::Hard` event in `maybe_compact()`
- Turn counter increments before all early-return guards (exhaustion, server compaction, `compacted_this_turn`) so no turns are silently dropped
- Final open segment is finalized at `shutdown()` and both fields are logged via `tracing::info!` when at least one hard compaction occurred
- Closes #1739

## Motivation

JetBrains Research (Dec 2025) found LLM summarization causes agents to run 13-15% longer on average. This change adds the instrumentation needed to detect and measure trajectory elongation in real Zeph sessions via `.local/testing/debug/session.log`.

## Test plan

- [ ] `cargo +nightly fmt --check` — pass
- [ ] `cargo clippy --workspace --features full -- -D warnings` — pass
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --features full --lib --bins` — 5581 passed, 12 skipped
- [ ] 4 new unit tests: `compaction_hard_count_zero_by_default`, `compaction_hard_count_increments_on_hard_tier`, `compaction_turns_after_hard_tracks_segments`, `compaction_turn_counter_increments_before_exhaustion_guard`