### PR TITLE
fix(memory): fix inflated edges_created, batch embed/search, add missing tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- fix(memory): `edges_created` stat in `link_memory_notes` was inflated when both endpoints of a pair appeared in `entity_ids` — the second normalised `insert_edge(src, tgt)` call returned `Ok` (updating confidence on the existing row), incrementing the counter twice for one physical edge; a `HashSet` of seen `(src, tgt)` pairs now deduplicates within each pass, keeping the stat accurate (closes #1792)
+- perf(memory): `link_memory_notes` now embeds all entity texts in parallel via `futures::join_all` instead of N sequential HTTP round-trips, reducing embed latency from O(N) to O(1) round-trips (closes #1793)
+- perf(memory): `link_memory_notes` now runs all Qdrant `search_collection` calls in parallel via `futures::join_all`, reducing search latency from O(N) to O(1) round-trips (closes #1794)
+- test(memory): add `link_memory_notes_edges_created_not_inflated` — verifies `edges_created == 1` when both endpoints are in `entity_ids`, catching the bidirectional double-count regression (closes #1792)
+- test(memory): add `link_memory_notes_secondary_self_skip_guard` — seeds entity A without `qdrant_point_id` in SQLite (primary point-id guard inactive), verifies the secondary `target_id == entity_id` guard prevents self-edges when A appears in its own top-K search results (closes #1790)
+- test(memory): add `link_memory_notes_threshold_rejection` — sets `similarity_threshold = 2.0` (above maximum cosine similarity 1.0), verifies zero edges are created, covering the `score < threshold` filter path (closes #1791)
+
 - feat(memory): A-MEM dynamic note linking — fire-and-forget similarity edges on graph write; `NoteLinkingConfig` nested in `[memory.graph.note_linking]`; `link_memory_notes` runs after each successful extraction inside the spawned task, bounded by `timeout_secs`; unidirectional `similar_to` edges (source < target) avoid BFS double-counting; `similarity_threshold` deserialization rejects NaN, Inf, and values outside `[0.0, 1.0]`; disabled by default (closes #1694)
 
 - feat(memory,core): migrate tool overflow storage from filesystem to SQLite (`tool_overflow` table, migration 031); `maybe_summarize_tool_output` now writes to `SqliteStore.save_overflow` instead of disk files; overflow references use opaque `overflow:<uuid>` format (eliminates absolute-path leakage SEC-JIT-03); new `read_overflow` native tool allows LLM to retrieve full content; age-based cleanup via `SqliteStore.cleanup_overflow` on startup; `ON DELETE CASCADE` automatically removes overflow rows when conversation is deleted (closes #1774)

--- a/crates/zeph-memory/src/semantic/graph.rs
+++ b/crates/zeph-memory/src/semantic/graph.rs
@@ -77,18 +77,30 @@ pub struct LinkingStats {
 /// Qdrant collection name for entity embeddings (mirrors the constant in `resolver.rs`).
 const ENTITY_COLLECTION: &str = "zeph_graph_entities";
 
+/// Work item for a single entity during a note-linking pass.
+struct EntityWorkItem {
+    entity_id: i64,
+    canonical_name: String,
+    embed_text: String,
+    self_point_id: Option<String>,
+}
+
 /// Link newly extracted entities to semantically similar entities in the graph.
 ///
 /// For each entity in `entity_ids`:
 /// 1. Load the entity name + summary from `SQLite`.
-/// 2. Re-embed the entity text using `provider.embed()`.
-/// 3. Search the entity embedding collection for the `top_k + 1` most similar points.
-/// 4. Filter out the entity itself (by `qdrant_point_id`) and points below `similarity_threshold`.
+/// 2. Embed all entity texts in parallel.
+/// 3. Search the entity embedding collection in parallel for the `top_k + 1` most similar points.
+/// 4. Filter out the entity itself (by `qdrant_point_id` or `entity_id` payload) and points
+///    below `similarity_threshold`.
 /// 5. Insert a unidirectional `similar_to` edge where `source_id < target_id` to avoid
 ///    double-counting in BFS recall while still being traversable via the OR clause in
 ///    `edges_for_entity`. The edge confidence is set to the cosine similarity score.
+/// 6. Deduplicate pairs within a single pass so that a pair encountered from both A→B and B→A
+///    directions is only inserted once, keeping `edges_created` accurate.
 ///
 /// Errors are logged and not propagated — this is a best-effort background enrichment step.
+#[allow(clippy::too_many_lines)]
 pub async fn link_memory_notes(
     entity_ids: &[i64],
     pool: sqlx::SqlitePool,
@@ -96,11 +108,15 @@ pub async fn link_memory_notes(
     provider: AnyProvider,
     cfg: &NoteLinkingConfig,
 ) -> LinkingStats {
+    use futures::future;
+
     use crate::graph::GraphStore;
 
     let store = GraphStore::new(pool);
     let mut stats = LinkingStats::default();
 
+    // Phase 1: load entities from DB sequentially (cheap; avoids connection-pool contention).
+    let mut work_items: Vec<EntityWorkItem> = Vec::with_capacity(entity_ids.len());
     for &entity_id in entity_ids {
         let entity = match store.find_entity_by_id(entity_id).await {
             Ok(Some(e)) => e,
@@ -113,39 +129,68 @@ pub async fn link_memory_notes(
                 continue;
             }
         };
-
-        // Build embed text matching the pattern used during entity resolution.
         let embed_text = match &entity.summary {
             Some(s) if !s.is_empty() => format!("{}: {s}", entity.canonical_name),
             _ => entity.canonical_name.clone(),
         };
+        work_items.push(EntityWorkItem {
+            entity_id,
+            canonical_name: entity.canonical_name,
+            embed_text,
+            self_point_id: entity.qdrant_point_id,
+        });
+    }
 
-        let query_vec = match provider.embed(&embed_text).await {
-            Ok(v) => v,
+    if work_items.is_empty() {
+        return stats;
+    }
+
+    // Phase 2: embed all entity texts in parallel to reduce N serial HTTP round-trips to 1.
+    let embed_results: Vec<_> =
+        future::join_all(work_items.iter().map(|w| provider.embed(&w.embed_text))).await;
+
+    // Phase 3: search for similar entities in parallel for all successfully embedded entities.
+    let search_limit = cfg.top_k + 1; // +1 to account for self-match
+    let valid: Vec<(usize, Vec<f32>)> = embed_results
+        .into_iter()
+        .enumerate()
+        .filter_map(|(i, r)| match r {
+            Ok(v) => Some((i, v)),
             Err(e) => {
                 tracing::debug!(
                     "note_linking: embed failed for entity {:?}: {e:#}",
-                    entity.canonical_name
+                    work_items[i].canonical_name
                 );
-                continue;
+                None
             }
-        };
+        })
+        .collect();
 
-        let search_limit = cfg.top_k + 1; // +1 to account for self-match
-        let results = match embedding_store
-            .search_collection(
-                ENTITY_COLLECTION,
-                &query_vec,
-                search_limit,
-                None::<VectorFilter>,
-            )
-            .await
-        {
+    let search_results: Vec<_> = future::join_all(valid.iter().map(|(_, vec)| {
+        embedding_store.search_collection(
+            ENTITY_COLLECTION,
+            vec,
+            search_limit,
+            None::<VectorFilter>,
+        )
+    }))
+    .await;
+
+    // Phase 4: insert edges; deduplicate pairs seen from both A→B and B→A directions.
+    // Without deduplication, both directions call insert_edge for the same normalised pair and
+    // both return Ok (the second call updates confidence on the existing row), inflating
+    // edges_created by the number of bidirectional hits.
+    let mut seen_pairs = std::collections::HashSet::new();
+
+    for ((work_idx, _), search_result) in valid.iter().zip(search_results.iter()) {
+        let w = &work_items[*work_idx];
+
+        let results = match search_result {
             Ok(r) => r,
             Err(e) => {
                 tracing::debug!(
                     "note_linking: search failed for entity {:?}: {e:#}",
-                    entity.canonical_name
+                    w.canonical_name
                 );
                 continue;
             }
@@ -153,16 +198,11 @@ pub async fn link_memory_notes(
 
         stats.entities_processed += 1;
 
-        // Filter: exclude self, exclude below-threshold, then take top_k.
-        let self_point_id = entity.qdrant_point_id.as_deref();
-        let candidates: Vec<_> = results
+        let self_point_id = w.self_point_id.as_deref();
+        let candidates = results
             .iter()
-            .filter(|p| {
-                // Exclude self by point_id comparison.
-                Some(p.id.as_str()) != self_point_id && p.score >= cfg.similarity_threshold
-            })
-            .take(cfg.top_k)
-            .collect();
+            .filter(|p| Some(p.id.as_str()) != self_point_id && p.score >= cfg.similarity_threshold)
+            .take(cfg.top_k);
 
         for point in candidates {
             let Some(target_id) = point
@@ -177,18 +217,21 @@ pub async fn link_memory_notes(
                 continue;
             };
 
-            if target_id == entity_id {
-                continue; // additional self-guard in case qdrant_point_id was null
+            if target_id == w.entity_id {
+                continue; // secondary self-guard when qdrant_point_id is null
             }
 
-            // Unidirectional: only insert where source < target to avoid double-counting in BFS.
-            // edges_for_entity uses "source = ? OR target = ?" so the edge is still traversable
-            // in both directions without creating a duplicate in the opposite direction.
-            let (src, tgt) = if entity_id < target_id {
-                (entity_id, target_id)
+            // Normalise direction: always store source_id < target_id.
+            let (src, tgt) = if w.entity_id < target_id {
+                (w.entity_id, target_id)
             } else {
-                (target_id, entity_id)
+                (target_id, w.entity_id)
             };
+
+            // Skip pairs already processed in this pass to avoid double-counting.
+            if !seen_pairs.insert((src, tgt)) {
+                continue;
+            }
 
             let fact = format!("Semantically similar entities (score: {:.3})", point.score);
 

--- a/crates/zeph-memory/src/semantic/tests/graph.rs
+++ b/crates/zeph-memory/src/semantic/tests/graph.rs
@@ -352,6 +352,45 @@ async fn seed_entity_with_zero_embedding(
     id
 }
 
+/// Seed an entity with a zero embedding but WITHOUT writing qdrant_point_id back to SQLite.
+///
+/// Used to exercise the secondary `target_id == entity_id` guard — when `qdrant_point_id` is NULL
+/// in the DB the primary point-id comparison cannot exclude the self-result, so the secondary
+/// guard must catch it.
+async fn seed_entity_no_db_point_id(
+    store: &GraphStore,
+    embedding_store: &crate::embedding_store::EmbeddingStore,
+    name: &str,
+) -> i64 {
+    use serde_json::json;
+
+    let id = store
+        .upsert_entity(name, name, EntityType::Concept, None)
+        .await
+        .unwrap();
+
+    let point_id = uuid::Uuid::new_v4().to_string();
+    let payload = json!({
+        "entity_id": id,
+        "entity_type": "concept",
+        "name": name,
+        "summary": "",
+    });
+    embedding_store
+        .upsert_to_collection(
+            "zeph_graph_entities",
+            &point_id,
+            payload,
+            vec![0.0_f32; 384],
+        )
+        .await
+        .unwrap();
+
+    // Intentionally NOT writing qdrant_point_id to graph_entities.
+    // The DB row keeps qdrant_point_id = NULL so the primary self-exclusion guard is inactive.
+    id
+}
+
 fn embedding_provider() -> AnyProvider {
     use zeph_llm::mock::MockProvider;
     let mut mock = MockProvider::default();
@@ -475,5 +514,139 @@ async fn link_memory_notes_unidirectional() {
     assert_eq!(
         count, 1,
         "must have exactly one unidirectional edge per pair"
+    );
+}
+
+// ── edges_created stat accuracy (fix #1792) ──────────────────────────────────
+//
+// When both A and B are in entity_ids, the A→B and B→A directions both produce
+// the same normalised (min, max) pair. Previously both calls to insert_edge
+// returned Ok (the second updated confidence on the existing row), inflating
+// edges_created to 2. After the fix, seen_pairs deduplication ensures only one
+// insert_edge call is made per pair, keeping edges_created == 1.
+
+#[tokio::test]
+async fn link_memory_notes_edges_created_not_inflated() {
+    let (memory, embedding_store) = memory_with_in_memory_vector_store().await;
+    let store = GraphStore::new(memory.sqlite.pool().clone());
+
+    let id_a = seed_entity_with_zero_embedding(&store, &embedding_store, "stat_entity_a").await;
+    let id_b = seed_entity_with_zero_embedding(&store, &embedding_store, "stat_entity_b").await;
+
+    let cfg = NoteLinkingConfig {
+        enabled: true,
+        similarity_threshold: 0.0,
+        top_k: 5,
+        timeout_secs: 10,
+    };
+    // Pass both A and B so each will find the other during search.
+    let stats = link_memory_notes(
+        &[id_a, id_b],
+        memory.sqlite.pool().clone(),
+        embedding_store,
+        embedding_provider(),
+        &cfg,
+    )
+    .await;
+
+    assert_eq!(
+        stats.edges_created, 1,
+        "edges_created must be 1 even when both endpoints are in entity_ids"
+    );
+}
+
+// ── secondary self-skip guard (test #1790) ────────────────────────────────────
+//
+// When qdrant_point_id is NULL in the DB the primary point-id guard cannot exclude
+// the self-result from the search. The secondary guard (`target_id == entity_id`)
+// must catch it so no self-edge is created.
+
+#[tokio::test]
+async fn link_memory_notes_secondary_self_skip_guard() {
+    let (memory, embedding_store) = memory_with_in_memory_vector_store().await;
+    let store = GraphStore::new(memory.sqlite.pool().clone());
+
+    // Entity A: qdrant_point_id NOT written to DB — primary guard is inactive.
+    let id_a = seed_entity_no_db_point_id(&store, &embedding_store, "secondary_guard_a").await;
+    // Entity B: normal seeding so that search returns at least one non-self result.
+    let id_b = seed_entity_with_zero_embedding(&store, &embedding_store, "secondary_guard_b").await;
+    let id_c = seed_entity_with_zero_embedding(&store, &embedding_store, "secondary_guard_c").await;
+
+    let cfg = NoteLinkingConfig {
+        enabled: true,
+        similarity_threshold: 0.0,
+        top_k: 10,
+        timeout_secs: 10,
+    };
+    link_memory_notes(
+        &[id_a],
+        memory.sqlite.pool().clone(),
+        embedding_store,
+        embedding_provider(),
+        &cfg,
+    )
+    .await;
+
+    // No self-edge A→A must exist.
+    let self_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM graph_edges
+         WHERE source_entity_id = ?1 AND target_entity_id = ?1",
+    )
+    .bind(id_a)
+    .fetch_one(memory.sqlite.pool())
+    .await
+    .unwrap();
+    assert_eq!(
+        self_count, 0,
+        "self-edge must not be created via secondary guard"
+    );
+
+    // At least one edge to B or C must exist (confirming A was processed successfully).
+    let other_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM graph_edges
+         WHERE (source_entity_id = ?1 OR target_entity_id = ?1)
+           AND source_entity_id != target_entity_id",
+    )
+    .bind(id_a)
+    .fetch_one(memory.sqlite.pool())
+    .await
+    .unwrap();
+    let _ = (id_b, id_c); // referenced for context
+    assert!(other_count > 0, "A must have at least one edge to B or C");
+}
+
+// ── threshold rejection (test #1791) ─────────────────────────────────────────
+//
+// MockProvider returns vec![0.0; 384]; InMemoryVectorStore scores identical zero
+// vectors as 1.0. Setting similarity_threshold = 2.0 (above the maximum possible
+// cosine similarity) must reject all candidates, producing zero edges.
+
+#[tokio::test]
+async fn link_memory_notes_threshold_rejection() {
+    let (memory, embedding_store) = memory_with_in_memory_vector_store().await;
+    let store = GraphStore::new(memory.sqlite.pool().clone());
+
+    let id_a = seed_entity_with_zero_embedding(&store, &embedding_store, "rej_entity_a").await;
+    let _id_b = seed_entity_with_zero_embedding(&store, &embedding_store, "rej_entity_b").await;
+
+    // threshold = 2.0 is above the maximum possible cosine similarity (1.0).
+    let cfg = NoteLinkingConfig {
+        enabled: true,
+        similarity_threshold: 2.0,
+        top_k: 5,
+        timeout_secs: 10,
+    };
+    let stats = link_memory_notes(
+        &[id_a],
+        memory.sqlite.pool().clone(),
+        embedding_store,
+        embedding_provider(),
+        &cfg,
+    )
+    .await;
+
+    assert_eq!(
+        stats.edges_created, 0,
+        "no edges must be created when all scores are below threshold"
     );
 }


### PR DESCRIPTION
## Summary

- **#1792 fix**: `edges_created` stat was inflated when both endpoints of a pair appeared in `entity_ids`. `insert_edge` returns `Ok` even for duplicate calls (it updates confidence), so the counter incremented twice per physical edge. Added `HashSet<(i64, i64)>` deduplication per pass.
- **#1793 perf**: Replaced N sequential `provider.embed()` calls with a single `futures::join_all`, reducing embed latency from O(N) serial RTTs to O(1) concurrent.
- **#1794 perf**: Replaced N sequential `embedding_store.search_collection()` calls with a single `futures::join_all`, reducing Qdrant search latency from O(N) serial RTTs to O(1) concurrent.
- **#1790 test**: `link_memory_notes_secondary_self_skip_guard` — seeds entity A without `qdrant_point_id` in SQLite (primary point-id guard inactive), verifies secondary `target_id == entity_id` guard blocks self-edges when A appears in its own top-K results.
- **#1791 test**: `link_memory_notes_threshold_rejection` — sets `similarity_threshold = 2.0` (above maximum cosine similarity 1.0), asserts zero edges created, covering the `score < threshold` filter path.
- **#1792 test**: `link_memory_notes_edges_created_not_inflated` — asserts `edges_created == 1` when both pair endpoints are in `entity_ids`, acting as a regression guard for the double-count bug.

## Test plan

- [x] All 6 `link_memory_notes` unit tests pass (including 3 new ones)
- [x] Full workspace test suite: 5630 passed, 0 failed
- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --workspace --features full -- -D warnings` passes