### PR TITLE
fix(memory): pass embedding store to EntityResolver in extract_and_store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Qdrant collection dimension mismatch when switching embedding models on collections with 0 points (#1815)
 - fix(debug): trace.json now written inside per-session subdir, preventing overwrites (#1814)
+- A-MEM note linking never created `similar_to` edges because `EntityResolver` in `extract_and_store` was constructed without `with_embedding_store()`, leaving `zeph_graph_entities` unpopulated; pass the Qdrant embedding store through to the resolver so entity embeddings are stored and note linking can find semantically similar entities across sessions (#1817)
 
 ## [0.15.1] - 2026-03-15
 

--- a/crates/zeph-core/src/agent/graph_commands.rs
+++ b/crates/zeph-core/src/agent/graph_commands.rs
@@ -371,6 +371,7 @@ impl<C: Channel> Agent<C> {
                     pool,
                     extraction_cfg,
                     None,
+                    None,
                 )
                 .await
                 {

--- a/crates/zeph-memory/src/semantic/graph.rs
+++ b/crates/zeph-memory/src/semantic/graph.rs
@@ -261,6 +261,9 @@ pub async fn link_memory_notes(
 ///
 /// This function runs inside a spawned task — it receives owned data only.
 ///
+/// The optional `embedding_store` enables entity embedding storage in Qdrant, which is
+/// required for A-MEM note linking to find semantically similar entities across sessions.
+///
 /// # Errors
 ///
 /// Returns an error if the database query fails or LLM extraction fails.
@@ -271,6 +274,7 @@ pub async fn extract_and_store(
     pool: sqlx::SqlitePool,
     config: GraphExtractionConfig,
     post_extract_validator: PostExtractValidator,
+    embedding_store: Option<Arc<EmbeddingStore>>,
 ) -> Result<ExtractionResult, MemoryError> {
     use crate::graph::{EntityResolver, GraphExtractor, GraphStore};
 
@@ -310,7 +314,11 @@ pub async fn extract_and_store(
         return Ok(ExtractionResult::default());
     }
 
-    let resolver = EntityResolver::new(&store);
+    let resolver = if let Some(ref emb) = embedding_store {
+        EntityResolver::new(&store).with_embedding_store(emb)
+    } else {
+        EntityResolver::new(&store)
+    };
 
     let mut entities_upserted = 0usize;
     let mut entity_name_to_id: std::collections::HashMap<String, i64> =
@@ -406,6 +414,7 @@ impl SemanticMemory {
                     pool.clone(),
                     config.clone(),
                     post_extract_validator,
+                    embedding_store.clone(),
                 ),
             )
             .await;

--- a/crates/zeph-memory/src/semantic/tests/graph.rs
+++ b/crates/zeph-memory/src/semantic/tests/graph.rs
@@ -109,6 +109,7 @@ async fn extract_and_store_returns_zero_stats_for_empty_content() {
             ..Default::default()
         },
         None,
+        None,
     )
     .await
     .unwrap();
@@ -134,6 +135,7 @@ async fn extraction_count_increments_atomically() {
                 extraction_timeout_secs: 5,
                 ..Default::default()
             },
+            None,
             None,
         )
         .await;


### PR DESCRIPTION
## Summary

- `EntityResolver` in the production `extract_and_store` path was constructed without `.with_embedding_store()`, so `store_entity_embedding()` was never called — `zeph_graph_entities` stayed empty and `link_memory_notes` found no candidates, silently producing zero `similar_to` edges
- Thread the optional `Arc<EmbeddingStore>` from `spawn_graph_extraction` into `extract_and_store` and wire it into `EntityResolver` construction, matching the pattern already used in test helpers
- Call sites that intentionally have no embedding store (graph backfill in `graph_commands`, unit tests) pass `None`

Closes #1817

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --features full -- -D warnings` — zero warnings
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features full --lib --bins` — 5790 passed