### PR TITLE
fix(memory): pass provider to EntityResolver in extract_and_store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Qdrant collection dimension mismatch when switching embedding models on collections with 0 points (#1815)
 - fix(debug): trace.json now written inside per-session subdir, preventing overwrites (#1814)
 - A-MEM note linking never created `similar_to` edges because `EntityResolver` in `extract_and_store` was constructed without `with_embedding_store()`, leaving `zeph_graph_entities` unpopulated; pass the Qdrant embedding store through to the resolver so entity embeddings are stored and note linking can find semantically similar entities across sessions (#1817)
+- graph-memory: entity embeddings now correctly stored in Qdrant — `EntityResolver` was built without a provider in `extract_and_store()`, causing `store_entity_embedding()` to never be called and `zeph_graph_entities` collection to remain empty (fixes #1829)
 - fix(core): JIT tool reference injection now works after overflow migration to SQLite — `OVERFLOW_NOTICE_PREFIX` and `extract_overflow_ref()` updated to match the `overflow:{uuid}` format; pruned tool output notices now read `[tool output pruned; use read_overflow {uuid} to retrieve]` instead of a stale file-path reference (closes #1818)
 
 ## [0.15.1] - 2026-03-15

--- a/crates/zeph-memory/src/semantic/graph.rs
+++ b/crates/zeph-memory/src/semantic/graph.rs
@@ -278,7 +278,7 @@ pub async fn extract_and_store(
 ) -> Result<ExtractionResult, MemoryError> {
     use crate::graph::{EntityResolver, GraphExtractor, GraphStore};
 
-    let extractor = GraphExtractor::new(provider, config.max_entities, config.max_edges);
+    let extractor = GraphExtractor::new(provider.clone(), config.max_entities, config.max_edges);
     let ctx_refs: Vec<&str> = context_messages.iter().map(String::as_str).collect();
 
     let store = GraphStore::new(pool);
@@ -315,7 +315,9 @@ pub async fn extract_and_store(
     }
 
     let resolver = if let Some(ref emb) = embedding_store {
-        EntityResolver::new(&store).with_embedding_store(emb)
+        EntityResolver::new(&store)
+            .with_embedding_store(emb)
+            .with_provider(&provider)
     } else {
         EntityResolver::new(&store)
     };
@@ -373,6 +375,126 @@ pub async fn extract_and_store(
         },
         entity_ids: new_entity_ids,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use zeph_llm::any::AnyProvider;
+
+    use super::extract_and_store;
+    use crate::embedding_store::EmbeddingStore;
+    use crate::graph::GraphStore;
+    use crate::in_memory_store::InMemoryVectorStore;
+    use crate::sqlite::SqliteStore;
+
+    use super::GraphExtractionConfig;
+
+    async fn setup() -> (GraphStore, Arc<EmbeddingStore>) {
+        let sqlite = SqliteStore::new(":memory:").await.unwrap();
+        let pool = sqlite.pool().clone();
+        let mem_store = Box::new(InMemoryVectorStore::new());
+        let emb = Arc::new(EmbeddingStore::with_store(mem_store, pool.clone()));
+        let gs = GraphStore::new(pool);
+        (gs, emb)
+    }
+
+    /// Regression test for #1829: extract_and_store() must pass the provider to EntityResolver
+    /// so that store_entity_embedding() is called and qdrant_point_id is set in SQLite.
+    #[tokio::test]
+    async fn extract_and_store_sets_qdrant_point_id_when_embedding_store_provided() {
+        let (gs, emb) = setup().await;
+
+        // MockProvider: supports embeddings, returns a valid extraction JSON for chat
+        let extraction_json = r#"{"entities":[{"name":"Rust","type":"language","summary":"systems language"}],"edges":[]}"#;
+        let mut mock =
+            zeph_llm::mock::MockProvider::with_responses(vec![extraction_json.to_owned()]);
+        mock.supports_embeddings = true;
+        mock.embedding = vec![1.0_f32, 0.0, 0.0, 0.0];
+        let provider = AnyProvider::Mock(mock);
+
+        let config = GraphExtractionConfig {
+            max_entities: 10,
+            max_edges: 10,
+            extraction_timeout_secs: 10,
+            ..Default::default()
+        };
+
+        let result = extract_and_store(
+            "Rust is a systems programming language.".to_owned(),
+            vec![],
+            provider,
+            gs.pool().clone(),
+            config,
+            None,
+            Some(emb.clone()),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            result.stats.entities_upserted, 1,
+            "one entity should be upserted"
+        );
+
+        // The entity must have a qdrant_point_id — this proves store_entity_embedding() was called.
+        // Before the fix, EntityResolver was built without a provider, so embed() was never called
+        // and qdrant_point_id remained NULL.
+        let entity = gs
+            .find_entity("rust", crate::graph::EntityType::Language)
+            .await
+            .unwrap()
+            .expect("entity 'rust' must exist in SQLite");
+
+        assert!(
+            entity.qdrant_point_id.is_some(),
+            "qdrant_point_id must be set when embedding_store + provider are both provided (regression for #1829)"
+        );
+    }
+
+    /// When no embedding_store is provided, extract_and_store() must still work correctly
+    /// (no embeddings stored, but entities are still upserted).
+    #[tokio::test]
+    async fn extract_and_store_without_embedding_store_still_upserts_entities() {
+        let (gs, _emb) = setup().await;
+
+        let extraction_json = r#"{"entities":[{"name":"Python","type":"language","summary":"scripting"}],"edges":[]}"#;
+        let mock = zeph_llm::mock::MockProvider::with_responses(vec![extraction_json.to_owned()]);
+        let provider = AnyProvider::Mock(mock);
+
+        let config = GraphExtractionConfig {
+            max_entities: 10,
+            max_edges: 10,
+            extraction_timeout_secs: 10,
+            ..Default::default()
+        };
+
+        let result = extract_and_store(
+            "Python is a scripting language.".to_owned(),
+            vec![],
+            provider,
+            gs.pool().clone(),
+            config,
+            None,
+            None, // no embedding_store
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.stats.entities_upserted, 1);
+
+        let entity = gs
+            .find_entity("python", crate::graph::EntityType::Language)
+            .await
+            .unwrap()
+            .expect("entity 'python' must exist");
+
+        assert!(
+            entity.qdrant_point_id.is_none(),
+            "qdrant_point_id must remain None when no embedding_store is provided"
+        );
+    }
 }
 
 impl SemanticMemory {


### PR DESCRIPTION
## Summary

- `EntityResolver` in `extract_and_store()` was constructed with `.with_embedding_store()` but without `.with_provider()`, so `store_entity_embedding()` never called `embed()` and `qdrant_point_id` remained `NULL` in SQLite — leaving `zeph_graph_entities` collection permanently empty
- Fix: add `.with_provider(&provider)` to the `EntityResolver` builder when `embedding_store` is present; add `provider.clone()` before passing to `GraphExtractor` to retain ownership
- Two regression tests added: one verifying `qdrant_point_id` is set when both provider and embedding_store are supplied, one verifying the no-embedding-store path is unaffected

Fixes #1829.

## Test plan

- [ ] `cargo +nightly fmt --check` — passes
- [ ] `cargo clippy --workspace --features full -- -D warnings` — passes (0 warnings)
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --features full --lib --bins` — 5795 passed, 12 skipped
- [ ] New test `extract_and_store_sets_qdrant_point_id_when_embedding_store_provided` asserts `qdrant_point_id.is_some()` after extraction
- [ ] New test `extract_and_store_without_embedding_store_still_upserts_entities` asserts `qdrant_point_id.is_none()` when no embedding_store passed