### PR TITLE
feat(memory): add --compression-guidelines CLI flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - feat(memory): `conversation_id` column added to `compression_guidelines` table (migration 034); guidelines now prefer conversation-specific over global when a conversation is in scope, with global (NULL) guidelines as fallback (closes #1806)
+- feat(memory): add `--compression-guidelines` CLI flag to override `memory.compression_guidelines.enabled` at startup (#1802)
 - feat(memory,core): session summary on shutdown (#1816) — when no hard compaction fired during a session, `Agent::shutdown()` now generates a lightweight LLM summary and stores it to the vector store for cross-session recall; the LLM call is wrapped in a 5-second timeout so shutdown never hangs; `SemanticMemory::has_session_summary()` is the primary guard (resilient to failed Qdrant writes); `SemanticMemory::store_shutdown_summary()` persists to both SQLite and the vector store with real FK-linked key facts; new config params `memory.shutdown_summary` (default `true`), `memory.shutdown_summary_min_messages` (default `4`, user turns only), `memory.shutdown_summary_max_messages` (default `20`); `--init` wizard prompts for the feature toggle; TUI status indicator shown during summarization
 - test(memory): unit tests for `sanitize_guidelines` special-token (`<|system|>`) and role-prefix (`assistant:`, `user:`) patterns (#1807)
 

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -308,6 +308,7 @@ See [Debug Dump](../advanced/debug-dump.md) for the file layout and how to read 
 | `--vault-key <PATH>` | Path to age identity (private key) file (default: `~/.config/zeph/vault-key.txt`, overrides `ZEPH_VAULT_KEY` env var) |
 | `--vault-path <PATH>` | Path to age-encrypted secrets file (default: `~/.config/zeph/secrets.age`, overrides `ZEPH_VAULT_PATH` env var) |
 | `--graph-memory` | Enable graph-based knowledge memory for this session, overriding `memory.graph.enabled`. See [Graph Memory](../concepts/graph-memory.md) |
+| `--compression-guidelines` | Enable ACON failure-driven compression guidelines for this session, overriding `memory.compression_guidelines.enabled`. Requires `compression-guidelines` feature at compile time; silently ignored otherwise. See [Memory](../concepts/memory.md) |
 | `--lsp-context` | Enable automatic LSP context injection for this session, overriding `agent.lsp.enabled`. Injects diagnostics after file writes and hover info on reads. Requires mcpls MCP server and `lsp-context` feature. See [LSP Code Intelligence](../guides/lsp.md#lsp-context-injection) |
 | `--experiment-run` | Run a single experiment session and exit (requires `experiments` feature). See [Experiments](../concepts/experiments.md) |
 | `--experiment-report` | Print past experiment results summary and exit (requires `experiments` feature). See [Experiments](../concepts/experiments.md) |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -83,6 +83,13 @@ pub(crate) struct Cli {
     #[arg(long)]
     pub(crate) graph_memory: bool,
 
+    /// Enable ACON failure-driven compression guidelines for this session.
+    /// Overrides `memory.compression_guidelines.enabled` from config.
+    /// Requires `compression-guidelines` feature at compile time; silently
+    /// ignored if the feature is not enabled.
+    #[arg(long)]
+    pub(crate) compression_guidelines: bool,
+
     /// Enable Claude server-side context compaction (compact-2026-01-12 beta).
     /// Requires a Claude provider. Overrides `llm.cloud.server_compaction` from config.
     #[arg(long)]
@@ -385,6 +392,18 @@ mod tests {
     fn cli_graph_memory_flag_defaults_to_false() {
         let cli = Cli::try_parse_from(["zeph"]).unwrap();
         assert!(!cli.graph_memory);
+    }
+
+    #[test]
+    fn cli_parses_compression_guidelines_flag() {
+        let cli = Cli::try_parse_from(["zeph", "--compression-guidelines"]).unwrap();
+        assert!(cli.compression_guidelines);
+    }
+
+    #[test]
+    fn cli_compression_guidelines_defaults_to_false() {
+        let cli = Cli::try_parse_from(["zeph"]).unwrap();
+        assert!(!cli.compression_guidelines);
     }
 
     #[cfg(feature = "experiments")]

--- a/src/init.rs
+++ b/src/init.rs
@@ -2065,6 +2065,28 @@ mod tests {
     }
 
     #[test]
+    fn build_config_compression_guidelines_enabled() {
+        let state = WizardState {
+            compression_guidelines_enabled: true,
+            vault_backend: "env".into(),
+            ..WizardState::default()
+        };
+        let config = build_config(&state);
+        assert!(config.memory.compression_guidelines.enabled);
+    }
+
+    #[test]
+    fn build_config_compression_guidelines_disabled() {
+        let state = WizardState {
+            compression_guidelines_enabled: false,
+            vault_backend: "env".into(),
+            ..WizardState::default()
+        };
+        let config = build_config(&state);
+        assert!(!config.memory.compression_guidelines.enabled);
+    }
+
+    #[test]
     fn build_config_mcpls_enabled_produces_mcp_server() {
         let state = WizardState {
             mcpls_enabled: true,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -380,6 +380,12 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         app.config_mut().memory.graph.enabled = true;
     }
 
+    if cli.compression_guidelines {
+        // Config field and builder are unconditional; only the background
+        // task spawn is feature-gated (compression-guidelines feature).
+        app.config_mut().memory.compression_guidelines.enabled = true;
+    }
+
     if cli.server_compaction
         && let Some(cloud) = app.config_mut().llm.cloud.as_mut()
     {


### PR DESCRIPTION
## Summary

- Add `--compression-guidelines` boolean CLI flag to override `config.memory.compression_guidelines.enabled = true` at startup
- Follows the `--graph-memory` pattern: plain clap bool in `src/cli.rs`, config override in `src/runner.rs`
- Feature gate (`compression-guidelines`) remains only on the spawn block — passing the flag without the feature compiled in is harmless (silent no-op)
- Add `build_config` tests for wizard `compression_guidelines_enabled` path in `src/init.rs`, parallel to existing `graph_memory` tests

Closes #1802.

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace --features full -- -D warnings` — clean
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --features full --lib --bins` — 5832 passed