### PR TITLE
feat(tui): add compression guidelines status line and /guidelines command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- feat(tui): compression guidelines status line in memory panel (version + last update) and `/guidelines` slash command to display current guidelines text (closes #1803)
+- feat(memory): add `load_compression_guidelines_meta()` query returning `(version, created_at)` without fetching full text
 - feat(memory): `conversation_id` column added to `compression_guidelines` table (migration 034); guidelines now prefer conversation-specific over global when a conversation is in scope, with global (NULL) guidelines as fallback (closes #1806)
 - feat(memory): add `--compression-guidelines` CLI flag to override `memory.compression_guidelines.enabled` at startup (#1802)
 - feat(memory,core): session summary on shutdown (#1816) — when no hard compaction fired during a session, `Agent::shutdown()` now generates a lightweight LLM summary and stores it to the vector store for cross-session recall; the LLM call is wrapped in a 5-second timeout so shutdown never hangs; `SemanticMemory::has_session_summary()` is the primary guard (resilient to failed Qdrant writes); `SemanticMemory::store_shutdown_summary()` persists to both SQLite and the vector store with real FK-linked key facts; new config params `memory.shutdown_summary` (default `true`), `memory.shutdown_summary_min_messages` (default `4`, user turns only), `memory.shutdown_summary_max_messages` (default `20`); `--init` wizard prompts for the feature toggle; TUI status indicator shown during summarization

--- a/crates/zeph-core/src/agent/guidelines_commands.rs
+++ b/crates/zeph-core/src/agent/guidelines_commands.rs
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Handler for the `/guidelines` slash command.
+
+use crate::channel::Channel;
+
+use super::Agent;
+use super::error::AgentError;
+
+/// Maximum characters of guidelines text shown in TUI chat to avoid flooding.
+const MAX_DISPLAY_CHARS: usize = 4096;
+
+impl<C: Channel> Agent<C> {
+    /// Display the current compression guidelines or a "no guidelines" notice.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if sending the message to the channel fails.
+    pub(super) async fn handle_guidelines_command(&mut self) -> Result<(), AgentError> {
+        let Some(memory) = &self.memory_state.memory else {
+            return self
+                .channel
+                .send("No memory backend initialised.")
+                .await
+                .map_err(AgentError::from);
+        };
+
+        let cid = self.memory_state.conversation_id;
+        let sqlite = memory.sqlite();
+
+        let (version, text) = sqlite.load_compression_guidelines(cid).await.map_err(
+            |e: zeph_memory::MemoryError| {
+                tracing::warn!("failed to load compression guidelines: {e:#}");
+                AgentError::from(e)
+            },
+        )?;
+
+        if version == 0 || text.is_empty() {
+            return self
+                .channel
+                .send("No compression guidelines generated yet.")
+                .await
+                .map_err(AgentError::from);
+        }
+
+        let (_, created_at) = sqlite
+            .load_compression_guidelines_meta(cid)
+            .await
+            .unwrap_or((0, String::new()));
+
+        let (body, truncated) = if text.len() > MAX_DISPLAY_CHARS {
+            let end = text.floor_char_boundary(MAX_DISPLAY_CHARS);
+            (&text[..end], true)
+        } else {
+            (text.as_str(), false)
+        };
+
+        let mut output =
+            format!("Compression Guidelines (v{version}, updated {created_at}):\n\n{body}");
+        if truncated {
+            output.push_str("\n\n[truncated]");
+        }
+
+        self.channel.send(&output).await.map_err(AgentError::from)
+    }
+}

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -11,6 +11,8 @@ pub mod error;
 mod experiment_cmd;
 pub(super) mod feedback_detector;
 mod graph_commands;
+#[cfg(feature = "compression-guidelines")]
+mod guidelines_commands;
 mod index;
 mod learning;
 pub(crate) mod learning_engine;
@@ -2625,6 +2627,11 @@ impl<C: Channel> Agent<C> {
 
         if trimmed == "/graph" || trimmed.starts_with("/graph ") {
             handled!(self.handle_graph_command(trimmed).await);
+        }
+
+        #[cfg(feature = "compression-guidelines")]
+        if trimmed == "/guidelines" {
+            handled!(self.handle_guidelines_command().await);
         }
 
         #[cfg(feature = "scheduler")]

--- a/crates/zeph-core/src/agent/persistence.rs
+++ b/crates/zeph-core/src/agent/persistence.rs
@@ -469,6 +469,8 @@ impl<C: Channel> Agent<C> {
         self.sync_community_detection_failures();
         self.sync_graph_extraction_metrics();
         self.sync_graph_counts().await;
+        #[cfg(feature = "compression-guidelines")]
+        self.sync_guidelines_status().await;
     }
 
     pub(crate) async fn check_summarization(&mut self) {

--- a/crates/zeph-core/src/agent/slash_commands.rs
+++ b/crates/zeph-core/src/agent/slash_commands.rs
@@ -132,6 +132,14 @@ pub const COMMANDS: &[SlashCommandInfo] = &[
         category: SlashCategory::Memory,
         feature_gate: None,
     },
+    #[cfg(feature = "compression-guidelines")]
+    SlashCommandInfo {
+        name: "/guidelines",
+        args: "",
+        description: "Show current compression guidelines",
+        category: SlashCategory::Memory,
+        feature_gate: Some("compression-guidelines"),
+    },
     // --- Tools ---
     SlashCommandInfo {
         name: "/skill",

--- a/crates/zeph-core/src/agent/utils.rs
+++ b/crates/zeph-core/src/agent/utils.rs
@@ -63,6 +63,31 @@ impl<C: Channel> Agent<C> {
         });
     }
 
+    /// Fetch compression-guidelines metadata from `SQLite` and write to metrics.
+    ///
+    /// Only fetches version and `created_at`; does not load the full guidelines text.
+    /// Feature-gated: compiled only when `compression-guidelines` is enabled.
+    #[cfg(feature = "compression-guidelines")]
+    pub async fn sync_guidelines_status(&self) {
+        let Some(memory) = self.memory_state.memory.as_ref() else {
+            return;
+        };
+        let cid = self.memory_state.conversation_id;
+        match memory.sqlite().load_compression_guidelines_meta(cid).await {
+            Ok((version, created_at)) => {
+                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                let version_u32 = u32::try_from(version).unwrap_or(0);
+                self.update_metrics(|m| {
+                    m.guidelines_version = version_u32;
+                    m.guidelines_updated_at = created_at;
+                });
+            }
+            Err(e) => {
+                tracing::warn!("failed to sync guidelines status: {e:#}");
+            }
+        }
+    }
+
     pub(super) fn update_metrics(&self, f: impl FnOnce(&mut MetricsSnapshot)) {
         if let Some(ref tx) = self.metrics.metrics_tx {
             let elapsed = self.lifecycle.start_time.elapsed().as_secs();

--- a/crates/zeph-core/src/config/types/tests/snapshots/zeph_core__config__types__tests__config_default_snapshot_no_lsp_context.snap
+++ b/crates/zeph-core/src/config/types/tests/snapshots/zeph_core__config__types__tests__config_default_snapshot_no_lsp_context.snap
@@ -78,6 +78,9 @@ autosave_assistant = false
 autosave_min_length = 20
 tool_call_cutoff = 6
 sqlite_pool_size = 5
+shutdown_summary = true
+shutdown_summary_min_messages = 4
+shutdown_summary_max_messages = 20
 
 [memory.compression_guidelines]
 enabled = false

--- a/crates/zeph-core/src/metrics.rs
+++ b/crates/zeph-core/src/metrics.rs
@@ -228,6 +228,10 @@ pub struct MetricsSnapshot {
     /// `true` when `config.llm.cloud.enable_extended_context = true`.
     /// Never set for other providers to avoid false positives.
     pub extended_context: bool,
+    /// Latest compression-guidelines version (0 = no guidelines yet).
+    pub guidelines_version: u32,
+    /// ISO 8601 timestamp of the latest guidelines update (empty if none).
+    pub guidelines_updated_at: String,
 }
 
 /// Strip ASCII control characters and ANSI escape sequences from a string for safe TUI display.

--- a/crates/zeph-memory/src/sqlite/compression_guidelines.rs
+++ b/crates/zeph-memory/src/sqlite/compression_guidelines.rs
@@ -91,6 +91,34 @@ impl SqliteStore {
         Ok(row.unwrap_or((0, String::new())))
     }
 
+    /// Load only the version and creation timestamp of the latest active compression guidelines.
+    ///
+    /// Same scoping rules as [`load_compression_guidelines`]: conversation-specific rows are
+    /// preferred over global ones.  Returns `(0, "")` if no guidelines exist yet.
+    ///
+    /// Use this in hot paths where the full text is not needed (e.g. metrics sync).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database query fails.
+    pub async fn load_compression_guidelines_meta(
+        &self,
+        conversation_id: Option<ConversationId>,
+    ) -> Result<(i64, String), MemoryError> {
+        let row = sqlx::query_as::<_, (i64, String)>(
+            "SELECT version, created_at FROM compression_guidelines \
+             WHERE conversation_id = ? OR conversation_id IS NULL \
+             ORDER BY CASE WHEN conversation_id IS NOT NULL THEN 0 ELSE 1 END, \
+                      version DESC \
+             LIMIT 1",
+        )
+        .bind(conversation_id.map(|c| c.0))
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.unwrap_or((0, String::new())))
+    }
+
     /// Save a new version of the compression guidelines.
     ///
     /// When `conversation_id` is `Some`, the guidelines are scoped to that conversation.
@@ -276,6 +304,26 @@ mod tests {
         SqliteStore::with_pool_size(":memory:", 1)
             .await
             .expect("in-memory SqliteStore")
+    }
+
+    #[tokio::test]
+    async fn load_guidelines_meta_returns_defaults_when_empty() {
+        let store = make_store().await;
+        let (version, created_at) = store.load_compression_guidelines_meta(None).await.unwrap();
+        assert_eq!(version, 0);
+        assert!(created_at.is_empty());
+    }
+
+    #[tokio::test]
+    async fn load_guidelines_meta_returns_version_and_created_at() {
+        let store = make_store().await;
+        store
+            .save_compression_guidelines("keep file paths", 4, None)
+            .await
+            .unwrap();
+        let (version, created_at) = store.load_compression_guidelines_meta(None).await.unwrap();
+        assert_eq!(version, 1);
+        assert!(!created_at.is_empty(), "created_at should be populated");
     }
 
     #[tokio::test]

--- a/crates/zeph-tui/src/app.rs
+++ b/crates/zeph-tui/src/app.rs
@@ -928,6 +928,9 @@ impl App {
             TuiCommand::ServerCompactionStatus => {
                 let _ = self.user_input_tx.try_send("/server-compaction".to_owned());
             }
+            TuiCommand::ViewGuidelines => {
+                let _ = self.user_input_tx.try_send("/guidelines".to_owned());
+            }
             _ => {}
         }
     }

--- a/crates/zeph-tui/src/command.rs
+++ b/crates/zeph-tui/src/command.rs
@@ -72,6 +72,8 @@ pub enum TuiCommand {
     MigrateConfig,
     // Server-side compaction
     ServerCompactionStatus,
+    // Compression guidelines
+    ViewGuidelines,
 }
 
 /// Metadata for command palette display and fuzzy matching.
@@ -447,6 +449,13 @@ fn build_graph_experiment_commands() -> Vec<CommandEntry> {
             shortcut: None,
             command: TuiCommand::ExperimentBest,
         },
+        CommandEntry {
+            id: "guidelines:view",
+            label: "Show compression guidelines (/guidelines)",
+            category: "memory",
+            shortcut: None,
+            command: TuiCommand::ViewGuidelines,
+        },
     ]
 }
 
@@ -538,12 +547,12 @@ mod tests {
     #[test]
     fn extra_registry_has_correct_command_count() {
         // 24 base (14 + 5 plan + 5 graph) + 5 experiment + 1 log:status + 1 config:migrate
-        // + 1 compaction:status = 32
+        // + 1 compaction:status + 1 guidelines:view = 33
         // + 1 lsp:status command (when lsp-context feature enabled)
         #[cfg(feature = "lsp-context")]
-        assert_eq!(extra_command_registry().len(), 33);
+        assert_eq!(extra_command_registry().len(), 34);
         #[cfg(not(feature = "lsp-context"))]
-        assert_eq!(extra_command_registry().len(), 32);
+        assert_eq!(extra_command_registry().len(), 33);
     }
 
     #[test]

--- a/crates/zeph-tui/src/widgets/memory.rs
+++ b/crates/zeph-tui/src/widgets/memory.rs
@@ -49,6 +49,12 @@ pub fn render(metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect) {
             metrics.graph_extraction_count, metrics.graph_extraction_failures,
         )));
     }
+    if metrics.guidelines_version > 0 {
+        mem_lines.push(Line::from(format!(
+            "  Guidelines: v{} ({})",
+            metrics.guidelines_version, metrics.guidelines_updated_at,
+        )));
+    }
     let memory = Paragraph::new(mem_lines).block(
         Block::default()
             .borders(Borders::ALL)
@@ -76,6 +82,22 @@ mod tests {
         };
 
         let output = render_to_string(30, 8, |frame, area| {
+            super::render(&metrics, frame, area);
+        });
+        assert_snapshot!(output);
+    }
+
+    #[test]
+    fn memory_with_guidelines() {
+        let metrics = MetricsSnapshot {
+            sqlite_message_count: 10,
+            embeddings_generated: 0,
+            guidelines_version: 3,
+            guidelines_updated_at: "2026-03-15T17:00:00.000Z".into(),
+            ..MetricsSnapshot::default()
+        };
+
+        let output = render_to_string(50, 10, |frame, area| {
             super::render(&metrics, frame, area);
         });
         assert_snapshot!(output);

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__memory__tests__memory_with_guidelines.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__memory__tests__memory_with_guidelines.snap
@@ -1,0 +1,14 @@
+---
+source: crates/zeph-tui/src/widgets/memory.rs
+expression: output
+---
+┌ Memory ────────────────────────────────────────┐
+│  SQLite: 10 msgs                               │
+│  Conv ID: ---                                  │
+│  Embeddings: 0                                 │
+│  Graph: 0 entities, 0 edges, 0 communities     │
+│  Graph extractions: 0 ok, 0 failed             │
+│  Guidelines: v3 (2026-03-15T17:00:00.000Z)     │
+│                                                │
+│                                                │
+└────────────────────────────────────────────────┘


### PR DESCRIPTION
Closes #1803

## Summary

Implements two TUI features deferred from MVP (ACON compression guidelines section 8.2):

- **Guidelines status line** in the memory panel: shows `Guidelines: vN (timestamp)` when compression guidelines exist, hidden when version is 0
- **`/guidelines` slash command**: displays current guidelines text with version and last-updated header, truncated at 4096 chars to avoid flooding

## Changes

- `zeph-memory`: `load_compression_guidelines_meta()` — lightweight query returning `(version, created_at)` without fetching full text
- `zeph-core`: `sync_guidelines_status()` called from persistence sync (same pattern as `sync_graph_counts`)
- `zeph-core`: `guidelines_commands.rs` — `/guidelines` handler; `dispatch_slash_command()` dispatch
- `zeph-core`: `/guidelines` entry in slash commands registry (Memory category)
- `zeph-tui`: `TuiCommand::ViewGuidelines` in `build_graph_experiment_commands()`; forwarding via `user_input_tx`
- `zeph-tui`: conditional guidelines status line in memory panel widget
- All new code feature-gated on `compression-guidelines` (core/memory) and `tui`

## Test plan

- [ ] 5817 tests pass with `--features full`
- [ ] New `memory_with_guidelines` snapshot test pins the rendered status line
- [ ] 2 new unit tests for `load_compression_guidelines_meta()`
- [ ] Command count assertion updated (32→33 / 33→34)
- [ ] Fix stale config snapshot missing `shutdown_summary` fields from #1816