### PR TITLE
fix(core): wire Focus Agent and SideQuest config from TOML to agent builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Wire `[agent.focus]` and `[memory.sidequest]` config to `AgentBuilder` in all bootstrap paths (`runner.rs`, `daemon.rs`, `acp.rs`); previously both configs were parsed but never applied, causing focus and sidequest to always use defaults (`enabled = false`) (closes #1907)
+
 ### Security
 
 - Suppress CodeQL `rust/cleartext-logging` false positives on intentional debug/trace log sites (closes #1905)

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1049,6 +1049,42 @@ mod tests {
         );
     }
 
+    #[test]
+    fn with_focus_config_propagates_to_focus_state() {
+        let cfg = crate::config::FocusConfig {
+            enabled: true,
+            compression_interval: 7,
+            ..Default::default()
+        };
+        let agent = make_agent().with_focus_config(cfg.clone());
+        assert!(
+            agent.focus.config.enabled,
+            "with_focus_config must set enabled"
+        );
+        assert_eq!(
+            agent.focus.config.compression_interval, 7,
+            "with_focus_config must propagate compression_interval"
+        );
+    }
+
+    #[test]
+    fn with_sidequest_config_propagates_to_sidequest_state() {
+        let cfg = crate::config::SidequestConfig {
+            enabled: true,
+            interval_turns: 3,
+            ..Default::default()
+        };
+        let agent = make_agent().with_sidequest_config(cfg.clone());
+        assert!(
+            agent.sidequest.config.enabled,
+            "with_sidequest_config must set enabled"
+        );
+        assert_eq!(
+            agent.sidequest.config.interval_turns, 3,
+            "with_sidequest_config must propagate interval_turns"
+        );
+    }
+
     /// Verify that apply_session_config does NOT create an anomaly detector when disabled.
     #[test]
     fn apply_session_config_skips_anomaly_detector_when_disabled() {

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -131,6 +131,8 @@ struct SharedAgentDeps {
 
     // Config snapshot — single source of truth for all config-derived agent settings
     session_config: zeph_core::AgentSessionConfig,
+    focus_config: zeph_core::config::FocusConfig,
+    sidequest_config: zeph_core::config::SidequestConfig,
 
     // ACP-specific fields (transport-level; not agent-level)
     acp_agent_name: String,
@@ -437,6 +439,8 @@ async fn build_acp_deps(
         #[cfg(feature = "guardrail")]
         guardrail_provider: app.build_guardrail_provider(),
         session_config,
+        focus_config: config.agent.focus.clone(),
+        sidequest_config: config.memory.sidequest.clone(),
         acp_agent_name: config.acp.agent_name.clone(),
         acp_agent_version: config.acp.agent_version.clone(),
         acp_max_sessions: config.acp.max_sessions,
@@ -654,7 +658,9 @@ async fn spawn_acp_agent(
         Some(Arc::clone(&mcp_manager)),
         &mcp_config,
     )
-    .with_mcp_shared_tools(mcp_shared_tools);
+    .with_mcp_shared_tools(mcp_shared_tools)
+    .with_focus_config(d.focus_config.clone())
+    .with_sidequest_config(d.sidequest_config.clone());
 
     // Wire scheduler per session: apply update/custom receivers and add executor.
     #[cfg(feature = "scheduler")]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -323,7 +323,9 @@ pub(crate) async fn run_daemon(
     .with_config_reload(config_path_owned, config_reload_rx)
     .with_mcp(mcp_tools, mcp_registry, Some(mcp_manager), &config.mcp)
     .with_mcp_shared_tools(mcp_shared_tools)
-    .with_hybrid_search(config.skills.hybrid_search);
+    .with_hybrid_search(config.skills.hybrid_search)
+    .with_focus_config(config.agent.focus.clone())
+    .with_sidequest_config(config.memory.sidequest.clone());
 
     let summary_provider = app.build_summary_provider();
     let agent = if let Some(sp) = summary_provider {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -808,7 +808,9 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     )
     .with_tool_call_cutoff(config.memory.tool_call_cutoff)
     .with_hybrid_search(config.skills.hybrid_search)
-    .with_compression_guidelines_config(config.memory.compression_guidelines.clone());
+    .with_compression_guidelines_config(config.memory.compression_guidelines.clone())
+    .with_focus_config(config.agent.focus.clone())
+    .with_sidequest_config(config.memory.sidequest.clone());
 
     #[cfg(feature = "policy-enforcer")]
     let agent = if config.tools.policy.enabled {


### PR DESCRIPTION
Fixes #1907.

## Root Cause

`AgentBuilder::with_focus_config()` and `AgentBuilder::with_sidequest_config()` were defined but never called from any bootstrap path. All bootstrap entry points constructed `AgentBuilder` without passing `config.agent.focus` or `config.memory.sidequest`, so both subsystems always ran with defaults (`enabled = false`).

## Changes

- `src/runner.rs`: chain `.with_focus_config()` and `.with_sidequest_config()` when building the agent
- `src/daemon.rs`: same wiring for daemon path
- `src/acp.rs`: add `focus_config` and `sidequest_config` to `SharedAgentDeps`, populated from config at init, applied in `spawn_acp_agent`
- `crates/zeph-core/src/agent/builder.rs`: add two unit tests verifying config propagation to `FocusState` and `SidequestState`
- `CHANGELOG.md`: fix entry under `[Unreleased]`

## Test Plan

- `cargo +nightly fmt --check` — pass
- `cargo clippy --workspace --features full -- -D warnings` — pass (0 warnings)
- `cargo nextest run --workspace --features full --lib --bins` — 6045 passed, 0 failed
- New unit tests: `with_focus_config_propagates_to_focus_state`, `with_sidequest_config_propagates_to_sidequest_state`