### PR TITLE
fix(tui): clear graph spinner after spawn_graph_extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fix(core): corrections now stored even when `LearningConfig::enabled = false` (closes #1910)
 - fix(memory): sync session summaries to Qdrant on compact_context happy path (#1911) — `store_session_summary()` was only called in fallback branches; now also called after a successful `replace_conversation()` in both `compact_context` variants
 - Wire `[agent.focus]` and `[memory.sidequest]` config to `AgentBuilder` in all bootstrap paths (`runner.rs`, `daemon.rs`, `acp.rs`); previously both configs were parsed but never applied, causing focus and sidequest to always use defaults (`enabled = false`) (closes #1907)
+- fix(tui): clear "saving to graph..." spinner immediately after `spawn_graph_extraction` — spinner was never cleared since the spawn is fire-and-forget; status is now reset to `""` right after scheduling the background task (closes #1924)
 - fix(graph-memory): prevent structural noise from polluting `zeph_graph_entities` graph (closes #1912)
   - Skip graph extraction entirely for `Role::User` messages containing `ToolResult` parts — tool outputs (TOML, JSON, command output) are structural data, not conversational content (FIX-1)
   - Exclude `ToolResult` user messages from the context window passed to the extraction LLM call (FIX-2)

--- a/crates/zeph-core/src/agent/persistence.rs
+++ b/crates/zeph-core/src/agent/persistence.rs
@@ -470,7 +470,7 @@ impl<C: Channel> Agent<C> {
             .map(|m| m.content.clone())
             .collect();
 
-        let _ = self.channel.send_status("extracting graph...").await;
+        let _ = self.channel.send_status("saving to graph...").await;
 
         if let Some(memory) = &self.memory_state.memory {
             // Build optional validation callback from MemoryWriteValidator (S3 fix).
@@ -492,6 +492,7 @@ impl<C: Channel> Agent<C> {
                 validator,
             );
         }
+        let _ = self.channel.send_status("").await;
         self.sync_community_detection_failures();
         self.sync_graph_extraction_metrics();
         self.sync_graph_counts().await;


### PR DESCRIPTION
## Problem

The TUI status bar shows `saving to graph...` spinner indefinitely after each turn where graph extraction is triggered. The spinner was never cleared because `spawn_graph_extraction()` is fire-and-forget and returns immediately.

## Fix

Add `let _ = self.channel.send_status("").await;` immediately after `spawn_graph_extraction()` in `maybe_spawn_graph_extraction()`. Also rename the status message from `"extracting graph..."` to `"saving to graph..."` to better reflect the async/background nature of the operation.

## Changes

- `crates/zeph-core/src/agent/persistence.rs`: +2 lines, 2-line diff

## Test plan

- [x] `cargo +nightly fmt --check` — PASS
- [x] `cargo clippy --workspace --features full -- -D warnings` — PASS
- [x] `cargo nextest run --workspace --features full --lib --bins` — PASS (6053 passed)

Closes #1924