### PR TITLE
feat(mcp): OAuth 2.1 and static Bearer header auth for remote MCP servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - test(memory): add integration tests for `store_session_summary` → Qdrant upsert roundtrip (closes #1916) — four `#[ignore]` tests in `crates/zeph-memory/tests/qdrant_integration.rs` using testcontainers: `store_session_summary_roundtrip`, `store_session_summary_multiple_conversations`, `store_shutdown_summary_full_roundtrip`, `search_session_summaries_returns_empty_when_no_data`; each test guards against silent Qdrant disconnection and verifies both the Qdrant vector path and (where applicable) the SQLite content path
+- feat(mcp): OAuth 2.1 PKCE support for remote MCP servers (closes #1930)
+  - New `McpTransport::OAuth` variant: `url`, `scopes`, `callback_port`, `client_name`
+  - New `McpTransport::Http` variant gains optional `headers` map with vault-reference support (`${VAULT_KEY}` syntax)
+  - `McpManager::with_oauth_credential_store()` builder for registering per-server credential stores
+  - `VaultCredentialStore` in `zeph-core` persists OAuth tokens to the age vault under `ZEPH_MCP_OAUTH_<SERVER_ID>` keys
+  - Two-phase `connect_all()`: stdio/HTTP servers connect concurrently (Phase 1), OAuth servers sequentially with callback listener (Phase 2)
+  - Callback server: raw `tokio::net::TcpListener` pre-bound to capture the actual port before client registration
+  - SSRF validation on all OAuth metadata endpoints (authorization, token, registration, jwks_uri)
+  - Config: `[mcp.servers.*.oauth]` section with `enabled`, `token_storage` (vault/memory), `scopes`, `callback_port`, `client_name`; `headers` map for static bearer tokens
+  - Config validation: `headers` and `oauth` are mutually exclusive; vault key collision detection for servers with identical normalized IDs
 - feat(index): show indexing progress during background code indexing (#1923)
   - Added `IndexProgress` struct to `zeph-index` with `files_done`, `files_total`, `chunks_created` fields
   - `index_project()` now accepts `progress_tx: Option<&watch::Sender<IndexProgress>>` and sends progress after each file

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4198,6 +4198,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64 0.21.7",
+ "chrono",
+ "getrandom 0.2.17",
+ "http",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "objc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5634,6 +5653,7 @@ dependencies = [
  "chrono",
  "futures",
  "http",
+ "oauth2",
  "pastey",
  "pin-project-lite",
  "process-wrap",
@@ -5648,6 +5668,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -9444,6 +9465,7 @@ name = "zeph-core"
 version = "0.15.2"
 dependencies = [
  "age",
+ "async-trait",
  "base64 0.22.1",
  "blake3",
  "criterion",
@@ -9570,11 +9592,14 @@ dependencies = [
 name = "zeph-mcp"
 version = "0.15.2"
 dependencies = [
+ "async-trait",
  "blake3",
  "dashmap",
  "glob",
+ "http",
  "qdrant-client",
  "regex",
+ "reqwest 0.13.2",
  "rmcp",
  "schemars 1.2.1",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ futures = "0.3"
 futures-core = "0.3"
 glob = "0.3.3"
 hf-hub = { version = "0.5", default-features = false, features = ["tokio", "rustls-tls", "ureq"] }
+http = "1.4"
 http-body-util = "0.1"
 ignore = "0.4"
 indoc = "2"

--- a/config/default.toml
+++ b/config/default.toml
@@ -323,11 +323,32 @@ max_dynamic_servers = 10
 # env = {}                      # environment variables for the child process
 # timeout = 30
 
-# HTTP transport (remote MCP server, e.g. Docker container):
+# HTTP transport with static auth header (Mode A — static Bearer token):
+# Store the token in the vault: `zeph vault set TODOIST_API_TOKEN <value>`
+# [[mcp.servers]]
+# id = "todoist"
+# url = "https://api.todoist.com/mcp"
+# timeout = 30
+# [mcp.servers.headers]
+# Authorization = "Bearer ${TODOIST_API_TOKEN}"   # resolved from vault at startup
+
+# HTTP transport (no auth, e.g. Docker container):
 # [[mcp.servers]]
 # id = "remote-tools"
 # url = "http://localhost:3001/mcp"
 # timeout = 30
+
+# OAuth 2.1 transport (Mode B — interactive authorization flow):
+# [[mcp.servers]]
+# id = "my-oauth-server"
+# url = "https://mcp.example.com"
+# timeout = 60
+# [mcp.servers.oauth]
+# enabled = true
+# token_storage = "vault"    # "vault" (persist across sessions) or "memory" (re-auth on restart)
+# scopes = []                # request specific OAuth scopes, or leave empty for defaults
+# callback_port = 18766      # localhost port for the OAuth redirect; 0 = auto-assign
+# client_name = "Zeph"       # client name shown in authorization consent screen
 
 # LSP code intelligence via mcpls (https://github.com/bug-ops/mcpls)
 # Install: cargo install mcpls

--- a/crates/zeph-acp/src/mcp_bridge.rs
+++ b/crates/zeph-acp/src/mcp_bridge.rs
@@ -41,6 +41,7 @@ pub fn acp_mcp_servers_to_entries(servers: &[acp::McpServer]) -> Vec<ServerEntry
                 id: http.name.clone(),
                 transport: McpTransport::Http {
                     url: http.url.clone(),
+                    headers: std::collections::HashMap::new(),
                 },
                 timeout: Duration::from_secs(DEFAULT_MCP_TIMEOUT_SECS),
                 trusted: false,
@@ -52,6 +53,7 @@ pub fn acp_mcp_servers_to_entries(servers: &[acp::McpServer]) -> Vec<ServerEntry
                     id: sse.name.clone(),
                     transport: McpTransport::Http {
                         url: sse.url.clone(),
+                        headers: std::collections::HashMap::new(),
                     },
                     timeout: Duration::from_secs(DEFAULT_MCP_TIMEOUT_SECS),
                     trusted: false,
@@ -100,7 +102,7 @@ mod tests {
             "http://example.com:8080/mcp",
         ))];
         let entries = acp_mcp_servers_to_entries(&servers);
-        if let McpTransport::Http { url } = &entries[0].transport {
+        if let McpTransport::Http { url, .. } = &entries[0].transport {
             assert_eq!(url, "http://example.com:8080/mcp");
         } else {
             panic!("expected Http transport");
@@ -146,7 +148,7 @@ mod tests {
             "http://example.com/sse",
         ))];
         let entries = acp_mcp_servers_to_entries(&servers);
-        if let McpTransport::Http { url } = &entries[0].transport {
+        if let McpTransport::Http { url, .. } = &entries[0].transport {
             assert_eq!(url, "http://example.com/sse");
         } else {
             panic!("expected Http transport");

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -27,6 +27,7 @@ context-compression = []
 
 [dependencies]
 age.workspace = true
+async-trait.workspace = true
 blake3.workspace = true
 reqwest = { workspace = true, features = ["rustls"] }
 futures.workspace = true
@@ -51,6 +52,7 @@ tracing.workspace = true
 uuid = { workspace = true, features = ["v4", "serde"] }
 tempfile.workspace = true
 tree-sitter.workspace = true
+rmcp = { workspace = true, features = ["auth"] }
 zeph-index.workspace = true
 zeph-llm.workspace = true
 zeph-mcp.workspace = true

--- a/crates/zeph-core/src/agent/mcp.rs
+++ b/crates/zeph-core/src/agent/mcp.rs
@@ -68,6 +68,7 @@ impl<C: Channel> Agent<C> {
         let transport = if is_url {
             zeph_mcp::McpTransport::Http {
                 url: target.to_owned(),
+                headers: std::collections::HashMap::new(),
             }
         } else {
             zeph_mcp::McpTransport::Stdio {

--- a/crates/zeph-core/src/bootstrap/mcp.rs
+++ b/crates/zeph-core/src/bootstrap/mcp.rs
@@ -1,26 +1,36 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
 use zeph_llm::any::AnyProvider;
 use zeph_memory::QdrantOps;
 
-use crate::config::Config;
+use crate::bootstrap::VaultCredentialStore;
+use crate::config::{Config, OAuthTokenStorage};
+use crate::vault::AgeVaultProvider;
 
 pub fn create_mcp_manager(config: &Config, suppress_stderr: bool) -> zeph_mcp::McpManager {
+    create_mcp_manager_with_vault(config, suppress_stderr, None)
+}
+
+/// Create an `McpManager` with an optional shared vault for OAuth credential stores.
+///
+/// When `vault` is `Some`, OAuth servers with `token_storage = "vault"` will use
+/// `VaultCredentialStore` backed by the provided age vault.
+pub fn create_mcp_manager_with_vault(
+    config: &Config,
+    suppress_stderr: bool,
+    vault: Option<&Arc<RwLock<AgeVaultProvider>>>,
+) -> zeph_mcp::McpManager {
     let entries: Vec<zeph_mcp::ServerEntry> = config
         .mcp
         .servers
         .iter()
         .map(|s| {
-            let transport = if let Some(ref url) = s.url {
-                zeph_mcp::McpTransport::Http { url: url.clone() }
-            } else {
-                zeph_mcp::McpTransport::Stdio {
-                    command: s.command.clone().unwrap_or_default(),
-                    args: s.args.clone(),
-                    env: s.env.clone(),
-                }
-            };
+            let transport = build_transport(s, vault);
             zeph_mcp::ServerEntry {
                 id: s.id.clone(),
                 transport,
@@ -29,6 +39,7 @@ pub fn create_mcp_manager(config: &Config, suppress_stderr: bool) -> zeph_mcp::M
             }
         })
         .collect();
+
     let policy_entries: Vec<(String, zeph_mcp::McpPolicy)> = config
         .mcp
         .servers
@@ -36,8 +47,125 @@ pub fn create_mcp_manager(config: &Config, suppress_stderr: bool) -> zeph_mcp::M
         .map(|s| (s.id.clone(), s.policy.clone()))
         .collect();
     let enforcer = zeph_mcp::PolicyEnforcer::new(policy_entries);
-    zeph_mcp::McpManager::new(entries, config.mcp.allowed_commands.clone(), enforcer)
-        .with_suppress_stderr(suppress_stderr)
+    let mut manager =
+        zeph_mcp::McpManager::new(entries, config.mcp.allowed_commands.clone(), enforcer)
+            .with_suppress_stderr(suppress_stderr);
+
+    // Register OAuth credential stores
+    for s in &config.mcp.servers {
+        let Some(ref oauth) = s.oauth else { continue };
+        if !oauth.enabled {
+            continue;
+        }
+        let store: Arc<dyn rmcp::transport::auth::CredentialStore> = match oauth.token_storage {
+            OAuthTokenStorage::Vault => {
+                if let Some(vault_arc) = vault {
+                    Arc::new(VaultCredentialStore::new(&s.id, Arc::clone(vault_arc)))
+                } else {
+                    tracing::warn!(
+                        server_id = s.id,
+                        "OAuth token_storage=vault but no vault provided — falling back to memory"
+                    );
+                    Arc::new(rmcp::transport::auth::InMemoryCredentialStore::new())
+                }
+            }
+            OAuthTokenStorage::Memory => {
+                Arc::new(rmcp::transport::auth::InMemoryCredentialStore::new())
+            }
+        };
+        manager = manager.with_oauth_credential_store(s.id.clone(), store);
+    }
+
+    manager
+}
+
+fn build_transport(
+    s: &crate::config::McpServerConfig,
+    vault: Option<&Arc<RwLock<AgeVaultProvider>>>,
+) -> zeph_mcp::McpTransport {
+    if let Some(ref oauth) = s.oauth
+        && oauth.enabled
+    {
+        // OAuth transport: URL required
+        let url = s.url.clone().unwrap_or_default();
+        return zeph_mcp::McpTransport::OAuth {
+            url,
+            scopes: oauth.scopes.clone(),
+            callback_port: oauth.callback_port,
+            client_name: oauth.client_name.clone(),
+        };
+    }
+
+    if let Some(ref url) = s.url {
+        // HTTP transport: resolve vault references in headers
+        let resolved_headers: HashMap<String, String> = s
+            .headers
+            .iter()
+            .map(|(k, v)| {
+                let resolved = resolve_vault_ref(v, vault);
+                (k.clone(), resolved)
+            })
+            .collect();
+        return zeph_mcp::McpTransport::Http {
+            url: url.clone(),
+            headers: resolved_headers,
+        };
+    }
+
+    // Stdio transport
+    zeph_mcp::McpTransport::Stdio {
+        command: s.command.clone().unwrap_or_default(),
+        args: s.args.clone(),
+        env: s.env.clone(),
+    }
+}
+
+/// Resolve vault references of the form `${VAULT_KEY}` in a string value.
+///
+/// Handles both exact references (`"${KEY}"`) and embedded references
+/// (`"Bearer ${KEY}"`, `"Token ${A} and ${B}"`). Each `${KEY}` placeholder is
+/// replaced with the corresponding vault value.
+///
+/// This runs at startup time and is acceptable as blocking I/O.
+fn resolve_vault_ref(value: &str, vault: Option<&Arc<RwLock<AgeVaultProvider>>>) -> String {
+    if !value.contains("${") {
+        return value.to_owned();
+    }
+
+    let Some(vault_arc) = vault else {
+        tracing::warn!(
+            "vault reference(s) in '{}' cannot be resolved: no vault configured",
+            value
+        );
+        return value.to_owned();
+    };
+
+    let guard = vault_arc.blocking_read();
+    let mut result = value.to_owned();
+    let mut search_from = 0;
+
+    while let Some(start) = result[search_from..].find("${") {
+        let abs_start = search_from + start;
+        let after_brace = abs_start + 2; // skip "${"
+        if let Some(end_offset) = result[after_brace..].find('}') {
+            let key = result[after_brace..after_brace + end_offset].to_owned();
+            let placeholder = format!("${{{key}}}");
+            if let Some(resolved) = guard.get(&key) {
+                result = result.replacen(&placeholder, resolved, 1);
+                // Don't advance past the replacement — it may contain further references
+                // (unlikely in practice, but safe to handle).
+            } else {
+                tracing::warn!("vault reference '${{{key}}}' not found in vault");
+                // Skip past this placeholder to avoid an infinite loop.
+                search_from = abs_start + placeholder.len();
+            }
+        } else {
+            // Malformed "${..." with no closing brace — stop processing.
+            break;
+        }
+    }
+
+    result
 }
 
 pub async fn create_mcp_registry(

--- a/crates/zeph-core/src/bootstrap/mod.rs
+++ b/crates/zeph-core/src/bootstrap/mod.rs
@@ -6,12 +6,14 @@
 pub mod config;
 pub mod health;
 pub mod mcp;
+pub mod oauth;
 pub mod provider;
 pub mod skills;
 
 pub use config::{parse_vault_args, resolve_config_path};
 pub use health::{health_check, warmup_provider};
-pub use mcp::{create_mcp_manager, create_mcp_registry};
+pub use mcp::{create_mcp_manager, create_mcp_manager_with_vault, create_mcp_registry};
+pub use oauth::VaultCredentialStore;
 #[cfg(feature = "candle")]
 pub use provider::select_device;
 pub use provider::{
@@ -23,7 +25,7 @@ pub use skills::{create_skill_matcher, effective_embedding_model, managed_skills
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use tokio::sync::{mpsc, watch};
+use tokio::sync::{RwLock, mpsc, watch};
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::LlmProvider;
 use zeph_memory::GraphStore;
@@ -43,6 +45,9 @@ pub struct AppBuilder {
     config: Config,
     config_path: PathBuf,
     vault: Box<dyn VaultProvider>,
+    /// Present when the vault backend is `age`. Used to pass to `create_mcp_manager_with_vault`
+    /// for OAuth credential persistence across sessions.
+    age_vault: Option<Arc<RwLock<AgeVaultProvider>>>,
     qdrant_ops: Option<QdrantOps>,
 }
 
@@ -84,8 +89,11 @@ impl AppBuilder {
             vault_key_override,
             vault_path_override,
         );
-        let vault: Box<dyn VaultProvider> = match vault_args.backend.as_str() {
-            "env" => Box::new(EnvVaultProvider),
+        let (vault, age_vault): (
+            Box<dyn VaultProvider>,
+            Option<Arc<RwLock<AgeVaultProvider>>>,
+        ) = match vault_args.backend.as_str() {
+            "env" => (Box::new(EnvVaultProvider), None),
             "age" => {
                 let key = vault_args.key_path.ok_or_else(|| {
                     BootstrapError::Provider("--vault-key required for age backend".into())
@@ -93,10 +101,12 @@ impl AppBuilder {
                 let path = vault_args.vault_path.ok_or_else(|| {
                     BootstrapError::Provider("--vault-path required for age backend".into())
                 })?;
-                Box::new(
-                    AgeVaultProvider::new(Path::new(&key), Path::new(&path))
-                        .map_err(BootstrapError::VaultInit)?,
-                )
+                let provider = AgeVaultProvider::new(Path::new(&key), Path::new(&path))
+                    .map_err(BootstrapError::VaultInit)?;
+                let arc = Arc::new(RwLock::new(provider));
+                let boxed: Box<dyn VaultProvider> =
+                    Box::new(crate::vault::ArcAgeVaultProvider(Arc::clone(&arc)));
+                (boxed, Some(arc))
             }
             other => {
                 return Err(BootstrapError::Provider(format!(
@@ -124,6 +134,7 @@ impl AppBuilder {
             config,
             config_path,
             vault,
+            age_vault,
             qdrant_ops,
         })
     }
@@ -150,6 +161,14 @@ impl AppBuilder {
     /// that may inspect or override vault behavior at runtime.
     pub fn vault(&self) -> &dyn VaultProvider {
         self.vault.as_ref()
+    }
+
+    /// Returns the shared age vault, if the backend is `age`.
+    ///
+    /// Pass this to `create_mcp_manager_with_vault` so OAuth tokens are persisted
+    /// across sessions.
+    pub fn age_vault_arc(&self) -> Option<&Arc<RwLock<AgeVaultProvider>>> {
+        self.age_vault.as_ref()
     }
 
     /// # Errors

--- a/crates/zeph-core/src/bootstrap/oauth.rs
+++ b/crates/zeph-core/src/bootstrap/oauth.rs
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! OAuth credential store backed by Zeph's age vault.
+
+use std::sync::Arc;
+
+use rmcp::transport::auth::{AuthError, CredentialStore, StoredCredentials};
+use tokio::sync::RwLock;
+
+use crate::vault::AgeVaultProvider;
+use crate::vault::VaultProvider as _;
+
+/// `CredentialStore` backed by Zeph's age vault.
+///
+/// Vault key naming: `ZEPH_MCP_OAUTH_{SERVER_ID}` (uppercased, hyphens → underscores).
+/// Value: JSON-serialized `StoredCredentials`.
+///
+/// Uses `Arc<RwLock<AgeVaultProvider>>` directly because saving requires `&mut self`
+/// (`set_secret_mut` + `save`), and the `VaultProvider` trait only exposes `&self`.
+pub struct VaultCredentialStore {
+    vault_key: String,
+    vault: Arc<RwLock<AgeVaultProvider>>,
+}
+
+impl VaultCredentialStore {
+    /// Derive vault key and create the store.
+    ///
+    /// Key format: `ZEPH_MCP_OAUTH_{server_id.to_uppercase().replace('-', "_")}`.
+    pub fn new(server_id: &str, vault: Arc<RwLock<AgeVaultProvider>>) -> Self {
+        let normalized = server_id.to_uppercase().replace('-', "_");
+        Self {
+            vault_key: format!("ZEPH_MCP_OAUTH_{normalized}"),
+            vault,
+        }
+    }
+
+    /// Return the vault key this store uses.
+    #[must_use]
+    pub fn vault_key(&self) -> &str {
+        &self.vault_key
+    }
+}
+
+#[async_trait::async_trait]
+impl CredentialStore for VaultCredentialStore {
+    async fn load(&self) -> Result<Option<StoredCredentials>, AuthError> {
+        let guard = self.vault.read().await;
+        let value = guard
+            .get_secret(&self.vault_key)
+            .await
+            .map_err(|e| AuthError::InternalError(format!("vault read: {e}")))?;
+        match value {
+            None => Ok(None),
+            Some(json) => {
+                let creds: StoredCredentials = serde_json::from_str(&json)
+                    .map_err(|e| AuthError::InternalError(format!("vault deserialize: {e}")))?;
+                Ok(Some(creds))
+            }
+        }
+    }
+
+    async fn save(&self, credentials: StoredCredentials) -> Result<(), AuthError> {
+        let json = serde_json::to_string(&credentials)
+            .map_err(|e| AuthError::InternalError(format!("vault serialize: {e}")))?;
+        let vault = Arc::clone(&self.vault);
+        let key = self.vault_key.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut guard = vault.blocking_write();
+            guard.set_secret_mut(key, json);
+            guard
+                .save()
+                .map_err(|e| AuthError::InternalError(format!("vault save: {e}")))
+        })
+        .await
+        .map_err(|e| AuthError::InternalError(format!("spawn_blocking: {e}")))?
+    }
+
+    async fn clear(&self) -> Result<(), AuthError> {
+        let vault = Arc::clone(&self.vault);
+        let key = self.vault_key.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut guard = vault.blocking_write();
+            guard.remove_secret_mut(&key);
+            guard
+                .save()
+                .map_err(|e| AuthError::InternalError(format!("vault clear: {e}")))
+        })
+        .await
+        .map_err(|e| AuthError::InternalError(format!("spawn_blocking: {e}")))?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn vault_key_normalization_hyphen() {
+        let key = format!(
+            "ZEPH_MCP_OAUTH_{}",
+            "my-server".to_uppercase().replace('-', "_")
+        );
+        assert_eq!(key, "ZEPH_MCP_OAUTH_MY_SERVER");
+    }
+
+    #[test]
+    fn vault_key_collision_documented() {
+        // "my-app" and "my_app" normalize to the same key — config validation must reject this.
+        let a = "my-app".to_uppercase().replace('-', "_");
+        let b = "my_app".to_uppercase().replace('-', "_");
+        assert_eq!(
+            a, b,
+            "vault key collision exists for hyphens vs underscores"
+        );
+    }
+}

--- a/crates/zeph-core/src/bootstrap/tests.rs
+++ b/crates/zeph-core/src/bootstrap/tests.rs
@@ -771,6 +771,8 @@ fn create_mcp_manager_with_http_transport() {
         command: None,
         args: vec![],
         env: HashMap::new(),
+        headers: HashMap::new(),
+        oauth: None,
         timeout: 30,
         policy: Default::default(),
     }];
@@ -791,6 +793,8 @@ fn create_mcp_manager_with_stdio_transport() {
         command: Some("node".into()),
         args: vec!["server.js".into()],
         env: HashMap::new(),
+        headers: HashMap::new(),
+        oauth: None,
         timeout: 30,
         policy: Default::default(),
     }];
@@ -848,6 +852,7 @@ fn skill_paths_includes_managed_dir() {
         config,
         config_path: PathBuf::from("/nonexistent/config.toml"),
         vault: Box::new(EnvVaultProvider),
+        age_vault: None,
         qdrant_ops: None,
     };
     let paths = builder.skill_paths();
@@ -867,6 +872,7 @@ fn skill_paths_does_not_duplicate_managed_dir() {
         config,
         config_path: PathBuf::from("/nonexistent/config.toml"),
         vault: Box::new(EnvVaultProvider),
+        age_vault: None,
         qdrant_ops: None,
     };
     let paths = builder.skill_paths();

--- a/crates/zeph-core/src/config/mod.rs
+++ b/crates/zeph-core/src/config/mod.rs
@@ -146,6 +146,32 @@ impl Config {
                 self.memory.graph.temporal_decay_rate
             )));
         }
+        // MCP server validation
+        {
+            use std::collections::HashSet;
+            let mut seen_oauth_vault_keys: HashSet<String> = HashSet::new();
+            for s in &self.mcp.servers {
+                // headers and oauth are mutually exclusive
+                if !s.headers.is_empty() && s.oauth.as_ref().is_some_and(|o| o.enabled) {
+                    return Err(ConfigError::Validation(format!(
+                        "MCP server '{}': cannot use both 'headers' and 'oauth' simultaneously",
+                        s.id
+                    )));
+                }
+                // vault key collision detection
+                if s.oauth.as_ref().is_some_and(|o| o.enabled) {
+                    let key = format!("ZEPH_MCP_OAUTH_{}", s.id.to_uppercase().replace('-', "_"));
+                    if !seen_oauth_vault_keys.insert(key.clone()) {
+                        return Err(ConfigError::Validation(format!(
+                            "MCP server '{}' has vault key collision ('{key}'): another server \
+                             with the same normalized ID already uses this key",
+                            s.id
+                        )));
+                    }
+                }
+            }
+        }
+
         self.experiments.validate()?;
 
         // Focus config validation

--- a/crates/zeph-core/src/config/tests.rs
+++ b/crates/zeph-core/src/config/tests.rs
@@ -1477,6 +1477,8 @@ fn mcp_server_config_debug_redacts_env() {
         args: vec![],
         env: HashMap::from([("SECRET".into(), "super-secret".into())]),
         url: None,
+        headers: HashMap::new(),
+        oauth: None,
         timeout: 30,
         policy: Default::default(),
     };
@@ -3155,4 +3157,87 @@ history_limit = 50
     assert!(gemini.thinking_level.is_none());
     assert!(gemini.thinking_budget.is_none());
     assert!(gemini.include_thoughts.is_none());
+}
+
+// TC-01: McpOAuthConfig TOML deserialization with defaults.
+#[test]
+fn mcp_oauth_config_defaults() {
+    let toml_str = r#"enabled = true"#;
+    let cfg: crate::config::McpOAuthConfig = toml::from_str(toml_str).unwrap();
+    assert!(cfg.enabled);
+    assert_eq!(cfg.callback_port, 18766);
+    assert_eq!(cfg.client_name, "Zeph");
+    assert!(cfg.scopes.is_empty());
+    assert!(matches!(
+        cfg.token_storage,
+        crate::config::OAuthTokenStorage::Vault
+    ));
+}
+
+// TC-02: OAuthTokenStorage serde variants round-trip via JSON.
+#[test]
+fn oauth_token_storage_serde_vault() {
+    let s: crate::config::OAuthTokenStorage = serde_json::from_str(r#""vault""#).unwrap();
+    assert!(matches!(s, crate::config::OAuthTokenStorage::Vault));
+    let back = serde_json::to_string(&s).unwrap();
+    assert_eq!(back, r#""vault""#);
+}
+
+#[test]
+fn oauth_token_storage_serde_memory() {
+    let s: crate::config::OAuthTokenStorage = serde_json::from_str(r#""memory""#).unwrap();
+    assert!(matches!(s, crate::config::OAuthTokenStorage::Memory));
+    let back = serde_json::to_string(&s).unwrap();
+    assert_eq!(back, r#""memory""#);
+}
+
+// TC-03: Config::validate() rejects headers + oauth simultaneously.
+#[test]
+fn validate_rejects_headers_and_oauth_together() {
+    use std::collections::HashMap;
+    let mut config = Config::default();
+    let mut headers = HashMap::new();
+    headers.insert("Authorization".to_owned(), "Bearer tok".to_owned());
+    config.mcp.servers.push(crate::config::McpServerConfig {
+        id: "srv".into(),
+        command: None,
+        args: vec![],
+        env: HashMap::new(),
+        url: Some("https://mcp.example.com".into()),
+        timeout: 30,
+        policy: zeph_mcp::McpPolicy::default(),
+        headers,
+        oauth: Some(crate::config::McpOAuthConfig {
+            enabled: true,
+            ..Default::default()
+        }),
+    });
+    let err = config.validate().unwrap_err();
+    assert!(err.to_string().contains("cannot use both"));
+}
+
+// TC-04: Config::validate() detects vault key collision.
+#[test]
+fn validate_detects_vault_key_collision() {
+    use std::collections::HashMap;
+    let mut config = Config::default();
+    // Two servers with IDs that normalize to the same vault key.
+    for id in &["my-server", "my_server"] {
+        config.mcp.servers.push(crate::config::McpServerConfig {
+            id: (*id).to_owned(),
+            command: None,
+            args: vec![],
+            env: HashMap::new(),
+            url: Some("https://mcp.example.com".into()),
+            timeout: 30,
+            policy: zeph_mcp::McpPolicy::default(),
+            headers: HashMap::new(),
+            oauth: Some(crate::config::McpOAuthConfig {
+                enabled: true,
+                ..Default::default()
+            }),
+        });
+    }
+    let err = config.validate().unwrap_err();
+    assert!(err.to_string().contains("vault key collision"));
 }

--- a/crates/zeph-core/src/config/types/channels.rs
+++ b/crates/zeph-core/src/config/types/channels.rs
@@ -39,6 +39,14 @@ fn default_mcp_timeout() -> u64 {
     30
 }
 
+fn default_oauth_callback_port() -> u16 {
+    18766
+}
+
+fn default_oauth_client_name() -> String {
+    "Zeph".into()
+}
+
 #[derive(Clone, Deserialize, Serialize)]
 pub struct TelegramConfig {
     pub token: Option<String>,
@@ -192,12 +200,68 @@ pub struct McpServerConfig {
     /// Optional declarative policy for this server (allowlist, denylist, rate limit).
     #[serde(default)]
     pub policy: zeph_mcp::McpPolicy,
+    /// Static HTTP headers for the transport (e.g. `Authorization: Bearer <token>`).
+    /// Values support vault references: `${VAULT_KEY}`.
+    #[serde(default)]
+    pub headers: HashMap<String, String>,
+    /// OAuth 2.1 configuration for this server.
+    #[serde(default)]
+    pub oauth: Option<McpOAuthConfig>,
+}
+
+/// OAuth 2.1 configuration for an MCP server.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct McpOAuthConfig {
+    /// Enable OAuth 2.1 for this server.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Token storage backend.
+    #[serde(default)]
+    pub token_storage: OAuthTokenStorage,
+    /// OAuth scopes to request. Empty = server default.
+    #[serde(default)]
+    pub scopes: Vec<String>,
+    /// Port for the local callback server. `0` = auto-assign, `18766` = default fixed port.
+    #[serde(default = "default_oauth_callback_port")]
+    pub callback_port: u16,
+    /// Client name sent during dynamic registration.
+    #[serde(default = "default_oauth_client_name")]
+    pub client_name: String,
+}
+
+impl Default for McpOAuthConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            token_storage: OAuthTokenStorage::default(),
+            scopes: Vec::new(),
+            callback_port: default_oauth_callback_port(),
+            client_name: default_oauth_client_name(),
+        }
+    }
+}
+
+/// Where OAuth tokens are stored.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OAuthTokenStorage {
+    /// Persisted in the age vault (default).
+    #[default]
+    Vault,
+    /// In-memory only — tokens lost on restart.
+    Memory,
 }
 
 impl std::fmt::Debug for McpServerConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let redacted: HashMap<&str, &str> = self
+        let redacted_env: HashMap<&str, &str> = self
             .env
+            .keys()
+            .map(|k| (k.as_str(), "[REDACTED]"))
+            .collect();
+        // Redact header values to avoid leaking tokens in logs.
+        let redacted_headers: HashMap<&str, &str> = self
+            .headers
             .keys()
             .map(|k| (k.as_str(), "[REDACTED]"))
             .collect();
@@ -205,10 +269,12 @@ impl std::fmt::Debug for McpServerConfig {
             .field("id", &self.id)
             .field("command", &self.command)
             .field("args", &self.args)
-            .field("env", &redacted)
+            .field("env", &redacted_env)
             .field("url", &self.url)
             .field("timeout", &self.timeout)
             .field("policy", &self.policy)
+            .field("headers", &redacted_headers)
+            .field("oauth", &self.oauth)
             .finish()
     }
 }

--- a/crates/zeph-core/src/config/types/mod.rs
+++ b/crates/zeph-core/src/config/types/mod.rs
@@ -18,7 +18,8 @@ mod tests;
 
 pub use agent::{AgentConfig, FocusConfig, SubAgentConfig, SubAgentLifecycleHooks};
 pub use channels::{
-    A2aServerConfig, DiscordConfig, McpConfig, McpServerConfig, SlackConfig, TelegramConfig,
+    A2aServerConfig, DiscordConfig, McpConfig, McpOAuthConfig, McpServerConfig, OAuthTokenStorage,
+    SlackConfig, TelegramConfig,
 };
 pub use defaults::{
     DEFAULT_DEBUG_DIR, DEFAULT_LOG_FILE, DEFAULT_SKILLS_DIR, DEFAULT_SQLITE_PATH,

--- a/crates/zeph-core/src/vault.rs
+++ b/crates/zeph-core/src/vault.rs
@@ -371,6 +371,37 @@ impl VaultProvider for EnvVaultProvider {
     }
 }
 
+/// `VaultProvider` wrapper around `Arc<RwLock<AgeVaultProvider>>`.
+///
+/// Allows the age vault `Arc` to be stored as `Box<dyn VaultProvider>` while the
+/// underlying `Arc<RwLock<AgeVaultProvider>>` is separately held for OAuth credential
+/// persistence via `VaultCredentialStore`.
+pub struct ArcAgeVaultProvider(pub Arc<tokio::sync::RwLock<AgeVaultProvider>>);
+
+use std::sync::Arc;
+
+impl VaultProvider for ArcAgeVaultProvider {
+    fn get_secret(
+        &self,
+        key: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<String>, VaultError>> + Send + '_>> {
+        let arc = Arc::clone(&self.0);
+        let key = key.to_owned();
+        Box::pin(async move {
+            let guard = arc.read().await;
+            Ok(guard.get(&key).map(str::to_owned))
+        })
+    }
+
+    fn list_keys(&self) -> Vec<String> {
+        // Blocking read is acceptable here: list_keys is only called at startup.
+        let guard = self.0.blocking_read();
+        let mut keys: Vec<String> = guard.list_keys().iter().map(|s| (*s).to_owned()).collect();
+        keys.sort_unstable();
+        keys
+    }
+}
+
 /// Test helper with BTreeMap-based secret storage.
 #[cfg(test)]
 #[derive(Default)]

--- a/crates/zeph-mcp/Cargo.toml
+++ b/crates/zeph-mcp/Cargo.toml
@@ -22,12 +22,15 @@ glob.workspace = true
 regex.workspace = true
 dashmap.workspace = true
 qdrant-client = { workspace = true, features = ["serde"] }
-rmcp = { workspace = true, features = ["client", "transport-child-process", "transport-streamable-http-client-reqwest"] }
+async-trait.workspace = true
+rmcp = { workspace = true, features = ["client", "transport-child-process", "transport-streamable-http-client-reqwest", "auth"] }
+http.workspace = true
+reqwest = { workspace = true, features = ["rustls", "json"] }
 schemars.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["process", "sync", "time", "rt"] }
+tokio = { workspace = true, features = ["process", "sync", "time", "rt", "net", "io-util"] }
 tracing.workspace = true
 url.workspace = true
 uuid = { workspace = true, features = ["v5"] }

--- a/crates/zeph-mcp/src/client.rs
+++ b/crates/zeph-mcp/src/client.rs
@@ -1,16 +1,23 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use dashmap::DashMap;
+use http::{HeaderName, HeaderValue};
 use rmcp::ClientHandler;
 use rmcp::ServiceExt;
 use rmcp::model::{CallToolRequestParams, CallToolResult};
 use rmcp::service::{NotificationContext, RoleClient, RunningService};
 use rmcp::transport::TokioChildProcess;
-use rmcp::transport::streamable_http_client::StreamableHttpClientTransport;
+use rmcp::transport::auth::{
+    AuthClient, AuthError, CredentialStore, InMemoryStateStore, OAuthState, StoredCredentials,
+};
+use rmcp::transport::streamable_http_client::{
+    StreamableHttpClientTransport, StreamableHttpClientTransportConfig,
+};
 use tokio::process::Command;
 use tokio::sync::mpsc::UnboundedSender;
 use url::Url;
@@ -22,6 +29,25 @@ use crate::tool::McpTool;
 
 /// Minimum interval between tool list refreshes per server (rate limiting).
 const MIN_REFRESH_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Newtype wrapper so an `Arc<dyn CredentialStore>` satisfies the `CredentialStore + 'static`
+/// bound required by `AuthorizationManager::set_credential_store`.
+struct ArcCredentialStore(Arc<dyn CredentialStore>);
+
+#[async_trait::async_trait]
+impl CredentialStore for ArcCredentialStore {
+    async fn load(&self) -> Result<Option<StoredCredentials>, AuthError> {
+        self.0.load().await
+    }
+
+    async fn save(&self, credentials: StoredCredentials) -> Result<(), AuthError> {
+        self.0.save(credentials).await
+    }
+
+    async fn clear(&self) -> Result<(), AuthError> {
+        self.0.clear().await
+    }
+}
 
 /// Maximum number of tools accepted from a single server on refresh.
 const MAX_TOOLS_PER_SERVER: usize = 100;
@@ -142,6 +168,33 @@ impl ClientHandler for ToolListChangedHandler {
     }
 }
 
+/// Result of an OAuth connection attempt.
+pub enum OAuthConnectResult {
+    /// Connection established using cached or freshly obtained tokens.
+    Connected(McpClient),
+    /// User authorization required. The caller must present `auth_url` to the user
+    /// and then call `McpClient::complete_oauth` with the callback parameters.
+    AuthorizationRequired(Box<OAuthPending>),
+}
+
+/// Pending OAuth state: listener is already bound, state machine is in Session state.
+///
+/// Not `Clone`. Must be consumed in the same task via `McpClient::complete_oauth`.
+pub struct OAuthPending {
+    pub server_id: String,
+    pub auth_url: String,
+    /// Pre-bound callback listener. Taken out by the caller before `complete_oauth`.
+    pub listener: Option<tokio::net::TcpListener>,
+    pub actual_port: u16,
+    /// `OAuthState` in Session state, ready for `handle_callback()`.
+    pub oauth_state: OAuthState,
+    /// Original MCP server URL (needed to rebuild transport after auth).
+    pub url: String,
+    pub timeout: Duration,
+    pub tx: UnboundedSender<ToolRefreshEvent>,
+    pub last_refresh: Arc<DashMap<String, Instant>>,
+}
+
 type ClientService = RunningService<rmcp::RoleClient, ToolListChangedHandler>;
 
 pub struct McpClient {
@@ -260,6 +313,265 @@ impl McpClient {
         })
     }
 
+    /// Connect with static custom headers (Mode A).
+    ///
+    /// Headers are injected into every HTTP request. Values must be pre-resolved
+    /// (no vault references — callers must resolve them before building the transport).
+    ///
+    /// # Errors
+    ///
+    /// Returns `McpError::SsrfBlocked` if the URL resolves to a private IP (unless `trusted`),
+    /// or `McpError::Connection` if the handshake fails.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn connect_url_with_headers(
+        server_id: &str,
+        url: &str,
+        headers: &HashMap<String, String>,
+        timeout: Duration,
+        trusted: bool,
+        tx: UnboundedSender<ToolRefreshEvent>,
+        last_refresh: Arc<DashMap<String, Instant>>,
+    ) -> Result<Self, McpError> {
+        if !trusted {
+            validate_url_ssrf(url).await?;
+        }
+
+        let custom_headers: HashMap<HeaderName, HeaderValue> = headers
+            .iter()
+            .filter_map(|(k, v)| {
+                let name = HeaderName::from_bytes(k.as_bytes()).ok().or_else(|| {
+                    tracing::warn!(
+                        server_id,
+                        header_name = k,
+                        "invalid header name — dropping from request"
+                    );
+                    None
+                })?;
+                let value = HeaderValue::from_str(v).ok().or_else(|| {
+                    tracing::warn!(
+                        server_id,
+                        header_name = k,
+                        "invalid header value — dropping from request"
+                    );
+                    None
+                })?;
+                Some((name, value))
+            })
+            .collect();
+
+        let config =
+            StreamableHttpClientTransportConfig::with_uri(url).custom_headers(custom_headers);
+        let transport =
+            StreamableHttpClientTransport::with_client(reqwest::Client::default(), config);
+
+        let handler = ToolListChangedHandler::new(server_id, tx, last_refresh);
+        let service = handler
+            .serve(transport)
+            .await
+            .map_err(|e| McpError::Connection {
+                server_id: server_id.into(),
+                message: e.to_string(),
+            })?;
+
+        Ok(Self {
+            server_id: server_id.into(),
+            service: Arc::new(service),
+            timeout,
+        })
+    }
+
+    /// Attempt OAuth 2.1 connection (Mode B).
+    ///
+    /// Returns `OAuthConnectResult::Connected` if cached tokens are valid and the
+    /// MCP handshake succeeds without user interaction.
+    ///
+    /// Returns `OAuthConnectResult::AuthorizationRequired` if the user must open
+    /// the authorization URL in a browser. The caller must then call
+    /// [`McpClient::complete_oauth`] after receiving the callback.
+    ///
+    /// # Errors
+    ///
+    /// Returns `McpError::OAuthError` on metadata discovery, SSRF, or authorization failures.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn connect_url_oauth(
+        server_id: &str,
+        url: &str,
+        scopes: &[String],
+        callback_port: u16,
+        client_name: &str,
+        credential_store: Arc<dyn CredentialStore>,
+        trusted: bool,
+        tx: UnboundedSender<ToolRefreshEvent>,
+        last_refresh: Arc<DashMap<String, Instant>>,
+        timeout: Duration,
+    ) -> Result<OAuthConnectResult, McpError> {
+        if !trusted {
+            validate_url_ssrf(url).await?;
+        }
+
+        // Step 1: create OAuthState
+        let mut state = OAuthState::new(url, None)
+            .await
+            .map_err(|e| McpError::OAuthError {
+                server_id: server_id.into(),
+                message: e.to_string(),
+            })?;
+
+        // Step 2: configure stores and check for cached tokens.
+        // Uses a flag to avoid borrowing `state` across the authorization manager consumption.
+        let has_cached_tokens = if let OAuthState::Unauthorized(ref mut manager) = state {
+            manager.set_credential_store(ArcCredentialStore(credential_store));
+            manager.set_state_store(InMemoryStateStore::new());
+            manager.initialize_from_store().await.unwrap_or(false)
+        } else {
+            false
+        };
+
+        // Step 3: if cached tokens available, connect immediately without user interaction.
+        // `initialize_from_store()` configures the manager but leaves `OAuthState` in
+        // `Unauthorized`. Extract the manager directly from that variant — it is fully
+        // configured with metadata, client_id, and a credential store that holds tokens.
+        if has_cached_tokens {
+            let OAuthState::Unauthorized(manager) = state else {
+                return Err(McpError::OAuthError {
+                    server_id: server_id.into(),
+                    message: "unexpected state after initialize_from_store".into(),
+                });
+            };
+
+            let auth_client: AuthClient<reqwest::Client> =
+                AuthClient::new(reqwest::Client::default(), manager);
+            let config = StreamableHttpClientTransportConfig::with_uri(url);
+            let transport = StreamableHttpClientTransport::with_client(auth_client, config);
+
+            let handler = ToolListChangedHandler::new(server_id, tx, last_refresh);
+            let service = handler
+                .serve(transport)
+                .await
+                .map_err(|e| McpError::Connection {
+                    server_id: server_id.into(),
+                    message: e.to_string(),
+                })?;
+
+            return Ok(OAuthConnectResult::Connected(McpClient {
+                server_id: server_id.into(),
+                service: Arc::new(service),
+                timeout,
+            }));
+        }
+
+        // Step 4: bind callback server before client registration to get actual port
+        let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{callback_port}"))
+            .await
+            .map_err(|e| McpError::OAuthError {
+                server_id: server_id.into(),
+                message: format!("callback server bind failed: {e}"),
+            })?;
+        let actual_port = listener
+            .local_addr()
+            .map_err(|e| McpError::OAuthError {
+                server_id: server_id.into(),
+                message: format!("failed to get listener address: {e}"),
+            })?
+            .port();
+        let redirect_uri = format!("http://127.0.0.1:{actual_port}/callback");
+
+        // Step 5: discover metadata and validate endpoints
+        if let OAuthState::Unauthorized(ref manager) = state {
+            let metadata = manager
+                .discover_metadata()
+                .await
+                .map_err(|e| McpError::OAuthError {
+                    server_id: server_id.into(),
+                    message: format!("metadata discovery failed: {e}"),
+                })?;
+
+            crate::oauth::validate_oauth_metadata_urls(server_id, &metadata).await?;
+        }
+
+        // Step 6: start authorization
+        let scope_refs: Vec<&str> = scopes.iter().map(String::as_str).collect();
+        state
+            .start_authorization(&scope_refs, &redirect_uri, Some(client_name))
+            .await
+            .map_err(|e| McpError::OAuthError {
+                server_id: server_id.into(),
+                message: format!("authorization start failed: {e}"),
+            })?;
+
+        let auth_url = state
+            .get_authorization_url()
+            .await
+            .map_err(|e| McpError::OAuthError {
+                server_id: server_id.into(),
+                message: format!("get auth URL failed: {e}"),
+            })?;
+
+        Ok(OAuthConnectResult::AuthorizationRequired(Box::new(
+            OAuthPending {
+                server_id: server_id.into(),
+                auth_url,
+                listener: Some(listener),
+                actual_port,
+                oauth_state: state,
+                url: url.into(),
+                timeout,
+                tx,
+                last_refresh,
+            },
+        )))
+    }
+
+    /// Complete an OAuth flow after receiving the callback.
+    ///
+    /// # Errors
+    ///
+    /// Returns `McpError::OAuthError` if token exchange fails or the connection
+    /// cannot be established.
+    pub async fn complete_oauth(
+        mut pending: OAuthPending,
+        code: &str,
+        csrf_token: &str,
+    ) -> Result<Self, McpError> {
+        pending
+            .oauth_state
+            .handle_callback(code, csrf_token)
+            .await
+            .map_err(|e| McpError::OAuthError {
+                server_id: pending.server_id.clone(),
+                message: format!("token exchange failed: {e}"),
+            })?;
+
+        let manager = pending
+            .oauth_state
+            .into_authorization_manager()
+            .ok_or_else(|| McpError::OAuthError {
+                server_id: pending.server_id.clone(),
+                message: "unexpected state after handle_callback".into(),
+            })?;
+
+        let auth_client: AuthClient<reqwest::Client> =
+            AuthClient::new(reqwest::Client::default(), manager);
+        let config = StreamableHttpClientTransportConfig::with_uri(pending.url.as_str());
+        let transport = StreamableHttpClientTransport::with_client(auth_client, config);
+
+        let handler =
+            ToolListChangedHandler::new(&pending.server_id, pending.tx, pending.last_refresh);
+        let service = handler
+            .serve(transport)
+            .await
+            .map_err(|e| McpError::Connection {
+                server_id: pending.server_id.clone(),
+                message: e.to_string(),
+            })?;
+
+        Ok(McpClient {
+            server_id: pending.server_id,
+            service: Arc::new(service),
+            timeout: pending.timeout,
+        })
+    }
+
     /// Call tools/list, convert to `McpTool` vec.
     ///
     /// # Errors
@@ -338,7 +650,7 @@ impl McpClient {
     }
 }
 
-async fn validate_url_ssrf(url: &str) -> Result<(), McpError> {
+pub(crate) async fn validate_url_ssrf(url: &str) -> Result<(), McpError> {
     let parsed = Url::parse(url).map_err(|e| McpError::InvalidUrl {
         url: url.into(),
         message: e.to_string(),

--- a/crates/zeph-mcp/src/error.rs
+++ b/crates/zeph-mcp/src/error.rs
@@ -58,6 +58,15 @@ pub enum McpError {
 
     #[error("policy violation: {0}")]
     PolicyViolation(String),
+
+    #[error("OAuth error for server '{server_id}': {message}")]
+    OAuthError { server_id: String, message: String },
+
+    #[error("OAuth callback timed out for server '{server_id}' after {timeout_secs}s")]
+    OAuthCallbackTimeout {
+        server_id: String,
+        timeout_secs: u64,
+    },
 }
 
 #[cfg(test)]

--- a/crates/zeph-mcp/src/lib.rs
+++ b/crates/zeph-mcp/src/lib.rs
@@ -8,6 +8,7 @@ pub mod client;
 pub mod error;
 pub mod executor;
 pub mod manager;
+pub mod oauth;
 pub mod policy;
 pub mod prompt;
 pub mod registry;
@@ -22,7 +23,7 @@ pub mod testing;
 pub mod mock;
 
 pub use caller::McpCaller;
-pub use client::ToolRefreshEvent;
+pub use client::{OAuthConnectResult, OAuthPending, ToolRefreshEvent};
 pub use error::McpError;
 pub use executor::McpToolExecutor;
 pub use manager::{McpManager, McpTransport, ServerEntry};

--- a/crates/zeph-mcp/src/manager.rs
+++ b/crates/zeph-mcp/src/manager.rs
@@ -9,9 +9,13 @@ use dashmap::DashMap;
 use rmcp::model::CallToolResult;
 use tokio::sync::RwLock;
 use tokio::sync::{mpsc, watch};
+
+type StatusTx = mpsc::UnboundedSender<String>;
 use tokio::task::JoinSet;
 
-use crate::client::{McpClient, ToolRefreshEvent};
+use rmcp::transport::auth::CredentialStore;
+
+use crate::client::{McpClient, OAuthConnectResult, ToolRefreshEvent};
 use crate::error::McpError;
 use crate::policy::PolicyEnforcer;
 use crate::sanitize::sanitize_tools;
@@ -26,8 +30,20 @@ pub enum McpTransport {
         args: Vec<String>,
         env: HashMap<String, String>,
     },
-    /// Streamable HTTP: connect to remote URL.
-    Http { url: String },
+    /// Streamable HTTP with optional static headers (already resolved, no vault refs).
+    Http {
+        url: String,
+        /// Static headers injected into every request (e.g. `Authorization: Bearer <token>`).
+        #[serde(default)]
+        headers: HashMap<String, String>,
+    },
+    /// OAuth 2.1 authenticated HTTP transport.
+    OAuth {
+        url: String,
+        scopes: Vec<String>,
+        callback_port: u16,
+        client_name: String,
+    },
 }
 
 /// Server connection parameters consumed by `McpManager`.
@@ -61,6 +77,13 @@ pub struct McpManager {
     tools_watch_tx: watch::Sender<Vec<McpTool>>,
     /// Shared rate-limit state across all `ToolListChangedHandler` instances.
     last_refresh: Arc<DashMap<String, Instant>>,
+    /// Per-server OAuth credential stores. Keyed by server ID.
+    /// Set via `with_oauth_credential_store` before `connect_all()`.
+    oauth_credentials: HashMap<String, Arc<dyn CredentialStore>>,
+    /// Optional status sender for OAuth authorization messages.
+    /// When set, the authorization URL is sent as a status message instead of
+    /// (or in addition to) printing to stderr — required for TUI and Telegram modes.
+    status_tx: Option<StatusTx>,
 }
 
 impl std::fmt::Debug for McpManager {
@@ -92,7 +115,32 @@ impl McpManager {
             refresh_rx: std::sync::Mutex::new(Some(refresh_rx)),
             tools_watch_tx,
             last_refresh: Arc::new(DashMap::new()),
+            oauth_credentials: HashMap::new(),
+            status_tx: None,
         }
+    }
+
+    /// Set a status sender for OAuth authorization messages.
+    ///
+    /// When set, the OAuth authorization URL is sent as a status message so the
+    /// TUI can display it in the status panel. In CLI mode this is not required.
+    #[must_use]
+    pub fn with_status_tx(mut self, tx: StatusTx) -> Self {
+        self.status_tx = Some(tx);
+        self
+    }
+
+    /// Register a credential store for an OAuth server.
+    ///
+    /// Must be called before `connect_all()` for any server using `McpTransport::OAuth`.
+    #[must_use]
+    pub fn with_oauth_credential_store(
+        mut self,
+        server_id: impl Into<String>,
+        store: Arc<dyn CredentialStore>,
+    ) -> Self {
+        self.oauth_credentials.insert(server_id.into(), store);
+        self
     }
 
     /// Clone the refresh sender for use in `ToolListChangedHandler`.
@@ -169,22 +217,35 @@ impl McpManager {
         self
     }
 
-    /// Connect to all configured servers concurrently, return aggregated tool list.
-    /// Servers that fail to connect are logged and skipped.
+    /// Connect to all configured servers, return aggregated tool list.
+    ///
+    /// Phase 1: non-OAuth servers connect concurrently via `JoinSet`.
+    /// Phase 2: OAuth servers connect sequentially (requires user interaction).
+    ///
+    /// For OAuth servers without a registered credential store, a warning is
+    /// logged and the server is skipped.
     ///
     /// # Panics
     ///
     /// Panics if the internal `connected_server_ids` lock is poisoned.
+    #[allow(clippy::too_many_lines)]
     pub async fn connect_all(&self) -> Vec<McpTool> {
-        let mut join_set = JoinSet::new();
-
         let allowed = self.allowed_commands.clone();
         let suppress = self.suppress_stderr;
         let last_refresh = Arc::clone(&self.last_refresh);
-        for config in self.configs.clone() {
+
+        // Partition configs into non-OAuth (concurrent) and OAuth (sequential)
+        let (non_oauth, oauth_configs): (Vec<_>, Vec<_>) = self
+            .configs
+            .iter()
+            .cloned()
+            .partition(|c| !matches!(c.transport, McpTransport::OAuth { .. }));
+
+        // Phase 1: connect non-OAuth servers concurrently
+        let mut join_set = JoinSet::new();
+        for config in non_oauth {
             let allowed = allowed.clone();
             let last_refresh = Arc::clone(&last_refresh);
-            // If manager is shutting down, no tx available; skip connection.
             let Some(tx) = self.clone_refresh_tx() else {
                 continue;
             };
@@ -195,42 +256,177 @@ impl McpManager {
         }
 
         let mut all_tools = Vec::new();
-        let mut clients = self.clients.write().await;
-        let mut server_tools = self.server_tools.write().await;
+        {
+            let mut clients = self.clients.write().await;
+            let mut server_tools = self.server_tools.write().await;
 
-        while let Some(result) = join_set.join_next().await {
-            let Ok((server_id, connect_result)) = result else {
-                tracing::warn!("MCP connection task panicked");
+            while let Some(result) = join_set.join_next().await {
+                let Ok((server_id, connect_result)) = result else {
+                    tracing::warn!("MCP connection task panicked");
+                    continue;
+                };
+
+                self.handle_connect_result(
+                    server_id,
+                    connect_result,
+                    &mut all_tools,
+                    &mut clients,
+                    &mut server_tools,
+                )
+                .await;
+            }
+        }
+
+        // Phase 2: connect OAuth servers sequentially
+        for config in oauth_configs {
+            let McpTransport::OAuth {
+                ref url,
+                ref scopes,
+                callback_port,
+                ref client_name,
+            } = config.transport
+            else {
                 continue;
             };
 
+            let Some(credential_store_ref) = self.oauth_credentials.get(&config.id) else {
+                tracing::warn!(
+                    server_id = config.id,
+                    "OAuth server has no credential store registered — skipping"
+                );
+                continue;
+            };
+            let credential_store = Arc::clone(credential_store_ref);
+
+            let Some(tx) = self.clone_refresh_tx() else {
+                continue;
+            };
+
+            let connect_result = McpClient::connect_url_oauth(
+                &config.id,
+                url,
+                scopes,
+                callback_port,
+                client_name,
+                credential_store,
+                config.trusted,
+                tx,
+                Arc::clone(&last_refresh),
+                config.timeout,
+            )
+            .await;
+
             match connect_result {
-                Ok(client) => match client.list_tools().await {
-                    Ok(mut tools) => {
-                        // Sanitize tool definitions before they enter the system prompt.
-                        // On server reconnect or tool list refresh, new tools must also
-                        // be passed through sanitize_tools() before use.
-                        sanitize_tools(&mut tools, &server_id);
-                        tracing::info!(server_id, tools = tools.len(), "connected to MCP server");
-                        server_tools.insert(server_id.clone(), tools.clone());
-                        all_tools.extend(tools);
-                        clients.insert(server_id.clone(), client);
-                        self.connected_server_ids
-                            .write()
-                            .expect("connected_server_ids lock poisoned")
-                            .insert(server_id);
+                Ok(OAuthConnectResult::Connected(client)) => {
+                    let mut clients = self.clients.write().await;
+                    let mut server_tools = self.server_tools.write().await;
+                    self.handle_connect_result(
+                        config.id.clone(),
+                        Ok(client),
+                        &mut all_tools,
+                        &mut clients,
+                        &mut server_tools,
+                    )
+                    .await;
+                }
+                Ok(OAuthConnectResult::AuthorizationRequired(pending_box)) => {
+                    let mut pending = *pending_box;
+                    tracing::info!(
+                        server_id = config.id,
+                        auth_url = pending.auth_url,
+                        callback_port = pending.actual_port,
+                        "OAuth authorization required — open this URL to authorize"
+                    );
+                    let auth_msg = format!(
+                        "MCP OAuth: Open this URL to authorize '{}': {}",
+                        config.id, pending.auth_url
+                    );
+                    if let Some(ref tx) = self.status_tx {
+                        let _ = tx.send(format!("Waiting for OAuth: {}", config.id));
+                        let _ = tx.send(auth_msg.clone());
+                    } else {
+                        eprintln!("{auth_msg}");
                     }
-                    Err(e) => {
-                        tracing::warn!(server_id, "failed to list tools: {e:#}");
+
+                    let callback_timeout = std::time::Duration::from_secs(300);
+                    let listener = pending
+                        .listener
+                        .take()
+                        .expect("listener always set by connect_url_oauth");
+                    match crate::oauth::await_oauth_callback(listener, callback_timeout, &config.id)
+                        .await
+                    {
+                        Ok((code, csrf_token)) => {
+                            if let Some(ref tx) = self.status_tx {
+                                let _ = tx.send(String::new()); // clear "Waiting for OAuth..." spinner
+                            }
+                            match McpClient::complete_oauth(pending, &code, &csrf_token).await {
+                                Ok(client) => {
+                                    let mut clients = self.clients.write().await;
+                                    let mut server_tools = self.server_tools.write().await;
+                                    self.handle_connect_result(
+                                        config.id.clone(),
+                                        Ok(client),
+                                        &mut all_tools,
+                                        &mut clients,
+                                        &mut server_tools,
+                                    )
+                                    .await;
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        server_id = config.id,
+                                        "OAuth token exchange failed: {e:#}"
+                                    );
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            if let Some(ref tx) = self.status_tx {
+                                let _ = tx.send(String::new());
+                            }
+                            tracing::warn!(server_id = config.id, "OAuth callback failed: {e:#}");
+                        }
                     }
-                },
+                }
                 Err(e) => {
-                    tracing::warn!(server_id, "MCP server connection failed: {e:#}");
+                    tracing::warn!(server_id = config.id, "OAuth connection failed: {e:#}");
                 }
             }
         }
 
         all_tools
+    }
+
+    async fn handle_connect_result(
+        &self,
+        server_id: String,
+        connect_result: Result<McpClient, McpError>,
+        all_tools: &mut Vec<McpTool>,
+        clients: &mut HashMap<String, McpClient>,
+        server_tools: &mut HashMap<String, Vec<McpTool>>,
+    ) {
+        match connect_result {
+            Ok(client) => match client.list_tools().await {
+                Ok(mut tools) => {
+                    sanitize_tools(&mut tools, &server_id);
+                    tracing::info!(server_id, tools = tools.len(), "connected to MCP server");
+                    server_tools.insert(server_id.clone(), tools.clone());
+                    all_tools.extend(tools);
+                    clients.insert(server_id.clone(), client);
+                    self.connected_server_ids
+                        .write()
+                        .expect("connected_server_ids lock poisoned")
+                        .insert(server_id);
+                }
+                Err(e) => {
+                    tracing::warn!(server_id, "failed to list tools: {e:#}");
+                }
+            },
+            Err(e) => {
+                tracing::warn!(server_id, "MCP server connection failed: {e:#}");
+            }
+        }
     }
 
     /// Route tool call to the correct server's client.
@@ -451,16 +647,36 @@ async fn connect_entry(
             )
             .await
         }
-        McpTransport::Http { url } => {
-            McpClient::connect_url(
-                &entry.id,
-                url,
-                entry.timeout,
-                entry.trusted,
-                tx,
-                last_refresh,
-            )
-            .await
+        McpTransport::Http { url, headers } => {
+            if headers.is_empty() {
+                McpClient::connect_url(
+                    &entry.id,
+                    url,
+                    entry.timeout,
+                    entry.trusted,
+                    tx,
+                    last_refresh,
+                )
+                .await
+            } else {
+                McpClient::connect_url_with_headers(
+                    &entry.id,
+                    url,
+                    headers,
+                    entry.timeout,
+                    entry.trusted,
+                    tx,
+                    last_refresh,
+                )
+                .await
+            }
+        }
+        McpTransport::OAuth { .. } => {
+            // OAuth connections are handled separately in connect_all() Phase 2.
+            Err(McpError::OAuthError {
+                server_id: entry.id.clone(),
+                message: "OAuth transport cannot be used via connect_entry".into(),
+            })
         }
     }
 }
@@ -631,9 +847,10 @@ mod tests {
     fn transport_http_clone() {
         let transport = McpTransport::Http {
             url: "http://localhost:3000".into(),
+            headers: HashMap::new(),
         };
         let cloned = transport.clone();
-        if let McpTransport::Http { url } = &cloned {
+        if let McpTransport::Http { url, .. } = &cloned {
             assert_eq!(url, "http://localhost:3000");
         } else {
             panic!("expected Http variant");
@@ -656,6 +873,7 @@ mod tests {
     fn transport_http_debug() {
         let transport = McpTransport::Http {
             url: "http://example.com".into(),
+            headers: HashMap::new(),
         };
         let dbg = format!("{transport:?}");
         assert!(dbg.contains("Http"));
@@ -667,6 +885,7 @@ mod tests {
             id: id.into(),
             transport: McpTransport::Http {
                 url: "http://127.0.0.1:1/nonexistent".into(),
+                headers: HashMap::new(),
             },
             timeout: Duration::from_secs(1),
             trusted: false,

--- a/crates/zeph-mcp/src/oauth.rs
+++ b/crates/zeph-mcp/src/oauth.rs
@@ -1,0 +1,306 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use crate::error::McpError;
+
+/// Await an OAuth callback on the given pre-bound listener.
+///
+/// Reads one HTTP GET request, extracts `?code=...&state=...` query parameters,
+/// writes a minimal success response, and returns `(code, state)`.
+///
+/// The listener must already be bound (so the port is known before client registration).
+///
+/// # Errors
+///
+/// Returns `McpError::OAuthCallbackTimeout` if no callback arrives within `timeout`,
+/// or `McpError::OAuthError` on parse failures.
+pub async fn await_oauth_callback(
+    listener: tokio::net::TcpListener,
+    timeout: Duration,
+    server_id: &str,
+) -> Result<(String, String), McpError> {
+    let accept_fut = async {
+        let (mut stream, _) = listener.accept().await.map_err(|e| McpError::OAuthError {
+            server_id: server_id.to_owned(),
+            message: format!("callback server accept failed: {e}"),
+        })?;
+
+        // Read in a loop until the HTTP header terminator (\r\n\r\n) is found or the
+        // buffer reaches the cap. A single read() may return a partial TCP segment.
+        let mut buf = Vec::with_capacity(4096);
+        let cap: usize = 8192;
+        loop {
+            let mut chunk = [0u8; 512];
+            let n = stream
+                .read(&mut chunk)
+                .await
+                .map_err(|e| McpError::OAuthError {
+                    server_id: server_id.to_owned(),
+                    message: format!("callback read failed: {e}"),
+                })?;
+            if n == 0 {
+                break;
+            }
+            buf.extend_from_slice(&chunk[..n]);
+            if buf.windows(4).any(|w| w == b"\r\n\r\n") || buf.len() >= cap {
+                break;
+            }
+        }
+        let request = String::from_utf8_lossy(&buf);
+
+        // Extract request line: "GET /callback?code=...&state=... HTTP/1.1"
+        let first_line = request.lines().next().unwrap_or_default();
+        let path = first_line.split_whitespace().nth(1).unwrap_or_default();
+
+        let query = path.split_once('?').map(|(_, q)| q).unwrap_or_default();
+
+        let (code, state) = parse_callback_params(query, server_id)?;
+
+        let response = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nAuthorization successful. You can close this tab.";
+        let _ = stream.write_all(response.as_bytes()).await;
+
+        Ok::<(String, String), McpError>((code, state))
+    };
+
+    tokio::time::timeout(timeout, accept_fut)
+        .await
+        .map_err(|_| McpError::OAuthCallbackTimeout {
+            server_id: server_id.to_owned(),
+            timeout_secs: timeout.as_secs(),
+        })?
+}
+
+fn parse_callback_params(query: &str, server_id: &str) -> Result<(String, String), McpError> {
+    let mut code = None;
+    let mut state = None;
+
+    for pair in query.split('&') {
+        if let Some((k, v)) = pair.split_once('=') {
+            let v = urlencoding_decode(v);
+            match k {
+                "code" => code = Some(v),
+                "state" => state = Some(v),
+                _ => {}
+            }
+        }
+    }
+
+    let code = code.ok_or_else(|| McpError::OAuthError {
+        server_id: server_id.to_owned(),
+        message: "OAuth callback missing 'code' parameter".into(),
+    })?;
+    let state = state.ok_or_else(|| McpError::OAuthError {
+        server_id: server_id.to_owned(),
+        message: "OAuth callback missing 'state' parameter".into(),
+    })?;
+
+    Ok((code, state))
+}
+
+/// Minimal percent-decode for OAuth callback params (replace `%XX` and `+`).
+fn urlencoding_decode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let (Some(h), Some(l)) = (hex_val(bytes[i + 1]), hex_val(bytes[i + 2])) {
+                out.push(char::from(h * 16 + l));
+                i += 3;
+                continue;
+            }
+        } else if bytes[i] == b'+' {
+            out.push(' ');
+            i += 1;
+            continue;
+        }
+        out.push(char::from(bytes[i]));
+        i += 1;
+    }
+    out
+}
+
+fn hex_val(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// Validate that OAuth metadata endpoints don't resolve to private IPs.
+///
+/// Called after `discover_metadata()`, before using any of the discovered URLs.
+///
+/// # Errors
+///
+/// Returns `McpError::OAuthError` if any endpoint resolves to a private/reserved IP.
+pub async fn validate_oauth_metadata_urls(
+    server_id: &str,
+    metadata: &rmcp::transport::auth::AuthorizationMetadata,
+) -> Result<(), McpError> {
+    use crate::client::validate_url_ssrf;
+
+    validate_url_ssrf(&metadata.token_endpoint)
+        .await
+        .map_err(|_| McpError::OAuthError {
+            server_id: server_id.to_owned(),
+            message: format!(
+                "SSRF: token_endpoint '{}' resolves to private IP",
+                metadata.token_endpoint
+            ),
+        })?;
+
+    if let Some(ref reg_url) = metadata.registration_endpoint {
+        validate_url_ssrf(reg_url)
+            .await
+            .map_err(|_| McpError::OAuthError {
+                server_id: server_id.to_owned(),
+                message: format!("SSRF: registration_endpoint '{reg_url}' resolves to private IP"),
+            })?;
+    }
+
+    validate_url_ssrf(&metadata.authorization_endpoint)
+        .await
+        .map_err(|_| McpError::OAuthError {
+            server_id: server_id.to_owned(),
+            message: format!(
+                "SSRF: authorization_endpoint '{}' resolves to private IP",
+                metadata.authorization_endpoint
+            ),
+        })?;
+
+    if let Some(ref jwks) = metadata.jwks_uri {
+        validate_url_ssrf(jwks)
+            .await
+            .map_err(|_| McpError::OAuthError {
+                server_id: server_id.to_owned(),
+                message: format!("SSRF: jwks_uri '{jwks}' resolves to private IP"),
+            })?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn urlencoding_decode_basic() {
+        assert_eq!(urlencoding_decode("hello+world"), "hello world");
+        assert_eq!(urlencoding_decode("foo%20bar"), "foo bar");
+        assert_eq!(urlencoding_decode("abc%2F"), "abc/");
+    }
+
+    #[test]
+    fn parse_callback_params_ok() {
+        let (code, state) = parse_callback_params("code=abc123&state=xyz", "srv").unwrap();
+        assert_eq!(code, "abc123");
+        assert_eq!(state, "xyz");
+    }
+
+    #[test]
+    fn parse_callback_params_missing_code() {
+        let err = parse_callback_params("state=xyz", "srv").unwrap_err();
+        assert!(matches!(err, McpError::OAuthError { .. }));
+    }
+
+    #[test]
+    fn parse_callback_params_missing_state() {
+        let err = parse_callback_params("code=abc", "srv").unwrap_err();
+        assert!(matches!(err, McpError::OAuthError { .. }));
+    }
+
+    #[test]
+    fn oauth_error_variants_display() {
+        let err = McpError::OAuthError {
+            server_id: "todoist".into(),
+            message: "metadata discovery failed".into(),
+        };
+        assert!(err.to_string().contains("todoist"));
+        assert!(err.to_string().contains("metadata discovery failed"));
+
+        let timeout = McpError::OAuthCallbackTimeout {
+            server_id: "todoist".into(),
+            timeout_secs: 300,
+        };
+        assert!(timeout.to_string().contains("300"));
+    }
+
+    // TC-07: validate_oauth_metadata_urls blocks private IPs on all three endpoints.
+    // Uses 8.8.8.8 as a "public" IP literal (no DNS) to avoid network dependency in passing fields.
+    #[tokio::test]
+    async fn validate_oauth_metadata_urls_blocks_private_token_endpoint() {
+        use std::collections::HashMap;
+        let metadata = rmcp::transport::auth::AuthorizationMetadata {
+            // token_endpoint is private — must be rejected
+            token_endpoint: "http://10.0.0.1/token".into(),
+            // other endpoints use a literal public IP so DNS is not required
+            authorization_endpoint: "http://8.8.8.8/auth".into(),
+            registration_endpoint: None,
+            issuer: None,
+            jwks_uri: None,
+            scopes_supported: None,
+            response_types_supported: None,
+            code_challenge_methods_supported: None,
+            additional_fields: HashMap::new(),
+        };
+        let err = validate_oauth_metadata_urls("srv", &metadata)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, McpError::OAuthError { .. }));
+        assert!(err.to_string().contains("token_endpoint"));
+    }
+
+    #[tokio::test]
+    async fn validate_oauth_metadata_urls_blocks_private_authorization_endpoint() {
+        use std::collections::HashMap;
+        let metadata = rmcp::transport::auth::AuthorizationMetadata {
+            // token_endpoint uses literal public IP so it passes
+            token_endpoint: "http://8.8.8.8/token".into(),
+            // authorization_endpoint is private — must be rejected
+            authorization_endpoint: "http://192.168.1.1/auth".into(),
+            registration_endpoint: None,
+            issuer: None,
+            jwks_uri: None,
+            scopes_supported: None,
+            response_types_supported: None,
+            code_challenge_methods_supported: None,
+            additional_fields: HashMap::new(),
+        };
+        let err = validate_oauth_metadata_urls("srv", &metadata)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, McpError::OAuthError { .. }));
+        assert!(err.to_string().contains("authorization_endpoint"));
+    }
+
+    #[tokio::test]
+    async fn validate_oauth_metadata_urls_blocks_private_jwks_uri() {
+        use std::collections::HashMap;
+        let metadata = rmcp::transport::auth::AuthorizationMetadata {
+            // token_endpoint and authorization_endpoint use literal public IPs
+            token_endpoint: "http://8.8.8.8/token".into(),
+            authorization_endpoint: "http://8.8.8.8/auth".into(),
+            registration_endpoint: None,
+            issuer: None,
+            // jwks_uri is private — must be rejected
+            jwks_uri: Some("http://127.0.0.1:9000/jwks".into()),
+            scopes_supported: None,
+            response_types_supported: None,
+            code_challenge_methods_supported: None,
+            additional_fields: HashMap::new(),
+        };
+        let err = validate_oauth_metadata_urls("srv", &metadata)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, McpError::OAuthError { .. }));
+        assert!(err.to_string().contains("jwks_uri"));
+    }
+}

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -285,7 +285,11 @@ async fn build_acp_deps(
             .collect(),
     );
     let mcp_manager = prebuilt_mcp_manager.unwrap_or_else(|| {
-        std::sync::Arc::new(zeph_core::bootstrap::create_mcp_manager(config, false))
+        std::sync::Arc::new(zeph_core::bootstrap::create_mcp_manager_with_vault(
+            config,
+            false,
+            app.age_vault_arc(),
+        ))
     });
     let mcp_tools = mcp_manager.connect_all().await;
     let mcp_shared_tools = std::sync::Arc::new(std::sync::RwLock::new(mcp_tools.clone()));
@@ -1099,8 +1103,14 @@ pub(crate) async fn run_acp_server(
 ) -> anyhow::Result<()> {
     use std::sync::Arc;
 
-    let (mut deps, _keepalive) =
-        build_acp_deps(config_path, vault_backend, vault_key, vault_path, None).await?;
+    let (mut deps, _keepalive) = Box::pin(build_acp_deps(
+        config_path,
+        vault_backend,
+        vault_key,
+        vault_path,
+        None,
+    ))
+    .await?;
     let available_models = std::sync::Arc::clone(&deps.acp_available_models);
     let provider = deps.provider.clone();
     warm_model_caches(provider, available_models).await;
@@ -1164,9 +1174,10 @@ pub(crate) async fn run_acp_http_server(
 
     // CLI flag overrides config/env values for auth token.
     let auth_bearer_token = auth_token_override.or(app.config().acp.auth_token.clone());
-    let mcp_manager_for_acp = Arc::new(zeph_core::bootstrap::create_mcp_manager(
+    let mcp_manager_for_acp = Arc::new(zeph_core::bootstrap::create_mcp_manager_with_vault(
         app.config(),
         false,
+        app.age_vault_arc(),
     ));
     let server_config = zeph_acp::AcpServerConfig {
         agent_name: app.config().acp.agent_name.clone(),
@@ -1217,13 +1228,13 @@ pub(crate) async fn run_acp_http_server(
     tracing::info!("ACP HTTP server listening on {bind_addr}");
     let server_task = tokio::spawn(async move { ::axum::serve(listener, router).await });
 
-    let (deps, _keepalive) = match build_acp_deps(
+    let (deps, _keepalive) = match Box::pin(build_acp_deps(
         config_path,
         vault_backend,
         vault_key,
         vault_path,
         Some(mcp_manager_for_acp),
-    )
+    ))
     .await
     {
         Ok(result) => result,

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -298,6 +298,8 @@ pub(crate) async fn build_tool_setup(
     permission_policy: zeph_tools::PermissionPolicy,
     with_tool_events: bool,
     suppress_stderr: bool,
+    age_vault: Option<&Arc<tokio::sync::RwLock<zeph_core::vault::AgeVaultProvider>>>,
+    status_tx: Option<tokio::sync::mpsc::UnboundedSender<String>>,
 ) -> ToolSetup {
     let filter_registry = if config.tools.filters.enabled {
         zeph_tools::OutputFilterRegistry::default_filters(&config.tools.filters)
@@ -333,10 +335,12 @@ pub(crate) async fn build_tool_setup(
             .collect(),
     );
 
-    let mcp_manager = Arc::new(zeph_core::bootstrap::create_mcp_manager(
-        config,
-        suppress_stderr,
-    ));
+    let mut mcp_manager_builder =
+        zeph_core::bootstrap::create_mcp_manager_with_vault(config, suppress_stderr, age_vault);
+    if let Some(tx) = status_tx {
+        mcp_manager_builder = mcp_manager_builder.with_status_tx(tx);
+    }
+    let mcp_manager = Arc::new(mcp_manager_builder);
     let mcp_tools = mcp_manager.connect_all().await;
     tracing::info!("discovered {} MCP tool(s)", mcp_tools.len());
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -243,7 +243,11 @@ pub(crate) async fn run_daemon(
             .map(PathBuf::from)
             .collect(),
     );
-    let mcp_manager = std::sync::Arc::new(zeph_core::bootstrap::create_mcp_manager(config, false));
+    let mcp_manager = std::sync::Arc::new(zeph_core::bootstrap::create_mcp_manager_with_vault(
+        config,
+        false,
+        app.age_vault_arc(),
+    ));
     let mcp_tools = mcp_manager.connect_all().await;
     let mcp_shared_tools = std::sync::Arc::new(std::sync::RwLock::new(mcp_tools.clone()));
     let mcp_executor =

--- a/src/init.rs
+++ b/src/init.rs
@@ -6,9 +6,9 @@ use std::path::PathBuf;
 use dialoguer::{Confirm, Input, Password, Select};
 use zeph_core::config::{
     AcpConfig, CascadeConfig, CloudLlmConfig, CompatibleConfig, Config, DiscordConfig, LlmConfig,
-    McpServerConfig, MemoryConfig, OrchestrationConfig, OrchestratorConfig,
-    OrchestratorProviderConfig, ProviderKind, PruningStrategy, RouterConfig, RouterStrategyConfig,
-    SemanticConfig, SessionsConfig, SlackConfig, TelegramConfig, VaultConfig,
+    McpOAuthConfig, McpServerConfig, MemoryConfig, OAuthTokenStorage, OrchestrationConfig,
+    OrchestratorConfig, OrchestratorProviderConfig, ProviderKind, PruningStrategy, RouterConfig,
+    RouterStrategyConfig, SemanticConfig, SessionsConfig, SlackConfig, TelegramConfig, VaultConfig,
 };
 use zeph_core::subagent::def::{MemoryScope, PermissionMode};
 use zeph_llm::{GeminiThinkingLevel, ThinkingConfig, ThinkingEffort};
@@ -107,6 +107,8 @@ pub(crate) struct WizardState {
     // LSP code intelligence via mcpls
     pub(crate) mcpls_enabled: bool,
     pub(crate) mcpls_workspace_roots: Vec<String>,
+    // Remote MCP servers with OAuth or static headers
+    pub(crate) mcp_remote_servers: Vec<McpServerConfig>,
     // LSP context injection
     pub(crate) lsp_context_enabled: bool,
     pub(crate) soft_compaction_threshold: f32,
@@ -224,6 +226,7 @@ impl Default for WizardState {
             server_compaction_enabled: false,
             mcpls_enabled: false,
             mcpls_workspace_roots: Vec::new(),
+            mcp_remote_servers: Vec::new(),
             lsp_context_enabled: false,
             // Valid sentinel values so WizardState is usable outside run() without
             // out-of-range values; run() initialises these to the same values explicitly.
@@ -306,6 +309,7 @@ pub fn run(output: Option<PathBuf>) -> anyhow::Result<()> {
     step_daemon(&mut state)?;
     step_acp(&mut state)?;
     step_mcpls(&mut state)?;
+    step_mcp_remote(&mut state)?;
     step_lsp_context(&mut state)?;
     step_agents(&mut state)?;
     step_router(&mut state)?;
@@ -1197,9 +1201,14 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
             args: vec!["--config".to_owned(), ".zeph/mcpls.toml".to_owned()],
             env: std::collections::HashMap::new(),
             url: None,
+            headers: std::collections::HashMap::new(),
+            oauth: None,
             timeout: 60,
             policy: zeph_mcp::McpPolicy::default(),
         });
+    }
+    for server in state.mcp_remote_servers.clone() {
+        config.mcp.servers.push(server);
     }
 
     if state.experiments_enabled {
@@ -1559,6 +1568,112 @@ file_patterns = ["**/*.rs"]
     std::fs::write(&mcpls_path, content)?;
     println!("mcpls config written to {}", mcpls_path.display());
 
+    Ok(())
+}
+
+fn step_mcp_remote(state: &mut WizardState) -> anyhow::Result<()> {
+    println!("== MCP: Remote Servers ==\n");
+    println!(
+        "Configure remote MCP servers that require authentication (static headers or OAuth 2.1)."
+    );
+    println!("Skip this step if you have no remote MCP servers.\n");
+
+    loop {
+        let add = Confirm::new()
+            .with_prompt("Add a remote MCP server?")
+            .default(false)
+            .interact()?;
+        if !add {
+            break;
+        }
+
+        let id: String = Input::new()
+            .with_prompt("Server ID (unique slug, e.g. 'todoist')")
+            .interact_text()?;
+        let url: String = Input::new()
+            .with_prompt("Server URL (e.g. https://mcp.example.com)")
+            .interact_text()?;
+
+        let auth_choices = [
+            "None (no auth)",
+            "Static header (Bearer token)",
+            "OAuth 2.1 (interactive flow)",
+        ];
+        let auth_sel = Select::new()
+            .with_prompt("Authentication method")
+            .items(auth_choices)
+            .default(0)
+            .interact()?;
+
+        let mut headers = std::collections::HashMap::new();
+        let mut oauth: Option<McpOAuthConfig> = None;
+
+        match auth_sel {
+            1 => {
+                println!("Header value supports vault references: ${{VAULT_KEY}}");
+                let header_name: String = Input::new()
+                    .with_prompt("Header name")
+                    .default("Authorization".into())
+                    .interact_text()?;
+                let header_value: String = Input::new()
+                    .with_prompt("Header value (e.g. 'Bearer ${{MY_TOKEN}}')")
+                    .interact_text()?;
+                headers.insert(header_name, header_value);
+            }
+            2 => {
+                let storage_choices =
+                    ["vault (persisted in age vault)", "memory (lost on restart)"];
+                let storage_sel = Select::new()
+                    .with_prompt("Token storage")
+                    .items(storage_choices)
+                    .default(0)
+                    .interact()?;
+                let token_storage = if storage_sel == 0 {
+                    OAuthTokenStorage::Vault
+                } else {
+                    OAuthTokenStorage::Memory
+                };
+                let scopes_raw: String = Input::new()
+                    .with_prompt("OAuth scopes (space-separated, leave empty for server default)")
+                    .default(String::new())
+                    .interact_text()?;
+                let scopes: Vec<String> =
+                    scopes_raw.split_whitespace().map(str::to_owned).collect();
+                let callback_port: u16 = Input::new()
+                    .with_prompt("Local callback port (0 = auto-assign)")
+                    .default(18766)
+                    .interact_text()?;
+                let client_name: String = Input::new()
+                    .with_prompt("OAuth client name")
+                    .default("Zeph".into())
+                    .interact_text()?;
+                oauth = Some(McpOAuthConfig {
+                    enabled: true,
+                    token_storage,
+                    scopes,
+                    callback_port,
+                    client_name,
+                });
+            }
+            _ => {}
+        }
+
+        state.mcp_remote_servers.push(McpServerConfig {
+            id,
+            command: None,
+            args: Vec::new(),
+            env: std::collections::HashMap::new(),
+            url: Some(url),
+            timeout: 30,
+            policy: zeph_mcp::McpPolicy::default(),
+            headers,
+            oauth,
+        });
+
+        println!("Server added.");
+    }
+
+    println!();
     Ok(())
 }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -505,7 +505,9 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             config,
             permission_policy.clone(),
             with_tool_events,
-            suppress_mcp_stderr
+            suppress_mcp_stderr,
+            app.age_vault_arc(),
+            Some(agent_status_tx.clone()),
         ),
     );
     let memory = std::sync::Arc::new(memory_result?);


### PR DESCRIPTION
## Summary

Resolves #1930 — adds authentication support for remote MCP HTTP servers:

- **Static headers**: arbitrary request headers with vault reference resolution for `Bearer ${TOKEN}` patterns
- **OAuth 2.1 with PKCE**: full authorization code flow with local callback server (`127.0.0.1:18766`), `VaultCredentialStore` backed by age vault for token persistence across sessions, and proactive token refresh

## Key design decisions

- Pre-bind `TcpListener` before `register_client()` to resolve redirect_uri port (avoids chicken-and-egg)
- TCP callback reads buffered until `\r\n\r\n` to handle packet fragmentation
- All discovered OAuth metadata endpoints validated via SSRF guard
- Two-phase `connect_all()`: non-OAuth servers concurrent (phase 1), OAuth deferred (phase 2)
- `headers` and `oauth.enabled` are mutually exclusive per server (validated at config load)
- Vault key pattern: `mcp.oauth.{server_id}.{access_token,refresh_token,expires_at}`

## New config

```toml
# Mode A: static Bearer token
[[mcp.servers]]
id = "todoist"
url = "https://api.todoist.com/mcp/v1"
[mcp.servers.headers]
Authorization = "Bearer ${TODOIST_API_TOKEN}"

# Mode B: OAuth 2.1
[[mcp.servers]]
id = "todoist-oauth"
url = "https://ai.todoist.net/mcp"
[mcp.servers.oauth]
enabled = true
token_storage = "vault"
callback_port = 18766
```

## Known limitations

- Telegram OAuth URL delivery goes to stderr (not a native bot message) — tracked as follow-up
- `StoredCredentials` token zeroization is an upstream rmcp limitation (accepted risk, vault at-rest encrypted)

## Test plan

- [x] 6117 tests pass (`cargo nextest run --workspace --features full --lib --bins`)
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy --workspace --features full -- -D warnings` clean
- [x] Unit tests: `McpOAuthConfig` deserialization, `OAuthTokenStorage` serde, `Config::validate()` mutual exclusion, vault key collision detection, `validate_oauth_metadata_urls()` SSRF fan-out