### PR TITLE
fix(vault): replace blocking_read with block_in_place in ArcAgeVaultProvider

### DIFF
--- a/crates/zeph-core/src/vault.rs
+++ b/crates/zeph-core/src/vault.rs
@@ -394,8 +394,10 @@ impl VaultProvider for ArcAgeVaultProvider {
     }
 
     fn list_keys(&self) -> Vec<String> {
-        // Blocking read is acceptable here: list_keys is only called at startup.
-        let guard = self.0.blocking_read();
+        // block_in_place is required because list_keys is a sync trait method that may be called
+        // from within a tokio async context (e.g. resolve_secrets). blocking_read() panics there.
+        let arc = Arc::clone(&self.0);
+        let guard = tokio::task::block_in_place(|| arc.blocking_read());
         let mut keys: Vec<String> = guard.list_keys().iter().map(|s| (*s).to_owned()).collect();
         keys.sort_unstable();
         keys


### PR DESCRIPTION
## Summary

- `ArcAgeVaultProvider::list_keys()` called `blocking_read()` on a `tokio::sync::RwLock`, which panics when invoked from within an async runtime
- `list_keys()` is a synchronous trait method called inside `async fn resolve_secrets()`, making the panic reproducible on every TUI startup with `vault.backend = "age"`
- Replaced `blocking_read()` with `tokio::task::block_in_place(|| arc.blocking_read())` so tokio can reschedule other tasks while the thread is held

## Test plan

- [ ] `cargo +nightly fmt --check` — passed
- [ ] `cargo clippy --workspace --features full -- -D warnings` — passed
- [ ] `cargo nextest run --workspace --features full --lib --bins` — 6117 passed
- [ ] `zeph --config .local/config/cloud.toml --tui` — no longer panics at startup