### PR TITLE
fix: update config snapshot version to 0.15.3

### DIFF
--- a/crates/zeph-core/src/config/types/tests/snapshots/zeph_core__config__types__tests__config_default_snapshot_no_lsp_context.snap
+++ b/crates/zeph-core/src/config/types/tests/snapshots/zeph_core__config__types__tests__config_default_snapshot_no_lsp_context.snap
@@ -354,7 +354,7 @@ show_source_labels = false
 [acp]
 enabled = false
 agent_name = "zeph"
-agent_version = "0.15.2"
+agent_version = "0.15.3"
 max_sessions = 4
 session_idle_timeout_secs = 1800
 broadcast_capacity = 256


### PR DESCRIPTION
## Summary
- Update config snapshot test expectations to match v0.15.3
- Fixes Windows CI test failure: `config_default_snapshot`

## Root Cause
The snapshot was generated with version 0.15.2, but the current version in Cargo.toml is 0.15.3. The snapshot test serializes the default config which includes the agent version, causing the test to fail on version mismatch.

## Test Plan
- ✅ Snapshot test passes locally: `cargo test -p zeph-core config_default_snapshot --lib`
- ✅ All tests pass: 5624 passed, 12 skipped
- ✅ Formatting check passed: `cargo +nightly fmt --check`
- ✅ Linting passed: `cargo clippy --workspace --features full -- -D warnings`