### PR TITLE
fix: Windows OpenAI test regression — StructuredApiMessage content Option<String>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(llm): OpenAI API 400 Bad Request on skill documentation queries (closes #1952)
+  - Root cause: `StructuredApiMessage.content` was `String` instead of `Option<String>`. When LLM called tools without preceding text, empty string `""` was serialized alongside `tool_calls`, but OpenAI API requires `null` (or absent) for messages with `tool_calls`
+  - Changed `content: String` → `content: Option<String>` with `#[serde(skip_serializing_if = "Option::is_none")]`
+  - Updated `convert_messages_structured` to emit `None` when text content is empty
+  - Fixed tool `arguments` JSON fallback: `unwrap_or_default()` → `unwrap_or_else(|_| "{}".to_owned())`
+  - All StructuredApiMessage creation sites updated to wrap content in Some()
+  - Added regression test: `convert_messages_structured_assistant_tool_only_content_is_none`
+  - Enhanced test coverage: explicit content assertions in `convert_messages_structured_with_tool_parts` to catch regressions on Windows and other platforms
+  - Error was intermittent because it only manifested when prior assistant turns had tool_calls without text and survived compression cycles
+
 ## [0.15.3] - 2026-03-17
 
 ### Fixed

--- a/crates/zeph-llm/src/openai.rs
+++ b/crates/zeph-llm/src/openai.rs
@@ -989,7 +989,8 @@ struct ToolChatRequest<'a> {
 #[derive(Serialize)]
 struct StructuredApiMessage {
     role: String,
-    content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tool_calls: Option<Vec<OpenAiToolCallOut>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1083,7 +1084,8 @@ fn convert_messages_structured(messages: &[Message]) -> Vec<StructuredApiMessage
                             r#type: "function".to_owned(),
                             function: OpenAiFunctionCall {
                                 name: name.clone(),
-                                arguments: serde_json::to_string(input).unwrap_or_default(),
+                                arguments: serde_json::to_string(input)
+                                    .unwrap_or_else(|_| "{}".to_owned()),
                             },
                         }),
                         _ => None,
@@ -1092,7 +1094,11 @@ fn convert_messages_structured(messages: &[Message]) -> Vec<StructuredApiMessage
 
                 result.push(StructuredApiMessage {
                     role: "assistant".to_owned(),
-                    content: text_content,
+                    content: if text_content.is_empty() {
+                        None
+                    } else {
+                        Some(text_content)
+                    },
                     tool_calls: if tool_calls.is_empty() {
                         None
                     } else {
@@ -1111,7 +1117,7 @@ fn convert_messages_structured(messages: &[Message]) -> Vec<StructuredApiMessage
                         } => {
                             result.push(StructuredApiMessage {
                                 role: "tool".to_owned(),
-                                content: content.clone(),
+                                content: Some(content.clone()),
                                 tool_calls: None,
                                 tool_call_id: Some(tool_use_id.clone()),
                             });
@@ -1119,7 +1125,7 @@ fn convert_messages_structured(messages: &[Message]) -> Vec<StructuredApiMessage
                         MessagePart::Text { text } if !text.is_empty() => {
                             result.push(StructuredApiMessage {
                                 role: "user".to_owned(),
-                                content: text.clone(),
+                                content: Some(text.clone()),
                                 tool_calls: None,
                                 tool_call_id: None,
                             });
@@ -1136,7 +1142,7 @@ fn convert_messages_structured(messages: &[Message]) -> Vec<StructuredApiMessage
             };
             result.push(StructuredApiMessage {
                 role: role.to_owned(),
-                content: msg.to_llm_content().to_owned(),
+                content: Some(msg.to_llm_content().to_owned()),
                 tool_calls: None,
                 tool_call_id: None,
             });
@@ -1618,7 +1624,7 @@ mod tests {
     fn tool_chat_request_serialization_uses_gpt5_completion_tokens() {
         let msgs = [StructuredApiMessage {
             role: "user".to_owned(),
-            content: "hello".to_owned(),
+            content: Some("hello".to_owned()),
             tool_calls: None,
             tool_call_id: None,
         }];
@@ -2063,8 +2069,10 @@ mod tests {
         let result = convert_messages_structured(&messages);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].role, "assistant");
+        assert_eq!(result[0].content.as_deref(), Some("Running command"));
         assert!(result[0].tool_calls.is_some());
         assert_eq!(result[1].role, "tool");
+        assert_eq!(result[1].content.as_deref(), Some("file1.rs"));
         assert_eq!(result[1].tool_call_id.as_deref(), Some("call_1"));
     }
 
@@ -2074,8 +2082,30 @@ mod tests {
         let result = convert_messages_structured(&messages);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].role, "user");
-        assert_eq!(result[0].content, "hello");
+        assert_eq!(result[0].content.as_deref(), Some("hello"));
         assert!(result[0].tool_calls.is_none());
+    }
+
+    #[test]
+    fn convert_messages_structured_assistant_tool_only_content_is_none() {
+        // When assistant message has tool_calls but no text, content must be None (not "")
+        // OpenAI API rejects "content": "" combined with "tool_calls" with HTTP 400
+        let messages = vec![Message::from_parts(
+            Role::Assistant,
+            vec![MessagePart::ToolUse {
+                id: "call_1".into(),
+                name: "bash".into(),
+                input: serde_json::json!({"command": "ls"}),
+            }],
+        )];
+        let result = convert_messages_structured(&messages);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].role, "assistant");
+        assert!(
+            result[0].content.is_none(),
+            "content must be None (not \"\") for tool-only assistant messages"
+        );
+        assert!(result[0].tool_calls.is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the Windows CI test failure for OpenAI provider by ensuring all `StructuredApiMessage` creation sites properly wrap content in `Some()` and adding comprehensive test coverage to catch similar regressions.

## Changes

- Updated all `StructuredApiMessage` creation sites in `convert_messages_structured()` to wrap content values in `Some()`
- When assistant messages have tool calls but no text, content is now set to `None` (not empty string) — OpenAI API requires this
- Fixed `tool_arguments` JSON fallback: `unwrap_or_default()` → `unwrap_or_else(|_| "{}".to_owned())` for better error handling
- Enhanced test assertions in `convert_messages_structured_with_tool_parts` to explicitly verify content values
- Updated test comparisons to use `as_deref()` for `Option<String>` assertions

## Test Plan

- ✅ All 94 openai tests pass
- ✅ All 5625 workspace tests pass
- ✅ Clippy clean (no warnings)
- ✅ Formatting check passes

## Related Issues

Fixes test failure in Windows CI: https://github.com/bug-ops/zeph/actions/runs/23218939946/job/67487879275