### PR TITLE
fix(tests): normalize TOML quote style for cross-platform snapshot consistency

### DIFF
--- a/crates/zeph-core/src/config/types/tests/mod.rs
+++ b/crates/zeph-core/src/config/types/tests/mod.rs
@@ -21,6 +21,21 @@ fn normalize_runtime_paths_for_snapshot(mut toml: String) -> String {
         toml = toml.replace(&actual.replace('\\', "\\\\"), &placeholder);
         toml = toml.replace(&actual, &placeholder);
     }
+
+    // TOML may use single quotes for Windows paths containing backslashes.
+    // After replacement, normalize single-quoted placeholders to double quotes
+    // so snapshots are consistent across platforms.
+    for placeholder in [
+        "<DEFAULT_SKILLS_DIR>",
+        "<DEFAULT_SQLITE_PATH>",
+        "<DEFAULT_DEBUG_DIR>",
+        "<DEFAULT_LOG_FILE>",
+    ] {
+        let single = format!("'{placeholder}'");
+        let double = format!("\"{placeholder}\"");
+        toml = toml.replace(&single, &double);
+    }
+
     toml
 }
 


### PR DESCRIPTION
## Summary

Fixes Windows snapshot test failure (#1957) caused by TOML quote style mismatch.

On Windows, the TOML serializer uses single quotes for paths containing backslashes (literal strings). After test normalization replaced path values with placeholders, the single quotes were preserved, creating snapshot mismatches when comparing with Unix snapshots (which use double quotes).

## Changes

- Modified `normalize_runtime_paths_for_snapshot()` in `crates/zeph-core/src/config/types/tests/mod.rs`
- Added post-processing step to normalize single-quoted placeholders to double quotes
- Affects 4 paths: skills.paths, memory.sqlite_path, debug.output_dir, logging.file

## Testing

- ✅ `config_default_snapshot` test passes
- ✅ All 265 config tests pass (zero regressions)
- ✅ No snapshot files modified
- ✅ Cross-platform verified (no-op on Unix)

## Related

- Fixes #1957
- Related to snapshot test infrastructure