### PR TITLE
refactor(epic-1974): improve type safety - CompactionState, BoxFuture, schema helper

### DIFF
--- a/crates/zeph-core/src/agent/context/summarization.rs
+++ b/crates/zeph-core/src/agent/context/summarization.rs
@@ -1398,19 +1398,23 @@ impl<C: Channel> Agent<C> {
         }
 
         // Guard 3 — Exhaustion: stop compaction permanently when it cannot reduce context.
-        if self.context_manager.compaction_exhausted {
-            if !self.context_manager.exhaustion_warned {
-                self.context_manager.exhaustion_warned = true;
-                tracing::warn!("compaction exhausted: context budget too tight for this session");
-                let _ = self
-                    .channel
-                    .send(
-                        "Warning: context budget is too tight — compaction cannot free enough \
-                         space. Consider increasing [memory] context_budget_tokens or starting \
-                         a new session.",
-                    )
-                    .await;
-            }
+        // One-shot warning: flip warned → true on first visit, no-op on subsequent calls.
+        if let crate::agent::context_manager::CompactionState::Exhausted { ref mut warned } =
+            self.context_manager.compaction
+            && !*warned
+        {
+            *warned = true;
+            tracing::warn!("compaction exhausted: context budget too tight for this session");
+            let _ = self
+                .channel
+                .send(
+                    "Warning: context budget is too tight — compaction cannot free enough \
+                     space. Consider increasing [memory] context_budget_tokens or starting \
+                     a new session.",
+                )
+                .await;
+        }
+        if self.context_manager.compaction.is_exhausted() {
             return Ok(());
         }
 
@@ -1443,14 +1447,24 @@ impl<C: Channel> Agent<C> {
             }
         }
         // Skip if hard compaction already ran this turn (CRIT-03).
-        if self.context_manager.compacted_this_turn {
+        if self.context_manager.compaction.is_compacted_this_turn() {
             return Ok(());
         }
         // Guard 1 — Cooldown: skip Hard-tier LLM compaction for N turns after the last successful
         // compaction. Soft compaction (pruning only) is still allowed during cooldown.
-        let in_cooldown = self.context_manager.compaction_turns_since > 0;
+        let in_cooldown = self.context_manager.compaction.cooldown_remaining() > 0;
         if in_cooldown {
-            self.context_manager.compaction_turns_since -= 1;
+            // Decrement the Cooling counter in place.
+            if let crate::agent::context_manager::CompactionState::Cooling {
+                ref mut turns_remaining,
+            } = self.context_manager.compaction
+            {
+                *turns_remaining -= 1;
+                if *turns_remaining == 0 {
+                    self.context_manager.compaction =
+                        crate::agent::context_manager::CompactionState::Ready;
+                }
+            }
         }
 
         match self.compaction_tier() {
@@ -1509,7 +1523,7 @@ impl<C: Channel> Agent<C> {
                 // Cooldown guard: skip LLM summarization while cooling down.
                 if in_cooldown {
                     tracing::debug!(
-                        turns_remaining = self.context_manager.compaction_turns_since,
+                        turns_remaining = self.context_manager.compaction.cooldown_remaining(),
                         "hard compaction skipped: cooldown active"
                     );
                     return Ok(());
@@ -1535,9 +1549,10 @@ impl<C: Channel> Agent<C> {
                 let freed = self.prune_tool_outputs(min_to_free);
                 if freed >= min_to_free {
                     tracing::info!(freed, "hard compaction: pruning sufficient");
-                    self.context_manager.compacted_this_turn = true;
-                    self.context_manager.compaction_turns_since =
-                        self.context_manager.compaction_cooldown_turns;
+                    self.context_manager.compaction =
+                        crate::agent::context_manager::CompactionState::CompactedThisTurn {
+                            cooldown: self.context_manager.compaction_cooldown_turns,
+                        };
                     let _ = self.channel.send_status("").await;
                     return Ok(());
                 }
@@ -1551,7 +1566,9 @@ impl<C: Channel> Agent<C> {
                         compactable,
                         "hard compaction: too few messages to compact, marking exhausted"
                     );
-                    self.context_manager.compaction_exhausted = true;
+                    // Only reachable from Ready state (Cooling is guarded by in_cooldown above).
+                    self.context_manager.compaction =
+                        crate::agent::context_manager::CompactionState::Exhausted { warned: false };
                     let _ = self.channel.send_status("").await;
                     return Ok(());
                 }
@@ -1574,7 +1591,11 @@ impl<C: Channel> Agent<C> {
                             "hard compaction: summary consumed all freed tokens — no net \
                              reduction, marking exhausted"
                         );
-                        self.context_manager.compaction_exhausted = true;
+                        // Only reachable from Ready state (Cooling is guarded by in_cooldown).
+                        self.context_manager.compaction =
+                            crate::agent::context_manager::CompactionState::Exhausted {
+                                warned: false,
+                            };
                         let _ = self.channel.send_status("").await;
                         return result;
                     }
@@ -1586,13 +1607,18 @@ impl<C: Channel> Agent<C> {
                             "hard compaction: context still above hard threshold after \
                              compaction, marking exhausted"
                         );
-                        self.context_manager.compaction_exhausted = true;
+                        // Only reachable from Ready state (Cooling is guarded by in_cooldown).
+                        self.context_manager.compaction =
+                            crate::agent::context_manager::CompactionState::Exhausted {
+                                warned: false,
+                            };
                         let _ = self.channel.send_status("").await;
                         return result;
                     }
-                    self.context_manager.compacted_this_turn = true;
-                    self.context_manager.compaction_turns_since =
-                        self.context_manager.compaction_cooldown_turns;
+                    self.context_manager.compaction =
+                        crate::agent::context_manager::CompactionState::CompactedThisTurn {
+                            cooldown: self.context_manager.compaction_cooldown_turns,
+                        };
                 }
                 let _ = self.channel.send_status("").await;
                 result
@@ -1613,7 +1639,7 @@ impl<C: Channel> Agent<C> {
         clippy::cast_sign_loss
     )]
     pub(in crate::agent) fn maybe_soft_compact_mid_iteration(&mut self) {
-        if self.context_manager.compacted_this_turn {
+        if self.context_manager.compaction.is_compacted_this_turn() {
             return;
         }
         if !matches!(
@@ -1692,7 +1718,9 @@ impl<C: Channel> Agent<C> {
             .await;
 
         if result.is_ok() {
-            self.context_manager.compacted_this_turn = true;
+            // Proactive compression does not impose a post-compaction cooldown.
+            self.context_manager.compaction =
+                crate::agent::context_manager::CompactionState::CompactedThisTurn { cooldown: 0 };
             let tokens_saved = tokens_before.saturating_sub(self.providers.cached_prompt_tokens);
             self.update_metrics(|m| {
                 m.compression_events += 1;

--- a/crates/zeph-core/src/agent/context/tests.rs
+++ b/crates/zeph-core/src/agent/context/tests.rs
@@ -11,7 +11,7 @@ use zeph_skills::loader::SkillMeta;
 use super::*;
 #[allow(clippy::wildcard_imports)]
 use crate::agent::agent_tests::*;
-use crate::agent::context_manager::CompactionTier;
+use crate::agent::context_manager::{CompactionState, CompactionTier};
 use crate::agent::state::MemoryState;
 
 #[test]
@@ -2811,17 +2811,17 @@ async fn compacted_this_turn_reset_between_turns() {
 
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
 
-    // Manually set the flag as if proactive compression fired
-    agent.context_manager.compacted_this_turn = true;
+    // Manually set state as if proactive compression fired
+    agent.context_manager.compaction = CompactionState::CompactedThisTurn { cooldown: 0 };
 
-    // Process a message — reset happens at turn start
+    // Process a message — advance_turn() resets state at turn start
     let _ = agent.process_user_message("first".to_owned(), vec![]).await;
 
-    // After turn, flag should have been reset (reset at start) and may have been
-    // set again only if proactive compression fired. Since threshold is reactive
-    // by default, flag should be false after turn (no proactive).
+    // After turn, state should have been reset (via advance_turn at start) and may
+    // have been set again only if proactive compression fired. Since threshold is
+    // reactive by default, state should be Ready after turn (no proactive).
     // We can't inspect mid-turn, but we can check the default config doesn't trigger.
-    assert!(!agent.context_manager.compacted_this_turn);
+    assert!(!agent.context_manager.compaction.is_compacted_this_turn());
 }
 
 #[tokio::test]
@@ -2838,7 +2838,7 @@ async fn maybe_proactive_compress_does_not_fire_with_reactive_strategy() {
     // should_proactively_compress returns None for Reactive → no compression
     let result = agent.maybe_proactive_compress().await;
     assert!(result.is_ok());
-    assert!(!agent.context_manager.compacted_this_turn);
+    assert!(!agent.context_manager.compaction.is_compacted_this_turn());
 }
 
 // BudgetAllocation.graph_facts tests
@@ -3422,10 +3422,10 @@ fn tier0_does_not_set_compacted_this_turn() {
     // Simulate token usage above 70% soft threshold
     agent.providers.cached_prompt_tokens = 75_000;
 
-    assert!(!agent.context_manager.compacted_this_turn);
+    assert!(!agent.context_manager.compaction.is_compacted_this_turn());
     agent.maybe_apply_deferred_summaries();
     assert!(
-        !agent.context_manager.compacted_this_turn,
+        !agent.context_manager.compaction.is_compacted_this_turn(),
         "tier-0 must not set compacted_this_turn"
     );
 }
@@ -3608,7 +3608,7 @@ fn remove_lsp_messages_removes_lsp_system_keeps_others() {
 
 // --- Compaction guard tests (issue #1708) ---
 
-// Cooldown guard: compaction_turns_since counts down and blocks compaction.
+// Cooldown guard: cooling turns_remaining counts down and blocks compaction.
 #[tokio::test]
 async fn cooldown_guard_decrements_and_skips_compaction() {
     let provider = mock_provider(vec!["summary".to_string()]);
@@ -3622,8 +3622,8 @@ async fn cooldown_guard_decrements_and_skips_compaction() {
         .with_compaction_cooldown(2)
         .with_metrics(tx);
 
-    // Manually set cooldown counter as if compaction just fired.
-    agent.context_manager.compaction_turns_since = 2;
+    // Manually set cooling state as if compaction just fired and turn advanced.
+    agent.context_manager.compaction = CompactionState::Cooling { turns_remaining: 2 };
 
     // Push enough tokens to trigger compaction threshold.
     for i in 0..10 {
@@ -3635,14 +3635,14 @@ async fn cooldown_guard_decrements_and_skips_compaction() {
         });
     }
 
-    // First call: turns_since = 2 → skips, decrements to 1. No compaction fired.
+    // First call: turns_remaining = 2 → skips, decrements to 1. No compaction fired.
     agent.maybe_compact().await.unwrap();
-    assert_eq!(agent.context_manager.compaction_turns_since, 1);
+    assert_eq!(agent.context_manager.compaction.cooldown_remaining(), 1);
     assert_eq!(rx.borrow().context_compactions, 0);
 
-    // Second call: turns_since = 1 → skips, decrements to 0. No compaction fired.
+    // Second call: turns_remaining = 1 → skips, decrements to 0 → transitions to Ready.
     agent.maybe_compact().await.unwrap();
-    assert_eq!(agent.context_manager.compaction_turns_since, 0);
+    assert_eq!(agent.context_manager.compaction.cooldown_remaining(), 0);
     assert_eq!(rx.borrow().context_compactions, 0);
 }
 
@@ -3660,8 +3660,8 @@ async fn cooldown_guard_fires_after_expiry_and_resets_counter() {
         .with_compaction_cooldown(2)
         .with_metrics(tx);
 
-    // turns_since = 0 means cooldown has already expired.
-    agent.context_manager.compaction_turns_since = 0;
+    // Ready state means cooldown has already expired.
+    assert_eq!(agent.context_manager.compaction, CompactionState::Ready);
 
     for i in 0..10 {
         agent.msg.messages.push(Message {
@@ -3683,7 +3683,7 @@ async fn cooldown_guard_fires_after_expiry_and_resets_counter() {
     assert_eq!(rx.borrow().context_compactions, 1);
     // After compaction the system prompt alone exceeds the tiny 100-token budget, so
     // Guard 3 marks exhaustion (still above threshold). Cooldown is not reset — correct.
-    assert!(agent.context_manager.compaction_exhausted);
+    assert!(agent.context_manager.compaction.is_exhausted());
 }
 
 // Exhaustion guard: when compaction_exhausted is set, maybe_compact returns early.
@@ -3699,7 +3699,7 @@ async fn exhaustion_guard_skips_compaction_when_exhausted() {
         .with_context_budget(100, 0.20, 0.75, 2, 0)
         .with_metrics(tx);
 
-    agent.context_manager.compaction_exhausted = true;
+    agent.context_manager.compaction = CompactionState::Exhausted { warned: false };
 
     for i in 0..10 {
         agent.msg.messages.push(Message {
@@ -3727,7 +3727,7 @@ async fn exhaustion_guard_warned_flag_set_once() {
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
         .with_context_budget(100, 0.20, 0.75, 2, 0);
 
-    agent.context_manager.compaction_exhausted = true;
+    agent.context_manager.compaction = CompactionState::Exhausted { warned: false };
 
     for i in 0..5 {
         agent.msg.messages.push(Message {
@@ -3738,14 +3738,23 @@ async fn exhaustion_guard_warned_flag_set_once() {
         });
     }
 
-    // First call: warning not yet sent → flag set.
-    assert!(!agent.context_manager.exhaustion_warned);
+    // First call: warning not yet sent → warned flipped to true.
+    assert!(matches!(
+        agent.context_manager.compaction,
+        CompactionState::Exhausted { warned: false }
+    ));
     agent.maybe_compact().await.unwrap();
-    assert!(agent.context_manager.exhaustion_warned);
+    assert!(matches!(
+        agent.context_manager.compaction,
+        CompactionState::Exhausted { warned: true }
+    ));
 
-    // Second call: flag already set, no state change.
+    // Second call: warned already set, no state change.
     agent.maybe_compact().await.unwrap();
-    assert!(agent.context_manager.exhaustion_warned);
+    assert!(matches!(
+        agent.context_manager.compaction,
+        CompactionState::Exhausted { warned: true }
+    ));
 }
 
 // Exhaustion guard fires before cooldown guard.
@@ -3763,9 +3772,9 @@ async fn exhaustion_guard_takes_precedence_over_cooldown() {
         .with_context_budget(100, 0.20, 0.75, 2, 0)
         .with_compaction_cooldown(2);
 
-    // Both exhaustion and cooldown set.
-    agent.context_manager.compaction_exhausted = true;
-    agent.context_manager.compaction_turns_since = 2;
+    // Exhausted state (the Cooling state would normally guard against exhaustion, but
+    // we test the ordering guarantee that exhaustion check happens before cooldown decrement).
+    agent.context_manager.compaction = CompactionState::Exhausted { warned: false };
 
     for i in 0..10 {
         agent.msg.messages.push(Message {
@@ -3778,8 +3787,8 @@ async fn exhaustion_guard_takes_precedence_over_cooldown() {
 
     agent.maybe_compact().await.unwrap();
 
-    // Cooldown counter must NOT have been decremented — exhaustion guard returned first.
-    assert_eq!(agent.context_manager.compaction_turns_since, 2);
+    // State must remain Exhausted — exhaustion guard returned before cooldown decrement.
+    assert!(agent.context_manager.compaction.is_exhausted());
     // No "compacting context..." status emitted.
     assert!(
         !statuses
@@ -3822,7 +3831,7 @@ async fn counterproductive_guard_sets_exhausted_when_too_few_messages() {
     agent.maybe_compact().await.unwrap();
 
     // Counterproductive guard: compactable ≤ 1 → exhausted set.
-    assert!(agent.context_manager.compaction_exhausted);
+    assert!(agent.context_manager.compaction.is_exhausted());
 }
 
 // Default value for compaction_cooldown_turns is 2.
@@ -3830,9 +3839,7 @@ async fn counterproductive_guard_sets_exhausted_when_too_few_messages() {
 fn context_manager_defaults_have_compaction_guard_fields() {
     let cm = crate::agent::context_manager::ContextManager::new();
     assert_eq!(cm.compaction_cooldown_turns, 2);
-    assert_eq!(cm.compaction_turns_since, 0);
-    assert!(!cm.compaction_exhausted);
-    assert!(!cm.exhaustion_warned);
+    assert_eq!(cm.compaction, CompactionState::Ready);
 }
 
 // with_compaction_cooldown builder sets the cooldown turns field.
@@ -3896,10 +3903,10 @@ async fn compaction_turns_after_hard_tracks_segments() {
     // turns_since_last_hard_compaction is now Some(0).
 
     // Simulate 3 turns where context is below threshold.
-    // Reset per-turn guard (done by handle_message at the start of each turn).
+    // Reset per-turn state (done by advance_turn at the start of each turn).
     agent.providers.cached_prompt_tokens = 0;
     for _ in 0..3 {
-        agent.context_manager.compacted_this_turn = false;
+        agent.context_manager.compaction = agent.context_manager.compaction.advance_turn();
         agent.maybe_compact().await.unwrap();
     }
     // turns_since_last_hard_compaction is now Some(3).
@@ -3931,7 +3938,7 @@ async fn compaction_turn_counter_increments_before_exhaustion_guard() {
 
     // Manually set tracking active and exhaust compaction.
     agent.context_manager.turns_since_last_hard_compaction = Some(0);
-    agent.context_manager.compaction_exhausted = true;
+    agent.context_manager.compaction = CompactionState::Exhausted { warned: false };
 
     // Call maybe_compact — early return via exhaustion guard.
     agent.maybe_compact().await.unwrap();
@@ -3961,7 +3968,7 @@ fn mid_iteration_skips_when_compacted_this_turn() {
     // Simulate token pressure above soft threshold
     agent.providers.cached_prompt_tokens = 75_000;
     // Mark hard compaction already ran this turn
-    agent.context_manager.compacted_this_turn = true;
+    agent.context_manager.compaction = CompactionState::CompactedThisTurn { cooldown: 2 };
 
     agent.maybe_soft_compact_mid_iteration();
 
@@ -4047,10 +4054,10 @@ fn mid_iteration_does_not_set_compacted_this_turn() {
     make_tool_pair_with_output(&mut agent, "a");
     agent.providers.cached_prompt_tokens = 75_000;
 
-    assert!(!agent.context_manager.compacted_this_turn);
+    assert!(!agent.context_manager.compaction.is_compacted_this_turn());
     agent.maybe_soft_compact_mid_iteration();
     assert!(
-        !agent.context_manager.compacted_this_turn,
+        !agent.context_manager.compaction.is_compacted_this_turn(),
         "maybe_soft_compact_mid_iteration must not set compacted_this_turn"
     );
 }
@@ -4083,9 +4090,9 @@ fn mid_iteration_fires_at_hard_tier() {
         summary_inserted,
         "deferred summaries must be applied even when tier is Hard"
     );
-    // compacted_this_turn must remain false (no LLM call, no Hard compaction)
+    // compaction state must remain unchanged (no LLM call, no Hard compaction)
     assert!(
-        !agent.context_manager.compacted_this_turn,
+        !agent.context_manager.compaction.is_compacted_this_turn(),
         "mid-iteration must not set compacted_this_turn even at Hard tier"
     );
 }

--- a/crates/zeph-core/src/agent/context_manager.rs
+++ b/crates/zeph-core/src/agent/context_manager.rs
@@ -4,6 +4,100 @@
 use crate::config::{CompressionConfig, RoutingConfig};
 use crate::context::ContextBudget;
 
+/// Lifecycle state of the compaction subsystem within a single session.
+///
+/// Replaces four independent boolean/u8 fields with an explicit state machine that makes
+/// invalid states unrepresentable (e.g., warned-without-exhausted).
+///
+/// # Transition map
+///
+/// ```text
+/// Ready
+///   → CompactedThisTurn { cooldown } when hard compaction succeeds (pruning or LLM)
+///   → CompactedThisTurn { cooldown: 0 } when focus truncation, eviction, or proactive
+///     compression fires (these callers do not want post-compaction cooldown)
+///   → Exhausted { warned: false } when compaction is counterproductive (too few messages,
+///     zero net freed tokens, or still above hard threshold after LLM compaction)
+///
+/// CompactedThisTurn { cooldown }
+///   → Cooling { turns_remaining: cooldown } when cooldown > 0  (via advance_turn)
+///   → Ready                                 when cooldown == 0 (via advance_turn)
+///
+/// Cooling { turns_remaining }
+///   → Cooling { turns_remaining - 1 } decremented inside maybe_compact each turn
+///   → Ready                           when turns_remaining reaches 0
+///   NOTE: Exhausted is NOT reachable from Cooling — all exhaustion-setting sites in
+///   summarization.rs are guarded by an early-return when in_cooldown is true.
+///
+/// Exhausted { warned: false }
+///   → Exhausted { warned: true } after the user warning is sent (one-shot)
+///
+/// Exhausted { warned: true }  (terminal — no further transitions)
+/// ```
+///
+/// `turns_since_last_hard_compaction` is a **metric counter**, not part of this state machine,
+/// and remains a separate field on `ContextManager`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CompactionState {
+    /// Normal state — compaction may fire if context exceeds thresholds.
+    Ready,
+    /// Hard compaction (or focus truncation / eviction / proactive compression) ran this turn.
+    /// No further compaction until `advance_turn()` is called at the next turn boundary.
+    /// `cooldown` carries the number of cooling turns to enforce after this turn ends.
+    CompactedThisTurn { cooldown: u8 },
+    /// Cooling down after a recent hard compaction. Hard tier is skipped; soft is still allowed.
+    /// Counter decrements inside `maybe_compact` each turn until it reaches 0.
+    Cooling { turns_remaining: u8 },
+    /// Compaction cannot reduce context further. No more attempts will be made.
+    /// `warned` tracks whether the one-shot user warning has been sent.
+    Exhausted { warned: bool },
+}
+
+impl CompactionState {
+    /// Whether hard compaction (or a compaction-equivalent operation) already ran this turn.
+    ///
+    /// When `true`, `maybe_compact`, `maybe_proactive_compress`, and
+    /// `maybe_soft_compact_mid_iteration` all skip execution (CRIT-03).
+    pub(crate) fn is_compacted_this_turn(self) -> bool {
+        matches!(self, Self::CompactedThisTurn { .. })
+    }
+
+    /// Whether compaction is permanently disabled for this session.
+    pub(crate) fn is_exhausted(self) -> bool {
+        matches!(self, Self::Exhausted { .. })
+    }
+
+    /// Remaining cooldown turns (0 when not in `Cooling` state).
+    pub(crate) fn cooldown_remaining(self) -> u8 {
+        match self {
+            Self::Cooling { turns_remaining } => turns_remaining,
+            _ => 0,
+        }
+    }
+
+    /// Transition to the next-turn state at the start of each user turn.
+    ///
+    /// **Must be called exactly once per turn, before any compaction, eviction, or
+    /// focus truncation can run.** This guarantees that `is_compacted_this_turn()`
+    /// returns `false` when the sidequest check at `mod.rs:3024` executes — preserving
+    /// the invariant that the sidequest only sees same-turn compaction set by eviction
+    /// at `mod.rs:4055`, which runs *after* this call.
+    ///
+    /// Transitions:
+    /// - `CompactedThisTurn { cooldown: 0 }` → `Ready`
+    /// - `CompactedThisTurn { cooldown: n }` → `Cooling { turns_remaining: n }`
+    /// - All other states are returned unchanged.
+    pub(crate) fn advance_turn(self) -> Self {
+        match self {
+            Self::CompactedThisTurn { cooldown } if cooldown > 0 => Self::Cooling {
+                turns_remaining: cooldown,
+            },
+            Self::CompactedThisTurn { .. } => Self::Ready,
+            other => other,
+        }
+    }
+}
+
 /// Indicates which compaction tier applies for the current context size.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CompactionTier {
@@ -27,19 +121,13 @@ pub(crate) struct ContextManager {
     pub(super) compression: CompressionConfig,
     /// Routing configuration for query-aware memory routing (#1162).
     pub(super) routing: RoutingConfig,
-    /// Set to `true` when compaction or proactive compression fires in the current turn.
-    /// Cleared at the start of each turn. Prevents double LLM summarization per turn (CRIT-03).
-    pub(super) compacted_this_turn: bool,
-    /// Number of turns to skip compaction after a successful compaction (cooldown guard).
-    /// Prevents compaction from re-triggering immediately when the summary itself is large.
+    /// Compaction lifecycle state. Replaces four independent boolean/u8 fields to make
+    /// invalid states unrepresentable. See [`CompactionState`] for the full transition map.
+    pub(super) compaction: CompactionState,
+    /// Number of cooling turns to enforce after a successful hard compaction.
+    /// This is configuration, not state — it is read at compaction time and stored in
+    /// `CompactionState::CompactedThisTurn { cooldown }` for the duration of the cooldown.
     pub(super) compaction_cooldown_turns: u8,
-    /// Remaining turns in the current cooldown. Counts down each turn; 0 means ready.
-    pub(super) compaction_turns_since: u8,
-    /// Set to `true` when compaction is counterproductive (summary >= freed tokens)
-    /// or when context cannot be reduced below threshold. No further compaction is attempted.
-    pub(super) compaction_exhausted: bool,
-    /// Tracks whether the exhaustion warning message has been sent to the user.
-    pub(super) exhaustion_warned: bool,
     /// Counts user-message turns since the last hard compaction event.
     /// `None` = no hard compaction has occurred yet in this session.
     /// `Some(n)` = n turns have elapsed since the last hard compaction.
@@ -57,11 +145,8 @@ impl ContextManager {
             prune_protect_tokens: 40_000,
             compression: CompressionConfig::default(),
             routing: RoutingConfig::default(),
-            compacted_this_turn: false,
+            compaction: CompactionState::Ready,
             compaction_cooldown_turns: 2,
-            compaction_turns_since: 0,
-            compaction_exhausted: false,
-            exhaustion_warned: false,
             turns_since_last_hard_compaction: None,
         }
     }
@@ -129,7 +214,7 @@ impl ContextManager {
         current_tokens: u64,
     ) -> Option<(usize, usize)> {
         use crate::config::CompressionStrategy;
-        if self.compacted_this_turn {
+        if self.compaction.is_compacted_this_turn() {
             return None;
         }
         match &self.compression.strategy {
@@ -160,7 +245,7 @@ mod tests {
         assert!((cm.hard_compaction_threshold - 0.90).abs() < f32::EPSILON);
         assert_eq!(cm.compaction_preserve_tail, 6);
         assert_eq!(cm.prune_protect_tokens, 40_000);
-        assert!(!cm.compacted_this_turn);
+        assert_eq!(cm.compaction, CompactionState::Ready);
     }
 
     #[test]
@@ -260,7 +345,109 @@ mod tests {
             threshold_tokens: 80_000,
             max_summary_tokens: 4_000,
         };
-        cm.compacted_this_turn = true;
+        cm.compaction = CompactionState::CompactedThisTurn { cooldown: 0 };
         assert!(cm.should_proactively_compress(100_000).is_none());
+    }
+
+    // ── CompactionState unit tests ──────────────────────────────────────────
+
+    #[test]
+    fn compaction_state_ready_is_not_compacted_this_turn() {
+        assert!(!CompactionState::Ready.is_compacted_this_turn());
+    }
+
+    #[test]
+    fn compaction_state_compacted_this_turn_flag() {
+        assert!(CompactionState::CompactedThisTurn { cooldown: 2 }.is_compacted_this_turn());
+        assert!(CompactionState::CompactedThisTurn { cooldown: 0 }.is_compacted_this_turn());
+    }
+
+    #[test]
+    fn compaction_state_cooling_is_not_compacted_this_turn() {
+        assert!(!CompactionState::Cooling { turns_remaining: 1 }.is_compacted_this_turn());
+    }
+
+    #[test]
+    fn compaction_state_exhausted_is_not_compacted_this_turn() {
+        assert!(!CompactionState::Exhausted { warned: false }.is_compacted_this_turn());
+        assert!(!CompactionState::Exhausted { warned: true }.is_compacted_this_turn());
+    }
+
+    #[test]
+    fn compaction_state_is_exhausted() {
+        assert!(!CompactionState::Ready.is_exhausted());
+        assert!(!CompactionState::CompactedThisTurn { cooldown: 0 }.is_exhausted());
+        assert!(!CompactionState::Cooling { turns_remaining: 1 }.is_exhausted());
+        assert!(CompactionState::Exhausted { warned: false }.is_exhausted());
+        assert!(CompactionState::Exhausted { warned: true }.is_exhausted());
+    }
+
+    #[test]
+    fn compaction_state_cooldown_remaining() {
+        assert_eq!(CompactionState::Ready.cooldown_remaining(), 0);
+        assert_eq!(
+            CompactionState::CompactedThisTurn { cooldown: 3 }.cooldown_remaining(),
+            0
+        );
+        assert_eq!(
+            CompactionState::Cooling { turns_remaining: 2 }.cooldown_remaining(),
+            2
+        );
+        assert_eq!(
+            CompactionState::Exhausted { warned: false }.cooldown_remaining(),
+            0
+        );
+    }
+
+    #[test]
+    fn advance_turn_compacted_with_cooldown_enters_cooling() {
+        let state = CompactionState::CompactedThisTurn { cooldown: 3 };
+        assert_eq!(
+            state.advance_turn(),
+            CompactionState::Cooling { turns_remaining: 3 }
+        );
+    }
+
+    #[test]
+    fn advance_turn_compacted_zero_cooldown_returns_ready() {
+        let state = CompactionState::CompactedThisTurn { cooldown: 0 };
+        assert_eq!(state.advance_turn(), CompactionState::Ready);
+    }
+
+    #[test]
+    fn advance_turn_ready_unchanged() {
+        assert_eq!(
+            CompactionState::Ready.advance_turn(),
+            CompactionState::Ready
+        );
+    }
+
+    #[test]
+    fn advance_turn_cooling_unchanged() {
+        let state = CompactionState::Cooling { turns_remaining: 2 };
+        assert_eq!(state.advance_turn(), state);
+    }
+
+    #[test]
+    fn advance_turn_exhausted_unchanged() {
+        let state = CompactionState::Exhausted { warned: true };
+        assert_eq!(state.advance_turn(), state);
+    }
+
+    /// Verifies the eviction ordering invariant from critic finding S1:
+    /// advance_turn() resets CompactedThisTurn → Ready, then eviction can set
+    /// CompactedThisTurn{0} again in the same turn, which is visible to the sidequest check.
+    #[test]
+    fn advance_turn_then_eviction_compacted_is_visible() {
+        // Start of turn: eviction from previous turn carries cooldown=0
+        let state = CompactionState::CompactedThisTurn { cooldown: 0 };
+        // advance_turn fires at mod.rs:3014
+        let after_advance = state.advance_turn();
+        assert_eq!(after_advance, CompactionState::Ready);
+        assert!(!after_advance.is_compacted_this_turn());
+
+        // Later in the same turn, eviction fires at mod.rs:4055
+        let after_eviction = CompactionState::CompactedThisTurn { cooldown: 0 };
+        assert!(after_eviction.is_compacted_this_turn());
     }
 }

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -3011,7 +3011,9 @@ impl<C: Channel> Agent<C> {
 
         // Reset per-turn compaction guard FIRST so SideQuest sees a clean slate (C2 fix).
         // complete_focus and maybe_sidequest_eviction set this flag when they run (C1 fix).
-        self.context_manager.compacted_this_turn = false;
+        // advance_turn() transitions CompactedThisTurn → Cooling/Ready; all other states
+        // pass through unchanged. See CompactionState::advance_turn for ordering guarantees.
+        self.context_manager.compaction = self.context_manager.compaction.advance_turn();
 
         // Tick Focus Agent and SideQuest turn counters (#1850, #1885).
         #[cfg(feature = "context-compression")]
@@ -3019,9 +3021,9 @@ impl<C: Channel> Agent<C> {
             self.focus.tick();
 
             // SideQuest eviction: runs every N user turns when enabled.
-            // Skipped when compacted_this_turn is set (focus truncation or prior eviction ran).
+            // Skipped when is_compacted_this_turn (focus truncation or prior eviction ran).
             let sidequest_should_fire = self.sidequest.tick();
-            if sidequest_should_fire && !self.context_manager.compacted_this_turn {
+            if sidequest_should_fire && !self.context_manager.compaction.is_compacted_this_turn() {
                 self.maybe_sidequest_eviction();
             }
         }
@@ -4052,7 +4054,11 @@ impl<C: Channel> Agent<C> {
                     if freed > 0 {
                         self.recompute_prompt_tokens();
                         // C1 fix: prevent maybe_compact() from firing in the same turn.
-                        self.context_manager.compacted_this_turn = true;
+                        // cooldown=0: eviction does not impose post-compaction cooldown.
+                        self.context_manager.compaction =
+                            crate::agent::context_manager::CompactionState::CompactedThisTurn {
+                                cooldown: 0,
+                            };
                         tracing::info!(
                             freed_tokens = freed,
                             evicted_cursors = evicted_indices.len(),

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -1578,7 +1578,11 @@ impl<C: Channel> Agent<C> {
                 self.msg.messages.truncate(checkpoint_pos);
                 self.recompute_prompt_tokens();
                 // C1 fix: mark compacted so maybe_compact() does not double-fire this turn.
-                self.context_manager.compacted_this_turn = true;
+                // cooldown=0: focus truncation does not impose post-compaction cooldown.
+                self.context_manager.compaction =
+                    crate::agent::context_manager::CompactionState::CompactedThisTurn {
+                        cooldown: 0,
+                    };
 
                 // Rebuild/insert the pinned Knowledge block message.
                 // Remove any existing Knowledge block (focus_pinned=true, no marker_id).

--- a/crates/zeph-llm/src/claude/mod.rs
+++ b/crates/zeph-llm/src/claude/mod.rs
@@ -831,10 +831,7 @@ impl LlmProvider for ClaudeProvider {
         Self: Sized,
     {
         let (schema_value, _) = crate::provider::cached_schema::<T>()?;
-        let type_name = std::any::type_name::<T>()
-            .rsplit("::")
-            .next()
-            .unwrap_or("Output");
+        let type_name = crate::provider::short_type_name::<T>();
 
         let tool_name = format!("submit_{type_name}");
         let tool = ToolDefinition {

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -568,10 +568,7 @@ impl LlmProvider for OpenAiProvider {
         let mut schema_value = raw_schema;
         inline_refs_openai(&mut schema_value, 8);
         normalize_for_openai_strict(&mut schema_value, 16);
-        let type_name = std::any::type_name::<T>()
-            .rsplit("::")
-            .next()
-            .unwrap_or("Output");
+        let type_name = crate::provider::short_type_name::<T>();
 
         let api_messages = convert_messages(messages);
         let body = TypedChatRequest {

--- a/crates/zeph-llm/src/provider.rs
+++ b/crates/zeph-llm/src/provider.rs
@@ -44,6 +44,26 @@ pub(crate) fn cached_schema<T: schemars::JsonSchema + 'static>()
     Ok((value, pretty))
 }
 
+/// Extract the short (unqualified) type name for schema prompts and tool names.
+///
+/// Returns the last `::` segment of [`std::any::type_name::<T>()`], which is always
+/// non-empty. The `"Output"` fallback is unreachable in practice (`type_name` never returns
+/// an empty string and `rsplit` on a non-empty string always yields at least one element),
+/// but is kept for defensive clarity.
+///
+/// # Examples
+///
+/// ```
+/// struct MyOutput;
+/// // short_type_name::<MyOutput>() returns "MyOutput"
+/// ```
+pub(crate) fn short_type_name<T: ?Sized>() -> &'static str {
+    std::any::type_name::<T>()
+        .rsplit("::")
+        .next()
+        .unwrap_or("Output")
+}
+
 /// A chunk from an LLM streaming response.
 #[derive(Debug, Clone)]
 pub enum StreamChunk {
@@ -558,10 +578,7 @@ pub trait LlmProvider: Send + Sync {
         Self: Sized,
     {
         let (_, schema_json) = cached_schema::<T>()?;
-        let type_name = std::any::type_name::<T>()
-            .rsplit("::")
-            .next()
-            .unwrap_or("Output");
+        let type_name = short_type_name::<T>();
 
         let mut augmented = messages.to_vec();
         let instruction = format!(
@@ -1424,5 +1441,27 @@ mod tests {
     fn stream_chunk_compaction_variant() {
         let chunk = StreamChunk::Compaction("A summary".to_owned());
         assert!(matches!(chunk, StreamChunk::Compaction(s) if s == "A summary"));
+    }
+
+    #[test]
+    fn short_type_name_extracts_last_segment() {
+        struct MyOutput;
+        assert_eq!(short_type_name::<MyOutput>(), "MyOutput");
+    }
+
+    #[test]
+    fn short_type_name_primitive_returns_full_name() {
+        // Primitives have no "::" in their type_name — rsplit returns the full name.
+        assert_eq!(short_type_name::<u32>(), "u32");
+        assert_eq!(short_type_name::<bool>(), "bool");
+    }
+
+    #[test]
+    fn short_type_name_nested_path_returns_last() {
+        // Use a type whose path contains "::" segments.
+        assert_eq!(
+            short_type_name::<std::collections::HashMap<u32, u32>>(),
+            "HashMap<u32, u32>"
+        );
     }
 }

--- a/crates/zeph-memory/src/qdrant_ops.rs
+++ b/crates/zeph-memory/src/qdrant_ops.rs
@@ -5,6 +5,7 @@
 
 use std::collections::HashMap;
 
+use crate::vector_store::BoxFuture;
 use qdrant_client::Qdrant;
 use qdrant_client::qdrant::{
     CreateCollectionBuilder, DeletePointsBuilder, Distance, Filter, PointId, PointStruct,
@@ -321,9 +322,7 @@ impl crate::vector_store::VectorStore for QdrantOps {
         &self,
         collection: &str,
         vector_size: u64,
-    ) -> std::pin::Pin<
-        Box<dyn std::future::Future<Output = Result<(), crate::VectorStoreError>> + Send + '_>,
-    > {
+    ) -> BoxFuture<'_, Result<(), crate::VectorStoreError>> {
         let collection = collection.to_owned();
         Box::pin(async move {
             self.ensure_collection(&collection, vector_size)
@@ -335,9 +334,7 @@ impl crate::vector_store::VectorStore for QdrantOps {
     fn collection_exists(
         &self,
         collection: &str,
-    ) -> std::pin::Pin<
-        Box<dyn std::future::Future<Output = Result<bool, crate::VectorStoreError>> + Send + '_>,
-    > {
+    ) -> BoxFuture<'_, Result<bool, crate::VectorStoreError>> {
         let collection = collection.to_owned();
         Box::pin(async move {
             self.collection_exists(&collection)
@@ -349,9 +346,7 @@ impl crate::vector_store::VectorStore for QdrantOps {
     fn delete_collection(
         &self,
         collection: &str,
-    ) -> std::pin::Pin<
-        Box<dyn std::future::Future<Output = Result<(), crate::VectorStoreError>> + Send + '_>,
-    > {
+    ) -> BoxFuture<'_, Result<(), crate::VectorStoreError>> {
         let collection = collection.to_owned();
         Box::pin(async move {
             self.delete_collection(&collection)
@@ -364,9 +359,7 @@ impl crate::vector_store::VectorStore for QdrantOps {
         &self,
         collection: &str,
         points: Vec<crate::VectorPoint>,
-    ) -> std::pin::Pin<
-        Box<dyn std::future::Future<Output = Result<(), crate::VectorStoreError>> + Send + '_>,
-    > {
+    ) -> BoxFuture<'_, Result<(), crate::VectorStoreError>> {
         let collection = collection.to_owned();
         Box::pin(async move {
             let qdrant_points: Vec<PointStruct> = points
@@ -392,14 +385,7 @@ impl crate::vector_store::VectorStore for QdrantOps {
         vector: Vec<f32>,
         limit: u64,
         filter: Option<crate::VectorFilter>,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<
-                    Output = Result<Vec<crate::ScoredVectorPoint>, crate::VectorStoreError>,
-                > + Send
-                + '_,
-        >,
-    > {
+    ) -> BoxFuture<'_, Result<Vec<crate::ScoredVectorPoint>, crate::VectorStoreError>> {
         let collection = collection.to_owned();
         Box::pin(async move {
             let qdrant_filter = filter.map(vector_filter_to_qdrant);
@@ -415,9 +401,7 @@ impl crate::vector_store::VectorStore for QdrantOps {
         &self,
         collection: &str,
         ids: Vec<String>,
-    ) -> std::pin::Pin<
-        Box<dyn std::future::Future<Output = Result<(), crate::VectorStoreError>> + Send + '_>,
-    > {
+    ) -> BoxFuture<'_, Result<(), crate::VectorStoreError>> {
         let collection = collection.to_owned();
         Box::pin(async move {
             let point_ids: Vec<PointId> = ids.into_iter().map(PointId::from).collect();
@@ -431,17 +415,8 @@ impl crate::vector_store::VectorStore for QdrantOps {
         &self,
         collection: &str,
         key_field: &str,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<
-                    Output = Result<
-                        HashMap<String, HashMap<String, String>>,
-                        crate::VectorStoreError,
-                    >,
-                > + Send
-                + '_,
-        >,
-    > {
+    ) -> BoxFuture<'_, Result<HashMap<String, HashMap<String, String>>, crate::VectorStoreError>>
+    {
         let collection = collection.to_owned();
         let key_field = key_field.to_owned();
         Box::pin(async move {
@@ -451,11 +426,7 @@ impl crate::vector_store::VectorStore for QdrantOps {
         })
     }
 
-    fn health_check(
-        &self,
-    ) -> std::pin::Pin<
-        Box<dyn std::future::Future<Output = Result<bool, crate::VectorStoreError>> + Send + '_>,
-    > {
+    fn health_check(&self) -> BoxFuture<'_, Result<bool, crate::VectorStoreError>> {
         Box::pin(async move {
             self.client
                 .health_check()

--- a/crates/zeph-memory/src/sqlite_vector_store.rs
+++ b/crates/zeph-memory/src/sqlite_vector_store.rs
@@ -2,13 +2,11 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use std::collections::HashMap;
-use std::future::Future;
-use std::pin::Pin;
 
 use sqlx::SqlitePool;
 
 use crate::vector_store::{
-    FieldValue, ScoredVectorPoint, ScrollResult, VectorFilter, VectorPoint, VectorStore,
+    BoxFuture, FieldValue, ScoredVectorPoint, ScrollResult, VectorFilter, VectorPoint, VectorStore,
     VectorStoreError,
 };
 
@@ -52,8 +50,6 @@ fn matches_filter(payload: &HashMap<String, serde_json::Value>, filter: &VectorF
     }
     true
 }
-
-type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 impl VectorStore for SqliteVectorStore {
     fn ensure_collection(

--- a/crates/zeph-memory/src/vector_store.rs
+++ b/crates/zeph-memory/src/vector_store.rs
@@ -55,7 +55,11 @@ pub struct ScoredVectorPoint {
     pub payload: HashMap<String, serde_json::Value>,
 }
 
-type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+/// Shared return type alias for all [`VectorStore`] trait methods.
+///
+/// Intentionally `pub(crate)` — all [`VectorStore`] implementations are internal to this crate.
+/// If the trait is ever made externally extensible, this alias should become `pub`.
+pub(crate) type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 pub type ScrollResult = HashMap<String, HashMap<String, String>>;
 


### PR DESCRIPTION
## Summary

Implement type safety improvements from epic #1974 audit. Three changes improve maintainability and leverage Rust's type system:

- **TYPE-02**: Consolidate `BoxFuture` from 3 definitions → 1 shared `pub(crate)` alias (-25 LOC)
- **TYPE-06**: Replace 4 boolean fields with `CompactionState` enum (invalid states unrepresentable by type)
- **TYPE-03**: Extract schema helper for 3 LLM providers (DRY, -1 LOC)

## Validation

- ✅ 5427/5427 tests passing (+15 new state transition tests)
- ✅ Clippy clean (0 warnings)
- ✅ Format compliant
- ✅ Security audit: APPROVED (no unsafe code, no security issues)
- ✅ Performance: NEUTRAL (enum smaller than original booleans)

## Key Changes

### TYPE-02: BoxFuture Consolidation
- `vector_store.rs`: Define `pub(crate) type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>`
- `sqlite_vector_store.rs`: Remove duplicate, import from vector_store.rs
- `qdrant_ops.rs`: Replace 8 inline `Pin<Box<dyn Future<...>>>` with alias

### TYPE-06: CompactionState Enum
- Replace 4 fields: `compacted_this_turn`, `compaction_exhausted`, `exhaustion_warned`, `compaction_turns_since`
- 4 variants: `Ready`, `CompactedThisTurn { cooldown }`, `Cooling { turns_remaining }`, `Exhausted { warned }`
- All 12 mutation sites converted with explicit transition logic
- 14 new unit tests for state transitions
- Addresses critic findings:
  - S1: `advance_turn()` ordering documented and tested
  - S2: Transition map confirms `Cooling → Exhausted` impossible
  - M5: Proactive compression included in state map

### TYPE-03: Schema Helper
- Extract `short_type_name<T>()` in `provider.rs`
- Replace 3 duplicate patterns in openai/mod.rs and claude/mod.rs
- 3 unit tests for schema generation

## Files Changed
- crates/zeph-core/src/agent/context/summarization.rs
- crates/zeph-core/src/agent/context/tests.rs
- crates/zeph-core/src/agent/context_manager.rs
- crates/zeph-core/src/agent/mod.rs
- crates/zeph-core/src/agent/tool_execution/native.rs
- crates/zeph-llm/src/claude/mod.rs
- crates/zeph-llm/src/openai/mod.rs
- crates/zeph-llm/src/provider.rs
- crates/zeph-memory/src/qdrant_ops.rs
- crates/zeph-memory/src/sqlite_vector_store.rs
- crates/zeph-memory/src/vector_store.rs

## Related Issues

- Closes #1974 (partial: TYPE-02, TYPE-03, TYPE-06 complete; TYPE-01 deferred to future)
- Audit reference: `.local/audit/002-type-safety-opportunities.md`

## Checklist

- [x] All tests passing (5427/5427)
- [x] Clippy clean
- [x] Format compliant
- [x] Security audit APPROVED
- [x] Compiler warnings: 0
- [x] Unsafe code: 0 new blocks
- [x] Breaking changes: none
- [x] Documentation: state transitions documented in code