### PR TITLE
refactor(memory): wrap cleanup() in atomic transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - feat(channels): register Discord slash commands (`/reset`, `/skills`, `/agent`) at startup via fire-and-forget background task; idempotent via `PUT /applications/{id}/commands` (CHAN-05, epic #1978)
 - feat(channels): extract shared `CONFIRM_TIMEOUT` constant (30s) to `zeph-channels` crate; Telegram, Discord, and Slack `confirm()` all reference it (CHAN-02, epic #1978)
 
+- refactor(memory): wrap `ResponseCache::cleanup()` DELETE and UPDATE operations in a single SQLite transaction for atomicity (closes #2032)
+
 ### Changed
 
 - fix(channels): `AnyChannel` and `AppChannel` now forward all 16 `Channel` trait methods; previously `send_thinking_chunk`, `send_stop_hint`, `send_usage`, and `send_tool_start` fell through to trait defaults, silently dropping events (CHAN-01, epic #1978)

--- a/crates/zeph-memory/src/response_cache.rs
+++ b/crates/zeph-memory/src/response_cache.rs
@@ -185,9 +185,11 @@ impl ResponseCache {
     /// Returns an error if either database operation fails.
     pub async fn cleanup(&self, current_embedding_model: &str) -> Result<u64, MemoryError> {
         let now = unix_now();
+        let mut tx = self.pool.begin().await?;
+
         let deleted = sqlx::query("DELETE FROM response_cache WHERE expires_at <= ?")
             .bind(now)
-            .execute(&self.pool)
+            .execute(&mut *tx)
             .await?
             .rows_affected();
 
@@ -197,10 +199,11 @@ impl ResponseCache {
              WHERE embedding IS NOT NULL AND embedding_model != ?",
         )
         .bind(current_embedding_model)
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await?
         .rows_affected();
 
+        tx.commit().await?;
         Ok(deleted + updated)
     }
 


### PR DESCRIPTION
## Problem
ResponseCache::cleanup() executed two SQL operations independently.
A failure between them left partial state: expired rows deleted but
stale embeddings still present, or vice versa.

## Solution
Wrap both operations in a single SQLite transaction via pool.begin() /
tx.commit(). On error, sqlx automatically rolls back for all-or-nothing semantics.

## Tests
6014/6014 pass. No new test needed — atomicity is enforced by SQLite.

Closes #2032