### PR TITLE
enh(tools): /status reports tool_filter state when enabled (#2028)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - feat(core): `DebugDumper::dump_anchored_summary()` writes `{N}_anchored-summary.json` with section completeness metrics, total_items, token_estimate, and fallback flag when `--debug-dump` is active (issue #1607)
 - feat(config): `[memory] structured_summaries = false` config field enables opt-in structured compaction summaries (issue #1607)
 - feat(tools): dynamic tool schema filtering — sends only relevant tool definitions to the LLM per turn, selected by embedding similarity between user query and tool descriptions; configurable via `[agent.tool_filter]` with `enabled`, `top_k`, `always_on`, and `min_description_words`; disabled by default (#2020)
+- enh(tools): `/status` reports `tool_filter` state when enabled — shows Filter line with top_k, always_on count, and embedding count; silent when filter is disabled (#2028)
 - feat(channels): register Discord slash commands (`/reset`, `/skills`, `/agent`) at startup via fire-and-forget background task; idempotent via `PUT /applications/{id}/commands` (CHAN-05, epic #1978)
 - feat(channels): extract shared `CONFIRM_TIMEOUT` constant (30s) to `zeph-channels` crate; Telegram, Discord, and Slack `confirm()` all reference it (CHAN-02, epic #1978)
 

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -3260,6 +3260,15 @@ impl<C: Channel> Agent<C> {
         );
         let _ = writeln!(out, "Skills:    {skill_count}");
         let _ = writeln!(out, "MCP:       {mcp_servers} server(s)");
+        if let Some(ref tf) = self.tool_schema_filter {
+            let _ = writeln!(
+                out,
+                "Filter:    enabled (top_k={}, always_on={}, {} embeddings)",
+                tf.top_k(),
+                tf.always_on_count(),
+                tf.embedding_count(),
+            );
+        }
         if cost_cents > 0.0 {
             let _ = writeln!(out, "Cost:      ${:.4}", cost_cents / 100.0);
         }

--- a/crates/zeph-tools/src/schema_filter.rs
+++ b/crates/zeph-tools/src/schema_filter.rs
@@ -85,6 +85,18 @@ impl ToolSchemaFilter {
         self.embeddings.len()
     }
 
+    /// Configured top-K limit for similarity ranking.
+    #[must_use]
+    pub fn top_k(&self) -> usize {
+        self.top_k
+    }
+
+    /// Number of always-on tools in the filter config.
+    #[must_use]
+    pub fn always_on_count(&self) -> usize {
+        self.always_on.len()
+    }
+
     /// Replace tool embeddings (e.g. after MCP tool changes) and bump version.
     pub fn recompute(&mut self, embeddings: Vec<ToolEmbedding>) {
         self.embeddings = embeddings;
@@ -356,6 +368,14 @@ mod tests {
         let result = filter.filter(&all_ids, &[], "test", &query_emb);
 
         assert_eq!(result.included.len(), 6);
+    }
+
+    #[test]
+    fn accessors_return_configured_values() {
+        let filter = make_filter(vec!["bash", "read"], 7);
+        assert_eq!(filter.top_k(), 7);
+        assert_eq!(filter.always_on_count(), 2);
+        assert_eq!(filter.embedding_count(), 5);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Add visibility into dynamic tool schema filter state in the `/status` command.

When `[agent.tool_filter]` is enabled, `/status` now displays:
```
Filter:    enabled (top_k=N, always_on=N, N embeddings)
```

When disabled (default), the line is omitted (zero noise).

## Changes
- **crates/zeph-tools/src/schema_filter.rs**: Add `pub fn top_k()` and `pub fn always_on_count()` accessor methods with unit test
- **crates/zeph-core/src/agent/mod.rs**: Add conditional Filter line to `handle_status_command()` output
- **CHANGELOG.md**: Document the enhancement

## Testing
- All 5528 unit/integration tests pass
- Label alignment verified (11 chars, matching other /status fields)
- Manual testing: filter line appears when enabled, silent when disabled

## Validation
- Architect ✓ — minimal 2-file design
- Critic ✓ — alignment fix applied
- Developer ✓ — implementation complete
- Tester ✓ — test coverage adequate
- Perf ✓ — zero overhead
- Security ✓ — no risks
- Impl-Critic ✓ — code quality solid
- Code Reviewer ✓ — approved with CHANGELOG

Closes #2028