### PR TITLE
Update aws-lc-sys to resolve RUSTSEC-2026-0048

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,9 +405,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -415,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
  "cc",
  "cmake",


### PR DESCRIPTION
## Summary
- refresh `Cargo.lock` to upgrade `aws-lc-sys` from `0.38.0` to `0.39.0`
- pull in `aws-lc-rs` `1.16.2` as the matching transitive update
- remove the vulnerable AWS-LC dependency version flagged by security scan

## Testing
- Not run (not requested)