### PR TITLE
docs: document semantic_cache_max_candidates recall tradeoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- docs: document `semantic_cache_max_candidates` and `semantic_cache_threshold` recall-vs-performance tradeoff with detailed doc comments and tuning guidance; add DEBUG-level diagnostic logs for semantic cache lookup lifecycle (candidate count, per-candidate scores, hit/miss verdicts) (#2031)
+
 ### Added
 
 - feat(orchestration): plan template caching for LLM planner cost reduction (#1856) — `PlanCache` stores completed `TaskGraph` plans as reusable `PlanTemplate` skeletons in SQLite with BLOB-encoded embeddings; cosine similarity computed in-process (no Qdrant dependency); cache lookup returns the closest template if similarity >= threshold, then uses a lightweight LLM adaptation call instead of full decomposition; `PlanCacheConfig` in `[orchestration.plan_cache]` with `enabled` (default: false), `similarity_threshold` (0.90), `ttl_days` (30), `max_templates` (100); goal normalization (trim + collapse whitespace + lowercase) and BLAKE3 hash for deduplication; `INSERT OR REPLACE ON CONFLICT(goal_hash)` prevents duplicate templates; stale embeddings NULLed on model change; two-phase eviction: TTL sweep + LRU size cap; graceful degradation: any cache failure falls back to full `planner.plan()` without blocking; DB migration 040

--- a/crates/zeph-config/src/providers.rs
+++ b/crates/zeph-config/src/providers.rs
@@ -184,10 +184,25 @@ pub struct LlmConfig {
     /// Enable semantic similarity-based response caching. Requires embedding support.
     #[serde(default)]
     pub semantic_cache_enabled: bool,
-    /// Cosine similarity threshold for semantic cache hits (0.0-1.0). Recommended: 0.92-0.98.
+    /// Cosine similarity threshold for semantic cache hits (0.0–1.0).
+    ///
+    /// Only the highest-scoring candidate above this threshold is returned.
+    /// Lower values produce more cache hits but risk returning less relevant responses.
+    /// Recommended range: 0.92–0.98; default: 0.95.
     #[serde(default = "default_semantic_cache_threshold")]
     pub semantic_cache_threshold: f32,
-    /// Maximum cache entries to scan per semantic query. Limits search cost.
+    /// Maximum cached entries to examine per semantic lookup (SQL `LIMIT` clause in
+    /// `ResponseCache::get_semantic()`). Controls the recall-vs-performance tradeoff:
+    ///
+    /// - **Higher values** (e.g. 50): scan more entries, better chance of finding a
+    ///   semantically similar cached response, but slower queries.
+    /// - **Lower values** (e.g. 5): faster queries, but may miss relevant cached entries
+    ///   when the cache is large.
+    /// - **Default (10)**: balanced middle ground for typical workloads.
+    ///
+    /// Tuning guidance: set to 50+ when recall matters more than latency (e.g. long-running
+    /// sessions with many cached responses); reduce to 5 for low-latency interactive use.
+    /// Env override: `ZEPH_LLM_SEMANTIC_CACHE_MAX_CANDIDATES`.
     #[serde(default = "default_semantic_cache_max_candidates")]
     pub semantic_cache_max_candidates: u32,
     #[serde(default)]

--- a/crates/zeph-core/src/agent/tool_execution/mod.rs
+++ b/crates/zeph-core/src/agent/tool_execution/mod.rs
@@ -534,20 +534,22 @@ impl<C: Channel> Agent<C> {
         // Semantic fallback: embed once, search by similarity.
         if self.runtime.semantic_cache_enabled && self.provider.supports_embeddings() {
             use zeph_llm::provider::LlmProvider as _;
+            let threshold = self.runtime.semantic_cache_threshold;
+            let max_candidates = self.runtime.semantic_cache_max_candidates;
+            tracing::debug!(
+                max_candidates,
+                threshold,
+                "semantic cache lookup: examining up to {max_candidates} candidates",
+            );
             match self.provider.embed(&content).await {
                 Ok(embedding) => {
                     let embed_model = self.skill_state.embedding_model.clone();
                     match cache
-                        .get_semantic(
-                            &embedding,
-                            &embed_model,
-                            self.runtime.semantic_cache_threshold,
-                            self.runtime.semantic_cache_max_candidates,
-                        )
+                        .get_semantic(&embedding, &embed_model, threshold, max_candidates)
                         .await
                     {
                         Ok(Some((response, score))) => {
-                            tracing::debug!(score, "response cache hit (semantic)");
+                            tracing::debug!(score, max_candidates, "response cache hit (semantic)",);
                             let cleaned = self.scan_output_and_warn(&response);
                             if !cleaned.is_empty() {
                                 let display = self.maybe_redact(&cleaned);
@@ -556,6 +558,11 @@ impl<C: Channel> Agent<C> {
                             return Ok(CacheCheckResult::Hit(cleaned));
                         }
                         Ok(None) => {
+                            tracing::debug!(
+                                max_candidates,
+                                threshold,
+                                "semantic cache miss: no candidate met threshold",
+                            );
                             // Semantic miss — pass embedding through to store path.
                             return Ok(CacheCheckResult::Miss {
                                 query_embedding: Some(embedding),

--- a/crates/zeph-memory/src/response_cache.rs
+++ b/crates/zeph-memory/src/response_cache.rs
@@ -89,14 +89,19 @@ impl ResponseCache {
         let mut best_score = -1.0_f32;
         let mut best_response: Option<String> = None;
 
-        for (response, blob) in rows {
+        for (response, blob) in &rows {
             // bytemuck::try_cast_slice handles corrupt BLOBs (non-multiple-of-4 length) safely.
-            match bytemuck::try_cast_slice::<u8, f32>(&blob) {
+            match bytemuck::try_cast_slice::<u8, f32>(blob) {
                 Ok(stored) => {
                     let score = crate::math::cosine_similarity(embedding, stored);
+                    tracing::debug!(
+                        score,
+                        threshold = similarity_threshold,
+                        "semantic cache candidate evaluated",
+                    );
                     if score > best_score {
                         best_score = score;
-                        best_response = Some(response);
+                        best_response = Some(response.clone());
                     }
                 }
                 Err(e) => {
@@ -104,6 +109,14 @@ impl ResponseCache {
                 }
             }
         }
+
+        tracing::debug!(
+            examined = rows.len(),
+            best_score,
+            threshold = similarity_threshold,
+            hit = best_score >= similarity_threshold,
+            "semantic cache scan complete",
+        );
 
         if best_score >= similarity_threshold {
             Ok(best_response.map(|r| (r, best_score)))


### PR DESCRIPTION
## Summary

Documents the semantic_cache_max_candidates parameter and its recall vs performance tradeoff in PR #2029. Users can now understand why setting `max_candidates=10` limits the number of cached entries examined during similarity lookup.

## Changes

1. **Config help comments** (`crates/zeph-config/src/providers.rs`):
   - Added detailed doc comment explaining the recall-vs-performance tradeoff
   - Tuning guidance: 50+ for recall focus, 5 for speed focus, default 10 balanced
   - References SQL LIMIT clause and env override
   - Also expanded `semantic_cache_threshold` documentation

2. **Debug logs** (`crates/zeph-core/src/agent/tool_execution/mod.rs`):
   - Log cache lookup start with max_candidates and threshold
   - Log cache hit/miss results with parameters
   
3. **Per-candidate debug logs** (`crates/zeph-memory/src/response_cache.rs`):
   - Log each candidate's cosine similarity score
   - Log scan summary with examined count, best score, threshold, hit/miss verdict

4. **CHANGELOG** updated

## Validation

- ✅ `cargo +nightly fmt --check`
- ✅ `cargo clippy --workspace -- -D warnings`
- ✅ `cargo nextest run --workspace --lib --bins` (5734 tests)
- ✅ Code review approved

Fixes #2031