### PR TITLE
fix(memory): align MAGMA entity extraction prompt with EntityType enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(memory): align MAGMA entity extraction prompt taxonomy with EntityType enum — replace `technology` with `tool` and `language` as separate types with clarifying descriptions; prevents "unknown entity type, falling back to Concept" resolver warnings for programming languages and frameworks (#2079)
+
 ### Documentation
 
 - Add compaction probe documentation to context engineering guide (#2050)

--- a/crates/zeph-memory/src/graph/extractor.rs
+++ b/crates/zeph-memory/src/graph/extractor.rs
@@ -21,8 +21,9 @@ configuration files, JSON/TOML/YAML data, code snippets, or error messages. \
 If the message is structured data or raw command output, return empty arrays.
 3. Do NOT extract structural data: config keys, file paths, tool names, TOML/JSON keys, \
 programming keywords, or single-letter identifiers.
-4. Entity types must be one of: person, project, technology, organization, concept. \
-\"technology\" covers programming languages, frameworks, tools, and software. \
+4. Entity types must be one of: person, project, tool, language, organization, concept. \
+\"tool\" covers frameworks, software tools, and libraries. \
+\"language\" covers programming and natural languages. \
 \"concept\" covers abstract ideas, methodologies, and practices.
 5. Only extract entities with clear semantic meaning about people, projects, or domain knowledge.
 6. Entity names must be at least 3 characters long. Reject single characters, two-letter \
@@ -47,7 +48,7 @@ phone numbers, physical addresses, SSNs, or API keys. Use generic references ins
 Output JSON schema:
 {
   \"entities\": [
-    {\"name\": \"string\", \"type\": \"person|project|technology|organization|concept\", \"summary\": \"optional string\"}
+    {\"name\": \"string\", \"type\": \"person|project|tool|language|organization|concept\", \"summary\": \"optional string\"}
   ],
   \"edges\": [
     {\"source\": \"entity name\", \"target\": \"entity name\", \"relation\": \"verb phrase\", \"fact\": \"human-readable sentence\", \"temporal_hint\": \"optional string\", \"edge_type\": \"semantic|temporal|causal|entity\"}


### PR DESCRIPTION
Fixes #2079

## Summary

- Updated entity type taxonomy in the MAGMA graph extraction prompt to match the `EntityType` Rust enum
- Replaced `technology` with two distinct types: `tool` (frameworks, libraries, software tools) and `language` (programming and natural languages)
- Updated the output JSON schema example to reflect the corrected type list
- No changes to `types.rs` or `resolver/mod.rs` — `FromStr`/`Display` already covered all variants and the fallback log was already clear

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --features full -- -D warnings` — clean
- [x] `cargo nextest run --workspace --features full --lib --bins` — 6323/6323 passed