### PR TITLE
fix(skills): convert unsupported >- block scalar modifier to > in all skill files

### DIFF
--- a/.zeph/skills/api-request/SKILL.md
+++ b/.zeph/skills/api-request/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: api-request
-description: >-
+description: >
   Send HTTP API requests using curl. Use when the user asks to call an API,
   fetch data from a URL, send POST/PUT/PATCH/DELETE requests, work with REST
   or GraphQL endpoints, upload files, authenticate with Bearer tokens or API

--- a/.zeph/skills/archive/SKILL.md
+++ b/.zeph/skills/archive/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: archive
-description: >-
+description: >
   Create, extract, list, and convert compressed archives using tar, zip, gzip,
   bzip2, xz, zstd, and 7z. Use when the user asks to compress files, extract
   archives, list archive contents, split large archives, create backups,

--- a/.zeph/skills/code-analysis/SKILL.md
+++ b/.zeph/skills/code-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-analysis
-description: >-
+description: >
   LSP-based code analysis via mcpls MCP server. Use for compiler-accurate type
   inspection, go-to-definition, find-all-references, diagnostics, call hierarchy,
   workspace symbol search, code actions, rename refactoring, and document formatting.

--- a/.zeph/skills/cron/SKILL.md
+++ b/.zeph/skills/cron/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cron
-description: >-
+description: >
   Schedule recurring and one-time tasks using cron, crontab, at, and launchd.
   Use when the user asks to set up scheduled jobs, configure crontab entries,
   write cron expressions, schedule one-time tasks with at, create launchd

--- a/.zeph/skills/database/SKILL.md
+++ b/.zeph/skills/database/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: database
-description: >-
+description: >
   Query and manage SQLite, PostgreSQL, and MySQL databases from the command
   line. Use when the user asks to run SQL queries, inspect database schemas,
   create or alter tables, import or export data, manage indexes, analyze query

--- a/.zeph/skills/docker/SKILL.md
+++ b/.zeph/skills/docker/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docker
-description: >-
+description: >
   Manage Docker containers, images, volumes, networks, and Compose stacks.
   Use when the user asks to build, run, stop, restart, remove, inspect, or debug
   containers; pull, push, tag, or delete images; manage volumes and networks;

--- a/.zeph/skills/file-ops/SKILL.md
+++ b/.zeph/skills/file-ops/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: file-ops
-description: >-
+description: >
   File system operations — list directory contents, find files by name or glob
   pattern, search text inside files with grep or ripgrep, read and display file
   contents, analyze file size and type, count lines, compare files with diff,

--- a/.zeph/skills/git/SKILL.md
+++ b/.zeph/skills/git/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git
-description: >-
+description: >
   Run git version control commands for repository management. Use when the user
   asks to check status, view history or diffs, stage and commit changes, manage
   branches, merge or rebase, work with remotes, stash changes, tag releases,

--- a/.zeph/skills/github/SKILL.md
+++ b/.zeph/skills/github/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github
-description: >-
+description: >
   GitHub CLI (gh) for repository management, issues, pull requests, releases,
   workflows, search, gists, and API access. Use when the user asks about any
   GitHub operation — creating repos, forking, cloning, PR workflows, issue

--- a/.zeph/skills/json-yaml/SKILL.md
+++ b/.zeph/skills/json-yaml/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: json-yaml
-description: >-
+description: >
   Parse, query, transform, validate, and convert JSON and YAML data using jq
   and fy (fast-yaml). Use when the user asks to filter JSON arrays, extract
   nested fields, reshape data structures, convert between JSON and YAML formats,

--- a/.zeph/skills/network/SKILL.md
+++ b/.zeph/skills/network/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: network
-description: >-
+description: >
   Network diagnostics, DNS lookup, port scanning, and connectivity testing.
   Use when the user asks to check if a host is reachable, trace network routes,
   resolve DNS records, inspect open ports, debug HTTP requests, check SSL/TLS

--- a/.zeph/skills/process-management/SKILL.md
+++ b/.zeph/skills/process-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: process-management
-description: >-
+description: >
   Monitor, manage, and control system processes. Use when the user asks to list
   running processes, find a process by name or PID, kill or terminate processes,
   manage background jobs, check resource usage, set resource limits, manage

--- a/.zeph/skills/qdrant/SKILL.md
+++ b/.zeph/skills/qdrant/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qdrant
-description: >-
+description: >
   Manage Qdrant vector database via REST API. Use when the user asks to create
   or delete collections, upsert or search vectors, inspect points, filter by
   payload fields, manage snapshots, check cluster status, or debug semantic

--- a/.zeph/skills/regex/SKILL.md
+++ b/.zeph/skills/regex/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: regex
-description: >-
+description: >
   Write, test, and debug regular expressions for pattern matching, search, and
   text extraction across programming languages. Use when the user asks to match
   patterns in text, validate input formats (email, URL, IP, phone, date),

--- a/.zeph/skills/ssh-remote/SKILL.md
+++ b/.zeph/skills/ssh-remote/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ssh-remote
-description: >-
+description: >
   Manage SSH connections, key management, remote command execution, tunneling,
   and file transfer with scp and rsync. Use when the user asks to connect to
   a remote server, generate SSH keys, set up port forwarding or tunnels,

--- a/.zeph/skills/system-info/SKILL.md
+++ b/.zeph/skills/system-info/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: system-info
-description: >-
+description: >
   System diagnostics and resource monitoring — retrieve OS version and kernel
   info, check CPU load and core count, inspect memory and swap usage, analyze
   disk space and filesystem mounts, list running processes sorted by resource

--- a/.zeph/skills/text-processing/SKILL.md
+++ b/.zeph/skills/text-processing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: text-processing
-description: >-
+description: >
   Transform, filter, sort, and analyze text using sed, awk, sort, uniq, cut,
   tr, wc, and other text processing tools. Use when the user asks to find and
   replace text in files, extract columns from data, count lines or words, sort

--- a/.zeph/skills/web-scrape/SKILL.md
+++ b/.zeph/skills/web-scrape/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: web-scrape
-description: >-
+description: >
   Extract structured data from web pages using CSS selectors. Use when the user
   asks to scrape a website, extract text or links from a page, parse HTML
   content, get data from a table, read article content, collect image URLs,

--- a/.zeph/skills/web-search/SKILL.md
+++ b/.zeph/skills/web-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: web-search
-description: >-
+description: >
   Search the internet for current information using the DuckDuckGo Instant
   Answer API. Use when the user asks to find, look up, or search for something
   online, needs up-to-date information, wants facts about a topic, definitions,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(skills): convert unsupported `>-` YAML block scalar modifier to `>` in all 19 skill files in `.zeph/skills/` — resolves silent load failures for all rewritten skills; 9 new skills (archive, cron, database, json-yaml, network, process-management, qdrant, regex, ssh-remote, text-processing) were completely unavailable (#2087)
+
 ## [0.16.1] - 2026-03-21
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Converts `description: >-` to `description: >` in all 19 affected `.zeph/skills/*/SKILL.md` files
- The SKILL.md parser only supports plain `>` or `|` (no chomping modifiers); `>-` caused all 19 skills to fail to load silently
- 9 new skills (archive, cron, database, json-yaml, network, process-management, qdrant, regex, ssh-remote, text-processing) were completely unavailable; 10 existing skills silently fell back to stale managed-dir versions
- No semantic change: `>-` and `>` differ only in trailing-newline stripping, which has no effect on skill matching

Closes #2087

## Test plan

- [ ] `cargo +nightly fmt --check` passes
- [ ] `cargo clippy --workspace -- -D warnings` passes (0 warnings)
- [ ] `cargo nextest run --workspace --lib --bins` passes (5763 tests)
- [ ] Verify a skill with `description: >` loads correctly in a live session