### PR TITLE
test(config): add similarity_threshold upper-bound validation test in PlanCacheConfig

### DIFF
--- a/crates/zeph-config/src/experiment.rs
+++ b/crates/zeph-config/src/experiment.rs
@@ -284,3 +284,21 @@ impl ExperimentConfig {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_cache_similarity_threshold_above_one_is_rejected() {
+        let cfg = PlanCacheConfig {
+            similarity_threshold: 1.1,
+            ..PlanCacheConfig::default()
+        };
+        let result = cfg.validate();
+        assert!(
+            result.is_err(),
+            "similarity_threshold = 1.1 must return a validation error"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a unit test for the `similarity_threshold > 1.0` rejection path in `PlanCacheConfig::validate()` that was previously uncovered
- Sets `similarity_threshold = 1.1` and asserts the call returns an error

## Test plan

- [x] `cargo nextest run -p zeph-config --lib` — 41 tests pass
- [x] `cargo nextest run --workspace --features full --lib --bins` — 6300 tests pass (+1)
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --features full -- -D warnings` — clean

Closes #2095