### PR TITLE
docs: remove dead feature gate references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - test(memory): add unit tests for `SqliteStore` tier DB methods (#2094) — covers `fetch_tiers`, `count_messages_by_tier`, `find_promotion_candidates`, `manual_promote`, `promote_to_semantic`, and migration 042 schema defaults; 29 new tests across happy path, edge cases (empty input, already-promoted rows, soft-deleted rows, nonexistent IDs), and idempotency invariants
 
+### Documentation
+
+- docs: remove dead feature gate references — clarify that 8 capabilities (`openai`, `compatible`, `orchestrator`, `router`, `self-learning`, `qdrant`, `vault-age`, `graph-memory`) are built-in and not Cargo feature flags; update feature-flags.md, CLAUDE.md (#2098)
+
 ### Fixed
 
 - fix(skills): convert unsupported `>-` YAML block scalar modifier to `>` in all 19 skill files in `.zeph/skills/` — resolves silent load failures for all rewritten skills; 9 new skills (archive, cron, database, json-yaml, network, process-management, qdrant, regex, ssh-remote, text-processing) were completely unavailable (#2087)

--- a/book/src/reference/feature-flags.md
+++ b/book/src/reference/feature-flags.md
@@ -1,6 +1,6 @@
 # Feature Flags
 
-Zeph uses Cargo feature flags to control optional functionality. Twelve previously optional features are now always-on and compiled into every build. The remaining optional features are organized into **use-case bundles** for common deployment scenarios, with individual flags available for fine-grained control.
+Zeph uses Cargo feature flags to control optional functionality. The remaining optional features are organized into **use-case bundles** for common deployment scenarios, with individual flags available for fine-grained control.
 
 ## Use-Case Bundles
 
@@ -33,22 +33,24 @@ cargo build --release --features full,ml          # everything including local i
 
 > **No `cli` bundle**: the default build (`cargo build --release`, no features) already represents the minimal CLI use case. A separate `cli` bundle would be a no-op alias.
 
-## Always-On (compiled unconditionally)
+## Built-In Capabilities (always compiled, no feature flag required)
 
-| Feature | Description |
-|---------|-------------|
-| `openai` | OpenAI-compatible provider (GPT, Together, Groq, Fireworks, etc.) |
-| `compatible` | `CompatibleProvider` for OpenAI-compatible third-party APIs |
-| `orchestrator` | Multi-model routing with task-based classification and fallback chains |
-| `router` | `RouterProvider` for chaining multiple providers with fallback |
-| `self-learning` | Skill evolution via failure detection, self-reflection, and LLM-generated improvements |
-| `qdrant` | Qdrant-backed vector storage for skill matching and MCP tool registry |
-| `vault-age` | Age-encrypted vault backend for file-based secret storage ([age](https://age-encryption.org/)) |
-| `mcp` | MCP client for external tool servers via stdio/HTTP transport |
-| `mock` | Mock providers and channels for integration testing |
-| `daemon` | Daemon supervisor with component lifecycle, PID file, and health monitoring |
-| `orchestration` | Task orchestration with DAG-based execution, failure strategies, and SQLite persistence |
-| `graph-memory` | SQLite-based knowledge graph with entity-relationship tracking and BFS traversal |
+The following capabilities compile unconditionally into every build. They are **not** Cargo feature flags — there is no `#[cfg(feature)]` gate and no way to disable them. They are listed here for reference only.
+
+| Capability | Description |
+|------------|-------------|
+| OpenAI provider | OpenAI-compatible provider (GPT, Together, Groq, Fireworks, etc.) |
+| Compatible provider | `CompatibleProvider` for OpenAI-compatible third-party APIs |
+| Multi-model orchestrator | Multi-model routing with task-based classification and fallback chains |
+| Router provider | `RouterProvider` for chaining multiple providers with fallback |
+| Self-learning | Skill evolution via failure detection, self-reflection, and LLM-generated improvements |
+| Qdrant integration | Qdrant-backed vector storage for skill matching and MCP tool registry |
+| Age vault | Age-encrypted vault backend for file-based secret storage ([age](https://age-encryption.org/)) |
+| MCP client | MCP client for external tool servers via stdio/HTTP transport |
+| Mock providers | Mock providers and channels for integration testing |
+| Daemon supervisor | Daemon supervisor with component lifecycle, PID file, and health monitoring |
+| Task orchestration | DAG-based execution with failure strategies and SQLite persistence |
+| Graph memory | SQLite-based knowledge graph with entity-relationship tracking and BFS traversal |
 
 ## Optional Features
 


### PR DESCRIPTION
## Summary

- Rename "Always-On (compiled unconditionally)" section in `feature-flags.md` to "Built-In Capabilities" with explicit note that these are not Cargo feature flags
- Remove `zeph-mcp` from the optional crates list in `CLAUDE.md` (MCP compiles unconditionally)
- Add changelog entry

8 capabilities (`openai`, `compatible`, `orchestrator`, `router`, `self-learning`, `qdrant`, `vault-age`, `graph-memory`) have zero `#[cfg(feature)]` annotations and are not declared in the root `Cargo.toml` `[features]` section. The previous docs misleadingly called them feature flags.

## Test plan

- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --workspace --features full -- -D warnings` passes
- [x] `cargo nextest run` — 6363 tests pass
- [ ] Verify feature-flags.md renders correctly in mdbook

Closes #2098