### PR TITLE
fix(memory): use source conversation_id in AOI tier promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- fix(memory): AOI tier promotion FOREIGN KEY constraint violation (#2102) — `run_promotion_sweep()` used `ConversationId(0)` as a sentinel for promoted semantic facts, but `conversations` uses `AUTOINCREMENT` starting at 1 so id=0 never exists; replaced with the real `conversation_id` from the highest-ranked candidate in the cluster; `PromotionCandidate` now carries `conversation_id` propagated from `find_promotion_candidates()` SELECT; added FK regression guard test and `find_promotion_candidates` conversation_id assertion test
 - fix(skills): convert unsupported `>-` YAML block scalar modifier to `>` in all 19 skill files in `.zeph/skills/` — resolves silent load failures for all rewritten skills; 9 new skills (archive, cron, database, json-yaml, network, process-management, qdrant, regex, ssh-remote, text-processing) were completely unavailable (#2087)
 
 ## [0.16.1] - 2026-03-21

--- a/crates/zeph-memory/src/sqlite/messages/mod.rs
+++ b/crates/zeph-memory/src/sqlite/messages/mod.rs
@@ -814,8 +814,8 @@ impl SqliteStore {
     ) -> Result<Vec<PromotionCandidate>, MemoryError> {
         let limit = i64::try_from(batch_size).unwrap_or(i64::MAX);
         let min = i64::from(min_sessions);
-        let rows: Vec<(MessageId, String, i64, f64)> = sqlx::query_as(
-            "SELECT id, content, session_count, importance_score \
+        let rows: Vec<(MessageId, ConversationId, String, i64, f64)> = sqlx::query_as(
+            "SELECT id, conversation_id, content, session_count, importance_score \
              FROM messages \
              WHERE tier = 'episodic' AND session_count >= ? AND deleted_at IS NULL \
              ORDER BY session_count DESC, importance_score DESC \
@@ -829,11 +829,14 @@ impl SqliteStore {
         Ok(rows
             .into_iter()
             .map(
-                |(id, content, session_count, importance_score)| PromotionCandidate {
-                    id,
-                    content,
-                    session_count: session_count.try_into().unwrap_or(0),
-                    importance_score,
+                |(id, conversation_id, content, session_count, importance_score)| {
+                    PromotionCandidate {
+                        id,
+                        conversation_id,
+                        content,
+                        session_count: session_count.try_into().unwrap_or(0),
+                        importance_score,
+                    }
                 },
             )
             .collect())
@@ -1018,6 +1021,7 @@ impl SqliteStore {
 #[derive(Debug, Clone)]
 pub struct PromotionCandidate {
     pub id: MessageId,
+    pub conversation_id: ConversationId,
     pub content: String,
     pub session_count: u32,
     pub importance_score: f64,

--- a/crates/zeph-memory/src/sqlite/messages/tests.rs
+++ b/crates/zeph-memory/src/sqlite/messages/tests.rs
@@ -1270,3 +1270,43 @@ async fn migration_042_default_session_count_for_preexisting_rows() {
 
     assert_eq!(row.0, 0, "legacy rows must default to session_count = 0");
 }
+
+#[tokio::test]
+async fn promote_to_semantic_with_sentinel_zero_fails() {
+    // Regression guard: ConversationId(0) must never be used as the FK value —
+    // conversations uses AUTOINCREMENT starting at 1, so id=0 never exists.
+    let store = test_store().await;
+    let cid = store.create_conversation().await.unwrap();
+    let id = store.save_message(cid, "user", "fact x").await.unwrap();
+
+    let result = store
+        .promote_to_semantic(ConversationId(0), "merged", &[id])
+        .await;
+    assert!(
+        result.is_err(),
+        "promote_to_semantic with ConversationId(0) must fail FK constraint"
+    );
+}
+
+#[tokio::test]
+async fn find_promotion_candidates_returns_conversation_id() {
+    let store = test_store().await;
+    let cid = store.create_conversation().await.unwrap();
+    let id = store
+        .save_message(cid, "user", "cross-session fact")
+        .await
+        .unwrap();
+
+    sqlx::query("UPDATE messages SET session_count = 3 WHERE id = ?")
+        .bind(id)
+        .execute(store.pool())
+        .await
+        .unwrap();
+
+    let candidates = store.find_promotion_candidates(2, 100).await.unwrap();
+    let candidate = candidates.iter().find(|c| c.id == id).unwrap();
+    assert_eq!(
+        candidate.conversation_id, cid,
+        "find_promotion_candidates must return the source conversation_id"
+    );
+}

--- a/crates/zeph-memory/src/tiers.rs
+++ b/crates/zeph-memory/src/tiers.rs
@@ -177,11 +177,9 @@ async fn run_promotion_sweep(
 
         stats.clusters_formed += 1;
 
-        // Use a sentinel conversation_id for cross-session semantic facts.
-        // ConversationId(0) is used as the "no specific session" sentinel.
-        let sentinel_conv_id = ConversationId(0);
+        let source_conv_id = cluster[0].0.conversation_id;
 
-        match merge_cluster_and_promote(store, provider, &cluster, sentinel_conv_id).await {
+        match merge_cluster_and_promote(store, provider, &cluster, source_conv_id).await {
             Ok(()) => stats.promotions_completed += 1,
             Err(e) => {
                 tracing::warn!(
@@ -375,6 +373,7 @@ mod tests {
     fn make_candidate(id: i64) -> PromotionCandidate {
         PromotionCandidate {
             id: crate::types::MessageId(id),
+            conversation_id: ConversationId(1),
             content: format!("content {id}"),
             session_count: 3,
             importance_score: 0.5,


### PR DESCRIPTION
Closes #2102

## Summary

- `ConversationId(0)` sentinel in `promote_to_semantic()` caused FK violations on every promotion attempt — SQLite autoincrement starts at 1, so `id=0` never exists
- Replace with `cluster[0].0.conversation_id` (highest-ranked candidate by `session_count DESC`)
- Add `conversation_id: ConversationId` field to `PromotionCandidate` struct and propagate through `find_promotion_candidates()` SELECT query
- No schema migration required

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --features full -- -D warnings` — clean (0 warnings)
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features full --lib --bins` — 6365 passed (+2 new)
- [x] `promote_to_semantic_with_sentinel_zero_fails` — FK regression guard confirms `ConversationId(0)` fails
- [x] `find_promotion_candidates_returns_conversation_id` — verifies correct `conversation_id` propagation through real SQLite store