### PR TITLE
feat(config): promote scheduler and guardrail features to default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - docs: remove dead feature gate references — clarify that 8 capabilities (`openai`, `compatible`, `orchestrator`, `router`, `self-learning`, `qdrant`, `vault-age`, `graph-memory`) are built-in and not Cargo feature flags; update feature-flags.md, CLAUDE.md (#2098)
 
+### Changed
+
+- Promote `scheduler` and `guardrail` features to the default feature set; users with `default-features = false` are unaffected
+
 ### Fixed
 
 - fix(memory): AOI tier promotion FOREIGN KEY constraint violation (#2102) — `run_promotion_sweep()` used `ConversationId(0)` as a sentinel for promoted semantic facts, but `conversations` uses `AUTOINCREMENT` starting at 1 so id=0 never exists; replaced with the real `conversation_id` from the highest-ranked candidate in the cluster; `PromotionCandidate` now carries `conversation_id` propagated from `find_promotion_candidates()` SELECT; added FK regression guard test and `find_promotion_candidates` conversation_id assertion test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,15 +158,15 @@ description = "Lightweight AI agent with hybrid inference, skills-first architec
 readme = "README.md"
 
 [features]
-default = ["bundled-skills"]
+default = ["bundled-skills", "scheduler", "guardrail"]
 
 # === Use-case bundles ===
-desktop = ["tui", "scheduler", "compression-guidelines", "context-compression"]
+desktop = ["tui", "compression-guidelines", "context-compression"]
 ide     = ["acp", "acp-http", "lsp-context"]
-server  = ["gateway", "a2a", "scheduler", "otel"]
+server  = ["gateway", "a2a", "otel"]
 chat    = ["discord", "slack"]
 ml      = ["candle", "pdf", "stt"]
-full    = ["desktop", "ide", "server", "chat", "pdf", "stt", "acp-unstable", "experiments", "guardrail", "policy-enforcer", "context-compression", "bundled-skills"]
+full    = ["desktop", "ide", "server", "chat", "pdf", "stt", "acp-unstable", "experiments", "guardrail", "policy-enforcer", "context-compression", "bundled-skills", "scheduler"]
 bundled-skills = ["zeph-skills/bundled-skills", "zeph-core/bundled-skills"]
 
 # === Individual feature flags ===

--- a/config/default.toml
+++ b/config/default.toml
@@ -519,7 +519,7 @@ health_interval_secs = 30
 max_restart_backoff_secs = 60
 
 [scheduler]
-# Enable cron scheduler (feature-gated: --features scheduler)
+# Enable cron scheduler (included in default features)
 enabled = true
 # Example task definitions:
 # [[scheduler.tasks]]

--- a/crates/zeph-config/config/default.toml
+++ b/crates/zeph-config/config/default.toml
@@ -478,7 +478,7 @@ health_interval_secs = 30
 max_restart_backoff_secs = 60
 
 [scheduler]
-# Enable cron scheduler (feature-gated: --features scheduler)
+# Enable cron scheduler (included in default features)
 enabled = true
 # Example task definitions:
 # [[scheduler.tasks]]

--- a/crates/zeph-core/config/default.toml
+++ b/crates/zeph-core/config/default.toml
@@ -478,7 +478,7 @@ health_interval_secs = 30
 max_restart_backoff_secs = 60
 
 [scheduler]
-# Enable cron scheduler (feature-gated: --features scheduler)
+# Enable cron scheduler (included in default features)
 enabled = true
 # Example task definitions:
 # [[scheduler.tasks]]


### PR DESCRIPTION
## Summary

- Add `scheduler` and `guardrail` to `default` features in root `Cargo.toml`
- Remove `scheduler` from `desktop` and `server` bundles (now redundant with default)
- Add `scheduler` explicitly to `full` bundle (preserves `--no-default-features --features full` behavior)
- Update scheduler config comments in all three `default.toml` copies

## Motivation

Both features have demonstrated strong stability through extensive live testing:
- **scheduler**: live verified across CI-30, CI-32, CI-54, CI-58 — zero open bugs. Natural-language scheduling, cron parsing, deferred tasks all working. Config already defaults to `scheduler.enabled = true`.
- **guardrail**: GuardrailFilter, DestructiveCommandVerifier, InjectionPatternVerifier all live verified. Zero additional dependencies — purely a compilation toggle. Runtime behavior unchanged (`[security.guardrail] enabled = false` by default).

## Risk

LOW. Adding features to default is additive. Users with `default-features = false` are unaffected. No behavioral change at runtime.

## Pre-commit checks

- `cargo +nightly fmt --check` — clean
- `cargo clippy --workspace --features full -- -D warnings` — 0 warnings
- `cargo nextest run --config-file .github/nextest.toml --workspace --features full --lib --bins` — 6363 tests passed
- `cargo check` (default features) — compiles cleanly
- `cargo check --no-default-features` — compiles cleanly

Closes #2099