### PR TITLE
chore(testing): add canonical config/testing.toml with provider=router for RAPS coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing
 
+- chore(testing): add canonical `config/testing.toml` with `provider = "router"` to enable RAPS/reputation scoring in CI sessions (#2104) — previously `.local/config/testing.toml` used `provider = "openai"` which silently ignored `[llm.router]` and `[llm.router.reputation]`; the new tracked reference config uses `provider = "router"` with `chain = ["openai"]` keeping identical LLM behavior while activating RAPS; copy to `.local/config/testing.toml` before use
 - test(memory): add unit tests for `SqliteStore` tier DB methods (#2094) — covers `fetch_tiers`, `count_messages_by_tier`, `find_promotion_candidates`, `manual_promote`, `promote_to_semantic`, and migration 042 schema defaults; 29 new tests across happy path, edge cases (empty input, already-promoted rows, soft-deleted rows, nonexistent IDs), and idempotency invariants
 
 ### Documentation

--- a/config/testing.toml
+++ b/config/testing.toml
@@ -1,0 +1,301 @@
+# Zeph testing configuration for continuous improvement workflow.
+# This is the canonical reference config. Copy to .local/config/testing.toml before use:
+#   cp config/testing.toml .local/config/testing.toml
+# Usage: cargo run --features full -- --config .local/config/testing.toml
+#        RUST_LOG=debug cargo run --features full -- --config .local/config/testing.toml 2>.local/testing/debug/session.log
+
+[agent]
+name = "Zeph-Test"
+max_tool_iterations = 15
+auto_update_check = false
+instruction_auto_detect = true
+
+[llm]
+provider = "router"
+base_url = "https://api.openai.com/v1"
+model = "gpt-4o-mini"
+max_tokens = 4096
+embedding_model = "text-embedding-3-small"
+response_cache_enabled = false
+
+[llm.openai]
+base_url = "https://api.openai.com/v1"
+model = "gpt-4o-mini"
+max_tokens = 4096
+embedding_model = "text-embedding-3-small"
+
+[llm.stt]
+provider = "whisper"
+model = "gpt-4o-mini-transcribe"
+base_url = "https://api.openai.com/v1"
+language = "auto"
+
+# Router: openai as primary (used for RAPS/Thompson testing)
+[llm.router]
+chain = ["openai"]
+
+# Quality fallback: MoE model (35B params, 3B active)
+# Requires: export ZEPH_COMPATIBLE_QUALITY_API_KEY=unused
+# [[llm.compatible]]
+# name = "quality"
+# base_url = "http://localhost:11434/v1"
+# model = "qwen3.5:35b-a3b"
+# max_tokens = 8192
+
+[skills]
+paths = [".local/testing/skills"]
+max_active_skills = 5
+prompt_mode = "auto"
+disambiguation_threshold = 0.05
+cosine_weight = 0.7
+hybrid_search = true
+
+[skills.learning]
+enabled = true
+auto_activate = false
+min_failures = 2
+improve_threshold = 0.7
+rollback_threshold = 0.5
+min_evaluations = 3
+max_versions = 10
+cooldown_minutes = 5
+correction_detection = true
+correction_confidence_threshold = 0.6
+detector_mode = "regex"
+correction_recall_limit = 3
+correction_min_similarity = 0.75
+auto_promote_min_uses = 10
+auto_promote_threshold = 0.95
+auto_demote_min_uses = 5
+auto_demote_threshold = 0.40
+
+[skills.trust]
+default_level = "quarantined"
+local_level = "trusted"
+hash_mismatch_level = "quarantined"
+
+[memory]
+sqlite_path = ".local/testing/data/zeph-test.db"
+history_limit = 50
+qdrant_url = "http://localhost:6334"
+summarization_threshold = 20
+context_budget_tokens = 0
+auto_budget = true
+deferred_apply_threshold = 0.70
+compaction_threshold = 0.80
+compaction_preserve_tail = 6
+prune_protect_tokens = 40000
+cross_session_score_threshold = 0.35
+vector_backend = "sqlite"
+token_safety_margin = 1.0
+redact_credentials = true
+autosave_assistant = true
+autosave_min_length = 20
+tool_call_cutoff = 6
+
+[memory.semantic]
+enabled = true
+recall_limit = 5
+vector_weight = 0.7
+keyword_weight = 0.3
+temporal_decay_enabled = true
+temporal_decay_half_life_days = 30
+mmr_enabled = true
+mmr_lambda = 0.7
+importance_enabled = true
+importance_weight = 0.15
+
+[memory.sessions]
+max_history = 100
+title_max_chars = 60
+
+[memory.documents]
+collection = "zeph_test_documents"
+chunk_size = 1000
+chunk_overlap = 100
+top_k = 3
+rag_enabled = false
+
+[memory.compression]
+strategy = "reactive"
+
+[memory.routing]
+strategy = "heuristic"
+
+[memory.graph]
+enabled = true
+extract_model = ""
+max_entities_per_message = 8
+max_edges_per_message = 12
+community_refresh_interval = 50
+entity_similarity_threshold = 0.85
+extraction_timeout_secs = 30
+use_embedding_resolution = false
+max_hops = 2
+recall_limit = 10
+temporal_decay_rate = 0.01
+
+[memory.graph.spreading_activation]
+enabled = true
+decay_lambda = 0.85
+max_hops = 3
+activation_threshold = 0.1
+inhibition_threshold = 0.8
+max_activated_nodes = 50
+
+[index]
+enabled = false
+
+[mcp]
+allowed_commands = ["npx", "uvx", "node", "python", "python3"]
+max_dynamic_servers = 10
+
+[agent.tool_filter]
+enabled = true
+top_k = 5
+always_on = ["memory_search", "memory_save", "load_skill", "bash", "read", "edit"]
+min_description_words = 5
+
+[tools]
+enabled = true
+summarize_output = true
+
+[tools.dependencies]
+enabled = true
+boost_per_dep = 0.15
+max_total_boost = 0.20
+
+[tools.dependencies.rules.web_scrape]
+requires = ["read"]
+
+[tools.dependencies.rules.glob]
+prefers = ["read"]
+
+[tools.shell]
+timeout = 30
+blocked_commands = []
+allowed_commands = []
+allowed_paths = []
+allow_network = true
+confirm_patterns = ["rm ", "git push -f", "git push --force", "drop table", "drop database", "truncate ", "$(", "`", "<(", ">(", "<<<", "eval "]
+
+[tools.scrape]
+timeout = 15
+max_body_bytes = 4194304
+
+[tools.filters]
+enabled = true
+
+[tools.overflow]
+threshold = 50000
+retention_days = 7
+
+[tools.audit]
+enabled = true
+destination = ".local/testing/data/audit-test.jsonl"
+
+[tools.anomaly]
+enabled = true
+window_size = 10
+error_threshold = 0.5
+critical_threshold = 0.8
+
+[cost]
+enabled = true
+max_daily_cents = 500
+
+[vault]
+backend = "age"
+
+[orchestration]
+enabled = true
+max_tasks = 10
+max_parallel = 2
+default_failure_strategy = "abort"
+default_max_retries = 2
+task_timeout_secs = 120
+confirm_before_execute = false
+
+[orchestration.handoff]
+validate_context = true
+verify_output = true
+strict_mode = false
+auto_criteria = false
+
+[orchestration.plan_cache]
+enabled = true
+similarity_threshold = 0.85
+ttl_days = 30
+max_templates = 100
+
+[a2a]
+enabled = false
+
+[security]
+redact_secrets = true
+autonomy_level = "supervised"
+
+[security.content_isolation]
+enabled = true
+max_content_size = 65536
+flag_injection_patterns = true
+spotlight_untrusted = true
+
+[security.content_isolation.quarantine]
+enabled = false
+
+[security.pii_filter]
+enabled = true
+filter_email = true
+filter_phone = true
+filter_ssn = true
+filter_credit_card = true
+
+[security.exfiltration_guard]
+block_markdown_images = true
+validate_tool_urls = true
+guard_memory_writes = true
+
+[timeouts]
+llm_seconds = 120
+llm_request_timeout_secs = 600
+embedding_seconds = 30
+a2a_seconds = 30
+max_parallel_tools = 8
+
+[debug]
+enabled = true
+output_dir = ".local/testing/debug"
+format = "raw"
+
+[tui]
+show_source_labels = true
+
+[scheduler]
+enabled = true
+tick_interval_secs = 60
+
+[gateway]
+enabled = false
+
+[daemon]
+enabled = false
+
+[logging]
+file = ".local/testing/debug/zeph-acp.log"
+
+[observability]
+exporter = ""
+
+[memory.tiers]
+enabled = true
+promotion_min_sessions = 2
+similarity_threshold = 0.85
+sweep_interval_secs = 30
+sweep_batch_size = 10
+
+[llm.router.reputation]
+enabled = true
+decay_factor = 0.95
+weight = 0.3
+min_observations = 3


### PR DESCRIPTION
## Summary

- Adds `config/testing.toml` as a tracked canonical reference config for CI sessions
- Fixes `provider = "openai"` → `provider = "router"` so `[llm.router.reputation]` RAPS config is active
- Keeps identical LLM behavior: `[llm.router]` chain is `["openai"]`, same model/endpoint
- Adds copy instruction in header comment: `cp config/testing.toml .local/config/testing.toml`

**Root cause**: With `provider = "openai"`, bootstrap creates `OpenAIProvider` directly, skipping `[llm.router]` and `[llm.router.reputation]` entirely. `ReputationTracker` is never activated, `record_quality_outcome` is never called.

**Evidence from CI-62**: zero change to `router_reputation_state.json` with `provider = "openai"`. With `provider = "router"` alpha incremented from 5.43 → 6.21 → 6.95 across sessions.

Closes #2104

## Test plan

- [x] `cargo +nightly fmt --check` — pass
- [x] `cargo clippy --workspace --features full -- -D warnings` — pass (0 warnings)
- [x] `cargo nextest run --workspace --features full --lib --bins` — 6363 passed
- [ ] Copy `config/testing.toml` to `.local/config/testing.toml`, run a live session, verify `router_reputation_state.json` updates after tool calls