### PR TITLE
test(cost): add unit test for max_daily_cents=0 unlimited budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing
 
+- test(cost): add unit test for `max_daily_cents = 0.0` unlimited budget behavior — `CostTracker::check_budget()` must return `Ok(())` regardless of spend when the daily limit is zero (#2110)
 - chore(testing): add canonical `config/testing.toml` with `provider = "router"` to enable RAPS/reputation scoring in CI sessions (#2104) — previously `.local/config/testing.toml` used `provider = "openai"` which silently ignored `[llm.router]` and `[llm.router.reputation]`; the new tracked reference config uses `provider = "router"` with `chain = ["openai"]` keeping identical LLM behavior while activating RAPS; copy to `.local/config/testing.toml` before use
 - test(memory): add unit tests for `SqliteStore` tier DB methods (#2094) — covers `fetch_tiers`, `count_messages_by_tier`, `find_promotion_candidates`, `manual_promote`, `promote_to_semantic`, and migration 042 schema defaults; 29 new tests across happy path, edge cases (empty input, already-promoted rows, soft-deleted rows, nonexistent IDs), and idempotency invariants
 

--- a/crates/zeph-core/src/cost.rs
+++ b/crates/zeph-core/src/cost.rs
@@ -311,4 +311,11 @@ mod tests {
         assert!(tracker.check_budget().is_ok());
         assert!((tracker.current_spend() - 0.0).abs() < 0.001);
     }
+
+    #[test]
+    fn check_budget_unlimited_when_max_daily_cents_is_zero() {
+        let tracker = CostTracker::new(true, 0.0);
+        tracker.record_usage("claude-opus-4-20250514", 100_000, 100_000);
+        assert!(tracker.check_budget().is_ok());
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `check_budget_unlimited_when_max_daily_cents_is_zero` to `crates/zeph-core/src/cost.rs`
- Covers the branch `if self.max_daily_cents > 0.0 && ...` — confirms that `max_daily_cents = 0.0` means unlimited regardless of accumulated spend
- Updates `CHANGELOG.md` `[Unreleased]` Testing section

## Test plan

- [ ] `cargo nextest run -p zeph-core -E 'test(check_budget_unlimited)'` — passes
- [ ] `cargo +nightly fmt --check` — OK
- [ ] `cargo clippy --workspace -- -D warnings` — OK
- [ ] `cargo nextest run --workspace --lib --bins` — 5915 passed

Closes #2110