### PR TITLE
fix(tui): remove duplicate ToolStart/ToolOutput events in TUI bridge (#2116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- fix(tui): remove duplicate ToolStart/ToolOutput events from `forward_tool_events_to_tui` bridge (#2116) — `ToolEvent::Started` and `ToolEvent::Completed` are now skipped in the bridge; `TuiChannel::send_tool_start` / `send_tool_output` (called via the `Channel` trait) are the sole source of these events
 - fix(memory): AOI tier promotion FOREIGN KEY constraint violation (#2102) — `run_promotion_sweep()` used `ConversationId(0)` as a sentinel for promoted semantic facts, but `conversations` uses `AUTOINCREMENT` starting at 1 so id=0 never exists; replaced with the real `conversation_id` from the highest-ranked candidate in the cluster; `PromotionCandidate` now carries `conversation_id` propagated from `find_promotion_candidates()` SELECT; added FK regression guard test and `find_promotion_candidates` conversation_id assertion test
 - fix(skills): convert unsupported `>-` YAML block scalar modifier to `>` in all 19 skill files in `.zeph/skills/` — resolves silent load failures for all rewritten skills; 9 new skills (archive, cron, database, json-yaml, network, process-management, qdrant, regex, ssh-remote, text-processing) were completely unavailable (#2087)
 

--- a/src/tui_bridge.rs
+++ b/src/tui_bridge.rs
@@ -207,10 +207,13 @@ pub(crate) async fn forward_tool_events_to_tui(
     mut rx: tokio::sync::mpsc::UnboundedReceiver<zeph_tools::ToolEvent>,
     tx: tokio::sync::mpsc::Sender<zeph_tui::AgentEvent>,
 ) {
+    // Only forward streaming chunks. ToolStart and ToolOutput are already sent via
+    // TuiChannel::send_tool_start / send_tool_output from the Channel trait — forwarding
+    // Started and Completed here would duplicate those events in the TUI.
     while let Some(event) = rx.recv().await {
         let agent_event = match event {
-            zeph_tools::ToolEvent::Started { tool_name, command } => {
-                zeph_tui::AgentEvent::ToolStart { tool_name, command }
+            zeph_tools::ToolEvent::Started { .. } | zeph_tools::ToolEvent::Completed { .. } => {
+                continue;
             }
             zeph_tools::ToolEvent::OutputChunk {
                 tool_name,
@@ -221,36 +224,64 @@ pub(crate) async fn forward_tool_events_to_tui(
                 command,
                 chunk: zeph_tools::strip_ansi(&chunk),
             },
-            zeph_tools::ToolEvent::Completed {
-                tool_name,
-                command,
-                output,
-                success,
-                diff,
-                filter_stats,
-            } => {
-                let stats_line = filter_stats.as_ref().and_then(|fs| {
-                    (fs.filtered_chars < fs.raw_chars)
-                        .then(|| format!("{:.1}% filtered", fs.savings_pct()))
-                });
-                let kept = filter_stats
-                    .as_ref()
-                    .filter(|fs| !fs.kept_lines.is_empty())
-                    .map(|fs| fs.kept_lines.clone());
-                zeph_tui::AgentEvent::ToolOutput {
-                    tool_name,
-                    command,
-                    output,
-                    success,
-                    diff,
-                    filter_stats: stats_line,
-                    kept_lines: kept,
-                }
-            }
         };
         if tx.send(agent_event).await.is_err() {
             break;
         }
+    }
+}
+
+#[cfg(all(test, feature = "tui"))]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn forward_tool_events_skips_started_and_completed() {
+        let (tool_tx, tool_rx) = tokio::sync::mpsc::unbounded_channel::<zeph_tools::ToolEvent>();
+        let (agent_tx, mut agent_rx) = tokio::sync::mpsc::channel::<zeph_tui::AgentEvent>(16);
+
+        tokio::spawn(forward_tool_events_to_tui(tool_rx, agent_tx));
+
+        tool_tx
+            .send(zeph_tools::ToolEvent::Started {
+                tool_name: "shell".into(),
+                command: "ls".into(),
+            })
+            .unwrap();
+        tool_tx
+            .send(zeph_tools::ToolEvent::OutputChunk {
+                tool_name: "shell".into(),
+                command: "ls".into(),
+                chunk: "file.txt\n".into(),
+            })
+            .unwrap();
+        tool_tx
+            .send(zeph_tools::ToolEvent::Completed {
+                tool_name: "shell".into(),
+                command: "ls".into(),
+                output: "file.txt\n".into(),
+                success: true,
+                diff: None,
+                filter_stats: None,
+            })
+            .unwrap();
+        drop(tool_tx);
+
+        let mut received = Vec::new();
+        while let Some(ev) = agent_rx.recv().await {
+            received.push(ev);
+        }
+
+        assert_eq!(
+            received.len(),
+            1,
+            "expected exactly one event (OutputChunk)"
+        );
+        assert!(
+            matches!(received[0], zeph_tui::AgentEvent::ToolOutputChunk { .. }),
+            "expected ToolOutputChunk, got {:?}",
+            received[0]
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

- Fixes #2116 — tool calls displayed twice in TUI mode
- `forward_tool_events_to_tui` was forwarding `ToolEvent::Started` and `ToolEvent::Completed` as `AgentEvent::ToolStart`/`ToolOutput`, duplicating events already sent by `TuiChannel::send_tool_start`/`send_tool_output` from the Channel trait
- Now only `ToolEvent::OutputChunk` is forwarded (for real-time streaming); `Started` and `Completed` are skipped

## Root Cause

Two independent paths wrote to the same `agent_event_tx` channel:

| Path | Events |
|------|--------|
| `TuiChannel` (Channel trait) | `ToolStart`, `ToolOutput` ← authoritative |
| `forward_tool_events_to_tui` | `ToolStart`, `ToolOutputChunk`, `ToolOutput` ← `Started`/`Completed` were duplicates |

## Changes

- `src/tui_bridge.rs`: skip `ToolEvent::Started` and `ToolEvent::Completed` in `forward_tool_events_to_tui`; add regression test `forward_tool_events_skips_started_and_completed`
- `CHANGELOG.md`: entry in `[Unreleased] ### Fixed`

## Test Plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --features full -- -D warnings` — no new warnings
- [x] `cargo nextest run --workspace --features full --lib --bins` — **6367 passed** (+1 regression test)
- [x] Regression test `forward_tool_events_skips_started_and_completed` passes: sends Started + OutputChunk + Completed, asserts only 1 `ToolOutputChunk` event received
- [x] No data loss: `filter_stats`/`diff`/`kept_lines` are delivered via `TuiChannel::send_tool_output` in `native.rs:1546` — the removed `Completed` forwarding never used these values