### PR TITLE
chore(deps): update github-actions

### DIFF
--- a/.github/workflows/ci-non-linux.yml
+++ b/.github/workflows/ci-non-linux.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           cache-targets: "false"
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
-      - uses: taiki-e/install-action@9786bf093d06fe2c715bc12b6ff3b97a491cab4f # nextest
+      - uses: taiki-e/install-action@6ee2d1f3a2f8ca91cc2bf3180c6ec89fb3a109ad # nextest
       - name: Build and archive tests
         run: cargo nextest archive --config-file .github/nextest.toml --workspace --features full --lib --bins --archive-file nextest-archive.tar.zst
         env:
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.ref }}
-      - uses: taiki-e/install-action@9786bf093d06fe2c715bc12b6ff3b97a491cab4f # nextest
+      - uses: taiki-e/install-action@6ee2d1f3a2f8ca91cc2bf3180c6ec89fb3a109ad # nextest
       - name: Download test archive
         uses: actions/download-artifact@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
         with:
           cache-targets: "false"
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
-      - uses: taiki-e/install-action@9786bf093d06fe2c715bc12b6ff3b97a491cab4f # nextest
+      - uses: taiki-e/install-action@6ee2d1f3a2f8ca91cc2bf3180c6ec89fb3a109ad # nextest
       - name: Build and archive tests
         run: cargo nextest archive --config-file .github/nextest.toml --cargo-profile ci --workspace --features full --lib --bins --tests --archive-file nextest-archive.tar.zst
         env:
@@ -198,7 +198,7 @@ jobs:
         partition: ["1/4", "2/4", "3/4", "4/4"]
     steps:
       - uses: actions/checkout@v6
-      - uses: taiki-e/install-action@9786bf093d06fe2c715bc12b6ff3b97a491cab4f # nextest
+      - uses: taiki-e/install-action@6ee2d1f3a2f8ca91cc2bf3180c6ec89fb3a109ad # nextest
       - name: Download test archive
         uses: actions/download-artifact@v7
         with:
@@ -220,7 +220,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
-      - uses: taiki-e/install-action@9786bf093d06fe2c715bc12b6ff3b97a491cab4f # nextest
+      - uses: taiki-e/install-action@6ee2d1f3a2f8ca91cc2bf3180c6ec89fb3a109ad # nextest
       - name: Download test archive
         uses: actions/download-artifact@v7
         with:
@@ -243,15 +243,15 @@ jobs:
         with:
           cache-targets: "false"
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
-      - uses: taiki-e/install-action@cc19c700fe6a7d5586ed0f40851f53637847e8dc # cargo-llvm-cov
-      - uses: taiki-e/install-action@9786bf093d06fe2c715bc12b6ff3b97a491cab4f # nextest
+      - uses: taiki-e/install-action@cff9fdfca2088e53d33015e47b75d0653d76aa25 # cargo-llvm-cov
+      - uses: taiki-e/install-action@6ee2d1f3a2f8ca91cc2bf3180c6ec89fb3a109ad # nextest
       - name: Generate coverage
         run: cargo llvm-cov nextest --config-file .github/nextest.toml --cargo-profile ci --workspace --features full --lib --bins --lcov --output-path lcov.info
         env:
           RUSTC_WRAPPER: sccache
           SCCACHE_GHA_ENABLED: "true"
       - name: Upload coverage
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
@@ -297,7 +297,7 @@ jobs:
           exit-code: '1'
           limit-severities-for-sarif: true
       - name: Upload Trivy results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4
         if: always()
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/openai-integration.yml
+++ b/.github/workflows/openai-integration.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         if: steps.secrets-check.outputs.skip == 'false'
 
-      - uses: taiki-e/install-action@9786bf093d06fe2c715bc12b6ff3b97a491cab4f # nextest
+      - uses: taiki-e/install-action@6ee2d1f3a2f8ca91cc2bf3180c6ec89fb3a109ad # nextest
         if: steps.secrets-check.outputs.skip == 'false'
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-targets: "false"
-      - uses: taiki-e/install-action@56720d582cf58295f40f53e94c01dfddeab22f1d # cross
+      - uses: taiki-e/install-action@879e9c8ba9a16a9dde5253c07a5826b902ca048c # cross
       - name: Build binary (cross)
         if: matrix.use_cross
         run: cross build --release --features full --target ${{ matrix.target }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: renovatebot/github-action@8d75b92f43899d483728e9a8a7fd44238020f6e6 # v46.1.2
+      - uses: renovatebot/github-action@abd08c7549b2a864af5df4a2e369c43f035a6a9d # v46.1.5
         env:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - uses: taiki-e/install-action@91088e9c58a0023c1d75564c5a813cf8f8f50fea # cargo-deny
+      - uses: taiki-e/install-action@d03f93f522d3f26de755b383f3ba3f8d77b79f69 # cargo-deny
       - name: Check advisories and licenses
         run: cargo deny check --config .github/deny.toml
         env:

--- a/.github/workflows/telegram-e2e.yml
+++ b/.github/workflows/telegram-e2e.yml
@@ -94,7 +94,7 @@ jobs:
         if: steps.secrets-check.outputs.skip == 'false'
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.14.3"
           cache: pip
 
       - name: Install Telethon


### PR DESCRIPTION
## Summary

- Bump `taiki-e/install-action` (nextest, cargo-llvm-cov) to latest SHAs
- Bump `codecov/codecov-action` v5 to latest SHA
- Bump `github/codeql-action/upload-sarif` v4 to latest SHA
- Applies to `ci.yml`, `ci-non-linux.yml`, `openai-integration.yml`, `release.yml`, `renovate.yml`, `security.yml`, `telegram-e2e.yml`

## Checklist

- [x] SHA pins updated across all workflows
- [x] No logic changes — version bump only