### PR TITLE
fix(core,mcp): provider display name and MCP injection false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - fix(llm): `TriageRouter` now delegates `embed()` to the first embedding-capable tier provider instead of always returning `EmbeddingNotSupported`; `supports_embeddings()` reflects tier provider capability — resolves tool schema filter being silently disabled when `routing = "triage"` (#2174)
+- fix(core): `/provider` switch and `/provider status` now display the configured `name` field from `[[llm.providers]]` instead of the provider type string (e.g. `"openai"`); `active_provider_name` stored in `RuntimeConfig` and updated on every switch (#2173)
+- fix(mcp): narrow `new_directive` injection pattern to require colon suffix, preventing false positive match on legitimate phrases like "new persona" in Todoist MCP tool descriptions; add regression test (#2170)
 - fix(memory): run `PRAGMA wal_checkpoint(PASSIVE)` after FTS5 entity inserts to fix cross-session SYNAPSE seed lookup (#2166); checkpoint is called at `SqliteStore` startup (safety net) and after every `EntityResolver::resolve_batch` (targeted hook)
 - fix(config): add `[security.guardrail]` stub to `default.toml` so `--migrate-config` injects commented guardrail defaults for configs that have `[security]` but no `[security.guardrail]` (#2158)
 - ci: increase publish-crates timeout from 20 to 60 minutes and add `no-verify: true` to skip recompilation during publish (workspace has 21 crates; sequential publish with 15 s delays exceeded the previous limit)

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -636,6 +636,16 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Set the configured provider name (from `[[llm.providers]]` `name` field).
+    ///
+    /// Used by the TUI metrics panel and `/provider status` to display the logical name
+    /// instead of the provider type string returned by `LlmProvider::name()`.
+    #[must_use]
+    pub fn with_active_provider_name(mut self, name: impl Into<String>) -> Self {
+        self.runtime.active_provider_name = name.into();
+        self
+    }
+
     #[must_use]
     pub fn with_working_dir(mut self, path: impl Into<PathBuf>) -> Self {
         let path = path.into();
@@ -683,7 +693,11 @@ impl<C: Channel> Agent<C> {
     /// Panics if the registry `RwLock` is poisoned.
     #[must_use]
     pub fn with_metrics(mut self, tx: watch::Sender<MetricsSnapshot>) -> Self {
-        let provider_name = self.provider.name().to_string();
+        let provider_name = if self.runtime.active_provider_name.is_empty() {
+            self.provider.name().to_owned()
+        } else {
+            self.runtime.active_provider_name.clone()
+        };
         let model_name = self.runtime.model_name.clone();
         let total_skills = self
             .skill_state

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -308,6 +308,7 @@ impl<C: Channel> Agent<C> {
                 security: SecurityConfig::default(),
                 timeouts: TimeoutConfig::default(),
                 model_name: String::new(),
+                active_provider_name: String::new(),
                 permission_policy: zeph_tools::PermissionPolicy::default(),
                 redact_credentials: true,
                 rate_limiter: rate_limiter::ToolRateLimiter::new(

--- a/crates/zeph-core/src/agent/provider_cmd.rs
+++ b/crates/zeph-core/src/agent/provider_cmd.rs
@@ -29,12 +29,20 @@ impl<C: Channel> Agent<C> {
                 .await;
             return;
         }
-        let current = self.provider.name().to_owned();
+        let current = if self.runtime.active_provider_name.is_empty() {
+            self.provider.name().to_owned()
+        } else {
+            self.runtime.active_provider_name.clone()
+        };
         let mut lines = vec!["Configured providers:".to_string()];
         for (i, entry) in pool.iter().enumerate() {
             let name = entry.effective_name();
             let model = entry.model.as_deref().unwrap_or("(default)");
-            let marker = if name == current { " (active)" } else { "" };
+            let marker = if name.eq_ignore_ascii_case(&current) {
+                " (active)"
+            } else {
+                ""
+            };
             lines.push(format!(
                 "  {}. {} [{}] model={}{}",
                 i + 1,
@@ -49,7 +57,12 @@ impl<C: Channel> Agent<C> {
 
     async fn handle_provider_status(&mut self) {
         let mut out = String::from("Current provider:\n\n");
-        let _ = writeln!(out, "Name:  {}", self.provider.name());
+        let display_name = if self.runtime.active_provider_name.is_empty() {
+            self.provider.name().to_owned()
+        } else {
+            self.runtime.active_provider_name.clone()
+        };
+        let _ = writeln!(out, "Name:  {display_name}");
         let _ = writeln!(out, "Model: {}", self.runtime.model_name);
         if let Some(ref tx) = self.metrics.metrics_tx {
             let m = tx.borrow();
@@ -94,13 +107,15 @@ impl<C: Channel> Agent<C> {
         };
 
         // Warn if the provider is already active.
-        if self.provider.name().eq_ignore_ascii_case(name) {
+        let current_name = if self.runtime.active_provider_name.is_empty() {
+            self.provider.name().to_owned()
+        } else {
+            self.runtime.active_provider_name.clone()
+        };
+        if current_name.eq_ignore_ascii_case(name) {
             let _ = self
                 .channel
-                .send(&format!(
-                    "Provider '{}' is already active.",
-                    self.provider.name()
-                ))
+                .send(&format!("Provider '{current_name}' is already active."))
                 .await;
             return;
         }
@@ -118,9 +133,12 @@ impl<C: Channel> Agent<C> {
                 // Resolve actual model name: use the entry's effective model (explicit or
                 // provider-type default) instead of the provider type string returned by name().
                 let model_name = entry.effective_model();
+                // Use the configured name from [[llm.providers]] for display and metrics.
+                let configured_name = entry.effective_name();
 
                 self.provider = new_provider;
                 self.runtime.model_name = model_name.clone();
+                self.runtime.active_provider_name = configured_name.clone();
 
                 // Reset state that is provider-specific.
                 self.providers.cached_prompt_tokens = 0;
@@ -131,7 +149,7 @@ impl<C: Channel> Agent<C> {
 
                 // C2: Log provider switch in metrics for cost-tracking boundary awareness.
                 tracing::info!(
-                    provider = self.provider.name(),
+                    provider = configured_name,
                     model = model_name,
                     "provider switched via /provider command"
                 );
@@ -159,9 +177,8 @@ impl<C: Channel> Agent<C> {
                     .as_ref()
                     .and_then(|c| c.generation.top_p.map(|v| v as f32));
                 let switched_model = self.runtime.model_name.clone();
-                let switched_provider = self.provider.name().to_owned();
                 self.update_metrics(|m| {
-                    m.provider_name = switched_provider;
+                    m.provider_name.clone_from(&configured_name);
                     m.model_name = switched_model;
                     m.provider_temperature = provider_temperature;
                     m.provider_top_p = provider_top_p;
@@ -171,8 +188,7 @@ impl<C: Channel> Agent<C> {
                     .channel
                     .send(&format!(
                         "Switched to provider: {} (model: {})",
-                        self.provider.name(),
-                        self.runtime.model_name
+                        configured_name, self.runtime.model_name
                     ))
                     .await;
             }

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -100,6 +100,9 @@ pub(crate) struct RuntimeConfig {
     pub(crate) security: SecurityConfig,
     pub(crate) timeouts: TimeoutConfig,
     pub(crate) model_name: String,
+    /// Configured name from `[[llm.providers]]` (the `name` field), set at startup and on
+    /// `/provider` switch. Falls back to the provider type string when empty.
+    pub(crate) active_provider_name: String,
     pub(crate) permission_policy: zeph_tools::PermissionPolicy,
     pub(crate) redact_credentials: bool,
     pub(crate) rate_limiter: super::rate_limiter::ToolRateLimiter,

--- a/crates/zeph-core/src/agent/state/tests.rs
+++ b/crates/zeph-core/src/agent/state/tests.rs
@@ -79,6 +79,7 @@ fn make_runtime_config() -> RuntimeConfig {
         security: SecurityConfig::default(),
         timeouts: TimeoutConfig::default(),
         model_name: String::new(),
+        active_provider_name: String::new(),
         permission_policy: zeph_tools::PermissionPolicy::default(),
         redact_credentials: true,
         rate_limiter: ToolRateLimiter::new(RateLimitConfig::default()),

--- a/crates/zeph-mcp/src/sanitize.rs
+++ b/crates/zeph-mcp/src/sanitize.rs
@@ -812,6 +812,23 @@ mod tests {
         assert_eq!(result, "[sanitized]");
     }
 
+    // Regression for #2170: "new persona" in legitimate Todoist API tool descriptions must NOT
+    // trigger injection detection — only "new instructions:" / "new directives:" syntax should.
+    #[test]
+    fn new_persona_in_tool_description_not_flagged() {
+        let result = sanitize_string(
+            "add-labels: Add labels to a task. Use this to assign a new persona label or category.",
+            "todoist",
+            "add-labels",
+            "description",
+            MAX_TOOL_DESCRIPTION_BYTES,
+        );
+        assert_ne!(
+            result, "[sanitized]",
+            "'new persona' in legitimate tool description must not be flagged as injection"
+        );
+    }
+
     #[test]
     fn developer_mode_detected() {
         let result = sanitize_string(

--- a/crates/zeph-tools/src/patterns.rs
+++ b/crates/zeph-tools/src/patterns.rs
@@ -34,7 +34,7 @@ pub const RAW_INJECTION_PATTERNS: &[(&str, &str)] = &[
     ("role_override", r"(?i)you\s+are\s+now"),
     (
         "new_directive",
-        r"(?i)new\s+(instructions?|directives?|roles?|personas?)",
+        r"(?i)new\s+(instructions?|directives?)\s*:",
     ),
     ("developer_mode", r"(?i)developer\s+mode"),
     ("system_prompt_leak", r"(?i)system\s+prompt"),

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -871,6 +871,10 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         tool_executor,
     )
     .apply_session_config(session_config)
+    .with_active_provider_name(config.llm.providers.first().map_or_else(
+        || provider.name().to_owned(),
+        zeph_core::config::ProviderEntry::effective_name,
+    ))
     .with_disambiguation_threshold(config.skills.disambiguation_threshold)
     .with_skill_reload(skill_paths.clone(), reload_rx)
     .with_managed_skills_dir(zeph_core::bootstrap::managed_skills_dir())


### PR DESCRIPTION
## Summary

- `/provider` switch and `/provider status` now show the configured `name` from `[[llm.providers]]` instead of the provider type string (e.g. `openai`) — fixes #2173
- Narrowed `new_directive` injection pattern to require a colon suffix, eliminating false positive on "new persona" in Todoist MCP tool descriptions — fixes #2170

## Changes

**#2173 — provider name display:**
- `RuntimeConfig`: added `active_provider_name: String` field
- `builder.rs`: `with_active_provider_name()` builder method
- `provider_cmd.rs`: switch/status/list handlers use `active_provider_name` (fallback to `provider.name()` when empty)
- `runner.rs`: initializes `active_provider_name` from first pool entry at startup

**#2170 — MCP injection false positive:**
- `patterns.rs`: `new_directive` regex narrowed from `new\s+(instructions?|directives?|roles?|personas?)` to `new\s+(instructions?|directives?)\s*:` — colon suffix required
- `sanitize.rs`: regression test `new_persona_in_tool_description_not_flagged` added

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --features full --workspace --lib --bins -- -D warnings` — clean
- [ ] `cargo nextest run --workspace --features full --lib --bins` — 6469 passed, 0 failed
- [ ] Regression test `new_persona_in_tool_description_not_flagged` passes
- [ ] Existing `/provider` tests pass (list/status/switch/already-active paths)