### PR TITLE
feat(config): unify STT provider under [[llm.providers]] with stt_model field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- feat(config): unify STT provider under `[[llm.providers]]` (#2175) — `SttConfig` now holds only `provider` (name reference) and `language`; `model` and `base_url` move to a `stt_model` field on `ProviderEntry` (mirrors `embedding_model` pattern); `LlmConfig::stt_provider_entry()` resolves the active STT entry by name with auto-detect fallback to the first entry with `stt_model`; `LlmConfig::validate_stt()` checks cross-reference consistency; `migrate_stt_to_provider()` auto-converts old `[llm.stt]` `model`/`base_url` fields to `stt_model` on the matching provider entry (W2: forces explicit `name` on migrated entries); env vars `ZEPH_STT_MODEL` and `ZEPH_STT_BASE_URL` removed (log deprecation warning); unified dispatch in `runner.rs` respects `#[cfg(feature = "candle")]` and `#[cfg(feature = "stt")]` gates with explicit error log when feature is absent; TUI metrics `stt_model` now read from resolved `ProviderEntry`
+
+### Breaking Changes
+
+- `[llm.stt].model` and `[llm.stt].base_url` fields removed from `SttConfig`; move them to `stt_model` / `base_url` on the corresponding `[[llm.providers]]` entry. Run `zeph --migrate-config --in-place` to auto-convert.
+- `ZEPH_STT_MODEL` and `ZEPH_STT_BASE_URL` environment variables no longer applied; use provider-level config instead.
+
 - feat(tui): Phase 2 dynamic metrics — add `stt_model`, `compaction_model`, `provider_temperature`, `provider_top_p`, `active_channel`, `embedding_model`, `token_budget`, `self_learning_enabled`, `semantic_cache_enabled` to `MetricsSnapshot`; status bar shows active model name and `ch:<channel>` segment; resources panel shows embedding model, token budget, and learning flag; `/provider` switch updates `provider_temperature`/`provider_top_p` in real time for Candle providers (#2160)
 - feat(tui): Phase 1 dynamic metrics in TUI — 8 new fields in `MetricsSnapshot` (`embedding_model`, `token_budget`, `compaction_threshold`, `vault_backend`, `active_channel`, `self_learning_enabled`, `cache_enabled`, `autosave_enabled`); Resources panel redesigned with LLM/Session/Infra grouped sections and overflow collapse at height < 30; status bar shows active model name replacing the low-value Panel toggle indicator
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -26,10 +26,16 @@ max_tool_iterations = 10
 # response_cache_enabled = false
 # response_cache_ttl_secs = 3600
 
-# Speech-to-text provider (Whisper API)
+# Speech-to-text: set stt_model on a [[llm.providers]] entry to enable STT.
+# Then reference that provider name in [llm.stt].
+# [[llm.providers]]
+# name = "openai-stt"
+# type = "openai"
+# stt_model = "whisper-1"
+#
 # [llm.stt]
-# provider = "whisper"
-# model = "whisper-1"
+# provider = "openai-stt"
+# language = "auto"
 
 # Provider pool: each [[llm.providers]] entry defines one backend.
 # The first entry (or the one with default = true) is the primary chat provider.

--- a/config/testing.toml
+++ b/config/testing.toml
@@ -11,28 +11,23 @@ auto_update_check = false
 instruction_auto_detect = true
 
 [llm]
-provider = "router"
-base_url = "https://api.openai.com/v1"
-model = "gpt-4o-mini"
-max_tokens = 4096
-embedding_model = "text-embedding-3-small"
 response_cache_enabled = false
 
-[llm.openai]
-base_url = "https://api.openai.com/v1"
-model = "gpt-4o-mini"
+[[llm.providers]]
+type = "openai"
+name = "quality"
+model = "gpt-5.4"
 max_tokens = 4096
 embedding_model = "text-embedding-3-small"
+stt_model = "gpt-4o-mini-transcribe"
 
 [llm.stt]
-provider = "whisper"
-model = "gpt-4o-mini-transcribe"
-base_url = "https://api.openai.com/v1"
+provider = "quality"
 language = "auto"
 
 # Router: openai as primary (used for RAPS/Thompson testing)
 [llm.router]
-chain = ["openai"]
+chain = ["quality"]
 
 # Quality fallback: MoE model (35B params, 3B active)
 # Requires: export ZEPH_COMPATIBLE_QUALITY_API_KEY=unused

--- a/crates/zeph-config/src/env.rs
+++ b/crates/zeph-config/src/env.rs
@@ -1,9 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::providers::{
-    ProviderEntry, SttConfig, default_stt_language, default_stt_model, default_stt_provider,
-};
+use crate::providers::{ProviderEntry, SttConfig, default_stt_language, default_stt_provider};
 use crate::root::Config;
 
 impl Config {
@@ -220,38 +218,28 @@ impl Config {
         if let Ok(v) = std::env::var("ZEPH_STT_PROVIDER") {
             let stt = self.llm.stt.get_or_insert_with(|| SttConfig {
                 provider: default_stt_provider(),
-                model: default_stt_model(),
                 language: default_stt_language(),
-                base_url: None,
             });
             stt.provider = v;
-        }
-        if let Ok(v) = std::env::var("ZEPH_STT_MODEL") {
-            let stt = self.llm.stt.get_or_insert_with(|| SttConfig {
-                provider: default_stt_provider(),
-                model: default_stt_model(),
-                language: default_stt_language(),
-                base_url: None,
-            });
-            stt.model = v;
         }
         if let Ok(v) = std::env::var("ZEPH_STT_LANGUAGE") {
             let stt = self.llm.stt.get_or_insert_with(|| SttConfig {
                 provider: default_stt_provider(),
-                model: default_stt_model(),
                 language: default_stt_language(),
-                base_url: None,
             });
             stt.language = v;
         }
-        if let Ok(v) = std::env::var("ZEPH_STT_BASE_URL") {
-            let stt = self.llm.stt.get_or_insert_with(|| SttConfig {
-                provider: default_stt_provider(),
-                model: default_stt_model(),
-                language: default_stt_language(),
-                base_url: None,
-            });
-            stt.base_url = Some(v);
+        if std::env::var("ZEPH_STT_MODEL").is_ok() {
+            tracing::warn!(
+                "env var ZEPH_STT_MODEL is no longer supported; set `stt_model` on the \
+                 [[llm.providers]] entry instead"
+            );
+        }
+        if std::env::var("ZEPH_STT_BASE_URL").is_ok() {
+            tracing::warn!(
+                "env var ZEPH_STT_BASE_URL is no longer supported; set `base_url` on the \
+                 [[llm.providers]] entry instead"
+            );
         }
     }
 

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -61,7 +61,7 @@ pub use providers::{
     ProviderEntry, ProviderKind, RouterConfig, RouterStrategyConfig, SttConfig, TierMapping,
     validate_pool,
 };
-pub use providers::{default_stt_language, default_stt_model, default_stt_provider};
+pub use providers::{default_stt_language, default_stt_provider};
 pub use rate_limit::RateLimitConfig;
 pub use sanitizer::{
     ContentIsolationConfig, CustomPiiPattern, ExfiltrationGuardConfig, MemoryWriteValidationConfig,

--- a/crates/zeph-config/src/memory.rs
+++ b/crates/zeph-config/src/memory.rs
@@ -1081,13 +1081,13 @@ mod tests {
     #[test]
     fn importance_weight_valid_zero() {
         let cfg = deserialize_importance_weight("0.0").unwrap();
-        assert_eq!(cfg.importance_weight, 0.0);
+        assert!((cfg.importance_weight - 0.0_f64).abs() < f64::EPSILON);
     }
 
     #[test]
     fn importance_weight_valid_one() {
         let cfg = deserialize_importance_weight("1.0").unwrap();
-        assert_eq!(cfg.importance_weight, 1.0);
+        assert!((cfg.importance_weight - 1.0_f64).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/crates/zeph-config/src/migrate.rs
+++ b/crates/zeph-config/src/migrate.rs
@@ -49,6 +49,10 @@ pub enum MigrateError {
     /// Failed to parse the embedded reference config (should never happen in practice).
     #[error("failed to parse reference config: {0}")]
     Reference(toml_edit::TomlError),
+    /// The document structure is inconsistent (e.g. `[llm.stt].model` exists but `[llm]` table
+    /// cannot be obtained as a mutable table — can happen when `[llm]` is absent or not a table).
+    #[error("migration failed: invalid TOML structure — {0}")]
+    InvalidStructure(&'static str),
 }
 
 /// Result of a migration operation.
@@ -946,6 +950,201 @@ fn replace_llm_section(toml_str: &str, new_llm_section: &str) -> String {
     out
 }
 
+/// Migrate an old `[llm.stt]` section (with `model` / `base_url` fields) to the new format
+/// where those fields live on a `[[llm.providers]]` entry via `stt_model`.
+///
+/// Transformations:
+/// - `[llm.stt].model` → `stt_model` on the matching or new `[[llm.providers]]` entry
+/// - `[llm.stt].base_url` → `base_url` on that entry (skipped when already present)
+/// - `[llm.stt].provider` is updated to the provider name; the entry is assigned an explicit
+///   `name` when it lacked one (W2 guard).
+/// - Old `model` and `base_url` keys are stripped from `[llm.stt]`.
+///
+/// If `[llm.stt]` is absent or already uses the new format (no `model` / `base_url`), the
+/// input is returned unchanged.
+///
+/// # Errors
+///
+/// Returns `MigrateError::Parse` if the input TOML is invalid.
+/// Returns `MigrateError::InvalidStructure` if `[llm.stt].model` is present but the `[llm]`
+/// key is absent or not a table, making mutation impossible.
+#[allow(clippy::too_many_lines)]
+pub fn migrate_stt_to_provider(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    let mut doc = toml_src.parse::<toml_edit::DocumentMut>()?;
+
+    // Extract fields from [llm.stt] if present.
+    let stt_model = doc
+        .get("llm")
+        .and_then(toml_edit::Item::as_table)
+        .and_then(|llm| llm.get("stt"))
+        .and_then(toml_edit::Item::as_table)
+        .and_then(|stt| stt.get("model"))
+        .and_then(toml_edit::Item::as_str)
+        .map(ToOwned::to_owned);
+
+    let stt_base_url = doc
+        .get("llm")
+        .and_then(toml_edit::Item::as_table)
+        .and_then(|llm| llm.get("stt"))
+        .and_then(toml_edit::Item::as_table)
+        .and_then(|stt| stt.get("base_url"))
+        .and_then(toml_edit::Item::as_str)
+        .map(ToOwned::to_owned);
+
+    let stt_provider_hint = doc
+        .get("llm")
+        .and_then(toml_edit::Item::as_table)
+        .and_then(|llm| llm.get("stt"))
+        .and_then(toml_edit::Item::as_table)
+        .and_then(|stt| stt.get("provider"))
+        .and_then(toml_edit::Item::as_str)
+        .map(ToOwned::to_owned)
+        .unwrap_or_default();
+
+    // Nothing to migrate if [llm.stt] does not exist or already lacks the old fields.
+    if stt_model.is_none() && stt_base_url.is_none() {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            added_count: 0,
+            sections_added: Vec::new(),
+        });
+    }
+
+    let stt_model = stt_model.unwrap_or_else(|| "whisper-1".to_owned());
+
+    // Determine the target provider type based on provider hint.
+    let target_type = match stt_provider_hint.as_str() {
+        "candle-whisper" | "candle" => "candle",
+        _ => "openai",
+    };
+
+    // Find or create a [[llm.providers]] entry to attach stt_model to.
+    // Priority: entry whose effective name matches the hint, else first entry of matching type.
+    let providers = doc
+        .get("llm")
+        .and_then(toml_edit::Item::as_table)
+        .and_then(|llm| llm.get("providers"))
+        .and_then(toml_edit::Item::as_array_of_tables);
+
+    let matching_idx = providers.and_then(|arr| {
+        arr.iter().enumerate().find_map(|(i, t)| {
+            let name = t
+                .get("name")
+                .and_then(toml_edit::Item::as_str)
+                .unwrap_or("");
+            let ptype = t
+                .get("type")
+                .and_then(toml_edit::Item::as_str)
+                .unwrap_or("");
+            // Match by explicit name hint or by type when hint is a legacy backend string.
+            let name_match = !stt_provider_hint.is_empty()
+                && (name == stt_provider_hint || ptype == stt_provider_hint);
+            let type_match = ptype == target_type;
+            if name_match || type_match {
+                Some(i)
+            } else {
+                None
+            }
+        })
+    });
+
+    // Determine the final provider name to write into [llm.stt].provider.
+    let resolved_provider_name: String;
+
+    if let Some(idx) = matching_idx {
+        // Attach stt_model to the existing entry.
+        let llm_mut = doc
+            .get_mut("llm")
+            .and_then(toml_edit::Item::as_table_mut)
+            .ok_or(MigrateError::InvalidStructure(
+                "[llm] table not accessible for mutation",
+            ))?;
+        let providers_mut = llm_mut
+            .get_mut("providers")
+            .and_then(toml_edit::Item::as_array_of_tables_mut)
+            .ok_or(MigrateError::InvalidStructure(
+                "[[llm.providers]] array not accessible for mutation",
+            ))?;
+        let entry = providers_mut
+            .iter_mut()
+            .nth(idx)
+            .ok_or(MigrateError::InvalidStructure(
+                "[[llm.providers]] entry index out of range during mutation",
+            ))?;
+
+        // W2: ensure explicit name.
+        let existing_name = entry
+            .get("name")
+            .and_then(toml_edit::Item::as_str)
+            .map(ToOwned::to_owned);
+        let entry_name = existing_name.unwrap_or_else(|| {
+            let t = entry
+                .get("type")
+                .and_then(toml_edit::Item::as_str)
+                .unwrap_or("openai");
+            format!("{t}-stt")
+        });
+        entry.insert("name", toml_edit::value(entry_name.clone()));
+        entry.insert("stt_model", toml_edit::value(stt_model.clone()));
+        if stt_base_url.is_some() && entry.get("base_url").is_none() {
+            entry.insert(
+                "base_url",
+                toml_edit::value(stt_base_url.as_deref().unwrap_or_default()),
+            );
+        }
+        resolved_provider_name = entry_name;
+    } else {
+        // No matching entry — append a new [[llm.providers]] block.
+        let new_name = if target_type == "candle" {
+            "local-whisper".to_owned()
+        } else {
+            "openai-stt".to_owned()
+        };
+        let mut new_entry = toml_edit::Table::new();
+        new_entry.insert("name", toml_edit::value(new_name.clone()));
+        new_entry.insert("type", toml_edit::value(target_type));
+        new_entry.insert("stt_model", toml_edit::value(stt_model.clone()));
+        if let Some(ref url) = stt_base_url {
+            new_entry.insert("base_url", toml_edit::value(url.clone()));
+        }
+        // Ensure [[llm.providers]] array exists.
+        let llm_mut = doc
+            .get_mut("llm")
+            .and_then(toml_edit::Item::as_table_mut)
+            .ok_or(MigrateError::InvalidStructure(
+                "[llm] table not accessible for mutation",
+            ))?;
+        if let Some(item) = llm_mut.get_mut("providers") {
+            if let Some(arr) = item.as_array_of_tables_mut() {
+                arr.push(new_entry);
+            }
+        } else {
+            let mut arr = toml_edit::ArrayOfTables::new();
+            arr.push(new_entry);
+            llm_mut.insert("providers", toml_edit::Item::ArrayOfTables(arr));
+        }
+        resolved_provider_name = new_name;
+    }
+
+    // Update [llm.stt]: set provider name, remove old fields.
+    if let Some(stt_table) = doc
+        .get_mut("llm")
+        .and_then(toml_edit::Item::as_table_mut)
+        .and_then(|llm| llm.get_mut("stt"))
+        .and_then(toml_edit::Item::as_table_mut)
+    {
+        stt_table.insert("provider", toml_edit::value(resolved_provider_name.clone()));
+        stt_table.remove("model");
+        stt_table.remove("base_url");
+    }
+
+    Ok(MigrationResult {
+        output: doc.to_string(),
+        added_count: 1,
+        sections_added: vec!["llm.providers.stt_model".to_owned()],
+    })
+}
+
 // Helper to create a formatted value (used in tests).
 #[cfg(test)]
 fn make_formatted_str(s: &str) -> Value {
@@ -1168,10 +1367,7 @@ name = "Test"
     // for a pre-guardrail config that has [security] but no [security.guardrail].
     #[test]
     fn security_without_guardrail_gets_guardrail_commented() {
-        let user = r#"
-[security]
-redact_secrets = true
-"#;
+        let user = "[security]\nredact_secrets = true\n";
         let migrator = ConfigMigrator::new();
         let result = migrator.migrate(user).expect("migrate");
         // The generic diff mechanism must add guardrail keys as commented defaults.
@@ -1399,6 +1595,200 @@ type = "ollama"
         assert!(
             migrate_llm_to_providers(src).is_err(),
             "mixed format must return error"
+        );
+    }
+
+    // ─── migrate_stt_to_provider ──────────────────────────────────────────────
+
+    #[test]
+    fn stt_migration_no_stt_section_returns_unchanged() {
+        let src = "[llm]\n\n[[llm.providers]]\ntype = \"openai\"\nname = \"quality\"\nmodel = \"gpt-5.4\"\n";
+        let result = migrate_stt_to_provider(src).unwrap();
+        assert_eq!(result.added_count, 0);
+        assert_eq!(result.output, src);
+    }
+
+    #[test]
+    fn stt_migration_no_model_or_base_url_returns_unchanged() {
+        let src = "[llm]\n\n[[llm.providers]]\ntype = \"openai\"\nname = \"quality\"\n\n[llm.stt]\nprovider = \"quality\"\nlanguage = \"en\"\n";
+        let result = migrate_stt_to_provider(src).unwrap();
+        assert_eq!(result.added_count, 0);
+    }
+
+    #[test]
+    fn stt_migration_moves_model_to_provider_entry() {
+        let src = r#"
+[llm]
+
+[[llm.providers]]
+type = "openai"
+name = "quality"
+model = "gpt-5.4"
+
+[llm.stt]
+provider = "quality"
+model = "gpt-4o-mini-transcribe"
+language = "en"
+"#;
+        let result = migrate_stt_to_provider(src).unwrap();
+        assert_eq!(result.added_count, 1);
+        // stt_model should appear in providers entry.
+        assert!(
+            result.output.contains("stt_model"),
+            "stt_model must be in output"
+        );
+        // model should be removed from [llm.stt].
+        // The output should parse cleanly.
+        let doc: toml_edit::DocumentMut = result.output.parse().unwrap();
+        let stt = doc
+            .get("llm")
+            .and_then(toml_edit::Item::as_table)
+            .and_then(|l| l.get("stt"))
+            .and_then(toml_edit::Item::as_table)
+            .unwrap();
+        assert!(
+            stt.get("model").is_none(),
+            "model must be removed from [llm.stt]"
+        );
+        assert_eq!(
+            stt.get("provider").and_then(toml_edit::Item::as_str),
+            Some("quality")
+        );
+    }
+
+    #[test]
+    fn stt_migration_creates_new_provider_when_no_match() {
+        let src = r#"
+[llm]
+
+[[llm.providers]]
+type = "ollama"
+name = "local"
+model = "qwen3:8b"
+
+[llm.stt]
+provider = "whisper"
+model = "whisper-1"
+base_url = "https://api.openai.com/v1"
+language = "en"
+"#;
+        let result = migrate_stt_to_provider(src).unwrap();
+        assert!(
+            result.output.contains("openai-stt"),
+            "new entry name must be openai-stt"
+        );
+        assert!(
+            result.output.contains("stt_model"),
+            "stt_model must be in output"
+        );
+    }
+
+    #[test]
+    fn stt_migration_candle_whisper_creates_candle_entry() {
+        let src = r#"
+[llm]
+
+[llm.stt]
+provider = "candle-whisper"
+model = "openai/whisper-tiny"
+language = "auto"
+"#;
+        let result = migrate_stt_to_provider(src).unwrap();
+        assert!(
+            result.output.contains("local-whisper"),
+            "candle entry name must be local-whisper"
+        );
+        assert!(result.output.contains("candle"), "type must be candle");
+    }
+
+    #[test]
+    fn stt_migration_w2_assigns_explicit_name() {
+        // Provider has no explicit name (type = "openai") — migration must assign one.
+        let src = r#"
+[llm]
+
+[[llm.providers]]
+type = "openai"
+model = "gpt-5.4"
+
+[llm.stt]
+provider = "openai"
+model = "whisper-1"
+language = "auto"
+"#;
+        let result = migrate_stt_to_provider(src).unwrap();
+        let doc: toml_edit::DocumentMut = result.output.parse().unwrap();
+        let providers = doc
+            .get("llm")
+            .and_then(toml_edit::Item::as_table)
+            .and_then(|l| l.get("providers"))
+            .and_then(toml_edit::Item::as_array_of_tables)
+            .unwrap();
+        let entry = providers
+            .iter()
+            .find(|t| t.get("stt_model").is_some())
+            .unwrap();
+        // Must have an explicit `name` field (W2).
+        assert!(
+            entry.get("name").is_some(),
+            "migrated entry must have explicit name"
+        );
+    }
+
+    #[test]
+    fn stt_migration_removes_base_url_from_stt_table() {
+        // MEDIUM: verify that base_url is stripped from [llm.stt] after migration.
+        let src = r#"
+[llm]
+
+[[llm.providers]]
+type = "openai"
+name = "quality"
+model = "gpt-5.4"
+
+[llm.stt]
+provider = "quality"
+model = "whisper-1"
+base_url = "https://api.openai.com/v1"
+language = "en"
+"#;
+        let result = migrate_stt_to_provider(src).unwrap();
+        let doc: toml_edit::DocumentMut = result.output.parse().unwrap();
+        let stt = doc
+            .get("llm")
+            .and_then(toml_edit::Item::as_table)
+            .and_then(|l| l.get("stt"))
+            .and_then(toml_edit::Item::as_table)
+            .unwrap();
+        assert!(
+            stt.get("model").is_none(),
+            "model must be removed from [llm.stt]"
+        );
+        assert!(
+            stt.get("base_url").is_none(),
+            "base_url must be removed from [llm.stt]"
+        );
+    }
+
+    #[test]
+    fn migrate_error_invalid_structure_formats_correctly() {
+        // HIGH: verify that MigrateError::InvalidStructure exists, matches correctly, and
+        // produces a human-readable message. The error path is triggered when the [llm] item
+        // is present but cannot be obtained as a mutable table (defensive guard replacing the
+        // previous .expect() calls that would have panicked).
+        let err = MigrateError::InvalidStructure("test sentinel");
+        assert!(
+            matches!(err, MigrateError::InvalidStructure(_)),
+            "variant must match"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("invalid TOML structure"),
+            "error message must mention 'invalid TOML structure', got: {msg}"
+        );
+        assert!(
+            msg.contains("test sentinel"),
+            "message must include reason: {msg}"
         );
     }
 }

--- a/crates/zeph-config/src/providers.rs
+++ b/crates/zeph-config/src/providers.rs
@@ -86,12 +86,7 @@ fn default_reputation_min_observations() -> u64 {
 
 #[must_use]
 pub fn default_stt_provider() -> String {
-    "whisper".into()
-}
-
-#[must_use]
-pub fn default_stt_model() -> String {
-    "whisper-1".into()
+    String::new()
 }
 
 #[must_use]
@@ -262,6 +257,25 @@ impl LlmConfig {
             .unwrap_or("qwen3:8b")
     }
 
+    /// Find the provider entry designated for STT.
+    ///
+    /// Resolution priority:
+    /// 1. `[llm.stt].provider` matches `[[llm.providers]].name` and the entry has `stt_model`
+    /// 2. `[llm.stt].provider` is empty — fall through to auto-detect
+    /// 3. First provider with `stt_model` set (auto-detect fallback)
+    /// 4. `None` — STT disabled
+    #[must_use]
+    pub fn stt_provider_entry(&self) -> Option<&ProviderEntry> {
+        let name_hint = self.stt.as_ref().map_or("", |s| s.provider.as_str());
+        if name_hint.is_empty() {
+            self.providers.iter().find(|p| p.stt_model.is_some())
+        } else {
+            self.providers
+                .iter()
+                .find(|p| p.effective_name() == name_hint && p.stt_model.is_some())
+        }
+    }
+
     /// Validate that the config uses the new `[[llm.providers]]` format.
     ///
     /// # Errors
@@ -270,18 +284,53 @@ impl LlmConfig {
     pub fn check_legacy_format(&self) -> Result<(), crate::error::ConfigError> {
         Ok(())
     }
+
+    /// Validate STT config cross-references.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ConfigError::Validation` when the referenced STT provider does not exist.
+    pub fn validate_stt(&self) -> Result<(), crate::error::ConfigError> {
+        use crate::error::ConfigError;
+
+        let Some(stt) = &self.stt else {
+            return Ok(());
+        };
+        if stt.provider.is_empty() {
+            return Ok(());
+        }
+        let found = self
+            .providers
+            .iter()
+            .find(|p| p.effective_name() == stt.provider);
+        match found {
+            None => {
+                return Err(ConfigError::Validation(format!(
+                    "[llm.stt].provider = {:?} does not match any [[llm.providers]] entry",
+                    stt.provider
+                )));
+            }
+            Some(entry) if entry.stt_model.is_none() => {
+                tracing::warn!(
+                    provider = stt.provider,
+                    "[[llm.providers]] entry exists but has no `stt_model` — STT will not be activated"
+                );
+            }
+            _ => {}
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SttConfig {
+    /// Provider name from `[[llm.providers]]`. Empty string means auto-detect first provider
+    /// with `stt_model` set.
     #[serde(default = "default_stt_provider")]
     pub provider: String,
-    #[serde(default = "default_stt_model")]
-    pub model: String,
+    /// Language hint for transcription (e.g. `"en"`, `"auto"`).
     #[serde(default = "default_stt_language")]
     pub language: String,
-    #[serde(default)]
-    pub base_url: Option<String>,
 }
 
 /// Routing strategy selection for multi-provider routing.
@@ -653,6 +702,11 @@ pub struct ProviderEntry {
     #[serde(default)]
     pub embedding_model: Option<String>,
 
+    /// STT model. When set, this provider supports speech-to-text via the Whisper API or
+    /// Candle-local inference.
+    #[serde(default)]
+    pub stt_model: Option<String>,
+
     /// Mark this entry as the embedding provider (handles `embed()` calls).
     #[serde(default)]
     pub embed: bool,
@@ -711,6 +765,7 @@ impl Default for ProviderEntry {
             base_url: None,
             max_tokens: None,
             embedding_model: None,
+            stt_model: None,
             embed: false,
             default: false,
             thinking: None,
@@ -855,6 +910,16 @@ impl ProviderEntry {
                 }
             }
             _ => {}
+        }
+
+        // W6: Candle STT-only provider (stt_model set, no model) is valid — no warning needed.
+        // Warn if Ollama has stt_model set (Ollama does not support Whisper API).
+        if self.stt_model.is_some() && self.provider_type == ProviderKind::Ollama {
+            tracing::warn!(
+                provider = self.effective_name(),
+                "field `stt_model` is set on an Ollama provider; Ollama does not support the \
+                 Whisper STT API — use OpenAI, compatible, or candle instead"
+            );
         }
 
         Ok(())
@@ -1255,5 +1320,198 @@ routing = "triage"
 "#,
         );
         assert!(matches!(cfg.routing, LlmRoutingStrategy::Triage));
+    }
+
+    // ─── stt_provider_entry ───────────────────────────────────────────────────
+
+    #[test]
+    fn stt_provider_entry_by_name_match() {
+        let cfg = parse_llm(
+            r#"
+[llm]
+
+[[llm.providers]]
+type = "openai"
+name = "quality"
+model = "gpt-5.4"
+stt_model = "gpt-4o-mini-transcribe"
+
+[llm.stt]
+provider = "quality"
+"#,
+        );
+        let entry = cfg.stt_provider_entry().expect("should find stt provider");
+        assert_eq!(entry.effective_name(), "quality");
+        assert_eq!(entry.stt_model.as_deref(), Some("gpt-4o-mini-transcribe"));
+    }
+
+    #[test]
+    fn stt_provider_entry_auto_detect_when_provider_empty() {
+        let cfg = parse_llm(
+            r#"
+[llm]
+
+[[llm.providers]]
+type = "openai"
+name = "openai-stt"
+stt_model = "whisper-1"
+
+[llm.stt]
+provider = ""
+"#,
+        );
+        let entry = cfg.stt_provider_entry().expect("should auto-detect");
+        assert_eq!(entry.effective_name(), "openai-stt");
+    }
+
+    #[test]
+    fn stt_provider_entry_auto_detect_no_stt_section() {
+        let cfg = parse_llm(
+            r#"
+[llm]
+
+[[llm.providers]]
+type = "openai"
+name = "openai-stt"
+stt_model = "whisper-1"
+"#,
+        );
+        // No [llm.stt] section — should still find first provider with stt_model.
+        let entry = cfg.stt_provider_entry().expect("should auto-detect");
+        assert_eq!(entry.effective_name(), "openai-stt");
+    }
+
+    #[test]
+    fn stt_provider_entry_none_when_no_stt_model() {
+        let cfg = parse_llm(
+            r#"
+[llm]
+
+[[llm.providers]]
+type = "openai"
+name = "quality"
+model = "gpt-5.4"
+"#,
+        );
+        assert!(cfg.stt_provider_entry().is_none());
+    }
+
+    #[test]
+    fn stt_provider_entry_name_mismatch_falls_back_to_none() {
+        // Named provider exists but has no stt_model; another unnamed has stt_model.
+        let cfg = parse_llm(
+            r#"
+[llm]
+
+[[llm.providers]]
+type = "openai"
+name = "quality"
+model = "gpt-5.4"
+
+[[llm.providers]]
+type = "openai"
+name = "openai-stt"
+stt_model = "whisper-1"
+
+[llm.stt]
+provider = "quality"
+"#,
+        );
+        // "quality" has no stt_model — returns None for name-based lookup.
+        assert!(cfg.stt_provider_entry().is_none());
+    }
+
+    #[test]
+    fn stt_config_deserializes_new_slim_format() {
+        let cfg = parse_llm(
+            r#"
+[llm]
+
+[[llm.providers]]
+type = "openai"
+name = "quality"
+stt_model = "whisper-1"
+
+[llm.stt]
+provider = "quality"
+language = "en"
+"#,
+        );
+        let stt = cfg.stt.as_ref().expect("stt section present");
+        assert_eq!(stt.provider, "quality");
+        assert_eq!(stt.language, "en");
+    }
+
+    #[test]
+    fn stt_config_default_provider_is_empty() {
+        // Verify that W4 fix: default_stt_provider() returns "" not "whisper".
+        assert_eq!(default_stt_provider(), "");
+    }
+
+    #[test]
+    fn validate_stt_missing_provider_ok() {
+        let cfg = parse_llm("[llm]\n");
+        assert!(cfg.validate_stt().is_ok());
+    }
+
+    #[test]
+    fn validate_stt_valid_reference() {
+        let cfg = parse_llm(
+            r#"
+[llm]
+
+[[llm.providers]]
+type = "openai"
+name = "quality"
+stt_model = "whisper-1"
+
+[llm.stt]
+provider = "quality"
+"#,
+        );
+        assert!(cfg.validate_stt().is_ok());
+    }
+
+    #[test]
+    fn validate_stt_nonexistent_provider_errors() {
+        let cfg = parse_llm(
+            r#"
+[llm]
+
+[[llm.providers]]
+type = "openai"
+name = "quality"
+model = "gpt-5.4"
+
+[llm.stt]
+provider = "nonexistent"
+"#,
+        );
+        assert!(cfg.validate_stt().is_err());
+    }
+
+    #[test]
+    fn validate_stt_provider_exists_but_no_stt_model_returns_ok_with_warn() {
+        // MEDIUM: provider is found but has no stt_model — should return Ok (warn path, not error).
+        let cfg = parse_llm(
+            r#"
+[llm]
+
+[[llm.providers]]
+type = "openai"
+name = "quality"
+model = "gpt-5.4"
+
+[llm.stt]
+provider = "quality"
+"#,
+        );
+        // validate_stt must succeed (only a tracing::warn is emitted — not an error).
+        assert!(cfg.validate_stt().is_ok());
+        // stt_provider_entry must return None because no stt_model is set.
+        assert!(
+            cfg.stt_provider_entry().is_none(),
+            "stt_provider_entry must be None when provider has no stt_model"
+        );
     }
 }

--- a/crates/zeph-core/src/config.rs
+++ b/crates/zeph-core/src/config.rs
@@ -44,9 +44,7 @@ pub use zeph_config::{
     is_legacy_default_sqlite_path,
 };
 
-pub use zeph_config::providers::{
-    default_stt_language, default_stt_model, default_stt_provider, validate_pool,
-};
+pub use zeph_config::providers::{default_stt_language, default_stt_provider, validate_pool};
 
 pub mod migrate {
     pub use zeph_config::migrate::*;

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -687,13 +687,10 @@ fn resolve_search_lsp_server_id(config: &Config) -> Option<String> {
 #[cfg(feature = "candle")]
 pub(crate) fn apply_candle_stt<C: Channel>(
     agent: zeph_core::agent::Agent<C>,
-    stt_config: Option<&zeph_core::config::SttConfig>,
+    entry: &zeph_core::config::ProviderEntry,
+    language: &str,
 ) -> zeph_core::agent::Agent<C> {
-    if !stt_config.is_some_and(|s| s.provider == "candle-whisper") {
-        return agent;
-    }
-    let model = stt_config.map_or("openai/whisper-tiny", |s| s.model.as_str());
-    let language = stt_config.map_or("auto", |s| s.language.as_str());
+    let model = entry.stt_model.as_deref().unwrap_or("openai/whisper-tiny");
     match zeph_llm::candle_whisper::CandleWhisperProvider::load(model, None, language) {
         Ok(provider) => {
             tracing::info!("STT enabled via candle-whisper (model: {model})");
@@ -709,29 +706,23 @@ pub(crate) fn apply_candle_stt<C: Channel>(
 #[cfg(feature = "stt")]
 pub(crate) fn apply_whisper_stt<C: Channel>(
     agent: zeph_core::agent::Agent<C>,
-    stt_config: Option<&zeph_core::config::SttConfig>,
-    openai_base_url: &str,
+    entry: &zeph_core::config::ProviderEntry,
+    language: &str,
     api_key: String,
 ) -> zeph_core::agent::Agent<C> {
-    let Some(stt_cfg) = stt_config else {
-        return agent;
-    };
-    if stt_cfg.provider == "candle-whisper" {
-        return agent;
-    }
-    let base_url = stt_cfg.base_url.as_deref().unwrap_or(openai_base_url);
+    let model = entry.stt_model.as_deref().unwrap_or("whisper-1");
+    let base_url = entry
+        .base_url
+        .as_deref()
+        .unwrap_or("https://api.openai.com/v1");
     let whisper = zeph_llm::whisper::WhisperProvider::new(
         zeph_core::http::default_client(),
         api_key,
         base_url,
-        &stt_cfg.model,
+        model,
     )
-    .with_language(&stt_cfg.language);
-    tracing::info!(
-        model = stt_cfg.model,
-        base_url,
-        "STT enabled via Whisper API"
-    );
+    .with_language(language);
+    tracing::info!(model, base_url, "STT enabled via Whisper API");
     agent.with_stt(Box::new(whisper))
 }
 

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -4,7 +4,7 @@
 use std::path::Path;
 
 use similar::{ChangeTag, TextDiff};
-use zeph_core::config::migrate::ConfigMigrator;
+use zeph_core::config::migrate::{ConfigMigrator, migrate_stt_to_provider};
 
 /// Handle the `zeph migrate-config` command.
 ///
@@ -23,11 +23,19 @@ pub(crate) fn handle_migrate_config(
         String::new()
     };
 
+    // Step 1: migrate [llm.stt] model/base_url fields to [[llm.providers]] stt_model.
+    let stt_result = migrate_stt_to_provider(&input)?;
+    let after_stt = stt_result.output;
+
+    // Step 2: add missing default keys as commented-out entries.
     let migrator = ConfigMigrator::new();
-    let result = migrator.migrate(&input)?;
+    let result = migrator.migrate(&after_stt)?;
 
     if diff {
         print_diff(&input, &result.output);
+        if stt_result.added_count > 0 {
+            eprintln!("STT migration: moved model/base_url to [[llm.providers]] entry.");
+        }
         eprintln!(
             "Migration would add {} entries ({} sections).",
             result.added_count,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -229,6 +229,24 @@ fn warn_if_acp_enabled_but_unavailable(config: &Config) {
     }
 }
 
+/// Resolve the API key for the STT provider entry.
+///
+/// `OpenAI` and Candle use the `OpenAI` key; Compatible providers use their own inline key or the
+/// compatible-provider key from the vault.
+#[cfg(feature = "stt")]
+fn resolve_stt_api_key(config: &Config, entry: &zeph_core::config::ProviderEntry) -> String {
+    use zeph_core::config::ProviderKind;
+    match entry.provider_type {
+        ProviderKind::OpenAi => config
+            .secrets
+            .openai_api_key
+            .as_ref()
+            .map_or(String::new(), |k| k.expose().to_string()),
+        ProviderKind::Compatible => entry.api_key.clone().unwrap_or_default(),
+        _ => String::new(),
+    }
+}
+
 #[allow(clippy::too_many_lines, clippy::large_futures)]
 pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     // Load logging config early (sync, cheap) so every code path gets file logging.
@@ -1247,33 +1265,62 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         crate::gateway_spawn::spawn_gateway_server(config, shutdown_rx.clone());
     }
 
-    #[cfg(feature = "candle")]
-    let agent = agent_setup::apply_candle_stt(agent, config.llm.stt.as_ref());
-
-    #[cfg(feature = "stt")]
+    #[allow(unused_variables)]
     let agent = {
-        let openai_base_url = config
+        let language = config
             .llm
-            .providers
-            .iter()
-            .find(|e| e.provider_type == zeph_core::config::ProviderKind::OpenAi)
-            .map_or("https://api.openai.com/v1".to_owned(), |e| {
-                e.base_url
-                    .clone()
-                    .unwrap_or_else(|| "https://api.openai.com/v1".to_owned())
-            });
-        let api_key = config
-            .secrets
-            .openai_api_key
+            .stt
             .as_ref()
-            .map_or(String::new(), |k| k.expose().to_string());
-        agent_setup::apply_whisper_stt(agent, config.llm.stt.as_ref(), &openai_base_url, api_key)
+            .map_or("auto", |s| s.language.as_str());
+        if let Some(stt_entry) = config.llm.stt_provider_entry() {
+            match stt_entry.provider_type {
+                #[cfg(feature = "candle")]
+                zeph_core::config::ProviderKind::Candle => {
+                    agent_setup::apply_candle_stt(agent, stt_entry, language)
+                }
+                #[cfg(not(feature = "candle"))]
+                zeph_core::config::ProviderKind::Candle => {
+                    tracing::error!(
+                        provider = stt_entry.effective_name(),
+                        "STT provider is type candle but the `candle` feature is not enabled; \
+                         STT disabled"
+                    );
+                    agent
+                }
+                #[cfg(feature = "stt")]
+                _ => {
+                    let api_key = resolve_stt_api_key(config, stt_entry);
+                    agent_setup::apply_whisper_stt(agent, stt_entry, language, api_key)
+                }
+                #[cfg(not(feature = "stt"))]
+                _ => {
+                    tracing::error!(
+                        provider = stt_entry.effective_name(),
+                        "STT provider configured but the `stt` feature is not enabled; \
+                         STT disabled"
+                    );
+                    agent
+                }
+            }
+        } else {
+            if config.llm.stt.is_some() {
+                tracing::warn!(
+                    provider = config.llm.stt.as_ref().map_or("", |s| s.provider.as_str()),
+                    "[[llm.stt]] is configured but no matching [[llm.providers]] entry with \
+                     `stt_model` was found; STT disabled"
+                );
+            }
+            agent
+        }
     };
 
     let (metrics_tx, metrics_rx) =
         tokio::sync::watch::channel(zeph_core::metrics::MetricsSnapshot::default());
     {
-        let stt_model = config.llm.stt.as_ref().map(|s| s.model.clone());
+        let stt_model = config
+            .llm
+            .stt_provider_entry()
+            .and_then(|e| e.stt_model.clone());
         let compaction_model = config.llm.summary_model.clone();
         let semantic_cache_enabled = config.llm.semantic_cache_enabled;
         let embedding_model = zeph_core::bootstrap::effective_embedding_model(config).clone();


### PR DESCRIPTION
Closes #2175

## Summary

- Add `stt_model: Option<String>` to `ProviderEntry`, following the existing `embedding_model`/`vision_model` flat-union pattern
- Slim `SttConfig`: remove `model` and `base_url` (moved to provider entry); keep `provider` (name ref) and `language`
- Add `stt_provider_entry()` and `validate_stt()` resolution helpers on `LlmConfig`
- Replace string-based candle detection with type-safe `ProviderKind::Candle` + `stt_model` check
- Add `migrate_stt_to_provider()` as step 1 of the `--migrate-config` pipeline
- Remove deprecated env vars `ZEPH_STT_MODEL` and `ZEPH_STT_BASE_URL`
- Add `MigrateError::InvalidStructure` for proper error propagation (replaces `.expect()` panics)
- 22 new unit tests across `providers.rs` and `migrate.rs`

## Breaking Change

Configs with `[llm.stt] model = ...` or `[llm.stt] base_url = ...` must be migrated:

```
cargo run --features full -- --migrate-config path/to/config.toml
```

## Config before/after

**Before:**
```toml
[llm.stt]
model = "gpt-4o-mini-transcribe"
base_url = "https://api.openai.com/v1"
provider = "openai"
language = "auto"
```

**After:**
```toml
[[llm.providers]]
name = "whisper"
type = "openai"
model = "gpt-4o-mini-transcribe"
stt_model = "gpt-4o-mini-transcribe"

[llm.stt]
provider = "whisper"
language = "auto"
```

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --features full -- -D warnings` — 0 warnings
- [x] `cargo nextest run --workspace --features full --lib --bins` — 6488 passed (+32 vs base)
- [x] Security audit: no secrets leaked in logs or migration output
- [x] Adversarial implementation review: all 6 pre-implementation warnings addressed