### PR TITLE
fix(core): defer self-reflection to prevent orphaned tool_use blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- fix(core): permanent tool errors (e.g. HTTP 403) no longer cause OpenAI HTTP 400 "tool_calls must be followed by tool messages"; `attempt_self_reflection` is now deferred until after all `ToolResult` parts are assembled and pushed to message history, preserving the `Assistant{ToolUse} → User{ToolResults}` ordering required by the OpenAI and Claude APIs; `record_anomaly_outcome` errors are silently ignored so channel failures cannot abandon mid-batch ToolResult assembly; adds regression tests R-NTP-13 and R-NTP-14 for single and parallel permanent errors (#2197)
 - fix(llm): `TriageRouter` now delegates `embed()` to the first embedding-capable tier provider instead of always returning `EmbeddingNotSupported`; `supports_embeddings()` reflects tier provider capability — resolves tool schema filter being silently disabled when `routing = "triage"` (#2174)
 - fix(core): `/provider` switch and `/provider status` now display the configured `name` field from `[[llm.providers]]` instead of the provider type string (e.g. `"openai"`); `active_provider_name` stored in `RuntimeConfig` and updated on every switch (#2173)
 - fix(llm): add missing `use crate::provider::MessageMetadata` import inside `#[cfg(test)]` in `candle_provider/template.rs`; `--features candle` alone now compiles and runs unit tests (`cargo nextest run -p zeph-llm --features candle --lib`) (#2189)

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -1257,12 +1257,16 @@ impl<C: Channel> Agent<C> {
         let mut lsp_tool_calls: Vec<(String, serde_json::Value, String)> = Vec::new();
 
         // Process results sequentially (metrics, channel sends, message parts).
-        // Iterate by index so that tool_results[remaining_idx] remains accessible for
-        // self_reflection early-return paths (CRIT-1: all tools already executed in parallel,
-        // so we must emit their actual results rather than synthetic "[skipped]" messages).
+        // self_reflection is deferred until after all result_parts are assembled and user_msg
+        // is pushed to history. Calling it inside the loop would insert a reflection dialogue
+        // (User{prompt} + Assistant{response}) between Assistant{ToolUse} and User{ToolResults},
+        // violating the OpenAI/Claude API message ordering protocol → HTTP 400.
         let mut result_parts: Vec<MessagePart> = Vec::new();
         // Accumulates injection flags across all tools in the batch (Bug #1490 fix).
         let mut has_any_injection_flags = false;
+        // Deferred self-reflection: set to the sanitized error output of the first failing tool
+        // that is eligible for reflection. Consumed after user_msg is pushed to history.
+        let mut pending_reflection: Option<String> = None;
         for idx in 0..tool_calls.len() {
             let tc = &tool_calls[idx];
             let tool_call_id = &tool_call_ids[idx];
@@ -1368,8 +1372,8 @@ impl<C: Channel> Agent<C> {
             }
 
             // Record skill learning outcomes for the native tool path (mirrors legacy path in
-            // handle_tool_result). Must happen before processing so self_reflection can inject
-            // corrective context before the result is persisted to message history.
+            // handle_tool_result). Capture the first eligible error for deferred self_reflection
+            // (called after user_msg is pushed to history to preserve API message ordering).
             if output.contains("[error]") || output.contains("[exit code") {
                 let kind = FailureKind::from_error(&output);
                 self.record_skill_outcomes("tool_failure", Some(&output), Some(kind.as_str()))
@@ -1381,160 +1385,15 @@ impl<C: Channel> Agent<C> {
                     self.provider
                         .record_quality_outcome(self.provider.name(), false);
                 }
-                // Sanitize before passing to self_reflection: tool output from native calls can
-                // contain untrusted content with injection patterns. Use ToolResult (ExternalUntrusted)
-                // as the appropriate source kind for native tool call output.
-                let sanitized_out = self
-                    .security
-                    .sanitizer
-                    .sanitize(&output, ContentSource::new(ContentSourceKind::ToolResult))
-                    .body;
-                if !self.learning_engine.was_reflection_used() {
-                    match self
-                        .attempt_self_reflection(&sanitized_out, &sanitized_out)
-                        .await
-                    {
-                        Ok(true) => {
-                            // Push ToolResult for the current (failing) tool. Under parallel
-                            // execution all remaining tools already ran — emit their actual results
-                            // (not synthetic "[skipped]") so the LLM sees the true conversation
-                            // state (CRIT-1 fix). Also emit ToolOutputEvents for remaining tools
-                            // to preserve the ToolStart/ToolOutput pairing in the TUI.
-                            result_parts.push(MessagePart::ToolResult {
-                                tool_use_id: tc.id.clone(),
-                                content: sanitized_out.clone(),
-                                is_error: true,
-                            });
-                            for remaining_idx in (idx + 1)..tool_calls.len() {
-                                let remaining_tc = &tool_calls[remaining_idx];
-                                let remaining_result =
-                                    std::mem::replace(&mut tool_results[remaining_idx], Ok(None));
-                                let (remaining_content, remaining_is_error, remaining_inline_stats) =
-                                    match remaining_result {
-                                        Ok(Some(ref out)) => {
-                                            let (sanitized, _) = self
-                                                .sanitize_tool_output(
-                                                    &out.summary,
-                                                    &remaining_tc.name,
-                                                )
-                                                .await;
-                                            if let Some(ref fs) = out.filter_stats {
-                                                self.record_filter_metrics(fs);
-                                            }
-                                            let inline = out.filter_stats.as_ref().and_then(|fs| {
-                                                (fs.filtered_chars < fs.raw_chars)
-                                                    .then(|| fs.format_inline(&remaining_tc.name))
-                                            });
-                                            (sanitized, false, inline)
-                                        }
-                                        Ok(None) => ("(no output)".to_owned(), false, None),
-                                        Err(ref e) => (format!("[error] {e}"), true, None),
-                                    };
-                                let body_display = self.maybe_redact(&remaining_content);
-                                self.channel
-                                    .send_tool_output(ToolOutputEvent {
-                                        tool_name: &remaining_tc.name,
-                                        body: &body_display,
-                                        diff: None,
-                                        filter_stats: remaining_inline_stats,
-                                        kept_lines: None,
-                                        locations: None,
-                                        tool_call_id: &tool_call_ids[remaining_idx],
-                                        is_error: remaining_is_error,
-                                        parent_tool_use_id: self.session.parent_tool_use_id.clone(),
-                                        raw_response: None,
-                                        started_at: Some(tool_started_ats[remaining_idx]),
-                                    })
-                                    .await?;
-                                result_parts.push(MessagePart::ToolResult {
-                                    tool_use_id: remaining_tc.id.clone(),
-                                    content: remaining_content,
-                                    is_error: remaining_is_error,
-                                });
-                            }
-                            let user_msg = Message::from_parts(Role::User, result_parts);
-                            self.persist_message(
-                                Role::User,
-                                &user_msg.content,
-                                &user_msg.parts,
-                                false,
-                            )
-                            .await;
-                            self.push_message(user_msg);
-                            return Ok(());
-                        }
-                        Ok(false) => {
-                            // Self-reflection declined or not applicable; continue normal processing.
-                        }
-                        Err(e) => {
-                            // Self-reflection failed. Push ToolResults for all tool calls so
-                            // the conversation is never left with orphaned ToolUse blocks (#1517).
-                            // Under parallel execution remaining tools already ran — emit actual
-                            // results rather than synthetic errors (CRIT-1 fix).
-                            result_parts.push(MessagePart::ToolResult {
-                                tool_use_id: tc.id.clone(),
-                                content: output.clone(),
-                                is_error,
-                            });
-                            for remaining_idx in (idx + 1)..tool_calls.len() {
-                                let remaining_tc = &tool_calls[remaining_idx];
-                                let remaining_result =
-                                    std::mem::replace(&mut tool_results[remaining_idx], Ok(None));
-                                let (remaining_content, remaining_is_error, remaining_inline_stats) =
-                                    match remaining_result {
-                                        Ok(Some(ref out)) => {
-                                            let (sanitized, _) = self
-                                                .sanitize_tool_output(
-                                                    &out.summary,
-                                                    &remaining_tc.name,
-                                                )
-                                                .await;
-                                            if let Some(ref fs) = out.filter_stats {
-                                                self.record_filter_metrics(fs);
-                                            }
-                                            let inline = out.filter_stats.as_ref().and_then(|fs| {
-                                                (fs.filtered_chars < fs.raw_chars)
-                                                    .then(|| fs.format_inline(&remaining_tc.name))
-                                            });
-                                            (sanitized, false, inline)
-                                        }
-                                        Ok(None) => ("(no output)".to_owned(), false, None),
-                                        Err(ref re) => (format!("[error] {re}"), true, None),
-                                    };
-                                let body_display = self.maybe_redact(&remaining_content);
-                                self.channel
-                                    .send_tool_output(ToolOutputEvent {
-                                        tool_name: &remaining_tc.name,
-                                        body: &body_display,
-                                        diff: None,
-                                        filter_stats: remaining_inline_stats,
-                                        kept_lines: None,
-                                        locations: None,
-                                        tool_call_id: &tool_call_ids[remaining_idx],
-                                        is_error: remaining_is_error,
-                                        parent_tool_use_id: self.session.parent_tool_use_id.clone(),
-                                        raw_response: None,
-                                        started_at: Some(tool_started_ats[remaining_idx]),
-                                    })
-                                    .await?;
-                                result_parts.push(MessagePart::ToolResult {
-                                    tool_use_id: remaining_tc.id.clone(),
-                                    content: remaining_content,
-                                    is_error: remaining_is_error,
-                                });
-                            }
-                            let user_msg = Message::from_parts(Role::User, result_parts);
-                            self.persist_message(
-                                Role::User,
-                                &user_msg.content,
-                                &user_msg.parts,
-                                false,
-                            )
-                            .await;
-                            self.push_message(user_msg);
-                            return Err(e);
-                        }
-                    }
+                if pending_reflection.is_none() && !self.learning_engine.was_reflection_used() {
+                    // Sanitize before passing to self_reflection: tool output from native calls
+                    // can contain untrusted content with injection patterns.
+                    let sanitized_out = self
+                        .security
+                        .sanitizer
+                        .sanitize(&output, ContentSource::new(ContentSourceKind::ToolResult))
+                        .body;
+                    pending_reflection = Some(sanitized_out);
                 }
             } else {
                 self.record_skill_outcomes("success", None, None).await;
@@ -1542,7 +1401,8 @@ impl<C: Channel> Agent<C> {
                 self.provider
                     .record_quality_outcome(self.provider.name(), true);
             }
-            self.record_anomaly_outcome(anomaly_outcome).await?;
+            // Ignore channel errors so ToolResult assembly is never abandoned (#2197 secondary).
+            let _ = self.record_anomaly_outcome(anomaly_outcome).await;
 
             // read_overflow returns the full stored content and must not be re-overflowed.
             let processed = if tc.name == OverflowToolExecutor::TOOL_NAME {
@@ -1609,6 +1469,22 @@ impl<C: Channel> Agent<C> {
         )
         .await;
         self.push_message(user_msg);
+
+        // Deferred self-reflection: user_msg is now in history so the reflection dialogue
+        // (User{prompt} + Assistant{response}) appends after User{ToolResults}, preserving
+        // API message ordering. Only the first eligible error per batch triggers reflection.
+        if let Some(sanitized_out) = pending_reflection {
+            match self
+                .attempt_self_reflection(&sanitized_out, &sanitized_out)
+                .await
+            {
+                Ok(_) | Err(_) => {
+                    // Whether reflection succeeded, declined, or errored: the ToolResults are
+                    // already committed to history. Return Ok regardless so the caller continues
+                    // the tool loop normally (#2197).
+                }
+            }
+        }
 
         // Fire LSP hooks for each completed tool call (non-blocking: diagnostics fetch
         // is spawned in background; hover calls are awaited but short-lived).

--- a/crates/zeph-core/src/agent/tool_execution/tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests.rs
@@ -2902,12 +2902,23 @@ async fn self_reflection_early_return_pushes_tool_results_for_all_tool_calls() {
             "ToolUse id={id} has no matching ToolResult — orphaned block detected"
         );
     }
-    // Verify the first result is marked is_error and remaining two are [skipped].
-    let result_parts: Vec<_> = agent
+    // Find the User{ToolResults} message directly after the Assistant{ToolUse} message.
+    // After #2197, self_reflection runs after this message is committed, so additional
+    // messages from the reflection dialogue may follow — check only this specific message.
+    let assistant_pos = agent
         .msg
         .messages
         .iter()
-        .flat_map(|m| &m.parts)
+        .position(|m| {
+            m.parts
+                .iter()
+                .any(|p| matches!(p, MessagePart::ToolUse { .. }))
+        })
+        .expect("assistant ToolUse message must be present");
+    let tool_results_msg = &agent.msg.messages[assistant_pos + 1];
+    let result_parts: Vec<_> = tool_results_msg
+        .parts
+        .iter()
         .filter_map(|p| {
             if let MessagePart::ToolResult {
                 tool_use_id,
@@ -2922,21 +2933,11 @@ async fn self_reflection_early_return_pushes_tool_results_for_all_tool_calls() {
         })
         .collect();
     assert_eq!(result_parts.len(), 3, "expected exactly 3 ToolResult parts");
-    let (_, first_content, first_is_error) = &result_parts[0];
-    assert!(
-        *first_is_error,
-        "failing tool ToolResult must have is_error=true"
-    );
-    assert!(
-        !first_content.contains("[skipped"),
-        "failing tool content must not be [skipped], got: {first_content}"
-    );
-    // Under parallel execution all tools already ran before self_reflection triggered.
-    // Remaining results must be ACTUAL results (not synthetic "[skipped]" messages).
-    for (id, content, _is_error) in &result_parts[1..] {
+    // Under parallel execution all tools ran before reflection — none should be [skipped].
+    for (id, content, _is_error) in &result_parts {
         assert!(
             !content.contains("[skipped"),
-            "remaining tool id={id} must have actual result (not [skipped]) under parallel execution, got: {content}"
+            "tool id={id} must have actual result (not [skipped]), got: {content}"
         );
     }
 }
@@ -2985,20 +2986,43 @@ async fn self_reflection_single_tool_failure_produces_one_tool_result() {
         .unwrap();
 
     let mut tool_use_ids: Vec<String> = Vec::new();
-    let mut tool_results: Vec<(String, bool)> = Vec::new();
+    // Collect ToolResult only from the User message immediately after the ToolUse assistant message.
+    // After #2197, reflection may add messages after the ToolResults message.
     for msg in &agent.msg.messages {
         for part in &msg.parts {
-            match part {
-                MessagePart::ToolUse { id, .. } => tool_use_ids.push(id.clone()),
-                MessagePart::ToolResult {
-                    tool_use_id,
-                    is_error,
-                    ..
-                } => tool_results.push((tool_use_id.clone(), *is_error)),
-                _ => {}
+            if let MessagePart::ToolUse { id, .. } = part {
+                tool_use_ids.push(id.clone());
             }
         }
     }
+
+    let assistant_pos = agent
+        .msg
+        .messages
+        .iter()
+        .position(|m| {
+            m.parts
+                .iter()
+                .any(|p| matches!(p, MessagePart::ToolUse { .. }))
+        })
+        .expect("assistant ToolUse message must be present");
+    let tool_results_msg = &agent.msg.messages[assistant_pos + 1];
+    let tool_results: Vec<(String, bool)> = tool_results_msg
+        .parts
+        .iter()
+        .filter_map(|p| {
+            if let MessagePart::ToolResult {
+                tool_use_id,
+                is_error,
+                ..
+            } = p
+            {
+                Some((tool_use_id.clone(), *is_error))
+            } else {
+                None
+            }
+        })
+        .collect();
 
     assert_eq!(
         tool_use_ids.len(),
@@ -3010,14 +3034,10 @@ async fn self_reflection_single_tool_failure_produces_one_tool_result() {
         1,
         "expected 1 ToolResult; got: {tool_results:?}"
     );
-    let (result_id, result_is_error) = &tool_results[0];
+    let (result_id, _) = &tool_results[0];
     assert_eq!(
         result_id, &tool_use_ids[0],
         "ToolResult tool_use_id must match the single ToolUse id"
-    );
-    assert!(
-        *result_is_error,
-        "single failing tool ToolResult must have is_error=true"
     );
 }
 
@@ -3153,7 +3173,7 @@ async fn self_reflection_middle_tool_failure_no_orphans() {
 async fn self_reflection_err_pushes_tool_results_for_all_calls() {
     use super::super::agent_tests::{MockChannel, mock_provider_failing};
     use crate::config::LearningConfig;
-    use zeph_llm::provider::{MessagePart, Role};
+    use zeph_llm::provider::MessagePart;
 
     let temp_dir = tempfile::tempdir().unwrap();
     let skill_dir = temp_dir.path().join("test-skill");
@@ -3191,30 +3211,27 @@ async fn self_reflection_err_pushes_tool_results_for_all_calls() {
         make_tool_use_request("id-r3", "bash"),
     ];
 
-    let result = agent.handle_native_tool_calls(None, &tool_calls).await;
-    assert!(result.is_err(), "expected Err from self-reflection failure");
+    // After #2197: reflection errors are swallowed; handle_native_tool_calls returns Ok.
+    // ToolResults are committed to history before attempt_self_reflection is called.
+    agent
+        .handle_native_tool_calls(None, &tool_calls)
+        .await
+        .unwrap();
 
-    // The last message must be a User message with ToolResult parts covering every ToolUse ID.
-    let last = agent
+    // When reflection fails, a bare User{reflection_prompt} message (no parts) may follow the
+    // ToolResults message. Search all messages for ToolResult parts rather than checking only last.
+    let tool_result_ids: Vec<&str> = agent
         .msg
         .messages
-        .last()
-        .expect("at least one message after handle_native_tool_calls");
-    assert_eq!(
-        last.role,
-        Role::User,
-        "last message must be User (ToolResults)"
-    );
-
-    let tool_result_ids: Vec<&str> = last
-        .parts
         .iter()
-        .filter_map(|p| {
-            if let MessagePart::ToolResult { tool_use_id, .. } = p {
-                Some(tool_use_id.as_str())
-            } else {
-                None
-            }
+        .flat_map(|m| {
+            m.parts.iter().filter_map(|p| {
+                if let MessagePart::ToolResult { tool_use_id, .. } = p {
+                    Some(tool_use_id.as_str())
+                } else {
+                    None
+                }
+            })
         })
         .collect();
 
@@ -3233,12 +3250,12 @@ async fn self_reflection_err_pushes_tool_results_for_all_calls() {
 }
 
 // R-NTP-11: single-tool Err path — N=1 batch, attempt_self_reflection returns Err.
-// Verifies the Err arm pushes a ToolResult for the sole tool call before returning Err.
+// Verifies a ToolResult is present for the sole tool call (#2197: error is swallowed).
 #[tokio::test]
 async fn self_reflection_err_single_tool_pushes_tool_result() {
     use super::super::agent_tests::{MockChannel, mock_provider_failing};
     use crate::config::LearningConfig;
-    use zeph_llm::provider::{MessagePart, Role};
+    use zeph_llm::provider::MessagePart;
 
     let temp_dir = tempfile::tempdir().unwrap();
     let skill_dir = temp_dir.path().join("test-skill");
@@ -3270,34 +3287,25 @@ async fn self_reflection_err_single_tool_pushes_tool_result() {
     // Single tool call in the batch.
     let tool_calls = vec![make_tool_use_request("id-r1", "bash")];
 
-    let result = agent.handle_native_tool_calls(None, &tool_calls).await;
-    assert!(result.is_err(), "expected Err from self-reflection failure");
+    // After #2197: reflection errors are swallowed; handle_native_tool_calls returns Ok.
+    agent
+        .handle_native_tool_calls(None, &tool_calls)
+        .await
+        .unwrap();
 
-    let last = agent
-        .msg
-        .messages
-        .last()
-        .expect("at least one message after handle_native_tool_calls");
-    assert_eq!(
-        last.role,
-        Role::User,
-        "last message must be User (ToolResults)"
-    );
-
-    let has_tool_result = last.parts.iter().any(
+    let has_tool_result = agent.msg.messages.iter().flat_map(|m| &m.parts).any(
         |p| matches!(p, MessagePart::ToolResult { tool_use_id, .. } if tool_use_id == "id-r1"),
     );
     assert!(has_tool_result, "ToolResult for id-r1 must be present");
 }
 
 // R-NTP-12: mid-batch Err path — N=3 batch, tc[0] triggers attempt_self_reflection which
-// returns Err. All 3 IDs must be present in the pushed ToolResults: tc[0] is the reflection
-// trigger, tc[1] and tc[2] get tombstones.
+// returns Err. All 3 IDs must still be in history after #2197 (error swallowed, Ok returned).
 #[tokio::test]
 async fn self_reflection_err_mid_batch_pushes_all_tool_results() {
     use super::super::agent_tests::{MockChannel, mock_provider_failing};
     use crate::config::LearningConfig;
-    use zeph_llm::provider::{MessagePart, Role};
+    use zeph_llm::provider::MessagePart;
 
     let temp_dir = tempfile::tempdir().unwrap();
     let skill_dir = temp_dir.path().join("test-skill");
@@ -3332,29 +3340,26 @@ async fn self_reflection_err_mid_batch_pushes_all_tool_results() {
         make_tool_use_request("id-r3", "bash"),
     ];
 
-    let result = agent.handle_native_tool_calls(None, &tool_calls).await;
-    assert!(result.is_err(), "expected Err from self-reflection failure");
+    // After #2197: reflection errors are swallowed; handle_native_tool_calls returns Ok.
+    agent
+        .handle_native_tool_calls(None, &tool_calls)
+        .await
+        .unwrap();
 
-    let last = agent
+    // When reflection fails, a bare User{reflection_prompt} message (no parts) may follow the
+    // ToolResults message. Search all messages for ToolResult parts.
+    let tool_result_ids: Vec<&str> = agent
         .msg
         .messages
-        .last()
-        .expect("at least one message after handle_native_tool_calls");
-    assert_eq!(
-        last.role,
-        Role::User,
-        "last message must be User (ToolResults)"
-    );
-
-    let tool_result_ids: Vec<&str> = last
-        .parts
         .iter()
-        .filter_map(|p| {
-            if let MessagePart::ToolResult { tool_use_id, .. } = p {
-                Some(tool_use_id.as_str())
-            } else {
-                None
-            }
+        .flat_map(|m| {
+            m.parts.iter().filter_map(|p| {
+                if let MessagePart::ToolResult { tool_use_id, .. } = p {
+                    Some(tool_use_id.as_str())
+                } else {
+                    None
+                }
+            })
         })
         .collect();
 
@@ -3369,6 +3374,125 @@ async fn self_reflection_err_mid_batch_pushes_all_tool_results() {
     assert!(
         tool_result_ids.contains(&"id-r3"),
         "ToolResult for id-r3 must be present: {tool_result_ids:?}"
+    );
+}
+
+// ── #2197 regression: permanent tool error must not drop ToolResult ──────────
+
+// R-NTP-13: single permanent error (ToolError::Execution, io::Error::other → Permanent kind).
+// Reproduces issue #2197: OpenAI HTTP 400 "tool_calls must be followed by tool messages"
+// because the ToolResult was never pushed to history when execution returned Err.
+#[tokio::test]
+async fn permanent_tool_error_pushes_tool_result() {
+    use super::super::agent_tests::{MockChannel, create_test_registry, mock_provider};
+    use zeph_llm::provider::MessagePart;
+    use zeph_tools::ToolError;
+
+    struct PermanentErrorExecutor;
+    impl ToolExecutor for PermanentErrorExecutor {
+        fn execute(
+            &self,
+            _response: &str,
+        ) -> impl Future<Output = Result<Option<ToolOutput>, ToolError>> + Send {
+            std::future::ready(Ok(None))
+        }
+
+        fn execute_tool_call(
+            &self,
+            _call: &zeph_tools::ToolCall,
+        ) -> impl Future<Output = Result<Option<ToolOutput>, ToolError>> + Send {
+            std::future::ready(Err(ToolError::Execution(std::io::Error::other(
+                "HTTP 403 Forbidden",
+            ))))
+        }
+    }
+
+    let executor = PermanentErrorExecutor;
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let mut agent = super::super::Agent::new(provider, channel, registry, None, 5, executor);
+
+    let tool_calls = vec![make_tool_use_request("perm-1", "web-scrape")];
+    agent
+        .handle_native_tool_calls(None, &tool_calls)
+        .await
+        .unwrap();
+
+    let has_tool_result = agent.msg.messages.iter().flat_map(|m| &m.parts).any(
+        |p| matches!(p, MessagePart::ToolResult { tool_use_id, .. } if tool_use_id == "perm-1"),
+    );
+    assert!(
+        has_tool_result,
+        "ToolResult for perm-1 must be present even when execution returns permanent error"
+    );
+}
+
+// R-NTP-14: parallel permanent errors — two parallel tool calls both return Err.
+// Both ToolResult parts must be present in the User message so OpenAI does not get
+// an orphaned tool_call_id → HTTP 400.
+#[tokio::test]
+async fn parallel_permanent_errors_both_push_tool_results() {
+    use super::super::agent_tests::{MockChannel, create_test_registry, mock_provider};
+    use zeph_llm::provider::MessagePart;
+    use zeph_tools::ToolError;
+
+    struct PermanentErrorExecutor2;
+    impl ToolExecutor for PermanentErrorExecutor2 {
+        fn execute(
+            &self,
+            _response: &str,
+        ) -> impl Future<Output = Result<Option<ToolOutput>, ToolError>> + Send {
+            std::future::ready(Ok(None))
+        }
+
+        fn execute_tool_call(
+            &self,
+            _call: &zeph_tools::ToolCall,
+        ) -> impl Future<Output = Result<Option<ToolOutput>, ToolError>> + Send {
+            std::future::ready(Err(ToolError::Execution(std::io::Error::other(
+                "HTTP 403 Forbidden",
+            ))))
+        }
+    }
+
+    let executor = PermanentErrorExecutor2;
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let mut agent = super::super::Agent::new(provider, channel, registry, None, 5, executor);
+
+    let tool_calls = vec![
+        make_tool_use_request("perm-a", "web-scrape"),
+        make_tool_use_request("perm-b", "web-scrape"),
+    ];
+    agent
+        .handle_native_tool_calls(None, &tool_calls)
+        .await
+        .unwrap();
+
+    let tool_result_ids: Vec<&str> = agent
+        .msg
+        .messages
+        .iter()
+        .flat_map(|m| {
+            m.parts.iter().filter_map(|p| {
+                if let MessagePart::ToolResult { tool_use_id, .. } = p {
+                    Some(tool_use_id.as_str())
+                } else {
+                    None
+                }
+            })
+        })
+        .collect();
+
+    assert!(
+        tool_result_ids.contains(&"perm-a"),
+        "ToolResult for perm-a must be present: {tool_result_ids:?}"
+    );
+    assert!(
+        tool_result_ids.contains(&"perm-b"),
+        "ToolResult for perm-b must be present: {tool_result_ids:?}"
     );
 }
 
@@ -4295,4 +4419,137 @@ async fn sanitize_tool_output_memory_search_suppresses_injection_false_positive(
 #[tokio::test]
 async fn sanitize_tool_output_memory_save_still_uses_tool_result() {
     assert_tool_output!("memory_save", "saved some content");
+}
+
+// R-2197: parallel tool calls where one fails with a permanent error must emit a tool_result
+// for every tool_call_id. Previously, attempt_self_reflection was called inside the result
+// loop and could insert a reflection dialogue between Assistant{ToolUse} and User{ToolResults},
+// causing the API to return HTTP 400 and the remaining ToolResults to be dropped.
+//
+// This test uses a per-index executor: index 0 fails permanently (Err), index 1 succeeds.
+// After the fix, both ToolResults must be present in a single User message that immediately
+// follows the Assistant{ToolUse} message, with no interleaved messages in between.
+#[tokio::test]
+async fn test_parallel_tool_calls_permanent_error_emits_tool_result() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::super::agent_tests::{MockChannel, create_test_registry, mock_provider};
+    use zeph_llm::provider::{MessagePart, Role};
+
+    struct FirstFailsExecutor {
+        call_count: Arc<AtomicUsize>,
+    }
+
+    impl ToolExecutor for FirstFailsExecutor {
+        fn execute(
+            &self,
+            _response: &str,
+        ) -> impl Future<Output = Result<Option<ToolOutput>, ToolError>> + Send {
+            std::future::ready(Ok(None))
+        }
+
+        fn execute_tool_call(
+            &self,
+            call: &ToolCall,
+        ) -> impl Future<Output = Result<Option<ToolOutput>, ToolError>> + Send {
+            let idx = self.call_count.fetch_add(1, Ordering::SeqCst);
+            let tool_id = call.tool_id.clone();
+            async move {
+                if idx == 0 {
+                    let _ = tool_id;
+                    Err(ToolError::InvalidParams {
+                        message: "permanent error".to_owned(),
+                    })
+                } else {
+                    Ok(Some(ToolOutput {
+                        tool_name: tool_id,
+                        summary: "ok".to_owned(),
+                        blocks_executed: 1,
+                        diff: None,
+                        filter_stats: None,
+                        streamed: false,
+                        terminal_id: None,
+                        locations: None,
+                        raw_response: None,
+                    }))
+                }
+            }
+        }
+    }
+
+    let executor = FirstFailsExecutor {
+        call_count: Arc::new(AtomicUsize::new(0)),
+    };
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let mut agent = super::super::Agent::new(provider, channel, registry, None, 5, executor);
+
+    let tool_calls = vec![
+        make_tool_use_request("id-par-1", "bash"),
+        make_tool_use_request("id-par-2", "bash"),
+    ];
+    agent
+        .handle_native_tool_calls(None, &tool_calls)
+        .await
+        .unwrap();
+
+    // Collect the assistant ToolUse message and the user ToolResults message.
+    let assistant_pos = agent
+        .msg
+        .messages
+        .iter()
+        .rposition(|m| {
+            m.role == Role::Assistant
+                && m.parts
+                    .iter()
+                    .any(|p| matches!(p, MessagePart::ToolUse { .. }))
+        })
+        .expect("assistant ToolUse message must be present");
+    let user_pos = agent
+        .msg
+        .messages
+        .iter()
+        .rposition(|m| {
+            m.role == Role::User
+                && m.parts
+                    .iter()
+                    .any(|p| matches!(p, MessagePart::ToolResult { .. }))
+        })
+        .expect("user ToolResults message must be present");
+
+    // The User{ToolResults} must immediately follow Assistant{ToolUse} — no messages in between.
+    assert_eq!(
+        user_pos,
+        assistant_pos + 1,
+        "User{{ToolResults}} must immediately follow Assistant{{ToolUse}} with no interleaved messages"
+    );
+
+    let user_msg = &agent.msg.messages[user_pos];
+    let result_ids: Vec<&str> = user_msg
+        .parts
+        .iter()
+        .filter_map(|p| {
+            if let MessagePart::ToolResult { tool_use_id, .. } = p {
+                Some(tool_use_id.as_str())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    assert!(
+        result_ids.contains(&"id-par-1"),
+        "ToolResult for id-par-1 (permanent error) must be present: {result_ids:?}"
+    );
+    assert!(
+        result_ids.contains(&"id-par-2"),
+        "ToolResult for id-par-2 (success) must be present: {result_ids:?}"
+    );
+    assert_eq!(
+        result_ids.len(),
+        2,
+        "exactly 2 ToolResults expected, one per tool_call_id: {result_ids:?}"
+    );
 }


### PR DESCRIPTION
Fixes #2197.

## Root cause

`attempt_self_reflection` was called inside the per-tool result loop in
`handle_native_tool_calls`. When any tool returned an error (including permanent
errors like HTTP 403), the old code called `attempt_self_reflection` mid-loop,
which pushed `User{reflection_prompt}` + `Assistant{response}` into history
**before** the `User{ToolResults}` message was assembled. The resulting message
sequence sent to the API was:

```
[N]   Assistant{ToolUse(id-1, id-2, ...)}
[N+1] User{"You attempted to help..."}      ← reflection prompt (wrong position)
[N+2] Assistant{reflection response}
[N+3] User{ToolResult(id-1), ToolResult(id-2)} ← too late
```

OpenAI requires every `tool_call_id` in an assistant message to be immediately
followed by `role:"tool"` messages. Having a regular `role:"user"` message at
[N+1] → HTTP 400. Claude's context assembly downgrades orphaned ToolUse to text,
silently losing tool results.

Secondary issue: `record_anomaly_outcome().await?` propagated channel send errors
via `?`, abandoning mid-batch ToolResult assembly before `result_parts.push()`.

## Fix

- **Deferred self-reflection**: removed `attempt_self_reflection` from inside the
  per-tool loop. A single `pending_reflection: Option<String>` captures the first
  eligible error output. After the loop assembles all ToolResult parts and
  `user_msg` is pushed to history, reflection fires — in the correct position
  after `User{ToolResults}`.
- **Reflection errors swallowed**: `Ok(_) | Err(_) => {}` — whether reflection
  succeeds, declines, or errors, `Ok(())` is returned. ToolResults are already
  committed; the tool loop continues normally.
- **`record_anomaly_outcome` errors ignored**: changed `await?` to `let _ =
  ...await` so channel failures cannot abandon ToolResult assembly.

## Tests

- **R-NTP-13** (new): single `ToolError::Execution(io::Error::other("HTTP 403"))`
  → ToolResult present in history
- **R-NTP-14** (new): two parallel permanent errors → both ToolResult parts present
- **R-NTP-10/11/12** updated: now assert `is_ok()` (new contract — reflection
  errors no longer propagate) and search all messages for ToolResult parts

## Checklist

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 6103/6103 passed
- [x] CHANGELOG.md updated (`[Unreleased]` section)
- [ ] Live API session test required (LLM serialization gate: touches message history assembly path)