### PR TITLE
fix(memory): reject self-loop edges in graph extractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- fix(memory): reject self-loop edges in graph extractor — `extract_and_store` skips edges where source and target resolve to the same entity ID; `insert_edge_typed` returns `MemoryError::InvalidInput` for same-ID pairs; migration `044` removes existing self-loops and adds a BEFORE INSERT trigger to enforce the constraint at the DB level (#2215)
+
 - fix(security): agent no longer calls `fetch`/`web_scrape` with hallucinated URLs; three-layer defense: (1) tool descriptions now explicitly prohibit constructing or inferring URLs from entity names; (2) system prompt `## Guidelines` adds a fetch/URL grounding rule; (3) new `UrlGroundingVerifier` pre-execution gate blocks `fetch`, `web_scrape`, and `*_fetch` tool calls when the requested URL was not present in any user message in the session — returns "fetch rejected: URL was not provided by the user"; `user_provided_urls` extracted via `extract_flagged_urls` on every user turn, cleared on `/clear`; configurable via `[security.pre_execution_verify.url_grounding]` (#2191)
 
 - fix(core): permanent tool errors (e.g. HTTP 403) no longer cause OpenAI HTTP 400 "tool_calls must be followed by tool messages"; `attempt_self_reflection` is now deferred until after all `ToolResult` parts are assembled and pushed to message history, preserving the `Assistant{ToolUse} → User{ToolResults}` ordering required by the OpenAI and Claude APIs; `record_anomaly_outcome` errors are silently ignored so channel failures cannot abandon mid-batch ToolResult assembly; adds regression tests R-NTP-13 and R-NTP-14 for single and parallel permanent errors (#2197)

--- a/crates/zeph-memory/migrations/044_graph_edges_no_self_loops.sql
+++ b/crates/zeph-memory/migrations/044_graph_edges_no_self_loops.sql
@@ -1,0 +1,13 @@
+-- SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+-- SPDX-License-Identifier: MIT OR Apache-2.0
+
+-- Remove any existing self-loop edges.
+DELETE FROM graph_edges WHERE source_entity_id = target_entity_id;
+
+-- Prevent future self-loop edges at the DB level (SQLite has no CHECK on ALTER TABLE).
+CREATE TRIGGER IF NOT EXISTS graph_edges_no_self_loops
+    BEFORE INSERT ON graph_edges
+BEGIN
+    SELECT RAISE(ABORT, 'self-loop edge rejected: source and target entity must differ')
+    WHERE NEW.source_entity_id = NEW.target_entity_id;
+END;

--- a/crates/zeph-memory/src/error.rs
+++ b/crates/zeph-memory/src/error.rs
@@ -33,6 +33,9 @@ pub enum MemoryError {
     #[error("graph store error: {0}")]
     GraphStore(String),
 
+    #[error("invalid input: {0}")]
+    InvalidInput(String),
+
     #[error("{0}")]
     Other(String),
 }

--- a/crates/zeph-memory/src/graph/store/mod.rs
+++ b/crates/zeph-memory/src/graph/store/mod.rs
@@ -380,6 +380,11 @@ impl GraphStore {
         episode_id: Option<MessageId>,
         edge_type: EdgeType,
     ) -> Result<i64, MemoryError> {
+        if source_entity_id == target_entity_id {
+            return Err(MemoryError::InvalidInput(format!(
+                "self-loop edge rejected: source and target are the same entity (id={source_entity_id})"
+            )));
+        }
         let confidence = confidence.clamp(0.0, 1.0);
         let edge_type_str = edge_type.as_str();
 

--- a/crates/zeph-memory/src/graph/store/tests.rs
+++ b/crates/zeph-memory/src/graph/store/tests.rs
@@ -3255,3 +3255,31 @@ async fn entity_community_ids_empty_input_returns_empty() {
     let result = store.entity_community_ids(&[]).await.unwrap();
     assert!(result.is_empty());
 }
+
+/// Regression test for #2215: insert_edge_typed must reject self-loop edges.
+#[tokio::test]
+async fn insert_edge_typed_rejects_self_loop() {
+    let gs = setup().await;
+    let id = gs
+        .upsert_entity("Solo", "Solo", EntityType::Concept, None)
+        .await
+        .unwrap();
+
+    let err = gs
+        .insert_edge_typed(
+            id,
+            id,
+            "self",
+            "Solo is Solo",
+            0.9,
+            None,
+            EdgeType::Semantic,
+        )
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, crate::error::MemoryError::InvalidInput(_)),
+        "expected InvalidInput for self-loop, got: {err:?}"
+    );
+}

--- a/crates/zeph-memory/src/semantic/graph.rs
+++ b/crates/zeph-memory/src/semantic/graph.rs
@@ -378,6 +378,14 @@ pub async fn extract_and_store(
             );
             continue;
         };
+        if src_id == tgt_id {
+            tracing::debug!(
+                "graph: skipping self-loop edge {:?}->{:?} (entity_id={src_id})",
+                edge.source,
+                edge.target
+            );
+            continue;
+        }
         // Parse LLM-provided edge_type; default to Semantic on any parse failure so
         // edges are never dropped due to classification errors.
         let edge_type = edge
@@ -583,6 +591,46 @@ mod tests {
         assert!(
             !results.is_empty(),
             "FTS5 cross-session (#2166): entity extracted in session A must be visible in session B"
+        );
+    }
+
+    /// Regression test for #2215: self-loop edges (source == target entity) must be silently
+    /// skipped; no edge row should be inserted.
+    #[tokio::test]
+    async fn extract_and_store_skips_self_loop_edges() {
+        let (gs, _emb) = setup().await;
+
+        // LLM returns one entity and one self-loop edge (source == target).
+        let extraction_json = r#"{
+            "entities":[{"name":"Rust","type":"language","summary":"systems language"}],
+            "edges":[{"source":"Rust","target":"Rust","relation":"is","fact":"Rust is Rust","edge_type":"semantic"}]
+        }"#;
+        let mock = zeph_llm::mock::MockProvider::with_responses(vec![extraction_json.to_owned()]);
+        let provider = AnyProvider::Mock(mock);
+
+        let config = GraphExtractionConfig {
+            max_entities: 10,
+            max_edges: 10,
+            extraction_timeout_secs: 10,
+            ..Default::default()
+        };
+
+        let result = extract_and_store(
+            "Rust is a language.".to_owned(),
+            vec![],
+            provider,
+            gs.pool().clone(),
+            config,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.stats.entities_upserted, 1);
+        assert_eq!(
+            result.stats.edges_inserted, 0,
+            "self-loop edge must be rejected (#2215)"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Add three-layer defense against `source_entity_id == target_entity_id` edges in the knowledge graph
- `extract_and_store` in `semantic/graph.rs`: skip self-loops after entity ID resolution with debug log
- `insert_edge_typed` in `graph/store/mod.rs`: return `MemoryError::InvalidInput` for self-loops
- Migration `044`: DELETE existing self-loops + BEFORE INSERT trigger (SQLite lacks ALTER TABLE CHECK)
- New `MemoryError::InvalidInput(String)` variant following existing thiserror patterns

## Test plan

- [ ] `zeph-memory::semantic::graph::tests::extract_and_store_skips_self_loop_edges` — mock returns self-loop, asserts 0 edges inserted
- [ ] `zeph-memory::graph::store::tests::insert_edge_typed_rejects_self_loop` — asserts InvalidInput error
- [ ] `cargo nextest run --workspace --features full --lib --bins` — 6638 passed

Closes #2215