### PR TITLE
fix(mcp): make OAuth server connections non-blocking at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,7 +1119,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1799,7 +1799,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1970,7 +1970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3048,7 +3048,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3450,6 +3450,25 @@ checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -4064,7 +4083,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4210,7 +4229,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
  "http",
@@ -4336,6 +4355,17 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "open"
+version = "5.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
 
 [[package]]
 name = "openssl-probe"
@@ -4493,6 +4523,12 @@ name = "pastey"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pbkdf2"
@@ -5109,7 +5145,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5147,9 +5183,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5779,7 +5815,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5847,7 +5883,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7101,7 +7137,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8653,7 +8689,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9648,6 +9684,7 @@ dependencies = [
  "dashmap",
  "glob",
  "http",
+ "open",
  "qdrant-client",
  "regex",
  "reqwest 0.13.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ notify = "8"
 notify-debouncer-mini = "0.7"
 nucleo-matcher = "0.3.1"
 ollama-rs = { version = "0.3", default-features = false }
+open = "5"
 opentelemetry = "0.31"
 opentelemetry-otlp = { version = "0.31", default-features = false }
 opentelemetry_sdk = { version = "0.31", default-features = false }

--- a/crates/zeph-mcp/Cargo.toml
+++ b/crates/zeph-mcp/Cargo.toml
@@ -24,6 +24,7 @@ dashmap.workspace = true
 glob.workspace = true
 http.workspace = true
 qdrant-client = { workspace = true, features = ["serde"] }
+open.workspace = true
 regex.workspace = true
 reqwest = { workspace = true, features = ["rustls", "json"] }
 rmcp = { workspace = true, features = ["client", "transport-child-process", "transport-streamable-http-client-reqwest", "auth"] }

--- a/crates/zeph-mcp/src/manager.rs
+++ b/crates/zeph-mcp/src/manager.rs
@@ -262,31 +262,26 @@ impl McpManager {
         self
     }
 
-    /// Connect to all configured servers, return aggregated tool list.
+    /// Connect to all non-OAuth servers, return aggregated tool list.
     ///
-    /// Phase 1: non-OAuth servers connect concurrently via `JoinSet`.
-    /// Phase 2: OAuth servers connect sequentially (requires user interaction).
-    ///
-    /// For OAuth servers without a registered credential store, a warning is
-    /// logged and the server is skipped.
+    /// OAuth servers are skipped — call `connect_oauth_deferred()` after the
+    /// UI channel is ready so the auth URL is visible and startup is not blocked.
     ///
     /// # Panics
     ///
     /// Panics if the internal `connected_server_ids` lock is poisoned.
-    #[allow(clippy::too_many_lines)]
     pub async fn connect_all(&self) -> Vec<McpTool> {
         let allowed = self.allowed_commands.clone();
         let suppress = self.suppress_stderr;
         let last_refresh = Arc::clone(&self.last_refresh);
 
-        // Partition configs into non-OAuth (concurrent) and OAuth (sequential)
-        let (non_oauth, oauth_configs): (Vec<_>, Vec<_>) = self
+        let non_oauth: Vec<_> = self
             .configs
             .iter()
+            .filter(|&c| !matches!(c.transport, McpTransport::OAuth { .. }))
             .cloned()
-            .partition(|c| !matches!(c.transport, McpTransport::OAuth { .. }));
+            .collect();
 
-        // Phase 1: connect non-OAuth servers concurrently
         let mut join_set = JoinSet::new();
         for config in non_oauth {
             let allowed = allowed.clone();
@@ -322,7 +317,39 @@ impl McpManager {
             }
         }
 
-        // Phase 2: connect OAuth servers sequentially
+        all_tools
+    }
+
+    /// Returns `true` if any configured server uses OAuth transport.
+    #[must_use]
+    pub fn has_oauth_servers(&self) -> bool {
+        self.configs
+            .iter()
+            .any(|c| matches!(c.transport, McpTransport::OAuth { .. }))
+    }
+
+    /// Connect OAuth servers in the background.
+    ///
+    /// Must be called after the UI channel is running so that auth URLs are
+    /// visible to the user. For each server requiring authorization, the
+    /// browser is opened automatically and the callback is awaited (up to 300 s).
+    /// Discovered tools are published via `tools_watch_tx` so the running agent
+    /// picks them up automatically.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal `connected_server_ids` lock is poisoned.
+    #[allow(clippy::too_many_lines)]
+    pub async fn connect_oauth_deferred(&self) {
+        let last_refresh = Arc::clone(&self.last_refresh);
+
+        let oauth_configs: Vec<_> = self
+            .configs
+            .iter()
+            .filter(|&c| matches!(c.transport, McpTransport::OAuth { .. }))
+            .cloned()
+            .collect();
+
         for config in oauth_configs {
             let McpTransport::OAuth {
                 ref url,
@@ -363,6 +390,7 @@ impl McpManager {
 
             match connect_result {
                 Ok(OAuthConnectResult::Connected(client)) => {
+                    let mut all_tools = Vec::new();
                     let mut clients = self.clients.write().await;
                     let mut server_tools = self.server_tools.write().await;
                     self.handle_connect_result(
@@ -373,6 +401,8 @@ impl McpManager {
                         &mut server_tools,
                     )
                     .await;
+                    let updated: Vec<McpTool> = server_tools.values().flatten().cloned().collect();
+                    let _ = self.tools_watch_tx.send(updated);
                 }
                 Ok(OAuthConnectResult::AuthorizationRequired(pending_box)) => {
                     let mut pending = *pending_box;
@@ -392,6 +422,9 @@ impl McpManager {
                     } else {
                         eprintln!("{auth_msg}");
                     }
+                    // open::that_in_background spawns an OS thread; ignore the handle —
+                    // we don't need to wait for the browser to open.
+                    let _ = open::that_in_background(pending.auth_url.clone());
 
                     let callback_timeout = std::time::Duration::from_secs(300);
                     let listener = pending
@@ -403,10 +436,11 @@ impl McpManager {
                     {
                         Ok((code, csrf_token)) => {
                             if let Some(ref tx) = self.status_tx {
-                                let _ = tx.send(String::new()); // clear "Waiting for OAuth..." spinner
+                                let _ = tx.send(String::new());
                             }
                             match McpClient::complete_oauth(pending, &code, &csrf_token).await {
                                 Ok(client) => {
+                                    let mut all_tools = Vec::new();
                                     let mut clients = self.clients.write().await;
                                     let mut server_tools = self.server_tools.write().await;
                                     self.handle_connect_result(
@@ -417,6 +451,9 @@ impl McpManager {
                                         &mut server_tools,
                                     )
                                     .await;
+                                    let updated: Vec<McpTool> =
+                                        server_tools.values().flatten().cloned().collect();
+                                    let _ = self.tools_watch_tx.send(updated);
                                 }
                                 Err(e) => {
                                     tracing::warn!(
@@ -439,8 +476,6 @@ impl McpManager {
                 }
             }
         }
-
-        all_tools
     }
 
     async fn handle_connect_result(
@@ -801,7 +836,7 @@ async fn connect_entry(
             }
         }
         McpTransport::OAuth { .. } => {
-            // OAuth connections are handled separately in connect_all() Phase 2.
+            // OAuth connections are handled separately in connect_oauth_deferred().
             Err(McpError::OAuthError {
                 server_id: entry.id.clone(),
                 message: "OAuth transport cannot be used via connect_entry".into(),

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -645,6 +645,16 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     #[cfg(not(feature = "tui"))]
     let channel = create_channel_inner(app.config(), cli_history).await?;
 
+    // Spawn deferred OAuth connections now that the UI channel is ready and can
+    // display the authorization URL. Non-OAuth tools are already available from
+    // connect_all(); OAuth tools arrive via tools_watch_tx when authorized.
+    if tool_setup.mcp_manager.has_oauth_servers() {
+        let mgr = std::sync::Arc::clone(&tool_setup.mcp_manager);
+        tokio::spawn(async move {
+            mgr.connect_oauth_deferred().await;
+        });
+    }
+
     #[cfg(feature = "tui")]
     let is_cli = matches!(channel, AppChannel::Standard(AnyChannel::Cli(_)));
     #[cfg(not(feature = "tui"))]


### PR DESCRIPTION
## Summary

- Extract OAuth Phase 2 from `connect_all()` into `connect_oauth_deferred()` in `crates/zeph-mcp/src/manager.rs`
- `connect_all()` now only connects non-OAuth servers (fast, no blocking)
- `connect_oauth_deferred()` runs as a background task spawned in `src/runner.rs` **after** TUI/channel is initialised
- Auto-opens browser via `open::that_in_background()` before awaiting callback
- CLI fallback: `eprintln` prints auth URL when no `status_tx` is present
- OAuth tools are published via `tools_watch_tx` on success — picked up automatically by the agent loop
- Adds `open = "5"` workspace dependency for cross-platform browser launch

## Fixes

Fixes #2276

## Test plan

- [ ] Agent starts immediately without freezing when OAuth MCP server is configured
- [ ] Auth URL appears in TUI status bar after startup completes
- [ ] Browser auto-opens with the OAuth authorization URL
- [ ] After completing OAuth flow in browser, MCP tools become available in the agent
- [ ] CLI mode: auth URL printed to stderr, browser opens
- [ ] Non-OAuth MCP servers are unaffected
- [ ] `cargo clippy --workspace --features full -- -D warnings` — clean
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --features full --lib --bins` — 6821 passed