### PR TITLE
fix(tools): quote cwd path in sandbox_allows_cwd_by_default test

### DIFF
--- a/crates/zeph-tools/src/shell/tests.rs
+++ b/crates/zeph-tools/src/shell/tests.rs
@@ -516,7 +516,7 @@ fn sandbox_allows_cwd_by_default() {
     let executor = ShellExecutor::new(&default_config());
     let cwd = std::env::current_dir().unwrap();
     let cwd_path = cwd.display().to_string();
-    let code = format!("cat {cwd_path}/file.txt");
+    let code = format!("cat \"{cwd_path}/file.txt\"");
     assert!(executor.validate_sandbox(&code).is_ok());
 }
 


### PR DESCRIPTION
## Summary

- Fixes `sandbox_allows_cwd_by_default` test failure on macOS systems where the home directory path contains spaces (e.g. `Documents - rabax's MacBook Pro`)
- Root cause: the test built a shell command string with an unquoted CWD path, which `extract_paths()` tokenized by splitting on whitespace — producing path fragments that failed the sandbox `starts_with` check
- Fix: wrap the path in double quotes (`"cat \"{path}/file.txt\""`) to match real shell usage, where paths with spaces must be quoted

## Test plan

- [x] `cargo nextest run -p zeph-tools -E 'test(sandbox_allows_cwd_by_default)'` passes
- [x] Full `cargo nextest run -p zeph-tools --lib --bins` — 852/852 passed

Closes #2279