### PR TITLE
fix(memory): compat deserializer and migration for pre-v0.17.1 MessagePart format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - fix(tui): MCP Tools panel and Resources widget now show per-server connection status — `connect_all()` returns `(Vec<McpTool>, Vec<ServerConnectOutcome>)` with per-server id, connected flag, tool count, and error string; `MetricsSnapshot` gains `mcp_connected_count` and `mcp_servers: Vec<McpServerStatus>`; Resources panel shows `N/M connected, K tools`; Skills panel shows per-server OK (green) / FAIL (red) rows above the tool list; `mcp_server_count` now reflects total configured servers, not just connected ones (#2277)
 - fix(skills): tighten `system_prompt_leak` pattern to require an extraction verb or interrogative before "system prompt"; eliminates false-positive WARN for user-installed skills (e.g. `mcp-generate`) whose documentation describes where MCP tool output appears in the system prompt (#2274)
+- `zeph-memory`: compat deserializer for pre-v0.17.1 `MessagePart` SQLite records; SQLite migration resets legacy-format `parts` rows to `[]` (#2278)
 
 ## [0.17.1] - 2026-03-27
 

--- a/crates/zeph-memory/migrations/045_fix_message_parts_legacy_format.sql
+++ b/crates/zeph-memory/migrations/045_fix_message_parts_legacy_format.sql
@@ -1,0 +1,27 @@
+-- SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+-- SPDX-License-Identifier: MIT OR Apache-2.0
+
+-- Rewrite legacy externally-tagged MessagePart JSON in the messages table.
+-- Old format (pre-v0.17.1): [{"Summary":{"text":"..."}}, ...]
+-- New format (v0.17.1+):    [{"kind":"summary","text":"..."}, ...]
+-- Detection: presence of known variant name as an object key.
+-- SQLite lacks procedural JSON rewriting; rows with complex old-format parts
+-- are reset to parts='[]'. The plain-text content column always holds the
+-- message text and is used as the display fallback.
+UPDATE messages
+SET parts = '[]'
+WHERE parts != '[]'
+  AND (
+    parts LIKE '%{"Text":%'
+    OR parts LIKE '%{"ToolOutput":%'
+    OR parts LIKE '%{"Recall":%'
+    OR parts LIKE '%{"CodeContext":%'
+    OR parts LIKE '%{"Summary":%'
+    OR parts LIKE '%{"CrossSession":%'
+    OR parts LIKE '%{"ToolUse":%'
+    OR parts LIKE '%{"ToolResult":%'
+    OR parts LIKE '%{"Image":%'
+    OR parts LIKE '%{"ThinkingBlock":%'
+    OR parts LIKE '%{"RedactedThinkingBlock":%'
+    OR parts LIKE '%{"Compaction":%'
+  );

--- a/crates/zeph-memory/src/sqlite/messages/mod.rs
+++ b/crates/zeph-memory/src/sqlite/messages/mod.rs
@@ -41,6 +41,65 @@ pub fn role_str(role: Role) -> &'static str {
     }
 }
 
+/// Map a legacy externally-tagged variant key to the `kind` value used by the current
+/// internally-tagged schema.
+fn legacy_key_to_kind(key: &str) -> Option<&'static str> {
+    match key {
+        "Text" => Some("text"),
+        "ToolOutput" => Some("tool_output"),
+        "Recall" => Some("recall"),
+        "CodeContext" => Some("code_context"),
+        "Summary" => Some("summary"),
+        "CrossSession" => Some("cross_session"),
+        "ToolUse" => Some("tool_use"),
+        "ToolResult" => Some("tool_result"),
+        "Image" => Some("image"),
+        "ThinkingBlock" => Some("thinking_block"),
+        "RedactedThinkingBlock" => Some("redacted_thinking_block"),
+        "Compaction" => Some("compaction"),
+        _ => None,
+    }
+}
+
+/// Attempt to parse a JSON string written in the pre-v0.17.1 externally-tagged format.
+///
+/// Old format: `[{"Summary":{"text":"..."}}, ...]`
+/// New format: `[{"kind":"summary","text":"..."}, ...]`
+///
+/// Returns `None` if the input does not look like the old format or if any element fails
+/// to deserialize after conversion.
+fn try_parse_legacy_parts(parts_json: &str) -> Option<Vec<MessagePart>> {
+    let array: Vec<serde_json::Value> = serde_json::from_str(parts_json).ok()?;
+    let mut result = Vec::with_capacity(array.len());
+    for element in array {
+        let obj = element.as_object()?;
+        if obj.contains_key("kind") {
+            return None;
+        }
+        if obj.len() != 1 {
+            return None;
+        }
+        let (key, inner) = obj.iter().next()?;
+        let kind = legacy_key_to_kind(key)?;
+        let mut new_obj = match inner {
+            serde_json::Value::Object(m) => m.clone(),
+            // Image variant wraps a single object directly
+            other => {
+                let mut m = serde_json::Map::new();
+                m.insert("data".to_string(), other.clone());
+                m
+            }
+        };
+        new_obj.insert(
+            "kind".to_string(),
+            serde_json::Value::String(kind.to_string()),
+        );
+        let part: MessagePart = serde_json::from_value(serde_json::Value::Object(new_obj)).ok()?;
+        result.push(part);
+    }
+    Some(result)
+}
+
 /// Deserialize message parts from a stored JSON string.
 ///
 /// Returns an empty `Vec` and logs a warning if deserialization fails, including the role and
@@ -52,6 +111,15 @@ fn parse_parts_json(role_str: &str, parts_json: &str) -> Vec<MessagePart> {
     match serde_json::from_str(parts_json) {
         Ok(p) => p,
         Err(e) => {
+            if let Some(parts) = try_parse_legacy_parts(parts_json) {
+                let truncated = parts_json.chars().take(120).collect::<String>();
+                tracing::warn!(
+                    role = %role_str,
+                    parts_json = %truncated,
+                    "loaded legacy-format message parts via compat path"
+                );
+                return parts;
+            }
             let truncated = parts_json.chars().take(120).collect::<String>();
             tracing::warn!(
                 role = %role_str,

--- a/crates/zeph-memory/src/sqlite/messages/tests.rs
+++ b/crates/zeph-memory/src/sqlite/messages/tests.rs
@@ -1406,18 +1406,85 @@ async fn apply_tool_pair_summaries_parts_deserialize_as_summary_variant() {
     }
 }
 
-// Documents that the old externally-tagged format `{"Summary":{"text":"..."}}` does NOT
-// deserialize as `Vec<MessagePart>` with the current `#[serde(tag = "kind")]` schema.
-// Records with this format written by pre-fix code will silently fall back to an empty
-// parts list via `parse_parts_json`. A migration is required to repair such rows.
+// Verifies that the old externally-tagged format still does NOT deserialize directly via
+// serde (i.e. the schema change is real), but that the compat path in `parse_parts_json`
+// recovers it correctly.
 #[test]
-fn old_external_tag_summary_format_fails_to_deserialize() {
+fn old_external_tag_summary_format_via_compat_path() {
     use zeph_llm::provider::MessagePart;
 
     let old_json = r#"[{"Summary":{"text":"something"}}]"#;
-    let result: Result<Vec<MessagePart>, _> = serde_json::from_str(old_json);
+
+    // Direct serde still fails — the schema change is intact.
+    let direct: Result<Vec<MessagePart>, _> = serde_json::from_str(old_json);
     assert!(
-        result.is_err(),
+        direct.is_err(),
         "old externally-tagged format must not deserialize with the current internally-tagged schema"
     );
+
+    // Compat path recovers the record.
+    let parts = try_parse_legacy_parts(old_json).expect("compat path must succeed for Summary");
+    assert_eq!(parts.len(), 1);
+    match &parts[0] {
+        MessagePart::Summary { text } => assert_eq!(text, "something"),
+        other => panic!("expected MessagePart::Summary, got {other:?}"),
+    }
+}
+
+#[allow(clippy::type_complexity)]
+#[test]
+fn legacy_compat_all_text_like_variants() {
+    let cases: &[(&str, fn(&MessagePart) -> bool)] = &[
+        (r#"[{"Text":{"text":"t"}}]"#, |p| {
+            matches!(p, MessagePart::Text { .. })
+        }),
+        (r#"[{"Recall":{"text":"r"}}]"#, |p| {
+            matches!(p, MessagePart::Recall { .. })
+        }),
+        (r#"[{"CodeContext":{"text":"c"}}]"#, |p| {
+            matches!(p, MessagePart::CodeContext { .. })
+        }),
+        (r#"[{"CrossSession":{"text":"x"}}]"#, |p| {
+            matches!(p, MessagePart::CrossSession { .. })
+        }),
+        (r#"[{"Compaction":{"summary":"s"}}]"#, |p| {
+            matches!(p, MessagePart::Compaction { .. })
+        }),
+    ];
+    for (json, check) in cases {
+        let parts =
+            try_parse_legacy_parts(json).unwrap_or_else(|| panic!("compat failed for: {json}"));
+        assert_eq!(parts.len(), 1);
+        assert!(check(&parts[0]), "wrong variant for: {json}");
+    }
+}
+
+#[test]
+fn legacy_compat_mixed_array() {
+    let json = r#"[{"Text":{"text":"hello"}},{"Summary":{"text":"world"}}]"#;
+    let parts = try_parse_legacy_parts(json).expect("compat path must succeed for mixed array");
+    assert_eq!(parts.len(), 2);
+    assert!(matches!(&parts[0], MessagePart::Text { text } if text == "hello"));
+    assert!(matches!(&parts[1], MessagePart::Summary { text } if text == "world"));
+}
+
+#[test]
+fn new_format_not_intercepted_by_compat() {
+    // Already-new-format: compat returns None so primary path handles it.
+    let json = r#"[{"kind":"summary","text":"hello"}]"#;
+    assert!(
+        try_parse_legacy_parts(json).is_none(),
+        "new-format arrays must not be handled by the compat path"
+    );
+    // Primary path still deserializes it.
+    let parts: Vec<zeph_llm::provider::MessagePart> =
+        serde_json::from_str(json).expect("new format must deserialize directly");
+    assert_eq!(parts.len(), 1);
+}
+
+#[test]
+fn garbage_json_returns_none_from_compat() {
+    assert!(try_parse_legacy_parts("not json at all").is_none());
+    assert!(try_parse_legacy_parts(r#"{"not":"an array"}"#).is_none());
+    assert!(try_parse_legacy_parts(r#"[{"UnknownVariant":{"x":"y"}}]"#).is_none());
 }


### PR DESCRIPTION
Fixes #2278.

## Summary

- Add `try_parse_legacy_parts()` compat fallback in `parse_parts_json()`: recognizes all 12 old externally-tagged variant keys (`{"Summary":{"text":"..."}}`) and converts to the current internally-tagged format (`{"kind":"summary","text":"..."}`); emits `tracing::warn` on the legacy path for observability
- Add SQLite migration `045_fix_message_parts_legacy_format.sql` that resets legacy-format `parts` rows to `[]`; the `content` column is preserved as the plain-text fallback
- Update existing test `old_external_tag_summary_format_fails_to_deserialize` → now asserts the old format succeeds via the compat path; add 4 new compat tests covering all major variants, mixed arrays, new-format passthrough, and garbage JSON

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo nextest run -p zeph-memory --lib` — 835 passed, 0 failed
- [ ] No new clippy errors introduced (pre-existing 45 errors in zeph-memory unchanged)
- [ ] Compat path emits `tracing::warn` with `"loaded legacy-format message parts via compat path"` for observability