### PR TITLE
fix(tools): propagate ClaimSource and ErrorDomain to AuditEntry

### DIFF
--- a/crates/zeph-tools/src/audit.rs
+++ b/crates/zeph-tools/src/audit.rs
@@ -258,6 +258,72 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[test]
+    fn claim_source_serde_roundtrip() {
+        use crate::executor::ClaimSource;
+        let cases = [
+            (ClaimSource::Shell, "\"shell\""),
+            (ClaimSource::FileSystem, "\"file_system\""),
+            (ClaimSource::WebScrape, "\"web_scrape\""),
+            (ClaimSource::Mcp, "\"mcp\""),
+            (ClaimSource::A2a, "\"a2a\""),
+            (ClaimSource::CodeSearch, "\"code_search\""),
+            (ClaimSource::Diagnostics, "\"diagnostics\""),
+            (ClaimSource::Memory, "\"memory\""),
+        ];
+        for (variant, expected_json) in cases {
+            let serialized = serde_json::to_string(&variant).unwrap();
+            assert_eq!(serialized, expected_json, "serialize {variant:?}");
+            let deserialized: ClaimSource = serde_json::from_str(&serialized).unwrap();
+            assert_eq!(deserialized, variant, "deserialize {variant:?}");
+        }
+    }
+
+    #[test]
+    fn audit_entry_claim_source_none_omitted() {
+        let entry = AuditEntry {
+            timestamp: "0".into(),
+            tool: "shell".into(),
+            command: "echo".into(),
+            result: AuditResult::Success,
+            duration_ms: 1,
+            error_category: None,
+            error_domain: None,
+            claim_source: None,
+            mcp_server_id: None,
+            injection_flagged: false,
+            embedding_anomalous: false,
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(
+            !json.contains("claim_source"),
+            "claim_source must be omitted when None: {json}"
+        );
+    }
+
+    #[test]
+    fn audit_entry_claim_source_some_present() {
+        use crate::executor::ClaimSource;
+        let entry = AuditEntry {
+            timestamp: "0".into(),
+            tool: "shell".into(),
+            command: "echo".into(),
+            result: AuditResult::Success,
+            duration_ms: 1,
+            error_category: None,
+            error_domain: None,
+            claim_source: Some(ClaimSource::Shell),
+            mcp_server_id: None,
+            injection_flagged: false,
+            embedding_anomalous: false,
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(
+            json.contains("\"claim_source\":\"shell\""),
+            "expected claim_source=shell in JSON: {json}"
+        );
+    }
+
     #[tokio::test]
     async fn audit_logger_multiple_entries() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/zeph-tools/src/scrape.rs
+++ b/crates/zeph-tools/src/scrape.rs
@@ -142,14 +142,21 @@ impl ToolExecutor for WebScrapeExecutor {
                         &instruction.url,
                         AuditResult::Success,
                         duration_ms,
+                        None,
                     )
                     .await;
                     outputs.push(output);
                 }
                 Err(e) => {
                     let audit_result = tool_error_to_audit_result(&e);
-                    self.log_audit("web_scrape", &instruction.url, audit_result, duration_ms)
-                        .await;
+                    self.log_audit(
+                        "web_scrape",
+                        &instruction.url,
+                        audit_result,
+                        duration_ms,
+                        Some(&e),
+                    )
+                    .await;
                     return Err(e);
                 }
             }
@@ -184,6 +191,7 @@ impl ToolExecutor for WebScrapeExecutor {
                             &instruction.url,
                             AuditResult::Success,
                             duration_ms,
+                            None,
                         )
                         .await;
                         Ok(Some(ToolOutput {
@@ -201,8 +209,14 @@ impl ToolExecutor for WebScrapeExecutor {
                     }
                     Err(e) => {
                         let audit_result = tool_error_to_audit_result(&e);
-                        self.log_audit("web_scrape", &instruction.url, audit_result, duration_ms)
-                            .await;
+                        self.log_audit(
+                            "web_scrape",
+                            &instruction.url,
+                            audit_result,
+                            duration_ms,
+                            Some(&e),
+                        )
+                        .await;
                         Err(e)
                     }
                 }
@@ -215,7 +229,7 @@ impl ToolExecutor for WebScrapeExecutor {
                 let duration_ms = start.elapsed().as_millis() as u64;
                 match result {
                     Ok(output) => {
-                        self.log_audit("fetch", &p.url, AuditResult::Success, duration_ms)
+                        self.log_audit("fetch", &p.url, AuditResult::Success, duration_ms, None)
                             .await;
                         Ok(Some(ToolOutput {
                             tool_name: "fetch".to_owned(),
@@ -232,7 +246,7 @@ impl ToolExecutor for WebScrapeExecutor {
                     }
                     Err(e) => {
                         let audit_result = tool_error_to_audit_result(&e);
-                        self.log_audit("fetch", &p.url, audit_result, duration_ms)
+                        self.log_audit("fetch", &p.url, audit_result, duration_ms, Some(&e))
                             .await;
                         Err(e)
                     }
@@ -260,17 +274,31 @@ fn tool_error_to_audit_result(e: &ToolError) -> AuditResult {
 }
 
 impl WebScrapeExecutor {
-    async fn log_audit(&self, tool: &str, command: &str, result: AuditResult, duration_ms: u64) {
+    async fn log_audit(
+        &self,
+        tool: &str,
+        command: &str,
+        result: AuditResult,
+        duration_ms: u64,
+        error: Option<&ToolError>,
+    ) {
         if let Some(ref logger) = self.audit_logger {
+            let (error_category, error_domain) = error.map_or((None, None), |e| {
+                let cat = e.category();
+                (
+                    Some(cat.label().to_owned()),
+                    Some(cat.domain().label().to_owned()),
+                )
+            });
             let entry = AuditEntry {
                 timestamp: chrono_now(),
                 tool: tool.into(),
                 command: command.into(),
                 result,
                 duration_ms,
-                error_category: None,
-                error_domain: None,
-                claim_source: None,
+                error_category,
+                error_domain,
+                claim_source: Some(ClaimSource::WebScrape),
                 mcp_server_id: None,
                 injection_flagged: false,
                 embedding_anomalous: false,
@@ -1830,6 +1858,7 @@ mod tests {
                 "https://example.com/page",
                 AuditResult::Success,
                 42,
+                None,
             )
             .await;
 
@@ -1868,6 +1897,7 @@ mod tests {
                     reason: "scheme not allowed: http".into(),
                 },
                 0,
+                None,
             )
             .await;
 

--- a/crates/zeph-tools/src/shell/mod.rs
+++ b/crates/zeph-tools/src/shell/mod.rs
@@ -301,7 +301,7 @@ impl ShellExecutor {
         } else {
             AuditResult::Success
         };
-        self.log_audit(block, audit_result, duration_ms).await;
+        self.log_audit(block, audit_result, duration_ms, None).await;
 
         if is_timeout {
             self.emit_completed(block, &out, false, None);
@@ -382,33 +382,37 @@ impl ShellExecutor {
         // Always check the blocklist first — it is a hard security boundary
         // that must not be bypassed by the PermissionPolicy layer.
         if let Some(blocked) = self.find_blocked_command(block) {
+            let err = ToolError::Blocked {
+                command: blocked.to_owned(),
+            };
             self.log_audit(
                 block,
                 AuditResult::Blocked {
                     reason: format!("blocked command: {blocked}"),
                 },
                 0,
+                Some(&err),
             )
             .await;
-            return Err(ToolError::Blocked {
-                command: blocked.to_owned(),
-            });
+            return Err(err);
         }
 
         if let Some(ref policy) = self.permission_policy {
             match policy.check("bash", block) {
                 PermissionAction::Deny => {
+                    let err = ToolError::Blocked {
+                        command: block.to_owned(),
+                    };
                     self.log_audit(
                         block,
                         AuditResult::Blocked {
                             reason: "denied by permission policy".to_owned(),
                         },
                         0,
+                        Some(&err),
                     )
                     .await;
-                    return Err(ToolError::Blocked {
-                        command: block.to_owned(),
-                    });
+                    return Err(err);
                 }
                 PermissionAction::Ask if !skip_confirm => {
                     return Err(ToolError::ConfirmationRequired {
@@ -524,17 +528,30 @@ impl ShellExecutor {
         None
     }
 
-    async fn log_audit(&self, command: &str, result: AuditResult, duration_ms: u64) {
+    async fn log_audit(
+        &self,
+        command: &str,
+        result: AuditResult,
+        duration_ms: u64,
+        error: Option<&ToolError>,
+    ) {
         if let Some(ref logger) = self.audit_logger {
+            let (error_category, error_domain) = error.map_or((None, None), |e| {
+                let cat = e.category();
+                (
+                    Some(cat.label().to_owned()),
+                    Some(cat.domain().label().to_owned()),
+                )
+            });
             let entry = AuditEntry {
                 timestamp: chrono_now(),
                 tool: "shell".into(),
                 command: command.into(),
                 result,
                 duration_ms,
-                error_category: None,
-                error_domain: None,
-                claim_source: None,
+                error_category,
+                error_domain,
+                claim_source: Some(ClaimSource::Shell),
                 mcp_server_id: None,
                 injection_flagged: false,
                 embedding_anomalous: false,


### PR DESCRIPTION
## Summary

- Fix all `AuditEntry` construction sites in `ShellExecutor` and `WebScrapeExecutor` that hardcoded `claim_source: None` and `error_domain: None`, making the audit trail always null for both fields despite `ToolOutput` setting them correctly since PR #2293
- Add missing serde tests for `ClaimSource` and `AuditEntry.claim_source` serialization

## Changes

**`crates/zeph-tools/src/shell/mod.rs`**
- `log_audit()` now takes `Option<&ToolError>`; `claim_source` is always `Some(ClaimSource::Shell)`
- Blocked/permission-denied sites pass `Some(&err)`, success/timeout paths pass `None`
- `error_category` and `error_domain` derived via `ToolErrorCategory::domain()`

**`crates/zeph-tools/src/scrape.rs`**
- Same pattern; `claim_source` is always `Some(ClaimSource::WebScrape)`

**`crates/zeph-tools/src/audit.rs`**
- `claim_source_serde_roundtrip`: all 8 `ClaimSource` variants serialize to snake_case JSON and deserialize back
- `audit_entry_claim_source_none_omitted`: `None` → field absent from JSON output
- `audit_entry_claim_source_some_present`: `Some(ClaimSource::Shell)` → `"claim_source":"shell"`

`policy_gate.rs` retains `claim_source: None` — policy checks are not tool execution results.

## Test plan

- [ ] `cargo +nightly fmt --check` — pass
- [ ] `cargo clippy --all-targets --all-features --workspace -- -D warnings` — pass (0 warnings)
- [ ] `cargo nextest run --workspace --all-features --lib --bins` — 6913 passed (+3 new tests)

Closes #2308
Closes #2299