### PR TITLE
fix(a2a): drain output_rx until Flush to prevent response shift (#2326, #2313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- fix(a2a): `message/send` returning empty artifacts on second and subsequent requests — drain stale events from `output_rx` with `try_recv()` after breaking out of the recv loop so they do not leak into the next request (#2302)
+- fix(a2a): A2A response shift — replace `try_recv()` drain with a blocking drain-until-`Flush` loop; the agent loop always emits `Flush` as the definitive end-of-turn sentinel after `FullMessage`, so waiting for it eliminates the TOCTOU race where tail events (`Usage`, `SessionTitle`, `Flush`) arrived after the drain window and leaked into the next request (#2326)
+- fix(mcp): silent drop of embedding guard result on closed receiver — replace `let _ = tx.send(result)` with an explicit `is_err()` check that logs a `WARN` when the result channel is closed; prevents silent failure hiding in `EmbeddingAnomalyGuard::check_async()` (#2313)
 - fix(daemon): stale PID file from a crashed run no longer blocks startup — read and liveness-check the existing PID before writing; remove the file if the process is dead, error if the process is still alive (#2295)
 - fix(mcp): `prune_tools` `max_tools == 0` now means no cap on LLM-selected candidates (#2294)
 - fix(security): sanitize MCP tool descriptions and names before interpolating into the pruning prompt — strip control characters, cap description at 200 chars and name at 64 chars (#2297)

--- a/crates/zeph-mcp/src/embedding_guard.rs
+++ b/crates/zeph-mcp/src/embedding_guard.rs
@@ -130,11 +130,17 @@ impl EmbeddingAnomalyGuard {
         let Some(centroid) = centroid_opt else {
             // Cold-start: synchronous regex check, sub-millisecond.
             let injection_detected = check_regex(tool_output);
-            let _ = self.result_tx.send(EmbeddingGuardEvent {
-                server_id: server_id.to_owned(),
-                tool_name: tool_name.to_owned(),
-                result: EmbeddingGuardResult::RegexFallback { injection_detected },
-            });
+            if self
+                .result_tx
+                .send(EmbeddingGuardEvent {
+                    server_id: server_id.to_owned(),
+                    tool_name: tool_name.to_owned(),
+                    result: EmbeddingGuardResult::RegexFallback { injection_detected },
+                })
+                .is_err()
+            {
+                tracing::warn!("embedding guard: result channel closed, receiver dropped");
+            }
             return;
         };
 
@@ -164,11 +170,16 @@ impl EmbeddingAnomalyGuard {
                     } else {
                         EmbeddingGuardResult::Normal { distance }
                     };
-                    let _ = tx.send(EmbeddingGuardEvent {
-                        server_id,
-                        tool_name,
-                        result,
-                    });
+                    if tx
+                        .send(EmbeddingGuardEvent {
+                            server_id,
+                            tool_name,
+                            result,
+                        })
+                        .is_err()
+                    {
+                        tracing::warn!("embedding guard: result channel closed, receiver dropped");
+                    }
                 }
                 Err(e) => {
                     // Fail-open: embedding failure does not block the tool output path.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -107,6 +107,7 @@ impl zeph_a2a::TaskProcessor for AgentTaskProcessor {
                 .await
                 .map_err(|_| zeph_a2a::A2aError::Server("event channel closed".to_owned()))?;
 
+            let mut exited_on_flush = false;
             while let Some(event) = handle.output_rx.recv().await {
                 match event {
                     zeph_core::LoopbackEvent::Chunk(text) => {
@@ -124,6 +125,7 @@ impl zeph_a2a::TaskProcessor for AgentTaskProcessor {
                                 is_final: true,
                             })
                             .await;
+                        exited_on_flush = true;
                         break;
                     }
                     zeph_core::LoopbackEvent::FullMessage(text) => {
@@ -146,9 +148,18 @@ impl zeph_a2a::TaskProcessor for AgentTaskProcessor {
                 }
             }
 
-            // Drain any stale events left in the channel from previous requests
-            // (e.g. a Flush emitted after a FullMessage was already consumed).
-            while let Ok(_stale) = handle.output_rx.try_recv() {}
+            // Wait for Flush — the definitive end-of-turn sentinel always emitted by the
+            // agent loop after FullMessage or stop-hint paths. This prevents stale tail
+            // events (e.g. the Flush that follows FullMessage, Usage, SessionTitle) from
+            // leaking into the next request's recv loop.
+            if !exited_on_flush {
+                loop {
+                    match handle.output_rx.recv().await {
+                        Some(zeph_core::LoopbackEvent::Flush) | None => break,
+                        Some(_) => {} // discard tail events
+                    }
+                }
+            }
 
             let _ = event_tx
                 .send(zeph_a2a::ProcessorEvent::StatusUpdate {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -424,6 +424,72 @@ async fn loopback_stale_flush_drained_after_full_message() {
     assert!(rx.try_recv().is_err());
 }
 
+// Fix #2326: drain-until-Flush guarantees no tail event leaks into the next request.
+// Simulates the race: agent emits FullMessage (exits recv loop), then asynchronously
+// emits Usage + Flush. The drain loop must consume both before process() returns.
+#[cfg(feature = "a2a")]
+#[tokio::test]
+async fn a2a_response_shift_drain_until_flush_prevents_leak() {
+    use zeph_core::LoopbackEvent;
+
+    // Test the drain logic directly using a channel pair.
+    // Sequence: FullMessage → Usage (tail) → Flush (tail, arrives with delay).
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<LoopbackEvent>(8);
+
+    tx.send(LoopbackEvent::FullMessage("req1-response".into()))
+        .await
+        .unwrap();
+
+    // Tail events arrive asynchronously after the primary response — models the race.
+    let tx2 = tx.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        let _ = tx2
+            .send(LoopbackEvent::Usage {
+                input_tokens: 10,
+                output_tokens: 5,
+                context_window: 8192,
+            })
+            .await;
+        let _ = tx2.send(LoopbackEvent::Flush).await;
+    });
+    drop(tx);
+
+    // Recv loop: exit on FullMessage (mirrors src/daemon.rs process()).
+    let mut exited_on_flush = false;
+    let mut response = String::new();
+    while let Some(event) = rx.recv().await {
+        match event {
+            LoopbackEvent::Flush => {
+                exited_on_flush = true;
+                break;
+            }
+            LoopbackEvent::FullMessage(text) => {
+                response = text;
+                break;
+            }
+            _ => {}
+        }
+    }
+    assert_eq!(response, "req1-response");
+
+    // Drain until Flush — the fix for #2326.
+    if !exited_on_flush {
+        loop {
+            match rx.recv().await {
+                Some(LoopbackEvent::Flush) | None => break,
+                Some(_) => {}
+            }
+        }
+    }
+
+    // Channel must be empty — stale events must not leak into the next request.
+    assert!(
+        rx.try_recv().is_err(),
+        "channel must be empty after drain; stale events would shift next response"
+    );
+}
+
 // Fix #2295: stale PID detection — read_pid_file + is_process_alive roundtrip.
 #[test]
 fn stale_pid_detection_dead_process() {


### PR DESCRIPTION
## Summary

- **#2326**: Replace the non-blocking `try_recv` drain in `AgentTaskProcessor::process()` with a blocking `recv().await`-until-`Flush` loop. The previous drain was a TOCTOU race: the agent loop continued emitting `Usage`/`Flush` tail events after `try_recv` had already returned empty, leaving them buffered in `output_rx` for the next `message/send` call. Each subsequent request then consumed the previous response, producing the observed one-position shift. `Flush` is the universal end-of-turn sentinel across all agent code paths.
- **#2313**: Replace `let _ = tx.send(result)` with an `is_err()` check and `tracing::warn!()` in `EmbeddingAnomalyGuard::check_async()` — both the cold-start and warm async paths.

## Test plan

- [ ] `cargo +nightly fmt --check` passes
- [ ] `cargo clippy --features full --workspace -- -D warnings` passes (0 warnings)
- [ ] `cargo nextest run --workspace --features full --lib --bins` — 6927 passed (+1 new test)
- [ ] New test `a2a_response_shift_drain_until_flush_prevents_leak` verifies the drain loop consumes `FullMessage` + delayed `Usage + Flush` and leaves the channel empty before the next request
- [ ] Follow-up: consider filing P3 issue for a configurable drain timeout to guard against agent loop panics mid-turn (currently `recv().await` falls back to `None` on channel close)