### PR TITLE
fix(mcp): wire DefaultMcpProber and TrustScoreStore into bootstrap, fix stale delta, add ema_floor validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - fix(a2a): A2A response shift — replace `try_recv()` drain with a blocking drain-until-`Flush` loop; the agent loop always emits `Flush` as the definitive end-of-turn sentinel after `FullMessage`, so waiting for it eliminates the TOCTOU race where tail events (`Usage`, `SessionTitle`, `Flush`) arrived after the drain window and leaked into the next request (#2326)
 - fix(mcp): silent drop of embedding guard result on closed receiver — replace `let _ = tx.send(result)` with an explicit `is_err()` check that logs a `WARN` when the result channel is closed; prevents silent failure hiding in `EmbeddingAnomalyGuard::check_async()` (#2313)
+- fix(mcp): wire `DefaultMcpProber` and `TrustScoreStore` into all three bootstrap paths (runner, daemon, ACP) via new `wire_trust_calibration()` in `zeph-core::bootstrap`; `TrustCalibrationConfig.enabled` now has effect at startup (#2315)
+- fix(mcp): `TrustScoreStore::apply_delta()` operated on stale pre-decay score; new `load_and_apply_delta()` reads with decay applied in-memory before writing back, preventing inflated base scores after long server idle periods; both call sites in `manager.rs` updated (#2323)
+- fix(config): `EmbeddingGuardConfig::threshold` now validated to `(0.0, 1.0]` at deserialization time; `min_samples` validated to `>= 1`; invalid values produce a descriptive config error at startup (#2322)
 - fix(daemon): stale PID file from a crashed run no longer blocks startup — read and liveness-check the existing PID before writing; remove the file if the process is dead, error if the process is still alive (#2295)
 - fix(mcp): `prune_tools` `max_tools == 0` now means no cap on LLM-selected candidates (#2294)
 - fix(security): sanitize MCP tool descriptions and names before interpolating into the pruning prompt — strip control characters, cap description at 200 chars and name at 64 chars (#2297)

--- a/crates/zeph-config/src/sanitizer.rs
+++ b/crates/zeph-config/src/sanitizer.rs
@@ -21,11 +21,17 @@ pub struct EmbeddingGuardConfig {
     #[serde(default)]
     pub enabled: bool,
     /// Cosine distance threshold above which outputs are flagged as anomalous.
-    #[serde(default = "default_embedding_threshold")]
+    #[serde(
+        default = "default_embedding_threshold",
+        deserialize_with = "validate_embedding_threshold"
+    )]
     pub threshold: f64,
     /// Minimum clean samples before centroid-based detection activates.
     /// Before this count, regex fallback is used instead.
-    #[serde(default = "default_embedding_min_samples")]
+    #[serde(
+        default = "default_embedding_min_samples",
+        deserialize_with = "validate_min_samples"
+    )]
     pub min_samples: usize,
     /// EMA alpha floor for centroid updates after stabilization (n >= `min_samples`).
     ///
@@ -35,6 +41,37 @@ pub struct EmbeddingGuardConfig {
     /// changes. Default: 0.01 (1% per sample).
     #[serde(default = "default_ema_floor")]
     pub ema_floor: f32,
+}
+
+fn validate_embedding_threshold<'de, D>(deserializer: D) -> Result<f64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = <f64 as serde::Deserialize>::deserialize(deserializer)?;
+    if value.is_nan() || value.is_infinite() {
+        return Err(serde::de::Error::custom(
+            "embedding_guard.threshold must be a finite number",
+        ));
+    }
+    if !(value > 0.0 && value <= 1.0) {
+        return Err(serde::de::Error::custom(
+            "embedding_guard.threshold must be in (0.0, 1.0]",
+        ));
+    }
+    Ok(value)
+}
+
+fn validate_min_samples<'de, D>(deserializer: D) -> Result<usize, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = <usize as serde::Deserialize>::deserialize(deserializer)?;
+    if value == 0 {
+        return Err(serde::de::Error::custom(
+            "embedding_guard.min_samples must be >= 1",
+        ));
+    }
+    Ok(value)
 }
 
 fn default_embedding_threshold() -> f64 {
@@ -430,5 +467,52 @@ impl Default for ResponseVerificationConfig {
             block_on_detection: false,
             verifier_provider: String::new(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn de_guard(toml: &str) -> Result<EmbeddingGuardConfig, toml::de::Error> {
+        toml::from_str(toml)
+    }
+
+    #[test]
+    fn threshold_valid() {
+        let cfg = de_guard("threshold = 0.35\nmin_samples = 5").unwrap();
+        assert!((cfg.threshold - 0.35).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn threshold_one_valid() {
+        let cfg = de_guard("threshold = 1.0\nmin_samples = 1").unwrap();
+        assert!((cfg.threshold - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn threshold_zero_rejected() {
+        assert!(de_guard("threshold = 0.0\nmin_samples = 1").is_err());
+    }
+
+    #[test]
+    fn threshold_above_one_rejected() {
+        assert!(de_guard("threshold = 1.5\nmin_samples = 1").is_err());
+    }
+
+    #[test]
+    fn threshold_negative_rejected() {
+        assert!(de_guard("threshold = -0.1\nmin_samples = 1").is_err());
+    }
+
+    #[test]
+    fn min_samples_zero_rejected() {
+        assert!(de_guard("threshold = 0.35\nmin_samples = 0").is_err());
+    }
+
+    #[test]
+    fn min_samples_one_valid() {
+        let cfg = de_guard("threshold = 0.35\nmin_samples = 1").unwrap();
+        assert_eq!(cfg.min_samples, 1);
     }
 }

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -47,6 +47,7 @@ schemars.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_norway.workspace = true
+sqlx = { workspace = true, features = ["runtime-tokio-rustls", "sqlite"] }
 tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["fs", "macros", "rt-multi-thread", "sync", "time"] }

--- a/crates/zeph-core/src/bootstrap/mcp.rs
+++ b/crates/zeph-core/src/bootstrap/mcp.rs
@@ -4,6 +4,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use sqlx::SqlitePool;
 use tokio::sync::RwLock;
 use zeph_llm::any::AnyProvider;
 use zeph_memory::QdrantOps;
@@ -168,6 +169,40 @@ fn resolve_vault_ref(value: &str, vault: Option<&Arc<RwLock<AgeVaultProvider>>>)
     }
 
     result
+}
+
+/// Wire `TrustScoreStore` and `DefaultMcpProber` into an `McpManager` based on config.
+///
+/// When `config.mcp.trust_calibration.enabled` is `false` or `pool` is `None`, the manager
+/// is returned unchanged. On `TrustScoreStore::init` failure the error is logged and the
+/// manager is returned without trust wiring rather than propagating a hard failure.
+///
+/// # Errors (none propagated)
+///
+/// `TrustScoreStore::init` errors are logged as warnings and result in trust calibration
+/// being skipped for this startup.
+pub async fn wire_trust_calibration(
+    manager: zeph_mcp::McpManager,
+    config: &Config,
+    pool: Option<&SqlitePool>,
+) -> zeph_mcp::McpManager {
+    if !config.mcp.trust_calibration.enabled {
+        return manager;
+    }
+    let Some(pool) = pool else {
+        tracing::warn!("trust_calibration.enabled but no SQLite pool available — skipping");
+        return manager;
+    };
+    let store = zeph_mcp::TrustScoreStore::new(pool.clone() as sqlx::SqlitePool);
+    if let Err(e) = store.init().await {
+        tracing::warn!("TrustScoreStore init failed: {e:#} — trust calibration skipped");
+        return manager;
+    }
+    let mut manager = manager.with_trust_store(Arc::new(store));
+    if config.mcp.trust_calibration.probe_on_connect {
+        manager = manager.with_prober(zeph_mcp::DefaultMcpProber);
+    }
+    manager
 }
 
 pub async fn create_mcp_registry(

--- a/crates/zeph-core/src/bootstrap/mod.rs
+++ b/crates/zeph-core/src/bootstrap/mod.rs
@@ -12,7 +12,9 @@ pub mod skills;
 
 pub use config::{parse_vault_args, resolve_config_path};
 pub use health::{health_check, warmup_provider};
-pub use mcp::{create_mcp_manager, create_mcp_manager_with_vault, create_mcp_registry};
+pub use mcp::{
+    create_mcp_manager, create_mcp_manager_with_vault, create_mcp_registry, wire_trust_calibration,
+};
 pub use oauth::VaultCredentialStore;
 #[cfg(feature = "candle")]
 pub use provider::select_device;

--- a/crates/zeph-mcp/src/manager.rs
+++ b/crates/zeph-mcp/src/manager.rs
@@ -582,7 +582,7 @@ impl McpManager {
                         );
                         if let Some(ref store) = self.trust_store {
                             let _ = store
-                                .apply_delta(
+                                .load_and_apply_delta(
                                     &server_id,
                                     probe.score_delta,
                                     0,
@@ -737,7 +737,7 @@ impl McpManager {
             );
             if let Some(ref store) = self.trust_store {
                 let _ = store
-                    .apply_delta(&entry.id, probe.score_delta, 0, u64::from(probe.block))
+                    .load_and_apply_delta(&entry.id, probe.score_delta, 0, u64::from(probe.block))
                     .await;
             }
             if probe.block {

--- a/crates/zeph-mcp/src/trust_score.rs
+++ b/crates/zeph-mcp/src/trust_score.rs
@@ -213,6 +213,46 @@ impl TrustScoreStore {
         Ok(())
     }
 
+    /// Load the current score with decay applied, then write back the decayed-plus-delta value.
+    ///
+    /// Unlike [`apply_delta`], this method reads the stored score first, applies time-based
+    /// decay in-memory, and then upserts the corrected value. This prevents delta application
+    /// on a stale (pre-decay) score when a server has not been probed for an extended period.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the SQL query or execution fails.
+    pub async fn load_and_apply_delta(
+        &self,
+        server_id: &str,
+        score_delta: f64,
+        success_increment: u64,
+        failure_increment: u64,
+    ) -> Result<(), sqlx::Error> {
+        let current = self.load(server_id).await?;
+        let base_score = current.map_or(ServerTrustScore::INITIAL_SCORE, |s| s.score);
+        let new_score = (base_score + score_delta).clamp(0.0, 1.0);
+        let now = i64::try_from(unix_now()).unwrap_or(i64::MAX);
+        sqlx::query(
+            "INSERT INTO mcp_trust_scores
+                (server_id, score, success_count, failure_count, updated_at_secs)
+             VALUES (?, ?, ?, ?, ?)
+             ON CONFLICT(server_id) DO UPDATE SET
+                score           = excluded.score,
+                success_count   = success_count + excluded.success_count,
+                failure_count   = failure_count + excluded.failure_count,
+                updated_at_secs = excluded.updated_at_secs",
+        )
+        .bind(server_id)
+        .bind(new_score)
+        .bind(i64::try_from(success_increment).unwrap_or(i64::MAX))
+        .bind(i64::try_from(failure_increment).unwrap_or(i64::MAX))
+        .bind(now)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
     /// Load all server trust scores with decay applied for display accuracy.
     ///
     /// Decay is applied in-memory but NOT persisted. This is intentional: persisting
@@ -582,6 +622,61 @@ mod tests {
             (final_score.score - expected).abs() < 1e-6,
             "delta must be applied to decayed score: expected={expected}, got={}",
             final_score.score
+        );
+    }
+
+    #[tokio::test]
+    async fn load_and_apply_delta_new_entry() {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        let store = TrustScoreStore::new(pool);
+        store.init().await.unwrap();
+
+        store
+            .load_and_apply_delta("srv1", ServerTrustScore::SUCCESS_BOOST, 1, 0)
+            .await
+            .unwrap();
+
+        let score = store.load("srv1").await.unwrap().unwrap();
+        assert!(
+            score.score > ServerTrustScore::INITIAL_SCORE,
+            "new entry should start at INITIAL_SCORE + delta"
+        );
+        assert_eq!(score.success_count, 1);
+    }
+
+    #[tokio::test]
+    async fn load_and_apply_delta_applies_decay_before_delta() {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        let store = TrustScoreStore::new(pool);
+        store.init().await.unwrap();
+
+        // Insert a high score with an old timestamp (simulate 30 days ago).
+        let old_ts = unix_now().saturating_sub(30 * 86_400);
+        sqlx::query(
+            "INSERT INTO mcp_trust_scores (server_id, score, success_count, failure_count, updated_at_secs)
+             VALUES (?, 0.9, 0, 0, ?)",
+        )
+        .bind("srv1")
+        .bind(i64::try_from(old_ts).unwrap())
+        .execute(&store.pool)
+        .await
+        .unwrap();
+
+        // Delta = 0.0 — decay only.
+        store.load_and_apply_delta("srv1", 0.0, 0, 0).await.unwrap();
+
+        let score = store.load("srv1").await.unwrap().unwrap();
+        // After 30 days of decay (0.01/day) from 0.9, effective base ≈ 0.60.
+        // Written back score should be below 0.9.
+        assert!(
+            score.score < 0.9,
+            "score should have decayed from 0.9, got {}",
+            score.score
+        );
+        assert!(
+            score.score >= ServerTrustScore::INITIAL_SCORE,
+            "score should not decay below INITIAL_SCORE, got {}",
+            score.score
         );
     }
 }

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -291,13 +291,19 @@ async fn build_acp_deps(
             .map(PathBuf::from)
             .collect(),
     );
-    let mcp_manager = prebuilt_mcp_manager.unwrap_or_else(|| {
-        std::sync::Arc::new(zeph_core::bootstrap::create_mcp_manager_with_vault(
+    let mcp_manager = if let Some(m) = prebuilt_mcp_manager {
+        m
+    } else {
+        let builder =
+            zeph_core::bootstrap::create_mcp_manager_with_vault(config, false, app.age_vault_arc());
+        let builder = zeph_core::bootstrap::wire_trust_calibration(
+            builder,
             config,
-            false,
-            app.age_vault_arc(),
-        ))
-    });
+            Some(memory.sqlite().pool()),
+        )
+        .await;
+        std::sync::Arc::new(builder)
+    };
     let (mcp_tools, _mcp_outcomes) = mcp_manager.connect_all().await;
     let mcp_shared_tools = std::sync::Arc::new(std::sync::RwLock::new(mcp_tools.clone()));
     let mcp_executor =

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -301,6 +301,7 @@ pub(crate) async fn build_tool_setup(
     suppress_stderr: bool,
     age_vault: Option<&Arc<tokio::sync::RwLock<zeph_core::vault::AgeVaultProvider>>>,
     status_tx: Option<tokio::sync::mpsc::UnboundedSender<String>>,
+    pool: Option<&sqlx::SqlitePool>,
 ) -> ToolSetup {
     let filter_registry = if config.tools.filters.enabled {
         zeph_tools::OutputFilterRegistry::default_filters(&config.tools.filters)
@@ -341,6 +342,8 @@ pub(crate) async fn build_tool_setup(
     if let Some(tx) = status_tx {
         mcp_manager_builder = mcp_manager_builder.with_status_tx(tx);
     }
+    mcp_manager_builder =
+        zeph_core::bootstrap::wire_trust_calibration(mcp_manager_builder, config, pool).await;
     let mcp_manager = Arc::new(mcp_manager_builder);
     let (mcp_tools, mcp_outcomes) = mcp_manager.connect_all().await;
     tracing::info!("discovered {} MCP tool(s)", mcp_tools.len());

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -279,10 +279,16 @@ pub(crate) async fn run_daemon(
             .map(PathBuf::from)
             .collect(),
     );
-    let mcp_manager = std::sync::Arc::new(
+    let mcp_manager_builder =
         zeph_core::bootstrap::create_mcp_manager_with_vault(config, false, app.age_vault_arc())
-            .with_status_tx(status_tx),
-    );
+            .with_status_tx(status_tx);
+    let mcp_manager_builder = zeph_core::bootstrap::wire_trust_calibration(
+        mcp_manager_builder,
+        config,
+        Some(memory.sqlite().pool()),
+    )
+    .await;
+    let mcp_manager = std::sync::Arc::new(mcp_manager_builder);
     let (mcp_tools, _mcp_outcomes) = mcp_manager.connect_all().await;
     let mcp_shared_tools = std::sync::Arc::new(std::sync::RwLock::new(mcp_tools.clone()));
     let mcp_executor =

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -549,18 +549,17 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     #[cfg(not(feature = "tui"))]
     let suppress_mcp_stderr = false;
 
-    let (memory_result, tool_setup) = tokio::join!(
-        app.build_memory(&provider),
-        agent_setup::build_tool_setup(
-            config,
-            permission_policy.clone(),
-            with_tool_events,
-            suppress_mcp_stderr,
-            app.age_vault_arc(),
-            Some(agent_status_tx.clone()),
-        ),
-    );
-    let memory = std::sync::Arc::new(memory_result?);
+    let memory = std::sync::Arc::new(app.build_memory(&provider).await?);
+    let tool_setup = agent_setup::build_tool_setup(
+        config,
+        permission_policy.clone(),
+        with_tool_events,
+        suppress_mcp_stderr,
+        app.age_vault_arc(),
+        Some(agent_status_tx.clone()),
+        Some(memory.sqlite().pool()),
+    )
+    .await;
 
     let registry = std::sync::Arc::new(std::sync::RwLock::new(registry));
     let all_meta_owned: Vec<zeph_skills::loader::SkillMeta> = registry


### PR DESCRIPTION
## Summary

- Wire `DefaultMcpProber` and `TrustScoreStore` into agent bootstrap via `wire_trust_calibration()`; respects `trust_calibration.enabled` and `probe_on_connect` config flags (closes #2315)
- Add `TrustScoreStore::load_and_apply_delta()` to apply time-decay before writing score delta; replace raw `apply_delta()` at both `manager.rs` call sites (closes #2323)
- Add `validate_embedding_threshold` and `validate_min_samples` custom deserializers to `EmbeddingGuardConfig`; reject `threshold` outside `(0.0, 1.0]` and `min_samples == 0` (closes #2322)

`EmbeddingAnomalyGuard` bootstrap wiring is deferred — `McpManager` has no `with_embedding_guard()` API; a follow-up issue will be filed.

## Test plan

- [ ] `cargo +nightly fmt --check` — passes
- [ ] `cargo clippy --workspace -- -D warnings` — passes (0 warnings)
- [ ] `cargo nextest run --workspace --lib --bins` — 6396 passed, 15 skipped
- [ ] Config with `trust_calibration.enabled = true` and `probe_on_connect = true`: prober and trust store wired at connect
- [ ] Config with `embedding_guard.threshold = 0.0`: deserialization error returned
- [ ] Config with `embedding_guard.threshold = 1.5`: deserialization error returned