### PR TITLE
fix(telegram): split long streaming responses and reduce edit throttle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- fix(telegram): split messages exceeding 4096 bytes at UTF-8 boundaries in `send_or_edit()`; both the new-message (None) and edit-overflow (Some) branches now iterate `utf8_chunks()` output (#2345)
+- fix(telegram): reduce streaming throttle from 10s to 3s in `should_send_update()` to improve perceived response speed (#2341)
 - fix(core): `/reset` command now handled in `handle_builtin_command` as an alias for `/clear` with confirmation reply; previously fell through to LLM inference in all channels (#2339)
 - fix(telegram-e2e): reduce `scenario_long_output` prompt from 400 to 100 items and `first_timeout` from 90s to 60s to avoid LLM timeout under load (#2340)
 

--- a/crates/zeph-channels/src/any.rs
+++ b/crates/zeph-channels/src/any.rs
@@ -221,10 +221,10 @@ mod tests {
         );
     }
 
-    /// Exhaustive Channel method coverage for AnyChannel.
+    /// Exhaustive `Channel` method coverage for `AnyChannel`.
     ///
     /// When a new method is added to the Channel trait, it must be called here.
-    /// If a forwarding is missing in AnyChannel, this test serves as a manual checklist
+    /// If a forwarding is missing in `AnyChannel`, this test serves as a manual checklist
     /// to catch the gap during review.
     #[tokio::test]
     #[cfg(not(target_os = "windows"))]

--- a/crates/zeph-channels/src/telegram.rs
+++ b/crates/zeph-channels/src/telegram.rs
@@ -216,7 +216,7 @@ impl TelegramChannel {
     fn should_send_update(&self) -> bool {
         match self.last_edit {
             None => true,
-            Some(last) => last.elapsed() > Duration::from_secs(10),
+            Some(last) => last.elapsed() > Duration::from_secs(3),
         }
     }
 
@@ -243,14 +243,17 @@ impl TelegramChannel {
         match self.message_id {
             None => {
                 tracing::debug!("sending new message (length: {})", formatted_text.len());
-                let msg = self
-                    .bot
-                    .send_message(chat_id, formatted_text)
-                    .parse_mode(ParseMode::MarkdownV2)
-                    .await
-                    .map_err(ChannelError::other)?;
-                self.message_id = Some(msg.id);
-                tracing::debug!("new message sent with id: {:?}", msg.id);
+                let chunks = crate::markdown::utf8_chunks(&formatted_text, MAX_MESSAGE_LEN);
+                for chunk in chunks {
+                    let msg = self
+                        .bot
+                        .send_message(chat_id, chunk)
+                        .parse_mode(ParseMode::MarkdownV2)
+                        .await
+                        .map_err(ChannelError::other)?;
+                    self.message_id = Some(msg.id);
+                    tracing::debug!("new message sent with id: {:?}", msg.id);
+                }
             }
             Some(msg_id) => {
                 tracing::debug!(
@@ -258,39 +261,68 @@ impl TelegramChannel {
                     msg_id,
                     formatted_text.len()
                 );
-                let edit_result = self
-                    .bot
-                    .edit_message_text(chat_id, msg_id, &formatted_text)
-                    .parse_mode(ParseMode::MarkdownV2)
-                    .await;
+                if formatted_text.len() <= MAX_MESSAGE_LEN {
+                    let edit_result = self
+                        .bot
+                        .edit_message_text(chat_id, msg_id, &formatted_text)
+                        .parse_mode(ParseMode::MarkdownV2)
+                        .await;
 
-                if let Err(e) = edit_result {
-                    let error_msg = e.to_string();
+                    if let Err(e) = edit_result {
+                        let error_msg = e.to_string();
 
-                    if error_msg.contains("message is not modified") {
-                        // Text hasn't changed, just skip this update
-                        tracing::debug!("message content unchanged, skipping edit");
-                    } else if error_msg.contains("message to edit not found")
-                        || error_msg.contains("MESSAGE_ID_INVALID")
-                    {
-                        tracing::warn!(
-                            "Telegram edit failed (message_id stale?): {e}, sending new message"
-                        );
-                        self.message_id = None;
-                        self.last_edit = None;
+                        if error_msg.contains("message is not modified") {
+                            tracing::debug!("message content unchanged, skipping edit");
+                        } else if error_msg.contains("message to edit not found")
+                            || error_msg.contains("MESSAGE_ID_INVALID")
+                        {
+                            tracing::warn!(
+                                "Telegram edit failed (message_id stale?): {e}, sending new message"
+                            );
+                            self.message_id = None;
+                            self.last_edit = None;
 
+                            let msg = self
+                                .bot
+                                .send_message(chat_id, &formatted_text)
+                                .parse_mode(ParseMode::MarkdownV2)
+                                .await
+                                .map_err(ChannelError::other)?;
+                            self.message_id = Some(msg.id);
+                        } else {
+                            return Err(ChannelError::other(e));
+                        }
+                    } else {
+                        tracing::debug!("message edited successfully");
+                    }
+                } else {
+                    // Accumulated text exceeds limit: edit first chunk into existing message,
+                    // send remaining chunks as new messages.
+                    let chunks = crate::markdown::utf8_chunks(&formatted_text, MAX_MESSAGE_LEN);
+                    let mut iter = chunks.into_iter();
+                    if let Some(first) = iter.next() {
+                        let edit_result = self
+                            .bot
+                            .edit_message_text(chat_id, msg_id, first)
+                            .parse_mode(ParseMode::MarkdownV2)
+                            .await;
+                        if let Err(e) = edit_result {
+                            let error_msg = e.to_string();
+                            if !error_msg.contains("message is not modified") {
+                                tracing::warn!("Telegram edit failed during split: {e}");
+                            }
+                        }
+                    }
+                    for chunk in iter {
                         let msg = self
                             .bot
-                            .send_message(chat_id, &formatted_text)
+                            .send_message(chat_id, chunk)
                             .parse_mode(ParseMode::MarkdownV2)
                             .await
                             .map_err(ChannelError::other)?;
                         self.message_id = Some(msg.id);
-                    } else {
-                        return Err(ChannelError::other(e));
+                        tracing::debug!("overflow chunk sent with id: {:?}", msg.id);
                     }
-                } else {
-                    tracing::debug!("message edited successfully");
                 }
             }
         }
@@ -553,14 +585,18 @@ mod tests {
     fn should_send_update_time_threshold() {
         let mut channel = TelegramChannel::new("test_token".to_string(), Vec::new());
         channel.accumulated = "test".to_string();
-        channel.last_edit = Some(Instant::now().checked_sub(Duration::from_secs(11)).unwrap());
+        channel.last_edit = Some(Instant::now().checked_sub(Duration::from_secs(4)).unwrap());
         assert!(channel.should_send_update());
     }
 
     #[test]
     fn should_not_send_update_within_threshold() {
         let mut channel = TelegramChannel::new("test_token".to_string(), Vec::new());
-        channel.last_edit = Some(Instant::now().checked_sub(Duration::from_secs(1)).unwrap());
+        channel.last_edit = Some(
+            Instant::now()
+                .checked_sub(Duration::from_millis(500))
+                .unwrap(),
+        );
         assert!(!channel.should_send_update());
     }
 
@@ -571,9 +607,9 @@ mod tests {
 
     #[test]
     fn photo_size_limit_enforcement() {
-        assert!(MAX_IMAGE_BYTES - 1 <= MAX_IMAGE_BYTES);
-        assert!(MAX_IMAGE_BYTES <= MAX_IMAGE_BYTES);
-        assert!(MAX_IMAGE_BYTES + 1 > MAX_IMAGE_BYTES);
+        const { assert!(MAX_IMAGE_BYTES - 1 <= MAX_IMAGE_BYTES) };
+        const { assert!(MAX_IMAGE_BYTES <= MAX_IMAGE_BYTES) };
+        const { assert!(MAX_IMAGE_BYTES + 1 > MAX_IMAGE_BYTES) };
     }
 
     #[test]
@@ -744,5 +780,70 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(!result.text.trim().eq_ignore_ascii_case("yes"));
+    }
+
+    // ---------------------------------------------------------------------------
+    // send_or_edit() — split at MAX_MESSAGE_LEN
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn send_or_edit_splits_long_message_into_multiple_sends() {
+        let server = MockServer::start().await;
+        let (mut channel, _tx) = make_mocked_channel(&server, vec![]).await;
+
+        // Build text that exceeds MAX_MESSAGE_LEN after markdown_to_telegram pass.
+        // Plain ASCII repeated is safe: markdown_to_telegram won't expand it beyond itself.
+        let long_text = "a".repeat(MAX_MESSAGE_LEN + 1);
+        channel.accumulated = long_text;
+
+        channel.send_or_edit().await.unwrap();
+
+        // The mock server records every request; ≥2 sendMessage calls expected.
+        let requests = server.received_requests().await.unwrap();
+        assert!(
+            requests.len() >= 2,
+            "expected ≥2 API calls for oversized message, got {}",
+            requests.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn send_or_edit_single_message_when_within_limit() {
+        let server = MockServer::start().await;
+        let (mut channel, _tx) = make_mocked_channel(&server, vec![]).await;
+
+        channel.accumulated = "short text".to_string();
+
+        channel.send_or_edit().await.unwrap();
+
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(
+            requests.len(),
+            1,
+            "expected exactly 1 API call for short message"
+        );
+        // message_id must be recorded after a successful send
+        assert!(channel.message_id.is_some());
+    }
+
+    #[tokio::test]
+    async fn send_or_edit_splits_when_edit_overflows() {
+        let server = MockServer::start().await;
+        let (mut channel, _tx) = make_mocked_channel(&server, vec![]).await;
+
+        // Pre-set a message_id to trigger the edit branch.
+        channel.message_id = Some(teloxide::types::MessageId(42));
+        let long_text = "b".repeat(MAX_MESSAGE_LEN + 1);
+        channel.accumulated = long_text;
+
+        channel.send_or_edit().await.unwrap();
+
+        // Expect: 1 editMessageText call + ≥1 sendMessage call for overflow chunks.
+        let requests = server.received_requests().await.unwrap();
+        assert!(
+            requests.len() >= 2,
+            "expected edit + at least 1 overflow send, got {}",
+            requests.len()
+        );
     }
 }

--- a/scripts/telegram-e2e/telegram_e2e.py
+++ b/scripts/telegram-e2e/telegram_e2e.py
@@ -259,7 +259,7 @@ async def scenario_empty_msg(client: TelegramClient, bot: str) -> bool:
 async def scenario_long_output(client: TelegramClient, bot: str) -> bool:
     """A prompt that forces >4096 chars of output must split into ≥2 messages."""
     prompt = (
-        "Write a numbered list from 1 to 100, one item per line, in this exact format: "
+        "Write a numbered list from 1 to 150, one item per line, in this exact format: "
         "'N. This is item number N in the list.' "
         "Do not use any tools or shell commands — output the list directly. "
         "Output ONLY the list with no preamble and no trailing summary."


### PR DESCRIPTION
## Summary

- `send_or_edit()` now splits accumulated text at `MAX_MESSAGE_LEN` using `utf8_chunks()` in both the initial-send (None) and edit-overflow (Some) branches, matching the behavior of `send()`. Fixes Telegram API errors for streaming responses >4096 chars and unblocks the `long_output` E2E scenario.
- `should_send_update()` throttle reduced from 10s to 3s to improve streaming UX when the provider emits chunks at high frequency.
- `long_output` E2E item count increased 100→150 to reliably exceed 4096 chars post-MarkdownV2 escaping.

Closes #2345, #2341

## Test plan

- [ ] `cargo nextest run -p zeph-channels --lib` — 3 new tests for `send_or_edit()` split logic pass
- [ ] Full test suite passes (6985 tests)
- [ ] Telegram E2E: `long_output` scenario passes with ≥2 messages
- [ ] Telegram E2E: `streaming` scenario shows edit events with 3s throttle