### PR TITLE
feat(memory): MemScene consolidation, compress_context tool, A-MAC admission control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- feat(memory): A-MAC adaptive admission control — `AdmissionControl` in `zeph-memory::admission` evaluates 5 factors (future utility via LLM, factual confidence via hedging heuristics, semantic novelty via Qdrant top-3 cosine search, temporal recency fixed at 1.0 at write time, content-type prior by role) and rejects messages scoring below a configurable threshold; `remember()` now returns `Result<Option<MessageId>>` and `remember_with_parts()` returns `Result<(Option<MessageId>, bool)>` — `None` means admission rejected, no panic, no silent drop; `unsummarized_count` only incremented when a message is truly persisted; `[memory.admission]` config block added with `enabled`, `threshold`, `fast_path_margin`, `admission_provider`, and `weights` fields; runtime weight normalization eliminates the fragile sum-to-1.0 constraint; `memory_save` tool returns a human-readable rejection message when admission fails (#2317)
+- feat(memory): `MemScene` consolidation — `mem_scenes` and `mem_scene_members` SQLite tables (migration 049) store entity profiles derived from clusters of semantic-tier messages; `start_scene_consolidation_loop()` runs a background sweep on a configurable interval independent of tier promotion; greedy nearest-neighbor cosine clustering groups messages above `scene_similarity_threshold`; LLM generates a short label and 2–3 sentence profile per scene with JSON fallback; `[memory.tiers]` config gains `scene_enabled`, `scene_similarity_threshold`, `scene_batch_size`, `scene_provider` fields (#2332)
+- feat(core): `compress_context` native tool — always available when `context-compression` feature is enabled regardless of `CompressionStrategy`; compresses the current conversation (excluding pinned Knowledge and system messages) via LLM, appends the summary to the Knowledge block, and removes original messages from history; guarded by `Arc<AtomicBool>` concurrency lock in `FocusState` (`try_acquire_compression()` / `release_compression()`); blocked when a focus session is active; `CompressionStrategy::Autonomous` variant added; `compress_provider` field added to `CompressionConfig` (#2218)
+
 ### Fixed
 
 - fix(tools): write `AuditEntry` with `AuditResult::Blocked` when a pre-execution verifier blocks a tool call; previously the block was logged and metered but never recorded in the audit log (#2343)

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -53,9 +53,10 @@ pub use features::{
 pub use learning::{DetectorMode, LearningConfig};
 pub use logging::{LogRotation, LoggingConfig};
 pub use memory::{
-    CompressionConfig, CompressionStrategy, ContextStrategy, DigestConfig, DocumentConfig,
-    GraphConfig, MemoryConfig, NoteLinkingConfig, PruningStrategy, RoutingConfig, RoutingStrategy,
-    SemanticConfig, SessionsConfig, SidequestConfig, VectorBackend,
+    AdmissionConfig, AdmissionWeights, CompressionConfig, CompressionStrategy, ContextStrategy,
+    DigestConfig, DocumentConfig, GraphConfig, MemoryConfig, NoteLinkingConfig, PruningStrategy,
+    RoutingConfig, RoutingStrategy, SemanticConfig, SessionsConfig, SidequestConfig, TierConfig,
+    VectorBackend,
 };
 pub use providers::{
     CandleConfig, CandleInlineConfig, CascadeClassifierMode, CascadeConfig,

--- a/crates/zeph-config/src/memory.rs
+++ b/crates/zeph-config/src/memory.rs
@@ -275,6 +275,43 @@ fn default_tier_sweep_batch_size() -> usize {
     100
 }
 
+fn default_scene_similarity_threshold() -> f32 {
+    0.80
+}
+
+fn default_scene_batch_size() -> usize {
+    50
+}
+
+fn validate_scene_similarity_threshold<'de, D>(deserializer: D) -> Result<f32, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = <f32 as serde::Deserialize>::deserialize(deserializer)?;
+    if value.is_nan() || value.is_infinite() {
+        return Err(serde::de::Error::custom(
+            "scene_similarity_threshold must be a finite number",
+        ));
+    }
+    if !(0.5..=1.0).contains(&value) {
+        return Err(serde::de::Error::custom(
+            "scene_similarity_threshold must be in [0.5, 1.0]",
+        ));
+    }
+    Ok(value)
+}
+
+fn validate_scene_batch_size<'de, D>(deserializer: D) -> Result<usize, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = <usize as serde::Deserialize>::deserialize(deserializer)?;
+    if value == 0 {
+        return Err(serde::de::Error::custom("scene_batch_size must be >= 1"));
+    }
+    Ok(value)
+}
+
 /// Configuration for the AOI three-layer memory tier promotion system (`[memory.tiers]`).
 ///
 /// When `enabled = true`, a background sweep promotes frequently-accessed episodic messages
@@ -286,6 +323,8 @@ fn default_tier_sweep_batch_size() -> usize {
 /// - `similarity_threshold` in `[0.5, 1.0]`
 /// - `promotion_min_sessions >= 2`
 /// - `sweep_batch_size >= 1`
+/// - `scene_similarity_threshold` in `[0.5, 1.0]`
+/// - `scene_batch_size >= 1`
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 #[serde(default)]
 pub struct TierConfig {
@@ -305,6 +344,23 @@ pub struct TierConfig {
     /// Maximum number of messages to evaluate per sweep cycle. Must be `>= 1`. Default: `100`.
     #[serde(deserialize_with = "validate_tier_sweep_batch_size")]
     pub sweep_batch_size: usize,
+    /// Enable `MemScene` consolidation of semantic-tier messages. Default: `false`.
+    pub scene_enabled: bool,
+    /// Cosine similarity threshold for `MemScene` clustering. Must be in `[0.5, 1.0]`. Default: `0.80`.
+    #[serde(deserialize_with = "validate_scene_similarity_threshold")]
+    pub scene_similarity_threshold: f32,
+    /// Maximum unassigned semantic messages processed per scene consolidation sweep. Default: `50`.
+    #[serde(deserialize_with = "validate_scene_batch_size")]
+    pub scene_batch_size: usize,
+    /// Provider name from `[[llm.providers]]` for scene label/profile generation.
+    /// Falls back to the primary provider when empty. Default: `""`.
+    pub scene_provider: String,
+    /// How often the background scene consolidation sweep runs, in seconds. Default: `7200`.
+    pub scene_sweep_interval_secs: u64,
+}
+
+fn default_scene_sweep_interval_secs() -> u64 {
+    7200
 }
 
 impl Default for TierConfig {
@@ -315,6 +371,11 @@ impl Default for TierConfig {
             similarity_threshold: default_tier_similarity_threshold(),
             sweep_interval_secs: default_tier_sweep_interval_secs(),
             sweep_batch_size: default_tier_sweep_batch_size(),
+            scene_enabled: false,
+            scene_similarity_threshold: default_scene_similarity_threshold(),
+            scene_batch_size: default_scene_batch_size(),
+            scene_provider: String::new(),
+            scene_sweep_interval_secs: default_scene_sweep_interval_secs(),
         }
     }
 }
@@ -628,6 +689,12 @@ pub struct MemoryConfig {
     /// messages to a semantic tier by clustering near-duplicates and distilling via LLM.
     #[serde(default)]
     pub tiers: TierConfig,
+    /// A-MAC adaptive memory admission control.
+    ///
+    /// When `admission.enabled = true`, each message is evaluated before saving and rejected
+    /// if its composite admission score falls below the configured threshold.
+    #[serde(default)]
+    pub admission: AdmissionConfig,
     /// Session digest generation at session end. Default: disabled.
     #[serde(default)]
     pub digest: DigestConfig,
@@ -810,6 +877,9 @@ pub enum CompressionStrategy {
         /// Maximum tokens for the compressed summary (passed to LLM as `max_tokens`).
         max_summary_tokens: usize,
     },
+    /// Agent calls `compress_context` tool explicitly. Reactive compaction still fires as a
+    /// safety net. The `compress_context` tool is also available in all other strategies.
+    Autonomous,
 }
 
 /// Pruning strategy for tool-output eviction inside the compaction pipeline (#1851, #2022).
@@ -895,6 +965,9 @@ pub struct CompressionConfig {
     /// Currently unused — the primary summary provider is used regardless of this value.
     /// Reserved for future per-compression model selection. Setting this field has no effect.
     pub model: String,
+    /// Provider name from `[[llm.providers]]` for `compress_context` summaries.
+    /// Falls back to the primary provider when empty. Default: `""`.
+    pub compress_provider: String,
     /// Compaction probe: validates summary quality before committing it (#1609).
     #[serde(default)]
     pub probe: zeph_memory::CompactionProbeConfig,
@@ -1093,6 +1166,157 @@ where
     Ok(value)
 }
 
+fn validate_admission_threshold<'de, D>(deserializer: D) -> Result<f32, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = <f32 as serde::Deserialize>::deserialize(deserializer)?;
+    if value.is_nan() || value.is_infinite() {
+        return Err(serde::de::Error::custom(
+            "threshold must be a finite number",
+        ));
+    }
+    if !(0.0..=1.0).contains(&value) {
+        return Err(serde::de::Error::custom("threshold must be in [0.0, 1.0]"));
+    }
+    Ok(value)
+}
+
+fn validate_admission_fast_path_margin<'de, D>(deserializer: D) -> Result<f32, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = <f32 as serde::Deserialize>::deserialize(deserializer)?;
+    if value.is_nan() || value.is_infinite() {
+        return Err(serde::de::Error::custom(
+            "fast_path_margin must be a finite number",
+        ));
+    }
+    if !(0.0..=1.0).contains(&value) {
+        return Err(serde::de::Error::custom(
+            "fast_path_margin must be in [0.0, 1.0]",
+        ));
+    }
+    Ok(value)
+}
+
+fn default_admission_threshold() -> f32 {
+    0.40
+}
+
+fn default_admission_fast_path_margin() -> f32 {
+    0.15
+}
+
+fn validate_admission_weight<'de, D>(deserializer: D) -> Result<f32, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = <f32 as serde::Deserialize>::deserialize(deserializer)?;
+    if value < 0.0 {
+        return Err(serde::de::Error::custom(
+            "admission weight must be non-negative (>= 0.0)",
+        ));
+    }
+    Ok(value)
+}
+
+/// Per-factor weights for the A-MAC admission score (`[memory.admission.weights]`).
+///
+/// Weights are normalized at runtime (divided by their sum), so they do not need to sum to 1.0.
+/// All values must be non-negative.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct AdmissionWeights {
+    /// LLM-estimated future reuse probability. Default: `0.30`.
+    #[serde(deserialize_with = "validate_admission_weight")]
+    pub future_utility: f32,
+    /// Factual confidence heuristic (inverse of hedging markers). Default: `0.15`.
+    #[serde(deserialize_with = "validate_admission_weight")]
+    pub factual_confidence: f32,
+    /// Semantic novelty: 1 - max similarity to existing memories. Default: `0.30`.
+    #[serde(deserialize_with = "validate_admission_weight")]
+    pub semantic_novelty: f32,
+    /// Temporal recency: always 1.0 at write time. Default: `0.10`.
+    #[serde(deserialize_with = "validate_admission_weight")]
+    pub temporal_recency: f32,
+    /// Content type prior based on role. Default: `0.15`.
+    #[serde(deserialize_with = "validate_admission_weight")]
+    pub content_type_prior: f32,
+}
+
+impl Default for AdmissionWeights {
+    fn default() -> Self {
+        Self {
+            future_utility: 0.30,
+            factual_confidence: 0.15,
+            semantic_novelty: 0.30,
+            temporal_recency: 0.10,
+            content_type_prior: 0.15,
+        }
+    }
+}
+
+impl AdmissionWeights {
+    /// Return weights normalized so they sum to 1.0.
+    ///
+    /// All weights are non-negative; the sum is always > 0 when defaults are used.
+    #[must_use]
+    pub fn normalized(&self) -> Self {
+        let sum = self.future_utility
+            + self.factual_confidence
+            + self.semantic_novelty
+            + self.temporal_recency
+            + self.content_type_prior;
+        if sum <= f32::EPSILON {
+            return Self::default();
+        }
+        Self {
+            future_utility: self.future_utility / sum,
+            factual_confidence: self.factual_confidence / sum,
+            semantic_novelty: self.semantic_novelty / sum,
+            temporal_recency: self.temporal_recency / sum,
+            content_type_prior: self.content_type_prior / sum,
+        }
+    }
+}
+
+/// Configuration for A-MAC adaptive memory admission control (`[memory.admission]` TOML section).
+///
+/// When `enabled = true`, a write-time gate evaluates each message before saving to memory.
+/// Messages below the composite admission threshold are rejected and not persisted.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct AdmissionConfig {
+    /// Enable A-MAC admission control. Default: `false`.
+    pub enabled: bool,
+    /// Composite score threshold below which messages are rejected. Range: `[0.0, 1.0]`.
+    /// Default: `0.40`.
+    #[serde(deserialize_with = "validate_admission_threshold")]
+    pub threshold: f32,
+    /// Margin above threshold at which the fast path admits without an LLM call. Range: `[0.0, 1.0]`.
+    /// When heuristic score >= threshold + margin, LLM call is skipped. Default: `0.15`.
+    #[serde(deserialize_with = "validate_admission_fast_path_margin")]
+    pub fast_path_margin: f32,
+    /// Provider name from `[[llm.providers]]` for `future_utility` LLM evaluation.
+    /// Falls back to the primary provider when empty. Default: `""`.
+    pub admission_provider: String,
+    /// Per-factor weights. Normalized at runtime. Default: `{0.30, 0.15, 0.30, 0.10, 0.15}`.
+    pub weights: AdmissionWeights,
+}
+
+impl Default for AdmissionConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            threshold: default_admission_threshold(),
+            fast_path_margin: default_admission_fast_path_margin(),
+            admission_provider: String::new(),
+            weights: AdmissionWeights::default(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1222,5 +1446,73 @@ mod tests {
     fn importance_weight_rejects_greater_than_one() {
         let result = deserialize_importance_weight("1.01");
         assert!(result.is_err(), "value > 1.0 must be rejected");
+    }
+
+    // ── AdmissionWeights::normalized() tests (#2317) ────────────────────────
+
+    // Test: weights that don't sum to 1.0 are normalized to sum to 1.0.
+    #[test]
+    fn admission_weights_normalized_sums_to_one() {
+        let w = AdmissionWeights {
+            future_utility: 2.0,
+            factual_confidence: 1.0,
+            semantic_novelty: 3.0,
+            temporal_recency: 1.0,
+            content_type_prior: 3.0,
+        };
+        let n = w.normalized();
+        let sum = n.future_utility
+            + n.factual_confidence
+            + n.semantic_novelty
+            + n.temporal_recency
+            + n.content_type_prior;
+        assert!(
+            (sum - 1.0).abs() < 0.001,
+            "normalized weights must sum to 1.0, got {sum}"
+        );
+    }
+
+    // Test: already-normalized weights are preserved.
+    #[test]
+    fn admission_weights_normalized_preserves_already_unit_sum() {
+        let w = AdmissionWeights::default();
+        let n = w.normalized();
+        let sum = n.future_utility
+            + n.factual_confidence
+            + n.semantic_novelty
+            + n.temporal_recency
+            + n.content_type_prior;
+        assert!(
+            (sum - 1.0).abs() < 0.001,
+            "default weights sum to ~1.0 after normalization"
+        );
+    }
+
+    // Test: zero weights fall back to default (no divide-by-zero panic).
+    #[test]
+    fn admission_weights_normalized_zero_sum_falls_back_to_default() {
+        let w = AdmissionWeights {
+            future_utility: 0.0,
+            factual_confidence: 0.0,
+            semantic_novelty: 0.0,
+            temporal_recency: 0.0,
+            content_type_prior: 0.0,
+        };
+        let n = w.normalized();
+        let default = AdmissionWeights::default();
+        assert!(
+            (n.future_utility - default.future_utility).abs() < 0.001,
+            "zero-sum weights must fall back to defaults"
+        );
+    }
+
+    // Test: AdmissionConfig default values match documented defaults.
+    #[test]
+    fn admission_config_defaults() {
+        let cfg = AdmissionConfig::default();
+        assert!(!cfg.enabled);
+        assert!((cfg.threshold - 0.40).abs() < 0.001);
+        assert!((cfg.fast_path_margin - 0.15).abs() < 0.001);
+        assert!(cfg.admission_provider.is_empty());
     }
 }

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -198,6 +198,7 @@ impl Default for Config {
                 shutdown_summary_timeout_secs: 10,
                 structured_summaries: false,
                 tiers: TierConfig::default(),
+                admission: crate::memory::AdmissionConfig::default(),
                 digest: crate::memory::DigestConfig::default(),
                 context_strategy: crate::memory::ContextStrategy::default(),
                 crossover_turn_threshold: 20,

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1328,6 +1328,7 @@ mod tests {
             model: String::new(),
             pruning_strategy: crate::config::PruningStrategy::default(),
             probe: Default::default(),
+            compress_provider: String::new(),
         };
         let agent = make_agent().with_compression(compression);
         assert!(

--- a/crates/zeph-core/src/agent/focus.rs
+++ b/crates/zeph-core/src/agent/focus.rs
@@ -9,6 +9,10 @@
 //! removed from the conversation history.
 
 #[cfg(feature = "context-compression")]
+use std::sync::Arc;
+#[cfg(feature = "context-compression")]
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(feature = "context-compression")]
 use uuid::Uuid;
 #[cfg(feature = "context-compression")]
 use zeph_llm::provider::{Message, MessageMetadata, Role, ToolDefinition};
@@ -66,6 +70,29 @@ pub(crate) fn focus_tool_definitions() -> Vec<ToolDefinition> {
     ]
 }
 
+/// Build the tool definition for `compress_context` (#2218).
+///
+/// Always available when `context-compression` feature is enabled, regardless of compression
+/// strategy. The strategy controls automatic compression; this tool provides explicit control.
+#[cfg(feature = "context-compression")]
+pub(crate) fn compress_context_tool_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: "compress_context".into(),
+        description: "Compress the current conversation context. Summarizes conversation history \
+                      (excluding pinned Knowledge) into a compact summary, appends it to the \
+                      Knowledge block, and removes the original messages from context.\n\n\
+                      Use when the conversation is getting long and you want to free context space. \
+                      Cannot be called while a focus session is active or while another compression \
+                      is in progress.\n\nParameters: none.\nReturns: confirmation with token count."
+            .into(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {},
+            "required": []
+        }),
+    }
+}
+
 // Used by build_knowledge_message (context-compression feature).
 #[cfg_attr(not(feature = "context-compression"), allow(dead_code))]
 pub(crate) const KNOWLEDGE_BLOCK_PREFIX: &str = "[knowledge]\n";
@@ -87,6 +114,10 @@ pub(crate) struct FocusState {
     pub(crate) turns_since_focus: usize,
     /// Turns elapsed since the last reminder was injected.
     pub(crate) turns_since_reminder: usize,
+    /// Concurrency guard: `true` while `compress_context` is executing.
+    /// Prevents double compression and races with reactive compaction.
+    #[cfg(feature = "context-compression")]
+    pub(crate) compressing: Arc<AtomicBool>,
 }
 
 #[cfg_attr(not(feature = "context-compression"), allow(dead_code))]
@@ -100,7 +131,26 @@ impl FocusState {
             active_scope: None,
             turns_since_focus: 0,
             turns_since_reminder: 0,
+            #[cfg(feature = "context-compression")]
+            compressing: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    /// Try to acquire the compression lock.
+    ///
+    /// Returns `true` if acquired (caller must call `release_compression()` when done).
+    /// Returns `false` if another compression is already in progress.
+    #[cfg(feature = "context-compression")]
+    pub(crate) fn try_acquire_compression(&self) -> bool {
+        self.compressing
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
+            .is_ok()
+    }
+
+    /// Release the compression lock.
+    #[cfg(feature = "context-compression")]
+    pub(crate) fn release_compression(&self) {
+        self.compressing.store(false, Ordering::Release);
     }
 
     /// Returns `true` if a focus session is currently active.
@@ -335,5 +385,65 @@ mod tests {
         state.tick();
         assert_eq!(state.turns_since_focus, 2);
         assert_eq!(state.turns_since_reminder, 2);
+    }
+
+    // Test: concurrency guard prevents double-compression (#2218).
+    #[cfg(feature = "context-compression")]
+    #[test]
+    fn try_acquire_compression_prevents_double_call() {
+        let state = FocusState::new(FocusConfig::default());
+
+        // First acquire must succeed.
+        assert!(
+            state.try_acquire_compression(),
+            "first acquire must succeed"
+        );
+
+        // Second acquire must fail while first is held.
+        assert!(
+            !state.try_acquire_compression(),
+            "second acquire must fail while lock is held"
+        );
+
+        // After release, acquire must succeed again.
+        state.release_compression();
+        assert!(
+            state.try_acquire_compression(),
+            "acquire must succeed after release"
+        );
+        state.release_compression();
+    }
+
+    // Test: Knowledge block persists across compaction cycles (#2218).
+    // Verifies that knowledge accumulated before a compress_context call
+    // is preserved after another append_knowledge call.
+    #[test]
+    fn knowledge_block_persists_across_multiple_appends() {
+        let mut state = FocusState::new(FocusConfig::default());
+
+        state.append_knowledge("First compression summary.".to_string());
+        state.append_knowledge("Second compression summary.".to_string());
+
+        assert_eq!(
+            state.knowledge_blocks.len(),
+            2,
+            "both summaries must persist"
+        );
+        assert!(state.knowledge_blocks[0].contains("First"));
+        assert!(state.knowledge_blocks[1].contains("Second"));
+    }
+
+    // Test: Knowledge block message contains all summaries after multiple compressions.
+    #[cfg(feature = "context-compression")]
+    #[test]
+    fn knowledge_message_contains_all_summaries() {
+        let mut state = FocusState::new(FocusConfig::default());
+        state.append_knowledge("Summary A: learned about auth.".to_string());
+        state.append_knowledge("Summary B: learned about storage.".to_string());
+
+        let msg = state.build_knowledge_message().unwrap();
+        assert!(msg.content.contains("Summary A"));
+        assert!(msg.content.contains("Summary B"));
+        assert!(msg.metadata.focus_pinned, "knowledge block must be pinned");
     }
 }

--- a/crates/zeph-core/src/agent/persistence.rs
+++ b/crates/zeph-core/src/agent/persistence.rs
@@ -376,14 +376,18 @@ impl<C: Channel> Agent<C> {
             }
         };
 
-        let embedding_stored = if should_embed {
+        let (embedding_stored, was_persisted) = if should_embed {
             match memory
                 .remember_with_parts(cid, role_str(role), content, &parts_json)
                 .await
             {
-                Ok((message_id, stored)) => {
+                Ok((Some(message_id), stored)) => {
                     self.last_persisted_message_id = Some(message_id.0);
-                    stored
+                    (stored, true)
+                }
+                Ok((None, _)) => {
+                    // A-MAC admission rejected — skip increment and further processing.
+                    return;
                 }
                 Err(e) => {
                     tracing::error!("failed to persist message: {e:#}");
@@ -397,7 +401,7 @@ impl<C: Channel> Agent<C> {
             {
                 Ok(message_id) => {
                     self.last_persisted_message_id = Some(message_id.0);
-                    false
+                    (false, true)
                 }
                 Err(e) => {
                     tracing::error!("failed to persist message: {e:#}");
@@ -405,6 +409,10 @@ impl<C: Channel> Agent<C> {
                 }
             }
         };
+
+        if !was_persisted {
+            return;
+        }
 
         self.memory_state.unsummarized_count += 1;
 

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -92,6 +92,10 @@ impl<C: Channel> Agent<C> {
             tool_defs.extend(super::super::focus::focus_tool_definitions());
         }
 
+        // Inject compress_context tool — always available when context-compression is enabled (#2218).
+        #[cfg(feature = "context-compression")]
+        tool_defs.push(super::super::focus::compress_context_tool_definition());
+
         // Pre-compute the full tool set for iterations 1+ before filtering.
         let all_tool_defs = tool_defs.clone();
 
@@ -813,13 +817,21 @@ impl<C: Channel> Agent<C> {
         let mut tool_results: Vec<Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>> =
             (0..tool_calls.len()).map(|_| Ok(None)).collect();
 
-        // Pre-process focus tool calls (#1850). These need &mut self and cannot run inside the
-        // parallel tier futures. Pre-populate their results so the tier loop skips them.
+        // Pre-process focus tool calls (#1850) and compress_context (#2218).
+        // These need &mut self and cannot run inside the parallel tier futures.
+        // Pre-populate their results so the tier loop skips them.
         #[cfg(feature = "context-compression")]
-        if self.focus.config.enabled {
+        {
             for (idx, tc) in tool_calls.iter().enumerate() {
-                if tc.name == "start_focus" || tc.name == "complete_focus" {
-                    let result = self.handle_focus_tool(&tc.name, &tc.input);
+                let is_focus_tool = self.focus.config.enabled
+                    && (tc.name == "start_focus" || tc.name == "complete_focus");
+                let is_compress = tc.name == "compress_context";
+                if is_focus_tool || is_compress {
+                    let result = if is_compress {
+                        self.handle_compress_context().await
+                    } else {
+                        self.handle_focus_tool(&tc.name, &tc.input)
+                    };
                     tool_results[idx] = Ok(Some(zeph_tools::ToolOutput {
                         tool_name: tc.name.clone(),
                         summary: result,
@@ -901,10 +913,11 @@ impl<C: Channel> Agent<C> {
                 let tc = &tool_calls[idx];
                 let call = &calls[idx];
 
-                // Skip focus tools pre-handled above (they already have results).
+                // Skip focus tools and compress_context pre-handled above (they already have results).
                 #[cfg(feature = "context-compression")]
-                if self.focus.config.enabled
-                    && (tc.name == "start_focus" || tc.name == "complete_focus")
+                if tc.name == "compress_context"
+                    || (self.focus.config.enabled
+                        && (tc.name == "start_focus" || tc.name == "complete_focus"))
                 {
                     continue;
                 }
@@ -1781,6 +1794,167 @@ impl<C: Channel> Agent<C> {
 
             other => format!("[error] Unknown focus tool: {other}"),
         }
+    }
+
+    /// Handle the `compress_context` tool call (#2218).
+    ///
+    /// Summarizes non-pinned conversation history, appends to the Knowledge block, and removes
+    /// the compressed messages from context. Returns a string result to the LLM.
+    ///
+    /// Guards:
+    /// - Returns error if a focus session is active (would interfere with focus boundaries).
+    /// - Returns error if a compression is already in progress (concurrency guard).
+    #[cfg(feature = "context-compression")]
+    #[allow(clippy::too_many_lines)]
+    pub(crate) async fn handle_compress_context(&mut self) -> String {
+        use zeph_llm::provider::LlmProvider as _;
+
+        // Guard: no active focus session.
+        if self.focus.is_active() {
+            return "[error] Cannot compress context while a focus session is active. \
+                    Call complete_focus first."
+                .to_string();
+        }
+
+        // Guard: concurrency — no double compression.
+        if !self.focus.try_acquire_compression() {
+            return "[error] A context compression is already in progress.".to_string();
+        }
+
+        // Collect indices of non-pinned, non-system messages (candidates for compression),
+        // then select the head slice (excluding the preserve tail) as the removal set.
+        let preserve_tail = self.context_manager.compaction_preserve_tail;
+        let compressible_indices: Vec<usize> = self
+            .msg
+            .messages
+            .iter()
+            .enumerate()
+            .filter(|(_, m)| !m.metadata.focus_pinned && m.role != zeph_llm::provider::Role::System)
+            .map(|(i, _)| i)
+            .collect();
+
+        let total = compressible_indices.len();
+        if total <= preserve_tail + 3 {
+            self.focus.release_compression();
+            return format!(
+                "Not enough messages to compress (found {total}, need at least {}).",
+                preserve_tail + 4
+            );
+        }
+
+        let to_remove_indices: std::collections::HashSet<usize> = compressible_indices
+            [..total.saturating_sub(preserve_tail)]
+            .iter()
+            .copied()
+            .collect();
+
+        let to_compress: Vec<zeph_llm::provider::Message> = to_remove_indices
+            .iter()
+            .map(|&i| self.msg.messages[i].clone())
+            .collect();
+
+        // Build summary prompt from the messages to compress.
+        let role_label = |role: &zeph_llm::provider::Role| match role {
+            zeph_llm::provider::Role::User => "user",
+            zeph_llm::provider::Role::Assistant => "assistant",
+            zeph_llm::provider::Role::System => "system",
+        };
+        let bullet_list: String = to_compress
+            .iter()
+            .enumerate()
+            .map(|(i, m)| {
+                format!(
+                    "{}. [{}] {}",
+                    i + 1,
+                    role_label(&m.role),
+                    m.content.chars().take(500).collect::<String>()
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let system_content = "You are a context compression agent. \
+            Summarize the following conversation messages into a concise, information-dense summary. \
+            Preserve key facts, decisions, and context. Strip filler and small talk. \
+            Output ONLY the summary — no headers, no preamble.";
+
+        let summary_messages = vec![
+            zeph_llm::provider::Message {
+                role: zeph_llm::provider::Role::System,
+                content: system_content.to_owned(),
+                parts: vec![],
+                metadata: zeph_llm::provider::MessageMetadata::default(),
+            },
+            zeph_llm::provider::Message {
+                role: zeph_llm::provider::Role::User,
+                content: format!("Summarize these {total} conversation messages:\n\n{bullet_list}"),
+                parts: vec![],
+                metadata: zeph_llm::provider::MessageMetadata::default(),
+            },
+        ];
+
+        let summary = match tokio::time::timeout(
+            std::time::Duration::from_secs(30),
+            self.provider.chat(&summary_messages),
+        )
+        .await
+        {
+            Ok(Ok(s)) => s,
+            Ok(Err(e)) => {
+                self.focus.release_compression();
+                return format!("[error] Compression LLM call failed: {e}");
+            }
+            Err(_) => {
+                self.focus.release_compression();
+                return "[error] Compression LLM call timed out.".to_string();
+            }
+        };
+
+        if summary.trim().is_empty() {
+            self.focus.release_compression();
+            return "[error] Compression produced an empty summary.".to_string();
+        }
+
+        let tokens_freed = to_compress
+            .iter()
+            .map(|m| m.content.len() / 4)
+            .sum::<usize>();
+
+        // Append summary to Knowledge block.
+        self.focus.append_knowledge(summary.trim().to_owned());
+
+        // Remove compressed messages from in-memory history using their original indices.
+        // Index-based removal avoids false positives when two messages share identical content.
+        let mut remove_idx = to_remove_indices.iter().copied().collect::<Vec<_>>();
+        remove_idx.sort_unstable_by(|a, b| b.cmp(a)); // reverse order to preserve earlier indices
+        for idx in remove_idx {
+            if idx < self.msg.messages.len() {
+                self.msg.messages.remove(idx);
+            }
+        }
+
+        // Rebuild Knowledge block message.
+        self.msg
+            .messages
+            .retain(|m| !(m.metadata.focus_pinned && m.metadata.focus_marker_id.is_none()));
+        if let Some(kb_msg) = self.focus.build_knowledge_message() {
+            if self.msg.messages.is_empty() {
+                self.msg.messages.push(kb_msg);
+            } else {
+                self.msg.messages.insert(1, kb_msg);
+            }
+        }
+        self.recompute_prompt_tokens();
+        self.context_manager.compaction =
+            crate::agent::context_manager::CompactionState::CompactedThisTurn { cooldown: 0 };
+
+        self.focus.release_compression();
+
+        format!(
+            "Compressed {compressed_count} messages into a summary (~{tokens_freed} tokens freed). \
+             Knowledge block updated.",
+            compressed_count = to_compress.len()
+        )
     }
 
     /// Persist a tombstone `ToolResult` (`is_error=true`) for every tool call in `tool_calls`.

--- a/crates/zeph-core/src/bootstrap/mod.rs
+++ b/crates/zeph-core/src/bootstrap/mod.rs
@@ -305,7 +305,60 @@ impl AppBuilder {
             tracing::info!("graph memory enabled, GraphStore attached");
         }
 
+        if self.config.memory.admission.enabled {
+            memory = memory.with_admission_control(self.build_admission_control(provider));
+        }
+
         Ok(memory)
+    }
+
+    fn build_admission_control(
+        &self,
+        fallback_provider: &AnyProvider,
+    ) -> zeph_memory::AdmissionControl {
+        let admission_provider = if self.config.memory.admission.admission_provider.is_empty() {
+            fallback_provider.clone()
+        } else {
+            match create_named_provider(
+                &self.config.memory.admission.admission_provider,
+                &self.config,
+            ) {
+                Ok(p) => {
+                    tracing::info!(
+                        provider = %self.config.memory.admission.admission_provider,
+                        "A-MAC admission provider configured"
+                    );
+                    p
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        provider = %self.config.memory.admission.admission_provider,
+                        error = %e,
+                        "A-MAC admission provider resolution failed — primary provider will be used"
+                    );
+                    fallback_provider.clone()
+                }
+            }
+        };
+        let w = &self.config.memory.admission.weights;
+        let weights = zeph_memory::AdmissionWeights {
+            future_utility: w.future_utility,
+            factual_confidence: w.factual_confidence,
+            semantic_novelty: w.semantic_novelty,
+            temporal_recency: w.temporal_recency,
+            content_type_prior: w.content_type_prior,
+        };
+        let control = zeph_memory::AdmissionControl::new(
+            self.config.memory.admission.threshold,
+            self.config.memory.admission.fast_path_margin,
+            weights,
+        )
+        .with_provider(admission_provider);
+        tracing::info!(
+            threshold = self.config.memory.admission.threshold,
+            "A-MAC admission control enabled"
+        );
+        control
     }
 
     pub async fn build_skill_matcher(
@@ -761,6 +814,31 @@ impl AppBuilder {
                     eval_model = %model_spec,
                     error = %e,
                     "failed to create eval provider — primary provider will be used as judge"
+                );
+                None
+            }
+        }
+    }
+
+    /// Build a dedicated provider for `MemScene` label/profile LLM generation.
+    ///
+    /// Returns `None` when `tiers.scene_provider` is empty (caller falls back to primary provider).
+    /// Emits a `tracing::warn` on resolution failure; primary provider is used as fallback.
+    pub fn build_scene_provider(&self) -> Option<AnyProvider> {
+        let name = &self.config.memory.tiers.scene_provider;
+        if name.is_empty() {
+            return None;
+        }
+        match create_named_provider(name, &self.config) {
+            Ok(p) => {
+                tracing::info!(provider = %name, "scene consolidation provider configured");
+                Some(p)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    provider = %name,
+                    error = %e,
+                    "scene provider resolution failed — primary provider will be used"
                 );
                 None
             }

--- a/crates/zeph-core/src/memory_tools.rs
+++ b/crates/zeph-core/src/memory_tools.rs
@@ -188,18 +188,24 @@ impl ToolExecutor for MemoryToolExecutor {
 
                 let role = params.role.as_str();
 
-                let message_id = self
+                let message_id_opt = self
                     .memory
                     .remember(self.conversation_id, role, &params.content)
                     .await
                     .map_err(|e| ToolError::Execution(std::io::Error::other(e.to_string())))?;
 
-                Ok(Some(ToolOutput {
-                    tool_name: "memory_save".to_owned(),
-                    summary: format!(
+                let summary = match message_id_opt {
+                    Some(message_id) => format!(
                         "Saved to memory (message_id: {message_id}, conversation: {}). Content will be available for future recall.",
                         self.conversation_id
                     ),
+                    None => "Memory admission rejected: message did not meet quality threshold."
+                        .to_owned(),
+                };
+
+                Ok(Some(ToolOutput {
+                    tool_name: "memory_save".to_owned(),
+                    summary,
                     blocks_executed: 1,
                     filter_stats: None,
                     diff: None,

--- a/crates/zeph-memory/migrations/049_mem_scenes.sql
+++ b/crates/zeph-memory/migrations/049_mem_scenes.sql
@@ -1,0 +1,19 @@
+-- MemScene: groups of semantically related MemCells with a stable entity profile.
+-- Original MemCells are preserved (non-destructive); the scene adds a grouping layer.
+CREATE TABLE IF NOT EXISTS mem_scenes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    label TEXT NOT NULL,
+    profile TEXT NOT NULL,
+    member_count INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+-- Junction table linking messages to scenes (N:M — a message can belong to multiple scenes).
+CREATE TABLE IF NOT EXISTS mem_scene_members (
+    scene_id INTEGER NOT NULL REFERENCES mem_scenes(id) ON DELETE CASCADE,
+    message_id INTEGER NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    PRIMARY KEY (scene_id, message_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_mem_scene_members_msg ON mem_scene_members(message_id);

--- a/crates/zeph-memory/src/admission.rs
+++ b/crates/zeph-memory/src/admission.rs
@@ -1,0 +1,554 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! A-MAC adaptive memory admission control (#2317).
+//!
+//! Write-time gate inserted before `SQLite` persistence in `remember()` and `remember_with_parts()`.
+//! Evaluates 5 factors and rejects messages below the configured threshold.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use zeph_llm::any::AnyProvider;
+use zeph_llm::provider::LlmProvider as _;
+
+use crate::embedding_store::EmbeddingStore;
+
+/// Per-factor scores for the admission decision.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AdmissionFactors {
+    /// LLM-estimated reuse probability. `[0, 1]`. Set to 0.5 on fast path or LLM failure.
+    pub future_utility: f32,
+    /// Inverse hedging heuristic: high confidence → high score. `[0, 1]`.
+    pub factual_confidence: f32,
+    /// `1.0 - max_similarity_to_top3_neighbors`. `[0, 1]`. 1.0 when memory is empty.
+    pub semantic_novelty: f32,
+    /// Always `1.0` at write time (decay applied at recall). `[0, 1]`.
+    pub temporal_recency: f32,
+    /// Prior based on message role. `[0, 1]`.
+    pub content_type_prior: f32,
+}
+
+/// Result of an admission evaluation.
+#[derive(Debug, Clone)]
+pub struct AdmissionDecision {
+    pub admitted: bool,
+    pub composite_score: f32,
+    pub factors: AdmissionFactors,
+}
+
+/// Normalized weights for the composite score.
+#[derive(Debug, Clone, Copy)]
+pub struct AdmissionWeights {
+    pub future_utility: f32,
+    pub factual_confidence: f32,
+    pub semantic_novelty: f32,
+    pub temporal_recency: f32,
+    pub content_type_prior: f32,
+}
+
+impl AdmissionWeights {
+    /// Return a copy with all fields clamped to `>= 0.0` and normalized so they sum to `1.0`.
+    ///
+    /// Falls back to equal weights when the sum is effectively zero (all fields were zero/negative).
+    #[must_use]
+    pub fn normalized(&self) -> Self {
+        let fu = self.future_utility.max(0.0);
+        let fc = self.factual_confidence.max(0.0);
+        let sn = self.semantic_novelty.max(0.0);
+        let tr = self.temporal_recency.max(0.0);
+        let cp = self.content_type_prior.max(0.0);
+        let sum = fu + fc + sn + tr + cp;
+        if sum <= f32::EPSILON {
+            // Equal fallback weights.
+            return Self {
+                future_utility: 0.2,
+                factual_confidence: 0.2,
+                semantic_novelty: 0.2,
+                temporal_recency: 0.2,
+                content_type_prior: 0.2,
+            };
+        }
+        Self {
+            future_utility: fu / sum,
+            factual_confidence: fc / sum,
+            semantic_novelty: sn / sum,
+            temporal_recency: tr / sum,
+            content_type_prior: cp / sum,
+        }
+    }
+}
+
+/// A-MAC admission controller.
+pub struct AdmissionControl {
+    threshold: f32,
+    fast_path_margin: f32,
+    weights: AdmissionWeights,
+    /// Dedicated provider for LLM-based evaluation. Falls back to the caller-supplied provider
+    /// when `None` (e.g. in tests or when `admission_provider` is not configured).
+    provider: Option<AnyProvider>,
+}
+
+impl AdmissionControl {
+    #[must_use]
+    pub fn new(threshold: f32, fast_path_margin: f32, weights: AdmissionWeights) -> Self {
+        Self {
+            threshold,
+            fast_path_margin,
+            weights: weights.normalized(),
+            provider: None,
+        }
+    }
+
+    /// Attach a dedicated LLM provider for `future_utility` evaluation.
+    ///
+    /// When set, this provider is used instead of the caller-supplied fallback.
+    #[must_use]
+    pub fn with_provider(mut self, provider: AnyProvider) -> Self {
+        self.provider = Some(provider);
+        self
+    }
+
+    /// Return the configured admission threshold.
+    #[must_use]
+    pub fn threshold(&self) -> f32 {
+        self.threshold
+    }
+
+    /// Evaluate admission for a message.
+    ///
+    /// Fast path: skips LLM when heuristic-only score is already above `threshold + fast_path_margin`.
+    /// Slow path: calls LLM for `future_utility` when borderline.
+    ///
+    /// On LLM failure, `future_utility` defaults to `0.5` (neutral).
+    pub async fn evaluate(
+        &self,
+        content: &str,
+        role: &str,
+        fallback_provider: &AnyProvider,
+        qdrant: Option<&Arc<EmbeddingStore>>,
+    ) -> AdmissionDecision {
+        let effective_provider = self.provider.as_ref().unwrap_or(fallback_provider);
+        let factual_confidence = compute_factual_confidence(content);
+        let temporal_recency = 1.0f32;
+        let content_type_prior = compute_content_type_prior(role);
+
+        // Semantic novelty requires an async embedding search.
+        let semantic_novelty = compute_semantic_novelty(content, effective_provider, qdrant).await;
+
+        // Heuristic-only composite (future_utility treated as 0.5 neutral placeholder).
+        let heuristic_score = self.weighted_score(
+            0.5,
+            factual_confidence,
+            semantic_novelty,
+            temporal_recency,
+            content_type_prior,
+        );
+
+        // Fast path: admit without LLM if score is clearly above threshold + margin.
+        let future_utility = if heuristic_score >= self.threshold + self.fast_path_margin {
+            0.5 // not used in final score since we admit early, but kept for audit
+        } else {
+            compute_future_utility(content, role, effective_provider).await
+        };
+
+        let composite_score = self.weighted_score(
+            future_utility,
+            factual_confidence,
+            semantic_novelty,
+            temporal_recency,
+            content_type_prior,
+        );
+
+        let admitted = composite_score >= self.threshold
+            || heuristic_score >= self.threshold + self.fast_path_margin;
+
+        AdmissionDecision {
+            admitted,
+            composite_score,
+            factors: AdmissionFactors {
+                future_utility,
+                factual_confidence,
+                semantic_novelty,
+                temporal_recency,
+                content_type_prior,
+            },
+        }
+    }
+
+    fn weighted_score(
+        &self,
+        future_utility: f32,
+        factual_confidence: f32,
+        semantic_novelty: f32,
+        temporal_recency: f32,
+        content_type_prior: f32,
+    ) -> f32 {
+        future_utility * self.weights.future_utility
+            + factual_confidence * self.weights.factual_confidence
+            + semantic_novelty * self.weights.semantic_novelty
+            + temporal_recency * self.weights.temporal_recency
+            + content_type_prior * self.weights.content_type_prior
+    }
+}
+
+/// Heuristic: detect hedging markers and compute confidence score.
+///
+/// Returns `1.0` for confident content, lower for content with hedging language.
+#[must_use]
+pub fn compute_factual_confidence(content: &str) -> f32 {
+    // Common English hedging markers. Content in other languages scores 1.0 (no penalty).
+    const HEDGING_MARKERS: &[&str] = &[
+        "maybe",
+        "might",
+        "perhaps",
+        "i think",
+        "i believe",
+        "not sure",
+        "could be",
+        "possibly",
+        "probably",
+        "uncertain",
+        "not certain",
+        "i'm not sure",
+        "im not sure",
+        "not confident",
+    ];
+    let lower = content.to_lowercase();
+    let matches = HEDGING_MARKERS
+        .iter()
+        .filter(|&&m| lower.contains(m))
+        .count();
+    // Each hedging marker reduces confidence by 0.1, min 0.2.
+    #[allow(clippy::cast_precision_loss)]
+    let penalty = (matches as f32) * 0.1;
+    (1.0 - penalty).max(0.2)
+}
+
+/// Prior score based on message role.
+///
+/// Tool results (role "tool") are treated as high-value since they contain factual data.
+/// The table is not symmetric to role importance — it's calibrated by typical content density.
+#[must_use]
+pub fn compute_content_type_prior(role: &str) -> f32 {
+    match role {
+        "user" => 0.7,
+        "assistant" => 0.6,
+        "tool" | "tool_result" => 0.8,
+        "system" => 0.3,
+        _ => 0.5,
+    }
+}
+
+/// Compute semantic novelty as `1.0 - max_cosine_similarity_to_top3_neighbors`.
+///
+/// Returns `1.0` when the memory is empty (everything is novel at cold start).
+async fn compute_semantic_novelty(
+    content: &str,
+    provider: &AnyProvider,
+    qdrant: Option<&Arc<EmbeddingStore>>,
+) -> f32 {
+    let Some(store) = qdrant else {
+        return 1.0;
+    };
+    if !provider.supports_embeddings() {
+        return 1.0;
+    }
+    let vector = match provider.embed(content).await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::debug!(error = %e, "A-MAC: failed to embed for novelty, using 1.0");
+            return 1.0;
+        }
+    };
+    let Ok(vector_size) = u64::try_from(vector.len()) else {
+        return 1.0;
+    };
+    if let Err(e) = store.ensure_collection(vector_size).await {
+        tracing::debug!(error = %e, "A-MAC: collection not ready for novelty check");
+        return 1.0;
+    }
+    let results = match store.search(&vector, 3, None).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::debug!(error = %e, "A-MAC: novelty search failed, using 1.0");
+            return 1.0;
+        }
+    };
+    let max_sim = results.iter().map(|r| r.score).fold(0.0f32, f32::max);
+    (1.0 - max_sim).max(0.0)
+}
+
+/// LLM-based future utility estimate.
+///
+/// On timeout or error, returns `0.5` (neutral — no bias toward admit or reject).
+async fn compute_future_utility(content: &str, role: &str, provider: &AnyProvider) -> f32 {
+    use zeph_llm::provider::{Message, MessageMetadata, Role};
+
+    let system = "You are a memory relevance judge. Rate how likely this message will be \
+        referenced in future conversations on a scale of 0.0 to 1.0. \
+        Respond with ONLY a decimal number between 0.0 and 1.0, nothing else.";
+
+    let user = format!(
+        "Role: {role}\nContent: {}\n\nFuture utility score (0.0-1.0):",
+        content.chars().take(500).collect::<String>()
+    );
+
+    let messages = vec![
+        Message {
+            role: Role::System,
+            content: system.to_owned(),
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        },
+        Message {
+            role: Role::User,
+            content: user,
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        },
+    ];
+
+    let result = match tokio::time::timeout(Duration::from_secs(8), provider.chat(&messages)).await
+    {
+        Ok(Ok(r)) => r,
+        Ok(Err(e)) => {
+            tracing::debug!(error = %e, "A-MAC: future_utility LLM call failed, using 0.5");
+            return 0.5;
+        }
+        Err(_) => {
+            tracing::debug!("A-MAC: future_utility LLM timed out, using 0.5");
+            return 0.5;
+        }
+    };
+
+    result.trim().parse::<f32>().unwrap_or(0.5).clamp(0.0, 1.0)
+}
+
+/// Log an admission decision to the audit log via `tracing`.
+///
+/// Rejections are always logged at debug level. Admissions are trace-level.
+pub fn log_admission_decision(
+    decision: &AdmissionDecision,
+    content_preview: &str,
+    role: &str,
+    threshold: f32,
+) {
+    if decision.admitted {
+        tracing::trace!(
+            role,
+            composite_score = decision.composite_score,
+            threshold,
+            content_preview,
+            "A-MAC: admitted"
+        );
+    } else {
+        tracing::debug!(
+            role,
+            composite_score = decision.composite_score,
+            threshold,
+            future_utility = decision.factors.future_utility,
+            factual_confidence = decision.factors.factual_confidence,
+            semantic_novelty = decision.factors.semantic_novelty,
+            content_type_prior = decision.factors.content_type_prior,
+            content_preview,
+            "A-MAC: rejected"
+        );
+    }
+}
+
+/// Error type for admission-rejected persists.
+#[derive(Debug)]
+pub struct AdmissionRejected {
+    pub composite_score: f32,
+    pub threshold: f32,
+}
+
+impl std::fmt::Display for AdmissionRejected {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "A-MAC admission rejected (score={:.3} < threshold={:.3})",
+            self.composite_score, self.threshold
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn factual_confidence_no_hedging() {
+        assert!((compute_factual_confidence("The server uses TLS 1.3.") - 1.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn factual_confidence_with_one_marker() {
+        let score = compute_factual_confidence("Maybe we should use TLS 1.3.");
+        assert!((score - 0.9).abs() < 0.01);
+    }
+
+    #[test]
+    fn factual_confidence_many_markers_floors_at_0_2() {
+        let content = "maybe i think perhaps possibly might not sure i believe";
+        let score = compute_factual_confidence(content);
+        assert!(score >= 0.2);
+        assert!(score < 0.5);
+    }
+
+    #[test]
+    fn content_type_prior_values() {
+        assert!((compute_content_type_prior("user") - 0.7).abs() < 0.01);
+        assert!((compute_content_type_prior("assistant") - 0.6).abs() < 0.01);
+        assert!((compute_content_type_prior("tool") - 0.8).abs() < 0.01);
+        assert!((compute_content_type_prior("system") - 0.3).abs() < 0.01);
+        assert!((compute_content_type_prior("unknown") - 0.5).abs() < 0.01);
+    }
+
+    #[test]
+    fn admission_control_admits_high_score() {
+        let weights = AdmissionWeights {
+            future_utility: 0.30,
+            factual_confidence: 0.15,
+            semantic_novelty: 0.30,
+            temporal_recency: 0.10,
+            content_type_prior: 0.15,
+        };
+        let ctrl = AdmissionControl::new(0.40, 0.15, weights);
+        // Score all factors at 1.0 → composite = 1.0.
+        let score = ctrl.weighted_score(1.0, 1.0, 1.0, 1.0, 1.0);
+        assert!(score >= 0.99);
+        // Admitted when score >= threshold.
+        let admitted = score >= ctrl.threshold;
+        assert!(admitted);
+    }
+
+    #[test]
+    fn admission_control_rejects_low_score() {
+        let weights = AdmissionWeights {
+            future_utility: 0.30,
+            factual_confidence: 0.15,
+            semantic_novelty: 0.30,
+            temporal_recency: 0.10,
+            content_type_prior: 0.15,
+        };
+        let ctrl = AdmissionControl::new(0.40, 0.15, weights);
+        // Score all factors at 0.0 → composite = 0.0.
+        let score = ctrl.weighted_score(0.0, 0.0, 0.0, 0.0, 0.0);
+        assert!(score < ctrl.threshold);
+    }
+
+    // Test: fast-path score above threshold + margin bypasses slow-path (LLM call skipped).
+    // We verify the branch logic in weighted_score: if heuristic >= threshold + margin, admitted.
+    #[test]
+    fn fast_path_admits_when_heuristic_above_threshold_plus_margin() {
+        let weights = AdmissionWeights {
+            future_utility: 0.20,
+            factual_confidence: 0.20,
+            semantic_novelty: 0.20,
+            temporal_recency: 0.20,
+            content_type_prior: 0.20,
+        };
+        let threshold = 0.40f32;
+        let margin = 0.15f32;
+        let ctrl = AdmissionControl::new(threshold, margin, weights);
+
+        // All non-future_utility factors at 1.0; future_utility treated as 0.5 (fast path neutral).
+        let heuristic = ctrl.weighted_score(0.5, 1.0, 1.0, 1.0, 1.0);
+        // heuristic = 0.5*0.2 + 1.0*0.2 + 1.0*0.2 + 1.0*0.2 + 1.0*0.2 = 0.1 + 0.8 = 0.9
+        assert!(
+            heuristic >= threshold + margin,
+            "heuristic {heuristic} must exceed threshold+margin {}",
+            threshold + margin
+        );
+        // In evaluate(), admitted = composite >= threshold || heuristic >= threshold + margin.
+        let admitted = heuristic >= threshold + margin;
+        assert!(admitted, "fast path must admit without LLM call");
+    }
+
+    // Test: slow-path engages when heuristic is below threshold + margin.
+    #[test]
+    fn slow_path_required_when_heuristic_below_threshold_plus_margin() {
+        let weights = AdmissionWeights {
+            future_utility: 0.40,
+            factual_confidence: 0.15,
+            semantic_novelty: 0.15,
+            temporal_recency: 0.15,
+            content_type_prior: 0.15,
+        };
+        let threshold = 0.50f32;
+        let margin = 0.20f32;
+        let ctrl = AdmissionControl::new(threshold, margin, weights);
+
+        // All factors low — heuristic will be below threshold + margin.
+        let heuristic = ctrl.weighted_score(0.5, 0.3, 0.3, 0.3, 0.3);
+        assert!(
+            heuristic < threshold + margin,
+            "heuristic {heuristic} must be below threshold+margin {}",
+            threshold + margin
+        );
+    }
+
+    // Test: log_admission_decision runs without panic for both admitted and rejected.
+    #[test]
+    fn log_admission_decision_does_not_panic() {
+        let admitted_decision = AdmissionDecision {
+            admitted: true,
+            composite_score: 0.75,
+            factors: AdmissionFactors {
+                future_utility: 0.8,
+                factual_confidence: 0.9,
+                semantic_novelty: 0.7,
+                temporal_recency: 1.0,
+                content_type_prior: 0.7,
+            },
+        };
+        log_admission_decision(&admitted_decision, "preview text", "user", 0.40);
+
+        let rejected_decision = AdmissionDecision {
+            admitted: false,
+            composite_score: 0.20,
+            factors: AdmissionFactors {
+                future_utility: 0.1,
+                factual_confidence: 0.2,
+                semantic_novelty: 0.3,
+                temporal_recency: 1.0,
+                content_type_prior: 0.3,
+            },
+        };
+        log_admission_decision(&rejected_decision, "maybe short content", "assistant", 0.40);
+    }
+
+    // Test: AdmissionRejected Display formats correctly.
+    #[test]
+    fn admission_rejected_display() {
+        let err = AdmissionRejected {
+            composite_score: 0.25,
+            threshold: 0.45,
+        };
+        let msg = format!("{err}");
+        assert!(msg.contains("0.250"));
+        assert!(msg.contains("0.450"));
+    }
+
+    // Test: threshold() accessor returns the configured value.
+    #[test]
+    fn threshold_accessor() {
+        let weights = AdmissionWeights {
+            future_utility: 0.20,
+            factual_confidence: 0.20,
+            semantic_novelty: 0.20,
+            temporal_recency: 0.20,
+            content_type_prior: 0.20,
+        };
+        let ctrl = AdmissionControl::new(0.55, 0.10, weights);
+        assert!((ctrl.threshold() - 0.55).abs() < 0.001);
+    }
+
+    // Test: content_type_prior for "tool_result" alias.
+    #[test]
+    fn content_type_prior_tool_result_alias() {
+        assert!((compute_content_type_prior("tool_result") - 0.8).abs() < 0.01);
+    }
+}

--- a/crates/zeph-memory/src/lib.rs
+++ b/crates/zeph-memory/src/lib.rs
@@ -3,10 +3,12 @@
 
 //! SQLite-backed conversation persistence with Qdrant vector search.
 
+pub mod admission;
 pub mod anchored_summary;
 pub mod compaction_probe;
 pub mod compression_guidelines;
 pub mod document;
+pub mod scenes;
 pub mod tiers;
 
 pub mod embedding_registry;
@@ -28,6 +30,10 @@ pub mod token_counter;
 pub mod types;
 pub mod vector_store;
 
+pub use admission::{
+    AdmissionControl, AdmissionDecision, AdmissionFactors, AdmissionRejected, AdmissionWeights,
+    compute_content_type_prior, compute_factual_confidence, log_admission_decision,
+};
 pub use anchored_summary::AnchoredSummary;
 pub use compaction_probe::{
     CategoryScore, CompactionProbeConfig, CompactionProbeResult, ProbeCategory, ProbeQuestion,
@@ -60,6 +66,9 @@ pub use router::{
     HeuristicRouter, MemoryRoute, MemoryRouter, TemporalRange, classify_graph_subgraph,
     strip_temporal_keywords,
 };
+pub use scenes::{
+    MemScene, SceneConfig, consolidate_scenes, list_scenes, start_scene_consolidation_loop,
+};
 pub use semantic::{
     ExtractionResult, ExtractionStats, GraphExtractionConfig, LinkingStats, NoteLinkingConfig,
     StructuredSummary, build_summarization_prompt, extract_and_store, link_memory_notes,
@@ -74,8 +83,7 @@ pub use sqlite::session_digest::SessionDigest;
 pub use tiers::{TierPromotionConfig, start_tier_promotion_loop};
 pub use token_counter::TokenCounter;
 pub use tokio_util::sync::CancellationToken;
-pub use types::MemoryTier;
-pub use types::{ConversationId, MessageId};
+pub use types::{ConversationId, MemSceneId, MemoryTier, MessageId};
 pub use vector_store::{
     FieldCondition, FieldValue, ScoredVectorPoint, VectorFilter, VectorPoint, VectorStore,
     VectorStoreError,

--- a/crates/zeph-memory/src/scenes.rs
+++ b/crates/zeph-memory/src/scenes.rs
@@ -1,0 +1,343 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `MemScene` consolidation (#2332).
+//!
+//! Groups semantically related semantic-tier messages into stable entity profiles (scenes).
+//! Runs as a separate background loop, decoupled from tier promotion timing.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use zeph_llm::any::AnyProvider;
+use zeph_llm::provider::LlmProvider as _;
+
+use crate::error::MemoryError;
+use crate::math::cosine_similarity;
+use crate::sqlite::SqliteStore;
+use crate::types::{MemSceneId, MessageId};
+
+/// A `MemScene` groups semantically related semantic-tier messages with a stable entity profile.
+#[derive(Debug, Clone)]
+pub struct MemScene {
+    pub id: MemSceneId,
+    pub label: String,
+    pub profile: String,
+    pub member_count: u32,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+/// Configuration for scene consolidation.
+#[derive(Debug, Clone)]
+pub struct SceneConfig {
+    pub enabled: bool,
+    pub similarity_threshold: f32,
+    pub batch_size: usize,
+    pub sweep_interval_secs: u64,
+}
+
+/// Start the background scene consolidation loop.
+///
+/// Each sweep clusters unassigned semantic-tier messages into `MemScenes`.
+/// Runs independently from the tier promotion loop.
+pub fn start_scene_consolidation_loop(
+    store: Arc<SqliteStore>,
+    provider: AnyProvider,
+    config: SceneConfig,
+    cancel: CancellationToken,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        if !config.enabled {
+            tracing::debug!("scene consolidation disabled (tiers.scene_enabled = false)");
+            return;
+        }
+
+        let mut ticker = tokio::time::interval(Duration::from_secs(config.sweep_interval_secs));
+        // Skip first tick to avoid running immediately at startup.
+        ticker.tick().await;
+
+        loop {
+            tokio::select! {
+                () = cancel.cancelled() => {
+                    tracing::debug!("scene consolidation loop shutting down");
+                    return;
+                }
+                _ = ticker.tick() => {}
+            }
+
+            tracing::debug!("scene consolidation: starting sweep");
+            let start = std::time::Instant::now();
+
+            match consolidate_scenes(&store, &provider, &config).await {
+                Ok(stats) => {
+                    tracing::info!(
+                        candidates = stats.candidates,
+                        scenes_created = stats.scenes_created,
+                        messages_assigned = stats.messages_assigned,
+                        elapsed_ms = start.elapsed().as_millis(),
+                        "scene consolidation: sweep complete"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        elapsed_ms = start.elapsed().as_millis(),
+                        "scene consolidation: sweep failed, will retry"
+                    );
+                }
+            }
+        }
+    })
+}
+
+/// Stats collected during a single scene consolidation sweep.
+#[derive(Debug, Default)]
+pub struct SceneStats {
+    pub candidates: usize,
+    pub scenes_created: usize,
+    pub messages_assigned: usize,
+}
+
+/// Execute one full scene consolidation sweep.
+///
+/// # Errors
+///
+/// Returns an error if the `SQLite` query fails. LLM and embedding errors are logged but skipped.
+pub async fn consolidate_scenes(
+    store: &SqliteStore,
+    provider: &AnyProvider,
+    config: &SceneConfig,
+) -> Result<SceneStats, MemoryError> {
+    let candidates = store
+        .find_unscened_semantic_messages(config.batch_size)
+        .await?;
+
+    if candidates.len() < 2 {
+        return Ok(SceneStats::default());
+    }
+
+    let mut stats = SceneStats {
+        candidates: candidates.len(),
+        ..SceneStats::default()
+    };
+
+    // Embed all candidates.
+    let mut embedded: Vec<(MessageId, String, Vec<f32>)> = Vec::with_capacity(candidates.len());
+    if provider.supports_embeddings() {
+        for (msg_id, content) in candidates {
+            match provider.embed(&content).await {
+                Ok(vec) => embedded.push((msg_id, content, vec)),
+                Err(e) => {
+                    tracing::warn!(
+                        message_id = msg_id.0,
+                        error = %e,
+                        "scene consolidation: failed to embed candidate, skipping"
+                    );
+                }
+            }
+        }
+    } else {
+        return Ok(stats);
+    }
+
+    if embedded.len() < 2 {
+        return Ok(stats);
+    }
+
+    // Cluster by cosine similarity.
+    let clusters = cluster_messages(embedded, config.similarity_threshold);
+
+    for cluster in clusters {
+        if cluster.len() < 2 {
+            continue;
+        }
+
+        let contents: Vec<&str> = cluster.iter().map(|(_, c, _)| c.as_str()).collect();
+        let msg_ids: Vec<MessageId> = cluster.iter().map(|(id, _, _)| *id).collect();
+
+        match generate_scene_label_and_profile(provider, &contents).await {
+            Ok((label, profile)) => {
+                let label = label.chars().take(100).collect::<String>();
+                let profile = profile.chars().take(2000).collect::<String>();
+                match store.insert_mem_scene(&label, &profile, &msg_ids).await {
+                    Ok(_scene_id) => {
+                        stats.scenes_created += 1;
+                        stats.messages_assigned += msg_ids.len();
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            cluster_size = msg_ids.len(),
+                            "scene consolidation: failed to insert scene"
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    cluster_size = msg_ids.len(),
+                    "scene consolidation: LLM label generation failed, skipping cluster"
+                );
+            }
+        }
+    }
+
+    Ok(stats)
+}
+
+fn cluster_messages(
+    candidates: Vec<(MessageId, String, Vec<f32>)>,
+    threshold: f32,
+) -> Vec<Vec<(MessageId, String, Vec<f32>)>> {
+    let mut clusters: Vec<Vec<(MessageId, String, Vec<f32>)>> = Vec::new();
+
+    'outer: for candidate in candidates {
+        for cluster in &mut clusters {
+            let rep = &cluster[0].2;
+            if cosine_similarity(&candidate.2, rep) >= threshold {
+                cluster.push(candidate);
+                continue 'outer;
+            }
+        }
+        clusters.push(vec![candidate]);
+    }
+
+    clusters
+}
+
+async fn generate_scene_label_and_profile(
+    provider: &AnyProvider,
+    contents: &[&str],
+) -> Result<(String, String), MemoryError> {
+    use zeph_llm::provider::{Message, MessageMetadata, Role};
+
+    let bullet_list: String = contents
+        .iter()
+        .enumerate()
+        .map(|(i, c)| format!("{}. {c}", i + 1))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let system_content = "You are a memory scene architect. \
+        Given a set of related semantic facts, generate:\n\
+        1. A short label (5 words max) identifying the core entity or topic.\n\
+        2. A 2-3 sentence entity profile summarizing the key facts.\n\
+        Respond in JSON: {\"label\": \"...\", \"profile\": \"...\"}";
+
+    let user_content =
+        format!("Generate a label and profile for these related facts:\n\n{bullet_list}");
+
+    let messages = vec![
+        Message {
+            role: Role::System,
+            content: system_content.to_owned(),
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        },
+        Message {
+            role: Role::User,
+            content: user_content,
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        },
+    ];
+
+    let result = tokio::time::timeout(Duration::from_secs(15), provider.chat(&messages))
+        .await
+        .map_err(|_| MemoryError::Other("scene LLM call timed out after 15s".into()))?
+        .map_err(MemoryError::Llm)?;
+
+    parse_label_profile(&result)
+}
+
+fn parse_label_profile(response: &str) -> Result<(String, String), MemoryError> {
+    // Try JSON parsing first.
+    if let Ok(val) = serde_json::from_str::<serde_json::Value>(response) {
+        let label = val
+            .get("label")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim()
+            .to_owned();
+        let profile = val
+            .get("profile")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim()
+            .to_owned();
+        if !label.is_empty() && !profile.is_empty() {
+            return Ok((label, profile));
+        }
+    }
+    // Fallback: treat first line as label, rest as profile.
+    let trimmed = response.trim();
+    let mut lines = trimmed.splitn(2, '\n');
+    let label = lines.next().unwrap_or("").trim().to_owned();
+    let profile = lines.next().unwrap_or(trimmed).trim().to_owned();
+    if label.is_empty() {
+        return Err(MemoryError::Other("scene LLM returned empty label".into()));
+    }
+    let profile = if profile.is_empty() {
+        label.clone()
+    } else {
+        profile
+    };
+    Ok((label, profile))
+}
+
+/// List all `MemScenes` from the store.
+///
+/// # Errors
+///
+/// Returns an error if the `SQLite` query fails.
+pub async fn list_scenes(store: &SqliteStore) -> Result<Vec<MemScene>, MemoryError> {
+    store.list_mem_scenes().await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cluster_messages_groups_similar() {
+        let v1 = vec![1.0f32, 0.0, 0.0];
+        let v2 = vec![1.0f32, 0.0, 0.0];
+        let v3 = vec![0.0f32, 1.0, 0.0];
+
+        let candidates = vec![
+            (MessageId(1), "a".to_owned(), v1),
+            (MessageId(2), "b".to_owned(), v2),
+            (MessageId(3), "c".to_owned(), v3),
+        ];
+
+        let clusters = cluster_messages(candidates, 0.80);
+        assert_eq!(clusters.len(), 2);
+        assert_eq!(clusters[0].len(), 2);
+        assert_eq!(clusters[1].len(), 1);
+    }
+
+    #[test]
+    fn parse_label_profile_valid_json() {
+        let json = r#"{"label": "Rust Auth JWT", "profile": "The project uses JWT for auth."}"#;
+        let (label, profile) = parse_label_profile(json).unwrap();
+        assert_eq!(label, "Rust Auth JWT");
+        assert_eq!(profile, "The project uses JWT for auth.");
+    }
+
+    #[test]
+    fn parse_label_profile_fallback_lines() {
+        let text = "Rust Auth\nJWT tokens used for authentication. Rate limited at 100 rps.";
+        let (label, profile) = parse_label_profile(text).unwrap();
+        assert_eq!(label, "Rust Auth");
+        assert!(profile.contains("JWT"));
+    }
+
+    #[test]
+    fn parse_label_profile_empty_fails() {
+        assert!(parse_label_profile("").is_err());
+    }
+}

--- a/crates/zeph-memory/src/semantic/mod.rs
+++ b/crates/zeph-memory/src/semantic/mod.rs
@@ -17,6 +17,7 @@ use std::sync::atomic::AtomicU64;
 
 use zeph_llm::any::AnyProvider;
 
+use crate::admission::AdmissionControl;
 use crate::embedding_store::EmbeddingStore;
 use crate::error::MemoryError;
 use crate::sqlite::SqliteStore;
@@ -56,6 +57,8 @@ pub struct SemanticMemory {
     pub(crate) community_detection_failures: Arc<AtomicU64>,
     pub(crate) graph_extraction_count: Arc<AtomicU64>,
     pub(crate) graph_extraction_failures: Arc<AtomicU64>,
+    /// A-MAC admission control gate. When `Some`, each `remember()` call is evaluated.
+    pub(crate) admission_control: Option<Arc<AdmissionControl>>,
 }
 
 impl SemanticMemory {
@@ -153,6 +156,7 @@ impl SemanticMemory {
             community_detection_failures: Arc::new(AtomicU64::new(0)),
             graph_extraction_count: Arc::new(AtomicU64::new(0)),
             graph_extraction_failures: Arc::new(AtomicU64::new(0)),
+            admission_control: None,
         })
     }
 
@@ -196,6 +200,7 @@ impl SemanticMemory {
             community_detection_failures: Arc::new(AtomicU64::new(0)),
             graph_extraction_count: Arc::new(AtomicU64::new(0)),
             graph_extraction_failures: Arc::new(AtomicU64::new(0)),
+            admission_control: None,
         })
     }
 
@@ -263,6 +268,16 @@ impl SemanticMemory {
         self
     }
 
+    /// Attach an A-MAC admission controller.
+    ///
+    /// When set, `remember()` and `remember_with_parts()` evaluate each message before persisting.
+    /// Messages below the admission threshold return `Ok(None)` without incrementing counts.
+    #[must_use]
+    pub fn with_admission_control(mut self, control: AdmissionControl) -> Self {
+        self.admission_control = Some(Arc::new(control));
+        self
+    }
+
     /// Construct a `SemanticMemory` from pre-built parts.
     ///
     /// Intended for tests that need full control over the backing stores.
@@ -295,6 +310,7 @@ impl SemanticMemory {
             community_detection_failures: Arc::new(AtomicU64::new(0)),
             graph_extraction_count: Arc::new(AtomicU64::new(0)),
             graph_extraction_failures: Arc::new(AtomicU64::new(0)),
+            admission_control: None,
         }
     }
 
@@ -357,6 +373,7 @@ impl SemanticMemory {
             community_detection_failures: Arc::new(AtomicU64::new(0)),
             graph_extraction_count: Arc::new(AtomicU64::new(0)),
             graph_extraction_failures: Arc::new(AtomicU64::new(0)),
+            admission_control: None,
         })
     }
 

--- a/crates/zeph-memory/src/semantic/recall.rs
+++ b/crates/zeph-memory/src/semantic/recall.rs
@@ -3,6 +3,7 @@
 
 use zeph_llm::provider::{LlmProvider as _, Message};
 
+use crate::admission::log_admission_decision;
 use crate::embedding_store::{MessageKind, SearchFilter};
 use crate::error::MemoryError;
 use crate::types::{ConversationId, MessageId};
@@ -19,7 +20,8 @@ pub struct RecalledMessage {
 impl SemanticMemory {
     /// Save a message to `SQLite` and optionally embed and store in Qdrant.
     ///
-    /// Returns the message ID assigned by `SQLite`.
+    /// Returns `Ok(Some(message_id))` when admitted and persisted.
+    /// Returns `Ok(None)` when A-MAC admission control rejects the message (not an error).
     ///
     /// # Errors
     ///
@@ -30,7 +32,19 @@ impl SemanticMemory {
         conversation_id: ConversationId,
         role: &str,
         content: &str,
-    ) -> Result<MessageId, MemoryError> {
+    ) -> Result<Option<MessageId>, MemoryError> {
+        // A-MAC admission gate.
+        if let Some(ref admission) = self.admission_control {
+            let decision = admission
+                .evaluate(content, role, &self.provider, self.qdrant.as_ref())
+                .await;
+            let preview: String = content.chars().take(100).collect();
+            log_admission_decision(&decision, &preview, role, admission.threshold());
+            if !decision.admitted {
+                return Ok(None);
+            }
+        }
+
         let message_id = self
             .sqlite
             .save_message(conversation_id, role, content)
@@ -64,13 +78,13 @@ impl SemanticMemory {
             }
         }
 
-        Ok(message_id)
+        Ok(Some(message_id))
     }
 
     /// Save a message with pre-serialized parts JSON to `SQLite` and optionally embed in Qdrant.
     ///
-    /// Returns `(message_id, embedding_stored)` tuple where `embedding_stored` is `true` if
-    /// an embedding was successfully generated and stored in Qdrant.
+    /// Returns `Ok((Some(message_id), embedding_stored))` when admitted and persisted.
+    /// Returns `Ok((None, false))` when A-MAC admission control rejects the message.
     ///
     /// # Errors
     ///
@@ -81,7 +95,19 @@ impl SemanticMemory {
         role: &str,
         content: &str,
         parts_json: &str,
-    ) -> Result<(MessageId, bool), MemoryError> {
+    ) -> Result<(Option<MessageId>, bool), MemoryError> {
+        // A-MAC admission gate.
+        if let Some(ref admission) = self.admission_control {
+            let decision = admission
+                .evaluate(content, role, &self.provider, self.qdrant.as_ref())
+                .await;
+            let preview: String = content.chars().take(100).collect();
+            log_admission_decision(&decision, &preview, role, admission.threshold());
+            if !decision.admitted {
+                return Ok((None, false));
+            }
+        }
+
         let message_id = self
             .sqlite
             .save_message_with_parts(conversation_id, role, content, parts_json)
@@ -119,7 +145,7 @@ impl SemanticMemory {
             }
         }
 
-        Ok((message_id, embedding_stored))
+        Ok((Some(message_id), embedding_stored))
     }
 
     /// Save a message to `SQLite` without generating an embedding.

--- a/crates/zeph-memory/src/semantic/tests/graph.rs
+++ b/crates/zeph-memory/src/semantic/tests/graph.rs
@@ -323,6 +323,7 @@ async fn memory_with_in_memory_vector_store() -> (
         graph_extraction_count: Arc::new(AtomicU64::new(0)),
         graph_extraction_failures: Arc::new(AtomicU64::new(0)),
         tier_boost_semantic: 1.3,
+        admission_control: None,
     };
 
     (memory, embedding_store)

--- a/crates/zeph-memory/src/semantic/tests/mod.rs
+++ b/crates/zeph-memory/src/semantic/tests/mod.rs
@@ -46,6 +46,7 @@ pub(super) async fn test_semantic_memory(_supports_embeddings: bool) -> Semantic
         graph_extraction_count: Arc::new(AtomicU64::new(0)),
         graph_extraction_failures: Arc::new(AtomicU64::new(0)),
         tier_boost_semantic: 1.3,
+        admission_control: None,
     }
 }
 
@@ -66,7 +67,11 @@ async fn remember_saves_to_sqlite() {
     let memory = test_semantic_memory(false).await;
 
     let cid = memory.sqlite.create_conversation().await.unwrap();
-    let msg_id = memory.remember(cid, "user", "hello").await.unwrap();
+    let msg_id = memory
+        .remember(cid, "user", "hello")
+        .await
+        .unwrap()
+        .unwrap();
 
     assert_eq!(msg_id, MessageId(1));
 
@@ -83,10 +88,11 @@ async fn remember_with_parts_saves_parts_json() {
 
     let parts_json =
         r#"[{"kind":"ToolOutput","tool_name":"shell","body":"hello","compacted_at":null}]"#;
-    let (msg_id, _embedding_stored) = memory
+    let (msg_id_opt, _embedding_stored) = memory
         .remember_with_parts(cid, "assistant", "tool output", parts_json)
         .await
         .unwrap();
+    let msg_id = msg_id_opt.unwrap();
     assert!(msg_id > MessageId(0));
 
     let history = memory.sqlite.load_history(cid, 50).await.unwrap();
@@ -168,8 +174,12 @@ async fn message_count_after_saves() {
     let memory = test_semantic_memory(false).await;
     let cid = memory.sqlite().create_conversation().await.unwrap();
 
-    memory.remember(cid, "user", "msg1").await.unwrap();
-    memory.remember(cid, "assistant", "msg2").await.unwrap();
+    memory.remember(cid, "user", "msg1").await.unwrap().unwrap();
+    memory
+        .remember(cid, "assistant", "msg2")
+        .await
+        .unwrap()
+        .unwrap();
 
     let count = memory.message_count(cid).await.unwrap();
     assert_eq!(count, 2);
@@ -180,9 +190,21 @@ async fn remember_multiple_messages_increments_ids() {
     let memory = test_semantic_memory(false).await;
     let cid = memory.sqlite.create_conversation().await.unwrap();
 
-    let id1 = memory.remember(cid, "user", "first").await.unwrap();
-    let id2 = memory.remember(cid, "assistant", "second").await.unwrap();
-    let id3 = memory.remember(cid, "user", "third").await.unwrap();
+    let id1 = memory
+        .remember(cid, "user", "first")
+        .await
+        .unwrap()
+        .unwrap();
+    let id2 = memory
+        .remember(cid, "assistant", "second")
+        .await
+        .unwrap()
+        .unwrap();
+    let id3 = memory
+        .remember(cid, "user", "third")
+        .await
+        .unwrap()
+        .unwrap();
 
     assert!(id1 < id2);
     assert!(id2 < id3);
@@ -194,9 +216,21 @@ async fn message_count_across_conversations() {
     let cid1 = memory.sqlite().create_conversation().await.unwrap();
     let cid2 = memory.sqlite().create_conversation().await.unwrap();
 
-    memory.remember(cid1, "user", "msg1").await.unwrap();
-    memory.remember(cid1, "user", "msg2").await.unwrap();
-    memory.remember(cid2, "user", "msg3").await.unwrap();
+    memory
+        .remember(cid1, "user", "msg1")
+        .await
+        .unwrap()
+        .unwrap();
+    memory
+        .remember(cid1, "user", "msg2")
+        .await
+        .unwrap()
+        .unwrap();
+    memory
+        .remember(cid2, "user", "msg3")
+        .await
+        .unwrap()
+        .unwrap();
 
     assert_eq!(memory.message_count(cid1).await.unwrap(), 2);
     assert_eq!(memory.message_count(cid2).await.unwrap(), 1);
@@ -210,10 +244,10 @@ async fn message_count_multiple_conversations_isolated() {
     let cid3 = memory.sqlite().create_conversation().await.unwrap();
 
     for _ in 0..5 {
-        memory.remember(cid1, "user", "msg").await.unwrap();
+        memory.remember(cid1, "user", "msg").await.unwrap().unwrap();
     }
     for _ in 0..3 {
-        memory.remember(cid2, "user", "msg").await.unwrap();
+        memory.remember(cid2, "user", "msg").await.unwrap().unwrap();
     }
 
     assert_eq!(memory.message_count(cid1).await.unwrap(), 5);
@@ -226,7 +260,11 @@ async fn remember_with_embeddings_supported_but_no_qdrant() {
     let memory = test_semantic_memory(true).await;
     let cid = memory.sqlite.create_conversation().await.unwrap();
 
-    let msg_id = memory.remember(cid, "user", "hello embed").await.unwrap();
+    let msg_id = memory
+        .remember(cid, "user", "hello embed")
+        .await
+        .unwrap()
+        .unwrap();
     assert!(msg_id > MessageId(0));
 
     let history = memory.sqlite.load_history(cid, 50).await.unwrap();
@@ -239,9 +277,21 @@ async fn remember_verifies_content_via_load_history() {
     let memory = test_semantic_memory(false).await;
     let cid = memory.sqlite.create_conversation().await.unwrap();
 
-    memory.remember(cid, "user", "alpha").await.unwrap();
-    memory.remember(cid, "assistant", "beta").await.unwrap();
-    memory.remember(cid, "user", "gamma").await.unwrap();
+    memory
+        .remember(cid, "user", "alpha")
+        .await
+        .unwrap()
+        .unwrap();
+    memory
+        .remember(cid, "assistant", "beta")
+        .await
+        .unwrap()
+        .unwrap();
+    memory
+        .remember(cid, "user", "gamma")
+        .await
+        .unwrap()
+        .unwrap();
 
     let history = memory.sqlite().load_history(cid, 50).await.unwrap();
     assert_eq!(history.len(), 3);
@@ -255,9 +305,13 @@ async fn remember_preserves_role_mapping() {
     let memory = test_semantic_memory(false).await;
     let cid = memory.sqlite.create_conversation().await.unwrap();
 
-    memory.remember(cid, "user", "u").await.unwrap();
-    memory.remember(cid, "assistant", "a").await.unwrap();
-    memory.remember(cid, "system", "s").await.unwrap();
+    memory.remember(cid, "user", "u").await.unwrap().unwrap();
+    memory
+        .remember(cid, "assistant", "a")
+        .await
+        .unwrap()
+        .unwrap();
+    memory.remember(cid, "system", "s").await.unwrap().unwrap();
 
     let history = memory.sqlite.load_history(cid, 50).await.unwrap();
     assert_eq!(history.len(), 3);
@@ -280,7 +334,7 @@ async fn new_with_invalid_qdrant_url_graceful() {
 async fn has_embedding_returns_false_when_no_qdrant() {
     let memory = test_semantic_memory(false).await;
     let cid = memory.sqlite.create_conversation().await.unwrap();
-    let msg_id = memory.remember(cid, "user", "test").await.unwrap();
+    let msg_id = memory.remember(cid, "user", "test").await.unwrap().unwrap();
     assert!(!memory.has_embedding(msg_id).await.unwrap());
 }
 
@@ -394,6 +448,7 @@ async fn store_correction_embedding_sqlite_clean_db_roundtrip() {
         graph_extraction_count: Arc::new(AtomicU64::new(0)),
         graph_extraction_failures: Arc::new(AtomicU64::new(0)),
         tier_boost_semantic: 1.3,
+        admission_control: None,
     };
 
     memory

--- a/crates/zeph-memory/src/semantic/tests/recall.rs
+++ b/crates/zeph-memory/src/semantic/tests/recall.rs
@@ -63,6 +63,7 @@ async fn test_semantic_memory_sqlite_remember_recall_roundtrip() {
         graph_extraction_count: Arc::new(AtomicU64::new(0)),
         graph_extraction_failures: Arc::new(AtomicU64::new(0)),
         tier_boost_semantic: 1.3,
+        admission_control: None,
     };
 
     let cid = memory.sqlite().create_conversation().await.unwrap();
@@ -142,7 +143,11 @@ async fn recall_fts5_fallback_with_filter() {
     let cid1 = memory.sqlite.create_conversation().await.unwrap();
     let cid2 = memory.sqlite.create_conversation().await.unwrap();
 
-    memory.remember(cid1, "user", "hello world").await.unwrap();
+    memory
+        .remember(cid1, "user", "hello world")
+        .await
+        .unwrap()
+        .unwrap();
     memory
         .remember(cid2, "user", "hello universe")
         .await
@@ -161,7 +166,11 @@ async fn recall_fts5_no_matches_returns_empty() {
     let memory = test_semantic_memory(false).await;
     let cid = memory.sqlite.create_conversation().await.unwrap();
 
-    memory.remember(cid, "user", "hello world").await.unwrap();
+    memory
+        .remember(cid, "user", "hello world")
+        .await
+        .unwrap()
+        .unwrap();
 
     let recalled = memory.recall("nonexistent", 5, None).await.unwrap();
     assert!(recalled.is_empty());
@@ -370,7 +379,11 @@ async fn recall_importance_enabled_blends_score() {
         .remember(cid, "user", "remember: the API key rotates weekly")
         .await
         .unwrap();
-    memory.remember(cid, "user", "API key info").await.unwrap();
+    memory
+        .remember(cid, "user", "API key info")
+        .await
+        .unwrap()
+        .unwrap();
 
     let recalled = memory.recall("API key", 5, None).await.unwrap();
     assert!(
@@ -401,7 +414,11 @@ async fn recall_importance_disabled_no_blending() {
         .remember(cid, "user", "remember: the API key rotates weekly")
         .await
         .unwrap();
-    memory.remember(cid, "user", "API key info").await.unwrap();
+    memory
+        .remember(cid, "user", "API key info")
+        .await
+        .unwrap()
+        .unwrap();
 
     let recalled = memory.recall("API key", 5, None).await.unwrap();
     // Must return results without panicking.
@@ -459,4 +476,109 @@ fn recalled_message_debug() {
     let dbg = format!("{recalled:?}");
     assert!(dbg.contains("RecalledMessage"));
     assert!(dbg.contains("0.95"));
+}
+
+// ── A-MAC admission control integration tests (#2317) ────────────────────────
+
+fn make_always_reject_admission() -> crate::admission::AdmissionControl {
+    // Threshold of 1.1 → no message can ever score above it → always rejected.
+    let weights = crate::admission::AdmissionWeights {
+        future_utility: 0.20,
+        factual_confidence: 0.20,
+        semantic_novelty: 0.20,
+        temporal_recency: 0.20,
+        content_type_prior: 0.20,
+    };
+    crate::admission::AdmissionControl::new(1.1, 0.0, weights)
+}
+
+fn make_always_admit_admission() -> crate::admission::AdmissionControl {
+    // Threshold of 0.0 → every message is admitted.
+    let weights = crate::admission::AdmissionWeights {
+        future_utility: 0.20,
+        factual_confidence: 0.20,
+        semantic_novelty: 0.20,
+        temporal_recency: 0.20,
+        content_type_prior: 0.20,
+    };
+    crate::admission::AdmissionControl::new(0.0, 0.0, weights)
+}
+
+#[tokio::test]
+async fn remember_returns_none_when_admission_rejects() {
+    let memory = test_semantic_memory(false)
+        .await
+        .with_admission_control(make_always_reject_admission());
+
+    let cid = memory.sqlite.create_conversation().await.unwrap();
+    let result = memory
+        .remember(cid, "user", "this message will be rejected")
+        .await
+        .unwrap();
+    assert!(
+        result.is_none(),
+        "remember() must return None when A-MAC rejects"
+    );
+
+    // SQLite must have no messages (rejected = not persisted).
+    let history = memory.sqlite.load_history(cid, 50).await.unwrap();
+    assert!(
+        history.is_empty(),
+        "rejected messages must not be persisted"
+    );
+}
+
+#[tokio::test]
+async fn remember_returns_some_when_admission_admits() {
+    let memory = test_semantic_memory(false)
+        .await
+        .with_admission_control(make_always_admit_admission());
+
+    let cid = memory.sqlite.create_conversation().await.unwrap();
+    let result = memory
+        .remember(cid, "user", "important factual content")
+        .await
+        .unwrap();
+    assert!(
+        result.is_some(),
+        "remember() must return Some(id) when A-MAC admits"
+    );
+
+    let history = memory.sqlite.load_history(cid, 50).await.unwrap();
+    assert_eq!(history.len(), 1, "admitted message must be persisted");
+}
+
+#[tokio::test]
+async fn remember_with_parts_returns_none_when_admission_rejects() {
+    let memory = test_semantic_memory(false)
+        .await
+        .with_admission_control(make_always_reject_admission());
+
+    let cid = memory.sqlite.create_conversation().await.unwrap();
+    let (opt_id, stored) = memory
+        .remember_with_parts(cid, "assistant", "rejected content", "[]")
+        .await
+        .unwrap();
+    assert!(
+        opt_id.is_none(),
+        "remember_with_parts must return None when rejected"
+    );
+    assert!(!stored, "embedding_stored must be false when rejected");
+}
+
+#[tokio::test]
+async fn remember_with_parts_returns_some_when_admission_admits() {
+    let memory = test_semantic_memory(false)
+        .await
+        .with_admission_control(make_always_admit_admission());
+
+    let cid = memory.sqlite.create_conversation().await.unwrap();
+    let (opt_id, _stored) = memory
+        .remember_with_parts(cid, "user", "admitted content", "[]")
+        .await
+        .unwrap();
+    assert!(
+        opt_id.is_some(),
+        "remember_with_parts must return Some(id) when admitted"
+    );
 }

--- a/crates/zeph-memory/src/semantic/tests/summarization.rs
+++ b/crates/zeph-memory/src/semantic/tests/summarization.rs
@@ -47,9 +47,13 @@ async fn load_summaries_ordered() {
     let memory = test_semantic_memory(false).await;
     let cid = memory.sqlite().create_conversation().await.unwrap();
 
-    let msg_id1 = memory.remember(cid, "user", "m1").await.unwrap();
-    let msg_id2 = memory.remember(cid, "assistant", "m2").await.unwrap();
-    let msg_id3 = memory.remember(cid, "user", "m3").await.unwrap();
+    let msg_id1 = memory.remember(cid, "user", "m1").await.unwrap().unwrap();
+    let msg_id2 = memory
+        .remember(cid, "assistant", "m2")
+        .await
+        .unwrap()
+        .unwrap();
+    let msg_id3 = memory.remember(cid, "user", "m3").await.unwrap().unwrap();
 
     let s1 = memory
         .sqlite()
@@ -75,7 +79,11 @@ async fn summarize_below_threshold() {
     let memory = test_semantic_memory(false).await;
     let cid = memory.sqlite().create_conversation().await.unwrap();
 
-    memory.remember(cid, "user", "hello").await.unwrap();
+    memory
+        .remember(cid, "user", "hello")
+        .await
+        .unwrap()
+        .unwrap();
 
     let result = memory.summarize(cid, 10).await.unwrap();
     assert!(result.is_none());
@@ -244,6 +252,7 @@ async fn summarize_fails_when_provider_chat_fails() {
         graph_extraction_count: Arc::new(AtomicU64::new(0)),
         graph_extraction_failures: Arc::new(AtomicU64::new(0)),
         tier_boost_semantic: 1.3,
+        admission_control: None,
     };
     let cid = memory.sqlite().create_conversation().await.unwrap();
 
@@ -304,6 +313,7 @@ async fn summarize_fallback_to_plain_text_when_structured_fails() {
         graph_extraction_count: Arc::new(AtomicU64::new(0)),
         graph_extraction_failures: Arc::new(AtomicU64::new(0)),
         tier_boost_semantic: 1.3,
+        admission_control: None,
     };
 
     let cid = memory.sqlite().create_conversation().await.unwrap();

--- a/crates/zeph-memory/src/sqlite/mem_scenes.rs
+++ b/crates/zeph-memory/src/sqlite/mem_scenes.rs
@@ -1,0 +1,320 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `SQLite` operations for `MemScene` consolidation (#2332).
+
+use crate::scenes::MemScene;
+use crate::types::{MemSceneId, MessageId};
+
+use crate::error::MemoryError;
+
+use super::SqliteStore;
+
+impl SqliteStore {
+    /// Fetch semantic-tier messages not yet assigned to any scene.
+    ///
+    /// Returns `(message_id, content)` pairs ordered by `id` ASC.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the `SQLite` query fails.
+    pub async fn find_unscened_semantic_messages(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<(MessageId, String)>, MemoryError> {
+        let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
+        let rows: Vec<(i64, String)> = sqlx::query_as(
+            r"
+            SELECT m.id, m.content
+            FROM messages m
+            WHERE m.tier = 'semantic'
+              AND m.deleted_at IS NULL
+              AND m.id NOT IN (SELECT message_id FROM mem_scene_members)
+            ORDER BY m.id ASC
+            LIMIT ?
+            ",
+        )
+        .bind(limit_i64)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|(id, content)| (MessageId(id), content))
+            .collect())
+    }
+
+    /// Insert a new `MemScene` and link member messages to it.
+    ///
+    /// Returns the new scene's ID.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the `SQLite` insert fails.
+    pub async fn insert_mem_scene(
+        &self,
+        label: &str,
+        profile: &str,
+        member_ids: &[MessageId],
+    ) -> Result<MemSceneId, MemoryError> {
+        let member_count = i64::try_from(member_ids.len()).unwrap_or(0);
+        let mut tx = self.pool.begin().await?;
+
+        let row: (i64,) = sqlx::query_as(
+            "INSERT INTO mem_scenes (label, profile, member_count) VALUES (?, ?, ?) RETURNING id",
+        )
+        .bind(label)
+        .bind(profile)
+        .bind(member_count)
+        .fetch_one(&mut *tx)
+        .await?;
+        let scene_id = row.0;
+
+        for &msg_id in member_ids {
+            sqlx::query(
+                "INSERT OR IGNORE INTO mem_scene_members (scene_id, message_id) VALUES (?, ?)",
+            )
+            .bind(scene_id)
+            .bind(msg_id.0)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        tx.commit().await?;
+        Ok(MemSceneId(scene_id))
+    }
+
+    /// List all `MemScenes` ordered by creation time descending.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the `SQLite` query fails.
+    pub async fn list_mem_scenes(&self) -> Result<Vec<MemScene>, MemoryError> {
+        let rows: Vec<(i64, String, String, i64, i64, i64)> = sqlx::query_as(
+            "SELECT id, label, profile, member_count, created_at, updated_at \
+             FROM mem_scenes ORDER BY created_at DESC",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(
+                |(id, label, profile, member_count, created_at, updated_at)| MemScene {
+                    id: MemSceneId(id),
+                    label,
+                    profile,
+                    member_count: u32::try_from(member_count).unwrap_or(0),
+                    created_at,
+                    updated_at,
+                },
+            )
+            .collect())
+    }
+
+    /// Fetch member message IDs for a given scene.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the `SQLite` query fails.
+    pub async fn scene_member_ids(
+        &self,
+        scene_id: MemSceneId,
+    ) -> Result<Vec<MessageId>, MemoryError> {
+        let rows: Vec<(i64,)> =
+            sqlx::query_as("SELECT message_id FROM mem_scene_members WHERE scene_id = ?")
+                .bind(scene_id.0)
+                .fetch_all(&self.pool)
+                .await?;
+
+        Ok(rows.into_iter().map(|(id,)| MessageId(id)).collect())
+    }
+
+    /// Delete all `MemScenes` and their memberships (reset for re-clustering).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the `SQLite` delete fails.
+    pub async fn reset_mem_scenes(&self) -> Result<u64, MemoryError> {
+        let result = sqlx::query("DELETE FROM mem_scenes")
+            .execute(&self.pool)
+            .await?;
+        Ok(result.rows_affected())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn make_store() -> SqliteStore {
+        SqliteStore::new(":memory:").await.unwrap()
+    }
+
+    /// Create N real messages in the DB and return their IDs.
+    async fn seed_messages(store: &SqliteStore, n: usize) -> Vec<MessageId> {
+        let cid = store.create_conversation().await.unwrap();
+        let mut ids = Vec::with_capacity(n);
+        for i in 0..n {
+            let id = store
+                .save_message(cid, "user", &format!("msg {i}"))
+                .await
+                .unwrap();
+            ids.push(id);
+        }
+        ids
+    }
+
+    // Test: insert_mem_scene creates a scene and links member messages.
+    #[tokio::test]
+    async fn insert_and_list_scene() {
+        let store = make_store().await;
+        let ids = seed_messages(&store, 2).await;
+
+        let scene_id = store
+            .insert_mem_scene("Rust Auth", "JWT tokens used for RS256.", &ids)
+            .await
+            .unwrap();
+        assert!(scene_id.0 > 0, "scene id must be positive");
+
+        let scenes = store.list_mem_scenes().await.unwrap();
+        assert_eq!(scenes.len(), 1);
+        assert_eq!(scenes[0].label, "Rust Auth");
+        assert_eq!(scenes[0].member_count, 2);
+    }
+
+    // Test: scene_member_ids returns linked message IDs (scene member expansion on demand).
+    #[tokio::test]
+    async fn scene_member_ids_expansion() {
+        let store = make_store().await;
+        let ids = seed_messages(&store, 3).await;
+
+        let scene_id = store
+            .insert_mem_scene("Topic A", "Profile text.", &ids)
+            .await
+            .unwrap();
+
+        let members = store.scene_member_ids(scene_id).await.unwrap();
+        assert_eq!(members.len(), 3);
+        for id in &ids {
+            assert!(members.contains(id), "member {id} must be in expansion");
+        }
+    }
+
+    // Test: find_unscened_semantic_messages excludes already-assigned messages.
+    #[tokio::test]
+    async fn find_unscened_excludes_assigned_members() {
+        let store = make_store().await;
+        let ids = seed_messages(&store, 3).await;
+
+        // Promote all to semantic tier.
+        for id in &ids {
+            sqlx::query("UPDATE messages SET tier = 'semantic' WHERE id = ?")
+                .bind(id.0)
+                .execute(store.pool())
+                .await
+                .unwrap();
+        }
+
+        // All three should appear as unscened.
+        let unscened = store.find_unscened_semantic_messages(100).await.unwrap();
+        assert_eq!(unscened.len(), 3);
+
+        // Assign first two to a scene.
+        store
+            .insert_mem_scene("Partial Scene", "Some profile", &ids[..2])
+            .await
+            .unwrap();
+
+        // Now only the third should be unscened.
+        let unscened_after = store.find_unscened_semantic_messages(100).await.unwrap();
+        assert_eq!(unscened_after.len(), 1);
+        assert_eq!(unscened_after[0].0, ids[2]);
+    }
+
+    // Test: reset_mem_scenes clears all scenes and allows re-clustering.
+    #[tokio::test]
+    async fn reset_scenes_clears_all() {
+        let store = make_store().await;
+        let ids1 = seed_messages(&store, 1).await;
+        let ids2 = seed_messages(&store, 1).await;
+
+        store
+            .insert_mem_scene("Scene 1", "Profile 1", &ids1)
+            .await
+            .unwrap();
+        store
+            .insert_mem_scene("Scene 2", "Profile 2", &ids2)
+            .await
+            .unwrap();
+
+        let deleted = store.reset_mem_scenes().await.unwrap();
+        assert_eq!(deleted, 2);
+
+        let scenes = store.list_mem_scenes().await.unwrap();
+        assert!(scenes.is_empty());
+    }
+
+    // Test: list_mem_scenes returns newest first (by id DESC as proxy for created_at DESC).
+    // unixepoch() has 1-second resolution — use explicit created_at override via INSERT to
+    // guarantee ordering even when both inserts happen within the same second.
+    #[tokio::test]
+    async fn list_scenes_ordered_newest_first() {
+        let store = make_store().await;
+        let ids1 = seed_messages(&store, 1).await;
+        let ids2 = seed_messages(&store, 1).await;
+
+        // Insert directly with distinct created_at values to avoid single-second collision.
+        sqlx::query(
+            "INSERT INTO mem_scenes (label, profile, member_count, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind("First")
+        .bind("Profile first")
+        .bind(1i64)
+        .bind(1_000_000i64)
+        .bind(1_000_000i64)
+        .execute(store.pool())
+        .await
+        .unwrap();
+        let scene1_id: (i64,) = sqlx::query_as("SELECT last_insert_rowid()")
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+
+        sqlx::query(
+            "INSERT INTO mem_scenes (label, profile, member_count, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind("Second")
+        .bind("Profile second")
+        .bind(1i64)
+        .bind(2_000_000i64)
+        .bind(2_000_000i64)
+        .execute(store.pool())
+        .await
+        .unwrap();
+        let scene2_id: (i64,) = sqlx::query_as("SELECT last_insert_rowid()")
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+
+        // Link messages to satisfy FK.
+        sqlx::query("INSERT INTO mem_scene_members (scene_id, message_id) VALUES (?, ?)")
+            .bind(scene1_id.0)
+            .bind(ids1[0].0)
+            .execute(store.pool())
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO mem_scene_members (scene_id, message_id) VALUES (?, ?)")
+            .bind(scene2_id.0)
+            .bind(ids2[0].0)
+            .execute(store.pool())
+            .await
+            .unwrap();
+
+        let scenes = store.list_mem_scenes().await.unwrap();
+        // "Second" has created_at=2_000_000 > "First" created_at=1_000_000 → Second comes first.
+        assert_eq!(scenes.len(), 2);
+        assert_eq!(scenes[0].label, "Second");
+        assert_eq!(scenes[1].label, "First");
+    }
+}

--- a/crates/zeph-memory/src/sqlite/mod.rs
+++ b/crates/zeph-memory/src/sqlite/mod.rs
@@ -8,6 +8,7 @@ pub mod corrections;
 pub mod experiments;
 pub mod graph_store;
 mod history;
+mod mem_scenes;
 pub(crate) mod messages;
 pub mod overflow;
 pub mod preferences;

--- a/crates/zeph-memory/src/types.rs
+++ b/crates/zeph-memory/src/types.rs
@@ -53,6 +53,17 @@ pub struct ConversationId(pub i64);
 #[sqlx(transparent)]
 pub struct MessageId(pub i64);
 
+/// Strongly typed wrapper for `mem_scene` row IDs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, sqlx::Type)]
+#[sqlx(transparent)]
+pub struct MemSceneId(pub i64);
+
+impl std::fmt::Display for MemSceneId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 impl std::fmt::Display for ConversationId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -750,6 +750,32 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         )
     };
 
+    let _scene_consolidation_handle = {
+        let scene_cancel = zeph_memory::CancellationToken::new();
+        let scene_cancel_clone = scene_cancel.clone();
+        let mut shutdown_for_scenes = shutdown_rx.clone();
+        tokio::spawn(async move {
+            let _ = shutdown_for_scenes.changed().await;
+            scene_cancel_clone.cancel();
+        });
+        let sqlite_store = std::sync::Arc::new(memory.sqlite().clone());
+        let scene_provider = app
+            .build_scene_provider()
+            .unwrap_or_else(|| provider.clone());
+        let scene_cfg = zeph_memory::SceneConfig {
+            enabled: config.memory.tiers.scene_enabled,
+            similarity_threshold: config.memory.tiers.scene_similarity_threshold,
+            batch_size: config.memory.tiers.scene_batch_size,
+            sweep_interval_secs: config.memory.tiers.scene_sweep_interval_secs,
+        };
+        zeph_memory::start_scene_consolidation_loop(
+            sqlite_store,
+            scene_provider,
+            scene_cfg,
+            scene_cancel,
+        )
+    };
+
     #[cfg(feature = "compression-guidelines")]
     let _guidelines_handle = if config.memory.compression_guidelines.enabled {
         let guidelines_cancel = zeph_memory::CancellationToken::new();


### PR DESCRIPTION
## Summary

Implements three research-backed memory improvements:

- **#2332 EverMemOS MemScene consolidation** — brain-inspired engram lifecycle. Background loop clusters semantically-related SQLite messages into `MemScene` records (migration 049). Scene members excluded from regular recall via MessageKind filter. LLM-generated label/profile per scene, label truncated to 100 chars.
- **#2218 Focus compress_context tool** — agent-invokable native tool (not threshold-triggered). Knowledge block in `ContextBuilder` survives compaction. `AtomicBool` concurrency guard. `CompressionStrategy::Autonomous` variant.
- **#2317 A-MAC admission control** — write-time admission gate on `memory_save` path. 5-factor scoring with normalized weights. Fast path skips LLM when heuristic score exceeds threshold+margin. `remember()` return type changed to `Result<Option<MessageId>>` (breaking, pre-v1.0.0). Wired in `AppBuilder`, decisions logged via `AuditLogger`.

All new LLM-calling subsystems expose `*_provider` config fields. New `[memory.admission]` and `[memory.tiers]` scene fields added to config.

## New config

```toml
[memory.admission]
enabled = true
threshold = 0.4
admission_provider = "fast"
[memory.admission.weights]
future_utility = 0.3
factual_confidence = 0.2
semantic_novelty = 0.25
temporal_recency = 0.15
content_type_prior = 0.1

[memory.tiers]
scene_enabled = true
scene_similarity_threshold = 0.80
scene_batch_size = 50
scene_sweep_interval_secs = 7200
scene_provider = "fast"

[memory.compression]
strategy = "autonomous"
compress_provider = "quality"
```

## Breaking changes

- `remember()` returns `Result<Option<MessageId>>` (was `Result<MessageId>`) — all call sites updated
- `remember_with_parts()` returns `Result<(Option<MessageId>, bool)>` — all call sites updated

## Test plan

- [ ] Verify `cargo nextest run --workspace --features full --lib --bins` passes (7074 tests)
- [ ] Enable `[memory.admission]` in testing.toml and verify A-MAC gate logs admission decisions
- [ ] Run a session with `strategy = "autonomous"` and call `compress_context` manually
- [ ] Verify scene consolidation loop starts with `scene_enabled = true` (log: `scene consolidation: starting sweep`)

## Follow-up

- compress_provider runtime resolution for compress_context is deferred to a follow-up issue

Closes #2332
Closes #2218
Closes #2317