### PR TITLE
fix(tools): wire reasoning model detection and compress_provider into agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- fix(tools): wire `is_reasoning_model()` and `record_reasoning_quality_failure()` into the agent tool execution path; quality failures (`ToolNotFound`, `InvalidParameters`, `TypeMismatch`) from reasoning models (o1, o3, o4-mini, QwQ, DeepSeek-R1, Claude extended-thinking) now call `record_reasoning_quality_failure()` on the anomaly detector which emits a `reasoning_amplification` WARN log; `reasoning_model_warning = false` suppresses the WARN while still counting the error; `AuditEntry.error_phase` now populated from `ToolErrorCategory::phase()` in `ShellExecutor`, `WebScrapeExecutor`, and pre-execution verifier audit entries (#2357)
+- fix(memory): `handle_compress_context()` now resolves `compression.compress_provider` from `[[llm.providers]]` at bootstrap and passes the named provider to the LLM summarization call; falls back to the primary provider when the field is empty or resolution fails (#2356)
 - fix(tools): write `AuditEntry` with `AuditResult::Blocked` when a pre-execution verifier blocks a tool call; previously the block was logged and metered but never recorded in the audit log (#2343)
 - fix(telegram): split messages exceeding 4096 bytes at UTF-8 boundaries in `send_or_edit()`; both the new-message (None) and edit-overflow (Some) branches now iterate `utf8_chunks()` output (#2345)
 - fix(telegram): reduce streaming throttle from 10s to 3s in `should_send_update()` to improve perceived response speed (#2341)

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -461,6 +461,16 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Set a dedicated provider for `compress_context` LLM calls (#2356).
+    ///
+    /// When not set, `handle_compress_context` falls back to the primary provider.
+    #[must_use]
+    #[cfg(feature = "context-compression")]
+    pub fn with_compress_provider(mut self, provider: AnyProvider) -> Self {
+        self.providers.compress_provider = Some(provider);
+        self
+    }
+
     #[must_use]
     pub fn with_planner_provider(mut self, provider: AnyProvider) -> Self {
         self.orchestration.planner_provider = Some(provider);
@@ -1282,6 +1292,7 @@ impl<C: Channel> Agent<C> {
             .with_graph_config(graph_config)
             .with_orchestration_config(orchestration_config);
 
+        self.debug_state.reasoning_model_warning = anomaly_config.reasoning_model_warning;
         if anomaly_config.enabled {
             self = self.with_anomaly_detector(zeph_tools::AnomalyDetector::new(
                 anomaly_config.window_size,

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -357,6 +357,7 @@ impl<C: Channel> Agent<C> {
                 trace_collector: None,
                 iteration_counter: 0,
                 anomaly_detector: None,
+                reasoning_model_warning: true,
                 logging_config: crate::config::LoggingConfig::default(),
                 dump_dir: None,
                 trace_service_name: String::new(),
@@ -482,6 +483,8 @@ impl<C: Channel> Agent<C> {
                 provider_override: None,
                 judge_provider: None,
                 probe_provider: None,
+                #[cfg(feature = "context-compression")]
+                compress_provider: None,
                 cached_prompt_tokens: initial_prompt_tokens,
                 server_compaction_active: false,
                 stt: None,

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -205,6 +205,9 @@ pub(crate) struct DebugState {
     /// Used to key spans in `trace_collector.active_iterations`.
     pub(crate) iteration_counter: usize,
     pub(crate) anomaly_detector: Option<zeph_tools::AnomalyDetector>,
+    /// Whether to emit `reasoning_amplification` warnings for quality failures from reasoning
+    /// models. Mirrors `AnomalyConfig::reasoning_model_warning`. Default: `true`.
+    pub(crate) reasoning_model_warning: bool,
     pub(crate) logging_config: crate::config::LoggingConfig,
     /// Base dump directory — stored so `/dump-format trace` can create a `TracingCollector` (CR-04).
     pub(crate) dump_dir: Option<PathBuf>,
@@ -252,6 +255,10 @@ pub(crate) struct ProviderState {
     /// Dedicated provider for compaction probe LLM calls. Falls back to `summary_provider`
     /// (or primary) when `None`.
     pub(crate) probe_provider: Option<AnyProvider>,
+    /// Dedicated provider for `compress_context` LLM calls (#2356).
+    /// Falls back to the primary provider when `None`.
+    #[cfg(feature = "context-compression")]
+    pub(crate) compress_provider: Option<AnyProvider>,
     pub(crate) cached_prompt_tokens: u64,
     /// Whether the active provider has server-side compaction enabled (Claude compact-2026-01-12).
     /// When true, client-side compaction is skipped.

--- a/crates/zeph-core/src/agent/tool_execution/mod.rs
+++ b/crates/zeph-core/src/agent/tool_execution/mod.rs
@@ -23,6 +23,13 @@ enum AnomalyOutcome {
     Success,
     Error,
     Blocked,
+    /// Quality failure (`ToolNotFound`, `InvalidParameters`, `TypeMismatch`) from a
+    /// reasoning-enhanced model. Triggers `record_reasoning_quality_failure` which both
+    /// counts the error in the sliding window and emits a `reasoning_amplification` warning.
+    ReasoningQualityFailure {
+        model: String,
+        tool: String,
+    },
 }
 
 /// Result of a response cache lookup.
@@ -265,6 +272,13 @@ impl<C: Channel> Agent<C> {
             AnomalyOutcome::Success => det.record_success(),
             AnomalyOutcome::Error => det.record_error(),
             AnomalyOutcome::Blocked => det.record_blocked(),
+            AnomalyOutcome::ReasoningQualityFailure { model, tool } => {
+                if self.debug_state.reasoning_model_warning {
+                    det.record_reasoning_quality_failure(&model, &tool);
+                } else {
+                    det.record_error();
+                }
+            }
         }
         if let Some(anomaly) = det.check() {
             tracing::warn!(severity = ?anomaly.severity, "{}", anomaly.description);

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -738,7 +738,11 @@ impl<C: Channel> Agent<C> {
                                     duration_ms: 0,
                                     error_category: Some("pre_execution_block".to_owned()),
                                     error_domain: Some("security".to_owned()),
-                                    error_phase: None,
+                                    error_phase: Some(
+                                        zeph_tools::error_taxonomy::ToolInvocationPhase::Setup
+                                            .label()
+                                            .to_owned(),
+                                    ),
                                     claim_source: None,
                                     mcp_server_id: None,
                                     injection_flagged: false,
@@ -1510,6 +1514,13 @@ impl<C: Channel> Agent<C> {
                     tool_err_category = Some(category);
                     anomaly_outcome = if matches!(e, zeph_tools::ToolError::Blocked { .. }) {
                         AnomalyOutcome::Blocked
+                    } else if is_quality_failure
+                        && zeph_tools::is_reasoning_model(self.provider.name())
+                    {
+                        AnomalyOutcome::ReasoningQualityFailure {
+                            model: self.provider.name().to_owned(),
+                            tool: tc.name.clone(),
+                        }
                     } else {
                         AnomalyOutcome::Error
                     };
@@ -1955,9 +1966,14 @@ impl<C: Channel> Agent<C> {
             },
         ];
 
+        let compress_provider = self
+            .providers
+            .compress_provider
+            .as_ref()
+            .unwrap_or(&self.provider);
         let summary = match tokio::time::timeout(
             std::time::Duration::from_secs(30),
-            self.provider.chat(&summary_messages),
+            compress_provider.chat(&summary_messages),
         )
         .await
         {

--- a/crates/zeph-core/src/bootstrap/mod.rs
+++ b/crates/zeph-core/src/bootstrap/mod.rs
@@ -715,6 +715,32 @@ impl AppBuilder {
         }
     }
 
+    /// Build a dedicated provider for `compress_context` LLM calls (#2356).
+    ///
+    /// Returns `None` when `compress_provider` is empty (falls back to primary provider at call site).
+    /// Emits a `tracing::warn` on resolution failure (primary provider used as fallback).
+    #[cfg(feature = "context-compression")]
+    pub fn build_compress_provider(&self) -> Option<AnyProvider> {
+        let name = &self.config.memory.compression.compress_provider;
+        if name.is_empty() {
+            return None;
+        }
+        match create_named_provider(name, &self.config) {
+            Ok(p) => {
+                tracing::info!(provider = %name, "compress_context provider configured");
+                Some(p)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    provider = %name,
+                    error = %e,
+                    "compress_context provider resolution failed — primary provider will be used"
+                );
+                None
+            }
+        }
+    }
+
     /// Build a dedicated provider for ACON compression guidelines LLM calls.
     ///
     /// Returns `None` when `guidelines_provider` is empty (falls back to primary provider at call site).

--- a/crates/zeph-tools/src/scrape.rs
+++ b/crates/zeph-tools/src/scrape.rs
@@ -283,13 +283,15 @@ impl WebScrapeExecutor {
         error: Option<&ToolError>,
     ) {
         if let Some(ref logger) = self.audit_logger {
-            let (error_category, error_domain) = error.map_or((None, None), |e| {
-                let cat = e.category();
-                (
-                    Some(cat.label().to_owned()),
-                    Some(cat.domain().label().to_owned()),
-                )
-            });
+            let (error_category, error_domain, error_phase) =
+                error.map_or((None, None, None), |e| {
+                    let cat = e.category();
+                    (
+                        Some(cat.label().to_owned()),
+                        Some(cat.domain().label().to_owned()),
+                        Some(cat.phase().label().to_owned()),
+                    )
+                });
             let entry = AuditEntry {
                 timestamp: chrono_now(),
                 tool: tool.into(),
@@ -298,7 +300,7 @@ impl WebScrapeExecutor {
                 duration_ms,
                 error_category,
                 error_domain,
-                error_phase: None,
+                error_phase,
                 claim_source: Some(ClaimSource::WebScrape),
                 mcp_server_id: None,
                 injection_flagged: false,

--- a/crates/zeph-tools/src/shell/mod.rs
+++ b/crates/zeph-tools/src/shell/mod.rs
@@ -536,13 +536,15 @@ impl ShellExecutor {
         error: Option<&ToolError>,
     ) {
         if let Some(ref logger) = self.audit_logger {
-            let (error_category, error_domain) = error.map_or((None, None), |e| {
-                let cat = e.category();
-                (
-                    Some(cat.label().to_owned()),
-                    Some(cat.domain().label().to_owned()),
-                )
-            });
+            let (error_category, error_domain, error_phase) =
+                error.map_or((None, None, None), |e| {
+                    let cat = e.category();
+                    (
+                        Some(cat.label().to_owned()),
+                        Some(cat.domain().label().to_owned()),
+                        Some(cat.phase().label().to_owned()),
+                    )
+                });
             let entry = AuditEntry {
                 timestamp: chrono_now(),
                 tool: "shell".into(),
@@ -551,7 +553,7 @@ impl ShellExecutor {
                 duration_ms,
                 error_category,
                 error_domain,
-                error_phase: None,
+                error_phase,
                 claim_source: Some(ClaimSource::Shell),
                 mcp_server_id: None,
                 injection_flagged: false,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1145,6 +1145,15 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     } else {
         agent
     };
+    #[cfg(feature = "context-compression")]
+    let agent = {
+        let compress_provider = app.build_compress_provider();
+        if let Some(cp) = compress_provider {
+            agent.with_compress_provider(cp)
+        } else {
+            agent
+        }
+    };
     let planner_provider = app.build_planner_provider();
     let agent = if let Some(pp) = planner_provider {
         agent.with_planner_provider(pp)


### PR DESCRIPTION
## Summary

- Wire `is_reasoning_model()` / `record_reasoning_quality_failure()` into the agent tool execution path: quality failures (`ToolNotFound`, `InvalidParameters`, `TypeMismatch`) from reasoning-enhanced models (o1, o3, o4-mini, QwQ, DeepSeek-R1, Claude extended-thinking) now emit a `reasoning_amplification` WARN log and count in the anomaly window; gated by `AnomalyConfig::reasoning_model_warning` (default `true`)
- Populate `AuditEntry.error_phase` from `ToolErrorCategory::phase()` in `ShellExecutor`, `WebScrapeExecutor`, and pre-execution verifier audit entries — was always `null`
- Resolve `compression.compress_provider` from `[[llm.providers]]` at bootstrap and pass the named provider to `handle_compress_context()` LLM call; falls back to primary provider when field is empty or resolution fails

## Changes

### #2357 — `is_reasoning_model()` + `error_phase` wiring

- `tool_execution/mod.rs`: new `AnomalyOutcome::ReasoningQualityFailure { model, tool }` variant; `record_anomaly_outcome()` dispatches to `det.record_reasoning_quality_failure()` when `debug_state.reasoning_model_warning = true`
- `tool_execution/native.rs` (`Err` arm): sets `ReasoningQualityFailure` when `is_quality_failure && is_reasoning_model(provider.name())`
- `state/mod.rs`: `DebugState.reasoning_model_warning: bool` field mirrors `AnomalyConfig::reasoning_model_warning`
- `builder.rs`: stores `anomaly_config.reasoning_model_warning` into `DebugState` in `apply_session_config()`
- `shell/mod.rs`, `scrape.rs`: `log_audit` now sets `error_phase` from `e.category().phase().label()`
- `native.rs` pre-execution verifier block: `error_phase = Some("setup")`

### #2356 — `compress_provider` wiring

- `state/mod.rs`: `ProviderState.compress_provider: Option<AnyProvider>` (`#[cfg(feature = "context-compression")]`)
- `builder.rs`: `with_compress_provider()` builder method (feature-gated)
- `bootstrap/mod.rs`: `build_compress_provider()` reads `config.memory.compression.compress_provider` and resolves via `create_named_provider()` (feature-gated)
- `runner.rs`: wires `build_compress_provider()` → `with_compress_provider()` inside `#[cfg(feature = "context-compression")]`
- `native.rs`: `handle_compress_context()` uses `providers.compress_provider.as_ref().unwrap_or(&self.provider)`

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy -p zeph-tools -- -D warnings` — clean
- [x] `cargo clippy -p zeph-core -- -D warnings` — clean
- [x] `cargo clippy -p zeph-core --features context-compression -- -D warnings` — clean
- [x] `cargo nextest run -p zeph-tools -p zeph-core --lib --bins` — 2047 passed
- [x] `cargo nextest run -p zeph-core --features context-compression --lib --bins` — 1212 passed

Closes #2357
Closes #2356