### PR TITLE
feat(postgres): fix call sites and add tests for postgres build

### DIFF
--- a/src/acp.rs
+++ b/src/acp.rs
@@ -502,7 +502,7 @@ async fn build_acp_deps(
                     .to_string(),
             )
         },
-        sqlite_path: config.memory.sqlite_path.clone(),
+        sqlite_path: crate::db_url::resolve_db_url(config).to_owned(),
         acp_provider_factory: Some(build_acp_provider_factory(config)),
         acp_project_rules,
         #[cfg(feature = "scheduler")]
@@ -1273,7 +1273,7 @@ pub(crate) async fn run_acp_http_server(
         project_rules: collect_project_rules(&app.skill_paths()),
         title_max_chars: app.config().memory.sessions.title_max_chars,
         max_history: app.config().memory.sessions.max_history,
-        sqlite_path: Some(app.config().memory.sqlite_path.clone()),
+        sqlite_path: Some(crate::db_url::resolve_db_url(app.config()).to_owned()),
         ready_notification: None,
     };
     let shared_deps: Arc<RwLock<Option<Arc<SharedAgentDeps>>>> = Arc::new(RwLock::new(None));
@@ -1290,7 +1290,7 @@ pub(crate) async fn run_acp_http_server(
         })
     });
     let mut state = zeph_acp::AcpHttpState::new(spawner, server_config);
-    match zeph_memory::store::SqliteStore::new(&app.config().memory.sqlite_path).await {
+    match zeph_memory::store::SqliteStore::new(crate::db_url::resolve_db_url(app.config())).await {
         Ok(store) => state = state.with_store(store),
         Err(e) => tracing::warn!(error = %e, "failed to open SQLite for HTTP session endpoints"),
     }

--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -18,12 +18,7 @@ pub(crate) async fn handle_db_migrate(config_path: Option<&std::path::Path>) -> 
     let config_path = resolve_config_path(config_path);
     let config = Config::load(&config_path).unwrap_or_default();
 
-    let db_url = config
-        .memory
-        .database_url
-        .as_deref()
-        .filter(|s| !s.is_empty())
-        .unwrap_or(&config.memory.sqlite_path);
+    let db_url = crate::db_url::resolve_db_url(&config);
 
     // C-001: validate that the URL matches the compiled-in backend.
     #[cfg(feature = "postgres")]
@@ -75,5 +70,23 @@ mod tests {
                 command: DbCommand::Migrate
             })
         ));
+    }
+
+    #[cfg(feature = "postgres")]
+    #[test]
+    fn is_postgres_url_accepts_postgres_schemes() {
+        assert!(zeph_db::is_postgres_url("postgres://localhost/test"));
+        assert!(zeph_db::is_postgres_url("postgresql://localhost/test"));
+        assert!(!zeph_db::is_postgres_url("/tmp/test.db"));
+        assert!(!zeph_db::is_postgres_url("sqlite:///tmp/test.db"));
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn is_postgres_url_rejects_sqlite_paths() {
+        assert!(!zeph_db::is_postgres_url("/tmp/test.db"));
+        assert!(!zeph_db::is_postgres_url("sqlite:///tmp/test.db"));
+        assert!(zeph_db::is_postgres_url("postgres://localhost/test"));
+        assert!(zeph_db::is_postgres_url("postgresql://localhost/test"));
     }
 }

--- a/src/commands/memory.rs
+++ b/src/commands/memory.rs
@@ -12,7 +12,7 @@ pub(crate) async fn handle_memory_command(
 
     let config_file = resolve_config_path(config_path);
     let config = zeph_core::config::Config::load(&config_file).unwrap_or_default();
-    let sqlite = SqliteStore::new(&config.memory.sqlite_path)
+    let sqlite = SqliteStore::new(crate::db_url::resolve_db_url(&config))
         .await
         .map_err(|e| anyhow::anyhow!("failed to open SQLite: {e}"))?;
 

--- a/src/commands/sessions.rs
+++ b/src/commands/sessions.rs
@@ -15,7 +15,7 @@ pub(crate) async fn handle_sessions_command(
 
     let config_file = resolve_config_path(config_path);
     let config = zeph_core::config::Config::load(&config_file).unwrap_or_default();
-    let store = SqliteStore::new(&config.memory.sqlite_path)
+    let store = SqliteStore::new(crate::db_url::resolve_db_url(&config))
         .await
         .map_err(|e| anyhow::anyhow!("failed to open SQLite: {e}"))?;
 

--- a/src/commands/skill.rs
+++ b/src/commands/skill.rs
@@ -21,7 +21,7 @@ pub(crate) async fn handle_skill_command(
 
     let mgr = SkillManager::new(managed_dir.clone());
 
-    let sqlite_path = config.memory.sqlite_path.clone();
+    let sqlite_path = crate::db_url::resolve_db_url(&config).to_owned();
 
     match cmd {
         SkillCommand::Install { source } => {

--- a/src/db_url.rs
+++ b/src/db_url.rs
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+/// Returns the effective database URL for the current build.
+///
+/// Prefers `database_url` when set and non-empty (postgres backend), otherwise falls
+/// back to `sqlite_path` (sqlite backend). Mirrors the logic in `AppBuilder::build_memory`.
+pub(crate) fn resolve_db_url(config: &zeph_core::config::Config) -> &str {
+    config
+        .memory
+        .database_url
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .unwrap_or(&config.memory.sqlite_path)
+}

--- a/src/init.rs
+++ b/src/init.rs
@@ -3198,4 +3198,41 @@ mod tests {
                 < f32::EPSILON
         );
     }
+
+    #[test]
+    fn build_config_postgres_backend_sets_database_url() {
+        let state = WizardState {
+            database_url: Some("postgres://localhost:5432/zeph".to_owned()),
+            provider: Some(ProviderKind::Ollama),
+            model: Some("qwen3:8b".into()),
+            vault_backend: "env".into(),
+            ..WizardState::default()
+        };
+        let config = build_config(&state);
+        assert_eq!(
+            config.memory.database_url.as_deref(),
+            Some("postgres://localhost:5432/zeph"),
+        );
+        assert_eq!(
+            config.memory.sqlite_path,
+            zeph_core::config::default_sqlite_path(),
+        );
+    }
+
+    #[test]
+    fn build_config_sqlite_backend_leaves_database_url_none() {
+        let state = WizardState {
+            database_url: None,
+            provider: Some(ProviderKind::Ollama),
+            model: Some("qwen3:8b".into()),
+            vault_backend: "env".into(),
+            ..WizardState::default()
+        };
+        let config = build_config(&state);
+        assert!(config.memory.database_url.is_none());
+        assert_eq!(
+            config.memory.sqlite_path,
+            zeph_core::config::default_sqlite_path(),
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod channel;
 mod cli;
 mod commands;
 mod daemon;
+mod db_url;
 mod gateway_spawn;
 mod init;
 mod runner;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1625,8 +1625,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
 async fn run_experiment_report(app: &zeph_core::bootstrap::AppBuilder) -> anyhow::Result<()> {
     use zeph_memory::store::SqliteStore;
 
-    let sqlite_path = app.config().memory.sqlite_path.clone();
-    let store = SqliteStore::new(&sqlite_path).await?;
+    let store = SqliteStore::new(crate::db_url::resolve_db_url(app.config())).await?;
     let rows = store.list_experiment_results(None, 50).await?;
 
     if rows.is_empty() {

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -277,7 +277,8 @@ pub(crate) async fn init_scheduler(
         return None;
     }
 
-    let store = match JobStore::open(&config.memory.sqlite_path).await {
+    let db_url = crate::db_url::resolve_db_url(config);
+    let store = match JobStore::open(db_url).await {
         Ok(s) => s,
         Err(e) => {
             tracing::warn!("scheduler: failed to open store: {e}");
@@ -286,7 +287,7 @@ pub(crate) async fn init_scheduler(
     };
 
     let store_arc = Arc::new(store);
-    let scheduler_store = match JobStore::open(&config.memory.sqlite_path).await {
+    let scheduler_store = match JobStore::open(db_url).await {
         Ok(s) => s,
         Err(e) => {
             tracing::warn!("scheduler: failed to open second store handle: {e}");


### PR DESCRIPTION
Closes #2374
Closes #2377
Closes #2378

## Summary

- Introduce `resolve_db_url(config)` helper in `src/db_url.rs` that returns `database_url` when set and non-empty, falling back to `sqlite_path`. Eliminates the duplicated inline logic that was in `handle_db_migrate`.
- Replace hardcoded `config.memory.sqlite_path` across 6 files (`skill.rs`, `memory.rs`, `sessions.rs`, `runner.rs`, `acp.rs`, `scheduler.rs`) so all call sites work correctly under both `--features sqlite` and `--features postgres`.
- Add cfg-gated unit tests for `is_postgres_url` predicate in `src/commands/db.rs` (#2377).
- Add `build_config` unit tests for the postgres backend path in `src/init.rs` (#2378).

## Pre-existing postgres check failures

`cargo check --features postgres,...` still fails with 27 `E0271` errors in `zeph-memory` (Pool<Postgres> vs Sqlite type mismatches from Phase 2, PR #2372). Zero new errors are introduced by this PR — verified by checking that all failing file paths are in `crates/zeph-memory/`.

## Test plan

- [x] `cargo +nightly fmt --check` — pass
- [x] `cargo clippy --workspace --features full -- -D warnings` — pass
- [x] `cargo nextest run --workspace --features full --lib --bins` — 7195 passed, 22 skipped
- [x] `cargo check --features postgres,... 2>&1 | grep "^error\[" | grep -v "zeph-memory"` — zero output (no new errors)