### PR TITLE
fix(memory,llm): correct BFS ESCAPE clause and persist bandit state (#2393, #2394)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(memory): correct ESCAPE clause in spreading activation BFS alias query — `ESCAPE '\\\\'` (2 chars) changed to `ESCAPE '\\'` (1 char) as required by SQLite (closes #2393)
+- fix(llm): call `save_bandit_state()` in `save_router_state()` to persist PILOT LinUCB bandit state across restarts (closes #2394)
+
 ## [0.18.0] - 2026-03-29
 
 ### Changed

--- a/crates/zeph-llm/src/any.rs
+++ b/crates/zeph-llm/src/any.rs
@@ -137,6 +137,7 @@ impl AnyProvider {
         if let Self::Router(p) = self {
             p.save_thompson_state();
             p.save_reputation_state();
+            p.save_bandit_state();
         }
     }
 

--- a/crates/zeph-memory/src/graph/store/mod.rs
+++ b/crates/zeph-memory/src/graph/store/mod.rs
@@ -1078,7 +1078,7 @@ impl GraphStore {
                         0.5 AS fts_rank \
                  FROM graph_entity_aliases a \
                  JOIN graph_entities e ON e.id = a.entity_id \
-                 WHERE a.alias_name LIKE ? ESCAPE '\\\\' {} \
+                 WHERE a.alias_name LIKE ? ESCAPE '\\' {} \
              ) \
              ORDER BY fts_rank DESC \
              LIMIT ?",


### PR DESCRIPTION
## Summary

- **#2393 (P1)**: Spreading activation BFS alias query used `ESCAPE '\\\\'` (2 chars in SQL), which SQLite rejects. Changed to `ESCAPE '\\'` (1 char). Regression introduced in PR #2371.
- **#2394 (P2)**: `save_router_state()` was missing `save_bandit_state()`, causing PILOT LinUCB bandit to cold-start on every restart. Added the missing call.

## Changes

- `crates/zeph-memory/src/graph/store/mod.rs:1081` — fix ESCAPE clause
- `crates/zeph-llm/src/any.rs` — add `save_bandit_state()` to shutdown path
- `CHANGELOG.md` — document both fixes under `[Unreleased]`

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --features full -- -D warnings` — 0 warnings
- [x] `cargo nextest run --workspace --features full --lib --bins` — 7233 passed, 0 failed