### PR TITLE
fix(classifiers): use Metal/CUDA device when available in candle classifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - fix(memory): correct ESCAPE clause in spreading activation BFS alias query — `ESCAPE '\\\\'` (2 chars) changed to `ESCAPE '\\'` (1 char) as required by SQLite (closes #2393)
 - fix(llm): call `save_bandit_state()` in `save_router_state()` to persist PILOT LinUCB bandit state across restarts (closes #2394)
+- fix(classifiers): use Metal/CUDA device when available in candle classifiers — falls back to CPU (#2396)
 
 ## [0.18.0] - 2026-03-29
 

--- a/crates/zeph-llm/src/candle_whisper.rs
+++ b/crates/zeph-llm/src/candle_whisper.rs
@@ -40,22 +40,6 @@ fn device_name(d: &Device) -> &'static str {
     }
 }
 
-fn detect_device() -> Device {
-    #[cfg(feature = "metal")]
-    {
-        if let Ok(d) = Device::new_metal(0) {
-            return d;
-        }
-    }
-    #[cfg(feature = "cuda")]
-    {
-        if let Ok(d) = Device::new_cuda(0) {
-            return d;
-        }
-    }
-    Device::Cpu
-}
-
 impl CandleWhisperProvider {
     /// Load a Whisper model from a `HuggingFace` repo.
     ///
@@ -64,7 +48,7 @@ impl CandleWhisperProvider {
     /// Returns `LlmError::ModelLoad` if downloading or loading fails.
     #[allow(unsafe_code)]
     pub fn load(repo_id: &str, device: Option<Device>, language: &str) -> Result<Self, LlmError> {
-        let device = device.unwrap_or_else(detect_device);
+        let device = device.unwrap_or_else(crate::device::detect_device);
         tracing::info!(
             repo = repo_id,
             device = device_name(&device),
@@ -354,6 +338,7 @@ fn resample(input: &[f32], from_rate: u32, to_rate: u32) -> Result<Vec<f32>, Llm
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::device::detect_device;
 
     #[test]
     fn device_detection_returns_cpu_by_default() {

--- a/crates/zeph-llm/src/classifier/candle.rs
+++ b/crates/zeph-llm/src/classifier/candle.rs
@@ -262,7 +262,7 @@ impl CandleClassifier {
 
         validate_safetensors(&weights_path)?;
 
-        let device = Device::Cpu;
+        let device = crate::device::detect_device();
         // SAFETY: validated safetensors header above; file not modified during VarBuilder lifetime
         let vb =
             unsafe { VarBuilder::from_mmaped_safetensors(&[weights_path], DType::F32, &device)? };

--- a/crates/zeph-llm/src/classifier/candle_pii.rs
+++ b/crates/zeph-llm/src/classifier/candle_pii.rs
@@ -139,7 +139,7 @@ impl CandlePiiClassifier {
 
         super::candle::CandleClassifier::validate_safetensors_path(&weights_path)?;
 
-        let device = Device::Cpu;
+        let device = crate::device::detect_device();
         // SAFETY: validated safetensors header above; file not modified during VarBuilder lifetime
         let vb =
             unsafe { VarBuilder::from_mmaped_safetensors(&[weights_path], DType::F32, &device)? };

--- a/crates/zeph-llm/src/classifier/ner.rs
+++ b/crates/zeph-llm/src/classifier/ner.rs
@@ -31,7 +31,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, OnceLock};
 
-use candle_core::{DType, Device, Tensor};
+use candle_core::{DType, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::models::debertav2::{Config as DebertaConfig, DebertaV2NERModel};
 use tokenizers::Tokenizer;
@@ -149,7 +149,7 @@ impl CandleNerClassifier {
 
         validate_safetensors(&weights_path)?;
 
-        let device = Device::Cpu;
+        let device = crate::device::detect_device();
         // SAFETY: validated safetensors header above; file not modified during VarBuilder lifetime
         let vb =
             unsafe { VarBuilder::from_mmaped_safetensors(&[weights_path], DType::F32, &device)? };

--- a/crates/zeph-llm/src/classifier/three_class.rs
+++ b/crates/zeph-llm/src/classifier/three_class.rs
@@ -324,7 +324,7 @@ impl CandleThreeClassClassifier {
 
         validate_safetensors(&weights_path)?;
 
-        let device = Device::Cpu;
+        let device = crate::device::detect_device();
         // SAFETY: validated safetensors header above; file not modified during VarBuilder lifetime
         let vb =
             unsafe { VarBuilder::from_mmaped_safetensors(&[weights_path], DType::F32, &device)? };

--- a/crates/zeph-llm/src/device.rs
+++ b/crates/zeph-llm/src/device.rs
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use candle_core::Device;
+
+pub(crate) fn detect_device() -> Device {
+    #[cfg(feature = "metal")]
+    {
+        if let Ok(d) = Device::new_metal(0) {
+            return d;
+        }
+    }
+    #[cfg(feature = "cuda")]
+    {
+        if let Ok(d) = Device::new_cuda(0) {
+            return d;
+        }
+    }
+    Device::Cpu
+}

--- a/crates/zeph-llm/src/lib.rs
+++ b/crates/zeph-llm/src/lib.rs
@@ -11,6 +11,8 @@ pub mod candle_whisper;
 pub mod classifier;
 pub mod claude;
 pub mod compatible;
+#[cfg(feature = "candle")]
+pub(crate) mod device;
 pub mod ema;
 pub mod error;
 pub mod extractor;


### PR DESCRIPTION
## Summary

- Extract `detect_device()` from `candle_whisper.rs` into a new crate-level `crates/zeph-llm/src/device.rs` module (gated under `#[cfg(feature = "candle")]`)
- Replace hardcoded `Device::Cpu` in all four candle classifiers (`candle.rs`, `candle_pii.rs`, `three_class.rs`, `ner.rs`) with `crate::device::detect_device()`
- `detect_device()` tries `Device::new_metal(0)` under `metal` feature, `Device::new_cuda(0)` under `cuda` feature, falls back to `Device::Cpu` on any failure

## Test plan

- [ ] `cargo +nightly fmt --check` — PASS
- [ ] `cargo clippy --profile ci --workspace --features full -- -D warnings` — PASS
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --features full --lib --bins` — 7233/7233 PASS
- [ ] `cargo check --features candle -p zeph-llm` — PASS (candle_whisper test module compiles correctly)

Closes #2396