### PR TITLE
fix(memory): consolidation prompt isolation, Update in-place semantics, concurrent embeddings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fix(memory): correct ESCAPE clause in spreading activation BFS alias query — `ESCAPE '\\\\'` (2 chars) changed to `ESCAPE '\\'` (1 char) as required by SQLite (closes #2393)
 - fix(llm): call `save_bandit_state()` in `save_router_state()` to persist PILOT LinUCB bandit state across restarts (closes #2394)
 - fix(classifiers): use Metal/CUDA device when available in candle classifiers — falls back to CPU (#2396)
+- fix(memory): consolidation LLM prompt splits into `Role::System` (instructions) + `Role::User` (memory entries) to prevent adversarial content from influencing consolidation decisions (#2362)
+- fix(memory): `TopologyOp::Update` now performs an actual in-place content UPDATE on the target row instead of duplicating `apply_consolidation_merge` logic; `target_id` is no longer ignored (#2364)
+
+### Changed
+
+- perf(memory): consolidation sweep embeds all candidates concurrently via `futures::future::join_all` instead of sequentially, reducing latency for large batches (#2365)
 
 ## [0.18.0] - 2026-03-29
 

--- a/crates/zeph-memory/src/consolidation.rs
+++ b/crates/zeph-memory/src/consolidation.rs
@@ -174,17 +174,28 @@ pub async fn run_consolidation_sweep(
         }
 
         // Embed all candidates for clustering.
-        let mut embedded: Vec<(i64, String, Vec<f32>)> = Vec::with_capacity(candidates.len());
-        for (id, content) in candidates {
-            if !provider.supports_embeddings() {
-                // No embedding support — cannot cluster, skip this conversation.
-                break;
-            }
-            match provider.embed(&content).await {
-                Ok(vec) => embedded.push((id.0, content, vec)),
+        if !provider.supports_embeddings() {
+            // No embedding support — cannot cluster, skip this conversation.
+            continue;
+        }
+
+        let futures: Vec<_> = candidates
+            .iter()
+            .map(|(id, content)| {
+                let id = id.0;
+                let content = content.clone();
+                async move { (id, content.clone(), provider.embed(&content).await) }
+            })
+            .collect();
+        let results = futures::future::join_all(futures).await;
+
+        let mut embedded: Vec<(i64, String, Vec<f32>)> = Vec::with_capacity(results.len());
+        for (id, content, result) in results {
+            match result {
+                Ok(vec) => embedded.push((id, content, vec)),
                 Err(e) => {
                     tracing::warn!(
-                        message_id = id.0,
+                        message_id = id,
                         error = %e,
                         "consolidation: failed to embed candidate, skipping"
                     );
@@ -243,20 +254,18 @@ pub async fn run_consolidation_sweep(
                     }
                 }
                 Some(TopologyOp::Update {
+                    target_id,
                     new_content,
                     additional_source_ids,
                     confidence,
-                    ..
                 }) => {
-                    // Update: same apply path but with a fresh merge for MVP simplicity.
                     let source_msg_ids: Vec<crate::types::MessageId> = additional_source_ids
                         .iter()
                         .map(|&id| crate::types::MessageId(id))
                         .collect();
                     match store
-                        .apply_consolidation_merge(
-                            conv_id,
-                            "assistant",
+                        .apply_consolidation_update(
+                            crate::types::MessageId(target_id),
                             &new_content,
                             &source_msg_ids,
                             confidence,
@@ -269,6 +278,7 @@ pub async fn run_consolidation_sweep(
                         Err(e) => {
                             tracing::warn!(
                                 error = %e,
+                                target_id,
                                 "consolidation: update failed"
                             );
                         }
@@ -323,19 +333,20 @@ async fn propose_merge_op(provider: &AnyProvider, cluster: &[(i64, String)]) -> 
         .collect::<Vec<_>>()
         .join("\n");
 
-    let prompt = format!(
-        "You are a memory consolidation assistant. \
-         The following messages are semantically similar and should be consolidated.\n\n\
-         Messages:\n{entries}\n\n\
+    let system_prompt = "You are a memory consolidation assistant. \
          Produce a single JSON object representing a consolidation operation.\n\
          Use this exact schema (choose either 'merge' or 'update'):\n\
-         {{\"op\":\"merge\",\"source_ids\":[<list of ids>],\"merged_content\":\"<combined fact>\",\"confidence\":<0.0-1.0>}}\n\
+         {\"op\":\"merge\",\"source_ids\":[<list of ids>],\"merged_content\":\"<combined fact>\",\"confidence\":<0.0-1.0>}\n\
          OR\n\
-         {{\"op\":\"update\",\"target_id\":<id>,\"new_content\":\"<updated fact>\",\"additional_source_ids\":[<ids>],\"confidence\":<0.0-1.0>}}\n\n\
-         Return ONLY the JSON object, no explanation."
-    );
+         {\"op\":\"update\",\"target_id\":<id>,\"new_content\":\"<updated fact>\",\"additional_source_ids\":[<ids>],\"confidence\":<0.0-1.0>}\n\
+         Return ONLY the JSON object, no explanation.";
 
-    let messages = vec![Message::from_legacy(Role::User, &prompt)];
+    let user_prompt = format!("Messages:\n{entries}");
+
+    let messages = vec![
+        Message::from_legacy(Role::System, system_prompt),
+        Message::from_legacy(Role::User, &user_prompt),
+    ];
     let text = match provider.chat(&messages).await {
         Ok(t) => t,
         Err(e) => {
@@ -918,20 +929,26 @@ mod tests {
             .expect("sweep must not error");
         assert_eq!(r.updates, 1);
 
-        // Verify the consolidated message exists in DB.
-        let consol_rows: Vec<(String, i64)> = zeph_db::query_as(sql!(
-            "SELECT content, consolidated FROM messages \
-             WHERE consolidated = 1 AND content = ?"
+        // Update is in-place: total row count must stay 2 (no new row inserted).
+        let total: (i64,) = zeph_db::query_as(sql!("SELECT COUNT(*) FROM messages"))
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+        assert_eq!(total.0, 2, "update must not insert a new row");
+
+        // The target row (m1) must have its content changed in-place.
+        let target_row: (String, i64) = zeph_db::query_as(sql!(
+            "SELECT content, consolidated FROM messages WHERE id = ?"
         ))
-        .bind(new_content)
-        .fetch_all(store.pool())
+        .bind(m1)
+        .fetch_one(store.pool())
         .await
         .unwrap();
         assert_eq!(
-            consol_rows.len(),
-            1,
-            "one consolidated message must be persisted"
+            target_row.0, new_content,
+            "target m1 content must be updated in-place"
         );
+        assert_eq!(target_row.1, 1, "target m1 must be marked consolidated=1");
 
         // Verify source m2 is marked consolidated (m2 was the additional_source_id).
         let source_row: (i64,) =

--- a/crates/zeph-memory/src/store/messages/mod.rs
+++ b/crates/zeph-memory/src/store/messages/mod.rs
@@ -1283,6 +1283,63 @@ impl SqliteStore {
         tx.commit().await?;
         Ok(true)
     }
+
+    /// Update an existing consolidated message in-place with new content.
+    ///
+    /// Atomically:
+    /// 1. Updates `content` and `consolidation_confidence` on `target_id`.
+    /// 2. Inserts rows into `memory_consolidation_sources` linking `target_id` → each source.
+    /// 3. Marks each source message's `consolidated = 1`.
+    ///
+    /// If `confidence < confidence_threshold` the operation is skipped and `false` is returned.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any database operation fails.
+    pub async fn apply_consolidation_update(
+        &self,
+        target_id: MessageId,
+        new_content: &str,
+        additional_source_ids: &[MessageId],
+        confidence: f32,
+        confidence_threshold: f32,
+    ) -> Result<bool, MemoryError> {
+        if confidence < confidence_threshold {
+            return Ok(false);
+        }
+
+        let mut tx = self.pool.begin().await?;
+
+        zeph_db::query(sql!(
+            "UPDATE messages SET content = ?, consolidation_confidence = ?, consolidated = 1 WHERE id = ?"
+        ))
+        .bind(new_content)
+        .bind(confidence)
+        .bind(target_id)
+        .execute(&mut *tx)
+        .await?;
+
+        let consol_sql = format!(
+            "{} INTO memory_consolidation_sources (consolidated_id, source_id) VALUES (?, ?){}",
+            <ActiveDialect as zeph_db::dialect::Dialect>::INSERT_IGNORE,
+            <ActiveDialect as zeph_db::dialect::Dialect>::CONFLICT_NOTHING,
+        );
+        for &source_id in additional_source_ids {
+            zeph_db::query(&consol_sql)
+                .bind(target_id)
+                .bind(source_id)
+                .execute(&mut *tx)
+                .await?;
+
+            zeph_db::query(sql!("UPDATE messages SET consolidated = 1 WHERE id = ?"))
+                .bind(source_id)
+                .execute(&mut *tx)
+                .await?;
+        }
+
+        tx.commit().await?;
+        Ok(true)
+    }
 }
 
 /// A candidate message for tier promotion, returned by [`SqliteStore::find_promotion_candidates`].

--- a/crates/zeph-memory/src/store/messages/tests.rs
+++ b/crates/zeph-memory/src/store/messages/tests.rs
@@ -1502,3 +1502,101 @@ fn garbage_json_returns_none_from_compat() {
     assert!(try_parse_legacy_parts(r#"{"not":"an array"}"#).is_none());
     assert!(try_parse_legacy_parts(r#"[{"UnknownVariant":{"x":"y"}}]"#).is_none());
 }
+
+// ── apply_consolidation_update in-place semantics (#2364) ────────────────────
+
+#[tokio::test]
+async fn apply_consolidation_update_in_place() {
+    let store = test_store().await;
+    let cid = store.create_conversation().await.unwrap();
+
+    let target = store
+        .save_message(cid, "user", "Alice uses Rust")
+        .await
+        .unwrap();
+    let source = store
+        .save_message(cid, "user", "Alice loves Rust")
+        .await
+        .unwrap();
+
+    let new_content = "Alice uses and loves Rust";
+    let accepted = store
+        .apply_consolidation_update(target, new_content, &[source], 0.9, 0.7)
+        .await
+        .unwrap();
+    assert!(
+        accepted,
+        "update must be accepted when confidence >= threshold"
+    );
+
+    // Target row must have content updated in-place — same row ID, new content.
+    let row: (i64, String, i64) = sqlx::query_as(sql!(
+        "SELECT id, content, consolidated FROM messages WHERE id = ?"
+    ))
+    .bind(target)
+    .fetch_one(store.pool())
+    .await
+    .unwrap();
+    assert_eq!(row.0, target.0, "row ID must not change (in-place update)");
+    assert_eq!(row.1, new_content, "content must be updated in-place");
+    assert_eq!(row.2, 1, "target must be marked consolidated=1");
+
+    // No new row must have been inserted — total message count stays 2.
+    let count: (i64,) = sqlx::query_as(sql!("SELECT COUNT(*) FROM messages"))
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+    assert_eq!(count.0, 2, "update must not insert a new row");
+
+    // Additional source must be marked consolidated=1.
+    let src_row: (i64,) = sqlx::query_as(sql!("SELECT consolidated FROM messages WHERE id = ?"))
+        .bind(source)
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+    assert_eq!(
+        src_row.0, 1,
+        "additional source must be marked consolidated=1"
+    );
+
+    // Join table must link target → source.
+    let join: (i64,) = sqlx::query_as(sql!(
+        "SELECT COUNT(*) FROM memory_consolidation_sources \
+         WHERE consolidated_id = ? AND source_id = ?"
+    ))
+    .bind(target)
+    .bind(source)
+    .fetch_one(store.pool())
+    .await
+    .unwrap();
+    assert_eq!(join.0, 1, "join table must record the target→source link");
+}
+
+#[tokio::test]
+async fn apply_consolidation_update_skips_below_threshold() {
+    let store = test_store().await;
+    let cid = store.create_conversation().await.unwrap();
+
+    let target = store.save_message(cid, "user", "fact").await.unwrap();
+    let source = store.save_message(cid, "user", "other fact").await.unwrap();
+
+    let accepted = store
+        .apply_consolidation_update(target, "combined", &[source], 0.3, 0.7)
+        .await
+        .unwrap();
+    assert!(
+        !accepted,
+        "update must be skipped when confidence < threshold"
+    );
+
+    // Content must remain unchanged.
+    let row: (String,) = sqlx::query_as(sql!("SELECT content FROM messages WHERE id = ?"))
+        .bind(target)
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+    assert_eq!(
+        row.0, "fact",
+        "content must not change when update is skipped"
+    );
+}


### PR DESCRIPTION
## Summary

- **#2362**: Split consolidation LLM prompt into `Role::System` (instructions) + `Role::User` (memory entries) — prevents adversarial memory content from influencing consolidation decisions
- **#2364**: `TopologyOp::Update` now performs an actual in-place `UPDATE messages SET content = ?` on `target_id` instead of re-using `apply_consolidation_merge`; `target_id` was previously ignored with `..`
- **#2365**: Consolidation sweep replaces sequential embed loop with `futures::future::join_all` for concurrent embedding — reduces latency for large batches

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings` — 0 warnings
- [x] `cargo nextest run --workspace --all-features --lib --bins` — 7235 passed (+2 new tests)
- [x] Updated `run_consolidation_sweep_update_db_state` to verify in-place semantics (no new row inserted, content changed on existing row)
- [x] Added `apply_consolidation_update_in_place` — verifies same row ID with updated content, join table entry, source marked consolidated=1
- [x] Added `apply_consolidation_update_skips_below_threshold` — verifies content unchanged when confidence < threshold

Closes #2362, #2364, #2365