### PR TITLE
feat(skills): semantic confusability mitigation — category grouping, two-stage matching (#2268)

### DIFF
--- a/.zeph/skills/api-request/SKILL.md
+++ b/.zeph/skills/api-request/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: api-request
+category: web
 description: >
   Send HTTP API requests using curl. Use when the user asks to call an API,
   fetch data from a URL, send POST/PUT/PATCH/DELETE requests, work with REST

--- a/.zeph/skills/archive/SKILL.md
+++ b/.zeph/skills/archive/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: archive
+category: system
 description: >
   Create, extract, list, and convert compressed archives using tar, zip, gzip,
   bzip2, xz, zstd, and 7z. Use when the user asks to compress files, extract

--- a/.zeph/skills/browser/SKILL.md
+++ b/.zeph/skills/browser/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: browser
+category: web
 description: >
   Browser automation via Playwright MCP — navigate pages, click elements,
   fill forms, take screenshots, extract text, manage tabs, and run

--- a/.zeph/skills/code-analysis/SKILL.md
+++ b/.zeph/skills/code-analysis/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: code-analysis
+category: dev
 description: >
   LSP-based code analysis via mcpls MCP server. Use for compiler-accurate type
   inspection, go-to-definition, find-all-references, diagnostics, call hierarchy,

--- a/.zeph/skills/cron/SKILL.md
+++ b/.zeph/skills/cron/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: cron
+category: system
 description: >
   Schedule recurring and one-time tasks using cron, crontab, at, and launchd.
   Use when the user asks to set up scheduled jobs, configure crontab entries,

--- a/.zeph/skills/database/SKILL.md
+++ b/.zeph/skills/database/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: database
+category: data
 description: >
   Query and manage SQLite, PostgreSQL, and MySQL databases from the command
   line. Use when the user asks to run SQL queries, inspect database schemas,

--- a/.zeph/skills/docker/SKILL.md
+++ b/.zeph/skills/docker/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: docker
+category: system
 description: >
   Manage Docker containers, images, volumes, networks, and Compose stacks.
   Use when the user asks to build, run, stop, restart, remove, inspect, or debug

--- a/.zeph/skills/file-ops/SKILL.md
+++ b/.zeph/skills/file-ops/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: file-ops
+category: system
 description: >
   File system operations — list directory contents, find files by name or glob
   pattern, search text inside files with grep or ripgrep, read and display file

--- a/.zeph/skills/git/SKILL.md
+++ b/.zeph/skills/git/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: git
+category: dev
 description: >
   Run git version control commands for repository management. Use when the user
   asks to check status, view history or diffs, stage and commit changes, manage

--- a/.zeph/skills/github/SKILL.md
+++ b/.zeph/skills/github/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: github
+category: dev
 description: >
   GitHub CLI (gh) for repository management, issues, pull requests, releases,
   workflows, search, gists, and API access. Use when the user asks about any

--- a/.zeph/skills/json-yaml/SKILL.md
+++ b/.zeph/skills/json-yaml/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: json-yaml
+category: data
 description: >
   Parse, query, transform, validate, and convert JSON and YAML data using jq
   and fy (fast-yaml). Use when the user asks to filter JSON arrays, extract

--- a/.zeph/skills/network/SKILL.md
+++ b/.zeph/skills/network/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: network
+category: web
 description: >
   Network diagnostics, DNS lookup, port scanning, and connectivity testing.
   Use when the user asks to check if a host is reachable, trace network routes,

--- a/.zeph/skills/os-automation/SKILL.md
+++ b/.zeph/skills/os-automation/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: os-automation
+category: system
 description: >
   Cross-platform OS automation — send desktop notifications, read and write
   the clipboard, take screenshots, open files and URLs in default apps,

--- a/.zeph/skills/process-management/SKILL.md
+++ b/.zeph/skills/process-management/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: process-management
+category: system
 description: >
   Monitor, manage, and control system processes. Use when the user asks to list
   running processes, find a process by name or PID, kill or terminate processes,

--- a/.zeph/skills/qdrant/SKILL.md
+++ b/.zeph/skills/qdrant/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: qdrant
+category: data
 description: >
   Manage Qdrant vector database via REST API. Use when the user asks to create
   or delete collections, upsert or search vectors, inspect points, filter by

--- a/.zeph/skills/regex/SKILL.md
+++ b/.zeph/skills/regex/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: regex
+category: data
 description: >
   Write, test, and debug regular expressions for pattern matching, search, and
   text extraction across programming languages. Use when the user asks to match

--- a/.zeph/skills/rust-agent-handoff/SKILL.md
+++ b/.zeph/skills/rust-agent-handoff/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: rust-agent-handoff
+category: dev
 description: >
   Handoff protocol for Rust multi-agent development system with structured YAML communication.
   Use when working as rust-architect, rust-developer, rust-testing-engineer,

--- a/.zeph/skills/scheduler/SKILL.md
+++ b/.zeph/skills/scheduler/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: scheduler
+category: system
 description: >
   Create, cancel, and manage periodic (cron) and one-shot (deferred) background tasks.
   Use when the user wants to schedule recurring work (daily summaries, cleanups),

--- a/.zeph/skills/setup-guide/SKILL.md
+++ b/.zeph/skills/setup-guide/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: setup-guide
+category: system
 description: >
   Zeph configuration reference for LLM providers, memory, tools, channels, and features.
   Use when the user asks about setup, configuration, environment variables, TOML settings,

--- a/.zeph/skills/skill-audit/SKILL.md
+++ b/.zeph/skills/skill-audit/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-audit
+category: dev
 description: >
   Audit installed skills for agentskills.io specification compliance and security issues.
   Use when the user asks to review, audit, check, validate, or lint skills,

--- a/.zeph/skills/skill-creator/SKILL.md
+++ b/.zeph/skills/skill-creator/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-creator
+category: dev
 description: >
   Create new Agent Skills following the agentskills.io specification.
   Use when the user asks to create, write, build, or generate a new skill,

--- a/.zeph/skills/ssh-remote/SKILL.md
+++ b/.zeph/skills/ssh-remote/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: ssh-remote
+category: system
 description: >
   Manage SSH connections, key management, remote command execution, tunneling,
   and file transfer with scp and rsync. Use when the user asks to connect to

--- a/.zeph/skills/system-info/SKILL.md
+++ b/.zeph/skills/system-info/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: system-info
+category: system
 description: >
   System diagnostics and resource monitoring — retrieve OS version and kernel
   info, check CPU load and core count, inspect memory and swap usage, analyze

--- a/.zeph/skills/text-processing/SKILL.md
+++ b/.zeph/skills/text-processing/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: text-processing
+category: data
 description: >
   Transform, filter, sort, and analyze text using sed, awk, sort, uniq, cut,
   tr, wc, and other text processing tools. Use when the user asks to find and

--- a/.zeph/skills/web-scrape/SKILL.md
+++ b/.zeph/skills/web-scrape/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: web-scrape
+category: web
 description: >
   Extract structured data from web pages using CSS selectors. Use when the user
   asks to scrape a website, extract text or links from a page, parse HTML

--- a/.zeph/skills/web-search/SKILL.md
+++ b/.zeph/skills/web-search/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: web-search
+category: web
 description: >
   Search the internet for current information using the DuckDuckGo Instant
   Answer API. Use when the user asks to find, look up, or search for something

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- feat(skills): add `category` field to SKILL.md frontmatter — optional grouping for skill library organisation; all 26 bundled skills annotated with categories (`web`, `data`, `dev`, `system`) (#2268)
+- feat(skills): `/skills` command now groups output by category when skills have `category` set; uncategorised skills appear under `[other]` (#2268)
+- feat(skills): `/skills confusability` — new command showing all skill pairs whose cosine similarity exceeds `[skills] confusability_threshold`; identifies disambiguation risk before library phase transition (#2268)
+- feat(skills): two-stage category-first skill matching — coarse category centroid selection followed by fine-grained within-category matching; enabled via `[skills] two_stage_matching = true`; singleton-category skills automatically fall back to uncategorised pool; inactive by default (#2268)
+- feat(skills): confusability report (`SkillMatcher::confusability_report`) — O(n²) pairwise cosine similarity with `spawn_blocking` offload; lists excluded skills whose embedding failed; disabled by default (`confusability_threshold = 0.0`) (#2268)
+
 ### Fixed
 
 - fix(memory): correct ESCAPE clause in spreading activation BFS alias query — `ESCAPE '\\\\'` (2 chars) changed to `ESCAPE '\\'` (1 char) as required by SQLite (closes #2393)

--- a/crates/zeph-config/src/features.rs
+++ b/crates/zeph-config/src/features.rs
@@ -127,6 +127,14 @@ pub struct SkillsConfig {
     pub trust: TrustConfig,
     #[serde(default)]
     pub prompt_mode: SkillPromptMode,
+    /// Enable two-stage category-first skill matching (requires `category` set in SKILL.md).
+    /// Falls back to flat matching when no multi-skill categories are available.
+    #[serde(default)]
+    pub two_stage_matching: bool,
+    /// Warn when any two skills have cosine similarity ≥ this threshold.
+    /// Set to 0.0 (default) to disable the confusability check entirely.
+    #[serde(default)]
+    pub confusability_threshold: f32,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -162,6 +162,8 @@ impl Default for Config {
                 learning: LearningConfig::default(),
                 trust: TrustConfig::default(),
                 prompt_mode: SkillPromptMode::Auto,
+                two_stage_matching: false,
+                confusability_threshold: 0.0,
             },
             memory: MemoryConfig {
                 sqlite_path: default_sqlite_path_field(),

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -1084,6 +1084,7 @@ impl<C: Channel> Agent<C> {
                     &all_meta,
                     query,
                     self.skill_state.max_active_skills,
+                    self.skill_state.two_stage_matching,
                     |text| {
                         let owned = text.to_owned();
                         let p = provider.clone();

--- a/crates/zeph-core/src/agent/context/tests.rs
+++ b/crates/zeph-core/src/agent/context/tests.rs
@@ -1639,6 +1639,7 @@ async fn disambiguate_skills_reorders_on_match() {
             skill_dir: std::path::PathBuf::new(),
             source_url: None,
             git_hash: None,
+            category: None,
         },
         SkillMeta {
             name: "beta_skill".into(),
@@ -1651,6 +1652,7 @@ async fn disambiguate_skills_reorders_on_match() {
             skill_dir: std::path::PathBuf::new(),
             source_url: None,
             git_hash: None,
+            category: None,
         },
     ];
     let refs: Vec<&SkillMeta> = metas.iter().collect();
@@ -1693,6 +1695,7 @@ async fn disambiguate_skills_returns_none_on_error() {
         skill_dir: std::path::PathBuf::new(),
         source_url: None,
         git_hash: None,
+        category: None,
     }];
     let refs: Vec<&SkillMeta> = metas.iter().collect();
     let scored = vec![ScoredMatch {
@@ -1745,6 +1748,7 @@ async fn disambiguate_skills_unknown_skill_preserves_order() {
             skill_dir: std::path::PathBuf::new(),
             source_url: None,
             git_hash: None,
+            category: None,
         },
         SkillMeta {
             name: "second".into(),
@@ -1757,6 +1761,7 @@ async fn disambiguate_skills_unknown_skill_preserves_order() {
             skill_dir: std::path::PathBuf::new(),
             source_url: None,
             git_hash: None,
+            category: None,
         },
     ];
     let refs: Vec<&SkillMeta> = metas.iter().collect();
@@ -1801,6 +1806,7 @@ async fn disambiguate_single_candidate_no_swap() {
         skill_dir: std::path::PathBuf::new(),
         source_url: None,
         git_hash: None,
+        category: None,
     }];
     let refs: Vec<&SkillMeta> = metas.iter().collect();
     let scored = vec![ScoredMatch {
@@ -1841,6 +1847,7 @@ async fn rebuild_system_prompt_excludes_skill_when_secret_missing() {
         skill_dir: std::path::PathBuf::new(),
         source_url: None,
         git_hash: None,
+        category: None,
     };
 
     // available_custom_secrets is empty — skill must be excluded
@@ -1893,6 +1900,7 @@ async fn rebuild_system_prompt_includes_skill_when_secret_present() {
         skill_dir: std::path::PathBuf::new(),
         source_url: None,
         git_hash: None,
+        category: None,
     };
 
     // Secret IS available
@@ -1949,6 +1957,7 @@ async fn rebuild_system_prompt_excludes_skill_when_only_partial_secrets_present(
         skill_dir: std::path::PathBuf::new(),
         source_url: None,
         git_hash: None,
+        category: None,
     };
 
     // Only "secret_a" present, "secret_b" missing — skill must be excluded.

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -342,6 +342,8 @@ impl<C: Channel> Agent<C> {
                 cosine_weight: 0.7,
                 hybrid_search: false,
                 bm25_index: None,
+                two_stage_matching: false,
+                confusability_threshold: 0.0,
             },
             context_manager: context_manager::ContextManager::new(),
             tool_orchestrator: tool_orchestrator::ToolOrchestrator::new(),
@@ -3130,8 +3132,9 @@ impl<C: Channel> Agent<C> {
             handled!(self.handle_guardrail_command().await);
         }
 
-        if trimmed == "/skills" {
-            handled!(self.handle_skills_command().await);
+        if trimmed == "/skills" || trimmed.starts_with("/skills ") {
+            let subcommand = trimmed.strip_prefix("/skills").unwrap_or("").trim();
+            handled!(self.handle_skills_family(subcommand).await);
         }
 
         if trimmed == "/skill" || trimmed.starts_with("/skill ") {
@@ -4046,10 +4049,24 @@ impl<C: Channel> Agent<C> {
         Ok(())
     }
 
-    async fn handle_skills_command(&mut self) -> Result<(), error::AgentError> {
-        use std::fmt::Write;
+    async fn handle_skills_family(&mut self, subcommand: &str) -> Result<(), error::AgentError> {
+        match subcommand {
+            "" => self.handle_skills_command().await,
+            "confusability" => self.handle_skills_confusability_command().await,
+            other => {
+                self.channel
+                    .send(&format!(
+                        "Unknown /skills subcommand: '{other}'. Available: confusability"
+                    ))
+                    .await?;
+                Ok(())
+            }
+        }
+    }
 
-        let mut output = String::from("Available skills:\n\n");
+    async fn handle_skills_command(&mut self) -> Result<(), error::AgentError> {
+        use std::collections::BTreeMap;
+        use std::fmt::Write;
 
         let all_meta: Vec<zeph_skills::loader::SkillMeta> = self
             .skill_state
@@ -4061,19 +4078,47 @@ impl<C: Channel> Agent<C> {
             .cloned()
             .collect();
 
+        // Collect trust info for all skills.
+        let mut trust_map: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
         for meta in &all_meta {
-            let trust_info = if let Some(memory) = &self.memory_state.memory {
-                memory
+            if let Some(memory) = &self.memory_state.memory {
+                let info = memory
                     .sqlite()
                     .load_skill_trust(&meta.name)
                     .await
                     .ok()
                     .flatten()
-                    .map_or_else(String::new, |r| format!(" [{}]", r.trust_level))
-            } else {
-                String::new()
-            };
-            let _ = writeln!(output, "- {} — {}{trust_info}", meta.name, meta.description);
+                    .map_or_else(String::new, |r| format!(" [{}]", r.trust_level));
+                trust_map.insert(meta.name.clone(), info);
+            }
+        }
+
+        let mut output = String::from("Available skills:\n\n");
+
+        // Group by category when any skill has one set.
+        let has_categories = all_meta.iter().any(|m| m.category.is_some());
+        if has_categories {
+            // BTreeMap for stable alphabetical category order.
+            let mut by_category: BTreeMap<&str, Vec<&zeph_skills::loader::SkillMeta>> =
+                BTreeMap::new();
+            for meta in &all_meta {
+                let cat = meta.category.as_deref().unwrap_or("other");
+                by_category.entry(cat).or_default().push(meta);
+            }
+            for (cat, skills) in &by_category {
+                let _ = writeln!(output, "[{cat}]");
+                for meta in skills {
+                    let trust_info = trust_map.get(&meta.name).map_or("", String::as_str);
+                    let _ = writeln!(output, "- {} — {}{trust_info}", meta.name, meta.description);
+                }
+                output.push('\n');
+            }
+        } else {
+            for meta in &all_meta {
+                let trust_info = trust_map.get(&meta.name).map_or("", String::as_str);
+                let _ = writeln!(output, "- {} — {}{trust_info}", meta.name, meta.description);
+            }
         }
 
         if let Some(memory) = &self.memory_state.memory {
@@ -4094,6 +4139,41 @@ impl<C: Channel> Agent<C> {
         }
 
         self.channel.send(&output).await?;
+        Ok(())
+    }
+
+    async fn handle_skills_confusability_command(&mut self) -> Result<(), error::AgentError> {
+        let threshold = self.skill_state.confusability_threshold;
+        if threshold <= 0.0 {
+            self.channel
+                .send(
+                    "Confusability monitoring is disabled. \
+                     Set [skills] confusability_threshold in config (e.g. 0.85) to enable.",
+                )
+                .await?;
+            return Ok(());
+        }
+
+        let Some(matcher) = &self.skill_state.matcher else {
+            self.channel
+                .send("Skill matcher not available (no embedding provider configured).")
+                .await?;
+            return Ok(());
+        };
+
+        let all_meta: Vec<zeph_skills::loader::SkillMeta> = self
+            .skill_state
+            .registry
+            .read()
+            .expect("registry read lock")
+            .all_meta()
+            .into_iter()
+            .cloned()
+            .collect();
+        let refs: Vec<&zeph_skills::loader::SkillMeta> = all_meta.iter().collect();
+
+        let report = matcher.confusability_report(&refs, threshold).await;
+        self.channel.send(&report.to_string()).await?;
         Ok(())
     }
 
@@ -4681,6 +4761,9 @@ impl<C: Channel> Agent<C> {
         self.skill_state.disambiguation_threshold = config.skills.disambiguation_threshold;
         self.skill_state.cosine_weight = config.skills.cosine_weight.clamp(0.0, 1.0);
         self.skill_state.hybrid_search = config.skills.hybrid_search;
+        self.skill_state.two_stage_matching = config.skills.two_stage_matching;
+        self.skill_state.confusability_threshold =
+            config.skills.confusability_threshold.clamp(0.0, 1.0);
 
         if config.memory.context_budget_tokens > 0 {
             self.context_manager.budget = Some(

--- a/crates/zeph-core/src/agent/slash_commands.rs
+++ b/crates/zeph-core/src/agent/slash_commands.rs
@@ -69,7 +69,14 @@ pub const COMMANDS: &[SlashCommandInfo] = &[
     SlashCommandInfo {
         name: "/skills",
         args: "",
-        description: "List loaded skills",
+        description: "List loaded skills (grouped by category when available)",
+        category: SlashCategory::Info,
+        feature_gate: None,
+    },
+    SlashCommandInfo {
+        name: "/skills confusability",
+        args: "",
+        description: "Show skill pairs with high embedding similarity (potential disambiguation failures)",
         category: SlashCategory::Info,
         feature_gate: None,
     },

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -83,6 +83,9 @@ pub(crate) struct SkillState {
     pub(crate) cosine_weight: f32,
     pub(crate) hybrid_search: bool,
     pub(crate) bm25_index: Option<zeph_skills::bm25::Bm25Index>,
+    pub(crate) two_stage_matching: bool,
+    /// Threshold for confusability warnings (0.0 = disabled).
+    pub(crate) confusability_threshold: f32,
 }
 
 pub(crate) struct McpState {

--- a/crates/zeph-llm/src/router/bandit.rs
+++ b/crates/zeph-llm/src/router/bandit.rs
@@ -501,7 +501,7 @@ mod tests {
         // After L2 normalisation ||x|| = 1, so UCB = alpha.
         let dim = 4;
         let arm = identity_arm(dim);
-        let x = vec![0.5f32, 0.5, 0.5, 0.5];
+        let x = [0.5f32, 0.5, 0.5, 0.5];
         let norm: f32 = x.iter().map(|v| v * v).sum::<f32>().sqrt();
         let x_norm: Vec<f32> = x.iter().map(|v| v / norm).collect();
         let alpha = 1.0f32;
@@ -519,7 +519,7 @@ mod tests {
         let score = arm.ucb_score(&x, 1.0);
         // Either None (if detected) or Some(NaN-based), but we normalise so should be None or invalid.
         // Our solve_linear will likely return a non-finite result → ucb_score returns None.
-        assert!(score.map_or(true, |s: f32| !s.is_finite()));
+        assert!(score.is_none_or(|s: f32| !s.is_finite()));
     }
 
     // ── Arm update ───────────────────────────────────────────────────────────
@@ -835,8 +835,8 @@ mod tests {
         state.update("zebra", &x, 0.5);
         state.update("apple", &x, 0.9);
         state.update("mango", &x, 0.3);
-        let stats = state.stats();
-        let names: Vec<&str> = stats.iter().map(|(n, _, _)| n.as_str()).collect();
+        let sorted = state.stats();
+        let names: Vec<&str> = sorted.iter().map(|(n, _, _)| n.as_str()).collect();
         assert_eq!(names, vec!["apple", "mango", "zebra"]);
     }
 }

--- a/crates/zeph-skills/src/loader.rs
+++ b/crates/zeph-skills/src/loader.rs
@@ -19,6 +19,8 @@ pub struct SkillMeta {
     pub source_url: Option<String>,
     /// Upstream git commit hash at install time (from `x-git-hash` frontmatter field).
     pub git_hash: Option<String>,
+    /// Optional category grouping (from `category` frontmatter field, e.g. "web", "data", "dev", "system").
+    pub category: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -84,6 +86,41 @@ struct RawFrontmatter {
     deprecated_requires_secrets: bool,
     source_url: Option<String>,
     git_hash: Option<String>,
+    category: Option<String>,
+}
+
+/// Validate a skill category name.
+///
+/// Rules (consistent with skill name validation, minus directory-match and length requirements):
+/// - 1–32 characters
+/// - Lowercase ASCII letters, digits, and hyphens only
+/// - No leading, trailing, or consecutive hyphens
+fn validate_category(category: &str) -> Result<(), SkillError> {
+    if category.is_empty() || category.len() > 32 {
+        return Err(SkillError::Invalid(format!(
+            "category must be 1-32 characters, got {}",
+            category.len()
+        )));
+    }
+    if !category
+        .bytes()
+        .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+    {
+        return Err(SkillError::Invalid(format!(
+            "category must contain only lowercase letters, digits, and hyphens: {category}"
+        )));
+    }
+    if category.starts_with('-') || category.ends_with('-') {
+        return Err(SkillError::Invalid(format!(
+            "category must not start or end with hyphen: {category}"
+        )));
+    }
+    if category.contains("--") {
+        return Err(SkillError::Invalid(format!(
+            "category must not contain consecutive hyphens: {category}"
+        )));
+    }
+    Ok(())
 }
 
 /// Detect whether `value` is a YAML block scalar indicator (`>` or `|`),
@@ -239,6 +276,14 @@ fn apply_field(raw: &mut RawFrontmatter, key: &str, value: String) {
                     .collect();
             }
         }
+        "category" => {
+            if !value.is_empty() {
+                match validate_category(&value) {
+                    Ok(()) => raw.category = Some(value),
+                    Err(e) => tracing::warn!("frontmatter key 'category': {e}"),
+                }
+            }
+        }
         "metadata" if value.is_empty() => {
             // Handled by caller — sets in_metadata flag.
         }
@@ -262,6 +307,7 @@ fn parse_frontmatter(yaml_str: &str) -> RawFrontmatter {
         deprecated_requires_secrets: false,
         source_url: None,
         git_hash: None,
+        category: None,
     };
     let mut in_metadata = false;
 
@@ -456,6 +502,7 @@ pub fn load_skill_meta(path: &Path) -> Result<SkillMeta, SkillError> {
         skill_dir,
         source_url: raw.source_url,
         git_hash: raw.git_hash,
+        category: raw.category,
     })
 }
 
@@ -1260,5 +1307,75 @@ mod tests {
         let raw = parse_frontmatter(yaml);
         assert!(raw.source_url.is_none());
         assert!(raw.git_hash.is_none());
+    }
+
+    #[test]
+    fn category_valid_stored_on_meta() {
+        let raw = parse_frontmatter("category: web\n");
+        assert_eq!(raw.category.as_deref(), Some("web"));
+    }
+
+    #[test]
+    fn category_with_digits_and_hyphens_valid() {
+        let raw = parse_frontmatter("category: data-v2\n");
+        assert_eq!(raw.category.as_deref(), Some("data-v2"));
+    }
+
+    #[test]
+    fn category_too_long_ignored() {
+        let long = "a".repeat(33);
+        let yaml = format!("category: {long}\n");
+        let raw = parse_frontmatter(&yaml);
+        assert!(raw.category.is_none());
+    }
+
+    #[test]
+    fn category_exactly_32_chars_valid() {
+        let exactly = "a".repeat(32);
+        let yaml = format!("category: {exactly}\n");
+        let raw = parse_frontmatter(&yaml);
+        assert!(raw.category.is_some());
+    }
+
+    #[test]
+    fn category_uppercase_rejected() {
+        let raw = parse_frontmatter("category: Web\n");
+        assert!(raw.category.is_none());
+    }
+
+    #[test]
+    fn category_leading_hyphen_rejected() {
+        let raw = parse_frontmatter("category: -web\n");
+        assert!(raw.category.is_none());
+    }
+
+    #[test]
+    fn category_trailing_hyphen_rejected() {
+        let raw = parse_frontmatter("category: web-\n");
+        assert!(raw.category.is_none());
+    }
+
+    #[test]
+    fn category_consecutive_hyphens_rejected() {
+        let raw = parse_frontmatter("category: web--tools\n");
+        assert!(raw.category.is_none());
+    }
+
+    #[test]
+    fn category_empty_value_produces_none() {
+        let raw = parse_frontmatter("category: \n");
+        assert!(raw.category.is_none());
+    }
+
+    #[test]
+    fn category_stored_on_loaded_skill_meta() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_skill(
+            dir.path(),
+            "my-skill",
+            "---\nname: my-skill\ndescription: A test skill.\ncategory: dev\n---\nbody",
+        );
+        let meta = load_skill_meta(&path).unwrap();
+        assert_eq!(meta.category.as_deref(), Some("dev"));
     }
 }

--- a/crates/zeph-skills/src/matcher.rs
+++ b/crates/zeph-skills/src/matcher.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use std::collections::HashMap;
+use std::fmt;
 use std::time::Duration;
 
 use schemars::JsonSchema;
@@ -27,9 +28,156 @@ pub struct IntentClassification {
     pub params: HashMap<String, String>,
 }
 
+/// A pair of skills with similar embeddings.
+#[derive(Debug, Clone)]
+pub struct ConfusabilityPair {
+    pub skill_a: String,
+    pub skill_b: String,
+    pub similarity: f32,
+}
+
+/// Report of all skill pairs whose cosine similarity exceeds a threshold.
+#[derive(Debug, Clone)]
+pub struct ConfusabilityReport {
+    /// Pairs sorted descending by similarity.
+    pub pairs: Vec<ConfusabilityPair>,
+    pub threshold: f32,
+    /// Skills excluded from the report because their embedding failed.
+    pub excluded_skills: Vec<String>,
+}
+
+impl fmt::Display for ConfusabilityReport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.pairs.is_empty() {
+            write!(
+                f,
+                "No confusable skill pairs found above {:.2}.",
+                self.threshold
+            )?;
+        } else {
+            writeln!(
+                f,
+                "Confusability report (threshold: {:.2}):",
+                self.threshold
+            )?;
+            for pair in &self.pairs {
+                writeln!(
+                    f,
+                    "  {} \u{2194} {}: {:.3}",
+                    pair.skill_a, pair.skill_b, pair.similarity
+                )?;
+            }
+        }
+        if !self.excluded_skills.is_empty() {
+            write!(
+                f,
+                "\nNote: {} skill(s) excluded (embedding unavailable): {}",
+                self.excluded_skills.len(),
+                self.excluded_skills.join(", ")
+            )?;
+        }
+        Ok(())
+    }
+}
+
+/// Category-aware index for two-stage skill matching.
+///
+/// Categories with fewer than 2 embedded skills are treated as uncategorized
+/// (their skills always enter Stage 2 directly) to prevent Stage 1 from
+/// accidentally excluding singleton-category skills.
+#[derive(Debug, Clone)]
+struct CategoryMatcher {
+    /// Category name → embedding positions (index into `SkillMatcher::embeddings`).
+    /// Only categories with ≥ 2 embedded skills are stored here.
+    categories: HashMap<String, Vec<usize>>,
+    /// Centroid embedding per category.
+    centroids: HashMap<String, Vec<f32>>,
+    /// Embedding positions for uncategorized skills or singleton-category skills.
+    uncategorized: Vec<usize>,
+}
+
+impl CategoryMatcher {
+    /// Build from completed embeddings. `skills` is the original skill slice passed to
+    /// `SkillMatcher::new`; `embeddings` is the successful subset.
+    fn build(skills: &[&SkillMeta], embeddings: &[(usize, Vec<f32>)]) -> Self {
+        // Group embedding positions by category.
+        let mut by_category: HashMap<String, Vec<usize>> = HashMap::new();
+        let mut uncategorized: Vec<usize> = Vec::new();
+
+        for (pos, (skill_idx, _)) in embeddings.iter().enumerate() {
+            match skills[*skill_idx].category.as_deref() {
+                Some(cat) => by_category.entry(cat.to_string()).or_default().push(pos),
+                None => uncategorized.push(pos),
+            }
+        }
+
+        // Promote singleton categories to uncategorized.
+        let mut categories: HashMap<String, Vec<usize>> = HashMap::new();
+        for (cat, positions) in by_category {
+            if positions.len() >= 2 {
+                categories.insert(cat, positions);
+            } else {
+                uncategorized.extend(positions);
+            }
+        }
+
+        // Compute centroids for multi-skill categories.
+        let mut centroids: HashMap<String, Vec<f32>> = HashMap::new();
+        for (cat, positions) in &categories {
+            let dim = embeddings[positions[0]].1.len();
+            let mut centroid = vec![0.0f32; dim];
+            for &pos in positions {
+                for (c, v) in centroid.iter_mut().zip(embeddings[pos].1.iter()) {
+                    *c += v;
+                }
+            }
+            #[allow(clippy::cast_precision_loss)]
+            let n = positions.len() as f32;
+            for c in &mut centroid {
+                *c /= n;
+            }
+            centroids.insert(cat.clone(), centroid);
+        }
+
+        Self {
+            categories,
+            centroids,
+            uncategorized,
+        }
+    }
+
+    /// Whether two-stage matching is useful (≥2 categories with ≥2 skills each).
+    fn is_useful(&self) -> bool {
+        self.categories.len() >= 2
+    }
+
+    /// Return embedding positions in the Stage 2 candidate pool for the given query.
+    /// Selects top-2 categories by centroid cosine similarity, plus all uncategorized.
+    fn candidate_positions(&self, query_vec: &[f32]) -> Vec<usize> {
+        // Score categories by centroid similarity.
+        let mut cat_scores: Vec<(&str, f32)> = self
+            .centroids
+            .iter()
+            .map(|(cat, centroid)| (cat.as_str(), cosine_similarity(query_vec, centroid)))
+            .collect();
+        cat_scores
+            .sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+        let mut positions: Vec<usize> = self.uncategorized.clone();
+        for (cat, _) in cat_scores.iter().take(2) {
+            if let Some(cat_positions) = self.categories.get(*cat) {
+                positions.extend_from_slice(cat_positions);
+            }
+        }
+        positions
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct SkillMatcher {
     embeddings: Vec<(usize, Vec<f32>)>,
+    /// Populated when at least 2 multi-skill categories exist.
+    category_matcher: Option<CategoryMatcher>,
 }
 
 impl SkillMatcher {
@@ -95,11 +243,22 @@ impl SkillMatcher {
             return None;
         }
 
-        Some(Self { embeddings })
+        let category_matcher = {
+            let cm = CategoryMatcher::build(skills, &embeddings);
+            if cm.is_useful() { Some(cm) } else { None }
+        };
+
+        Some(Self {
+            embeddings,
+            category_matcher,
+        })
     }
 
     /// Match a user query against stored skill embeddings, returning the top-K scored matches
     /// ranked by cosine similarity.
+    ///
+    /// When `two_stage` is true and a [`CategoryMatcher`] is available, uses category-first
+    /// filtering before fine-grained matching. Falls back to flat matching otherwise.
     ///
     /// Returns an empty vec if the query embedding fails.
     pub async fn match_skills<F>(
@@ -107,6 +266,7 @@ impl SkillMatcher {
         count: usize,
         query: &str,
         limit: usize,
+        two_stage: bool,
         embed_fn: F,
     ) -> Vec<ScoredMatch>
     where
@@ -125,14 +285,32 @@ impl SkillMatcher {
             }
         };
 
-        let mut scored: Vec<ScoredMatch> = self
-            .embeddings
-            .iter()
-            .map(|(idx, emb)| ScoredMatch {
-                index: *idx,
-                score: cosine_similarity(&query_vec, emb),
-            })
-            .collect();
+        // Two-stage: restrict candidate pool to top-2 categories + uncategorized.
+        let candidate_positions: Option<Vec<usize>> = if two_stage {
+            self.category_matcher
+                .as_ref()
+                .map(|cm| cm.candidate_positions(&query_vec))
+        } else {
+            None
+        };
+
+        let mut scored: Vec<ScoredMatch> = match candidate_positions {
+            Some(positions) => positions
+                .iter()
+                .map(|&pos| ScoredMatch {
+                    index: self.embeddings[pos].0,
+                    score: cosine_similarity(&query_vec, &self.embeddings[pos].1),
+                })
+                .collect(),
+            None => self
+                .embeddings
+                .iter()
+                .map(|(idx, emb)| ScoredMatch {
+                    index: *idx,
+                    score: cosine_similarity(&query_vec, emb),
+                })
+                .collect(),
+        };
 
         scored.sort_unstable_by(|a, b| {
             b.score
@@ -142,6 +320,52 @@ impl SkillMatcher {
         scored.truncate(limit);
 
         scored
+    }
+
+    /// Compute pairwise cosine similarity for all skill pairs with successful embeddings.
+    ///
+    /// Returns pairs where similarity ≥ `threshold`, sorted descending. Skills that failed
+    /// to embed are listed in [`ConfusabilityReport::excluded_skills`].
+    ///
+    /// This is an O(n²) operation. For large skill libraries, call from a blocking context.
+    #[must_use]
+    pub fn confusability_report(
+        &self,
+        skills: &[&SkillMeta],
+        threshold: f32,
+    ) -> ConfusabilityReport {
+        let embedded_indices: std::collections::HashSet<usize> =
+            self.embeddings.iter().map(|(i, _)| *i).collect();
+        let excluded_skills: Vec<String> = skills
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| !embedded_indices.contains(i))
+            .map(|(_, m)| m.name.clone())
+            .collect();
+
+        let mut pairs = Vec::new();
+        for i in 0..self.embeddings.len() {
+            for j in (i + 1)..self.embeddings.len() {
+                let sim = cosine_similarity(&self.embeddings[i].1, &self.embeddings[j].1);
+                if sim >= threshold {
+                    pairs.push(ConfusabilityPair {
+                        skill_a: skills[self.embeddings[i].0].name.clone(),
+                        skill_b: skills[self.embeddings[j].0].name.clone(),
+                        similarity: sim,
+                    });
+                }
+            }
+        }
+        pairs.sort_unstable_by(|a, b| {
+            b.similarity
+                .partial_cmp(&a.similarity)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        ConfusabilityReport {
+            pairs,
+            threshold,
+            excluded_skills,
+        }
     }
 }
 
@@ -165,14 +389,54 @@ impl SkillMatcherBackend {
         meta: &[&SkillMeta],
         query: &str,
         limit: usize,
+        two_stage: bool,
         embed_fn: F,
     ) -> Vec<ScoredMatch>
     where
         F: Fn(&str) -> EmbedFuture,
     {
         match self {
-            Self::InMemory(m) => m.match_skills(meta.len(), query, limit, embed_fn).await,
+            Self::InMemory(m) => {
+                m.match_skills(meta.len(), query, limit, two_stage, embed_fn)
+                    .await
+            }
             Self::Qdrant(m) => m.match_skills(meta, query, limit, embed_fn).await,
+        }
+    }
+
+    /// Compute the confusability report for the in-memory matcher.
+    ///
+    /// Offloads the O(n²) computation to a blocking thread pool to avoid stalling the
+    /// async runtime. Returns an empty report for the Qdrant backend.
+    pub async fn confusability_report(
+        &self,
+        meta: &[&SkillMeta],
+        threshold: f32,
+    ) -> ConfusabilityReport {
+        match self {
+            Self::InMemory(m) => {
+                let matcher = m.clone();
+                let meta_owned: Vec<crate::loader::SkillMeta> =
+                    meta.iter().map(|m| (*m).clone()).collect();
+                tokio::task::spawn_blocking(move || {
+                    let refs: Vec<&SkillMeta> = meta_owned.iter().collect();
+                    matcher.confusability_report(&refs, threshold)
+                })
+                .await
+                .unwrap_or_else(|e| {
+                    tracing::warn!("confusability_report task panicked: {e}");
+                    ConfusabilityReport {
+                        pairs: vec![],
+                        threshold,
+                        excluded_skills: vec![],
+                    }
+                })
+            }
+            Self::Qdrant(_) => ConfusabilityReport {
+                pairs: vec![],
+                threshold,
+                excluded_skills: vec![],
+            },
         }
     }
 
@@ -223,6 +487,23 @@ mod tests {
             skill_dir: PathBuf::new(),
             source_url: None,
             git_hash: None,
+            category: None,
+        }
+    }
+
+    fn make_meta_with_category(name: &str, description: &str, category: &str) -> SkillMeta {
+        SkillMeta {
+            name: name.into(),
+            description: description.into(),
+            compatibility: None,
+            license: None,
+            metadata: Vec::new(),
+            allowed_tools: Vec::new(),
+            requires_secrets: Vec::new(),
+            skill_dir: PathBuf::new(),
+            source_url: None,
+            git_hash: None,
+            category: Some(category.into()),
         }
     }
 
@@ -258,7 +539,7 @@ mod tests {
 
         let skill_matcher = SkillMatcher::new(&refs, embed_fn_mapping).await.unwrap();
         let match_results = skill_matcher
-            .match_skills(refs.len(), "query", 2, embed_fn_mapping)
+            .match_skills(refs.len(), "query", 2, false, embed_fn_mapping)
             .await;
 
         assert_eq!(match_results.len(), 2);
@@ -281,7 +562,7 @@ mod tests {
 
         let skill_matcher = SkillMatcher::new(&refs, embed_fn_constant).await.unwrap();
         let match_results = skill_matcher
-            .match_skills(refs.len(), "query", 5, embed_fn_constant)
+            .match_skills(refs.len(), "query", 5, false, embed_fn_constant)
             .await;
 
         assert_eq!(match_results.len(), 1);
@@ -392,7 +673,7 @@ mod tests {
 
         let skill_matcher = SkillMatcher::new(&refs, embed_fn_constant).await.unwrap();
         let match_results = skill_matcher
-            .match_skills(refs.len(), "query", 100, embed_fn_constant)
+            .match_skills(refs.len(), "query", 100, false, embed_fn_constant)
             .await;
 
         assert_eq!(match_results.len(), 2);
@@ -405,7 +686,7 @@ mod tests {
 
         let skill_matcher = SkillMatcher::new(&refs, embed_fn_constant).await.unwrap();
         let match_results = skill_matcher
-            .match_skills(refs.len(), "query", 5, embed_fn_fail)
+            .match_skills(refs.len(), "query", 5, false, embed_fn_fail)
             .await;
 
         assert!(match_results.is_empty());
@@ -447,7 +728,7 @@ mod tests {
 
         let skill_matcher = SkillMatcher::new(&refs, embed_fn_constant).await.unwrap();
         let match_results = skill_matcher
-            .match_skills(refs.len(), "query", 0, embed_fn_constant)
+            .match_skills(refs.len(), "query", 0, false, embed_fn_constant)
             .await;
 
         assert!(match_results.is_empty());
@@ -464,7 +745,7 @@ mod tests {
 
         let skill_matcher = SkillMatcher::new(&refs, embed_fn_mapping).await.unwrap();
         let match_results = skill_matcher
-            .match_skills(refs.len(), "query", 3, embed_fn_mapping)
+            .match_skills(refs.len(), "query", 3, false, embed_fn_mapping)
             .await;
 
         assert_eq!(match_results.len(), 3);
@@ -475,6 +756,7 @@ mod tests {
     fn matcher_backend_in_memory_is_not_qdrant() {
         let matcher = SkillMatcher {
             embeddings: vec![(0, vec![1.0, 0.0])],
+            category_matcher: None,
         };
         let backend = SkillMatcherBackend::InMemory(matcher);
         assert!(!backend.is_qdrant());
@@ -482,7 +764,10 @@ mod tests {
 
     #[tokio::test]
     async fn backend_in_memory_sync_is_noop() {
-        let matcher = SkillMatcher { embeddings: vec![] };
+        let matcher = SkillMatcher {
+            embeddings: vec![],
+            category_matcher: None,
+        };
         let mut backend = SkillMatcherBackend::InMemory(matcher);
         let metas: Vec<&SkillMeta> = vec![];
         let result = backend.sync(&metas, "model", embed_fn_constant).await;
@@ -497,7 +782,7 @@ mod tests {
         let inner = SkillMatcher::new(&refs, embed_fn_constant).await.unwrap();
         let backend = SkillMatcherBackend::InMemory(inner);
         let matches = backend
-            .match_skills(&refs, "query", 5, embed_fn_constant)
+            .match_skills(&refs, "query", 5, false, embed_fn_constant)
             .await;
         assert_eq!(matches.len(), 2);
     }
@@ -506,6 +791,7 @@ mod tests {
     fn matcher_debug() {
         let matcher = SkillMatcher {
             embeddings: vec![(0, vec![1.0])],
+            category_matcher: None,
         };
         let dbg = format!("{matcher:?}");
         assert!(dbg.contains("SkillMatcher"));
@@ -513,7 +799,10 @@ mod tests {
 
     #[test]
     fn backend_debug() {
-        let matcher = SkillMatcher { embeddings: vec![] };
+        let matcher = SkillMatcher {
+            embeddings: vec![],
+            category_matcher: None,
+        };
         let backend = SkillMatcherBackend::InMemory(matcher);
         let dbg = format!("{backend:?}");
         assert!(dbg.contains("InMemory"));
@@ -621,7 +910,7 @@ mod tests {
 
         let skill_matcher = SkillMatcher::new(&refs, embed_fn_mapping).await.unwrap();
         let match_results = skill_matcher
-            .match_skills(refs.len(), "query", 2, embed_fn_mapping)
+            .match_skills(refs.len(), "query", 2, false, embed_fn_mapping)
             .await;
 
         assert_eq!(match_results.len(), 2);
@@ -651,5 +940,205 @@ mod tests {
                 assert!((-1.01..=1.01).contains(&result), "got {result}");
             }
         }
+    }
+
+    #[tokio::test]
+    async fn two_stage_matching_uses_categories() {
+        // Skills: 2 "web" + 2 "data", query matches "web" category.
+        let metas = [
+            make_meta_with_category("web-a", "alpha", "web"),
+            make_meta_with_category("web-b", "beta", "web"),
+            make_meta_with_category("data-a", "gamma", "data"),
+            make_meta_with_category("data-b", "delta", "data"),
+        ];
+        let refs: Vec<&SkillMeta> = metas.iter().collect();
+        let matcher = SkillMatcher::new(&refs, embed_fn_mapping).await.unwrap();
+        // Two-stage should still return results (not crash or empty).
+        let results = matcher
+            .match_skills(refs.len(), "query", 4, true, embed_fn_mapping)
+            .await;
+        assert!(!results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn two_stage_falls_back_when_no_categories() {
+        // All skills without category → two-stage falls back to flat.
+        let metas = [make_meta("a", "alpha"), make_meta("b", "beta")];
+        let refs: Vec<&SkillMeta> = metas.iter().collect();
+        let matcher = SkillMatcher::new(&refs, embed_fn_mapping).await.unwrap();
+        // category_matcher is None when <2 multi-skill categories.
+        assert!(matcher.category_matcher.is_none());
+        let results = matcher
+            .match_skills(refs.len(), "query", 2, true, embed_fn_mapping)
+            .await;
+        assert_eq!(results.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn two_stage_singleton_category_goes_to_uncategorized() {
+        // One category with 1 skill, one with 2 → singleton is uncategorized.
+        let metas = [
+            make_meta_with_category("lone", "alpha", "solo"),
+            make_meta_with_category("pair-a", "beta", "pair"),
+            make_meta_with_category("pair-b", "gamma", "pair"),
+        ];
+        let refs: Vec<&SkillMeta> = metas.iter().collect();
+        let matcher = SkillMatcher::new(&refs, embed_fn_mapping).await.unwrap();
+        // Only 1 multi-skill category ("pair") → category_matcher is None (not useful).
+        assert!(matcher.category_matcher.is_none());
+    }
+
+    #[test]
+    fn confusability_report_empty_when_threshold_high() {
+        let matcher = SkillMatcher {
+            embeddings: vec![(0, vec![1.0, 0.0]), (1, vec![0.0, 1.0])],
+            category_matcher: None,
+        };
+        let metas = [make_meta("a", "alpha"), make_meta("b", "beta")];
+        let refs: Vec<&SkillMeta> = metas.iter().collect();
+        let report = matcher.confusability_report(&refs, 0.99);
+        assert!(report.pairs.is_empty());
+        assert!(report.excluded_skills.is_empty());
+    }
+
+    #[test]
+    fn confusability_report_finds_similar_pair() {
+        let v = vec![1.0_f32, 0.0, 0.0];
+        let matcher = SkillMatcher {
+            embeddings: vec![(0, v.clone()), (1, v)],
+            category_matcher: None,
+        };
+        let metas = [make_meta("a", "alpha"), make_meta("b", "beta")];
+        let refs: Vec<&SkillMeta> = metas.iter().collect();
+        let report = matcher.confusability_report(&refs, 0.9);
+        assert_eq!(report.pairs.len(), 1);
+        assert!((report.pairs[0].similarity - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn confusability_report_tracks_excluded_skills() {
+        // embeddings only contains index 0; index 1 has no embedding.
+        let matcher = SkillMatcher {
+            embeddings: vec![(0, vec![1.0, 0.0])],
+            category_matcher: None,
+        };
+        let metas = [make_meta("a", "alpha"), make_meta("b", "beta")];
+        let refs: Vec<&SkillMeta> = metas.iter().collect();
+        let report = matcher.confusability_report(&refs, 0.5);
+        assert_eq!(report.excluded_skills, vec!["b".to_string()]);
+    }
+
+    #[test]
+    fn confusability_report_display_clean() {
+        let report = ConfusabilityReport {
+            pairs: vec![],
+            threshold: 0.85,
+            excluded_skills: vec![],
+        };
+        let s = report.to_string();
+        assert!(s.contains("0.85"));
+    }
+
+    #[test]
+    fn confusability_report_display_with_pairs() {
+        let report = ConfusabilityReport {
+            pairs: vec![ConfusabilityPair {
+                skill_a: "web-search".into(),
+                skill_b: "web-scrape".into(),
+                similarity: 0.91,
+            }],
+            threshold: 0.85,
+            excluded_skills: vec![],
+        };
+        let s = report.to_string();
+        assert!(s.contains("web-search"));
+        assert!(s.contains("web-scrape"));
+        assert!(s.contains("0.910"));
+    }
+
+    #[test]
+    fn confusability_report_display_with_excluded_skills() {
+        let report = ConfusabilityReport {
+            pairs: vec![],
+            threshold: 0.85,
+            excluded_skills: vec!["embed-failed".to_string(), "timeout-skill".to_string()],
+        };
+        let s = report.to_string();
+        assert!(s.contains("embed-failed"));
+        assert!(s.contains("timeout-skill"));
+        assert!(s.contains("2 skill(s) excluded"));
+    }
+
+    #[test]
+    fn confusability_report_display_with_pairs_and_excluded() {
+        let report = ConfusabilityReport {
+            pairs: vec![ConfusabilityPair {
+                skill_a: "web-search".into(),
+                skill_b: "web-scrape".into(),
+                similarity: 0.91,
+            }],
+            threshold: 0.85,
+            excluded_skills: vec!["no-embed".to_string()],
+        };
+        let s = report.to_string();
+        assert!(s.contains("web-search"));
+        assert!(s.contains("no-embed"));
+        assert!(s.contains("1 skill(s) excluded"));
+    }
+
+    #[tokio::test]
+    async fn two_stage_category_matcher_is_some_with_two_categories() {
+        let metas = [
+            make_meta_with_category("web-a", "alpha", "web"),
+            make_meta_with_category("web-b", "beta", "web"),
+            make_meta_with_category("data-a", "gamma", "data"),
+            make_meta_with_category("data-b", "delta", "data"),
+        ];
+        let refs: Vec<&SkillMeta> = metas.iter().collect();
+        let matcher = SkillMatcher::new(&refs, embed_fn_mapping).await.unwrap();
+        assert!(
+            matcher.category_matcher.is_some(),
+            "expected CategoryMatcher with 2 multi-skill categories"
+        );
+    }
+
+    #[tokio::test]
+    async fn two_stage_mixed_categorized_and_uncategorized_single_category() {
+        // 2 skills in one category + 1 uncategorized → only 1 multi-skill category → not useful.
+        let metas = [
+            make_meta_with_category("web-a", "alpha", "web"),
+            make_meta_with_category("web-b", "beta", "web"),
+            make_meta("no-cat", "gamma"),
+        ];
+        let refs: Vec<&SkillMeta> = metas.iter().collect();
+        let matcher = SkillMatcher::new(&refs, embed_fn_mapping).await.unwrap();
+        assert!(
+            matcher.category_matcher.is_none(),
+            "only 1 multi-skill category is not useful for two-stage"
+        );
+    }
+
+    #[tokio::test]
+    async fn two_stage_result_count_within_flat_count() {
+        let metas = [
+            make_meta_with_category("web-a", "alpha", "web"),
+            make_meta_with_category("web-b", "beta", "web"),
+            make_meta_with_category("data-a", "gamma", "data"),
+            make_meta_with_category("data-b", "delta", "data"),
+        ];
+        let refs: Vec<&SkillMeta> = metas.iter().collect();
+        let matcher = SkillMatcher::new(&refs, embed_fn_mapping).await.unwrap();
+
+        let flat = matcher
+            .match_skills(refs.len(), "alpha", 4, false, embed_fn_mapping)
+            .await;
+        let two = matcher
+            .match_skills(refs.len(), "alpha", 4, true, embed_fn_mapping)
+            .await;
+
+        // Top result must be the same regardless of strategy.
+        assert_eq!(flat[0].index, two[0].index);
+        // Two-stage must not return more results than flat.
+        assert!(two.len() <= flat.len());
     }
 }

--- a/crates/zeph-skills/src/prompt.rs
+++ b/crates/zeph-skills/src/prompt.rs
@@ -220,6 +220,7 @@ mod tests {
                 skill_dir: PathBuf::new(),
                 source_url: None,
                 git_hash: None,
+                category: None,
             },
             body: body.into(),
         }
@@ -238,6 +239,7 @@ mod tests {
                 skill_dir: dir,
                 source_url: None,
                 git_hash: None,
+                category: None,
             },
             body: body.into(),
         }

--- a/crates/zeph-skills/src/qdrant_matcher.rs
+++ b/crates/zeph-skills/src/qdrant_matcher.rs
@@ -159,6 +159,7 @@ mod tests {
             skill_dir: PathBuf::new(),
             source_url: None,
             git_hash: None,
+            category: None,
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds `category` field to SKILL.md frontmatter (strict validation: 1-32 chars, `[a-z0-9-]`, no leading/trailing/consecutive hyphens)
- Categorizes all 26 bundled skills across `web`, `data`, `dev`, `system`
- Implements `CategoryMatcher` for two-stage matching: Stage 1 selects top-2 categories by centroid similarity, Stage 2 does fine-grained matching within the candidate pool — mitigates phase-transition degradation as library grows
- Adds `SkillMatcher::confusability_report()` — O(n²) pairwise cosine similarity offloaded to blocking thread, with configurable threshold
- Adds `/skills confusability` slash command surfacing confusable pairs (disabled by default: `confusability_threshold = 0.0`)
- Groups `/skills` output by category in alphabetical order via BTreeMap
- Wires `two_stage_matching` and `confusability_threshold` config fields in `[skills]` TOML section
- Fixes three pre-existing clippy warnings in `bandit.rs` (binding shadowing, map_or, useless vec!)
- Adds 20 new tests: `validate_category` validation boundaries, `CategoryMatcher` build/is_useful/candidate_positions, `ConfusabilityReport::Display` excluded skills branch, two-stage correctness and result count invariant

## Motivation

arXiv:2601.04748 shows skill selection accuracy degrades sharply past a critical library size due to semantic confusability — not library size alone. This PR adds the three mitigations described in issue #2268: category field (SHORT), two-stage matching (MEDIUM), and confusability monitoring (MONITORING).

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` — 6705/6705 passed
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean
- [ ] Security audit: all 5 areas PASS (no injection, no prompt leakage, safe numerics)
- [ ] Post-impl adversarial critique: **minor** verdict (no significant/critical gaps)
- [ ] Validate `/skills` shows grouped output with category headers
- [ ] Validate `/skills confusability` works when `confusability_threshold > 0` in config