### PR TITLE
fix(acp): populate authMethods, add /agent.json endpoint, eliminate IPI duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - fix(memory): use `wait=true` on Qdrant upsert to eliminate testcontainer timing race — points are now indexed and queryable immediately after `upsert` returns (closes #2413)
+- fix(acp): populate `authMethods` in `initialize` response with `Agent` auth method — ACP clients now receive `[{type: "agent", id: "zeph", name: "Zeph"}]` in the `authMethods` field of every `InitializeResponse` (closes #2422)
+- fix(acp): serve agent identity manifest at `GET /agent.json` — new endpoint gated on `discovery_enabled`, returns `id`, `name`, `version`, `description`, and `distribution` fields for ACP Registry discovery (closes #2422)
+- fix(acp): eliminate IPI wiring duplication in `acp.rs` `spawn_acp_agent` — extract `apply_three_class_classifier_with_cfg` and `apply_causal_analyzer_with_cfg` helpers in `agent_setup.rs`; `spawn_acp_agent` now delegates to shared helpers instead of inlining classifier construction (closes #2370)
+- fix(acp): discovery endpoint already reflects `ProtocolVersion::LATEST` — confirmed fixed in PR #2423; no code change required (#2412)
 
 ### Added (tests)
 
 - test(core): add `multi_layer_before_after_tool_ordering` — verifies both layers are called in FIFO order for `before_tool` and `after_tool` (#2361)
-
 - fix(classifiers): sha2 0.11 hex formatting — replace `format!("{:x}", ...)` with `hex::encode(...)` in `verify_sha256` and its test helper (#2401)
 - fix(deps): bump sha2 0.10→0.11, ordered-float 5.1→5.3, proptest 1.10→1.11, toml 1.0→1.1, uuid 1.22→1.23 (#2401)
 - fix(skills): `two_stage_matching` and `confusability_threshold` config fields are now applied at agent startup; `AgentBuilder` gains `with_two_stage_matching` and `with_confusability_threshold` builder methods wired in `runner.rs` and `daemon.rs` (closes #2404)

--- a/crates/zeph-acp/src/agent/mod.rs
+++ b/crates/zeph-acp/src/agent/mod.rs
@@ -756,6 +756,9 @@ impl acp::Agent for ZephAcpAgent {
             .auth(acp::AgentAuthCapabilities::default().logout(acp::LogoutCapabilities::default()));
 
         Ok(acp::InitializeResponse::new(acp::ProtocolVersion::LATEST)
+            .auth_methods(vec![acp::AuthMethod::Agent(acp::AuthMethodAgent::new(
+                "zeph", "Zeph",
+            ))])
             .agent_info(
                 acp::Implementation::new(&self.agent_name, &self.agent_version).title(title),
             )

--- a/crates/zeph-acp/src/agent/tests.rs
+++ b/crates/zeph-acp/src/agent/tests.rs
@@ -175,6 +175,39 @@ async fn initialize_returns_load_session_capability_and_auth_hint() {
 }
 
 #[tokio::test]
+async fn initialize_response_includes_agent_auth_method() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let (agent, _rx) = make_agent();
+            let resp = agent
+                .initialize(acp::InitializeRequest::new(acp::ProtocolVersion::LATEST))
+                .await
+                .unwrap();
+            assert_eq!(
+                resp.auth_methods.len(),
+                1,
+                "expected exactly one authMethod in InitializeResponse"
+            );
+            let method = &resp.auth_methods[0];
+            let acp::AuthMethod::Agent(agent_method) = method else {
+                panic!("expected AuthMethod::Agent, got a different variant");
+            };
+            assert_eq!(
+                agent_method.id.0.as_ref(),
+                "zeph",
+                "authMethod id must be 'zeph'"
+            );
+            assert_eq!(
+                agent_method.name.as_str(),
+                "Zeph",
+                "authMethod name must be 'Zeph'"
+            );
+        })
+        .await;
+}
+
+#[tokio::test]
 async fn ext_notification_accepts_unknown_method() {
     let local = tokio::task::LocalSet::new();
     local

--- a/crates/zeph-acp/src/transport/discovery.rs
+++ b/crates/zeph-acp/src/transport/discovery.rs
@@ -39,3 +39,24 @@ pub async fn discovery_handler(State(state): State<AcpHttpState>) -> impl IntoRe
 
     Json(manifest)
 }
+
+/// `GET /agent.json` — machine-readable agent identity manifest for ACP Registry discovery.
+///
+/// Returns static agent metadata: identifier, display name, version, description, and
+/// distribution targets. This endpoint is never behind auth middleware.
+pub async fn agent_json_handler(State(state): State<AcpHttpState>) -> impl IntoResponse {
+    // `id` and `description` are fixed software-identity values for the Zeph project (not
+    // deployment-configurable); `name` and `version` are deployment-specific from server config.
+    let manifest = json!({
+        "id": "zeph",
+        "name": state.server_config.agent_name,
+        "version": state.server_config.agent_version,
+        "description": "Lightweight Rust AI agent with hybrid inference, semantic memory, and multi-channel I/O",
+        "distribution": {
+            "type": "binary",
+            "platforms": ["linux-x64", "darwin-arm64", "darwin-x64"]
+        }
+    });
+
+    Json(manifest)
+}

--- a/crates/zeph-acp/src/transport/router.rs
+++ b/crates/zeph-acp/src/transport/router.rs
@@ -13,7 +13,7 @@ use tower_http::cors::CorsLayer;
 #[cfg(feature = "acp-http")]
 use crate::transport::auth::BearerAuthLayer;
 #[cfg(feature = "acp-http")]
-use crate::transport::discovery::discovery_handler;
+use crate::transport::discovery::{agent_json_handler, discovery_handler};
 #[cfg(feature = "acp-http")]
 use crate::transport::http::{
     AcpHttpState, get_handler, health_handler, list_sessions_handler, post_handler,
@@ -34,6 +34,7 @@ const MAX_BODY_BYTES: usize = 1_048_576;
 /// - `GET /acp/ws` — WebSocket upgrade
 /// - `GET /health` — public readiness probe
 /// - `GET /.well-known/acp.json` — discovery manifest (always public, no auth)
+/// - `GET /agent.json` — agent identity manifest for ACP Registry (always public, no auth)
 ///
 /// Security layers applied:
 /// - `DefaultBodyLimit::max(1_048_576)` — rejects oversized POST bodies
@@ -64,7 +65,9 @@ pub fn acp_router(state: AcpHttpState) -> Router {
         .merge(acp_routes);
 
     if state.server_config.discovery_enabled {
-        router = router.route("/.well-known/acp.json", get(discovery_handler));
+        router = router
+            .route("/.well-known/acp.json", get(discovery_handler))
+            .route("/agent.json", get(agent_json_handler));
     }
 
     router.with_state(state)

--- a/crates/zeph-acp/src/transport/tests.rs
+++ b/crates/zeph-acp/src/transport/tests.rs
@@ -621,6 +621,79 @@ async fn discovery_disabled_returns_404() {
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
+// ── agent.json endpoint tests ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn agent_json_returns_expected_fields() {
+    use axum::body::to_bytes;
+
+    let router = acp_router(test_state());
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/agent.json")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = router.oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = to_bytes(response.into_body(), 1_048_576).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["id"], "zeph");
+    assert_eq!(json["name"], "test");
+    assert_eq!(json["version"], "0.0.1");
+    assert!(
+        json["description"].is_string(),
+        "description must be a string"
+    );
+    assert!(
+        json["distribution"].is_object(),
+        "distribution must be an object"
+    );
+    assert_eq!(json["distribution"]["type"], "binary");
+    assert!(
+        json["distribution"]["platforms"].is_array(),
+        "platforms must be an array"
+    );
+}
+
+#[tokio::test]
+async fn agent_json_disabled_returns_404() {
+    let state = AcpHttpState::new(
+        noop_spawner(),
+        AcpServerConfig {
+            agent_name: "test".into(),
+            agent_version: "0.0.1".into(),
+            max_sessions: 4,
+            session_idle_timeout_secs: 1800,
+            permission_file: None,
+            provider_factory: None,
+            available_models: shared_models(vec![]),
+            mcp_manager: None,
+            auth_bearer_token: None,
+            discovery_enabled: false,
+            terminal_timeout_secs: 120,
+            project_rules: vec![],
+            title_max_chars: 60,
+            max_history: 100,
+            sqlite_path: None,
+            ready_notification: None,
+        },
+    );
+    let router = acp_router(state);
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/agent.json")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = router.oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
 // ── Reaper test ───────────────────────────────────────────────────────────────
 
 #[tokio::test(start_paused = true)]

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -783,30 +783,12 @@ async fn spawn_acp_agent(
         agent = agent_setup::apply_injection_classifier_with_cfg(agent, &classifiers_config);
         if classifiers_config.enabled {
             agent = agent.with_enforcement_mode(classifiers_config.enforcement_mode);
-            if let Some(ref repo_id) = classifiers_config.three_class_model {
-                let mut tc = zeph_llm::classifier::three_class::CandleThreeClassClassifier::new(
-                    repo_id.as_str(),
-                );
-                if let Some(ref token) = classifiers_config.hf_token {
-                    tc = tc.with_hf_token(token.as_str());
-                }
-                if let Some(ref hash) = classifiers_config.three_class_model_sha256 {
-                    tc = tc.with_sha256(hash.as_str());
-                }
-                agent = agent.with_three_class_classifier(
-                    std::sync::Arc::new(tc),
-                    classifiers_config.three_class_threshold,
-                );
-            }
         }
+        agent = agent_setup::apply_three_class_classifier_with_cfg(agent, &classifiers_config);
         agent = agent_setup::apply_pii_classifier_with_cfg(agent, &classifiers_config);
     }
-    if causal_ipi_config.enabled {
-        agent = agent.with_causal_analyzer(zeph_sanitizer::causal_ipi::TurnCausalAnalyzer::new(
-            provider.clone(),
-            &causal_ipi_config,
-        ));
-    }
+    agent =
+        agent_setup::apply_causal_analyzer_with_cfg(agent, provider.clone(), &causal_ipi_config);
 
     if debug_config.enabled {
         // Use session_id as a subdirectory prefix so concurrent sessions never share the same

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -680,27 +680,36 @@ pub(crate) fn apply_three_class_classifier<C: Channel>(
     agent: zeph_core::agent::Agent<C>,
     config: &Config,
 ) -> zeph_core::agent::Agent<C> {
-    let Some(ref repo_id) = config.classifiers.three_class_model else {
+    apply_three_class_classifier_with_cfg(agent, &config.classifiers)
+}
+
+/// Wire the three-class `AlignSentinel` refinement model into the agent's sanitizer (takes `ClassifiersConfig` directly).
+#[cfg(feature = "classifiers")]
+pub(crate) fn apply_three_class_classifier_with_cfg<C: Channel>(
+    agent: zeph_core::agent::Agent<C>,
+    classifiers: &zeph_core::config::ClassifiersConfig,
+) -> zeph_core::agent::Agent<C> {
+    let Some(ref repo_id) = classifiers.three_class_model else {
         return agent;
     };
-    if !config.classifiers.enabled {
+    if !classifiers.enabled {
         return agent;
     }
     let mut classifier =
         zeph_llm::classifier::three_class::CandleThreeClassClassifier::new(repo_id.as_str());
-    if let Some(token) = &config.classifiers.hf_token {
+    if let Some(token) = &classifiers.hf_token {
         classifier = classifier.with_hf_token(token.as_str());
     }
-    if let Some(hash) = &config.classifiers.three_class_model_sha256 {
+    if let Some(hash) = &classifiers.three_class_model_sha256 {
         classifier = classifier.with_sha256(hash.as_str());
     }
     let backend = std::sync::Arc::new(classifier);
     tracing::info!(
         repo_id = %repo_id,
-        threshold = config.classifiers.three_class_threshold,
+        threshold = classifiers.three_class_threshold,
         "three-class AlignSentinel classifier attached (model loads lazily on first use)"
     );
-    agent.with_three_class_classifier(backend, config.classifiers.three_class_threshold)
+    agent.with_three_class_classifier(backend, classifiers.three_class_threshold)
 }
 
 /// Wire the `TurnCausalAnalyzer` into the agent's security config.
@@ -711,14 +720,22 @@ pub(crate) fn apply_causal_analyzer<C: Channel>(
     provider: zeph_llm::any::AnyProvider,
     config: &Config,
 ) -> zeph_core::agent::Agent<C> {
-    if !config.security.causal_ipi.enabled {
+    apply_causal_analyzer_with_cfg(agent, provider, &config.security.causal_ipi)
+}
+
+/// Wire the `TurnCausalAnalyzer` into the agent's security config (takes `CausalIpiConfig` directly).
+pub(crate) fn apply_causal_analyzer_with_cfg<C: Channel>(
+    agent: zeph_core::agent::Agent<C>,
+    provider: zeph_llm::any::AnyProvider,
+    causal_config: &zeph_sanitizer::causal_ipi::CausalIpiConfig,
+) -> zeph_core::agent::Agent<C> {
+    if !causal_config.enabled {
         return agent;
     }
-    let analyzer =
-        zeph_sanitizer::causal_ipi::TurnCausalAnalyzer::new(provider, &config.security.causal_ipi);
+    let analyzer = zeph_sanitizer::causal_ipi::TurnCausalAnalyzer::new(provider, causal_config);
     tracing::info!(
-        threshold = config.security.causal_ipi.threshold,
-        probe_timeout_ms = config.security.causal_ipi.probe_timeout_ms,
+        threshold = causal_config.threshold,
+        probe_timeout_ms = causal_config.probe_timeout_ms,
         "causal IPI analyzer attached"
     );
     agent.with_causal_analyzer(analyzer)


### PR DESCRIPTION
## Summary

- Populate `InitializeResponse.auth_methods` with `[{type: "agent", id: "zeph", name: "Zeph"}]` — previously returned `authMethods: []` which blocked ACP Registry inclusion
- Serve `GET /agent.json` with agent identity manifest (`id`, `name`, `version`, `description`, `distribution`) for ACP Registry discovery; gated on `discovery_enabled`
- Extract `apply_three_class_classifier_with_cfg` and `apply_causal_analyzer_with_cfg` helpers in `agent_setup.rs`; `spawn_acp_agent` now delegates to shared helpers eliminating the DRY gap from #2369
- `discovery.rs` already reflects `ProtocolVersion::LATEST` since PR #2423 (confirmed, no code change)

Closes #2422, closes #2370

## Test plan

- [ ] `cargo +nightly fmt --check` passes
- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] `cargo nextest run --workspace --lib --bins` passes (6715 tests)
- [ ] `cargo nextest run -p zeph-acp --lib --features acp-http` passes (322 tests)
- New tests: `initialize_response_includes_agent_auth_method`, `agent_json_returns_expected_fields`, `agent_json_disabled_returns_404`