### PR TITLE
feat(security): MCP→ACP confused-deputy boundary enforcement and security model audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- feat(security): MCP-to-ACP confused-deputy boundary enforcement — when `mcp_to_acp_boundary = true` (default) and agent is in an ACP session, MCP tool results are unconditionally quarantined before entering the ACP response stream; cross-boundary flows emit `CrossBoundaryMcpToAcp` security events and `cross_boundary_mcp_to_acp: true` audit entries (#2417)
+- feat(security): env var sanitization for MCP stdio child processes — `LD_PRELOAD`, `LD_LIBRARY_PATH`, `DYLD_INSERT_LIBRARIES`, `DYLD_LIBRARY_PATH`, `DYLD_FRAMEWORK_PATH`, `DYLD_FALLBACK_LIBRARY_PATH` are stripped from ACP-provided env vars (#2417)
+
+### Changed
+
+- **BREAKING**: `tool_allowlist` type changed from `Vec<String>` to `Option<Vec<String>>` in `ServerEntry` and `McpServerConfig` — `None` means no override (all tools, with untrusted warning), `Some(vec![])` means explicit deny-all (fail-closed), `Some(vec![...])` filters to named tools (#2417)
+
+### Added (continued)
+
 - feat(acp): implement `session/close` handler — `ZephAcpAgent::close_session` removes the in-memory session entry, fires `cancel_signal` to stop any running turn, and returns idempotent `Ok` for unknown session IDs; advertise `session.close` capability in `initialize()`; gated behind `unstable-session-close` feature included in `default` and `acp-unstable` (closes #2421)
 - feat(acp): bump `agent-client-protocol` 0.10.2→0.10.3, `agent-client-protocol-schema` 0.11.2→0.11.3; add `unstable-logout` feature with no-op logout handler and `auth.logout` capability advertisement; add `unstable-elicitation` feature gate (exposes schema types; SDK methods not yet available upstream); fix discovery endpoint `protocol_version` to use `ProtocolVersion::LATEST`; fix double-feature-activation antipattern in `zeph-acp` feature flags (#2411)
 - feat(skills): add `category` field to SKILL.md frontmatter — optional grouping for skill library organisation; all 26 bundled skills annotated with categories (`web`, `data`, `dev`, `system`) (#2268)

--- a/crates/zeph-acp/src/mcp_bridge.rs
+++ b/crates/zeph-acp/src/mcp_bridge.rs
@@ -19,11 +19,10 @@ pub fn acp_mcp_servers_to_entries(servers: &[acp::McpServer]) -> Vec<ServerEntry
         .iter()
         .filter_map(|s| match s {
             acp::McpServer::Stdio(stdio) => {
-                // IDE is the trusted client in the stdio transport model; env vars are passed
-                // as-is to the MCP server child process without further sanitization.
                 let env: HashMap<String, String> = stdio
                     .env
                     .iter()
+                    .filter(|e| !is_dangerous_env_var(&e.name))
                     .map(|e| (e.name.clone(), e.value.clone()))
                     .collect();
                 Some(ServerEntry {
@@ -35,7 +34,7 @@ pub fn acp_mcp_servers_to_entries(servers: &[acp::McpServer]) -> Vec<ServerEntry
                     },
                     timeout: Duration::from_secs(DEFAULT_MCP_TIMEOUT_SECS),
                     trust_level: McpTrustLevel::Untrusted,
-                    tool_allowlist: Vec::new(),
+                    tool_allowlist: None,
                     expected_tools: Vec::new(),
                 })
             }
@@ -47,7 +46,7 @@ pub fn acp_mcp_servers_to_entries(servers: &[acp::McpServer]) -> Vec<ServerEntry
                 },
                 timeout: Duration::from_secs(DEFAULT_MCP_TIMEOUT_SECS),
                 trust_level: McpTrustLevel::Untrusted,
-                tool_allowlist: Vec::new(),
+                tool_allowlist: None,
                 expected_tools: Vec::new(),
             }),
             acp::McpServer::Sse(sse) => {
@@ -61,7 +60,7 @@ pub fn acp_mcp_servers_to_entries(servers: &[acp::McpServer]) -> Vec<ServerEntry
                     },
                     timeout: Duration::from_secs(DEFAULT_MCP_TIMEOUT_SECS),
                     trust_level: McpTrustLevel::Untrusted,
-                    tool_allowlist: Vec::new(),
+                    tool_allowlist: None,
                     expected_tools: Vec::new(),
                 })
             }
@@ -71,6 +70,21 @@ pub fn acp_mcp_servers_to_entries(servers: &[acp::McpServer]) -> Vec<ServerEntry
             }
         })
         .collect()
+}
+
+/// Env vars that must never be passed from ACP clients to MCP child processes.
+/// These enable library injection, path hijacking, and other privilege escalation vectors.
+fn is_dangerous_env_var(name: &str) -> bool {
+    let upper = name.to_ascii_uppercase();
+    matches!(
+        upper.as_str(),
+        "LD_PRELOAD"
+            | "LD_LIBRARY_PATH"
+            | "DYLD_INSERT_LIBRARIES"
+            | "DYLD_LIBRARY_PATH"
+            | "DYLD_FRAMEWORK_PATH"
+            | "DYLD_FALLBACK_LIBRARY_PATH"
+    )
 }
 
 #[cfg(test)]
@@ -175,5 +189,54 @@ mod tests {
         assert_eq!(entries[1].id, "http-1");
         assert_eq!(entries[2].id, "stdio-2");
         assert_eq!(entries[3].id, "sse-1");
+    }
+
+    #[test]
+    fn dangerous_env_vars_stripped() {
+        let stdio = acp::McpServerStdio::new("env-mcp", "/bin/mcp").env(vec![
+            acp::EnvVariable::new("SAFE_VAR", "ok"),
+            acp::EnvVariable::new("LD_PRELOAD", "/tmp/evil.so"),
+            acp::EnvVariable::new("DYLD_INSERT_LIBRARIES", "/tmp/evil.dylib"),
+            acp::EnvVariable::new("LD_LIBRARY_PATH", "/tmp"),
+        ]);
+        let entries = acp_mcp_servers_to_entries(&[acp::McpServer::Stdio(stdio)]);
+        if let McpTransport::Stdio { env, .. } = &entries[0].transport {
+            assert_eq!(env.get("SAFE_VAR"), Some(&"ok".to_owned()));
+            assert!(env.get("LD_PRELOAD").is_none());
+            assert!(env.get("DYLD_INSERT_LIBRARIES").is_none());
+            assert!(env.get("LD_LIBRARY_PATH").is_none());
+        } else {
+            panic!("expected Stdio transport");
+        }
+    }
+
+    #[test]
+    fn acp_servers_have_none_allowlist() {
+        let servers = vec![
+            acp::McpServer::Stdio(acp::McpServerStdio::new("s", "/bin/s")),
+            acp::McpServer::Http(acp::McpServerHttp::new("h", "http://localhost")),
+            acp::McpServer::Sse(acp::McpServerSse::new("e", "http://localhost/sse")),
+        ];
+        let entries = acp_mcp_servers_to_entries(&servers);
+        for entry in &entries {
+            assert!(
+                entry.tool_allowlist.is_none(),
+                "ACP-requested server '{}' must have tool_allowlist=None",
+                entry.id
+            );
+        }
+    }
+
+    #[test]
+    fn is_dangerous_env_var_cases() {
+        assert!(super::is_dangerous_env_var("LD_PRELOAD"));
+        assert!(super::is_dangerous_env_var("ld_preload"));
+        assert!(super::is_dangerous_env_var("DYLD_INSERT_LIBRARIES"));
+        assert!(super::is_dangerous_env_var("DYLD_LIBRARY_PATH"));
+        assert!(super::is_dangerous_env_var("DYLD_FRAMEWORK_PATH"));
+        assert!(super::is_dangerous_env_var("DYLD_FALLBACK_LIBRARY_PATH"));
+        assert!(!super::is_dangerous_env_var("PATH"));
+        assert!(!super::is_dangerous_env_var("HOME"));
+        assert!(!super::is_dangerous_env_var("MY_VAR"));
     }
 }

--- a/crates/zeph-config/src/channels.rs
+++ b/crates/zeph-config/src/channels.rs
@@ -376,12 +376,11 @@ pub struct McpServerConfig {
     /// Trust level for this server. Default: Untrusted.
     #[serde(default)]
     pub trust_level: McpTrustLevel,
-    /// Tool allowlist. Behavior depends on `trust_level`:
-    /// - Trusted: ignored (all tools exposed)
-    /// - Untrusted: empty = all tools (with warning), non-empty = only listed tools
-    /// - Sandboxed: empty = NO tools (fail-closed), non-empty = only listed tools
+    /// Tool allowlist. `None` means no override (inherit defaults).
+    /// `Some(vec![])` is an explicit empty list (deny all for Untrusted/Sandboxed).
+    /// `Some(vec!["a", "b"])` allows only listed tools.
     #[serde(default)]
-    pub tool_allowlist: Vec<String>,
+    pub tool_allowlist: Option<Vec<String>>,
     /// Expected tool names for attestation. Supplements `tool_allowlist`.
     ///
     /// When non-empty: tools not in this list are filtered out (Untrusted/Sandboxed)

--- a/crates/zeph-config/src/sanitizer.rs
+++ b/crates/zeph-config/src/sanitizer.rs
@@ -100,6 +100,7 @@ impl Default for EmbeddingGuardConfig {
 /// Configuration for the content isolation pipeline, nested under
 /// `[security.content_isolation]` in the agent config file.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct ContentIsolationConfig {
     /// When `false`, the sanitizer is a no-op: content passes through unchanged.
     #[serde(default = "default_true")]
@@ -126,6 +127,13 @@ pub struct ContentIsolationConfig {
     /// Embedding anomaly guard configuration.
     #[serde(default)]
     pub embedding_guard: EmbeddingGuardConfig,
+
+    /// When `true`, MCP tool results flowing through ACP-serving sessions receive
+    /// unconditional quarantine summarization and cross-boundary audit log entries.
+    /// This prevents confused-deputy attacks where untrusted MCP output influences
+    /// responses served to ACP clients (e.g. IDE integrations).
+    #[serde(default = "default_true")]
+    pub mcp_to_acp_boundary: bool,
 }
 
 impl Default for ContentIsolationConfig {
@@ -137,6 +145,7 @@ impl Default for ContentIsolationConfig {
             spotlight_untrusted: true,
             quarantine: QuarantineConfig::default(),
             embedding_guard: EmbeddingGuardConfig::default(),
+            mcp_to_acp_boundary: true,
         }
     }
 }
@@ -473,6 +482,27 @@ impl Default for ResponseVerificationConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn content_isolation_default_mcp_to_acp_boundary_true() {
+        let cfg = ContentIsolationConfig::default();
+        assert!(cfg.mcp_to_acp_boundary);
+    }
+
+    #[test]
+    fn content_isolation_deserialize_mcp_to_acp_boundary_false() {
+        let toml = r"
+            mcp_to_acp_boundary = false
+        ";
+        let cfg: ContentIsolationConfig = toml::from_str(toml).unwrap();
+        assert!(!cfg.mcp_to_acp_boundary);
+    }
+
+    #[test]
+    fn content_isolation_deserialize_absent_defaults_true() {
+        let cfg: ContentIsolationConfig = toml::from_str("").unwrap();
+        assert!(cfg.mcp_to_acp_boundary);
+    }
 
     fn de_guard(toml: &str) -> Result<EmbeddingGuardConfig, toml::de::Error> {
         toml::from_str(toml)

--- a/crates/zeph-core/config/default.toml
+++ b/crates/zeph-core/config/default.toml
@@ -507,6 +507,9 @@ max_content_size = 65536
 flag_injection_patterns = true
 # Wrap untrusted content in spotlighting XML delimiters (default: true)
 spotlight_untrusted = true
+# Enforce strict MCP→ACP trust boundary when agent serves ACP clients (default: true)
+# When enabled, MCP tool results in ACP sessions are unconditionally quarantined
+mcp_to_acp_boundary = true
 
 [security.content_isolation.quarantine]
 # Route high-risk content through an isolated LLM for fact extraction (default: false)

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -697,6 +697,15 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Mark this agent session as serving an ACP client.
+    /// When `true` and `mcp_to_acp_boundary` is enabled, MCP tool results
+    /// receive unconditional quarantine and cross-boundary audit logging.
+    #[must_use]
+    pub fn with_acp_session(mut self, is_acp: bool) -> Self {
+        self.security.is_acp_session = is_acp;
+        self
+    }
+
     /// Attach an ML classifier backend to the sanitizer for injection detection.
     ///
     /// When attached, `classify_injection()` is called on each incoming user message when

--- a/crates/zeph-core/src/agent/mcp.rs
+++ b/crates/zeph-core/src/agent/mcp.rs
@@ -84,7 +84,7 @@ impl<C: Channel> Agent<C> {
             transport,
             timeout: std::time::Duration::from_secs(30),
             trust_level: zeph_mcp::McpTrustLevel::Untrusted,
-            tool_allowlist: Vec::new(),
+            tool_allowlist: None,
             expected_tools: Vec::new(),
         };
 

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -423,6 +423,7 @@ impl<C: Channel> Agent<C> {
             security: SecurityState {
                 sanitizer: ContentSanitizer::new(&zeph_sanitizer::ContentIsolationConfig::default()),
                 quarantine_summarizer: None,
+                is_acp_session: false,
                 exfiltration_guard: zeph_sanitizer::exfiltration::ExfiltrationGuard::new(
                     zeph_sanitizer::exfiltration::ExfiltrationGuardConfig::default(),
                 ),

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -176,6 +176,10 @@ pub(crate) struct FeedbackState {
 pub(crate) struct SecurityState {
     pub(crate) sanitizer: ContentSanitizer,
     pub(crate) quarantine_summarizer: Option<QuarantinedSummarizer>,
+    /// Whether this agent session is serving an ACP client.
+    /// When `true` and `mcp_to_acp_boundary` is enabled, MCP tool results
+    /// receive unconditional quarantine and cross-boundary audit logging.
+    pub(crate) is_acp_session: bool,
     pub(crate) exfiltration_guard: zeph_sanitizer::exfiltration::ExfiltrationGuard,
     pub(crate) flagged_urls: HashSet<String>,
     /// URLs explicitly provided by the user across all turns in this session.

--- a/crates/zeph-core/src/agent/tool_execution/mod.rs
+++ b/crates/zeph-core/src/agent/tool_execution/mod.rs
@@ -403,8 +403,72 @@ impl<C: Channel> Agent<C> {
             }
         }
 
+        // MCP-to-ACP boundary enforcement: unconditionally quarantine MCP tool results
+        // in ACP sessions, bypassing `should_quarantine()` source config (#2427, S10).
+        let is_cross_boundary = self.security.is_acp_session
+            && self.runtime.security.content_isolation.mcp_to_acp_boundary
+            && kind == ContentSourceKind::McpResponse;
+        if is_cross_boundary {
+            tracing::warn!(
+                tool = %tool_name,
+                mcp_server_id = tool_name.split(':').next().unwrap_or("unknown"),
+                "MCP tool result crossing ACP trust boundary"
+            );
+            self.push_security_event(
+                crate::metrics::SecurityEventCategory::CrossBoundaryMcpToAcp,
+                tool_name,
+                "MCP result force-quarantined for ACP session",
+            );
+            if let Some(ref logger) = self.tool_orchestrator.audit_logger {
+                let entry = zeph_tools::AuditEntry {
+                    timestamp: zeph_tools::chrono_now(),
+                    tool: tool_name.to_owned(),
+                    command: String::new(),
+                    result: zeph_tools::AuditResult::Success,
+                    duration_ms: 0,
+                    error_category: None,
+                    error_domain: Some("security".to_owned()),
+                    error_phase: None,
+                    claim_source: None,
+                    mcp_server_id: tool_name.split(':').next().map(ToOwned::to_owned),
+                    injection_flagged: has_injection_flags,
+                    embedding_anomalous: false,
+                    cross_boundary_mcp_to_acp: true,
+                };
+                let logger = std::sync::Arc::clone(logger);
+                tokio::spawn(async move { logger.log(&entry).await });
+            }
+            if let Some(ref qs) = self.security.quarantine_summarizer {
+                match qs.extract_facts(&sanitized, &self.security.sanitizer).await {
+                    Ok((facts, flags)) => {
+                        self.update_metrics(|m| m.quarantine_invocations += 1);
+                        let escaped =
+                            zeph_sanitizer::ContentSanitizer::escape_delimiter_tags(&facts);
+                        return (
+                            zeph_sanitizer::ContentSanitizer::apply_spotlight(
+                                &escaped,
+                                &sanitized.source,
+                                &flags,
+                            ),
+                            has_injection_flags,
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            tool = %tool_name,
+                            error = %e,
+                            "cross-boundary quarantine failed, using spotlighted output"
+                        );
+                        self.update_metrics(|m| m.quarantine_failures += 1);
+                    }
+                }
+            }
+            // Quarantine summarizer unavailable or failed — fall through to spotlighted output.
+        }
+
         // Quarantine step: route high-risk sources through an isolated LLM (defense-in-depth).
-        if self.security.sanitizer.is_enabled()
+        if !is_cross_boundary
+            && self.security.sanitizer.is_enabled()
             && let Some(ref qs) = self.security.quarantine_summarizer
             && qs.should_quarantine(kind)
         {

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -763,6 +763,7 @@ impl<C: Channel> Agent<C> {
                                     mcp_server_id: None,
                                     injection_flagged: false,
                                     embedding_anomalous: false,
+                                    cross_boundary_mcp_to_acp: false,
                                 };
                                 let logger = std::sync::Arc::clone(logger);
                                 tokio::spawn(async move { logger.log(&entry).await });

--- a/crates/zeph-core/src/agent/tool_execution/tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests.rs
@@ -4652,3 +4652,171 @@ async fn infrastructure_error_does_not_trigger_self_reflection() {
         last.content
     );
 }
+
+// --- MCP-to-ACP cross-boundary enforcement tests ---
+
+#[tokio::test]
+async fn sanitize_tool_output_cross_boundary_acp_mcp_quarantines() {
+    use super::super::agent_tests::{
+        MockChannel, MockToolExecutor, create_test_registry, mock_provider,
+    };
+    use crate::metrics::SecurityEventCategory;
+    use tokio::sync::watch;
+    use zeph_llm::mock::MockProvider;
+    use zeph_sanitizer::QuarantineConfig;
+    use zeph_sanitizer::quarantine::QuarantinedSummarizer;
+    use zeph_sanitizer::{ContentIsolationConfig, ContentSanitizer};
+
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    let (tx, rx) = watch::channel(crate::metrics::MetricsSnapshot::default());
+
+    let quarantine_provider = zeph_llm::any::AnyProvider::Mock(MockProvider::with_responses(vec![
+        "Extracted: safe summary".to_owned(),
+    ]));
+    let qcfg = QuarantineConfig {
+        enabled: true,
+        sources: vec![],
+        model: "mock".to_owned(),
+    };
+    let qs = QuarantinedSummarizer::new(quarantine_provider, &qcfg);
+
+    let mut agent = super::super::Agent::new(provider, channel, registry, None, 5, executor)
+        .with_metrics(tx)
+        .with_acp_session(true)
+        .with_quarantine_summarizer(qs);
+    agent.security.sanitizer = ContentSanitizer::new(&ContentIsolationConfig {
+        enabled: true,
+        spotlight_untrusted: true,
+        flag_injection_patterns: false,
+        mcp_to_acp_boundary: true,
+        ..Default::default()
+    });
+
+    // "mcp_server:tool_name" triggers McpResponse kind
+    let (result, _) = agent
+        .sanitize_tool_output("malicious MCP payload", "evil_server:tool_x")
+        .await;
+
+    assert!(
+        result.contains("Extracted: safe summary"),
+        "cross-boundary MCP result must be quarantined: {result}"
+    );
+    let snap = rx.borrow().clone();
+    assert_eq!(snap.quarantine_invocations, 1);
+    assert!(
+        snap.security_events
+            .iter()
+            .any(|e| e.category == SecurityEventCategory::CrossBoundaryMcpToAcp),
+        "must emit CrossBoundaryMcpToAcp security event"
+    );
+}
+
+#[tokio::test]
+async fn sanitize_tool_output_cross_boundary_disabled_skips_quarantine() {
+    use super::super::agent_tests::{
+        MockChannel, MockToolExecutor, create_test_registry, mock_provider,
+    };
+    use crate::metrics::SecurityEventCategory;
+    use tokio::sync::watch;
+    use zeph_llm::mock::MockProvider;
+    use zeph_sanitizer::QuarantineConfig;
+    use zeph_sanitizer::quarantine::QuarantinedSummarizer;
+    use zeph_sanitizer::{ContentIsolationConfig, ContentSanitizer};
+
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    let (tx, rx) = watch::channel(crate::metrics::MetricsSnapshot::default());
+
+    let quarantine_provider = zeph_llm::any::AnyProvider::Mock(MockProvider::with_responses(vec![
+        "should not appear".to_owned(),
+    ]));
+    let qcfg = QuarantineConfig {
+        enabled: true,
+        sources: vec![],
+        model: "mock".to_owned(),
+    };
+    let qs = QuarantinedSummarizer::new(quarantine_provider, &qcfg);
+
+    let iso_cfg = ContentIsolationConfig {
+        enabled: true,
+        spotlight_untrusted: true,
+        flag_injection_patterns: false,
+        mcp_to_acp_boundary: false,
+        ..Default::default()
+    };
+    let mut agent = super::super::Agent::new(provider, channel, registry, None, 5, executor)
+        .with_metrics(tx)
+        .with_acp_session(true)
+        .with_quarantine_summarizer(qs);
+    agent.security.sanitizer = ContentSanitizer::new(&iso_cfg);
+    agent.runtime.security.content_isolation = iso_cfg;
+
+    let (result, _) = agent
+        .sanitize_tool_output("MCP content", "some_server:tool_y")
+        .await;
+
+    // With boundary disabled, no cross-boundary quarantine — content passes through spotlight
+    assert!(
+        !result.contains("should not appear"),
+        "boundary disabled must not trigger cross-boundary quarantine: {result}"
+    );
+    let snap = rx.borrow().clone();
+    assert_eq!(snap.quarantine_invocations, 0);
+    assert!(
+        !snap
+            .security_events
+            .iter()
+            .any(|e| e.category == SecurityEventCategory::CrossBoundaryMcpToAcp),
+        "must NOT emit CrossBoundaryMcpToAcp when boundary disabled"
+    );
+}
+
+#[tokio::test]
+async fn sanitize_tool_output_non_acp_session_normal_path() {
+    use super::super::agent_tests::{
+        MockChannel, MockToolExecutor, create_test_registry, mock_provider,
+    };
+    use crate::metrics::SecurityEventCategory;
+    use tokio::sync::watch;
+    use zeph_sanitizer::{ContentIsolationConfig, ContentSanitizer};
+
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    let (tx, rx) = watch::channel(crate::metrics::MetricsSnapshot::default());
+
+    // is_acp_session defaults to false (no with_acp_session call)
+    let mut agent =
+        super::super::Agent::new(provider, channel, registry, None, 5, executor).with_metrics(tx);
+    agent.security.sanitizer = ContentSanitizer::new(&ContentIsolationConfig {
+        enabled: true,
+        spotlight_untrusted: true,
+        flag_injection_patterns: false,
+        mcp_to_acp_boundary: true,
+        ..Default::default()
+    });
+
+    let (result, _) = agent
+        .sanitize_tool_output("normal MCP data", "server:tool_z")
+        .await;
+
+    // Non-ACP session: no cross-boundary enforcement, just normal spotlight
+    assert!(
+        result.contains("normal MCP data"),
+        "non-ACP session must not quarantine MCP results: {result}"
+    );
+    let snap = rx.borrow().clone();
+    assert!(
+        !snap
+            .security_events
+            .iter()
+            .any(|e| e.category == SecurityEventCategory::CrossBoundaryMcpToAcp),
+        "non-ACP session must NOT emit CrossBoundaryMcpToAcp"
+    );
+}

--- a/crates/zeph-core/src/bootstrap/mod.rs
+++ b/crates/zeph-core/src/bootstrap/mod.rs
@@ -559,8 +559,17 @@ impl AppBuilder {
     pub fn build_quarantine_provider(
         &self,
     ) -> Option<(AnyProvider, zeph_sanitizer::QuarantineConfig)> {
-        let qc = &self.config.security.content_isolation.quarantine;
+        let ci = &self.config.security.content_isolation;
+        let qc = &ci.quarantine;
         if !qc.enabled {
+            if ci.mcp_to_acp_boundary {
+                tracing::warn!(
+                    "mcp_to_acp_boundary is enabled but quarantine is disabled — \
+                     cross-boundary MCP tool results in ACP sessions will be \
+                     spotlighted but NOT quarantine-summarized; enable \
+                     [security.content_isolation.quarantine] for full protection"
+                );
+            }
             return None;
         }
         match create_named_provider(&qc.model, &self.config) {

--- a/crates/zeph-core/src/bootstrap/tests.rs
+++ b/crates/zeph-core/src/bootstrap/tests.rs
@@ -322,7 +322,7 @@ fn create_mcp_manager_with_http_transport() {
         timeout: 30,
         policy: Default::default(),
         trust_level: Default::default(),
-        tool_allowlist: vec![],
+        tool_allowlist: None,
         expected_tools: vec![],
     }];
 
@@ -347,7 +347,7 @@ fn create_mcp_manager_with_stdio_transport() {
         timeout: 30,
         policy: Default::default(),
         trust_level: Default::default(),
-        tool_allowlist: vec![],
+        tool_allowlist: None,
         expected_tools: vec![],
     }];
 

--- a/crates/zeph-core/src/metrics.rs
+++ b/crates/zeph-core/src/metrics.rs
@@ -24,6 +24,8 @@ pub enum SecurityEventCategory {
     ResponseVerification,
     /// `TurnCausalAnalyzer` flagged behavioral deviation at tool-return boundary.
     CausalIpiFlag,
+    /// MCP tool result crossing into an ACP-serving session boundary.
+    CrossBoundaryMcpToAcp,
 }
 
 impl SecurityEventCategory {
@@ -41,6 +43,7 @@ impl SecurityEventCategory {
             Self::PreExecutionWarn => "pre_exec_warn",
             Self::ResponseVerification => "response_verify",
             Self::CausalIpiFlag => "causal_ipi",
+            Self::CrossBoundaryMcpToAcp => "cross_boundary_mcp_to_acp",
         }
     }
 }
@@ -622,6 +625,10 @@ mod tests {
         assert_eq!(SecurityEventCategory::ExfiltrationBlock.as_str(), "exfil");
         assert_eq!(SecurityEventCategory::Quarantine.as_str(), "quarantine");
         assert_eq!(SecurityEventCategory::Truncation.as_str(), "truncation");
+        assert_eq!(
+            SecurityEventCategory::CrossBoundaryMcpToAcp.as_str(),
+            "cross_boundary_mcp_to_acp"
+        );
     }
 
     #[test]

--- a/crates/zeph-mcp/src/manager.rs
+++ b/crates/zeph-mcp/src/manager.rs
@@ -13,7 +13,7 @@ use tokio::sync::{mpsc, watch};
 type StatusTx = mpsc::UnboundedSender<String>;
 /// Per-server trust config: (`trust_level`, `tool_allowlist`, `expected_tools`).
 type ServerTrust =
-    Arc<tokio::sync::RwLock<HashMap<String, (McpTrustLevel, Vec<String>, Vec<String>)>>>;
+    Arc<tokio::sync::RwLock<HashMap<String, (McpTrustLevel, Option<Vec<String>>, Vec<String>)>>>;
 use tokio::task::JoinSet;
 
 use rmcp::transport::auth::CredentialStore;
@@ -77,9 +77,10 @@ pub struct ServerEntry {
     /// `Trusted` skips SSRF checks (for operator-controlled static config).
     #[serde(default)]
     pub trust_level: McpTrustLevel,
-    /// Tool allowlist. See `McpTrustLevel` for per-level semantics.
+    /// Tool allowlist. `None` means no override (inherit from config or deny by default).
+    /// `Some(vec![])` is an explicit empty list. See `McpTrustLevel` for per-level semantics.
     #[serde(default)]
-    pub tool_allowlist: Vec<String>,
+    pub tool_allowlist: Option<Vec<String>>,
     /// Expected tool names for attestation. When non-empty, tools outside this
     /// list are filtered (Untrusted/Sandboxed) or warned (Trusted).
     #[serde(default)]
@@ -151,7 +152,7 @@ impl McpManager {
     ) -> Self {
         let (refresh_tx, refresh_rx) = mpsc::unbounded_channel();
         let (tools_watch_tx, _) = watch::channel(Vec::new());
-        let server_trust: HashMap<String, (McpTrustLevel, Vec<String>, Vec<String>)> = configs
+        let server_trust: HashMap<String, _> = configs
             .iter()
             .map(|c| {
                 (
@@ -283,14 +284,14 @@ impl McpManager {
                     let trust_guard = server_trust.read().await;
                     let (trust_level, allowlist, expected_tools) =
                         trust_guard.get(&event.server_id).map_or(
-                            (McpTrustLevel::Untrusted, Vec::new(), Vec::new()),
+                            (McpTrustLevel::Untrusted, None, Vec::new()),
                             |(tl, al, et)| (*tl, al.clone(), et.clone()),
                         );
                     ingest_tools(
                         event.tools,
                         &event.server_id,
                         trust_level,
-                        &allowlist,
+                        allowlist.as_deref(),
                         &expected_tools,
                         status_tx.as_ref(),
                     )
@@ -620,14 +621,14 @@ impl McpManager {
 
                     let (trust_level, allowlist, expected_tools) =
                         self.server_trust.read().await.get(&server_id).map_or(
-                            (McpTrustLevel::Untrusted, Vec::new(), Vec::new()),
+                            (McpTrustLevel::Untrusted, None, Vec::new()),
                             |(tl, al, et)| (*tl, al.clone(), et.clone()),
                         );
                     let tools = ingest_tools(
                         raw_tools,
                         &server_id,
                         trust_level,
-                        &allowlist,
+                        allowlist.as_deref(),
                         &expected_tools,
                         self.status_tx.as_ref(),
                     );
@@ -773,7 +774,7 @@ impl McpManager {
             raw_tools,
             &entry.id,
             entry.trust_level,
-            &entry.tool_allowlist,
+            entry.tool_allowlist.as_deref(),
             &entry.expected_tools,
             self.status_tx.as_ref(),
         );
@@ -936,7 +937,7 @@ fn ingest_tools(
     mut tools: Vec<McpTool>,
     server_id: &str,
     trust_level: McpTrustLevel,
-    allowlist: &[String],
+    allowlist: Option<&[String]>,
     expected_tools: &[String],
     status_tx: Option<&StatusTx>,
 ) -> Vec<McpTool> {
@@ -985,8 +986,8 @@ fn ingest_tools(
 
     match trust_level {
         McpTrustLevel::Trusted => tools,
-        McpTrustLevel::Untrusted => {
-            if allowlist.is_empty() {
+        McpTrustLevel::Untrusted => match allowlist {
+            None => {
                 let msg = format!(
                     "MCP server '{}' is untrusted with no tool_allowlist — all {} tools exposed; \
                      consider adding an explicit allowlist",
@@ -998,10 +999,19 @@ fn ingest_tools(
                     let _ = tx.send(msg);
                 }
                 tools
-            } else {
+            }
+            Some([]) => {
+                tracing::warn!(
+                    server_id,
+                    "untrusted MCP server has empty tool_allowlist — \
+                     no tools exposed (fail-closed)"
+                );
+                Vec::new()
+            }
+            Some(list) => {
                 let filtered: Vec<McpTool> = tools
                     .into_iter()
-                    .filter(|t| allowlist.iter().any(|a| a == &t.name))
+                    .filter(|t| list.iter().any(|a| a == &t.name))
                     .collect();
                 tracing::info!(
                     server_id,
@@ -1010,18 +1020,20 @@ fn ingest_tools(
                 );
                 filtered
             }
-        }
+        },
         McpTrustLevel::Sandboxed => {
-            if allowlist.is_empty() {
+            let list = allowlist.unwrap_or(&[]);
+            if list.is_empty() {
                 tracing::warn!(
                     server_id,
-                    "sandboxed MCP server has empty tool_allowlist — no tools exposed (fail-closed)"
+                    "sandboxed MCP server has empty tool_allowlist — \
+                     no tools exposed (fail-closed)"
                 );
                 Vec::new()
             } else {
                 let filtered: Vec<McpTool> = tools
                     .into_iter()
-                    .filter(|t| allowlist.iter().any(|a| a == &t.name))
+                    .filter(|t| list.iter().any(|a| a == &t.name))
                     .collect();
                 tracing::info!(
                     server_id,
@@ -1098,7 +1110,7 @@ mod tests {
             },
             timeout: Duration::from_secs(5),
             trust_level: McpTrustLevel::Untrusted,
-            tool_allowlist: Vec::new(),
+            tool_allowlist: None,
             expected_tools: Vec::new(),
         }
     }
@@ -1296,7 +1308,7 @@ mod tests {
             },
             timeout: Duration::from_secs(1),
             trust_level: McpTrustLevel::Untrusted,
-            tool_allowlist: Vec::new(),
+            tool_allowlist: None,
             expected_tools: Vec::new(),
         }
     }
@@ -1512,7 +1524,7 @@ mod tests {
     fn server_entry_default_trust_is_untrusted_and_allowlist_empty() {
         let entry = make_entry("srv");
         assert_eq!(entry.trust_level, McpTrustLevel::Untrusted);
-        assert!(entry.tool_allowlist.is_empty());
+        assert!(entry.tool_allowlist.is_none());
     }
 
     // --- ingest_tools ---
@@ -1520,18 +1532,26 @@ mod tests {
     #[test]
     fn ingest_tools_trusted_returns_all_tools_unsanitized_by_trust() {
         let tools = vec![make_tool("srv", "tool_a"), make_tool("srv", "tool_b")];
-        let result = ingest_tools(tools, "srv", McpTrustLevel::Trusted, &[], &[], None);
+        let result = ingest_tools(tools, "srv", McpTrustLevel::Trusted, None, &[], None);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].name, "tool_a");
         assert_eq!(result[1].name, "tool_b");
     }
 
     #[test]
-    fn ingest_tools_untrusted_empty_allowlist_returns_all_with_warning() {
+    fn ingest_tools_untrusted_none_allowlist_returns_all_with_warning() {
         let tools = vec![make_tool("srv", "tool_a"), make_tool("srv", "tool_b")];
-        let result = ingest_tools(tools, "srv", McpTrustLevel::Untrusted, &[], &[], None);
-        // Empty allowlist on Untrusted → all tools pass through (warn-only, not fail-closed)
+        let result = ingest_tools(tools, "srv", McpTrustLevel::Untrusted, None, &[], None);
+        // None allowlist on Untrusted = no override → all tools pass through (warn-only)
         assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn ingest_tools_untrusted_explicit_empty_allowlist_denies_all() {
+        let tools = vec![make_tool("srv", "tool_a"), make_tool("srv", "tool_b")];
+        let result = ingest_tools(tools, "srv", McpTrustLevel::Untrusted, Some(&[]), &[], None);
+        // Some(empty) on Untrusted = explicit deny-all (fail-closed)
+        assert!(result.is_empty());
     }
 
     #[test]
@@ -1546,7 +1566,7 @@ mod tests {
             tools,
             "srv",
             McpTrustLevel::Untrusted,
-            &allowlist,
+            Some(&allowlist),
             &[],
             None,
         );
@@ -1560,7 +1580,7 @@ mod tests {
     #[test]
     fn ingest_tools_sandboxed_empty_allowlist_returns_no_tools() {
         let tools = vec![make_tool("srv", "tool_a"), make_tool("srv", "tool_b")];
-        let result = ingest_tools(tools, "srv", McpTrustLevel::Sandboxed, &[], &[], None);
+        let result = ingest_tools(tools, "srv", McpTrustLevel::Sandboxed, Some(&[]), &[], None);
         // Sandboxed + empty allowlist = fail-closed: no tools exposed
         assert!(result.is_empty());
     }
@@ -1573,7 +1593,7 @@ mod tests {
             tools,
             "srv",
             McpTrustLevel::Sandboxed,
-            &allowlist,
+            Some(&allowlist),
             &[],
             None,
         );
@@ -1593,7 +1613,7 @@ mod tests {
             tools,
             "srv",
             McpTrustLevel::Untrusted,
-            &allowlist,
+            Some(&allowlist),
             &[],
             None,
         );

--- a/crates/zeph-tools/src/audit.rs
+++ b/crates/zeph-tools/src/audit.rs
@@ -46,6 +46,9 @@ pub struct AuditEntry {
     /// Raw cosine distance is NOT stored (prevents threshold reverse-engineering).
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub embedding_anomalous: bool,
+    /// Tool result crossed the MCP-to-ACP trust boundary (MCP tool result served to an ACP client).
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub cross_boundary_mcp_to_acp: bool,
 }
 
 #[derive(serde::Serialize)]
@@ -134,6 +137,7 @@ mod tests {
             mcp_server_id: None,
             injection_flagged: false,
             embedding_anomalous: false,
+            cross_boundary_mcp_to_acp: false,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(json.contains("\"type\":\"success\""));
@@ -158,6 +162,7 @@ mod tests {
             mcp_server_id: None,
             injection_flagged: false,
             embedding_anomalous: false,
+            cross_boundary_mcp_to_acp: false,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(json.contains("\"type\":\"blocked\""));
@@ -181,6 +186,7 @@ mod tests {
             mcp_server_id: None,
             injection_flagged: false,
             embedding_anomalous: false,
+            cross_boundary_mcp_to_acp: false,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(json.contains("\"type\":\"error\""));
@@ -201,6 +207,7 @@ mod tests {
             mcp_server_id: None,
             injection_flagged: false,
             embedding_anomalous: false,
+            cross_boundary_mcp_to_acp: false,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(json.contains("\"type\":\"timeout\""));
@@ -226,6 +233,7 @@ mod tests {
             mcp_server_id: None,
             injection_flagged: false,
             embedding_anomalous: false,
+            cross_boundary_mcp_to_acp: false,
         };
         logger.log(&entry).await;
     }
@@ -252,6 +260,7 @@ mod tests {
             mcp_server_id: None,
             injection_flagged: false,
             embedding_anomalous: false,
+            cross_boundary_mcp_to_acp: false,
         };
         logger.log(&entry).await;
 
@@ -305,6 +314,7 @@ mod tests {
             mcp_server_id: None,
             injection_flagged: false,
             embedding_anomalous: false,
+            cross_boundary_mcp_to_acp: false,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(
@@ -329,6 +339,7 @@ mod tests {
             mcp_server_id: None,
             injection_flagged: false,
             embedding_anomalous: false,
+            cross_boundary_mcp_to_acp: false,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(
@@ -361,6 +372,7 @@ mod tests {
                 mcp_server_id: None,
                 injection_flagged: false,
                 embedding_anomalous: false,
+                cross_boundary_mcp_to_acp: false,
             };
             logger.log(&entry).await;
         }

--- a/crates/zeph-tools/src/policy_gate.rs
+++ b/crates/zeph-tools/src/policy_gate.rs
@@ -107,6 +107,7 @@ impl<T: ToolExecutor> PolicyGateExecutor<T> {
                         mcp_server_id: None,
                         injection_flagged: false,
                         embedding_anomalous: false,
+                        cross_boundary_mcp_to_acp: false,
                     };
                     audit.log(&entry).await;
                 }
@@ -130,6 +131,7 @@ impl<T: ToolExecutor> PolicyGateExecutor<T> {
                         mcp_server_id: None,
                         injection_flagged: false,
                         embedding_anomalous: false,
+                        cross_boundary_mcp_to_acp: false,
                     };
                     audit.log(&entry).await;
                 }
@@ -179,6 +181,7 @@ impl<T: ToolExecutor> ToolExecutor for PolicyGateExecutor<T> {
                     mcp_server_id: Some(server_id),
                     injection_flagged: false,
                     embedding_anomalous: false,
+                    cross_boundary_mcp_to_acp: false,
                 };
                 audit.log(&entry).await;
             }

--- a/crates/zeph-tools/src/scrape.rs
+++ b/crates/zeph-tools/src/scrape.rs
@@ -305,6 +305,7 @@ impl WebScrapeExecutor {
                 mcp_server_id: None,
                 injection_flagged: false,
                 embedding_anomalous: false,
+                cross_boundary_mcp_to_acp: false,
             };
             logger.log(&entry).await;
         }

--- a/crates/zeph-tools/src/shell/mod.rs
+++ b/crates/zeph-tools/src/shell/mod.rs
@@ -558,6 +558,7 @@ impl ShellExecutor {
                 mcp_server_id: None,
                 injection_flagged: false,
                 embedding_anomalous: false,
+                cross_boundary_mcp_to_acp: false,
             };
             logger.log(&entry).await;
         }

--- a/crates/zeph-tui/src/app.rs
+++ b/crates/zeph-tui/src/app.rs
@@ -1969,6 +1969,7 @@ fn format_security_report(metrics: &MetricsSnapshot) -> String {
             SecurityEventCategory::PreExecutionWarn => "PRE_EXEC_WARN  ",
             SecurityEventCategory::ResponseVerification => "RESP_VERIFY    ",
             SecurityEventCategory::CausalIpiFlag => "CAUSAL_IPI     ",
+            SecurityEventCategory::CrossBoundaryMcpToAcp => "CROSS_BOUNDARY ",
         };
         lines.push(format!("  [{ts}] {cat}  {:<20}  {}", ev.source, ev.detail));
     }

--- a/crates/zeph-tui/src/widgets/security.rs
+++ b/crates/zeph-tui/src/widgets/security.rs
@@ -174,6 +174,9 @@ fn append_event_items<'a>(
             SecurityEventCategory::PreExecutionWarn => ("[pexw] ", flag_style),
             SecurityEventCategory::ResponseVerification => ("[rver] ", flag_style),
             SecurityEventCategory::CausalIpiFlag => ("[cipi] ", flag_style),
+            SecurityEventCategory::CrossBoundaryMcpToAcp => {
+                ("[xbnd] ", Style::default().fg(Color::Red))
+            }
         };
         let hm = format_hm(ev.timestamp);
         items.push(ListItem::new(Line::from(vec![

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -707,6 +707,8 @@ async fn spawn_acp_agent(
     )
     .await;
 
+    agent = agent.with_acp_session(true);
+
     if let Some(ref logger) = d.audit_logger {
         agent = agent.with_audit_logger(std::sync::Arc::clone(logger));
     }

--- a/src/init.rs
+++ b/src/init.rs
@@ -1456,7 +1456,7 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
             timeout: 60,
             policy: zeph_mcp::McpPolicy::default(),
             trust_level: McpTrustLevel::Trusted,
-            tool_allowlist: Vec::new(),
+            tool_allowlist: None,
             expected_tools: Vec::new(),
         });
     }
@@ -1887,7 +1887,7 @@ fn step_mcp_remote(state: &mut WizardState) -> anyhow::Result<()> {
             headers,
             oauth,
             trust_level,
-            tool_allowlist: Vec::new(),
+            tool_allowlist: None,
             expected_tools: Vec::new(),
         });
 


### PR DESCRIPTION
## Summary

- Add `mcp_to_acp_boundary` config (default: `true`) — unconditionally quarantines MCP tool results in ACP sessions, preventing confused-deputy privilege amplification
- Fix `tool_allowlist: Vec::new()` for ACP-requested MCP servers (was allow-all, now fail-closed via `Option<Vec<String>>`)
- Sanitize dangerous env vars (`LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, etc.) before passing to MCP stdio child processes
- Add `CrossBoundaryMcpToAcp` security event + `cross_boundary_mcp_to_acp` audit field for forensic traceability
- Startup warning when boundary enforcement enabled but quarantine not configured
- Security audit spec mapping all Zeph components to 4 formal properties (Task/Action/Source/Data alignment) at `.local/specs/security-model-audit.md`

## Breaking change

`tool_allowlist = []` for MCP servers previously warned and allowed all tools. It now denies all tools (fail-closed). Set `tool_allowlist` to the explicit list of allowed tools, or remove the field to inherit server config.

## Test plan

- [ ] `cargo nextest run --workspace --features full --lib --bins` — 7279 passed (+10 over baseline)
- [ ] `cargo clippy --all-targets --features full --workspace -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean
- [ ] New tests: `sanitize_tool_output_cross_boundary_acp_mcp_quarantines`, `sanitize_tool_output_cross_boundary_disabled_skips_quarantine`, `sanitize_tool_output_non_acp_session_normal_path`

## Follow-up issues

- P2: `PATH` and `*_proxy` missing from env var blocklist in `mcp_bridge.rs`
- P3: `AuditLogger::log()` silently drops entries on serialization failure (no error logged)

Closes #2417, #2426, #2427