### PR TITLE
fix(security): extend MCP env var blocklist and fix audit logger silent drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fix(acp): populate `authMethods` in `initialize` response with `Agent` auth method — ACP clients now receive `[{type: "agent", id: "zeph", name: "Zeph"}]` in the `authMethods` field of every `InitializeResponse` (closes #2422)
 - fix(acp): serve agent identity manifest at `GET /agent.json` — new endpoint gated on `discovery_enabled`, returns `id`, `name`, `version`, `description`, and `distribution` fields for ACP Registry discovery (closes #2422)
 - fix(acp): eliminate IPI wiring duplication in `acp.rs` `spawn_acp_agent` — extract `apply_three_class_classifier_with_cfg` and `apply_causal_analyzer_with_cfg` helpers in `agent_setup.rs`; `spawn_acp_agent` now delegates to shared helpers instead of inlining classifier construction (closes #2370)
-- fix(acp): discovery endpoint already reflects `ProtocolVersion::LATEST` — confirmed fixed in PR #2423; no code change required (#2412)
+- fix(acp): discovery endpoint already reflects `ProtocolVersion::LATEST` — confirmed fixed in PR #2423; no code change required (closes #2412)
+- fix(security): extend MCP env var blocklist — `PATH`, `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `NO_PROXY`, `BASH_ENV`, `ENV`, `PYTHONPATH`, `NODE_PATH`, `RUBYLIB` are now stripped from ACP-provided env vars for MCP stdio child processes (closes #2437)
+- fix(tools): `AuditLogger::log` now emits `tracing::error!` when `serde_json` serialization fails instead of silently dropping the audit entry (closes #2438)
 
 ### Added (tests)
 

--- a/crates/zeph-acp/src/mcp_bridge.rs
+++ b/crates/zeph-acp/src/mcp_bridge.rs
@@ -73,17 +73,33 @@ pub fn acp_mcp_servers_to_entries(servers: &[acp::McpServer]) -> Vec<ServerEntry
 }
 
 /// Env vars that must never be passed from ACP clients to MCP child processes.
-/// These enable library injection, path hijacking, and other privilege escalation vectors.
+/// These enable library injection, path hijacking, proxy interception, and other privilege
+/// escalation vectors.
 fn is_dangerous_env_var(name: &str) -> bool {
     let upper = name.to_ascii_uppercase();
     matches!(
         upper.as_str(),
+        // Library injection (Linux / macOS)
         "LD_PRELOAD"
             | "LD_LIBRARY_PATH"
             | "DYLD_INSERT_LIBRARIES"
             | "DYLD_LIBRARY_PATH"
             | "DYLD_FRAMEWORK_PATH"
             | "DYLD_FALLBACK_LIBRARY_PATH"
+            // Path hijacking — attacker-controlled PATH redirects binary execution
+            | "PATH"
+            // Network proxy interception
+            | "HTTP_PROXY"
+            | "HTTPS_PROXY"
+            | "ALL_PROXY"
+            | "NO_PROXY"
+            // Shell startup injection — executed by bash/sh unconditionally on startup
+            | "BASH_ENV"
+            | "ENV"
+            // Interpreted-runtime module injection
+            | "PYTHONPATH"
+            | "NODE_PATH"
+            | "RUBYLIB"
     )
 }
 
@@ -198,6 +214,16 @@ mod tests {
             acp::EnvVariable::new("LD_PRELOAD", "/tmp/evil.so"),
             acp::EnvVariable::new("DYLD_INSERT_LIBRARIES", "/tmp/evil.dylib"),
             acp::EnvVariable::new("LD_LIBRARY_PATH", "/tmp"),
+            acp::EnvVariable::new("PATH", "/tmp/evil/bin:/bin"),
+            acp::EnvVariable::new("HTTP_PROXY", "http://evil.proxy:8080"),
+            acp::EnvVariable::new("HTTPS_PROXY", "http://evil.proxy:8080"),
+            acp::EnvVariable::new("ALL_PROXY", "http://evil.proxy:8080"),
+            acp::EnvVariable::new("NO_PROXY", ""),
+            acp::EnvVariable::new("BASH_ENV", "/tmp/evil.sh"),
+            acp::EnvVariable::new("ENV", "/tmp/evil.sh"),
+            acp::EnvVariable::new("PYTHONPATH", "/tmp/evil"),
+            acp::EnvVariable::new("NODE_PATH", "/tmp/evil"),
+            acp::EnvVariable::new("RUBYLIB", "/tmp/evil"),
         ]);
         let entries = acp_mcp_servers_to_entries(&[acp::McpServer::Stdio(stdio)]);
         if let McpTransport::Stdio { env, .. } = &entries[0].transport {
@@ -205,6 +231,16 @@ mod tests {
             assert!(env.get("LD_PRELOAD").is_none());
             assert!(env.get("DYLD_INSERT_LIBRARIES").is_none());
             assert!(env.get("LD_LIBRARY_PATH").is_none());
+            assert!(env.get("PATH").is_none());
+            assert!(env.get("HTTP_PROXY").is_none());
+            assert!(env.get("HTTPS_PROXY").is_none());
+            assert!(env.get("ALL_PROXY").is_none());
+            assert!(env.get("NO_PROXY").is_none());
+            assert!(env.get("BASH_ENV").is_none());
+            assert!(env.get("ENV").is_none());
+            assert!(env.get("PYTHONPATH").is_none());
+            assert!(env.get("NODE_PATH").is_none());
+            assert!(env.get("RUBYLIB").is_none());
         } else {
             panic!("expected Stdio transport");
         }
@@ -229,14 +265,32 @@ mod tests {
 
     #[test]
     fn is_dangerous_env_var_cases() {
+        // Library injection
         assert!(super::is_dangerous_env_var("LD_PRELOAD"));
         assert!(super::is_dangerous_env_var("ld_preload"));
         assert!(super::is_dangerous_env_var("DYLD_INSERT_LIBRARIES"));
         assert!(super::is_dangerous_env_var("DYLD_LIBRARY_PATH"));
         assert!(super::is_dangerous_env_var("DYLD_FRAMEWORK_PATH"));
         assert!(super::is_dangerous_env_var("DYLD_FALLBACK_LIBRARY_PATH"));
-        assert!(!super::is_dangerous_env_var("PATH"));
+        // Path hijacking
+        assert!(super::is_dangerous_env_var("PATH"));
+        assert!(super::is_dangerous_env_var("path"));
+        // Network proxy interception
+        assert!(super::is_dangerous_env_var("HTTP_PROXY"));
+        assert!(super::is_dangerous_env_var("HTTPS_PROXY"));
+        assert!(super::is_dangerous_env_var("ALL_PROXY"));
+        assert!(super::is_dangerous_env_var("NO_PROXY"));
+        assert!(super::is_dangerous_env_var("http_proxy"));
+        // Shell startup injection
+        assert!(super::is_dangerous_env_var("BASH_ENV"));
+        assert!(super::is_dangerous_env_var("ENV"));
+        // Runtime module injection
+        assert!(super::is_dangerous_env_var("PYTHONPATH"));
+        assert!(super::is_dangerous_env_var("NODE_PATH"));
+        assert!(super::is_dangerous_env_var("RUBYLIB"));
+        // Safe vars
         assert!(!super::is_dangerous_env_var("HOME"));
         assert!(!super::is_dangerous_env_var("MY_VAR"));
+        assert!(!super::is_dangerous_env_var("LANG"));
     }
 }

--- a/crates/zeph-tools/src/audit.rs
+++ b/crates/zeph-tools/src/audit.rs
@@ -86,8 +86,12 @@ impl AuditLogger {
     }
 
     pub async fn log(&self, entry: &AuditEntry) {
-        let Ok(json) = serde_json::to_string(entry) else {
-            return;
+        let json = match serde_json::to_string(entry) {
+            Ok(j) => j,
+            Err(err) => {
+                tracing::error!("audit entry serialization failed: {err}");
+                return;
+            }
         };
 
         match &self.destination {


### PR DESCRIPTION
## Summary

- **#2437**: Extend `is_dangerous_env_var()` in `crates/zeph-acp/src/mcp_bridge.rs` — PR #2436 only blocked library injection vectors (`LD_PRELOAD`, `DYLD_*`). This PR adds the remaining attack surface: `PATH` (path hijacking), `HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY`/`NO_PROXY` (proxy interception), `BASH_ENV`/`ENV` (shell startup injection), `PYTHONPATH`/`NODE_PATH`/`RUBYLIB` (runtime module injection).
- **#2438**: Replace the silent `return` in `AuditLogger::log()` with `tracing::error!("audit entry serialization failed: {err}")` so broken audit entries are observable in logs.
- **#2412**: Already resolved in PR #2423 (`ProtocolVersion::LATEST` in discovery handler). CHANGELOG entry added.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --features full --lib --bins` — 7279 passed
- [x] New and updated unit tests in `mcp_bridge.rs` cover all 14 newly-blocked env var names plus case-insensitivity