### PR TITLE
fix(db): force max_connections=1 for in-memory SQLite pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - fix(tools): agent now prefers `memory_search` over `search_code` when recalling user-provided facts — updated `search_code` description to exclude user facts/preferences; updated `memory_search` description to emphasise user-provided context recall; session-level hint injected into the volatile system prompt block when `memory_save` was called in the current session (closes #2475)
+- fix(db): in-memory SQLite pool forced to `max_connections = 1` so all queries share the same connection and the migrated schema — previously each additional connection in the pool opened a separate empty in-memory database, causing `no such column: superseded_by` in 91 graph tests after migration 056 was introduced (closes #2468)
 
 ### Added
 

--- a/crates/zeph-db/src/pool.rs
+++ b/crates/zeph-db/src/pool.rs
@@ -74,7 +74,13 @@ impl DbConfig {
 
         // BEGIN IMMEDIATE serializes concurrent writers at the SQLite level.
         // pool_size controls the connection count; max_connections is the upper bound.
-        let effective_max = max_connections.max(pool_size);
+        // In-memory databases are connection-scoped: each new connection is a separate
+        // empty DB. Force a single connection so all queries share the migrated schema.
+        let effective_max = if path == ":memory:" {
+            1
+        } else {
+            max_connections.max(pool_size)
+        };
         let pool = SqlitePoolOptions::new()
             .max_connections(effective_max)
             .min_connections(1)


### PR DESCRIPTION
## Summary

- In-memory SQLite DBs are connection-scoped: each new pool connection is a separate empty database
- When `pool_size > 1`, queries routed to non-migration connections hit a schema-less DB and fail with `no such column: superseded_by`
- Fix: cap `max_connections = 1` for `:memory:` URLs in `DbConfig::connect_sqlite`

## Root cause

`sqlite::memory:` in sqlx creates a distinct in-memory database per physical connection. The pool had `min_connections = 1` and `max_connections = 5`. Migrations ran on the first connection; subsequent connections opened fresh, schema-less DBs. After migration 056 (`superseded_by` column on `graph_edges`), all graph tests that used `SqliteStore::new(":memory:")` began failing with `code: 1, message: "no such column: superseded_by"`.

## Test results

Before: 7326 pass / 91 fail  
After: 7445 pass / 0 fail

Closes #2468