### PR TITLE
fix(skills): prevent low-confidence skill injection (#2512, #2513, #2501)

### DIFF
--- a/.zeph/skills/os-automation/SKILL.md
+++ b/.zeph/skills/os-automation/SKILL.md
@@ -8,7 +8,8 @@ description: >
   create scheduled tasks and cron jobs, and manage display brightness.
   Use when the user asks to send a notification, copy to clipboard, take a
   screenshot, open a file or URL, launch an app, adjust volume, check WiFi,
-  schedule a task, or automate any OS-level action on macOS, Windows, or Linux.
+  schedule a task, or control OS UI and system settings on macOS, Windows, or Linux.
+  Do not use for running arbitrary shell commands or scripts — use the shell tool instead.
 license: MIT
 compatibility: Uses built-in OS utilities; some features require specific tools (see per-platform references)
 metadata:

--- a/.zeph/skills/process-management/SKILL.md
+++ b/.zeph/skills/process-management/SKILL.md
@@ -5,8 +5,8 @@ description: >
   Monitor, manage, and control system processes. Use when the user asks to list
   running processes, find a process by name or PID, kill or terminate processes,
   manage background jobs, check resource usage, set resource limits, manage
-  system services with systemctl or launchctl, or troubleshoot CPU and memory
-  consumption with ps, top, htop, kill, pgrep, and related tools.
+  system services with systemctl or launchctl, or troubleshoot CPU and RAM usage
+  with ps, top, htop, kill, pgrep, and related tools.
 license: MIT
 metadata:
   author: zeph

--- a/.zeph/skills/rust-agent-handoff/SKILL.md
+++ b/.zeph/skills/rust-agent-handoff/SKILL.md
@@ -2,11 +2,11 @@
 name: rust-agent-handoff
 category: dev
 description: >
-  Handoff protocol for Rust multi-agent development system with structured YAML communication.
-  Use when working as rust-architect, rust-developer, rust-testing-engineer,
-  rust-performance-engineer, rust-security-maintenance, rust-code-reviewer,
-  rust-cicd-devops, rust-debugger, or rust-critic. ALWAYS read on agent startup.
-  Keywords: handoff, agent, subagent, workflow, orchestration, yaml, protocol, team.
+  Handoff protocol for the Rust multi-agent development team (rust-architect, rust-developer,
+  rust-testing-engineer, rust-performance-engineer, rust-security-maintenance,
+  rust-code-reviewer, rust-cicd-devops, rust-debugger, rust-critic). Use only when
+  orchestrating subagents via structured YAML files in .local/handoff/. Not for general
+  agent interactions or memory updates.
 metadata:
   author: zeph
   version: "1.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- skills: raise `disambiguation_threshold` default from 0.05 to 0.20 to prevent low-confidence skill injection (#2512)
+- skills: add `min_injection_score` config field (default 0.20) — skills scoring below threshold are no longer injected (#2512)
+- skills: fix `process-management` SKILL.md false positive on user queries containing "memory" by replacing with "RAM" (#2513)
+- skills: fix `os-automation` SKILL.md over-triggering on generic shell commands — add explicit negative scope sentence (#2501)
+- skills: fix `rust-agent-handoff` SKILL.md — remove noisy Keywords line, tighten description to exclude generic update/memory prompts (#2512)
+
 ## [0.18.1] - 2026-03-31
 
 ### Fixed

--- a/crates/zeph-config/src/features.rs
+++ b/crates/zeph-config/src/features.rs
@@ -8,7 +8,11 @@ use crate::learning::LearningConfig;
 use crate::security::TrustConfig;
 
 fn default_disambiguation_threshold() -> f32 {
-    0.05
+    0.20
+}
+
+fn default_min_injection_score() -> f32 {
+    0.20
 }
 
 fn default_cosine_weight() -> f32 {
@@ -117,6 +121,8 @@ pub struct SkillsConfig {
     pub max_active_skills: usize,
     #[serde(default = "default_disambiguation_threshold")]
     pub disambiguation_threshold: f32,
+    #[serde(default = "default_min_injection_score")]
+    pub min_injection_score: f32,
     #[serde(default = "default_cosine_weight")]
     pub cosine_weight: f32,
     #[serde(default = "default_hybrid_search")]

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -156,7 +156,8 @@ impl Default for Config {
             skills: SkillsConfig {
                 paths: default_skill_paths(),
                 max_active_skills: 5,
-                disambiguation_threshold: 0.05,
+                disambiguation_threshold: 0.20,
+                min_injection_score: 0.20,
                 cosine_weight: 0.7,
                 hybrid_search: true,
                 learning: LearningConfig::default(),

--- a/crates/zeph-core/config/default.toml
+++ b/crates/zeph-core/config/default.toml
@@ -167,7 +167,9 @@ max_active_skills = 5
 # Prompt mode: "full" (inject full SKILL.md), "compact" (name+description only), "auto" (compact if budget < 8192)
 # prompt_mode = "auto"
 # Minimum score delta for skill disambiguation (0.0-1.0)
-# disambiguation_threshold = 0.05
+# disambiguation_threshold = 0.20
+# Minimum absolute score a skill must reach to be injected into context (0.0-1.0)
+# min_injection_score = 0.20
 
 [skills.learning]
 # Enable self-learning skill improvement (feature enabled by default, runtime toggle)

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -1327,6 +1327,10 @@ impl<C: Channel> Agent<C> {
                 tracing::warn!("skill matcher returned no results, falling back to all skills");
                 (0..all_meta.len()).collect()
             } else {
+                // Drop skills whose score falls below the minimum injection floor.
+                let min_score = self.skill_state.min_injection_score;
+                scored.retain(|s| s.score >= min_score);
+
                 // Capture the names of skills that had real embedding scores for
                 // usage stats — before disambiguation may reorder indices.
                 skills_to_record = scored

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -334,7 +334,8 @@ impl<C: Channel> Agent<C> {
                 trust_config: crate::config::TrustConfig::default(),
                 matcher,
                 max_active_skills,
-                disambiguation_threshold: 0.05,
+                disambiguation_threshold: 0.20,
+                min_injection_score: 0.20,
                 embedding_model: String::new(),
                 skill_reload_rx: None,
                 active_skill_names: Vec::new(),
@@ -4807,6 +4808,7 @@ impl<C: Channel> Agent<C> {
         self.memory_state.summarization_threshold = config.memory.summarization_threshold;
         self.skill_state.max_active_skills = config.skills.max_active_skills;
         self.skill_state.disambiguation_threshold = config.skills.disambiguation_threshold;
+        self.skill_state.min_injection_score = config.skills.min_injection_score;
         self.skill_state.cosine_weight = config.skills.cosine_weight.clamp(0.0, 1.0);
         self.skill_state.hybrid_search = config.skills.hybrid_search;
         self.skill_state.two_stage_matching = config.skills.two_stage_matching;

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -80,6 +80,7 @@ pub(crate) struct SkillState {
     pub(crate) matcher: Option<SkillMatcherBackend>,
     pub(crate) max_active_skills: usize,
     pub(crate) disambiguation_threshold: f32,
+    pub(crate) min_injection_score: f32,
     pub(crate) embedding_model: String,
     pub(crate) skill_reload_rx: Option<mpsc::Receiver<SkillEvent>>,
     pub(crate) active_skill_names: Vec<String>,

--- a/crates/zeph-memory/src/admission.rs
+++ b/crates/zeph-memory/src/admission.rs
@@ -772,14 +772,14 @@ mod tests {
     fn cosine_similarity_zero_vector_returns_zero() {
         let z = vec![0.0f32, 0.0, 0.0];
         let v = vec![1.0f32, 2.0, 3.0];
-        assert_eq!(cosine_similarity(&z, &v), 0.0);
+        assert!(cosine_similarity(&z, &v).abs() < f32::EPSILON);
     }
 
     #[test]
     fn cosine_similarity_length_mismatch_returns_zero() {
         let a = vec![1.0f32, 0.0];
         let b = vec![1.0f32, 0.0, 0.0];
-        assert_eq!(cosine_similarity(&a, &b), 0.0);
+        assert!(cosine_similarity(&a, &b).abs() < f32::EPSILON);
     }
 
     // ── with_goal_gate tests ──────────────────────────────────────────────────
@@ -836,6 +836,6 @@ mod tests {
             provider: None,
         };
         let ctrl = ctrl.with_goal_gate(config);
-        assert_eq!(ctrl.weights.goal_utility, 0.0);
+        assert!(ctrl.weights.goal_utility.abs() < f32::EPSILON);
     }
 }


### PR DESCRIPTION
## Summary

- Add `min_injection_score` config field (default 0.20) — skills scoring below threshold are no longer injected, closing the structural gap where top-N skills were injected regardless of absolute score (#2512)
- Raise `disambiguation_threshold` default from 0.05 to 0.20
- Fix `process-management` SKILL.md: replace "memory" → "RAM" to prevent BM25 false match on user queries containing the word "memory" (#2513)
- Fix `os-automation` SKILL.md: replace catch-all phrase, add explicit negative scope sentence to prevent over-triggering on generic shell commands (#2501)
- Fix `rust-agent-handoff` SKILL.md: remove noisy `Keywords:` line, tighten description to exclude generic update/memory prompts (#2512)
- Fix pre-existing `clippy::float_cmp` violations in `zeph-memory/src/admission.rs`

## Test plan

- [x] `cargo +nightly fmt --check` — passed
- [x] `cargo clippy --all-targets --features full --workspace -- -D warnings` — passed
- [x] `cargo nextest run --workspace --features full --lib --bins` — 7564 passed, 22 skipped

Closes #2512, #2513, #2501