### PR TITLE
fix(security): reclassify search_code as ToolResult, add PII NER input truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - skills: fix `process-management` SKILL.md false positive on user queries containing "memory" by replacing with "RAM" (#2513)
 - skills: fix `os-automation` SKILL.md over-triggering on generic shell commands — add explicit negative scope sentence (#2501)
 - skills: fix `rust-agent-handoff` SKILL.md — remove noisy Keywords line, tighten description to exclude generic update/memory prompts (#2512)
+- security: reclassify `search_code` as `ToolResult` to prevent false-positive injection detection on local index output (#2515)
+- security: truncate PII NER input to `pii_ner_max_chars` (default 8192) to prevent timeout on large `search_code` outputs (#2516)
+
+### Added
+
+- metrics: add `sanitizer_injection_fp_local` counter for injection flags on local (`ToolResult`) sources (#2515)
+- metrics: add `pii_ner_timeouts` counter for NER classifier timeout events (#2516)
 
 ## [0.18.1] - 2026-03-31
 

--- a/crates/zeph-config/src/classifiers.rs
+++ b/crates/zeph-config/src/classifiers.rs
@@ -31,6 +31,10 @@ fn default_pii_threshold() -> f32 {
     0.75
 }
 
+fn default_pii_ner_max_chars() -> usize {
+    8192
+}
+
 fn default_three_class_threshold() -> f32 {
     0.7
 }
@@ -192,6 +196,13 @@ pub struct ClassifiersConfig {
     /// Optional SHA-256 hex digest of the PII model safetensors file.
     #[serde(default)]
     pub pii_model_sha256: Option<String>,
+
+    /// Maximum number of bytes passed to the NER PII classifier per call.
+    ///
+    /// Input is truncated at a valid UTF-8 boundary before classification to prevent
+    /// timeout on large tool outputs (e.g. `search_code`). Default `8192`.
+    #[serde(default = "default_pii_ner_max_chars")]
+    pub pii_ner_max_chars: usize,
 }
 
 impl Default for ClassifiersConfig {
@@ -213,6 +224,7 @@ impl Default for ClassifiersConfig {
             pii_model: default_pii_model(),
             pii_threshold: default_pii_threshold(),
             pii_model_sha256: None,
+            pii_ner_max_chars: default_pii_ner_max_chars(),
         }
     }
 }
@@ -324,6 +336,7 @@ mod tests {
             pii_model: "org/pii-model".into(),
             pii_threshold: 0.80,
             pii_model_sha256: None,
+            pii_ner_max_chars: 4096,
         };
         let serialized = toml::to_string(&original).unwrap();
         let deserialized: ClassifiersConfig = toml::from_str(&serialized).unwrap();

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -845,9 +845,11 @@ impl<C: Channel> Agent<C> {
         mut self,
         backend: std::sync::Arc<dyn zeph_llm::classifier::ClassifierBackend>,
         timeout_ms: u64,
+        max_chars: usize,
     ) -> Self {
         self.security.pii_ner_backend = Some(backend);
         self.security.pii_ner_timeout_ms = timeout_ms;
+        self.security.pii_ner_max_chars = max_chars;
         self
     }
 

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -443,6 +443,8 @@ impl<C: Channel> Agent<C> {
                 pii_ner_backend: None,
                 #[cfg(feature = "classifiers")]
                 pii_ner_timeout_ms: 5000,
+                #[cfg(feature = "classifiers")]
+                pii_ner_max_chars: 8192,
                 memory_validator: zeph_sanitizer::memory_validation::MemoryWriteValidator::new(
                     zeph_sanitizer::memory_validation::MemoryWriteValidationConfig::default(),
                 ),

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -215,6 +215,12 @@ pub(crate) struct SecurityState {
     /// Per-call timeout for the NER PII classifier in milliseconds.
     #[cfg(feature = "classifiers")]
     pub(crate) pii_ner_timeout_ms: u64,
+    /// Maximum number of bytes passed to the NER PII classifier per call.
+    ///
+    /// Large tool outputs (e.g. `search_code`) can produce 150+ `DeBERTa` chunks and exceed
+    /// the per-call timeout. Input is truncated at a valid UTF-8 boundary before classification.
+    #[cfg(feature = "classifiers")]
+    pub(crate) pii_ner_max_chars: usize,
     pub(crate) memory_validator: zeph_sanitizer::memory_validation::MemoryWriteValidator,
     /// LLM-based prompt injection pre-screener (opt-in).
     #[cfg(feature = "guardrail")]

--- a/crates/zeph-core/src/agent/tool_execution/mod.rs
+++ b/crates/zeph-core/src/agent/tool_execution/mod.rs
@@ -301,8 +301,7 @@ impl<C: Channel> Agent<C> {
         // MCP tools use "server:tool" format (contains ':') or legacy "mcp" name.
         // Web scrape tools use "web-scrape" (hyphenated) or "fetch".
         // Everything else is local shell/file output.
-        let source = if tool_name.contains(':') || tool_name == "mcp" || tool_name == "search_code"
-        {
+        let source = if tool_name.contains(':') || tool_name == "mcp" {
             ContentSource::new(ContentSourceKind::McpResponse).with_identifier(tool_name)
         } else if tool_name == "web-scrape" || tool_name == "web_scrape" || tool_name == "fetch" {
             ContentSource::new(ContentSourceKind::WebScrape).with_identifier(tool_name)
@@ -331,7 +330,11 @@ impl<C: Channel> Agent<C> {
                 "injection patterns detected in tool output"
             );
             self.update_metrics(|m| {
-                m.sanitizer_injection_flags += sanitized.injection_flags.len() as u64;
+                let flag_count = sanitized.injection_flags.len() as u64;
+                m.sanitizer_injection_flags += flag_count;
+                if sanitized.source.kind == zeph_sanitizer::ContentSourceKind::ToolResult {
+                    m.sanitizer_injection_fp_local += flag_count;
+                }
             });
             let detail = sanitized
                 .injection_flags
@@ -540,24 +543,31 @@ impl<C: Channel> Agent<C> {
         if let Some(ref backend) = self.security.pii_ner_backend {
             use zeph_sanitizer::pii::build_char_to_byte_map;
             let timeout_ms = self.security.pii_ner_timeout_ms;
+            let ner_input = if text.len() > self.security.pii_ner_max_chars {
+                let boundary = text.floor_char_boundary(self.security.pii_ner_max_chars);
+                &text[..boundary]
+            } else {
+                text
+            };
             match tokio::time::timeout(
                 std::time::Duration::from_millis(timeout_ms),
-                backend.classify(text),
+                backend.classify(ner_input),
             )
             .await
             {
                 Ok(Ok(result)) if result.is_positive => {
                     // Precompute char→byte map once for all NER spans (C2).
-                    let char_to_byte = build_char_to_byte_map(text);
+                    // Use ner_input: NER offsets are relative to the (possibly truncated) input.
+                    let char_to_byte = build_char_to_byte_map(ner_input);
                     for ner_span in &result.spans {
                         let byte_start = char_to_byte
                             .get(ner_span.start)
                             .copied()
-                            .unwrap_or(text.len());
+                            .unwrap_or(ner_input.len());
                         let byte_end = char_to_byte
                             .get(ner_span.end)
                             .copied()
-                            .unwrap_or(text.len());
+                            .unwrap_or(ner_input.len());
                         if byte_end > byte_start {
                             spans.push(zeph_sanitizer::pii::PiiSpan {
                                 label: ner_span.label.clone(),
@@ -577,6 +587,7 @@ impl<C: Channel> Agent<C> {
                         tool = %tool_name,
                         "PII NER timed out, regex only"
                     );
+                    self.update_metrics(|m| m.pii_ner_timeouts += 1);
                 }
             }
         }

--- a/crates/zeph-core/src/metrics.rs
+++ b/crates/zeph-core/src/metrics.rs
@@ -263,6 +263,12 @@ pub struct MetricsSnapshot {
     pub server_compaction_events: u64,
     pub sanitizer_runs: u64,
     pub sanitizer_injection_flags: u64,
+    /// Injection pattern hits on `ToolResult` (local) sources — likely false positives.
+    ///
+    /// Counts regex hits that fired on content from `shell`, `read_file`, `search_code`, etc.
+    /// These sources are user-owned and not adversarial; a non-zero value indicates a pattern
+    /// that needs tightening or a source reclassification.
+    pub sanitizer_injection_fp_local: u64,
     pub sanitizer_truncations: u64,
     pub quarantine_invocations: u64,
     pub quarantine_failures: u64,
@@ -276,6 +282,8 @@ pub struct MetricsSnapshot {
     pub exfiltration_tool_urls_flagged: u64,
     pub exfiltration_memory_guards: u64,
     pub pii_scrub_count: u64,
+    /// Number of times the PII NER classifier timed out; input fell back to regex-only.
+    pub pii_ner_timeouts: u64,
     pub memory_validation_failures: u64,
     pub rate_limit_trips: u64,
     pub pre_execution_blocks: u64,

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -654,7 +654,11 @@ pub(crate) fn apply_pii_ner_classifier<C: Channel>(
         repo_id = %config.classifiers.pii_model,
         "NER PII classifier attached for union merge pipeline (model loads lazily on first use)"
     );
-    agent.with_pii_ner_classifier(backend, config.classifiers.timeout_ms)
+    agent.with_pii_ner_classifier(
+        backend,
+        config.classifiers.timeout_ms,
+        config.classifiers.pii_ner_max_chars,
+    )
 }
 
 /// Wire `enforcement_mode` from config into the agent's injection classifier.


### PR DESCRIPTION
## Summary

- Reclassify `search_code` as `ToolResult` (same trust tier as `shell`/`read_file`) instead of `McpResponse`. The tool queries a local AST index built from user-owned code — treating it as remote/untrusted caused false-positive injection flags on Cargo.toml section headers, README badge URLs, and shell examples in code blocks, silently blocking Qdrant memory writes.
- Add `pii_ner_max_chars` config field (default 8192) to `ClassifiersConfig` / `AgentSecurity`. PII NER input is now truncated at a valid UTF-8 boundary before `backend.classify()`, preventing 150+ DeBERTa chunks on large `search_code` outputs from exceeding the per-call timeout and falling back to regex-only detection.
- Add `sanitizer_injection_fp_local` and `pii_ner_timeouts` metrics counters.

Closes #2515, closes #2516.

## Changed files

- `crates/zeph-config/src/classifiers.rs` — new `pii_ner_max_chars: usize` field (default 8192)
- `crates/zeph-core/src/agent/state/mod.rs` — `pii_ner_max_chars` in `SecurityState`
- `crates/zeph-core/src/agent/builder.rs` — `with_pii_ner_classifier` accepts `max_chars`
- `crates/zeph-core/src/agent/mod.rs` — default initializer
- `crates/zeph-core/src/agent/tool_execution/mod.rs` — reclassify `search_code`; truncate NER input
- `crates/zeph-core/src/metrics.rs` — two new counters
- `src/agent_setup.rs` — passes `pii_ner_max_chars` from config to builder
- `CHANGELOG.md` — entries under `[Unreleased]`

## Test plan

- [ ] 7564/7564 tests pass (`cargo nextest run --workspace --features full --lib --bins`)
- [ ] `cargo clippy --workspace --features full -- -D warnings` clean
- [ ] `cargo +nightly fmt --check` clean
- [ ] Live session: ask agent to read `Cargo.toml` — no injection flags in log
- [ ] Live session: trigger `search_code` — no PII NER timeout in log