### PR TITLE
feat(tools): structured shell output envelope and per-path read sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- feat(tools): structured shell output envelope (#2488) — `execute_bash` now captures stdout and stderr as separate streams at the process level using a tagged `(bool, String)` channel; `ShellOutputEnvelope { stdout, stderr, exit_code, truncated }` is built post-execution and serialized into `ToolOutput.raw_response` for ACP/audit consumers; LLM context continues using the interleaved combined output in `summary`; `AuditEntry` gains optional `exit_code: Option<i32>` and `truncated: bool` fields (`skip_serializing_if` for backward compat)
+- feat(tools): per-path read allow/deny sandbox for file tool (#2489) — new `[tools.file]` config section with `deny_read` and `allow_read` glob pattern lists; evaluation order: deny-then-allow; all patterns matched against canonicalized absolute paths (prevents symlink bypass); `FileExecutor::with_read_sandbox()` builder method applies the sandbox; `handle_read()` checks sandbox before `read_to_string`; `grep_recursive` skips denied files before reading content; `FileConfig` exported from `zeph-tools`
+
 ### Fixed
 
 - skills: raise `disambiguation_threshold` default from 0.05 to 0.20 to prevent low-confidence skill injection (#2512)

--- a/crates/zeph-core/src/agent/tool_execution/mod.rs
+++ b/crates/zeph-core/src/agent/tool_execution/mod.rs
@@ -438,6 +438,8 @@ impl<C: Channel> Agent<C> {
                     embedding_anomalous: false,
                     cross_boundary_mcp_to_acp: true,
                     adversarial_policy_decision: None,
+                    exit_code: None,
+                    truncated: false,
                 };
                 let logger = std::sync::Arc::clone(logger);
                 tokio::spawn(async move { logger.log(&entry).await });

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -766,6 +766,8 @@ impl<C: Channel> Agent<C> {
                                     embedding_anomalous: false,
                                     cross_boundary_mcp_to_acp: false,
                                     adversarial_policy_decision: None,
+                                    exit_code: None,
+                                    truncated: false,
                                 };
                                 let logger = std::sync::Arc::clone(logger);
                                 tokio::spawn(async move { logger.log(&entry).await });

--- a/crates/zeph-tools/src/adversarial_gate.rs
+++ b/crates/zeph-tools/src/adversarial_gate.rs
@@ -142,6 +142,8 @@ impl<T: ToolExecutor> AdversarialPolicyGateExecutor<T> {
             embedding_anomalous: false,
             cross_boundary_mcp_to_acp: false,
             adversarial_policy_decision: Some(decision.to_owned()),
+            exit_code: None,
+            truncated: false,
         };
         audit.log(&entry).await;
     }

--- a/crates/zeph-tools/src/audit.rs
+++ b/crates/zeph-tools/src/audit.rs
@@ -17,6 +17,7 @@ enum AuditDestination {
 }
 
 #[derive(serde::Serialize)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct AuditEntry {
     pub timestamp: String,
     pub tool: String,
@@ -55,6 +56,12 @@ pub struct AuditEntry {
     /// `None` when adversarial policy is disabled or not applicable.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub adversarial_policy_decision: Option<String>,
+    /// Process exit code for shell tool executions. `None` for non-shell tools.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    /// Whether tool output was truncated before storage. Default false.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub truncated: bool,
 }
 
 #[derive(serde::Serialize)]
@@ -151,6 +158,8 @@ mod tests {
             embedding_anomalous: false,
             cross_boundary_mcp_to_acp: false,
             adversarial_policy_decision: None,
+            exit_code: None,
+            truncated: false,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(json.contains("\"type\":\"success\""));
@@ -177,6 +186,8 @@ mod tests {
             embedding_anomalous: false,
             cross_boundary_mcp_to_acp: false,
             adversarial_policy_decision: None,
+            exit_code: None,
+            truncated: false,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(json.contains("\"type\":\"blocked\""));
@@ -202,6 +213,8 @@ mod tests {
             embedding_anomalous: false,
             cross_boundary_mcp_to_acp: false,
             adversarial_policy_decision: None,
+            exit_code: None,
+            truncated: false,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(json.contains("\"type\":\"error\""));
@@ -224,6 +237,8 @@ mod tests {
             embedding_anomalous: false,
             cross_boundary_mcp_to_acp: false,
             adversarial_policy_decision: None,
+            exit_code: None,
+            truncated: false,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(json.contains("\"type\":\"timeout\""));
@@ -251,6 +266,8 @@ mod tests {
             embedding_anomalous: false,
             cross_boundary_mcp_to_acp: false,
             adversarial_policy_decision: None,
+            exit_code: None,
+            truncated: false,
         };
         logger.log(&entry).await;
     }
@@ -279,6 +296,8 @@ mod tests {
             embedding_anomalous: false,
             cross_boundary_mcp_to_acp: false,
             adversarial_policy_decision: None,
+            exit_code: None,
+            truncated: false,
         };
         logger.log(&entry).await;
 
@@ -334,6 +353,8 @@ mod tests {
             embedding_anomalous: false,
             cross_boundary_mcp_to_acp: false,
             adversarial_policy_decision: None,
+            exit_code: None,
+            truncated: false,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(
@@ -360,6 +381,8 @@ mod tests {
             embedding_anomalous: false,
             cross_boundary_mcp_to_acp: false,
             adversarial_policy_decision: None,
+            exit_code: None,
+            truncated: false,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(
@@ -394,11 +417,67 @@ mod tests {
                 embedding_anomalous: false,
                 cross_boundary_mcp_to_acp: false,
                 adversarial_policy_decision: None,
+                exit_code: None,
+                truncated: false,
             };
             logger.log(&entry).await;
         }
 
         let content = tokio::fs::read_to_string(&path).await.unwrap();
         assert_eq!(content.lines().count(), 5);
+    }
+
+    #[test]
+    fn audit_entry_exit_code_serialized() {
+        let entry = AuditEntry {
+            timestamp: "0".into(),
+            tool: "shell".into(),
+            command: "echo hi".into(),
+            result: AuditResult::Success,
+            duration_ms: 5,
+            error_category: None,
+            error_domain: None,
+            error_phase: None,
+            claim_source: None,
+            mcp_server_id: None,
+            injection_flagged: false,
+            embedding_anomalous: false,
+            cross_boundary_mcp_to_acp: false,
+            adversarial_policy_decision: None,
+            exit_code: Some(0),
+            truncated: false,
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(
+            json.contains("\"exit_code\":0"),
+            "exit_code must be serialized: {json}"
+        );
+    }
+
+    #[test]
+    fn audit_entry_exit_code_none_omitted() {
+        let entry = AuditEntry {
+            timestamp: "0".into(),
+            tool: "file".into(),
+            command: "read /tmp/x".into(),
+            result: AuditResult::Success,
+            duration_ms: 1,
+            error_category: None,
+            error_domain: None,
+            error_phase: None,
+            claim_source: None,
+            mcp_server_id: None,
+            injection_flagged: false,
+            embedding_anomalous: false,
+            cross_boundary_mcp_to_acp: false,
+            adversarial_policy_decision: None,
+            exit_code: None,
+            truncated: false,
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(
+            !json.contains("exit_code"),
+            "exit_code None must be omitted: {json}"
+        );
     }
 }

--- a/crates/zeph-tools/src/config.rs
+++ b/crates/zeph-tools/src/config.rs
@@ -420,6 +420,22 @@ impl AdversarialPolicyConfig {
     }
 }
 
+/// Per-path read allow/deny sandbox for the file tool.
+///
+/// Evaluation order: deny-then-allow. If a path matches `deny_read` and does NOT
+/// match `allow_read`, access is denied. Empty `deny_read` means no read restrictions.
+///
+/// All patterns are matched against the canonicalized (absolute, symlink-resolved) path.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct FileConfig {
+    /// Glob patterns for paths denied for reading. Evaluated first.
+    #[serde(default)]
+    pub deny_read: Vec<String>,
+    /// Glob patterns for paths allowed for reading. Evaluated second (overrides deny).
+    #[serde(default)]
+    pub allow_read: Vec<String>,
+}
+
 /// Top-level configuration for tool execution.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ToolsConfig {
@@ -460,6 +476,9 @@ pub struct ToolsConfig {
     /// Utility-guided tool dispatch gate.
     #[serde(default)]
     pub utility: UtilityScoringConfig,
+    /// Per-path read allow/deny sandbox for the file tool.
+    #[serde(default)]
+    pub file: FileConfig,
 }
 
 impl ToolsConfig {
@@ -572,6 +591,7 @@ impl Default for ToolsConfig {
             #[cfg(feature = "policy-enforcer")]
             adversarial_policy: AdversarialPolicyConfig::default(),
             utility: UtilityScoringConfig::default(),
+            file: FileConfig::default(),
         }
     }
 }

--- a/crates/zeph-tools/src/file.rs
+++ b/crates/zeph-tools/src/file.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use schemars::JsonSchema;
 use serde::Deserialize;
 
+use crate::config::FileConfig;
 use crate::executor::{
     ClaimSource, DiffData, ToolCall, ToolError, ToolExecutor, ToolOutput, deserialize_params,
 };
@@ -96,6 +97,8 @@ struct CopyPathParams {
 #[derive(Debug)]
 pub struct FileExecutor {
     allowed_paths: Vec<PathBuf>,
+    read_deny_globs: Option<globset::GlobSet>,
+    read_allow_globs: Option<globset::GlobSet>,
 }
 
 fn expand_tilde(path: PathBuf) -> PathBuf {
@@ -108,6 +111,24 @@ fn expand_tilde(path: PathBuf) -> PathBuf {
         return home.join(rest);
     }
     path
+}
+
+fn build_globset(patterns: &[String]) -> Option<globset::GlobSet> {
+    if patterns.is_empty() {
+        return None;
+    }
+    let mut builder = globset::GlobSetBuilder::new();
+    for pattern in patterns {
+        match globset::Glob::new(pattern) {
+            Ok(g) => {
+                builder.add(g);
+            }
+            Err(e) => {
+                tracing::warn!(pattern = %pattern, err = %e, "invalid file sandbox glob pattern, skipping");
+            }
+        }
+    }
+    builder.build().ok().filter(|s| !s.is_empty())
 }
 
 impl FileExecutor {
@@ -123,7 +144,37 @@ impl FileExecutor {
                 .into_iter()
                 .map(|p| p.canonicalize().unwrap_or(p))
                 .collect(),
+            read_deny_globs: None,
+            read_allow_globs: None,
         }
+    }
+
+    /// Apply per-path read allow/deny sandbox rules from config.
+    #[must_use]
+    pub fn with_read_sandbox(mut self, config: &FileConfig) -> Self {
+        self.read_deny_globs = build_globset(&config.deny_read);
+        self.read_allow_globs = build_globset(&config.allow_read);
+        self
+    }
+
+    /// Check if the canonical path is permitted by the deny/allow glob rules.
+    ///
+    /// Always matches against the canonicalized path to prevent symlink bypass (CR-02, MJ-01).
+    fn check_read_sandbox(&self, canonical: &Path) -> Result<(), ToolError> {
+        let Some(ref deny) = self.read_deny_globs else {
+            return Ok(());
+        };
+        if deny.is_match(canonical)
+            && !self
+                .read_allow_globs
+                .as_ref()
+                .is_some_and(|allow| allow.is_match(canonical))
+        {
+            return Err(ToolError::SandboxViolation {
+                path: canonical.display().to_string(),
+            });
+        }
+        Ok(())
     }
 
     fn validate_path(&self, path: &Path) -> Result<PathBuf, ToolError> {
@@ -201,6 +252,7 @@ impl FileExecutor {
 
     fn handle_read(&self, params: &ReadParams) -> Result<Option<ToolOutput>, ToolError> {
         let path = self.validate_path(Path::new(&params.path))?;
+        self.check_read_sandbox(&path)?;
         let content = std::fs::read_to_string(&path)?;
 
         let offset = params.offset.unwrap_or(0) as usize;
@@ -340,8 +392,9 @@ impl FileExecutor {
             ))
         })?;
 
+        let sandbox = |p: &Path| self.check_read_sandbox(p);
         let mut results = Vec::new();
-        grep_recursive(&path, &regex, &mut results, 100)?;
+        grep_recursive(&path, &regex, &mut results, 100, &sandbox)?;
 
         Ok(Some(ToolOutput {
             tool_name: "grep".to_owned(),
@@ -696,11 +749,17 @@ fn grep_recursive(
     regex: &regex::Regex,
     results: &mut Vec<String>,
     limit: usize,
+    sandbox: &impl Fn(&Path) -> Result<(), ToolError>,
 ) -> Result<(), ToolError> {
     if results.len() >= limit {
         return Ok(());
     }
     if path.is_file() {
+        // Canonicalize before sandbox check to prevent symlink bypass (SEC-01).
+        let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        if sandbox(&canonical).is_err() {
+            return Ok(());
+        }
         if let Ok(content) = std::fs::read_to_string(path) {
             for (i, line) in content.lines().enumerate() {
                 if regex.is_match(line) {
@@ -719,7 +778,7 @@ fn grep_recursive(
             if name.is_some_and(|n| n.starts_with('.') || IGNORED_DIRS.contains(&n)) {
                 continue;
             }
-            grep_recursive(&p, regex, results, limit)?;
+            grep_recursive(&p, regex, results, limit, sandbox)?;
         }
     }
     Ok(())
@@ -1543,5 +1602,89 @@ mod tests {
         let params = make_params(&[("path", serde_json::json!(dotpath))]);
         let result = exec.execute_file_tool("read", &params);
         assert!(result.is_ok());
+    }
+
+    // --- #2489: per-path read allow/deny sandbox tests ---
+
+    #[test]
+    fn read_sandbox_deny_blocks_file() {
+        let dir = temp_dir();
+        let secret = dir.path().join(".env");
+        fs::write(&secret, "SECRET=abc").unwrap();
+
+        let config = crate::config::FileConfig {
+            deny_read: vec!["**/.env".to_owned()],
+            allow_read: vec![],
+        };
+        let exec = FileExecutor::new(vec![dir.path().to_path_buf()]).with_read_sandbox(&config);
+        let params = make_params(&[("path", serde_json::json!(secret.to_str().unwrap()))]);
+        let result = exec.execute_file_tool("read", &params);
+        assert!(
+            matches!(result, Err(ToolError::SandboxViolation { .. })),
+            "expected SandboxViolation, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn read_sandbox_allow_overrides_deny() {
+        let dir = temp_dir();
+        let public = dir.path().join("public.env");
+        fs::write(&public, "VAR=ok").unwrap();
+
+        let config = crate::config::FileConfig {
+            deny_read: vec!["**/*.env".to_owned()],
+            allow_read: vec![format!("**/public.env")],
+        };
+        let exec = FileExecutor::new(vec![dir.path().to_path_buf()]).with_read_sandbox(&config);
+        let params = make_params(&[("path", serde_json::json!(public.to_str().unwrap()))]);
+        let result = exec.execute_file_tool("read", &params);
+        assert!(
+            result.is_ok(),
+            "allow override should permit read: {result:?}"
+        );
+    }
+
+    #[test]
+    fn read_sandbox_empty_deny_allows_all() {
+        let dir = temp_dir();
+        let file = dir.path().join("data.txt");
+        fs::write(&file, "data").unwrap();
+
+        let config = crate::config::FileConfig::default();
+        let exec = FileExecutor::new(vec![dir.path().to_path_buf()]).with_read_sandbox(&config);
+        let params = make_params(&[("path", serde_json::json!(file.to_str().unwrap()))]);
+        let result = exec.execute_file_tool("read", &params);
+        assert!(result.is_ok(), "empty deny should allow all: {result:?}");
+    }
+
+    #[test]
+    fn read_sandbox_grep_skips_denied_files() {
+        let dir = temp_dir();
+        let allowed = dir.path().join("allowed.txt");
+        let denied = dir.path().join(".env");
+        fs::write(&allowed, "needle").unwrap();
+        fs::write(&denied, "needle").unwrap();
+
+        let config = crate::config::FileConfig {
+            deny_read: vec!["**/.env".to_owned()],
+            allow_read: vec![],
+        };
+        let exec = FileExecutor::new(vec![dir.path().to_path_buf()]).with_read_sandbox(&config);
+        let params = make_params(&[
+            ("pattern", serde_json::json!("needle")),
+            ("path", serde_json::json!(dir.path().to_str().unwrap())),
+        ]);
+        let result = exec.execute_file_tool("grep", &params).unwrap().unwrap();
+        // Should find match in allowed.txt but not in .env
+        assert!(
+            result.summary.contains("allowed.txt"),
+            "expected match in allowed.txt: {}",
+            result.summary
+        );
+        assert!(
+            !result.summary.contains(".env"),
+            "should not match in denied .env: {}",
+            result.summary
+        );
     }
 }

--- a/crates/zeph-tools/src/lib.rs
+++ b/crates/zeph-tools/src/lib.rs
@@ -49,8 +49,9 @@ pub use composite::CompositeExecutor;
 #[cfg(feature = "policy-enforcer")]
 pub use config::AdversarialPolicyConfig;
 pub use config::{
-    AnomalyConfig, AuditConfig, DependencyConfig, OverflowConfig, ResultCacheConfig, RetryConfig,
-    ScrapeConfig, ShellConfig, TafcConfig, ToolDependency, ToolsConfig, UtilityScoringConfig,
+    AnomalyConfig, AuditConfig, DependencyConfig, FileConfig, OverflowConfig, ResultCacheConfig,
+    RetryConfig, ScrapeConfig, ShellConfig, TafcConfig, ToolDependency, ToolsConfig,
+    UtilityScoringConfig,
 };
 pub use diagnostics::DiagnosticsExecutor;
 pub use error_taxonomy::{
@@ -88,8 +89,8 @@ pub use search_code::{
     LspSearchBackend, SearchCodeExecutor, SearchCodeHit, SearchCodeSource, SemanticSearchBackend,
 };
 pub use shell::{
-    DEFAULT_BLOCKED_COMMANDS, SHELL_INTERPRETERS, ShellExecutor, check_blocklist,
-    effective_shell_command,
+    DEFAULT_BLOCKED_COMMANDS, SHELL_INTERPRETERS, ShellExecutor, ShellOutputEnvelope,
+    check_blocklist, effective_shell_command,
 };
 pub use tool_filter::ToolFilter;
 pub use trust_gate::TrustGateExecutor;

--- a/crates/zeph-tools/src/policy_gate.rs
+++ b/crates/zeph-tools/src/policy_gate.rs
@@ -109,6 +109,8 @@ impl<T: ToolExecutor> PolicyGateExecutor<T> {
                         embedding_anomalous: false,
                         cross_boundary_mcp_to_acp: false,
                         adversarial_policy_decision: None,
+                        exit_code: None,
+                        truncated: false,
                     };
                     audit.log(&entry).await;
                 }
@@ -134,6 +136,8 @@ impl<T: ToolExecutor> PolicyGateExecutor<T> {
                         embedding_anomalous: false,
                         cross_boundary_mcp_to_acp: false,
                         adversarial_policy_decision: None,
+                        exit_code: None,
+                        truncated: false,
                     };
                     audit.log(&entry).await;
                 }
@@ -185,6 +189,8 @@ impl<T: ToolExecutor> ToolExecutor for PolicyGateExecutor<T> {
                     embedding_anomalous: false,
                     cross_boundary_mcp_to_acp: false,
                     adversarial_policy_decision: None,
+                    exit_code: None,
+                    truncated: false,
                 };
                 audit.log(&entry).await;
             }

--- a/crates/zeph-tools/src/scrape.rs
+++ b/crates/zeph-tools/src/scrape.rs
@@ -307,6 +307,8 @@ impl WebScrapeExecutor {
                 embedding_anomalous: false,
                 cross_boundary_mcp_to_acp: false,
                 adversarial_policy_decision: None,
+                exit_code: None,
+                truncated: false,
             };
             logger.log(&entry).await;
         }

--- a/crates/zeph-tools/src/shell/mod.rs
+++ b/crates/zeph-tools/src/shell/mod.rs
@@ -230,11 +230,13 @@ impl ShellExecutor {
 
         let mut outputs = Vec::with_capacity(blocks.len());
         let mut cumulative_filter_stats: Option<FilterStats> = None;
+        let mut last_envelope: Option<ShellOutputEnvelope> = None;
         #[allow(clippy::cast_possible_truncation)]
         let blocks_executed = blocks.len() as u32;
 
         for block in &blocks {
-            let (output_line, per_block_stats) = self.execute_block(block, skip_confirm).await?;
+            let (output_line, per_block_stats, envelope) =
+                self.execute_block(block, skip_confirm).await?;
             if let Some(fs) = per_block_stats {
                 let stats = cumulative_filter_stats.get_or_insert_with(FilterStats::default);
                 stats.raw_chars += fs.raw_chars;
@@ -254,8 +256,13 @@ impl ShellExecutor {
                     stats.kept_lines = fs.kept_lines;
                 }
             }
+            last_envelope = Some(envelope);
             outputs.push(output_line);
         }
+
+        let raw_response = last_envelope
+            .as_ref()
+            .and_then(|e| serde_json::to_value(e).ok());
 
         Ok(Some(ToolOutput {
             tool_name: "bash".to_owned(),
@@ -266,7 +273,7 @@ impl ShellExecutor {
             streamed: self.tool_event_tx.is_some(),
             terminal_id: None,
             locations: None,
-            raw_response: None,
+            raw_response,
             claim_source: Some(ClaimSource::Shell),
         }))
     }
@@ -276,7 +283,7 @@ impl ShellExecutor {
         &self,
         block: &str,
         skip_confirm: bool,
-    ) -> Result<(String, Option<FilterStats>), ToolError> {
+    ) -> Result<(String, Option<FilterStats>, ShellOutputEnvelope), ToolError> {
         self.check_permissions(block, skip_confirm).await?;
         self.validate_sandbox(block)?;
 
@@ -323,7 +330,7 @@ impl ShellExecutor {
         let start = Instant::now();
         let skill_env_snapshot: Option<std::collections::HashMap<String, String>> =
             self.skill_env.read().ok().and_then(|g| g.clone());
-        let (out, exit_code) = execute_bash(
+        let (mut envelope, out) = execute_bash(
             block,
             self.timeout,
             self.tool_event_tx.as_ref(),
@@ -332,6 +339,7 @@ impl ShellExecutor {
             &self.env_blocklist,
         )
         .await;
+        let exit_code = envelope.exit_code;
         if exit_code == 130
             && self
                 .cancel_token
@@ -367,6 +375,8 @@ impl ShellExecutor {
                             },
                             duration_ms,
                             None,
+                            Some(exit_code),
+                            false,
                         )
                         .await;
                         if let Some(ref tx) = self.tool_event_tx {
@@ -396,9 +406,16 @@ impl ShellExecutor {
         } else {
             AuditResult::Success
         };
-        self.log_audit(block, audit_result, duration_ms, None).await;
-
         if is_timeout {
+            self.log_audit(
+                block,
+                audit_result,
+                duration_ms,
+                None,
+                Some(exit_code),
+                false,
+            )
+            .await;
             self.emit_completed(block, &out, false, None);
             return Err(ToolError::Timeout {
                 timeout_secs: self.timeout.as_secs(),
@@ -450,12 +467,25 @@ impl ShellExecutor {
             per_block_stats.clone(),
         );
 
+        // Mark truncated if output was shortened during filtering.
+        envelope.truncated = filtered.len() < out.len();
+
+        self.log_audit(
+            block,
+            audit_result,
+            duration_ms,
+            None,
+            Some(exit_code),
+            envelope.truncated,
+        )
+        .await;
+
         let output_line = if let Some(warn) = snapshot_warning {
             format!("{warn}\n$ {block}\n{filtered}")
         } else {
             format!("$ {block}\n{filtered}")
         };
-        Ok((output_line, per_block_stats))
+        Ok((output_line, per_block_stats, envelope))
     }
 
     fn emit_completed(
@@ -492,6 +522,8 @@ impl ShellExecutor {
                 },
                 0,
                 Some(&err),
+                None,
+                false,
             )
             .await;
             return Err(err);
@@ -510,6 +542,8 @@ impl ShellExecutor {
                         },
                         0,
                         Some(&err),
+                        None,
+                        false,
                     )
                     .await;
                     return Err(err);
@@ -634,6 +668,8 @@ impl ShellExecutor {
         result: AuditResult,
         duration_ms: u64,
         error: Option<&ToolError>,
+        exit_code: Option<i32>,
+        truncated: bool,
     ) {
         if let Some(ref logger) = self.audit_logger {
             let (error_category, error_domain, error_phase) =
@@ -660,6 +696,8 @@ impl ShellExecutor {
                 embedding_anomalous: false,
                 cross_boundary_mcp_to_acp: false,
                 adversarial_policy_decision: None,
+                exit_code,
+                truncated,
             };
             logger.log(&entry).await;
         }
@@ -1027,6 +1065,16 @@ async fn kill_process_tree(child: &mut tokio::process::Child) {
     let _ = child.kill().await;
 }
 
+/// Structured output from a shell command execution.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ShellOutputEnvelope {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
+    pub truncated: bool,
+}
+
+#[allow(clippy::too_many_lines)]
 async fn execute_bash(
     code: &str,
     timeout: Duration,
@@ -1034,7 +1082,7 @@ async fn execute_bash(
     cancel_token: Option<&CancellationToken>,
     extra_env: Option<&std::collections::HashMap<String, String>>,
     env_blocklist: &[String],
-) -> (String, i32) {
+) -> (ShellOutputEnvelope, String) {
     use std::process::Stdio;
     use tokio::io::{AsyncBufReadExt, BufReader};
 
@@ -1062,20 +1110,33 @@ async fn execute_bash(
 
     let mut child = match child_result {
         Ok(c) => c,
-        Err(e) => return (format!("[error] {e}"), 1),
+        Err(e) => {
+            let msg = format!("[error] {e}");
+            return (
+                ShellOutputEnvelope {
+                    stdout: String::new(),
+                    stderr: msg.clone(),
+                    exit_code: 1,
+                    truncated: false,
+                },
+                msg,
+            );
+        }
     };
 
     let stdout = child.stdout.take().expect("stdout piped");
     let stderr = child.stderr.take().expect("stderr piped");
 
-    let (line_tx, mut line_rx) = tokio::sync::mpsc::channel::<String>(64);
+    // Channel carries (is_stderr, line) so we can accumulate separate buffers
+    // while still building a combined interleaved string for streaming and LLM context.
+    let (line_tx, mut line_rx) = tokio::sync::mpsc::channel::<(bool, String)>(64);
 
     let stdout_tx = line_tx.clone();
     tokio::spawn(async move {
         let mut reader = BufReader::new(stdout);
         let mut buf = String::new();
         while reader.read_line(&mut buf).await.unwrap_or(0) > 0 {
-            let _ = stdout_tx.send(buf.clone()).await;
+            let _ = stdout_tx.send((false, buf.clone())).await;
             buf.clear();
         }
     });
@@ -1084,34 +1145,55 @@ async fn execute_bash(
         let mut reader = BufReader::new(stderr);
         let mut buf = String::new();
         while reader.read_line(&mut buf).await.unwrap_or(0) > 0 {
-            let _ = line_tx.send(format!("[stderr] {buf}")).await;
+            let _ = line_tx.send((true, buf.clone())).await;
             buf.clear();
         }
     });
 
     let mut combined = String::new();
+    let mut stdout_buf = String::new();
+    let mut stderr_buf = String::new();
     let deadline = tokio::time::Instant::now() + timeout;
 
     loop {
         tokio::select! {
             line = line_rx.recv() => {
                 match line {
-                    Some(chunk) => {
+                    Some((is_stderr, chunk)) => {
+                        let interleaved = if is_stderr {
+                            format!("[stderr] {chunk}")
+                        } else {
+                            chunk.clone()
+                        };
                         if let Some(tx) = event_tx {
                             let _ = tx.send(ToolEvent::OutputChunk {
                                 tool_name: "bash".to_owned(),
                                 command: code.to_owned(),
-                                chunk: chunk.clone(),
+                                chunk: interleaved.clone(),
                             });
                         }
-                        combined.push_str(&chunk);
+                        combined.push_str(&interleaved);
+                        if is_stderr {
+                            stderr_buf.push_str(&chunk);
+                        } else {
+                            stdout_buf.push_str(&chunk);
+                        }
                     }
                     None => break,
                 }
             }
             () = tokio::time::sleep_until(deadline) => {
                 kill_process_tree(&mut child).await;
-                return (format!("[error] command timed out after {timeout_secs}s"), 1);
+                let msg = format!("[error] command timed out after {timeout_secs}s");
+                return (
+                    ShellOutputEnvelope {
+                        stdout: stdout_buf,
+                        stderr: format!("{stderr_buf}command timed out after {timeout_secs}s"),
+                        exit_code: 1,
+                        truncated: false,
+                    },
+                    msg,
+                );
             }
             () = async {
                 match cancel_token {
@@ -1120,7 +1202,15 @@ async fn execute_bash(
                 }
             } => {
                 kill_process_tree(&mut child).await;
-                return ("[cancelled] operation aborted".to_string(), 130);
+                return (
+                    ShellOutputEnvelope {
+                        stdout: stdout_buf,
+                        stderr: format!("{stderr_buf}operation aborted"),
+                        exit_code: 130,
+                        truncated: false,
+                    },
+                    "[cancelled] operation aborted".to_string(),
+                );
             }
         }
     }
@@ -1128,11 +1218,28 @@ async fn execute_bash(
     let status = child.wait().await;
     let exit_code = status.ok().and_then(|s| s.code()).unwrap_or(1);
 
-    if combined.is_empty() {
-        ("(no output)".to_string(), exit_code)
+    let (envelope, combined) = if combined.is_empty() {
+        (
+            ShellOutputEnvelope {
+                stdout: String::new(),
+                stderr: String::new(),
+                exit_code,
+                truncated: false,
+            },
+            "(no output)".to_string(),
+        )
     } else {
-        (combined, exit_code)
-    }
+        (
+            ShellOutputEnvelope {
+                stdout: stdout_buf.trim_end().to_owned(),
+                stderr: stderr_buf.trim_end().to_owned(),
+                exit_code,
+                truncated: false,
+            },
+            combined,
+        )
+    };
+    (envelope, combined)
 }
 
 #[cfg(test)]

--- a/crates/zeph-tools/src/shell/tests.rs
+++ b/crates/zeph-tools/src/shell/tests.rs
@@ -66,16 +66,16 @@ fn unclosed_block_ignored() {
 #[tokio::test]
 #[cfg(not(target_os = "windows"))]
 async fn execute_simple_command() {
-    let (result, code) =
+    let (envelope, result) =
         execute_bash("echo hello", Duration::from_secs(30), None, None, None, &[]).await;
     assert!(result.contains("hello"));
-    assert_eq!(code, 0);
+    assert_eq!(envelope.exit_code, 0);
 }
 
 #[tokio::test]
 #[cfg(not(target_os = "windows"))]
 async fn execute_stderr_output() {
-    let (result, _) = execute_bash(
+    let (envelope, result) = execute_bash(
         "echo err >&2",
         Duration::from_secs(30),
         None,
@@ -86,12 +86,13 @@ async fn execute_stderr_output() {
     .await;
     assert!(result.contains("[stderr]"));
     assert!(result.contains("err"));
+    assert!(envelope.stderr.contains("err"));
 }
 
 #[tokio::test]
 #[cfg(not(target_os = "windows"))]
 async fn execute_stdout_and_stderr_combined() {
-    let (result, _) = execute_bash(
+    let (envelope, result) = execute_bash(
         "echo out && echo err >&2",
         Duration::from_secs(30),
         None,
@@ -104,14 +105,17 @@ async fn execute_stdout_and_stderr_combined() {
     assert!(result.contains("[stderr]"));
     assert!(result.contains("err"));
     assert!(result.contains('\n'));
+    assert!(envelope.stdout.contains("out"));
+    assert!(envelope.stderr.contains("err"));
 }
 
 #[tokio::test]
 #[cfg(not(target_os = "windows"))]
 async fn execute_empty_output() {
-    let (result, code) = execute_bash("true", Duration::from_secs(30), None, None, None, &[]).await;
+    let (envelope, result) =
+        execute_bash("true", Duration::from_secs(30), None, None, None, &[]).await;
     assert_eq!(result, "(no output)");
-    assert_eq!(code, 0);
+    assert_eq!(envelope.exit_code, 0);
 }
 
 #[tokio::test]
@@ -909,7 +913,7 @@ async fn execute_bash_injects_extra_env() {
         "ZEPH_TEST_INJECTED_VAR".to_owned(),
         "hello-from-env".to_owned(),
     );
-    let (result, code) = execute_bash(
+    let (envelope, result) = execute_bash(
         "echo $ZEPH_TEST_INJECTED_VAR",
         Duration::from_secs(5),
         None,
@@ -918,7 +922,7 @@ async fn execute_bash_injects_extra_env() {
         &[],
     )
     .await;
-    assert_eq!(code, 0);
+    assert_eq!(envelope.exit_code, 0);
     assert!(result.contains("hello-from-env"));
 }
 
@@ -949,15 +953,16 @@ async fn shell_executor_set_skill_env_injects_vars() {
 #[cfg(unix)]
 #[tokio::test]
 async fn execute_bash_error_handling() {
-    let (result, code) = execute_bash("false", Duration::from_secs(5), None, None, None, &[]).await;
+    let (envelope, result) =
+        execute_bash("false", Duration::from_secs(5), None, None, None, &[]).await;
     assert_eq!(result, "(no output)");
-    assert_eq!(code, 1);
+    assert_eq!(envelope.exit_code, 1);
 }
 
 #[cfg(unix)]
 #[tokio::test]
 async fn execute_bash_command_not_found() {
-    let (result, _) = execute_bash(
+    let (_, result) = execute_bash(
         "nonexistent-command-xyz",
         Duration::from_secs(5),
         None,
@@ -1065,7 +1070,7 @@ async fn cancel_token_kills_child_process() {
         tokio::time::sleep(Duration::from_millis(100)).await;
         token_clone.cancel();
     });
-    let (result, code) = execute_bash(
+    let (envelope, result) = execute_bash(
         "sleep 60",
         Duration::from_secs(30),
         None,
@@ -1074,16 +1079,16 @@ async fn cancel_token_kills_child_process() {
         &[],
     )
     .await;
-    assert_eq!(code, 130);
+    assert_eq!(envelope.exit_code, 130);
     assert!(result.contains("[cancelled]"));
 }
 
 #[tokio::test]
 #[cfg(not(target_os = "windows"))]
 async fn cancel_token_none_does_not_cancel() {
-    let (result, code) =
+    let (envelope, result) =
         execute_bash("echo ok", Duration::from_secs(5), None, None, None, &[]).await;
-    assert_eq!(code, 0);
+    assert_eq!(envelope.exit_code, 0);
     assert!(result.contains("ok"));
 }
 
@@ -1099,7 +1104,7 @@ async fn cancel_kills_child_process_group() {
         tokio::time::sleep(Duration::from_millis(200)).await;
         token_clone.cancel();
     });
-    let (result, code) = execute_bash(
+    let (envelope, result) = execute_bash(
         &script,
         Duration::from_secs(30),
         None,
@@ -1108,7 +1113,7 @@ async fn cancel_kills_child_process_group() {
         &[],
     )
     .await;
-    assert_eq!(code, 130);
+    assert_eq!(envelope.exit_code, 130);
     assert!(result.contains("[cancelled]"));
     // Wait briefly, then verify the subprocess did NOT create the marker file
     tokio::time::sleep(Duration::from_millis(500)).await;
@@ -1584,7 +1589,7 @@ async fn env_blocklist_strips_sensitive_vars() {
     // Set a fake sensitive env var in the current process
     unsafe { std::env::set_var("ZEPH_SECRET_TEST_VAR", "should-not-leak") };
     let blocklist = vec!["ZEPH_".to_owned()];
-    let (result, code) = execute_bash(
+    let (envelope, result) = execute_bash(
         "echo ${ZEPH_SECRET_TEST_VAR:-absent}",
         Duration::from_secs(5),
         None,
@@ -1594,7 +1599,7 @@ async fn env_blocklist_strips_sensitive_vars() {
     )
     .await;
     unsafe { std::env::remove_var("ZEPH_SECRET_TEST_VAR") };
-    assert_eq!(code, 0);
+    assert_eq!(envelope.exit_code, 0);
     assert!(
         result.contains("absent"),
         "ZEPH_ var should have been stripped, got: {result}"
@@ -1606,7 +1611,7 @@ async fn env_blocklist_strips_sensitive_vars() {
 async fn env_blocklist_preserves_safe_vars() {
     let blocklist = vec!["ZEPH_".to_owned()];
     // PATH and HOME are always set in the test environment; verify they are inherited.
-    let (result, code) = execute_bash(
+    let (envelope, result) = execute_bash(
         "echo ${PATH:+present}",
         Duration::from_secs(5),
         None,
@@ -1615,7 +1620,7 @@ async fn env_blocklist_preserves_safe_vars() {
         &blocklist,
     )
     .await;
-    assert_eq!(code, 0);
+    assert_eq!(envelope.exit_code, 0);
     assert!(
         result.contains("present"),
         "PATH should be preserved, got: {result}"
@@ -1629,7 +1634,7 @@ async fn env_blocklist_extra_env_still_injected() {
     let blocklist = vec!["ZEPH_".to_owned()];
     let mut extra = std::collections::HashMap::new();
     extra.insert("SKILL_TEST_VAR".to_owned(), "skill-value".to_owned());
-    let (result, code) = execute_bash(
+    let (envelope, result) = execute_bash(
         "echo $SKILL_TEST_VAR",
         Duration::from_secs(5),
         None,
@@ -1638,7 +1643,7 @@ async fn env_blocklist_extra_env_still_injected() {
         &blocklist,
     )
     .await;
-    assert_eq!(code, 0);
+    assert_eq!(envelope.exit_code, 0);
     assert!(
         result.contains("skill-value"),
         "skill extra_env should be injected, got: {result}"
@@ -1654,7 +1659,7 @@ async fn env_blocklist_multiple_prefixes() {
         std::env::set_var("OPENAI_API_KEY", "openai-secret");
     }
     let blocklist = vec!["AWS_".to_owned(), "OPENAI_".to_owned()];
-    let (result, code) = execute_bash(
+    let (envelope, result) = execute_bash(
         "echo ${AWS_SECRET_ACCESS_KEY:-absent1} ${OPENAI_API_KEY:-absent2}",
         Duration::from_secs(5),
         None,
@@ -1667,7 +1672,7 @@ async fn env_blocklist_multiple_prefixes() {
         std::env::remove_var("AWS_SECRET_ACCESS_KEY");
         std::env::remove_var("OPENAI_API_KEY");
     }
-    assert_eq!(code, 0);
+    assert_eq!(envelope.exit_code, 0);
     assert!(
         result.contains("absent1"),
         "AWS_ var should be stripped, got: {result}"
@@ -1683,7 +1688,7 @@ async fn env_blocklist_multiple_prefixes() {
 #[tokio::test]
 async fn empty_env_blocklist_passes_all_vars() {
     unsafe { std::env::set_var("ZEPH_EMPTY_BLOCKLIST_TEST", "visible") };
-    let (result, code) = execute_bash(
+    let (envelope, result) = execute_bash(
         "echo ${ZEPH_EMPTY_BLOCKLIST_TEST:-absent}",
         Duration::from_secs(5),
         None,
@@ -1693,7 +1698,7 @@ async fn empty_env_blocklist_passes_all_vars() {
     )
     .await;
     unsafe { std::env::remove_var("ZEPH_EMPTY_BLOCKLIST_TEST") };
-    assert_eq!(code, 0);
+    assert_eq!(envelope.exit_code, 0);
     assert!(
         result.contains("visible"),
         "empty blocklist should pass all vars, got: {result}"
@@ -2226,4 +2231,125 @@ fn transaction_snapshot_size_limit_within_budget() {
 
     let result = TransactionSnapshot::capture(&[file], 1024);
     assert!(result.is_ok());
+}
+
+// --- #2488: ShellOutputEnvelope tests ---
+
+#[cfg(unix)]
+#[tokio::test]
+async fn shell_output_envelope_separates_streams() {
+    let (envelope, combined) = execute_bash(
+        "echo stdout-line && echo stderr-line >&2",
+        Duration::from_secs(5),
+        None,
+        None,
+        None,
+        &[],
+    )
+    .await;
+    assert!(
+        envelope.stdout.contains("stdout-line"),
+        "stdout should contain stdout-line: {:?}",
+        envelope.stdout
+    );
+    assert!(
+        envelope.stderr.contains("stderr-line"),
+        "stderr should contain stderr-line: {:?}",
+        envelope.stderr
+    );
+    assert!(
+        !envelope.stdout.contains("stderr-line"),
+        "stdout must not bleed stderr: {:?}",
+        envelope.stdout
+    );
+    assert!(
+        !envelope.stderr.contains("stdout-line"),
+        "stderr must not bleed stdout: {:?}",
+        envelope.stderr
+    );
+    assert!(combined.contains("[stderr]"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn shell_output_envelope_in_tool_output_raw_response() {
+    let executor = ShellExecutor::new(&default_config());
+    let response = "```bash\necho hello && echo err >&2\n```";
+    let output = executor.execute(response).await.unwrap().unwrap();
+    assert!(
+        output.raw_response.is_some(),
+        "raw_response should be set for shell output"
+    );
+    let val = output.raw_response.unwrap();
+    let stdout = val["stdout"].as_str().unwrap_or("");
+    let stderr = val["stderr"].as_str().unwrap_or("");
+    assert!(
+        stdout.contains("hello"),
+        "stdout in raw_response: {stdout:?}"
+    );
+    assert!(stderr.contains("err"), "stderr in raw_response: {stderr:?}");
+    assert!(
+        val["exit_code"].as_i64().is_some(),
+        "exit_code should be present"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn shell_output_envelope_nonzero_exit_code() {
+    let (envelope, _combined) =
+        execute_bash("exit 42", Duration::from_secs(5), None, None, None, &[]).await;
+    assert_eq!(
+        envelope.exit_code, 42,
+        "exit_code should reflect the actual exit status"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn shell_output_envelope_truncated_flag_set_when_filter_shortens_output() {
+    use crate::filter::{CommandMatcher, FilterConfidence, FilterResult, OutputFilter};
+    use std::sync::LazyLock;
+
+    struct TruncatingFilter;
+    static MATCH_ALL: LazyLock<CommandMatcher> =
+        LazyLock::new(|| CommandMatcher::Custom(Box::new(|_| true)));
+    impl OutputFilter for TruncatingFilter {
+        fn name(&self) -> &'static str {
+            "truncating"
+        }
+        fn matcher(&self) -> &CommandMatcher {
+            &MATCH_ALL
+        }
+        fn filter(&self, _command: &str, raw_output: &str, _exit_code: i32) -> FilterResult {
+            // Return a strictly shorter output to trigger truncated=true.
+            let shortened = if raw_output.len() > 5 {
+                raw_output[..5].to_owned()
+            } else {
+                raw_output.to_owned()
+            };
+            FilterResult {
+                raw_chars: raw_output.len(),
+                filtered_chars: shortened.len(),
+                raw_lines: 1,
+                filtered_lines: 1,
+                output: shortened,
+                confidence: FilterConfidence::Full,
+                kept_lines: Vec::new(),
+            }
+        }
+    }
+
+    let mut registry = OutputFilterRegistry::new(true);
+    registry.register(Box::new(TruncatingFilter));
+
+    let executor = ShellExecutor::new(&default_config()).with_output_filters(registry);
+    // Produce output longer than 5 bytes to ensure truncation occurs.
+    let response = "```bash\necho 'hello world this is long output'\n```";
+    let output = executor.execute(response).await.unwrap().unwrap();
+    let val = output.raw_response.unwrap();
+    assert!(
+        val["truncated"].as_bool().unwrap_or(false),
+        "truncated flag should be true when filter shortens output"
+    );
 }


### PR DESCRIPTION
## Summary

- **#2488**: `ShellOutputEnvelope { stdout, stderr, exit_code, truncated }` — separate stdout/stderr capture via tagged channel, JSON-serialized into `ToolOutput`, `AuditEntry` extended with `exit_code`/`truncated` (backward-compatible via `#[serde(default)]`)
- **#2489**: `FileConfig { deny_read, allow_read }` glob lists in `ToolsConfig` — deny-then-allow evaluation with canonicalized paths in `FileExecutor::handle_read()` and `grep_recursive()` to prevent symlink bypass

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --all-targets --all-features --workspace -- -D warnings` — clean
- [ ] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node --lib --bins` — 7179/7179 pass (+10 new tests)
- [ ] SEC-01 (symlink bypass in grep_recursive) — fixed, canonicalize before sandbox check
- [ ] IC-02 (truncated not propagated to audit) — fixed, `log_audit` receives `envelope.truncated`

## Follow-up
#2525, #2526, #2527 — wizard, default config, docs