### PR TITLE
feat(tools): document and configure [tools.file] read sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - feat(tools): structured shell output envelope (#2488) — `execute_bash` now captures stdout and stderr as separate streams at the process level using a tagged `(bool, String)` channel; `ShellOutputEnvelope { stdout, stderr, exit_code, truncated }` is built post-execution and serialized into `ToolOutput.raw_response` for ACP/audit consumers; LLM context continues using the interleaved combined output in `summary`; `AuditEntry` gains optional `exit_code: Option<i32>` and `truncated: bool` fields (`skip_serializing_if` for backward compat)
 - feat(tools): per-path read allow/deny sandbox for file tool (#2489) — new `[tools.file]` config section with `deny_read` and `allow_read` glob pattern lists; evaluation order: deny-then-allow; all patterns matched against canonicalized absolute paths (prevents symlink bypass); `FileExecutor::with_read_sandbox()` builder method applies the sandbox; `handle_read()` checks sandbox before `read_to_string`; `grep_recursive` skips denied files before reading content; `FileConfig` exported from `zeph-tools`
 
+- feat(config): add commented `[tools.file]` section to `config/default.toml` with `deny_read` and `allow_read` glob examples (#2526)
+- feat(init): add `[tools.file]` wizard step to `--init` interactive config wizard — two prompts for `deny_read` and conditional `allow_read` comma-separated glob lists, wired into `build_config()` (#2525)
+- docs: add File Read Sandbox page to mdBook under Reference / Security (`book/src/reference/security/file-sandbox.md`), linked in `SUMMARY.md` (#2527)
+
 ### Fixed
 
 - fix(mcp): replace unbounded elicitation mpsc channel with a bounded channel (default capacity 16) to prevent memory exhaustion from misbehaving MCP servers; requests that arrive when the queue is full are auto-declined with a warning log instead of accumulating indefinitely; capacity is configurable via `[mcp] elicitation_queue_capacity` (closes #2524)

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -91,6 +91,7 @@
 - [Security](reference/security.md)
   - [MCP Security](reference/security/mcp.md)
   - [Untrusted Content Isolation](reference/security/untrusted-content-isolation.md)
+  - [File Read Sandbox](reference/security/file-sandbox.md)
 
 # Development
 

--- a/book/src/reference/security/file-sandbox.md
+++ b/book/src/reference/security/file-sandbox.md
@@ -1,0 +1,78 @@
+# File Read Sandbox
+
+The `[tools.file]` configuration section restricts which paths the agent is
+allowed to read via the file tool. This provides a per-path sandbox that
+complements the shell tool's `allowed_paths` setting.
+
+## How It Works
+
+Evaluation follows a **deny-then-allow** order:
+
+1. If `deny_read` is non-empty and the path matches a deny pattern, access is
+   denied.
+2. If the path also matches an `allow_read` pattern, the deny is overridden and
+   access is granted.
+3. Empty `deny_read` means no read restrictions are applied.
+
+All patterns are matched against the **canonicalized** path — absolute and with
+all symlinks resolved — so symlink traversal cannot bypass the sandbox.
+
+## Configuration
+
+```toml
+[tools.file]
+# Glob patterns for paths denied for reading. Evaluated first.
+deny_read = ["/etc/shadow", "/root/*", "/home/*/.ssh/*"]
+
+# Glob patterns for paths allowed despite a deny match. Evaluated second.
+allow_read = ["/etc/hostname"]
+```
+
+| Field        | Type             | Default | Description                                              |
+|--------------|------------------|---------|----------------------------------------------------------|
+| `deny_read`  | `Vec<String>`    | `[]`    | Glob patterns for paths to block. Empty = no restriction |
+| `allow_read` | `Vec<String>`    | `[]`    | Glob patterns that override a `deny_read` match          |
+
+## Glob Syntax
+
+Patterns use standard glob syntax:
+
+| Pattern     | Matches                                      |
+|-------------|----------------------------------------------|
+| `/etc/shadow` | Exact path `/etc/shadow`                   |
+| `/root/*`   | All direct children of `/root/`              |
+| `/home/*/.ssh/*` | `.ssh` contents for any user in `/home/` |
+| `**`        | Any path segment, including nested           |
+
+## Examples
+
+### Deny all sensitive system files
+
+```toml
+[tools.file]
+deny_read = [
+    "/etc/shadow",
+    "/etc/sudoers",
+    "/root/*",
+    "/home/*/.ssh/*",
+    "/home/*/.gnupg/*",
+]
+```
+
+### Deny all of `/etc` except a few safe entries
+
+```toml
+[tools.file]
+deny_read  = ["/etc/*"]
+allow_read = ["/etc/hostname", "/etc/os-release", "/etc/timezone"]
+```
+
+## Security Notes
+
+- Patterns are applied to canonicalized paths. Symlinks pointing into a denied
+  directory are still blocked after resolution.
+- An empty `deny_read` list disables the sandbox entirely — all paths readable
+  by the process are accessible to the file tool.
+- `allow_read` has no effect when `deny_read` is empty.
+- This setting does not restrict the shell tool. Use `[tools.shell]
+  allowed_paths` for shell-level path restrictions.

--- a/config/default.toml
+++ b/config/default.toml
@@ -476,6 +476,12 @@ allow_network = true
 # Commands that require user confirmation before execution
 confirm_patterns = ["rm ", "git push -f", "git push --force", "drop table", "drop database", "truncate "]
 
+# [tools.file]
+# Per-path read sandbox using glob patterns. Evaluation: deny first, then allow overrides.
+# All patterns are matched against canonicalized (absolute, symlink-resolved) paths.
+# deny_read = ["/etc/shadow", "/root/*", "/home/*/.ssh/*"]
+# allow_read = ["/etc/hostname"]
+
 [tools.scrape]
 # HTTP request timeout in seconds
 timeout = 15

--- a/src/init.rs
+++ b/src/init.rs
@@ -187,6 +187,9 @@ pub(crate) struct WizardState {
     // Transactional shell (#2414)
     pub(crate) shell_transactional: bool,
     pub(crate) shell_auto_rollback: bool,
+    // File read sandbox (#2525)
+    pub(crate) file_deny_read: Vec<String>,
+    pub(crate) file_allow_read: Vec<String>,
 }
 
 impl Default for WizardState {
@@ -331,6 +334,8 @@ impl Default for WizardState {
             database_url: None,
             shell_transactional: false,
             shell_auto_rollback: false,
+            file_deny_read: Vec::new(),
+            file_allow_read: Vec::new(),
         }
     }
 }
@@ -1399,6 +1404,16 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
     }
     config.tools.shell.transactional = state.shell_transactional;
     config.tools.shell.auto_rollback = state.shell_auto_rollback;
+    config
+        .tools
+        .file
+        .deny_read
+        .clone_from(&state.file_deny_read);
+    config
+        .tools
+        .file
+        .allow_read
+        .clone_from(&state.file_allow_read);
     config.skills.trust.scan_on_load = state.skill_scan_on_load;
     config.skills.trust.scanner.capability_escalation_check =
         state.skill_capability_escalation_check;
@@ -2255,6 +2270,31 @@ fn step_security(state: &mut WizardState) -> anyhow::Result<()> {
             )
             .default(false)
             .interact()?;
+    }
+
+    let deny_raw: String = dialoguer::Input::new()
+        .with_prompt(
+            "File read deny patterns (comma-separated globs, e.g. /etc/shadow,/root/*, empty = no restrictions)",
+        )
+        .allow_empty(true)
+        .interact_text()?;
+    state.file_deny_read = deny_raw
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned)
+        .collect();
+    if !state.file_deny_read.is_empty() {
+        let allow_raw: String = dialoguer::Input::new()
+            .with_prompt("File read allow overrides (comma-separated globs, empty = none)")
+            .allow_empty(true)
+            .interact_text()?;
+        state.file_allow_read = allow_raw
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned)
+            .collect();
     }
 
     #[cfg(feature = "guardrail")]
@@ -3290,5 +3330,29 @@ mod tests {
             config.memory.sqlite_path,
             zeph_core::config::default_sqlite_path(),
         );
+    }
+
+    #[test]
+    fn build_config_file_deny_allow_mapped() {
+        let state = WizardState {
+            file_deny_read: vec!["/etc/shadow".into(), "/root/*".into()],
+            file_allow_read: vec!["/etc/hostname".into()],
+            vault_backend: "env".into(),
+            ..WizardState::default()
+        };
+        let config = build_config(&state);
+        assert_eq!(config.tools.file.deny_read, vec!["/etc/shadow", "/root/*"]);
+        assert_eq!(config.tools.file.allow_read, vec!["/etc/hostname"]);
+    }
+
+    #[test]
+    fn build_config_file_empty_by_default() {
+        let state = WizardState {
+            vault_backend: "env".into(),
+            ..WizardState::default()
+        };
+        let config = build_config(&state);
+        assert!(config.tools.file.deny_read.is_empty());
+        assert!(config.tools.file.allow_read.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Follow-ups from #2488/#2489 (`[tools.file]` read sandbox implementation):

- **#2526**: Add commented-out `[tools.file]` section with `deny_read`/`allow_read` glob examples to `config/default.toml` so users discover the feature
- **#2525**: Add `[tools.file]` wizard step to `--init` interactive config — two prompts in `step_security()` with conditional `allow_read` prompt shown only when `deny_read` is non-empty; two new tests
- **#2527**: Add `book/src/reference/security/file-sandbox.md` documenting deny-then-allow evaluation, canonicalization, glob syntax, practical examples, and security guidance; linked in `SUMMARY.md`

## Test plan

- [ ] `cargo +nightly fmt --check` passes
- [ ] `cargo clippy --workspace -- -D warnings` passes (0 warnings)
- [ ] `cargo nextest run --workspace --lib --bins` passes (6999 passed)
- [ ] Run `cargo run -- --init` and verify `[tools.file]` prompts appear in the security step
- [ ] Verify `config/default.toml` renders correctly with commented section
- [ ] Build mdBook (`mdbook build book/`) and verify file-sandbox page renders

Closes #2525, #2526, #2527