### PR TITLE
fix(subagent): prevent exit after 1 turn on text-only LLM response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- fix(subagent): inject working directory into sub-agent system prompt so the LLM knows where the project is; send a one-time nudge when the first turn returns text-only (no tool calls) to prevent the agent from announcing intent without acting (#2582)
 - fix(tools): add PII NER circuit breaker — after `pii_ner_circuit_breaker` consecutive timeouts (default 2), NER is disabled for the session and PII detection falls back to regex-only, preventing up to 6-minute blocking on paginated reads (12 chunks × 30 s timeout); set `pii_ner_circuit_breaker = 0` to disable (#2562)
 - fix(memory): chunk large messages into overlapping ~400-token segments in `embed_missing()` — each chunk is stored as a separate Qdrant vector, so the full content of long tool outputs is indexed rather than truncated; search deduplicates results by `message_id` keeping the highest-scoring chunk (#2551, #2552)
 - fix(llm): classify HTTP 400 embed responses as non-retryable `LlmError::InvalidInput`; the router fallback loop now breaks immediately on `InvalidInput` without penalizing provider reputation (#2551)

--- a/crates/zeph-subagent/src/manager.rs
+++ b/crates/zeph-subagent/src/manager.rs
@@ -317,6 +317,7 @@ async fn run_agent_loop(args: AgentLoopArgs) -> Result<String, SubAgentError> {
 
     let mut turns: u32 = 0;
     let mut last_result = String::new();
+    let mut any_tool_called = false;
 
     loop {
         if cancel.is_cancelled() {
@@ -439,7 +440,7 @@ async fn run_agent_loop(args: AgentLoopArgs) -> Result<String, SubAgentError> {
         }
 
         let prev_len = messages.len();
-        if handle_tool_step(
+        let no_tool = handle_tool_step(
             &executor,
             response,
             &mut messages,
@@ -447,15 +448,30 @@ async fn run_agent_loop(args: AgentLoopArgs) -> Result<String, SubAgentError> {
             &loop_task_id,
             &agent_name,
         )
-        .await
-        {
-            // handle_tool_step returned true (no tool call) — loop will break.
-            // Write the last assistant message to transcript.
+        .await;
+
+        if no_tool {
+            // handle_tool_step returned true (no tool call).
             for msg in &messages[prev_len..] {
                 append_transcript(&mut transcript_writer, &mut seq, msg);
             }
+            // If this is the very first turn and no tool was ever called, the LLM
+            // announced intent without acting. Nudge it once to execute via tools.
+            if turns == 1 && !any_tool_called {
+                tracing::debug!("sub-agent text-only first turn — sending nudge to use tools");
+                let nudge = make_message(
+                    Role::User,
+                    "Please use the available tools to complete the task. \
+                     Do not announce intentions — execute them."
+                        .into(),
+                );
+                append_transcript(&mut transcript_writer, &mut seq, &nudge);
+                messages.push(nudge);
+                continue;
+            }
             break;
         }
+        any_tool_called = true;
         // Write any newly pushed messages to the transcript.
         for msg in &messages[prev_len..] {
             append_transcript(&mut transcript_writer, &mut seq, msg);
@@ -619,8 +635,17 @@ pub(crate) fn build_system_prompt_with_memory(
     def: &mut SubAgentDef,
     scope: Option<MemoryScope>,
 ) -> String {
+    let cwd = std::env::current_dir()
+        .map(|p| p.display().to_string())
+        .unwrap_or_default();
+    let cwd_line = if cwd.is_empty() {
+        String::new()
+    } else {
+        format!("\nWorking directory: {cwd}")
+    };
+
     let Some(scope) = scope else {
-        return def.system_prompt.clone();
+        return format!("{}{cwd_line}", def.system_prompt);
     };
 
     // HIGH-04: if all three file tools are blocked (via disallowed_tools OR DenyList),
@@ -697,6 +722,7 @@ pub(crate) fn build_system_prompt_with_memory(
     });
 
     let mut prompt = def.system_prompt.clone();
+    prompt.push_str(&cwd_line);
     prompt.push_str(&memory_instruction);
     if let Some(block) = memory_block {
         prompt.push_str(&block);
@@ -3550,5 +3576,61 @@ mod tests {
             "execute_tool_call_erased must be called once"
         );
         assert_eq!(recorded[0], "shell");
+    }
+
+    // --- Fix #2582 tests ---
+
+    #[test]
+    fn build_system_prompt_injects_working_directory() {
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let orig = std::env::current_dir().unwrap();
+        std::env::set_current_dir(tmp.path()).unwrap();
+
+        let mut def = SubAgentDef::parse(indoc! {"
+            ---
+            name: cwd-agent
+            description: test
+            ---
+            Base prompt.
+        "})
+        .unwrap();
+
+        let prompt = build_system_prompt_with_memory(&mut def, None);
+        std::env::set_current_dir(orig).unwrap();
+
+        assert!(
+            prompt.contains("Working directory:"),
+            "system prompt must contain 'Working directory:', got: {prompt}"
+        );
+        assert!(
+            prompt.contains(tmp.path().to_str().unwrap()),
+            "system prompt must contain the actual cwd path, got: {prompt}"
+        );
+    }
+
+    #[tokio::test]
+    async fn text_only_first_turn_sends_nudge_and_retries() {
+        use zeph_llm::mock::MockProvider;
+
+        // First call returns text-only; second call also text (loop should stop after nudge retry).
+        let (mock, call_count) = MockProvider::default().with_tool_use(vec![
+            ChatResponse::Text("I will now do the task...".into()),
+            ChatResponse::Text("Done.".into()),
+        ]);
+
+        let executor = FilteredToolExecutor::new(noop_executor(), ToolPolicy::InheritAll);
+        let args = make_agent_loop_args(AnyProvider::Mock(mock), executor, 10);
+        let result = run_agent_loop(args).await;
+        assert!(result.is_ok(), "loop should succeed: {result:?}");
+        assert_eq!(result.unwrap(), "Done.");
+
+        // Provider must have been called twice: initial turn + nudge retry.
+        let count = *call_count.lock().unwrap();
+        assert_eq!(
+            count, 2,
+            "provider must be called exactly twice (initial + nudge retry), got {count}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #2582. Sub-agents were exiting after exactly 1 LLM turn when the model returned a text-only response (intent announcement) instead of calling tools.

- Inject the working directory into the sub-agent system prompt so the LLM knows where the project is and acts instead of hedging
- On text-only first turn with no tool calls, push a one-time nudge message and continue the loop for one more turn instead of breaking immediately

## Changes

- `crates/zeph-subagent/src/manager.rs`: two targeted fixes in `build_system_prompt_with_memory` and `run_agent_loop`
- `CHANGELOG.md`: entry under `[Unreleased]`

## Test plan

- [ ] `build_system_prompt_injects_working_directory` — verifies "Working directory:" appears in the system prompt with the correct path
- [ ] `text_only_first_turn_sends_nudge_and_retries` — verifies the provider is called twice when first turn is text-only (initial + nudge retry)
- [ ] All 301 `zeph-subagent` tests pass
- [ ] `cargo +nightly fmt --check` passes
- [ ] `cargo clippy -p zeph-subagent -- -D warnings` passes