### PR TITLE
fix(memory): apply multi-vector chunking in real-time embed paths (#2570, #2571)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - fix(subagent): inject working directory into sub-agent system prompt so the LLM knows where the project is; send a one-time nudge when the first turn returns text-only (no tool calls) to prevent the agent from announcing intent without acting (#2582)
 - fix(tools): add PII NER circuit breaker — after `pii_ner_circuit_breaker` consecutive timeouts (default 2), NER is disabled for the session and PII detection falls back to regex-only, preventing up to 6-minute blocking on paginated reads (12 chunks × 30 s timeout); set `pii_ner_circuit_breaker = 0` to disable (#2562)
+- fix(memory): apply multi-vector chunking in real-time embedding paths (`remember`, `remember_with_parts`) — long messages are now split into overlapping ~400-token segments at write time, matching the existing `embed_missing()` behaviour; both SQLite and Qdrant backends are updated atomically (#2570)
+- fix(db): add `build.rs` to `zeph-db` so Cargo re-runs the build script when any migration `.sql` file changes, preventing stale migration state after schema updates (#2571)
 - fix(memory): chunk large messages into overlapping ~400-token segments in `embed_missing()` — each chunk is stored as a separate Qdrant vector, so the full content of long tool outputs is indexed rather than truncated; search deduplicates results by `message_id` keeping the highest-scoring chunk (#2551, #2552)
 - fix(llm): classify HTTP 400 embed responses as non-retryable `LlmError::InvalidInput`; the router fallback loop now breaks immediately on `InvalidInput` without penalizing provider reputation (#2551)
 - Add backticks to doc comments in telegram.rs elicitation tests to fix clippy `doc_markdown` warnings (#2549)

--- a/crates/zeph-db/build.rs
+++ b/crates/zeph-db/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-changed=migrations/");
+}

--- a/crates/zeph-memory/src/semantic/recall.rs
+++ b/crates/zeph-memory/src/semantic/recall.rs
@@ -116,28 +116,46 @@ impl SemanticMemory {
         if let Some(qdrant) = &self.qdrant
             && self.provider.supports_embeddings()
         {
-            match self.provider.embed(content).await {
-                Ok(vector) => {
-                    let vector_size = u64::try_from(vector.len()).unwrap_or(896);
-                    if let Err(e) = qdrant.ensure_collection(vector_size).await {
-                        tracing::warn!("Failed to ensure Qdrant collection: {e:#}");
-                    } else if let Err(e) = qdrant
-                        .store(
-                            message_id,
-                            conversation_id,
-                            role,
-                            vector,
-                            MessageKind::Regular,
-                            &self.embedding_model,
-                            0,
-                        )
-                        .await
-                    {
-                        tracing::warn!("Failed to store embedding: {e:#}");
+            let chunks = chunk_text(content);
+            let chunk_count = chunks.len();
+            let mut collection_ready = false;
+
+            for (chunk_index, chunk) in chunks.into_iter().enumerate() {
+                let chunk_index_u32 = u32::try_from(chunk_index).unwrap_or(u32::MAX);
+                match self.provider.embed(chunk).await {
+                    Ok(vector) => {
+                        if !collection_ready {
+                            let vector_size = u64::try_from(vector.len()).unwrap_or(896);
+                            if let Err(e) = qdrant.ensure_collection(vector_size).await {
+                                tracing::warn!("Failed to ensure Qdrant collection: {e:#}");
+                                break;
+                            }
+                            collection_ready = true;
+                        }
+                        if let Err(e) = qdrant
+                            .store(
+                                message_id,
+                                conversation_id,
+                                role,
+                                vector,
+                                MessageKind::Regular,
+                                &self.embedding_model,
+                                chunk_index_u32,
+                            )
+                            .await
+                        {
+                            tracing::warn!(
+                                "Failed to store chunk {chunk_index}/{chunk_count} \
+                                 for msg {message_id}: {e:#}"
+                            );
+                        }
                     }
-                }
-                Err(e) => {
-                    tracing::warn!("Failed to generate embedding: {e:#}");
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to embed chunk {chunk_index}/{chunk_count} \
+                             for msg {message_id}: {e:#}"
+                        );
+                    }
                 }
             }
         }
@@ -189,30 +207,48 @@ impl SemanticMemory {
         if let Some(qdrant) = &self.qdrant
             && self.provider.supports_embeddings()
         {
-            match self.provider.embed(content).await {
-                Ok(vector) => {
-                    let vector_size = u64::try_from(vector.len()).unwrap_or(896);
-                    if let Err(e) = qdrant.ensure_collection(vector_size).await {
-                        tracing::warn!("Failed to ensure Qdrant collection: {e:#}");
-                    } else if let Err(e) = qdrant
-                        .store(
-                            message_id,
-                            conversation_id,
-                            role,
-                            vector,
-                            MessageKind::Regular,
-                            &self.embedding_model,
-                            0,
-                        )
-                        .await
-                    {
-                        tracing::warn!("Failed to store embedding: {e:#}");
-                    } else {
-                        embedding_stored = true;
+            let chunks = chunk_text(content);
+            let chunk_count = chunks.len();
+            let mut collection_ready = false;
+
+            for (chunk_index, chunk) in chunks.into_iter().enumerate() {
+                let chunk_index_u32 = u32::try_from(chunk_index).unwrap_or(u32::MAX);
+                match self.provider.embed(chunk).await {
+                    Ok(vector) => {
+                        if !collection_ready {
+                            let vector_size = u64::try_from(vector.len()).unwrap_or(896);
+                            if let Err(e) = qdrant.ensure_collection(vector_size).await {
+                                tracing::warn!("Failed to ensure Qdrant collection: {e:#}");
+                                break;
+                            }
+                            collection_ready = true;
+                        }
+                        if let Err(e) = qdrant
+                            .store(
+                                message_id,
+                                conversation_id,
+                                role,
+                                vector,
+                                MessageKind::Regular,
+                                &self.embedding_model,
+                                chunk_index_u32,
+                            )
+                            .await
+                        {
+                            tracing::warn!(
+                                "Failed to store chunk {chunk_index}/{chunk_count} \
+                                 for msg {message_id}: {e:#}"
+                            );
+                        } else {
+                            embedding_stored = true;
+                        }
                     }
-                }
-                Err(e) => {
-                    tracing::warn!("Failed to generate embedding: {e:#}");
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to embed chunk {chunk_index}/{chunk_count} \
+                             for msg {message_id}: {e:#}"
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Real-time embedding paths (`remember`, `remember_with_parts`) now call `chunk_text()` before embedding, storing one vector per chunk with correct `chunk_index`. Matches the existing batch path (`embed_missing`). Single-chunk content is unaffected.
- Add `crates/zeph-db/build.rs` with `cargo:rerun-if-changed=migrations/` so Cargo recompiles `zeph-db` when new `.sql` migration files are added.

Fixes #2570, #2571

## Test plan

- [ ] `cargo +nightly fmt --check` — pass
- [ ] `cargo clippy --features full --workspace -- -D warnings` — pass
- [ ] `cargo nextest run --features full --workspace --lib --bins` — 7617/7617 pass
- [ ] Live: send a large message (>token limit) and verify `embeddings_metadata` shows multiple `chunk_index` values