### PR TITLE
fix(sanitizer,clippy): skip ML classification for policy_blocked outputs; raise hard threshold; fix doc_markdown lints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- fix(sanitizer): skip ML injection classification for `policy_blocked` tool error outputs — sandbox/policy denial messages produced by `ToolErrorFeedback::format_for_llm` reliably triggered the DeBERTa classifier as false positives; add `is_policy_blocked_output` guard before `classify_injection` call in tool execution (#2574)
+- fix(classifiers): raise default ML injection hard threshold from `0.80` to `0.95` to reduce false positives on benign tool outputs (e.g. `echo 'hello'`) while maintaining strong detection coverage (#2574)
+- fix(clippy): add backticks around identifiers (`InvalidInput`, `embed()`, `NoProviders`, `record_availability`, `thompson_stats`) in router test doc comments to fix `doc_markdown` lint errors (#2573)
 - fix(subagent): inject working directory into sub-agent system prompt so the LLM knows where the project is; send a one-time nudge when the first turn returns text-only (no tool calls) to prevent the agent from announcing intent without acting (#2582)
 - fix(tools): add PII NER circuit breaker — after `pii_ner_circuit_breaker` consecutive timeouts (default 2), NER is disabled for the session and PII detection falls back to regex-only, preventing up to 6-minute blocking on paginated reads (12 chunks × 30 s timeout); set `pii_ner_circuit_breaker = 0` to disable (#2562)
 - fix(memory): apply multi-vector chunking in real-time embedding paths (`remember`, `remember_with_parts`) — long messages are now split into overlapping ~400-token segments at write time, matching the existing `embed_missing()` behaviour; both SQLite and Qdrant backends are updated atomically (#2570)

--- a/crates/zeph-config/src/classifiers.rs
+++ b/crates/zeph-config/src/classifiers.rs
@@ -12,7 +12,7 @@ fn default_injection_model() -> String {
 }
 
 fn default_injection_threshold() -> f32 {
-    0.8
+    0.95
 }
 
 fn default_injection_threshold_soft() -> f32 {
@@ -149,7 +149,7 @@ pub struct ClassifiersConfig {
     /// Hard threshold: classifier score at or above this blocks the content (in `block` mode)
     /// or emits WARN (in `warn` mode).
     ///
-    /// Range: `(0.0, 1.0]`. Conservative default of `0.8` minimises false positives.
+    /// Range: `(0.0, 1.0]`. Conservative default of `0.95` minimises false positives.
     /// Real-world ML injection classifiers have 12–37% recall gaps at high thresholds —
     /// defense-in-depth via regex fallback and spotlighting is mandatory.
     #[serde(
@@ -285,7 +285,7 @@ mod tests {
         );
         assert_eq!(cfg.enforcement_mode, InjectionEnforcementMode::Warn);
         assert!((cfg.injection_threshold_soft - 0.5).abs() < 1e-6);
-        assert!((cfg.injection_threshold - 0.8).abs() < 1e-6);
+        assert!((cfg.injection_threshold - 0.95).abs() < 1e-6);
         assert!(cfg.injection_model_sha256.is_none());
         assert!(cfg.three_class_model.is_none());
         assert!((cfg.three_class_threshold - 0.7).abs() < 1e-6);
@@ -324,7 +324,7 @@ mod tests {
             "protectai/deberta-v3-small-prompt-injection-v2"
         );
         assert!((cfg.injection_threshold_soft - 0.5).abs() < 1e-6);
-        assert!((cfg.injection_threshold - 0.8).abs() < 1e-6);
+        assert!((cfg.injection_threshold - 0.95).abs() < 1e-6);
         assert!(!cfg.pii_enabled);
         assert!((cfg.pii_threshold - 0.75).abs() < 1e-6);
     }
@@ -418,7 +418,7 @@ mod tests {
             "protectai/deberta-v3-small-prompt-injection-v2"
         );
         assert!((cfg.injection_threshold_soft - 0.5).abs() < 1e-6);
-        assert!((cfg.injection_threshold - 0.8).abs() < 1e-6);
+        assert!((cfg.injection_threshold - 0.95).abs() < 1e-6);
     }
 
     #[test]

--- a/crates/zeph-core/src/agent/tool_execution/mod.rs
+++ b/crates/zeph-core/src/agent/tool_execution/mod.rs
@@ -13,6 +13,22 @@ use crate::redact::redact_secrets;
 use zeph_sanitizer::{ContentSource, ContentSourceKind, MemorySourceHint};
 use zeph_skills::loader::Skill;
 
+/// Returns `true` when `body` is a structured tool error with `category: policy_blocked`.
+///
+/// `ToolErrorFeedback::format_for_llm()` serialises blocked/sandbox errors as:
+/// ```text
+/// [tool_error]
+/// category: policy_blocked
+/// ...
+/// ```
+/// The `DeBERTa` injection classifier reliably fires on this text (sandbox denial messages
+/// contain imperative-style phrasing), producing a circular false positive: the sanitizer's
+/// own output is flagged by the sanitizer. Skip ML classification for these outputs entirely.
+#[cfg(feature = "classifiers")]
+fn is_policy_blocked_output(body: &str) -> bool {
+    body.contains("[tool_error]") && body.contains("category: policy_blocked")
+}
+
 /// Prefix used in the overflow notice appended to tool outputs that exceed the size threshold.
 /// Shared with the pruning logic so both sides stay in sync if the format changes.
 ///
@@ -366,6 +382,9 @@ impl<C: Channel> Agent<C> {
         // ML injection classifier: runs on tool output after regex sanitization.
         // Skip for memory_search (ConversationHistory hint) — same rationale as regex skip:
         // the user's own prior messages legitimately contain terms like "system prompt".
+        // Skip for policy_blocked error outputs — they are the sanitizer's own error format
+        // (produced by ToolErrorFeedback::format_for_llm) and classifying them is circular:
+        // the sandbox/policy denial text reliably triggers the DeBERTa model as a false positive.
         #[cfg(feature = "classifiers")]
         {
             let skip_ml = matches!(
@@ -374,7 +393,7 @@ impl<C: Channel> Agent<C> {
                     zeph_sanitizer::MemorySourceHint::ConversationHistory
                         | zeph_sanitizer::MemorySourceHint::LlmSummary
                 )
-            );
+            ) || is_policy_blocked_output(body);
             if !skip_ml && self.security.sanitizer.has_classifier_backend() {
                 // Classify the original body, not sanitized.body: the spotlight wrapper
                 // (<external-data ...>) would trigger the delimiter_escape pattern in

--- a/crates/zeph-llm/src/router/mod.rs
+++ b/crates/zeph-llm/src/router/mod.rs
@@ -2539,8 +2539,8 @@ mod tests {
 
     // ── InvalidInput embed break tests ────────────────────────────────────────
 
-    /// When a provider returns InvalidInput from embed(), the router must break
-    /// the fallback loop immediately and return InvalidInput — not NoProviders.
+    /// When a provider returns `InvalidInput` from `embed()`, the router must break
+    /// the fallback loop immediately and return `InvalidInput` — not `NoProviders`.
     #[tokio::test]
     async fn embed_invalid_input_breaks_loop_and_returns_invalid_input() {
         use crate::mock::MockProvider;
@@ -2554,7 +2554,7 @@ mod tests {
         );
     }
 
-    /// When a provider returns InvalidInput, the router must NOT fall through to
+    /// When a provider returns `InvalidInput`, the router must NOT fall through to
     /// the next provider — a second embed-capable provider must never be called.
     #[tokio::test]
     async fn embed_invalid_input_does_not_fall_through_to_second_provider() {
@@ -2610,9 +2610,9 @@ mod tests {
         assert_eq!(result, vec![1.0, 2.0, 3.0]);
     }
 
-    /// InvalidInput from embed does not call record_availability (no reputation penalty).
-    /// We verify this indirectly: thompson_stats must show no entry for the provider
-    /// after an InvalidInput embed, whereas a normal embed failure increments it.
+    /// `InvalidInput` from embed does not call `record_availability` (no reputation penalty).
+    /// We verify this indirectly: `thompson_stats` must show no entry for the provider
+    /// after an `InvalidInput` embed, whereas a normal embed failure increments it.
     #[tokio::test]
     async fn embed_invalid_input_does_not_record_availability() {
         use crate::mock::MockProvider;


### PR DESCRIPTION
## Summary

- Fixes #2573: 9 `clippy::doc_markdown` errors in `crates/zeph-llm/src/router/mod.rs` test doc comments — added backticks around `InvalidInput`, `embed()`, `NoProviders`, `record_availability`, `thompson_stats`
- Fixes #2574: ML injection classifier false positive on benign echo output and sandbox error text

## Changes

### #2573 — doc_markdown clippy

Added backticks around identifiers in test doc comments in `crates/zeph-llm/src/router/mod.rs` (lines 2542, 2543, 2557, 2613–2615). Resolves pre-commit check failure under `--all-targets`.

### #2574 — ML classifier false positive

**Primary fix**: Added `is_policy_blocked_output()` guard in `crates/zeph-core/src/agent/tool_execution/mod.rs`. Policy-blocked outputs (the sanitizer's own `[tool_error] category: policy_blocked` format) are now exempted from ML classification, breaking the circular false-positive: sandbox denial text → DeBERTa fires → sanitizer blocks its own error.

**Secondary fix**: Raised default `injection_threshold` from `0.80` to `0.95` in `crates/zeph-config/src/classifiers.rs`. Updated affected test assertions for the default value; test-local configs with explicit `injection_threshold: 0.8` are unchanged.

## Test plan

- `cargo clippy --all-targets --workspace --features full -- -D warnings` passes (was failing on main)
- `cargo +nightly fmt --check` passes
- `cargo nextest run --workspace --all-features --lib --bins` — 7617/7617 passed
- Live test required: run `echo 'hello from zeph ci373'` as shell command via agent and verify no false-positive INJECTION warning in log