### PR TITLE
fix(memory): resolve SQLite pool starvation causing multi-turn session hangs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(memory): resolve SQLite pool starvation causing multi-turn session hangs (#2591)
+
 ### Changed
 
 - **BREAKING**: Removed feature flags `guardrail`, `context-compression`, `compression-guidelines`, `policy-enforcer`, `lsp-context`, `experiments` — these features are now always compiled in and cannot be disabled (#2565)

--- a/crates/zeph-config/src/memory.rs
+++ b/crates/zeph-config/src/memory.rs
@@ -1201,6 +1201,17 @@ pub struct GraphConfig {
     /// pipeline. A consecutive-skip safety valve ensures no turn is silently skipped indefinitely.
     #[serde(default)]
     pub rpe: RpeConfig,
+    /// `SQLite` connection pool size dedicated to graph operations.
+    ///
+    /// Graph tables share the same database file as messages/embeddings but use a
+    /// separate pool to prevent pool starvation when community detection or spreading
+    /// activation runs concurrently with regular memory operations. Default: `3`.
+    #[serde(default = "default_graph_pool_size")]
+    pub pool_size: u32,
+}
+
+fn default_graph_pool_size() -> u32 {
+    3
 }
 
 impl Default for GraphConfig {
@@ -1230,6 +1241,7 @@ impl Default for GraphConfig {
             link_weight_decay_interval_secs: default_link_weight_decay_interval_secs(),
             belief_revision: BeliefRevisionConfig::default(),
             rpe: RpeConfig::default(),
+            pool_size: default_graph_pool_size(),
         }
     }
 }

--- a/crates/zeph-core/src/bootstrap/mod.rs
+++ b/crates/zeph-core/src/bootstrap/mod.rs
@@ -312,10 +312,23 @@ impl AppBuilder {
         }
 
         if self.config.memory.graph.enabled {
-            let pool = memory.sqlite().pool().clone();
-            let store = Arc::new(GraphStore::new(pool));
+            // Open a dedicated pool for graph operations to prevent pool starvation.
+            // Community detection and spreading activation can saturate the shared message pool
+            // (pool_size=5), causing pool.acquire() cancellation and semaphore drift in sqlx 0.8.
+            let graph_pool = zeph_db::DbConfig {
+                url: db_path.to_string(),
+                max_connections: self.config.memory.graph.pool_size,
+                pool_size: self.config.memory.graph.pool_size,
+            }
+            .connect()
+            .await
+            .map_err(|e| BootstrapError::Memory(e.to_string()))?;
+            let store = Arc::new(GraphStore::new(graph_pool));
             memory = memory.with_graph_store(store);
-            tracing::info!("graph memory enabled, GraphStore attached");
+            tracing::info!(
+                pool_size = self.config.memory.graph.pool_size,
+                "graph memory enabled, GraphStore attached with dedicated pool"
+            );
         }
 
         if self.config.memory.admission.enabled {

--- a/crates/zeph-memory/src/error.rs
+++ b/crates/zeph-memory/src/error.rs
@@ -38,4 +38,7 @@ pub enum MemoryError {
 
     #[error("{0}")]
     Other(String),
+
+    #[error("operation timed out: {0}")]
+    Timeout(String),
 }

--- a/crates/zeph-memory/src/graph/store/mod.rs
+++ b/crates/zeph-memory/src/graph/store/mod.rs
@@ -597,7 +597,15 @@ impl GraphStore {
             query = query.bind(et.as_str());
         }
 
-        let rows: Vec<EdgeRow> = query.fetch_all(&self.pool).await?;
+        // Wrap pool.acquire() + query execution in a short timeout to prevent the outer
+        // tokio::time::timeout (in SemanticMemory recall) from cancelling a mid-acquire
+        // future, which causes sqlx 0.8 semaphore count drift and permanent pool starvation.
+        let rows: Vec<EdgeRow> = tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            query.fetch_all(&self.pool),
+        )
+        .await
+        .map_err(|_| MemoryError::Timeout("graph pool acquire timed out after 500ms".into()))??;
         Ok(rows.into_iter().map(edge_from_row).collect())
     }
 

--- a/crates/zeph-memory/src/graph/store/tests.rs
+++ b/crates/zeph-memory/src/graph/store/tests.rs
@@ -3317,3 +3317,76 @@ async fn insert_edge_typed_rejects_self_loop() {
         "expected InvalidInput for self-loop, got: {err:?}"
     );
 }
+
+// ── Regression: #2591 pool isolation ─────────────────────────────────────────
+
+/// Regression test for #2591: two `GraphStore` instances backed by independent pools
+/// on the same file must not interfere — writes in one are visible in the other after
+/// WAL checkpoint, and pool exhaustion in one does not block the other.
+#[tokio::test]
+async fn pool_isolation_independent_pools_do_not_starve() {
+    let file = tempfile::NamedTempFile::new().expect("tempfile");
+    let path = file.path().to_str().expect("valid path").to_string();
+
+    // Pool A — simulates the shared messages pool (pool_size=5).
+    let store_a = SqliteStore::with_pool_size(&path, 5).await.unwrap();
+    let gs_a = GraphStore::new(store_a.pool().clone());
+
+    // Pool B — simulates the dedicated graph pool (pool_size=3).
+    let store_b = SqliteStore::with_pool_size(&path, 3).await.unwrap();
+    let gs_b = GraphStore::new(store_b.pool().clone());
+
+    // Write via pool A and checkpoint so pool B can see the data.
+    let alice = gs_a
+        .upsert_entity("Alice", "alice", EntityType::Person, None)
+        .await
+        .unwrap();
+    let bob = gs_a
+        .upsert_entity("Bob", "bob", EntityType::Person, None)
+        .await
+        .unwrap();
+    gs_a.insert_edge(alice, bob, "knows", "Alice knows Bob", 0.9, None)
+        .await
+        .unwrap();
+    gs_a.checkpoint_wal().await.unwrap();
+
+    // Pool B must be able to read independently without acquiring from pool A.
+    let edges = gs_b.edges_for_entity(alice).await.unwrap();
+    assert!(
+        !edges.is_empty(),
+        "#2591 regression: pool B must read edges written by pool A after checkpoint"
+    );
+
+    // Both pools are isolated — saturating pool A connections must not block pool B.
+    // Spawn 5 concurrent tasks all holding connections from pool A, then verify pool B
+    // still responds. (In-memory WAL mode: connections come from the same file but
+    // different pool semaphores are independent.)
+    let pool_a = store_a.pool().clone();
+    let handles: Vec<_> = (0..5)
+        .map(|_| {
+            let p = pool_a.clone();
+            tokio::spawn(async move {
+                // Acquire and hold the connection briefly.
+                let _conn = p.acquire().await.expect("pool A connection");
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            })
+        })
+        .collect();
+
+    // Pool B query must complete while pool A is saturated.
+    let result = tokio::time::timeout(
+        std::time::Duration::from_millis(500),
+        gs_b.edges_for_entity(alice),
+    )
+    .await;
+
+    for h in handles {
+        h.await.expect("task");
+    }
+
+    assert!(
+        result.is_ok(),
+        "#2591 regression: pool B must not block when pool A is saturated"
+    );
+    assert!(result.unwrap().is_ok(), "pool B query must succeed");
+}


### PR DESCRIPTION
## Summary

- GraphStore now uses a dedicated SQLite pool instead of sharing the main pool with messages/embeddings stores
- Added `tokio::time::timeout(500ms)` guard in `query_batch_edges` to prevent sqlx 0.8 semaphore drift on cancelled `pool.acquire()` futures
- New config field `[memory.graph] pool_size` (default: 3) for tuning

## Root cause

All three stores (SqliteStore, GraphStore, EmbeddingStore) shared one pool (`pool_size=5`). After 3-4 prompts, community detection spawned and pushed concurrent connection demand to 9+, exhausting the pool. When `tokio::time::timeout` cancelled `pool.acquire()` mid-wait, sqlx 0.8 leaked a semaphore waiter slot — causing all subsequent acquires to wait forever. Agent went silent with no error or panic.

## Test plan

- [x] `cargo +nightly fmt --check` — PASS
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings` — PASS
- [x] `cargo nextest run --workspace --all-features --lib --bins` — 7630/7630 PASS
- [x] Regression test `pool_isolation_independent_pools_do_not_starve` — PASS
- [ ] Live multi-turn session test required before merge (per LLM serialization gate)

Closes #2591