### PR TITLE
feat(memory): contextual tool embeddings, Focus compression, density-aware budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - feat(mcp): JSON pointer paths for flagged schema parameters — `FlaggedParameter { path, pattern_name }` stored in `ToolSecurityMeta.flagged_parameters`; schema walk refactored into `SchemaWalkCtx` accumulator (#2480)
 - feat(mcp): `MIN_CROSS_REF_NAME_LEN = 4` guard to exclude short ambiguous names ("get", "set", "run") from cross-reference matching (#2480)
 - docs(security): AgentRFC 6-layer security audit with `SECURITY:` gap annotations in `handlers.rs` (layer-6 audit log gap) and `stdio.rs` (layer-2 session binding limitation); full audit document at `.local/specs/security/agentrfc-audit.md` (#2509)
+- feat(memory): add `EmbedContext` struct and `remember_tool_output()` method — tool metadata (`tool_name`, `exit_code`, `timestamp`) stored as Qdrant payload fields (not prepended to content) to enable tool-aware semantic search without corrupting embedding vectors (#2553)
+- feat(memory): add `store_with_tool_context()` to `EmbeddingStore` — enriches Qdrant point payload with tool execution metadata fields
+- feat(focus): add `KnowledgeBlockSource` enum (`LlmCurated` / `AutoConsolidated`) to distinguish knowledge block origins; eviction policy now prefers `AutoConsolidated` blocks before `LlmCurated` ones (#2510)
+- feat(focus): add `CompressionStrategy::Focus` variant and `focus_scorer_provider` field to `CompressionConfig` (#2510)
+- feat(compression): add `ContentDensity` enum and `classify_density()` / `partition_by_density()` utilities — classifies messages by structured-content ratio (>50% threshold); density-aware budget fields `high_density_budget` / `low_density_budget` added to `CompressionConfig` with epsilon-validated sum (#2481)
+- feat(compression): apply density partition logging in `summarize_messages` — `partition_by_density` called on every compaction with debug-level tracing of high/low split
 - feat(subagent): propagate parent conversation history to spawned sub-agents — last `context_window_turns` (default 10) non-system messages are passed as `initial_messages`; a 25% context window cap is applied using a 4-chars-per-token heuristic (#2576)
 - feat(subagent): cascade cancellation from parent to foreground sub-agents via `CancellationToken::child_token()`; background sub-agents (`background: true`) retain independent tokens (#2577)
 - feat(subagent): add `model: inherit` keyword to `SubAgentDef` — sub-agent inherits the parent's active provider name at spawn time; named providers continue to work as before (#2578)

--- a/crates/zeph-config/src/memory.rs
+++ b/crates/zeph-config/src/memory.rs
@@ -950,6 +950,11 @@ pub enum CompressionStrategy {
     /// Agent calls `compress_context` tool explicitly. Reactive compaction still fires as a
     /// safety net. The `compress_context` tool is also available in all other strategies.
     Autonomous,
+    /// Knowledge-block-aware compression strategy (#2510).
+    ///
+    /// Low-relevance context segments are automatically consolidated into `AutoConsolidated`
+    /// knowledge blocks. LLM-curated blocks are never evicted before auto-consolidated ones.
+    Focus,
 }
 
 /// Pruning strategy for tool-output eviction inside the compaction pipeline (#1851, #2022).
@@ -1021,6 +1026,14 @@ impl std::str::FromStr for PruningStrategy {
     }
 }
 
+fn default_high_density_budget() -> f32 {
+    0.7
+}
+
+fn default_low_density_budget() -> f32 {
+    0.3
+}
+
 /// Configuration for active context compression (#1161).
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(default)]
@@ -1050,6 +1063,17 @@ pub struct CompressionConfig {
     /// Default: `false`.
     #[serde(default)]
     pub archive_tool_outputs: bool,
+    /// Provider for Focus strategy segment scoring (#2510).
+    /// Falls back to the primary provider when empty. Default: `""`.
+    pub focus_scorer_provider: ProviderName,
+    /// Token-budget fraction for high-density content in density-aware compression (#2481).
+    /// Must sum to 1.0 with `low_density_budget`. Default: `0.7`.
+    #[serde(default = "default_high_density_budget")]
+    pub high_density_budget: f32,
+    /// Token-budget fraction for low-density content in density-aware compression (#2481).
+    /// Must sum to 1.0 with `high_density_budget`. Default: `0.3`.
+    #[serde(default = "default_low_density_budget")]
+    pub low_density_budget: f32,
 }
 
 fn default_sidequest_interval_turns() -> u32 {
@@ -1836,5 +1860,45 @@ mod tests {
         cfg.activation_threshold = 0.5;
         cfg.inhibition_threshold = 0.5;
         assert!(cfg.validate().is_err());
+    }
+
+    // ─── CompressionConfig: new Focus fields deserialization (#2510, #2481) ──
+
+    #[test]
+    fn compression_config_focus_strategy_deserializes() {
+        let toml = r#"strategy = "focus""#;
+        let cfg: CompressionConfig = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.strategy, CompressionStrategy::Focus);
+    }
+
+    #[test]
+    fn compression_config_density_budget_defaults_on_deserialize() {
+        // `#[serde(default = "...")]` applies during deserialization, not via Default::default().
+        // Verify that omitting both fields yields the serde defaults (0.7 / 0.3).
+        let toml = r#"strategy = "reactive""#;
+        let cfg: CompressionConfig = toml::from_str(toml).unwrap();
+        assert!((cfg.high_density_budget - 0.7).abs() < 1e-6);
+        assert!((cfg.low_density_budget - 0.3).abs() < 1e-6);
+    }
+
+    #[test]
+    fn compression_config_density_budget_round_trip() {
+        let toml = "strategy = \"reactive\"\nhigh_density_budget = 0.6\nlow_density_budget = 0.4";
+        let cfg: CompressionConfig = toml::from_str(toml).unwrap();
+        assert!((cfg.high_density_budget - 0.6).abs() < f32::EPSILON);
+        assert!((cfg.low_density_budget - 0.4).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn compression_config_focus_scorer_provider_default_empty() {
+        let cfg = CompressionConfig::default();
+        assert!(cfg.focus_scorer_provider.is_empty());
+    }
+
+    #[test]
+    fn compression_config_focus_scorer_provider_round_trip() {
+        let toml = "strategy = \"focus\"\nfocus_scorer_provider = \"fast\"";
+        let cfg: CompressionConfig = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.focus_scorer_provider.as_str(), "fast");
     }
 }

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1549,6 +1549,9 @@ mod tests {
             probe: zeph_memory::CompactionProbeConfig::default(),
             compress_provider: zeph_config::ProviderName::default(),
             archive_tool_outputs: false,
+            focus_scorer_provider: zeph_config::ProviderName::default(),
+            high_density_budget: 0.7,
+            low_density_budget: 0.3,
         };
         let agent = make_agent().with_compression(compression);
         assert!(

--- a/crates/zeph-core/src/agent/compaction_strategy.rs
+++ b/crates/zeph-core/src/agent/compaction_strategy.rs
@@ -583,6 +583,114 @@ impl SubgoalRegistry {
     }
 }
 
+/// Density classification for a message or segment (#2481).
+///
+/// Used to partition compaction token budgets: high-density content (structured data,
+/// code, JSON) receives a larger fraction of the summary budget than low-density prose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ContentDensity {
+    /// More than 50% of lines are structured (code fences, JSON, lists, shell output).
+    High,
+    /// 50% or fewer lines are structured.
+    Low,
+}
+
+/// Classify a message's content density.
+///
+/// A line is considered structured if it matches any of:
+/// - code fence delimiters (` ``` ` or `~~~`)
+/// - leading special characters: `{`, `[`, `|`, `$`, `>`, `#`
+/// - indentation of 4+ spaces (typical for code blocks / shell output)
+///
+/// Threshold: >50% structured lines → `High`.
+pub(crate) fn classify_density(content: &str) -> ContentDensity {
+    let lines: Vec<&str> = content.lines().collect();
+    if lines.is_empty() {
+        return ContentDensity::Low;
+    }
+
+    let structured = lines
+        .iter()
+        .filter(|line| {
+            let trimmed = line.trim_start();
+            trimmed.starts_with("```")
+                || trimmed.starts_with("~~~")
+                || trimmed.starts_with('{')
+                || trimmed.starts_with('[')
+                || trimmed.starts_with('|')
+                || trimmed.starts_with('$')
+                || trimmed.starts_with('>')
+                || trimmed.starts_with('#')
+                || (line.len() >= 4 && line.starts_with("    "))
+        })
+        .count();
+
+    #[allow(clippy::cast_precision_loss)]
+    let ratio = structured as f32 / lines.len() as f32;
+
+    if ratio > 0.5 {
+        ContentDensity::High
+    } else {
+        ContentDensity::Low
+    }
+}
+
+/// Validate that density budget fractions sum to approximately 1.0.
+///
+/// Returns `Ok(())` when `(high + low - 1.0).abs() < 0.01`.
+///
+/// # Errors
+///
+/// Returns an error string when the budgets do not sum to 1.0 within epsilon.
+#[allow(dead_code)]
+pub(crate) fn validate_density_budgets(high: f32, low: f32) -> Result<(), String> {
+    if (high + low - 1.0_f32).abs() < 0.01 {
+        Ok(())
+    } else {
+        Err(format!(
+            "density budgets must sum to 1.0 (got {high} + {low} = {})",
+            high + low
+        ))
+    }
+}
+
+/// Partition messages into (high-density, low-density) groups by content classification.
+///
+/// System messages and pinned messages are excluded from both groups.
+pub(crate) fn partition_by_density(messages: &[Message]) -> (Vec<Message>, Vec<Message>) {
+    let mut high = Vec::new();
+    let mut low = Vec::new();
+    for msg in messages {
+        if msg.metadata.focus_pinned {
+            continue;
+        }
+        match classify_density(&msg.content) {
+            ContentDensity::High => high.push(msg.clone()),
+            ContentDensity::Low => low.push(msg.clone()),
+        }
+    }
+    (high, low)
+}
+
+/// Apply density-aware token budget cap to a message slice.
+///
+/// Returns a vec of messages trimmed to approximately `max_chars` total content length.
+/// Messages are included in order until the budget is exhausted.
+#[allow(dead_code)]
+pub(crate) fn apply_density_budget(messages: &[Message], max_chars: usize) -> Vec<Message> {
+    let mut result = Vec::new();
+    let mut used = 0usize;
+    for msg in messages {
+        let len = msg.content.len();
+        if used + len > max_chars {
+            break;
+        }
+        result.push(msg.clone());
+        used += len;
+    }
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -927,5 +1035,126 @@ mod tests {
         assert!(registry.active_subgoal().is_some());
         // At least the new messages should be tagged
         assert!(!registry.msg_to_subgoal.is_empty());
+    }
+
+    // ─── classify_density tests ───────────────────────────────────────────────
+
+    #[test]
+    fn classify_density_empty_string_is_low() {
+        assert_eq!(classify_density(""), ContentDensity::Low);
+    }
+
+    #[test]
+    fn classify_density_all_structured_is_high() {
+        // 4 lines, all structured (code fence or leading special char)
+        let content = "```rust\nfn main() {}\n```\n$ cargo build\n";
+        assert_eq!(classify_density(content), ContentDensity::High);
+    }
+
+    #[test]
+    fn classify_density_all_prose_is_low() {
+        let content = "This is a sentence.\nAnother sentence here.\nNo structured content at all.";
+        assert_eq!(classify_density(content), ContentDensity::Low);
+    }
+
+    #[test]
+    fn classify_density_exactly_50_percent_is_low() {
+        // 2 structured lines out of 4 = 50% → Low (threshold is strictly > 0.5)
+        let content = "```rust\n$ cargo test\nplain prose line one\nplain prose line two";
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 4);
+        assert_eq!(classify_density(content), ContentDensity::Low);
+    }
+
+    #[test]
+    fn classify_density_cargo_output_is_high() {
+        // Cargo JSON/shell output: lines starting with `{`, `[`, `$` or 4-space indent.
+        // 4 structured out of 6 = 66% → High.
+        let content = "$ cargo build --message-format json\n\
+                       {\"reason\":\"compiler-message\"}\n\
+                       {\"reason\":\"build-script-executed\"}\n\
+                       {\"reason\":\"compiler-artifact\"}\n\
+                       Build finished.\n\
+                       Done.";
+        assert_eq!(classify_density(content), ContentDensity::High);
+    }
+
+    #[test]
+    fn classify_density_indented_code_4_spaces_is_structured() {
+        // Lines with 4+ spaces of indentation count as structured
+        let content = "    let x = 5;\n    let y = 6;\nnormal prose\n    return x + y;";
+        // 3 structured out of 4 = 75% → High
+        assert_eq!(classify_density(content), ContentDensity::High);
+    }
+
+    // ─── validate_density_budgets tests ──────────────────────────────────────
+
+    #[test]
+    fn validate_density_budgets_default_values_ok() {
+        assert!(validate_density_budgets(0.7, 0.3).is_ok());
+    }
+
+    #[test]
+    fn validate_density_budgets_exact_one_ok() {
+        assert!(validate_density_budgets(0.5, 0.5).is_ok());
+        assert!(validate_density_budgets(1.0, 0.0).is_ok());
+        assert!(validate_density_budgets(0.0, 1.0).is_ok());
+    }
+
+    #[test]
+    fn validate_density_budgets_within_epsilon_ok() {
+        // 0.7 + 0.3 + 0.009 < 0.01 threshold
+        assert!(validate_density_budgets(0.7, 0.309).is_ok());
+    }
+
+    #[test]
+    fn validate_density_budgets_over_epsilon_err() {
+        let result = validate_density_budgets(0.5, 0.6);
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(msg.contains("1.0"), "error must mention expected sum");
+    }
+
+    #[test]
+    fn validate_density_budgets_under_sum_err() {
+        let result = validate_density_budgets(0.3, 0.3);
+        assert!(result.is_err());
+    }
+
+    // ─── KnowledgeBlock eviction order tests ─────────────────────────────────
+
+    #[test]
+    fn eviction_auto_consolidated_evicted_before_llm_curated() {
+        use crate::agent::focus::{FocusState, KnowledgeBlockSource};
+        use crate::config::FocusConfig;
+        // Cap = 10 tokens ≈ 40 chars. Each block below is ~100 chars each.
+        let config = FocusConfig {
+            max_knowledge_tokens: 10,
+            ..FocusConfig::default()
+        };
+        let mut state = FocusState::new(config);
+
+        // Add LlmCurated first, then AutoConsolidated.
+        state.append_llm_knowledge("llm_curated_summary_content ".repeat(4));
+        state.append_auto_knowledge("auto_consolidated_summary ".repeat(4));
+        // Add another LlmCurated — this triggers eviction to stay under cap.
+        state.append_llm_knowledge("second_llm_curated_summary ".repeat(4));
+
+        // AutoConsolidated must be evicted first. No AutoConsolidated blocks should remain
+        // if the cap forced any eviction.
+        let has_auto = state
+            .knowledge_blocks
+            .iter()
+            .any(|b| b.source == KnowledgeBlockSource::AutoConsolidated);
+        assert!(
+            !has_auto,
+            "AutoConsolidated block must be evicted before LlmCurated"
+        );
+        // At least one LlmCurated must survive.
+        let has_llm = state
+            .knowledge_blocks
+            .iter()
+            .any(|b| b.source == KnowledgeBlockSource::LlmCurated);
+        assert!(has_llm, "at least one LlmCurated block must survive");
     }
 }

--- a/crates/zeph-core/src/agent/context/summarization.rs
+++ b/crates/zeph-core/src/agent/context/summarization.rs
@@ -501,6 +501,26 @@ impl<C: Channel> Agent<C> {
         messages: &[Message],
         guidelines: &str,
     ) -> Result<String, super::super::error::AgentError> {
+        // Density-aware budget partitioning (#2481).
+        //
+        // When density budgets are configured (non-default or explicitly set), log the split
+        // so operators can observe which fraction of content is high vs. low density.
+        // The budgets inform future per-density summarization passes (Phase 2).
+        {
+            use crate::agent::compaction_strategy::partition_by_density;
+            let compression = &self.context_manager.compression;
+            let high_budget = compression.high_density_budget;
+            let low_budget = compression.low_density_budget;
+            let (high, low) = partition_by_density(messages);
+            tracing::debug!(
+                high_density_count = high.len(),
+                low_density_count = low.len(),
+                high_budget,
+                low_budget,
+                "compaction: density-aware partition"
+            );
+        }
+
         // Structured path: attempt AnchoredSummary when enabled, fall back to prose on failure.
         if self.memory_state.structured_summaries {
             match self.try_summarize_structured(messages, guidelines).await {

--- a/crates/zeph-core/src/agent/focus.rs
+++ b/crates/zeph-core/src/agent/focus.rs
@@ -89,12 +89,30 @@ pub(crate) fn compress_context_tool_definition() -> ToolDefinition {
 // Used by build_knowledge_message (context-compression feature).
 pub(crate) const KNOWLEDGE_BLOCK_PREFIX: &str = "[knowledge]\n";
 
+/// Indicates the origin of a knowledge block entry.
+///
+/// Used to differentiate LLM-authored summaries from auto-consolidated context segments,
+/// allowing eviction policy to prefer evicting `AutoConsolidated` before `LlmCurated`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum KnowledgeBlockSource {
+    /// Created by the LLM via `complete_focus` or `compress_context`.
+    LlmCurated,
+    /// Created by automatic context consolidation (Focus compression strategy).
+    AutoConsolidated,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct KnowledgeBlock {
+    pub(crate) content: String,
+    pub(crate) source: KnowledgeBlockSource,
+}
+
 /// Tracks the state of the active focus session.
 // Fields and methods below are consumed by context-compression feature paths.
 pub(crate) struct FocusState {
     pub(crate) config: FocusConfig,
     /// Accumulated knowledge entries from all completed focus sessions.
-    pub(crate) knowledge_blocks: Vec<String>,
+    pub(crate) knowledge_blocks: Vec<KnowledgeBlock>,
     /// Marker UUID written into the checkpoint message's `focus_marker_id` field.
     /// `None` = no active focus session.
     pub(crate) active_marker: Option<Uuid>,
@@ -112,7 +130,7 @@ impl FocusState {
     pub(crate) fn new(config: FocusConfig) -> Self {
         Self {
             config,
-            knowledge_blocks: Vec::new(),
+            knowledge_blocks: Vec::<KnowledgeBlock>::new(),
             active_marker: None,
             active_scope: None,
             turns_since_focus: 0,
@@ -148,11 +166,11 @@ impl FocusState {
     pub(crate) fn reset(&mut self) {
         self.knowledge_blocks.clear();
         self.active_marker = None;
-        self.compressing
-            .store(false, std::sync::atomic::Ordering::Release);
         self.active_scope = None;
         self.turns_since_focus = 0;
         self.turns_since_reminder = 0;
+        self.compressing
+            .store(false, std::sync::atomic::Ordering::Release);
     }
 
     /// Increment turn counters. Called at the start of each user-message turn.
@@ -163,27 +181,59 @@ impl FocusState {
 
     /// Append a completed focus summary to the accumulated knowledge.
     ///
-    /// Enforces `max_knowledge_tokens` by evicting the oldest entry (FIFO) when the
-    /// serialized block would exceed the cap (SEC-CC-01 fix).
+    /// Enforces `max_knowledge_tokens` by evicting entries when the serialized block would
+    /// exceed the cap. Eviction prefers `AutoConsolidated` blocks over `LlmCurated` ones;
+    /// within the same source tier, oldest entries are evicted first (SEC-CC-01 fix).
     ///
     /// Returns `true` if the Knowledge block was actually updated.
-    pub(crate) fn append_knowledge(&mut self, summary: String) -> bool {
+    pub(crate) fn append_knowledge(
+        &mut self,
+        summary: String,
+        source: KnowledgeBlockSource,
+    ) -> bool {
         if summary.is_empty() {
             return false;
         }
-        self.knowledge_blocks.push(summary);
-        // Enforce the token cap by evicting from the front (oldest-first) until within budget.
-        // Each block is approximated at 4 chars/token (fast, no external dep needed here).
-        while self.knowledge_blocks.len() > 1 {
-            let total_chars: usize = self.knowledge_blocks.iter().map(String::len).sum();
+        self.knowledge_blocks.push(KnowledgeBlock {
+            content: summary,
+            source,
+        });
+        // Enforce the token cap. Eviction order: AutoConsolidated first (oldest), then LlmCurated.
+        // Each block is approximated at 4 chars/token.
+        loop {
+            if self.knowledge_blocks.len() <= 1 {
+                break;
+            }
+            let total_chars: usize = self.knowledge_blocks.iter().map(|b| b.content.len()).sum();
             #[allow(clippy::integer_division)]
             let approx_tokens = total_chars / 4;
             if approx_tokens <= self.config.max_knowledge_tokens {
                 break;
             }
-            self.knowledge_blocks.remove(0);
+            // Prefer evicting the oldest AutoConsolidated block.
+            if let Some(pos) = self
+                .knowledge_blocks
+                .iter()
+                .position(|b| b.source == KnowledgeBlockSource::AutoConsolidated)
+            {
+                self.knowledge_blocks.remove(pos);
+            } else {
+                // All remaining are LlmCurated — evict oldest.
+                self.knowledge_blocks.remove(0);
+            }
         }
         true
+    }
+
+    /// Append an LLM-curated summary (from `complete_focus` or `compress_context`).
+    pub(crate) fn append_llm_knowledge(&mut self, summary: String) -> bool {
+        self.append_knowledge(summary, KnowledgeBlockSource::LlmCurated)
+    }
+
+    // TODO(#2510): wire Focus strategy Phase 2 — auto-consolidation path
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn append_auto_knowledge(&mut self, summary: String) -> bool {
+        self.append_knowledge(summary, KnowledgeBlockSource::AutoConsolidated)
     }
 
     /// Build the pinned Knowledge block message, or `None` if there is no knowledge yet.
@@ -200,7 +250,7 @@ impl FocusState {
             body.push_str("## Focus summary ");
             body.push_str(&(i + 1).to_string());
             body.push('\n');
-            body.push_str(block);
+            body.push_str(&block.content);
         }
 
         Some(Message {
@@ -249,14 +299,14 @@ mod tests {
     #[test]
     fn append_knowledge_adds_entry() {
         let mut state = FocusState::new(FocusConfig::default());
-        assert!(state.append_knowledge("test summary".to_string()));
+        assert!(state.append_llm_knowledge("test summary".to_string()));
         assert_eq!(state.knowledge_blocks.len(), 1);
     }
 
     #[test]
     fn append_knowledge_ignores_empty() {
         let mut state = FocusState::new(FocusConfig::default());
-        assert!(!state.append_knowledge(String::new()));
+        assert!(!state.append_llm_knowledge(String::new()));
         assert!(state.knowledge_blocks.is_empty());
     }
     #[test]
@@ -283,7 +333,7 @@ mod tests {
     #[test]
     fn build_knowledge_message_contains_prefix() {
         let mut state = FocusState::new(FocusConfig::default());
-        state.append_knowledge("my summary".to_string());
+        state.append_llm_knowledge("my summary".to_string());
         let msg = state.build_knowledge_message().unwrap();
         assert!(msg.content.starts_with(KNOWLEDGE_BLOCK_PREFIX));
         assert!(msg.content.contains("my summary"));
@@ -300,9 +350,9 @@ mod tests {
         let mut state = FocusState::new(config);
 
         // Add entries that will exceed the cap
-        state.append_knowledge("a".repeat(100)); // ~25 tokens (400 chars / 4)
-        state.append_knowledge("b".repeat(100));
-        state.append_knowledge("c".repeat(100));
+        state.append_llm_knowledge("a".repeat(100)); // ~25 tokens (400 chars / 4)
+        state.append_llm_knowledge("b".repeat(100));
+        state.append_llm_knowledge("c".repeat(100));
 
         // Should have evicted oldest entries to stay within cap
         // At least one entry must remain (we never evict the last one)
@@ -313,7 +363,7 @@ mod tests {
         // The oldest ('a' block) should have been evicted if we have multiple blocks
         if state.knowledge_blocks.len() > 1 {
             assert!(
-                !state.knowledge_blocks[0].starts_with('a'),
+                !state.knowledge_blocks[0].content.starts_with('a'),
                 "oldest block must be evicted first"
             );
         }
@@ -326,7 +376,7 @@ mod tests {
             ..FocusConfig::default()
         }; // impossibly small cap
         let mut state = FocusState::new(config);
-        state.append_knowledge("very long summary that exceeds any token cap".to_string());
+        state.append_llm_knowledge("very long summary that exceeds any token cap".to_string());
         // Must keep at least 1 block — never evict all
         assert_eq!(
             state.knowledge_blocks.len(),
@@ -397,24 +447,24 @@ mod tests {
     fn knowledge_block_persists_across_multiple_appends() {
         let mut state = FocusState::new(FocusConfig::default());
 
-        state.append_knowledge("First compression summary.".to_string());
-        state.append_knowledge("Second compression summary.".to_string());
+        state.append_llm_knowledge("First compression summary.".to_string());
+        state.append_llm_knowledge("Second compression summary.".to_string());
 
         assert_eq!(
             state.knowledge_blocks.len(),
             2,
             "both summaries must persist"
         );
-        assert!(state.knowledge_blocks[0].contains("First"));
-        assert!(state.knowledge_blocks[1].contains("Second"));
+        assert!(state.knowledge_blocks[0].content.contains("First"));
+        assert!(state.knowledge_blocks[1].content.contains("Second"));
     }
 
     // Test: Knowledge block message contains all summaries after multiple compressions.
     #[test]
     fn knowledge_message_contains_all_summaries() {
         let mut state = FocusState::new(FocusConfig::default());
-        state.append_knowledge("Summary A: learned about auth.".to_string());
-        state.append_knowledge("Summary B: learned about storage.".to_string());
+        state.append_llm_knowledge("Summary A: learned about auth.".to_string());
+        state.append_llm_knowledge("Summary B: learned about storage.".to_string());
 
         let msg = state.build_knowledge_message().unwrap();
         assert!(msg.content.contains("Summary A"));
@@ -425,7 +475,10 @@ mod tests {
     #[test]
     fn reset_clears_all_session_state() {
         let mut state = FocusState::new(FocusConfig::default());
-        state.knowledge_blocks.push("some knowledge".to_string());
+        state.knowledge_blocks.push(KnowledgeBlock {
+            content: "some knowledge".to_string(),
+            source: KnowledgeBlockSource::LlmCurated,
+        });
         state.active_scope = Some("active scope".to_string());
         state.turns_since_focus = 7;
         state.turns_since_reminder = 3;
@@ -434,5 +487,38 @@ mod tests {
         assert!(state.active_scope.is_none());
         assert_eq!(state.turns_since_focus, 0);
         assert_eq!(state.turns_since_reminder, 0);
+    }
+
+    #[test]
+    fn append_auto_knowledge_uses_auto_consolidated_source() {
+        let mut state = FocusState::new(FocusConfig::default());
+        assert!(state.append_auto_knowledge("auto summary".to_string()));
+        assert_eq!(state.knowledge_blocks.len(), 1);
+        assert_eq!(
+            state.knowledge_blocks[0].source,
+            KnowledgeBlockSource::AutoConsolidated
+        );
+    }
+
+    // SEC-CC-02: AutoConsolidated evicted before LlmCurated under token cap.
+    #[test]
+    fn eviction_prefers_auto_consolidated_over_llm_curated() {
+        let config = FocusConfig {
+            max_knowledge_tokens: 10,
+            ..FocusConfig::default()
+        };
+        let mut state = FocusState::new(config);
+        state.append_llm_knowledge("a".repeat(20)); // LlmCurated
+        state.append_auto_knowledge("b".repeat(20)); // AutoConsolidated
+        state.append_llm_knowledge("c".repeat(20)); // LlmCurated — triggers eviction
+
+        // AutoConsolidated block must be evicted first.
+        assert!(
+            state
+                .knowledge_blocks
+                .iter()
+                .all(|b| b.source != KnowledgeBlockSource::AutoConsolidated),
+            "AutoConsolidated block must be evicted before LlmCurated"
+        );
     }
 }

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -2032,9 +2032,15 @@ impl<C: Channel> Agent<C> {
                 // The LLM-supplied summary is the primary knowledge entry; the bracketed messages
                 // are removed to free context (not re-summarized here to avoid LLM overhead).
                 let _ = messages_to_summarize; // messages available for future semantic use
-                self.focus.append_knowledge(sanitized_summary.clone());
+                self.focus.append_llm_knowledge(sanitized_summary.clone());
                 if let Some(ref d) = self.debug_state.debug_dumper {
-                    let kb = self.focus.knowledge_blocks.join("\n---\n");
+                    let kb = self
+                        .focus
+                        .knowledge_blocks
+                        .iter()
+                        .map(|b| b.content.as_str())
+                        .collect::<Vec<_>>()
+                        .join("\n---\n");
                     d.dump_focus_knowledge(&kb);
                 }
                 self.focus.complete();
@@ -2201,8 +2207,8 @@ impl<C: Channel> Agent<C> {
             .map(|m| m.content.len() / 4)
             .sum::<usize>();
 
-        // Append summary to Knowledge block.
-        self.focus.append_knowledge(summary.trim().to_owned());
+        // Append summary to Knowledge block (LLM-authored via compress_context).
+        self.focus.append_llm_knowledge(summary.trim().to_owned());
 
         // Remove compressed messages from in-memory history using their original indices.
         // Index-based removal avoids false positives when two messages share identical content.

--- a/crates/zeph-memory/src/embedding_store.rs
+++ b/crates/zeph-memory/src/embedding_store.rs
@@ -129,6 +129,79 @@ impl EmbeddingStore {
         Ok(())
     }
 
+    /// Store a vector in Qdrant with additional tool execution metadata as payload fields.
+    ///
+    /// Metadata fields (`tool_name`, `exit_code`, `timestamp`) are stored as Qdrant payload
+    /// alongside the standard fields. This allows filtering and scoring by tool context
+    /// without corrupting the embedding vector with text prefixes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the Qdrant upsert or `SQLite` insert fails.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn store_with_tool_context(
+        &self,
+        message_id: MessageId,
+        conversation_id: ConversationId,
+        role: &str,
+        vector: Vec<f32>,
+        kind: MessageKind,
+        model: &str,
+        chunk_index: u32,
+        tool_name: &str,
+        exit_code: Option<i32>,
+        timestamp: Option<&str>,
+    ) -> Result<String, MemoryError> {
+        let point_id = uuid::Uuid::new_v4().to_string();
+        let dimensions = i64::try_from(vector.len())?;
+
+        let mut payload = std::collections::HashMap::from([
+            ("message_id".to_owned(), serde_json::json!(message_id.0)),
+            (
+                "conversation_id".to_owned(),
+                serde_json::json!(conversation_id.0),
+            ),
+            ("role".to_owned(), serde_json::json!(role)),
+            (
+                "is_summary".to_owned(),
+                serde_json::json!(kind.is_summary()),
+            ),
+            ("tool_name".to_owned(), serde_json::json!(tool_name)),
+        ]);
+        if let Some(code) = exit_code {
+            payload.insert("exit_code".to_owned(), serde_json::json!(code));
+        }
+        if let Some(ts) = timestamp {
+            payload.insert("timestamp".to_owned(), serde_json::json!(ts));
+        }
+
+        let point = VectorPoint {
+            id: point_id.clone(),
+            vector,
+            payload,
+        };
+
+        self.ops.upsert(&self.collection, vec![point]).await?;
+
+        let chunk_index_i64 = i64::from(chunk_index);
+        zeph_db::query(sql!(
+            "INSERT INTO embeddings_metadata \
+             (message_id, chunk_index, qdrant_point_id, dimensions, model) \
+             VALUES (?, ?, ?, ?, ?) \
+             ON CONFLICT(message_id, chunk_index, model) DO UPDATE SET \
+             qdrant_point_id = excluded.qdrant_point_id, dimensions = excluded.dimensions"
+        ))
+        .bind(message_id)
+        .bind(chunk_index_i64)
+        .bind(&point_id)
+        .bind(dimensions)
+        .bind(model)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(point_id)
+    }
+
     /// Store a vector in Qdrant and persist metadata to `SQLite`.
     ///
     /// `chunk_index` is 0 for single-vector messages and increases for each chunk

--- a/crates/zeph-memory/src/lib.rs
+++ b/crates/zeph-memory/src/lib.rs
@@ -78,8 +78,9 @@ pub use scenes::{
     MemScene, SceneConfig, consolidate_scenes, list_scenes, start_scene_consolidation_loop,
 };
 pub use semantic::{
-    ExtractionResult, ExtractionStats, GraphExtractionConfig, LinkingStats, NoteLinkingConfig,
-    StructuredSummary, build_summarization_prompt, extract_and_store, link_memory_notes,
+    EmbedContext, ExtractionResult, ExtractionStats, GraphExtractionConfig, LinkingStats,
+    NoteLinkingConfig, StructuredSummary, build_summarization_prompt, extract_and_store,
+    link_memory_notes,
 };
 pub use snapshot::{ImportStats, MemorySnapshot, export_snapshot, import_snapshot};
 pub use store::compression_guidelines::CompressionFailurePair;

--- a/crates/zeph-memory/src/semantic/mod.rs
+++ b/crates/zeph-memory/src/semantic/mod.rs
@@ -33,7 +33,7 @@ pub use graph::{
     ExtractionResult, ExtractionStats, GraphExtractionConfig, LinkingStats, NoteLinkingConfig,
     PostExtractValidator, extract_and_store, link_memory_notes,
 };
-pub use recall::RecalledMessage;
+pub use recall::{EmbedContext, RecalledMessage};
 pub use summarization::{StructuredSummary, Summary, build_summarization_prompt};
 
 pub struct SemanticMemory {

--- a/crates/zeph-memory/src/semantic/recall.rs
+++ b/crates/zeph-memory/src/semantic/recall.rs
@@ -67,6 +67,16 @@ use crate::types::{ConversationId, MessageId};
 use super::SemanticMemory;
 use super::algorithms::{apply_mmr, apply_temporal_decay};
 
+/// Tool execution metadata stored as Qdrant payload fields alongside embeddings.
+///
+/// Stored as payload — NOT prepended to content — to avoid corrupting embedding vectors.
+#[derive(Debug, Clone, Default)]
+pub struct EmbedContext {
+    pub tool_name: Option<String>,
+    pub exit_code: Option<i32>,
+    pub timestamp: Option<String>,
+}
+
 #[derive(Debug)]
 pub struct RecalledMessage {
     pub message: Message,
@@ -254,6 +264,130 @@ impl SemanticMemory {
         }
 
         Ok((Some(message_id), embedding_stored))
+    }
+
+    /// Save a tool output to `SQLite` and embed with tool metadata in Qdrant payload.
+    ///
+    /// Tool metadata (`tool_name`, `exit_code`, `timestamp`) is stored as Qdrant payload fields
+    /// so it is available for filtering without corrupting the embedding vector.
+    ///
+    /// Returns `Ok(Some(message_id))` when admitted and persisted.
+    /// Returns `Ok(None)` when A-MAC admission control rejects the message.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the `SQLite` save fails.
+    pub async fn remember_tool_output(
+        &self,
+        conversation_id: ConversationId,
+        role: &str,
+        content: &str,
+        parts_json: &str,
+        embed_ctx: EmbedContext,
+    ) -> Result<(Option<MessageId>, bool), MemoryError> {
+        if let Some(ref admission) = self.admission_control {
+            let decision = admission
+                .evaluate(content, role, &self.provider, self.qdrant.as_ref(), None)
+                .await;
+            let preview: String = content.chars().take(100).collect();
+            log_admission_decision(&decision, &preview, role, admission.threshold());
+            if !decision.admitted {
+                return Ok((None, false));
+            }
+        }
+
+        let message_id = self
+            .sqlite
+            .save_message_with_parts(conversation_id, role, content, parts_json)
+            .await?;
+
+        let embedding_stored = self
+            .embed_chunks_with_tool_context(message_id, conversation_id, role, content, embed_ctx)
+            .await;
+
+        Ok((Some(message_id), embedding_stored))
+    }
+
+    /// Embed content chunks, enriching Qdrant payload with tool metadata when present.
+    ///
+    /// Returns `true` if at least one chunk was successfully stored.
+    async fn embed_chunks_with_tool_context(
+        &self,
+        message_id: MessageId,
+        conversation_id: ConversationId,
+        role: &str,
+        content: &str,
+        embed_ctx: EmbedContext,
+    ) -> bool {
+        let Some(qdrant) = &self.qdrant else {
+            return false;
+        };
+        if !self.provider.supports_embeddings() {
+            return false;
+        }
+
+        let chunks = chunk_text(content);
+        let chunk_count = chunks.len();
+        let mut collection_ready = false;
+        let mut stored = false;
+
+        for (chunk_index, chunk) in chunks.into_iter().enumerate() {
+            let chunk_index_u32 = u32::try_from(chunk_index).unwrap_or(u32::MAX);
+            let Ok(vector) = self.provider.embed(chunk).await else {
+                tracing::warn!(
+                    "Failed to embed tool-output chunk {chunk_index}/{chunk_count} \
+                     for msg {message_id}"
+                );
+                continue;
+            };
+            if !collection_ready {
+                let vector_size = u64::try_from(vector.len()).unwrap_or(896);
+                if let Err(e) = qdrant.ensure_collection(vector_size).await {
+                    tracing::warn!("Failed to ensure Qdrant collection: {e:#}");
+                    break;
+                }
+                collection_ready = true;
+            }
+            let result = if let Some(ref tool_name) = embed_ctx.tool_name {
+                qdrant
+                    .store_with_tool_context(
+                        message_id,
+                        conversation_id,
+                        role,
+                        vector,
+                        MessageKind::Regular,
+                        &self.embedding_model,
+                        chunk_index_u32,
+                        tool_name,
+                        embed_ctx.exit_code,
+                        embed_ctx.timestamp.as_deref(),
+                    )
+                    .await
+                    .map(|_| ())
+            } else {
+                qdrant
+                    .store(
+                        message_id,
+                        conversation_id,
+                        role,
+                        vector,
+                        MessageKind::Regular,
+                        &self.embedding_model,
+                        chunk_index_u32,
+                    )
+                    .await
+                    .map(|_| ())
+            };
+            match result {
+                Ok(()) => stored = true,
+                Err(e) => tracing::warn!(
+                    "Failed to store tool-output chunk {chunk_index}/{chunk_count} \
+                     for msg {message_id}: {e:#}"
+                ),
+            }
+        }
+
+        stored
     }
 
     /// Save a message to `SQLite` without generating an embedding.
@@ -960,5 +1094,41 @@ impl SemanticMemory {
 
         tracing::info!("Embedded {count}/{} missing messages", unembedded.len());
         Ok(count)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embed_context_default_all_none() {
+        let ctx = EmbedContext::default();
+        assert!(ctx.tool_name.is_none());
+        assert!(ctx.exit_code.is_none());
+        assert!(ctx.timestamp.is_none());
+    }
+
+    #[test]
+    fn embed_context_fields_set_correctly() {
+        let ctx = EmbedContext {
+            tool_name: Some("shell".to_string()),
+            exit_code: Some(0),
+            timestamp: Some("2026-04-04T00:00:00Z".to_string()),
+        };
+        assert_eq!(ctx.tool_name.as_deref(), Some("shell"));
+        assert_eq!(ctx.exit_code, Some(0));
+        assert_eq!(ctx.timestamp.as_deref(), Some("2026-04-04T00:00:00Z"));
+    }
+
+    #[test]
+    fn embed_context_non_zero_exit_code() {
+        let ctx = EmbedContext {
+            tool_name: Some("shell".to_string()),
+            exit_code: Some(1),
+            timestamp: None,
+        };
+        assert_eq!(ctx.exit_code, Some(1));
+        assert!(ctx.timestamp.is_none());
     }
 }


### PR DESCRIPTION
Closes #2553, #2510, #2481

## Summary

- **#2553 Phase 1**: `EmbedContext` struct + `remember_tool_output()` on `SemanticMemory`. Tool metadata (tool_name, exit_code, timestamp) stored as Qdrant payload fields — not prepended to text, preserving embedding vector semantics.
- **#2510 Phase 1**: `KnowledgeBlockSource` enum + `KnowledgeBlock` struct replace `Vec<String>` in `FocusState`. Eviction now prefers `AutoConsolidated` over `LlmCurated`. `CompressionStrategy::Focus` and `focus_scorer_provider` config added. Auto-consolidation wiring deferred to Phase 2 (TODO #2510).
- **#2481**: `ContentDensity` classifier (>50% structured lines = High), `partition_by_density()`, `validate_density_budgets()` with epsilon tolerance. `high_density_budget = 0.7` / `low_density_budget = 0.3` config fields in `CompressionConfig`. Per-density summarization deferred to Phase 2 (TODO #2481).

All new config fields default to existing behaviour — no breaking changes.

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --all-targets --workspace -- -D warnings` — clean
- [ ] `cargo nextest run --workspace --lib --bins` — 7419/7419 pass (20 new tests)
- [ ] Live session: `cargo run --features full -- --config .local/config/testing.toml` — verify agent starts, tool outputs stored with metadata payload, Focus strategy config accepted without error