### PR TITLE
fix(agent): defer utility gate System hint injection until after tool results (#2615)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(agent): defer utility gate System hint injection until after tool results are persisted (#2615)
+
 ### Added
 
 - `/skill create <description>` command: generate a SKILL.md via LLM from natural language, preview before save (#2418)

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -971,6 +971,9 @@ impl<C: Channel> Agent<C> {
         // IMP-02: ConfirmationRequired is treated as a failure for dependency propagation —
         // a dependent tool must not proceed when its prerequisite is awaiting user approval.
         let mut failed_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
+        // Utility gate hints (Retrieve/Verify) are deferred so they are pushed after
+        // User(tool_results), maintaining valid OpenAI message ordering (#2615).
+        let mut pending_system_hints: Vec<String> = Vec::new();
 
         for (tier_idx, tier) in tiers.into_iter().enumerate() {
             if cancel.is_cancelled() {
@@ -1120,10 +1123,7 @@ impl<C: Channel> Agent<C> {
                              the call is well-targeted.",
                             tc.name
                         );
-                        self.push_message(zeph_llm::provider::Message::from_legacy(
-                            zeph_llm::provider::Role::System,
-                            &hint,
-                        ));
+                        pending_system_hints.push(hint);
                         let out = skipped_output(
                             tc.name.clone(),
                             format!(
@@ -1147,10 +1147,7 @@ impl<C: Channel> Agent<C> {
                              and that further tool use is necessary.",
                             tc.name
                         );
-                        self.push_message(zeph_llm::provider::Message::from_legacy(
-                            zeph_llm::provider::Role::System,
-                            &hint,
-                        ));
+                        pending_system_hints.push(hint);
                         let out = skipped_output(
                             tc.name.clone(),
                             format!(
@@ -1960,6 +1957,15 @@ impl<C: Channel> Agent<C> {
             (self.last_persisted_message_id, self.msg.messages.last_mut())
         {
             last.metadata.db_id = Some(id);
+        }
+
+        // Flush deferred utility gate hints (Retrieve/Verify). Pushed after User(tool_results)
+        // so the ordering Assistant→User→System is valid for OpenAI (#2615).
+        for hint in pending_system_hints {
+            self.push_message(zeph_llm::provider::Message::from_legacy(
+                zeph_llm::provider::Role::System,
+                &hint,
+            ));
         }
 
         // Deferred self-reflection: user_msg is now in history so the reflection dialogue


### PR DESCRIPTION
## Summary

- `Retrieve` and `Verify` utility gate arms called `push_message(System hint)` during tier execution, before tool results were assembled
- This produced invalid OpenAI API message ordering: `Assistant(tool_use) → System(hint) → User(tool_results)`, causing 400 errors
- Fix: collect hints in a per-batch `pending_system_hints` vec; flush after `push_message(user_msg)`
- Correct ordering: `Assistant(tool_use) → User(tool_results) → System(hint)`

## Test plan

- [ ] `cargo +nightly fmt --check` — pass
- [ ] `cargo clippy --all-features --workspace -- -D warnings` — pass
- [ ] `cargo nextest run --all-features --workspace --lib --bins` — 7814/7814 pass

Closes #2615