### PR TITLE
feat(skills): wire channel allowlist, cap skill-create description, wrap github_token in Secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `/skill create` injection hard block (#2606): if the generated skill contains injection patterns, require `yes force` confirmation instead of plain `yes`. Adds `has_injection_patterns` field to `GeneratedSkill`.
 - `/skill create` dedup against registry (#2609): after generation, embed the new skill and compare cosine similarity against all existing in-memory skill embeddings. If any similarity exceeds 0.85, a warning naming the similar skill is shown in the preview.
 
+### Changed
+- `SkillMiner::github_token` wrapped in `zeph_common::secret::Secret` (zeroize-on-drop, redacted in Debug/Display); `SkillMiner::new` now accepts `impl Into<String>` (#2607)
+- `/skill create`: cap description at 2048 characters; return error "Description too long (max 2048 characters)." for longer inputs (#2608)
+- Channel skill allowlist (`ChannelSkillsConfig::allowed`) now enforced at prompt assembly time: skills not matching the allowlist are excluded from `<available_skills>` and the skill catalog, with a `DEBUG` log per filtered skill. Wired from `[telegram.skills]`, `[discord.skills]`, `[slack.skills]` config sections (#2612)
+
 ### Security
 - Fix trust level fallback in `format_skills_prompt`: replace `unwrap_or(SkillTrustLevel::Trusted)` with `unwrap_or_default()` (yields `Quarantined`) — unknown skills no longer bypass sanitization (#2506)
 - Add `sanitize_skill_text()` in `zeph-skills/src/prompt.rs`: applies XML tag escaping plus injection marker removal (defense-in-depth) to both `description` and `body` for non-Trusted skills (#2506)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9928,6 +9928,7 @@ dependencies = [
  "tracing-subscriber",
  "tracing-test",
  "uuid",
+ "zeph-common",
  "zeph-config",
  "zeph-llm",
  "zeph-memory",

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -38,6 +38,7 @@ pub use channels::{
     A2aServerConfig, ChannelSkillsConfig, DiscordConfig, IbctKeyConfig, McpConfig, McpOAuthConfig,
     McpServerConfig, McpTrustLevel, OAuthTokenStorage, SlackConfig, TelegramConfig,
     ToolDiscoveryConfig, ToolDiscoveryStrategyConfig, ToolPruningConfig, TrustCalibrationConfig,
+    is_skill_allowed,
 };
 pub use defaults::{
     DEFAULT_DEBUG_DIR, DEFAULT_LOG_FILE, DEFAULT_SKILLS_DIR, DEFAULT_SQLITE_PATH,

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -721,6 +721,12 @@ impl<C: Channel> Agent<C> {
     }
 
     #[must_use]
+    pub fn with_channel_skills(mut self, config: zeph_config::ChannelSkillsConfig) -> Self {
+        self.runtime.channel_skills = config;
+        self
+    }
+
+    #[must_use]
     pub fn with_tool_summarization(mut self, enabled: bool) -> Self {
         self.tool_orchestrator.summarize_tool_output_enabled = enabled;
         self

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -1489,12 +1489,31 @@ impl<C: Channel> Agent<C> {
                 .all_meta()
                 .iter()
                 .filter_map(|m| reg.get_skill(&m.name).ok())
+                .filter(|s| {
+                    let allowed =
+                        zeph_config::is_skill_allowed(s.name(), &self.runtime.channel_skills);
+                    if !allowed {
+                        tracing::debug!(skill = s.name(), "skill excluded by channel allowlist");
+                    }
+                    allowed
+                })
                 .collect();
             let active: Vec<Skill> = self
                 .skill_state
                 .active_skill_names
                 .iter()
                 .filter_map(|name| reg.get_skill(name).ok())
+                .filter(|s| {
+                    let allowed =
+                        zeph_config::is_skill_allowed(s.name(), &self.runtime.channel_skills);
+                    if !allowed {
+                        tracing::debug!(
+                            skill = s.name(),
+                            "active skill excluded by channel allowlist"
+                        );
+                    }
+                    allowed
+                })
                 .collect();
             (all, active)
         };

--- a/crates/zeph-core/src/agent/learning.rs
+++ b/crates/zeph-core/src/agent/learning.rs
@@ -739,6 +739,13 @@ impl<C: Channel> Agent<C> {
             return Ok(());
         }
 
+        if description.chars().count() > 2048 {
+            self.channel
+                .send("Description too long (max 2048 characters).")
+                .await?;
+            return Ok(());
+        }
+
         // Determine output directory: generation_output_dir > managed_dir > first skill_path.
         let output_dir = if let Some(ref dir) = self.skill_state.generation_output_dir {
             dir.clone()

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -384,6 +384,7 @@ impl<C: Channel> Agent<C> {
                 adversarial_policy_info: None,
                 spawn_depth: 0,
                 budget_hint_enabled: true,
+                channel_skills: zeph_config::ChannelSkillsConfig::default(),
             },
             mcp: McpState {
                 tools: Vec::new(),

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -209,6 +209,9 @@ pub(crate) struct RuntimeConfig {
     pub(crate) spawn_depth: u32,
     /// Inject `<budget>` XML into the volatile system prompt section (#2267).
     pub(crate) budget_hint_enabled: bool,
+    /// Per-channel skill allowlist. Skills not matching the allowlist are excluded from the
+    /// prompt. An empty `allowed` list means all skills are permitted (default).
+    pub(crate) channel_skills: zeph_config::ChannelSkillsConfig,
 }
 
 /// Groups feedback detection subsystems: correction detector, judge detector, and LLM classifier.

--- a/crates/zeph-core/src/agent/state/tests.rs
+++ b/crates/zeph-core/src/agent/state/tests.rs
@@ -82,6 +82,7 @@ fn make_runtime_config() -> RuntimeConfig {
         adversarial_policy_info: None,
         spawn_depth: 0,
         budget_hint_enabled: true,
+        channel_skills: zeph_config::ChannelSkillsConfig::default(),
     }
 }
 

--- a/crates/zeph-skills/Cargo.toml
+++ b/crates/zeph-skills/Cargo.toml
@@ -38,6 +38,7 @@ toml = { workspace = true, optional = true }
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"], optional = true }
 uuid = { workspace = true, features = ["v5"] }
+zeph-common.workspace = true
 zeph-config.workspace = true
 zeph-llm.workspace = true
 zeph-memory.workspace = true

--- a/crates/zeph-skills/src/miner.rs
+++ b/crates/zeph-skills/src/miner.rs
@@ -17,6 +17,8 @@ use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::{LlmProvider, Message, Role};
 use zeph_memory::cosine_similarity;
 
+use zeph_common::secret::Secret;
+
 use crate::error::SkillError;
 use crate::generator::{GeneratedSkill, SkillGenerator};
 use crate::loader::SkillMeta;
@@ -69,7 +71,7 @@ pub struct MiningConfig {
 pub struct SkillMiner {
     generator: SkillGenerator,
     embed_provider: AnyProvider,
-    github_token: String,
+    github_token: Secret,
     config: MiningConfig,
     http: reqwest::Client,
 }
@@ -83,7 +85,7 @@ impl SkillMiner {
     pub fn new(
         generation_provider: AnyProvider,
         embed_provider: AnyProvider,
-        github_token: String,
+        github_token: impl Into<String>,
         config: MiningConfig,
     ) -> Result<Self, SkillError> {
         let http = reqwest::Client::builder()
@@ -97,7 +99,7 @@ impl SkillMiner {
         Ok(Self {
             generator,
             embed_provider,
-            github_token,
+            github_token: Secret::new(github_token),
             config,
             http,
         })
@@ -248,7 +250,10 @@ impl SkillMiner {
         let resp = self
             .http
             .get(&url)
-            .header("Authorization", format!("Bearer {}", self.github_token))
+            .header(
+                "Authorization",
+                format!("Bearer {}", self.github_token.expose()),
+            )
             .header("Accept", "application/vnd.github.v3+json")
             .send()
             .await
@@ -335,7 +340,10 @@ impl SkillMiner {
         let resp = self
             .http
             .get(&url)
-            .header("Authorization", format!("Bearer {}", self.github_token))
+            .header(
+                "Authorization",
+                format!("Bearer {}", self.github_token.expose()),
+            )
             .header("Accept", "application/vnd.github.raw")
             .send()
             .await
@@ -435,7 +443,7 @@ mod tests {
             embed_provider: zeph_llm::any::AnyProvider::Mock(
                 zeph_llm::mock::MockProvider::default(),
             ),
-            github_token: String::new(),
+            github_token: Secret::new(String::new()),
             config,
             http: reqwest::Client::new(),
         };
@@ -480,7 +488,7 @@ mod tests {
         SkillMiner {
             generator: SkillGenerator::new(mock.clone(), PathBuf::from(output_dir)),
             embed_provider: mock,
-            github_token: String::new(),
+            github_token: Secret::new(String::new()),
             config,
             http: reqwest::Client::new(),
         }
@@ -569,7 +577,7 @@ mod tests {
         let miner = SkillMiner {
             generator: SkillGenerator::new(mock.clone(), dir.path().to_path_buf()),
             embed_provider: mock,
-            github_token: String::new(),
+            github_token: Secret::new(String::new()),
             config,
             http: reqwest::Client::new(),
         };
@@ -632,7 +640,7 @@ mod tests {
             embed_provider: zeph_llm::any::AnyProvider::Mock(
                 zeph_llm::mock::MockProvider::default(),
             ),
-            github_token: String::new(),
+            github_token: Secret::new(String::new()),
             config,
             http: reqwest::Client::new(),
         };

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -724,6 +724,63 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     }
     .to_owned();
 
+    // Derive per-channel skill allowlist from the matching config section.
+    // CLI/TUI channels use the default (allow-all) allowlist.
+    #[cfg(feature = "tui")]
+    let channel_skills_config: zeph_core::config::ChannelSkillsConfig = match &channel {
+        AppChannel::Standard(AnyChannel::Telegram(_)) => app
+            .config()
+            .telegram
+            .as_ref()
+            .map_or_else(zeph_core::config::ChannelSkillsConfig::default, |c| {
+                c.skills.clone()
+            }),
+        #[cfg(feature = "discord")]
+        AppChannel::Standard(AnyChannel::Discord(_)) => app
+            .config()
+            .discord
+            .as_ref()
+            .map_or_else(zeph_core::config::ChannelSkillsConfig::default, |c| {
+                c.skills.clone()
+            }),
+        #[cfg(feature = "slack")]
+        AppChannel::Standard(AnyChannel::Slack(_)) => app
+            .config()
+            .slack
+            .as_ref()
+            .map_or_else(zeph_core::config::ChannelSkillsConfig::default, |c| {
+                c.skills.clone()
+            }),
+        _ => zeph_core::config::ChannelSkillsConfig::default(),
+    };
+    #[cfg(not(feature = "tui"))]
+    let channel_skills_config: zeph_core::config::ChannelSkillsConfig = match &channel {
+        AnyChannel::Telegram(_) => app
+            .config()
+            .telegram
+            .as_ref()
+            .map_or_else(zeph_core::config::ChannelSkillsConfig::default, |c| {
+                c.skills.clone()
+            }),
+        #[cfg(feature = "discord")]
+        AnyChannel::Discord(_) => app
+            .config()
+            .discord
+            .as_ref()
+            .map_or_else(zeph_core::config::ChannelSkillsConfig::default, |c| {
+                c.skills.clone()
+            }),
+        #[cfg(feature = "slack")]
+        AnyChannel::Slack(_) => app
+            .config()
+            .slack
+            .as_ref()
+            .map_or_else(zeph_core::config::ChannelSkillsConfig::default, |c| {
+                c.skills.clone()
+            }),
+        _ => zeph_core::config::ChannelSkillsConfig::default(),
+    };
+
     let conversation_id = match memory.sqlite().latest_conversation_id().await? {
         Some(id) => id,
         None => memory.sqlite().create_conversation().await?,
@@ -1372,6 +1429,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         agent
     };
     let agent = agent.with_hooks_config(&config.hooks);
+    let agent = agent.with_channel_skills(channel_skills_config);
     let agent = agent.with_learning(config.skills.learning.clone());
     let judge_provider = app.build_judge_provider();
     let agent = if let Some(jp) = judge_provider {


### PR DESCRIPTION
## Summary

- **#2612** — `ChannelSkillsConfig.allowed` is now enforced at prompt assembly time. Skills not matching the allowlist are excluded from `<available_skills>` and the skill catalog before the LLM sees them. A `tracing::debug!` log is emitted per filtered skill. `RuntimeConfig` gains `channel_skills`; `AgentBuilder` gains `with_channel_skills()`. Populated at startup from `[telegram/discord/slack.skills]` config sections.
- **#2608** — `handle_skill_create()` rejects descriptions longer than 2048 characters before any LLM call, returning `"Description too long (max 2048 characters)."`.
- **#2607** — `SkillMiner.github_token` changed from `String` to `zeph_common::secret::Secret` (zeroize-on-drop, redacted in Debug/Display). `SkillMiner::new` now accepts `impl Into<String>`. Token is exposed only at HTTP `Authorization` header construction.

## Test plan

- [ ] `cargo +nightly fmt --check` — pass
- [ ] `cargo clippy --features full --workspace -- -D warnings` — pass
- [ ] `cargo nextest run --features full --workspace --lib --bins` — 7814/7814 pass
- [ ] Live session: `/skill create <2049-char string>` → "Description too long (max 2048 characters)."
- [ ] Live session: CLI mode — all skills visible (default allow-all)
- [ ] Config: `[telegram.skills] allowed = ["web-*"]` — only web-prefixed skills in prompt (requires Telegram token)
- [ ] `grep -i "Bearer " session.log` — no raw token in debug log