### PR TITLE
fix(skills): RL cold start, injection hard block, /skill create dedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - feat(memory): SleepGate forgetting sweep (#2397) — background loop that decays importance scores (synaptic downscaling), restores recently-accessed memories (selective replay), and prunes memories below `forgetting_floor`. Configurable via `[memory.forgetting]`. Disabled by default.
 - feat(memory): performance-floor compression ratio predictor (#2460) — lightweight linear regression model that selects the most aggressive compression ratio keeping predicted probe quality above `hard_fail_threshold`. Training data collected from live compaction probes. Configurable via `[memory.compression.predictor]`. Disabled by default.
 
+### Fixed
+
+- SkillOrchestra RL routing cold start (#2610): when `rl_routing_enabled = true` and no persisted weights exist, initialize a fresh `RoutingHead` instead of skipping RL entirely. Add `skills.rl_embed_dim` config field (default 1536). Add dimension mismatch guard in assembly to skip RL with a warning when embed dim does not match head dim.
+- `/skill create` injection hard block (#2606): if the generated skill contains injection patterns, require `yes force` confirmation instead of plain `yes`. Adds `has_injection_patterns` field to `GeneratedSkill`.
+- `/skill create` dedup against registry (#2609): after generation, embed the new skill and compare cosine similarity against all existing in-memory skill embeddings. If any similarity exceeds 0.85, a warning naming the similar skill is shown in the preview.
+
 ### Security
 - Fix trust level fallback in `format_skills_prompt`: replace `unwrap_or(SkillTrustLevel::Trusted)` with `unwrap_or_default()` (yields `Quarantined`) — unknown skills no longer bypass sanitization (#2506)
 - Add `sanitize_skill_text()` in `zeph-skills/src/prompt.rs`: applies XML tag escaping plus injection marker removal (defense-in-depth) to both `description` and `body` for non-Trusted skills (#2506)

--- a/crates/zeph-config/src/features.rs
+++ b/crates/zeph-config/src/features.rs
@@ -175,6 +175,11 @@ pub struct SkillsConfig {
     /// Skip RL blending for the first N updates (cold-start warmup).
     #[serde(default = "default_rl_warmup_updates")]
     pub rl_warmup_updates: u32,
+    /// Embedding dimension for the RL routing head.
+    /// Must match the output dimension of the configured embedding provider.
+    /// Defaults to `None` → 1536 (`text-embedding-3-small` output dimension).
+    #[serde(default)]
+    pub rl_embed_dim: Option<usize>,
 
     // --- NL skill generation ---
     /// Provider name for `/skill create` NL generation. Empty = primary provider.

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -171,6 +171,7 @@ impl Default for Config {
                 rl_weight: 0.3,
                 rl_persist_interval: 10,
                 rl_warmup_updates: 50,
+                rl_embed_dim: None,
                 generation_provider: crate::providers::ProviderName::default(),
                 generation_output_dir: None,
                 mining: crate::features::SkillMiningConfig::default(),

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -1336,6 +1336,17 @@ impl<C: Channel> Agent<C> {
                 // SkillOrchestra: RL routing head re-rank (past warmup only).
                 if let Some(rl_head) = &self.skill_state.rl_head
                     && let Ok(query_embed) = self.embedding_provider.embed(query).await
+                    && {
+                        let ok = query_embed.len() == rl_head.embed_dim();
+                        if !ok {
+                            tracing::warn!(
+                                query_dim = query_embed.len(),
+                                head_dim = rl_head.embed_dim(),
+                                "rl_head: embed dim mismatch, skipping RL re-rank this turn"
+                            );
+                        }
+                        ok
+                    }
                 {
                     let rl_weight = self.skill_state.rl_weight;
                     let warmup = self.skill_state.rl_warmup_updates;

--- a/crates/zeph-core/src/agent/learning.rs
+++ b/crates/zeph-core/src/agent/learning.rs
@@ -783,7 +783,7 @@ impl<C: Channel> Agent<C> {
             allowed_tools: Vec::new(),
         };
 
-        let generated = match generator.generate(request).await {
+        let mut generated = match generator.generate(request).await {
             Ok(g) => g,
             Err(e) => {
                 self.channel
@@ -792,6 +792,31 @@ impl<C: Channel> Agent<C> {
                 return Ok(());
             }
         };
+
+        // Dedup check: compare against existing registry embeddings.
+        if let Some(ref matcher) = self.skill_state.matcher {
+            let skill_text = format!("{} {}", generated.meta.description, generated.content);
+            if let Ok(new_embed) = self.embedding_provider.embed(&skill_text).await {
+                let registry = self.skill_state.registry.read().unwrap();
+                let all_meta = registry.all_meta();
+                let mut best_sim = 0.0_f32;
+                let mut best_name = String::new();
+                for (idx, meta) in all_meta.iter().enumerate() {
+                    if let Some(existing_emb) = matcher.skill_embedding(idx) {
+                        let sim = zeph_common::math::cosine_similarity(&new_embed, existing_emb);
+                        if sim > best_sim {
+                            best_sim = sim;
+                            best_name.clone_from(&meta.name);
+                        }
+                    }
+                }
+                if best_sim > 0.85 {
+                    generated.warnings.push(format!(
+                        "Similar skill exists: **{best_name}** (similarity: {best_sim:.2}). Consider using the existing skill instead."
+                    ));
+                }
+            }
+        }
 
         // Show preview.
         let mut preview = format!(
@@ -806,13 +831,24 @@ impl<C: Channel> Agent<C> {
                 preview.push_str(w);
             }
         }
-        preview.push_str("\n\nType **yes** to save, anything else to discard.");
+        let confirm_text = if generated.has_injection_patterns {
+            "\n\nInjection patterns detected. Type **yes force** to save anyway, anything else to discard."
+        } else {
+            "\n\nType **yes** to save, anything else to discard."
+        };
+        preview.push_str(confirm_text);
         self.channel.send(&preview).await?;
 
         // Wait for confirmation.
         let reply = self.channel.recv().await;
-        let confirmed =
-            matches!(reply, Ok(Some(ref msg)) if msg.text.trim().eq_ignore_ascii_case("yes"));
+        let confirmed = matches!(reply, Ok(Some(ref msg)) if {
+            let trimmed = msg.text.trim();
+            if generated.has_injection_patterns {
+                trimmed.eq_ignore_ascii_case("yes force")
+            } else {
+                trimmed.eq_ignore_ascii_case("yes")
+            }
+        });
 
         if !confirmed {
             self.channel.send("Skill discarded.").await?;

--- a/crates/zeph-skills/src/generator.rs
+++ b/crates/zeph-skills/src/generator.rs
@@ -82,6 +82,8 @@ pub struct GeneratedSkill {
     pub meta: SkillMeta,
     /// Non-fatal validation warnings (e.g. injection pattern matches).
     pub warnings: Vec<String>,
+    /// True when the scanner detected injection patterns in the generated content.
+    pub has_injection_patterns: bool,
 }
 
 /// Orchestrates the NL-to-SKILL.md generation pipeline.
@@ -307,11 +309,13 @@ fn parse_and_validate(content: &str) -> Result<GeneratedSkill, SkillError> {
         )));
     }
 
+    let has_injection_patterns = fm_scan.has_matches() || body_scan.has_matches();
     Ok(GeneratedSkill {
         name: meta.name.clone(),
         content: content.to_string(),
         meta,
         warnings,
+        has_injection_patterns,
     })
 }
 
@@ -436,6 +440,7 @@ mod tests {
             content: content.clone(),
             meta,
             warnings: vec![],
+            has_injection_patterns: false,
         };
         let path = generator.approve_and_save(&skill).await.unwrap();
         assert!(path.exists());
@@ -462,6 +467,7 @@ mod tests {
             content,
             meta,
             warnings: vec![],
+            has_injection_patterns: false,
         };
         let err = generator.approve_and_save(&skill).await.unwrap_err();
         assert!(matches!(err, SkillError::AlreadyExists(_)));

--- a/crates/zeph-skills/src/miner.rs
+++ b/crates/zeph-skills/src/miner.rs
@@ -496,6 +496,7 @@ mod tests {
             content: content.into(),
             meta,
             warnings: vec![],
+            has_injection_patterns: false,
         }
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -416,11 +416,15 @@ pub(crate) async fn run_daemon(
 
     // SkillOrchestra: load persisted RL routing head weights if enabled.
     let agent = if config.skills.rl_routing_enabled {
-        if let Some(head) = crate::runner::load_rl_head(&memory).await {
-            agent.with_rl_head(head)
-        } else {
-            agent
-        }
+        let dim = config.skills.rl_embed_dim.unwrap_or(1536);
+        let head = crate::runner::load_rl_head(&memory)
+            .await
+            .unwrap_or_else(|| {
+                // Cold start: no persisted weights yet, initialize a fresh head.
+                tracing::info!(dim, "rl_head: cold start, initializing fresh routing head");
+                zeph_skills::rl_head::RoutingHead::new(dim)
+            });
+        agent.with_rl_head(head)
     } else {
         agent
     };

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1149,11 +1149,14 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
 
     // SkillOrchestra: load persisted RL routing head weights if enabled.
     let agent = if config.skills.rl_routing_enabled {
-        if let Some(head) = load_rl_head(&memory).await {
-            agent.with_rl_head(head)
-        } else {
-            agent
-        }
+        let dim = config.skills.rl_embed_dim.unwrap_or(1536);
+        let head = load_rl_head(&memory).await.unwrap_or_else(|| {
+            // Cold start: no persisted weights yet, initialize a fresh head.
+            // Dimension must match the configured embedding provider output.
+            tracing::info!(dim, "rl_head: cold start, initializing fresh routing head");
+            zeph_skills::rl_head::RoutingHead::new(dim)
+        });
+        agent.with_rl_head(head)
     } else {
         agent
     };


### PR DESCRIPTION
## Summary

- **#2610** — SkillOrchestra RL routing cold start: when `rl_routing_enabled = true` and no persisted weights exist, initialize a fresh `RoutingHead` instead of silently skipping RL. Adds `skills.rl_embed_dim` config field (default 1536). Adds embed dim mismatch guard in assembly.
- **#2606** — `/skill create` injection hard block: when generated skill body contains injection patterns, require `yes force` confirmation instead of plain `yes`. Adds `has_injection_patterns: bool` to `GeneratedSkill`.
- **#2609** — `/skill create` dedup: after generation, embed the new skill and compare cosine similarity against all existing in-memory registry embeddings; warn if similarity > 0.85.

## Known limitations

- Qdrant backend: `skill_embedding()` returns `None`, so dedup silently no-ops for Qdrant users — by design (out of scope pre-v1.0.0)
- `registry.read().unwrap()` blocking lock in async context — acceptable (no `.await` held, low contention)

## Test plan

- [ ] All 7814 unit tests pass (verified locally)
- [ ] Live session: enable `rl_routing_enabled = true` on fresh DB, verify RL head initializes and training begins
- [ ] Live session: run `/skill create` with injected content, verify `yes force` is required
- [ ] Live session: run `/skill create` with description similar to existing skill, verify dedup warning appears

Closes #2610, #2606, #2609