### PR TITLE
refactor: consolidate duplicated utilities into zeph-common

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - fix(agent): defer utility gate System hint injection until after tool results are persisted (#2615)
+- refactor(dry): remove duplicate `cosine_similarity` in `zeph-mcp` — use canonical `zeph-common::math::cosine_similarity`
+- refactor(dry): eliminate `zeph-memory/src/math.rs` single-line re-export module — direct imports from `zeph_common::math`
+- refactor(dry): consolidate `normalize_path` in `zeph-tools` — `policy.rs` now delegates to `file::normalize_path`
+- refactor(dry): add `strip_control_chars_preserve_whitespace` to `zeph-common::sanitize`; remove duplicate implementations in `zeph-sanitizer` and `zeph-gateway`
+- refactor(dry): add `estimate_tokens` to `zeph-common::text`; replace all inline `chars().count() / 4` expressions in `zeph-llm` and `zeph-memory`
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9702,6 +9702,7 @@ dependencies = [
  "tower 0.5.3",
  "tower-http",
  "tracing",
+ "zeph-common",
 ]
 
 [[package]]

--- a/crates/zeph-common/src/sanitize.rs
+++ b/crates/zeph-common/src/sanitize.rs
@@ -18,6 +18,21 @@ pub fn strip_control_chars(s: &str) -> String {
         .collect()
 }
 
+/// Strip ASCII control characters while preserving common whitespace (`\t`, `\n`, `\r`).
+///
+/// Also strips Unicode `BiDi` override codepoints (U+202A–U+202E, U+2066–U+2069).
+/// Use this variant when the input may contain intentional newlines or tabs that
+/// should be kept (e.g., multi-line tool output, webhook payloads).
+#[must_use]
+pub fn strip_control_chars_preserve_whitespace(s: &str) -> String {
+    s.chars()
+        .filter(|&c| {
+            (!c.is_control() || c == '\t' || c == '\n' || c == '\r')
+                && !matches!(c as u32, 0x202A..=0x202E | 0x2066..=0x2069)
+        })
+        .collect()
+}
+
 /// Remove null bytes (`\0`) from `s`.
 #[must_use]
 pub fn strip_null_bytes(s: &str) -> String {

--- a/crates/zeph-common/src/text.rs
+++ b/crates/zeph-common/src/text.rs
@@ -42,6 +42,16 @@ pub fn truncate_to_bytes_ref(s: &str, max_bytes: usize) -> &str {
     &s[..end]
 }
 
+/// Rough token count estimate: 1 token ≈ 4 Unicode scalar values.
+///
+/// Uses `chars().count()` rather than byte length to avoid overestimating for
+/// non-ASCII content. This is the canonical fallback used when a BPE tokenizer
+/// is unavailable or the input exceeds the tokenizer's size limit.
+#[must_use]
+pub fn estimate_tokens(text: &str) -> usize {
+    text.chars().count() / 4
+}
+
 /// Borrow a prefix of `s` that is at most `max_chars` Unicode scalar values long.
 ///
 /// Returns a subslice of `s`. No ellipsis is appended.

--- a/crates/zeph-gateway/Cargo.toml
+++ b/crates/zeph-gateway/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { workspace = true, features = ["net", "sync", "time"] }
 tower.workspace = true
 tower-http = { workspace = true, features = ["limit", "trace"] }
 tracing.workspace = true
+zeph-common.workspace = true
 # See https://github.com/bug-ops/zeph (workspace dependencies only contain versions)
 
 [dev-dependencies]

--- a/crates/zeph-gateway/src/handlers.rs
+++ b/crates/zeph-gateway/src/handlers.rs
@@ -15,12 +15,6 @@ pub(crate) struct WebhookPayload {
     pub body: String,
 }
 
-pub(crate) fn sanitize_control_chars(s: &str) -> String {
-    s.chars()
-        .filter(|c| !c.is_ascii_control() || *c == '\n')
-        .collect()
-}
-
 impl WebhookPayload {
     pub(crate) fn validate(&self) -> Result<(), &'static str> {
         if self.sender.len() > 256 {
@@ -54,8 +48,8 @@ pub(crate) async fn webhook_handler(
     if let Err(e) = payload.validate() {
         return (StatusCode::UNPROCESSABLE_ENTITY, e).into_response();
     }
-    let sender = sanitize_control_chars(&payload.sender);
-    let channel = sanitize_control_chars(&payload.channel);
+    let sender = zeph_common::sanitize::strip_control_chars_preserve_whitespace(&payload.sender);
+    let channel = zeph_common::sanitize::strip_control_chars_preserve_whitespace(&payload.channel);
     let msg = format!("[{}@{}] {}", sender, channel, payload.body);
     match state.webhook_tx.send(msg).await {
         Ok(()) => Json(WebhookResponse { status: "accepted" }).into_response(),
@@ -136,14 +130,14 @@ mod tests {
     #[test]
     fn sanitize_strips_control_chars_keeps_newline() {
         let input = "hel\x01lo\x7f\nworld";
-        let result = sanitize_control_chars(input);
+        let result = zeph_common::sanitize::strip_control_chars_preserve_whitespace(input);
         assert_eq!(result, "hello\nworld");
     }
 
     #[test]
     fn sanitize_strips_null_byte() {
         let input = "he\x00llo";
-        let result = sanitize_control_chars(input);
+        let result = zeph_common::sanitize::strip_control_chars_preserve_whitespace(input);
         assert_eq!(result, "hello");
     }
 

--- a/crates/zeph-llm/src/claude/cache.rs
+++ b/crates/zeph-llm/src/claude/cache.rs
@@ -108,7 +108,7 @@ pub(super) fn split_system_into_blocks(system: &str, model: &str) -> Vec<SystemC
         // last explicit cacheable block). When no markers exist, `remaining` equals the
         // full system prompt — apply the same min-token threshold as the fallback path.
         let had_markers = remaining.len() < cacheable_part.trim().len();
-        let estimated_tokens = remaining.chars().count() / 4;
+        let estimated_tokens = zeph_common::text::estimate_tokens(remaining);
         let cc = if had_markers || estimated_tokens >= min_tokens {
             Some(CacheControl {
                 cache_type: CacheType::Ephemeral,

--- a/crates/zeph-llm/src/router/mod.rs
+++ b/crates/zeph-llm/src/router/mod.rs
@@ -1392,13 +1392,9 @@ impl RouterProvider {
                 Ok(response) => {
                     let latency = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
 
-                    // Estimate token cost: rough approximation (1 token ≈ 4 Unicode chars).
-                    // Use chars().count() rather than len() (bytes) to avoid overestimating
-                    // for non-ASCII content (PERF-CASCADE-06).
-                    // Minimum 1 token for any non-empty response to ensure budget accounting
-                    // is not defeated by very short outputs.
                     let estimated_tokens =
-                        u32::try_from((response.chars().count() / 4).max(1)).unwrap_or(u32::MAX);
+                        u32::try_from(zeph_common::text::estimate_tokens(&response).max(1))
+                            .unwrap_or(u32::MAX);
                     tokens_used = tokens_used.saturating_add(estimated_tokens);
 
                     let verdict = Self::evaluate_quality(
@@ -1577,7 +1573,8 @@ impl RouterProvider {
                 }
                 Ok(text) => {
                     let estimated_tokens =
-                        u32::try_from((text.chars().count() / 4).max(1)).unwrap_or(u32::MAX);
+                        u32::try_from(zeph_common::text::estimate_tokens(&text).max(1))
+                            .unwrap_or(u32::MAX);
                     tokens_used = tokens_used.saturating_add(estimated_tokens);
 
                     let verdict = Self::evaluate_quality(

--- a/crates/zeph-mcp/src/semantic_index.rs
+++ b/crates/zeph-mcp/src/semantic_index.rs
@@ -16,6 +16,7 @@
 //! Callers in `zeph-core` convert between the two.
 
 use futures::stream::{self, StreamExt};
+use zeph_common::math::cosine_similarity;
 
 use crate::tool::McpTool;
 
@@ -286,28 +287,6 @@ impl Default for DiscoveryParams {
     }
 }
 
-// ── Cosine similarity ─────────────────────────────────────────────────────────
-
-/// Compute cosine similarity between two equal-length vectors.
-///
-/// Returns 0.0 if either vector has zero magnitude (avoids NaN).
-fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
-    debug_assert_eq!(a.len(), b.len(), "cosine_similarity: dimension mismatch");
-
-    let mut dot = 0.0f32;
-    let mut mag_a = 0.0f32;
-    let mut mag_b = 0.0f32;
-
-    for (x, y) in a.iter().zip(b.iter()) {
-        dot += x * y;
-        mag_a += x * x;
-        mag_b += y * y;
-    }
-
-    let denom = mag_a.sqrt() * mag_b.sqrt();
-    if denom == 0.0 { 0.0 } else { dot / denom }
-}
-
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -461,29 +440,6 @@ mod tests {
         // Query with 2-dim vector — dimension mismatch, tool must be skipped.
         let result = idx.select(&[1.0, 0.0], 10, 0.0, &[]);
         assert!(result.is_empty(), "dimension mismatch must skip entry");
-    }
-
-    #[test]
-    fn cosine_similarity_identical_vectors() {
-        let v = vec![1.0, 2.0, 3.0];
-        let s = cosine_similarity(&v, &v);
-        assert!((s - 1.0).abs() < 1e-5);
-    }
-
-    #[test]
-    fn cosine_similarity_orthogonal() {
-        let a = vec![1.0, 0.0];
-        let b = vec![0.0, 1.0];
-        let s = cosine_similarity(&a, &b);
-        assert!(s.abs() < 1e-5);
-    }
-
-    #[test]
-    fn cosine_similarity_zero_vector_returns_zero() {
-        let a = vec![0.0, 0.0];
-        let b = vec![1.0, 2.0];
-        let s = cosine_similarity(&a, &b);
-        assert!(s.abs() < f32::EPSILON);
     }
 
     // top_k larger than the number of available tools: must return all tools, not panic.

--- a/crates/zeph-memory/src/admission.rs
+++ b/crates/zeph-memory/src/admission.rs
@@ -13,7 +13,7 @@ use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::LlmProvider as _;
 
 use crate::embedding_store::EmbeddingStore;
-use crate::math::cosine_similarity;
+use zeph_common::math::cosine_similarity;
 
 /// Per-factor scores for the admission decision.
 #[derive(Debug, Clone, serde::Serialize)]

--- a/crates/zeph-memory/src/consolidation.rs
+++ b/crates/zeph-memory/src/consolidation.rs
@@ -30,8 +30,8 @@ use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::LlmProvider as _;
 
 use crate::error::MemoryError;
-use crate::math::cosine_similarity;
 use crate::store::SqliteStore;
+use zeph_common::math::cosine_similarity;
 
 /// Topology operation proposed by the LLM for memory consolidation.
 ///

--- a/crates/zeph-memory/src/db_vector_store.rs
+++ b/crates/zeph-memory/src/db_vector_store.rs
@@ -30,7 +30,7 @@ impl DbVectorStore {
     }
 }
 
-use crate::math::cosine_similarity;
+use zeph_common::math::cosine_similarity;
 
 fn matches_filter(payload: &HashMap<String, serde_json::Value>, filter: &VectorFilter) -> bool {
     for cond in &filter.must {

--- a/crates/zeph-memory/src/in_memory_store.rs
+++ b/crates/zeph-memory/src/in_memory_store.rs
@@ -44,7 +44,7 @@ impl std::fmt::Debug for InMemoryVectorStore {
     }
 }
 
-use crate::math::cosine_similarity;
+use zeph_common::math::cosine_similarity;
 
 fn matches_filter(payload: &HashMap<String, serde_json::Value>, filter: &VectorFilter) -> bool {
     for cond in &filter.must {

--- a/crates/zeph-memory/src/lib.rs
+++ b/crates/zeph-memory/src/lib.rs
@@ -22,7 +22,6 @@ pub mod error;
 pub mod eviction;
 pub mod graph;
 pub mod in_memory_store;
-pub mod math;
 pub mod qdrant_ops;
 pub mod response_cache;
 pub mod router;
@@ -72,7 +71,6 @@ pub use graph::{
     BeliefRevisionConfig, Community, Edge, EdgeType, Entity, EntityType, GraphFact, GraphStore,
     RpeRouter, RpeSignal, extract_candidate_entities,
 };
-pub use math::cosine_similarity;
 pub use qdrant_ops::QdrantOps;
 pub use response_cache::ResponseCache;
 pub use router::{

--- a/crates/zeph-memory/src/math.rs
+++ b/crates/zeph-memory/src/math.rs
@@ -1,8 +1,0 @@
-// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
-// SPDX-License-Identifier: MIT OR Apache-2.0
-
-//! Mathematical utilities for vector operations.
-//!
-//! Re-exports from `zeph-common::math` — the canonical implementation lives there.
-
-pub use zeph_common::math::cosine_similarity;

--- a/crates/zeph-memory/src/response_cache.rs
+++ b/crates/zeph-memory/src/response_cache.rs
@@ -102,7 +102,7 @@ impl ResponseCache {
                 .chunks_exact(4)
                 .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
                 .collect();
-            let score = crate::math::cosine_similarity(embedding, &stored);
+            let score = zeph_common::math::cosine_similarity(embedding, &stored);
             tracing::debug!(
                 score,
                 threshold = similarity_threshold,

--- a/crates/zeph-memory/src/scenes.rs
+++ b/crates/zeph-memory/src/scenes.rs
@@ -15,9 +15,9 @@ use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::LlmProvider as _;
 
 use crate::error::MemoryError;
-use crate::math::cosine_similarity;
 use crate::store::SqliteStore;
 use crate::types::{MemSceneId, MessageId};
+use zeph_common::math::cosine_similarity;
 
 /// A `MemScene` groups semantically related semantic-tier messages with a stable entity profile.
 #[derive(Debug, Clone)]

--- a/crates/zeph-memory/src/semantic/algorithms.rs
+++ b/crates/zeph-memory/src/semantic/algorithms.rs
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::math::cosine_similarity;
 use crate::types::MessageId;
+use zeph_common::math::cosine_similarity;
 
 #[allow(clippy::implicit_hasher)]
 pub fn apply_temporal_decay(

--- a/crates/zeph-memory/src/tiers.rs
+++ b/crates/zeph-memory/src/tiers.rs
@@ -23,10 +23,10 @@ use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::LlmProvider as _;
 
 use crate::error::MemoryError;
-use crate::math::cosine_similarity;
 use crate::store::SqliteStore;
 use crate::store::messages::PromotionCandidate;
 use crate::types::ConversationId;
+use zeph_common::math::cosine_similarity;
 
 /// Minimum cosine similarity between the merged result and at least one original for the
 /// merge to be accepted. Prevents the LLM from producing semantically unrelated output.

--- a/crates/zeph-memory/src/token_counter.rs
+++ b/crates/zeph-memory/src/token_counter.rs
@@ -70,7 +70,7 @@ impl TokenCounter {
         }
 
         if text.len() > MAX_INPUT_LEN {
-            return text.chars().count() / 4;
+            return zeph_common::text::estimate_tokens(text);
         }
 
         let key = hash_text(text);
@@ -81,7 +81,7 @@ impl TokenCounter {
 
         let count = match &self.bpe {
             Some(bpe) => bpe.encode_with_special_tokens(text).len(),
-            None => text.chars().count() / 4,
+            None => zeph_common::text::estimate_tokens(text),
         };
 
         // TOCTOU between len() check and insert is benign: worst case we evict
@@ -433,7 +433,7 @@ mod tests {
         let large = "a".repeat(MAX_INPUT_LEN + 1);
         let result = counter.count_tokens(&large);
         // chars/4 fallback: (65537 chars) / 4
-        assert_eq!(result, large.chars().count() / 4);
+        assert_eq!(result, zeph_common::text::estimate_tokens(&large));
         // Must not be cached
         assert!(counter.cache.is_empty());
     }
@@ -443,7 +443,7 @@ mod tests {
         let counter = TokenCounter::new();
         let text = "Привет мир! 你好世界! こんにちは! 🌍";
         let bpe_count = counter.count_tokens(text);
-        let fallback_count = text.chars().count() / 4;
+        let fallback_count = zeph_common::text::estimate_tokens(text);
         // BPE should return > 0
         assert!(bpe_count > 0, "BPE count must be positive");
         // BPE result should differ from naive chars/4 for multi-byte text

--- a/crates/zeph-orchestration/src/plan_cache.rs
+++ b/crates/zeph-orchestration/src/plan_cache.rs
@@ -284,7 +284,7 @@ impl PlanCache {
 
         for (id, template_json, blob) in rows {
             if let Some(stored) = blob_to_embedding(&blob) {
-                let score = zeph_memory::cosine_similarity(goal_embedding, &stored);
+                let score = zeph_common::math::cosine_similarity(goal_embedding, &stored);
                 if score > best_score {
                     best_score = score;
                     best_id = Some(id);

--- a/crates/zeph-sanitizer/src/lib.rs
+++ b/crates/zeph-sanitizer/src/lib.rs
@@ -588,7 +588,7 @@ impl ContentSanitizer {
         let (truncated, was_truncated) = Self::truncate(content, self.max_content_size);
 
         // Step 2: strip control characters
-        let cleaned = Self::strip_control_chars(truncated);
+        let cleaned = zeph_common::sanitize::strip_control_chars_preserve_whitespace(truncated);
 
         // Step 3: detect injection patterns (advisory only — never blocks content).
         // For memory retrieval sub-sources that carry ConversationHistory or LlmSummary
@@ -639,15 +639,6 @@ impl ContentSanitizer {
         // floor_char_boundary is stable since Rust 1.82
         let boundary = content.floor_char_boundary(max_bytes);
         (&content[..boundary], true)
-    }
-
-    fn strip_control_chars(s: &str) -> String {
-        s.chars()
-            .filter(|&c| {
-                // Allow tab (0x09), LF (0x0A), CR (0x0D); strip everything else in 0x00-0x1F
-                !c.is_control() || c == '\t' || c == '\n' || c == '\r'
-            })
-            .collect()
     }
 
     pub(crate) fn detect_injections(content: &str) -> Vec<InjectionFlag> {

--- a/crates/zeph-skills/src/matcher.rs
+++ b/crates/zeph-skills/src/matcher.rs
@@ -487,7 +487,7 @@ impl SkillMatcherBackend {
     }
 }
 
-pub use zeph_memory::cosine_similarity;
+pub use zeph_common::math::cosine_similarity;
 
 #[cfg(test)]
 mod tests {

--- a/crates/zeph-skills/src/miner.rs
+++ b/crates/zeph-skills/src/miner.rs
@@ -13,9 +13,9 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
+use zeph_common::math::cosine_similarity;
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::{LlmProvider, Message, Role};
-use zeph_memory::cosine_similarity;
 
 use zeph_common::secret::Secret;
 

--- a/crates/zeph-tools/src/file.rs
+++ b/crates/zeph-tools/src/file.rs
@@ -657,7 +657,7 @@ impl ToolExecutor for FileExecutor {
 /// Lexically normalize a path by collapsing `.` and `..` components without
 /// any filesystem access. This prevents `..` components from bypassing the
 /// sandbox check inside `validate_path`.
-fn normalize_path(path: &Path) -> PathBuf {
+pub(crate) fn normalize_path(path: &Path) -> PathBuf {
     use std::path::Component;
     // On Windows, paths may have a drive prefix (e.g. `D:` or `\\?\D:`).
     // We track it separately so that `RootDir` (the `\` after the drive letter)

--- a/crates/zeph-tools/src/policy.rs
+++ b/crates/zeph-tools/src/policy.rs
@@ -6,7 +6,7 @@
 //! Evaluates TOML-based access-control rules before any tool executes.
 //! Deny-wins semantics: deny rules checked first, then allow rules, then `default_effect`.
 
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -153,7 +153,9 @@ impl CompiledRule {
         if !self.path_matchers.is_empty() {
             let paths = extract_paths(params);
             let any_path_matches = paths.iter().any(|p| {
-                let normalized = normalize_path(p);
+                let normalized = crate::file::normalize_path(Path::new(p))
+                    .to_string_lossy()
+                    .into_owned();
                 self.path_matchers
                     .iter()
                     .any(|pat| pat.matches(&normalized))
@@ -431,50 +433,6 @@ fn extract_paths(params: &serde_json::Map<String, serde_json::Value>) -> Vec<Str
     }
 
     paths
-}
-
-/// Lexically normalize a path by resolving `.` and `..` components
-/// without any filesystem I/O (no `canonicalize`).
-///
-/// This addresses CRIT-01 path traversal: `/tmp/../etc/passwd` normalizes to `/etc/passwd`
-/// and will match a deny rule for `/etc/*`.
-fn normalize_path(raw: &str) -> String {
-    let mut components: Vec<&str> = Vec::new();
-    for component in Path::new(raw).components() {
-        match component {
-            Component::RootDir => {
-                components.clear();
-                components.push("/");
-            }
-            Component::CurDir => {} // skip `.`
-            Component::ParentDir => {
-                // Pop the last component (but never pop root `/`).
-                if components.len() > 1 {
-                    components.pop();
-                }
-            }
-            Component::Normal(s) => {
-                components.push(s.to_str().unwrap_or(""));
-            }
-            Component::Prefix(_) => {
-                components.push(component.as_os_str().to_str().unwrap_or(""));
-            }
-        }
-    }
-
-    if components.is_empty() {
-        return raw.to_owned();
-    }
-    if components == ["/"] {
-        return "/".to_owned();
-    }
-    let root = if components.first() == Some(&"/") {
-        components.remove(0);
-        "/"
-    } else {
-        ""
-    };
-    format!("{root}{}", components.join("/"))
 }
 
 #[cfg(test)]
@@ -800,45 +758,6 @@ mod tests {
             PolicyEnforcer::compile(&config),
             Err(PolicyCompileError::TooManyRules { .. })
         ));
-    }
-
-    // ── normalize_path unit tests ─────────────────────────────────────────────
-
-    #[test]
-    fn normalize_path_simple() {
-        assert_eq!(normalize_path("/etc/passwd"), "/etc/passwd");
-    }
-
-    #[test]
-    fn normalize_path_dot_dot() {
-        assert_eq!(normalize_path("/tmp/../etc/passwd"), "/etc/passwd");
-    }
-
-    #[test]
-    fn normalize_path_dot() {
-        assert_eq!(normalize_path("/etc/./shadow"), "/etc/shadow");
-    }
-
-    #[test]
-    fn normalize_path_root_stays() {
-        assert_eq!(normalize_path("/"), "/");
-    }
-
-    #[test]
-    fn normalize_path_double_dot_at_root() {
-        // Can't go above root.
-        assert_eq!(normalize_path("/../etc"), "/etc");
-    }
-
-    // GAP-01: deep `..` chain traversal must still normalize correctly.
-    #[test]
-    fn normalize_path_deep_dotdot_chain() {
-        // /a/b/c/d/../../../../../../etc/passwd
-        // After normalization: /etc/passwd (excess `..` above root are discarded)
-        assert_eq!(
-            normalize_path("/a/b/c/d/../../../../../../etc/passwd"),
-            "/etc/passwd"
-        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `cosine_similarity` centralised in `zeph-common::math`; redundant copies removed from `zeph-mcp`, `zeph-memory` (`math.rs` deleted), and all 8 downstream call sites updated
- `estimate_tokens` added to `zeph-common::text`; 4 inline `chars().count() / 4` expressions replaced in `zeph-llm` and `zeph-memory`
- `strip_control_chars_preserve_whitespace` moved to `zeph-common::sanitize`; private duplicates removed from `zeph-sanitizer` and `zeph-gateway`
- `normalize_path` made `pub(crate)` in `zeph-tools::file`; duplicate removed from `zeph-tools::policy` (6 redundant tests eliminated)
- `zeph-common` added as dependency to `zeph-gateway` and `zeph-skills`

Net: **65 insertions / 184 deletions**

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace --features full -- -D warnings` — 0 warnings
- [ ] `cargo nextest run --workspace --features full --lib --bins` — 7805/7805 passed