### PR TITLE
fix(agent): exclude [skipped] utility messages from semantic memory (#2620)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- fix(agent): exclude [skipped] utility messages from semantic memory, strengthen Retrieve re-dispatch hint (#2620)
 - fix(agent): defer utility gate System hint injection until after tool results are persisted (#2615)
 - refactor(dry): remove duplicate `cosine_similarity` in `zeph-mcp` — use canonical `zeph-common::math::cosine_similarity`
 - refactor(dry): eliminate `zeph-memory/src/math.rs` single-line re-export module — direct imports from `zeph_common::math`

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -301,6 +301,14 @@ impl<C: Channel> Agent<C> {
         let mut tokens_used = tc.count_tokens(&recall_text);
 
         for item in &recalled {
+            // Filter out internal utility-policy markers so they never surface as recalled
+            // context — a [skipped] bash ToolResult in Qdrant would make the LLM believe the
+            // tool is blocked and prevent re-dispatch after a Retrieve gate (#2620).
+            if item.message.content.starts_with("[skipped]")
+                || item.message.content.starts_with("[stopped]")
+            {
+                continue;
+            }
             let role_label = match item.message.role {
                 Role::User => "user",
                 Role::Assistant => "assistant",
@@ -2153,5 +2161,88 @@ mod tests {
         let xml = hint.format_xml().unwrap();
         assert!(!xml.contains("remaining_cost_cents"));
         assert!(!xml.contains("total_budget_cents"));
+    }
+
+    // ── recall snippet filter (#2620) ────────────────────────────────────────
+
+    /// Mirrors the filter condition in `fetch_semantic_recall` — used to verify
+    /// that `[skipped]`/`[stopped]` markers are recognised and that normal
+    /// snippets are not accidentally rejected.
+    fn recall_is_policy_marker(content: &str) -> bool {
+        content.starts_with("[skipped]") || content.starts_with("[stopped]")
+    }
+
+    /// Simulates the recall-text assembly loop from `fetch_semantic_recall`,
+    /// returning only the snippets that pass the policy-marker filter.
+    fn apply_recall_filter(snippets: &[&str]) -> Vec<String> {
+        snippets
+            .iter()
+            .filter(|s| !recall_is_policy_marker(s))
+            .map(|s| s.to_string())
+            .collect()
+    }
+
+    #[test]
+    fn recall_filter_skipped_marker_is_excluded() {
+        let snippets = ["[skipped] bash was blocked by utility gate"];
+        let result = apply_recall_filter(&snippets);
+        assert!(
+            result.is_empty(),
+            "[skipped] snippet must be filtered from recall block"
+        );
+    }
+
+    #[test]
+    fn recall_filter_stopped_marker_is_excluded() {
+        let snippets = ["[stopped] execution limit reached"];
+        let result = apply_recall_filter(&snippets);
+        assert!(
+            result.is_empty(),
+            "[stopped] snippet must be filtered from recall block"
+        );
+    }
+
+    #[test]
+    fn recall_filter_normal_snippet_passes_through() {
+        let snippets = ["total 42\ndrwxr-xr-x  5 user group  160 Jan  1 00:00 src"];
+        let result = apply_recall_filter(&snippets);
+        assert_eq!(
+            result.len(),
+            1,
+            "normal snippet must not be filtered from recall block"
+        );
+        assert_eq!(result[0], snippets[0]);
+    }
+
+    #[test]
+    fn recall_filter_mixed_passes_only_normal_snippets() {
+        let snippets = [
+            "[skipped] bash blocked",
+            "real output line",
+            "[stopped] limit hit",
+            "another real line",
+        ];
+        let result = apply_recall_filter(&snippets);
+        assert_eq!(result, vec!["real output line", "another real line"]);
+    }
+
+    #[test]
+    fn recall_filter_empty_content_is_not_a_marker() {
+        // Empty string does not start with either marker → must pass through.
+        let snippets = [""];
+        let result = apply_recall_filter(&snippets);
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn recall_filter_partial_prefix_is_not_a_marker() {
+        // "[skip]" and "[stop]" are not the recognised markers.
+        let snippets = ["[skip] not a real marker", "[stop] also not a marker"];
+        let result = apply_recall_filter(&snippets);
+        assert_eq!(
+            result.len(),
+            2,
+            "partial prefixes must not be treated as policy markers"
+        );
     }
 }

--- a/crates/zeph-core/src/agent/persistence.rs
+++ b/crates/zeph-core/src/agent/persistence.rs
@@ -426,6 +426,7 @@ impl<C: Channel> Agent<C> {
     /// `has_injection_flags` controls whether Qdrant embedding is skipped for this message.
     /// When `true` and `guard_memory_writes` is enabled, only `SQLite` is written — the message
     /// is saved for conversation continuity but will not pollute semantic search (M2, D2).
+    #[allow(clippy::too_many_lines)]
     pub(crate) async fn persist_message(
         &mut self,
         role: Role,
@@ -470,7 +471,18 @@ impl<C: Channel> Agent<C> {
 
         let skip_embedding = guard_event.is_some();
 
-        let should_embed = if skip_embedding {
+        // Do not embed [skipped] or [stopped] ToolResult content into Qdrant — these are
+        // internal policy markers that carry no useful semantic information and would
+        // contaminate memory_search results, causing the utility-gate Retrieve loop (#2620).
+        let has_skipped_tool_result = parts.iter().any(|p| {
+            if let MessagePart::ToolResult { content, .. } = p {
+                content.starts_with("[skipped]") || content.starts_with("[stopped]")
+            } else {
+                false
+            }
+        });
+
+        let should_embed = if skip_embedding || has_skipped_tool_result {
             false
         } else {
             match role {
@@ -3035,5 +3047,127 @@ mod tests {
             mixed_msg.content, "Let me list the directory. [tool_use: shell(call_mixed)]",
             "content field must be unchanged — only parts are stripped"
         );
+    }
+
+    // ── [skipped]/[stopped] ToolResult embedding guard (#2620) ──────────────
+
+    #[tokio::test]
+    async fn persist_message_skipped_tool_result_does_not_embed() {
+        use zeph_llm::provider::MessagePart;
+
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+
+        let (tx, rx) = tokio::sync::watch::channel(MetricsSnapshot::default());
+        let memory = test_memory(&AnyProvider::Mock(zeph_llm::mock::MockProvider::default())).await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
+            .with_metrics(tx)
+            .with_memory(std::sync::Arc::new(memory), cid, 50, 5, 100)
+            .with_autosave_config(true, 0);
+
+        let parts = vec![MessagePart::ToolResult {
+            tool_use_id: "tu1".into(),
+            content: "[skipped] bash tool was blocked by utility gate".into(),
+            is_error: false,
+        }];
+
+        agent
+            .persist_message(
+                Role::User,
+                "[skipped] bash tool was blocked by utility gate",
+                &parts,
+                false,
+            )
+            .await;
+
+        assert_eq!(
+            rx.borrow().embeddings_generated,
+            0,
+            "[skipped] ToolResult must not be embedded into Qdrant"
+        );
+    }
+
+    #[tokio::test]
+    async fn persist_message_stopped_tool_result_does_not_embed() {
+        use zeph_llm::provider::MessagePart;
+
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+
+        let (tx, rx) = tokio::sync::watch::channel(MetricsSnapshot::default());
+        let memory = test_memory(&AnyProvider::Mock(zeph_llm::mock::MockProvider::default())).await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
+            .with_metrics(tx)
+            .with_memory(std::sync::Arc::new(memory), cid, 50, 5, 100)
+            .with_autosave_config(true, 0);
+
+        let parts = vec![MessagePart::ToolResult {
+            tool_use_id: "tu2".into(),
+            content: "[stopped] execution limit reached".into(),
+            is_error: false,
+        }];
+
+        agent
+            .persist_message(
+                Role::User,
+                "[stopped] execution limit reached",
+                &parts,
+                false,
+            )
+            .await;
+
+        assert_eq!(
+            rx.borrow().embeddings_generated,
+            0,
+            "[stopped] ToolResult must not be embedded into Qdrant"
+        );
+    }
+
+    #[tokio::test]
+    async fn persist_message_normal_tool_result_is_saved_not_blocked_by_guard() {
+        // Regression: a normal ToolResult (no [skipped]/[stopped] prefix) must not be
+        // suppressed by the utility-gate guard and must reach the save path (SQLite).
+        use zeph_llm::provider::MessagePart;
+
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+
+        let memory = test_memory(&AnyProvider::Mock(zeph_llm::mock::MockProvider::default())).await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let memory_arc = std::sync::Arc::new(memory);
+
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
+            .with_memory(memory_arc.clone(), cid, 50, 5, 100)
+            .with_autosave_config(true, 0);
+
+        let content = "total 42\ndrwxr-xr-x  5 user group";
+        let parts = vec![MessagePart::ToolResult {
+            tool_use_id: "tu3".into(),
+            content: content.into(),
+            is_error: false,
+        }];
+
+        agent
+            .persist_message(Role::User, content, &parts, false)
+            .await;
+
+        // Must be saved to SQLite — confirms the guard did not block this path.
+        let history = memory_arc.sqlite().load_history(cid, 50).await.unwrap();
+        assert_eq!(
+            history.len(),
+            1,
+            "normal ToolResult must be saved to SQLite"
+        );
+        assert_eq!(history[0].content, content);
     }
 }

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -1116,12 +1116,16 @@ impl<C: Channel> Agent<C> {
                             .channel
                             .send_status(&format!("Utility action: Retrieve ({})", tc.name))
                             .await;
-                        // Inject a system message directing the LLM to retrieve context first.
+                        // Inject a system message directing the LLM to retrieve context first,
+                        // then re-invoke the original tool. Without the explicit re-dispatch
+                        // instruction the LLM tends to treat the skipped result as a hard
+                        // block and responds in text instead of calling the tool again (#2620).
                         let hint = format!(
                             "[utility:retrieve] Before executing the '{}' tool, retrieve \
                              relevant context via memory_search or a related lookup to ensure \
-                             the call is well-targeted.",
-                            tc.name
+                             the call is well-targeted. After retrieving context, you MUST call \
+                             the '{}' tool again with the same arguments.",
+                            tc.name, tc.name
                         );
                         pending_system_hints.push(hint);
                         let out = skipped_output(


### PR DESCRIPTION
## Summary

- `[skipped]` and `[stopped]` ToolResult content from the utility gate is no longer stored in Qdrant semantic memory, preventing it from contaminating future `memory_search` results
- Retrieve hint now explicitly instructs the LLM to call the original tool again after memory retrieval
- Defense-in-depth: recall assembly filters out any `[skipped]`/`[stopped]` prefixed snippets before they reach LLM context

## Root cause

When the utility gate recommended `Retrieve` for a bash call, it synthesized a `[skipped]` ToolResult that was unconditionally embedded into Qdrant (`persistence.rs` `should_embed` always `true` for `Role::User` messages). On the next turn, `memory_search` returned this synthetic text, leading the LLM to conclude bash was permanently blocked.

## Changes

- `crates/zeph-core/src/agent/persistence.rs` — `has_skipped_tool_result` guard sets `should_embed = false` when ToolResult content starts with `[skipped]` or `[stopped]`
- `crates/zeph-core/src/agent/tool_execution/native.rs` — Retrieve hint strengthened to mandate re-dispatch: "After retrieving context, you MUST call the '{tool_name}' tool again with the same arguments"
- `crates/zeph-core/src/agent/context/assembly.rs` — recall loop skips snippets prefixed with `[skipped]` or `[stopped]`
- 9 unit tests added (persistence.rs × 3, assembly.rs × 6)

## Test plan

- [ ] `cargo +nightly fmt --check` ✅
- [ ] `cargo clippy --all-targets --all-features --workspace -- -D warnings` ✅
- [ ] `cargo nextest run --workspace --all-features --lib --bins` — 7814/7814 ✅
- [ ] Live session: fresh DB + `echo hello_from_zeph` prompt → bash executes after Retrieve cycle (see playbook `bats-budget-hint-utility-action.md` scenario 7)

Closes #2620