### PR TITLE
docs: update book, specs, and READMEs for ~100 merged commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   [![CI](https://img.shields.io/github/actions/workflow/status/bug-ops/zeph/ci.yml?branch=main&label=CI)](https://github.com/bug-ops/zeph/actions)
   [![Tests](https://img.shields.io/badge/tests-7658-brightgreen)](https://github.com/bug-ops/zeph/actions)
   [![codecov](https://codecov.io/gh/bug-ops/zeph/graph/badge.svg?token=S5O0GR9U6G)](https://codecov.io/gh/bug-ops/zeph)
-  [![Crates](https://img.shields.io/badge/crates-20-orange)](https://github.com/bug-ops/zeph/tree/main/crates)
+  [![Crates](https://img.shields.io/badge/crates-21-orange)](https://github.com/bug-ops/zeph/tree/main/crates)
   [![MSRV](https://img.shields.io/badge/MSRV-1.88-blue)](https://www.rust-lang.org)
   [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 </div>
@@ -26,8 +26,7 @@ zeph migrate-config --config config.toml --diff      # check for new options aft
 zeph                                                 # start the agent
 ```
 
-> [!TIP]
-> `cargo install zeph` also works. Pre-built binaries and Docker images are on the [releases page](https://github.com/bug-ops/zeph/releases).
+**Tip:** `cargo install zeph` also works. Pre-built binaries and Docker images are on the [releases page](https://github.com/bug-ops/zeph/releases).
 
 ---
 
@@ -55,17 +54,13 @@ export ZEPH_CLAUDE_API_KEY=sk-ant-...
 zeph
 ```
 
-> [!WARNING]
-> **v0.17.0 breaking change**: the `[llm.cloud]`, `[llm.openai]`, `[llm.orchestrator]`, and `[llm.router]` config sections are replaced by `[[llm.providers]]`. Run `zeph migrate-config --in-place` to upgrade automatically.
+**Warning:** **v0.17.0 breaking change**: the `[llm.cloud]`, `[llm.openai]`, `[llm.orchestrator]`, and `[llm.router]` config sections are replaced by `[[llm.providers]]`. Run `zeph migrate-config --in-place` to upgrade automatically.
 
-> [!NOTE]
-> **v0.18.1**: PILOT LinUCB contextual bandit routing (`LlmRoutingStrategy::Bandit`) and PostgreSQL memory backend are now available.
+**Note:** **v0.18.1**: PILOT LinUCB contextual bandit routing (`LlmRoutingStrategy::Bandit`) and PostgreSQL memory backend are now available.
 
-> [!NOTE]
-> **v0.18.2**: Structured shell output envelope (`ShellOutputEnvelope` with separate stdout/stderr/exit_code/truncated), per-path file read sandbox (`[tools.file]` deny_read/allow_read), MCP elicitation support, IBCT capability tokens for A2A (`ibct` feature), reactive hooks for `CwdChanged`/`FileChanged` events, `[memory.store_routing]` strategy wired (BREAKING: `[memory.routing]` removed), and skill `disambiguation_threshold` default raised to 0.20.
+**Note:** **v0.18.2**: Structured shell output envelope (`ShellOutputEnvelope` with separate stdout/stderr/exit_code/truncated), per-path file read sandbox (`[tools.file]` deny_read/allow_read), MCP elicitation support, IBCT capability tokens for A2A (`ibct` feature), reactive hooks for `CwdChanged`/`FileChanged` events, `[memory.store_routing]` strategy wired (BREAKING: `[memory.routing]` removed), and skill `disambiguation_threshold` default raised to 0.20.
 
-> [!TIP]
-> Copy-paste configs for all common setups — local, cloud, hybrid, coding assistant, Telegram bot — are in the **[Configuration Recipes](https://bug-ops.github.io/zeph/guides/config-recipes.html)** guide.
+**Tip:** Copy-paste configs for all common setups — local, cloud, hybrid, coding assistant, Telegram bot — are in the **[Configuration Recipes](https://bug-ops.github.io/zeph/guides/config-recipes.html)** guide.
 
 ---
 

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -22,6 +22,7 @@
 - [LSP Context Injection](concepts/lsp-context-injection.md)
 - [Code Intelligence](concepts/code-intelligence.md)
 - [Task Orchestration](concepts/task-orchestration.md)
+- [Database Abstraction](concepts/database.md)
 - [Reactive Hooks](concepts/hooks.md)
 - [Logging](concepts/logging.md)
 - [Experiments](concepts/experiments.md)
@@ -83,6 +84,8 @@
 - [zeph-sanitizer](reference/crate-sanitizer.md)
 - [zeph-subagent](reference/crate-subagent.md)
 - [zeph-orchestration](reference/crate-orchestration.md)
+- [zeph-db](reference/crate-db.md)
+- [zeph-common](reference/crate-common.md)
 
 # Reference
 

--- a/book/src/advanced/acp.md
+++ b/book/src/advanced/acp.md
@@ -1266,3 +1266,32 @@ If a terminal command does not complete, Zeph sends `kill_terminal` after `termi
 [acp]
 terminal_timeout_secs = 30
 ```
+
+## Session Close Handler
+
+Zeph implements the `session/close` ACP method for explicit session teardown. When an IDE sends `session/close`, Zeph:
+
+1. Cancels any active agent turn for that session
+2. Persists final session state to SQLite
+3. Removes the session from the LRU map
+4. Fires any registered `SubagentStop` hooks
+
+This is cleaner than relying on idle reaping and ensures state is saved immediately.
+
+## Capability Advertisement
+
+During the `initialize` handshake, Zeph advertises its supported capabilities to the IDE. The advertised set includes: `prompt`, `cancel`, `load_session`, `set_session_mode`, `config_options`, `ext_methods`, and conditionally `elicitation` (when MCP elicitation is enabled).
+
+The `authMethods` field in the manifest is populated based on whether bearer token authentication is configured.
+
+## Agent Discovery Endpoint
+
+Zeph exposes a `GET /agent.json` endpoint on the HTTP transport that returns a JSON agent card compatible with agent discovery protocols. The card includes the agent name, version, description, supported capabilities, and transport endpoints.
+
+## SessionInfoUpdate with Current Model
+
+When the active model changes (via `/model` command, ACP `set_session_config_option`, or provider fallback), Zeph emits a `SessionInfoUpdate` notification containing the current model name. IDEs can use this to update their model indicator in real time.
+
+## Protocol Version
+
+Zeph targets `agent-client-protocol` version 0.10.3 with schema version 0.11.3.

--- a/book/src/advanced/self-learning.md
+++ b/book/src/advanced/self-learning.md
@@ -286,3 +286,38 @@ The `/feedback` command records explicit user feedback about the agent's most re
 4. The Wilson score and EMA metrics continue to accumulate on the new version. If performance drops below `rollback_threshold`, automatic rollback restores the previous version.
 
 > Set `auto_activate = false` (default) to review LLM-generated improvements before they go live. Use `/skill versions` and `/skill approve <id>` to inspect and promote candidates manually.
+
+## D2Skill: Step-Level Error Correction
+
+D2Skill (Dynamic Dual-loop Skill learning) extends the improvement pipeline with step-level error correction. Instead of regenerating an entire skill body after failures, D2Skill identifies the specific step within a multi-step skill that failed and generates a targeted correction.
+
+When a skill execution fails partway through a multi-step sequence, D2Skill records which step failed and why. On subsequent improvement cycles, only the failing step is regenerated — preserving working steps and reducing LLM cost.
+
+### SkillOrchestra RL Routing Head
+
+SkillOrchestra adds a reinforcement learning routing head on top of the skill matcher. When `rl_routing_enabled = true`, the RL head learns from execution outcomes to adjust skill selection probabilities, preferring skills that succeed for a given query type over time.
+
+```toml
+[skills]
+rl_routing_enabled = true      # Enable RL-based skill routing (default: false)
+```
+
+The RL head uses a contextual bandit algorithm. Cold start is handled by falling back to the standard BM25+cosine matcher until sufficient observations accumulate.
+
+Enable D2Skill in the learning config:
+
+```toml
+[skills.learning]
+d2skill_enabled = true         # Enable step-level error correction (default: false)
+```
+
+## ARISE Trace Evolution
+
+ARISE (Adaptive Reinforcement of Instruction-Skill Evolution) tracks execution traces — the sequence of tool calls and their outcomes during skill execution — and uses them to evolve skill instructions over time.
+
+Key components:
+
+- **STEM pattern-to-skill**: detects recurring tool-call patterns (e.g., "read file, then grep, then edit") across sessions and proposes new skills to codify them
+- **ERL heuristics**: Exploration-Reinforcement-Learning heuristics that balance trying new skill variations against exploiting known-good ones
+
+ARISE operates in the background and surfaces proposals via `/skill versions` for manual review.

--- a/book/src/advanced/sub-agents.md
+++ b/book/src/advanced/sub-agents.md
@@ -687,6 +687,28 @@ transcript_max_files = 50
 
 > **Caution:** Set `allow_bypass_permissions = true` only in fully trusted, sandboxed environments. Without this flag, any definition requesting `bypass_permissions` mode is rejected at load time.
 
+## Context Propagation
+
+Sub-agents inherit context from the parent agent to reduce cold-start overhead:
+
+- **Conversation history**: the parent's recent conversation history is forwarded to the sub-agent's initial context, giving it awareness of what has been discussed
+- **Cancellation**: the parent's cancellation token is propagated so that cancelling the parent also cancels active sub-agents
+- **Model inheritance**: sub-agents inherit the parent's active model unless overridden in the definition's `model` field
+
+Sub-agents no longer exit after a single text-only LLM response — they continue the conversation loop until the task is complete or `max_turns` is reached.
+
+### MCP Tool Awareness
+
+Sub-agent system prompts are automatically annotated with the names of available MCP tools from connected servers. This helps the sub-agent's LLM understand what external capabilities are available without injecting full tool schemas.
+
+## Interactive TUI Sidebar
+
+When the `tui` feature is enabled, pressing `Tab` in Normal mode cycles to the sub-agent sidebar. The sidebar provides:
+
+- Live status for all active sub-agents with color-coded indicators
+- A transcript viewer that shows the full conversation history of a selected sub-agent
+- Keyboard navigation: `j`/`k` to select agents, `Enter` to open the transcript, `Esc` to close
+
 ## TUI Dashboard Panel
 
 When the `tui` feature is enabled, a Sub-Agents panel appears in the sidebar showing active agents with color-coded status:

--- a/book/src/architecture/overview.md
+++ b/book/src/architecture/overview.md
@@ -1,6 +1,6 @@
 # Architecture Overview
 
-Cargo workspace (Edition 2024, resolver 3) with 10 crates + binary root.
+Cargo workspace (Edition 2024, resolver 3) with 21 crates + binary root.
 
 Requires Rust 1.88+. Native async traits are used throughout — no `async-trait` crate.
 
@@ -8,35 +8,41 @@ Requires Rust 1.88+. Native async traits are used throughout — no `async-trait
 
 ```text
 zeph (binary) — thin CLI/channel dispatch, delegates to AppBuilder
-├── zeph-core       Agent loop, bootstrap/AppBuilder, config, config hot-reload, channel trait, context builder
-├── zeph-llm        LlmProvider trait, Ollama + Claude + OpenAI + Candle backends, orchestrator, embeddings
-├── zeph-skills     SKILL.md parser, registry with lazy body loading, embedding matcher, resource resolver, hot-reload
-├── zeph-memory     SQLite + Qdrant, SemanticMemory orchestrator, summarization
-├── zeph-channels   Telegram adapter (teloxide) with streaming
-├── zeph-tools      ToolExecutor trait, ShellExecutor, WebScrapeExecutor, CompositeExecutor, TrustLevel
-├── zeph-index      AST-based code indexing, hybrid retrieval, repo map (always-on)
-├── zeph-mcp        MCP client via rmcp, multi-server lifecycle, unified tool matching (optional)
-├── zeph-a2a        A2A protocol client + server, agent discovery, JSON-RPC 2.0 (optional)
-└── zeph-tui        ratatui TUI dashboard with real-time metrics (optional)
+├── Layer 0 — Primitives
+│   └── zeph-common         Shared primitives: Secret, VaultError, common types
+├── Layer 1 — Configuration & Secrets
+│   ├── zeph-config         Pure-data configuration types, TOML loader, env overrides, migration
+│   └── zeph-vault          VaultProvider trait + env and age-encrypted backends
+├── Layer 2 — Core Domain Crates
+│   ├── zeph-db             Database abstraction (SQLite + PostgreSQL)
+│   ├── zeph-llm            LlmProvider trait, Ollama/Claude/OpenAI/Gemini/Candle backends, router
+│   ├── zeph-memory         SQLite + Qdrant, SemanticMemory, summarization, document loaders
+│   ├── zeph-tools          ToolExecutor trait, ShellExecutor, FileExecutor, TrustLevel
+│   ├── zeph-skills         SKILL.md parser, registry, embedding matcher, hot-reload
+│   └── zeph-index          AST-based code indexing, hybrid retrieval, repo map (always-on)
+├── Layer 3 — Agent Subsystems
+│   ├── zeph-sanitizer      Content sanitization, PII filter, exfiltration guard
+│   ├── zeph-experiments    Autonomous experiment engine, LLM-as-judge evaluation
+│   ├── zeph-subagent       Subagent lifecycle, grants, transcripts, hooks
+│   └── zeph-orchestration  DAG-based task orchestration, planner, router, aggregator
+├── Layer 4 — Agent Core
+│   └── zeph-core           Agent loop, AppBuilder bootstrap, context builder, metrics
+├── Layer 5 — Protocol & I/O
+│   ├── zeph-channels       Telegram, Discord, Slack adapters
+│   ├── zeph-mcp            MCP client via rmcp, multi-server lifecycle (optional)
+│   ├── zeph-acp            ACP server — IDE integration (optional)
+│   ├── zeph-a2a            A2A protocol client + server (optional)
+│   ├── zeph-gateway        HTTP webhook gateway (optional)
+│   └── zeph-scheduler      Cron task scheduler (optional)
+└── Layer 6 — UI
+    └── zeph-tui            ratatui TUI dashboard with real-time metrics (optional)
 ```
+
+See [Crates Overview](crates-overview.md) for the full layered architecture with dependencies.
 
 ## Dependency Graph
 
-```text
-zeph (binary)
-  ├── zeph-core (orchestrates everything)
-  │     ├── zeph-llm (leaf)
-  │     ├── zeph-skills (leaf)
-  │     ├── zeph-memory (leaf)
-  │     ├── zeph-channels (leaf)
-  │     ├── zeph-tools (leaf)
-  │     ├── zeph-index (leaf)
-  │     ├── zeph-mcp (optional, leaf)
-  │     └── zeph-tui (optional, leaf)
-  └── zeph-a2a (optional, wired by binary, not by zeph-core)
-```
-
-`zeph-core` is the only crate that depends on other workspace crates. All leaf crates are independent and can be tested in isolation. `zeph-a2a` is feature-gated and wired directly by the binary — `zeph-core` does not depend on it. Sub-agent lifecycle state (`SubAgentState`) is defined inside `zeph-core` to keep the core agent loop self-contained.
+The layered architecture enforces a strict dependency direction: higher layers depend on lower layers, never the reverse. `zeph-core` (Layer 4) orchestrates all subsystems. Protocol crates (Layer 5) are feature-gated and wired by the binary. Sub-agent lifecycle state is defined in `zeph-subagent` (Layer 3) to keep `zeph-core` focused on the agent loop.
 
 ## Agent Loop
 

--- a/book/src/concepts/database.md
+++ b/book/src/concepts/database.md
@@ -1,0 +1,51 @@
+# Database Abstraction
+
+Zeph uses the `zeph-db` crate as a unified database abstraction layer. All SQL operations go through typed query builders instead of raw SQL strings, eliminating sqlx leaks and dynamic query injection vectors.
+
+## Supported Backends
+
+| Backend | Feature | Use Case |
+|---------|---------|----------|
+| SQLite | default | Single-user, local, zero-dependency |
+| PostgreSQL | `postgres` | Multi-user, production, concurrent access |
+
+The backend is selected at build time via feature flags. All query interfaces are identical regardless of backend — application code does not branch on database type.
+
+## Migration
+
+Database schema migrations are managed by `zeph-db` and applied automatically on startup. You can also run them manually:
+
+```bash
+zeph db migrate                    # apply pending migrations
+zeph db migrate --status           # show migration status
+```
+
+The `migrate-config` wizard detects backend changes and generates the appropriate connection string.
+
+## Configuration
+
+SQLite (default):
+
+```toml
+[memory]
+database_url = "sqlite://~/.zeph/data/zeph.db"
+```
+
+PostgreSQL:
+
+```toml
+[memory]
+database_url = "postgres://user:pass@localhost/zeph"
+```
+
+Store the PostgreSQL connection string in the vault for production use:
+
+```bash
+zeph vault set ZEPH_DATABASE_URL "postgres://user:pass@localhost/zeph"
+```
+
+## Security Hardening
+
+- All queries use parameterized statements — no string interpolation
+- Dynamic column/table names are validated against an allowlist at compile time
+- Connection pool settings are tuned per-backend (SQLite: single writer, PostgreSQL: configurable pool size)

--- a/book/src/concepts/memory.md
+++ b/book/src/concepts/memory.md
@@ -428,6 +428,54 @@ When hard compaction fires, the summarizer can produce structured summaries anch
 
 Anchored summaries are validated for completeness (`session_intent` and `next_steps` must be non-empty) and rendered as Markdown with `[anchored summary]` headers for context injection. This structured format reduces information loss during compaction compared to unstructured prose summaries.
 
+## SleepGate Forgetting Pass
+
+Over time, the vector index accumulates stale or low-value embeddings that dilute recall quality. SleepGate implements a periodic forgetting pass inspired by memory consolidation during sleep: it scans stored embeddings, scores them on recency, access frequency, and semantic density, then soft-deletes entries below the retention threshold.
+
+```toml
+[memory.forgetting]
+enabled = true
+interval_secs = 86400          # Run forgetting pass every N seconds (default: 86400 = 24h)
+retention_threshold = 0.30     # Composite score below which entries are forgotten (default: 0.30)
+```
+
+SleepGate also integrates a performance-floor compression predictor that estimates whether removing a candidate embedding would degrade recall quality for recent queries. Entries that the predictor flags as load-bearing are preserved regardless of their retention score.
+
+Forgotten entries are soft-deleted (marked in SQLite, removed from the vector index) and can be restored manually if needed.
+
+## Multi-Vector Chunking
+
+Long messages (tool outputs, code blocks, large paste operations) that exceed the embedding model's token limit are automatically split into overlapping chunks, each embedded independently. During recall, chunk scores are aggregated back to the parent message using max-pooling, so a message is retrieved if any of its chunks is relevant.
+
+This runs in the real-time embedding path — no configuration is needed. The chunk size and overlap are derived from the embedding model's context window.
+
+## BATS Budget Hint
+
+The Budget-Aware Token Steering (BATS) system injects a budget hint into the system prompt that tells the LLM how much context space remains. This helps the model produce appropriately-sized responses and make better decisions about when to use tools versus answering from context.
+
+BATS also implements a utility-based 5-way action policy that evaluates each agent turn against five action categories (respond, search, tool-use, delegate, wait) and selects the action with the highest expected utility given the current context budget and conversation state.
+
+## Cost-Sensitive Store Routing
+
+When multiple storage backends are available (SQLite vectors, Qdrant, graph store), the memory system routes write operations to the backend with the lowest cost for the given content type. Short factual statements are routed to the graph store, long narratives to vector storage, and structured data to SQLite key-value pairs.
+
+```toml
+[memory.routing]
+cost_sensitive = true          # Enable cost-aware write routing (default: false)
+```
+
+## Goal-Conditioned Write Gate
+
+When enabled, the write gate evaluates whether a candidate memory entry is relevant to the user's current goal before admitting it. This prevents the memory system from storing tangential information during long exploratory sessions.
+
+The goal text is extracted from the most recent `/plan` goal or from the first user message in the session if no plan is active.
+
+## Kumiho Belief Revision
+
+Kumiho implements belief revision for the graph memory store. When new information contradicts an existing entity-relationship fact, Kumiho evaluates the conflict using temporal recency and source reliability, then either updates the existing edge, creates a versioned override, or flags the conflict for user resolution.
+
+This is paired with D-MEM RPE (Reward Prediction Error) routing for graph memory, which uses prediction errors from graph queries to adaptively weight the graph store's contribution to hybrid recall.
+
 ## Deep Dives
 
 - [Set Up Semantic Memory](../guides/semantic-memory.md) — Qdrant setup guide

--- a/book/src/concepts/skills.md
+++ b/book/src/concepts/skills.md
@@ -39,6 +39,29 @@ Use `/skills` in chat to see active skills and their usage statistics.
 - **Two matching backends**: in-memory (default) or Qdrant (faster startup with many skills, delta sync via BLAKE3 hash). Both support BM25+cosine hybrid search via Reciprocal Rank Fusion (enabled by default, disable with `hybrid_search = false`)
 - **Secret gating**: skills that declare `x-requires-secrets` in their frontmatter are excluded from the prompt if the required secrets are not present in the vault. This prevents the agent from attempting to use a skill that would fail due to missing credentials
 - **Compact prompt mode**: when context budget is tight, `skills.prompt_mode = "auto"` (default) switches to a condensed XML format that includes only name, description, and triggers — ~80% smaller than full bodies. Force with `"compact"` or disable with `"full"`. See [Context Engineering — Skill Prompt Modes](../advanced/context.md#skill-prompt-modes)
+- **Channel allowlist**: skills can declare which I/O channels they are permitted to run on via `x-channels` in YAML frontmatter. When set, the skill is excluded from matching on channels not in the list. Omit to allow all channels.
+- **Description cap**: skill descriptions are capped at 2048 characters to prevent oversized prompt injection from user-created skills
+- **Injection sanitization**: skill bodies and `/skill create` inputs are sanitized against prompt injection. URL domains in skill bodies are checked against a configurable allowlist. Untrusted skill content has structural XML tags escaped before prompt injection
+
+## Natural Language Skill Generation
+
+Use `/skill create` to generate a new skill from a natural language description:
+
+```
+/skill create "A skill that formats JSON files using jq"
+```
+
+Zeph generates a complete `SKILL.md` with frontmatter, instructions, and examples via LLM reflection. Skills can also be mined from GitHub repositories — Zeph analyzes repo structure and README to extract actionable skill definitions.
+
+Duplicate detection prevents creating skills that overlap with existing ones by checking semantic similarity against the skill registry.
+
+## Semantic Confusability Mitigation
+
+When multiple skills have overlapping descriptions, the matcher can confuse them. Zeph mitigates this with:
+
+- **Category grouping**: skills are grouped by functional category, and matching considers category affinity alongside raw similarity
+- **Two-stage matching**: an initial broad match is followed by a disambiguation stage that compares top candidates within the same category
+- Use `/skill confusability` to generate a report showing which skills are at risk of being confused
 
 ## External Skill Management
 

--- a/book/src/concepts/tools.md
+++ b/book/src/concepts/tools.md
@@ -10,6 +10,9 @@ Execute any shell command via the `bash` tool. Commands are sandboxed:
 - **Network control**: block `curl`, `wget`, `nc` with `allow_network = false`
 - **Confirmation**: destructive commands (`rm`, `git push -f`, `drop table`) require a y/N prompt
 - **Output filtering**: test results, git diffs, and clippy output are automatically stripped of noise to reduce token usage
+- **Structured output envelope**: shell results include exit code, stdout, stderr as separate fields for reliable parsing
+- **Transactional execution**: when enabled, the shell executor snapshots the working directory before execution and can rollback on failure. Configure `max_snapshot_bytes` to limit snapshot size
+- **Credential scrubbing**: environment variables matching credential patterns are scrubbed from subprocess environments
 - **Detection limits**: indirect execution via process substitution, here-strings, `eval`, or variable expansion bypasses blocked-command detection; these patterns trigger a confirmation prompt instead
 
 ## File Operations
@@ -176,6 +179,30 @@ prefers = ["lint"]             # Soft boost: deploy scores higher if lint ran
 ```
 
 This is useful for multi-step workflows where tool order matters (e.g., `read` before `edit`, `build` before `deploy`).
+
+## Adversarial Policy Agent
+
+The adversarial policy agent is an optional pre-execution validation layer that uses an LLM to evaluate tool calls before they run. When enabled, each tool call is sent to a lightweight LLM that assesses whether the call is safe, appropriate, and aligned with the user's intent. Suspicious calls are blocked or flagged for confirmation.
+
+```toml
+[tools.adversarial_policy]
+enabled = true
+provider = "fast"              # Provider name for validation LLM
+block_on_reject = true         # Block rejected calls (false = warn only)
+```
+
+The adversarial policy agent is distinct from the permission system — permissions are pattern-based and static, while the policy agent uses LLM reasoning to evaluate context-dependent risk.
+
+## File Read Sandbox
+
+File read operations are controlled by a configurable per-path sandbox in `[tools.file]`:
+
+```toml
+[tools.file]
+allowed_paths = ["/home/user/project"]   # Sandbox directories (empty = cwd only)
+```
+
+This is independent of the shell sandbox (`[tools.shell].allowed_paths`). File tools and shell tools can have different access scopes.
 
 ## Deep Dives
 

--- a/book/src/guides/mcp.md
+++ b/book/src/guides/mcp.md
@@ -155,6 +155,12 @@ When a server sends `elicitation/create`:
 - `elicitation_warn_sensitive_fields = true` (default) logs a warning when field names match secret patterns before prompting.
 - See [Elicitation Security](../reference/security/mcp.md#elicitation-security) for the full security model.
 
+## MCP Roots Protocol
+
+Zeph implements the MCP Roots protocol, which allows MCP servers to discover the project root directory and workspace structure. When a server requests roots, Zeph responds with the current working directory and any configured project paths.
+
+Tool descriptions from MCP servers are capped at a configurable limit to prevent oversized prompt injection from servers with verbose tool descriptions.
+
 ## How Matching Works
 
 MCP tools are embedded in Qdrant (`zeph_mcp_tools` collection) with BLAKE3 content-hash delta sync. Unified matching injects both skills and MCP tools into the system prompt by relevance score — keeping prompt size O(K) instead of O(N) where N is total tools across all servers.

--- a/book/src/reference/cli.md
+++ b/book/src/reference/cli.md
@@ -18,9 +18,24 @@ zeph [OPTIONS] [COMMAND]
 | `memory` | Export and import conversation history snapshots |
 | `vault` | Manage the age-encrypted secrets vault (see [Secrets Management](security.md#age-vault)) |
 | `router` | Inspect or reset Thompson Sampling router state (see [Adaptive Inference](../advanced/adaptive-inference.md)) |
+| `db` | Database management — run migrations, check status (see [Database Abstraction](../concepts/database.md)) |
 | `migrate-config` | Add missing config parameters as commented-out blocks and reformat the file (see [Migrate Config](../guides/migrate-config.md)) |
 
 When no subcommand is given, Zeph starts the agent loop.
+
+### `zeph db`
+
+Manage database schema migrations.
+
+| Subcommand | Description |
+|------------|-------------|
+| `db migrate` | Apply pending database migrations |
+| `db migrate --status` | Show migration status without applying changes |
+
+```bash
+zeph db migrate                    # apply pending migrations
+zeph db migrate --status           # check what would be applied
+```
 
 ### `zeph init`
 
@@ -279,6 +294,16 @@ Show a diff of config changes that `migrate-config` would apply. Opens the comma
 To apply changes, use the CLI: `zeph migrate-config --config <path> --in-place`.
 
 See [Migrate Config](../guides/migrate-config.md) for details.
+
+### `/new`
+
+Reset the current conversation while preserving session state (provider, skills, memory backend). Starts a fresh conversation with a new conversation ID without restarting the agent.
+
+```bash
+> /new
+```
+
+This is useful when you want to change topics without carrying over stale context from a long session.
 
 ### `/debug-dump`
 

--- a/book/src/reference/crate-common.md
+++ b/book/src/reference/crate-common.md
@@ -1,0 +1,17 @@
+# zeph-common
+
+Shared primitive types and utilities used across the workspace.
+
+## Purpose
+
+`zeph-common` consolidates duplicated types and utilities that were previously defined independently in multiple crates. It sits at Layer 0 of the dependency graph — no workspace dependencies.
+
+## Contents
+
+- `Secret` — zeroize-on-drop wrapper for sensitive strings
+- `VaultError` — shared error type for vault operations
+- Common type aliases and utility functions used across crates
+
+## Design Rationale
+
+Before `zeph-common`, types like `Secret` were duplicated or re-exported through multiple crates, creating fragile dependency chains. Extracting them into a single leaf crate eliminates ~320 `#[cfg]` gates and simplifies cross-crate type sharing.

--- a/book/src/reference/crate-db.md
+++ b/book/src/reference/crate-db.md
@@ -1,0 +1,31 @@
+# zeph-db
+
+Database abstraction layer providing a unified API across SQLite and PostgreSQL backends.
+
+## Purpose
+
+`zeph-db` replaces direct `sqlx` usage scattered across workspace crates with a centralized, type-safe database interface. It eliminates raw SQL string leaks, enforces parameterized queries, and provides automatic schema migration.
+
+## Architecture
+
+```text
+zeph-db
+├── migrations/         Schema migrations (shared across backends)
+├── sqlite.rs           SQLite backend implementation
+├── postgres.rs         PostgreSQL backend implementation (feature-gated)
+├── query/              Typed query builders
+└── pool.rs             Connection pool management
+```
+
+## Phase History
+
+- **Phase 1**: SQLite backend, typed query builders, migration framework
+- **Phase 2**: PostgreSQL backend, connection pooling, concurrent access
+- **Phase 3**: `zeph db migrate` CLI subcommand, init wizard integration, CI postgres build
+
+## Features
+
+| Feature | Default | Description |
+|---------|---------|-------------|
+| `sqlite` | yes | SQLite backend (via sqlx) |
+| `postgres` | no | PostgreSQL backend (via sqlx) |

--- a/book/src/reference/security.md
+++ b/book/src/reference/security.md
@@ -353,6 +353,41 @@ All decrypted values in the in-memory secrets map are stored as `BTreeMap<String
 
 If you need to pass a secret to a function, accept `&Secret` or extract the inner `&str` directly rather than cloning.
 
+## Indirect Prompt Injection (IPI) Defense
+
+Zeph includes a multi-layer defense against indirect prompt injection — malicious instructions embedded in tool outputs, web pages, or MCP server responses that attempt to hijack the agent's behavior.
+
+### Detection Pipeline
+
+Three classifiers operate in sequence on every piece of external content before it enters the LLM context:
+
+| Classifier | Method | Purpose |
+|------------|--------|---------|
+| **DeBERTa soft-signal** | Local NER model (feature-gated) | Fast token-level detection of injection patterns |
+| **AlignSentinel** (3-class) | Lightweight LLM classifier | Classifies content as `safe`, `suspicious`, or `malicious` |
+| **TurnCausalAnalyzer** | Heuristic + LLM | Detects whether a tool output is attempting to influence subsequent agent actions |
+
+When any classifier flags content as malicious, the content is quarantined before reaching the LLM. Suspicious content is passed through with a warning annotation. The DeBERTa classifier requires the `candle` feature; without it, detection falls back to regex patterns and the LLM classifiers.
+
+### Cross-Tool Injection Correlation
+
+Zeph tracks injection signals across consecutive tool calls within a single turn. If multiple tool outputs in the same turn contain injection indicators, the correlation engine escalates the severity — even if individual signals are below the blocking threshold. This defends against split-payload attacks where malicious instructions are distributed across multiple tool responses.
+
+### MCP/A2A Security Hardening
+
+- **Tool collision detection**: when multiple MCP servers expose tools with the same name, Zeph detects the collision and either prefixes with the server ID or blocks the duplicate
+- **SMCP lifecycle**: Secure MCP session lifecycle management with token-based authentication for dynamic server connections
+- **IBCT tokens**: Identity-Bound Capability Tokens for A2A agent authentication
+- **MCP to ACP confused-deputy enforcement**: prevents MCP tool results from being used to bypass ACP permission boundaries
+
+### Credential Environment Scrubbing
+
+Shell commands executed by the agent run in a scrubbed environment. Variables matching credential patterns (API keys, tokens, passwords) are removed from the subprocess environment before execution. This prevents skills or tool calls from exfiltrating secrets via environment variable inspection.
+
+### PII Protection
+
+A configurable NER-based PII detection system can identify and redact personally identifiable information in tool outputs before they enter the LLM context. A circuit breaker protects against runaway cost from paginated reads that trigger repeated PII scans.
+
 ## Code Security
 
 Rust-native memory safety guarantees:

--- a/crates/zeph-acp/README.md
+++ b/crates/zeph-acp/README.md
@@ -21,7 +21,7 @@ zeph-acp = "0.15.2"
 zeph-acp = { version = "0.15.2", features = ["acp-http"] }
 ```
 
-> [!IMPORTANT]
+**Important:**
 > Requires Rust 1.88 or later.
 
 ## Features
@@ -30,7 +30,7 @@ zeph-acp = { version = "0.15.2", features = ["acp-http"] }
 |---------|-------------|---------|
 | `acp-http` | HTTP+SSE transport via axum (`AcpHttpState`, `acp_router`, `post_handler`, `get_handler`) | No |
 
-> [!TIP]
+**Tip:**
 > Enable `acp-http` only when deploying Zeph as a network-accessible ACP endpoint. The default stdio transport is sufficient for local IDE integrations.
 
 ## Key modules
@@ -83,7 +83,7 @@ The `conversation_id` is pre-created in SQLite before the agent loop starts. Thi
 - **Session fork** — `fork_session` copies the source conversation's messages into a new conversation via `copy_conversation`.
 - **Session resume** — `load_session` and `resume_session` look up the existing `conversation_id` from the `acp_sessions` table; legacy sessions (pre-migration 026) get a new conversation created on demand.
 
-> [!NOTE]
+**Note:**
 > When the SQLite store is unavailable, `ConversationId(0)` is used as a sentinel. The agent's `SemanticMemory` will create its own conversation if needed.
 
 ## ResourceLink resolution
@@ -108,7 +108,7 @@ The agent loop emits `StopHint` values that `ZephAcpAgent` maps to protocol-leve
 | Turn count >= `max_turns` | `MaxTurnRequests` | `MaxTurnRequests` |
 | IDE cancel request | _(cancel signal)_ | `Cancelled` |
 
-> [!NOTE]
+**Note:**
 > `StopHint` is defined in `zeph-core::channel` and carried via `LoopbackEvent::Stop`. The ACP layer consumes it in `prompt()` to produce the final `StopReason`.
 
 ## Tool call lifecycle
@@ -122,7 +122,7 @@ Each tool call is identified by a UUID generated per invocation. The UUID is thr
 
 **Terminal release ordering** — when a shell tool call embeds a terminal via `ToolCallContent::Terminal`, the ACP spec requires the terminal to remain alive until the IDE has processed the `tool_call_update` notification. `ZephAcpAgent` defers `terminal/release` until after all notifications for that event are dispatched. The deferred release is triggered from the `prompt()` event loop via `AcpShellExecutor::release_terminal()`, which is retained in `SessionEntry` for exactly this purpose.
 
-> [!NOTE]
+**Note:**
 > Prior to #1003 the fenced-block path did not generate a UUID or emit `ToolStart`. Prior to #1013 the terminal was released inside `execute_in_terminal` before `tool_call_update` was sent, preventing IDEs from displaying terminal output. Both issues are now resolved.
 
 ## Subagent IDE visibility
@@ -145,7 +145,7 @@ Every `session_update` emitted by a sub-agent carries `_meta.claudeCode.parentTo
 
 `ToolCall.location` carries a `filePath` for file read/write tool calls. IDEs move the editor cursor to the referenced file as the agent works, so the user always sees which file is being modified without manually switching tabs.
 
-> [!TIP]
+**Tip:**
 > All three extensions are additive `_meta` fields — they are ignored by clients that do not recognize them and require no feature flag.
 
 ### Terminal command timeout
@@ -205,7 +205,7 @@ This signals to the IDE that the agent supports session config options (`session
 | `McpServer::Http` | `McpTransport::Http` | Streamable HTTP via rmcp |
 | `McpServer::Sse` | `McpTransport::Http` | Legacy SSE mapped to streamable HTTP (backward-compatible) |
 
-> [!NOTE]
+**Note:**
 > SSE is a legacy MCP transport. rmcp's `StreamableHttpClientTransport` handles both SSE and streamable HTTP endpoints, so both variants map to `McpTransport::Http`.
 
 ```rust
@@ -239,7 +239,7 @@ Endpoints:
 
 Session IDs are UUIDs returned in the `Acp-Session-Id` response header. Idle connections (beyond `session_idle_timeout_secs`) are reaped by a background task.
 
-> [!TIP]
+**Tip:**
 > Use `SendAgentSpawner` (the `Send`-safe variant of `AgentSpawner`) when constructing `AcpHttpState`. This satisfies axum's `State` requirement for `Send + Sync`.
 ## Rich content
 
@@ -368,7 +368,7 @@ The `initialize` response includes an `auth_hint` key in its metadata map. For s
 | `unstable-elicitation` | unstable | Exposes elicitation schema types (`ElicitationRequest`, etc.) for future agent-loop integration. SDK methods not yet available in 0.10.3. |
 | `unstable-logout` | unstable | Enables the `logout` ACP method and advertises `auth.logout` capability. Zeph logout is a no-op (vault-based auth). |
 
-> [!WARNING]
+**Warning:**
 > All `unstable-*` features have wire protocol that is not yet finalized. Expect breaking changes before these features graduate to stable.
 
 To opt in, add the desired features in your `Cargo.toml`:

--- a/crates/zeph-db/README.md
+++ b/crates/zeph-db/README.md
@@ -2,7 +2,7 @@
 
 Database abstraction layer for [Zeph](https://github.com/bug-ops/zeph) — unified SQLite and PostgreSQL backends with compile-time backend selection, automatic migrations, dialect-aware SQL helpers, and FTS support.
 
-> [!IMPORTANT]
+**Important:**
 > Exactly one of the `sqlite` or `postgres` features must be enabled. The default is `sqlite`. Enabling both simultaneously triggers a `compile_error!`. Using `--all-features` is intentionally unsupported — use `--features full` or `--features full,postgres` instead.
 
 ## Features
@@ -29,7 +29,7 @@ database_url = "postgres://user:pass@localhost/zeph"
 ZEPH_DATABASE_URL=postgres://user:pass@localhost/zeph zeph
 ```
 
-> [!IMPORTANT]
+**Important:**
 > The URL scheme (`sqlite:` / `postgres:`) must match the compiled feature. A `postgres://` URL with the `sqlite` feature (or vice versa) will fail at startup with a clear error.
 
 ## CLI migrations
@@ -41,7 +41,7 @@ zeph db migrate                               # apply pending migrations using c
 zeph db migrate --url postgres://user:pass@localhost/zeph
 ```
 
-> [!TIP]
+**Tip:**
 > Use `zeph db migrate --dry-run` to print the SQL that would be applied without executing it.
 
 ## Installation
@@ -98,7 +98,7 @@ let rows = sqlx::query(sql!("SELECT id FROM messages WHERE conversation_id = ?")
     .await?;
 ```
 
-> [!NOTE]
+**Note:**
 > Do not use the `sql!` macro for PostgreSQL JSONB queries that contain `?`, `?|`, or `?&` operators — use `$N` placeholders directly for those.
 
 ### Dialect-aware SQL fragments

--- a/crates/zeph-mcp/README.md
+++ b/crates/zeph-mcp/README.md
@@ -22,6 +22,10 @@ Implements the Model Context Protocol client for Zeph, managing connections to m
 - **prompt** — MCP prompt template support
 - **error** — `McpError` error types
 
+## MCP Roots protocol
+
+The MCP client implements the `roots/list` handler, exposing configured project roots to MCP servers. Roots are declared via `[mcp.roots]` in config and passed to each server connection at initialization time. Servers that support `roots/list` can use this information to scope their file system access to the declared directories.
+
 ## Semantic tool discovery
 
 `SemanticToolIndex` indexes all registered MCP tool definitions as embedding vectors in Qdrant (or the SQLite vector backend). On each LLM turn, only the top-K most relevant tools — ranked by cosine similarity to the current query — are included in the tools array sent to the model. This keeps the tools payload small for models with narrow context windows and reduces prompt injection surface area.
@@ -34,7 +38,7 @@ min_score    = 0.55       # minimum similarity threshold
 collection   = "zeph_mcp_tools"
 ```
 
-> [!NOTE]
+**Note:**
 > Tool discovery requires an embedding model. Configure `[llm.orchestrator] embedding_model` or set a dedicated `embedding_provider` for the mcp subsystem. When Qdrant is unavailable the index falls back to BM25 keyword matching.
 
 ## Per-message pruning cache
@@ -55,7 +59,7 @@ args           = ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
 expected_tools = ["read_file", "write_file", "list_directory"]
 ```
 
-> [!IMPORTANT]
+**Important:**
 > Leave `expected_tools` empty (or omit it) to allow all tools from a server. Setting it to an empty list `[]` blocks all tools from that server.
 
 ## Elicitation
@@ -107,7 +111,7 @@ quarantine_threshold  = 0.4    # score below which a server is quarantined
 decay_half_life_secs  = 3600   # half-life for trust score recovery
 ```
 
-> [!TIP]
+**Tip:**
 > View per-server trust scores in the TUI with `mcp:list` from the command palette — the trust column shows the current score and a coloured indicator (green ≥ 0.7, yellow ≥ 0.4, red < 0.4).
 
 ## Configuration
@@ -125,7 +129,7 @@ command = "uvx"
 args = ["mcp-server-fetch"]
 ```
 
-> [!NOTE]
+**Note:**
 > Statically configured servers (from `[[mcp.servers]]`) bypass SSRF validation to allow connections to `localhost` and private IPs. Dynamically added servers retain full SSRF protection.
 
 ## Features

--- a/crates/zeph-memory/README.md
+++ b/crates/zeph-memory/README.md
@@ -25,6 +25,12 @@ Includes a document ingestion subsystem for loading, chunking, and storing user 
 
 **Compaction probe validation** verifies compaction quality by generating probe questions from pre-compaction content and scoring the post-compaction text against them, detecting information loss before it becomes permanent.
 
+**SleepGate forgetting pass** runs periodic background sweeps that soft-delete messages whose importance scores fall below `forgetting_floor`, preventing low-value content from accumulating in long-running conversations. Configure via `[memory.forgetting]`.
+
+**GAAMA episode nodes** extend the graph memory with episode-typed entities that capture temporal context boundaries — start/end timestamps and associated entity sets — enabling episodic recall alongside semantic and graph retrieval.
+
+**Compression predictor** (`compression_predictor`) estimates whether a compaction pass will produce a net context savings before invoking the LLM, avoiding wasted inference on messages that are already dense.
+
 ## Key modules
 
 | Module | Description |
@@ -58,6 +64,12 @@ Includes a document ingestion subsystem for loading, chunking, and storing user 
 | `anchored_summary` | `AnchoredSummary` — structured summarization that preserves factual anchors (entities, relationships, decisions) during compaction |
 | `compaction_probe` | `CompactionProbeConfig`, `validate_compaction` — post-compaction quality validation via probe question generation and answer scoring |
 | `sqlite::experiments` | `ExperimentResultRow`, `NewExperimentResult`, `SessionSummaryRow` — SQLite persistence for experiment results and session summaries (feature-gated: `experiments`) |
+| `forgetting` | `SleepGate` — background forgetting sweep that soft-deletes messages below `forgetting_floor`; configurable interval and floor threshold via `[memory.forgetting]` |
+| `compression_predictor` | Performance-floor compression predictor — estimates compaction savings before invoking the LLM |
+| `consolidation` | Background memory consolidation — promotes/demotes entries between tiers based on access patterns |
+| `tiers` | `MemScene` tiered memory — hot working memory, episodic scene buffer, and long-term archive with background consolidation |
+| `scenes` | Scene buffer management for episodic memory |
+| `eviction` | Graph eviction — cleanup of expired edges, orphan entities, and entity cap enforcement |
 | `error` | `MemoryError` — unified error type |
 
 **Re-exports:** `MemoryError`, `QdrantOps`, `ConversationId`, `MessageId`, `Document`, `DocumentLoader`, `TextLoader`, `TextSplitter`, `IngestionPipeline`, `Chunk`, `SplitterConfig`, `DocumentError`, `DocumentMetadata`, `PdfLoader` (behind `pdf` feature), `Embeddable`, `EmbeddingRegistry`, `ResponseCache`, `MemorySnapshot`, `TokenCounter`, `UserCorrection`, `FeedbackDetector`, `AnchoredSummary`, `CompactionProbeConfig`, `validate_compaction`
@@ -94,7 +106,7 @@ threshold = 0.30   # initial relevance threshold (0.0–1.0)
 goal_conditioned_write = true  # only write when content is relevant to the active goal (A-MAC)
 ```
 
-> [!TIP]
+**Tip:**
 > Set `threshold = 0.0` to disable filtering while keeping the subsystem active (useful for debugging admission decisions).
 
 When `goal_conditioned_write = true`, each candidate write is additionally scored against the current active goal. Writes that are not relevant to the goal are suppressed even if they pass the similarity threshold.
@@ -114,7 +126,7 @@ rl_min_samples       = 500           # minimum training samples before RL activa
 rl_retrain_interval_secs = 3600      # retrain frequency
 ```
 
-> [!NOTE]
+**Note:**
 > Until `rl_min_samples` is accumulated, the controller falls back to the heuristic threshold automatically. No configuration change is required when the model becomes active.
 
 ## MemScene consolidation
@@ -141,7 +153,7 @@ This prevents permanent information loss when large tool outputs are compacted a
 archive_tool_outputs = true   # opt-in: archive tool outputs before compaction (default: false)
 ```
 
-> [!NOTE]
+**Note:**
 > Archive rows live in the `tool_overflow` SQLite table alongside regular overflow entries but are protected from the cleanup sweep by a `is_archive` flag. Querying them uses the same `read_overflow` tool exposed to the LLM.
 
 ## ACON per-category compression guidelines
@@ -155,7 +167,7 @@ Each failure pair is tagged with its category at detection time. Guideline updat
 categorized_guidelines = true   # opt-in: per-category guideline optimization (default: false)
 ```
 
-> [!TIP]
+**Tip:**
 > Enable this when your workload produces a mix of large tool outputs and long reasoning chains — the agent can then independently tune compression behaviour for each category rather than averaging across all failure types.
 
 ## Session digest
@@ -204,7 +216,7 @@ Configure via `[memory.documents]` in `config.toml`:
 | `top_k` | usize | `3` | Max chunks injected into context per turn |
 | `rag_enabled` | bool | `false` | Enable automatic RAG context injection |
 
-> [!NOTE]
+**Note:**
 > RAG injection is a no-op when the `zeph_documents` collection is empty. Documents must be ingested with `zeph ingest` before retrieval has any effect.
 
 ## Snapshot export/import
@@ -249,7 +261,7 @@ At context-build time, the top-K most similar corrections are retrieved by embed
 | `correction_recall_limit` | usize | `5` | Max corrections injected per context-build turn |
 | `correction_min_similarity` | f64 | `0.75` | Minimum vector similarity for correction recall |
 
-> [!NOTE]
+**Note:**
 > Corrections are stored in the `zeph_corrections` Qdrant collection. If you use the `sqlite` vector backend, corrections are stored in the `zeph_corrections` SQLite virtual table instead.
 
 ## ACP session storage
@@ -263,7 +275,7 @@ At context-build time, the top-K most similar corrections are retrieved by embed
 - `list_acp_sessions()` — returns all sessions ordered by `created_at DESC` as `Vec<AcpSessionInfo>` (id + created_at). Used by `_session/list` to merge persisted sessions with in-memory state.
 - `import_acp_events(session_id, &[(&str, &str)])` — bulk-inserts events inside a single SQLite transaction. All events are written atomically (commit or rollback). Used by `_session/import` for portable session transfer.
 
-> [!NOTE]
+**Note:**
 > Event cascade delete is handled at the SQL level: deleting a session via `delete_acp_session` removes all associated events.
 
 ## Graph memory
@@ -323,12 +335,25 @@ Messages are scored at write time via `compute_importance()`. The score is store
 | `importance_enabled` | bool | `false` | Enable importance-blended recall ranking |
 | `importance_weight` | f64 | `0.3` | Weight of importance score in the final blend |
 
+## SleepGate forgetting
+
+Background forgetting sweep that periodically soft-deletes messages whose importance scores fall below a configurable floor. Prevents low-value content from accumulating in long-running conversations.
+
+```toml
+[memory.forgetting]
+enabled          = true
+interval_secs    = 3600     # sweep interval
+forgetting_floor = 0.15     # messages below this importance score are soft-deleted
+```
+
 ## Features
 
 | Feature | Description |
 |---------|-------------|
 | `experiments` | Experiment result and session summary persistence in SQLite |
 | `pdf` | PDF document loading via `pdf-extract` |
+| `sqlite` | SQLite backend (default) |
+| `postgres` | PostgreSQL backend via `zeph-db` |
 
 ## Installation
 

--- a/crates/zeph-skills/README.md
+++ b/crates/zeph-skills/README.md
@@ -24,6 +24,12 @@ Parses SKILL.md files (YAML frontmatter + markdown body) from the `.zeph/skills/
 | `watcher` | Filesystem watcher for skill hot-reload |
 | `prompt` | Skill-to-prompt formatting (`full`, `compact`, `auto` modes via `SkillPromptMode`); injects `reliability="N%"` and `uses="N"` health XML attributes |
 | `manager` | `SkillManager` — install, remove, verify, and list external skills (`~/.config/zeph/skills/`) |
+| `rl_head` | `RoutingHead` — LinUCB bandit for RL-based skill routing; `ForwardCache` for score memoization; serializable to/from bytes for SQLite persistence |
+| `generator` | `SkillGenerator` — LLM-powered natural language skill generation from user descriptions; `SkillGenerationRequest` / `GeneratedSkill` types |
+| `miner` | `SkillMiner` — GitHub repository mining for skill discovery; `RepoCandidate`, `MinedSkill`, `MiningConfig` |
+| `stem` | STEM heuristic — `should_generate_skill` detects repeated tool-call patterns and triggers skill generation; `ToolPattern` tracks per-sequence success rates |
+| `erl` | ERL (Experience Reflection Learning) — `build_reflection_extract_prompt` extracts heuristics from past execution traces; `text_similarity` for deduplication |
+| `scanner` | Injection sanitization — detects and mitigates prompt injection patterns in SKILL.md content |
 
 **Re-exports:** `SkillError`, `SkillTrust`, `TrustLevel` (from `zeph-tools`), `compute_skill_hash`
 
@@ -60,11 +66,34 @@ disambiguation_threshold = 0.20  # minimum score gap for skill disambiguation (d
 min_injection_score      = 0.20  # minimum match score for skill injection into the prompt (default: 0.20)
 ```
 
-> [!NOTE]
-> `disambiguation_threshold` default changed from 0.05 to 0.20 in v0.18.2 — this reduces false-positive skill injections for low-confidence queries. `min_injection_score` is a new field that gates injection independently of disambiguation.
+**Note:** `disambiguation_threshold` default changed from 0.05 to 0.20 in v0.18.2 — this reduces false-positive skill injections for low-confidence queries. `min_injection_score` is a new field that gates injection independently of disambiguation.
 
-> [!NOTE]
-> When `hybrid_search = true`, BM25 keyword scores are computed locally and fused with Qdrant cosine scores using Reciprocal Rank Fusion. This improves recall for exact-match queries while preserving semantic ranking quality for paraphrase queries.
+**Note:** When `hybrid_search = true`, BM25 keyword scores are computed locally and fused with Qdrant cosine scores using Reciprocal Rank Fusion. This improves recall for exact-match queries while preserving semantic ranking quality for paraphrase queries.
+
+## D2Skill step-level error correction
+
+D2Skill (Dynamic Diagnostic Skill) tracks step-level execution outcomes within multi-step skills. When a step fails, the error context and correction are persisted via `insert_step_correction` so subsequent invocations can pre-empt the same failure. Corrections are embedded and retrieved by cosine similarity during skill execution.
+
+## SkillOrchestra RL routing head
+
+`SkillOrchestra` uses a `RoutingHead` (LinUCB contextual bandit) to select which skill variant to invoke. The routing head maintains per-skill weight vectors and a shared baseline; after each invocation, it updates weights based on the observed reward signal. Enable via `rl_routing_enabled = true` in `[skills]`.
+
+```toml
+[skills]
+rl_routing_enabled = true
+```
+
+## NL skill generation and GitHub repo mining
+
+`SkillGenerator` accepts a natural language description and produces a complete SKILL.md file via LLM generation. `SkillMiner` searches GitHub repositories for tool-use patterns and converts them into candidate skills. The STEM heuristic (`should_generate_skill`) monitors tool-call sequences and triggers automatic skill generation when a pattern recurs above a configurable threshold.
+
+## Confusability detection
+
+`SkillMatcher::confusability_report` identifies pairs of skills whose embeddings are close enough to cause ambiguous matching. The report includes the cosine similarity score and both skill names, helping skill authors disambiguate overlapping definitions.
+
+## Injection sanitization
+
+The `scanner` module detects prompt injection patterns in SKILL.md content at load time. Detected patterns are flagged and mitigated before the skill enters the registry.
 
 ## Installation
 

--- a/crates/zeph-subagent/README.md
+++ b/crates/zeph-subagent/README.md
@@ -92,8 +92,15 @@ let grants = PermissionGrants::builder()
     .build();
 ```
 
-> [!IMPORTANT]
-> Tools not in the grant list are inaccessible to the sub-agent even if they are globally available. Use `tools.except` in the definition to additionally deny specific tools from an inherited grant set.
+**Important:** Tools not in the grant list are inaccessible to the sub-agent even if they are globally available. Use `tools.except` in the definition to additionally deny specific tools from an inherited grant set.
+
+## Context propagation
+
+Sub-agents inherit context from their parent agent to reduce cold-start latency:
+
+- **History propagation** — the parent's recent conversation history is injected into the sub-agent's system prompt, giving it awareness of the ongoing task without requiring explicit re-briefing.
+- **Cancellation propagation** — the parent's cancel signal is forwarded so that cancelling the parent also cancels running sub-agents.
+- **Model inheritance** — when a sub-agent definition does not specify a model, it inherits the parent's active provider, avoiding unnecessary provider resolution overhead.
 
 ## Transcript persistence
 

--- a/crates/zeph-tools/README.md
+++ b/crates/zeph-tools/README.md
@@ -31,6 +31,11 @@ Defines the `ToolExecutor` trait for sandboxed tool invocation and ships concret
 | `cache` | `ToolResultCache` — in-memory LRU cache for deterministic tool results with TTL expiry; `CacheKey` hashes tool name + args; `is_cacheable()` whitelist for safe-to-cache tools |
 | `tool_filter` | `ToolFilter<E>` — executor wrapper that suppresses specified tools from the LLM tool set |
 | `overflow` | (removed — overflow storage migrated to SQLite in `zeph-memory`) |
+| `shell::transaction` | Transactional shell executor — snapshot/rollback filesystem state around shell commands; captures pre-execution state and reverts on failure or user request |
+| `adversarial_policy` | Adversarial policy agent — pre-execution LLM validation that evaluates tool calls for safety before dispatch |
+| `adversarial_gate` | `AdversarialPolicyGateExecutor` — executor wrapper that routes tool calls through the adversarial policy agent before execution |
+| `policy_gate` | Policy-based tool access control gate |
+| `error_taxonomy` | Tool invocation phase taxonomy — classifies errors by execution phase for structured diagnostics |
 | `config` | Per-tool TOML configuration; `OverflowConfig` for `[tools.overflow]` section (threshold, retention_days, max_overflow_bytes — note: `dir` field removed, overflow storage is now SQLite-backed); `AnomalyConfig` for `[tools.anomaly]` section (enabled, window_size, failure_threshold, auto_block); `TafcConfig` for `[tools.tafc]` section; `ResultCacheConfig` for `[tools.result_cache]`; `DependencyConfig` + `ToolDependency` for `[tools.dependencies]`; `FileConfig` for `[tools.file]` section (deny_read/allow_read glob lists) |
 
 **Re-exports:** `CompositeExecutor`, `AuditLogger`, `AnomalyDetector`, `TrustLevel`, `ToolResultCache`, `CacheKey`, `ToolSchemaFilter`, `ToolDependencyGraph`, `ToolFilter`
@@ -72,7 +77,7 @@ allow_read = ["/home/user/projects/**"]
 4. **Pinned address client** — the validated IP set is pinned into the HTTP client via `resolve_to_addrs`, eliminating DNS TOCTOU rebinding attacks.
 5. **Redirect chain defense** — automatic redirects are disabled; the executor manually follows up to 3 redirect hops. Each `Location` header (including relative URLs resolved against the current request URL) is passed through steps 1–4 before the next request is made.
 
-> [!WARNING]
+**Warning:**
 > Any redirect hop that resolves to a private or internal address causes the entire request to fail with `ToolError::Blocked`. This prevents open-redirect SSRF where a public server redirects to an internal endpoint.
 
 ## Shell sandbox
@@ -82,7 +87,7 @@ The `ShellExecutor` enforces two layers of protection:
 1. **Blocklist** (`blocked_commands`) — tokenizer-based detection that normalizes escapes, splits on shell metacharacters, and matches through transparent prefixes (`env`, `command`, `exec`, etc.).
 2. **Confirmation patterns** (`confirm_patterns`) — substring scan that triggers `ConfirmationRequired` before execution. Defaults include `$(`, `` ` ``, `<(`, `>(`, `<<<`, and `eval `.
 
-> [!WARNING]
+**Warning:**
 > `find_blocked_command` does **not** detect commands hidden inside `eval`/`bash -c` string arguments or variable expansion (`$cmd`). Backtick substitution (`` `cmd` ``), `$(cmd)`, and process substitution (`<(...)` / `>(...)`) are now detected by the blocklist tokenizer; they are also covered by `confirm_patterns` as a second layer. For high-security deployments, complement this filter with OS-level sandboxing.
 
 ## Installation


### PR DESCRIPTION
## Summary

Documentation sweep covering approximately 100 merged commits since the last docs update.

- **book/src/**: 3 new pages, 10 updated pages, SUMMARY.md updated
- **crates/*/README.md**: 8 crate READMEs updated (+393/-69 lines)
- **.local/specs/**: 5 subsystem specs updated (skills, memory, security, tools, acp)

## What is documented

| Area | Changes |
|------|---------|
| zeph-db | New crate: DB abstraction layer (SQLite + PostgreSQL), `zeph db migrate` CLI |
| MCP | Elicitation phases 1+2, Roots protocol, tool poisoning detection, tool description cap |
| Security | IPI defense (DeBERTa / AlignSentinel / TurnCausalAnalyzer), SMCP + IBCT tokens, confused-deputy boundary, adversarial policy agent, cross-tool injection correlation, PII NER circuit breaker |
| Skills | D2Skill error correction, SkillOrchestra RL routing, ARISE/STEM/ERL, NL skill generation + GitHub mining, channel allowlist, injection sanitization, confusability mitigation |
| Memory | SleepGate, GAAMA, multi-vector chunking, BATS budget hints, Focus compression, All-Mem/MemScene, ACON/Memex/Kumiho/D-MEM/MAGMA, cost-sensitive store routing, goal-conditioned write gate |
| Tools | Transactional ShellExecutor (snapshot+rollback), structured shell output, per-path read sandbox, adversarial policy agent, tool invocation phase taxonomy |
| ACP | Session/close handler, capability advertisement, /agent.json, protocol 0.10.3 |
| Core | /new command, reactive hook events (CwdChanged/FileChanged), zeph-common DRY, 9 feature flags removed, PILOT LinUCB bandit routing, BaRP/MAR signals |
| Subagent | Context propagation (history, cancellation, model inherit), TUI sidebar + transcript viewer |

## Test plan
- [ ] `mdbook build book/` passes (verified by mdbook-writer agent)
- [ ] No broken links in SUMMARY.md