### PR TITLE
fix(memory): ensure conversation row exists before graph episode insert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- fix(memory): ensure conversation row exists before `graph_episodes` FK insert on fresh DB (#2627)
 - fix(agent): exclude [skipped] utility messages from semantic memory, strengthen Retrieve re-dispatch hint (#2620)
 - fix(skills): scan `/skill create` input description for injection patterns before LLM generation (#2621)
 - fix(skills): `/skill create` dedup now works with Qdrant backend via `match_skills` (#2622)

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -2178,7 +2178,7 @@ mod tests {
         snippets
             .iter()
             .filter(|s| !recall_is_policy_marker(s))
-            .map(|s| s.to_string())
+            .map(ToString::to_string)
             .collect()
     }
 

--- a/crates/zeph-memory/src/graph/store/mod.rs
+++ b/crates/zeph-memory/src/graph/store/mod.rs
@@ -2222,6 +2222,14 @@ impl GraphStore {
     ///
     /// Returns an error if the database query fails.
     pub async fn ensure_episode(&self, conversation_id: i64) -> Result<i64, MemoryError> {
+        // Ensure the conversation row exists before inserting into graph_episodes,
+        // which has a FK referencing conversations(id). On a fresh database the agent
+        // may run graph extraction before the conversation row is committed.
+        zeph_db::query(sql!("INSERT OR IGNORE INTO conversations (id) VALUES (?)"))
+            .bind(conversation_id)
+            .execute(&self.pool)
+            .await?;
+
         let id: i64 = zeph_db::query_scalar(sql!(
             "INSERT INTO graph_episodes (conversation_id)
              VALUES (?)


### PR DESCRIPTION
## Summary

Fixes #2627.

On a fresh database the `conversations` table is empty when graph extraction runs for the first
time. `ensure_episode()` in `GraphStore` inserts a row into `graph_episodes` which has a foreign
key referencing `conversations(id)`. With no parent row present the insert fails with a SQLite
FK constraint error, silently aborting the first graph extraction cycle.

**Root cause**: `ensure_episode()` assumed the conversation row was always committed before the
graph extraction task ran. This assumption does not hold on a brand-new database where no
conversation has ever been persisted.

**Fix**: Add `INSERT OR IGNORE INTO conversations (id) VALUES (?)` before the `graph_episodes`
upsert. This is idempotent — when the row already exists the statement is a no-op; when it does
not exist it creates a minimal placeholder row so the FK constraint is satisfied.

Also fixes a pre-existing `redundant_closure` clippy warning in `assembly.rs` (unrelated to the
bug, spotted during review).

## Changes

- `crates/zeph-memory/src/graph/store/mod.rs`: `ensure_episode()` — add `INSERT OR IGNORE` for
  `conversations` before the `graph_episodes` upsert.
- `crates/zeph-core/src/agent/context/assembly.rs`: replace `|s| s.to_string()` with
  `ToString::to_string` to silence clippy.

## Testing

- All 7535 unit tests pass (`cargo nextest run --workspace --all-features --lib --bins`).
- Clippy clean (`cargo clippy --all-targets --all-features --workspace -- -D warnings`).
- Formatting clean (`cargo +nightly fmt --check`).
- Live regression scenario added to `.local/testing/playbooks/memory-graph.md`.
- Coverage-status row added (status: Untested — requires fresh-DB live session).

## Breaking changes

None.