### PR TITLE
fix(persistence): flush orphaned tool_use on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- fix(persistence): persist tombstone `ToolResult` entries on shutdown for any unpaired `tool_use` written to the DB mid-execution (stdin EOF) — eliminates orphaned tool_use WARN messages on next session startup (#2628)
 - fix(memory): ensure conversation row exists before `graph_episodes` FK insert on fresh DB (#2627)
 - fix(agent): exclude [skipped] utility messages from semantic memory, strengthen Retrieve re-dispatch hint (#2620)
 - fix(skills): scan `/skill create` input description for injection patterns before LLM generation (#2621)

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -588,6 +588,74 @@ impl<C: Channel> Agent<C> {
         }
     }
 
+    /// Persist tombstone `ToolResult` messages for any assistant `ToolUse` parts that were written
+    /// to the DB during this session but never paired with a `ToolResult` (e.g. because stdin
+    /// closed while tool execution was in progress). Without this the next session startup strips
+    /// those assistant messages and emits orphan warnings.
+    async fn flush_orphaned_tool_use_on_shutdown(&mut self) {
+        use zeph_llm::provider::{MessagePart, Role};
+
+        // Walk messages in reverse: if the last assistant message (ignoring any trailing
+        // system messages) has ToolUse parts and is NOT immediately followed by a user
+        // message whose ToolResult ids cover those ToolUse ids, persist tombstones.
+        let msgs = &self.msg.messages;
+        // Find last assistant message index.
+        let Some(asst_idx) = msgs.iter().rposition(|m| m.role == Role::Assistant) else {
+            return;
+        };
+        let asst_msg = &msgs[asst_idx];
+        let tool_use_ids: Vec<(&str, &str, &serde_json::Value)> = asst_msg
+            .parts
+            .iter()
+            .filter_map(|p| {
+                if let MessagePart::ToolUse { id, name, input } = p {
+                    Some((id.as_str(), name.as_str(), input))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        if tool_use_ids.is_empty() {
+            return;
+        }
+
+        // Check whether a following user message already pairs all ToolUse ids.
+        let paired_ids: std::collections::HashSet<&str> = msgs
+            .get(asst_idx + 1..)
+            .into_iter()
+            .flatten()
+            .filter(|m| m.role == Role::User)
+            .flat_map(|m| m.parts.iter())
+            .filter_map(|p| {
+                if let MessagePart::ToolResult { tool_use_id, .. } = p {
+                    Some(tool_use_id.as_str())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let unpaired: Vec<zeph_llm::provider::ToolUseRequest> = tool_use_ids
+            .iter()
+            .filter(|(id, _, _)| !paired_ids.contains(*id))
+            .map(|(id, name, input)| zeph_llm::provider::ToolUseRequest {
+                id: (*id).to_owned(),
+                name: (*name).to_owned(),
+                input: (*input).clone(),
+            })
+            .collect();
+
+        if unpaired.is_empty() {
+            return;
+        }
+
+        tracing::info!(
+            count = unpaired.len(),
+            "shutdown: persisting tombstone ToolResults for unpaired in-flight tool calls"
+        );
+        self.persist_cancelled_tool_results(&unpaired).await;
+    }
+
     /// Generate and store a lightweight session summary at shutdown when no hard compaction fired.
     ///
     /// Guards:
@@ -744,6 +812,11 @@ impl<C: Channel> Agent<C> {
                 );
             }
         }
+
+        // Flush tombstone ToolResults for any assistant ToolUse that was persisted but never
+        // paired with a ToolResult (e.g. stdin EOF mid-execution). Without this the next session
+        // startup strips the orphaned ToolUse and emits warnings.
+        self.flush_orphaned_tool_use_on_shutdown().await;
 
         self.maybe_store_shutdown_summary().await;
         self.maybe_store_session_digest().await;

--- a/crates/zeph-core/src/agent/tests.rs
+++ b/crates/zeph-core/src/agent/tests.rs
@@ -4890,3 +4890,237 @@ mod pre_execution_audit_tests {
         );
     }
 }
+
+// #2628: flush_orphaned_tool_use_on_shutdown must persist tombstone ToolResults on shutdown.
+#[cfg(test)]
+mod flush_orphaned_tests {
+    use zeph_llm::any::AnyProvider;
+    use zeph_memory::semantic::SemanticMemory;
+
+    use super::super::Agent;
+    use super::agent_tests::{MockChannel, MockToolExecutor, create_test_registry, mock_provider};
+
+    async fn flush_test_memory() -> SemanticMemory {
+        let provider = AnyProvider::Mock(zeph_llm::mock::MockProvider::default());
+        SemanticMemory::new(":memory:", "http://127.0.0.1:1", provider, "test-model")
+            .await
+            .unwrap()
+    }
+
+    /// FO1: no-op when the message list has no assistant message.
+    #[tokio::test]
+    async fn flush_orphaned_noop_when_no_assistant_message() {
+        use zeph_llm::provider::{Message, MessageMetadata, MessagePart, Role};
+
+        let provider = mock_provider(vec![]);
+        let memory = flush_test_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor).with_memory(
+            std::sync::Arc::new(memory),
+            cid,
+            50,
+            5,
+            100,
+        );
+
+        // Push only a user message — no assistant message.
+        agent.msg.messages.push(Message {
+            role: Role::User,
+            content: "hi".into(),
+            parts: vec![MessagePart::Text { text: "hi".into() }],
+            metadata: MessageMetadata::default(),
+        });
+
+        agent.flush_orphaned_tool_use_on_shutdown().await;
+
+        let history = agent
+            .memory_state
+            .memory
+            .as_ref()
+            .unwrap()
+            .sqlite()
+            .load_history(cid, 50)
+            .await
+            .unwrap();
+        assert!(
+            history.is_empty(),
+            "no tombstone must be persisted when there is no assistant message"
+        );
+    }
+
+    /// FO2: no-op when the last assistant message contains no ToolUse parts.
+    #[tokio::test]
+    async fn flush_orphaned_noop_when_no_tool_use_parts() {
+        use zeph_llm::provider::{Message, MessageMetadata, MessagePart, Role};
+
+        let provider = mock_provider(vec![]);
+        let memory = flush_test_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor).with_memory(
+            std::sync::Arc::new(memory),
+            cid,
+            50,
+            5,
+            100,
+        );
+
+        agent.msg.messages.push(Message {
+            role: Role::Assistant,
+            content: "just text".into(),
+            parts: vec![MessagePart::Text {
+                text: "just text".into(),
+            }],
+            metadata: MessageMetadata::default(),
+        });
+
+        agent.flush_orphaned_tool_use_on_shutdown().await;
+
+        let history = agent
+            .memory_state
+            .memory
+            .as_ref()
+            .unwrap()
+            .sqlite()
+            .load_history(cid, 50)
+            .await
+            .unwrap();
+        assert!(
+            history.is_empty(),
+            "no tombstone must be persisted when there are no ToolUse parts"
+        );
+    }
+
+    /// FO3: tombstone ToolResult is persisted for each unpaired ToolUse.
+    #[tokio::test]
+    async fn flush_orphaned_persists_tombstone_for_unpaired_tool_use() {
+        use zeph_llm::provider::{Message, MessageMetadata, MessagePart, Role};
+
+        let provider = mock_provider(vec![]);
+        let memory = flush_test_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor).with_memory(
+            std::sync::Arc::new(memory),
+            cid,
+            50,
+            5,
+            100,
+        );
+
+        agent.msg.messages.push(Message {
+            role: Role::Assistant,
+            content: "[tool_use]".into(),
+            parts: vec![
+                MessagePart::ToolUse {
+                    id: "orphan_1".into(),
+                    name: "shell".into(),
+                    input: serde_json::json!({}),
+                },
+                MessagePart::ToolUse {
+                    id: "orphan_2".into(),
+                    name: "read_file".into(),
+                    input: serde_json::json!({}),
+                },
+            ],
+            metadata: MessageMetadata::default(),
+        });
+
+        agent.flush_orphaned_tool_use_on_shutdown().await;
+
+        let history = agent
+            .memory_state
+            .memory
+            .as_ref()
+            .unwrap()
+            .sqlite()
+            .load_history(cid, 50)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            history.len(),
+            1,
+            "exactly one tombstone user message must be persisted"
+        );
+        assert_eq!(history[0].role, Role::User);
+        for id in ["orphan_1", "orphan_2"] {
+            assert!(
+                history[0].parts.iter().any(|p| matches!(
+                    p,
+                    MessagePart::ToolResult { tool_use_id, is_error, .. }
+                        if tool_use_id == id && *is_error
+                )),
+                "tombstone ToolResult for {id} must be is_error=true"
+            );
+        }
+    }
+
+    /// FO4: no-op when all ToolUse ids are already covered by a following ToolResult.
+    #[tokio::test]
+    async fn flush_orphaned_noop_when_tool_use_already_paired() {
+        use zeph_llm::provider::{Message, MessageMetadata, MessagePart, Role};
+
+        let provider = mock_provider(vec![]);
+        let memory = flush_test_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor).with_memory(
+            std::sync::Arc::new(memory),
+            cid,
+            50,
+            5,
+            100,
+        );
+
+        agent.msg.messages.push(Message {
+            role: Role::Assistant,
+            content: "[tool_use]".into(),
+            parts: vec![MessagePart::ToolUse {
+                id: "paired_id".into(),
+                name: "shell".into(),
+                input: serde_json::json!({}),
+            }],
+            metadata: MessageMetadata::default(),
+        });
+        agent.msg.messages.push(Message {
+            role: Role::User,
+            content: "[tool_result]".into(),
+            parts: vec![MessagePart::ToolResult {
+                tool_use_id: "paired_id".into(),
+                content: "ok".into(),
+                is_error: false,
+            }],
+            metadata: MessageMetadata::default(),
+        });
+
+        agent.flush_orphaned_tool_use_on_shutdown().await;
+
+        let history = agent
+            .memory_state
+            .memory
+            .as_ref()
+            .unwrap()
+            .sqlite()
+            .load_history(cid, 50)
+            .await
+            .unwrap();
+        assert!(
+            history.is_empty(),
+            "no tombstone must be persisted when all ToolUse parts are already paired"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `flush_orphaned_tool_use_on_shutdown()` called from `Agent::shutdown()` before `maybe_store_shutdown_summary()`
- Detects any unpaired `tool_use` parts in the last assistant message and persists tombstone `ToolResult` entries (`is_error=true`, `content="[Cancelled]"`) so the DB has a complete pair before the session closes
- Eliminates the noisy WARN messages on next session startup when a session ended mid-tool-call (e.g. stdin EOF in piped testing)

## Test plan

- [ ] 4 unit tests added in `flush_orphaned_tests` module in `tests.rs`: FO1 (no-op, no assistant message), FO2 (no-op, no ToolUse), FO3 (tombstone persisted for unpaired ToolUse), FO4 (no-op when already paired)
- [ ] All 7539 workspace tests pass
- [ ] Clippy clean, fmt clean

Closes #2628