### PR TITLE
fix(tools): utility gate explicit-request bypass and ML classifier false-positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - **MCP server instructions not injected into system prompt** (`#2637`): `append_mcp_prompt` now collects server-level instructions from all connected MCP servers via `McpManager::all_server_instructions()` and prepends them to the system prompt on every turn, regardless of whether the provider supports native tool_use. Added `all_server_instructions()` helper to `McpManager` that returns all stored instructions concatenated in stable order.
+- **Utility gate explicit-request bypass** (`#2636`): when the user message contains an unambiguous tool-invocation phrase (e.g. "using a tool", "call the X tool", "run the X tool"), the utility gate now sets `user_requested = true` and routes directly to `ToolCall`, bypassing the Retrieve→Respond cycle that previously caused the agent to respond with "I'm unable to use tools". Detection uses a LazyLock regex on the last user `MessagePart::Text` only — never on LLM call content or tool outputs, preserving the existing prompt-injection bypass protection.
+- **ML classifier false-positive on utility gate synthetic output** (`#2635`): `sanitize_tool_output` now skips the ML injection classifier for bodies that start with `[skipped]` or `[stopped]`. These strings are produced internally by the utility gate and are trusted content; classifying them produced noisy `WARN` log entries and incremented `classifier_tool_suspicious` metrics, which could mask real injection events.
 
 ## [0.18.3] - 2026-04-04
 

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -793,8 +793,9 @@ impl<C: Channel> Agent<C> {
 
         // Utility gate: score each call and recommend an action (#2477).
         // Fail-closed on scoring errors (None when scoring produces invalid result).
-        // user_requested is only true for explicit /tool slash commands — never set from
-        // LLM-requested calls to prevent prompt-injection bypass (C2 fix).
+        // user_requested is set when the user message explicitly requests tool invocation
+        // (e.g. "using a tool", "call the X tool"). Detected from the last user message only —
+        // never from LLM call content or tool outputs to prevent prompt-injection bypass (C2 fix).
         let utility_actions: Vec<zeph_tools::UtilityAction> = {
             #[allow(clippy::cast_possible_truncation)]
             let tokens_consumed =
@@ -802,6 +803,28 @@ impl<C: Channel> Agent<C> {
             // token_budget = 0 signals "unknown" to UtilityContext — cost component is zeroed.
             let token_budget: usize = 0;
             let tool_calls_this_turn = self.tool_orchestrator.recent_tool_calls.len();
+            // Extract the last user message text for explicit-request detection.
+            // We only read MessagePart::Text parts so tool outputs/thinking blocks are excluded.
+            let explicit_request = self
+                .msg
+                .messages
+                .iter()
+                .rfind(|m| m.role == zeph_llm::provider::Role::User)
+                .is_some_and(|m| {
+                    let text = m
+                        .parts
+                        .iter()
+                        .filter_map(|p| {
+                            if let zeph_llm::provider::MessagePart::Text { text } = p {
+                                Some(text.as_str())
+                            } else {
+                                None
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    zeph_tools::has_explicit_tool_request(&text)
+                });
             calls
                 .iter()
                 .enumerate()
@@ -814,8 +837,7 @@ impl<C: Channel> Agent<C> {
                         tool_calls_this_turn: tool_calls_this_turn + idx,
                         tokens_consumed,
                         token_budget,
-                        // Never set from LLM call content to prevent prompt-injection bypass.
-                        user_requested: false,
+                        user_requested: explicit_request,
                     };
                     let score = self.tool_orchestrator.utility_scorer.score(call, &ctx);
                     let action = self

--- a/crates/zeph-core/src/agent/tool_execution/sanitize.rs
+++ b/crates/zeph-core/src/agent/tool_execution/sanitize.rs
@@ -82,13 +82,18 @@ impl<C: Channel> Agent<C> {
 
         #[cfg(feature = "classifiers")]
         {
+            // Synthetic outputs from the utility gate are trusted internal content — never
+            // classify them. Only real tool output from external sources needs ML inspection.
+            let is_utility_gate_synthetic =
+                body.starts_with("[skipped]") || body.starts_with("[stopped]");
             let skip_ml = matches!(
                 memory_hint,
                 Some(
                     zeph_sanitizer::MemorySourceHint::ConversationHistory
                         | zeph_sanitizer::MemorySourceHint::LlmSummary
                 )
-            ) || is_policy_blocked_output(body);
+            ) || is_policy_blocked_output(body)
+                || is_utility_gate_synthetic;
             if !skip_ml && self.security.sanitizer.has_classifier_backend() {
                 let ml_verdict = self.security.sanitizer.classify_injection(body).await;
                 match ml_verdict {

--- a/crates/zeph-core/src/agent/tool_execution/tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests.rs
@@ -4929,6 +4929,65 @@ async fn utility_gate_disabled_does_not_produce_skipped_output() {
     );
 }
 
+// --- #2635: ML classifier must skip [skipped]/[stopped] synthetic outputs ---
+
+#[tokio::test]
+async fn sanitize_tool_output_skipped_prefix_no_injection_flags() {
+    use super::super::agent_tests::{
+        MockChannel, MockToolExecutor, create_test_registry, mock_provider,
+    };
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    let mut agent = super::super::Agent::new(provider, channel, registry, None, 5, executor);
+    let cfg = zeph_sanitizer::ContentIsolationConfig {
+        enabled: true,
+        flag_injection_patterns: true,
+        ..Default::default()
+    };
+    agent.security.sanitizer = zeph_sanitizer::ContentSanitizer::new(&cfg);
+    let body =
+        "[skipped] Tool call to list_directory skipped — utility policy recommends Retrieve.";
+    let (result, has_injection_flags) = agent.sanitize_tool_output(body, "list_directory").await;
+    assert!(
+        !has_injection_flags,
+        "[skipped] output must not trigger injection flags"
+    );
+    assert!(
+        !result.contains("[tool output blocked"),
+        "[skipped] output must not be blocked by sanitizer"
+    );
+}
+
+#[tokio::test]
+async fn sanitize_tool_output_stopped_prefix_no_injection_flags() {
+    use super::super::agent_tests::{
+        MockChannel, MockToolExecutor, create_test_registry, mock_provider,
+    };
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    let mut agent = super::super::Agent::new(provider, channel, registry, None, 5, executor);
+    let cfg = zeph_sanitizer::ContentIsolationConfig {
+        enabled: true,
+        flag_injection_patterns: true,
+        ..Default::default()
+    };
+    agent.security.sanitizer = zeph_sanitizer::ContentSanitizer::new(&cfg);
+    let body = "[stopped] Tool call to shell halted by the utility gate — budget exhausted or score below threshold 0.10.";
+    let (result, has_injection_flags) = agent.sanitize_tool_output(body, "shell").await;
+    assert!(
+        !has_injection_flags,
+        "[stopped] output must not trigger injection flags"
+    );
+    assert!(
+        !result.contains("[tool output blocked"),
+        "[stopped] output must not be blocked by sanitizer"
+    );
+}
+
 // --- PII NER circuit-breaker tests ---
 
 #[cfg(feature = "classifiers")]

--- a/crates/zeph-tools/src/lib.rs
+++ b/crates/zeph-tools/src/lib.rs
@@ -86,7 +86,9 @@ pub use shell::{
 pub use tool_filter::ToolFilter;
 pub use trust_gate::TrustGateExecutor;
 pub use trust_level::SkillTrustLevel;
-pub use utility::{UtilityAction, UtilityContext, UtilityScore, UtilityScorer};
+pub use utility::{
+    UtilityAction, UtilityContext, UtilityScore, UtilityScorer, has_explicit_tool_request,
+};
 pub use verifier::{
     DestructiveCommandVerifier, DestructiveVerifierConfig, FirewallVerifier,
     FirewallVerifierConfig, InjectionPatternVerifier, InjectionVerifierConfig,

--- a/crates/zeph-tools/src/utility.rs
+++ b/crates/zeph-tools/src/utility.rs
@@ -8,9 +8,38 @@
 
 use std::collections::HashMap;
 use std::hash::{DefaultHasher, Hash, Hasher};
+use std::sync::LazyLock;
+
+use regex::Regex;
 
 use crate::config::UtilityScoringConfig;
 use crate::executor::ToolCall;
+
+/// Returns `true` when a user message explicitly requests tool invocation.
+///
+/// Patterns are matched case-insensitively against the user message text.
+/// This is intentionally limited to unambiguous phrasings to avoid false positives
+/// that would incorrectly bypass the utility gate.
+///
+/// Safe to call on user-supplied text — does NOT bypass prompt-injection defences
+/// because those are enforced on tool OUTPUT paths, not on gate routing decisions.
+#[must_use]
+pub fn has_explicit_tool_request(user_message: &str) -> bool {
+    static RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?xi)
+            using\s+a\s+tool
+            | call\s+(the\s+)?[a-z_]+\s+tool
+            | use\s+(the\s+)?[a-z_]+\s+tool
+            | run\s+(the\s+)?[a-z_]+\s+tool
+            | invoke\s+(the\s+)?[a-z_]+\s+tool
+            | execute\s+(the\s+)?[a-z_]+\s+tool
+            ",
+        )
+        .expect("static regex is valid")
+    });
+    RE.is_match(user_message)
+}
 
 /// Estimated gain for known tool categories.
 ///
@@ -66,8 +95,9 @@ pub struct UtilityContext {
     pub tokens_consumed: usize,
     /// Token budget for the current turn. 0 = budget unknown (cost component treated as 0).
     pub token_budget: usize,
-    /// True only when the tool was explicitly invoked via a `/tool` slash command.
-    /// Must NOT be set based on tool names found inside user message text or tool outputs.
+    /// True when the user explicitly requested tool invocation — either via a `/tool` slash
+    /// command or when the user message contains an unambiguous tool-invocation phrase detected
+    /// by [`has_explicit_tool_request`]. Must NOT be set from LLM call content or tool outputs.
     pub user_requested: bool,
 }
 
@@ -648,5 +678,56 @@ mod tests {
             scorer.recommend_action(Some(&score), &ctx),
             UtilityAction::Respond
         );
+    }
+
+    // ── has_explicit_tool_request tests ──────────────────────────────────────
+
+    #[test]
+    fn explicit_request_using_a_tool() {
+        assert!(has_explicit_tool_request(
+            "Please list the files in the current directory using a tool"
+        ));
+    }
+
+    #[test]
+    fn explicit_request_call_the_tool() {
+        assert!(has_explicit_tool_request("call the list_directory tool"));
+    }
+
+    #[test]
+    fn explicit_request_use_the_tool() {
+        assert!(has_explicit_tool_request("use the shell tool to run ls"));
+    }
+
+    #[test]
+    fn explicit_request_run_the_tool() {
+        assert!(has_explicit_tool_request("run the bash tool"));
+    }
+
+    #[test]
+    fn explicit_request_invoke_the_tool() {
+        assert!(has_explicit_tool_request("invoke the search_code tool"));
+    }
+
+    #[test]
+    fn explicit_request_execute_the_tool() {
+        assert!(has_explicit_tool_request("execute the grep tool for me"));
+    }
+
+    #[test]
+    fn explicit_request_case_insensitive() {
+        assert!(has_explicit_tool_request("USING A TOOL to find files"));
+    }
+
+    #[test]
+    fn explicit_request_no_match_plain_message() {
+        assert!(!has_explicit_tool_request("what is the weather today?"));
+    }
+
+    #[test]
+    fn explicit_request_no_match_tool_mentioned_without_invocation() {
+        assert!(!has_explicit_tool_request(
+            "the shell tool is very useful in general"
+        ));
     }
 }


### PR DESCRIPTION
## Summary

Fixes two related bugs in the utility gate subsystem:

- **#2636 P2**: when the user message contains an unambiguous tool-invocation phrase (e.g. "using a tool", "call the X tool", "run the X tool"), the utility gate now sets `user_requested = true`, routing directly to `ToolCall` and bypassing the Retrieve→Respond cycle that previously caused the agent to respond with "I am unable to use tools".
- **#2635 P3**: `sanitize_tool_output` now skips the ML injection classifier when the body starts with `[skipped]` or `[stopped]`. These strings are produced internally by the utility gate and are trusted; classifying them generated false-positive WARN logs and inflated the `classifier_tool_suspicious` metric.

## Changes

- `zeph-tools/src/utility.rs`: add `has_explicit_tool_request(user_message: &str) -> bool` using a `LazyLock<Regex>` matching unambiguous invocation phrases (case-insensitive)
- `zeph-core/src/agent/tool_execution/native.rs`: detect explicit tool intent from the last user `MessagePart::Text` and set `user_requested` accordingly; detection is limited to user text parts only — never LLM call content or tool outputs
- `zeph-core/src/agent/tool_execution/sanitize.rs`: add `is_utility_gate_synthetic` guard before the ML classifier call
- 11 new unit tests covering both fixes

## Test plan

- [ ] All 7829 unit tests pass (`cargo nextest run --workspace --features full --lib --bins`)
- [ ] Clippy clean (`cargo clippy --all-targets --features full --workspace -- -D warnings`)
- [ ] Live session: `"Please list the files in the current directory using a tool"` → tool executes immediately (no Retrieve→Respond loop)
- [ ] Live session: utility gate Retrieve action → no `WARN ML classifier: suspicious tool output` in logs