### PR TITLE
fix(mcp): inject server instructions into system prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **MCP server instructions not injected into system prompt** (`#2637`): `append_mcp_prompt` now collects server-level instructions from all connected MCP servers via `McpManager::all_server_instructions()` and prepends them to the system prompt on every turn, regardless of whether the provider supports native tool_use. Added `all_server_instructions()` helper to `McpManager` that returns all stored instructions concatenated in stable order.
+
 ## [0.18.3] - 2026-04-04
 
 ### Added

--- a/crates/zeph-core/src/agent/mcp.rs
+++ b/crates/zeph-core/src/agent/mcp.rs
@@ -329,6 +329,13 @@ impl<C: Channel> Agent<C> {
             m.mcp_server_count = mcp_server_count;
             m.mcp_connected_count = mcp_connected_count;
         });
+        if let Some(ref manager) = self.mcp.manager {
+            let instructions = manager.all_server_instructions().await;
+            if !instructions.is_empty() {
+                system_prompt.push_str("\n\n");
+                system_prompt.push_str(&instructions);
+            }
+        }
         // When native tool_use is active, MCP tools flow through the executor chain
         // as ToolDefinitions — skip text prompt injection to avoid duplication.
         if self.provider.supports_tool_use() {

--- a/crates/zeph-mcp/src/manager.rs
+++ b/crates/zeph-mcp/src/manager.rs
@@ -1217,6 +1217,14 @@ impl McpManager {
         Ok(())
     }
 
+    /// Return all non-empty server instructions, concatenated with double newlines.
+    pub async fn all_server_instructions(&self) -> String {
+        let map = self.server_instructions.read().await;
+        let mut parts: Vec<&str> = map.values().map(String::as_str).collect();
+        parts.sort_unstable();
+        parts.join("\n\n")
+    }
+
     /// Return sorted list of connected server IDs.
     pub async fn list_servers(&self) -> Vec<String> {
         let clients = self.clients.read().await;


### PR DESCRIPTION
## Summary

- Add `McpManager::all_server_instructions()` that collects and joins instructions from all connected MCP servers in stable order
- In `append_mcp_prompt()`, inject server instructions into the system prompt before the `supports_tool_use()` early-return guard, ensuring instructions are always present regardless of provider capabilities

## Root cause

`append_mcp_prompt()` returned early when `supports_tool_use()` was true, silently dropping server-level instructions. `McpManager::server_instructions()` was never called in `zeph-core`.

## Test plan

- [x] `cargo +nightly fmt --check` — pass
- [x] `cargo clippy --all-targets --workspace -- -D warnings` — pass (0 warnings)
- [x] `cargo nextest run --workspace --lib --bins` — 7539/7539 passed
- [ ] Live session test: connect Todoist MCP, verify server instructions appear in system prompt and LLM no longer responds "no access to Todoist"

Fixes #2637