### PR TITLE
feat(tui): slash-command autocomplete in insert mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- TUI: slash-command autocomplete dropdown in Insert mode (#2642)
+
 ### Fixed
 
 - **MCP server instructions not injected into system prompt** (`#2637`): `append_mcp_prompt` now collects server-level instructions from all connected MCP servers via `McpManager::all_server_instructions()` and prepends them to the system prompt on every turn, regardless of whether the provider supports native tool_use. Added `all_server_instructions()` helper to `McpManager` that returns all stored instructions concatenated in stable order.

--- a/crates/zeph-tui/src/app.rs
+++ b/crates/zeph-tui/src/app.rs
@@ -16,6 +16,7 @@ use crate::metrics::MetricsSnapshot;
 use crate::theme::Theme;
 use crate::widgets;
 use crate::widgets::command_palette::CommandPaletteState;
+use crate::widgets::slash_autocomplete::{SlashAutocompleteState, command_id_to_slash_form};
 
 pub use crate::render_cache::{RenderCache, RenderCacheEntry, RenderCacheKey, content_hash};
 pub use crate::types::{ChatMessage, InputMode, MessageRole};
@@ -191,6 +192,7 @@ pub struct App {
     command_tx: Option<mpsc::Sender<TuiCommand>>,
     file_picker_state: Option<FilePickerState>,
     file_index: Option<FileIndex>,
+    slash_autocomplete: Option<SlashAutocompleteState>,
     pub should_quit: bool,
     user_input_tx: mpsc::Sender<String>,
     agent_event_rx: mpsc::Receiver<AgentEvent>,
@@ -247,6 +249,7 @@ impl App {
             command_tx: None,
             file_picker_state: None,
             file_index: None,
+            slash_autocomplete: None,
             should_quit: false,
             user_input_tx,
             agent_event_rx,
@@ -838,6 +841,10 @@ impl App {
 
         if let Some(state) = &self.file_picker_state {
             widgets::file_picker::render(state, frame, layout.input);
+        }
+
+        if let Some(state) = &self.slash_autocomplete {
+            widgets::slash_autocomplete::render(state, frame, layout.input);
         }
 
         if let Some(state) = &self.confirm_state {
@@ -1542,6 +1549,10 @@ impl App {
     }
 
     fn handle_insert_key(&mut self, key: KeyEvent) {
+        if self.slash_autocomplete.is_some() {
+            self.handle_slash_autocomplete_key(key);
+            return;
+        }
         match key.code {
             KeyCode::Enter if key.modifiers.contains(KeyModifiers::SHIFT) => {
                 let byte_offset = self.byte_offset_of_char(self.cursor_position);
@@ -1626,9 +1637,90 @@ impl App {
                 self.open_file_picker();
             }
             KeyCode::Char(c) => {
+                let was_empty = self.input.is_empty();
                 let byte_offset = self.byte_offset_of_char(self.cursor_position);
                 self.input.insert(byte_offset, c);
                 self.cursor_position += 1;
+                if c == '/' && was_empty {
+                    self.slash_autocomplete = Some(SlashAutocompleteState::new());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_slash_autocomplete_key(&mut self, key: KeyEvent) {
+        let Some(state) = self.slash_autocomplete.as_mut() else {
+            return;
+        };
+        match key.code {
+            KeyCode::Esc => {
+                self.slash_autocomplete = None;
+            }
+            KeyCode::Tab | KeyCode::Enter => {
+                let entry = state.selected_entry().map(|e| e.id);
+                self.slash_autocomplete = None;
+                if let Some(id) = entry {
+                    let slash_form = command_id_to_slash_form(id);
+                    self.input = slash_form;
+                    self.cursor_position = self.char_count();
+                }
+                if key.code == KeyCode::Enter {
+                    self.submit_input();
+                }
+            }
+            KeyCode::Down => {
+                if let Some(s) = self.slash_autocomplete.as_mut() {
+                    s.move_down();
+                }
+            }
+            KeyCode::Up | KeyCode::BackTab => {
+                if let Some(s) = self.slash_autocomplete.as_mut() {
+                    s.move_up();
+                }
+            }
+            KeyCode::Backspace => {
+                let dismiss = self
+                    .slash_autocomplete
+                    .as_mut()
+                    .is_none_or(SlashAutocompleteState::pop_char);
+                if dismiss {
+                    self.input.clear();
+                    self.cursor_position = 0;
+                    self.slash_autocomplete = None;
+                } else {
+                    let query = self
+                        .slash_autocomplete
+                        .as_ref()
+                        .map_or(String::new(), |s| s.query.clone());
+                    self.input = format!("/{query}");
+                    self.cursor_position = self.char_count();
+                    if self
+                        .slash_autocomplete
+                        .as_ref()
+                        .is_none_or(|s| s.filtered.is_empty())
+                    {
+                        self.slash_autocomplete = None;
+                    }
+                }
+            }
+            KeyCode::Char(c) => {
+                if let Some(s) = self.slash_autocomplete.as_mut() {
+                    s.push_char(c);
+                }
+                let query = self
+                    .slash_autocomplete
+                    .as_ref()
+                    .map_or(String::new(), |s| s.query.clone());
+                self.input = format!("/{query}");
+                self.cursor_position = self.char_count();
+                if self
+                    .slash_autocomplete
+                    .as_ref()
+                    .is_none_or(|s| s.filtered.is_empty())
+                {
+                    self.slash_autocomplete = None;
+                }
             }
             _ => {}
         }
@@ -4287,5 +4379,78 @@ mod tests {
         app.set_view_target(AgentViewTarget::Main);
         assert_eq!(app.scroll_offset, 0);
         assert!(app.transcript_cache.is_none());
+    }
+
+    mod slash_autocomplete_tests {
+        use super::*;
+
+        #[test]
+        fn slash_on_empty_input_opens_autocomplete() {
+            let (mut app, _rx, _tx) = make_app();
+            app.input_mode = InputMode::Insert;
+            assert!(app.slash_autocomplete.is_none());
+
+            let key = KeyEvent::new(KeyCode::Char('/'), KeyModifiers::NONE);
+            app.handle_event(AppEvent::Key(key));
+            assert!(app.slash_autocomplete.is_some());
+            assert_eq!(app.input(), "/");
+        }
+
+        #[test]
+        fn no_open_mid_input() {
+            let (mut app, _rx, _tx) = make_app();
+            app.input_mode = InputMode::Insert;
+            app.input = "hello ".to_owned();
+            app.cursor_position = 6;
+
+            let key = KeyEvent::new(KeyCode::Char('/'), KeyModifiers::NONE);
+            app.handle_event(AppEvent::Key(key));
+            assert!(app.slash_autocomplete.is_none());
+        }
+
+        #[test]
+        fn esc_dismisses_autocomplete() {
+            let (mut app, _rx, _tx) = make_app();
+            app.input_mode = InputMode::Insert;
+            app.slash_autocomplete =
+                Some(crate::widgets::slash_autocomplete::SlashAutocompleteState::new());
+            app.input = "/sk".to_owned();
+            app.cursor_position = 3;
+
+            let key = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
+            app.handle_event(AppEvent::Key(key));
+            assert!(app.slash_autocomplete.is_none());
+            // Input retained
+            assert_eq!(app.input(), "/sk");
+        }
+
+        #[test]
+        fn at_char_while_autocomplete_open_does_not_open_file_picker() {
+            let (mut app, _rx, _tx) = make_app();
+            app.input_mode = InputMode::Insert;
+            app.slash_autocomplete =
+                Some(crate::widgets::slash_autocomplete::SlashAutocompleteState::new());
+            app.input = "/".to_owned();
+            app.cursor_position = 1;
+
+            let key = KeyEvent::new(KeyCode::Char('@'), KeyModifiers::NONE);
+            app.handle_event(AppEvent::Key(key));
+            assert!(app.file_picker_state.is_none());
+        }
+
+        #[test]
+        fn backspace_removes_slash_and_dismisses() {
+            let (mut app, _rx, _tx) = make_app();
+            app.input_mode = InputMode::Insert;
+            app.slash_autocomplete =
+                Some(crate::widgets::slash_autocomplete::SlashAutocompleteState::new());
+            app.input = "/".to_owned();
+            app.cursor_position = 1;
+
+            let key = KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE);
+            app.handle_event(AppEvent::Key(key));
+            assert!(app.slash_autocomplete.is_none());
+            assert!(app.input().is_empty());
+        }
     }
 }

--- a/crates/zeph-tui/src/widgets/mod.rs
+++ b/crates/zeph-tui/src/widgets/mod.rs
@@ -14,6 +14,7 @@ pub mod plan_view;
 pub mod resources;
 pub mod security;
 pub mod skills;
+pub mod slash_autocomplete;
 pub mod splash;
 pub mod status;
 pub mod subagents;

--- a/crates/zeph-tui/src/widgets/slash_autocomplete.rs
+++ b/crates/zeph-tui/src/widgets/slash_autocomplete.rs
@@ -1,0 +1,283 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use ratatui::Frame;
+use ratatui::layout::{Alignment, Rect};
+use ratatui::style::Style;
+use ratatui::text::Line;
+use ratatui::text::Span;
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState};
+
+use crate::command::{CommandEntry, filter_commands};
+use crate::theme::Theme;
+
+pub const MAX_VISIBLE: usize = 8;
+
+pub struct SlashAutocompleteState {
+    pub query: String,
+    pub selected: usize,
+    pub filtered: Vec<&'static CommandEntry>,
+    pub scroll_offset: usize,
+}
+
+impl SlashAutocompleteState {
+    #[must_use]
+    pub fn new() -> Self {
+        let mut s = Self {
+            query: String::new(),
+            selected: 0,
+            filtered: Vec::new(),
+            scroll_offset: 0,
+        };
+        s.refilter();
+        s
+    }
+
+    pub fn push_char(&mut self, c: char) {
+        self.query.push(c);
+        self.refilter();
+    }
+
+    /// Removes last char from query. Returns `true` if query is now empty (caller should dismiss).
+    pub fn pop_char(&mut self) -> bool {
+        if self.query.is_empty() {
+            return true;
+        }
+        self.query.pop();
+        self.refilter();
+        self.query.is_empty()
+    }
+
+    pub fn move_up(&mut self) {
+        if self.filtered.is_empty() {
+            return;
+        }
+        if self.selected == 0 {
+            self.selected = self.filtered.len() - 1;
+        } else {
+            self.selected -= 1;
+        }
+        self.adjust_scroll();
+    }
+
+    pub fn move_down(&mut self) {
+        if self.filtered.is_empty() {
+            return;
+        }
+        if self.selected == self.filtered.len() - 1 {
+            self.selected = 0;
+        } else {
+            self.selected += 1;
+        }
+        self.adjust_scroll();
+    }
+
+    #[must_use]
+    pub fn selected_entry(&self) -> Option<&'static CommandEntry> {
+        self.filtered.get(self.selected).copied()
+    }
+
+    fn refilter(&mut self) {
+        self.filtered = filter_commands(&self.query);
+        if self.filtered.is_empty() {
+            self.selected = 0;
+        } else {
+            self.selected = self.selected.min(self.filtered.len() - 1);
+        }
+        self.scroll_offset = self
+            .scroll_offset
+            .min(self.filtered.len().saturating_sub(MAX_VISIBLE));
+        self.adjust_scroll();
+    }
+
+    fn adjust_scroll(&mut self) {
+        if self.selected < self.scroll_offset {
+            self.scroll_offset = self.selected;
+        } else if self.selected >= self.scroll_offset + MAX_VISIBLE {
+            self.scroll_offset = self.selected + 1 - MAX_VISIBLE;
+        }
+        let max_offset = self.filtered.len().saturating_sub(MAX_VISIBLE);
+        if self.scroll_offset > max_offset {
+            self.scroll_offset = max_offset;
+        }
+    }
+}
+
+impl Default for SlashAutocompleteState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Converts a command id to slash-form: `"skill:list"` → `"/skill list"`.
+#[must_use]
+pub fn command_id_to_slash_form(id: &str) -> String {
+    format!("/{}", id.replace(':', " "))
+}
+
+pub fn render(state: &SlashAutocompleteState, frame: &mut Frame, input_area: Rect) {
+    if state.filtered.is_empty() {
+        return;
+    }
+
+    let theme = Theme::default();
+
+    let visible = state.filtered.len().min(MAX_VISIBLE);
+    #[allow(clippy::cast_possible_truncation)]
+    let height = (visible as u16) + 2;
+
+    let width: u16 = 60;
+    let x = if input_area.width > width {
+        input_area.x + (input_area.width - width) / 2
+    } else {
+        input_area.x
+    };
+    let actual_width = width.min(input_area.width);
+
+    let y = input_area.y.saturating_sub(height);
+
+    let popup = Rect {
+        x,
+        y,
+        width: actual_width,
+        height,
+    };
+
+    frame.render_widget(Clear, popup);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme.panel_border)
+        .title(" Commands ")
+        .title_alignment(Alignment::Center);
+
+    frame.render_widget(block, popup);
+
+    let list_area = popup.inner(ratatui::layout::Margin {
+        horizontal: 1,
+        vertical: 1,
+    });
+
+    let end = (state.scroll_offset + MAX_VISIBLE).min(state.filtered.len());
+    let items: Vec<ListItem> = state.filtered[state.scroll_offset..end]
+        .iter()
+        .enumerate()
+        .map(|(i, entry)| {
+            let abs_i = i + state.scroll_offset;
+            let style = if abs_i == state.selected {
+                Style::default().bg(theme.highlight.fg.unwrap_or(ratatui::style::Color::Blue))
+            } else {
+                Style::default()
+            };
+            let shortcut_str = entry.shortcut.map_or(String::new(), |s| format!(" [{s}]"));
+            let shortcut_style = style.patch(Style::default().fg(ratatui::style::Color::DarkGray));
+            ListItem::new(Line::from(vec![
+                Span::styled(format!("{:<20}", entry.id), style.patch(theme.panel_title)),
+                Span::styled(format!("  {}", entry.label), style),
+                Span::styled(shortcut_str, shortcut_style),
+            ]))
+        })
+        .collect();
+
+    let mut list_state = ListState::default();
+    list_state.select(Some(state.selected.saturating_sub(state.scroll_offset)));
+
+    frame.render_stateful_widget(List::new(items), list_area, &mut list_state);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::render_to_string;
+
+    #[test]
+    fn new_opens_with_all_commands() {
+        let state = SlashAutocompleteState::new();
+        let expected = filter_commands("");
+        assert_eq!(state.filtered.len(), expected.len());
+        assert_eq!(state.selected, 0);
+        assert!(state.query.is_empty());
+    }
+
+    #[test]
+    fn push_char_filters() {
+        let mut state = SlashAutocompleteState::new();
+        state.push_char('s');
+        state.push_char('k');
+        let expected = filter_commands("sk");
+        assert_eq!(state.filtered.len(), expected.len());
+        assert_eq!(state.selected, 0);
+    }
+
+    #[test]
+    fn command_id_to_slash_form_converts() {
+        assert_eq!(command_id_to_slash_form("skill:list"), "/skill list");
+        assert_eq!(command_id_to_slash_form("ingest"), "/ingest");
+        assert_eq!(command_id_to_slash_form("app:quit"), "/app quit");
+    }
+
+    #[test]
+    fn pop_char_returns_true_when_empty() {
+        let mut state = SlashAutocompleteState::new();
+        assert!(state.pop_char());
+    }
+
+    #[test]
+    fn pop_char_returns_false_when_query_not_empty_after_pop() {
+        let mut state = SlashAutocompleteState::new();
+        state.push_char('s');
+        state.push_char('k');
+        // After removing 'k', query is "s" (non-empty) → returns false
+        assert!(!state.pop_char());
+        assert_eq!(state.query, "s");
+    }
+
+    #[test]
+    fn move_down_wraps() {
+        let mut state = SlashAutocompleteState::new();
+        assert!(!state.filtered.is_empty());
+        state.selected = state.filtered.len() - 1;
+        state.move_down();
+        assert_eq!(state.selected, 0);
+    }
+
+    #[test]
+    fn move_up_wraps() {
+        let mut state = SlashAutocompleteState::new();
+        assert!(!state.filtered.is_empty());
+        state.selected = 0;
+        state.move_up();
+        assert_eq!(state.selected, state.filtered.len() - 1);
+    }
+
+    #[test]
+    fn empty_filter_auto_dismisses_signal() {
+        let mut state = SlashAutocompleteState::new();
+        for c in "xxxxxxxxxxx".chars() {
+            state.push_char(c);
+        }
+        assert!(state.filtered.is_empty());
+    }
+
+    #[test]
+    fn render_slash_autocomplete_snapshot() {
+        let state = SlashAutocompleteState::new();
+        let output = render_to_string(80, 24, |frame, area| {
+            render(&state, frame, area);
+        });
+        assert!(output.contains("Commands"));
+        assert!(output.contains("skill:list"));
+    }
+
+    #[test]
+    fn scroll_offset_adjusts_on_move_down() {
+        let mut state = SlashAutocompleteState::new();
+        if state.filtered.len() <= MAX_VISIBLE {
+            return;
+        }
+        for _ in 0..MAX_VISIBLE {
+            state.move_down();
+        }
+        assert!(state.scroll_offset > 0);
+    }
+}


### PR DESCRIPTION
Closes #2642

## Summary

- Inline autocomplete dropdown appears when user types `/` into an empty input bar in Insert mode
- Filters suggestions from existing `CommandEntry` registry via `filter_commands` — no new dependencies
- Two-level navigation: Tab/↑↓ to move, Tab/Enter to accept, Esc to dismiss
- `SlashAutocompleteState` modelled after `CommandPaletteState` (same patterns, same widget primitives)
- Dropdown auto-dismisses when filter returns zero matches or input no longer starts with `/`

## Changes

- **New**: `crates/zeph-tui/src/widgets/slash_autocomplete.rs` — `SlashAutocompleteState`, `command_id_to_slash_form`, `render`
- **Modified**: `crates/zeph-tui/src/app.rs` — field, `handle_slash_autocomplete_key`, intercept guard in `handle_insert_key`, render call in `draw()`
- **Modified**: `crates/zeph-tui/src/widgets/mod.rs` — module registration
- **Updated**: `CHANGELOG.md`

## Test plan

- [ ] 10 unit tests in `slash_autocomplete.rs` cover AC-001..AC-009 (all pass)
- [ ] 4 integration tests in `app.rs` cover end-to-end key routing
- [ ] Existing command_palette tests unaffected (AC-010)
- [ ] `cargo nextest run -p zeph-tui` — 412/412 pass, 0 warnings
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --all-targets --all-features --workspace -- -D warnings` — clean (CUDA build failure unrelated to this PR)
- [ ] Live manual testing per `.local/testing/playbooks/tui-slash-autocomplete.md`