### PR TITLE
fix(index): offload directory walk to spawn_blocking to unblock TUI startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **TUI blocked until code indexing completed** (`#2647`): the directory walk inside `index_project` was performed synchronously on a tokio worker thread, starving the TUI render loop. The walk and `current_files` set construction are now offloaded via `tokio::task::spawn_blocking`; a `JoinError` (panic in the walk) is mapped to `IndexError::Other`. The TUI now starts and renders immediately while indexing proceeds in the background.
+
 - **Code indexer always indexed `current_dir` regardless of config** (`#2646`): `apply_code_indexer` now resolves `workspace_root` from `IndexConfig` (canonicalized) and falls back to `current_dir()` only when the field is `None`. Both the background indexing task and the file watcher use the same resolved root.
 - **Sequential per-chunk Qdrant upserts caused slow full-project indexing** (`#2647`): `index_project` now processes files concurrently via `futures::stream::buffer_unordered(concurrency)`. Within each file, new chunks are collected, embedded in order, and upserted in a single batched `Qdrant` call + single `SQLite` transaction via the new `CodeStore::upsert_chunks_batch` method, reducing per-chunk overhead significantly.
 - **MCP server instructions not injected into system prompt** (`#2637`): `append_mcp_prompt` now collects server-level instructions from all connected MCP servers via `McpManager::all_server_instructions()` and prepends them to the system prompt on every turn, regardless of whether the provider supports native tool_use. Added `all_server_instructions()` helper to `McpManager` that returns all stored instructions concatenated in stable order.

--- a/crates/zeph-index/src/indexer.rs
+++ b/crates/zeph-index/src/indexer.rs
@@ -95,27 +95,33 @@ impl CodeIndexer {
         let vector_size = u64::try_from(probe.len())?;
         self.store.ensure_collection(vector_size).await?;
 
-        let entries: Vec<_> = ignore::WalkBuilder::new(root)
-            .hidden(true)
-            .git_ignore(true)
-            .build()
-            .flatten()
-            .filter(|e| e.file_type().is_some_and(|ft| ft.is_file()) && is_indexable(e.path()))
-            .collect();
+        let root_buf = root.to_path_buf();
+        let (entries, current_files) = tokio::task::spawn_blocking(move || {
+            let entries: Vec<_> = ignore::WalkBuilder::new(&root_buf)
+                .hidden(true)
+                .git_ignore(true)
+                .build()
+                .flatten()
+                .filter(|e| e.file_type().is_some_and(|ft| ft.is_file()) && is_indexable(e.path()))
+                .collect();
+
+            let mut current_files: HashSet<String> = HashSet::new();
+            for entry in &entries {
+                let rel_path = entry
+                    .path()
+                    .strip_prefix(&root_buf)
+                    .unwrap_or(entry.path())
+                    .to_string_lossy()
+                    .to_string();
+                current_files.insert(rel_path);
+            }
+            (entries, current_files)
+        })
+        .await
+        .map_err(|e| IndexError::Other(format!("directory walk panicked: {e}")))?;
 
         let total = entries.len();
         tracing::info!(total, "indexing started");
-
-        let mut current_files: HashSet<String> = HashSet::new();
-        for entry in &entries {
-            let rel_path = entry
-                .path()
-                .strip_prefix(root)
-                .unwrap_or(entry.path())
-                .to_string_lossy()
-                .to_string();
-            current_files.insert(rel_path);
-        }
 
         let concurrency = self.config.concurrency;
         let store = self.store.clone();


### PR DESCRIPTION
## Summary

- The synchronous `ignore::WalkBuilder` walk in `index_project` ran on a tokio worker thread, blocking it for the duration of directory traversal. On repos with many files this starved the TUI render loop (250 ms tick), preventing the interface from appearing until indexing finished.
- Directory walk and `current_files` HashSet construction are now wrapped in `tokio::task::spawn_blocking`. `JoinError` (closure panic) is mapped to `IndexError::Other`.
- All async stream processing (`embed`/`upsert`, `buffer_unordered`) is unchanged.
- TUI starts and renders immediately; indexing progress updates continue via the existing `IndexProgress` watch channel.

## Changes

- `crates/zeph-index/src/indexer.rs`: wrap lines 98-118 in `spawn_blocking`
- `CHANGELOG.md`: document fix under `[Unreleased]`

## Test plan

- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --features full --lib --bins` — 7893/7893 pass
- [ ] `cargo clippy -p zeph-index --all-features -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean
- [ ] Live TUI session: interface appears immediately on startup, status bar shows "Indexing codebase... X/Y files (Z%)" while indexing proceeds in background