### PR TITLE
fix(memory): move embed_missing to background, add early Ctrl+C handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **`embed_missing` blocks startup** (`#2662`): the embedding backfill was running synchronously in `build_memory`, causing startup to hang for minutes and consuming excessive RAM. It is now spawned as a background task via `zeph_core::bootstrap::spawn_embed_backfill` with a 300s timeout. An early `Ctrl+C` handler (`std::process::exit(130)`) is registered before `build_memory` so the process can be killed during the init phase; the handler is aborted once the full signal handler is wired. TUI shows "Backfilling embeddings..." status while the task runs.
+
 - **TUI status bar stuck on last init message** (`#2658`): `tui_status!` macro used `try_send` which could silently drop messages; switched to `send().await`. After `load_history` completes, an empty status string is sent immediately so the status bar clears before `run_tui_agent` takes over, eliminating the "Loading conversation history..." label lingering until the warmup task ran.
 - **TUI startup race condition** (`#2660`): initial "Starting up…" status was sent via `tokio::spawn`, creating a race where the message could arrive after later status updates or be lost entirely; replaced with a direct `try_send` (channel is empty at this point, capacity 256).
 - **Blocking `compute_skill_hash` loop on tokio thread** (`#2660`): trust DB population loop called `compute_skill_hash` (which does `std::fs::read`) synchronously inside an async `for` loop, blocking the tokio executor for every loaded skill; all FS reads are now batched in a single `spawn_blocking` call, followed by async DB upserts.

--- a/crates/zeph-core/src/bootstrap/mod.rs
+++ b/crates/zeph-core/src/bootstrap/mod.rs
@@ -304,11 +304,6 @@ impl AppBuilder {
 
         if self.config.memory.semantic.enabled && memory.is_vector_store_connected().await {
             tracing::info!("semantic memory enabled, vector store connected");
-            match memory.embed_missing().await {
-                Ok(n) if n > 0 => tracing::info!("backfilled {n} missing embedding(s)"),
-                Ok(_) => {}
-                Err(e) => tracing::warn!("embed_missing failed: {e:#}"),
-            }
         }
 
         if self.config.memory.graph.enabled {
@@ -337,7 +332,36 @@ impl AppBuilder {
 
         Ok(memory)
     }
+}
 
+/// Spawn a background task that backfills missing embeddings.
+///
+/// Fire-and-forget: the caller does not need to await the returned handle.
+/// The task runs for at most `timeout_secs` seconds.
+///
+/// # Errors
+///
+/// The returned `JoinHandle` resolves to `()` — errors are logged internally.
+pub fn spawn_embed_backfill(
+    memory: Arc<SemanticMemory>,
+    timeout_secs: u64,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(timeout_secs),
+            memory.embed_missing(),
+        )
+        .await;
+        match result {
+            Ok(Ok(n)) if n > 0 => tracing::info!("backfilled {n} missing embedding(s)"),
+            Ok(Ok(_)) => {}
+            Ok(Err(e)) => tracing::warn!("embed_missing failed: {e:#}"),
+            Err(_) => tracing::warn!("embed_missing timed out after {timeout_secs}s"),
+        }
+    })
+}
+
+impl AppBuilder {
     fn build_admission_control(
         &self,
         fallback_provider: &AnyProvider,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -654,9 +654,37 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         };
     }
 
+    // Early Ctrl+C: terminate during init before the full handler is wired.
+    let early_ctrlc = tokio::spawn(async {
+        let _ = tokio::signal::ctrl_c().await;
+        std::process::exit(130);
+    });
+
     #[cfg(feature = "tui")]
     tui_status!("Loading memory...");
     let memory = std::sync::Arc::new(app.build_memory(&provider).await?);
+    {
+        let memory_arc = std::sync::Arc::clone(&memory);
+        #[cfg(feature = "tui")]
+        let embed_tx = early_tui_guard.0.as_ref().map(|e| e.agent_tx.clone());
+        // Outer spawn sends TUI status updates; inner spawn_embed_backfill does the actual work.
+        let _embed_status_handle = tokio::spawn(async move {
+            #[cfg(feature = "tui")]
+            if let Some(ref tx) = embed_tx {
+                let _ = tx
+                    .send(zeph_tui::AgentEvent::Status(
+                        "Backfilling embeddings...".into(),
+                    ))
+                    .await;
+            }
+            let handle = zeph_core::bootstrap::spawn_embed_backfill(memory_arc, 300);
+            handle.await.ok();
+            #[cfg(feature = "tui")]
+            if let Some(ref tx) = embed_tx {
+                let _ = tx.send(zeph_tui::AgentEvent::Status(String::new())).await;
+            }
+        });
+    }
     #[cfg(feature = "tui")]
     tui_status!("Connecting tools...");
     let tool_setup = agent_setup::build_tool_setup(
@@ -1875,6 +1903,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     agent.init_semantic_index().await;
 
     agent_setup::spawn_ctrl_c_handler(agent.cancel_signal(), shutdown_tx);
+    early_ctrlc.abort();
     #[cfg(feature = "tui")]
     tui_status!("Loading conversation history...");
     // load_history is the last fallible call before run_tui_agent.


### PR DESCRIPTION
## Summary

- **Remove `embed_missing()` from startup** — it no longer blocks `build_memory`. Embedding backfill now runs in a background `tokio::spawn` task via `spawn_embed_backfill(memory, timeout_secs)`
- **`spawn_embed_backfill`** — new public function in `zeph-core::bootstrap`; runs with a 300s timeout; sends TUI status "Backfilling embeddings..." / "" (clear) via `agent_tx` when available
- **Early Ctrl+C handler** — simple `exit(130)` task spawned before `build_memory`, aborted after `spawn_ctrl_c_handler` is registered in phase 2. Ensures Ctrl+C terminates the process at any point during initialization

## Root Cause

`embed_missing()` in `build_memory` made serial HTTP requests to Ollama (one per chunk, no batching) for up to 1000 messages. Ollama loaded `qwen3-embedding:latest` (~2-4GB) on first request. No Ctrl+C handler existed during phase-1 init.

## Test Plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --features full --workspace -- -D warnings` — clean
- [ ] `cargo nextest run --workspace --features full --lib --bins` — 7897/7897 PASS
- [ ] Live TUI test: startup completes in < 2s; "Backfilling embeddings..." appears briefly in status bar if backlog exists; Ctrl+C during startup terminates process immediately

Closes #2662