### PR TITLE
fix(index): add embed_provider to IndexConfig to prevent guardrail contention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `IndexConfig`: new `workspace_root` (`Option<PathBuf>`), `concurrency` (default 4), and `batch_size` (default 32) config fields (#2646); `workspace_root` overrides the previous hard-coded `current_dir()` fallback so the indexer targets the configured project root.
 - `IndexerConfig`: `concurrency` and `batch_size` fields mirror the new `IndexConfig` fields and are passed through from `apply_code_indexer`.
 - **`IndexConfig`/`IndexerConfig`: `memory_batch_size` and `max_file_bytes` fields** (`#2664`): `index_project` now processes files in bounded memory batches (default 32 files per batch); after each batch the stream is dropped and the tokio executor yields so the allocator can reclaim pages. Files larger than `max_file_bytes` (default 512 KiB) are skipped entirely. Both fields are wired through `apply_code_indexer`.
+- **`IndexConfig`: `embed_provider` field** (`#2668`): new optional `embed_provider` config field in `[index]` references a `[[llm.providers]]` name. When set, the background indexer uses a dedicated provider for embedding calls instead of cloning the main agent provider, preventing server-side rate-limit contention and Ollama model-lock from starving the guardrail LLM call. Falls back to the main provider when unset.
 
 ### Fixed
+
+- **TUI status bar stalls 3 s after indexing completes** (`#2668`): `forward_index_progress_to_tui` now tracks whether indexing finished normally. When it did, the post-completion delay is 1 s (down from 3 s); when the sender was dropped unexpectedly (error path) the delay is 200 ms, so the status bar clears promptly in both cases.
 
 - **`embed_missing` blocks startup** (`#2662`): the embedding backfill was running synchronously in `build_memory`, causing startup to hang for minutes and consuming excessive RAM. It is now spawned as a background task via `zeph_core::bootstrap::spawn_embed_backfill` with a 300s timeout. An early `Ctrl+C` handler (`std::process::exit(130)`) is registered before `build_memory` so the process can be killed during the init phase; the handler is aborted once the full signal handler is wired. TUI shows "Backfilling embeddings..." status while the task runs.
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -357,6 +357,12 @@ budget_ratio = 0.40
 repo_map_tokens = 500
 # Cache TTL for repo map in seconds (avoids regeneration on every message)
 repo_map_ttl_secs = 300
+# Dedicated provider for embedding calls during indexing.
+# References a [[llm.providers]] name. When set, the indexer uses this provider instead of the
+# main agent provider, preventing server-side rate-limit contention and Ollama model-lock with
+# the guardrail. Recommended: a cheap embedding model (e.g. text-embedding-3-small for OpenAI,
+# nomic-embed-text for Ollama). Defaults to the main provider when unset.
+# embed_provider = "ollama-embed"
 
 # [discord]
 # token = ""                    # or set ZEPH_DISCORD_TOKEN

--- a/crates/zeph-config/src/features.rs
+++ b/crates/zeph-config/src/features.rs
@@ -291,6 +291,12 @@ pub struct IndexConfig {
     /// Default: 512 KiB.
     #[serde(default = "default_index_max_file_bytes")]
     pub max_file_bytes: usize,
+    /// Name of a `[[llm.providers]]` entry to use exclusively for embedding calls during
+    /// indexing. A dedicated provider prevents the indexer from contending with the guardrail
+    /// at the API server level (rate limits, Ollama single-model lock). When unset or empty,
+    /// falls back to the main agent provider.
+    #[serde(default)]
+    pub embed_provider: Option<String>,
 }
 
 impl Default for IndexConfig {
@@ -310,6 +316,7 @@ impl Default for IndexConfig {
             batch_size: default_index_batch_size(),
             memory_batch_size: default_index_memory_batch_size(),
             max_file_bytes: default_index_max_file_bytes(),
+            embed_provider: None,
         }
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1237,7 +1237,27 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     .await;
 
     let index_pool = memory.sqlite().pool().clone();
-    let index_provider = provider.clone();
+    let index_provider = config
+        .index
+        .embed_provider
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .and_then(
+            |name| match zeph_core::bootstrap::create_named_provider(name, config) {
+                Ok(p) => {
+                    tracing::info!(provider = %name, "Using dedicated embed provider for indexer");
+                    Some(p)
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        provider = %name,
+                        "Index embed_provider resolution failed, using main provider: {e:#}"
+                    );
+                    None
+                }
+            },
+        )
+        .unwrap_or_else(|| provider.clone());
     let provider_has_tools = provider.supports_tool_use();
     let index_qdrant_ops = app.qdrant_ops().cloned();
     let config_path = app.config_path().to_owned();

--- a/src/tui_bridge.rs
+++ b/src/tui_bridge.rs
@@ -376,12 +376,14 @@ pub(crate) async fn forward_index_progress_to_tui(
     mut rx: tokio::sync::watch::Receiver<zeph_index::IndexProgress>,
     tx: tokio::sync::mpsc::Sender<zeph_tui::AgentEvent>,
 ) {
+    let mut indexing_completed = false;
     while rx.changed().await.is_ok() {
         let p = rx.borrow_and_update().clone();
         if p.files_total == 0 {
             continue;
         }
         let msg = if p.files_done >= p.files_total {
+            indexing_completed = true;
             format!(
                 "Index ready ({} files, {} chunks)",
                 p.files_total, p.chunks_created
@@ -397,6 +399,14 @@ pub(crate) async fn forward_index_progress_to_tui(
             break;
         }
     }
-    tokio::time::sleep(Duration::from_secs(3)).await;
+    // Keep the final message visible briefly so the user can read it, then clear.
+    // Use a shorter delay when indexing finished normally vs. when the sender was
+    // dropped unexpectedly (e.g. error path) so the status bar does not stall.
+    let delay = if indexing_completed {
+        Duration::from_secs(1)
+    } else {
+        Duration::from_millis(200)
+    };
+    tokio::time::sleep(delay).await;
     let _ = tx.send(zeph_tui::AgentEvent::Status(String::new())).await;
 }


### PR DESCRIPTION
Closes #2668

## Root cause

After indexing completes, users see `[guardrail] Input blocked: check failed` on every message. The indexer and guardrail shared the same provider, causing server-side contention:
- For Ollama: embed calls occupied the model inference queue, blocking guardrail's chat call
- For OpenAI/API providers: same API key rate limit, embed batch exhausted quota

With `fail_strategy = "closed"` (default), a guardrail timeout blocks input instead of allowing it through.

## Fix

- Adds `embed_provider: Option<String>` to `IndexConfig`. When set to a dedicated embedding provider name (e.g. `"ollama-embed"`), the indexer uses it instead of cloning the main agent provider
- Falls back to `provider.clone()` when unset — no breaking change for existing configs
- Adds a commented example in `[index]` section of `default.toml` explaining the setting
- Reduces TUI status clear delay from 3s to 1s after normal indexing completion

## Configuration

For Ollama users, set in config:
```toml
[index]
embed_provider = "ollama-embed"  # dedicated embedding provider, no contention with guardrail
```

## Test plan

- [ ] `cargo nextest run --workspace --features full --lib --bins` — 7897/7897 pass
- [ ] Run with `--tui --config ~/.config/zeph/default.toml`, send messages during/after indexing — no guardrail blocks
- [ ] Verify `embed_provider = "ollama-embed"` is respected (log: `Using dedicated embed provider for indexer`)