### PR TITLE
fix(mcp): resolve tool_discovery.embedding_provider in runner.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`mcp.tool_discovery.embedding_provider` config field now respected in `runner.rs`** (`#2684`): `create_mcp_registry` was always called with the main chat provider instead of the configured embed provider. The runner now resolves `config.mcp.tool_discovery.embedding_provider` via `create_named_provider`, matching the pattern used by the agent setup path. Falls back to the main provider when the field is empty or resolution fails.
+
 ## [0.18.4] - 2026-04-06
 
 ### Added

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1225,9 +1225,33 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     let _config_watcher = watchers.config_watcher;
     let config_reload_rx = watchers.config_reload_rx;
 
+    let mcp_embed_provider = {
+        let discovery = &config.mcp.tool_discovery;
+        if discovery.embedding_provider.is_empty() {
+            provider.clone()
+        } else {
+            match zeph_core::bootstrap::create_named_provider(&discovery.embedding_provider, config)
+            {
+                Ok(p) => {
+                    tracing::info!(
+                        provider = %discovery.embedding_provider,
+                        "Using dedicated embed provider for MCP registry"
+                    );
+                    p
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        provider = %discovery.embedding_provider,
+                        "MCP registry embed_provider resolution failed, using main provider: {e:#}"
+                    );
+                    provider.clone()
+                }
+            }
+        }
+    };
     let mcp_registry = create_mcp_registry(
         config,
-        &provider,
+        &mcp_embed_provider,
         &mcp_tools,
         &embed_model,
         app.qdrant_ops(),


### PR DESCRIPTION
## Summary

- `create_mcp_registry` was always receiving the main chat provider (`&provider`) instead of the configured `mcp.tool_discovery.embedding_provider`
- This caused `zeph_mcp_tools` Qdrant collection to be recreated every session due to embedding dimension mismatch (e.g. OpenAI 1536-dim vs Ollama 768-dim)
- Skill matching degraded to full fallback and MCP tool search failed with `Wrong input: Vector dimension error` every startup

## Fix

Added `mcp_embed_provider` resolution block in `src/runner.rs` before `create_mcp_registry` call, mirroring the existing `index_provider` and `discovery_provider` patterns:
- If `mcp.tool_discovery.embedding_provider` is empty → use main provider (fallback)
- Otherwise → resolve via `create_named_provider`, warn and fall back on failure

`create_mcp_registry` signature unchanged — bug was at the call site only.

## Test plan

- [x] 7917/7917 tests pass (`--features full`)
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [ ] Live verification: run agent with `mcp.tool_discovery.embedding_provider = "ollama-embed"` and confirm no `vector dimension mismatch` warning on startup (playbook: `.local/testing/playbooks/mcp.md`)

Closes #2684