### PR TITLE
fix(skills): pass embedding_provider to build_skill_matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **`build_skill_matcher` now uses embedding provider** (`#2686`): `runner.rs`, `acp.rs`, and `daemon.rs` were passing the main chat provider to `build_skill_matcher` instead of the configured embedding provider, causing a Qdrant dimension mismatch on every session startup and falling back to returning all skills.
+
 - **`mcp.tool_discovery.embedding_provider` config field now respected in `runner.rs`** (`#2684`): `create_mcp_registry` was always called with the main chat provider instead of the configured embed provider. The runner now resolves `config.mcp.tool_discovery.embedding_provider` via `create_named_provider`, matching the pattern used by the agent setup path. Falls back to the main provider when the field is empty or resolution fails.
 
 ## [0.18.4] - 2026-04-06

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -264,7 +264,7 @@ async fn build_acp_deps(
         .collect();
     let all_meta_refs: Vec<&zeph_skills::loader::SkillMeta> = all_meta_owned.iter().collect();
     let matcher = app
-        .build_skill_matcher(&provider, &all_meta_refs, &memory)
+        .build_skill_matcher(&embedding_provider, &all_meta_refs, &memory)
         .await;
     let config = app.config();
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -242,7 +242,7 @@ pub(crate) async fn run_daemon(
         .collect();
     let all_meta_refs: Vec<&zeph_skills::loader::SkillMeta> = all_meta_owned.iter().collect();
     let matcher = app
-        .build_skill_matcher(&provider, &all_meta_refs, &memory)
+        .build_skill_matcher(&embedding_provider, &all_meta_refs, &memory)
         .await;
     let skill_count = all_meta_owned.len();
     tracing::info!("skills loaded: {skill_count}");

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -777,7 +777,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     #[cfg(feature = "tui")]
     tui_status!("Loading skills...");
     let (matcher, cli_history) = tokio::join!(
-        app.build_skill_matcher(&provider, &all_meta_refs, &memory),
+        app.build_skill_matcher(&embedding_provider, &all_meta_refs, &memory),
         build_cli_history(&memory),
     );
     if matcher.is_some() {


### PR DESCRIPTION
## Summary

- `runner.rs`, `acp.rs`, and `daemon.rs` were passing `&provider` (main chat provider, e.g. OpenAI 1536-dim) to `build_skill_matcher` instead of the locally-created `&embedding_provider` (e.g. nomic 768-dim)
- This caused a Qdrant dimension mismatch on every session startup: `zeph_skills` collection was created with 1536-dim vectors, but search queries used 768-dim, so skill matching always fell back to returning all skills
- Fixed by passing `&embedding_provider` at all three call sites

Fixes #2686

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets --features full -- -D warnings` — clean
- [x] `cargo nextest run --workspace --features full --lib --bins` — 7917/7917 passed