### PR TITLE
fix(skills): pass embedding_provider to Agent::new_with_registry_arc (#2688)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **`Agent::new_with_registry_arc` now accepts explicit `embedding_provider` parameter** (`#2688`): the constructor previously hardcoded `embedding_provider = provider.clone()`, so `rebuild_skill_matcher` (called on skill hot-reload) always used the chat provider (OpenAI 1536-dim) instead of the configured embed provider (nomic 768-dim), re-corrupting the `zeph_skills` Qdrant collection every session. All production call sites (`runner.rs`, `acp.rs`, `daemon.rs`) now pass the correct embedding provider at construction time.
+
 - **`build_skill_matcher` now uses embedding provider** (`#2686`): `runner.rs`, `acp.rs`, and `daemon.rs` were passing the main chat provider to `build_skill_matcher` instead of the configured embedding provider, causing a Qdrant dimension mismatch on every session startup and falling back to returning all skills.
 - **`mcp.tool_discovery.embedding_provider` config field now respected in `runner.rs`** (`#2684`): `create_mcp_registry` was always called with the main chat provider instead of the configured embed provider. The runner now resolves `config.mcp.tool_discovery.embedding_provider` via `create_named_provider`, matching the pattern used by the agent setup path. Falls back to the main provider when the field is empty or resolution fails.
 

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -180,8 +180,10 @@ impl<C: Channel> Agent<C> {
         tool_executor: impl ToolExecutor + 'static,
     ) -> Self {
         let registry = std::sync::Arc::new(std::sync::RwLock::new(registry));
+        let embedding_provider = provider.clone();
         Self::new_with_registry_arc(
             provider,
+            embedding_provider,
             channel,
             registry,
             matcher,
@@ -200,6 +202,7 @@ impl<C: Channel> Agent<C> {
     #[allow(clippy::too_many_lines)] // flat struct literal initializing all Agent sub-structs — one field per sub-struct, cannot be split further
     pub fn new_with_registry_arc(
         provider: AnyProvider,
+        embedding_provider: AnyProvider,
         channel: C,
         registry: std::sync::Arc<std::sync::RwLock<SkillRegistry>>,
         matcher: Option<SkillMatcherBackend>,
@@ -228,7 +231,6 @@ impl<C: Channel> Agent<C> {
         // select! branch in the agent loop compiles unconditionally. The sender is only
         // stored when the experiments feature is enabled (it is only used in experiment_cmd.rs).
         let (exp_notify_tx, exp_notify_rx) = tokio::sync::mpsc::channel::<String>(4);
-        let embedding_provider = provider.clone();
         Self {
             provider,
             embedding_provider,

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -681,6 +681,7 @@ async fn spawn_acp_agent(
     let mut agent = Box::pin(
         Agent::new_with_registry_arc(
             provider.clone(),
+            d.embedding_provider.clone(),
             channel,
             Arc::clone(&registry),
             matcher,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -370,6 +370,7 @@ pub(crate) async fn run_daemon(
     let agent = Box::pin(
         Agent::new_with_registry_arc(
             provider.clone(),
+            embedding_provider.clone(),
             loopback_channel,
             registry,
             matcher,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1299,6 +1299,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
 
     let agent = Agent::new_with_registry_arc(
         provider.clone(),
+        embedding_provider.clone(),
         channel,
         registry,
         matcher,


### PR DESCRIPTION
## Problem

`Agent::new_with_registry_arc` hardcoded:

```rust
let embedding_provider = provider.clone();  // always chat provider
```

`rebuild_skill_matcher` uses `self.embedding_provider` to re-sync skill embeddings on hot-reload. With the chat provider (OpenAI, 1536-dim) stored there instead of the embed provider (nomic, 768-dim), the `zeph_skills` Qdrant collection was recreated with wrong dimensions on every session, immediately undoing the startup correction from PR #2687.

Reproduction (CI-468): two consecutive sessions both showed:
```
vector dimension mismatch, recreating collection zeph_skills existing=Some(1536) required=768
```

## Fix

Add `embedding_provider: AnyProvider` as an explicit parameter to `Agent::new_with_registry_arc`. The `Agent::new` convenience constructor defaults to `provider.clone()` for callers that do not separate chat and embed providers. Update all three production call sites to pass the real embedding provider.

## Changes

- `crates/zeph-core/src/agent/mod.rs` — add `embedding_provider` param to `new_with_registry_arc`, remove hardcoded clone
- `src/runner.rs` — pass `embedding_provider.clone()`
- `src/acp.rs` — pass `d.embedding_provider.clone()`
- `src/daemon.rs` — pass `embedding_provider.clone()`

Closes #2688