### PR TITLE
fix(test): abort gateway task to eliminate thread leak in spawn_gateway_returns_receiver

### DIFF
--- a/crates/zeph-channels/src/discord/gateway.rs
+++ b/crates/zeph-channels/src/discord/gateway.rs
@@ -54,12 +54,16 @@ struct Heartbeat {
     d: Option<u64>,
 }
 
-/// Spawn the gateway connection loop, returning a receiver of incoming messages.
+/// Spawn the gateway connection loop, returning a handle and a receiver of incoming messages.
+///
+/// The caller should abort the handle when the gateway is no longer needed.
 #[must_use]
-pub fn spawn_gateway(token: String) -> mpsc::Receiver<IncomingMessage> {
+pub fn spawn_gateway(
+    token: String,
+) -> (tokio::task::JoinHandle<()>, mpsc::Receiver<IncomingMessage>) {
     let (tx, rx) = mpsc::channel(64);
-    tokio::spawn(gateway_loop(token, tx));
-    rx
+    let handle = tokio::spawn(gateway_loop(token, tx));
+    (handle, rx)
 }
 
 async fn gateway_loop(token: String, tx: mpsc::Sender<IncomingMessage>) {
@@ -353,7 +357,11 @@ mod tests {
             .enable_all()
             .build()
             .unwrap();
-        let _rx = rt.block_on(async { spawn_gateway("invalid-token".into()) });
+        rt.block_on(async {
+            let (handle, _rx) = spawn_gateway("invalid-token".into());
+            handle.abort();
+            let _ = handle.await;
+        });
     }
 
     #[test]

--- a/crates/zeph-channels/src/discord/mod.rs
+++ b/crates/zeph-channels/src/discord/mod.rs
@@ -49,7 +49,7 @@ impl DiscordChannel {
         allowed_role_ids: Vec<String>,
         allowed_channel_ids: Vec<String>,
     ) -> Self {
-        let rx = gateway::spawn_gateway(token.clone());
+        let (_gateway_handle, rx) = gateway::spawn_gateway(token.clone());
         let rest = rest::RestClient::new(token);
         // Register slash commands asynchronously; failure is non-fatal.
         let rest_for_reg = rest.clone();


### PR DESCRIPTION
## Summary

- `spawn_gateway` now returns `(JoinHandle<()>, Receiver<IncomingMessage>)` instead of just the receiver
- The test `spawn_gateway_returns_receiver` aborts and awaits the handle before returning, eliminating the nextest `LEAK` report
- The one call site in `DiscordChannel::new` is updated to destructure the tuple (`_gateway_handle` intentionally ignored — background reconnect loop is fire-and-forget by design)

## Test plan

- [x] `cargo nextest run -p zeph-channels` — 106/106 PASS, 0 leaky
- [x] `cargo nextest run --workspace --lib --bins` — 7663/7663 PASS, 0 leaky
- [x] `cargo clippy -p zeph-channels -- -D warnings` — clean
- [x] `cargo +nightly fmt --check` — clean

Closes #2706