### PR TITLE
fix(test): eliminate thread leak in shared_agent_deps_has_document_and_graph_config_fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Thread leak in `shared_agent_deps_has_document_and_graph_config_fields` test** (`#2710`): the test constructed `GraphConfig` via `..Default::default()` which transitively initializes lazy globals, leaving background threads alive and causing nextest to report a thread leak. Replaced `GraphConfig::default()` with a never-called closure that performs only compile-time type-checking of the `enabled` field, eliminating runtime construction. `DocumentConfig` is now constructed with explicit field literals (5 fields, no nesting) instead of `..Default::default()`.
+
 - **Graph episode FK constraint on `link_entity_to_episode`** (`#2704`): `INSERT INTO graph_episode_entities` failed with `FOREIGN KEY constraint failed` when the entity was pruned or missing at link time. Changed to `INSERT OR IGNORE` so missing entities are silently skipped. Downgraded the episode-linking failure log from `warn!` to `debug!` in `zeph-memory/src/semantic/graph.rs` — the error is non-actionable when caused by intentional entity pruning.
 - **Thread leak in `apply_summary_provider_none_returns_agent_unchanged` test** (`#2698`): the plain `#[test]` function constructed an `Agent` that spawns background Tokio tasks; without a runtime to shut them down, `cargo nextest` reported a thread leak. Converted the test to `#[tokio::test] async fn` so the runtime tears down tasks cleanly on exit.
 

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -1444,23 +1444,31 @@ mod tests {
     // Verify that SharedAgentDeps has the document_config and graph_config fields with the
     // correct types. This is a compile-time regression test for issue #1634: before the fix,
     // these fields were absent and spawn_acp_agent could not propagate RAG config to the agent.
+    //
+    // Implementation note: `GraphConfig` has 20+ fields with deeply nested sub-configs whose
+    // `Default` impls may trigger lazy global initialization (once_cell / tracing subscribers)
+    // that leaves background threads running, causing nextest to report this test as leaky.
+    // To avoid the issue entirely, field existence is verified via a never-called closure —
+    // the closure must compile (proving the fields exist with the right types) but is never
+    // invoked at runtime, so no Default construction or global initialization occurs.
     #[test]
     fn shared_agent_deps_has_document_and_graph_config_fields() {
+        // Explicit construction for the small DocumentConfig (5 fields, no nested types).
         let doc_cfg = zeph_core::config::DocumentConfig {
             rag_enabled: true,
             top_k: 7,
-            ..Default::default()
+            collection: String::new(),
+            chunk_size: 0,
+            chunk_overlap: 0,
         };
-        let graph_cfg = zeph_core::config::GraphConfig {
-            enabled: true,
-            ..Default::default()
-        };
-        // Use ZST trick: read through a raw pointer to verify field offsets exist without
-        // constructing the full SharedAgentDeps (which has ~50 required fields).
-        // The assertions below confirm the field types are correct at compile time.
         assert!(doc_cfg.rag_enabled);
         assert_eq!(doc_cfg.top_k, 7);
-        assert!(graph_cfg.enabled);
+
+        // Closure-based compile-time check for GraphConfig: the closure is never called,
+        // so no Default construction takes place, but the field accesses are type-checked.
+        let _check_graph = |g: &zeph_core::config::GraphConfig| {
+            let _: bool = g.enabled;
+        };
     }
 
     // Compile-time regression test for issue #1643: anomaly_config and orchestration_config


### PR DESCRIPTION
## Summary

- Replaces `GraphConfig::default()` construction with a never-called closure that verifies the `enabled` field exists at compile time, eliminating runtime Default initialization
- Constructs `DocumentConfig` with explicit field literals instead of `..Default::default()`
- Nextest no longer reports a `LEAK` for this test

## Root cause

`GraphConfig::default()` has 20+ fields with deeply nested sub-configs (`NoteLinkingConfig`, `SpreadingActivationConfig`, `BeliefRevisionConfig`, `RpeConfig`, etc.). Their `Default` implementations transitively initialize lazy globals that leave background OS threads alive, causing nextest to count them as leaked from this sync test.

## Fix approach

The test is a pure compile-time field-existence check — the assertions are trivially true because we set the values ourselves. The compile-time protection is preserved via a never-called closure: it must compile (proving the fields exist with correct types) but is never invoked at runtime, so no `Default` construction or global initialization occurs.

## Test plan

- `cargo +nightly fmt --check` passes
- `cargo clippy --workspace -- -D warnings` passes (0 warnings)
- `cargo nextest run --features full --lib --bins -E 'test(shared_agent_deps_has_document_and_graph_config_fields)'` → `PASS [0.012s]` (no `LEAK` prefix)

Closes #2710