### PR TITLE
fix(test): eliminate thread leak in compression_predictor tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Thread leak in `store::compression_predictor` tests** (`#2716`): `#[tokio::test]` tests in `store::compression_predictor::tests` now call `store.pool().close().await` before returning, ensuring all sqlx-sqlite background connection threads fully exit before nextest measures the thread count. Previously, pool drop only signalled threads to stop without waiting, causing nextest to attribute lingering connection threads as a LEAK for the concurrently-running pure `compression_predictor::tests::training_on_high_ratio_improves_high_ratio_prediction` test.
+
 ### Added
 
 - **Agent Stability Index (ASI) coherence tracking** (`#1841`): per-provider sliding window of response embeddings tracks coherence (cosine similarity of latest vs. window mean). Low coherence penalizes Thompson beta priors and EMA scores via `penalty_weight`. Enabled with `[llm.routing.asi] enabled = true`. Session-only; no persistence. Fire-and-forget embed via `tokio::spawn` — routing is not blocked. Emits `tracing::warn` when coherence drops below `coherence_threshold`. New file `crates/zeph-llm/src/router/asi.rs`.

--- a/crates/zeph-memory/src/store/compression_predictor.rs
+++ b/crates/zeph-memory/src/store/compression_predictor.rs
@@ -190,6 +190,13 @@ mod tests {
         (store, cid)
     }
 
+    // Each test calls `store.pool().close().await` before returning so that the
+    // sqlx-sqlite background connection threads fully exit before nextest measures
+    // the thread count. Without an explicit close, the pool's Drop only signals the
+    // threads to stop; they may still be alive when a concurrently-running plain
+    // `#[test]` (e.g. `compression_predictor::tests::*`) is executing, causing
+    // nextest to attribute those lingering threads as a LEAK for that innocent test.
+
     #[tokio::test]
     async fn record_and_count_training_data() {
         let (store, cid) = make_store().await;
@@ -202,6 +209,7 @@ mod tests {
             .await
             .expect("count");
         assert_eq!(count, 1);
+        store.pool().close().await;
     }
 
     #[tokio::test]
@@ -218,6 +226,7 @@ mod tests {
         assert_eq!(batch.len(), 1);
         assert!((batch[0].compression_ratio - 0.5).abs() < 1e-4);
         assert!((batch[0].probe_score - 0.75).abs() < 1e-4);
+        store.pool().close().await;
     }
 
     #[tokio::test]
@@ -235,6 +244,7 @@ mod tests {
             .await
             .expect("count");
         assert_eq!(count, 2);
+        store.pool().close().await;
     }
 
     #[tokio::test]
@@ -250,6 +260,7 @@ mod tests {
             .expect("load");
         assert!(loaded.is_some());
         assert!(loaded.unwrap().contains("weights"));
+        store.pool().close().await;
     }
 
     #[tokio::test]
@@ -260,5 +271,6 @@ mod tests {
             .await
             .expect("load");
         assert!(loaded.is_none());
+        store.pool().close().await;
     }
 }


### PR DESCRIPTION
## Summary

- Closes #2716
- `store::compression_predictor` tests now call `store.pool().close().await` before returning, ensuring all sqlx-sqlite background connection threads fully exit before nextest measures the thread count
- Without an explicit close, pool `Drop` only signals threads to stop; they may remain alive for a few ms and be falsely attributed as a `LEAK` to the concurrently-running pure sync test `compression_predictor::tests::training_on_high_ratio_improves_high_ratio_prediction`
- Verified: 8 consecutive `cargo nextest run -p zeph-memory --lib` runs with 0 leaky tests

## Root cause

SQLx SQLite uses a dedicated OS thread per connection. With the default pool size of 5, each `SqliteStore::new(":memory:")` in the store tests spawns 5 connection threads. When a `#[tokio::test]` completes and drops the store, those threads are signalled to stop but take a few milliseconds to actually exit. During that window, any concurrently-running plain `#[test]` (the ~16ms compression_predictor training test) is running, causing nextest to attribute the lingering threads as a LEAK.

`Pool::close().await` waits for all connection threads to fully exit before returning, eliminating the race.

## Test plan

- [x] `cargo nextest run -p zeph-memory -E 'test(compression_predictor)'` — 14/14 pass
- [x] `cargo nextest run -p zeph-memory --lib` — 8 consecutive runs, 0 leaky
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean