### PR TITLE
feat(context): surface compaction failure as user-visible message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Surface compaction failure as user-visible message** (`#2718`): when context compaction fails to persist to the database (SQLite or Qdrant), a user-visible message is now sent: "Context compaction failed — response quality may be affected in long sessions." When the compaction probe rejects a summary as too lossy (recoverable), "Context compaction skipped this turn — will retry." is sent instead. Previously both cases were silent (tracing::warn only). Changes in `crates/zeph-core/src/agent/context/summarization.rs`.
+
 - **Thread leak in `store::compression_predictor` tests** (`#2716`): `#[tokio::test]` tests in `store::compression_predictor::tests` now call `store.pool().close().await` before returning, ensuring all sqlx-sqlite background connection threads fully exit before nextest measures the thread count. Previously, pool drop only signalled threads to stop without waiting, causing nextest to attribute lingering connection threads as a LEAK for the concurrently-running pure `compression_predictor::tests::training_on_high_ratio_improves_high_ratio_prediction` test.
 
 ### Added

--- a/crates/zeph-core/src/agent/context/summarization.rs
+++ b/crates/zeph-core/src/agent/context/summarization.rs
@@ -936,6 +936,7 @@ impl<C: Channel> Agent<C> {
             let ids = sqlite
                 .oldest_message_ids(cid, u32::try_from(compacted_count + 1).unwrap_or(u32::MAX))
                 .await;
+            let mut persist_failed = false;
             match ids {
                 Ok(ids) if ids.len() >= 2 => {
                     // ids[0] is the system prompt; compact ids[1..=compacted_count]
@@ -946,14 +947,17 @@ impl<C: Channel> Agent<C> {
                         .await
                     {
                         tracing::warn!("failed to persist compaction in sqlite: {e:#}");
+                        persist_failed = true;
                     } else if let Err(e) = memory.store_session_summary(cid, &summary).await {
                         tracing::warn!("failed to store session summary in Qdrant: {e:#}");
+                        persist_failed = true;
                     }
                 }
                 Ok(_) => {
                     // Not enough messages in DB — fall back to legacy summary storage
                     if let Err(e) = memory.store_session_summary(cid, &summary).await {
                         tracing::warn!("failed to store session summary: {e:#}");
+                        persist_failed = true;
                     }
                 }
                 Err(e) => {
@@ -961,7 +965,17 @@ impl<C: Channel> Agent<C> {
                     if let Err(e) = memory.store_session_summary(cid, &summary).await {
                         tracing::warn!("failed to store session summary: {e:#}");
                     }
+                    persist_failed = true;
                 }
+            }
+            if persist_failed {
+                let _ = self
+                    .channel
+                    .send(
+                        "Context compaction failed — response quality may be affected in long \
+                         sessions.",
+                    )
+                    .await;
             }
         }
 
@@ -2024,6 +2038,10 @@ impl<C: Channel> Agent<C> {
                             crate::agent::context_manager::CompactionState::CompactedThisTurn {
                                 cooldown: self.context_manager.compaction_cooldown_turns,
                             };
+                        let _ = self
+                            .channel
+                            .send("Context compaction skipped this turn — will retry.")
+                            .await;
                     }
                     CompactionOutcome::Compacted => {
                         // Guard 2 — Counterproductive: net freed tokens is zero (summary ate all
@@ -2251,6 +2269,7 @@ impl<C: Channel> Agent<C> {
             let ids = sqlite
                 .oldest_message_ids(cid, u32::try_from(compacted_count + 1).unwrap_or(u32::MAX))
                 .await;
+            let mut persist_failed = false;
             match ids {
                 Ok(ids) if ids.len() >= 2 => {
                     let start = ids[1];
@@ -2260,13 +2279,16 @@ impl<C: Channel> Agent<C> {
                         .await
                     {
                         tracing::warn!("failed to persist compaction in sqlite: {e:#}");
+                        persist_failed = true;
                     } else if let Err(e) = memory.store_session_summary(cid, &summary).await {
                         tracing::warn!("failed to store session summary in Qdrant: {e:#}");
+                        persist_failed = true;
                     }
                 }
                 Ok(_) => {
                     if let Err(e) = memory.store_session_summary(cid, &summary).await {
                         tracing::warn!("failed to store session summary: {e:#}");
+                        persist_failed = true;
                     }
                 }
                 Err(e) => {
@@ -2274,7 +2296,17 @@ impl<C: Channel> Agent<C> {
                     if let Err(e) = memory.store_session_summary(cid, &summary).await {
                         tracing::warn!("failed to store session summary: {e:#}");
                     }
+                    persist_failed = true;
                 }
+            }
+            if persist_failed {
+                let _ = self
+                    .channel
+                    .send(
+                        "Context compaction failed — response quality may be affected in long \
+                         sessions.",
+                    )
+                    .await;
             }
         }
 


### PR DESCRIPTION
## Summary

Closes #2718

When compaction fails non-recoverably, Zeph previously only logged a `WARN`. The user had no visibility into context management failures, which could lead to degraded response quality without any indication.

This PR adds user-visible channel messages at three failure sites in `summarization.rs`:

- **`compact_context()` persist block**: uses a `persist_failed` flag across all error arms (SQLite, Qdrant, legacy fallback) and sends one notification: _"Context compaction failed — response quality may be affected in long sessions."_
- **`compact_context_with_budget()` persist block**: identical pattern
- **`maybe_compact()` ProbeRejected arm**: sends a shorter, recoverable message: _"Context compaction skipped this turn — will retry."_

The exhaustion warning path (lines 1816–1824) was already user-visible and is not changed.

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — 0 warnings
- [ ] `cargo nextest run --workspace --lib --bins` — 7690/7690 pass
- [ ] Unit tests for the 3 notification paths are tracked in coverage-status as `Untested` (playbook at `.local/testing/playbooks/compaction.md`)