### PR TITLE
fix(db): gate connect_sqlite on sqlite-only, fix --all-features build

### DIFF
--- a/crates/zeph-db/src/pool.rs
+++ b/crates/zeph-db/src/pool.rs
@@ -34,7 +34,7 @@ impl DbConfig {
     ///
     /// Returns [`DbError`] if connection or migration fails.
     pub async fn connect(&self) -> Result<DbPool, DbError> {
-        #[cfg(feature = "sqlite")]
+        #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
         {
             Self::connect_sqlite(&self.url, self.max_connections, self.pool_size).await
         }
@@ -44,7 +44,7 @@ impl DbConfig {
         }
     }
 
-    #[cfg(feature = "sqlite")]
+    #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
     async fn connect_sqlite(
         path: &str,
         max_connections: u32,


### PR DESCRIPTION
## Summary

- Change `#[cfg(feature = "sqlite")]` to `#[cfg(all(feature = "sqlite", not(feature = "postgres")))]` on `connect_sqlite` fn and its call site in `connect()`
- When both features are active, postgres takes priority — matches the pattern already used in `migrate.rs` and `transaction.rs`

Fixes #2738

## Test plan

- [x] `cargo build -p zeph-db --all-features` compiles cleanly
- [x] `cargo nextest run -p zeph-db --all-features --lib --bins` — 22/22 passed
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean