### PR TITLE
fix(scheduler): prevent unbounded tokio::spawn in TUI metrics refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Unbounded `tokio::spawn` in TUI scheduler metrics refresh** (`#2742`): the `do_refresh` closure in `src/runner.rs` previously called `tokio::spawn` for every `refresh_rx.changed()` event, spawning hundreds of concurrent `SELECT FROM scheduled_jobs` queries during scheduler mutation bursts (up to 849 concurrent queries observed vs. the expected 1 per 30 s). The inner `tokio::spawn` has been removed; `store.list_jobs().await` is now called directly in each `select!` arm. Since the outer loop already runs inside a `tokio::spawn`, at most one query is in flight at a time.
+
 - **Unbounded RSS growth in TUI mode — 4 leak sites** (`#2737`):
   - *Cancel bridge task accumulation (critical)*: `process_user_message_inner` now stores the cancel bridge `JoinHandle` in `LifecycleState::cancel_bridge_handle` and aborts it before spawning a new one each turn. Previously N turns leaked N tasks waiting indefinitely on `Arc<Notify>`.
   - *TUI message buffer (high)*: `App::messages` and `render_cache` are now capped at 2000 entries; `input_history` is capped at 500. Oldest entries are evicted from the front when limits are exceeded. Render cache is cleared on eviction (indices shift after a drain; cache is rebuilt on next render).

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1933,35 +1933,38 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             let mut refresh_rx = sched_refresh_rx.take();
             tokio::spawn(async move {
                 let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
-                let do_refresh = |store: &std::sync::Arc<zeph_scheduler::JobStore>,
-                                  tx: &tokio::sync::watch::Sender<
-                    zeph_core::metrics::MetricsSnapshot,
-                >| {
-                    let store = std::sync::Arc::clone(store);
-                    let tx = tx.clone();
-                    tokio::spawn(async move {
-                        if let Ok(jobs) = store.list_jobs().await {
-                            tx.send_modify(|m| {
-                                m.scheduled_tasks = jobs
-                                    .into_iter()
-                                    .map(|(name, kind, mode, next_run)| {
-                                        [name, kind, mode, next_run]
-                                    })
-                                    .collect();
-                            });
-                        }
-                    });
-                };
                 loop {
                     tokio::select! {
-                        _ = interval.tick() => do_refresh(&store, &tx_clone),
+                        _ = interval.tick() => {
+                            if let Ok(jobs) = store.list_jobs().await {
+                                tx_clone.send_modify(|m| {
+                                    m.scheduled_tasks = jobs
+                                        .into_iter()
+                                        .map(|(name, kind, mode, next_run)| {
+                                            [name, kind, mode, next_run]
+                                        })
+                                        .collect();
+                                });
+                            }
+                        }
                         () = async {
                             if let Some(ref mut rx) = refresh_rx {
                                 let _ = rx.changed().await;
                             } else {
                                 std::future::pending::<()>().await;
                             }
-                        } => do_refresh(&store, &tx_clone),
+                        } => {
+                            if let Ok(jobs) = store.list_jobs().await {
+                                tx_clone.send_modify(|m| {
+                                    m.scheduled_tasks = jobs
+                                        .into_iter()
+                                        .map(|(name, kind, mode, next_run)| {
+                                            [name, kind, mode, next_run]
+                                        })
+                                        .collect();
+                                });
+                            }
+                        }
                         _ = shutdown.changed() => break,
                     }
                 }


### PR DESCRIPTION
## Summary

- Removes the inner `tokio::spawn` inside the TUI scheduler metrics refresh loop in `src/runner.rs` (line ~1942)
- Replaces with direct `.await` calls in each `select!` arm, ensuring at most one `list_jobs()` query is in flight at a time
- Fixes the SQL query storm: 849 concurrent `SELECT FROM scheduled_jobs` queries per second observed; root cause was `tokio::spawn` firing for every `refresh_rx.changed()` event during scheduler mutation bursts

## Root Cause

`do_refresh` was a non-async closure that called `tokio::spawn(async move { store.list_jobs().await })`. Since the closure was called synchronously on every `refresh_rx.changed()` event, rapid scheduler mutations spawned hundreds of independent tasks simultaneously, exhausting the SQLite connection pool.

The outer `tokio::spawn` at line 1934 already provides the async context. Making the select! arms directly await the query is the correct fix.

## Test Plan

- [x] `cargo +nightly fmt --check` — passes
- [x] `cargo clippy --workspace -- -D warnings` — passes (0 warnings)
- [x] `cargo nextest run --workspace --lib --bins` — 7719 passed, 15 skipped
- [x] `CHANGELOG.md` updated (`[Unreleased]` section)
- [x] `coverage-status.md` updated (Fixed)
- [x] `scheduler-cli.md` playbook updated with regression test scenario

Closes #2742