### PR TITLE
perf(core): cache BPE data in OnceLock to avoid repeated disk loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Performance
+
+- perf(core): cache BPE data in `OnceLock` to avoid repeated disk loads on `TokenCounter` construction (`#2741`)
+
 ### Fixed
 
 - **Unbounded `tokio::spawn` in TUI scheduler metrics refresh** (`#2742`): the `do_refresh` closure in `src/runner.rs` previously called `tokio::spawn` for every `refresh_rx.changed()` event, spawning hundreds of concurrent `SELECT FROM scheduled_jobs` queries during scheduler mutation bursts (up to 849 concurrent queries observed vs. the expected 1 per 30 s). The inner `tokio::spawn` has been removed; `store.list_jobs().await` is now called directly in each `select!` arm. Since the outer loop already runs inside a `tokio::spawn`, at most one query is in flight at a time.

--- a/crates/zeph-memory/src/token_counter.rs
+++ b/crates/zeph-memory/src/token_counter.rs
@@ -3,10 +3,13 @@
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
+use std::sync::OnceLock;
 
 use dashmap::DashMap;
 use tiktoken_rs::CoreBPE;
 use zeph_llm::provider::{Message, MessagePart};
+
+static BPE: OnceLock<Option<CoreBPE>> = OnceLock::new();
 
 const CACHE_CAP: usize = 10_000;
 /// Inputs larger than this limit bypass BPE encoding and use the chars/4 fallback.
@@ -36,22 +39,24 @@ const IMAGE_DEFAULT_TOKENS: usize = 1000;
 const THINKING_OVERHEAD: usize = 10;
 
 pub struct TokenCounter {
-    bpe: Option<CoreBPE>,
+    bpe: &'static Option<CoreBPE>,
     cache: DashMap<u64, usize>,
     cache_cap: usize,
 }
 
 impl TokenCounter {
     /// Create a new counter. Falls back to chars/4 if tiktoken init fails.
+    ///
+    /// BPE data is loaded once and cached in a `OnceLock` for the process lifetime.
     #[must_use]
     pub fn new() -> Self {
-        let bpe = match tiktoken_rs::cl100k_base() {
+        let bpe = BPE.get_or_init(|| match tiktoken_rs::cl100k_base() {
             Ok(b) => Some(b),
             Err(e) => {
                 tracing::warn!("tiktoken cl100k_base init failed, using chars/4 fallback: {e}");
                 None
             }
-        };
+        });
         Self {
             bpe,
             cache: DashMap::new(),
@@ -79,7 +84,7 @@ impl TokenCounter {
             return *cached;
         }
 
-        let count = match &self.bpe {
+        let count = match self.bpe {
             Some(bpe) => bpe.encode_with_special_tokens(text).len(),
             None => zeph_common::text::estimate_tokens(text),
         };
@@ -212,6 +217,16 @@ fn count_schema_value(counter: &TokenCounter, value: &serde_json::Value) -> usiz
 mod tests {
     use super::*;
     use zeph_llm::provider::{ImageData, Message, MessageMetadata, MessagePart, Role};
+
+    static BPE_NONE: Option<CoreBPE> = None;
+
+    fn counter_with_no_bpe(cache_cap: usize) -> TokenCounter {
+        TokenCounter {
+            bpe: &BPE_NONE,
+            cache: DashMap::new(),
+            cache_cap,
+        }
+    }
 
     fn make_msg(parts: Vec<MessagePart>) -> Message {
         Message::from_parts(Role::User, parts)
@@ -416,11 +431,7 @@ mod tests {
 
     #[test]
     fn count_tokens_fallback_mode() {
-        let counter = TokenCounter {
-            bpe: None,
-            cache: DashMap::new(),
-            cache_cap: CACHE_CAP,
-        };
+        let counter = counter_with_no_bpe(CACHE_CAP);
         // 8 chars / 4 = 2
         assert_eq!(counter.count_tokens("abcdefgh"), 2);
         assert_eq!(counter.count_tokens(""), 0);
@@ -477,12 +488,15 @@ mod tests {
     }
 
     #[test]
+    fn two_instances_share_bpe_pointer() {
+        let a = TokenCounter::new();
+        let b = TokenCounter::new();
+        assert!(std::ptr::eq(a.bpe, b.bpe));
+    }
+
+    #[test]
     fn cache_eviction_at_capacity() {
-        let counter = TokenCounter {
-            bpe: None,
-            cache: DashMap::new(),
-            cache_cap: 3,
-        };
+        let counter = counter_with_no_bpe(3);
         let _ = counter.count_tokens("aaaa");
         let _ = counter.count_tokens("bbbb");
         let _ = counter.count_tokens("cccc");


### PR DESCRIPTION
## Summary

- `TokenCounter::new()` was calling `tiktoken_rs::cl100k_base()` on every construction, reloading BPE data from disk each time
- Fixed by caching in `static BPE: OnceLock<Option<CoreBPE>>` — BPE loads once per process, all instances share a `&'static` reference
- BPE load failures are handled gracefully: warning logged once, fallback to `chars/4` estimation for the process lifetime
- Added `two_instances_share_bpe_pointer` test to explicitly guard the OnceLock caching invariant

Measured impact: 2.6% CPU reduction (531 samples in a 3-turn session via samply profiling).

Closes #2741

## Test plan

- [x] `cargo nextest run -p zeph-memory --lib` — 1096 passed
- [x] `cargo nextest run --workspace --lib --bins` — 7720 passed
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean