### PR TITLE
perf(core): skip debug_request_json and truncate graph context (#2757, #2759)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **`persist_message` stores tool output without content size cap** (`#2748`): truncate message content to 100KB before SQLite write, preserving UTF-8 boundary via `floor_char_boundary`. `parts_json` is not truncated to avoid producing invalid JSON.
 
+### Performance
+
+- **Skip `debug_request_json` when dump format is Trace** (`#2757`): add `is_trace_format()` to `DebugDumper` and guard the `convert_messages_structured` call in `native.rs` and `legacy.rs` — eliminates ~400KB transient allocation per LLM call in the default Trace-format configuration.
+
+- **Truncate graph extraction context messages to 2KB** (`#2759`): cap each cloned message content at `floor_char_boundary(2048)` bytes before passing to `maybe_spawn_graph_extraction`, bounding context allocation to ≤8KB regardless of message size.
+
 ### Changed
 
 - **Embed concurrency cap** (`#2749`): add `embed_concurrency` config field (default 4, 0 = unlimited) backed by `Arc<Semaphore>` in the router. Prevents indexer, backfill, and graph extraction from saturating Ollama embed slots simultaneously.

--- a/crates/zeph-core/src/agent/persistence.rs
+++ b/crates/zeph-core/src/agent/persistence.rs
@@ -649,7 +649,13 @@ impl<C: Channel> Agent<C> {
                         .any(|p| matches!(p, MessagePart::ToolResult { .. }))
             })
             .take(4)
-            .map(|m| m.content.clone())
+            .map(|m| {
+                if m.content.len() > 2048 {
+                    m.content[..m.content.floor_char_boundary(2048)].to_owned()
+                } else {
+                    m.content.clone()
+                }
+            })
             .collect();
 
         let _ = self.channel.send_status("saving to graph...").await;

--- a/crates/zeph-core/src/agent/tool_execution/legacy.rs
+++ b/crates/zeph-core/src/agent/tool_execution/legacy.rs
@@ -279,15 +279,21 @@ impl<C: Channel> Agent<C> {
                 .debug_dumper
                 .as_ref()
                 .map(|d: &crate::debug_dump::DebugDumper| {
+                    // Skip expensive serialization when Trace format returns early without using it.
+                    let provider_request = if d.is_trace_format() {
+                        serde_json::Value::Null
+                    } else {
+                        self.provider.debug_request_json(
+                            &self.msg.messages,
+                            &[],
+                            self.provider.supports_streaming(),
+                        )
+                    };
                     d.dump_request(&crate::debug_dump::RequestDebugDump {
                         model_name: &self.runtime.model_name,
                         messages: &self.msg.messages,
                         tools: &[],
-                        provider_request: self.provider.debug_request_json(
-                            &self.msg.messages,
-                            &[],
-                            self.provider.supports_streaming(),
-                        ),
+                        provider_request,
                     })
                 });
 

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -350,15 +350,18 @@ impl<C: Channel> Agent<C> {
                 .debug_dumper
                 .as_ref()
                 .map(|d: &crate::debug_dump::DebugDumper| {
+                    // Skip expensive serialization when Trace format returns early without using it.
+                    let provider_request = if d.is_trace_format() {
+                        serde_json::Value::Null
+                    } else {
+                        self.provider
+                            .debug_request_json(&self.msg.messages, tool_defs, false) // lgtm[rust/cleartext-logging]
+                    };
                     d.dump_request(&crate::debug_dump::RequestDebugDump {
                         model_name: &self.runtime.model_name,
                         messages: &self.msg.messages,
                         tools: tool_defs,
-                        provider_request: self.provider.debug_request_json(
-                            &self.msg.messages,
-                            tool_defs,
-                            false,
-                        ), // lgtm[rust/cleartext-logging]
+                        provider_request,
                     })
                 });
 

--- a/crates/zeph-core/src/debug_dump/mod.rs
+++ b/crates/zeph-core/src/debug_dump/mod.rs
@@ -58,6 +58,15 @@ impl DebugDumper {
         &self.dir
     }
 
+    /// Returns `true` when the dump format is [`DumpFormat::Trace`].
+    ///
+    /// In Trace mode `dump_request` returns early without using `provider_request`, so callers
+    /// can skip the expensive `debug_request_json` serialization.
+    #[must_use]
+    pub fn is_trace_format(&self) -> bool {
+        self.format == DumpFormat::Trace
+    }
+
     fn next_id(&self) -> u32 {
         self.counter.fetch_add(1, Ordering::Relaxed)
     }


### PR DESCRIPTION
## Summary

- Skip `convert_messages_structured` in debug dump path when `DumpFormat::Trace` is active — eliminates ~400KB transient allocation per LLM call (`native.rs` + `legacy.rs`)
- Truncate graph extraction context messages to 2KB via `floor_char_boundary(2048)` — caps context clone at ≤8KB regardless of message size

Both fixes are part of epic #2755 (reduce agent memory pressure in tool-heavy sessions).

## Changes

- `crates/zeph-core/src/debug_dump/mod.rs` — add `DebugDumper::is_trace_format()` (`#[must_use]`)
- `crates/zeph-core/src/agent/tool_execution/native.rs` — guard `debug_request_json` with `is_trace_format()` check
- `crates/zeph-core/src/agent/tool_execution/legacy.rs` — same guard (critic-identified gap)
- `crates/zeph-core/src/agent/persistence.rs` — truncate context messages in `maybe_spawn_graph_extraction`

## Test plan

- [ ] 7727/7727 unit tests pass (`cargo nextest run --workspace --lib --bins`)
- [ ] Live session: start with `[debug_dump] format = "trace"` (default), send 5+ messages, verify no `debug_request_json` allocations in session log
- [ ] Live session: send a message with >2KB content, verify graph extraction completes without error
- [ ] Non-Trace path: temporarily set `format = "json"`, verify debug dump files contain populated `provider_request`

## Follow-up

`maybe_spawn_persona_extraction` (`persistence.rs:738`) has the same unbounded `.map(|m| m.content.clone())` pattern — separate issue to be filed.

Closes #2757
Closes #2759