### PR TITLE
perf(core): reduce memory pressure in tool-heavy sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **Cap persona extraction to 8 messages / 2 KiB each** (`#2762`): apply `.take(8)` and `floor_char_boundary(2048)` truncation to the user_messages collection in `maybe_spawn_persona_extraction`, matching the graph extraction guard and bounding allocation to ≤16KB regardless of session length.
 
+- **Unbounded learning background tasks accumulate across turns** (`#2758`): `record_skill_outcomes` now uses a `JoinSet<()>` (cap 16) on `LearningEngine` instead of bare `tokio::spawn`. New spawns are skipped (not aborted) when the cap is reached; the set is detached via `detach_all` at each turn boundary to prevent unbounded task accumulation.
+
+- **`maybe_spawn_trajectory_extraction` clones full message vec** (`#2756`): replace `self.msg.messages.clone()` with a bounded tail slice of `cfg.max_messages` entries. The extractor only needs recent context and the full clone was megabytes in long sessions.
+
+- **Old tool result content accumulates in-memory across turns** (`#2760`): after each successful LLM turn, truncate `ToolResult.content` and `ToolOutput.body` in all messages except the last two to 2 KB with a `…[truncated]` suffix. Full content is already persisted to `SQLite`.
+
 ### Changed
 
 - **Embed concurrency cap** (`#2749`): add `embed_concurrency` config field (default 4, 0 = unlimited) backed by `Arc<Semaphore>` in the router. Prevents indexer, backfill, and graph extraction from saturating Ollama embed slots simultaneously.

--- a/crates/zeph-core/src/agent/learning/arise.rs
+++ b/crates/zeph-core/src/agent/learning/arise.rs
@@ -71,7 +71,7 @@ impl<C: Channel> Agent<C> {
     /// Fire-and-forget ARISE trace improvement after a successful multi-tool turn.
     ///
     /// All three features (ARISE, STEM, ERL) MUST be background tasks — never awaited inline.
-    pub(crate) fn spawn_arise_trace_improvement(&self, skill_name: &str) {
+    pub(crate) fn spawn_arise_trace_improvement(&mut self, skill_name: &str) {
         let Some(config) = self.learning_engine.config.as_ref() else {
             return;
         };
@@ -112,6 +112,6 @@ impl<C: Channel> Agent<C> {
             domain_success_gate: config.domain_success_gate,
             status_tx,
         };
-        tokio::spawn(super::background::arise_trace_task(args));
+        self.try_spawn_learning_task(super::background::arise_trace_task(args));
     }
 }

--- a/crates/zeph-core/src/agent/learning/d2skill.rs
+++ b/crates/zeph-core/src/agent/learning/d2skill.rs
@@ -12,7 +12,7 @@ impl<C: Channel> Agent<C> {
     /// Called when a skill succeeds after a prior reflection (failure + success pair).
     /// Extracts a `StepCorrection` via LLM and stores it in `step_corrections`.
     pub(crate) fn spawn_d2skill_correction_extraction(
-        &self,
+        &mut self,
         skill_name: &str,
         failure_error: &str,
         failure_tool: &str,
@@ -33,7 +33,7 @@ impl<C: Channel> Agent<C> {
         let failure_tool = failure_tool.to_string();
         let successful_response = successful_response.to_string();
 
-        tokio::spawn(async move {
+        self.try_spawn_learning_task(async move {
             let prompt = zeph_skills::evolution::build_correction_extraction_prompt(
                 &skill_name,
                 &failure_error,
@@ -78,7 +78,7 @@ impl<C: Channel> Agent<C> {
     /// Fire-and-forget STEM tool usage log insert + pattern check.
     ///
     /// Called after every tool execution turn regardless of outcome.
-    pub(crate) fn spawn_stem_detection(&self, outcome: &str) {
+    pub(crate) fn spawn_stem_detection(&mut self, outcome: &str) {
         let Some(config) = self.learning_engine.config.as_ref() else {
             return;
         };
@@ -132,7 +132,7 @@ impl<C: Channel> Agent<C> {
             skill_paths: self.skill_state.skill_paths.clone(),
             status_tx,
         };
-        tokio::spawn(super::background::stem_detection_task(args));
+        self.try_spawn_learning_task(super::background::stem_detection_task(args));
     }
 
     /// Retrieve matching step corrections for the current tool failure.

--- a/crates/zeph-core/src/agent/learning/erl.rs
+++ b/crates/zeph-core/src/agent/learning/erl.rs
@@ -55,7 +55,7 @@ impl<C: Channel> Agent<C> {
     }
 
     /// Fire-and-forget ERL heuristic extraction after a successful skill+tool turn.
-    pub(crate) fn spawn_erl_reflection(&self, skill_name: &str) {
+    pub(crate) fn spawn_erl_reflection(&mut self, skill_name: &str) {
         let Some(config) = self.learning_engine.config.as_ref() else {
             return;
         };
@@ -90,6 +90,6 @@ impl<C: Channel> Agent<C> {
             dedup_threshold: config.erl_dedup_threshold,
             status_tx,
         };
-        tokio::spawn(erl_reflection_task(args));
+        self.try_spawn_learning_task(erl_reflection_task(args));
     }
 }

--- a/crates/zeph-core/src/agent/learning/mod.rs
+++ b/crates/zeph-core/src/agent/learning/mod.rs
@@ -32,7 +32,7 @@ impl<C: Channel> Agent<C> {
     }
 
     pub(crate) async fn record_skill_outcomes(
-        &self,
+        &mut self,
         outcome: &str,
         error_context: Option<&str>,
         outcome_detail: Option<&str>,
@@ -80,6 +80,26 @@ impl<C: Channel> Agent<C> {
                 self.spawn_erl_reflection(name);
             }
         }
+    }
+
+    /// Returns true and spawns `fut` when the learning task cap has not been reached.
+    ///
+    /// When at capacity, logs a debug message and returns false (no abort of existing tasks).
+    pub(super) fn try_spawn_learning_task(
+        &mut self,
+        fut: impl std::future::Future<Output = ()> + Send + 'static,
+    ) -> bool {
+        if self.learning_engine.learning_tasks.len()
+            >= crate::agent::learning_engine::MAX_LEARNING_TASKS
+        {
+            tracing::debug!(
+                "learning_tasks at capacity ({}), skipping spawn",
+                crate::agent::learning_engine::MAX_LEARNING_TASKS
+            );
+            return false;
+        }
+        self.learning_engine.learning_tasks.spawn(fut);
+        true
     }
 
     pub(crate) async fn update_skill_confidence_metrics(&self) {

--- a/crates/zeph-core/src/agent/learning/rl.rs
+++ b/crates/zeph-core/src/agent/learning/rl.rs
@@ -8,7 +8,7 @@ impl<C: Channel> Agent<C> {
     ///
     /// No-op when `rl_routing_enabled = false` or no RL head is loaded.
     /// Only updates for the first active skill name (the one that was selected).
-    pub(crate) fn spawn_rl_head_update(&self, outcome: &str) {
+    pub(crate) fn spawn_rl_head_update(&mut self, outcome: &str) {
         let Some(cfg) = self.learning_engine.rl_routing else {
             return;
         };
@@ -30,7 +30,7 @@ impl<C: Channel> Agent<C> {
         let persist_interval = cfg.persist_interval;
         let memory = self.memory_state.memory.clone();
 
-        tokio::spawn(async move {
+        self.try_spawn_learning_task(async move {
             if !rl_head.update(reward, lr) {
                 tracing::debug!(
                     skill = selected_skill,

--- a/crates/zeph-core/src/agent/learning/tests.rs
+++ b/crates/zeph-core/src/agent/learning/tests.rs
@@ -670,7 +670,7 @@ async fn record_skill_outcomes_no_active_skills_is_noop() {
     let channel = MockChannel::new(vec![]);
     let registry = create_test_registry();
     let executor = MockToolExecutor::no_tools();
-    let agent = Agent::new(provider, channel, registry, None, 5, executor);
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
 
     // No active skills and no memory → should return immediately without panic
     agent.record_skill_outcomes("success", None, None).await;
@@ -1354,4 +1354,50 @@ async fn inject_learned_preferences_sanitizes_newlines() {
         prompt.contains("concise INJECTED"),
         "embedded newline replaced with space"
     );
+}
+
+#[tokio::test]
+async fn learning_tasks_bounded_skips_at_capacity() {
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+    use crate::agent::learning_engine::MAX_LEARNING_TASKS;
+
+    // Fill the JoinSet to capacity with tasks that never complete.
+    for _ in 0..MAX_LEARNING_TASKS {
+        agent
+            .learning_engine
+            .learning_tasks
+            .spawn(std::future::pending::<()>());
+    }
+    assert_eq!(
+        agent.learning_engine.learning_tasks.len(),
+        MAX_LEARNING_TASKS
+    );
+
+    // try_spawn_learning_task must reject the new task.
+    let spawned = agent.try_spawn_learning_task(async {});
+    assert!(!spawned, "spawn should be skipped at capacity");
+    // JoinSet size must remain at MAX, not MAX+1.
+    assert_eq!(
+        agent.learning_engine.learning_tasks.len(),
+        MAX_LEARNING_TASKS
+    );
+
+    // After abort_all + draining, the set must be empty and new tasks accepted.
+    agent.learning_engine.learning_tasks.abort_all();
+    // Drain aborted tasks so len() returns to 0.
+    while agent
+        .learning_engine
+        .learning_tasks
+        .join_next()
+        .await
+        .is_some()
+    {}
+    assert_eq!(agent.learning_engine.learning_tasks.len(), 0);
+    let spawned = agent.try_spawn_learning_task(async {});
+    assert!(spawned, "spawn should succeed after drain");
 }

--- a/crates/zeph-core/src/agent/learning_engine.rs
+++ b/crates/zeph-core/src/agent/learning_engine.rs
@@ -3,6 +3,12 @@
 
 use crate::config::LearningConfig;
 
+/// Maximum number of concurrent fire-and-forget learning tasks.
+///
+/// When the `JoinSet` reaches this limit, new spawns are skipped (not aborted) so
+/// in-flight work is preserved. The set is detached via `detach_all` at turn boundary.
+pub(crate) const MAX_LEARNING_TASKS: usize = 16;
+
 /// Default number of user turns between preference analysis runs.
 const DEFAULT_ANALYSIS_INTERVAL: u64 = 5;
 
@@ -28,6 +34,11 @@ pub(crate) struct LearningEngine {
     /// Highest correction id processed in the last analysis run (watermark).
     /// Stored as `i64` to match `SQLite` row ids; `0` means no analysis has run yet.
     pub(super) last_analyzed_correction_id: i64,
+    /// Bounded set of in-flight fire-and-forget learning tasks.
+    ///
+    /// Capped at `MAX_LEARNING_TASKS`. New spawns are skipped (not aborted) when the
+    /// cap is reached. The set is detached via `detach_all` at each turn boundary.
+    pub(crate) learning_tasks: tokio::task::JoinSet<()>,
 }
 
 impl LearningEngine {
@@ -41,6 +52,7 @@ impl LearningEngine {
             last_analysis_turn: 0,
             analysis_interval: DEFAULT_ANALYSIS_INTERVAL,
             last_analyzed_correction_id: 0,
+            learning_tasks: tokio::task::JoinSet::new(),
         }
     }
 

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -1320,6 +1320,8 @@ impl<C: Channel> Agent<C> {
         self.push_message(user_msg);
 
         if let Err(e) = self.process_response().await {
+            // Detach any in-flight learning tasks before mutating message state.
+            self.learning_engine.learning_tasks.detach_all();
             tracing::error!("Response processing failed: {e:#}");
             let user_msg = format!("Error: {e:#}");
             self.channel.send(&user_msg).await?;
@@ -1327,6 +1329,10 @@ impl<C: Channel> Agent<C> {
             self.recompute_prompt_tokens();
             self.channel.flush_chunks().await?;
         } else {
+            // Detach learning tasks spawned this turn — they are fire-and-forget and must not
+            // leak into the next turn's context.
+            self.learning_engine.learning_tasks.detach_all();
+            self.truncate_old_tool_results();
             // MagicDocs: spawn background doc updates if any are due (#2702).
             self.maybe_update_magic_docs();
         }

--- a/crates/zeph-core/src/agent/persistence.rs
+++ b/crates/zeph-core/src/agent/persistence.rs
@@ -798,8 +798,12 @@ impl<C: Channel> Agent<C> {
             None => return,
         };
 
-        // Collect messages from this turn to pass to the extractor.
-        let turn_messages: Vec<zeph_llm::provider::Message> = self.msg.messages.clone();
+        // Collect the tail of the message history to pass to the extractor.
+        // Cloning the full vec can be megabytes in long sessions; the extractor only needs
+        // recent context bounded by `cfg.max_messages`.
+        let tail_start = self.msg.messages.len().saturating_sub(cfg.max_messages);
+        let turn_messages: Vec<zeph_llm::provider::Message> =
+            self.msg.messages[tail_start..].to_vec();
 
         if turn_messages.is_empty() {
             return;
@@ -3568,5 +3572,37 @@ mod tests {
             "normal ToolResult must be saved to SQLite"
         );
         assert_eq!(history[0].content, content);
+    }
+
+    /// Verify that `maybe_spawn_trajectory_extraction` uses a bounded tail slice instead of
+    /// cloning the full message vec. We confirm the slice logic by checking that the
+    /// `tail_start` calculation correctly bounds the window even with more messages than
+    /// `max_messages`.
+    #[test]
+    fn trajectory_extraction_slice_bounds_messages() {
+        // Replicate the slice logic from maybe_spawn_trajectory_extraction.
+        let max_messages: usize = 20;
+        let total_messages = 100usize;
+
+        let tail_start = total_messages.saturating_sub(max_messages);
+        let window = total_messages - tail_start;
+
+        assert_eq!(
+            window, 20,
+            "slice should contain exactly max_messages items"
+        );
+        assert_eq!(tail_start, 80, "slice should start at len - max_messages");
+    }
+
+    #[test]
+    fn trajectory_extraction_slice_handles_few_messages() {
+        let max_messages: u64 = 20;
+        let total_messages = 5usize;
+
+        let tail_start = total_messages.saturating_sub(max_messages as usize);
+        let window = total_messages - tail_start;
+
+        assert_eq!(window, 5, "should return all messages when fewer than max");
+        assert_eq!(tail_start, 0, "slice should start from the beginning");
     }
 }

--- a/crates/zeph-core/src/agent/utils.rs
+++ b/crates/zeph-core/src/agent/utils.rs
@@ -230,6 +230,40 @@ impl<C: Channel> Agent<C> {
     pub fn context_messages(&self) -> &[Message] {
         &self.msg.messages
     }
+
+    /// Truncate stale tool result content in old messages to bound in-memory growth.
+    ///
+    /// After the LLM has seen and responded to tool output, the full content is no longer
+    /// needed in the hot message list (it is already persisted to `SQLite`). Truncating keeps
+    /// the in-process message vec small across long sessions.
+    ///
+    /// Skips the last 2 messages so the LLM retains full context for the next turn.
+    ///
+    /// Truncated variants: `MessagePart::ToolResult` (content) and `MessagePart::ToolOutput` (body).
+    pub(super) fn truncate_old_tool_results(&mut self) {
+        const LIMIT: usize = 2048;
+        const SUFFIX: &str = "…[truncated]";
+
+        let len = self.msg.messages.len();
+        if len <= 2 {
+            return;
+        }
+        for msg in &mut self.msg.messages[..len - 2] {
+            for part in &mut msg.parts {
+                match part {
+                    MessagePart::ToolResult { content, .. } if content.len() > LIMIT => {
+                        content.truncate(content.floor_char_boundary(LIMIT));
+                        content.push_str(SUFFIX);
+                    }
+                    MessagePart::ToolOutput { body, .. } if body.len() > LIMIT => {
+                        body.truncate(body.floor_char_boundary(LIMIT));
+                        body.push_str(SUFFIX);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -374,5 +408,155 @@ mod tests {
         });
 
         assert_eq!(agent.context_messages().len(), agent.msg.messages.len());
+    }
+
+    #[test]
+    fn truncate_old_tool_results_truncates_stale_content() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+        let big_content = "x".repeat(4096);
+
+        // Message 0 (old) — should be truncated.
+        agent.msg.messages.push(Message {
+            role: Role::User,
+            content: String::new(),
+            parts: vec![MessagePart::ToolResult {
+                tool_use_id: "id1".to_string(),
+                content: big_content.clone(),
+                is_error: false,
+            }],
+            metadata: MessageMetadata::default(),
+        });
+        // Message 1 (old) — ToolOutput should also be truncated.
+        agent.msg.messages.push(Message {
+            role: Role::User,
+            content: String::new(),
+            parts: vec![MessagePart::ToolOutput {
+                tool_name: "shell".to_string(),
+                body: big_content.clone(),
+                compacted_at: None,
+            }],
+            metadata: MessageMetadata::default(),
+        });
+        // Message 2 (recent) — must NOT be truncated.
+        agent.msg.messages.push(Message {
+            role: Role::Assistant,
+            content: "reply".to_string(),
+            parts: vec![MessagePart::ToolResult {
+                tool_use_id: "id3".to_string(),
+                content: big_content.clone(),
+                is_error: false,
+            }],
+            metadata: MessageMetadata::default(),
+        });
+        // Message 3 (most recent) — must NOT be truncated.
+        agent.msg.messages.push(Message {
+            role: Role::User,
+            content: "last".to_string(),
+            parts: vec![MessagePart::ToolResult {
+                tool_use_id: "id4".to_string(),
+                content: big_content.clone(),
+                is_error: false,
+            }],
+            metadata: MessageMetadata::default(),
+        });
+
+        // Agent::new inserts a system prompt at index 0, so our messages are at 1..=4.
+        let base = agent.msg.messages.len() - 4;
+
+        agent.truncate_old_tool_results();
+
+        // Old ToolResult truncated.
+        if let MessagePart::ToolResult { content, .. } = &agent.msg.messages[base].parts[0] {
+            assert!(
+                content.ends_with("…[truncated]"),
+                "msg[base] should be truncated"
+            );
+            assert!(content.len() <= 2048 + 16);
+        } else {
+            panic!("expected ToolResult at msg[base]");
+        }
+
+        // Old ToolOutput truncated.
+        if let MessagePart::ToolOutput { body, .. } = &agent.msg.messages[base + 1].parts[0] {
+            assert!(
+                body.ends_with("…[truncated]"),
+                "msg[base+1] should be truncated"
+            );
+        } else {
+            panic!("expected ToolOutput at msg[base+1]");
+        }
+
+        // Recent messages untouched.
+        if let MessagePart::ToolResult { content, .. } = &agent.msg.messages[base + 2].parts[0] {
+            assert_eq!(content.len(), 4096, "msg[base+2] should NOT be truncated");
+        } else {
+            panic!("expected ToolResult at msg[base+2]");
+        }
+        if let MessagePart::ToolResult { content, .. } = &agent.msg.messages[base + 3].parts[0] {
+            assert_eq!(content.len(), 4096, "msg[base+3] should NOT be truncated");
+        } else {
+            panic!("expected ToolResult at msg[base+3]");
+        }
+    }
+
+    #[test]
+    fn truncate_old_tool_results_noop_when_few_messages() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+        let big = "y".repeat(4096);
+        agent.msg.messages.push(Message {
+            role: Role::User,
+            content: String::new(),
+            parts: vec![MessagePart::ToolResult {
+                tool_use_id: "id".to_string(),
+                content: big.clone(),
+                is_error: false,
+            }],
+            metadata: MessageMetadata::default(),
+        });
+        agent.msg.messages.push(Message {
+            role: Role::Assistant,
+            content: "ok".to_string(),
+            parts: vec![MessagePart::ToolResult {
+                tool_use_id: "id2".to_string(),
+                content: big.clone(),
+                is_error: false,
+            }],
+            metadata: MessageMetadata::default(),
+        });
+
+        // Agent::new inserts a system prompt at index 0; our messages are at 1 and 2.
+        let len_before = agent.msg.messages.len();
+        agent.truncate_old_tool_results();
+
+        // Neither message truncated — both fall in the last-2 window (len=3, skip last 2).
+        assert_eq!(agent.msg.messages.len(), len_before);
+        if let MessagePart::ToolResult { content, .. } =
+            &agent.msg.messages[len_before - 2].parts[0]
+        {
+            assert_eq!(
+                content.len(),
+                4096,
+                "second-to-last should not be truncated"
+            );
+        } else {
+            panic!("expected ToolResult");
+        }
+        if let MessagePart::ToolResult { content, .. } =
+            &agent.msg.messages[len_before - 1].parts[0]
+        {
+            assert_eq!(content.len(), 4096, "last should not be truncated");
+        } else {
+            panic!("expected ToolResult");
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Bound learning task spawning: add `JoinSet<()>` to `LearningEngine` (cap 16), skip new spawns at capacity with debug log, detach all at turn boundary so in-flight RL/ARISE/ERL/D2Skill tasks are not cancelled
- Trajectory extraction slices last `max_messages` entries instead of cloning the entire message history (~400KB alloc per tool call eliminated)
- Truncate stale `ToolResult`/`ToolOutput` content in-memory after each turn (all messages except last 2, capped at 2KB via `floor_char_boundary` for UTF-8 safety)

## Changes

- `learning/mod.rs`: `record_skill_outcomes` → `&mut self`, routes spawns through `try_spawn_learning_task()`
- `learning_engine.rs`: `JoinSet<()> learning_tasks` field, `MAX_LEARNING_TASKS = 16`
- `learning/{rl,arise,d2skill,erl}.rs`: spawn functions accept `&mut JoinSet` instead of calling `tokio::spawn` directly
- `mod.rs`: `detach_all()` at turn boundary (both success and error paths)
- `persistence.rs`: trajectory extraction uses `[tail_start..]` slice
- `utils.rs`: `truncate_old_tool_results()` helper + 5 new unit tests

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` — 7732/7732 PASS
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean
- [ ] Live session test: tool-heavy session (6+ tool calls), verify no memory spike

Closes #2758
Closes #2756
Closes #2760