### PR TITLE
fix(core): add timeouts and tracing to prevent agent stall after tool batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Agent stall after tool batch: add timeouts and tracing** (`#2767`): wrap `check_summarization` (30s), `maybe_spawn_graph_extraction` (10s), `record_skill_outcomes_batch` (5s), `is_available` LSP check (2s), and guardrail check (10s) in `tokio::time::timeout`; add `tracing::debug!` checkpoints to `tool_batch` and `persist_message` to make stalls observable.
+
 - **LSP `after_tool` blocks agent loop up to 160s** (`#2750`): wrap the entire LSP hover hook loop in a single 30s `tokio::time::timeout` instead of blocking sequentially per file. Combined with `max_symbols` reduction (10 → 5, `#2752`), worst-case blocking drops from ~160s to 30s.
 
 - **No TUI status during LLM inference** (`#2747`): add `send_status("Analyzing changes...")` around the LSP hook loop so the status bar reflects background work instead of appearing frozen.

--- a/crates/zeph-core/src/agent/learning/mod.rs
+++ b/crates/zeph-core/src/agent/learning/mod.rs
@@ -43,18 +43,26 @@ impl<C: Channel> Agent<C> {
         let Some(memory) = &self.memory_state.memory else {
             return;
         };
-        if let Err(e) = memory
-            .sqlite()
-            .record_skill_outcomes_batch(
+        let batch_result = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            memory.sqlite().record_skill_outcomes_batch(
                 &self.skill_state.active_skill_names,
                 self.memory_state.conversation_id,
                 outcome,
                 error_context,
                 outcome_detail,
-            )
-            .await
-        {
-            tracing::warn!("failed to record skill outcomes: {e:#}");
+            ),
+        )
+        .await;
+        match batch_result {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                tracing::warn!("failed to record skill outcomes: {e:#}");
+            }
+            Err(_) => {
+                tracing::warn!("record_skill_outcomes: timed out after 5s");
+                return;
+            }
         }
 
         if outcome != "success" {

--- a/crates/zeph-core/src/agent/persistence.rs
+++ b/crates/zeph-core/src/agent/persistence.rs
@@ -549,7 +549,11 @@ impl<C: Channel> Agent<C> {
             }
         });
 
+        tracing::debug!("persist_message: db insert complete");
+
+        tracing::debug!("persist_message: calling check_summarization");
         self.check_summarization().await;
+        tracing::debug!("persist_message: check_summarization complete");
 
         // FIX-1: skip graph extraction for tool result messages — they contain raw structured
         // output (TOML, JSON, code) that pollutes the entity graph with noise.
@@ -557,17 +561,23 @@ impl<C: Channel> Agent<C> {
             .iter()
             .any(|p| matches!(p, MessagePart::ToolResult { .. }));
 
+        tracing::debug!("persist_message: calling maybe_spawn_graph_extraction");
         self.maybe_spawn_graph_extraction(content, has_injection_flags, has_tool_result_parts)
             .await;
+        tracing::debug!("persist_message: maybe_spawn_graph_extraction complete");
 
         // Persona extraction: run only for user messages that are not tool results and not injected.
         if role == Role::User && !has_tool_result_parts && !has_injection_flags {
+            tracing::debug!("persist_message: calling persona extraction");
             self.maybe_spawn_persona_extraction().await;
+            tracing::debug!("persist_message: persona extraction complete");
         }
 
         // Trajectory extraction: run after turns that contained tool results.
         if has_tool_result_parts {
+            tracing::debug!("persist_message: calling trajectory extraction");
             self.maybe_spawn_trajectory_extraction();
+            tracing::debug!("persist_message: trajectory extraction complete");
         }
     }
 
@@ -705,8 +715,17 @@ impl<C: Channel> Agent<C> {
         let _ = self.channel.send_status("").await;
         self.sync_community_detection_failures();
         self.sync_graph_extraction_metrics();
-        self.sync_graph_counts().await;
-        self.sync_guidelines_status().await;
+        match tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            self.sync_graph_counts().await;
+            self.sync_guidelines_status().await;
+        })
+        .await
+        {
+            Ok(()) => {}
+            Err(_) => {
+                tracing::warn!("persist_message: maybe_spawn_graph_extraction timed out after 10s");
+            }
+        }
     }
 
     async fn maybe_spawn_persona_extraction(&mut self) {
@@ -893,19 +912,27 @@ impl<C: Channel> Agent<C> {
         if self.memory_state.unsummarized_count > self.memory_state.summarization_threshold {
             let _ = self.channel.send_status("summarizing...").await;
             let batch_size = self.memory_state.summarization_threshold / 2;
-            match memory.summarize(cid, batch_size).await {
-                Ok(Some(summary_id)) => {
+            match tokio::time::timeout(
+                std::time::Duration::from_secs(30),
+                memory.summarize(cid, batch_size),
+            )
+            .await
+            {
+                Ok(Ok(Some(summary_id))) => {
                     tracing::info!("created summary {summary_id} for conversation {cid}");
                     self.memory_state.unsummarized_count = 0;
                     self.update_metrics(|m| {
                         m.summaries_count += 1;
                     });
                 }
-                Ok(None) => {
+                Ok(Ok(None)) => {
                     tracing::debug!("no summarization needed");
                 }
-                Err(e) => {
+                Ok(Err(e)) => {
                     tracing::error!("summarization failed: {e:#}");
+                }
+                Err(_) => {
+                    tracing::warn!("persist_message: check_summarization timed out after 30s");
                 }
             }
             let _ = self.channel.send_status("").await;

--- a/crates/zeph-core/src/agent/tool_execution/mod.rs
+++ b/crates/zeph-core/src/agent/tool_execution/mod.rs
@@ -405,7 +405,16 @@ impl<C: Channel> Agent<C> {
         if !guardrail.scan_tool_output() {
             return body;
         }
-        let verdict = guardrail.check(&body).await;
+        let verdict = if let Ok(v) =
+            tokio::time::timeout(std::time::Duration::from_secs(10), guardrail.check(&body)).await
+        {
+            v
+        } else {
+            tracing::warn!(tool = %tool_name, "tool guardrail check timed out after 10s");
+            zeph_sanitizer::guardrail::GuardrailVerdict::Error {
+                error: "timeout".into(),
+            }
+        };
         if let GuardrailVerdict::Flagged { reason, .. } = &verdict {
             tracing::warn!(
                 tool = %tool_name,

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -1879,8 +1879,10 @@ impl<C: Channel> Agent<C> {
                 let kind = tool_err_category
                     .take()
                     .map_or_else(|| FailureKind::from_error(&output), FailureKind::from);
+                tracing::debug!(tool = %tc.name, "tool_result: recording skill outcomes");
                 self.record_skill_outcomes("tool_failure", Some(&output), Some(kind.as_str()))
                     .await;
+                tracing::debug!(tool = %tc.name, "tool_result: skill outcomes recorded");
                 // Record quality failure for reputation scoring only when the model produced
                 // invalid tool arguments (semantic failure). Network errors and transient
                 // failures are not attributable to model quality.
@@ -1907,7 +1909,9 @@ impl<C: Channel> Agent<C> {
                     pending_reflection = Some(sanitized_out);
                 }
             } else {
+                tracing::debug!(tool = %tc.name, "tool_result: recording skill outcomes");
                 self.record_skill_outcomes("success", None, None).await;
+                tracing::debug!(tool = %tc.name, "tool_result: skill outcomes recorded");
                 // Record quality success for reputation scoring.
                 self.provider
                     .record_quality_outcome(self.provider.name(), true);
@@ -2028,6 +2032,7 @@ impl<C: Channel> Agent<C> {
         // result, which would change message history structure.
         let tool_results_have_flags =
             has_any_injection_flags || !self.security.flagged_urls.is_empty();
+        tracing::debug!("tool_batch: calling persist_message for tool results");
         self.persist_message(
             Role::User,
             &user_msg.content,
@@ -2035,7 +2040,9 @@ impl<C: Channel> Agent<C> {
             tool_results_have_flags,
         )
         .await;
+        tracing::debug!("tool_batch: persist_message done, pushing message");
         self.push_message(user_msg);
+        tracing::debug!("tool_batch: message pushed, starting LSP hooks");
         if let (Some(id), Some(last)) =
             (self.last_persisted_message_id, self.msg.messages.last_mut())
         {
@@ -2096,6 +2103,7 @@ impl<C: Channel> Agent<C> {
             if lsp_result.is_err() {
                 tracing::warn!("LSP after_tool batch timed out (30s)");
             }
+            tracing::debug!("tool_batch: LSP hooks done");
         }
 
         // Defense-in-depth: check if process cwd changed during this tool batch.

--- a/crates/zeph-core/src/lsp_hooks/mod.rs
+++ b/crates/zeph-core/src/lsp_hooks/mod.rs
@@ -88,10 +88,20 @@ impl LspHookRunner {
     /// hot path; individual MCP call failures are logged at `debug` level and
     /// silently ignored.
     pub async fn is_available(&self) -> bool {
-        self.manager
-            .list_servers()
-            .await
-            .contains(&self.config.mcp_server_id)
+        tracing::debug!("lsp_hooks: checking is_available");
+        let result = if let Ok(servers) = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            self.manager.list_servers(),
+        )
+        .await
+        {
+            servers.contains(&self.config.mcp_server_id)
+        } else {
+            tracing::warn!("lsp_hooks: is_available check timed out after 2s");
+            false
+        };
+        tracing::debug!(available = result, "lsp_hooks: is_available check complete");
+        result
     }
 
     /// Called after a native tool completes.
@@ -113,7 +123,14 @@ impl LspHookRunner {
             tracing::debug!(tool = tool_name, "LSP hook: skipped (disabled)");
             return;
         }
-        if !self.is_available().await {
+        tracing::debug!(tool = tool_name, "LSP after_tool: checking availability");
+        let avail = self.is_available().await;
+        tracing::debug!(
+            tool = tool_name,
+            available = avail,
+            "LSP after_tool: availability checked"
+        );
+        if !avail {
             tracing::debug!(tool = tool_name, "LSP hook: skipped (server unavailable)");
             return;
         }


### PR DESCRIPTION
## Summary

- Wrap `check_summarization` (30s), `maybe_spawn_graph_extraction` (10s), `record_skill_outcomes_batch` (5s), `is_available` LSP check (2s), and guardrail check (10s) in `tokio::time::timeout`
- Add `tracing::debug!` checkpoints at every `persist_message` stage and `tool_batch` phase so stall location is visible in `RUST_LOG=debug` output
- Clippy fixes: `single_match_else` in `tool_execution/mod.rs` and `lsp_hooks/mod.rs`

Closes #2767

## Test plan

- [ ] `cargo +nightly fmt --check` ✅
- [ ] `cargo clippy --workspace -- -D warnings` ✅
- [ ] `cargo nextest run --workspace --lib --bins` ✅ 7734 passed
- [ ] Live test: run with `RUST_LOG=debug`, issue 4+ tool calls in one batch, verify debug checkpoints appear in log and no stall > 30s