### PR TITLE
perf(learning): batch record_skill_outcomes per tool batch, add query timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Performance
 
+- **Batch `record_skill_outcomes` per tool batch, add per-query timeouts** (`#2770`): `record_skill_outcomes` was called once per tool result inside the batch loop, triggering N×M×13 sequential SQLite queries (10 tools × 2 skills × 13 queries × ~50ms ≈ 13s stall). Three changes: (1) accumulate `PendingSkillOutcome` during the tool loop and flush once via `flush_skill_outcomes` after; (2) wrap `check_rollback` and `check_trust_transition` bodies in a 2s `tokio::time::timeout` (outer delegates to `_inner`; timeout logs a warning and returns the safe default); (3) wrap `update_skill_confidence_metrics` in a 2s timeout instead of spawning (metrics field is `watch::Sender`, not `Clone`).
+
 - **Skip `debug_request_json` when dump format is Trace** (`#2757`): add `is_trace_format()` to `DebugDumper` and guard the `convert_messages_structured` call in `native.rs` and `legacy.rs` — eliminates ~400KB transient allocation per LLM call in the default Trace-format configuration.
 
 - **Truncate graph extraction context messages to 2KB** (`#2759`): cap each cloned message content at `floor_char_boundary(2048)` bytes before passing to `maybe_spawn_graph_extraction`, bounding context allocation to ≤8KB regardless of message size.

--- a/crates/zeph-core/src/agent/learning/mod.rs
+++ b/crates/zeph-core/src/agent/learning/mod.rs
@@ -16,6 +16,15 @@ mod tests;
 
 use super::{Agent, Channel};
 
+/// Accumulated skill outcome for a single tool result within a batch.
+/// Used by `flush_skill_outcomes` to collapse N per-tool-result `record_skill_outcomes`
+/// calls into a single pass after the tool batch completes.
+pub(crate) struct PendingSkillOutcome {
+    pub outcome: String,
+    pub error_context: Option<String>,
+    pub outcome_detail: Option<String>,
+}
+
 impl<C: Channel> Agent<C> {
     pub(crate) fn is_learning_enabled(&self) -> bool {
         self.learning_engine.is_enabled()
@@ -83,6 +92,91 @@ impl<C: Channel> Agent<C> {
         // ARISE + STEM + ERL background tasks (fire-and-forget, never block response).
         self.spawn_stem_detection(outcome);
         if outcome == "success" {
+            for name in &names {
+                self.spawn_arise_trace_improvement(name);
+                self.spawn_erl_reflection(name);
+            }
+        }
+    }
+
+    /// Flush all accumulated skill outcomes from a tool batch in a single pass.
+    ///
+    /// Replaces N sequential `record_skill_outcomes` calls (one per tool result) with one
+    /// batched write + one rollback/trust check per skill. This eliminates the N×M×13
+    /// sequential `SQLite` awaits that stalled the agent loop (#2770).
+    ///
+    /// # Dominant outcome for RL/ARISE/ERL signals
+    ///
+    /// Mixed batches (successes + failures) are collapsed to a single "dominant" outcome:
+    /// any failure in the batch → `"tool_failure"`, otherwise `"success"`. This trades
+    /// per-tool RL signal granularity for loop latency — acceptable because the RL head
+    /// operates at turn granularity anyway.
+    pub(crate) async fn flush_skill_outcomes(&mut self, outcomes: Vec<PendingSkillOutcome>) {
+        if outcomes.is_empty() || self.skill_state.active_skill_names.is_empty() {
+            return;
+        }
+        let Some(memory) = &self.memory_state.memory else {
+            return;
+        };
+
+        // Batch-insert each outcome entry (one DB call per entry, but only once per tool —
+        // not once per tool × skill as was the case before batching).
+        for o in &outcomes {
+            let batch_result = tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                memory.sqlite().record_skill_outcomes_batch(
+                    &self.skill_state.active_skill_names,
+                    self.memory_state.conversation_id,
+                    &o.outcome,
+                    o.error_context.as_deref(),
+                    o.outcome_detail.as_deref(),
+                ),
+            )
+            .await;
+            match batch_result {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => tracing::warn!("failed to record skill outcomes: {e:#}"),
+                Err(_) => {
+                    tracing::warn!("record_skill_outcomes: timed out after 5s");
+                    break;
+                }
+            }
+        }
+
+        let had_failure = outcomes.iter().any(|o| o.outcome != "success");
+
+        // Run rollback + trust checks ONCE per skill (not once per tool result).
+        if had_failure {
+            for name in &self.skill_state.active_skill_names.clone() {
+                self.check_rollback(name).await;
+            }
+        }
+        let names: Vec<String> = self.skill_state.active_skill_names.clone();
+        for name in &names {
+            self.check_trust_transition(name).await;
+        }
+
+        // update_skill_confidence_metrics does one SQLite read + one watch::Sender::send_modify.
+        // Wrap with a timeout to prevent stalling the loop if SQLite is slow.
+        if let Err(_elapsed) = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            self.update_skill_confidence_metrics(),
+        )
+        .await
+        {
+            tracing::warn!("update_skill_confidence_metrics timed out after 2s");
+        }
+
+        // Determine dominant outcome: any failure → "tool_failure", else "success".
+        let dominant = if had_failure {
+            "tool_failure"
+        } else {
+            "success"
+        };
+
+        self.spawn_rl_head_update(dominant);
+        self.spawn_stem_detection(dominant);
+        if !had_failure {
             for name in &names {
                 self.spawn_arise_trace_improvement(name);
                 self.spawn_erl_reflection(name);

--- a/crates/zeph-core/src/agent/learning/outcomes.rs
+++ b/crates/zeph-core/src/agent/learning/outcomes.rs
@@ -427,8 +427,19 @@ impl<C: Channel> Agent<C> {
         }
     }
 
-    #[allow(clippy::cast_precision_loss)]
     pub(crate) async fn check_rollback(&self, skill_name: &str) {
+        if let Err(_elapsed) = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            self.check_rollback_inner(skill_name),
+        )
+        .await
+        {
+            tracing::warn!(skill = skill_name, "check_rollback timed out after 2s");
+        }
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    async fn check_rollback_inner(&self, skill_name: &str) {
         if !self.is_learning_enabled() {
             return;
         }

--- a/crates/zeph-core/src/agent/learning/tests.rs
+++ b/crates/zeph-core/src/agent/learning/tests.rs
@@ -1358,13 +1358,13 @@ async fn inject_learned_preferences_sanitizes_newlines() {
 
 #[tokio::test]
 async fn learning_tasks_bounded_skips_at_capacity() {
+    use crate::agent::learning_engine::MAX_LEARNING_TASKS;
+
     let provider = mock_provider(vec![]);
     let channel = MockChannel::new(vec![]);
     let registry = create_test_registry();
     let executor = MockToolExecutor::no_tools();
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
-
-    use crate::agent::learning_engine::MAX_LEARNING_TASKS;
 
     // Fill the JoinSet to capacity with tasks that never complete.
     for _ in 0..MAX_LEARNING_TASKS {

--- a/crates/zeph-core/src/agent/learning/trust.rs
+++ b/crates/zeph-core/src/agent/learning/trust.rs
@@ -4,8 +4,22 @@
 use super::super::{Agent, Channel};
 
 impl<C: Channel> Agent<C> {
-    #[allow(clippy::too_many_lines)]
     pub(crate) async fn check_trust_transition(&self, skill_name: &str) {
+        if let Err(_elapsed) = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            self.check_trust_transition_inner(skill_name),
+        )
+        .await
+        {
+            tracing::warn!(
+                skill = skill_name,
+                "check_trust_transition timed out after 2s"
+            );
+        }
+    }
+
+    #[allow(clippy::too_many_lines)]
+    async fn check_trust_transition_inner(&self, skill_name: &str) {
         let Some(memory) = &self.memory_state.memory else {
             return;
         };

--- a/crates/zeph-core/src/agent/tool_execution/legacy.rs
+++ b/crates/zeph-core/src/agent/tool_execution/legacy.rs
@@ -520,6 +520,10 @@ impl<C: Channel> Agent<C> {
         unreachable!("loop covers all attempts")
     }
 
+    // Note: the legacy path processes one tool result at a time (no batch) because providers
+    // that reach this path do not support native tool_use. Batching outcomes (as done in
+    // native.rs via flush_skill_outcomes, see #2770) is not applicable here — each call
+    // already represents one outcome for the turn.
     pub(super) async fn handle_tool_result(
         &mut self,
         response: &str,

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -1744,6 +1744,9 @@ impl<C: Channel> Agent<C> {
         // Deferred self-reflection: set to the sanitized error output of the first failing tool
         // that is eligible for reflection. Consumed after user_msg is pushed to history.
         let mut pending_reflection: Option<String> = None;
+        // Accumulate skill outcomes during the tool loop; flushed once after the loop via
+        // flush_skill_outcomes to avoid N×M×13 sequential SQLite awaits (#2770).
+        let mut pending_outcomes: Vec<crate::agent::learning::PendingSkillOutcome> = Vec::new();
         for idx in 0..tool_calls.len() {
             let tc = &tool_calls[idx];
             let tool_call_id = &tool_call_ids[idx];
@@ -1879,10 +1882,11 @@ impl<C: Channel> Agent<C> {
                 let kind = tool_err_category
                     .take()
                     .map_or_else(|| FailureKind::from_error(&output), FailureKind::from);
-                tracing::debug!(tool = %tc.name, "tool_result: recording skill outcomes");
-                self.record_skill_outcomes("tool_failure", Some(&output), Some(kind.as_str()))
-                    .await;
-                tracing::debug!(tool = %tc.name, "tool_result: skill outcomes recorded");
+                pending_outcomes.push(crate::agent::learning::PendingSkillOutcome {
+                    outcome: "tool_failure".into(),
+                    error_context: Some(output.clone()),
+                    outcome_detail: Some(kind.as_str().into()),
+                });
                 // Record quality failure for reputation scoring only when the model produced
                 // invalid tool arguments (semantic failure). Network errors and transient
                 // failures are not attributable to model quality.
@@ -1909,9 +1913,11 @@ impl<C: Channel> Agent<C> {
                     pending_reflection = Some(sanitized_out);
                 }
             } else {
-                tracing::debug!(tool = %tc.name, "tool_result: recording skill outcomes");
-                self.record_skill_outcomes("success", None, None).await;
-                tracing::debug!(tool = %tc.name, "tool_result: skill outcomes recorded");
+                pending_outcomes.push(crate::agent::learning::PendingSkillOutcome {
+                    outcome: "success".into(),
+                    error_context: None,
+                    outcome_detail: None,
+                });
                 // Record quality success for reputation scoring.
                 self.provider
                     .record_quality_outcome(self.provider.name(), true);
@@ -1965,6 +1971,11 @@ impl<C: Channel> Agent<C> {
                 is_error,
             });
         }
+
+        // Flush all accumulated skill outcomes from the tool batch in a single pass.
+        // This replaces the per-tool record_skill_outcomes calls that caused N×M sequential
+        // SQLite awaits (#2770).
+        self.flush_skill_outcomes(pending_outcomes).await;
 
         // Causal IPI post-probe: compare behavioral state after tool batch results.
         // Uses tool output snippets (first 200 chars each) — never the full sanitized content.


### PR DESCRIPTION
## Summary

- `record_skill_outcomes()` was called once per tool result in the batch loop, producing N×M×13 sequential unbounded SQLite awaits (10 tools × 2 skills × 13 queries × ~50ms ≈ 13s stall)
- Accumulate `PendingSkillOutcome` during the tool loop; call `flush_skill_outcomes()` once after — eliminates the N multiplier
- Wrap `check_rollback` and `check_trust_transition` in 2s `tokio::time::timeout` (outer delegates to `_inner`; timeout logs warn and returns safe default)
- Wrap `update_skill_confidence_metrics` in 2s timeout (`watch::Sender` is not `Clone`, spawn not viable)

## Files changed

- `learning/mod.rs` — `PendingSkillOutcome` struct, `flush_skill_outcomes` method, metrics timeout
- `learning/outcomes.rs` — `check_rollback` → outer (2s timeout) + `check_rollback_inner`
- `learning/trust.rs` — `check_trust_transition` → outer (2s timeout) + `check_trust_transition_inner`
- `tool_execution/native.rs` — accumulate outcomes during loop, flush after
- `tool_execution/legacy.rs` — comment documenting deliberate exclusion from batching

## Test plan

- [x] `cargo nextest run --workspace --lib --bins` — 7734/7734 PASS
- [x] `cargo +nightly fmt --check` — clean
- [x] Clippy — clean (pre-existing `persistence.rs` cast warning not introduced by this PR)
- [ ] Live session test: run multi-turn session with tool-heavy prompt and verify no stall logged

## Notes

Worst-case bounded latency after fix: M×4s + 2s (rollback + trust per skill + metrics) — down from unbounded N×M multiplication. Follow-up: file issue for `record_skill_outcomes_multi` multi-row INSERT to eliminate the remaining N per-outcome loop inside `flush_skill_outcomes`.

Closes #2770
Part of #2755