### PR TITLE
refactor(core): DRY token estimation and system message removal (#2778, #2779)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Refactored
+
+- **Replace inline `len()/4` token estimation with `estimate_tokens()`** (`#2778`): 15 call sites across `zeph-core`, `zeph-llm`, and `zeph-memory` now use the centralized `zeph_common::text::estimate_tokens()` function, which counts Unicode scalars (`chars().count() / 4`) instead of bytes — more accurate for non-ASCII content and trivial to improve later from a single location.
+
+- **Extract shared `remove_system_messages` helpers in context assembly** (`#2779`): 11 nearly-identical `remove_*_messages()` methods in `ContextAssembly` now delegate to two private helpers (`remove_by_prefix`, `remove_by_part_or_prefix`), reducing ~80 lines of duplicated retain logic to one-liner delegates.
+
 ### Added
 
 - **Embed backfill progress tracking with bounded memory and concurrency** (`#2765`): `embed_missing` now accepts a `watch::Sender<Option<BackfillProgress>>` and reports `done/total` progress after each message. Messages are processed in micro-batches of 32 with `buffer_unordered(4)` concurrency, reducing peak memory from all-at-once to ~32 messages worth of content and cutting wall-clock time 3-4x via parallel HTTP embedding calls. The TUI status bar shows `Backfilling embeddings: N/M (X%)` during backfill and clears on completion.

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -22,6 +22,7 @@ use crate::context::ContextBudget;
 use crate::cost::CostTracker;
 use crate::instructions::{InstructionEvent, InstructionReloadState};
 use crate::metrics::MetricsSnapshot;
+use zeph_common::text::estimate_tokens;
 use zeph_memory::semantic::SemanticMemory;
 use zeph_skills::watcher::SkillEvent;
 
@@ -1278,7 +1279,7 @@ impl<C: Channel> Agent<C> {
             .msg
             .messages
             .first()
-            .map_or(0, |m| u64::try_from(m.content.len()).unwrap_or(0) / 4);
+            .map_or(0, |m| estimate_tokens(&m.content) as u64);
         let mcp_tool_count = self.mcp.tools.len();
         let mcp_server_count = if self.mcp.server_outcomes.is_empty() {
             // Fallback: count unique server IDs from connected tools

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -41,49 +41,50 @@ impl<C: Channel> Agent<C> {
         self.recompute_prompt_tokens();
     }
 
-    pub(in crate::agent) fn remove_recall_messages(&mut self) {
+    fn remove_by_prefix(&mut self, role: Role, prefix: &str) {
+        self.msg
+            .messages
+            .retain(|m| m.role != role || !m.content.starts_with(prefix));
+    }
+
+    fn remove_by_part_or_prefix(
+        &mut self,
+        prefix: &str,
+        part_matches: impl Fn(&MessagePart) -> bool,
+    ) {
         self.msg.messages.retain(|m| {
             if m.role != Role::System {
                 return true;
             }
-            if m.parts
-                .first()
-                .is_some_and(|p| matches!(p, MessagePart::Recall { .. }))
-            {
+            if m.parts.first().is_some_and(&part_matches) {
                 return false;
             }
-            !m.content.starts_with(RECALL_PREFIX)
+            !m.content.starts_with(prefix)
         });
+    }
+
+    pub(in crate::agent) fn remove_recall_messages(&mut self) {
+        self.remove_by_part_or_prefix(RECALL_PREFIX, |p| matches!(p, MessagePart::Recall { .. }));
     }
 
     pub(in crate::agent) fn remove_correction_messages(&mut self) {
-        self.msg
-            .messages
-            .retain(|m| m.role != Role::System || !m.content.starts_with(CORRECTIONS_PREFIX));
+        self.remove_by_prefix(Role::System, CORRECTIONS_PREFIX);
     }
 
     pub(in crate::agent) fn remove_graph_facts_messages(&mut self) {
-        self.msg
-            .messages
-            .retain(|m| m.role != Role::System || !m.content.starts_with(GRAPH_FACTS_PREFIX));
+        self.remove_by_prefix(Role::System, GRAPH_FACTS_PREFIX);
     }
 
     pub(in crate::agent) fn remove_persona_facts_messages(&mut self) {
-        self.msg
-            .messages
-            .retain(|m| m.role != Role::System || !m.content.starts_with(super::PERSONA_PREFIX));
+        self.remove_by_prefix(Role::System, super::PERSONA_PREFIX);
     }
 
     pub(in crate::agent) fn remove_trajectory_hints_messages(&mut self) {
-        self.msg
-            .messages
-            .retain(|m| m.role != Role::System || !m.content.starts_with(super::TRAJECTORY_PREFIX));
+        self.remove_by_prefix(Role::System, super::TRAJECTORY_PREFIX);
     }
 
     pub(in crate::agent) fn remove_tree_memory_messages(&mut self) {
-        self.msg.messages.retain(|m| {
-            m.role != Role::System || !m.content.starts_with(super::TREE_MEMORY_PREFIX)
-        });
+        self.remove_by_prefix(Role::System, super::TREE_MEMORY_PREFIX);
     }
 
     /// Remove previously injected LSP context notes from the message history.
@@ -93,9 +94,7 @@ impl<C: Channel> Agent<C> {
     /// LSP notes use `Role::System` (consistent with graph facts and recall),
     /// so they are skipped by tool-pair summarization automatically.
     pub(in crate::agent) fn remove_lsp_messages(&mut self) {
-        self.msg
-            .messages
-            .retain(|m| m.role != Role::System || !m.content.starts_with(LSP_NOTE_PREFIX));
+        self.remove_by_prefix(Role::System, LSP_NOTE_PREFIX);
     }
 
     fn effective_recall_timeout_ms(configured: u64) -> u64 {
@@ -485,60 +484,27 @@ impl<C: Channel> Agent<C> {
     }
 
     pub(in crate::agent) fn remove_code_context_messages(&mut self) {
-        self.msg.messages.retain(|m| {
-            if m.role != Role::System {
-                return true;
-            }
-            if m.parts
-                .first()
-                .is_some_and(|p| matches!(p, MessagePart::CodeContext { .. }))
-            {
-                return false;
-            }
-            !m.content.starts_with(CODE_CONTEXT_PREFIX)
+        self.remove_by_part_or_prefix(CODE_CONTEXT_PREFIX, |p| {
+            matches!(p, MessagePart::CodeContext { .. })
         });
     }
 
     pub(super) fn remove_summary_messages(&mut self) {
-        self.msg.messages.retain(|m| {
-            if m.role != Role::System {
-                return true;
-            }
-            if m.parts
-                .first()
-                .is_some_and(|p| matches!(p, MessagePart::Summary { .. }))
-            {
-                return false;
-            }
-            !m.content.starts_with(SUMMARY_PREFIX)
-        });
+        self.remove_by_part_or_prefix(SUMMARY_PREFIX, |p| matches!(p, MessagePart::Summary { .. }));
     }
 
     pub(super) fn remove_cross_session_messages(&mut self) {
-        self.msg.messages.retain(|m| {
-            if m.role != Role::System {
-                return true;
-            }
-            if m.parts
-                .first()
-                .is_some_and(|p| matches!(p, MessagePart::CrossSession { .. }))
-            {
-                return false;
-            }
-            !m.content.starts_with(CROSS_SESSION_PREFIX)
+        self.remove_by_part_or_prefix(CROSS_SESSION_PREFIX, |p| {
+            matches!(p, MessagePart::CrossSession { .. })
         });
     }
 
     fn remove_document_rag_messages(&mut self) {
-        self.msg
-            .messages
-            .retain(|m| m.role != Role::System || !m.content.starts_with(DOCUMENT_RAG_PREFIX));
+        self.remove_by_prefix(Role::System, DOCUMENT_RAG_PREFIX);
     }
 
     pub(in crate::agent) fn remove_session_digest_message(&mut self) {
-        self.msg
-            .messages
-            .retain(|m| m.role != Role::User || !m.content.starts_with(SESSION_DIGEST_PREFIX));
+        self.remove_by_prefix(Role::User, SESSION_DIGEST_PREFIX);
     }
 
     /// Spawn a fire-and-forget background task to generate and persist a session digest for

--- a/crates/zeph-core/src/agent/focus.rs
+++ b/crates/zeph-core/src/agent/focus.rs
@@ -13,6 +13,7 @@ use uuid::Uuid;
 use zeph_llm::provider::{Message, MessageMetadata, Role, ToolDefinition};
 
 use crate::config::FocusConfig;
+use zeph_common::text::estimate_tokens;
 
 /// Build tool definitions for `start_focus` and `complete_focus` (#1850).
 ///
@@ -204,9 +205,11 @@ impl FocusState {
             if self.knowledge_blocks.len() <= 1 {
                 break;
             }
-            let total_chars: usize = self.knowledge_blocks.iter().map(|b| b.content.len()).sum();
-            #[allow(clippy::integer_division)]
-            let approx_tokens = total_chars / 4;
+            let approx_tokens: usize = self
+                .knowledge_blocks
+                .iter()
+                .map(|b| estimate_tokens(&b.content))
+                .sum();
             if approx_tokens <= self.config.max_knowledge_tokens {
                 break;
             }

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -67,6 +67,7 @@ use crate::config::{SecurityConfig, SkillPromptMode, TimeoutConfig};
 use crate::context::{
     ContextBudget, EnvironmentContext, build_system_prompt, build_system_prompt_with_instructions,
 };
+use zeph_common::text::estimate_tokens;
 use zeph_sanitizer::ContentSanitizer;
 
 use message_queue::{MAX_AUDIO_BYTES, MAX_IMAGE_BYTES, detect_image_mime};
@@ -231,7 +232,7 @@ impl<C: Channel> Agent<C> {
         tracing::debug!(len = system_prompt.len(), "initial system prompt built");
         tracing::trace!(prompt = %system_prompt, "full system prompt");
 
-        let initial_prompt_tokens = u64::try_from(system_prompt.len()).unwrap_or(0) / 4;
+        let initial_prompt_tokens = estimate_tokens(&system_prompt) as u64;
         let (_tx, rx) = watch::channel(false);
         let token_counter = Arc::new(TokenCounter::new());
         // Always create the receiver side of the experiment notification channel so the

--- a/crates/zeph-core/src/agent/persistence.rs
+++ b/crates/zeph-core/src/agent/persistence.rs
@@ -3627,10 +3627,10 @@ mod tests {
 
     #[test]
     fn trajectory_extraction_slice_handles_few_messages() {
-        let max_messages: u64 = 20;
+        let max_messages: usize = 20;
         let total_messages = 5usize;
 
-        let tail_start = total_messages.saturating_sub(max_messages as usize);
+        let tail_start = total_messages.saturating_sub(max_messages);
         let window = total_messages - tail_start;
 
         assert_eq!(window, 5, "should return all messages when fewer than max");

--- a/crates/zeph-core/src/agent/session_digest.rs
+++ b/crates/zeph-core/src/agent/session_digest.rs
@@ -11,6 +11,7 @@ use std::sync::LazyLock;
 use std::time::Duration;
 
 use regex::Regex;
+use zeph_common::text::estimate_tokens;
 use zeph_llm::provider::{Message, MessageMetadata, Role};
 use zeph_memory::TokenCounter;
 
@@ -291,8 +292,8 @@ impl<C: Channel> Agent<C> {
 
         match memory.sqlite().load_session_digest(conversation_id).await {
             Ok(Some(digest)) => {
-                let token_count =
-                    usize::try_from(digest.token_count).unwrap_or(digest.digest.len() / 4);
+                let token_count = usize::try_from(digest.token_count)
+                    .unwrap_or_else(|_| estimate_tokens(&digest.digest));
                 tracing::debug!(
                     conversation_id = conversation_id.0,
                     tokens = token_count,

--- a/crates/zeph-core/src/agent/tool_execution/legacy.rs
+++ b/crates/zeph-core/src/agent/tool_execution/legacy.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use zeph_common::text::estimate_tokens;
 use zeph_llm::provider::{LlmProvider, Message, MessageMetadata, MessagePart, Role};
 use zeph_tools::executor::{ToolError, ToolOutput};
 
@@ -391,18 +392,13 @@ impl<C: Channel> Agent<C> {
             if let Some(final_completion) = final_completion_opt {
                 m.completion_tokens = m
                     .completion_tokens
-                    .saturating_sub(
-                        r.as_ref()
-                            .map_or(0, |s| u64::try_from(s.len()).unwrap_or(0) / 4),
-                    )
+                    .saturating_sub(r.as_ref().map_or(0, |s| estimate_tokens(s) as u64))
                     .saturating_add(final_completion);
             }
             m.total_tokens = m.prompt_tokens + m.completion_tokens;
         });
-        let cost_completion = final_completion_opt.unwrap_or_else(|| {
-            r.as_ref()
-                .map_or(0, |s| u64::try_from(s.len()).unwrap_or(0) / 4)
-        });
+        let cost_completion = final_completion_opt
+            .unwrap_or_else(|| r.as_ref().map_or(0, |s| estimate_tokens(s) as u64));
         self.record_cost_and_cache(final_prompt, cost_completion);
         let raw = r?;
         if let (Some(d), Some(id)) = (self.debug_state.debug_dumper.as_ref(), dump_id) {
@@ -450,7 +446,7 @@ impl<C: Channel> Agent<C> {
         match result {
             Ok(Ok(resp)) => {
                 let latency = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
-                let completion_heuristic = u64::try_from(resp.len()).unwrap_or(0) / 4;
+                let completion_heuristic = estimate_tokens(&resp) as u64;
                 let (final_prompt, final_completion) = self
                     .provider
                     .last_usage()
@@ -853,7 +849,7 @@ impl<C: Channel> Agent<C> {
 
         // For streaming paths, last_usage() is None (providers don't return usage in streams),
         // so the heuristic is the fallback. For non-streaming via this path, use real counts.
-        let completion_heuristic = u64::try_from(response.len()).unwrap_or(0) / 4;
+        let completion_heuristic = estimate_tokens(&response) as u64;
         let completion_tokens = self
             .provider
             .last_usage()

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use futures::FutureExt as _;
+use zeph_common::text::estimate_tokens;
 use zeph_llm::provider::{
     ChatResponse, LlmProvider, Message, MessageMetadata, MessagePart, Role, ThinkingBlock,
     ToolDefinition,
@@ -498,16 +499,16 @@ impl<C: Channel> Agent<C> {
         let latency = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
         let prompt_estimate = self.providers.cached_prompt_tokens;
         let completion_heuristic = match result {
-            ChatResponse::Text(t) => u64::try_from(t.len()).unwrap_or(0) / 4,
+            ChatResponse::Text(t) => estimate_tokens(t) as u64,
             ChatResponse::ToolUse {
                 text, tool_calls, ..
             } => {
-                let text_len = text.as_deref().map_or(0, str::len);
-                let calls_len: usize = tool_calls
+                let text_tokens = estimate_tokens(text.as_deref().unwrap_or(""));
+                let calls_tokens: usize = tool_calls
                     .iter()
-                    .map(|c| c.name.len() + c.input.to_string().len())
+                    .map(|c| estimate_tokens(&c.name) + estimate_tokens(&c.input.to_string()))
                     .sum();
-                u64::try_from(text_len + calls_len).unwrap_or(0) / 4
+                (text_tokens + calls_tokens) as u64
             }
         };
         let (final_prompt, final_completion) = self
@@ -2396,7 +2397,7 @@ impl<C: Channel> Agent<C> {
 
         let tokens_freed = to_compress
             .iter()
-            .map(|m| m.content.len() / 4)
+            .map(|m| estimate_tokens(&m.content))
             .sum::<usize>();
 
         // Append summary to Knowledge block (LLM-authored via compress_context).

--- a/crates/zeph-llm/src/claude/cache.rs
+++ b/crates/zeph-llm/src/claude/cache.rs
@@ -3,6 +3,8 @@
 
 //! Prompt caching utilities for the Claude provider.
 
+use zeph_common::text::estimate_tokens;
+
 use crate::provider::ToolDefinition;
 
 use super::types::{
@@ -62,7 +64,7 @@ pub(super) fn split_system_into_blocks(system: &str, model: &str) -> Vec<SystemC
                 // when it is below the cache minimum threshold. This ensures
                 // the block gets cache_control and avoids silent cache misses.
                 let text = if first_block {
-                    let estimated = before.len() / 4;
+                    let estimated = estimate_tokens(before);
                     if estimated < min_tokens {
                         tracing::debug!(
                             estimated_tokens = estimated,
@@ -77,7 +79,7 @@ pub(super) fn split_system_into_blocks(system: &str, model: &str) -> Vec<SystemC
                 } else {
                     before.to_owned()
                 };
-                let estimated_tokens = text.len() / 4;
+                let estimated_tokens = estimate_tokens(&text);
                 let cc = if estimated_tokens >= min_tokens {
                     Some(CacheControl {
                         cache_type: CacheType::Ephemeral,
@@ -108,7 +110,7 @@ pub(super) fn split_system_into_blocks(system: &str, model: &str) -> Vec<SystemC
         // last explicit cacheable block). When no markers exist, `remaining` equals the
         // full system prompt — apply the same min-token threshold as the fallback path.
         let had_markers = remaining.len() < cacheable_part.trim().len();
-        let estimated_tokens = zeph_common::text::estimate_tokens(remaining);
+        let estimated_tokens = estimate_tokens(remaining);
         let cc = if had_markers || estimated_tokens >= min_tokens {
             Some(CacheControl {
                 cache_type: CacheType::Ephemeral,

--- a/crates/zeph-llm/src/router/triage.rs
+++ b/crates/zeph-llm/src/router/triage.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
-use zeph_common::text::truncate_chars;
+use zeph_common::text::{estimate_tokens, truncate_chars};
 
 use crate::any::AnyProvider;
 use crate::embed::owned_strs;
@@ -500,7 +500,7 @@ impl LlmProvider for TriageRouter {
         let router = self.clone();
         let messages = messages.to_vec();
         Box::pin(async move {
-            let context_tokens: usize = messages.iter().map(|m| m.content.len() / 4).sum();
+            let context_tokens: usize = messages.iter().map(|m| estimate_tokens(&m.content)).sum();
             let idx = router.classify(&messages).await;
             let idx = router.maybe_escalate_for_context(idx, context_tokens);
             let (tier, provider) = &router.tier_providers[idx];
@@ -524,7 +524,7 @@ impl LlmProvider for TriageRouter {
         let router = self.clone();
         let messages = messages.to_vec();
         Box::pin(async move {
-            let context_tokens: usize = messages.iter().map(|m| m.content.len() / 4).sum();
+            let context_tokens: usize = messages.iter().map(|m| estimate_tokens(&m.content)).sum();
             let idx = router.classify(&messages).await;
             let idx = router.maybe_escalate_for_context(idx, context_tokens);
             let (tier, provider) = &router.tier_providers[idx];
@@ -550,7 +550,7 @@ impl LlmProvider for TriageRouter {
         let messages = messages.to_vec();
         let tools = tools.to_vec();
         Box::pin(async move {
-            let context_tokens: usize = messages.iter().map(|m| m.content.len() / 4).sum();
+            let context_tokens: usize = messages.iter().map(|m| estimate_tokens(&m.content)).sum();
             let idx = router.classify(&messages).await;
             let idx = router.maybe_escalate_for_context(idx, context_tokens);
             let (tier, provider) = &router.tier_providers[idx];

--- a/crates/zeph-memory/src/token_counter.rs
+++ b/crates/zeph-memory/src/token_counter.rs
@@ -7,6 +7,7 @@ use std::sync::OnceLock;
 
 use dashmap::DashMap;
 use tiktoken_rs::CoreBPE;
+use zeph_common::text::estimate_tokens;
 use zeph_llm::provider::{Message, MessagePart};
 
 static BPE: OnceLock<Option<CoreBPE>> = OnceLock::new();
@@ -162,7 +163,9 @@ impl TokenCounter {
             } => THINKING_OVERHEAD + self.count_tokens(thinking) + self.count_tokens(signature),
 
             // RedactedThinkingBlock is an opaque base64 blob — BPE is not meaningful here.
-            MessagePart::RedactedThinkingBlock { data } => THINKING_OVERHEAD + data.len() / 4,
+            MessagePart::RedactedThinkingBlock { data } => {
+                THINKING_OVERHEAD + estimate_tokens(data)
+            }
 
             // Compaction summary is sent back verbatim to the API.
             MessagePart::Compaction { summary } => self.count_tokens(summary),


### PR DESCRIPTION
## Summary

- Replace ~15 inline `len() / 4` byte-based token estimations with `zeph_common::text::estimate_tokens()` across `zeph-core`, `zeph-llm`, `zeph-memory` — more accurate for non-ASCII content (#2778)
- Extract two private helpers (`remove_by_prefix`, `remove_by_part_or_prefix`) in `ContextAssembly`, reducing 11 duplicated retain blocks to one-liner delegates (#2779)

Part of #2776 (architectural review epic).

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --all-targets --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 7734/7734 pass
- [x] Performance analysis: `chars().count()` O(n) vs `len()` O(1) — negligible (all sites post-LLM-await, ~1µs vs 100ms+ network)
- [x] No missed sites: `grep -rn 'len() / 4' crates/` returns only `candle_whisper.rs` (byte→f32, not token estimation)

Closes #2778
Closes #2779