### PR TITLE
refactor(llm): remove duplicate cosine_similarity and dead chat_with_named_provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **Extract shared `remove_system_messages` helpers in context assembly** (`#2779`): 11 nearly-identical `remove_*_messages()` methods in `ContextAssembly` now delegate to two private helpers (`remove_by_prefix`, `remove_by_part_or_prefix`), reducing ~80 lines of duplicated retain logic to one-liner delegates.
 
+- **Remove duplicate `cosine_similarity` from `zeph-llm::router::asi`** (`#2777`): replaced with canonical `zeph_common::math::cosine_similarity`, deleted duplicate function and 3 redundant tests.
+
+- **Remove dead `chat_with_named_provider` methods from `AnyProvider`** (`#2786`): deleted `chat_with_named_provider` and `chat_with_named_provider_and_tools` that accepted a `name` parameter but ignored it. Updated 7 call sites across 6 files to use `chat()` / `chat_with_tools()` directly. Removed dead `provider_name` field from `AdversarialPolicyLlmAdapter`, dead `persona_provider` field from `PersonaExtractionConfig`, and dead `model` field from `SubAgentLoopArgs`.
+
 ### Added
 
 - **Embed backfill progress tracking with bounded memory and concurrency** (`#2765`): `embed_missing` now accepts a `watch::Sender<Option<BackfillProgress>>` and reports `done/total` progress after each message. Messages are processed in micro-batches of 32 with `buffer_unordered(4)` concurrency, reducing peak memory from all-at-once to ~32 messages worth of content and cutting wall-clock time 3-4x via parallel HTTP embedding calls. The TUI status bar shows `Backfilling embeddings: N/M (X%)` during backfill and clears on completion.

--- a/crates/zeph-core/src/agent/persistence.rs
+++ b/crates/zeph-core/src/agent/persistence.rs
@@ -776,7 +776,6 @@ impl<C: Channel> Agent<C> {
         let timeout_secs = cfg.extraction_timeout_secs;
         let extraction_cfg = PersonaExtractionConfig {
             enabled: cfg.enabled,
-            persona_provider: cfg.persona_provider.as_str().to_owned(),
             min_messages: cfg.min_messages,
             max_messages: cfg.max_messages,
             extraction_timeout_secs: timeout_secs,

--- a/crates/zeph-core/src/agent/session_digest.rs
+++ b/crates/zeph-core/src/agent/session_digest.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 use regex::Regex;
 use zeph_common::text::estimate_tokens;
-use zeph_llm::provider::{Message, MessageMetadata, Role};
+use zeph_llm::provider::{LlmProvider as _, Message, MessageMetadata, Role};
 use zeph_memory::TokenCounter;
 
 /// Strip prompt-injection patterns from LLM-generated digest text.
@@ -128,7 +128,7 @@ pub(super) async fn generate_and_store_digest(
             tracing::warn!("session digest (/new): LLM call timed out");
             return;
         }
-        result = provider.chat_with_named_provider(&digest_config.provider, &chat_messages) => {
+        result = provider.chat(&chat_messages) => {
             match result {
                 Ok(text) => text,
                 Err(e) => {
@@ -175,7 +175,6 @@ impl<C: Channel> Agent<C> {
 
         let max_input = self.memory_state.digest_config.max_input_messages;
         let max_tokens = self.memory_state.digest_config.max_tokens;
-        let provider_name = self.memory_state.digest_config.provider.clone();
 
         // Collect last N non-system messages.
         let non_system: Vec<_> = self
@@ -232,7 +231,7 @@ impl<C: Channel> Agent<C> {
                 let _ = self.channel.send_status("").await;
                 return;
             }
-            result = self.provider.chat_with_named_provider(&provider_name, &chat_messages) => {
+            result = self.provider.chat(&chat_messages) => {
                 match result {
                     Ok(text) => text,
                     Err(e) => {

--- a/crates/zeph-llm/src/any.rs
+++ b/crates/zeph-llm/src/any.rs
@@ -195,44 +195,6 @@ impl AnyProvider {
         }
     }
 
-    /// Route to a specific named provider, or fall through to default routing.
-    ///
-    /// The `name` parameter is informational only (used for logging/tracing);
-    /// routing is always performed by the underlying provider's default strategy.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`crate::LlmError`] if the underlying provider call fails.
-    pub async fn chat_with_named_provider(
-        &self,
-        name: &str,
-        messages: &[Message],
-    ) -> Result<String, crate::LlmError> {
-        tracing::debug!(name, "chat_with_named_provider: delegating to provider");
-        self.chat(messages).await
-    }
-
-    /// Route a tool-aware request to a specific named provider, or fall through to default routing.
-    ///
-    /// The `name` parameter is informational only (used for logging/tracing);
-    /// routing is always performed by the underlying provider's default strategy.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`crate::LlmError`] if the underlying provider call fails.
-    pub async fn chat_with_named_provider_and_tools(
-        &self,
-        name: &str,
-        messages: &[Message],
-        tools: &[crate::provider::ToolDefinition],
-    ) -> Result<crate::provider::ChatResponse, crate::LlmError> {
-        tracing::debug!(
-            name,
-            "chat_with_named_provider_and_tools: delegating to provider"
-        );
-        self.chat_with_tools(messages, tools).await
-    }
-
     /// Propagate a status sender to the inner provider (where supported).
     pub fn set_status_tx(&mut self, tx: StatusTx) {
         match self {

--- a/crates/zeph-llm/src/router/asi.rs
+++ b/crates/zeph-llm/src/router/asi.rs
@@ -20,6 +20,8 @@
 
 use std::collections::{HashMap, VecDeque};
 
+use zeph_common::math::cosine_similarity;
+
 /// Per-provider sliding window of response embeddings + derived coherence score.
 #[derive(Debug, Clone)]
 struct AsiWindow {
@@ -107,44 +109,9 @@ fn mean_embedding(window: &VecDeque<Vec<f32>>) -> Vec<f32> {
     mean
 }
 
-/// Cosine similarity of two vectors. Returns `0.0` when either vector has zero norm.
-#[must_use]
-pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
-    if a.len() != b.len() || a.is_empty() {
-        return 0.0;
-    }
-    let dot: f32 = a.iter().zip(b.iter()).map(|(&x, &y)| x * y).sum();
-    let norm_a: f32 = a.iter().map(|&x| x * x).sum::<f32>().sqrt();
-    let norm_b: f32 = b.iter().map(|&x| x * x).sum::<f32>().sqrt();
-    if norm_a == 0.0 || norm_b == 0.0 {
-        return 0.0;
-    }
-    (dot / (norm_a * norm_b)).clamp(-1.0, 1.0)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn cosine_similarity_identical_vectors() {
-        let v = vec![1.0, 2.0, 3.0];
-        assert!((cosine_similarity(&v, &v) - 1.0).abs() < 1e-6);
-    }
-
-    #[test]
-    fn cosine_similarity_orthogonal_vectors() {
-        let a = vec![1.0, 0.0];
-        let b = vec![0.0, 1.0];
-        assert!((cosine_similarity(&a, &b)).abs() < 1e-6);
-    }
-
-    #[test]
-    fn cosine_similarity_zero_norm() {
-        let z = vec![0.0, 0.0];
-        let v = vec![1.0, 0.0];
-        assert!((cosine_similarity(&z, &v) - 0.0).abs() < f32::EPSILON);
-    }
 
     #[test]
     fn asi_state_returns_one_before_warmup() {

--- a/crates/zeph-llm/src/router/mod.rs
+++ b/crates/zeph-llm/src/router/mod.rs
@@ -32,6 +32,7 @@ use bandit::{BanditState, embedding_to_features};
 use cascade::{CascadeState, ClassifierMode, heuristic_score};
 use reputation::ReputationTracker;
 use thompson::ThompsonState;
+use zeph_common::math::cosine_similarity;
 
 /// Simple bounded embedding cache for bandit feature vectors.
 ///
@@ -1262,7 +1263,7 @@ impl LlmProvider for RouterProvider {
                             let resp_emb = router.embed(&r).await.ok();
                             let similarity = resp_emb
                                 .as_ref()
-                                .map_or(threshold, |e| asi::cosine_similarity(qemb, e)); // fail-open: None → treat as passing
+                                .map_or(threshold, |e| cosine_similarity(qemb, e)); // fail-open: None → treat as passing
                             if similarity < threshold {
                                 tracing::info!(
                                     provider = p.name(),

--- a/crates/zeph-memory/src/semantic/persona.rs
+++ b/crates/zeph-memory/src/semantic/persona.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 use tokio::time::timeout;
 use zeph_llm::any::AnyProvider;
-use zeph_llm::provider::{Message, Role};
+use zeph_llm::provider::{LlmProvider as _, Message, Role};
 
 use crate::error::MemoryError;
 use crate::store::DbStore;
@@ -51,8 +51,6 @@ Output JSON array of objects:
 /// Configuration for persona extraction.
 pub struct PersonaExtractionConfig {
     pub enabled: bool,
-    /// Provider name from `[[llm.providers]]` for extraction. Falls back to default when empty.
-    pub persona_provider: String,
     /// Minimum user messages in a session before extraction runs.
     pub min_messages: usize,
     /// Maximum user messages sent to LLM per extraction pass.
@@ -128,18 +126,7 @@ pub async fn extract_persona_facts(
     ];
 
     let extraction_timeout = Duration::from_secs(config.extraction_timeout_secs);
-    // Use the configured provider name; fall back to "persona" label if empty.
-    let provider_name = if config.persona_provider.is_empty() {
-        "persona"
-    } else {
-        &config.persona_provider
-    };
-    let response = match timeout(
-        extraction_timeout,
-        provider.chat_with_named_provider(provider_name, &llm_messages),
-    )
-    .await
-    {
+    let response = match timeout(extraction_timeout, provider.chat(&llm_messages)).await {
         Ok(Ok(text)) => text,
         Ok(Err(e)) => return Err(MemoryError::Llm(e)),
         Err(_) => {
@@ -312,7 +299,6 @@ mod tests {
         // and test the self-ref gate separately by passing non-self-ref messages.
         let cfg = PersonaExtractionConfig {
             enabled: true,
-            persona_provider: String::new(),
             min_messages: 1,
             max_messages: 10,
             extraction_timeout_secs: 5,
@@ -323,7 +309,6 @@ mod tests {
         // (already tested above) and via the enabled=false path here.
         let cfg_disabled = PersonaExtractionConfig {
             enabled: false,
-            persona_provider: String::new(),
             min_messages: 1,
             max_messages: 10,
             extraction_timeout_secs: 5,
@@ -333,7 +318,6 @@ mod tests {
         // min_messages gate instead.
         let cfg_min = PersonaExtractionConfig {
             enabled: true,
-            persona_provider: String::new(),
             min_messages: 5,
             max_messages: 10,
             extraction_timeout_secs: 5,

--- a/crates/zeph-memory/src/semantic/trajectory.rs
+++ b/crates/zeph-memory/src/semantic/trajectory.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 use tokio::time::timeout;
 use zeph_llm::any::AnyProvider;
-use zeph_llm::provider::{Message, Role};
+use zeph_llm::provider::{LlmProvider as _, Message, Role};
 
 use crate::error::MemoryError;
 
@@ -104,12 +104,7 @@ pub async fn extract_trajectory_entries(
     ];
 
     let extraction_timeout = Duration::from_secs(config.extraction_timeout_secs);
-    let response = match timeout(
-        extraction_timeout,
-        provider.chat_with_named_provider("trajectory", &llm_messages),
-    )
-    .await
-    {
+    let response = match timeout(extraction_timeout, provider.chat(&llm_messages)).await {
         Ok(Ok(text)) => text,
         Ok(Err(e)) => return Err(MemoryError::Llm(e)),
         Err(_) => {

--- a/crates/zeph-memory/src/semantic/tree_consolidation.rs
+++ b/crates/zeph-memory/src/semantic/tree_consolidation.rs
@@ -300,7 +300,7 @@ async fn merge_via_llm(provider: &AnyProvider, contents: &[&str]) -> Result<Stri
     ];
 
     let response = provider
-        .chat_with_named_provider("tree_consolidation", &llm_messages)
+        .chat(&llm_messages)
         .await
         .map_err(MemoryError::Llm)?;
 

--- a/crates/zeph-subagent/src/agent_loop.rs
+++ b/crates/zeph-subagent/src/agent_loop.rs
@@ -50,7 +50,6 @@ pub(super) struct AgentLoopArgs {
     pub(super) agent_name: String,
     pub(super) initial_messages: Vec<Message>,
     pub(super) transcript_writer: Option<TranscriptWriter>,
-    pub(super) model: Option<String>,
     pub(super) spawn_depth: u32,
     pub(super) mcp_tool_names: Vec<String>,
 }
@@ -212,7 +211,6 @@ pub(super) async fn run_agent_loop(
         agent_name,
         initial_messages,
         mut transcript_writer,
-        model,
         spawn_depth: _spawn_depth,
         mcp_tool_names,
     } = args;
@@ -279,13 +277,7 @@ pub(super) async fn run_agent_loop(
             break;
         }
 
-        let llm_result = if let Some(ref m) = model {
-            provider
-                .chat_with_named_provider_and_tools(m, &messages, &tool_defs)
-                .await
-        } else {
-            provider.chat_with_tools(&messages, &tool_defs).await
-        };
+        let llm_result = provider.chat_with_tools(&messages, &tool_defs).await;
         let response = match llm_result {
             Ok(r) => r,
             Err(e) => {

--- a/crates/zeph-subagent/src/manager.rs
+++ b/crates/zeph-subagent/src/manager.rs
@@ -18,7 +18,7 @@ use zeph_config::SubAgentConfig;
 
 use crate::agent_loop::{AgentLoopArgs, run_agent_loop};
 
-use super::def::{MemoryScope, ModelSpec, PermissionMode, SubAgentDef, ToolPolicy};
+use super::def::{MemoryScope, PermissionMode, SubAgentDef, ToolPolicy};
 use super::error::SubAgentError;
 use super::filter::{FilteredToolExecutor, PlanModeExecutor};
 use super::grants::{PermissionGrants, SecretRequest};
@@ -39,7 +39,7 @@ pub struct SpawnContext {
     pub parent_messages: Vec<Message>,
     /// Parent's cancellation token for linked cancellation (foreground spawns).
     pub parent_cancel: Option<CancellationToken>,
-    /// Parent's active provider name for `ModelSpec::Inherit` resolution.
+    /// Parent's active provider name (for context propagation).
     pub parent_provider_name: Option<String>,
     /// Current spawn depth (0 = top-level agent).
     pub spawn_depth: u32,
@@ -618,13 +618,6 @@ impl SubAgentManager {
         // be constructed AFTER this call to pick up the updated tool list.
         let system_prompt = build_system_prompt_with_memory(&mut def, effective_memory);
 
-        // Resolve model: Inherit uses parent's active provider, Named uses the given name.
-        let resolved_model = match &def.model {
-            Some(ModelSpec::Inherit) => ctx.parent_provider_name.clone(),
-            Some(ModelSpec::Named(name)) => Some(name.clone()),
-            None => None,
-        };
-
         // Apply context injection: prepend last assistant turn to task prompt when configured.
         let effective_task_prompt = apply_context_injection(
             task_prompt,
@@ -667,7 +660,6 @@ impl SubAgentManager {
                 agent_name: agent_name_clone,
                 initial_messages: parent_messages,
                 transcript_writer,
-                model: resolved_model,
                 spawn_depth: spawn_depth + 1,
                 mcp_tool_names,
             }));
@@ -1125,10 +1117,6 @@ impl SubAgentManager {
                 agent_name: agent_name_clone,
                 initial_messages,
                 transcript_writer,
-                model: match &def.model {
-                    Some(ModelSpec::Named(name)) => Some(name.clone()),
-                    Some(ModelSpec::Inherit) | None => None,
-                },
                 spawn_depth: 0,
                 mcp_tool_names: Vec::new(),
             }));
@@ -1363,7 +1351,7 @@ mod tests {
     use serial_test::serial;
 
     use crate::agent_loop::{AgentLoopArgs, make_message, run_agent_loop};
-    use crate::def::MemoryScope;
+    use crate::def::{MemoryScope, ModelSpec};
     use zeph_config::SubAgentConfig;
     use zeph_llm::provider::ChatResponse;
 
@@ -3073,7 +3061,6 @@ mod tests {
             agent_name: "test-bot".into(),
             initial_messages: vec![],
             transcript_writer: None,
-            model: None,
             spawn_depth: 0,
             mcp_tool_names: Vec::new(),
         }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -51,12 +51,11 @@ use zeph_llm::provider::LlmProvider;
 
 use zeph_core::config::Config;
 
-/// Adapter that bridges `PolicyLlmClient` to `AnyProvider::chat_with_named_provider`.
+/// Adapter that bridges `PolicyLlmClient` to `AnyProvider::chat`.
 ///
 /// Defined in `runner.rs` to keep `zeph-tools` decoupled from `zeph-llm`.
 struct AdversarialPolicyLlmAdapter {
     provider: LlmAnyProvider,
-    provider_name: String,
 }
 impl zeph_tools::PolicyLlmClient for AdversarialPolicyLlmAdapter {
     fn chat<'a>(
@@ -78,10 +77,8 @@ impl zeph_tools::PolicyLlmClient for AdversarialPolicyLlmAdapter {
                 })
                 .collect();
 
-            let result: Result<String, zeph_llm::LlmError> = self
-                .provider
-                .chat_with_named_provider(&self.provider_name, &llm_messages)
-                .await;
+            let result: Result<String, zeph_llm::LlmError> =
+                self.provider.chat(&llm_messages).await;
             result.map_err(|e| e.to_string())
         })
     }
@@ -1149,12 +1146,9 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
                 adv_cfg.exempt_tools.clone(),
             ));
 
-            let provider_name = adv_cfg.policy_provider.clone();
-            let llm_provider = provider.clone();
             let llm_client: std::sync::Arc<dyn zeph_tools::PolicyLlmClient> =
                 std::sync::Arc::new(AdversarialPolicyLlmAdapter {
-                    provider: llm_provider,
-                    provider_name,
+                    provider: provider.clone(),
                 });
 
             let mut gate =


### PR DESCRIPTION
## Summary

- Remove duplicate `cosine_similarity` from `zeph-llm::router::asi`, replace with canonical `zeph_common::math::cosine_similarity` (#2777)
- Remove dead `chat_with_named_provider` and `chat_with_named_provider_and_tools` from `AnyProvider` that ignored the `name` parameter, update 7 call sites to use `chat()`/`chat_with_tools()` directly (#2786)
- Clean up 3 dead struct fields left over: `AdversarialPolicyLlmAdapter::provider_name`, `PersonaExtractionConfig::persona_provider`, `SubAgentLoopArgs::model`

Net: -140 lines, 12 files changed, pure deletion refactor with no behavioral changes.

Closes #2777
Closes #2786

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 7731/7731 pass
- [x] No remaining references to deleted methods (`chat_with_named_provider`)
- [x] Canonical `cosine_similarity` tests in `zeph-common` verified (8 tests)
- [ ] CI green