### PR TITLE
fix(core): route reload_config() through auto_budget_tokens() fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **`reload_config()` bypasses `auto_budget_tokens()` fallback** (`#2793`): extract `resolve_context_budget()` free function that mirrors the startup `auto_budget_tokens()` logic (auto-detect from provider context window, fallback to 128k). `reload_config()` now always sets a valid budget instead of reading the raw config value.
+
 - **Unbounded memory growth when `context_budget_tokens = 0`** (`#2773`): `auto_budget_tokens()` now falls back to 128k tokens when the resolved budget is 0, preventing silent compaction bypass that let messages accumulate without bound. Defence-in-depth WARN fires when message count exceeds 200 without a budget.
 
 - **TUI `RenderCache::clear()` does not release backing Vec** (`#2774`): replace entry-nulling loop with `Vec::new()` to release heap allocation on trim cycles instead of retaining capacity indefinitely.

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -2127,6 +2127,7 @@ impl<C: Channel> Agent<C> {
             }
         };
 
+        let budget_tokens = resolve_context_budget(&config, &self.provider);
         self.runtime.security = config.security;
         self.runtime.timeouts = config.timeouts;
         self.runtime.redact_credentials = config.memory.redact_credentials;
@@ -2156,20 +2157,9 @@ impl<C: Channel> Agent<C> {
                 }
             });
 
-        if config.memory.context_budget_tokens > 0 {
-            self.context_manager.budget = Some(
-                ContextBudget::new(config.memory.context_budget_tokens, 0.20)
-                    .with_graph_enabled(config.memory.graph.enabled),
-            );
-        } else {
-            if self.msg.messages.len() >= 200 {
-                tracing::warn!(
-                    message_count = self.msg.messages.len(),
-                    "no context budget set — messages growing without compaction"
-                );
-            }
-            self.context_manager.budget = None;
-        }
+        self.context_manager.budget = Some(
+            ContextBudget::new(budget_tokens, 0.20).with_graph_enabled(config.memory.graph.enabled),
+        );
 
         {
             let graph_cfg = &config.memory.graph;
@@ -2516,6 +2506,35 @@ pub(crate) async fn recv_optional<T>(rx: &mut Option<mpsc::Receiver<T>>) -> Opti
             }
         }
         None => std::future::pending().await,
+    }
+}
+
+/// Resolve the effective context budget from config, applying the `auto_budget` fallback.
+///
+/// Mirrors `AppBuilder::auto_budget_tokens` so hot-reload and initial startup use the same
+/// logic: if `auto_budget = true` and `context_budget_tokens == 0`, query the provider's
+/// context window; if still 0, fall back to 128 000 tokens.
+pub(crate) fn resolve_context_budget(config: &Config, provider: &AnyProvider) -> usize {
+    let tokens = if config.memory.auto_budget && config.memory.context_budget_tokens == 0 {
+        if let Some(ctx_size) = provider.context_window() {
+            tracing::info!(
+                model_context = ctx_size,
+                "auto-configured context budget on reload"
+            );
+            ctx_size
+        } else {
+            0
+        }
+    } else {
+        config.memory.context_budget_tokens
+    };
+    if tokens == 0 {
+        tracing::warn!(
+            "context_budget_tokens resolved to 0 on reload — using fallback of 128000 tokens"
+        );
+        128_000
+    } else {
+        tokens
     }
 }
 

--- a/crates/zeph-core/src/agent/tests.rs
+++ b/crates/zeph-core/src/agent/tests.rs
@@ -5124,3 +5124,49 @@ mod flush_orphaned_tests {
         );
     }
 }
+
+// ── resolve_context_budget (#2793) ───────────────────────────────────────────
+
+#[cfg(test)]
+mod resolve_context_budget_tests {
+    use std::path::Path;
+
+    use crate::config::Config;
+    use zeph_llm::any::AnyProvider;
+    use zeph_llm::mock::MockProvider;
+
+    use super::super::resolve_context_budget;
+
+    #[test]
+    fn explicit_budget_returned_as_is() {
+        let mut config = Config::load(Path::new("/nonexistent")).unwrap();
+        config.memory.auto_budget = false;
+        config.memory.context_budget_tokens = 65536;
+        let provider = AnyProvider::Mock(MockProvider::default());
+        assert_eq!(resolve_context_budget(&config, &provider), 65536);
+    }
+
+    #[test]
+    fn auto_budget_true_budget_zero_no_window_falls_back_to_128k() {
+        let mut config = Config::load(Path::new("/nonexistent")).unwrap();
+        config.memory.auto_budget = true;
+        config.memory.context_budget_tokens = 0;
+        // MockProvider::context_window() returns None — triggers 128k fallback.
+        let provider = AnyProvider::Mock(MockProvider::default());
+        assert_ne!(
+            resolve_context_budget(&config, &provider),
+            0,
+            "budget must not be zero when auto_budget=true and context_budget_tokens=0"
+        );
+        assert_eq!(resolve_context_budget(&config, &provider), 128_000);
+    }
+
+    #[test]
+    fn auto_budget_false_budget_zero_falls_back_to_128k() {
+        let mut config = Config::load(Path::new("/nonexistent")).unwrap();
+        config.memory.auto_budget = false;
+        config.memory.context_budget_tokens = 0;
+        let provider = AnyProvider::Mock(MockProvider::default());
+        assert_eq!(resolve_context_budget(&config, &provider), 128_000);
+    }
+}


### PR DESCRIPTION
## Summary

- Extract `resolve_context_budget()` free function that mirrors startup `auto_budget_tokens()` logic
- `reload_config()` now calls `resolve_context_budget()` instead of reading raw `context_budget_tokens` — auto-budget fallback (128k) applies consistently on hot-reload
- 3 unit tests covering: explicit budget, auto-budget with no provider window, explicit zero fallback

Closes #2793

## Test plan

- [x] `cargo nextest run -p zeph-core -E 'test(resolve_context_budget)'` — 3/3 pass
- [x] Full suite: 7747/7747 pass
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo +nightly fmt --check` clean