### PR TITLE
refactor(core): consolidate tool-related standalone fields into ToolState sub-struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Refactored
 
+- **Consolidate 6 tool fields into `ToolState` sub-struct** (`#2798`): extracted `tool_schema_filter`, `cached_filtered_tool_ids`, `dependency_graph`, `dependency_always_on`, `completed_tool_ids`, and `current_tool_iteration` from `Agent` into a new `pub(crate) ToolState` struct in `agent/state/mod.rs`, following the existing `*State` pattern. All 7 affected files updated with `tool_state.` prefix. No logic changes.
+
 - **Replace `std::sync::RwLock`/`Mutex` with `parking_lot` across workspace** (`#2780`): migrated all synchronous lock usages in `zeph-acp`, `zeph-core`, `zeph-llm`, `zeph-mcp`, `zeph-memory`, `zeph-tools`, and the binary crate to `parking_lot::RwLock`/`Mutex`. Removed all poison-handling boilerplate (`.unwrap()`, `.expect()`, `.map_err()`, `.unwrap_or_else(PoisonError::into_inner)` on lock results) and rewrote `if let Ok(guard) = lock.read()` patterns to direct guard assignment. `tokio::sync` async locks are not affected. Net: 45 files changed, ~400 lines removed.
 
 - **Replace inline `len()/4` token estimation with `estimate_tokens()`** (`#2778`): 15 call sites across `zeph-core`, `zeph-llm`, and `zeph-memory` now use the centralized `zeph_common::text::estimate_tokens()` function, which counts Unicode scalars (`chars().count() / 4`) instead of bytes — more accurate for non-ASCII content and trivial to improve later from a single location.

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1393,7 +1393,7 @@ impl<C: Channel> Agent<C> {
     /// Set the dynamic tool schema filter (pre-computed tool embeddings).
     #[must_use]
     pub fn with_tool_schema_filter(mut self, filter: zeph_tools::ToolSchemaFilter) -> Self {
-        self.tool_schema_filter = Some(filter);
+        self.tool_state.tool_schema_filter = Some(filter);
         self
     }
 
@@ -1414,8 +1414,8 @@ impl<C: Channel> Agent<C> {
         graph: zeph_tools::ToolDependencyGraph,
         always_on: std::collections::HashSet<String>,
     ) -> Self {
-        self.dependency_graph = Some(graph);
-        self.dependency_always_on = always_on;
+        self.tool_state.dependency_graph = Some(graph);
+        self.tool_state.dependency_always_on = always_on;
         self
     }
 
@@ -1481,7 +1481,7 @@ impl<C: Channel> Agent<C> {
             config.min_description_words,
             embeddings,
         );
-        self.tool_schema_filter = Some(filter);
+        self.tool_state.tool_schema_filter = Some(filter);
         self
     }
 

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -37,7 +37,7 @@ impl<C: Channel> Agent<C> {
         }
         // Clear completed tool IDs along with message history: dependency state is
         // session-scoped and should reset when the conversation resets.
-        self.completed_tool_ids.clear();
+        self.tool_state.completed_tool_ids.clear();
         self.recompute_prompt_tokens();
     }
 
@@ -658,7 +658,7 @@ impl<C: Channel> Agent<C> {
         self.last_persisted_message_id = None;
         self.deferred_db_hide_ids.clear();
         self.deferred_db_summaries.clear();
-        self.cached_filtered_tool_ids = None;
+        self.tool_state.cached_filtered_tool_ids = None;
         self.providers.cached_prompt_tokens = 0;
 
         // --- Step 10: update conversation ID and memory state ---
@@ -1871,8 +1871,8 @@ impl<C: Channel> Agent<C> {
         // Dynamic tool schema filtering (#2020): compute once per turn, cache for native path.
         // Query embedding is computed here; when strategy=Embedding already computed it above,
         // but providers are stateless so a second embed() call is acceptable for MVP.
-        self.cached_filtered_tool_ids = None;
-        if let Some(ref filter) = self.tool_schema_filter
+        self.tool_state.cached_filtered_tool_ids = None;
+        if let Some(ref filter) = self.tool_state.tool_schema_filter
             && self.provider.supports_tool_use()
         {
             let defs = self.tool_executor.tool_definitions_erased();
@@ -1890,14 +1890,14 @@ impl<C: Channel> Agent<C> {
                     // Apply dependency graph AFTER schema filter (and after any TAFC
                     // augmentation that may have added tools). This ensures hard gates
                     // are the final word on tool availability (MED-04 fix).
-                    if let Some(ref dep_graph) = self.dependency_graph {
+                    if let Some(ref dep_graph) = self.tool_state.dependency_graph {
                         let dep_config = &self.runtime.dependency_config;
                         dep_graph.apply(
                             &mut result,
-                            &self.completed_tool_ids,
+                            &self.tool_state.completed_tool_ids,
                             dep_config.boost_per_dep,
                             dep_config.max_total_boost,
-                            &self.dependency_always_on,
+                            &self.tool_state.dependency_always_on,
                         );
                         if !result.dependency_exclusions.is_empty() {
                             tracing::info!(
@@ -1927,7 +1927,7 @@ impl<C: Channel> Agent<C> {
                     for (tool_id, reason) in &result.inclusion_reasons {
                         tracing::debug!(tool_id, ?reason, "tool inclusion reason");
                     }
-                    self.cached_filtered_tool_ids = Some(result.included);
+                    self.tool_state.cached_filtered_tool_ids = Some(result.included);
                 }
                 Err(e) => {
                     tracing::warn!("tool filter: query embed failed, using all tools: {e:#}");
@@ -2014,7 +2014,7 @@ impl<C: Channel> Agent<C> {
 
         // If memory_save was used this session, remind the model to use memory_search
         // (not search_code) to recall user-provided facts (#2475).
-        if self.completed_tool_ids.contains("memory_save") {
+        if self.tool_state.completed_tool_ids.contains("memory_save") {
             system_prompt.push_str(
                 "\n\nFacts provided by the user in this session have been saved with memory_save — use memory_search to recall them, not search_code.",
             );
@@ -2037,7 +2037,8 @@ impl<C: Channel> Agent<C> {
                 if max > 0.0 { Some(max) } else { None }
             });
             let max_tool_calls = self.tool_orchestrator.max_iterations;
-            let remaining_tool_calls = max_tool_calls.saturating_sub(self.current_tool_iteration);
+            let remaining_tool_calls =
+                max_tool_calls.saturating_sub(self.tool_state.current_tool_iteration);
             let hint = BudgetHint {
                 remaining_cost_cents,
                 total_budget_cents,

--- a/crates/zeph-core/src/agent/context/tests.rs
+++ b/crates/zeph-core/src/agent/context/tests.rs
@@ -4336,7 +4336,7 @@ async fn probe_rejected_does_not_trigger_exhausted() {
 
 // --- #2475: memory_save session hint in system prompt ---
 
-/// When `memory_save` is present in `completed_tool_ids`, `rebuild_system_prompt`
+/// When `memory_save` is present in `tool_state.completed_tool_ids`, `rebuild_system_prompt`
 /// must append the disambiguation hint directing the model to use `memory_search`
 /// rather than `search_code` for user-provided facts.
 #[tokio::test]
@@ -4348,7 +4348,10 @@ async fn rebuild_system_prompt_injects_memory_save_hint_when_tool_was_used() {
     let executor = MockToolExecutor::no_tools();
 
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
-    agent.completed_tool_ids.insert("memory_save".to_owned());
+    agent
+        .tool_state
+        .completed_tool_ids
+        .insert("memory_save".to_owned());
     agent.rebuild_system_prompt("test query").await;
 
     let prompt = &agent.msg.messages[0].content;
@@ -4358,7 +4361,7 @@ async fn rebuild_system_prompt_injects_memory_save_hint_when_tool_was_used() {
     );
 }
 
-/// When `completed_tool_ids` does NOT contain `memory_save`, no hint must be
+/// When `tool_state.completed_tool_ids` does NOT contain `memory_save`, no hint must be
 /// appended — the system prompt must stay clean to avoid unnecessary noise.
 #[tokio::test]
 async fn rebuild_system_prompt_omits_memory_save_hint_when_tool_not_used() {
@@ -4369,7 +4372,7 @@ async fn rebuild_system_prompt_omits_memory_save_hint_when_tool_not_used() {
     let executor = MockToolExecutor::no_tools();
 
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
-    // completed_tool_ids is empty by default — no memory_save.
+    // tool_state.completed_tool_ids is empty by default — no memory_save.
     agent.rebuild_system_prompt("test query").await;
 
     let prompt = &agent.msg.messages[0].content;

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -76,7 +76,7 @@ use state::CompressionState;
 use state::{
     DebugState, ExperimentState, FeedbackState, IndexState, InstructionState, LifecycleState,
     McpState, MemoryState, MessageState, MetricsState, OrchestrationState, ProviderState,
-    RuntimeConfig, SecurityState, SessionState, SkillState,
+    RuntimeConfig, SecurityState, SessionState, SkillState, ToolState,
 };
 
 pub(crate) const DOOM_LOOP_WINDOW: usize = 3;
@@ -144,20 +144,8 @@ pub struct Agent<C: Channel> {
     pub(super) focus: focus::FocusState,
     /// `SideQuest` state: cursor tracking, turn counter, eviction stats (#1885).
     pub(super) sidequest: sidequest::SidequestState,
-    /// Dynamic tool schema filter: pre-computed tool embeddings for per-turn filtering (#2020).
-    pub(super) tool_schema_filter: Option<zeph_tools::ToolSchemaFilter>,
-    /// Cached filtered tool IDs for the current user turn. Set by `compute_filtered_tool_ids()`
-    /// in `rebuild_system_prompt()`, consumed by the native tool loop on iteration 0.
-    pub(super) cached_filtered_tool_ids: Option<HashSet<String>>,
-    /// Tool dependency graph for sequential tool availability (issue #2024).
-    /// Built once from config, applied per-turn after tool schema filtering.
-    pub(super) dependency_graph: Option<zeph_tools::ToolDependencyGraph>,
-    /// Always-on tool IDs, mirrored from the tool schema filter for dependency gate bypass.
-    pub(super) dependency_always_on: HashSet<String>,
-    /// Tool IDs that completed successfully in the current session.
-    /// Grows monotonically per session; cleared on `/clear`.
-    /// NOTE: bounded by session length, typically < 1000 entries.
-    pub(super) completed_tool_ids: HashSet<String>,
+    /// Tool filtering, dependency tracking, and iteration bookkeeping.
+    pub(super) tool_state: ToolState,
     /// DB row ID of the most recently persisted message. Set by `persist_message`;
     /// consumed by `push_message` call sites to populate `metadata.db_id` on in-memory messages.
     pub(super) last_persisted_message_id: Option<i64>,
@@ -169,9 +157,6 @@ pub struct Agent<C: Channel> {
     ///
     /// Default: empty vec (zero-cost — loops never iterate).
     pub(super) runtime_layers: Vec<std::sync::Arc<dyn crate::runtime_layer::RuntimeLayer>>,
-    /// Current tool loop iteration index within the active user turn. Reset to 0 at turn start,
-    /// incremented each iteration. Used to compute remaining tool call budget for `BudgetHint` (#2267).
-    pub(super) current_tool_iteration: usize,
     /// autoDream session state (#2697). Tracks session count and last consolidation time.
     pub(super) autodream_state: autodream::AutoDreamState,
     /// `MagicDocs` session state (#2702). Tracks registered doc paths and last update turn.
@@ -494,16 +479,18 @@ impl<C: Channel> Agent<C> {
             },
             focus: focus::FocusState::default(),
             sidequest: sidequest::SidequestState::default(),
-            tool_schema_filter: None,
-            cached_filtered_tool_ids: None,
-            dependency_graph: None,
-            dependency_always_on: HashSet::new(),
-            completed_tool_ids: HashSet::new(),
+            tool_state: ToolState {
+                tool_schema_filter: None,
+                cached_filtered_tool_ids: None,
+                dependency_graph: None,
+                dependency_always_on: HashSet::new(),
+                completed_tool_ids: HashSet::new(),
+                current_tool_iteration: 0,
+            },
             last_persisted_message_id: None,
             deferred_db_hide_ids: Vec::new(),
             deferred_db_summaries: Vec::new(),
             runtime_layers: Vec::new(),
-            current_tool_iteration: 0,
             autodream_state: autodream::AutoDreamState::new(),
             magic_docs_state: magic_docs::MagicDocsState::new(),
         }

--- a/crates/zeph-core/src/agent/slash_commands.rs
+++ b/crates/zeph-core/src/agent/slash_commands.rs
@@ -740,7 +740,7 @@ impl<C: crate::channel::Channel> Agent<C> {
         );
         let _ = writeln!(out, "Skills:    {skill_count}");
         let _ = writeln!(out, "MCP:       {mcp_servers} server(s)");
-        if let Some(ref tf) = self.tool_schema_filter {
+        if let Some(ref tf) = self.tool_state.tool_schema_filter {
             let _ = writeln!(
                 out,
                 "Filter:    enabled (top_k={}, always_on={}, {} embeddings)",

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -470,6 +470,22 @@ pub(crate) struct CompressionState {
     pub(crate) subgoal_user_msg_hash: Option<u64>,
 }
 
+/// Groups runtime tool filtering, dependency tracking, and iteration bookkeeping.
+pub(crate) struct ToolState {
+    /// Dynamic tool schema filter: pre-computed tool embeddings for per-turn filtering (#2020).
+    pub(crate) tool_schema_filter: Option<zeph_tools::ToolSchemaFilter>,
+    /// Cached filtered tool IDs for the current user turn.
+    pub(crate) cached_filtered_tool_ids: Option<HashSet<String>>,
+    /// Tool dependency graph for sequential tool availability (#2024).
+    pub(crate) dependency_graph: Option<zeph_tools::ToolDependencyGraph>,
+    /// Always-on tool IDs, mirrored from the tool schema filter for dependency gate bypass.
+    pub(crate) dependency_always_on: HashSet<String>,
+    /// Tool IDs that completed successfully in the current session.
+    pub(crate) completed_tool_ids: HashSet<String>,
+    /// Current tool loop iteration index within the active user turn.
+    pub(crate) current_tool_iteration: usize,
+}
+
 /// Groups per-session I/O and policy state.
 pub(crate) struct SessionState {
     pub(crate) env_context: EnvironmentContext,

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -100,7 +100,7 @@ impl<C: Channel> Agent<C> {
         let all_tool_defs = tool_defs.clone();
 
         // Iteration 0: apply dynamic tool schema filter (#2020) if cached IDs are available.
-        if let Some(ref filtered_ids) = self.cached_filtered_tool_ids {
+        if let Some(ref filtered_ids) = self.tool_state.cached_filtered_tool_ids {
             tool_defs.retain(|d| filtered_ids.contains(&d.name));
             tracing::debug!(
                 filtered = tool_defs.len(),
@@ -146,25 +146,30 @@ impl<C: Channel> Agent<C> {
             let gated_iter1_defs: Vec<ToolDefinition>;
             let defs_for_turn: &[ToolDefinition] = if iteration == 0 {
                 &tool_defs
-            } else if let Some(ref dep_graph) = self.dependency_graph
+            } else if let Some(ref dep_graph) = self.tool_state.dependency_graph
                 && !dep_graph.is_empty()
             {
                 let names: Vec<&str> = all_tool_defs.iter().map(|d| d.name.as_str()).collect();
                 let allowed = dep_graph.filter_tool_names(
                     &names,
-                    &self.completed_tool_ids,
-                    &self.dependency_always_on,
+                    &self.tool_state.completed_tool_ids,
+                    &self.tool_state.dependency_always_on,
                 );
                 let allowed_set: std::collections::HashSet<&str> = allowed.into_iter().collect();
                 // Deadlock fallback: if all non-always-on tools would be blocked,
                 // use the full set for this iteration.
                 let non_ao_allowed = allowed_set
                     .iter()
-                    .filter(|n| !self.dependency_always_on.contains(**n))
+                    .filter(|n| !self.tool_state.dependency_always_on.contains(**n))
                     .count();
                 let non_ao_total = all_tool_defs
                     .iter()
-                    .filter(|d| !self.dependency_always_on.contains(d.name.as_str()))
+                    .filter(|d| {
+                        !self
+                            .tool_state
+                            .dependency_always_on
+                            .contains(d.name.as_str())
+                    })
                     .count();
                 if non_ao_allowed == 0 && non_ao_total > 0 {
                     tracing::warn!(
@@ -212,7 +217,7 @@ impl<C: Channel> Agent<C> {
         query_embedding: Option<Vec<f32>>,
     ) -> Result<Option<()>, super::super::error::AgentError> {
         // Track iteration for BudgetHint injection (#2267).
-        self.current_tool_iteration = iteration;
+        self.tool_state.current_tool_iteration = iteration;
         self.channel.send_typing().await?;
 
         // Inject any pending LSP notes as a Role::System message before calling
@@ -1452,8 +1457,10 @@ impl<C: Channel> Agent<C> {
 
                 // Record successful tool completions for the dependency graph (#2024).
                 // Only record on success (non-error) so `requires` chains work correctly.
-                if !is_failed && self.dependency_graph.is_some() {
-                    self.completed_tool_ids.insert(tool_calls[idx].name.clone());
+                if !is_failed && self.tool_state.dependency_graph.is_some() {
+                    self.tool_state
+                        .completed_tool_ids
+                        .insert(tool_calls[idx].name.clone());
                 }
 
                 // RuntimeLayer after_tool hooks.


### PR DESCRIPTION
## Summary

- Extract 6 scattered tool-related fields from `Agent` into a new `ToolState` sub-struct in `state/mod.rs`
- Follow the existing `*State` pattern (`MessageState`, `McpState`, etc.) with `pub(crate)` visibility
- Mechanical rename: `self.field` → `self.tool_state.field` across 7 source files
- No logic changes, no behavioral changes

Part of #2787 (Agent struct decomposition, Phase 0). Closes #2798.

## Test plan

- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` — 0 warnings
- [x] `cargo nextest run --workspace --lib --bins` — 7739 passed, 15 skipped, 0 failed
- [x] grep confirms zero orphaned references to old field paths