### PR TITLE
refactor(core): extract SecurityState/SkillState methods, consolidate Agent fields (#2802, #2803, #2805)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Refactored
 
+- **Extract security pipeline methods into `SecurityState` impl block** (`#2802`): moved PII scrubbing, guardrail pre-screening, and NER circuit breaker management from Agent wrappers into `impl SecurityState` in `agent/state/security.rs`. New `PiiScrubResult` value type carries metric descriptors; Agent wrappers apply side effects from the result struct.
+
+- **Extract skill management methods into `SkillState` impl block** (`#2803`): moved `rebuild_prompt()`, `rebuild_bm25()`, and `fingerprint()` from Agent into `impl SkillState` in `agent/state/skill.rs`. Agent methods delegate to these helpers. Methods requiring channel/memory/provider access remain on Agent.
+
+- **Consolidate 6 standalone fields into existing sub-structs** (`#2805`): relocated `last_persisted_message_id`, `deferred_db_hide_ids`, `deferred_db_summaries` to `MessageState`; `runtime_layers` to `RuntimeConfig` (as `layers`); `autodream_state` to `MemoryState` (as `autodream`); `magic_docs_state` to `MemoryState` (as `magic_docs`). ~20 call sites updated. Agent top-level field count reduced by 6.
+
 - **Consolidate 6 tool fields into `ToolState` sub-struct** (`#2798`): extracted `tool_schema_filter`, `cached_filtered_tool_ids`, `dependency_graph`, `dependency_always_on`, `completed_tool_ids`, and `current_tool_iteration` from `Agent` into a new `pub(crate) ToolState` struct in `agent/state/mod.rs`, following the existing `*State` pattern. All 7 affected files updated with `tool_state.` prefix. No logic changes.
 
 - **Extract MCP, Index, Debug methods into State impl blocks** (`#2799`, `#2800`, `#2801`): moved pure data operations from `impl Agent<C>` into `impl McpState` (3 methods), `impl IndexState` (1 method), and `impl DebugState` (4 methods). Agent methods requiring channel/provider context remain as thin wrappers. Part of Agent struct decomposition (`#2787`). 6 files changed, net -0 logic lines.

--- a/crates/zeph-core/src/agent/autodream.rs
+++ b/crates/zeph-core/src/agent/autodream.rs
@@ -71,14 +71,15 @@ impl<C: Channel> super::Agent<C> {
             return;
         }
 
-        self.autodream_state.record_session();
+        self.memory_state.autodream.record_session();
 
         if !self
-            .autodream_state
+            .memory_state
+            .autodream
             .should_consolidate(cfg.min_sessions, cfg.min_hours)
         {
             tracing::debug!(
-                sessions = self.autodream_state.sessions_since_consolidation,
+                sessions = self.memory_state.autodream.sessions_since_consolidation,
                 min_sessions = cfg.min_sessions,
                 "autoDream: gates not met, skipping"
             );
@@ -149,7 +150,7 @@ impl<C: Channel> super::Agent<C> {
                     elapsed_ms = start.elapsed().as_millis(),
                     "autoDream: consolidation complete"
                 );
-                self.autodream_state.mark_consolidated();
+                self.memory_state.autodream.mark_consolidated();
             }
             Ok(Err(e)) => {
                 tracing::warn!(error = %e, "autoDream: consolidation failed");

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -655,9 +655,9 @@ impl<C: Channel> Agent<C> {
 
         // --- Step 9: reset misc session-scoped fields ---
         self.debug_state.iteration_counter = 0;
-        self.last_persisted_message_id = None;
-        self.deferred_db_hide_ids.clear();
-        self.deferred_db_summaries.clear();
+        self.msg.last_persisted_message_id = None;
+        self.msg.deferred_db_hide_ids.clear();
+        self.msg.deferred_db_summaries.clear();
         self.tool_state.cached_filtered_tool_ids = None;
         self.providers.cached_prompt_tokens = 0;
 

--- a/crates/zeph-core/src/agent/context/summarization.rs
+++ b/crates/zeph-core/src/agent/context/summarization.rs
@@ -1725,9 +1725,9 @@ impl<C: Channel> Agent<C> {
             self.msg.messages[resp_idx].metadata.deferred_summary = None;
 
             if let (Some(req_id), Some(resp_id)) = (req_db_id, resp_db_id) {
-                self.deferred_db_hide_ids.push(req_id);
-                self.deferred_db_hide_ids.push(resp_id);
-                self.deferred_db_summaries.push(summary.clone());
+                self.msg.deferred_db_hide_ids.push(req_id);
+                self.msg.deferred_db_hide_ids.push(resp_id);
+                self.msg.deferred_db_summaries.push(summary.clone());
             }
 
             let content = format!("[tool summary] {summary}");
@@ -1746,18 +1746,18 @@ impl<C: Channel> Agent<C> {
     }
 
     pub(in crate::agent) async fn flush_deferred_summaries(&mut self) {
-        if self.deferred_db_hide_ids.is_empty() {
+        if self.msg.deferred_db_hide_ids.is_empty() {
             return;
         }
         let (Some(memory), Some(cid)) =
             (&self.memory_state.memory, self.memory_state.conversation_id)
         else {
-            self.deferred_db_hide_ids.clear();
-            self.deferred_db_summaries.clear();
+            self.msg.deferred_db_hide_ids.clear();
+            self.msg.deferred_db_summaries.clear();
             return;
         };
-        let hide_ids = std::mem::take(&mut self.deferred_db_hide_ids);
-        let summaries = std::mem::take(&mut self.deferred_db_summaries);
+        let hide_ids = std::mem::take(&mut self.msg.deferred_db_hide_ids);
+        let summaries = std::mem::take(&mut self.msg.deferred_db_summaries);
         if let Err(e) = memory
             .sqlite()
             .apply_tool_pair_summaries(cid, &hide_ids, &summaries)

--- a/crates/zeph-core/src/agent/context/tests.rs
+++ b/crates/zeph-core/src/agent/context/tests.rs
@@ -3194,6 +3194,8 @@ fn make_mem_state(
         microcompact_config: crate::config::MicrocompactConfig::default(),
         autodream_config: crate::config::AutoDreamConfig::default(),
         magic_docs_config: crate::config::MagicDocsConfig::default(),
+        autodream: crate::agent::autodream::AutoDreamState::new(),
+        magic_docs: crate::agent::magic_docs::MagicDocsState::new(),
     }
 }
 

--- a/crates/zeph-core/src/agent/magic_docs.rs
+++ b/crates/zeph-core/src/agent/magic_docs.rs
@@ -135,7 +135,8 @@ impl<C: Channel> super::Agent<C> {
         }
 
         for path in detected_paths {
-            self.magic_docs_state
+            self.memory_state
+                .magic_docs
                 .registered
                 .entry(path.clone())
                 .or_insert(turn);
@@ -149,12 +150,12 @@ impl<C: Channel> super::Agent<C> {
     /// No-op when `MagicDocs` is disabled, no docs are registered, or update is not due.
     pub(super) fn maybe_update_magic_docs(&mut self) {
         let cfg = self.memory_state.magic_docs_config.clone();
-        if !cfg.enabled || self.magic_docs_state.registered.is_empty() {
+        if !cfg.enabled || self.memory_state.magic_docs.registered.is_empty() {
             return;
         }
 
         // Await any previous pending update before spawning another.
-        if let Some(handle) = self.magic_docs_state.pending.take()
+        if let Some(handle) = self.memory_state.magic_docs.pending.take()
             && !handle.is_finished()
         {
             tracing::debug!("magic_docs: previous update still running, skipping this turn");
@@ -163,7 +164,8 @@ impl<C: Channel> super::Agent<C> {
 
         let current_turn = u32::try_from(self.sidequest.turn_counter).unwrap_or(u32::MAX);
         let due_paths: Vec<PathBuf> = self
-            .magic_docs_state
+            .memory_state
+            .magic_docs
             .registered
             .iter()
             .filter(|(_, last_turn)| {
@@ -225,13 +227,13 @@ impl<C: Channel> super::Agent<C> {
         });
 
         // Mark all due paths as updated (due_paths moved into spawn — use registered keys).
-        for path in self.magic_docs_state.registered.values_mut() {
+        for path in self.memory_state.magic_docs.registered.values_mut() {
             if current_turn.saturating_sub(*path) >= cfg.min_turns_between_updates {
                 *path = current_turn;
             }
         }
 
-        self.magic_docs_state.pending = Some(handle);
+        self.memory_state.magic_docs.pending = Some(handle);
     }
 }
 

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -146,21 +146,6 @@ pub struct Agent<C: Channel> {
     pub(super) sidequest: sidequest::SidequestState,
     /// Tool filtering, dependency tracking, and iteration bookkeeping.
     pub(super) tool_state: ToolState,
-    /// DB row ID of the most recently persisted message. Set by `persist_message`;
-    /// consumed by `push_message` call sites to populate `metadata.db_id` on in-memory messages.
-    pub(super) last_persisted_message_id: Option<i64>,
-    /// DB message IDs pending hide after deferred tool pair summarization.
-    pub(super) deferred_db_hide_ids: Vec<i64>,
-    /// Summary texts pending insertion after deferred tool pair summarization.
-    pub(super) deferred_db_summaries: Vec<String>,
-    /// Runtime middleware layers for LLM calls and tool dispatch (#2286).
-    ///
-    /// Default: empty vec (zero-cost — loops never iterate).
-    pub(super) runtime_layers: Vec<std::sync::Arc<dyn crate::runtime_layer::RuntimeLayer>>,
-    /// autoDream session state (#2697). Tracks session count and last consolidation time.
-    pub(super) autodream_state: autodream::AutoDreamState,
-    /// `MagicDocs` session state (#2702). Tracks registered doc paths and last update turn.
-    pub(super) magic_docs_state: magic_docs::MagicDocsState,
 }
 
 impl<C: Channel> Agent<C> {
@@ -239,6 +224,9 @@ impl<C: Channel> Agent<C> {
                 }],
                 message_queue: VecDeque::new(),
                 pending_image_parts: Vec::new(),
+                last_persisted_message_id: None,
+                deferred_db_hide_ids: Vec::new(),
+                deferred_db_summaries: Vec::new(),
             },
             memory_state: MemoryState {
                 memory: None,
@@ -274,6 +262,8 @@ impl<C: Channel> Agent<C> {
                 microcompact_config: crate::config::MicrocompactConfig::default(),
                 autodream_config: crate::config::AutoDreamConfig::default(),
                 magic_docs_config: crate::config::MagicDocsConfig::default(),
+                autodream: autodream::AutoDreamState::new(),
+                magic_docs: magic_docs::MagicDocsState::new(),
             },
             skill_state: SkillState {
                 registry,
@@ -340,6 +330,7 @@ impl<C: Channel> Agent<C> {
                 spawn_depth: 0,
                 budget_hint_enabled: true,
                 channel_skills: zeph_config::ChannelSkillsConfig::default(),
+                layers: Vec::new(),
             },
             mcp: McpState {
                 tools: Vec::new(),
@@ -487,12 +478,6 @@ impl<C: Channel> Agent<C> {
                 completed_tool_ids: HashSet::new(),
                 current_tool_iteration: 0,
             },
-            last_persisted_message_id: None,
-            deferred_db_hide_ids: Vec::new(),
-            deferred_db_summaries: Vec::new(),
-            runtime_layers: Vec::new(),
-            autodream_state: autodream::AutoDreamState::new(),
-            magic_docs_state: magic_docs::MagicDocsState::new(),
         }
     }
 
@@ -1948,13 +1933,13 @@ impl<C: Channel> Agent<C> {
         if self.skill_state.hybrid_search {
             let descs: Vec<&str> = all_meta.iter().map(|m| m.description.as_str()).collect();
             let _ = self.channel.send_status("rebuilding search index...").await;
-            self.skill_state.bm25_index = Some(zeph_skills::bm25::Bm25Index::build(&descs));
+            self.skill_state.rebuild_bm25(&descs);
         }
     }
 
     async fn reload_skills(&mut self) {
         let new_registry = SkillRegistry::load(&self.skill_state.skill_paths);
-        if new_registry.fingerprint() == self.skill_state.registry.read().fingerprint() {
+        if new_registry.fingerprint() == self.skill_state.fingerprint() {
             return;
         }
         let _ = self.channel.send_status("reloading skills...").await;
@@ -1983,7 +1968,7 @@ impl<C: Channel> Agent<C> {
         };
         let trust_map = self.build_skill_trust_map().await;
         let empty_health: HashMap<String, (f64, u32)> = HashMap::new();
-        let skills_prompt = format_skills_prompt(&all_skills, &trust_map, &empty_health);
+        let skills_prompt = SkillState::rebuild_prompt(&all_skills, &trust_map, &empty_health);
         self.skill_state
             .last_skills_prompt
             .clone_from(&skills_prompt);

--- a/crates/zeph-core/src/agent/persistence.rs
+++ b/crates/zeph-core/src/agent/persistence.rs
@@ -511,7 +511,7 @@ impl<C: Channel> Agent<C> {
                 .await
             {
                 Ok((Some(message_id), stored)) => {
-                    self.last_persisted_message_id = Some(message_id.0);
+                    self.msg.last_persisted_message_id = Some(message_id.0);
                     (stored, true)
                 }
                 Ok((None, _)) => {
@@ -529,7 +529,7 @@ impl<C: Channel> Agent<C> {
                 .await
             {
                 Ok(message_id) => {
-                    self.last_persisted_message_id = Some(message_id.0);
+                    self.msg.last_persisted_message_id = Some(message_id.0);
                     (false, true)
                 }
                 Err(e) => {

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -96,6 +96,10 @@ pub(crate) struct MemoryState {
     /// Background tree consolidation loop handle — kept alive for the agent's lifetime (#2262).
     /// `None` when tree consolidation is disabled or memory is not initialized.
     pub(crate) tree_consolidation_handle: Option<tokio::task::JoinHandle<()>>,
+    /// autoDream session state (#2697). Tracks session count and last consolidation time.
+    pub(crate) autodream: super::autodream::AutoDreamState,
+    /// `MagicDocs` session state (#2702). Tracks registered doc paths and last update turn.
+    pub(crate) magic_docs: super::magic_docs::MagicDocsState,
 }
 
 pub(crate) struct SkillState {
@@ -232,6 +236,10 @@ pub(crate) struct RuntimeConfig {
     /// Per-channel skill allowlist. Skills not matching the allowlist are excluded from the
     /// prompt. An empty `allowed` list means all skills are permitted (default).
     pub(crate) channel_skills: zeph_config::ChannelSkillsConfig,
+    /// Runtime middleware layers for LLM calls and tool dispatch (#2286).
+    ///
+    /// Default: empty vec (zero-cost — loops never iterate).
+    pub(crate) layers: Vec<std::sync::Arc<dyn crate::runtime_layer::RuntimeLayer>>,
 }
 
 /// Groups feedback detection subsystems: correction detector, judge detector, and LLM classifier.
@@ -526,6 +534,13 @@ pub(crate) struct MessageState {
     pub(crate) message_queue: VecDeque<QueuedMessage>,
     /// Image parts staged by `/image` commands, attached to the next user message.
     pub(crate) pending_image_parts: Vec<zeph_llm::provider::MessagePart>,
+    /// DB row ID of the most recently persisted message. Set by `persist_message`;
+    /// consumed by `push_message` call sites to populate `metadata.db_id` on in-memory messages.
+    pub(crate) last_persisted_message_id: Option<i64>,
+    /// DB message IDs pending hide after deferred tool pair summarization.
+    pub(crate) deferred_db_hide_ids: Vec<i64>,
+    /// Summary texts pending insertion after deferred tool pair summarization.
+    pub(crate) deferred_db_summaries: Vec<String>,
 }
 
 impl McpState {
@@ -682,6 +697,9 @@ impl DebugState {
         d.dump_response(id, &text);
     }
 }
+
+pub(super) mod security;
+pub(super) mod skill;
 
 #[cfg(test)]
 mod tests;

--- a/crates/zeph-core/src/agent/state/security.rs
+++ b/crates/zeph-core/src/agent/state/security.rs
@@ -1,0 +1,190 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `SecurityState` impl block: PII scrubbing and guardrail checking.
+//!
+//! These methods contain only security-state logic (no cross-cutting agent dependencies).
+//! The Agent wrappers in `tool_execution/mod.rs` apply metrics and channel side-effects.
+
+use super::SecurityState;
+
+/// Result returned by [`SecurityState::scrub_pii`], carrying the scrubbed text and
+/// side-effect descriptors that the Agent wrapper must apply to metrics.
+pub(crate) struct PiiScrubResult {
+    pub(crate) text: String,
+    /// Whether PII was actually redacted (`scrub_count` increment + `push_classifier_metrics`).
+    pub(crate) scrubbed: bool,
+    /// Number of NER timeouts that occurred (metrics: `pii_ner_timeouts` increment).
+    pub(crate) ner_timeouts: u32,
+    /// Whether the circuit breaker tripped during this call (`pii_ner_circuit_breaker_trips` increment).
+    pub(crate) circuit_breaker_tripped: bool,
+}
+
+impl SecurityState {
+    /// Run regex PII filter and (optionally) NER classifier, merge spans, and redact in one pass.
+    ///
+    /// Returns a [`PiiScrubResult`] with the scrubbed text and metric side-effects.
+    /// The caller is responsible for applying metrics updates from the result.
+    #[cfg_attr(not(feature = "classifiers"), allow(clippy::unused_async))]
+    #[allow(clippy::too_many_lines)]
+    pub(crate) async fn scrub_pii(&mut self, text: &str, tool_name: &str) -> PiiScrubResult {
+        use zeph_sanitizer::pii::{merge_spans, redact_spans};
+
+        if !self.pii_filter.is_enabled() {
+            return PiiScrubResult {
+                text: text.to_owned(),
+                scrubbed: false,
+                ner_timeouts: 0,
+                circuit_breaker_tripped: false,
+            };
+        }
+
+        #[cfg_attr(not(feature = "classifiers"), allow(unused_mut))]
+        let mut spans = self.pii_filter.detect_spans(text);
+        #[cfg_attr(not(feature = "classifiers"), allow(unused_mut))]
+        let mut ner_timeouts: u32 = 0;
+        #[cfg_attr(not(feature = "classifiers"), allow(unused_mut))]
+        let mut circuit_breaker_tripped = false;
+
+        #[cfg(feature = "classifiers")]
+        if let Some(ref backend) = self.pii_ner_backend {
+            use zeph_sanitizer::pii::build_char_to_byte_map;
+
+            if self.pii_ner_tripped {
+                tracing::debug!(tool = %tool_name, "PII NER circuit breaker open, regex only");
+            } else {
+                let timeout_ms = self.pii_ner_timeout_ms;
+                let ner_input = if text.len() > self.pii_ner_max_chars {
+                    let boundary = text.floor_char_boundary(self.pii_ner_max_chars);
+                    &text[..boundary]
+                } else {
+                    text
+                };
+                match tokio::time::timeout(
+                    std::time::Duration::from_millis(timeout_ms),
+                    backend.classify(ner_input),
+                )
+                .await
+                {
+                    Ok(Ok(result)) if result.is_positive => {
+                        let char_to_byte = build_char_to_byte_map(ner_input);
+                        for ner_span in &result.spans {
+                            let byte_start = char_to_byte
+                                .get(ner_span.start)
+                                .copied()
+                                .unwrap_or(ner_input.len());
+                            let byte_end = char_to_byte
+                                .get(ner_span.end)
+                                .copied()
+                                .unwrap_or(ner_input.len());
+                            if byte_end > byte_start {
+                                spans.push(zeph_sanitizer::pii::PiiSpan {
+                                    label: ner_span.label.clone(),
+                                    start: byte_start,
+                                    end: byte_end,
+                                });
+                            }
+                        }
+                        self.pii_ner_consecutive_timeouts = 0;
+                    }
+                    Ok(Ok(_)) => {
+                        self.pii_ner_consecutive_timeouts = 0;
+                    }
+                    Ok(Err(e)) => {
+                        tracing::warn!(error = %e, tool = %tool_name, "PII NER failed, regex only");
+                    }
+                    Err(_) => {
+                        ner_timeouts += 1;
+                        self.pii_ner_consecutive_timeouts += 1;
+                        let threshold = self.pii_ner_circuit_breaker_threshold;
+                        if threshold > 0 && self.pii_ner_consecutive_timeouts >= threshold {
+                            self.pii_ner_tripped = true;
+                            circuit_breaker_tripped = true;
+                            tracing::warn!(
+                                consecutive_timeouts = self.pii_ner_consecutive_timeouts,
+                                threshold = threshold,
+                                tool = %tool_name,
+                                "PII NER circuit breaker tripped — NER disabled for this session, falling back to regex-only PII detection"
+                            );
+                        } else {
+                            tracing::warn!(
+                                timeout_ms = timeout_ms,
+                                tool = %tool_name,
+                                consecutive = self.pii_ner_consecutive_timeouts,
+                                "PII NER timed out, regex only"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        let merged = merge_spans(spans);
+        if merged.is_empty() {
+            return PiiScrubResult {
+                text: text.to_owned(),
+                scrubbed: false,
+                ner_timeouts,
+                circuit_breaker_tripped,
+            };
+        }
+
+        tracing::debug!(tool = %tool_name, span_count = merged.len(), "PII scrubbed from tool output");
+        PiiScrubResult {
+            text: redact_spans(text, &merged),
+            scrubbed: true,
+            ner_timeouts,
+            circuit_breaker_tripped,
+        }
+    }
+
+    /// Run the guardrail filter against a tool output body. Returns the body (possibly replaced).
+    ///
+    /// Only reads `self.guardrail` — no metric side-effects. Pure security-state logic.
+    pub(crate) async fn check_guardrail(&self, mut body: String, tool_name: &str) -> String {
+        use zeph_sanitizer::guardrail::GuardrailVerdict;
+        let Some(ref guardrail) = self.guardrail else {
+            return body;
+        };
+        if !guardrail.scan_tool_output() {
+            return body;
+        }
+        let verdict = if let Ok(v) =
+            tokio::time::timeout(std::time::Duration::from_secs(10), guardrail.check(&body)).await
+        {
+            v
+        } else {
+            tracing::warn!(tool = %tool_name, "tool guardrail check timed out after 10s");
+            zeph_sanitizer::guardrail::GuardrailVerdict::Error {
+                error: "timeout".into(),
+            }
+        };
+        if let GuardrailVerdict::Flagged { reason, .. } = &verdict {
+            tracing::warn!(
+                tool = %tool_name,
+                reason = %reason,
+                should_block = verdict.should_block(),
+                "guardrail flagged tool output"
+            );
+            if verdict.should_block() {
+                body = format!("[guardrail blocked] Tool output flagged: {reason}");
+            }
+        } else if let GuardrailVerdict::Error { error } = &verdict {
+            if guardrail.error_should_block() {
+                tracing::warn!(
+                    tool = %tool_name,
+                    %error,
+                    "guardrail check failed (fail_strategy=closed), blocking tool output"
+                );
+                "[guardrail blocked] Tool output check failed (see logs)".clone_into(&mut body);
+            } else {
+                tracing::warn!(
+                    tool = %tool_name,
+                    %error,
+                    "guardrail check failed (fail_strategy=open), allowing tool output"
+                );
+            }
+        }
+        body
+    }
+}

--- a/crates/zeph-core/src/agent/state/skill.rs
+++ b/crates/zeph-core/src/agent/state/skill.rs
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `SkillState` impl block: pure data-manipulation helpers.
+//!
+//! Methods here only access `SkillState` fields — no cross-cutting agent dependencies.
+//! Agent methods (`reload_skills`, `rebuild_skill_matcher`) stay on `Agent<C>` because
+//! they need the embedding provider, channel, and memory state.
+
+use std::collections::HashMap;
+
+use zeph_skills::loader::Skill;
+use zeph_skills::trust::SkillTrustLevel;
+
+use super::SkillState;
+
+impl SkillState {
+    /// Rebuild the skills prompt text from the current registry + trust/health maps.
+    ///
+    /// Returns the formatted prompt string. Does NOT update `last_skills_prompt` —
+    /// the caller is responsible for storing the result.
+    pub(crate) fn rebuild_prompt(
+        all_skills: &[Skill],
+        trust_map: &HashMap<String, SkillTrustLevel>,
+        health_map: &HashMap<String, (f64, u32)>,
+    ) -> String {
+        zeph_skills::prompt::format_skills_prompt(all_skills, trust_map, health_map)
+    }
+
+    /// Rebuild the BM25 index from current registry metadata, if hybrid search is enabled.
+    pub(crate) fn rebuild_bm25(&mut self, descs: &[&str]) {
+        if self.hybrid_search {
+            self.bm25_index = Some(zeph_skills::bm25::Bm25Index::build(descs));
+        }
+    }
+
+    /// Return the current registry fingerprint.
+    pub(crate) fn fingerprint(&self) -> u64 {
+        self.registry.read().fingerprint()
+    }
+}

--- a/crates/zeph-core/src/agent/state/tests.rs
+++ b/crates/zeph-core/src/agent/state/tests.rs
@@ -51,6 +51,9 @@ fn make_message_state() -> MessageState {
         }],
         message_queue: VecDeque::new(),
         pending_image_parts: Vec::new(),
+        last_persisted_message_id: None,
+        deferred_db_hide_ids: Vec::new(),
+        deferred_db_summaries: Vec::new(),
     }
 }
 
@@ -84,6 +87,7 @@ fn make_runtime_config() -> RuntimeConfig {
         spawn_depth: 0,
         budget_hint_enabled: true,
         channel_skills: zeph_config::ChannelSkillsConfig::default(),
+        layers: Vec::new(),
     }
 }
 

--- a/crates/zeph-core/src/agent/tool_execution/mod.rs
+++ b/crates/zeph-core/src/agent/tool_execution/mod.rs
@@ -291,160 +291,25 @@ impl<C: Channel> Agent<C> {
 
     /// Run regex PII filter and (optionally) NER classifier, merge spans, and redact in one pass.
     ///
-    /// When `pii_ner_backend` is configured, both sources are combined so neither regex-only
-    /// nor NER-only detections are missed. Falls back to regex-only when NER is unavailable.
-    #[cfg_attr(not(feature = "classifiers"), allow(clippy::unused_async))]
+    /// Thin wrapper: delegates to [`SecurityState::scrub_pii`] and applies metrics side-effects.
     async fn scrub_pii_union(&mut self, text: &str, tool_name: &str) -> String {
-        use zeph_sanitizer::pii::{merge_spans, redact_spans};
-
-        if !self.security.pii_filter.is_enabled() {
-            // NER alone does not activate PII scrubbing — the regex filter must be enabled.
-            return text.to_owned();
+        let result = self.security.scrub_pii(text, tool_name).await;
+        if result.ner_timeouts > 0 {
+            self.update_metrics(|m| m.pii_ner_timeouts += u64::from(result.ner_timeouts));
         }
-
-        // Step 1: regex spans (byte offsets).
-        #[cfg_attr(not(feature = "classifiers"), allow(unused_mut))]
-        let mut spans = self.security.pii_filter.detect_spans(text);
-
-        // Step 2: NER spans (char offsets → convert to byte offsets, then append).
-        #[cfg(feature = "classifiers")]
-        if let Some(ref backend) = self.security.pii_ner_backend {
-            use zeph_sanitizer::pii::build_char_to_byte_map;
-
-            if self.security.pii_ner_tripped {
-                tracing::debug!(tool = %tool_name, "PII NER circuit breaker open, regex only");
-            } else {
-                let timeout_ms = self.security.pii_ner_timeout_ms;
-                let ner_input = if text.len() > self.security.pii_ner_max_chars {
-                    let boundary = text.floor_char_boundary(self.security.pii_ner_max_chars);
-                    &text[..boundary]
-                } else {
-                    text
-                };
-                match tokio::time::timeout(
-                    std::time::Duration::from_millis(timeout_ms),
-                    backend.classify(ner_input),
-                )
-                .await
-                {
-                    Ok(Ok(result)) if result.is_positive => {
-                        // Precompute char→byte map once for all NER spans (C2).
-                        // Use ner_input: NER offsets are relative to the (possibly truncated) input.
-                        let char_to_byte = build_char_to_byte_map(ner_input);
-                        for ner_span in &result.spans {
-                            let byte_start = char_to_byte
-                                .get(ner_span.start)
-                                .copied()
-                                .unwrap_or(ner_input.len());
-                            let byte_end = char_to_byte
-                                .get(ner_span.end)
-                                .copied()
-                                .unwrap_or(ner_input.len());
-                            if byte_end > byte_start {
-                                spans.push(zeph_sanitizer::pii::PiiSpan {
-                                    label: ner_span.label.clone(),
-                                    start: byte_start,
-                                    end: byte_end,
-                                });
-                            }
-                        }
-                        self.security.pii_ner_consecutive_timeouts = 0;
-                    }
-                    Ok(Ok(_)) => {
-                        // no positive detection — still counts as success
-                        self.security.pii_ner_consecutive_timeouts = 0;
-                    }
-                    Ok(Err(e)) => {
-                        // Non-timeout backend error: do not count toward circuit breaker.
-                        tracing::warn!(error = %e, tool = %tool_name, "PII NER failed, regex only");
-                    }
-                    Err(_) => {
-                        self.update_metrics(|m| m.pii_ner_timeouts += 1);
-                        self.security.pii_ner_consecutive_timeouts += 1;
-                        let threshold = self.security.pii_ner_circuit_breaker_threshold;
-                        if threshold > 0 && self.security.pii_ner_consecutive_timeouts >= threshold
-                        {
-                            self.security.pii_ner_tripped = true;
-                            self.update_metrics(|m| m.pii_ner_circuit_breaker_trips += 1);
-                            tracing::warn!(
-                                consecutive_timeouts = self.security.pii_ner_consecutive_timeouts,
-                                threshold = threshold,
-                                tool = %tool_name,
-                                "PII NER circuit breaker tripped — NER disabled for this session, falling back to regex-only PII detection"
-                            );
-                        } else {
-                            tracing::warn!(
-                                timeout_ms = timeout_ms,
-                                tool = %tool_name,
-                                consecutive = self.security.pii_ner_consecutive_timeouts,
-                                "PII NER timed out, regex only"
-                            );
-                        }
-                    }
-                }
-            }
+        if result.circuit_breaker_tripped {
+            self.update_metrics(|m| m.pii_ner_circuit_breaker_trips += 1);
         }
-
-        // Step 3: merge overlapping/adjacent spans.
-        let merged = merge_spans(spans);
-        if merged.is_empty() {
-            return text.to_owned();
+        if result.scrubbed {
+            self.update_metrics(|m| m.pii_scrub_count += 1);
+            self.push_classifier_metrics();
         }
-
-        // Step 4: single-pass redaction.
-        self.update_metrics(|m| m.pii_scrub_count += 1);
-        self.push_classifier_metrics();
-        tracing::debug!(tool = %tool_name, span_count = merged.len(), "PII scrubbed from tool output");
-        redact_spans(text, &merged)
+        result.text
     }
-    async fn apply_guardrail_to_tool_output(&self, mut body: String, tool_name: &str) -> String {
-        use zeph_sanitizer::guardrail::GuardrailVerdict;
-        let Some(ref guardrail) = self.security.guardrail else {
-            return body;
-        };
-        if !guardrail.scan_tool_output() {
-            return body;
-        }
-        let verdict = if let Ok(v) =
-            tokio::time::timeout(std::time::Duration::from_secs(10), guardrail.check(&body)).await
-        {
-            v
-        } else {
-            tracing::warn!(tool = %tool_name, "tool guardrail check timed out after 10s");
-            zeph_sanitizer::guardrail::GuardrailVerdict::Error {
-                error: "timeout".into(),
-            }
-        };
-        if let GuardrailVerdict::Flagged { reason, .. } = &verdict {
-            tracing::warn!(
-                tool = %tool_name,
-                reason = %reason,
-                should_block = verdict.should_block(),
-                "guardrail flagged tool output"
-            );
-            if verdict.should_block() {
-                body = format!("[guardrail blocked] Tool output flagged: {reason}");
-            }
-            // Warn mode: log only, no user-channel notification. Tool output warn is intentionally
-            // silent to avoid flooding the user with warnings for every suspicious tool result —
-            // unlike user-input warn mode which notifies the user because it is interactive.
-        } else if let GuardrailVerdict::Error { error } = &verdict {
-            if guardrail.error_should_block() {
-                tracing::warn!(
-                    tool = %tool_name,
-                    %error,
-                    "guardrail check failed (fail_strategy=closed), blocking tool output"
-                );
-                "[guardrail blocked] Tool output check failed (see logs)".clone_into(&mut body);
-            } else {
-                tracing::warn!(
-                    tool = %tool_name,
-                    %error,
-                    "guardrail check failed (fail_strategy=open), allowing tool output"
-                );
-            }
-        }
-        body
+
+    /// Delegate guardrail check to [`SecurityState::check_guardrail`].
+    async fn apply_guardrail_to_tool_output(&self, body: String, tool_name: &str) -> String {
+        self.security.check_guardrail(body, tool_name).await
     }
 
     fn scan_output_and_warn(&mut self, text: &str) -> String {

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -372,13 +372,13 @@ impl<C: Channel> Agent<C> {
                 });
 
         // RuntimeLayer before_chat hooks (MVP: empty vec = zero iterations).
-        if !self.runtime_layers.is_empty() {
+        if !self.runtime.layers.is_empty() {
             let conv_id_str = self.memory_state.conversation_id.map(|id| id.0.to_string());
             let ctx = crate::runtime_layer::LayerContext {
                 conversation_id: conv_id_str.as_deref(),
                 turn_number: u32::try_from(self.sidequest.turn_counter).unwrap_or(u32::MAX),
             };
-            for layer in &self.runtime_layers {
+            for layer in &self.runtime.layers {
                 let hook_result = std::panic::AssertUnwindSafe(layer.before_chat(
                     &ctx,
                     &self.msg.messages,
@@ -454,13 +454,13 @@ impl<C: Channel> Agent<C> {
             .write_chat_debug_dump(dump_id, &result, &self.security.pii_filter);
 
         // RuntimeLayer after_chat hooks (MVP: empty vec = zero iterations).
-        if !self.runtime_layers.is_empty() {
+        if !self.runtime.layers.is_empty() {
             let conv_id_str = self.memory_state.conversation_id.map(|id| id.0.to_string());
             let ctx = crate::runtime_layer::LayerContext {
                 conversation_id: conv_id_str.as_deref(),
                 turn_number: u32::try_from(self.sidequest.turn_counter).unwrap_or(u32::MAX),
             };
-            for layer in &self.runtime_layers {
+            for layer in &self.runtime.layers {
                 let hook_result = std::panic::AssertUnwindSafe(layer.after_chat(&ctx, &result))
                     .catch_unwind()
                     .await;
@@ -634,9 +634,10 @@ impl<C: Channel> Agent<C> {
         )
         .await;
         self.push_message(assistant_msg);
-        if let (Some(id), Some(last)) =
-            (self.last_persisted_message_id, self.msg.messages.last_mut())
-        {
+        if let (Some(id), Some(last)) = (
+            self.msg.last_persisted_message_id,
+            self.msg.messages.last_mut(),
+        ) {
             last.metadata.db_id = Some(id);
         }
 
@@ -1313,14 +1314,14 @@ impl<C: Channel> Agent<C> {
                 }
 
                 // RuntimeLayer before_tool hooks: may short-circuit execution.
-                if !self.runtime_layers.is_empty() {
+                if !self.runtime.layers.is_empty() {
                     let conv_id_str = self.memory_state.conversation_id.map(|id| id.0.to_string());
                     let ctx = crate::runtime_layer::LayerContext {
                         conversation_id: conv_id_str.as_deref(),
                         turn_number: u32::try_from(self.sidequest.turn_counter).unwrap_or(u32::MAX),
                     };
                     let mut sc_result: crate::runtime_layer::BeforeToolResult = None;
-                    for layer in &self.runtime_layers {
+                    for layer in &self.runtime.layers {
                         let hook_result =
                             std::panic::AssertUnwindSafe(layer.before_tool(&ctx, call))
                                 .catch_unwind()
@@ -1441,13 +1442,13 @@ impl<C: Channel> Agent<C> {
                 }
 
                 // RuntimeLayer after_tool hooks.
-                if !self.runtime_layers.is_empty() {
+                if !self.runtime.layers.is_empty() {
                     let conv_id_str = self.memory_state.conversation_id.map(|id| id.0.to_string());
                     let ctx = crate::runtime_layer::LayerContext {
                         conversation_id: conv_id_str.as_deref(),
                         turn_number: u32::try_from(self.sidequest.turn_counter).unwrap_or(u32::MAX),
                     };
-                    for layer in &self.runtime_layers {
+                    for layer in &self.runtime.layers {
                         let hook_result = std::panic::AssertUnwindSafe(layer.after_tool(
                             &ctx,
                             &calls[idx],
@@ -2039,9 +2040,10 @@ impl<C: Channel> Agent<C> {
         tracing::debug!("tool_batch: persist_message done, pushing message");
         self.push_message(user_msg);
         tracing::debug!("tool_batch: message pushed, starting LSP hooks");
-        if let (Some(id), Some(last)) =
-            (self.last_persisted_message_id, self.msg.messages.last_mut())
-        {
+        if let (Some(id), Some(last)) = (
+            self.msg.last_persisted_message_id,
+            self.msg.messages.last_mut(),
+        ) {
             last.metadata.db_id = Some(id);
         }
 


### PR DESCRIPTION
## Summary

- **#2802 (Phase 4)**: Extract PII scrubbing, guardrail pre-screening, and NER circuit breaker management into `impl SecurityState` in `agent/state/security.rs`. New `PiiScrubResult` value type carries metric descriptors; Agent wrappers apply side effects from the result struct.
- **#2803 (Phase 5)**: Extract `rebuild_prompt()`, `rebuild_bm25()`, `fingerprint()` into `impl SkillState` in `agent/state/skill.rs`. Agent methods delegate to these helpers.
- **#2805 (Phase 7)**: Relocate 6 standalone fields into existing sub-structs (`MessageState`, `RuntimeConfig`, `MemoryState`), reducing Agent top-level field count by 6.

Part of #2787 (Agent struct decomposition).

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --features full -- -D warnings` — clean
- [x] `cargo nextest run --workspace --features full --lib --bins` — 8018 passed, 22 skipped
- [x] Security audit: all sanitization logic preserved 1:1
- [x] Performance analysis: zero impact (embedded sub-structs, no extra indirection)

Closes #2802, closes #2803, closes #2805