### PR TITLE
refactor(core): consolidate builder methods with sub-struct constructors (#2804)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Refactored
 
+- **Consolidate `AgentBuilder` methods: 30% reduction** (`#2804`): added `Default`/`new()` constructors to all sub-structs (`McpState`, `IndexState`, `DebugState`, `SecurityState`, `SkillState`, `ToolState`, `SessionState`, `LifecycleState`, `ProviderState`, `MetricsState`, `ExperimentState`, `FeedbackState`, `RuntimeConfig`, etc.), simplified `new_with_registry_arc()` from ~260 to ~50 lines, and removed 40 of 132 `pub fn with_*` builder methods (30.3%). Groups of related single-field setters were consolidated into batch methods: `with_skill_matching_config` (disambiguation/two-stage/confusability), `with_memory_formatting_config` (guidelines/digest/context-strategy), `with_trajectory_and_category_config`, `with_focus_and_sidequest_config`. Unused methods `with_skill_prompt_mode`, `with_result_cache_config`, `with_tool_schema_filter`, `with_classifier_metrics`, `with_server_compaction` removed. All call sites in `src/` and `crates/zeph-core/src/` updated. No behavioral changes.
+
 - **Extract security pipeline methods into `SecurityState` impl block** (`#2802`): moved PII scrubbing, guardrail pre-screening, and NER circuit breaker management from Agent wrappers into `impl SecurityState` in `agent/state/security.rs`. New `PiiScrubResult` value type carries metric descriptors; Agent wrappers apply side effects from the result struct.
 
 - **Extract skill management methods into `SkillState` impl block** (`#2803`): moved `rebuild_prompt()`, `rebuild_bm25()`, and `fingerprint()` from Agent into `impl SkillState` in `agent/state/skill.rs`. Agent methods delegate to these helpers. Methods requiring channel/memory/provider access remain on Agent.

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::collections::VecDeque;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -114,6 +113,13 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Override the embedding model name used for skill matching.
+    #[must_use]
+    pub fn with_embedding_model(mut self, model: String) -> Self {
+        self.skill_state.embedding_model = model;
+        self
+    }
+
     /// Set the dedicated embedding provider (resolved once at bootstrap, never changed by
     /// `/provider switch`). When not called, defaults to the primary provider clone set in
     /// `Agent::new`.
@@ -198,57 +204,6 @@ impl<C: Channel> Agent<C> {
     }
 
     #[must_use]
-    pub fn with_max_tool_iterations(mut self, max: usize) -> Self {
-        self.tool_orchestrator.max_iterations = max;
-        self
-    }
-
-    /// Set the maximum number of retry attempts for transient tool errors (0 = disabled, max 5).
-    #[must_use]
-    pub fn with_max_tool_retries(mut self, max: usize) -> Self {
-        self.tool_orchestrator.max_tool_retries = max.min(5);
-        self
-    }
-
-    /// Set the maximum wall-clock budget (seconds) for retries per tool call (0 = unlimited).
-    #[must_use]
-    pub fn with_max_retry_duration_secs(mut self, secs: u64) -> Self {
-        self.tool_orchestrator.max_retry_duration_secs = secs;
-        self
-    }
-
-    /// Set the maximum tool calls allowed per session (`None` = unlimited).
-    #[must_use]
-    pub fn with_max_tool_calls_per_session(mut self, max: Option<u32>) -> Self {
-        self.tool_orchestrator.max_tool_calls_per_session = max;
-        self
-    }
-
-    /// Set the provider name for LLM-based parameter reformatting (empty = disabled).
-    #[must_use]
-    pub fn with_parameter_reformat_provider(mut self, provider: impl Into<String>) -> Self {
-        self.tool_orchestrator.parameter_reformat_provider = provider.into();
-        self
-    }
-
-    /// Set the exponential backoff parameters for tool retries.
-    #[must_use]
-    pub fn with_retry_backoff(mut self, base_ms: u64, max_ms: u64) -> Self {
-        self.tool_orchestrator.retry_base_ms = base_ms;
-        self.tool_orchestrator.retry_max_ms = max_ms;
-        self
-    }
-
-    /// Set the repeat-detection threshold (0 = disabled).
-    /// Window size is `2 * threshold`.
-    #[must_use]
-    pub fn with_tool_repeat_threshold(mut self, threshold: usize) -> Self {
-        self.tool_orchestrator.repeat_threshold = threshold;
-        self.tool_orchestrator.recent_tool_calls = VecDeque::with_capacity(2 * threshold.max(1));
-        self
-    }
-
-    #[must_use]
     pub fn with_memory(
         mut self,
         memory: Arc<SemanticMemory>,
@@ -269,33 +224,17 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Configure skill matching parameters (disambiguation, two-stage, confusability).
     #[must_use]
-    pub fn with_embedding_model(mut self, model: String) -> Self {
-        self.skill_state.embedding_model = model;
-        self
-    }
-
-    #[must_use]
-    pub fn with_disambiguation_threshold(mut self, threshold: f32) -> Self {
-        self.skill_state.disambiguation_threshold = threshold;
-        self
-    }
-
-    #[must_use]
-    pub fn with_two_stage_matching(mut self, enabled: bool) -> Self {
-        self.skill_state.two_stage_matching = enabled;
-        self
-    }
-
-    #[must_use]
-    pub fn with_confusability_threshold(mut self, threshold: f32) -> Self {
-        self.skill_state.confusability_threshold = threshold.clamp(0.0, 1.0);
-        self
-    }
-
-    #[must_use]
-    pub fn with_skill_prompt_mode(mut self, mode: crate::config::SkillPromptMode) -> Self {
-        self.skill_state.prompt_mode = mode;
+    pub fn with_skill_matching_config(
+        mut self,
+        disambiguation_threshold: f32,
+        two_stage_matching: bool,
+        confusability_threshold: f32,
+    ) -> Self {
+        self.skill_state.disambiguation_threshold = disambiguation_threshold;
+        self.skill_state.two_stage_matching = two_stage_matching;
+        self.skill_state.confusability_threshold = confusability_threshold.clamp(0.0, 1.0);
         self
     }
 
@@ -305,71 +244,31 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Configure memory formatting: compression guidelines, digest, and context strategy.
     #[must_use]
-    pub fn with_compression_guidelines_config(
+    pub fn with_memory_formatting_config(
         mut self,
-        config: zeph_memory::CompressionGuidelinesConfig,
-    ) -> Self {
-        self.memory_state.compression_guidelines_config = config;
-        self
-    }
-
-    #[must_use]
-    pub fn with_digest_config(mut self, config: crate::config::DigestConfig) -> Self {
-        self.memory_state.digest_config = config;
-        self
-    }
-
-    #[must_use]
-    pub fn with_context_strategy(
-        mut self,
-        strategy: crate::config::ContextStrategy,
+        compression_guidelines: zeph_memory::CompressionGuidelinesConfig,
+        digest: crate::config::DigestConfig,
+        context_strategy: crate::config::ContextStrategy,
         crossover_turn_threshold: u32,
     ) -> Self {
-        self.memory_state.context_strategy = strategy;
+        self.memory_state.compression_guidelines_config = compression_guidelines;
+        self.memory_state.digest_config = digest;
+        self.memory_state.context_strategy = context_strategy;
         self.memory_state.crossover_turn_threshold = crossover_turn_threshold;
         self
     }
 
+    /// Configure trajectory and category memory settings together.
     #[must_use]
-    pub fn with_persona_config(mut self, config: crate::config::PersonaConfig) -> Self {
-        self.memory_state.persona_config = config;
-        self
-    }
-
-    #[must_use]
-    pub fn with_trajectory_config(mut self, config: crate::config::TrajectoryConfig) -> Self {
-        self.memory_state.trajectory_config = config;
-        self
-    }
-
-    #[must_use]
-    pub fn with_category_config(mut self, config: crate::config::CategoryConfig) -> Self {
-        self.memory_state.category_config = config;
-        self
-    }
-
-    #[must_use]
-    pub fn with_tree_config(mut self, config: crate::config::TreeConfig) -> Self {
-        self.memory_state.tree_config = config;
-        self
-    }
-
-    #[must_use]
-    pub fn with_microcompact_config(mut self, config: crate::config::MicrocompactConfig) -> Self {
-        self.memory_state.microcompact_config = config;
-        self
-    }
-
-    #[must_use]
-    pub fn with_autodream_config(mut self, config: crate::config::AutoDreamConfig) -> Self {
-        self.memory_state.autodream_config = config;
-        self
-    }
-
-    #[must_use]
-    pub fn with_magic_docs_config(mut self, config: crate::config::MagicDocsConfig) -> Self {
-        self.memory_state.magic_docs_config = config;
+    pub fn with_trajectory_and_category_config(
+        mut self,
+        trajectory: crate::config::TrajectoryConfig,
+        category: crate::config::CategoryConfig,
+    ) -> Self {
+        self.memory_state.trajectory_config = trajectory;
+        self.memory_state.category_config = category;
         self
     }
 
@@ -494,15 +393,6 @@ impl<C: Channel> Agent<C> {
         self
     }
 
-    #[must_use]
-    pub fn with_available_secrets(
-        mut self,
-        secrets: impl IntoIterator<Item = (String, crate::vault::Secret)>,
-    ) -> Self {
-        self.skill_state.available_custom_secrets = secrets.into_iter().collect();
-        self
-    }
-
     /// # Panics
     ///
     #[must_use]
@@ -617,15 +507,6 @@ impl<C: Channel> Agent<C> {
     #[must_use]
     pub fn with_verify_provider(mut self, provider: AnyProvider) -> Self {
         self.orchestration.verify_provider = Some(provider);
-        self
-    }
-
-    /// Enable server-side compaction mode (Claude compact-2026-01-12 beta).
-    ///
-    /// When active, client-side reactive and proactive compaction are skipped.
-    #[must_use]
-    pub fn with_server_compaction(mut self, enabled: bool) -> Self {
-        self.providers.server_compaction_active = enabled;
         self
     }
 
@@ -783,32 +664,8 @@ impl<C: Channel> Agent<C> {
     }
 
     #[must_use]
-    pub fn with_redact_credentials(mut self, enabled: bool) -> Self {
-        self.runtime.redact_credentials = enabled;
-        self
-    }
-
-    #[must_use]
-    pub fn with_budget_hint_enabled(mut self, enabled: bool) -> Self {
-        self.runtime.budget_hint_enabled = enabled;
-        self
-    }
-
-    #[must_use]
     pub fn with_channel_skills(mut self, config: zeph_config::ChannelSkillsConfig) -> Self {
         self.runtime.channel_skills = config;
-        self
-    }
-
-    #[must_use]
-    pub fn with_tool_summarization(mut self, enabled: bool) -> Self {
-        self.tool_orchestrator.summarize_tool_output_enabled = enabled;
-        self
-    }
-
-    #[must_use]
-    pub fn with_overflow_config(mut self, config: zeph_tools::OverflowConfig) -> Self {
-        self.tool_orchestrator.overflow_config = config;
         self
     }
 
@@ -818,12 +675,6 @@ impl<C: Channel> Agent<C> {
     #[must_use]
     pub fn with_tafc_config(mut self, config: zeph_tools::TafcConfig) -> Self {
         self.tool_orchestrator.tafc = config.validated();
-        self
-    }
-
-    #[must_use]
-    pub fn with_result_cache_config(mut self, config: &zeph_tools::ResultCacheConfig) -> Self {
-        self.tool_orchestrator.set_cache_config(config);
         self
     }
 
@@ -998,29 +849,6 @@ impl<C: Channel> Agent<C> {
         self
     }
 
-    /// Attach a [`ClassifierMetrics`] instance to record injection, PII, and feedback latencies.
-    ///
-    /// The same `Arc` is shared with `ContentSanitizer` (injection + PII) and `LlmClassifier`
-    /// (feedback) so all three tasks write into the same ring buffers. Call this before
-    /// `with_injection_classifier`, `with_pii_detector`, and `with_llm_classifier`.
-    #[cfg(feature = "classifiers")]
-    #[must_use]
-    pub fn with_classifier_metrics(
-        mut self,
-        metrics: std::sync::Arc<zeph_llm::ClassifierMetrics>,
-    ) -> Self {
-        // Wire into sanitizer for injection + PII recording.
-        let old = std::mem::replace(
-            &mut self.security.sanitizer,
-            zeph_sanitizer::ContentSanitizer::new(
-                &zeph_sanitizer::ContentIsolationConfig::default(),
-            ),
-        );
-        self.security.sanitizer = old.with_classifier_metrics(std::sync::Arc::clone(&metrics));
-        // Store Arc for snapshot push and LlmClassifier wiring.
-        self.metrics.classifier_metrics = Some(metrics);
-        self
-    }
     #[must_use]
     pub fn with_guardrail(mut self, filter: zeph_sanitizer::guardrail::GuardrailFilter) -> Self {
         use zeph_sanitizer::guardrail::GuardrailAction;
@@ -1060,12 +888,6 @@ impl<C: Channel> Agent<C> {
     }
 
     #[must_use]
-    pub fn with_permission_policy(mut self, policy: zeph_tools::PermissionPolicy) -> Self {
-        self.runtime.permission_policy = policy;
-        self
-    }
-
-    #[must_use]
     pub fn with_context_budget(
         mut self,
         budget_tokens: usize,
@@ -1087,50 +909,26 @@ impl<C: Channel> Agent<C> {
     }
 
     #[must_use]
-    pub fn with_soft_compaction_threshold(mut self, threshold: f32) -> Self {
-        self.context_manager.soft_compaction_threshold = threshold;
-        self
-    }
-
-    /// Sets the number of turns to skip compaction after a successful compaction.
-    ///
-    /// Prevents the compaction loop from re-triggering immediately when the
-    /// summary itself is large. A value of `0` disables the cooldown.
-    #[must_use]
-    pub fn with_compaction_cooldown(mut self, cooldown_turns: u8) -> Self {
-        self.context_manager.compaction_cooldown_turns = cooldown_turns;
-        self
-    }
-
-    #[must_use]
     pub fn with_compression(mut self, compression: CompressionConfig) -> Self {
         self.context_manager.compression = compression;
         self
     }
 
-    /// Configure Focus-based active context compression (#1850).
+    /// Configure `Focus` and `SideQuest` LLM-driven context management (#1850, #1885).
     #[must_use]
-    pub fn with_focus_config(mut self, config: crate::config::FocusConfig) -> Self {
-        self.focus = super::focus::FocusState::new(config);
-        self
-    }
-
-    /// Configure `SideQuest` LLM-driven tool output eviction (#1885).
-    #[must_use]
-    pub fn with_sidequest_config(mut self, config: crate::config::SidequestConfig) -> Self {
-        self.sidequest = super::sidequest::SidequestState::new(config);
+    pub fn with_focus_and_sidequest_config(
+        mut self,
+        focus: crate::config::FocusConfig,
+        sidequest: crate::config::SidequestConfig,
+    ) -> Self {
+        self.focus = super::focus::FocusState::new(focus);
+        self.sidequest = super::sidequest::SidequestState::new(sidequest);
         self
     }
 
     #[must_use]
     pub fn with_routing(mut self, routing: StoreRoutingConfig) -> Self {
         self.context_manager.routing = routing;
-        self
-    }
-
-    #[must_use]
-    pub fn with_model_name(mut self, name: impl Into<String>) -> Self {
-        self.runtime.model_name = name.into();
         self
     }
 
@@ -1381,13 +1179,6 @@ impl<C: Channel> Agent<C> {
         self
     }
 
-    /// Set the dynamic tool schema filter (pre-computed tool embeddings).
-    #[must_use]
-    pub fn with_tool_schema_filter(mut self, filter: zeph_tools::ToolSchemaFilter) -> Self {
-        self.tool_state.tool_schema_filter = Some(filter);
-        self
-    }
-
     /// Set dependency config parameters (boost values) used per-turn.
     #[must_use]
     pub fn with_dependency_config(mut self, config: zeph_tools::DependencyConfig) -> Self {
@@ -1535,49 +1326,51 @@ impl<C: Channel> Agent<C> {
             secrets,
         } = cfg;
 
+        self.tool_orchestrator.apply_config(
+            max_tool_iterations,
+            max_tool_retries,
+            max_retry_duration_secs,
+            retry_base_ms,
+            retry_max_ms,
+            parameter_reformat_provider,
+            tool_repeat_threshold,
+            max_tool_calls_per_session,
+            tool_summarization,
+            overflow_config,
+        );
+        self.runtime.permission_policy = permission_policy;
+        self.runtime.model_name = model_name;
+        self.skill_state.embedding_model = embed_model;
+        self.context_manager.apply_budget_config(
+            budget_tokens,
+            CONTEXT_BUDGET_RESERVE_RATIO,
+            hard_compaction_threshold,
+            compaction_preserve_tail,
+            prune_protect_tokens,
+            soft_compaction_threshold,
+            compaction_cooldown_turns,
+        );
         self = self
-            .with_max_tool_iterations(max_tool_iterations)
-            .with_max_tool_calls_per_session(max_tool_calls_per_session)
-            .with_max_tool_retries(max_tool_retries)
-            .with_max_retry_duration_secs(max_retry_duration_secs)
-            .with_retry_backoff(retry_base_ms, retry_max_ms)
-            .with_parameter_reformat_provider(parameter_reformat_provider)
-            .with_tool_repeat_threshold(tool_repeat_threshold)
-            .with_model_name(model_name)
-            .with_embedding_model(embed_model)
-            .with_context_budget(
-                budget_tokens,
-                CONTEXT_BUDGET_RESERVE_RATIO,
-                hard_compaction_threshold,
-                compaction_preserve_tail,
-                prune_protect_tokens,
-            )
-            .with_soft_compaction_threshold(soft_compaction_threshold)
-            .with_compaction_cooldown(compaction_cooldown_turns)
             .with_security(security, timeouts)
-            .with_redact_credentials(redact_credentials)
-            .with_tool_summarization(tool_summarization)
-            .with_overflow_config(overflow_config)
-            .with_permission_policy(permission_policy)
-            .with_learning(learning)
-            .with_tool_call_cutoff(tool_call_cutoff)
-            .with_available_secrets(
-                secrets
-                    .iter()
-                    .map(|(k, v)| (k.clone(), crate::vault::Secret::new(v.expose().to_owned()))),
-            )
-            .with_server_compaction(server_compaction)
-            .with_document_config(document_config)
-            .with_graph_config(graph_config)
-            .with_persona_config(persona_config)
-            .with_trajectory_config(trajectory_config)
-            .with_category_config(category_config)
-            .with_tree_config(tree_config)
-            .with_microcompact_config(microcompact_config)
-            .with_autodream_config(autodream_config)
-            .with_magic_docs_config(magic_docs_config)
-            .with_orchestration_config(orchestration_config)
-            .with_budget_hint_enabled(budget_hint_enabled);
+            .with_learning(learning);
+        self.runtime.redact_credentials = redact_credentials;
+        self.memory_state.tool_call_cutoff = tool_call_cutoff;
+        self.skill_state.available_custom_secrets = secrets
+            .iter()
+            .map(|(k, v)| (k.clone(), crate::vault::Secret::new(v.expose().to_owned())))
+            .collect();
+        self.providers.server_compaction_active = server_compaction;
+        self.memory_state.document_config = document_config;
+        self.memory_state.apply_graph_config(graph_config);
+        self.memory_state.persona_config = persona_config;
+        self.memory_state.trajectory_config = trajectory_config;
+        self.memory_state.category_config = category_config;
+        self.memory_state.tree_config = tree_config;
+        self.memory_state.microcompact_config = microcompact_config;
+        self.memory_state.autodream_config = autodream_config;
+        self.memory_state.magic_docs_config = magic_docs_config;
+        self.orchestration.orchestration_config = orchestration_config;
+        self.runtime.budget_hint_enabled = budget_hint_enabled;
 
         self.debug_state.reasoning_model_warning = anomaly_config.reasoning_model_warning;
         if anomaly_config.enabled {
@@ -1591,7 +1384,8 @@ impl<C: Channel> Agent<C> {
         self.runtime.semantic_cache_enabled = semantic_cache_enabled;
         self.runtime.semantic_cache_threshold = semantic_cache_threshold;
         self.runtime.semantic_cache_max_candidates = semantic_cache_max_candidates;
-        self = self.with_result_cache_config(&result_cache_config);
+        self.tool_orchestrator
+            .set_cache_config(&result_cache_config);
 
         // When MagicDocs is enabled, file-read tools must bypass the utility gate so that
         // MagicDocs detection can inspect real file content (not a [skipped] sentinel).
@@ -1841,38 +1635,27 @@ mod tests {
     }
 
     #[test]
-    fn with_focus_config_propagates_to_focus_state() {
-        let cfg = crate::config::FocusConfig {
+    fn with_focus_and_sidequest_config_propagates() {
+        let focus = crate::config::FocusConfig {
             enabled: true,
             compression_interval: 7,
             ..Default::default()
         };
-        let agent = make_agent().with_focus_config(cfg.clone());
-        assert!(
-            agent.focus.config.enabled,
-            "with_focus_config must set enabled"
-        );
-        assert_eq!(
-            agent.focus.config.compression_interval, 7,
-            "with_focus_config must propagate compression_interval"
-        );
-    }
-
-    #[test]
-    fn with_sidequest_config_propagates_to_sidequest_state() {
-        let cfg = crate::config::SidequestConfig {
+        let sidequest = crate::config::SidequestConfig {
             enabled: true,
             interval_turns: 3,
             ..Default::default()
         };
-        let agent = make_agent().with_sidequest_config(cfg.clone());
-        assert!(
-            agent.sidequest.config.enabled,
-            "with_sidequest_config must set enabled"
+        let agent = make_agent().with_focus_and_sidequest_config(focus, sidequest);
+        assert!(agent.focus.config.enabled, "must set focus.enabled");
+        assert_eq!(
+            agent.focus.config.compression_interval, 7,
+            "must propagate compression_interval"
         );
+        assert!(agent.sidequest.config.enabled, "must set sidequest.enabled");
         assert_eq!(
             agent.sidequest.config.interval_turns, 3,
-            "with_sidequest_config must propagate interval_turns"
+            "must propagate interval_turns"
         );
     }
 
@@ -1894,38 +1677,34 @@ mod tests {
     }
 
     #[test]
-    fn with_two_stage_matching_sets_flag() {
-        let agent = make_agent().with_two_stage_matching(true);
+    fn with_skill_matching_config_sets_fields() {
+        let agent = make_agent().with_skill_matching_config(0.7, true, 0.85);
         assert!(
             agent.skill_state.two_stage_matching,
-            "with_two_stage_matching(true) must enable two_stage_matching"
+            "with_skill_matching_config must set two_stage_matching"
         );
-
-        let agent = make_agent().with_two_stage_matching(false);
         assert!(
-            !agent.skill_state.two_stage_matching,
-            "with_two_stage_matching(false) must disable two_stage_matching"
+            (agent.skill_state.disambiguation_threshold - 0.7).abs() < f32::EPSILON,
+            "with_skill_matching_config must set disambiguation_threshold"
+        );
+        assert!(
+            (agent.skill_state.confusability_threshold - 0.85).abs() < f32::EPSILON,
+            "with_skill_matching_config must set confusability_threshold"
         );
     }
 
     #[test]
-    fn with_confusability_threshold_sets_and_clamps() {
-        let agent = make_agent().with_confusability_threshold(0.85);
-        assert!(
-            (agent.skill_state.confusability_threshold - 0.85).abs() < f32::EPSILON,
-            "with_confusability_threshold must store the provided value"
-        );
-
-        let agent = make_agent().with_confusability_threshold(1.5);
+    fn with_skill_matching_config_clamps_confusability() {
+        let agent = make_agent().with_skill_matching_config(0.5, false, 1.5);
         assert!(
             (agent.skill_state.confusability_threshold - 1.0).abs() < f32::EPSILON,
-            "with_confusability_threshold must clamp values above 1.0"
+            "with_skill_matching_config must clamp confusability above 1.0"
         );
 
-        let agent = make_agent().with_confusability_threshold(-0.1);
+        let agent = make_agent().with_skill_matching_config(0.5, false, -0.1);
         assert!(
             agent.skill_state.confusability_threshold.abs() < f32::EPSILON,
-            "with_confusability_threshold must clamp values below 0.0"
+            "with_skill_matching_config must clamp confusability below 0.0"
         );
     }
 }

--- a/crates/zeph-core/src/agent/context/tests.rs
+++ b/crates/zeph-core/src/agent/context/tests.rs
@@ -175,8 +175,8 @@ fn compaction_tier_hard_above_threshold() {
     let executor = MockToolExecutor::no_tools();
 
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
-        .with_context_budget(100, 0.20, 0.75, 4, 0)
-        .with_soft_compaction_threshold(0.50);
+        .with_context_budget(100, 0.20, 0.75, 4, 0);
+    agent.context_manager.soft_compaction_threshold = 0.50;
 
     for i in 0..20 {
         agent.msg.messages.push(Message {
@@ -1426,8 +1426,8 @@ async fn test_prepare_context_scrubs_secrets_when_redact_enabled() {
     let executor = MockToolExecutor::no_tools();
 
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
-        .with_context_budget(4096, 0.20, 0.80, 4, 0)
-        .with_redact_credentials(true);
+        .with_context_budget(4096, 0.20, 0.80, 4, 0);
+    agent.runtime.redact_credentials = true;
 
     // Push a user message containing a secret and a path
     agent.msg.messages.push(Message {
@@ -1472,8 +1472,8 @@ async fn test_prepare_context_preserves_system_prompt_paths() {
 
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
         .with_context_budget(4096, 0.20, 0.80, 4, 0)
-        .with_redact_credentials(true)
         .with_working_dir("/Users/dev/project");
+    agent.runtime.redact_credentials = true;
 
     agent.msg.messages.push(Message {
         role: Role::User,
@@ -1531,8 +1531,8 @@ async fn test_prepare_context_no_scrub_when_redact_disabled() {
     let executor = MockToolExecutor::no_tools();
 
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
-        .with_context_budget(4096, 0.20, 0.80, 4, 0)
-        .with_redact_credentials(false);
+        .with_context_budget(4096, 0.20, 0.80, 4, 0);
+    agent.runtime.redact_credentials = false;
 
     let original = "key sk-abc123xyz at /Users/dev/file.rs".to_string();
     agent.msg.messages.push(Message {
@@ -1586,8 +1586,8 @@ fn compaction_tier_hard_triggers_when_cached_tokens_exceed_hard_threshold() {
 
     // budget 1000, hard=0.75, soft=0.50 → hard fires above 750
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
-        .with_context_budget(1000, 0.20, 0.75, 4, 0)
-        .with_soft_compaction_threshold(0.50);
+        .with_context_budget(1000, 0.20, 0.75, 4, 0);
+    agent.context_manager.soft_compaction_threshold = 0.50;
     agent.providers.cached_prompt_tokens = 900;
 
     assert_eq!(
@@ -1606,8 +1606,8 @@ fn compaction_tier_none_does_not_trigger_below_soft_threshold() {
 
     // budget 1000, hard=0.75, soft=0.50 → nothing fires below 500
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
-        .with_context_budget(1000, 0.20, 0.75, 4, 0)
-        .with_soft_compaction_threshold(0.50);
+        .with_context_budget(1000, 0.20, 0.75, 4, 0);
+    agent.context_manager.soft_compaction_threshold = 0.50;
     agent.providers.cached_prompt_tokens = 100;
 
     assert_eq!(
@@ -3457,8 +3457,8 @@ fn tier0_does_not_set_compacted_this_turn() {
     let registry = create_test_registry();
     let executor = MockToolExecutor::no_tools();
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
-        .with_context_budget(100_000, 0.20, 0.80, 4, 0)
-        .with_soft_compaction_threshold(0.70);
+        .with_context_budget(100_000, 0.20, 0.80, 4, 0);
+    agent.context_manager.soft_compaction_threshold = 0.70;
 
     make_tool_pair(&mut agent, "a");
     make_tool_pair(&mut agent, "b");
@@ -3486,8 +3486,8 @@ fn tier0_count_trigger_fires_without_budget_pressure() {
     let executor = MockToolExecutor::no_tools();
     // Large budget: soft threshold 70% = 70_000 tokens — far above cached_prompt_tokens
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
-        .with_context_budget(100_000, 0.20, 0.80, 4, 0)
-        .with_soft_compaction_threshold(0.70);
+        .with_context_budget(100_000, 0.20, 0.80, 4, 0);
+    agent.context_manager.soft_compaction_threshold = 0.70;
 
     // tool_call_cutoff defaults to 6; add exactly that many deferred summaries
     for label in ["a", "b", "c", "d", "e", "f"] {
@@ -3662,8 +3662,8 @@ async fn cooldown_guard_decrements_and_skips_compaction() {
 
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
         .with_context_budget(100, 0.20, 0.75, 2, 0)
-        .with_compaction_cooldown(2)
         .with_metrics(tx);
+    agent.context_manager.compaction_cooldown_turns = 2;
 
     // Manually set cooling state as if compaction just fired and turn advanced.
     agent.context_manager.compaction = CompactionState::Cooling { turns_remaining: 2 };
@@ -3700,8 +3700,8 @@ async fn cooldown_guard_fires_after_expiry_and_resets_counter() {
 
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
         .with_context_budget(100, 0.20, 0.75, 2, 0)
-        .with_compaction_cooldown(2)
         .with_metrics(tx);
+    agent.context_manager.compaction_cooldown_turns = 2;
 
     // Ready state means cooldown has already expired.
     assert_eq!(agent.context_manager.compaction, CompactionState::Ready);
@@ -3812,8 +3812,8 @@ async fn exhaustion_guard_takes_precedence_over_cooldown() {
     let executor = MockToolExecutor::no_tools();
 
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
-        .with_context_budget(100, 0.20, 0.75, 2, 0)
-        .with_compaction_cooldown(2);
+        .with_context_budget(100, 0.20, 0.75, 2, 0);
+    agent.context_manager.compaction_cooldown_turns = 2;
 
     // Exhausted state (the Cooling state would normally guard against exhaustion, but
     // we test the ordering guarantee that exhaustion check happens before cooldown decrement).
@@ -3893,8 +3893,8 @@ fn builder_with_compaction_cooldown_sets_field() {
     let registry = create_test_registry();
     let executor = MockToolExecutor::no_tools();
 
-    let agent =
-        Agent::new(provider, channel, registry, None, 5, executor).with_compaction_cooldown(5);
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+    agent.context_manager.compaction_cooldown_turns = 5;
 
     assert_eq!(agent.context_manager.compaction_cooldown_turns, 5);
 }
@@ -3936,8 +3936,8 @@ async fn compaction_turns_after_hard_tracks_segments() {
 
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
         .with_context_budget(1000, 0.20, 0.75, 4, 0)
-        .with_compaction_cooldown(0)
         .with_metrics(tx);
+    agent.context_manager.compaction_cooldown_turns = 0;
 
     // Simulate first hard compaction by driving cached tokens above threshold.
     agent.providers.cached_prompt_tokens = 900;
@@ -4003,8 +4003,8 @@ fn mid_iteration_skips_when_compacted_this_turn() {
     let executor = MockToolExecutor::no_tools();
     // budget=100_000, soft=0.60 → soft_threshold=60_000
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
-        .with_context_budget(100_000, 0.20, 0.90, 4, 0)
-        .with_soft_compaction_threshold(0.60);
+        .with_context_budget(100_000, 0.20, 0.90, 4, 0);
+    agent.context_manager.soft_compaction_threshold = 0.60;
 
     make_tool_pair_with_output(&mut agent, "a");
     agent.msg.messages[2].metadata.deferred_summary = Some("sum_a".into());
@@ -4035,8 +4035,8 @@ fn mid_iteration_skips_when_tier_is_none() {
     let executor = MockToolExecutor::no_tools();
     // budget=100_000, soft=0.60 → soft_threshold=60_000
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
-        .with_context_budget(100_000, 0.20, 0.90, 4, 0)
-        .with_soft_compaction_threshold(0.60);
+        .with_context_budget(100_000, 0.20, 0.90, 4, 0);
+    agent.context_manager.soft_compaction_threshold = 0.60;
 
     make_tool_pair_with_output(&mut agent, "a");
     agent.msg.messages[2].metadata.deferred_summary = Some("sum_a".into());
@@ -4062,8 +4062,8 @@ fn mid_iteration_applies_deferred_summaries_at_soft_tier() {
     let executor = MockToolExecutor::no_tools();
     // budget=100_000, soft=0.60 → soft_threshold=60_000; hard=0.90
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
-        .with_context_budget(100_000, 0.20, 0.90, 4, 0)
-        .with_soft_compaction_threshold(0.60);
+        .with_context_budget(100_000, 0.20, 0.90, 4, 0);
+    agent.context_manager.soft_compaction_threshold = 0.60;
 
     make_tool_pair_with_output(&mut agent, "a");
     agent.msg.messages[2].metadata.deferred_summary = Some("sum_a".into());
@@ -4091,8 +4091,8 @@ fn mid_iteration_does_not_set_compacted_this_turn() {
     let registry = create_test_registry();
     let executor = MockToolExecutor::no_tools();
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
-        .with_context_budget(100_000, 0.20, 0.90, 4, 0)
-        .with_soft_compaction_threshold(0.60);
+        .with_context_budget(100_000, 0.20, 0.90, 4, 0);
+    agent.context_manager.soft_compaction_threshold = 0.60;
 
     make_tool_pair_with_output(&mut agent, "a");
     agent.providers.cached_prompt_tokens = 75_000;
@@ -4113,8 +4113,8 @@ fn mid_iteration_fires_at_hard_tier() {
     let executor = MockToolExecutor::no_tools();
     // budget=100_000, soft=0.60 → 60_000; hard=0.90 → 90_000
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
-        .with_context_budget(100_000, 0.20, 0.90, 4, 0)
-        .with_soft_compaction_threshold(0.60);
+        .with_context_budget(100_000, 0.20, 0.90, 4, 0);
+    agent.context_manager.soft_compaction_threshold = 0.60;
 
     make_tool_pair_with_output(&mut agent, "a");
     agent.msg.messages[2].metadata.deferred_summary = Some("sum_a".into());

--- a/crates/zeph-core/src/agent/context_manager.rs
+++ b/crates/zeph-core/src/agent/context_manager.rs
@@ -157,6 +157,30 @@ impl ContextManager {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn apply_budget_config(
+        &mut self,
+        budget_tokens: usize,
+        reserve_ratio: f32,
+        hard_compaction_threshold: f32,
+        compaction_preserve_tail: usize,
+        prune_protect_tokens: usize,
+        soft_compaction_threshold: f32,
+        compaction_cooldown_turns: u8,
+    ) {
+        if budget_tokens == 0 {
+            tracing::warn!("context budget is 0 — agent will have no token tracking");
+        }
+        if budget_tokens > 0 {
+            self.budget = Some(ContextBudget::new(budget_tokens, reserve_ratio));
+        }
+        self.hard_compaction_threshold = hard_compaction_threshold;
+        self.compaction_preserve_tail = compaction_preserve_tail;
+        self.prune_protect_tokens = prune_protect_tokens;
+        self.soft_compaction_threshold = soft_compaction_threshold;
+        self.compaction_cooldown_turns = compaction_cooldown_turns;
+    }
+
     /// Reset compaction state for a new conversation.
     ///
     /// Clears cooldown, exhaustion, and turn counters so the new conversation starts

--- a/crates/zeph-core/src/agent/microcompact.rs
+++ b/crates/zeph-core/src/agent/microcompact.rs
@@ -216,15 +216,16 @@ mod tests {
     use zeph_config::MicrocompactConfig;
 
     fn make_agent_with_microcompact(cfg: MicrocompactConfig) -> Agent<MockChannel> {
-        Agent::new(
+        let mut agent = Agent::new(
             mock_provider(vec![]),
             MockChannel::new(vec![]),
             create_test_registry(),
             None,
             5,
             MockToolExecutor::no_tools(),
-        )
-        .with_microcompact_config(cfg)
+        );
+        agent.memory_state.microcompact_config = cfg;
+        agent
     }
 
     #[test]

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -44,13 +44,12 @@ pub(crate) mod tool_orchestrator;
 mod trust_commands;
 mod utils;
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 
 use parking_lot::RwLock;
-use std::time::Instant;
 
-use tokio::sync::{Notify, mpsc, watch};
+use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::{LlmProvider, Message, MessageMetadata, Role};
@@ -64,10 +63,8 @@ use zeph_tools::executor::{ErasedToolExecutor, ToolExecutor};
 
 use crate::channel::Channel;
 use crate::config::Config;
-use crate::config::{SecurityConfig, SkillPromptMode, TimeoutConfig};
-use crate::context::{ContextBudget, EnvironmentContext, build_system_prompt};
+use crate::context::{ContextBudget, build_system_prompt};
 use zeph_common::text::estimate_tokens;
-use zeph_sanitizer::ContentSanitizer;
 
 use message_queue::{MAX_AUDIO_BYTES, MAX_IMAGE_BYTES, detect_image_mime};
 use state::CompressionState;
@@ -202,12 +199,7 @@ impl<C: Channel> Agent<C> {
         tracing::trace!(prompt = %system_prompt, "full system prompt");
 
         let initial_prompt_tokens = estimate_tokens(&system_prompt) as u64;
-        let (_tx, rx) = watch::channel(false);
         let token_counter = Arc::new(TokenCounter::new());
-        // Always create the receiver side of the experiment notification channel so the
-        // select! branch in the agent loop compiles unconditionally. The sender is only
-        // stored when the experiments feature is enabled (it is only used in experiment_cmd.rs).
-        let (exp_notify_tx, exp_notify_rx) = tokio::sync::mpsc::channel::<String>(4);
         Self {
             provider,
             embedding_provider,
@@ -226,256 +218,28 @@ impl<C: Channel> Agent<C> {
                 deferred_db_hide_ids: Vec::new(),
                 deferred_db_summaries: Vec::new(),
             },
-            memory_state: MemoryState {
-                memory: None,
-                conversation_id: None,
-                history_limit: 50,
-                recall_limit: 5,
-                summarization_threshold: 50,
-                cross_session_score_threshold: 0.35,
-                autosave_assistant: false,
-                autosave_min_length: 20,
-                tool_call_cutoff: 6,
-                unsummarized_count: 0,
-                document_config: crate::config::DocumentConfig::default(),
-                graph_config: crate::config::GraphConfig::default(),
-                compression_guidelines_config: zeph_memory::CompressionGuidelinesConfig::default(),
-                shutdown_summary: true,
-                shutdown_summary_min_messages: 4,
-                shutdown_summary_max_messages: 20,
-                shutdown_summary_timeout_secs: 10,
-                structured_summaries: false,
-                last_recall_confidence: None,
-                digest_config: crate::config::DigestConfig::default(),
-                cached_session_digest: None,
-                context_strategy: crate::config::ContextStrategy::default(),
-                crossover_turn_threshold: 20,
-                rpe_router: None,
-                goal_text: None,
-                persona_config: crate::config::PersonaConfig::default(),
-                trajectory_config: crate::config::TrajectoryConfig::default(),
-                category_config: crate::config::CategoryConfig::default(),
-                tree_config: crate::config::TreeConfig::default(),
-                tree_consolidation_handle: None,
-                microcompact_config: crate::config::MicrocompactConfig::default(),
-                autodream_config: crate::config::AutoDreamConfig::default(),
-                magic_docs_config: crate::config::MagicDocsConfig::default(),
-                autodream: autodream::AutoDreamState::new(),
-                magic_docs: magic_docs::MagicDocsState::new(),
-            },
-            skill_state: SkillState {
-                registry,
-                skill_paths: Vec::new(),
-                managed_dir: None,
-                trust_config: crate::config::TrustConfig::default(),
-                matcher,
-                max_active_skills,
-                disambiguation_threshold: 0.20,
-                min_injection_score: 0.20,
-                embedding_model: String::new(),
-                skill_reload_rx: None,
-                active_skill_names: Vec::new(),
-                last_skills_prompt: skills_prompt,
-                prompt_mode: SkillPromptMode::Auto,
-                available_custom_secrets: HashMap::new(),
-                cosine_weight: 0.7,
-                hybrid_search: false,
-                bm25_index: None,
-                two_stage_matching: false,
-                confusability_threshold: 0.0,
-                rl_head: None,
-                rl_weight: 0.3,
-                rl_warmup_updates: 50,
-                generation_output_dir: None,
-                generation_provider_name: String::new(),
-            },
+            memory_state: MemoryState::default(),
+            skill_state: SkillState::new(registry, matcher, max_active_skills, skills_prompt),
             context_manager: context_manager::ContextManager::new(),
             tool_orchestrator: tool_orchestrator::ToolOrchestrator::new(),
             learning_engine: learning_engine::LearningEngine::new(),
-            feedback: FeedbackState {
-                detector: feedback_detector::FeedbackDetector::new(0.6),
-                judge: None,
-                llm_classifier: None,
-            },
-            debug_state: DebugState {
-                debug_dumper: None,
-                dump_format: crate::debug_dump::DumpFormat::default(),
-                trace_collector: None,
-                iteration_counter: 0,
-                anomaly_detector: None,
-                reasoning_model_warning: true,
-                logging_config: crate::config::LoggingConfig::default(),
-                dump_dir: None,
-                trace_service_name: String::new(),
-                trace_redact: true,
-                current_iteration_span_id: None,
-            },
-            runtime: RuntimeConfig {
-                security: SecurityConfig::default(),
-                timeouts: TimeoutConfig::default(),
-                model_name: String::new(),
-                active_provider_name: String::new(),
-                permission_policy: zeph_tools::PermissionPolicy::default(),
-                redact_credentials: true,
-                rate_limiter: rate_limiter::ToolRateLimiter::new(
-                    rate_limiter::RateLimitConfig::default(),
-                ),
-                semantic_cache_enabled: false,
-                semantic_cache_threshold: 0.95,
-                semantic_cache_max_candidates: 10,
-                dependency_config: zeph_tools::DependencyConfig::default(),
-                adversarial_policy_info: None,
-                spawn_depth: 0,
-                budget_hint_enabled: true,
-                channel_skills: zeph_config::ChannelSkillsConfig::default(),
-                layers: Vec::new(),
-            },
-            mcp: McpState {
-                tools: Vec::new(),
-                registry: None,
-                manager: None,
-                allowed_commands: Vec::new(),
-                max_dynamic: 10,
-                elicitation_rx: None,
-                shared_tools: None,
-                tool_rx: None,
-                server_outcomes: Vec::new(),
-                pruning_cache: zeph_mcp::PruningCache::new(),
-                pruning_provider: None,
-                pruning_enabled: false,
-                pruning_params: zeph_mcp::PruningParams::default(),
-                semantic_index: None,
-                discovery_strategy: zeph_mcp::ToolDiscoveryStrategy::default(),
-                discovery_params: zeph_mcp::DiscoveryParams::default(),
-                discovery_provider: None,
-                elicitation_warn_sensitive_fields: true,
-            },
-            index: IndexState {
-                retriever: None,
-                repo_map_tokens: 0,
-                cached_repo_map: None,
-                repo_map_ttl: std::time::Duration::from_secs(300),
-            },
-            session: SessionState {
-                env_context: EnvironmentContext::gather(""),
-                last_assistant_at: None,
-                response_cache: None,
-                parent_tool_use_id: None,
-                status_tx: None,
-                lsp_hooks: None,
-                policy_config: None,
-                hooks_config: state::HooksConfigSnapshot::default(),
-            },
-            instructions: InstructionState {
-                blocks: Vec::new(),
-                reload_rx: None,
-                reload_state: None,
-            },
-            security: SecurityState {
-                sanitizer: ContentSanitizer::new(&zeph_sanitizer::ContentIsolationConfig::default()),
-                quarantine_summarizer: None,
-                is_acp_session: false,
-                exfiltration_guard: zeph_sanitizer::exfiltration::ExfiltrationGuard::new(
-                    zeph_sanitizer::exfiltration::ExfiltrationGuardConfig::default(),
-                ),
-                flagged_urls: std::collections::HashSet::new(),
-                user_provided_urls: Arc::new(RwLock::new(std::collections::HashSet::new())),
-                pii_filter: zeph_sanitizer::pii::PiiFilter::new(
-                    zeph_sanitizer::pii::PiiFilterConfig::default(),
-                ),
-                #[cfg(feature = "classifiers")]
-                pii_ner_backend: None,
-                #[cfg(feature = "classifiers")]
-                pii_ner_timeout_ms: 5000,
-                #[cfg(feature = "classifiers")]
-                pii_ner_max_chars: 8192,
-                #[cfg(feature = "classifiers")]
-                pii_ner_circuit_breaker_threshold: 2,
-                #[cfg(feature = "classifiers")]
-                pii_ner_consecutive_timeouts: 0,
-                #[cfg(feature = "classifiers")]
-                pii_ner_tripped: false,
-                memory_validator: zeph_sanitizer::memory_validation::MemoryWriteValidator::new(
-                    zeph_sanitizer::memory_validation::MemoryWriteValidationConfig::default(),
-                ),
-                guardrail: None,
-                response_verifier: zeph_sanitizer::response_verifier::ResponseVerifier::new(
-                    zeph_config::ResponseVerificationConfig::default(),
-                ),
-                causal_analyzer: None,
-            },
-            experiments: ExperimentState {
-                config: crate::config::ExperimentConfig::default(),
-                cancel: None,
-                baseline: zeph_experiments::ConfigSnapshot::default(),
-                eval_provider: None,
-                notify_rx: Some(exp_notify_rx),
-                notify_tx: exp_notify_tx,
-            },
-            compression: CompressionState {
-                current_task_goal: None,
-                task_goal_user_msg_hash: None,
-                pending_task_goal: None,
-                pending_sidequest_result: None,
-                subgoal_registry: crate::agent::compaction_strategy::SubgoalRegistry::default(),
-                pending_subgoal: None,
-                subgoal_user_msg_hash: None,
-            },
-            lifecycle: LifecycleState {
-                shutdown: rx,
-                start_time: Instant::now(),
-                cancel_signal: Arc::new(Notify::new()),
-                cancel_token: CancellationToken::new(),
-                cancel_bridge_handle: None,
-                config_path: None,
-                config_reload_rx: None,
-                warmup_ready: None,
-                update_notify_rx: None,
-                custom_task_rx: None,
-                last_known_cwd: std::env::current_dir().unwrap_or_default(),
-                file_changed_rx: None,
-                file_watcher: None,
-            },
-            providers: ProviderState {
-                summary_provider: None,
-                provider_override: None,
-                judge_provider: None,
-                probe_provider: None,
-                compress_provider: None,
-                cached_prompt_tokens: initial_prompt_tokens,
-                server_compaction_active: false,
-                stt: None,
-                provider_pool: Vec::new(),
-                provider_config_snapshot: None,
-            },
-            metrics: MetricsState {
-                metrics_tx: None,
-                cost_tracker: None,
-                token_counter,
-                extended_context: false,
-                classifier_metrics: None,
-            },
-            orchestration: OrchestrationState {
-                planner_provider: None,
-                verify_provider: None,
-                pending_graph: None,
-                plan_cancel_token: None,
-                subagent_manager: None,
-                subagent_config: crate::config::SubAgentConfig::default(),
-                orchestration_config: crate::config::OrchestrationConfig::default(),
-                plan_cache: None,
-                pending_goal_embedding: None,
-            },
+            feedback: FeedbackState::default(),
+            debug_state: DebugState::default(),
+            runtime: RuntimeConfig::default(),
+            mcp: McpState::default(),
+            index: IndexState::default(),
+            session: SessionState::new(),
+            instructions: InstructionState::default(),
+            security: SecurityState::default(),
+            experiments: ExperimentState::new(),
+            compression: CompressionState::default(),
+            lifecycle: LifecycleState::new(),
+            providers: ProviderState::new(initial_prompt_tokens),
+            metrics: MetricsState::new(token_counter),
+            orchestration: OrchestrationState::default(),
             focus: focus::FocusState::default(),
             sidequest: sidequest::SidequestState::default(),
-            tool_state: ToolState {
-                tool_schema_filter: None,
-                cached_filtered_tool_ids: None,
-                dependency_graph: None,
-                dependency_always_on: HashSet::new(),
-                completed_tool_ids: HashSet::new(),
-                current_tool_iteration: 0,
-            },
+            tool_state: ToolState::default(),
         }
     }
 

--- a/crates/zeph-core/src/agent/persistence.rs
+++ b/crates/zeph-core/src/agent/persistence.rs
@@ -1208,8 +1208,9 @@ mod tests {
 
         let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
             .with_metrics(tx)
-            .with_memory(std::sync::Arc::new(memory), cid, 50, 5, 100)
-            .with_autosave_config(false, 20);
+            .with_memory(std::sync::Arc::new(memory), cid, 50, 5, 100);
+        agent.memory_state.autosave_assistant = false;
+        agent.memory_state.autosave_min_length = 20;
 
         agent
             .persist_message(Role::Assistant, "short assistant reply", &[], false)
@@ -1244,8 +1245,9 @@ mod tests {
         // autosave_assistant=true but min_length=1000 — short content falls back to save_only
         let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
             .with_metrics(tx)
-            .with_memory(std::sync::Arc::new(memory), cid, 50, 5, 100)
-            .with_autosave_config(true, 1000);
+            .with_memory(std::sync::Arc::new(memory), cid, 50, 5, 100);
+        agent.memory_state.autosave_assistant = true;
+        agent.memory_state.autosave_min_length = 1000;
 
         agent
             .persist_message(Role::Assistant, "too short", &[], false)
@@ -1280,8 +1282,9 @@ mod tests {
         let min_length = 10usize;
         let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
             .with_metrics(tx)
-            .with_memory(std::sync::Arc::new(memory), cid, 50, 5, 100)
-            .with_autosave_config(true, min_length);
+            .with_memory(std::sync::Arc::new(memory), cid, 50, 5, 100);
+        agent.memory_state.autosave_assistant = true;
+        agent.memory_state.autosave_min_length = min_length;
 
         // Exact boundary: len == min_length → embed path.
         let content_at_boundary = "A".repeat(min_length);
@@ -1309,8 +1312,9 @@ mod tests {
         let min_length = 10usize;
         let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
             .with_metrics(tx)
-            .with_memory(std::sync::Arc::new(memory), cid, 50, 5, 100)
-            .with_autosave_config(true, min_length);
+            .with_memory(std::sync::Arc::new(memory), cid, 50, 5, 100);
+        agent.memory_state.autosave_assistant = true;
+        agent.memory_state.autosave_min_length = min_length;
 
         // One below boundary: len == min_length - 1 → save_only path, no embedding.
         let content_below_boundary = "A".repeat(min_length - 1);
@@ -1844,8 +1848,9 @@ mod tests {
         // autosave_assistant=false — but User role always takes embedding path
         let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
             .with_metrics(tx)
-            .with_memory(std::sync::Arc::new(memory), cid, 50, 5, 100)
-            .with_autosave_config(false, 20);
+            .with_memory(std::sync::Arc::new(memory), cid, 50, 5, 100);
+        agent.memory_state.autosave_assistant = false;
+        agent.memory_state.autosave_min_length = 20;
 
         let long_user_msg = "A".repeat(100);
         agent
@@ -3499,8 +3504,9 @@ mod tests {
 
         let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
             .with_metrics(tx)
-            .with_memory(std::sync::Arc::new(memory), cid, 50, 5, 100)
-            .with_autosave_config(true, 0);
+            .with_memory(std::sync::Arc::new(memory), cid, 50, 5, 100);
+        agent.memory_state.autosave_assistant = true;
+        agent.memory_state.autosave_min_length = 0;
 
         let parts = vec![MessagePart::ToolResult {
             tool_use_id: "tu1".into(),
@@ -3539,8 +3545,9 @@ mod tests {
 
         let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
             .with_metrics(tx)
-            .with_memory(std::sync::Arc::new(memory), cid, 50, 5, 100)
-            .with_autosave_config(true, 0);
+            .with_memory(std::sync::Arc::new(memory), cid, 50, 5, 100);
+        agent.memory_state.autosave_assistant = true;
+        agent.memory_state.autosave_min_length = 0;
 
         let parts = vec![MessagePart::ToolResult {
             tool_use_id: "tu2".into(),
@@ -3579,9 +3586,15 @@ mod tests {
         let cid = memory.sqlite().create_conversation().await.unwrap();
         let memory_arc = std::sync::Arc::new(memory);
 
-        let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
-            .with_memory(memory_arc.clone(), cid, 50, 5, 100)
-            .with_autosave_config(true, 0);
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor).with_memory(
+            memory_arc.clone(),
+            cid,
+            50,
+            5,
+            100,
+        );
+        agent.memory_state.autosave_assistant = true;
+        agent.memory_state.autosave_min_length = 0;
 
         let content = "total 42\ndrwxr-xr-x  5 user group";
         let parts = vec![MessagePart::ToolResult {

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -395,6 +395,7 @@ pub(crate) struct MetricsState {
 }
 
 /// Groups task orchestration and subagent state.
+#[derive(Default)]
 pub(crate) struct OrchestrationState {
     /// On `OrchestrationState` (not `ProviderState`) because this provider is used exclusively
     /// by `LlmPlanner` during orchestration, not shared across subsystems.
@@ -426,6 +427,7 @@ pub(crate) struct OrchestrationState {
 }
 
 /// Groups instruction hot-reload state.
+#[derive(Default)]
 pub(crate) struct InstructionState {
     pub(crate) blocks: Vec<InstructionBlock>,
     pub(crate) reload_rx: Option<mpsc::Receiver<InstructionEvent>>,
@@ -458,6 +460,7 @@ pub(crate) struct SubgoalExtractionResult {
 }
 
 /// Groups context-compression feature state (gated behind `context-compression` feature flag).
+#[derive(Default)]
 pub(crate) struct CompressionState {
     /// Cached task goal for TaskAware/MIG pruning. Set by `maybe_compact()`,
     /// invalidated when the last user message hash changes.
@@ -479,6 +482,7 @@ pub(crate) struct CompressionState {
 }
 
 /// Groups runtime tool filtering, dependency tracking, and iteration bookkeeping.
+#[derive(Default)]
 pub(crate) struct ToolState {
     /// Dynamic tool schema filter: pre-computed tool embeddings for per-turn filtering (#2020).
     pub(crate) tool_schema_filter: Option<zeph_tools::ToolSchemaFilter>,
@@ -695,6 +699,272 @@ impl DebugState {
             raw
         };
         d.dump_response(id, &text);
+    }
+}
+
+impl Default for MemoryState {
+    fn default() -> Self {
+        Self {
+            memory: None,
+            conversation_id: None,
+            history_limit: 50,
+            recall_limit: 5,
+            summarization_threshold: 50,
+            cross_session_score_threshold: 0.35,
+            autosave_assistant: false,
+            autosave_min_length: 20,
+            tool_call_cutoff: 6,
+            unsummarized_count: 0,
+            document_config: crate::config::DocumentConfig::default(),
+            graph_config: crate::config::GraphConfig::default(),
+            compression_guidelines_config: zeph_memory::CompressionGuidelinesConfig::default(),
+            shutdown_summary: true,
+            shutdown_summary_min_messages: 4,
+            shutdown_summary_max_messages: 20,
+            shutdown_summary_timeout_secs: 10,
+            structured_summaries: false,
+            last_recall_confidence: None,
+            digest_config: crate::config::DigestConfig::default(),
+            cached_session_digest: None,
+            context_strategy: crate::config::ContextStrategy::default(),
+            crossover_turn_threshold: 20,
+            rpe_router: None,
+            goal_text: None,
+            persona_config: crate::config::PersonaConfig::default(),
+            trajectory_config: crate::config::TrajectoryConfig::default(),
+            category_config: crate::config::CategoryConfig::default(),
+            tree_config: crate::config::TreeConfig::default(),
+            tree_consolidation_handle: None,
+            microcompact_config: crate::config::MicrocompactConfig::default(),
+            autodream_config: crate::config::AutoDreamConfig::default(),
+            magic_docs_config: crate::config::MagicDocsConfig::default(),
+            autodream: super::autodream::AutoDreamState::new(),
+            magic_docs: super::magic_docs::MagicDocsState::new(),
+        }
+    }
+}
+
+impl MemoryState {
+    pub(crate) fn apply_graph_config(&mut self, config: crate::config::GraphConfig) {
+        if config.enabled {
+            tracing::warn!(
+                "graph-memory is enabled: extracted entities are stored without PII redaction. \
+                 Do not use with sensitive personal data until redaction is implemented."
+            );
+        }
+        if config.rpe.enabled {
+            self.rpe_router = Some(std::sync::Mutex::new(zeph_memory::RpeRouter::new(
+                config.rpe.threshold,
+                config.rpe.max_skip_turns,
+            )));
+        } else {
+            self.rpe_router = None;
+        }
+        self.graph_config = config;
+    }
+}
+
+impl Default for McpState {
+    fn default() -> Self {
+        Self {
+            tools: Vec::new(),
+            registry: None,
+            manager: None,
+            allowed_commands: Vec::new(),
+            max_dynamic: 10,
+            elicitation_rx: None,
+            shared_tools: None,
+            tool_rx: None,
+            server_outcomes: Vec::new(),
+            pruning_cache: zeph_mcp::PruningCache::new(),
+            pruning_provider: None,
+            pruning_enabled: false,
+            pruning_params: zeph_mcp::PruningParams::default(),
+            semantic_index: None,
+            discovery_strategy: zeph_mcp::ToolDiscoveryStrategy::default(),
+            discovery_params: zeph_mcp::DiscoveryParams::default(),
+            discovery_provider: None,
+            elicitation_warn_sensitive_fields: true,
+        }
+    }
+}
+
+impl Default for IndexState {
+    fn default() -> Self {
+        Self {
+            retriever: None,
+            repo_map_tokens: 0,
+            cached_repo_map: None,
+            repo_map_ttl: std::time::Duration::from_secs(300),
+        }
+    }
+}
+
+impl Default for DebugState {
+    fn default() -> Self {
+        Self {
+            debug_dumper: None,
+            dump_format: crate::debug_dump::DumpFormat::default(),
+            trace_collector: None,
+            iteration_counter: 0,
+            anomaly_detector: None,
+            reasoning_model_warning: true,
+            logging_config: crate::config::LoggingConfig::default(),
+            dump_dir: None,
+            trace_service_name: String::new(),
+            trace_redact: true,
+            current_iteration_span_id: None,
+        }
+    }
+}
+
+impl Default for FeedbackState {
+    fn default() -> Self {
+        Self {
+            detector: super::feedback_detector::FeedbackDetector::new(0.6),
+            judge: None,
+            llm_classifier: None,
+        }
+    }
+}
+
+impl Default for RuntimeConfig {
+    fn default() -> Self {
+        Self {
+            security: SecurityConfig::default(),
+            timeouts: TimeoutConfig::default(),
+            model_name: String::new(),
+            active_provider_name: String::new(),
+            permission_policy: zeph_tools::PermissionPolicy::default(),
+            redact_credentials: true,
+            rate_limiter: super::rate_limiter::ToolRateLimiter::new(
+                super::rate_limiter::RateLimitConfig::default(),
+            ),
+            semantic_cache_enabled: false,
+            semantic_cache_threshold: 0.95,
+            semantic_cache_max_candidates: 10,
+            dependency_config: zeph_tools::DependencyConfig::default(),
+            adversarial_policy_info: None,
+            spawn_depth: 0,
+            budget_hint_enabled: true,
+            channel_skills: zeph_config::ChannelSkillsConfig::default(),
+            layers: Vec::new(),
+        }
+    }
+}
+
+impl SessionState {
+    pub(crate) fn new() -> Self {
+        Self {
+            env_context: EnvironmentContext::gather(""),
+            last_assistant_at: None,
+            response_cache: None,
+            parent_tool_use_id: None,
+            status_tx: None,
+            lsp_hooks: None,
+            policy_config: None,
+            hooks_config: HooksConfigSnapshot::default(),
+        }
+    }
+}
+
+impl SkillState {
+    pub(crate) fn new(
+        registry: Arc<RwLock<SkillRegistry>>,
+        matcher: Option<SkillMatcherBackend>,
+        max_active_skills: usize,
+        last_skills_prompt: String,
+    ) -> Self {
+        Self {
+            registry,
+            skill_paths: Vec::new(),
+            managed_dir: None,
+            trust_config: crate::config::TrustConfig::default(),
+            matcher,
+            max_active_skills,
+            disambiguation_threshold: 0.20,
+            min_injection_score: 0.20,
+            embedding_model: String::new(),
+            skill_reload_rx: None,
+            active_skill_names: Vec::new(),
+            last_skills_prompt,
+            prompt_mode: crate::config::SkillPromptMode::Auto,
+            available_custom_secrets: HashMap::new(),
+            cosine_weight: 0.7,
+            hybrid_search: false,
+            bm25_index: None,
+            two_stage_matching: false,
+            confusability_threshold: 0.0,
+            rl_head: None,
+            rl_weight: 0.3,
+            rl_warmup_updates: 50,
+            generation_output_dir: None,
+            generation_provider_name: String::new(),
+        }
+    }
+}
+
+impl LifecycleState {
+    pub(crate) fn new() -> Self {
+        let (_tx, rx) = watch::channel(false);
+        Self {
+            shutdown: rx,
+            start_time: Instant::now(),
+            cancel_signal: Arc::new(tokio::sync::Notify::new()),
+            cancel_token: tokio_util::sync::CancellationToken::new(),
+            cancel_bridge_handle: None,
+            config_path: None,
+            config_reload_rx: None,
+            warmup_ready: None,
+            update_notify_rx: None,
+            custom_task_rx: None,
+            last_known_cwd: std::env::current_dir().unwrap_or_default(),
+            file_changed_rx: None,
+            file_watcher: None,
+        }
+    }
+}
+
+impl ProviderState {
+    pub(crate) fn new(initial_prompt_tokens: u64) -> Self {
+        Self {
+            summary_provider: None,
+            provider_override: None,
+            judge_provider: None,
+            probe_provider: None,
+            compress_provider: None,
+            cached_prompt_tokens: initial_prompt_tokens,
+            server_compaction_active: false,
+            stt: None,
+            provider_pool: Vec::new(),
+            provider_config_snapshot: None,
+        }
+    }
+}
+
+impl MetricsState {
+    pub(crate) fn new(token_counter: Arc<zeph_memory::TokenCounter>) -> Self {
+        Self {
+            metrics_tx: None,
+            cost_tracker: None,
+            token_counter,
+            extended_context: false,
+            classifier_metrics: None,
+        }
+    }
+}
+
+impl ExperimentState {
+    pub(crate) fn new() -> Self {
+        let (notify_tx, notify_rx) = tokio::sync::mpsc::channel::<String>(4);
+        Self {
+            config: crate::config::ExperimentConfig::default(),
+            cancel: None,
+            baseline: zeph_experiments::ConfigSnapshot::default(),
+            eval_provider: None,
+            notify_rx: Some(notify_rx),
+            notify_tx,
+        }
     }
 }
 

--- a/crates/zeph-core/src/agent/state/security.rs
+++ b/crates/zeph-core/src/agent/state/security.rs
@@ -6,7 +6,51 @@
 //! These methods contain only security-state logic (no cross-cutting agent dependencies).
 //! The Agent wrappers in `tool_execution/mod.rs` apply metrics and channel side-effects.
 
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
 use super::SecurityState;
+
+impl Default for SecurityState {
+    fn default() -> Self {
+        Self {
+            sanitizer: zeph_sanitizer::ContentSanitizer::new(
+                &zeph_sanitizer::ContentIsolationConfig::default(),
+            ),
+            quarantine_summarizer: None,
+            is_acp_session: false,
+            exfiltration_guard: zeph_sanitizer::exfiltration::ExfiltrationGuard::new(
+                zeph_sanitizer::exfiltration::ExfiltrationGuardConfig::default(),
+            ),
+            flagged_urls: std::collections::HashSet::new(),
+            user_provided_urls: Arc::new(RwLock::new(std::collections::HashSet::new())),
+            pii_filter: zeph_sanitizer::pii::PiiFilter::new(
+                zeph_sanitizer::pii::PiiFilterConfig::default(),
+            ),
+            #[cfg(feature = "classifiers")]
+            pii_ner_backend: None,
+            #[cfg(feature = "classifiers")]
+            pii_ner_timeout_ms: 5000,
+            #[cfg(feature = "classifiers")]
+            pii_ner_max_chars: 8192,
+            #[cfg(feature = "classifiers")]
+            pii_ner_circuit_breaker_threshold: 2,
+            #[cfg(feature = "classifiers")]
+            pii_ner_consecutive_timeouts: 0,
+            #[cfg(feature = "classifiers")]
+            pii_ner_tripped: false,
+            memory_validator: zeph_sanitizer::memory_validation::MemoryWriteValidator::new(
+                zeph_sanitizer::memory_validation::MemoryWriteValidationConfig::default(),
+            ),
+            guardrail: None,
+            response_verifier: zeph_sanitizer::response_verifier::ResponseVerifier::new(
+                zeph_config::ResponseVerificationConfig::default(),
+            ),
+            causal_analyzer: None,
+        }
+    }
+}
 
 /// Result returned by [`SecurityState::scrub_pii`], carrying the scrubbed text and
 /// side-effect descriptors that the Agent wrapper must apply to metrics.

--- a/crates/zeph-core/src/agent/tests.rs
+++ b/crates/zeph-core/src/agent/tests.rs
@@ -260,9 +260,9 @@ pub mod agent_tests {
         let executor = MockToolExecutor::no_tools();
         let tmp = tempfile::tempdir().unwrap();
 
-        let agent = Agent::new(provider, channel, registry, None, 5, executor)
-            .with_model_name("test-model")
-            .with_working_dir(tmp.path().to_path_buf());
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+        agent.runtime.model_name = "test-model".to_string();
+        let agent = agent.with_working_dir(tmp.path().to_path_buf());
 
         assert_eq!(
             agent.session.env_context.working_dir,
@@ -278,8 +278,8 @@ pub mod agent_tests {
         let registry = create_test_registry();
         let executor = MockToolExecutor::no_tools();
 
-        let agent = Agent::new(provider, channel, registry, None, 5, executor)
-            .with_embedding_model("test-embed-model".to_string());
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+        agent.skill_state.embedding_model = "test-embed-model".to_string();
 
         assert_eq!(agent.skill_state.embedding_model, "test-embed-model");
     }
@@ -954,9 +954,9 @@ pub mod agent_tests {
         let executor = MockToolExecutor::no_tools();
         let (tx, rx) = watch::channel(crate::metrics::MetricsSnapshot::default());
 
-        let _agent = Agent::new(provider, channel, registry, None, 5, executor)
-            .with_model_name("test-model")
-            .with_metrics(tx);
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+        agent.runtime.model_name = "test-model".to_string();
+        let _agent = agent.with_metrics(tx);
 
         let snapshot = rx.borrow().clone();
         assert_eq!(snapshot.provider_name, "mock");
@@ -1112,8 +1112,8 @@ pub mod agent_tests {
         let registry = create_test_registry();
         let executor = MockToolExecutor::no_tools();
 
-        let agent = Agent::new(provider, channel, registry, None, 5, executor)
-            .with_tool_summarization(true);
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+        agent.tool_orchestrator.summarize_tool_output_enabled = true;
 
         let short = "short output";
         let result = agent.maybe_summarize_tool_output(short).await;
@@ -1143,14 +1143,19 @@ pub mod agent_tests {
         let registry = create_test_registry();
         let executor = MockToolExecutor::no_tools();
 
-        let agent = Agent::new(provider, channel, registry, None, 5, executor)
-            .with_tool_summarization(false)
-            .with_overflow_config(zeph_tools::OverflowConfig {
-                threshold: 100,
-                retention_days: 7,
-                max_overflow_bytes: 0,
-            })
-            .with_memory(Arc::new(memory), cid, 100, 5, 1000);
+        let agent = Agent::new(provider, channel, registry, None, 5, executor).with_memory(
+            Arc::new(memory),
+            cid,
+            100,
+            5,
+            1000,
+        );
+        let mut agent = agent;
+        agent.tool_orchestrator.overflow_config = zeph_tools::OverflowConfig {
+            threshold: 100,
+            retention_days: 7,
+            max_overflow_bytes: 0,
+        };
 
         let long = "x".repeat(zeph_tools::MAX_TOOL_OUTPUT_CHARS + 1000);
         let result = agent.maybe_summarize_tool_output(&long).await;
@@ -1180,13 +1185,12 @@ pub mod agent_tests {
         let registry = create_test_registry();
         let executor = MockToolExecutor::no_tools();
 
-        let agent = Agent::new(provider, channel, registry, None, 5, executor)
-            .with_tool_summarization(false)
-            .with_overflow_config(zeph_tools::OverflowConfig {
-                threshold: 1000,
-                retention_days: 7,
-                max_overflow_bytes: 0,
-            });
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+        agent.tool_orchestrator.overflow_config = zeph_tools::OverflowConfig {
+            threshold: 1000,
+            retention_days: 7,
+            max_overflow_bytes: 0,
+        };
 
         // Must exceed overflow threshold (1000) so that truncate_tool_output_at produces
         // the "truncated" marker. MAX_TOOL_OUTPUT_CHARS is no longer used in this path.
@@ -1202,13 +1206,13 @@ pub mod agent_tests {
         let registry = create_test_registry();
         let executor = MockToolExecutor::no_tools();
 
-        let agent = Agent::new(provider, channel, registry, None, 5, executor)
-            .with_tool_summarization(true)
-            .with_overflow_config(zeph_tools::OverflowConfig {
-                threshold: 1000,
-                retention_days: 7,
-                max_overflow_bytes: 0,
-            });
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+        agent.tool_orchestrator.summarize_tool_output_enabled = true;
+        agent.tool_orchestrator.overflow_config = zeph_tools::OverflowConfig {
+            threshold: 1000,
+            retention_days: 7,
+            max_overflow_bytes: 0,
+        };
 
         let long = "x".repeat(zeph_tools::MAX_TOOL_OUTPUT_CHARS + 1000);
         let result = agent.maybe_summarize_tool_output(&long).await;
@@ -1224,13 +1228,13 @@ pub mod agent_tests {
         let registry = create_test_registry();
         let executor = MockToolExecutor::no_tools();
 
-        let agent = Agent::new(provider, channel, registry, None, 5, executor)
-            .with_tool_summarization(true)
-            .with_overflow_config(zeph_tools::OverflowConfig {
-                threshold: 1000,
-                retention_days: 7,
-                max_overflow_bytes: 0,
-            });
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+        agent.tool_orchestrator.summarize_tool_output_enabled = true;
+        agent.tool_orchestrator.overflow_config = zeph_tools::OverflowConfig {
+            threshold: 1000,
+            retention_days: 7,
+            max_overflow_bytes: 0,
+        };
 
         let long = "x".repeat(zeph_tools::MAX_TOOL_OUTPUT_CHARS + 1000);
         let result = agent.maybe_summarize_tool_output(&long).await;
@@ -1246,13 +1250,12 @@ pub mod agent_tests {
         let registry = create_test_registry();
         let executor = MockToolExecutor::no_tools();
 
-        let agent = Agent::new(provider, channel, registry, None, 5, executor)
-            .with_tool_summarization(false)
-            .with_overflow_config(zeph_tools::OverflowConfig {
-                threshold: 100,
-                retention_days: 7,
-                max_overflow_bytes: 0,
-            });
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+        agent.tool_orchestrator.overflow_config = zeph_tools::OverflowConfig {
+            threshold: 100,
+            retention_days: 7,
+            max_overflow_bytes: 0,
+        };
         // No memory backend set.
 
         let long = "x".repeat(200);
@@ -1261,27 +1264,6 @@ pub mod agent_tests {
             result.contains("could not be saved — no memory backend or conversation available"),
             "S3 fallback message must appear when no memory backend, got: {result}"
         );
-    }
-
-    #[test]
-    fn with_tool_summarization_sets_flag() {
-        let provider = mock_provider(vec![]);
-        let channel = MockChannel::new(vec![]);
-        let registry = create_test_registry();
-        let executor = MockToolExecutor::no_tools();
-
-        let agent = Agent::new(provider, channel, registry, None, 5, executor)
-            .with_tool_summarization(true);
-        assert!(agent.tool_orchestrator.summarize_tool_output_enabled);
-
-        let provider2 = mock_provider(vec![]);
-        let channel2 = MockChannel::new(vec![]);
-        let registry2 = create_test_registry();
-        let executor2 = MockToolExecutor::no_tools();
-
-        let agent2 = Agent::new(provider2, channel2, registry2, None, 5, executor2)
-            .with_tool_summarization(false);
-        assert!(!agent2.tool_orchestrator.summarize_tool_output_enabled);
     }
 
     #[test]

--- a/crates/zeph-core/src/agent/tool_orchestrator.rs
+++ b/crates/zeph-core/src/agent/tool_orchestrator.rs
@@ -122,6 +122,33 @@ impl ToolOrchestrator {
         self.utility_scorer = UtilityScorer::new(config);
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn apply_config(
+        &mut self,
+        max_iterations: usize,
+        max_tool_retries: usize,
+        max_retry_duration_secs: u64,
+        retry_base_ms: u64,
+        retry_max_ms: u64,
+        parameter_reformat_provider: String,
+        tool_repeat_threshold: usize,
+        max_tool_calls_per_session: Option<u32>,
+        tool_summarization: bool,
+        overflow_config: OverflowConfig,
+    ) {
+        self.max_iterations = max_iterations;
+        self.max_tool_retries = max_tool_retries.min(5);
+        self.max_retry_duration_secs = max_retry_duration_secs;
+        self.retry_base_ms = retry_base_ms;
+        self.retry_max_ms = retry_max_ms;
+        self.parameter_reformat_provider = parameter_reformat_provider;
+        self.repeat_threshold = tool_repeat_threshold;
+        self.recent_tool_calls = VecDeque::with_capacity(2 * tool_repeat_threshold.max(1));
+        self.max_tool_calls_per_session = max_tool_calls_per_session;
+        self.summarize_tool_output_enabled = tool_summarization;
+        self.overflow_config = overflow_config;
+    }
+
     /// Check whether the per-session quota allows another tool call.
     /// Returns `Some(max)` when quota is exhausted, `None` when allowed.
     #[must_use]

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -703,10 +703,8 @@ async fn spawn_acp_agent(
             &mcp_config,
         )
         .with_mcp_shared_tools(mcp_shared_tools)
-        .with_focus_config(d.focus_config.clone())
-        .with_sidequest_config(d.sidequest_config.clone())
-        .with_trajectory_config(d.trajectory_config.clone())
-        .with_category_config(d.category_config.clone())
+        .with_focus_and_sidequest_config(d.focus_config.clone(), d.sidequest_config.clone())
+        .with_trajectory_and_category_config(d.trajectory_config.clone(), d.category_config.clone())
         .with_embedding_provider(d.embedding_provider.clone())
         .maybe_init_tool_schema_filter(&d.tool_filter_config, &provider),
     )

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -385,9 +385,11 @@ pub(crate) async fn run_daemon(
             tool_executor,
         )
         .apply_session_config(session_config)
-        .with_disambiguation_threshold(config.skills.disambiguation_threshold)
-        .with_two_stage_matching(config.skills.two_stage_matching)
-        .with_confusability_threshold(config.skills.confusability_threshold)
+        .with_skill_matching_config(
+            config.skills.disambiguation_threshold,
+            config.skills.two_stage_matching,
+            config.skills.confusability_threshold,
+        )
         .with_skill_reload(skill_paths, reload_rx)
         .with_managed_skills_dir(zeph_core::bootstrap::managed_skills_dir())
         .with_memory(
@@ -409,10 +411,14 @@ pub(crate) async fn run_daemon(
             config.skills.rl_persist_interval,
             config.skills.rl_warmup_updates,
         )
-        .with_focus_config(config.agent.focus.clone())
-        .with_sidequest_config(config.memory.sidequest.clone())
-        .with_trajectory_config(config.memory.trajectory.clone())
-        .with_category_config(config.memory.category.clone())
+        .with_focus_and_sidequest_config(
+            config.agent.focus.clone(),
+            config.memory.sidequest.clone(),
+        )
+        .with_trajectory_and_category_config(
+            config.memory.trajectory.clone(),
+            config.memory.category.clone(),
+        )
         .with_embedding_provider(embedding_provider)
         .maybe_init_tool_schema_filter(&config.agent.tool_filter, &provider),
     )

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1321,9 +1321,11 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         || provider.name().to_owned(),
         zeph_core::config::ProviderEntry::effective_name,
     ))
-    .with_disambiguation_threshold(config.skills.disambiguation_threshold)
-    .with_two_stage_matching(config.skills.two_stage_matching)
-    .with_confusability_threshold(config.skills.confusability_threshold)
+    .with_skill_matching_config(
+        config.skills.disambiguation_threshold,
+        config.skills.two_stage_matching,
+        config.skills.confusability_threshold,
+    )
     .with_skill_reload(skill_paths.clone(), reload_rx)
     .with_managed_skills_dir(zeph_core::bootstrap::managed_skills_dir())
     .with_trust_config(config.skills.trust.clone())
@@ -1359,16 +1361,17 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         config.skills.rl_persist_interval,
         config.skills.rl_warmup_updates,
     )
-    .with_compression_guidelines_config(config.memory.compression_guidelines.clone())
-    .with_digest_config(config.memory.digest.clone())
-    .with_context_strategy(
+    .with_memory_formatting_config(
+        config.memory.compression_guidelines.clone(),
+        config.memory.digest.clone(),
         config.memory.context_strategy,
         config.memory.crossover_turn_threshold,
     )
-    .with_focus_config(config.agent.focus.clone())
-    .with_sidequest_config(config.memory.sidequest.clone())
-    .with_trajectory_config(config.memory.trajectory.clone())
-    .with_category_config(config.memory.category.clone())
+    .with_focus_and_sidequest_config(config.agent.focus.clone(), config.memory.sidequest.clone())
+    .with_trajectory_and_category_config(
+        config.memory.trajectory.clone(),
+        config.memory.category.clone(),
+    )
     .with_embedding_provider(embedding_provider)
     .with_tree_consolidation_loop(
         app.build_tree_consolidation_provider()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2098,7 +2098,7 @@ async fn agent_disambiguation_reorders_skill_selection() {
         MockToolExecutor,
     )
     // Threshold of 1.0 guarantees disambiguation fires: any score delta < 1.0.
-    .with_disambiguation_threshold(1.0)
+    .with_skill_matching_config(1.0, false, 0.0)
     .with_metrics(tx);
 
     agent.run().await.unwrap();


### PR DESCRIPTION
## Summary

- Add `Default`/`new()` constructors to 6 sub-structs (`SessionState`, `SkillState`, `LifecycleState`, `ProviderState`, `MetricsState`, `ExperimentState`) and `from_config`/`apply_config` methods to `ContextManager`, `ToolOrchestrator`, `SecurityState`
- Consolidate 40 individual `with_*` builder methods into 4 batch methods (`with_skill_matching_config`, `with_memory_formatting_config`, `with_trajectory_and_category_config`, `with_focus_and_sidequest_config`)
- Simplify `new_with_registry_arc()` from ~260 to ~50 lines
- Builder method count: 132 → 92 (30.3% reduction)

Phase 6 of #2787 (Agent struct decomposition).

Closes #2804

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --all-targets --workspace -- -D warnings` — 0 warnings
- [x] `cargo nextest run --workspace --lib --bins` — 7721 passed
- [x] All removed builder methods verified unreferenced
- [x] No behavioral changes — pure refactoring