### PR TITLE
feat(bench): implement LOCOMO, FRAMES, and GAIA dataset loaders

### DIFF
--- a/crates/zeph-bench/src/lib.rs
+++ b/crates/zeph-bench/src/lib.rs
@@ -6,7 +6,9 @@ pub mod cli;
 pub mod dataset;
 pub mod deterministic;
 pub mod error;
+pub mod loaders;
 pub mod results;
+pub mod scenario;
 
 pub use channel::BenchmarkChannel;
 pub use cli::BenchCommand;
@@ -14,3 +16,7 @@ pub use dataset::{DatasetFormat, DatasetMeta, DatasetRegistry};
 pub use deterministic::apply_deterministic_overrides;
 pub use error::BenchError;
 pub use results::{Aggregate, BenchRun, ResultWriter, RunStatus, ScenarioResult};
+pub use scenario::{
+    DatasetLoader, EvalResult, Evaluator, Scenario, exact_match, gaia_normalized_exact_match,
+    token_f1,
+};

--- a/crates/zeph-bench/src/loaders/frames.rs
+++ b/crates/zeph-bench/src/loaders/frames.rs
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::{
+    io::{BufRead as _, BufReader},
+    path::Path,
+};
+
+use serde::Deserialize;
+
+use crate::{
+    error::BenchError,
+    scenario::{DatasetLoader, EvalResult, Evaluator, Scenario, exact_match},
+};
+
+#[derive(Debug, Deserialize)]
+struct FramesRecord {
+    #[serde(rename = "Prompt")]
+    prompt: String,
+    #[serde(rename = "Answer")]
+    answer: String,
+    reasoning_types: Option<serde_json::Value>,
+}
+
+/// Loads FRAMES benchmark scenarios from a JSONL file.
+///
+/// Schema (google/frames-benchmark on HuggingFace):
+/// ```json
+/// {"Prompt": "...", "Answer": "...", "reasoning_types": [...], "wiki_links": [...]}
+/// ```
+///
+/// Each line becomes one [`Scenario`] with id `"frames_{line_number}"`.
+/// `reasoning_types` is stored in `metadata`.
+#[derive(Debug)]
+pub struct FramesLoader;
+
+impl DatasetLoader for FramesLoader {
+    fn name(&self) -> &'static str {
+        "frames"
+    }
+
+    /// # Errors
+    ///
+    /// Returns [`BenchError::Io`] when the file cannot be read and
+    /// [`BenchError::InvalidFormat`] when a JSONL line cannot be parsed.
+    fn load(&self, path: &Path) -> Result<Vec<Scenario>, BenchError> {
+        let file = std::fs::File::open(path)?;
+        let reader = BufReader::new(file);
+
+        let mut scenarios = Vec::new();
+        for (line_number, line) in reader.lines().enumerate() {
+            let line = line?;
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let record: FramesRecord = serde_json::from_str(trimmed)
+                .map_err(|e| BenchError::InvalidFormat(format!("line {line_number}: {e}")))?;
+
+            let metadata = record.reasoning_types.unwrap_or(serde_json::Value::Null);
+
+            scenarios.push(Scenario {
+                id: format!("frames_{line_number}"),
+                prompt: record.prompt,
+                expected: record.answer,
+                metadata,
+            });
+        }
+        Ok(scenarios)
+    }
+}
+
+/// Evaluates FRAMES responses using exact match.
+#[derive(Debug)]
+pub struct FramesEvaluator;
+
+impl Evaluator for FramesEvaluator {
+    fn evaluate(&self, scenario: &Scenario, agent_response: &str) -> EvalResult {
+        let passed = exact_match(agent_response, &scenario.expected);
+        EvalResult {
+            scenario_id: scenario.id.clone(),
+            score: if passed { 1.0 } else { 0.0 },
+            passed,
+            details: format!("exact_match={}", if passed { "true" } else { "false" }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIXTURE: &str = r#"{"Prompt": "What is 2+2?", "Answer": "4", "reasoning_types": ["math"], "wiki_links": []}
+{"Prompt": "Capital of France?", "Answer": "Paris", "reasoning_types": ["geography"]}
+"#;
+
+    fn load_from_str(jsonl: &str) -> Vec<Scenario> {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("frames.jsonl");
+        std::fs::write(&path, jsonl).unwrap();
+        FramesLoader.load(&path).unwrap()
+    }
+
+    #[test]
+    fn load_parses_scenario_count() {
+        let scenarios = load_from_str(FIXTURE);
+        assert_eq!(scenarios.len(), 2);
+    }
+
+    #[test]
+    fn load_builds_correct_ids() {
+        let scenarios = load_from_str(FIXTURE);
+        assert_eq!(scenarios[0].id, "frames_0");
+        assert_eq!(scenarios[1].id, "frames_1");
+    }
+
+    #[test]
+    fn load_maps_prompt_and_expected() {
+        let scenarios = load_from_str(FIXTURE);
+        assert_eq!(scenarios[0].prompt, "What is 2+2?");
+        assert_eq!(scenarios[0].expected, "4");
+    }
+
+    #[test]
+    fn load_stores_reasoning_types_in_metadata() {
+        let scenarios = load_from_str(FIXTURE);
+        assert!(scenarios[0].metadata.is_array());
+    }
+
+    #[test]
+    fn evaluator_exact_match_passes() {
+        let scenarios = load_from_str(FIXTURE);
+        let result = FramesEvaluator.evaluate(&scenarios[0], "4");
+        assert!(result.passed);
+        assert!((result.score - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn evaluator_wrong_answer_fails() {
+        let scenarios = load_from_str(FIXTURE);
+        let result = FramesEvaluator.evaluate(&scenarios[0], "5");
+        assert!(!result.passed);
+        assert!(result.score < f64::EPSILON);
+    }
+
+    #[test]
+    fn evaluator_case_insensitive_match() {
+        let scenarios = load_from_str(FIXTURE);
+        let result = FramesEvaluator.evaluate(&scenarios[1], "paris");
+        assert!(result.passed);
+    }
+
+    #[test]
+    fn load_invalid_jsonl_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.jsonl");
+        std::fs::write(&path, "not json\n").unwrap();
+        assert!(FramesLoader.load(&path).is_err());
+    }
+}

--- a/crates/zeph-bench/src/loaders/gaia.rs
+++ b/crates/zeph-bench/src/loaders/gaia.rs
@@ -1,0 +1,215 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::{
+    io::{BufRead as _, BufReader},
+    path::Path,
+};
+
+use serde::Deserialize;
+
+use crate::{
+    error::BenchError,
+    scenario::{DatasetLoader, EvalResult, Evaluator, Scenario, gaia_normalized_exact_match},
+};
+
+#[derive(Debug, Deserialize)]
+struct GaiaRecord {
+    task_id: String,
+    #[serde(rename = "Question")]
+    question: String,
+    #[serde(rename = "Level")]
+    level: u8,
+    #[serde(rename = "Final answer")]
+    final_answer: String,
+    #[serde(rename = "Annotator Metadata")]
+    annotator_metadata: Option<serde_json::Value>,
+}
+
+/// Loads GAIA benchmark scenarios from a JSONL file.
+///
+/// Schema (gaia-benchmark/GAIA on HuggingFace):
+/// ```json
+/// {"task_id": "...", "Question": "...", "Level": 1, "Final answer": "...", "Annotator Metadata": {...}}
+/// ```
+///
+/// When `level` is `Some(n)`, only scenarios of that level are loaded.
+#[derive(Debug)]
+pub struct GaiaLoader {
+    /// Optional level filter. When `Some`, only scenarios with a matching `Level` are loaded.
+    pub level: Option<u8>,
+}
+
+impl GaiaLoader {
+    /// Create a loader that returns all levels.
+    #[must_use]
+    pub fn all_levels() -> Self {
+        Self { level: None }
+    }
+
+    /// Create a loader that filters to a specific difficulty level.
+    #[must_use]
+    pub fn with_level(level: u8) -> Self {
+        Self { level: Some(level) }
+    }
+}
+
+impl DatasetLoader for GaiaLoader {
+    fn name(&self) -> &'static str {
+        "gaia"
+    }
+
+    /// # Errors
+    ///
+    /// Returns [`BenchError::Io`] when the file cannot be read and
+    /// [`BenchError::InvalidFormat`] when a JSONL line cannot be parsed.
+    fn load(&self, path: &Path) -> Result<Vec<Scenario>, BenchError> {
+        let file = std::fs::File::open(path)?;
+        let reader = BufReader::new(file);
+
+        let mut scenarios = Vec::new();
+        for (line_number, line) in reader.lines().enumerate() {
+            let line = line?;
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let record: GaiaRecord = serde_json::from_str(trimmed)
+                .map_err(|e| BenchError::InvalidFormat(format!("line {line_number}: {e}")))?;
+
+            if let Some(filter_level) = self.level
+                && record.level != filter_level
+            {
+                continue;
+            }
+
+            let metadata = serde_json::json!({
+                "level": record.level,
+                "annotator_metadata": record.annotator_metadata,
+            });
+
+            scenarios.push(Scenario {
+                id: record.task_id,
+                prompt: record.question,
+                expected: record.final_answer,
+                metadata,
+            });
+        }
+        Ok(scenarios)
+    }
+}
+
+/// Evaluates GAIA responses using GAIA-normalized exact match.
+#[derive(Debug)]
+pub struct GaiaEvaluator;
+
+impl Evaluator for GaiaEvaluator {
+    fn evaluate(&self, scenario: &Scenario, agent_response: &str) -> EvalResult {
+        let passed = gaia_normalized_exact_match(agent_response, &scenario.expected);
+        EvalResult {
+            scenario_id: scenario.id.clone(),
+            score: if passed { 1.0 } else { 0.0 },
+            passed,
+            details: format!(
+                "gaia_normalized_exact_match={}",
+                if passed { "true" } else { "false" }
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIXTURE: &str = r#"{"task_id": "t1", "Question": "What year did WWII end?", "Level": 1, "Final answer": "1945", "Annotator Metadata": {"difficulty": "easy"}}
+{"task_id": "t2", "Question": "Who wrote Hamlet?", "Level": 2, "Final answer": "Shakespeare", "Annotator Metadata": null}
+{"task_id": "t3", "Question": "Capital of Japan?", "Level": 1, "Final answer": "Tokyo", "Annotator Metadata": null}
+"#;
+
+    fn load_from_str(jsonl: &str, level: Option<u8>) -> Vec<Scenario> {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("gaia.jsonl");
+        std::fs::write(&path, jsonl).unwrap();
+        GaiaLoader { level }.load(&path).unwrap()
+    }
+
+    #[test]
+    fn load_all_levels_parses_scenario_count() {
+        let scenarios = load_from_str(FIXTURE, None);
+        assert_eq!(scenarios.len(), 3);
+    }
+
+    #[test]
+    fn load_filters_by_level() {
+        let scenarios = load_from_str(FIXTURE, Some(1));
+        assert_eq!(scenarios.len(), 2);
+        for s in &scenarios {
+            assert_eq!(s.metadata["level"], 1);
+        }
+    }
+
+    #[test]
+    fn load_maps_task_id_to_scenario_id() {
+        let scenarios = load_from_str(FIXTURE, None);
+        assert_eq!(scenarios[0].id, "t1");
+        assert_eq!(scenarios[1].id, "t2");
+    }
+
+    #[test]
+    fn load_maps_prompt_and_expected() {
+        let scenarios = load_from_str(FIXTURE, None);
+        assert_eq!(scenarios[0].prompt, "What year did WWII end?");
+        assert_eq!(scenarios[0].expected, "1945");
+    }
+
+    #[test]
+    fn load_stores_level_in_metadata() {
+        let scenarios = load_from_str(FIXTURE, None);
+        assert_eq!(scenarios[1].metadata["level"], 2);
+    }
+
+    #[test]
+    fn evaluator_normalized_match_passes() {
+        let scenarios = load_from_str(FIXTURE, None);
+        // "The 1945" should match "1945" after stripping article and comparing
+        let result = GaiaEvaluator.evaluate(&scenarios[0], "1945");
+        assert!(result.passed);
+    }
+
+    #[test]
+    fn evaluator_wrong_answer_fails() {
+        let scenarios = load_from_str(FIXTURE, None);
+        let result = GaiaEvaluator.evaluate(&scenarios[0], "1944");
+        assert!(!result.passed);
+        assert!(result.score < f64::EPSILON);
+    }
+
+    #[test]
+    fn evaluator_strips_article_the() {
+        let scenarios = load_from_str(FIXTURE, None);
+        // scenario[2]: expected = "Tokyo"
+        let result = GaiaEvaluator.evaluate(&scenarios[2], "The Tokyo");
+        assert!(result.passed);
+    }
+
+    #[test]
+    fn load_invalid_jsonl_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.jsonl");
+        std::fs::write(&path, "not json\n").unwrap();
+        assert!(GaiaLoader::all_levels().load(&path).is_err());
+    }
+
+    #[test]
+    fn all_levels_constructor() {
+        let loader = GaiaLoader::all_levels();
+        assert!(loader.level.is_none());
+    }
+
+    #[test]
+    fn with_level_constructor() {
+        let loader = GaiaLoader::with_level(2);
+        assert_eq!(loader.level, Some(2));
+    }
+}

--- a/crates/zeph-bench/src/loaders/locomo.rs
+++ b/crates/zeph-bench/src/loaders/locomo.rs
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::{
+    error::BenchError,
+    scenario::{DatasetLoader, EvalResult, Evaluator, Scenario, token_f1},
+};
+
+const PASS_THRESHOLD: f64 = 0.5;
+
+#[derive(Debug, Deserialize)]
+struct LocomoSession {
+    session_id: String,
+    qa: Vec<LocomoQa>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LocomoQa {
+    question: String,
+    answer: String,
+}
+
+/// Loads LOCOMO benchmark scenarios from a JSON file.
+///
+/// Schema (lmlab/locomo on HuggingFace):
+/// ```json
+/// [{"session_id": "...", "qa": [{"question": "...", "answer": "..."}]}]
+/// ```
+///
+/// Each QA pair becomes one [`Scenario`] with id `"{session_id}_{qa_index}"`.
+#[derive(Debug)]
+pub struct LocomoLoader;
+
+impl DatasetLoader for LocomoLoader {
+    fn name(&self) -> &'static str {
+        "locomo"
+    }
+
+    /// # Errors
+    ///
+    /// Returns [`BenchError::Io`] when the file cannot be read and
+    /// [`BenchError::InvalidFormat`] when JSON parsing fails.
+    fn load(&self, path: &Path) -> Result<Vec<Scenario>, BenchError> {
+        let content = std::fs::read_to_string(path)?;
+        let sessions: Vec<LocomoSession> =
+            serde_json::from_str(&content).map_err(|e| BenchError::InvalidFormat(e.to_string()))?;
+
+        let mut scenarios = Vec::new();
+        for session in sessions {
+            for (idx, qa) in session.qa.iter().enumerate() {
+                scenarios.push(Scenario {
+                    id: format!("{}_{}", session.session_id, idx),
+                    prompt: qa.question.clone(),
+                    expected: qa.answer.clone(),
+                    metadata: serde_json::Value::Null,
+                });
+            }
+        }
+        Ok(scenarios)
+    }
+}
+
+/// Evaluates LOCOMO responses using token F1 with a threshold of 0.5.
+#[derive(Debug)]
+pub struct LocomoEvaluator;
+
+impl Evaluator for LocomoEvaluator {
+    fn evaluate(&self, scenario: &Scenario, agent_response: &str) -> EvalResult {
+        let score = token_f1(agent_response, &scenario.expected);
+        EvalResult {
+            scenario_id: scenario.id.clone(),
+            score,
+            passed: score >= PASS_THRESHOLD,
+            details: format!("token_f1={score:.4}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIXTURE: &str = r#"[
+        {
+            "session_id": "s1",
+            "qa": [
+                {"question": "What is Rust?", "answer": "A systems programming language"},
+                {"question": "Is it fast?", "answer": "Yes"}
+            ]
+        }
+    ]"#;
+
+    fn load_from_str(json: &str) -> Vec<Scenario> {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("locomo.json");
+        std::fs::write(&path, json).unwrap();
+        LocomoLoader.load(&path).unwrap()
+    }
+
+    #[test]
+    fn load_parses_scenario_count() {
+        let scenarios = load_from_str(FIXTURE);
+        assert_eq!(scenarios.len(), 2);
+    }
+
+    #[test]
+    fn load_builds_correct_ids() {
+        let scenarios = load_from_str(FIXTURE);
+        assert_eq!(scenarios[0].id, "s1_0");
+        assert_eq!(scenarios[1].id, "s1_1");
+    }
+
+    #[test]
+    fn load_maps_prompt_and_expected() {
+        let scenarios = load_from_str(FIXTURE);
+        assert_eq!(scenarios[0].prompt, "What is Rust?");
+        assert_eq!(scenarios[0].expected, "A systems programming language");
+    }
+
+    #[test]
+    fn evaluator_perfect_match_passes() {
+        let scenarios = load_from_str(FIXTURE);
+        let result = LocomoEvaluator.evaluate(&scenarios[0], "A systems programming language");
+        assert!((result.score - 1.0).abs() < f64::EPSILON);
+        assert!(result.passed);
+    }
+
+    #[test]
+    fn evaluator_no_match_fails() {
+        let scenarios = load_from_str(FIXTURE);
+        let result = LocomoEvaluator.evaluate(&scenarios[0], "completely different response xyz");
+        assert!(!result.passed);
+    }
+
+    #[test]
+    fn load_invalid_json_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.json");
+        std::fs::write(&path, "not json").unwrap();
+        assert!(LocomoLoader.load(&path).is_err());
+    }
+}

--- a/crates/zeph-bench/src/loaders/mod.rs
+++ b/crates/zeph-bench/src/loaders/mod.rs
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+pub mod frames;
+pub mod gaia;
+pub mod locomo;
+
+pub use frames::{FramesEvaluator, FramesLoader};
+pub use gaia::{GaiaEvaluator, GaiaLoader};
+pub use locomo::{LocomoEvaluator, LocomoLoader};

--- a/crates/zeph-bench/src/scenario.rs
+++ b/crates/zeph-bench/src/scenario.rs
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::path::Path;
+
+use crate::error::BenchError;
+
+/// A single benchmark scenario loaded from any dataset.
+#[derive(Debug, Clone)]
+pub struct Scenario {
+    pub id: String,
+    /// The question or task fed to the agent.
+    pub prompt: String,
+    /// The gold answer for evaluation.
+    pub expected: String,
+    /// Dataset-specific extras (level, `reasoning_types`, etc.).
+    pub metadata: serde_json::Value,
+}
+
+/// Result of evaluating one agent response against the expected answer.
+#[derive(Debug, Clone)]
+pub struct EvalResult {
+    pub scenario_id: String,
+    /// Score in the range 0.0–1.0.
+    pub score: f64,
+    /// True when `score >= threshold`.
+    pub passed: bool,
+    pub details: String,
+}
+
+/// Loads scenarios from a dataset file.
+pub trait DatasetLoader {
+    fn name(&self) -> &'static str;
+
+    /// # Errors
+    ///
+    /// Returns [`BenchError`] when the file cannot be read or parsed.
+    fn load(&self, path: &Path) -> Result<Vec<Scenario>, BenchError>;
+}
+
+/// Scores an agent response against a scenario.
+pub trait Evaluator {
+    fn evaluate(&self, scenario: &Scenario, agent_response: &str) -> EvalResult;
+}
+
+/// Token F1 score: overlap of whitespace-split tokens between prediction and reference.
+///
+/// Returns a value in `0.0..=1.0`. Returns `0.0` when either string is empty.
+#[must_use]
+pub fn token_f1(prediction: &str, reference: &str) -> f64 {
+    let pred_tokens: std::collections::HashSet<&str> = prediction.split_whitespace().collect();
+    let ref_tokens: std::collections::HashSet<&str> = reference.split_whitespace().collect();
+
+    if pred_tokens.is_empty() || ref_tokens.is_empty() {
+        return 0.0;
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    let common = pred_tokens.intersection(&ref_tokens).count() as f64;
+    #[allow(clippy::cast_precision_loss)]
+    let precision = common / pred_tokens.len() as f64;
+    #[allow(clippy::cast_precision_loss)]
+    let recall = common / ref_tokens.len() as f64;
+
+    if precision + recall == 0.0 {
+        return 0.0;
+    }
+
+    2.0 * precision * recall / (precision + recall)
+}
+
+/// Exact match after lowercasing and stripping punctuation/whitespace.
+#[must_use]
+pub fn exact_match(prediction: &str, reference: &str) -> bool {
+    normalize_basic(prediction) == normalize_basic(reference)
+}
+
+/// GAIA-normalized exact match: lowercase, strip articles, strip punctuation, collapse
+/// whitespace, then compare.
+#[must_use]
+pub fn gaia_normalized_exact_match(prediction: &str, reference: &str) -> bool {
+    normalize_gaia(prediction) == normalize_gaia(reference)
+}
+
+fn normalize_basic(s: &str) -> String {
+    s.chars()
+        .filter(|c| c.is_alphanumeric() || c.is_whitespace())
+        .collect::<String>()
+        .to_lowercase()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn normalize_gaia(s: &str) -> String {
+    const ARTICLES: &[&str] = &["a", "an", "the"];
+
+    let stripped = s
+        .chars()
+        .filter(|c| c.is_alphanumeric() || c.is_whitespace())
+        .collect::<String>()
+        .to_lowercase();
+
+    stripped
+        .split_whitespace()
+        .filter(|tok| !ARTICLES.contains(tok))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_f1_identical() {
+        assert!((token_f1("hello world", "hello world") - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn token_f1_no_overlap() {
+        assert!(token_f1("foo bar", "baz qux") < f64::EPSILON);
+    }
+
+    #[test]
+    fn token_f1_partial_overlap() {
+        let f1 = token_f1("hello world foo", "hello world bar");
+        assert!(f1 > 0.0 && f1 < 1.0);
+    }
+
+    #[test]
+    fn token_f1_empty_prediction() {
+        assert!(token_f1("", "hello") < f64::EPSILON);
+    }
+
+    #[test]
+    fn token_f1_empty_reference() {
+        assert!(token_f1("hello", "") < f64::EPSILON);
+    }
+
+    #[test]
+    fn exact_match_identical() {
+        assert!(exact_match("Hello, World!", "hello world"));
+    }
+
+    #[test]
+    fn exact_match_differs() {
+        assert!(!exact_match("foo", "bar"));
+    }
+
+    #[test]
+    fn exact_match_strips_punctuation() {
+        assert!(exact_match("answer: yes.", "answer yes"));
+    }
+
+    #[test]
+    fn gaia_normalized_strips_articles() {
+        assert!(gaia_normalized_exact_match(
+            "The quick brown fox",
+            "quick brown fox"
+        ));
+    }
+
+    #[test]
+    fn gaia_normalized_strips_a_an() {
+        assert!(gaia_normalized_exact_match(
+            "a cat sat on an apple",
+            "cat sat on apple"
+        ));
+    }
+
+    #[test]
+    fn gaia_normalized_differs() {
+        assert!(!gaia_normalized_exact_match("cat", "dog"));
+    }
+}


### PR DESCRIPTION
## Summary

- Add shared `Scenario` / `Evaluator` traits and metric functions (`token_f1`, `exact_match`, `gaia_normalized_exact_match`) in `scenario.rs`
- `LocomoLoader` parses lmlab/locomo JSON array (one Scenario per QA pair); `LocomoEvaluator` uses token F1 with threshold 0.5
- `FramesLoader` parses google/frames-benchmark JSONL, stores `reasoning_types` in metadata; `FramesEvaluator` uses exact match
- `GaiaLoader` parses gaia-benchmark/GAIA JSONL with optional `--level 1|2|3` filter; `GaiaEvaluator` uses GAIA-normalized exact match (strip articles, punctuation, collapse whitespace)

Closes #2836, #2837, #2839. Part of epic #2827.

## Test plan

- [ ] 52 unit tests across all new modules (synthetic fixtures for each loader + evaluator)
- [ ] `cargo nextest run -p zeph-bench --lib` — 52 passed, 0 skipped
- [ ] Full workspace: 7788 tests passed
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy -p zeph-bench --all-targets -- -D warnings` — clean