### PR TITLE
fix(mcp): add missing meta field and consolidate documentation URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,9 +936,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1238,7 +1238,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -2135,17 +2135,6 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
-dependencies = [
- "bit-set 0.5.3",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "fancy-regex"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
@@ -2168,9 +2157,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferroid"
@@ -2828,7 +2817,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2885,6 +2874,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -3397,12 +3392,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -3735,14 +3730,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -3811,7 +3806,7 @@ dependencies = [
  "encoding_rs",
  "flate2",
  "getrandom 0.3.4",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itoa",
  "log",
  "md-5",
@@ -4720,7 +4715,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset 0.5.7",
  "hashbrown 0.15.5",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "serde",
 ]
 
@@ -5038,7 +5033,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
 dependencies = [
  "futures",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "nix 0.31.2",
  "tokio",
  "tracing",
@@ -5579,9 +5574,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -5757,9 +5752,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2231b2c085b371c01bc90c0e6c1cab8834711b6394533375bdbf870b0166d419"
+checksum = "f542f74cf247da16f19bbc87e298cd201e912314f4083e88cdd671f44f5fcb53"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5786,9 +5781,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea0e100fadf81be85d7ff70f86cd805c7572601d4ab2946207f36540854b43"
+checksum = "b2391e4ae47f314e70eaafb6c7bd82e495e770b935448864446302143019151f"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -5991,9 +5986,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -6283,7 +6278,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -6297,7 +6292,7 @@ version = "0.9.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -6366,7 +6361,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -6658,7 +6653,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "memchr",
  "once_cell",
@@ -6817,9 +6812,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
+checksum = "2c5e6deb40826033bd7b11c7ef25ef71193fabd71f680f40dd16538a2704d2f4"
 dependencies = [
  "bytes",
  "futures-util",
@@ -7431,14 +7426,14 @@ dependencies = [
 
 [[package]]
 name = "tiktoken-rs"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a19830747d9034cd9da43a60eaa8e552dfda7712424aebf187b7a60126bae0d"
+checksum = "fac4a168cfc1d8ed65bf17a6ee0843ad9a68f863c63c0fb2fa7eab67838782ee"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "bstr",
- "fancy-regex 0.13.0",
+ "fancy-regex 0.17.0",
  "lazy_static",
  "regex",
  "rustc-hash 1.1.0",
@@ -7549,9 +7544,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -7654,7 +7649,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
@@ -7674,11 +7669,11 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.10+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
  "toml_writer",
@@ -7802,7 +7797,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -8601,7 +8596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -8640,7 +8635,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -9345,7 +9340,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -9376,7 +9371,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -9395,7 +9390,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -10245,7 +10240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
 dependencies = [
  "crc32fast",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "memchr",
  "typed-path",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ publish = true
 
 [workspace.dependencies]
 age = { version = "0.11.2", default-features = false }
-agent-client-protocol = "0.10.3"
+agent-client-protocol = "0.10"
 anyhow = "1.0"
 async-stream = "0.3"
 async-trait = "0.1"
@@ -68,14 +68,14 @@ rand_distr = "0.6"
 ratatui = "0.30"
 regex = "1.12"
 reqwest = { version = "0.13", default-features = false }
-rmcp = "1.3"
+rmcp = "1.4"
 audioadapter-buffers = "3.0"
 rubato = "2.0"
 schemars = "1.2"
 hmac = "0.13"
 sha2 = "0.11"
 scrape-core = "0.2"
-semver = "1.0.27"
+semver = "1.0"
 serde = "1.0"
 serde_json = "1.0"
 serde_norway = "0.9.42"
@@ -90,7 +90,7 @@ tempfile = "3.27"
 testcontainers = "0.27"
 testcontainers-modules = { version = "0.15", default-features = false }
 thiserror = "2.0"
-tiktoken-rs = "0.9"
+tiktoken-rs = "0.11"
 tokenizers = { version = "0.22", default-features = false }
 tokio = "1"
 tokio-stream = "0.1"
@@ -122,28 +122,28 @@ url = "2.5"
 uuid = "1.23"
 wiremock = "0.6.5"
 zeroize = { version = "1", default-features = false }
-zeph-a2a = { path = "crates/zeph-a2a", version = "0.18.5" }
-zeph-bench = { path = "crates/zeph-bench", version = "0.18.6" }
-zeph-acp = { path = "crates/zeph-acp", version = "0.18.5" }
-zeph-db = { path = "crates/zeph-db", version = "0.18.5", default-features = false }
-zeph-channels = { path = "crates/zeph-channels", version = "0.18.5" }
-zeph-common = { path = "crates/zeph-common", version = "0.18.5" }
-zeph-config = { path = "crates/zeph-config", version = "0.18.5" }
-zeph-core = { path = "crates/zeph-core", version = "0.18.5" }
-zeph-experiments = { path = "crates/zeph-experiments", version = "0.18.5" }
-zeph-gateway = { path = "crates/zeph-gateway", version = "0.18.5" }
-zeph-index = { path = "crates/zeph-index", version = "0.18.5" }
-zeph-llm = { path = "crates/zeph-llm", version = "0.18.5" }
-zeph-mcp = { path = "crates/zeph-mcp", version = "0.18.5" }
-zeph-memory = { path = "crates/zeph-memory", version = "0.18.5", default-features = false }
-zeph-scheduler = { path = "crates/zeph-scheduler", version = "0.18.5" }
-zeph-skills = { path = "crates/zeph-skills", version = "0.18.5" }
-zeph-tools = { path = "crates/zeph-tools", version = "0.18.5" }
-zeph-tui = { path = "crates/zeph-tui", version = "0.18.5" }
-zeph-vault = { path = "crates/zeph-vault", version = "0.18.5" }
-zeph-orchestration = { path = "crates/zeph-orchestration", version = "0.18.5" }
-zeph-sanitizer = { path = "crates/zeph-sanitizer", version = "0.18.5" }
-zeph-subagent = { path = "crates/zeph-subagent", version = "0.18.5" }
+zeph-a2a = { path = "crates/zeph-a2a" }
+zeph-bench = { path = "crates/zeph-bench" }
+zeph-acp = { path = "crates/zeph-acp" }
+zeph-db = { path = "crates/zeph-db", default-features = false }
+zeph-channels = { path = "crates/zeph-channels" }
+zeph-common = { path = "crates/zeph-common" }
+zeph-config = { path = "crates/zeph-config" }
+zeph-core = { path = "crates/zeph-core" }
+zeph-experiments = { path = "crates/zeph-experiments" }
+zeph-gateway = { path = "crates/zeph-gateway" }
+zeph-index = { path = "crates/zeph-index" }
+zeph-llm = { path = "crates/zeph-llm" }
+zeph-mcp = { path = "crates/zeph-mcp" }
+zeph-memory = { path = "crates/zeph-memory", default-features = false }
+zeph-scheduler = { path = "crates/zeph-scheduler" }
+zeph-skills = { path = "crates/zeph-skills" }
+zeph-tools = { path = "crates/zeph-tools" }
+zeph-tui = { path = "crates/zeph-tui" }
+zeph-vault = { path = "crates/zeph-vault" }
+zeph-orchestration = { path = "crates/zeph-orchestration" }
+zeph-sanitizer = { path = "crates/zeph-sanitizer" }
+zeph-subagent = { path = "crates/zeph-subagent" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/crates/zeph-a2a/Cargo.toml
+++ b/crates/zeph-a2a/Cargo.toml
@@ -6,7 +6,6 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-documentation.workspace = true
 keywords.workspace = true
 categories.workspace = true
 publish.workspace = true

--- a/crates/zeph-acp/Cargo.toml
+++ b/crates/zeph-acp/Cargo.toml
@@ -6,7 +6,6 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-documentation.workspace = true
 keywords.workspace = true
 categories.workspace = true
 publish.workspace = true

--- a/crates/zeph-bench/Cargo.toml
+++ b/crates/zeph-bench/Cargo.toml
@@ -6,7 +6,6 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-documentation.workspace = true
 keywords.workspace = true
 categories.workspace = true
 description = "Benchmark harness for evaluating Zeph agent performance on standardized datasets"

--- a/crates/zeph-channels/Cargo.toml
+++ b/crates/zeph-channels/Cargo.toml
@@ -6,7 +6,6 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-documentation.workspace = true
 keywords.workspace = true
 categories.workspace = true
 publish.workspace = true

--- a/crates/zeph-common/Cargo.toml
+++ b/crates/zeph-common/Cargo.toml
@@ -6,7 +6,6 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-documentation.workspace = true
 keywords.workspace = true
 categories.workspace = true
 publish.workspace = true

--- a/crates/zeph-config/Cargo.toml
+++ b/crates/zeph-config/Cargo.toml
@@ -6,7 +6,6 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-documentation.workspace = true
 keywords.workspace = true
 categories.workspace = true
 publish.workspace = true

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -6,7 +6,6 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-documentation.workspace = true
 keywords.workspace = true
 categories.workspace = true
 publish.workspace = true

--- a/crates/zeph-core/src/agent/mcp.rs
+++ b/crates/zeph-core/src/agent/mcp.rs
@@ -466,6 +466,7 @@ impl<C: Channel> Agent<C> {
         let decline = CreateElicitationResult {
             action: ElicitationAction::Decline,
             content: None,
+            meta: None,
         };
 
         let channel_request = match &event.request {
@@ -537,14 +538,17 @@ impl<C: Channel> Agent<C> {
             ElicitationResponse::Accepted(value) => CreateElicitationResult {
                 action: ElicitationAction::Accept,
                 content: Some(value),
+                meta: None,
             },
             ElicitationResponse::Declined => CreateElicitationResult {
                 action: ElicitationAction::Decline,
                 content: None,
+                meta: None,
             },
             ElicitationResponse::Cancelled => CreateElicitationResult {
                 action: ElicitationAction::Cancel,
                 content: None,
+                meta: None,
             },
         };
 

--- a/crates/zeph-db/Cargo.toml
+++ b/crates/zeph-db/Cargo.toml
@@ -6,7 +6,6 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-documentation.workspace = true
 keywords.workspace = true
 categories.workspace = true
 publish.workspace = true

--- a/crates/zeph-experiments/Cargo.toml
+++ b/crates/zeph-experiments/Cargo.toml
@@ -5,7 +5,6 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
-documentation.workspace = true
 homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/crates/zeph-gateway/Cargo.toml
+++ b/crates/zeph-gateway/Cargo.toml
@@ -6,7 +6,6 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-documentation.workspace = true
 keywords.workspace = true
 categories.workspace = true
 publish.workspace = true

--- a/crates/zeph-index/Cargo.toml
+++ b/crates/zeph-index/Cargo.toml
@@ -6,7 +6,6 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-documentation.workspace = true
 keywords.workspace = true
 categories.workspace = true
 publish.workspace = true

--- a/crates/zeph-llm/Cargo.toml
+++ b/crates/zeph-llm/Cargo.toml
@@ -6,7 +6,6 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-documentation.workspace = true
 keywords.workspace = true
 categories.workspace = true
 publish.workspace = true

--- a/crates/zeph-mcp/Cargo.toml
+++ b/crates/zeph-mcp/Cargo.toml
@@ -6,7 +6,6 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-documentation.workspace = true
 keywords.workspace = true
 categories.workspace = true
 publish.workspace = true

--- a/crates/zeph-mcp/src/client.rs
+++ b/crates/zeph-mcp/src/client.rs
@@ -148,6 +148,7 @@ impl rmcp::ClientHandler for ToolListChangedHandler {
         let decline = rmcp::model::CreateElicitationResult {
             action: rmcp::model::ElicitationAction::Decline,
             content: None,
+            meta: None,
         };
 
         async move {

--- a/crates/zeph-mcp/src/elicitation.rs
+++ b/crates/zeph-mcp/src/elicitation.rs
@@ -86,6 +86,7 @@ mod tests {
         let result = CreateElicitationResult {
             action: ElicitationAction::Decline,
             content: None,
+            meta: None,
         };
         event.response_tx.send(result).unwrap();
         let received = response_rx.await.unwrap();

--- a/crates/zeph-memory/Cargo.toml
+++ b/crates/zeph-memory/Cargo.toml
@@ -6,7 +6,6 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-documentation.workspace = true
 keywords.workspace = true
 categories.workspace = true
 publish.workspace = true

--- a/crates/zeph-orchestration/Cargo.toml
+++ b/crates/zeph-orchestration/Cargo.toml
@@ -6,7 +6,6 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-documentation.workspace = true
 keywords.workspace = true
 categories.workspace = true
 publish.workspace = true

--- a/crates/zeph-sanitizer/Cargo.toml
+++ b/crates/zeph-sanitizer/Cargo.toml
@@ -5,7 +5,6 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
-documentation.workspace = true
 homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/crates/zeph-scheduler/Cargo.toml
+++ b/crates/zeph-scheduler/Cargo.toml
@@ -6,7 +6,6 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-documentation.workspace = true
 keywords.workspace = true
 categories.workspace = true
 publish.workspace = true

--- a/crates/zeph-skills/Cargo.toml
+++ b/crates/zeph-skills/Cargo.toml
@@ -6,7 +6,6 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-documentation.workspace = true
 keywords.workspace = true
 categories.workspace = true
 publish.workspace = true

--- a/crates/zeph-subagent/Cargo.toml
+++ b/crates/zeph-subagent/Cargo.toml
@@ -5,7 +5,6 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
-documentation.workspace = true
 homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/crates/zeph-tools/Cargo.toml
+++ b/crates/zeph-tools/Cargo.toml
@@ -6,7 +6,6 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-documentation.workspace = true
 keywords.workspace = true
 categories.workspace = true
 publish.workspace = true

--- a/crates/zeph-tui/Cargo.toml
+++ b/crates/zeph-tui/Cargo.toml
@@ -6,7 +6,6 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-documentation.workspace = true
 keywords.workspace = true
 categories.workspace = true
 publish.workspace = true

--- a/crates/zeph-vault/Cargo.toml
+++ b/crates/zeph-vault/Cargo.toml
@@ -6,7 +6,6 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-documentation.workspace = true
 keywords.workspace = true
 categories.workspace = true
 publish.workspace = true


### PR DESCRIPTION
## Summary
- Add missing `meta: None` field in `CreateElicitationResult` initializers (rmcp v1.4 breaking change)
- Consolidate documentation URLs to workspace-level book reference (`https://bug-ops.github.io/zeph/`)
- Remove per-crate documentation URLs—they now inherit from workspace automatically

## Changes
- **crates/zeph-mcp/src/client.rs**: Add `meta: None`
- **crates/zeph-mcp/src/elicitation.rs**: Add `meta: None`
- **crates/zeph-core/src/agent/mcp.rs**: Add `meta: None` (3 initializers)
- **Cargo.toml**: Update workspace documentation to book URL
- **crates/*/Cargo.toml**: Remove per-crate documentation entries

## Test plan
- [x] \`cargo check --all-targets\` passes
- [x] No new clippy warnings introduced