### PR TITLE
docs(specs): add graph memory sub-spec to 004-memory

### DIFF
--- a/specs/004-memory/004-6-graph-memory.md
+++ b/specs/004-memory/004-6-graph-memory.md
@@ -1,0 +1,168 @@
+---
+aliases:
+  - Graph Memory
+  - Entity Graph
+  - Knowledge Graph
+tags:
+  - sdd
+  - spec
+  - memory
+  - graph
+created: 2026-04-10
+status: approved
+related:
+  - "[[004-memory/spec]]"
+  - "[[012-graph-memory/spec]]"
+  - "[[004-1-architecture]]"
+  - "[[004-4-embeddings]]"
+---
+
+# Spec: Graph Memory
+
+> [!info]
+> Entity graph over conversation history: BFS recall, community detection,
+> MAGMA typed edges, SYNAPSE spreading activation.
+> Full details: [[012-graph-memory/spec]].
+
+## Overview
+
+Graph memory builds a persistent knowledge graph from conversation turns.
+After each turn, `GraphExtractor` fires in the background and extracts named entities
+and typed relationships from the message content; `EntityResolver` deduplicates
+against the existing graph using embedding similarity before writing to SQLite.
+
+Graph memory is optional — enabled by the `graph-memory` feature flag.
+When disabled, all graph calls are no-ops and the `SemanticMemory` API remains unchanged.
+
+---
+
+## Architecture
+
+```
+SemanticMemory
+└── GraphStore (graph-memory feature)
+    ├── entities               — canonical entities + aliases
+    ├── edges                  — typed, temporal, versioned relationships
+    └── communities            — label propagation clusters + LLM summaries
+```
+
+**Extraction pipeline** (fire-and-forget background task):
+1. `GraphExtractor` → structured LLM call → `(entities, edges)`
+2. `EntityResolver` → normalize → alias lookup → embedding dedup → SQLite write
+
+**Recall pipeline** (two modes, called from `graph_recall`):
+- **BFS** (`bfs_typed`): hop-limited breadth-first traversal from FTS5-matched seed entities
+- **SYNAPSE spreading activation** (`graph_recall_activated`): iterative score propagation with decay and lateral inhibition; wrapped in a 500 ms timeout
+
+---
+
+## Key Concepts
+
+### MAGMA Typed Edges
+
+Edges carry one of four `EdgeType` values partitioning the graph into orthogonal subgraphs:
+
+| Type | Examples |
+|------|----------|
+| `semantic` | `uses`, `knows`, `prefers`, `depends_on` |
+| `temporal` | `preceded_by`, `followed_by`, `happened_during` |
+| `causal` | `caused`, `triggered`, `resulted_in` |
+| `entity` | `is_a`, `part_of`, `alias_of` |
+
+Dedup key: `(source_entity_id, target_entity_id, relation, edge_type)` — the same entity pair may carry both Semantic and Causal edges for the same relation string.
+
+### Entity Resolution
+
+Thresholds (embedding cosine similarity):
+
+| Score | Action |
+|-------|--------|
+| ≥ 0.85 | Merge to existing entity |
+| 0.70–0.84 | LLM disambiguation call |
+| < 0.70 | Create new entity |
+
+`canonical_name` is **immutable after creation**: lowercase + trimmed + control chars stripped. Per-name serialized locking prevents concurrent duplicate creation.
+
+### A-MEM Link Weight Evolution
+
+Each edge tracks `retrieval_count` + `last_retrieved_at`.  
+Effective confidence during traversal:
+
+```
+effective_confidence = confidence * min(1.0, 1.0 + 0.2 * ln(1 + retrieval_count))
+```
+
+Counts decay daily (`new_count = count * exp(-lambda * elapsed_days)`) independently of the eviction cycle.
+
+---
+
+## Config
+
+```toml
+[memory.graph]
+enabled = true
+extract_provider = "fast"           # [[llm.providers]] name for extraction LLM
+max_entities_per_message = 10
+max_edges_per_message = 20
+max_hops = 2
+community_detection_interval_secs = 3600
+link_weight_decay_lambda = 0.01
+link_weight_decay_interval_secs = 86400
+
+[memory.synapse]
+enabled = false
+seed_structural_weight = 0.3        # blend FTS5 score with structural centrality
+seed_community_cap = 3              # max seeds per community cluster
+
+[memory.graph.spreading_activation]
+enabled = false
+decay_lambda = 0.85
+max_hops = 3
+activation_threshold = 0.1
+inhibition_threshold = 0.8
+max_activated_nodes = 50
+```
+
+---
+
+## Key Invariants
+
+- Extraction is always fire-and-forget — **never** await extraction before responding to user
+- `canonical_name` is immutable once set — never update; only create new canonical
+- `(canonical_name, entity_type)` uniqueness enforced by SQLite `UNIQUE` constraint
+- BFS uses only active edges: `valid_to IS NULL AND expired_at IS NULL`
+- Spreading activation wrapped in 500 ms timeout — **never** block recall pipeline
+- `EdgeType` `FromStr` is case-sensitive — only lowercase accepted (`"semantic"`, not `"Semantic"`)
+- `bfs_typed([])` = all edge types (backward-compatible empty-slice default)
+- `classify_graph_subgraph` is a pure function — **never** calls LLM or DB
+- Community fingerprint (BLAKE3) must be recomputed on any membership or edge change
+- A-MEM boost cap at 1.0 — `min(1.0, ...)` is mandatory; decay runs independently of GC
+
+---
+
+## TUI Commands
+
+```
+/graph entities [query]   — search entities
+/graph edges <entity>     — show entity relations
+/graph communities        — list communities
+/graph stats              — entity/edge/community counts
+/graph clear              — delete all graph data
+```
+
+---
+
+## Integration Points
+
+- [[004-1-architecture]] — `GraphStore` is the fourth component inside `SemanticMemory`
+- [[004-4-embeddings]] — embedding pipeline generates vectors used by `EntityResolver`
+- [[004-5-temporal-decay]] — temporal decay formula reused in `GraphFact::score_with_decay` and SYNAPSE `recency_weight`
+- [[012-graph-memory/spec]] — complete reference: data model, full algorithm listings, all invariants with codes (SA-INV-01..10)
+
+---
+
+## See Also
+
+- [[004-memory/spec]] — parent: all memory subsystems
+- [[012-graph-memory/spec]] — full graph memory specification
+- [[004-1-architecture]] — core dual-backend pipeline

--- a/specs/004-memory/spec.md
+++ b/specs/004-memory/spec.md
@@ -15,6 +15,7 @@ related:
   - "[[MOC-specs]]"
   - "[[001-system-invariants/spec#6. Memory Pipeline Contract]]"
   - "[[002-agent-loop/spec]]"
+  - "[[004-6-graph-memory]]"
   - "[[012-graph-memory/spec]]"
   - "[[031-database-abstraction/spec]]"
 ---
@@ -41,6 +42,7 @@ specific areas, refer to the child specs below.
 | [[004-3-admission-control]] | A-MAC & Filtering | Five-factor importance scoring, admission gates, noise filtering |
 | [[004-4-embeddings]] | Embedding Generation | Batch strategies, backfill, concurrent workers, TUI integration |
 | [[004-5-temporal-decay]] | Retention Scoring | Ebbinghaus forgetting curve, access frequency, decay-based eviction |
+| [[004-6-graph-memory]] | Graph Memory | Entity graph, BFS recall, MAGMA typed edges, SYNAPSE spreading activation, A-MEM link weights |
 
 ---
 
@@ -50,7 +52,7 @@ specific areas, refer to the child specs below.
 SemanticMemory (Arc)
 ├── SqliteStore         — conversation history, message metadata
 ├── QdrantStore         — vector embeddings for semantic search
-├── GraphStore          — entity/edge graph (if graph-memory feature)
+├── GraphStore          — entity/edge graph, see [[004-6-graph-memory]]
 └── ResponseCache       — deduplicated LLM response cache
 ```
 

--- a/specs/MOC-specs.md
+++ b/specs/MOC-specs.md
@@ -43,6 +43,7 @@ status: moc
 ### Memory Systems
 - [[004-memory/spec|Memory Pipeline]] — SQLite + Qdrant dual backend, semantic response cache, anchored summarization, compaction probe, importance scoring, A-MAC admission control, MemScene consolidation, cost-sensitive store routing, temporal decay, multi-vector chunking, GAAMA episode nodes, BATS budget hints, Focus compression, SleepGate forgetting pass, persona/trajectory/category-aware memory, TiMem tree, microcompact, autoDream, MagicDocs, embed backfill batching
 - [[012-graph-memory/spec|Entity Graph Memory]] — entity graph, BFS recall, community detection, MAGMA typed edges, SYNAPSE spreading activation; works with [[004-memory/spec|Memory Pipeline]]
+  - [[004-memory/004-6-graph-memory|Graph Memory (memory sub-spec)]] — concise reference within the memory subsystem: data model overview, MAGMA edge types, SYNAPSE config, key invariants
 
 ### Configuration & Loading
 - [[020-config-loading/spec|Config Loading]] — config resolution order, mode-agnostic defaults, environment overrides
@@ -130,6 +131,9 @@ status: moc
 ### Database Abstraction
 - [[031-database-abstraction/spec|PostgreSQL Backend & Database Abstraction]] — zeph-db crate, DatabaseDriver trait, Dialect trait, sql!() macro, PostgreSQL migrations, MemoryConfig::database_url, zeph db migrate CLI, --init backend selection; mutually exclusive sqlite/postgres features
 
+### Profiling & Tracing
+- [[035-profiling/spec|Profiling and Tracing Instrumentation]] — two-tier telemetry backend (Tier 1: local chrome traces, Tier 2: OTLP + Pyroscope), per-span instrumentation via #[instrument] macros, allocation tracking (profiling-alloc), system metrics (sysinfo), InstrumentedChannel wrappers; zero-overhead when disabled; `profiling`, `profiling-alloc`, `profiling-pyroscope` feature flags
+
 ---
 
 ## Special Topics & Documentation
@@ -180,6 +184,7 @@ status: moc
 | 032 | [[032-handoff-skill-system/spec\|Handoff Protocol]] | specify | approved |
 | 033 | [[033-subagent-context-propagation/spec\|Subagent Context]] | research | approved |
 | 034 | [[034-zeph-bench/spec\|Benchmark Harness]] | specify | approved |
+| 035 | [[035-profiling/spec\|Profiling & Tracing]] | specify | draft |
 
 ---
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -55,6 +55,7 @@ Spec IDs (001–034) follow a logical grouping:
 | `010-security/spec.md` | Vault, shell sandbox, content isolation, SSRF protection, IPI defense, PII NER circuit breaker, cross-tool injection correlation, AgentRFC protocol audit, MCP→ACP boundary enforcement, credential env-var scrubbing | cross-cutting |
 | `011-tui/spec.md` | ratatui dashboard, spinner rule for background operations, TuiChannel, RenderCache, embed backfill progress | `zeph-tui` |
 | `012-graph-memory/spec.md` | Entity graph, BFS recall, community detection, MAGMA typed edges, SYNAPSE spreading activation | `zeph-memory` |
+| `004-memory/004-6-graph-memory.md` | Graph memory sub-spec (concise reference within 004-memory): MAGMA typed edges, SYNAPSE config, A-MEM link weights, key invariants | `zeph-memory` |
 | `013-acp/spec.md` | ACP transports, session management, permissions, fork/resume, session/close handlers, capability advertisement, /agent.json endpoint | `zeph-acp` |
 | `014-a2a/spec.md` | A2A protocol, agent discovery, JSON-RPC 2.0, IBCT (Invocation-Bound Capability Tokens), HMAC-SHA256 signatures | `zeph-a2a` |
 | `015-self-learning/spec.md` | FeedbackDetector (multi-language), Wilson score, trust model, SAGE RL cross-session reward, ARISE trace improvement, STEM pattern-to-skill migration, ERL experiential learning | `zeph-skills` |


### PR DESCRIPTION
## Summary

- Add `specs/004-memory/004-6-graph-memory.md` — atomic reference note for graph memory within the 004-memory subsystem, following the same format as the other `004-x` sub-specs
- Covers: MAGMA typed edges, SYNAPSE spreading activation config, entity resolution thresholds, A-MEM link weight evolution, key invariants, TUI commands, integration points
- Full algorithm listings and SA-INV invariants remain in `012-graph-memory/spec.md`; the new file links there for deeper reference

## Changed files

- `specs/004-memory/004-6-graph-memory.md` — new sub-spec
- `specs/004-memory/spec.md` — added row in Child Specifications table, updated `related` frontmatter and System Architecture diagram
- `specs/MOC-specs.md` — added sub-entry under Entity Graph Memory
- `specs/README.md` — added row in Feature Docs table

## Test plan

- [ ] Obsidian: all wikilinks in the new file resolve without broken link warnings
- [ ] `specs/004-memory/spec.md` Child Specifications table includes `004-6-graph-memory`
- [ ] `specs/README.md` and `specs/MOC-specs.md` both reference the new file