### PR TITLE
feat(metrics): Phase 1 — Prometheus metrics export foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `skill_reload_rx` and `config_reload_rx` channel sites. New `MetricsBridge` tracing layer
   using `on_enter`/`on_exit` accumulation for correct async timing, replacing manual
   `Instant::now()` bookkeeping for the 4 watched turn-phase spans when profiling is active.
+- **Prometheus metrics export Phase 1** (epic `#2865`, `#2866`): added Prometheus/OpenMetrics
+  compatible `/metrics` endpoint to the HTTP gateway. New `prometheus` feature flag (included in
+  `server` and `full` bundles); `prometheus-client` 0.24 added as workspace dependency. New
+  `crates/zeph-config/src/metrics.rs` with `MetricsConfig` (`enabled`, `path`,
+  `sync_interval_secs`); integrated into root `Config`. New `src/metrics_export.rs` with
+  `PrometheusMetrics` struct owning 25 metric families (counters + gauges with `zeph_` prefix),
+  `sync()` with delta computation and session-restart reset detection, and
+  `spawn_metrics_sync()` background task. Gateway extended with feature-gated
+  `GatewayServer::with_metrics_registry()` builder and `/metrics` handler returning
+  `application/openmetrics-text; version=1.0.0`. Wiring in `runner.rs` creates the registry
+  after the `MetricsSnapshot` watch channel and spawns gateway and sync task in correct order.
+  Config migration adds commented `[metrics]` block; `--init` wizard gains a Prometheus step.
 
 - **Profiling and tracing Phase 1: foundation** (`#2847`, `#2848`, `#2849`, `#2850`, epic `#2846`):
   added two-tier telemetry backend with zero overhead when disabled. New `[telemetry]` config

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3634,9 +3634,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -5038,6 +5038,29 @@ dependencies = [
  "tokio",
  "tracing",
  "windows 0.62.2",
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cca3d75b4566b9a29fe1ed623587fb058e826eb329a0be4b7c4da1ebb2d7a6ca"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "parking_lot",
+ "prometheus-client-derive-encode",
+]
+
+[[package]]
+name = "prometheus-client-derive-encode"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9adf1691c04c0a5ff46ff8f262b58beb07b0dbb61f96f9f54f6cbd82106ed87f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8537,9 +8560,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8550,9 +8573,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8560,9 +8583,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8570,9 +8593,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -8583,9 +8606,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -8652,9 +8675,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9504,6 +9527,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "parking_lot",
+ "prometheus-client",
  "reqwest 0.13.2",
  "rmcp",
  "schemars 1.2.1",
@@ -9790,6 +9814,7 @@ dependencies = [
  "axum 0.8.8",
  "blake3",
  "http-body-util",
+ "prometheus-client",
  "serde",
  "serde_json",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ opentelemetry_sdk = { version = "0.31", default-features = false }
 ordered-float = "5.3"
 pdf-extract = "0.10"
 parking_lot = "0.12"
+prometheus-client = "0.24"
 petgraph = "0.8"
 proptest = "1.11"
 pulldown-cmark = "0.13"
@@ -173,7 +174,7 @@ default = ["scheduler", "sqlite"]
 # === Use-case bundles ===
 desktop = ["tui"]
 ide     = ["acp", "acp-http"]
-server  = ["gateway", "a2a", "otel"]
+server  = ["gateway", "a2a", "otel", "prometheus"]
 chat    = ["discord", "slack"]
 ml      = ["candle", "pdf"]
 full    = ["desktop", "ide", "server", "chat", "pdf", "scheduler", "classifiers", "profiling"]
@@ -191,6 +192,7 @@ tui = ["dep:zeph-tui"]
 discord = ["zeph-channels/discord"]
 slack = ["zeph-channels/slack"]
 gateway = ["dep:zeph-gateway"]
+prometheus = ["gateway", "dep:prometheus-client", "zeph-gateway/prometheus"]
 scheduler = ["dep:zeph-scheduler", "dep:blake3", "dep:cron", "dep:schemars", "dep:chrono", "zeph-core/scheduler"]
 otel = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp", "dep:tracing-opentelemetry"]
 pdf = ["zeph-memory/pdf"]
@@ -229,6 +231,7 @@ opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }
 parking_lot.workspace = true
+prometheus-client = { workspace = true, optional = true }
 reqwest.workspace = true
 rmcp.workspace = true
 schemars = { workspace = true, optional = true }

--- a/config/default.toml
+++ b/config/default.toml
@@ -633,6 +633,15 @@ rate_limit = 120
 # Maximum request body size in bytes (1MB)
 max_body_size = 1048576
 
+[metrics]
+# Enable Prometheus metrics export on the gateway /metrics endpoint.
+# Requires [gateway] enabled = true and the `prometheus` feature flag.
+enabled = false
+# HTTP path for the metrics endpoint
+path = "/metrics"
+# How often (seconds) to sync MetricsSnapshot to the Prometheus registry (min 1)
+sync_interval_secs = 5
+
 [daemon]
 # Enable daemon supervisor
 enabled = false

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -65,6 +65,7 @@ pub mod learning;
 mod loader;
 pub mod logging;
 pub mod memory;
+pub mod metrics;
 pub mod migrate;
 pub mod providers;
 pub mod rate_limit;
@@ -109,6 +110,7 @@ pub use memory::{
     SemanticConfig, SessionsConfig, SidequestConfig, StoreRoutingConfig, StoreRoutingStrategy,
     TierConfig, TrajectoryConfig, TreeConfig, VectorBackend,
 };
+pub use metrics::MetricsConfig;
 pub use providers::{
     BanditConfig, CandleConfig, CandleInlineConfig, CascadeClassifierMode, CascadeConfig,
     ComplexityRoutingConfig, GenerationParams, LlmConfig, LlmRoutingStrategy, MAX_TOKENS_CAP,

--- a/crates/zeph-config/src/metrics.rs
+++ b/crates/zeph-config/src/metrics.rs
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Prometheus metrics export configuration (`[metrics]` TOML section).
+//!
+//! Controls whether the agent exposes a `/metrics` endpoint on the gateway HTTP server
+//! and how frequently the internal `MetricsSnapshot` is synchronised to Prometheus counters
+//! and gauges.
+//!
+//! # Example (TOML)
+//!
+//! ```toml
+//! [metrics]
+//! enabled = true
+//! path = "/metrics"
+//! sync_interval_secs = 5
+//! ```
+
+use serde::{Deserialize, Serialize};
+
+fn default_metrics_path() -> String {
+    "/metrics".into()
+}
+
+fn default_sync_interval_secs() -> u64 {
+    5
+}
+
+/// Prometheus metrics export configuration.
+///
+/// When `enabled = true` and the binary is compiled with `--features prometheus`, the gateway
+/// HTTP server mounts a `/metrics` (or configured `path`) route that returns `OpenMetrics` 1.0.0
+/// text suitable for scraping by Prometheus.
+///
+/// Requires `[gateway] enabled = true`; if the gateway is disabled, metrics export is skipped
+/// with a warning.
+///
+/// # Example (TOML)
+///
+/// ```toml
+/// [metrics]
+/// enabled = true
+/// path = "/metrics"
+/// sync_interval_secs = 5
+/// ```
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct MetricsConfig {
+    /// Whether Prometheus metrics export is active.
+    ///
+    /// When `false` (the default), no sync task is started and the `/metrics` route is not
+    /// mounted even if the `prometheus` feature is compiled in.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// HTTP path on which the `/metrics` endpoint is mounted.
+    ///
+    /// Must begin with `/`. Defaults to `"/metrics"`.
+    #[serde(default = "default_metrics_path")]
+    pub path: String,
+
+    /// How often (in seconds) the `MetricsSnapshot` watch channel is read and synced to the
+    /// Prometheus registry.
+    ///
+    /// Zero is clamped to `1` at runtime. Defaults to `5`.
+    #[serde(default = "default_sync_interval_secs")]
+    pub sync_interval_secs: u64,
+}
+
+impl Default for MetricsConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            path: default_metrics_path(),
+            sync_interval_secs: default_sync_interval_secs(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_metrics_config_defaults() {
+        let config: MetricsConfig = toml::from_str("").unwrap();
+        assert!(!config.enabled);
+        assert_eq!(config.path, "/metrics");
+        assert_eq!(config.sync_interval_secs, 5);
+    }
+
+    #[test]
+    fn test_metrics_config_serde() {
+        let src = r#"
+            enabled = true
+            path = "/custom/metrics"
+            sync_interval_secs = 10
+        "#;
+        let config: MetricsConfig = toml::from_str(src).unwrap();
+        assert!(config.enabled);
+        assert_eq!(config.path, "/custom/metrics");
+        assert_eq!(config.sync_interval_secs, 10);
+
+        let serialized = toml::to_string(&config).unwrap();
+        let roundtrip: MetricsConfig = toml::from_str(&serialized).unwrap();
+        assert!(roundtrip.enabled);
+        assert_eq!(roundtrip.path, "/custom/metrics");
+        assert_eq!(roundtrip.sync_interval_secs, 10);
+    }
+}

--- a/crates/zeph-config/src/migrate.rs
+++ b/crates/zeph-config/src/migrate.rs
@@ -24,6 +24,7 @@ static CANONICAL_ORDER: &[&str] = &[
     "a2a",
     "acp",
     "gateway",
+    "metrics",
     "daemon",
     "scheduler",
     "orchestration",

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -23,6 +23,7 @@ use crate::memory::{
     CompressionConfig, DocumentConfig, GraphConfig, MagicDocsConfig, MemoryConfig, SemanticConfig,
     SessionsConfig, SidequestConfig, TierConfig, VectorBackend,
 };
+use crate::metrics::MetricsConfig;
 use crate::providers::{
     LlmConfig, get_default_embedding_model, get_default_response_cache_ttl_secs,
     get_default_router_ema_alpha, get_default_router_reorder_interval,
@@ -100,6 +101,9 @@ pub struct Config {
     /// Profiling and distributed tracing configuration.
     #[serde(default)]
     pub telemetry: TelemetryConfig,
+    /// Prometheus metrics export configuration.
+    #[serde(default)]
+    pub metrics: MetricsConfig,
     /// Resolved secrets from vault. Never serialized — populated at runtime.
     #[serde(skip)]
     pub secrets: ResolvedSecrets,
@@ -260,6 +264,7 @@ impl Default for Config {
             hooks: HooksConfig::default(),
             magic_docs: MagicDocsConfig::default(),
             telemetry: TelemetryConfig::default(),
+            metrics: MetricsConfig::default(),
             secrets: ResolvedSecrets::default(),
         }
     }

--- a/crates/zeph-gateway/Cargo.toml
+++ b/crates/zeph-gateway/Cargo.toml
@@ -12,9 +12,13 @@ publish.workspace = true
 description = "HTTP gateway for webhook ingestion with bearer auth for Zeph"
 readme = "README.md"
 
+[features]
+prometheus = ["dep:prometheus-client"]
+
 [dependencies]
 axum.workspace = true
 blake3.workspace = true
+prometheus-client = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 subtle.workspace = true

--- a/crates/zeph-gateway/src/handlers.rs
+++ b/crates/zeph-gateway/src/handlers.rs
@@ -110,6 +110,47 @@ pub(crate) async fn health_handler(State(state): State<AppState>) -> impl IntoRe
     })
 }
 
+/// Handler for `GET /metrics` (Prometheus scrape endpoint).
+///
+/// Returns the current registry contents encoded as `OpenMetrics` 1.0.0 text format, suitable for
+/// scraping by Prometheus or any compatible monitoring system.
+///
+/// This handler requires `State<Arc<Registry>>` injected via the nested router in
+/// [`crate::GatewayServer::with_metrics_registry`].
+///
+/// # Responses
+///
+/// | Status | Condition |
+/// |---|---|
+/// | 200 | Registry encoded successfully; `Content-Type: application/openmetrics-text; version=1.0.0; charset=utf-8` |
+/// | 500 | Registry encoding failed (logged as error) |
+#[cfg(feature = "prometheus")]
+pub(crate) async fn metrics_handler(
+    axum::extract::State(registry): axum::extract::State<
+        std::sync::Arc<prometheus_client::registry::Registry>,
+    >,
+) -> impl axum::response::IntoResponse {
+    let mut buf = String::new();
+    match prometheus_client::encoding::text::encode(&mut buf, &registry) {
+        Ok(()) => (
+            [(
+                axum::http::header::CONTENT_TYPE,
+                "application/openmetrics-text; version=1.0.0; charset=utf-8",
+            )],
+            buf,
+        )
+            .into_response(),
+        Err(e) => {
+            tracing::error!("failed to encode prometheus metrics: {e}");
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                "metrics encoding failed",
+            )
+                .into_response()
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/zeph-gateway/src/server.rs
+++ b/crates/zeph-gateway/src/server.rs
@@ -62,6 +62,12 @@ pub struct GatewayServer {
     max_body_size: usize,
     webhook_tx: mpsc::Sender<String>,
     shutdown_rx: watch::Receiver<bool>,
+    /// Prometheus metrics registry and endpoint path (feature-gated).
+    #[cfg(feature = "prometheus")]
+    metrics_registry: Option<(
+        std::sync::Arc<prometheus_client::registry::Registry>,
+        String,
+    )>,
 }
 
 impl GatewayServer {
@@ -103,6 +109,8 @@ impl GatewayServer {
             max_body_size: 1_048_576,
             webhook_tx,
             shutdown_rx,
+            #[cfg(feature = "prometheus")]
+            metrics_registry: None,
         }
     }
 
@@ -182,6 +190,43 @@ impl GatewayServer {
         self
     }
 
+    /// Attach a Prometheus metrics registry to the gateway.
+    ///
+    /// When set, the server mounts an additional route at `path` that returns the registry
+    /// contents encoded as `OpenMetrics` 1.0.0 text.  The endpoint is unauthenticated and
+    /// bypasses rate limiting.
+    ///
+    /// Requires the `prometheus` feature.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # #[cfg(feature = "prometheus")]
+    /// # {
+    /// use std::sync::Arc;
+    /// use prometheus_client::registry::Registry;
+    /// use tokio::sync::{mpsc, watch};
+    /// use zeph_gateway::GatewayServer;
+    ///
+    /// let (tx, _rx) = mpsc::channel::<String>(1);
+    /// let (_stx, srx) = watch::channel(false);
+    /// let registry = Arc::new(Registry::default());
+    ///
+    /// let server = GatewayServer::new("127.0.0.1", 8080, tx, srx)
+    ///     .with_metrics_registry(registry, "/metrics");
+    /// # }
+    /// ```
+    #[cfg(feature = "prometheus")]
+    #[must_use]
+    pub fn with_metrics_registry(
+        mut self,
+        registry: std::sync::Arc<prometheus_client::registry::Registry>,
+        path: impl Into<String>,
+    ) -> Self {
+        self.metrics_registry = Some((registry, path.into()));
+        self
+    }
+
     /// Start the HTTP gateway server and block until shutdown is signalled.
     ///
     /// Binds a TCP listener on the configured address, installs middleware
@@ -214,6 +259,16 @@ impl GatewayServer {
             self.max_body_size,
         );
 
+        #[cfg(feature = "prometheus")]
+        let router = if let Some((registry, path)) = self.metrics_registry {
+            let metrics_route = axum::Router::new()
+                .route(&path, axum::routing::get(crate::handlers::metrics_handler))
+                .with_state(registry);
+            router.merge(metrics_route)
+        } else {
+            router
+        };
+
         let listener = tokio::net::TcpListener::bind(self.addr)
             .await
             .map_err(|e| GatewayError::Bind(self.addr.to_string(), e))?;
@@ -242,6 +297,65 @@ impl GatewayServer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "prometheus")]
+    #[tokio::test]
+    async fn test_metrics_endpoint_returns_openmetrics() {
+        use axum::body::Body;
+        use http_body_util::BodyExt;
+        use prometheus_client::registry::Registry;
+        use tower::ServiceExt;
+
+        let registry = std::sync::Arc::new(Registry::default());
+
+        let (tx, _rx) = mpsc::channel(1);
+        let (_stx, srx) = watch::channel(false);
+        let server = GatewayServer::new("127.0.0.1", 19999, tx, srx)
+            .with_metrics_registry(std::sync::Arc::clone(&registry), "/metrics");
+
+        // Build the router directly without binding a port
+        let state = AppState {
+            webhook_tx: server.webhook_tx,
+            started_at: Instant::now(),
+        };
+        let router = crate::router::build_router(
+            state,
+            server.auth_token.as_deref(),
+            server.rate_limit,
+            server.max_body_size,
+        );
+        let metrics_route = axum::Router::new()
+            .route(
+                "/metrics",
+                axum::routing::get(crate::handlers::metrics_handler),
+            )
+            .with_state(registry);
+        let router = router.merge(metrics_route);
+
+        let req = axum::http::Request::builder()
+            .method("GET")
+            .uri("/metrics")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = router.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+
+        let ct = response
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(
+            ct.contains("application/openmetrics-text"),
+            "unexpected content-type: {ct}"
+        );
+
+        let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let body = String::from_utf8(body_bytes.to_vec()).unwrap();
+        assert!(body.ends_with("# EOF\n"), "missing EOF marker in:\n{body}");
+    }
 
     #[test]
     fn server_builder_chain() {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -538,7 +538,13 @@ pub(crate) async fn run_daemon(
 
     #[cfg(feature = "gateway")]
     if config.gateway.enabled {
-        spawn_gateway_server(config, shutdown_rx.clone());
+        spawn_gateway_server(
+            config,
+            shutdown_rx.clone(),
+            // Daemon mode has no MetricsSnapshot watch channel — skip Prometheus sync.
+            #[cfg(feature = "prometheus")]
+            None,
+        );
     }
 
     let pid_file = config.daemon.pid_file.clone();

--- a/src/gateway_spawn.rs
+++ b/src/gateway_spawn.rs
@@ -5,6 +5,10 @@
 pub(crate) fn spawn_gateway_server(
     config: &zeph_core::config::Config,
     shutdown_rx: tokio::sync::watch::Receiver<bool>,
+    #[cfg(feature = "prometheus")] metrics_registry: Option<(
+        std::sync::Arc<prometheus_client::registry::Registry>,
+        String,
+    )>,
 ) {
     use zeph_gateway::GatewayServer;
 
@@ -18,6 +22,13 @@ pub(crate) fn spawn_gateway_server(
     .with_auth(config.gateway.auth_token.clone())
     .with_rate_limit(config.gateway.rate_limit)
     .with_max_body_size(config.gateway.max_body_size);
+
+    #[cfg(feature = "prometheus")]
+    let gw = if let Some((registry, path)) = metrics_registry {
+        gw.with_metrics_registry(registry, path)
+    } else {
+        gw
+    };
 
     tracing::info!(
         "Gateway server spawned on {}:{}",

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -203,6 +203,8 @@ pub(crate) struct WizardState {
     pub(crate) magic_docs_enabled: bool,
     // Profiling and distributed tracing (#2846)
     pub(crate) telemetry_enabled: bool,
+    // Prometheus metrics export (#2866)
+    pub(crate) prometheus_enabled: bool,
 }
 
 impl Default for WizardState {
@@ -345,6 +347,7 @@ impl Default for WizardState {
             autodream_min_hours: 8,
             magic_docs_enabled: false,
             telemetry_enabled: false,
+            prometheus_enabled: false,
         }
     }
 }
@@ -409,6 +412,7 @@ pub fn run(output: Option<PathBuf>) -> anyhow::Result<()> {
     step_retry(&mut state)?;
     step_policy(&mut state)?;
     step_telemetry(&mut state)?;
+    step_prometheus(&mut state)?;
     step_review_and_write(&state, output)?;
 
     Ok(())
@@ -905,6 +909,13 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
     config.memory.autodream.min_hours = state.autodream_min_hours;
     config.magic_docs.enabled = state.magic_docs_enabled;
     config.telemetry.enabled = state.telemetry_enabled;
+    if state.prometheus_enabled {
+        config.metrics.enabled = true;
+        // Only enable gateway if not already enabled by the deployment bundle.
+        if !config.gateway.enabled {
+            config.gateway.enabled = true;
+        }
+    }
 
     config
 }
@@ -1232,6 +1243,21 @@ fn step_telemetry(state: &mut WizardState) -> anyhow::Result<()> {
 
     state.telemetry_enabled = Confirm::new()
         .with_prompt("Enable profiling/tracing telemetry?")
+        .default(false)
+        .interact()?;
+
+    println!();
+    Ok(())
+}
+
+fn step_prometheus(state: &mut WizardState) -> anyhow::Result<()> {
+    println!("== Prometheus Metrics Export ==\n");
+    println!("Requires the binary to be compiled with --features prometheus.");
+    println!("Exposes a /metrics endpoint on the HTTP gateway for Prometheus scraping.");
+    println!("Enabling this will also enable [gateway] if it is not already set.\n");
+
+    state.prometheus_enabled = Confirm::new()
+        .with_prompt("Enable Prometheus metrics export?")
         .default(false)
         .interact()?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,8 @@ mod daemon;
 mod db_url;
 mod gateway_spawn;
 mod init;
+#[cfg(feature = "prometheus")]
+mod metrics_export;
 mod runner;
 mod scheduler;
 #[cfg(feature = "scheduler")]

--- a/src/metrics_export.rs
+++ b/src/metrics_export.rs
@@ -1,0 +1,866 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Prometheus metrics export for Zeph.
+//!
+//! [`PrometheusMetrics`] owns an [`Arc<Registry>`] and all ~25 metric families derived from
+//! [`MetricsSnapshot`].  Call [`PrometheusMetrics::sync`] periodically to push the current
+//! snapshot values into the registry.  [`spawn_metrics_sync`] spawns the background task that
+//! drives the sync loop.
+//!
+//! This module is compiled only when the `prometheus` feature is enabled.
+
+#![cfg(feature = "prometheus")]
+
+use std::sync::Arc;
+
+use std::sync::atomic::AtomicU64;
+
+use prometheus_client::encoding::EncodeLabelSet;
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::metrics::family::Family;
+use prometheus_client::metrics::gauge::Gauge;
+use prometheus_client::registry::Registry;
+use tokio::sync::watch;
+use zeph_core::metrics::MetricsSnapshot;
+
+// ---------------------------------------------------------------------------
+// Label structs
+// ---------------------------------------------------------------------------
+
+/// Label for token direction (prompt / completion / `cache_read` / `cache_create`).
+#[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct DirectionLabels {
+    direction: &'static str,
+}
+
+/// Label for agent turn phase.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct PhaseLabels {
+    phase: &'static str,
+}
+
+/// Label for compaction tier (soft / hard).
+#[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct TierLabels {
+    tier: &'static str,
+}
+
+/// Label for tool cache result (hit / miss).
+#[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct CacheResultLabels {
+    result: &'static str,
+}
+
+/// Label for quarantine result (invoked / failed).
+#[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct QuarantineResultLabels {
+    result: &'static str,
+}
+
+/// Label for orchestration task status (completed / failed / skipped).
+#[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct TaskStatusLabels {
+    status: &'static str,
+}
+
+/// Label for MCP server connection status (connected / failed).
+#[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct McpStatusLabels {
+    status: &'static str,
+}
+
+/// Label for background task supervisor state (inflight / dropped / completed).
+#[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct BgStateLabels {
+    state: &'static str,
+}
+
+// ---------------------------------------------------------------------------
+// Helper: counter delta with reset detection
+// ---------------------------------------------------------------------------
+
+/// Compute the delta between `current` and `prev` counter values.
+///
+/// If `current < prev` a session reset is assumed and `current` is treated as the absolute value
+/// (i.e. the delta equals `current`).
+fn counter_delta(current: u64, prev: u64) -> u64 {
+    if current < prev {
+        current
+    } else {
+        current - prev
+    }
+}
+
+/// Same as [`counter_delta`] but for `f64` counters.
+///
+/// Both `current` and `prev` are expected to be finite. Non-finite values (NaN, infinity)
+/// produced by upstream arithmetic on `cost_spent_cents` will be passed through unchanged;
+/// `prometheus-client` will encode them as `0` via `AtomicU64` bit-cast.
+fn counter_delta_f64(current: f64, prev: f64) -> f64 {
+    if !current.is_finite() {
+        return 0.0;
+    }
+    if current < prev {
+        current
+    } else {
+        current - prev
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PrometheusMetrics
+// ---------------------------------------------------------------------------
+
+/// Owns all Prometheus metric families and an [`Arc<Registry>`].
+///
+/// Construct via [`PrometheusMetrics::new`], then pass the [`Arc<Registry>`] to the gateway and
+/// call [`PrometheusMetrics::sync`] periodically from [`spawn_metrics_sync`].
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::sync::Arc;
+/// use zeph::metrics_export::PrometheusMetrics;
+///
+/// let pm = Arc::new(PrometheusMetrics::new());
+/// let registry = Arc::clone(&pm.registry);
+/// ```
+pub struct PrometheusMetrics {
+    /// The shared registry passed to the gateway `/metrics` handler.
+    pub registry: Arc<Registry>,
+
+    // --- LLM metrics ---
+    llm_tokens_total: Family<DirectionLabels, Counter>,
+    llm_api_calls_total: Counter,
+    /// NOTE: deferred — no per-provider labels in `MetricsSnapshot`; use f64 for fractional cents.
+    llm_cost_cents_total: Counter<f64, AtomicU64>,
+    llm_latency_ms: Gauge,
+    llm_context_tokens: Gauge,
+
+    // --- Turn phase metrics ---
+    turn_phase_duration_ms: Family<PhaseLabels, Gauge>,
+    turn_phase_avg_ms: Family<PhaseLabels, Gauge>,
+    turn_phase_max_ms: Family<PhaseLabels, Gauge>,
+
+    // --- Memory metrics ---
+    memory_messages_total: Gauge,
+    memory_embeddings_total: Counter,
+    memory_summaries_total: Counter,
+    memory_compactions_total: Family<TierLabels, Counter>,
+    memory_qdrant_available: Gauge,
+
+    // --- Tool metrics ---
+    tool_cache_total: Family<CacheResultLabels, Counter>,
+    tool_output_prunes_total: Counter,
+
+    // --- Security metrics ---
+    security_injection_flags_total: Counter,
+    security_exfiltration_blocks_total: Counter,
+    security_quarantine_total: Family<QuarantineResultLabels, Counter>,
+    security_rate_limit_trips_total: Counter,
+
+    // --- Orchestration metrics ---
+    orchestration_plans_total: Counter,
+    orchestration_tasks_total: Family<TaskStatusLabels, Counter>,
+
+    // --- MCP metrics ---
+    mcp_servers: Family<McpStatusLabels, Gauge>,
+
+    // --- Background task supervisor metrics ---
+    background_tasks: Family<BgStateLabels, Gauge>,
+
+    // --- System metrics ---
+    uptime_seconds: Gauge,
+    skills_total: Gauge,
+}
+
+impl PrometheusMetrics {
+    /// Create a new `PrometheusMetrics` instance and register all metric families.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::sync::Arc;
+    /// # #[cfg(feature = "prometheus")]
+    /// let pm = Arc::new(zeph::metrics_export::PrometheusMetrics::new());
+    /// ```
+    #[allow(clippy::too_many_lines)] // flat registration of ~25 metric families — no meaningful split
+    #[must_use]
+    pub fn new() -> Self {
+        let mut registry = Registry::default();
+
+        let llm_tokens_total = Family::<DirectionLabels, Counter>::default();
+        registry.register(
+            "zeph_llm_tokens",
+            "Total LLM tokens consumed, partitioned by direction",
+            llm_tokens_total.clone(),
+        );
+
+        let llm_api_calls_total = Counter::default();
+        registry.register(
+            "zeph_llm_api_calls",
+            "Total LLM API calls made",
+            llm_api_calls_total.clone(),
+        );
+
+        let llm_cost_cents_total: Counter<f64, AtomicU64> = Counter::default();
+        registry.register(
+            "zeph_llm_cost_cents",
+            "Total LLM cost in fractional US cents",
+            llm_cost_cents_total.clone(),
+        );
+
+        let llm_latency_ms = Gauge::default();
+        registry.register(
+            "zeph_llm_latency_ms",
+            "Last LLM API call latency in milliseconds",
+            llm_latency_ms.clone(),
+        );
+
+        let llm_context_tokens = Gauge::default();
+        registry.register(
+            "zeph_llm_context_tokens",
+            "Current context window token count",
+            llm_context_tokens.clone(),
+        );
+
+        let turn_phase_duration_ms = Family::<PhaseLabels, Gauge>::default();
+        registry.register(
+            "zeph_turn_phase_duration_ms",
+            "Last agent turn phase duration in milliseconds",
+            turn_phase_duration_ms.clone(),
+        );
+
+        let turn_phase_avg_ms = Family::<PhaseLabels, Gauge>::default();
+        registry.register(
+            "zeph_turn_phase_avg_ms",
+            "Rolling average agent turn phase duration in milliseconds (last 10 turns)",
+            turn_phase_avg_ms.clone(),
+        );
+
+        let turn_phase_max_ms = Family::<PhaseLabels, Gauge>::default();
+        registry.register(
+            "zeph_turn_phase_max_ms",
+            "Maximum agent turn phase duration in milliseconds (last 10 turns)",
+            turn_phase_max_ms.clone(),
+        );
+
+        let memory_messages_total = Gauge::default();
+        registry.register(
+            "zeph_memory_messages",
+            "Number of messages stored in SQLite",
+            memory_messages_total.clone(),
+        );
+
+        let memory_embeddings_total = Counter::default();
+        registry.register(
+            "zeph_memory_embeddings",
+            "Total embeddings generated",
+            memory_embeddings_total.clone(),
+        );
+
+        let memory_summaries_total = Counter::default();
+        registry.register(
+            "zeph_memory_summaries",
+            "Total context summaries produced",
+            memory_summaries_total.clone(),
+        );
+
+        let memory_compactions_total = Family::<TierLabels, Counter>::default();
+        registry.register(
+            "zeph_memory_compactions",
+            "Total context compactions by tier (soft/hard)",
+            memory_compactions_total.clone(),
+        );
+
+        let memory_qdrant_available = Gauge::default();
+        registry.register(
+            "zeph_memory_qdrant_available",
+            "Whether the Qdrant vector store is reachable (1 = yes, 0 = no)",
+            memory_qdrant_available.clone(),
+        );
+
+        let tool_cache_total = Family::<CacheResultLabels, Counter>::default();
+        registry.register(
+            "zeph_tool_cache",
+            "Tool output cache hits and misses",
+            tool_cache_total.clone(),
+        );
+
+        let tool_output_prunes_total = Counter::default();
+        registry.register(
+            "zeph_tool_output_prunes",
+            "Total tool output prune events",
+            tool_output_prunes_total.clone(),
+        );
+
+        let security_injection_flags_total = Counter::default();
+        registry.register(
+            "zeph_security_injection_flags",
+            "Total prompt injection flags raised by the sanitizer",
+            security_injection_flags_total.clone(),
+        );
+
+        let security_exfiltration_blocks_total = Counter::default();
+        registry.register(
+            "zeph_security_exfiltration_blocks",
+            "Total exfiltration attempts blocked (image channel)",
+            security_exfiltration_blocks_total.clone(),
+        );
+
+        let security_quarantine_total = Family::<QuarantineResultLabels, Counter>::default();
+        registry.register(
+            "zeph_security_quarantine",
+            "Quarantine sandbox invocations and failures",
+            security_quarantine_total.clone(),
+        );
+
+        let security_rate_limit_trips_total = Counter::default();
+        registry.register(
+            "zeph_security_rate_limit_trips",
+            "Total rate-limit trips across all channels",
+            security_rate_limit_trips_total.clone(),
+        );
+
+        let orchestration_plans_total = Counter::default();
+        registry.register(
+            "zeph_orchestration_plans",
+            "Total orchestration plans created",
+            orchestration_plans_total.clone(),
+        );
+
+        let orchestration_tasks_total = Family::<TaskStatusLabels, Counter>::default();
+        registry.register(
+            "zeph_orchestration_tasks",
+            "Orchestration task outcomes by status (completed/failed/skipped)",
+            orchestration_tasks_total.clone(),
+        );
+
+        let uptime_seconds = Gauge::default();
+        registry.register(
+            "zeph_uptime_seconds",
+            "Agent uptime in seconds since the current session started",
+            uptime_seconds.clone(),
+        );
+
+        let skills_total = Gauge::default();
+        registry.register(
+            "zeph_skills",
+            "Total number of skills loaded in the registry",
+            skills_total.clone(),
+        );
+
+        let mcp_servers = Family::<McpStatusLabels, Gauge>::default();
+        registry.register(
+            "zeph_mcp_servers",
+            "Number of MCP servers by connection status (connected/failed)",
+            mcp_servers.clone(),
+        );
+
+        let background_tasks = Family::<BgStateLabels, Gauge>::default();
+        registry.register(
+            "zeph_background_tasks",
+            "Background task supervisor counts by state (inflight/dropped/completed)",
+            background_tasks.clone(),
+        );
+
+        Self {
+            registry: Arc::new(registry),
+            llm_tokens_total,
+            llm_api_calls_total,
+            llm_cost_cents_total,
+            llm_latency_ms,
+            llm_context_tokens,
+            turn_phase_duration_ms,
+            turn_phase_avg_ms,
+            turn_phase_max_ms,
+            memory_messages_total,
+            memory_embeddings_total,
+            memory_summaries_total,
+            memory_compactions_total,
+            memory_qdrant_available,
+            tool_cache_total,
+            tool_output_prunes_total,
+            security_injection_flags_total,
+            security_exfiltration_blocks_total,
+            security_quarantine_total,
+            security_rate_limit_trips_total,
+            orchestration_plans_total,
+            orchestration_tasks_total,
+            mcp_servers,
+            background_tasks,
+            uptime_seconds,
+            skills_total,
+        }
+    }
+
+    /// Synchronise metric values from `current` snapshot, computing counter deltas against `prev`.
+    ///
+    /// Gauges are set to the absolute value from `current`. Counters receive the delta
+    /// `current - prev` (or `current` when `current < prev`, which indicates a session restart).
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # #[cfg(feature = "prometheus")]
+    /// # {
+    /// use std::sync::Arc;
+    /// use zeph_core::metrics::MetricsSnapshot;
+    /// use zeph::metrics_export::PrometheusMetrics;
+    ///
+    /// let pm = Arc::new(PrometheusMetrics::new());
+    /// let prev = MetricsSnapshot::default();
+    /// let mut cur = MetricsSnapshot::default();
+    /// cur.api_calls = 3;
+    /// pm.sync(&cur, &prev);
+    /// # }
+    /// ```
+    #[allow(clippy::too_many_lines)] // one delta update per metric family — no meaningful split
+    pub fn sync(&self, current: &MetricsSnapshot, prev: &MetricsSnapshot) {
+        // --- LLM tokens (counters with direction label) ---
+        let prompt_delta = counter_delta(current.prompt_tokens, prev.prompt_tokens);
+        let completion_delta = counter_delta(current.completion_tokens, prev.completion_tokens);
+        let cache_read_delta = counter_delta(current.cache_read_tokens, prev.cache_read_tokens);
+        let cache_create_delta =
+            counter_delta(current.cache_creation_tokens, prev.cache_creation_tokens);
+
+        if prompt_delta > 0 {
+            self.llm_tokens_total
+                .get_or_create(&DirectionLabels {
+                    direction: "prompt",
+                })
+                .inc_by(prompt_delta);
+        }
+        if completion_delta > 0 {
+            self.llm_tokens_total
+                .get_or_create(&DirectionLabels {
+                    direction: "completion",
+                })
+                .inc_by(completion_delta);
+        }
+        if cache_read_delta > 0 {
+            self.llm_tokens_total
+                .get_or_create(&DirectionLabels {
+                    direction: "cache_read",
+                })
+                .inc_by(cache_read_delta);
+        }
+        if cache_create_delta > 0 {
+            self.llm_tokens_total
+                .get_or_create(&DirectionLabels {
+                    direction: "cache_create",
+                })
+                .inc_by(cache_create_delta);
+        }
+
+        // --- LLM API calls ---
+        let api_calls_delta = counter_delta(current.api_calls, prev.api_calls);
+        if api_calls_delta > 0 {
+            self.llm_api_calls_total.inc_by(api_calls_delta);
+        }
+
+        // --- LLM cost ---
+        let cost_delta = counter_delta_f64(current.cost_spent_cents, prev.cost_spent_cents);
+        if cost_delta > 0.0 {
+            self.llm_cost_cents_total.inc_by(cost_delta);
+        }
+
+        // --- LLM gauges ---
+        self.llm_latency_ms
+            .set(i64::try_from(current.last_llm_latency_ms).unwrap_or(i64::MAX));
+        self.llm_context_tokens
+            .set(i64::try_from(current.context_tokens).unwrap_or(i64::MAX));
+
+        // --- Turn phase gauges ---
+        for (label, last, avg, max) in [
+            (
+                "prepare_context",
+                current.last_turn_timings.prepare_context_ms,
+                current.avg_turn_timings.prepare_context_ms,
+                current.max_turn_timings.prepare_context_ms,
+            ),
+            (
+                "llm_chat",
+                current.last_turn_timings.llm_chat_ms,
+                current.avg_turn_timings.llm_chat_ms,
+                current.max_turn_timings.llm_chat_ms,
+            ),
+            (
+                "tool_exec",
+                current.last_turn_timings.tool_exec_ms,
+                current.avg_turn_timings.tool_exec_ms,
+                current.max_turn_timings.tool_exec_ms,
+            ),
+            (
+                "persist",
+                current.last_turn_timings.persist_message_ms,
+                current.avg_turn_timings.persist_message_ms,
+                current.max_turn_timings.persist_message_ms,
+            ),
+        ] {
+            let lbl = PhaseLabels { phase: label };
+            self.turn_phase_duration_ms
+                .get_or_create(&lbl)
+                .set(i64::try_from(last).unwrap_or(i64::MAX));
+            self.turn_phase_avg_ms
+                .get_or_create(&lbl)
+                .set(i64::try_from(avg).unwrap_or(i64::MAX));
+            self.turn_phase_max_ms
+                .get_or_create(&lbl)
+                .set(i64::try_from(max).unwrap_or(i64::MAX));
+        }
+
+        // --- Memory gauges and counters ---
+        self.memory_messages_total
+            .set(i64::try_from(current.sqlite_message_count).unwrap_or(i64::MAX));
+
+        let embeddings_delta =
+            counter_delta(current.embeddings_generated, prev.embeddings_generated);
+        if embeddings_delta > 0 {
+            self.memory_embeddings_total.inc_by(embeddings_delta);
+        }
+
+        let summaries_delta = counter_delta(current.summaries_count, prev.summaries_count);
+        if summaries_delta > 0 {
+            self.memory_summaries_total.inc_by(summaries_delta);
+        }
+
+        let soft_delta = counter_delta(current.context_compactions, prev.context_compactions);
+        if soft_delta > 0 {
+            self.memory_compactions_total
+                .get_or_create(&TierLabels { tier: "soft" })
+                .inc_by(soft_delta);
+        }
+        let hard_delta = counter_delta(current.compaction_hard_count, prev.compaction_hard_count);
+        if hard_delta > 0 {
+            self.memory_compactions_total
+                .get_or_create(&TierLabels { tier: "hard" })
+                .inc_by(hard_delta);
+        }
+
+        self.memory_qdrant_available
+            .set(i64::from(current.qdrant_available));
+
+        // --- Tool metrics ---
+        let cache_hit_delta = counter_delta(current.tool_cache_hits, prev.tool_cache_hits);
+        if cache_hit_delta > 0 {
+            self.tool_cache_total
+                .get_or_create(&CacheResultLabels { result: "hit" })
+                .inc_by(cache_hit_delta);
+        }
+        let cache_miss_delta = counter_delta(current.tool_cache_misses, prev.tool_cache_misses);
+        if cache_miss_delta > 0 {
+            self.tool_cache_total
+                .get_or_create(&CacheResultLabels { result: "miss" })
+                .inc_by(cache_miss_delta);
+        }
+
+        let prunes_delta = counter_delta(current.tool_output_prunes, prev.tool_output_prunes);
+        if prunes_delta > 0 {
+            self.tool_output_prunes_total.inc_by(prunes_delta);
+        }
+
+        // --- Security counters ---
+        let injection_delta = counter_delta(
+            current.sanitizer_injection_flags,
+            prev.sanitizer_injection_flags,
+        );
+        if injection_delta > 0 {
+            self.security_injection_flags_total.inc_by(injection_delta);
+        }
+
+        let exfil_delta = counter_delta(
+            current.exfiltration_images_blocked,
+            prev.exfiltration_images_blocked,
+        );
+        if exfil_delta > 0 {
+            self.security_exfiltration_blocks_total.inc_by(exfil_delta);
+        }
+
+        let quar_inv_delta =
+            counter_delta(current.quarantine_invocations, prev.quarantine_invocations);
+        if quar_inv_delta > 0 {
+            self.security_quarantine_total
+                .get_or_create(&QuarantineResultLabels { result: "invoked" })
+                .inc_by(quar_inv_delta);
+        }
+        let quar_fail_delta = counter_delta(current.quarantine_failures, prev.quarantine_failures);
+        if quar_fail_delta > 0 {
+            self.security_quarantine_total
+                .get_or_create(&QuarantineResultLabels { result: "failed" })
+                .inc_by(quar_fail_delta);
+        }
+
+        let rate_delta = counter_delta(current.rate_limit_trips, prev.rate_limit_trips);
+        if rate_delta > 0 {
+            self.security_rate_limit_trips_total.inc_by(rate_delta);
+        }
+
+        // --- Orchestration counters ---
+        let plans_delta = counter_delta(
+            current.orchestration.plans_total,
+            prev.orchestration.plans_total,
+        );
+        if plans_delta > 0 {
+            self.orchestration_plans_total.inc_by(plans_delta);
+        }
+
+        for (label, current_val, prev_val) in [
+            (
+                "completed",
+                current.orchestration.tasks_completed,
+                prev.orchestration.tasks_completed,
+            ),
+            (
+                "failed",
+                current.orchestration.tasks_failed,
+                prev.orchestration.tasks_failed,
+            ),
+            (
+                "skipped",
+                current.orchestration.tasks_skipped,
+                prev.orchestration.tasks_skipped,
+            ),
+        ] {
+            let delta = counter_delta(current_val, prev_val);
+            if delta > 0 {
+                self.orchestration_tasks_total
+                    .get_or_create(&TaskStatusLabels { status: label })
+                    .inc_by(delta);
+            }
+        }
+
+        // --- MCP gauges ---
+        self.mcp_servers
+            .get_or_create(&McpStatusLabels {
+                status: "connected",
+            })
+            .set(i64::try_from(current.mcp_connected_count).unwrap_or(i64::MAX));
+        // failed = total configured minus connected
+        let mcp_failed = current
+            .mcp_server_count
+            .saturating_sub(current.mcp_connected_count);
+        self.mcp_servers
+            .get_or_create(&McpStatusLabels { status: "failed" })
+            .set(i64::try_from(mcp_failed).unwrap_or(i64::MAX));
+
+        // --- Background task supervisor gauges ---
+        self.background_tasks
+            .get_or_create(&BgStateLabels { state: "inflight" })
+            .set(i64::try_from(current.bg_inflight).unwrap_or(i64::MAX));
+        self.background_tasks
+            .get_or_create(&BgStateLabels { state: "dropped" })
+            .set(i64::try_from(current.bg_dropped).unwrap_or(i64::MAX));
+        self.background_tasks
+            .get_or_create(&BgStateLabels { state: "completed" })
+            .set(i64::try_from(current.bg_completed).unwrap_or(i64::MAX));
+
+        // --- System gauges ---
+        self.uptime_seconds
+            .set(i64::try_from(current.uptime_seconds).unwrap_or(i64::MAX));
+        self.skills_total
+            .set(i64::try_from(current.total_skills).unwrap_or(i64::MAX));
+    }
+}
+
+impl Default for PrometheusMetrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Background sync task
+// ---------------------------------------------------------------------------
+
+/// Spawn a background task that periodically reads the `MetricsSnapshot` watch channel and
+/// calls [`PrometheusMetrics::sync`].
+///
+/// `interval_secs` is clamped to a minimum of 1 second.  The task uses
+/// [`tokio::time::MissedTickBehavior::Skip`] so slow syncs do not accumulate ticks.
+///
+/// Returns a [`tokio::task::JoinHandle`] that should be stored and awaited on shutdown.
+///
+/// # Examples
+///
+/// ```no_run
+/// # #[cfg(feature = "prometheus")]
+/// # {
+/// use std::sync::Arc;
+/// use tokio::sync::watch;
+/// use zeph_core::metrics::MetricsSnapshot;
+/// use zeph::metrics_export::{PrometheusMetrics, spawn_metrics_sync};
+///
+/// let pm = Arc::new(PrometheusMetrics::new());
+/// let (_tx, rx) = watch::channel(MetricsSnapshot::default());
+/// let _handle = spawn_metrics_sync(pm, rx, 5);
+/// # }
+/// ```
+pub fn spawn_metrics_sync(
+    metrics: Arc<PrometheusMetrics>,
+    snapshot_rx: watch::Receiver<MetricsSnapshot>,
+    interval_secs: u64,
+) -> tokio::task::JoinHandle<()> {
+    let original = interval_secs;
+    let interval_secs = original.max(1);
+    if original == 0 {
+        tracing::warn!("[metrics] sync_interval_secs=0 is invalid; clamped to 1 second");
+    }
+
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        let mut prev = MetricsSnapshot::default();
+
+        loop {
+            interval.tick().await;
+
+            let current = snapshot_rx.borrow().clone();
+            metrics.sync(&current, &prev);
+            prev = current;
+        }
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zeph_core::metrics::MetricsSnapshot;
+
+    #[test]
+    fn test_counter_delta_normal() {
+        assert_eq!(counter_delta(105, 100), 5);
+        assert_eq!(counter_delta(100, 100), 0);
+        assert_eq!(counter_delta(50, 0), 50);
+        assert_eq!(counter_delta(0, 0), 0);
+    }
+
+    #[test]
+    fn test_counter_delta_reset() {
+        // current < prev means session restart — treat current as absolute
+        assert_eq!(counter_delta(20, 100), 20);
+        assert_eq!(counter_delta(0, 50), 0);
+    }
+
+    #[test]
+    fn test_counter_delta_f64_normal() {
+        let delta = counter_delta_f64(1.5, 1.0);
+        assert!((delta - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_counter_delta_f64_reset() {
+        let delta = counter_delta_f64(0.3, 1.0);
+        assert!((delta - 0.3).abs() < 1e-9);
+    }
+
+    #[test]
+    #[allow(clippy::field_reassign_with_default)]
+    fn test_sync_no_double_count() {
+        let pm = PrometheusMetrics::new();
+
+        let mut snap1 = MetricsSnapshot::default();
+        let mut snap2 = MetricsSnapshot::default();
+
+        snap1.api_calls = 0;
+        snap2.api_calls = 5;
+
+        // First sync: delta = 5
+        pm.sync(&snap2, &snap1);
+
+        let snap3 = snap2.clone(); // identical to snap2
+
+        // Second sync with same values: delta = 0, counter should not increase
+        pm.sync(&snap3, &snap2);
+
+        // We can verify the counter via encoding
+        let mut buf = String::new();
+        prometheus_client::encoding::text::encode(&mut buf, &pm.registry).unwrap();
+        // The counter should appear once with value 5, not 10
+        assert!(
+            buf.contains("zeph_llm_api_calls_total 5"),
+            "counter should be 5, got:\n{buf}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_clamp_interval() {
+        // This verifies the clamping logic compiles and runs without panic
+        // (interval_secs=0 should clamp to 1 without panic)
+        let pm = Arc::new(PrometheusMetrics::new());
+        let (tx, rx) = watch::channel(MetricsSnapshot::default());
+        let handle = spawn_metrics_sync(pm, rx, 0);
+        // Drop tx so the watch channel is closed; handle will finish on next tick
+        drop(tx);
+        // Abort the task — we just want to confirm no panic during construction
+        handle.abort();
+    }
+
+    #[test]
+    #[allow(clippy::field_reassign_with_default)]
+    fn test_openmetrics_encoding_format() {
+        let pm = PrometheusMetrics::new();
+
+        let mut snap = MetricsSnapshot::default();
+        snap.api_calls = 7;
+        snap.uptime_seconds = 42;
+        snap.prompt_tokens = 100;
+
+        pm.sync(&snap, &MetricsSnapshot::default());
+
+        let mut buf = String::new();
+        prometheus_client::encoding::text::encode(&mut buf, &pm.registry).unwrap();
+
+        assert!(
+            buf.contains("zeph_llm_api_calls_total"),
+            "missing api_calls metric"
+        );
+        assert!(buf.contains("zeph_uptime_seconds"), "missing uptime metric");
+        assert!(
+            buf.contains("direction=\"prompt\""),
+            "missing direction label"
+        );
+        assert!(buf.ends_with("# EOF\n"), "OpenMetrics requires EOF marker");
+    }
+
+    #[test]
+    #[allow(clippy::field_reassign_with_default)]
+    fn test_mcp_and_bg_metrics_sync() {
+        let pm = PrometheusMetrics::new();
+
+        let mut snap = MetricsSnapshot::default();
+        snap.mcp_server_count = 3;
+        snap.mcp_connected_count = 2;
+        snap.bg_inflight = 1;
+        snap.bg_dropped = 0;
+        snap.bg_completed = 10;
+
+        pm.sync(&snap, &MetricsSnapshot::default());
+
+        let mut buf = String::new();
+        prometheus_client::encoding::text::encode(&mut buf, &pm.registry).unwrap();
+
+        assert!(
+            buf.contains("status=\"connected\""),
+            "missing mcp connected label"
+        );
+        assert!(
+            buf.contains("status=\"failed\""),
+            "missing mcp failed label"
+        );
+        assert!(
+            buf.contains("state=\"inflight\""),
+            "missing bg inflight label"
+        );
+        assert!(
+            buf.contains("state=\"completed\""),
+            "missing bg completed label"
+        );
+    }
+}

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1805,10 +1805,8 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         }
     };
 
-    #[cfg(feature = "gateway")]
-    if config.gateway.enabled {
-        crate::gateway_spawn::spawn_gateway_server(config, shutdown_rx.clone());
-    }
+    // Gateway is spawned after the metrics channel is created (lines ~1835 below).
+    // The actual spawn_gateway_server call is deferred to after metrics wiring.
 
     #[allow(unused_variables)]
     let agent = {
@@ -1891,6 +1889,10 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             m.autosave_enabled = config.memory.autosave_assistant;
         });
     }
+    // Clone metrics_rx for Prometheus sync task before it is consumed by TUI or dropped.
+    #[cfg(feature = "prometheus")]
+    let prometheus_metrics_rx = metrics_rx.clone();
+
     #[cfg(all(feature = "tui", feature = "scheduler"))]
     let metrics_tx_for_sched = metrics_tx.clone();
     let extended_context = config
@@ -1985,6 +1987,52 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         tui_metrics_rx = None;
         drop(metrics_rx);
     };
+
+    // Wire up Prometheus metrics sync and spawn the gateway server.
+    //
+    // S1 fix (critic review): gateway is spawned HERE, after the metrics watch channel exists,
+    // so prometheus_metrics_rx is available. This replaces the earlier placeholder comment.
+    // TODO(#2866 Phase 2): register prometheus_sync_handle with the background task supervisor
+    // instead of storing it as a fire-and-forget binding. For MVP the handle is kept alive by the
+    // binding until the process exits.
+    // `prometheus` feature implies `gateway` (see Cargo.toml feature definition), so no inner
+    // `#[cfg(feature = "gateway")]` guards are needed inside this block.
+    #[cfg(feature = "prometheus")]
+    let _prometheus_sync_handle = {
+        if config.metrics.enabled && config.gateway.enabled {
+            let prom = std::sync::Arc::new(crate::metrics_export::PrometheusMetrics::new());
+            let handle = crate::metrics_export::spawn_metrics_sync(
+                std::sync::Arc::clone(&prom),
+                prometheus_metrics_rx,
+                config.metrics.sync_interval_secs,
+            );
+            crate::gateway_spawn::spawn_gateway_server(
+                config,
+                shutdown_rx.clone(),
+                Some((
+                    std::sync::Arc::clone(&prom.registry),
+                    config.metrics.path.clone(),
+                )),
+            );
+            Some(handle)
+        } else {
+            if config.metrics.enabled && !config.gateway.enabled {
+                tracing::warn!(
+                    "[metrics] enabled=true but [gateway] enabled=false; skipping Prometheus metrics export"
+                );
+            }
+            if config.gateway.enabled {
+                crate::gateway_spawn::spawn_gateway_server(config, shutdown_rx.clone(), None);
+            }
+            None
+        }
+    };
+
+    // When `prometheus` feature is disabled, spawn gateway unconditionally if enabled.
+    #[cfg(all(feature = "gateway", not(feature = "prometheus")))]
+    if config.gateway.enabled {
+        crate::gateway_spawn::spawn_gateway_server(config, shutdown_rx.clone());
+    }
 
     let mut agent = agent;
     #[cfg(feature = "tui")]


### PR DESCRIPTION
## Summary

- Add Prometheus/OpenMetrics `/metrics` endpoint to `zeph-gateway`
- 25 metric families (counters + gauges, `zeph_` prefix) synced from `MetricsSnapshot`
- `prometheus` feature flag added to `server` and `full` bundles
- `prometheus-client` 0.24 workspace dependency (OpenMetrics-native, no global state)

## Architecture

- **Registry**: `Arc<prometheus_client::registry::Registry>` created in binary crate, passed to gateway
- **Data flow**: `watch::Receiver<MetricsSnapshot>` → `spawn_metrics_sync` task → `PrometheusMetrics::sync()` → registry → `GET /metrics`
- **Delta computation**: counter deltas computed per-sync with session-restart detection (if `current < prev`, treat as absolute)
- **Feature gating**: `prometheus` disabled = no endpoint compiled, zero overhead

## New files

- `crates/zeph-config/src/metrics.rs` — `MetricsConfig` (`enabled`, `path`, `sync_interval_secs`)
- `src/metrics_export.rs` — `PrometheusMetrics`, `spawn_metrics_sync`, `counter_delta` helpers

## Metric families (25 total)

LLM (5), agent turns (3), memory (5), tools (2), security (4), orchestration (2), system (4)

## Test plan

- [ ] `cargo build --features prometheus` compiles
- [ ] `cargo nextest run --workspace --features full --lib --bins` — 8105 passed
- [ ] `GET http://localhost:8090/metrics` returns OpenMetrics text when `metrics.enabled=true`
- [ ] Counter values match `MetricsSnapshot` fields within one sync interval
- [ ] `prometheus` feature disabled → no `/metrics` handler in binary

## Related

- Epic: #2865
- Spec: `specs/036-prometheus-metrics/spec.md`
- Next: Phase 2 (#2867, Grafana stack), Phase 3 (#2868, histograms)