### PR TITLE
feat(metrics): implement Phase 2 Grafana stack and Phase 3 histogram metrics (#2865)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `skill_reload_rx` and `config_reload_rx` channel sites. New `MetricsBridge` tracing layer
   using `on_enter`/`on_exit` accumulation for correct async timing, replacing manual
   `Instant::now()` bookkeeping for the 4 watched turn-phase spans when profiling is active.
+- **Prometheus metrics export Phase 3: histogram metrics** (epic `#2865`): added `HistogramRecorder`
+  trait to `zeph-core::metrics` for per-event latency recording without coupling core to
+  `prometheus-client`. `PrometheusMetrics` implements the trait with three histograms —
+  `zeph_llm_latency_seconds`, `zeph_turn_duration_seconds`, `zeph_tool_execution_seconds` — using
+  buckets `[0.1, 0.5, 1.0, 5.0, 10.0, 30.0, 60.0]` s. Recording points: LLM call completion in
+  `record_chat_metrics_and_compact`, turn end in `flush_turn_timings`, per-tool completion in
+  `handle_native_tool_calls`. New `Agent::with_histogram_recorder` builder method. Wired in
+  `runner.rs` via a single pre-created `Arc<PrometheusMetrics>` shared between histogram recorder
+  and sync task. Metrics path validated at startup — warns if empty or missing leading `/`.
+
+- **Prometheus metrics export Phase 2: Grafana stack** (epic `#2865`): added ready-to-run local
+  monitoring stack. New `docker/docker-compose.metrics.yml` overlay (Prometheus v3.4.0, Grafana
+  11.6.0); `docker/prometheus/prometheus.yml` with scrape config; Grafana provisioning YAML for
+  datasource and dashboard discovery; `docker/grafana/dashboards/zeph-overview.json` with panels
+  for all 25 Phase 1 metrics plus Phase 3 histogram percentiles (p50/p95/p99) organized in 7 rows.
+  New `book/src/guides/prometheus.md` setup guide. Start with:
+  `docker compose -f docker/docker-compose.metrics.yml up`.
+
 - **Prometheus metrics export Phase 1** (epic `#2865`, `#2866`): added Prometheus/OpenMetrics
   compatible `/metrics` endpoint to the HTTP gateway. New `prometheus` feature flag (included in
   `server` and `full` bundles); `prometheus-client` 0.24 added as workspace dependency. New

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -42,6 +42,7 @@
 - [Migrate Config](guides/migrate-config.md)
 - [Deploy with Docker](guides/docker.md)
 - [Daemon Mode](guides/daemon-mode.md)
+- [Prometheus Monitoring](guides/prometheus.md)
 
 # Advanced
 

--- a/book/src/guides/prometheus.md
+++ b/book/src/guides/prometheus.md
@@ -1,0 +1,143 @@
+# Prometheus Monitoring
+
+Zeph can expose a `/metrics` endpoint in [OpenMetrics](https://openmetrics.io/) format that
+Prometheus can scrape. A pre-built Grafana dashboard is included for instant visualization.
+
+## Prerequisites
+
+- Zeph built with the `prometheus` feature (included in `server` and `full` feature sets)
+- Docker (for the bundled Prometheus + Grafana stack)
+
+## Enable the Metrics Endpoint
+
+In your `config.toml`:
+
+```toml
+[gateway]
+enabled = true
+port = 8090
+
+[metrics]
+enabled = true
+path = "/metrics"
+sync_interval_secs = 5
+```
+
+The `prometheus` feature implies `gateway`, so you only need to enable the gateway once.
+
+Verify the endpoint is live:
+
+```bash
+curl http://localhost:8090/metrics
+```
+
+You should see OpenMetrics text output ending with `# EOF`.
+
+## Start the Monitoring Stack
+
+```bash
+docker compose -f docker/docker-compose.metrics.yml up
+```
+
+This starts:
+- **Prometheus** on `http://localhost:9090` — scrapes Zeph every 10 seconds
+- **Grafana** on `http://localhost:3000` — pre-configured with the Zeph dashboard
+
+Both services include health checks; Grafana waits until Prometheus passes its health check before starting.
+
+Open Grafana at `http://localhost:3000`. No login is required in the default configuration
+(anonymous viewer access is enabled). The **Zeph Overview** dashboard is available under
+**Dashboards → Zeph**.
+
+### Custom Metrics Host
+
+If Zeph listens on a different port, set `ZEPH_METRICS_HOST` before starting the stack.
+You must also update `docker/prometheus/prometheus.yml` (`static_configs.targets`) to match,
+since Prometheus does not expand environment variables in its scrape config:
+
+```bash
+# 1. Edit docker/prometheus/prometheus.yml targets to ["192.168.1.10:9000"]
+# 2. Start the stack:
+ZEPH_METRICS_HOST=192.168.1.10:9000 docker compose -f docker/docker-compose.metrics.yml up
+```
+
+### Linux Networking
+
+`host.docker.internal` resolves automatically on Docker Desktop (macOS/Windows) and on
+Docker Engine >= 20.10 with the `extra_hosts: host.docker.internal:host-gateway` entry already
+set in `docker-compose.metrics.yml`. On older Linux setups, set `network_mode: host` on the
+`prometheus` service in the compose file instead.
+
+## Running Alongside the Docker Stack
+
+If Zeph is running inside Docker (e.g. `docker-compose.yml`), add the metrics overlay:
+
+```bash
+docker compose -f docker/docker-compose.yml -f docker/docker-compose.metrics.yml up
+```
+
+Then edit `docker/prometheus/prometheus.yml` to scrape the Zeph container instead of the host:
+
+```yaml
+scrape_configs:
+  - job_name: "zeph"
+    static_configs:
+      - targets: ["zeph:8090"]   # Docker service name
+```
+
+## Dashboard Panels
+
+The **Zeph Overview** dashboard includes these panel rows:
+
+| Row | Metrics |
+|-----|---------|
+| LLM Performance | Token rate, API call rate, last-call latency, context tokens |
+| LLM Latency Histograms | p50/p95/p99 for LLM calls, turns, and tool executions |
+| Agent Turn Phases | Last/average/max duration per phase (prepare_context, llm_chat, tool_exec, persist) |
+| Memory & Context | Message count, embedding rate, compaction rate, Qdrant status |
+| Tools & Cache | Cache hit/miss rate, tool output prune rate |
+| Security | Injection flags, exfiltration blocks, quarantine invocations, rate-limit trips |
+| System | Uptime, skills loaded, MCP server status, background task counts, orchestration rates |
+
+## Custom Prometheus Configuration
+
+If you already have a Prometheus instance, add Zeph as a scrape target:
+
+```yaml
+scrape_configs:
+  - job_name: "zeph"
+    static_configs:
+      - targets: ["<zeph-host>:8090"]
+    metrics_path: "/metrics"
+    scrape_interval: 10s
+```
+
+Replace `<zeph-host>` with the hostname or IP where Zeph is running.
+
+## Change the Admin Password
+
+Set `GRAFANA_ADMIN_PASSWORD` before starting the stack:
+
+```bash
+GRAFANA_ADMIN_PASSWORD=mysecret docker compose -f docker/docker-compose.metrics.yml up
+```
+
+## Troubleshooting
+
+**`curl http://localhost:8090/metrics` returns connection refused**
+
+Check that both `[gateway] enabled = true` and `[metrics] enabled = true` are set in your config.
+The gateway binds to `0.0.0.0:8090` by default.
+
+**Prometheus shows `zeph` target as DOWN**
+
+On Linux, `host.docker.internal` requires Docker Engine 20.10+ with `--add-host`.
+If your setup doesn't support it, switch to `network_mode: host` in
+`docker/docker-compose.metrics.yml` for the `prometheus` service, or use the container name
+when Zeph runs inside Docker.
+
+**No data in Grafana**
+
+Confirm Prometheus can reach the metrics endpoint: open `http://localhost:9090/targets` and
+check that `zeph` is in state UP. If the target is down, verify the `targets` in
+`docker/prometheus/prometheus.yml` matches where Zeph is listening.

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1109,6 +1109,22 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Attach a histogram recorder for per-event Prometheus observations.
+    ///
+    /// When set, the agent records individual LLM call, turn, and tool execution
+    /// latencies into the provided recorder. The recorder must be `Send + Sync`
+    /// and is shared across the agent loop via `Arc`.
+    ///
+    /// Pass `None` to disable histogram recording (the default).
+    #[must_use]
+    pub fn with_histogram_recorder(
+        mut self,
+        recorder: Option<std::sync::Arc<dyn crate::metrics::HistogramRecorder>>,
+    ) -> Self {
+        self.metrics.histogram_recorder = recorder;
+        self
+    }
+
     /// Returns a handle that can cancel the current in-flight operation.
     /// The returned `Notify` is stable across messages — callers invoke
     /// `notify_waiters()` to cancel whatever operation is running.

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -399,6 +399,9 @@ pub(crate) struct MetricsState {
     pub(crate) timing_window: std::collections::VecDeque<crate::metrics::TurnTimings>,
     /// Accumulator for the current turn's timings. Flushed at turn end via `flush_turn_timings`.
     pub(crate) pending_timings: crate::metrics::TurnTimings,
+    /// Optional histogram recorder for per-event Prometheus observations.
+    /// `None` when the `prometheus` feature is disabled or metrics are not enabled.
+    pub(crate) histogram_recorder: Option<std::sync::Arc<dyn crate::metrics::HistogramRecorder>>,
 }
 
 /// Groups task orchestration and subagent state.
@@ -960,6 +963,7 @@ impl MetricsState {
             classifier_metrics: None,
             timing_window: std::collections::VecDeque::new(),
             pending_timings: crate::metrics::TurnTimings::default(),
+            histogram_recorder: None,
         }
     }
 }

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -360,7 +360,8 @@ impl<C: Channel> Agent<C> {
         };
         match result {
             Ok(Ok(resp)) => {
-                let latency = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+                let elapsed = start.elapsed();
+                let latency = u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX);
                 let completion_heuristic = estimate_tokens(&resp) as u64;
                 let (final_prompt, final_completion) = self
                     .provider
@@ -375,6 +376,9 @@ impl<C: Channel> Agent<C> {
                     m.total_tokens = m.prompt_tokens + m.completion_tokens;
                 });
                 self.record_cost_and_cache(final_prompt, final_completion);
+                if let Some(ref recorder) = self.metrics.histogram_recorder {
+                    recorder.observe_llm_latency(elapsed);
+                }
                 if self.run_response_verification(&resp) {
                     let _ = self
                         .channel
@@ -964,7 +968,8 @@ impl<C: Channel> Agent<C> {
         start: std::time::Instant,
         result: &ChatResponse,
     ) -> Result<(), super::super::error::AgentError> {
-        let latency = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+        let elapsed = start.elapsed();
+        let latency = u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX);
         let prompt_estimate = self.providers.cached_prompt_tokens;
         let completion_heuristic = match result {
             ChatResponse::Text(t) => estimate_tokens(t) as u64,
@@ -996,6 +1001,10 @@ impl<C: Channel> Agent<C> {
             }
         });
         self.record_cost_and_cache(final_prompt, final_completion);
+
+        if let Some(ref recorder) = self.metrics.histogram_recorder {
+            recorder.observe_llm_latency(elapsed);
+        }
 
         if let Some((input_tokens, output_tokens)) = self.provider.last_usage() {
             let context_window =
@@ -2331,6 +2340,10 @@ impl<C: Channel> Agent<C> {
                     )
                 }
             };
+
+            if let Some(ref recorder) = self.metrics.histogram_recorder {
+                recorder.observe_tool_execution(started_at.elapsed());
+            }
 
             // CR-01: emit a tool span for each completed tool call.
             if let Some(ref mut trace_coll) = self.debug_state.trace_collector

--- a/crates/zeph-core/src/agent/utils.rs
+++ b/crates/zeph-core/src/agent/utils.rs
@@ -166,12 +166,22 @@ impl<C: Channel> Agent<C> {
         avg.tool_exec_ms /= n;
         avg.persist_message_ms /= n;
 
+        let total_ms = timings
+            .prepare_context_ms
+            .saturating_add(timings.llm_chat_ms)
+            .saturating_add(timings.tool_exec_ms)
+            .saturating_add(timings.persist_message_ms);
+
         self.update_metrics(|m| {
             m.last_turn_timings = timings;
             m.avg_turn_timings = avg;
             m.max_turn_timings = max;
             m.timing_sample_count = n;
         });
+
+        if let Some(ref recorder) = self.metrics.histogram_recorder {
+            recorder.observe_turn_duration(std::time::Duration::from_millis(total_ms));
+        }
     }
 
     /// Push the current classifier metrics snapshot into `MetricsSnapshot`.

--- a/crates/zeph-core/src/metrics.rs
+++ b/crates/zeph-core/src/metrics.rs
@@ -484,6 +484,53 @@ impl MetricsCollector {
     }
 }
 
+// ---------------------------------------------------------------------------
+// HistogramRecorder
+// ---------------------------------------------------------------------------
+
+/// Per-event histogram recording contract for the agent loop.
+///
+/// Implementors record individual latency observations into Prometheus histograms
+/// (or any other backend). The trait is object-safe: the agent stores an
+/// `Option<Arc<dyn HistogramRecorder>>` and calls these methods at each measurement
+/// point. When `None`, recording is a no-op with zero overhead.
+///
+/// # Contract for implementors
+///
+/// - All methods must be non-blocking; they must not call async code or acquire
+///   mutexes that may block.
+/// - Implementations must be `Send + Sync` — the agent loop runs on the tokio
+///   thread pool and the recorder may be called from multiple tasks.
+///
+/// # Examples
+///
+/// ```rust
+/// use std::sync::Arc;
+/// use std::time::Duration;
+/// use zeph_core::metrics::HistogramRecorder;
+///
+/// struct NoOpRecorder;
+///
+/// impl HistogramRecorder for NoOpRecorder {
+///     fn observe_llm_latency(&self, _: Duration) {}
+///     fn observe_turn_duration(&self, _: Duration) {}
+///     fn observe_tool_execution(&self, _: Duration) {}
+/// }
+///
+/// let recorder: Arc<dyn HistogramRecorder> = Arc::new(NoOpRecorder);
+/// recorder.observe_llm_latency(Duration::from_millis(500));
+/// ```
+pub trait HistogramRecorder: Send + Sync {
+    /// Record a single LLM API call latency observation.
+    fn observe_llm_latency(&self, duration: std::time::Duration);
+
+    /// Record a full agent turn duration observation (context prep + LLM + tools + persist).
+    fn observe_turn_duration(&self, duration: std::time::Duration);
+
+    /// Record a single tool execution latency observation.
+    fn observe_tool_execution(&self, duration: std::time::Duration);
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::field_reassign_with_default)]
@@ -885,5 +932,24 @@ mod tests {
         assert_eq!(snapshot.graph_communities_total, 2);
         assert_eq!(snapshot.graph_extraction_count, 7);
         assert_eq!(snapshot.graph_extraction_failures, 1);
+    }
+
+    #[test]
+    fn histogram_recorder_trait_is_object_safe() {
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        struct NoOpRecorder;
+        impl HistogramRecorder for NoOpRecorder {
+            fn observe_llm_latency(&self, _: Duration) {}
+            fn observe_turn_duration(&self, _: Duration) {}
+            fn observe_tool_execution(&self, _: Duration) {}
+        }
+
+        // Verify the trait can be used as a trait object (object-safe).
+        let recorder: Arc<dyn HistogramRecorder> = Arc::new(NoOpRecorder);
+        recorder.observe_llm_latency(Duration::from_millis(500));
+        recorder.observe_turn_duration(Duration::from_millis(3000));
+        recorder.observe_tool_execution(Duration::from_millis(100));
     }
 }

--- a/docker/docker-compose.metrics.yml
+++ b/docker/docker-compose.metrics.yml
@@ -1,0 +1,71 @@
+# Prometheus + Grafana monitoring overlay for Zeph.
+#
+# Usage (Zeph running on the host via `cargo run`):
+#   docker compose -f docker/docker-compose.metrics.yml up
+#
+# Usage (Zeph running inside Docker alongside this stack):
+#   docker compose -f docker/docker-compose.yml -f docker/docker-compose.metrics.yml up
+#
+# After starting:
+#   Prometheus: http://localhost:9090
+#   Grafana:    http://localhost:3000  (admin / admin by default)
+#   Metrics:    http://localhost:${ZEPH_METRICS_PORT:-8090}/metrics  (served by Zeph gateway)
+#
+# Networking notes:
+#   - `extra_hosts: host.docker.internal:host-gateway` works on Docker Desktop (macOS/Windows)
+#     and Docker Engine >= 20.10 on Linux.
+#   - On older Linux setups without extra_hosts support, set `network_mode: host` on the
+#     prometheus service, or switch ZEPH_METRICS_HOST to the container name when Zeph runs
+#     inside Docker.
+#
+# Environment variables:
+#   ZEPH_METRICS_HOST      Host:port where Zeph's /metrics endpoint is listening.
+#                          Default: host.docker.internal:8090
+#   GRAFANA_ADMIN_PASSWORD Grafana admin password. Default: admin
+
+services:
+  prometheus:
+    image: prom/prometheus:v3.4.0
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    healthcheck:
+      interval: 10s
+      retries: 3
+      start_period: 15s
+      test: ["CMD", "wget", "-qO-", "http://localhost:9090/-/healthy"]
+      timeout: 5s
+    ports:
+      - "9090:9090"
+    restart: unless-stopped
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    environment:
+      ZEPH_METRICS_HOST: ${ZEPH_METRICS_HOST:-host.docker.internal:8090}
+
+  grafana:
+    depends_on:
+      prometheus:
+        condition: service_healthy
+    environment:
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+    healthcheck:
+      interval: 10s
+      retries: 3
+      start_period: 20s
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+      timeout: 5s
+    image: grafana/grafana:11.6.0
+    ports:
+      - "3000:3000"
+    restart: unless-stopped
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana_data:/var/lib/grafana
+
+volumes:
+  grafana_data: null
+  prometheus_data: null

--- a/docker/grafana/dashboards/zeph-overview.json
+++ b/docker/grafana/dashboards/zeph-overview.json
@@ -1,0 +1,598 @@
+{
+  "__inputs": [],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "11.0.0" },
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" }
+  ],
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "title": "LLM Performance",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 1 },
+      "id": 2,
+      "options": { "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "rate(zeph_llm_tokens_total{direction=\"prompt\"}[5m])",
+          "legendFormat": "prompt tokens/s"
+        },
+        {
+          "expr": "rate(zeph_llm_tokens_total{direction=\"completion\"}[5m])",
+          "legendFormat": "completion tokens/s"
+        },
+        {
+          "expr": "rate(zeph_llm_tokens_total{direction=\"cache_read\"}[5m])",
+          "legendFormat": "cache_read tokens/s"
+        }
+      ],
+      "title": "LLM Token Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 1 },
+      "id": 3,
+      "targets": [
+        {
+          "expr": "rate(zeph_llm_api_calls_total[5m])",
+          "legendFormat": "API calls/s"
+        }
+      ],
+      "title": "LLM API Call Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 1 },
+      "id": 4,
+      "targets": [
+        {
+          "expr": "zeph_llm_latency_ms",
+          "legendFormat": "last call latency (ms)"
+        }
+      ],
+      "title": "LLM Last Call Latency (ms)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 1 },
+      "id": 5,
+      "targets": [
+        {
+          "expr": "zeph_llm_context_tokens",
+          "legendFormat": "context tokens"
+        }
+      ],
+      "title": "LLM Context Tokens",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 },
+      "id": 10,
+      "title": "LLM Latency Histograms (Phase 3)",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "s" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 10 },
+      "id": 11,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, rate(zeph_llm_latency_seconds_bucket[5m]))",
+          "legendFormat": "p50"
+        },
+        {
+          "expr": "histogram_quantile(0.95, rate(zeph_llm_latency_seconds_bucket[5m]))",
+          "legendFormat": "p95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, rate(zeph_llm_latency_seconds_bucket[5m]))",
+          "legendFormat": "p99"
+        }
+      ],
+      "title": "LLM Latency Percentiles (s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "s" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 10 },
+      "id": 12,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, rate(zeph_turn_duration_seconds_bucket[5m]))",
+          "legendFormat": "p50"
+        },
+        {
+          "expr": "histogram_quantile(0.95, rate(zeph_turn_duration_seconds_bucket[5m]))",
+          "legendFormat": "p95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, rate(zeph_turn_duration_seconds_bucket[5m]))",
+          "legendFormat": "p99"
+        }
+      ],
+      "title": "Turn Duration Percentiles (s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "s" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 10 },
+      "id": 13,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, rate(zeph_tool_execution_seconds_bucket[5m]))",
+          "legendFormat": "p50"
+        },
+        {
+          "expr": "histogram_quantile(0.95, rate(zeph_tool_execution_seconds_bucket[5m]))",
+          "legendFormat": "p95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, rate(zeph_tool_execution_seconds_bucket[5m]))",
+          "legendFormat": "p99"
+        }
+      ],
+      "title": "Tool Execution Percentiles (s)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 18 },
+      "id": 20,
+      "title": "Agent Turn Phases",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "ms" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 19 },
+      "id": 21,
+      "targets": [
+        {
+          "expr": "zeph_turn_phase_duration_ms{phase=\"prepare_context\"}",
+          "legendFormat": "prepare_context"
+        },
+        {
+          "expr": "zeph_turn_phase_duration_ms{phase=\"llm_chat\"}",
+          "legendFormat": "llm_chat"
+        },
+        {
+          "expr": "zeph_turn_phase_duration_ms{phase=\"tool_exec\"}",
+          "legendFormat": "tool_exec"
+        },
+        {
+          "expr": "zeph_turn_phase_duration_ms{phase=\"persist\"}",
+          "legendFormat": "persist"
+        }
+      ],
+      "title": "Last Turn Phase Durations (ms)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "ms" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 19 },
+      "id": 22,
+      "targets": [
+        {
+          "expr": "zeph_turn_phase_avg_ms{phase=\"prepare_context\"}",
+          "legendFormat": "prepare_context avg"
+        },
+        {
+          "expr": "zeph_turn_phase_avg_ms{phase=\"llm_chat\"}",
+          "legendFormat": "llm_chat avg"
+        },
+        {
+          "expr": "zeph_turn_phase_avg_ms{phase=\"tool_exec\"}",
+          "legendFormat": "tool_exec avg"
+        }
+      ],
+      "title": "Rolling Avg Phase Durations (ms)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "ms" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 19 },
+      "id": 23,
+      "targets": [
+        {
+          "expr": "zeph_turn_phase_max_ms{phase=\"llm_chat\"}",
+          "legendFormat": "llm_chat max"
+        },
+        {
+          "expr": "zeph_turn_phase_max_ms{phase=\"tool_exec\"}",
+          "legendFormat": "tool_exec max"
+        }
+      ],
+      "title": "Max Phase Durations (ms)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 27 },
+      "id": 30,
+      "title": "Memory & Context",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 28 },
+      "id": 31,
+      "targets": [
+        { "expr": "zeph_memory_messages", "legendFormat": "messages" }
+      ],
+      "title": "Memory Messages Total",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 28 },
+      "id": 32,
+      "targets": [
+        {
+          "expr": "rate(zeph_memory_embeddings_total[5m])",
+          "legendFormat": "embeddings/s"
+        },
+        {
+          "expr": "rate(zeph_memory_summaries_total[5m])",
+          "legendFormat": "summaries/s"
+        }
+      ],
+      "title": "Memory Operations Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 28 },
+      "id": 33,
+      "targets": [
+        {
+          "expr": "rate(zeph_memory_compactions_total{tier=\"soft\"}[5m])",
+          "legendFormat": "soft compactions/s"
+        },
+        {
+          "expr": "rate(zeph_memory_compactions_total{tier=\"hard\"}[5m])",
+          "legendFormat": "hard compactions/s"
+        }
+      ],
+      "title": "Compaction Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "options": { "0": { "color": "red", "text": "Unavailable" } }, "type": "value" },
+            { "options": { "1": { "color": "green", "text": "Available" } }, "type": "value" }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 28 },
+      "id": 34,
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [
+        { "expr": "zeph_memory_qdrant_available", "legendFormat": "Qdrant" }
+      ],
+      "title": "Qdrant Available",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 36 },
+      "id": 40,
+      "title": "Tools & Cache",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 37 },
+      "id": 41,
+      "targets": [
+        {
+          "expr": "rate(zeph_tool_cache_total{result=\"hit\"}[5m])",
+          "legendFormat": "cache hits/s"
+        },
+        {
+          "expr": "rate(zeph_tool_cache_total{result=\"miss\"}[5m])",
+          "legendFormat": "cache misses/s"
+        }
+      ],
+      "title": "Tool Cache Hit/Miss Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 37 },
+      "id": 42,
+      "targets": [
+        {
+          "expr": "rate(zeph_tool_output_prunes_total[5m])",
+          "legendFormat": "prunes/s"
+        }
+      ],
+      "title": "Tool Output Prune Rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 45 },
+      "id": 50,
+      "title": "Security",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 46 },
+      "id": 51,
+      "targets": [
+        {
+          "expr": "rate(zeph_security_injection_flags_total[5m])",
+          "legendFormat": "injection flags/s"
+        },
+        {
+          "expr": "rate(zeph_security_exfiltration_blocks_total[5m])",
+          "legendFormat": "exfiltration blocks/s"
+        },
+        {
+          "expr": "rate(zeph_security_rate_limit_trips_total[5m])",
+          "legendFormat": "rate limit trips/s"
+        }
+      ],
+      "title": "Security Event Rates",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 46 },
+      "id": 52,
+      "targets": [
+        {
+          "expr": "rate(zeph_security_quarantine_total{result=\"invoked\"}[5m])",
+          "legendFormat": "quarantine invoked/s"
+        },
+        {
+          "expr": "rate(zeph_security_quarantine_total{result=\"failed\"}[5m])",
+          "legendFormat": "quarantine failed/s"
+        }
+      ],
+      "title": "Quarantine Rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 54 },
+      "id": 60,
+      "title": "System",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "s" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 55 },
+      "id": 61,
+      "targets": [
+        { "expr": "zeph_uptime_seconds", "legendFormat": "uptime (s)" }
+      ],
+      "title": "Agent Uptime",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 55 },
+      "id": 62,
+      "targets": [
+        { "expr": "zeph_skills", "legendFormat": "skills loaded" }
+      ],
+      "title": "Skills Loaded",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 55 },
+      "id": 63,
+      "targets": [
+        {
+          "expr": "zeph_mcp_servers{status=\"connected\"}",
+          "legendFormat": "connected"
+        },
+        {
+          "expr": "zeph_mcp_servers{status=\"failed\"}",
+          "legendFormat": "failed"
+        }
+      ],
+      "title": "MCP Servers",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 55 },
+      "id": 64,
+      "targets": [
+        {
+          "expr": "zeph_background_tasks{state=\"inflight\"}",
+          "legendFormat": "inflight"
+        },
+        {
+          "expr": "zeph_background_tasks{state=\"completed\"}",
+          "legendFormat": "completed"
+        },
+        {
+          "expr": "zeph_background_tasks{state=\"dropped\"}",
+          "legendFormat": "dropped"
+        }
+      ],
+      "title": "Background Tasks",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 63 },
+      "id": 65,
+      "targets": [
+        {
+          "expr": "rate(zeph_orchestration_plans_total[5m])",
+          "legendFormat": "plans/s"
+        }
+      ],
+      "title": "Orchestration Plan Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 63 },
+      "id": 66,
+      "targets": [
+        {
+          "expr": "rate(zeph_orchestration_tasks_total{status=\"completed\"}[5m])",
+          "legendFormat": "completed/s"
+        },
+        {
+          "expr": "rate(zeph_orchestration_tasks_total{status=\"failed\"}[5m])",
+          "legendFormat": "failed/s"
+        },
+        {
+          "expr": "rate(zeph_orchestration_tasks_total{status=\"skipped\"}[5m])",
+          "legendFormat": "skipped/s"
+        }
+      ],
+      "title": "Orchestration Task Rate",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": ["zeph", "observability"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Zeph Overview",
+  "uid": "zeph-overview",
+  "version": 1
+}

--- a/docker/grafana/provisioning/dashboards/dashboards.yml
+++ b/docker/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: Zeph
+    folder: Zeph
+    orgId: 1
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/docker/grafana/provisioning/datasources/prometheus.yml
+++ b/docker/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -1,0 +1,16 @@
+global:
+  evaluation_interval: 15s
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: zeph
+    metrics_path: /metrics
+    scrape_interval: 10s
+    # Default: scrape Zeph running on the host (cargo run / native development).
+    # On macOS/Windows with Docker Desktop and on Linux Docker Engine >= 20.10,
+    # host.docker.internal resolves to the host's loopback address automatically
+    # via extra_hosts in docker-compose.metrics.yml.
+    # To scrape Zeph running inside Docker, replace the target with the Docker
+    # service name, e.g. ["zeph:8090"].
+    static_configs:
+      - targets: ["host.docker.internal:8090"]

--- a/src/metrics_export.rs
+++ b/src/metrics_export.rs
@@ -20,9 +20,18 @@ use prometheus_client::encoding::EncodeLabelSet;
 use prometheus_client::metrics::counter::Counter;
 use prometheus_client::metrics::family::Family;
 use prometheus_client::metrics::gauge::Gauge;
+use prometheus_client::metrics::histogram::Histogram;
 use prometheus_client::registry::Registry;
 use tokio::sync::watch;
 use zeph_core::metrics::MetricsSnapshot;
+
+/// Bucket boundaries for latency histograms, in seconds.
+///
+/// Covers the typical range for LLM calls (1–30 s), tool executions (0.01–60 s),
+/// and full agent turns (1–120 s).  Using a single set keeps the implementation
+/// uniform; callers can adjust bucket resolution in a future iteration once
+/// real-world data is available.
+const LATENCY_BUCKETS: &[f64] = &[0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0];
 
 // ---------------------------------------------------------------------------
 // Label structs
@@ -173,6 +182,11 @@ pub struct PrometheusMetrics {
     // --- System metrics ---
     uptime_seconds: Gauge,
     skills_total: Gauge,
+
+    // --- Histogram metrics (Phase 3) ---
+    llm_latency_seconds: Histogram,
+    turn_duration_seconds: Histogram,
+    tool_execution_seconds: Histogram,
 }
 
 impl PrometheusMetrics {
@@ -365,6 +379,27 @@ impl PrometheusMetrics {
             background_tasks.clone(),
         );
 
+        let llm_latency_seconds = Histogram::new(LATENCY_BUCKETS.iter().copied());
+        registry.register(
+            "zeph_llm_latency_seconds",
+            "LLM API call latency distribution in seconds",
+            llm_latency_seconds.clone(),
+        );
+
+        let turn_duration_seconds = Histogram::new(LATENCY_BUCKETS.iter().copied());
+        registry.register(
+            "zeph_turn_duration_seconds",
+            "Full agent turn duration distribution in seconds (context + LLM + tools + persist)",
+            turn_duration_seconds.clone(),
+        );
+
+        let tool_execution_seconds = Histogram::new(LATENCY_BUCKETS.iter().copied());
+        registry.register(
+            "zeph_tool_execution_seconds",
+            "Individual tool execution latency distribution in seconds",
+            tool_execution_seconds.clone(),
+        );
+
         Self {
             registry: Arc::new(registry),
             llm_tokens_total,
@@ -392,6 +427,9 @@ impl PrometheusMetrics {
             background_tasks,
             uptime_seconds,
             skills_total,
+            llm_latency_seconds,
+            turn_duration_seconds,
+            tool_execution_seconds,
         }
     }
 
@@ -670,6 +708,20 @@ impl Default for PrometheusMetrics {
     }
 }
 
+impl zeph_core::metrics::HistogramRecorder for PrometheusMetrics {
+    fn observe_llm_latency(&self, duration: std::time::Duration) {
+        self.llm_latency_seconds.observe(duration.as_secs_f64());
+    }
+
+    fn observe_turn_duration(&self, duration: std::time::Duration) {
+        self.turn_duration_seconds.observe(duration.as_secs_f64());
+    }
+
+    fn observe_tool_execution(&self, duration: std::time::Duration) {
+        self.tool_execution_seconds.observe(duration.as_secs_f64());
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Background sync task
 // ---------------------------------------------------------------------------
@@ -699,7 +751,7 @@ impl Default for PrometheusMetrics {
 /// ```
 pub fn spawn_metrics_sync(
     metrics: Arc<PrometheusMetrics>,
-    snapshot_rx: watch::Receiver<MetricsSnapshot>,
+    mut snapshot_rx: watch::Receiver<MetricsSnapshot>,
     interval_secs: u64,
 ) -> tokio::task::JoinHandle<()> {
     let original = interval_secs;
@@ -717,7 +769,7 @@ pub fn spawn_metrics_sync(
         loop {
             interval.tick().await;
 
-            let current = snapshot_rx.borrow().clone();
+            let current = snapshot_rx.borrow_and_update().clone();
             metrics.sync(&current, &prev);
             prev = current;
         }
@@ -862,5 +914,61 @@ mod tests {
             buf.contains("state=\"completed\""),
             "missing bg completed label"
         );
+    }
+
+    #[test]
+    fn test_histogram_observation() {
+        use zeph_core::metrics::HistogramRecorder;
+
+        let pm = PrometheusMetrics::new();
+
+        pm.observe_llm_latency(std::time::Duration::from_secs_f64(2.5));
+        pm.observe_turn_duration(std::time::Duration::from_secs_f64(8.0));
+        pm.observe_tool_execution(std::time::Duration::from_secs_f64(0.3));
+
+        let mut buf = String::new();
+        prometheus_client::encoding::text::encode(&mut buf, &pm.registry).unwrap();
+
+        assert!(
+            buf.contains("zeph_llm_latency_seconds"),
+            "missing llm latency histogram"
+        );
+        assert!(
+            buf.contains("zeph_turn_duration_seconds"),
+            "missing turn duration histogram"
+        );
+        assert!(
+            buf.contains("zeph_tool_execution_seconds"),
+            "missing tool execution histogram"
+        );
+        // Verify at least one bucket and the sum are encoded.
+        assert!(buf.contains("_bucket"), "missing histogram buckets");
+        assert!(buf.contains("_sum"), "missing histogram sum");
+        assert!(buf.contains("_count"), "missing histogram count");
+    }
+
+    #[test]
+    fn test_histogram_buckets_are_valid() {
+        // All bucket boundaries must be positive and strictly increasing.
+        assert!(!LATENCY_BUCKETS.is_empty(), "bucket list must not be empty");
+        let mut prev = f64::NEG_INFINITY;
+        for &b in LATENCY_BUCKETS {
+            assert!(b > 0.0, "bucket boundary {b} must be positive");
+            assert!(b > prev, "bucket boundaries must be strictly increasing");
+            prev = b;
+        }
+    }
+
+    #[test]
+    fn test_histogram_recorder_trait_impl() {
+        use zeph_core::metrics::HistogramRecorder;
+
+        let pm = PrometheusMetrics::new();
+        let recorder: &dyn HistogramRecorder = &pm;
+
+        // These calls must not panic.
+        recorder.observe_llm_latency(std::time::Duration::from_millis(100));
+        recorder.observe_turn_duration(std::time::Duration::from_millis(5000));
+        recorder.observe_tool_execution(std::time::Duration::from_millis(50));
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1893,6 +1893,28 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     #[cfg(feature = "prometheus")]
     let prometheus_metrics_rx = metrics_rx.clone();
 
+    // Pre-create the PrometheusMetrics instance so its Arc can be passed both to the
+    // histogram recorder wiring (before agent construction) and to the sync task (below).
+    // The Arc is None when the feature is disabled or metrics/gateway is not enabled.
+    #[cfg(feature = "prometheus")]
+    let prom_arc: Option<std::sync::Arc<crate::metrics_export::PrometheusMetrics>> =
+        if config.metrics.enabled && config.gateway.enabled {
+            // M4: validate metrics.path before using it.
+            let path = &config.metrics.path;
+            if path.is_empty() || !path.starts_with('/') {
+                tracing::warn!(
+                    path = %path,
+                    "[metrics] metrics.path must be non-empty and start with '/'; \
+                     got '{path}' — using default '/metrics'"
+                );
+            }
+            Some(std::sync::Arc::new(
+                crate::metrics_export::PrometheusMetrics::new(),
+            ))
+        } else {
+            None
+        };
+
     #[cfg(all(feature = "tui", feature = "scheduler"))]
     let metrics_tx_for_sched = metrics_tx.clone();
     let extended_context = config
@@ -1930,6 +1952,16 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         .with_metrics(metrics_tx)
         .with_status_tx(agent_status_tx)
         .with_provider_pool(config.llm.providers.clone(), provider_config_snapshot);
+
+    #[cfg(feature = "prometheus")]
+    let agent = {
+        let recorder: Option<std::sync::Arc<dyn zeph_core::metrics::HistogramRecorder>> =
+            prom_arc.as_ref().map(|p| {
+                std::sync::Arc::clone(p)
+                    as std::sync::Arc<dyn zeph_core::metrics::HistogramRecorder>
+            });
+        agent.with_histogram_recorder(recorder)
+    };
     #[cfg(not(feature = "tui"))]
     drop(metrics_rx);
 
@@ -1999,20 +2031,24 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     // `#[cfg(feature = "gateway")]` guards are needed inside this block.
     #[cfg(feature = "prometheus")]
     let _prometheus_sync_handle = {
-        if config.metrics.enabled && config.gateway.enabled {
-            let prom = std::sync::Arc::new(crate::metrics_export::PrometheusMetrics::new());
+        if let Some(prom) = prom_arc {
             let handle = crate::metrics_export::spawn_metrics_sync(
                 std::sync::Arc::clone(&prom),
                 prometheus_metrics_rx,
                 config.metrics.sync_interval_secs,
             );
+            let effective_path = {
+                let p = &config.metrics.path;
+                if p.is_empty() || !p.starts_with('/') {
+                    "/metrics".to_owned()
+                } else {
+                    p.clone()
+                }
+            };
             crate::gateway_spawn::spawn_gateway_server(
                 config,
                 shutdown_rx.clone(),
-                Some((
-                    std::sync::Arc::clone(&prom.registry),
-                    config.metrics.path.clone(),
-                )),
+                Some((std::sync::Arc::clone(&prom.registry), effective_path)),
             );
             Some(handle)
         } else {


### PR DESCRIPTION
## Summary

- **Phase 2 — Grafana stack**: `docker/docker-compose.metrics.yml` overlay (Prometheus v3.4.0 + Grafana 11.6.0), auto-provisioned datasource + pre-built 7-row dashboard covering all 25 Phase 1 metrics, mdbook setup guide with Linux/macOS networking notes
- **Phase 3 — Histogram metrics**: `HistogramRecorder` trait in `zeph-core::metrics`, 3 histograms (`zeph_llm_latency_seconds`, `zeph_turn_duration_seconds`, `zeph_tool_execution_seconds`) with buckets [0.1..60s], recording points in agent loop, single `elapsed` capture per call site, `borrow_and_update()` in sync task

Closes #2865

## Non-blocking follow-ups filed

- #2872 — add 120s bucket to `zeph_turn_duration_seconds` histogram
- #2873 — remove/document dead `ZEPH_METRICS_HOST` env var in docker-compose
- #2874 — add tests for `HistogramRecorder` wiring through agent builder and recording call sites

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo build --features prometheus` — compiles
- [x] `cargo build --features full` — compiles
- [x] `cargo nextest run --workspace --features full --lib --bins` — 8109 passed
- [x] Phase 2: docker files present and validated, mdbook entry confirmed
- [x] Phase 3: 11 metrics-specific tests pass (histogram observation, bucket config, trait dispatch)
- [ ] Live test: `docker compose -f docker/docker-compose.metrics.yml up` + `curl localhost:8090/metrics` (manual, post-merge)