### PR TITLE
fix(metrics): remove dead ZEPH_METRICS_HOST env var, add 120s histogram bucket, wire recorder tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Prometheus metrics follow-up fixes** (`#2872`, `#2873`, `#2874`): removed dead
+  `ZEPH_METRICS_HOST` environment variable from `docker/docker-compose.metrics.yml` (Prometheus
+  does not support env var substitution in its config file; added a comment in
+  `docker/prometheus/prometheus.yml` pointing to the correct place to change the scrape target).
+  Added missing `120.0` s bucket to `LATENCY_BUCKETS` in `src/metrics_export.rs` so the full
+  `[0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 120.0]` range is covered (closes the gap for long
+  agent turns). Added four unit tests for `HistogramRecorder` wiring: `with_histogram_recorder`
+  builder sets recorder to `Some`; `flush_turn_timings` calls `observe_turn_duration`; 
+  `record_chat_metrics_and_compact` calls `observe_llm_latency`; `handle_native_tool_calls` calls
+  `observe_tool_execution` once per tool call.
+
 - **Profiling and tracing Phase 2: deep instrumentation** (`#2851`, `#2852`, `#2853`, `#2854`,
   `#2855`, `#2856`, `#2857`, epic `#2846`): added spans to all 5 subsystem crates. Memory:
   `memory.remember`, `memory.recall`, `memory.summarize`, `memory.graph_extract`,

--- a/book/src/guides/prometheus.md
+++ b/book/src/guides/prometheus.md
@@ -51,14 +51,14 @@ Open Grafana at `http://localhost:3000`. No login is required in the default con
 
 ### Custom Metrics Host
 
-If Zeph listens on a different port, set `ZEPH_METRICS_HOST` before starting the stack.
-You must also update `docker/prometheus/prometheus.yml` (`static_configs.targets`) to match,
-since Prometheus does not expand environment variables in its scrape config:
+If Zeph listens on a different host or port, edit `docker/prometheus/prometheus.yml` and update
+the `static_configs.targets` value. Prometheus does not support environment variable substitution
+in its config file.
 
 ```bash
-# 1. Edit docker/prometheus/prometheus.yml targets to ["192.168.1.10:9000"]
+# 1. Edit docker/prometheus/prometheus.yml: change targets to ["192.168.1.10:9000"]
 # 2. Start the stack:
-ZEPH_METRICS_HOST=192.168.1.10:9000 docker compose -f docker/docker-compose.metrics.yml up
+docker compose -f docker/docker-compose.metrics.yml up
 ```
 
 ### Linux Networking

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -2999,11 +2999,17 @@ fn skipped_output(
 // T-CRIT-02: handle_focus_tool tests — happy path, error paths, checkpoint pinning (S5 fix).
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{Duration, Instant};
+
+    use zeph_llm::provider::{ChatResponse, Message, Role};
+
     use crate::agent::Agent;
     use crate::agent::tests::agent_tests::{
         MockChannel, MockToolExecutor, create_test_registry, mock_provider,
     };
-    use zeph_llm::provider::{Message, Role};
+    use crate::metrics::HistogramRecorder;
 
     fn make_agent() -> Agent<MockChannel> {
         let mut agent = Agent::new(
@@ -3296,6 +3302,56 @@ mod tests {
         assert!(
             !zeph_tools::has_explicit_tool_request(&text),
             "explicit_request must be false when content has no tool request"
+        );
+    }
+
+    // T-HR-3: `record_chat_metrics_and_compact` calls `observe_llm_latency` on the recorder.
+    #[tokio::test]
+    async fn record_chat_metrics_calls_observe_llm_latency() {
+        struct CountingRecorder {
+            llm_count: AtomicU64,
+        }
+
+        impl HistogramRecorder for CountingRecorder {
+            fn observe_llm_latency(&self, _: Duration) {
+                self.llm_count.fetch_add(1, Ordering::Relaxed);
+            }
+
+            fn observe_turn_duration(&self, _: Duration) {}
+
+            fn observe_tool_execution(&self, _: Duration) {}
+        }
+
+        let recorder = Arc::new(CountingRecorder {
+            llm_count: AtomicU64::new(0),
+        });
+
+        let mut agent = Agent::new(
+            mock_provider(vec![]),
+            MockChannel::new(vec![]),
+            create_test_registry(),
+            None,
+            5,
+            MockToolExecutor::no_tools(),
+        )
+        .with_histogram_recorder(Some(Arc::clone(&recorder) as Arc<dyn HistogramRecorder>));
+
+        agent
+            .msg
+            .messages
+            .push(Message::from_legacy(Role::System, "system"));
+
+        let start = Instant::now();
+        let response = ChatResponse::Text("hello".to_owned());
+        agent
+            .record_chat_metrics_and_compact(start, &response)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            recorder.llm_count.load(Ordering::Relaxed),
+            1,
+            "record_chat_metrics_and_compact must call observe_llm_latency once"
         );
     }
 }

--- a/crates/zeph-core/src/agent/tool_execution/tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests.rs
@@ -4983,3 +4983,141 @@ mod pii_ner_circuit_breaker {
         );
     }
 }
+
+// ── HistogramRecorder wiring tests (#2874) ────────────────────────────────
+//
+// T-HR-1: `with_histogram_recorder` sets histogram_recorder to Some.
+// T-HR-2: `flush_turn_timings` calls `observe_turn_duration` on the recorder.
+// T-HR-3: `observe_llm_latency` fires via `handle_native_tool_calls` (indirectly
+//          through the internal `record_chat_metrics_and_compact` path).
+// T-HR-4: `observe_tool_execution` fires per tool call via `handle_native_tool_calls`.
+
+#[cfg(test)]
+mod histogram_recorder_wiring {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::Duration;
+
+    use super::super::super::agent_tests::{
+        MockChannel, MockToolExecutor, create_test_registry, mock_provider,
+    };
+    use crate::metrics::HistogramRecorder;
+    use zeph_llm::provider::ToolUseRequest;
+
+    struct CountingRecorder {
+        llm_count: AtomicU64,
+        turn_count: AtomicU64,
+        tool_count: AtomicU64,
+    }
+
+    impl CountingRecorder {
+        fn new() -> Self {
+            Self {
+                llm_count: AtomicU64::new(0),
+                turn_count: AtomicU64::new(0),
+                tool_count: AtomicU64::new(0),
+            }
+        }
+    }
+
+    impl HistogramRecorder for CountingRecorder {
+        fn observe_llm_latency(&self, _: Duration) {
+            self.llm_count.fetch_add(1, Ordering::Relaxed);
+        }
+
+        fn observe_turn_duration(&self, _: Duration) {
+            self.turn_count.fetch_add(1, Ordering::Relaxed);
+        }
+
+        fn observe_tool_execution(&self, _: Duration) {
+            self.tool_count.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    // T-HR-1: `with_histogram_recorder` builder wires histogram_recorder to Some.
+    #[test]
+    fn with_histogram_recorder_sets_some() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let recorder: Arc<dyn HistogramRecorder> = Arc::new(CountingRecorder::new());
+
+        let agent = super::super::super::Agent::new(provider, channel, registry, None, 5, executor)
+            .with_histogram_recorder(Some(Arc::clone(&recorder)));
+
+        assert!(
+            agent.metrics.histogram_recorder.is_some(),
+            "histogram_recorder must be Some after with_histogram_recorder(Some(...))"
+        );
+    }
+
+    // T-HR-2: `flush_turn_timings` calls `observe_turn_duration` exactly once.
+    #[test]
+    fn flush_turn_timings_calls_observe_turn_duration() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let recorder = Arc::new(CountingRecorder::new());
+
+        let mut agent =
+            super::super::super::Agent::new(provider, channel, registry, None, 5, executor)
+                .with_histogram_recorder(Some(Arc::clone(&recorder) as Arc<dyn HistogramRecorder>));
+
+        agent.metrics.pending_timings = crate::metrics::TurnTimings {
+            prepare_context_ms: 10,
+            llm_chat_ms: 200,
+            tool_exec_ms: 50,
+            persist_message_ms: 5,
+        };
+        agent.flush_turn_timings();
+
+        assert_eq!(
+            recorder.turn_count.load(Ordering::Relaxed),
+            1,
+            "flush_turn_timings must call observe_turn_duration once"
+        );
+    }
+
+    // T-HR-4: `observe_tool_execution` fires once per tool call in `handle_native_tool_calls`.
+    #[tokio::test]
+    async fn handle_native_tool_calls_calls_observe_tool_execution() {
+        let executor = super::FixedOutputExecutor {
+            summary: "ok".to_string(),
+            is_err: false,
+        };
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let recorder = Arc::new(CountingRecorder::new());
+
+        let mut agent =
+            super::super::super::Agent::new(provider, channel, registry, None, 5, executor)
+                .with_histogram_recorder(Some(Arc::clone(&recorder) as Arc<dyn HistogramRecorder>));
+
+        let tool_calls = vec![
+            ToolUseRequest {
+                id: "id-hr4a".to_owned(),
+                name: "bash".to_owned(),
+                input: serde_json::json!({"command": "echo a"}),
+            },
+            ToolUseRequest {
+                id: "id-hr4b".to_owned(),
+                name: "bash".to_owned(),
+                input: serde_json::json!({"command": "echo b"}),
+            },
+        ];
+
+        agent
+            .handle_native_tool_calls(None, &tool_calls)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            recorder.tool_count.load(Ordering::Relaxed),
+            2,
+            "observe_tool_execution must fire once per tool call (2 calls → count = 2)"
+        );
+    }
+}

--- a/docker/docker-compose.metrics.yml
+++ b/docker/docker-compose.metrics.yml
@@ -15,12 +15,9 @@
 #   - `extra_hosts: host.docker.internal:host-gateway` works on Docker Desktop (macOS/Windows)
 #     and Docker Engine >= 20.10 on Linux.
 #   - On older Linux setups without extra_hosts support, set `network_mode: host` on the
-#     prometheus service, or switch ZEPH_METRICS_HOST to the container name when Zeph runs
-#     inside Docker.
+#     prometheus service, or change the target in prometheus.yml when Zeph runs inside Docker.
 #
 # Environment variables:
-#   ZEPH_METRICS_HOST      Host:port where Zeph's /metrics endpoint is listening.
-#                          Default: host.docker.internal:8090
 #   GRAFANA_ADMIN_PASSWORD Grafana admin password. Default: admin
 
 services:
@@ -40,8 +37,6 @@ services:
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus
-    environment:
-      ZEPH_METRICS_HOST: ${ZEPH_METRICS_HOST:-host.docker.internal:8090}
 
   grafana:
     depends_on:

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -12,5 +12,7 @@ scrape_configs:
     # via extra_hosts in docker-compose.metrics.yml.
     # To scrape Zeph running inside Docker, replace the target with the Docker
     # service name, e.g. ["zeph:8090"].
+    # To change the scrape target, edit the target address below.
+    # Prometheus does not support environment variable substitution in this file.
     static_configs:
       - targets: ["host.docker.internal:8090"]

--- a/src/metrics_export.rs
+++ b/src/metrics_export.rs
@@ -31,7 +31,7 @@ use zeph_core::metrics::MetricsSnapshot;
 /// and full agent turns (1–120 s).  Using a single set keeps the implementation
 /// uniform; callers can adjust bucket resolution in a future iteration once
 /// real-world data is available.
-const LATENCY_BUCKETS: &[f64] = &[0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0];
+const LATENCY_BUCKETS: &[f64] = &[0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 120.0];
 
 // ---------------------------------------------------------------------------
 // Label structs


### PR DESCRIPTION
## Summary

Closes #2873, #2872, #2874

- **#2873** — Remove dead `ZEPH_METRICS_HOST` env var from `docker/docker-compose.metrics.yml` (Prometheus does not support env var substitution in its config YAML); update `book/src/guides/prometheus.md` to direct users to edit `prometheus.yml` directly
- **#2872** — Extend `LATENCY_BUCKETS` with `120.0` so agent turns exceeding 60 s land in a finite Prometheus bucket instead of `+Inf`
- **#2874** — Add 4 unit tests (`T-HR-1` through `T-HR-4`) verifying `HistogramRecorder` wiring through the agent builder and all recording call sites

## Changes

| File | Change |
|------|--------|
| `docker/docker-compose.metrics.yml` | Remove `ZEPH_METRICS_HOST` environment block from prometheus service |
| `docker/prometheus/prometheus.yml` | Add comment explaining env var substitution is not supported |
| `book/src/guides/prometheus.md` | Rewrite "Custom Metrics Host" section to use direct file editing |
| `src/metrics_export.rs` | Add `120.0` to `LATENCY_BUCKETS` |
| `crates/zeph-core/src/agent/tool_execution/tests.rs` | Add `histogram_recorder_wiring` module (T-HR-1, T-HR-2, T-HR-4) |
| `crates/zeph-core/src/agent/tool_execution/native.rs` | Add T-HR-3 in existing tests module |
| `CHANGELOG.md` | Update `[Unreleased]` section |

## Test plan

- [x] `cargo +nightly fmt --check` — PASS
- [x] `cargo clippy --workspace --features full -- -D warnings` — PASS (0 warnings)
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 7809 passed, 17 skipped
- [x] T-HR-1 `with_histogram_recorder_sets_some` — PASS
- [x] T-HR-2 `flush_turn_timings_calls_observe_turn_duration` — PASS
- [x] T-HR-3 `record_chat_metrics_calls_observe_llm_latency` — PASS
- [x] T-HR-4 `handle_native_tool_calls_calls_observe_tool_execution` — PASS
- [x] `test_histogram_buckets_are_valid` (requires `--features prometheus`) — PASS