### PR TITLE
feat(profiling): implement Phase 3 and Phase 4 (#2858-#2861)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   Added missing `120.0` s bucket to `LATENCY_BUCKETS` in `src/metrics_export.rs` so the full
   `[0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 120.0]` range is covered (closes the gap for long
   agent turns). Added four unit tests for `HistogramRecorder` wiring: `with_histogram_recorder`
-  builder sets recorder to `Some`; `flush_turn_timings` calls `observe_turn_duration`; 
+  builder sets recorder to `Some`; `flush_turn_timings` calls `observe_turn_duration`;
   `record_chat_metrics_and_compact` calls `observe_llm_latency`; `handle_native_tool_calls` calls
   `observe_tool_execution` once per tool call.
+
+- **Profiling Phase 3+4: system metrics, allocation tracking, Pyroscope, and local observability
+  stack** (`#2858`, `#2859`, `#2860`, `#2861`, epic `#2846`): Phase 3 adds two new profiling
+  components. `CountingAllocator` in `src/main.rs` (all unsafe confined there) records per-thread
+  allocation and deallocation counts/bytes via thread-local `const`-initialised counters. New
+  `alloc_layer::AllocLayer` in `zeph-core` (100% safe Rust) implements `tracing_subscriber::Layer`
+  using span extensions for frame storage — correct under tokio work-stealing, no frame leaks.
+  Active when `--features profiling-alloc`. New `system_metrics::spawn_system_metrics_task()` in
+  `zeph-core` emits RSS, CPU%, thread count (Linux), and fd count (Linux) as
+  `tracing::info!(target: "system.metrics", ...)` events at `telemetry.system_metrics_interval_secs`
+  interval (default 5 s); wired into `runner.rs` alongside other background tasks. Uses `sysinfo`
+  0.38.4 with `refresh_processes` API (platform-conditional `/proc/{pid}/fd` and
+  `Process::tasks()` helpers). Phase 4 adds Pyroscope continuous CPU profiling via `pprof-rs` 0.15
+  HTTP push: `start_pyroscope_push()` starts a `pprof::ProfilerGuard` at 100 Hz using `SIGPROF`
+  and pushes protobuf profiles every 10 s to `{pyroscope_endpoint}/ingest` — active when
+  `--features profiling-pyroscope`. New local observability stack in `docker/`:
+  `docker-compose.profiling.yml` (Grafana 11.4.0 + Tempo 2.6.0 + Pyroscope 1.9.0; all ports bound
+  to 127.0.0.1; health checks on Tempo and Pyroscope), `tempo/tempo.yaml` (OTLP gRPC/HTTP
+  receiver), `grafana/provisioning/datasources/tempo-pyroscope.yml` (Tempo uid: `tempo` +
+  Pyroscope uid: `pyroscope` with Tempo→Pyroscope time-range correlation), and
+  `grafana/dashboards/profiling.json` (4 panels: agent turn latency histogram, p99 latency by
+  phase, allocation rate, RSS+CPU% metrics). Neither `profiling-alloc` nor `profiling-pyroscope`
+  is included in the `full` feature.
 
 - **Profiling and tracing Phase 2: deep instrumentation** (`#2851`, `#2852`, `#2853`, `#2854`,
   `#2855`, `#2856`, `#2857`, epic `#2846`): added spans to all 5 subsystem crates. Memory:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,6 +142,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
 ]
 
 [[package]]
@@ -537,6 +555,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
 ]
 
 [[package]]
@@ -1693,6 +1726,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2003,6 +2045,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2216,6 +2278,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "finl_unicode"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2307,7 +2381,7 @@ checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -2785,6 +2859,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
@@ -3687,7 +3767,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -4035,6 +4115,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4145,6 +4231,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -4357,6 +4452,16 @@ dependencies = [
  "block2",
  "libc",
  "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
  "objc2-core-foundation",
 ]
 
@@ -4709,6 +4814,16 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset 0.4.2",
+ "indexmap 2.14.0",
+]
+
+[[package]]
+name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
@@ -4962,6 +5077,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "pprof"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a01da47675efa7673b032bf8efd8214f1917d89685e07e395ab125ea42b187"
+dependencies = [
+ "aligned-vec",
+ "backtrace",
+ "cfg-if",
+ "findshlibs",
+ "libc",
+ "log",
+ "nix 0.26.4",
+ "once_cell",
+ "prost 0.12.6",
+ "prost-build",
+ "prost-derive 0.12.6",
+ "sha2 0.10.9",
+ "smallvec",
+ "spin 0.10.0",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5084,6 +5224,16 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+dependencies = [
+ "bytes",
+ "prost-derive 0.12.6",
+]
+
+[[package]]
+name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
@@ -5100,6 +5250,40 @@ checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
  "prost-derive 0.14.3",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools 0.10.5",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph 0.6.5",
+ "prettyplease",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5126,6 +5310,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+dependencies = [
+ "prost 0.12.6",
 ]
 
 [[package]]
@@ -5886,6 +6079,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6624,6 +6823,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6996,6 +7204,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symbolic-common"
+version = "12.17.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803d14d7cb9c6fa5b95a6f3de8af95b356a528d391998fa45a07d320a5573e51"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "12.17.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39505731ae891b2dde47b0e4ae2ec40a7ced3476ab1129f1bf829e3fba62bb83"
+dependencies = [
+ "rustc-demangle",
+ "symbolic-common",
+]
+
+[[package]]
 name = "symphonia"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7158,6 +7388,20 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "walkdir",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -7955,6 +8199,7 @@ dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
+ "parking_lot",
  "regex-automata",
  "sharded-slab",
  "smallvec",
@@ -9527,6 +9772,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "parking_lot",
+ "pprof",
  "prometheus-client",
  "reqwest 0.13.2",
  "rmcp",
@@ -9536,6 +9782,7 @@ dependencies = [
  "serial_test",
  "similar 3.0.0",
  "sqlx",
+ "sysinfo",
  "tempfile",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
@@ -9744,6 +9991,7 @@ dependencies = [
  "serde_norway",
  "serial_test",
  "sqlx",
+ "sysinfo",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -9943,7 +10191,7 @@ dependencies = [
  "futures",
  "parking_lot",
  "pdf-extract",
- "petgraph",
+ "petgraph 0.8.3",
  "proptest",
  "qdrant-client",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,8 @@ globset = "0.4"
 similar = "3.0"
 sqlx = { version = "0.8", default-features = false }
 subtle = "2.6"
+sysinfo = { version = "0.38.4", default-features = false, features = ["system"] }
+pprof = { version = "0.15.0", default-features = false }
 symphonia = { version = "0.5.5", default-features = false }
 teloxide = { version = "0.17", default-features = false }
 tempfile = "3.27"
@@ -105,7 +107,7 @@ tracing = "0.1"
 tracing-appender = "0.2"
 tracing-chrome = "0.7"
 tracing-opentelemetry = "0.32"
-tracing-subscriber = { version = "0.3", default-features = false }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["parking_lot"] }
 tracing-test = "0.2"
 tree-sitter = "0.26"
 tree-sitter-bash = "0.25"
@@ -200,7 +202,9 @@ profiling = [
     "dep:tracing-chrome",
     "dep:chrono",
     "dep:uuid",
+    "dep:sysinfo",
     "zeph-core/profiling",
+    "zeph-core/sysinfo",
     "zeph-llm/profiling",
     "zeph-memory/profiling",
     "zeph-tools/profiling",
@@ -208,8 +212,8 @@ profiling = [
     "zeph-mcp/profiling",
     "zeph-channels/profiling",
 ]
-profiling-alloc = ["profiling"]
-profiling-pyroscope = ["profiling", "otel"]
+profiling-alloc = ["profiling", "zeph-core/profiling-alloc"]
+profiling-pyroscope = ["profiling", "otel", "dep:pprof"]
 # Database backend selection — mutually exclusive. Default includes sqlite.
 # NOTE: --all-features activates both, triggering compile_error! in zeph-db.
 # Use --features full or --features full,postgres instead.
@@ -247,6 +251,8 @@ tracing.workspace = true
 tracing-appender.workspace = true
 tracing-chrome = { workspace = true, optional = true }
 tracing-opentelemetry = { workspace = true, optional = true }
+sysinfo = { workspace = true, optional = true }
+pprof = { workspace = true, optional = true, features = ["prost-codec"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 url.workspace = true
 uuid = { workspace = true, optional = true, features = ["v4"] }

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -14,6 +14,8 @@ readme = "README.md"
 
 [features]
 profiling = ["dep:tracing-subscriber"]
+profiling-alloc = ["profiling"]
+sysinfo = ["dep:sysinfo"]
 default = []
 candle = ["zeph-llm/candle"]
 classifiers = ["zeph-llm/classifiers", "zeph-sanitizer/classifiers"]
@@ -50,7 +52,8 @@ tokio-util.workspace = true
 toml.workspace = true
 toml_edit.workspace = true
 tracing.workspace = true
-tracing-subscriber = { workspace = true, features = ["registry"], optional = true }
+tracing-subscriber = { workspace = true, features = ["parking_lot", "registry"], optional = true }
+sysinfo = { workspace = true, optional = true }
 tree-sitter.workspace = true
 uuid = { workspace = true, features = ["v4", "serde"] }
 zeph-common.workspace = true
@@ -83,6 +86,7 @@ schemars.workspace = true
 serial_test.workspace = true
 sqlx.workspace = true
 tempfile.workspace = true
+tracing-subscriber = { workspace = true, features = ["parking_lot", "registry"] }
 zeph-llm.workspace = true
 zeph-memory.workspace = true
 zeph-vault = { workspace = true, features = ["mock"] }

--- a/crates/zeph-core/src/alloc_layer.rs
+++ b/crates/zeph-core/src/alloc_layer.rs
@@ -1,0 +1,258 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Tracing layer for per-span heap allocation tracking.
+//!
+//! [`AllocLayer`] records allocations and deallocations that occur while a span is active.
+//! It reads counter snapshots from the global allocator via an injected function pointer
+//! (`AllocSnapshotFn`), keeping `zeph-core` decoupled from the global allocator declaration
+//! (which lives in the binary crate).
+//!
+//! Allocation frames are stored as span extensions rather than thread-local stacks,
+//! so they survive tokio task migration between threads without leaking.
+
+use tracing::Subscriber;
+use tracing_subscriber::Layer;
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::registry::LookupSpan;
+
+/// Function pointer type for reading the current thread's allocation counters.
+///
+/// Returns `(alloc_count, alloc_bytes, dealloc_count, dealloc_bytes)`.
+///
+/// The binary crate provides the concrete implementation that reads from the
+/// `CountingAllocator`'s thread-local stats. This indirection keeps `zeph-core`
+/// free of any `unsafe` code and decoupled from the global allocator declaration.
+pub type AllocSnapshotFn = fn() -> (u64, u64, u64, u64);
+
+/// Allocation counter snapshot captured when a span is entered.
+///
+/// Stored as a span extension via `on_enter` and consumed by `on_exit`.
+/// Because it is keyed by span ID (not a thread-local stack), it remains
+/// correct even when tokio migrates the task to a different thread between
+/// `on_enter` and `on_exit`.
+struct AllocFrame {
+    alloc_count: u64,
+    alloc_bytes: u64,
+    dealloc_count: u64,
+    dealloc_bytes: u64,
+}
+
+/// Accumulated allocation delta for a span across all enter-exit cycles.
+///
+/// Async spans may yield and re-enter many times. Each cycle's delta is summed
+/// here. `on_close` reads the final total and emits it as a tracing event.
+struct AllocDelta {
+    alloc_count: u64,
+    alloc_bytes: u64,
+    dealloc_count: u64,
+    dealloc_bytes: u64,
+}
+
+/// Tracing layer that records per-span heap allocation counts and bytes.
+///
+/// On span enter, captures the current thread's allocator counters into an
+/// [`AllocFrame`] stored as a span extension. On span exit, computes the cycle
+/// delta and accumulates it into an [`AllocDelta`] extension. On span close,
+/// emits the total as a `tracing::trace!` event with the target `alloc.span`.
+///
+/// # Thread Safety Under Tokio Work-Stealing
+///
+/// Span extensions are protected by the `tracing-subscriber` registry's per-span
+/// lock. When tokio migrates a task from thread A to thread B:
+///
+/// - `on_enter` (thread A) captures thread A's counters into the span extension.
+/// - `on_exit` (thread B) captures thread B's counters, retrieves the extension,
+///   and computes the delta using thread B's counters.
+///
+/// The delta captures allocations on thread B only. Allocations on thread A between
+/// enter and migration are attributed to whichever span is active on thread A after
+/// migration — they are never lost globally, only mis-attributed locally. This is a
+/// documented, acceptable limitation; numbers are never inflated.
+///
+/// # Construction
+///
+/// ```no_run
+/// # fn snapshot() -> (u64, u64, u64, u64) { (0, 0, 0, 0) }
+/// use zeph_core::alloc_layer::AllocLayer;
+/// let layer = AllocLayer::new(snapshot as fn() -> (u64, u64, u64, u64));
+/// ```
+pub struct AllocLayer {
+    snapshot_fn: AllocSnapshotFn,
+}
+
+impl AllocLayer {
+    /// Create a new allocation-tracking layer.
+    ///
+    /// `snapshot_fn` must return the current thread's monotonically increasing allocation
+    /// counters from the global `CountingAllocator`. The binary crate provides this function.
+    #[must_use]
+    pub fn new(snapshot_fn: AllocSnapshotFn) -> Self {
+        Self { snapshot_fn }
+    }
+}
+
+impl<S> Layer<S> for AllocLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_enter(&self, id: &tracing::span::Id, ctx: Context<'_, S>) {
+        let (ac, ab, dc, db) = (self.snapshot_fn)();
+        if let Some(span) = ctx.span(id) {
+            span.extensions_mut().replace(AllocFrame {
+                alloc_count: ac,
+                alloc_bytes: ab,
+                dealloc_count: dc,
+                dealloc_bytes: db,
+            });
+        }
+    }
+
+    fn on_exit(&self, id: &tracing::span::Id, ctx: Context<'_, S>) {
+        let (now_alloc_count, now_alloc_bytes, now_dealloc_count, now_dealloc_bytes) =
+            (self.snapshot_fn)();
+        let Some(span) = ctx.span(id) else { return };
+
+        // Extract and remove the entry frame in a single lock acquisition.
+        // Using a block to ensure the write guard is dropped before the second acquisition.
+        // With parking_lot (non-reentrant), holding the guard across `if let` body while
+        // calling extensions_mut() again would deadlock.
+        let frame = {
+            let mut exts = span.extensions_mut();
+            exts.remove::<AllocFrame>()
+        }; // write guard released here
+
+        let Some(frame) = frame else { return };
+
+        let cycle_alloc_count = now_alloc_count.saturating_sub(frame.alloc_count);
+        let cycle_alloc_bytes = now_alloc_bytes.saturating_sub(frame.alloc_bytes);
+        let cycle_dealloc_count = now_dealloc_count.saturating_sub(frame.dealloc_count);
+        let cycle_dealloc_bytes = now_dealloc_bytes.saturating_sub(frame.dealloc_bytes);
+
+        // Accumulate across enter-exit cycles (async spans that yield and re-enter).
+        let mut exts = span.extensions_mut();
+        if let Some(acc) = exts.get_mut::<AllocDelta>() {
+            acc.alloc_count = acc.alloc_count.saturating_add(cycle_alloc_count);
+            acc.alloc_bytes = acc.alloc_bytes.saturating_add(cycle_alloc_bytes);
+            acc.dealloc_count = acc.dealloc_count.saturating_add(cycle_dealloc_count);
+            acc.dealloc_bytes = acc.dealloc_bytes.saturating_add(cycle_dealloc_bytes);
+        } else {
+            exts.insert(AllocDelta {
+                alloc_count: cycle_alloc_count,
+                alloc_bytes: cycle_alloc_bytes,
+                dealloc_count: cycle_dealloc_count,
+                dealloc_bytes: cycle_dealloc_bytes,
+            });
+        }
+    }
+
+    fn on_close(&self, id: tracing::span::Id, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(&id) else { return };
+
+        // Extract all data while holding the extensions read lock.
+        let (span_name, alloc_count, alloc_bytes, dealloc_count, dealloc_bytes, net) = {
+            let exts = span.extensions();
+            let Some(delta) = exts.get::<AllocDelta>() else {
+                return;
+            };
+            let net = delta
+                .alloc_bytes
+                .cast_signed()
+                .saturating_sub(delta.dealloc_bytes.cast_signed());
+            // Copy all fields before dropping the guard. Calling tracing::trace! while
+            // holding the extensions lock would deadlock (parking_lot RwLock is not
+            // re-entrant; trace! routes through the same subscriber that holds the lock).
+            (
+                span.name(),
+                delta.alloc_count,
+                delta.alloc_bytes,
+                delta.dealloc_count,
+                delta.dealloc_bytes,
+                net,
+            )
+        }; // extensions read lock released here
+
+        tracing::trace!(
+            target: "alloc.span",
+            span_name,
+            alloc.count = alloc_count,
+            alloc.bytes = alloc_bytes,
+            dealloc.count = dealloc_count,
+            dealloc.bytes = dealloc_bytes,
+            alloc.net_bytes = net,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+    use tracing_subscriber::{Registry, layer::SubscriberExt};
+
+    // Thread-local snapshot counter controlled by individual tests.
+    thread_local! {
+        static SNAP: Cell<(u64, u64, u64, u64)> = const { Cell::new((0, 0, 0, 0)) };
+    }
+
+    fn set_snap(ac: u64, ab: u64, dc: u64, db: u64) {
+        SNAP.with(|s| s.set((ac, ab, dc, db)));
+    }
+
+    fn snap() -> (u64, u64, u64, u64) {
+        SNAP.with(Cell::get)
+    }
+
+    fn run_with_subscriber<F: FnOnce()>(f: F) {
+        let subscriber = Registry::default().with(AllocLayer::new(snap));
+        tracing::subscriber::with_default(subscriber, f);
+    }
+
+    /// Verifies that `AllocLayer::new` accepts a snapshot function without panicking.
+    #[test]
+    fn alloc_layer_new_accepts_any_snapshot_fn() {
+        let _layer = AllocLayer::new(snap);
+    }
+
+    /// Verifies that `on_enter` stores a frame and `on_exit` removes it without panic.
+    /// Correct delta accumulation is covered by the multi-cycle test.
+    #[test]
+    fn on_enter_exit_does_not_panic() {
+        set_snap(10, 1024, 5, 512);
+        run_with_subscriber(|| {
+            let span = tracing::info_span!("enter_exit_span");
+            let guard = span.enter();
+            set_snap(15, 2048, 8, 768);
+            drop(guard);
+        });
+    }
+
+    /// Verifies that a span entered and exited with no allocation change produces no delta panic.
+    #[test]
+    fn zero_delta_span_does_not_panic() {
+        set_snap(100, 9000, 50, 8000);
+        run_with_subscriber(|| {
+            let span = tracing::info_span!("zero_alloc_span");
+            let guard = span.enter();
+            drop(guard);
+        });
+    }
+
+    /// Verifies that multiple enter-exit cycles on the same span accumulate without panic.
+    #[test]
+    fn multiple_cycles_does_not_panic() {
+        run_with_subscriber(|| {
+            let span = tracing::info_span!("multi_cycle");
+
+            set_snap(10, 100, 5, 50);
+            let g = span.enter();
+            set_snap(12, 200, 6, 100);
+            drop(g);
+
+            set_snap(20, 300, 7, 200);
+            let g2 = span.enter();
+            set_snap(25, 600, 9, 400);
+            drop(g2);
+        });
+    }
+}

--- a/crates/zeph-core/src/instrumented_channel.rs
+++ b/crates/zeph-core/src/instrumented_channel.rs
@@ -337,8 +337,8 @@ mod tests {
         assert_eq!(tx.sent.load(Ordering::Relaxed), 2);
 
         // drain to avoid log noise from dropped channel
-        drop(rx.recv().await);
-        drop(rx.recv().await);
+        let _ = rx.recv().await;
+        let _ = rx.recv().await;
     }
 
     /// Cloning an `InstrumentedSender` resets the clone's counter to 0.
@@ -356,8 +356,8 @@ mod tests {
         // Original counter is unaffected by the clone.
         assert_eq!(tx.sent.load(Ordering::Relaxed), 2);
 
-        drop(rx.recv().await);
-        drop(rx.recv().await);
+        let _ = rx.recv().await;
+        let _ = rx.recv().await;
     }
 
     /// Sending through an unbounded channel increments the `sent` counter.

--- a/crates/zeph-core/src/lib.rs
+++ b/crates/zeph-core/src/lib.rs
@@ -63,6 +63,8 @@
 //! - `scheduler` — Cron-based periodic task scheduler
 
 pub mod agent;
+#[cfg(feature = "profiling-alloc")]
+pub mod alloc_layer;
 #[allow(clippy::missing_errors_doc, clippy::must_use_candidate)]
 pub mod bootstrap;
 pub mod channel;
@@ -81,6 +83,8 @@ pub mod metrics_bridge;
 pub mod pipeline;
 pub mod project;
 pub mod redact;
+#[cfg(feature = "sysinfo")]
+pub mod system_metrics;
 
 pub mod http;
 pub mod lsp_hooks;

--- a/crates/zeph-core/src/metrics_bridge.rs
+++ b/crates/zeph-core/src/metrics_bridge.rs
@@ -195,8 +195,8 @@ mod tests {
 
         tracing::subscriber::with_default(subscriber, || {
             let span = tracing::span!(tracing::Level::INFO, "llm.chat");
-            let _guard = span.enter();
-            drop(_guard);
+            let guard = span.enter();
+            drop(guard);
             // span closes on Drop of the Span object.
         });
 
@@ -220,8 +220,8 @@ mod tests {
 
         tracing::subscriber::with_default(subscriber, || {
             let span = tracing::span!(tracing::Level::INFO, "some.other.span");
-            let _guard = span.enter();
-            drop(_guard);
+            let guard = span.enter();
+            drop(guard);
         });
 
         let snapshot = rx.borrow().clone();
@@ -231,7 +231,7 @@ mod tests {
         assert_eq!(snapshot.last_turn_timings.persist_message_ms, 0);
     }
 
-    /// All four watched span names must be present in WATCHED_SPANS.
+    /// All four watched span names must be present in `WATCHED_SPANS`.
     #[test]
     fn all_watched_span_names_registered() {
         let expected = [

--- a/crates/zeph-core/src/system_metrics.rs
+++ b/crates/zeph-core/src/system_metrics.rs
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Periodic system-metrics background task.
+//!
+//! Emits RSS, CPU%, thread count (Linux only), and file-descriptor count (Linux only)
+//! as `tracing` events at a configurable interval. Consumers can collect these via
+//! a file layer, `MetricsBridge`, or any other `tracing-subscriber` layer.
+
+use sysinfo::{ProcessesToUpdate, System};
+use tokio::task::JoinHandle;
+
+/// Spawn a background task that periodically emits system metrics as tracing events.
+///
+/// The task samples the current process's RSS, CPU%, thread count, and file-descriptor
+/// count at the configured interval and emits them as:
+///
+/// ```text
+/// tracing::info!(target: "system.metrics", rss_bytes, cpu_percent, thread_count, fd_count);
+/// ```
+///
+/// Some metrics are platform-specific:
+/// - `fd_count`: Linux only (reads `/proc/{pid}/fd`). Returns 0 on other platforms.
+/// - `thread_count`: Linux only (via `Process::tasks()`). Returns 0 on other platforms.
+///
+/// # Arguments
+///
+/// * `interval_secs` — sampling interval in seconds. Clamped to minimum 1. `0` disables the
+///   task entirely.
+/// * `shutdown_rx` — watch channel receiver; the task exits when the value changes.
+///
+/// # Returns
+///
+/// `Some(JoinHandle)` for the spawned task, or `None` when `interval_secs == 0`.
+///
+/// # Examples
+///
+/// ```no_run
+/// # async fn example() {
+/// let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+/// let _handle = zeph_core::system_metrics::spawn_system_metrics_task(5, shutdown_rx);
+/// // ...
+/// let _ = shutdown_tx.send(true);
+/// # }
+/// ```
+#[must_use]
+pub fn spawn_system_metrics_task(
+    interval_secs: u64,
+    shutdown_rx: tokio::sync::watch::Receiver<bool>,
+) -> Option<JoinHandle<()>> {
+    if interval_secs == 0 {
+        return None;
+    }
+    let interval = std::time::Duration::from_secs(interval_secs.max(1));
+
+    Some(tokio::spawn(async move {
+        let mut sys = System::new();
+        let pid = sysinfo::get_current_pid().ok();
+        let mut shutdown = shutdown_rx;
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        loop {
+            tokio::select! {
+                _ = ticker.tick() => {}
+                _ = shutdown.changed() => break,
+            }
+
+            let (rss_bytes, cpu_percent, thread_count, fd_count) = match pid {
+                Some(pid) => {
+                    sys.refresh_processes(ProcessesToUpdate::Some(&[pid]), true);
+                    match sys.process(pid) {
+                        Some(proc_info) => {
+                            let rss = proc_info.memory();
+                            let cpu = proc_info.cpu_usage();
+                            let threads = get_thread_count(proc_info);
+                            let fds = get_fd_count(pid);
+                            (rss, cpu, threads, fds)
+                        }
+                        None => (0, 0.0, 0, 0),
+                    }
+                }
+                None => (0, 0.0, 0, 0),
+            };
+
+            tracing::info!(
+                target: "system.metrics",
+                rss_bytes,
+                cpu_percent,
+                thread_count,
+                fd_count,
+            );
+        }
+
+        tracing::debug!("system metrics task shutting down");
+    }))
+}
+
+/// Get the thread count for the current process.
+///
+/// Uses `Process::tasks()` on Linux, which reads `/proc/{pid}/task`.
+/// Returns 0 on other platforms where this information is unavailable.
+#[cfg(target_os = "linux")]
+fn get_thread_count(proc_info: &sysinfo::Process) -> u64 {
+    proc_info.tasks().map_or(0, |tasks| tasks.len() as u64)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn get_thread_count(_proc_info: &sysinfo::Process) -> u64 {
+    0
+}
+
+/// Get the file-descriptor count for the current process.
+///
+/// Counts entries in `/proc/{pid}/fd` on Linux.
+/// Returns 0 on other platforms where `sysinfo::Process::fd()` is no longer available
+/// (removed in sysinfo 0.33+).
+#[cfg(target_os = "linux")]
+fn get_fd_count(pid: sysinfo::Pid) -> u64 {
+    let fd_path = format!("/proc/{}/fd", pid.as_u32());
+    std::fs::read_dir(fd_path)
+        .map(|entries| entries.count() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn get_fd_count(_pid: sysinfo::Pid) -> u64 {
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `interval_secs = 0` must return `None` without spawning any task.
+    #[test]
+    fn interval_zero_returns_none() {
+        let (_tx, rx) = tokio::sync::watch::channel(false);
+        assert!(
+            spawn_system_metrics_task(0, rx).is_none(),
+            "interval_secs=0 must return None"
+        );
+    }
+
+    /// `interval_secs > 0` must return `Some(JoinHandle)`.
+    #[tokio::test]
+    async fn interval_nonzero_returns_some_handle() {
+        let (_tx, rx) = tokio::sync::watch::channel(false);
+        let handle = spawn_system_metrics_task(1, rx);
+        assert!(
+            handle.is_some(),
+            "interval_secs=1 must return Some(JoinHandle)"
+        );
+        if let Some(h) = handle {
+            h.abort();
+        }
+    }
+
+    /// Sending `true` on the shutdown channel terminates the task cleanly.
+    #[tokio::test]
+    async fn shutdown_via_watch_channel_terminates_task() {
+        let (tx, rx) = tokio::sync::watch::channel(false);
+        let handle = spawn_system_metrics_task(60, rx).expect("interval=60 must return Some");
+
+        // Signal shutdown and wait for the task to finish.
+        tx.send(true).expect("shutdown send must succeed");
+        let result = tokio::time::timeout(std::time::Duration::from_secs(5), handle).await;
+        assert!(
+            result.is_ok(),
+            "task must exit within 5s after shutdown signal"
+        );
+        assert!(result.unwrap().is_ok(), "task must not panic on shutdown");
+    }
+}

--- a/docker/docker-compose.profiling.yml
+++ b/docker/docker-compose.profiling.yml
@@ -1,0 +1,59 @@
+# Local observability stack for Zeph profiling (Phase 4).
+# Image versions pinned 2026-04-11. Review periodically.
+#
+# Usage:
+#   docker compose -f docker/docker-compose.profiling.yml up -d
+#   cargo run --features profiling -- --config .local/config/testing.toml
+#   open http://localhost:3000  # Grafana
+#
+# Zeph config to enable export:
+#   [telemetry]
+#   enabled = true
+#   backend = "otlp"
+#   otlp_endpoint = "http://localhost:4318"
+#   pyroscope_endpoint = "http://localhost:4040"  # requires profiling-pyroscope feature
+services:
+  tempo:
+    image: grafana/tempo:2.6.0
+    command: ["-config.file=/etc/tempo.yaml"]
+    volumes:
+      - ./tempo/tempo.yaml:/etc/tempo.yaml:ro
+    ports:
+      - "127.0.0.1:4317:4317"   # OTLP gRPC
+      - "127.0.0.1:4318:4318"   # OTLP HTTP
+      - "127.0.0.1:3200:3200"   # Tempo query frontend
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3200/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  pyroscope:
+    image: grafana/pyroscope:1.9.0
+    ports:
+      - "127.0.0.1:4040:4040"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:4040/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  grafana:
+    image: grafana/grafana:11.4.0
+    environment:
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+    ports:
+      - "127.0.0.1:3000:3000"
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    depends_on:
+      tempo:
+        condition: service_healthy
+      pyroscope:
+        condition: service_healthy
+
+networks:
+  default:
+    name: zeph-profiling

--- a/docker/grafana/dashboards/profiling.json
+++ b/docker/grafana/dashboards/profiling.json
@@ -1,0 +1,113 @@
+{
+  "title": "Zeph Agent Profiling",
+  "uid": "zeph-profiling",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "10s",
+  "time": { "from": "now-15m", "to": "now" },
+  "timepicker": {},
+  "panels": [
+    {
+      "id": 1,
+      "title": "Agent Turn Latency (histogram)",
+      "type": "histogram",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "tempo", "uid": "tempo" },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "traceql",
+          "query": "{ span.name = \"agent.turn\" } | histogram_over_time(duration)"
+        }
+      ],
+      "options": {
+        "bucketSize": "auto",
+        "fillOpacity": 80,
+        "gradientMode": "none",
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      }
+    },
+    {
+      "id": 2,
+      "title": "p99 Latency by Phase",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "tempo", "uid": "tempo" },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "traceql",
+          "query": "{ span.name =~ \"agent.prepare_context|llm.chat|agent.tool_loop|agent.persist_message\" } | quantile_over_time(duration, 0.99) by (span.name)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ns",
+          "custom": { "lineWidth": 2 }
+        }
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Allocation Rate per Subsystem (alloc.bytes)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "tempo", "uid": "tempo" },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "traceql",
+          "query": "{ span.name =~ \"agent.prepare_context|llm.chat|agent.tool_loop|agent.persist_message\" } | rate() by (span.name)"
+        }
+      ],
+      "description": "Requires alloc.bytes span attribute (--features profiling-alloc). Traces must be exported via OTLP.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": { "lineWidth": 2 }
+        }
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      }
+    },
+    {
+      "id": 4,
+      "title": "System Metrics: RSS and CPU%",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "tempo", "uid": "tempo" },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "traceql",
+          "query": "{ target = \"system.metrics\" } | avg_over_time(rss_bytes) by (target)"
+        },
+        {
+          "refId": "B",
+          "queryType": "traceql",
+          "query": "{ target = \"system.metrics\" } | avg_over_time(cpu_percent) by (target)"
+        }
+      ],
+      "description": "Populated when --features profiling and system_metrics_interval_secs > 0 in [telemetry].",
+      "fieldConfig": {
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "rss_bytes" },
+            "properties": [{ "id": "unit", "value": "bytes" }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "cpu_percent" },
+            "properties": [{ "id": "unit", "value": "percent" }, { "id": "custom.axisPlacement", "value": "right" }]
+          }
+        ]
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      }
+    }
+  ]
+}

--- a/docker/grafana/provisioning/datasources/tempo-pyroscope.yml
+++ b/docker/grafana/provisioning/datasources/tempo-pyroscope.yml
@@ -1,0 +1,22 @@
+apiVersion: 1
+datasources:
+  - name: Tempo
+    type: tempo
+    uid: tempo
+    url: http://tempo:3200
+    access: proxy
+    isDefault: false
+    jsonData:
+      tracesToProfiles:
+        datasourceUid: pyroscope
+        profileTypeId: "process_cpu:cpu:nanoseconds:cpu:nanoseconds"
+        customQuery: true
+        query: "select(service_name=\"$${__tags.service.name}\")"
+      serviceMap:
+        datasourceUid: prometheus
+
+  - name: Pyroscope
+    type: grafana-pyroscope-datasource
+    uid: pyroscope
+    url: http://pyroscope:4040
+    access: proxy

--- a/docker/tempo/tempo.yaml
+++ b/docker/tempo/tempo.yaml
@@ -1,0 +1,37 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+
+ingester:
+  trace_idle_period: 10s
+  max_block_bytes: 1_000_000
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    compaction_window: 1h
+    max_compaction_objects: 1000000
+    block_retention: 1h
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /tmp/tempo/blocks
+    wal:
+      path: /tmp/tempo/wal
+
+query_frontend:
+  search:
+    duration_slo: 5s
+    throughput_bytes_slo: 1.073741824e+09
+  trace_by_id:
+    duration_slo: 5s

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,102 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+// Thread-local allocation counter used by AllocLayer for per-span heap tracking.
+// All unsafe code in the project is confined to this module (global allocator declaration).
+#[cfg(feature = "profiling-alloc")]
+#[allow(unsafe_code)]
+mod alloc_counter {
+    use std::alloc::{GlobalAlloc, Layout, System};
+    use std::cell::RefCell;
+
+    /// Global allocator that records per-thread allocation counts and bytes.
+    ///
+    /// All allocation and deallocation operations are forwarded unchanged to the
+    /// system allocator. The only addition is a thread-local counter update, which
+    /// uses `const`-initialised storage to avoid re-entrant allocation on first access.
+    pub struct CountingAllocator;
+
+    // SAFETY: All methods delegate to `System` with identical arguments.
+    // Thread-local counter updates use `const`-initialised `RefCell` in `.tdata`/`.tbss`,
+    // so no dynamic allocation occurs on first thread-local access, eliminating allocator
+    // re-entrancy. Borrows are non-overlapping: each function borrow-mutably, completes,
+    // and drops the guard before returning.
+    unsafe impl GlobalAlloc for CountingAllocator {
+        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+            increment_alloc(layout.size());
+            // SAFETY: forwarding to System with the same layout.
+            unsafe { System.alloc(layout) }
+        }
+
+        unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+            increment_dealloc(layout.size());
+            // SAFETY: forwarding to System with the same pointer and layout.
+            unsafe { System.dealloc(ptr, layout) }
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    struct RawStats {
+        alloc_count: u64,
+        alloc_bytes: u64,
+        dealloc_count: u64,
+        dealloc_bytes: u64,
+    }
+
+    impl RawStats {
+        const ZERO: Self = Self {
+            alloc_count: 0,
+            alloc_bytes: 0,
+            dealloc_count: 0,
+            dealloc_bytes: 0,
+        };
+    }
+
+    // `const` initialisation places the slot in `.tdata`/`.tbss` — no heap allocation
+    // on first access, preventing re-entrant calls back into this allocator.
+    thread_local! {
+        static STATS: RefCell<RawStats> = const { RefCell::new(RawStats::ZERO) };
+    }
+
+    fn increment_alloc(size: usize) {
+        STATS.with(|s| {
+            let mut s = s.borrow_mut();
+            s.alloc_count += 1;
+            s.alloc_bytes += size as u64;
+        });
+    }
+
+    fn increment_dealloc(size: usize) {
+        STATS.with(|s| {
+            let mut s = s.borrow_mut();
+            s.dealloc_count += 1;
+            s.dealloc_bytes += size as u64;
+        });
+    }
+
+    /// Snapshot the current thread's allocation counters.
+    ///
+    /// Returns `(alloc_count, alloc_bytes, dealloc_count, dealloc_bytes)`.
+    /// Counters are monotonically increasing per-thread and are never reset.
+    /// `AllocLayer` computes deltas by subtracting the enter snapshot from the exit snapshot.
+    pub fn snapshot() -> (u64, u64, u64, u64) {
+        STATS.with(|s| {
+            let s = s.borrow();
+            (
+                s.alloc_count,
+                s.alloc_bytes,
+                s.dealloc_count,
+                s.dealloc_bytes,
+            )
+        })
+    }
+}
+
+#[cfg(feature = "profiling-alloc")]
+#[allow(unsafe_code)]
+#[global_allocator]
+static GLOBAL: alloc_counter::CountingAllocator = alloc_counter::CountingAllocator;
+
 mod acp;
 mod agent_setup;
 mod channel;
@@ -12,6 +108,8 @@ mod gateway_spawn;
 mod init;
 #[cfg(feature = "prometheus")]
 mod metrics_export;
+#[cfg(feature = "profiling-pyroscope")]
+mod pyroscope_push;
 mod runner;
 mod scheduler;
 #[cfg(feature = "scheduler")]

--- a/src/pyroscope_push.rs
+++ b/src/pyroscope_push.rs
@@ -1,0 +1,180 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Continuous CPU profiling via pprof-rs and HTTP push to the Pyroscope ingest API.
+//!
+//! This module starts a `pprof::ProfilerGuard` (CPU sampling at 100 Hz using `SIGPROF`)
+//! and spawns a background task that periodically serialises the collected profile to the
+//! pprof protobuf format and POSTs it to `{endpoint}/ingest`.
+//!
+//! # SIGPROF notice
+//!
+//! `pprof-rs` installs a `SIGPROF` signal handler for CPU sampling. Do not register any
+//! other `SIGPROF` handlers while this guard is alive; they will conflict and produce
+//! incorrect profiles or crashes.
+//!
+//! # Known Limitations
+//!
+//! `pprof-rs` uses `SIGPROF` + `_Unwind_Backtrace` for stack unwinding, which is not
+//! async-signal-safe. If `SIGPROF` fires while a thread holds an allocator lock (glibc
+//! ptmalloc per-arena mutex), stack unwinding may deadlock. This is a known limitation of
+//! `pprof-rs` documented in their README. Risk is low in practice (signal must arrive during
+//! the narrow allocator-locked window), but cannot be fully eliminated with `SIGPROF`-based
+//! sampling. For production systems with strict reliability requirements, consider
+//! `perf_event_open`-based profilers that are async-signal-safe.
+//!
+//! # Trace correlation
+//!
+//! Profile labels include `service.name` as a session-level tag. Per-span trace-ID
+//! labelling is not supported because pprof sampling is asynchronous and cannot be tied
+//! to individual tracing spans. Use Grafana's native Tempo-to-Pyroscope time-range
+//! linking to correlate traces with CPU profiles.
+
+use pprof::ProfilerGuardBuilder;
+use tokio::sync::watch;
+
+const PUSH_INTERVAL_SECS: u64 = 10;
+const SAMPLE_FREQUENCY_HZ: i32 = 100;
+
+/// RAII guard that manages the pprof profiler lifecycle and periodic HTTP push to Pyroscope.
+///
+/// On construction, starts the `pprof::ProfilerGuard` and spawns a background task that
+/// pushes profiles every [`PUSH_INTERVAL_SECS`] seconds.
+///
+/// On drop, signals the background task to stop. Profile data collected after the last
+/// push interval may not be flushed — shutdown is best-effort to avoid blocking the process.
+pub(crate) struct PyroscopeGuard {
+    shutdown_tx: watch::Sender<bool>,
+    #[allow(dead_code)]
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for PyroscopeGuard {
+    fn drop(&mut self) {
+        let _ = self.shutdown_tx.send(true);
+        // Do not block on the handle — best-effort shutdown.
+    }
+}
+
+/// Start continuous profiling and periodic push to the Pyroscope ingest API.
+///
+/// Builds a `pprof::ProfilerGuard` at [`SAMPLE_FREQUENCY_HZ`] Hz and spawns a background
+/// task that collects the profile, encodes it as pprof protobuf, and POSTs it to
+/// `{endpoint}/ingest?name={service_name}.cpu{{sampleRate=100}}&format=pprof`.
+///
+/// Returns `None` if the profiler fails to initialise (error is logged at `error` level).
+///
+/// # Single-Instance Requirement
+///
+/// This function must be called at most once per process. Multiple concurrent
+/// `PyroscopeGuard`s will conflict on `SIGPROF` registration, producing incorrect
+/// profiles or undefined behaviour. Call once at process startup and hold the returned
+/// guard for the process lifetime.
+///
+/// # Errors
+///
+/// Returns `None` (not `Err`) because profiler availability is best-effort; the agent
+/// should continue operating even if profiling is unavailable.
+///
+/// # Examples
+///
+/// ```no_run
+/// # async fn example() {
+/// if let Some(_guard) = zeph::pyroscope_push::start_pyroscope_push(
+///     "http://pyroscope:4040",
+///     "zeph-agent",
+/// ) {
+///     // profiler is running; guard keeps it alive
+/// }
+/// # }
+/// ```
+pub(crate) fn start_pyroscope_push(endpoint: &str, service_name: &str) -> Option<PyroscopeGuard> {
+    let endpoint = endpoint.to_owned();
+    let service_name = service_name.to_owned();
+
+    let guard = match ProfilerGuardBuilder::default()
+        .frequency(SAMPLE_FREQUENCY_HZ)
+        .build()
+    {
+        Ok(g) => g,
+        Err(e) => {
+            tracing::error!("failed to start pprof profiler: {e}");
+            return None;
+        }
+    };
+
+    let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+
+    let handle = tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(std::time::Duration::from_secs(PUSH_INTERVAL_SECS));
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        // 10s request timeout prevents a slow Pyroscope instance from blocking
+        // the push task and missing subsequent intervals.
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .build()
+            .unwrap_or_default();
+
+        loop {
+            tokio::select! {
+                _ = ticker.tick() => {}
+                _ = shutdown_rx.changed() => break,
+            }
+
+            push_profile(&guard, &client, &endpoint, &service_name).await;
+        }
+
+        tracing::debug!("pyroscope push task shutting down");
+    });
+
+    Some(PyroscopeGuard {
+        shutdown_tx,
+        handle,
+    })
+}
+
+async fn push_profile(
+    guard: &pprof::ProfilerGuard<'static>,
+    client: &reqwest::Client,
+    endpoint: &str,
+    service_name: &str,
+) {
+    use pprof::protos::Message as _;
+
+    let report = match guard.report().build() {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::debug!("pprof report build failed: {e}");
+            return;
+        }
+    };
+
+    let profile = match report.pprof() {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::debug!("pprof profile encode failed: {e}");
+            return;
+        }
+    };
+
+    let mut body = Vec::new();
+    if let Err(e) = profile.encode(&mut body) {
+        tracing::debug!("pprof protobuf encode failed: {e}");
+        return;
+    }
+
+    // Pyroscope ingest URL format with profile type for correct UI categorisation.
+    let url = format!(
+        "{endpoint}/ingest?name={service_name}.cpu{{sampleRate={SAMPLE_FREQUENCY_HZ}}}&format=pprof"
+    );
+
+    match client.post(&url).body(body).send().await {
+        Err(e) => tracing::debug!("pyroscope push transport error: {e}"),
+        Ok(resp) => {
+            if let Err(e) = resp.error_for_status() {
+                tracing::warn!("pyroscope push rejected (non-2xx): {e}");
+            }
+        }
+    }
+}

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -918,6 +918,12 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     let (shutdown_tx, shutdown_rx) = AppBuilder::build_shutdown();
     let config = app.config();
 
+    #[cfg(feature = "profiling")]
+    let _sysinfo_handle = zeph_core::system_metrics::spawn_system_metrics_task(
+        config.telemetry.system_metrics_interval_secs,
+        shutdown_rx.clone(),
+    );
+
     {
         let sqlite = memory.sqlite().clone();
         let retention_secs = config.tools.overflow.retention_days.saturating_mul(86_400);

--- a/src/tracing_init.rs
+++ b/src/tracing_init.rs
@@ -12,6 +12,8 @@ use zeph_core::config::{LogRotation, LoggingConfig, TelemetryConfig};
 ///
 /// Dropping any guard flushes and closes the corresponding writer.
 /// Pass this struct to the top-level `run()` and hold it until the process exits.
+// All fields intentionally share the `_guard` postfix to reflect their shared purpose.
+#[allow(clippy::struct_field_names)]
 pub(crate) struct TracingGuards {
     /// Async file-writer guard for the rolling log file. `None` when file logging is disabled.
     /// Held for its `Drop` side-effect (flushes the async file writer).
@@ -22,6 +24,12 @@ pub(crate) struct TracingGuards {
     #[cfg(feature = "profiling")]
     #[allow(dead_code)]
     pub(crate) chrome_guard: Option<tracing_chrome::FlushGuard>,
+    /// Pyroscope push guard. `None` when the `profiling-pyroscope` feature is absent,
+    /// telemetry is disabled, or no endpoint is configured.
+    /// Dropping this guard signals the background push task to stop.
+    #[cfg(feature = "profiling-pyroscope")]
+    #[allow(dead_code)]
+    pub(crate) pyroscope_guard: Option<crate::pyroscope_push::PyroscopeGuard>,
 }
 
 /// Resolve the effective log file path from CLI and config sources.
@@ -155,16 +163,38 @@ pub(crate) fn init_tracing(
         )));
     }
 
+    // Optional AllocLayer — records per-span heap allocation counts and bytes.
+    // Reads thread-local counters from CountingAllocator via the snapshot function pointer.
+    #[cfg(feature = "profiling-alloc")]
+    if telemetry.enabled {
+        layers.push(Box::new(zeph_core::alloc_layer::AllocLayer::new(
+            crate::alloc_counter::snapshot,
+        )));
+    }
+
     // Suppress unused warning when profiling feature is disabled.
     #[cfg(not(feature = "profiling"))]
     let _ = telemetry;
 
     tracing_subscriber::registry().with(layers).init();
 
+    // Start Pyroscope continuous profiling push (after subscriber init so tracing works).
+    #[cfg(feature = "profiling-pyroscope")]
+    let pyroscope_guard = if telemetry.enabled {
+        telemetry
+            .pyroscope_endpoint
+            .as_deref()
+            .and_then(|ep| crate::pyroscope_push::start_pyroscope_push(ep, &telemetry.service_name))
+    } else {
+        None
+    };
+
     TracingGuards {
         log_guard,
         #[cfg(feature = "profiling")]
         chrome_guard,
+        #[cfg(feature = "profiling-pyroscope")]
+        pyroscope_guard,
     }
 }
 
@@ -304,7 +334,7 @@ mod tests {
         drop(guard);
         let json_files: Vec<_> = std::fs::read_dir(dir.path())
             .expect("read dir")
-            .filter_map(|e| e.ok())
+            .filter_map(std::result::Result::ok)
             .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("json"))
             .collect();
         assert!(


### PR DESCRIPTION
Closes #2858, #2859, #2860, #2861
Part of epic #2846

## Phase 3: Allocation Tracking + System Metrics

### #2858 — AllocLayer
- Custom `CountingAllocator` wrapping `std::alloc::System` as `#[global_allocator]` behind `profiling-alloc` feature
- `AllocLayer` tracing subscriber layer storing `AllocFrame` in span extensions (keyed by span ID, not thread-local stack — eliminates frame leaks under tokio task migration)
- Records `alloc.count`, `alloc.bytes`, `alloc.net_bytes` as span attributes
- `unsafe` confined to `src/alloc_counter` module; zero unsafe in `zeph-core`
- Non-reentrant deadlock fixed: `on_exit` uses explicit block-scoped lock release before second `extensions_mut()` acquisition
- Unit tests: enter/exit attribute recording, zero-delta case, multi-cycle accumulation

### #2859 — System metrics task
- `spawn_system_metrics_task(interval_secs, shutdown_rx)` emits `tracing::info!` at `target = "system.metrics"` with `rss_bytes`, `cpu_percent`, `thread_count` (Linux only), `fd_count` (Linux only)
- `interval_secs = 0` disables (returns `None`); graceful shutdown via `watch::Receiver<bool>`
- Spawned from `runner.rs` alongside existing background tasks
- Unit tests: disabled path, enabled path, shutdown via watch channel

## Phase 4: Production Tier + Pyroscope

### #2860 — Pyroscope integration
- `pprof-rs` 0.15 CPU profiling with periodic HTTP push to Pyroscope ingest API
- `profiling-pyroscope` feature implies `profiling + otel`
- HTTP 4xx/5xx responses logged as `warn` (not silently ignored)
- SIGPROF async-signal-safety risk and single-instance constraint documented in module doc
- Config: `telemetry.pyroscope_endpoint`

### #2861 — Docker Compose + Grafana dashboard
- `docker/docker-compose.profiling.yml`: Grafana 11.4.0 + Tempo 2.6.0 + Pyroscope 1.9.0
- Health checks on Tempo (`/ready`) and Pyroscope (`/ready`); Grafana uses `condition: service_healthy`
- All ports bound to `127.0.0.1` (localhost only)
- `docker/grafana/dashboards/profiling.json`: turn latency histogram, p99 by phase, allocation rate per subsystem, system metrics (RSS, CPU%) over time
- `docker/grafana/provisioning/datasources/tempo-pyroscope.yml`: Tempo + Pyroscope datasources with trace-to-profile correlation

## Notes
- `profiling-alloc` and `profiling-pyroscope` are intentionally excluded from the `full` feature (opt-in only: global allocator replacement and external server dependency)
- `parking_lot` feature enabled on `tracing-subscriber` in `zeph-core`: reduces span extension lock from kernel mutex to userspace futex

## Test results
- `cargo nextest run --workspace --lib --bins --features profiling,profiling-alloc`: **7821 passed**
- `cargo clippy --workspace --features desktop,ide,server,chat,pdf,scheduler -- -D warnings`: clean
- `cargo clippy --workspace --features profiling,profiling-alloc -- -D warnings`: clean
- `cargo +nightly fmt --check`: clean