### PR TITLE
feat(bench): add isolation, LongMemEval, tau-bench loaders, and baseline comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Bench isolation per scenario** (`#2830`): new `BenchIsolation` struct in `zeph-bench` providing
+  per-run `SQLite` database and Qdrant collection isolation. The Qdrant collection name follows
+  `bench_{dataset}_{run_id}` so production collections are never touched. `reset()` deletes the
+  `SQLite` file before each scenario run (uses `std::fs`, no extra tokio feature required).
+
+- **LongMemEval dataset loader** (`#2832`): `LongMemEvalLoader` (JSONL, one record per line) and
+  `LongMemEvalEvaluator` for the
+  [`xiaowu0162/longmemeval`](https://huggingface.co/datasets/xiaowu0162/longmemeval) benchmark.
+  Evaluator uses exact match as primary (`passed`) metric and token F1 as partial-credit `score`;
+  `details` reports both metrics.
+
+- **tau-bench dataset loader** (`#2838`): `TauBenchLoader` (JSON array) and `TauBenchEvaluator`
+  for the [`sierra-research/tau-bench`](https://github.com/sierra-research/tau-bench) benchmark.
+  Binary exact match: `score = 1.0` on pass, `0.0` on fail; `details` = `task_completion=true/false`.
+
+- **Baseline comparison** (`#2834`): `BaselineComparison::compute()` joins two `BenchRun`s
+  (memory-on vs memory-off) by scenario ID and computes per-scenario deltas and aggregate mean
+  delta. Writes `comparison.json` atomically and appends a `## Baseline Comparison` section to
+  `summary.md`.
+
 - **Prometheus metrics follow-up fixes** (`#2872`, `#2873`, `#2874`): removed dead
   `ZEPH_METRICS_HOST` environment variable from `docker/docker-compose.metrics.yml` (Prometheus
   does not support env var substitution in its config file; added a comment in

--- a/crates/zeph-bench/src/baseline.rs
+++ b/crates/zeph-bench/src/baseline.rs
@@ -1,0 +1,327 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::collections::HashMap;
+use std::fmt::Write as _;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{BenchError, BenchRun};
+
+/// Score delta for a single scenario between memory-on and memory-off runs.
+///
+/// Produced by [`BaselineComparison::compute`] for each scenario that appears
+/// in both runs.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_bench::baseline::ScenarioDelta;
+///
+/// let delta = ScenarioDelta {
+///     scenario_id: "q_001".into(),
+///     score_with_memory: 1.0,
+///     score_without_memory: 0.5,
+///     delta: 0.5,
+/// };
+/// assert!(delta.delta > 0.0, "positive delta means memory helped");
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScenarioDelta {
+    /// Scenario identifier (matches [`crate::Scenario::id`]).
+    pub scenario_id: String,
+    /// Score from the memory-on run.
+    pub score_with_memory: f64,
+    /// Score from the memory-off run.
+    pub score_without_memory: f64,
+    /// `score_with_memory - score_without_memory`. Positive = memory helped.
+    pub delta: f64,
+}
+
+/// Comparison between two benchmark runs (memory-on vs memory-off).
+///
+/// Use [`BaselineComparison::compute`] to join two [`BenchRun`]s by scenario ID
+/// and compute per-scenario deltas and an aggregate mean delta.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_bench::{BenchRun, RunStatus, ScenarioResult, Aggregate};
+/// use zeph_bench::baseline::BaselineComparison;
+///
+/// fn make_run(run_id: &str, scores: &[(&str, f64)]) -> BenchRun {
+///     BenchRun {
+///         dataset: "test".into(),
+///         model: "model".into(),
+///         run_id: run_id.into(),
+///         started_at: "2026-01-01T00:00:00Z".into(),
+///         finished_at: "2026-01-01T00:01:00Z".into(),
+///         status: RunStatus::Completed,
+///         results: scores.iter().map(|(id, score)| ScenarioResult {
+///             scenario_id: id.to_string(),
+///             score: *score,
+///             response_excerpt: String::new(),
+///             error: None,
+///             elapsed_ms: 0,
+///         }).collect(),
+///         aggregate: Aggregate::default(),
+///     }
+/// }
+///
+/// let on = make_run("r1", &[("s1", 1.0), ("s2", 0.5)]);
+/// let off = make_run("r2", &[("s1", 0.5), ("s2", 0.0)]);
+/// let cmp = BaselineComparison::compute(&on, &off);
+/// assert_eq!(cmp.deltas.len(), 2);
+/// assert!((cmp.aggregate_delta - 0.5).abs() < f64::EPSILON);
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BaselineComparison {
+    /// Dataset name (from the memory-on run).
+    pub dataset: String,
+    /// Model identifier (from the memory-on run).
+    pub model: String,
+    /// Run ID of the memory-on run.
+    pub run_id_memory_on: String,
+    /// Run ID of the memory-off run.
+    pub run_id_memory_off: String,
+    /// Per-scenario deltas, sorted by `scenario_id`.
+    ///
+    /// Only scenarios present in **both** runs are included (inner join).
+    pub deltas: Vec<ScenarioDelta>,
+    /// Arithmetic mean of all `delta` values. `0.0` if no scenarios overlap.
+    pub aggregate_delta: f64,
+}
+
+impl BaselineComparison {
+    /// Compute deltas by joining `memory_on` and `memory_off` runs on `scenario_id`.
+    ///
+    /// Only scenarios present in **both** runs are included. Non-overlapping
+    /// scenarios are silently dropped. `aggregate_delta` is the arithmetic mean
+    /// of all per-scenario deltas; `0.0` when there are no overlapping scenarios.
+    #[must_use]
+    pub fn compute(memory_on: &BenchRun, memory_off: &BenchRun) -> Self {
+        let off_scores: HashMap<&str, f64> = memory_off
+            .results
+            .iter()
+            .map(|r| (r.scenario_id.as_str(), r.score))
+            .collect();
+
+        let mut deltas: Vec<ScenarioDelta> = memory_on
+            .results
+            .iter()
+            .filter_map(|r| {
+                let score_off = *off_scores.get(r.scenario_id.as_str())?;
+                Some(ScenarioDelta {
+                    scenario_id: r.scenario_id.clone(),
+                    score_with_memory: r.score,
+                    score_without_memory: score_off,
+                    delta: r.score - score_off,
+                })
+            })
+            .collect();
+
+        deltas.sort_by(|a, b| a.scenario_id.cmp(&b.scenario_id));
+
+        #[allow(clippy::cast_precision_loss)]
+        let aggregate_delta = if deltas.is_empty() {
+            0.0
+        } else {
+            deltas.iter().map(|d| d.delta).sum::<f64>() / deltas.len() as f64
+        };
+
+        Self {
+            dataset: memory_on.dataset.clone(),
+            model: memory_on.model.clone(),
+            run_id_memory_on: memory_on.run_id.clone(),
+            run_id_memory_off: memory_off.run_id.clone(),
+            deltas,
+            aggregate_delta,
+        }
+    }
+
+    /// Write this comparison as pretty-printed JSON to `{output_dir}/comparison.json`.
+    ///
+    /// The file is written atomically via a `.tmp` sibling + rename, so a concurrent
+    /// SIGINT cannot leave a half-written file.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BenchError::InvalidFormat`] on serialization failure and
+    /// [`BenchError::Io`] on write failure.
+    pub fn write_comparison_json(&self, output_dir: &Path) -> Result<(), BenchError> {
+        let json = serde_json::to_string_pretty(self)
+            .map_err(|e| BenchError::InvalidFormat(e.to_string()))?;
+        write_atomic(&output_dir.join("comparison.json"), json.as_bytes())?;
+        Ok(())
+    }
+
+    /// Append a delta table section to the Markdown file at `summary_path`.
+    ///
+    /// Creates the file if it does not exist. The section header is
+    /// `## Baseline Comparison (Memory On vs Off)` followed by a Markdown table
+    /// of per-scenario deltas and a final aggregate delta line.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BenchError::Io`] on read/write failure.
+    pub fn write_delta_table(&self, summary_path: &Path) -> Result<(), BenchError> {
+        use std::fs::OpenOptions;
+        use std::io::Write as _;
+
+        let mut section = String::new();
+        let _ = writeln!(section);
+        let _ = writeln!(section, "## Baseline Comparison (Memory On vs Off)");
+        let _ = writeln!(section);
+        let _ = writeln!(section, "| scenario_id | memory_on | memory_off | delta |");
+        let _ = writeln!(section, "|-------------|-----------|------------|-------|");
+        for d in &self.deltas {
+            let sign = if d.delta >= 0.0 { "+" } else { "" };
+            let _ = writeln!(
+                section,
+                "| {} | {:.4} | {:.4} | {sign}{:.4} |",
+                d.scenario_id, d.score_with_memory, d.score_without_memory, d.delta
+            );
+        }
+        let sign = if self.aggregate_delta >= 0.0 { "+" } else { "" };
+        let _ = writeln!(
+            section,
+            "\n**Aggregate delta**: {sign}{:.4} (mean score improvement with memory)",
+            self.aggregate_delta
+        );
+
+        let mut file = OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(summary_path)?;
+        file.write_all(section.as_bytes())?;
+        Ok(())
+    }
+}
+
+/// Write `data` to `path` atomically via a `.tmp` sibling + rename.
+fn write_atomic(path: &Path, data: &[u8]) -> Result<(), std::io::Error> {
+    let tmp = path.with_extension("tmp");
+    std::fs::write(&tmp, data)?;
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Aggregate, RunStatus, ScenarioResult};
+
+    fn make_run(run_id: &str, scores: &[(&str, f64)]) -> BenchRun {
+        BenchRun {
+            dataset: "test-dataset".into(),
+            model: "test-model".into(),
+            run_id: run_id.into(),
+            started_at: "2026-01-01T00:00:00Z".into(),
+            finished_at: "2026-01-01T00:01:00Z".into(),
+            status: RunStatus::Completed,
+            results: scores
+                .iter()
+                .map(|(id, score)| ScenarioResult {
+                    scenario_id: id.to_string(),
+                    score: *score,
+                    response_excerpt: String::new(),
+                    error: None,
+                    elapsed_ms: 0,
+                })
+                .collect(),
+            aggregate: Aggregate::default(),
+        }
+    }
+
+    #[test]
+    fn compute_correct_aggregate_delta() {
+        let on = make_run("r1", &[("s1", 1.0), ("s2", 0.5)]);
+        let off = make_run("r2", &[("s1", 0.5), ("s2", 0.0)]);
+        let cmp = BaselineComparison::compute(&on, &off);
+        assert_eq!(cmp.deltas.len(), 2);
+        // mean delta = (0.5 + 0.5) / 2 = 0.5
+        assert!((cmp.aggregate_delta - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn compute_handles_missing_scenarios_gracefully() {
+        // off run has s1 but not s2 — s2 is excluded from deltas
+        let on = make_run("r1", &[("s1", 1.0), ("s2", 0.5)]);
+        let off = make_run("r2", &[("s1", 0.5)]);
+        let cmp = BaselineComparison::compute(&on, &off);
+        assert_eq!(cmp.deltas.len(), 1);
+        assert_eq!(cmp.deltas[0].scenario_id, "s1");
+    }
+
+    #[test]
+    fn compute_empty_overlap_returns_zero_aggregate() {
+        let on = make_run("r1", &[("s1", 1.0)]);
+        let off = make_run("r2", &[("s2", 0.5)]);
+        let cmp = BaselineComparison::compute(&on, &off);
+        assert!(cmp.deltas.is_empty());
+        assert!(cmp.aggregate_delta.abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn compute_sorts_deltas_by_scenario_id() {
+        let on = make_run("r1", &[("z_last", 1.0), ("a_first", 0.5)]);
+        let off = make_run("r2", &[("z_last", 0.5), ("a_first", 0.0)]);
+        let cmp = BaselineComparison::compute(&on, &off);
+        assert_eq!(cmp.deltas[0].scenario_id, "a_first");
+        assert_eq!(cmp.deltas[1].scenario_id, "z_last");
+    }
+
+    #[test]
+    fn json_round_trip() {
+        let on = make_run("r1", &[("s1", 1.0)]);
+        let off = make_run("r2", &[("s1", 0.5)]);
+        let cmp = BaselineComparison::compute(&on, &off);
+        let json = serde_json::to_string_pretty(&cmp).unwrap();
+        let decoded: BaselineComparison = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.dataset, cmp.dataset);
+        assert_eq!(decoded.deltas.len(), 1);
+        assert!((decoded.aggregate_delta - cmp.aggregate_delta).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn write_delta_table_appends_section() {
+        let dir = tempfile::tempdir().unwrap();
+        let summary = dir.path().join("summary.md");
+        std::fs::write(&summary, "# Header\n").unwrap();
+        let on = make_run("r1", &[("s1", 1.0)]);
+        let off = make_run("r2", &[("s1", 0.5)]);
+        let cmp = BaselineComparison::compute(&on, &off);
+        cmp.write_delta_table(&summary).unwrap();
+        let content = std::fs::read_to_string(&summary).unwrap();
+        assert!(content.contains("# Header"));
+        assert!(content.contains("## Baseline Comparison"));
+        assert!(content.contains("s1"));
+    }
+
+    #[test]
+    fn write_delta_table_creates_file_if_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let summary = dir.path().join("new_summary.md");
+        let on = make_run("r1", &[("s1", 1.0)]);
+        let off = make_run("r2", &[("s1", 0.5)]);
+        let cmp = BaselineComparison::compute(&on, &off);
+        cmp.write_delta_table(&summary).unwrap();
+        assert!(summary.exists());
+        let content = std::fs::read_to_string(&summary).unwrap();
+        assert!(content.contains("## Baseline Comparison"));
+    }
+
+    #[test]
+    fn write_comparison_json_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let on = make_run("r1", &[("s1", 1.0)]);
+        let off = make_run("r2", &[("s1", 0.5)]);
+        let cmp = BaselineComparison::compute(&on, &off);
+        cmp.write_comparison_json(dir.path()).unwrap();
+        let json = std::fs::read_to_string(dir.path().join("comparison.json")).unwrap();
+        let decoded: BaselineComparison = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.run_id_memory_on, "r1");
+        assert_eq!(decoded.run_id_memory_off, "r2");
+    }
+}

--- a/crates/zeph-bench/src/isolation.rs
+++ b/crates/zeph-bench/src/isolation.rs
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::path::{Path, PathBuf};
+
+use crate::BenchError;
+
+/// Per-scenario storage isolation for benchmark runs.
+///
+/// Before each scenario starts, call [`reset`] to delete and recreate the
+/// bench-namespaced `SQLite` database so earlier scenario memories cannot
+/// contaminate later ones.
+///
+/// # Collection naming
+///
+/// The Qdrant collection name follows the pattern `bench_{dataset}_{run_id}`.
+/// Production collections (`zeph_memory`, `zeph_skills`, etc.) are never touched.
+///
+/// # Examples
+///
+/// ```
+/// use std::path::Path;
+/// use zeph_bench::BenchIsolation;
+///
+/// let iso = BenchIsolation::new("locomo", "run-2026-01-01", Path::new("/data/bench"));
+/// assert_eq!(iso.qdrant_collection, "bench_locomo_run-2026-01-01");
+/// assert!(iso.sqlite_db_path.ends_with("bench-run-2026-01-01.db"));
+/// ```
+///
+/// [`reset`]: BenchIsolation::reset
+pub struct BenchIsolation {
+    /// Qdrant collection name: `bench_{dataset}_{run_id}`.
+    pub qdrant_collection: String,
+    /// Absolute path to the bench-namespaced `SQLite` database.
+    pub sqlite_db_path: PathBuf,
+}
+
+impl BenchIsolation {
+    /// Create a new isolation context for a benchmark run.
+    ///
+    /// The Qdrant collection is named `bench_{dataset}_{run_id}` and the `SQLite`
+    /// database is placed at `{data_dir}/bench-{run_id}.db`.
+    ///
+    /// # Note
+    ///
+    /// `dataset` and `run_id` are not sanitized. Callers should use alphanumeric
+    /// values (plus hyphens/underscores) to ensure a valid Qdrant collection name
+    /// and a safe filesystem path component.
+    #[must_use]
+    pub fn new(dataset: &str, run_id: &str, data_dir: &Path) -> Self {
+        Self {
+            qdrant_collection: format!("bench_{dataset}_{run_id}"),
+            sqlite_db_path: data_dir.join(format!("bench-{run_id}.db")),
+        }
+    }
+
+    /// Reset isolation state for a fresh scenario run.
+    ///
+    /// Deletes the `SQLite` database file at [`sqlite_db_path`] if it exists, so
+    /// memories from a previous scenario cannot bleed into the next one.
+    ///
+    /// Qdrant isolation is currently a no-op: `zeph-bench` does not depend on
+    /// `qdrant-client`, so collection cleanup must be performed externally if
+    /// needed. The collection is overwritten on the next run anyway.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BenchError::Io`] if the `SQLite` file exists but cannot be deleted.
+    ///
+    /// [`sqlite_db_path`]: BenchIsolation::sqlite_db_path
+    // The async signature is part of the public API (callers may await it alongside
+    // other futures). The body is synchronous because file deletion is O(1) and
+    // std::fs is sufficient without the tokio "fs" feature.
+    #[allow(clippy::unused_async)]
+    pub async fn reset(&self) -> Result<(), BenchError> {
+        if self.sqlite_db_path.exists() {
+            // Use std::fs (not tokio::fs) to avoid requiring the tokio "fs" feature.
+            std::fs::remove_file(&self.sqlite_db_path)?;
+        }
+        // Qdrant isolation requires the qdrant feature; currently a no-op.
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+
+    #[test]
+    fn collection_name_follows_bench_prefix() {
+        let iso = BenchIsolation::new("locomo", "run42", Path::new("/tmp"));
+        assert!(iso.qdrant_collection.starts_with("bench_"));
+        assert!(!iso.qdrant_collection.contains("zeph_memory"));
+        assert!(!iso.qdrant_collection.contains("zeph_skills"));
+        assert_eq!(iso.qdrant_collection, "bench_locomo_run42");
+    }
+
+    #[test]
+    fn sqlite_path_inside_data_dir() {
+        let iso = BenchIsolation::new("locomo", "run42", Path::new("/data"));
+        assert_eq!(iso.sqlite_db_path, Path::new("/data/bench-run42.db"));
+    }
+
+    #[tokio::test]
+    async fn reset_deletes_sqlite_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let iso = BenchIsolation::new("test", "r1", dir.path());
+        std::fs::write(&iso.sqlite_db_path, b"data").unwrap();
+        iso.reset().await.unwrap();
+        assert!(!iso.sqlite_db_path.exists());
+    }
+
+    #[tokio::test]
+    async fn reset_succeeds_when_db_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let iso = BenchIsolation::new("test", "r1", dir.path());
+        // No file created — should not error.
+        iso.reset().await.unwrap();
+    }
+
+    /// Integration test: verifies the NFR-007 reset time budget.
+    #[tokio::test]
+    #[ignore]
+    async fn reset_completes_under_2_seconds() {
+        let dir = tempfile::tempdir().unwrap();
+        let iso = BenchIsolation::new("test", "timing", dir.path());
+        std::fs::write(&iso.sqlite_db_path, b"data").unwrap();
+        let start = std::time::Instant::now();
+        iso.reset().await.unwrap();
+        assert!(start.elapsed().as_secs() < 2, "reset exceeded 2s NFR-007");
+    }
+}

--- a/crates/zeph-bench/src/lib.rs
+++ b/crates/zeph-bench/src/lib.rs
@@ -49,29 +49,35 @@
 //!
 //! | Module | Purpose |
 //! |--------|---------|
+//! | [`baseline`] | Baseline comparison types and delta computation |
 //! | [`channel`] | Headless [`BenchmarkChannel`] that drives the agent without I/O |
 //! | [`cli`] | Clap subcommand definition ([`BenchCommand`]) |
 //! | [`dataset`] | Dataset registry and metadata types |
 //! | [`deterministic`] | Temperature-zero override helpers |
 //! | [`error`] | [`BenchError`] error type |
-//! | [`loaders`] | Concrete loaders for LOCOMO, FRAMES, and GAIA |
+//! | [`isolation`] | Per-scenario storage isolation ([`BenchIsolation`]) |
+//! | [`loaders`] | Concrete loaders for LOCOMO, FRAMES, GAIA, LongMemEval, and tau-bench |
 //! | [`results`] | Result types and [`ResultWriter`] |
 //! | [`scenario`] | Core traits ([`DatasetLoader`], [`Evaluator`]) and scoring helpers |
 
+pub mod baseline;
 pub mod channel;
 pub mod cli;
 pub mod dataset;
 pub mod deterministic;
 pub mod error;
+pub mod isolation;
 pub mod loaders;
 pub mod results;
 pub mod scenario;
 
+pub use baseline::{BaselineComparison, ScenarioDelta};
 pub use channel::BenchmarkChannel;
 pub use cli::BenchCommand;
 pub use dataset::{DatasetFormat, DatasetMeta, DatasetRegistry};
 pub use deterministic::apply_deterministic_overrides;
 pub use error::BenchError;
+pub use isolation::BenchIsolation;
 pub use results::{Aggregate, BenchRun, ResultWriter, RunStatus, ScenarioResult};
 pub use scenario::{
     DatasetLoader, EvalResult, Evaluator, Scenario, exact_match, gaia_normalized_exact_match,

--- a/crates/zeph-bench/src/loaders/longmemeval.rs
+++ b/crates/zeph-bench/src/loaders/longmemeval.rs
@@ -1,0 +1,220 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::{
+    io::{BufRead as _, BufReader},
+    path::Path,
+};
+
+use serde::Deserialize;
+
+use crate::{
+    error::BenchError,
+    scenario::{DatasetLoader, EvalResult, Evaluator, Scenario, exact_match, token_f1},
+};
+
+#[derive(Debug, Deserialize)]
+struct LongMemEvalItem {
+    question_id: String,
+    question: String,
+    answer: String,
+    session_id: String,
+    sessions: serde_json::Value,
+}
+
+/// Loads `LongMemEval` benchmark scenarios from a JSONL file.
+///
+/// **Source**: [`xiaowu0162/longmemeval`](https://huggingface.co/datasets/xiaowu0162/longmemeval)
+/// on `HuggingFace`.
+///
+/// **Schema**: one JSON object per line:
+/// ```json
+/// {"question_id":"q_001","question":"...","answer":"...","session_id":"sess_1","sessions":[...]}
+/// ```
+///
+/// Each non-empty line becomes one [`Scenario`]:
+/// - `id` — `question_id`
+/// - `prompt` — `question`
+/// - `expected` — `answer`
+/// - `metadata` — `{"session_id": ..., "sessions": [...]}`
+///
+/// Empty lines are skipped. Parse errors include the 1-based line number.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::path::Path;
+/// use zeph_bench::loaders::LongMemEvalLoader;
+/// use zeph_bench::scenario::DatasetLoader;
+///
+/// let scenarios = LongMemEvalLoader.load(Path::new("/data/longmemeval.jsonl")).unwrap();
+/// println!("loaded {} scenarios", scenarios.len());
+/// ```
+#[derive(Debug)]
+pub struct LongMemEvalLoader;
+
+impl DatasetLoader for LongMemEvalLoader {
+    fn name(&self) -> &'static str {
+        "longmemeval"
+    }
+
+    /// # Errors
+    ///
+    /// Returns [`BenchError::Io`] when the file cannot be read and
+    /// [`BenchError::InvalidFormat`] when a JSONL line cannot be parsed
+    /// (message includes the 1-based line number).
+    fn load(&self, path: &Path) -> Result<Vec<Scenario>, BenchError> {
+        let file = std::fs::File::open(path)?;
+        let reader = BufReader::new(file);
+
+        let mut scenarios = Vec::new();
+        for (idx, line) in reader.lines().enumerate() {
+            let line = line?;
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let item: LongMemEvalItem = serde_json::from_str(trimmed)
+                .map_err(|e| BenchError::InvalidFormat(format!("line {}: {e}", idx + 1)))?;
+
+            scenarios.push(Scenario {
+                id: item.question_id,
+                prompt: item.question,
+                expected: item.answer,
+                metadata: serde_json::json!({
+                    "session_id": item.session_id,
+                    "sessions": item.sessions,
+                }),
+            });
+        }
+        Ok(scenarios)
+    }
+}
+
+/// Evaluates `LongMemEval` responses using exact match as primary metric.
+///
+/// - `passed` = `exact_match(agent_response, expected)`
+/// - `score` = `1.0` if exact match, otherwise `token_f1` value (partial credit)
+/// - `details` = `"exact_match=true/false token_f1=0.XXXX"`
+///
+/// # Examples
+///
+/// ```
+/// use zeph_bench::{Scenario, loaders::LongMemEvalEvaluator};
+/// use zeph_bench::scenario::Evaluator;
+///
+/// let scenario = Scenario {
+///     id: "q1".into(),
+///     prompt: "What is Rust?".into(),
+///     expected: "A systems language".into(),
+///     metadata: serde_json::Value::Null,
+/// };
+///
+/// let result = LongMemEvalEvaluator.evaluate(&scenario, "A systems language");
+/// assert!(result.passed);
+/// assert!((result.score - 1.0).abs() < f64::EPSILON);
+/// ```
+#[derive(Debug)]
+pub struct LongMemEvalEvaluator;
+
+impl Evaluator for LongMemEvalEvaluator {
+    fn evaluate(&self, scenario: &Scenario, agent_response: &str) -> EvalResult {
+        let matched = exact_match(agent_response, &scenario.expected);
+        let f1 = token_f1(agent_response, &scenario.expected);
+        let score = if matched { 1.0 } else { f1 };
+        EvalResult {
+            scenario_id: scenario.id.clone(),
+            score,
+            passed: matched,
+            details: format!("exact_match={matched} token_f1={f1:.4}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIXTURE: &str = r#"{"question_id":"q1","question":"What is Rust?","answer":"A systems language","session_id":"s1","sessions":[]}
+{"question_id":"q2","question":"Is it fast?","answer":"Yes","session_id":"s1","sessions":[]}
+{"question_id":"q3","question":"Creator?","answer":"Graydon Hoare","session_id":"s2","sessions":[]}"#;
+
+    fn load_from_str(jsonl: &str) -> Vec<Scenario> {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("longmemeval.jsonl");
+        std::fs::write(&path, jsonl).unwrap();
+        LongMemEvalLoader.load(&path).unwrap()
+    }
+
+    #[test]
+    fn load_parses_scenario_count() {
+        assert_eq!(load_from_str(FIXTURE).len(), 3);
+    }
+
+    #[test]
+    fn load_builds_correct_ids() {
+        let scenarios = load_from_str(FIXTURE);
+        assert_eq!(scenarios[0].id, "q1");
+        assert_eq!(scenarios[1].id, "q2");
+        assert_eq!(scenarios[2].id, "q3");
+    }
+
+    #[test]
+    fn load_maps_prompt_and_expected() {
+        let scenarios = load_from_str(FIXTURE);
+        assert_eq!(scenarios[0].prompt, "What is Rust?");
+        assert_eq!(scenarios[0].expected, "A systems language");
+    }
+
+    #[test]
+    fn load_stores_session_id_in_metadata() {
+        let scenarios = load_from_str(FIXTURE);
+        assert_eq!(scenarios[0].metadata["session_id"], "s1");
+    }
+
+    #[test]
+    fn load_stores_sessions_in_metadata() {
+        let scenarios = load_from_str(FIXTURE);
+        assert!(scenarios[0].metadata["sessions"].is_array());
+    }
+
+    #[test]
+    fn evaluator_exact_match_passes() {
+        let scenarios = load_from_str(FIXTURE);
+        let result = LongMemEvalEvaluator.evaluate(&scenarios[0], "A systems language");
+        assert!(result.passed);
+        assert!((result.score - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn evaluator_wrong_answer_fails() {
+        let scenarios = load_from_str(FIXTURE);
+        let result = LongMemEvalEvaluator.evaluate(&scenarios[0], "A web framework");
+        assert!(!result.passed);
+    }
+
+    #[test]
+    fn evaluator_partial_overlap_gives_token_f1_score() {
+        let scenarios = load_from_str(FIXTURE);
+        // "A systems framework" overlaps with "A systems language" on "systems"
+        let result = LongMemEvalEvaluator.evaluate(&scenarios[0], "A systems framework");
+        assert!(!result.passed);
+        let expected_f1 = token_f1("A systems framework", "A systems language");
+        assert!((result.score - expected_f1).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn evaluator_details_contain_token_f1() {
+        let scenarios = load_from_str(FIXTURE);
+        let result = LongMemEvalEvaluator.evaluate(&scenarios[0], "some answer");
+        assert!(result.details.contains("token_f1="));
+    }
+
+    #[test]
+    fn load_invalid_jsonl_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.jsonl");
+        std::fs::write(&path, "not json\n").unwrap();
+        assert!(LongMemEvalLoader.load(&path).is_err());
+    }
+}

--- a/crates/zeph-bench/src/loaders/mod.rs
+++ b/crates/zeph-bench/src/loaders/mod.rs
@@ -8,6 +8,8 @@
 //! | LOCOMO | [`LocomoLoader`] | [`LocomoEvaluator`] | Token F1, threshold 0.5 |
 //! | FRAMES | [`FramesLoader`] | [`FramesEvaluator`] | Exact match (case-insensitive) |
 //! | GAIA | [`GaiaLoader`] | [`GaiaEvaluator`] | GAIA-normalized exact match |
+//! | LongMemEval | [`LongMemEvalLoader`] | [`LongMemEvalEvaluator`] | Exact match + token F1 |
+//! | tau-bench | [`TauBenchLoader`] | [`TauBenchEvaluator`] | Task completion rate |
 //!
 //! [`DatasetLoader`]: crate::DatasetLoader
 //! [`Evaluator`]: crate::Evaluator
@@ -15,7 +17,11 @@
 pub mod frames;
 pub mod gaia;
 pub mod locomo;
+pub mod longmemeval;
+pub mod tau_bench;
 
 pub use frames::{FramesEvaluator, FramesLoader};
 pub use gaia::{GaiaEvaluator, GaiaLoader};
 pub use locomo::{LocomoEvaluator, LocomoLoader};
+pub use longmemeval::{LongMemEvalEvaluator, LongMemEvalLoader};
+pub use tau_bench::{TauBenchEvaluator, TauBenchLoader};

--- a/crates/zeph-bench/src/loaders/tau_bench.rs
+++ b/crates/zeph-bench/src/loaders/tau_bench.rs
@@ -1,0 +1,213 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::{io::BufReader, path::Path};
+
+use serde::Deserialize;
+
+use crate::{
+    error::BenchError,
+    scenario::{DatasetLoader, EvalResult, Evaluator, Scenario, exact_match},
+};
+
+#[derive(Debug, Deserialize)]
+struct TauBenchTask {
+    task_id: String,
+    instruction: String,
+    expected_actions: Vec<String>,
+    ground_truth: String,
+    domain: String,
+}
+
+/// Loads tau-bench scenarios from a JSON array file.
+///
+/// **Source**: [`sierra-research/tau-bench`](https://github.com/sierra-research/tau-bench)
+/// on GitHub.
+///
+/// **Schema**: JSON array of task objects:
+/// ```json
+/// [{"task_id":"retail_001","instruction":"...","expected_actions":["search_product"],"ground_truth":"...","domain":"retail"}]
+/// ```
+///
+/// Each task becomes one [`Scenario`]:
+/// - `id` — `task_id`
+/// - `prompt` — `instruction`
+/// - `expected` — `ground_truth`
+/// - `metadata` — `{"domain": ..., "expected_actions": [...]}`
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::path::Path;
+/// use zeph_bench::loaders::TauBenchLoader;
+/// use zeph_bench::scenario::DatasetLoader;
+///
+/// let scenarios = TauBenchLoader.load(Path::new("/data/tau_bench.json")).unwrap();
+/// println!("loaded {} scenarios", scenarios.len());
+/// ```
+#[derive(Debug)]
+pub struct TauBenchLoader;
+
+impl DatasetLoader for TauBenchLoader {
+    fn name(&self) -> &'static str {
+        "tau-bench"
+    }
+
+    /// # Errors
+    ///
+    /// Returns [`BenchError::Io`] when the file cannot be read and
+    /// [`BenchError::InvalidFormat`] when JSON parsing fails.
+    fn load(&self, path: &Path) -> Result<Vec<Scenario>, BenchError> {
+        let file = std::fs::File::open(path)?;
+        let reader = BufReader::new(file);
+        let tasks: Vec<TauBenchTask> = serde_json::from_reader(reader)
+            .map_err(|e| BenchError::InvalidFormat(e.to_string()))?;
+
+        let scenarios = tasks
+            .into_iter()
+            .map(|t| Scenario {
+                id: t.task_id,
+                prompt: t.instruction,
+                expected: t.ground_truth,
+                metadata: serde_json::json!({
+                    "domain": t.domain,
+                    "expected_actions": t.expected_actions,
+                }),
+            })
+            .collect();
+        Ok(scenarios)
+    }
+}
+
+/// Evaluates tau-bench responses using binary exact match.
+///
+/// - `passed` = `exact_match(agent_response, ground_truth)`
+/// - `score` = `1.0` if passed, `0.0` otherwise
+/// - `details` = `"task_completion=true/false"`
+///
+/// # Examples
+///
+/// ```
+/// use zeph_bench::{Scenario, loaders::TauBenchEvaluator};
+/// use zeph_bench::scenario::Evaluator;
+///
+/// let scenario = Scenario {
+///     id: "retail_001".into(),
+///     prompt: "Find a product".into(),
+///     expected: "found item XYZ".into(),
+///     metadata: serde_json::Value::Null,
+/// };
+///
+/// let result = TauBenchEvaluator.evaluate(&scenario, "found item XYZ");
+/// assert!(result.passed);
+/// assert!((result.score - 1.0).abs() < f64::EPSILON);
+/// ```
+#[derive(Debug)]
+pub struct TauBenchEvaluator;
+
+impl Evaluator for TauBenchEvaluator {
+    fn evaluate(&self, scenario: &Scenario, agent_response: &str) -> EvalResult {
+        let passed = exact_match(agent_response, &scenario.expected);
+        EvalResult {
+            scenario_id: scenario.id.clone(),
+            score: if passed { 1.0 } else { 0.0 },
+            passed,
+            details: format!("task_completion={}", if passed { "true" } else { "false" }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIXTURE: &str = r#"[
+        {
+            "task_id": "retail_001",
+            "instruction": "Find product X",
+            "expected_actions": ["search", "select"],
+            "ground_truth": "Product X found",
+            "domain": "retail"
+        },
+        {
+            "task_id": "airline_002",
+            "instruction": "Book flight to Paris",
+            "expected_actions": ["search_flight", "book"],
+            "ground_truth": "Flight booked",
+            "domain": "airline"
+        }
+    ]"#;
+
+    fn load_from_str(json: &str) -> Vec<Scenario> {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tau_bench.json");
+        std::fs::write(&path, json).unwrap();
+        TauBenchLoader.load(&path).unwrap()
+    }
+
+    #[test]
+    fn load_parses_scenario_count() {
+        assert_eq!(load_from_str(FIXTURE).len(), 2);
+    }
+
+    #[test]
+    fn load_builds_correct_ids() {
+        let scenarios = load_from_str(FIXTURE);
+        assert_eq!(scenarios[0].id, "retail_001");
+        assert_eq!(scenarios[1].id, "airline_002");
+    }
+
+    #[test]
+    fn load_maps_prompt_and_expected() {
+        let scenarios = load_from_str(FIXTURE);
+        assert_eq!(scenarios[0].prompt, "Find product X");
+        assert_eq!(scenarios[0].expected, "Product X found");
+    }
+
+    #[test]
+    fn load_stores_domain_in_metadata() {
+        let scenarios = load_from_str(FIXTURE);
+        assert_eq!(scenarios[0].metadata["domain"], "retail");
+        assert_eq!(scenarios[1].metadata["domain"], "airline");
+    }
+
+    #[test]
+    fn load_stores_expected_actions_in_metadata() {
+        let scenarios = load_from_str(FIXTURE);
+        assert!(scenarios[0].metadata["expected_actions"].is_array());
+    }
+
+    #[test]
+    fn evaluator_exact_match_passes() {
+        let scenarios = load_from_str(FIXTURE);
+        let result = TauBenchEvaluator.evaluate(&scenarios[0], "Product X found");
+        assert!(result.passed);
+        assert!((result.score - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn evaluator_wrong_answer_fails() {
+        let scenarios = load_from_str(FIXTURE);
+        let result = TauBenchEvaluator.evaluate(&scenarios[0], "Product not found");
+        assert!(!result.passed);
+        assert!(result.score < f64::EPSILON);
+    }
+
+    #[test]
+    fn evaluator_details_format() {
+        let scenarios = load_from_str(FIXTURE);
+        let pass_result = TauBenchEvaluator.evaluate(&scenarios[0], "Product X found");
+        assert_eq!(pass_result.details, "task_completion=true");
+
+        let fail_result = TauBenchEvaluator.evaluate(&scenarios[0], "wrong answer");
+        assert_eq!(fail_result.details, "task_completion=false");
+    }
+
+    #[test]
+    fn load_invalid_json_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.json");
+        std::fs::write(&path, "not json").unwrap();
+        assert!(TauBenchLoader.load(&path).is_err());
+    }
+}


### PR DESCRIPTION
Closes #2830, #2832, #2834, #2838

## Summary

- **BenchIsolation** (#2830): per-scenario `SQLite` database and Qdrant collection isolation. Collection name follows `bench_{dataset}_{run_id}`; production collections are never touched. `reset()` uses `std::fs` to avoid requiring the tokio `"fs"` feature.
- **LongMemEvalLoader + LongMemEvalEvaluator** (#2832): JSONL loader for `xiaowu0162/longmemeval`. Streams via `BufReader`. Evaluator uses `exact_match` as primary metric and `token_f1` for partial-credit score; both reported in `details`.
- **TauBenchLoader + TauBenchEvaluator** (#2838): JSON array loader for `sierra-research/tau-bench`. Streams via `BufReader` + `serde_json::from_reader`. Binary exact match; `details = task_completion=true/false`.
- **BaselineComparison + ScenarioDelta** (#2834): joins two `BenchRun` results (memory-on vs memory-off) by scenario ID, computes per-scenario deltas and aggregate mean delta. Writes `comparison.json` atomically and appends a `## Baseline Comparison` section to `summary.md`.

All new types follow the existing `locomo`/`frames`/`gaia` patterns. No new dependencies added.

## Test plan

- [ ] `cargo +nightly fmt --check` — PASS
- [ ] `cargo clippy --workspace -- -D warnings` — PASS (0 warnings)
- [ ] `cargo nextest run --workspace --lib --bins` — 7840/7840 PASS
- [ ] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features -p zeph-bench` — PASS
- [ ] `cargo test --doc -p zeph-bench` — 47/47 PASS
- [ ] Live bench run with real dataset files — see `.local/testing/playbooks/bench-datasets.md`