### PR TITLE
feat(core): introduce Turn domain type and CommandRegistry (#2895, #2896)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Turn domain type** (`#2895`): introduced `Turn` as a first-class domain entity in
+  `zeph-core::agent::turn`. Phase 1 includes `TurnId` (per-conversation monotonic newtype),
+  `TurnInput` (text + image parts), `TurnMetrics` (wraps `TurnTimings`), and `Turn` itself with
+  four fields: `id`, `input`, `metrics`, `cancel_token`. `Agent::process_user_message` now uses
+  `begin_turn`/`end_turn` lifecycle methods, making turn-level tracing and metrics deterministic.
+  Enables future per-turn metrics, cost tracking, and turn replay (Phase 2).
+
+- **CommandRegistry** (`#2896`): extracted slash command dispatch into a trait-based
+  `CommandRegistry<C>` in `zeph-core::agent::command_registry`. Introduces `CommandHandler<C>`
+  (object-safe via `Pin<Box<dyn Future>>`), `CommandContext<'_, C>` (lifetime-bound subsystem
+  borrows), and `CommandOutput` enum (`Message` / `Silent` / `Exit` / `Continue`). Batch 1
+  handlers migrated: `/exit`, `/quit`, `/clear`, `/reset`, `/clear-queue`, `/debug-dump`,
+  `/dump-format`, `/log`. Registry dispatches first; unregistered commands fall through to the
+  existing dispatcher. Enables independent handler unit testing and runtime command enumeration.
+  Batch 2/3 migration deferred to follow-up PRs.
+
 - **OTLP tracing pipeline wired** (`#2881`): `init_tracing` now activates the
   `tracing-opentelemetry` layer when `telemetry.enabled = true` and `backend = "otlp"` (requires
   `--features otel` or `--features server`). Spans are exported to an OTLP gRPC collector

--- a/crates/zeph-core/src/agent/command_registry.rs
+++ b/crates/zeph-core/src/agent/command_registry.rs
@@ -1,0 +1,560 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Trait-based registry for slash command handlers.
+//!
+//! Replaces the hand-written `if`-chain dispatch in `handle_builtin_command` and
+//! `dispatch_slash_command` with a unified `CommandRegistry` that supports `register`,
+//! `dispatch`, and `list`. Handlers are registered once at agent initialization and
+//! dispatched via longest-word-boundary matching.
+//!
+//! # Phase 1 scope
+//!
+//! The registry infrastructure and Batch 1 (trivial, self-contained) commands are implemented
+//! here. Batch 2 and Batch 3 commands continue to dispatch through the existing `Agent<C>`
+//! methods as a fallback until they are migrated in a follow-up PR.
+//!
+//! # Dispatch algorithm
+//!
+//! 1. Input must start with `/` to be considered a slash command.
+//! 2. All registered handlers whose `name()` exactly matches the input, or whose `name()` is a
+//!    word-boundary prefix of the input (i.e., `input.starts_with(name + " ")`), are collected.
+//! 3. The handler with the longest matching name wins (subcommand resolution: `/plan confirm`
+//!    beats `/plan`).
+//! 4. `args` is extracted as `input[name.len()..].trim()`.
+//! 5. Returns `None` when no handler matches, signalling the caller to fall through to the
+//!    existing dispatch logic or LLM processing.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use zeph_llm::any::AnyProvider;
+use zeph_tools::executor::ErasedToolExecutor;
+
+use crate::channel::Channel;
+
+use super::context_manager;
+use super::error::AgentError;
+use super::focus;
+use super::learning_engine;
+use super::sidequest;
+use super::state::{
+    CompressionState, DebugState, ExperimentState, FeedbackState, IndexState, LifecycleState,
+    McpState, MemoryState, MessageState, MetricsState, OrchestrationState, ProviderState,
+    RuntimeConfig, SecurityState, SkillState, ToolState,
+};
+use super::tool_orchestrator;
+
+/// Result of executing a slash command.
+///
+/// Replaces the heterogeneous return types of `handle_builtin_command`
+/// (`Option<bool>`) and `dispatch_slash_command` (`Option<Result<(), AgentError>>`)
+/// with a single, exhaustive enum.
+pub(crate) enum CommandOutput {
+    /// Send a message to the user via the channel.
+    Message(String),
+    /// Command handled silently; no output (e.g., `/clear`).
+    Silent,
+    /// Exit the agent loop immediately.
+    Exit,
+    /// Continue to the next loop iteration (command handled, don't process as LLM input).
+    Continue,
+}
+
+/// Category for grouping commands in `/help` output.
+// Used by CommandHandler implementations in commands/ and future /help handler.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SlashCategory {
+    /// Session management: `/clear`, `/reset`, `/exit`, etc.
+    Session,
+    /// Model and provider configuration: `/model`, `/provider`, `/guardrail`, etc.
+    Configuration,
+    /// Memory and knowledge: `/memory`, `/graph`, `/compact`, etc.
+    Memory,
+    /// Skill management: `/skill`, `/skills`, etc.
+    Skills,
+    /// Planning and focus: `/plan`, `/focus`, `/sidequest`, etc.
+    Planning,
+    /// Debugging and diagnostics: `/debug-dump`, `/log`, `/lsp`, etc.
+    Debugging,
+    /// External integrations: `/mcp`, `/image`, `/agent`, etc.
+    Integration,
+    /// Advanced and experimental: `/experiment`, `/policy`, `/scheduler`, etc.
+    Advanced,
+}
+
+impl SlashCategory {
+    /// Return the display label for this category in `/help` output.
+    // Used by future /help handler; suppressed until handler is wired.
+    #[must_use]
+    #[allow(dead_code)]
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Session => "Session",
+            Self::Configuration => "Configuration",
+            Self::Memory => "Memory",
+            Self::Skills => "Skills",
+            Self::Planning => "Planning",
+            Self::Debugging => "Debugging",
+            Self::Integration => "Integration",
+            Self::Advanced => "Advanced",
+        }
+    }
+}
+
+/// Static metadata about a registered command, used for `/help` output generation.
+// Fields read by future /help handler; suppressed until wired.
+#[allow(dead_code)]
+pub(crate) struct CommandInfo {
+    /// Command name including the leading slash, e.g. `"/help"`.
+    pub name: &'static str,
+    /// Argument hint shown after the command name in help, e.g. `"[path]"`.
+    pub args: &'static str,
+    /// One-line description shown in `/help` output.
+    pub description: &'static str,
+    /// Category for grouping in `/help`.
+    pub category: SlashCategory,
+    /// Feature gate label, if this command is conditionally compiled.
+    pub feature_gate: Option<&'static str>,
+}
+
+/// Typed access to agent subsystems needed by command handlers.
+///
+/// Constructed from `&mut Agent<C>` at dispatch time. Provides references to the subsystems
+/// that commands need, without requiring direct access to the full `Agent<C>` struct.
+///
+/// # Phase 1 design note
+///
+/// `CommandContext` contains references to all major agent subsystems because handlers in
+/// Phase 1 may have heterogeneous dependencies. Phase 2 will decompose this into narrower
+/// per-handler context types. This is a transitional design that enables Batch 2/3 delegation.
+///
+/// # Lifetime
+///
+/// The lifetime `'a` ties all references to the dispatch scope. A `CommandContext` must not
+/// outlive the `&mut Agent<C>` it was constructed from.
+// Fields used by handler implementations in commands/; not all read at link-time.
+#[allow(dead_code)]
+pub(crate) struct CommandContext<'a, C: Channel> {
+    /// I/O channel for sending responses to the user.
+    pub channel: &'a mut C,
+    /// Active LLM provider.
+    pub provider: &'a mut AnyProvider,
+    /// Dedicated embedding provider (never replaced by `/provider switch`).
+    pub embedding_provider: &'a AnyProvider,
+    /// Conversation message history and pending image parts.
+    pub msg: &'a mut MessageState,
+    /// Memory subsystems: persistence, compaction, extraction, subsystems.
+    pub memory_state: &'a mut MemoryState,
+    /// Skill registry, matcher, and self-learning state.
+    pub skill_state: &'a mut SkillState,
+    /// Context budgeting and summarization.
+    pub context_manager: &'a mut context_manager::ContextManager,
+    /// DAG-based tool execution with caching.
+    pub tool_orchestrator: &'a mut tool_orchestrator::ToolOrchestrator,
+    /// MCP server lifecycle and tool registry.
+    pub mcp: &'a mut McpState,
+    /// AST-based code index (read-only during command dispatch).
+    pub index: &'a IndexState,
+    /// Debug state: debug dumper, dump format, logging config, trace collector.
+    pub debug_state: &'a mut DebugState,
+    /// Runtime configuration: model name, adversarial policy info, etc.
+    pub runtime: &'a mut RuntimeConfig,
+    /// Session metrics snapshot (read-only during command dispatch).
+    pub metrics: &'a MetricsState,
+    /// Security state: guardrail, content sanitizer, URL tracking.
+    pub security: &'a mut SecurityState,
+    /// Orchestration state: sub-agent manager, orchestration metrics.
+    pub orchestration: &'a mut OrchestrationState,
+    /// Session lifecycle: cancel token, shutdown signal, start time.
+    pub lifecycle: &'a mut LifecycleState,
+    /// Focus Agent state (read-only during command dispatch).
+    pub focus: &'a focus::FocusState,
+    /// `SideQuest` state (read-only during command dispatch).
+    pub sidequest: &'a sidequest::SidequestState,
+    /// Provider registry for multi-model routing.
+    pub providers: &'a mut ProviderState,
+    /// Compression and subgoal registry state.
+    pub compression: &'a mut CompressionState,
+    /// Tool executor for shell, web, and custom tools.
+    pub tool_executor: &'a Arc<dyn ErasedToolExecutor>,
+    /// Experimental feature state.
+    pub experiments: &'a mut ExperimentState,
+    /// Feedback and correction tracking.
+    pub feedback: &'a mut FeedbackState,
+    /// Self-learning and skill evolution engine.
+    pub learning_engine: &'a mut learning_engine::LearningEngine,
+    /// Tool filtering, dependency tracking, and iteration bookkeeping.
+    pub tool_state: &'a mut ToolState,
+}
+
+/// A slash command handler that can be registered with the [`CommandRegistry`].
+///
+/// Implementors must be `Send + Sync` because the registry is constructed at agent
+/// initialization time and handlers may be invoked from async contexts.
+///
+/// # Object safety
+///
+/// The `handle` method uses `Pin<Box<dyn Future>>` instead of `async fn` to remain
+/// object-safe, enabling the registry to store `Box<dyn CommandHandler<C>>`. Slash commands
+/// are user-initiated, so the box allocation is negligible.
+// Trait methods called through dynamic dispatch; dead_code lint cannot track dyn usage.
+#[allow(dead_code)]
+pub(crate) trait CommandHandler<C: Channel>: Send + Sync {
+    /// Command name including the leading slash, e.g. `"/help"`.
+    ///
+    /// Must be unique per registry. Used as the dispatch key.
+    fn name(&self) -> &'static str;
+
+    /// One-line description shown in `/help` output.
+    fn description(&self) -> &'static str;
+
+    /// Argument hint shown after the command name in help, e.g. `"[path]"`.
+    ///
+    /// Return empty string if the command takes no arguments.
+    fn args_hint(&self) -> &'static str {
+        ""
+    }
+
+    /// Category for grouping in `/help`.
+    fn category(&self) -> SlashCategory;
+
+    /// Feature gate label, if this command is conditionally compiled.
+    ///
+    /// If `Some("feature_name")`, the command is only available when compiled with
+    /// `--features feature_name`.
+    fn feature_gate(&self) -> Option<&'static str> {
+        None
+    }
+
+    /// Execute the command.
+    ///
+    /// # Arguments
+    ///
+    /// - `ctx`: Typed access to agent subsystems.
+    /// - `args`: Trimmed text after the command name. For `/model gpt-4`, args is `"gpt-4"`.
+    ///   For commands that take no arguments, args is an empty string.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(AgentError)` when the command fails (I/O error, invalid args, etc.).
+    /// The error is logged and reported to the user by the dispatch site.
+    fn handle<'a>(
+        &'a self,
+        ctx: &'a mut CommandContext<'_, C>,
+        args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<CommandOutput, AgentError>> + Send + 'a>>;
+}
+
+/// Registry of slash command handlers.
+///
+/// Handlers are stored in a `Vec`, not a `HashMap`, because command count is small (< 40)
+/// and registration happens once at agent initialization. Dispatch performs a linear scan
+/// with longest-word-boundary match to support subcommands (e.g., `/plan confirm`, `/skill create`).
+///
+/// # Dispatch
+///
+/// See [`CommandRegistry::dispatch`] for the full dispatch algorithm.
+///
+/// # Borrow splitting
+///
+/// When stored as an `Agent<C>` field, the dispatch call site uses `std::mem::take` to
+/// temporarily move the registry out of the agent, construct a `CommandContext`, dispatch,
+/// and restore the registry. This avoids borrow-checker conflicts between `&self.command_registry`
+/// and `&mut self.channel`, `&mut self.msg`, etc.
+///
+/// ```rust,ignore
+/// let mut registry = std::mem::take(&mut self.command_registry);
+/// let result = registry.dispatch(&mut ctx, input).await;
+/// self.command_registry = registry;
+/// ```
+///
+/// # Panic safety
+///
+/// If a handler panics, `std::mem::take` leaves an empty registry for the rest of the session.
+/// Commands will fall through to the legacy dispatcher. This is a known Phase 1 limitation.
+pub(crate) struct CommandRegistry<C: Channel> {
+    handlers: Vec<Box<dyn CommandHandler<C>>>,
+}
+
+impl<C: Channel> CommandRegistry<C> {
+    /// Create an empty registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            handlers: Vec::new(),
+        }
+    }
+
+    /// Register a command handler.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a handler with the same name is already registered. Duplicate names indicate
+    /// a programming error (two handlers claiming the same command slot).
+    pub fn register(&mut self, handler: impl CommandHandler<C> + 'static) {
+        let name = handler.name();
+        assert!(
+            !self.handlers.iter().any(|h| h.name() == name),
+            "duplicate command name: {name}"
+        );
+        self.handlers.push(Box::new(handler));
+    }
+
+    /// Dispatch a command string to the matching handler.
+    ///
+    /// # Algorithm
+    ///
+    /// 1. Return `None` if `input` does not start with `/`.
+    /// 2. Find all handlers where `input == name` or `input.starts_with(name + " ")`.
+    /// 3. Pick the handler with the longest matching name (subcommand resolution).
+    /// 4. Extract `args = input[name.len()..].trim()`.
+    /// 5. Call `handler.handle(ctx, args)` and return the result.
+    /// 6. Return `None` if no handler matches (caller should fall through to existing dispatch).
+    ///
+    /// # Word-boundary matching
+    ///
+    /// Uses exact word-boundary matching: a match occurs if and only if
+    /// `input == name` OR `input.starts_with(name + " ")`. This prevents `/skillset` from
+    /// matching `/skill`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Some(Err(_))` when the matched handler returns an error.
+    pub async fn dispatch(
+        &self,
+        ctx: &mut CommandContext<'_, C>,
+        input: &str,
+    ) -> Option<Result<CommandOutput, AgentError>> {
+        let trimmed = input.trim();
+        if !trimmed.starts_with('/') {
+            return None;
+        }
+
+        // Collect all matching handlers with their match length.
+        let mut best_len: usize = 0;
+        let mut best_idx: Option<usize> = None;
+        for (idx, handler) in self.handlers.iter().enumerate() {
+            let name = handler.name();
+            let matched = trimmed == name
+                || trimmed
+                    .strip_prefix(name)
+                    .is_some_and(|rest| rest.starts_with(' '));
+            if matched && name.len() >= best_len {
+                best_len = name.len();
+                best_idx = Some(idx);
+            }
+        }
+
+        let handler = &self.handlers[best_idx?];
+        let name = handler.name();
+        let args = trimmed[name.len()..].trim();
+        Some(handler.handle(ctx, args).await)
+    }
+
+    /// Find the handler that would be selected for the given input, without dispatching.
+    ///
+    /// Returns `Some((idx, name))` with the index into the handler list and the matched command
+    /// name, or `None` if no handler matches. Uses the same word-boundary algorithm as
+    /// [`Self::dispatch`].
+    ///
+    /// Primarily used in tests to verify routing without constructing a [`CommandContext`].
+    // Used in tests; production dispatch goes through Self::dispatch.
+    #[allow(dead_code)]
+    pub(crate) fn find_handler(&self, input: &str) -> Option<(usize, &'static str)> {
+        let trimmed = input.trim();
+        if !trimmed.starts_with('/') {
+            return None;
+        }
+        let mut best_len: usize = 0;
+        let mut best: Option<(usize, &'static str)> = None;
+        for (idx, handler) in self.handlers.iter().enumerate() {
+            let name = handler.name();
+            let matched = trimmed == name
+                || trimmed
+                    .strip_prefix(name)
+                    .is_some_and(|rest| rest.starts_with(' '));
+            if matched && name.len() >= best_len {
+                best_len = name.len();
+                best = Some((idx, name));
+            }
+        }
+        best
+    }
+
+    /// List all registered commands for `/help` generation.
+    ///
+    /// Returns metadata in registration order.
+    // Called by future /help handler; not yet wired in Phase 1.
+    #[allow(dead_code)]
+    pub fn list(&self) -> Vec<CommandInfo> {
+        self.handlers
+            .iter()
+            .map(|h| CommandInfo {
+                name: h.name(),
+                args: h.args_hint(),
+                description: h.description(),
+                category: h.category(),
+                feature_gate: h.feature_gate(),
+            })
+            .collect()
+    }
+}
+
+impl<C: Channel> Default for CommandRegistry<C> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::channel::{Channel, ChannelError, ChannelMessage};
+
+    // --- Minimal stub channel for testing ---
+
+    struct StubChannel;
+
+    impl Channel for StubChannel {
+        async fn send(&mut self, _message: &str) -> Result<(), ChannelError> {
+            Ok(())
+        }
+
+        async fn send_chunk(&mut self, _chunk: &str) -> Result<(), ChannelError> {
+            Ok(())
+        }
+
+        async fn recv(&mut self) -> Result<Option<ChannelMessage>, ChannelError> {
+            Ok(None)
+        }
+
+        fn supports_exit(&self) -> bool {
+            true
+        }
+
+        async fn flush_chunks(&mut self) -> Result<(), ChannelError> {
+            Ok(())
+        }
+    }
+
+    // --- Test handlers (name-only, no ctx access) ---
+
+    struct NamedHandler {
+        name: &'static str,
+    }
+
+    impl CommandHandler<StubChannel> for NamedHandler {
+        fn name(&self) -> &'static str {
+            self.name
+        }
+        fn description(&self) -> &'static str {
+            "test handler"
+        }
+        fn category(&self) -> SlashCategory {
+            SlashCategory::Debugging
+        }
+        fn handle<'a>(
+            &'a self,
+            _ctx: &'a mut CommandContext<'_, StubChannel>,
+            _args: &'a str,
+        ) -> Pin<Box<dyn Future<Output = Result<CommandOutput, AgentError>> + Send + 'a>> {
+            let name = self.name;
+            Box::pin(async move { Ok(CommandOutput::Message(name.to_owned())) })
+        }
+    }
+
+    // --- list() tests ---
+
+    #[test]
+    fn list_returns_registered_entries() {
+        let mut reg: CommandRegistry<StubChannel> = CommandRegistry::new();
+        reg.register(NamedHandler { name: "/ping" });
+        reg.register(NamedHandler { name: "/exit" });
+
+        let list = reg.list();
+        assert_eq!(list.len(), 2);
+        assert_eq!(list[0].name, "/ping");
+        assert_eq!(list[1].name, "/exit");
+    }
+
+    #[test]
+    fn list_empty_when_no_handlers() {
+        let reg: CommandRegistry<StubChannel> = CommandRegistry::new();
+        assert!(reg.list().is_empty());
+    }
+
+    // --- dispatch word-boundary tests (via find_handler) ---
+    // These tests verify the matching algorithm without needing a CommandContext.
+
+    #[test]
+    fn find_handler_exact_match() {
+        let mut reg: CommandRegistry<StubChannel> = CommandRegistry::new();
+        reg.register(NamedHandler { name: "/ping" });
+        assert!(reg.find_handler("/ping").is_some());
+    }
+
+    #[test]
+    fn find_handler_no_spurious_prefix_match() {
+        let mut reg: CommandRegistry<StubChannel> = CommandRegistry::new();
+        reg.register(NamedHandler { name: "/ping" });
+        // /pingpong must NOT match /ping
+        assert!(reg.find_handler("/pingpong").is_none());
+    }
+
+    #[test]
+    fn find_handler_word_boundary_with_args() {
+        let mut reg: CommandRegistry<StubChannel> = CommandRegistry::new();
+        reg.register(NamedHandler { name: "/ping" });
+        // "/ping foo" should match /ping
+        assert!(reg.find_handler("/ping foo").is_some());
+    }
+
+    #[test]
+    fn find_handler_subcommand_picks_longest_match() {
+        let mut reg: CommandRegistry<StubChannel> = CommandRegistry::new();
+        reg.register(NamedHandler { name: "/ping" });
+        reg.register(NamedHandler {
+            name: "/ping verbose",
+        });
+        let (_, name) = reg.find_handler("/ping verbose").unwrap();
+        assert_eq!(name, "/ping verbose", "longer match must win");
+    }
+
+    #[test]
+    fn find_handler_none_for_non_slash() {
+        let reg: CommandRegistry<StubChannel> = CommandRegistry::new();
+        assert!(reg.find_handler("hello").is_none());
+    }
+
+    #[test]
+    fn find_handler_none_for_unknown_slash_command() {
+        let mut reg: CommandRegistry<StubChannel> = CommandRegistry::new();
+        reg.register(NamedHandler { name: "/ping" });
+        assert!(reg.find_handler("/unknown").is_none());
+    }
+
+    // --- /skill does NOT match /skillset ---
+
+    #[test]
+    fn find_handler_skill_does_not_match_skillset() {
+        let mut reg: CommandRegistry<StubChannel> = CommandRegistry::new();
+        reg.register(NamedHandler { name: "/skill" });
+        assert!(
+            reg.find_handler("/skillset").is_none(),
+            "/skillset must not match /skill"
+        );
+    }
+
+    // --- register duplicate panic test ---
+
+    #[test]
+    #[should_panic(expected = "duplicate command name: /ping")]
+    fn register_duplicate_panics() {
+        let mut reg: CommandRegistry<StubChannel> = CommandRegistry::new();
+        reg.register(NamedHandler { name: "/ping" });
+        reg.register(NamedHandler { name: "/ping" }); // second registration must panic
+    }
+}

--- a/crates/zeph-core/src/agent/commands/clear.rs
+++ b/crates/zeph-core/src/agent/commands/clear.rs
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Handlers for `/clear` and `/reset` slash commands.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use crate::channel::Channel;
+
+use super::super::command_registry::{
+    CommandContext, CommandHandler, CommandOutput, SlashCategory,
+};
+use super::super::error::AgentError;
+
+/// Clear conversation history and tool caches without sending a confirmation message.
+///
+/// Mirrors the logic of `Agent::clear_history()` + the original `/clear` inline cleanup:
+/// retains only the first (system prompt) message, clears completed tool IDs, recomputes
+/// prompt token count, clears the tool cache, pending images, and URL tracking.
+pub(crate) struct ClearCommand;
+
+impl<C: Channel> CommandHandler<C> for ClearCommand {
+    fn name(&self) -> &'static str {
+        "/clear"
+    }
+
+    fn description(&self) -> &'static str {
+        "Clear conversation history"
+    }
+
+    fn category(&self) -> SlashCategory {
+        SlashCategory::Session
+    }
+
+    fn handle<'a>(
+        &'a self,
+        ctx: &'a mut CommandContext<'_, C>,
+        _args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<CommandOutput, AgentError>> + Send + 'a>> {
+        Box::pin(async move {
+            clear_history(ctx);
+            Ok(CommandOutput::Silent)
+        })
+    }
+}
+
+/// Reset conversation history (alias for `/clear`, replies with confirmation).
+pub(crate) struct ResetCommand;
+
+impl<C: Channel> CommandHandler<C> for ResetCommand {
+    fn name(&self) -> &'static str {
+        "/reset"
+    }
+
+    fn description(&self) -> &'static str {
+        "Reset conversation history (alias for /clear, replies with confirmation)"
+    }
+
+    fn category(&self) -> SlashCategory {
+        SlashCategory::Session
+    }
+
+    fn handle<'a>(
+        &'a self,
+        ctx: &'a mut CommandContext<'_, C>,
+        _args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<CommandOutput, AgentError>> + Send + 'a>> {
+        Box::pin(async move {
+            clear_history(ctx);
+            Ok(CommandOutput::Message(
+                "Conversation history reset.".to_owned(),
+            ))
+        })
+    }
+}
+
+/// Shared history-clearing logic used by both `/clear` and `/reset`.
+///
+/// Mirrors `Agent::clear_history()` combined with the inline cleanup in the original
+/// `handle_builtin_command` handler.
+fn clear_history<C: Channel>(ctx: &mut CommandContext<'_, C>) {
+    // Keep only the first message (system prompt), matching Agent::clear_history().
+    let system_prompt = ctx.msg.messages.first().cloned();
+    ctx.msg.messages.clear();
+    if let Some(sp) = system_prompt {
+        ctx.msg.messages.push(sp);
+    }
+    // Clear tool dependency state (reset between conversations).
+    ctx.tool_state.completed_tool_ids.clear();
+    // Recompute cached prompt token count after truncation.
+    ctx.providers.cached_prompt_tokens = ctx
+        .msg
+        .messages
+        .iter()
+        .map(|m| ctx.metrics.token_counter.count_message_tokens(m) as u64)
+        .sum();
+    // Clear runtime per-turn caches.
+    ctx.msg.pending_image_parts.clear();
+    ctx.tool_orchestrator.clear_cache();
+    ctx.security.user_provided_urls.write().clear();
+}

--- a/crates/zeph-core/src/agent/commands/clear_queue.rs
+++ b/crates/zeph-core/src/agent/commands/clear_queue.rs
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Handler for `/clear-queue` slash command.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use crate::channel::Channel;
+
+use super::super::command_registry::{
+    CommandContext, CommandHandler, CommandOutput, SlashCategory,
+};
+use super::super::error::AgentError;
+
+/// Discard all messages currently queued for processing.
+pub(crate) struct ClearQueueCommand;
+
+impl<C: Channel> CommandHandler<C> for ClearQueueCommand {
+    fn name(&self) -> &'static str {
+        "/clear-queue"
+    }
+
+    fn description(&self) -> &'static str {
+        "Discard queued messages"
+    }
+
+    fn category(&self) -> SlashCategory {
+        SlashCategory::Session
+    }
+
+    fn handle<'a>(
+        &'a self,
+        ctx: &'a mut CommandContext<'_, C>,
+        _args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<CommandOutput, AgentError>> + Send + 'a>> {
+        Box::pin(async move {
+            let n = ctx.msg.message_queue.len();
+            ctx.msg.message_queue.clear();
+            // Notify channel of updated queue count (no-op for most channels).
+            let _ = ctx.channel.send_queue_count(0).await;
+            Ok(CommandOutput::Message(format!(
+                "Cleared {n} queued messages."
+            )))
+        })
+    }
+}

--- a/crates/zeph-core/src/agent/commands/debug_dump.rs
+++ b/crates/zeph-core/src/agent/commands/debug_dump.rs
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Handler for `/debug-dump` slash command.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use crate::channel::Channel;
+
+use super::super::command_registry::{
+    CommandContext, CommandHandler, CommandOutput, SlashCategory,
+};
+use super::super::error::AgentError;
+
+/// Enable or show the status of debug dump output.
+///
+/// With no arguments, reports whether debug dump is active and where.
+/// With a path argument, enables debug dump to that directory.
+pub(crate) struct DebugDumpCommand;
+
+impl<C: Channel> CommandHandler<C> for DebugDumpCommand {
+    fn name(&self) -> &'static str {
+        "/debug-dump"
+    }
+
+    fn description(&self) -> &'static str {
+        "Enable or toggle debug dump output"
+    }
+
+    fn args_hint(&self) -> &'static str {
+        "[path]"
+    }
+
+    fn category(&self) -> SlashCategory {
+        SlashCategory::Debugging
+    }
+
+    fn handle<'a>(
+        &'a self,
+        ctx: &'a mut CommandContext<'_, C>,
+        args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<CommandOutput, AgentError>> + Send + 'a>> {
+        Box::pin(async move {
+            if args.is_empty() {
+                let msg = match &ctx.debug_state.debug_dumper {
+                    Some(d) => format!("Debug dump active: {}", d.dir().display()),
+                    None => "Debug dump is inactive. Use `/debug-dump <path>` to enable, \
+                         or start with `--debug-dump [dir]`."
+                        .to_owned(),
+                };
+                return Ok(CommandOutput::Message(msg));
+            }
+
+            let dir = std::path::PathBuf::from(args);
+            match crate::debug_dump::DebugDumper::new(&dir, ctx.debug_state.dump_format) {
+                Ok(dumper) => {
+                    let path = dumper.dir().display().to_string();
+                    ctx.debug_state.debug_dumper = Some(dumper);
+                    Ok(CommandOutput::Message(format!(
+                        "Debug dump enabled: {path}"
+                    )))
+                }
+                Err(e) => Ok(CommandOutput::Message(format!(
+                    "Failed to enable debug dump: {e}"
+                ))),
+            }
+        })
+    }
+}

--- a/crates/zeph-core/src/agent/commands/dump_format.rs
+++ b/crates/zeph-core/src/agent/commands/dump_format.rs
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Handler for `/dump-format` slash command.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use crate::channel::Channel;
+
+use super::super::command_registry::{
+    CommandContext, CommandHandler, CommandOutput, SlashCategory,
+};
+use super::super::error::AgentError;
+
+/// Switch debug dump format at runtime.
+pub(crate) struct DumpFormatCommand;
+
+impl<C: Channel> CommandHandler<C> for DumpFormatCommand {
+    fn name(&self) -> &'static str {
+        "/dump-format"
+    }
+
+    fn description(&self) -> &'static str {
+        "Switch debug dump format at runtime"
+    }
+
+    fn args_hint(&self) -> &'static str {
+        "<json|raw|trace>"
+    }
+
+    fn category(&self) -> SlashCategory {
+        SlashCategory::Debugging
+    }
+
+    fn handle<'a>(
+        &'a self,
+        ctx: &'a mut CommandContext<'_, C>,
+        args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<CommandOutput, AgentError>> + Send + 'a>> {
+        Box::pin(async move {
+            if args.is_empty() {
+                return Ok(CommandOutput::Message(format!(
+                    "Current dump format: {:?}. Use `/dump-format json|raw|trace` to change.",
+                    ctx.debug_state.dump_format
+                )));
+            }
+
+            let new_format = match args {
+                "json" => crate::debug_dump::DumpFormat::Json,
+                "raw" => crate::debug_dump::DumpFormat::Raw,
+                "trace" => crate::debug_dump::DumpFormat::Trace,
+                other => {
+                    return Ok(CommandOutput::Message(format!(
+                        "Unknown format '{other}'. Valid values: json, raw, trace."
+                    )));
+                }
+            };
+
+            ctx.debug_state.switch_format(new_format);
+            Ok(CommandOutput::Message(format!(
+                "Debug dump format set to: {args}"
+            )))
+        })
+    }
+}

--- a/crates/zeph-core/src/agent/commands/exit.rs
+++ b/crates/zeph-core/src/agent/commands/exit.rs
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Handler for `/exit` and `/quit` slash commands.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use crate::channel::Channel;
+
+use super::super::command_registry::{
+    CommandContext, CommandHandler, CommandOutput, SlashCategory,
+};
+use super::super::error::AgentError;
+
+/// Exit the agent loop.
+///
+/// `/exit` and `/quit` are treated as aliases; both map to this handler via the registry.
+/// When the channel does not support exit (e.g., Telegram), the command is rejected with
+/// a user-visible message.
+pub(crate) struct ExitCommand;
+
+impl<C: Channel> CommandHandler<C> for ExitCommand {
+    fn name(&self) -> &'static str {
+        "/exit"
+    }
+
+    fn description(&self) -> &'static str {
+        "Exit the agent (also: /quit)"
+    }
+
+    fn category(&self) -> SlashCategory {
+        SlashCategory::Session
+    }
+
+    fn handle<'a>(
+        &'a self,
+        ctx: &'a mut CommandContext<'_, C>,
+        _args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<CommandOutput, AgentError>> + Send + 'a>> {
+        Box::pin(async move {
+            if ctx.channel.supports_exit() {
+                Ok(CommandOutput::Exit)
+            } else {
+                ctx.channel
+                    .send("/exit is not supported in this channel.")
+                    .await?;
+                Ok(CommandOutput::Continue)
+            }
+        })
+    }
+}
+
+/// Alias for `/exit`.
+pub(crate) struct QuitCommand;
+
+impl<C: Channel> CommandHandler<C> for QuitCommand {
+    fn name(&self) -> &'static str {
+        "/quit"
+    }
+
+    fn description(&self) -> &'static str {
+        "Exit the agent (alias for /exit)"
+    }
+
+    fn category(&self) -> SlashCategory {
+        SlashCategory::Session
+    }
+
+    fn handle<'a>(
+        &'a self,
+        ctx: &'a mut CommandContext<'_, C>,
+        _args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<CommandOutput, AgentError>> + Send + 'a>> {
+        Box::pin(async move {
+            if ctx.channel.supports_exit() {
+                Ok(CommandOutput::Exit)
+            } else {
+                ctx.channel
+                    .send("/exit is not supported in this channel.")
+                    .await?;
+                Ok(CommandOutput::Continue)
+            }
+        })
+    }
+}

--- a/crates/zeph-core/src/agent/commands/log.rs
+++ b/crates/zeph-core/src/agent/commands/log.rs
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Handler for `/log` slash command.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use crate::channel::Channel;
+
+use super::super::command_registry::{
+    CommandContext, CommandHandler, CommandOutput, SlashCategory,
+};
+use super::super::error::AgentError;
+use super::super::log_commands;
+
+/// Show log file path and recent log entries.
+pub(crate) struct LogCommand;
+
+impl<C: Channel> CommandHandler<C> for LogCommand {
+    fn name(&self) -> &'static str {
+        "/log"
+    }
+
+    fn description(&self) -> &'static str {
+        "Toggle verbose log output"
+    }
+
+    fn category(&self) -> SlashCategory {
+        SlashCategory::Debugging
+    }
+
+    fn handle<'a>(
+        &'a self,
+        ctx: &'a mut CommandContext<'_, C>,
+        _args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<CommandOutput, AgentError>> + Send + 'a>> {
+        Box::pin(async move {
+            use std::fmt::Write as _;
+
+            let logging = ctx.debug_state.logging_config.clone();
+            let mut out = String::new();
+            log_commands::format_logging_status(&logging, &mut out);
+
+            if !logging.file.is_empty() {
+                let base_path = std::path::PathBuf::from(&logging.file);
+                let tail = tokio::task::spawn_blocking(move || {
+                    let actual = log_commands::resolve_current_log_file(&base_path);
+                    actual.and_then(|p| log_commands::read_log_tail(&p, 20))
+                })
+                .await
+                .unwrap_or(None);
+
+                if let Some(lines) = tail {
+                    let _ = writeln!(out);
+                    let _ = writeln!(out, "Recent entries:");
+                    out.push_str(&crate::redact::scrub_content(&lines));
+                }
+            }
+
+            Ok(CommandOutput::Message(out.trim_end().to_owned()))
+        })
+    }
+}

--- a/crates/zeph-core/src/agent/commands/mod.rs
+++ b/crates/zeph-core/src/agent/commands/mod.rs
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Batch 1 slash command handler implementations.
+//!
+//! Each module contains a single command handler struct implementing [`CommandHandler<C>`].
+//! These are self-contained commands that do not require delegation to `Agent<C>` methods.
+//!
+//! [`CommandHandler<C>`]: super::command_registry::CommandHandler
+
+pub(super) mod clear;
+pub(super) mod clear_queue;
+pub(super) mod debug_dump;
+pub(super) mod dump_format;
+pub(super) mod exit;
+pub(super) mod log;

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -45,7 +45,7 @@ pub(crate) mod supervisor;
 pub(crate) mod tool_execution;
 pub(crate) mod tool_orchestrator;
 mod trust_commands;
-pub(crate) mod turn;
+pub mod turn;
 mod utils;
 
 use std::collections::{HashMap, VecDeque};

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -3,6 +3,8 @@
 
 mod autodream;
 mod builder;
+pub(crate) mod command_registry;
+mod commands;
 pub(crate) mod compaction_strategy;
 pub(super) mod compression_feedback;
 mod context;
@@ -43,6 +45,7 @@ pub(crate) mod supervisor;
 pub(crate) mod tool_execution;
 pub(crate) mod tool_orchestrator;
 mod trust_commands;
+pub(crate) mod turn;
 mod utils;
 
 use std::collections::{HashMap, VecDeque};
@@ -173,6 +176,11 @@ pub struct Agent<C: Channel> {
     pub(super) sidequest: sidequest::SidequestState,
     /// Tool filtering, dependency tracking, and iteration bookkeeping.
     pub(super) tool_state: ToolState,
+    /// Trait-based slash command registry (Batch 1 commands).
+    ///
+    /// Batch 2 and Batch 3 commands continue to dispatch through existing
+    /// `dispatch_slash_command` logic until they are migrated in a follow-up PR.
+    pub(super) command_registry: command_registry::CommandRegistry<C>,
 }
 
 impl<C: Channel> Agent<C> {
@@ -295,6 +303,7 @@ impl<C: Channel> Agent<C> {
             focus: focus::FocusState::default(),
             sidequest: sidequest::SidequestState::default(),
             tool_state: ToolState::default(),
+            command_registry: build_command_registry(),
         }
     }
 
@@ -715,6 +724,7 @@ impl<C: Channel> Agent<C> {
     /// # Errors
     ///
     /// Returns an error if the channel, LLM provider, or tool execution encounters a fatal error.
+    #[allow(clippy::too_many_lines)] // run loop is inherently large; each branch is independent
     pub async fn run(&mut self) -> Result<(), error::AgentError> {
         if let Some(mut rx) = self.lifecycle.warmup_ready.take()
             && !*rx.borrow()
@@ -813,6 +823,65 @@ impl<C: Channel> Agent<C> {
 
             let trimmed = text.trim();
 
+            // Registry dispatch (Batch 1: trivial self-contained commands).
+            // Uses std::mem::take to avoid borrow-checker conflict between &self.command_registry
+            // and the &mut subsystem borrows required by CommandContext.
+            let registry_handled = {
+                let reg = std::mem::take(&mut self.command_registry);
+                let mut ctx = command_registry::CommandContext {
+                    channel: &mut self.channel,
+                    provider: &mut self.provider,
+                    embedding_provider: &self.embedding_provider,
+                    msg: &mut self.msg,
+                    memory_state: &mut self.memory_state,
+                    skill_state: &mut self.skill_state,
+                    context_manager: &mut self.context_manager,
+                    tool_orchestrator: &mut self.tool_orchestrator,
+                    mcp: &mut self.mcp,
+                    index: &self.index,
+                    debug_state: &mut self.debug_state,
+                    runtime: &mut self.runtime,
+                    metrics: &self.metrics,
+                    security: &mut self.security,
+                    orchestration: &mut self.orchestration,
+                    lifecycle: &mut self.lifecycle,
+                    focus: &self.focus,
+                    sidequest: &self.sidequest,
+                    providers: &mut self.providers,
+                    compression: &mut self.compression,
+                    tool_executor: &self.tool_executor,
+                    experiments: &mut self.experiments,
+                    feedback: &mut self.feedback,
+                    learning_engine: &mut self.learning_engine,
+                    tool_state: &mut self.tool_state,
+                };
+                let result = reg.dispatch(&mut ctx, trimmed).await;
+                self.command_registry = reg;
+                result
+            };
+            match registry_handled {
+                Some(Ok(command_registry::CommandOutput::Exit)) => {
+                    let _ = self.channel.flush_chunks().await;
+                    break;
+                }
+                Some(Ok(
+                    command_registry::CommandOutput::Continue
+                    | command_registry::CommandOutput::Silent,
+                )) => {
+                    let _ = self.channel.flush_chunks().await;
+                    continue;
+                }
+                Some(Ok(command_registry::CommandOutput::Message(msg))) => {
+                    let _ = self.channel.send(&msg).await;
+                    let _ = self.channel.flush_chunks().await;
+                    continue;
+                }
+                Some(Err(e)) => return Err(e),
+                None => {
+                    // Not handled by registry; fall through to existing dispatch.
+                }
+            }
+
             match self.handle_builtin_command(trimmed).await? {
                 Some(true) => break,
                 Some(false) => continue,
@@ -832,82 +901,6 @@ impl<C: Channel> Agent<C> {
         }
 
         Ok(())
-    }
-
-    /// Handle `/debug-dump` and `/debug-dump <path>` commands.
-    async fn handle_debug_dump_command(&mut self, trimmed: &str) {
-        let arg = trimmed.strip_prefix("/debug-dump").map_or("", str::trim);
-        if arg.is_empty() {
-            match &self.debug_state.debug_dumper {
-                Some(d) => {
-                    let _ = self
-                        .channel
-                        .send(&format!("Debug dump active: {}", d.dir().display()))
-                        .await;
-                }
-                None => {
-                    let _ = self
-                        .channel
-                        .send(
-                            "Debug dump is inactive. Use `/debug-dump <path>` to enable, \
-                             or start with `--debug-dump [dir]`.",
-                        )
-                        .await;
-                }
-            }
-            return;
-        }
-        let dir = std::path::PathBuf::from(arg);
-        match crate::debug_dump::DebugDumper::new(&dir, self.debug_state.dump_format) {
-            Ok(dumper) => {
-                let path = dumper.dir().display().to_string();
-                self.debug_state.debug_dumper = Some(dumper);
-                let _ = self
-                    .channel
-                    .send(&format!("Debug dump enabled: {path}"))
-                    .await;
-            }
-            Err(e) => {
-                let _ = self
-                    .channel
-                    .send(&format!("Failed to enable debug dump: {e}"))
-                    .await;
-            }
-        }
-    }
-
-    /// Handle `/dump-format <json|raw|trace>` command — switch debug dump format at runtime.
-    async fn handle_dump_format_command(&mut self, trimmed: &str) {
-        let arg = trimmed.strip_prefix("/dump-format").map_or("", str::trim);
-        if arg.is_empty() {
-            let _ = self
-                .channel
-                .send(&format!(
-                    "Current dump format: {:?}. Use `/dump-format json|raw|trace` to change.",
-                    self.debug_state.dump_format
-                ))
-                .await;
-            return;
-        }
-        let new_format = match arg {
-            "json" => crate::debug_dump::DumpFormat::Json,
-            "raw" => crate::debug_dump::DumpFormat::Raw,
-            "trace" => crate::debug_dump::DumpFormat::Trace,
-            other => {
-                let _ = self
-                    .channel
-                    .send(&format!(
-                        "Unknown format '{other}'. Valid values: json, raw, trace."
-                    ))
-                    .await;
-                return;
-            }
-        };
-        self.debug_state.switch_format(new_format);
-        let _ = self
-            .channel
-            .send(&format!("Debug dump format set to: {arg}"))
-            .await;
     }
 
     async fn resolve_message(
@@ -1000,6 +993,31 @@ impl<C: Channel> Agent<C> {
         (text, image_parts)
     }
 
+    /// Create a new [`Turn`] for the given input and advance the turn counter.
+    ///
+    /// Clears per-turn state that must not carry over between turns:
+    /// - per-turn `CancellationToken` (new token for each turn)
+    /// - per-turn URL set in `SecurityState` (cleared here; re-populated in
+    ///   `process_user_message_inner` after security checks)
+    fn begin_turn(&mut self, input: turn::TurnInput) -> turn::Turn {
+        let id = turn::TurnId(self.debug_state.iteration_counter as u64);
+        self.debug_state.iteration_counter += 1;
+        self.lifecycle.cancel_token = CancellationToken::new();
+        self.security.user_provided_urls.write().clear();
+        turn::Turn::new(id, input)
+    }
+
+    /// Finalise a turn: copy accumulated timings into `MetricsState` and flush.
+    ///
+    /// Must be called exactly once per turn, after `process_user_message_inner` returns
+    /// (regardless of success or error). Corresponds to the M2 resolution in the spec:
+    /// `TurnMetrics.timings` is the single source of truth; `MetricsState.pending_timings`
+    /// is populated from it here so the rest of the pipeline is unchanged.
+    fn end_turn(&mut self, turn: turn::Turn) {
+        self.metrics.pending_timings = turn.metrics.timings;
+        self.flush_turn_timings();
+    }
+
     #[cfg_attr(
         feature = "profiling",
         tracing::instrument(name = "agent.turn", skip_all, fields(turn_id))
@@ -1009,16 +1027,16 @@ impl<C: Channel> Agent<C> {
         text: String,
         image_parts: Vec<zeph_llm::provider::MessagePart>,
     ) -> Result<(), error::AgentError> {
-        // Record iteration start in trace collector (C-02: owned guard, no borrow held).
-        let iteration_index = self.debug_state.iteration_counter;
-        self.debug_state.iteration_counter += 1;
-        tracing::Span::current().record("turn_id", iteration_index);
-        self.debug_state
-            .start_iteration_span(iteration_index, text.trim());
+        let input = turn::TurnInput::new(text, image_parts);
+        let mut t = self.begin_turn(input);
 
-        let result = self
-            .process_user_message_inner(text, image_parts, iteration_index)
-            .await;
+        let turn_idx = usize::try_from(t.id().0).unwrap_or(usize::MAX);
+        tracing::Span::current().record("turn_id", t.id().0);
+        // Record iteration start in trace collector (C-02: owned guard, no borrow held).
+        self.debug_state
+            .start_iteration_span(turn_idx, t.input.text.trim());
+
+        let result = self.process_user_message_inner(&mut t).await;
 
         // Close iteration span regardless of outcome (partial trace preserved on error).
         let span_status = if result.is_ok() {
@@ -1028,20 +1046,16 @@ impl<C: Channel> Agent<C> {
                 message: "iteration failed".to_owned(),
             }
         };
-        self.debug_state
-            .end_iteration_span(iteration_index, span_status);
+        self.debug_state.end_iteration_span(turn_idx, span_status);
 
+        self.end_turn(t);
         result
     }
 
     async fn process_user_message_inner(
         &mut self,
-        text: String,
-        image_parts: Vec<zeph_llm::provider::MessagePart>,
-        iteration_index: usize,
+        turn: &mut turn::Turn,
     ) -> Result<(), error::AgentError> {
-        let _ = iteration_index; // Used indirectly via debug_state.current_iteration_span_id.
-
         // Reap completed background tasks from the previous turn. The summarization signal
         // is applied here — between turns — so `unsummarized_count` is always reset on the
         // foreground without shared mutable state across tasks (S1 fix from critic review).
@@ -1070,11 +1084,13 @@ impl<C: Channel> Agent<C> {
                 .abort_class(supervisor::TaskClass::Enrichment);
         }
 
-        self.lifecycle.cancel_token = CancellationToken::new();
+        // Wire the per-turn cancellation token into the cancel bridge.
+        // The bridge translates the `cancel_signal` (Notify) into a CancellationToken cancel.
+        // Abort the previous bridge before spawning to prevent unbounded accumulation (#2737).
         let signal = Arc::clone(&self.lifecycle.cancel_signal);
-        let token = self.lifecycle.cancel_token.clone();
-        // Abort the previous cancel bridge task before spawning a new one to prevent
-        // unbounded task accumulation across turns (fix for #2737 leak 1).
+        let token = turn.cancel_token.clone();
+        // Keep lifecycle.cancel_token in sync so existing code that reads it still works.
+        self.lifecycle.cancel_token = turn.cancel_token.clone();
         if let Some(prev) = self.lifecycle.cancel_bridge_handle.take() {
             prev.abort();
         }
@@ -1082,7 +1098,11 @@ impl<C: Channel> Agent<C> {
             signal.notified().await;
             token.cancel();
         }));
-        let trimmed = text.trim();
+
+        // Clone text out of Turn so we can hold both `&str` borrows and mutate turn.metrics.
+        let text = turn.input.text.clone();
+        let trimmed_owned = text.trim().to_owned();
+        let trimmed = trimmed_owned.as_str();
 
         if let Some(result) = self.dispatch_slash_command(trimmed).await {
             return result;
@@ -1094,25 +1114,21 @@ impl<C: Channel> Agent<C> {
             return Ok(());
         }
 
-        // Reset pending timings for this turn.
-        self.metrics.pending_timings = crate::metrics::TurnTimings::default();
-
         let t_ctx = std::time::Instant::now();
         tracing::debug!("turn timing: prepare_context start");
         self.advance_context_lifecycle(&text, trimmed).await;
-        self.metrics.pending_timings.prepare_context_ms =
+        turn.metrics_mut().timings.prepare_context_ms =
             u64::try_from(t_ctx.elapsed().as_millis()).unwrap_or(u64::MAX);
         tracing::debug!(
-            ms = self.metrics.pending_timings.prepare_context_ms,
+            ms = turn.metrics_snapshot().timings.prepare_context_ms,
             "turn timing: prepare_context done"
         );
 
+        let image_parts = std::mem::take(&mut turn.input.image_parts);
         let user_msg = self.build_user_message(&text, image_parts);
 
-        // Clear URLs from the previous turn before re-populating for this turn.
-        // The set is per-turn context; accumulating across turns causes unbounded growth (#2737).
-        self.security.user_provided_urls.write().clear();
         // Extract URLs from user input and add to user_provided_urls for grounding checks.
+        // URL set was cleared in begin_turn; re-populate for this turn.
         let urls = zeph_sanitizer::exfiltration::extract_flagged_urls(trimmed);
         if !urls.is_empty() {
             self.security.user_provided_urls.write().extend(urls);
@@ -1126,10 +1142,10 @@ impl<C: Channel> Agent<C> {
         tracing::debug!("turn timing: persist_message(user) start");
         // Image parts intentionally excluded — base64 payloads too large for message history.
         self.persist_message(Role::User, &text, &[], false).await;
-        self.metrics.pending_timings.persist_message_ms =
+        turn.metrics_mut().timings.persist_message_ms =
             u64::try_from(t_persist.elapsed().as_millis()).unwrap_or(u64::MAX);
         tracing::debug!(
-            ms = self.metrics.pending_timings.persist_message_ms,
+            ms = turn.metrics_snapshot().timings.persist_message_ms,
             "turn timing: persist_message(user) done"
         );
         self.push_message(user_msg);
@@ -1156,7 +1172,12 @@ impl<C: Channel> Agent<C> {
         }
         tracing::debug!("turn timing: process_response done");
 
-        self.flush_turn_timings();
+        // Collect llm_chat_ms and tool_exec_ms from MetricsState.pending_timings (accumulated
+        // by the tool execution chain) into turn.metrics so end_turn can flush them.
+        // This is the Phase 1 bridging: existing code writes to pending_timings directly;
+        // we harvest those values into Turn before end_turn overwrites pending_timings.
+        turn.metrics_mut().timings.llm_chat_ms = self.metrics.pending_timings.llm_chat_ms;
+        turn.metrics_mut().timings.tool_exec_ms = self.metrics.pending_timings.tool_exec_ms;
 
         Ok(())
     }
@@ -2370,6 +2391,24 @@ pub(crate) fn resolve_context_budget(config: &Config, provider: &AnyProvider) ->
     } else {
         tokens
     }
+}
+
+/// Build the command registry populated with all Batch 1 slash command handlers.
+///
+/// Batch 1 contains trivial, self-contained commands that do not require delegation
+/// to existing `Agent<C>` methods. Batch 2 and 3 commands continue to dispatch through
+/// `dispatch_slash_command` until they are migrated in a follow-up PR.
+fn build_command_registry<C: Channel>() -> command_registry::CommandRegistry<C> {
+    let mut reg = command_registry::CommandRegistry::new();
+    reg.register(commands::exit::ExitCommand);
+    reg.register(commands::exit::QuitCommand);
+    reg.register(commands::clear::ClearCommand);
+    reg.register(commands::clear::ResetCommand);
+    reg.register(commands::clear_queue::ClearQueueCommand);
+    reg.register(commands::debug_dump::DebugDumpCommand);
+    reg.register(commands::dump_format::DumpFormatCommand);
+    reg.register(commands::log::LogCommand);
+    reg
 }
 
 #[cfg(test)]

--- a/crates/zeph-core/src/agent/slash_commands.rs
+++ b/crates/zeph-core/src/agent/slash_commands.rs
@@ -303,16 +303,6 @@ impl<C: crate::channel::Channel> Agent<C> {
         &mut self,
         trimmed: &str,
     ) -> Result<Option<bool>, error::AgentError> {
-        if trimmed == "/clear-queue" {
-            let n = self.clear_queue();
-            self.notify_queue_count().await;
-            self.channel
-                .send(&format!("Cleared {n} queued messages."))
-                .await?;
-            let _ = self.channel.flush_chunks().await;
-            return Ok(Some(false));
-        }
-
         if trimmed == "/compact" {
             if self.msg.messages.len() > self.context_manager.compaction_preserve_tail + 1 {
                 match self.compact_context().await {
@@ -367,23 +357,6 @@ impl<C: crate::channel::Channel> Agent<C> {
             return Ok(Some(false));
         }
 
-        if trimmed == "/clear" {
-            self.clear_history();
-            self.tool_orchestrator.clear_cache();
-            self.security.user_provided_urls.write().clear();
-            let _ = self.channel.flush_chunks().await;
-            return Ok(Some(false));
-        }
-
-        if trimmed == "/reset" {
-            self.clear_history();
-            self.tool_orchestrator.clear_cache();
-            self.security.user_provided_urls.write().clear();
-            self.channel.send("Conversation history reset.").await?;
-            let _ = self.channel.flush_chunks().await;
-            return Ok(Some(false));
-        }
-
         if trimmed == "/cache-stats" {
             let stats = self.tool_orchestrator.cache_stats();
             self.channel.send(&stats).await?;
@@ -400,29 +373,6 @@ impl<C: crate::channel::Channel> Agent<C> {
         if trimmed == "/provider" || trimmed.starts_with("/provider ") {
             self.handle_provider_command(trimmed).await;
             let _ = self.channel.flush_chunks().await;
-            return Ok(Some(false));
-        }
-
-        if trimmed == "/debug-dump" || trimmed.starts_with("/debug-dump ") {
-            self.handle_debug_dump_command(trimmed).await;
-            let _ = self.channel.flush_chunks().await;
-            return Ok(Some(false));
-        }
-
-        if trimmed.starts_with("/dump-format") {
-            self.handle_dump_format_command(trimmed).await;
-            let _ = self.channel.flush_chunks().await;
-            return Ok(Some(false));
-        }
-
-        if trimmed == "/exit" || trimmed == "/quit" {
-            if self.channel.supports_exit() {
-                return Ok(Some(true));
-            }
-            let _ = self
-                .channel
-                .send("/exit is not supported in this channel.")
-                .await;
             return Ok(Some(false));
         }
 
@@ -539,10 +489,6 @@ impl<C: crate::channel::Channel> Agent<C> {
                 .trim()
                 .to_owned();
             handled!(self.handle_policy_command(&args).await);
-        }
-
-        if trimmed == "/log" {
-            handled!(self.handle_log_command().await);
         }
 
         if trimmed.starts_with("/agent") || trimmed.starts_with('@') {

--- a/crates/zeph-core/src/agent/turn.rs
+++ b/crates/zeph-core/src/agent/turn.rs
@@ -4,7 +4,7 @@
 //! Per-turn state carrier for the agent loop.
 //!
 //! A [`Turn`] is created at the start of each `process_user_message` call, lives on the call
-//! stack for the duration of the turn, and is consumed at the end via [`Agent::end_turn`].
+//! stack for the duration of the turn, and is consumed at the end via `Agent::end_turn`.
 //! It is never stored on the `Agent` struct.
 //!
 //! # Phase 1 scope

--- a/crates/zeph-core/src/agent/turn.rs
+++ b/crates/zeph-core/src/agent/turn.rs
@@ -1,0 +1,206 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Per-turn state carrier for the agent loop.
+//!
+//! A [`Turn`] is created at the start of each `process_user_message` call, lives on the call
+//! stack for the duration of the turn, and is consumed at the end via [`Agent::end_turn`].
+//! It is never stored on the `Agent` struct.
+//!
+//! # Phase 1 scope
+//!
+//! Only input, ID, metrics (timings only), and the cancellation token are tracked.
+//! Fields `context`, `response_text`, and `tool_results` are deferred to Phase 2.
+
+use tokio_util::sync::CancellationToken;
+use zeph_llm::provider::MessagePart;
+
+use crate::metrics::TurnTimings;
+
+/// Monotonically increasing per-conversation turn identifier.
+///
+/// Wraps `debug_state.iteration_counter` as a proper newtype, enabling turn IDs to be passed
+/// through the turn lifecycle and recorded in metrics and traces.
+///
+/// `TurnId(0)` is the first turn in a conversation. Values are strictly increasing by 1.
+/// The counter resets to 0 when a new conversation starts (e.g., via `/new`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct TurnId(pub(crate) u64);
+
+impl TurnId {
+    /// Return the next turn ID in sequence.
+    #[allow(dead_code)]
+    pub(crate) fn next(self) -> TurnId {
+        TurnId(self.0 + 1)
+    }
+}
+
+impl std::fmt::Display for TurnId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Resolved input for a single agent turn.
+///
+/// Built from a `ChannelMessage` after attachment resolution and image extraction.
+/// Separates input parsing from input processing and bundles the two values previously
+/// passed as separate arguments to `process_user_message`.
+pub(crate) struct TurnInput {
+    /// Plain-text user input. May be empty for image-only messages.
+    pub(crate) text: String,
+    /// Decoded image parts extracted from attachments or inline data.
+    pub(crate) image_parts: Vec<MessagePart>,
+}
+
+impl TurnInput {
+    /// Create input from text and image parts.
+    pub(crate) fn new(text: String, image_parts: Vec<MessagePart>) -> Self {
+        Self { text, image_parts }
+    }
+}
+
+/// Per-turn performance measurements captured during the turn lifecycle.
+///
+/// In Phase 1, only `timings` is populated. Token counts and cost are managed via the existing
+/// `MetricsState` path and are deferred to Phase 2.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct TurnMetrics {
+    /// Turn timing breakdown populated at each lifecycle phase boundary.
+    pub(crate) timings: TurnTimings,
+}
+
+/// Record of a single tool execution within a turn.
+///
+/// Defined in Phase 1 for forward compatibility. Populated in Phase 2 when
+/// `Turn.tool_results` is wired through the tool execution chain.
+#[allow(dead_code)]
+pub(crate) struct ToolOutputRecord {
+    /// Registered tool name (e.g., `"shell"`, `"web_scrape"`).
+    pub(crate) tool_name: String,
+    /// Short human-readable summary of the tool output.
+    pub(crate) summary: String,
+    /// Wall-clock execution time in milliseconds.
+    pub(crate) latency_ms: u64,
+}
+
+/// Complete state of a single agent turn from input through metrics capture.
+///
+/// Created at the start of `process_user_message`, populated through the turn lifecycle,
+/// and consumed at the end for metrics emission and trace completion.
+///
+/// **Ownership**: `Turn` is stack-owned — created in `begin_turn`, passed through sub-methods
+/// by `&mut Turn`, and consumed in `end_turn`. It is never stored on the `Agent` struct.
+///
+/// **Phase 1 scope**: carries `id`, `input`, `metrics`, and `cancel_token` only.
+pub(crate) struct Turn {
+    /// Monotonically increasing identifier for this turn within the session.
+    pub(crate) id: TurnId,
+    /// Resolved user input for this turn.
+    pub(crate) input: TurnInput,
+    /// Per-turn metrics accumulated during the turn lifecycle.
+    pub(crate) metrics: TurnMetrics,
+    /// Per-turn cancellation token. Cancelled when the user aborts the turn or the agent shuts
+    /// down. Created fresh in [`Turn::new`] so each turn has an independent token.
+    pub(crate) cancel_token: CancellationToken,
+}
+
+impl Turn {
+    /// Create a new turn with the given ID and input.
+    ///
+    /// A fresh [`CancellationToken`] is created for each turn so that cancelling one turn
+    /// does not affect subsequent turns.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use zeph_core::agent::turn::{Turn, TurnId, TurnInput};
+    /// # use zeph_llm::provider::MessagePart;
+    /// let input = TurnInput::new("hello".to_owned(), vec![]);
+    /// let turn = Turn::new(TurnId(0), input);
+    /// assert_eq!(turn.id, TurnId(0));
+    /// ```
+    pub(crate) fn new(id: TurnId, input: TurnInput) -> Self {
+        Self {
+            id,
+            input,
+            metrics: TurnMetrics::default(),
+            cancel_token: CancellationToken::new(),
+        }
+    }
+
+    /// Return the turn ID.
+    pub(crate) fn id(&self) -> TurnId {
+        self.id
+    }
+
+    /// Return an immutable reference to the turn metrics.
+    pub(crate) fn metrics_snapshot(&self) -> &TurnMetrics {
+        &self.metrics
+    }
+
+    /// Return a mutable reference to the turn metrics.
+    pub(crate) fn metrics_mut(&mut self) -> &mut TurnMetrics {
+        &mut self.metrics
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn turn_new_sets_id() {
+        let input = TurnInput::new("hello".to_owned(), vec![]);
+        let turn = Turn::new(TurnId(7), input);
+        assert_eq!(turn.id, TurnId(7));
+        assert_eq!(turn.id(), TurnId(7));
+    }
+
+    #[test]
+    fn turn_id_display() {
+        assert_eq!(TurnId(42).to_string(), "42");
+    }
+
+    #[test]
+    fn turn_id_next() {
+        assert_eq!(TurnId(3).next(), TurnId(4));
+    }
+
+    #[test]
+    fn turn_input_fields() {
+        let input = TurnInput::new("hi".to_owned(), vec![]);
+        assert_eq!(input.text, "hi");
+        assert!(input.image_parts.is_empty());
+    }
+
+    #[test]
+    fn turn_metrics_default_timings_are_zero() {
+        let m = TurnMetrics::default();
+        assert_eq!(m.timings.prepare_context_ms, 0);
+        assert_eq!(m.timings.llm_chat_ms, 0);
+    }
+
+    #[test]
+    fn turn_cancel_token_not_cancelled_on_new() {
+        let input = TurnInput::new("x".to_owned(), vec![]);
+        let turn = Turn::new(TurnId(0), input);
+        assert!(!turn.cancel_token.is_cancelled());
+    }
+
+    #[test]
+    fn turn_cancel_token_cancel() {
+        let input = TurnInput::new("x".to_owned(), vec![]);
+        let turn = Turn::new(TurnId(0), input);
+        turn.cancel_token.cancel();
+        assert!(turn.cancel_token.is_cancelled());
+    }
+
+    #[test]
+    fn turn_metrics_mut_allows_write() {
+        let input = TurnInput::new("x".to_owned(), vec![]);
+        let mut turn = Turn::new(TurnId(0), input);
+        turn.metrics_mut().timings.prepare_context_ms = 99;
+        assert_eq!(turn.metrics_snapshot().timings.prepare_context_ms, 99);
+    }
+}

--- a/crates/zeph-core/src/agent/turn.rs
+++ b/crates/zeph-core/src/agent/turn.rs
@@ -25,7 +25,7 @@ use crate::metrics::TurnTimings;
 /// `TurnId(0)` is the first turn in a conversation. Values are strictly increasing by 1.
 /// The counter resets to 0 when a new conversation starts (e.g., via `/new`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) struct TurnId(pub(crate) u64);
+pub struct TurnId(pub u64);
 
 impl TurnId {
     /// Return the next turn ID in sequence.
@@ -46,16 +46,17 @@ impl std::fmt::Display for TurnId {
 /// Built from a `ChannelMessage` after attachment resolution and image extraction.
 /// Separates input parsing from input processing and bundles the two values previously
 /// passed as separate arguments to `process_user_message`.
-pub(crate) struct TurnInput {
+pub struct TurnInput {
     /// Plain-text user input. May be empty for image-only messages.
-    pub(crate) text: String,
+    pub text: String,
     /// Decoded image parts extracted from attachments or inline data.
-    pub(crate) image_parts: Vec<MessagePart>,
+    pub image_parts: Vec<MessagePart>,
 }
 
 impl TurnInput {
     /// Create input from text and image parts.
-    pub(crate) fn new(text: String, image_parts: Vec<MessagePart>) -> Self {
+    #[must_use]
+    pub fn new(text: String, image_parts: Vec<MessagePart>) -> Self {
         Self { text, image_parts }
     }
 }
@@ -65,9 +66,9 @@ impl TurnInput {
 /// In Phase 1, only `timings` is populated. Token counts and cost are managed via the existing
 /// `MetricsState` path and are deferred to Phase 2.
 #[derive(Debug, Default, Clone)]
-pub(crate) struct TurnMetrics {
+pub struct TurnMetrics {
     /// Turn timing breakdown populated at each lifecycle phase boundary.
-    pub(crate) timings: TurnTimings,
+    pub timings: TurnTimings,
 }
 
 /// Record of a single tool execution within a turn.
@@ -93,16 +94,16 @@ pub(crate) struct ToolOutputRecord {
 /// by `&mut Turn`, and consumed in `end_turn`. It is never stored on the `Agent` struct.
 ///
 /// **Phase 1 scope**: carries `id`, `input`, `metrics`, and `cancel_token` only.
-pub(crate) struct Turn {
-    /// Monotonically increasing identifier for this turn within the session.
-    pub(crate) id: TurnId,
+pub struct Turn {
+    /// Monotonically increasing identifier for this turn within the conversation.
+    pub id: TurnId,
     /// Resolved user input for this turn.
-    pub(crate) input: TurnInput,
+    pub input: TurnInput,
     /// Per-turn metrics accumulated during the turn lifecycle.
-    pub(crate) metrics: TurnMetrics,
+    pub metrics: TurnMetrics,
     /// Per-turn cancellation token. Cancelled when the user aborts the turn or the agent shuts
     /// down. Created fresh in [`Turn::new`] so each turn has an independent token.
-    pub(crate) cancel_token: CancellationToken,
+    pub cancel_token: CancellationToken,
 }
 
 impl Turn {
@@ -120,7 +121,8 @@ impl Turn {
     /// let turn = Turn::new(TurnId(0), input);
     /// assert_eq!(turn.id, TurnId(0));
     /// ```
-    pub(crate) fn new(id: TurnId, input: TurnInput) -> Self {
+    #[must_use]
+    pub fn new(id: TurnId, input: TurnInput) -> Self {
         Self {
             id,
             input,
@@ -130,17 +132,19 @@ impl Turn {
     }
 
     /// Return the turn ID.
-    pub(crate) fn id(&self) -> TurnId {
+    #[must_use]
+    pub fn id(&self) -> TurnId {
         self.id
     }
 
     /// Return an immutable reference to the turn metrics.
-    pub(crate) fn metrics_snapshot(&self) -> &TurnMetrics {
+    #[must_use]
+    pub fn metrics_snapshot(&self) -> &TurnMetrics {
         &self.metrics
     }
 
     /// Return a mutable reference to the turn metrics.
-    pub(crate) fn metrics_mut(&mut self) -> &mut TurnMetrics {
+    pub fn metrics_mut(&mut self) -> &mut TurnMetrics {
         &mut self.metrics
     }
 }


### PR DESCRIPTION
## Summary

- **Turn domain type** (`#2895`): `Turn` struct in `zeph-core::agent::turn` with `TurnId` (per-conversation monotonic newtype), `TurnInput`, `TurnMetrics` (Phase 1 wraps `TurnTimings`), and `begin_turn`/`end_turn` lifecycle methods in `Agent`. Sets the foundation for per-turn metrics, tracing, and future turn replay (Phase 2).
- **CommandRegistry** (`#2896`): `CommandHandler<C>` trait, `CommandRegistry<C>` (Vec-backed, word-boundary dispatch), `CommandContext<'_, C>` (lifetime-bound subsystem borrows), `CommandOutput` enum. Batch 1 (8 commands) migrated. Dead legacy branches removed.

## Wave 2 of architecture epic #2909

Depends on: #2897 (MemoryState decomposition, closed), #2899 (AgentBuilder consolidation, closed).
Enables: #2898 (run loop event handler — depends on `Turn`).

## Changes

- `crates/zeph-core/src/agent/turn.rs` — new file
- `crates/zeph-core/src/agent/command_registry.rs` — new file
- `crates/zeph-core/src/agent/commands/` — 7 new files (Batch 1 handlers + mod.rs)
- `crates/zeph-core/src/agent/mod.rs` — begin_turn/end_turn, command_registry field, run loop dispatch
- `crates/zeph-core/src/agent/slash_commands.rs` — dead Batch 1 branches removed

## Test plan

- [ ] 8071 tests pass (`cargo nextest run --workspace --features desktop,ide,server,chat,pdf,scheduler --lib --bins`)
- [ ] `cargo clippy --workspace --features desktop,ide,server,chat,pdf,scheduler -- -D warnings` clean
- [ ] `cargo +nightly fmt --check` clean
- [ ] Live: `/exit`, `/clear`, `/debug-dump`, `/log debug` behave identically to pre-PR (see `.local/testing/playbooks/turn-command-registry.md`)
- [ ] Live: non-migrated commands (`/new`, `/compact`, `/model`) unaffected