### PR TITLE
refactor(common): introduce ToolName and SessionId newtypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **`ToolName` newtype** (`#2901`): introduced `ToolName(Arc<str>)` in `zeph-common` replacing
+  raw `String` for all tool name fields across `zeph-tools` (`ToolCall.tool_id`,
+  `ToolOutput.tool_name`, `ToolEvent` variants), `zeph-llm` (`ToolDefinition.name`,
+  `ToolUseRequest.name`, `MessagePart::ToolOutput.tool_name`), `zeph-core` (`ToolStartData`,
+  `ToolOutputData`, `ToolTimeout`, channel events), `zeph-tui`, `zeph-mcp`, `zeph-sanitizer`,
+  `zeph-skills`, `zeph-acp`, and root binary. `ToolName` uses `Arc<str>` for O(1) clone in
+  event channels, `#[serde(transparent)]` for wire compatibility, and implements `Display`,
+  `AsRef<str>`, `Borrow<str>`, `From<&str>`, `From<String>`, `FromStr`.
+  Does not implement `Deref<Target=str>` to prevent `.to_owned()` footgun.
+
+- **`SessionId` newtype** (`#2902`): introduced `SessionId(String)` in `zeph-common` replacing
+  raw `String`/`uuid::Uuid` for session identifiers across `zeph-core`, `zeph-experiments`,
+  and `zeph-memory`. `SessionId::generate()` produces UUID v4; `SessionId::new(s)` wraps
+  arbitrary strings (test-only path, guarded with `debug_assert!(!s.is_empty())`).
+  Uses `String` internally to support both UUID and non-UUID values in tests.
+  `#[serde(transparent)]` preserves wire format. Implements same `PartialEq<str/String>`
+  set as `ToolName`.
+
 ### Added
 
 - **Turn domain type** (`#2895`): introduced `Turn` as a first-class domain entity in

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,7 +738,7 @@ dependencies = [
  "log",
  "num",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
@@ -861,7 +861,7 @@ dependencies = [
  "num_cpus",
  "objc2-foundation",
  "objc2-metal",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_distr 0.5.1",
  "rayon",
  "safetensors 0.7.0",
@@ -924,7 +924,7 @@ dependencies = [
  "candle-nn",
  "fancy-regex 0.17.0",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rayon",
  "serde",
  "serde_json",
@@ -2230,7 +2230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb330bbd4cb7a5b9f559427f06f98a4f853a137c8298f3bd3f8ca57663e21986"
 dependencies = [
  "portable-atomic",
- "rand 0.9.2",
+ "rand 0.9.3",
  "web-time",
 ]
 
@@ -2325,7 +2325,7 @@ checksum = "c2d1f04709a8ac06e8e8042875a3c466cc4832d3c1a18dbcb9dba3c6e83046bc"
 dependencies = [
  "half",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_distr 0.5.1",
 ]
 
@@ -2914,7 +2914,7 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_distr 0.5.1",
  "zerocopy",
 ]
@@ -3001,7 +3001,7 @@ dependencies = [
  "libc",
  "log",
  "num_cpus",
- "rand 0.9.2",
+ "rand 0.9.3",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -3636,6 +3636,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -3892,7 +3901,7 @@ dependencies = [
  "md-5",
  "nom 8.0.0",
  "nom_locate",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rangemap",
  "sha2 0.10.9",
  "stringprep",
@@ -4624,7 +4633,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.3",
  "thiserror 2.0.18",
 ]
 
@@ -5222,7 +5231,7 @@ dependencies = [
  "bit-vec 0.8.0",
  "bitflags 2.11.0",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -5269,7 +5278,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -5289,7 +5298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5479,7 +5488,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash 2.1.2",
  "rustls",
@@ -5540,9 +5549,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -5550,9 +5559,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
@@ -5611,7 +5620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
 ]
 
 [[package]]
@@ -5621,7 +5630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
- "rand 0.10.0",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -6763,9 +6772,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "similar"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d0b06eba54f0ca0770f970a3e89823e766ca638dd940f8469fa0fa50c75396"
+checksum = "04d93e861ede2e497b47833469b8ec9d5c07fa4c78ce7a00f6eb7dd8168b4b3f"
 dependencies = [
  "bstr",
 ]
@@ -7804,7 +7813,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rayon",
  "rayon-cond",
  "regex",
@@ -8394,7 +8403,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.3",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -8411,7 +8420,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -9789,7 +9798,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "similar 3.0.0",
+ "similar 3.1.0",
  "sqlx",
  "sysinfo",
  "tempfile",
@@ -9939,6 +9948,7 @@ version = "0.18.6"
 dependencies = [
  "blake3",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "tracing",
  "tree-sitter",
@@ -9947,6 +9957,7 @@ dependencies = [
  "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-typescript",
+ "uuid",
  "zeroize",
 ]
 
@@ -9990,7 +10001,7 @@ dependencies = [
  "ordered-float 5.3.0",
  "parking_lot",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "regex",
  "reqwest 0.13.2",
  "rmcp",
@@ -10058,7 +10069,7 @@ dependencies = [
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
- "uuid",
+ "zeph-common",
  "zeph-config",
  "zeph-llm",
  "zeph-memory",
@@ -10137,7 +10148,7 @@ dependencies = [
  "ollama-rs",
  "parking_lot",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_distr 0.6.0",
  "reqwest 0.13.2",
  "rubato",
@@ -10397,7 +10408,7 @@ dependencies = [
  "ratatui",
  "regex",
  "serde_json",
- "similar 3.0.0",
+ "similar 3.1.0",
  "tempfile",
  "thiserror 2.0.18",
  "throbber-widgets-tui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ serde_json = "1.0"
 serde_norway = "0.9.42"
 serial_test = "3.4"
 globset = "0.4"
-similar = "3.0"
+similar = "3.1"
 sqlx = { version = "0.8", default-features = false }
 subtle = "2.6"
 sysinfo = { version = "0.38.4", default-features = false, features = ["system"] }

--- a/crates/zeph-acp/src/agent/helpers.rs
+++ b/crates/zeph-acp/src/agent/helpers.rs
@@ -264,7 +264,7 @@ fn tool_start_to_updates(data: zeph_core::ToolStartData) -> Vec<acp::SessionUpda
         })
         .and_then(|v| v.as_str())
         .map_or_else(
-            || tool_name.clone(),
+            || tool_name.to_string(),
             |s| {
                 const MAX_CHARS: usize = 120;
                 if s.chars().count() > MAX_CHARS {
@@ -275,7 +275,7 @@ fn tool_start_to_updates(data: zeph_core::ToolStartData) -> Vec<acp::SessionUpda
                 }
             },
         );
-    let kind = tool_kind_from_name(&tool_name);
+    let kind = tool_kind_from_name(tool_name.as_str());
     let mut tool_call = acp::ToolCall::new(tool_call_id.clone(), title)
         .kind(kind)
         .status(acp::ToolCallStatus::InProgress);
@@ -309,7 +309,7 @@ fn tool_start_to_updates(data: zeph_core::ToolStartData) -> Vec<acp::SessionUpda
     let mut claude_code = serde_json::Map::new();
     claude_code.insert(
         "toolName".to_owned(),
-        serde_json::Value::String(tool_name.clone()),
+        serde_json::Value::String(tool_name.to_string()),
     );
     // Record ISO 8601 start time so clients can compute elapsed duration.
     let started_at_iso = {
@@ -340,7 +340,7 @@ fn tool_start_to_updates(data: zeph_core::ToolStartData) -> Vec<acp::SessionUpda
 fn terminal_tool_updates(
     tool_call_id: String,
     display: String,
-    tool_name: String,
+    tool_name: &zeph_tools::ToolName,
     elapsed_ms: Option<u64>,
     parent_tool_use_id: Option<String>,
     is_error: bool,
@@ -363,7 +363,10 @@ fn terminal_tool_updates(
         serde_json::json!({ "terminal_id": tool_call_id, "exit_code": exit_code, "signal": null }),
     );
     let mut cc = serde_json::Map::new();
-    cc.insert("toolName".to_owned(), serde_json::Value::String(tool_name));
+    cc.insert(
+        "toolName".to_owned(),
+        serde_json::Value::String(tool_name.to_string()),
+    );
     if let Some(ms) = elapsed_ms {
         cc.insert("elapsedMs".to_owned(), serde_json::Value::Number(ms.into()));
     }
@@ -394,7 +397,7 @@ fn non_terminal_tool_updates(
     tool_call_id: String,
     display: String,
     diff: Option<zeph_core::DiffData>,
-    tool_name: String,
+    tool_name: &zeph_tools::ToolName,
     elapsed_ms: Option<u64>,
     parent_tool_use_id: Option<String>,
     status: acp::ToolCallStatus,
@@ -416,7 +419,10 @@ fn non_terminal_tool_updates(
     }
     let mut meta = serde_json::Map::new();
     let mut cc = serde_json::Map::new();
-    cc.insert("toolName".to_owned(), serde_json::Value::String(tool_name));
+    cc.insert(
+        "toolName".to_owned(),
+        serde_json::Value::String(tool_name.to_string()),
+    );
     if let Some(ms) = elapsed_ms {
         cc.insert("elapsedMs".to_owned(), serde_json::Value::Number(ms.into()));
     }
@@ -463,7 +469,7 @@ fn tool_output_to_updates(data: zeph_core::ToolOutputData) -> Vec<acp::SessionUp
         let mut cc = serde_json::Map::new();
         cc.insert(
             "toolName".to_owned(),
-            serde_json::Value::String(tool_name.clone()),
+            serde_json::Value::String(tool_name.to_string()),
         );
         cc.insert("toolResponse".to_owned(), resp);
         if let Some(ref parent_id) = parent_tool_use_id {
@@ -483,7 +489,7 @@ fn tool_output_to_updates(data: zeph_core::ToolOutputData) -> Vec<acp::SessionUp
         terminal_tool_updates(
             tool_call_id,
             display,
-            tool_name,
+            &tool_name,
             elapsed_ms,
             parent_tool_use_id,
             is_error,
@@ -495,7 +501,7 @@ fn tool_output_to_updates(data: zeph_core::ToolOutputData) -> Vec<acp::SessionUp
             tool_call_id,
             display,
             diff,
-            tool_name,
+            &tool_name,
             elapsed_ms,
             parent_tool_use_id,
             status,

--- a/crates/zeph-acp/src/agent/tests.rs
+++ b/crates/zeph-acp/src/agent/tests.rs
@@ -483,7 +483,7 @@ fn loopback_empty_chunk_returns_none() {
 #[test]
 fn loopback_tool_start_parent_tool_use_id_injected_into_meta() {
     let event = LoopbackEvent::ToolStart(Box::new(ToolStartData {
-        tool_name: "bash".to_owned(),
+        tool_name: "bash".into(),
         tool_call_id: "child-id".to_owned(),
         params: None,
         parent_tool_use_id: Some("parent-uuid".to_owned()),
@@ -511,7 +511,7 @@ fn loopback_tool_start_parent_tool_use_id_injected_into_meta() {
 #[test]
 fn loopback_tool_output_parent_tool_use_id_injected_into_meta() {
     let event = LoopbackEvent::ToolOutput(Box::new(ToolOutputData {
-        tool_name: "bash".to_owned(),
+        tool_name: "bash".into(),
         display: "done".to_owned(),
         diff: None,
         filter_stats: None,
@@ -551,7 +551,7 @@ fn loopback_tool_output_parent_tool_use_id_injected_into_meta() {
 #[test]
 fn loopback_tool_start_maps_to_tool_call_in_progress() {
     let event = LoopbackEvent::ToolStart(Box::new(ToolStartData {
-        tool_name: "bash".to_owned(),
+        tool_name: "bash".into(),
         tool_call_id: "test-id".to_owned(),
         params: None,
         parent_tool_use_id: None,
@@ -573,7 +573,7 @@ fn loopback_tool_start_maps_to_tool_call_in_progress() {
 fn loopback_tool_start_uses_command_as_title() {
     let params = serde_json::json!({ "command": "ls -la /tmp" });
     let event = LoopbackEvent::ToolStart(Box::new(ToolStartData {
-        tool_name: "bash".to_owned(),
+        tool_name: "bash".into(),
         tool_call_id: "test-id-2".to_owned(),
         params: Some(params),
         parent_tool_use_id: None,
@@ -595,7 +595,7 @@ fn loopback_tool_start_truncates_long_command() {
     let long_cmd = "a".repeat(200);
     let params = serde_json::json!({ "command": long_cmd });
     let event = LoopbackEvent::ToolStart(Box::new(ToolStartData {
-        tool_name: "bash".to_owned(),
+        tool_name: "bash".into(),
         tool_call_id: "test-id-3".to_owned(),
         params: Some(params),
         parent_tool_use_id: None,
@@ -615,7 +615,7 @@ fn loopback_tool_start_truncates_long_command() {
 #[test]
 fn loopback_tool_output_maps_to_tool_call_update() {
     let event = LoopbackEvent::ToolOutput(Box::new(ToolOutputData {
-        tool_name: "bash".to_owned(),
+        tool_name: "bash".into(),
         display: "done".to_owned(),
         diff: None,
         filter_stats: None,
@@ -641,7 +641,7 @@ fn loopback_tool_output_maps_to_tool_call_update() {
 #[test]
 fn loopback_tool_output_error_maps_to_failed() {
     let event = LoopbackEvent::ToolOutput(Box::new(ToolOutputData {
-        tool_name: "bash".to_owned(),
+        tool_name: "bash".into(),
         display: "error".to_owned(),
         diff: None,
         filter_stats: None,
@@ -668,7 +668,7 @@ fn loopback_tool_output_error_maps_to_failed() {
 #[test]
 fn tool_start_always_includes_tool_name_in_claude_code() {
     let event = LoopbackEvent::ToolStart(Box::new(ToolStartData {
-        tool_name: "bash".to_owned(),
+        tool_name: "bash".into(),
         tool_call_id: "tc-1".to_owned(),
         params: None,
         parent_tool_use_id: None,
@@ -697,7 +697,7 @@ fn tool_start_always_includes_tool_name_in_claude_code() {
 #[test]
 fn tool_start_tool_name_and_parent_merged_in_claude_code() {
     let event = LoopbackEvent::ToolStart(Box::new(ToolStartData {
-        tool_name: "read_file".to_owned(),
+        tool_name: "read_file".into(),
         tool_call_id: "tc-2".to_owned(),
         params: None,
         parent_tool_use_id: Some("parent-abc".to_owned()),
@@ -732,7 +732,7 @@ fn tool_start_tool_name_and_parent_merged_in_claude_code() {
 #[test]
 fn tool_output_always_includes_tool_name_in_claude_code() {
     let event = LoopbackEvent::ToolOutput(Box::new(ToolOutputData {
-        tool_name: "bash".to_owned(),
+        tool_name: "bash".into(),
         display: "ok".to_owned(),
         diff: None,
         filter_stats: None,
@@ -768,7 +768,7 @@ fn tool_output_always_includes_tool_name_in_claude_code() {
 fn tool_start_read_kind_sets_location_from_file_path_param() {
     let params = serde_json::json!({ "file_path": "/src/main.rs" });
     let event = LoopbackEvent::ToolStart(Box::new(ToolStartData {
-        tool_name: "read_file".to_owned(),
+        tool_name: "read_file".into(),
         tool_call_id: "tc-read".to_owned(),
         params: Some(params),
         parent_tool_use_id: None,
@@ -790,7 +790,7 @@ fn tool_start_read_kind_sets_location_from_file_path_param() {
 fn tool_start_read_kind_sets_location_from_path_param() {
     let params = serde_json::json!({ "path": "/tmp/file.txt" });
     let event = LoopbackEvent::ToolStart(Box::new(ToolStartData {
-        tool_name: "read_file".to_owned(),
+        tool_name: "read_file".into(),
         tool_call_id: "tc-read2".to_owned(),
         params: Some(params),
         parent_tool_use_id: None,
@@ -812,7 +812,7 @@ fn tool_start_read_kind_sets_location_from_path_param() {
 fn tool_start_execute_kind_does_not_set_locations() {
     let params = serde_json::json!({ "command": "ls" });
     let event = LoopbackEvent::ToolStart(Box::new(ToolStartData {
-        tool_name: "bash".to_owned(),
+        tool_name: "bash".into(),
         tool_call_id: "tc-bash".to_owned(),
         params: Some(params),
         parent_tool_use_id: None,
@@ -836,7 +836,7 @@ fn tool_output_with_raw_response_emits_intermediate_before_final() {
         "file": { "filePath": "/foo.rs", "content": "fn main(){}", "numLines": 1, "startLine": 1, "totalLines": 1 }
     });
     let event = LoopbackEvent::ToolOutput(Box::new(ToolOutputData {
-        tool_name: "read_file".to_owned(),
+        tool_name: "read_file".into(),
         display: "fn main(){}".to_owned(),
         diff: None,
         filter_stats: None,
@@ -890,7 +890,7 @@ fn tool_output_terminal_with_raw_response_emits_three_updates() {
         "stdout": "hello", "stderr": "", "interrupted": false, "isImage": false, "noOutputExpected": false
     });
     let event = LoopbackEvent::ToolOutput(Box::new(ToolOutputData {
-        tool_name: "bash".to_owned(),
+        tool_name: "bash".into(),
         display: "hello".to_owned(),
         diff: None,
         filter_stats: None,
@@ -1201,7 +1201,7 @@ fn mime_to_ext_known_types() {
 #[test]
 fn loopback_tool_output_with_locations() {
     let event = LoopbackEvent::ToolOutput(Box::new(ToolOutputData {
-        tool_name: "read_file".to_owned(),
+        tool_name: "read_file".into(),
         display: "content".to_owned(),
         diff: None,
         filter_stats: None,
@@ -1230,7 +1230,7 @@ fn loopback_tool_output_with_locations() {
 #[test]
 fn loopback_tool_output_empty_locations() {
     let event = LoopbackEvent::ToolOutput(Box::new(ToolOutputData {
-        tool_name: "bash".to_owned(),
+        tool_name: "bash".into(),
         display: "ok".to_owned(),
         diff: None,
         filter_stats: None,
@@ -1269,7 +1269,7 @@ fn tool_use_marker_filtered_duplicate() {
 #[test]
 fn loopback_tool_output_with_terminal_id() {
     let event = LoopbackEvent::ToolOutput(Box::new(ToolOutputData {
-        tool_name: "bash".to_owned(),
+        tool_name: "bash".into(),
         display: "ls output".to_owned(),
         diff: None,
         filter_stats: None,
@@ -1327,7 +1327,7 @@ fn loopback_tool_output_with_terminal_id() {
 #[test]
 fn loopback_tool_start_execute_sets_terminal_info() {
     let event = LoopbackEvent::ToolStart(Box::new(ToolStartData {
-        tool_name: "bash".to_owned(),
+        tool_name: "bash".into(),
         tool_call_id: "tc-bash".to_owned(),
         params: Some(serde_json::json!({ "command": "ls" })),
         parent_tool_use_id: None,
@@ -2204,7 +2204,7 @@ fn loopback_plan_empty_entries() {
 fn loopback_tool_output_multiline_preserves_newlines_in_terminal_data() {
     let raw = "file1.rs\nfile2.rs\nfile3.rs".to_owned();
     let event = LoopbackEvent::ToolOutput(Box::new(ToolOutputData {
-        tool_name: "bash".to_owned(),
+        tool_name: "bash".into(),
         display: raw.clone(),
         diff: None,
         filter_stats: None,
@@ -2375,7 +2375,7 @@ async fn new_session_meta_absent_when_no_rules() {
 #[test]
 fn tool_start_includes_started_at_in_meta() {
     let event = LoopbackEvent::ToolStart(Box::new(ToolStartData {
-        tool_name: "bash".to_owned(),
+        tool_name: "bash".into(),
         tool_call_id: "tc-elapsed".to_owned(),
         params: None,
         parent_tool_use_id: None,
@@ -2412,7 +2412,7 @@ fn tool_start_includes_started_at_in_meta() {
 fn tool_output_includes_elapsed_ms_in_meta() {
     let started_at = std::time::Instant::now();
     let event = LoopbackEvent::ToolOutput(Box::new(ToolOutputData {
-        tool_name: "bash".to_owned(),
+        tool_name: "bash".into(),
         display: "ok".to_owned(),
         diff: None,
         filter_stats: None,
@@ -2452,7 +2452,7 @@ fn tool_output_includes_elapsed_ms_in_meta() {
 #[test]
 fn tool_output_no_elapsed_ms_when_started_at_absent() {
     let event = LoopbackEvent::ToolOutput(Box::new(ToolOutputData {
-        tool_name: "bash".to_owned(),
+        tool_name: "bash".into(),
         display: "ok".to_owned(),
         diff: None,
         filter_stats: None,

--- a/crates/zeph-acp/src/fs.rs
+++ b/crates/zeph-acp/src/fs.rs
@@ -342,7 +342,7 @@ impl zeph_tools::ToolExecutor for AcpFileExecutor {
                     }
                 }));
                 Ok(Some(ToolOutput {
-                    tool_name: "read_file".to_owned(),
+                    tool_name: zeph_tools::ToolName::new("read_file"),
                     summary: content,
                     blocks_executed: 1,
                     filter_stats: None,
@@ -465,7 +465,7 @@ impl AcpFileExecutor {
                 message: e.to_string(),
             })?;
         Ok(Some(ToolOutput {
-            tool_name: "write_file".to_owned(),
+            tool_name: zeph_tools::ToolName::new("write_file"),
             summary: format!("wrote {}", params.path),
             blocks_executed: 1,
             filter_stats: None,
@@ -520,7 +520,7 @@ impl AcpFileExecutor {
         });
         let summary = serde_json::to_string(&items).unwrap_or_default();
         Ok(Some(ToolOutput {
-            tool_name: "list_directory".to_owned(),
+            tool_name: zeph_tools::ToolName::new("list_directory"),
             summary,
             blocks_executed: 1,
             filter_stats: None,
@@ -571,7 +571,7 @@ impl AcpFileExecutor {
 
         let summary = matches.join("\n");
         Ok(Some(ToolOutput {
-            tool_name: "find_path".to_owned(),
+            tool_name: zeph_tools::ToolName::new("find_path"),
             summary,
             blocks_executed: 1,
             filter_stats: None,
@@ -723,7 +723,7 @@ mod tests {
                 let mut params = serde_json::Map::new();
                 params.insert("path".to_owned(), serde_json::json!(test_path("test.txt")));
                 let call = ToolCall {
-                    tool_id: "read_file".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("read_file"),
                     params,
                     caller_id: None,
                 };
@@ -755,7 +755,7 @@ mod tests {
                 params.insert("path".to_owned(), serde_json::json!(test_path("out.txt")));
                 params.insert("content".to_owned(), serde_json::json!("data"));
                 let call = ToolCall {
-                    tool_id: "write_file".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("write_file"),
                     params,
                     caller_id: None,
                 };
@@ -783,7 +783,7 @@ mod tests {
                 tokio::task::spawn_local(handler);
 
                 let call = ToolCall {
-                    tool_id: "unknown".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("unknown"),
                     params: serde_json::Map::new(),
                     caller_id: None,
                 };
@@ -868,7 +868,7 @@ mod tests {
             serde_json::json!(dir.path().to_str().unwrap()),
         );
         let call = ToolCall {
-            tool_id: "list_directory".to_owned(),
+            tool_id: zeph_tools::ToolName::new("list_directory"),
             params,
             caller_id: None,
         };
@@ -900,7 +900,7 @@ mod tests {
             serde_json::json!(dir.path().to_str().unwrap()),
         );
         let call = ToolCall {
-            tool_id: "find_path".to_owned(),
+            tool_id: zeph_tools::ToolName::new("find_path"),
             params,
             caller_id: None,
         };
@@ -926,7 +926,7 @@ mod tests {
                 let mut params = serde_json::Map::new();
                 params.insert("path".to_owned(), serde_json::json!(test_path("test.txt")));
                 let call = ToolCall {
-                    tool_id: "read_file".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("read_file"),
                     params,
                     caller_id: None,
                 };
@@ -954,7 +954,7 @@ mod tests {
                 params.insert("path".to_owned(), serde_json::json!(test_path("out.txt")));
                 params.insert("content".to_owned(), serde_json::json!("data"));
                 let call = ToolCall {
-                    tool_id: "write_file".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("write_file"),
                     params,
                     caller_id: None,
                 };
@@ -983,7 +983,7 @@ mod tests {
             serde_json::json!(nonexistent.to_string_lossy()),
         );
         let call = ToolCall {
-            tool_id: "list_directory".to_owned(),
+            tool_id: zeph_tools::ToolName::new("list_directory"),
             params,
             caller_id: None,
         };
@@ -1009,7 +1009,7 @@ mod tests {
             serde_json::json!(dir.path().to_str().unwrap()),
         );
         let call = ToolCall {
-            tool_id: "list_directory".to_owned(),
+            tool_id: zeph_tools::ToolName::new("list_directory"),
             params,
             caller_id: None,
         };
@@ -1036,7 +1036,7 @@ mod tests {
             serde_json::json!(dir.path().to_str().unwrap()),
         );
         let call = ToolCall {
-            tool_id: "find_path".to_owned(),
+            tool_id: zeph_tools::ToolName::new("find_path"),
             params,
             caller_id: None,
         };
@@ -1063,7 +1063,7 @@ mod tests {
             serde_json::json!(dir.path().to_str().unwrap()),
         );
         let call = ToolCall {
-            tool_id: "find_path".to_owned(),
+            tool_id: zeph_tools::ToolName::new("find_path"),
             params,
             caller_id: None,
         };
@@ -1085,7 +1085,7 @@ mod tests {
         let mut params = serde_json::Map::new();
         params.insert("path".to_owned(), serde_json::json!(test_path("some_dir")));
         let call = ToolCall {
-            tool_id: "list_directory".to_owned(),
+            tool_id: zeph_tools::ToolName::new("list_directory"),
             params,
             caller_id: None,
         };
@@ -1112,7 +1112,7 @@ mod tests {
             serde_json::json!(dir.path().to_str().unwrap()),
         );
         let call = ToolCall {
-            tool_id: "find_path".to_owned(),
+            tool_id: zeph_tools::ToolName::new("find_path"),
             params,
             caller_id: None,
         };
@@ -1139,7 +1139,7 @@ mod tests {
             serde_json::json!(dir.path().to_str().unwrap()),
         );
         let call = ToolCall {
-            tool_id: "find_path".to_owned(),
+            tool_id: zeph_tools::ToolName::new("find_path"),
             params,
             caller_id: None,
         };
@@ -1162,7 +1162,7 @@ mod tests {
         params.insert("pattern".to_owned(), serde_json::json!("*.rs"));
         // no "path" key — should error, not default to "."
         let call = ToolCall {
-            tool_id: "find_path".to_owned(),
+            tool_id: zeph_tools::ToolName::new("find_path"),
             params,
             caller_id: None,
         };
@@ -1213,7 +1213,7 @@ mod tests {
                 let mut params = serde_json::Map::new();
                 params.insert("path".to_owned(), serde_json::json!("relative/path.txt"));
                 let call = ToolCall {
-                    tool_id: "read_file".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("read_file"),
                     params,
                     caller_id: None,
                 };
@@ -1260,7 +1260,7 @@ mod tests {
                 params.insert("path".to_owned(), serde_json::json!(traversal));
                 params.insert("content".to_owned(), serde_json::json!("evil"));
                 let call = ToolCall {
-                    tool_id: "write_file".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("write_file"),
                     params,
                     caller_id: None,
                 };
@@ -1357,7 +1357,7 @@ mod tests {
                 params.insert("path".to_owned(), serde_json::json!(test_path("out.txt")));
                 params.insert("content".to_owned(), serde_json::json!("data"));
                 let call = ToolCall {
-                    tool_id: "write_file".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("write_file"),
                     params,
                     caller_id: None,
                 };
@@ -1384,7 +1384,7 @@ mod tests {
                 params.insert("path".to_owned(), serde_json::json!(test_path("out.txt")));
                 params.insert("content".to_owned(), serde_json::json!("data"));
                 let call = ToolCall {
-                    tool_id: "write_file".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("write_file"),
                     params,
                     caller_id: None,
                 };
@@ -1411,7 +1411,7 @@ mod tests {
                 params.insert("path".to_owned(), serde_json::json!(test_path("out.txt")));
                 params.insert("content".to_owned(), serde_json::json!("data"));
                 let call = ToolCall {
-                    tool_id: "write_file".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("write_file"),
                     params,
                     caller_id: None,
                 };
@@ -1486,7 +1486,7 @@ mod tests {
             serde_json::json!(sandbox.path().to_str().unwrap()),
         );
         let call = ToolCall {
-            tool_id: "list_directory".to_owned(),
+            tool_id: zeph_tools::ToolName::new("list_directory"),
             params,
             caller_id: None,
         };
@@ -1530,7 +1530,7 @@ mod tests {
             serde_json::json!(sandbox.path().to_str().unwrap()),
         );
         let call = ToolCall {
-            tool_id: "find_path".to_owned(),
+            tool_id: zeph_tools::ToolName::new("find_path"),
             params,
             caller_id: None,
         };
@@ -1575,7 +1575,7 @@ mod tests {
                 let mut params = serde_json::Map::new();
                 params.insert("path".to_owned(), serde_json::json!(link.to_str().unwrap()));
                 let call = ToolCall {
-                    tool_id: "read_file".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("read_file"),
                     params,
                     caller_id: None,
                 };
@@ -1616,7 +1616,7 @@ mod tests {
                 params.insert("path".to_owned(), serde_json::json!(link.to_str().unwrap()));
                 params.insert("content".to_owned(), serde_json::json!("evil"));
                 let call = ToolCall {
-                    tool_id: "write_file".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("write_file"),
                     params,
                     caller_id: None,
                 };
@@ -1667,7 +1667,7 @@ mod tests {
                 params.insert("path".to_owned(), serde_json::json!(test_path("big.txt")));
                 params.insert("content".to_owned(), serde_json::json!(oversized));
                 let call = ToolCall {
-                    tool_id: "write_file".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("write_file"),
                     params,
                     caller_id: None,
                 };
@@ -1698,7 +1698,7 @@ mod tests {
                     serde_json::json!("hello\u{0000}world"),
                 );
                 let call = ToolCall {
-                    tool_id: "write_file".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("write_file"),
                     params,
                     caller_id: None,
                 };
@@ -1767,7 +1767,7 @@ mod tests {
                 params.insert("path".to_owned(), serde_json::json!(test_path("out.txt")));
                 params.insert("content".to_owned(), serde_json::json!("new content\n"));
                 let call = ToolCall {
-                    tool_id: "write_file".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("write_file"),
                     params,
                     caller_id: None,
                 };
@@ -1836,7 +1836,7 @@ mod tests {
                 params.insert("path".to_owned(), serde_json::json!(test_path("out.txt")));
                 params.insert("content".to_owned(), serde_json::json!("new\n"));
                 let call = ToolCall {
-                    tool_id: "write_file".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("write_file"),
                     params,
                     caller_id: None,
                 };
@@ -1948,7 +1948,7 @@ mod tests {
                 params.insert("path".to_owned(), serde_json::json!(test_path("toctou.txt")));
                 params.insert("content".to_owned(), serde_json::json!("my new content\n"));
                 let call = ToolCall {
-                    tool_id: "write_file".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("write_file"),
                     params,
                     caller_id: None,
                 };
@@ -1982,7 +1982,7 @@ mod tests {
                 params.insert("path".to_owned(), serde_json::json!(test_path("new.txt")));
                 params.insert("content".to_owned(), serde_json::json!("hello\n"));
                 let call = ToolCall {
-                    tool_id: "write_file".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("write_file"),
                     params,
                     caller_id: None,
                 };

--- a/crates/zeph-acp/src/terminal.rs
+++ b/crates/zeph-acp/src/terminal.rs
@@ -270,7 +270,7 @@ impl AcpShellExecutor {
             })?;
 
         Ok(Some(ToolOutput {
-            tool_name: "bash_stdin".to_owned(),
+            tool_name: zeph_tools::ToolName::new("bash_stdin"),
             summary: format!(
                 "wrote {} bytes to stdin of {}",
                 params.data.len(),
@@ -431,7 +431,7 @@ impl zeph_tools::ToolExecutor for AcpShellExecutor {
         }));
 
         Ok(Some(ToolOutput {
-            tool_name: "bash".to_owned(),
+            tool_name: zeph_tools::ToolName::new("bash"),
             summary,
             blocks_executed: 1,
             filter_stats: None,
@@ -823,7 +823,7 @@ mod tests {
                 params.insert("command".to_owned(), serde_json::json!("echo"));
                 params.insert("args".to_owned(), serde_json::json!(["hello"]));
                 let call = ToolCall {
-                    tool_id: "bash".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("bash"),
                     params,
                     caller_id: None,
                 };
@@ -846,7 +846,7 @@ mod tests {
                 tokio::task::spawn_local(handler);
 
                 let call = ToolCall {
-                    tool_id: "unknown".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("unknown"),
                     params: serde_json::Map::new(),
                     caller_id: None,
                 };
@@ -936,7 +936,7 @@ mod tests {
                 let mut params = serde_json::Map::new();
                 params.insert("command".to_owned(), serde_json::json!("false"));
                 let call = ToolCall {
-                    tool_id: "bash".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("bash"),
                     params,
                     caller_id: None,
                 };
@@ -1027,7 +1027,7 @@ mod tests {
                 params.insert("command".to_owned(), serde_json::json!("rm"));
                 params.insert("args".to_owned(), serde_json::json!(["-rf", "/important"]));
                 let call = ToolCall {
-                    tool_id: "bash".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("bash"),
                     params,
                     caller_id: None,
                 };
@@ -1131,7 +1131,7 @@ mod tests {
                 let mut params = serde_json::Map::new();
                 params.insert("command".to_owned(), serde_json::json!("rm -rf /"));
                 let call = ToolCall {
-                    tool_id: "bash".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("bash"),
                     params,
                     caller_id: None,
                 };
@@ -1158,7 +1158,7 @@ mod tests {
                     serde_json::json!("sudo apt install vim"),
                 );
                 let call = ToolCall {
-                    tool_id: "bash".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("bash"),
                     params,
                     caller_id: None,
                 };
@@ -1187,7 +1187,7 @@ mod tests {
                     serde_json::json!(["-c", "sudo rm -rf /"]),
                 );
                 let call = ToolCall {
-                    tool_id: "bash".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("bash"),
                     params,
                     caller_id: None,
                 };
@@ -1215,7 +1215,7 @@ mod tests {
                     serde_json::json!(["-c", "shutdown -h now"]),
                 );
                 let call = ToolCall {
-                    tool_id: "bash".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("bash"),
                     params,
                     caller_id: None,
                 };
@@ -1255,7 +1255,7 @@ mod tests {
                 params.insert("terminal_id".to_owned(), serde_json::json!("term-1"));
                 params.insert("data".to_owned(), serde_json::json!("hello\n"));
                 let call = ToolCall {
-                    tool_id: "bash_stdin".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("bash_stdin"),
                     params,
                     caller_id: None,
                 };
@@ -1299,7 +1299,7 @@ mod tests {
                 params.insert("terminal_id".to_owned(), serde_json::json!("term-1"));
                 params.insert("data".to_owned(), serde_json::json!(oversized));
                 let call = ToolCall {
-                    tool_id: "bash_stdin".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("bash_stdin"),
                     params,
                     caller_id: None,
                 };
@@ -1349,7 +1349,7 @@ mod tests {
                 params.insert("terminal_id".to_owned(), serde_json::json!("term-1"));
                 params.insert("data".to_owned(), serde_json::json!("echo hello\n"));
                 let call = ToolCall {
-                    tool_id: "bash_stdin".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("bash_stdin"),
                     params,
                     caller_id: None,
                 };
@@ -1400,7 +1400,7 @@ mod tests {
                 params.insert("terminal_id".to_owned(), serde_json::json!("term-1"));
                 params.insert("data".to_owned(), serde_json::json!(at_limit));
                 let call = ToolCall {
-                    tool_id: "bash_stdin".to_owned(),
+                    tool_id: zeph_tools::ToolName::new("bash_stdin"),
                     params,
                     caller_id: None,
                 };

--- a/crates/zeph-common/Cargo.toml
+++ b/crates/zeph-common/Cargo.toml
@@ -25,8 +25,9 @@ treesitter = [
 
 [dependencies]
 blake3.workspace = true
-serde = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive", "rc"] }
 thiserror.workspace = true
+uuid = { workspace = true, features = ["v4"] }
 zeroize = { workspace = true, features = ["alloc", "derive", "serde"] }
 tree-sitter = { workspace = true, optional = true }
 tree-sitter-go = { workspace = true, optional = true }
@@ -37,6 +38,7 @@ tree-sitter-typescript = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
+serde_json.workspace = true
 
 [lints]
 workspace = true

--- a/crates/zeph-common/src/lib.rs
+++ b/crates/zeph-common/src/lib.rs
@@ -4,9 +4,10 @@
 //! Shared utility functions and security primitives for Zeph crates.
 //!
 //! This crate provides pure utility functions (text manipulation, network helpers,
-//! sanitization primitives) and security primitives (`Secret`, `VaultError`) that are
-//! needed by multiple crates. It has no `zeph-*` dependencies. The optional `treesitter`
-//! feature adds tree-sitter query constants and helpers.
+//! sanitization primitives), security primitives (`Secret`, `VaultError`), and
+//! strongly-typed identifiers (`ToolName`, `SessionId`) that are needed by multiple crates.
+//! It has no `zeph-*` dependencies. The optional `treesitter` feature adds tree-sitter
+//! query constants and helpers.
 
 pub mod config;
 pub mod hash;
@@ -15,6 +16,9 @@ pub mod net;
 pub mod sanitize;
 pub mod secret;
 pub mod text;
+pub mod types;
+
+pub use types::{SessionId, ToolName};
 
 #[cfg(feature = "treesitter")]
 pub mod treesitter;

--- a/crates/zeph-common/src/types.rs
+++ b/crates/zeph-common/src/types.rs
@@ -1,0 +1,459 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Strongly-typed identifiers shared across `zeph-*` crates.
+//!
+//! This module defines `ToolName` and `SessionId` — newtypes that replace raw `String`
+//! fields in tool execution, LLM provider, and experiment subsystems.
+//!
+//! Both types use `#[serde(transparent)]` for zero-cost serialization compatibility:
+//! the JSON wire format is unchanged relative to plain `String` fields.
+
+use std::borrow::Borrow;
+use std::fmt;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+/// Strongly-typed tool name label.
+///
+/// `ToolName` identifies a tool by its canonical name (e.g., `"shell"`, `"web_scrape"`).
+/// It is produced by the LLM in JSON tool-use responses and matched against the registered
+/// tool registry at dispatch time.
+///
+/// # Label semantics (not a validated reference)
+///
+/// `ToolName` is an unvalidated label from untrusted input (LLM JSON). It does **not**
+/// guarantee that a tool with this name is registered. Validation happens downstream at
+/// tool dispatch, not at construction.
+///
+/// # Inner type: `Arc<str>`
+///
+/// The inner type is `Arc<str>`, not `String`. Tool names are cloned into multiple contexts
+/// (event channels, tracing spans, tool output structs) during a single tool execution.
+/// `Arc<str>` makes all clones O(1) vs O(n) for `String`. Use `.clone()` to duplicate
+/// a `ToolName` — it is cheap.
+///
+/// # No `Deref<Target=str>`
+///
+/// `ToolName` does **not** implement `Deref<Target=str>`. This prevents the `.to_owned()`
+/// footgun where muscle memory returns `String` instead of `ToolName`. Use `.as_str()` for
+/// explicit string conversion and `.clone()` to duplicate the `ToolName`.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_common::ToolName;
+///
+/// let name = ToolName::new("shell");
+/// assert_eq!(name.as_str(), "shell");
+/// assert_eq!(name, "shell");
+///
+/// // Clone is O(1) — Arc reference count increment only.
+/// let name2 = name.clone();
+/// assert_eq!(name, name2);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ToolName(Arc<str>);
+
+impl ToolName {
+    /// Construct a `ToolName` from any value convertible to `Arc<str>`.
+    ///
+    /// This is the primary constructor. The name is accepted without validation — it is a
+    /// label from the LLM wire or tool registry, not a proof of registration.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_common::ToolName;
+    ///
+    /// let name = ToolName::new("shell");
+    /// assert_eq!(name.as_str(), "shell");
+    /// ```
+    #[must_use]
+    pub fn new(s: impl Into<Arc<str>>) -> Self {
+        Self(s.into())
+    }
+
+    /// Return the inner string slice.
+    ///
+    /// Prefer this over `Deref` (which is intentionally not implemented) when an `&str`
+    /// reference is needed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_common::ToolName;
+    ///
+    /// let name = ToolName::new("web_scrape");
+    /// assert_eq!(name.as_str(), "web_scrape");
+    /// ```
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Default for ToolName {
+    /// Returns an empty `ToolName`.
+    ///
+    /// This implementation exists solely for `#[serde(default)]` on optional fields.
+    /// Do not construct a `ToolName` with an empty string in application code.
+    fn default() -> Self {
+        Self(Arc::from(""))
+    }
+}
+
+impl fmt::Display for ToolName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for ToolName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Borrow<str> for ToolName {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for ToolName {
+    fn from(s: &str) -> Self {
+        Self(Arc::from(s))
+    }
+}
+
+impl From<String> for ToolName {
+    fn from(s: String) -> Self {
+        Self(Arc::from(s.as_str()))
+    }
+}
+
+impl FromStr for ToolName {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from(s))
+    }
+}
+
+impl PartialEq<str> for ToolName {
+    fn eq(&self, other: &str) -> bool {
+        self.0.as_ref() == other
+    }
+}
+
+impl PartialEq<&str> for ToolName {
+    fn eq(&self, other: &&str) -> bool {
+        self.0.as_ref() == *other
+    }
+}
+
+impl PartialEq<String> for ToolName {
+    fn eq(&self, other: &String) -> bool {
+        self.0.as_ref() == other.as_str()
+    }
+}
+
+impl PartialEq<ToolName> for str {
+    fn eq(&self, other: &ToolName) -> bool {
+        self == other.0.as_ref()
+    }
+}
+
+impl PartialEq<ToolName> for String {
+    fn eq(&self, other: &ToolName) -> bool {
+        self.as_str() == other.0.as_ref()
+    }
+}
+
+// ── SessionId ────────────────────────────────────────────────────────────────
+
+/// Identifies a single agent session (one binary invocation or one ACP connection).
+///
+/// Uses `String` internally to support both UUID-based IDs (production) and
+/// arbitrary string IDs (tests, experiments). UUID validation is enforced only at
+/// [`SessionId::generate`] time; [`SessionId::new`] accepts any non-empty string for
+/// flexibility in test fixtures.
+///
+/// # Serialization
+///
+/// `SessionId` uses `#[serde(transparent)]` — it serializes as a plain JSON string
+/// identical to the raw `String` fields it replaces. No wire format change, no DB
+/// schema migration required.
+///
+/// # ACP Note
+///
+/// `acp::SessionId` from the external `agent_client_protocol` crate is distinct.
+/// This type is for **our own** session tracking only.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_common::SessionId;
+///
+/// // Production: generate a fresh UUID session
+/// let id = SessionId::generate();
+/// assert!(!id.as_str().is_empty());
+///
+/// // Tests: use a readable fixture string
+/// let test_id = SessionId::new("test-session");
+/// assert_eq!(test_id.as_str(), "test-session");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SessionId(String);
+
+impl SessionId {
+    /// Create a `SessionId` from any non-empty string.
+    ///
+    /// Accepts UUID strings (production), readable names (tests), or any other
+    /// non-empty value. In debug builds, an empty string triggers a `debug_assert!`
+    /// to catch accidental construction early.
+    ///
+    /// # Panics
+    ///
+    /// Panics in **debug builds only** if `s` is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_common::SessionId;
+    ///
+    /// let id = SessionId::new("test-session");
+    /// assert_eq!(id.as_str(), "test-session");
+    /// ```
+    pub fn new(s: impl Into<String>) -> Self {
+        let s = s.into();
+        debug_assert!(!s.is_empty(), "SessionId must not be empty");
+        Self(s)
+    }
+
+    /// Generate a new session ID backed by a random UUID v4.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_common::SessionId;
+    ///
+    /// let id = SessionId::generate();
+    /// assert!(!id.as_str().is_empty());
+    /// // UUIDs are 36 chars: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+    /// assert_eq!(id.as_str().len(), 36);
+    /// ```
+    #[must_use]
+    pub fn generate() -> Self {
+        Self(uuid::Uuid::new_v4().to_string())
+    }
+
+    /// Return the inner string slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_common::SessionId;
+    ///
+    /// let id = SessionId::new("s1");
+    /// assert_eq!(id.as_str(), "s1");
+    /// ```
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Default for SessionId {
+    /// Generate a new UUID-backed session ID.
+    fn default() -> Self {
+        Self::generate()
+    }
+}
+
+impl fmt::Display for SessionId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for SessionId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for SessionId {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for SessionId {
+    fn from(s: String) -> Self {
+        Self::new(s)
+    }
+}
+
+impl From<&str> for SessionId {
+    fn from(s: &str) -> Self {
+        Self::new(s)
+    }
+}
+
+impl From<uuid::Uuid> for SessionId {
+    fn from(u: uuid::Uuid) -> Self {
+        Self(u.to_string())
+    }
+}
+
+impl FromStr for SessionId {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::new(s))
+    }
+}
+
+impl PartialEq<str> for SessionId {
+    fn eq(&self, other: &str) -> bool {
+        self.0 == other
+    }
+}
+
+impl PartialEq<&str> for SessionId {
+    fn eq(&self, other: &&str) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialEq<String> for SessionId {
+    fn eq(&self, other: &String) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialEq<SessionId> for str {
+    fn eq(&self, other: &SessionId) -> bool {
+        self == other.0
+    }
+}
+
+impl PartialEq<SessionId> for String {
+    fn eq(&self, other: &SessionId) -> bool {
+        *self == other.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_name_construction_and_equality() {
+        let name = ToolName::new("shell");
+        assert_eq!(name.as_str(), "shell");
+        assert_eq!(name, "shell");
+        assert_eq!(name, "shell".to_owned());
+        assert_eq!(name, "shell"); // symmetric check via PartialEq<str>
+    }
+
+    #[test]
+    fn tool_name_clone_is_cheap() {
+        let name = ToolName::new("web_scrape");
+        let name2 = name.clone();
+        assert_eq!(name, name2);
+        // Both Arc<str> point to same allocation
+        assert!(Arc::ptr_eq(&name.0, &name2.0));
+    }
+
+    #[test]
+    fn tool_name_from_impls() {
+        let from_str: ToolName = ToolName::from("bash");
+        let from_string: ToolName = ToolName::from("bash".to_owned());
+        let parsed: ToolName = "bash".parse().unwrap();
+        assert_eq!(from_str, from_string);
+        assert_eq!(from_str, parsed);
+    }
+
+    #[test]
+    fn tool_name_as_hashmap_key() {
+        use std::collections::HashMap;
+        let mut map: HashMap<ToolName, u32> = HashMap::new();
+        map.insert(ToolName::new("shell"), 1);
+        // Borrow<str> enables lookup by &str
+        assert_eq!(map.get("shell"), Some(&1));
+    }
+
+    #[test]
+    fn tool_name_display() {
+        let name = ToolName::new("my_tool");
+        assert_eq!(format!("{name}"), "my_tool");
+    }
+
+    #[test]
+    fn tool_name_serde_transparent() {
+        let name = ToolName::new("shell");
+        let json = serde_json::to_string(&name).unwrap();
+        assert_eq!(json, r#""shell""#);
+        let back: ToolName = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, name);
+    }
+
+    #[test]
+    fn session_id_new_roundtrip() {
+        let id = SessionId::new("test-session");
+        assert_eq!(id.as_str(), "test-session");
+        assert_eq!(id.to_string(), "test-session");
+    }
+
+    #[test]
+    fn session_id_generate_is_uuid() {
+        let id = SessionId::generate();
+        assert_eq!(id.as_str().len(), 36);
+        assert!(uuid::Uuid::parse_str(id.as_str()).is_ok());
+    }
+
+    #[test]
+    fn session_id_default_is_generated() {
+        let id = SessionId::default();
+        assert!(!id.as_str().is_empty());
+        assert_eq!(id.as_str().len(), 36);
+    }
+
+    #[test]
+    fn session_id_from_uuid() {
+        let u = uuid::Uuid::new_v4();
+        let id = SessionId::from(u);
+        assert_eq!(id.as_str(), u.to_string());
+    }
+
+    #[test]
+    fn session_id_deref_slicing() {
+        let id = SessionId::new("abcdefgh");
+        // Deref<Target=str> enables string slicing
+        assert_eq!(&id[..4], "abcd");
+    }
+
+    #[test]
+    fn session_id_serde_transparent() {
+        let id = SessionId::new("sess-abc");
+        let json = serde_json::to_string(&id).unwrap();
+        assert_eq!(json, r#""sess-abc""#);
+        let back: SessionId = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, id);
+    }
+
+    #[test]
+    fn session_id_from_str_parses() {
+        let id: SessionId = "my-session".parse().unwrap();
+        assert_eq!(id.as_str(), "my-session");
+    }
+}

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -888,7 +888,7 @@ impl<C: Channel> Agent<C> {
             match provider.embed(&text).await {
                 Ok(emb) => {
                     embeddings.push(zeph_tools::ToolEmbedding {
-                        tool_id: def.id.to_string(),
+                        tool_id: def.id.as_ref().into(),
                         embedding: emb,
                     });
                 }

--- a/crates/zeph-core/src/agent/compaction_strategy.rs
+++ b/crates/zeph-core/src/agent/compaction_strategy.rs
@@ -112,7 +112,7 @@ pub(crate) fn extract_scorable_text(msg: &Message) -> String {
             MessagePart::ToolOutput {
                 body, tool_name, ..
             } => {
-                parts_text.push_str(tool_name);
+                parts_text.push_str(tool_name.as_str());
                 parts_text.push(' ');
                 parts_text.push_str(body);
                 parts_text.push(' ');

--- a/crates/zeph-core/src/agent/context/tests.rs
+++ b/crates/zeph-core/src/agent/context/tests.rs
@@ -1276,7 +1276,7 @@ fn prune_stale_tool_outputs_clears_old() {
         agent.msg.messages.push(Message::from_parts(
             Role::User,
             vec![MessagePart::ToolOutput {
-                tool_name: format!("tool_{i}"),
+                tool_name: format!("tool_{i}").into(),
                 body: "x".repeat(200),
                 compacted_at: None,
             }],
@@ -2916,7 +2916,7 @@ fn make_tool_pair_with_output(agent: &mut Agent<MockChannel>, tool_name: &str) {
     agent.msg.messages.push(Message::from_parts(
         Role::User,
         vec![MessagePart::ToolOutput {
-            tool_name: tool_name.to_owned(),
+            tool_name: tool_name.into(),
             body: format!("full output of {tool_name}"),
             compacted_at: None,
         }],

--- a/crates/zeph-core/src/agent/error.rs
+++ b/crates/zeph-core/src/agent/error.rs
@@ -31,7 +31,7 @@ pub enum AgentError {
 
     /// A tool call exceeded its configured timeout.
     #[error("tool timed out: {tool_name}")]
-    ToolTimeout { tool_name: String },
+    ToolTimeout { tool_name: zeph_common::ToolName },
 
     /// Structured output did not conform to the expected JSON schema.
     #[error("schema validation failed: {0}")]

--- a/crates/zeph-core/src/agent/magic_docs.rs
+++ b/crates/zeph-core/src/agent/magic_docs.rs
@@ -108,7 +108,7 @@ impl<C: Channel> super::Agent<C> {
                             .and_then(|idx| use_queue.remove(idx))
                             .and_then(|(_, p)| p);
 
-                        if is_file_read_tool(tool_name)
+                        if is_file_read_tool(tool_name.as_str())
                             && body.contains(MAGIC_DOC_HEADER)
                             && let Some(path_str) = file_path
                         {
@@ -122,7 +122,7 @@ impl<C: Channel> super::Agent<C> {
                         ..
                     } => {
                         if let Some((tool_name, file_path)) = id_map.get(tool_use_id)
-                            && is_file_read_tool(tool_name)
+                            && is_file_read_tool(tool_name.as_str())
                             && content.contains(MAGIC_DOC_HEADER)
                             && let Some(path_str) = file_path
                         {
@@ -403,7 +403,7 @@ mod tests {
                                 .and_then(|idx| use_queue.remove(idx))
                                 .and_then(|(_, p)| p);
 
-                            if is_file_read_tool(tool_name)
+                            if is_file_read_tool(tool_name.as_str())
                                 && body.contains(MAGIC_DOC_HEADER)
                                 && let Some(path_str) = file_path
                             {
@@ -450,7 +450,7 @@ mod tests {
                             .and_then(|idx| use_queue.remove(idx))
                             .and_then(|(_, p)| p);
 
-                        if is_file_read_tool(tool_name)
+                        if is_file_read_tool(tool_name.as_str())
                             && body.contains(MAGIC_DOC_HEADER)
                             && let Some(path_str) = file_path
                         {
@@ -516,7 +516,7 @@ mod tests {
                         ..
                     } = part
                         && let Some((tool_name, file_path)) = id_map.get(tool_use_id)
-                        && is_file_read_tool(tool_name)
+                        && is_file_read_tool(tool_name.as_str())
                         && content.contains(MAGIC_DOC_HEADER)
                         && let Some(path_str) = file_path
                     {
@@ -555,7 +555,7 @@ mod tests {
                         ..
                     } = part
                         && let Some((tool_name, file_path)) = id_map.get(tool_use_id)
-                        && is_file_read_tool(tool_name)
+                        && is_file_read_tool(tool_name.as_str())
                         && content.contains(MAGIC_DOC_HEADER)
                         && let Some(path_str) = file_path
                     {

--- a/crates/zeph-core/src/agent/microcompact.rs
+++ b/crates/zeph-core/src/agent/microcompact.rs
@@ -111,7 +111,7 @@ impl<C: Channel> super::Agent<C> {
                     } => {
                         if compacted_at.is_some()
                             || body.starts_with(CLEARED_SENTINEL_PREFIX)
-                            || !is_low_value_tool(tool_name)
+                            || !is_low_value_tool(tool_name.as_str())
                         {
                             continue;
                         }

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -460,7 +460,7 @@ impl<C: Channel> Agent<C> {
             .filter(|(id, _, _)| !paired_ids.contains(*id))
             .map(|(id, name, input)| zeph_llm::provider::ToolUseRequest {
                 id: (*id).to_owned(),
-                name: (*name).to_owned(),
+                name: (*name).to_owned().into(),
                 input: (*input).clone(),
             })
             .collect();

--- a/crates/zeph-core/src/agent/persistence.rs
+++ b/crates/zeph-core/src/agent/persistence.rs
@@ -2230,7 +2230,7 @@ mod tests {
         );
 
         let parts = vec![MessagePart::ToolOutput {
-            tool_name: "shell".to_string(),
+            tool_name: "shell".into(),
             body: "hello from shell".to_string(),
             compacted_at: None,
         }];
@@ -3131,12 +3131,12 @@ mod tests {
         let tool_calls = vec![
             zeph_llm::provider::ToolUseRequest {
                 id: "cancel_id_1".to_string(),
-                name: "shell".to_string(),
+                name: "shell".to_string().into(),
                 input: serde_json::json!({}),
             },
             zeph_llm::provider::ToolUseRequest {
                 id: "cancel_id_2".to_string(),
-                name: "read_file".to_string(),
+                name: "read_file".to_string().into(),
                 input: serde_json::json!({}),
             },
         ];

--- a/crates/zeph-core/src/agent/scheduler_commands.rs
+++ b/crates/zeph-core/src/agent/scheduler_commands.rs
@@ -27,7 +27,7 @@ impl<C: Channel> Agent<C> {
 
     async fn handle_scheduler_list(&mut self) -> Result<(), AgentError> {
         let call = ToolCall {
-            tool_id: "list_tasks".to_owned(),
+            tool_id: zeph_common::ToolName::new("list_tasks"),
             params: serde_json::Map::new(),
             caller_id: None,
         };

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -491,7 +491,7 @@ impl<C: crate::channel::Channel> Agent<C> {
                     for tc in &tool_calls {
                         parts.push(MessagePart::ToolUse {
                             id: tc.id.clone(),
-                            name: tc.name.clone(),
+                            name: tc.name.to_string(),
                             input: tc.input.clone(),
                         });
                     }

--- a/crates/zeph-core/src/agent/sidequest.rs
+++ b/crates/zeph-core/src/agent/sidequest.rs
@@ -35,7 +35,7 @@ pub(crate) struct ToolOutputCursor {
     /// Part index within the message parts vec.
     pub(crate) part_index: usize,
     /// Tool name for display.
-    pub(crate) tool_name: String,
+    pub(crate) tool_name: zeph_common::ToolName,
     /// Token count of the tool output.
     pub(crate) token_count: usize,
     /// One-line preview (first 120 chars).
@@ -107,7 +107,7 @@ impl SidequestState {
                 continue;
             }
             for (part_index, part) in msg.parts.iter().enumerate() {
-                let (body, tool_name) = match part {
+                let (body, tool_name): (&str, zeph_common::ToolName) = match part {
                     MessagePart::ToolOutput {
                         body,
                         tool_name,
@@ -118,7 +118,7 @@ impl SidequestState {
                         if compacted_at.is_some() || body.is_empty() {
                             continue;
                         }
-                        (body.as_str(), tool_name.as_str())
+                        (body.as_str(), tool_name.clone())
                     }
                     MessagePart::ToolResult {
                         tool_use_id,
@@ -128,7 +128,10 @@ impl SidequestState {
                         if content == "[evicted by sidequest]" || content.is_empty() {
                             continue;
                         }
-                        (content.as_str(), tool_use_id.as_str())
+                        (
+                            content.as_str(),
+                            zeph_common::ToolName::new(tool_use_id.as_str()),
+                        )
                     }
                     _ => continue,
                 };
@@ -140,7 +143,7 @@ impl SidequestState {
                 self.tool_output_cursors.push(ToolOutputCursor {
                     msg_index,
                     part_index,
-                    tool_name: tool_name.to_string(),
+                    tool_name,
                     token_count,
                     preview,
                 });
@@ -306,7 +309,7 @@ mod tests {
         state.tool_output_cursors.push(ToolOutputCursor {
             msg_index: 1,
             part_index: 0,
-            tool_name: "my_tool".to_string(),
+            tool_name: "my_tool".into(),
             token_count: 500,
             preview: "some output".to_string(),
         });
@@ -445,7 +448,7 @@ mod tests {
                     role: Role::User,
                     content: body.clone(),
                     parts: vec![MessagePart::ToolOutput {
-                        tool_name: format!("tool_{i}"),
+                        tool_name: zeph_common::ToolName::new(format!("tool_{i}")),
                         body,
                         compacted_at: None,
                     }],
@@ -558,7 +561,7 @@ mod tests {
         state.tool_output_cursors.push(ToolOutputCursor {
             msg_index: 0,
             part_index: 0,
-            tool_name: "shell".to_string(),
+            tool_name: "shell".into(),
             token_count: 100,
             preview: "output".to_string(),
         });

--- a/crates/zeph-core/src/agent/tests.rs
+++ b/crates/zeph-core/src/agent/tests.rs
@@ -419,7 +419,7 @@ pub mod agent_tests {
         ]);
         let registry = create_test_registry();
         let executor = MockToolExecutor::new(vec![Ok(Some(ToolOutput {
-            tool_name: "bash".to_string(),
+            tool_name: "bash".into(),
             summary: "tool executed successfully".to_string(),
             blocks_executed: 1,
             filter_stats: None,
@@ -724,7 +724,7 @@ pub mod agent_tests {
         let registry = create_test_registry();
         let executor = MockToolExecutor::new(vec![
             Ok(Some(ToolOutput {
-                tool_name: "bash".to_string(),
+                tool_name: "bash".into(),
                 summary: "[error] command failed [exit code 1]".to_string(),
                 blocks_executed: 1,
                 filter_stats: None,
@@ -750,7 +750,7 @@ pub mod agent_tests {
         let channel = MockChannel::new(vec!["test".to_string()]);
         let registry = create_test_registry();
         let executor = MockToolExecutor::new(vec![Ok(Some(ToolOutput {
-            tool_name: "bash".to_string(),
+            tool_name: "bash".into(),
             summary: "   ".to_string(),
             blocks_executed: 1,
             filter_stats: None,
@@ -879,7 +879,7 @@ pub mod agent_tests {
         let channel = MockChannel::new(vec!["start task".to_string()]);
         let registry = create_test_registry();
         let executor = MockToolExecutor::new(vec![Ok(Some(ToolOutput {
-            tool_name: "bash".to_string(),
+            tool_name: "bash".into(),
             summary: "step 1 complete".to_string(),
             blocks_executed: 1,
             filter_stats: None,
@@ -919,7 +919,7 @@ pub mod agent_tests {
         let mut outputs = vec![];
         for _ in 0..10 {
             outputs.push(Ok(Some(ToolOutput {
-                tool_name: "bash".to_string(),
+                tool_name: "bash".into(),
                 summary: "continuing".to_string(),
                 blocks_executed: 1,
                 filter_stats: None,
@@ -3872,7 +3872,7 @@ mod inline_tool_loop_tests {
             text: None,
             tool_calls: vec![ToolUseRequest {
                 id: tool_id.to_owned(),
-                name: tool_name.to_owned(),
+                name: tool_name.into(),
                 input: serde_json::json!({"arg": "val"}),
             }],
             thinking_blocks: vec![],
@@ -4160,7 +4160,7 @@ mod confirmation_propagation_tests {
 
         fn make_output(tool_name: &str, summary: &str) -> ToolOutput {
             ToolOutput {
-                tool_name: tool_name.to_owned(),
+                tool_name: tool_name.into(),
                 summary: summary.to_owned(),
                 blocks_executed: 1,
                 filter_stats: None,
@@ -4207,14 +4207,14 @@ mod confirmation_propagation_tests {
             call: &ToolCall,
         ) -> Result<Option<ToolOutput>, ToolError> {
             let mut results = self.results.lock().unwrap();
-            results.remove(&call.tool_id).unwrap_or(Ok(None))
+            results.remove(call.tool_id.as_str()).unwrap_or(Ok(None))
         }
 
         async fn execute_tool_call_confirmed(
             &self,
             call: &ToolCall,
         ) -> Result<Option<ToolOutput>, ToolError> {
-            Ok(Some(Self::make_output(&call.tool_id, "confirmed")))
+            Ok(Some(Self::make_output(call.tool_id.as_str(), "confirmed")))
         }
     }
 
@@ -4224,12 +4224,12 @@ mod confirmation_propagation_tests {
             tool_calls: vec![
                 ToolUseRequest {
                     id: "tool_a_id".to_owned(),
-                    name: "tool_a".to_owned(),
+                    name: "tool_a".to_owned().into(),
                     input: serde_json::json!({"arg": "value"}),
                 },
                 ToolUseRequest {
                     id: "tool_b_id".to_owned(),
-                    name: "tool_b".to_owned(),
+                    name: "tool_b".to_owned().into(),
                     input: serde_json::json!({"source": "tool_a_id"}),
                 },
             ],
@@ -4243,12 +4243,12 @@ mod confirmation_propagation_tests {
             tool_calls: vec![
                 ToolUseRequest {
                     id: "tool_a_id".to_owned(),
-                    name: "tool_a".to_owned(),
+                    name: "tool_a".to_owned().into(),
                     input: serde_json::json!({"arg": "value"}),
                 },
                 ToolUseRequest {
                     id: "tool_c_id".to_owned(),
-                    name: "tool_c".to_owned(),
+                    name: "tool_c".to_owned().into(),
                     input: serde_json::json!({"arg": "independent"}),
                 },
             ],
@@ -4594,7 +4594,7 @@ mod shutdown_summary_tests {
                 text: None,
                 tool_calls: vec![ToolUseRequest {
                     id: format!("toolu_{i:06}"),
-                    name: "stub_tool".to_owned(),
+                    name: "stub_tool".to_owned().into(),
                     // Vary the input so args_hash differs each iteration → no repeat-detect
                     input: serde_json::json!({ "iteration": i }),
                 }],
@@ -4649,7 +4649,7 @@ mod shutdown_summary_tests {
                 _call: &ToolCall,
             ) -> Result<Option<ToolOutput>, ToolError> {
                 Ok(Some(ToolOutput {
-                    tool_name: "shell".to_owned(),
+                    tool_name: "shell".into(),
                     summary: "filtered output".to_owned(),
                     blocks_executed: 1,
                     filter_stats: Some(FilterStats {
@@ -4676,7 +4676,7 @@ mod shutdown_summary_tests {
                 text: None,
                 tool_calls: vec![ToolUseRequest {
                     id: "call-1".to_owned(),
-                    name: "shell".to_owned(),
+                    name: "shell".to_owned().into(),
                     input: serde_json::json!({"cmd": "ls"}),
                 }],
                 thinking_blocks: vec![],
@@ -4745,7 +4745,7 @@ mod shutdown_summary_tests {
                 };
                 if n == 1 || call.tool_id == "tool_a_id" {
                     Ok(Some(ToolOutput {
-                        tool_name: "tool_a".to_owned(),
+                        tool_name: "tool_a".into(),
                         summary: "[error] command failed [exit code 1]".to_owned(),
                         blocks_executed: 1,
                         filter_stats: None,
@@ -4758,7 +4758,7 @@ mod shutdown_summary_tests {
                     }))
                 } else {
                     Ok(Some(ToolOutput {
-                        tool_name: "tool_b".to_owned(),
+                        tool_name: "tool_b".into(),
                         summary: "filtered output".to_owned(),
                         blocks_executed: 1,
                         filter_stats: Some(FilterStats {
@@ -4789,12 +4789,12 @@ mod shutdown_summary_tests {
                 tool_calls: vec![
                     ToolUseRequest {
                         id: "tool_a_id".to_owned(),
-                        name: "tool_a".to_owned(),
+                        name: "tool_a".to_owned().into(),
                         input: serde_json::json!({}),
                     },
                     ToolUseRequest {
                         id: "tool_b_id".to_owned(),
-                        name: "tool_b".to_owned(),
+                        name: "tool_b".to_owned().into(),
                         input: serde_json::json!({}),
                     },
                 ],
@@ -4963,7 +4963,7 @@ mod pre_execution_audit_tests {
                 text: None,
                 tool_calls: vec![ToolUseRequest {
                     id: "call-block".to_owned(),
-                    name: "read_file".to_owned(),
+                    name: "read_file".to_owned().into(),
                     input: serde_json::json!({"file_path": "/etc/passwd"}),
                 }],
                 thinking_blocks: vec![],

--- a/crates/zeph-core/src/agent/tool_execution/mod.rs
+++ b/crates/zeph-core/src/agent/tool_execution/mod.rs
@@ -626,7 +626,9 @@ pub(crate) fn tool_def_to_definition(def: &zeph_tools::registry::ToolDef) -> Too
         map.remove("title");
     }
     ToolDefinition {
-        name: def.id.to_string(),
+        // NOTE: ToolDef.id uses Cow<'static, str> for zero-copy registration.
+        // Converted to ToolName at the LLM boundary for type safety downstream.
+        name: zeph_common::ToolName::new(def.id.as_ref()),
         description: def.description.to_string(),
         parameters: params,
     }

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -110,7 +110,7 @@ impl<C: Channel> Agent<C> {
 
         // Iteration 0: apply dynamic tool schema filter (#2020) if cached IDs are available.
         if let Some(ref filtered_ids) = self.tool_state.cached_filtered_tool_ids {
-            tool_defs.retain(|d| filtered_ids.contains(&d.name));
+            tool_defs.retain(|d| filtered_ids.contains(d.name.as_str()));
             tracing::debug!(
                 filtered = tool_defs.len(),
                 total = all_tool_defs.len(),
@@ -547,7 +547,7 @@ impl<C: Channel> Agent<C> {
         let tool_started_at = std::time::Instant::now();
         self.channel
             .send_tool_start(ToolStartEvent {
-                tool_name: &output.tool_name,
+                tool_name: output.tool_name.as_str(),
                 tool_call_id: &tool_call_id,
                 params: None,
                 parent_tool_use_id: self.session.parent_tool_use_id.clone(),
@@ -559,23 +559,26 @@ impl<C: Channel> Agent<C> {
             } else {
                 output.summary.clone()
             };
-            d.dump_tool_output(&output.tool_name, &dump_content);
+            d.dump_tool_output(output.tool_name.as_str(), &dump_content);
         }
         let processed = self.maybe_summarize_tool_output(&output.summary).await;
         let body = if let Some(ref fs) = output.filter_stats
             && fs.filtered_chars < fs.raw_chars
         {
-            format!("{}\n{processed}", fs.format_inline(&output.tool_name))
+            format!(
+                "{}\n{processed}",
+                fs.format_inline(output.tool_name.as_str())
+            )
         } else {
             processed.clone()
         };
         let filter_stats_inline = output.filter_stats.as_ref().and_then(|fs| {
-            (fs.filtered_chars < fs.raw_chars).then(|| fs.format_inline(&output.tool_name))
+            (fs.filtered_chars < fs.raw_chars).then(|| fs.format_inline(output.tool_name.as_str()))
         });
-        let formatted_output = format_tool_output(&output.tool_name, &body);
+        let formatted_output = format_tool_output(output.tool_name.as_str(), &body);
         self.channel
             .send_tool_output(ToolOutputEvent {
-                tool_name: &output.tool_name,
+                tool_name: output.tool_name.as_str(),
                 body: &self.maybe_redact(&body),
                 diff: None,
                 filter_stats: filter_stats_inline,
@@ -590,7 +593,7 @@ impl<C: Channel> Agent<C> {
             .await?;
 
         let (llm_body, has_injection_flags) = self
-            .sanitize_tool_output(&processed, &output.tool_name)
+            .sanitize_tool_output(&processed, output.tool_name.as_str())
             .await;
         let user_msg = Message::from_parts(
             Role::User,
@@ -633,7 +636,7 @@ impl<C: Channel> Agent<C> {
                 let confirmed_started_at = std::time::Instant::now();
                 self.channel
                     .send_tool_start(ToolStartEvent {
-                        tool_name: &out.tool_name,
+                        tool_name: out.tool_name.as_str(),
                         tool_call_id: &confirmed_tool_call_id,
                         params: None,
                         parent_tool_use_id: self.session.parent_tool_use_id.clone(),
@@ -645,13 +648,13 @@ impl<C: Channel> Agent<C> {
                     } else {
                         out.summary.clone()
                     };
-                    d.dump_tool_output(&out.tool_name, &dump_content);
+                    d.dump_tool_output(out.tool_name.as_str(), &dump_content);
                 }
                 let processed = self.maybe_summarize_tool_output(&out.summary).await;
-                let formatted = format_tool_output(&out.tool_name, &processed);
+                let formatted = format_tool_output(out.tool_name.as_str(), &processed);
                 self.channel
                     .send_tool_output(ToolOutputEvent {
-                        tool_name: &out.tool_name,
+                        tool_name: out.tool_name.as_str(),
                         body: &self.maybe_redact(&processed),
                         diff: None,
                         filter_stats: None,
@@ -664,8 +667,9 @@ impl<C: Channel> Agent<C> {
                         started_at: Some(confirmed_started_at),
                     })
                     .await?;
-                let (llm_body, has_injection_flags) =
-                    self.sanitize_tool_output(&processed, &out.tool_name).await;
+                let (llm_body, has_injection_flags) = self
+                    .sanitize_tool_output(&processed, out.tool_name.as_str())
+                    .await;
                 let confirmed_msg = Message::from_parts(
                     Role::User,
                     vec![MessagePart::ToolOutput {
@@ -987,7 +991,9 @@ impl<C: Channel> Agent<C> {
                 let text_tokens = estimate_tokens(text.as_deref().unwrap_or(""));
                 let calls_tokens: usize = tool_calls
                     .iter()
-                    .map(|c| estimate_tokens(&c.name) + estimate_tokens(&c.input.to_string()))
+                    .map(|c| {
+                        estimate_tokens(c.name.as_str()) + estimate_tokens(&c.input.to_string())
+                    })
                     .sum();
                 (text_tokens + calls_tokens) as u64
             }
@@ -1131,7 +1137,7 @@ impl<C: Channel> Agent<C> {
         for tc in tool_calls {
             parts.push(MessagePart::ToolUse {
                 id: tc.id.clone(),
-                name: tc.name.clone(),
+                name: tc.name.to_string(),
                 input: tc.input.clone(),
             });
         }
@@ -1162,7 +1168,7 @@ impl<C: Channel> Agent<C> {
                     } else {
                         serde_json::Map::new()
                     };
-                if tafc_enabled && strip_tafc_fields(&mut params, &tc.name).is_err() {
+                if tafc_enabled && strip_tafc_fields(&mut params, tc.name.as_str()).is_err() {
                     // Model produced only think fields — skip this tool call.
                     return None;
                 }
@@ -1188,7 +1194,7 @@ impl<C: Channel> Agent<C> {
         for tc in tool_calls {
             let args_json = tc.input.to_string();
             let url_events = self.security.exfiltration_guard.validate_tool_call(
-                &tc.name,
+                tc.name.as_str(),
                 &args_json,
                 &self.security.flagged_urls,
             );
@@ -1203,7 +1209,7 @@ impl<C: Channel> Agent<C> {
                 });
                 self.push_security_event(
                     crate::metrics::SecurityEventCategory::ExfiltrationBlock,
-                    &tc.name,
+                    tc.name.as_str(),
                     format!(
                         "{} suspicious URL(s) flagged in tool args",
                         url_events.len()
@@ -1221,7 +1227,7 @@ impl<C: Channel> Agent<C> {
             for (idx, call) in calls.iter().enumerate() {
                 let args_value = serde_json::Value::Object(call.params.clone());
                 for verifier in &self.tool_orchestrator.pre_execution_verifiers {
-                    match verifier.verify(&call.tool_id, &args_value) {
+                    match verifier.verify(call.tool_id.as_str(), &args_value) {
                         zeph_tools::VerificationResult::Allow => {}
                         zeph_tools::VerificationResult::Block { reason } => {
                             tracing::warn!(
@@ -1233,7 +1239,7 @@ impl<C: Channel> Agent<C> {
                             self.update_metrics(|m| m.pre_execution_blocks += 1);
                             self.push_security_event(
                                 crate::metrics::SecurityEventCategory::PreExecutionBlock,
-                                &call.tool_id,
+                                call.tool_id.as_str(),
                                 format!("{}: {}", verifier.name(), reason),
                             );
                             if let Some(ref logger) = self.tool_orchestrator.audit_logger {
@@ -1285,7 +1291,7 @@ impl<C: Channel> Agent<C> {
                             self.update_metrics(|m| m.pre_execution_warnings += 1);
                             self.push_security_event(
                                 crate::metrics::SecurityEventCategory::PreExecutionWarn,
-                                &call.tool_id,
+                                call.tool_id.as_str(),
                                 format!("{}: {}", verifier.name(), message),
                             );
                         }
@@ -1342,7 +1348,7 @@ impl<C: Channel> Agent<C> {
                     if self
                         .tool_orchestrator
                         .utility_scorer
-                        .is_exempt(&call.tool_id)
+                        .is_exempt(call.tool_id.as_str())
                     {
                         return zeph_tools::UtilityAction::ToolCall;
                     }
@@ -1403,7 +1409,9 @@ impl<C: Channel> Agent<C> {
             .iter()
             .zip(args_hashes.iter())
             .map(|(call, &hash)| {
-                let blocked = self.tool_orchestrator.is_repeat(&call.tool_id, hash);
+                let blocked = self
+                    .tool_orchestrator
+                    .is_repeat(call.tool_id.as_str(), hash);
                 if blocked {
                     tracing::warn!(
                         tool = %call.tool_id,
@@ -1417,7 +1425,8 @@ impl<C: Channel> Agent<C> {
         // Cache hits are also pushed here (P1 invariant): a cached tool called N times must
         // still trigger repeat-detection to prevent infinite loops if the LLM keeps requesting it.
         for (call, &hash) in calls.iter().zip(args_hashes.iter()) {
-            self.tool_orchestrator.push_tool_call(&call.tool_id, hash);
+            self.tool_orchestrator
+                .push_tool_call(call.tool_id.as_str(), hash);
         }
 
         // Cache lookup: for each non-repeat, cacheable call, check result cache before dispatch.
@@ -1427,10 +1436,10 @@ impl<C: Channel> Agent<C> {
             .zip(args_hashes.iter())
             .zip(repeat_blocked.iter())
             .map(|((call, &hash), &blocked)| {
-                if blocked || !zeph_tools::is_cacheable(&call.tool_id) {
+                if blocked || !zeph_tools::is_cacheable(call.tool_id.as_str()) {
                     return None;
                 }
-                let key = zeph_tools::CacheKey::new(&call.tool_id, hash);
+                let key = zeph_tools::CacheKey::new(call.tool_id.as_str(), hash);
                 self.tool_orchestrator.result_cache.get(&key)
             })
             .collect();
@@ -1501,7 +1510,7 @@ impl<C: Channel> Agent<C> {
                     let result = if is_compress {
                         self.handle_compress_context().await
                     } else {
-                        self.handle_focus_tool(&tc.name, &tc.input)
+                        self.handle_focus_tool(tc.name.as_str(), &tc.input)
                     };
                     tool_results[idx] = Ok(Some(zeph_tools::ToolOutput {
                         tool_name: tc.name.clone(),
@@ -1561,7 +1570,7 @@ impl<C: Channel> Agent<C> {
                 let tool_call_id = &tool_call_ids[idx];
                 self.channel
                     .send_tool_start(ToolStartEvent {
-                        tool_name: &tc.name,
+                        tool_name: tc.name.as_str(),
                         tool_call_id,
                         params: Some(tc.input.clone()),
                         parent_tool_use_id: self.session.parent_tool_use_id.clone(),
@@ -1678,7 +1687,7 @@ impl<C: Channel> Agent<C> {
                             .send_status(&format!("Utility action: Respond ({})", tc.name))
                             .await;
                         let out = skipped_output(
-                            tc.name.clone(),
+                            tc.name.to_string(),
                             format!(
                                 "[skipped] Tool call to {} skipped — utility policy recommends a \
                                  direct response without further tool use.",
@@ -1706,7 +1715,7 @@ impl<C: Channel> Agent<C> {
                         );
                         pending_system_hints.push(hint);
                         let out = skipped_output(
-                            tc.name.clone(),
+                            tc.name.to_string(),
                             format!(
                                 "[skipped] Tool call to {} skipped — utility policy recommends \
                                  retrieving additional context first.",
@@ -1730,7 +1739,7 @@ impl<C: Channel> Agent<C> {
                         );
                         pending_system_hints.push(hint);
                         let out = skipped_output(
-                            tc.name.clone(),
+                            tc.name.to_string(),
                             format!(
                                 "[skipped] Tool call to {} skipped — utility policy recommends \
                                  verifying the previous result first.",
@@ -1747,7 +1756,7 @@ impl<C: Channel> Agent<C> {
                             .await;
                         let threshold = self.tool_orchestrator.utility_scorer.threshold();
                         let out = skipped_output(
-                            tc.name.clone(),
+                            tc.name.to_string(),
                             format!(
                                 "[stopped] Tool call to {} halted by the utility gate — \
                                  budget exhausted or score below threshold {threshold:.2}.",
@@ -1804,7 +1813,7 @@ impl<C: Channel> Agent<C> {
                     self.update_metrics(|m| m.rate_limit_trips += 1);
                     self.push_security_event(
                         crate::metrics::SecurityEventCategory::RateLimit,
-                        &tc.name,
+                        tc.name.as_str(),
                         format!(
                             "{} calls exceeded {}/min",
                             exceeded.category.as_str(),
@@ -1944,10 +1953,13 @@ impl<C: Channel> Agent<C> {
                 // Skip if this was already a cache hit (no point caching a cached result).
                 if !is_failed
                     && cache_hits[idx].is_none()
-                    && zeph_tools::is_cacheable(&tool_calls[idx].name)
+                    && zeph_tools::is_cacheable(tool_calls[idx].name.as_str())
                     && let Ok(Some(ref out)) = result
                 {
-                    let key = zeph_tools::CacheKey::new(&tool_calls[idx].name, args_hashes[idx]);
+                    let key = zeph_tools::CacheKey::new(
+                        tool_calls[idx].name.to_string(),
+                        args_hashes[idx],
+                    );
                     self.tool_orchestrator.result_cache.put(key, out.clone());
                 }
 
@@ -1956,7 +1968,7 @@ impl<C: Channel> Agent<C> {
                 if !is_failed && self.tool_state.dependency_graph.is_some() {
                     self.tool_state
                         .completed_tool_ids
-                        .insert(tool_calls[idx].name.clone());
+                        .insert(tool_calls[idx].name.to_string());
                 }
 
                 // RuntimeLayer after_tool hooks.
@@ -2050,7 +2062,7 @@ impl<C: Channel> Agent<C> {
                 if let Err(ref e) = result
                     && let Some(ref d) = self.debug_state.debug_dumper
                 {
-                    d.dump_tool_error(&tool_calls[idx].name, e);
+                    d.dump_tool_error(tool_calls[idx].name.as_str(), e);
                 }
                 tool_results[idx] = result;
             }
@@ -2084,7 +2096,10 @@ impl<C: Channel> Agent<C> {
                 }
 
                 let tc = &tool_calls[idx];
-                if !self.tool_executor.is_tool_retryable_erased(&tc.name) {
+                if !self
+                    .tool_executor
+                    .is_tool_retryable_erased(tc.name.as_str())
+                {
                     continue;
                 }
 
@@ -2279,7 +2294,8 @@ impl<C: Channel> Agent<C> {
                         self.record_filter_metrics(fs);
                     }
                     let inline_stats = out.filter_stats.as_ref().and_then(|fs| {
-                        (fs.filtered_chars < fs.raw_chars).then(|| fs.format_inline(&tc.name))
+                        (fs.filtered_chars < fs.raw_chars)
+                            .then(|| fs.format_inline(tc.name.as_str()))
                     });
                     let kept = out
                         .filter_stats
@@ -2324,13 +2340,13 @@ impl<C: Channel> Agent<C> {
                     {
                         AnomalyOutcome::ReasoningQualityFailure {
                             model: self.provider.name().to_owned(),
-                            tool: tc.name.clone(),
+                            tool: tc.name.to_string(),
                         }
                     } else {
                         AnomalyOutcome::Error
                     };
                     if let Some(ref d) = self.debug_state.debug_dumper {
-                        d.dump_tool_error(&tc.name, e);
+                        d.dump_tool_error(tc.name.as_str(), e);
                     }
                     // Count memory write validation rejections.
                     if tc.name == "memory_save"
@@ -2370,7 +2386,8 @@ impl<C: Channel> Agent<C> {
                 && let Some(iter_span_id) = self.debug_state.current_iteration_span_id
             {
                 let latency = u64::try_from(started_at.elapsed().as_millis()).unwrap_or(u64::MAX);
-                let guard = trace_coll.begin_tool_call_at(&tc.name, iter_span_id, started_at);
+                let guard =
+                    trace_coll.begin_tool_call_at(tc.name.as_str(), iter_span_id, started_at);
                 let error_kind = if is_error {
                     Some(output.chars().take(200).collect::<String>())
                 } else {
@@ -2378,7 +2395,7 @@ impl<C: Channel> Agent<C> {
                 };
                 trace_coll.end_tool_call(
                     guard,
-                    &tc.name,
+                    tc.name.as_str(),
                     crate::debug_dump::trace::ToolAttributes {
                         latency_ms: latency,
                         is_error,
@@ -2451,7 +2468,7 @@ impl<C: Channel> Agent<C> {
             let body_display = self.maybe_redact(&body);
             self.channel
                 .send_tool_output(ToolOutputEvent {
-                    tool_name: &tc.name,
+                    tool_name: tc.name.as_str(),
                     body: &body_display,
                     diff,
                     filter_stats: inline_stats,
@@ -2468,13 +2485,14 @@ impl<C: Channel> Agent<C> {
             // Sanitize tool output before inserting into LLM message history (Bug #1490 fix).
             // sanitize_tool_output is the sole sanitization point for tool output data flows.
             // channel send above uses body_display (redacted for privacy); LLM sees sanitize_tool_output output.
-            let (llm_content, tool_had_injection_flags) =
-                self.sanitize_tool_output(&processed, &tc.name).await;
+            let (llm_content, tool_had_injection_flags) = self
+                .sanitize_tool_output(&processed, tc.name.as_str())
+                .await;
             has_any_injection_flags |= tool_had_injection_flags;
 
             // Capture tool call details for LSP hooks before building result part.
             if !is_error {
-                lsp_tool_calls.push((tc.name.clone(), tc.input.clone(), llm_content.clone()));
+                lsp_tool_calls.push((tc.name.to_string(), tc.input.clone(), llm_content.clone()));
             }
 
             result_parts.push(MessagePart::ToolResult {
@@ -2999,7 +3017,7 @@ async fn recv_elicitation(
 /// All four non-execute arms (Respond/Retrieve/Verify/Stop) produce an identical struct shape
 /// with zero blocks executed and no diff/filter metadata.
 fn skipped_output(
-    tool_name: impl Into<String>,
+    tool_name: impl Into<zeph_common::ToolName>,
     summary: impl Into<String>,
 ) -> zeph_tools::ToolOutput {
     zeph_tools::ToolOutput {
@@ -3229,7 +3247,7 @@ mod tests {
             });
 
         let call = ToolCall {
-            tool_id: "bash".to_owned(),
+            tool_id: zeph_common::ToolName::new("bash"),
             params: serde_json::Map::new(),
             caller_id: None,
         };

--- a/crates/zeph-core/src/agent/tool_execution/sanitize.rs
+++ b/crates/zeph-core/src/agent/tool_execution/sanitize.rs
@@ -139,7 +139,7 @@ impl<C: Channel> Agent<C> {
             if let Some(ref logger) = self.tool_orchestrator.audit_logger {
                 let entry = zeph_tools::AuditEntry {
                     timestamp: zeph_tools::chrono_now(),
-                    tool: tool_name.to_owned(),
+                    tool: tool_name.into(),
                     command: String::new(),
                     result: zeph_tools::AuditResult::Success,
                     duration_ms: 0,

--- a/crates/zeph-core/src/agent/tool_execution/tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests.rs
@@ -230,7 +230,7 @@ impl ToolExecutor for FailingNthExecutor {
 fn make_calls(n: usize) -> Vec<ToolCall> {
     (0..n)
         .map(|i| ToolCall {
-            tool_id: format!("tool-{i}"),
+            tool_id: zeph_common::ToolName::new(format!("tool-{i}")),
             params: serde_json::Map::new(),
             caller_id: None,
         })
@@ -3916,7 +3916,7 @@ fn schema_complexity_range() {
 fn augment_with_tafc_injects_think_field() {
     use zeph_llm::provider::ToolDefinition;
     let def = ToolDefinition {
-        name: "file_op".to_owned(),
+        name: "file_op".to_owned().into(),
         description: "file operation".to_owned(),
         parameters: make_complex_schema(),
     };
@@ -3935,7 +3935,7 @@ fn augment_with_tafc_injects_think_field() {
 fn augment_with_tafc_skips_simple_schema() {
     use zeph_llm::provider::ToolDefinition;
     let def = ToolDefinition {
-        name: "bash".to_owned(),
+        name: "bash".to_owned().into(),
         description: "run shell".to_owned(),
         parameters: make_simple_schema(),
     };
@@ -4071,7 +4071,7 @@ fn tool_def_to_definition_with_tafc_skips_when_disabled() {
 fn tafc_complexity_threshold_boundary() {
     use zeph_llm::provider::ToolDefinition;
     let def = ToolDefinition {
-        name: "op".to_owned(),
+        name: "op".to_owned().into(),
         description: "op".to_owned(),
         parameters: make_complex_schema(),
     };
@@ -4691,7 +4691,7 @@ async fn utility_gate_blocks_call_and_produces_skipped_output() {
 
     let tool_calls = vec![ToolUseRequest {
         id: "call-1".to_owned(),
-        name: "bash".to_owned(),
+        name: "bash".to_owned().into(),
         input: serde_json::json!({"command": "ls"}),
     }];
 
@@ -4740,7 +4740,7 @@ async fn utility_gate_disabled_does_not_produce_skipped_output() {
 
     let tool_calls = vec![ToolUseRequest {
         id: "call-2".to_owned(),
-        name: "bash".to_owned(),
+        name: "bash".to_owned().into(),
         input: serde_json::json!({"command": "ls"}),
     }];
 
@@ -5101,12 +5101,12 @@ mod histogram_recorder_wiring {
         let tool_calls = vec![
             ToolUseRequest {
                 id: "id-hr4a".to_owned(),
-                name: "bash".to_owned(),
+                name: "bash".to_owned().into(),
                 input: serde_json::json!({"command": "echo a"}),
             },
             ToolUseRequest {
                 id: "id-hr4b".to_owned(),
-                name: "bash".to_owned(),
+                name: "bash".to_owned().into(),
                 input: serde_json::json!({"command": "echo b"}),
             },
         ];

--- a/crates/zeph-core/src/agent/tool_execution/tool_call_dag.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tool_call_dag.rs
@@ -204,7 +204,7 @@ mod tests {
     fn make_call(id: &str, input: Value) -> ToolUseRequest {
         ToolUseRequest {
             id: id.to_owned(),
-            name: "test_tool".to_owned(),
+            name: "test_tool".to_owned().into(),
             input,
         }
     }

--- a/crates/zeph-core/src/agent/tool_orchestrator.rs
+++ b/crates/zeph-core/src/agent/tool_orchestrator.rs
@@ -517,7 +517,7 @@ mod tests {
         // Directly manipulate the cache to simulate 1 hit and 1 miss.
         // put() one entry, get() it (hit), then get() a missing key (miss).
         let output = zeph_tools::ToolOutput {
-            tool_name: "read".to_owned(),
+            tool_name: "read".into(),
             summary: "contents".to_owned(),
             blocks_executed: 1,
             filter_stats: None,

--- a/crates/zeph-core/src/agent/utils.rs
+++ b/crates/zeph-core/src/agent/utils.rs
@@ -493,7 +493,7 @@ mod tests {
             role: Role::User,
             content: String::new(),
             parts: vec![MessagePart::ToolOutput {
-                tool_name: "shell".to_string(),
+                tool_name: "shell".into(),
                 body: big_content.clone(),
                 compacted_at: None,
             }],

--- a/crates/zeph-core/src/channel.rs
+++ b/crates/zeph-core/src/channel.rs
@@ -331,7 +331,7 @@ pub enum StopHint {
 /// Data carried by a [`LoopbackEvent::ToolStart`] variant.
 #[derive(Debug, Clone)]
 pub struct ToolStartData {
-    pub tool_name: String,
+    pub tool_name: zeph_common::ToolName,
     pub tool_call_id: String,
     /// Raw input parameters passed to the tool (e.g. `{"command": "..."}` for bash).
     pub params: Option<serde_json::Value>,
@@ -344,7 +344,7 @@ pub struct ToolStartData {
 /// Data carried by a [`LoopbackEvent::ToolOutput`] variant.
 #[derive(Debug, Clone)]
 pub struct ToolOutputData {
-    pub tool_name: String,
+    pub tool_name: zeph_common::ToolName,
     pub display: String,
     pub diff: Option<crate::DiffData>,
     pub filter_stats: Option<String>,
@@ -365,7 +365,7 @@ pub struct ToolOutputData {
 impl From<ToolStartEvent<'_>> for ToolStartData {
     fn from(e: ToolStartEvent<'_>) -> Self {
         Self {
-            tool_name: e.tool_name.to_owned(),
+            tool_name: e.tool_name.into(),
             tool_call_id: e.tool_call_id.to_owned(),
             params: e.params,
             parent_tool_use_id: e.parent_tool_use_id,
@@ -377,7 +377,7 @@ impl From<ToolStartEvent<'_>> for ToolStartData {
 impl From<ToolOutputEvent<'_>> for ToolOutputData {
     fn from(e: ToolOutputEvent<'_>) -> Self {
         Self {
-            tool_name: e.tool_name.to_owned(),
+            tool_name: e.tool_name.into(),
             display: e.body.to_owned(),
             diff: e.diff,
             filter_stats: e.filter_stats,

--- a/crates/zeph-core/src/memory_tools.rs
+++ b/crates/zeph-core/src/memory_tools.rs
@@ -154,7 +154,7 @@ impl ToolExecutor for MemoryToolExecutor {
                 }
 
                 Ok(Some(ToolOutput {
-                    tool_name: "memory_search".to_owned(),
+                    tool_name: zeph_common::ToolName::new("memory_search"),
                     summary: output,
                     blocks_executed: 1,
                     filter_stats: None,
@@ -206,7 +206,7 @@ impl ToolExecutor for MemoryToolExecutor {
                 };
 
                 Ok(Some(ToolOutput {
-                    tool_name: "memory_save".to_owned(),
+                    tool_name: zeph_common::ToolName::new("memory_save"),
                     summary,
                     blocks_executed: 1,
                     filter_stats: None,
@@ -269,7 +269,7 @@ mod tests {
         let memory = make_memory().await;
         let executor = make_executor(memory);
         let call = ToolCall {
-            tool_id: "unknown_tool".to_owned(),
+            tool_id: zeph_common::ToolName::new("unknown_tool"),
             params: serde_json::Map::new(),
             caller_id: None,
         };
@@ -287,7 +287,7 @@ mod tests {
             serde_json::Value::String("test query".into()),
         );
         let call = ToolCall {
-            tool_id: "memory_search".to_owned(),
+            tool_id: zeph_common::ToolName::new("memory_search"),
             params,
             caller_id: None,
         };
@@ -314,7 +314,7 @@ mod tests {
             serde_json::Value::String("User prefers dark mode".into()),
         );
         let call = ToolCall {
-            tool_id: "memory_save".to_owned(),
+            tool_id: zeph_common::ToolName::new("memory_save"),
             params,
             caller_id: None,
         };
@@ -332,7 +332,7 @@ mod tests {
         let mut params = serde_json::Map::new();
         params.insert("content".into(), serde_json::Value::String(String::new()));
         let call = ToolCall {
-            tool_id: "memory_save".to_owned(),
+            tool_id: zeph_common::ToolName::new("memory_save"),
             params,
             caller_id: None,
         };
@@ -350,7 +350,7 @@ mod tests {
             serde_json::Value::String("x".repeat(4097)),
         );
         let call = ToolCall {
-            tool_id: "memory_save".to_owned(),
+            tool_id: zeph_common::ToolName::new("memory_save"),
             params,
             caller_id: None,
         };

--- a/crates/zeph-core/src/overflow_tools.rs
+++ b/crates/zeph-core/src/overflow_tools.rs
@@ -80,7 +80,7 @@ impl ToolExecutor for OverflowToolExecutor {
             Ok(Some(bytes)) => {
                 let text = String::from_utf8_lossy(&bytes).into_owned();
                 Ok(Some(ToolOutput {
-                    tool_name: Self::TOOL_NAME.to_owned(),
+                    tool_name: zeph_common::ToolName::new(Self::TOOL_NAME),
                     summary: text,
                     blocks_executed: 1,
                     filter_stats: None,
@@ -122,7 +122,7 @@ mod tests {
         let mut params = serde_json::Map::new();
         params.insert("id".into(), serde_json::Value::String(id.to_owned()));
         ToolCall {
-            tool_id: "read_overflow".to_owned(),
+            tool_id: zeph_common::ToolName::new("read_overflow"),
             params,
             caller_id: None,
         }
@@ -150,7 +150,7 @@ mod tests {
         let (store, _) = make_store_with_conv().await;
         let exec = OverflowToolExecutor::new(store);
         let call = ToolCall {
-            tool_id: "other_tool".to_owned(),
+            tool_id: zeph_common::ToolName::new("other_tool"),
             params: serde_json::Map::new(),
             caller_id: None,
         };

--- a/crates/zeph-core/src/skill_loader.rs
+++ b/crates/zeph-core/src/skill_loader.rs
@@ -63,7 +63,7 @@ impl ToolExecutor for SkillLoaderExecutor {
         };
 
         Ok(Some(ToolOutput {
-            tool_name: "load_skill".to_owned(),
+            tool_name: zeph_common::ToolName::new("load_skill"),
             summary,
             blocks_executed: 1,
             filter_stats: None,
@@ -101,7 +101,7 @@ mod tests {
             make_registry_with_skill(dir.path(), "git-commit", "## Instructions\nDo git stuff");
         let executor = SkillLoaderExecutor::new(Arc::new(RwLock::new(registry)));
         let call = ToolCall {
-            tool_id: "load_skill".to_owned(),
+            tool_id: zeph_common::ToolName::new("load_skill"),
             params: serde_json::json!({"skill_name": "git-commit"})
                 .as_object()
                 .unwrap()
@@ -119,7 +119,7 @@ mod tests {
         let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
         let executor = SkillLoaderExecutor::new(Arc::new(RwLock::new(registry)));
         let call = ToolCall {
-            tool_id: "load_skill".to_owned(),
+            tool_id: zeph_common::ToolName::new("load_skill"),
             params: serde_json::json!({"skill_name": "nonexistent"})
                 .as_object()
                 .unwrap()
@@ -147,7 +147,7 @@ mod tests {
         let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
         let executor = SkillLoaderExecutor::new(Arc::new(RwLock::new(registry)));
         let call = ToolCall {
-            tool_id: "bash".to_owned(),
+            tool_id: zeph_common::ToolName::new("bash"),
             params: serde_json::Map::new(),
             caller_id: None,
         };
@@ -163,7 +163,7 @@ mod tests {
         let registry = make_registry_with_skill(dir.path(), "big-skill", &long_body);
         let executor = SkillLoaderExecutor::new(Arc::new(RwLock::new(registry)));
         let call = ToolCall {
-            tool_id: "load_skill".to_owned(),
+            tool_id: zeph_common::ToolName::new("load_skill"),
             params: serde_json::json!({"skill_name": "big-skill"})
                 .as_object()
                 .unwrap()
@@ -181,7 +181,7 @@ mod tests {
         let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
         let executor = SkillLoaderExecutor::new(Arc::new(RwLock::new(registry)));
         let call = ToolCall {
-            tool_id: "load_skill".to_owned(),
+            tool_id: zeph_common::ToolName::new("load_skill"),
             params: serde_json::json!({"skill_name": "any"})
                 .as_object()
                 .unwrap()
@@ -215,7 +215,7 @@ mod tests {
                 let ex = Arc::clone(&executor);
                 tokio::spawn(async move {
                     let call = ToolCall {
-                        tool_id: "load_skill".to_owned(),
+                        tool_id: zeph_common::ToolName::new("load_skill"),
                         params: serde_json::json!({"skill_name": "shared-skill"})
                             .as_object()
                             .unwrap()
@@ -240,7 +240,7 @@ mod tests {
         let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
         let executor = SkillLoaderExecutor::new(Arc::new(RwLock::new(registry)));
         let call = ToolCall {
-            tool_id: "load_skill".to_owned(),
+            tool_id: zeph_common::ToolName::new("load_skill"),
             params: serde_json::json!({"skill_name": ""})
                 .as_object()
                 .unwrap()
@@ -258,7 +258,7 @@ mod tests {
         let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
         let executor = SkillLoaderExecutor::new(Arc::new(RwLock::new(registry)));
         let call = ToolCall {
-            tool_id: "load_skill".to_owned(),
+            tool_id: zeph_common::ToolName::new("load_skill"),
             params: serde_json::Map::new(),
             caller_id: None,
         };

--- a/crates/zeph-core/src/testing.rs
+++ b/crates/zeph-core/src/testing.rs
@@ -156,7 +156,10 @@ impl MockToolExecutor {
 
     /// Executor that returns a single successful tool output with the given summary.
     #[must_use]
-    pub fn with_output(tool_name: impl Into<String>, summary: impl Into<String>) -> Self {
+    pub fn with_output(
+        tool_name: impl Into<zeph_tools::ToolName>,
+        summary: impl Into<String>,
+    ) -> Self {
         let output = ToolOutput {
             tool_name: tool_name.into(),
             summary: summary.into(),

--- a/crates/zeph-experiments/Cargo.toml
+++ b/crates/zeph-experiments/Cargo.toml
@@ -17,7 +17,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"
 rand = { version = "0.8", features = ["small_rng"] }
-uuid = { version = "1.0", features = ["v4", "serde"] }
 tracing = "0.1"
 futures.workspace = true
 ordered-float.workspace = true
@@ -25,6 +24,7 @@ schemars.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 toml.workspace = true
+zeph-common.workspace = true
 zeph-config.workspace = true
 zeph-llm.workspace = true
 zeph-memory.workspace = true

--- a/crates/zeph-experiments/src/engine.rs
+++ b/crates/zeph-experiments/src/engine.rs
@@ -25,6 +25,7 @@ use std::time::Instant;
 
 use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
+use zeph_common::SessionId;
 use zeph_llm::any::AnyProvider;
 use zeph_memory::semantic::SemanticMemory;
 use zeph_memory::store::experiments::NewExperimentResult;
@@ -45,8 +46,8 @@ use zeph_config::ExperimentConfig;
 /// [`EvalError`]: crate::EvalError
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExperimentSessionReport {
-    /// UUID generated at [`ExperimentEngine`] construction time.
-    pub session_id: String,
+    /// Session ID generated at [`ExperimentEngine`] construction time.
+    pub session_id: SessionId,
     /// All variation results recorded in this session (both accepted and rejected).
     pub results: Vec<ExperimentResult>,
     /// The best-known config snapshot at session end (may equal the initial baseline).
@@ -97,7 +98,7 @@ pub struct ExperimentEngine {
     baseline: ConfigSnapshot,
     config: ExperimentConfig,
     memory: Option<Arc<SemanticMemory>>,
-    session_id: String,
+    session_id: SessionId,
     cancel: CancellationToken,
     source: ExperimentSource,
 }
@@ -134,7 +135,7 @@ impl ExperimentEngine {
             baseline,
             config,
             memory,
-            session_id: uuid::Uuid::new_v4().to_string(),
+            session_id: SessionId::generate(),
             cancel: CancellationToken::new(),
             source: ExperimentSource::Manual,
         }
@@ -372,7 +373,7 @@ impl ExperimentEngine {
             .map_err(|e| EvalError::Storage(e.to_string()))?;
         #[allow(clippy::cast_possible_wrap)]
         let new_result = NewExperimentResult {
-            session_id: &self.session_id,
+            session_id: self.session_id.as_str(),
             parameter: variation.parameter.as_str(),
             value_json: &value_json,
             baseline_score,
@@ -881,13 +882,13 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(rows.len(), 1, "expected one persisted result");
-        assert_eq!(rows[0].session_id, session_id);
+        assert_eq!(rows[0].session_id, session_id.as_str());
     }
 
     #[test]
     fn session_report_serde_roundtrip() {
         let report = ExperimentSessionReport {
-            session_id: "test-session".to_string(),
+            session_id: SessionId::new("test-session"),
             results: vec![],
             best_config: ConfigSnapshot::default(),
             baseline_score: 7.5,

--- a/crates/zeph-experiments/src/types.rs
+++ b/crates/zeph-experiments/src/types.rs
@@ -3,6 +3,7 @@
 
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
+use zeph_common::SessionId;
 
 /// A single-parameter variation: the parameter to change and its candidate value.
 ///
@@ -212,8 +213,8 @@ impl std::fmt::Display for VariationValue {
 pub struct ExperimentResult {
     /// Row ID in the SQLite experiments table (`-1` when not yet persisted).
     pub id: i64,
-    /// UUID of the experiment session that produced this result.
-    pub session_id: String,
+    /// Session ID of the experiment session that produced this result.
+    pub session_id: SessionId,
     /// The parameter variation that was tested.
     pub variation: Variation,
     /// Mean score of the current progressive baseline before this variation was tested.
@@ -381,7 +382,7 @@ mod tests {
     fn experiment_result_serde_roundtrip() {
         let result = ExperimentResult {
             id: 1,
-            session_id: "sess-abc".to_string(),
+            session_id: SessionId::new("sess-abc"),
             variation: Variation {
                 parameter: ParameterKind::Temperature,
                 value: VariationValue::Float(OrderedFloat(0.7)),

--- a/crates/zeph-llm/src/claude/mod.rs
+++ b/crates/zeph-llm/src/claude/mod.rs
@@ -899,7 +899,7 @@ impl LlmProvider for ClaudeProvider {
 
         let tool_name = format!("submit_{type_name}");
         let tool = ToolDefinition {
-            name: tool_name.clone(),
+            name: tool_name.clone().into(),
             description: format!("Submit the structured {type_name} result"),
             parameters: schema_value,
         };
@@ -907,7 +907,7 @@ impl LlmProvider for ClaudeProvider {
         let (system, mut chat_messages) =
             split_messages_structured(messages, self.cache_user_messages);
         let api_tool = AnthropicTool {
-            name: &tool.name,
+            name: tool.name.as_str(),
             description: &tool.description,
             input_schema: &tool.parameters,
         };

--- a/crates/zeph-llm/src/claude/request.rs
+++ b/crates/zeph-llm/src/claude/request.rs
@@ -164,7 +164,11 @@ pub(super) fn parse_tool_response(resp: ToolApiResponse) -> (ChatResponse, Optio
         match block {
             AnthropicContentBlock::Text { text, .. } => text_parts.push(text),
             AnthropicContentBlock::ToolUse { id, name, input } => {
-                tool_calls.push(ToolUseRequest { id, name, input });
+                tool_calls.push(ToolUseRequest {
+                    id,
+                    name: name.into(),
+                    input,
+                });
             }
             AnthropicContentBlock::Thinking {
                 thinking,

--- a/crates/zeph-llm/src/gemini/mod.rs
+++ b/crates/zeph-llm/src/gemini/mod.rs
@@ -497,7 +497,7 @@ fn parse_tool_response(resp: GenerateContentResponse) -> Result<ChatResponse, Ll
         if let Some(fc) = part.function_call {
             tool_calls.push(ToolUseRequest {
                 id: uuid::Uuid::new_v4().to_string(),
-                name: fc.name,
+                name: fc.name.into(),
                 input: fc
                     .args
                     .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::default())),
@@ -749,7 +749,7 @@ fn convert_tool_definitions(tools: &[ToolDefinition]) -> Vec<GeminiFunctionDecla
                 Some(prepared)
             };
             GeminiFunctionDeclaration {
-                name: t.name.clone(),
+                name: t.name.to_string(),
                 description: t.description.clone(),
                 parameters,
             }

--- a/crates/zeph-llm/src/gemini/tests.rs
+++ b/crates/zeph-llm/src/gemini/tests.rs
@@ -464,7 +464,7 @@ fn test_normalize_schema_anyof_complex_dropped() {
 #[test]
 fn test_convert_tool_definitions_single() {
     let tool = ToolDefinition {
-        name: "get_weather".to_owned(),
+        name: "get_weather".to_owned().into(),
         description: "Get current weather".to_owned(),
         parameters: serde_json::json!({
             "type": "object",
@@ -495,12 +495,12 @@ fn test_convert_tool_definitions_empty() {
 fn test_convert_tool_definitions_multiple() {
     let tools = vec![
         ToolDefinition {
-            name: "tool_a".to_owned(),
+            name: "tool_a".to_owned().into(),
             description: "Tool A".to_owned(),
             parameters: serde_json::json!({"type": "object", "properties": {}}),
         },
         ToolDefinition {
-            name: "tool_b".to_owned(),
+            name: "tool_b".to_owned().into(),
             description: "Tool B".to_owned(),
             parameters: serde_json::json!({"type": "object", "properties": {}}),
         },
@@ -516,7 +516,7 @@ fn test_convert_tool_definitions_multiple() {
 #[test]
 fn test_convert_tool_no_parameters() {
     let tool = ToolDefinition {
-        name: "no_params".to_owned(),
+        name: "no_params".to_owned().into(),
         description: "A tool with no parameters".to_owned(),
         parameters: serde_json::json!({"type": "object", "properties": {}}),
     };
@@ -635,12 +635,12 @@ fn test_inline_refs_nested_multi_level() {
 fn test_build_tool_request_parameterless_tools_still_includes_tools_field() {
     let tools = vec![
         ToolDefinition {
-            name: "ping".to_owned(),
+            name: "ping".to_owned().into(),
             description: "Ping".to_owned(),
             parameters: serde_json::json!({"type": "object"}),
         },
         ToolDefinition {
-            name: "pong".to_owned(),
+            name: "pong".to_owned().into(),
             description: "Pong".to_owned(),
             parameters: serde_json::json!({"type": "object", "properties": {}}),
         },
@@ -1020,7 +1020,7 @@ fn test_parse_null_args_uses_empty_object() {
 fn test_debug_request_json_with_tools_includes_function_declarations() {
     let messages = vec![msg(Role::User, "What is the weather?")];
     let tools = vec![ToolDefinition {
-        name: "get_weather".to_owned(),
+        name: "get_weather".to_owned().into(),
         description: "Get weather".to_owned(),
         parameters: serde_json::json!({
             "type": "object",
@@ -1187,7 +1187,7 @@ async fn test_chat_with_tools_returns_tool_use() {
         .with_base_url(format!("http://127.0.0.1:{port}"));
     let messages = vec![msg(Role::User, "What's the weather in Berlin?")];
     let tools = vec![ToolDefinition {
-        name: "get_weather".to_owned(),
+        name: "get_weather".to_owned().into(),
         description: "Get weather".to_owned(),
         parameters: serde_json::json!({"type": "object", "properties": {"location": {"type": "string"}}}),
     }];

--- a/crates/zeph-llm/src/ollama.rs
+++ b/crates/zeph-llm/src/ollama.rs
@@ -339,7 +339,7 @@ impl LlmProvider for OllamaProvider {
                 .map(|t| ToolInfo {
                     tool_type: ToolType::Function,
                     function: ToolFunctionInfo {
-                        name: t.name.clone(),
+                        name: t.name.to_string(),
                         description: t.description.clone(),
                         parameters: serde_json::from_value(t.parameters.clone())
                             .unwrap_or_default(),
@@ -384,7 +384,7 @@ impl LlmProvider for OllamaProvider {
             .map(|t| ToolInfo {
                 tool_type: ToolType::Function,
                 function: ToolFunctionInfo {
-                    name: t.name.clone(),
+                    name: t.name.to_string(),
                     description: t.description.clone(),
                     parameters: serde_json::from_value(t.parameters.clone()).unwrap_or_default(),
                 },
@@ -420,7 +420,7 @@ impl LlmProvider for OllamaProvider {
             .enumerate()
             .map(|(i, tc)| ToolUseRequest {
                 id: format!("call_{i}"),
-                name: tc.function.name,
+                name: tc.function.name.into(),
                 input: tc.function.arguments,
             })
             .collect();

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -615,7 +615,7 @@ impl LlmProvider for OpenAiProvider {
                 .map(|t| OpenAiTool {
                     r#type: "function",
                     function: OpenAiFunction {
-                        name: &t.name,
+                        name: t.name.as_str(),
                         description: &t.description,
                         parameters: prepare_tool_params(&t.parameters),
                     },
@@ -754,7 +754,7 @@ impl LlmProvider for OpenAiProvider {
             .map(|t| OpenAiTool {
                 r#type: "function",
                 function: OpenAiFunction {
-                    name: &t.name,
+                    name: t.name.as_str(),
                     description: &t.description,
                     parameters: prepare_tool_params(&t.parameters),
                 },
@@ -843,7 +843,7 @@ impl OpenAiProvider {
                         .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
                     ToolUseRequest {
                         id: tc.id,
-                        name: tc.function.name,
+                        name: tc.function.name.into(),
                         input,
                     }
                 })

--- a/crates/zeph-llm/src/provider.rs
+++ b/crates/zeph-llm/src/provider.rs
@@ -12,6 +12,8 @@ use std::{
 use futures_core::Stream;
 use serde::{Deserialize, Serialize};
 
+use zeph_common::ToolName;
+
 use crate::embed::owned_strs;
 use crate::error::LlmError;
 
@@ -111,7 +113,7 @@ pub type ChatStream = Pin<Box<dyn Stream<Item = Result<StreamChunk, LlmError>> +
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolDefinition {
     /// Tool name — must match the name used in the response `ToolUseRequest`.
-    pub name: String,
+    pub name: ToolName,
     /// Human-readable description guiding the model on when to call this tool.
     pub description: String,
     /// JSON Schema object describing parameters.
@@ -128,7 +130,7 @@ pub struct ToolUseRequest {
     /// Opaque call identifier assigned by the model; must be echoed in `ToolResult.tool_use_id`.
     pub id: String,
     /// Name of the tool to invoke, matching a [`ToolDefinition::name`].
-    pub name: String,
+    pub name: ToolName,
     /// JSON arguments the model wants to pass to the tool.
     pub input: serde_json::Value,
 }
@@ -262,7 +264,7 @@ pub enum MessagePart {
     Text { text: String },
     /// Output from a tool execution, optionally compacted.
     ToolOutput {
-        tool_name: String,
+        tool_name: zeph_common::ToolName,
         body: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         compacted_at: Option<i64>,

--- a/crates/zeph-llm/src/sse.rs
+++ b/crates/zeph-llm/src/sse.rs
@@ -251,7 +251,7 @@ fn parse_gemini_sse_event(data: &str) -> Option<Result<StreamChunk, LlmError>> {
         if let Some(ref fc) = part.function_call {
             tool_calls.push(ToolUseRequest {
                 id: uuid::Uuid::new_v4().to_string(),
-                name: fc.name.clone(),
+                name: fc.name.clone().into(),
                 input: fc
                     .args
                     .clone()

--- a/crates/zeph-mcp/src/embedding_guard.rs
+++ b/crates/zeph-mcp/src/embedding_guard.rs
@@ -14,6 +14,8 @@
 
 use std::sync::{Arc, LazyLock};
 
+use zeph_common::ToolName;
+
 use dashmap::DashMap;
 use regex::Regex;
 use tokio::sync::mpsc;
@@ -43,7 +45,7 @@ pub enum EmbeddingGuardResult {
 #[derive(Debug)]
 pub struct EmbeddingGuardEvent {
     pub server_id: String,
-    pub tool_name: String,
+    pub tool_name: ToolName,
     pub result: EmbeddingGuardResult,
 }
 
@@ -134,7 +136,7 @@ impl EmbeddingAnomalyGuard {
                 .result_tx
                 .send(EmbeddingGuardEvent {
                     server_id: server_id.to_owned(),
-                    tool_name: tool_name.to_owned(),
+                    tool_name: tool_name.into(),
                     result: EmbeddingGuardResult::RegexFallback { injection_detected },
                 })
                 .is_err()
@@ -148,7 +150,7 @@ impl EmbeddingAnomalyGuard {
         let threshold = self.threshold;
         let tx = self.result_tx.clone();
         let server_id = server_id.to_owned();
-        let tool_name = tool_name.to_owned();
+        let tool_name: ToolName = tool_name.into();
         let output = tool_output.to_owned();
 
         tokio::spawn(async move {
@@ -158,7 +160,7 @@ impl EmbeddingAnomalyGuard {
                     let result = if distance > threshold {
                         tracing::debug!(
                             server_id,
-                            tool_name,
+                            tool_name = %tool_name,
                             distance,
                             threshold,
                             "embedding anomaly detected"
@@ -185,7 +187,7 @@ impl EmbeddingAnomalyGuard {
                     // Fail-open: embedding failure does not block the tool output path.
                     tracing::debug!(
                         server_id,
-                        tool_name,
+                        tool_name = %tool_name,
                         "embedding guard: computation failed: {e:#}"
                     );
                 }

--- a/crates/zeph-mcp/src/error.rs
+++ b/crates/zeph-mcp/src/error.rs
@@ -50,7 +50,7 @@ impl McpErrorCode {
 ///
 /// let err = McpError::Timeout {
 ///     server_id: "github".to_owned(),
-///     tool_name: "create_issue".to_owned(),
+///     tool_name: "create_issue".into(),
 ///     timeout_secs: 30,
 /// };
 /// assert_eq!(err.code(), Some(McpErrorCode::Transient));

--- a/crates/zeph-mcp/src/error.rs
+++ b/crates/zeph-mcp/src/error.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use zeph_common::ToolName;
+
 /// Typed error code for MCP tool call retry and recovery classification.
 ///
 /// Used by [`McpError::code`] and callers such as the agent retry loop to decide
@@ -62,7 +64,7 @@ pub enum McpError {
     #[error("tool call failed: {server_id}/{tool_name}: {message}")]
     ToolCall {
         server_id: String,
-        tool_name: String,
+        tool_name: ToolName,
         message: String,
         /// Typed error code for retry classification.
         code: McpErrorCode,
@@ -77,13 +79,13 @@ pub enum McpError {
     #[error("tool '{tool_name}' not found on server '{server_id}'")]
     ToolNotFound {
         server_id: String,
-        tool_name: String,
+        tool_name: ToolName,
     },
 
     #[error("tool call timed out after {timeout_secs}s: {server_id}/{tool_name}")]
     Timeout {
         server_id: String,
-        tool_name: String,
+        tool_name: ToolName,
         timeout_secs: u64,
     },
 

--- a/crates/zeph-mcp/src/executor.rs
+++ b/crates/zeph-mcp/src/executor.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use parking_lot::RwLock;
 
+use zeph_common::ToolName;
 use zeph_tools::executor::{ToolCall, ToolError, ToolExecutor, ToolOutput, extract_fenced_blocks};
 use zeph_tools::registry::{InvocationHint, ToolDef};
 
@@ -127,7 +128,7 @@ impl ToolExecutor for McpToolExecutor {
         let text = crate::sanitize::intent_anchor_wrap(&tool.server_id, &tool.name, &raw_text);
 
         Ok(Some(ToolOutput {
-            tool_name: tool.qualified_name(),
+            tool_name: tool.qualified_name().into(),
             summary: text,
             blocks_executed: 1,
             filter_stats: None,
@@ -174,7 +175,7 @@ impl ToolExecutor for McpToolExecutor {
 
             // Delegate to execute_tool_call() so all security layers apply.
             let call = ToolCall {
-                tool_id: tool.sanitized_id(),
+                tool_id: tool.sanitized_id().into(),
                 params: match instruction.args {
                     serde_json::Value::Object(map) => map,
                     _ => serde_json::Map::new(),
@@ -188,7 +189,7 @@ impl ToolExecutor for McpToolExecutor {
 
         Ok(Some(ToolOutput {
             // SECURITY: Use qualified format so quarantine routing works (tool_name must contain ':').
-            tool_name: "mcp:fenced_block".to_owned(),
+            tool_name: ToolName::new("mcp:fenced_block"),
             summary: outputs.join("\n\n"),
             blocks_executed,
             filter_stats: None,
@@ -435,7 +436,7 @@ mod tests {
     async fn execute_tool_call_unknown_format_returns_none() {
         let executor = make_executor();
         let call = ToolCall {
-            tool_id: "no_colon_here".to_owned(),
+            tool_id: ToolName::new("no_colon_here"),
             params: serde_json::Map::new(),
             caller_id: None,
         };
@@ -447,7 +448,7 @@ mod tests {
     async fn execute_tool_call_unknown_server_returns_none() {
         let executor = make_executor();
         let call = ToolCall {
-            tool_id: "unknown_server:tool".to_owned(),
+            tool_id: ToolName::new("unknown_server:tool"),
             params: serde_json::Map::new(),
             caller_id: None,
         };
@@ -473,7 +474,7 @@ mod tests {
 
         // A different sanitized id must not match.
         let call = ToolCall {
-            tool_id: "gh_list_issues".to_owned(),
+            tool_id: ToolName::new("gh_list_issues"),
             params: serde_json::Map::new(),
             caller_id: None,
         };
@@ -497,7 +498,7 @@ mod tests {
 
         // tool_id matches the sanitized_id "missing_server_some_tool".
         let call = ToolCall {
-            tool_id: "missing_server_some_tool".to_owned(),
+            tool_id: ToolName::new("missing_server_some_tool"),
             params: serde_json::Map::new(),
             caller_id: None,
         };

--- a/crates/zeph-mcp/src/policy.rs
+++ b/crates/zeph-mcp/src/policy.rs
@@ -16,6 +16,8 @@ use std::time::Instant;
 use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
 
+use zeph_common::ToolName;
+
 use crate::manager::McpTrustLevel;
 use crate::tool::{DataSensitivity, McpTool};
 
@@ -31,7 +33,7 @@ pub enum DataFlowViolation {
     )]
     SensitivityTrustMismatch {
         server_id: String,
-        tool_name: String,
+        tool_name: ToolName,
         sensitivity: DataSensitivity,
         trust: McpTrustLevel,
     },
@@ -55,7 +57,7 @@ pub fn check_data_flow(
         (DataSensitivity::High, McpTrustLevel::Untrusted | McpTrustLevel::Sandboxed) => {
             Err(DataFlowViolation::SensitivityTrustMismatch {
                 server_id: tool.server_id.clone(),
-                tool_name: tool.name.clone(),
+                tool_name: tool.name.as_str().into(),
                 sensitivity: tool.security_meta.data_sensitivity,
                 trust: server_trust,
             })
@@ -104,13 +106,13 @@ pub enum PolicyViolation {
     #[error("tool '{tool_name}' is denied on server '{server_id}'")]
     ToolDenied {
         server_id: String,
-        tool_name: String,
+        tool_name: ToolName,
     },
 
     #[error("tool '{tool_name}' is not in the allowlist for server '{server_id}'")]
     ToolNotAllowed {
         server_id: String,
-        tool_name: String,
+        tool_name: ToolName,
     },
 
     #[error("rate limit exceeded for server '{server_id}' (max {max_calls_per_minute}/min)")]

--- a/crates/zeph-mcp/src/testing.rs
+++ b/crates/zeph-mcp/src/testing.rs
@@ -19,8 +19,10 @@ use zeph_tools::registry::{InvocationHint, ToolDef};
 
 use crate::tool::McpTool;
 
+use zeph_tools::ToolName;
+
 type MockResponses = Arc<Mutex<HashMap<String, Vec<Result<String, String>>>>>;
-type RecordedCalls = Arc<Mutex<Vec<(String, serde_json::Value)>>>;
+type RecordedCalls = Arc<Mutex<Vec<(ToolName, serde_json::Value)>>>;
 
 /// Configurable MCP tool executor for unit tests.
 ///
@@ -144,7 +146,7 @@ impl ToolExecutor for MockMcpServer {
         let known = self
             .tools
             .iter()
-            .any(|t| t.qualified_name() == call.tool_id);
+            .any(|t| t.qualified_name() == call.tool_id.as_str());
         if !known {
             return Ok(None);
         }
@@ -154,7 +156,7 @@ impl ToolExecutor for MockMcpServer {
             .responses
             .lock()
             .unwrap()
-            .get_mut(&call.tool_id)
+            .get_mut(call.tool_id.as_str())
             .and_then(|queue| {
                 if queue.is_empty() {
                     None

--- a/crates/zeph-memory/src/graph/entity_lock.rs
+++ b/crates/zeph-memory/src/graph/entity_lock.rs
@@ -15,6 +15,7 @@
 use std::time::Duration;
 
 use tokio::time::sleep;
+use zeph_common::SessionId;
 use zeph_db::{DbPool, query, query_scalar, sql};
 
 use crate::error::MemoryError;
@@ -31,12 +32,16 @@ const BASE_BACKOFF_MS: u64 = 50;
 /// Advisory entity lock manager for a single session.
 pub struct EntityLockManager {
     pool: DbPool,
-    session_id: String,
+    session_id: SessionId,
 }
 
 impl EntityLockManager {
+    /// Create an `EntityLockManager` for the given session.
+    ///
+    /// Accepts anything convertible to [`SessionId`]: a `SessionId` directly,
+    /// a `&str`, or a `String`.
     #[must_use]
-    pub fn new(pool: DbPool, session_id: impl Into<String>) -> Self {
+    pub fn new(pool: DbPool, session_id: impl Into<SessionId>) -> Self {
         Self {
             pool,
             session_id: session_id.into(),
@@ -92,9 +97,9 @@ impl EntityLockManager {
              RETURNING (session_id = ?) AS acquired"
         ))
         .bind(entity_name)
-        .bind(&self.session_id)
+        .bind(self.session_id.as_str())
         .bind(LOCK_TTL_SECS.to_string())
-        .bind(&self.session_id)
+        .bind(self.session_id.as_str())
         .fetch_optional(self.pool())
         .await?
         .unwrap_or(false);
@@ -124,7 +129,7 @@ impl EntityLockManager {
         ))
         .bind(extra_secs.to_string())
         .bind(entity_name)
-        .bind(&self.session_id)
+        .bind(self.session_id.as_str())
         .execute(self.pool())
         .await?
         .rows_affected();
@@ -145,7 +150,7 @@ impl EntityLockManager {
              WHERE entity_name = ? AND session_id = ?"
         ))
         .bind(entity_name)
-        .bind(&self.session_id)
+        .bind(self.session_id.as_str())
         .execute(self.pool())
         .await?;
 
@@ -163,7 +168,7 @@ impl EntityLockManager {
         query(sql!(
             "DELETE FROM entity_advisory_locks WHERE session_id = ?"
         ))
-        .bind(&self.session_id)
+        .bind(self.session_id.as_str())
         .execute(self.pool())
         .await?;
 

--- a/crates/zeph-memory/src/store/experiments.rs
+++ b/crates/zeph-memory/src/store/experiments.rs
@@ -3,13 +3,14 @@
 
 use super::SqliteStore;
 use crate::error::MemoryError;
+use zeph_common::SessionId;
 #[allow(unused_imports)]
 use zeph_db::sql;
 
 #[derive(Debug, Clone)]
 pub struct ExperimentResultRow {
     pub id: i64,
-    pub session_id: String,
+    pub session_id: SessionId,
     pub parameter: String,
     pub value_json: String,
     pub baseline_score: f64,
@@ -38,7 +39,7 @@ pub struct NewExperimentResult<'a> {
 
 #[derive(Debug, Clone)]
 pub struct SessionSummaryRow {
-    pub session_id: String,
+    pub session_id: SessionId,
     pub total: i64,
     pub accepted_count: i64,
     pub best_delta: f64,
@@ -106,7 +107,7 @@ type ResultTuple = (
 fn row_from_tuple(t: ResultTuple) -> ExperimentResultRow {
     ExperimentResultRow {
         id: t.0,
-        session_id: t.1,
+        session_id: SessionId::new(t.1),
         parameter: t.2,
         value_json: t.3,
         baseline_score: t.4,
@@ -259,7 +260,7 @@ impl SqliteStore {
         .await?;
         Ok(row.map(
             |(sid, total, accepted_count, best_delta, total_tokens)| SessionSummaryRow {
-                session_id: sid,
+                session_id: SessionId::new(sid),
                 total,
                 accepted_count,
                 best_delta: best_delta.unwrap_or(0.0),

--- a/crates/zeph-memory/src/token_counter.rs
+++ b/crates/zeph-memory/src/token_counter.rs
@@ -152,7 +152,11 @@ impl TokenCounter {
             // When body is emptied by compaction, count_tokens(body) returns 0 naturally.
             MessagePart::ToolOutput {
                 tool_name, body, ..
-            } => TOOL_OUTPUT_OVERHEAD + self.count_tokens(tool_name) + self.count_tokens(body),
+            } => {
+                TOOL_OUTPUT_OVERHEAD
+                    + self.count_tokens(tool_name.as_str())
+                    + self.count_tokens(body)
+            }
 
             // API sends structured JSON block: `{"type":"tool_use","id":"...","name":"...","input":...}`
             MessagePart::ToolUse { id, name, input } => {

--- a/crates/zeph-sanitizer/src/exfiltration.rs
+++ b/crates/zeph-sanitizer/src/exfiltration.rs
@@ -28,6 +28,7 @@ use std::fmt::Write as _;
 use std::sync::LazyLock;
 
 use regex::Regex;
+use zeph_common::ToolName;
 
 pub use zeph_config::ExfiltrationGuardConfig;
 
@@ -83,7 +84,7 @@ pub enum ExfiltrationEvent {
     /// A markdown image with an external URL was stripped from LLM output.
     MarkdownImageBlocked { url: String },
     /// A tool call argument contained a URL that appeared in untrusted flagged content.
-    SuspiciousToolUrl { url: String, tool_name: String },
+    SuspiciousToolUrl { url: String, tool_name: ToolName },
     /// A memory write was intercepted because the content had injection flags.
     MemoryWriteGuarded { reason: String },
 }
@@ -292,7 +293,7 @@ impl ExfiltrationGuard {
                 if flagged_urls.contains(url) {
                     events.push(ExfiltrationEvent::SuspiciousToolUrl {
                         url: url.to_owned(),
-                        tool_name: tool_name.to_owned(),
+                        tool_name: tool_name.into(),
                     });
                 }
             }
@@ -334,7 +335,7 @@ impl ExfiltrationGuard {
             .filter(|m| flagged_urls.contains(m.as_str()))
             .map(|m| ExfiltrationEvent::SuspiciousToolUrl {
                 url: m.as_str().to_owned(),
-                tool_name: tool_name.to_owned(),
+                tool_name: tool_name.into(),
             })
             .collect()
     }

--- a/crates/zeph-skills/src/evolution.rs
+++ b/crates/zeph-skills/src/evolution.rs
@@ -14,6 +14,8 @@
 //! Step corrections ([`StepCorrection`]) allow fine-grained recovery: when a specific tool
 //! failure pattern is detected, a hint is injected into the next agent turn.
 
+use zeph_common::ToolName;
+
 /// Structured failure classification for tool execution errors.
 ///
 /// Used to decide whether a failure is attributable to the skill (systematic) or to
@@ -107,8 +109,8 @@ pub struct FailurePattern {
     pub failure_kind: String,
     /// Substring match against `error_context` (empty = match any error text).
     pub error_substring: String,
-    /// Optional tool name filter (empty = match any tool).
-    pub tool_name: String,
+    /// Optional tool name filter (empty string = match any tool).
+    pub tool_name: ToolName,
 }
 
 /// A step-level correction hint: when a tool failure matches `trigger`,
@@ -848,7 +850,7 @@ mod tests {
             trigger: FailurePattern {
                 failure_kind: "exit_nonzero".to_string(),
                 error_substring: "not a git repo".to_string(),
-                tool_name: String::new(),
+                tool_name: "".into(),
             },
             hint: "Run git init before any git commands.".to_string(),
         };
@@ -862,7 +864,7 @@ mod tests {
         let original = FailurePattern {
             failure_kind: "timeout".to_string(),
             error_substring: "timed out".to_string(),
-            tool_name: "shell".to_string(),
+            tool_name: "shell".into(),
         };
         let json = serde_json::to_string(&original).unwrap();
         let decoded: FailurePattern = serde_json::from_str(&json).unwrap();

--- a/crates/zeph-subagent/src/agent_loop.rs
+++ b/crates/zeph-subagent/src/agent_loop.rs
@@ -85,7 +85,7 @@ fn tool_def_to_definition(
         map.remove("title");
     }
     zeph_llm::provider::ToolDefinition {
-        name: def.id.to_string(),
+        name: def.id.to_string().into(),
         description: def.description.to_string(),
         parameters: params,
     }
@@ -119,7 +119,7 @@ async fn handle_tool_step(
             for tc in &tool_calls {
                 assistant_parts.push(MessagePart::ToolUse {
                     id: tc.id.clone(),
-                    name: tc.name.clone(),
+                    name: tc.name.to_string(),
                     input: tc.input.clone(),
                 });
             }
@@ -127,9 +127,10 @@ async fn handle_tool_step(
 
             let mut result_parts: Vec<MessagePart> = Vec::new();
             for tc in &tool_calls {
-                let hook_env = make_hook_env(task_id, agent_name, &tc.name);
+                let hook_env = make_hook_env(task_id, agent_name, tc.name.as_str());
 
-                let pre_hooks: Vec<&HookDef> = matching_hooks(&hooks.pre_tool_use, &tc.name);
+                let pre_hooks: Vec<&HookDef> =
+                    matching_hooks(&hooks.pre_tool_use, tc.name.as_str());
                 if !pre_hooks.is_empty() {
                     let pre_owned: Vec<HookDef> = pre_hooks.into_iter().cloned().collect();
                     if let Err(e) = fire_hooks(&pre_owned, &hook_env).await {
@@ -169,7 +170,8 @@ async fn handle_tool_step(
                 });
 
                 if !hooks.post_tool_use.is_empty() {
-                    let post_hooks: Vec<&HookDef> = matching_hooks(&hooks.post_tool_use, &tc.name);
+                    let post_hooks: Vec<&HookDef> =
+                        matching_hooks(&hooks.post_tool_use, tc.name.as_str());
                     if !post_hooks.is_empty() {
                         let post_owned: Vec<HookDef> = post_hooks.into_iter().cloned().collect();
                         if let Err(e) = fire_hooks(&post_owned, &hook_env).await {

--- a/crates/zeph-subagent/src/filter.rs
+++ b/crates/zeph-subagent/src/filter.rs
@@ -170,13 +170,13 @@ impl ErasedToolExecutor for FilteredToolExecutor {
         call: &'a ToolCall,
     ) -> Pin<Box<dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a>>
     {
-        if !self.is_allowed(&call.tool_id) {
+        if !self.is_allowed(call.tool_id.as_str()) {
             tracing::warn!(
                 tool_id = %call.tool_id,
                 "sub-agent tool call rejected by policy"
             );
             return Box::pin(std::future::ready(Err(ToolError::Blocked {
-                command: call.tool_id.clone(),
+                command: call.tool_id.to_string(),
             })));
         }
         Box::pin(self.inner.execute_tool_call_erased(call))
@@ -246,7 +246,7 @@ impl ErasedToolExecutor for PlanModeExecutor {
             "tool execution blocked in plan mode"
         );
         Box::pin(std::future::ready(Err(ToolError::Blocked {
-            command: call.tool_id.clone(),
+            command: call.tool_id.to_string(),
         })))
     }
 

--- a/crates/zeph-subagent/src/manager.rs
+++ b/crates/zeph-subagent/src/manager.rs
@@ -3255,7 +3255,7 @@ mod tests {
                         + 'a,
                 >,
             > {
-                self.calls.lock().unwrap().push(call.tool_id.clone());
+                self.calls.lock().unwrap().push(call.tool_id.to_string());
                 let output = ToolOutput {
                     tool_name: call.tool_id.clone(),
                     summary: "executed".into(),

--- a/crates/zeph-tools/src/adversarial_gate.rs
+++ b/crates/zeph-tools/src/adversarial_gate.rs
@@ -69,7 +69,7 @@ impl<T: ToolExecutor> AdversarialPolicyGateExecutor<T> {
 
         let decision = self
             .validator
-            .validate(&call.tool_id, &call.params, self.llm.as_ref())
+            .validate(call.tool_id.as_str(), &call.params, self.llm.as_ref())
             .await;
 
         match decision {

--- a/crates/zeph-tools/src/audit.rs
+++ b/crates/zeph-tools/src/audit.rs
@@ -19,6 +19,8 @@
 
 use std::path::Path;
 
+use zeph_common::ToolName;
+
 use crate::config::AuditConfig;
 
 /// Async writer that appends [`AuditEntry`] records to a structured JSONL log.
@@ -59,7 +61,7 @@ pub struct AuditEntry {
     /// Unix timestamp (seconds) when the tool invocation started.
     pub timestamp: String,
     /// Tool identifier (e.g. `"shell"`, `"web_scrape"`, `"fetch"`).
-    pub tool: String,
+    pub tool: ToolName,
     /// Human-readable command or URL being invoked.
     pub command: String,
     /// Outcome of the invocation.

--- a/crates/zeph-tools/src/cache.rs
+++ b/crates/zeph-tools/src/cache.rs
@@ -5,6 +5,8 @@ use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
 use std::time::{Duration, Instant};
 
+use zeph_common::ToolName;
+
 use crate::executor::ToolOutput;
 
 /// Tools that must never have their results cached due to side effects.
@@ -37,13 +39,13 @@ pub fn is_cacheable(tool_name: &str) -> bool {
 /// Composite key identifying a unique tool invocation.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CacheKey {
-    pub tool_name: String,
+    pub tool_name: ToolName,
     pub args_hash: u64,
 }
 
 impl CacheKey {
     #[must_use]
-    pub fn new(tool_name: impl Into<String>, args_hash: u64) -> Self {
+    pub fn new(tool_name: impl Into<ToolName>, args_hash: u64) -> Self {
         Self {
             tool_name: tool_name.into(),
             args_hash,
@@ -178,10 +180,11 @@ impl ToolResultCache {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ToolName;
 
     fn make_output(summary: &str) -> ToolOutput {
         ToolOutput {
-            tool_name: "test".to_owned(),
+            tool_name: ToolName::new("test"),
             summary: summary.to_owned(),
             blocks_executed: 1,
             filter_stats: None,

--- a/crates/zeph-tools/src/composite.rs
+++ b/crates/zeph-tools/src/composite.rs
@@ -87,13 +87,14 @@ impl<A: ToolExecutor, B: ToolExecutor> ToolExecutor for CompositeExecutor<A, B> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ToolName;
 
     #[derive(Debug)]
     struct MatchingExecutor;
     impl ToolExecutor for MatchingExecutor {
         async fn execute(&self, _response: &str) -> Result<Option<ToolOutput>, ToolError> {
             Ok(Some(ToolOutput {
-                tool_name: "test".to_owned(),
+                tool_name: ToolName::new("test"),
                 summary: "matched".to_owned(),
                 blocks_executed: 1,
                 filter_stats: None,
@@ -130,7 +131,7 @@ mod tests {
     impl ToolExecutor for SecondExecutor {
         async fn execute(&self, _response: &str) -> Result<Option<ToolOutput>, ToolError> {
             Ok(Some(ToolOutput {
-                tool_name: "test".to_owned(),
+                tool_name: ToolName::new("test"),
                 summary: "second".to_owned(),
                 blocks_executed: 1,
                 filter_stats: None,
@@ -241,7 +242,7 @@ mod tests {
         ) -> Result<Option<ToolOutput>, ToolError> {
             if call.tool_id == "bash" {
                 Ok(Some(ToolOutput {
-                    tool_name: "bash".to_owned(),
+                    tool_name: ToolName::new("bash"),
                     summary: "shell_handler".to_owned(),
                     blocks_executed: 1,
                     filter_stats: None,
@@ -262,7 +263,7 @@ mod tests {
     async fn tool_call_routes_to_file_executor() {
         let composite = CompositeExecutor::new(FileToolExecutor, ShellToolExecutor);
         let call = ToolCall {
-            tool_id: "read".to_owned(),
+            tool_id: ToolName::new("read"),
             params: serde_json::Map::new(),
             caller_id: None,
         };
@@ -274,7 +275,7 @@ mod tests {
     async fn tool_call_routes_to_shell_executor() {
         let composite = CompositeExecutor::new(FileToolExecutor, ShellToolExecutor);
         let call = ToolCall {
-            tool_id: "bash".to_owned(),
+            tool_id: ToolName::new("bash"),
             params: serde_json::Map::new(),
             caller_id: None,
         };
@@ -286,7 +287,7 @@ mod tests {
     async fn tool_call_unhandled_returns_none() {
         let composite = CompositeExecutor::new(FileToolExecutor, ShellToolExecutor);
         let call = ToolCall {
-            tool_id: "unknown".to_owned(),
+            tool_id: ToolName::new("unknown"),
             params: serde_json::Map::new(),
             caller_id: None,
         };

--- a/crates/zeph-tools/src/cwd.rs
+++ b/crates/zeph-tools/src/cwd.rs
@@ -6,6 +6,8 @@ use std::path::PathBuf;
 use schemars::JsonSchema;
 use serde::Deserialize;
 
+use zeph_common::ToolName;
+
 use crate::executor::{
     ClaimSource, ToolCall, ToolError, ToolExecutor, ToolOutput, deserialize_params,
 };
@@ -55,7 +57,7 @@ impl ToolExecutor for SetCwdExecutor {
         let summary = new_cwd.display().to_string();
 
         Ok(Some(ToolOutput {
-            tool_name: TOOL_NAME.to_owned(),
+            tool_name: ToolName::new(TOOL_NAME),
             summary,
             blocks_executed: 1,
             filter_stats: None,
@@ -97,7 +99,7 @@ mod tests {
             serde_json::Value::String(path.to_owned()),
         );
         ToolCall {
-            tool_id: TOOL_NAME.to_owned(),
+            tool_id: ToolName::new(TOOL_NAME),
             params,
             caller_id: None,
         }
@@ -123,7 +125,7 @@ mod tests {
     async fn set_cwd_returns_none_for_unknown_tool() {
         let executor = SetCwdExecutor;
         let call = ToolCall {
-            tool_id: "other_tool".to_owned(),
+            tool_id: ToolName::new("other_tool"),
             params: serde_json::Map::new(),
             caller_id: None,
         };

--- a/crates/zeph-tools/src/diagnostics.rs
+++ b/crates/zeph-tools/src/diagnostics.rs
@@ -6,6 +6,8 @@ use std::path::{Path, PathBuf};
 use schemars::JsonSchema;
 use serde::Deserialize;
 
+use zeph_common::ToolName;
+
 use crate::executor::{ToolCall, ToolError, ToolExecutor, ToolOutput, deserialize_params};
 use crate::registry::{InvocationHint, ToolDef};
 
@@ -134,7 +136,7 @@ impl ToolExecutor for DiagnosticsExecutor {
         };
 
         Ok(Some(ToolOutput {
-            tool_name: "diagnostics".to_owned(),
+            tool_name: ToolName::new("diagnostics"),
             summary,
             blocks_executed: 1,
             filter_stats: None,
@@ -343,7 +345,7 @@ mod tests {
         let exec = DiagnosticsExecutor::new(vec![dir.path().to_path_buf()]);
 
         let call = ToolCall {
-            tool_id: "diagnostics".to_owned(),
+            tool_id: ToolName::new("diagnostics"),
             params: make_params(&[("path", serde_json::json!("/etc"))]),
             caller_id: None,
         };
@@ -355,7 +357,7 @@ mod tests {
     async fn diagnostics_unknown_tool_returns_none() {
         let exec = DiagnosticsExecutor::new(vec![]);
         let call = ToolCall {
-            tool_id: "other".to_owned(),
+            tool_id: ToolName::new("other"),
             params: serde_json::Map::new(),
             caller_id: None,
         };

--- a/crates/zeph-tools/src/executor.rs
+++ b/crates/zeph-tools/src/executor.rs
@@ -3,6 +3,8 @@
 
 use std::fmt;
 
+use zeph_common::ToolName;
+
 /// Data for rendering file diffs in the TUI.
 ///
 /// Produced by [`ShellExecutor`](crate::ShellExecutor) and [`FileExecutor`](crate::FileExecutor)
@@ -26,9 +28,10 @@ pub struct DiffData {
 ///
 /// ```rust
 /// use zeph_tools::ToolCall;
+/// use zeph_common::ToolName;
 ///
 /// let call = ToolCall {
-///     tool_id: "bash".to_owned(),
+///     tool_id: ToolName::new("bash"),
 ///     params: {
 ///         let mut m = serde_json::Map::new();
 ///         m.insert("command".to_owned(), serde_json::Value::String("echo hello".to_owned()));
@@ -41,7 +44,7 @@ pub struct DiffData {
 #[derive(Debug, Clone)]
 pub struct ToolCall {
     /// The tool identifier, matching a value from [`ToolExecutor::tool_definitions`].
-    pub tool_id: String,
+    pub tool_id: ToolName,
     /// JSON parameters for the tool call, deserialized into the tool's parameter struct.
     pub params: serde_json::Map<String, serde_json::Value>,
     /// Opaque caller identifier propagated from the channel (user ID, session ID, etc.).
@@ -169,9 +172,10 @@ pub enum ClaimSource {
 ///
 /// ```rust
 /// use zeph_tools::{ToolOutput, executor::ClaimSource};
+/// use zeph_common::ToolName;
 ///
 /// let output = ToolOutput {
-///     tool_name: "shell".to_owned(),
+///     tool_name: ToolName::new("shell"),
 ///     summary: "hello\n".to_owned(),
 ///     blocks_executed: 1,
 ///     filter_stats: None,
@@ -187,7 +191,7 @@ pub enum ClaimSource {
 #[derive(Debug, Clone)]
 pub struct ToolOutput {
     /// Name of the tool that produced this output (e.g. `"shell"`, `"web-scrape"`).
-    pub tool_name: String,
+    pub tool_name: ToolName,
     /// Human-readable result text injected into the LLM context.
     pub summary: String,
     /// Number of code blocks processed in this invocation.
@@ -278,16 +282,19 @@ pub fn truncate_tool_output_at(output: &str, max_chars: usize) -> String {
 #[derive(Debug, Clone)]
 pub enum ToolEvent {
     /// The tool has started. Displayed in the TUI as a spinner with the command text.
-    Started { tool_name: String, command: String },
+    Started {
+        tool_name: ToolName,
+        command: String,
+    },
     /// A chunk of streaming output was produced (e.g. from a long-running command).
     OutputChunk {
-        tool_name: String,
+        tool_name: ToolName,
         command: String,
         chunk: String,
     },
     /// The tool finished. Contains the full output and optional filter/diff data.
     Completed {
-        tool_name: String,
+        tool_name: ToolName,
         command: String,
         /// Full output text (possibly filtered and truncated).
         output: String,
@@ -298,7 +305,7 @@ pub enum ToolEvent {
     },
     /// A transactional rollback was performed, restoring or deleting files.
     Rollback {
-        tool_name: String,
+        tool_name: ToolName,
         command: String,
         /// Number of files restored to their pre-execution content.
         restored_count: usize,
@@ -778,7 +785,7 @@ mod tests {
     #[test]
     fn tool_output_display() {
         let output = ToolOutput {
-            tool_name: "bash".to_owned(),
+            tool_name: ToolName::new("bash"),
             summary: "$ echo hello\nhello".to_owned(),
             blocks_executed: 1,
             filter_stats: None,
@@ -1068,7 +1075,7 @@ mod tests {
     async fn execute_tool_call_default_returns_none() {
         let exec = DefaultExecutor;
         let call = ToolCall {
-            tool_id: "anything".to_owned(),
+            tool_id: ToolName::new("anything"),
             params: serde_json::Map::new(),
             caller_id: None,
         };
@@ -1132,7 +1139,7 @@ mod tests {
     impl ToolExecutor for FixedExecutor {
         async fn execute(&self, _response: &str) -> Result<Option<ToolOutput>, ToolError> {
             Ok(Some(ToolOutput {
-                tool_name: self.tool_id.to_owned(),
+                tool_name: ToolName::new(self.tool_id),
                 summary: self.output.to_owned(),
                 blocks_executed: 1,
                 filter_stats: None,
@@ -1154,7 +1161,7 @@ mod tests {
             _call: &ToolCall,
         ) -> Result<Option<ToolOutput>, ToolError> {
             Ok(Some(ToolOutput {
-                tool_name: self.tool_id.to_owned(),
+                tool_name: ToolName::new(self.tool_id),
                 summary: self.output.to_owned(),
                 blocks_executed: 1,
                 filter_stats: None,
@@ -1212,7 +1219,7 @@ mod tests {
         });
         let exec = DynExecutor(inner);
         let call = ToolCall {
-            tool_id: "bash".to_owned(),
+            tool_id: ToolName::new("bash"),
             params: serde_json::Map::new(),
             caller_id: None,
         };

--- a/crates/zeph-tools/src/executor.rs
+++ b/crates/zeph-tools/src/executor.rs
@@ -485,7 +485,7 @@ pub fn deserialize_params<T: serde::de::DeserializeOwned>(
 ///             .unwrap_or("")
 ///             .to_owned();
 ///         Ok(Some(ToolOutput {
-///             tool_name: "echo".to_owned(),
+///             tool_name: "echo".into(),
 ///             summary: text,
 ///             blocks_executed: 1,
 ///             filter_stats: None,

--- a/crates/zeph-tools/src/file.rs
+++ b/crates/zeph-tools/src/file.rs
@@ -11,6 +11,7 @@ use crate::executor::{
     ClaimSource, DiffData, ToolCall, ToolError, ToolExecutor, ToolOutput, deserialize_params,
 };
 use crate::registry::{InvocationHint, ToolDef};
+use zeph_common::ToolName;
 
 #[derive(Deserialize, JsonSchema)]
 pub(crate) struct ReadParams {
@@ -273,7 +274,7 @@ impl FileExecutor {
             .collect();
 
         Ok(Some(ToolOutput {
-            tool_name: "read".to_owned(),
+            tool_name: ToolName::new("read"),
             summary: selected.join("\n"),
             blocks_executed: 1,
             filter_stats: None,
@@ -296,7 +297,7 @@ impl FileExecutor {
         std::fs::write(&path, &params.content)?;
 
         Ok(Some(ToolOutput {
-            tool_name: "write".to_owned(),
+            tool_name: ToolName::new("write"),
             summary: format!("Wrote {} bytes to {}", params.content.len(), params.path),
             blocks_executed: 1,
             filter_stats: None,
@@ -328,7 +329,7 @@ impl FileExecutor {
         std::fs::write(&path, &new_content)?;
 
         Ok(Some(ToolOutput {
-            tool_name: "edit".to_owned(),
+            tool_name: ToolName::new("edit"),
             summary: format!("Edited {}", params.path),
             blocks_executed: 1,
             filter_stats: None,
@@ -369,7 +370,7 @@ impl FileExecutor {
         }
 
         Ok(Some(ToolOutput {
-            tool_name: "find_path".to_owned(),
+            tool_name: ToolName::new("find_path"),
             summary: if matches.is_empty() {
                 format!("No files matching: {}", params.pattern)
             } else if truncated {
@@ -415,7 +416,7 @@ impl FileExecutor {
         grep_recursive(&path, &regex, &mut results, 100, &sandbox)?;
 
         Ok(Some(ToolOutput {
-            tool_name: "grep".to_owned(),
+            tool_name: ToolName::new("grep"),
             summary: if results.is_empty() {
                 format!("No matches for: {}", params.pattern)
             } else {
@@ -472,7 +473,7 @@ impl FileExecutor {
         entries.extend(symlinks);
 
         Ok(Some(ToolOutput {
-            tool_name: "list_directory".to_owned(),
+            tool_name: ToolName::new("list_directory"),
             summary: if entries.is_empty() {
                 format!("Empty directory: {}", params.path)
             } else {
@@ -497,7 +498,7 @@ impl FileExecutor {
         std::fs::create_dir_all(&path)?;
 
         Ok(Some(ToolOutput {
-            tool_name: "create_directory".to_owned(),
+            tool_name: ToolName::new("create_directory"),
             summary: format!("Created directory: {}", params.path),
             blocks_executed: 1,
             filter_stats: None,
@@ -537,7 +538,7 @@ impl FileExecutor {
         }
 
         Ok(Some(ToolOutput {
-            tool_name: "delete_path".to_owned(),
+            tool_name: ToolName::new("delete_path"),
             summary: format!("Deleted: {}", params.path),
             blocks_executed: 1,
             filter_stats: None,
@@ -556,7 +557,7 @@ impl FileExecutor {
         std::fs::rename(&src, &dst)?;
 
         Ok(Some(ToolOutput {
-            tool_name: "move_path".to_owned(),
+            tool_name: ToolName::new("move_path"),
             summary: format!("Moved: {} -> {}", params.source, params.destination),
             blocks_executed: 1,
             filter_stats: None,
@@ -583,7 +584,7 @@ impl FileExecutor {
         }
 
         Ok(Some(ToolOutput {
-            tool_name: "copy_path".to_owned(),
+            tool_name: ToolName::new("copy_path"),
             summary: format!("Copied: {} -> {}", params.source, params.destination),
             blocks_executed: 1,
             filter_stats: None,
@@ -607,7 +608,7 @@ impl ToolExecutor for FileExecutor {
         tracing::instrument(name = "tool.file.execute_call", skip_all, fields(tool_id = %call.tool_id))
     )]
     async fn execute_tool_call(&self, call: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
-        self.execute_file_tool(&call.tool_id, &call.params)
+        self.execute_file_tool(call.tool_id.as_str(), &call.params)
     }
 
     fn tool_definitions(&self) -> Vec<ToolDef> {
@@ -1016,7 +1017,7 @@ mod tests {
 
         let exec = FileExecutor::new(vec![dir.path().to_path_buf()]);
         let call = ToolCall {
-            tool_id: "read".to_owned(),
+            tool_id: ToolName::new("read"),
             params: make_params(&[("path", serde_json::json!(file.to_str().unwrap()))]),
             caller_id: None,
         };

--- a/crates/zeph-tools/src/lib.rs
+++ b/crates/zeph-tools/src/lib.rs
@@ -145,3 +145,4 @@ pub use verifier::{
     PreExecutionVerifier, PreExecutionVerifierConfig, UrlGroundingVerifier,
     UrlGroundingVerifierConfig, VerificationResult,
 };
+pub use zeph_common::ToolName;

--- a/crates/zeph-tools/src/policy_gate.rs
+++ b/crates/zeph-tools/src/policy_gate.rs
@@ -75,7 +75,9 @@ impl<T: ToolExecutor> PolicyGateExecutor<T> {
 
     async fn check_policy(&self, call: &ToolCall) -> Result<(), ToolError> {
         let ctx = self.read_context();
-        let decision = self.enforcer.evaluate(&call.tool_id, &call.params, &ctx);
+        let decision = self
+            .enforcer
+            .evaluate(call.tool_id.as_str(), &call.params, &ctx);
 
         match &decision {
             PolicyDecision::Allow { trace } => {
@@ -172,9 +174,9 @@ impl<T: ToolExecutor> ToolExecutor for PolicyGateExecutor<T> {
         // Populate mcp_server_id in audit when the inner executor produces MCP output.
         // MCP tool outputs use qualified_name() format: "server_id:tool_name".
         if let Ok(Some(ref output)) = result
-            && let Some(colon) = output.tool_name.find(':')
+            && let Some(colon) = output.tool_name.as_str().find(':')
         {
-            let server_id = output.tool_name[..colon].to_owned();
+            let server_id = output.tool_name.as_str()[..colon].to_owned();
             if let Some(audit) = &self.audit {
                 let entry = AuditEntry {
                     timestamp: chrono_now(),
@@ -333,7 +335,7 @@ mod tests {
             default_effect: DefaultEffect::Allow,
             rules: vec![PolicyRuleConfig {
                 effect: PolicyEffect::Deny,
-                tool: "shell".to_owned(),
+                tool: "shell".into(),
                 paths: vec!["/etc/*".to_owned()],
                 env: vec![],
                 trust_level: None,
@@ -356,7 +358,7 @@ mod tests {
             default_effect: DefaultEffect::Deny,
             rules: vec![PolicyRuleConfig {
                 effect: PolicyEffect::Allow,
-                tool: "shell".to_owned(),
+                tool: "shell".into(),
                 paths: vec!["/tmp/*".to_owned()],
                 env: vec![],
                 trust_level: None,
@@ -462,7 +464,7 @@ mod tests {
             default_effect: DefaultEffect::Deny,
             rules: vec![PolicyRuleConfig {
                 effect: PolicyEffect::Allow,
-                tool: "shell".to_owned(),
+                tool: "shell".into(),
                 paths: vec![],
                 env: vec![],
                 trust_level: Some(SkillTrustLevel::Verified),
@@ -490,7 +492,7 @@ mod tests {
             default_effect: DefaultEffect::Deny,
             rules: vec![PolicyRuleConfig {
                 effect: PolicyEffect::Allow,
-                tool: "shell".to_owned(),
+                tool: "shell".into(),
                 paths: vec![],
                 env: vec![],
                 trust_level: Some(SkillTrustLevel::Verified),

--- a/crates/zeph-tools/src/schema_filter.rs
+++ b/crates/zeph-tools/src/schema_filter.rs
@@ -9,6 +9,7 @@
 
 use std::collections::{HashMap, HashSet};
 
+use zeph_common::ToolName;
 use zeph_common::math::cosine_similarity;
 
 use crate::config::ToolDependency;
@@ -16,7 +17,7 @@ use crate::config::ToolDependency;
 /// Cached embedding for a tool definition.
 #[derive(Debug, Clone)]
 pub struct ToolEmbedding {
-    pub tool_id: String,
+    pub tool_id: ToolName,
     pub embedding: Vec<f32>,
 }
 
@@ -42,7 +43,7 @@ pub enum InclusionReason {
 /// Exclusion reason for a tool that was blocked by the dependency gate.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DependencyExclusion {
-    pub tool_id: String,
+    pub tool_id: ToolName,
     /// IDs of `requires` entries that are not yet satisfied.
     pub unmet_requires: Vec<String>,
 }
@@ -210,7 +211,7 @@ impl ToolDependencyGraph {
                 .collect();
             if !unmet.is_empty() {
                 to_exclude.push(DependencyExclusion {
-                    tool_id: tool_id.clone(),
+                    tool_id: tool_id.as_str().into(),
                     unmet_requires: unmet,
                 });
             }
@@ -235,8 +236,8 @@ impl ToolDependencyGraph {
 
         // Apply hard gates.
         for excl in &to_exclude {
-            result.included.remove(&excl.tool_id);
-            result.excluded.push(excl.tool_id.clone());
+            result.included.remove(excl.tool_id.as_str());
+            result.excluded.push(excl.tool_id.to_string());
             tracing::debug!(
                 tool_id = %excl.tool_id,
                 unmet = ?excl.unmet_requires,
@@ -462,10 +463,10 @@ impl ToolSchemaFilter {
         let mut scores: Vec<(String, f32)> = self
             .embeddings
             .iter()
-            .filter(|e| !included.contains(&e.tool_id))
+            .filter(|e| !included.contains(e.tool_id.as_str()))
             .map(|e| {
                 let score = cosine_similarity(query_embedding, &e.embedding);
-                (e.tool_id.clone(), score)
+                (e.tool_id.to_string(), score)
             })
             .collect();
 

--- a/crates/zeph-tools/src/scrape.rs
+++ b/crates/zeph-tools/src/scrape.rs
@@ -97,6 +97,7 @@ impl ExtractMode {
 ///
 /// ```rust,no_run
 /// use zeph_tools::{WebScrapeExecutor, ToolExecutor, ToolCall, config::ScrapeConfig};
+/// use zeph_common::ToolName;
 ///
 /// # async fn example() {
 /// let executor = WebScrapeExecutor::new(&ScrapeConfig::default());

--- a/crates/zeph-tools/src/scrape.rs
+++ b/crates/zeph-tools/src/scrape.rs
@@ -24,6 +24,8 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use url::Url;
 
+use zeph_common::ToolName;
+
 use crate::audit::{AuditEntry, AuditLogger, AuditResult, chrono_now};
 use crate::config::ScrapeConfig;
 use crate::executor::{
@@ -100,7 +102,7 @@ impl ExtractMode {
 /// let executor = WebScrapeExecutor::new(&ScrapeConfig::default());
 ///
 /// let call = ToolCall {
-///     tool_id: "fetch".to_owned(),
+///     tool_id: ToolName::new("fetch"),
 ///     params: {
 ///         let mut m = serde_json::Map::new();
 ///         m.insert("url".to_owned(), serde_json::json!("https://example.com"));
@@ -219,7 +221,7 @@ impl ToolExecutor for WebScrapeExecutor {
         }
 
         Ok(Some(ToolOutput {
-            tool_name: "web-scrape".to_owned(),
+            tool_name: ToolName::new("web-scrape"),
             summary: outputs.join("\n\n"),
             blocks_executed,
             filter_stats: None,
@@ -255,7 +257,7 @@ impl ToolExecutor for WebScrapeExecutor {
                         )
                         .await;
                         Ok(Some(ToolOutput {
-                            tool_name: "web-scrape".to_owned(),
+                            tool_name: ToolName::new("web-scrape"),
                             summary: output,
                             blocks_executed: 1,
                             filter_stats: None,
@@ -292,7 +294,7 @@ impl ToolExecutor for WebScrapeExecutor {
                         self.log_audit("fetch", &p.url, AuditResult::Success, duration_ms, None)
                             .await;
                         Ok(Some(ToolOutput {
-                            tool_name: "fetch".to_owned(),
+                            tool_name: ToolName::new("fetch"),
                             summary: output,
                             blocks_executed: 1,
                             filter_stats: None,
@@ -1691,7 +1693,7 @@ mod tests {
         let config = ScrapeConfig::default();
         let executor = WebScrapeExecutor::new(&config);
         let call = crate::executor::ToolCall {
-            tool_id: "fetch".to_owned(),
+            tool_id: ToolName::new("fetch"),
             params: {
                 let mut m = serde_json::Map::new();
                 m.insert("url".to_owned(), serde_json::json!("http://example.com"));
@@ -1708,7 +1710,7 @@ mod tests {
         let config = ScrapeConfig::default();
         let executor = WebScrapeExecutor::new(&config);
         let call = crate::executor::ToolCall {
-            tool_id: "fetch".to_owned(),
+            tool_id: ToolName::new("fetch"),
             params: {
                 let mut m = serde_json::Map::new();
                 m.insert(
@@ -1728,7 +1730,7 @@ mod tests {
         let config = ScrapeConfig::default();
         let executor = WebScrapeExecutor::new(&config);
         let call = crate::executor::ToolCall {
-            tool_id: "fetch".to_owned(),
+            tool_id: ToolName::new("fetch"),
             params: {
                 let mut m = serde_json::Map::new();
                 m.insert(
@@ -1748,7 +1750,7 @@ mod tests {
         let config = ScrapeConfig::default();
         let executor = WebScrapeExecutor::new(&config);
         let call = crate::executor::ToolCall {
-            tool_id: "unknown_tool".to_owned(),
+            tool_id: ToolName::new("unknown_tool"),
             params: serde_json::Map::new(),
             caller_id: None,
         };
@@ -1970,7 +1972,7 @@ mod tests {
         let executor = WebScrapeExecutor::new(&config).with_audit(logger);
 
         let call = crate::executor::ToolCall {
-            tool_id: "fetch".to_owned(),
+            tool_id: ToolName::new("fetch"),
             params: {
                 let mut m = serde_json::Map::new();
                 m.insert("url".to_owned(), serde_json::json!("http://example.com"));
@@ -2077,7 +2079,7 @@ mod tests {
         let executor = WebScrapeExecutor::new(&config).with_audit(logger);
 
         let call = crate::executor::ToolCall {
-            tool_id: "web_scrape".to_owned(),
+            tool_id: ToolName::new("web_scrape"),
             params: {
                 let mut m = serde_json::Map::new();
                 m.insert("url".to_owned(), serde_json::json!("http://example.com"));
@@ -2107,7 +2109,7 @@ mod tests {
         assert!(executor.audit_logger.is_none());
 
         let call = crate::executor::ToolCall {
-            tool_id: "fetch".to_owned(),
+            tool_id: ToolName::new("fetch"),
             params: {
                 let mut m = serde_json::Map::new();
                 m.insert("url".to_owned(), serde_json::json!("http://example.com"));

--- a/crates/zeph-tools/src/search_code.rs
+++ b/crates/zeph-tools/src/search_code.rs
@@ -10,6 +10,8 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use tree_sitter::{Parser, Query, QueryCursor, StreamingIterator};
 
+use zeph_common::ToolName;
+
 use crate::executor::{
     ClaimSource, ToolCall, ToolError, ToolExecutor, ToolOutput, deserialize_params,
 };
@@ -334,7 +336,7 @@ impl SearchCodeExecutor {
         });
 
         Ok(Some(ToolOutput {
-            tool_name: "search_code".to_owned(),
+            tool_name: ToolName::new("search_code"),
             summary,
             blocks_executed: 1,
             filter_stats: None,

--- a/crates/zeph-tools/src/shell/mod.rs
+++ b/crates/zeph-tools/src/shell/mod.rs
@@ -33,6 +33,8 @@ use std::sync::Arc;
 
 use parking_lot::RwLock;
 
+use zeph_common::ToolName;
+
 use crate::audit::{AuditEntry, AuditLogger, AuditResult, chrono_now};
 use crate::config::ShellConfig;
 use crate::executor::{
@@ -334,7 +336,7 @@ impl ShellExecutor {
             .and_then(|e| serde_json::to_value(e).ok());
 
         Ok(Some(ToolOutput {
-            tool_name: "bash".to_owned(),
+            tool_name: ToolName::new("bash"),
             summary: outputs.join("\n\n"),
             blocks_executed,
             filter_stats: cumulative_filter_stats,
@@ -391,7 +393,7 @@ impl ShellExecutor {
 
         if let Some(ref tx) = self.tool_event_tx {
             let _ = tx.send(ToolEvent::Started {
-                tool_name: "bash".to_owned(),
+                tool_name: ToolName::new("bash"),
                 command: block.to_owned(),
             });
         }
@@ -450,7 +452,7 @@ impl ShellExecutor {
                         .await;
                         if let Some(ref tx) = self.tool_event_tx {
                             let _ = tx.send(ToolEvent::Rollback {
-                                tool_name: "bash".to_owned(),
+                                tool_name: ToolName::new("bash"),
                                 command: block.to_owned(),
                                 restored_count: report.restored_count,
                                 deleted_count: report.deleted_count,
@@ -566,7 +568,7 @@ impl ShellExecutor {
     ) {
         if let Some(ref tx) = self.tool_event_tx {
             let _ = tx.send(ToolEvent::Completed {
-                tool_name: "bash".to_owned(),
+                tool_name: ToolName::new("bash"),
                 command: command.to_owned(),
                 output: output.to_owned(),
                 success,
@@ -1276,7 +1278,7 @@ async fn execute_bash(
                         };
                         if let Some(tx) = event_tx {
                             let _ = tx.send(ToolEvent::OutputChunk {
-                                tool_name: "bash".to_owned(),
+                                tool_name: ToolName::new("bash"),
                                 command: code.to_owned(),
                                 chunk: interleaved.clone(),
                             });

--- a/crates/zeph-tools/src/shell/tests.rs
+++ b/crates/zeph-tools/src/shell/tests.rs
@@ -1183,7 +1183,7 @@ async fn shell_executor_cancel_returns_cancelled_error() {
 async fn execute_tool_call_valid_command() {
     let executor = ShellExecutor::new(&default_config());
     let call = ToolCall {
-        tool_id: "bash".to_owned(),
+        tool_id: ToolName::new("bash"),
         params: [("command".to_owned(), serde_json::json!("echo hi"))]
             .into_iter()
             .collect(),
@@ -1197,7 +1197,7 @@ async fn execute_tool_call_valid_command() {
 async fn execute_tool_call_missing_command_returns_invalid_params() {
     let executor = ShellExecutor::new(&default_config());
     let call = ToolCall {
-        tool_id: "bash".to_owned(),
+        tool_id: ToolName::new("bash"),
         params: serde_json::Map::new(),
         caller_id: None,
     };
@@ -1209,7 +1209,7 @@ async fn execute_tool_call_missing_command_returns_invalid_params() {
 async fn execute_tool_call_empty_command_returns_none() {
     let executor = ShellExecutor::new(&default_config());
     let call = ToolCall {
-        tool_id: "bash".to_owned(),
+        tool_id: ToolName::new("bash"),
         params: [("command".to_owned(), serde_json::json!(""))]
             .into_iter()
             .collect(),

--- a/crates/zeph-tools/src/tool_filter.rs
+++ b/crates/zeph-tools/src/tool_filter.rs
@@ -50,6 +50,7 @@ impl<E: ToolExecutor> ToolExecutor for ToolFilter<E> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ToolName;
 
     #[derive(Debug)]
     struct StubExecutor;
@@ -112,7 +113,7 @@ mod tests {
     async fn suppressed_tool_call_returns_none() {
         let filter = ToolFilter::new(StubExecutor, &["read", "glob"]);
         let call = ToolCall {
-            tool_id: "read".to_owned(),
+            tool_id: ToolName::new("read"),
             params: serde_json::Map::new(),
             caller_id: None,
         };
@@ -124,7 +125,7 @@ mod tests {
     async fn allowed_tool_call_passes_through() {
         let filter = ToolFilter::new(StubExecutor, &["read", "glob"]);
         let call = ToolCall {
-            tool_id: "edit".to_owned(),
+            tool_id: ToolName::new("edit"),
             params: serde_json::Map::new(),
             caller_id: None,
         };

--- a/crates/zeph-tools/src/trust_gate.rs
+++ b/crates/zeph-tools/src/trust_gate.rs
@@ -215,7 +215,7 @@ impl<T: ToolExecutor> ToolExecutor for TrustGateExecutor<T> {
             .or_else(|| call.params.get("uri"))
             .and_then(|v| v.as_str())
             .unwrap_or("");
-        self.check_trust(&call.tool_id, input)?;
+        self.check_trust(call.tool_id.as_str(), input)?;
         self.inner.execute_tool_call(call).await
     }
 
@@ -232,7 +232,9 @@ impl<T: ToolExecutor> ToolExecutor for TrustGateExecutor<T> {
                 });
             }
             SkillTrustLevel::Quarantined => {
-                if is_quarantine_denied(&call.tool_id) || self.is_mcp_tool(&call.tool_id) {
+                if is_quarantine_denied(call.tool_id.as_str())
+                    || self.is_mcp_tool(call.tool_id.as_str())
+                {
                     return Err(ToolError::Blocked {
                         command: format!("{} denied (trust=quarantined)", call.tool_id),
                     });

--- a/crates/zeph-tools/src/utility.rs
+++ b/crates/zeph-tools/src/utility.rs
@@ -165,7 +165,7 @@ impl UtilityScorer {
             return None;
         }
 
-        let gain = default_gain(&call.tool_id);
+        let gain = default_gain(call.tool_id.as_str());
 
         let cost = if ctx.token_budget > 0 {
             #[allow(clippy::cast_precision_loss)]
@@ -297,11 +297,12 @@ impl UtilityScorer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ToolName;
     use serde_json::json;
 
     fn make_call(name: &str, params: serde_json::Value) -> ToolCall {
         ToolCall {
-            tool_id: name.to_owned(),
+            tool_id: ToolName::new(name),
             params: if let serde_json::Value::Object(m) = params {
                 m
             } else {

--- a/crates/zeph-tui/src/app.rs
+++ b/crates/zeph-tui/src/app.rs
@@ -164,7 +164,7 @@ impl AgentViewTarget {
 pub struct TuiTranscriptEntry {
     pub role: String,
     pub content: String,
-    pub tool_name: Option<String>,
+    pub tool_name: Option<zeph_common::ToolName>,
     pub timestamp: Option<String>,
 }
 
@@ -518,7 +518,7 @@ impl App {
                 && let Some((tool_name, body)) = parse_tool_output(content, TOOL_SUFFIX)
             {
                 self.messages
-                    .push(ChatMessage::new(MessageRole::Tool, body).with_tool(tool_name));
+                    .push(ChatMessage::new(MessageRole::Tool, body).with_tool(tool_name.into()));
                 continue;
             }
 
@@ -1137,7 +1137,7 @@ impl App {
 
     fn handle_tool_output_event(
         &mut self,
-        tool_name: String,
+        tool_name: zeph_common::ToolName,
         output: String,
         diff: Option<zeph_core::DiffData>,
         filter_stats: Option<String>,
@@ -2352,7 +2352,7 @@ fn load_transcript_file(
                 let tool_name = msg
                     .get("tool_name")
                     .and_then(|t| t.as_str())
-                    .map(ToOwned::to_owned);
+                    .map(zeph_common::ToolName::new);
                 let timestamp = v
                     .get("timestamp")
                     .and_then(|t| t.as_str())
@@ -2373,7 +2373,7 @@ fn load_transcript_file(
                 let tool_name = v
                     .get("tool_name")
                     .and_then(|t| t.as_str())
-                    .map(ToOwned::to_owned);
+                    .map(zeph_common::ToolName::new);
                 let timestamp = v
                     .get("timestamp")
                     .and_then(|t| t.as_str())
@@ -2964,7 +2964,10 @@ mod tests {
         assert_eq!(app.messages()[0].role, MessageRole::User);
         assert_eq!(app.messages()[1].role, MessageRole::Assistant);
         assert_eq!(app.messages()[2].role, MessageRole::Tool);
-        assert_eq!(app.messages()[2].tool_name.as_deref(), Some("bash"));
+        assert_eq!(
+            app.messages()[2].tool_name.as_ref().map(|t| t.as_str()),
+            Some("bash")
+        );
         assert_eq!(app.messages()[2].content, "$ echo hello\nhello");
         assert_eq!(app.messages()[3].role, MessageRole::Assistant);
     }
@@ -2975,7 +2978,10 @@ mod tests {
         app.load_history(&[("user", "[tool output]\n```\n$ ls\nfile.txt\n```")]);
         assert_eq!(app.messages().len(), 1);
         assert_eq!(app.messages()[0].role, MessageRole::Tool);
-        assert_eq!(app.messages()[0].tool_name.as_deref(), Some("bash"));
+        assert_eq!(
+            app.messages()[0].tool_name.as_ref().map(|t| t.as_str()),
+            Some("bash")
+        );
         assert_eq!(app.messages()[0].content, "$ ls\nfile.txt");
     }
 
@@ -2988,7 +2994,10 @@ mod tests {
         )]);
         assert_eq!(app.messages().len(), 1);
         assert_eq!(app.messages()[0].role, MessageRole::Tool);
-        assert_eq!(app.messages()[0].tool_name.as_deref(), Some("tool"));
+        assert_eq!(
+            app.messages()[0].tool_name.as_ref().map(|t| t.as_str()),
+            Some("tool")
+        );
     }
 
     #[test]
@@ -2997,7 +3006,10 @@ mod tests {
         app.load_history(&[("user", "[tool_result: toolu_abc]\n$ echo hello\nhello")]);
         assert_eq!(app.messages().len(), 1);
         assert_eq!(app.messages()[0].role, MessageRole::Tool);
-        assert_eq!(app.messages()[0].tool_name.as_deref(), Some("bash"));
+        assert_eq!(
+            app.messages()[0].tool_name.as_ref().map(|t| t.as_str()),
+            Some("bash")
+        );
         assert_eq!(app.messages()[0].content, "$ echo hello\nhello");
     }
 
@@ -4518,7 +4530,7 @@ mod tests {
             timestamp: Some("12:34".into()),
         };
         let msg = entry.to_chat_message();
-        assert_eq!(msg.tool_name.as_deref(), Some("bash"));
+        assert_eq!(msg.tool_name.as_ref().map(|t| t.as_str()), Some("bash"));
         assert_eq!(msg.timestamp, "12:34");
         assert_eq!(msg.content, "result");
     }
@@ -4630,7 +4642,10 @@ mod tests {
         .unwrap();
         let (entries, _total) = load_transcript_file(tmp.path(), false);
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].tool_name.as_deref(), Some("bash"));
+        assert_eq!(
+            entries[0].tool_name.as_ref().map(|t| t.as_str()),
+            Some("bash")
+        );
     }
 
     #[test]

--- a/crates/zeph-tui/src/channel.rs
+++ b/crates/zeph-tui/src/channel.rs
@@ -215,7 +215,7 @@ impl Channel for TuiChannel {
             .to_owned();
         self.agent_event_tx
             .send(AgentEvent::ToolStart {
-                tool_name: event.tool_name.to_owned(),
+                tool_name: event.tool_name.into(),
                 command,
             })
             .await
@@ -231,7 +231,7 @@ impl Channel for TuiChannel {
         );
         self.agent_event_tx
             .send(AgentEvent::ToolOutput {
-                tool_name: event.tool_name.to_owned(),
+                tool_name: event.tool_name.into(),
                 command: event.body.to_owned(),
                 output: event.body.to_owned(),
                 success: !event.is_error,

--- a/crates/zeph-tui/src/event.rs
+++ b/crates/zeph-tui/src/event.rs
@@ -144,14 +144,14 @@ pub enum AgentEvent {
     /// A tool call has started; the TUI should display a spinner with the tool name.
     ToolStart {
         /// Canonical tool name (e.g. `"bash"`, `"read_file"`).
-        tool_name: String,
+        tool_name: zeph_common::ToolName,
         /// The primary command or argument string shown in the status bar.
         command: String,
     },
     /// An incremental output chunk from a long-running tool (e.g. streaming shell output).
     ToolOutputChunk {
         /// Tool that produced the chunk.
-        tool_name: String,
+        tool_name: zeph_common::ToolName,
         /// Command argument associated with the tool call.
         command: String,
         /// The chunk text to append.
@@ -160,7 +160,7 @@ pub enum AgentEvent {
     /// Final tool output, replacing any in-progress chunks for this call.
     ToolOutput {
         /// Tool that produced the output.
-        tool_name: String,
+        tool_name: zeph_common::ToolName,
         /// Command argument associated with the tool call.
         command: String,
         /// Full rendered output body.

--- a/crates/zeph-tui/src/types.rs
+++ b/crates/zeph-tui/src/types.rs
@@ -71,7 +71,7 @@ pub struct ChatMessage {
     /// `true` while the message is still being streamed from the LLM.
     pub streaming: bool,
     /// Name of the tool that produced this message, if any.
-    pub tool_name: Option<String>,
+    pub tool_name: Option<zeph_common::ToolName>,
     /// Inline diff attached to a tool-output message.
     pub diff_data: Option<zeph_core::DiffData>,
     /// Human-readable filter statistics (e.g. "kept 12/40 lines").
@@ -135,11 +135,11 @@ impl ChatMessage {
     /// use zeph_tui::{ChatMessage, MessageRole};
     ///
     /// let msg = ChatMessage::new(MessageRole::Tool, "output")
-    ///     .with_tool("bash".to_string());
-    /// assert_eq!(msg.tool_name.as_deref(), Some("bash"));
+    ///     .with_tool(zeph_common::ToolName::new("bash"));
+    /// assert!(msg.tool_name.is_some());
     /// ```
     #[must_use]
-    pub fn with_tool(mut self, name: String) -> Self {
+    pub fn with_tool(mut self, name: zeph_common::ToolName) -> Self {
         self.tool_name = Some(name);
         self
     }

--- a/crates/zeph-tui/src/widgets/chat.rs
+++ b/crates/zeph-tui/src/widgets/chat.rs
@@ -358,7 +358,10 @@ fn render_tool_message(
     _show_labels: bool,
     lines: &mut Vec<Line<'static>>,
 ) {
-    let name = msg.tool_name.as_deref().unwrap_or("tool");
+    let name = msg
+        .tool_name
+        .as_ref()
+        .map_or("tool", zeph_common::ToolName::as_str);
     let content_lines: Vec<&str> = msg.content.lines().collect();
     let cmd_line = content_lines.first().copied().unwrap_or("");
     let dim = Style::default().add_modifier(Modifier::DIM);

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -317,7 +317,7 @@ async fn drain_embedding_guard_events(
             } => {
                 tracing::warn!(
                     server_id = event.server_id,
-                    tool_name = event.tool_name,
+                    tool_name = %event.tool_name,
                     distance,
                     threshold,
                     "embedding anomaly detected in MCP tool output"
@@ -328,7 +328,7 @@ async fn drain_embedding_guard_events(
             } => {
                 tracing::warn!(
                     server_id = event.server_id,
-                    tool_name = event.tool_name,
+                    tool_name = %event.tool_name,
                     "regex injection detected in MCP tool output (cold-start fallback)"
                 );
             }

--- a/src/scheduler_executor.rs
+++ b/src/scheduler_executor.rs
@@ -427,7 +427,7 @@ impl SchedulerExecutor {
 
 fn make_output(tool_name: &str, summary: &str) -> ToolOutput {
     ToolOutput {
-        tool_name: tool_name.to_owned(),
+        tool_name: tool_name.to_owned().into(),
         summary: truncate_tool_output(summary),
         blocks_executed: 1,
         filter_stats: None,
@@ -552,7 +552,7 @@ mod tests {
             panic!("scheduler test params must be a JSON object");
         };
         ToolCall {
-            tool_id: tool_id.to_owned(),
+            tool_id: zeph_tools::ToolName::new(tool_id),
             params,
             caller_id: None,
         }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -179,7 +179,7 @@ struct OutputToolExecutor {
 impl ToolExecutor for OutputToolExecutor {
     async fn execute(&self, _response: &str) -> Result<Option<ToolOutput>, ToolError> {
         Ok(Some(ToolOutput {
-            tool_name: "bash".to_string(),
+            tool_name: zeph_tools::ToolName::new("bash"),
             summary: self.output.clone(),
             blocks_executed: 1,
             filter_stats: None,
@@ -213,7 +213,7 @@ struct EmptyOutputToolExecutor;
 impl ToolExecutor for EmptyOutputToolExecutor {
     async fn execute(&self, _response: &str) -> Result<Option<ToolOutput>, ToolError> {
         Ok(Some(ToolOutput {
-            tool_name: "bash".to_string(),
+            tool_name: zeph_tools::ToolName::new("bash"),
             summary: String::new(),
             blocks_executed: 1,
             filter_stats: None,
@@ -247,7 +247,7 @@ struct ErrorOutputToolExecutor;
 impl ToolExecutor for ErrorOutputToolExecutor {
     async fn execute(&self, _response: &str) -> Result<Option<ToolOutput>, ToolError> {
         Ok(Some(ToolOutput {
-            tool_name: "bash".to_string(),
+            tool_name: zeph_tools::ToolName::new("bash"),
             summary: "[error] command failed".into(),
             blocks_executed: 1,
             filter_stats: None,
@@ -303,7 +303,7 @@ impl ToolExecutor for ConfirmToolExecutor {
 
     async fn execute_confirmed(&self, _response: &str) -> Result<Option<ToolOutput>, ToolError> {
         Ok(Some(ToolOutput {
-            tool_name: "bash".to_string(),
+            tool_name: zeph_tools::ToolName::new("bash"),
             summary: "confirmed output".into(),
             blocks_executed: 1,
             filter_stats: None,
@@ -380,7 +380,7 @@ struct ExitCodeToolExecutor;
 impl ToolExecutor for ExitCodeToolExecutor {
     async fn execute(&self, _response: &str) -> Result<Option<ToolOutput>, ToolError> {
         Ok(Some(ToolOutput {
-            tool_name: "bash".to_string(),
+            tool_name: zeph_tools::ToolName::new("bash"),
             summary: "[exit code 1] process failed".into(),
             blocks_executed: 1,
             filter_stats: None,
@@ -2487,7 +2487,7 @@ mod self_learning {
     impl ToolExecutor for ErrorToolExecutor {
         async fn execute(&self, _response: &str) -> Result<Option<ToolOutput>, ToolError> {
             Ok(Some(ToolOutput {
-                tool_name: "bash".to_string(),
+                tool_name: zeph_tools::ToolName::new("bash"),
                 summary: "[error] command failed".into(),
                 blocks_executed: 1,
                 filter_stats: None,

--- a/tests/performance_agent_integration.rs
+++ b/tests/performance_agent_integration.rs
@@ -151,7 +151,7 @@ impl ToolExecutor for BlockingMockExecutor {
 
     async fn execute_tool_call(&self, call: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
         Err(ToolError::Blocked {
-            command: call.tool_id.clone(),
+            command: call.tool_id.to_string(),
         })
     }
 }


### PR DESCRIPTION
## Summary

- Introduces `ToolName(Arc<str>)` in `zeph-common` replacing raw `String` for all tool name fields across 15+ crates (#2901)
- Introduces `SessionId(String)` in `zeph-common` replacing raw `String`/`uuid::Uuid` session identifiers across 4 crates (#2902)
- Both use `#[serde(transparent)]` — no wire format changes, no DB migration

Closes #2901, #2902

## Changes

### `zeph-common/src/types.rs` (new file)

- `ToolName(Arc<str>)`: `Display`, `AsRef<str>`, `Borrow<str>`, `From<&str>`, `From<String>`, `FromStr`, `PartialEq<str/String>`. No `Deref` (prevents `.to_owned()` footgun). Documented as unvalidated LLM label.
- `SessionId(String)`: `generate()` (UUID v4), `new(s)` (with `debug_assert!(!s.is_empty())`), `Deref<Target=str>`, `From<uuid::Uuid>`, same `PartialEq` set as `ToolName`.

### Propagation

**ToolName** — `zeph-tools` (`ToolCall.tool_id`, `ToolOutput.tool_name`, `ToolEvent` variants, `AuditEntry.tool`, `CacheKey.tool_name`, `ToolEmbedding.tool_id`), `zeph-llm` (`ToolDefinition.name`, `ToolUseRequest.name`, **`MessagePart::ToolOutput.tool_name`**), `zeph-core` (`ToolStartData`, `ToolOutputData`, `ToolTimeout`, `sidequest`, `persistence`, channel events), `zeph-tui` (events, app state, types), `zeph-mcp` (error variants, policy violations, embedding guard events), `zeph-sanitizer` (`SuspiciousToolUrl`), `zeph-skills` (`FailurePattern`), `zeph-acp` (helpers), root binary.

**SessionId** — `zeph-core` (agent session context), `zeph-experiments` (`ExperimentEngine`, `ExperimentSessionReport`, `ExperimentResult`), `zeph-memory` (`EntityLockManager`, `ExperimentResultRow`, `SessionSummaryRow`).

### Intentional String boundaries

- `zeph-mcp/src/mock.rs` — test stub capturing raw wire strings (`#[cfg(feature = "mock")]`)
- `zeph-memory/src/semantic/recall.rs` — Qdrant payload metadata (raw JSON)
- `zeph-memory/src/store/experiments.rs` internal `ResultTuple` — private SQLite `FromRow` boundary

## ⚠️ LLM Serialization Gate

**This PR touches `MessagePart::ToolOutput.tool_name` in `zeph-llm/src/provider.rs`** — a struct on the LLM context assembly path.

Per project policy, a live API session test is required before merge:

```bash
cargo run --features full -- --config .local/config/testing.toml
```

Verify: multi-turn prompt with tool call completes without 400/422 errors; debug dump shows `tool_name` as a plain string in the `messages` array.

Playbook: `.local/testing/playbooks/toolname-sessionid-newtypes.md`

## Test plan

- [ ] CI passes (cargo fmt, clippy, nextest)
- [ ] Live session test: tool dispatch round-trip (shell tool, one invocation)
- [ ] Live session test: multi-tool session (shell + web_scrape or similar)
- [ ] Check debug dump: `MessagePart::ToolOutput.tool_name` serializes as plain string
- [ ] No 400/422 errors from LLM provider
- [ ] Coverage status updated: `.local/testing/coverage-status.md`