### PR TITLE
refactor: type safety cleanup and MemoryFacade trait (#2907, #2903)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `Agent::run()` body is now ~30 lines. Behavior is unchanged; cancellation safety is preserved.
   New file: `crates/zeph-core/src/agent/loop_event.rs`.
 
+- **Type-safety cleanup + `MemoryFacade` trait** (`#2907`, `#2903`):
+  - `ToolDefinition` moved from `zeph-llm` to `zeph-common`; `zeph-llm` re-exports it.
+  - `PolicyMessage`, `PolicyRole`, `PolicyLlmClient` moved from `zeph-tools` to `zeph-common`.
+  - `MessageVisibility` enum (`Both` | `AgentOnly` | `UserOnly`) replaces the `(agent_visible: bool, user_visible: bool)` pair in `MessageMetadata`. The invalid `(false, false)` state is now unrepresentable. SQLite migration 073 drops the two boolean columns and adds a single `visibility TEXT NOT NULL DEFAULT 'both'` column.
+  - `ToolStartEvent` and `ToolOutputEvent` are now owned structs (no lifetimes). `ToolStartData` / `ToolOutputData` are type aliases for backward compatibility with the ACP layer. `ToolOutputEvent.display` replaces the former `body` field.
+  - `MemoryFacade` trait (`remember` / `recall` / `summarize` / `compact`) and `InMemoryFacade` in-process test double added to `zeph-memory`. `SemanticMemory` implements `MemoryFacade`.
+
 - **`zeph-skills` dependency decoupling** (`#2905`): removed unconditional dependencies on
   `zeph-memory` and `zeph-tools` from `zeph-skills`. `SkillTrustLevel`, `ToolErrorCategory`,
   `ErrorDomain`, injection patterns, and quarantine lists are moved to `zeph-common`; `zeph-tools`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -261,6 +261,7 @@ uuid = { workspace = true, optional = true, features = ["v4"] }
 zeph-a2a = { workspace = true, optional = true }
 zeph-acp = { workspace = true, optional = true }
 zeph-channels.workspace = true
+zeph-common.workspace = true
 zeph-core.workspace = true
 zeph-gateway = { workspace = true, optional = true }
 zeph-index.workspace = true

--- a/crates/zeph-acp/src/agent/helpers.rs
+++ b/crates/zeph-acp/src/agent/helpers.rs
@@ -247,6 +247,7 @@ pub(super) fn build_config_options(
     opts
 }
 
+#[allow(deprecated)]
 fn tool_start_to_updates(data: zeph_core::ToolStartData) -> Vec<acp::SessionUpdate> {
     let tool_name = data.tool_name;
     let tool_call_id = data.tool_call_id;
@@ -437,6 +438,7 @@ fn non_terminal_tool_updates(
     vec![acp::SessionUpdate::ToolCallUpdate(update)]
 }
 
+#[allow(deprecated)]
 fn tool_output_to_updates(data: zeph_core::ToolOutputData) -> Vec<acp::SessionUpdate> {
     let tool_name = data.tool_name;
     let display = data.display;

--- a/crates/zeph-acp/src/agent/helpers.rs
+++ b/crates/zeph-acp/src/agent/helpers.rs
@@ -247,7 +247,6 @@ pub(super) fn build_config_options(
     opts
 }
 
-#[allow(deprecated)]
 fn tool_start_to_updates(data: zeph_core::ToolStartData) -> Vec<acp::SessionUpdate> {
     let tool_name = data.tool_name;
     let tool_call_id = data.tool_call_id;
@@ -438,7 +437,6 @@ fn non_terminal_tool_updates(
     vec![acp::SessionUpdate::ToolCallUpdate(update)]
 }
 
-#[allow(deprecated)]
 fn tool_output_to_updates(data: zeph_core::ToolOutputData) -> Vec<acp::SessionUpdate> {
     let tool_name = data.tool_name;
     let display = data.display;

--- a/crates/zeph-bench/src/channel.rs
+++ b/crates/zeph-bench/src/channel.rs
@@ -258,7 +258,7 @@ impl zeph_core::channel::Channel for BenchmarkChannel {
     // The default trait impl calls self.send(&formatted), which would push tool output
     // into responses and corrupt benchmark metrics. Override to no-op until Phase 2
     // when tool calls are captured separately.
-    async fn send_tool_output(&mut self, _event: ToolOutputEvent<'_>) -> Result<(), ChannelError> {
+    async fn send_tool_output(&mut self, _event: ToolOutputEvent) -> Result<(), ChannelError> {
         Ok(())
     }
 }
@@ -350,13 +350,15 @@ mod tests {
         let mut ch = BenchmarkChannel::new(vec!["p".into()]);
         let _ = ch.recv().await.unwrap();
         ch.send_tool_output(ToolOutputEvent {
-            tool_name: "bash",
-            body: "some tool output",
+            tool_name: "bash".into(),
+            display: "some tool output".into(),
             diff: None,
             filter_stats: None,
             kept_lines: None,
             locations: None,
-            tool_call_id: "tc-1",
+            tool_call_id: "tc-1".into(),
+
+            terminal_id: None,
             is_error: false,
             parent_tool_use_id: None,
             raw_response: None,

--- a/crates/zeph-channels/src/any.rs
+++ b/crates/zeph-channels/src/any.rs
@@ -137,7 +137,7 @@ impl Channel for AnyChannel {
         dispatch_channel!(self, send_diff, diff)
     }
 
-    async fn send_tool_output(&mut self, event: ToolOutputEvent<'_>) -> Result<(), ChannelError> {
+    async fn send_tool_output(&mut self, event: ToolOutputEvent) -> Result<(), ChannelError> {
         dispatch_channel!(self, send_tool_output, event)
     }
 
@@ -164,7 +164,7 @@ impl Channel for AnyChannel {
         )
     }
 
-    async fn send_tool_start(&mut self, event: ToolStartEvent<'_>) -> Result<(), ChannelError> {
+    async fn send_tool_start(&mut self, event: ToolStartEvent) -> Result<(), ChannelError> {
         dispatch_channel!(self, send_tool_start, event)
     }
 }
@@ -253,10 +253,11 @@ mod tests {
         let mut ch = AnyChannel::Cli(CliChannel::new());
         assert!(
             ch.send_tool_start(ToolStartEvent {
-                tool_name: "shell",
-                tool_call_id: "tc-001",
+                tool_name: "shell".into(),
+                tool_call_id: "tc-001".into(),
                 params: None,
                 parent_tool_use_id: None,
+                started_at: std::time::Instant::now(),
             })
             .await
             .is_ok()
@@ -305,22 +306,25 @@ mod tests {
         .unwrap();
         // 13. send_tool_start
         ch.send_tool_start(ToolStartEvent {
-            tool_name: "bash",
-            tool_call_id: "x",
+            tool_name: "bash".into(),
+            tool_call_id: "x".into(),
             params: None,
             parent_tool_use_id: None,
+            started_at: std::time::Instant::now(),
         })
         .await
         .unwrap();
         // 14. send_tool_output
         ch.send_tool_output(ToolOutputEvent {
-            tool_name: "bash",
-            body: "ok",
+            tool_name: "bash".into(),
+            display: "ok".into(),
             diff: None,
             filter_stats: None,
             kept_lines: None,
             locations: None,
-            tool_call_id: "x",
+            tool_call_id: "x".into(),
+
+            terminal_id: None,
             is_error: false,
             parent_tool_use_id: None,
             raw_response: None,

--- a/crates/zeph-common/Cargo.toml
+++ b/crates/zeph-common/Cargo.toml
@@ -26,6 +26,7 @@ treesitter = [
 [dependencies]
 blake3.workspace = true
 serde = { workspace = true, features = ["derive", "rc"] }
+serde_json.workspace = true
 thiserror.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 zeroize = { workspace = true, features = ["alloc", "derive", "serde"] }

--- a/crates/zeph-common/src/lib.rs
+++ b/crates/zeph-common/src/lib.rs
@@ -15,6 +15,7 @@ pub mod hash;
 pub mod math;
 pub mod net;
 pub mod patterns;
+pub mod policy;
 pub mod quarantine;
 pub mod sanitize;
 pub mod secret;
@@ -22,8 +23,9 @@ pub mod text;
 pub mod trust_level;
 pub mod types;
 
+pub use policy::{PolicyLlmClient, PolicyMessage, PolicyRole};
 pub use trust_level::SkillTrustLevel;
-pub use types::{SessionId, ToolName};
+pub use types::{SessionId, ToolDefinition, ToolName};
 
 #[cfg(feature = "treesitter")]
 pub mod treesitter;

--- a/crates/zeph-common/src/policy.rs
+++ b/crates/zeph-common/src/policy.rs
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Policy LLM client trait and minimal message types.
+//!
+//! Defines the interface used by `zeph-tools` adversarial policy validation,
+//! moved here to keep `zeph-tools` decoupled from `zeph-llm`.
+
+use std::future::Future;
+use std::pin::Pin;
+
+/// Minimal message type for policy LLM calls.
+///
+/// Uses a dedicated type rather than importing `zeph-llm::Message` to keep
+/// `zeph-common` free of `zeph-*` dependencies.
+#[derive(Debug, Clone)]
+pub struct PolicyMessage {
+    /// Role of the message sender.
+    pub role: PolicyRole,
+    /// Message content.
+    pub content: String,
+}
+
+/// Role for a [`PolicyMessage`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PolicyRole {
+    /// System-level instruction.
+    System,
+    /// User-level prompt.
+    User,
+}
+
+/// Trait for sending chat messages to the policy LLM.
+///
+/// Implemented externally (e.g. in `runner.rs` on a newtype wrapping `Arc<AnyProvider>`).
+/// `zeph-tools` defines the usage; `zeph-common` defines the contract, keeping both
+/// crates decoupled from `zeph-llm`.
+pub trait PolicyLlmClient: Send + Sync {
+    /// Send a sequence of messages and return the assistant's text response.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(String)` if the LLM call fails (network error, timeout, etc.).
+    fn chat<'a>(
+        &'a self,
+        messages: &'a [PolicyMessage],
+    ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + 'a>>;
+}

--- a/crates/zeph-common/src/types.rs
+++ b/crates/zeph-common/src/types.rs
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Strongly-typed identifiers shared across `zeph-*` crates.
+//! Strongly-typed identifiers and shared tool types across `zeph-*` crates.
 //!
-//! This module defines `ToolName` and `SessionId` — newtypes that replace raw `String`
-//! fields in tool execution, LLM provider, and experiment subsystems.
+//! This module defines `ToolName`, `SessionId`, and `ToolDefinition` — types shared
+//! by multiple crates without creating cross-crate dependencies.
 //!
-//! Both types use `#[serde(transparent)]` for zero-cost serialization compatibility:
-//! the JSON wire format is unchanged relative to plain `String` fields.
+//! `ToolName` and `SessionId` use `#[serde(transparent)]` for zero-cost serialization
+//! compatibility: the JSON wire format is unchanged relative to plain `String` fields.
 
 use std::borrow::Borrow;
 use std::fmt;
@@ -350,6 +350,42 @@ impl PartialEq<SessionId> for String {
     fn eq(&self, other: &SessionId) -> bool {
         *self == other.0
     }
+}
+
+// ── ToolDefinition ───────────────────────────────────────────────────────────
+
+/// Minimal tool definition passed to LLM providers.
+///
+/// Decoupled from `zeph-tools::ToolDef` to avoid cross-crate dependencies.
+/// Providers translate this into their native tool/function format before sending to the API.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_common::types::ToolDefinition;
+/// use zeph_common::ToolName;
+///
+/// let tool = ToolDefinition {
+///     name: ToolName::new("get_weather"),
+///     description: "Return current weather for a city.".into(),
+///     parameters: serde_json::json!({
+///         "type": "object",
+///         "properties": {
+///             "city": { "type": "string" }
+///         },
+///         "required": ["city"]
+///     }),
+/// };
+/// assert_eq!(tool.name, "get_weather");
+/// ```
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ToolDefinition {
+    /// Tool name — must match the name used in the response `ToolUseRequest`.
+    pub name: ToolName,
+    /// Human-readable description guiding the model on when to call this tool.
+    pub description: String,
+    /// JSON Schema object describing parameters.
+    pub parameters: serde_json::Value,
 }
 
 #[cfg(test)]

--- a/crates/zeph-core/src/agent/context/summarization.rs
+++ b/crates/zeph-core/src/agent/context/summarization.rs
@@ -1506,7 +1506,7 @@ impl<C: Channel> Agent<C> {
         let mut i = 1; // skip system prompt
         while i < self.msg.messages.len() {
             let msg = &self.msg.messages[i];
-            if !msg.metadata.agent_visible {
+            if !msg.metadata.visibility.is_agent_visible() {
                 i += 1;
                 continue;
             }
@@ -1517,7 +1517,7 @@ impl<C: Channel> Agent<C> {
                     .any(|p| matches!(p, MessagePart::ToolUse { .. }));
             if is_tool_request && i + 1 < self.msg.messages.len() {
                 let next = &self.msg.messages[i + 1];
-                if next.metadata.agent_visible
+                if next.metadata.visibility.is_agent_visible()
                     && next.role == Role::User
                     && next.parts.iter().any(|p| {
                         matches!(
@@ -1547,7 +1547,7 @@ impl<C: Channel> Agent<C> {
         let mut i = 1; // skip system prompt
         while i < self.msg.messages.len() {
             let msg = &self.msg.messages[i];
-            if !msg.metadata.agent_visible {
+            if !msg.metadata.visibility.is_agent_visible() {
                 i += 1;
                 continue;
             }
@@ -1558,7 +1558,7 @@ impl<C: Channel> Agent<C> {
                     .any(|p| matches!(p, MessagePart::ToolUse { .. }));
             if is_tool_request && i + 1 < self.msg.messages.len() {
                 let next = &self.msg.messages[i + 1];
-                if next.metadata.agent_visible
+                if next.metadata.visibility.is_agent_visible()
                     && next.role == Role::User
                     && next.parts.iter().any(|p| {
                         matches!(
@@ -1687,10 +1687,13 @@ impl<C: Channel> Agent<C> {
             }
             // Verify the structural invariant: tool response preceded by matching tool request.
             if self.msg.messages[i].role == Role::User
-                && self.msg.messages[i].metadata.agent_visible
+                && self.msg.messages[i].metadata.visibility.is_agent_visible()
                 && i > 0
                 && self.msg.messages[i - 1].role == Role::Assistant
-                && self.msg.messages[i - 1].metadata.agent_visible
+                && self.msg.messages[i - 1]
+                    .metadata
+                    .visibility
+                    .is_agent_visible()
                 && self.msg.messages[i - 1]
                     .parts
                     .iter()
@@ -1722,8 +1725,10 @@ impl<C: Channel> Agent<C> {
             let req_db_id = self.msg.messages[req_idx].metadata.db_id;
             let resp_db_id = self.msg.messages[resp_idx].metadata.db_id;
 
-            self.msg.messages[req_idx].metadata.agent_visible = false;
-            self.msg.messages[resp_idx].metadata.agent_visible = false;
+            self.msg.messages[req_idx].metadata.visibility =
+                zeph_llm::provider::MessageVisibility::UserOnly;
+            self.msg.messages[resp_idx].metadata.visibility =
+                zeph_llm::provider::MessageVisibility::UserOnly;
             self.msg.messages[resp_idx].metadata.deferred_summary = None;
 
             if let (Some(req_id), Some(resp_id)) = (req_db_id, resp_db_id) {
@@ -2710,7 +2715,9 @@ impl<C: Channel> Agent<C> {
             .messages
             .iter()
             .rev()
-            .find(|m| m.role == zeph_llm::provider::Role::User && m.metadata.agent_visible)
+            .find(|m| {
+                m.role == zeph_llm::provider::Role::User && m.metadata.visibility.is_agent_visible()
+            })
             .map(|m| m.content.as_str())
             .unwrap_or_default();
 
@@ -2736,7 +2743,7 @@ impl<C: Channel> Agent<C> {
             .messages
             .iter()
             .filter(|m| {
-                m.metadata.agent_visible
+                m.metadata.visibility.is_agent_visible()
                     && matches!(
                         m.role,
                         zeph_llm::provider::Role::User | zeph_llm::provider::Role::Assistant

--- a/crates/zeph-core/src/agent/context/tests.rs
+++ b/crates/zeph-core/src/agent/context/tests.rs
@@ -2478,8 +2478,8 @@ fn count_unsummarized_pairs_ignores_hidden_pairs() {
 
     make_tool_pair(&mut agent, "bash");
     // hide the first pair
-    agent.msg.messages[1].metadata.agent_visible = false;
-    agent.msg.messages[2].metadata.agent_visible = false;
+    agent.msg.messages[1].metadata.visibility = zeph_llm::provider::MessageVisibility::UserOnly;
+    agent.msg.messages[2].metadata.visibility = zeph_llm::provider::MessageVisibility::UserOnly;
 
     assert_eq!(agent.count_unsummarized_pairs(), 0);
 }
@@ -2514,8 +2514,8 @@ fn find_oldest_unsummarized_pair_skips_hidden() {
     make_tool_pair(&mut agent, "bash");
     make_tool_pair(&mut agent, "read_file");
     // hide first pair
-    agent.msg.messages[1].metadata.agent_visible = false;
-    agent.msg.messages[2].metadata.agent_visible = false;
+    agent.msg.messages[1].metadata.visibility = zeph_llm::provider::MessageVisibility::UserOnly;
+    agent.msg.messages[2].metadata.visibility = zeph_llm::provider::MessageVisibility::UserOnly;
 
     // second pair: request = 3, response = 4
     assert_eq!(agent.find_oldest_unsummarized_pair(), Some((3, 4)));
@@ -2580,8 +2580,8 @@ async fn maybe_summarize_tool_pair_above_cutoff_stores_deferred_summary() {
     // message count must NOT change — deferred, no immediate mutation
     assert_eq!(agent.msg.messages.len(), msg_count_before);
     // oldest pair (indices 1, 2) must remain visible
-    assert!(agent.msg.messages[1].metadata.agent_visible);
-    assert!(agent.msg.messages[2].metadata.agent_visible);
+    assert!(agent.msg.messages[1].metadata.visibility.is_agent_visible());
+    assert!(agent.msg.messages[2].metadata.visibility.is_agent_visible());
     // deferred_summary must be set on the response message (index 2)
     assert_eq!(
         agent.msg.messages[2].metadata.deferred_summary.as_deref(),
@@ -2642,8 +2642,8 @@ async fn maybe_summarize_tool_pair_llm_error_skips_gracefully() {
     agent.maybe_summarize_tool_pair().await;
     // No messages should be added or hidden
     assert_eq!(agent.msg.messages.len(), msg_count_before);
-    assert!(agent.msg.messages[1].metadata.agent_visible);
-    assert!(agent.msg.messages[2].metadata.agent_visible);
+    assert!(agent.msg.messages[1].metadata.visibility.is_agent_visible());
+    assert!(agent.msg.messages[2].metadata.visibility.is_agent_visible());
 }
 
 #[test]
@@ -2957,11 +2957,11 @@ async fn summarize_then_prune_preserves_intact_content_for_summarizer() {
 
     // The summarized pair is now hidden.
     assert!(
-        !agent.msg.messages[1].metadata.agent_visible,
+        !agent.msg.messages[1].metadata.visibility.is_agent_visible(),
         "oldest pair request should be hidden"
     );
     assert!(
-        !agent.msg.messages[2].metadata.agent_visible,
+        !agent.msg.messages[2].metadata.visibility.is_agent_visible(),
         "oldest pair response should be hidden"
     );
 }
@@ -2995,7 +2995,7 @@ async fn prune_after_summarize_does_not_destroy_visible_pairs() {
         .msg
         .messages
         .iter()
-        .filter(|m| m.metadata.agent_visible)
+        .filter(|m| m.metadata.visibility.is_agent_visible())
     {
         for part in &msg.parts {
             if let MessagePart::ToolOutput {
@@ -3095,7 +3095,7 @@ async fn cutoff_one_edge_case_summarize_then_prune() {
         .msg
         .messages
         .iter()
-        .filter(|m| m.metadata.agent_visible)
+        .filter(|m| m.metadata.visibility.is_agent_visible())
         .flat_map(|m| m.parts.iter())
         .filter(|p| matches!(p, MessagePart::ToolOutput { .. }))
         .collect();
@@ -3262,7 +3262,7 @@ async fn deferred_summary_stored_not_applied() {
     // All messages stay visible
     for msg in &agent.msg.messages {
         assert!(
-            msg.metadata.agent_visible,
+            msg.metadata.visibility.is_agent_visible(),
             "no message should be hidden after deferred storage"
         );
     }
@@ -3361,7 +3361,7 @@ fn apply_deferred_summaries_batch() {
         .msg
         .messages
         .iter()
-        .filter(|m| !m.metadata.agent_visible)
+        .filter(|m| !m.metadata.visibility.is_agent_visible())
         .count();
     assert_eq!(hidden, 6);
 
@@ -3427,15 +3427,15 @@ fn apply_deferred_summaries_reverse_order() {
     assert_eq!(applied, 2);
 
     // req3 and resp3 are hidden
-    assert!(!agent.msg.messages[5].metadata.agent_visible);
-    assert!(!agent.msg.messages[6].metadata.agent_visible);
+    assert!(!agent.msg.messages[5].metadata.visibility.is_agent_visible());
+    assert!(!agent.msg.messages[6].metadata.visibility.is_agent_visible());
 
     // 4 total messages hidden
     let hidden = agent
         .msg
         .messages
         .iter()
-        .filter(|m| !m.metadata.agent_visible)
+        .filter(|m| !m.metadata.visibility.is_agent_visible())
         .count();
     assert_eq!(hidden, 4);
 

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -547,10 +547,11 @@ impl<C: Channel> Agent<C> {
         let tool_started_at = std::time::Instant::now();
         self.channel
             .send_tool_start(ToolStartEvent {
-                tool_name: output.tool_name.as_str(),
-                tool_call_id: &tool_call_id,
+                tool_name: output.tool_name.clone(),
+                tool_call_id: tool_call_id.clone(),
                 params: None,
                 parent_tool_use_id: self.session.parent_tool_use_id.clone(),
+                started_at: std::time::Instant::now(),
             })
             .await?;
         if let Some(ref d) = self.debug_state.debug_dumper {
@@ -578,13 +579,14 @@ impl<C: Channel> Agent<C> {
         let formatted_output = format_tool_output(output.tool_name.as_str(), &body);
         self.channel
             .send_tool_output(ToolOutputEvent {
-                tool_name: output.tool_name.as_str(),
-                body: &self.maybe_redact(&body),
+                tool_name: output.tool_name.clone(),
+                display: self.maybe_redact(&body).to_string(),
                 diff: None,
                 filter_stats: filter_stats_inline,
                 kept_lines: None,
                 locations: output.locations,
-                tool_call_id: &tool_call_id,
+                tool_call_id: tool_call_id.clone(),
+                terminal_id: None,
                 is_error: false,
                 parent_tool_use_id: self.session.parent_tool_use_id.clone(),
                 raw_response: None,
@@ -636,10 +638,11 @@ impl<C: Channel> Agent<C> {
                 let confirmed_started_at = std::time::Instant::now();
                 self.channel
                     .send_tool_start(ToolStartEvent {
-                        tool_name: out.tool_name.as_str(),
-                        tool_call_id: &confirmed_tool_call_id,
+                        tool_name: out.tool_name.clone(),
+                        tool_call_id: confirmed_tool_call_id.clone(),
                         params: None,
                         parent_tool_use_id: self.session.parent_tool_use_id.clone(),
+                        started_at: std::time::Instant::now(),
                     })
                     .await?;
                 if let Some(ref d) = self.debug_state.debug_dumper {
@@ -654,13 +657,14 @@ impl<C: Channel> Agent<C> {
                 let formatted = format_tool_output(out.tool_name.as_str(), &processed);
                 self.channel
                     .send_tool_output(ToolOutputEvent {
-                        tool_name: out.tool_name.as_str(),
-                        body: &self.maybe_redact(&processed),
+                        tool_name: out.tool_name.clone(),
+                        display: self.maybe_redact(&processed).to_string(),
                         diff: None,
                         filter_stats: None,
                         kept_lines: None,
                         locations: out.locations,
-                        tool_call_id: &confirmed_tool_call_id,
+                        tool_call_id: confirmed_tool_call_id.clone(),
+                        terminal_id: None,
                         is_error: false,
                         parent_tool_use_id: self.session.parent_tool_use_id.clone(),
                         raw_response: None,
@@ -1570,10 +1574,11 @@ impl<C: Channel> Agent<C> {
                 let tool_call_id = &tool_call_ids[idx];
                 self.channel
                     .send_tool_start(ToolStartEvent {
-                        tool_name: tc.name.as_str(),
-                        tool_call_id,
+                        tool_name: tc.name.clone(),
+                        tool_call_id: tool_call_id.clone(),
                         params: Some(tc.input.clone()),
                         parent_tool_use_id: self.session.parent_tool_use_id.clone(),
+                        started_at: std::time::Instant::now(),
                     })
                     .await?;
             }
@@ -2468,14 +2473,15 @@ impl<C: Channel> Agent<C> {
             let body_display = self.maybe_redact(&body);
             self.channel
                 .send_tool_output(ToolOutputEvent {
-                    tool_name: tc.name.as_str(),
-                    body: &body_display,
+                    tool_name: tc.name.clone(),
+                    display: body_display.into_owned(),
                     diff,
                     filter_stats: inline_stats,
                     kept_lines,
                     locations,
-                    tool_call_id,
+                    tool_call_id: tool_call_id.clone(),
                     is_error,
+                    terminal_id: None,
                     parent_tool_use_id: self.session.parent_tool_use_id.clone(),
                     raw_response: None,
                     started_at: Some(*started_at),

--- a/crates/zeph-core/src/channel.rs
+++ b/crates/zeph-core/src/channel.rs
@@ -73,31 +73,6 @@ impl ChannelError {
     }
 }
 
-/// All fields that describe a tool-start event sent to a channel.
-#[derive(Debug)]
-pub struct ToolStartEvent<'a> {
-    pub tool_name: &'a str,
-    pub tool_call_id: &'a str,
-    pub params: Option<serde_json::Value>,
-    pub parent_tool_use_id: Option<String>,
-}
-
-/// All fields that describe a completed tool-output event sent to a channel.
-#[derive(Debug)]
-pub struct ToolOutputEvent<'a> {
-    pub tool_name: &'a str,
-    pub body: &'a str,
-    pub diff: Option<crate::DiffData>,
-    pub filter_stats: Option<String>,
-    pub kept_lines: Option<Vec<usize>>,
-    pub locations: Option<Vec<String>>,
-    pub tool_call_id: &'a str,
-    pub is_error: bool,
-    pub parent_tool_use_id: Option<String>,
-    pub raw_response: Option<serde_json::Value>,
-    pub started_at: Option<std::time::Instant>,
-}
-
 /// Kind of binary attachment on an incoming message.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AttachmentKind {
@@ -248,26 +223,25 @@ pub trait Channel: Send {
     /// Returns an error if the underlying I/O fails.
     fn send_tool_start(
         &mut self,
-        _event: ToolStartEvent<'_>,
+        _event: ToolStartEvent,
     ) -> impl Future<Output = Result<(), ChannelError>> + Send {
         async { Ok(()) }
     }
 
     /// Send a complete tool output with optional diff and filter stats atomically.
     ///
-    /// `body` is the raw tool output content (no header). The default implementation
-    /// formats it with `[tool output: <name>]` prefix for human-readable channels.
-    /// Structured channels (e.g. `LoopbackChannel`) override this to emit a typed event
-    /// so consumers can access `tool_name` and `body` as separate fields.
+    /// `display` is the formatted tool output. The default implementation forwards to
+    /// [`Channel::send`]. Structured channels (e.g. `LoopbackChannel`) override this to
+    /// emit a typed event so consumers can access `tool_name` and `display` as separate fields.
     ///
     /// # Errors
     ///
     /// Returns an error if the underlying I/O fails.
     fn send_tool_output(
         &mut self,
-        event: ToolOutputEvent<'_>,
+        event: ToolOutputEvent,
     ) -> impl Future<Output = Result<(), ChannelError>> + Send {
-        let formatted = crate::agent::format_tool_output(event.tool_name, event.body);
+        let formatted = crate::agent::format_tool_output(event.tool_name.as_str(), &event.display);
         async move { self.send(&formatted).await }
     }
 
@@ -328,10 +302,15 @@ pub enum StopHint {
     MaxTurnRequests,
 }
 
-/// Data carried by a [`LoopbackEvent::ToolStart`] variant.
+/// Event carrying data for a tool call start, emitted before execution begins.
+///
+/// Passed by value to [`Channel::send_tool_start`] and carried by
+/// [`LoopbackEvent::ToolStart`]. All fields are owned — no lifetime parameters.
 #[derive(Debug, Clone)]
-pub struct ToolStartData {
+pub struct ToolStartEvent {
+    /// Name of the tool being invoked.
     pub tool_name: zeph_common::ToolName,
+    /// Opaque tool call ID assigned by the LLM.
     pub tool_call_id: String,
     /// Raw input parameters passed to the tool (e.g. `{"command": "..."}` for bash).
     pub params: Option<serde_json::Value>,
@@ -341,16 +320,27 @@ pub struct ToolStartData {
     pub started_at: std::time::Instant,
 }
 
-/// Data carried by a [`LoopbackEvent::ToolOutput`] variant.
+/// Event carrying data for a completed tool output, emitted after execution.
+///
+/// Passed by value to [`Channel::send_tool_output`] and carried by
+/// [`LoopbackEvent::ToolOutput`]. All fields are owned — no lifetime parameters.
 #[derive(Debug, Clone)]
-pub struct ToolOutputData {
+pub struct ToolOutputEvent {
+    /// Name of the tool that produced this output.
     pub tool_name: zeph_common::ToolName,
+    /// Human-readable output text.
     pub display: String,
+    /// Optional diff for file-editing tools.
     pub diff: Option<crate::DiffData>,
+    /// Optional filter statistics from output filtering.
     pub filter_stats: Option<String>,
+    /// Kept line indices after filtering (for display).
     pub kept_lines: Option<Vec<usize>>,
+    /// Source locations for code search results.
     pub locations: Option<Vec<String>>,
+    /// Opaque tool call ID matching the corresponding `ToolStartEvent`.
     pub tool_call_id: String,
+    /// Whether this output represents an error.
     pub is_error: bool,
     /// Terminal ID for shell tool calls routed through the IDE terminal.
     pub terminal_id: Option<String>,
@@ -358,40 +348,21 @@ pub struct ToolOutputData {
     pub parent_tool_use_id: Option<String>,
     /// Structured tool response payload for ACP intermediate `tool_call_update` notifications.
     pub raw_response: Option<serde_json::Value>,
-    /// Wall-clock instant when the corresponding `ToolStart` was emitted; used for elapsed time.
+    /// Wall-clock instant when the corresponding `ToolStartEvent` was emitted.
     pub started_at: Option<std::time::Instant>,
 }
 
-impl From<ToolStartEvent<'_>> for ToolStartData {
-    fn from(e: ToolStartEvent<'_>) -> Self {
-        Self {
-            tool_name: e.tool_name.into(),
-            tool_call_id: e.tool_call_id.to_owned(),
-            params: e.params,
-            parent_tool_use_id: e.parent_tool_use_id,
-            started_at: std::time::Instant::now(),
-        }
-    }
-}
+/// Backward-compatible alias for [`ToolStartEvent`].
+///
+/// Deprecated name kept for use in the ACP layer. Prefer `ToolStartEvent` in new code.
+#[deprecated(since = "0.18.6", note = "use ToolStartEvent directly")]
+pub type ToolStartData = ToolStartEvent;
 
-impl From<ToolOutputEvent<'_>> for ToolOutputData {
-    fn from(e: ToolOutputEvent<'_>) -> Self {
-        Self {
-            tool_name: e.tool_name.into(),
-            display: e.body.to_owned(),
-            diff: e.diff,
-            filter_stats: e.filter_stats,
-            kept_lines: e.kept_lines,
-            locations: e.locations,
-            tool_call_id: e.tool_call_id.to_owned(),
-            is_error: e.is_error,
-            terminal_id: None,
-            parent_tool_use_id: e.parent_tool_use_id,
-            raw_response: e.raw_response,
-            started_at: e.started_at,
-        }
-    }
-}
+/// Backward-compatible alias for [`ToolOutputEvent`].
+///
+/// Deprecated name kept for use in the ACP layer. Prefer `ToolOutputEvent` in new code.
+#[deprecated(since = "0.18.6", note = "use ToolOutputEvent directly")]
+pub type ToolOutputData = ToolOutputEvent;
 
 /// Events emitted by the agent side toward the A2A caller.
 #[derive(Debug, Clone)]
@@ -401,8 +372,8 @@ pub enum LoopbackEvent {
     FullMessage(String),
     Status(String),
     /// Emitted immediately before tool execution begins.
-    ToolStart(Box<ToolStartData>),
-    ToolOutput(Box<ToolOutputData>),
+    ToolStart(Box<ToolStartEvent>),
+    ToolOutput(Box<ToolOutputEvent>),
     /// Token usage from the last LLM turn.
     Usage {
         input_tokens: u64,
@@ -508,16 +479,16 @@ impl Channel for LoopbackChannel {
             .map_err(|_| ChannelError::ChannelClosed)
     }
 
-    async fn send_tool_start(&mut self, event: ToolStartEvent<'_>) -> Result<(), ChannelError> {
+    async fn send_tool_start(&mut self, event: ToolStartEvent) -> Result<(), ChannelError> {
         self.output_tx
-            .send(LoopbackEvent::ToolStart(Box::new(event.into())))
+            .send(LoopbackEvent::ToolStart(Box::new(event)))
             .await
             .map_err(|_| ChannelError::ChannelClosed)
     }
 
-    async fn send_tool_output(&mut self, event: ToolOutputEvent<'_>) -> Result<(), ChannelError> {
+    async fn send_tool_output(&mut self, event: ToolOutputEvent) -> Result<(), ChannelError> {
         self.output_tx
-            .send(LoopbackEvent::ToolOutput(Box::new(event.into())))
+            .send(LoopbackEvent::ToolOutput(Box::new(event)))
             .await
             .map_err(|_| ChannelError::ChannelClosed)
     }
@@ -763,13 +734,14 @@ mod tests {
         let (mut channel, mut handle) = LoopbackChannel::pair(8);
         channel
             .send_tool_output(ToolOutputEvent {
-                tool_name: "bash",
-                body: "exit 0",
+                tool_name: "bash".into(),
+                display: "exit 0".into(),
                 diff: None,
                 filter_stats: None,
                 kept_lines: None,
                 locations: None,
-                tool_call_id: "",
+                tool_call_id: String::new(),
+                terminal_id: None,
                 is_error: false,
                 parent_tool_use_id: None,
                 raw_response: None,
@@ -907,18 +879,19 @@ mod tests {
         let (mut channel, mut handle) = LoopbackChannel::pair(8);
         channel
             .send_tool_start(ToolStartEvent {
-                tool_name: "shell",
-                tool_call_id: "tc-001",
+                tool_name: "shell".into(),
+                tool_call_id: "tc-001".into(),
                 params: Some(serde_json::json!({"command": "ls"})),
                 parent_tool_use_id: None,
+                started_at: std::time::Instant::now(),
             })
             .await
             .unwrap();
         let event = handle.output_rx.recv().await.unwrap();
         match event {
             LoopbackEvent::ToolStart(data) => {
-                assert_eq!(data.tool_name, "shell");
-                assert_eq!(data.tool_call_id, "tc-001");
+                assert_eq!(data.tool_name.as_str(), "shell");
+                assert_eq!(data.tool_call_id.as_str(), "tc-001");
                 assert!(data.params.is_some());
                 assert!(data.parent_tool_use_id.is_none());
             }
@@ -931,10 +904,11 @@ mod tests {
         let (mut channel, mut handle) = LoopbackChannel::pair(8);
         channel
             .send_tool_start(ToolStartEvent {
-                tool_name: "web",
-                tool_call_id: "tc-002",
+                tool_name: "web".into(),
+                tool_call_id: "tc-002".into(),
                 params: None,
                 parent_tool_use_id: Some("parent-123".into()),
+                started_at: std::time::Instant::now(),
             })
             .await
             .unwrap();
@@ -951,10 +925,11 @@ mod tests {
         drop(handle);
         let result = channel
             .send_tool_start(ToolStartEvent {
-                tool_name: "shell",
-                tool_call_id: "tc-003",
+                tool_name: "shell".into(),
+                tool_call_id: "tc-003".into(),
                 params: None,
                 parent_tool_use_id: None,
+                started_at: std::time::Instant::now(),
             })
             .await;
         assert!(matches!(result, Err(ChannelError::ChannelClosed)));
@@ -965,13 +940,14 @@ mod tests {
         let mut ch = StubChannel;
         // Default impl calls self.send() which is a no-op in StubChannel — just verify it doesn't panic.
         ch.send_tool_output(ToolOutputEvent {
-            tool_name: "bash",
-            body: "hello",
+            tool_name: "bash".into(),
+            display: "hello".into(),
             diff: None,
             filter_stats: None,
             kept_lines: None,
             locations: None,
-            tool_call_id: "id",
+            tool_call_id: "id".into(),
+            terminal_id: None,
             is_error: false,
             parent_tool_use_id: None,
             raw_response: None,

--- a/crates/zeph-core/src/channel.rs
+++ b/crates/zeph-core/src/channel.rs
@@ -354,14 +354,12 @@ pub struct ToolOutputEvent {
 
 /// Backward-compatible alias for [`ToolStartEvent`].
 ///
-/// Deprecated name kept for use in the ACP layer. Prefer `ToolStartEvent` in new code.
-#[deprecated(since = "0.18.6", note = "use ToolStartEvent directly")]
+/// Kept for use in the ACP layer. Prefer [`ToolStartEvent`] in new code.
 pub type ToolStartData = ToolStartEvent;
 
 /// Backward-compatible alias for [`ToolOutputEvent`].
 ///
-/// Deprecated name kept for use in the ACP layer. Prefer `ToolOutputEvent` in new code.
-#[deprecated(since = "0.18.6", note = "use ToolOutputEvent directly")]
+/// Kept for use in the ACP layer. Prefer [`ToolOutputEvent`] in new code.
 pub type ToolOutputData = ToolOutputEvent;
 
 /// Events emitted by the agent side toward the A2A caller.

--- a/crates/zeph-core/src/debug_dump/mod.rs
+++ b/crates/zeph-core/src/debug_dump/mod.rs
@@ -454,14 +454,14 @@ fn sanitize_dump_name(name: &str) -> String {
 fn messages_to_api_value(messages: &[Message]) -> serde_json::Value {
     let system: String = messages
         .iter()
-        .filter(|m| m.metadata.agent_visible && m.role == Role::System)
+        .filter(|m| m.metadata.visibility.is_agent_visible() && m.role == Role::System)
         .map(zeph_llm::provider::Message::to_llm_content)
         .collect::<Vec<_>>()
         .join("\n\n");
 
     let chat: Vec<serde_json::Value> = messages
         .iter()
-        .filter(|m| m.metadata.agent_visible && m.role != Role::System)
+        .filter(|m| m.metadata.visibility.is_agent_visible() && m.role != Role::System)
         .filter_map(|m| {
             let role = match m.role {
                 Role::User => "user",

--- a/crates/zeph-core/src/lib.rs
+++ b/crates/zeph-core/src/lib.rs
@@ -102,6 +102,7 @@ pub use agent::error::AgentError;
 pub use agent::session_config::{AgentSessionConfig, CONTEXT_BUDGET_RESERVE_RATIO};
 pub use agent::state::AdversarialPolicyInfo;
 pub use agent::state::ProviderConfigSnapshot;
+#[allow(deprecated)]
 pub use channel::{
     Attachment, AttachmentKind, Channel, ChannelError, ChannelMessage, LoopbackChannel,
     LoopbackEvent, LoopbackHandle, StopHint, ToolOutputData, ToolOutputEvent, ToolStartData,

--- a/crates/zeph-core/src/lib.rs
+++ b/crates/zeph-core/src/lib.rs
@@ -102,7 +102,6 @@ pub use agent::error::AgentError;
 pub use agent::session_config::{AgentSessionConfig, CONTEXT_BUDGET_RESERVE_RATIO};
 pub use agent::state::AdversarialPolicyInfo;
 pub use agent::state::ProviderConfigSnapshot;
-#[allow(deprecated)]
 pub use channel::{
     Attachment, AttachmentKind, Channel, ChannelError, ChannelMessage, LoopbackChannel,
     LoopbackEvent, LoopbackHandle, StopHint, ToolOutputData, ToolOutputEvent, ToolStartData,

--- a/crates/zeph-db/migrations/postgres/073_message_visibility_enum.sql
+++ b/crates/zeph-db/migrations/postgres/073_message_visibility_enum.sql
@@ -1,0 +1,18 @@
+-- Migrate messages.agent_visible + messages.user_visible to messages.visibility TEXT.
+-- Maps:
+--   (true, true)   -> 'both'
+--   (true, false)  -> 'agent_only'
+--   (false, true)  -> 'user_only'
+--   (false, false) -> 'both' (invalid state; safest default)
+
+ALTER TABLE messages ADD COLUMN visibility TEXT NOT NULL DEFAULT 'both';
+
+UPDATE messages SET visibility =
+    CASE
+        WHEN agent_visible = TRUE AND user_visible = FALSE THEN 'agent_only'
+        WHEN agent_visible = FALSE AND user_visible = TRUE THEN 'user_only'
+        ELSE 'both'
+    END;
+
+ALTER TABLE messages DROP COLUMN agent_visible;
+ALTER TABLE messages DROP COLUMN user_visible;

--- a/crates/zeph-db/migrations/sqlite/073_message_visibility_enum.sql
+++ b/crates/zeph-db/migrations/sqlite/073_message_visibility_enum.sql
@@ -1,0 +1,18 @@
+-- Migrate messages.agent_visible + messages.user_visible to messages.visibility TEXT.
+-- Maps:
+--   (1, 1) -> 'both'       (visible to agent and user)
+--   (1, 0) -> 'agent_only' (visible to agent only)
+--   (0, 1) -> 'user_only'  (visible to user only)
+--   (0, 0) -> 'both'       (invalid state; safest default)
+
+ALTER TABLE messages ADD COLUMN visibility TEXT NOT NULL DEFAULT 'both';
+
+UPDATE messages SET visibility =
+    CASE
+        WHEN agent_visible = 1 AND user_visible = 0 THEN 'agent_only'
+        WHEN agent_visible = 0 AND user_visible = 1 THEN 'user_only'
+        ELSE 'both'
+    END;
+
+ALTER TABLE messages DROP COLUMN agent_visible;
+ALTER TABLE messages DROP COLUMN user_visible;

--- a/crates/zeph-llm/src/claude/request.rs
+++ b/crates/zeph-llm/src/claude/request.rs
@@ -18,7 +18,7 @@ pub(super) fn split_messages(messages: &[Message]) -> (Option<String>, Vec<ApiMe
     let mut chat = Vec::new();
 
     for msg in messages {
-        if !msg.metadata.agent_visible {
+        if !msg.metadata.visibility.is_agent_visible() {
             continue;
         }
         match msg.role {
@@ -55,7 +55,7 @@ pub(super) fn split_messages_structured(
 
     for msg in messages
         .iter()
-        .filter(|m| m.metadata.agent_visible && m.role == Role::System)
+        .filter(|m| m.metadata.visibility.is_agent_visible() && m.role == Role::System)
     {
         system_parts.push(msg.to_llm_content());
     }
@@ -64,7 +64,7 @@ pub(super) fn split_messages_structured(
     // user or assistant message (RC4: system messages in `visible` would break +1 index peek).
     let visible: Vec<&Message> = messages
         .iter()
-        .filter(|m| m.metadata.agent_visible && m.role != Role::System)
+        .filter(|m| m.metadata.visibility.is_agent_visible() && m.role != Role::System)
         .collect();
 
     // Track which tool_use IDs were actually emitted as native AnthropicContentBlock::ToolUse

--- a/crates/zeph-llm/src/provider.rs
+++ b/crates/zeph-llm/src/provider.rs
@@ -14,6 +14,8 @@ use serde::{Deserialize, Serialize};
 
 use zeph_common::ToolName;
 
+pub use zeph_common::ToolDefinition;
+
 use crate::embed::owned_strs;
 use crate::error::LlmError;
 
@@ -86,39 +88,6 @@ pub enum StreamChunk {
 /// Obtain via [`LlmProvider::chat_stream`]. Drive the stream with
 /// `futures::StreamExt::next` or `tokio_stream::StreamExt::next`.
 pub type ChatStream = Pin<Box<dyn Stream<Item = Result<StreamChunk, LlmError>> + Send>>;
-
-/// Minimal tool definition for LLM providers.
-///
-/// Decoupled from `zeph-tools::ToolDef` to avoid cross-crate dependency.
-/// Providers translate this into their native tool/function format before sending to the API.
-///
-/// # Examples
-///
-/// ```
-/// use zeph_llm::provider::ToolDefinition;
-///
-/// let tool = ToolDefinition {
-///     name: "get_weather".into(),
-///     description: "Return current weather for a city.".into(),
-///     parameters: serde_json::json!({
-///         "type": "object",
-///         "properties": {
-///             "city": { "type": "string" }
-///         },
-///         "required": ["city"]
-///     }),
-/// };
-/// assert_eq!(tool.name, "get_weather");
-/// ```
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ToolDefinition {
-    /// Tool name — must match the name used in the response `ToolUseRequest`.
-    pub name: ToolName,
-    /// Human-readable description guiding the model on when to call this tool.
-    pub description: String,
-    /// JSON Schema object describing parameters.
-    pub parameters: serde_json::Value,
-}
 
 /// Structured tool invocation request from the model.
 ///
@@ -358,20 +327,85 @@ mod serde_bytes_base64 {
     }
 }
 
-/// Per-message visibility flags controlling agent context and user display.
+/// Visibility of a message to agent and user.
 ///
-/// The `agent_visible` and `user_visible` flags are independent: a message can be
-/// visible to the agent (included in the LLM context) but hidden from the user (UI),
-/// or shown to the user but stripped from the LLM context.
+/// Replaces the former `(agent_visible: bool, user_visible: bool)` pair, which
+/// allowed the semantically invalid `(false, false)` combination. Every variant
+/// guarantees at least one consumer can see the message.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_llm::provider::MessageVisibility;
+///
+/// let v = MessageVisibility::AgentOnly;
+/// assert!(v.is_agent_visible());
+/// assert!(!v.is_user_visible());
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageVisibility {
+    /// Visible to both the agent (LLM context) and the user (conversation log).
+    Both,
+    /// Visible to the agent only (e.g. compaction summaries, internal context).
+    AgentOnly,
+    /// Visible to the user only (e.g. compacted originals shown in history).
+    UserOnly,
+}
+
+impl MessageVisibility {
+    /// Returns `true` if this message should be included in the LLM request context.
+    #[must_use]
+    pub fn is_agent_visible(self) -> bool {
+        matches!(self, MessageVisibility::Both | MessageVisibility::AgentOnly)
+    }
+
+    /// Returns `true` if this message should appear in the user-facing conversation log.
+    #[must_use]
+    pub fn is_user_visible(self) -> bool {
+        matches!(self, MessageVisibility::Both | MessageVisibility::UserOnly)
+    }
+}
+
+impl Default for MessageVisibility {
+    /// Defaults to [`Both`](MessageVisibility::Both) — visible to agent and user.
+    fn default() -> Self {
+        MessageVisibility::Both
+    }
+}
+
+impl MessageVisibility {
+    /// Serialize to the SQLite/PostgreSQL text value stored in the `visibility` column.
+    #[must_use]
+    pub fn as_db_str(self) -> &'static str {
+        match self {
+            MessageVisibility::Both => "both",
+            MessageVisibility::AgentOnly => "agent_only",
+            MessageVisibility::UserOnly => "user_only",
+        }
+    }
+
+    /// Deserialize from the SQLite/PostgreSQL text value stored in the `visibility` column.
+    ///
+    /// Unknown values (e.g. from a future migration) default to `Both` for safety.
+    #[must_use]
+    pub fn from_db_str(s: &str) -> Self {
+        match s {
+            "agent_only" => MessageVisibility::AgentOnly,
+            "user_only" => MessageVisibility::UserOnly,
+            _ => MessageVisibility::Both,
+        }
+    }
+}
+
+/// Per-message visibility and metadata controlling agent context and user display.
 ///
 /// Constructors [`agent_only`](Self::agent_only), [`user_only`](Self::user_only),
-/// and [`focus_pinned`](Self::focus_pinned) cover the most common flag combinations.
+/// and [`focus_pinned`](Self::focus_pinned) cover the most common combinations.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MessageMetadata {
-    /// Include this message in the LLM request context.
-    pub agent_visible: bool,
-    /// Show this message in the user-facing conversation log.
-    pub user_visible: bool,
+    /// Who can see this message.
+    pub visibility: MessageVisibility,
     /// Unix timestamp (seconds) when this message was compacted, if applicable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub compacted_at: Option<i64>,
@@ -396,8 +430,7 @@ pub struct MessageMetadata {
 impl Default for MessageMetadata {
     fn default() -> Self {
         Self {
-            agent_visible: true,
-            user_visible: true,
+            visibility: MessageVisibility::Both,
             compacted_at: None,
             deferred_summary: None,
             focus_pinned: false,
@@ -412,8 +445,7 @@ impl MessageMetadata {
     #[must_use]
     pub fn agent_only() -> Self {
         Self {
-            agent_visible: true,
-            user_visible: false,
+            visibility: MessageVisibility::AgentOnly,
             compacted_at: None,
             deferred_summary: None,
             focus_pinned: false,
@@ -426,8 +458,7 @@ impl MessageMetadata {
     #[must_use]
     pub fn user_only() -> Self {
         Self {
-            agent_visible: false,
-            user_visible: true,
+            visibility: MessageVisibility::UserOnly,
             compacted_at: None,
             deferred_summary: None,
             focus_pinned: false,
@@ -440,8 +471,7 @@ impl MessageMetadata {
     #[must_use]
     pub fn focus_pinned() -> Self {
         Self {
-            agent_visible: true,
-            user_visible: false,
+            visibility: MessageVisibility::AgentOnly,
             compacted_at: None,
             deferred_summary: None,
             focus_pinned: true,
@@ -1565,31 +1595,34 @@ mod tests {
     #[test]
     fn message_metadata_default_both_visible() {
         let m = MessageMetadata::default();
-        assert!(m.agent_visible);
-        assert!(m.user_visible);
+        assert!(m.visibility.is_agent_visible());
+        assert!(m.visibility.is_user_visible());
+        assert_eq!(m.visibility, MessageVisibility::Both);
         assert!(m.compacted_at.is_none());
     }
 
     #[test]
     fn message_metadata_agent_only() {
         let m = MessageMetadata::agent_only();
-        assert!(m.agent_visible);
-        assert!(!m.user_visible);
+        assert!(m.visibility.is_agent_visible());
+        assert!(!m.visibility.is_user_visible());
+        assert_eq!(m.visibility, MessageVisibility::AgentOnly);
     }
 
     #[test]
     fn message_metadata_user_only() {
         let m = MessageMetadata::user_only();
-        assert!(!m.agent_visible);
-        assert!(m.user_visible);
+        assert!(!m.visibility.is_agent_visible());
+        assert!(m.visibility.is_user_visible());
+        assert_eq!(m.visibility, MessageVisibility::UserOnly);
     }
 
     #[test]
     fn message_metadata_serde_default() {
         let json = r#"{"role":"user","content":"hello"}"#;
         let msg: Message = serde_json::from_str(json).unwrap();
-        assert!(msg.metadata.agent_visible);
-        assert!(msg.metadata.user_visible);
+        assert!(msg.metadata.visibility.is_agent_visible());
+        assert!(msg.metadata.visibility.is_user_visible());
     }
 
     #[test]
@@ -1602,8 +1635,9 @@ mod tests {
         };
         let json = serde_json::to_string(&msg).unwrap();
         let decoded: Message = serde_json::from_str(&json).unwrap();
-        assert!(decoded.metadata.agent_visible);
-        assert!(!decoded.metadata.user_visible);
+        assert!(decoded.metadata.visibility.is_agent_visible());
+        assert!(!decoded.metadata.visibility.is_user_visible());
+        assert_eq!(decoded.metadata.visibility, MessageVisibility::AgentOnly);
     }
 
     #[test]
@@ -1708,5 +1742,41 @@ mod tests {
         for vec in &result {
             assert_eq!(vec, &[0.1_f32, 0.2, 0.3]);
         }
+    }
+
+    #[test]
+    fn message_visibility_db_roundtrip_both() {
+        assert_eq!(MessageVisibility::Both.as_db_str(), "both");
+        assert_eq!(
+            MessageVisibility::from_db_str("both"),
+            MessageVisibility::Both
+        );
+    }
+
+    #[test]
+    fn message_visibility_db_roundtrip_agent_only() {
+        assert_eq!(MessageVisibility::AgentOnly.as_db_str(), "agent_only");
+        assert_eq!(
+            MessageVisibility::from_db_str("agent_only"),
+            MessageVisibility::AgentOnly
+        );
+    }
+
+    #[test]
+    fn message_visibility_db_roundtrip_user_only() {
+        assert_eq!(MessageVisibility::UserOnly.as_db_str(), "user_only");
+        assert_eq!(
+            MessageVisibility::from_db_str("user_only"),
+            MessageVisibility::UserOnly
+        );
+    }
+
+    #[test]
+    fn message_visibility_from_db_str_unknown_defaults_to_both() {
+        assert_eq!(
+            MessageVisibility::from_db_str("unknown_future_value"),
+            MessageVisibility::Both
+        );
+        assert_eq!(MessageVisibility::from_db_str(""), MessageVisibility::Both);
     }
 }

--- a/crates/zeph-memory/src/facade.rs
+++ b/crates/zeph-memory/src/facade.rs
@@ -1,0 +1,485 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Thin trait abstraction over [`crate::semantic::SemanticMemory`].
+//!
+//! `MemoryFacade` is a narrow interface covering the four operations the agent loop
+//! depends on: `remember`, `recall`, `summarize`, and `compact`. It exists for two
+//! reasons:
+//!
+//! 1. **Unit testing** — `InMemoryFacade` implements the trait using in-process
+//!    storage so tests that exercise memory-dependent agent logic do not need `SQLite`
+//!    or `Qdrant`.
+//!
+//! 2. **Future migration path** — the agent can eventually hold
+//!    `Arc<dyn MemoryFacade>` instead of `Arc<SemanticMemory>`. Phase 2 will
+//!    require making the trait object-safe (e.g. via `#[trait_variant::make]`
+//!    or boxed-future signatures). This PR implements Phase 1 only.
+//!
+//! # Design constraints
+//!
+//! `MemoryEntry.parts` uses `Vec<serde_json::Value>` (opaque JSON) rather than
+//! `Vec<zeph_llm::MessagePart>` to keep `zeph-memory` free of `zeph-llm` dependencies.
+
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+
+use crate::error::MemoryError;
+use crate::types::{ConversationId, MessageId};
+
+// ── Supporting types ─────────────────────────────────────────────────────────
+
+/// An entry to persist in memory.
+///
+/// The `parts` field is opaque `serde_json::Value` — callers are responsible for
+/// serializing their content model. This avoids a `zeph-memory` → `zeph-llm`
+/// dependency at the trait boundary.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_memory::facade::MemoryEntry;
+/// use zeph_memory::ConversationId;
+///
+/// let entry = MemoryEntry {
+///     conversation_id: ConversationId(1),
+///     role: "user".into(),
+///     content: "Hello".into(),
+///     parts: vec![],
+///     metadata: None,
+/// };
+/// assert_eq!(entry.role, "user");
+/// ```
+#[derive(Debug, Clone)]
+pub struct MemoryEntry {
+    /// Conversation this entry belongs to.
+    pub conversation_id: ConversationId,
+    /// Role string (`"user"`, `"assistant"`, `"system"`).
+    pub role: String,
+    /// Flat text content of the message.
+    pub content: String,
+    /// Structured content parts as opaque JSON values.
+    pub parts: Vec<serde_json::Value>,
+    /// Optional per-entry metadata as opaque JSON.
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// A matching entry returned by a recall query.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_memory::facade::{MemoryMatch, MemorySource};
+///
+/// let m = MemoryMatch {
+///     content: "Rust is a systems language.".into(),
+///     score: 0.92,
+///     source: MemorySource::Semantic,
+/// };
+/// assert!(m.score > 0.0);
+/// ```
+#[derive(Debug, Clone)]
+pub struct MemoryMatch {
+    /// Matching message content.
+    pub content: String,
+    /// Relevance score in `[0.0, 1.0]`.
+    pub score: f32,
+    /// Backend that produced this match.
+    pub source: MemorySource,
+}
+
+/// Which memory backend produced a [`MemoryMatch`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemorySource {
+    /// Qdrant vector search.
+    Semantic,
+    /// Timestamp-filtered `SQLite` FTS5.
+    Episodic,
+    /// Graph traversal from extracted entities.
+    Graph,
+    /// `SQLite` FTS5 keyword search.
+    Keyword,
+}
+
+/// Input context for a compaction run.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_memory::facade::CompactionContext;
+/// use zeph_memory::ConversationId;
+///
+/// let ctx = CompactionContext { conversation_id: ConversationId(1), token_budget: 4096 };
+/// assert_eq!(ctx.token_budget, 4096);
+/// ```
+#[derive(Debug, Clone)]
+pub struct CompactionContext {
+    /// Conversation to compact.
+    pub conversation_id: ConversationId,
+    /// Target token budget; the compactor aims to bring context below this limit.
+    pub token_budget: usize,
+}
+
+/// Result of a compaction run.
+#[derive(Debug, Clone)]
+pub struct CompactionResult {
+    /// Summary text replacing the compacted messages.
+    pub summary: String,
+    /// Number of messages that were replaced by the summary.
+    pub messages_compacted: usize,
+}
+
+// ── MemoryFacade trait ────────────────────────────────────────────────────────
+
+/// Narrow read/write interface over a memory backend.
+///
+/// Implement this trait to provide an alternative backend for unit testing
+/// (see [`InMemoryFacade`]) or future agent refactoring.
+///
+/// # Contract
+///
+/// - `remember` stores a message and returns its stable ID.
+/// - `recall` performs a best-effort similarity search; empty results are valid.
+/// - `summarize` returns a textual summary of the conversation so far.
+/// - `compact` reduces context size to within `ctx.token_budget`.
+///
+/// Implementations must be `Send + Sync` to support `Arc<dyn MemoryFacade>` usage.
+// The `Send` bound on returned futures is guaranteed by the `Send + Sync` supertrait
+// requirement on all implementors. `async_fn_in_trait` fires because auto-trait bounds
+// on the implicit future type cannot be declared without #[trait_variant::make], which
+// is deferred to Phase 2 when the trait becomes object-safe.
+#[allow(async_fn_in_trait)]
+pub trait MemoryFacade: Send + Sync {
+    /// Store a memory entry and return its ID.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError`] if the backend fails to persist the entry.
+    async fn remember(&self, entry: MemoryEntry) -> Result<MessageId, MemoryError>;
+
+    /// Retrieve the most relevant entries for `query`, up to `limit` results.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError`] if the recall query fails.
+    async fn recall(&self, query: &str, limit: usize) -> Result<Vec<MemoryMatch>, MemoryError>;
+
+    /// Produce a textual summary of `conv_id`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError`] if summarization fails.
+    async fn summarize(&self, conv_id: ConversationId) -> Result<String, MemoryError>;
+
+    /// Compact a conversation to fit within the token budget.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError`] if compaction fails.
+    async fn compact(&self, ctx: &CompactionContext) -> Result<CompactionResult, MemoryError>;
+}
+
+// ── InMemoryFacade ────────────────────────────────────────────────────────────
+
+/// In-process test double for [`MemoryFacade`].
+///
+/// Stores entries in a `Vec` and uses substring matching for recall.
+/// No `SQLite` or `Qdrant` required — suitable for unit tests that exercise
+/// memory-dependent agent logic without external infrastructure.
+///
+/// # Examples
+///
+/// ```
+/// # use zeph_memory::facade::{InMemoryFacade, MemoryEntry, MemoryFacade};
+/// # use zeph_memory::ConversationId;
+/// # tokio_test::block_on(async {
+/// let facade = InMemoryFacade::new();
+/// let entry = MemoryEntry {
+///     conversation_id: ConversationId(1),
+///     role: "user".into(),
+///     content: "Rust borrow checker".into(),
+///     parts: vec![],
+///     metadata: None,
+/// };
+/// let id = facade.remember(entry).await.unwrap();
+/// let matches = facade.recall("borrow", 10).await.unwrap();
+/// assert!(!matches.is_empty());
+/// # });
+/// ```
+#[derive(Debug, Default)]
+pub struct InMemoryFacade {
+    entries: Mutex<BTreeMap<i64, MemoryEntry>>,
+    next_id: Mutex<i64>,
+}
+
+impl InMemoryFacade {
+    /// Create a new empty facade.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return the number of stored entries.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries.lock().map_or(0, |g| g.len())
+    }
+
+    /// Return `true` if no entries have been stored.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl MemoryFacade for InMemoryFacade {
+    async fn remember(&self, entry: MemoryEntry) -> Result<MessageId, MemoryError> {
+        let mut id_guard = self
+            .next_id
+            .lock()
+            .map_err(|e| MemoryError::Other(format!("InMemoryFacade lock poisoned: {e}")))?;
+        *id_guard += 1;
+        let id = *id_guard;
+        let mut entries = self
+            .entries
+            .lock()
+            .map_err(|e| MemoryError::Other(format!("InMemoryFacade lock poisoned: {e}")))?;
+        entries.insert(id, entry);
+        Ok(MessageId(id))
+    }
+
+    async fn recall(&self, query: &str, limit: usize) -> Result<Vec<MemoryMatch>, MemoryError> {
+        let entries = self
+            .entries
+            .lock()
+            .map_err(|e| MemoryError::Other(format!("InMemoryFacade lock poisoned: {e}")))?;
+        let query_lower = query.to_lowercase();
+        let mut matches: Vec<MemoryMatch> = entries
+            .values()
+            .filter(|e| e.content.to_lowercase().contains(&query_lower))
+            .map(|e| MemoryMatch {
+                content: e.content.clone(),
+                score: 1.0,
+                source: MemorySource::Keyword,
+            })
+            .take(limit)
+            .collect();
+        // Stable order for deterministic tests
+        matches.sort_by(|a, b| a.content.cmp(&b.content));
+        Ok(matches)
+    }
+
+    async fn summarize(&self, conv_id: ConversationId) -> Result<String, MemoryError> {
+        let entries = self
+            .entries
+            .lock()
+            .map_err(|e| MemoryError::Other(format!("InMemoryFacade lock poisoned: {e}")))?;
+        let texts: Vec<&str> = entries
+            .values()
+            .filter(|e| e.conversation_id == conv_id)
+            .map(|e| e.content.as_str())
+            .collect();
+        Ok(texts.join("\n"))
+    }
+
+    async fn compact(&self, ctx: &CompactionContext) -> Result<CompactionResult, MemoryError> {
+        let mut entries = self
+            .entries
+            .lock()
+            .map_err(|e| MemoryError::Other(format!("InMemoryFacade lock poisoned: {e}")))?;
+        let ids_to_remove: Vec<i64> = entries
+            .iter()
+            .filter(|(_, e)| e.conversation_id == ctx.conversation_id)
+            .map(|(&id, _)| id)
+            .collect();
+        let count = ids_to_remove.len();
+        let summary: Vec<String> = ids_to_remove
+            .iter()
+            .filter_map(|id| entries.get(id).map(|e| e.content.clone()))
+            .collect();
+        for id in &ids_to_remove {
+            entries.remove(id);
+        }
+        Ok(CompactionResult {
+            summary: summary.join("\n"),
+            messages_compacted: count,
+        })
+    }
+}
+
+// ── SemanticMemory impl ───────────────────────────────────────────────────────
+
+impl MemoryFacade for crate::semantic::SemanticMemory {
+    async fn remember(&self, entry: MemoryEntry) -> Result<MessageId, MemoryError> {
+        let parts_json = serde_json::to_string(&entry.parts)
+            .map_err(|e| MemoryError::Other(format!("parts serialization failed: {e}")))?;
+        let (id_opt, _embedded) = self
+            .remember_with_parts(
+                entry.conversation_id,
+                &entry.role,
+                &entry.content,
+                &parts_json,
+                None,
+            )
+            .await?;
+        id_opt.ok_or_else(|| MemoryError::Other("message rejected by admission control".into()))
+    }
+
+    async fn recall(&self, query: &str, limit: usize) -> Result<Vec<MemoryMatch>, MemoryError> {
+        let recalled = self.recall(query, limit, None).await?;
+        Ok(recalled
+            .into_iter()
+            .map(|r| MemoryMatch {
+                content: r.message.content,
+                score: r.score,
+                source: MemorySource::Semantic,
+            })
+            .collect())
+    }
+
+    async fn summarize(&self, conv_id: ConversationId) -> Result<String, MemoryError> {
+        let summaries = self.load_summaries(conv_id).await?;
+        Ok(summaries
+            .into_iter()
+            .map(|s| s.content)
+            .collect::<Vec<_>>()
+            .join("\n"))
+    }
+
+    async fn compact(&self, ctx: &CompactionContext) -> Result<CompactionResult, MemoryError> {
+        let before = self.message_count(ctx.conversation_id).await?;
+        let messages_compacted = usize::try_from(before).unwrap_or(0);
+        // Trigger a summarization pass to reduce context below the token budget.
+        // The message_count parameter drives how many messages to summarize at once.
+        // Approximate: 4 chars per token; produce a target message count that
+        // keeps the resulting context under the token budget.
+        let target_msgs = ctx.token_budget.checked_div(4).unwrap_or(512);
+        let _ = self.summarize(ctx.conversation_id, target_msgs).await?;
+        let summary = self
+            .load_summaries(ctx.conversation_id)
+            .await?
+            .into_iter()
+            .map(|s| s.content)
+            .collect::<Vec<_>>()
+            .join("\n");
+        Ok(CompactionResult {
+            summary,
+            messages_compacted,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn remember_and_recall() {
+        let facade = InMemoryFacade::new();
+        let entry = MemoryEntry {
+            conversation_id: ConversationId(1),
+            role: "user".into(),
+            content: "Rust ownership model".into(),
+            parts: vec![],
+            metadata: None,
+        };
+        let id = facade.remember(entry).await.unwrap();
+        assert_eq!(id, MessageId(1));
+
+        let matches = facade.recall("ownership", 10).await.unwrap();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].content, "Rust ownership model");
+        assert_eq!(matches[0].source, MemorySource::Keyword);
+    }
+
+    #[tokio::test]
+    async fn recall_no_match() {
+        let facade = InMemoryFacade::new();
+        let entry = MemoryEntry {
+            conversation_id: ConversationId(1),
+            role: "user".into(),
+            content: "Rust ownership model".into(),
+            parts: vec![],
+            metadata: None,
+        };
+        facade.remember(entry).await.unwrap();
+        let matches = facade.recall("Python", 10).await.unwrap();
+        assert!(matches.is_empty());
+    }
+
+    #[tokio::test]
+    async fn summarize_joins_content() {
+        let facade = InMemoryFacade::new();
+        for content in ["Hello", "World"] {
+            facade
+                .remember(MemoryEntry {
+                    conversation_id: ConversationId(1),
+                    role: "user".into(),
+                    content: content.into(),
+                    parts: vec![],
+                    metadata: None,
+                })
+                .await
+                .unwrap();
+        }
+        let summary = facade.summarize(ConversationId(1)).await.unwrap();
+        assert!(summary.contains("Hello") && summary.contains("World"));
+    }
+
+    #[tokio::test]
+    async fn compact_removes_conversation_entries() {
+        let facade = InMemoryFacade::new();
+        facade
+            .remember(MemoryEntry {
+                conversation_id: ConversationId(1),
+                role: "user".into(),
+                content: "entry 1".into(),
+                parts: vec![],
+                metadata: None,
+            })
+            .await
+            .unwrap();
+        facade
+            .remember(MemoryEntry {
+                conversation_id: ConversationId(2),
+                role: "user".into(),
+                content: "other conv".into(),
+                parts: vec![],
+                metadata: None,
+            })
+            .await
+            .unwrap();
+
+        let result = facade
+            .compact(&CompactionContext {
+                conversation_id: ConversationId(1),
+                token_budget: 100,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.messages_compacted, 1);
+        assert!(result.summary.contains("entry 1"));
+        // Other conversation untouched
+        assert_eq!(facade.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn recall_respects_limit() {
+        let facade = InMemoryFacade::new();
+        for i in 0..5 {
+            facade
+                .remember(MemoryEntry {
+                    conversation_id: ConversationId(1),
+                    role: "user".into(),
+                    content: format!("memory item {i}"),
+                    parts: vec![],
+                    metadata: None,
+                })
+                .await
+                .unwrap();
+        }
+        let matches = facade.recall("memory", 3).await.unwrap();
+        assert_eq!(matches.len(), 3);
+    }
+}

--- a/crates/zeph-memory/src/facade.rs
+++ b/crates/zeph-memory/src/facade.rs
@@ -189,10 +189,10 @@ pub trait MemoryFacade: Send + Sync {
 ///
 /// # Examples
 ///
-/// ```
+/// ```no_run
 /// # use zeph_memory::facade::{InMemoryFacade, MemoryEntry, MemoryFacade};
 /// # use zeph_memory::ConversationId;
-/// # tokio_test::block_on(async {
+/// # #[tokio::main] async fn main() {
 /// let facade = InMemoryFacade::new();
 /// let entry = MemoryEntry {
 ///     conversation_id: ConversationId(1),
@@ -204,7 +204,7 @@ pub trait MemoryFacade: Send + Sync {
 /// let id = facade.remember(entry).await.unwrap();
 /// let matches = facade.recall("borrow", 10).await.unwrap();
 /// assert!(!matches.is_empty());
-/// # });
+/// # }
 /// ```
 #[derive(Debug, Default)]
 pub struct InMemoryFacade {

--- a/crates/zeph-memory/src/lib.rs
+++ b/crates/zeph-memory/src/lib.rs
@@ -71,6 +71,7 @@ pub mod compression_guidelines;
 pub mod compression_predictor;
 pub mod consolidation;
 pub mod document;
+pub mod facade;
 pub mod forgetting;
 pub mod scenes;
 pub mod tiers;
@@ -127,6 +128,10 @@ pub use embedding_registry::{
 pub use embedding_store::ensure_qdrant_collection;
 pub use error::MemoryError;
 pub use eviction::{EbbinghausPolicy, EvictionConfig, EvictionPolicy, start_eviction_loop};
+pub use facade::{
+    CompactionContext, CompactionResult, InMemoryFacade, MemoryEntry, MemoryFacade, MemoryMatch,
+    MemorySource,
+};
 pub use forgetting::{ForgettingConfig, ForgettingResult, start_forgetting_loop};
 pub use graph::EntityLockManager;
 pub use graph::{

--- a/crates/zeph-memory/src/store/acp_sessions.rs
+++ b/crates/zeph-memory/src/store/acp_sessions.rs
@@ -319,12 +319,12 @@ impl SqliteStore {
         // Copy messages in order. Only columns present across all migrations are included;
         // per-message auto-fields (id, created_at, last_accessed, access_count, qdrant_cleaned)
         // are excluded so they are generated fresh for the target conversation.
-        zeph_db::query(
-            sql!("INSERT INTO messages \
-                (conversation_id, role, content, parts, agent_visible, user_visible, compacted_at, deleted_at) \
-             SELECT ?, role, content, parts, agent_visible, user_visible, compacted_at, deleted_at \
-             FROM messages WHERE conversation_id = ? ORDER BY id"),
-        )
+        zeph_db::query(sql!(
+            "INSERT INTO messages \
+                (conversation_id, role, content, parts, visibility, compacted_at, deleted_at) \
+             SELECT ?, role, content, parts, visibility, compacted_at, deleted_at \
+             FROM messages WHERE conversation_id = ? ORDER BY id"
+        ))
         .bind(target)
         .bind(source)
         .execute(&mut *tx)

--- a/crates/zeph-memory/src/store/messages/mod.rs
+++ b/crates/zeph-memory/src/store/messages/mod.rs
@@ -8,7 +8,7 @@ use zeph_db::ActiveDialect;
 use zeph_db::fts::sanitize_fts_query;
 #[allow(unused_imports)]
 use zeph_db::{begin_write, sql};
-use zeph_llm::provider::{Message, MessageMetadata, MessagePart, Role};
+use zeph_llm::provider::{Message, MessageMetadata, MessagePart, MessageVisibility, Role};
 
 use super::SqliteStore;
 use crate::error::MemoryError;
@@ -164,8 +164,14 @@ impl SqliteStore {
         content: &str,
         parts_json: &str,
     ) -> Result<MessageId, MemoryError> {
-        self.save_message_with_metadata(conversation_id, role, content, parts_json, true, true)
-            .await
+        self.save_message_with_metadata(
+            conversation_id,
+            role,
+            content,
+            parts_json,
+            MessageVisibility::Both,
+        )
+        .await
     }
 
     /// Save a message with an optional category tag.
@@ -185,9 +191,9 @@ impl SqliteStore {
         let importance_score = crate::semantic::importance::compute_importance(content, role);
         let row: (MessageId,) = zeph_db::query_as(sql!(
             "INSERT INTO messages \
-                 (conversation_id, role, content, parts, agent_visible, user_visible, \
+                 (conversation_id, role, content, parts, visibility, \
                   importance_score, category) \
-                 VALUES (?, ?, ?, '[]', 1, 1, ?, ?) RETURNING id"
+                 VALUES (?, ?, ?, '[]', 'both', ?, ?) RETURNING id"
         ))
         .bind(conversation_id)
         .bind(role)
@@ -210,8 +216,7 @@ impl SqliteStore {
         role: &str,
         content: &str,
         parts_json: &str,
-        agent_visible: bool,
-        user_visible: bool,
+        visibility: MessageVisibility,
     ) -> Result<MessageId, MemoryError> {
         const MAX_BYTES: usize = 100 * 1024;
 
@@ -234,15 +239,14 @@ impl SqliteStore {
 
         let importance_score = crate::semantic::importance::compute_importance(&content_cow, role);
         let row: (MessageId,) = zeph_db::query_as(
-            sql!("INSERT INTO messages (conversation_id, role, content, parts, agent_visible, user_visible, importance_score) \
-             VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id"),
+            sql!("INSERT INTO messages (conversation_id, role, content, parts, visibility, importance_score) \
+             VALUES (?, ?, ?, ?, ?, ?) RETURNING id"),
         )
         .bind(conversation_id)
         .bind(role)
         .bind(content_cow.as_ref())
         .bind(parts_json)
-        .bind(i64::from(agent_visible))
-        .bind(i64::from(user_visible))
+        .bind(visibility.as_db_str())
         .bind(importance_score)
         .fetch_one(&self.pool)
         .await?;
@@ -259,9 +263,9 @@ impl SqliteStore {
         conversation_id: ConversationId,
         limit: u32,
     ) -> Result<Vec<Message>, MemoryError> {
-        let rows: Vec<(String, String, String, i64, i64, i64)> = zeph_db::query_as(sql!(
-            "SELECT role, content, parts, agent_visible, user_visible, id FROM (\
-                SELECT role, content, parts, agent_visible, user_visible, id FROM messages \
+        let rows: Vec<(String, String, String, String, i64)> = zeph_db::query_as(sql!(
+            "SELECT role, content, parts, visibility, id FROM (\
+                SELECT role, content, parts, visibility, id FROM messages \
                 WHERE conversation_id = ? AND deleted_at IS NULL \
                 ORDER BY id DESC \
                 LIMIT ?\
@@ -274,25 +278,22 @@ impl SqliteStore {
 
         let messages = rows
             .into_iter()
-            .map(
-                |(role_str, content, parts_json, agent_visible, user_visible, row_id)| {
-                    let parts = parse_parts_json(&role_str, &parts_json);
-                    Message {
-                        role: parse_role(&role_str),
-                        content,
-                        parts,
-                        metadata: MessageMetadata {
-                            agent_visible: agent_visible != 0,
-                            user_visible: user_visible != 0,
-                            compacted_at: None,
-                            deferred_summary: None,
-                            focus_pinned: false,
-                            focus_marker_id: None,
-                            db_id: Some(row_id),
-                        },
-                    }
-                },
-            )
+            .map(|(role_str, content, parts_json, visibility_str, row_id)| {
+                let parts = parse_parts_json(&role_str, &parts_json);
+                Message {
+                    role: parse_role(&role_str),
+                    content,
+                    parts,
+                    metadata: MessageMetadata {
+                        visibility: MessageVisibility::from_db_str(&visibility_str),
+                        compacted_at: None,
+                        deferred_summary: None,
+                        focus_pinned: false,
+                        focus_marker_id: None,
+                        db_id: Some(row_id),
+                    },
+                }
+            })
             .collect();
         Ok(messages)
     }
@@ -311,50 +312,50 @@ impl SqliteStore {
         agent_visible: Option<bool>,
         user_visible: Option<bool>,
     ) -> Result<Vec<Message>, MemoryError> {
-        let av = agent_visible.map(i64::from);
-        let uv = user_visible.map(i64::from);
+        // Map boolean filters to SQL predicates on the visibility column.
+        // agent_visible=true  → exclude 'user_only'  rows
+        // user_visible=true   → exclude 'agent_only' rows
+        // The two filters are independent; when both are Some(true) the
+        // combined effect is to keep only 'both' rows.
+        let exclude_user_only = agent_visible == Some(true);
+        let exclude_agent_only = user_visible == Some(true);
 
-        let rows: Vec<(String, String, String, i64, i64, i64)> = zeph_db::query_as(
-            sql!("WITH recent AS (\
-                SELECT role, content, parts, agent_visible, user_visible, id FROM messages \
+        let rows: Vec<(String, String, String, String, i64)> = zeph_db::query_as(sql!(
+            "WITH recent AS (\
+                SELECT role, content, parts, visibility, id FROM messages \
                 WHERE conversation_id = ? \
                   AND deleted_at IS NULL \
-                  AND (? IS NULL OR agent_visible = ?) \
-                  AND (? IS NULL OR user_visible = ?) \
+                  AND (NOT ? OR visibility != 'user_only') \
+                  AND (NOT ? OR visibility != 'agent_only') \
                 ORDER BY id DESC \
                 LIMIT ?\
-             ) SELECT role, content, parts, agent_visible, user_visible, id FROM recent ORDER BY id ASC"),
-        )
+             ) SELECT role, content, parts, visibility, id FROM recent ORDER BY id ASC"
+        ))
         .bind(conversation_id)
-        .bind(av)
-        .bind(av)
-        .bind(uv)
-        .bind(uv)
+        .bind(exclude_user_only)
+        .bind(exclude_agent_only)
         .bind(limit)
         .fetch_all(&self.pool)
         .await?;
 
         let messages = rows
             .into_iter()
-            .map(
-                |(role_str, content, parts_json, agent_visible, user_visible, row_id)| {
-                    let parts = parse_parts_json(&role_str, &parts_json);
-                    Message {
-                        role: parse_role(&role_str),
-                        content,
-                        parts,
-                        metadata: MessageMetadata {
-                            agent_visible: agent_visible != 0,
-                            user_visible: user_visible != 0,
-                            compacted_at: None,
-                            deferred_summary: None,
-                            focus_pinned: false,
-                            focus_marker_id: None,
-                            db_id: Some(row_id),
-                        },
-                    }
-                },
-            )
+            .map(|(role_str, content, parts_json, visibility_str, row_id)| {
+                let parts = parse_parts_json(&role_str, &parts_json);
+                Message {
+                    role: parse_role(&role_str),
+                    content,
+                    parts,
+                    metadata: MessageMetadata {
+                        visibility: MessageVisibility::from_db_str(&visibility_str),
+                        compacted_at: None,
+                        deferred_summary: None,
+                        focus_pinned: false,
+                        focus_marker_id: None,
+                        db_id: Some(row_id),
+                    },
+                }
+            })
             .collect();
         Ok(messages)
     }
@@ -362,8 +363,8 @@ impl SqliteStore {
     /// Atomically mark a range of messages as user-only and insert a summary as agent-only.
     ///
     /// Within a single transaction:
-    /// 1. Updates `agent_visible=0, compacted_at=now` for messages in `compacted_range`.
-    /// 2. Inserts `summary_content` with `agent_visible=1, user_visible=0`.
+    /// 1. Updates `visibility=user_only, compacted_at=now` for messages in `compacted_range`.
+    /// 2. Inserts `summary_content` with `visibility=agent_only`.
     ///
     /// Returns the `MessageId` of the inserted summary.
     ///
@@ -390,7 +391,7 @@ impl SqliteStore {
         let mut tx = self.pool.begin().await?;
 
         zeph_db::query(sql!(
-            "UPDATE messages SET agent_visible = 0, compacted_at = ? \
+            "UPDATE messages SET visibility = 'user_only', compacted_at = ? \
              WHERE conversation_id = ? AND id >= ? AND id <= ?"
         ))
         .bind(&now)
@@ -403,8 +404,8 @@ impl SqliteStore {
         // importance_score uses schema DEFAULT 0.5 (neutral); compaction summaries are not scored at write time.
         let row: (MessageId,) = zeph_db::query_as(sql!(
             "INSERT INTO messages \
-             (conversation_id, role, content, parts, agent_visible, user_visible) \
-             VALUES (?, ?, ?, '[]', 1, 0) RETURNING id"
+             (conversation_id, role, content, parts, visibility) \
+             VALUES (?, ?, ?, '[]', 'agent_only') RETURNING id"
         ))
         .bind(conversation_id)
         .bind(summary_role)
@@ -420,7 +421,7 @@ impl SqliteStore {
     /// Atomically hide `tool_use/tool_result` message pairs and insert summary messages.
     ///
     /// Within a single transaction:
-    /// 1. Sets `agent_visible=0, compacted_at=<now>` for each ID in `hide_ids`.
+    /// 1. Sets `visibility=user_only, compacted_at=<now>` for each ID in `hide_ids`.
     /// 2. Inserts each text in `summaries` as a new agent-only assistant message.
     ///
     /// # Errors
@@ -446,7 +447,7 @@ impl SqliteStore {
 
         for &id in hide_ids {
             zeph_db::query(sql!(
-                "UPDATE messages SET agent_visible = 0, compacted_at = ? WHERE id = ?"
+                "UPDATE messages SET visibility = 'user_only', compacted_at = ? WHERE id = ?"
             ))
             .bind(&now)
             .bind(id)
@@ -462,8 +463,8 @@ impl SqliteStore {
             .unwrap_or_else(|_| "[]".to_string());
             zeph_db::query(sql!(
                 "INSERT INTO messages \
-                 (conversation_id, role, content, parts, agent_visible, user_visible) \
-                 VALUES (?, 'assistant', ?, ?, 1, 0)"
+                 (conversation_id, role, content, parts, visibility) \
+                 VALUES (?, 'assistant', ?, ?, 'agent_only')"
             ))
             .bind(conversation_id)
             .bind(&content)
@@ -519,32 +520,29 @@ impl SqliteStore {
         &self,
         message_id: MessageId,
     ) -> Result<Option<Message>, MemoryError> {
-        let row: Option<(String, String, String, i64, i64)> = zeph_db::query_as(
-            sql!("SELECT role, content, parts, agent_visible, user_visible FROM messages WHERE id = ? AND deleted_at IS NULL"),
+        let row: Option<(String, String, String, String)> = zeph_db::query_as(
+            sql!("SELECT role, content, parts, visibility FROM messages WHERE id = ? AND deleted_at IS NULL"),
         )
         .bind(message_id)
         .fetch_optional(&self.pool)
         .await?;
 
-        Ok(row.map(
-            |(role_str, content, parts_json, agent_visible, user_visible)| {
-                let parts = parse_parts_json(&role_str, &parts_json);
-                Message {
-                    role: parse_role(&role_str),
-                    content,
-                    parts,
-                    metadata: MessageMetadata {
-                        agent_visible: agent_visible != 0,
-                        user_visible: user_visible != 0,
-                        compacted_at: None,
-                        deferred_summary: None,
-                        focus_pinned: false,
-                        focus_marker_id: None,
-                        db_id: None,
-                    },
-                }
-            },
-        ))
+        Ok(row.map(|(role_str, content, parts_json, visibility_str)| {
+            let parts = parse_parts_json(&role_str, &parts_json);
+            Message {
+                role: parse_role(&role_str),
+                content,
+                parts,
+                metadata: MessageMetadata {
+                    visibility: MessageVisibility::from_db_str(&visibility_str),
+                    compacted_at: None,
+                    deferred_summary: None,
+                    focus_pinned: false,
+                    focus_marker_id: None,
+                    db_id: None,
+                },
+            }
+        }))
     }
 
     /// Fetch messages by a list of IDs in a single query.
@@ -564,7 +562,7 @@ impl SqliteStore {
 
         let query = format!(
             "SELECT id, role, content, parts FROM messages \
-             WHERE id IN ({placeholders}) AND agent_visible = 1 AND deleted_at IS NULL"
+             WHERE id IN ({placeholders}) AND visibility != 'user_only' AND deleted_at IS NULL"
         );
         let mut q = zeph_db::query_as::<_, (MessageId, String, String, String)>(&query);
         for &id in ids {
@@ -724,7 +722,7 @@ impl SqliteStore {
                 sql!("SELECT m.id, -rank AS score \
                  FROM messages_fts f \
                  JOIN messages m ON m.id = f.rowid \
-                 WHERE messages_fts MATCH ? AND m.conversation_id = ? AND m.agent_visible = 1 AND m.deleted_at IS NULL \
+                 WHERE messages_fts MATCH ? AND m.conversation_id = ? AND m.visibility != 'user_only' AND m.deleted_at IS NULL \
                  ORDER BY rank \
                  LIMIT ?"),
             )
@@ -738,7 +736,7 @@ impl SqliteStore {
                 "SELECT m.id, -rank AS score \
                  FROM messages_fts f \
                  JOIN messages m ON m.id = f.rowid \
-                 WHERE messages_fts MATCH ? AND m.agent_visible = 1 AND m.deleted_at IS NULL \
+                 WHERE messages_fts MATCH ? AND m.visibility != 'user_only' AND m.deleted_at IS NULL \
                  ORDER BY rank \
                  LIMIT ?"
             ))
@@ -798,7 +796,7 @@ impl SqliteStore {
             "SELECT m.id, -rank AS score \
              FROM messages_fts f \
              JOIN messages m ON m.id = f.rowid \
-             WHERE messages_fts MATCH ? AND m.agent_visible = 1 AND m.deleted_at IS NULL\
+             WHERE messages_fts MATCH ? AND m.visibility != 'user_only' AND m.deleted_at IS NULL\
              {after_clause}{before_clause}{conv_clause} \
              ORDER BY rank \
              LIMIT ?"
@@ -1133,9 +1131,9 @@ impl SqliteStore {
         let epoch_now = <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::EPOCH_NOW;
         let promote_insert_raw = format!(
             "INSERT INTO messages \
-             (conversation_id, role, content, parts, agent_visible, user_visible, \
+             (conversation_id, role, content, parts, visibility, \
               tier, promotion_timestamp) \
-             VALUES (?, 'assistant', ?, '[]', 1, 0, 'semantic', {epoch_now}) \
+             VALUES (?, 'assistant', ?, '[]', 'agent_only', 'semantic', {epoch_now}) \
              RETURNING id"
         );
         let promote_insert_sql = zeph_db::rewrite_placeholders(&promote_insert_raw);
@@ -1346,9 +1344,9 @@ impl SqliteStore {
         let importance = crate::semantic::importance::compute_importance(merged_content, role);
         let row: (MessageId,) = zeph_db::query_as(sql!(
             "INSERT INTO messages \
-               (conversation_id, role, content, parts, agent_visible, user_visible, \
+               (conversation_id, role, content, parts, visibility, \
                 importance_score, consolidated, consolidation_confidence) \
-             VALUES (?, ?, ?, '[]', 1, 1, ?, 1, ?) \
+             VALUES (?, ?, ?, '[]', 'both', ?, 1, ?) \
              RETURNING id"
         ))
         .bind(conversation_id)

--- a/crates/zeph-memory/src/store/messages/tests.rs
+++ b/crates/zeph-memory/src/store/messages/tests.rs
@@ -435,14 +435,14 @@ async fn save_message_with_metadata_stores_visibility() {
     let cid = store.create_conversation().await.unwrap();
 
     let id = store
-        .save_message_with_metadata(cid, "user", "hello", "[]", false, true)
+        .save_message_with_metadata(cid, "user", "hello", "[]", MessageVisibility::UserOnly)
         .await
         .unwrap();
 
     let history = store.load_history(cid, 10).await.unwrap();
     assert_eq!(history.len(), 1);
-    assert!(!history[0].metadata.agent_visible);
-    assert!(history[0].metadata.user_visible);
+    assert!(!history[0].metadata.visibility.is_agent_visible());
+    assert!(history[0].metadata.visibility.is_user_visible());
     assert_eq!(id, MessageId(1));
 }
 
@@ -452,11 +452,17 @@ async fn load_history_filtered_by_agent_visible() {
     let cid = store.create_conversation().await.unwrap();
 
     store
-        .save_message_with_metadata(cid, "user", "visible to agent", "[]", true, true)
+        .save_message_with_metadata(
+            cid,
+            "user",
+            "visible to agent",
+            "[]",
+            MessageVisibility::Both,
+        )
         .await
         .unwrap();
     store
-        .save_message_with_metadata(cid, "user", "user only", "[]", false, true)
+        .save_message_with_metadata(cid, "user", "user only", "[]", MessageVisibility::UserOnly)
         .await
         .unwrap();
 
@@ -474,11 +480,17 @@ async fn load_history_filtered_by_user_visible() {
     let cid = store.create_conversation().await.unwrap();
 
     store
-        .save_message_with_metadata(cid, "system", "agent only summary", "[]", true, false)
+        .save_message_with_metadata(
+            cid,
+            "system",
+            "agent only summary",
+            "[]",
+            MessageVisibility::AgentOnly,
+        )
         .await
         .unwrap();
     store
-        .save_message_with_metadata(cid, "user", "user sees this", "[]", true, true)
+        .save_message_with_metadata(cid, "user", "user sees this", "[]", MessageVisibility::Both)
         .await
         .unwrap();
 
@@ -496,11 +508,11 @@ async fn load_history_filtered_no_filter_returns_all() {
     let cid = store.create_conversation().await.unwrap();
 
     store
-        .save_message_with_metadata(cid, "user", "msg1", "[]", true, false)
+        .save_message_with_metadata(cid, "user", "msg1", "[]", MessageVisibility::AgentOnly)
         .await
         .unwrap();
     store
-        .save_message_with_metadata(cid, "user", "msg2", "[]", false, true)
+        .save_message_with_metadata(cid, "user", "msg2", "[]", MessageVisibility::UserOnly)
         .await
         .unwrap();
 
@@ -532,19 +544,19 @@ async fn replace_conversation_marks_originals_and_inserts_summary() {
     let all = store.load_history(cid, 50).await.unwrap();
     // id1 and id2 marked agent_visible=false, id3 untouched, summary inserted
     let by_id1 = all.iter().find(|m| m.content == "first").unwrap();
-    assert!(!by_id1.metadata.agent_visible);
-    assert!(by_id1.metadata.user_visible);
+    assert!(!by_id1.metadata.visibility.is_agent_visible());
+    assert!(by_id1.metadata.visibility.is_user_visible());
 
     let by_id2 = all.iter().find(|m| m.content == "second").unwrap();
-    assert!(!by_id2.metadata.agent_visible);
+    assert!(!by_id2.metadata.visibility.is_agent_visible());
 
     let by_id3 = all.iter().find(|m| m.content == "third").unwrap();
-    assert!(by_id3.metadata.agent_visible);
+    assert!(by_id3.metadata.visibility.is_agent_visible());
 
     // Summary is agent_only (agent_visible=1, user_visible=0)
     let summary = all.iter().find(|m| m.content == "summary text").unwrap();
-    assert!(summary.metadata.agent_visible);
-    assert!(!summary.metadata.user_visible);
+    assert!(summary.metadata.visibility.is_agent_visible());
+    assert!(!summary.metadata.visibility.is_user_visible());
     assert!(summary_id > id3);
 }
 
@@ -573,8 +585,8 @@ async fn message_metadata_default_both_visible() {
     store.save_message(cid, "user", "normal").await.unwrap();
 
     let history = store.load_history(cid, 10).await.unwrap();
-    assert!(history[0].metadata.agent_visible);
-    assert!(history[0].metadata.user_visible);
+    assert!(history[0].metadata.visibility.is_agent_visible());
+    assert!(history[0].metadata.visibility.is_user_visible());
     assert!(history[0].metadata.compacted_at.is_none());
 }
 
@@ -662,7 +674,7 @@ async fn load_history_filtered_empty_parts_json_fast_path() {
     let cid = store.create_conversation().await.unwrap();
 
     store
-        .save_message_with_metadata(cid, "user", "msg", "[]", true, true)
+        .save_message_with_metadata(cid, "user", "msg", "[]", MessageVisibility::Both)
         .await
         .unwrap();
 
@@ -896,8 +908,8 @@ async fn migration_039_default_importance_score_for_preexisting_rows() {
     let cid = store.create_conversation().await.unwrap();
 
     sqlx::query(sql!(
-        "INSERT INTO messages (conversation_id, role, content, parts, agent_visible, user_visible) \
-         VALUES (?, 'user', 'legacy row', '[]', 1, 1)"
+        "INSERT INTO messages (conversation_id, role, content, parts, visibility) \
+         VALUES (?, 'user', 'legacy row', '[]', 'both')"
     ))
     .bind(cid)
     .execute(store.pool())
@@ -1240,8 +1252,8 @@ async fn migration_042_default_tier_for_preexisting_rows() {
     let cid = store.create_conversation().await.unwrap();
 
     sqlx::query(sql!(
-        "INSERT INTO messages (conversation_id, role, content, parts, agent_visible, user_visible) \
-         VALUES (?, 'user', 'legacy row', '[]', 1, 1)"
+        "INSERT INTO messages (conversation_id, role, content, parts, visibility) \
+         VALUES (?, 'user', 'legacy row', '[]', 'both')"
     ))
     .bind(cid)
     .execute(store.pool())
@@ -1267,8 +1279,8 @@ async fn migration_042_default_session_count_for_preexisting_rows() {
     let cid = store.create_conversation().await.unwrap();
 
     sqlx::query(sql!(
-        "INSERT INTO messages (conversation_id, role, content, parts, agent_visible, user_visible) \
-         VALUES (?, 'user', 'session count row', '[]', 1, 1)"
+        "INSERT INTO messages (conversation_id, role, content, parts, visibility) \
+         VALUES (?, 'user', 'session count row', '[]', 'both')"
     ))
     .bind(cid)
     .execute(store.pool())

--- a/crates/zeph-tools/src/adversarial_policy.rs
+++ b/crates/zeph-tools/src/adversarial_policy.rs
@@ -10,9 +10,9 @@
 //! Addresses CRIT-02: LLM client is injected via `PolicyLlmClient` trait.
 //! Addresses CRIT-01: fail behavior is configurable via `fail_open: bool`.
 
-use std::future::Future;
-use std::pin::Pin;
 use std::time::Duration;
+
+pub use zeph_common::{PolicyLlmClient, PolicyMessage, PolicyRole};
 
 /// Decision returned by the adversarial policy validator.
 #[derive(Debug, Clone)]
@@ -26,34 +26,6 @@ pub enum PolicyDecision {
     },
     /// LLM call failed (timeout, network error, or malformed response).
     Error { message: String },
-}
-
-/// Trait for sending chat messages to the policy LLM.
-///
-/// Implemented in `runner.rs` on a newtype wrapping `Arc<AnyProvider>`.
-/// `zeph-tools` defines the trait; `runner.rs` supplies the implementation,
-/// keeping `zeph-tools` decoupled from `zeph-llm`.
-pub trait PolicyLlmClient: Send + Sync {
-    /// Send a sequence of messages and return the assistant's text response.
-    fn chat<'a>(
-        &'a self,
-        messages: &'a [PolicyMessage],
-    ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + 'a>>;
-}
-
-/// Minimal message type for policy LLM calls.
-///
-/// Uses a dedicated type to avoid importing `zeph-llm` types into `zeph-tools`.
-#[derive(Debug, Clone)]
-pub struct PolicyMessage {
-    pub role: PolicyRole,
-    pub content: String,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PolicyRole {
-    System,
-    User,
 }
 
 /// Validates tool calls against plain-language policies using an LLM.
@@ -252,8 +224,11 @@ pub fn parse_policy_lines(content: &str) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::future::Future;
+    use std::pin::Pin;
     use std::sync::Arc;
+
+    use super::*;
 
     struct MockLlmClient {
         response: String,

--- a/crates/zeph-tui/src/channel.rs
+++ b/crates/zeph-tui/src/channel.rs
@@ -201,7 +201,7 @@ impl Channel for TuiChannel {
         Ok(())
     }
 
-    async fn send_tool_start(&mut self, event: ToolStartEvent<'_>) -> Result<(), ChannelError> {
+    async fn send_tool_start(&mut self, event: ToolStartEvent) -> Result<(), ChannelError> {
         let command = event
             .params
             .as_ref()
@@ -211,11 +211,11 @@ impl Channel for TuiChannel {
                     .or_else(|| p.get("url"))
             })
             .and_then(|v| v.as_str())
-            .unwrap_or(event.tool_name)
+            .unwrap_or(event.tool_name.as_str())
             .to_owned();
         self.agent_event_tx
             .send(AgentEvent::ToolStart {
-                tool_name: event.tool_name.into(),
+                tool_name: event.tool_name,
                 command,
             })
             .await
@@ -223,17 +223,17 @@ impl Channel for TuiChannel {
         Ok(())
     }
 
-    async fn send_tool_output(&mut self, event: ToolOutputEvent<'_>) -> Result<(), ChannelError> {
+    async fn send_tool_output(&mut self, event: ToolOutputEvent) -> Result<(), ChannelError> {
         tracing::debug!(
-            tool_name = %event.tool_name,
+            tool_name = %event.tool_name.as_str(),
             has_diff = event.diff.is_some(),
             "TuiChannel::send_tool_output called"
         );
         self.agent_event_tx
             .send(AgentEvent::ToolOutput {
-                tool_name: event.tool_name.into(),
-                command: event.body.to_owned(),
-                output: event.body.to_owned(),
+                tool_name: event.tool_name,
+                command: event.display.clone(),
+                output: event.display.clone(),
                 success: !event.is_error,
                 diff: event.diff,
                 filter_stats: event.filter_stats,
@@ -464,10 +464,11 @@ mod tests {
         use zeph_core::channel::ToolStartEvent;
         let (mut ch, _user_tx, mut agent_rx) = make_channel();
         ch.send_tool_start(ToolStartEvent {
-            tool_name: "bash",
-            tool_call_id: "id1",
+            tool_name: "bash".into(),
+            tool_call_id: "id1".into(),
             params: Some(serde_json::json!({"command": "ls -la"})),
             parent_tool_use_id: None,
+            started_at: std::time::Instant::now(),
         })
         .await
         .unwrap();
@@ -484,10 +485,11 @@ mod tests {
         use zeph_core::channel::ToolStartEvent;
         let (mut ch, _user_tx, mut agent_rx) = make_channel();
         ch.send_tool_start(ToolStartEvent {
-            tool_name: "memory_search",
-            tool_call_id: "id2",
+            tool_name: "memory_search".into(),
+            tool_call_id: "id2".into(),
             params: None,
             parent_tool_use_id: None,
+            started_at: std::time::Instant::now(),
         })
         .await
         .unwrap();
@@ -509,13 +511,15 @@ mod tests {
             new_content: "new".into(),
         };
         ch.send_tool_output(ToolOutputEvent {
-            tool_name: "bash",
-            body: "[tool output: bash]\n```\nok\n```",
+            tool_name: "bash".into(),
+            display: "[tool output: bash]\n```\nok\n```".into(),
             diff: Some(diff),
             filter_stats: None,
             kept_lines: None,
             locations: None,
-            tool_call_id: "",
+            tool_call_id: "".into(),
+
+            terminal_id: None,
             is_error: false,
             parent_tool_use_id: None,
             raw_response: None,
@@ -536,13 +540,15 @@ mod tests {
         use zeph_core::channel::ToolOutputEvent;
         let (mut ch, _user_tx, mut agent_rx) = make_channel();
         ch.send_tool_output(ToolOutputEvent {
-            tool_name: "read",
-            body: "[tool output: read]\n```\ncontent\n```",
+            tool_name: "read".into(),
+            display: "[tool output: read]\n```\ncontent\n```".into(),
             diff: None,
             filter_stats: None,
             kept_lines: None,
             locations: None,
-            tool_call_id: "",
+            tool_call_id: "".into(),
+
+            terminal_id: None,
             is_error: false,
             parent_tool_use_id: None,
             raw_response: None,

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -77,7 +77,7 @@ impl Channel for AppChannel {
     async fn send_diff(&mut self, diff: zeph_core::DiffData) -> Result<(), ChannelError> {
         dispatch_app_channel!(self, send_diff, diff)
     }
-    async fn send_tool_output(&mut self, event: ToolOutputEvent<'_>) -> Result<(), ChannelError> {
+    async fn send_tool_output(&mut self, event: ToolOutputEvent) -> Result<(), ChannelError> {
         dispatch_app_channel!(self, send_tool_output, event)
     }
 
@@ -104,7 +104,7 @@ impl Channel for AppChannel {
         )
     }
 
-    async fn send_tool_start(&mut self, event: ToolStartEvent<'_>) -> Result<(), ChannelError> {
+    async fn send_tool_start(&mut self, event: ToolStartEvent) -> Result<(), ChannelError> {
         dispatch_app_channel!(self, send_tool_start, event)
     }
 }
@@ -244,10 +244,11 @@ mod tests {
         let mut ch = make_app_channel();
         assert!(
             ch.send_tool_start(ToolStartEvent {
-                tool_name: "shell",
-                tool_call_id: "tc-001",
+                tool_name: zeph_core::ToolName::from("shell"),
+                tool_call_id: "tc-001".to_string(),
                 params: None,
                 parent_tool_use_id: None,
+                started_at: std::time::Instant::now(),
             })
             .await
             .is_ok()
@@ -295,23 +296,25 @@ mod tests {
         .unwrap();
         // 13. send_tool_start
         ch.send_tool_start(ToolStartEvent {
-            tool_name: "bash",
-            tool_call_id: "x",
+            tool_name: zeph_core::ToolName::from("bash"),
+            tool_call_id: "x".to_string(),
             params: None,
             parent_tool_use_id: None,
+            started_at: std::time::Instant::now(),
         })
         .await
         .unwrap();
         // 14. send_tool_output
         ch.send_tool_output(ToolOutputEvent {
-            tool_name: "bash",
-            body: "ok",
+            tool_name: zeph_core::ToolName::from("bash"),
+            display: "ok".to_string(),
             diff: None,
             filter_stats: None,
             kept_lines: None,
             locations: None,
-            tool_call_id: "x",
+            tool_call_id: "x".to_string(),
             is_error: false,
+            terminal_id: None,
             parent_tool_use_id: None,
             raw_response: None,
             started_at: None,

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -244,7 +244,7 @@ mod tests {
         let mut ch = make_app_channel();
         assert!(
             ch.send_tool_start(ToolStartEvent {
-                tool_name: zeph_core::ToolName::from("shell"),
+                tool_name: zeph_common::ToolName::from("shell"),
                 tool_call_id: "tc-001".to_string(),
                 params: None,
                 parent_tool_use_id: None,
@@ -296,7 +296,7 @@ mod tests {
         .unwrap();
         // 13. send_tool_start
         ch.send_tool_start(ToolStartEvent {
-            tool_name: zeph_core::ToolName::from("bash"),
+            tool_name: zeph_common::ToolName::from("bash"),
             tool_call_id: "x".to_string(),
             params: None,
             parent_tool_use_id: None,
@@ -306,7 +306,7 @@ mod tests {
         .unwrap();
         // 14. send_tool_output
         ch.send_tool_output(ToolOutputEvent {
-            tool_name: zeph_core::ToolName::from("bash"),
+            tool_name: zeph_common::ToolName::from("bash"),
             display: "ok".to_string(),
             diff: None,
             filter_stats: None,

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -215,6 +215,7 @@ mod tests {
     use super::*;
     use zeph_channels::AnyChannel;
     use zeph_channels::CliChannel;
+    use zeph_common::ToolName;
     use zeph_core::channel::{Channel, StopHint, ToolStartEvent};
 
     fn make_app_channel() -> AppChannel {
@@ -244,7 +245,7 @@ mod tests {
         let mut ch = make_app_channel();
         assert!(
             ch.send_tool_start(ToolStartEvent {
-                tool_name: zeph_common::ToolName::from("shell"),
+                tool_name: ToolName::from("shell"),
                 tool_call_id: "tc-001".to_string(),
                 params: None,
                 parent_tool_use_id: None,
@@ -296,7 +297,7 @@ mod tests {
         .unwrap();
         // 13. send_tool_start
         ch.send_tool_start(ToolStartEvent {
-            tool_name: zeph_common::ToolName::from("bash"),
+            tool_name: ToolName::from("bash"),
             tool_call_id: "x".to_string(),
             params: None,
             parent_tool_use_id: None,
@@ -306,7 +307,7 @@ mod tests {
         .unwrap();
         // 14. send_tool_output
         ch.send_tool_output(ToolOutputEvent {
-            tool_name: zeph_common::ToolName::from("bash"),
+            tool_name: ToolName::from("bash"),
             display: "ok".to_string(),
             diff: None,
             filter_stats: None,


### PR DESCRIPTION
## Summary

Implements two architecture Wave 1+2 items from the 2026-04-11 audit (#2909):

- **#2907**: Five type safety and common types improvements (D-2/M-3, TS-3, D-1)
- **#2903**: MemoryFacade trait for test decoupling from SQLite/Qdrant

## Changes

### D-2 + M-3: Type consolidation in zeph-common
- `ToolDefinition` moved from `zeph-llm` → `zeph-common/src/types.rs`
- `PolicyMessage`, `PolicyRole`, `PolicyLlmClient` moved from `zeph-tools` → `zeph-common/src/policy.rs`
- Removes parallel type hierarchies; original crates retain `pub use` re-exports for callers

### TS-3: MessageVisibility enum
- `MessageMetadata.agent_visible: bool` + `user_visible: bool` replaced with `visibility: MessageVisibility`
- Enum variants: `Both` | `AgentOnly` | `UserOnly` — invalid `(false, false)` state is unrepresentable
- Adds DB migration `073_message_visibility_enum.sql` (SQLite + Postgres)
- Existing `(0,0)` rows map to `both` (safest default)

### D-1: Owned ToolStartEvent / ToolOutputEvent
- Removes borrowed `ToolStartEvent<'a>` / `ToolOutputEvent<'a>` (lifetime duplication)
- Keeps only owned structs; `ToolStartData` / `ToolOutputData` become `#[deprecated]` type aliases

### #2903: MemoryFacade trait
- Defines `MemoryFacade` trait (`remember`, `recall`, `summarize`, `compact`) in `zeph-memory/src/facade.rs`
- Native `async fn` in trait (Rust Edition 2024, no `async-trait` crate)
- `SemanticMemory` implements `MemoryFacade`
- `InMemoryFacade` test double — no SQLite/Qdrant needed in unit tests
- Phase 1: `Agent` keeps `Arc<SemanticMemory>`; Phase 2 migration to `Arc<dyn MemoryFacade>` deferred pending `#[trait_variant::make]` stabilization

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 7869 passed (4 new tests for `MessageVisibility` DB round-trips)
- [x] 5 unit tests for `InMemoryFacade` in `facade.rs`
- [x] DB migration covers all existing boolean combinations including invalid `(0,0)`

Closes #2907
Closes #2903