### PR TITLE
refactor(core): extract ContextAssembler as standalone testable struct (#2904)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **`ContextAssembler` extraction** (`#2904`): extracted stateless `ContextAssembler` struct
+  with `gather(input: &ContextAssemblyInput<'_>) -> Result<PreparedContext, AgentError>` into
+  `crates/zeph-core/src/agent/context/assembler.rs`. All 9 `fetch_*` methods moved from
+  `impl<C: Channel> Agent<C>` to module-level free functions in `assembler.rs`. `Agent::prepare_context`
+  is now a thin wrapper (~30 LOC) that builds `ContextAssemblyInput`, calls `ContextAssembler::gather`,
+  and delegates injection to `Agent::apply_prepared_context`. `ContextAssemblyInput<'a>` borrows all
+  fields from `Agent`; `PreparedContext` carries all fetched `Option<Message>` values plus
+  `memory_first` flag and `recent_history_budget`. `session_digest` stays in
+  `apply_prepared_context` (cached, not async). No public API changes.
+
 - **`ToolName` newtype** (`#2901`): introduced `ToolName(Arc<str>)` in `zeph-common` replacing
   raw `String` for all tool name fields across `zeph-tools` (`ToolCall.tool_id`,
   `ToolOutput.tool_name`, `ToolEvent` variants), `zeph-llm` (`ToolDefinition.name`,

--- a/crates/zeph-core/src/agent/context/assembler.rs
+++ b/crates/zeph-core/src/agent/context/assembler.rs
@@ -1,0 +1,801 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Stateless context assembler.
+//!
+//! [`ContextAssembler`] gathers all memory-sourced context for a single agent turn by running
+//! all async fetch operations concurrently. It takes only borrowed references via
+//! [`ContextAssemblyInput`] and returns a [`PreparedContext`] ready for injection.
+//!
+//! Invariants:
+//! - No `Agent` field mutations inside `gather()`.
+//! - No channel communication inside `gather()`.
+//! - All `send_status` calls remain in `Agent::prepare_context`.
+//! - `session_digest` is cached (not async) and stays in `Agent::apply_prepared_context`.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use futures::StreamExt as _;
+use futures::stream::FuturesUnordered;
+
+use zeph_llm::provider::{Message, MessageMetadata, MessagePart, Role};
+use zeph_memory::TokenCounter;
+
+use super::super::error::AgentError;
+use super::super::{
+    CORRECTIONS_PREFIX, CROSS_SESSION_PREFIX, DOCUMENT_RAG_PREFIX, GRAPH_FACTS_PREFIX, MemoryState,
+    RECALL_PREFIX, SUMMARY_PREFIX,
+};
+use super::ContextSlot;
+use crate::agent::context_manager::ContextManager;
+use crate::agent::learning_engine::LearningEngine;
+use crate::agent::state::{IndexState, SkillState};
+use crate::redact::scrub_content;
+
+/// All borrowed fields needed to assemble context for one agent turn.
+///
+/// All fields are shared references — `ContextAssembler::gather` never mutates state.
+pub(crate) struct ContextAssemblyInput<'a> {
+    pub memory_state: &'a MemoryState,
+    pub context_manager: &'a ContextManager,
+    pub token_counter: &'a Arc<TokenCounter>,
+    pub skill_state: &'a SkillState,
+    pub index: &'a IndexState,
+    pub learning_engine: &'a LearningEngine,
+    /// Current value of `Agent::sidequest.turn_counter`, for adaptive strategy selection.
+    pub sidequest_turn_counter: u64,
+    /// Message window snapshot used for strategy resolution and system-prompt extraction.
+    pub messages: &'a [Message],
+    /// The user query for the current turn, used as the search query for all memory lookups.
+    pub query: &'a str,
+}
+
+/// Result of one context-assembly pass.
+///
+/// All source fields are `Option` — `None` means disabled, empty, or budget-exhausted.
+/// `session_digest` is excluded: it is a cached value injected by `Agent::apply_prepared_context`.
+pub(crate) struct PreparedContext {
+    pub graph_facts: Option<Message>,
+    pub doc_rag: Option<Message>,
+    pub corrections: Option<Message>,
+    pub recall: Option<Message>,
+    pub recall_confidence: Option<f32>,
+    pub cross_session: Option<Message>,
+    pub summaries: Option<Message>,
+    pub code_context: Option<String>,
+    pub persona_facts: Option<Message>,
+    pub trajectory_hints: Option<Message>,
+    pub tree_memory: Option<Message>,
+    /// Whether the memory-first context strategy is active for this turn.
+    pub memory_first: bool,
+    /// Token budget for recent conversation history (passed to trim step in apply).
+    pub recent_history_budget: usize,
+}
+
+/// Stateless coordinator for parallel context fetching.
+pub(crate) struct ContextAssembler;
+
+impl ContextAssembler {
+    /// Gather all context sources concurrently and return a [`PreparedContext`].
+    ///
+    /// Returns an empty `PreparedContext` immediately when `context_manager.budget` is `None`.
+    ///
+    /// # Errors
+    ///
+    /// Propagates errors from any async fetch operation.
+    #[allow(clippy::too_many_lines)] // parallel context gathering: memory, graph, skills — coupled async fanout
+    pub(crate) async fn gather(
+        input: &ContextAssemblyInput<'_>,
+    ) -> Result<PreparedContext, AgentError> {
+        type CtxFuture<'a> =
+            Pin<Box<dyn Future<Output = Result<ContextSlot, AgentError>> + Send + 'a>>;
+
+        let Some(ref budget) = input.context_manager.budget else {
+            return Ok(PreparedContext {
+                graph_facts: None,
+                doc_rag: None,
+                corrections: None,
+                recall: None,
+                recall_confidence: None,
+                cross_session: None,
+                summaries: None,
+                code_context: None,
+                persona_facts: None,
+                trajectory_hints: None,
+                tree_memory: None,
+                memory_first: false,
+                recent_history_budget: 0,
+            });
+        };
+
+        let memory_state = input.memory_state;
+        let tc = input.token_counter.clone();
+
+        let effective_strategy = match memory_state.compaction.context_strategy {
+            crate::config::ContextStrategy::FullHistory => {
+                crate::config::ContextStrategy::FullHistory
+            }
+            crate::config::ContextStrategy::MemoryFirst => {
+                crate::config::ContextStrategy::MemoryFirst
+            }
+            crate::config::ContextStrategy::Adaptive => {
+                if input.sidequest_turn_counter
+                    >= u64::from(memory_state.compaction.crossover_turn_threshold)
+                {
+                    crate::config::ContextStrategy::MemoryFirst
+                } else {
+                    crate::config::ContextStrategy::FullHistory
+                }
+            }
+        };
+        let memory_first = effective_strategy == crate::config::ContextStrategy::MemoryFirst;
+
+        let system_prompt = input
+            .messages
+            .first()
+            .filter(|m| m.role == Role::System)
+            .map_or("", |m| m.content.as_str());
+
+        let digest_tokens = memory_state
+            .compaction
+            .cached_session_digest
+            .as_ref()
+            .map_or(0, |(_, tokens)| *tokens);
+
+        let graph_enabled = memory_state.extraction.graph_config.enabled;
+
+        let alloc = budget.allocate_with_opts(
+            system_prompt,
+            &input.skill_state.last_skills_prompt,
+            &tc,
+            graph_enabled,
+            digest_tokens,
+            memory_first,
+        );
+
+        let correction_params = input
+            .learning_engine
+            .config
+            .as_ref()
+            .filter(|c| c.correction_detection)
+            .map(|c| {
+                (
+                    c.correction_recall_limit as usize,
+                    c.correction_min_similarity,
+                )
+            });
+        let (recall_limit, min_sim) = correction_params.unwrap_or((3, 0.75));
+
+        let router = input.context_manager.build_router();
+        let router_ref: &dyn zeph_memory::AsyncMemoryRouter = router.as_ref();
+        let query = input.query;
+
+        let mut fetchers: FuturesUnordered<CtxFuture<'_>> = FuturesUnordered::new();
+
+        tracing::debug!(
+            active_sources = alloc.active_sources(),
+            "context budget allocated"
+        );
+
+        if alloc.summaries > 0 {
+            fetchers.push(Box::pin(async {
+                fetch_summaries(memory_state, alloc.summaries, &tc)
+                    .await
+                    .map(ContextSlot::Summaries)
+            }));
+        }
+        if alloc.cross_session > 0 {
+            fetchers.push(Box::pin(async {
+                fetch_cross_session(memory_state, query, alloc.cross_session, &tc)
+                    .await
+                    .map(ContextSlot::CrossSession)
+            }));
+        }
+        if alloc.semantic_recall > 0 {
+            fetchers.push(Box::pin(async {
+                fetch_semantic_recall(
+                    memory_state,
+                    query,
+                    alloc.semantic_recall,
+                    &tc,
+                    Some(router_ref),
+                )
+                .await
+                .map(|(msg, score)| ContextSlot::SemanticRecall(msg, score))
+            }));
+            fetchers.push(Box::pin(async {
+                fetch_document_rag(memory_state, query, alloc.semantic_recall, &tc)
+                    .await
+                    .map(ContextSlot::DocumentRag)
+            }));
+        }
+        // Corrections are safety-critical and never budget-gated.
+        fetchers.push(Box::pin(async {
+            fetch_corrections(memory_state, query, recall_limit, min_sim)
+                .await
+                .map(ContextSlot::Corrections)
+        }));
+        if alloc.code_context > 0 {
+            let index = input.index;
+            fetchers.push(Box::pin(async {
+                index
+                    .fetch_code_rag(query, alloc.code_context)
+                    .await
+                    .map(ContextSlot::CodeContext)
+            }));
+        }
+        if alloc.graph_facts > 0 {
+            fetchers.push(Box::pin(async {
+                fetch_graph_facts(memory_state, query, alloc.graph_facts, &tc)
+                    .await
+                    .map(ContextSlot::GraphFacts)
+            }));
+        }
+        if memory_state.extraction.persona_config.context_budget_tokens > 0 {
+            fetchers.push(Box::pin(async {
+                let persona_budget = memory_state.extraction.persona_config.context_budget_tokens;
+                fetch_persona_facts(memory_state, persona_budget, &tc)
+                    .await
+                    .map(ContextSlot::PersonaFacts)
+            }));
+        }
+        if memory_state
+            .extraction
+            .trajectory_config
+            .context_budget_tokens
+            > 0
+        {
+            fetchers.push(Box::pin(async {
+                let tbudget = memory_state
+                    .extraction
+                    .trajectory_config
+                    .context_budget_tokens;
+                fetch_trajectory_hints(memory_state, tbudget, &tc)
+                    .await
+                    .map(ContextSlot::TrajectoryHints)
+            }));
+        }
+        if memory_state.subsystems.tree_config.context_budget_tokens > 0 {
+            fetchers.push(Box::pin(async {
+                let tbudget = memory_state.subsystems.tree_config.context_budget_tokens;
+                fetch_tree_memory(memory_state, tbudget, &tc)
+                    .await
+                    .map(ContextSlot::TreeMemory)
+            }));
+        }
+
+        let mut prepared = PreparedContext {
+            graph_facts: None,
+            doc_rag: None,
+            corrections: None,
+            recall: None,
+            recall_confidence: None,
+            cross_session: None,
+            summaries: None,
+            code_context: None,
+            persona_facts: None,
+            trajectory_hints: None,
+            tree_memory: None,
+            memory_first,
+            recent_history_budget: alloc.recent_history,
+        };
+
+        while let Some(result) = fetchers.next().await {
+            match result {
+                Ok(slot) => match slot {
+                    ContextSlot::Summaries(msg) => prepared.summaries = msg,
+                    ContextSlot::CrossSession(msg) => prepared.cross_session = msg,
+                    ContextSlot::SemanticRecall(msg, score) => {
+                        prepared.recall = msg;
+                        prepared.recall_confidence = score;
+                    }
+                    ContextSlot::DocumentRag(msg) => prepared.doc_rag = msg,
+                    ContextSlot::Corrections(msg) => prepared.corrections = msg,
+                    ContextSlot::CodeContext(text) => prepared.code_context = text,
+                    ContextSlot::GraphFacts(msg) => prepared.graph_facts = msg,
+                    ContextSlot::PersonaFacts(msg) => prepared.persona_facts = msg,
+                    ContextSlot::TrajectoryHints(msg) => prepared.trajectory_hints = msg,
+                    ContextSlot::TreeMemory(msg) => prepared.tree_memory = msg,
+                },
+                Err(e) => return Err(e),
+            }
+        }
+
+        Ok(prepared)
+    }
+}
+
+pub(super) fn effective_recall_timeout_ms(configured: u64) -> u64 {
+    if configured == 0 {
+        tracing::warn!(
+            "recall_timeout_ms is 0, which would disable spreading activation recall; \
+             clamping to 100ms"
+        );
+        100
+    } else {
+        configured
+    }
+}
+
+pub(super) async fn fetch_graph_facts(
+    memory_state: &MemoryState,
+    query: &str,
+    budget_tokens: usize,
+    tc: &TokenCounter,
+) -> Result<Option<Message>, AgentError> {
+    if budget_tokens == 0 || !memory_state.extraction.graph_config.enabled {
+        return Ok(None);
+    }
+    let Some(ref memory) = memory_state.persistence.memory else {
+        return Ok(None);
+    };
+    let recall_limit = memory_state.extraction.graph_config.recall_limit;
+    let temporal_decay_rate = memory_state.extraction.graph_config.temporal_decay_rate;
+    let edge_types = zeph_memory::classify_graph_subgraph(query);
+    let sa_config = &memory_state.extraction.graph_config.spreading_activation;
+
+    let mut body = String::from(GRAPH_FACTS_PREFIX);
+    let mut tokens_so_far = tc.count_tokens(&body);
+
+    if sa_config.enabled {
+        let sa_params = zeph_memory::graph::SpreadingActivationParams {
+            decay_lambda: sa_config.decay_lambda,
+            max_hops: sa_config.max_hops,
+            activation_threshold: sa_config.activation_threshold,
+            inhibition_threshold: sa_config.inhibition_threshold,
+            max_activated_nodes: sa_config.max_activated_nodes,
+            temporal_decay_rate,
+            seed_structural_weight: sa_config.seed_structural_weight,
+            seed_community_cap: sa_config.seed_community_cap,
+        };
+        let timeout_ms = effective_recall_timeout_ms(sa_config.recall_timeout_ms);
+        let recall_fut = memory.recall_graph_activated(query, recall_limit, sa_params, &edge_types);
+        let activated_facts =
+            match tokio::time::timeout(std::time::Duration::from_millis(timeout_ms), recall_fut)
+                .await
+            {
+                Ok(Ok(facts)) => facts,
+                Ok(Err(e)) => {
+                    tracing::warn!("spreading activation recall failed: {e:#}");
+                    Vec::new()
+                }
+                Err(_) => {
+                    tracing::warn!("spreading activation recall timed out ({timeout_ms}ms)");
+                    Vec::new()
+                }
+            };
+
+        if activated_facts.is_empty() {
+            return Ok(None);
+        }
+
+        for f in &activated_facts {
+            let fact_text = f.edge.fact.replace(['\n', '\r', '<', '>'], " ");
+            let line = format!(
+                "- {} (confidence: {:.2}, activation: {:.2})\n",
+                fact_text, f.edge.confidence, f.activation_score
+            );
+            let line_tokens = tc.count_tokens(&line);
+            if tokens_so_far + line_tokens > budget_tokens {
+                break;
+            }
+            body.push_str(&line);
+            tokens_so_far += line_tokens;
+        }
+    } else {
+        let max_hops = memory_state.extraction.graph_config.max_hops;
+        let facts = memory
+            .recall_graph(
+                query,
+                recall_limit,
+                max_hops,
+                None,
+                temporal_decay_rate,
+                &edge_types,
+            )
+            .await
+            .map_err(|e| {
+                tracing::warn!("graph recall failed: {e:#}");
+                AgentError::Memory(e)
+            })?;
+
+        if facts.is_empty() {
+            return Ok(None);
+        }
+
+        for f in &facts {
+            let fact_text = f.fact.replace(['\n', '\r', '<', '>'], " ");
+            let line = format!("- {} (confidence: {:.2})\n", fact_text, f.confidence);
+            let line_tokens = tc.count_tokens(&line);
+            if tokens_so_far + line_tokens > budget_tokens {
+                break;
+            }
+            body.push_str(&line);
+            tokens_so_far += line_tokens;
+        }
+    }
+
+    if body == GRAPH_FACTS_PREFIX {
+        return Ok(None);
+    }
+
+    Ok(Some(Message::from_legacy(Role::System, body)))
+}
+
+pub(super) async fn fetch_persona_facts(
+    memory_state: &MemoryState,
+    budget_tokens: usize,
+    tc: &TokenCounter,
+) -> Result<Option<Message>, AgentError> {
+    if budget_tokens == 0 || !memory_state.extraction.persona_config.enabled {
+        return Ok(None);
+    }
+    let Some(ref memory) = memory_state.persistence.memory else {
+        return Ok(None);
+    };
+
+    let min_confidence = memory_state.extraction.persona_config.min_confidence;
+    let facts = memory.sqlite().load_persona_facts(min_confidence).await?;
+
+    if facts.is_empty() {
+        return Ok(None);
+    }
+
+    let mut body = String::from(super::PERSONA_PREFIX);
+    let mut tokens_so_far = tc.count_tokens(&body);
+
+    for fact in &facts {
+        let line = format!("[{}] {}\n", fact.category, fact.content);
+        let line_tokens = tc.count_tokens(&line);
+        if tokens_so_far + line_tokens > budget_tokens {
+            break;
+        }
+        body.push_str(&line);
+        tokens_so_far += line_tokens;
+    }
+
+    if body == super::PERSONA_PREFIX {
+        return Ok(None);
+    }
+
+    Ok(Some(Message::from_legacy(Role::System, body)))
+}
+
+pub(super) async fn fetch_trajectory_hints(
+    memory_state: &MemoryState,
+    budget_tokens: usize,
+    tc: &TokenCounter,
+) -> Result<Option<Message>, AgentError> {
+    if budget_tokens == 0 || !memory_state.extraction.trajectory_config.enabled {
+        return Ok(None);
+    }
+    let Some(ref memory) = memory_state.persistence.memory else {
+        return Ok(None);
+    };
+
+    let top_k = memory_state.extraction.trajectory_config.recall_top_k;
+    let min_conf = memory_state.extraction.trajectory_config.min_confidence;
+    let entries = memory
+        .sqlite()
+        .load_trajectory_entries(Some("procedural"), top_k)
+        .await?;
+
+    if entries.is_empty() {
+        return Ok(None);
+    }
+
+    let mut body = String::from(super::TRAJECTORY_PREFIX);
+    let mut tokens_so_far = tc.count_tokens(&body);
+
+    for entry in entries
+        .iter()
+        .filter(|e| e.confidence >= min_conf)
+        .take(top_k)
+    {
+        let line = format!("- {}: {}\n", entry.intent, entry.outcome);
+        let line_tokens = tc.count_tokens(&line);
+        if tokens_so_far + line_tokens > budget_tokens {
+            break;
+        }
+        body.push_str(&line);
+        tokens_so_far += line_tokens;
+    }
+
+    if body == super::TRAJECTORY_PREFIX {
+        return Ok(None);
+    }
+
+    Ok(Some(Message::from_legacy(Role::System, body)))
+}
+
+pub(super) async fn fetch_tree_memory(
+    memory_state: &MemoryState,
+    budget_tokens: usize,
+    tc: &TokenCounter,
+) -> Result<Option<Message>, AgentError> {
+    if budget_tokens == 0 || !memory_state.subsystems.tree_config.enabled {
+        return Ok(None);
+    }
+    let Some(ref memory) = memory_state.persistence.memory else {
+        return Ok(None);
+    };
+
+    let top_k = memory_state.subsystems.tree_config.recall_top_k;
+    let nodes = memory.sqlite().load_tree_level(1, top_k).await?;
+
+    if nodes.is_empty() {
+        return Ok(None);
+    }
+
+    let mut body = String::from(super::TREE_MEMORY_PREFIX);
+    let mut tokens_so_far = tc.count_tokens(&body);
+
+    for node in nodes.iter().take(top_k) {
+        let line = format!("- {}\n", node.content);
+        let line_tokens = tc.count_tokens(&line);
+        if tokens_so_far + line_tokens > budget_tokens {
+            break;
+        }
+        body.push_str(&line);
+        tokens_so_far += line_tokens;
+    }
+
+    if body == super::TREE_MEMORY_PREFIX {
+        return Ok(None);
+    }
+
+    Ok(Some(Message::from_legacy(Role::System, body)))
+}
+
+pub(super) fn format_correction_note(_original_output: &str, correction_text: &str) -> String {
+    // Never replay the faulty assistant/tool output itself into future prompts.
+    format!(
+        "- Past user correction: \"{}\"",
+        super::truncate_chars(&scrub_content(correction_text), 200)
+    )
+}
+
+pub(super) async fn fetch_corrections(
+    memory_state: &MemoryState,
+    query: &str,
+    limit: usize,
+    min_score: f32,
+) -> Result<Option<Message>, AgentError> {
+    let Some(ref memory) = memory_state.persistence.memory else {
+        return Ok(None);
+    };
+    let corrections = memory
+        .retrieve_similar_corrections(query, limit, min_score)
+        .await
+        .unwrap_or_default();
+    if corrections.is_empty() {
+        return Ok(None);
+    }
+    let mut text = String::from(CORRECTIONS_PREFIX);
+    for c in &corrections {
+        text.push_str(&format_correction_note(
+            &c.original_output,
+            &c.correction_text,
+        ));
+        text.push('\n');
+    }
+    Ok(Some(Message::from_legacy(Role::System, text)))
+}
+
+pub(super) async fn fetch_semantic_recall(
+    memory_state: &MemoryState,
+    query: &str,
+    token_budget: usize,
+    tc: &TokenCounter,
+    router: Option<&dyn zeph_memory::AsyncMemoryRouter>,
+) -> Result<(Option<Message>, Option<f32>), AgentError> {
+    let Some(memory) = &memory_state.persistence.memory else {
+        return Ok((None, None));
+    };
+    if memory_state.persistence.recall_limit == 0 || token_budget == 0 {
+        return Ok((None, None));
+    }
+
+    let recalled = if let Some(r) = router {
+        memory
+            .recall_routed_async(query, memory_state.persistence.recall_limit, None, r)
+            .await?
+    } else {
+        memory
+            .recall(query, memory_state.persistence.recall_limit, None)
+            .await?
+    };
+    if recalled.is_empty() {
+        return Ok((None, None));
+    }
+
+    let top_score = recalled.first().map(|r| r.score);
+
+    let mut recall_text = String::with_capacity(token_budget * 3);
+    recall_text.push_str(RECALL_PREFIX);
+    let mut tokens_used = tc.count_tokens(&recall_text);
+
+    for item in &recalled {
+        if item.message.content.starts_with("[skipped]")
+            || item.message.content.starts_with("[stopped]")
+        {
+            continue;
+        }
+        let role_label = match item.message.role {
+            Role::User => "user",
+            Role::Assistant => "assistant",
+            Role::System => "system",
+        };
+        let entry = format!("- [{}] {}\n", role_label, item.message.content);
+        let entry_tokens = tc.count_tokens(&entry);
+        if tokens_used + entry_tokens > token_budget {
+            break;
+        }
+        recall_text.push_str(&entry);
+        tokens_used += entry_tokens;
+    }
+
+    if tokens_used > tc.count_tokens(RECALL_PREFIX) {
+        Ok((
+            Some(Message::from_parts(
+                Role::System,
+                vec![MessagePart::Recall { text: recall_text }],
+            )),
+            top_score,
+        ))
+    } else {
+        Ok((None, None))
+    }
+}
+
+pub(super) async fn fetch_document_rag(
+    memory_state: &MemoryState,
+    query: &str,
+    token_budget: usize,
+    tc: &TokenCounter,
+) -> Result<Option<Message>, AgentError> {
+    if !memory_state.extraction.document_config.rag_enabled || token_budget == 0 {
+        return Ok(None);
+    }
+    let Some(memory) = &memory_state.persistence.memory else {
+        return Ok(None);
+    };
+
+    let collection = &memory_state.extraction.document_config.collection;
+    let top_k = memory_state.extraction.document_config.top_k;
+    let points = memory
+        .search_document_collection(collection, query, top_k)
+        .await?;
+    if points.is_empty() {
+        return Ok(None);
+    }
+
+    let mut text = String::from(DOCUMENT_RAG_PREFIX);
+    let mut tokens_used = tc.count_tokens(&text);
+
+    for point in &points {
+        let chunk = point
+            .payload
+            .get("text")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        if chunk.is_empty() {
+            continue;
+        }
+        let entry = format!("{chunk}\n");
+        let cost = tc.count_tokens(&entry);
+        if tokens_used + cost > token_budget {
+            break;
+        }
+        text.push_str(&entry);
+        tokens_used += cost;
+    }
+
+    if tokens_used > tc.count_tokens(DOCUMENT_RAG_PREFIX) {
+        Ok(Some(Message {
+            role: Role::System,
+            content: text,
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        }))
+    } else {
+        Ok(None)
+    }
+}
+
+pub(super) async fn fetch_summaries(
+    memory_state: &MemoryState,
+    token_budget: usize,
+    tc: &TokenCounter,
+) -> Result<Option<Message>, AgentError> {
+    let (Some(memory), Some(cid)) = (
+        &memory_state.persistence.memory,
+        memory_state.persistence.conversation_id,
+    ) else {
+        return Ok(None);
+    };
+    if token_budget == 0 {
+        return Ok(None);
+    }
+
+    let summaries = memory.load_summaries(cid).await?;
+    if summaries.is_empty() {
+        return Ok(None);
+    }
+
+    let mut summary_text = String::from(SUMMARY_PREFIX);
+    let mut tokens_used = tc.count_tokens(&summary_text);
+
+    for summary in summaries.iter().rev() {
+        let first = summary.first_message_id.map_or(0, |m| m.0);
+        let last = summary.last_message_id.map_or(0, |m| m.0);
+        let entry = format!("- Messages {first}-{last}: {}\n", summary.content);
+        let cost = tc.count_tokens(&entry);
+        if tokens_used + cost > token_budget {
+            break;
+        }
+        summary_text.push_str(&entry);
+        tokens_used += cost;
+    }
+
+    if tokens_used > tc.count_tokens(SUMMARY_PREFIX) {
+        Ok(Some(Message::from_parts(
+            Role::System,
+            vec![MessagePart::Summary { text: summary_text }],
+        )))
+    } else {
+        Ok(None)
+    }
+}
+
+pub(super) async fn fetch_cross_session(
+    memory_state: &MemoryState,
+    query: &str,
+    token_budget: usize,
+    tc: &TokenCounter,
+) -> Result<Option<Message>, AgentError> {
+    let (Some(memory), Some(cid)) = (
+        &memory_state.persistence.memory,
+        memory_state.persistence.conversation_id,
+    ) else {
+        return Ok(None);
+    };
+    if token_budget == 0 {
+        return Ok(None);
+    }
+
+    let threshold = memory_state.persistence.cross_session_score_threshold;
+    let results: Vec<_> = memory
+        .search_session_summaries(query, 5, Some(cid))
+        .await?
+        .into_iter()
+        .filter(|r| r.score >= threshold)
+        .collect();
+    if results.is_empty() {
+        return Ok(None);
+    }
+
+    let mut text = String::from(CROSS_SESSION_PREFIX);
+    let mut tokens_used = tc.count_tokens(&text);
+
+    for item in &results {
+        let entry = format!("- {}\n", item.summary_text);
+        let cost = tc.count_tokens(&entry);
+        if tokens_used + cost > token_budget {
+            break;
+        }
+        text.push_str(&entry);
+        tokens_used += cost;
+    }
+
+    if tokens_used > tc.count_tokens(CROSS_SESSION_PREFIX) {
+        Ok(Some(Message::from_parts(
+            Role::System,
+            vec![MessagePart::CrossSession { text }],
+        )))
+    } else {
+        Ok(None)
+    }
+}

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -1,18 +1,11 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::borrow::Cow;
 use std::fmt::Write;
-use std::future::Future;
 use std::path::PathBuf;
-use std::pin::Pin;
 use std::sync::Arc;
 
-use futures::StreamExt as _;
-use futures::stream::FuturesUnordered;
-
 use zeph_llm::provider::{LlmProvider, Message, MessageMetadata, MessagePart, Role};
-use zeph_memory::TokenCounter;
 use zeph_skills::ScoredMatch;
 use zeph_skills::loader::SkillMeta;
 use zeph_skills::prompt::{format_skills_catalog, format_skills_prompt_compact};
@@ -20,10 +13,9 @@ use zeph_skills::prompt::{format_skills_catalog, format_skills_prompt_compact};
 use super::super::LSP_NOTE_PREFIX;
 use super::super::{
     Agent, CODE_CONTEXT_PREFIX, CORRECTIONS_PREFIX, CROSS_SESSION_PREFIX, DOCUMENT_RAG_PREFIX,
-    GRAPH_FACTS_PREFIX, MemoryState, RECALL_PREFIX, SESSION_DIGEST_PREFIX, SUMMARY_PREFIX, Skill,
+    GRAPH_FACTS_PREFIX, RECALL_PREFIX, SESSION_DIGEST_PREFIX, SUMMARY_PREFIX, Skill,
     format_skills_prompt,
 };
-use super::ContextSlot;
 use crate::channel::Channel;
 use crate::context::build_system_prompt_with_instructions;
 use crate::redact::scrub_content;
@@ -98,298 +90,6 @@ impl<C: Channel> Agent<C> {
         self.remove_by_prefix(Role::System, LSP_NOTE_PREFIX);
     }
 
-    fn effective_recall_timeout_ms(configured: u64) -> u64 {
-        if configured == 0 {
-            tracing::warn!(
-                "recall_timeout_ms is 0, which would disable spreading activation recall; \
-                 clamping to 100ms"
-            );
-            100
-        } else {
-            configured
-        }
-    }
-
-    pub(super) async fn fetch_graph_facts(
-        memory_state: &MemoryState,
-        query: &str,
-        budget_tokens: usize,
-        tc: &TokenCounter,
-    ) -> Result<Option<Message>, super::super::error::AgentError> {
-        if budget_tokens == 0 || !memory_state.extraction.graph_config.enabled {
-            return Ok(None);
-        }
-        let Some(ref memory) = memory_state.persistence.memory else {
-            return Ok(None);
-        };
-        let recall_limit = memory_state.extraction.graph_config.recall_limit;
-        let temporal_decay_rate = memory_state.extraction.graph_config.temporal_decay_rate;
-        let edge_types = zeph_memory::classify_graph_subgraph(query);
-        let sa_config = &memory_state.extraction.graph_config.spreading_activation;
-
-        let mut body = String::from(GRAPH_FACTS_PREFIX);
-        let mut tokens_so_far = tc.count_tokens(&body);
-
-        if sa_config.enabled {
-            // Build SpreadingActivationParams from config (zeph-memory has no zeph-config dep).
-            let sa_params = zeph_memory::graph::SpreadingActivationParams {
-                decay_lambda: sa_config.decay_lambda,
-                max_hops: sa_config.max_hops,
-                activation_threshold: sa_config.activation_threshold,
-                inhibition_threshold: sa_config.inhibition_threshold,
-                max_activated_nodes: sa_config.max_activated_nodes,
-                temporal_decay_rate,
-                seed_structural_weight: sa_config.seed_structural_weight,
-                seed_community_cap: sa_config.seed_community_cap,
-            };
-            // Spreading activation path: wrap in a configurable timeout to bound latency.
-            let timeout_ms = Self::effective_recall_timeout_ms(sa_config.recall_timeout_ms);
-            let recall_fut =
-                memory.recall_graph_activated(query, recall_limit, sa_params, &edge_types);
-            let activated_facts = match tokio::time::timeout(
-                std::time::Duration::from_millis(timeout_ms),
-                recall_fut,
-            )
-            .await
-            {
-                Ok(Ok(facts)) => facts,
-                Ok(Err(e)) => {
-                    tracing::warn!("spreading activation recall failed: {e:#}");
-                    Vec::new()
-                }
-                Err(_) => {
-                    tracing::warn!("spreading activation recall timed out ({timeout_ms}ms)");
-                    Vec::new()
-                }
-            };
-
-            if activated_facts.is_empty() {
-                return Ok(None);
-            }
-
-            for f in &activated_facts {
-                let fact_text = f.edge.fact.replace(['\n', '\r', '<', '>'], " ");
-                let line = format!(
-                    "- {} (confidence: {:.2}, activation: {:.2})\n",
-                    fact_text, f.edge.confidence, f.activation_score
-                );
-                let line_tokens = tc.count_tokens(&line);
-                if tokens_so_far + line_tokens > budget_tokens {
-                    break;
-                }
-                body.push_str(&line);
-                tokens_so_far += line_tokens;
-            }
-        } else {
-            // BFS path (default when spreading_activation.enabled = false).
-            let max_hops = memory_state.extraction.graph_config.max_hops;
-            let facts = memory
-                .recall_graph(
-                    query,
-                    recall_limit,
-                    max_hops,
-                    None,
-                    temporal_decay_rate,
-                    &edge_types,
-                )
-                .await
-                .map_err(|e| {
-                    tracing::warn!("graph recall failed: {e:#}");
-                    super::super::error::AgentError::Memory(e)
-                })?;
-
-            if facts.is_empty() {
-                return Ok(None);
-            }
-
-            for f in &facts {
-                // Strip newlines and angle-brackets from stored entity names/relations
-                // to prevent graph-stored injection strings from escaping into the prompt.
-                let fact_text = f.fact.replace(['\n', '\r', '<', '>'], " ");
-                let line = format!("- {} (confidence: {:.2})\n", fact_text, f.confidence);
-                let line_tokens = tc.count_tokens(&line);
-                if tokens_so_far + line_tokens > budget_tokens {
-                    break;
-                }
-                body.push_str(&line);
-                tokens_so_far += line_tokens;
-            }
-        }
-
-        if body == GRAPH_FACTS_PREFIX {
-            return Ok(None);
-        }
-
-        Ok(Some(Message::from_legacy(Role::System, body)))
-    }
-
-    /// Fetch persona facts from `SQLite` and format as a system message.
-    ///
-    /// Injects facts after the system prompt (position 1 in message list), giving the LLM
-    /// supplementary user context without overriding the authoritative system prompt.
-    pub(super) async fn fetch_persona_facts(
-        memory_state: &MemoryState,
-        budget_tokens: usize,
-        tc: &TokenCounter,
-    ) -> Result<Option<Message>, super::super::error::AgentError> {
-        if budget_tokens == 0 || !memory_state.extraction.persona_config.enabled {
-            return Ok(None);
-        }
-        let Some(ref memory) = memory_state.persistence.memory else {
-            return Ok(None);
-        };
-
-        let min_confidence = memory_state.extraction.persona_config.min_confidence;
-        let facts = memory.sqlite().load_persona_facts(min_confidence).await?;
-
-        if facts.is_empty() {
-            return Ok(None);
-        }
-
-        let mut body = String::from(super::PERSONA_PREFIX);
-        let mut tokens_so_far = tc.count_tokens(&body);
-
-        for fact in &facts {
-            let line = format!("[{}] {}\n", fact.category, fact.content);
-            let line_tokens = tc.count_tokens(&line);
-            if tokens_so_far + line_tokens > budget_tokens {
-                break;
-            }
-            body.push_str(&line);
-            tokens_so_far += line_tokens;
-        }
-
-        if body == super::PERSONA_PREFIX {
-            return Ok(None);
-        }
-
-        Ok(Some(Message::from_legacy(Role::System, body)))
-    }
-
-    pub(super) async fn fetch_trajectory_hints(
-        memory_state: &MemoryState,
-        budget_tokens: usize,
-        tc: &TokenCounter,
-    ) -> Result<Option<Message>, super::super::error::AgentError> {
-        if budget_tokens == 0 || !memory_state.extraction.trajectory_config.enabled {
-            return Ok(None);
-        }
-        let Some(ref memory) = memory_state.persistence.memory else {
-            return Ok(None);
-        };
-
-        let top_k = memory_state.extraction.trajectory_config.recall_top_k;
-        let min_conf = memory_state.extraction.trajectory_config.min_confidence;
-        let entries = memory
-            .sqlite()
-            .load_trajectory_entries(Some("procedural"), top_k)
-            .await?;
-
-        if entries.is_empty() {
-            return Ok(None);
-        }
-
-        let mut body = String::from(super::TRAJECTORY_PREFIX);
-        let mut tokens_so_far = tc.count_tokens(&body);
-
-        for entry in entries
-            .iter()
-            .filter(|e| e.confidence >= min_conf)
-            .take(top_k)
-        {
-            let line = format!("- {}: {}\n", entry.intent, entry.outcome);
-            let line_tokens = tc.count_tokens(&line);
-            if tokens_so_far + line_tokens > budget_tokens {
-                break;
-            }
-            body.push_str(&line);
-            tokens_so_far += line_tokens;
-        }
-
-        if body == super::TRAJECTORY_PREFIX {
-            return Ok(None);
-        }
-
-        Ok(Some(Message::from_legacy(Role::System, body)))
-    }
-
-    pub(super) async fn fetch_tree_memory(
-        memory_state: &MemoryState,
-        budget_tokens: usize,
-        tc: &TokenCounter,
-    ) -> Result<Option<Message>, super::super::error::AgentError> {
-        if budget_tokens == 0 || !memory_state.subsystems.tree_config.enabled {
-            return Ok(None);
-        }
-        let Some(ref memory) = memory_state.persistence.memory else {
-            return Ok(None);
-        };
-
-        let top_k = memory_state.subsystems.tree_config.recall_top_k;
-        // Load level-1+ nodes (consolidated summaries) — level 0 are raw leaves.
-        let nodes = memory.sqlite().load_tree_level(1, top_k).await?;
-
-        if nodes.is_empty() {
-            return Ok(None);
-        }
-
-        let mut body = String::from(super::TREE_MEMORY_PREFIX);
-        let mut tokens_so_far = tc.count_tokens(&body);
-
-        for node in nodes.iter().take(top_k) {
-            let line = format!("- {}\n", node.content);
-            let line_tokens = tc.count_tokens(&line);
-            if tokens_so_far + line_tokens > budget_tokens {
-                break;
-            }
-            body.push_str(&line);
-            tokens_so_far += line_tokens;
-        }
-
-        if body == super::TREE_MEMORY_PREFIX {
-            return Ok(None);
-        }
-
-        Ok(Some(Message::from_legacy(Role::System, body)))
-    }
-
-    pub(super) fn format_correction_note(_original_output: &str, correction_text: &str) -> String {
-        // Never replay the faulty assistant/tool output itself into future prompts.
-        // If it contained a bad command with an absolute path, path redaction would turn it
-        // into a literal placeholder like `[PATH]` that the model may copy verbatim.
-        format!(
-            "- Past user correction: \"{}\"",
-            super::truncate_chars(&scrub_content(correction_text), 200)
-        )
-    }
-
-    async fn fetch_corrections(
-        memory_state: &MemoryState,
-        query: &str,
-        limit: usize,
-        min_score: f32,
-    ) -> Result<Option<Message>, super::super::error::AgentError> {
-        let Some(ref memory) = memory_state.persistence.memory else {
-            return Ok(None);
-        };
-        let corrections = memory
-            .retrieve_similar_corrections(query, limit, min_score)
-            .await
-            .unwrap_or_default();
-        if corrections.is_empty() {
-            return Ok(None);
-        }
-        let mut text = String::from(CORRECTIONS_PREFIX);
-        for c in &corrections {
-            text.push_str(&Self::format_correction_note(
-                &c.original_output,
-                &c.correction_text,
-            ));
-            text.push('\n');
-        }
-        Ok(Some(Message::from_legacy(Role::System, text)))
-    }
-
     #[cfg(test)]
     pub(in crate::agent) async fn inject_semantic_recall(
         &mut self,
@@ -398,7 +98,7 @@ impl<C: Channel> Agent<C> {
     ) -> Result<(), super::super::error::AgentError> {
         self.remove_recall_messages();
 
-        let (msg, _score) = Self::fetch_semantic_recall(
+        let (msg, _score) = super::assembler::fetch_semantic_recall(
             &self.memory_state,
             query,
             token_budget,
@@ -413,75 +113,6 @@ impl<C: Channel> Agent<C> {
         }
 
         Ok(())
-    }
-
-    async fn fetch_semantic_recall(
-        memory_state: &MemoryState,
-        query: &str,
-        token_budget: usize,
-        tc: &TokenCounter,
-        router: Option<&dyn zeph_memory::AsyncMemoryRouter>,
-    ) -> Result<(Option<Message>, Option<f32>), super::super::error::AgentError> {
-        let Some(memory) = &memory_state.persistence.memory else {
-            return Ok((None, None));
-        };
-        if memory_state.persistence.recall_limit == 0 || token_budget == 0 {
-            return Ok((None, None));
-        }
-
-        let recalled = if let Some(r) = router {
-            memory
-                .recall_routed_async(query, memory_state.persistence.recall_limit, None, r)
-                .await?
-        } else {
-            memory
-                .recall(query, memory_state.persistence.recall_limit, None)
-                .await?
-        };
-        if recalled.is_empty() {
-            return Ok((None, None));
-        }
-
-        let top_score = recalled.first().map(|r| r.score);
-
-        let mut recall_text = String::with_capacity(token_budget * 3);
-        recall_text.push_str(RECALL_PREFIX);
-        let mut tokens_used = tc.count_tokens(&recall_text);
-
-        for item in &recalled {
-            // Filter out internal utility-policy markers so they never surface as recalled
-            // context — a [skipped] bash ToolResult in Qdrant would make the LLM believe the
-            // tool is blocked and prevent re-dispatch after a Retrieve gate (#2620).
-            if item.message.content.starts_with("[skipped]")
-                || item.message.content.starts_with("[stopped]")
-            {
-                continue;
-            }
-            let role_label = match item.message.role {
-                Role::User => "user",
-                Role::Assistant => "assistant",
-                Role::System => "system",
-            };
-            let entry = format!("- [{}] {}\n", role_label, item.message.content);
-            let entry_tokens = tc.count_tokens(&entry);
-            if tokens_used + entry_tokens > token_budget {
-                break;
-            }
-            recall_text.push_str(&entry);
-            tokens_used += entry_tokens;
-        }
-
-        if tokens_used > tc.count_tokens(RECALL_PREFIX) {
-            Ok((
-                Some(Message::from_parts(
-                    Role::System,
-                    vec![MessagePart::Recall { text: recall_text }],
-                )),
-                top_score,
-            ))
-        } else {
-            Ok((None, None))
-        }
     }
 
     pub(in crate::agent) fn remove_code_context_messages(&mut self) {
@@ -676,61 +307,6 @@ impl<C: Channel> Agent<C> {
         Ok((old_conversation_id, new_conversation_id))
     }
 
-    async fn fetch_document_rag(
-        memory_state: &MemoryState,
-        query: &str,
-        token_budget: usize,
-        tc: &TokenCounter,
-    ) -> Result<Option<Message>, super::super::error::AgentError> {
-        if !memory_state.extraction.document_config.rag_enabled || token_budget == 0 {
-            return Ok(None);
-        }
-        let Some(memory) = &memory_state.persistence.memory else {
-            return Ok(None);
-        };
-
-        let collection = &memory_state.extraction.document_config.collection;
-        let top_k = memory_state.extraction.document_config.top_k;
-        let points = memory
-            .search_document_collection(collection, query, top_k)
-            .await?;
-        if points.is_empty() {
-            return Ok(None);
-        }
-
-        let mut text = String::from(DOCUMENT_RAG_PREFIX);
-        let mut tokens_used = tc.count_tokens(&text);
-
-        for point in &points {
-            let chunk = point
-                .payload
-                .get("text")
-                .and_then(|v| v.as_str())
-                .unwrap_or_default();
-            if chunk.is_empty() {
-                continue;
-            }
-            let entry = format!("{chunk}\n");
-            let cost = tc.count_tokens(&entry);
-            if tokens_used + cost > token_budget {
-                break;
-            }
-            text.push_str(&entry);
-            tokens_used += cost;
-        }
-
-        if tokens_used > tc.count_tokens(DOCUMENT_RAG_PREFIX) {
-            Ok(Some(Message {
-                role: Role::System,
-                content: text,
-                parts: vec![],
-                metadata: MessageMetadata::default(),
-            }))
-        } else {
-            Ok(None)
-        }
-    }
-
     #[cfg(test)]
     pub(super) async fn inject_cross_session_context(
         &mut self,
@@ -739,7 +315,7 @@ impl<C: Channel> Agent<C> {
     ) -> Result<(), super::super::error::AgentError> {
         self.remove_cross_session_messages();
 
-        if let Some(msg) = Self::fetch_cross_session(
+        if let Some(msg) = super::assembler::fetch_cross_session(
             &self.memory_state,
             query,
             token_budget,
@@ -755,56 +331,6 @@ impl<C: Channel> Agent<C> {
         Ok(())
     }
 
-    async fn fetch_cross_session(
-        memory_state: &MemoryState,
-        query: &str,
-        token_budget: usize,
-        tc: &TokenCounter,
-    ) -> Result<Option<Message>, super::super::error::AgentError> {
-        let (Some(memory), Some(cid)) = (
-            &memory_state.persistence.memory,
-            memory_state.persistence.conversation_id,
-        ) else {
-            return Ok(None);
-        };
-        if token_budget == 0 {
-            return Ok(None);
-        }
-
-        let threshold = memory_state.persistence.cross_session_score_threshold;
-        let results: Vec<_> = memory
-            .search_session_summaries(query, 5, Some(cid))
-            .await?
-            .into_iter()
-            .filter(|r| r.score >= threshold)
-            .collect();
-        if results.is_empty() {
-            return Ok(None);
-        }
-
-        let mut text = String::from(CROSS_SESSION_PREFIX);
-        let mut tokens_used = tc.count_tokens(&text);
-
-        for item in &results {
-            let entry = format!("- {}\n", item.summary_text);
-            let cost = tc.count_tokens(&entry);
-            if tokens_used + cost > token_budget {
-                break;
-            }
-            text.push_str(&entry);
-            tokens_used += cost;
-        }
-
-        if tokens_used > tc.count_tokens(CROSS_SESSION_PREFIX) {
-            Ok(Some(Message::from_parts(
-                Role::System,
-                vec![MessagePart::CrossSession { text }],
-            )))
-        } else {
-            Ok(None)
-        }
-    }
-
     #[cfg(test)]
     pub(super) async fn inject_summaries(
         &mut self,
@@ -812,7 +338,7 @@ impl<C: Channel> Agent<C> {
     ) -> Result<(), super::super::error::AgentError> {
         self.remove_summary_messages();
 
-        if let Some(msg) = Self::fetch_summaries(
+        if let Some(msg) = super::assembler::fetch_summaries(
             &self.memory_state,
             token_budget,
             &self.metrics.token_counter,
@@ -825,51 +351,6 @@ impl<C: Channel> Agent<C> {
         }
 
         Ok(())
-    }
-
-    async fn fetch_summaries(
-        memory_state: &MemoryState,
-        token_budget: usize,
-        tc: &TokenCounter,
-    ) -> Result<Option<Message>, super::super::error::AgentError> {
-        let (Some(memory), Some(cid)) = (
-            &memory_state.persistence.memory,
-            memory_state.persistence.conversation_id,
-        ) else {
-            return Ok(None);
-        };
-        if token_budget == 0 {
-            return Ok(None);
-        }
-
-        let summaries = memory.load_summaries(cid).await?;
-        if summaries.is_empty() {
-            return Ok(None);
-        }
-
-        let mut summary_text = String::from(SUMMARY_PREFIX);
-        let mut tokens_used = tc.count_tokens(&summary_text);
-
-        for summary in summaries.iter().rev() {
-            let first = summary.first_message_id.map_or(0, |m| m.0);
-            let last = summary.last_message_id.map_or(0, |m| m.0);
-            let entry = format!("- Messages {first}-{last}: {}\n", summary.content);
-            let cost = tc.count_tokens(&entry);
-            if tokens_used + cost > token_budget {
-                break;
-            }
-            summary_text.push_str(&entry);
-            tokens_used += cost;
-        }
-
-        if tokens_used > tc.count_tokens(SUMMARY_PREFIX) {
-            Ok(Some(Message::from_parts(
-                Role::System,
-                vec![MessagePart::Summary { text: summary_text }],
-            )))
-        } else {
-            Ok(None)
-        }
     }
 
     pub(super) fn trim_messages_to_budget(&mut self, token_budget: usize) {
@@ -915,59 +396,20 @@ impl<C: Channel> Agent<C> {
         }
     }
 
-    // FuturesUnordered is chosen for extensibility (graph-memory, future sources) rather
-    // than performance. The overhead of ~7 heap allocations is negligible vs. network I/O.
-    #[allow(clippy::too_many_lines)] // parallel context gathering: memory, graph, skill, knowledge — coupled async fanout
+    /// Gather context from all memory sources and inject into the message window.
+    ///
+    /// Delegates concurrent fetching to [`super::assembler::ContextAssembler::gather`] and then
+    /// calls [`Self::apply_prepared_context`] to mutate the message window.
     pub(in crate::agent) async fn prepare_context(
         &mut self,
         query: &str,
     ) -> Result<(), super::super::error::AgentError> {
-        let Some(ref budget) = self.context_manager.budget else {
+        if self.context_manager.budget.is_none() {
             return Ok(());
-        };
+        }
         let _ = self.channel.send_status("recalling context...").await;
 
-        let system_prompt = self.msg.messages.first().map_or("", |m| m.content.as_str());
-        let graph_enabled = self.memory_state.extraction.graph_config.enabled;
-
-        // Resolve effective context strategy (#2288).
-        let effective_strategy = match self.memory_state.compaction.context_strategy {
-            crate::config::ContextStrategy::FullHistory => {
-                crate::config::ContextStrategy::FullHistory
-            }
-            crate::config::ContextStrategy::MemoryFirst => {
-                crate::config::ContextStrategy::MemoryFirst
-            }
-            crate::config::ContextStrategy::Adaptive => {
-                if self.sidequest.turn_counter
-                    >= u64::from(self.memory_state.compaction.crossover_turn_threshold)
-                {
-                    crate::config::ContextStrategy::MemoryFirst
-                } else {
-                    crate::config::ContextStrategy::FullHistory
-                }
-            }
-        };
-        let memory_first = effective_strategy == crate::config::ContextStrategy::MemoryFirst;
-
-        // Pre-count digest tokens so the budget allocator can deduct them before splits.
-        let digest_tokens = self
-            .memory_state
-            .compaction
-            .cached_session_digest
-            .as_ref()
-            .map_or(0, |(_, tokens)| *tokens);
-
-        let alloc = budget.allocate_with_opts(
-            system_prompt,
-            &self.skill_state.last_skills_prompt,
-            &self.metrics.token_counter,
-            graph_enabled,
-            digest_tokens,
-            memory_first,
-        );
-
-        // Remove stale injected messages before concurrent fetch
+        // Remove stale injected messages before concurrent fetch.
         self.remove_session_digest_message();
         self.remove_summary_messages();
         self.remove_cross_session_messages();
@@ -980,180 +422,45 @@ impl<C: Channel> Agent<C> {
         self.remove_trajectory_hints_messages();
         self.remove_tree_memory_messages();
 
-        // Own the query to satisfy Send bounds when agent.run() is spawned
-        let query = query.to_owned();
+        let input = super::assembler::ContextAssemblyInput {
+            memory_state: &self.memory_state,
+            context_manager: &self.context_manager,
+            token_counter: &self.metrics.token_counter,
+            skill_state: &self.skill_state,
+            index: &self.index,
+            learning_engine: &self.learning_engine,
+            sidequest_turn_counter: self.sidequest.turn_counter,
+            messages: &self.msg.messages,
+            query,
+        };
 
-        let correction_params = self
-            .learning_engine
-            .config
-            .as_ref()
-            .filter(|c| c.correction_detection)
-            .map(|c| {
-                (
-                    c.correction_recall_limit as usize,
-                    c.correction_min_similarity,
-                )
-            });
+        let prepared = super::assembler::ContextAssembler::gather(&input)
+            .await
+            .inspect_err(|_| {
+                // Status clear is best-effort; we drop the future intentionally.
+                std::mem::drop(self.channel.send_status(""));
+            })?;
 
-        // Fetch all context sources concurrently via FuturesUnordered.
-        // All immutable field borrows are scoped to the block below, so they are released
-        // before mutable self access (insert, trim, recompute) below.
-        let mut summaries_msg: Option<Message> = None;
-        let mut cross_session_msg: Option<Message> = None;
-        let mut recall_msg: Option<Message> = None;
-        let mut recall_confidence: Option<f32> = None;
-        let mut doc_rag_msg: Option<Message> = None;
-        let mut corrections_msg: Option<Message> = None;
-        let mut code_rag_text: Option<String> = None;
-        let mut graph_facts_msg: Option<Message> = None;
-        let mut persona_facts_msg: Option<Message> = None;
-        let mut trajectory_hints_msg: Option<Message> = None;
-        let mut tree_memory_msg: Option<Message> = None;
+        self.apply_prepared_context(prepared).await;
+        let _ = self.channel.send_status("").await;
+        Ok(())
+    }
 
-        {
-            type CtxFuture<'a> = Pin<
-                Box<
-                    dyn Future<Output = Result<ContextSlot, super::super::error::AgentError>>
-                        + Send
-                        + 'a,
-                >,
-            >;
-
-            let tc = self.metrics.token_counter.clone();
-            let router = self.context_manager.build_router();
-            let router_ref: &dyn zeph_memory::AsyncMemoryRouter = router.as_ref();
-            let memory_state = &self.memory_state;
-            let index = &self.index;
-
-            let (recall_limit, min_sim) = correction_params.unwrap_or((3, 0.75));
-
-            let mut fetchers: FuturesUnordered<CtxFuture<'_>> = FuturesUnordered::new();
-
-            tracing::debug!(
-                active_sources = alloc.active_sources(),
-                "context budget allocated"
-            );
-
-            if alloc.summaries > 0 {
-                fetchers.push(Box::pin(async {
-                    Self::fetch_summaries(memory_state, alloc.summaries, &tc)
-                        .await
-                        .map(ContextSlot::Summaries)
-                }));
-            }
-            if alloc.cross_session > 0 {
-                fetchers.push(Box::pin(async {
-                    Self::fetch_cross_session(memory_state, &query, alloc.cross_session, &tc)
-                        .await
-                        .map(ContextSlot::CrossSession)
-                }));
-            }
-            if alloc.semantic_recall > 0 {
-                fetchers.push(Box::pin(async {
-                    Self::fetch_semantic_recall(
-                        memory_state,
-                        &query,
-                        alloc.semantic_recall,
-                        &tc,
-                        Some(router_ref),
-                    )
-                    .await
-                    .map(|(msg, score)| ContextSlot::SemanticRecall(msg, score))
-                }));
-                fetchers.push(Box::pin(async {
-                    Self::fetch_document_rag(memory_state, &query, alloc.semantic_recall, &tc)
-                        .await
-                        .map(ContextSlot::DocumentRag)
-                }));
-            }
-            // Corrections are safety-critical and never budget-gated.
-            fetchers.push(Box::pin(async {
-                Self::fetch_corrections(memory_state, &query, recall_limit, min_sim)
-                    .await
-                    .map(ContextSlot::Corrections)
-            }));
-            if alloc.code_context > 0 {
-                fetchers.push(Box::pin(async {
-                    index
-                        .fetch_code_rag(&query, alloc.code_context)
-                        .await
-                        .map(ContextSlot::CodeContext)
-                }));
-            }
-            if alloc.graph_facts > 0 {
-                fetchers.push(Box::pin(async {
-                    Self::fetch_graph_facts(memory_state, &query, alloc.graph_facts, &tc)
-                        .await
-                        .map(ContextSlot::GraphFacts)
-                }));
-            }
-            if memory_state.extraction.persona_config.context_budget_tokens > 0 {
-                fetchers.push(Box::pin(async {
-                    let persona_budget =
-                        memory_state.extraction.persona_config.context_budget_tokens;
-                    Self::fetch_persona_facts(memory_state, persona_budget, &tc)
-                        .await
-                        .map(ContextSlot::PersonaFacts)
-                }));
-            }
-            if memory_state
-                .extraction
-                .trajectory_config
-                .context_budget_tokens
-                > 0
-            {
-                fetchers.push(Box::pin(async {
-                    let budget = memory_state
-                        .extraction
-                        .trajectory_config
-                        .context_budget_tokens;
-                    Self::fetch_trajectory_hints(memory_state, budget, &tc)
-                        .await
-                        .map(ContextSlot::TrajectoryHints)
-                }));
-            }
-            if memory_state.subsystems.tree_config.context_budget_tokens > 0 {
-                fetchers.push(Box::pin(async {
-                    let budget = memory_state.subsystems.tree_config.context_budget_tokens;
-                    Self::fetch_tree_memory(memory_state, budget, &tc)
-                        .await
-                        .map(ContextSlot::TreeMemory)
-                }));
-            }
-
-            while let Some(result) = fetchers.next().await {
-                match result {
-                    Ok(slot) => match slot {
-                        ContextSlot::Summaries(msg) => summaries_msg = msg,
-                        ContextSlot::CrossSession(msg) => cross_session_msg = msg,
-                        ContextSlot::SemanticRecall(msg, score) => {
-                            recall_msg = msg;
-                            recall_confidence = score;
-                        }
-                        ContextSlot::DocumentRag(msg) => doc_rag_msg = msg,
-                        ContextSlot::Corrections(msg) => corrections_msg = msg,
-                        ContextSlot::CodeContext(text) => code_rag_text = text,
-                        ContextSlot::GraphFacts(msg) => graph_facts_msg = msg,
-                        ContextSlot::PersonaFacts(msg) => persona_facts_msg = msg,
-                        ContextSlot::TrajectoryHints(msg) => trajectory_hints_msg = msg,
-                        ContextSlot::TreeMemory(msg) => tree_memory_msg = msg,
-                    },
-                    Err(e) => {
-                        // Drop fetchers (releases immutable borrows) before &mut self below
-                        drop(fetchers);
-                        let _ = self.channel.send_status("").await;
-                        return Err(e);
-                    }
-                }
-            }
-        }
+    /// Apply a [`super::assembler::PreparedContext`] to the agent's message window.
+    ///
+    /// Injects all fetched messages in order, handles `MemoryFirst` history drain, sanitizes
+    /// memory content, trims to budget, and injects the session digest.
+    #[allow(clippy::too_many_lines)] // sequential message injection: order matters, cannot split
+    async fn apply_prepared_context(&mut self, prepared: super::assembler::PreparedContext) {
+        use std::borrow::Cow;
+        use zeph_sanitizer::{ContentSource, ContentSourceKind, MemorySourceHint};
 
         // Store top-1 recall score on agent state for MAR routing signal.
-        self.memory_state.persistence.last_recall_confidence = recall_confidence;
+        self.memory_state.persistence.last_recall_confidence = prepared.recall_confidence;
 
         // MemoryFirst: drain conversation history BEFORE inserting memory messages so that the
         // memory inserts land into the shorter array and are not accidentally removed.
-        if memory_first {
+        if prepared.memory_first {
             let history_start = 1usize; // skip system prompt
             let len = self.msg.messages.len();
             let keep_tail = memory_first_keep_tail(&self.msg.messages, history_start);
@@ -1174,7 +481,7 @@ impl<C: Channel> Agent<C> {
         //   ExternalContent  — full detection (graph facts, document RAG may hold adversarial content)
         //   ConversationHistory — detection skipped (user's own prior turns, false-positive suppression)
         //   LlmSummary       — detection skipped (generated by our model from already-sanitized content)
-        if let Some(msg) = graph_facts_msg.filter(|_| self.msg.messages.len() > 1) {
+        if let Some(msg) = prepared.graph_facts.filter(|_| self.msg.messages.len() > 1) {
             self.msg.messages.insert(
                 1,
                 self.sanitize_memory_message(msg, MemorySourceHint::ExternalContent)
@@ -1182,7 +489,7 @@ impl<C: Channel> Agent<C> {
             ); // lgtm[rust/cleartext-logging]
             tracing::debug!("injected knowledge graph facts into context");
         }
-        if let Some(msg) = doc_rag_msg.filter(|_| self.msg.messages.len() > 1) {
+        if let Some(msg) = prepared.doc_rag.filter(|_| self.msg.messages.len() > 1) {
             self.msg.messages.insert(
                 1,
                 self.sanitize_memory_message(msg, MemorySourceHint::ExternalContent)
@@ -1190,7 +497,7 @@ impl<C: Channel> Agent<C> {
             ); // lgtm[rust/cleartext-logging]
             tracing::debug!("injected document RAG context");
         }
-        if let Some(msg) = corrections_msg.filter(|_| self.msg.messages.len() > 1) {
+        if let Some(msg) = prepared.corrections.filter(|_| self.msg.messages.len() > 1) {
             self.msg.messages.insert(
                 1,
                 self.sanitize_memory_message(msg, MemorySourceHint::ConversationHistory)
@@ -1198,21 +505,24 @@ impl<C: Channel> Agent<C> {
             ); // lgtm[rust/cleartext-logging]
             tracing::debug!("injected past corrections into context");
         }
-        if let Some(msg) = recall_msg.filter(|_| self.msg.messages.len() > 1) {
+        if let Some(msg) = prepared.recall.filter(|_| self.msg.messages.len() > 1) {
             self.msg.messages.insert(
                 1,
                 self.sanitize_memory_message(msg, MemorySourceHint::ConversationHistory)
                     .await,
             ); // lgtm[rust/cleartext-logging]
         }
-        if let Some(msg) = cross_session_msg.filter(|_| self.msg.messages.len() > 1) {
+        if let Some(msg) = prepared
+            .cross_session
+            .filter(|_| self.msg.messages.len() > 1)
+        {
             self.msg.messages.insert(
                 1,
                 self.sanitize_memory_message(msg, MemorySourceHint::LlmSummary)
                     .await,
             ); // lgtm[rust/cleartext-logging]
         }
-        if let Some(msg) = summaries_msg.filter(|_| self.msg.messages.len() > 1) {
+        if let Some(msg) = prepared.summaries.filter(|_| self.msg.messages.len() > 1) {
             self.msg.messages.insert(
                 1,
                 self.sanitize_memory_message(msg, MemorySourceHint::LlmSummary)
@@ -1221,10 +531,10 @@ impl<C: Channel> Agent<C> {
             tracing::debug!("injected summaries into context");
         }
         // Persona facts are inserted last so they land immediately after the system prompt (pos 1).
-        // The system prompt remains the authoritative first message; persona is supplementary.
-        // Use ExternalContent hint: persona facts are extracted from user conversation by LLM and
-        // stored in SQLite — they can contain adversarial content if the extraction was poisoned.
-        if let Some(msg) = persona_facts_msg.filter(|_| self.msg.messages.len() > 1) {
+        if let Some(msg) = prepared
+            .persona_facts
+            .filter(|_| self.msg.messages.len() > 1)
+        {
             self.msg.messages.insert(
                 1,
                 self.sanitize_memory_message(msg, MemorySourceHint::ExternalContent)
@@ -1233,7 +543,10 @@ impl<C: Channel> Agent<C> {
             tracing::debug!("injected persona facts into context");
         }
 
-        if let Some(msg) = trajectory_hints_msg.filter(|_| self.msg.messages.len() > 1) {
+        if let Some(msg) = prepared
+            .trajectory_hints
+            .filter(|_| self.msg.messages.len() > 1)
+        {
             self.msg.messages.insert(
                 1,
                 self.sanitize_memory_message(msg, MemorySourceHint::ExternalContent)
@@ -1242,7 +555,7 @@ impl<C: Channel> Agent<C> {
             tracing::debug!("injected trajectory hints into context");
         }
 
-        if let Some(msg) = tree_memory_msg.filter(|_| self.msg.messages.len() > 1) {
+        if let Some(msg) = prepared.tree_memory.filter(|_| self.msg.messages.len() > 1) {
             self.msg.messages.insert(
                 1,
                 self.sanitize_memory_message(msg, MemorySourceHint::ExternalContent)
@@ -1251,10 +564,9 @@ impl<C: Channel> Agent<C> {
             tracing::debug!("injected tree memory summary into context");
         }
 
-        if let Some(text) = code_rag_text {
+        if let Some(text) = prepared.code_context {
             // Sanitize before injection: indexed repo files can contain injection patterns
-            // embedded in comments, docstrings, or string literals (ContentSourceKind::ToolResult
-            // / LocalUntrusted — local repo, not external).
+            // embedded in comments, docstrings, or string literals.
             let sanitized = self
                 .security
                 .sanitizer
@@ -1291,8 +603,8 @@ impl<C: Channel> Agent<C> {
             self.inject_code_context(&sanitized.body);
         }
 
-        if !memory_first {
-            self.trim_messages_to_budget(alloc.recent_history);
+        if !prepared.memory_first {
+            self.trim_messages_to_budget(prepared.recent_history_budget);
         }
 
         // Inject session digest AFTER all other memory inserts so it lands at position 1
@@ -1329,9 +641,6 @@ impl<C: Channel> Agent<C> {
         }
 
         self.recompute_prompt_tokens();
-        let _ = self.channel.send_status("").await;
-
-        Ok(())
     }
 
     /// Apply spotlighting sanitization to a memory retrieval message before inserting it
@@ -2194,25 +1503,23 @@ mod tests {
     use super::*;
     use zeph_llm::provider::{Message, MessagePart, Role};
 
-    use crate::agent::agent_tests::MockChannel;
-
     // ── effective_recall_timeout_ms tests (#2514) ────────────────────────────
 
     #[test]
     fn effective_recall_timeout_ms_nonzero_returns_unchanged() {
-        let result = Agent::<MockChannel>::effective_recall_timeout_ms(500);
+        let result = crate::agent::context::assembler::effective_recall_timeout_ms(500);
         assert_eq!(result, 500, "non-zero value must pass through unchanged");
     }
 
     #[test]
     fn effective_recall_timeout_ms_nonzero_large_returns_unchanged() {
-        let result = Agent::<MockChannel>::effective_recall_timeout_ms(5000);
+        let result = crate::agent::context::assembler::effective_recall_timeout_ms(5000);
         assert_eq!(result, 5000);
     }
 
     #[test]
     fn effective_recall_timeout_ms_zero_clamps_to_100() {
-        let result = Agent::<MockChannel>::effective_recall_timeout_ms(0);
+        let result = crate::agent::context::assembler::effective_recall_timeout_ms(0);
         assert_eq!(
             result, 100,
             "zero recall_timeout_ms must be clamped to 100ms"
@@ -2223,7 +1530,7 @@ mod tests {
     fn spreading_activation_default_timeout_is_nonzero() {
         // Ensures the default used in production is not accidentally set to zero —
         // which would always trigger the zero-clamp warn path in effective_recall_timeout_ms.
-        let result = Agent::<MockChannel>::effective_recall_timeout_ms(
+        let result = crate::agent::context::assembler::effective_recall_timeout_ms(
             zeph_config::memory::SpreadingActivationConfig::default().recall_timeout_ms,
         );
         assert!(

--- a/crates/zeph-core/src/agent/context/mod.rs
+++ b/crates/zeph-core/src/agent/context/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+pub(super) mod assembler;
 mod assembly;
 mod summarization;
 

--- a/crates/zeph-core/src/agent/context/tests.rs
+++ b/crates/zeph-core/src/agent/context/tests.rs
@@ -1558,7 +1558,7 @@ async fn test_prepare_context_no_scrub_when_redact_disabled() {
 
 #[test]
 fn correction_prompt_does_not_replay_bad_path_commands() {
-    let note = crate::agent::Agent::<MockChannel>::format_correction_note(
+    let note = crate::agent::context::assembler::format_correction_note(
         "cd /Users/m/dev/zeph && grep -n \"acp\" Cargo.toml | head -40",
         "Use the current repository and avoid hard-coded absolute paths.",
     );
@@ -3208,7 +3208,7 @@ async fn fetch_graph_facts_returns_none_when_graph_config_disabled() {
     let cid = memory.sqlite().create_conversation().await.unwrap();
     let mem_state = make_mem_state(std::sync::Arc::new(memory), cid, false);
     let tc = std::sync::Arc::new(zeph_memory::TokenCounter::new());
-    let result = Agent::<MockChannel>::fetch_graph_facts(&mem_state, "test", 1000, &tc)
+    let result = crate::agent::context::assembler::fetch_graph_facts(&mem_state, "test", 1000, &tc)
         .await
         .unwrap();
     assert!(result.is_none());
@@ -3220,7 +3220,7 @@ async fn fetch_graph_facts_returns_none_when_budget_zero() {
     let cid = memory.sqlite().create_conversation().await.unwrap();
     let mem_state = make_mem_state(std::sync::Arc::new(memory), cid, true);
     let tc = std::sync::Arc::new(zeph_memory::TokenCounter::new());
-    let result = Agent::<MockChannel>::fetch_graph_facts(&mem_state, "test", 0, &tc)
+    let result = crate::agent::context::assembler::fetch_graph_facts(&mem_state, "test", 0, &tc)
         .await
         .unwrap();
     assert!(result.is_none());
@@ -3232,7 +3232,7 @@ async fn fetch_graph_facts_returns_none_when_graph_is_empty() {
     let cid = memory.sqlite().create_conversation().await.unwrap();
     let mem_state = make_mem_state(std::sync::Arc::new(memory), cid, true);
     let tc = std::sync::Arc::new(zeph_memory::TokenCounter::new());
-    let result = Agent::<MockChannel>::fetch_graph_facts(&mem_state, "rust", 1000, &tc)
+    let result = crate::agent::context::assembler::fetch_graph_facts(&mem_state, "rust", 1000, &tc)
         .await
         .unwrap();
     assert!(result.is_none(), "empty graph must return None");
@@ -3592,7 +3592,7 @@ async fn fetch_graph_facts_returns_some_with_entities_and_has_prefix() {
 
     let mem_state = make_mem_state(std::sync::Arc::new(memory), cid, true);
     let tc = std::sync::Arc::new(zeph_memory::TokenCounter::new());
-    let result = Agent::<MockChannel>::fetch_graph_facts(&mem_state, "rust", 2000, &tc)
+    let result = crate::agent::context::assembler::fetch_graph_facts(&mem_state, "rust", 2000, &tc)
         .await
         .unwrap();
     assert!(result.is_some());

--- a/crates/zeph-core/src/agent/context_manager.rs
+++ b/crates/zeph-core/src/agent/context_manager.rs
@@ -237,7 +237,7 @@ impl ContextManager {
     /// Returns a `Box<dyn AsyncMemoryRouter>` so callers can use `route_async()` for LLM-based
     /// classification. `HeuristicRouter` implements `AsyncMemoryRouter` via a blanket impl that
     /// delegates to the sync `route_with_confidence`.
-    pub(super) fn build_router(&self) -> Box<dyn zeph_memory::AsyncMemoryRouter + Send + Sync> {
+    pub(crate) fn build_router(&self) -> Box<dyn zeph_memory::AsyncMemoryRouter + Send + Sync> {
         use crate::config::StoreRoutingStrategy;
         if !self.routing.enabled {
             return Box::new(zeph_memory::HeuristicRouter);


### PR DESCRIPTION
## Summary

- Extracts context assembly logic from `Agent` into a standalone `ContextAssembler` struct (`crates/zeph-core/src/agent/context/assembler.rs`)
- `ContextAssembler::gather(input: &ContextAssemblyInput<'_>) -> Result<PreparedContext, AgentError>` has zero access to `Agent` state — all inputs are explicit
- All `fetch_*` helpers run concurrently via `FuturesUnordered`
- `Agent::prepare_context` is now a ~30 LOC thin wrapper; injection, sanitization, and session digest live in `apply_prepared_context`
- Closes #2904

Note: #2906 (move bootstrap to binary crate) is descoped from this PR. It requires pre-work to extract shared provider helpers from `bootstrap/` that are used internally by `zeph-core`. See #2916.

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace --lib --bins -- -D warnings` — clean
- [ ] `cargo nextest run --workspace --lib --bins` — 7860 passed
- [ ] Security audit: 0 findings (borrowed refs only, no credentials in PreparedContext)
- [ ] Performance: zero new allocations on hot path, FuturesUnordered concurrency verified race-free