### PR TITLE
refactor(core): extract shared provider helpers from bootstrap (#2916)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Provider helpers extraction** (`#2916`): extracted `BootstrapError`, `build_provider_for_switch`,
+  `build_provider_from_entry`, and `effective_embedding_model` from `zeph-core/src/bootstrap/` into
+  a new internal module `crates/zeph-core/src/provider_factory.rs`. All 5 internal callers
+  (`autodream.rs`, `learning/arise.rs`, `magic_docs.rs`, `provider_cmd.rs`, `session_config.rs`)
+  updated to use `crate::provider_factory::`. Backward-compat `pub use` re-exports added to
+  `bootstrap/provider.rs` and `bootstrap/skills.rs` so the binary crate is unaffected.
+  Prerequisite for moving `bootstrap/` to the binary crate (#2906).
+
 - **`ContextAssembler` extraction** (`#2904`): extracted stateless `ContextAssembler` struct
   with `gather(input: &ContextAssemblyInput<'_>) -> Result<PreparedContext, AgentError>` into
   `crates/zeph-core/src/agent/context/assembler.rs`. All 9 `fetch_*` methods moved from

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9816,6 +9816,7 @@ dependencies = [
  "zeph-acp",
  "zeph-bench",
  "zeph-channels",
+ "zeph-common",
  "zeph-core",
  "zeph-db",
  "zeph-experiments",

--- a/crates/zeph-core/src/agent/autodream.rs
+++ b/crates/zeph-core/src/agent/autodream.rs
@@ -113,7 +113,7 @@ impl<C: Channel> super::Agent<C> {
                 .find(|e| e.name.as_deref() == Some(cfg.consolidation_provider.as_str())),
             self.providers.provider_config_snapshot.as_ref(),
         ) {
-            crate::bootstrap::provider::build_provider_for_switch(entry, snapshot).unwrap_or_else(
+            crate::provider_factory::build_provider_for_switch(entry, snapshot).unwrap_or_else(
                 |e| {
                     tracing::warn!(
                         provider = cfg.consolidation_provider.as_str(),

--- a/crates/zeph-core/src/agent/learning/arise.rs
+++ b/crates/zeph-core/src/agent/learning/arise.rs
@@ -31,7 +31,7 @@ impl<C: Channel> Agent<C> {
         let Some(ref snapshot) = self.providers.provider_config_snapshot else {
             return self.provider.clone();
         };
-        match crate::bootstrap::build_provider_for_switch(&entry, snapshot) {
+        match crate::provider_factory::build_provider_for_switch(&entry, snapshot) {
             Ok(p) => p,
             Err(e) => {
                 tracing::warn!("failed to build provider '{provider_name}': {e:#}, using primary");

--- a/crates/zeph-core/src/agent/magic_docs.rs
+++ b/crates/zeph-core/src/agent/magic_docs.rs
@@ -197,7 +197,7 @@ impl<C: Channel> super::Agent<C> {
                 .find(|e| e.name.as_deref() == Some(cfg.update_provider.as_str())),
             self.providers.provider_config_snapshot.as_ref(),
         ) {
-            crate::bootstrap::provider::build_provider_for_switch(entry, snapshot).unwrap_or_else(
+            crate::provider_factory::build_provider_for_switch(entry, snapshot).unwrap_or_else(
                 |e| {
                     tracing::warn!(
                         provider = cfg.update_provider.as_str(),

--- a/crates/zeph-core/src/agent/provider_cmd.rs
+++ b/crates/zeph-core/src/agent/provider_cmd.rs
@@ -128,7 +128,7 @@ impl<C: Channel> Agent<C> {
             return;
         };
 
-        match crate::bootstrap::build_provider_for_switch(&entry, snapshot) {
+        match crate::provider_factory::build_provider_for_switch(&entry, snapshot) {
             Ok(new_provider) => {
                 // Resolve actual model name: use the entry's effective model (explicit or
                 // provider-type default) instead of the provider type string returned by name().
@@ -336,7 +336,8 @@ mod tests {
 
         let entry = make_entry("ollama", ProviderKind::Ollama, Some("qwen3:8b"));
         let snapshot = ollama_snapshot();
-        let new_provider = crate::bootstrap::build_provider_for_switch(&entry, &snapshot).unwrap();
+        let new_provider =
+            crate::provider_factory::build_provider_for_switch(&entry, &snapshot).unwrap();
 
         let mut agent = Agent::new(new_provider, channel, registry, None, 5, executor);
         agent.providers.provider_pool = vec![entry];
@@ -365,7 +366,8 @@ mod tests {
     async fn provider_switch_already_active_warns() {
         let entry = make_entry("ollama", ProviderKind::Ollama, Some("qwen3:8b"));
         let snapshot = ollama_snapshot();
-        let provider = crate::bootstrap::build_provider_for_switch(&entry, &snapshot).unwrap();
+        let provider =
+            crate::provider_factory::build_provider_for_switch(&entry, &snapshot).unwrap();
 
         let channel = MockChannel::new(vec![]);
         let registry = create_test_registry();
@@ -397,7 +399,8 @@ mod tests {
         let entry_a = make_entry("ollama", ProviderKind::Ollama, Some("qwen3:8b"));
         let entry_b = make_entry("ollama2", ProviderKind::Ollama, Some("llama3.2"));
         let snapshot = ollama_snapshot();
-        let provider_a = crate::bootstrap::build_provider_for_switch(&entry_a, &snapshot).unwrap();
+        let provider_a =
+            crate::provider_factory::build_provider_for_switch(&entry_a, &snapshot).unwrap();
 
         let channel = MockChannel::new(vec![]);
         let registry = create_test_registry();
@@ -465,7 +468,8 @@ mod tests {
         let snapshot = ollama_snapshot();
 
         // Build a real Ollama provider for entry_b to switch to.
-        let provider_b = crate::bootstrap::build_provider_for_switch(&entry_b, &snapshot).unwrap();
+        let provider_b =
+            crate::provider_factory::build_provider_for_switch(&entry_b, &snapshot).unwrap();
 
         let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
         // embedding_provider defaults to provider.clone() (mock). After switch the chat
@@ -497,7 +501,8 @@ mod tests {
         let entry_a = make_entry("ollama", ProviderKind::Ollama, Some("qwen3:8b"));
         let entry_b = make_entry("ollama2", ProviderKind::Ollama, Some("llama3.2"));
         let snapshot = ollama_snapshot();
-        let provider_a = crate::bootstrap::build_provider_for_switch(&entry_a, &snapshot).unwrap();
+        let provider_a =
+            crate::provider_factory::build_provider_for_switch(&entry_a, &snapshot).unwrap();
 
         // embed_provider is a MockProvider — name() returns "mock", which differs from
         // any Ollama provider's name() ("ollama").
@@ -533,11 +538,12 @@ mod tests {
         let entry_a = make_entry("ollama", ProviderKind::Ollama, Some("qwen3:8b"));
         let entry_b = make_entry("ollama2", ProviderKind::Ollama, Some("llama3.2"));
         let snapshot = ollama_snapshot();
-        let provider_a = crate::bootstrap::build_provider_for_switch(&entry_a, &snapshot).unwrap();
+        let provider_a =
+            crate::provider_factory::build_provider_for_switch(&entry_a, &snapshot).unwrap();
 
         let entry_embed = make_entry("embed", ProviderKind::Ollama, Some("nomic-embed-text"));
         let embed_provider =
-            crate::bootstrap::build_provider_for_switch(&entry_embed, &snapshot).unwrap();
+            crate::provider_factory::build_provider_for_switch(&entry_embed, &snapshot).unwrap();
 
         let channel = MockChannel::new(vec![]);
         let registry = create_test_registry();

--- a/crates/zeph-core/src/agent/session_config.rs
+++ b/crates/zeph-core/src/agent/session_config.rs
@@ -133,7 +133,7 @@ impl AgentSessionConfig {
                 .tools
                 .permission_policy(config.security.autonomy_level),
             model_name: config.llm.effective_model().to_owned(),
-            embed_model: crate::bootstrap::effective_embedding_model(config),
+            embed_model: crate::provider_factory::effective_embedding_model(config),
             semantic_cache_enabled: config.llm.semantic_cache_enabled,
             semantic_cache_threshold: config.llm.semantic_cache_threshold,
             semantic_cache_max_candidates: config.llm.semantic_cache_max_candidates,
@@ -199,7 +199,7 @@ mod tests {
         assert_eq!(sc.model_name, config.llm.effective_model());
         assert_eq!(
             sc.embed_model,
-            crate::bootstrap::effective_embedding_model(&config)
+            crate::provider_factory::effective_embedding_model(&config)
         );
         assert_eq!(sc.semantic_cache_enabled, config.llm.semantic_cache_enabled);
         assert!(

--- a/crates/zeph-core/src/bootstrap/provider.rs
+++ b/crates/zeph-core/src/bootstrap/provider.rs
@@ -1,40 +1,27 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use zeph_llm::any::AnyProvider;
-use zeph_llm::router::triage::{ComplexityTier, TriageRouter};
+pub use crate::provider_factory::{
+    BootstrapError, build_provider_for_switch, build_provider_from_entry,
+};
 
-/// Error type for bootstrap / provider construction failures.
-///
-/// String-based variants flatten the error chain intentionally: bootstrap errors are
-/// terminal (the application exits), so downcasting is not needed at this stage.
-/// If a future phase requires programmatic retry on specific failures, expand these
-/// variants into typed sub-errors.
-#[derive(Debug, thiserror::Error)]
-pub enum BootstrapError {
-    #[error("config error: {0}")]
-    Config(#[from] crate::config::ConfigError),
-    #[error("provider error: {0}")]
-    Provider(String),
-    #[error("memory error: {0}")]
-    Memory(String),
-    #[error("vault init error: {0}")]
-    VaultInit(crate::vault::AgeVaultError),
-    #[error("I/O error: {0}")]
-    Io(#[from] std::io::Error),
-}
-use zeph_llm::claude::ClaudeProvider;
-use zeph_llm::compatible::CompatibleProvider;
-use zeph_llm::gemini::GeminiProvider;
-use zeph_llm::http::llm_client;
+use zeph_llm::any::AnyProvider;
 use zeph_llm::ollama::OllamaProvider;
-use zeph_llm::openai::OpenAiProvider;
 use zeph_llm::router::cascade::ClassifierMode;
+use zeph_llm::router::triage::{ComplexityTier, TriageRouter};
 use zeph_llm::router::{AsiRouterConfig, BanditRouterConfig, CascadeRouterConfig, RouterProvider};
 
-use crate::agent::state::ProviderConfigSnapshot;
-use crate::config::{Config, LlmRoutingStrategy, ProviderEntry, ProviderKind};
+use crate::config::{Config, LlmRoutingStrategy, ProviderEntry};
 
+/// Build the primary `AnyProvider` from the resolved config.
+///
+/// Delegates to the internal provider pool builder. Entry point for bootstrap and channel
+/// initialization — call this once per startup or config reload.
+///
+/// # Errors
+///
+/// Returns `BootstrapError::Provider` when no provider in `[[llm.providers]]` can be
+/// initialized.
 pub fn create_provider(config: &Config) -> Result<AnyProvider, BootstrapError> {
     create_provider_from_pool(config)
 }
@@ -206,6 +193,15 @@ pub fn create_summary_provider(
     )))
 }
 
+/// Select the hardware device for Candle inference based on a preference string.
+///
+/// Preference values: `"metal"` (Apple GPU), `"cuda"` (NVIDIA GPU), `"auto"` (best available),
+/// or any other string falls back to CPU.
+///
+/// # Errors
+///
+/// Returns `BootstrapError::Provider` when the requested device is not available (e.g.
+/// `"metal"` requested but compiled without the `metal` feature).
 #[cfg(feature = "candle")]
 pub fn select_device(
     preference: &str,
@@ -241,269 +237,6 @@ pub fn select_device(
             Ok(zeph_llm::candle_provider::Device::Cpu)
         }
         _ => Ok(zeph_llm::candle_provider::Device::Cpu),
-    }
-}
-
-#[cfg(feature = "candle")]
-fn build_candle_provider(
-    source: &zeph_llm::candle_provider::loader::ModelSource,
-    candle_cfg: &crate::config::CandleConfig,
-    device_pref: &str,
-) -> Result<AnyProvider, BootstrapError> {
-    let template =
-        zeph_llm::candle_provider::template::ChatTemplate::parse_str(&candle_cfg.chat_template);
-    let gen_config = zeph_llm::candle_provider::generate::GenerationConfig {
-        temperature: candle_cfg.generation.temperature,
-        top_p: candle_cfg.generation.top_p,
-        top_k: candle_cfg.generation.top_k,
-        max_tokens: candle_cfg.generation.capped_max_tokens(),
-        seed: candle_cfg.generation.seed,
-        repeat_penalty: candle_cfg.generation.repeat_penalty,
-        repeat_last_n: candle_cfg.generation.repeat_last_n,
-    };
-    let device = select_device(device_pref)?;
-    // S1: floor at 1s so that inference_timeout_secs = 0 does not cause every request to
-    // immediately time out. The effective maximum wait per request is 2 × this value because
-    // dispatch() applies the timeout once to the channel send and once to the oneshot recv.
-    let inference_timeout =
-        std::time::Duration::from_secs(candle_cfg.inference_timeout_secs.max(1));
-    zeph_llm::candle_provider::CandleProvider::new_with_timeout(
-        source,
-        template,
-        gen_config,
-        candle_cfg.embedding_repo.as_deref(),
-        candle_cfg.hf_token.as_deref(),
-        device,
-        inference_timeout,
-    )
-    .map(AnyProvider::Candle)
-    .map_err(|e| BootstrapError::Provider(e.to_string()))
-}
-
-/// Build an `AnyProvider` from a `ProviderEntry` using a runtime config snapshot.
-///
-/// Called by the `/provider <name>` slash command to switch providers at runtime without
-/// requiring the full `Config`. Router and Orchestrator provider kinds are not supported
-/// for runtime switching — they require the full provider pool to be re-initialized.
-///
-/// # Errors
-///
-/// Returns `BootstrapError::Provider` when the provider kind is unsupported for runtime
-/// switching, a required secret is missing, or the entry is misconfigured.
-pub fn build_provider_for_switch(
-    entry: &ProviderEntry,
-    snapshot: &ProviderConfigSnapshot,
-) -> Result<AnyProvider, BootstrapError> {
-    use zeph_common::secret::Secret;
-    // Reconstruct a minimal Config from the snapshot so we can reuse build_provider_from_entry.
-    // Only fields read by build_provider_from_entry are populated; everything else uses defaults.
-    // Secrets are stored as plain strings in the snapshot because Secret does not implement Clone.
-    let mut config = Config::default();
-    config.secrets.claude_api_key = snapshot.claude_api_key.as_deref().map(Secret::new);
-    config.secrets.openai_api_key = snapshot.openai_api_key.as_deref().map(Secret::new);
-    config.secrets.gemini_api_key = snapshot.gemini_api_key.as_deref().map(Secret::new);
-    config.secrets.compatible_api_keys = snapshot
-        .compatible_api_keys
-        .iter()
-        .map(|(k, v)| (k.clone(), Secret::new(v.as_str())))
-        .collect();
-    config.timeouts.llm_request_timeout_secs = snapshot.llm_request_timeout_secs;
-    config
-        .llm
-        .embedding_model
-        .clone_from(&snapshot.embedding_model);
-    build_provider_from_entry(entry, &config)
-}
-
-/// Build an `AnyProvider` from a unified `ProviderEntry` (new `[[llm.providers]]` format).
-///
-/// All provider-specific fields come from `entry`; the global `config` is used only for
-/// secrets and timeout settings.
-///
-/// # Errors
-///
-/// Returns `BootstrapError::Provider` when a required secret is missing or an entry is
-/// misconfigured (e.g. compatible provider without a name).
-#[allow(clippy::too_many_lines)]
-pub fn build_provider_from_entry(
-    entry: &ProviderEntry,
-    config: &Config,
-) -> Result<AnyProvider, BootstrapError> {
-    match entry.provider_type {
-        ProviderKind::Ollama => {
-            let base_url = entry
-                .base_url
-                .as_deref()
-                .unwrap_or("http://localhost:11434");
-            let model = entry.model.as_deref().unwrap_or("qwen3:8b").to_owned();
-            let embed = entry
-                .embedding_model
-                .clone()
-                .unwrap_or_else(|| config.llm.embedding_model.clone());
-            let mut provider = OllamaProvider::new(base_url, model, embed);
-            if let Some(ref vm) = entry.vision_model {
-                provider = provider.with_vision_model(vm.clone());
-            }
-            Ok(AnyProvider::Ollama(provider))
-        }
-        ProviderKind::Claude => {
-            let api_key = config
-                .secrets
-                .claude_api_key
-                .as_ref()
-                .ok_or_else(|| {
-                    BootstrapError::Provider("ZEPH_CLAUDE_API_KEY not found in vault".into())
-                })?
-                .expose()
-                .to_owned();
-            let model = entry
-                .model
-                .clone()
-                .unwrap_or_else(|| "claude-haiku-4-5-20251001".to_owned());
-            let max_tokens = entry.max_tokens.unwrap_or(4096);
-            let provider = ClaudeProvider::new(api_key, model, max_tokens)
-                .with_client(llm_client(config.timeouts.llm_request_timeout_secs))
-                .with_extended_context(entry.enable_extended_context)
-                .with_thinking_opt(entry.thinking.clone())
-                .map_err(|e| BootstrapError::Provider(format!("invalid thinking config: {e}")))?
-                .with_server_compaction(entry.server_compaction);
-            Ok(AnyProvider::Claude(provider))
-        }
-        ProviderKind::OpenAi => {
-            let api_key = config
-                .secrets
-                .openai_api_key
-                .as_ref()
-                .ok_or_else(|| {
-                    BootstrapError::Provider("ZEPH_OPENAI_API_KEY not found in vault".into())
-                })?
-                .expose()
-                .to_owned();
-            let base_url = entry
-                .base_url
-                .clone()
-                .unwrap_or_else(|| "https://api.openai.com/v1".to_owned());
-            let model = entry
-                .model
-                .clone()
-                .unwrap_or_else(|| "gpt-4o-mini".to_owned());
-            let max_tokens = entry.max_tokens.unwrap_or(4096);
-            Ok(AnyProvider::OpenAi(
-                OpenAiProvider::new(
-                    api_key,
-                    base_url,
-                    model,
-                    max_tokens,
-                    entry.embedding_model.clone(),
-                    entry.reasoning_effort.clone(),
-                )
-                .with_client(llm_client(config.timeouts.llm_request_timeout_secs)),
-            ))
-        }
-        ProviderKind::Gemini => {
-            let api_key = config
-                .secrets
-                .gemini_api_key
-                .as_ref()
-                .ok_or_else(|| {
-                    BootstrapError::Provider("ZEPH_GEMINI_API_KEY not found in vault".into())
-                })?
-                .expose()
-                .to_owned();
-            let model = entry
-                .model
-                .clone()
-                .unwrap_or_else(|| "gemini-2.0-flash".to_owned());
-            let max_tokens = entry.max_tokens.unwrap_or(8192);
-            let base_url = entry
-                .base_url
-                .clone()
-                .unwrap_or_else(|| "https://generativelanguage.googleapis.com".to_owned());
-            let mut provider = GeminiProvider::new(api_key, model, max_tokens)
-                .with_base_url(base_url)
-                .with_client(llm_client(config.timeouts.llm_request_timeout_secs));
-            if let Some(ref em) = entry.embedding_model {
-                provider = provider.with_embedding_model(em.clone());
-            }
-            if let Some(level) = entry.thinking_level {
-                provider = provider.with_thinking_level(level);
-            }
-            if let Some(budget) = entry.thinking_budget {
-                provider = provider
-                    .with_thinking_budget(budget)
-                    .map_err(|e| BootstrapError::Provider(e.to_string()))?;
-            }
-            if let Some(include) = entry.include_thoughts {
-                provider = provider.with_include_thoughts(include);
-            }
-            Ok(AnyProvider::Gemini(provider))
-        }
-        ProviderKind::Compatible => {
-            let name = entry.name.as_deref().ok_or_else(|| {
-                BootstrapError::Provider(
-                    "compatible provider requires 'name' field in [[llm.providers]]".into(),
-                )
-            })?;
-            let base_url = entry.base_url.clone().ok_or_else(|| {
-                BootstrapError::Provider(format!(
-                    "compatible provider '{name}' requires 'base_url'"
-                ))
-            })?;
-            let model = entry.model.clone().unwrap_or_default();
-            let api_key = entry.api_key.clone().unwrap_or_else(|| {
-                config
-                    .secrets
-                    .compatible_api_keys
-                    .get(name)
-                    .map(|s| s.expose().to_owned())
-                    .unwrap_or_default()
-            });
-            let max_tokens = entry.max_tokens.unwrap_or(4096);
-            Ok(AnyProvider::Compatible(CompatibleProvider::new(
-                name.to_owned(),
-                api_key,
-                base_url,
-                model,
-                max_tokens,
-                entry.embedding_model.clone(),
-            )))
-        }
-        #[cfg(feature = "candle")]
-        ProviderKind::Candle => {
-            let candle = entry.candle.as_ref().ok_or_else(|| {
-                BootstrapError::Provider(
-                    "candle provider requires 'candle' section in [[llm.providers]]".into(),
-                )
-            })?;
-            let source = match candle.source.as_str() {
-                "local" => zeph_llm::candle_provider::loader::ModelSource::Local {
-                    path: std::path::PathBuf::from(&candle.local_path),
-                },
-                _ => zeph_llm::candle_provider::loader::ModelSource::HuggingFace {
-                    repo_id: entry
-                        .model
-                        .clone()
-                        .unwrap_or_else(|| config.llm.effective_model().to_owned()),
-                    filename: candle.filename.clone(),
-                },
-            };
-            let candle_cfg_adapter = crate::config::CandleConfig {
-                source: candle.source.clone(),
-                local_path: candle.local_path.clone(),
-                filename: candle.filename.clone(),
-                chat_template: candle.chat_template.clone(),
-                device: candle.device.clone(),
-                embedding_repo: candle.embedding_repo.clone(),
-                hf_token: candle.hf_token.clone(),
-                generation: candle.generation.clone(),
-                inference_timeout_secs: candle.inference_timeout_secs,
-            };
-            build_candle_provider(&source, &candle_cfg_adapter, &candle.device)
-        }
-        #[cfg(not(feature = "candle"))]
-        ProviderKind::Candle => Err(BootstrapError::Provider(
-            "candle feature is not enabled".into(),
-        )),
     }
 }
 

--- a/crates/zeph-core/src/bootstrap/skills.rs
+++ b/crates/zeph-core/src/bootstrap/skills.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+pub use crate::provider_factory::effective_embedding_model;
+
 use std::path::PathBuf;
 use zeph_llm::any::AnyProvider;
 use zeph_memory::QdrantOps;
@@ -90,29 +92,6 @@ pub fn create_embedding_provider(config: &Config, primary: &AnyProvider) -> AnyP
             primary.clone()
         }
     }
-}
-
-pub fn effective_embedding_model(config: &Config) -> String {
-    // Prefer a dedicated embed provider.
-    if let Some(m) = config
-        .llm
-        .providers
-        .iter()
-        .find(|e| e.embed)
-        .and_then(|e| e.embedding_model.as_ref())
-    {
-        return m.clone();
-    }
-    // Fall back to the first provider's embedding model.
-    if let Some(m) = config
-        .llm
-        .providers
-        .first()
-        .and_then(|e| e.embedding_model.as_ref())
-    {
-        return m.clone();
-    }
-    config.llm.embedding_model.clone()
 }
 
 /// Returns the default managed skills directory: `~/.config/zeph/skills/`.

--- a/crates/zeph-core/src/lib.rs
+++ b/crates/zeph-core/src/lib.rs
@@ -82,6 +82,7 @@ pub mod metrics;
 pub mod metrics_bridge;
 pub mod pipeline;
 pub mod project;
+pub mod provider_factory;
 pub mod redact;
 #[cfg(feature = "sysinfo")]
 pub mod system_metrics;

--- a/crates/zeph-core/src/provider_factory.rs
+++ b/crates/zeph-core/src/provider_factory.rs
@@ -1,0 +1,317 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Pure provider factory helpers: build `AnyProvider` instances from config entries.
+//!
+//! This module contains configuration-to-provider transformation functions that are
+//! used by internal `zeph-core` subsystems (skills, tools, autodream, session config).
+//! They are intentionally separated from bootstrap orchestration logic so that provider
+//! construction can be reasoned about and tested independently of startup sequencing.
+
+use zeph_llm::any::AnyProvider;
+use zeph_llm::claude::ClaudeProvider;
+use zeph_llm::compatible::CompatibleProvider;
+use zeph_llm::gemini::GeminiProvider;
+use zeph_llm::http::llm_client;
+use zeph_llm::ollama::OllamaProvider;
+use zeph_llm::openai::OpenAiProvider;
+
+use crate::agent::state::ProviderConfigSnapshot;
+use crate::config::{Config, ProviderEntry, ProviderKind};
+
+/// Error type for provider construction failures.
+///
+/// String-based variants flatten the error chain intentionally: bootstrap errors are
+/// terminal (the application exits), so downcasting is not needed at this stage.
+/// If a future phase requires programmatic retry on specific failures, expand these
+/// variants into typed sub-errors.
+#[derive(Debug, thiserror::Error)]
+pub enum BootstrapError {
+    /// Configuration validation failed.
+    #[error("config error: {0}")]
+    Config(#[from] crate::config::ConfigError),
+    /// Provider construction failed (missing secrets, unsupported kind, etc.).
+    #[error("provider error: {0}")]
+    Provider(String),
+    /// Memory subsystem initialization failed.
+    #[error("memory error: {0}")]
+    Memory(String),
+    /// Age vault initialization failed.
+    #[error("vault init error: {0}")]
+    VaultInit(crate::vault::AgeVaultError),
+    /// I/O error during bootstrap.
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Build an `AnyProvider` from a `ProviderEntry` using a runtime config snapshot.
+///
+/// Called by the `/provider <name>` slash command to switch providers at runtime without
+/// requiring the full `Config`. Router and Orchestrator provider kinds are not supported
+/// for runtime switching — they require the full provider pool to be re-initialized.
+///
+/// # Errors
+///
+/// Returns `BootstrapError::Provider` when the provider kind is unsupported for runtime
+/// switching, a required secret is missing, or the entry is misconfigured.
+pub fn build_provider_for_switch(
+    entry: &ProviderEntry,
+    snapshot: &ProviderConfigSnapshot,
+) -> Result<AnyProvider, BootstrapError> {
+    use zeph_common::secret::Secret;
+    // Reconstruct a minimal Config from the snapshot so we can reuse build_provider_from_entry.
+    // Only fields read by build_provider_from_entry are populated; everything else uses defaults.
+    // Secrets are stored as plain strings in the snapshot because Secret does not implement Clone.
+    let mut config = Config::default();
+    config.secrets.claude_api_key = snapshot.claude_api_key.as_deref().map(Secret::new);
+    config.secrets.openai_api_key = snapshot.openai_api_key.as_deref().map(Secret::new);
+    config.secrets.gemini_api_key = snapshot.gemini_api_key.as_deref().map(Secret::new);
+    config.secrets.compatible_api_keys = snapshot
+        .compatible_api_keys
+        .iter()
+        .map(|(k, v)| (k.clone(), Secret::new(v.as_str())))
+        .collect();
+    config.timeouts.llm_request_timeout_secs = snapshot.llm_request_timeout_secs;
+    config
+        .llm
+        .embedding_model
+        .clone_from(&snapshot.embedding_model);
+    build_provider_from_entry(entry, &config)
+}
+
+/// Build an `AnyProvider` from a unified `ProviderEntry` (new `[[llm.providers]]` format).
+///
+/// All provider-specific fields come from `entry`; the global `config` is used only for
+/// secrets and timeout settings.
+///
+/// # Errors
+///
+/// Returns `BootstrapError::Provider` when a required secret is missing or an entry is
+/// misconfigured (e.g. compatible provider without a name).
+#[allow(clippy::too_many_lines)]
+pub fn build_provider_from_entry(
+    entry: &ProviderEntry,
+    config: &Config,
+) -> Result<AnyProvider, BootstrapError> {
+    match entry.provider_type {
+        ProviderKind::Ollama => {
+            let base_url = entry
+                .base_url
+                .as_deref()
+                .unwrap_or("http://localhost:11434");
+            let model = entry.model.as_deref().unwrap_or("qwen3:8b").to_owned();
+            let embed = entry
+                .embedding_model
+                .clone()
+                .unwrap_or_else(|| config.llm.embedding_model.clone());
+            let mut provider = OllamaProvider::new(base_url, model, embed);
+            if let Some(ref vm) = entry.vision_model {
+                provider = provider.with_vision_model(vm.clone());
+            }
+            Ok(AnyProvider::Ollama(provider))
+        }
+        ProviderKind::Claude => {
+            let api_key = config
+                .secrets
+                .claude_api_key
+                .as_ref()
+                .ok_or_else(|| {
+                    BootstrapError::Provider("ZEPH_CLAUDE_API_KEY not found in vault".into())
+                })?
+                .expose()
+                .to_owned();
+            let model = entry
+                .model
+                .clone()
+                .unwrap_or_else(|| "claude-haiku-4-5-20251001".to_owned());
+            let max_tokens = entry.max_tokens.unwrap_or(4096);
+            let provider = ClaudeProvider::new(api_key, model, max_tokens)
+                .with_client(llm_client(config.timeouts.llm_request_timeout_secs))
+                .with_extended_context(entry.enable_extended_context)
+                .with_thinking_opt(entry.thinking.clone())
+                .map_err(|e| BootstrapError::Provider(format!("invalid thinking config: {e}")))?
+                .with_server_compaction(entry.server_compaction);
+            Ok(AnyProvider::Claude(provider))
+        }
+        ProviderKind::OpenAi => {
+            let api_key = config
+                .secrets
+                .openai_api_key
+                .as_ref()
+                .ok_or_else(|| {
+                    BootstrapError::Provider("ZEPH_OPENAI_API_KEY not found in vault".into())
+                })?
+                .expose()
+                .to_owned();
+            let base_url = entry
+                .base_url
+                .clone()
+                .unwrap_or_else(|| "https://api.openai.com/v1".to_owned());
+            let model = entry
+                .model
+                .clone()
+                .unwrap_or_else(|| "gpt-4o-mini".to_owned());
+            let max_tokens = entry.max_tokens.unwrap_or(4096);
+            Ok(AnyProvider::OpenAi(
+                OpenAiProvider::new(
+                    api_key,
+                    base_url,
+                    model,
+                    max_tokens,
+                    entry.embedding_model.clone(),
+                    entry.reasoning_effort.clone(),
+                )
+                .with_client(llm_client(config.timeouts.llm_request_timeout_secs)),
+            ))
+        }
+        ProviderKind::Gemini => {
+            let api_key = config
+                .secrets
+                .gemini_api_key
+                .as_ref()
+                .ok_or_else(|| {
+                    BootstrapError::Provider("ZEPH_GEMINI_API_KEY not found in vault".into())
+                })?
+                .expose()
+                .to_owned();
+            let model = entry
+                .model
+                .clone()
+                .unwrap_or_else(|| "gemini-2.0-flash".to_owned());
+            let max_tokens = entry.max_tokens.unwrap_or(8192);
+            let base_url = entry
+                .base_url
+                .clone()
+                .unwrap_or_else(|| "https://generativelanguage.googleapis.com".to_owned());
+            let mut provider = GeminiProvider::new(api_key, model, max_tokens)
+                .with_base_url(base_url)
+                .with_client(llm_client(config.timeouts.llm_request_timeout_secs));
+            if let Some(ref em) = entry.embedding_model {
+                provider = provider.with_embedding_model(em.clone());
+            }
+            if let Some(level) = entry.thinking_level {
+                provider = provider.with_thinking_level(level);
+            }
+            if let Some(budget) = entry.thinking_budget {
+                provider = provider
+                    .with_thinking_budget(budget)
+                    .map_err(|e| BootstrapError::Provider(e.to_string()))?;
+            }
+            if let Some(include) = entry.include_thoughts {
+                provider = provider.with_include_thoughts(include);
+            }
+            Ok(AnyProvider::Gemini(provider))
+        }
+        ProviderKind::Compatible => {
+            let name = entry.name.as_deref().ok_or_else(|| {
+                BootstrapError::Provider(
+                    "compatible provider requires 'name' field in [[llm.providers]]".into(),
+                )
+            })?;
+            let base_url = entry.base_url.clone().ok_or_else(|| {
+                BootstrapError::Provider(format!(
+                    "compatible provider '{name}' requires 'base_url'"
+                ))
+            })?;
+            let model = entry.model.clone().unwrap_or_default();
+            let api_key = entry.api_key.clone().unwrap_or_else(|| {
+                config
+                    .secrets
+                    .compatible_api_keys
+                    .get(name)
+                    .map(|s| s.expose().to_owned())
+                    .unwrap_or_default()
+            });
+            let max_tokens = entry.max_tokens.unwrap_or(4096);
+            Ok(AnyProvider::Compatible(CompatibleProvider::new(
+                name.to_owned(),
+                api_key,
+                base_url,
+                model,
+                max_tokens,
+                entry.embedding_model.clone(),
+            )))
+        }
+        #[cfg(feature = "candle")]
+        ProviderKind::Candle => {
+            let candle = entry.candle.as_ref().ok_or_else(|| {
+                BootstrapError::Provider(
+                    "candle provider requires 'candle' section in [[llm.providers]]".into(),
+                )
+            })?;
+            let source = match candle.source.as_str() {
+                "local" => zeph_llm::candle_provider::loader::ModelSource::Local {
+                    path: std::path::PathBuf::from(&candle.local_path),
+                },
+                _ => zeph_llm::candle_provider::loader::ModelSource::HuggingFace {
+                    repo_id: entry
+                        .model
+                        .clone()
+                        .unwrap_or_else(|| config.llm.effective_model().to_owned()),
+                    filename: candle.filename.clone(),
+                },
+            };
+            let template =
+                zeph_llm::candle_provider::template::ChatTemplate::parse_str(&candle.chat_template);
+            let gen_config = zeph_llm::candle_provider::generate::GenerationConfig {
+                temperature: candle.generation.temperature,
+                top_p: candle.generation.top_p,
+                top_k: candle.generation.top_k,
+                max_tokens: candle.generation.capped_max_tokens(),
+                seed: candle.generation.seed,
+                repeat_penalty: candle.generation.repeat_penalty,
+                repeat_last_n: candle.generation.repeat_last_n,
+            };
+            let device = crate::bootstrap::select_device(&candle.device)?;
+            // Floor at 1s so that inference_timeout_secs = 0 does not cause every request to
+            // immediately time out.
+            let inference_timeout =
+                std::time::Duration::from_secs(candle.inference_timeout_secs.max(1));
+            zeph_llm::candle_provider::CandleProvider::new_with_timeout(
+                &source,
+                template,
+                gen_config,
+                candle.embedding_repo.as_deref(),
+                candle.hf_token.as_deref(),
+                device,
+                inference_timeout,
+            )
+            .map(AnyProvider::Candle)
+            .map_err(|e| BootstrapError::Provider(e.to_string()))
+        }
+        #[cfg(not(feature = "candle"))]
+        ProviderKind::Candle => Err(BootstrapError::Provider(
+            "candle feature is not enabled".into(),
+        )),
+    }
+}
+
+/// Determine the effective embedding model name for the memory subsystem.
+///
+/// Resolution order:
+/// 1. `embedding_model` from the `[[llm.providers]]` entry marked `embed = true`
+/// 2. `embedding_model` from the first entry in `[[llm.providers]]`
+/// 3. `[llm] embedding_model` global fallback
+#[must_use]
+pub fn effective_embedding_model(config: &Config) -> String {
+    // Prefer a dedicated embed provider.
+    if let Some(m) = config
+        .llm
+        .providers
+        .iter()
+        .find(|e| e.embed)
+        .and_then(|e| e.embedding_model.as_ref())
+    {
+        return m.clone();
+    }
+    // Fall back to the first provider's embedding model.
+    if let Some(m) = config
+        .llm
+        .providers
+        .first()
+        .and_then(|e| e.embedding_model.as_ref())
+    {
+        return m.clone();
+    }
+    config.llm.embedding_model.clone()
+}


### PR DESCRIPTION
## Summary

- Extracted `BootstrapError`, `build_provider_for_switch`, `build_provider_from_entry`, and `effective_embedding_model` from `zeph-core/src/bootstrap/` into a new internal module `crates/zeph-core/src/provider_factory.rs`
- Updated all 5 internal callers (`autodream.rs`, `learning/arise.rs`, `magic_docs.rs`, `provider_cmd.rs`, `session_config.rs`) to use `crate::provider_factory::`
- Added `pub use` re-exports in `bootstrap/provider.rs` and `bootstrap/skills.rs` for backward compatibility — binary crate is unaffected

`create_named_provider` and `create_summary_provider` remain in `bootstrap/` (no agent-internal callers).

Closes #2916. Prerequisite for #2906.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 7869 passed