### PR TITLE
refactor(commands,core): migrate 3 slash handlers to Send-compatible registry (phase 5, #2928)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Handler migration phase 5** (`#2928`): migrated `/new`, `/experiment`, and `/plan` from the
+  legacy `dispatch_slash_command` to the `CommandHandler` registry using the extract-before-await
+  pattern. `/compact` and `/mcp` remain in `dispatch_slash_command` pending upstream fixes:
+  `AnyProvider: !Sync` blocks `/compact`, `RwLockWriteGuard`-across-await blocks `/mcp`. Added
+  `parse_new_flags()` helper and 5 unit tests for `--keep-plan`/`--no-digest` argument parsing.
+  Removed dead `CompactCommand` and `McpCommand` structs. Removed redundant `flush_chunks` call
+  from `dispatch_plan_command`.
+
 - **Handler migration phase 4** (`#2924`): migrated 13 remaining slash commands from the legacy
   `dispatch_slash_command` fallback in `zeph-core` to typed handler structs in `zeph-commands`.
   Moved the `COMMANDS` constant from `zeph-core::agent::slash_commands` to

--- a/crates/zeph-commands/src/handlers/compaction.rs
+++ b/crates/zeph-commands/src/handlers/compaction.rs
@@ -1,7 +1,12 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Context compaction and conversation reset handlers: `/compact`, `/new`.
+//! Conversation reset handler: `/new`.
+//!
+//! Note: `/compact` is intentionally absent. `AgentAccess::compact_context` cannot be made
+//! `Send` due to HRTB constraints on `AnyProvider` (the provider is `!Sync`, so
+//! `&AnyProvider` across `.await` in a `Box<dyn Future + Send>` fails). `/compact` remains
+//! in `dispatch_slash_command` until `AnyProvider` is made `Sync` in `zeph-llm`.
 
 use std::future::Future;
 use std::pin::Pin;
@@ -9,50 +14,11 @@ use std::pin::Pin;
 use crate::context::CommandContext;
 use crate::{CommandError, CommandHandler, CommandOutput, SlashCategory};
 
-/// Context compaction handler stub.
+/// New conversation handler for `/new`.
 ///
-/// This handler is NOT registered in any command registry. The `/compact` command is
-/// dispatched directly via `dispatch_slash_command` because `compact_context` holds `&self`
-/// across `.await` points (via `load_compression_guidelines_if_enabled`), making the future
-/// non-Send.
-///
-/// This struct exists to document the intended handler shape for when the Send constraint
-/// is lifted in a future migration phase.
-pub struct CompactCommand;
-
-impl CommandHandler<CommandContext<'_>> for CompactCommand {
-    fn name(&self) -> &'static str {
-        "/compact"
-    }
-
-    fn description(&self) -> &'static str {
-        "Compact the context window"
-    }
-
-    fn category(&self) -> SlashCategory {
-        SlashCategory::Session
-    }
-
-    fn handle<'a>(
-        &'a self,
-        ctx: &'a mut CommandContext<'_>,
-        _args: &'a str,
-    ) -> Pin<Box<dyn Future<Output = Result<CommandOutput, CommandError>> + Send + 'a>> {
-        Box::pin(async move {
-            let result = ctx.agent.compact_context().await?;
-            Ok(CommandOutput::Message(result))
-        })
-    }
-}
-
-/// New conversation handler stub.
-///
-/// This handler is NOT registered in any command registry. The `/new` command is dispatched
-/// directly via `dispatch_slash_command` for the same non-Send reason as `CompactCommand`
-/// (calls `load_compression_guidelines_if_enabled` across an `.await`).
-///
-/// This struct exists to document the intended handler shape for when the Send constraint
-/// is lifted in a future migration phase.
+/// Delegates to [`AgentAccess::reset_conversation`] which is now Send-compatible:
+/// `reset_conversation` clones the `Arc<SemanticMemory>` before `.await` so no
+/// `&mut self` borrow is held across the await boundary.
 pub struct NewConversationCommand;
 
 impl CommandHandler<CommandContext<'_>> for NewConversationCommand {
@@ -78,10 +44,51 @@ impl CommandHandler<CommandContext<'_>> for NewConversationCommand {
         args: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<CommandOutput, CommandError>> + Send + 'a>> {
         Box::pin(async move {
-            let keep_plan = args.split_whitespace().any(|a| a == "--keep-plan");
-            let no_digest = args.split_whitespace().any(|a| a == "--no-digest");
+            let (keep_plan, no_digest) = parse_new_flags(args);
             let result = ctx.agent.reset_conversation(keep_plan, no_digest).await?;
             Ok(CommandOutput::Message(result))
         })
+    }
+}
+
+/// Parse `--keep-plan` and `--no-digest` flags from the `/new` command args string.
+fn parse_new_flags(args: &str) -> (bool, bool) {
+    let keep_plan = args.split_whitespace().any(|a| a == "--keep-plan");
+    let no_digest = args.split_whitespace().any(|a| a == "--no-digest");
+    (keep_plan, no_digest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_new_flags;
+
+    #[test]
+    fn no_flags_both_false() {
+        assert_eq!(parse_new_flags(""), (false, false));
+        assert_eq!(parse_new_flags("   "), (false, false));
+    }
+
+    #[test]
+    fn keep_plan_flag_detected() {
+        assert_eq!(parse_new_flags("--keep-plan"), (true, false));
+        assert_eq!(parse_new_flags("--keep-plan --no-digest"), (true, true));
+    }
+
+    #[test]
+    fn no_digest_flag_detected() {
+        assert_eq!(parse_new_flags("--no-digest"), (false, true));
+    }
+
+    #[test]
+    fn both_flags_order_independent() {
+        assert_eq!(parse_new_flags("--no-digest --keep-plan"), (true, true));
+        assert_eq!(parse_new_flags("--keep-plan --no-digest"), (true, true));
+    }
+
+    #[test]
+    fn partial_flag_name_not_matched() {
+        assert_eq!(parse_new_flags("--keep"), (false, false));
+        assert_eq!(parse_new_flags("--no"), (false, false));
+        assert_eq!(parse_new_flags("keep-plan"), (false, false));
     }
 }

--- a/crates/zeph-commands/src/handlers/compaction.rs
+++ b/crates/zeph-commands/src/handlers/compaction.rs
@@ -16,7 +16,7 @@ use crate::{CommandError, CommandHandler, CommandOutput, SlashCategory};
 
 /// New conversation handler for `/new`.
 ///
-/// Delegates to [`AgentAccess::reset_conversation`] which is now Send-compatible:
+/// Delegates to `AgentAccess::reset_conversation` which is now Send-compatible:
 /// `reset_conversation` clones the `Arc<SemanticMemory>` before `.await` so no
 /// `&mut self` borrow is held across the await boundary.
 pub struct NewConversationCommand;

--- a/crates/zeph-commands/src/handlers/experiment.rs
+++ b/crates/zeph-commands/src/handlers/experiment.rs
@@ -9,14 +9,11 @@ use std::pin::Pin;
 use crate::context::CommandContext;
 use crate::{CommandError, CommandHandler, CommandOutput, SlashCategory};
 
-/// Experimental features handler stub.
+/// Experimental features handler for `/experiment`.
 ///
-/// This handler is NOT registered in any command registry. The `/experiment` command is
-/// dispatched directly via `dispatch_slash_command` because `handle_experiment_command`
-/// produces a non-Send future.
-///
-/// This struct exists to document the intended handler shape for when the Send constraint
-/// is lifted in a future migration phase.
+/// Delegates to [`AgentAccess::handle_experiment`] which is now Send-compatible:
+/// `handle_experiment_command_as_string` clones all `Arc` references before `.await`
+/// so no `&mut self` borrow is held across await boundaries.
 pub struct ExperimentCommand;
 
 impl CommandHandler<CommandContext<'_>> for ExperimentCommand {

--- a/crates/zeph-commands/src/handlers/experiment.rs
+++ b/crates/zeph-commands/src/handlers/experiment.rs
@@ -11,7 +11,7 @@ use crate::{CommandError, CommandHandler, CommandOutput, SlashCategory};
 
 /// Experimental features handler for `/experiment`.
 ///
-/// Delegates to [`AgentAccess::handle_experiment`] which is now Send-compatible:
+/// Delegates to `AgentAccess::handle_experiment` which is now Send-compatible:
 /// `handle_experiment_command_as_string` clones all `Arc` references before `.await`
 /// so no `&mut self` borrow is held across await boundaries.
 pub struct ExperimentCommand;

--- a/crates/zeph-commands/src/handlers/mcp.rs
+++ b/crates/zeph-commands/src/handlers/mcp.rs
@@ -2,52 +2,10 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! MCP management handler: `/mcp`.
-
-use std::future::Future;
-use std::pin::Pin;
-
-use crate::context::CommandContext;
-use crate::{CommandError, CommandHandler, CommandOutput, SlashCategory};
-
-/// MCP management handler stub.
-///
-/// This handler is NOT registered in any command registry. The `/mcp` command is dispatched
-/// directly via `dispatch_slash_command` because `handle_mcp_command` holds a
-/// `RwLockGuard<McpRegistry>` across `.await` points, making the future non-Send.
-///
-/// This struct exists to document the intended handler shape for when the Send constraint
-/// is lifted in a future migration phase.
-pub struct McpCommand;
-
-impl CommandHandler<CommandContext<'_>> for McpCommand {
-    fn name(&self) -> &'static str {
-        "/mcp"
-    }
-
-    fn description(&self) -> &'static str {
-        "Manage MCP servers"
-    }
-
-    fn args_hint(&self) -> &'static str {
-        "[add|list|tools|remove]"
-    }
-
-    fn category(&self) -> SlashCategory {
-        SlashCategory::Integration
-    }
-
-    fn handle<'a>(
-        &'a self,
-        ctx: &'a mut CommandContext<'_>,
-        args: &'a str,
-    ) -> Pin<Box<dyn Future<Output = Result<CommandOutput, CommandError>> + Send + 'a>> {
-        Box::pin(async move {
-            let result = ctx.agent.handle_mcp(args).await?;
-            if result.is_empty() {
-                Ok(CommandOutput::Silent)
-            } else {
-                Ok(CommandOutput::Message(result))
-            }
-        })
-    }
-}
+//!
+//! Note: a `McpCommand` struct is intentionally absent. `AgentAccess::handle_mcp` cannot be
+//! made `Send` due to HRTB constraints on `tokio::sync::RwLockWriteGuard` inside
+//! `McpManager::add_server` / `remove_server` — the guard is held across `.await`, which
+//! fails the `for<'a> &'a Agent<C>: Send` bound in a `Box<dyn Future + Send>`. `/mcp`
+//! remains in `dispatch_slash_command` until `McpManager` is refactored to avoid holding the
+//! write guard across await boundaries.

--- a/crates/zeph-commands/src/handlers/plan.rs
+++ b/crates/zeph-commands/src/handlers/plan.rs
@@ -11,7 +11,7 @@ use crate::{CommandError, CommandHandler, CommandOutput, SlashCategory};
 
 /// Planning handler for `/plan`.
 ///
-/// Delegates to [`AgentAccess::handle_plan`] which dispatches to `dispatch_plan_command`.
+/// Delegates to `AgentAccess::handle_plan` which dispatches to `dispatch_plan_command`.
 /// The future is Send because `Agent<C>: Send` and no non-Send guards are held across
 /// await boundaries.
 pub struct PlanCommand;

--- a/crates/zeph-commands/src/handlers/plan.rs
+++ b/crates/zeph-commands/src/handlers/plan.rs
@@ -9,14 +9,11 @@ use std::pin::Pin;
 use crate::context::CommandContext;
 use crate::{CommandError, CommandHandler, CommandOutput, SlashCategory};
 
-/// Planning handler stub.
+/// Planning handler for `/plan`.
 ///
-/// This handler is NOT registered in any command registry. The `/plan` command is dispatched
-/// directly via `dispatch_slash_command` because `dispatch_plan_command` produces a non-Send
-/// future.
-///
-/// This struct exists to document the intended handler shape for when the Send constraint
-/// is lifted in a future migration phase.
+/// Delegates to [`AgentAccess::handle_plan`] which dispatches to `dispatch_plan_command`.
+/// The future is Send because `Agent<C>: Send` and no non-Send guards are held across
+/// await boundaries.
 pub struct PlanCommand;
 
 impl CommandHandler<CommandContext<'_>> for PlanCommand {

--- a/crates/zeph-context/src/summarization.rs
+++ b/crates/zeph-context/src/summarization.rs
@@ -25,6 +25,7 @@ use zeph_memory::{AnchoredSummary, TokenCounter};
 ///
 /// Passed to [`single_pass_summary`], [`summarize_with_llm`], and [`summarize_structured`]
 /// so these functions can be called from `zeph-context` without depending on `zeph-core`.
+#[derive(Clone)]
 pub struct SummarizationDeps {
     /// LLM provider used for all summarization calls.
     pub provider: AnyProvider,

--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -561,10 +561,10 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
 
     // ----- /compact -----
     //
-    // compact_context() is not Send because load_compression_guidelines_if_enabled holds &self
-    // across an .await. The method signature is required by the AgentAccess trait (NullAgent
-    // needs it), but Agent<C>'s implementation panics — the actual dispatch remains in
-    // dispatch_slash_command which calls self.compact_context() directly without the Send bound.
+    // compact_context() is not Send because summarize_messages holds &self (via &AnyProvider
+    // in SummarizationDeps) across .await points — a fundamental HRTB limitation.
+    // The actual dispatch remains in dispatch_slash_command which calls compact_context()
+    // directly without the Send bound.
 
     fn compact_context<'a>(
         &'a mut self,
@@ -581,14 +581,21 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
 
     fn reset_conversation<'a>(
         &'a mut self,
-        _keep_plan: bool,
-        _no_digest: bool,
+        keep_plan: bool,
+        no_digest: bool,
     ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>> {
-        Box::pin(async {
-            Err(CommandError::new(
-                "/new cannot be dispatched via AgentAccess (non-Send future); \
-                 handled directly in dispatch_slash_command",
-            ))
+        Box::pin(async move {
+            match self.reset_conversation(keep_plan, no_digest).await {
+                Ok((old_id, new_id)) => {
+                    let old = old_id.map_or_else(|| "none".to_string(), |id| id.0.to_string());
+                    let new = new_id.map_or_else(|| "none".to_string(), |id| id.0.to_string());
+                    let keep_note = if keep_plan { " (plan preserved)" } else { "" };
+                    Ok(format!(
+                        "New conversation started. Previous: {old} → Current: {new}{keep_note}"
+                    ))
+                }
+                Err(e) => Ok(format!("Failed to start new conversation: {e}")),
+            }
         })
     }
 
@@ -635,8 +642,9 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
 
     // ----- /mcp -----
     //
-    // handle_mcp_command holds RwLockGuard across .await points — not Send.
-    // Dispatched via slash_commands directly, not through AgentAccess.
+    // handle_mcp_command_as_string is not Send because McpManager::add_server/remove_server
+    // hold tokio::sync::RwLockWriteGuard across .await points — an HRTB limitation.
+    // The actual dispatch remains in dispatch_slash_command.
 
     fn handle_mcp<'a>(
         &'a mut self,
@@ -644,7 +652,7 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
     ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>> {
         Box::pin(async {
             Err(CommandError::new(
-                "/mcp cannot be dispatched via AgentAccess (RwLockGuard held across await); \
+                "/mcp cannot be dispatched via AgentAccess (non-Send future); \
                  handled directly in dispatch_slash_command",
             ))
         })
@@ -654,13 +662,13 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
 
     fn handle_plan<'a>(
         &'a mut self,
-        _input: &'a str,
+        input: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>> {
-        Box::pin(async {
-            Err(CommandError::new(
-                "/plan cannot be dispatched via AgentAccess (non-Send future); \
-                 handled directly in dispatch_slash_command",
-            ))
+        Box::pin(async move {
+            self.dispatch_plan_command(input)
+                .await
+                .map(|()| String::new())
+                .map_err(|e| CommandError::new(e.to_string()))
         })
     }
 
@@ -668,13 +676,12 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
 
     fn handle_experiment<'a>(
         &'a mut self,
-        _input: &'a str,
+        input: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>> {
-        Box::pin(async {
-            Err(CommandError::new(
-                "/experiment cannot be dispatched via AgentAccess (non-Send future); \
-                 handled directly in dispatch_slash_command",
-            ))
+        Box::pin(async move {
+            self.handle_experiment_command_as_string(input)
+                .await
+                .map_err(|e| CommandError::new(e.to_string()))
         })
     }
 

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -210,7 +210,9 @@ impl<C: Channel> Agent<C> {
         super::super::error::AgentError,
     > {
         // --- Step 1: create new ConversationId FIRST (fail-fast) ---
-        let new_conversation_id = if let Some(ref memory) = self.memory_state.persistence.memory {
+        // Clone the Arc before .await so &mut self is not held across the await boundary.
+        let memory_arc = self.memory_state.persistence.memory.clone();
+        let new_conversation_id = if let Some(memory) = memory_arc {
             match memory.sqlite().create_conversation().await {
                 Ok(id) => Some(id),
                 Err(e) => return Err(super::super::error::AgentError::Memory(e)),

--- a/crates/zeph-core/src/agent/context/summarization.rs
+++ b/crates/zeph-core/src/agent/context/summarization.rs
@@ -55,6 +55,14 @@ impl<C: Channel> Agent<C> {
         zeph_context::summarization::summarize_structured(&deps, messages, guidelines).await
     }
 
+    async fn try_summarize_structured_with_deps(
+        deps: SummarizationDeps,
+        messages: &[Message],
+        guidelines: &str,
+    ) -> Result<AnchoredSummary, zeph_llm::LlmError> {
+        zeph_context::summarization::summarize_structured(&deps, messages, guidelines).await
+    }
+
     /// Build a metadata-only summary without calling the LLM.
     /// Used as last-resort fallback when LLM summarization repeatedly fails.
     pub(super) fn build_metadata_summary(messages: &[Message]) -> String {
@@ -69,6 +77,14 @@ impl<C: Channel> Agent<C> {
         guidelines: &str,
     ) -> Result<String, zeph_llm::LlmError> {
         let deps = self.build_summarization_deps();
+        zeph_context::summarization::summarize_with_llm(&deps, messages, guidelines).await
+    }
+
+    async fn try_summarize_with_llm_with_deps(
+        deps: SummarizationDeps,
+        messages: &[Message],
+        guidelines: &str,
+    ) -> Result<String, zeph_llm::LlmError> {
         zeph_context::summarization::summarize_with_llm(&deps, messages, guidelines).await
     }
 
@@ -170,29 +186,117 @@ impl<C: Channel> Agent<C> {
         Ok(Self::build_metadata_summary(messages))
     }
 
+    /// Summarize `messages` using `deps` extracted from `&self` before any `.await`.
+    ///
+    /// Equivalent to `summarize_messages` but takes `SummarizationDeps` by value so the
+    /// caller can extract deps synchronously, then call this without holding `&self` across
+    /// any `.await`, making the enclosing future `Send`.
+    async fn summarize_messages_with_deps(
+        deps: SummarizationDeps,
+        structured_summaries: bool,
+        messages: &[Message],
+        guidelines: &str,
+    ) -> Result<String, super::super::error::AgentError> {
+        if structured_summaries {
+            match Self::try_summarize_structured_with_deps(deps.clone(), messages, guidelines).await
+            {
+                Ok(anchored) => {
+                    if let Some(ref cb) = deps.on_anchored_summary {
+                        cb(&anchored, false);
+                    }
+                    return Ok(super::cap_summary(anchored.to_markdown(), 16_000));
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "structured summarization failed, falling back to prose");
+                    if let Some(ref cb) = deps.on_anchored_summary {
+                        let empty = AnchoredSummary {
+                            session_intent: String::new(),
+                            files_modified: vec![],
+                            decisions_made: vec![],
+                            open_questions: vec![],
+                            next_steps: vec![],
+                        };
+                        cb(&empty, true);
+                    }
+                }
+            }
+        }
+
+        match Self::try_summarize_with_llm_with_deps(deps.clone(), messages, guidelines).await {
+            Ok(summary) => return Ok(summary),
+            Err(e) if !e.is_context_length_error() => return Err(e.into()),
+            Err(e) => {
+                tracing::warn!(
+                    "summarization hit context length error ({e}), trying progressive tool response removal"
+                );
+            }
+        }
+
+        for fraction in [0.10f32, 0.20, 0.50, 1.0] {
+            let reduced = Self::remove_tool_responses_middle_out(messages.to_vec(), fraction);
+            tracing::debug!(
+                fraction,
+                "retrying summarization with reduced tool responses"
+            );
+            match Self::try_summarize_with_llm_with_deps(deps.clone(), &reduced, guidelines).await {
+                Ok(summary) => {
+                    tracing::info!(
+                        fraction,
+                        "summarization succeeded after tool response removal"
+                    );
+                    return Ok(summary);
+                }
+                Err(e) if e.is_context_length_error() => {
+                    tracing::warn!(fraction, "still context length error, trying next tier");
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+
+        tracing::warn!("all LLM summarization attempts failed, using metadata fallback");
+        Ok(Self::build_metadata_summary(messages))
+    }
+
     /// Load the current compression guidelines from `SQLite` if the feature is enabled.
     ///
     /// Returns an empty string when the feature is disabled, memory is not initialized,
     /// or the database query fails (non-fatal).
-    async fn load_compression_guidelines_if_enabled(&self) -> String {
-        let config = &self.memory_state.compaction.compression_guidelines_config;
-        if !config.enabled {
+    ///
+    /// Callers must extract `memory` and `conv_id` from `&self` before the first `.await`
+    /// so that `&self` is not held across the await boundary (required for Send futures).
+    async fn load_compression_guidelines(
+        enabled: bool,
+        memory: Option<std::sync::Arc<zeph_memory::semantic::SemanticMemory>>,
+        conv_id: Option<zeph_memory::ConversationId>,
+    ) -> String {
+        if !enabled {
             return String::new();
         }
-        let Some(memory) = &self.memory_state.persistence.memory else {
+        let Some(memory) = memory else {
             return String::new();
         };
-        match memory
-            .sqlite()
-            .load_compression_guidelines(self.memory_state.persistence.conversation_id)
-            .await
-        {
+        match memory.sqlite().load_compression_guidelines(conv_id).await {
             Ok((_, text)) => text,
             Err(e) => {
                 tracing::warn!("failed to load compression guidelines: {e:#}");
                 String::new()
             }
         }
+    }
+
+    /// Load the current compression guidelines from `SQLite` if the feature is enabled.
+    ///
+    /// Returns an empty string when the feature is disabled, memory is not initialized,
+    /// or the database query fails (non-fatal).
+    async fn load_compression_guidelines_if_enabled(&self) -> String {
+        let enabled = self
+            .memory_state
+            .compaction
+            .compression_guidelines_config
+            .enabled;
+        let memory = self.memory_state.persistence.memory.clone();
+        let conv_id = self.memory_state.persistence.conversation_id;
+        Self::load_compression_guidelines(enabled, memory, conv_id).await
     }
 
     /// Archive tool output bodies from `to_compact` messages before compaction (Memex #2432).
@@ -203,14 +307,19 @@ impl<C: Channel> Agent<C> {
     ///
     /// References are injected AFTER summarization (fix C1: LLM would destroy them).
     /// Returns an empty vec when `archive_tool_outputs` is disabled or memory is unavailable.
-    async fn archive_tool_outputs_for_compaction(&self, to_compact: &[Message]) -> Vec<String> {
-        if !self.context_manager.compression.archive_tool_outputs {
+    ///
+    /// Callers must extract `memory` and `cid` from `&self` before the first `.await`
+    /// so that `&self` is not held across the await boundary (required for Send futures).
+    async fn archive_tool_outputs(
+        archive_enabled: bool,
+        memory: Option<std::sync::Arc<zeph_memory::semantic::SemanticMemory>>,
+        cid: Option<zeph_memory::ConversationId>,
+        to_compact: &[Message],
+    ) -> Vec<String> {
+        if !archive_enabled {
             return Vec::new();
         }
-        let (Some(memory), Some(cid)) = (
-            &self.memory_state.persistence.memory,
-            self.memory_state.persistence.conversation_id,
-        ) else {
+        let (Some(memory), Some(cid)) = (memory, cid) else {
             return Vec::new();
         };
 
@@ -256,6 +365,13 @@ impl<C: Channel> Agent<C> {
             );
         }
         refs
+    }
+
+    async fn archive_tool_outputs_for_compaction(&self, to_compact: &[Message]) -> Vec<String> {
+        let archive_enabled = self.context_manager.compression.archive_tool_outputs;
+        let memory = self.memory_state.persistence.memory.clone();
+        let cid = self.memory_state.persistence.conversation_id;
+        Self::archive_tool_outputs(archive_enabled, memory, cid, to_compact).await
     }
 
     #[allow(clippy::too_many_lines)]
@@ -345,7 +461,17 @@ impl<C: Channel> Agent<C> {
         }
 
         // Load compression guidelines if configured.
-        let guidelines = self.load_compression_guidelines_if_enabled().await;
+        // Extract all params from &self before .await so no &self is held across await.
+        let guidelines = {
+            let enabled = self
+                .memory_state
+                .compaction
+                .compression_guidelines_config
+                .enabled;
+            let memory = self.memory_state.persistence.memory.clone();
+            let conv_id = self.memory_state.persistence.conversation_id;
+            Self::load_compression_guidelines(enabled, memory, conv_id).await
+        };
 
         // Memex: archive tool output bodies before compaction (#2432).
         //
@@ -355,10 +481,20 @@ impl<C: Channel> Agent<C> {
         //
         // Invariant: save_archive() is called before the placeholder is created;
         // the placeholder is only inserted into the postfix, not into `to_compact`.
-        let archived_refs: Vec<String> =
-            self.archive_tool_outputs_for_compaction(&to_compact).await;
+        // Extract all params from &self before .await so no &self is held across await.
+        let archived_refs: Vec<String> = {
+            let archive_enabled = self.context_manager.compression.archive_tool_outputs;
+            let memory = self.memory_state.persistence.memory.clone();
+            let cid = self.memory_state.persistence.conversation_id;
+            Self::archive_tool_outputs(archive_enabled, memory, cid, &to_compact).await
+        };
 
-        let summary = self.summarize_messages(&to_compact, &guidelines).await?;
+        // Extract deps before .await so &self is not held across the await boundary.
+        let summary = {
+            let deps = self.build_summarization_deps();
+            let structured = self.memory_state.compaction.structured_summaries;
+            Self::summarize_messages_with_deps(deps, structured, &to_compact, &guidelines).await?
+        };
 
         // Compaction probe: validate summary quality before committing it.
         if self.context_manager.compression.probe.enabled {

--- a/crates/zeph-core/src/agent/experiment_cmd.rs
+++ b/crates/zeph-core/src/agent/experiment_cmd.rs
@@ -314,6 +314,197 @@ impl<C: Channel> Agent<C> {
         }
         Ok(())
     }
+    /// Dispatch `/experiment` returning output as a string instead of writing to the channel.
+    ///
+    /// All `Arc` clones are extracted before `.await` so `&mut self` is not held across await
+    /// boundaries, making the returned future `Send`.
+    pub(super) async fn handle_experiment_command_as_string(
+        &mut self,
+        input: &str,
+    ) -> Result<String, AgentError> {
+        let args = input.strip_prefix("/experiment").unwrap_or("").trim();
+        match args {
+            "" | "status" => self.experiment_status().await,
+            "stop" => Ok(self.experiment_stop()),
+            "report" => self.experiment_report().await,
+            "best" => self.experiment_best().await,
+            _ if args == "start" || args.starts_with("start ") => {
+                let max_override = args
+                    .strip_prefix("start")
+                    .and_then(|s| s.trim().parse::<u32>().ok());
+                Ok(self.experiment_start(max_override))
+            }
+            _ => Ok(
+                "Unknown /experiment subcommand. Available: /experiment start [N], \
+                 /experiment stop, /experiment status, /experiment report, /experiment best"
+                    .to_owned(),
+            ),
+        }
+    }
+
+    async fn experiment_status(&mut self) -> Result<String, AgentError> {
+        let running = self
+            .experiments
+            .cancel
+            .as_ref()
+            .is_some_and(|t| !t.is_cancelled());
+        let mut msg = if running {
+            String::from("Experiment: **running**. Use `/experiment stop` to cancel.")
+        } else {
+            String::from("Experiment: **idle**. Use `/experiment start [N]` to begin.")
+        };
+        let memory = self.memory_state.persistence.memory.clone();
+        if let Some(memory) = memory {
+            let rows = memory.sqlite().list_experiment_results(None, 1).await?;
+            if let Some(latest) = rows.first()
+                && let Some(summary) = memory
+                    .sqlite()
+                    .experiment_session_summary(&latest.session_id)
+                    .await?
+            {
+                let sid_len = summary.session_id.len().min(11);
+                let _ = write!(
+                    msg,
+                    "\nLast session: `{}` | {} experiments | {} accepted | best delta: {:.3}",
+                    &summary.session_id[..sid_len],
+                    summary.total,
+                    summary.accepted_count,
+                    summary.best_delta,
+                );
+            }
+        }
+        Ok(msg)
+    }
+
+    fn experiment_stop(&mut self) -> String {
+        match &self.experiments.cancel {
+            Some(token) if !token.is_cancelled() => {
+                token.cancel();
+                "Experiment session cancelled. Results so far are saved.".to_owned()
+            }
+            _ => "No experiment is currently running.".to_owned(),
+        }
+    }
+
+    async fn experiment_report(&mut self) -> Result<String, AgentError> {
+        let memory = self.memory_state.persistence.memory.clone();
+        let Some(memory) = memory else {
+            return Ok("Memory is not enabled — cannot query experiment results.".to_owned());
+        };
+        let rows = memory.sqlite().list_experiment_results(None, 50).await?;
+        if rows.is_empty() {
+            return Ok("No experiment results found.".to_owned());
+        }
+        let mut out = String::from("**Experiment Results** (last 50, newest first)\n\n```\n");
+        let _ = writeln!(
+            out,
+            "{:<8} {:<12} {:<20} {:<8} {:<8} {:<8} {:<8}",
+            "ID", "Session", "Parameter", "Delta", "Baseline", "Candidate", "Accepted"
+        );
+        for r in &rows {
+            let sid_len = r.session_id.len().min(11);
+            let _ = writeln!(
+                out,
+                "{:<8} {:<12} {:<20} {:<8.3} {:<8.3} {:<8.3} {:<8}",
+                r.id,
+                &r.session_id[..sid_len],
+                &r.parameter,
+                r.delta,
+                r.baseline_score,
+                r.candidate_score,
+                if r.accepted { "yes" } else { "no" },
+            );
+        }
+        out.push_str("```");
+        Ok(out)
+    }
+
+    async fn experiment_best(&mut self) -> Result<String, AgentError> {
+        let memory = self.memory_state.persistence.memory.clone();
+        let Some(memory) = memory else {
+            return Ok("Memory is not enabled — cannot query experiment results.".to_owned());
+        };
+        let row = memory.sqlite().best_experiment_result(None).await?;
+        let msg = match row {
+            None => "No accepted experiment results found yet.".to_owned(),
+            Some(r) => {
+                let sid_len = r.session_id.len().min(11);
+                format!(
+                    "**Best experiment result**\n\
+                     - Session: `{}`\n\
+                     - Parameter: `{}`\n\
+                     - Delta: `{:.3}` ({:.3} → {:.3})\n\
+                     - Source: `{}`\n\
+                     - At: {}",
+                    &r.session_id[..sid_len],
+                    r.parameter,
+                    r.delta,
+                    r.baseline_score,
+                    r.candidate_score,
+                    r.source,
+                    r.created_at,
+                )
+            }
+        };
+        Ok(msg)
+    }
+
+    fn experiment_start(&mut self, max_override: Option<u32>) -> String {
+        if self
+            .experiments
+            .cancel
+            .as_ref()
+            .is_some_and(|t| !t.is_cancelled())
+        {
+            return "Experiment already running. Use /experiment stop to cancel.".to_owned();
+        }
+        let mut config = self.experiments.config.clone();
+        if !config.enabled {
+            return "Experiments are disabled. Set `experiments.enabled = true` in config and restart."
+                .to_owned();
+        }
+        if let Some(n) = max_override {
+            config.max_experiments = n;
+        }
+        if let Err(e) = config.validate() {
+            return format!("Experiment config is invalid: {e}");
+        }
+        let max_n = config.max_experiments;
+        let engine = match self.build_experiment_engine(config) {
+            Ok(e) => e,
+            Err(msg) => return msg,
+        };
+        let cancel = engine.cancel_token();
+        self.experiments.cancel = Some(cancel);
+        let notify_tx = self.experiments.notify_tx.clone();
+        tokio::spawn(async move {
+            let mut engine = engine;
+            let msg = match engine.run().await {
+                Ok(report) => {
+                    let accepted = report.results.iter().filter(|r| r.accepted).count();
+                    let wall_secs =
+                        f64::from(u32::try_from(report.wall_time_ms).unwrap_or(u32::MAX)) / 1000.0;
+                    format!(
+                        "Experiment session `{}` complete: {}/{} accepted, \
+                         baseline {:.3} → {:.3} (improvement {:.3}), {wall_secs:.1}s{}",
+                        &report.session_id[..report.session_id.len().min(8)],
+                        accepted,
+                        report.results.len(),
+                        report.baseline_score,
+                        report.final_score,
+                        report.total_improvement,
+                        if report.cancelled { " [cancelled]" } else { "" },
+                    )
+                }
+                Err(e) => format!("Experiment session failed: {e}"),
+            };
+            let _ = notify_tx.send(msg).await;
+        });
+        format!(
+            "Experiment session starting (max {max_n} experiments). \
+             Use /experiment stop to cancel. Results will be shown when complete."
+        )
+    }
 }
 
 #[cfg(test)]

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -891,10 +891,13 @@ impl<C: Channel> Agent<C> {
                 use zeph_commands::CommandRegistry;
                 use zeph_commands::handlers::{
                     agent_cmd::AgentCommand,
+                    compaction::NewConversationCommand,
+                    experiment::ExperimentCommand,
                     lsp::LspCommand,
                     memory::{GraphCommand, GuidelinesCommand, MemoryCommand},
                     misc::{CacheStatsCommand, ImageCommand},
                     model::{ModelCommand, ProviderCommand},
+                    plan::PlanCommand,
                     policy::PolicyCommand,
                     scheduler::SchedulerCommand,
                     status::{FocusCommand, GuardrailCommand, SideQuestCommand, StatusCommand},
@@ -909,8 +912,10 @@ impl<C: Channel> Agent<C> {
                 // Note: SkillCommand, SkillsCommand, FeedbackCommand are intentionally NOT
                 // registered here — their implementations hold non-Send references across .await
                 // points. They continue to be dispatched via dispatch_slash_command below.
-                // Similarly, CompactCommand, NewConversationCommand, McpCommand, PlanCommand,
-                // ExperimentCommand hold non-Send futures and remain in dispatch_slash_command.
+                // Note: /compact and /mcp remain in dispatch_slash_command below — their
+                // AgentAccess impls cannot be made Send due to HRTB limitations:
+                // - /compact: AnyProvider is !Sync, so &AnyProvider across .await fails
+                // - /mcp: RwLockWriteGuard held across .await in McpManager::add_server
                 agent_reg.register(PolicyCommand);
                 agent_reg.register(SchedulerCommand);
                 agent_reg.register(LspCommand);
@@ -922,6 +927,10 @@ impl<C: Channel> Agent<C> {
                 agent_reg.register(FocusCommand);
                 agent_reg.register(SideQuestCommand);
                 agent_reg.register(AgentCommand);
+                // Phase 5 migrations (Send-compatible):
+                agent_reg.register(NewConversationCommand);
+                agent_reg.register(ExperimentCommand);
+                agent_reg.register(PlanCommand);
 
                 let mut ctx = zeph_commands::CommandContext {
                     sink: &mut agent_null_sink,

--- a/crates/zeph-core/src/agent/plan.rs
+++ b/crates/zeph-core/src/agent/plan.rs
@@ -106,12 +106,14 @@ impl<C: crate::channel::Channel> Agent<C> {
         }
     }
 
-    pub(super) async fn goal_embedding_for_cache(&self, goal: &str) -> Option<Vec<f32>> {
+    pub(super) async fn goal_embedding_for_cache(&mut self, goal: &str) -> Option<Vec<f32>> {
         use zeph_orchestration::normalize_goal;
 
         self.orchestration.plan_cache.as_ref()?;
         let normalized = normalize_goal(goal);
-        match self.embedding_provider.embed(&normalized).await {
+        // Clone provider before .await so &self is not held across the await boundary.
+        let provider = self.embedding_provider.clone();
+        match provider.embed(&normalized).await {
             Ok(emb) => Some(emb),
             Err(zeph_llm::LlmError::EmbedUnsupported { .. }) => {
                 tracing::debug!(
@@ -914,7 +916,6 @@ impl<C: crate::channel::Channel> Agent<C> {
                     .map_err(error::AgentError::from)?;
             }
         }
-        let _ = self.channel.flush_chunks().await;
         Ok(())
     }
 }

--- a/crates/zeph-core/src/agent/slash_commands.rs
+++ b/crates/zeph-core/src/agent/slash_commands.rs
@@ -32,10 +32,8 @@ impl<C: crate::channel::Channel> Agent<C> {
     /// Commands that remain here could not be migrated to the registry pattern because their
     /// implementations hold non-Send futures (references across `.await` points):
     /// - `/skill`, `/skills`, `/feedback` — non-Send DB references
-    /// - `/compact`, `/new` — `compact_context`/`reset_conversation` hold `&self` across .await
-    /// - `/mcp` — `RwLockGuard` across .await
-    /// - `/plan` — orchestration internals
-    /// - `/experiment` — spawned task handles
+    /// - `/compact` — `AnyProvider::embed/chat` creates `&AnyProvider` across await (HRTB)
+    /// - `/mcp` — `McpManager` methods hold `RwLockWriteGuard` across await (HRTB)
     ///
     /// All other slash commands are dispatched through `session_registry` or `agent_registry`
     /// in `Agent::run`.
@@ -79,33 +77,9 @@ impl<C: crate::channel::Channel> Agent<C> {
             handled!(self.channel.send(&msg).await.map_err(Into::into));
         }
 
-        if trimmed == "/new" || trimmed.starts_with("/new ") {
-            let args = trimmed.strip_prefix("/new").unwrap_or("").trim();
-            let keep_plan = args.split_whitespace().any(|a| a == "--keep-plan");
-            let no_digest = args.split_whitespace().any(|a| a == "--no-digest");
-            let msg = match self.reset_conversation(keep_plan, no_digest).await {
-                Ok((old_id, new_id)) => {
-                    let old = old_id.map_or_else(|| "none".to_string(), |id| id.0.to_string());
-                    let new = new_id.map_or_else(|| "none".to_string(), |id| id.0.to_string());
-                    let keep_note = if keep_plan { " (plan preserved)" } else { "" };
-                    format!("New conversation started. Previous: {old} → Current: {new}{keep_note}")
-                }
-                Err(e) => format!("Failed to start new conversation: {e}"),
-            };
-            handled!(self.channel.send(&msg).await.map_err(Into::into));
-        }
-
         if trimmed == "/mcp" || trimmed.starts_with("/mcp ") {
             let args = trimmed.strip_prefix("/mcp").unwrap_or("").trim().to_owned();
             handled!(self.handle_mcp_command(&args).await);
-        }
-
-        if trimmed == "/plan" || trimmed.starts_with("/plan ") {
-            return Some(self.dispatch_plan_command(trimmed).await);
-        }
-
-        if trimmed == "/experiment" || trimmed.starts_with("/experiment ") {
-            handled!(self.handle_experiment_command(trimmed).await);
         }
 
         if trimmed == "/skills" || trimmed.starts_with("/skills ") {


### PR DESCRIPTION
## Summary

Migrates `/new`, `/experiment`, and `/plan` from the legacy `dispatch_slash_command` switch
to the `CommandHandler` registry, making them `Send`-compatible via the extract-before-await
pattern.

- `/new` → `NewConversationCommand`: clones `Arc<SemanticMemory>` in `reset_conversation`
  before `.await`; `--keep-plan`/`--no-digest` flag parsing extracted and covered by 5 unit
  tests
- `/experiment` → `ExperimentCommand`: `handle_experiment_command_as_string` dispatches to
  5 focused helpers; all clone `Arc<SemanticMemory>` before each `.await`
- `/plan` → `PlanCommand`: delegates to `dispatch_plan_command`; `goal_embedding_for_cache`
  changed to clone `embedding_provider` before `.await`; redundant `flush_chunks` call removed
  (registry already flushes after each handler)

`/compact` and `/mcp` remain in `dispatch_slash_command` with documented HRTB blockers:
- `/compact`: `AnyProvider: !Sync` — `&AnyProvider` across `.await` in a
  `Box<dyn Future + Send>` fails for all lifetimes
- `/mcp`: `RwLockWriteGuard` held across `.await` inside `McpManager::add_server/remove_server`

Dead `CompactCommand` and `McpCommand` structs (never registered, always returned `Err`) are
removed. Their handler files now carry module-level docs explaining the upstream changes
required to unblock registration.

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo nextest run --workspace --lib --bins` — 7915 passed, 0 failed
- [ ] `cargo nextest run --workspace --features full --lib --bins` — 8231 passed, 0 failed
- [ ] Verify `/new`, `/experiment`, `/plan` dispatch through registry (existing integration coverage)
- [ ] Verify `/compact` and `/mcp` still dispatch through `dispatch_slash_command`

## Follow-up issues to file

- Make `AnyProvider: Sync` in `zeph-llm` to unblock `/compact` migration
- Refactor `McpManager::add_server/remove_server` to avoid `RwLockWriteGuard` across `.await`
  to unblock `/mcp` migration