### PR TITLE
fix(bootstrap,channels,core): unused import and CLI image path traversal

### DIFF
--- a/crates/zeph-channels/src/cli.rs
+++ b/crates/zeph-channels/src/cli.rs
@@ -105,9 +105,14 @@ async fn process_line(
             return Ok(None);
         }
         let path_owned = path.to_owned();
+        let p = std::path::Path::new(&path_owned);
+        if p.is_absolute() || p.components().any(|c| c == std::path::Component::ParentDir) {
+            println!("Zeph: Invalid image path: path traversal not allowed");
+            return Ok(None);
+        }
         match tokio::fs::read(&path_owned).await {
             Err(e) => {
-                println!("Zeph: File not found: {path_owned}: {e}");
+                println!("Zeph: Cannot read image {path_owned}: {e}");
             }
             Ok(data) => {
                 let filename = std::path::Path::new(&path_owned)
@@ -771,5 +776,35 @@ mod tests {
         let result = ch.recv().await.unwrap();
         assert!(result.is_some());
         assert_eq!(result.unwrap().text, "hello");
+    }
+
+    #[tokio::test]
+    async fn image_command_absolute_path_is_rejected() {
+        let mut pending: Vec<Attachment> = Vec::new();
+        let mut history = Some(InputHistory::new(vec![], Box::new(|_| {})));
+        let result = process_line(
+            "/image /etc/passwd".to_owned(),
+            false,
+            &mut history,
+            &mut pending,
+        )
+        .await;
+        assert!(matches!(result, Ok(None)));
+        assert!(pending.is_empty());
+    }
+
+    #[tokio::test]
+    async fn image_command_parent_dir_traversal_is_rejected() {
+        let mut pending: Vec<Attachment> = Vec::new();
+        let mut history = Some(InputHistory::new(vec![], Box::new(|_| {})));
+        let result = process_line(
+            "/image ../../../etc/passwd".to_owned(),
+            false,
+            &mut history,
+            &mut pending,
+        )
+        .await;
+        assert!(matches!(result, Ok(None)));
+        assert!(pending.is_empty());
     }
 }

--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -660,6 +660,7 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
 
     // ----- /plan -----
 
+    #[cfg(feature = "scheduler")]
     fn handle_plan<'a>(
         &'a mut self,
         input: &'a str,
@@ -670,6 +671,14 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
                 .map(|()| String::new())
                 .map_err(|e| CommandError::new(e.to_string()))
         })
+    }
+
+    #[cfg(not(feature = "scheduler"))]
+    fn handle_plan<'a>(
+        &'a mut self,
+        _input: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>> {
+        Box::pin(async move { Ok(String::new()) })
     }
 
     // ----- /experiment -----

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -27,6 +27,7 @@ mod message_queue;
 mod microcompact;
 mod model_commands;
 mod persistence;
+#[cfg(feature = "scheduler")]
 mod plan;
 mod policy_commands;
 mod provider_cmd;

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -21,8 +21,6 @@ pub use provider::{
 pub use skills::{
     create_embedding_provider, create_skill_matcher, effective_embedding_model, managed_skills_dir,
 };
-#[cfg(feature = "candle")]
-pub use zeph_core::provider_factory::select_device;
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;

--- a/src/bootstrap/tests.rs
+++ b/src/bootstrap/tests.rs
@@ -209,6 +209,9 @@ fn create_provider_openai_missing_api_key_errors() {
 }
 
 #[cfg(feature = "candle")]
+use zeph_core::provider_factory::select_device;
+
+#[cfg(feature = "candle")]
 #[test]
 fn select_device_cpu_default() {
     let device = select_device("cpu").unwrap();


### PR DESCRIPTION
## Summary

- **#2932**: removes unused `pub use select_device` re-export from `src/bootstrap/mod.rs` under `#[cfg(feature = "candle")]`; moves the `use` into the test module — fixes clippy error with `--features full`
- **#2933**: adds path traversal + absolute path rejection to the CLI `/image` handler in `zeph-channels/src/cli.rs`; unifies error message with `ImageCommand` handler; adds two regression tests
- Adds missing `#[cfg(feature = "scheduler")]` guard on `mod plan` / `handle_plan` in `zeph-core` to fix compile without scheduler feature (pre-existing regression found during CI)

## Test plan

- [ ] `cargo clippy --workspace --features "desktop,ide,server,chat,pdf,scheduler,classifiers" -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo nextest run --workspace --lib --bins --features "desktop,ide,server,chat,pdf,scheduler,classifiers"` — 8221 passed
- [ ] `image_command_absolute_path_is_rejected` test verifies `/etc/passwd` is blocked
- [ ] `image_command_parent_dir_traversal_is_rejected` test verifies `../../../etc/passwd` is blocked

## Related

- Filed #2937 for the identical incomplete traversal check in `zeph-core/src/agent/slash_commands.rs`