### PR TITLE
fix(core,experiments): path traversal in ImageCommand and rand RUSTSEC-2026-0097

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Security
+
+- **Path traversal fix in `ImageCommand`** (`#2937`): `handle_image_as_string` in
+  `zeph-core` now rejects absolute paths (e.g. `/etc/passwd`) in addition to `../`
+  traversal sequences. Mirrors the equivalent fix applied to the CLI channel in `#2933`.
+
+- **Upgrade `zeph-experiments` to `rand 0.10`** (`#2929`): removed unsound `rand 0.8.5`
+  dependency (RUSTSEC-2026-0097). `rand` now resolves via `workspace = true` to the safe
+  `rand 0.10.1`. Updated call sites from `Rng::gen_range` to `RngExt::random_range` per
+  the rand 0.10 API. All other previously inline-versioned dependencies (`serde`,
+  `serde_json`, `thiserror`, `tracing`) in `zeph-experiments` also migrated to workspace
+  references.
+
 ### Changed
 
 - **Handler migration phase 5** (`#2928`): migrated `/new`, `/experiment`, and `/plan` from the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10089,7 +10089,7 @@ dependencies = [
  "futures",
  "ordered-float 5.3.0",
  "proptest",
- "rand 0.8.5",
+ "rand 0.10.1",
  "schemars 1.2.1",
  "serde",
  "serde_json",

--- a/crates/zeph-core/src/agent/slash_commands.rs
+++ b/crates/zeph-core/src/agent/slash_commands.rs
@@ -381,10 +381,8 @@ impl<C: crate::channel::Channel> Agent<C> {
         use std::path::Component;
         use zeph_llm::provider::{ImageData, MessagePart};
 
-        let has_parent_dir = std::path::Path::new(path)
-            .components()
-            .any(|c| c == Component::ParentDir);
-        if has_parent_dir {
+        let p = std::path::Path::new(path);
+        if p.is_absolute() || p.components().any(|c| c == Component::ParentDir) {
             return "Invalid image path: path traversal not allowed".to_owned();
         }
 

--- a/crates/zeph-core/src/agent/tests.rs
+++ b/crates/zeph-core/src/agent/tests.rs
@@ -1575,9 +1575,35 @@ pub mod agent_tests {
         let executor = MockToolExecutor::no_tools();
         let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
 
-        let result = agent.handle_image_as_string("/nonexistent/image.png");
+        let result = agent.handle_image_as_string("nonexistent/image.png");
         assert!(agent.msg.pending_image_parts.is_empty());
         assert!(result.contains("Cannot read image"));
+    }
+
+    #[test]
+    fn handle_image_command_absolute_path_is_rejected() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+        let result = agent.handle_image_as_string("/etc/passwd");
+        assert!(agent.msg.pending_image_parts.is_empty());
+        assert!(result.contains("path traversal not allowed"));
+    }
+
+    #[test]
+    fn handle_image_command_parent_dir_traversal_is_rejected() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+        let result = agent.handle_image_as_string("../../etc/passwd");
+        assert!(agent.msg.pending_image_parts.is_empty());
+        assert!(result.contains("path traversal not allowed"));
     }
 
     #[test]

--- a/crates/zeph-core/src/agent/tests.rs
+++ b/crates/zeph-core/src/agent/tests.rs
@@ -1608,18 +1608,29 @@ pub mod agent_tests {
 
     #[test]
     fn handle_image_command_loads_valid_file() {
-        use std::io::Write;
+        use std::io::Write as _;
         let provider = mock_provider(vec![]);
         let channel = MockChannel::new(vec![]);
         let registry = create_test_registry();
         let executor = MockToolExecutor::no_tools();
         let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
 
-        // Write a small temp image
-        let mut tmp = tempfile::NamedTempFile::with_suffix(".jpg").unwrap();
+        // Use a temp dir under cwd so the resulting path can be made relative,
+        // which is required by the path-traversal guard.
+        let cwd = std::env::current_dir().unwrap();
+        let tmp_dir = tempfile::TempDir::new_in(&cwd).unwrap();
+        let file_path = tmp_dir.path().join("test.jpg");
         let data = vec![0xFFu8, 0xD8, 0xFF, 0xE0];
-        tmp.write_all(&data).unwrap();
-        let path = tmp.path().to_str().unwrap().to_owned();
+        std::fs::File::create(&file_path)
+            .unwrap()
+            .write_all(&data)
+            .unwrap();
+        let path = file_path
+            .strip_prefix(&cwd)
+            .unwrap_or(&file_path)
+            .to_str()
+            .unwrap()
+            .to_owned();
 
         let result = agent.handle_image_as_string(&path);
         assert_eq!(agent.msg.pending_image_parts.len(), 1);

--- a/crates/zeph-experiments/Cargo.toml
+++ b/crates/zeph-experiments/Cargo.toml
@@ -13,11 +13,11 @@ description = "Experiment engine for adaptive agent behavior testing and hyperpa
 readme = "README.md"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-thiserror = "2.0"
-rand = { version = "0.8", features = ["small_rng"] }
-tracing = "0.1"
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+thiserror.workspace = true
+rand.workspace = true
+tracing.workspace = true
 futures.workspace = true
 ordered-float.workspace = true
 schemars.workspace = true

--- a/crates/zeph-experiments/src/neighborhood.rs
+++ b/crates/zeph-experiments/src/neighborhood.rs
@@ -13,7 +13,7 @@
 use std::collections::HashSet;
 
 use ordered_float::OrderedFloat;
-use rand::Rng as _;
+use rand::RngExt as _;
 use rand::SeedableRng as _;
 use rand::rngs::SmallRng;
 
@@ -94,14 +94,14 @@ impl VariationGenerator for Neighborhood {
             return None;
         }
         for _ in 0..MAX_RETRIES {
-            let idx = self.rng.gen_range(0..self.search_space.parameters.len());
+            let idx = self.rng.random_range(0..self.search_space.parameters.len());
             let range = &self.search_space.parameters[idx];
             let current = baseline.get(range.kind);
             // DEFAULT_STEPS is used when step is None (continuous parameter).
             let step = range
                 .step
                 .unwrap_or_else(|| (range.max - range.min) / DEFAULT_STEPS);
-            let delta = self.rng.gen_range(-self.radius..=self.radius) * step;
+            let delta = self.rng.random_range(-self.radius..=self.radius) * step;
             // Skip zero perturbations — they produce the baseline value, wasting an attempt.
             if delta.abs() < f64::EPSILON {
                 continue;

--- a/crates/zeph-experiments/src/random.rs
+++ b/crates/zeph-experiments/src/random.rs
@@ -14,7 +14,7 @@ use std::collections::HashSet;
 use std::sync::Mutex;
 
 use ordered_float::OrderedFloat;
-use rand::Rng as _;
+use rand::RngExt as _;
 use rand::SeedableRng as _;
 use rand::rngs::SmallRng;
 
@@ -96,9 +96,9 @@ impl VariationGenerator for Random {
         }
         let mut rng = self.rng.lock().expect("rng mutex poisoned");
         for _ in 0..MAX_RETRIES {
-            let idx = rng.gen_range(0..self.search_space.parameters.len());
+            let idx = rng.random_range(0..self.search_space.parameters.len());
             let range = &self.search_space.parameters[idx];
-            let raw: f64 = rng.gen_range(range.min..=range.max);
+            let raw: f64 = rng.random_range(range.min..=range.max);
             let value = range.quantize(raw);
             let variation = Variation {
                 parameter: range.kind,


### PR DESCRIPTION
## Summary

- Closes #2937: `handle_image_as_string` in `zeph-core` now rejects absolute paths (e.g. `/etc/passwd`) alongside `../` traversal sequences. Mirrors the fix applied to the CLI channel in #2933/#2938.
- Closes #2929: `zeph-experiments` upgraded from `rand 0.8.5` (RUSTSEC-2026-0097, unsound) to `rand 0.10.1` via `workspace = true`. Updated `gen_range` → `random_range` (`RngExt` trait). Removed `small_rng` feature (dropped in rand 0.10). Migrated `serde`, `serde_json`, `thiserror`, `tracing` to workspace references.

## Test plan

- [ ] `cargo build -p zeph-core -p zeph-experiments` passes
- [ ] `cargo nextest run -p zeph-experiments --lib` — 123 tests pass
- [ ] `cargo +nightly fmt --check` passes
- [ ] `/image /etc/passwd` returns `Invalid image path: path traversal not allowed`
- [ ] `cargo deny check advisories` no longer reports RUSTSEC-2026-0097