### PR TITLE
docs(specs): add BRD, SRS, NFR and fill gaps in spec coverage

### DIFF
--- a/specs/021-zeph-context/spec.md
+++ b/specs/021-zeph-context/spec.md
@@ -1,0 +1,228 @@
+---
+aliases:
+  - Context Budget
+  - Context Manager
+  - Context Assembler
+  - Context Crate
+tags:
+  - sdd
+  - spec
+  - core
+  - context
+  - compaction
+created: 2026-04-13
+status: approved
+related:
+  - "[[MOC-specs]]"
+  - "[[constitution]]"
+  - "[[001-system-invariants/spec]]"
+  - "[[002-agent-loop/spec]]"
+  - "[[004-memory/spec]]"
+---
+
+# Spec: Context Crate (`zeph-context`)
+
+> [!info]
+> Token budget calculation, context lifecycle state machine, and stateless context assembler
+> for the Zeph agent. Extracted from `zeph-core` to eliminate monolith growth and improve
+> compile-time isolation. Has no dependency on `zeph-core`.
+
+## 1. Overview
+
+### Problem Statement
+
+Context management grew into a large, intertwined subsystem inside `zeph-core`. Compaction
+logic, budget arithmetic, and parallel fetch coordination mixed with agent loop concerns,
+creating long rebuild times and making the subsystem difficult to test in isolation.
+
+### Goal
+
+Provide a self-contained crate (`zeph-context`) that owns the **stateless and data-only**
+parts of context management: budget arithmetic, compaction state machine, parallel context
+assembly, and associated helpers. `zeph-core` depends on this crate but not vice versa.
+
+### Out of Scope
+
+- Agent loop control flow (owned by `zeph-core`)
+- LLM calls for summarization (callers in `zeph-core` pass results in)
+- Channel communication during assembly (all `send_status` calls stay in `zeph-core`)
+- Persistence (owned by `zeph-memory`)
+
+---
+
+## 2. User Stories
+
+### US-001: Budget Allocation
+
+AS A `zeph-core` agent loop
+I WANT to compute a per-slot token budget for the current turn
+SO THAT each context source (summaries, graph facts, semantic recall, code context, etc.)
+receives a fair share and the response reserve is always protected.
+
+**Acceptance criteria:**
+
+```
+GIVEN the model's context window size and current prompt usage
+WHEN ContextBudget::allocate() is called
+THEN a BudgetAllocation is returned with non-negative per-slot values
+AND the sum of all slots plus response_reserve does not exceed the total window
+AND slots are zero when disabled or budget is exhausted
+```
+
+### US-002: Compaction State Machine
+
+AS A `zeph-core` agent loop
+I WANT a strict state machine to track compaction lifecycle
+SO THAT invalid states (e.g., compaction warning without exhaustion, double-compact per turn)
+are structurally unrepresentable.
+
+**Acceptance criteria:**
+
+```
+GIVEN CompactionState::Ready
+WHEN hard compaction succeeds
+THEN state transitions to CompactedThisTurn { cooldown }
+
+GIVEN CompactionState::CompactedThisTurn { cooldown: 0 }
+WHEN advance_turn() is called
+THEN state transitions to Ready
+
+GIVEN CompactionState::Exhausted { warned: false }
+WHEN the warning is dispatched
+THEN state transitions to Exhausted { warned: true } and no further transitions occur
+```
+
+### US-003: Parallel Context Assembly
+
+AS A `zeph-core` agent loop
+I WANT all context sources fetched concurrently in a single pass
+SO THAT context assembly latency is bounded by the slowest single source, not their sum.
+
+**Acceptance criteria:**
+
+```
+GIVEN a ContextAssemblyInput with multiple enabled sources
+WHEN ContextAssembler::gather() is called
+THEN all source futures are driven via FuturesUnordered concurrently
+AND the result is a PreparedContext with each slot as Option (None = disabled / empty)
+AND no Agent fields are mutated inside gather()
+AND no channel messages are sent inside gather()
+```
+
+### US-004: Microcompact Detection
+
+AS A `zeph-core` agent loop
+I WANT to detect turns dominated by low-value tool results
+SO THAT microcompact eviction can target the right messages without reading full history.
+
+**Acceptance criteria:**
+
+```
+GIVEN a recent turn's tool results
+WHEN microcompact::is_low_value_result() is called
+THEN it returns true for outputs matching known low-signal patterns
+AND it returns false for results with meaningful content
+```
+
+---
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN `ContextBudget::allocate()` is called THEN the system SHALL return a `BudgetAllocation` where the sum of all slots plus `response_reserve` is less than or equal to the total context window | must |
+| FR-002 | WHEN any context slot exceeds its allocated budget THEN the system SHALL truncate or omit that slot rather than overflow into adjacent slots | must |
+| FR-003 | WHEN `CompactionState` transitions are applied THEN the system SHALL enforce the documented state machine and reject invalid transitions | must |
+| FR-004 | WHEN `ContextAssembler::gather()` is called THEN the system SHALL fan out all source futures concurrently using `FuturesUnordered` and collect all results before returning | must |
+| FR-005 | WHEN a context source returns an error THEN the system SHALL log the error at `WARN` level and treat that slot as `None` (graceful degradation) | must |
+| FR-006 | WHEN `ContextManager` is queried for compaction eligibility THEN it SHALL check both the compaction state and the turn-boundary cooldown before returning a recommendation | must |
+| FR-007 | WHEN summarization prompt helpers are called THEN the system SHALL produce deterministic prompt strings given the same inputs | should |
+| FR-008 | WHEN `compression_feedback` detects context loss THEN it SHALL classify the failure into a `CompressionFailureClass` for downstream handling | should |
+| FR-009 | WHEN slot helpers compute a trimmed slice THEN the system SHALL return only the tokens that fit within the allocated budget and not mutate the source | must |
+
+---
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | `ContextBudget::allocate()` must complete in < 1 µs (pure arithmetic, no I/O) |
+| NFR-002 | Performance | `ContextAssembler::gather()` latency must equal max(individual source latency) not sum(all latencies) |
+| NFR-003 | Correctness | `CompactionState` must be `Copy` — transitions must be side-effect-free value operations |
+| NFR-004 | Isolation | `zeph-context` must not depend on `zeph-core`; the dependency DAG is strictly downward |
+| NFR-005 | Testability | Budget and state machine logic must be testable with unit tests only (no external services) |
+| NFR-006 | Safety | No `unsafe` code; `unsafe_code = "deny"` workspace lint applies |
+
+---
+
+## 5. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `ContextBudget` | Token budget for a single agent session | `max_tokens`, per-slot ratios, `response_reserve` |
+| `BudgetAllocation` | Result of one budget split | Per-slot token counts: `summaries`, `semantic_recall`, `cross_session`, `code_context`, `graph_facts`, `recent_history`, `response_reserve`, `session_digest` |
+| `ContextManager` | Compaction lifecycle tracker | `CompactionState`, `turns_since_last_hard_compaction`, routing config |
+| `CompactionState` | State machine enum | Variants: `Ready`, `CompactedThisTurn { cooldown }`, `Cooling { turns_remaining }`, `Exhausted { warned }` |
+| `ContextAssembler` | Stateless parallel fetch coordinator | Takes `ContextAssemblyInput`, returns `PreparedContext` |
+| `ContextAssemblyInput` | Borrowed view of all assembly inputs | References to memory stores, index, config, token counter |
+| `PreparedContext` | Result of one assembly pass | `graph_facts`, `doc_rag`, `semantic_recall`, `cross_session`, `summaries`, `corrections` — all `Option<Message>` |
+| `ContextSlot` | Single fetched context source result | Content string, token count, source label |
+| `CompressionFailureClass` | Classification of a compaction failure | Enum: `ContextLoss`, `OversizedInput`, `SummarizationFailure`, `NothingToCompact` |
+
+---
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Total budget < response_reserve | All source slots are zero; only response_reserve is allocated |
+| Single source fetch panics | Other sources continue; panic is caught at the assembler boundary |
+| Source returns empty content | Slot is set to `None`; budget is not charged |
+| `CompactionState::Exhausted` reached | No further compaction attempts; one user-facing warning dispatched |
+| Cooldown turns = 0 | State immediately advances to `Ready` on `advance_turn()` |
+| Budget arithmetic overflow | Saturating arithmetic used throughout; no panic |
+
+---
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Unit test coverage for `CompactionState` transitions | All documented transitions have a test |
+| SC-002 | `ContextAssembler::gather()` in tests | All futures are driven concurrently (verified via timing) |
+| SC-003 | Compile-time isolation | `cargo check -p zeph-context` completes without `zeph-core` in the dependency graph |
+| SC-004 | Budget arithmetic | `BudgetAllocation` slot sum ≤ max_tokens in all property tests |
+
+---
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Run `cargo nextest run -p zeph-context` after changes
+- Follow stateless-only convention: no agent fields mutated inside `gather()`
+
+### Ask First
+- Adding new context slots to `BudgetAllocation` (affects all callers in `zeph-core`)
+- Changing `CompactionState` transitions (must update the documented transition map)
+- Adding dependencies to `zeph-context`'s `Cargo.toml`
+
+### Never
+- Add a dependency on `zeph-core`
+- Perform channel I/O or logging to users inside `ContextAssembler::gather()`
+- Use `unsafe` blocks
+
+---
+
+## 9. Open Questions
+
+None.
+
+---
+
+## 10. See Also
+
+- [[constitution]] — project principles
+- [[001-system-invariants/spec]] — cross-cutting invariants
+- [[002-agent-loop/spec]] — agent loop that consumes this crate
+- [[004-memory/spec]] — memory stores queried by `ContextAssembler`
+- [[MOC-specs]] — all specifications

--- a/specs/042-zeph-commands/spec.md
+++ b/specs/042-zeph-commands/spec.md
@@ -1,0 +1,208 @@
+---
+aliases:
+  - Slash Commands
+  - Command Registry
+  - Command Dispatch
+tags:
+  - sdd
+  - spec
+  - commands
+  - dispatch
+created: 2026-04-13
+status: approved
+related:
+  - "[[MOC-specs]]"
+  - "[[constitution]]"
+  - "[[001-system-invariants/spec]]"
+  - "[[002-agent-loop/spec]]"
+  - "[[030-tui-slash-autocomplete/spec]]"
+---
+
+# Spec: Slash Command Registry (`zeph-commands`)
+
+> [!info]
+> Non-generic slash command registry, handler trait, channel sink abstraction, and static
+> command metadata used by `zeph-core` for `/command` dispatch. Does not depend on `zeph-core`.
+
+## 1. Overview
+
+### Problem Statement
+
+The original agent loop used a generic `Agent<C: Channel>` parameter that propagated
+through every slash command handler. Adding or modifying a handler required recompiling
+`zeph-core`. Registering a new command and exposing its metadata (for `/help` and TUI
+autocomplete) required touching the monolith.
+
+### Goal
+
+Provide a compile-time-isolated crate (`zeph-commands`) that owns the command registry,
+handler trait, dispatch algorithm, and static command list. `zeph-core` wires concrete
+subsystem traits into `CommandContext` at dispatch time; handlers operate on trait objects.
+
+### Out of Scope
+
+- Agent loop control flow (owned by `zeph-core`)
+- Concrete LLM, memory, or tool calls inside handlers (delegated through trait objects)
+- TUI rendering and autocomplete (consume `COMMANDS` from this crate but render in `zeph-tui`)
+- Telegram-specific command routing
+
+---
+
+## 2. User Stories
+
+### US-001: Command Dispatch
+
+AS A `zeph-core` agent loop
+I WANT to dispatch a user input string to the matching slash command handler
+SO THAT the handler runs without the agent loop knowing handler-specific logic.
+
+**Acceptance criteria:**
+
+```
+GIVEN a CommandRegistry with registered handlers
+WHEN dispatch() is called with "/plan confirm foo"
+THEN the handler registered as "/plan confirm" is selected (longest-word-boundary match)
+AND args = "foo" is passed to the handler
+AND the CommandOutput is returned to the agent loop
+```
+
+### US-002: Unique Registration
+
+AS A developer registering a new handler
+I WANT the registry to panic on duplicate command names at initialization
+SO THAT accidental duplicate registration is caught early, not at dispatch time.
+
+**Acceptance criteria:**
+
+```
+GIVEN a registry with "/plan" already registered
+WHEN register() is called with another "/plan" handler
+THEN the process panics with a message containing "duplicate command name"
+```
+
+### US-003: Help Metadata
+
+AS A `/help` handler
+I WANT to list all registered commands with category and argument hints
+SO THAT users see a complete and grouped help output.
+
+**Acceptance criteria:**
+
+```
+GIVEN a registry with N handlers
+WHEN list() is called
+THEN N CommandInfo structs are returned in registration order
+AND each struct has a non-empty name, description, and category
+```
+
+### US-004: ChannelSink Abstraction
+
+AS A command handler
+I WANT to send messages to the user via a ChannelSink trait object
+SO THAT the handler is not coupled to any concrete Channel type.
+
+**Acceptance criteria:**
+
+```
+GIVEN a handler receiving a &mut dyn ChannelSink
+WHEN the handler calls sink.send("text").await
+THEN the message is delivered to the underlying channel without the handler knowing its type
+```
+
+---
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN `CommandRegistry::dispatch()` receives input not starting with `/` THEN the system SHALL return `None` | must |
+| FR-002 | WHEN multiple handlers match (subcommand hierarchy) THEN the system SHALL select the handler with the longest matching command name | must |
+| FR-003 | WHEN `register()` is called with a duplicate name THEN the system SHALL panic with an informative message | must |
+| FR-004 | WHEN `list()` is called THEN the system SHALL return `CommandInfo` for every registered handler in registration order | must |
+| FR-005 | WHEN a handler returns `CommandOutput::Exit` THEN the system SHALL propagate this to the caller and the agent loop SHALL terminate | must |
+| FR-006 | WHEN a handler returns `CommandOutput::Silent` THEN the system SHALL produce no user-facing output for that command | must |
+| FR-007 | WHEN a handler is feature-gated THEN it SHALL set `feature_gate: Some("feature-name")` in its `CommandInfo` so `/help` can annotate it | should |
+| FR-008 | WHEN `CommandRegistry::find_handler()` is called THEN it SHALL return the handler index and name without executing the handler | should |
+
+---
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Isolation | `zeph-commands` must not depend on `zeph-core` |
+| NFR-002 | Performance | Dispatch is O(N) linear scan over < 40 handlers — no hash map needed |
+| NFR-003 | Object Safety | `CommandHandler<Ctx>` must be object-safe; uses `Pin<Box<dyn Future>>` not `async fn` |
+| NFR-004 | Thread Safety | All handlers must be `Send + Sync` for use in async contexts |
+| NFR-005 | Safety | No `unsafe` code |
+
+---
+
+## 5. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `CommandRegistry<Ctx>` | Registry storing boxed handlers | `Vec<Box<dyn CommandHandler<Ctx>>>` |
+| `CommandHandler<Ctx>` | Object-safe handler trait | `name()`, `description()`, `args_hint()`, `category()`, `feature_gate()`, `handle()` |
+| `CommandContext` | Concrete dispatch context | Trait-object fields for each subsystem access trait |
+| `CommandOutput` | Result of a dispatch | Variants: `Message(String)`, `Silent`, `Exit`, `Continue` |
+| `CommandError` | Handler error | Wraps agent-level errors as `String` |
+| `CommandInfo` | Static command metadata | `name`, `args`, `description`, `category`, `feature_gate` |
+| `SlashCategory` | Display grouping | Variants: `Session`, `Configuration`, `Memory`, `Skills`, `Planning`, `Debugging`, `Integration`, `Advanced` |
+| `ChannelSink` | Minimal async I/O trait | `async fn send(&mut self, msg: &str)` |
+| `NullSink` | No-op sink for tests | Discards all messages |
+
+---
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Input is "/" with no command name | `dispatch()` returns `None` |
+| Input matches no handler | `dispatch()` returns `None` |
+| Handler returns `Err(CommandError)` | Agent loop logs and reports to user; does not crash |
+| Registry is empty | `dispatch()` always returns `None`; `list()` returns empty Vec |
+| `/plan` and `/plan confirm` both registered, input is "/plan" | `/plan` handler selected (exact match, not prefix) |
+
+---
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Longest-match dispatch | Unit tests cover exact match, subcommand match, and no-match cases |
+| SC-002 | Compile isolation | `cargo check -p zeph-commands` succeeds without `zeph-core` in the graph |
+| SC-003 | Duplicate guard | Test confirms `register()` panics on duplicate name |
+
+---
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Run `cargo nextest run -p zeph-commands` after changes
+- Keep handlers object-safe (no generic `async fn` in trait)
+
+### Ask First
+- Adding a new `SlashCategory` variant (affects `/help` grouping and TUI autocomplete)
+- Changing `CommandOutput` variants (affects all dispatch sites in `zeph-core`)
+- Adding dependencies to `zeph-commands`
+
+### Never
+- Add a dependency on `zeph-core`
+- Make `CommandHandler` non-object-safe
+- Use `unsafe` blocks
+
+---
+
+## 9. Open Questions
+
+None.
+
+---
+
+## 10. See Also
+
+- [[constitution]] — project principles
+- [[002-agent-loop/spec]] — consumes `CommandRegistry` at dispatch time
+- [[030-tui-slash-autocomplete/spec]] — reads `COMMANDS` for autocomplete suggestions
+- [[MOC-specs]] — all specifications

--- a/specs/043-zeph-common/spec.md
+++ b/specs/043-zeph-common/spec.md
@@ -1,0 +1,221 @@
+---
+aliases:
+  - Shared Primitives
+  - Common Utilities
+  - Security Primitives
+tags:
+  - sdd
+  - spec
+  - common
+  - primitives
+  - security
+created: 2026-04-13
+status: approved
+related:
+  - "[[MOC-specs]]"
+  - "[[constitution]]"
+  - "[[001-system-invariants/spec]]"
+  - "[[010-security/spec]]"
+  - "[[038-vault/spec]]"
+---
+
+# Spec: Shared Primitives (`zeph-common`)
+
+> [!info]
+> Pure utility functions, security primitives, and strongly-typed identifiers shared by
+> multiple `zeph-*` crates. Has no `zeph-*` dependencies; it is the lowest layer in the
+> workspace dependency DAG.
+
+## 1. Overview
+
+### Problem Statement
+
+Multiple crates in the workspace needed the same utility functions (text manipulation,
+network helpers, hash utilities), security primitives (`Secret` with zeroize-on-drop,
+trust levels, sanitization helpers), and strongly-typed identifiers (`ToolName`, `SessionId`,
+`ToolDefinition`). Without a shared crate, these were duplicated or forced awkward
+dependencies through higher-level crates.
+
+### Goal
+
+Provide a single foundation crate (`zeph-common`) that all other `zeph-*` crates may
+depend on for shared types and utilities. The crate must remain free of `zeph-*` peer
+dependencies to avoid cycles in the dependency DAG.
+
+### Out of Scope
+
+- Business logic (agent loop, LLM calls, memory operations)
+- Configuration parsing (owned by `zeph-config`)
+- Vault key storage and encryption (owned by `zeph-vault`)
+- Database access
+
+---
+
+## 2. User Stories
+
+### US-001: Secret Handling
+
+AS A any `zeph-*` crate handling user credentials or API keys
+I WANT a `Secret<T>` wrapper that redacts output in logs and zeroes memory on drop
+SO THAT secrets never appear in debug output and are not retained in memory after use.
+
+**Acceptance criteria:**
+
+```
+GIVEN a Secret wrapping a string value
+WHEN Debug or Display is formatted
+THEN the output is "[REDACTED]" not the actual value
+
+GIVEN a Secret that goes out of scope
+WHEN the drop runs
+THEN the inner memory is overwritten via zeroize
+```
+
+### US-002: Strongly-Typed Tool Names
+
+AS A tool registry or LLM response parser
+I WANT a `ToolName` newtype backed by `Arc<str>`
+SO THAT cloning is O(1) and accidental `String` conversion is prevented at compile time.
+
+**Acceptance criteria:**
+
+```
+GIVEN a ToolName("shell")
+WHEN it is cloned N times
+THEN all clones share the same Arc allocation (O(1) clone cost)
+
+GIVEN a ToolName
+WHEN serialized to JSON
+THEN the output is a plain string (serde transparent)
+```
+
+### US-003: Session Identity
+
+AS A channel adapter or memory store
+I WANT a `SessionId` newtype wrapping UUIDs
+SO THAT session identifiers are type-safe and cannot be confused with tool names or other IDs.
+
+**Acceptance criteria:**
+
+```
+GIVEN a SessionId
+WHEN compared to another SessionId for the same session
+THEN equality holds
+
+GIVEN a SessionId generated via SessionId::new()
+THEN it is globally unique (UUID v4)
+```
+
+### US-004: Text and Hash Utilities
+
+AS A sanitizer or context builder
+I WANT utility functions for text truncation, Unicode normalization, and BLAKE3 hashing
+SO THAT each crate does not reimplement these operations with subtle differences.
+
+**Acceptance criteria:**
+
+```
+GIVEN the same input string
+WHEN hash::blake3_hex() is called multiple times
+THEN the same hex string is returned (deterministic)
+```
+
+---
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN `Secret::new()` is called THEN the system SHALL wrap the value in `Zeroizing<String>` so memory is overwritten on drop | must |
+| FR-002 | WHEN `Secret` is formatted via `Debug` or `Display` THEN the system SHALL output `"[REDACTED]"` | must |
+| FR-003 | WHEN `ToolName::new()` is called THEN the system SHALL store the string in an `Arc<str>` for O(1) clones | must |
+| FR-004 | WHEN `ToolName` is serialized THEN the system SHALL use `#[serde(transparent)]` producing a plain JSON string | must |
+| FR-005 | WHEN `SessionId::new()` is called THEN the system SHALL generate a UUID v4 | must |
+| FR-006 | WHEN `hash::blake3_hex()` is called with the same input THEN the system SHALL return the same output (deterministic) | must |
+| FR-007 | WHEN the `treesitter` feature is enabled THEN the system SHALL expose tree-sitter query constants and language helpers | should |
+| FR-008 | WHEN `policy::PolicyLlmClient` is used THEN the system SHALL provide a minimal LLM interface for policy checks that does not depend on `zeph-llm` | must |
+| FR-009 | WHEN `trust_level::SkillTrustLevel` is evaluated THEN the system SHALL express the Untrusted/Provisional/Trusted trust gradient | must |
+| FR-010 | WHEN `sanitize` utilities are called THEN the system SHALL provide content sanitization helpers usable by any crate without depending on `zeph-sanitizer` | should |
+
+---
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Isolation | `zeph-common` must have zero `zeph-*` peer dependencies |
+| NFR-002 | Security | `Secret` must use `Zeroizing<String>` from the `zeroize` crate; Clone must not be derived |
+| NFR-003 | Performance | `ToolName::clone()` must be O(1) via `Arc<str>` |
+| NFR-004 | Correctness | `ToolName` must not implement `Deref<Target=str>` to prevent `.to_owned()` footgun |
+| NFR-005 | Safety | No `unsafe` code |
+| NFR-006 | Minimalism | This crate must not grow into a utility dumping ground; new additions require justification |
+
+---
+
+## 5. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `Secret` | Redacted, zeroized secret wrapper | `Zeroizing<String>` inner; no `Clone`; `expose() -> &str` |
+| `ToolName` | Strongly-typed tool name label | `Arc<str>` inner; `as_str()`, `PartialEq<str>` |
+| `SessionId` | Strongly-typed session identifier | UUID v4; `new()`, `Display` |
+| `ToolDefinition` | Shared tool schema struct | Name, description, JSON schema blob |
+| `SkillTrustLevel` | Trust gradient for skills | Enum: `Untrusted`, `Provisional`, `Trusted` |
+| `PolicyLlmClient` | Minimal LLM interface for policy | Trait for content-policy checking without `zeph-llm` dependency |
+| `PolicyMessage` | Message for policy evaluation | Role + content |
+| `PolicyRole` | Role in policy context | `User`, `Assistant` |
+
+---
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Empty string passed to `Secret::new()` | Allowed; `expose()` returns `""` |
+| `ToolName` constructed from empty string | Allowed; represents a degenerate tool name (validation is caller's responsibility) |
+| `blake3_hex()` called with empty input | Returns deterministic BLAKE3 hash of empty bytes |
+| `treesitter` feature disabled | Module is excluded from compilation; no dead-code warnings |
+
+---
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Compile isolation | `cargo check -p zeph-common` succeeds with no `zeph-*` in dependency graph |
+| SC-002 | Secret zeroization | Unit test confirms `Secret` does not implement `Clone` (compile_fail doctest) |
+| SC-003 | ToolName O(1) clone | Unit test or doctest verifies `Arc` semantics |
+
+---
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Run `cargo nextest run -p zeph-common` after changes
+- Keep the crate free of `zeph-*` peer dependencies
+
+### Ask First
+- Adding new public types (affects all dependent crates)
+- Enabling new features in `Cargo.toml`
+- Removing or renaming public items (breaking change before v1.0)
+
+### Never
+- Add a dependency on any `zeph-*` crate
+- Derive `Clone` on `Secret`
+- Use `unsafe` blocks
+
+---
+
+## 9. Open Questions
+
+None.
+
+---
+
+## 10. See Also
+
+- [[constitution]] — project principles
+- [[001-system-invariants/spec]] — system-wide invariants
+- [[010-security/spec]] — security model that `zeph-common` primitives enforce
+- [[038-vault/spec]] — vault crate that uses `Secret` from this crate
+- [[MOC-specs]] — all specifications

--- a/specs/044-subagent-lifecycle/spec.md
+++ b/specs/044-subagent-lifecycle/spec.md
@@ -1,0 +1,287 @@
+---
+aliases:
+  - Subagent Management
+  - Subagent Lifecycle
+  - Agent Spawning
+tags:
+  - sdd
+  - spec
+  - subagent
+  - delegation
+  - lifecycle
+created: 2026-04-13
+status: approved
+related:
+  - "[[MOC-specs]]"
+  - "[[constitution]]"
+  - "[[001-system-invariants/spec]]"
+  - "[[002-agent-loop/spec]]"
+  - "[[010-security/spec]]"
+  - "[[026-tui-subagent-management/spec]]"
+  - "[[033-subagent-context-propagation/spec]]"
+---
+
+# Spec: Subagent Lifecycle (`zeph-subagent`)
+
+> [!info]
+> Full lifecycle of sub-agent tasks within the Zeph agent framework: definition parsing,
+> spawning, concurrency management, permission grants, hooks, tool filtering, transcript
+> persistence, and memory injection. Implements the `/agent` and `/agents` slash commands.
+
+## 1. Overview
+
+### Problem Statement
+
+Delegating sub-tasks to isolated LLM sessions requires strict lifecycle management:
+controlled spawning, bounded concurrency, cancellation propagation, TTL-bounded permission
+grants, per-agent tool policies, and persistent transcripts for resume and audit. Without
+a dedicated crate, this logic would accumulate in `zeph-core` and couple unrelated concerns.
+
+### Goal
+
+Provide `zeph-subagent` as the single source of truth for everything relating to sub-agent
+lifecycle: parsing `SubAgentDef` files, spawning isolated agent loops, enforcing permission
+grants and tool policies, firing lifecycle hooks, and persisting transcripts.
+
+### Out of Scope
+
+- TUI sidebar rendering for subagents (owned by `zeph-tui`, spec `026`)
+- Context propagation details (spec `033` covers the gap analysis; this spec covers the full lifecycle)
+- MCP server lifecycle (owned by `zeph-mcp`)
+- A2A protocol (owned by `zeph-a2a`)
+
+---
+
+## 2. User Stories
+
+### US-001: Spawning a Subagent
+
+AS A parent agent loop
+I WANT to spawn a named subagent definition with an initial prompt and parent context
+SO THAT isolated work is delegated without blocking the parent.
+
+**Acceptance criteria:**
+
+```
+GIVEN a valid SubAgentDef file and a SpawnContext with parent messages
+WHEN SubAgentManager::spawn() is called
+THEN a SubAgentHandle is returned with a unique task ID
+AND the subagent runs in an isolated tokio task
+AND parent_cancel propagation cancels the child when the parent is cancelled (foreground mode)
+AND spawn_depth is incremented by 1
+```
+
+### US-002: Concurrency Limit
+
+AS A system operator
+I WANT to cap the number of concurrently running subagents
+SO THAT runaway `/agent spawn` chains cannot exhaust system resources.
+
+**Acceptance criteria:**
+
+```
+GIVEN the concurrency limit is set to N
+WHEN N subagents are already running
+AND another spawn is attempted
+THEN spawn() returns Err(SubAgentError::ConcurrencyLimitExceeded)
+```
+
+### US-003: Permission Grants
+
+AS A parent agent giving a subagent access to vault secrets or tools
+I WANT TTL-bounded permission grants
+SO THAT secrets are not exposed beyond the subagent's session lifetime.
+
+**Acceptance criteria:**
+
+```
+GIVEN a Grant with kind=VaultSecret and a TTL of 300s
+WHEN the grant expires (TTL elapses)
+THEN subsequent calls to grants.check() return Err for that grant
+AND memory is zeroized when the grant is dropped
+```
+
+### US-004: Tool Policy Enforcement
+
+AS A subagent spawned with a restricted tool policy
+I WANT the FilteredToolExecutor to block disallowed tool calls
+SO THAT the subagent cannot exceed its declared permissions.
+
+**Acceptance criteria:**
+
+```
+GIVEN a SubAgentDef with tool_policy = "readonly"
+WHEN the subagent calls the "shell" write tool
+THEN FilteredToolExecutor rejects the call with a permission-denied error
+AND the rejection is logged at WARN level
+```
+
+### US-005: Transcript Persistence
+
+AS A user or operator reviewing past subagent sessions
+I WANT subagent conversations persisted to JSONL transcript files
+SO THAT I can inspect what the subagent did and resume interrupted sessions.
+
+**Acceptance criteria:**
+
+```
+GIVEN a subagent session that completes or is cancelled
+WHEN the session ends
+THEN a JSONL transcript file exists with one JSON line per turn
+AND TranscriptMeta records start time, end time, and exit reason
+AND sweep_old_transcripts() removes transcripts beyond the retention limit
+```
+
+### US-006: Lifecycle Hooks
+
+AS A developer configuring subagent behavior
+I WANT to define shell commands that run at PreToolUse, PostToolUse, SubagentStart, and SubagentStop
+SO THAT external integrations can react to subagent lifecycle events.
+
+**Acceptance criteria:**
+
+```
+GIVEN a hook definition with type = "SubagentStart" and a shell command
+WHEN a subagent starts
+THEN the shell command is executed with the subagent name in the environment
+AND hook execution failures are logged at WARN but do not abort the session
+```
+
+### US-007: Memory Injection
+
+AS A subagent starting a new session
+I WANT persistent `MEMORY.md` content injected into my system prompt
+SO THAT cross-session knowledge is available without explicit retrieval.
+
+**Acceptance criteria:**
+
+```
+GIVEN a MEMORY.md file in the subagent's memory directory
+WHEN the subagent's system prompt is assembled
+THEN the memory content is prepended to the system prompt
+AND memory content exceeding the token budget is truncated, not omitted entirely
+```
+
+---
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN `SubAgentDef::parse()` receives a Markdown file with YAML frontmatter THEN the system SHALL extract name, description, system prompt, permissions, and hooks | must |
+| FR-002 | WHEN an agent name fails the regex `^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$` THEN the system SHALL reject the definition with `SubAgentError::InvalidName` | must |
+| FR-003 | WHEN `SubAgentDef::load()` is called THEN the system SHALL enforce the 256 KiB file size limit and reject oversized files | must |
+| FR-004 | WHEN `SubAgentDef::load_all()` scans directories THEN the system SHALL process files in priority order and cap per-directory scans at the configured limit | must |
+| FR-005 | WHEN `SubAgentManager::spawn()` is called at the concurrency limit THEN the system SHALL return `Err(ConcurrencyLimitExceeded)` | must |
+| FR-006 | WHEN a subagent is spawned with `parent_cancel` THEN cancelling the parent token SHALL cancel the child's `CancellationToken` | must |
+| FR-007 | WHEN a `Grant` TTL expires THEN `PermissionGrants::check()` SHALL return an error for that grant | must |
+| FR-008 | WHEN `FilteredToolExecutor` receives a tool call THEN it SHALL check the `ToolPolicy` and denylist before forwarding to the real executor | must |
+| FR-009 | WHEN a subagent session ends (normally or via cancellation) THEN a JSONL transcript SHALL be written with complete turn history | must |
+| FR-010 | WHEN `sweep_old_transcripts()` is called THEN transcripts beyond the retention window SHALL be deleted | must |
+| FR-011 | WHEN lifecycle hooks are defined THEN `fire_hooks()` SHALL execute matching hooks for each `HookType` event | must |
+| FR-012 | WHEN hook execution fails THEN the failure SHALL be logged at `WARN` and the subagent session SHALL continue | must |
+| FR-013 | WHEN `load_memory_content()` is called THEN it SHALL read `MEMORY.md` from the resolved memory directory and return its content | should |
+| FR-014 | WHEN `AgentCommand` or `AgentsCommand` is parsed from user input THEN it SHALL map to a typed command variant (`spawn`, `list`, `cancel`, `resume`, `show`) | must |
+
+---
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Security | Agent names must be ASCII-only with the validated regex; path traversal characters are rejected |
+| NFR-002 | Security | Definition files are size-capped at 256 KiB before parsing |
+| NFR-003 | Security | `PermissionGrants` must be TTL-bounded; no grant may outlive its declared expiry |
+| NFR-004 | Concurrency | `SubAgentManager` must enforce the concurrency cap atomically (no TOCTOU) |
+| NFR-005 | Isolation | Subagent tool executors are independent instances; they do not share state with the parent |
+| NFR-006 | Persistence | Transcripts must be written atomically (write to temp file, then rename) |
+| NFR-007 | Safety | No `unsafe` code |
+
+---
+
+## 5. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `SubAgentDef` | Parsed subagent definition | `name`, `description`, system prompt body, `permissions: SubAgentPermissions`, `hooks: SubagentHooks` |
+| `SubAgentPermissions` | Permission set for a subagent | `tool_policy: ToolPolicy`, `skill_filter: SkillFilter`, `memory_scope: MemoryScope`, `permission_mode: PermissionMode` |
+| `SubAgentManager` | Lifecycle manager | Concurrency limit, active handles map, cancellation registry |
+| `SubAgentHandle` | Reference to a running task | Task ID (UUID), status channel, cancellation token |
+| `SubAgentStatus` | Current state of a task | Variants: `Running`, `Completed`, `Failed`, `Cancelled` |
+| `SpawnContext` | Parent-derived spawn state | `parent_messages`, `parent_cancel`, `parent_provider_name`, `spawn_depth`, `mcp_tool_names` |
+| `PermissionGrants` | TTL-bounded permission registry | Map of `GrantKind` → expiry timestamp |
+| `Grant` | Single permission grant | `kind: GrantKind`, `ttl_secs`, expiry instant |
+| `GrantKind` | Type of permission | Variants: `VaultSecret`, `Tool` |
+| `FilteredToolExecutor` | Tool executor with policy gate | Wraps real executor; enforces `ToolPolicy` and denylist |
+| `PlanModeExecutor` | Executor for plan mode | Wraps real executor; disables write operations |
+| `HookDef` | Lifecycle hook definition | `hook_type: HookType`, shell command template |
+| `HookType` | Lifecycle event | `PreToolUse`, `PostToolUse`, `SubagentStart`, `SubagentStop` |
+| `HookMatcher` | Pattern for hook selection | Glob or regex pattern on tool name / agent name |
+| `TranscriptWriter` | Append-only JSONL writer | Session ID, file path, turn counter |
+| `TranscriptReader` | Replay reader for transcripts | Iterates JSONL lines as `Message` |
+| `TranscriptMeta` | Session metadata record | Start time, end time, exit reason, turn count |
+| `SubAgentState` | Mutable runtime state | Active provider, current conversation, tool executor reference |
+
+---
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Definition file contains TOML frontmatter (deprecated) | Parsed with a deprecation warning in logs |
+| Agent name contains path traversal (e.g., `../etc`) | `is_valid_agent_name()` returns false; load rejected |
+| Spawn depth exceeds configured maximum | `spawn()` returns `Err(MaxDepthExceeded)` |
+| Transcript write fails (disk full) | Error logged at `ERROR`; session continues; partial transcript preserved |
+| Hook shell command not found | Hook fails; logged at `WARN`; session continues |
+| Grant checked after TTL expiry | Returns `Err`; no panic |
+| Subagent cancelled mid-turn | Tool in progress receives cancellation signal; transcript records `Cancelled` exit reason |
+| `load_all()` encounters symlink outside allowed boundary | File is skipped with a security warning in logs |
+
+---
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Name validation | Unit tests cover valid names, path traversal, unicode homoglyphs, empty, too-long |
+| SC-002 | Concurrency cap | Integration test spawns N+1 agents and confirms Nth+1 is rejected |
+| SC-003 | TTL expiry | Unit test advances mock clock past TTL and confirms grant check fails |
+| SC-004 | Tool policy | Unit test confirms disallowed tool is rejected by `FilteredToolExecutor` |
+| SC-005 | Transcript completeness | Integration test verifies all turns appear in JSONL after session ends |
+
+---
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Run `cargo nextest run -p zeph-subagent` after changes
+- Validate agent names with `is_valid_agent_name()` before any file I/O
+
+### Ask First
+- Adding new `HookType` variants (affects all callers that pattern-match)
+- Changing `SubAgentPermissions` fields (affects definition file format)
+- Raising the default concurrency limit (resource impact)
+- Adding new dependencies to `zeph-subagent`
+
+### Never
+- Allow agent names containing path separators without validation
+- Grant permissions beyond the declaring `SubAgentDef`'s declared policy
+- Bypass the size limit on definition file loading
+- Use `unsafe` blocks
+
+---
+
+## 9. Open Questions
+
+None.
+
+---
+
+## 10. See Also
+
+- [[constitution]] — project principles
+- [[002-agent-loop/spec]] — parent agent loop that uses `SubAgentManager`
+- [[010-security/spec]] — security model; agent name validation and grant TTLs are security controls
+- [[026-tui-subagent-management/spec]] — TUI sidebar that displays running subagents
+- [[033-subagent-context-propagation/spec]] — context propagation spec (shipped v0.18+)
+- [[MOC-specs]] — all specifications

--- a/specs/BRD.md
+++ b/specs/BRD.md
@@ -1,0 +1,487 @@
+---
+aliases:
+  - Zeph BRD
+  - Zeph Business Requirements
+tags:
+  - brd
+  - ai-agent
+  - rust
+  - status/draft
+created: 2026-04-13
+project: "Zeph"
+status: draft
+related:
+  - "[[SRS]]"
+  - "[[NFR]]"
+  - "[[constitution]]"
+  - "[[MOC-specs]]"
+---
+
+# Zeph: Business Requirements Document
+
+> [!abstract]
+> Zeph is a lightweight, open-source Rust AI agent with hybrid multi-provider
+> inference, a skills-first architecture, and semantic memory. This BRD defines
+> what Zeph is, why it exists, and what success looks like for its primary personas.
+> It serves as the business-level input to [[SRS]] and [[NFR]].
+
+## Executive Summary
+
+Zeph is an open-source, self-hostable AI agent written in Rust that integrates
+multiple LLM backends (Ollama, Claude, OpenAI, HuggingFace/candle) behind a
+unified interface. It gives developers, power users, and teams a programmable,
+privacy-respecting agent that runs locally or as a lightweight service, with
+no cloud lock-in. Skills-based extensibility lets users teach the agent domain
+knowledge without retraining a model. Semantic memory with SQLite and Qdrant
+gives the agent long-term recall across sessions. All I/O is handled through
+interchangeable channels (CLI, TUI, Telegram), and secrets are managed
+exclusively via an age-encrypted vault. Zeph targets pre-v1.0 active
+development and is not yet production-hardened for multi-tenant deployments.
+
+---
+
+## Problem Statement
+
+### What problem exists today?
+
+Existing AI agents are predominantly:
+
+1. **Cloud-only** — locked to a single provider's API, data leaves the machine.
+2. **Monoglot** — written in Python or TypeScript, making them difficult to
+   embed in Rust toolchains or operate with minimal runtime overhead.
+3. **Opaque** — behaviour is not auditable; there is no structured way to
+   extend the agent with domain knowledge beyond system-prompt hacking.
+4. **Memory-poor** — most agents have no durable cross-session memory; every
+   conversation starts cold.
+5. **Single-channel** — built for one interface (web chat or CLI), not portable
+   to Telegram, TUI dashboards, or programmatic APIs.
+
+### Who experiences this problem?
+
+- Rust developers who need an agent embedded in their workflow without a Python
+  dependency.
+- Privacy-aware power users who cannot send proprietary data to a cloud API.
+- Small teams that want a lightweight, self-hosted agent without infrastructure
+  complexity.
+
+### What is the impact of not solving it?
+
+Without Zeph, users must choose between heavyweight Python frameworks (LangChain,
+AutoGPT), cloud-only products (ChatGPT Plugins, Claude Projects), or writing
+agent glue code from scratch — all of which either leak data, require a Python
+runtime, or provide no semantic memory or skill governance.
+
+### Current workarounds
+
+- Pasting context manually into each conversation.
+- Shell scripts wrapping raw `curl` calls to OpenAI.
+- Python wrappers (LangChain) with substantial runtime overhead.
+- Local Ollama with no skill management or memory.
+
+> [!warning] Assumptions
+> - The primary deployment target is a developer's local machine or a small
+>   VPS, not a multi-tenant SaaS platform.
+> - Users are comfortable with TOML configuration and a terminal interface.
+> - The age vault is the only accepted secret storage; `.env` files are out
+>   of scope.
+
+---
+
+## Target Users
+
+### Primary Users
+
+| Persona | Description | Primary Goal | Key Pain Point |
+|---------|-------------|-------------|----------------|
+| **CLI Developer** | Rust/systems developer using Zeph as a daily coding assistant | Integrate an agent into shell workflows, pipe output, use slash commands | Existing agents require Python or cloud APIs |
+| **Power User (TUI)** | Technical user running Zeph full-time in a terminal TUI | Monitor agent state, context, metrics, and memory in real time | No visibility into what the agent is doing |
+| **Remote User (Telegram)** | Developer or team member accessing Zeph via a Telegram bot | Use the agent from mobile or when away from the terminal | CLI-only agents are inaccessible from mobile |
+
+### Secondary Users
+
+| Persona | Description | Primary Goal |
+|---------|-------------|-------------|
+| **Team Operator** | DevOps / infrastructure engineer deploying Zeph as a shared service | Expose Zeph via HTTP gateway, schedule tasks, monitor Prometheus metrics |
+| **Skill Author** | Developer writing SKILL.md files to extend agent behaviour | Teach the agent domain knowledge without touching Rust code |
+| **Benchmark Researcher** | ML engineer running Zeph against standard agent benchmarks | Compare memory, skill, and reasoning quality across providers |
+
+### Stakeholders
+
+- **Open-source contributors** — pull quality, project momentum, community trust.
+- **Anthropic / OpenAI / Ollama ecosystems** — compatibility with their APIs
+  is a dependency, not a requirement to control.
+
+---
+
+## Functional Requirements
+
+> [!tip] Priority Legend
+> - **Must** — without this the system is pointless (MVP)
+> - **Should** — important but can ship without it
+> - **Could** — nice to have
+
+### Agent Core
+
+- **FR-001**: As a CLI developer, I need the agent to receive messages, call
+  LLMs, execute tools, and return responses in a single coherent turn loop,
+  so that I can have a productive conversation with the agent.
+  - *Acceptance criteria*: a user message results in an LLM response within the
+    same terminal session; tool calls are dispatched and results appended before
+    the final reply.
+  - *Priority*: Must
+
+- **FR-002**: As any user, I need the agent to support slash commands
+  (`/help`, `/clear`, `/compact`, `/plan`, `/exit`), so that I can control
+  agent behaviour without leaving the current channel.
+  - *Acceptance criteria*: typing `/help` prints available commands; `/clear`
+    resets conversation; `/compact` triggers context compaction.
+  - *Priority*: Must
+
+- **FR-003**: As a power user, I need the agent to swap the active LLM provider
+  at runtime without restarting, so that I can switch between local and cloud
+  models mid-session.
+  - *Acceptance criteria*: provider swap via config hot-reload completes without
+    dropping the current conversation history.
+  - *Priority*: Should
+
+### Multi-Provider LLM Inference
+
+- **FR-010**: As a developer, I need Zeph to support Ollama, Claude (Anthropic),
+  OpenAI, OpenAI-compatible, and HuggingFace/candle providers behind a unified
+  interface, so that I am not locked to a single vendor.
+  - *Acceptance criteria*: each provider passes the standard chat, streaming,
+    and tool-call test suite.
+  - *Priority*: Must
+
+- **FR-011**: As a team operator, I need a provider pool with routing strategies
+  (cascade, cost-weighted, bandit, complexity-tiered), so that expensive models
+  are used only for complex tasks.
+  - *Acceptance criteria*: a configured `TriageRouter` sends simple queries to
+    the fast provider and complex queries to the quality provider, measurable
+    via debug logs.
+  - *Priority*: Should
+
+- **FR-012**: As any user, I need the agent to support prompt caching where
+  the provider supports it, so that repeated system prompts do not incur
+  unnecessary token costs.
+  - *Priority*: Could
+
+### Skills System
+
+- **FR-020**: As a skill author, I need to define agent skills in plain
+  `SKILL.md` files that are loaded and hot-reloaded without restarting the agent,
+  so that domain knowledge can be added or updated at runtime.
+  - *Acceptance criteria*: adding or editing a SKILL.md file is reflected in the
+    active registry within 500ms debounce.
+  - *Priority*: Must
+
+- **FR-021**: As a developer, I need skills to be matched to user messages via
+  hybrid BM25 + embedding scoring with a configurable disambiguation threshold,
+  so that irrelevant skills are not injected.
+  - *Acceptance criteria*: with a threshold set to 0.7, a message with < 0.7
+    score against all skills results in no skill injection.
+  - *Priority*: Must
+
+- **FR-022**: As a skill author, I need a self-learning loop that upgrades skill
+  trust scores based on positive/negative feedback signals, so that well-performing
+  skills are preferred automatically.
+  - *Priority*: Should
+
+### Semantic Memory
+
+- **FR-030**: As any user, I need the agent to persist conversation history in
+  SQLite and retrieve semantically similar memories from Qdrant across sessions,
+  so that the agent remembers relevant context from past interactions.
+  - *Acceptance criteria*: querying the agent about a topic discussed in a
+    previous session returns a contextually relevant recalled memory.
+  - *Priority*: Must
+
+- **FR-031**: As a developer, I need the agent to detect rising context pressure
+  and compact conversation history (soft threshold at ~60%, hard at ~90%),
+  so that long sessions do not exhaust the model's context window.
+  - *Acceptance criteria*: at 90% context utilisation, compaction fires and
+    context length drops below 60%.
+  - *Priority*: Must
+
+- **FR-032**: As any user, I need the agent to maintain an entity graph
+  (MAGMA typed edges) for BFS-based graph recall, so that factual relationships
+  extracted from conversations are reused in future turns.
+  - *Priority*: Should
+
+### Multi-Channel I/O
+
+- **FR-040**: As a CLI developer, I need a text-based CLI channel that reads
+  from stdin and writes to stdout, so that Zeph can be used in shell pipelines.
+  - *Priority*: Must
+
+- **FR-041**: As a power user, I need a ratatui-based TUI channel with real-time
+  metrics, context pressure gauge, memory panel, and spinner indicators for all
+  background operations, so that I have full situational awareness during a session.
+  - *Priority*: Should
+
+- **FR-042**: As a remote user, I need a Telegram channel with streaming output
+  support, so that I can interact with Zeph from mobile without a terminal.
+  - *Priority*: Should
+
+### Tool Execution
+
+- **FR-050**: As a developer, I need the agent to execute shell commands,
+  web scraping, and file operations via a composable tool executor, with a
+  blocklist check and optional user-approval gate, so that I control what the
+  agent can do autonomously.
+  - *Acceptance criteria*: a blocklisted command is rejected before the
+    permission policy is consulted; a non-blocklisted command in the "ask first"
+    set prompts the user for confirmation.
+  - *Priority*: Must
+
+- **FR-051**: As a team operator, I need tool execution audit logging with
+  `claim_source` attribution, so that every tool call is traceable to its
+  origin.
+  - *Priority*: Should
+
+### MCP Integration
+
+- **FR-060**: As a developer, I need Zeph to act as an MCP client connecting
+  to one or more MCP servers, discovering their tools semantically, and invoking
+  them transparently alongside native tools, so that I can extend Zeph's
+  capabilities via the MCP ecosystem.
+  - *Priority*: Should
+
+- **FR-061**: As a team operator, I need per-server tool quotas and structured
+  error codes from MCP tool calls, so that runaway MCP servers cannot consume
+  unlimited resources.
+  - *Priority*: Could
+
+### A2A and ACP Protocols
+
+- **FR-070**: As a developer, I need Zeph to implement the A2A (Agent-to-Agent)
+  JSON-RPC 2.0 protocol for agent discovery and invocation, so that Zeph can
+  participate in multi-agent networks.
+  - *Priority*: Could
+
+- **FR-071**: As a developer, I need ACP (Agent Control Protocol) transport
+  support with session management and capability advertisement, so that Zeph
+  can be controlled or forked by another agent.
+  - *Priority*: Could
+
+### Vault and Secrets
+
+- **FR-080**: As any user, I need all secrets (API keys, tokens) to be stored
+  exclusively in an age-encrypted vault, never in environment variables or TOML
+  config files, so that secrets are not leaked in configuration or logs.
+  - *Acceptance criteria*: attempting to set `ZEPH_OPENAI_API_KEY` via env var
+    is ignored; the key is resolved only from the age vault.
+  - *Priority*: Must
+
+### Gateway and Scheduler
+
+- **FR-090**: As a team operator, I need an HTTP gateway with bearer-token
+  authentication for webhook ingestion, so that external systems can send
+  events to Zeph without direct terminal access.
+  - *Priority*: Could
+
+- **FR-091**: As a team operator, I need a cron-based task scheduler with
+  SQLite persistence and CLI management (`schedule list/add/remove`), so that
+  periodic agent tasks run unattended.
+  - *Priority*: Could
+
+### Code Indexing
+
+- **FR-100**: As a CLI developer, I need AST-based code indexing with semantic
+  retrieval and repo-map generation, so that the agent can answer questions
+  about the current codebase without manual context injection.
+  - *Priority*: Could
+
+### Subagent Lifecycle
+
+- **FR-110**: As a developer, I need to spawn named subagents with scoped tool
+  permissions, TTL-based grants, and JSONL transcript persistence via `/agent spawn`,
+  so that complex tasks can be delegated to isolated agent instances.
+  - *Priority*: Could
+
+---
+
+## Non-Functional Requirements
+
+Detailed targets are in [[NFR]]. High-level constraints for business context:
+
+### Performance
+
+- The CLI channel round-trip (user message → LLM → response displayed) must
+  complete within the LLM provider's own latency; no significant overhead added
+  by Zeph's routing and memory pipeline.
+- The release binary must stay under 15 MiB (current constraint from constitution).
+
+### Security & Privacy
+
+- All secrets managed via age vault; no plaintext credentials anywhere in the
+  system.
+- Shell command execution protected by a blocklist that runs unconditionally
+  before permission policy.
+- SSRF protection: private IP ranges rejected in web tool.
+- PII detection and redaction in the sanitizer pipeline.
+
+### Availability
+
+- Designed for single-user / small-team use; no high-availability or multi-tenant
+  SLA targets in pre-v1.0.
+- Graceful degradation: agent operates without memory (no Qdrant) or without
+  MCP servers.
+
+### Usability
+
+- All background operations in TUI must have a visible spinner with a descriptive
+  status message — no silent background work.
+- CLI ergonomics: `/help` lists all available slash commands.
+
+---
+
+## Scope & Boundaries
+
+### In Scope
+
+- Single-binary Rust agent with CLI, TUI, and Telegram channels.
+- Multi-provider LLM routing with cost and complexity awareness.
+- SKILL.md-based skill system with hot-reload and self-learning.
+- Dual-backend memory (SQLite + Qdrant) with graph recall.
+- Tool execution with shell, web scraping, and file operations.
+- MCP client for third-party tool servers.
+- A2A and ACP protocol support (feature-gated).
+- Age-encrypted vault for all secrets.
+- Optional HTTP gateway, cron scheduler, code indexer, benchmark harness.
+- Prometheus metrics export (feature-gated with gateway).
+- PostgreSQL database backend (feature-gated alternative to SQLite).
+
+### Out of Scope
+
+> [!danger] Explicit Exclusions
+>
+> - **Multi-tenant SaaS platform**: Zeph is not a hosted service; no
+>   user accounts, billing, or tenant isolation.
+> - **Web UI**: there is no browser-based interface; CLI, TUI, and Telegram
+>   are the only channels.
+> - **Windows support**: the primary supported platforms are macOS and Linux.
+> - **Model training or fine-tuning**: Zeph does not train models; it only
+>   infers.
+> - **Python or Node.js runtime**: Zeph is a single Rust binary; no polyglot
+>   runtime dependencies.
+> - **Backward compatibility shims before v1.0**: breaking changes are
+>   documented in CHANGELOG.md without deprecation warnings.
+> - **OpenSSL**: `openssl-sys` is banned; rustls is the only TLS stack.
+
+---
+
+## Integrations & Dependencies
+
+| System | Direction | Data | Status |
+|--------|-----------|------|--------|
+| Ollama (local) | Outbound | Chat completions, embeddings | Exists |
+| Anthropic Claude API | Outbound | Chat completions, tool calls | Exists |
+| OpenAI API | Outbound | Chat, tools, embeddings | Exists |
+| OpenAI-compatible APIs | Outbound | Chat, embeddings | Exists |
+| HuggingFace / candle | Outbound | Local embeddings, inference | Exists |
+| Qdrant (local/remote) | Both | Vector store: embeddings, recall | Exists |
+| SQLite (embedded) | Both | Conversation history, scheduler, experiments | Exists |
+| PostgreSQL (optional) | Both | Alternative to SQLite for teams | Feature-gated |
+| Telegram Bot API | Both | Inbound messages, outbound replies | Exists |
+| MCP servers (any) | Both | Tool discovery, tool calls | Exists |
+| A2A peers | Both | JSON-RPC 2.0 agent invocation | Feature-gated |
+| ACP clients | Both | ACP session management | Feature-gated |
+| age (encryption) | Both | Vault secret encryption/decryption | Exists |
+| Prometheus / OpenMetrics | Outbound | Metrics scraping | Feature-gated |
+| OTLP / Jaeger | Outbound | Distributed traces | Feature-gated |
+| Pyroscope | Outbound | Continuous profiling | Feature-gated |
+
+---
+
+## Constraints & Assumptions
+
+### Technical Constraints
+
+- Language: Rust 1.88 (MSRV), Edition 2024, no `unsafe` blocks.
+- Async: tokio; no `async-trait` crate in library crates.
+- TLS: rustls only; `openssl-sys` banned.
+- YAML: `serde_norway` only; `serde_yaml` / `serde_yml` banned.
+- Database: SQLite (default) or PostgreSQL (opt-in); `sqlx::Any` banned.
+- Feature flags: `default = []`; always-on capabilities compiled without flags.
+- Binary size: release binary must stay under 15 MiB.
+- Unsafe code: `unsafe_code = "deny"` workspace-wide.
+
+### Business Constraints
+
+- Open-source project; no commercial license or paid support tier.
+- Pre-v1.0: no backward-compatibility obligation; breaking changes documented.
+- No dedicated infrastructure budget; the age vault is the only secret store.
+- No fixed team size or deadline; development is community-driven.
+
+> [!warning] Assumptions
+> - Users accept that pre-v1.0 releases may have breaking configuration changes.
+> - Ollama or at least one cloud provider API key is available for LLM inference.
+> - Qdrant is optional; the agent degrades gracefully to SQLite-only memory.
+> - Skills are authored by users as SKILL.md files; there is no GUI skill editor.
+
+---
+
+## Success Criteria
+
+- [ ] A developer can install a single binary and start a productive CLI
+      session with a local Ollama model within 5 minutes.
+- [ ] Skills added as SKILL.md files are active within 500ms without restarting
+      the agent.
+- [ ] A message discussed in session N is recalled in session N+1 via semantic
+      memory with no user-side configuration beyond enabling Qdrant.
+- [ ] The TUI shows a spinner for every background operation; no silent waits.
+- [ ] All secrets are resolved from the age vault at startup; zero plaintext
+      credentials appear in logs or TOML.
+- [ ] The release binary stays under 15 MiB.
+- [ ] `cargo nextest run --workspace --features full` passes with zero test
+      failures on every commit.
+- [ ] A team operator can expose Zeph's metrics to Prometheus and receive
+      ~25 gauge/counter metrics without code changes.
+
+---
+
+## Open Questions
+
+> [!question] Unresolved Items
+>
+> - [ ] What is the target v1.0 feature freeze milestone and date?
+> - [ ] Is Windows support ever in scope, or permanently out of scope?
+> - [ ] Should Zeph publish crates to crates.io, or remain a binary-only
+>       distribution?
+> - [ ] Will ACP and A2A remain feature-gated in v1.0, or become always-on?
+> - [ ] Is there a plan for user documentation (mdBook) alongside the inline
+>       rustdoc?
+
+---
+
+## Glossary
+
+| Term | Definition |
+|------|-----------|
+| Agent | The Zeph runtime instance that handles a user session end-to-end |
+| Channel | The I/O boundary abstraction (CLI, TUI, Telegram) |
+| Skill | A SKILL.md file defining domain knowledge injected into the system prompt |
+| Provider | An LLM backend (Ollama, Claude, OpenAI, candle) |
+| Vault | The age-encrypted secret store managed by the `zeph-vault` crate |
+| Compaction | The process of summarising old messages to reduce context size |
+| MCP | Model Context Protocol — a standard for LLM tool servers |
+| A2A | Agent-to-Agent — JSON-RPC 2.0 protocol for inter-agent calls |
+| ACP | Agent Control Protocol — session-oriented agent control transport |
+| SKILL.md | A Markdown file describing a skill's trigger patterns and instructions |
+| BM25 | Sparse text ranking algorithm used in skill matching |
+| Qdrant | Open-source vector database used for semantic memory recall |
+| age | A modern file encryption tool used for the Zeph vault backend |
+| EARS | Easy Approach to Requirements Syntax (WHEN…SHALL notation) |
+| TUI | Terminal User Interface (ratatui-based dashboard) |
+| DAG | Directed Acyclic Graph — used for multi-step orchestration |
+
+---
+
+## See Also
+
+- [[SRS]] — functional requirements derived from this BRD
+- [[NFR]] — non-functional / quality requirements
+- [[constitution]] — project-wide non-negotiable principles
+- [[MOC-specs]] — index of all technical specifications
+- [[001-system-invariants/spec]] — architectural invariants

--- a/specs/MOC-specs.md
+++ b/specs/MOC-specs.md
@@ -19,6 +19,14 @@ status: moc
 
 ---
 
+## Business and Requirements Documentation
+
+- [[BRD]] — Business Requirements Document: executive summary, problem statement, target personas (CLI Developer, Power User/TUI, Remote User/Telegram, Team Operator), functional requirements, business constraints, success criteria, open questions
+- [[SRS]] — Software Requirements Specification (ISO/IEC/IEEE 29148:2018): system context diagram, full functional requirements in EARS notation for all 17 subsystems, traceability matrix to BRD, verification matrix
+- [[NFR]] — Non-Functional Requirements (ISO/IEC 25010:2011): measurable quality targets for all 8 ISO 25010 characteristics plus operational safety; verification matrix with methods and environments
+
+---
+
 ## Foundation & Architecture
 
 ### System Invariants
@@ -52,6 +60,15 @@ status: moc
 
 ### Background Task Management
 - [[039-background-task-supervisor/spec|Supervised Background Task Manager]] — (proposed) AgentTaskSupervisor with JoinSet, task priority classes (Critical/Enrichment/Telemetry), queue depth limits, turn-boundary cleanup, metrics integration (`bg_inflight`, `bg_dropped`, `bg_completed`); addresses GitHub issue #2816
+
+### Context Management
+- [[021-zeph-context/spec|Context Crate]] — `zeph-context` crate: `ContextBudget` token arithmetic, `CompactionState` state machine (Ready → CompactedThisTurn → Cooling → Exhausted), `ContextAssembler` parallel fetch via `FuturesUnordered`, `PreparedContext` output; extracted from `zeph-core` with no reverse dependency
+
+### Shared Primitives
+- [[043-zeph-common/spec|Shared Primitives]] — `zeph-common` crate: `Secret` (zeroize-on-drop, redacted Debug), `ToolName` (Arc<str>, O(1) clone), `SessionId` (UUID v4), `ToolDefinition`, `SkillTrustLevel`, `PolicyLlmClient`, sanitization helpers; no `zeph-*` peer dependencies
+
+### Slash Command Dispatch
+- [[042-zeph-commands/spec|Slash Command Registry]] — `zeph-commands` crate: `CommandRegistry` with longest-word-boundary dispatch, object-safe `CommandHandler<Ctx>` trait, `CommandOutput` enum, `ChannelSink` abstraction, static `COMMANDS` list for `/help` and TUI autocomplete; no dependency on `zeph-core`
 
 ---
 
@@ -153,6 +170,7 @@ status: moc
 
 ### Subagent Context
 - [[033-subagent-context-propagation/spec|Subagent Context Propagation]] — gap analysis of `/agent spawn` context vs Claude Code reference, 12 gaps (P1–P4), phase-based fix plan; documents GAP-07 (cwd) and GAP-08b (loop exits) resolution
+- [[044-subagent-lifecycle/spec|Subagent Lifecycle]] — full `zeph-subagent` crate spec: `SubAgentDef` parsing, `SubAgentManager` spawning and concurrency cap, `PermissionGrants` TTL, `FilteredToolExecutor` policy gate, transcript persistence, lifecycle hooks, and memory injection
 
 ---
 
@@ -201,6 +219,10 @@ status: moc
 | 039 | [[039-background-task-supervisor/spec\|Background Task Supervisor]] | specify | draft |
 | 040 | [[040-sanitizer/spec\|Content Sanitizer]] | specify | approved |
 | 041 | [[041-experiments/spec\|Experiments & Runtime Feature Gating]] | specify | approved |
+| 021 | [[021-zeph-context/spec\|Context Crate]] | specify | approved |
+| 042 | [[042-zeph-commands/spec\|Slash Command Registry]] | specify | approved |
+| 043 | [[043-zeph-common/spec\|Shared Primitives]] | specify | approved |
+| 044 | [[044-subagent-lifecycle/spec\|Subagent Lifecycle]] | specify | approved |
 
 ---
 

--- a/specs/NFR.md
+++ b/specs/NFR.md
@@ -1,0 +1,402 @@
+---
+aliases:
+  - "Zeph NFR"
+  - "Zeph Quality Requirements"
+tags:
+  - nfr
+  - requirements/non-functional
+  - ai-agent
+  - rust
+  - status/draft
+created: 2026-04-13
+project: "Zeph"
+status: draft
+standard: "ISO/IEC 25010:2011"
+related:
+  - "[[BRD]]"
+  - "[[SRS]]"
+  - "[[constitution]]"
+  - "[[MOC-specs]]"
+---
+
+# Zeph: Non-Functional Requirements Specification
+
+> [!abstract]
+> Quality attribute requirements for Zeph, based on ISO/IEC 25010:2011.
+> Traceable to [[BRD]]. Detailed functional requirements are in [[SRS]].
+> Targets reflect a pre-v1.0, single-user / small-team deployment context.
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+This document specifies the non-functional (quality) requirements for Zeph.
+It complements [[SRS]] which covers functional requirements. Targets here are
+the authoritative source for CI pass/fail criteria, architecture decisions, and
+acceptance testing related to quality attributes.
+
+### 1.2 Scope
+
+Quality attributes covered and their relevance:
+
+| Characteristic | Relevance |
+|---------------|-----------|
+| Performance Efficiency | Critical — agent latency and binary size directly affect developer UX |
+| Reliability | High — single-user: crashes must not lose data; Qdrant/MCP absence must degrade gracefully |
+| Security | Critical — vault, secrets, SSRF, injection defense, PII |
+| Maintainability | High — 24-crate workspace, pre-v1.0 rapid iteration |
+| Portability | Medium — macOS + Linux; Windows out of scope |
+| Usability | Medium — CLI ergonomics and TUI responsiveness |
+| Compatibility | High — MCP, A2A, ACP, Ollama, OpenAI protocol compliance |
+| Safety | High — no data loss on crash; audit trail |
+
+### 1.3 Definitions
+
+| Term | Definition |
+|------|-----------|
+| P95 | 95th percentile latency |
+| P99 | 99th percentile latency |
+| RTO | Recovery Time Objective — time to restore service after failure |
+| RPO | Recovery Point Objective — maximum data loss tolerated |
+| MSRV | Minimum Supported Rust Version |
+| SSRF | Server-Side Request Forgery |
+| PII | Personally Identifiable Information |
+| BLAKE3 | Cryptographic hash function used for bearer token comparison |
+| zeroize | Rust crate that zeroes memory on drop |
+| rustls | Pure-Rust TLS implementation used in place of OpenSSL |
+
+### 1.4 References
+
+- [[BRD]] — Business Requirements Document
+- [[SRS]] — Software Requirements Specification
+- [[constitution]] — Project-wide non-negotiable principles
+- [[038-vault/spec]] — Vault and secret management
+- [[010-security/spec]] — Security framework
+- [[035-profiling/spec]] — Profiling and tracing
+- [[036-prometheus-metrics/spec]] — Prometheus metrics
+- ISO/IEC 25010:2011 — Systems and software Quality Requirements and Evaluation
+
+### 1.5 Priority and Trade-offs
+
+> [!tip] Quality Attribute Priority
+> When quality attributes conflict, prioritise in this order:
+> 1. **Security** — secrets must never leak; injection defenses must not be bypassed
+> 2. **Reliability** — no data loss; graceful degradation
+> 3. **Performance Efficiency** — agent latency and binary size
+> 4. **Maintainability** — codebase health for a fast-moving pre-v1.0 project
+> 5. **Usability** — developer ergonomics (TUI, CLI, Telegram UX)
+> 6. **Compatibility** — protocol compliance with MCP, A2A, ACP, OpenAI
+> 7. **Portability** — macOS + Linux; Windows is explicitly out of scope
+
+---
+
+## 2. Performance Efficiency
+
+### 2.1 Time Behaviour
+
+| ID | Requirement | Target | Measurement | Conditions |
+|----|------------|--------|-------------|-----------|
+| NFR-PERF-001 | Agent turn overhead (excluding LLM latency) | < 50ms added latency at P95 | Span trace (Tier 1 local chrome) | Single-user session, SQLite memory, no MCP |
+| NFR-PERF-002 | Skill hot-reload latency | ≤ 500ms from file change to registry update | `notify` debounce timer in unit test | Directory with ≤ 100 SKILL.md files |
+| NFR-PERF-003 | SQLite write per turn | < 50ms | nextest integration test | Local disk, single session |
+| NFR-PERF-004 | Qdrant vector insert per turn | < 200ms | nextest integration test | Local Qdrant, 1 000-dim embedding |
+| NFR-PERF-005 | TUI frame render time | < 33ms (≥ 30 fps) | ratatui benchmark | During background LLM inference |
+| NFR-PERF-006 | Skill matching latency (BM25 + embedding) | < 100ms at P95 | Unit benchmark | Registry ≤ 200 skills |
+| NFR-PERF-007 | Config hot-reload after file change | < 2 s from file write to active config | Integration test | Standard config file size |
+
+### 2.2 Resource Utilization
+
+| ID | Requirement | Target | Measurement |
+|----|------------|--------|-------------|
+| NFR-PERF-010 | Release binary size | ≤ 15 MiB | `ls -la target/release/zeph` |
+| NFR-PERF-011 | Idle CPU usage | < 1% | `top` / system metrics during idle TUI |
+| NFR-PERF-012 | Baseline RSS (idle session, no Qdrant) | < 80 MiB | `/proc/<pid>/status` or `ps` |
+| NFR-PERF-013 | Heap allocations per agent turn (excluding LLM payload) | No unbounded allocations in hot loop | `#[global_allocator]` tracking in profiling build |
+| NFR-PERF-014 | No blocking I/O in async hot paths | Zero `std::thread::sleep` or blocking calls inside `.await` chains | Clippy lint `clippy::blocking_in_async` + code review |
+
+### 2.3 Capacity
+
+| ID | Requirement | Target |
+|----|------------|--------|
+| NFR-PERF-020 | Maximum conversation history per session (SQLite) | Unlimited (never deleted); compaction handles context pressure |
+| NFR-PERF-021 | Qdrant index capacity | Limited only by Qdrant configuration; Zeph imposes no artificial cap |
+| NFR-PERF-022 | Concurrent MCP server connections | ≥ 10 simultaneous servers per session |
+| NFR-PERF-023 | Skill registry size | ≥ 500 SKILL.md files without degrading match latency beyond NFR-PERF-006 |
+
+---
+
+## 3. Reliability
+
+### 3.1 Availability
+
+| ID | Requirement | Target | Measurement |
+|----|------------|--------|-------------|
+| NFR-REL-001 | Single-session uptime | No agent crashes during a normal session of up to 8 hours | Manual live testing session |
+| NFR-REL-002 | Graceful degradation without Qdrant | Agent starts and operates with SQLite-only memory | Integration test: start with `[memory.qdrant] enabled = false` |
+| NFR-REL-003 | Graceful degradation without configured MCP servers | Agent starts and operates without any MCP tools | Integration test: misconfigured MCP endpoint |
+| NFR-REL-004 | Recovery after LLM provider error | Cascade fallback or logged error; agent turn continues or aborts gracefully (no panic) | Integration test: kill primary provider mid-session |
+
+> [!note] Not Applicable — SLA / Uptime Percentage
+> Zeph is a single-user / small-team local agent, not a hosted SaaS.
+> Traditional 99.9% uptime SLAs do not apply in pre-v1.0.
+
+### 3.2 Fault Tolerance
+
+| ID | Requirement | Behaviour |
+|----|------------|-----------|
+| NFR-REL-010 | LLM provider 5xx or timeout | Cascade to next provider if routing strategy supports it; else log error and return user-visible error message |
+| NFR-REL-011 | MCP server crash or unavailability | Log failure; remove server's tools from registry; agent continues without them |
+| NFR-REL-012 | Skill file parse error | Log error with file path and line; skip the malformed skill; continue loading others |
+| NFR-REL-013 | RuntimeLayer hook panic | Hook error is caught; agent turn continues normally |
+| NFR-REL-014 | Vault absence or decryption failure | Providers requiring missing secrets are skipped with a logged warning; agent may still start with the remaining providers |
+| NFR-REL-015 | Admission control scoring failure | Fail-open: content is admitted; error logged but not propagated |
+
+### 3.3 Recoverability
+
+| ID | Requirement | Target |
+|----|------------|--------|
+| NFR-REL-020 | Recovery from crash (restart) | Agent restarts and resumes with SQLite history intact; no conversation data lost |
+| NFR-REL-021 | RPO (data loss on crash) | Zero message loss: messages are written to SQLite before the LLM is called |
+| NFR-REL-022 | RTO (restart time) | < 5 s from process start to accepting the first user message |
+| NFR-REL-023 | Config reload without dropping in-flight requests | In-flight LLM calls complete before the new config is applied |
+
+---
+
+## 4. Security
+
+### 4.1 Confidentiality
+
+| ID | Requirement | Implementation |
+|----|------------|---------------|
+| NFR-SEC-001 | Secrets at rest | All `ZEPH_*` keys encrypted with age (X25519 or scrypt); no plaintext keys on disk |
+| NFR-SEC-002 | Secrets in transit | All outbound API traffic via TLS 1.2+ (rustls); `openssl-sys` banned |
+| NFR-SEC-003 | Secret memory lifecycle | `Secret<T>` values zeroized on drop via `zeroize` crate; verified in unit tests |
+| NFR-SEC-004 | PII in conversation | PII is detected via NER classifier and redacted before injection into LLM context or memory |
+| NFR-SEC-005 | Credential env-var scrubbing | `ZEPH_*` and known credential vars are removed from subprocess environments before shell execution |
+| NFR-SEC-006 | Debug log redaction | `Secret<T>` renders as `[REDACTED]` in `Debug` output; no key material in logs |
+
+### 4.2 Authentication and Authorization
+
+| ID | Requirement | Implementation |
+|----|------------|---------------|
+| NFR-SEC-010 | HTTP gateway bearer token | BLAKE3 + constant-time comparison (`subtle` crate); timing-safe |
+| NFR-SEC-011 | A2A invocation tokens | IBCT tokens signed with HMAC-SHA256; `key_id` included for rotation |
+| NFR-SEC-012 | Subagent tool permissions | `FilteredToolExecutor` enforces `PermissionGrants` with TTL; no tool outside the granted set is accessible |
+| NFR-SEC-013 | MCP OAP authorization | Per-server `[tools.authorization]` policy gates MCP tool calls before dispatch |
+
+### 4.3 Integrity
+
+| ID | Requirement | Implementation |
+|----|------------|---------------|
+| NFR-SEC-020 | Input validation | All external input (user messages, tool output, MCP responses) validated and sanitized at system boundaries |
+| NFR-SEC-021 | Injection defense | Eight-layer sanitizer pipeline (spotlighting, regex, NER, guardrail, quarantined summarizer, response verification, exfiltration guard, memory validation) |
+| NFR-SEC-022 | SSRF protection | Private IP ranges (RFC 1918, loopback, link-local) rejected; redirect chains validated |
+| NFR-SEC-023 | Shell blocklist | Blocklist check runs unconditionally before `PermissionPolicy`; cannot be bypassed |
+| NFR-SEC-024 | Symlink boundary | File-loading paths enforce symlink boundary checks; no path traversal |
+| NFR-SEC-025 | Tool audit trail | Every tool call logged with `claim_source`, tool name, timestamp |
+| NFR-SEC-026 | MCP tool input scan | MCP tool argument schemas scanned for injection patterns before dispatch |
+
+### 4.4 Compliance
+
+> [!note] Not Applicable — Regulatory Compliance
+> Zeph is open-source software without a commercial SaaS offering. GDPR, HIPAA,
+> PCI DSS, and SOC 2 formal compliance are not applicable in pre-v1.0.
+> Users deploying Zeph as a service are responsible for their own compliance obligations.
+
+---
+
+## 5. Usability
+
+### 5.1 Learnability
+
+| ID | Requirement | Target |
+|----|------------|--------|
+| NFR-USE-001 | Time to first productive CLI session | A developer who has installed the binary and configured one provider completes a first useful conversation in < 5 minutes |
+| NFR-USE-002 | Slash command discoverability | `/help` lists all available commands with a one-line description each |
+| NFR-USE-003 | Error message quality | All user-facing errors are actionable: state what went wrong and what the user can do to fix it |
+
+### 5.2 Operability
+
+| ID | Requirement | Target |
+|----|------------|--------|
+| NFR-USE-010 | Background operation visibility in TUI | 100% of background operations (LLM inference, memory search, tool execution, MCP connection, skill reload) show a spinner with a status message |
+| NFR-USE-011 | TUI slash autocomplete | Typing `/` in TUI Insert mode shows an autocomplete dropdown populated within one keypress |
+| NFR-USE-012 | Config migration | `zeph --migrate-config` upgrades a config from a previous minor version without data loss and without manual editing |
+| NFR-USE-013 | Init wizard coverage | `zeph --init` asks about all user-configurable features; no undocumented option requires manual TOML editing for initial setup |
+
+### 5.3 Accessibility
+
+> [!note] Not Applicable — WCAG / Section 508
+> Zeph is a terminal application. Web accessibility standards (WCAG 2.1) do not
+> apply. Keyboard-only operation is the primary interaction model by design.
+
+### 5.4 Internationalization
+
+| ID | Requirement | Details |
+|----|------------|---------|
+| NFR-USE-030 | Self-learning feedback language support | `FeedbackDetector` recognises positive/negative signals in at least English, Russian, and German |
+| NFR-USE-031 | Configuration language | Configuration file keys and CLI flags are English-only |
+
+---
+
+## 6. Compatibility
+
+### 6.1 Interoperability
+
+| ID | Requirement | Standard/Protocol |
+|----|------------|-------------------|
+| NFR-COM-001 | OpenAI API compatibility | Zeph's `compatible` provider passes the OpenAI chat completions API schema; tested against known OpenAI-compatible endpoints (LM Studio, vLLM) |
+| NFR-COM-002 | MCP protocol compliance | MCP client implements the Model Context Protocol as specified; `rmcp` crate is the wire implementation |
+| NFR-COM-003 | A2A protocol compliance | A2A client/server implements JSON-RPC 2.0 with IBCT token signing |
+| NFR-COM-004 | ACP protocol compliance | ACP transport implements `agent-client-protocol 0.10.3` |
+| NFR-COM-005 | Prometheus / OpenMetrics | `/metrics` endpoint emits valid OpenMetrics 1.0.0 format; scrape-compatible with Prometheus 2.x |
+| NFR-COM-006 | OTLP trace export | Tier 2 traces exported in OTLP format compatible with Jaeger 1.x and OpenTelemetry Collector |
+
+### 6.2 Co-existence
+
+| ID | Requirement | Details |
+|----|------------|---------|
+| NFR-COM-010 | OS support | macOS 13+ (x86_64, aarch64), Linux with glibc 2.31+ (x86_64, aarch64) |
+| NFR-COM-011 | Terminal compatibility | CLI channel: any POSIX terminal. TUI: xterm-compatible, 256-colour or truecolour |
+| NFR-COM-012 | Ollama version compatibility | Tested against Ollama 0.3+ (current API; `/api/chat` endpoint) |
+| NFR-COM-013 | Qdrant version compatibility | Qdrant 1.x; gRPC and HTTP REST interfaces |
+| NFR-COM-014 | SQLite version compatibility | sqlx 0.8 with bundled SQLite; no external SQLite installation required |
+| NFR-COM-015 | PostgreSQL version compatibility (optional) | PostgreSQL 15+ when `postgres` feature is enabled |
+
+---
+
+## 7. Maintainability
+
+### 7.1 Modularity and Modifiability
+
+| ID | Requirement | Details |
+|----|------------|---------|
+| NFR-MNT-001 | Workspace structure | 24-crate Cargo workspace with a strict 5-layer DAG; same-layer imports prohibited |
+| NFR-MNT-002 | Feature flag discipline | `default = []`; optional features declared with `dep:zeph-<name>`; no optional feature enabled by default |
+| NFR-MNT-003 | Dependency additions | New external dependencies require version check via context7 MCP and explicit justification in PR description |
+| NFR-MNT-004 | No backward-compatibility shims before v1.0 | Breaking changes documented in `CHANGELOG.md`; no `#[deprecated]` shims required before v1.0 |
+| NFR-MNT-005 | No unsafe code | `unsafe_code = "deny"` in workspace `Cargo.toml`; verified by CI |
+
+### 7.2 Testability
+
+| ID | Requirement | Details |
+|----|------------|---------|
+| NFR-MNT-010 | Pre-merge test pass | `cargo nextest run --config-file .github/nextest.toml --workspace --features full --lib --bins` passes with zero failures on every PR |
+| NFR-MNT-011 | Formatting check | `cargo +nightly fmt --check` passes on every PR |
+| NFR-MNT-012 | Lint check | `cargo clippy --all-targets --all-features --workspace -- -D warnings` passes on every PR |
+| NFR-MNT-013 | Doc-test coverage | `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` passes for all touched crates |
+| NFR-MNT-014 | LLM serialization gate | Any PR touching LLM request/response serialization paths requires a live API session test with debug dump verification |
+| NFR-MNT-015 | Integration tests | `cargo nextest run -- --ignored` covers Qdrant-dependent tests; run in CI with Qdrant service |
+| NFR-MNT-016 | Unit test patterns | Unit tests use `MockProvider` and `MockChannel` patterns; no real network calls in unit tests |
+
+### 7.3 Analysability
+
+| ID | Requirement | Details |
+|----|------------|---------|
+| NFR-MNT-020 | Structured logging | All log calls use the `tracing` crate; `log` crate is banned |
+| NFR-MNT-021 | API documentation | Every `pub` type, trait, function, and method has a `///` doc comment explaining what and why |
+| NFR-MNT-022 | Doc build verification | `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p <crate>` passes for every touched crate |
+| NFR-MNT-023 | Debug request visibility | `LlmProvider::debug_request_json()` returns the exact JSON payload sent to the API; used in debug dumps |
+| NFR-MNT-024 | Two-tier trace instrumentation | Tier 1 (local Chrome JSON): zero-overhead when disabled; Tier 2 (OTLP): gated by `profiling` feature |
+| NFR-MNT-025 | Metrics snapshot | ~25 gauge/counter metrics available in `MetricsSnapshot`; exported to TUI and Prometheus |
+| NFR-MNT-026 | CHANGELOG maintenance | `CHANGELOG.md` `[Unreleased]` section updated at the end of every implementation phase |
+
+---
+
+## 8. Portability
+
+### 8.1 Adaptability
+
+| ID | Requirement | Details |
+|----|------------|---------|
+| NFR-POR-001 | Supported platforms | macOS 13+ and Linux (glibc 2.31+); x86_64 and aarch64 |
+| NFR-POR-002 | No containerization requirement | Zeph runs as a native binary; Docker is not required; Docker may be used optionally for Qdrant |
+| NFR-POR-003 | No cloud lock-in | Provider abstraction allows any combination of local (Ollama, candle) and cloud (Claude, OpenAI) providers |
+| NFR-POR-004 | Cross-compilation | The workspace supports cross-compilation to aarch64 targets via `cross` or standard cargo targets |
+
+### 8.2 Installability
+
+| ID | Requirement | Details |
+|----|------------|---------|
+| NFR-POR-010 | Installation method | Single binary distribution; `cargo install` from source or pre-built GitHub releases |
+| NFR-POR-011 | Configuration | TOML config file with `ZEPH_*` env-var overrides; `--init` wizard for first-time setup |
+| NFR-POR-012 | No system-level dependencies | No dynamic library dependencies beyond the system libc; all TLS via rustls (statically linked) |
+
+> [!note] Windows — Explicitly Out of Scope
+> Windows is not a supported platform for Zeph. This is a deliberate business
+> constraint documented in [[BRD#Out of Scope]]. No portability targets for
+> Windows are required.
+
+---
+
+## 9. Safety
+
+> [!note]
+> ISO 25010 does not define "Safety" as a primary characteristic, but the term
+> is used here to capture operational safety properties: no data loss on crash,
+> graceful shutdown, and audit logging.
+
+| ID | Requirement | Target | Verification |
+|----|------------|--------|--------------|
+| NFR-SAF-001 | No message data loss on crash | Messages written to SQLite before LLM is called; RPO = 0 messages | Integration test: kill -9 the agent process mid-turn; confirm prior messages intact |
+| NFR-SAF-002 | Graceful shutdown on SIGTERM | Agent completes the in-flight LLM call (or times out after 10 s) and flushes pending SQLite writes before exiting | Signal handler test |
+| NFR-SAF-003 | Immutable audit trail | Tool call audit log (JSONL) is append-only; no modification API exposed | Code review of audit writer |
+| NFR-SAF-004 | No panic in library crates | `panic!()` is forbidden in `zeph-*` library crates except in tests and unreachable branches | `cargo clippy -- -W clippy::panic` in CI |
+| NFR-SAF-005 | Vault key zeroize on drop | `Secret<T>` memory is zeroed on drop | Unit test using address sanitizer / valgrind |
+| NFR-SAF-006 | No credentials in panic messages | Error types derived with `thiserror` must not include secret field values in `Display` | Code review; `Secret<T>` redacted `Debug` impl |
+
+---
+
+## 10. Verification Matrix
+
+| ID | Method | Environment | Frequency |
+|----|--------|-------------|-----------|
+| NFR-PERF-001 | Span trace analysis (Tier 1 chrome JSON) | Local dev machine | Per feature PR |
+| NFR-PERF-002 | `notify` debounce unit test | CI | Every commit |
+| NFR-PERF-010 | `ls -la target/release/zeph` | CI release build | Per release |
+| NFR-PERF-011 | `top` / system metrics | Manual | Per milestone |
+| NFR-REL-001 | 8-hour live session test | Developer machine | Per release |
+| NFR-REL-002 | nextest integration test | CI | Every commit |
+| NFR-REL-020 | nextest integration test | CI | Every commit |
+| NFR-SEC-001 | Vault inspection (`zeph vault get`) | Local | Config review |
+| NFR-SEC-003 | Unit test with address sanitizer | CI (nightly) | Per release |
+| NFR-SEC-010 | Unit test (constant-time comparison) | CI | Every commit |
+| NFR-SEC-022 | Unit test (SSRF rejection) | CI | Every commit |
+| NFR-MNT-010 | `cargo nextest run` | CI | Every commit |
+| NFR-MNT-011 | `cargo +nightly fmt --check` | CI | Every commit |
+| NFR-MNT-012 | `cargo clippy -- -D warnings` | CI | Every commit |
+| NFR-MNT-013 | `cargo test --doc` | CI | Every PR |
+| NFR-MNT-022 | `cargo doc --no-deps` | CI | Every PR |
+| NFR-POR-001 | GitHub Actions matrix (macOS + Linux) | CI | Every commit |
+| NFR-SAF-001 | Kill-9 integration test | Local | Per milestone |
+| NFR-SAF-002 | SIGTERM integration test | CI | Per release |
+| NFR-SAF-004 | `cargo clippy -- -W clippy::panic` | CI | Every commit |
+
+---
+
+## 11. Open Questions
+
+> [!question] Unresolved Quality Requirements
+>
+> - [ ] Should a formal memory / resource limit be enforced per session (e.g.,
+>       max SQLite DB size) before v1.0?
+> - [ ] What is the P99 latency budget for MCP tool discovery at session start
+>       with 10+ servers?
+> - [ ] Should the binary size limit (15 MiB) apply to the `full` feature set
+>       or to the default build only?
+> - [ ] Is there a plan for fuzz testing on the sanitizer pipeline or config
+>       parser before v1.0?
+
+---
+
+## See Also
+
+- [[BRD]] — business requirements (source)
+- [[SRS]] — functional requirements
+- [[constitution]] — project-wide non-negotiable principles
+- [[MOC-specs]] — index of all specifications
+- [[010-security/spec]] — security framework detail
+- [[035-profiling/spec]] — profiling and tracing detail
+- [[036-prometheus-metrics/spec]] — Prometheus metrics detail

--- a/specs/README.md
+++ b/specs/README.md
@@ -25,16 +25,25 @@ See `[[constitution]]` for project-wide non-negotiable rules.
 
 ## Numbering Scheme
 
-Spec IDs (001–041) follow a logical grouping:
+Spec IDs (001–044) follow a logical grouping:
 
 - **001–010**: Foundational contracts and core systems (invariants, loop, providers, memory, skills, tools, channels, mcp, orchestration, security)
 - **011–020**: User-facing features and operational integration (TUI, graph memory, protocols, self-learning, filtering, indexing, scheduler, gateway, config loading)
-- **021**: Reserved for future core feature
+- **021**: `zeph-context` crate — context budget, compaction state machine, context assembler
 - **022–034**: Architectural extensions and specialized features (provider registry, complexity routing, multi-model design, classifiers, TUI enhancements, hooks, database abstraction, handoff, feature flags, subagent context, benchmark harness)
 - **035–037**: Observability and configuration (profiling/tracing instrumentation, Prometheus metrics export, config schema)
 - **038–041**: Infrastructure and security (vault, background task supervisor, content sanitizer, experiments)
+- **042–044**: Foundation crates (slash command registry, shared primitives, subagent lifecycle)
 
 ---
+
+## Business and Requirements Documentation
+
+| Doc | Contents |
+|---|---|
+| `BRD.md` | Business Requirements Document — what Zeph is, why it exists, target personas, business constraints, success criteria |
+| `SRS.md` | Software Requirements Specification (ISO/IEC/IEEE 29148:2018) — all functional requirements grouped by subsystem, EARS notation, traceability to BRD |
+| `NFR.md` | Non-Functional Requirements (ISO/IEC 25010:2011) — measurable quality targets for performance, reliability, security, maintainability, portability, usability, compatibility, and safety |
 
 ## System Invariants
 
@@ -66,6 +75,7 @@ Spec IDs (001–041) follow a logical grouping:
 | `018-scheduler/spec.md` | Cron scheduler, SQLite persistence, CLI subcommands (list/add/remove/show) | `zeph-scheduler` |
 | `019-gateway/spec.md` | HTTP webhook ingestion, bearer token authentication | `zeph-gateway` |
 | `020-config-loading/spec.md` | Config resolution order, mode-agnostic defaults, environment overrides | `zeph-core` |
+| `021-zeph-context/spec.md` | `zeph-context` crate: `ContextBudget` token arithmetic, `CompactionState` state machine, `ContextAssembler` parallel fetch, `PreparedContext` output; extracted from `zeph-core` | `zeph-context` |
 | `022-config-simplification/spec.md` | Provider Registry Architecture: canonical `[[llm.providers]]` format, ProviderEntry schema, routing strategies, LinUCB bandit routing, cost-weight dial, memory-augmented routing | `zeph-config`, `zeph-core` |
 | `023-complexity-triage-routing/spec.md` | Pre-inference complexity classification routing, ComplexityTier, TriageRouter, context escalation, metrics | `zeph-llm`, `zeph-config`, `zeph-core` |
 | `024-multi-model-design/spec.md` | Multi-model design principle: complexity tiers, `*_provider` subsystem reference pattern, STT unification | cross-cutting |
@@ -86,3 +96,6 @@ Spec IDs (001–041) follow a logical grouping:
 | `039-background-task-supervisor/spec.md` | (Proposed) Supervised Background Task Manager: AgentTaskSupervisor, task priority classes, queue depth limits, turn-boundary cleanup, metrics (`bg_inflight`, `bg_dropped`) | `zeph-core` |
 | `040-sanitizer/spec.md` | Content Sanitizer: spotlighting pipeline, regex injection detection, PII scrubber, guardrail filter, quarantined summarizer, response verification, exfiltration guards, memory validation, causal analysis (eight-layer defense-in-depth) | `zeph-sanitizer` |
 | `041-experiments/spec.md` | Experiments & Runtime Feature Gating: `[experiments]` config section, ExperimentConfig, rollout percentage, experiment results reporting, CLI subcommands; distinct from compile-time feature flags | `zeph-experiments` |
+| `042-zeph-commands/spec.md` | Slash command registry, `CommandHandler<Ctx>` object-safe trait, `CommandRegistry` with longest-word-boundary dispatch, `ChannelSink` abstraction, static `COMMANDS` list; no dependency on `zeph-core` | `zeph-commands` |
+| `043-zeph-common/spec.md` | Shared primitives: `Secret` (zeroize-on-drop), `ToolName` (Arc<str>), `SessionId` (UUID v4), `ToolDefinition`, `SkillTrustLevel`, `PolicyLlmClient`; no `zeph-*` peer dependencies | `zeph-common` |
+| `044-subagent-lifecycle/spec.md` | Full `zeph-subagent` crate: `SubAgentDef` parsing, `SubAgentManager` spawning and concurrency cap, `PermissionGrants` TTL, `FilteredToolExecutor` policy gate, transcript JSONL persistence, lifecycle hooks, memory injection | `zeph-subagent` |

--- a/specs/SRS.md
+++ b/specs/SRS.md
@@ -1,0 +1,1186 @@
+---
+aliases:
+  - "Zeph SRS"
+  - "Zeph Functional Spec"
+tags:
+  - srs
+  - requirements/functional
+  - ai-agent
+  - rust
+  - status/draft
+created: 2026-04-13
+project: "Zeph"
+status: draft
+standard: "ISO/IEC/IEEE 29148:2018"
+related:
+  - "[[BRD]]"
+  - "[[NFR]]"
+  - "[[constitution]]"
+  - "[[MOC-specs]]"
+---
+
+# Zeph: Software Requirements Specification
+
+> [!abstract]
+> Functional requirements specification for Zeph.
+> Based on ISO/IEC/IEEE 29148:2018. Traceable to [[BRD]].
+> Requirements are derived from the 44 feature specs in `/specs/` and the
+> system invariants in [[001-system-invariants/spec]].
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+This document specifies the functional requirements for Zeph — a lightweight,
+open-source, self-hostable Rust AI agent. It is intended for:
+
+- Coding agents implementing features (primary audience)
+- Contributors reviewing scope
+- Researchers comparing Zeph capabilities against reference agents
+
+The document covers Zeph pre-v1.0 and will be updated at each milestone.
+
+### 1.2 Scope
+
+Zeph is a single-binary Rust application exposing an AI agent across CLI, TUI,
+and Telegram channels. It orchestrates multiple LLM backends, a skills system,
+semantic memory, tool execution, MCP client, A2A / ACP protocols, a vault for
+secrets, an HTTP gateway, a cron scheduler, and a code indexer.
+
+This SRS specifies what the system shall do. Quality targets (latency,
+reliability, security thresholds) are in [[NFR]].
+
+### 1.3 Definitions, Acronyms, and Abbreviations
+
+| Term | Definition |
+|------|-----------|
+| Agent | Zeph runtime instance managing one user session |
+| EARS | Easy Approach to Requirements Syntax (`WHEN … THE SYSTEM SHALL …`) |
+| MCP | Model Context Protocol — standard for LLM tool servers |
+| A2A | Agent-to-Agent — JSON-RPC 2.0 inter-agent protocol |
+| ACP | Agent Control Protocol — session-oriented agent control transport |
+| TUI | Terminal User Interface (ratatui dashboard) |
+| SKILL.md | Markdown file encoding one agent skill |
+| BM25 | Sparse text ranking algorithm |
+| Qdrant | Vector database used for semantic recall |
+| age | File encryption tool used for the vault backend |
+| DAG | Directed Acyclic Graph |
+| IBCT | Invocation-Bound Capability Token |
+| HMAC | Hash-based Message Authentication Code |
+| IPI | Indirect Prompt Injection |
+| PII | Personally Identifiable Information |
+| SSRF | Server-Side Request Forgery |
+| OAP | Operator Authorization Policy |
+| TAFC | Tool-Argument Format Checker |
+| MMR | Maximum Marginal Relevance |
+| GAAMA | Graph-Augmented Adaptive Memory Architecture |
+| BATS | Budget-Aware Token Scheduling |
+| VMAO | Value-Maximising Adaptive Orchestration |
+
+### 1.4 References
+
+- [[BRD]] — Business Requirements Document
+- [[NFR]] — Non-Functional Requirements Specification
+- [[constitution]] — Project-wide non-negotiable principles
+- [[001-system-invariants/spec]] — Architectural invariants (authoritative)
+- [[002-agent-loop/spec]] — Agent loop spec
+- [[003-llm-providers/spec]] — LLM providers spec
+- [[004-memory/spec]] — Memory pipeline spec
+- [[005-skills/spec]] — Skills system spec
+- [[006-tools/spec]] — Tool execution spec
+- [[007-channels/spec]] — Channel system spec
+- [[008-mcp/spec]] — MCP client spec
+- [[009-orchestration/spec]] — Orchestration spec
+- [[010-security/spec]] — Security spec
+- [[011-tui/spec]] — TUI dashboard spec
+- [[012-graph-memory/spec]] — Entity graph spec
+- [[013-acp/spec]] — ACP spec
+- [[014-a2a/spec]] — A2A spec
+- [[015-self-learning/spec]] — Self-learning spec
+- [[016-output-filtering/spec]] — Output filtering spec
+- [[017-index/spec]] — Code indexing spec
+- [[018-scheduler/spec]] — Scheduler spec
+- [[019-gateway/spec]] — Gateway spec
+- [[020-config-loading/spec]] — Config loading spec
+- [[021-zeph-context/spec]] — Context crate spec
+- [[022-config-simplification/spec]] — Provider registry spec
+- [[023-complexity-triage-routing/spec]] — Complexity routing spec
+- [[024-multi-model-design/spec]] — Multi-model design spec
+- [[025-classifiers/spec]] — ML classifiers spec
+- [[026-tui-subagent-management/spec]] — TUI subagent sidebar spec
+- [[027-runtime-layer/spec]] — Runtime layer spec
+- [[028-hooks/spec]] — Hooks spec
+- [[029-feature-flags/spec]] — Feature flags spec
+- [[030-tui-slash-autocomplete/spec]] — TUI slash autocomplete spec
+- [[031-database-abstraction/spec]] — Database abstraction spec
+- [[032-handoff-skill-system/spec]] — Handoff protocol spec
+- [[033-subagent-context-propagation/spec]] — Subagent context spec
+- [[034-zeph-bench/spec]] — Benchmark harness spec
+- [[035-profiling/spec]] — Profiling spec
+- [[036-prometheus-metrics/spec]] — Prometheus metrics spec
+- [[037-config-schema/spec]] — Config schema spec
+- [[038-vault/spec]] — Vault spec
+- [[039-background-task-supervisor/spec]] — Background task supervisor spec
+- [[040-sanitizer/spec]] — Content sanitizer spec
+- [[041-experiments/spec]] — Experiments spec
+- [[042-zeph-commands/spec]] — Slash command registry spec
+- [[043-zeph-common/spec]] — Shared primitives spec
+- [[044-subagent-lifecycle/spec]] — Subagent lifecycle spec
+
+### 1.5 Document Overview
+
+Section 2 describes the system context, user classes, and operating environment.
+Section 3 contains all functional requirements grouped by subsystem, using EARS
+notation. Section 4 presents the verification matrix. Section 5 contains the
+traceability matrix.
+
+---
+
+## 2. Overall Description
+
+### 2.1 Product Perspective
+
+Zeph is a standalone binary that sits between the user (via CLI, TUI, or Telegram)
+and one or more LLM providers. It mediates skill injection, tool execution, memory
+read/write, MCP server connections, and optional gateway / scheduler services.
+
+```mermaid
+graph TD
+    User["User (CLI / TUI / Telegram)"]
+    Zeph["Zeph Agent Binary"]
+    LLM["LLM Providers\n(Ollama / Claude / OpenAI / candle)"]
+    Qdrant["Qdrant\n(vector store)"]
+    SQLite["SQLite\n(relational store)"]
+    MCP["MCP Servers\n(external tools)"]
+    A2A["A2A Peers\n(other agents)"]
+    ACP["ACP Clients\n(agent controllers)"]
+    Gateway["HTTP Gateway\n(webhooks)"]
+    Scheduler["Cron Scheduler"]
+    Vault["age Vault\n(secrets)"]
+
+    User -->|"message / command"| Zeph
+    Zeph -->|"response / stream"| User
+    Zeph -->|"chat / tools"| LLM
+    LLM -->|"completion"| Zeph
+    Zeph <-->|"read / write"| Qdrant
+    Zeph <-->|"read / write"| SQLite
+    Zeph <-->|"tool calls"| MCP
+    Zeph <-->|"JSON-RPC"| A2A
+    ACP -->|"control"| Zeph
+    Gateway -->|"events"| Zeph
+    Scheduler -->|"tasks"| Zeph
+    Zeph -->|"key resolution"| Vault
+```
+
+### 2.2 Product Functions
+
+Major functional areas:
+
+- **Agent loop** — single-threaded async turn lifecycle
+- **LLM provider abstraction** — unified interface over multiple backends
+- **Skills system** — SKILL.md registry with hot-reload and hybrid matching
+- **Semantic memory** — SQLite + Qdrant dual-backend with graph recall
+- **Channel system** — CLI, TUI, and Telegram I/O channels
+- **Tool execution** — shell, web, file tools with permission gates
+- **MCP integration** — multi-server MCP client with semantic discovery
+- **A2A / ACP protocols** — inter-agent communication
+- **Vault & secrets** — age-encrypted secret storage
+- **Slash command dispatch** — extensible `/` command registry
+- **Subagent lifecycle** — scoped child agents with permission grants
+- **Code indexing** — AST-based codebase retrieval
+- **Gateway** — HTTP webhook ingestion
+- **Scheduler** — cron-based periodic task execution
+- **Observability** — profiling, Prometheus metrics, structured logging
+
+### 2.3 User Classes and Characteristics
+
+| User Class | Description | Proficiency | Frequency |
+|-----------|-------------|-------------|-----------|
+| CLI Developer | Uses Zeph in shell, pipes output, writes skills | High | Daily |
+| Power User (TUI) | Runs Zeph in ratatui TUI for full situational awareness | High | Daily |
+| Remote User (Telegram) | Accesses Zeph from mobile via Telegram bot | Medium | Daily |
+| Team Operator | Deploys Zeph as a service, manages gateway/scheduler/metrics | High | Weekly |
+| Skill Author | Writes SKILL.md files to teach domain knowledge | Medium | Occasional |
+| Benchmark Researcher | Runs Zeph against standard benchmarks | High | Occasional |
+
+### 2.4 Operating Environment
+
+- OS: macOS 13+, Linux (glibc 2.31+); Windows not supported.
+- Architecture: x86_64, aarch64.
+- Runtime: single Rust binary; no Python, Node.js, or JVM required.
+- LLM dependency: at least one provider configured (Ollama local or cloud API key).
+- Optional: Qdrant 1.x for vector memory; PostgreSQL 15+ for alternative DB backend.
+- Network: outbound HTTPS to cloud LLM APIs; local TCP to Ollama / Qdrant.
+
+### 2.5 Design and Implementation Constraints
+
+- Rust 1.88 (MSRV), Edition 2024; `unsafe_code = "deny"` workspace-wide.
+- Async: tokio; no `async-trait` crate in library crates.
+- TLS: rustls; `openssl-sys` banned.
+- Crate layering: `zeph-core` orchestrates all leaf crates; same-layer imports prohibited.
+- Feature flags: `default = []`; bundles (`desktop`, `ide`, `server`, `full`) for CI.
+- Binary size: release binary ≤ 15 MiB.
+- No blocking I/O in async hot paths.
+
+### 2.6 Assumptions and Dependencies
+
+> [!warning] Assumptions
+> - Users configure at least one LLM provider before first run.
+> - The age vault is initialised before secrets are needed; the agent fails
+>   gracefully (logged error, not panic) if the vault is absent.
+> - Qdrant is optional; the agent degrades to SQLite-only memory.
+> - Telegram channel requires a valid bot token in the vault.
+> - MCP servers are user-managed external processes; Zeph is not responsible
+>   for their availability.
+
+---
+
+## 3. Specific Requirements
+
+### 3.1 External Interface Requirements
+
+#### 3.1.1 User Interfaces
+
+- **CLI**: line-oriented stdin/stdout; supports piped input and TTY mode.
+- **TUI**: ratatui full-screen terminal dashboard; requires a compatible terminal
+  emulator (xterm-compatible, 256-colour or truecolour).
+- **Telegram**: Telegram Bot API messages; formatted with Markdown where supported.
+
+#### 3.1.2 Hardware Interfaces
+
+None. Zeph is a pure software application.
+
+#### 3.1.3 Software Interfaces
+
+| Interface | System | Protocol | Data Format |
+|-----------|--------|----------|-------------|
+| Ollama | Local LLM runtime | HTTP / SSE | JSON |
+| Anthropic API | Claude LLM | HTTPS / SSE | JSON |
+| OpenAI API | GPT series | HTTPS / SSE | JSON |
+| OpenAI-compatible | Any compatible endpoint | HTTPS / SSE | JSON |
+| HuggingFace / candle | Local inference | In-process | Tensor |
+| Qdrant | Vector database | gRPC / HTTP | protobuf / JSON |
+| SQLite | Embedded database | sqlx | SQL |
+| PostgreSQL | Relational database (opt-in) | sqlx | SQL |
+| Telegram Bot API | Messaging | HTTPS long-poll / webhook | JSON |
+| MCP servers | Tool servers | stdio / HTTP | JSON-RPC 2.0 |
+| A2A peers | Other agents | HTTPS | JSON-RPC 2.0 |
+| ACP clients | Agent controllers | stdio / HTTP | ACP 0.10.3 |
+| age | Vault backend | File I/O | Binary ciphertext |
+| Prometheus | Metrics scraper | HTTP `/metrics` | OpenMetrics 1.0 |
+| OTLP / Jaeger | Trace collector | gRPC / HTTP | OTLP |
+| Pyroscope | Profiler | HTTP | Pyroscope wire format |
+
+#### 3.1.4 Communication Interfaces
+
+- All outbound cloud API traffic uses HTTPS with rustls and TLS 1.2+.
+- MCP servers communicate via stdio subprocess pipes or HTTP.
+- Qdrant: gRPC (preferred) or HTTP REST.
+- Telegram: HTTPS long-polling or webhook.
+
+---
+
+### 3.2 Functional Requirements
+
+#### 3.2.1 Agent Loop and Orchestration
+
+> [!info] Traceability
+> Traces to: [[BRD#Agent Core]], [[002-agent-loop/spec]], [[001-system-invariants/spec#2-agent-loop-contract]]
+
+**FR-AL-001**: WHEN a user message arrives on any channel, THE SYSTEM SHALL
+process it through the agent turn loop: receive → build context → call LLM →
+handle tool calls (if any) → return response.
+
+- *Rationale*: Core agent behaviour; without this, Zeph is not an agent.
+- *Source*: [[BRD]], FR-001
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. A user message on the CLI channel produces an LLM-sourced reply within the same session.
+  2. Tool call results are appended to the conversation before the final reply is sent.
+  3. The loop handles at least one round of tool calls per turn.
+
+**FR-AL-002**: WHEN a user types a slash command (`/help`, `/clear`, `/compact`,
+`/plan`, `/exit`, or any registered handler), THE SYSTEM SHALL dispatch it to the
+`CommandRegistry` and short-circuit the LLM call.
+
+- *Rationale*: Direct control without consuming LLM tokens.
+- *Source*: [[BRD]], FR-002; [[042-zeph-commands/spec]]
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. `/help` returns the list of available commands without an LLM call.
+  2. `/clear` resets conversation history without restarting the agent process.
+  3. `/compact` triggers context compaction and confirms completion.
+  4. Unknown commands produce an actionable error message.
+
+**FR-AL-003**: WHEN a `VecDeque<QueuedMessage>` contains pending messages, THE
+SYSTEM SHALL drain the queue before calling `channel.recv()`.
+
+- *Rationale*: Ensures injected messages (e.g., from scheduler or subagent) are processed in order.
+- *Source*: [[001-system-invariants/spec]], §2
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. Injected messages are processed before the next user message is read from the channel.
+
+**FR-AL-004**: WHEN the active LLM provider config changes at runtime (via
+config hot-reload), THE SYSTEM SHALL swap the provider without dropping the
+current conversation history.
+
+- *Rationale*: Enables switching between local and cloud models mid-session.
+- *Source*: [[BRD]], FR-003
+- *Priority*: Should
+- *Acceptance criteria*:
+  1. Editing `config.toml` to change the active provider takes effect within the
+     config watch debounce window without a process restart.
+  2. Conversation history is intact after the swap.
+
+**FR-AL-005**: WHEN the agent executes a multi-step plan (DAG), THE SYSTEM SHALL
+use the `DagScheduler` to topologically sort and dispatch tasks, retrying
+failed nodes per the VMAO adaptive replanning policy.
+
+- *Rationale*: Multi-step tasks require dependency-ordered execution.
+- *Source*: [[009-orchestration/spec]]
+- *Priority*: Should
+- *Acceptance criteria*:
+  1. `/plan` produces a DAG with at least one node and dispatches tasks in
+     topological order.
+  2. A failed task is retried up to the configured maximum before the plan aborts.
+
+**FR-AL-006**: WHEN a `RuntimeLayer` hook fires (`before_chat`, `after_chat`,
+`before_tool`, `after_tool`), THE SYSTEM SHALL call the hook without blocking
+the agent loop; a hook panic or error MUST NOT abort the agent turn.
+
+- *Rationale*: Extensibility point for observability and side effects.
+- *Source*: [[027-runtime-layer/spec]], [[001-system-invariants/spec]], §15
+- *Priority*: Should
+- *Acceptance criteria*:
+  1. A hook that raises an error does not propagate the error to the agent turn result.
+  2. `turn_number` is incremented exactly once per user turn, before any hooks fire.
+
+---
+
+#### 3.2.2 LLM Provider Abstraction and Routing
+
+> [!info] Traceability
+> Traces to: [[BRD#Multi-Provider LLM Inference]], [[003-llm-providers/spec]],
+> [[022-config-simplification/spec]], [[023-complexity-triage-routing/spec]],
+> [[024-multi-model-design/spec]]
+
+**FR-LLM-001**: THE SYSTEM SHALL support at minimum the following LLM providers,
+each implementing the `LlmProvider` trait: Ollama, Anthropic Claude, OpenAI,
+OpenAI-compatible, and HuggingFace candle (local inference).
+
+- *Source*: [[BRD]], FR-010
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. Each provider passes `chat`, `chat_stream`, and `chat_with_tools` test suites.
+  2. `debug_request_json()` returns the exact JSON payload for each provider.
+
+**FR-LLM-002**: WHEN a provider is configured in `[[llm.providers]]`, THE SYSTEM
+SHALL resolve it by `name` field at startup; duplicate names SHALL produce a
+config error; an unknown `*_provider` reference SHALL fall back to the default
+provider with a warning log, never a hard error.
+
+- *Source*: [[001-system-invariants/spec]], §8a; [[022-config-simplification/spec]]
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. Two providers with the same name cause a startup error with a descriptive message.
+  2. A subsystem referencing a non-existent provider name logs a warning and uses
+     the default provider.
+
+**FR-LLM-003**: WHEN `RoutingStrategy` is set to `complexity`, THE SYSTEM SHALL
+classify each query via `ComplexityTier` (Simple / Medium / Complex / Expert) and
+route to the configured provider for that tier.
+
+- *Source*: [[BRD]], FR-011; [[023-complexity-triage-routing/spec]]
+- *Priority*: Should
+- *Acceptance criteria*:
+  1. A trivially simple query (e.g., entity lookup) is dispatched to the `simple`-tier
+     provider, visible in debug logs.
+  2. A multi-step reasoning query is dispatched to the `complex`-tier provider.
+
+**FR-LLM-004**: WHEN `RoutingStrategy` is set to `cascade`, THE SYSTEM SHALL try
+providers in order and fall back to the next on error or timeout.
+
+- *Source*: [[003-llm-providers/spec]]
+- *Priority*: Should
+- *Acceptance criteria*:
+  1. If the primary provider returns a 5xx error, the next provider in the list is tried.
+
+**FR-LLM-005**: THE SYSTEM SHALL provide three independent call paths on each
+provider: `chat` (blocking), `chat_stream` (SSE streaming), `chat_with_tools`
+(native tool_use); these paths MUST NOT share implementation in a way that
+alters the other's behaviour.
+
+- *Source*: [[001-system-invariants/spec]], §3
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. Enabling streaming does not change the structure of tool call dispatch.
+
+**FR-LLM-006**: WHEN prompt caching is supported by the active provider, THE
+SYSTEM SHALL enable it for the system message to reduce token costs.
+
+- *Source*: [[BRD]], FR-012
+- *Priority*: Could
+- *Acceptance criteria*:
+  1. Prompt cache hit count is visible in the debug dump when caching is active.
+
+---
+
+#### 3.2.3 Skills System
+
+> [!info] Traceability
+> Traces to: [[BRD#Skills System]], [[005-skills/spec]], [[015-self-learning/spec]]
+
+**FR-SK-001**: WHEN a SKILL.md file is added to, modified in, or removed from
+the skills directory, THE SYSTEM SHALL update the `SkillRegistry` within 500ms
+(debounce) without restarting the agent.
+
+- *Source*: [[BRD]], FR-020; [[005-skills/spec]]
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. Adding a SKILL.md is reflected in the active registry within 500ms.
+  2. The agent loop is not blocked during skill reload.
+
+**FR-SK-002**: WHEN a user message arrives, THE SYSTEM SHALL score it against
+all registered skills using BM25 + embedding hybrid matching; if the top score
+is below `disambiguation_threshold`, no skill SHALL be injected.
+
+- *Source*: [[BRD]], FR-021; [[005-skills/spec]]
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. With `disambiguation_threshold = 0.7`, a message scoring 0.65 against all
+     skills results in zero injected skills.
+  2. At most `max_active_skills` skills are injected per turn.
+
+**FR-SK-003**: WHEN the agent detects explicit positive or negative feedback
+in the user message (multi-language `FeedbackDetector`), THE SYSTEM SHALL update
+the Wilson score confidence interval for the matched skill and persist the update.
+
+- *Source*: [[BRD]], FR-022; [[015-self-learning/spec]]
+- *Priority*: Should
+- *Acceptance criteria*:
+  1. A message containing "good job" (or equivalent in supported languages)
+     increments the positive signal count for the last matched skill.
+  2. Trust level transitions (Untrusted → Provisional → Trusted) are persisted.
+
+**FR-SK-004**: WHEN a skill trust level is `Untrusted`, THE SYSTEM SHALL NOT
+inject that skill without explicit user confirmation.
+
+- *Source*: [[005-skills/spec]]
+- *Priority*: Should
+- *Acceptance criteria*:
+  1. A newly added skill starts at `Untrusted` and is not injected into the
+     system prompt until it reaches `Provisional`.
+
+---
+
+#### 3.2.4 Semantic Memory
+
+> [!info] Traceability
+> Traces to: [[BRD#Semantic Memory]], [[004-memory/spec]], [[012-graph-memory/spec]],
+> [[021-zeph-context/spec]]
+
+**FR-MEM-001**: WHEN a turn completes, THE SYSTEM SHALL persist the conversation
+messages to SQLite and (if Qdrant is available) store embedding vectors for
+semantic retrieval.
+
+- *Source*: [[BRD]], FR-030; [[004-memory/spec]]
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. After a session ends and a new session starts, semantic recall returns a
+     relevant memory from the previous session.
+  2. If Qdrant is unavailable, the agent continues with SQLite-only history.
+
+**FR-MEM-002**: WHEN context utilisation reaches the soft threshold (~60%),
+THE SYSTEM SHALL begin deferred compaction; WHEN it reaches the hard threshold
+(~90%), THE SYSTEM SHALL compact immediately.
+
+- *Source*: [[BRD]], FR-031; [[001-system-invariants/spec]], §6
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. At 90% utilisation, compaction fires and context drops below 60% within
+     the same turn.
+  2. Messages are never deleted — only marked `compacted_at`.
+
+**FR-MEM-003**: THE SYSTEM SHALL NEVER delete messages from conversation history;
+messages are marked `compacted_at` or summarised but retained in SQLite.
+
+- *Source*: [[001-system-invariants/spec]], §6
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. The SQLite `messages` table row count never decreases.
+  2. Compacted messages have a non-null `compacted_at` column.
+
+**FR-MEM-004**: WHEN context is assembled, THE SYSTEM SHALL inject recalled
+memory in the order: semantic recall → code context → graph facts.
+
+- *Source*: [[001-system-invariants/spec]], §6
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. Debug dumps show memory injection in the specified order.
+
+**FR-MEM-005**: WHEN the admission control is enabled, THE SYSTEM SHALL score
+each candidate memory with a five-factor importance score and admit it only if
+the score exceeds the configured threshold; scoring failures SHALL be fail-open
+(content admitted).
+
+- *Source*: [[004-memory/spec]], [[001-system-invariants/spec]], §14
+- *Priority*: Should
+- *Acceptance criteria*:
+  1. `remember()` returns `Option<MessageId>`; `None` indicates rejection by
+     admission control, not an error.
+  2. A scorer crash does not prevent the message from being admitted.
+
+**FR-MEM-006**: WHEN graph memory is enabled, THE SYSTEM SHALL extract entities
+and MAGMA-typed edges from conversation and expose them via BFS recall and
+SYNAPSE spreading activation.
+
+- *Source*: [[BRD]], FR-032; [[012-graph-memory/spec]]
+- *Priority*: Should
+- *Acceptance criteria*:
+  1. An entity mentioned in turn N is retrievable via BFS from a related entity
+     in turn N+5.
+
+**FR-MEM-007**: WHEN `ContextBudget` is constructed, THE SYSTEM SHALL perform
+token arithmetic to track available budget and prevent context overflow.
+
+- *Source*: [[021-zeph-context/spec]]
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. `ContextBudget::remaining()` returns a non-negative value when context is
+     within limits.
+  2. An attempt to exceed the budget triggers the compaction state machine.
+
+---
+
+#### 3.2.5 Channel System
+
+> [!info] Traceability
+> Traces to: [[BRD#Multi-Channel I/O]], [[007-channels/spec]],
+> [[001-system-invariants/spec#1-channel-contract]]
+
+**FR-CH-001**: THE SYSTEM SHALL expose a `Channel` trait with `recv`, `send`,
+`send_stream`, and metadata methods; all implementations SHALL be native async
+(Edition 2024); `Box<dyn Channel>` and `Arc<dyn Channel>` are prohibited.
+
+- *Source*: [[001-system-invariants/spec]], §1
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. The Channel trait has no `async_trait` attribute.
+  2. `AnyChannel` is the sole multi-channel dispatch point.
+
+**FR-CH-002**: WHEN Zeph is started without `--tui`, THE SYSTEM SHALL activate
+the CLI channel reading from stdin and writing to stdout.
+
+- *Source*: [[BRD]], FR-040
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. `echo "hello" | cargo run` produces an LLM-sourced reply on stdout.
+
+**FR-CH-003**: WHEN Zeph is started with `--tui`, THE SYSTEM SHALL activate the
+TUI channel displaying the ratatui dashboard with context pressure gauge, memory
+panel, metrics, and conversation pane.
+
+- *Source*: [[BRD]], FR-041; [[011-tui/spec]]
+- *Priority*: Should
+- *Acceptance criteria*:
+  1. The TUI renders without errors on a 80×24 terminal.
+  2. The context pressure gauge updates in real time.
+
+**FR-CH-004**: WHEN a background operation executes in TUI mode (LLM inference,
+memory search, tool execution, MCP connection, skill reload), THE SYSTEM SHALL
+display a visible spinner with a descriptive status message.
+
+- *Source*: [[constitution]], §I; [[011-tui/spec]]
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. Every background operation produces a visible spinner in the TUI status bar.
+  2. The spinner disappears when the operation completes.
+
+**FR-CH-005**: WHEN the Telegram feature is enabled and a bot token is configured,
+THE SYSTEM SHALL activate the Telegram channel with streaming message support.
+
+- *Source*: [[BRD]], FR-042; [[007-channels/spec]]
+- *Priority*: Should
+- *Acceptance criteria*:
+  1. A message sent to the Telegram bot produces a streamed reply in the chat.
+
+**FR-CH-006**: WHEN the user types `/` in TUI Insert mode, THE SYSTEM SHALL
+display an inline autocomplete dropdown populated from the `CommandRegistry`.
+
+- *Source*: [[030-tui-slash-autocomplete/spec]]
+- *Priority*: Should
+- *Acceptance criteria*:
+  1. Typing `/h` narrows the dropdown to commands starting with `h`.
+  2. Tab or Enter accepts the selection; Esc dismisses without action.
+
+**FR-CH-007**: WHEN TUI and ACP stdio transport are both requested at startup,
+THE SYSTEM SHALL reject the combination with a startup error.
+
+- *Source*: [[001-system-invariants/spec]], §10
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. `cargo run -- --tui --acp stdio` exits with a clear error message.
+
+---
+
+#### 3.2.6 Tool Execution
+
+> [!info] Traceability
+> Traces to: [[BRD#Tool Execution]], [[006-tools/spec]],
+> [[016-output-filtering/spec]], [[001-system-invariants/spec#5-tool-execution-contract]]
+
+**FR-TOOL-001**: WHEN an LLM requests a tool call, THE SYSTEM SHALL dispatch it
+exclusively through the native `tool_use` path; there is no legacy text-based
+tool call path.
+
+- *Source*: [[001-system-invariants/spec]], §5
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. All tool invocations appear in the `tool_use` field of the LLM message, never
+     as JSON embedded in assistant text.
+
+**FR-TOOL-002**: WHEN a shell command is requested, THE SYSTEM SHALL run the
+blocklist check unconditionally before consulting the `PermissionPolicy`.
+
+- *Source*: [[BRD]], FR-050; [[001-system-invariants/spec]], §5
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. A blocklisted command is rejected even if the permission policy would allow it.
+  2. The rejection is logged with the blocked command and the reason.
+
+**FR-TOOL-003**: THE SYSTEM SHALL maintain two separate tool execution entry
+points: `execute_tool_call` (pre-approved) and `execute_tool_call_confirmed`
+(requires user approval); these MUST NOT be merged.
+
+- *Source*: [[001-system-invariants/spec]], §5
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. A tool in the "ask first" set triggers a user-approval prompt before execution
+     when called via the unconfirmed path.
+
+**FR-TOOL-004**: WHEN a `CompositeExecutor` is used, THE SYSTEM SHALL dispatch
+tool calls to executors in order; the first executor returning `Some(output)` wins;
+`None` passes the call to the next executor.
+
+- *Source*: [[006-tools/spec]]
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. A tool owned by executor A is not re-executed by executor B.
+
+**FR-TOOL-005**: WHEN tool output is produced, THE SYSTEM SHALL run it through
+the `FilterPipeline` to detect and redact sensitive data patterns before the
+output is injected into the conversation.
+
+- *Source*: [[016-output-filtering/spec]]
+- *Priority*: Should
+- *Acceptance criteria*:
+  1. A tool output containing an API key pattern is redacted before reaching the LLM.
+
+**FR-TOOL-006**: WHEN a tool call is executed, THE SYSTEM SHALL record a
+`claim_source` audit entry with the tool name, caller origin, and timestamp.
+
+- *Source*: [[BRD]], FR-051; [[006-tools/spec]]
+- *Priority*: Should
+- *Acceptance criteria*:
+  1. The audit log contains one entry per tool call with non-null `claim_source`.
+
+---
+
+#### 3.2.7 MCP Integration
+
+> [!info] Traceability
+> Traces to: [[BRD#MCP Integration]], [[008-mcp/spec]]
+
+**FR-MCP-001**: WHEN MCP servers are configured, THE SYSTEM SHALL connect to
+each server at startup, discover available tools, and register them in the tool
+executor alongside native tools.
+
+- *Source*: [[BRD]], FR-060; [[008-mcp/spec]]
+- *Priority*: Should
+- *Acceptance criteria*:
+  1. Tools from an MCP server appear in `/help` tool list.
+  2. An MCP tool call is dispatched to the correct server.
+
+**FR-MCP-002**: WHEN the same tool name is advertised by multiple MCP servers,
+THE SYSTEM SHALL detect the collision and apply the configured collision strategy
+(prefix / reject / first-wins).
+
+- *Source*: [[008-mcp/spec]]
+- *Priority*: Should
+- *Acceptance criteria*:
+  1. Two servers advertising `read_file` trigger a collision warning in logs.
+
+**FR-MCP-003**: WHEN an MCP server exceeds its configured `max_tool_calls_per_session`
+quota, THE SYSTEM SHALL reject further calls from that server with a structured
+`McpErrorCode::QuotaExceeded` response.
+
+- *Source*: [[BRD]], FR-061; [[008-mcp/spec]]
+- *Priority*: Could
+- *Acceptance criteria*:
+  1. After N+1 calls to a server with quota N, the (N+1)th call returns a quota
+     error without executing.
+
+**FR-MCP-004**: WHEN an MCP server is unavailable at startup, THE SYSTEM SHALL
+log the failure and continue without that server's tools; the agent MUST NOT crash.
+
+- *Source*: [[008-mcp/spec]]
+- *Priority*: Should
+- *Acceptance criteria*:
+  1. With a misconfigured MCP server, the agent starts and operates normally
+     without that server's tools.
+
+**FR-MCP-005**: WHEN elicitation is supported (Phase 1: bounded channel, Phase
+2: structured prompt), THE SYSTEM SHALL limit elicitation rounds to the configured
+maximum and present structured prompts to the user.
+
+- *Source*: [[008-mcp/spec]]
+- *Priority*: Could
+- *Acceptance criteria*:
+  1. Elicitation does not loop indefinitely; it stops at the configured maximum.
+
+---
+
+#### 3.2.8 A2A Protocol
+
+> [!info] Traceability
+> Traces to: [[BRD#A2A and ACP Protocols]], [[014-a2a/spec]]
+
+**FR-A2A-001**: WHEN A2A is enabled, THE SYSTEM SHALL implement the JSON-RPC 2.0
+A2A protocol for agent discovery, task sending, and result receiving.
+
+- *Source*: [[BRD]], FR-070; [[014-a2a/spec]]
+- *Priority*: Could
+- *Acceptance criteria*:
+  1. A `/agent discover` command lists available A2A peers.
+  2. A task sent to a peer returns a result via JSON-RPC.
+
+**FR-A2A-002**: WHEN invoking a remote A2A agent, THE SYSTEM SHALL attach an
+IBCT (Invocation-Bound Capability Token) signed with HMAC-SHA256 and a `key_id`
+in the `X-Zeph-IBCT` header.
+
+- *Source*: [[014-a2a/spec]]
+- *Priority*: Could
+- *Acceptance criteria*:
+  1. Outbound A2A requests contain the `X-Zeph-IBCT` header with a valid HMAC.
+
+---
+
+#### 3.2.9 ACP Protocol
+
+> [!info] Traceability
+> Traces to: [[BRD#A2A and ACP Protocols]], [[013-acp/spec]]
+
+**FR-ACP-001**: WHEN ACP is enabled, THE SYSTEM SHALL implement the
+`agent-client-protocol 0.10.3` transport with session management, fork/resume,
+and the `/agent.json` capability advertisement endpoint.
+
+- *Source*: [[BRD]], FR-071; [[013-acp/spec]]
+- *Priority*: Could
+- *Acceptance criteria*:
+  1. An ACP client can connect, fork a session, and receive streamed responses.
+  2. `/agent.json` returns a valid capability document.
+
+---
+
+#### 3.2.10 Vault and Secrets Management
+
+> [!info] Traceability
+> Traces to: [[BRD#Vault and Secrets]], [[038-vault/spec]],
+> [[010-security/spec]]
+
+**FR-VLT-001**: WHEN the agent starts, THE SYSTEM SHALL resolve all `ZEPH_*`
+secrets exclusively from the age-encrypted vault; plaintext secrets in TOML
+or environment variables SHALL be rejected.
+
+- *Source*: [[BRD]], FR-080; [[038-vault/spec]]
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. Setting `ZEPH_OPENAI_API_KEY` as an env var does not inject the key.
+  2. The vault `get` CLI command returns the stored key without exposing it in
+     logs.
+
+**FR-VLT-002**: WHEN a `Secret<T>` value goes out of scope, THE SYSTEM SHALL
+zeroize its memory via the `zeroize` crate.
+
+- *Source*: [[038-vault/spec]], [[043-zeph-common/spec]]
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. Valgrind / address sanitizer shows no secret bytes remain after `Secret`
+     drops (verified in test).
+
+**FR-VLT-003**: WHEN the vault is absent or decryption fails, THE SYSTEM SHALL
+log a descriptive error and fail gracefully; providers requiring missing secrets
+SHALL be skipped with a warning.
+
+- *Source*: [[038-vault/spec]]
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. Starting Zeph without a vault configured produces a logged warning, not a panic.
+
+---
+
+#### 3.2.11 Slash Command Registry
+
+> [!info] Traceability
+> Traces to: [[BRD#Agent Core]], [[042-zeph-commands/spec]]
+
+**FR-CMD-001**: THE SYSTEM SHALL maintain a `CommandRegistry` that dispatches
+slash commands using longest-word-boundary matching; the registry MUST NOT depend
+on `zeph-core`.
+
+- *Source*: [[042-zeph-commands/spec]]
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. `/plan advanced` is matched to `PlanCommand` (longest prefix), not a shorter
+     hypothetical `/plan` handler.
+  2. The `zeph-commands` crate has no compile-time dependency on `zeph-core`.
+
+**FR-CMD-002**: THE SYSTEM SHALL expose a static `COMMANDS` list for `/help`
+output and TUI slash autocomplete.
+
+- *Source*: [[042-zeph-commands/spec]], [[030-tui-slash-autocomplete/spec]]
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. `/help` output lists every command in the `COMMANDS` list.
+  2. TUI autocomplete populates from the same list.
+
+---
+
+#### 3.2.12 Subagent Lifecycle
+
+> [!info] Traceability
+> Traces to: [[BRD#Subagent Lifecycle]], [[044-subagent-lifecycle/spec]],
+> [[033-subagent-context-propagation/spec]]
+
+**FR-SUB-001**: WHEN `/agent spawn <name>` is issued, THE SYSTEM SHALL parse a
+`SubAgentDef`, enforce the concurrency cap, and spawn a child agent with scoped
+`FilteredToolExecutor` and TTL-based `PermissionGrants`.
+
+- *Source*: [[BRD]], FR-110; [[044-subagent-lifecycle/spec]]
+- *Priority*: Could
+- *Acceptance criteria*:
+  1. Spawning beyond the concurrency cap returns an error.
+  2. The child agent's tool access is restricted to the granted set.
+
+**FR-SUB-002**: WHEN a subagent session ends, THE SYSTEM SHALL persist a JSONL
+transcript to disk and optionally inject a summary into the parent agent's memory.
+
+- *Source*: [[044-subagent-lifecycle/spec]]
+- *Priority*: Could
+- *Acceptance criteria*:
+  1. A `.jsonl` file exists in the configured transcript directory after the
+     subagent exits.
+
+**FR-SUB-003**: WHEN the TUI subagent sidebar is open (`a` key), THE SYSTEM SHALL
+list active subagents; `j`/`k` navigates, `Enter` loads the JSONL transcript
+into the conversation pane, `Esc` returns to main view.
+
+- *Source*: [[026-tui-subagent-management/spec]]
+- *Priority*: Could
+- *Acceptance criteria*:
+  1. The sidebar appears on `a`; navigation keys work without lag.
+
+---
+
+#### 3.2.13 Code Indexing
+
+> [!info] Traceability
+> Traces to: [[BRD#Code Indexing]], [[017-index/spec]]
+
+**FR-IDX-001**: WHEN code indexing is enabled and a repository root is configured,
+THE SYSTEM SHALL build an AST-based index and expose semantic retrieval and
+repo-map generation to the agent context.
+
+- *Source*: [[BRD]], FR-100; [[017-index/spec]]
+- *Priority*: Could
+- *Acceptance criteria*:
+  1. A question about a function in the indexed codebase returns a snippet from
+     the correct file without the user specifying the file.
+
+**FR-IDX-002**: WHEN the working directory changes (via `set_working_directory`
+tool or `cwd_changed` hook), THE SYSTEM SHALL reindex the new directory.
+
+- *Source*: [[028-hooks/spec]]
+- *Priority*: Could
+- *Acceptance criteria*:
+  1. After `set_working_directory /path/to/new/project`, queries about the new
+     project return results from the new directory.
+
+---
+
+#### 3.2.14 HTTP Gateway and Scheduler
+
+> [!info] Traceability
+> Traces to: [[BRD#Gateway and Scheduler]], [[019-gateway/spec]], [[018-scheduler/spec]]
+
+**FR-GW-001**: WHEN the gateway feature is enabled, THE SYSTEM SHALL expose an
+HTTP endpoint for webhook ingestion protected by BLAKE3 + constant-time bearer
+token comparison.
+
+- *Source*: [[BRD]], FR-090; [[019-gateway/spec]]
+- *Priority*: Could
+- *Acceptance criteria*:
+  1. A request with a valid bearer token is accepted; an invalid token is rejected
+     with HTTP 401.
+  2. Token comparison uses constant-time equality.
+
+**FR-GW-002**: WHEN the Prometheus feature is enabled, THE SYSTEM SHALL expose
+a `/metrics` endpoint in OpenMetrics 1.0 format with ~25 gauge/counter metrics
+from `MetricsSnapshot`.
+
+- *Source*: [[036-prometheus-metrics/spec]]
+- *Priority*: Could
+- *Acceptance criteria*:
+  1. A Prometheus scrape of `/metrics` returns at least 25 distinct metric families.
+
+**FR-SCH-001**: WHEN a cron schedule is configured (via `zeph schedule add`
+or `config.toml`), THE SYSTEM SHALL fire the task at the scheduled time using
+SQLite-persisted state and inject the resulting message into the agent queue.
+
+- *Source*: [[BRD]], FR-091; [[018-scheduler/spec]]
+- *Priority*: Could
+- *Acceptance criteria*:
+  1. `zeph schedule list` shows the configured task.
+  2. The task fires at the cron-specified time within a 5-second tolerance.
+
+---
+
+#### 3.2.15 Observability and Experiments
+
+> [!info] Traceability
+> Traces to: [[035-profiling/spec]], [[036-prometheus-metrics/spec]],
+> [[041-experiments/spec]]
+
+**FR-OBS-001**: WHEN the `profiling` feature is enabled, THE SYSTEM SHALL record
+per-span traces to a local Chrome JSON file (Tier 1) or an OTLP endpoint (Tier 2),
+with zero overhead when the feature is disabled.
+
+- *Source*: [[035-profiling/spec]]
+- *Priority*: Could
+- *Acceptance criteria*:
+  1. A trace file is written to `.local/traces/` when `profiling-backend = "local"`.
+  2. The binary built without the `profiling` feature has no performance regression.
+
+**FR-OBS-002**: WHEN an experiment is configured with a `rollout_pct` percentage,
+THE SYSTEM SHALL enrol sessions deterministically based on `SessionId` and apply
+the experiment's overrides only to enrolled sessions.
+
+- *Source*: [[041-experiments/spec]]
+- *Priority*: Could
+- *Acceptance criteria*:
+  1. 50% rollout results in approximately 50% of sessions enrolled (verified
+     statistically over 100 sessions).
+
+---
+
+#### 3.2.16 Security and Content Sanitization
+
+> [!info] Traceability
+> Traces to: [[010-security/spec]], [[025-classifiers/spec]], [[040-sanitizer/spec]]
+
+**FR-SEC-001**: WHEN user or tool input is received, THE SYSTEM SHALL run it
+through the eight-layer sanitizer pipeline: spotlighting → regex injection
+detection → PII scrubber → guardrail filter → quarantined summarizer → response
+verification → exfiltration guard → memory validation.
+
+- *Source*: [[040-sanitizer/spec]]
+- *Priority*: Should
+- *Acceptance criteria*:
+  1. Input containing a known injection pattern is flagged before reaching the LLM.
+  2. PII in tool output is redacted before injection into conversation history.
+
+**FR-SEC-002**: WHEN SSRF protection is active, THE SYSTEM SHALL reject HTTP
+requests from web tools to private IP ranges (RFC 1918, loopback, link-local)
+and validate redirect chains.
+
+- *Source*: [[010-security/spec]]
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. A web scrape request to `http://192.168.1.1` is rejected with a logged reason.
+
+**FR-SEC-003**: WHEN the `env-scrub` feature is active, THE SYSTEM SHALL remove
+`ZEPH_*` and known credential environment variable names from subprocess
+environments before spawning shell commands.
+
+- *Source*: [[010-security/spec]]
+- *Priority*: Should
+- *Acceptance criteria*:
+  1. A shell command cannot read `ZEPH_OPENAI_API_KEY` from its environment.
+
+---
+
+#### 3.2.17 Configuration Loading and Migration
+
+> [!info] Traceability
+> Traces to: [[020-config-loading/spec]], [[037-config-schema/spec]]
+
+**FR-CFG-001**: WHEN Zeph starts, THE SYSTEM SHALL resolve configuration in this
+order: default values → `config.toml` → `ZEPH_*` env overrides; each source
+overrides the previous.
+
+- *Source*: [[020-config-loading/spec]]
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. `ZEPH_AGENT_NAME=myagent` overrides the `agent.name` TOML value.
+
+**FR-CFG-002**: WHEN `--migrate-config` is passed, THE SYSTEM SHALL apply all
+registered migration steps in order and write the updated config to the file.
+
+- *Source*: [[037-config-schema/spec]], [[001-system-invariants/spec]], §8
+- *Priority*: Should
+- *Acceptance criteria*:
+  1. A config produced for a previous minor version is automatically upgraded
+     to the current schema without data loss.
+
+**FR-CFG-003**: WHEN a config section marked `#[serde(default)]` is absent from
+the TOML, THE SYSTEM SHALL produce sensible defaults and MUST NOT panic.
+
+- *Source*: [[001-system-invariants/spec]], §8
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. A minimal config with only the mandatory sections (`agent`, `llm`, `skills`,
+     `memory`, `tools`) starts the agent without errors.
+
+---
+
+### 3.3 Performance Requirements
+
+> [!note]
+> Detailed performance metrics are in [[NFR#2-performance-efficiency]].
+> This section notes performance aspects tied to specific functional requirements.
+
+- FR-AL-001: agent turn processing adds no observable latency beyond the LLM
+  provider's own response time for simple queries.
+- FR-MEM-001: SQLite writes must complete within 50ms per turn under normal load.
+- FR-SK-001: skill hot-reload must not block the agent loop; reload completes
+  within 500ms debounce.
+- FR-CH-004: TUI frame rate must remain ≥ 30 fps during background operations.
+
+---
+
+### 3.4 Logical Database Requirements
+
+| Entity | Key Attributes | Relationships | Retention |
+|--------|---------------|--------------|-----------|
+| Message | id, session_id, role, content, compacted_at, created_at | belongs to Session | Permanent (never deleted) |
+| Session | id, channel, started_at, ended_at | has many Messages | Permanent |
+| MemoryVector | id, message_id, embedding, namespace | references Message | Until explicit purge |
+| SkillRecord | id, name, trust_level, positive_signals, negative_signals | standalone | Until skill file removed |
+| ScheduledTask | id, cron_expr, next_run, last_run, payload | standalone | Until removed |
+| Experiment | id, name, rollout_pct, config_overrides, enrolled_sessions | standalone | Until removed |
+| GraphEntity | id, label, type, session_id | has many GraphEdges | Permanent |
+| GraphEdge | id, source_id, target_id, type, weight | between GraphEntities | Permanent |
+
+---
+
+### 3.5 Design Constraints
+
+- The `zeph-commands` crate MUST NOT import `zeph-core` (Layer 0 constraint).
+- All SQL in consumer crates MUST use the `sql!()` macro for dialect portability.
+- `sqlite` and `postgres` features in `zeph-db` are mutually exclusive.
+- `ThinkingBlock` and `RedactedThinkingBlock` message parts MUST be forwarded
+  verbatim to the next LLM request.
+- The system message MUST be the first element in the messages array.
+
+---
+
+### 3.6 Software System Attributes
+
+> [!note]
+> Full quality attribute specifications are in [[NFR]].
+
+- **Reliability**: agent must not panic on provider errors; graceful degradation
+  without Qdrant or MCP servers.
+- **Security**: no plaintext secrets; blocklist gate before permission policy;
+  SSRF protection; PII redaction.
+- **Maintainability**: 24-crate workspace with strict layered DAG; no same-layer
+  imports; comprehensive rustdoc for all `pub` items.
+
+---
+
+## 4. Verification and Validation
+
+### 4.1 Verification Matrix
+
+| Requirement | Method | Criteria | Status |
+|------------|--------|----------|--------|
+| FR-AL-001 | Automated test (nextest) | Turn loop completes; tool results appended | Pending |
+| FR-AL-002 | Automated test | Slash commands dispatch correctly | Pending |
+| FR-AL-003 | Automated test | Queue drains before recv | Pending |
+| FR-LLM-001 | Provider test suite | All 5 providers pass chat/stream/tools | Pending |
+| FR-LLM-002 | Config validation test | Duplicate name → startup error | Pending |
+| FR-LLM-003 | Integration test | Routing by complexity tier | Pending |
+| FR-SK-001 | File system test | Skill appears within 500ms | Pending |
+| FR-SK-002 | Unit test | Threshold gate prevents injection | Pending |
+| FR-MEM-001 | Integration test (Qdrant) | Cross-session recall | Pending |
+| FR-MEM-002 | Unit test | Compaction at 90% threshold | Pending |
+| FR-MEM-003 | Database test | Row count never decreases | Pending |
+| FR-CH-002 | CLI smoke test | Piped input produces output | Pending |
+| FR-CH-004 | TUI visual test | Spinner visible during LLM call | Pending |
+| FR-TOOL-002 | Unit test | Blocklist check before policy | Pending |
+| FR-VLT-001 | Config test | Env var rejected; vault used | Pending |
+| FR-SEC-002 | Unit test | Private IP rejected | Pending |
+| FR-CFG-003 | Unit test | Minimal config starts agent | Pending |
+
+### 4.2 Acceptance Test Outline
+
+1. **CLI smoke test**: `echo "What is 2+2?" | cargo run -- --config .local/config/testing.toml`
+   — expects a coherent LLM reply on stdout.
+2. **Cross-session memory**: session 1 says "my name is Alice"; session 2 asks
+   "what is my name?" — expects "Alice" via semantic recall.
+3. **Skill hot-reload**: add a SKILL.md; within 500ms the skill appears in
+   `SkillRegistry` without restart.
+4. **Provider fallback**: configure cascade with a failing primary; confirm fallback
+   provider handles the request.
+5. **Secret isolation**: confirm no `ZEPH_*` key is readable from a spawned shell
+   command environment.
+6. **TUI spinner**: start `--tui`; send a message; confirm spinner appears during
+   LLM inference.
+
+---
+
+## 5. Appendices
+
+### 5.1 Traceability Matrix
+
+| BRD Requirement | SRS Requirement(s) | Notes |
+|----------------|-------------------|-------|
+| BRD FR-001 (Agent loop) | FR-AL-001, FR-AL-002, FR-AL-003 | |
+| BRD FR-002 (Slash commands) | FR-AL-002, FR-CMD-001, FR-CMD-002 | |
+| BRD FR-003 (Provider hot-swap) | FR-AL-004 | |
+| BRD FR-010 (Multi-provider) | FR-LLM-001, FR-LLM-005 | |
+| BRD FR-011 (Provider routing) | FR-LLM-002, FR-LLM-003, FR-LLM-004 | |
+| BRD FR-012 (Prompt caching) | FR-LLM-006 | |
+| BRD FR-020 (Skills hot-reload) | FR-SK-001 | |
+| BRD FR-021 (Skill matching) | FR-SK-002 | |
+| BRD FR-022 (Self-learning) | FR-SK-003, FR-SK-004 | |
+| BRD FR-030 (Semantic memory) | FR-MEM-001, FR-MEM-004 | |
+| BRD FR-031 (Compaction) | FR-MEM-002, FR-MEM-003, FR-MEM-007 | |
+| BRD FR-032 (Graph memory) | FR-MEM-006 | |
+| BRD FR-040 (CLI channel) | FR-CH-001, FR-CH-002 | |
+| BRD FR-041 (TUI channel) | FR-CH-001, FR-CH-003, FR-CH-004, FR-CH-006 | |
+| BRD FR-042 (Telegram) | FR-CH-001, FR-CH-005 | |
+| BRD FR-050 (Tool execution) | FR-TOOL-001, FR-TOOL-002, FR-TOOL-003, FR-TOOL-004 | |
+| BRD FR-051 (Tool audit) | FR-TOOL-006 | |
+| BRD FR-060 (MCP client) | FR-MCP-001, FR-MCP-002, FR-MCP-004 | |
+| BRD FR-061 (MCP quotas) | FR-MCP-003 | |
+| BRD FR-070 (A2A) | FR-A2A-001, FR-A2A-002 | |
+| BRD FR-071 (ACP) | FR-ACP-001 | |
+| BRD FR-080 (Vault) | FR-VLT-001, FR-VLT-002, FR-VLT-003 | |
+| BRD FR-090 (Gateway) | FR-GW-001, FR-GW-002 | |
+| BRD FR-091 (Scheduler) | FR-SCH-001 | |
+| BRD FR-100 (Code indexing) | FR-IDX-001, FR-IDX-002 | |
+| BRD FR-110 (Subagents) | FR-SUB-001, FR-SUB-002, FR-SUB-003 | |
+
+---
+
+## See Also
+
+- [[BRD]] — business requirements (source)
+- [[NFR]] — non-functional requirements
+- [[constitution]] — project-wide principles
+- [[MOC-specs]] — index of all specifications
+- [[001-system-invariants/spec]] — architectural invariants (authoritative)

--- a/specs/constitution.md
+++ b/specs/constitution.md
@@ -21,10 +21,10 @@ related:
 
 ## I. Architecture
 
-- Cargo workspace (Edition 2024, resolver 3): 22 crates (including `zeph-common`), root binary `zeph`
+- Cargo workspace (Edition 2024, resolver 3): 24 crates (including `zeph-common`, `zeph-commands`, `zeph-context`), root binary `zeph`
 - `zeph-core` orchestrates all crates. Crate dependencies must follow the layered DAG:
-  - **Layer 0** (foundation, no zeph-* deps): `zeph-llm`, `zeph-a2a`, `zeph-gateway`, `zeph-scheduler`, `zeph-common`, `zeph-config`, `zeph-vault`, `zeph-db`
-  - **Layer 1** (depends on Layer 0): `zeph-memory` (→ llm, config, vault, db), `zeph-tools` (→ common, config), `zeph-index` (→ llm, memory)
+  - **Layer 0** (foundation, no zeph-* deps): `zeph-llm`, `zeph-a2a`, `zeph-gateway`, `zeph-scheduler`, `zeph-common`, `zeph-config`, `zeph-vault`, `zeph-db`, `zeph-commands`
+  - **Layer 1** (depends on Layer 0): `zeph-context` (→ llm, memory, config, common), `zeph-memory` (→ llm, config, vault, db), `zeph-tools` (→ common, config), `zeph-index` (→ llm, memory)
   - **Layer 2** (depends on Layers 0–1): `zeph-skills` (→ llm, memory, tools), `zeph-mcp` (→ llm, memory, tools, common), `zeph-sanitizer` (→ llm, tools, common)
   - **Layer 3** (orchestrator): `zeph-core` (→ all Layer 0–2 crates)
   - **Layer 4** (consumers): `zeph-channels`, `zeph-tui`, `zeph-acp`, `zeph-orchestration`, `zeph-subagent` (→ core + selective Layer 0–2)


### PR DESCRIPTION
## Summary

- Add `specs/BRD.md` — Business Requirements Document: personas, business goals, success metrics, explicit out-of-scope boundaries
- Add `specs/SRS.md` — Software Requirements Specification (ISO/IEC/IEEE 29148): 70+ functional requirements in EARS notation across 17 subsystems, system context diagram, BRD→SRS traceability matrix
- Add `specs/NFR.md` — Non-Functional Requirements (ISO/IEC 25010): 65+ measurable targets (latency, throughput, security, portability, usability) with verification methods
- Fill four spec gaps: `021-zeph-context`, `042-zeph-commands`, `043-zeph-common`, `044-subagent-lifecycle`
- Update `constitution.md`: crate count 22→24, add `zeph-commands` and `zeph-context` to dependency DAG
- Update `MOC-specs.md` and `README.md`: index all new documents

## No code changes

This PR is documentation-only (`specs/` directory). No Rust source files were modified.