### PR TITLE
ci: remove sccache from lightweight jobs, expand cargo cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,9 +139,6 @@ jobs:
             label: desktop-ide-server-chat-pdf-scheduler
           - features: bench
             label: bench
-    env:
-      RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -150,9 +147,7 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          cache-targets: "false"
           shared-key: "ci"
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - name: Clippy
         run: cargo clippy --profile ci --workspace --features ${{ matrix.features }} -- -D warnings
 
@@ -354,9 +349,6 @@ jobs:
         include:
           - bundle: ml
             allow_failure: true
-    env:
-      RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -364,9 +356,7 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          cache-targets: "false"
           shared-key: "ci"
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - name: Check bundle
         continue-on-error: ${{ matrix.allow_failure == true }}
         run: cargo check --features ${{ matrix.bundle }}
@@ -377,9 +367,6 @@ jobs:
     if: needs.detect-changes.outputs.run-full-ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    env:
-      RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -387,9 +374,7 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          cache-targets: "false"
           shared-key: "ci"
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - name: Check postgres build (zeph-db)
         run: cargo check -p zeph-db --no-default-features --features postgres
 
@@ -401,8 +386,6 @@ jobs:
     timeout-minutes: 10
     env:
       RUSTDOCFLAGS: "--deny rustdoc::broken_intra_doc_links"
-      RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -410,9 +393,7 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          cache-targets: "false"
           shared-key: "ci"
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - name: Build docs (all features except candle)
         run: cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"
       - name: Doc-tests


### PR DESCRIPTION
## Summary

- Remove sccache from lightweight CI jobs (lint-clippy, bundle-check, build-postgres, rustdoc) where cache hit rate was poor
- Expand rust-cache to include `target/` on those jobs for incremental cargo check/clippy
- Keep sccache only on heavy jobs: build-tests, coverage, release/build-binaries

## Why

sccache keys on compiler invocations. Lightweight `cargo check`/`clippy` builds produce a different artifact set than full `cargo build`/`nextest archive`, so both job types were polluting and evicting each other's sccache entries — resulting in near-zero hit rates across the board.

Separating the two layers fixes this: rust-cache handles incremental builds for lightweight jobs, sccache handles distributed compilation for heavy jobs only.

## Test plan

- [ ] CI passes on this PR
- [ ] sccache hit rate improves on build-tests/coverage runs (visible in job logs)