### PR TITLE
fix(tui,context): eliminate per-frame clone and context over-allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **TUI: remove per-frame message list clone** (`#2955`): `visible_messages().into_owned()` in
+  `chat.rs` replaced with a borrowed reference; eliminates ~20,000 `ChatMessage` clones/sec at
+  2000-message history, reducing idle CPU usage proportional to message count.
+
+- **Context assembler: cap `String::with_capacity` for recall text** (`#2956`): allocation is now
+  `min(recall_limit * 512, token_budget * 3)` instead of `token_budget * 3`; reduces worst-case
+  pre-allocation from ~200KB to a few KB per context assembly pass when using large-context
+  providers (Claude, GPT-4).
+
 ## [0.19.0] - 2026-04-13
 
 ### Changed

--- a/crates/zeph-core/src/agent/context/assembler.rs
+++ b/crates/zeph-core/src/agent/context/assembler.rs
@@ -180,7 +180,8 @@ pub(super) async fn fetch_semantic_recall(
 
     let top_score = recalled.first().map(|r| r.score);
 
-    let mut recall_text = String::with_capacity(token_budget * 3);
+    let initial_cap = (memory_state.persistence.recall_limit * 512).min(token_budget * 3);
+    let mut recall_text = String::with_capacity(initial_cap);
     recall_text.push_str(RECALL_PREFIX);
     let mut tokens_used = tc.count_tokens(&recall_text);
 

--- a/crates/zeph-tui/src/widgets/chat.rs
+++ b/crates/zeph-tui/src/widgets/chat.rs
@@ -33,7 +33,7 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, cache: &mut RenderCa
     let wrap_width = area.width.saturating_sub(4) as usize;
 
     // Use visible_messages() to support subagent transcript view.
-    let messages = app.visible_messages().into_owned();
+    let messages = app.visible_messages();
     let truncation_info = app.transcript_truncation_info();
     let title = if let Some(ref name) = app.view_target.subagent_name().map(str::to_owned) {
         format!(" Subagent: {name} ")


### PR DESCRIPTION
## Summary

- **#2955**: Remove `visible_messages().into_owned()` in `chat.rs` — replaces unconditional `Vec<ChatMessage>` clone on every render frame (10fps) with a borrowed `Cow` reference. Eliminates ~20,000 `ChatMessage` clones/sec at 2000-message history, reducing idle CPU and memory pressure.
- **#2956**: Cap `String::with_capacity` in context assembler to `min(recall_limit * 512, token_budget * 3)`. With `context_window = 1_000_000` (Claude/GPT-4), this reduces worst-case pre-allocation from ~200KB to a few KB per context assembly pass.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy -p zeph-tui -p zeph-core -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 7923 passed, 0 failed
- [x] Existing `visible_messages()` tests (4 tests in `app.rs`) cover both Cow::Borrowed and Cow::Owned paths
- [x] Both fixes are pure allocation changes with no observable behavioral difference

Closes #2955, closes #2956