### PR TITLE
fix(tui,mcp,tools): eliminate async discipline violations causing TUI freeze and 1000% CPU

### DIFF
--- a/crates/zeph-mcp/src/manager.rs
+++ b/crates/zeph-mcp/src/manager.rs
@@ -672,32 +672,46 @@ impl McpManager {
 
         let mut all_tools = Vec::new();
         let mut outcomes: Vec<ServerConnectOutcome> = Vec::new();
-        {
+
+        // Collect all connection results first — no locks held during async work.
+        let mut connect_results = Vec::new();
+        while let Some(result) = join_set.join_next().await {
+            let Ok((server_id, connect_result)) = result else {
+                tracing::warn!("MCP connection task panicked");
+                continue;
+            };
+            connect_results.push((server_id, connect_result));
+        }
+
+        // Process results one at a time, acquiring locks per-result.
+        // NOTE: `clients` and `server_tools` write guards are acquired here and held
+        // across the `handle_connect_result(...).await` call, which may perform HTTP
+        // requests, probe execution, and additional lock acquisitions on other fields
+        // (server_instructions, server_trust). Other tasks needing clients/server_tools
+        // are blocked for the duration of each handle_connect_result call. This is
+        // strictly better than the previous code (which held both locks for ALL results),
+        // but the contention window per-result remains. A future optimization could pass
+        // owned data into handle_connect_result instead of mutable guard references.
+        for (server_id, connect_result) in connect_results {
             let mut clients = self.clients.write().await;
             let mut server_tools = self.server_tools.write().await;
 
-            while let Some(result) = join_set.join_next().await {
-                let Ok((server_id, connect_result)) = result else {
-                    tracing::warn!("MCP connection task panicked");
-                    continue;
-                };
-
-                self.handle_connect_result(
-                    server_id,
-                    connect_result,
-                    &mut ConnectState {
-                        all_tools: &mut all_tools,
-                        clients: &mut clients,
-                        server_tools: &mut server_tools,
-                        outcomes: &mut outcomes,
-                    },
-                    IngestLimits {
-                        description_bytes: self.max_description_bytes,
-                        instructions_bytes: self.max_instructions_bytes,
-                    },
-                )
-                .await;
-            }
+            self.handle_connect_result(
+                server_id,
+                connect_result,
+                &mut ConnectState {
+                    all_tools: &mut all_tools,
+                    clients: &mut clients,
+                    server_tools: &mut server_tools,
+                    outcomes: &mut outcomes,
+                },
+                IngestLimits {
+                    description_bytes: self.max_description_bytes,
+                    instructions_bytes: self.max_instructions_bytes,
+                },
+            )
+            .await;
+            // clients and server_tools write guards dropped here at end of each iteration.
         }
 
         // Detect sanitized_id collisions across the aggregated tool list (SF-6/MF-1).

--- a/crates/zeph-tools/src/search_code.rs
+++ b/crates/zeph-tools/src/search_code.rs
@@ -279,11 +279,15 @@ impl SearchCodeExecutor {
         }
 
         if let Some(symbol) = symbol {
-            hits.extend(self.structural_search(
-                symbol,
-                params.file_pattern.as_deref(),
-                max_results,
-            )?);
+            let paths = self.allowed_paths.clone();
+            let sym = symbol.to_owned();
+            let pat = params.file_pattern.clone();
+            let structural_hits = tokio::task::spawn_blocking(move || {
+                collect_all_structural_hits(&paths, &sym, pat.as_deref(), max_results)
+            })
+            .await
+            .map_err(|e| ToolError::Execution(e.into()))??;
+            hits.extend(structural_hits);
 
             if let Some(backend) = &self.lsp_backend {
                 if let Ok(lsp_hits) = backend
@@ -349,31 +353,6 @@ impl SearchCodeExecutor {
         }))
     }
 
-    fn structural_search(
-        &self,
-        symbol: &str,
-        file_pattern: Option<&str>,
-        max_results: usize,
-    ) -> Result<Vec<SearchCodeHit>, ToolError> {
-        let matcher = file_pattern
-            .map(glob::Pattern::new)
-            .transpose()
-            .map_err(|e| ToolError::InvalidParams {
-                message: format!("invalid file_pattern: {e}"),
-            })?;
-        let mut hits = Vec::new();
-        let symbol_lower = symbol.to_lowercase();
-
-        for root in &self.allowed_paths {
-            collect_structural_hits(root, root, matcher.as_ref(), &symbol_lower, &mut hits)?;
-            if hits.len() >= max_results {
-                break;
-            }
-        }
-
-        Ok(hits)
-    }
-
     fn grep_fallback(
         &self,
         pattern: &str,
@@ -429,6 +408,33 @@ impl ToolExecutor for SearchCodeExecutor {
             invocation: InvocationHint::ToolCall,
         }]
     }
+}
+
+/// Traverse `allowed_paths` collecting structural symbol hits synchronously.
+///
+/// Extracted as a free function so callers can run it inside
+/// `tokio::task::spawn_blocking` without borrowing `self`.
+fn collect_all_structural_hits(
+    allowed_paths: &[PathBuf],
+    symbol: &str,
+    file_pattern: Option<&str>,
+    max_results: usize,
+) -> Result<Vec<SearchCodeHit>, ToolError> {
+    let matcher = file_pattern
+        .map(glob::Pattern::new)
+        .transpose()
+        .map_err(|e| ToolError::InvalidParams {
+            message: format!("invalid file_pattern: {e}"),
+        })?;
+    let mut hits = Vec::new();
+    let symbol_lower = symbol.to_lowercase();
+    for root in allowed_paths {
+        collect_structural_hits(root, root, matcher.as_ref(), &symbol_lower, &mut hits)?;
+        if hits.len() >= max_results {
+            break;
+        }
+    }
+    Ok(hits)
 }
 
 fn dedupe_hits(mut hits: Vec<SearchCodeHit>, max_results: usize) -> Vec<SearchCodeHit> {

--- a/crates/zeph-tui/src/lib.rs
+++ b/crates/zeph-tui/src/lib.rs
@@ -131,16 +131,6 @@ async fn tui_loop(
     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     loop {
-        app.poll_metrics();
-        app.poll_pending_file_index();
-        app.poll_pending_transcript();
-        terminal.draw(|frame| app.draw(frame))?;
-
-        let links = app.take_hyperlinks();
-        if !links.is_empty() {
-            hyperlink::write_osc8(terminal.backend_mut(), &links)?;
-        }
-
         tokio::select! {
             biased;
             Some(event) = event_rx.recv() => {
@@ -153,6 +143,16 @@ async fn tui_loop(
                 }
             }
             _ = tick.tick() => {}
+        }
+
+        app.poll_metrics();
+        app.poll_pending_file_index();
+        app.poll_pending_transcript();
+        terminal.draw(|frame| app.draw(frame))?;
+
+        let links = app.take_hyperlinks();
+        if !links.is_empty() {
+            hyperlink::write_osc8(terminal.backend_mut(), &links)?;
         }
 
         if app.should_quit {

--- a/src/bootstrap/mcp.rs
+++ b/src/bootstrap/mcp.rs
@@ -172,7 +172,7 @@ fn resolve_vault_ref(value: &str, vault: Option<&Arc<RwLock<AgeVaultProvider>>>)
         return value.to_owned();
     };
 
-    let guard = vault_arc.blocking_read();
+    let guard = tokio::task::block_in_place(|| vault_arc.blocking_read());
     let mut result = value.to_owned();
     let mut search_from = 0;
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1127,19 +1127,25 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             let policies: Vec<String> = if let Some(ref path) = adv_cfg.policy_file {
                 // SEC-01: canonicalize + boundary check matching load_policy_file() in policy.rs.
                 // Prevents symlink attacks that could exfiltrate arbitrary files via the policy LLM.
-                let load_result = (|| -> Result<Vec<String>, std::io::Error> {
-                    let p = std::path::Path::new(path);
-                    let canonical = std::fs::canonicalize(p)?;
-                    let canonical_base = std::env::current_dir().and_then(std::fs::canonicalize)?;
-                    if !canonical.starts_with(&canonical_base) {
-                        return Err(std::io::Error::new(
-                            std::io::ErrorKind::PermissionDenied,
-                            "adversarial policy file escapes project root",
-                        ));
-                    }
-                    let content = std::fs::read_to_string(&canonical)?;
-                    Ok(zeph_tools::parse_policy_lines(&content))
-                })();
+                // spawn_blocking: canonicalize and read_to_string are blocking fs calls.
+                let path_owned = path.clone();
+                let load_result =
+                    tokio::task::spawn_blocking(move || -> Result<Vec<String>, std::io::Error> {
+                        let p = std::path::Path::new(&path_owned);
+                        let canonical = std::fs::canonicalize(p)?;
+                        let canonical_base =
+                            std::env::current_dir().and_then(std::fs::canonicalize)?;
+                        if !canonical.starts_with(&canonical_base) {
+                            return Err(std::io::Error::new(
+                                std::io::ErrorKind::PermissionDenied,
+                                "adversarial policy file escapes project root",
+                            ));
+                        }
+                        let content = std::fs::read_to_string(&canonical)?;
+                        Ok(zeph_tools::parse_policy_lines(&content))
+                    })
+                    .await
+                    .unwrap_or_else(|e| Err(std::io::Error::other(e)));
                 match load_result {
                     Ok(lines) => lines,
                     Err(e) => {


### PR DESCRIPTION
## Summary

Fixes TUI freeze on \"Connecting tools...\" and ~1000% CPU at startup. Four blocking-in-async violations were starving the tokio runtime after embed backfill completed, preventing TUI render and OTLP trace export from being scheduled.

- Move `select!` before `terminal.draw()` in `tui_loop` — executor yields before rendering
- Wrap `vault_arc.blocking_read()` in `block_in_place` in MCP bootstrap
- Collect JoinSet results before acquiring write locks in `connect_all`
- Extract `structural_search` into sync free fn + `spawn_blocking` at callsite
- Wrap adversarial policy file load in `spawn_blocking` in `runner.rs`

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 7935/7935 passed
- [ ] Manual: `zeph --tui` — TUI responsive within 1s, no freeze on "Connecting tools..."
- [ ] Manual: CPU below 200% during startup
- [ ] Manual: Jaeger traces appear from process start

## Related

Closes #2972
Closes #2968
Closes #2969
Closes #2970
Closes #2971
Follow-up: #2974 — eliminate remaining lock-across-await in `handle_connect_result`
Part of epic #2958 (TaskSupervisor) async discipline track