### PR TITLE
feat(core): migrate bootstrap memory loops to TaskSupervisor (#2960)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   backoff for `RestartPolicy::Restart`, registry visibility for blocking and oneshot tasks,
   `TaskStatus::Aborted` for force-aborted entries, and 6 regression tests.
 
+- **Bootstrap: migrate 7 memory loops + tree consolidation to TaskSupervisor** (`#2960`):
+  `runner.rs` no longer creates per-loop `CancellationToken` + cancel-bridge `tokio::spawn`
+  boilerplate for each of the 7 memory background tasks (eviction, tier promotion, scene
+  consolidation, consolidation, forgetting, compression guidelines, tree consolidation).
+  All loops are now registered via a single `Arc<TaskSupervisor>` with `RestartPolicy::RunOnce`.
+  A single `shutdown_rx → CancellationToken` bridge replaces 7 identical bridge tasks.
+  `with_tree_consolidation_loop` removed from `AgentBuilder`; tree consolidation is now
+  spawned in `runner.rs` alongside all other memory loops.
+  `supervisor.shutdown_all(10s)` added to the orderly shutdown sequence.
+  `start_*` functions in `zeph-memory` now return `impl Future` instead of `JoinHandle`.
+
 ### Fixed
 
 - **TUI: remove per-frame message list clone** (`#2955`): `visible_messages().into_owned()` in

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9803,6 +9803,7 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "tokio",
+ "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "toml_edit",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -252,6 +252,7 @@ similar.workspace = true
 tempfile.workspace = true
 zeph-db.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }
+tokio-util.workspace = true
 toml.workspace = true
 toml_edit.workspace = true
 tracing.workspace = true

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -169,37 +169,6 @@ impl<C: Channel> Agent<C> {
         self
     }
 
-    /// Start the `TiMem` tree consolidation background loop and store the handle.
-    ///
-    /// Call after memory and tree configuration have been applied so that both the `SQLite`
-    /// store and config are available. The loop runs until the agent cancel token fires.
-    /// The handle is kept in the memory state and is aborted when the agent is dropped.
-    ///
-    /// No-op if tree consolidation is disabled in the config or memory has not been set.
-    #[must_use]
-    pub fn with_tree_consolidation_loop(mut self, provider: zeph_llm::any::AnyProvider) -> Self {
-        let cfg = &self.memory_state.subsystems.tree_config;
-        if !cfg.enabled {
-            return self;
-        }
-        let Some(ref memory) = self.memory_state.persistence.memory else {
-            return self;
-        };
-        let sqlite = std::sync::Arc::new(memory.sqlite().clone());
-        let tree_cfg = zeph_memory::TreeConsolidationConfig {
-            enabled: cfg.enabled,
-            sweep_interval_secs: cfg.sweep_interval_secs,
-            batch_size: cfg.batch_size,
-            similarity_threshold: cfg.similarity_threshold,
-            max_level: cfg.max_level,
-            min_cluster_size: cfg.min_cluster_size,
-        };
-        let cancel = self.lifecycle.cancel_token.clone();
-        let handle = zeph_memory::start_tree_consolidation_loop(sqlite, provider, tree_cfg, cancel);
-        self.memory_state.subsystems.tree_consolidation_handle = Some(handle);
-        self
-    }
-
     // ---- Shutdown Summary ----
 
     /// Configure the shutdown summary: whether to produce one, message count bounds, and timeout.

--- a/crates/zeph-core/src/agent/state/subsystems.rs
+++ b/crates/zeph-core/src/agent/state/subsystems.rs
@@ -5,8 +5,7 @@
 //!
 //! [`MemorySubsystemState`] groups configuration and runtime state for three advanced memory
 //! subsystems: `TiMem` (temporal-hierarchical memory tree), `autoDream` (background consolidation),
-//! and `MagicDocs` (document context injection). Also tracks the background tree consolidation
-//! task handle.
+//! and `MagicDocs` (document context injection).
 
 /// `TiMem` tree config, `autoDream`, `MagicDocs`, and microcompact subsystem state.
 ///
@@ -16,10 +15,6 @@
 pub(crate) struct MemorySubsystemState {
     /// `TiMem` temporal-hierarchical memory tree configuration (#2262).
     pub(crate) tree_config: zeph_config::TreeConfig,
-    /// Background tree consolidation loop handle — kept alive for the agent's lifetime (#2262).
-    ///
-    /// `None` when tree consolidation is disabled or memory is not initialized.
-    pub(crate) tree_consolidation_handle: Option<tokio::task::JoinHandle<()>>,
     /// Time-based microcompact configuration (#2699).
     pub(crate) microcompact_config: zeph_config::MicrocompactConfig,
     /// autoDream configuration (#2697).
@@ -36,7 +31,6 @@ impl Default for MemorySubsystemState {
     fn default() -> Self {
         Self {
             tree_config: zeph_config::TreeConfig::default(),
-            tree_consolidation_handle: None,
             microcompact_config: zeph_config::MicrocompactConfig::default(),
             autodream_config: zeph_config::AutoDreamConfig::default(),
             autodream: super::super::autodream::AutoDreamState::new(),

--- a/crates/zeph-memory/src/compression_guidelines.rs
+++ b/crates/zeph-memory/src/compression_guidelines.rs
@@ -289,62 +289,59 @@ mod updater {
     /// Wakes every `config.update_interval_secs` seconds. When the number of unused
     /// failure pairs reaches `config.update_threshold`, runs an update cycle.
     /// Uses exponential backoff on LLM failure (capped at 1 hour).
-    pub fn start_guidelines_updater(
+    pub async fn start_guidelines_updater(
         sqlite: Arc<SqliteStore>,
         provider: AnyProvider,
         token_counter: Arc<TokenCounter>,
         config: CompressionGuidelinesConfig,
         cancel: CancellationToken,
-    ) -> tokio::task::JoinHandle<()> {
-        tokio::spawn(async move {
-            let base_interval = Duration::from_secs(config.update_interval_secs);
-            let mut backoff = base_interval;
-            let max_backoff = Duration::from_secs(3600);
+    ) {
+        let base_interval = Duration::from_secs(config.update_interval_secs);
+        let mut backoff = base_interval;
+        let max_backoff = Duration::from_secs(3600);
 
-            let mut ticker = tokio::time::interval(base_interval);
-            // Skip first immediate tick so the loop doesn't fire at startup.
-            ticker.tick().await;
+        let mut ticker = tokio::time::interval(base_interval);
+        // Skip first immediate tick so the loop doesn't fire at startup.
+        ticker.tick().await;
 
-            loop {
-                tokio::select! {
-                    () = cancel.cancelled() => {
-                        tracing::debug!("compression guidelines updater shutting down");
-                        return;
-                    }
-                    _ = ticker.tick() => {}
+        loop {
+            tokio::select! {
+                () = cancel.cancelled() => {
+                    tracing::debug!("compression guidelines updater shutting down");
+                    return;
                 }
+                _ = ticker.tick() => {}
+            }
 
-                let count = match sqlite.count_unused_failure_pairs().await {
-                    Ok(c) => c,
-                    Err(e) => {
-                        tracing::warn!("guidelines updater: count query failed: {e:#}");
-                        continue;
-                    }
-                };
-
-                if count < i64::from(config.update_threshold) {
-                    backoff = base_interval;
+            let count = match sqlite.count_unused_failure_pairs().await {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::warn!("guidelines updater: count query failed: {e:#}");
                     continue;
                 }
+            };
 
-                match update_guidelines_once(&sqlite, &provider, &token_counter, &config, &cancel)
-                    .await
-                {
-                    Ok(()) => {
-                        backoff = base_interval;
-                    }
-                    Err(e) => {
-                        tracing::warn!("guidelines update failed (backoff={backoff:?}): {e:#}");
-                        backoff = (backoff * 2).min(max_backoff);
-                        // Sleep the backoff period before next attempt.
-                        tokio::select! {
-                            () = cancel.cancelled() => return,
-                            () = tokio::time::sleep(backoff) => {}
-                        }
+            if count < i64::from(config.update_threshold) {
+                backoff = base_interval;
+                continue;
+            }
+
+            match update_guidelines_once(&sqlite, &provider, &token_counter, &config, &cancel).await
+            {
+                Ok(()) => {
+                    backoff = base_interval;
+                }
+                Err(e) => {
+                    tracing::warn!("guidelines update failed (backoff={backoff:?}): {e:#}");
+                    backoff = (backoff * 2).min(max_backoff);
+                    // Sleep the backoff period before next attempt.
+                    tokio::select! {
+                        () = cancel.cancelled() => return,
+                        () = tokio::time::sleep(backoff) => {}
                     }
                 }
             }
-        })
+        }
     }
 }
 pub use updater::{

--- a/crates/zeph-memory/src/consolidation.rs
+++ b/crates/zeph-memory/src/consolidation.rs
@@ -24,7 +24,6 @@ use std::time::Duration;
 use zeph_db::sql;
 
 use serde::{Deserialize, Serialize};
-use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::LlmProvider as _;
@@ -79,62 +78,60 @@ pub use zeph_common::config::memory::ConsolidationConfig;
 /// The loop exits immediately if `config.enabled = false`.
 ///
 /// Database and LLM errors are logged but do not stop the loop.
-pub fn start_consolidation_loop(
+pub async fn start_consolidation_loop(
     store: Arc<SqliteStore>,
     provider: AnyProvider,
     config: ConsolidationConfig,
     cancel: CancellationToken,
-) -> JoinHandle<()> {
-    tokio::spawn(async move {
-        if !config.enabled {
-            tracing::debug!("consolidation disabled (consolidation.enabled = false)");
-            return;
+) {
+    if !config.enabled {
+        tracing::debug!("consolidation disabled (consolidation.enabled = false)");
+        return;
+    }
+
+    let mut ticker = tokio::time::interval(Duration::from_secs(config.sweep_interval_secs));
+    // Skip the first immediate tick to avoid running at startup.
+    ticker.tick().await;
+
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => {
+                tracing::debug!("consolidation loop shutting down");
+                return;
+            }
+            _ = ticker.tick() => {}
         }
 
-        let mut ticker = tokio::time::interval(Duration::from_secs(config.sweep_interval_secs));
-        // Skip the first immediate tick to avoid running at startup.
-        ticker.tick().await;
+        tracing::debug!("consolidation: starting sweep");
+        let start = std::time::Instant::now();
 
-        loop {
-            tokio::select! {
-                () = cancel.cancelled() => {
-                    tracing::debug!("consolidation loop shutting down");
-                    return;
-                }
-                _ = ticker.tick() => {}
-            }
+        let result = run_consolidation_sweep(&store, &provider, &config).await;
+        let elapsed_ms = start.elapsed().as_millis();
 
-            tracing::debug!("consolidation: starting sweep");
-            let start = std::time::Instant::now();
-
-            let result = run_consolidation_sweep(&store, &provider, &config).await;
-            let elapsed_ms = start.elapsed().as_millis();
-
-            match result {
-                Ok(r) => {
-                    if r.skipped > 0 && r.merges + r.updates == 0 {
-                        tracing::warn!(
-                            skipped = r.skipped,
-                            elapsed_ms,
-                            "consolidation: all proposed ops below confidence threshold — \
+        match result {
+            Ok(r) => {
+                if r.skipped > 0 && r.merges + r.updates == 0 {
+                    tracing::warn!(
+                        skipped = r.skipped,
+                        elapsed_ms,
+                        "consolidation: all proposed ops below confidence threshold — \
                              consider lowering confidence_threshold or checking provider quality"
-                        );
-                    } else {
-                        tracing::info!(
-                            merges = r.merges,
-                            updates = r.updates,
-                            skipped = r.skipped,
-                            elapsed_ms,
-                            "consolidation: sweep complete"
-                        );
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!(error = %e, elapsed_ms, "consolidation: sweep failed, will retry");
+                    );
+                } else {
+                    tracing::info!(
+                        merges = r.merges,
+                        updates = r.updates,
+                        skipped = r.skipped,
+                        elapsed_ms,
+                        "consolidation: sweep complete"
+                    );
                 }
             }
+            Err(e) => {
+                tracing::warn!(error = %e, elapsed_ms, "consolidation: sweep failed, will retry");
+            }
         }
-    })
+    }
 }
 
 /// Execute one full consolidation sweep cycle.

--- a/crates/zeph-memory/src/eviction.rs
+++ b/crates/zeph-memory/src/eviction.rs
@@ -14,7 +14,6 @@
 
 use std::sync::Arc;
 
-use tokio::task::JoinHandle;
 use tokio::time::{Duration, interval};
 use tokio_util::sync::CancellationToken;
 
@@ -194,60 +193,57 @@ fn parse_sqlite_timestamp_secs(s: &str) -> Option<u64> {
 /// # Errors (non-fatal)
 ///
 /// Database and Qdrant errors are logged but do not stop the loop.
-pub fn start_eviction_loop(
+pub async fn start_eviction_loop(
     store: Arc<SqliteStore>,
-    config: &EvictionConfig,
+    config: EvictionConfig,
     policy: Arc<dyn EvictionPolicy + 'static>,
     cancel: CancellationToken,
-) -> JoinHandle<()> {
-    let config = config.clone();
-    tokio::spawn(async move {
-        if config.max_entries == 0 {
-            tracing::debug!("eviction disabled (max_entries = 0)");
-            return;
+) {
+    if config.max_entries == 0 {
+        tracing::debug!("eviction disabled (max_entries = 0)");
+        return;
+    }
+
+    let mut ticker = interval(Duration::from_secs(config.sweep_interval_secs));
+    // Skip the first immediate tick so the loop doesn't run at startup.
+    ticker.tick().await;
+
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => {
+                tracing::debug!("eviction loop shutting down");
+                return;
+            }
+            _ = ticker.tick() => {}
         }
 
-        let mut ticker = interval(Duration::from_secs(config.sweep_interval_secs));
-        // Skip the first immediate tick so the loop doesn't run at startup.
-        ticker.tick().await;
+        tracing::debug!(max_entries = config.max_entries, "running eviction sweep");
 
-        loop {
-            tokio::select! {
-                () = cancel.cancelled() => {
-                    tracing::debug!("eviction loop shutting down");
-                    return;
-                }
-                _ = ticker.tick() => {}
-            }
-
-            tracing::debug!(max_entries = config.max_entries, "running eviction sweep");
-
-            // Phase 1: score and soft-delete excess entries.
-            match run_eviction_phase1(&store, &*policy, config.max_entries).await {
-                Ok(deleted) => {
-                    if deleted > 0 {
-                        tracing::info!(deleted, "eviction phase 1: soft-deleted entries");
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!(error = %e, "eviction phase 1 failed, will retry next sweep");
+        // Phase 1: score and soft-delete excess entries.
+        match run_eviction_phase1(&store, &*policy, config.max_entries).await {
+            Ok(deleted) => {
+                if deleted > 0 {
+                    tracing::info!(deleted, "eviction phase 1: soft-deleted entries");
                 }
             }
-
-            // Phase 2: clean up soft-deleted entries from Qdrant.
-            // On startup or after a crash, this also cleans up any orphaned vectors.
-            match run_eviction_phase2(&store).await {
-                Ok(cleaned) => {
-                    if cleaned > 0 {
-                        tracing::info!(cleaned, "eviction phase 2: removed Qdrant vectors");
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!(error = %e, "eviction phase 2 failed, will retry next sweep");
-                }
+            Err(e) => {
+                tracing::warn!(error = %e, "eviction phase 1 failed, will retry next sweep");
             }
         }
-    })
+
+        // Phase 2: clean up soft-deleted entries from Qdrant.
+        // On startup or after a crash, this also cleans up any orphaned vectors.
+        match run_eviction_phase2(&store).await {
+            Ok(cleaned) => {
+                if cleaned > 0 {
+                    tracing::info!(cleaned, "eviction phase 2: removed Qdrant vectors");
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "eviction phase 2 failed, will retry next sweep");
+            }
+        }
+    }
 }
 
 async fn run_eviction_phase1(

--- a/crates/zeph-memory/src/forgetting.rs
+++ b/crates/zeph-memory/src/forgetting.rs
@@ -34,7 +34,6 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 use crate::error::MemoryError;
@@ -66,54 +65,51 @@ pub struct ForgettingResult {
 /// state, never an intermediate state.
 ///
 /// Database errors are logged but do not stop the loop.
-#[must_use]
-pub fn start_forgetting_loop(
+pub async fn start_forgetting_loop(
     store: Arc<SqliteStore>,
     config: ForgettingConfig,
     cancel: CancellationToken,
-) -> JoinHandle<()> {
-    tokio::spawn(async move {
-        if !config.enabled {
-            tracing::debug!("forgetting sweep disabled (forgetting.enabled = false)");
-            return;
+) {
+    if !config.enabled {
+        tracing::debug!("forgetting sweep disabled (forgetting.enabled = false)");
+        return;
+    }
+
+    let mut ticker = tokio::time::interval(Duration::from_secs(config.sweep_interval_secs));
+    // Skip the first immediate tick to avoid running at startup.
+    ticker.tick().await;
+
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => {
+                tracing::debug!("forgetting loop shutting down");
+                return;
+            }
+            _ = ticker.tick() => {}
         }
 
-        let mut ticker = tokio::time::interval(Duration::from_secs(config.sweep_interval_secs));
-        // Skip the first immediate tick to avoid running at startup.
-        ticker.tick().await;
+        tracing::debug!("forgetting: starting sweep");
+        let start = std::time::Instant::now();
 
-        loop {
-            tokio::select! {
-                () = cancel.cancelled() => {
-                    tracing::debug!("forgetting loop shutting down");
-                    return;
-                }
-                _ = ticker.tick() => {}
+        match run_forgetting_sweep(&store, &config).await {
+            Ok(r) => {
+                tracing::info!(
+                    downscaled = r.downscaled,
+                    replayed = r.replayed,
+                    pruned = r.pruned,
+                    elapsed_ms = start.elapsed().as_millis(),
+                    "forgetting: sweep complete"
+                );
             }
-
-            tracing::debug!("forgetting: starting sweep");
-            let start = std::time::Instant::now();
-
-            match run_forgetting_sweep(&store, &config).await {
-                Ok(r) => {
-                    tracing::info!(
-                        downscaled = r.downscaled,
-                        replayed = r.replayed,
-                        pruned = r.pruned,
-                        elapsed_ms = start.elapsed().as_millis(),
-                        "forgetting: sweep complete"
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        elapsed_ms = start.elapsed().as_millis(),
-                        "forgetting: sweep failed, will retry"
-                    );
-                }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    elapsed_ms = start.elapsed().as_millis(),
+                    "forgetting: sweep failed, will retry"
+                );
             }
         }
-    })
+    }
 }
 
 // ── Sweep implementation ──────────────────────────────────────────────────────

--- a/crates/zeph-memory/src/scenes.rs
+++ b/crates/zeph-memory/src/scenes.rs
@@ -9,7 +9,6 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::LlmProvider as _;
@@ -56,54 +55,52 @@ pub struct SceneConfig {
 ///
 /// Each sweep clusters unassigned semantic-tier messages into `MemScenes`.
 /// Runs independently from the tier promotion loop.
-pub fn start_scene_consolidation_loop(
+pub async fn start_scene_consolidation_loop(
     store: Arc<SqliteStore>,
     provider: AnyProvider,
     config: SceneConfig,
     cancel: CancellationToken,
-) -> JoinHandle<()> {
-    tokio::spawn(async move {
-        if !config.enabled {
-            tracing::debug!("scene consolidation disabled (tiers.scene_enabled = false)");
-            return;
+) {
+    if !config.enabled {
+        tracing::debug!("scene consolidation disabled (tiers.scene_enabled = false)");
+        return;
+    }
+
+    let mut ticker = tokio::time::interval(Duration::from_secs(config.sweep_interval_secs));
+    // Skip first tick to avoid running immediately at startup.
+    ticker.tick().await;
+
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => {
+                tracing::debug!("scene consolidation loop shutting down");
+                return;
+            }
+            _ = ticker.tick() => {}
         }
 
-        let mut ticker = tokio::time::interval(Duration::from_secs(config.sweep_interval_secs));
-        // Skip first tick to avoid running immediately at startup.
-        ticker.tick().await;
+        tracing::debug!("scene consolidation: starting sweep");
+        let start = std::time::Instant::now();
 
-        loop {
-            tokio::select! {
-                () = cancel.cancelled() => {
-                    tracing::debug!("scene consolidation loop shutting down");
-                    return;
-                }
-                _ = ticker.tick() => {}
+        match consolidate_scenes(&store, &provider, &config).await {
+            Ok(stats) => {
+                tracing::info!(
+                    candidates = stats.candidates,
+                    scenes_created = stats.scenes_created,
+                    messages_assigned = stats.messages_assigned,
+                    elapsed_ms = start.elapsed().as_millis(),
+                    "scene consolidation: sweep complete"
+                );
             }
-
-            tracing::debug!("scene consolidation: starting sweep");
-            let start = std::time::Instant::now();
-
-            match consolidate_scenes(&store, &provider, &config).await {
-                Ok(stats) => {
-                    tracing::info!(
-                        candidates = stats.candidates,
-                        scenes_created = stats.scenes_created,
-                        messages_assigned = stats.messages_assigned,
-                        elapsed_ms = start.elapsed().as_millis(),
-                        "scene consolidation: sweep complete"
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        elapsed_ms = start.elapsed().as_millis(),
-                        "scene consolidation: sweep failed, will retry"
-                    );
-                }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    elapsed_ms = start.elapsed().as_millis(),
+                    "scene consolidation: sweep failed, will retry"
+                );
             }
         }
-    })
+    }
 }
 
 /// Stats collected during a single scene consolidation sweep.

--- a/crates/zeph-memory/src/semantic/tree_consolidation.rs
+++ b/crates/zeph-memory/src/semantic/tree_consolidation.rs
@@ -14,7 +14,6 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::{LlmProvider as _, Message, Role};
@@ -31,6 +30,7 @@ Keep it to 2-4 sentences. Do not repeat details already captured in a single sen
 Return only the summary text — no JSON, no preamble.";
 
 /// Configuration for the tree consolidation loop.
+#[derive(Clone)]
 pub struct TreeConsolidationConfig {
     pub enabled: bool,
     pub sweep_interval_secs: u64,
@@ -50,52 +50,50 @@ pub struct TreeConsolidationResult {
 /// Start the background tree consolidation loop.
 ///
 /// The loop exits immediately when `config.enabled = false` or `cancel` fires.
-pub fn start_tree_consolidation_loop(
+pub async fn start_tree_consolidation_loop(
     store: Arc<SqliteStore>,
     provider: AnyProvider,
     config: TreeConsolidationConfig,
     cancel: CancellationToken,
-) -> JoinHandle<()> {
-    tokio::spawn(async move {
-        if !config.enabled {
-            tracing::debug!("tree consolidation disabled (tree.enabled = false)");
-            return;
+) {
+    if !config.enabled {
+        tracing::debug!("tree consolidation disabled (tree.enabled = false)");
+        return;
+    }
+
+    let mut ticker = tokio::time::interval(Duration::from_secs(config.sweep_interval_secs));
+    // Skip the first immediate tick to avoid running at startup.
+    ticker.tick().await;
+
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => {
+                tracing::debug!("tree consolidation loop shutting down");
+                return;
+            }
+            _ = ticker.tick() => {}
         }
 
-        let mut ticker = tokio::time::interval(Duration::from_secs(config.sweep_interval_secs));
-        // Skip the first immediate tick to avoid running at startup.
-        ticker.tick().await;
+        tracing::debug!("tree consolidation: starting sweep");
+        let start = std::time::Instant::now();
 
-        loop {
-            tokio::select! {
-                () = cancel.cancelled() => {
-                    tracing::debug!("tree consolidation loop shutting down");
-                    return;
-                }
-                _ = ticker.tick() => {}
-            }
+        let result = run_tree_consolidation_sweep(&store, &provider, &config).await;
+        let elapsed_ms = start.elapsed().as_millis();
 
-            tracing::debug!("tree consolidation: starting sweep");
-            let start = std::time::Instant::now();
-
-            let result = run_tree_consolidation_sweep(&store, &provider, &config).await;
-            let elapsed_ms = start.elapsed().as_millis();
-
-            match result {
-                Ok(r) => tracing::info!(
-                    clusters_merged = r.clusters_merged,
-                    nodes_created = r.nodes_created,
-                    elapsed_ms,
-                    "tree consolidation: sweep complete"
-                ),
-                Err(e) => tracing::warn!(
-                    error = %e,
-                    elapsed_ms,
-                    "tree consolidation: sweep failed, will retry"
-                ),
-            }
+        match result {
+            Ok(r) => tracing::info!(
+                clusters_merged = r.clusters_merged,
+                nodes_created = r.nodes_created,
+                elapsed_ms,
+                "tree consolidation: sweep complete"
+            ),
+            Err(e) => tracing::warn!(
+                error = %e,
+                elapsed_ms,
+                "tree consolidation: sweep failed, will retry"
+            ),
         }
-    })
+    }
 }
 
 /// Execute one full consolidation sweep: leaves → level 1, then level 1 → level 2, etc.

--- a/crates/zeph-memory/src/tiers.rs
+++ b/crates/zeph-memory/src/tiers.rs
@@ -17,7 +17,6 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::LlmProvider as _;
@@ -63,55 +62,53 @@ pub struct TierPromotionConfig {
 /// The loop exits immediately if `config.enabled = false`.
 ///
 /// Database and LLM errors are logged but do not stop the loop.
-pub fn start_tier_promotion_loop(
+pub async fn start_tier_promotion_loop(
     store: Arc<SqliteStore>,
     provider: AnyProvider,
     config: TierPromotionConfig,
     cancel: CancellationToken,
-) -> JoinHandle<()> {
-    tokio::spawn(async move {
-        if !config.enabled {
-            tracing::debug!("tier promotion disabled (tiers.enabled = false)");
-            return;
+) {
+    if !config.enabled {
+        tracing::debug!("tier promotion disabled (tiers.enabled = false)");
+        return;
+    }
+
+    let mut ticker = tokio::time::interval(Duration::from_secs(config.sweep_interval_secs));
+    // Skip the first immediate tick so we don't run at startup.
+    ticker.tick().await;
+
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => {
+                tracing::debug!("tier promotion loop shutting down");
+                return;
+            }
+            _ = ticker.tick() => {}
         }
 
-        let mut ticker = tokio::time::interval(Duration::from_secs(config.sweep_interval_secs));
-        // Skip the first immediate tick so we don't run at startup.
-        ticker.tick().await;
+        tracing::debug!("tier promotion: starting sweep");
+        let start = std::time::Instant::now();
 
-        loop {
-            tokio::select! {
-                () = cancel.cancelled() => {
-                    tracing::debug!("tier promotion loop shutting down");
-                    return;
-                }
-                _ = ticker.tick() => {}
+        let result = run_promotion_sweep(&store, &provider, &config).await;
+
+        let elapsed_ms = start.elapsed().as_millis();
+
+        match result {
+            Ok(stats) => {
+                tracing::info!(
+                    candidates = stats.candidates_evaluated,
+                    clusters = stats.clusters_formed,
+                    promoted = stats.promotions_completed,
+                    merge_failures = stats.merge_failures,
+                    elapsed_ms,
+                    "tier promotion: sweep complete"
+                );
             }
-
-            tracing::debug!("tier promotion: starting sweep");
-            let start = std::time::Instant::now();
-
-            let result = run_promotion_sweep(&store, &provider, &config).await;
-
-            let elapsed_ms = start.elapsed().as_millis();
-
-            match result {
-                Ok(stats) => {
-                    tracing::info!(
-                        candidates = stats.candidates_evaluated,
-                        clusters = stats.clusters_formed,
-                        promoted = stats.promotions_completed,
-                        merge_failures = stats.merge_failures,
-                        elapsed_ms,
-                        "tier promotion: sweep complete"
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!(error = %e, elapsed_ms, "tier promotion: sweep failed, will retry");
-                }
+            Err(e) => {
+                tracing::warn!(error = %e, elapsed_ms, "tier promotion: sweep failed, will retry");
             }
         }
-    })
+    }
 }
 
 /// Stats collected during a single promotion sweep.

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -26,6 +26,7 @@ use zeph_channels::AnyChannel;
 use zeph_core::agent::Agent;
 #[cfg(feature = "acp")]
 use zeph_core::config::AcpTransport;
+use zeph_core::{RestartPolicy, TaskDescriptor, TaskSupervisor};
 use zeph_llm::{ThinkingConfig, ThinkingEffort};
 
 #[cfg(feature = "acp-http")]
@@ -925,6 +926,19 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     let (shutdown_tx, shutdown_rx) = AppBuilder::build_shutdown();
     let config = app.config();
 
+    // Create a TaskSupervisor for all memory background loops.
+    // A single bridge from shutdown_rx → cancel token replaces per-loop cancel bridges.
+    let mem_cancel = tokio_util::sync::CancellationToken::new();
+    let supervisor = std::sync::Arc::new(TaskSupervisor::new(mem_cancel.clone()));
+    {
+        let mut rx = shutdown_rx.clone();
+        let cancel = mem_cancel.clone();
+        tokio::spawn(async move {
+            let _ = rx.changed().await;
+            cancel.cancel();
+        });
+    }
+
     #[cfg(feature = "profiling")]
     let _sysinfo_handle = zeph_core::system_metrics::spawn_system_metrics_task(
         config.telemetry.system_metrics_interval_secs,
@@ -943,32 +957,27 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         });
     }
 
-    let _eviction_handle = {
-        let eviction_cancel = zeph_memory::CancellationToken::new();
-        let eviction_cancel_clone = eviction_cancel.clone();
-        let mut shutdown_for_eviction = shutdown_rx.clone();
-        tokio::spawn(async move {
-            let _ = shutdown_for_eviction.changed().await;
-            eviction_cancel_clone.cancel();
+    {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let eviction_cfg = config.memory.eviction.clone();
+        let policy = std::sync::Arc::new(zeph_memory::EbbinghausPolicy::default());
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(TaskDescriptor {
+            name: "mem-eviction",
+            restart: RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_eviction_loop(
+                    store.clone(),
+                    eviction_cfg.clone(),
+                    policy.clone(),
+                    cancel.clone(),
+                )
+            },
         });
-        let sqlite_store = std::sync::Arc::new(memory.sqlite().clone());
-        zeph_memory::start_eviction_loop(
-            sqlite_store,
-            &config.memory.eviction,
-            std::sync::Arc::new(zeph_memory::EbbinghausPolicy::default()),
-            eviction_cancel,
-        )
-    };
+    }
 
-    let _tier_promotion_handle = {
-        let tier_cancel = zeph_memory::CancellationToken::new();
-        let tier_cancel_clone = tier_cancel.clone();
-        let mut shutdown_for_tiers = shutdown_rx.clone();
-        tokio::spawn(async move {
-            let _ = shutdown_for_tiers.changed().await;
-            tier_cancel_clone.cancel();
-        });
-        let sqlite_store = std::sync::Arc::new(memory.sqlite().clone());
+    {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
         let tier_cfg = zeph_memory::TierPromotionConfig {
             enabled: config.memory.tiers.enabled,
             promotion_min_sessions: config.memory.tiers.promotion_min_sessions,
@@ -976,23 +985,24 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             sweep_interval_secs: config.memory.tiers.sweep_interval_secs,
             sweep_batch_size: config.memory.tiers.sweep_batch_size,
         };
-        zeph_memory::start_tier_promotion_loop(
-            sqlite_store,
-            provider.clone(),
-            tier_cfg,
-            tier_cancel,
-        )
-    };
-
-    let _scene_consolidation_handle = {
-        let scene_cancel = zeph_memory::CancellationToken::new();
-        let scene_cancel_clone = scene_cancel.clone();
-        let mut shutdown_for_scenes = shutdown_rx.clone();
-        tokio::spawn(async move {
-            let _ = shutdown_for_scenes.changed().await;
-            scene_cancel_clone.cancel();
+        let tier_provider = provider.clone();
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(TaskDescriptor {
+            name: "mem-tier-promotion",
+            restart: RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_tier_promotion_loop(
+                    store.clone(),
+                    tier_provider.clone(),
+                    tier_cfg.clone(),
+                    cancel.clone(),
+                )
+            },
         });
-        let sqlite_store = std::sync::Arc::new(memory.sqlite().clone());
+    }
+
+    {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
         let scene_provider = app
             .build_scene_provider()
             .unwrap_or_else(|| provider.clone());
@@ -1002,23 +1012,23 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             batch_size: config.memory.tiers.scene_batch_size,
             sweep_interval_secs: config.memory.tiers.scene_sweep_interval_secs,
         };
-        zeph_memory::start_scene_consolidation_loop(
-            sqlite_store,
-            scene_provider,
-            scene_cfg,
-            scene_cancel,
-        )
-    };
-
-    let _consolidation_handle = {
-        let consolidation_cancel = zeph_memory::CancellationToken::new();
-        let consolidation_cancel_clone = consolidation_cancel.clone();
-        let mut shutdown_for_consolidation = shutdown_rx.clone();
-        tokio::spawn(async move {
-            let _ = shutdown_for_consolidation.changed().await;
-            consolidation_cancel_clone.cancel();
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(TaskDescriptor {
+            name: "mem-scene-consolidation",
+            restart: RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_scene_consolidation_loop(
+                    store.clone(),
+                    scene_provider.clone(),
+                    scene_cfg.clone(),
+                    cancel.clone(),
+                )
+            },
         });
-        let sqlite_store = std::sync::Arc::new(memory.sqlite().clone());
+    }
+
+    {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
         let consolidation_cfg = zeph_memory::ConsolidationConfig {
             enabled: config.memory.consolidation.enabled,
             confidence_threshold: config.memory.consolidation.confidence_threshold,
@@ -1029,22 +1039,23 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         let consolidation_provider = app
             .build_consolidation_provider()
             .unwrap_or_else(|| provider.clone());
-        zeph_memory::start_consolidation_loop(
-            sqlite_store,
-            consolidation_provider,
-            consolidation_cfg,
-            consolidation_cancel,
-        )
-    };
-    let _forgetting_handle = {
-        let forgetting_cancel = zeph_memory::CancellationToken::new();
-        let forgetting_cancel_clone = forgetting_cancel.clone();
-        let mut shutdown_for_forgetting = shutdown_rx.clone();
-        tokio::spawn(async move {
-            let _ = shutdown_for_forgetting.changed().await;
-            forgetting_cancel_clone.cancel();
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(TaskDescriptor {
+            name: "mem-consolidation",
+            restart: RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_consolidation_loop(
+                    store.clone(),
+                    consolidation_provider.clone(),
+                    consolidation_cfg.clone(),
+                    cancel.clone(),
+                )
+            },
         });
-        let sqlite_store = std::sync::Arc::new(memory.sqlite().clone());
+    }
+
+    {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
         let forgetting_cfg = zeph_memory::ForgettingConfig {
             enabled: config.memory.forgetting.enabled,
             decay_rate: config.memory.forgetting.decay_rate,
@@ -1056,30 +1067,70 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             protect_recent_hours: config.memory.forgetting.protect_recent_hours,
             protect_min_access_count: config.memory.forgetting.protect_min_access_count,
         };
-        zeph_memory::start_forgetting_loop(sqlite_store, forgetting_cfg, forgetting_cancel)
-    };
-
-    let _guidelines_handle = if config.memory.compression_guidelines.enabled {
-        let guidelines_cancel = zeph_memory::CancellationToken::new();
-        let guidelines_cancel_clone = guidelines_cancel.clone();
-        let mut shutdown_for_guidelines = shutdown_rx.clone();
-        tokio::spawn(async move {
-            let _ = shutdown_for_guidelines.changed().await;
-            guidelines_cancel_clone.cancel();
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(TaskDescriptor {
+            name: "mem-forgetting",
+            restart: RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_forgetting_loop(
+                    store.clone(),
+                    forgetting_cfg.clone(),
+                    cancel.clone(),
+                )
+            },
         });
+    }
+
+    if config.memory.compression_guidelines.enabled {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
         let guidelines_provider = app
             .build_guidelines_provider()
             .unwrap_or_else(|| provider.clone());
-        Some(zeph_memory::start_guidelines_updater(
-            std::sync::Arc::new(memory.sqlite().clone()),
-            guidelines_provider,
-            std::sync::Arc::clone(&memory.token_counter),
-            config.memory.compression_guidelines.clone(),
-            guidelines_cancel,
-        ))
-    } else {
-        None
-    };
+        let token_counter = std::sync::Arc::clone(&memory.token_counter);
+        let guidelines_cfg = config.memory.compression_guidelines.clone();
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(TaskDescriptor {
+            name: "mem-guidelines",
+            restart: RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_guidelines_updater(
+                    store.clone(),
+                    guidelines_provider.clone(),
+                    token_counter.clone(),
+                    guidelines_cfg.clone(),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+
+    if config.memory.tree.enabled {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let tree_provider = app
+            .build_tree_consolidation_provider()
+            .unwrap_or_else(|| provider.clone());
+        let tree_cfg = zeph_memory::TreeConsolidationConfig {
+            enabled: config.memory.tree.enabled,
+            sweep_interval_secs: config.memory.tree.sweep_interval_secs,
+            batch_size: config.memory.tree.batch_size,
+            similarity_threshold: config.memory.tree.similarity_threshold,
+            max_level: config.memory.tree.max_level,
+            min_cluster_size: config.memory.tree.min_cluster_size,
+        };
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(TaskDescriptor {
+            name: "mem-tree-consolidation",
+            restart: RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_tree_consolidation_loop(
+                    store.clone(),
+                    tree_provider.clone(),
+                    tree_cfg.clone(),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
 
     let skill_paths = app.skill_paths();
 
@@ -1418,10 +1469,6 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         config.memory.category.clone(),
     )
     .with_embedding_provider(embedding_provider)
-    .with_tree_consolidation_loop(
-        app.build_tree_consolidation_provider()
-            .unwrap_or_else(|| provider.clone()),
-    )
     .maybe_init_tool_schema_filter(&config.agent.tool_filter, &provider)
     .await;
 
@@ -2157,6 +2204,9 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     // are killed while the tokio runtime is still active (#2693).
     shutdown_mcp_manager.shutdown_all_shared().await;
     agent.shutdown().await;
+    supervisor
+        .shutdown_all(std::time::Duration::from_secs(10))
+        .await;
     Ok(result?)
 }
 


### PR DESCRIPTION
## Summary

- Replace 7 ad-hoc `tokio::spawn` + per-loop `CancellationToken` cancel-bridge tasks in `runner.rs` with a single `Arc<TaskSupervisor>` and one shared `shutdown_rx → CancellationToken` bridge
- All 8 memory background loops (eviction, tier promotion, scene consolidation, consolidation, forgetting, compression guidelines, tree consolidation) spawned via `supervisor.spawn(TaskDescriptor { restart: RestartPolicy::RunOnce, ... })`
- `supervisor.shutdown_all(Duration::from_secs(10))` called after `agent.shutdown()` in the shutdown sequence
- `with_tree_consolidation_loop` removed from `AgentBuilder`; tree consolidation now lives in `runner.rs` alongside other memory loops, gated on `config.memory.tree.enabled`
- All `start_*` functions in `zeph-memory` converted from `fn() -> impl Future<Output = ()> + Send + 'static` to `pub async fn` (fixes clippy `manual_async_fn`)
- `TreeConsolidationConfig` gains `#[derive(Clone)]` for use in factory closures

## Test plan

- [ ] `cargo clippy --workspace --features full -- -D warnings` — 0 warnings
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 7941 passed, 20 skipped
- [ ] Live session test: `cargo run --features full -- --config .local/config/testing.toml` — all memory loops start, shutdown completes within 10s

Closes #2960