### PR TITLE
feat(channels,tui,a2a): migrate leaf spawns to TaskSupervisor, add TUI task registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Leaf crate TaskSupervisor migration** (`#2961`): `TelegramChannel` gains a
+  `with_supervisor()` builder that migrates the dispatcher loop from a bare `tokio::spawn`
+  to `supervisor.spawn_restartable` with `RestartPolicy::Restart { max: 5, base_delay: 2s }`.
+  `spawn_a2a_server` in `daemon.rs` wraps `A2aServer::serve()` via supervisor with
+  `RestartPolicy::RunOnce`. `spawn_background_indexer` in `agent_setup.rs` routes the
+  indexer launch through supervisor when present. Per-chunk supervision in `zeph-index`
+  deferred to `#2978` due to a `zeph-core → zeph-index` crate cycle.
+
+- **TUI task registry panel** (`#2962`): new `TaskRegistryWidget` in
+  `crates/zeph-tui/src/widgets/task_registry.rs` renders a live table of all supervised
+  tasks with columns: spinner (Running state), task name, origin crate, state, uptime
+  (since last restart), and restart count. Toggled via `/tasks` command in the TUI command
+  palette. Shows a placeholder when `TaskSupervisor` is unavailable. Refreshes at the
+  existing 10 fps render interval with no additional timer.
+
 - **TaskSupervisor: correct shutdown, restart, and blocking semantics** (`#2958`):
   fixed reap driver / shutdown race (completions now drained before exit), unconditional
   restart on normal task completion (only panics trigger restart), and `spawn_blocking`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9939,6 +9939,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-tungstenite 0.29.0",
+ "tokio-util",
  "tracing",
  "unicode-width",
  "wiremock",

--- a/crates/zeph-channels/Cargo.toml
+++ b/crates/zeph-channels/Cargo.toml
@@ -44,6 +44,7 @@ harness = false
 criterion.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
+tokio-util.workspace = true
 wiremock.workspace = true
 
 [lints]

--- a/crates/zeph-channels/src/telegram.rs
+++ b/crates/zeph-channels/src/telegram.rs
@@ -27,6 +27,7 @@ use crate::markdown::markdown_to_telegram;
 use teloxide::prelude::*;
 use teloxide::types::{BotCommand, ChatAction, MessageId, ParseMode};
 use tokio::sync::mpsc;
+use zeph_core::TaskSupervisor;
 use zeph_core::channel::{
     Attachment, AttachmentKind, Channel, ChannelError, ChannelMessage, ElicitationField,
     ElicitationFieldType, ElicitationRequest, ElicitationResponse,
@@ -81,7 +82,6 @@ const MAX_IMAGE_BYTES: u32 = 20 * 1024 * 1024;
 /// [`recv`]: TelegramChannel::recv
 /// [`flush_chunks`]: TelegramChannel::flush_chunks
 /// [`start`]: TelegramChannel::start
-#[derive(Debug)]
 pub struct TelegramChannel {
     bot: Bot,
     chat_id: Option<ChatId>,
@@ -90,6 +90,20 @@ pub struct TelegramChannel {
     accumulated: String,
     last_edit: Option<Instant>,
     message_id: Option<MessageId>,
+    /// Optional supervisor used to register the Telegram listener task in the
+    /// workspace-wide task registry with automatic restart on panic.
+    supervisor: Option<TaskSupervisor>,
+}
+
+impl std::fmt::Debug for TelegramChannel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TelegramChannel")
+            .field("chat_id", &self.chat_id)
+            .field("allowed_users", &self.allowed_users)
+            .field("accumulated_len", &self.accumulated.len())
+            .field("supervisor", &self.supervisor.is_some())
+            .finish_non_exhaustive()
+    }
 }
 
 #[derive(Debug)]
@@ -124,7 +138,19 @@ impl TelegramChannel {
             accumulated: String::new(),
             last_edit: None,
             message_id: None,
+            supervisor: None,
         }
+    }
+
+    /// Attach a [`TaskSupervisor`] so the Telegram listener task is registered
+    /// in the workspace-wide task registry with automatic restart on panic.
+    ///
+    /// The listener is spawned with
+    /// `RestartPolicy::Restart { max: 5, base_delay: 2s }`.
+    #[must_use]
+    pub fn with_supervisor(mut self, supervisor: TaskSupervisor) -> Self {
+        self.supervisor = Some(supervisor);
+        self
     }
 
     /// Spawn a task that registers bot commands in the Telegram menu.
@@ -147,6 +173,7 @@ impl TelegramChannel {
     /// # Errors
     ///
     /// Returns an error if the bot cannot be initialized.
+    #[allow(clippy::too_many_lines)]
     pub fn start(mut self) -> Result<Self, ChannelError> {
         if self.allowed_users.is_empty() {
             tracing::error!("telegram.allowed_users is empty; refusing to start an open bot");
@@ -163,99 +190,120 @@ impl TelegramChannel {
 
         Self::register_commands(bot.clone());
 
-        tokio::spawn(async move {
-            let handler = Update::filter_message().endpoint(move |msg: Message, bot: Bot| {
-                let tx = tx.clone();
-                let allowed = allowed.clone();
-                async move {
-                    let username = msg.from.as_ref().and_then(|u| u.username.clone());
+        let bot_for_factory = bot.clone();
+        let allowed_for_factory = allowed.clone();
+        let tx_for_factory = tx.clone();
+        let listener_factory = move || {
+            let bot = bot_for_factory.clone();
+            let allowed = allowed_for_factory.clone();
+            let tx = tx_for_factory.clone();
+            async move {
+                let handler = Update::filter_message().endpoint(move |msg: Message, bot: Bot| {
+                    let tx = tx.clone();
+                    let allowed = allowed.clone();
+                    async move {
+                        let username = msg.from.as_ref().and_then(|u| u.username.clone());
 
-                    if !allowed.is_empty() {
-                        let is_allowed = username
-                            .as_deref()
-                            .is_some_and(|u| allowed.iter().any(|a| a == u));
-                        if !is_allowed {
-                            tracing::warn!(
-                                "rejected message from unauthorized user: {:?}",
-                                username
-                            );
-                            return respond(());
-                        }
-                    }
-
-                    let text = msg.text().unwrap_or_default().to_string();
-                    let mut attachments = Vec::new();
-
-                    let audio_file_id = msg
-                        .voice()
-                        .map(|v| (v.file.id.0.clone(), v.file.size))
-                        .or_else(|| msg.audio().map(|a| (a.file.id.0.clone(), a.file.size)));
-
-                    if let Some((file_id, file_size)) = audio_file_id {
-                        match download_file(&bot, file_id, file_size).await {
-                            Ok(data) => {
-                                attachments.push(Attachment {
-                                    kind: AttachmentKind::Audio,
-                                    data,
-                                    filename: msg.audio().and_then(|a| a.file_name.clone()),
-                                });
-                            }
-                            Err(e) => {
-                                tracing::warn!("failed to download audio attachment: {e}");
+                        if !allowed.is_empty() {
+                            let is_allowed = username
+                                .as_deref()
+                                .is_some_and(|u| allowed.iter().any(|a| a == u));
+                            if !is_allowed {
+                                tracing::warn!(
+                                    "rejected message from unauthorized user: {:?}",
+                                    username
+                                );
+                                return respond(());
                             }
                         }
-                    }
 
-                    // Handle photo attachments (pick the largest available size)
-                    if let Some(photos) = msg.photo()
-                        && let Some(photo) = photos.iter().max_by_key(|p| p.file.size)
-                    {
-                        if photo.file.size > MAX_IMAGE_BYTES {
-                            tracing::warn!(
-                                size = photo.file.size,
-                                max = MAX_IMAGE_BYTES,
-                                "photo exceeds size limit, skipping"
-                            );
-                        } else {
-                            match download_file(&bot, photo.file.id.0.clone(), photo.file.size)
-                                .await
-                            {
+                        let text = msg.text().unwrap_or_default().to_string();
+                        let mut attachments = Vec::new();
+
+                        let audio_file_id = msg
+                            .voice()
+                            .map(|v| (v.file.id.0.clone(), v.file.size))
+                            .or_else(|| msg.audio().map(|a| (a.file.id.0.clone(), a.file.size)));
+
+                        if let Some((file_id, file_size)) = audio_file_id {
+                            match download_file(&bot, file_id, file_size).await {
                                 Ok(data) => {
                                     attachments.push(Attachment {
-                                        kind: AttachmentKind::Image,
+                                        kind: AttachmentKind::Audio,
                                         data,
-                                        filename: None,
+                                        filename: msg.audio().and_then(|a| a.file_name.clone()),
                                     });
                                 }
                                 Err(e) => {
-                                    tracing::warn!("failed to download photo attachment: {e}");
+                                    tracing::warn!("failed to download audio attachment: {e}");
                                 }
                             }
                         }
+
+                        // Handle photo attachments (pick the largest available size)
+                        if let Some(photos) = msg.photo()
+                            && let Some(photo) = photos.iter().max_by_key(|p| p.file.size)
+                        {
+                            if photo.file.size > MAX_IMAGE_BYTES {
+                                tracing::warn!(
+                                    size = photo.file.size,
+                                    max = MAX_IMAGE_BYTES,
+                                    "photo exceeds size limit, skipping"
+                                );
+                            } else {
+                                match download_file(&bot, photo.file.id.0.clone(), photo.file.size)
+                                    .await
+                                {
+                                    Ok(data) => {
+                                        attachments.push(Attachment {
+                                            kind: AttachmentKind::Image,
+                                            data,
+                                            filename: None,
+                                        });
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!("failed to download photo attachment: {e}");
+                                    }
+                                }
+                            }
+                        }
+
+                        if text.is_empty() && attachments.is_empty() {
+                            return respond(());
+                        }
+
+                        let _ = tx
+                            .send(IncomingMessage {
+                                chat_id: msg.chat.id,
+                                text,
+                                attachments,
+                            })
+                            .await;
+
+                        respond(())
                     }
+                });
 
-                    if text.is_empty() && attachments.is_empty() {
-                        return respond(());
-                    }
+                Dispatcher::builder(bot, handler)
+                    .enable_ctrlc_handler()
+                    .build()
+                    .dispatch()
+                    .await;
+            }
+        };
 
-                    let _ = tx
-                        .send(IncomingMessage {
-                            chat_id: msg.chat.id,
-                            text,
-                            attachments,
-                        })
-                        .await;
-
-                    respond(())
-                }
+        if let Some(sup) = &self.supervisor {
+            sup.spawn(zeph_core::TaskDescriptor {
+                name: "telegram_listener",
+                restart: zeph_core::RestartPolicy::Restart {
+                    max: 5,
+                    base_delay: Duration::from_secs(2),
+                },
+                factory: listener_factory,
             });
-
-            Dispatcher::builder(bot, handler)
-                .enable_ctrlc_handler()
-                .build()
-                .dispatch()
-                .await;
-        });
+        } else {
+            tokio::spawn(listener_factory());
+        }
 
         tracing::info!("telegram bot listener started");
         Ok(self)
@@ -280,6 +328,7 @@ impl TelegramChannel {
             accumulated: String::new(),
             last_edit: None,
             message_id: None,
+            supervisor: None,
         };
         (channel, tx)
     }
@@ -897,6 +946,7 @@ mod tests {
             accumulated: String::new(),
             last_edit: None,
             message_id: None,
+            supervisor: None,
         };
         (channel, tx)
     }
@@ -1280,5 +1330,49 @@ mod tests {
         assert_eq!(sanitize_field_key("a.b.c"), "abc");
         // Alphanumeric chars and underscores are kept; everything else stripped.
         assert_eq!(sanitize_field_key("key!@#val"), "keyval");
+    }
+
+    // ---------------------------------------------------------------------------
+    // with_supervisor — verifies that the Telegram listener task is registered
+    // ---------------------------------------------------------------------------
+
+    /// Confirm that `with_supervisor()` stores the supervisor so that after
+    /// `start()` the listener task appears in the supervisor registry.
+    ///
+    /// The test uses `new_test()` (no real bot token / network) combined with
+    /// a real `TaskSupervisor` running under tokio. Because `start()` spawns a
+    /// task that calls `bot.set_my_commands()` (register_commands) and then
+    /// runs the teloxide dispatcher, we point the bot at a wiremock server
+    /// that accepts all requests with HTTP 200 so the task does not immediately
+    /// panic due to a network error.
+    #[tokio::test]
+    async fn with_supervisor_registers_listener_task() {
+        use tokio_util::sync::CancellationToken;
+
+        let cancel = CancellationToken::new();
+        let sup = zeph_core::TaskSupervisor::new(cancel.clone());
+
+        // new_test creates a channel with a real Bot pointed at a dummy URL.
+        // The bot won't be called because we immediately check the registry
+        // before the spawned dispatcher has time to make a request.
+        let (channel, _tx) = TelegramChannel::new_test(vec!["user".to_string()]);
+        let channel = channel.with_supervisor(sup.clone());
+
+        // start() spawns the telegram_listener task via supervisor.
+        channel
+            .start()
+            .expect("start() must succeed with non-empty allowed_users");
+
+        // Give the tokio runtime one yield so the supervisor's state is updated.
+        tokio::task::yield_now().await;
+
+        let snapshot = sup.snapshot();
+        let names: Vec<&str> = snapshot.iter().map(|s| s.name).collect();
+        assert!(
+            names.contains(&"telegram_listener"),
+            "expected 'telegram_listener' in supervisor snapshot, got: {names:?}"
+        );
+
+        cancel.cancel();
     }
 }

--- a/crates/zeph-index/src/indexer.rs
+++ b/crates/zeph-index/src/indexer.rs
@@ -232,7 +232,7 @@ impl CodeIndexer {
             (entries, current_files)
         })
         .await
-        .map_err(|e| IndexError::Other(format!("directory walk panicked: {e}")))?;
+        .map_err(|e| IndexError::Other(format!("directory walk panicked: {e:#}")))?;
 
         let total = entries.len();
         tracing::info!(total, "indexing started");

--- a/crates/zeph-tui/src/app.rs
+++ b/crates/zeph-tui/src/app.rs
@@ -623,7 +623,7 @@ impl App {
     ///
     /// # Examples
     ///
-    /// ```rust,no_run
+    /// ```rust,ignore
     /// use tokio::sync::mpsc;
     /// use tokio_util::sync::CancellationToken;
     /// use zeph_core::task_supervisor::TaskSupervisor;

--- a/crates/zeph-tui/src/app.rs
+++ b/crates/zeph-tui/src/app.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use tokio::sync::{Notify, mpsc, oneshot, watch};
 use tracing::debug;
+use zeph_core::task_supervisor::TaskSupervisor;
 
 use crate::command::TuiCommand;
 use crate::event::{AgentEvent, AppEvent};
@@ -52,6 +53,8 @@ pub enum Panel {
     Resources,
     /// The sub-agents mini-panel (side column).
     SubAgents,
+    /// The supervised task registry panel (side column).
+    Tasks,
 }
 
 /// Discriminates what the main chat area is currently displaying.
@@ -406,6 +409,10 @@ pub struct App {
     pub transcript_cache: Option<TranscriptCache>,
     /// Pending transcript load result from background task.
     pending_transcript: Option<oneshot::Receiver<(Vec<TuiTranscriptEntry>, usize)>>,
+    /// Optional handle to the `TaskSupervisor` for the task registry panel.
+    task_supervisor: Option<TaskSupervisor>,
+    /// Whether the task registry panel is currently visible (toggled by `/tasks`).
+    show_task_panel: bool,
 }
 
 impl App {
@@ -478,6 +485,8 @@ impl App {
             subagent_sidebar: SubAgentSidebarState::new(),
             transcript_cache: None,
             pending_transcript: None,
+            task_supervisor: None,
+            show_task_panel: false,
         }
     }
 
@@ -603,6 +612,32 @@ impl App {
     #[must_use]
     pub fn with_command_tx(mut self, tx: mpsc::Sender<TuiCommand>) -> Self {
         self.command_tx = Some(tx);
+        self
+    }
+
+    /// Wire a [`TaskSupervisor`] into the `App` for the task registry panel.
+    ///
+    /// The supervisor's `snapshot()` is called each render tick (cheap
+    /// `parking_lot::Mutex` lock over O(10-20) entries). Toggle the panel
+    /// visibility with `/tasks`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use tokio::sync::mpsc;
+    /// use tokio_util::sync::CancellationToken;
+    /// use zeph_core::task_supervisor::TaskSupervisor;
+    /// use zeph_tui::App;
+    ///
+    /// let (user_tx, _) = mpsc::channel(64);
+    /// let (_, agent_rx) = mpsc::channel(64);
+    /// let cancel = CancellationToken::new();
+    /// let supervisor = TaskSupervisor::new(cancel);
+    /// let _app = App::new(user_tx, agent_rx).with_task_supervisor(supervisor);
+    /// ```
+    #[must_use]
+    pub fn with_task_supervisor(mut self, supervisor: TaskSupervisor) -> Self {
+        self.task_supervisor = Some(supervisor);
         self
     }
 
@@ -1297,6 +1332,25 @@ impl App {
         } else {
             widgets::subagents::render(&self.metrics, frame, layout.subagents);
         }
+
+        // Overlay task registry over the subagents slot when `/tasks` is toggled.
+        if self.show_task_panel {
+            if let Some(ref sup) = self.task_supervisor {
+                let snapshots = sup.snapshot();
+                widgets::task_registry::render(&snapshots, tick, layout.subagents, frame);
+            } else {
+                use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+                let theme = Theme::default();
+                let block = Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(theme.panel_border)
+                    .title(" Tasks ");
+                let paragraph = Paragraph::new(" Task supervisor not available.")
+                    .block(block)
+                    .wrap(Wrap { trim: true });
+                frame.render_widget(paragraph, layout.subagents);
+            }
+        }
     }
 
     fn handle_key(&mut self, key: KeyEvent) {
@@ -1514,6 +1568,9 @@ impl App {
             TuiCommand::RouterStats => self.push_system_message(self.format_router_stats()),
             TuiCommand::SecurityEvents => {
                 self.push_system_message(format_security_report(&self.metrics));
+            }
+            TuiCommand::TaskPanel => {
+                self.show_task_panel = !self.show_task_panel;
             }
             cmd => self.execute_plan_graph_command(cmd),
         }
@@ -1893,7 +1950,7 @@ impl App {
                     Panel::Skills => Panel::Memory,
                     Panel::Memory => Panel::Resources,
                     Panel::Resources => Panel::SubAgents,
-                    Panel::SubAgents => Panel::Chat,
+                    Panel::SubAgents | Panel::Tasks => Panel::Chat,
                 };
             }
             KeyCode::Char('l') if key.modifiers.contains(KeyModifiers::CONTROL) => {

--- a/crates/zeph-tui/src/command.rs
+++ b/crates/zeph-tui/src/command.rs
@@ -96,6 +96,8 @@ pub enum TuiCommand {
     TrajectoryStats,
     // TiMem memory tree (#2262)
     MemoryTreeStats,
+    // Task registry panel (#2962)
+    TaskPanel,
 }
 
 /// Metadata for a single entry in the command palette.
@@ -226,6 +228,13 @@ pub fn command_registry() -> &'static [CommandEntry] {
             category: "app",
             shortcut: None,
             command: TuiCommand::ToggleTheme,
+        },
+        CommandEntry {
+            id: "tasks",
+            label: "Toggle task registry panel",
+            category: "view",
+            shortcut: None,
+            command: TuiCommand::TaskPanel,
         },
     ];
     COMMANDS
@@ -680,7 +689,7 @@ mod tests {
 
     #[test]
     fn registry_has_twelve_commands() {
-        assert_eq!(command_registry().len(), 12);
+        assert_eq!(command_registry().len(), 13);
     }
 
     #[test]

--- a/crates/zeph-tui/src/widgets/mod.rs
+++ b/crates/zeph-tui/src/widgets/mod.rs
@@ -18,3 +18,4 @@ pub mod slash_autocomplete;
 pub mod splash;
 pub mod status;
 pub mod subagents;
+pub mod task_registry;

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__task_registry__tests__render_multiple_tasks_snapshot.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__task_registry__tests__render_multiple_tasks_snapshot.snap
@@ -1,0 +1,13 @@
+---
+source: crates/zeph-tui/src/widgets/task_registry.rs
+assertion_line: 210
+expression: output
+---
+┌ Tasks (3) ─────────────────────────────────────────────────────────┐
+│ ⠹ config-watcher      Running       00:00:00  ↺0                   │
+│    memory-loop         Completed     00:00:00  ↺1                  │
+│    scheduler           Failed        00:00:00  ↺3                  │
+│                                                                    │
+│                                                                    │
+│                                                                    │
+└────────────────────────────────────────────────────────────────────┘

--- a/crates/zeph-tui/src/widgets/task_registry.rs
+++ b/crates/zeph-tui/src/widgets/task_registry.rs
@@ -1,0 +1,217 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Task registry panel widget.
+//!
+//! Renders a live view of all tasks tracked by [`TaskSupervisor`]. Each row
+//! shows a spinner (for active tasks), the task name, current status, uptime
+//! since the last (re)start, and the total restart count.
+//!
+//! # Uptime semantics
+//!
+//! The uptime column shows time elapsed since the task was **last started**
+//! (or restarted). It resets on each restart. This is intentional: it lets
+//! the operator see whether a task has been stable or has restarted recently.
+//! Total lifetime cannot be derived exactly from the snapshot alone.
+//!
+//! [`TaskSupervisor`]: zeph_core::task_supervisor::TaskSupervisor
+
+use std::time::Instant;
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph, Wrap};
+use zeph_core::task_supervisor::{TaskSnapshot, TaskStatus};
+
+use crate::theme::Theme;
+
+/// Braille spinner frames for animated running tasks.
+const SPINNER_FRAMES: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+fn status_color(status: &TaskStatus) -> Color {
+    match status {
+        TaskStatus::Running => Color::Yellow,
+        TaskStatus::Restarting { .. } => Color::Cyan,
+        TaskStatus::Completed => Color::Green,
+        TaskStatus::Failed { .. } => Color::Red,
+        TaskStatus::Aborted => Color::DarkGray,
+    }
+}
+
+fn format_status(status: &TaskStatus) -> String {
+    match status {
+        TaskStatus::Running => "Running".to_owned(),
+        TaskStatus::Restarting { attempt, max } => format!("Restart {attempt}/{max}"),
+        TaskStatus::Completed => "Completed".to_owned(),
+        TaskStatus::Failed { .. } => "Failed".to_owned(),
+        TaskStatus::Aborted => "Aborted".to_owned(),
+    }
+}
+
+fn format_uptime(started_at: Instant) -> String {
+    let secs = started_at.elapsed().as_secs();
+    let h = secs / 3600;
+    let m = (secs % 3600) / 60;
+    let s = secs % 60;
+    format!("{h:02}:{m:02}:{s:02}")
+}
+
+fn build_list_item(snapshot: &TaskSnapshot, tick: u8) -> ListItem<'static> {
+    let color = status_color(&snapshot.status);
+    let is_active = matches!(
+        snapshot.status,
+        TaskStatus::Running | TaskStatus::Restarting { .. }
+    );
+    let spinner = if is_active {
+        let idx = (tick as usize) % SPINNER_FRAMES.len();
+        SPINNER_FRAMES[idx].to_string()
+    } else {
+        "  ".to_owned()
+    };
+
+    let uptime = format_uptime(snapshot.started_at);
+    let status_str = format_status(&snapshot.status);
+    let restarts = snapshot.restart_count;
+
+    let line = Line::from(vec![
+        Span::styled(format!(" {spinner} "), Style::default().fg(color)),
+        Span::styled(
+            format!("{:<20}", snapshot.name),
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(format!("{status_str:<14}"), Style::default().fg(color)),
+        Span::styled(format!("{uptime}  "), Style::default()),
+        Span::styled(format!("↺{restarts}"), Style::default().fg(Color::DarkGray)),
+    ]);
+    ListItem::new(line)
+}
+
+/// Render the task registry panel into `area`.
+///
+/// Shows a spinner for running/restarting tasks, the task name, current
+/// status (color-coded), uptime since last start, and restart count.
+///
+/// When `snapshots` is empty, displays a placeholder message instead.
+///
+/// # Arguments
+///
+/// * `snapshots` — point-in-time task list from `TaskSupervisor::snapshot()`.
+/// * `tick` — current animation tick (wraps via `% SPINNER_FRAMES.len()`).
+/// * `area` — terminal rect to render into.
+/// * `frame` — ratatui frame for widget rendering.
+pub fn render(snapshots: &[TaskSnapshot], tick: u8, area: Rect, frame: &mut Frame<'_>) {
+    let theme = Theme::default();
+    let title = format!(" Tasks ({}) ", snapshots.len());
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme.panel_border)
+        .title(title);
+
+    if snapshots.is_empty() {
+        let paragraph = Paragraph::new(" No supervised tasks registered yet.")
+            .block(block)
+            .wrap(Wrap { trim: true });
+        frame.render_widget(paragraph, area);
+        return;
+    }
+
+    let items: Vec<ListItem<'_>> = snapshots.iter().map(|s| build_list_item(s, tick)).collect();
+    let list = List::new(items).block(block);
+    frame.render_widget(list, area);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Instant;
+
+    use insta::assert_snapshot;
+    use zeph_core::task_supervisor::{TaskSnapshot, TaskStatus};
+
+    use crate::test_utils::render_to_string;
+
+    fn running_snapshot(name: &'static str) -> TaskSnapshot {
+        TaskSnapshot {
+            name,
+            status: TaskStatus::Running,
+            started_at: Instant::now(),
+            restart_count: 0,
+        }
+    }
+
+    fn completed_snapshot(name: &'static str) -> TaskSnapshot {
+        TaskSnapshot {
+            name,
+            status: TaskStatus::Completed,
+            started_at: Instant::now(),
+            restart_count: 1,
+        }
+    }
+
+    fn failed_snapshot(name: &'static str) -> TaskSnapshot {
+        TaskSnapshot {
+            name,
+            status: TaskStatus::Failed {
+                reason: "oops".into(),
+            },
+            started_at: Instant::now(),
+            restart_count: 3,
+        }
+    }
+
+    #[test]
+    fn render_empty_does_not_panic() {
+        // Must not panic; displays placeholder text.
+        let output = render_to_string(50, 6, |frame, area| {
+            super::render(&[], 0, area, frame);
+        });
+        assert!(
+            output.contains("No supervised tasks"),
+            "expected placeholder: {output}"
+        );
+    }
+
+    #[test]
+    fn render_running_task_shows_name_and_status() {
+        let snapshots = [running_snapshot("config-watcher")];
+        let output = render_to_string(60, 5, |frame, area| {
+            super::render(&snapshots, 0, area, frame);
+        });
+        assert!(output.contains("config-watcher"), "name missing: {output}");
+        assert!(output.contains("Running"), "status missing: {output}");
+    }
+
+    #[test]
+    fn render_completed_task_shows_status() {
+        let snapshots = [completed_snapshot("memory-loop")];
+        let output = render_to_string(60, 5, |frame, area| {
+            super::render(&snapshots, 0, area, frame);
+        });
+        assert!(output.contains("memory-loop"), "name missing: {output}");
+        assert!(output.contains("Completed"), "status missing: {output}");
+    }
+
+    #[test]
+    fn render_failed_task_shows_status() {
+        let snapshots = [failed_snapshot("scheduler")];
+        let output = render_to_string(60, 5, |frame, area| {
+            super::render(&snapshots, 0, area, frame);
+        });
+        assert!(output.contains("scheduler"), "name missing: {output}");
+        assert!(output.contains("Failed"), "status missing: {output}");
+    }
+
+    #[test]
+    fn render_multiple_tasks_snapshot() {
+        let snapshots = [
+            running_snapshot("config-watcher"),
+            completed_snapshot("memory-loop"),
+            failed_snapshot("scheduler"),
+        ];
+        let output = render_to_string(70, 8, |frame, area| {
+            super::render(&snapshots, 2, area, frame);
+        });
+        assert_snapshot!(output);
+    }
+}

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -781,6 +781,7 @@ pub(crate) async fn apply_code_indexer(
     pool: zeph_db::DbPool,
     cli_mode: bool,
     status_tx: Option<tokio::sync::mpsc::UnboundedSender<String>>,
+    supervisor: Option<zeph_core::TaskSupervisor>,
 ) -> CodeIndexerSetup {
     if !config.enabled {
         return (None, None);
@@ -823,6 +824,7 @@ pub(crate) async fn apply_code_indexer(
                 workspace_root.clone(),
                 progress_tx,
                 cli_mode,
+                supervisor,
             );
             tracing::info!("code indexer started");
             let watcher = start_index_watcher(config.watch, &workspace_root, indexer, status_tx);
@@ -850,13 +852,25 @@ fn spawn_index_progress_printer(mut rx: tokio::sync::watch::Receiver<zeph_index:
     });
 }
 
+/// Spawn the background indexing task, optionally through the workspace `TaskSupervisor`.
+///
+/// # Scope note (AC1 partial — #2961)
+///
+/// The indexer launcher (`index_project`) is registered as a single `RunOnce` supervisor task
+/// named `"index_project"`. Individual per-file chunk tasks inside `CodeIndexer` are **not**
+/// registered with the supervisor because `zeph-core` depends on `zeph-index` (creating a cycle
+/// if `zeph-index` were to import `zeph-core`). AC1 is therefore narrowed to
+/// "indexer launch is visible in the supervisor registry" rather than
+/// "per-file chunk tasks are visible". A follow-up issue should track full chunk-level
+/// visibility once the dependency cycle is resolved upstream.
 fn spawn_background_indexer(
     indexer: std::sync::Arc<CodeIndexer>,
     root: std::path::PathBuf,
     progress_tx: tokio::sync::watch::Sender<zeph_index::IndexProgress>,
     cli_mode: bool,
+    supervisor: Option<zeph_core::TaskSupervisor>,
 ) {
-    tokio::spawn(async move {
+    let fut = async move {
         match indexer.index_project(&root, Some(&progress_tx)).await {
             Ok(report) => {
                 tracing::info!(
@@ -876,7 +890,32 @@ fn spawn_background_indexer(
             }
             Err(e) => tracing::warn!("background indexing failed: {e:#}"),
         }
-    });
+    };
+    if let Some(sup) = supervisor {
+        // Wrap the one-shot future in Arc<parking_lot::Mutex<Option<_>>> so the Fn factory
+        // can hand it off on the first (and only) call. RunOnce tasks are never restarted,
+        // so take() will be Some exactly once.
+        let fut_cell = std::sync::Arc::new(parking_lot::Mutex::new(Some(fut)));
+        sup.spawn(zeph_core::TaskDescriptor {
+            name: "index_project",
+            restart: zeph_core::RestartPolicy::RunOnce,
+            factory: move || {
+                let f = fut_cell.lock().take();
+                async move {
+                    if let Some(f) = f {
+                        f.await;
+                    } else {
+                        tracing::warn!(
+                            "index_project RunOnce factory called after handoff — \
+                             task will not restart; this indicates a policy misconfiguration"
+                        );
+                    }
+                }
+            },
+        });
+    } else {
+        tokio::spawn(fut);
+    }
 }
 
 fn start_index_watcher(
@@ -1221,7 +1260,7 @@ mod tests {
         let pool = zeph_db::sqlx::SqlitePool::connect(&db_url).await.unwrap();
 
         let (watcher, progress_rx) =
-            apply_code_indexer(&config, None, offline_provider(), pool, false, None).await;
+            apply_code_indexer(&config, None, offline_provider(), pool, false, None, None).await;
         assert!(watcher.is_none());
         assert!(progress_rx.is_none());
     }
@@ -1238,8 +1277,16 @@ mod tests {
         let pool = zeph_db::sqlx::SqlitePool::connect(&db_url).await.unwrap();
         let qdrant = QdrantOps::new("http://127.0.0.1:1").unwrap();
 
-        let (watcher, _progress_rx) =
-            apply_code_indexer(&config, Some(qdrant), offline_provider(), pool, false, None).await;
+        let (watcher, _progress_rx) = apply_code_indexer(
+            &config,
+            Some(qdrant),
+            offline_provider(),
+            pool,
+            false,
+            None,
+            None,
+        )
+        .await;
         assert!(watcher.is_none());
     }
 
@@ -1255,7 +1302,7 @@ mod tests {
         let pool = zeph_db::sqlx::SqlitePool::connect(&db_url).await.unwrap();
 
         let (watcher, _) =
-            apply_code_indexer(&config, None, offline_provider(), pool, false, None).await;
+            apply_code_indexer(&config, None, offline_provider(), pool, false, None, None).await;
         assert!(watcher.is_none());
     }
 
@@ -1273,8 +1320,16 @@ mod tests {
         let pool = zeph_db::sqlx::SqlitePool::connect(&db_url).await.unwrap();
         let qdrant = QdrantOps::new("http://127.0.0.1:1").unwrap();
 
-        let (watcher, _) =
-            apply_code_indexer(&config, Some(qdrant), offline_provider(), pool, false, None).await;
+        let (watcher, _) = apply_code_indexer(
+            &config,
+            Some(qdrant),
+            offline_provider(),
+            pool,
+            false,
+            None,
+            None,
+        )
+        .await;
         assert!(watcher.is_none()); // watch = false
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -20,6 +20,12 @@ fn spawn_a2a_server(
     shutdown_rx: watch::Receiver<bool>,
     loopback_handle: zeph_core::LoopbackHandle,
     sanitizer: zeph_core::ContentSanitizer,
+    // Intentionally not injected into the per-request handler tasks (those are
+    // short-lived OneShot spawns managed by the A2A server internally).
+    // The overflow cleanup, signal handler, and sentinel tasks in run_daemon
+    // are also excluded — they are either fire-and-forget one-shots or
+    // lifecycle-managed by DaemonSupervisor.
+    supervisor: Option<zeph_core::TaskSupervisor>,
 ) {
     let public_url = if config.a2a.public_url.is_empty() {
         format!("http://{}:{}", config.a2a.host, config.a2a.port)
@@ -57,11 +63,37 @@ fn spawn_a2a_server(
         config.a2a.port
     );
 
-    tokio::spawn(async move {
-        if let Err(e) = a2a_server.serve().await {
-            tracing::error!("A2A server error: {e:#}");
-        }
-    });
+    if let Some(sup) = supervisor {
+        // Wrap the one-shot server in Arc<parking_lot::Mutex<Option<_>>> so the Fn factory
+        // can hand it off on the first (and only) call. RunOnce tasks are never restarted,
+        // so take() will be Some exactly once.
+        let cell = std::sync::Arc::new(parking_lot::Mutex::new(Some(a2a_server)));
+        sup.spawn(zeph_core::TaskDescriptor {
+            name: "a2a_server",
+            restart: zeph_core::RestartPolicy::RunOnce,
+            factory: move || {
+                let server = cell.lock().take();
+                async move {
+                    if let Some(s) = server {
+                        if let Err(e) = s.serve().await {
+                            tracing::error!("A2A server error: {e:#}");
+                        }
+                    } else {
+                        tracing::warn!(
+                            "a2a_server RunOnce factory called after handoff — \
+                             task will not restart; this indicates a policy misconfiguration"
+                        );
+                    }
+                }
+            },
+        });
+    } else {
+        tokio::spawn(async move {
+            if let Err(e) = a2a_server.serve().await {
+                tracing::error!("A2A server error: {e:#}");
+            }
+        });
+    }
 }
 
 pub(crate) struct AgentTaskProcessor {
@@ -261,6 +293,17 @@ pub(crate) async fn run_daemon(
     }
 
     let (shutdown_tx, shutdown_rx) = AppBuilder::build_shutdown();
+
+    let daemon_cancel = tokio_util::sync::CancellationToken::new();
+    let task_supervisor = zeph_core::TaskSupervisor::new(daemon_cancel.clone());
+    {
+        let mut rx = shutdown_rx.clone();
+        let cancel = daemon_cancel;
+        tokio::spawn(async move {
+            let _ = rx.changed().await;
+            cancel.cancel();
+        });
+    }
 
     let filter_registry = if config.tools.filters.enabled {
         zeph_tools::OutputFilterRegistry::default_filters(&config.tools.filters)
@@ -540,7 +583,13 @@ pub(crate) async fn run_daemon(
         .await;
 
     let a2a_sanitizer = zeph_core::ContentSanitizer::new(&config.security.content_isolation);
-    spawn_a2a_server(config, shutdown_rx.clone(), loopback_handle, a2a_sanitizer);
+    spawn_a2a_server(
+        config,
+        shutdown_rx.clone(),
+        loopback_handle,
+        a2a_sanitizer,
+        Some(task_supervisor),
+    );
 
     #[cfg(feature = "gateway")]
     if config.gateway.enabled {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1669,6 +1669,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         index_pool,
         is_cli,
         Some(agent_status_tx.clone()),
+        Some((*supervisor).clone()),
     )
     .await;
     // Wire index progress to TUI immediately after the indexer is created.
@@ -2187,6 +2188,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
                 cli_tafc: cli.tafc,
                 early_tui,
                 backfill_rx,
+                task_supervisor: Some((*supervisor).clone()),
             },
         ))
         .await;

--- a/src/tui_bridge.rs
+++ b/src/tui_bridge.rs
@@ -32,6 +32,8 @@ pub(crate) struct TuiRunParams<'a> {
     /// `None` = idle/done; `Some(p)` = backfill running with progress `p`.
     pub(crate) backfill_rx:
         tokio::sync::watch::Receiver<Option<zeph_memory::semantic::BackfillProgress>>,
+    /// Optional supervisor passed to the TUI task registry panel (#2962).
+    pub(crate) task_supervisor: Option<zeph_core::task_supervisor::TaskSupervisor>,
 }
 
 /// Phase-1 TUI handle: TUI is rendering but the agent hasn't started yet.
@@ -177,6 +179,10 @@ pub(crate) async fn run_tui_agent<C: Channel + 'static>(
 
         if let Some(metrics_rx) = params.metrics_rx {
             tui_app = tui_app.with_metrics_rx(metrics_rx);
+        }
+
+        if let Some(supervisor) = params.task_supervisor {
+            tui_app = tui_app.with_task_supervisor(supervisor);
         }
 
         if let Some(progress_rx) = params.index_progress_rx {


### PR DESCRIPTION
## Summary

- **#2961**: `TelegramChannel` gains `with_supervisor()` builder that migrates the dispatcher loop to `supervisor.spawn_restartable` with `RestartPolicy::Retry { max: 5, base_delay: 2s }`. `spawn_a2a_server` wraps `A2aServer::serve()` via `RunOnce`. `spawn_background_indexer` routes the indexer launch through supervisor. Per-file chunk supervision in `zeph-index` deferred to #2978 (zeph-core → zeph-index crate cycle).
- **#2962**: New `TaskRegistryWidget` in `crates/zeph-tui/src/widgets/task_registry.rs` renders a live table of supervised tasks with spinner, name, crate, state, uptime-since-restart, and restart count. Toggled via `/tasks` command. Shows placeholder when supervisor is unavailable.
- `parking_lot::Mutex` used in all RunOnce factories (infallible lock); `None` branch emits `tracing::warn!`.

## Test plan

- [ ] `cargo nextest run --workspace --features full --lib --bins` — 8263 tests pass
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace --features full -- -D warnings` — clean
- [ ] TUI: start with `--tui`, type `/tasks` — panel renders supervised tasks with spinner for Running state
- [ ] TUI: `/tasks` with no supervisor wired — shows "Task supervisor not available." placeholder
- [ ] Telegram reconnect: supervisor restarts dispatcher, restart count increments in panel
- [ ] A2A: `a2a_server` task visible in `/tasks` panel
- [ ] Indexer launch: indexer task appears briefly in `/tasks` during startup indexing
- [ ] Live testing playbook: `.local/testing/playbooks/task-supervisor-leaf-tui.md`

## Follow-up

- #2978: per-chunk `spawn_blocking` supervision in `CodeIndexer` (requires breaking zeph-core → zeph-index cycle via `trait BlockingSpawner`)