### PR TITLE
feat(core,index): BlockingSpawner trait and TaskSupervisor observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **BlockingSpawner trait: per-chunk supervision in CodeIndexer** (`#2978`): introduced
+  `BlockingSpawner` trait in `zeph-common` to break the `zeph-core → zeph-index` crate
+  cycle. `TaskSupervisor` implements the trait, bridging through its existing
+  `spawn_blocking` method. `CodeIndexer` accepts `Option<Arc<dyn BlockingSpawner>>` via a
+  `with_spawner()` builder; each `chunk_file` invocation registers a unique task
+  `chunk_file_{N}` (AtomicU64 counter) so concurrent indexing with `embed_concurrency > 1`
+  is fully visible in `supervisor.list_tasks()` without name collisions.
+
+- **TaskSupervisor observability: CPU/wall-time metrics and tokio-console** (`#2963`):
+  new optional `task-metrics` feature in `zeph-core` (included in `full`) gates CPU-time
+  measurement and histogram emission. When enabled, `spawn_blocking` wraps each task with
+  `cpu-time::ThreadTime` + `Instant` measurements and emits
+  `metrics::histogram!("zeph.task.cpu_time_ms")` and
+  `metrics::histogram!("zeph.task.wall_time_ms")` on completion, plus `task.wall_time_ms`
+  and `task.cpu_time_ms` tracing span fields visible in Jaeger and tokio-console. Zero
+  overhead when the feature is disabled (identity `#[inline]` fn, no deps linked).
+  `TaskDescriptor` doc comment now documents the observability surface for each backend
+  (tokio-console / Jaeger / TUI / metrics).
+
 - **Leaf crate TaskSupervisor migration** (`#2961`): `TelegramChannel` gains a
   `with_supervisor()` builder that migrates the dispatcher loop from a bare `tokio::spawn`
   to `supervisor.spawn_restartable` with `RestartPolicy::Restart { max: 5, base_delay: 2s }`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,6 +1318,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpu-time"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e393a7668fe1fad3075085b86c781883000b4ede868f43627b34a87c8b7ded"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2025,6 +2035,12 @@ checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "enum-as-inner"
@@ -4057,6 +4073,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdfb1365fea27e6dd9dc1dbc19f570198bc86914533ad639dae939635f096be4"
+dependencies = [
+ "aho-corasick",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
+ "metrics",
+ "ordered-float 5.3.0",
+ "quanta",
+ "radix_trie",
+ "rand 0.9.4",
+ "rand_xoshiro",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4133,6 +4179,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "nix"
@@ -5452,6 +5507,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5533,6 +5603,16 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
 
 [[package]]
 name = "rand"
@@ -5637,6 +5717,15 @@ name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
  "rand_core 0.9.5",
 ]
@@ -6783,6 +6872,12 @@ name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"
@@ -9963,6 +10058,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "tree-sitter",
  "tree-sitter-go",
@@ -10020,11 +10116,14 @@ dependencies = [
  "base64 0.22.1",
  "blake3",
  "chrono",
+ "cpu-time",
  "criterion",
  "dirs",
  "futures",
  "indoc",
  "insta",
+ "metrics",
+ "metrics-util",
  "notify",
  "notify-debouncer-mini",
  "ordered-float 5.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ candle-nn = { version = "0.10", default-features = false }
 candle-transformers = { version = "0.10", default-features = false }
 chrono = { version = "0.4", default-features = false }
 clap = "4.6"
+cpu-time = "1.0"
 criterion = "0.8"
 cron = "0.16"
 crossterm = "0.29"
@@ -59,6 +60,8 @@ opentelemetry-otlp = { version = "0.31", default-features = false }
 opentelemetry_sdk = { version = "0.31", default-features = false }
 ordered-float = "5.3"
 pdf-extract = "0.10"
+metrics = "0.24"
+metrics-util = "0.20"
 parking_lot = "0.12"
 prometheus-client = "0.24"
 petgraph = "0.8"
@@ -183,7 +186,7 @@ ide     = ["acp", "acp-http"]
 server  = ["gateway", "a2a", "otel", "prometheus"]
 chat    = ["discord", "slack"]
 ml      = ["candle", "pdf"]
-full    = ["desktop", "ide", "server", "chat", "pdf", "scheduler", "classifiers", "profiling"]
+full    = ["desktop", "ide", "server", "chat", "pdf", "scheduler", "classifiers", "profiling", "task-metrics"]
 bench   = ["dep:zeph-bench"]
 
 # === Individual feature flags ===
@@ -218,6 +221,7 @@ profiling = [
 ]
 profiling-alloc = ["profiling", "zeph-core/profiling-alloc"]
 profiling-pyroscope = ["profiling", "otel", "dep:pprof"]
+task-metrics = ["zeph-core/task-metrics"]
 # Database backend selection — mutually exclusive. Default includes sqlite.
 # NOTE: --all-features activates both, triggering compile_error! in zeph-db.
 # Use --features full or --features full,postgres instead.

--- a/crates/zeph-common/Cargo.toml
+++ b/crates/zeph-common/Cargo.toml
@@ -28,6 +28,7 @@ blake3.workspace = true
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json.workspace = true
 thiserror.workspace = true
+tokio = { workspace = true, features = ["rt"] }
 uuid = { workspace = true, features = ["v4"] }
 zeroize = { workspace = true, features = ["alloc", "derive", "serde"] }
 tree-sitter = { workspace = true, optional = true }

--- a/crates/zeph-common/src/lib.rs
+++ b/crates/zeph-common/src/lib.rs
@@ -19,6 +19,7 @@ pub mod policy;
 pub mod quarantine;
 pub mod sanitize;
 pub mod secret;
+pub mod spawner;
 pub mod text;
 pub mod trust_level;
 pub mod types;
@@ -29,6 +30,7 @@ pub mod types;
 pub const OVERFLOW_NOTICE_PREFIX: &str = "[full output stored \u{2014} ID: ";
 
 pub use policy::{PolicyLlmClient, PolicyMessage, PolicyRole};
+pub use spawner::BlockingSpawner;
 pub use trust_level::SkillTrustLevel;
 pub use types::{SessionId, ToolDefinition, ToolName};
 

--- a/crates/zeph-common/src/spawner.rs
+++ b/crates/zeph-common/src/spawner.rs
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Dependency-inversion trait for supervised blocking thread spawns.
+//!
+//! Crates that cannot depend on `zeph-core` (e.g. `zeph-index`) accept an
+//! `Option<Arc<dyn BlockingSpawner>>` and fall back to raw
+//! `tokio::task::spawn_blocking` when `None`. This breaks the cyclic
+//! dependency that would otherwise arise from `zeph-index` importing
+//! `TaskSupervisor` from `zeph-core`.
+
+/// Trait for spawning CPU-bound work on a supervised blocking thread pool.
+///
+/// Implementors register each spawned task in their supervision layer so it
+/// is visible to lifecycle management (snapshots, graceful shutdown, metrics).
+/// Callers that do not have a supervised spawner may fall back to
+/// `tokio::task::spawn_blocking` directly.
+///
+/// The trait is object-safe: it accepts a `Box<dyn FnOnce() + Send + 'static>`
+/// and returns a `JoinHandle<()>`. Callers that need a typed return value
+/// must communicate results through a channel or shared state.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::sync::Arc;
+/// use zeph_common::BlockingSpawner;
+///
+/// fn do_work(spawner: Arc<dyn BlockingSpawner>) {
+///     let handle = spawner.spawn_blocking_named("my_task", Box::new(|| {
+///         // CPU-bound work
+///     }));
+///     // Caller can `.await` the handle.
+///     let _ = handle;
+/// }
+/// ```
+pub trait BlockingSpawner: Send + Sync + 'static {
+    /// Spawn a named blocking closure and return a `JoinHandle<()>` for completion.
+    ///
+    /// The implementation registers the task in its supervision layer before
+    /// the closure begins executing. Results must be communicated via channels
+    /// or shared state if needed.
+    ///
+    /// If the closure panics, the implementation should log the error rather than
+    /// propagating a panic to the caller. The returned `JoinHandle<()>` resolves
+    /// to `Ok(())` in all non-abort cases; it resolves to `Err(JoinError)` only
+    /// if the bridge task itself is aborted externally.
+    #[must_use]
+    fn spawn_blocking_named(
+        &self,
+        name: &'static str,
+        f: Box<dyn FnOnce() + Send + 'static>,
+    ) -> tokio::task::JoinHandle<()>;
+}

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -16,6 +16,7 @@ readme = "README.md"
 profiling = ["dep:tracing-subscriber"]
 profiling-alloc = ["profiling"]
 sysinfo = ["dep:sysinfo"]
+task-metrics = ["dep:cpu-time", "dep:metrics"]
 default = []
 candle = ["zeph-llm/candle"]
 classifiers = ["zeph-llm/classifiers", "zeph-sanitizer/classifiers"]
@@ -53,6 +54,8 @@ toml_edit.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["parking_lot", "registry"], optional = true }
 sysinfo = { workspace = true, optional = true }
+cpu-time = { workspace = true, optional = true }
+metrics = { workspace = true, optional = true }
 tree-sitter.workspace = true
 uuid = { workspace = true, features = ["v4", "serde"] }
 zeph-commands.workspace = true
@@ -79,6 +82,7 @@ harness = false
 [dev-dependencies]
 age.workspace = true
 criterion.workspace = true
+metrics-util = { workspace = true, features = ["debugging"] }
 rmcp.workspace = true
 indoc.workspace = true
 insta.workspace = true

--- a/crates/zeph-core/src/task_supervisor.rs
+++ b/crates/zeph-core/src/task_supervisor.rs
@@ -53,6 +53,7 @@ use tokio::sync::{mpsc, oneshot};
 use tokio::task::AbortHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument as _;
+use zeph_common::BlockingSpawner;
 
 // ── Public types ─────────────────────────────────────────────────────────────
 
@@ -199,6 +200,18 @@ pub enum TaskStatus {
 
 /// Point-in-time snapshot of a supervised task, returned by [`TaskSupervisor::snapshot`].
 #[derive(Debug, Clone)]
+/// Observability surface per field:
+///
+/// | Field | tokio-console | Jaeger / OTLP | TUI | `metrics` histogram |
+/// |-------|--------------|--------------|-----|---------------------|
+/// | `name` | span name | span name | task list | label `"task"` |
+/// | `task.wall_time_ms` | — | span field (`task-metrics`) | — | `zeph.task.wall_time_ms` |
+/// | `task.cpu_time_ms` | — | span field (`task-metrics`) | — | `zeph.task.cpu_time_ms` |
+/// | `status` | — | — | task list | — |
+/// | `restart_count` | — | — | task list | — |
+///
+/// The `task.wall_time_ms` and `task.cpu_time_ms` fields are only populated when
+/// the crate is compiled with the `task-metrics` feature.
 pub struct TaskSnapshot {
     /// Task name.
     pub name: &'static str,
@@ -422,11 +435,19 @@ impl TaskSupervisor {
         R: Send + 'static,
     {
         let (tx, rx) = oneshot::channel::<Result<R, BlockingError>>();
+        #[cfg(feature = "task-metrics")]
+        let span = tracing::info_span!(
+            "supervised_blocking_task",
+            task.name = name,
+            task.wall_time_ms = tracing::field::Empty,
+            task.cpu_time_ms = tracing::field::Empty,
+        );
+        #[cfg(not(feature = "task-metrics"))]
         let span = tracing::info_span!("supervised_blocking_task", task.name = name);
 
         let join_handle = tokio::task::spawn_blocking(move || {
             let _enter = span.enter();
-            f()
+            measure_blocking(name, f)
         });
         let abort = join_handle.abort_handle();
 
@@ -861,6 +882,65 @@ impl TaskSupervisor {
         }
 
         Self::wire_completion_reporter(name, jh, completion_tx);
+    }
+}
+
+// ── Task metrics helpers ──────────────────────────────────────────────────────
+
+/// Run `f` and record wall-time and CPU-time metrics when `task-metrics` is enabled.
+///
+/// When the feature is disabled this is a zero-overhead identity wrapper —
+/// no `cpu-time` or `metrics` crates are linked.
+#[cfg(feature = "task-metrics")]
+#[inline]
+fn measure_blocking<F, R>(name: &'static str, f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    use cpu_time::ThreadTime;
+    let wall_start = std::time::Instant::now();
+    let cpu_start = ThreadTime::now();
+    let result = f();
+    let wall_ms = wall_start.elapsed().as_secs_f64() * 1000.0;
+    let cpu_ms = cpu_start.elapsed().as_secs_f64() * 1000.0;
+    metrics::histogram!("zeph.task.wall_time_ms", "task" => name).record(wall_ms);
+    metrics::histogram!("zeph.task.cpu_time_ms", "task" => name).record(cpu_ms);
+    tracing::Span::current().record("task.wall_time_ms", wall_ms);
+    tracing::Span::current().record("task.cpu_time_ms", cpu_ms);
+    result
+}
+
+/// Identity wrapper when `task-metrics` feature is disabled.
+///
+/// Compiles to a direct call to `f()` with no overhead.
+#[cfg(not(feature = "task-metrics"))]
+#[inline]
+fn measure_blocking<F, R>(_name: &'static str, f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    f()
+}
+
+// ── BlockingSpawner impl ──────────────────────────────────────────────────────
+
+impl BlockingSpawner for TaskSupervisor {
+    /// Spawn a named blocking closure through the supervisor.
+    ///
+    /// The task is registered in the supervisor registry (visible in
+    /// [`snapshot`][Self::snapshot] and subject to graceful shutdown) before
+    /// the closure begins executing.
+    fn spawn_blocking_named(
+        &self,
+        name: &'static str,
+        f: Box<dyn FnOnce() + Send + 'static>,
+    ) -> tokio::task::JoinHandle<()> {
+        let handle = self.spawn_blocking(name, f);
+        tokio::spawn(async move {
+            if let Err(e) = handle.join().await {
+                tracing::error!(task.name = name, error = %e, "supervised blocking task failed");
+            }
+        })
     }
 }
 
@@ -1369,6 +1449,78 @@ mod tests {
         assert!(
             sup.cancellation_token().is_cancelled(),
             "token must be cancelled after shutdown"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_blocking_spawner_task_appears_in_snapshot() {
+        // Verify that tasks spawned via BlockingSpawner appear in supervisor.snapshot().
+        use zeph_common::BlockingSpawner;
+
+        let cancel = CancellationToken::new();
+        let sup = TaskSupervisor::new(cancel);
+
+        let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<()>();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+
+        let handle = sup.spawn_blocking_named(
+            "chunk_file",
+            Box::new(move || {
+                // Signal that the task has started.
+                let _ = ready_tx.send(());
+                // Block until test signals release.
+                let _ = release_rx.blocking_recv();
+            }),
+        );
+
+        // Wait until the blocking task has actually started.
+        ready_rx.await.expect("task should start");
+
+        let snapshot = sup.snapshot();
+        assert!(
+            snapshot.iter().any(|t| t.name == "chunk_file"),
+            "chunk_file task must appear in supervisor snapshot"
+        );
+
+        // Release the blocking task and await completion.
+        let _ = release_tx.send(());
+        handle.await.expect("task should complete");
+    }
+
+    /// Verify that `measure_blocking` emits wall-time and CPU-time histograms when
+    /// the `task-metrics` feature is enabled.
+    ///
+    /// `measure_blocking` calls `metrics::histogram!` on the current thread.
+    /// We test it directly using a `DebuggingRecorder` installed as the thread-local
+    /// recorder via `metrics::with_local_recorder`.
+    #[cfg(feature = "task-metrics")]
+    #[test]
+    fn test_measure_blocking_emits_metrics() {
+        use metrics_util::debugging::DebuggingRecorder;
+
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+
+        // Call measure_blocking inside the local recorder scope so histogram! calls
+        // are captured. The closure runs synchronously on this thread.
+        metrics::with_local_recorder(&recorder, || {
+            measure_blocking("test_task", || std::hint::black_box(42_u64));
+        });
+
+        let snapshot = snapshotter.snapshot();
+        let metric_names: Vec<String> = snapshot
+            .into_vec()
+            .into_iter()
+            .map(|(k, _, _, _)| k.key().name().to_owned())
+            .collect();
+
+        assert!(
+            metric_names.iter().any(|n| n == "zeph.task.wall_time_ms"),
+            "expected zeph.task.wall_time_ms histogram; got: {metric_names:?}"
+        );
+        assert!(
+            metric_names.iter().any(|n| n == "zeph.task.cpu_time_ms"),
+            "expected zeph.task.cpu_time_ms histogram; got: {metric_names:?}"
         );
     }
 }

--- a/crates/zeph-index/src/indexer.rs
+++ b/crates/zeph-index/src/indexer.rs
@@ -24,6 +24,7 @@
 use std::collections::HashSet;
 use std::path::Path;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use futures::StreamExt as _;
 use tokio::sync::watch;
@@ -33,8 +34,16 @@ use crate::context::contextualize_for_embedding;
 use crate::error::{IndexError, Result};
 use crate::languages::{detect_language, is_indexable};
 use crate::store::{ChunkInsert, CodeStore};
+use zeph_common::BlockingSpawner;
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::LlmProvider;
+
+/// Monotonically increasing counter for generating unique `chunk_file` task names.
+///
+/// Multiple concurrent `index_file` calls use the same logical name `"chunk_file"`.
+/// The supervisor aborts any existing task with the same name on re-registration, so
+/// each spawn must get a unique name to avoid silently aborting in-flight tasks.
+static CHUNK_TASK_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Configuration for [`CodeIndexer`].
 ///
@@ -175,6 +184,12 @@ pub struct CodeIndexer {
     store: CodeStore,
     provider: Arc<AnyProvider>,
     config: IndexerConfig,
+    /// Optional supervised spawner for `chunk_file` blocking tasks.
+    ///
+    /// When `Some`, each `chunk_file` call is routed through the spawner so it
+    /// appears in the supervisor registry (snapshot, graceful shutdown, metrics).
+    /// When `None`, falls back to `tokio::task::spawn_blocking`.
+    spawner: Option<Arc<dyn BlockingSpawner>>,
 }
 
 impl CodeIndexer {
@@ -188,7 +203,36 @@ impl CodeIndexer {
             store,
             provider,
             config,
+            spawner: None,
         }
+    }
+
+    /// Attach a supervised blocking spawner for `chunk_file` tasks.
+    ///
+    /// When set, each `chunk_file` call is routed through the spawner so it is
+    /// visible in supervisor snapshots and subject to graceful shutdown.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::sync::Arc;
+    /// use zeph_index::indexer::{CodeIndexer, IndexerConfig};
+    /// use zeph_index::store::CodeStore;
+    /// use zeph_common::BlockingSpawner;
+    ///
+    /// # fn example(
+    /// #     store: CodeStore,
+    /// #     provider: Arc<zeph_llm::any::AnyProvider>,
+    /// #     spawner: Arc<dyn BlockingSpawner>,
+    /// # ) {
+    /// let indexer = CodeIndexer::new(store, provider, IndexerConfig::default())
+    ///     .with_spawner(spawner);
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn with_spawner(mut self, spawner: Arc<dyn BlockingSpawner>) -> Self {
+        self.spawner = Some(spawner);
+        self
     }
 
     /// Full project indexing with incremental change detection.
@@ -210,6 +254,8 @@ impl CodeIndexer {
         self.store.ensure_collection(vector_size).await?;
 
         let root_buf = root.to_path_buf();
+        // TODO(#2978-walk): directory walk is left as raw spawn_blocking; routing it
+        // through BlockingSpawner is out of scope (single short-lived operation per run).
         let (entries, current_files) = tokio::task::spawn_blocking(move || {
             let entries: Vec<_> = ignore::WalkBuilder::new(&root_buf)
                 .hidden(true)
@@ -245,6 +291,7 @@ impl CodeIndexer {
             let store = self.store.clone();
             let provider = Arc::clone(&self.provider);
             let config = self.config.clone();
+            let spawner = self.spawner.clone();
 
             // Resolve paths eagerly so the async closures below have no lifetime dependency on
             // `entries` or `root`.
@@ -267,11 +314,13 @@ impl CodeIndexer {
                     let store = store.clone();
                     let provider = Arc::clone(&provider);
                     let config = config.clone();
+                    let spawner = spawner.clone();
                     async move {
                         let worker = FileIndexWorker {
                             store,
                             provider,
                             config,
+                            spawner,
                         };
                         let result = worker.index_file(&abs_path, &rel_path).await;
                         (rel_path, result)
@@ -345,6 +394,7 @@ impl CodeIndexer {
             store: self.store.clone(),
             provider: Arc::clone(&self.provider),
             config: self.config.clone(),
+            spawner: self.spawner.clone(),
         };
         let (created, _) = worker.index_file(abs_path, &rel_path).await?;
         Ok(created)
@@ -356,6 +406,7 @@ struct FileIndexWorker {
     store: CodeStore,
     provider: Arc<AnyProvider>,
     config: IndexerConfig,
+    spawner: Option<Arc<dyn BlockingSpawner>>,
 }
 
 impl FileIndexWorker {
@@ -378,11 +429,35 @@ impl FileIndexWorker {
 
         let rel_path_owned = rel_path.to_owned();
         let chunker_config = self.config.chunker.clone();
-        let chunks = tokio::task::spawn_blocking(move || {
-            chunk_file(&source, &rel_path_owned, lang, &chunker_config)
-        })
-        .await
-        .map_err(|e| IndexError::Other(format!("chunk_file panicked: {e}")))??;
+        let chunks = if let Some(ref spawner) = self.spawner {
+            // Route through the supervised spawner so the task appears in registry.
+            // BlockingSpawner::spawn_blocking_named is object-safe (returns JoinHandle<()>),
+            // so we communicate the typed result via a oneshot channel.
+            //
+            // Each spawn gets a unique name to prevent the supervisor's "abort if same
+            // name already exists" logic from silently aborting concurrent in-flight tasks
+            // when embed_concurrency > 1.
+            let task_id = CHUNK_TASK_COUNTER.fetch_add(1, Ordering::Relaxed);
+            let task_name: &'static str =
+                Box::leak(format!("chunk_file_{task_id}").into_boxed_str());
+            let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+            let _join = spawner.spawn_blocking_named(
+                task_name,
+                Box::new(move || {
+                    let result = chunk_file(&source, &rel_path_owned, lang, &chunker_config);
+                    let _ = result_tx.send(result);
+                }),
+            );
+            result_rx
+                .await
+                .map_err(|_| IndexError::Other("chunk_file task dropped result".to_owned()))??
+        } else {
+            tokio::task::spawn_blocking(move || {
+                chunk_file(&source, &rel_path_owned, lang, &chunker_config)
+            })
+            .await
+            .map_err(|e| IndexError::Other(format!("chunk_file panicked: {e}")))??
+        };
 
         // Batch-check which hashes already exist to avoid N individual queries.
         let all_hashes: Vec<&str> = chunks.iter().map(|c| c.content_hash.as_str()).collect();
@@ -617,6 +692,7 @@ mod tests {
             store,
             provider,
             config: IndexerConfig::default(),
+            spawner: None,
         };
 
         // First call: all hashes exist → (0, chunk_count).
@@ -628,5 +704,71 @@ mod tests {
         let (created2, skipped2) = worker.index_file(&rs_path, "sample.rs").await.unwrap();
         assert_eq!(created2, 0);
         assert_eq!(skipped2, chunk_count);
+    }
+
+    /// Verify that `index_file` works correctly when a `BlockingSpawner` is provided.
+    ///
+    /// Uses a minimal `MockBlockingSpawner` that delegates to `tokio::task::spawn_blocking`,
+    /// exercising the `spawner: Some(...)` branch in `FileIndexWorker::index_file`.
+    #[tokio::test]
+    async fn index_file_with_blocking_spawner() {
+        use std::sync::Arc;
+        use tempfile::TempDir;
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+        use zeph_memory::QdrantOps;
+
+        struct MockBlockingSpawner;
+
+        impl BlockingSpawner for MockBlockingSpawner {
+            fn spawn_blocking_named(
+                &self,
+                _name: &'static str,
+                f: Box<dyn FnOnce() + Send + 'static>,
+            ) -> tokio::task::JoinHandle<()> {
+                tokio::task::spawn_blocking(move || f())
+            }
+        }
+
+        let dir = TempDir::new().unwrap();
+        let rs_path = dir.path().join("sample.rs");
+        tokio::fs::write(&rs_path, b"fn hello() {}\n")
+            .await
+            .unwrap();
+
+        let pool = zeph_db::DbConfig {
+            url: ":memory:".to_string(),
+            ..Default::default()
+        }
+        .connect()
+        .await
+        .unwrap();
+
+        let ops = QdrantOps::new("http://127.0.0.1:1").unwrap();
+        let store = crate::store::CodeStore::with_ops(ops, pool);
+        let provider = Arc::new(AnyProvider::Mock(
+            MockProvider::default().with_embedding(vec![0.0_f32; 384]),
+        ));
+        let worker = FileIndexWorker {
+            store,
+            provider,
+            config: IndexerConfig::default(),
+            spawner: Some(Arc::new(MockBlockingSpawner)),
+        };
+
+        // With all hashes absent from SQLite the Qdrant upsert would be attempted, but
+        // our mock QdrantOps uses port 1 so it would fail. The test verifies that the
+        // spawner path is taken by confirming `chunk_file` runs (if it panicked or the
+        // oneshot was dropped, we'd get IndexError::Other, not IndexError::VectorStore).
+        let result = worker.index_file(&rs_path, "sample.rs").await;
+        // Qdrant is unavailable → we expect a VectorStore/Other error, NOT a panic.
+        // The important invariant is that we do NOT get "chunk_file task dropped result".
+        if let Err(ref e) = result {
+            let msg = e.to_string();
+            assert!(
+                !msg.contains("chunk_file task dropped result"),
+                "spawner path must not drop the result channel; got: {msg}"
+            );
+        }
     }
 }

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -793,7 +793,7 @@ pub(crate) async fn apply_code_indexer(
         })?;
         let store = CodeStore::with_ops(ops, pool);
         let provider_arc = std::sync::Arc::new(provider);
-        let indexer = std::sync::Arc::new(CodeIndexer::new(
+        let base_indexer = CodeIndexer::new(
             store,
             provider_arc,
             IndexerConfig {
@@ -804,7 +804,14 @@ pub(crate) async fn apply_code_indexer(
                 embed_concurrency: config.embed_concurrency,
                 ..IndexerConfig::default()
             },
-        ));
+        );
+        let base_indexer = if let Some(ref sup) = supervisor {
+            base_indexer.with_spawner(std::sync::Arc::new(sup.clone())
+                as std::sync::Arc<dyn zeph_common::BlockingSpawner>)
+        } else {
+            base_indexer
+        };
+        let indexer = std::sync::Arc::new(base_indexer);
         anyhow::Ok(indexer)
     };
 


### PR DESCRIPTION
## Summary

- Introduces `BlockingSpawner` trait in `zeph-common` to break the `zeph-core → zeph-index` crate cycle; `TaskSupervisor` implements it; `CodeIndexer` gains `with_spawner()` builder so `chunk_file` tasks are visible in `supervisor.list_tasks()` during indexing with unique per-task names (AtomicU64 counter prevents abort-on-collision with `embed_concurrency > 1`)
- Adds `task-metrics` optional feature to `zeph-core` (included in `full`) gating CPU/wall-time measurement on `spawn_blocking` via `cpu-time` crate; emits `zeph.task.cpu_time_ms` and `zeph.task.wall_time_ms` histograms + tracing span fields; zero overhead when feature is disabled

## Issues

Closes #2978
Closes #2963

## Test plan

- [ ] `cargo nextest run --workspace --features "desktop,ide,server,chat,pdf,scheduler,task-metrics" --lib --bins` — 8146 tests pass
- [ ] `cargo clippy --workspace --features "desktop,ide,server,chat,pdf,scheduler" -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean
- [ ] Live TUI session: trigger indexing, verify `chunk_file_N` tasks appear in `/tasks` panel
- [ ] Live metrics session: verify `zeph.task.cpu_time_ms` and `zeph.task.wall_time_ms` histograms populated with `--features full`
- [ ] Playbook: `.local/testing/playbooks/task-supervisor-blocking-spawner-observability.md`