### PR TITLE
fix(tui): eliminate CPU/memory regression and improve observability

### DIFF
--- a/crates/zeph-memory/src/eviction.rs
+++ b/crates/zeph-memory/src/eviction.rs
@@ -246,6 +246,10 @@ pub async fn start_eviction_loop(
     }
 }
 
+#[cfg_attr(
+    feature = "profiling",
+    tracing::instrument(name = "memory.eviction_phase1", skip_all)
+)]
 async fn run_eviction_phase1(
     store: &SqliteStore,
     policy: &dyn EvictionPolicy,
@@ -273,6 +277,10 @@ async fn run_eviction_phase1(
     Ok(ids_to_delete.len())
 }
 
+#[cfg_attr(
+    feature = "profiling",
+    tracing::instrument(name = "memory.eviction_phase2", skip_all)
+)]
 async fn run_eviction_phase2(store: &SqliteStore) -> Result<usize, MemoryError> {
     // Find all soft-deleted entries that haven't been cleaned from Qdrant yet.
     let ids = store.get_soft_deleted_message_ids().await?;

--- a/crates/zeph-memory/src/tiers.rs
+++ b/crates/zeph-memory/src/tiers.rs
@@ -121,6 +121,10 @@ struct SweepStats {
 }
 
 /// Execute one full promotion sweep cycle.
+#[cfg_attr(
+    feature = "profiling",
+    tracing::instrument(name = "memory.tier_promotion", skip_all)
+)]
 async fn run_promotion_sweep(
     store: &SqliteStore,
     provider: &AnyProvider,

--- a/crates/zeph-tools/src/cache.rs
+++ b/crates/zeph-tools/src/cache.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::LazyLock;
 use std::time::{Duration, Instant};
 
@@ -66,17 +66,27 @@ impl CacheEntry {
     }
 }
 
+/// Maximum number of entries retained in the cache at any time.
+///
+/// Long sessions accumulate tool results indefinitely without a cap, leading to unbounded memory
+/// growth. 512 entries covers typical session breadth with negligible overhead while bounding
+/// worst-case memory for long-running TUI sessions.
+const MAX_CACHE_ENTRIES: usize = 512;
+
 /// In-memory, session-scoped cache for tool results.
 ///
 /// # Design
 /// - `ttl = None` means entries never expire (useful for batch/scripted sessions).
 /// - `ttl = Some(d)` means entries expire after duration `d`.
 /// - Lazy eviction: expired entries are removed on `get()`.
-/// - No max-size cap: a session cache is bounded by session duration and interaction rate.
+/// - LRU eviction: when the entry count reaches [`MAX_CACHE_ENTRIES`], the least-recently-inserted
+///   entry is evicted to bound memory growth in long sessions.
 /// - Not `Send + Sync` by design — accessed only from the agent's single-threaded loop.
 #[derive(Debug)]
 pub struct ToolResultCache {
     entries: HashMap<CacheKey, CacheEntry>,
+    /// Insertion-order key list for LRU eviction (front = oldest).
+    insertion_order: VecDeque<CacheKey>,
     /// `None` = never expire. `Some(d)` = expire after `d`.
     ttl: Option<Duration>,
     enabled: bool,
@@ -92,6 +102,7 @@ impl ToolResultCache {
     pub fn new(enabled: bool, ttl: Option<Duration>) -> Self {
         Self {
             entries: HashMap::new(),
+            insertion_order: VecDeque::new(),
             ttl,
             enabled,
             hits: 0,
@@ -120,10 +131,25 @@ impl ToolResultCache {
     }
 
     /// Store a tool result in the cache.
+    ///
+    /// When the cache is at capacity ([`MAX_CACHE_ENTRIES`]), the oldest entry is evicted
+    /// before inserting the new one to prevent unbounded memory growth in long sessions.
     pub fn put(&mut self, key: CacheKey, output: ToolOutput) {
         if !self.enabled {
             return;
         }
+        if self.entries.len() >= MAX_CACHE_ENTRIES
+            && let Some(oldest_key) = self.insertion_order.pop_front()
+        {
+            self.entries.remove(&oldest_key);
+            tracing::debug!(
+                tool = %oldest_key.tool_name,
+                args_hash = oldest_key.args_hash,
+                "tool cache: evicted oldest entry (LRU cap {})",
+                MAX_CACHE_ENTRIES
+            );
+        }
+        self.insertion_order.push_back(key.clone());
         self.entries.insert(
             key,
             CacheEntry {
@@ -136,6 +162,7 @@ impl ToolResultCache {
     /// Remove all entries and reset hit/miss counters.
     pub fn clear(&mut self) {
         self.entries.clear();
+        self.insertion_order.clear();
         self.hits = 0;
         self.misses = 0;
     }
@@ -347,5 +374,26 @@ mod tests {
     fn ttl_secs_returns_seconds_for_some() {
         let cache = ToolResultCache::new(true, Some(Duration::from_secs(300)));
         assert_eq!(cache.ttl_secs(), 300);
+    }
+
+    #[test]
+    fn lru_eviction_at_capacity() {
+        let mut cache = ToolResultCache::new(true, None);
+        // Fill to capacity.
+        for i in 0..MAX_CACHE_ENTRIES {
+            cache.put(key("read", i as u64), make_output("v"));
+        }
+        assert_eq!(cache.len(), MAX_CACHE_ENTRIES);
+        // Inserting one more should evict the oldest (hash=0).
+        cache.put(key("read", MAX_CACHE_ENTRIES as u64), make_output("new"));
+        assert_eq!(cache.len(), MAX_CACHE_ENTRIES, "size must stay at cap");
+        assert!(
+            cache.get(&key("read", 0)).is_none(),
+            "oldest entry must be evicted"
+        );
+        assert!(
+            cache.get(&key("read", MAX_CACHE_ENTRIES as u64)).is_some(),
+            "new entry must be present"
+        );
     }
 }

--- a/crates/zeph-tui/src/app.rs
+++ b/crates/zeph-tui/src/app.rs
@@ -677,6 +677,7 @@ impl App {
                         | zeph_core::task_supervisor::TaskStatus::Restarting { .. }
                 )
             })
+            .filter(|t| !t.name.starts_with("mem-"))
             .peekable();
         let first = active.next()?;
         let label = if active.peek().is_none() {
@@ -1107,8 +1108,8 @@ impl App {
                         .push(ChatMessage::new(MessageRole::Assistant, text).streaming());
                     self.trim_messages();
                 }
-                let last_idx = self.messages.len().saturating_sub(1);
-                self.render_cache.invalidate(last_idx);
+                // No explicit cache invalidation needed: the cache key includes
+                // content_hash, so new chunk content causes a natural cache miss.
                 self.auto_scroll();
             }
             AgentEvent::FullMessage(text) => {

--- a/crates/zeph-tui/src/lib.rs
+++ b/crates/zeph-tui/src/lib.rs
@@ -122,6 +122,21 @@ pub async fn run_tui(mut app: App, mut event_rx: mpsc::Receiver<AppEvent>) -> Re
     result
 }
 
+/// Tracks how much of the UI needs to be redrawn after each event.
+///
+/// The render loop inspects this after every `select!` arm to decide whether
+/// to call `terminal.draw()` and, if so, how eagerly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DirtyState {
+    /// Nothing changed — skip `terminal.draw()` entirely.
+    Clean,
+    /// Only the spinner / progress indicator may have advanced (tick event).
+    /// Draw only when the agent is actively running so the spinner animates.
+    AnimationOnly,
+    /// Layout, content, or input changed — always redraw.
+    Full,
+}
+
 async fn tui_loop(
     app: &mut App,
     event_rx: &mut mpsc::Receiver<AppEvent>,
@@ -129,39 +144,55 @@ async fn tui_loop(
 ) -> Result<(), TuiError> {
     let mut tick = tokio::time::interval(std::time::Duration::from_millis(250));
     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut dirty = DirtyState::Clean;
 
     loop {
         tokio::select! {
             biased;
             Some(event) = event_rx.recv() => {
                 app.handle_event(event);
+                dirty = DirtyState::Full;
             }
             agent_poll = app.poll_agent_event() => {
-                match agent_poll {
-                    Some(agent_event) => {
-                        app.handle_agent_event(agent_event);
-                        while let Ok(ev) = app.try_recv_agent_event() {
-                            app.handle_agent_event(ev);
-                        }
+                if let Some(agent_event) = agent_poll {
+                    app.handle_agent_event(agent_event);
+                    while let Ok(ev) = app.try_recv_agent_event() {
+                        app.handle_agent_event(ev);
                     }
+                } else {
                     // Agent channel closed: agent exited. Quit the TUI.
-                    None => {
-                        app.should_quit = true;
-                    }
+                    app.should_quit = true;
+                }
+                dirty = DirtyState::Full;
+            }
+            _ = tick.tick() => {
+                // Tick: only upgrade to AnimationOnly if no full redraw is
+                // already scheduled, so a burst of agent events is not
+                // downgraded.
+                if dirty == DirtyState::Clean {
+                    dirty = DirtyState::AnimationOnly;
                 }
             }
-            _ = tick.tick() => {}
         }
 
         app.poll_metrics();
         app.poll_pending_file_index();
         app.poll_pending_transcript();
         app.refresh_task_snapshots();
-        terminal.draw(|frame| app.draw(frame))?;
 
-        let links = app.take_hyperlinks();
-        if !links.is_empty() {
-            hyperlink::write_osc8(terminal.backend_mut(), &links)?;
+        let should_draw = match dirty {
+            DirtyState::Clean => false,
+            DirtyState::AnimationOnly => app.is_agent_busy(),
+            DirtyState::Full => true,
+        };
+
+        if should_draw {
+            terminal.draw(|frame| app.draw(frame))?;
+            let links = app.take_hyperlinks();
+            if !links.is_empty() {
+                hyperlink::write_osc8(terminal.backend_mut(), &links)?;
+            }
+            dirty = DirtyState::Clean;
         }
 
         if app.should_quit {

--- a/crates/zeph-tui/src/widgets/chat.rs
+++ b/crates/zeph-tui/src/widgets/chat.rs
@@ -150,32 +150,30 @@ fn collect_message_lines_from(
             show_labels,
         };
 
-        // Streaming messages are never cached.
-        let (msg_lines, msg_md_links) = if msg.streaming {
-            render_message_lines(
-                msg,
-                tool_expanded,
-                compact_tools,
-                throbber_idx,
-                theme,
-                wrap_width,
-                show_labels,
-            )
-        } else if let Some((cached_lines, cached_links)) = cache.get(idx, &cache_key) {
-            (cached_lines.to_vec(), cached_links.to_vec())
-        } else {
-            let (rendered, extracted) = render_message_lines(
-                msg,
-                tool_expanded,
-                compact_tools,
-                throbber_idx,
-                theme,
-                wrap_width,
-                show_labels,
-            );
-            cache.put(idx, cache_key, rendered.clone(), extracted.clone());
-            (rendered, extracted)
-        };
+        // All messages (including streaming) use the render cache. For streaming
+        // messages the cache key includes content_hash, so a new chunk causes a
+        // cache miss and triggers re-render; unchanged content reuses the cached
+        // result, eliminating redundant pulldown-cmark + tree-sitter work every frame.
+        //
+        // Note: tool messages with streaming=true use throbber_idx for the braille
+        // spinner. Between content chunks the spinner freezes, but tool output
+        // typically arrives in one batch, making this trade-off acceptable.
+        let (msg_lines, msg_md_links) =
+            if let Some((cached_lines, cached_links)) = cache.get(idx, &cache_key) {
+                (cached_lines.to_vec(), cached_links.to_vec())
+            } else {
+                let (rendered, extracted) = render_message_lines(
+                    msg,
+                    tool_expanded,
+                    compact_tools,
+                    throbber_idx,
+                    theme,
+                    wrap_width,
+                    show_labels,
+                );
+                cache.put(idx, cache_key, rendered.clone(), extracted.clone());
+                (rendered, extracted)
+            };
 
         all_md_links.extend(msg_md_links);
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -686,6 +686,18 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         };
     }
 
+    // Macro to set a TUI status for the duration of an async block, clearing it on completion.
+    // Status is cleared even if the block returns an error.
+    #[cfg(feature = "tui")]
+    macro_rules! tui_status_scope {
+        ($msg:expr, $body:expr) => {{
+            tui_status!($msg);
+            let __result = $body;
+            tui_status!("");
+            __result
+        }};
+    }
+
     // Early Ctrl+C: terminate during init before the full handler is wired.
     let early_ctrlc = tokio::spawn(async {
         let _ = tokio::signal::ctrl_c().await;
@@ -709,7 +721,20 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         let _backfill_handle = crate::bootstrap::spawn_embed_backfill(memory_arc, 300, None);
     }
     #[cfg(feature = "tui")]
-    tui_status!("Connecting tools...");
+    let tool_setup = tui_status_scope!("Connecting tools...", {
+        agent_setup::build_tool_setup(
+            config,
+            permission_policy.clone(),
+            with_tool_events,
+            suppress_mcp_stderr,
+            app.age_vault_arc(),
+            Some(agent_status_tx.clone()),
+            Some(memory.sqlite().pool()),
+            &provider,
+        )
+        .await
+    });
+    #[cfg(not(feature = "tui"))]
     let tool_setup = agent_setup::build_tool_setup(
         config,
         permission_policy.clone(),


### PR DESCRIPTION
## Summary

Fixes the TUI performance regression (100% CPU, 12 GB+ memory growth) and observability gaps introduced after the render loop refactor.

- **#2993** (P1): streaming messages now route through `RenderCache` via content_hash invalidation — eliminates per-frame pulldown-cmark + tree-sitter re-render
- **#2988** (P2): `tui_status_scope!` macro auto-clears "Connecting tools..." on completion
- **#2989** (P2): `mem-*` background tasks filtered from spinner activity label
- **#2987** (P2): three-state `DirtyState` enum reduces unnecessary redraws on idle
- **#2990** (P3): absolute log file path in `testing.toml`
- **#2991** (P3): `#[instrument(skip_all)]` on memory sweep functions (under `profiling` feature)
- **#2992** (P3): `ToolResultCache` capped at 512 entries with LRU eviction

Closes epic #2994.

## Changes

| File | Change |
|------|--------|
| `crates/zeph-tui/src/widgets/chat.rs` | Unified streaming + non-streaming render cache path |
| `crates/zeph-tui/src/lib.rs` | Three-state dirty flag for tui_loop |
| `crates/zeph-tui/src/app.rs` | `mem-*` filter in `supervisor_activity_label()` |
| `src/runner.rs` | `tui_status_scope!` macro for auto-clearing status |
| `crates/zeph-tools/src/cache.rs` | LRU 512-entry cap with VecDeque eviction order |
| `crates/zeph-memory/src/eviction.rs` | `#[instrument]` on sweep functions |
| `crates/zeph-memory/src/tiers.rs` | `#[instrument]` on sweep functions |

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --features full -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins --features full` — 8272/8272 passed
- [ ] Live TUI session to confirm CPU/memory improvement (requires manual testing per `.local/testing/playbooks/`)

## Known limitations

- `DirtyState::AnimationOnly` branch not unit-tested (structural gap — private async loop)
- LRU eviction uses insertion order, not access order; ghost keys may accumulate in `insertion_order` after TTL expiry (minor bounded overshoot)
- Spinner freeze between streaming tool message chunks (documented trade-off, low impact)