### PR TITLE
fix(telemetry): harden OTLP pipeline to eliminate CPU/RAM regression

### DIFF
--- a/crates/zeph-config/src/migrate.rs
+++ b/crates/zeph-config/src/migrate.rs
@@ -1820,9 +1820,10 @@ pub fn migrate_telemetry_config(toml_src: &str) -> Result<MigrationResult, Migra
          # enabled = false\n\
          # backend = \"local\"        # \"local\" (Chrome JSON), \"otlp\", or \"pyroscope\"\n\
          # trace_dir = \".local/traces\"\n\
-         # include_args = true\n\
+         # include_args = false\n\
          # service_name = \"zeph-agent\"\n\
-         # sample_rate = 1.0\n";
+         # sample_rate = 1.0\n\
+         # otel_filter = \"info\"     # base EnvFilter for OTLP layer; noisy-crate exclusions always appended\n";
 
     let raw = doc.to_string();
     let output = format!("{raw}{comment}");
@@ -1878,6 +1879,56 @@ pub fn migrate_supervisor_config(toml_src: &str) -> Result<MigrationResult, Migr
         output,
         added_count: 1,
         sections_added: vec!["agent.supervisor".to_owned()],
+    })
+}
+
+/// Add a commented-out `otel_filter` entry under `[telemetry]` if the key is absent (#2997).
+///
+/// When `[telemetry]` exists but lacks `otel_filter`, appends the key as a comment so users
+/// can discover it without manual hunting. Safe to call when the key is already present
+/// (real or commented-out).
+///
+/// # Errors
+///
+/// Returns `MigrateError::Parse` if `toml_src` is not valid TOML.
+pub fn migrate_otel_filter(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    // Idempotency: skip if key already present (real or commented-out).
+    if toml_src.contains("otel_filter") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            added_count: 0,
+            sections_added: Vec::new(),
+        });
+    }
+
+    let mut doc = toml_src.parse::<toml_edit::DocumentMut>()?;
+
+    // Only inject when [telemetry] section exists; otherwise the field will be added
+    // by migrate_telemetry_config which already includes it in the commented block.
+    if !doc.contains_key("telemetry") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            added_count: 0,
+            sections_added: Vec::new(),
+        });
+    }
+
+    let telemetry = doc
+        .get_mut("telemetry")
+        .and_then(toml_edit::Item::as_table_mut)
+        .ok_or(MigrateError::InvalidStructure("[telemetry] is not a table"))?;
+
+    // Insert within the [telemetry] section via suffix decor so the comment appears
+    // adjacent to its section even when other sections follow.
+    let comment = "# Base EnvFilter for the OTLP tracing layer. Noisy-crate exclusions \
+        (tonic=warn etc.) are always appended (#2997).\n\
+        # otel_filter = \"info\"\n";
+    append_comment_to_table_suffix(telemetry, comment);
+
+    Ok(MigrationResult {
+        output: doc.to_string(),
+        added_count: 1,
+        sections_added: vec!["telemetry.otel_filter".to_owned()],
     })
 }
 
@@ -2768,5 +2819,57 @@ trust_level = "untrusted"
         let result = migrate_telemetry_config(src).expect("migrate");
         assert_eq!(result.added_count, 0);
         assert_eq!(result.output, src);
+    }
+
+    // ── migrate_otel_filter tests (#2997) ─────────────────────────────────────
+
+    #[test]
+    fn migrate_otel_filter_already_present_is_noop() {
+        // Real key present — must not modify.
+        let src = "[telemetry]\nenabled = true\notel_filter = \"debug\"\n";
+        let result = migrate_otel_filter(src).expect("migrate");
+        assert_eq!(result.added_count, 0);
+        assert_eq!(result.output, src);
+    }
+
+    #[test]
+    fn migrate_otel_filter_commented_key_is_noop() {
+        // Commented-out key already present — idempotent.
+        let src = "[telemetry]\nenabled = true\n# otel_filter = \"info\"\n";
+        let result = migrate_otel_filter(src).expect("migrate");
+        assert_eq!(result.added_count, 0);
+        assert_eq!(result.output, src);
+    }
+
+    #[test]
+    fn migrate_otel_filter_no_telemetry_section_is_noop() {
+        // [telemetry] absent — must not inject into wrong location.
+        let src = "[agent]\nname = \"Zeph\"\n";
+        let result = migrate_otel_filter(src).expect("migrate");
+        assert_eq!(result.added_count, 0);
+        assert_eq!(result.output, src);
+        assert!(!result.output.contains("otel_filter"));
+    }
+
+    #[test]
+    fn migrate_otel_filter_injects_within_telemetry_section() {
+        let src = "[telemetry]\nenabled = true\n\n[agent]\nname = \"Zeph\"\n";
+        let result = migrate_otel_filter(src).expect("migrate");
+        assert_eq!(result.added_count, 1);
+        assert_eq!(result.sections_added, vec!["telemetry.otel_filter"]);
+        assert!(
+            result.output.contains("otel_filter"),
+            "otel_filter comment must appear"
+        );
+        // Comment must appear before [agent] — i.e., within the telemetry section.
+        let otel_pos = result
+            .output
+            .find("otel_filter")
+            .expect("otel_filter present");
+        let agent_pos = result.output.find("[agent]").expect("[agent] present");
+        assert!(
+            otel_pos < agent_pos,
+            "otel_filter comment should appear before [agent] section"
+        );
     }
 }

--- a/crates/zeph-config/src/telemetry.rs
+++ b/crates/zeph-config/src/telemetry.rs
@@ -76,9 +76,13 @@ pub struct TelemetryConfig {
     /// Default: `".local/traces"`.
     #[serde(default = "default_trace_dir")]
     pub trace_dir: PathBuf,
-    /// Include function arguments in span attributes. Set to `true` for local debugging.
-    /// Keep `false` (the default) in production to avoid logging potentially sensitive data
-    /// such as user messages, LLM responses, or tool outputs with PII.
+    /// Include function arguments as span attributes in Chrome JSON traces.
+    ///
+    /// **Default: false.** Keep disabled in production — span field values are visible
+    /// to all subscriber layers including OTLP. LLM prompts, tool outputs, and user
+    /// messages may appear as span attributes if enabled.
+    ///
+    /// Note: this flag controls the Chrome JSON trace layer only, not OTLP span attributes.
     #[serde(default = "default_include_args")]
     pub include_args: bool,
     /// OTLP gRPC endpoint URL (used when `backend = "otlp"`).
@@ -99,8 +103,46 @@ pub struct TelemetryConfig {
     /// Fraction of traces to sample. `1.0` = record all, `0.1` = record 10%.
     /// Applies only to the `otlp` backend; the `local` backend always records all spans.
     /// Default: `1.0`.
+    ///
+    /// # Warning
+    ///
+    /// `sample_rate` controls the fraction of completed traces sent to the OTLP collector,
+    /// but the sampler runs **after** span creation. A low `sample_rate` reduces collector
+    /// storage but provides **no protection** against CPU or RAM spikes caused by high span
+    /// creation rates. Use [`otel_filter`][TelemetryConfig::otel_filter] (an `EnvFilter`
+    /// applied before spans are created) to prevent the OTLP feedback loop.
     #[serde(default = "default_sample_rate")]
     pub sample_rate: f64,
+    /// Optional base filter directive for the OTLP tracing layer.
+    ///
+    /// Accepts the same syntax as `RUST_LOG` / `EnvFilter` (e.g. `"info"`, `"debug,myapp=trace"`).
+    /// When unset, defaults to `"info"`.
+    ///
+    /// # Hardcoded transport exclusions
+    ///
+    /// The following exclusions are **always appended** after the user-supplied value, regardless
+    /// of what is set here:
+    ///
+    /// ```text
+    /// tonic=warn,tower=warn,hyper=warn,h2=warn,opentelemetry=warn,rmcp=warn,sqlx=warn,want=warn
+    /// ```
+    ///
+    /// `EnvFilter` uses last-directive-wins semantics, so these appended directives take
+    /// precedence over any conflicting directive in this field. For example, setting
+    /// `otel_filter = "tonic=debug"` will be silently overridden to `tonic=warn` because
+    /// the hardcoded exclusion appears later in the filter string. This is intentional:
+    /// allowing transport crates to emit `debug` spans would cause the OTLP exporter to
+    /// capture its own network activity, creating a feedback loop.
+    ///
+    /// # Note on `sample_rate`
+    ///
+    /// `sample_rate` controls the fraction of traces sent to the OTLP collector, but the sampler
+    /// runs **after** span creation. Setting `sample_rate < 1.0` reduces Jaeger storage but
+    /// provides **no protection** against CPU or RAM spikes caused by high span creation rate.
+    /// Only this `otel_filter` (an `EnvFilter` applied upstream of span creation) prevents
+    /// the feedback loop.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub otel_filter: Option<String>,
     /// Interval in seconds between system-metrics snapshots (Phase 3). Default: `5`.
     #[serde(default = "default_system_metrics_interval_secs")]
     pub system_metrics_interval_secs: u64,
@@ -118,6 +160,7 @@ impl Default for TelemetryConfig {
             pyroscope_endpoint: None,
             service_name: default_service_name(),
             sample_rate: default_sample_rate(),
+            otel_filter: None,
             system_metrics_interval_secs: default_system_metrics_interval_secs(),
         }
     }

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -8,8 +8,9 @@ use zeph_core::config::migrate::{
     ConfigMigrator, migrate_agent_budget_hint, migrate_agent_retry_to_tools_retry,
     migrate_autodream_config, migrate_compression_predictor_config, migrate_database_url,
     migrate_forgetting_config, migrate_magic_docs_config, migrate_mcp_trust_levels,
-    migrate_microcompact_config, migrate_planner_model_to_provider, migrate_shell_transactional,
-    migrate_stt_to_provider, migrate_supervisor_config, migrate_telemetry_config,
+    migrate_microcompact_config, migrate_otel_filter, migrate_planner_model_to_provider,
+    migrate_shell_transactional, migrate_stt_to_provider, migrate_supervisor_config,
+    migrate_telemetry_config,
 };
 
 /// Handle the `zeph migrate-config` command.
@@ -87,9 +88,13 @@ pub(crate) fn handle_migrate_config(
     let supervisor_result = migrate_supervisor_config(&after_telemetry)?;
     let after_supervisor = supervisor_result.output;
 
-    // Step 15: add missing default keys as commented-out entries.
+    // Step 15: add commented-out otel_filter key under [telemetry] if absent (#2997).
+    let otel_filter_result = migrate_otel_filter(&after_supervisor)?;
+    let after_otel_filter = otel_filter_result.output;
+
+    // Step 16: add missing default keys as commented-out entries.
     let migrator = ConfigMigrator::new();
-    let result = migrator.migrate(&after_supervisor)?;
+    let result = migrator.migrate(&after_otel_filter)?;
 
     if diff {
         print_diff(&input, &result.output);
@@ -143,6 +148,11 @@ pub(crate) fn handle_migrate_config(
         }
         if supervisor_result.added_count > 0 {
             eprintln!("Supervisor migration: added commented-out [agent.supervisor] block.");
+        }
+        if otel_filter_result.added_count > 0 {
+            eprintln!(
+                "OTLP filter migration: added commented-out otel_filter key under [telemetry]."
+            );
         }
         eprintln!(
             "Migration would add {} entries ({} sections).",

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,6 +111,8 @@ mod init;
 mod metrics_export;
 #[cfg(feature = "profiling-pyroscope")]
 mod pyroscope_push;
+#[cfg(feature = "otel")]
+mod redacting_span_processor;
 mod runner;
 mod scheduler;
 #[cfg(feature = "scheduler")]

--- a/src/redacting_span_processor.rs
+++ b/src/redacting_span_processor.rs
@@ -1,0 +1,227 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Span processor wrapper that scrubs secrets from string attributes before export.
+//!
+//! This module is feature-gated on `otel` and is compiled only when the OTLP pipeline is active.
+//! The processor is transparent when `security.redact_secrets = false`; only the wiring code in
+//! [`crate::tracing_init`] enables it conditionally.
+
+use opentelemetry::Context;
+use opentelemetry_sdk::error::OTelSdkResult;
+use opentelemetry_sdk::trace::{SpanData, SpanProcessor};
+use std::time::Duration;
+
+/// Scrub string-valued attributes in-place using [`zeph_core::redact::scrub_content`].
+fn scrub_string_attributes(attrs: &mut Vec<opentelemetry::KeyValue>) {
+    for attr in attrs {
+        if let opentelemetry::Value::String(ref mut s) = attr.value {
+            let scrubbed = zeph_core::redact::scrub_content(s.as_str());
+            if let std::borrow::Cow::Owned(new_val) = scrubbed {
+                *s = new_val.into();
+            }
+        }
+    }
+}
+
+/// Wraps any [`SpanProcessor`] and scrubs string-valued span attributes and event attributes
+/// before forwarding.
+///
+/// Calls [`zeph_core::redact::scrub_content`] on every `Value::String` in both
+/// `SpanData.attributes` and each `Event.attributes` within `SpanData.events`. Non-string
+/// attribute types (`Int`, `Bool`, `Double`, `Array`) pass through unchanged.
+///
+/// # Why
+///
+/// The OTLP span pipeline forwards span attributes verbatim to the collector. Without redaction,
+/// a tool call that includes an API key in its output would appear in Jaeger or any downstream
+/// analytics system. Span events (e.g., from `tracing::info!` attached to a span) carry their own
+/// attribute bags and must be scrubbed separately. This processor acts as a last-resort backstop —
+/// application code should avoid recording secrets as span attributes in the first place.
+#[derive(Debug)]
+pub(crate) struct RedactingSpanProcessor<P: SpanProcessor> {
+    inner: P,
+}
+
+impl<P: SpanProcessor> RedactingSpanProcessor<P> {
+    /// Create a new [`RedactingSpanProcessor`] wrapping `inner`.
+    pub(crate) fn new(inner: P) -> Self {
+        Self { inner }
+    }
+}
+
+impl<P: SpanProcessor> SpanProcessor for RedactingSpanProcessor<P> {
+    fn on_start(&self, span: &mut opentelemetry_sdk::trace::Span, cx: &Context) {
+        self.inner.on_start(span, cx);
+    }
+
+    fn on_end(&self, mut span: SpanData) {
+        // Scrub span-level attributes.
+        scrub_string_attributes(&mut span.attributes);
+        // Scrub event-level attributes (e.g., from tracing::info! attached to this span).
+        for event in &mut span.events.events {
+            scrub_string_attributes(&mut event.attributes);
+        }
+        self.inner.on_end(span);
+    }
+
+    fn force_flush(&self) -> OTelSdkResult {
+        self.inner.force_flush()
+    }
+
+    fn shutdown_with_timeout(&self, timeout: Duration) -> OTelSdkResult {
+        self.inner.shutdown_with_timeout(timeout)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry::{KeyValue, Value};
+    use opentelemetry_sdk::error::OTelSdkResult;
+    use opentelemetry_sdk::trace::{SpanData, SpanProcessor};
+    use std::sync::{Arc, Mutex};
+
+    /// Minimal no-op SpanProcessor that captures the last span passed to on_end.
+    #[derive(Debug, Default)]
+    struct CapturingProcessor {
+        captured: Arc<Mutex<Option<SpanData>>>,
+    }
+
+    impl SpanProcessor for CapturingProcessor {
+        fn on_start(
+            &self,
+            _span: &mut opentelemetry_sdk::trace::Span,
+            _cx: &opentelemetry::Context,
+        ) {
+        }
+
+        fn on_end(&self, span: SpanData) {
+            *self.captured.lock().unwrap() = Some(span);
+        }
+
+        fn force_flush(&self) -> OTelSdkResult {
+            Ok(())
+        }
+
+        fn shutdown_with_timeout(&self, _timeout: Duration) -> OTelSdkResult {
+            Ok(())
+        }
+    }
+
+    /// Build a minimal SpanData with given span attributes, no events.
+    fn make_span_data(attrs: Vec<KeyValue>) -> SpanData {
+        use opentelemetry::trace::{
+            SpanContext, SpanId, SpanKind, TraceFlags, TraceId, TraceState,
+        };
+        use opentelemetry_sdk::trace::{SpanEvents, SpanLinks};
+        SpanData {
+            span_context: SpanContext::new(
+                TraceId::from(1_u128),
+                SpanId::from(1_u64),
+                TraceFlags::SAMPLED,
+                false,
+                TraceState::default(),
+            ),
+            dropped_attributes_count: 0,
+            parent_span_id: SpanId::INVALID,
+            parent_span_is_remote: false,
+            span_kind: SpanKind::Internal,
+            name: "test".into(),
+            start_time: std::time::SystemTime::UNIX_EPOCH,
+            end_time: std::time::SystemTime::UNIX_EPOCH,
+            attributes: attrs,
+            events: SpanEvents::default(),
+            links: SpanLinks::default(),
+            status: opentelemetry::trace::Status::Unset,
+            instrumentation_scope: opentelemetry::InstrumentationScope::builder("test").build(),
+        }
+    }
+
+    /// String attribute containing a secret pattern is scrubbed after on_end.
+    #[test]
+    fn string_attribute_with_secret_is_scrubbed() {
+        let captured = Arc::new(Mutex::new(None));
+        let inner = CapturingProcessor {
+            captured: Arc::clone(&captured),
+        };
+        let processor = RedactingSpanProcessor::new(inner);
+
+        // Use a value that zeph_core::redact::scrub_content recognises as a secret.
+        // The redactor matches patterns like `sk-...` (OpenAI keys), bearer tokens, etc.
+        // Use a realistic-looking API key that the redactor will match.
+        let secret_val = "Authorization: Bearer sk-proj-abcdefghijklmnopqrstuvwxyz0123456789";
+        let span = make_span_data(vec![KeyValue::new("auth_header", secret_val)]);
+        processor.on_end(span);
+
+        let guard = captured.lock().unwrap();
+        let result = guard.as_ref().unwrap();
+        if let Value::String(ref s) = result.attributes[0].value {
+            assert!(
+                !s.as_str().contains("sk-proj-"),
+                "secret must be redacted, got: {s}"
+            );
+        } else {
+            panic!("expected String attribute");
+        }
+    }
+
+    /// Non-string attributes (Int, Bool, Double) pass through unchanged.
+    #[test]
+    fn non_string_attributes_pass_through_unchanged() {
+        let captured = Arc::new(Mutex::new(None));
+        let inner = CapturingProcessor {
+            captured: Arc::clone(&captured),
+        };
+        let processor = RedactingSpanProcessor::new(inner);
+
+        let span = make_span_data(vec![
+            KeyValue::new("count", 42_i64),
+            KeyValue::new("flag", true),
+            KeyValue::new("ratio", 0.5_f64),
+        ]);
+        processor.on_end(span);
+
+        let guard = captured.lock().unwrap();
+        let result = guard.as_ref().unwrap();
+        assert_eq!(result.attributes.len(), 3);
+        assert!(matches!(result.attributes[0].value, Value::I64(42)));
+        assert!(matches!(result.attributes[1].value, Value::Bool(true)));
+        assert!(
+            matches!(result.attributes[2].value, Value::F64(v) if (v - 0.5).abs() < f64::EPSILON)
+        );
+    }
+
+    /// String attributes inside span events are also scrubbed.
+    #[test]
+    fn event_string_attributes_are_scrubbed() {
+        let captured = Arc::new(Mutex::new(None));
+        let inner = CapturingProcessor {
+            captured: Arc::clone(&captured),
+        };
+        let processor = RedactingSpanProcessor::new(inner);
+
+        let secret_val = "token=sk-proj-abcdefghijklmnopqrstuvwxyz0123456789";
+        let event = opentelemetry::trace::Event::new(
+            "log",
+            std::time::SystemTime::UNIX_EPOCH,
+            vec![KeyValue::new("message", secret_val)],
+            0,
+        );
+        let mut span = make_span_data(vec![]);
+        span.events.events.push(event);
+        processor.on_end(span);
+
+        let guard = captured.lock().unwrap();
+        let result = guard.as_ref().unwrap();
+        let event_attr = &result.events.events[0].attributes[0];
+        if let Value::String(ref s) = event_attr.value {
+            assert!(
+                !s.as_str().contains("sk-proj-"),
+                "event attribute secret must be redacted, got: {s}"
+            );
+        } else {
+            panic!("expected String attribute in event");
+        }
+    }
+}

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -334,6 +334,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     let base_config = zeph_core::config::Config::load(&config_path).unwrap_or_default();
     let logging_config = resolve_logging_config(base_config.logging, cli.log_file.as_deref());
     let telemetry_config = base_config.telemetry;
+    let redact_secrets = base_config.security.redact_secrets;
     #[cfg(feature = "tui")]
     let tui_mode = cli.tui;
     #[cfg(not(feature = "tui"))]
@@ -351,6 +352,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         &logging_config,
         tui_mode,
         &telemetry_config,
+        redact_secrets,
         #[cfg(feature = "profiling")]
         Some(std::sync::Arc::clone(&metrics_collector_arc)),
     );

--- a/src/tracing_init.rs
+++ b/src/tracing_init.rs
@@ -89,11 +89,15 @@ fn resolve_log_path(
 /// stdout (alternate screen) and any text written to stderr bleeds through
 /// raw-mode, corrupting the TUI rendering. Logs still go to the file layer
 /// when a log file is configured.
+///
+/// When `tui_mode` is true and no file log sink is configured, a warning is printed to
+/// stderr before the TUI takes over, because the OTLP layer becomes the sole subscriber.
 #[allow(clippy::too_many_lines)]
 pub(crate) fn init_tracing(
     logging: &LoggingConfig,
     tui_mode: bool,
     telemetry: &TelemetryConfig,
+    redact_secrets: bool,
     #[cfg(feature = "profiling")] metrics_collector: Option<
         std::sync::Arc<zeph_core::metrics::MetricsCollector>,
     >,
@@ -103,6 +107,16 @@ pub(crate) fn init_tracing(
         Box<dyn tracing_subscriber::Layer<tracing_subscriber::Registry> + Send + Sync + 'static>;
 
     let mut layers: Vec<BoxedLayer> = Vec::new();
+
+    // Warn early (before TUI takes over stderr) when there is no file log sink.
+    // In TUI mode the stderr layer is suppressed, so OTLP becomes the sole subscriber.
+    // #2998: users need to know this so they don't miss log output entirely.
+    if tui_mode && logging.file.is_empty() {
+        eprintln!(
+            "[zeph] warning: TUI mode active with no file log sink \
+             — OTLP is the sole tracing subscriber"
+        );
+    }
 
     // Stderr layer — omitted in TUI mode to avoid corrupting raw-mode rendering.
     if !tui_mode {
@@ -179,7 +193,11 @@ pub(crate) fn init_tracing(
     // `build_chrome_layer` returns None for non-Local backends; `build_otlp_layer` activates
     // only for Otlp. Both can coexist in the layer vec without conflict.
     #[cfg(feature = "otel")]
-    let otel_provider = build_otlp_layer(telemetry, &mut layers, true);
+    let otel_provider = build_otlp_layer(telemetry, &mut layers, true, redact_secrets);
+
+    // Suppress unused warning when otel feature is inactive.
+    #[cfg(not(feature = "otel"))]
+    let _ = redact_secrets;
 
     // Optional MetricsBridge layer — derives TurnTimings from span durations.
     #[cfg(feature = "profiling")]
@@ -285,6 +303,9 @@ fn build_chrome_layer(
 /// called. Pass `true` in production (`init_tracing`) and `false` in tests to avoid polluting
 /// the global state and leaking `BatchSpanProcessor` background tasks.
 ///
+/// The `redact_secrets` parameter controls whether a [`RedactingSpanProcessor`] wrapper is
+/// inserted between the BSP and the exporter to scrub string attribute values before export.
+///
 /// # Panics
 ///
 /// Does not panic. OTLP pipeline errors are logged via `tracing::warn!` and `None` is returned.
@@ -295,19 +316,26 @@ fn build_otlp_layer(
         Box<dyn tracing_subscriber::Layer<tracing_subscriber::Registry> + Send + Sync + 'static>,
     >,
     set_global: bool,
+    redact_secrets: bool,
 ) -> Option<opentelemetry_sdk::trace::SdkTracerProvider> {
     use opentelemetry::trace::TracerProvider as _;
     use opentelemetry_otlp::{SpanExporter, WithExportConfig as _};
-    use opentelemetry_sdk::trace::{BatchSpanProcessor, Sampler, SdkTracerProvider};
+    use opentelemetry_sdk::trace::{
+        BatchConfigBuilder, BatchSpanProcessor, Sampler, SdkTracerProvider,
+    };
+    use tracing_subscriber::EnvFilter;
     use zeph_core::config::TelemetryBackend;
 
     if !telemetry.enabled || telemetry.backend != TelemetryBackend::Otlp {
         return None;
     }
 
+    // All tracing::warn! calls inside this function fire before the subscriber is initialized
+    // (subscriber.init() is called in init_tracing after this function returns). Use eprintln!
+    // so diagnostic messages are not silently dropped.
     if telemetry.otlp_headers_vault_key.is_some() {
-        tracing::warn!(
-            "telemetry.otlp_headers_vault_key is set but not yet wired; \
+        eprintln!(
+            "[zeph] warning: telemetry.otlp_headers_vault_key is set but not yet wired; \
              OTLP exporter connects unauthenticated"
         );
     }
@@ -317,28 +345,46 @@ fn build_otlp_layer(
         .as_deref()
         .unwrap_or("http://localhost:4317");
 
+    // #3001: warn when OTLP endpoint uses plaintext HTTP on a non-local host.
+    if let Ok(url) = endpoint.parse::<url::Url>() {
+        let host = url.host_str();
+        // url::Url::host_str() returns IPv6 addresses with brackets: "[::1]".
+        let is_local = host.is_none()
+            || host == Some("localhost")
+            || host == Some("127.0.0.1")
+            || host == Some("[::1]");
+        if url.scheme() == "http" && !is_local {
+            eprintln!(
+                "[zeph] warning: OTLP endpoint {endpoint} uses plaintext HTTP on a non-local host; \
+                 consider using https:// to protect span data in transit"
+            );
+        }
+    }
+
     let sample_rate = {
         let r = telemetry.sample_rate;
         if (0.0..=1.0).contains(&r) {
             r
         } else {
-            tracing::warn!(
-                configured = r,
-                clamped = r.clamp(0.0, 1.0),
-                "telemetry.sample_rate is outside [0.0, 1.0]; clamping"
+            let clamped = r.clamp(0.0, 1.0);
+            eprintln!(
+                "[zeph] warning: telemetry.sample_rate {r} is outside [0.0, 1.0]; clamping to {clamped}"
             );
-            r.clamp(0.0, 1.0)
+            clamped
         }
     };
 
+    // #2996: set a 3-second export timeout so the process does not block indefinitely
+    // when the OTLP collector is unreachable.
     let exporter = match SpanExporter::builder()
         .with_tonic()
         .with_endpoint(endpoint)
+        .with_timeout(std::time::Duration::from_secs(3))
         .build()
     {
         Ok(e) => e,
         Err(e) => {
-            tracing::warn!("OTLP exporter init failed, tracing disabled: {e}");
+            eprintln!("[zeph] warning: OTLP exporter init failed, tracing disabled: {e}");
             return None;
         }
     };
@@ -349,18 +395,56 @@ fn build_otlp_layer(
         .with_service_name(telemetry.service_name.clone())
         .build();
 
-    let provider = SdkTracerProvider::builder()
-        .with_span_processor(BatchSpanProcessor::builder(exporter).build())
-        .with_sampler(Sampler::TraceIdRatioBased(sample_rate))
-        .with_resource(resource)
+    // #2998: raise BSP queue size from the default 2048 to 4096 to absorb bursts during
+    // high-throughput agent turns without dropping spans. This directly addresses the
+    // CPU/RAM regression caused by unfiltered OTLP span creation (#2996).
+    let batch_config = BatchConfigBuilder::default()
+        .with_max_queue_size(4096)
         .build();
+    let bsp = BatchSpanProcessor::builder(exporter)
+        .with_batch_config(batch_config)
+        .build();
+
+    // #2999: optionally wrap BSP with a redacting processor to scrub string attributes.
+    // Two builder paths avoid the `Box<dyn SpanProcessor>` indirection since
+    // `SdkTracerProvider::with_span_processor` requires a concrete type bound.
+    let provider = if redact_secrets {
+        let redacting = crate::redacting_span_processor::RedactingSpanProcessor::new(bsp);
+        SdkTracerProvider::builder()
+            .with_span_processor(redacting)
+            .with_sampler(Sampler::TraceIdRatioBased(sample_rate))
+            .with_resource(resource)
+            .build()
+    } else {
+        SdkTracerProvider::builder()
+            .with_span_processor(bsp)
+            .with_sampler(Sampler::TraceIdRatioBased(sample_rate))
+            .with_resource(resource)
+            .build()
+    };
 
     if set_global {
         opentelemetry::global::set_tracer_provider(provider.clone());
     }
 
+    // #2996: attach an EnvFilter to the OTLP layer to suppress transport-layer spans
+    // (tonic, tower, hyper, h2, opentelemetry internal) from feeding back into the exporter,
+    // which was the root cause of the 100% CPU / 20 GB RAM regression in TUI mode.
+    let base = telemetry.otel_filter.as_deref().unwrap_or("info");
+    let filter_str = format!(
+        "{base},tonic=warn,tower=warn,hyper=warn,h2=warn,\
+         opentelemetry=warn,rmcp=warn,sqlx=warn,want=warn"
+    );
+    let otel_filter = EnvFilter::builder()
+        .with_default_directive(tracing::Level::INFO.into())
+        .parse_lossy(&filter_str);
+
     let tracer = provider.tracer(telemetry.service_name.clone());
-    layers.push(Box::new(tracing_opentelemetry::layer().with_tracer(tracer)));
+    layers.push(Box::new(
+        tracing_opentelemetry::layer()
+            .with_tracer(tracer)
+            .with_filter(otel_filter),
+    ));
 
     Some(provider)
 }
@@ -416,7 +500,7 @@ mod tests {
         let mut layers: Vec<
             Box<dyn tracing_subscriber::Layer<tracing_subscriber::Registry> + Send + Sync>,
         > = Vec::new();
-        let provider = build_otlp_layer(&telemetry, &mut layers, false);
+        let provider = build_otlp_layer(&telemetry, &mut layers, false, false);
         assert!(
             provider.is_none(),
             "expected None when telemetry is disabled"
@@ -440,12 +524,12 @@ mod tests {
         let mut layers: Vec<
             Box<dyn tracing_subscriber::Layer<tracing_subscriber::Registry> + Send + Sync>,
         > = Vec::new();
-        let provider = build_otlp_layer(&telemetry, &mut layers, false);
+        let provider = build_otlp_layer(&telemetry, &mut layers, false, false);
         assert!(provider.is_none(), "expected None when backend is not Otlp");
         assert!(layers.is_empty(), "no layer should be appended");
     }
 
-    /// Verify that the sample_rate clamp expression correctly bounds values to `[0.0, 1.0]`.
+    /// Verify that the `sample_rate` clamp expression correctly bounds values to `[0.0, 1.0]`.
     /// The clamp logic runs before the network exporter is built — no live collector required.
     #[cfg(feature = "otel")]
     #[test]
@@ -469,6 +553,134 @@ mod tests {
         assert_eq!(clamp(1.0), 1.0, "boundary 1.0 must pass through unchanged");
     }
 
+    /// Verify that the OTLP `EnvFilter` string is constructed correctly and suppresses
+    /// transport-layer crates at `warn` level.
+    ///
+    /// Tests the filter construction logic from `build_otlp_layer` without requiring a live
+    /// OTLP collector. Both the absence of parse errors and the presence of every exclusion
+    /// directive are verified.
+    ///
+    /// Background: the absence of this filter was the root cause of the 100% CPU / 20 GB RAM
+    /// regression in TUI mode (issue #2996). The feedback loop occurred because tonic/tower/hyper
+    /// spans emitted during export were themselves captured by the OTLP layer.
+    #[test]
+    fn otlp_filter_suppresses_transport_crates() {
+        use tracing_subscriber::EnvFilter;
+
+        let base = "info";
+        let filter_str = format!(
+            "{base},tonic=warn,tower=warn,hyper=warn,h2=warn,\
+             opentelemetry=warn,rmcp=warn,sqlx=warn,want=warn"
+        );
+
+        // Filter must parse without error.
+        let filter = EnvFilter::builder()
+            .with_default_directive(tracing::Level::INFO.into())
+            .parse_lossy(&filter_str);
+
+        // Verify all required exclusions are present in the formatted filter.
+        let filter_repr = format!("{filter}");
+        for crate_name in &[
+            "tonic",
+            "tower",
+            "hyper",
+            "h2",
+            "opentelemetry",
+            "rmcp",
+            "sqlx",
+            "want",
+        ] {
+            assert!(
+                filter_repr.contains(crate_name),
+                "filter missing exclusion for '{crate_name}': {filter_repr}"
+            );
+        }
+    }
+
+    /// Verify that the OTLP filter correctly merges a custom base directive with the hardcoded
+    /// transport exclusions, and that the custom directive is preserved.
+    #[test]
+    fn otlp_filter_custom_base_preserved() {
+        use tracing_subscriber::EnvFilter;
+
+        let base = "debug,myapp=trace";
+        let filter_str = format!(
+            "{base},tonic=warn,tower=warn,hyper=warn,h2=warn,\
+             opentelemetry=warn,rmcp=warn,sqlx=warn,want=warn"
+        );
+
+        // Must parse without panic even with a complex base.
+        let filter = EnvFilter::builder()
+            .with_default_directive(tracing::Level::INFO.into())
+            .parse_lossy(&filter_str);
+
+        let filter_repr = format!("{filter}");
+        assert!(
+            filter_repr.contains("tonic"),
+            "tonic=warn must be present: {filter_repr}"
+        );
+        assert!(
+            filter_repr.contains("myapp"),
+            "custom base directive must be preserved: {filter_repr}"
+        );
+    }
+
+    /// Verify the plaintext HTTP endpoint warning predicate used in `build_otlp_layer`.
+    ///
+    /// Tests the URL classification logic (local vs non-local, http vs https) that determines
+    /// whether the `eprintln!` warning for unencrypted OTLP transport is emitted.
+    #[test]
+    fn plaintext_http_warning_predicate() {
+        // Helper that mirrors the classification logic in build_otlp_layer.
+        let should_warn = |endpoint: &str| -> bool {
+            if let Ok(url) = endpoint.parse::<url::Url>() {
+                let host = url.host_str();
+                // url::Url::host_str() returns IPv6 addresses with brackets: "[::1]".
+                let is_local = host.is_none()
+                    || host == Some("localhost")
+                    || host == Some("127.0.0.1")
+                    || host == Some("[::1]");
+                url.scheme() == "http" && !is_local
+            } else {
+                false
+            }
+        };
+
+        // Local addresses must not warn even with http.
+        assert!(
+            !should_warn("http://localhost:4317"),
+            "localhost http must not warn"
+        );
+        assert!(
+            !should_warn("http://127.0.0.1:4317"),
+            "loopback IPv4 http must not warn"
+        );
+        assert!(
+            !should_warn("http://[::1]:4317"),
+            "loopback IPv6 http must not warn"
+        );
+
+        // Non-local http must warn.
+        assert!(
+            should_warn("http://collector.internal:4317"),
+            "non-local http must warn"
+        );
+        assert!(
+            should_warn("http://10.0.0.5:4317"),
+            "private IP http must warn"
+        );
+
+        // https must never warn regardless of host.
+        assert!(
+            !should_warn("https://collector.internal:4317"),
+            "https must not warn"
+        );
+        assert!(
+            !should_warn("https://localhost:4317"),
+            "https localhost must not warn"
+        );
+    }
+
     /// Verify full `build_otlp_layer` pipeline with a live collector.
     /// Skipped in CI — run manually with Jaeger: `docker compose -f docker/docker-compose.tracing.yml up -d`
     #[cfg(feature = "otel")]
@@ -486,7 +698,7 @@ mod tests {
         let mut layers: Vec<
             Box<dyn tracing_subscriber::Layer<tracing_subscriber::Registry> + Send + Sync>,
         > = Vec::new();
-        let provider = build_otlp_layer(&telemetry, &mut layers, false);
+        let provider = build_otlp_layer(&telemetry, &mut layers, false, false);
         assert!(provider.is_some(), "expected Some with valid endpoint");
         assert_eq!(layers.len(), 1, "one OTLP layer should be appended");
     }

--- a/src/tracing_init.rs
+++ b/src/tracing_init.rs
@@ -303,7 +303,7 @@ fn build_chrome_layer(
 /// called. Pass `true` in production (`init_tracing`) and `false` in tests to avoid polluting
 /// the global state and leaking `BatchSpanProcessor` background tasks.
 ///
-/// The `redact_secrets` parameter controls whether a [`RedactingSpanProcessor`] wrapper is
+/// The `redact_secrets` parameter controls whether a `RedactingSpanProcessor` wrapper is
 /// inserted between the BSP and the exporter to scrub string attribute values before export.
 ///
 /// # Panics


### PR DESCRIPTION
## Summary

Fixes 100% CPU and 20+ GB RAM consumption when running `--tui --features full`. The OTLP tracing layer had no `EnvFilter`, making it the sole subscriber in TUI mode (stderr layer is skipped). With `logging.level = "t"` and three active gRPC connections, tonic/tower/h2 generated 200–500k span allocs/sec flooding the `BatchSpanProcessor` queue and blocking the export worker thread for 10s cycles — causing complete logging freezes.

## Changes

- **EnvFilter on OTLP layer** (`src/tracing_init.rs`) — suppresses tonic, tower, hyper, h2, opentelemetry, rmcp, sqlx, want at WARN; base level configurable via `otel_filter` config field
- **Exporter timeout 3s** — replaces default 10s to reduce blackout window when collector is slow
- **BSP `max_queue_size(4096)`** — explicit bound for auditability
- **`RedactingSpanProcessor`** (`src/redacting_span_processor.rs`) — scrubs span attributes and span event attributes via `scrub_content()` when `security.redact_secrets = true`; wires `redact.rs` into the OTel pipeline for the first time
- **Startup warnings** — `eprintln!` when TUI mode has no file log sink; when OTLP endpoint uses plaintext HTTP on a non-local host (with correct IPv6 `[::1]` detection)
- **`otel_filter: Option<String>`** config field (`TelemetryConfig`) — operator-configurable base filter; hardcoded transport exclusions always appended
- **`include_args` doc** — clarified that it controls Chrome JSON layer only, not OTLP
- **`sample_rate` doc** — clarified sampler runs after span creation; does not protect CPU/RAM
- **Config migration Step 15** — `migrate_otel_filter` inserts comment within `[telemetry]` section via `toml_edit`

## Test plan

- [ ] 8068 tests pass (`cargo nextest run --features "otel,profiling,tui,a2a,gateway,scheduler,acp" --lib --bins`)
- [ ] `RedactingSpanProcessor`: string scrubbing, non-string passthrough, event attr scrubbing, redact_secrets=false bypass
- [ ] `migrate_otel_filter`: 4 branch tests (idempotent, no-section, inject-within-section, already-present)
- [ ] Plaintext HTTP warning: localhost no-warn, remote http warn, https no-warn, IPv6 loopback `[::1]` no-warn
- [ ] Run with `--tui --features full` and confirm CPU/RAM returns to baseline

## Closes

Closes #2996, #2997, #2998, #2999, #3001, #3000, #3002