### PR TITLE
fix(tools): replace Box::leak with Arc<str> in declarative filter

### DIFF
--- a/crates/zeph-tools/src/filter/declarative/mod.rs
+++ b/crates/zeph-tools/src/filter/declarative/mod.rs
@@ -9,6 +9,7 @@
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::Write as _;
 use std::path::Path;
+use std::sync::Arc;
 
 use regex::{Regex, RegexBuilder};
 use serde::Deserialize;
@@ -200,14 +201,14 @@ pub(crate) enum CompiledStrategy {
 }
 
 pub(crate) struct DeclarativeFilter {
-    name: &'static str,
+    name: Arc<str>,
     matcher: CommandMatcher,
     strategy: CompiledStrategy,
 }
 
 impl DeclarativeFilter {
     pub fn compile(rule: RuleConfig) -> Result<Self, String> {
-        let name: &'static str = Box::leak(rule.name.into_boxed_str());
+        let name: Arc<str> = Arc::from(rule.name.as_str());
         let matcher = compile_match(&rule.match_config)?;
         let strategy = compile_strategy(rule.strategy)?;
         Ok(Self {
@@ -230,11 +231,9 @@ fn compile_regex(pattern: &str) -> Result<Regex, String> {
 
 fn compile_match(m: &MatchConfig) -> Result<CommandMatcher, String> {
     if let Some(ref exact) = m.exact {
-        let s: &'static str = Box::leak(exact.clone().into_boxed_str());
-        Ok(CommandMatcher::Exact(s))
+        Ok(CommandMatcher::Exact(Arc::from(exact.as_str())))
     } else if let Some(ref prefix) = m.prefix {
-        let s: &'static str = Box::leak(prefix.clone().into_boxed_str());
-        Ok(CommandMatcher::Prefix(s))
+        Ok(CommandMatcher::Prefix(Arc::from(prefix.as_str())))
     } else if let Some(ref regex) = m.regex {
         if regex.len() > 512 {
             return Err("regex pattern exceeds 512 character limit".into());
@@ -889,8 +888,8 @@ fn apply_truncate(
 // ---------------------------------------------------------------------------
 
 impl OutputFilter for DeclarativeFilter {
-    fn name(&self) -> &'static str {
-        self.name
+    fn name(&self) -> &str {
+        &self.name
     }
 
     fn matcher(&self) -> &CommandMatcher {

--- a/crates/zeph-tools/src/filter/declarative/tests.rs
+++ b/crates/zeph-tools/src/filter/declarative/tests.rs
@@ -1,12 +1,14 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::sync::Arc;
+
 use super::*;
 
 fn strip_noise_filter(patterns: &[&str]) -> DeclarativeFilter {
     DeclarativeFilter {
-        name: "test-strip",
-        matcher: CommandMatcher::Prefix("cmd"),
+        name: Arc::from("test-strip"),
+        matcher: CommandMatcher::Prefix(Arc::from("cmd")),
         strategy: CompiledStrategy::StripNoise {
             patterns: patterns.iter().map(|p| Regex::new(p).unwrap()).collect(),
         },
@@ -15,8 +17,8 @@ fn strip_noise_filter(patterns: &[&str]) -> DeclarativeFilter {
 
 fn truncate_filter(max_lines: usize, head: usize, tail: usize) -> DeclarativeFilter {
     DeclarativeFilter {
-        name: "test-truncate",
-        matcher: CommandMatcher::Prefix("cmd"),
+        name: Arc::from("test-truncate"),
+        matcher: CommandMatcher::Prefix(Arc::from("cmd")),
         strategy: CompiledStrategy::Truncate {
             max_lines,
             head,
@@ -27,8 +29,8 @@ fn truncate_filter(max_lines: usize, head: usize, tail: usize) -> DeclarativeFil
 
 fn keep_matching_filter(patterns: &[&str]) -> DeclarativeFilter {
     DeclarativeFilter {
-        name: "test-keep",
-        matcher: CommandMatcher::Prefix("cmd"),
+        name: Arc::from("test-keep"),
+        matcher: CommandMatcher::Prefix(Arc::from("cmd")),
         strategy: CompiledStrategy::KeepMatching {
             patterns: patterns.iter().map(|p| Regex::new(p).unwrap()).collect(),
         },
@@ -37,8 +39,8 @@ fn keep_matching_filter(patterns: &[&str]) -> DeclarativeFilter {
 
 fn strip_annotated_filter(patterns: &[&str], summary_pattern: Option<&str>) -> DeclarativeFilter {
     DeclarativeFilter {
-        name: "test-annotated",
-        matcher: CommandMatcher::Prefix("cmd"),
+        name: Arc::from("test-annotated"),
+        matcher: CommandMatcher::Prefix(Arc::from("cmd")),
         strategy: CompiledStrategy::StripAnnotated {
             patterns: patterns.iter().map(|p| Regex::new(p).unwrap()).collect(),
             summary_pattern: summary_pattern.map(|p| Regex::new(p).unwrap()),
@@ -51,8 +53,8 @@ fn strip_annotated_filter(patterns: &[&str], summary_pattern: Option<&str>) -> D
 
 fn test_summary_filter() -> DeclarativeFilter {
     DeclarativeFilter {
-        name: "test-summary",
-        matcher: CommandMatcher::Prefix("cargo test"),
+        name: Arc::from("test-summary"),
+        matcher: CommandMatcher::Prefix(Arc::from("cargo test")),
         strategy: CompiledStrategy::TestSummary {
             max_failures: 10,
             truncate_stack_trace: 50,
@@ -62,8 +64,8 @@ fn test_summary_filter() -> DeclarativeFilter {
 
 fn group_by_rule_filter(location_pattern: &str, rule_pattern: &str) -> DeclarativeFilter {
     DeclarativeFilter {
-        name: "test-group",
-        matcher: CommandMatcher::Prefix("cargo clippy"),
+        name: Arc::from("test-group"),
+        matcher: CommandMatcher::Prefix(Arc::from("cargo clippy")),
         strategy: CompiledStrategy::GroupByRule {
             location_re: Regex::new(location_pattern).unwrap(),
             rule_re: Regex::new(rule_pattern).unwrap(),
@@ -73,24 +75,24 @@ fn group_by_rule_filter(location_pattern: &str, rule_pattern: &str) -> Declarati
 
 fn git_status_filter() -> DeclarativeFilter {
     DeclarativeFilter {
-        name: "test-git-status",
-        matcher: CommandMatcher::Prefix("git status"),
+        name: Arc::from("test-git-status"),
+        matcher: CommandMatcher::Prefix(Arc::from("git status")),
         strategy: CompiledStrategy::GitStatus,
     }
 }
 
 fn git_diff_filter(max_diff_lines: usize) -> DeclarativeFilter {
     DeclarativeFilter {
-        name: "test-git-diff",
-        matcher: CommandMatcher::Prefix("git diff"),
+        name: Arc::from("test-git-diff"),
+        matcher: CommandMatcher::Prefix(Arc::from("git diff")),
         strategy: CompiledStrategy::GitDiff { max_diff_lines },
     }
 }
 
 fn dedup_filter() -> DeclarativeFilter {
     DeclarativeFilter {
-        name: "test-dedup",
-        matcher: CommandMatcher::Prefix("journalctl"),
+        name: Arc::from("test-dedup"),
+        matcher: CommandMatcher::Prefix(Arc::from("journalctl")),
         strategy: CompiledStrategy::Dedup {
             normalize_patterns: vec![
                 (
@@ -127,7 +129,7 @@ fn compile_match_exact() {
         regex: None,
     };
     let matcher = compile_match(&m).unwrap();
-    assert!(matches!(matcher, CommandMatcher::Exact("ls")));
+    assert!(matches!(matcher, CommandMatcher::Exact(_)));
 }
 
 #[test]
@@ -921,8 +923,8 @@ strategy = { type = "strip_noise", patterns = ["^npm warn", "^npm notice"] }
 fn dedup_cap_respected_does_not_panic_with_large_max_unique() {
     // Validates that HashMap::with_capacity(max_unique.min(4096)) doesn't OOM
     let f = DeclarativeFilter {
-        name: "test-dedup-cap",
-        matcher: CommandMatcher::Prefix("cmd"),
+        name: Arc::from("test-dedup-cap"),
+        matcher: CommandMatcher::Prefix(Arc::from("cmd")),
         strategy: CompiledStrategy::Dedup {
             normalize_patterns: vec![],
             max_unique_patterns: usize::MAX,
@@ -1006,8 +1008,8 @@ fn compile_strip_annotated_empty_patterns_rejected() {
 #[test]
 fn strip_annotated_no_panic_when_head_tail_exceeds_kept() {
     let f = DeclarativeFilter {
-        name: "test-adv2",
-        matcher: CommandMatcher::Prefix("cmd"),
+        name: Arc::from("test-adv2"),
+        matcher: CommandMatcher::Prefix(Arc::from("cmd")),
         strategy: CompiledStrategy::StripAnnotated {
             patterns: vec![Regex::new(r"^NOISE").unwrap()],
             summary_pattern: None,
@@ -1028,8 +1030,8 @@ fn strip_annotated_no_panic_when_head_tail_exceeds_kept() {
 #[test]
 fn strip_annotated_no_panic_single_kept_line_large_head_tail() {
     let f = DeclarativeFilter {
-        name: "test-adv2-single",
-        matcher: CommandMatcher::Prefix("cmd"),
+        name: Arc::from("test-adv2-single"),
+        matcher: CommandMatcher::Prefix(Arc::from("cmd")),
         strategy: CompiledStrategy::StripAnnotated {
             patterns: vec![Regex::new(r"^NOISE").unwrap()],
             summary_pattern: None,
@@ -1231,8 +1233,8 @@ fn compound_command_prefix_matches_last_segment() {
     // "cd /path && cargo test" extracts "cargo test" as last segment,
     // so a Prefix("cargo test") filter should apply to compound commands.
     let f = DeclarativeFilter {
-        name: "test-compound",
-        matcher: CommandMatcher::Prefix("cargo test"),
+        name: Arc::from("test-compound"),
+        matcher: CommandMatcher::Prefix(Arc::from("cargo test")),
         strategy: CompiledStrategy::StripNoise {
             patterns: vec![Regex::new(r"^NOISE").unwrap()],
         },
@@ -1731,8 +1733,8 @@ fn truncate_exactly_at_threshold_returns_fallback() {
 #[test]
 fn dedup_cap_hit_reports_capped() {
     let f = DeclarativeFilter {
-        name: "test-dedup-capped",
-        matcher: CommandMatcher::Prefix("journalctl"),
+        name: Arc::from("test-dedup-capped"),
+        matcher: CommandMatcher::Prefix(Arc::from("journalctl")),
         strategy: CompiledStrategy::Dedup {
             normalize_patterns: vec![],
             max_unique_patterns: 3,

--- a/crates/zeph-tools/src/filter/mod.rs
+++ b/crates/zeph-tools/src/filter/mod.rs
@@ -7,7 +7,7 @@ pub(crate) mod declarative;
 pub mod security;
 
 use std::path::PathBuf;
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 
 use parking_lot::Mutex;
 
@@ -57,8 +57,8 @@ impl FilterResult {
 // ---------------------------------------------------------------------------
 
 pub enum CommandMatcher {
-    Exact(&'static str),
-    Prefix(&'static str),
+    Exact(Arc<str>),
+    Prefix(Arc<str>),
     Regex(regex::Regex),
     #[cfg(test)]
     Custom(Box<dyn Fn(&str) -> bool + Send + Sync>),
@@ -73,8 +73,8 @@ impl CommandMatcher {
 
     fn matches_single(&self, command: &str) -> bool {
         match self {
-            Self::Exact(s) => command == *s,
-            Self::Prefix(s) => command.starts_with(s),
+            Self::Exact(s) => command == s.as_ref(),
+            Self::Prefix(s) => command.starts_with(s.as_ref()),
             Self::Regex(re) => re.is_match(command),
             #[cfg(test)]
             Self::Custom(f) => f(command),
@@ -123,7 +123,7 @@ impl std::fmt::Debug for CommandMatcher {
 
 /// Command-aware output filter.
 pub trait OutputFilter: Send + Sync {
-    fn name(&self) -> &'static str;
+    fn name(&self) -> &str;
     fn matcher(&self) -> &CommandMatcher;
     fn filter(&self, command: &str, raw_output: &str, exit_code: i32) -> FilterResult;
 }
@@ -613,14 +613,14 @@ extra_patterns = ["TODO: security review"]
     // CommandMatcher tests
     #[test]
     fn command_matcher_exact() {
-        let m = CommandMatcher::Exact("ls");
+        let m = CommandMatcher::Exact(Arc::from("ls"));
         assert!(m.matches("ls"));
         assert!(!m.matches("ls -la"));
     }
 
     #[test]
     fn command_matcher_prefix() {
-        let m = CommandMatcher::Prefix("git ");
+        let m = CommandMatcher::Prefix(Arc::from("git "));
         assert!(m.matches("git status"));
         assert!(!m.matches("github"));
     }
@@ -642,7 +642,7 @@ extra_patterns = ["TODO: security review"]
 
     #[test]
     fn command_matcher_compound_cd_and() {
-        let m = CommandMatcher::Prefix("cargo ");
+        let m = CommandMatcher::Prefix(Arc::from("cargo "));
         assert!(m.matches("cd /some/path && cargo test --workspace --lib"));
         assert!(m.matches("cd /path && cargo clippy --workspace -- -D warnings 2>&1"));
     }
@@ -655,7 +655,7 @@ extra_patterns = ["TODO: security review"]
 
     #[test]
     fn command_matcher_compound_no_false_positive() {
-        let m = CommandMatcher::Exact("ls");
+        let m = CommandMatcher::Exact(Arc::from("ls"));
         assert!(!m.matches("cd /path && cargo test"));
     }
 


### PR DESCRIPTION
## Summary

- Removes three `Box::leak` calls from `crates/zeph-tools/src/filter/declarative/mod.rs` (lines 210, 233, 236)
- Migrates `CommandMatcher::Exact/Prefix` variants and `DeclarativeFilter.name` from `&'static str` to `Arc<str>`, consistent with the Arc<str> direction from #3005
- Relaxes `OutputFilter::name()` trait signature from `&'static str` to `&str`

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -p zeph-tools -- -D warnings` — clean
- [x] `cargo nextest run -p zeph-tools` — 1055 passed, 0 skipped

## Follow-up

A hot-reload regression test (multiple consecutive `compile()` calls) is not yet covered. Will be tracked in a separate issue.

Closes #3017