### PR TITLE
refactor(core): introduce RuntimeContext for runtime mode flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **RuntimeContext struct** (`#3016`): introduced `zeph_core::RuntimeContext` (`Copy + Clone + Debug + Default + PartialEq + Eq`) carrying `tui_mode` and `daemon_mode` flags. All subsystem initializers in `runner.rs`, `tracing_init.rs`, and `daemon.rs` now receive a single `RuntimeContext` instead of individual `bool` parameters. The `suppress_stderr()` helper centralizes the TUI/daemon stderr suppression decision.
+
 ### Fixed
 
 - **CPU/RAM regression: graph community detection OOM** (`#3007`): `detect_communities` in

--- a/crates/zeph-core/src/lib.rs
+++ b/crates/zeph-core/src/lib.rs
@@ -90,6 +90,7 @@ pub mod http;
 pub mod lsp_hooks;
 pub mod memory_tools;
 pub mod overflow_tools;
+pub mod runtime_context;
 pub mod runtime_layer;
 pub mod skill_loader;
 pub mod task_supervisor;
@@ -109,6 +110,7 @@ pub use channel::{
     ToolStartEvent,
 };
 pub use config::{Config, ConfigError};
+pub use runtime_context::RuntimeContext;
 pub use skill_loader::SkillLoaderExecutor;
 pub use task_supervisor::{
     BlockingError, BlockingHandle, MAX_RESTART_DELAY, RestartPolicy, TaskDescriptor, TaskHandle,

--- a/crates/zeph-core/src/runtime_context.rs
+++ b/crates/zeph-core/src/runtime_context.rs
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+/// Runtime mode flags determined at startup from CLI arguments.
+///
+/// This struct is intentionally `Copy` — it carries only boolean flags
+/// and is passed by value to subsystem initializers. Adding it to function
+/// signatures replaces individual `tui_mode: bool` parameters and provides
+/// a single extension point for future runtime flags.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_core::RuntimeContext;
+///
+/// let ctx = RuntimeContext { tui_mode: true, daemon_mode: false };
+/// assert!(ctx.suppress_stderr());
+///
+/// let default_ctx = RuntimeContext::default();
+/// assert!(!default_ctx.suppress_stderr());
+/// ```
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RuntimeContext {
+    /// True when the TUI dashboard is active (ratatui owns stderr).
+    pub tui_mode: bool,
+    /// True when running as a headless daemon (a2a feature).
+    ///
+    /// This field is forward-looking: it is set at daemon entry but has no
+    /// current consumer beyond [`RuntimeContext::suppress_stderr`]. When the
+    /// a2a subsystem grows additional mode-aware initializers, they will read
+    /// this field rather than threading a new `daemon_mode: bool` parameter.
+    pub daemon_mode: bool,
+}
+
+impl RuntimeContext {
+    /// Returns `true` when stderr output should be suppressed.
+    ///
+    /// Stderr is suppressed when the TUI owns the terminal (raw mode) or when
+    /// running as a headless daemon with no controlling terminal.
+    #[must_use]
+    pub fn suppress_stderr(&self) -> bool {
+        self.tui_mode || self.daemon_mode
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RuntimeContext;
+
+    #[test]
+    fn suppress_stderr_daemon_only() {
+        let ctx = RuntimeContext {
+            tui_mode: false,
+            daemon_mode: true,
+        };
+        assert!(ctx.suppress_stderr());
+    }
+
+    #[test]
+    fn suppress_stderr_both_true() {
+        let ctx = RuntimeContext {
+            tui_mode: true,
+            daemon_mode: true,
+        };
+        assert!(ctx.suppress_stderr());
+    }
+
+    #[test]
+    fn suppress_stderr_default_is_false() {
+        assert!(!RuntimeContext::default().suppress_stderr());
+    }
+}

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -305,6 +305,11 @@ pub(crate) async fn run_daemon(
         });
     }
 
+    let daemon_runtime_ctx = zeph_core::RuntimeContext {
+        tui_mode: false,
+        daemon_mode: true,
+    };
+
     let filter_registry = if config.tools.filters.enabled {
         zeph_tools::OutputFilterRegistry::default_filters(&config.tools.filters)
     } else {
@@ -320,7 +325,9 @@ pub(crate) async fn run_daemon(
     let mut scrape_executor = zeph_tools::WebScrapeExecutor::new(&config.tools.scrape);
     let mut daemon_audit_logger: Option<std::sync::Arc<zeph_tools::AuditLogger>> = None;
     if config.tools.audit.enabled
-        && let Ok(logger) = zeph_tools::AuditLogger::from_config(&config.tools.audit, false).await
+        && let Ok(logger) =
+            zeph_tools::AuditLogger::from_config(&config.tools.audit, daemon_runtime_ctx.tui_mode)
+                .await
     {
         let logger = std::sync::Arc::new(logger);
         shell_executor = shell_executor.with_audit(std::sync::Arc::clone(&logger));
@@ -336,9 +343,12 @@ pub(crate) async fn run_daemon(
             .map(PathBuf::from)
             .collect(),
     );
-    let mcp_manager_builder =
-        crate::bootstrap::create_mcp_manager_with_vault(config, false, app.age_vault_arc())
-            .with_status_tx(status_tx);
+    let mcp_manager_builder = crate::bootstrap::create_mcp_manager_with_vault(
+        config,
+        daemon_runtime_ctx.suppress_stderr(),
+        app.age_vault_arc(),
+    )
+    .with_status_tx(status_tx);
     let mcp_manager_builder = crate::bootstrap::wire_trust_calibration(
         mcp_manager_builder,
         config,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -335,10 +335,16 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     let logging_config = resolve_logging_config(base_config.logging, cli.log_file.as_deref());
     let telemetry_config = base_config.telemetry;
     let redact_secrets = base_config.security.redact_secrets;
-    #[cfg(feature = "tui")]
-    let tui_mode = cli.tui;
-    #[cfg(not(feature = "tui"))]
-    let tui_mode = false;
+    let runtime_ctx = zeph_core::RuntimeContext {
+        #[cfg(feature = "tui")]
+        tui_mode: cli.tui,
+        #[cfg(not(feature = "tui"))]
+        tui_mode: false,
+        #[cfg(feature = "a2a")]
+        daemon_mode: cli.daemon,
+        #[cfg(not(feature = "a2a"))]
+        daemon_mode: false,
+    };
 
     // Create MetricsCollector before init_tracing so the MetricsBridge layer
     // can be wired into the subscriber at startup (addresses critic finding S1).
@@ -350,7 +356,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
 
     let _tracing_guards = init_tracing(
         &logging_config,
-        tui_mode,
+        runtime_ctx,
         &telemetry_config,
         redact_secrets,
         #[cfg(feature = "profiling")]
@@ -646,10 +652,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         Some(tokio::spawn(async move { warmup_provider(&p).await }))
     };
 
-    #[cfg(feature = "tui")]
-    let suppress_mcp_stderr = tui_active;
-    #[cfg(not(feature = "tui"))]
-    let suppress_mcp_stderr = false;
+    let suppress_mcp_stderr = runtime_ctx.suppress_stderr();
 
     // For TUI path: create the channel and start rendering immediately so the user
     // sees a spinner during the heavy init phases below. For non-TUI paths (or when
@@ -733,7 +736,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             Some(agent_status_tx.clone()),
             Some(memory.sqlite().pool()),
             &provider,
-            tui_mode,
+            runtime_ctx.tui_mode,
         )
         .await
     });
@@ -747,7 +750,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         Some(agent_status_tx.clone()),
         Some(memory.sqlite().pool()),
         &provider,
-        tui_mode,
+        runtime_ctx.tui_mode,
     )
     .await;
 

--- a/src/tracing_init.rs
+++ b/src/tracing_init.rs
@@ -95,7 +95,7 @@ fn resolve_log_path(
 #[allow(clippy::too_many_lines)]
 pub(crate) fn init_tracing(
     logging: &LoggingConfig,
-    tui_mode: bool,
+    runtime_ctx: zeph_core::RuntimeContext,
     telemetry: &TelemetryConfig,
     redact_secrets: bool,
     #[cfg(feature = "profiling")] metrics_collector: Option<
@@ -119,7 +119,7 @@ pub(crate) fn init_tracing(
     let otlp_active = false;
 
     // Stderr layer — omitted in TUI mode to avoid corrupting raw-mode rendering.
-    if !tui_mode {
+    if !runtime_ctx.tui_mode {
         let stderr_filter = tracing_subscriber::EnvFilter::try_from_default_env()
             .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
         layers.push(Box::new(
@@ -135,7 +135,7 @@ pub(crate) fn init_tracing(
     // In TUI mode the stderr layer is suppressed to avoid corrupting raw-mode rendering.
     // If logging.file was explicitly set to "" and no OTLP is configured the process would run
     // completely silent. Activate the platform default log path so traces are always reachable.
-    if tui_mode && logging.file.is_empty() && !otlp_active {
+    if runtime_ctx.tui_mode && logging.file.is_empty() && !otlp_active {
         let fallback_path = std::path::PathBuf::from(zeph_core::config::default_log_file_path());
         let log_dir = fallback_path.parent().map_or_else(
             || std::path::PathBuf::from("."),
@@ -182,7 +182,7 @@ pub(crate) fn init_tracing(
             .map_or_else(|| "log".to_owned(), |s| s.to_string_lossy().into_owned());
 
         if let Err(e) = std::fs::create_dir_all(&dir) {
-            if !tui_mode {
+            if !runtime_ctx.tui_mode {
                 eprintln!("zeph: log directory creation failed, file logging disabled: {e}");
             }
         } else {
@@ -199,7 +199,7 @@ pub(crate) fn init_tracing(
                 .build(&dir)
             {
                 Err(e) => {
-                    if !tui_mode {
+                    if !runtime_ctx.tui_mode {
                         eprintln!(
                             "zeph: log file appender init failed, file logging disabled: {e}"
                         );


### PR DESCRIPTION
## Summary

- Introduces `RuntimeContext` (`Copy + Clone + Debug + Default + PartialEq + Eq`) in `zeph-core` carrying `tui_mode` and `daemon_mode` boolean flags
- Replaces individual `bool` parameters at all subsystem initializer call sites (`runner.rs`, `tracing_init.rs`, `daemon.rs`) with a single `RuntimeContext` value
- `suppress_stderr()` helper centralizes the TUI/daemon stderr suppression decision that was previously scattered across callers
- Confirms `TaskEntry`/`TaskSnapshot` fields already use `Arc<str>` (no changes needed for #3015)

## Changes

- `crates/zeph-core/src/runtime_context.rs` — new struct with doc comments and unit tests
- `crates/zeph-core/src/lib.rs` — module registration and `pub use` re-export
- `src/runner.rs` — construct `RuntimeContext` from CLI flags, pass to `init_tracing` and subsystem initializers
- `src/tracing_init.rs` — signature migrated from `tui_mode: bool` to `runtime_ctx: RuntimeContext`
- `src/daemon.rs` — construct daemon-specific context (`daemon_mode: true`), use in AuditLogger and MCP manager

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace --features "desktop,ide,server,chat,pdf,scheduler" -- -D warnings` — clean
- [ ] `cargo nextest run --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 8172 passed
- [ ] `cargo test --doc -p zeph-core` — 13 doc-tests passed
- [ ] Follow-up issue filed for `build_tool_setup` consolidation: #3021

Closes #3016
Closes #3015