### PR TITLE
fix(tui): wire status_rx to TUI early during init to unfreeze startup

### DIFF
--- a/crates/zeph-mcp/src/manager.rs
+++ b/crates/zeph-mcp/src/manager.rs
@@ -658,6 +658,7 @@ impl McpManager {
             .cloned()
             .collect();
 
+        let cloned_status_tx = self.status_tx.clone();
         let mut join_set = JoinSet::new();
         for config in non_oauth {
             let allowed = allowed.clone();
@@ -672,7 +673,12 @@ impl McpManager {
             if self.lock_tool_list {
                 self.tool_list_locked.insert(config.id.clone(), ());
             }
+            let status_tx = cloned_status_tx.clone();
             join_set.spawn(async move {
+                // SECURITY: only config.id is included — never transport URL, headers, or tokens.
+                if let Some(ref stx) = status_tx {
+                    let _ = stx.send(format!("Connecting to {}...", config.id));
+                }
                 let result =
                     connect_entry(&config, &allowed, suppress, tx, last_refresh, handler_cfg).await;
                 (config.id, result)
@@ -1814,6 +1820,30 @@ mod tests {
         assert_eq!(outcomes.len(), 2);
         assert!(outcomes.iter().all(|o| !o.connected));
         assert!(mgr.list_servers().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn connect_all_emits_status_messages() {
+        let (status_tx, mut status_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+        let mgr = McpManager::new(
+            vec![make_entry("my-mcp")],
+            vec![],
+            PolicyEnforcer::new(vec![]),
+        )
+        .with_status_tx(status_tx);
+
+        mgr.connect_all().await;
+
+        // The "Connecting to my-mcp..." message must have been emitted before
+        // the connection attempt (which will fail — no real server).
+        let mut messages = Vec::new();
+        while let Ok(msg) = status_rx.try_recv() {
+            messages.push(msg);
+        }
+        assert!(
+            messages.iter().any(|m| m.contains("my-mcp")),
+            "expected status message for my-mcp, got: {messages:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -678,6 +678,31 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         early_tui_guard = EarlyTuiGuard::new(None);
     }
 
+    // Drain status messages that arrive during init into the already-running TUI.
+    // Without this forwarder, messages sent via `agent_status_tx` before `run_tui_agent`
+    // is called (e.g. from MCP connect_all) accumulate in the unbounded channel and are
+    // never displayed — causing the TUI to appear frozen on "Connecting tools…".
+    // `status_rx` is consumed here; `tui_status_rx_for_params` is None when the early
+    // forwarder owns the receiver, so `run_tui_agent` skips the duplicate spawn.
+    #[cfg(feature = "tui")]
+    let tui_status_rx_for_params: Option<tokio::sync::mpsc::UnboundedReceiver<String>>;
+    #[cfg(feature = "tui")]
+    {
+        if let Some(ref early) = early_tui_guard.0 {
+            // The forwarder task terminates naturally when all `agent_status_tx` senders are
+            // dropped at the end of bootstrap. The TUI thread observes the channel close and
+            // shuts down independently, so explicit abort is not needed. Dropping the handle
+            // is intentional — we have no cleanup to do on the bootstrap error path here.
+            let _early_status_forwarder = tokio::spawn(crate::tui_bridge::forward_status_to_tui(
+                status_rx,
+                early.agent_tx.clone(),
+            ));
+            tui_status_rx_for_params = None;
+        } else {
+            tui_status_rx_for_params = Some(status_rx);
+        }
+    }
+
     // Macro to send a status update to TUI during setup (no-op if no early TUI).
     #[cfg(feature = "tui")]
     macro_rules! tui_status {
@@ -2214,7 +2239,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             TuiRunParams {
                 tui_handle,
                 config,
-                status_rx,
+                status_rx: tui_status_rx_for_params,
                 tool_rx: shell_executor_for_tui,
                 metrics_rx: tui_metrics_rx,
                 warmup_provider: warmup_provider_clone,
@@ -2234,6 +2259,12 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     if let Some(handle) = warmup_handle {
         let _ = handle.await;
     }
+    // When the tui feature is compiled in but running in CLI mode, status_rx was moved
+    // into tui_status_rx_for_params above. Recover it here; it is always Some in CLI mode
+    // because the early forwarder is only spawned when early_tui_guard.0 is Some (TUI path).
+    #[cfg(feature = "tui")]
+    let status_rx = tui_status_rx_for_params
+        .expect("status_rx must be Some in CLI mode: early forwarder only runs on TUI path");
     tokio::spawn(forward_status_to_stderr(status_rx));
     let result = Box::pin(agent.run()).await;
     // Explicitly shut down MCP connections before agent.shutdown() so that child processes

--- a/src/tui_bridge.rs
+++ b/src/tui_bridge.rs
@@ -17,7 +17,7 @@ use zeph_llm::any::AnyProvider;
 pub(crate) struct TuiRunParams<'a> {
     pub(crate) tui_handle: TuiHandle,
     pub(crate) config: &'a zeph_core::config::Config,
-    pub(crate) status_rx: tokio::sync::mpsc::UnboundedReceiver<String>,
+    pub(crate) status_rx: Option<tokio::sync::mpsc::UnboundedReceiver<String>>,
     pub(crate) tool_rx: Option<tokio::sync::mpsc::UnboundedReceiver<zeph_tools::ToolEvent>>,
     pub(crate) metrics_rx:
         Option<tokio::sync::watch::Receiver<zeph_core::metrics::MetricsSnapshot>>,
@@ -261,7 +261,10 @@ pub(crate) async fn run_tui_agent<C: Channel + 'static>(
     // ensuring the agent_event channel closes and the TUI thread quits.
     let mut forwarders = tokio::task::JoinSet::new();
 
-    forwarders.spawn(forward_status_to_tui(params.status_rx, agent_tx.clone()));
+    if let Some(rx) = params.status_rx {
+        forwarders.spawn(forward_status_to_tui(rx, agent_tx.clone()));
+    }
+    // else: early forwarder already owns status_rx and is draining it
     forwarders.spawn(forward_tui_commands(
         command_rx,
         agent_tx.clone(),
@@ -431,6 +434,44 @@ pub(crate) async fn forward_tool_events_to_tui(
 #[cfg(all(test, feature = "tui"))]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn forward_status_to_tui_delivers_messages() {
+        let (status_tx, status_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+        let (agent_tx, mut agent_rx) = tokio::sync::mpsc::channel::<zeph_tui::AgentEvent>(16);
+
+        tokio::spawn(forward_status_to_tui(status_rx, agent_tx));
+
+        status_tx.send("Connecting tools...".into()).unwrap();
+        status_tx.send("Memory ready".into()).unwrap();
+        drop(status_tx);
+
+        let mut received = Vec::new();
+        while let Some(ev) = agent_rx.recv().await {
+            received.push(ev);
+        }
+
+        assert_eq!(received.len(), 2);
+        assert!(
+            matches!(&received[0], zeph_tui::AgentEvent::Status(s) if s == "Connecting tools...")
+        );
+        assert!(matches!(&received[1], zeph_tui::AgentEvent::Status(s) if s == "Memory ready"));
+    }
+
+    #[tokio::test]
+    async fn forward_status_to_tui_stops_when_agent_rx_dropped() {
+        let (status_tx, status_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+        let (agent_tx, agent_rx) = tokio::sync::mpsc::channel::<zeph_tui::AgentEvent>(1);
+
+        let handle = tokio::spawn(forward_status_to_tui(status_rx, agent_tx));
+
+        // Drop receiver — forwarder must exit cleanly when send fails.
+        drop(agent_rx);
+
+        status_tx.send("some status".into()).unwrap();
+        // Give the forwarder a chance to detect the closed channel.
+        handle.await.expect("forwarder panicked");
+    }
 
     #[tokio::test]
     async fn forward_tool_events_skips_started_and_completed() {


### PR DESCRIPTION
Fixes #3022

## Summary

- Spawn `forward_status_to_tui` immediately after `early_tui_guard` creation (before MCP init), transferring `status_rx` ownership to the early forwarder so TUI receives status updates during bootstrap
- Change `TuiRunParams.status_rx` to `Option<UnboundedReceiver<String>>`; guard the existing spawn with `if let Some(rx)` to prevent double-consumption
- Add per-server `"Connecting to {server_id}..."` status emission in `connect_all()` — uses only `config.id`, no transport URLs or auth data

## Test plan

- [ ] Run `cargo nextest run --workspace --lib --bins` — 7973 tests pass
- [ ] Start agent with `--tui` and observe MCP connection status updates appear during startup instead of freezing
- [ ] Verify CLI mode (`cargo run`) still works (status_rx recovered via `expect` in non-TUI path)
- [ ] Check `.local/testing/playbooks/` for TUI live test playbook