### PR TITLE
refactor(agent_setup): consolidate suppress_stderr and tui_mode into RuntimeContext

### DIFF
--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use parking_lot::RwLock;
 
+use zeph_core::RuntimeContext;
 use zeph_core::channel::Channel;
 use zeph_core::config::Config;
 use zeph_tools::{
@@ -342,12 +343,11 @@ pub(crate) async fn build_tool_setup(
     config: &Config,
     permission_policy: zeph_tools::PermissionPolicy,
     with_tool_events: bool,
-    suppress_stderr: bool,
+    runtime_ctx: RuntimeContext,
     age_vault: Option<&Arc<tokio::sync::RwLock<zeph_core::vault::AgeVaultProvider>>>,
     status_tx: Option<tokio::sync::mpsc::UnboundedSender<String>>,
     pool: Option<&zeph_db::DbPool>,
     provider: &zeph_llm::any::AnyProvider,
-    tui_mode: bool,
 ) -> ToolSetup {
     let filter_registry = if config.tools.filters.enabled {
         zeph_tools::OutputFilterRegistry::default_filters(&config.tools.filters)
@@ -361,7 +361,7 @@ pub(crate) async fn build_tool_setup(
     let mut audit_logger: Option<Arc<zeph_tools::AuditLogger>> = None;
     if config.tools.audit.enabled
         && let Ok(logger) =
-            zeph_tools::AuditLogger::from_config(&config.tools.audit, tui_mode).await
+            zeph_tools::AuditLogger::from_config(&config.tools.audit, runtime_ctx.tui_mode).await
     {
         let logger = Arc::new(logger);
         shell_executor = shell_executor.with_audit(Arc::clone(&logger));
@@ -395,8 +395,11 @@ pub(crate) async fn build_tool_setup(
             .collect(),
     );
 
-    let mut mcp_manager_builder =
-        crate::bootstrap::create_mcp_manager_with_vault(config, suppress_stderr, age_vault);
+    let mut mcp_manager_builder = crate::bootstrap::create_mcp_manager_with_vault(
+        config,
+        runtime_ctx.suppress_stderr(),
+        age_vault,
+    );
     if let Some(tx) = status_tx {
         mcp_manager_builder = mcp_manager_builder.with_status_tx(tx);
     }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -652,8 +652,6 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         Some(tokio::spawn(async move { warmup_provider(&p).await }))
     };
 
-    let suppress_mcp_stderr = runtime_ctx.suppress_stderr();
-
     // For TUI path: create the channel and start rendering immediately so the user
     // sees a spinner during the heavy init phases below. For non-TUI paths (or when
     // --tui is not passed), channel creation is deferred until after the tokio::join!
@@ -756,12 +754,11 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             config,
             permission_policy.clone(),
             with_tool_events,
-            suppress_mcp_stderr,
+            runtime_ctx,
             app.age_vault_arc(),
             Some(agent_status_tx.clone()),
             Some(memory.sqlite().pool()),
             &provider,
-            runtime_ctx.tui_mode,
         )
         .await
     });
@@ -770,12 +767,11 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         config,
         permission_policy.clone(),
         with_tool_events,
-        suppress_mcp_stderr,
+        runtime_ctx,
         app.age_vault_arc(),
         Some(agent_status_tx.clone()),
         Some(memory.sqlite().pool()),
         &provider,
-        runtime_ctx.tui_mode,
     )
     .await;
 


### PR DESCRIPTION
## Summary

- Replaces two decomposed bool parameters (`suppress_stderr`, `tui_mode`) in `build_tool_setup` with a single `RuntimeContext` argument
- Removes the intermediate `suppress_mcp_stderr` local variable in `runner.rs` — it is no longer needed since the callers now pass `runtime_ctx` directly
- The function body accesses the needed values via `runtime_ctx.suppress_stderr()` and `runtime_ctx.tui_mode`

## Test plan

- [x] `cargo build` — clean
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 7968 passed, 20 skipped

Closes #3021