### PR TITLE
fix(memory): prevent infinite loop in chunk_text when overlap rewinds start

### DIFF
--- a/crates/zeph-memory/src/semantic/recall.rs
+++ b/crates/zeph-memory/src/semantic/recall.rs
@@ -49,12 +49,12 @@ fn chunk_text(text: &str) -> Vec<&str> {
         if end >= text.len() {
             break;
         }
-        // Next chunk starts with overlap.
+        // Next chunk starts with overlap, but must always advance past the
+        // current position to prevent infinite loops when rfind finds a match
+        // very early in the slice (end barely advances, overlap rewinds start).
         let next = end.saturating_sub(CHUNK_OVERLAP_CHARS);
-        start = text.ceil_char_boundary(next);
-        if start >= end {
-            start = end; // safeguard against infinite loop
-        }
+        let new_start = text.ceil_char_boundary(next);
+        start = if new_start > start { new_start } else { end };
     }
 
     chunks


### PR DESCRIPTION
## Summary

- `chunk_text` in `zeph-memory` had an infinite loop triggered by messages where `rfind("\n\n")` found a match very early in the 1600-byte sliding window
- When the match was at offset < 320 bytes, `end` advanced by fewer bytes than `CHUNK_OVERLAP_CHARS`; the overlap subtraction produced a `new_start` behind the current `start`
- The old safeguard (`if start >= end`) did not fire because `new_start < start < end`, so `start` regressed and the loop ran forever
- Fix: `start = if new_start > start { new_start } else { end }` — always guarantees forward progress

## Root Cause Evidence

macOS `sample` profiler on the live zeph process (CPU: 1126%, RAM: ~1 GB) showed all 12 tokio worker threads stuck in:

```
embed_and_store_regular_bg → chunk_text → rfind → StrSearcher::next_match_back
```

SQLite confirmed 12 unembedded messages, including an 85 KB `tool_result` (line-numbered Rust source). The embed backfill spawned background tasks for all of them at startup; all entered the infinite loop simultaneously, saturating the thread pool and blocking log flushing — explaining both the CPU/RAM spike and the frozen TUI status ("Connecting tools...").

## Test plan

- [x] `cargo nextest run -p zeph-memory --lib` — 1114 tests pass
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy -p zeph-memory -- -D warnings` — clean
- [ ] Live session: start agent with existing DB containing unembedded messages, confirm startup completes, CPU stays normal, TUI advances past "Connecting tools..."