### PR TITLE
release: v0.19.1

### DIFF
--- a/.github/deny.toml
+++ b/.github/deny.toml
@@ -13,9 +13,9 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 # rustls-pemfile unmaintained (RUSTSEC-2025-0134, via qdrant-client -> tonic 0.12)
 # Blocked on qdrant/rust-client#255 (tonic 0.14 upgrade removes rustls-pemfile)
 # number_prefix unmaintained (via indicatif -> hf-hub, candle transitive dep)
-# astral-tokio-tar PAX extension validation (RUSTSEC-2026-0066, via testcontainers dev-dep)
-# Fix requires astral-tokio-tar >= 0.6.0 but testcontainers 0.27.1 pins 0.5.x (semver break)
-ignore = ["RUSTSEC-2025-0134", "RUSTSEC-2024-0436", "RUSTSEC-2026-0066"]
+# rand 0.8.5 unsound with custom logger (RUSTSEC-2026-0097, via age v0.11.2)
+# Blocked on age upgrading to rand >=0.9.3; we do not use rand::rng() in any logger
+ignore = ["RUSTSEC-2025-0134", "RUSTSEC-2024-0436", "RUSTSEC-2026-0097"]
 
 [licenses]
 confidence-threshold = 0.93

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,55 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-### Changed
-
-- **RuntimeContext struct** (`#3016`): introduced `zeph_core::RuntimeContext` (`Copy + Clone + Debug + Default + PartialEq + Eq`) carrying `tui_mode` and `daemon_mode` flags. All subsystem initializers in `runner.rs`, `tracing_init.rs`, and `daemon.rs` now receive a single `RuntimeContext` instead of individual `bool` parameters. The `suppress_stderr()` helper centralizes the TUI/daemon stderr suppression decision.
-
-### Fixed
-
-- **CPU/RAM regression: graph community detection OOM** (`#3007`): `detect_communities` in
-  `zeph-memory` now guards `edge_chunk_size = 0` by falling back to `10_000` with a `WARN`
-  log, preventing full edge table load into a single `HashMap` that caused 12 GB RAM spikes.
-
-- **CPU/RAM regression: Qdrant upsert indefinite block** (`#3004`): `upsert_chunks_batch`
-  in `zeph-index` is now wrapped with a 30-second `tokio::time::timeout`. On expiry, the
-  batch is skipped with a `WARN` log and indexing continues instead of stalling indefinitely.
-
-- **CPU/RAM regression: `Box::leak` per indexed file** (`#3005`): `BlockingSpawner::spawn_blocking_named`
-  signature changed from `&'static str` to `Arc<str>` — eliminating the `Box::leak` call in
-  `CodeIndexer::index_file` that accumulated one heap allocation per file watcher event.
-  `TaskEntry`, `TaskSnapshot`, and `Completion` name fields are all `Arc<str>`.
-
-- **CPU regression: file watcher debounce** (`#3006`): `zeph-index` watcher now collects
-  FS events in a 500 ms debounce window (max 5 s cap) and reindexes each changed path
-  at most once per window, preventing CPU saturation during git operations or editor saves.
-
-- **TUI log silence: fallback to platform log directory** (`#3008`): when TUI mode is
-  active with no `logging.file` configured and OTLP is disabled, `tracing_init` now
-  automatically adds a file appender using `default_log_file_path()` (`~/Library/Application Support/Zeph/logs/zeph.log` on macOS) so logs are never silently discarded.
-
-- **`TaskSupervisor` blocking task capacity limit** (`#3009`): a configurable
-  `tokio::sync::Semaphore` (default capacity 8) now gates `spawn_blocking`, preventing
-  uncontrolled thread pool saturation when multiple subsystems index concurrently.
-
-- **Concurrent `index_project` re-entry guard** (`#3010`): `CodeIndexer` tracks an
-  `AtomicBool` flag; a second concurrent call to `index_project` returns
-  `Ok(IndexReport::default())` immediately with an `INFO` log rather than running a
-  redundant full-index pass.
-
-- **OTLP circuit breaker on export failure** (`#3011`): a `CircuitBreakerExporter` wrapper
-  (`src/circuit_breaker_exporter.rs`) opens the circuit after 3 consecutive BSP export
-  failures and applies exponential backoff (5 s → 30 s → 300 s). `open_count` resets on
-  successful export after recovery, preventing permanent 300 s stalls.
-
-- **Audit log silently dropped in TUI mode** (`#3012`): `AuditLogger::from_config` now
-  accepts `tui_mode: bool`; when `destination = stdout` and TUI mode is active, output is
-  redirected to the configured audit file path with a startup `WARN`.
-
-- **`IndexerConfig` safe defaults** (`#3013`): reduced defaults to prevent resource
-  saturation on typical developer machines: `memory_batch_size` 32→16,
-  `embed_concurrency` 2→1, `concurrency` 4→2, `batch_size` (Qdrant) 32→16. All values
-  remain user-configurable.
+## [0.19.1] - 2026-04-15
 
 ### Added
 
@@ -110,7 +62,55 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `supervisor.shutdown_all(10s)` added to the orderly shutdown sequence.
   `start_*` functions in `zeph-memory` now return `impl Future` instead of `JoinHandle`.
 
+### Changed
+
+- **RuntimeContext struct** (`#3016`): introduced `zeph_core::RuntimeContext` (`Copy + Clone + Debug + Default + PartialEq + Eq`) carrying `tui_mode` and `daemon_mode` flags. All subsystem initializers in `runner.rs`, `tracing_init.rs`, and `daemon.rs` now receive a single `RuntimeContext` instead of individual `bool` parameters. The `suppress_stderr()` helper centralizes the TUI/daemon stderr suppression decision.
+
 ### Fixed
+
+- **CPU/RAM regression: graph community detection OOM** (`#3007`): `detect_communities` in
+  `zeph-memory` now guards `edge_chunk_size = 0` by falling back to `10_000` with a `WARN`
+  log, preventing full edge table load into a single `HashMap` that caused 12 GB RAM spikes.
+
+- **CPU/RAM regression: Qdrant upsert indefinite block** (`#3004`): `upsert_chunks_batch`
+  in `zeph-index` is now wrapped with a 30-second `tokio::time::timeout`. On expiry, the
+  batch is skipped with a `WARN` log and indexing continues instead of stalling indefinitely.
+
+- **CPU/RAM regression: `Box::leak` per indexed file** (`#3005`): `BlockingSpawner::spawn_blocking_named`
+  signature changed from `&'static str` to `Arc<str>` — eliminating the `Box::leak` call in
+  `CodeIndexer::index_file` that accumulated one heap allocation per file watcher event.
+  `TaskEntry`, `TaskSnapshot`, and `Completion` name fields are all `Arc<str>`.
+
+- **CPU regression: file watcher debounce** (`#3006`): `zeph-index` watcher now collects
+  FS events in a 500 ms debounce window (max 5 s cap) and reindexes each changed path
+  at most once per window, preventing CPU saturation during git operations or editor saves.
+
+- **TUI log silence: fallback to platform log directory** (`#3008`): when TUI mode is
+  active with no `logging.file` configured and OTLP is disabled, `tracing_init` now
+  automatically adds a file appender using `default_log_file_path()` (`~/Library/Application Support/Zeph/logs/zeph.log` on macOS) so logs are never silently discarded.
+
+- **`TaskSupervisor` blocking task capacity limit** (`#3009`): a configurable
+  `tokio::sync::Semaphore` (default capacity 8) now gates `spawn_blocking`, preventing
+  uncontrolled thread pool saturation when multiple subsystems index concurrently.
+
+- **Concurrent `index_project` re-entry guard** (`#3010`): `CodeIndexer` tracks an
+  `AtomicBool` flag; a second concurrent call to `index_project` returns
+  `Ok(IndexReport::default())` immediately with an `INFO` log rather than running a
+  redundant full-index pass.
+
+- **OTLP circuit breaker on export failure** (`#3011`): a `CircuitBreakerExporter` wrapper
+  (`src/circuit_breaker_exporter.rs`) opens the circuit after 3 consecutive BSP export
+  failures and applies exponential backoff (5 s → 30 s → 300 s). `open_count` resets on
+  successful export after recovery, preventing permanent 300 s stalls.
+
+- **Audit log silently dropped in TUI mode** (`#3012`): `AuditLogger::from_config` now
+  accepts `tui_mode: bool`; when `destination = stdout` and TUI mode is active, output is
+  redirected to the configured audit file path with a startup `WARN`.
+
+- **`IndexerConfig` safe defaults** (`#3013`): reduced defaults to prevent resource
+  saturation on typical developer machines: `memory_batch_size` 32→16,
+  `embed_concurrency` 2→1, `concurrency` 4→2, `batch_size` (Qdrant) 32→16. All values
+  remain user-configurable.
 
 - **TUI: remove per-frame message list clone** (`#2955`): `visible_messages().into_owned()` in
   `chat.rs` replaced with a borrowed reference; eliminates ~20,000 `ChatMessage` clones/sec at
@@ -3985,7 +3985,8 @@ let agent = Agent::new(provider, channel, &skills_prompt, executor);
 - Agent::run() uses tokio::select! to race channel messages against shutdown signal
 
 [0.16.0]: https://github.com/bug-ops/zeph/compare/v0.15.3...v0.16.0
-[Unreleased]: https://github.com/bug-ops/zeph/compare/v0.19.0...HEAD
+[Unreleased]: https://github.com/bug-ops/zeph/compare/v0.19.1...HEAD
+[0.19.1]: https://github.com/bug-ops/zeph/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/bug-ops/zeph/compare/v0.18.6...v0.19.0
 [0.18.6]: https://github.com/bug-ops/zeph/compare/v0.18.5...v0.18.6
 [0.18.5]: https://github.com/bug-ops/zeph/compare/v0.18.4...v0.18.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6314,9 +6314,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9868,7 +9868,7 @@ dependencies = [
 
 [[package]]
 name = "zeph"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9933,7 +9933,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-a2a"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "axum 0.8.8",
  "base64 0.22.1",
@@ -9963,7 +9963,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-acp"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "agent-client-protocol",
  "async-stream",
@@ -10002,7 +10002,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-bench"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "clap",
  "serde",
@@ -10017,7 +10017,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-channels"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "axum 0.8.8",
  "criterion",
@@ -10043,7 +10043,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-commands"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "thiserror 2.0.18",
  "tokio",
@@ -10052,7 +10052,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-common"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "blake3",
  "serde",
@@ -10072,7 +10072,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-config"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "dirs",
  "insta",
@@ -10093,7 +10093,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-context"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "futures",
  "parking_lot",
@@ -10110,7 +10110,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-core"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "age",
  "base64 0.22.1",
@@ -10171,7 +10171,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-db"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "regex",
  "sqlx",
@@ -10184,7 +10184,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-experiments"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "futures",
  "ordered-float 5.3.0",
@@ -10207,7 +10207,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-gateway"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "axum 0.8.8",
  "blake3",
@@ -10226,7 +10226,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-index"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "futures",
  "ignore",
@@ -10260,7 +10260,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-llm"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-stream",
  "audioadapter-buffers",
@@ -10301,7 +10301,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-mcp"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "blake3",
@@ -10332,7 +10332,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-memory"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "blake3",
  "chrono",
@@ -10366,7 +10366,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-orchestration"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "blake3",
  "futures",
@@ -10388,7 +10388,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-sanitizer"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "proptest",
  "regex",
@@ -10408,7 +10408,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-scheduler"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "chrono",
  "cron",
@@ -10426,7 +10426,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-skills"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -10460,7 +10460,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-subagent"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "dirs",
  "indoc",
@@ -10486,7 +10486,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-tools"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "dirs",
  "glob",
@@ -10524,7 +10524,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-tui"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "chrono",
  "crossterm",
@@ -10560,7 +10560,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-vault"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "age",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 rust-version = "1.88"
-version = "0.19.0"
+version = "0.19.1"
 authors = ["bug-ops"]
 license = "MIT"
 repository = "https://github.com/bug-ops/zeph"
@@ -131,30 +131,30 @@ url = "2.5"
 uuid = "1.23"
 wiremock = "0.6.5"
 zeroize = { version = "1", default-features = false }
-zeph-a2a = { path = "crates/zeph-a2a", version = "0.19.0" }
-zeph-bench = { path = "crates/zeph-bench", version = "0.19.0" }
-zeph-acp = { path = "crates/zeph-acp", version = "0.19.0" }
-zeph-db = { path = "crates/zeph-db", default-features = false, version = "0.19.0" }
-zeph-channels = { path = "crates/zeph-channels", version = "0.19.0" }
-zeph-common = { path = "crates/zeph-common", version = "0.19.0" }
-zeph-config = { path = "crates/zeph-config", version = "0.19.0" }
-zeph-commands = { path = "crates/zeph-commands", version = "0.19.0" }
-zeph-context = { path = "crates/zeph-context", version = "0.19.0" }
-zeph-core = { path = "crates/zeph-core", version = "0.19.0" }
-zeph-experiments = { path = "crates/zeph-experiments", version = "0.19.0" }
-zeph-gateway = { path = "crates/zeph-gateway", version = "0.19.0" }
-zeph-index = { path = "crates/zeph-index", version = "0.19.0" }
-zeph-llm = { path = "crates/zeph-llm", version = "0.19.0" }
-zeph-mcp = { path = "crates/zeph-mcp", version = "0.19.0" }
-zeph-memory = { path = "crates/zeph-memory", default-features = false, version = "0.19.0" }
-zeph-scheduler = { path = "crates/zeph-scheduler", version = "0.19.0" }
-zeph-skills = { path = "crates/zeph-skills", version = "0.19.0" }
-zeph-tools = { path = "crates/zeph-tools", version = "0.19.0" }
-zeph-tui = { path = "crates/zeph-tui", version = "0.19.0" }
-zeph-vault = { path = "crates/zeph-vault", version = "0.19.0" }
-zeph-orchestration = { path = "crates/zeph-orchestration", version = "0.19.0" }
-zeph-sanitizer = { path = "crates/zeph-sanitizer", version = "0.19.0" }
-zeph-subagent = { path = "crates/zeph-subagent", version = "0.19.0" }
+zeph-a2a = { path = "crates/zeph-a2a", version = "0.19.1" }
+zeph-bench = { path = "crates/zeph-bench", version = "0.19.1" }
+zeph-acp = { path = "crates/zeph-acp", version = "0.19.1" }
+zeph-db = { path = "crates/zeph-db", default-features = false, version = "0.19.1" }
+zeph-channels = { path = "crates/zeph-channels", version = "0.19.1" }
+zeph-common = { path = "crates/zeph-common", version = "0.19.1" }
+zeph-config = { path = "crates/zeph-config", version = "0.19.1" }
+zeph-commands = { path = "crates/zeph-commands", version = "0.19.1" }
+zeph-context = { path = "crates/zeph-context", version = "0.19.1" }
+zeph-core = { path = "crates/zeph-core", version = "0.19.1" }
+zeph-experiments = { path = "crates/zeph-experiments", version = "0.19.1" }
+zeph-gateway = { path = "crates/zeph-gateway", version = "0.19.1" }
+zeph-index = { path = "crates/zeph-index", version = "0.19.1" }
+zeph-llm = { path = "crates/zeph-llm", version = "0.19.1" }
+zeph-mcp = { path = "crates/zeph-mcp", version = "0.19.1" }
+zeph-memory = { path = "crates/zeph-memory", default-features = false, version = "0.19.1" }
+zeph-scheduler = { path = "crates/zeph-scheduler", version = "0.19.1" }
+zeph-skills = { path = "crates/zeph-skills", version = "0.19.1" }
+zeph-tools = { path = "crates/zeph-tools", version = "0.19.1" }
+zeph-tui = { path = "crates/zeph-tui", version = "0.19.1" }
+zeph-vault = { path = "crates/zeph-vault", version = "0.19.1" }
+zeph-orchestration = { path = "crates/zeph-orchestration", version = "0.19.1" }
+zeph-sanitizer = { path = "crates/zeph-sanitizer", version = "0.19.1" }
+zeph-subagent = { path = "crates/zeph-subagent", version = "0.19.1" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   [![Crates.io](https://img.shields.io/crates/v/zeph)](https://crates.io/crates/zeph)
   [![docs](https://img.shields.io/badge/docs-book-blue)](https://bug-ops.github.io/zeph/)
   [![CI](https://img.shields.io/github/actions/workflow/status/bug-ops/zeph/ci.yml?branch=main&label=CI)](https://github.com/bug-ops/zeph/actions)
-  [![Tests](https://img.shields.io/badge/tests-8238-brightgreen)](https://github.com/bug-ops/zeph/actions)
+  [![Tests](https://img.shields.io/badge/tests-7973-brightgreen)](https://github.com/bug-ops/zeph/actions)
   [![codecov](https://codecov.io/gh/bug-ops/zeph/graph/badge.svg?token=S5O0GR9U6G)](https://codecov.io/gh/bug-ops/zeph)
   [![Crates](https://img.shields.io/badge/crates-25-orange)](https://github.com/bug-ops/zeph/tree/main/crates)
   [![MSRV](https://img.shields.io/badge/MSRV-1.88-blue)](https://www.rust-lang.org)

--- a/book/src/advanced/code-indexing.md
+++ b/book/src/advanced/code-indexing.md
@@ -135,7 +135,7 @@ On subsequent runs, the indexer skips unchanged chunks by checking BLAKE3 conten
 
 ## File Watcher
 
-When `watch = true` (default), an `IndexWatcher` monitors project files for changes during the session. On file modification, the changed file is automatically re-indexed via `reindex_file()` without rebuilding the entire index. The watcher uses 1-second debounce to batch rapid changes and only processes files with indexable extensions.
+When `watch = true` (default), an `IndexWatcher` monitors project files for changes during the session. On file modification, the changed file is automatically re-indexed via `reindex_file()` without rebuilding the entire index. The watcher uses 500ms debounce to batch rapid changes and only processes files with indexable extensions.
 
 Disable with:
 
@@ -143,6 +143,24 @@ Disable with:
 [index]
 watch = false
 ```
+
+## Task Supervision
+
+Code indexing integrates with the `TaskSupervisor` for observability of concurrent embedding operations. When `embed_concurrency > 1`, each chunk embedding is registered as a separate supervised task (`chunk_file_{N}`), making individual embedding progress visible in the TUI task registry and tracing systems.
+
+Access the task registry via the TUI command palette:
+
+```
+Ctrl+P -> /tasks
+```
+
+This displays a live table of all supervised tasks, including:
+
+- **Chunk embeddings**: Individual file chunks being embedded
+- **Background indexers**: Automatic re-indexing of modified files
+- **Refresh cycles**: Periodic re-index operations
+
+Each task shows: name, state (Running/Waiting), uptime since last restart, and restart count. This enables fine-grained debugging of indexing performance bottlenecks.
 
 ## Repo Map
 

--- a/book/src/advanced/observability.md
+++ b/book/src/advanced/observability.md
@@ -72,3 +72,69 @@ The same table is available in the TUI via the `/cost` command. Providers are so
 ### Token Counting
 
 Completion token counts use the `output_tokens` field from the API response (OpenAI, Ollama, and Compatible providers). Streaming paths retain a byte-length heuristic (`response.len() / 4`) as a fallback when the provider returns no usage data. Structured-output calls (`chat_typed`) also record usage so `eval_budget_tokens` enforcement reflects real token counts.
+
+## TaskSupervisor Metrics
+
+Zeph uses a `TaskSupervisor` to manage background tasks (embedding, memory consolidation, file watching, etc.). Task metrics provide CPU and wall-time measurement for performance debugging.
+
+### Enabling Task Metrics
+
+Enable the optional `task-metrics` feature (included in `full`):
+
+```bash
+cargo build --release --features task-metrics
+```
+
+When enabled, each supervised task records:
+
+- **Wall-time**: elapsed time from spawn to completion
+- **CPU-time**: actual CPU cycles spent (OS-level thread time measurement)
+
+Zero overhead when disabled — the feature gate compiles out the measurement code.
+
+### Viewing Task Metrics
+
+**In the TUI**, open the task registry via command palette:
+
+```
+Ctrl+P -> /tasks
+```
+
+Shows a live table of all active/completed tasks:
+
+| Column | Meaning |
+|--------|---------|
+| Name | Task identifier (e.g., `chunk_file_42`, `memory_eviction`) |
+| State | Running / Waiting / Completed / Aborted |
+| Uptime | Seconds since last restart |
+| Restarts | Number of times task has restarted |
+
+**In Jaeger traces**, task metrics appear as span attributes:
+
+- `task.wall_time_ms` — total elapsed time
+- `task.cpu_time_ms` — CPU time actually spent
+- `task.name` — task identifier
+
+**Via metrics export**, histograms are emitted to OTLP:
+
+```
+zeph.task.wall_time_ms    # milliseconds
+zeph.task.cpu_time_ms     # milliseconds
+```
+
+Use `tokio-console` for real-time task monitoring when connecting to a running Zeph instance.
+
+### Example: Debugging Slow Indexing
+
+If code indexing is slow, check the task registry:
+
+```
+Name              State   Uptime  Restarts
+────────────────────────────────────────────
+chunk_file_12     Done    2345ms  0
+chunk_file_13     Done    1890ms  0
+chunk_file_14     Running 523ms   0
+indexer_refresh   Done    5400ms  0
+```
+
+High wall-time with low CPU-time suggests I/O blocking (network, disk). High CPU-time suggests compute-heavy embedding. View the Jaeger trace for `chunk_file_14` to see where time is spent in the embedding pipeline.

--- a/book/src/advanced/tui.md
+++ b/book/src/advanced/tui.md
@@ -153,6 +153,7 @@ Available commands:
 | `plan:cancel` | Cancel the active plan | |
 | `plan:list` | List recent plans from persistence | |
 | `plan:toggle` | Toggle Plan View on/off in the side panel | `p` |
+| `tasks:list` | Show task registry with live metrics (name, state, uptime, restart count) | |
 
 View commands are read-only. Action commands (`session:new`, `app:quit`, `app:theme`) modify application state. Daemon commands manage the remote connection (see [Daemon Mode](../guides/daemon-mode.md)). The palette supports fuzzy matching on both command IDs and labels.
 

--- a/book/src/changelog.md
+++ b/book/src/changelog.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.19.1] - 2026-04-15
+
+### Added
+
+- **TaskSupervisor observability** — CPU and wall-time metrics for supervised tasks, visible in Jaeger traces and tokio-console. Optional `task-metrics` feature (included in `full`). See [Observability & Cost](advanced/observability.md#task-supervisor-metrics).
+- **TUI task registry panel** — new `/tasks` command displays live table of all supervised tasks (name, state, uptime, restart count). See [TUI Dashboard](advanced/tui.md#command-palette).
+- **Per-chunk code indexing supervision** — `CodeIndexer` now integrates with `TaskSupervisor` for fine-grained visibility of concurrent embedding tasks. Each chunk operation is registered as a separate task (`chunk_file_{N}`) in the supervisor registry.
+- **Bootstrap TaskSupervisor migration** — 7 memory background loops (eviction, tier promotion, consolidation, forgetting, compression, tree consolidation) migrated to `TaskSupervisor` with restart policies.
+
+### Changed
+
+- **RuntimeContext consolidation** — new `RuntimeContext` struct carries runtime mode flags (`tui_mode`, `daemon_mode`). All subsystem initializers now accept a single `RuntimeContext` instead of individual `bool` parameters.
+
+### Fixed
+
+- **CPU/RAM regressions** — graph community detection OOM guard, Qdrant upsert timeout (30s), `Box::leak` eliminated via `Arc<str>`, file watcher debounce (500ms), TUI log fallback to platform log directory, blocking task capacity limits, concurrent `index_project` re-entry guard, OTLP circuit breaker, audit log TUI redirect, and safe `IndexerConfig` defaults.
+- **TUI performance** — eliminated per-frame message list clones (20K clones/sec), reduced context assembler pre-allocation for large-context providers.
+
+For full details, see the [GitHub release](https://github.com/rabstolowski/zeph/releases/tag/v0.19.1).
+
 ## [0.19.0] - 2026-04-13
 
 ### Changed

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__splash__tests__splash_default.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__splash__tests__splash_default.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/zeph-tui/src/widgets/splash.rs
-assertion_line: 79
 expression: output
 ---
 ┌──────────────────────────────────────────────────────────┐
@@ -15,7 +14,7 @@ expression: output
 │              ███████╗███████╗██║     ██║  ██║            │
 │              ╚══════╝╚══════╝╚═╝     ╚═╝  ╚═╝            │
 │                                                          │
-│                          v0.19.0                         │
+│                          v0.19.1                         │
 │                                                          │
 │                  Type a message to start.                │
 │                                                          │

--- a/specs/001-system-invariants/spec.md
+++ b/specs/001-system-invariants/spec.md
@@ -254,6 +254,17 @@ Every new feature MUST be wired at all applicable integration points:
 
 **NEVER**: block the agent loop in a hook; store `Box<dyn RuntimeLayer>` in the agent (use `Arc<dyn RuntimeLayer>`).
 
+## 16. RuntimeContext Contract
+
+`RuntimeContext` (`zeph_core::RuntimeContext`, `Copy + Clone + Debug + Default + PartialEq + Eq`) is the single carrier for process-scoped runtime mode flags:
+
+- Fields: `tui_mode: bool`, `daemon_mode: bool`
+- Passed as a single parameter to all subsystem initializers in `runner.rs`, `tracing_init.rs`, and `daemon.rs` — never passed as individual `bool` parameters
+- `suppress_stderr()` helper method centralizes the TUI/daemon stderr suppression decision — never inline it
+- `Default` = `RuntimeContext { tui_mode: false, daemon_mode: false }` (CLI mode)
+
+**NEVER**: add `tui_mode: bool` or `daemon_mode: bool` as separate parameters to subsystem init functions; always pass `RuntimeContext`.
+
 ---
 
 ## Agent Boundaries
@@ -287,3 +298,4 @@ Every new feature MUST be wired at all applicable integration points:
 - Enable `sqlite` and `postgres` features simultaneously
 - Use `sqlx::Any` backend
 - Block the agent loop in a `RuntimeLayer` hook
+- Pass `tui_mode` or `daemon_mode` as individual `bool` parameters to subsystem initializers (use `RuntimeContext`)

--- a/specs/011-tui/spec.md
+++ b/specs/011-tui/spec.md
@@ -60,6 +60,7 @@ TuiApp
 | Plan View | `p` | DAG task graph, task states |
 | Security | `s` | Content sanitizer status, quarantine events |
 | SubAgents | `a` | Interactive subagent sidebar with j/k navigation and transcript viewer |
+| Task Registry | `/tasks` | Live table of all supervised tasks (see below) |
 | Status Bar | always | Current operation spinner + short status text |
 
 Tab cycling order includes SubAgents. See `026-tui-subagent-management/spec.md` for full SubAgents panel spec.
@@ -109,7 +110,26 @@ All `/commands` are parsed from chat input:
 /skills            — list active skills
 /models            — list available models
 /sec               — show security panel
+/tasks             — toggle TaskRegistryWidget (supervised task list)
 ```
+
+## TaskRegistryWidget
+
+`crates/zeph-tui/src/widgets/task_registry.rs` renders a live table of all tasks registered in `TaskSupervisor`:
+
+| Column | Content |
+|--------|---------|
+| Spinner | Animated spinner when state is `Running` |
+| Name | Task name (`Arc<str>`) |
+| Origin | Crate that spawned the task |
+| State | `Running`, `Aborted`, `Completed`, `Failed` |
+| Uptime | Duration since last restart |
+| Restarts | Restart count |
+
+- Toggled via `/tasks` command
+- Shows a placeholder row when `TaskSupervisor` is unavailable
+- Refreshes at the existing 10 fps render interval — no additional timer
+- Calls `supervisor.list_tasks()` each frame to populate the table
 
 ## RenderCache
 
@@ -129,6 +149,22 @@ Backfilling embeddings: {done}/{total} ({pct}%)
 
 This is driven by a `tokio::sync::watch` channel from `spawn_embed_backfill()`. The status clears automatically when the channel signals `None` (completion or timeout). No spinner is used — the fraction display is the progress indicator.
 
+## Log Fallback to Platform Log Directory
+
+When TUI mode is active with no `logging.file` configured and OTLP is disabled, `tracing_init` automatically adds a file appender using `default_log_file_path()`:
+
+- macOS: `~/Library/Application Support/Zeph/logs/zeph.log`
+
+This prevents logs from being silently discarded when stdout/stderr are suppressed by the TUI renderer.
+
+## Audit Log Redirect in TUI Mode
+
+`AuditLogger::from_config` accepts `tui_mode: bool`. When `destination = stdout` and TUI mode is active, audit output is redirected to the configured audit file path with a startup `WARN`. Audit logs are never silently dropped.
+
+## Per-Frame Clone Elimination
+
+`visible_messages()` returns a borrowed reference (`Cow::Borrowed`) instead of cloning the message list. This eliminates ~20,000 `ChatMessage` clones/sec at 2000-message history, reducing idle CPU usage proportional to history depth.
+
 ## Key Invariants
 
 - Metrics updated every turn — not only when a specific event fires
@@ -138,3 +174,5 @@ This is driven by a `tokio::sync::watch` channel from `spawn_embed_backfill()`. 
 - No blocking I/O on the TUI render thread — all heavy work offloaded to tokio tasks
 - `RenderCache::clear()` must release memory — never retain stale entries after `/clear`
 - `RenderCache::shift()` must be used (not `clear()`) when only leading messages are evicted
+- When `destination = stdout` audit log conflicts with TUI, redirect to file — never drop silently
+- When TUI suppresses stderr with no log file configured, use platform log dir — never discard logs

--- a/specs/012-graph-memory/spec.md
+++ b/specs/012-graph-memory/spec.md
@@ -136,6 +136,7 @@ The background extraction must **not block the agent loop**.
 - `EntityResolver` checks embedding similarity before LLM disambiguation (LLM is expensive)
 - FTS5 prefix search is mandatory — pure embedding search is not sufficient fallback
 - Community fingerprint (BLAKE3) must be recomputed when membership or edges change
+- `detect_communities`: `edge_chunk_size = 0` is invalid — fall back to `10_000` with a `WARN` log; never load the full edge table into a single `HashMap`
 
 ---
 

--- a/specs/017-index/spec.md
+++ b/specs/017-index/spec.md
@@ -91,10 +91,39 @@ CodeSymbol {
 
 ## Background Indexing
 
-- Runs in `tokio::spawn` at startup — **never blocks agent loop**
+- Runs via `TaskSupervisor::spawn_restartable` (or plain `tokio::spawn` if supervisor absent) — **never blocks agent loop**
 - Progress broadcasted via `tokio::watch` channel: `IndexProgress { files_done, files_total, chunks_created }`
 - TUI status bar shows: `Indexing repository… (N/M files)` with spinner during indexing
 - File watcher (`notify` crate) triggers incremental re-index on file changes
+
+### File Watcher Debounce
+
+FS events are collected in a **500 ms debounce window** (max 5 s cap). Each changed path is reindexed at most once per window. This prevents CPU saturation during git operations or editor saves that generate rapid bursts of events.
+
+### Qdrant Upsert Timeout
+
+`upsert_chunks_batch` is wrapped with a **30-second `tokio::time::timeout`**. On expiry the batch is skipped with a `WARN` log and indexing continues. This prevents indefinite stalls when Qdrant is slow or unavailable.
+
+### Re-entry Guard
+
+`CodeIndexer` tracks an `AtomicBool` flag. A second concurrent call to `index_project` returns `Ok(IndexReport::default())` immediately with an `INFO` log rather than running a redundant full-index pass.
+
+### BlockingSpawner Integration
+
+`CodeIndexer` accepts `Option<Arc<dyn BlockingSpawner>>` via a `with_spawner()` builder method. When a spawner is present, each `chunk_file` invocation is dispatched as a named blocking task (`chunk_file_{N}`, unique AtomicU64 counter) so concurrent indexing passes are fully visible in `TaskSupervisor::list_tasks()`. When absent, chunking runs inline. See [[039-background-task-supervisor/spec]] and [[043-zeph-common/spec]] for the `BlockingSpawner` trait.
+
+### IndexerConfig Safe Defaults
+
+Default values are tuned for developer machines to prevent resource saturation:
+
+| Field | Old Default | New Default |
+|-------|------------|-------------|
+| `memory_batch_size` | 32 | 16 |
+| `embed_concurrency` | 2 | 1 |
+| `concurrency` | 4 | 2 |
+| `batch_size` (Qdrant) | 32 | 16 |
+
+All values remain user-configurable via `[index]` config section.
 
 ## Repo Map
 
@@ -122,3 +151,7 @@ crates/zeph-core/src/agent/mod.rs
 - TUI must show indexing progress with spinner while background indexing runs
 - Invalid syntax files → log error in `IndexReport.errors`, skip — never panic
 - One collection per project root hash — cross-project mixing is forbidden
+- File watcher debounce window is 500 ms — reindex each path at most once per window
+- Qdrant upsert has a 30s timeout — on expiry, skip batch with WARN, never stall indefinitely
+- `index_project` re-entry is guarded by `AtomicBool` — second concurrent call returns immediately
+- Task names are `Arc<str>` — never `&'static str` or `Box::leak` in `BlockingSpawner` calls

--- a/specs/039-background-task-supervisor/spec.md
+++ b/specs/039-background-task-supervisor/spec.md
@@ -9,25 +9,27 @@ tags:
   - concurrency
   - background-work
 created: 2026-04-11
-status: partial
+status: approved
 related:
   - "[[MOC-specs]]"
   - "[[002-agent-loop/spec]]"
   - "[[036-prometheus-metrics/spec]]"
   - "[[001-system-invariants/spec#5. Concurrency Contract]]"
+  - "[[043-zeph-common/spec]]"
 ---
 
 # Spec: Supervised Background Task Manager
 
 > [!info]
-> **Phase 1 (core supervisor, JoinSet, per-class limits, drop policy, metrics)** is implemented as of PR #2816 (commit 81f2d28a).
-> This spec documents the Phase 1 implementation and tracks Phase 2 enhancements in GitHub Epic #2883.
+> **v0.19.1**: `TaskSupervisor` is the unified lifecycle manager for all supervised background
+> work. Phase 2 enhancements are complete. Leaf crates (`TelegramChannel`, `A2aServer`,
+> background indexer) are migrated. Bootstrap memory loops use `TaskSupervisor`. CPU/wall-time
+> metrics, blocking semaphore, `BlockingSpawner` trait, and TUI task registry are shipped.
 
-**Issue**: #2816  
-**Epic**: #2883  
-**Status**: Phase 1 complete, Phase 2 in design  
-**Crate**: `zeph-core::agent::supervisor`  
-**Dependencies**: spec [[002-agent-loop/spec]], [[036-prometheus-metrics/spec]]
+**Issues**: #2816 (Phase 1), #2958 #2960 #2961 #2963 #2978 (Phase 2 / v0.19.1)  
+**Status**: Complete  
+**Crate**: `zeph-core::agent::supervisor`, `zeph-common` (BlockingSpawner trait)  
+**Dependencies**: spec [[002-agent-loop/spec]], [[036-prometheus-metrics/spec]], [[043-zeph-common/spec]]
 
 ---
 
@@ -79,27 +81,40 @@ A lightweight supervisor that:
 4. Exports per-class metrics for observability
 5. Cleans up all tasks at agent shutdown with `abort_all()`
 
-### 2.1 Phase 1 Implementation
+### 2.1 Implementation (Complete)
 
-**Struct**: `BackgroundSupervisor` at `crates/zeph-core/src/agent/supervisor.rs`
+**Struct**: `TaskSupervisor` at `crates/zeph-core/src/agent/supervisor.rs`
 
 **Key design**:
-- Owned by `LifecycleState` (single agent per session), accessed via `&mut self` — no locks needed
+- Shared via `Arc<TaskSupervisor>` — usable by leaf crates without `zeph-core` ownership
 - Per-class inflight counter using `Arc<AtomicUsize>` (read-only from spawned tasks)
-- RAII `InflightGuard` decrements inflight immediately on task completion (not at `reap()` time)
+- RAII `InflightGuard` decrements inflight immediately on task completion
 - `reap()` called non-blocking at turn boundary to drain completed tasks
-- `abort_all()` called on agent shutdown (no graceful drain — tasks are lossy by design)
+- `shutdown_all(timeout)` called on agent shutdown — drains completions before exiting, then aborts remaining tasks
+- Task names are `Arc<str>` — no `Box::leak` or `&'static str` required
+- `spawn_blocking` routes through a `tokio::sync::Semaphore` (default capacity 8) to bound OS thread pool usage
+- `spawn_restartable` supports `RestartPolicy::Restart { max, base_delay }` with exponential backoff
+- All tasks visible in `list_tasks()` / `TaskSnapshot` for TUI and observability
 
 **Location in agent loop**:
 ```
 persistence.rs:
-  - spawn_summarization()        [line 602]
-  - spawn() for enrichment tasks [lines 734, 780, 880, 942]
+  - spawn_summarization()        — summarization signal
+  - spawn() for enrichment tasks — graph/persona/trajectory/audit
 corrections.rs:
-  - spawn() for audit tasks     [lines 122, 173]
+  - spawn() for audit tasks
 mod.rs:
-  - reap() at turn boundary     [line 1047]
-  - abort_all() on shutdown     [line 646]
+  - reap() at turn boundary
+  - supervisor.shutdown_all(10s) on orderly shutdown
+runner.rs:
+  - 7 memory background loops registered via supervisor (RestartPolicy::RunOnce)
+  - Single shutdown_rx → CancellationToken bridge (replaces 7 per-loop bridges)
+daemon.rs:
+  - A2aServer registered via supervisor (RestartPolicy::RunOnce)
+agent_setup.rs:
+  - Background indexer routed through supervisor when present
+zeph-channels:
+  - TelegramChannel dispatcher via supervisor (RestartPolicy::Restart { max: 5, base_delay: 2s })
 ```
 
 ### 2.2 Architecture
@@ -176,57 +191,93 @@ telemetry_limit = 8
 
 ### 4.3 Turn-Boundary Cleanup
 
-**Phase 1 status**: Turn-boundary abort does NOT happen automatically. Tasks continue across turn boundaries.
-
-**Phase 2D (#2887)**: Explicit `abort_class(TaskClass::Enrichment)` call to be added at turn boundary in agent loop to prevent backlog buildup.
+`abort_class(TaskClass::Enrichment)` is available and called at turn boundary (if configured via `abort_enrichment_on_turn`). See `TaskSupervisorConfig` in Section 5.1.
 
 ---
 
-## 5. Integration with Agent Loop (Phase 1)
+## 5. Integration
 
 ### 5.1 API
 
 ```rust
-pub(crate) struct BackgroundSupervisor {
-    tasks: JoinSet<TaskResult>,
-    class_inflight: [Arc<AtomicUsize>; NUM_CLASSES],
-    class_metrics: [ClassMetrics; NUM_CLASSES],
+pub struct TaskSupervisor {
+    // internal JoinSet + per-class state + blocking semaphore
 }
 
-impl BackgroundSupervisor {
-    /// Create a new supervisor for the agent session.
-    pub(crate) fn new() -> Self { ... }
-    
-    /// Spawn a background task under `class`.
-    /// Returns `true` when accepted, `false` when dropped due to class limit.
-    pub(crate) fn spawn(
-        &mut self,
+impl TaskSupervisor {
+    pub fn new(config: &TaskSupervisorConfig) -> Arc<Self>;
+
+    /// Spawn an async background task under `class`.
+    /// Returns true when accepted, false when dropped due to class limit.
+    pub fn spawn(
+        &self,
         class: TaskClass,
-        name: &'static str,
+        name: Arc<str>,
         fut: impl Future<Output = ()> + Send + 'static,
-    ) -> bool { ... }
-    
-    /// Variant for summarization tasks that signal completion via `SummarizationSignal`.
-    pub(crate) fn spawn_summarization(
-        &mut self,
-        name: &'static str,
+    ) -> bool;
+
+    /// Spawn a restartable task with the given restart policy.
+    pub fn spawn_restartable(
+        &self,
+        name: Arc<str>,
+        policy: RestartPolicy,
+        fut: impl Fn() -> BoxFuture<'static, ()> + Send + Sync + 'static,
+    );
+
+    /// Spawn a CPU-bound blocking task via OS thread pool (gated by semaphore).
+    pub fn spawn_blocking(
+        &self,
+        name: Arc<str>,
+        f: impl FnOnce() + Send + 'static,
+    );
+
+    /// Variant for summarization tasks that signal completion via SummarizationSignal.
+    pub fn spawn_summarization(
+        &self,
+        name: Arc<str>,
         fut: impl Future<Output = bool> + Send + 'static,
-    ) -> bool { ... }
-    
+    ) -> bool;
+
     /// Poll all completed tasks without blocking.
-    /// Returns `SummarizationSignal` if background summarization completed.
-    pub(crate) fn reap(&mut self) -> SummarizationSignal { ... }
-    
-    /// Abort all inflight tasks immediately (called at agent shutdown).
-    pub(crate) fn abort_all(&mut self) { ... }
-    
-    /// Get total inflight task count across all classes.
-    pub(crate) fn inflight(&self) -> usize { ... }
-    
-    /// Snapshot of current metrics (spawned / dropped / completed per class).
-    pub(crate) fn metrics_snapshot(&self) -> SupervisorMetrics { ... }
+    pub fn reap(&self) -> SummarizationSignal;
+
+    /// Gracefully drain completions, then abort remaining tasks after `timeout`.
+    pub async fn shutdown_all(&self, timeout: Duration);
+
+    /// Abort all tasks in a class immediately.
+    pub fn abort_class(&self, class: TaskClass);
+
+    /// Snapshot all registered tasks (name, state, uptime, restart count).
+    pub fn list_tasks(&self) -> Vec<TaskSnapshot>;
+
+    /// Per-class metrics snapshot.
+    pub fn metrics_snapshot(&self) -> SupervisorMetrics;
+}
+
+/// Config struct (nested in AgentConfig as `agent.supervisor`).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct TaskSupervisorConfig {
+    pub enrichment_limit: usize,          // default: 4
+    pub telemetry_limit: usize,           // default: 8
+    pub blocking_semaphore_capacity: u32, // default: 8
+    pub abort_enrichment_on_turn: bool,   // default: false
 }
 ```
+
+### 5.2 BlockingSpawner Trait
+
+`BlockingSpawner` is defined in `zeph-common` to break the `zeph-core → zeph-index` crate cycle:
+
+```rust
+// zeph-common::blocking_spawner
+pub trait BlockingSpawner: Send + Sync + 'static {
+    fn spawn_blocking_named(&self, name: Arc<str>, f: Box<dyn FnOnce() + Send + 'static>);
+}
+```
+
+`TaskSupervisor` in `zeph-core` implements `BlockingSpawner` by delegating to its `spawn_blocking` method. `CodeIndexer` in `zeph-index` accepts `Option<Arc<dyn BlockingSpawner>>` via a `with_spawner()` builder. Each `chunk_file` invocation uses a unique task name `chunk_file_{N}` (AtomicU64 counter) so concurrent indexing sessions are fully visible in `list_tasks()`.
+
+See [[043-zeph-common/spec]] for the `BlockingSpawner` trait definition.
 
 ### 5.2 Usage Pattern
 
@@ -268,7 +319,7 @@ self.lifecycle.supervisor.abort_all();
 
 ## 6. Observability & Metrics (Phase 1 & Phase 2)
 
-### 6.1 Phase 1 Metrics (Implemented)
+### 6.1 Metrics (Implemented)
 
 The supervisor tracks per-class counters in `ClassMetrics`:
 
@@ -281,25 +332,20 @@ The supervisor tracks per-class counters in `ClassMetrics`:
 
 Metrics are snapshottable via `metrics_snapshot()` for logging and TUI display.
 
-### 6.2 Phase 2B: Per-Class Latency Histogram (#2885)
+### 6.2 CPU/Wall-Time Metrics (task-metrics feature)
 
-**Not yet implemented**. Future enhancement to track task completion time:
+When the `task-metrics` feature is enabled (included in `full`), `spawn_blocking` wraps each task with `cpu-time::ThreadTime` + `Instant` measurements and emits:
 
-```
-bg_latency_seconds histogram
-  labels: class (enrichment | telemetry)
-  buckets: [0.001, 0.01, 0.1, 0.5, 1.0, 5.0]
-```
+- `metrics::histogram!("zeph.task.cpu_time_ms")` — CPU time per blocking task
+- `metrics::histogram!("zeph.task.wall_time_ms")` — wall time per blocking task
 
-### 6.3 Phase 2C: TUI Status Display (#2886)
+Both histogram values are also recorded as tracing span fields `task.cpu_time_ms` and `task.wall_time_ms`, visible in Jaeger and tokio-console.
 
-**Not yet implemented**. Future enhancement to show background task counts in TUI status bar:
+Zero overhead when the feature is disabled (`#[inline]` identity fn, no deps linked).
 
-```
-bg: 2 enrich, 1 telem | ↻ summarizing...
-```
+### 6.3 TUI Task Registry Panel
 
-Meaning: 2 enrichment tasks inflight, 1 telemetry task, with current operation being summarization.
+See [[011-tui/spec]] for `TaskRegistryWidget` and `/tasks` command. The widget calls `supervisor.list_tasks()` each render cycle to populate its table.
 
 ---
 
@@ -334,23 +380,26 @@ TRACE: background task dropped class=enrichment task=graph-extract limit=4
 ## 8. Key Invariants
 
 ### Always
-- All spawned tasks are tracked in a `JoinSet<TaskResult>` (never dropped, never orphaned)
+- All supervised tasks are tracked in the internal `JoinSet` + task registry (never orphaned)
 - Per-class inflight counters are updated atomically via `Arc<AtomicUsize>`
 - When a task completes, its inflight slot is freed immediately (via `InflightGuard` drop)
 - `reap()` is non-blocking and idempotent — safe to call every turn
-- Enrichment class tasks can be dropped at concurrency limit without data loss
-- Telemetry class tasks are dropped when limit is exceeded
-- At agent shutdown, `abort_all()` cancels all inflight tasks gracefully
+- `shutdown_all(timeout)` drains completions before timeout, then aborts remaining tasks
+- Task names are `Arc<str>` — never `&'static str` or `Box::leak`
+- `spawn_blocking` is gated by the blocking semaphore (default capacity 8)
+- `spawn_restartable` uses exponential backoff for `RestartPolicy::Restart`
+- `list_tasks()` includes blocking tasks and oneshot tasks — fully observable
 - Metrics snapshots are consistent (spawned ≥ dropped + completed at any point in time)
 
 ### Ask First
-- Adding new background task spawn sites outside the supervisor (escalate to team lead for decision)
+- Adding new background task spawn sites outside the supervisor
 - Changing per-class concurrency limits without testing load behavior
+- Increasing blocking semaphore capacity above 8
 
 ### Never
-- Spawn a task with `tokio::spawn()` directly — always use `supervisor.spawn()` or `spawn_summarization()`
+- Spawn a task with `tokio::spawn()` directly — always use `supervisor.spawn()`, `spawn_restartable()`, `spawn_blocking()`, or `spawn_summarization()`
 - Hold a lock across `supervisor.spawn()` call (deadlock risk with the inflight atomic)
-- Allow background tasks to panic — all spawned futures must be wrapped in proper error handling
+- Allow background tasks to panic — all spawned futures must use proper error handling
 - Assume a background task completed successfully without checking metrics
 
 ---
@@ -405,9 +454,10 @@ Benefits:
 
 The following systems are **explicitly excluded** from the supervisor's purview:
 
-- **Infrastructure loops** (~18 process-scoped `tokio::spawn` calls): Memory sweeps, channel watchers, session digest threads, scheduler loops. These have their own `CancellationToken` lifecycle, are NOT turn-scoped, and belong to their own subsystem lifecycle managers. Do NOT wrap these in `BackgroundSupervisor`.
+- **Scheduler cron loops**: The `zeph-scheduler` cron loop has its own `CancellationToken` lifecycle and is not turn-scoped. Do not wrap it in `TaskSupervisor`.
 - **Critical path tasks**: LLM calls, tool execution, message persistence. These run on the foreground `await` path with timeout guards and are not background work.
-- **Task coalescing and kind tracking**: Deduplication of identical task kinds is a Phase 2 enhancement and not part of Phase 1.
+- **Session digest on shutdown**: `spawn_outgoing_digest()` uses a plain `tokio::spawn` at shutdown because it requires access to fields that would create a borrow conflict with `supervisor.spawn()` at the session-close boundary.
+- **Task coalescing and deduplication**: Multiple spawns of the same task kind are not coalesced — each spawn gets a unique entry in the registry.
 - **Turn-boundary abort**: Automatic cleanup of enrichment tasks at turn boundaries is Phase 2D (#2887).
 
 ---
@@ -431,263 +481,21 @@ The following systems are **explicitly excluded** from the supervisor's purview:
 
 ## 12. Success Criteria
 
-### Phase 1 (Completed)
-
-- [x] `BackgroundSupervisor` struct compiles and integrates with agent loop (PR #2816)
-- [x] Five Enrichment task sites use the supervisor: summarization, graph/persona/trajectory extraction, audit logging (persistence.rs, corrections.rs)
-- [x] Per-class inflight limits enforced: Enrichment 4, Telemetry 8
+- [x] `TaskSupervisor` struct compiles and integrates with agent loop (PR #2816)
+- [x] Enrichment task sites use the supervisor: summarization, graph/persona/trajectory extraction, audit logging
+- [x] Per-class inflight limits enforced and configurable via `[agent.supervisor]` config
 - [x] Metrics (`spawned`, `dropped`, `completed`, `inflight`) exported per class
-- [x] All background tasks cleaned up on agent shutdown via `abort_all()`
-- [x] Five unit tests covering: spawn/reap, drop on overflow, summarization signal, abort all, inflight decrement timing
-- [x] `SummarizationSignal` enables foreground reset of `unsummarized_count` without shared state
-
-### Phase 2 (Planned)
-
-- [ ] Phase 2A (#2884): Route remaining fire-and-forget spawns through supervisor
-- [ ] Phase 2B (#2885): Per-class `bg_latency` histogram exported
-- [ ] Phase 2C (#2886): TUI status bar displays background task counts
-- [ ] Phase 2D (#2887): Explicit turn-boundary `abort_class(TaskClass::Enrichment)` call
-- [ ] Phase 2E (#2888): Queue depths configurable via `config.toml`
-- [ ] Phase 2F (#2889): Tracing span propagation into supervised tasks
-
----
-
-## 13. Phase 2 Implementation Plan
-
-Roadmap for Phase 2 enhancements coordinated under Epic #2883. **All 6 sub-phases are implemented in a single PR.**
-
-### 13.1 Implementation Order
-
-1. **2E** (config) — add `TaskSupervisorConfig` to `zeph-config`, wire through builder (dependency for 2B, 2D)
-2. **2B** (latency histogram) — extend `TaskResult`, `HistogramRecorder` trait, add `spawned_at` tracking
-3. **2D** (abort_class) — add `class_handles` tracking and `abort_class()` method
-4. **2F** (tracing spans) — small change to `spawn()`/`spawn_summarization()` (no dependencies)
-5. **2A** (route spawns) — replace 2 `tokio::spawn()` calls with supervisor (depends on 2E)
-6. **2C** (TUI status) — extend `MetricsSnapshot`, update TUI (depends on 2B/2D)
-
-### 13.2 Details by Sub-Phase
-
-#### Phase 2A: Route Remaining Fire-and-Forget Spawns (#2884)
-
-**Truly fire-and-forget spawns** (route through supervisor):
-
-| File | Line | Current Code | Class | Task Name |
-|------|------|-------------|-------|-----------|
-| `agent/tool_execution/native.rs` | 1261 | `tokio::spawn(async move { logger.log(&entry).await })` | Telemetry | `"audit-log"` |
-| `agent/tool_execution/sanitize.rs` | 161 | `tokio::spawn(async move { logger.log(&entry).await })` | Telemetry | `"audit-log-sanitize"` |
-
-**Explicitly excluded from supervisor routing:**
-
-| File | Line | Reason |
-|------|------|--------|
-| `context/assembly.rs` | 536 | `spawn_outgoing_digest(&self, ...)` — requires `&mut self` for supervisor.spawn(), cannot change signature at shutdown |
-| `experiment_cmd.rs` | 157 | Infrastructure loop with own `CancellationToken` lifecycle, not turn-scoped |
-| `scheduler_loop.rs` | 87 | Infrastructure loop with own lifecycle, tied to scheduler subsystem |
-
-**Success Criteria for 2A:**
-- Two audit log spawns replaced with `supervisor.spawn(TaskClass::Telemetry, ...)`
-- All three spawns previously listed in scope are now explicitly addressed (two routed, one documented as excluded)
-- Metrics verify the two audit spawns appear in `bg_spawned` counter
-
-#### Phase 2B: Per-Class Latency Histogram (#2885)
-
-Extend `TaskResult` to carry elapsed time since spawn:
-
-```rust
-enum TaskResult {
-    Done(TaskClass, Duration),           // class + elapsed since spawn
-    SummarizationDone(Duration),         // elapsed since spawn
-}
-```
-
-**Data model changes:**
-- Capture `Instant::now()` at spawn time in `spawn()` and `spawn_summarization()`
-- Compute `spawned_at.elapsed()` inside async block before returning `TaskResult`
-
-**Metric recording in `reap()`:**
-- Add method to `HistogramRecorder` trait:
-  ```rust
-  fn observe_bg_task(&self, class_label: &str, duration: Duration);
-  ```
-  where `class_label` is `"enrichment"` or `"telemetry"` (from `TaskClass::name()`)
-
-**Prometheus histogram** (in `src/metrics_export.rs`):
-```
-zeph_bg_task_duration_seconds{class="enrichment|telemetry"}
-buckets: [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 30.0]
-```
-
-**Important:** All existing match arms on `TaskResult` in tests and `join_all_for_test()` must be updated to handle the new `Duration` field.
-
-#### Phase 2C: TUI Status Bar (#2886)
-
-Extend `MetricsSnapshot` with per-class inflight counts:
-
-```rust
-pub bg_enrichment_inflight: u64,  // NEW
-pub bg_telemetry_inflight: u64,   // NEW
-```
-
-Update TUI status bar segment when either count > 0:
-```
-bg: 2 enrich, 1 telem
-```
-
-#### Phase 2D: Turn-Boundary Abort (#2887)
-
-New method on `BackgroundSupervisor`:
-
-```rust
-pub(crate) fn abort_class(&mut self, class: TaskClass) {
-    for handle in self.class_handles[class.index()].drain(..) {
-        handle.abort();
-    }
-}
-```
-
-**Data model changes:**
-- Add `class_handles: [Vec<AbortHandle>; NUM_CLASSES]` to supervisor struct
-- Capture `AbortHandle` from `self.tasks.spawn()` and store per-class (tokio ≥ 1.36 required)
-- Clean up stale handles in `reap()` via `handles.retain(|h| !h.is_finished())`
-
-**Config flag** (gated by 2E):
-```toml
-[agent.supervisor]
-abort_enrichment_on_turn = true   # default: false
-```
-
-**Call site** (in `process_user_message_inner`, after `reap()`):
-```rust
-if self.supervisor_config.abort_enrichment_on_turn {
-    self.lifecycle.supervisor.abort_class(TaskClass::Enrichment);
-}
-```
-
-**Important Note:** `AbortHandle::is_finished()` requires tokio ≥ 1.36.0 — verify in `Cargo.toml` before implementation.
-
-#### Phase 2E: Configurable Queue Depths (#2888)
-
-New config struct in `crates/zeph-config/src/agent.rs`:
-
-```rust
-/// Background task supervisor configuration.
-///
-/// # Example (TOML)
-///
-/// ```toml
-/// [agent.supervisor]
-/// enrichment_limit = 4
-/// telemetry_limit = 8
-/// abort_enrichment_on_turn = false
-/// ```
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct TaskSupervisorConfig {
-    #[serde(default = "default_enrichment_limit")]
-    pub enrichment_limit: usize,  // Default: 4
-    
-    #[serde(default = "default_telemetry_limit")]
-    pub telemetry_limit: usize,   // Default: 8
-    
-    #[serde(default)]
-    pub abort_enrichment_on_turn: bool,  // Default: false
-}
-```
-
-Nest in `AgentConfig`:
-```rust
-pub struct AgentConfig {
-    // ... existing fields ...
-    #[serde(default)]
-    pub supervisor: TaskSupervisorConfig,
-}
-```
-
-**BackgroundSupervisor constructor** (passes config):
-```rust
-pub(crate) fn new(
-    config: &TaskSupervisorConfig,
-    recorder: Option<Arc<dyn HistogramRecorder>>,
-) -> Self
-```
-
-**Config migration** (`--migrate-config`): Insert default `[agent.supervisor]` section when missing.
-
-#### Phase 2F: Tracing Span Propagation (#2889)
-
-Wrap spawned future with `instrument()` call:
-
-```rust
-pub(crate) fn spawn(
-    &mut self,
-    class: TaskClass,
-    name: &'static str,
-    fut: impl Future<Output = ()> + Send + 'static,
-) -> bool {
-    // ...
-    let span = tracing::info_span!("bg_task", class = class.name(), task = name);
-    
-    self.tasks.spawn(
-        async move {
-            let _guard = guard;
-            fut.await;
-            TaskResult::Done(class, spawned_at.elapsed())
-        }
-        .instrument(span),
-    );
-    // ...
-}
-```
-
-Requires `use tracing::Instrument;` import.
-
-### 13.3 Integration Points
-
-| Point | Files | Change |
-|-------|-------|--------|
-| Config | `crates/zeph-config/src/agent.rs` | Add `TaskSupervisorConfig` struct, nest in `AgentConfig` |
-| Config defaults | `crates/zeph-core/config/default.toml`, root `config/default.toml` | Add commented `[agent.supervisor]` section |
-| Config migration | `src/config_migration.rs` | Insert default `[agent.supervisor]` if missing |
-| Supervisor struct | `crates/zeph-core/src/agent/supervisor.rs` | Add `class_handles`, `class_limits`, `histogram_recorder`; change `TaskResult` enum |
-| HistogramRecorder | `crates/zeph-core/src/metrics.rs` | Add `observe_bg_task(&str, Duration)` method to trait |
-| Prometheus impl | `src/metrics_export.rs` | Implement new trait method, add `bg_task_duration_seconds` histogram vec |
-| Agent build | `crates/zeph-core/src/agent/builder.rs` | Pass config + recorder to `BackgroundSupervisor::new()` |
-| Agent turn | `crates/zeph-core/src/agent/mod.rs` | Call `abort_class(Enrichment)` after `reap()` if config flag set |
-| Spawn sites | `native.rs:1261`, `sanitize.rs:161` | Replace `tokio::spawn()` with `supervisor.spawn()` |
-| MetricsSnapshot | `crates/zeph-core/src/metrics.rs` | Add `bg_enrichment_inflight`, `bg_telemetry_inflight` fields |
-| TUI status | `crates/zeph-tui/src/widgets/status.rs` | Append background task segment when counts > 0 |
-| Interactive wizard | `--init` handler | Add supervisor config options to wizard |
-
-### 13.4 Test Plan
-
-| Sub-phase | Test |
-|-----------|------|
-| 2A | Verify two audit log spawns appear in supervisor metrics (check `spawned` counter) |
-| 2B | Unit test: spawn task, join, verify `reap()` produces `TaskResult::Done(_, duration)` with non-zero duration |
-| 2C | Unit test: verify `metrics_snapshot().class_inflight` reports correct per-class counts; TUI test is visual (manual) |
-| 2D | Unit test: spawn N enrichment tasks, call `abort_class(Enrichment)`, verify inflight drops to 0 and telemetry unaffected |
-| 2E | Unit test: construct supervisor with custom limits, verify spawn/drop behavior matches config |
-| 2F | Unit test: spawn task with tracing subscriber, verify span fields `class` and `task` are recorded |
-
-### 13.5 Known Constraints
-
-- **tokio ≥ 1.36.0 required** for `AbortHandle::is_finished()` (Phase 2D)
-- **Signature changes:** `BackgroundSupervisor::new()` signature changes; callers in `AgentBuilder::build()` must pass config + recorder
-- **Borrow conflict resolved:** `spawn_outgoing_digest()` at `assembly.rs:536` is explicitly excluded; session digest stays as plain `tokio::spawn()` (one-shot shutdown operation)
-
----
-
-## 14. Phase 2 Roadmap (by issue)
-
-| Issue | Phase | Title |
-|-------|-------|-------|
-| #2884 | 2A | Route remaining fire-and-forget spawns |
-| #2885 | 2B | Add per-class latency histogram |
-| #2886 | 2C | TUI background task display |
-| #2887 | 2D | Turn-boundary abort for Enrichment |
-| #2888 | 2E | Configurable concurrency limits |
-| #2889 | 2F | Span propagation (optional) |
-
----
+- [x] `shutdown_all(10s)` drains completions before aborting remaining tasks
+- [x] `spawn_restartable` with `RestartPolicy::Restart` applies exponential backoff
+- [x] `TaskStatus::Aborted` state for force-aborted entries; `list_tasks()` reflects all states
+- [x] 6 regression tests for shutdown/restart/blocking semantics (PR #2958)
+- [x] 7 bootstrap memory loops migrated to supervisor (PR #2960)
+- [x] `TelegramChannel`, `A2aServer`, background indexer migrated (PR #2961)
+- [x] TUI `/tasks` panel shows live task registry (PR #2962)
+- [x] CPU/wall-time metrics via `task-metrics` feature (PR #2963)
+- [x] `BlockingSpawner` trait in `zeph-common` breaks `zeph-core → zeph-index` cycle (PR #2978)
+- [x] Blocking semaphore (capacity 8) prevents OS thread pool saturation (PR #3009)
+- [x] Task names are `Arc<str>` — no `Box::leak` per indexed file (PR #3005)
 
 ---
 

--- a/specs/043-zeph-common/spec.md
+++ b/specs/043-zeph-common/spec.md
@@ -136,6 +136,7 @@ THEN the same hex string is returned (deterministic)
 | FR-008 | WHEN `policy::PolicyLlmClient` is used THEN the system SHALL provide a minimal LLM interface for policy checks that does not depend on `zeph-llm` | must |
 | FR-009 | WHEN `trust_level::SkillTrustLevel` is evaluated THEN the system SHALL express the Untrusted/Provisional/Trusted trust gradient | must |
 | FR-010 | WHEN `sanitize` utilities are called THEN the system SHALL provide content sanitization helpers usable by any crate without depending on `zeph-sanitizer` | should |
+| FR-011 | WHEN `BlockingSpawner::spawn_blocking_named` is called THEN the system SHALL dispatch the closure to the OS blocking thread pool with the given `Arc<str>` task name | must |
 
 ---
 
@@ -164,6 +165,7 @@ THEN the same hex string is returned (deterministic)
 | `PolicyLlmClient` | Minimal LLM interface for policy | Trait for content-policy checking without `zeph-llm` dependency |
 | `PolicyMessage` | Message for policy evaluation | Role + content |
 | `PolicyRole` | Role in policy context | `User`, `Assistant` |
+| `BlockingSpawner` | Trait for dispatching blocking tasks by name | `spawn_blocking_named(name: Arc<str>, f: Box<dyn FnOnce() + Send + 'static>)` |
 
 ---
 
@@ -175,6 +177,7 @@ THEN the same hex string is returned (deterministic)
 | `ToolName` constructed from empty string | Allowed; represents a degenerate tool name (validation is caller's responsibility) |
 | `blake3_hex()` called with empty input | Returns deterministic BLAKE3 hash of empty bytes |
 | `treesitter` feature disabled | Module is excluded from compilation; no dead-code warnings |
+| `BlockingSpawner::spawn_blocking_named` with `Arc<str>` name | Name is forwarded to the implementation; no heap leak per call |
 
 ---
 
@@ -203,6 +206,7 @@ THEN the same hex string is returned (deterministic)
 - Add a dependency on any `zeph-*` crate
 - Derive `Clone` on `Secret`
 - Use `unsafe` blocks
+- Use `&'static str` or `Box::leak` for task names — always `Arc<str>`
 
 ---
 
@@ -218,4 +222,6 @@ None.
 - [[001-system-invariants/spec]] — system-wide invariants
 - [[010-security/spec]] — security model that `zeph-common` primitives enforce
 - [[038-vault/spec]] — vault crate that uses `Secret` from this crate
+- [[039-background-task-supervisor/spec]] — `TaskSupervisor` implements `BlockingSpawner`
+- [[017-index/spec]] — `CodeIndexer` consumes `BlockingSpawner` via `with_spawner()`
 - [[MOC-specs]] — all specifications


### PR DESCRIPTION
## Summary

- Bump version from 0.19.0 to 0.19.1
- Update CHANGELOG.md with grouped release section
- Update test badge in README (7973 tests)
- Accept updated splash snapshot for new version string

## Checklist

- [x] Version updated in all manifests
- [x] CHANGELOG.md has release section with date, sections deduplicated
- [x] README test badge updated
- [x] All CI checks pass (7973/7973 tests, clippy clean)
- [ ] Ready for tagging after merge