### PR TITLE
fix(memory): use effective_embed_provider for all embedding ops in semantic submodules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix embedding dimension mismatch that silently wiped Qdrant memory collections (`zeph_conversations`, `zeph_key_facts`, `zeph_session_summaries`) on every session startup when `embedding_provider` differs from the main LLM provider. All 18 `self.provider` embedding call sites in `zeph-memory` semantic submodules (`recall.rs`, `cross_session.rs`, `summarization.rs`, `corrections.rs`) now use `self.effective_embed_provider()` consistently. Adds a regression test for embed provider routing. Fixes #3029.
+
 ## [0.19.1] - 2026-04-15
 
 ### Added

--- a/crates/zeph-memory/src/semantic/corrections.rs
+++ b/crates/zeph-memory/src/semantic/corrections.rs
@@ -23,11 +23,11 @@ impl SemanticMemory {
         let Some(ref store) = self.qdrant else {
             return Ok(());
         };
-        if !self.provider.supports_embeddings() {
+        if !self.effective_embed_provider().supports_embeddings() {
             return Ok(());
         }
         let embedding = self
-            .provider
+            .effective_embed_provider()
             .embed(correction_text)
             .await
             .map_err(|e| MemoryError::Other(e.to_string()))?;
@@ -60,12 +60,12 @@ impl SemanticMemory {
             tracing::debug!("corrections: skipped, no vector store");
             return Ok(vec![]);
         };
-        if !self.provider.supports_embeddings() {
+        if !self.effective_embed_provider().supports_embeddings() {
             tracing::debug!("corrections: skipped, no embedding support");
             return Ok(vec![]);
         }
         let embedding = self
-            .provider
+            .effective_embed_provider()
             .embed(query)
             .await
             .map_err(|e| MemoryError::Other(e.to_string()))?;

--- a/crates/zeph-memory/src/semantic/cross_session.rs
+++ b/crates/zeph-memory/src/semantic/cross_session.rs
@@ -94,11 +94,11 @@ impl SemanticMemory {
         let Some(qdrant) = &self.qdrant else {
             return Ok(());
         };
-        if !self.provider.supports_embeddings() {
+        if !self.effective_embed_provider().supports_embeddings() {
             return Ok(());
         }
 
-        let vector = self.provider.embed(summary_text).await?;
+        let vector = self.effective_embed_provider().embed(summary_text).await?;
         let vector_size = u64::try_from(vector.len()).unwrap_or(896);
         qdrant
             .ensure_named_collection(SESSION_SUMMARIES_COLLECTION, vector_size)
@@ -143,12 +143,12 @@ impl SemanticMemory {
             tracing::debug!("session-summaries: skipped, no vector store");
             return Ok(Vec::new());
         };
-        if !self.provider.supports_embeddings() {
+        if !self.effective_embed_provider().supports_embeddings() {
             tracing::debug!("session-summaries: skipped, no embedding support");
             return Ok(Vec::new());
         }
 
-        let vector = self.provider.embed(query).await?;
+        let vector = self.effective_embed_provider().embed(query).await?;
         let vector_size = u64::try_from(vector.len()).unwrap_or(896);
         qdrant
             .ensure_named_collection(SESSION_SUMMARIES_COLLECTION, vector_size)

--- a/crates/zeph-memory/src/semantic/recall.rs
+++ b/crates/zeph-memory/src/semantic/recall.rs
@@ -687,9 +687,9 @@ impl SemanticMemory {
         };
 
         let vector_results = if let Some(qdrant) = &self.qdrant
-            && self.provider.supports_embeddings()
+            && self.effective_embed_provider().supports_embeddings()
         {
-            let query_vector = self.provider.embed(query).await?;
+            let query_vector = self.effective_embed_provider().embed(query).await?;
             let vector_size = u64::try_from(query_vector.len()).unwrap_or(896);
             qdrant.ensure_collection(vector_size).await?;
             qdrant.search(&query_vector, limit * 2, filter).await?
@@ -731,10 +731,10 @@ impl SemanticMemory {
         let Some(qdrant) = &self.qdrant else {
             return Ok(Vec::new());
         };
-        if !self.provider.supports_embeddings() {
+        if !self.effective_embed_provider().supports_embeddings() {
             return Ok(Vec::new());
         }
-        let query_vector = self.provider.embed(query).await?;
+        let query_vector = self.effective_embed_provider().embed(query).await?;
         let vector_size = u64::try_from(query_vector.len()).unwrap_or(896);
         qdrant.ensure_collection(vector_size).await?;
         qdrant.search(&query_vector, limit * 2, filter).await

--- a/crates/zeph-memory/src/semantic/summarization.rs
+++ b/crates/zeph-memory/src/semantic/summarization.rs
@@ -163,9 +163,9 @@ impl SemanticMemory {
             .await?;
 
         if let Some(qdrant) = &self.qdrant
-            && self.provider.supports_embeddings()
+            && self.effective_embed_provider().supports_embeddings()
         {
-            match self.provider.embed(summary_text).await {
+            match self.effective_embed_provider().embed(summary_text).await {
                 Ok(vector) => {
                     let vector_size = u64::try_from(vector.len()).unwrap_or(896);
                     if let Err(e) = qdrant.ensure_collection(vector_size).await {
@@ -208,7 +208,7 @@ impl SemanticMemory {
         let Some(qdrant) = &self.qdrant else {
             return;
         };
-        if !self.provider.supports_embeddings() {
+        if !self.effective_embed_provider().supports_embeddings() {
             return;
         }
 
@@ -224,7 +224,7 @@ impl SemanticMemory {
         let Some(first_fact) = filtered.first().copied() else {
             return;
         };
-        let first_vector = match self.provider.embed(first_fact).await {
+        let first_vector = match self.effective_embed_provider().embed(first_fact).await {
             Ok(v) => v,
             Err(e) => {
                 tracing::warn!("Failed to embed key fact: {e:#}");
@@ -252,7 +252,7 @@ impl SemanticMemory {
         .await;
 
         for fact in filtered[1..].iter().copied() {
-            match self.provider.embed(fact).await {
+            match self.effective_embed_provider().embed(fact).await {
                 Ok(vector) => {
                     self.store_key_fact_if_unique(
                         qdrant,
@@ -325,12 +325,12 @@ impl SemanticMemory {
             tracing::debug!("key-facts: skipped, no vector store");
             return Ok(Vec::new());
         };
-        if !self.provider.supports_embeddings() {
+        if !self.effective_embed_provider().supports_embeddings() {
             tracing::debug!("key-facts: skipped, no embedding support");
             return Ok(Vec::new());
         }
 
-        let vector = self.provider.embed(query).await?;
+        let vector = self.effective_embed_provider().embed(query).await?;
         let vector_size = u64::try_from(vector.len()).unwrap_or(896);
         qdrant
             .ensure_named_collection(KEY_FACTS_COLLECTION, vector_size)
@@ -368,13 +368,13 @@ impl SemanticMemory {
         let Some(qdrant) = &self.qdrant else {
             return Ok(Vec::new());
         };
-        if !self.provider.supports_embeddings() {
+        if !self.effective_embed_provider().supports_embeddings() {
             return Ok(Vec::new());
         }
         if !qdrant.collection_exists(collection).await? {
             return Ok(Vec::new());
         }
-        let vector = self.provider.embed(query).await?;
+        let vector = self.effective_embed_provider().embed(query).await?;
         let results = qdrant
             .search_collection(collection, &vector, limit, None)
             .await?;

--- a/crates/zeph-memory/src/semantic/tests/mod.rs
+++ b/crates/zeph-memory/src/semantic/tests/mod.rs
@@ -9,6 +9,7 @@ mod summarization;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 
+use zeph_llm::LlmProvider;
 use zeph_llm::any::AnyProvider;
 use zeph_llm::mock::MockProvider;
 use zeph_llm::provider::Role;
@@ -101,6 +102,49 @@ async fn remember_with_parts_saves_parts_json() {
     let history = memory.sqlite.load_history(cid, 50).await.unwrap();
     assert_eq!(history.len(), 1);
     assert_eq!(history[0].content, "tool output");
+}
+
+#[tokio::test]
+async fn effective_embed_provider_routes_to_dedicated_embed_provider() {
+    // main_provider has embeddings disabled
+    let main_provider = AnyProvider::Mock(MockProvider::default());
+    // embed_provider has embeddings enabled
+    let embed_provider = AnyProvider::Mock(MockProvider::default().with_embedding(vec![0.1]));
+
+    let sqlite = SqliteStore::new(":memory:").await.unwrap();
+    let memory = SemanticMemory {
+        sqlite,
+        qdrant: None,
+        provider: main_provider,
+        embed_provider: Some(embed_provider),
+        embedding_model: "test-model".into(),
+        vector_weight: 0.7,
+        keyword_weight: 0.3,
+        temporal_decay_enabled: false,
+        temporal_decay_half_life_days: 30,
+        mmr_enabled: false,
+        mmr_lambda: 0.7,
+        importance_enabled: false,
+        importance_weight: 0.15,
+        token_counter: Arc::new(TokenCounter::new()),
+        graph_store: None,
+        community_detection_failures: Arc::new(AtomicU64::new(0)),
+        graph_extraction_count: Arc::new(AtomicU64::new(0)),
+        graph_extraction_failures: Arc::new(AtomicU64::new(0)),
+        tier_boost_semantic: 1.3,
+        admission_control: None,
+        key_facts_dedup_threshold: 0.95,
+        embed_tasks: std::sync::Mutex::new(tokio::task::JoinSet::new()),
+    };
+
+    assert!(
+        memory.effective_embed_provider().supports_embeddings(),
+        "effective_embed_provider() must return the dedicated embed provider"
+    );
+    assert!(
+        !memory.provider.supports_embeddings(),
+        "main provider must not support embeddings, proving the two providers are distinct"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Replaces `self.provider` with `self.effective_embed_provider()` at all 18 embedding call sites across `recall.rs`, `cross_session.rs`, `summarization.rs`, and `corrections.rs` in `zeph-memory`
- Adds regression test `effective_embed_provider_routes_to_dedicated_embed_provider` that verifies the dedicated embed provider is used instead of the main LLM provider

## Root Cause

`self.provider` (main LLM provider, e.g. OpenAI/text-embedding-3-small, 1536 dim) was used at recall time instead of `self.effective_embed_provider()` (e.g. Ollama/nomic-embed-text-v2-moe, 768 dim). `ensure_collection()` detected the dimension mismatch and silently deleted and recreated all Qdrant memory collections on every session startup, losing all stored embeddings.

## Test Plan

- [ ] `cargo build -p zeph-memory` — passes, 0 errors
- [ ] `cargo clippy -p zeph-memory -- -D warnings` — 0 warnings
- [ ] `cargo nextest run -p zeph-memory --lib` — 1115 passed, 7 skipped, 0 failed
- [ ] New regression test `effective_embed_provider_routes_to_dedicated_embed_provider` passes and would fail if any fixed call site reverted to `self.provider`
- [ ] Verify with mixed-provider config: `zeph_conversations` collection no longer recreated on startup

Closes #3029