### PR TITLE
fix(skills): warn on score threshold drop, fix RL skip log, init active_skills at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Fix embedding dimension mismatch that silently wiped Qdrant memory collections (`zeph_conversations`, `zeph_key_facts`, `zeph_session_summaries`) on every session startup when `embedding_provider` differs from the main LLM provider. All 18 `self.provider` embedding call sites in `zeph-memory` semantic submodules (`recall.rs`, `cross_session.rs`, `summarization.rs`, `corrections.rs`) now use `self.effective_embed_provider()` consistently. Adds a regression test for embed provider routing. Fixes #3029.
 
+- **skills: all candidates silently dropped below min_injection_score** (`#3030`): after
+  `scored.retain()`, if all candidates are filtered out, a structured `warn!` is now emitted
+  with `candidate_count`, `threshold`, and `max_score` fields. The agent correctly runs
+  without skill injection for that turn. Fallback-to-all-skills is not applied (spec
+  prohibits it).
+
+- **skills: RL re-rank silently disabled when Qdrant backend is active** (`#3032`): added a
+  startup `info!` log when both RL head and Qdrant matcher are configured, documenting that
+  in-process vector embeddings are unavailable with the Qdrant backend so RL re-ranking is
+  skipped. Per-turn skip is logged at `debug!` level to avoid log noise.
+
+- **tui: skills panel shows 0/N until first user message** (`#3031`): `with_metrics()` in
+  `AgentBuilder` now initializes `active_skills` with all loaded skill names as a baseline
+  so the TUI panel shows the correct count at startup. The list is refined per-turn by
+  `rebuild_system_prompt` as usual.
+
 ## [0.19.1] - 2026-04-15
 
 ### Added

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1130,7 +1130,17 @@ impl<C: Channel> Agent<C> {
             self.runtime.active_provider_name.clone()
         };
         let model_name = self.runtime.model_name.clone();
-        let total_skills = self.skill_state.registry.read().all_meta().len();
+        let registry_guard = self.skill_state.registry.read();
+        let total_skills = registry_guard.all_meta().len();
+        // Initialize active_skills with all loaded skills as a baseline.
+        // This is a placeholder representing "loaded" skills — the list is refined
+        // per-turn by rebuild_system_prompt once the first query is processed.
+        let all_skill_names: Vec<String> = registry_guard
+            .all_meta()
+            .iter()
+            .map(|m| m.name.clone())
+            .collect();
+        drop(registry_guard);
         let qdrant_available = false;
         let conversation_id = self.memory_state.persistence.conversation_id;
         let prompt_estimate = self
@@ -1179,6 +1189,7 @@ impl<C: Channel> Agent<C> {
             m.provider_name = provider_name;
             m.model_name = model_name;
             m.total_skills = total_skills;
+            m.active_skills = all_skill_names;
             m.qdrant_available = qdrant_available;
             m.sqlite_conversation_id = conversation_id;
             m.context_tokens = prompt_estimate;
@@ -1190,6 +1201,18 @@ impl<C: Channel> Agent<C> {
             m.mcp_servers = mcp_servers;
             m.extended_context = extended_context;
         });
+        if self.skill_state.rl_head.is_some()
+            && self
+                .skill_state
+                .matcher
+                .as_ref()
+                .is_some_and(zeph_skills::matcher::SkillMatcherBackend::is_qdrant)
+        {
+            tracing::info!(
+                "RL re-rank is configured but the Qdrant backend does not expose in-process skill \
+                 vectors; RL will be inactive until vector retrieval from Qdrant is implemented"
+            );
+        }
         self.metrics.metrics_tx = Some(tx);
         self
     }

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -947,6 +947,12 @@ impl<C: Channel> Agent<C> {
                             let pos_b = reranked.iter().position(|(i, _)| *i == b.index);
                             pos_a.cmp(&pos_b)
                         });
+                    } else {
+                        tracing::debug!(
+                            total = scored.len(),
+                            with_embeddings = candidates.len(),
+                            "RL re-rank skipped: skill embeddings unavailable (Qdrant backend does not expose in-process vectors)"
+                        );
                     }
                 }
             }
@@ -959,7 +965,20 @@ impl<C: Channel> Agent<C> {
             } else {
                 // Drop skills whose score falls below the minimum injection floor.
                 let min_score = self.skill_state.min_injection_score;
+                let pre_retain_count = scored.len();
+                let max_score_before_retain = scored
+                    .iter()
+                    .map(|s| s.score)
+                    .fold(f32::NEG_INFINITY, f32::max);
                 scored.retain(|s| s.score >= min_score);
+                if scored.is_empty() {
+                    tracing::warn!(
+                        candidate_count = pre_retain_count,
+                        threshold = min_score,
+                        max_score = max_score_before_retain,
+                        "all skill candidates dropped below min_injection_score threshold; running without skills this turn"
+                    );
+                }
 
                 // Capture the names of skills that had real embedding scores for
                 // usage stats — before disambiguation may reorder indices.

--- a/crates/zeph-core/src/agent/tests.rs
+++ b/crates/zeph-core/src/agent/tests.rs
@@ -967,6 +967,52 @@ pub mod agent_tests {
             "initial prompt estimate should be non-zero"
         );
         assert_eq!(snapshot.total_tokens, snapshot.prompt_tokens);
+        assert!(
+            !snapshot.active_skills.is_empty(),
+            "active_skills should be pre-populated at startup"
+        );
+    }
+
+    #[tokio::test]
+    async fn skill_all_candidates_dropped_below_threshold_active_skills_empty() {
+        // When min_injection_score = f32::MAX, every scored candidate fails the retain
+        // gate. The agent must not panic and must report zero active skills for the turn.
+        use zeph_skills::matcher::{SkillMatcher, SkillMatcherBackend};
+
+        // Use an embedding-capable provider so SkillMatcher::new succeeds and
+        // match_skills can embed the query — exercising the retain gate instead of
+        // the empty-matcher fallback.
+        let provider = AnyProvider::Mock(
+            MockProvider::with_responses(vec!["response".to_string()])
+                .with_embedding(vec![1.0, 0.0]),
+        );
+        let channel = MockChannel::new(vec!["hello".to_string()]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let (tx, rx) = watch::channel(crate::metrics::MetricsSnapshot::default());
+
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor).with_metrics(tx);
+
+        // Build an in-memory matcher so the retain gate is exercised rather than
+        // falling through the empty-matcher fallback path.
+        let registry_guard = agent.skill_state.registry.read();
+        let all_meta: Vec<&zeph_skills::loader::SkillMeta> = registry_guard.all_meta();
+        let embed_fn = |_text: &str| -> zeph_skills::matcher::EmbedFuture {
+            Box::pin(async { Ok(vec![1.0_f32, 0.0]) })
+        };
+        let matcher = SkillMatcher::new(&all_meta, embed_fn).await;
+        drop(registry_guard);
+        agent.skill_state.matcher = matcher.map(SkillMatcherBackend::InMemory);
+        // Set an impossibly high threshold so every candidate is dropped.
+        agent.skill_state.min_injection_score = f32::MAX;
+
+        agent.run().await.unwrap();
+
+        let snapshot = rx.borrow().clone();
+        assert!(
+            snapshot.active_skills.is_empty(),
+            "no skills should be active when all candidates fail the score gate"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **#3030**: after `scored.retain()`, emit `warn!` with `candidate_count`, `threshold`, and `max_score` when all candidates drop below `min_injection_score`. No fallback-to-all (spec gate: `specs/005-skills/spec.md:119-120`).
- **#3032**: emit `info!` once at startup when Qdrant backend + RL head are both configured, documenting that RL re-ranking is unavailable without in-process vectors. Per-turn skip logged at `debug!` to avoid noise.
- **#3031**: `AgentBuilder::with_metrics()` now initializes `active_skills` with all loaded skill names so TUI shows correct `N/N` at startup instead of `0/N`.

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` — 7974 passed, 20 skipped
- [ ] New test `skill_all_candidates_dropped_below_threshold_active_skills_empty` covers the `#3030` warn path
- [ ] Existing test `agent_with_metrics_sets_initial_values` extended to assert `!active_skills.is_empty()` for `#3031`
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — clean

Closes #3030, #3031, #3032