### PR TITLE
refactor(core): initialize all static MetricsSnapshot fields at builder time

### DIFF
--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -22,7 +22,7 @@ use crate::config_watcher::ConfigEvent;
 use crate::context::ContextBudget;
 use crate::cost::CostTracker;
 use crate::instructions::{InstructionEvent, InstructionReloadState};
-use crate::metrics::MetricsSnapshot;
+use crate::metrics::{MetricsSnapshot, StaticMetricsInit};
 use zeph_memory::semantic::SemanticMemory;
 use zeph_skills::watcher::SkillEvent;
 
@@ -1217,6 +1217,44 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Apply static, configuration-derived fields to the metrics snapshot.
+    ///
+    /// Call this immediately after [`with_metrics`][Self::with_metrics] with values resolved from
+    /// the application config. This consolidates all one-time metric initialization into the
+    /// builder phase instead of requiring a separate `send_modify` call in the runner.
+    ///
+    /// `cache_enabled` is treated as an alias for `semantic_cache_enabled` and is set to the same
+    /// value automatically.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called before [`with_metrics`][Self::with_metrics] (no sender is wired yet).
+    #[must_use]
+    pub fn with_static_metrics(self, init: StaticMetricsInit) -> Self {
+        let tx = self
+            .metrics
+            .metrics_tx
+            .as_ref()
+            .expect("with_static_metrics must be called after with_metrics");
+        tx.send_modify(|m| {
+            m.stt_model = init.stt_model;
+            m.compaction_model = init.compaction_model;
+            m.semantic_cache_enabled = init.semantic_cache_enabled;
+            m.cache_enabled = init.semantic_cache_enabled;
+            m.embedding_model = init.embedding_model;
+            m.self_learning_enabled = init.self_learning_enabled;
+            m.active_channel = init.active_channel;
+            m.token_budget = init.token_budget;
+            m.compaction_threshold = init.compaction_threshold;
+            m.vault_backend = init.vault_backend;
+            m.autosave_enabled = init.autosave_enabled;
+            if let Some(name) = init.model_name_override {
+                m.model_name = name;
+            }
+        });
+        self
+    }
+
     /// Attach a cost tracker for per-session token budget accounting.
     #[must_use]
     pub fn with_cost_tracker(mut self, tracker: CostTracker) -> Self {
@@ -1881,5 +1919,76 @@ mod tests {
             matches!(agent, Err(BuildError::MissingProviders)),
             "build must return MissingProviders when pool is empty and model_name is unset"
         );
+    }
+
+    #[test]
+    fn with_static_metrics_applies_all_fields() {
+        let (tx, rx) = tokio::sync::watch::channel(MetricsSnapshot::default());
+        let init = StaticMetricsInit {
+            stt_model: Some("whisper-1".to_owned()),
+            compaction_model: Some("haiku".to_owned()),
+            semantic_cache_enabled: true,
+            embedding_model: "nomic-embed-text".to_owned(),
+            self_learning_enabled: true,
+            active_channel: "cli".to_owned(),
+            token_budget: Some(100_000),
+            compaction_threshold: Some(80_000),
+            vault_backend: "age".to_owned(),
+            autosave_enabled: true,
+            model_name_override: Some("gpt-4o".to_owned()),
+        };
+        let _ = make_agent().with_metrics(tx).with_static_metrics(init);
+        let s = rx.borrow();
+        assert_eq!(s.stt_model.as_deref(), Some("whisper-1"));
+        assert_eq!(s.compaction_model.as_deref(), Some("haiku"));
+        assert!(s.semantic_cache_enabled);
+        assert!(
+            s.cache_enabled,
+            "cache_enabled must mirror semantic_cache_enabled"
+        );
+        assert_eq!(s.embedding_model, "nomic-embed-text");
+        assert!(s.self_learning_enabled);
+        assert_eq!(s.active_channel, "cli");
+        assert_eq!(s.token_budget, Some(100_000));
+        assert_eq!(s.compaction_threshold, Some(80_000));
+        assert_eq!(s.vault_backend, "age");
+        assert!(s.autosave_enabled);
+        assert_eq!(
+            s.model_name, "gpt-4o",
+            "model_name_override must replace model_name"
+        );
+    }
+
+    #[test]
+    fn with_static_metrics_cache_enabled_alias() {
+        let (tx, rx) = tokio::sync::watch::channel(MetricsSnapshot::default());
+        let init_true = StaticMetricsInit {
+            semantic_cache_enabled: true,
+            ..StaticMetricsInit::default()
+        };
+        let _ = make_agent().with_metrics(tx).with_static_metrics(init_true);
+        {
+            let s = rx.borrow();
+            assert_eq!(
+                s.cache_enabled, s.semantic_cache_enabled,
+                "cache_enabled must equal semantic_cache_enabled when true"
+            );
+        }
+
+        let (tx2, rx2) = tokio::sync::watch::channel(MetricsSnapshot::default());
+        let init_false = StaticMetricsInit {
+            semantic_cache_enabled: false,
+            ..StaticMetricsInit::default()
+        };
+        let _ = make_agent()
+            .with_metrics(tx2)
+            .with_static_metrics(init_false);
+        {
+            let s = rx2.borrow();
+            assert_eq!(
+                s.cache_enabled, s.semantic_cache_enabled,
+                "cache_enabled must equal semantic_cache_enabled when false"
+            );
+        }
     }
 }

--- a/crates/zeph-core/src/metrics.rs
+++ b/crates/zeph-core/src/metrics.rs
@@ -206,7 +206,7 @@ pub struct TurnTimings {
 ///
 /// Fields are updated at different rates: some once at startup (static), others every turn
 /// (dynamic). For fields that are known at agent startup and do not change during the session,
-/// use [`StaticMetricsInit`] and [`crate::agent::AgentBuilder::with_static_metrics`] instead of
+/// use [`StaticMetricsInit`] and `AgentBuilder::with_static_metrics` instead of
 /// adding a raw `send_modify` call in the runner.
 #[derive(Debug, Clone, Default)]
 #[allow(clippy::struct_excessive_bools)]
@@ -396,8 +396,8 @@ pub struct MetricsSnapshot {
 /// Configuration-derived fields of [`MetricsSnapshot`] that are known at agent startup and do
 /// not change during the session.
 ///
-/// Pass this struct to [`AgentBuilder::with_static_metrics`] immediately after
-/// [`AgentBuilder::with_metrics`] to initialize all static fields in one place rather than
+/// Pass this struct to `AgentBuilder::with_static_metrics` immediately after
+/// `AgentBuilder::with_metrics` to initialize all static fields in one place rather than
 /// through scattered `send_modify` calls in the runner.
 ///
 /// # Examples

--- a/crates/zeph-core/src/metrics.rs
+++ b/crates/zeph-core/src/metrics.rs
@@ -202,6 +202,12 @@ pub struct TurnTimings {
     pub persist_message_ms: u64,
 }
 
+/// Live snapshot of agent metrics broadcast via a [`tokio::sync::watch`] channel.
+///
+/// Fields are updated at different rates: some once at startup (static), others every turn
+/// (dynamic). For fields that are known at agent startup and do not change during the session,
+/// use [`StaticMetricsInit`] and [`crate::agent::AgentBuilder::with_static_metrics`] instead of
+/// adding a raw `send_modify` call in the runner.
 #[derive(Debug, Clone, Default)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct MetricsSnapshot {
@@ -385,6 +391,54 @@ pub struct MetricsSnapshot {
     pub max_turn_timings: TurnTimings,
     /// Number of turns included in `avg_turn_timings` and `max_turn_timings` (capped at 10).
     pub timing_sample_count: u64,
+}
+
+/// Configuration-derived fields of [`MetricsSnapshot`] that are known at agent startup and do
+/// not change during the session.
+///
+/// Pass this struct to [`AgentBuilder::with_static_metrics`] immediately after
+/// [`AgentBuilder::with_metrics`] to initialize all static fields in one place rather than
+/// through scattered `send_modify` calls in the runner.
+///
+/// # Examples
+///
+/// ```no_run
+/// use zeph_core::metrics::StaticMetricsInit;
+///
+/// let init = StaticMetricsInit {
+///     active_channel: "cli".to_owned(),
+///     ..StaticMetricsInit::default()
+/// };
+/// ```
+#[derive(Debug, Default)]
+pub struct StaticMetricsInit {
+    /// STT model name (e.g. `"whisper-1"`). `None` when STT is not configured.
+    pub stt_model: Option<String>,
+    /// Model used for context compaction/summarization. `None` when no summary provider is set.
+    pub compaction_model: Option<String>,
+    /// Whether the semantic response cache is enabled.
+    ///
+    /// This value is also written to [`MetricsSnapshot::cache_enabled`] which is an alias for the
+    /// same concept.
+    pub semantic_cache_enabled: bool,
+    /// Embedding model name (e.g. `"nomic-embed-text"`). Empty when embeddings are disabled.
+    pub embedding_model: String,
+    /// Whether self-learning (skill evolution) is enabled.
+    pub self_learning_enabled: bool,
+    /// Active I/O channel name: `"cli"`, `"telegram"`, `"tui"`, `"discord"`, `"slack"`.
+    pub active_channel: String,
+    /// Token budget for context window. `None` when not configured.
+    pub token_budget: Option<u64>,
+    /// Token threshold that triggers soft compaction. `None` when not configured.
+    pub compaction_threshold: Option<u32>,
+    /// Vault backend identifier: `"age"`, `"env"`, or `"none"`.
+    pub vault_backend: String,
+    /// Whether assistant messages are auto-saved to memory.
+    pub autosave_enabled: bool,
+    /// Override for the active model name. When `Some`, replaces the model name set by the
+    /// builder from `runtime.model_name` (which may be a placeholder) with the effective model
+    /// resolved from the LLM provider configuration.
+    pub model_name_override: Option<String>,
 }
 
 /// Strip ASCII control characters and ANSI escape sequences from a string for safe TUI display.

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1981,7 +1981,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     #[cfg(not(feature = "profiling"))]
     let (metrics_tx, metrics_rx) =
         tokio::sync::watch::channel(zeph_core::metrics::MetricsSnapshot::default());
-    {
+    let static_metrics_init = {
         let stt_model = config
             .llm
             .stt_provider_entry()
@@ -1997,21 +1997,20 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
                 (f64::from(b) * f64::from(config.memory.soft_compaction_threshold)) as u32;
             threshold
         });
-        metrics_tx.send_modify(|m| {
-            config.llm.effective_model().clone_into(&mut m.model_name);
-            m.stt_model = stt_model;
-            m.compaction_model = compaction_model;
-            m.semantic_cache_enabled = semantic_cache_enabled;
-            m.cache_enabled = semantic_cache_enabled;
-            m.embedding_model = embedding_model;
-            m.self_learning_enabled = self_learning_enabled;
-            active_channel_name.clone_into(&mut m.active_channel);
-            m.token_budget = token_budget;
-            m.compaction_threshold = compaction_threshold;
-            config.vault.backend.clone_into(&mut m.vault_backend);
-            m.autosave_enabled = config.memory.autosave_assistant;
-        });
-    }
+        zeph_core::metrics::StaticMetricsInit {
+            stt_model,
+            compaction_model,
+            semantic_cache_enabled,
+            embedding_model,
+            self_learning_enabled,
+            active_channel: active_channel_name.clone(),
+            token_budget,
+            compaction_threshold,
+            vault_backend: config.vault.backend.clone(),
+            autosave_enabled: config.memory.autosave_assistant,
+            model_name_override: Some(config.llm.effective_model().to_owned()),
+        }
+    };
     // Clone metrics_rx for Prometheus sync task before it is consumed by TUI or dropped.
     #[cfg(feature = "prometheus")]
     let prometheus_metrics_rx = metrics_rx.clone();
@@ -2073,6 +2072,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     let agent = agent
         .with_extended_context(extended_context)
         .with_metrics(metrics_tx)
+        .with_static_metrics(static_metrics_init)
         .with_status_tx(agent_status_tx)
         .with_provider_pool(config.llm.providers.clone(), provider_config_snapshot);
 


### PR DESCRIPTION
## Summary

- Introduces `StaticMetricsInit` struct in `zeph-core/metrics.rs` grouping 11 config-derived static fields
- Adds `AgentBuilder::with_static_metrics()` that applies all static fields in a single `send_modify` call at builder time
- Removes the scattered `send_modify` block in `runner.rs` that was setting these fields lazily post-builder
- TUI now receives a fully populated `MetricsSnapshot` before the first user message

## Root cause

`MetricsSnapshot` has ~30 fields. `with_metrics()` populated only ~10 of them; static-state fields (skill names, provider names, config flags) were being set lazily via a separate `send_modify` block in `runner.rs`, causing TUI to display stale/zero state before the first agent turn. This pattern was the systemic root cause of #3031.

## Changes

- `crates/zeph-core/src/metrics.rs` — `StaticMetricsInit` struct (11 fields, `Debug + Default`)
- `crates/zeph-core/src/agent/builder.rs` — `with_static_metrics()` builder method + 2 unit tests
- `src/runner.rs` — replaced scattered `send_modify` with `StaticMetricsInit` construction + `.with_static_metrics()` call

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` — 7980 tests pass (+2 new: `with_static_metrics_applies_all_fields`, `with_static_metrics_cache_enabled_alias`)
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean
- [ ] TUI shows correct initial state (skill list, provider, channel) before first user message

Closes #3033