### PR TITLE
fix(skills): assign Trusted trust to bundled skills on startup and hot-reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **skills: bundled skill trust level not distinguished from hub** (`#3041`): add
+  `SourceKind::Bundled` variant to the trust store and a `bundled_level` config field
+  (`[skills.trust] bundled_level = "trusted"`). Startup and hot-reload now detect the `.bundled`
+  marker file and classify bundled skills with `bundled_level` instead of `default_level`
+  (Quarantined). Migration upgrades existing hub-registered bundled skill rows without overwriting
+  operator-promoted trust levels. Operator-blocked skills (`Blocked`) are never unblocked by
+  source_kind migration.
+
 - Fix embedding dimension mismatch that silently wiped Qdrant memory collections (`zeph_conversations`, `zeph_key_facts`, `zeph_session_summaries`) on every session startup when `embedding_provider` differs from the main LLM provider. All 18 `self.provider` embedding call sites in `zeph-memory` semantic submodules (`recall.rs`, `cross_session.rs`, `summarization.rs`, `corrections.rs`) now use `self.effective_embed_provider()` consistently. Adds a regression test for embed provider routing. Fixes #3029.
 
 - **skills: all candidates silently dropped below min_injection_score** (`#3030`): after

--- a/crates/zeph-config/src/security.rs
+++ b/crates/zeph-config/src/security.rs
@@ -55,6 +55,10 @@ fn default_trust_hash_mismatch_level() -> SkillTrustLevel {
     SkillTrustLevel::Quarantined
 }
 
+fn default_trust_bundled_level() -> SkillTrustLevel {
+    SkillTrustLevel::Trusted
+}
+
 fn default_llm_timeout() -> u64 {
     120
 }
@@ -100,6 +104,9 @@ pub struct TrustConfig {
     /// Default: `quarantined`.
     #[serde(default = "default_trust_hash_mismatch_level")]
     pub hash_mismatch_level: SkillTrustLevel,
+    /// Trust level assigned to bundled (built-in) skills shipped with the binary. Default: `trusted`.
+    #[serde(default = "default_trust_bundled_level")]
+    pub bundled_level: SkillTrustLevel,
     /// Scan skill body content for injection patterns at load time.
     ///
     /// When `true`, `SkillRegistry::scan_loaded()` is called at agent startup.
@@ -120,6 +127,7 @@ impl Default for TrustConfig {
             default_level: default_trust_default_level(),
             local_level: default_trust_local_level(),
             hash_mismatch_level: default_trust_hash_mismatch_level(),
+            bundled_level: default_trust_bundled_level(),
             scan_on_load: true,
             scanner: ScannerConfig::default(),
         }
@@ -259,12 +267,14 @@ mod tests {
             default_level: SkillTrustLevel::Quarantined,
             local_level: SkillTrustLevel::Trusted,
             hash_mismatch_level: SkillTrustLevel::Quarantined,
+            bundled_level: SkillTrustLevel::Trusted,
             scan_on_load: false,
             scanner: ScannerConfig::default(),
         };
         let toml = toml::to_string(&config).expect("serialize");
         let deserialized: TrustConfig = toml::from_str(&toml).expect("deserialize");
         assert!(!deserialized.scan_on_load);
+        assert_eq!(deserialized.bundled_level, SkillTrustLevel::Trusted);
     }
 
     #[test]
@@ -278,6 +288,27 @@ hash_mismatch_level = "quarantined"
         assert!(
             config.scan_on_load,
             "missing scan_on_load must default to true"
+        );
+    }
+
+    #[test]
+    fn trust_config_default_has_bundled_level_trusted() {
+        let config = TrustConfig::default();
+        assert_eq!(config.bundled_level, SkillTrustLevel::Trusted);
+    }
+
+    #[test]
+    fn trust_config_missing_bundled_level_defaults_to_trusted() {
+        let toml = r#"
+default_level = "quarantined"
+local_level = "trusted"
+hash_mismatch_level = "quarantined"
+"#;
+        let config: TrustConfig = toml::from_str(toml).expect("deserialize");
+        assert_eq!(
+            config.bundled_level,
+            SkillTrustLevel::Trusted,
+            "missing bundled_level must default to trusted"
         );
     }
 

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -1928,55 +1928,90 @@ impl<C: Channel> Agent<C> {
         let trust_cfg = self.skill_state.trust_config.clone();
         let managed_dir = self.skill_state.managed_dir.clone();
         for meta in all_meta {
-            let source_kind = if managed_dir
-                .as_ref()
-                .is_some_and(|d| meta.skill_dir.starts_with(d))
-            {
-                zeph_memory::store::SourceKind::Hub
-            } else {
-                zeph_memory::store::SourceKind::Local
-            };
-            let initial_level = if matches!(source_kind, zeph_memory::store::SourceKind::Hub) {
-                &trust_cfg.default_level
-            } else {
-                &trust_cfg.local_level
-            };
-            match zeph_skills::compute_skill_hash(&meta.skill_dir) {
-                Ok(current_hash) => {
-                    let existing = memory
-                        .sqlite()
-                        .load_skill_trust(&meta.name)
-                        .await
-                        .ok()
-                        .flatten();
-                    let trust_level_str = if let Some(ref row) = existing {
-                        if row.blake3_hash == current_hash {
-                            row.trust_level.clone()
+            // Compute hash and classify source_kind in spawn_blocking — both are blocking FS calls
+            // (.bundled marker .exists() and compute_skill_hash both do std::fs I/O).
+            let skill_dir = meta.skill_dir.clone();
+            let managed_dir_ref = managed_dir.clone();
+            let fs_result: Option<(String, zeph_memory::store::SourceKind)> =
+                tokio::task::spawn_blocking(move || {
+                    let hash = zeph_skills::compute_skill_hash(&skill_dir).ok()?;
+                    // .bundled marker is written by bundled.rs for skills shipped with the binary.
+                    let source_kind = if managed_dir_ref
+                        .as_ref()
+                        .is_some_and(|d| skill_dir.starts_with(d))
+                    {
+                        if skill_dir.join(".bundled").exists() {
+                            zeph_memory::store::SourceKind::Bundled
                         } else {
-                            trust_cfg.hash_mismatch_level.to_string()
+                            zeph_memory::store::SourceKind::Hub
                         }
                     } else {
-                        initial_level.to_string()
+                        zeph_memory::store::SourceKind::Local
                     };
-                    let source_path = meta.skill_dir.to_str();
-                    if let Err(e) = memory
-                        .sqlite()
-                        .upsert_skill_trust(
-                            &meta.name,
-                            &trust_level_str,
-                            source_kind,
-                            None,
-                            source_path,
-                            &current_hash,
-                        )
-                        .await
-                    {
-                        tracing::warn!("failed to record trust for '{}': {e:#}", meta.name);
+                    Some((hash, source_kind))
+                })
+                .await
+                .unwrap_or(None);
+
+            let Some((current_hash, source_kind)) = fs_result else {
+                tracing::warn!("failed to compute hash for '{}'", meta.name);
+                continue;
+            };
+            let initial_level = match source_kind {
+                zeph_memory::store::SourceKind::Bundled => &trust_cfg.bundled_level,
+                zeph_memory::store::SourceKind::Hub => &trust_cfg.default_level,
+                zeph_memory::store::SourceKind::Local | zeph_memory::store::SourceKind::File => {
+                    &trust_cfg.local_level
+                }
+            };
+            let existing = memory
+                .sqlite()
+                .load_skill_trust(&meta.name)
+                .await
+                .ok()
+                .flatten();
+            let trust_level_str = if let Some(ref row) = existing {
+                if row.blake3_hash != current_hash {
+                    trust_cfg.hash_mismatch_level.to_string()
+                } else if row.source_kind != source_kind {
+                    // source_kind changed (e.g., hub → bundled on upgrade).
+                    // Never override an explicit operator block, and preserve operator-promoted trust.
+                    let stored = row
+                        .trust_level
+                        .parse::<zeph_tools::SkillTrustLevel>()
+                        .unwrap_or_else(|_| {
+                            tracing::warn!(
+                                skill = %meta.name,
+                                raw = %row.trust_level,
+                                "unrecognised trust_level in DB, treating as quarantined"
+                            );
+                            zeph_tools::SkillTrustLevel::Quarantined
+                        });
+                    if !stored.is_active() || stored.severity() <= initial_level.severity() {
+                        row.trust_level.clone()
+                    } else {
+                        initial_level.to_string()
                     }
+                } else {
+                    row.trust_level.clone()
                 }
-                Err(e) => {
-                    tracing::warn!("failed to compute hash for '{}': {e:#}", meta.name);
-                }
+            } else {
+                initial_level.to_string()
+            };
+            let source_path = meta.skill_dir.to_str();
+            if let Err(e) = memory
+                .sqlite()
+                .upsert_skill_trust(
+                    &meta.name,
+                    &trust_level_str,
+                    source_kind,
+                    None,
+                    source_path,
+                    &current_hash,
+                )
+                .await
+            {
+                tracing::warn!("failed to record trust for '{}': {e:#}", meta.name);
             }
         }
     }

--- a/crates/zeph-memory/src/store/trust.rs
+++ b/crates/zeph-memory/src/store/trust.rs
@@ -15,6 +15,8 @@ pub enum SourceKind {
     Local,
     Hub,
     File,
+    /// Skills shipped with the binary and provisioned at startup via `bundled.rs`.
+    Bundled,
 }
 
 impl SourceKind {
@@ -23,6 +25,7 @@ impl SourceKind {
             Self::Local => "local",
             Self::Hub => "hub",
             Self::File => "file",
+            Self::Bundled => "bundled",
         }
     }
 }
@@ -41,6 +44,7 @@ impl std::str::FromStr for SourceKind {
             "local" => Ok(Self::Local),
             "hub" => Ok(Self::Hub),
             "file" => Ok(Self::File),
+            "bundled" => Ok(Self::Bundled),
             other => Err(format!("unknown source_kind: {other}")),
         }
     }
@@ -554,6 +558,7 @@ mod tests {
             ("skill-local", SourceKind::Local),
             ("skill-hub", SourceKind::Hub),
             ("skill-file", SourceKind::File),
+            ("skill-bundled", SourceKind::Bundled),
         ];
         for (name, kind) in &variants {
             store
@@ -563,5 +568,162 @@ mod tests {
             let row = store.load_skill_trust(name).await.unwrap().unwrap();
             assert_eq!(&row.source_kind, kind);
         }
+    }
+
+    #[test]
+    fn source_kind_display_bundled() {
+        assert_eq!(SourceKind::Bundled.to_string(), "bundled");
+    }
+
+    #[test]
+    fn source_kind_from_str_bundled() {
+        let kind: SourceKind = "bundled".parse().unwrap();
+        assert_eq!(kind, SourceKind::Bundled);
+    }
+
+    #[test]
+    fn source_kind_serde_json_roundtrip_bundled() {
+        let original = SourceKind::Bundled;
+        let json = serde_json::to_string(&original).unwrap();
+        assert_eq!(json, r#""bundled""#);
+        let back: SourceKind = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, original);
+    }
+
+    #[test]
+    fn source_kind_from_str_unknown_falls_back_to_local_in_row_from_tuple() {
+        // Verify that unknown DB values (e.g., from a future version downgrade)
+        // deserialize gracefully via the unwrap_or(Local) in row_from_tuple.
+        let result: Result<SourceKind, _> = "future_variant".parse();
+        assert!(result.is_err());
+        // row_from_tuple uses unwrap_or(SourceKind::Local) — simulate that here.
+        let fallback = result.unwrap_or(SourceKind::Local);
+        assert_eq!(fallback, SourceKind::Local);
+    }
+
+    // Scenario 2: Bundled trust level is preserved when re-upserted with the same source_kind.
+    // This covers the hot-reload path where hash matches and source_kind is unchanged.
+    #[tokio::test]
+    async fn bundled_trust_preserved_on_same_source_kind_upsert() {
+        let store = test_store().await;
+
+        store
+            .upsert_skill_trust(
+                "web-search",
+                "trusted",
+                SourceKind::Bundled,
+                None,
+                None,
+                "hash1",
+            )
+            .await
+            .unwrap();
+
+        // Simulate a second startup (hash unchanged, source_kind unchanged) — trust must be preserved.
+        store
+            .upsert_skill_trust(
+                "web-search",
+                "trusted",
+                SourceKind::Bundled,
+                None,
+                None,
+                "hash1",
+            )
+            .await
+            .unwrap();
+
+        let row = store.load_skill_trust("web-search").await.unwrap().unwrap();
+        assert_eq!(row.source_kind, SourceKind::Bundled);
+        assert_eq!(row.trust_level, "trusted");
+    }
+
+    // Scenario 3: Migration from hub/quarantined to bundled/trusted when .bundled marker appears.
+    // The store upsert always overwrites source_kind and trust_level when called with new values.
+    #[tokio::test]
+    async fn migration_hub_quarantined_to_bundled_trusted() {
+        let store = test_store().await;
+
+        // Initial state: existing install has hub/quarantined.
+        store
+            .upsert_skill_trust("git", "quarantined", SourceKind::Hub, None, None, "hash1")
+            .await
+            .unwrap();
+
+        let row = store.load_skill_trust("git").await.unwrap().unwrap();
+        assert_eq!(row.source_kind, SourceKind::Hub);
+        assert_eq!(row.trust_level, "quarantined");
+
+        // After runner detects .bundled marker: upsert with Bundled/trusted (initial_level from bundled_level).
+        store
+            .upsert_skill_trust("git", "trusted", SourceKind::Bundled, None, None, "hash1")
+            .await
+            .unwrap();
+
+        let row = store.load_skill_trust("git").await.unwrap().unwrap();
+        assert_eq!(row.source_kind, SourceKind::Bundled);
+        assert_eq!(row.trust_level, "trusted");
+    }
+
+    // Regression test for C1: operator-blocked bundled skills must not be unblocked by migration.
+    // The store layer always overwrites; caller logic (runner/mod) must pass "blocked" through.
+    #[tokio::test]
+    async fn operator_blocked_bundled_skill_stays_blocked_when_upserted_with_blocked() {
+        let store = test_store().await;
+
+        // Existing install: hub/blocked (operator explicitly blocked this skill).
+        store
+            .upsert_skill_trust(
+                "web-search",
+                "blocked",
+                SourceKind::Hub,
+                None,
+                None,
+                "hash1",
+            )
+            .await
+            .unwrap();
+
+        // Migration: runner detects .bundled marker but preserves "blocked" (caller responsibility).
+        store
+            .upsert_skill_trust(
+                "web-search",
+                "blocked",
+                SourceKind::Bundled,
+                None,
+                None,
+                "hash1",
+            )
+            .await
+            .unwrap();
+
+        let row = store.load_skill_trust("web-search").await.unwrap().unwrap();
+        assert_eq!(row.source_kind, SourceKind::Bundled);
+        assert_eq!(
+            row.trust_level, "blocked",
+            "operator block must survive source_kind migration"
+        );
+    }
+
+    // Scenario 4: Configurable bundled_level (e.g., "supervised") is applied during classification.
+    // This tests that the store persists any trust level string correctly for non-default configs.
+    #[tokio::test]
+    async fn bundled_skill_with_configured_supervised_level() {
+        let store = test_store().await;
+
+        store
+            .upsert_skill_trust(
+                "git",
+                "supervised",
+                SourceKind::Bundled,
+                None,
+                None,
+                "hash1",
+            )
+            .await
+            .unwrap();
+
+        let row = store.load_skill_trust("git").await.unwrap().unwrap();
+        assert_eq!(row.source_kind, SourceKind::Bundled);
+        assert_eq!(row.trust_level, "supervised");
     }
 }

--- a/crates/zeph-skills/src/trust.rs
+++ b/crates/zeph-skills/src/trust.rs
@@ -35,6 +35,10 @@ pub use zeph_common::SkillTrustLevel;
 /// let src = SkillSource::Hub { url: "https://github.com/example/skill".into() };
 /// assert_eq!(src.to_string(), "hub(https://github.com/example/skill)");
 /// ```
+// TODO: SkillSource (used in zeph-skills for user-installed provenance) intentionally has no
+// `Bundled` variant — bundled skills are indistinguishable at the install API level. The trust DB
+// layer (`zeph-memory::store::SourceKind`) has the `Bundled` variant and is the authoritative
+// source. Align these enums if `SkillSource` ever gains first-class bundled-skill support.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 pub enum SkillSource {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -785,28 +785,47 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         let trust_cfg = config.skills.trust.clone();
         let managed_dir = crate::bootstrap::managed_skills_dir();
 
-        // Step 1: collect all hashes in a single spawn_blocking to avoid blocking the async
-        // executor with synchronous FS reads (compute_skill_hash does std::fs::read).
+        // Step 1: collect all hashes and source classifications in a single spawn_blocking
+        // to avoid blocking the async executor with synchronous FS reads.
+        // Both compute_skill_hash (std::fs::read) and .bundled marker .exists() are blocking FS calls.
         let dirs: Vec<_> = all_meta_owned.iter().map(|m| m.skill_dir.clone()).collect();
-        let hashes: Vec<Option<String>> = tokio::task::spawn_blocking(move || {
-            dirs.iter()
-                .map(|dir| zeph_skills::compute_skill_hash(dir).ok())
-                .collect()
-        })
-        .await
-        .unwrap_or_else(|_| vec![None; all_meta_owned.len()]);
+        let managed_dir_clone = managed_dir.clone();
+        let per_skill: Vec<(Option<String>, zeph_memory::store::SourceKind)> =
+            tokio::task::spawn_blocking(move || {
+                dirs.iter()
+                    .map(|dir| {
+                        let hash = zeph_skills::compute_skill_hash(dir).ok();
+                        // .bundled marker is written by bundled.rs for skills shipped with the binary.
+                        let source_kind = if dir.starts_with(&managed_dir_clone) {
+                            if dir.join(".bundled").exists() {
+                                zeph_memory::store::SourceKind::Bundled
+                            } else {
+                                zeph_memory::store::SourceKind::Hub
+                            }
+                        } else {
+                            zeph_memory::store::SourceKind::Local
+                        };
+                        (hash, source_kind)
+                    })
+                    .collect()
+            })
+            .await
+            .unwrap_or_else(|_| {
+                all_meta_owned
+                    .iter()
+                    .map(|_| (None, zeph_memory::store::SourceKind::Local))
+                    .collect()
+            });
 
-        // Step 2: async DB calls using pre-computed hashes.
-        for (meta, maybe_hash) in all_meta_owned.iter().zip(hashes.iter()) {
-            let source_kind = if meta.skill_dir.starts_with(&managed_dir) {
-                zeph_memory::store::SourceKind::Hub
-            } else {
-                zeph_memory::store::SourceKind::Local
-            };
-            let initial_level = if matches!(source_kind, zeph_memory::store::SourceKind::Hub) {
-                &trust_cfg.default_level
-            } else {
-                &trust_cfg.local_level
+        // Step 2: async DB calls using pre-computed hashes and source classifications.
+        for (meta, (maybe_hash, source_kind)) in all_meta_owned.iter().zip(per_skill.iter()) {
+            let source_kind = source_kind.clone();
+            let initial_level = match source_kind {
+                zeph_memory::store::SourceKind::Bundled => &trust_cfg.bundled_level,
+                zeph_memory::store::SourceKind::Hub => &trust_cfg.default_level,
+                zeph_memory::store::SourceKind::Local | zeph_memory::store::SourceKind::File => {
+                    &trust_cfg.local_level
+                }
             };
             let Some(current_hash) = maybe_hash else {
                 tracing::warn!("failed to compute hash for '{}'", meta.name);
@@ -820,10 +839,29 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
                 .ok()
                 .flatten();
             let trust_level_str = if let Some(ref row) = existing {
-                if row.blake3_hash == *current_hash {
-                    row.trust_level.clone()
-                } else {
+                if row.blake3_hash != *current_hash {
                     trust_cfg.hash_mismatch_level.to_string()
+                } else if row.source_kind != source_kind {
+                    // source_kind changed (e.g., hub → bundled on upgrade).
+                    // Never override an explicit operator block, and preserve operator-promoted trust.
+                    let stored = row
+                        .trust_level
+                        .parse::<zeph_tools::SkillTrustLevel>()
+                        .unwrap_or_else(|_| {
+                            tracing::warn!(
+                                skill = %meta.name,
+                                raw = %row.trust_level,
+                                "unrecognised trust_level in DB, treating as quarantined"
+                            );
+                            zeph_tools::SkillTrustLevel::Quarantined
+                        });
+                    if !stored.is_active() || stored.severity() <= initial_level.severity() {
+                        row.trust_level.clone()
+                    } else {
+                        initial_level.to_string()
+                    }
+                } else {
+                    row.trust_level.clone()
                 }
             } else {
                 initial_level.to_string()


### PR DESCRIPTION
## Summary

- Bundled skills (web-search, git, github, browser, docker, etc.) received `Quarantined` trust on every fresh install because the trust DB population loop classified all skills in `managed_dir` as `SourceKind::Hub`, ignoring the `.bundled` marker file written by `provision_bundled_skills()`
- `TrustGateExecutor` blocked `bash`/`curl` execution for Quarantined skills, silently failing all built-in skills that use these tools
- Both the startup path (`src/runner.rs`) and the hot-reload path (`crates/zeph-core/src/agent/mod.rs`) had the same bug

## Changes

- Add `SourceKind::Bundled` variant to `crates/zeph-memory/src/store/trust.rs`
- Add `bundled_level: SkillTrustLevel` field to `TrustConfig` in `crates/zeph-config/src/security.rs` (default: `Trusted`, configurable)
- Fix startup trust DB loop: check `.bundled` marker inside `spawn_blocking` before classifying as Hub
- Fix hot-reload path: same `.bundled` marker check, same classification logic
- Migration: existing `hub/quarantined` rows upgraded to `bundled/trusted` on restart; operator-promoted levels (including `Blocked`) are preserved

## Test Plan

- [x] `cargo build --workspace` — 0 errors
- [x] `cargo clippy --workspace -- -D warnings` — 0 warnings
- [x] `cargo nextest run --workspace --lib --bins` — 7990 passed, 20 skipped
- [x] `cargo +nightly fmt --check` — clean
- [ ] Live session test: fresh trust DB + `cargo run --features full -- --config .local/config/testing.toml` → verify `web-search` executes without `trust=quarantined` in logs
- [ ] Hot-reload test: modify a bundled skill file while running → verify trust level unchanged

## Closes

Closes #3039. Part of epic #3041.