### PR TITLE
fix(skills): activate injection scanner and harden bundled skill trust pipeline (#3050)

### DIFF
--- a/.zeph/skills/os-automation/SKILL.md
+++ b/.zeph/skills/os-automation/SKILL.md
@@ -14,7 +14,7 @@ license: MIT
 compatibility: Uses built-in OS utilities; some features require specific tools (see per-platform references)
 metadata:
   author: zeph
-  version: "1.0"
+  version: "1.1"
 ---
 
 # OS Automation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **skills: bundled skill trust scanner bypass** (`#3045`, `#3046`, `#3049`, `#3050`): three
+  defense-in-depth fixes closing a trust elevation bypass where a hub-installed skill with a
+  forged `.bundled` marker could receive `bundled_level` trust. (1) `build_registry()` in
+  bootstrap now calls `.with_hub_dirs()` before `scan_loaded()`, activating the injection
+  scanner for all hub-managed skills. (2) `reload_skills()` in the agent hot-reload path now
+  calls `registry.reload()` instead of creating a fresh registry, so `hub_dirs` is preserved
+  across hot-reload cycles. (3) Startup and hot-reload trust classification now require both
+  a `.bundled` marker *and* presence in the compile-time `bundled_skill_names()` allowlist
+  (derived from embedded `BUNDLED_SKILLS_DIR`); skills with a forged marker that fail the
+  allowlist check are classified as `SourceKind::Hub` and emit a `WARN` log. Adds public
+  `bundled_skill_names()` API to `zeph-skills`.
+
+- **skills: stale comment in trust elevation path** (`#3047`): corrected misleading comment
+  in `runner.rs` and `agent/mod.rs` trust classification blocks — "preserve operator-promoted
+  trust" replaced with accurate description of the source-kind initial-level adoption logic.
+
+- **skills: os-automation SKILL.md version bump** (`#3048`): version field updated from
+  `"1.0"` to `"1.1"` to trigger re-provisioning and pick up latest skill content.
+
 - **skills: bundled skill trust level not distinguished from hub** (`#3041`): add
   `SourceKind::Bundled` variant to the trust store and a `bundled_level` config field
   (`[skills.trust] bundled_level = "trusted"`). Startup and hot-reload now detect the `.bundled`

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -1915,6 +1915,34 @@ impl<C: Channel> Agent<C> {
             .collect()
     }
 
+    /// Classify a skill directory's source kind using on-disk markers and the bundled allowlist.
+    ///
+    /// Must be called from a blocking context (uses synchronous FS I/O).
+    fn classify_source_kind(
+        skill_dir: &std::path::Path,
+        managed_dir: Option<&std::path::PathBuf>,
+        bundled_names: &std::collections::HashSet<String>,
+    ) -> zeph_memory::store::SourceKind {
+        if managed_dir.is_some_and(|d| skill_dir.starts_with(d)) {
+            let skill_name = skill_dir.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            let has_marker = skill_dir.join(".bundled").exists();
+            if has_marker && bundled_names.contains(skill_name) {
+                zeph_memory::store::SourceKind::Bundled
+            } else {
+                if has_marker {
+                    tracing::warn!(
+                        skill = %skill_name,
+                        "skill has .bundled marker but is not in the bundled skill \
+                         allowlist — classifying as Hub"
+                    );
+                }
+                zeph_memory::store::SourceKind::Hub
+            }
+        } else {
+            zeph_memory::store::SourceKind::Local
+        }
+    }
+
     /// Update trust DB records for all reloaded skills.
     async fn update_trust_for_reloaded_skills(
         &mut self,
@@ -1927,27 +1955,22 @@ impl<C: Channel> Agent<C> {
         };
         let trust_cfg = self.skill_state.trust_config.clone();
         let managed_dir = self.skill_state.managed_dir.clone();
+        let bundled_names: std::collections::HashSet<String> =
+            zeph_skills::bundled_skill_names().into_iter().collect();
         for meta in all_meta {
             // Compute hash and classify source_kind in spawn_blocking — both are blocking FS calls
             // (.bundled marker .exists() and compute_skill_hash both do std::fs I/O).
             let skill_dir = meta.skill_dir.clone();
             let managed_dir_ref = managed_dir.clone();
+            let bundled_names_ref = bundled_names.clone();
             let fs_result: Option<(String, zeph_memory::store::SourceKind)> =
                 tokio::task::spawn_blocking(move || {
                     let hash = zeph_skills::compute_skill_hash(&skill_dir).ok()?;
-                    // .bundled marker is written by bundled.rs for skills shipped with the binary.
-                    let source_kind = if managed_dir_ref
-                        .as_ref()
-                        .is_some_and(|d| skill_dir.starts_with(d))
-                    {
-                        if skill_dir.join(".bundled").exists() {
-                            zeph_memory::store::SourceKind::Bundled
-                        } else {
-                            zeph_memory::store::SourceKind::Hub
-                        }
-                    } else {
-                        zeph_memory::store::SourceKind::Local
-                    };
+                    let source_kind = Self::classify_source_kind(
+                        &skill_dir,
+                        managed_dir_ref.as_ref(),
+                        &bundled_names_ref,
+                    );
                     Some((hash, source_kind))
                 })
                 .await
@@ -1975,7 +1998,8 @@ impl<C: Channel> Agent<C> {
                     trust_cfg.hash_mismatch_level.to_string()
                 } else if row.source_kind != source_kind {
                     // source_kind changed (e.g., hub → bundled on upgrade).
-                    // Never override an explicit operator block, and preserve operator-promoted trust.
+                    // Never override an explicit operator block. For active trust levels,
+                    // adopt the source-kind initial level when it grants more trust.
                     let stored = row
                         .trust_level
                         .parse::<zeph_tools::SkillTrustLevel>()
@@ -2083,12 +2107,15 @@ impl<C: Channel> Agent<C> {
         tracing::instrument(name = "skill.hot_reload", skip_all)
     )]
     async fn reload_skills(&mut self) {
-        let new_registry = SkillRegistry::load(&self.skill_state.skill_paths);
-        if new_registry.fingerprint() == self.skill_state.fingerprint() {
+        let old_fp = self.skill_state.fingerprint();
+        self.skill_state
+            .registry
+            .write()
+            .reload(&self.skill_state.skill_paths);
+        if self.skill_state.fingerprint() == old_fp {
             return;
         }
         let _ = self.channel.send_status("reloading skills...").await;
-        *self.skill_state.registry.write() = new_registry;
 
         let all_meta = self
             .skill_state

--- a/crates/zeph-skills/src/bundled.rs
+++ b/crates/zeph-skills/src/bundled.rs
@@ -28,6 +28,31 @@ use tracing::{debug, info, warn};
 
 static BUNDLED_SKILLS_DIR: Dir<'static> = include_dir!("$CARGO_MANIFEST_DIR/skills");
 
+/// Returns the names of all compile-time bundled skills.
+///
+/// Names are derived from the embedded skill directory entries that contain
+/// a `SKILL.md` file. This list is authoritative — it cannot be influenced
+/// by on-disk state.
+#[must_use]
+pub fn bundled_skill_names() -> Vec<String> {
+    BUNDLED_SKILLS_DIR
+        .entries()
+        .iter()
+        .filter_map(|entry| {
+            let include_dir::DirEntry::Dir(d) = entry else {
+                return None;
+            };
+            let name = d.path().to_string_lossy().into_owned();
+            let skill_md = format!("{name}/SKILL.md");
+            if BUNDLED_SKILLS_DIR.get_file(&skill_md).is_some() {
+                Some(name)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
 /// Summary of a single provisioning run.
 #[derive(Debug, Default)]
 pub struct ProvisionReport {

--- a/crates/zeph-skills/src/lib.rs
+++ b/crates/zeph-skills/src/lib.rs
@@ -73,6 +73,7 @@ pub mod trust;
 pub mod trust_score;
 pub mod watcher;
 
+pub use bundled::bundled_skill_names;
 pub use error::SkillError;
 pub use generator::{GeneratedSkill, SkillGenerationRequest, SkillGenerator};
 pub use matcher::{IntentClassification, MatchResult, ScoredMatch};

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -522,8 +522,8 @@ impl AppBuilder {
     }
 
     pub fn build_registry(&self) -> SkillRegistry {
+        let managed = managed_skills_dir();
         {
-            let managed = managed_skills_dir();
             match zeph_skills::bundled::provision_bundled_skills(&managed) {
                 Ok(report) => {
                     if !report.installed.is_empty() {
@@ -549,7 +549,7 @@ impl AppBuilder {
         }
 
         let skill_paths = self.skill_paths();
-        let registry = SkillRegistry::load(&skill_paths);
+        let registry = SkillRegistry::load(&skill_paths).with_hub_dirs(std::iter::once(managed));
 
         if self.config.skills.trust.scan_on_load {
             let findings = registry.scan_loaded();

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -790,16 +790,29 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         // Both compute_skill_hash (std::fs::read) and .bundled marker .exists() are blocking FS calls.
         let dirs: Vec<_> = all_meta_owned.iter().map(|m| m.skill_dir.clone()).collect();
         let managed_dir_clone = managed_dir.clone();
+        let bundled_names: std::collections::HashSet<String> =
+            zeph_skills::bundled_skill_names().into_iter().collect();
         let per_skill: Vec<(Option<String>, zeph_memory::store::SourceKind)> =
             tokio::task::spawn_blocking(move || {
                 dirs.iter()
                     .map(|dir| {
                         let hash = zeph_skills::compute_skill_hash(dir).ok();
                         // .bundled marker is written by bundled.rs for skills shipped with the binary.
+                        // The allowlist check prevents a hub-installed skill with a forged .bundled
+                        // marker from receiving elevated bundled trust.
                         let source_kind = if dir.starts_with(&managed_dir_clone) {
-                            if dir.join(".bundled").exists() {
+                            let skill_name = dir.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                            let has_marker = dir.join(".bundled").exists();
+                            if has_marker && bundled_names.contains(skill_name) {
                                 zeph_memory::store::SourceKind::Bundled
                             } else {
+                                if has_marker {
+                                    tracing::warn!(
+                                        skill = %skill_name,
+                                        "skill has .bundled marker but is not in the bundled \
+                                         skill allowlist — classifying as Hub"
+                                    );
+                                }
                                 zeph_memory::store::SourceKind::Hub
                             }
                         } else {
@@ -843,7 +856,8 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
                     trust_cfg.hash_mismatch_level.to_string()
                 } else if row.source_kind != source_kind {
                     // source_kind changed (e.g., hub → bundled on upgrade).
-                    // Never override an explicit operator block, and preserve operator-promoted trust.
+                    // Never override an explicit operator block. For active trust levels,
+                    // adopt the source-kind initial level when it grants more trust.
                     let stored = row
                         .trust_level
                         .parse::<zeph_tools::SkillTrustLevel>()


### PR DESCRIPTION
## Summary

- **#3045 (P1/security):** `bootstrap/mod.rs` — chain `.with_hub_dirs()` before `scan_loaded()` so the injection scanner receives hub directory context on every startup; the defense added in #3040 was never active in production
- **#3046 (P2/security):** `agent/mod.rs` — replace fresh `SkillRegistry` construction in `reload_skills()` with `registry.reload()` to preserve `hub_dirs` across hot-reload ticks
- **#3049 (P2/security):** `runner.rs` + `agent/mod.rs` — guard trust elevation with a `bundled_skill_names()` allowlist on both startup and hot-reload paths; forged `.bundled` markers are rejected and logged
- **#3047 (P3):** Fix misleading comment in trust migration loop (both `runner.rs` and `agent/mod.rs`)
- **#3048 (P3):** Bump `os-automation` SKILL.md to version `1.1` to trigger re-provisioning and restore missing shell boundary instruction

## Test plan

- [ ] All 7998 existing tests pass (`cargo nextest run --workspace --all-features --lib --bins`)
- [ ] `cargo +nightly fmt --check` passes
- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] Run agent with `cargo run --features full -- --config .local/config/testing.toml` — all 5 bundled skills should load as `trusted` after startup migration
- [ ] Verify `os-automation` SKILL.md on disk matches embedded content after startup (shell boundary instruction present)
- [ ] Verify forged `.bundled` marker in hub dir does not elevate skill to `Trusted` (check warning log)

Closes #3045, #3046, #3047, #3048, #3049, #3050