### PR TITLE
Fix system metrics log level noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- fix(profiling): emit periodic system resource metrics on `TRACE` instead of `INFO` to keep
+  routine RSS/CPU/thread/fd snapshots out of normal logs; `target = "system.metrics"` is
+  unchanged
+
 ### Added
 
 - **skills: hub skill install pipeline** (`#2806`, `#3040`): `SkillManager` now exposes

--- a/crates/zeph-core/src/system_metrics.rs
+++ b/crates/zeph-core/src/system_metrics.rs
@@ -16,7 +16,7 @@ use tokio::task::JoinHandle;
 /// count at the configured interval and emits them as:
 ///
 /// ```text
-/// tracing::info!(target: "system.metrics", rss_bytes, cpu_percent, thread_count, fd_count);
+/// tracing::trace!(target: "system.metrics", rss_bytes, cpu_percent, thread_count, fd_count);
 /// ```
 ///
 /// Some metrics are platform-specific:
@@ -83,7 +83,7 @@ pub fn spawn_system_metrics_task(
                 None => (0, 0.0, 0, 0),
             };
 
-            tracing::info!(
+            tracing::trace!(
                 target: "system.metrics",
                 rss_bytes,
                 cpu_percent,


### PR DESCRIPTION
## Summary
- change periodic `system.metrics` resource snapshots from `INFO` to `TRACE`
- keep the `system.metrics` target unchanged so existing filtering still works
- update `system_metrics` documentation and add the change to `CHANGELOG.md`

## Testing
- Not run (not requested)