### PR TITLE
fix(tui): handle bracketed paste as single message

### DIFF
--- a/crates/zeph-tui/src/app.rs
+++ b/crates/zeph-tui/src/app.rs
@@ -1064,6 +1064,7 @@ impl App {
                 }
             }
             AppEvent::Agent(agent_event) => self.handle_agent_event(agent_event),
+            AppEvent::Paste(text) => self.handle_paste(&text),
         }
     }
 
@@ -2067,6 +2068,16 @@ impl App {
             pos += 1;
         }
         pos
+    }
+
+    fn handle_paste(&mut self, text: &str) {
+        if self.input_mode != InputMode::Insert {
+            return;
+        }
+        self.slash_autocomplete = None;
+        let byte_offset = self.byte_offset_of_char(self.cursor_position);
+        self.input.insert_str(byte_offset, text);
+        self.cursor_position += text.chars().count();
     }
 
     fn handle_insert_key(&mut self, key: KeyEvent) {
@@ -5103,6 +5114,52 @@ mod tests {
         );
 
         cancel.cancel();
+    }
+
+    #[test]
+    fn paste_inserts_text_in_insert_mode() {
+        let (mut app, _rx, _tx) = make_app();
+        app.handle_event(AppEvent::Paste("hello".to_owned()));
+        assert_eq!(app.input(), "hello");
+        assert_eq!(app.cursor_position(), 5);
+    }
+
+    #[test]
+    fn paste_at_mid_cursor_inserts_at_position() {
+        let (mut app, _rx, _tx) = make_app();
+        app.handle_event(AppEvent::Paste("ac".to_owned()));
+        // Move cursor to position 1 (between 'a' and 'c') via Left key
+        let left = KeyEvent::new(KeyCode::Left, KeyModifiers::NONE);
+        app.handle_event(AppEvent::Key(left));
+        app.handle_event(AppEvent::Paste("b".to_owned()));
+        assert_eq!(app.input(), "abc");
+        assert_eq!(app.cursor_position(), 2);
+    }
+
+    #[test]
+    fn paste_multiline_inserts_newlines() {
+        let (mut app, _rx, _tx) = make_app();
+        app.handle_event(AppEvent::Paste("line1\nline2".to_owned()));
+        assert_eq!(app.input(), "line1\nline2");
+        assert_eq!(app.cursor_position(), 11);
+    }
+
+    #[test]
+    fn paste_in_normal_mode_ignored() {
+        let (mut app, _rx, _tx) = make_app();
+        app.input_mode = InputMode::Normal;
+        app.handle_event(AppEvent::Paste("should not appear".to_owned()));
+        assert!(app.input().is_empty());
+    }
+
+    #[test]
+    fn paste_clears_slash_autocomplete() {
+        let (mut app, _rx, _tx) = make_app();
+        app.slash_autocomplete =
+            Some(crate::widgets::slash_autocomplete::SlashAutocompleteState::new());
+        app.handle_event(AppEvent::Paste("text".to_owned()));
+        assert!(app.slash_autocomplete.is_none());
+        assert_eq!(app.input(), "text");
     }
 
     #[test]

--- a/crates/zeph-tui/src/event.rs
+++ b/crates/zeph-tui/src/event.rs
@@ -80,6 +80,7 @@ impl EventSource for CrosstermEventSource {
                     MouseEventKind::ScrollDown => Some(AppEvent::MouseScroll(-1)),
                     _ => Some(AppEvent::Tick),
                 },
+                Ok(CrosstermEvent::Paste(text)) => Some(AppEvent::Paste(text)),
                 _ => Some(AppEvent::Tick),
             }
         } else {
@@ -114,6 +115,12 @@ pub enum AppEvent {
     MouseScroll(i8),
     /// An event forwarded from the agent event channel.
     Agent(AgentEvent),
+    /// Text pasted via bracketed paste mode.
+    ///
+    /// The string may contain `\n` characters (multiline paste). The app
+    /// inserts it verbatim into the input buffer; Enter is still required
+    /// to submit (matching vim/neovim behaviour).
+    Paste(String),
 }
 
 /// Events produced by the agent and forwarded to the TUI via [`crate::TuiChannel`].
@@ -313,5 +320,10 @@ mod tests {
 
         let scroll_down = AppEvent::MouseScroll(-1);
         assert!(matches!(scroll_down, AppEvent::MouseScroll(-1)));
+    }
+
+    #[test]
+    fn app_event_paste_variant() {
+        assert!(matches!(AppEvent::Paste("x".into()), AppEvent::Paste(_)));
     }
 }

--- a/crates/zeph-tui/src/lib.rs
+++ b/crates/zeph-tui/src/lib.rs
@@ -105,7 +105,8 @@ pub async fn run_tui(mut app: App, mut event_rx: mpsc::Receiver<AppEvent>) -> Re
         let _ = crossterm::execute!(
             io::stdout(),
             crossterm::terminal::LeaveAlternateScreen,
-            crossterm::event::DisableMouseCapture
+            crossterm::event::DisableMouseCapture,
+            crossterm::event::DisableBracketedPaste,
         );
         original_hook(info);
     }));
@@ -209,6 +210,7 @@ fn init_terminal() -> Result<Terminal<CrosstermBackend<io::Stdout>>, TuiError> {
         stdout,
         crossterm::terminal::EnterAlternateScreen,
         crossterm::event::EnableMouseCapture,
+        crossterm::event::EnableBracketedPaste,
     )?;
     let backend = CrosstermBackend::new(stdout);
     Ok(Terminal::new(backend)?)
@@ -220,6 +222,7 @@ fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Re
         terminal.backend_mut(),
         crossterm::terminal::LeaveAlternateScreen,
         crossterm::event::DisableMouseCapture,
+        crossterm::event::DisableBracketedPaste,
     )?;
     terminal.show_cursor()?;
     Ok(())


### PR DESCRIPTION
## Summary

- Enable bracketed paste mode (`EnableBracketedPaste`) in TUI terminal init so that pasting multiline text is delivered as a single `Event::Paste` event rather than individual key events where each newline triggered message submit
- Add `AppEvent::Paste(String)` variant and map it from crossterm `Event::Paste`
- Add `handle_paste()`: inserts full pasted text at cursor position without submitting, resets slash autocomplete, guarded to Insert mode only
- `DisableBracketedPaste` is cleaned up in all three paths: `restore_terminal`, panic hook, and normal exit

## Behavior

Terminals without bracketed paste support retain the previous behavior (individual key events). Trailing newlines in pasted text do not auto-submit — user must press Enter explicitly. This matches vim/neovim conventions.

## Test plan

- [ ] Paste multiline text (log dump) in TUI — should appear in input buffer as one block, not submit multiple messages
- [ ] Press Enter after paste — single message submitted
- [ ] 6 new unit tests added: baseline insert, mid-buffer, multiline `\n`, normal-mode guard, autocomplete dismissal, `AppEvent::Paste` variant
- [ ] 8004 tests pass, clippy clean, fmt clean