### PR TITLE
feat(tui): compact paste indicator in input + collapsible paste in chat

### DIFF
--- a/crates/zeph-tui/src/app.rs
+++ b/crates/zeph-tui/src/app.rs
@@ -22,6 +22,8 @@ use crate::widgets::slash_autocomplete::{SlashAutocompleteState, command_id_to_s
 pub use crate::render_cache::{RenderCache, RenderCacheEntry, RenderCacheKey, content_hash};
 pub use crate::types::{ChatMessage, InputMode, MessageRole};
 
+use crate::types::PasteState;
+
 /// Maximum number of chat messages retained in the TUI message buffer.
 /// Older messages are evicted from the front when the limit is exceeded (#2737).
 const MAX_TUI_MESSAGES: usize = 2000;
@@ -413,6 +415,9 @@ pub struct App {
     task_supervisor: Option<TaskSupervisor>,
     /// Whether the task registry panel is currently visible (toggled by `/tasks`).
     show_task_panel: bool,
+    /// Active paste indicator state. `Some` when a multiline paste is in the buffer
+    /// and the user has not yet edited or submitted the input.
+    paste_state: Option<PasteState>,
     /// Snapshot of supervisor tasks cached once per render tick before `terminal.draw()`.
     ///
     /// Avoids acquiring `TaskSupervisor`'s inner mutex inside the draw closure, which
@@ -492,6 +497,7 @@ impl App {
             pending_transcript: None,
             task_supervisor: None,
             show_task_panel: false,
+            paste_state: None,
             cached_task_snapshots: Vec::new(),
         }
     }
@@ -948,6 +954,15 @@ impl App {
     #[must_use]
     pub fn tool_expanded(&self) -> bool {
         self.tool_expanded
+    }
+
+    /// Return the active paste indicator state, if any.
+    ///
+    /// `Some` when a multiline paste is in the input buffer and no edit
+    /// keypress has occurred since the paste. `None` otherwise.
+    #[must_use]
+    pub fn paste_state(&self) -> Option<&PasteState> {
+        self.paste_state.as_ref()
     }
 
     /// Return `true` when tool blocks use compact single-line rendering.
@@ -2078,8 +2093,20 @@ impl App {
         let byte_offset = self.byte_offset_of_char(self.cursor_position);
         self.input.insert_str(byte_offset, text);
         self.cursor_position += text.chars().count();
+
+        let line_count = text.matches('\n').count() + 1;
+        if line_count >= 2 {
+            // Replace any existing paste indicator — new paste supersedes the old one.
+            self.paste_state = Some(PasteState {
+                line_count,
+                byte_len: text.len(),
+            });
+        } else {
+            self.paste_state = None;
+        }
     }
 
+    #[allow(clippy::too_many_lines)]
     fn handle_insert_key(&mut self, key: KeyEvent) {
         if self.slash_autocomplete.is_some() {
             self.handle_slash_autocomplete_key(key);
@@ -2087,6 +2114,8 @@ impl App {
         }
         match key.code {
             KeyCode::Enter if key.modifiers.contains(KeyModifiers::SHIFT) => {
+                // First edit keystroke after paste reveals raw text; clear indicator.
+                self.paste_state = None;
                 let byte_offset = self.byte_offset_of_char(self.cursor_position);
                 self.input.insert(byte_offset, '\n');
                 self.cursor_position += 1;
@@ -2094,6 +2123,8 @@ impl App {
             KeyCode::Enter => self.submit_input(),
             KeyCode::Esc => self.input_mode = InputMode::Normal,
             KeyCode::Backspace if key.modifiers.contains(KeyModifiers::ALT) => {
+                // First edit keystroke after paste reveals raw text; subsequent keystrokes edit normally.
+                self.paste_state = None;
                 let boundary = self.prev_word_boundary();
                 if boundary < self.cursor_position {
                     let start = self.byte_offset_of_char(boundary);
@@ -2103,6 +2134,8 @@ impl App {
                 }
             }
             KeyCode::Backspace => {
+                // First edit keystroke after paste reveals raw text; subsequent keystrokes edit normally.
+                self.paste_state = None;
                 if self.cursor_position > 0 {
                     let byte_offset = self.byte_offset_of_char(self.cursor_position - 1);
                     self.input.remove(byte_offset);
@@ -2110,6 +2143,8 @@ impl App {
                 }
             }
             KeyCode::Delete => {
+                // First edit keystroke after paste reveals raw text; subsequent keystrokes edit normally.
+                self.paste_state = None;
                 if self.cursor_position < self.char_count() {
                     let byte_offset = self.byte_offset_of_char(self.cursor_position);
                     self.input.remove(byte_offset);
@@ -2119,6 +2154,7 @@ impl App {
                 self.handle_history_up();
             }
             KeyCode::Down => {
+                self.paste_state = None;
                 let Some(i) = self.history_index else {
                     return;
                 };
@@ -2137,28 +2173,41 @@ impl App {
                 self.cursor_position = self.char_count();
             }
             KeyCode::Left if key.modifiers.contains(KeyModifiers::ALT) => {
+                self.paste_state = None;
                 self.cursor_position = self.prev_word_boundary();
             }
             KeyCode::Right if key.modifiers.contains(KeyModifiers::ALT) => {
+                self.paste_state = None;
                 self.cursor_position = self.next_word_boundary();
             }
             KeyCode::Left => {
+                self.paste_state = None;
                 self.cursor_position = self.cursor_position.saturating_sub(1);
             }
             KeyCode::Right => {
+                self.paste_state = None;
                 if self.cursor_position < self.char_count() {
                     self.cursor_position += 1;
                 }
             }
-            KeyCode::Home => self.cursor_position = 0,
-            KeyCode::End => self.cursor_position = self.char_count(),
+            KeyCode::Home => {
+                self.paste_state = None;
+                self.cursor_position = 0;
+            }
+            KeyCode::End => {
+                self.paste_state = None;
+                self.cursor_position = self.char_count();
+            }
             KeyCode::Char('a') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.paste_state = None;
                 self.cursor_position = 0;
             }
             KeyCode::Char('e') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.paste_state = None;
                 self.cursor_position = self.char_count();
             }
             KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.paste_state = None;
                 self.input.clear();
                 self.cursor_position = 0;
             }
@@ -2169,6 +2218,8 @@ impl App {
                 self.open_file_picker();
             }
             KeyCode::Char(c) => {
+                // First edit keystroke after paste reveals raw text; subsequent keystrokes edit normally.
+                self.paste_state = None;
                 let was_empty = self.input.is_empty();
                 let byte_offset = self.byte_offset_of_char(self.cursor_position);
                 self.input.insert(byte_offset, c);
@@ -2259,6 +2310,7 @@ impl App {
     }
 
     fn handle_history_up(&mut self) {
+        self.paste_state = None;
         if self.input.is_empty() && self.pending_count > 0 && self.history_index.is_none() {
             if let Some(last) = self.input_history.pop() {
                 self.input = last;
@@ -2391,8 +2443,10 @@ impl App {
         }
         self.history_index = None;
         self.draft_input.clear();
-        self.messages
-            .push(ChatMessage::new(MessageRole::User, text.clone()));
+        let paste_lines = self.paste_state.take().map(|p| p.line_count);
+        let mut msg = ChatMessage::new(MessageRole::User, text.clone());
+        msg.paste_line_count = paste_lines;
+        self.messages.push(msg);
         self.trim_messages();
         self.input.clear();
         self.cursor_position = 0;
@@ -5178,5 +5232,125 @@ mod tests {
         );
         // Confirm byte-slicing the full string at char-boundary position doesn't panic.
         let _ = &long_name[..truncated.len()];
+    }
+
+    #[test]
+    fn paste_state_set_for_multiline() {
+        let (mut app, _rx, _tx) = make_app();
+        app.input_mode = InputMode::Insert;
+        app.handle_event(AppEvent::Paste("line1\nline2\nline3".to_owned()));
+        let ps = app.paste_state().expect("paste_state should be Some");
+        assert_eq!(ps.line_count, 3);
+        assert_eq!(ps.byte_len, "line1\nline2\nline3".len());
+    }
+
+    #[test]
+    fn paste_state_none_for_single_line() {
+        let (mut app, _rx, _tx) = make_app();
+        app.input_mode = InputMode::Insert;
+        app.handle_event(AppEvent::Paste("single line".to_owned()));
+        assert!(app.paste_state().is_none());
+    }
+
+    #[test]
+    fn paste_state_cleared_on_char() {
+        let (mut app, _rx, _tx) = make_app();
+        app.input_mode = InputMode::Insert;
+        app.handle_event(AppEvent::Paste("a\nb".to_owned()));
+        assert!(app.paste_state().is_some());
+        app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Char('x'),
+            KeyModifiers::NONE,
+        )));
+        assert!(app.paste_state().is_none());
+    }
+
+    #[test]
+    fn paste_state_cleared_on_backspace() {
+        let (mut app, _rx, _tx) = make_app();
+        app.input_mode = InputMode::Insert;
+        app.handle_event(AppEvent::Paste("a\nb".to_owned()));
+        assert!(app.paste_state().is_some());
+        app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Backspace,
+            KeyModifiers::NONE,
+        )));
+        assert!(app.paste_state().is_none());
+    }
+
+    #[test]
+    fn paste_state_cleared_on_ctrl_u() {
+        let (mut app, _rx, _tx) = make_app();
+        app.input_mode = InputMode::Insert;
+        app.handle_event(AppEvent::Paste("a\nb".to_owned()));
+        assert!(app.paste_state().is_some());
+        app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Char('u'),
+            KeyModifiers::CONTROL,
+        )));
+        assert!(app.paste_state().is_none());
+        assert!(
+            app.input().is_empty(),
+            "Ctrl+U must also clear input buffer"
+        );
+    }
+
+    #[test]
+    fn paste_state_cleared_on_shift_enter() {
+        let (mut app, _rx, _tx) = make_app();
+        app.input_mode = InputMode::Insert;
+        app.handle_event(AppEvent::Paste("a\nb".to_owned()));
+        assert!(app.paste_state().is_some());
+        app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Enter,
+            KeyModifiers::SHIFT,
+        )));
+        assert!(app.paste_state().is_none());
+    }
+
+    #[test]
+    fn paste_state_cleared_on_navigation() {
+        let (mut app, _rx, _tx) = make_app();
+        app.input_mode = InputMode::Insert;
+
+        // Left arrow
+        app.handle_event(AppEvent::Paste("a\nb".to_owned()));
+        assert!(app.paste_state().is_some());
+        app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Left,
+            KeyModifiers::NONE,
+        )));
+        assert!(app.paste_state().is_none(), "Left must clear paste_state");
+
+        // Home key
+        app.handle_event(AppEvent::Paste("c\nd".to_owned()));
+        assert!(app.paste_state().is_some());
+        app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Home,
+            KeyModifiers::NONE,
+        )));
+        assert!(app.paste_state().is_none(), "Home must clear paste_state");
+    }
+
+    #[test]
+    fn paste_state_consumed_on_submit() {
+        let (mut app, _rx, _tx) = make_app();
+        app.input_mode = InputMode::Insert;
+        app.handle_event(AppEvent::Paste("line1\nline2\nline3\nline4".to_owned()));
+        assert!(app.paste_state().is_some());
+        app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Enter,
+            KeyModifiers::NONE,
+        )));
+        assert!(
+            app.paste_state().is_none(),
+            "paste_state cleared after submit"
+        );
+        assert_eq!(app.messages().len(), 1);
+        assert_eq!(
+            app.messages()[0].paste_line_count,
+            Some(4),
+            "paste_line_count must be set on submitted message"
+        );
     }
 }

--- a/crates/zeph-tui/src/lib.rs
+++ b/crates/zeph-tui/src/lib.rs
@@ -65,7 +65,7 @@ pub use metrics::{MetricsCollector, MetricsSnapshot};
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 use tokio::sync::mpsc;
-pub use types::{ChatMessage, InputMode, MessageRole};
+pub use types::{ChatMessage, InputMode, MessageRole, PasteState};
 
 /// Run the TUI dashboard until the user quits.
 ///

--- a/crates/zeph-tui/src/types.rs
+++ b/crates/zeph-tui/src/types.rs
@@ -1,6 +1,27 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+/// Metadata for an active paste in the input buffer.
+///
+/// Present only while the input contains unsubmitted pasted text that was
+/// multiline (two or more lines). Single-line pastes do not set this.
+///
+/// # Examples
+///
+/// ```rust
+/// use zeph_tui::PasteState;
+///
+/// let ps = PasteState { line_count: 5, byte_len: 128 };
+/// assert_eq!(ps.line_count, 5);
+/// ```
+#[derive(Debug, Clone)]
+pub struct PasteState {
+    /// Number of lines in the pasted text (always >= 2).
+    pub line_count: usize,
+    /// Byte length of the pasted text.
+    pub byte_len: usize,
+}
+
 /// The current text-input mode of the TUI.
 ///
 /// Inspired by modal editors: in `Normal` mode key bindings trigger actions;
@@ -81,6 +102,10 @@ pub struct ChatMessage {
     pub kept_lines: Option<Vec<usize>>,
     /// Wall-clock time formatted as `HH:MM` when the message was created.
     pub timestamp: String,
+    /// Number of lines in the pasted content when this message was submitted
+    /// from a paste. `Some(n)` (n >= 2) enables collapsible display in the
+    /// chat renderer; `None` means normal display.
+    pub paste_line_count: Option<usize>,
 }
 
 impl ChatMessage {
@@ -105,6 +130,7 @@ impl ChatMessage {
             filter_stats: None,
             kept_lines: None,
             timestamp: format_local_time(),
+            paste_line_count: None,
         }
     }
 

--- a/crates/zeph-tui/src/widgets/chat.rs
+++ b/crates/zeph-tui/src/widgets/chat.rs
@@ -258,13 +258,21 @@ fn render_message_lines(
         );
         Vec::new()
     } else {
-        render_chat_message(msg, theme, wrap_width, show_labels, &mut lines)
+        render_chat_message(
+            msg,
+            tool_expanded,
+            theme,
+            wrap_width,
+            show_labels,
+            &mut lines,
+        )
     };
     (lines, md_links)
 }
 
 fn render_chat_message(
     msg: &crate::app::ChatMessage,
+    tool_expanded: bool,
     theme: &Theme,
     wrap_width: usize,
     _show_labels: bool,
@@ -280,6 +288,42 @@ fn render_chat_message(
 
     let indent = " ".repeat(prefix.len());
     let is_assistant = msg.role == MessageRole::Assistant;
+
+    // Collapsible paste block: show first PASTE_COLLAPSED_LINES lines and an
+    // expand hint when the message was submitted from a multiline paste and the
+    // global expand toggle is off. This reuses tool_expanded deliberately —
+    // 'e' means "show full content" for all collapsible blocks (paste and tool output).
+    if let Some(total_lines) = msg.paste_line_count
+        && !tool_expanded
+        && total_lines > PASTE_COLLAPSED_LINES
+    {
+        let content_lines: Vec<&str> = msg.content.lines().collect();
+        let visible: Vec<&str> = content_lines
+            .iter()
+            .take(PASTE_COLLAPSED_LINES)
+            .copied()
+            .collect();
+        let preview = visible.join("\n");
+        let (styled_lines, md_links) = render_md(&preview, base_style, theme);
+        for (i, spans) in styled_lines.iter().enumerate() {
+            let mut line_spans = Vec::with_capacity(spans.len() + 1);
+            let pfx = if i == 0 {
+                prefix.to_string()
+            } else {
+                indent.clone()
+            };
+            line_spans.push(Span::styled(pfx, base_style));
+            line_spans.extend(spans.iter().cloned());
+            lines.extend(wrap_spans(line_spans, wrap_width));
+        }
+        let hidden = total_lines - PASTE_COLLAPSED_LINES;
+        let dim = Style::default().add_modifier(Modifier::DIM);
+        lines.push(Line::from(Span::styled(
+            format!("[... {hidden} more lines — press e to expand]"),
+            dim,
+        )));
+        return md_links;
+    }
 
     let (styled_lines, md_links) = if is_assistant {
         render_with_thinking(&msg.content, base_style, theme)
@@ -358,6 +402,10 @@ fn render_scrollbar(
 }
 
 const TOOL_OUTPUT_COLLAPSED_LINES: usize = 3;
+
+/// Number of lines shown in a collapsed paste block before the expand hint.
+/// Mirrors `TOOL_OUTPUT_COLLAPSED_LINES` for visual consistency.
+const PASTE_COLLAPSED_LINES: usize = 3;
 
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 fn render_tool_message(
@@ -1196,5 +1244,90 @@ mod tests {
         assert_eq!(lines.len(), 5);
         let data: String = lines[3].iter().map(|s| s.content.as_ref()).collect();
         assert!(data.contains('1'));
+    }
+
+    fn make_paste_msg(content: &str, paste_line_count: Option<usize>) -> crate::app::ChatMessage {
+        let mut msg = crate::app::ChatMessage::new(crate::app::MessageRole::User, content);
+        msg.paste_line_count = paste_line_count;
+        msg
+    }
+
+    fn lines_text(lines: &[ratatui::text::Line<'_>]) -> String {
+        lines
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn paste_collapsed_shows_first_3_lines() {
+        let theme = Theme::default();
+        let content = "alpha\nbeta\ngamma\ndelta\nepsilon";
+        let msg = make_paste_msg(content, Some(5));
+        let mut lines = Vec::new();
+        render_chat_message(&msg, false, &theme, 80, false, &mut lines);
+        let text = lines_text(&lines);
+        assert!(text.contains("alpha"), "first line must be visible");
+        assert!(text.contains("beta"), "second line must be visible");
+        assert!(text.contains("gamma"), "third line must be visible");
+        assert!(
+            !text.contains("delta"),
+            "fourth line must be hidden when collapsed"
+        );
+        assert!(
+            text.contains("more lines"),
+            "expand hint must be present: {text}"
+        );
+    }
+
+    #[test]
+    fn paste_collapsed_no_hint_for_3_or_fewer_lines() {
+        let theme = Theme::default();
+        // 2 lines — no hint (nothing hidden beyond PASTE_COLLAPSED_LINES=3)
+        let content_2 = "one\ntwo";
+        let msg_2 = make_paste_msg(content_2, Some(2));
+        let mut lines_2 = Vec::new();
+        render_chat_message(&msg_2, false, &theme, 80, false, &mut lines_2);
+        assert!(
+            !lines_text(&lines_2).contains("more lines"),
+            "no hint for 2-line paste"
+        );
+        // Exactly 3 lines — still no hint (collapse only triggers when > 3)
+        let content_3 = "one\ntwo\nthree";
+        let msg_3 = make_paste_msg(content_3, Some(3));
+        let mut lines_3 = Vec::new();
+        render_chat_message(&msg_3, false, &theme, 80, false, &mut lines_3);
+        assert!(
+            !lines_text(&lines_3).contains("more lines"),
+            "no hint for 3-line paste"
+        );
+    }
+
+    #[test]
+    fn paste_expanded_shows_all_lines() {
+        let theme = Theme::default();
+        let content = "alpha\nbeta\ngamma\ndelta\nepsilon";
+        let msg = make_paste_msg(content, Some(5));
+        let mut lines = Vec::new();
+        render_chat_message(&msg, true, &theme, 80, false, &mut lines);
+        let text = lines_text(&lines);
+        assert!(
+            text.contains("delta"),
+            "fourth line must be visible when expanded"
+        );
+        assert!(
+            text.contains("epsilon"),
+            "fifth line must be visible when expanded"
+        );
+        assert!(
+            !text.contains("more lines"),
+            "no hint when expanded: {text}"
+        );
     }
 }

--- a/crates/zeph-tui/src/widgets/input.rs
+++ b/crates/zeph-tui/src/widgets/input.rs
@@ -32,7 +32,23 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect) {
         block = block.title_bottom(Span::styled(" [editing queued] ", theme.highlight));
     }
 
-    let paragraph = if app.input().is_empty() && matches!(app.input_mode(), InputMode::Insert) {
+    let paragraph = if let Some(ps) = app.paste_state() {
+        // Show compact indicator while multiline paste is pending in the buffer.
+        // Cursor is not shown — the user cannot edit within the indicator display.
+        let size_label = if ps.byte_len >= 1024 {
+            // Integer KB with one decimal place; precision loss at >4 PB is acceptable.
+            #[allow(clippy::cast_precision_loss)]
+            let kb = ps.byte_len as f64 / 1024.0;
+            format!("{kb:.1} KB")
+        } else {
+            format!("{} B", ps.byte_len)
+        };
+        let indicator = format!("[Pasted: {} lines · {}]", ps.line_count, size_label);
+        Paragraph::new(indicator)
+            .block(block)
+            .style(theme.system_message)
+            .wrap(Wrap { trim: false })
+    } else if app.input().is_empty() && matches!(app.input_mode(), InputMode::Insert) {
         Paragraph::new("Type a message, / for commands, @ to mention")
             .block(block)
             .style(theme.system_message)
@@ -46,7 +62,9 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect) {
 
     frame.render_widget(paragraph, area);
 
-    if matches!(app.input_mode(), InputMode::Insert) {
+    // Do not show cursor when paste indicator is active — the user interacts
+    // with the indicator as a whole unit, not individual characters.
+    if app.paste_state().is_none() && matches!(app.input_mode(), InputMode::Insert) {
         let prefix: String = app.input().chars().take(app.cursor_position()).collect();
         let last_line = prefix.rsplit('\n').next().unwrap_or(&prefix);
         #[allow(clippy::cast_possible_truncation)]


### PR DESCRIPTION
## Summary

Improves the paste UX in zeph-tui with two features built on top of the bracketed paste support:

**Input area — compact indicator**
Instead of rendering raw pasted text in the input box, a single-line indicator is shown:
```
[Pasted: 42 lines · 1.2 KB]
```
The raw buffer is preserved and submitted on Enter as normal. The indicator clears on any edit key: Char, Backspace, Delete, Shift+Enter, Ctrl+U, navigation (Left/Right/Home/End/Ctrl+A/E/Alt+Left/Right), and history navigation.

**Chat — collapsible paste blocks**
Submitted messages containing a paste render as collapsible blocks:
- Collapsed (default): first 3 lines + `[... N more lines — press e to expand]`
- Expanded: full content (via the existing `e` toggle, same as tool output)

Single-line pastes and paste content ≤ 3 lines show no collapse hint.

## Behavior notes
- Trailing newline in pasted text does not auto-submit (by design, matches vim/neovim conventions)
- The `e` key expands all paste blocks and tool outputs simultaneously (global toggle)

## Test plan
- [ ] Paste a multiline log dump — input shows `[Pasted: N lines · X KB]` indicator
- [ ] Press Enter — single message submitted, appears collapsed in chat with `[... N more lines — press e to expand]`
- [ ] Press `e` — paste block expands to full content
- [ ] Type a character while indicator is showing — indicator clears, raw text visible
- [ ] Press Left/Right while indicator is showing — indicator clears
- [ ] Ctrl+U while indicator is showing — indicator and buffer both cleared
- [ ] Paste single line — no indicator, no collapse in chat
- [ ] 8015 tests pass, clippy clean, fmt clean