### PR TITLE
fix(llm,index): Thompson 429 double-penalty + upsert CONFLICT target (#3060, #3065)

### DIFF
--- a/crates/zeph-index/src/store.rs
+++ b/crates/zeph-index/src/store.rs
@@ -183,8 +183,8 @@ impl CodeStore {
             sql!("INSERT INTO chunk_metadata \
              (qdrant_id, file_path, content_hash, line_start, line_end, language, node_type, entity_name) \
              VALUES (?, ?, ?, ?, ?, ?, ?, ?) \
-             ON CONFLICT(qdrant_id) DO UPDATE SET \
-               file_path = excluded.file_path, content_hash = excluded.content_hash, \
+             ON CONFLICT(file_path, content_hash) DO UPDATE SET \
+               qdrant_id = excluded.qdrant_id, \
                line_start = excluded.line_start, line_end = excluded.line_end, \
                language = excluded.language, node_type = excluded.node_type, \
                entity_name = excluded.entity_name"),
@@ -262,8 +262,8 @@ impl CodeStore {
                 sql!("INSERT INTO chunk_metadata \
                  (qdrant_id, file_path, content_hash, line_start, line_end, language, node_type, entity_name) \
                  VALUES (?, ?, ?, ?, ?, ?, ?, ?) \
-                 ON CONFLICT(qdrant_id) DO UPDATE SET \
-                   file_path = excluded.file_path, content_hash = excluded.content_hash, \
+                 ON CONFLICT(file_path, content_hash) DO UPDATE SET \
+                   qdrant_id = excluded.qdrant_id, \
                    line_start = excluded.line_start, line_end = excluded.line_end, \
                    language = excluded.language, node_type = excluded.node_type, \
                    entity_name = excluded.entity_name"),
@@ -643,6 +643,60 @@ mod tests {
         assert_eq!(files.len(), 2);
         assert!(files.contains(&"src/a.rs".to_string()));
         assert!(files.contains(&"src/b.rs".to_string()));
+    }
+
+    /// Verifies that inserting the same (file_path, content_hash) twice does not
+    /// produce a duplicate row — the ON CONFLICT(file_path, content_hash) clause
+    /// must perform an UPDATE, not a second INSERT.
+    #[tokio::test]
+    async fn upsert_same_file_path_and_hash_is_idempotent() {
+        let pool = setup_pool().await;
+
+        for i in 0..2_u32 {
+            zeph_db::query(sql!(
+                "INSERT INTO chunk_metadata \
+                 (qdrant_id, file_path, content_hash, line_start, line_end, language, node_type) \
+                 VALUES (?, ?, ?, ?, ?, ?, ?) \
+                 ON CONFLICT(file_path, content_hash) DO UPDATE SET \
+                   qdrant_id = excluded.qdrant_id, \
+                   line_start = excluded.line_start, line_end = excluded.line_end, \
+                   language = excluded.language, node_type = excluded.node_type, \
+                   entity_name = excluded.entity_name"
+            ))
+            .bind(format!("q{i}"))
+            .bind("src/lib.rs")
+            .bind("dedup_hash")
+            .bind(1_i64)
+            .bind(5_i64)
+            .bind("rust")
+            .bind("function_item")
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        let count: (i64,) = zeph_db::query_as(sql!(
+            "SELECT COUNT(*) FROM chunk_metadata \
+             WHERE file_path = 'src/lib.rs' AND content_hash = 'dedup_hash'"
+        ))
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(count.0, 1, "duplicate upsert must not produce a second row");
+
+        // The second upsert must have updated qdrant_id to the latest value.
+        let qdrant_id: (String,) = zeph_db::query_as(sql!(
+            "SELECT qdrant_id FROM chunk_metadata \
+             WHERE file_path = 'src/lib.rs' AND content_hash = 'dedup_hash'"
+        ))
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            qdrant_id.0, "q1",
+            "qdrant_id must reflect the latest upsert"
+        );
     }
 
     #[tokio::test]

--- a/crates/zeph-llm/src/router/mod.rs
+++ b/crates/zeph-llm/src/router/mod.rs
@@ -1358,6 +1358,9 @@ impl LlmProvider for RouterProvider {
                             false,
                             u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
                         );
+                        if e.is_rate_limited() {
+                            router.record_availability(p.name(), false, 0);
+                        }
                         if let Some(ref tx) = status_tx {
                             let _ = tx.send(format!("router: {} failed, falling back", p.name()));
                         }
@@ -1427,6 +1430,9 @@ impl LlmProvider for RouterProvider {
                             false,
                             u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
                         );
+                        if e.is_rate_limited() {
+                            router.record_availability(p.name(), false, 0);
+                        }
                         if let Some(ref tx) = status_tx {
                             let _ = tx.send(format!("router: {} failed, falling back", p.name()));
                         }
@@ -1700,6 +1706,9 @@ impl LlmProvider for RouterProvider {
                             false,
                             u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
                         );
+                        if e.is_rate_limited() {
+                            router.record_availability(p.name(), false, 0);
+                        }
                         if let Some(ref tx) = status_tx {
                             let _ = tx.send(format!(
                                 "router: {} tool call failed, falling back",

--- a/crates/zeph-llm/src/router/thompson.rs
+++ b/crates/zeph-llm/src/router/thompson.rs
@@ -478,6 +478,31 @@ mod tests {
         );
     }
 
+    /// Verifies that a 429 rate-limit error causes the beta distribution to shift by 2
+    /// (one from the normal failure path + one extra penalty for rate-limit).
+    ///
+    /// This mirrors `record_availability(false, latency)` followed by
+    /// `record_availability(false, 0)` in the router's chat dispatch on `is_rate_limited()`.
+    #[test]
+    fn rate_limited_error_increments_beta_by_two() {
+        let mut state = ThompsonState::default();
+        // Simulate the two record_availability(false) calls that happen on a 429 error.
+        state.update("provider", false); // normal failure
+        state.update("provider", false); // extra penalty for rate-limit
+        let dist = state.get_distribution("provider");
+        // Default prior: beta = 1.0; after two failures: beta = 3.0.
+        assert!(
+            (dist.beta - 3.0).abs() < f64::EPSILON,
+            "expected beta=3.0 after two failures, got {}",
+            dist.beta
+        );
+        assert!(
+            (dist.alpha - 1.0).abs() < f64::EPSILON,
+            "alpha must remain unchanged at 1.0, got {}",
+            dist.alpha
+        );
+    }
+
     #[test]
     fn load_clamps_out_of_range_values() {
         let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

- **#3060**: Thompson router now applies double beta-penalty on HTTP 429 (rate limited) errors, shifting the provider from `Beta(1,2)` to `Beta(1,3)` immediately. Applied in `chat()`, `chat_stream()`, and `chat_with_tools()` error branches in `crates/zeph-llm/src/router/mod.rs`.
- **#3065**: Fixed `ON CONFLICT(qdrant_id)` → `ON CONFLICT(file_path, content_hash)` in `upsert_chunk` and `upsert_chunks_batch` in `crates/zeph-index/src/store.rs`. The old target never fired because `qdrant_id` is regenerated on every pass; re-indexing unchanged files now correctly upserts instead of dropping the batch.

## Test plan

- [ ] `rate_limited_error_increments_beta_by_two` — asserts `beta == 3.0` after two `record_availability(false)` calls
- [ ] `upsert_same_file_path_and_hash_is_idempotent` — inserts same `(file_path, content_hash)` twice, asserts row count stays 1 and `qdrant_id` reflects latest write
- [ ] 8100 tests pass, 20 skipped (full workspace)

Closes #3060, closes #3065