### PR TITLE
fix(mcp): downgrade per-branch depth-cap WARN to debug in sanitizer

### DIFF
--- a/crates/zeph-mcp/src/sanitize.rs
+++ b/crates/zeph-mcp/src/sanitize.rs
@@ -301,7 +301,7 @@ fn sanitize_schema_value_tracked(
     depth: usize,
 ) {
     if depth > MAX_SCHEMA_DEPTH {
-        tracing::warn!(
+        tracing::debug!(
             server_id = ctx.server_id,
             tool_name = ctx.tool_name,
             max_depth = MAX_SCHEMA_DEPTH,
@@ -994,6 +994,40 @@ mod tests {
         // Should not panic; inner injection at depth > MAX_SCHEMA_DEPTH stays unsanitized
         // (acceptable: excessively deep schemas are already flagged via WARN)
         sanitize_schema_value(&mut schema, "srv", "t", 0);
+    }
+
+    #[test]
+    fn schema_deep_recursion_sets_depth_cap_hit() {
+        // Multiple sibling branches each exceeding MAX_SCHEMA_DEPTH — depth_cap_hit must be set.
+        let deep_branch = || {
+            let mut node = serde_json::json!({ "type": "string" });
+            for _ in 0..15 {
+                node = serde_json::json!({ "items": node });
+            }
+            node
+        };
+        let mut schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "a": deep_branch(),
+                "b": deep_branch(),
+            }
+        });
+
+        let mut depth_cap_hit = false;
+        let mut ctx = SchemaWalkCtx {
+            server_id: "srv",
+            tool_name: "t",
+            injection_count: &mut 0,
+            flagged_patterns: &mut Vec::new(),
+            flagged_parameters: &mut Vec::new(),
+            depth_cap_hit: &mut depth_cap_hit,
+        };
+        sanitize_schema_value_tracked(&mut schema, &mut ctx, "", 0);
+        assert!(
+            depth_cap_hit,
+            "depth_cap_hit must be true when schema exceeds MAX_SCHEMA_DEPTH"
+        );
     }
 
     // --- sanitize_tools (integration) ---


### PR DESCRIPTION
## Summary

- `sanitize_schema_value_tracked()` emitted a `warn!` for every recursive branch hitting `MAX_SCHEMA_DEPTH`, producing N identical WARNs per tool at startup
- Downgrade the per-branch `warn!` to `debug!`; the single meaningful "output_schema dropped" WARN at line 448 is unchanged
- Add test `schema_deep_recursion_sets_depth_cap_hit` asserting `depth_cap_hit == true` for multi-branch deep schemas

## Test plan

- [x] `cargo clippy -p zeph-mcp --all-features -- -D warnings` — clean
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo nextest run --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 8311 passed

Closes #3078