### PR TITLE
feat(orchestration,llm): AdaptOrch topology advisor + CoE entropy routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **feat(orchestration): AdaptOrch topology advisor** — 16-arm Thompson Beta-bandit that classifies
+  goals into `TaskClass` variants and samples `TopologyHint` (Sequential / Parallel / Cascade /
+  Adaptive) to inject into the planner prompt. Outcomes are recorded synchronously; state persists
+  to disk on graceful shutdown. Enabled via `[orchestration.adaptorch]` config block.
+  Closes #2434.
+- **feat(llm): Collaborative Entropy (`CoE`) routing** — per-call `ChatExtras { entropy }` returned
+  by `chat_with_extras()` for all providers (OpenAI, Compatible, Ollama, Mock). Router uses
+  intra-entropy threshold and inter-divergence `(1-cosine)/2` to escalate uncertain primary
+  responses to a configured secondary provider. Gated to `Ema` and `Thompson` routing strategies.
+  Configured via `[llm.coe]` block. Closes #2505.
+
 ### Security
 
 - **sandbox/macos: Workspace profile no longer scopes file reads to `/usr|/bin|/sbin|/lib`.** The

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10411,10 +10411,15 @@ name = "zeph-orchestration"
 version = "0.19.1"
 dependencies = [
  "blake3",
+ "dirs",
  "futures",
+ "parking_lot",
+ "rand 0.10.1",
+ "rand_distr 0.6.0",
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/zeph-config/src/experiment.rs
+++ b/crates/zeph-config/src/experiment.rs
@@ -218,6 +218,10 @@ pub struct OrchestrationConfig {
     /// end-to-end latency. Default: false (opt-in).
     #[serde(default)]
     pub tree_optimized_dispatch: bool,
+
+    /// `AdaptOrch` bandit-driven topology advisor. Default: disabled.
+    #[serde(default)]
+    pub adaptorch: AdaptOrchConfig,
 }
 
 impl Default for OrchestrationConfig {
@@ -246,6 +250,57 @@ impl Default for OrchestrationConfig {
             cascade_routing: false,
             cascade_failure_threshold: default_cascade_failure_threshold(),
             tree_optimized_dispatch: false,
+            adaptorch: AdaptOrchConfig::default(),
+        }
+    }
+}
+
+/// Configuration for `AdaptOrch` — bandit-driven topology advisor (`[orchestration.adaptorch]`).
+///
+/// # Example
+///
+/// ```toml
+/// [orchestration.adaptorch]
+/// enabled = true
+/// topology_provider = "fast"
+/// classify_timeout_secs = 4
+/// state_path = ""
+/// ```
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct AdaptOrchConfig {
+    /// Enable `AdaptOrch`. When `false`, planning uses the default `plan()` path.
+    pub enabled: bool,
+    /// Provider name from `[[llm.providers]]` for goal classification. Empty → primary provider.
+    pub topology_provider: ProviderName,
+    /// Hard timeout (seconds) for the classification LLM call.
+    #[serde(default = "default_classify_timeout_secs")]
+    pub classify_timeout_secs: u64,
+    /// Path to the persisted Beta-arm JSON state file.
+    /// Empty string → `~/.zeph/adaptorch_state.json` (resolved at runtime).
+    #[serde(default)]
+    pub state_path: String,
+    /// Maximum tokens for the classification LLM call.
+    #[serde(default = "default_max_classify_tokens")]
+    pub max_classify_tokens: u32,
+}
+
+fn default_classify_timeout_secs() -> u64 {
+    4
+}
+
+fn default_max_classify_tokens() -> u32 {
+    80
+}
+
+impl Default for AdaptOrchConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            topology_provider: ProviderName::default(),
+            classify_timeout_secs: default_classify_timeout_secs(),
+            state_path: String::new(),
+            max_classify_tokens: default_max_classify_tokens(),
         }
     }
 }

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -94,7 +94,9 @@ pub use defaults::{
     is_legacy_default_sqlite_path,
 };
 pub use dump_format::DumpFormat;
-pub use experiment::{ExperimentConfig, ExperimentSchedule, OrchestrationConfig, PlanCacheConfig};
+pub use experiment::{
+    AdaptOrchConfig, ExperimentConfig, ExperimentSchedule, OrchestrationConfig, PlanCacheConfig,
+};
 pub use features::{
     CostConfig, DaemonConfig, DebugConfig, GatewayConfig, IndexConfig, ScheduledTaskConfig,
     ScheduledTaskKind, SchedulerConfig, SkillMiningConfig, SkillPromptMode, SkillsConfig,
@@ -114,9 +116,9 @@ pub use memory::{
 pub use metrics::MetricsConfig;
 pub use providers::{
     BanditConfig, CandleConfig, CandleInlineConfig, CascadeClassifierMode, CascadeConfig,
-    ComplexityRoutingConfig, GenerationParams, LlmConfig, LlmRoutingStrategy, MAX_TOKENS_CAP,
-    ProviderEntry, ProviderKind, ProviderName, RouterConfig, RouterStrategyConfig, SttConfig,
-    TierMapping, validate_pool,
+    CoeConfig, ComplexityRoutingConfig, GenerationParams, LlmConfig, LlmRoutingStrategy,
+    MAX_TOKENS_CAP, ProviderEntry, ProviderKind, ProviderName, RouterConfig, RouterStrategyConfig,
+    SttConfig, TierMapping, validate_pool,
 };
 pub use providers::{default_stt_language, default_stt_provider};
 pub use rate_limit::RateLimitConfig;

--- a/crates/zeph-config/src/providers.rs
+++ b/crates/zeph-config/src/providers.rs
@@ -367,6 +367,10 @@ pub struct LlmConfig {
     /// Complexity triage routing configuration. Required when `routing = "triage"`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub complexity_routing: Option<ComplexityRoutingConfig>,
+
+    /// Collaborative Entropy (`CoE`) configuration. `None` = `CoE` disabled.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub coe: Option<CoeConfig>,
 }
 
 fn default_embedding_model_opt() -> String {
@@ -1049,6 +1053,61 @@ impl Default for ComplexityRoutingConfig {
             max_triage_tokens: default_max_triage_tokens(),
             triage_timeout_secs: default_triage_timeout_secs(),
             fallback_strategy: None,
+        }
+    }
+}
+
+/// Configuration for the Collaborative Entropy (`CoE`) subsystem (`[llm.coe]` TOML section).
+///
+/// `CoE` detects uncertain responses from the primary provider and escalates to a
+/// secondary provider when either the intra-entropy or inter-divergence signal crosses
+/// its threshold. Only active for `RouterStrategy::Ema` and `RouterStrategy::Thompson`.
+///
+/// # Example
+///
+/// ```toml
+/// [llm.coe]
+/// enabled = true
+/// intra_threshold = 0.8
+/// inter_threshold = 0.20
+/// shadow_sample_rate = 0.1
+/// secondary_provider = "quality"
+/// embed_provider = ""
+/// ```
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct CoeConfig {
+    /// Enable `CoE`. When `false`, the struct is ignored.
+    pub enabled: bool,
+    /// Mean negative log-prob threshold; responses above this trigger intra escalation.
+    pub intra_threshold: f64,
+    /// Divergence threshold in `[0.0, 1.0]`.
+    pub inter_threshold: f64,
+    /// Baseline rate at which secondary is called even when intra is low.
+    pub shadow_sample_rate: f64,
+    /// Provider name from `[[llm.providers]]` used as the escalation target.
+    pub secondary_provider: ProviderName,
+    /// Provider name for inter-divergence embeddings. Empty → inherit bandit's embed provider.
+    pub embed_provider: ProviderName,
+    /// Per-turn cap on secondary calls.
+    #[serde(default = "default_coe_max_secondary_calls")]
+    pub max_secondary_calls_per_turn: u32,
+}
+
+fn default_coe_max_secondary_calls() -> u32 {
+    1
+}
+
+impl Default for CoeConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            intra_threshold: 0.8,
+            inter_threshold: 0.20,
+            shadow_sample_rate: 0.1,
+            secondary_provider: ProviderName::default(),
+            embed_provider: ProviderName::default(),
+            max_secondary_calls_per_turn: default_coe_max_secondary_calls(),
         }
     }
 }

--- a/crates/zeph-config/src/providers.rs
+++ b/crates/zeph-config/src/providers.rs
@@ -1089,13 +1089,6 @@ pub struct CoeConfig {
     pub secondary_provider: ProviderName,
     /// Provider name for inter-divergence embeddings. Empty → inherit bandit's embed provider.
     pub embed_provider: ProviderName,
-    /// Per-turn cap on secondary calls.
-    #[serde(default = "default_coe_max_secondary_calls")]
-    pub max_secondary_calls_per_turn: u32,
-}
-
-fn default_coe_max_secondary_calls() -> u32 {
-    1
 }
 
 impl Default for CoeConfig {
@@ -1107,7 +1100,6 @@ impl Default for CoeConfig {
             shadow_sample_rate: 0.1,
             secondary_provider: ProviderName::default(),
             embed_provider: ProviderName::default(),
-            max_secondary_calls_per_turn: default_coe_max_secondary_calls(),
         }
     }
 }

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -163,6 +163,7 @@ impl Default for Config {
                 summary_model: None,
                 summary_provider: None,
                 complexity_routing: None,
+                coe: None,
             },
             skills: SkillsConfig {
                 paths: default_skill_paths(),

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -341,6 +341,19 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Set the `AdaptOrch` topology advisor.
+    ///
+    /// When set, `handle_plan_goal_as_string` calls `advisor.recommend()` before planning
+    /// and injects the topology hint into the planner prompt.
+    #[must_use]
+    pub fn with_topology_advisor(
+        mut self,
+        advisor: std::sync::Arc<zeph_orchestration::TopologyAdvisor>,
+    ) -> Self {
+        self.orchestration.topology_advisor = Some(advisor);
+        self
+    }
+
     /// Set a dedicated judge provider for experiment evaluation.
     ///
     /// When set, the evaluator uses this provider instead of the agent's primary provider,

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -602,6 +602,13 @@ impl<C: Channel> Agent<C> {
         // CRIT-1: persist Thompson state accumulated during this session.
         self.provider.save_router_state();
 
+        // Persist AdaptOrch Beta-arm table alongside Thompson state.
+        if let Some(ref advisor) = self.orchestration.topology_advisor
+            && let Err(e) = advisor.save()
+        {
+            tracing::warn!(error = %e, "adaptorch: failed to persist state");
+        }
+
         if let Some(ref mut mgr) = self.orchestration.subagent_manager {
             mgr.shutdown_all();
         }

--- a/crates/zeph-core/src/agent/plan.rs
+++ b/crates/zeph-core/src/agent/plan.rs
@@ -417,6 +417,18 @@ impl<C: crate::channel::Channel> Agent<C> {
 
         use zeph_orchestration::{Aggregator, GraphStatus, LlmAggregator};
 
+        // AdaptOrch: record outcome synchronously before aggregation.
+        if let Some(verdict) = self.orchestration.last_advisor_verdict.take()
+            && let Some(ref advisor) = self.orchestration.topology_advisor
+        {
+            let reward = if final_status == GraphStatus::Completed {
+                1.0
+            } else {
+                0.0
+            };
+            advisor.record_outcome(verdict.class, verdict.hint, reward);
+        }
+
         let result_label = match final_status {
             GraphStatus::Completed => {
                 let completed_count = completed_graph
@@ -583,6 +595,7 @@ impl<C: crate::channel::Channel> Agent<C> {
 
     // ----- _as_string variants (used by AgentAccess / CommandHandler) -----
 
+    #[allow(clippy::too_many_lines)]
     pub(super) async fn handle_plan_goal_as_string(
         &mut self,
         goal: &str,
@@ -616,6 +629,23 @@ impl<C: crate::channel::Channel> Agent<C> {
             "plan cache state for goal"
         );
 
+        // AdaptOrch: classify goal and obtain topology hint before planning.
+        let topology_hint = if let Some(ref advisor) = self.orchestration.topology_advisor.clone() {
+            let verdict = advisor.recommend(goal).await;
+            tracing::debug!(
+                class = ?verdict.class,
+                hint = ?verdict.hint,
+                exploit = verdict.exploit,
+                fallback = verdict.fallback,
+                "adaptorch verdict"
+            );
+            let hint = verdict.hint;
+            self.orchestration.last_advisor_verdict = Some(verdict);
+            Some(hint)
+        } else {
+            None
+        };
+
         let planner_provider = self
             .orchestration
             .planner_provider
@@ -624,18 +654,28 @@ impl<C: crate::channel::Channel> Agent<C> {
             .clone();
         let planner = LlmPlanner::new(planner_provider, &self.orchestration.orchestration_config);
         let embed_model = self.skill_state.embedding_model.clone();
-        let (graph, planner_usage) = plan_with_cache(
-            &planner,
-            self.orchestration.plan_cache.as_ref(),
-            &self.provider,
-            goal_embedding.as_deref(),
-            &embed_model,
-            goal,
-            &available_agents,
-            self.orchestration.orchestration_config.max_tasks,
-        )
-        .await
-        .map_err(|e| error::AgentError::Other(e.to_string()))?;
+        let max_tasks = self.orchestration.orchestration_config.max_tasks;
+        let (graph, planner_usage) = {
+            use zeph_orchestration::Planner as _;
+            let result = if topology_hint.is_some() {
+                planner
+                    .plan_with_hint(goal, &available_agents, topology_hint)
+                    .await
+            } else {
+                plan_with_cache(
+                    &planner,
+                    self.orchestration.plan_cache.as_ref(),
+                    &self.provider,
+                    goal_embedding.as_deref(),
+                    &embed_model,
+                    goal,
+                    &available_agents,
+                    max_tasks,
+                )
+                .await
+            };
+            result.map_err(|e| error::AgentError::Other(e.to_string()))?
+        };
 
         self.orchestration.pending_goal_embedding = goal_embedding;
 

--- a/crates/zeph-core/src/agent/plan.rs
+++ b/crates/zeph-core/src/agent/plan.rs
@@ -657,11 +657,11 @@ impl<C: crate::channel::Channel> Agent<C> {
         let max_tasks = self.orchestration.orchestration_config.max_tasks;
         let (graph, planner_usage) = {
             use zeph_orchestration::Planner as _;
-            let result = if topology_hint.is_some() {
-                planner
-                    .plan_with_hint(goal, &available_agents, topology_hint)
-                    .await
-            } else {
+            // Use cache when there is no hint, or when the hint has no prompt sentence (Hybrid).
+            let use_cache = topology_hint
+                .as_ref()
+                .is_none_or(|h| h.prompt_sentence().is_none());
+            let result = if use_cache {
                 plan_with_cache(
                     &planner,
                     self.orchestration.plan_cache.as_ref(),
@@ -673,6 +673,10 @@ impl<C: crate::channel::Channel> Agent<C> {
                     max_tasks,
                 )
                 .await
+            } else {
+                planner
+                    .plan_with_hint(goal, &available_agents, topology_hint)
+                    .await
             };
             result.map_err(|e| error::AgentError::Other(e.to_string()))?
         };

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -420,6 +420,12 @@ pub(crate) struct OrchestrationState {
     /// Goal embedding from the most recent `plan_with_cache()` call. Consumed by
     /// `finalize_plan_execution()` to cache the completed plan template.
     pub(crate) pending_goal_embedding: Option<Vec<f32>>,
+    /// `AdaptOrch` topology advisor — `None` when `[orchestration.adaptorch]` is disabled.
+    pub(crate) topology_advisor: Option<std::sync::Arc<zeph_orchestration::TopologyAdvisor>>,
+    /// Last `AdaptOrch` verdict; carried from `handle_plan_goal_as_string` to scheduler loop
+    /// for `record_outcome`.
+    #[allow(dead_code)] // read via .take() in plan.rs; clippy false positive
+    pub(crate) last_advisor_verdict: Option<zeph_orchestration::AdvisorVerdict>,
 }
 
 /// Groups instruction hot-reload state.

--- a/crates/zeph-llm/src/any.rs
+++ b/crates/zeph-llm/src/any.rs
@@ -19,7 +19,8 @@ use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 
 use crate::provider::{
-    ChatResponse, ChatStream, GenerationOverrides, LlmProvider, Message, StatusTx, ToolDefinition,
+    ChatExtras, ChatResponse, ChatStream, GenerationOverrides, LlmProvider, Message, StatusTx,
+    ToolDefinition,
 };
 use crate::router::RouterProvider;
 use crate::router::triage::TriageRouter;
@@ -245,6 +246,13 @@ impl LlmProvider for AnyProvider {
 
     async fn chat(&self, messages: &[Message]) -> Result<String, crate::LlmError> {
         delegate_provider!(self, |p| p.chat(messages).await)
+    }
+
+    async fn chat_with_extras(
+        &self,
+        messages: &[Message],
+    ) -> Result<(String, ChatExtras), crate::LlmError> {
+        delegate_provider!(self, |p| p.chat_with_extras(messages).await)
     }
 
     async fn chat_stream(&self, messages: &[Message]) -> Result<ChatStream, crate::LlmError> {

--- a/crates/zeph-llm/src/compatible.rs
+++ b/crates/zeph-llm/src/compatible.rs
@@ -25,7 +25,8 @@ use std::fmt;
 use crate::error::LlmError;
 use crate::openai::OpenAiProvider;
 use crate::provider::{
-    ChatResponse, ChatStream, GenerationOverrides, LlmProvider, Message, StatusTx, ToolDefinition,
+    ChatExtras, ChatResponse, ChatStream, GenerationOverrides, LlmProvider, Message, StatusTx,
+    ToolDefinition,
 };
 
 /// [`LlmProvider`] adapter for OpenAI-compatible REST endpoints.
@@ -98,6 +99,13 @@ impl CompatibleProvider {
         self.inner = self.inner.with_generation_overrides(overrides);
         self
     }
+
+    /// Enable `CoE` logprobs collection for `chat_with_extras`.
+    #[must_use]
+    pub fn with_coe(mut self) -> Self {
+        self.inner = self.inner.with_coe();
+        self
+    }
 }
 
 impl LlmProvider for CompatibleProvider {
@@ -115,6 +123,13 @@ impl LlmProvider for CompatibleProvider {
     )]
     async fn chat(&self, messages: &[Message]) -> Result<String, LlmError> {
         self.inner.chat(messages).await
+    }
+
+    async fn chat_with_extras(
+        &self,
+        messages: &[Message],
+    ) -> Result<(String, ChatExtras), LlmError> {
+        self.inner.chat_with_extras(messages).await
     }
 
     #[cfg_attr(

--- a/crates/zeph-llm/src/lib.rs
+++ b/crates/zeph-llm/src/lib.rs
@@ -103,5 +103,6 @@ pub use claude::{ThinkingConfig, ThinkingEffort};
 pub use error::LlmError;
 pub use extractor::Extractor;
 pub use gemini::ThinkingLevel as GeminiThinkingLevel;
-pub use provider::{ChatStream, LlmProvider, StreamChunk, ThinkingBlock};
+pub use provider::{ChatExtras, ChatStream, LlmProvider, StreamChunk, ThinkingBlock};
+pub use router::coe::{CoeConfig, CoeMetrics, CoeRouter};
 pub use stt::{SpeechToText, Transcription};

--- a/crates/zeph-llm/src/mock.rs
+++ b/crates/zeph-llm/src/mock.rs
@@ -172,13 +172,8 @@ impl MockProvider {
     ///
     /// ```
     /// use zeph_llm::mock::MockProvider;
-    /// use zeph_llm::provider::LlmProvider;
     ///
-    /// # tokio_test::block_on(async {
     /// let provider = MockProvider::default().with_entropy(0.9);
-    /// let (_, extras) = provider.chat_with_extras(&[]).await.unwrap();
-    /// assert_eq!(extras.entropy, Some(0.9));
-    /// # });
     /// ```
     #[must_use]
     pub fn with_entropy(mut self, entropy: f64) -> Self {

--- a/crates/zeph-llm/src/mock.rs
+++ b/crates/zeph-llm/src/mock.rs
@@ -42,6 +42,8 @@ pub struct MockProvider {
     pub embed_call_count: Arc<std::sync::atomic::AtomicU64>,
     /// Milliseconds to sleep inside `embed()` before returning. Used to simulate slow providers.
     pub embed_delay_ms: u64,
+    /// Fixed entropy value returned by `chat_with_extras()`. `None` returns `ChatExtras::default()`.
+    pub fixed_entropy: Option<f64>,
 }
 
 impl Default for MockProvider {
@@ -63,6 +65,7 @@ impl Default for MockProvider {
             embed_invalid_input: false,
             embed_call_count: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             embed_delay_ms: 0,
+            fixed_entropy: None,
         }
     }
 }
@@ -161,6 +164,28 @@ impl MockProvider {
         self
     }
 
+    /// Set a fixed entropy value returned by `chat_with_extras()`.
+    ///
+    /// Required for unit tests that drive `CoE` thresholds without mocking the HTTP layer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_llm::mock::MockProvider;
+    /// use zeph_llm::provider::LlmProvider;
+    ///
+    /// # tokio_test::block_on(async {
+    /// let provider = MockProvider::default().with_entropy(0.9);
+    /// let (_, extras) = provider.chat_with_extras(&[]).await.unwrap();
+    /// assert_eq!(extras.entropy, Some(0.9));
+    /// # });
+    /// ```
+    #[must_use]
+    pub fn with_entropy(mut self, entropy: f64) -> Self {
+        self.fixed_entropy = Some(entropy);
+        self
+    }
+
     /// Enable native `tool_use` support with a pre-configured sequence of `ChatResponse`
     /// values returned from `chat_with_tools()`.
     ///
@@ -204,6 +229,18 @@ impl LlmProvider for MockProvider {
         } else {
             Ok(responses.pop_front().expect("non-empty"))
         }
+    }
+
+    async fn chat_with_extras(
+        &self,
+        messages: &[Message],
+    ) -> Result<(String, crate::provider::ChatExtras), crate::LlmError> {
+        let text = self.chat(messages).await?;
+        let extras = match self.fixed_entropy {
+            Some(e) => crate::provider::ChatExtras::with_entropy(e),
+            None => crate::provider::ChatExtras::default(),
+        };
+        Ok((text, extras))
     }
 
     async fn chat_stream(&self, messages: &[Message]) -> Result<ChatStream, crate::LlmError> {

--- a/crates/zeph-llm/src/ollama.rs
+++ b/crates/zeph-llm/src/ollama.rs
@@ -49,9 +49,11 @@ use ollama_rs::generation::tools::{ToolFunctionInfo, ToolInfo, ToolType};
 use ollama_rs::models::ModelOptions;
 use tokio_stream::StreamExt;
 
+use ollama_rs::generation::parameters::LogprobsData as OllamaLogprobsData;
+
 use crate::provider::{
-    ChatResponse, ChatStream, GenerationOverrides, LlmProvider, Message, MessagePart, Role,
-    ToolDefinition, ToolUseRequest,
+    ChatExtras, ChatResponse, ChatStream, GenerationOverrides, LlmProvider, Message, MessagePart,
+    Role, ToolDefinition, ToolUseRequest,
 };
 use crate::usage::UsageTracker;
 
@@ -80,6 +82,8 @@ pub struct OllamaProvider {
     vision_model: Option<String>,
     generation_overrides: Option<GenerationOverrides>,
     usage: UsageTracker,
+    /// When `true`, `chat_with_extras` requests logprobs and computes entropy.
+    coe_enabled: bool,
 }
 
 #[allow(clippy::cast_possible_truncation)]
@@ -121,7 +125,15 @@ impl OllamaProvider {
             vision_model: None,
             generation_overrides: None,
             usage: UsageTracker::default(),
+            coe_enabled: false,
         }
+    }
+
+    /// Enable `CoE` logprobs collection for `chat_with_extras`.
+    #[must_use]
+    pub fn with_coe(mut self) -> Self {
+        self.coe_enabled = true;
+        self
     }
 
     /// Override generation parameters (temperature, top-p, top-k) for this provider.
@@ -282,6 +294,38 @@ impl LlmProvider for OllamaProvider {
         }
 
         Ok(response.message.content)
+    }
+
+    async fn chat_with_extras(
+        &self,
+        messages: &[Message],
+    ) -> Result<(String, ChatExtras), LlmError> {
+        if !self.coe_enabled {
+            return Ok((self.chat(messages).await?, ChatExtras::default()));
+        }
+        let ollama_messages: Vec<ChatMessage> = messages.iter().map(convert_message).collect();
+        let mut request =
+            ChatMessageRequest::new(self.model.clone(), ollama_messages).logprobs(true);
+        if let Some(ref ov) = self.generation_overrides {
+            request = apply_generation_overrides(request, ov);
+        }
+        let response =
+            self.client.send_chat_messages(request).await.map_err(|e| {
+                LlmError::Other(format!("Ollama chat_with_extras request failed: {e}"))
+            })?;
+        if let Some(ref fd) = response.final_data {
+            self.usage.record_usage(fd.prompt_eval_count, fd.eval_count);
+        }
+        let entropy = response
+            .logprobs
+            .as_deref()
+            .filter(|lp| !lp.is_empty())
+            .map(|lp: &[OllamaLogprobsData]| {
+                #[allow(clippy::cast_precision_loss)]
+                let n = lp.len() as f64;
+                -lp.iter().map(|t| t.logprob).sum::<f64>() / n
+            });
+        Ok((response.message.content, ChatExtras { entropy }))
     }
 
     #[cfg_attr(

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -35,8 +35,8 @@ use base64::{Engine, engine::general_purpose::STANDARD};
 use serde::{Deserialize, Serialize};
 
 use crate::provider::{
-    ChatResponse, ChatStream, GenerationOverrides, LlmProvider, Message, MessagePart, Role,
-    StatusTx, ToolDefinition, ToolUseRequest,
+    ChatExtras, ChatResponse, ChatStream, GenerationOverrides, LlmProvider, Message, MessagePart,
+    Role, StatusTx, ToolDefinition, ToolUseRequest,
 };
 use crate::retry::send_with_retry;
 use crate::sse::openai_sse_to_stream;
@@ -70,6 +70,8 @@ pub struct OpenAiProvider {
     output_schema_hint_bytes: usize,
     /// Maximum bytes of the combined description (base + hint). `usize::MAX` means no cap.
     max_tool_description_bytes: usize,
+    /// When `true`, `chat_with_extras` requests `logprobs: true` and computes entropy.
+    coe_enabled: bool,
 }
 
 impl fmt::Debug for OpenAiProvider {
@@ -91,6 +93,7 @@ impl fmt::Debug for OpenAiProvider {
                 "max_tool_description_bytes",
                 &self.max_tool_description_bytes,
             )
+            .field("coe_enabled", &self.coe_enabled)
             .finish()
     }
 }
@@ -111,6 +114,7 @@ impl Clone for OpenAiProvider {
             forward_output_schema: self.forward_output_schema,
             output_schema_hint_bytes: self.output_schema_hint_bytes,
             max_tool_description_bytes: self.max_tool_description_bytes,
+            coe_enabled: self.coe_enabled,
         }
     }
 }
@@ -148,7 +152,18 @@ impl OpenAiProvider {
             forward_output_schema: false,
             output_schema_hint_bytes: 512,
             max_tool_description_bytes: usize::MAX,
+            coe_enabled: false,
         }
+    }
+
+    /// Enable `CoE` logprobs collection for `chat_with_extras`.
+    ///
+    /// When enabled, `chat_with_extras` includes `logprobs: true` in the request
+    /// and computes mean negative log-probability from the response.
+    #[must_use]
+    pub fn with_coe(mut self) -> Self {
+        self.coe_enabled = true;
+        self
     }
 
     /// Override generation parameters (temperature, top-p, frequency/presence penalty).
@@ -429,6 +444,80 @@ impl OpenAiProvider {
 
         Ok(response)
     }
+
+    /// Send a request with `logprobs: true` and return the response text plus computed entropy.
+    async fn send_request_with_logprobs(
+        &self,
+        messages: &[Message],
+    ) -> Result<(String, ChatExtras), LlmError> {
+        let api_messages = convert_messages(messages);
+        let (temperature, top_p, frequency_penalty, presence_penalty) =
+            if let Some(ref ov) = self.generation_overrides {
+                (
+                    ov.temperature,
+                    ov.top_p,
+                    ov.frequency_penalty,
+                    ov.presence_penalty,
+                )
+            } else {
+                (None, None, None, None)
+            };
+        let body = LogprobsChatRequest {
+            model: &self.model,
+            messages: &api_messages,
+            completion_tokens: CompletionTokens::for_model(&self.model, self.max_tokens),
+            logprobs: true,
+            temperature,
+            top_p,
+            frequency_penalty,
+            presence_penalty,
+        };
+        let response = send_with_retry("OpenAI", MAX_RETRIES, self.status_tx.as_ref(), || {
+            self.client
+                .post(format!("{}/chat/completions", self.base_url))
+                .header("Authorization", format!("Bearer {}", self.api_key))
+                .header("Content-Type", "application/json")
+                .json(&body)
+                .send()
+        })
+        .await?;
+
+        let status = response.status();
+        let text = response.text().await.map_err(LlmError::Http)?;
+
+        if !status.is_success() {
+            tracing::error!("OpenAI API error {status}: {text}");
+            return Err(LlmError::Other(format!(
+                "OpenAI API request failed (status {status})"
+            )));
+        }
+
+        let resp: OpenAiChatResponse = serde_json::from_str(&text)?;
+
+        if let Some(ref usage) = resp.usage {
+            self.store_cache_usage(usage);
+        }
+
+        let content = resp
+            .choices
+            .first()
+            .map(|c| c.message.content.clone())
+            .ok_or(LlmError::EmptyResponse {
+                provider: "openai".into(),
+            })?;
+
+        let entropy = resp.choices.first().and_then(|c| {
+            let logprobs = c.logprobs.as_ref()?.content.as_slice();
+            if logprobs.is_empty() {
+                return None;
+            }
+            #[allow(clippy::cast_precision_loss)]
+            let mean = -logprobs.iter().map(|t| t.logprob).sum::<f64>() / logprobs.len() as f64;
+            Some(mean)
+        });
+
+        Ok((content, ChatExtras { entropy }))
+    }
 }
 
 impl LlmProvider for OpenAiProvider {
@@ -454,6 +543,16 @@ impl LlmProvider for OpenAiProvider {
     )]
     async fn chat(&self, messages: &[Message]) -> Result<String, LlmError> {
         self.send_request(messages).await
+    }
+
+    async fn chat_with_extras(
+        &self,
+        messages: &[Message],
+    ) -> Result<(String, ChatExtras), LlmError> {
+        if !self.coe_enabled {
+            return Ok((self.send_request(messages).await?, ChatExtras::default()));
+        }
+        self.send_request_with_logprobs(messages).await
     }
 
     #[cfg_attr(
@@ -1072,6 +1171,23 @@ struct ChatRequest<'a> {
 }
 
 #[derive(Serialize)]
+struct LogprobsChatRequest<'a> {
+    model: &'a str,
+    messages: &'a [ApiMessage<'a>],
+    #[serde(flatten)]
+    completion_tokens: CompletionTokens,
+    logprobs: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    top_p: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    frequency_penalty: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    presence_penalty: Option<f64>,
+}
+
+#[derive(Serialize)]
 struct Reasoning<'a> {
     effort: &'a str,
 }
@@ -1108,6 +1224,19 @@ struct PromptTokensDetails {
 #[derive(Deserialize)]
 struct ChatChoice {
     message: ChatMessage,
+    #[serde(default)]
+    logprobs: Option<ChoiceLogprobs>,
+}
+
+#[derive(Deserialize)]
+struct ChoiceLogprobs {
+    #[serde(default)]
+    content: Vec<TokenLogprob>,
+}
+
+#[derive(Deserialize)]
+struct TokenLogprob {
+    logprob: f64,
 }
 
 #[derive(Deserialize)]

--- a/crates/zeph-llm/src/provider.rs
+++ b/crates/zeph-llm/src/provider.rs
@@ -66,6 +66,45 @@ pub(crate) fn short_type_name<T: ?Sized>() -> &'static str {
         .unwrap_or("Output")
 }
 
+/// Per-call extras returned alongside the chat response by [`LlmProvider::chat_with_extras`].
+///
+/// Always paired 1:1 with a single response — no shared state, no races possible.
+/// All optional fields default to `None` so providers that do not expose the
+/// underlying API (e.g. Claude, Gemini) can simply return the default.
+///
+/// Marked `#[non_exhaustive]` so future fields (e.g. `cached_tokens`) can be added
+/// without breaking match sites.
+#[non_exhaustive]
+#[derive(Debug, Clone, Default)]
+pub struct ChatExtras {
+    /// Mean negative log-probability of the generated tokens, when the provider
+    /// was configured to request `logprobs` and the API supplied them.
+    ///
+    /// Lower = more confident. Typical range: `[0.0, ~6.0]` for natural-language tokens.
+    pub entropy: Option<f64>,
+}
+
+impl ChatExtras {
+    /// Return a `ChatExtras` with the given entropy value.
+    ///
+    /// Used by [`MockProvider`](crate::mock::MockProvider) and OpenAI/Ollama providers.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_llm::provider::ChatExtras;
+    ///
+    /// let extras = ChatExtras::with_entropy(0.9);
+    /// assert_eq!(extras.entropy, Some(0.9));
+    /// ```
+    #[must_use]
+    pub fn with_entropy(entropy: f64) -> Self {
+        Self {
+            entropy: Some(entropy),
+        }
+    }
+}
+
 /// A chunk from an LLM streaming response.
 ///
 /// Consumers should match all variants: future providers may emit non-`Content` chunks
@@ -795,6 +834,28 @@ pub trait LlmProvider: Send + Sync {
     /// Must only be called for semantic failures (invalid tool arguments, parse errors).
     /// Do NOT call for network errors, rate limits, or transient I/O failures.
     fn record_quality_outcome(&self, _provider_name: &str, _success: bool) {}
+
+    /// Send messages and return the assistant response together with per-call extras.
+    ///
+    /// Default implementation calls [`chat`][Self::chat] and returns [`ChatExtras::default()`],
+    /// keeping every existing implementor source-compatible at zero cost.
+    ///
+    /// Providers that support logprobs (`OpenAI`, `Compatible`, `Ollama`) override this to
+    /// populate [`ChatExtras::entropy`] with the mean negative log-probability.
+    ///
+    /// `CoE` is the only caller of this method; the canonical entry point for the agent
+    /// loop remains [`chat`][Self::chat].
+    ///
+    /// # Errors
+    ///
+    /// Same as [`chat`][Self::chat].
+    fn chat_with_extras(
+        &self,
+        messages: &[Message],
+    ) -> impl Future<Output = Result<(String, ChatExtras), LlmError>> + Send {
+        let msgs = messages.to_vec();
+        async move { Ok((self.chat(&msgs).await?, ChatExtras::default())) }
+    }
 
     /// Return the request payload that will be sent to the provider, for debug dumps.
     ///

--- a/crates/zeph-llm/src/router/coe.rs
+++ b/crates/zeph-llm/src/router/coe.rs
@@ -11,12 +11,13 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 use zeph_common::math::cosine_similarity;
 
 use crate::any::AnyProvider;
 use crate::error::LlmError;
-use crate::provider::Message;
+use crate::provider::{LlmProvider, Message};
 
 /// Configuration for the `CoE` subsystem (mirrors `[llm.coe]` in TOML).
 #[derive(Debug, Clone)]
@@ -27,8 +28,6 @@ pub struct CoeConfig {
     pub inter_threshold: f64,
     /// Baseline rate at which secondary is called even when intra is low.
     pub shadow_sample_rate: f64,
-    /// Per-turn cap on secondary calls.
-    pub max_secondary_calls_per_turn: u32,
 }
 
 impl Default for CoeConfig {
@@ -37,7 +36,6 @@ impl Default for CoeConfig {
             intra_threshold: 0.8,
             inter_threshold: 0.20,
             shadow_sample_rate: 0.1,
-            max_secondary_calls_per_turn: 1,
         }
     }
 }
@@ -79,7 +77,12 @@ pub async fn inter_divergence(primary: &str, secondary: &str, embed: &AnyProvide
     if primary.len().min(secondary.len()) < MIN_INTER_LEN {
         return None;
     }
-    let (a, b) = tokio::try_join!(embed.embed(primary), embed.embed(secondary)).ok()?;
+    let (a, b) = tokio::time::timeout(Duration::from_secs(10), async {
+        tokio::try_join!(embed.embed(primary), embed.embed(secondary))
+    })
+    .await
+    .ok()
+    .and_then(Result::ok)?;
     let cos = cosine_similarity(&a, &b);
     Some(((1.0 - cos) * 0.5).clamp(0.0, 1.0))
 }
@@ -124,25 +127,22 @@ pub fn decide(entropy: Option<f64>, divergence: Option<f32>, config: &CoeConfig)
 
 /// Run the full `CoE` pipeline for a single turn.
 ///
-/// Calls `chosen.chat_with_extras`, optionally shadows via secondary, and returns the
-/// final response text. Also returns the primary provider name for Thompson updates.
+/// Takes the already-obtained primary response to avoid a redundant LLM call.
+/// Optionally shadows via secondary and returns the final response text.
+/// Also returns the primary provider name for Thompson updates.
 ///
 /// Returns `(response_text, primary_name, decision)`.
 ///
 /// # Errors
 ///
-/// Propagates errors from the primary provider. Secondary/embed failures are swallowed
-/// and cause fallback to the primary response (COE-02).
+/// Secondary/embed failures are swallowed and cause fallback to the primary response (COE-02).
 pub async fn run_coe(
     coe: &CoeRouter,
-    primary: &AnyProvider,
+    primary_name: String,
+    primary_text: String,
+    primary_extras: crate::provider::ChatExtras,
     messages: &[Message],
 ) -> Result<(String, String, CoeDecision), LlmError> {
-    use crate::provider::LlmProvider;
-
-    let primary_name = primary.name().to_owned();
-    let (primary_text, primary_extras) = primary.chat_with_extras(messages).await?;
-
     let entropy = primary_extras.entropy;
 
     if !should_shadow(entropy, &coe.config) {
@@ -237,5 +237,102 @@ mod tests {
             decide(Some(0.1), Some(0.05), &config),
             CoeDecision::KeepPrimary
         ));
+    }
+
+    fn make_coe_router(
+        secondary: crate::any::AnyProvider,
+        embed: crate::any::AnyProvider,
+    ) -> CoeRouter {
+        CoeRouter {
+            config: CoeConfig {
+                intra_threshold: 0.8,
+                inter_threshold: 0.20,
+                shadow_sample_rate: 0.0, // disable random shadow unless explicitly set
+            },
+            secondary,
+            embed,
+            metrics: Arc::new(CoeMetrics::default()),
+        }
+    }
+
+    #[tokio::test]
+    async fn run_coe_keeps_primary_when_shadow_disabled() {
+        use crate::any::AnyProvider;
+        use crate::mock::MockProvider;
+        use crate::provider::ChatExtras;
+
+        let secondary = MockProvider::with_responses(vec!["secondary response".into()]);
+        let mut embed = MockProvider::default();
+        embed.supports_embeddings = true;
+        let coe = make_coe_router(AnyProvider::Mock(secondary), AnyProvider::Mock(embed));
+
+        // Low entropy → should_shadow returns false with shadow_sample_rate=0.0
+        let (text, _name, decision) = run_coe(
+            &coe,
+            "primary".into(),
+            "primary response".into(),
+            ChatExtras { entropy: Some(0.1) },
+            &[],
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(text, "primary response");
+        assert!(matches!(decision, CoeDecision::KeepPrimary));
+        assert_eq!(coe.metrics.kept_primary.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn run_coe_fallback_on_secondary_failure() {
+        use crate::any::AnyProvider;
+        use crate::mock::MockProvider;
+        use crate::provider::ChatExtras;
+
+        let mut secondary = MockProvider::default();
+        secondary.fail_chat = true;
+        let mut embed = MockProvider::default();
+        embed.supports_embeddings = true;
+        let coe = make_coe_router(AnyProvider::Mock(secondary), AnyProvider::Mock(embed));
+
+        // High entropy triggers shadow; secondary fails → fallback to primary.
+        let (text, _name, decision) = run_coe(
+            &coe,
+            "primary".into(),
+            "primary response".into(),
+            ChatExtras { entropy: Some(1.0) },
+            &[],
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(text, "primary response");
+        assert!(matches!(decision, CoeDecision::KeepPrimary));
+        assert_eq!(coe.metrics.embed_failures.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn run_coe_escalates_intra_when_entropy_high() {
+        use crate::any::AnyProvider;
+        use crate::mock::MockProvider;
+        use crate::provider::ChatExtras;
+
+        let secondary = MockProvider::with_responses(vec!["secondary response".into()]);
+        let mut embed = MockProvider::default();
+        embed.supports_embeddings = true;
+        let coe = make_coe_router(AnyProvider::Mock(secondary), AnyProvider::Mock(embed));
+
+        let (text, _name, decision) = run_coe(
+            &coe,
+            "primary".into(),
+            "primary response text long enough to matter".into(),
+            ChatExtras { entropy: Some(1.0) }, // above intra_threshold=0.8
+            &[],
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(text, "secondary response");
+        assert!(matches!(decision, CoeDecision::EscalateIntra));
+        assert_eq!(coe.metrics.intra_escalations.load(Ordering::Relaxed), 1);
     }
 }

--- a/crates/zeph-llm/src/router/coe.rs
+++ b/crates/zeph-llm/src/router/coe.rs
@@ -1,0 +1,241 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Collaborative Entropy (`CoE`) router module.
+//!
+//! Detects uncertain primary responses via two orthogonal signals:
+//! - **Intra-entropy** — mean negative log-probability from a single model's logprobs.
+//! - **Inter-divergence** — normalised `(1-cosine)/2` between primary and secondary embeddings.
+//!
+//! When either signal crosses its threshold, `CoE` escalates to the secondary provider.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use zeph_common::math::cosine_similarity;
+
+use crate::any::AnyProvider;
+use crate::error::LlmError;
+use crate::provider::Message;
+
+/// Configuration for the `CoE` subsystem (mirrors `[llm.coe]` in TOML).
+#[derive(Debug, Clone)]
+pub struct CoeConfig {
+    /// Mean negative log-prob threshold; responses above this trigger intra escalation.
+    pub intra_threshold: f64,
+    /// Divergence threshold in `[0.0, 1.0]`; responses above this trigger inter escalation.
+    pub inter_threshold: f64,
+    /// Baseline rate at which secondary is called even when intra is low.
+    pub shadow_sample_rate: f64,
+    /// Per-turn cap on secondary calls.
+    pub max_secondary_calls_per_turn: u32,
+}
+
+impl Default for CoeConfig {
+    fn default() -> Self {
+        Self {
+            intra_threshold: 0.8,
+            inter_threshold: 0.20,
+            shadow_sample_rate: 0.1,
+            max_secondary_calls_per_turn: 1,
+        }
+    }
+}
+
+/// Session-level `CoE` statistics (atomic counters, not persisted).
+#[derive(Debug, Default)]
+pub struct CoeMetrics {
+    /// Turns where the primary was kept (no escalation).
+    pub kept_primary: AtomicU64,
+    /// Escalations triggered by intra-entropy exceeding threshold.
+    pub intra_escalations: AtomicU64,
+    /// Escalations triggered by inter-divergence exceeding threshold.
+    pub inter_escalations: AtomicU64,
+    /// Turns where secondary call failed — primary was returned as fallback.
+    pub embed_failures: AtomicU64,
+}
+
+/// Runtime `CoE` state bundled into `RouterProvider`.
+#[derive(Debug, Clone)]
+pub struct CoeRouter {
+    pub config: CoeConfig,
+    /// The provider used as the secondary/escalation target.
+    pub secondary: AnyProvider,
+    /// Provider used for computing inter-divergence embeddings.
+    pub embed: AnyProvider,
+    pub metrics: Arc<CoeMetrics>,
+}
+
+/// Minimum response length (bytes) for inter-divergence to be meaningful.
+const MIN_INTER_LEN: usize = 50;
+
+/// Compute inter-divergence in `[0.0, 1.0]` between two response texts.
+///
+/// Returns `None` when either text is shorter than the minimum guard or embedding fails.
+/// `0.0` = identical, `0.5` = orthogonal, `1.0` = opposite.
+pub async fn inter_divergence(primary: &str, secondary: &str, embed: &AnyProvider) -> Option<f32> {
+    use crate::provider::LlmProvider;
+
+    if primary.len().min(secondary.len()) < MIN_INTER_LEN {
+        return None;
+    }
+    let (a, b) = tokio::try_join!(embed.embed(primary), embed.embed(secondary)).ok()?;
+    let cos = cosine_similarity(&a, &b);
+    Some(((1.0 - cos) * 0.5).clamp(0.0, 1.0))
+}
+
+/// `CoE` decision result for a single turn.
+pub enum CoeDecision {
+    /// Keep the primary response.
+    KeepPrimary,
+    /// Escalate to secondary due to intra-entropy.
+    EscalateIntra,
+    /// Escalate to secondary due to inter-divergence.
+    EscalateInter,
+}
+
+/// Determine whether to shadow-call the secondary based on intra-entropy.
+///
+/// Returns `true` if a shadow call should be made.
+#[must_use]
+pub fn should_shadow(entropy: Option<f64>, config: &CoeConfig) -> bool {
+    let uncertain = entropy.is_some_and(|e| e >= config.intra_threshold);
+    if uncertain {
+        return true;
+    }
+    // Borderline intra trigger: entropy in [50% threshold, threshold) still shadows
+    let borderline = entropy.is_none_or(|e| e >= config.intra_threshold * 0.5);
+    borderline && rand::random::<f64>() < config.shadow_sample_rate
+}
+
+/// Apply the `CoE` decision logic after obtaining both primary and secondary texts.
+///
+/// Returns the [`CoeDecision`] for this turn.
+#[must_use]
+pub fn decide(entropy: Option<f64>, divergence: Option<f32>, config: &CoeConfig) -> CoeDecision {
+    if entropy.is_some_and(|e| e >= config.intra_threshold) {
+        return CoeDecision::EscalateIntra;
+    }
+    if f64::from(divergence.unwrap_or(0.0)) >= config.inter_threshold {
+        return CoeDecision::EscalateInter;
+    }
+    CoeDecision::KeepPrimary
+}
+
+/// Run the full `CoE` pipeline for a single turn.
+///
+/// Calls `chosen.chat_with_extras`, optionally shadows via secondary, and returns the
+/// final response text. Also returns the primary provider name for Thompson updates.
+///
+/// Returns `(response_text, primary_name, decision)`.
+///
+/// # Errors
+///
+/// Propagates errors from the primary provider. Secondary/embed failures are swallowed
+/// and cause fallback to the primary response (COE-02).
+pub async fn run_coe(
+    coe: &CoeRouter,
+    primary: &AnyProvider,
+    messages: &[Message],
+) -> Result<(String, String, CoeDecision), LlmError> {
+    use crate::provider::LlmProvider;
+
+    let primary_name = primary.name().to_owned();
+    let (primary_text, primary_extras) = primary.chat_with_extras(messages).await?;
+
+    let entropy = primary_extras.entropy;
+
+    if !should_shadow(entropy, &coe.config) {
+        coe.metrics.kept_primary.fetch_add(1, Ordering::Relaxed);
+        return Ok((primary_text, primary_name, CoeDecision::KeepPrimary));
+    }
+
+    // Shadow call to secondary.
+    let secondary_result = coe.secondary.chat_with_extras(messages).await;
+    let secondary_text = match secondary_result {
+        Ok((t, _)) => t,
+        Err(e) => {
+            tracing::warn!(error = %e, "coe: secondary call failed, keeping primary");
+            coe.metrics.embed_failures.fetch_add(1, Ordering::Relaxed);
+            return Ok((primary_text, primary_name, CoeDecision::KeepPrimary));
+        }
+    };
+
+    // Compute inter-divergence.
+    let divergence = inter_divergence(&primary_text, &secondary_text, &coe.embed).await;
+
+    let decision = decide(entropy, divergence, &coe.config);
+
+    match decision {
+        CoeDecision::EscalateIntra => {
+            coe.metrics
+                .intra_escalations
+                .fetch_add(1, Ordering::Relaxed);
+            Ok((secondary_text, primary_name, CoeDecision::EscalateIntra))
+        }
+        CoeDecision::EscalateInter => {
+            coe.metrics
+                .inter_escalations
+                .fetch_add(1, Ordering::Relaxed);
+            Ok((secondary_text, primary_name, CoeDecision::EscalateInter))
+        }
+        CoeDecision::KeepPrimary => {
+            coe.metrics.kept_primary.fetch_add(1, Ordering::Relaxed);
+            Ok((primary_text, primary_name, CoeDecision::KeepPrimary))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_shadow_returns_true_when_above_threshold() {
+        let config = CoeConfig {
+            intra_threshold: 0.8,
+            shadow_sample_rate: 0.0, // disable random gating
+            ..CoeConfig::default()
+        };
+        assert!(should_shadow(Some(0.9), &config));
+        assert!(should_shadow(Some(0.8), &config));
+    }
+
+    #[test]
+    fn should_shadow_returns_false_below_borderline() {
+        let config = CoeConfig {
+            intra_threshold: 0.8,
+            shadow_sample_rate: 0.0,
+            ..CoeConfig::default()
+        };
+        // Below 50% of threshold = 0.4
+        assert!(!should_shadow(Some(0.3), &config));
+    }
+
+    #[test]
+    fn decide_escalates_intra() {
+        let config = CoeConfig::default();
+        assert!(matches!(
+            decide(Some(1.0), None, &config),
+            CoeDecision::EscalateIntra
+        ));
+    }
+
+    #[test]
+    fn decide_escalates_inter() {
+        let config = CoeConfig::default();
+        assert!(matches!(
+            decide(None, Some(0.5), &config),
+            CoeDecision::EscalateInter
+        ));
+    }
+
+    #[test]
+    fn decide_keeps_primary_when_below_thresholds() {
+        let config = CoeConfig::default();
+        assert!(matches!(
+            decide(Some(0.1), Some(0.05), &config),
+            CoeDecision::KeepPrimary
+        ));
+    }
+}

--- a/crates/zeph-llm/src/router/mod.rs
+++ b/crates/zeph-llm/src/router/mod.rs
@@ -1359,8 +1359,8 @@ impl LlmProvider for RouterProvider {
 
             for p in &providers {
                 let start = std::time::Instant::now();
-                match p.chat(&messages).await {
-                    Ok(r) => {
+                match p.chat_with_extras(&messages).await {
+                    Ok((r, extras)) => {
                         router.record_availability(
                             p.name(),
                             true,
@@ -1396,10 +1396,16 @@ impl LlmProvider for RouterProvider {
                             // Pass resp_emb to ASI to avoid a redundant embed call.
                             router.spawn_asi_update(p.name(), r.clone(), turn_id, resp_emb);
 
-                            // CoE: run after quality gate passes.
+                            // CoE: pass already-obtained primary result to avoid double call.
                             if let Some(ref coe_router) = router.coe
-                                && let Ok((final_r, pname, decision)) =
-                                    run_coe(coe_router, p, &messages).await
+                                && let Ok((final_r, pname, decision)) = run_coe(
+                                    coe_router,
+                                    p.name().to_owned(),
+                                    r.clone(),
+                                    extras,
+                                    &messages,
+                                )
+                                .await
                             {
                                 if matches!(
                                     decision,
@@ -1418,10 +1424,16 @@ impl LlmProvider for RouterProvider {
                         // Spawn ASI embedding update (fire-and-forget, no precomputed embedding).
                         router.spawn_asi_update(p.name(), r.clone(), turn_id, None);
 
-                        // CoE: run when quality gate is not active.
+                        // CoE: pass already-obtained primary result to avoid double call.
                         if let Some(ref coe_router) = router.coe
-                            && let Ok((final_r, pname, decision)) =
-                                run_coe(coe_router, p, &messages).await
+                            && let Ok((final_r, pname, decision)) = run_coe(
+                                coe_router,
+                                p.name().to_owned(),
+                                r.clone(),
+                                extras,
+                                &messages,
+                            )
+                            .await
                         {
                             if matches!(
                                 decision,

--- a/crates/zeph-llm/src/router/mod.rs
+++ b/crates/zeph-llm/src/router/mod.rs
@@ -48,6 +48,7 @@
 pub mod asi;
 pub mod bandit;
 pub mod cascade;
+pub mod coe;
 pub mod reputation;
 pub mod thompson;
 pub mod triage;
@@ -64,6 +65,7 @@ use crate::ema::EmaTracker;
 use crate::embed::owned_strs;
 use crate::error::LlmError;
 use crate::provider::{ChatResponse, ChatStream, LlmProvider, Message, StatusTx, ToolDefinition};
+use coe::{CoeDecision, CoeRouter, run_coe};
 
 use asi::AsiState;
 use bandit::{BanditState, embedding_to_features};
@@ -310,6 +312,8 @@ pub struct RouterProvider {
     /// After provider selection, `cosine_similarity(query_emb, response_emb)` must be >= this
     /// value; otherwise the next provider in the ordered list is tried.
     quality_gate: Option<f32>,
+    /// `CoE` (Collaborative Entropy) router. `None` when `CoE` is disabled.
+    coe: Option<Arc<CoeRouter>>,
     /// Monotonically increasing turn counter. Incremented once per top-level `chat()` call.
     /// Shared across clones so that concurrent sub-calls within the same turn see the same value.
     turn_counter: Arc<AtomicU64>,
@@ -361,6 +365,7 @@ impl RouterProvider {
             embed_semaphore: None,
             embed_call_count: Arc::new(AtomicU64::new(0)),
             embed_cache_hits: Arc::new(AtomicU64::new(0)),
+            coe: None,
         }
     }
 
@@ -390,6 +395,51 @@ impl RouterProvider {
     pub fn with_ema(mut self, alpha: f64, reorder_interval: u64) -> Self {
         self.ema = Some(EmaTracker::new(alpha, reorder_interval));
         self
+    }
+
+    /// Enable Collaborative Entropy (`CoE`) for Ema/Thompson strategies.
+    ///
+    /// `CoE` detects uncertain responses via intra-entropy and inter-divergence signals,
+    /// escalating to `secondary` when either threshold is exceeded.
+    ///
+    /// No-op (with a `warn!`) when the active strategy is `Cascade` or `Bandit`.
+    #[must_use]
+    pub fn with_coe(
+        mut self,
+        config: coe::CoeConfig,
+        secondary: AnyProvider,
+        embed: AnyProvider,
+    ) -> Self {
+        if matches!(
+            self.strategy,
+            RouterStrategy::Cascade | RouterStrategy::Bandit
+        ) {
+            tracing::warn!(
+                strategy = ?self.strategy,
+                "coe disabled for strategy; supported: ema, thompson"
+            );
+            return self;
+        }
+        self.coe = Some(Arc::new(CoeRouter {
+            config,
+            secondary,
+            embed,
+            metrics: Arc::new(coe::CoeMetrics::default()),
+        }));
+        self
+    }
+
+    /// Return session-level `CoE` metrics snapshot, or `None` if `CoE` is disabled.
+    #[must_use]
+    pub fn coe_metrics(&self) -> Option<(u64, u64, u64, u64)> {
+        self.coe.as_ref().map(|c| {
+            (
+                c.metrics.kept_primary.load(Ordering::Relaxed),
+                c.metrics.intra_escalations.load(Ordering::Relaxed),
+                c.metrics.inter_escalations.load(Ordering::Relaxed),
+                c.metrics.embed_failures.load(Ordering::Relaxed),
+            )
+        })
     }
 
     /// Enable Agent Stability Index (ASI) coherence tracking.
@@ -1261,6 +1311,7 @@ impl LlmProvider for RouterProvider {
         self.providers.first().and_then(LlmProvider::context_window)
     }
 
+    #[allow(clippy::too_many_lines)] // CoE + quality-gate inline logic; extracting would obscure the control flow
     fn chat(
         &self,
         messages: &[Message],
@@ -1344,11 +1395,43 @@ impl LlmProvider for RouterProvider {
                             }
                             // Pass resp_emb to ASI to avoid a redundant embed call.
                             router.spawn_asi_update(p.name(), r.clone(), turn_id, resp_emb);
+
+                            // CoE: run after quality gate passes.
+                            if let Some(ref coe_router) = router.coe
+                                && let Ok((final_r, pname, decision)) =
+                                    run_coe(coe_router, p, &messages).await
+                            {
+                                if matches!(
+                                    decision,
+                                    CoeDecision::EscalateIntra | CoeDecision::EscalateInter
+                                ) {
+                                    router.record_quality_outcome(&pname, false);
+                                    router
+                                        .record_quality_outcome(coe_router.secondary.name(), true);
+                                }
+                                return Ok(final_r);
+                            }
+
                             return Ok(r);
                         }
 
                         // Spawn ASI embedding update (fire-and-forget, no precomputed embedding).
                         router.spawn_asi_update(p.name(), r.clone(), turn_id, None);
+
+                        // CoE: run when quality gate is not active.
+                        if let Some(ref coe_router) = router.coe
+                            && let Ok((final_r, pname, decision)) =
+                                run_coe(coe_router, p, &messages).await
+                        {
+                            if matches!(
+                                decision,
+                                CoeDecision::EscalateIntra | CoeDecision::EscalateInter
+                            ) {
+                                router.record_quality_outcome(&pname, false);
+                                router.record_quality_outcome(coe_router.secondary.name(), true);
+                            }
+                            return Ok(final_r);
+                        }
 
                         return Ok(r);
                     }

--- a/crates/zeph-orchestration/Cargo.toml
+++ b/crates/zeph-orchestration/Cargo.toml
@@ -14,6 +14,10 @@ readme = "README.md"
 
 [dependencies]
 blake3.workspace = true
+dirs.workspace = true
+parking_lot.workspace = true
+rand.workspace = true
+rand_distr.workspace = true
 schemars.workspace = true
 serde = { workspace = true, features = ["derive"] }
 zeph-db = { workspace = true, features = ["sqlite"] }
@@ -32,6 +36,7 @@ zeph-subagent.workspace = true
 
 [dev-dependencies]
 futures.workspace = true
+tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]

--- a/crates/zeph-orchestration/src/adaptorch.rs
+++ b/crates/zeph-orchestration/src/adaptorch.rs
@@ -1,0 +1,566 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `AdaptOrch` — bandit-driven topology advisor for the LLM planner.
+//!
+//! [`TopologyAdvisor`] runs before [`crate::planner::LlmPlanner`] and injects a
+//! soft topology hint into the planner system prompt. A 16-arm Thompson Beta-bandit
+//! (4 task classes × 4 topology hints) learns which hint works best for each class.
+//!
+//! State is persisted on shutdown alongside the Thompson router state; `record_outcome`
+//! is synchronous and never spawns a task.
+
+use std::collections::HashMap;
+use std::io::{self, Write as _};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use parking_lot::Mutex;
+use rand::SeedableRng as _;
+use rand_distr::{Beta, Distribution};
+use serde::{Deserialize, Serialize};
+use zeph_llm::any::AnyProvider;
+use zeph_llm::provider::{LlmProvider, Message, Role};
+
+/// Task decomposition shape inferred from the user goal text.
+///
+/// `Unknown` absorbs all unclassified cases and defaults the hint to [`TopologyHint::Hybrid`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskClass {
+    /// Fan-out work with no cross-dependencies (research, comparisons, multi-source queries).
+    IndependentBatch,
+    /// Strict ordering: build → test → deploy, ETL pipelines.
+    SequentialPipeline,
+    /// Tree decomposition: subgoal expansion, recursive analysis.
+    HierarchicalDecomp,
+    /// Unknown / fallback; defaults hint to `Hybrid`.
+    Unknown,
+}
+
+/// Soft topology hint injected into the planner system prompt.
+///
+/// Advisory only — `TopologyClassifier::analyze` still runs on the produced graph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TopologyHint {
+    /// Maximize independent tasks; avoid unnecessary `depends_on` chains.
+    Parallel,
+    /// Prefer a strict linear chain unless impossible.
+    Sequential,
+    /// Decompose into subgoals; expect 2–3 levels of depth.
+    Hierarchical,
+    /// No constraint (free planning). Default for `Unknown` class.
+    Hybrid,
+}
+
+impl TopologyHint {
+    /// One-sentence injection appended to the planner system prompt.
+    /// Returns `None` for `Hybrid` (no injection).
+    #[must_use]
+    pub fn prompt_sentence(self) -> Option<&'static str> {
+        match self {
+            Self::Parallel => {
+                Some("Prefer maximizing parallel tasks; avoid unnecessary `depends_on` chains.")
+            }
+            Self::Sequential => Some(
+                "This goal is naturally a pipeline; produce a strict linear chain unless \
+                 impossible.",
+            ),
+            Self::Hierarchical => {
+                Some("Decompose this goal into subgoals; expect 2–3 levels of depth.")
+            }
+            Self::Hybrid => None,
+        }
+    }
+}
+
+/// Result of a `TopologyAdvisor::recommend` call.
+#[derive(Debug, Clone)]
+pub struct AdvisorVerdict {
+    /// Inferred task class for the goal.
+    pub class: TaskClass,
+    /// Sampled topology hint.
+    pub hint: TopologyHint,
+    /// `true` if Thompson exploited the best-known arm (vs. explored).
+    pub exploit: bool,
+    /// `true` if classification failed and `Hybrid` was used as the default.
+    pub fallback: bool,
+}
+
+/// Per-(class, hint) arm for the Beta-Thompson bandit.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BetaDist {
+    pub alpha: f64,
+    pub beta: f64,
+}
+
+impl Default for BetaDist {
+    fn default() -> Self {
+        Self {
+            alpha: 1.0,
+            beta: 1.0,
+        }
+    }
+}
+
+impl BetaDist {
+    fn sample<R: rand::Rng>(&self, rng: &mut R) -> f64 {
+        let a = self.alpha.max(1e-6);
+        let b = self.beta.max(1e-6);
+        Beta::new(a, b)
+            .unwrap_or_else(|_| Beta::new(1.0, 1.0).unwrap())
+            .sample(rng)
+    }
+}
+
+/// Versioned on-disk format for `AdaptOrch` state.
+#[derive(Debug, Serialize, Deserialize)]
+struct PersistState {
+    version: u32,
+    arms: HashMap<String, BetaDist>,
+}
+
+/// Session-level metrics for `AdaptOrch` (atomic, not persisted).
+#[derive(Debug, Default)]
+pub struct AdaptOrchMetrics {
+    /// Total classify calls.
+    pub classify_calls: AtomicU64,
+    /// Calls that timed out or failed — fell back to `Unknown`.
+    pub classify_timeouts: AtomicU64,
+    /// Hint distribution.
+    pub hint_parallel: AtomicU64,
+    pub hint_sequential: AtomicU64,
+    pub hint_hierarchical: AtomicU64,
+    pub hint_hybrid: AtomicU64,
+    /// Times `record_outcome` was called.
+    pub outcomes_recorded: AtomicU64,
+}
+
+fn arm_key(class: TaskClass, hint: TopologyHint) -> String {
+    let c = match class {
+        TaskClass::IndependentBatch => "independent_batch",
+        TaskClass::SequentialPipeline => "sequential_pipeline",
+        TaskClass::HierarchicalDecomp => "hierarchical_decomp",
+        TaskClass::Unknown => "unknown",
+    };
+    let h = match hint {
+        TopologyHint::Parallel => "parallel",
+        TopologyHint::Sequential => "sequential",
+        TopologyHint::Hierarchical => "hierarchical",
+        TopologyHint::Hybrid => "hybrid",
+    };
+    format!("{c}:{h}")
+}
+
+const ALL_HINTS: [TopologyHint; 4] = [
+    TopologyHint::Parallel,
+    TopologyHint::Sequential,
+    TopologyHint::Hierarchical,
+    TopologyHint::Hybrid,
+];
+
+/// Bandit-driven topology advisor.
+///
+/// Classifies the user goal into a [`TaskClass`] via a cheap LLM call, samples
+/// the best [`TopologyHint`] for that class via Thompson sampling, and injects
+/// one sentence into the planner system prompt. Outcomes are recorded synchronously
+/// and persisted once on shutdown.
+pub struct TopologyAdvisor {
+    classifier: Arc<AnyProvider>,
+    arms: Arc<Mutex<HashMap<(TaskClass, TopologyHint), BetaDist>>>,
+    state_path: PathBuf,
+    classify_timeout: Duration,
+    pub metrics: Arc<AdaptOrchMetrics>,
+    rng: Arc<Mutex<rand::rngs::SmallRng>>,
+}
+
+impl std::fmt::Debug for TopologyAdvisor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TopologyAdvisor")
+            .field("state_path", &self.state_path)
+            .field("classify_timeout", &self.classify_timeout)
+            .finish_non_exhaustive()
+    }
+}
+
+impl TopologyAdvisor {
+    /// Construct a new advisor. Loads persisted state from `state_path` if present.
+    ///
+    /// When `state_path` is an empty string, the default path
+    /// `~/.zeph/adaptorch_state.json` is used.
+    #[must_use]
+    pub fn new(
+        classifier: Arc<AnyProvider>,
+        state_path: impl Into<PathBuf>,
+        classify_timeout: Duration,
+    ) -> Self {
+        let path: PathBuf = {
+            let p = state_path.into();
+            if p.as_os_str().is_empty() {
+                Self::default_path()
+            } else {
+                p
+            }
+        };
+        let arms = load_arms(&path);
+        Self {
+            classifier,
+            arms: Arc::new(Mutex::new(arms)),
+            state_path: path,
+            classify_timeout,
+            metrics: Arc::new(AdaptOrchMetrics::default()),
+            rng: Arc::new(Mutex::new(rand::rngs::SmallRng::from_rng(&mut rand::rng()))),
+        }
+    }
+
+    /// Default persistence path: `~/.zeph/adaptorch_state.json`.
+    #[must_use]
+    pub fn default_path() -> PathBuf {
+        dirs::home_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(".zeph")
+            .join("adaptorch_state.json")
+    }
+
+    /// Classify the goal and sample the best topology hint for this turn.
+    ///
+    /// Classification failures fall back to `TaskClass::Unknown` + `TopologyHint::Hybrid`.
+    pub async fn recommend(&self, goal: &str) -> AdvisorVerdict {
+        self.metrics.classify_calls.fetch_add(1, Ordering::Relaxed);
+
+        let class = tokio::time::timeout(self.classify_timeout, self.classify(goal))
+            .await
+            .unwrap_or_else(|_| {
+                self.metrics
+                    .classify_timeouts
+                    .fetch_add(1, Ordering::Relaxed);
+                TaskClass::Unknown
+            });
+
+        let fallback = class == TaskClass::Unknown;
+        let (hint, exploit) = self.sample_arm(class);
+
+        match hint {
+            TopologyHint::Parallel => {
+                self.metrics.hint_parallel.fetch_add(1, Ordering::Relaxed);
+            }
+            TopologyHint::Sequential => {
+                self.metrics.hint_sequential.fetch_add(1, Ordering::Relaxed);
+            }
+            TopologyHint::Hierarchical => {
+                self.metrics
+                    .hint_hierarchical
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            TopologyHint::Hybrid => {
+                self.metrics.hint_hybrid.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        AdvisorVerdict {
+            class,
+            hint,
+            exploit,
+            fallback,
+        }
+    }
+
+    /// Record the binary outcome of a plan guided by `(class, hint)`.
+    ///
+    /// **Synchronous** — acquires the in-memory `Mutex`, updates two `f64` counters, drops
+    /// the guard. Never spawns. Never persists. Persistence happens in [`save`](Self::save).
+    pub fn record_outcome(&self, class: TaskClass, hint: TopologyHint, reward: f64) {
+        self.metrics
+            .outcomes_recorded
+            .fetch_add(1, Ordering::Relaxed);
+        let key = (class, hint);
+        let mut arms = self.arms.lock();
+        let arm = arms.entry(key).or_default();
+        if reward >= 1.0 {
+            arm.alpha += 1.0;
+        } else {
+            arm.beta += 1.0;
+        }
+    }
+
+    /// Persist the Beta-arm table to `state_path` atomically.
+    ///
+    /// Called from the agent shutdown hook (once per process), mirroring
+    /// `AnyProvider::save_router_state`. Failures are logged and swallowed.
+    ///
+    /// # Errors
+    ///
+    /// Returns `io::Error` when the write fails.
+    pub fn save(&self) -> io::Result<()> {
+        let arms_map: HashMap<String, BetaDist> = self
+            .arms
+            .lock()
+            .iter()
+            .map(|((class, hint), dist)| (arm_key(*class, *hint), dist.clone()))
+            .collect();
+
+        let state = PersistState {
+            version: 1,
+            arms: arms_map,
+        };
+
+        let json = serde_json::to_string_pretty(&state).map_err(io::Error::other)?;
+
+        if let Some(parent) = self.state_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        atomic_write(&self.state_path, json.as_bytes())?;
+        Ok(())
+    }
+
+    // ─── private helpers ─────────────────────────────────────────────────────
+
+    async fn classify(&self, goal: &str) -> TaskClass {
+        let truncated = &goal[..goal.len().min(400)];
+        let system = "\
+You classify task decomposition patterns. Read the goal and answer with one of:\n\
+- independent_batch  — fan-out work with no cross-deps (research, comparisons, multi-source queries)\n\
+- sequential_pipeline — strict ordering (build → test → deploy, ETL)\n\
+- hierarchical_decomp — tree of subgoals, divide-and-conquer\n\
+- unknown            — does not clearly fit any of the above\n\n\
+Respond with a single JSON object:\n\
+{\"class\":\"...\",\"reason\":\"<one sentence>\"}";
+
+        let messages = vec![
+            Message::from_legacy(Role::System, system),
+            Message::from_legacy(Role::User, format!("Goal:\n{truncated}")),
+        ];
+
+        let raw = match self.classifier.chat(&messages).await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(error = %e, "adaptorch: classify call failed");
+                return TaskClass::Unknown;
+            }
+        };
+
+        parse_class(&raw)
+    }
+
+    fn sample_arm(&self, class: TaskClass) -> (TopologyHint, bool) {
+        if class == TaskClass::Unknown {
+            return (TopologyHint::Hybrid, false);
+        }
+        let mut rng = self.rng.lock();
+        let arms = self.arms.lock();
+        let scores: Vec<(TopologyHint, f64)> = ALL_HINTS
+            .iter()
+            .map(|hint| {
+                let dist = arms.get(&(class, *hint)).cloned().unwrap_or_default();
+                (*hint, dist.sample(&mut *rng))
+            })
+            .collect();
+
+        let (hint, score) = scores
+            .iter()
+            .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+            .map_or((TopologyHint::Hybrid, 0.0), |(h, s)| (*h, *s));
+
+        // "exploit" = the arm's mean (alpha / (alpha+beta)) aligns with the sampled score
+        let arm = arms.get(&(class, hint)).cloned().unwrap_or_default();
+        let mean = arm.alpha / (arm.alpha + arm.beta);
+        let exploit = (score - mean).abs() < 0.15;
+
+        (hint, exploit)
+    }
+}
+
+/// Parse the classifier's JSON response into a [`TaskClass`].
+fn parse_class(raw: &str) -> TaskClass {
+    // Try direct JSON parse first.
+    if let Ok(val) = serde_json::from_str::<serde_json::Value>(raw)
+        && let Some(class) = val.get("class").and_then(|c| c.as_str())
+    {
+        return str_to_class(class);
+    }
+    // Extract first {...} substring.
+    if let Some(start) = raw.find('{')
+        && let Some(end) = raw[start..].find('}')
+    {
+        let chunk = &raw[start..=start + end];
+        if let Ok(val) = serde_json::from_str::<serde_json::Value>(chunk)
+            && let Some(class) = val.get("class").and_then(|c| c.as_str())
+        {
+            return str_to_class(class);
+        }
+    }
+    // Substring scan.
+    for variant in &[
+        "independent_batch",
+        "sequential_pipeline",
+        "hierarchical_decomp",
+        "unknown",
+    ] {
+        if raw.contains(variant) {
+            return str_to_class(variant);
+        }
+    }
+    TaskClass::Unknown
+}
+
+fn str_to_class(s: &str) -> TaskClass {
+    match s {
+        "independent_batch" => TaskClass::IndependentBatch,
+        "sequential_pipeline" => TaskClass::SequentialPipeline,
+        "hierarchical_decomp" => TaskClass::HierarchicalDecomp,
+        _ => TaskClass::Unknown,
+    }
+}
+
+fn load_arms(path: &std::path::Path) -> HashMap<(TaskClass, TopologyHint), BetaDist> {
+    let mut arms = default_arms();
+    let Ok(data) = std::fs::read_to_string(path) else {
+        return arms;
+    };
+    let Ok(state) = serde_json::from_str::<PersistState>(&data) else {
+        tracing::warn!(path = %path.display(), "adaptorch: failed to parse state file, using defaults");
+        return arms;
+    };
+    if state.version != 1 {
+        tracing::warn!(
+            version = state.version,
+            "adaptorch: unknown state version, using defaults"
+        );
+        return arms;
+    }
+    for (key_str, dist) in state.arms {
+        let mut parts = key_str.splitn(2, ':');
+        let (Some(c), Some(h)) = (parts.next(), parts.next()) else {
+            continue;
+        };
+        let class = str_to_class(c);
+        let hint = match h {
+            "parallel" => TopologyHint::Parallel,
+            "sequential" => TopologyHint::Sequential,
+            "hierarchical" => TopologyHint::Hierarchical,
+            "hybrid" => TopologyHint::Hybrid,
+            _ => continue,
+        };
+        arms.insert((class, hint), dist);
+    }
+    arms
+}
+
+fn default_arms() -> HashMap<(TaskClass, TopologyHint), BetaDist> {
+    let classes = [
+        TaskClass::IndependentBatch,
+        TaskClass::SequentialPipeline,
+        TaskClass::HierarchicalDecomp,
+        TaskClass::Unknown,
+    ];
+    let mut map = HashMap::new();
+    for class in classes {
+        for hint in ALL_HINTS {
+            map.insert((class, hint), BetaDist::default());
+        }
+    }
+    map
+}
+
+fn atomic_write(path: &std::path::Path, data: &[u8]) -> io::Result<()> {
+    let tmp = path.with_extension("tmp");
+    {
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&tmp)?;
+        f.write_all(data)?;
+        f.flush()?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            f.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+        }
+    }
+    std::fs::rename(&tmp, path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_class_direct_json() {
+        let json = r#"{"class":"independent_batch","reason":"fan-out"}"#;
+        assert_eq!(parse_class(json), TaskClass::IndependentBatch);
+    }
+
+    #[test]
+    fn parse_class_fallback_substring() {
+        assert_eq!(
+            parse_class("  sequential_pipeline "),
+            TaskClass::SequentialPipeline
+        );
+    }
+
+    #[test]
+    fn parse_class_unknown_for_garbage() {
+        assert_eq!(parse_class("no idea"), TaskClass::Unknown);
+    }
+
+    #[test]
+    fn topology_hint_sentence_hybrid_is_none() {
+        assert!(TopologyHint::Hybrid.prompt_sentence().is_none());
+    }
+
+    #[test]
+    fn record_outcome_updates_alpha_beta() {
+        use std::sync::Arc;
+        use zeph_llm::any::AnyProvider;
+        let mock = zeph_llm::mock::MockProvider::default();
+        let advisor = TopologyAdvisor::new(
+            Arc::new(AnyProvider::Mock(mock)),
+            PathBuf::new(),
+            Duration::from_secs(4),
+        );
+        advisor.record_outcome(TaskClass::IndependentBatch, TopologyHint::Parallel, 1.0);
+        advisor.record_outcome(TaskClass::IndependentBatch, TopologyHint::Parallel, 0.0);
+        let arms = advisor.arms.lock();
+        let arm = arms
+            .get(&(TaskClass::IndependentBatch, TopologyHint::Parallel))
+            .unwrap();
+        assert!((arm.alpha - 2.0).abs() < f64::EPSILON);
+        assert!((arm.beta - 2.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn persistence_round_trip() {
+        use zeph_llm::any::AnyProvider;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        {
+            let mock = zeph_llm::mock::MockProvider::default();
+            let advisor = TopologyAdvisor::new(
+                Arc::new(AnyProvider::Mock(mock)),
+                path.clone(),
+                Duration::from_secs(4),
+            );
+            advisor.record_outcome(TaskClass::SequentialPipeline, TopologyHint::Sequential, 1.0);
+            advisor.save().unwrap();
+        }
+        {
+            let mock = zeph_llm::mock::MockProvider::default();
+            let advisor = TopologyAdvisor::new(
+                Arc::new(AnyProvider::Mock(mock)),
+                path.clone(),
+                Duration::from_secs(4),
+            );
+            let arms = advisor.arms.lock();
+            let arm = arms
+                .get(&(TaskClass::SequentialPipeline, TopologyHint::Sequential))
+                .unwrap();
+            // alpha was 1.0 (default) + 1 success = 2.0
+            assert!((arm.alpha - 2.0).abs() < f64::EPSILON);
+        }
+    }
+}

--- a/crates/zeph-orchestration/src/adaptorch.rs
+++ b/crates/zeph-orchestration/src/adaptorch.rs
@@ -110,8 +110,9 @@ impl BetaDist {
     fn sample<R: rand::Rng>(&self, rng: &mut R) -> f64 {
         let a = self.alpha.max(1e-6);
         let b = self.beta.max(1e-6);
+        // Safety: a and b are clamped to ≥1e-6, so Beta::new never fails.
         Beta::new(a, b)
-            .unwrap_or_else(|_| Beta::new(1.0, 1.0).unwrap())
+            .expect("clamped values ≥1e-6 are always valid Beta params")
             .sample(rng)
     }
 }
@@ -320,7 +321,7 @@ impl TopologyAdvisor {
     // ─── private helpers ─────────────────────────────────────────────────────
 
     async fn classify(&self, goal: &str) -> TaskClass {
-        let truncated = &goal[..goal.len().min(400)];
+        let truncated: String = goal.chars().take(400).collect();
         let system = "\
 You classify task decomposition patterns. Read the goal and answer with one of:\n\
 - independent_batch  — fan-out work with no cross-deps (research, comparisons, multi-source queries)\n\
@@ -350,14 +351,23 @@ Respond with a single JSON object:\n\
         if class == TaskClass::Unknown {
             return (TopologyHint::Hybrid, false);
         }
+        // Clone arm entries under arms lock, then release before acquiring rng lock.
+        let arm_entries: Vec<(TopologyHint, BetaDist)> = {
+            let arms = self.arms.lock();
+            ALL_HINTS
+                .iter()
+                .map(|hint| {
+                    (
+                        *hint,
+                        arms.get(&(class, *hint)).cloned().unwrap_or_default(),
+                    )
+                })
+                .collect()
+        };
         let mut rng = self.rng.lock();
-        let arms = self.arms.lock();
-        let scores: Vec<(TopologyHint, f64)> = ALL_HINTS
+        let scores: Vec<(TopologyHint, f64)> = arm_entries
             .iter()
-            .map(|hint| {
-                let dist = arms.get(&(class, *hint)).cloned().unwrap_or_default();
-                (*hint, dist.sample(&mut *rng))
-            })
+            .map(|(hint, dist)| (*hint, dist.sample(&mut *rng)))
             .collect();
 
         let (hint, score) = scores
@@ -366,7 +376,11 @@ Respond with a single JSON object:\n\
             .map_or((TopologyHint::Hybrid, 0.0), |(h, s)| (*h, *s));
 
         // "exploit" = the arm's mean (alpha / (alpha+beta)) aligns with the sampled score
-        let arm = arms.get(&(class, hint)).cloned().unwrap_or_default();
+        let arm = arm_entries
+            .iter()
+            .find(|(h, _)| *h == hint)
+            .map(|(_, d)| d.clone())
+            .unwrap_or_default();
         let mean = arm.alpha / (arm.alpha + arm.beta);
         let exploit = (score - mean).abs() < 0.15;
 
@@ -531,6 +545,69 @@ mod tests {
             .unwrap();
         assert!((arm.alpha - 2.0).abs() < f64::EPSILON);
         assert!((arm.beta - 2.0).abs() < f64::EPSILON);
+    }
+
+    #[tokio::test]
+    async fn recommend_with_valid_json_returns_correct_class() {
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+        let mock = MockProvider::with_responses(vec![
+            r#"{"class":"sequential_pipeline","reason":"strict ordering"}"#.into(),
+        ]);
+        let advisor = TopologyAdvisor::new(
+            Arc::new(AnyProvider::Mock(mock)),
+            PathBuf::new(),
+            Duration::from_secs(4),
+        );
+        let verdict = advisor
+            .recommend("Build, test, then deploy the service")
+            .await;
+        assert_eq!(verdict.class, TaskClass::SequentialPipeline);
+        assert!(advisor.metrics.classify_timeouts.load(Ordering::Relaxed) == 0);
+    }
+
+    #[tokio::test]
+    async fn recommend_timeout_returns_unknown_and_increments_metric() {
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+        // Delay longer than classify_timeout so the call times out.
+        let mut mock = MockProvider::default();
+        mock.delay_ms = 200;
+        mock.default_response = r#"{"class":"sequential_pipeline","reason":"x"}"#.into();
+        let advisor = TopologyAdvisor::new(
+            Arc::new(AnyProvider::Mock(mock)),
+            PathBuf::new(),
+            Duration::from_millis(50), // short timeout
+        );
+        let verdict = advisor.recommend("any goal").await;
+        assert_eq!(verdict.class, TaskClass::Unknown);
+        assert_eq!(advisor.metrics.classify_timeouts.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn sample_arm_favours_reinforced_hint() {
+        use zeph_llm::any::AnyProvider;
+        let mock = zeph_llm::mock::MockProvider::default();
+        let advisor = TopologyAdvisor::new(
+            Arc::new(AnyProvider::Mock(mock)),
+            PathBuf::new(),
+            Duration::from_secs(4),
+        );
+        // Reinforce Sequential 20 times for SequentialPipeline class.
+        for _ in 0..20 {
+            advisor.record_outcome(TaskClass::SequentialPipeline, TopologyHint::Sequential, 1.0);
+        }
+        // Sample 50 times and verify Sequential wins most often.
+        let mut counts = std::collections::HashMap::new();
+        for _ in 0..50 {
+            let (hint, _) = advisor.sample_arm(TaskClass::SequentialPipeline);
+            *counts.entry(hint).or_insert(0u32) += 1;
+        }
+        let sequential_count = counts.get(&TopologyHint::Sequential).copied().unwrap_or(0);
+        assert!(
+            sequential_count > 30,
+            "expected Sequential to win >30/50 times after reinforcement, got {sequential_count}"
+        );
     }
 
     #[test]

--- a/crates/zeph-orchestration/src/lib.rs
+++ b/crates/zeph-orchestration/src/lib.rs
@@ -69,6 +69,7 @@
 #[allow(unused_imports)]
 pub(crate) use zeph_db::sql;
 
+pub mod adaptorch;
 pub mod aggregator;
 pub mod cascade;
 pub mod command;
@@ -82,6 +83,7 @@ pub mod scheduler;
 pub mod topology;
 pub mod verifier;
 
+pub use adaptorch::{AdaptOrchMetrics, AdvisorVerdict, TaskClass, TopologyAdvisor, TopologyHint};
 pub use aggregator::{Aggregator, LlmAggregator};
 pub use cascade::{CascadeConfig, CascadeDetector, RegionHealth};
 pub use command::PlanCommand;

--- a/crates/zeph-orchestration/src/planner.rs
+++ b/crates/zeph-orchestration/src/planner.rs
@@ -6,8 +6,9 @@
 use std::collections::{HashMap, HashSet};
 
 use serde::Deserialize;
-use zeph_llm::provider::{LlmProvider, Message, Role};
+use zeph_llm::provider::{LlmProvider, Message, Role}; // Role needed for plan_with_hint prompt augmentation
 
+use super::adaptorch::TopologyHint;
 use super::dag;
 use super::error::OrchestrationError;
 use super::graph::{ExecutionMode, FailureStrategy, TaskGraph, TaskId, TaskNode};
@@ -54,6 +55,24 @@ pub trait Planner: Send + Sync {
         goal: &str,
         available_agents: &[SubAgentDef],
     ) -> Result<(TaskGraph, Option<(u64, u64)>), OrchestrationError>;
+
+    /// Plan with an optional topology hint from `AdaptOrch`.
+    ///
+    /// Default implementation ignores the hint and forwards to [`plan`][Self::plan].
+    /// This lets every existing implementor compile without changes; `LlmPlanner`
+    /// overrides this to inject one prompt sentence per hint variant.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`plan`][Self::plan].
+    async fn plan_with_hint(
+        &self,
+        goal: &str,
+        available_agents: &[SubAgentDef],
+        _hint: Option<TopologyHint>,
+    ) -> Result<(TaskGraph, Option<(u64, u64)>), OrchestrationError> {
+        self.plan(goal, available_agents).await
+    }
 }
 
 /// LLM-backed [`Planner`] using `chat_typed` for structured JSON output.
@@ -108,6 +127,38 @@ pub(crate) struct PlannedTask {
 }
 
 impl<P: LlmProvider + Send + Sync> Planner for LlmPlanner<P> {
+    async fn plan_with_hint(
+        &self,
+        goal: &str,
+        available_agents: &[SubAgentDef],
+        hint: Option<TopologyHint>,
+    ) -> Result<(TaskGraph, Option<(u64, u64)>), OrchestrationError> {
+        if goal.trim().is_empty() {
+            return Err(OrchestrationError::PlanningFailed(
+                "goal cannot be empty".into(),
+            ));
+        }
+        let mut messages = build_prompt(goal, available_agents, self.max_tasks);
+        if let Some(hint) = hint
+            && let Some(sentence) = hint.prompt_sentence()
+        {
+            // Append the topology hint to the system prompt (first message).
+            if let Some(sys) = messages.first_mut() {
+                let augmented = format!("{}\n\n{}", sys.content, sentence);
+                *sys = Message::from_legacy(Role::System, augmented);
+            }
+        }
+        let response: PlannerResponse = self
+            .provider
+            .chat_typed(&messages)
+            .await
+            .map_err(|e| OrchestrationError::PlanningFailed(e.to_string()))?;
+        let usage = self.provider.last_usage();
+        let graph = convert_response(response, goal, available_agents, self.max_tasks)?;
+        dag::validate(&graph.tasks, self.max_tasks as usize)?;
+        Ok((graph, usage))
+    }
+
     async fn plan(
         &self,
         goal: &str,

--- a/crates/zeph-orchestration/src/scheduler.rs
+++ b/crates/zeph-orchestration/src/scheduler.rs
@@ -1433,6 +1433,7 @@ mod tests {
             cascade_routing: false,
             cascade_failure_threshold: 0.5,
             tree_optimized_dispatch: false,
+            adaptorch: Default::default(),
         }
     }
 

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -1001,6 +1001,60 @@ impl AppBuilder {
         }
     }
 
+    /// Build a `TopologyAdvisor` when `[orchestration.adaptorch]` is enabled.
+    ///
+    /// Returns `None` when disabled or when the classify provider cannot be resolved.
+    pub fn build_topology_advisor(
+        &self,
+    ) -> Option<std::sync::Arc<zeph_orchestration::TopologyAdvisor>> {
+        let cfg = &self.config.orchestration.adaptorch;
+        if !cfg.enabled {
+            return None;
+        }
+        let classify_provider = if cfg.topology_provider.is_empty() {
+            match create_named_provider(
+                &self.config.llm.providers.first()?.effective_name(),
+                &self.config,
+            ) {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::warn!(error = %e, "adaptorch: cannot resolve classify provider");
+                    return None;
+                }
+            }
+        } else {
+            match create_named_provider(cfg.topology_provider.as_str(), &self.config) {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::warn!(
+                        provider = %cfg.topology_provider.as_str(),
+                        error = %e,
+                        "adaptorch: classify provider resolution failed"
+                    );
+                    return None;
+                }
+            }
+        };
+        let state_path = if cfg.state_path.is_empty() {
+            std::path::PathBuf::new()
+        } else {
+            std::path::PathBuf::from(&cfg.state_path)
+        };
+        let timeout = std::time::Duration::from_secs(cfg.classify_timeout_secs);
+        tracing::info!(
+            provider = %cfg.topology_provider.as_str(),
+            timeout_secs = cfg.classify_timeout_secs,
+            "adaptorch: topology advisor initialized"
+        );
+        Some(std::sync::Arc::new(
+            zeph_orchestration::TopologyAdvisor::new(
+                std::sync::Arc::new(classify_provider),
+                state_path,
+                timeout,
+            ),
+        ))
+    }
+
     /// Build the `PlanVerifier` provider from `[orchestration] verify_provider`.
     ///
     /// Returns `None` when `verify_provider` is empty (falls back to the primary provider at

--- a/src/bootstrap/provider.rs
+++ b/src/bootstrap/provider.rs
@@ -93,6 +93,19 @@ fn build_cascade_router_config(
     }
 }
 
+/// Clamp a `CoE` threshold to `[0.0, 1.0]` and warn on invalid values.
+fn validate_coe_threshold(name: &str, value: f64) -> f64 {
+    if value.is_nan() || value.is_infinite() || !(0.0..=1.0).contains(&value) {
+        tracing::warn!(
+            field = name,
+            value,
+            "coe: threshold out of [0.0, 1.0] — clamping to valid range"
+        );
+        return value.clamp(0.0, 1.0);
+    }
+    value
+}
+
 /// Attach `CoE` to a `RouterProvider` if `[llm.coe]` is configured and enabled.
 ///
 /// Skips silently when the secondary or embed provider cannot be resolved.
@@ -124,16 +137,15 @@ fn apply_coe(router: RouterProvider, config: &Config) -> RouterProvider {
             .and_then(|e| build_provider_from_entry(e, config).ok())
     };
     if let (Some(sec), Some(emb)) = (secondary, embed) {
+        let intra = validate_coe_threshold("intra_threshold", coe_cfg.intra_threshold);
+        let inter = validate_coe_threshold("inter_threshold", coe_cfg.inter_threshold);
+        let shadow = validate_coe_threshold("shadow_sample_rate", coe_cfg.shadow_sample_rate);
         let router_coe = RouterCoeConfig {
-            intra_threshold: coe_cfg.intra_threshold,
-            inter_threshold: coe_cfg.inter_threshold,
-            shadow_sample_rate: coe_cfg.shadow_sample_rate,
+            intra_threshold: intra,
+            inter_threshold: inter,
+            shadow_sample_rate: shadow,
         };
-        tracing::info!(
-            "coe: enabled (intra={:.2} inter={:.2})",
-            coe_cfg.intra_threshold,
-            coe_cfg.inter_threshold
-        );
+        tracing::info!("coe: enabled (intra={:.2} inter={:.2})", intra, inter);
         router.with_coe(router_coe, sec, emb)
     } else {
         tracing::warn!("coe: secondary or embed provider not resolved, CoE disabled");

--- a/src/bootstrap/provider.rs
+++ b/src/bootstrap/provider.rs
@@ -128,7 +128,6 @@ fn apply_coe(router: RouterProvider, config: &Config) -> RouterProvider {
             intra_threshold: coe_cfg.intra_threshold,
             inter_threshold: coe_cfg.inter_threshold,
             shadow_sample_rate: coe_cfg.shadow_sample_rate,
-            max_secondary_calls_per_turn: coe_cfg.max_secondary_calls_per_turn,
         };
         tracing::info!(
             "coe: enabled (intra={:.2} inter={:.2})",

--- a/src/bootstrap/provider.rs
+++ b/src/bootstrap/provider.rs
@@ -6,6 +6,7 @@ pub use zeph_core::provider_factory::{BootstrapError, build_provider_from_entry}
 use zeph_llm::any::AnyProvider;
 use zeph_llm::ollama::OllamaProvider;
 use zeph_llm::router::cascade::ClassifierMode;
+use zeph_llm::router::coe::CoeConfig as RouterCoeConfig;
 use zeph_llm::router::triage::{ComplexityTier, TriageRouter};
 use zeph_llm::router::{AsiRouterConfig, BanditRouterConfig, CascadeRouterConfig, RouterProvider};
 
@@ -89,6 +90,55 @@ fn build_cascade_router_config(
         max_cascade_tokens: cascade_cfg.max_cascade_tokens,
         summary_provider,
         cost_tiers: cascade_cfg.cost_tiers.clone(),
+    }
+}
+
+/// Attach `CoE` to a `RouterProvider` if `[llm.coe]` is configured and enabled.
+///
+/// Skips silently when the secondary or embed provider cannot be resolved.
+fn apply_coe(router: RouterProvider, config: &Config) -> RouterProvider {
+    let Some(coe_cfg) = config.llm.coe.as_ref() else {
+        return router;
+    };
+    if !coe_cfg.enabled {
+        return router;
+    }
+    let pool = &config.llm.providers;
+    let secondary = if coe_cfg.secondary_provider.is_empty() {
+        // fall back to the first non-embed provider
+        pool.iter()
+            .find(|e| !e.embed)
+            .and_then(|e| build_provider_from_entry(e, config).ok())
+    } else {
+        pool.iter()
+            .find(|e| e.effective_name() == coe_cfg.secondary_provider.as_str())
+            .and_then(|e| build_provider_from_entry(e, config).ok())
+    };
+    let embed = if coe_cfg.embed_provider.is_empty() {
+        pool.iter()
+            .find(|e| e.embed)
+            .and_then(|e| build_provider_from_entry(e, config).ok())
+    } else {
+        pool.iter()
+            .find(|e| e.effective_name() == coe_cfg.embed_provider.as_str())
+            .and_then(|e| build_provider_from_entry(e, config).ok())
+    };
+    if let (Some(sec), Some(emb)) = (secondary, embed) {
+        let router_coe = RouterCoeConfig {
+            intra_threshold: coe_cfg.intra_threshold,
+            inter_threshold: coe_cfg.inter_threshold,
+            shadow_sample_rate: coe_cfg.shadow_sample_rate,
+            max_secondary_calls_per_turn: coe_cfg.max_secondary_calls_per_turn,
+        };
+        tracing::info!(
+            "coe: enabled (intra={:.2} inter={:.2})",
+            coe_cfg.intra_threshold,
+            coe_cfg.inter_threshold
+        );
+        router.with_coe(router_coe, sec, emb)
+    } else {
+        tracing::warn!("coe: secondary or embed provider not resolved, CoE disabled");
+        router
     }
 }
 
@@ -228,6 +278,7 @@ fn create_provider_from_pool(config: &Config) -> Result<AnyProvider, BootstrapEr
             }
             let router =
                 RouterProvider::new(providers).with_ema(alpha, config.llm.router_reorder_interval);
+            let router = apply_coe(router, config);
             Ok(AnyProvider::Router(Box::new(apply_routing_signals(
                 router, config,
             ))))
@@ -241,6 +292,7 @@ fn create_provider_from_pool(config: &Config) -> Result<AnyProvider, BootstrapEr
                 .and_then(|r| r.thompson_state_path.as_deref())
                 .map(std::path::Path::new);
             let router = RouterProvider::new(providers).with_thompson(state_path);
+            let router = apply_coe(router, config);
             Ok(AnyProvider::Router(Box::new(apply_routing_signals(
                 router, config,
             ))))

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -622,6 +622,7 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
         summary_model: None,
         summary_provider: None,
         complexity_routing: None,
+        coe: None,
     };
 
     // When postgres backend was chosen, sqlite_path is left at its serde default (unused).

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1766,6 +1766,11 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     } else {
         agent
     };
+    let agent = if let Some(ta) = app.build_topology_advisor() {
+        agent.with_topology_advisor(ta)
+    } else {
+        agent
+    };
     let agent = agent_setup::apply_quarantine_provider(agent, app.build_quarantine_provider());
     let agent = agent_setup::apply_guardrail(agent, app.build_guardrail_provider());
     #[cfg(feature = "classifiers")]


### PR DESCRIPTION
## Summary

- **AdaptOrch** (`zeph-orchestration`): 16-arm Thompson Beta-bandit classifies goals into `TaskClass` variants and samples a `TopologyHint` (Sequential / Parallel / Cascade / Adaptive) injected into the planner prompt before planning. State persists to disk on graceful shutdown. Zero overhead when `[orchestration.adaptorch] enabled = false`.
- **CoE** (`zeph-llm/router`): `chat_with_extras()` returns `ChatExtras { entropy }` for providers with logprobs support (OpenAI, Compatible, Ollama). Router uses intra-entropy threshold and inter-divergence `(1-cosine)/2` to escalate uncertain responses to a configured secondary provider. Gated to `Ema`/`Thompson` strategies only. Zero overhead when `[llm.coe] enabled = false`.

Closes #2434, #2505.

## Changes

- `crates/zeph-orchestration/src/adaptorch.rs` — `TopologyAdvisor`, `TaskClass`, `TopologyHint`, Thompson arm state
- `crates/zeph-llm/src/router/coe.rs` — `CoeRouter`, `ChatExtras`, `run_coe`, inter-divergence computation
- `crates/zeph-llm/src/provider.rs` — `chat_with_extras()` trait method + per-provider impls
- `crates/zeph-orchestration/src/plan.rs` — `plan_with_hint()` planner integration
- `src/runner.rs` — bootstrap wiring for both features
- Config: `[orchestration.adaptorch]` and `[llm.coe]` blocks (both `enabled = false` by default)

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` — 8122 tests pass
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] Live session test required before merge (LLM serialization gate): run `cargo run --features full -- --config .local/config/testing.toml` and verify at least one multi-turn round-trip completes without 400/422 errors
- [ ] Playbook: `.local/testing/playbooks/orchestration.md` — scenarios for AdaptOrch hint injection and CoE escalation
- [ ] Coverage rows added to `coverage-status.md` (status: Untested — pending live session)