### PR TITLE
fix(mcp): raise output_schema_hint_bytes default to 1024 and fix stub event name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **fix(mcp): raise default `output_schema_hint_bytes` from 512 to 1024** — the 512-byte default
+  caused stub fallback for most real-world MCP tool schemas, making `forward_output_schema`
+  largely ineffective at default config. Closes #3084.
+- **fix(mcp): distinguish stub event name from success event** — WARN emitted when
+  `output_schema_hint_bytes` budget is exceeded now uses `event = "mcp.output_schema.stub_used"`
+  instead of the misleading `mcp.output_schema.forwarded_to_llm`. Fixed in openai and claude
+  backends. Closes #3087.
+
 ### Added
 
 - **feat(orchestration): AdaptOrch topology advisor** — 16-arm Thompson Beta-bandit that classifies

--- a/crates/zeph-config/src/channels.rs
+++ b/crates/zeph-config/src/channels.rs
@@ -66,6 +66,17 @@ mod tests {
     }
 
     #[test]
+    fn test_default_output_schema_hint_bytes_is_1024() {
+        assert_eq!(default_output_schema_hint_bytes(), 1024);
+    }
+
+    #[test]
+    fn test_mcp_config_default_output_schema_hint_bytes_is_1024() {
+        let cfg = McpConfig::default();
+        assert_eq!(cfg.output_schema_hint_bytes, 1024);
+    }
+
+    #[test]
     fn wildcard_star_allows_any_skill() {
         let cfg = allow(&["*"]);
         assert!(is_skill_allowed("anything", &cfg));
@@ -529,7 +540,7 @@ fn default_elicitation_queue_capacity() -> usize {
 }
 
 fn default_output_schema_hint_bytes() -> usize {
-    512
+    1024
 }
 
 #[allow(clippy::struct_excessive_bools)]
@@ -596,7 +607,7 @@ pub struct McpConfig {
     #[serde(default)]
     pub forward_output_schema: bool,
     /// Maximum bytes of the compact JSON appended to the tool description as the output schema
-    /// hint when `forward_output_schema = true`. Default: 512.
+    /// hint when `forward_output_schema = true`. Default: 1024.
     ///
     /// If the serialized schema exceeds this budget, a stub message is used instead and a WARN
     /// is emitted once per session per tool.

--- a/crates/zeph-llm/src/claude/mod.rs
+++ b/crates/zeph-llm/src/claude/mod.rs
@@ -207,7 +207,7 @@ impl ClaudeProvider {
             tool_cache: Mutex::new(None),
             generation_overrides: None,
             forward_output_schema: false,
-            output_schema_hint_bytes: 512,
+            output_schema_hint_bytes: 1024,
             max_tool_description_bytes: usize::MAX,
             server_compaction: false,
             server_compaction_rejected: Arc::new(AtomicBool::new(false)),
@@ -1254,7 +1254,7 @@ pub(crate) fn build_tool_description(
                 tool = tool_name,
                 schema_bytes = compact.len(),
                 cap = hint_bytes,
-                event = "mcp.output_schema.forwarded_to_llm",
+                event = "mcp.output_schema.stub_used",
                 "MCP output_schema hint exceeds budget — using stub"
             );
         }

--- a/crates/zeph-llm/src/claude/tests.rs
+++ b/crates/zeph-llm/src/claude/tests.rs
@@ -3061,3 +3061,55 @@ fn tool_cache_key_sensitive_to_description() {
         "cache key must differ when description changes"
     );
 }
+
+#[test]
+fn test_claude_default_output_schema_hint_bytes_is_1024() {
+    use zeph_common::types::ToolDefinition;
+    let schema =
+        serde_json::json!({"type": "object", "properties": {"result": {"type": "string"}}});
+    let compact = serde_json::to_string(&schema).unwrap();
+    assert!(
+        compact.len() < 1024,
+        "test schema must be under 1024 bytes for this assertion to be meaningful"
+    );
+    let tool = ToolDefinition {
+        name: "do_something".into(),
+        description: "Do something".into(),
+        parameters: serde_json::json!({"type": "object"}),
+        output_schema: Some(schema),
+    };
+    let provider =
+        crate::claude::ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 1000)
+            .with_output_schema_forwarding(true, 1024, usize::MAX);
+    let api_tools = provider.get_or_build_api_tools(&[tool]);
+    let desc = api_tools[0]["description"].as_str().unwrap();
+    assert!(
+        desc.contains("Expected output schema"),
+        "schema under 1024 bytes must be forwarded with default budget"
+    );
+    assert!(
+        !desc.contains("too large"),
+        "schema under 1024 bytes must not trigger stub with default budget"
+    );
+}
+
+#[test]
+fn test_claude_stub_used_when_schema_exceeds_1024_bytes() {
+    use zeph_common::types::ToolDefinition;
+    let large_schema = serde_json::json!({"description": "y".repeat(1100)});
+    let tool = ToolDefinition {
+        name: "large_tool".into(),
+        description: "Base".into(),
+        parameters: serde_json::json!({"type": "object"}),
+        output_schema: Some(large_schema),
+    };
+    let provider =
+        crate::claude::ClaudeProvider::new("key".into(), "claude-sonnet-4-6".into(), 1000)
+            .with_output_schema_forwarding(true, 1024, usize::MAX);
+    let api_tools = provider.get_or_build_api_tools(&[tool]);
+    let desc = api_tools[0]["description"].as_str().unwrap();
+    assert!(
+        desc.contains("too large"),
+        "schema exceeding 1024 bytes must use stub with default budget"
+    );
+}

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -150,7 +150,7 @@ impl OpenAiProvider {
             usage: UsageTracker::default(),
             generation_overrides: None,
             forward_output_schema: false,
-            output_schema_hint_bytes: 512,
+            output_schema_hint_bytes: 1024,
             max_tool_description_bytes: usize::MAX,
             coe_enabled: false,
         }
@@ -1666,7 +1666,7 @@ pub(crate) fn build_tool_description(
                 tool = tool_name,
                 schema_bytes = compact.len(),
                 cap = hint_bytes,
-                event = "mcp.output_schema.forwarded_to_llm",
+                event = "mcp.output_schema.stub_used",
                 "MCP output_schema hint exceeds budget — using stub"
             );
         }

--- a/crates/zeph-llm/src/openai/tests.rs
+++ b/crates/zeph-llm/src/openai/tests.rs
@@ -1531,3 +1531,43 @@ fn output_schema_forwarding_none_schema_unchanged_description_openai() {
         "description must be unchanged when output_schema is None even if forwarding is enabled"
     );
 }
+
+#[test]
+fn test_openai_default_output_schema_hint_bytes_is_1024() {
+    // Default budget is 1024 — a schema under 1024 bytes must not trigger the stub
+    let schema =
+        serde_json::json!({"type": "object", "properties": {"result": {"type": "string"}}});
+    let compact = serde_json::to_string(&schema).unwrap();
+    assert!(
+        compact.len() < 1024,
+        "test schema must be under 1024 bytes for this assertion to be meaningful"
+    );
+    let desc = build_tool_description(
+        "Do something",
+        Some(&schema),
+        true,
+        1024,
+        usize::MAX,
+        "do_something",
+    );
+    assert!(
+        desc.contains("Expected output schema"),
+        "schema under 1024 bytes must be forwarded, not stubbed"
+    );
+    assert!(
+        !desc.contains("too large"),
+        "schema under 1024 bytes must not trigger stub with default budget"
+    );
+}
+
+#[test]
+fn test_openai_stub_used_when_schema_exceeds_1024_bytes() {
+    // Schema larger than 1024 bytes must produce the stub message
+    let large_value = "y".repeat(1100);
+    let schema = serde_json::json!({"description": large_value});
+    let desc = build_tool_description("Tool", Some(&schema), true, 1024, usize::MAX, "large_tool");
+    assert!(
+        desc.contains("too large"),
+        "schema exceeding 1024 bytes must use stub with default budget"
+    );
+}


### PR DESCRIPTION
## Summary

- Raises `output_schema_hint_bytes` default from 512 → 1024 bytes, fixing silent stub fallback for most real-world MCP tool schemas when `forward_output_schema = true` (#3084)
- Changes the WARN event name on the budget-exceeded path from `mcp.output_schema.forwarded_to_llm` to `mcp.output_schema.stub_used` in openai and claude backends, making telemetry unambiguous (#3087)
- Adds 6 unit tests: default value assertion in zeph-config, boundary tests for schema-fits vs stub path in both backends

## Files changed

- `crates/zeph-config/src/channels.rs` — `default_output_schema_hint_bytes()` 512 → 1024, doc comment updated
- `crates/zeph-llm/src/openai/mod.rs` — struct default + event name fix
- `crates/zeph-llm/src/openai/tests.rs` — 2 new boundary tests
- `crates/zeph-llm/src/claude/mod.rs` — struct default + event name fix
- `crates/zeph-llm/src/claude/tests.rs` — 2 new boundary tests

## Test plan

- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 8177 tests pass
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --lib --bins -- -D warnings` — clean
- [ ] Live session: verify `event="mcp.output_schema.stub_used"` in WARN log with Todoist MCP connected

Closes #3084, #3087