### PR TITLE
fix(mcp): wire forward_output_schema for Compatible, Gemini, and Ollama providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **fix(mcp): wire `forward_output_schema` for Compatible, Gemini, and Ollama providers** —
+  `forward_output_schema = true` was silently ignored for all backends except Claude and OpenAi.
+  `CompatibleProvider` now exposes `with_output_schema_forwarding()` (delegating to the inner
+  `OpenAiProvider`) and the factory wires it for the Compatible branch. Gemini and Ollama emit a
+  `WARN` log when the setting is enabled, since neither backend supports the feature, so users are
+  no longer silently misled. Closes #3111.
 - **fix(mcp): raise default `output_schema_hint_bytes` from 512 to 1024** — the 512-byte default
   caused stub fallback for most real-world MCP tool schemas, making `forward_output_schema`
   largely ineffective at default config. Closes #3084.

--- a/crates/zeph-core/src/provider_factory.rs
+++ b/crates/zeph-core/src/provider_factory.rs
@@ -108,6 +108,12 @@ pub fn build_provider_from_entry(
             if let Some(ref vm) = entry.vision_model {
                 provider = provider.with_vision_model(vm.clone());
             }
+            if config.mcp.forward_output_schema {
+                tracing::warn!(
+                    "mcp.forward_output_schema is enabled but Ollama does not support \
+                     output schema forwarding; setting ignored for this provider"
+                );
+            }
             Ok(AnyProvider::Ollama(provider))
         }
         ProviderKind::Claude => {
@@ -214,6 +220,12 @@ pub fn build_provider_from_entry(
             if let Some(include) = entry.include_thoughts {
                 provider = provider.with_include_thoughts(include);
             }
+            if config.mcp.forward_output_schema {
+                tracing::warn!(
+                    "mcp.forward_output_schema is enabled but Gemini does not support \
+                     output schema forwarding; setting ignored for this provider"
+                );
+            }
             Ok(AnyProvider::Gemini(provider))
         }
         ProviderKind::Compatible => {
@@ -237,14 +249,25 @@ pub fn build_provider_from_entry(
                     .unwrap_or_default()
             });
             let max_tokens = entry.max_tokens.unwrap_or(4096);
-            Ok(AnyProvider::Compatible(CompatibleProvider::new(
+            let provider = CompatibleProvider::new(
                 name.to_owned(),
                 api_key,
                 base_url,
                 model,
                 max_tokens,
                 entry.embedding_model.clone(),
-            )))
+            )
+            .with_output_schema_forwarding(
+                config.mcp.forward_output_schema,
+                config.mcp.output_schema_hint_bytes,
+                config.mcp.max_description_bytes,
+            );
+            tracing::info!(
+                forward = config.mcp.forward_output_schema,
+                provider = name,
+                "mcp.output_schema.forwarding_configured"
+            );
+            Ok(AnyProvider::Compatible(provider))
         }
         #[cfg(feature = "candle")]
         ProviderKind::Candle => {

--- a/crates/zeph-llm/src/compatible.rs
+++ b/crates/zeph-llm/src/compatible.rs
@@ -106,6 +106,24 @@ impl CompatibleProvider {
         self.inner = self.inner.with_coe();
         self
     }
+
+    /// Forward MCP tool output schemas as JSON hints appended to tool descriptions.
+    ///
+    /// Delegates to the inner [`OpenAiProvider`]. When `enabled` is `false` the call is a no-op.
+    /// `hint_bytes` caps the JSON representation; `max_description_bytes` caps the combined
+    /// description string.
+    #[must_use]
+    pub fn with_output_schema_forwarding(
+        mut self,
+        enabled: bool,
+        hint_bytes: usize,
+        max_description_bytes: usize,
+    ) -> Self {
+        self.inner =
+            self.inner
+                .with_output_schema_forwarding(enabled, hint_bytes, max_description_bytes);
+        self
+    }
 }
 
 impl LlmProvider for CompatibleProvider {
@@ -305,5 +323,12 @@ mod tests {
     #[test]
     fn last_usage_initially_none() {
         assert!(test_provider().last_usage().is_none());
+    }
+
+    #[test]
+    fn with_output_schema_forwarding_does_not_panic() {
+        // Smoke-test that the builder compiles and returns self without panicking.
+        let p = test_provider().with_output_schema_forwarding(true, 512, usize::MAX);
+        assert_eq!(p.name(), "groq");
     }
 }


### PR DESCRIPTION
## Summary

- `CompatibleProvider` gains `with_output_schema_forwarding()` builder that delegates to the inner `OpenAiProvider`
- `provider_factory.rs` now calls it in the Compatible branch so schema hints appear in tool descriptions when `forward_output_schema = true`
- Gemini and Ollama emit a `WARN` log when the setting is enabled (neither backend supports the feature) — users are no longer silently misled

## Changes

- `crates/zeph-llm/src/compatible.rs` — new `with_output_schema_forwarding()` builder + smoke-test
- `crates/zeph-core/src/provider_factory.rs` — Compatible branch wired; Gemini and Ollama branches emit diagnostic WARN; INFO log for Compatible matches the existing Claude/OpenAi pattern
- `CHANGELOG.md` — entry in `[Unreleased]`

## Test plan

- [ ] 2206 unit tests pass (`cargo nextest run -p zeph-llm -p zeph-core --lib`)
- [ ] `cargo +nightly fmt --check` passes
- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] Live session with Compatible provider + `forward_output_schema = true` to confirm schema hints appear in tool descriptions (coverage-status updated to Partial pending live test)

Closes #3111