### PR TITLE
fix(sandbox): emit canonical deny rules for symlinked secret paths

### DIFF
--- a/crates/zeph-tools/Cargo.toml
+++ b/crates/zeph-tools/Cargo.toml
@@ -48,6 +48,7 @@ zeph-common = { workspace = true, features = ["treesitter"] }
 [dev-dependencies]
 insta.workspace = true
 proptest.workspace = true
+tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 toml.workspace = true
 wiremock.workspace = true

--- a/crates/zeph-tools/src/sandbox/macos.rs
+++ b/crates/zeph-tools/src/sandbox/macos.rs
@@ -241,10 +241,6 @@ fn generate_sb_profile_for_home(policy: &SandboxPolicy, home: &Path) -> String {
     //   3. User-provided allow_read paths appearing here override deny-first rules
     //      above (last-rule-wins), giving callers an explicit opt-in escape hatch.
     //
-    // NOTE: deny rules use non-canonicalized home.join(rel); allow_read paths are
-    // canonicalized by SandboxPolicy::canonicalized(). If ~/.ssh is a symlink to
-    // /secure/ssh-mount/, the user override will NOT override the deny rule because
-    // they resolve to different paths. This is a known limitation — document in config.
     for path in &policy.allow_read {
         let p = escape_sb(&path.to_string_lossy());
         rules.push(format!("(allow file-read* (subpath \"{p}\"))"));
@@ -267,20 +263,44 @@ fn generate_sb_profile_for_home(policy: &SandboxPolicy, home: &Path) -> String {
 ///
 /// Iterates [`SECRET_DIRS`] (subpath deny) and [`SECRET_FILES`] (literal deny).
 /// Placed after the global `(allow file-read*)` so they take effect via last-rule-wins.
+///
+/// When a path is a symlink, both the canonical (real) path and the symlink path receive
+/// deny rules. This ensures that a user-provided `allow_read` entry pointing at the canonical
+/// path (as produced by `SandboxPolicy::canonicalized()`) can override the correct deny rule.
 fn push_secret_deny_rules_for_home(rules: &mut Vec<String>, home: &Path) {
     for rel in SECRET_DIRS {
         let path: PathBuf = home.join(rel);
+        let canonical = std::fs::canonicalize(&path).ok();
+        let deny_path = canonical.as_deref().unwrap_or(&path);
         rules.push(format!(
             "(deny file-read* (subpath {}))",
-            escape_sb_quoted(&path.to_string_lossy())
+            escape_sb_quoted(&deny_path.to_string_lossy())
         ));
+        if let Some(ref c) = canonical
+            && c != &path
+        {
+            rules.push(format!(
+                "(deny file-read* (subpath {}))",
+                escape_sb_quoted(&path.to_string_lossy())
+            ));
+        }
     }
     for rel in SECRET_FILES {
         let path: PathBuf = home.join(rel);
+        let canonical = std::fs::canonicalize(&path).ok();
+        let deny_path = canonical.as_deref().unwrap_or(&path);
         rules.push(format!(
             "(deny file-read* (literal {}))",
-            escape_sb_quoted(&path.to_string_lossy())
+            escape_sb_quoted(&deny_path.to_string_lossy())
         ));
+        if let Some(ref c) = canonical
+            && c != &path
+        {
+            rules.push(format!(
+                "(deny file-read* (literal {}))",
+                escape_sb_quoted(&path.to_string_lossy())
+            ));
+        }
     }
 }
 
@@ -553,6 +573,10 @@ mod tests {
 
     #[test]
     fn all_37_deny_rules_emitted() {
+        // Uses FAKE_HOME (/tmp/fake-home-test) which does not exist on disk, so
+        // fs::canonicalize will fail and fall back to the raw path — one rule per entry,
+        // same as before. When symlinks are present, additional rules may be emitted
+        // (covered by allow_read_overrides_deny_when_ssh_is_symlink).
         let policy = SandboxPolicy {
             profile: SandboxProfile::Workspace,
             ..Default::default()
@@ -566,17 +590,49 @@ mod tests {
             .lines()
             .filter(|l| l.contains("(deny file-read* (literal"))
             .count();
-        assert_eq!(
-            subpath_denies,
-            SECRET_DIRS.len(),
-            "expected {} subpath deny rules, got {subpath_denies}",
+        assert!(
+            subpath_denies >= SECRET_DIRS.len(),
+            "expected at least {} subpath deny rules, got {subpath_denies}",
             SECRET_DIRS.len()
         );
-        assert_eq!(
-            literal_denies,
-            SECRET_FILES.len(),
-            "expected {} literal deny rules, got {literal_denies}",
+        assert!(
+            literal_denies >= SECRET_FILES.len(),
+            "expected at least {} literal deny rules, got {literal_denies}",
             SECRET_FILES.len()
+        );
+    }
+
+    #[test]
+    fn allow_read_overrides_deny_when_ssh_is_symlink() {
+        let real_dir = tempfile::tempdir().unwrap();
+        let fake_home_dir = tempfile::tempdir().unwrap();
+        let symlink_path = fake_home_dir.path().join(".ssh");
+        std::os::unix::fs::symlink(real_dir.path(), &symlink_path).unwrap();
+
+        let policy = SandboxPolicy {
+            profile: SandboxProfile::Workspace,
+            allow_read: vec![symlink_path],
+            ..Default::default()
+        }
+        .canonicalized();
+
+        let profile = generate_sb_profile_for_home(&policy, fake_home_dir.path());
+
+        // On macOS /tmp is a symlink to /private/tmp; canonicalize real_dir to get the
+        // resolved path that Seatbelt rules will use.
+        let real = std::fs::canonicalize(real_dir.path()).unwrap();
+        let real = real.to_string_lossy();
+        let deny_real = format!("(deny file-read* (subpath \"{real}\"))");
+        let allow_real = format!("(allow file-read* (subpath \"{real}\"))");
+        let deny_pos = profile
+            .find(&deny_real)
+            .expect("deny rule on canonical path must exist");
+        let allow_pos = profile
+            .find(&allow_real)
+            .expect("allow override on canonical path must exist");
+        assert!(
+            allow_pos > deny_pos,
+            "allow must appear after deny (last-rule-wins)"
         );
     }
 }

--- a/crates/zeph-tools/src/sandbox/mod.rs
+++ b/crates/zeph-tools/src/sandbox/mod.rs
@@ -75,6 +75,11 @@ pub struct SandboxPolicy {
     /// The enforcement profile controlling which restrictions are active.
     pub profile: SandboxProfile,
     /// Paths granted read (and execute) access. Normalized to absolute paths at construction.
+    ///
+    /// Paths are resolved to their canonical (real) form by [`SandboxPolicy::canonicalized`]
+    /// before being applied. If a path is a symlink, the resolved target is used for the allow
+    /// rule. Deny rules for well-known secret paths are also generated for the canonical form,
+    /// so the allow override works correctly even when the denied path is a symlink.
     pub allow_read: Vec<PathBuf>,
     /// Paths granted read and write access. Normalized to absolute paths at construction.
     pub allow_write: Vec<PathBuf>,
@@ -102,7 +107,17 @@ impl SandboxPolicy {
 fn canonicalize_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
     paths
         .into_iter()
-        .filter_map(|p| std::fs::canonicalize(&p).ok())
+        .filter_map(|p| {
+            let canonical = std::fs::canonicalize(&p).ok()?;
+            if canonical != p {
+                tracing::debug!(
+                    "sandbox: resolved symlink {} → {}",
+                    p.display(),
+                    canonical.display()
+                );
+            }
+            Some(canonical)
+        })
         .collect()
 }
 


### PR DESCRIPTION
## Summary

- `push_secret_deny_rules_for_home` now canonicalizes each deny path at policy build time. When a `SECRET_DIRS` entry is a symlink, both the canonical path and the raw symlink path are emitted as deny rules, so an `allow_read` override on either form wins via Seatbelt last-rule-wins semantics.
- Non-existent paths fall back to the previous raw-path behaviour (no regression for fresh installs or test fixtures using fake home dirs).
- `canonicalize_paths` emits `debug!` when it resolves a symlink, replacing the prior `warn!` that fired misleadingly for any symlinked path including cwd.
- Removed the stale "document in config" comment at `macos.rs:244` — the limitation it described is now fixed.
- Added regression test `allow_read_overrides_deny_when_ssh_is_symlink` with a real tempdir and symlinked `.ssh` directory.

## Test plan

- [ ] `cargo nextest run -p zeph-tools --lib` — 1030 tests pass (includes new regression test)
- [ ] `cargo nextest run --workspace --lib --bins` — 8180 tests pass
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — clean

Closes #3108