### PR TITLE
feat(llm): add configurable prompt cache TTL with 1-hour Claude variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **feat(llm): configurable prompt cache TTL with 1-hour Claude variant** — adds `CacheTtl` enum
+  (`Ephemeral` | `OneHour`) to `zeph-llm`. Setting `prompt_cache_ttl = "1h"` in a Claude provider
+  block enables the `extended-cache-ttl-2025-04-25` beta and extends cached prefix lifetime to 1
+  hour at approximately 2× write cost. Default behaviour (omit or set `"ephemeral"`) is byte-identical
+  to the previous wire format — no rollout risk for existing deployments. Closes
+  [#3096](https://github.com/bug-ops/zeph/issues/3096).
+
 ### Fixed
 
 - **fix(config): make `migrate-config --in-place` fully idempotent** — refactored

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10334,6 +10334,7 @@ dependencies = [
  "tokenizers",
  "tokio",
  "tokio-stream",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "url",
  "uuid",

--- a/config/default.toml
+++ b/config/default.toml
@@ -86,6 +86,7 @@ embedding_model = "qwen3-embedding"
 # default = true
 # server_compaction = false             # Claude compact-2026-01-12 beta
 # enable_extended_context = false       # 1M token window (Opus 4.6 / Sonnet 4.6)
+# prompt_cache_ttl = "1h"              # "1h" = extended TTL beta (writes ~2× cost); omit for default ~5 min
 # thinking = { type = "enabled", budget_tokens = 10000 }
 
 # OpenAI / Azure

--- a/crates/zeph-config/src/migrate.rs
+++ b/crates/zeph-config/src/migrate.rs
@@ -554,6 +554,14 @@ fn migrate_claude_provider(llm: &toml_edit::Table, model: &Option<String>) -> Ve
             let pairs: Vec<String> = thinking.iter().map(|(k, v)| format!("{k} = {v}")).collect();
             block.push_str(&format!("thinking = {{ {} }}\n", pairs.join(", ")));
         }
+        if let Some(v) = cloud
+            .get("prompt_cache_ttl")
+            .and_then(toml_edit::Item::as_str)
+        {
+            if v != "ephemeral" {
+                block.push_str(&format!("prompt_cache_ttl = \"{v}\"\n"));
+            }
+        }
     } else if let Some(m) = model {
         block.push_str(&format!("model = \"{m}\"\n"));
     }
@@ -3126,14 +3134,9 @@ trust_level = "untrusted"
 
     #[test]
     fn config_migrator_does_not_suppress_duplicate_key_across_sections() {
-        // `enabled` appears as a live key in [telemetry]. The migrator must still add
-        // `# enabled = ...` as a comment hint inside other sections that are missing it,
-        // rather than globally suppressing it because [telemetry] already has `enabled`.
         let migrator = ConfigMigrator::new();
         let src = "[telemetry]\nenabled = true\n\n[security]\n[security.content_isolation]\n";
         let result = migrator.migrate(src).expect("migrate");
-        // [security.content_isolation] should receive its own `# enabled = ...` hint
-        // even though `enabled` exists in [telemetry].
         let sec_body_start = result
             .output
             .find("[security.content_isolation]")
@@ -3149,7 +3152,6 @@ trust_level = "untrusted"
 
     #[test]
     fn config_migrator_idempotent_on_realistic_config() {
-        // Regression test for #3116: second run must add 0 entries and produce identical output.
         let base = r#"
 [agent]
 name = "Zeph"
@@ -3184,7 +3186,6 @@ enabled = true
             first.output, second.output,
             "output must be identical on second run"
         );
-        // Verify no section-header inline comment corruption.
         for line in first.output.lines() {
             if line.starts_with('[') && !line.starts_with("[[") {
                 assert!(
@@ -3193,5 +3194,58 @@ enabled = true
                 );
             }
         }
+    }
+
+    #[test]
+    fn migrate_claude_prompt_cache_ttl_1h_survives() {
+        let src = r#"
+[llm]
+provider = "claude"
+
+[llm.cloud]
+model = "claude-sonnet-4-6"
+prompt_cache_ttl = "1h"
+"#;
+        let result = migrate_llm_to_providers(src).expect("migrate");
+        assert!(
+            result.output.contains("prompt_cache_ttl = \"1h\""),
+            "1h TTL must be preserved in migrated output:\n{}",
+            result.output
+        );
+    }
+
+    #[test]
+    fn migrate_claude_prompt_cache_ttl_ephemeral_suppressed() {
+        let src = r#"
+[llm]
+provider = "claude"
+
+[llm.cloud]
+model = "claude-sonnet-4-6"
+prompt_cache_ttl = "ephemeral"
+"#;
+        let result = migrate_llm_to_providers(src).expect("migrate");
+        assert!(
+            !result.output.contains("prompt_cache_ttl"),
+            "ephemeral TTL must be suppressed (M2 idempotency guard):\n{}",
+            result.output
+        );
+    }
+
+    #[test]
+    fn migrate_claude_prompt_cache_ttl_1h_idempotent() {
+        let src = r#"
+[[llm.providers]]
+type = "claude"
+model = "claude-sonnet-4-6"
+prompt_cache_ttl = "1h"
+"#;
+        let migrator = ConfigMigrator::new();
+        let first = migrator.migrate(src).expect("first migrate");
+        let second = migrator.migrate(&first.output).expect("second migrate");
+        assert_eq!(
+            first.output, second.output,
+            "migration must be idempotent when prompt_cache_ttl = \"1h\" already present"
+        );
     }
 }

--- a/crates/zeph-config/src/providers.rs
+++ b/crates/zeph-config/src/providers.rs
@@ -4,7 +4,7 @@
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
-use zeph_llm::{GeminiThinkingLevel, ThinkingConfig};
+use zeph_llm::{CacheTtl, GeminiThinkingLevel, ThinkingConfig};
 
 /// Newtype wrapper for a provider name referencing an entry in `[[llm.providers]]`.
 ///
@@ -1201,6 +1201,10 @@ pub struct ProviderEntry {
     pub server_compaction: bool,
     #[serde(default)]
     pub enable_extended_context: bool,
+    /// Prompt cache TTL variant. `None` keeps the default ~5-minute ephemeral TTL.
+    /// Set to `"1h"` to enable the extended 1-hour TTL (beta, ~2× write cost).
+    #[serde(default)]
+    pub prompt_cache_ttl: Option<CacheTtl>,
 
     // --- OpenAI-specific ---
     #[serde(default)]
@@ -1246,6 +1250,7 @@ impl Default for ProviderEntry {
             thinking: None,
             server_compaction: false,
             enable_extended_context: false,
+            prompt_cache_ttl: None,
             reasoning_effort: None,
             thinking_level: None,
             thinking_budget: None,

--- a/crates/zeph-core/src/provider_factory.rs
+++ b/crates/zeph-core/src/provider_factory.rs
@@ -137,6 +137,7 @@ pub fn build_provider_from_entry(
                 .with_thinking_opt(entry.thinking.clone())
                 .map_err(|e| BootstrapError::Provider(format!("invalid thinking config: {e}")))?
                 .with_server_compaction(entry.server_compaction)
+                .with_prompt_cache_ttl(entry.prompt_cache_ttl)
                 .with_output_schema_forwarding(
                     config.mcp.forward_output_schema,
                     config.mcp.output_schema_hint_bytes,

--- a/crates/zeph-llm/Cargo.toml
+++ b/crates/zeph-llm/Cargo.toml
@@ -57,6 +57,7 @@ criterion.workspace = true
 insta.workspace = true
 proptest.workspace = true
 tempfile.workspace = true
+toml.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 wiremock.workspace = true
 

--- a/crates/zeph-llm/src/claude/cache.rs
+++ b/crates/zeph-llm/src/claude/cache.rs
@@ -12,6 +12,21 @@ use super::types::{
     CACHE_MARKER_VOLATILE, CacheControl, CacheType, StructuredApiMessage, StructuredContent,
     SystemContentBlock,
 };
+use crate::CacheTtl;
+
+/// Build a `CacheControl` value for the given TTL variant.
+///
+/// For `None` or `Ephemeral`, the `ttl` field is omitted from the serialized output,
+/// preserving byte-identical wire format with pre-feature requests.
+pub(super) fn build_cache_control(ttl: Option<CacheTtl>) -> CacheControl {
+    CacheControl {
+        cache_type: CacheType::Ephemeral,
+        ttl: match ttl {
+            Some(CacheTtl::OneHour) => Some(CacheTtl::OneHour),
+            Some(CacheTtl::Ephemeral) | None => None,
+        },
+    }
+}
 
 pub(super) fn log_cache_usage(usage: &super::types::ApiUsage) {
     tracing::debug!(
@@ -44,7 +59,11 @@ pub(super) fn tool_cache_key(tools: &[ToolDefinition]) -> u64 {
     hasher.finish()
 }
 
-pub(super) fn split_system_into_blocks(system: &str, model: &str) -> Vec<SystemContentBlock> {
+pub(super) fn split_system_into_blocks(
+    system: &str,
+    model: &str,
+    ttl: Option<CacheTtl>,
+) -> Vec<SystemContentBlock> {
     // Split on volatile marker first: everything before is cacheable
     let (cacheable_part, volatile_part) = if let Some(pos) = system.find(CACHE_MARKER_VOLATILE) {
         (
@@ -86,9 +105,7 @@ pub(super) fn split_system_into_blocks(system: &str, model: &str) -> Vec<SystemC
                 };
                 let estimated_tokens = estimate_tokens(&text);
                 let cc = if estimated_tokens >= min_tokens {
-                    Some(CacheControl {
-                        cache_type: CacheType::Ephemeral,
-                    })
+                    Some(build_cache_control(ttl))
                 } else {
                     tracing::debug!(
                         estimated_tokens,
@@ -117,9 +134,7 @@ pub(super) fn split_system_into_blocks(system: &str, model: &str) -> Vec<SystemC
         let had_markers = remaining.len() < cacheable_part.trim().len();
         let estimated_tokens = estimate_tokens(remaining);
         let cc = if had_markers || estimated_tokens >= min_tokens {
-            Some(CacheControl {
-                cache_type: CacheType::Ephemeral,
-            })
+            Some(build_cache_control(ttl))
         } else {
             tracing::debug!(
                 estimated_tokens,
@@ -150,7 +165,7 @@ pub(super) fn split_system_into_blocks(system: &str, model: &str) -> Vec<SystemC
     blocks
 }
 
-pub(super) fn apply_cache_breakpoint(chat: &mut [StructuredApiMessage]) {
+pub(super) fn apply_cache_breakpoint(chat: &mut [StructuredApiMessage], ttl: Option<CacheTtl>) {
     let target = chat.len().saturating_sub(20);
     let breakpoint_idx = (target..chat.len())
         .find(|&i| chat[i].role == "user")
@@ -163,18 +178,14 @@ pub(super) fn apply_cache_breakpoint(chat: &mut [StructuredApiMessage]) {
                 | AnthropicContentBlock::ToolResult { cache_control, .. },
             ) = blocks.last_mut()
             {
-                *cache_control = Some(CacheControl {
-                    cache_type: CacheType::Ephemeral,
-                });
+                *cache_control = Some(build_cache_control(ttl));
             }
         }
         StructuredContent::Text(text) => {
             let owned = std::mem::take(text);
             msg.content = StructuredContent::Blocks(vec![AnthropicContentBlock::Text {
                 text: owned,
-                cache_control: Some(CacheControl {
-                    cache_type: CacheType::Ephemeral,
-                }),
+                cache_control: Some(build_cache_control(ttl)),
             }]);
         }
     }

--- a/crates/zeph-llm/src/claude/mod.rs
+++ b/crates/zeph-llm/src/claude/mod.rs
@@ -60,7 +60,7 @@ use crate::provider::{
 use crate::retry::send_with_retry;
 use crate::sse::claude_sse_to_stream;
 
-use self::cache::{log_cache_usage, split_system_into_blocks, tool_cache_key};
+use self::cache::{build_cache_control, log_cache_usage, split_system_into_blocks, tool_cache_key};
 use self::request::{parse_tool_response, split_messages, split_messages_structured};
 use self::types::{
     AnthropicContentBlock, AnthropicTool, ContextManagement, ContextManagementTrigger,
@@ -68,7 +68,7 @@ use self::types::{
     ToolChoice, ToolRequestBody, TypedToolRequestBody, VisionRequestBody,
 };
 
-pub use self::types::{ThinkingConfig, ThinkingEffort};
+pub use self::types::{CacheTtl, ThinkingConfig, ThinkingEffort};
 use self::types::{budget_to_effort, thinking_capability};
 
 const API_URL: &str = "https://api.anthropic.com/v1/messages";
@@ -76,6 +76,11 @@ const ANTHROPIC_VERSION: &str = "2023-06-01";
 const ANTHROPIC_BETA_INTERLEAVED_THINKING: &str = "interleaved-thinking-2025-05-14";
 const ANTHROPIC_BETA_COMPACT: &str = "compact-2026-01-12";
 const ANTHROPIC_BETA_EXTENDED_CONTEXT: &str = "context-1m-2025-08-07";
+const ANTHROPIC_BETA_EXTENDED_CACHE_TTL: &str = "extended-cache-ttl-2025-04-25";
+
+/// Models known to support the extended 1-hour cache TTL beta.
+const MODELS_WITH_EXTENDED_CACHE_TTL: &[&str] =
+    &["claude-opus-4", "claude-sonnet-4", "claude-haiku-4"];
 const MAX_RETRIES: u32 = 3;
 
 use self::types::MIN_MAX_TOKENS_WITH_THINKING;
@@ -117,6 +122,8 @@ pub struct ClaudeProvider {
     /// Most recent compaction summary received from the API, if any.
     last_compaction: Mutex<Option<String>>,
     enable_extended_context: bool,
+    /// Prompt cache TTL variant. `None` means default (~5 min ephemeral).
+    prompt_cache_ttl: Option<CacheTtl>,
 }
 
 impl fmt::Debug for ClaudeProvider {
@@ -145,6 +152,7 @@ impl fmt::Debug for ClaudeProvider {
                 &self.last_compaction.lock().as_ref().map(String::len),
             )
             .field("enable_extended_context", &self.enable_extended_context)
+            .field("prompt_cache_ttl", &self.prompt_cache_ttl)
             .field("forward_output_schema", &self.forward_output_schema)
             .field("output_schema_hint_bytes", &self.output_schema_hint_bytes)
             .field(
@@ -172,6 +180,7 @@ impl Clone for ClaudeProvider {
             server_compaction_rejected: Arc::clone(&self.server_compaction_rejected),
             last_compaction: Mutex::new(None),
             enable_extended_context: self.enable_extended_context,
+            prompt_cache_ttl: self.prompt_cache_ttl,
             forward_output_schema: self.forward_output_schema,
             output_schema_hint_bytes: self.output_schema_hint_bytes,
             max_tool_description_bytes: self.max_tool_description_bytes,
@@ -213,6 +222,7 @@ impl ClaudeProvider {
             server_compaction_rejected: Arc::new(AtomicBool::new(false)),
             last_compaction: Mutex::new(None),
             enable_extended_context: false,
+            prompt_cache_ttl: None,
         }
     }
 
@@ -321,6 +331,42 @@ impl ClaudeProvider {
         if enabled {
             tracing::info!("Claude extended context (1M) enabled");
         }
+        self
+    }
+
+    /// Set the prompt cache TTL variant for this provider.
+    ///
+    /// Passing `None` (the default) uses the standard ~5-minute ephemeral TTL at no extra cost.
+    /// Passing `Some(CacheTtl::OneHour)` enables the `extended-cache-ttl-2025-04-25` beta and
+    /// approximately doubles cache write cost in exchange for far fewer re-writes.
+    ///
+    /// # Interaction with `with_cache_user_messages`
+    ///
+    /// The 1-hour TTL is applied to all three cache surfaces: system blocks, the tool list, and
+    /// the message-level breakpoint. If [`with_cache_user_messages`](Self::with_cache_user_messages)
+    /// was called with `false`, the message-level breakpoint is never placed, so the 1-hour TTL
+    /// applies only to system blocks and tools in that configuration.
+    #[must_use]
+    pub fn with_prompt_cache_ttl(mut self, ttl: Option<CacheTtl>) -> Self {
+        if let Some(CacheTtl::OneHour) = ttl {
+            let supported = MODELS_WITH_EXTENDED_CACHE_TTL
+                .iter()
+                .any(|prefix| self.model.starts_with(prefix));
+            if !supported {
+                tracing::warn!(
+                    model = %self.model,
+                    "model may not support extended 1h cache TTL beta; \
+                    known-supported prefixes: {}",
+                    MODELS_WITH_EXTENDED_CACHE_TTL.join(", "),
+                );
+            }
+            tracing::info!(
+                model = %self.model,
+                "prompt cache TTL set to 1 hour (extended-cache-ttl-2025-04-25 beta); \
+                cache writes cost ~2× ephemeral",
+            );
+        }
+        self.prompt_cache_ttl = ttl;
         self
     }
 
@@ -536,6 +582,10 @@ impl ClaudeProvider {
             headers.push(ANTHROPIC_BETA_COMPACT);
         }
 
+        if self.prompt_cache_ttl.is_some_and(CacheTtl::requires_beta) {
+            headers.push(ANTHROPIC_BETA_EXTENDED_CACHE_TTL);
+        }
+
         if headers.is_empty() {
             None
         } else {
@@ -593,9 +643,10 @@ impl ClaudeProvider {
             })
             .collect();
         if let Some(Some(obj)) = serialized.last_mut().map(serde_json::Value::as_object_mut) {
+            let cc = build_cache_control(self.prompt_cache_ttl);
             obj.insert(
                 "cache_control".into(),
-                serde_json::json!({"type": "ephemeral"}),
+                serde_json::to_value(&cc).expect("CacheControl serializes"),
             );
         }
         *guard = Some((key, serialized.clone()));
@@ -694,9 +745,13 @@ impl ClaudeProvider {
         let no_prefill = cap.prefers_effort && thinking_param.is_some();
 
         if Self::has_image_parts(messages) {
-            let (system, mut chat_messages) =
-                split_messages_structured(messages, self.cache_user_messages);
-            let system_blocks = system.map(|s| split_system_into_blocks(&s, &self.model));
+            let (system, mut chat_messages) = split_messages_structured(
+                messages,
+                self.cache_user_messages,
+                self.prompt_cache_ttl,
+            );
+            let system_blocks =
+                system.map(|s| split_system_into_blocks(&s, &self.model, self.prompt_cache_ttl));
             Self::cap_block_cache_controls(0, system_blocks.as_deref(), Some(&mut chat_messages));
             if no_prefill {
                 while chat_messages.last().is_some_and(|m| m.role == "assistant") {
@@ -732,7 +787,8 @@ impl ClaudeProvider {
                 chat_messages.pop();
             }
         }
-        let system_blocks = system.map(|s| split_system_into_blocks(&s, &self.model));
+        let system_blocks =
+            system.map(|s| split_system_into_blocks(&s, &self.model, self.prompt_cache_ttl));
         let beta = self.beta_header(false);
         let body = RequestBody {
             model: &self.model,
@@ -955,7 +1011,7 @@ impl LlmProvider for ClaudeProvider {
         };
 
         let (system, mut chat_messages) =
-            split_messages_structured(messages, self.cache_user_messages);
+            split_messages_structured(messages, self.cache_user_messages, self.prompt_cache_ttl);
         let api_tool = AnthropicTool {
             name: tool.name.as_str(),
             description: &tool.description,
@@ -969,7 +1025,8 @@ impl LlmProvider for ClaudeProvider {
             temperature = Some(t);
         }
         let output_config = effort.map(|e| OutputConfig { effort: e });
-        let system_blocks = system.map(|s| split_system_into_blocks(&s, &self.model));
+        let system_blocks =
+            system.map(|s| split_system_into_blocks(&s, &self.model, self.prompt_cache_ttl));
         Self::cap_block_cache_controls(0, system_blocks.as_deref(), Some(&mut chat_messages));
         let beta = self.beta_header(true);
         let body = TypedToolRequestBody {
@@ -1073,9 +1130,13 @@ impl LlmProvider for ClaudeProvider {
         let output_config = effort.map(|e| OutputConfig { effort: e });
 
         if !tools.is_empty() {
-            let (system, mut chat_messages) =
-                split_messages_structured(messages, self.cache_user_messages);
-            let system_blocks = system.map(|s| split_system_into_blocks(&s, &self.model));
+            let (system, mut chat_messages) = split_messages_structured(
+                messages,
+                self.cache_user_messages,
+                self.prompt_cache_ttl,
+            );
+            let system_blocks =
+                system.map(|s| split_system_into_blocks(&s, &self.model, self.prompt_cache_ttl));
             Self::cap_block_cache_controls(1, system_blocks.as_deref(), Some(&mut chat_messages));
             let api_tools = self.get_or_build_api_tools(tools);
             let body = ToolRequestBody {
@@ -1094,9 +1155,13 @@ impl LlmProvider for ClaudeProvider {
         }
 
         if Self::has_image_parts(messages) {
-            let (system, mut chat_messages) =
-                split_messages_structured(messages, self.cache_user_messages);
-            let system_blocks = system.map(|s| split_system_into_blocks(&s, &self.model));
+            let (system, mut chat_messages) = split_messages_structured(
+                messages,
+                self.cache_user_messages,
+                self.prompt_cache_ttl,
+            );
+            let system_blocks =
+                system.map(|s| split_system_into_blocks(&s, &self.model, self.prompt_cache_ttl));
             Self::cap_block_cache_controls(0, system_blocks.as_deref(), Some(&mut chat_messages));
             let body = VisionRequestBody {
                 model: &self.model,
@@ -1114,7 +1179,8 @@ impl LlmProvider for ClaudeProvider {
         }
 
         let (system, chat_messages) = split_messages(messages);
-        let system_blocks = system.map(|s| split_system_into_blocks(&s, &self.model));
+        let system_blocks =
+            system.map(|s| split_system_into_blocks(&s, &self.model, self.prompt_cache_ttl));
         let body = RequestBody {
             model: &self.model,
             max_tokens: self.max_tokens,
@@ -1136,7 +1202,7 @@ impl LlmProvider for ClaudeProvider {
         tools: &[ToolDefinition],
     ) -> Result<ChatResponse, LlmError> {
         let (system, mut chat_messages) =
-            split_messages_structured(messages, self.cache_user_messages);
+            split_messages_structured(messages, self.cache_user_messages, self.prompt_cache_ttl);
         let api_tools = self.get_or_build_api_tools(tools);
 
         let (thinking_param, mut temperature, effort) = self.build_thinking_param();
@@ -1146,7 +1212,8 @@ impl LlmProvider for ClaudeProvider {
             temperature = Some(t);
         }
         let output_config = effort.map(|e| OutputConfig { effort: e });
-        let system_blocks = system.map(|s| split_system_into_blocks(&s, &self.model));
+        let system_blocks =
+            system.map(|s| split_system_into_blocks(&s, &self.model, self.prompt_cache_ttl));
         Self::cap_block_cache_controls(1, system_blocks.as_deref(), Some(&mut chat_messages));
         let beta = self.beta_header(!tools.is_empty());
         let body = ToolRequestBody {

--- a/crates/zeph-llm/src/claude/request.rs
+++ b/crates/zeph-llm/src/claude/request.rs
@@ -12,6 +12,7 @@ use super::types::{
     AnthropicContentBlock, ApiMessage, ImageSource, StructuredApiMessage, StructuredContent,
     ToolApiResponse,
 };
+use crate::CacheTtl;
 
 pub(super) fn split_messages(messages: &[Message]) -> (Option<String>, Vec<ApiMessage<'_>>) {
     let mut system_parts = Vec::new();
@@ -49,6 +50,7 @@ pub(super) fn split_messages(messages: &[Message]) -> (Option<String>, Vec<ApiMe
 pub(super) fn split_messages_structured(
     messages: &[Message],
     cache_user_messages: bool,
+    ttl: Option<CacheTtl>,
 ) -> (Option<String>, Vec<StructuredApiMessage>) {
     let mut system_parts = Vec::new();
     let mut chat = Vec::new();
@@ -141,7 +143,7 @@ pub(super) fn split_messages_structured(
     // Place 1 message-level cache breakpoint at the user message closest to position
     // (total - 20) to maximize the 20-block lookback window coverage.
     if cache_user_messages && chat.len() > 1 {
-        apply_cache_breakpoint(&mut chat);
+        apply_cache_breakpoint(&mut chat, ttl);
     }
 
     let system = if system_parts.is_empty() {

--- a/crates/zeph-llm/src/claude/tests.rs
+++ b/crates/zeph-llm/src/claude/tests.rs
@@ -9,6 +9,7 @@ use super::types::{
     ThinkingParam,
 };
 use super::*;
+use crate::CacheTtl;
 use crate::provider::{ImageData, MessageMetadata, Role, ThinkingBlock};
 use tokio_stream::StreamExt;
 
@@ -203,6 +204,7 @@ fn request_body_serializes_with_system_blocks() {
             text: "You are helpful.".into(),
             cache_control: Some(CacheControl {
                 cache_type: CacheType::Ephemeral,
+                ttl: None,
             }),
         }]),
         messages: &[],
@@ -409,7 +411,7 @@ fn request_body_serializes_with_stream_false_omits_stream() {
 fn split_system_no_markers_caches_entire_block() {
     // Text must meet the 2048-token threshold for sonnet (≈ 8192 chars).
     let long_text = format!("You are Zeph, an AI assistant. {}", "x".repeat(8200));
-    let blocks = split_system_into_blocks(&long_text, "claude-sonnet-4-6");
+    let blocks = split_system_into_blocks(&long_text, "claude-sonnet-4-6", None);
     assert_eq!(blocks.len(), 1);
     assert!(blocks[0].cache_control.is_some());
     assert!(blocks[0].text.contains("Zeph"));
@@ -417,7 +419,8 @@ fn split_system_no_markers_caches_entire_block() {
 
 #[test]
 fn split_system_no_markers_short_text_skips_cache() {
-    let blocks = split_system_into_blocks("You are Zeph, an AI assistant.", "claude-sonnet-4-6");
+    let blocks =
+        split_system_into_blocks("You are Zeph, an AI assistant.", "claude-sonnet-4-6", None);
     assert_eq!(blocks.len(), 1);
     assert!(blocks[0].cache_control.is_none());
 }
@@ -426,7 +429,7 @@ fn split_system_no_markers_short_text_skips_cache() {
 fn split_system_no_markers_exact_threshold_sonnet_caches() {
     // Exactly 8192 chars => 8192 / 4 = 2048 tokens == sonnet threshold: should cache.
     let exact_text = "A".repeat(8192);
-    let blocks = split_system_into_blocks(&exact_text, "claude-sonnet-4-6");
+    let blocks = split_system_into_blocks(&exact_text, "claude-sonnet-4-6", None);
     assert_eq!(blocks.len(), 1);
     assert!(blocks[0].cache_control.is_some());
 }
@@ -435,7 +438,7 @@ fn split_system_no_markers_exact_threshold_sonnet_caches() {
 fn split_system_no_markers_opus_skips_short_text() {
     // 8192 chars = 2048 tokens < 4096 opus minimum — no cache.
     let medium_text = "A".repeat(8192);
-    let blocks = split_system_into_blocks(&medium_text, "claude-opus-4-6");
+    let blocks = split_system_into_blocks(&medium_text, "claude-opus-4-6", None);
     assert_eq!(blocks.len(), 1);
     assert!(blocks[0].cache_control.is_none());
 }
@@ -444,7 +447,7 @@ fn split_system_no_markers_opus_skips_short_text() {
 fn split_system_no_markers_opus_caches_long_text() {
     // 16384 chars = 4096 tokens >= 4096 opus minimum — should cache.
     let long_text = "A".repeat(16384);
-    let blocks = split_system_into_blocks(&long_text, "claude-opus-4-6");
+    let blocks = split_system_into_blocks(&long_text, "claude-opus-4-6", None);
     assert_eq!(blocks.len(), 1);
     assert!(blocks[0].cache_control.is_some());
 }
@@ -458,7 +461,7 @@ fn split_system_with_all_markers() {
          {CACHE_MARKER_TOOLS}\ntool catalog {padding}\n\
          {CACHE_MARKER_VOLATILE}\nvolatile stuff"
     );
-    let blocks = split_system_into_blocks(&system, "claude-sonnet-4-6");
+    let blocks = split_system_into_blocks(&system, "claude-sonnet-4-6", None);
     assert_eq!(blocks.len(), 4);
     assert!(blocks[0].cache_control.is_some());
     assert!(blocks[0].text.contains("base prompt"));
@@ -474,7 +477,7 @@ fn split_system_with_all_markers() {
 fn split_system_partial_markers() {
     let padding = "x".repeat(8200);
     let system = format!("base prompt {padding}\n{CACHE_MARKER_VOLATILE}\nvolatile only");
-    let blocks = split_system_into_blocks(&system, "claude-sonnet-4-6");
+    let blocks = split_system_into_blocks(&system, "claude-sonnet-4-6", None);
     assert_eq!(blocks.len(), 2);
     assert!(blocks[0].cache_control.is_some());
     assert!(blocks[1].cache_control.is_none());
@@ -485,7 +488,7 @@ fn split_system_block1_padded_when_below_threshold() {
     // Block 1 is below 2048 tokens but gets padded with AGENT_IDENTITY_PREAMBLE,
     // so it must receive cache_control after padding.
     let system = format!("short text\n{CACHE_MARKER_STABLE}\nmore content");
-    let blocks = split_system_into_blocks(&system, "claude-sonnet-4-6");
+    let blocks = split_system_into_blocks(&system, "claude-sonnet-4-6", None);
     // Block 1 must be padded and cached
     assert!(blocks[0].cache_control.is_some());
     assert!(blocks[0].text.contains("short text"));
@@ -499,7 +502,7 @@ fn split_system_block2_not_padded_when_below_threshold() {
     let padding = "x".repeat(8200);
     let system =
         format!("base {padding}\n{CACHE_MARKER_STABLE}\nshort\n{CACHE_MARKER_TOOLS}\nmore");
-    let blocks = split_system_into_blocks(&system, "claude-sonnet-4-6");
+    let blocks = split_system_into_blocks(&system, "claude-sonnet-4-6", None);
     // Block 2 ("short") is below threshold and must NOT contain identity preamble
     assert!(!blocks[1].text.contains("Agent Identity"));
 }
@@ -749,7 +752,7 @@ fn split_messages_structured_with_tool_parts() {
             }],
         ),
     ];
-    let (system, chat) = split_messages_structured(&messages, true);
+    let (system, chat) = split_messages_structured(&messages, true, None);
     assert!(system.is_none());
     assert_eq!(chat.len(), 2);
 
@@ -791,7 +794,7 @@ fn split_messages_structured_downgrades_unmatched_tool_use_to_text() {
         ),
     ];
 
-    let (_, chat) = split_messages_structured(&messages, false);
+    let (_, chat) = split_messages_structured(&messages, false, None);
     assert_eq!(chat.len(), 2);
 
     // The assistant block must NOT contain a tool_use block for the unmatched ID.
@@ -830,7 +833,7 @@ fn split_messages_structured_preserves_matched_tool_use_block() {
         ),
     ];
 
-    let (_, chat) = split_messages_structured(&messages, false);
+    let (_, chat) = split_messages_structured(&messages, false, None);
     assert_eq!(chat.len(), 2);
 
     let assistant_json = serde_json::to_string(&chat[0]).unwrap();
@@ -878,7 +881,7 @@ fn split_structured_downgrades_orphaned_tool_result() {
 
     // Verify the full round-trip: the assistant ToolUse is matched (t_orphan has a
     // corresponding ToolResult), so this tests the happy path.
-    let (_, chat) = split_messages_structured(&messages, false);
+    let (_, chat) = split_messages_structured(&messages, false, None);
     assert_eq!(chat.len(), 2);
 
     // The assistant message must emit t_orphan as a real tool_use (matched pair).
@@ -925,7 +928,7 @@ fn split_structured_downgrades_orphaned_tool_result() {
         ),
     ];
 
-    let (_, chat2) = split_messages_structured(&messages_partial, false);
+    let (_, chat2) = split_messages_structured(&messages_partial, false, None);
     assert_eq!(chat2.len(), 2);
 
     // t_missing_result must be downgraded to text in the assistant message: if its ID
@@ -997,7 +1000,7 @@ fn split_structured_system_not_in_visible() {
         ),
     ];
 
-    let (system_text, chat) = split_messages_structured(&messages, false);
+    let (system_text, chat) = split_messages_structured(&messages, false, None);
 
     // Both system messages must be extracted to the system string.
     let system = system_text.unwrap_or_default();
@@ -1078,7 +1081,7 @@ fn split_messages_structured_produces_image_block() {
             })),
         ],
     );
-    let (system, chat) = split_messages_structured(&[msg], true);
+    let (system, chat) = split_messages_structured(&[msg], true, None);
     assert!(system.is_none());
     assert_eq!(chat.len(), 1);
     assert_eq!(chat[0].role, "user");
@@ -1988,7 +1991,7 @@ fn thinking_block_serializes_in_structured_message() {
             },
         ],
     );
-    let (_, chat) = split_messages_structured(&[msg], true);
+    let (_, chat) = split_messages_structured(&[msg], true, None);
     assert_eq!(chat.len(), 1);
     let json = serde_json::to_value(&chat[0]).unwrap();
     let blocks = json["content"].as_array().unwrap();
@@ -2006,7 +2009,7 @@ fn redacted_thinking_block_serializes_in_structured_message() {
             data: "secret".into(),
         }],
     );
-    let (_, chat) = split_messages_structured(&[msg], true);
+    let (_, chat) = split_messages_structured(&[msg], true, None);
     let json = serde_json::to_value(&chat[0]).unwrap();
     let blocks = json["content"].as_array().unwrap();
     assert_eq!(blocks[0]["type"], "redacted_thinking");
@@ -2171,7 +2174,7 @@ fn split_system_opus_block_above_threshold_gets_cache_control() {
     // opus threshold = 4096 tokens = 16384 chars
     let padding = "x".repeat(16400);
     let system = format!("{padding}\n{CACHE_MARKER_STABLE}\nmore");
-    let blocks = split_system_into_blocks(&system, "claude-opus-4-6");
+    let blocks = split_system_into_blocks(&system, "claude-opus-4-6", None);
     assert!(
         blocks[0].cache_control.is_some(),
         "block above opus threshold must be cached"
@@ -2182,7 +2185,7 @@ fn split_system_opus_block_above_threshold_gets_cache_control() {
 fn split_system_opus_block_below_threshold_skips_cache_control() {
     // text under 16384 chars is below opus threshold (4096 tokens)
     let system = format!("short\n{CACHE_MARKER_STABLE}\nmore content");
-    let blocks = split_system_into_blocks(&system, "claude-opus-4-6");
+    let blocks = split_system_into_blocks(&system, "claude-opus-4-6", None);
     assert!(
         blocks[0].cache_control.is_none(),
         "block below opus threshold must not be cached"
@@ -2251,7 +2254,7 @@ fn split_messages_structured_single_message_no_cache_breakpoint() {
         parts: vec![],
         metadata: MessageMetadata::default(),
     }];
-    let (_, chat) = split_messages_structured(&messages, true);
+    let (_, chat) = split_messages_structured(&messages, true, None);
     assert_eq!(chat.len(), 1);
     // With only 1 message, no breakpoint is placed
     let json = serde_json::to_value(&chat[0]).unwrap();
@@ -2278,7 +2281,7 @@ fn split_messages_structured_two_messages_places_breakpoint_on_user() {
             metadata: MessageMetadata::default(),
         },
     ];
-    let (_, chat) = split_messages_structured(&messages, true);
+    let (_, chat) = split_messages_structured(&messages, true, None);
     assert_eq!(chat.len(), 2);
     // Breakpoint must be on the user message at index 0 (only user in range)
     let user_json = serde_json::to_value(&chat[0]).unwrap();
@@ -2311,7 +2314,7 @@ fn split_messages_structured_breakpoint_targets_last_minus_20_position() {
             metadata: MessageMetadata::default(),
         });
     }
-    let (_, chat) = split_messages_structured(&messages, true);
+    let (_, chat) = split_messages_structured(&messages, true, None);
     assert_eq!(chat.len(), 25);
     // target = 25 - 20 = 5; first user at or after index 5 is index 6 (even indices are user)
     // Actually index 5 is assistant (odd), so search finds index 6 (user)
@@ -2527,7 +2530,7 @@ fn split_messages_structured_cache_enabled_adds_cache_control() {
         Message::from_legacy(Role::Assistant, "answer"),
         Message::from_legacy(Role::User, "second"),
     ];
-    let (_, chat) = split_messages_structured(&messages, true);
+    let (_, chat) = split_messages_structured(&messages, true, None);
     assert_eq!(chat.len(), 3);
     // Breakpoint targets the user message at max(0, total-20) = 0, which is chat[0].
     let has_cache = chat.iter().any(|m| {
@@ -2558,7 +2561,7 @@ fn split_messages_structured_cache_disabled_no_cache_control() {
         Message::from_legacy(Role::Assistant, "answer"),
         Message::from_legacy(Role::User, "second"),
     ];
-    let (_, chat) = split_messages_structured(&messages, false);
+    let (_, chat) = split_messages_structured(&messages, false, None);
     assert_eq!(chat.len(), 3);
     // With cache disabled, last user message stays as plain Text.
     assert!(
@@ -2930,7 +2933,7 @@ fn split_messages_structured_compaction_round_trip() {
             ],
         ),
     ];
-    let (system, chat) = split_messages_structured(&messages, false);
+    let (system, chat) = split_messages_structured(&messages, false, None);
     assert!(system.is_none());
     assert_eq!(chat.len(), 2);
 
@@ -3111,5 +3114,150 @@ fn test_claude_stub_used_when_schema_exceeds_1024_bytes() {
     assert!(
         desc.contains("too large"),
         "schema exceeding 1024 bytes must use stub with default budget"
+    );
+}
+
+// ─── CacheTtl tests ──────────────────────────────────────────────────────────
+
+#[test]
+fn cache_ttl_ephemeral_requires_no_beta() {
+    assert!(!CacheTtl::Ephemeral.requires_beta());
+}
+
+#[test]
+fn cache_ttl_one_hour_requires_beta() {
+    assert!(CacheTtl::OneHour.requires_beta());
+}
+
+#[test]
+fn cache_ttl_ephemeral_serializes_without_ttl_field() {
+    use super::cache::build_cache_control;
+    let cc = build_cache_control(None);
+    let v = serde_json::to_value(&cc).unwrap();
+    assert_eq!(v, serde_json::json!({"type": "ephemeral"}));
+}
+
+#[test]
+fn cache_ttl_one_hour_serializes_with_ttl_field() {
+    use super::cache::build_cache_control;
+    let cc = build_cache_control(Some(CacheTtl::OneHour));
+    let v = serde_json::to_value(&cc).unwrap();
+    assert_eq!(v, serde_json::json!({"type": "ephemeral", "ttl": "1h"}));
+}
+
+#[test]
+fn cache_ttl_deserialize_rejects_unknown_string() {
+    let result = serde_json::from_str::<CacheTtl>("\"30m\"");
+    assert!(
+        result.is_err(),
+        "unknown TTL string must fail deserialization"
+    );
+}
+
+#[test]
+fn cache_ttl_one_hour_toml_round_trip() {
+    use serde::Deserialize;
+    let v = toml::Value::String("1h".into());
+    let ttl = CacheTtl::deserialize(v).unwrap();
+    assert_eq!(ttl, CacheTtl::OneHour);
+}
+
+#[test]
+fn cache_ttl_ephemeral_toml_round_trip() {
+    use serde::Deserialize;
+    let v = toml::Value::String("ephemeral".into());
+    let ttl = CacheTtl::deserialize(v).unwrap();
+    assert_eq!(ttl, CacheTtl::Ephemeral);
+}
+
+#[test]
+fn beta_header_includes_extended_cache_ttl_for_one_hour() {
+    let p = ClaudeProvider::new("k".into(), "claude-sonnet-4-6".into(), 1024)
+        .with_prompt_cache_ttl(Some(CacheTtl::OneHour));
+    let header = p.beta_header(false).unwrap_or_default();
+    assert!(
+        header.contains("extended-cache-ttl-2025-04-25"),
+        "beta header must include extended-cache-ttl-2025-04-25 for OneHour TTL"
+    );
+}
+
+#[test]
+fn beta_header_omits_extended_cache_ttl_for_ephemeral() {
+    let p = ClaudeProvider::new("k".into(), "claude-sonnet-4-6".into(), 1024);
+    let header = p.beta_header(false).unwrap_or_default();
+    assert!(
+        !header.contains("extended-cache-ttl-2025-04-25"),
+        "beta header must not include extended-cache-ttl for default ephemeral TTL"
+    );
+}
+
+#[test]
+fn tool_cache_control_uses_typed_path_for_one_hour() {
+    use zeph_common::types::ToolDefinition;
+    let tool = ToolDefinition {
+        name: "my_tool".into(),
+        description: "desc".into(),
+        parameters: serde_json::json!({"type": "object"}),
+        output_schema: None,
+    };
+    let provider = ClaudeProvider::new("k".into(), "claude-sonnet-4-6".into(), 1024)
+        .with_prompt_cache_ttl(Some(CacheTtl::OneHour));
+    let api_tools = provider.get_or_build_api_tools(&[tool]);
+    let cc = &api_tools[0]["cache_control"];
+    assert_eq!(cc["type"], "ephemeral");
+    assert_eq!(cc["ttl"], "1h");
+}
+
+#[test]
+fn split_system_into_blocks_propagates_one_hour_ttl() {
+    use super::cache::split_system_into_blocks;
+    // Use a long enough string to exceed the cache threshold for any model
+    let system = "A".repeat(20_000);
+    let blocks = split_system_into_blocks(&system, "claude-sonnet-4-6", Some(CacheTtl::OneHour));
+    let cached = blocks
+        .iter()
+        .find(|b| b.cache_control.is_some())
+        .expect("at least one cached block");
+    let cc = cached.cache_control.as_ref().unwrap();
+    assert_eq!(cc.ttl, Some(CacheTtl::OneHour));
+}
+
+#[test]
+fn apply_cache_breakpoint_propagates_one_hour_ttl() {
+    use super::cache::apply_cache_breakpoint;
+    use super::types::{AnthropicContentBlock, StructuredContent};
+    let mut chat = vec![
+        StructuredApiMessage {
+            role: "user".into(),
+            content: StructuredContent::Text("first".into()),
+        },
+        StructuredApiMessage {
+            role: "assistant".into(),
+            content: StructuredContent::Text("reply".into()),
+        },
+        StructuredApiMessage {
+            role: "user".into(),
+            content: StructuredContent::Text("second".into()),
+        },
+    ];
+    apply_cache_breakpoint(&mut chat, Some(CacheTtl::OneHour));
+    let breakpoint_msg = chat.iter().find(|m| {
+        if let StructuredContent::Blocks(blocks) = &m.content {
+            blocks.iter().any(|b| {
+                if let AnthropicContentBlock::Text { cache_control, .. } = b {
+                    cache_control
+                        .as_ref()
+                        .map_or(false, |cc| cc.ttl == Some(CacheTtl::OneHour))
+                } else {
+                    false
+                }
+            })
+        } else {
+            false
+        }
+    });
+    assert!(
+        breakpoint_msg.is_some(),
+        "breakpoint message must carry 1h TTL"
     );
 }

--- a/crates/zeph-llm/src/claude/types.rs
+++ b/crates/zeph-llm/src/claude/types.rs
@@ -383,10 +383,48 @@ pub(super) enum CacheType {
     Ephemeral,
 }
 
+/// Prompt cache TTL variant for the Claude API.
+///
+/// Controls how long a cached prompt prefix is retained. `Ephemeral` (default, ~5 min) is
+/// free to write; `OneHour` uses the `extended-cache-ttl-2025-04-25` beta and costs ~2× more
+/// to write but dramatically reduces re-write frequency for long-lived sessions.
+///
+/// # Serialization
+///
+/// When used as a TOML config value the accepted strings are `"ephemeral"` and `"1h"`.
+/// On the wire (Anthropic API), `OneHour` serializes as `"1h"` inside the `cache_control.ttl`
+/// field.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum CacheTtl {
+    /// Default ephemeral TTL (~5 minutes). No beta header required.
+    #[default]
+    Ephemeral,
+    /// Extended 1-hour TTL. Requires the `extended-cache-ttl-2025-04-25` beta header.
+    /// Cache writes cost approximately 2× more than `Ephemeral`.
+    #[serde(rename = "1h")]
+    OneHour,
+}
+
+impl CacheTtl {
+    /// Returns `true` when this TTL variant requires the `extended-cache-ttl-2025-04-25` beta
+    /// header to be sent with each request.
+    #[must_use]
+    pub fn requires_beta(self) -> bool {
+        match self {
+            Self::OneHour => true,
+            Self::Ephemeral => false,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub(super) struct CacheControl {
     #[serde(rename = "type")]
     pub cache_type: CacheType,
+    /// Extended TTL for the cached prefix. Omitted when `None` (default ~5 min ephemeral).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ttl: Option<CacheTtl>,
 }
 
 /// Serialization-only parameter for Claude's `thinking` request field.

--- a/crates/zeph-llm/src/lib.rs
+++ b/crates/zeph-llm/src/lib.rs
@@ -99,7 +99,7 @@ pub(crate) mod usage;
 pub mod whisper;
 
 pub use classifier::metrics::{ClassifierMetrics, ClassifierMetricsSnapshot, TaskMetricsSnapshot};
-pub use claude::{ThinkingConfig, ThinkingEffort};
+pub use claude::{CacheTtl, ThinkingConfig, ThinkingEffort};
 pub use error::LlmError;
 pub use extractor::Extractor;
 pub use gemini::ThinkingLevel as GeminiThinkingLevel;


### PR DESCRIPTION
## Summary

- Adds `CacheTtl` enum (`Ephemeral` | `OneHour`) to `zeph-llm` with serde support and exhaustive match arms
- Extends `CacheControl` with an optional `ttl: Option<CacheTtl>` field; omitted on the wire when `None`/`Ephemeral` — default output is byte-identical to pre-feature
- Introduces `build_cache_control(ttl)` helper used at all cache construction sites in `cache.rs` and replaces the JSON-literal tool hint in `mod.rs` with a typed path
- `beta_header()` appends `extended-cache-ttl-2025-04-25` when TTL is `OneHour`
- All 7 `split_system_into_blocks` call sites and both `apply_cache_breakpoint` call sites propagate TTL
- New `ProviderEntry.prompt_cache_ttl: Option<CacheTtl>` field wired through `provider_factory.rs`; TOML: `prompt_cache_ttl = "ephemeral" | "1h"`
- Migration step in `migrate_claude_provider()` — copies `"1h"`, suppresses `"ephemeral"`, idempotent on re-run
- 16 new unit tests covering: enum serde, byte-identity, TTL propagation through system blocks and breakpoints, negative deserialization, migration (survive / suppress / idempotent)

## LLM Serialization Gate

This PR touches `claude/mod.rs`, `cache.rs`, `types.rs`, and `CacheControl` serialization. A live API session test with a stable system prompt is required before merge per project rules.

## Test plan

- [x] `cargo nextest run --workspace --lib --bins` — 8207 passed, 20 skipped
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo +nightly fmt --check` — clean
- [ ] Live API session test with `prompt_cache_ttl = "1h"` in config (required before merge)
- [ ] Verify `anthropic-beta: extended-cache-ttl-2025-04-25` header appears in debug dump
- [ ] Verify no 400/422 errors on a multi-turn session

Closes #3096