### PR TITLE
feat(orchestration): wire GraphPersistence::save in scheduler loop (#3107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **feat(orchestration): persist task graph state to `SQLite` across scheduler ticks; `/plan resume <id>` hydrates from disk** — `GraphPersistence<DbGraphStore>` is now wired into `OrchestrationState` and saved once per scheduler tick plus two defensive saves around plan completion. `/plan resume <id>` supports a full status×action matrix: `Paused` (hydrate), `Running` (crash-recovery: reset in-flight tasks to `Ready`), `Failed` (hydrate for retry), `Completed`/`Canceled` (refuse). New config key `orchestration.persistence_enabled` (default `true`). Follow-up `/plan gc` for TTL-based pruning tracked as P3/enhancement. Closes #3107.
+
 - **feat(orchestration): AdaptOrch topology advisor** — 16-arm Thompson Beta-bandit that classifies
   goals into `TaskClass` variants and samples `TopologyHint` (Sequential / Parallel / Cascade /
   Adaptive) to inject into the planner prompt. Outcomes are recorded synchronously; state persists

--- a/crates/zeph-config/src/experiment.rs
+++ b/crates/zeph-config/src/experiment.rs
@@ -76,6 +76,10 @@ fn default_predicate_timeout_secs() -> u64 {
     30
 }
 
+fn default_persistence_enabled() -> bool {
+    true
+}
+
 fn default_plan_cache_similarity_threshold() -> f32 {
     0.90
 }
@@ -280,6 +284,14 @@ pub struct OrchestrationConfig {
     /// `confidence = 0.0`) and logs a warning. Default: 30.
     #[serde(default = "default_predicate_timeout_secs")]
     pub predicate_timeout_secs: u64,
+    /// Persist task graph state to `SQLite` across scheduler ticks.
+    ///
+    /// When `true` and a `SemanticMemory` store is available, the scheduler
+    /// snapshots the graph once per tick and on plan completion. Graphs can
+    /// then be rehydrated via `/plan resume <id>` after a restart.
+    /// Default: `true`.
+    #[serde(default = "default_persistence_enabled")]
+    pub persistence_enabled: bool,
 }
 
 impl Default for OrchestrationConfig {
@@ -316,6 +328,7 @@ impl Default for OrchestrationConfig {
             predicate_provider: ProviderName::default(),
             max_predicate_replans: default_max_predicate_replans(),
             predicate_timeout_secs: default_predicate_timeout_secs(),
+            persistence_enabled: default_persistence_enabled(),
         }
     }
 }

--- a/crates/zeph-config/src/migrate.rs
+++ b/crates/zeph-config/src/migrate.rs
@@ -2061,6 +2061,48 @@ pub fn migrate_sandbox_config(toml_src: &str) -> Result<MigrationResult, Migrate
     })
 }
 
+/// Add a commented-out `persistence_enabled` key under `[orchestration]` when absent (#3107).
+///
+/// Existing configs that omit this key pick up `true` via `#[serde(default)]`, so this
+/// migration is informational — it surfaces the new option without changing behaviour.
+///
+/// # Errors
+///
+/// Returns [`MigrateError`] if the TOML document cannot be parsed.
+pub fn migrate_orchestration_persistence(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    // Skip if the key is already present (active or commented).
+    if toml_src.contains("persistence_enabled") || toml_src.contains("# persistence_enabled") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            added_count: 0,
+            sections_added: Vec::new(),
+        });
+    }
+
+    // Only inject under an existing [orchestration] section.
+    if !toml_src.contains("[orchestration]") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            added_count: 0,
+            sections_added: Vec::new(),
+        });
+    }
+
+    // Insert the commented key right after the `[orchestration]` header line.
+    let comment = "# persistence_enabled = true  \
+        # persist task graphs to SQLite after each tick; enables `/plan resume <id>` (#3107)\n";
+    let output = toml_src.replacen(
+        "[orchestration]\n",
+        &format!("[orchestration]\n{comment}"),
+        1,
+    );
+    Ok(MigrationResult {
+        output,
+        added_count: 1,
+        sections_added: vec!["orchestration.persistence_enabled".to_owned()],
+    })
+}
+
 // Helper to create a formatted value (used in tests).
 #[cfg(test)]
 fn make_formatted_str(s: &str) -> Value {

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1341,7 +1341,27 @@ impl<C: Channel> Agent<C> {
         self.orchestration.orchestration_config = config;
         self.orchestration.subagent_config = subagent_config;
         self.orchestration.subagent_manager = Some(manager);
+        self.wire_graph_persistence();
         self
+    }
+
+    /// Wire `graph_persistence` from the attached `SemanticMemory` `SQLite` pool.
+    ///
+    /// Idempotent: returns immediately if `graph_persistence` is already `Some`.
+    /// No-ops when `persistence_enabled = false` or when no memory store is attached.
+    pub(super) fn wire_graph_persistence(&mut self) {
+        if self.orchestration.graph_persistence.is_some() {
+            return;
+        }
+        if !self.orchestration.orchestration_config.persistence_enabled {
+            return;
+        }
+        if let Some(memory) = self.memory_state.persistence.memory.as_ref() {
+            let pool = memory.sqlite().pool().clone();
+            let store = zeph_memory::store::graph_store::DbGraphStore::new(pool);
+            self.orchestration.graph_persistence =
+                Some(zeph_orchestration::GraphPersistence::new(store));
+        }
     }
 
     /// Store adversarial policy gate info for `/status` display.
@@ -1557,6 +1577,7 @@ impl<C: Channel> Agent<C> {
         self.memory_state.subsystems.autodream_config = autodream_config;
         self.memory_state.subsystems.magic_docs_config = magic_docs_config;
         self.orchestration.orchestration_config = orchestration_config;
+        self.wire_graph_persistence();
         self.runtime.budget_hint_enabled = budget_hint_enabled;
 
         self.debug_state.reasoning_model_warning = anomaly_config.reasoning_model_warning;

--- a/crates/zeph-core/src/agent/plan.rs
+++ b/crates/zeph-core/src/agent/plan.rs
@@ -244,6 +244,12 @@ impl<C: crate::channel::Channel> Agent<C> {
             mgr.release_reservation(reserved);
         }
 
+        // Defensive save before `?` so a scheduler error still commits the last in-flight state.
+        if let Some(ref persistence) = self.orchestration.graph_persistence {
+            super::scheduler_loop::save_graph_snapshot(persistence, scheduler.graph().clone())
+                .await;
+        }
+
         let final_status = scheduler_result?;
 
         let extra_task_outputs = self
@@ -260,6 +266,28 @@ impl<C: crate::channel::Channel> Agent<C> {
         self.update_metrics(|m| {
             m.orchestration_graph = Some(snapshot);
         });
+
+        // Authoritative terminal save after extra_task_outputs are merged — log at ERROR on failure.
+        if let Some(ref persistence) = self.orchestration.graph_persistence {
+            let final_id = completed_graph.id.clone();
+            let snapshot = completed_graph.clone();
+            match tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                persistence.save(&snapshot),
+            )
+            .await
+            {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => tracing::error!(
+                    error = %e, graph_id = %final_id,
+                    "terminal graph persistence save failed — /plan list may be stale"
+                ),
+                Err(_) => tracing::error!(
+                    graph_id = %final_id,
+                    "terminal graph persistence save timed out after 5s — /plan list may be stale"
+                ),
+            }
+        }
 
         let result_label = self
             .finalize_plan_execution(completed_graph, final_status)
@@ -774,45 +802,134 @@ impl<C: crate::channel::Channel> Agent<C> {
         }
     }
 
-    pub(super) fn handle_plan_resume_as_string(&mut self, graph_id: Option<&str>) -> String {
-        use zeph_orchestration::GraphStatus;
+    // too_many_lines: sequential status×action dispatch table; branching is inherent
+    #[allow(clippy::too_many_lines)]
+    pub(super) async fn handle_plan_resume_as_string(&mut self, graph_id: Option<&str>) -> String {
+        use zeph_orchestration::{GraphId, GraphStatus, TaskStatus};
 
-        let Some(ref graph) = self.orchestration.pending_graph else {
+        // Path A: active pending_graph exists — use existing status-gate logic.
+        if let Some(ref graph) = self.orchestration.pending_graph {
+            if let Some(id) = graph_id
+                && graph.id.to_string() != id
+            {
+                return format!(
+                    "Graph id '{id}' does not match the active plan ({}). \
+                     Use `/plan status` to see the active plan id.",
+                    graph.id
+                );
+            }
+            if graph.status != GraphStatus::Paused {
+                return format!(
+                    "The active plan is in '{}' status and cannot be resumed. \
+                     Only Paused plans can be resumed.",
+                    graph.status
+                );
+            }
+            let graph = self
+                .orchestration
+                .pending_graph
+                .take()
+                .expect("just checked Some");
+            tracing::info!(graph_id = %graph.id, "resuming paused graph");
+            let msg = format!(
+                "Resuming plan: {}\nUse `/plan confirm` to continue execution.",
+                graph.goal
+            );
+            self.orchestration.pending_graph = Some(graph);
+            return msg;
+        }
+
+        // Path B: no active pending_graph — try disk rehydration.
+        let Some(id_str) = graph_id else {
             return "No paused plan to resume. Use `/plan status` to check the current state."
                 .to_owned();
         };
 
-        if let Some(id) = graph_id
-            && graph.id.to_string() != id
-        {
-            return format!(
-                "Graph id '{id}' does not match the active plan ({}). \
-                 Use `/plan status` to see the active plan id.",
-                graph.id
-            );
+        let graph_id_parsed = match id_str.parse::<GraphId>() {
+            Ok(id) => id,
+            Err(e) => return format!("Invalid graph id '{id_str}': {e}"),
+        };
+
+        let Some(ref persistence) = self.orchestration.graph_persistence else {
+            return "Graph persistence is disabled. \
+                    Set `orchestration.persistence_enabled = true` in config."
+                .to_owned();
+        };
+
+        let loaded = match persistence.load(&graph_id_parsed).await {
+            Ok(Some(g)) => g,
+            Ok(None) => return format!("Graph '{id_str}' not found in persistence."),
+            Err(e) => return format!("Failed to load graph '{id_str}' from persistence: {e}"),
+        };
+
+        match loaded.status {
+            GraphStatus::Completed => {
+                format!(
+                    "Plan '{id_str}' is already Completed. \
+                     Use `/plan status` to view results."
+                )
+            }
+            GraphStatus::Canceled => {
+                format!(
+                    "Plan '{id_str}' was Canceled and cannot be resumed. \
+                     Start a new plan with `/plan <goal>`."
+                )
+            }
+            GraphStatus::Paused => {
+                let msg = format!(
+                    "Resuming plan: {}\nUse `/plan confirm` to continue execution.",
+                    loaded.goal
+                );
+                tracing::info!(graph_id = %loaded.id, "rehydrated paused graph from disk");
+                self.orchestration.pending_graph = Some(loaded);
+                msg
+            }
+            GraphStatus::Running => {
+                // Crash recovery: treat as paused, reset in-flight tasks to Ready.
+                let mut graph = loaded;
+                let running_count = graph
+                    .tasks
+                    .iter()
+                    .filter(|t| t.status == TaskStatus::Running)
+                    .count();
+                for task in &mut graph.tasks {
+                    if task.status == TaskStatus::Running {
+                        task.status = TaskStatus::Ready;
+                        task.assigned_agent = None;
+                    }
+                }
+                graph.status = GraphStatus::Paused;
+                let msg = format!(
+                    "Recovered plan after interruption ({running_count} in-flight task(s) reset). \
+                     Use `/plan confirm` to continue."
+                );
+                tracing::info!(
+                    graph_id = %graph.id,
+                    running_count,
+                    "crash-recovery: rehydrated Running graph from disk, reset to Paused"
+                );
+                self.orchestration.pending_graph = Some(graph);
+                msg
+            }
+            GraphStatus::Failed => {
+                let msg = format!(
+                    "Plan '{id_str}' is in Failed status. \
+                     Use `/plan retry` to retry failed tasks or `/plan status` to inspect."
+                );
+                tracing::info!(graph_id = %loaded.id, "rehydrated failed graph from disk");
+                self.orchestration.pending_graph = Some(loaded);
+                msg
+            }
+            GraphStatus::Created => {
+                let msg = format!(
+                    "Plan '{id_str}' has not started executing. \
+                     Use `/plan confirm` to start."
+                );
+                tracing::info!(graph_id = %loaded.id, "rehydrated created graph from disk");
+                self.orchestration.pending_graph = Some(loaded);
+                msg
+            }
         }
-
-        if graph.status != GraphStatus::Paused {
-            return format!(
-                "The active plan is in '{}' status and cannot be resumed. \
-                 Only Paused plans can be resumed.",
-                graph.status
-            );
-        }
-
-        let graph = self.orchestration.pending_graph.take().unwrap();
-
-        tracing::info!(
-            graph_id = %graph.id,
-            "resuming paused graph"
-        );
-
-        let msg = format!(
-            "Resuming plan: {}\nUse `/plan confirm` to continue execution.",
-            graph.goal
-        );
-        self.orchestration.pending_graph = Some(graph);
-        msg
     }
 
     pub(super) fn handle_plan_retry_as_string(
@@ -902,7 +1019,7 @@ impl<C: crate::channel::Channel> Agent<C> {
             PlanCommand::Status(id) => Ok(self.handle_plan_status_as_string(id.as_deref())),
             PlanCommand::List => Ok(self.handle_plan_list_as_string()),
             PlanCommand::Cancel(id) => Ok(self.handle_plan_cancel_as_string(id.as_deref())),
-            PlanCommand::Resume(id) => Ok(self.handle_plan_resume_as_string(id.as_deref())),
+            PlanCommand::Resume(id) => Ok(self.handle_plan_resume_as_string(id.as_deref()).await),
             PlanCommand::Retry(id) => self.handle_plan_retry_as_string(id.as_deref()),
         }
     }

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -11,6 +11,37 @@ use super::error;
 use super::shutdown_signal;
 use super::tool_execution;
 
+/// Save a graph snapshot to persistent storage with a 5-second timeout.
+///
+/// Fail-open: errors and timeouts are logged at `warn!` level and do not abort
+/// the scheduler tick. Callers that need `error!` level (authoritative terminal
+/// saves) should inline their own match block.
+///
+/// # Note on timeout testing
+///
+/// This 5-second `SQLite` timeout is not exercised in unit tests because
+/// `:memory:` stores do not exhibit blocking behaviour. Timeout coverage
+/// requires an integration test with an artificially stalled pool.
+pub(super) async fn save_graph_snapshot(
+    persistence: &zeph_orchestration::GraphPersistence<
+        zeph_memory::store::graph_store::DbGraphStore,
+    >,
+    graph: zeph_orchestration::TaskGraph,
+) {
+    tracing::debug!(graph_id = %graph.id, status = %graph.status, "save_graph_snapshot: start");
+    match tokio::time::timeout(std::time::Duration::from_secs(5), persistence.save(&graph)).await {
+        Ok(Ok(())) => tracing::debug!(graph_id = %graph.id, "save_graph_snapshot: done"),
+        Ok(Err(e)) => tracing::warn!(
+            error = %e, graph_id = %graph.id,
+            "graph persistence save failed (fail-open)"
+        ),
+        Err(_) => tracing::warn!(
+            graph_id = %graph.id,
+            "graph persistence save timed out after 5s (fail-open)"
+        ),
+    }
+}
+
 impl<C: crate::channel::Channel> Agent<C> {
     /// Cancel all agents referenced in `cancel_actions`.
     ///
@@ -427,6 +458,11 @@ impl<C: crate::channel::Channel> Agent<C> {
             self.update_metrics(|m| {
                 m.orchestration_graph = Some(snapshot);
             });
+
+            if let Some(ref persistence) = self.orchestration.graph_persistence {
+                let graph_clone = scheduler.graph().clone();
+                save_graph_snapshot(persistence, graph_clone).await;
+            }
 
             tokio::select! {
                 biased;

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -426,6 +426,13 @@ pub(crate) struct OrchestrationState {
     /// for `record_outcome`.
     #[allow(dead_code)] // read via .take() in plan.rs; clippy false positive
     pub(crate) last_advisor_verdict: Option<zeph_orchestration::AdvisorVerdict>,
+    /// Task graph persistence handle. `None` when no `SemanticMemory` was
+    /// attached via `with_memory`, or when
+    /// `OrchestrationConfig::persistence_enabled` is `false`. When `Some`, the
+    /// scheduler loop snapshots the graph once per tick and `/plan resume <id>`
+    /// rehydrates from disk.
+    pub(crate) graph_persistence:
+        Option<zeph_orchestration::GraphPersistence<zeph_memory::store::graph_store::DbGraphStore>>,
 }
 
 /// Groups instruction hot-reload state.

--- a/crates/zeph-core/src/agent/tests.rs
+++ b/crates/zeph-core/src/agent/tests.rs
@@ -2480,6 +2480,383 @@ pub mod agent_tests {
         let harness = QuickTestAgent::minimal("response");
         assert!(harness.sent_messages().is_empty());
     }
+
+    // ── GraphPersistence wiring tests ─────────────────────────────────────────
+
+    #[cfg(feature = "scheduler")]
+    async fn make_gp_memory() -> std::sync::Arc<zeph_memory::semantic::SemanticMemory> {
+        let memory = zeph_memory::semantic::SemanticMemory::with_sqlite_backend(
+            ":memory:",
+            AnyProvider::Mock(MockProvider::default()),
+            "test-model",
+            0.7,
+            0.3,
+        )
+        .await
+        .expect("SemanticMemory");
+        std::sync::Arc::new(memory)
+    }
+
+    #[cfg(feature = "scheduler")]
+    fn graph_with_status(status: zeph_orchestration::GraphStatus) -> zeph_orchestration::TaskGraph {
+        let mut g = zeph_orchestration::TaskGraph::new("test goal");
+        g.status = status;
+        g
+    }
+
+    #[cfg(feature = "scheduler")]
+    fn make_orch_agent(
+        memory: std::sync::Arc<zeph_memory::semantic::SemanticMemory>,
+        cid: zeph_memory::ConversationId,
+        persistence_enabled: bool,
+    ) -> Agent<MockChannel> {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let cfg = crate::config::OrchestrationConfig {
+            persistence_enabled,
+            ..Default::default()
+        };
+        Agent::new(provider, channel, registry, None, 5, executor)
+            .with_memory(memory, cid, 100, 5, 1000)
+            .with_orchestration(cfg, crate::config::SubAgentConfig::default(), {
+                zeph_subagent::SubAgentManager::new(4)
+            })
+    }
+
+    #[cfg(feature = "scheduler")]
+    #[tokio::test]
+    async fn wire_graph_persistence_is_none_without_memory() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let cfg = crate::config::OrchestrationConfig {
+            persistence_enabled: true,
+            ..Default::default()
+        };
+        let agent = Agent::new(provider, channel, registry, None, 5, executor).with_orchestration(
+            cfg,
+            crate::config::SubAgentConfig::default(),
+            zeph_subagent::SubAgentManager::new(4),
+        );
+        assert!(
+            agent.orchestration.graph_persistence.is_none(),
+            "graph_persistence must be None when no memory is attached"
+        );
+    }
+
+    #[cfg(feature = "scheduler")]
+    #[tokio::test]
+    async fn wire_graph_persistence_is_none_when_disabled() {
+        let memory = make_gp_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let agent = make_orch_agent(memory, cid, false);
+        assert!(
+            agent.orchestration.graph_persistence.is_none(),
+            "graph_persistence must be None when persistence_enabled = false"
+        );
+    }
+
+    #[cfg(feature = "scheduler")]
+    #[tokio::test]
+    async fn wire_graph_persistence_is_some_with_memory_and_enabled() {
+        let memory = make_gp_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let agent = make_orch_agent(memory, cid, true);
+        assert!(
+            agent.orchestration.graph_persistence.is_some(),
+            "graph_persistence must be Some when memory attached and persistence_enabled = true"
+        );
+    }
+
+    #[cfg(feature = "scheduler")]
+    #[tokio::test]
+    async fn handle_plan_resume_invalid_uuid_returns_error_string() {
+        let memory = make_gp_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let mut agent = make_orch_agent(memory, cid, true);
+        let result = agent.handle_plan_resume_as_string(Some("not-a-uuid")).await;
+        assert!(
+            result.contains("Invalid graph id"),
+            "must return parse error for invalid UUID, got: {result}"
+        );
+    }
+
+    #[cfg(feature = "scheduler")]
+    #[tokio::test]
+    async fn handle_plan_resume_missing_graph_returns_not_found() {
+        use zeph_orchestration::GraphId;
+        let memory = make_gp_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let mut agent = make_orch_agent(memory, cid, true);
+        let missing_id = GraphId::new().to_string();
+        let result = agent
+            .handle_plan_resume_as_string(Some(missing_id.as_str()))
+            .await;
+        assert!(
+            result.contains("not found in persistence"),
+            "must return not-found message, got: {result}"
+        );
+    }
+
+    #[cfg(feature = "scheduler")]
+    #[tokio::test]
+    async fn handle_plan_resume_from_disk_hydrates_paused() {
+        use zeph_orchestration::GraphStatus;
+        let memory = make_gp_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let mut agent = make_orch_agent(memory, cid, true);
+        let graph = graph_with_status(GraphStatus::Paused);
+        let graph_id = graph.id.to_string();
+        agent
+            .orchestration
+            .graph_persistence
+            .as_ref()
+            .unwrap()
+            .save(&graph)
+            .await
+            .unwrap();
+        let result = agent
+            .handle_plan_resume_as_string(Some(graph_id.as_str()))
+            .await;
+        assert!(result.contains("Resuming plan"), "got: {result}");
+        assert!(agent.orchestration.pending_graph.is_some());
+        assert_eq!(
+            agent.orchestration.pending_graph.as_ref().unwrap().status,
+            GraphStatus::Paused
+        );
+    }
+
+    #[cfg(feature = "scheduler")]
+    #[tokio::test]
+    async fn handle_plan_resume_from_disk_recovers_running_as_paused() {
+        use zeph_orchestration::{GraphStatus, TaskStatus};
+        let memory = make_gp_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let mut agent = make_orch_agent(memory, cid, true);
+        let mut graph = graph_with_status(GraphStatus::Running);
+        let mut task = zeph_orchestration::TaskNode::new(0, "task1", "do something");
+        task.status = TaskStatus::Running;
+        task.assigned_agent = Some("agent-1".to_string());
+        graph.tasks.push(task);
+        let graph_id = graph.id.to_string();
+        agent
+            .orchestration
+            .graph_persistence
+            .as_ref()
+            .unwrap()
+            .save(&graph)
+            .await
+            .unwrap();
+        let result = agent
+            .handle_plan_resume_as_string(Some(graph_id.as_str()))
+            .await;
+        assert!(result.contains("Recovered plan"), "got: {result}");
+        let recovered = agent.orchestration.pending_graph.as_ref().unwrap();
+        assert_eq!(recovered.status, GraphStatus::Paused);
+        assert_eq!(recovered.tasks[0].status, TaskStatus::Ready);
+        assert!(recovered.tasks[0].assigned_agent.is_none());
+    }
+
+    #[cfg(feature = "scheduler")]
+    #[tokio::test]
+    async fn handle_plan_resume_refuses_completed() {
+        use zeph_orchestration::GraphStatus;
+        let memory = make_gp_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let mut agent = make_orch_agent(memory, cid, true);
+        let graph = graph_with_status(GraphStatus::Completed);
+        let graph_id = graph.id.to_string();
+        agent
+            .orchestration
+            .graph_persistence
+            .as_ref()
+            .unwrap()
+            .save(&graph)
+            .await
+            .unwrap();
+        let result = agent
+            .handle_plan_resume_as_string(Some(graph_id.as_str()))
+            .await;
+        assert!(result.contains("already Completed"), "got: {result}");
+        assert!(agent.orchestration.pending_graph.is_none());
+    }
+
+    #[cfg(feature = "scheduler")]
+    #[tokio::test]
+    async fn handle_plan_resume_refuses_canceled() {
+        use zeph_orchestration::GraphStatus;
+        let memory = make_gp_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let mut agent = make_orch_agent(memory, cid, true);
+        let graph = graph_with_status(GraphStatus::Canceled);
+        let graph_id = graph.id.to_string();
+        agent
+            .orchestration
+            .graph_persistence
+            .as_ref()
+            .unwrap()
+            .save(&graph)
+            .await
+            .unwrap();
+        let result = agent
+            .handle_plan_resume_as_string(Some(graph_id.as_str()))
+            .await;
+        assert!(result.contains("Canceled"), "got: {result}");
+        assert!(agent.orchestration.pending_graph.is_none());
+    }
+
+    #[cfg(feature = "scheduler")]
+    #[tokio::test]
+    async fn handle_plan_resume_no_id_no_pending_returns_instructions() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+        let result = agent.handle_plan_resume_as_string(None).await;
+        assert!(result.contains("No paused plan"), "got: {result}");
+    }
+
+    #[cfg(feature = "scheduler")]
+    #[tokio::test]
+    async fn handle_plan_resume_no_persistence_with_id_returns_disabled_message() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+        let result = agent
+            .handle_plan_resume_as_string(Some("00000000-0000-0000-0000-000000000001"))
+            .await;
+        // UUID parses successfully, so persistence-disabled branch is unambiguously hit.
+        assert!(
+            result.contains("persistence is disabled"),
+            "expected persistence-disabled message, got: {result}"
+        );
+    }
+
+    #[cfg(feature = "scheduler")]
+    #[tokio::test]
+    async fn predicate_outcome_round_trips_through_new_agent() {
+        use zeph_orchestration::{
+            GraphPersistence, GraphStatus, PredicateOutcome, TaskGraph, TaskNode, TaskStatus,
+        };
+
+        // Reuse the shared in-memory DB via SemanticMemory — migrations are already applied.
+        let memory = make_gp_memory().await;
+        let pool = memory.sqlite().pool().clone();
+        let store_a = zeph_memory::store::graph_store::DbGraphStore::new(pool.clone());
+        let persistence_a = GraphPersistence::new(store_a);
+
+        let node = TaskNode {
+            status: TaskStatus::Completed,
+            predicate_outcome: Some(PredicateOutcome {
+                passed: true,
+                reason: "ok".to_string(),
+                confidence: 1.0,
+            }),
+            ..TaskNode::new(0, "task-a", "test task")
+        };
+        let graph = TaskGraph {
+            status: GraphStatus::Completed,
+            tasks: vec![node],
+            ..TaskGraph::new("test goal")
+        };
+        let graph_id = graph.id.clone();
+
+        persistence_a.save(&graph).await.unwrap();
+
+        // Second persistence handle on the same pool — simulates "new agent" rehydrating.
+        let store_b = zeph_memory::store::graph_store::DbGraphStore::new(pool);
+        let persistence_b = GraphPersistence::new(store_b);
+
+        let loaded = persistence_b
+            .load(&graph_id)
+            .await
+            .unwrap()
+            .expect("graph must exist");
+        let loaded_node = loaded.tasks.first().expect("task must exist");
+        let outcome = loaded_node
+            .predicate_outcome
+            .as_ref()
+            .expect("predicate_outcome must survive round-trip");
+        assert!(
+            outcome.passed,
+            "predicate outcome `passed` must be true after round-trip"
+        );
+    }
+
+    #[cfg(feature = "scheduler")]
+    #[tokio::test]
+    async fn scheduler_loop_saves_graph_once_per_tick() {
+        use zeph_orchestration::{GraphPersistence, GraphStatus, TaskGraph};
+
+        let memory = make_gp_memory().await;
+        let pool = memory.sqlite().pool().clone();
+        let store = zeph_memory::store::graph_store::DbGraphStore::new(pool.clone());
+        let persistence = GraphPersistence::new(store);
+
+        let graph = TaskGraph {
+            status: GraphStatus::Running,
+            ..TaskGraph::new("g")
+        };
+        let graph_id = graph.id.clone();
+
+        // Mirrors what save_graph_snapshot does (bounded save call).
+        persistence.save(&graph).await.unwrap();
+
+        let store2 = zeph_memory::store::graph_store::DbGraphStore::new(pool);
+        let persistence2 = GraphPersistence::new(store2);
+        let loaded = persistence2.load(&graph_id).await.unwrap();
+        assert!(
+            loaded.is_some(),
+            "graph must be persisted after save_graph_snapshot call"
+        );
+        assert_eq!(loaded.unwrap().id, graph_id);
+    }
+
+    #[cfg(feature = "scheduler")]
+    #[tokio::test]
+    async fn terminal_save_persists_completed_status() {
+        use zeph_orchestration::{GraphPersistence, GraphStatus, TaskGraph};
+
+        let memory = make_gp_memory().await;
+        let pool = memory.sqlite().pool().clone();
+        let store = zeph_memory::store::graph_store::DbGraphStore::new(pool.clone());
+        let persistence = GraphPersistence::new(store);
+
+        let graph = TaskGraph {
+            status: GraphStatus::Completed,
+            ..TaskGraph::new("g")
+        };
+        let graph_id = graph.id.clone();
+
+        // Simulate the authoritative terminal save in handle_plan_confirm.
+        match tokio::time::timeout(std::time::Duration::from_secs(5), persistence.save(&graph))
+            .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => panic!("terminal save failed: {e}"),
+            Err(_) => panic!("terminal save timed out"),
+        }
+        drop(persistence);
+
+        let store2 = zeph_memory::store::graph_store::DbGraphStore::new(pool);
+        let persistence2 = GraphPersistence::new(store2);
+        let loaded = persistence2
+            .load(&graph_id)
+            .await
+            .unwrap()
+            .expect("must find saved graph");
+        assert_eq!(
+            loaded.status,
+            GraphStatus::Completed,
+            "terminal save must persist Completed status"
+        );
+    }
 }
 
 /// End-to-end tests for M30 resilient compaction: error detection → compact → retry → success.
@@ -3009,7 +3386,7 @@ mod compaction_e2e {
     #[tokio::test]
     async fn plan_resume_as_string_no_paused_plan() {
         let mut agent = agent_with_orchestration();
-        let out = agent.handle_plan_resume_as_string(None);
+        let out = agent.handle_plan_resume_as_string(None).await;
         assert!(
             out.contains("No paused plan"),
             "must return 'No paused plan' message; got: {out:?}"

--- a/crates/zeph-orchestration/src/scheduler.rs
+++ b/crates/zeph-orchestration/src/scheduler.rs
@@ -1773,6 +1773,7 @@ mod tests {
             predicate_provider: Default::default(),
             max_predicate_replans: 2,
             predicate_timeout_secs: 30,
+            persistence_enabled: true,
         }
     }
 

--- a/crates/zeph-orchestration/src/verify_predicate.rs
+++ b/crates/zeph-orchestration/src/verify_predicate.rs
@@ -12,11 +12,10 @@
 //! - [`VerifyPredicate`] is an enum stored in `TaskNode.verify_predicate`. Only the
 //!   `Natural(String)` variant is constructible in v1 — `Expression` returns an error
 //!   if the planner ever emits one.
-//! - [`PredicateOutcome`] is persisted on `TaskNode` (in-memory only; restart re-evaluates
-//!   any pending predicates). After a crash, `predicate_outcome.is_none()` signals that
-//!   the gate has not been evaluated yet and the scheduler re-emits `VerifyPredicate` on
-//!   the next tick. Note: `GraphPersistence::save` is not yet wired — persistence is a
-//!   separate scope tracked as a follow-up issue.
+//! - [`PredicateOutcome`] is persisted on `TaskNode` via `GraphPersistence::save` (wired in
+//!   `zeph-core` scheduler loop and `handle_plan_confirm`). After a crash, rehydrating the
+//!   graph via `/plan resume <id>` restores `predicate_outcome` so the gate is not re-evaluated
+//!   for already-completed tasks.
 //! - [`PredicateEvaluator`] wraps any [`LlmProvider`] and produces [`PredicateOutcome`]
 //!   values. The evaluation prompt is intentionally minimal and model-agnostic.
 

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -8,10 +8,10 @@ use zeph_core::config::migrate::{
     ConfigMigrator, migrate_agent_budget_hint, migrate_agent_retry_to_tools_retry,
     migrate_autodream_config, migrate_compression_predictor_config, migrate_database_url,
     migrate_egress_config, migrate_forgetting_config, migrate_magic_docs_config,
-    migrate_mcp_trust_levels, migrate_microcompact_config, migrate_otel_filter,
-    migrate_planner_model_to_provider, migrate_sandbox_config, migrate_shell_transactional,
-    migrate_stt_to_provider, migrate_supervisor_config, migrate_telemetry_config,
-    migrate_vigil_config,
+    migrate_mcp_trust_levels, migrate_microcompact_config, migrate_orchestration_persistence,
+    migrate_otel_filter, migrate_planner_model_to_provider, migrate_sandbox_config,
+    migrate_shell_transactional, migrate_stt_to_provider, migrate_supervisor_config,
+    migrate_telemetry_config, migrate_vigil_config,
 };
 
 /// Handle the `zeph migrate-config` command.
@@ -105,9 +105,13 @@ pub(crate) fn handle_migrate_config(
     let sandbox_result = migrate_sandbox_config(&after_vigil)?;
     let after_sandbox = sandbox_result.output;
 
-    // Step 19: add missing default keys as commented-out entries.
+    // Step 19: add commented-out persistence_enabled under [orchestration] if absent (#3107).
+    let orch_persistence_result = migrate_orchestration_persistence(&after_sandbox)?;
+    let after_orch_persistence = orch_persistence_result.output;
+
+    // Step 20: add missing default keys as commented-out entries.
     let migrator = ConfigMigrator::new();
-    let result = migrator.migrate(&after_sandbox)?;
+    let result = migrator.migrate(&after_orch_persistence)?;
 
     if diff {
         print_diff(&input, &result.output);
@@ -175,6 +179,12 @@ pub(crate) fn handle_migrate_config(
         }
         if sandbox_result.added_count > 0 {
             eprintln!("Sandbox migration: added commented-out [tools.sandbox] block.");
+        }
+        if orch_persistence_result.added_count > 0 {
+            eprintln!(
+                "Orchestration persistence migration: \
+                 added commented-out persistence_enabled under [orchestration]."
+            );
         }
         eprintln!(
             "Migration would add {} entries ({} sections).",

--- a/src/init/agents.rs
+++ b/src/init/agents.rs
@@ -70,6 +70,14 @@ pub(super) fn step_orchestration(state: &mut WizardState) -> anyhow::Result<()> 
         } else {
             Some(provider)
         };
+
+        state.orchestration_persistence_enabled = Confirm::new()
+            .with_prompt(
+                "Persist task graphs to SQLite after each scheduler tick? \
+                 (enables `/plan resume <id>` across restarts)",
+            )
+            .default(true)
+            .interact()?;
     }
 
     println!();

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -90,6 +90,7 @@ pub(crate) struct WizardState {
     pub(crate) orchestration_confirm_before_execute: bool,
     pub(crate) orchestration_failure_strategy: String,
     pub(crate) orchestration_planner_provider: Option<String>,
+    pub(crate) orchestration_persistence_enabled: bool,
     // Debug settings
     pub(crate) debug_dump_enabled: bool,
     pub(crate) debug_dump_format: zeph_core::debug_dump::DumpFormat,
@@ -273,6 +274,7 @@ impl Default for WizardState {
             orchestration_confirm_before_execute: false,
             orchestration_failure_strategy: String::new(),
             orchestration_planner_provider: None,
+            orchestration_persistence_enabled: true,
             debug_dump_enabled: false,
             debug_dump_format: zeph_core::debug_dump::DumpFormat::Json,
             graph_memory_enabled: false,
@@ -782,6 +784,7 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
                 .clone()
                 .unwrap_or_default(),
         ),
+        persistence_enabled: state.orchestration_persistence_enabled,
         ..OrchestrationConfig::default()
     };
 


### PR DESCRIPTION
## Summary

- Predicate outcomes and task graph state are now persisted to SQLite after each scheduler tick and on plan termination
- `/plan resume <id>` rehydrates the graph from disk, restoring predicate outcomes so `VerifyPredicate` actions are not redundantly re-emitted after restart
- Adds `OrchestrationConfig::persistence_enabled` (default `true`) with wizard prompt and `--migrate-config` migration

## Changes

- `OrchestrationState.graph_persistence: Option<GraphPersistence<DbGraphStore>>` — ungated field, populated when memory is attached and `persistence_enabled = true`
- `save_graph_snapshot()` free fn in `scheduler_loop.rs` — called once per tick (clone-before-await borrow discipline) and twice in `handle_plan_confirm` (defensive before `?`, authoritative after `extra_task_outputs`)
- `handle_plan_resume_as_string` made `async` with 11-row status×action matrix (Paused / Running crash-recovery / Failed / Completed refused / Canceled refused / Created / invalid UUID / not-found / no-persistence)
- `--migrate-config` Step 19 inserts `persistence_enabled = true` for existing configs
- 14 new unit tests including cross-agent round-trip (primary acceptance scenario)

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --all-targets --all-features --workspace -- -D warnings` — clean
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --all-features --lib --bins` — 8528/8528 pass
- [ ] `cargo check --no-default-features -p zeph-core` — clean
- [ ] Manual smoke test: `cargo run --features full -- --config .local/config/testing.toml`, confirm plan, Ctrl-C, restart, `/plan list` shows row, `/plan resume <id>` hydrates, `/plan confirm` continues

## Follow-up items

- `/plan gc` retention policy for unbounded `task_graphs` growth (P3, noted in CHANGELOG)
- Dirty-flag optimization to skip clone+serialize when graph unchanged (P3, noted by perf validator)

Closes #3107