### PR TITLE
feat(skills,plugins): add agent-invocable skills and plugin packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   to the previous wire format — no rollout risk for existing deployments. Closes
   [#3096](https://github.com/bug-ops/zeph/issues/3096).
 
+- **feat(core): `invoke_skill` tool (`SkillInvokeExecutor`)** — new `invoke_skill` tool that
+  returns a skill body as tool output with trust-aware sanitization. Blocked skills are refused
+  before any body read; non-Trusted bodies pass through `sanitize_skill_text`; Quarantined bodies
+  are additionally wrapped with `wrap_quarantined`. A per-turn trust snapshot
+  (`Arc<RwLock<HashMap>>`) is written by `prepare_context` and read by the executor without
+  re-querying SQLite on every tool call. `invoke_skill` and `load_skill` are added to
+  `QUARANTINE_DENIED` and `READONLY_TOOLS`. CLI subcommand `zeph skill invoke <name> [args]`
+  with the same trust-aware pipeline. Closes [#3105](https://github.com/bug-ops/zeph/issues/3105).
+
+- **feat(plugins): `zeph-plugins` crate + `zeph plugin` CLI** — new `zeph-plugins` crate with
+  `PluginManager` for install/remove/list of plugin packages. Enforces tighten-only config overlay
+  validation at install time (union on `blocked_commands`, intersection on `allowed_commands`, max
+  on `disambiguation_threshold`; keys outside this safelist are rejected with `UnsafeOverlay`).
+  **Note:** runtime application of overlay values to the live config is validated and stored in
+  `plugin.toml` but not yet merged into the running `Config` struct — scheduled for a follow-up PR.
+  MCP allowlist validation, skill name conflict detection (managed, bundled, other-plugin), path
+  traversal defense (canonicalize + `starts_with(root)`), and recursive `.bundled` marker stripping
+  via `walkdir`. CLI subcommand `zeph plugin list|add|remove`. TUI slash command
+  `/plugins list|add|remove` wired through `AgentAccess::handle_plugins` and TUI command palette.
+  Implements [#2806](https://github.com/bug-ops/zeph/issues/2806).
+
 ### Fixed
 
 - **fix(config): make `migrate-config --in-place` fully idempotent** — refactored

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9964,6 +9964,7 @@ dependencies = [
  "zeph-mcp",
  "zeph-memory",
  "zeph-orchestration",
+ "zeph-plugins",
  "zeph-sanitizer",
  "zeph-scheduler",
  "zeph-skills",
@@ -10204,6 +10205,7 @@ dependencies = [
  "zeph-mcp",
  "zeph-memory",
  "zeph-orchestration",
+ "zeph-plugins",
  "zeph-sanitizer",
  "zeph-skills",
  "zeph-subagent",
@@ -10432,6 +10434,24 @@ dependencies = [
  "zeph-memory",
  "zeph-sanitizer",
  "zeph-subagent",
+]
+
+[[package]]
+name = "zeph-plugins"
+version = "0.19.1"
+dependencies = [
+ "dirs",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml 1.1.2+spec-1.1.0",
+ "tracing",
+ "walkdir",
+ "zeph-common",
+ "zeph-config",
+ "zeph-skills",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,7 @@ unicode-normalization = "0.1"
 unicode-width = "0.2"
 url = "2.5"
 uuid = "1.23"
+walkdir = "2.5"
 wiremock = "0.6.5"
 zeroize = { version = "1", default-features = false }
 zeph-a2a = { path = "crates/zeph-a2a", version = "0.19.1" }
@@ -153,6 +154,7 @@ zeph-tools = { path = "crates/zeph-tools", version = "0.19.1" }
 zeph-tui = { path = "crates/zeph-tui", version = "0.19.1" }
 zeph-vault = { path = "crates/zeph-vault", version = "0.19.1" }
 zeph-orchestration = { path = "crates/zeph-orchestration", version = "0.19.1" }
+zeph-plugins = { path = "crates/zeph-plugins", version = "0.19.1" }
 zeph-sanitizer = { path = "crates/zeph-sanitizer", version = "0.19.1" }
 zeph-subagent = { path = "crates/zeph-subagent", version = "0.19.1" }
 
@@ -284,6 +286,7 @@ zeph-sanitizer.workspace = true
 zeph-scheduler = { workspace = true, optional = true }
 zeph-experiments.workspace = true
 zeph-orchestration.workspace = true
+zeph-plugins.workspace = true
 zeph-skills.workspace = true
 zeph-subagent.workspace = true
 zeph-tools.workspace = true

--- a/crates/zeph-commands/src/traits/agent.rs
+++ b/crates/zeph-commands/src/traits/agent.rs
@@ -361,6 +361,20 @@ pub trait AgentAccess: Send {
         &'a mut self,
         input: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<Option<String>, CommandError>> + Send + 'a>>;
+
+    // ----- /plugins -----
+
+    /// Handle `/plugins [subcommand] [args]` and return a user-visible result.
+    ///
+    /// Subcommands: `list`, `add <source>`, `remove <name>`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` when a plugin operation fails.
+    fn handle_plugins<'a>(
+        &'a mut self,
+        args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>>;
 }
 
 /// A no-op [`AgentAccess`] implementation.
@@ -554,5 +568,12 @@ impl AgentAccess for NullAgent {
         _input: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<Option<String>, CommandError>> + Send + 'a>> {
         Box::pin(async { Ok(None) })
+    }
+
+    fn handle_plugins<'a>(
+        &'a mut self,
+        _args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>> {
+        Box::pin(async { Ok(String::new()) })
     }
 }

--- a/crates/zeph-common/src/quarantine.rs
+++ b/crates/zeph-common/src/quarantine.rs
@@ -30,4 +30,8 @@ pub const QUARANTINE_DENIED: &[&str] = &[
     "fetch",
     // Memory persistence
     "memory_save",
+    // Skill body retrieval — denied for Quarantined active skills to prevent
+    // side-channel injection via dynamically loaded skill bodies.
+    "load_skill",
+    "invoke_skill",
 ];

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -71,6 +71,7 @@ zeph-index.workspace = true
 zeph-llm.workspace = true
 zeph-memory.workspace = true
 zeph-mcp.workspace = true
+zeph-plugins.workspace = true
 zeph-skills = { workspace = true, features = ["qdrant"] }
 zeph-tools.workspace = true
 # See https://github.com/bug-ops/zeph (workspace dependencies only contain versions)

--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -810,6 +810,23 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
             }
         })
     }
+
+    // ----- /plugins -----
+
+    fn handle_plugins<'a>(
+        &'a mut self,
+        args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>> {
+        let args_owned = args.to_owned();
+        // PluginManager performs synchronous filesystem I/O (copy, remove_dir_all, read_dir).
+        // Off-load to a blocking thread so the tokio runtime worker is never stalled.
+        let result = self.handle_plugins_as_string(&args_owned);
+        Box::pin(async move {
+            tokio::task::spawn_blocking(move || result)
+                .await
+                .map_err(|e| CommandError(format!("plugin task panicked: {e}")))
+        })
+    }
 }
 
 /// Convert `AgentError` to `CommandError` for the trait boundary.

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -216,6 +216,22 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Replace the trust snapshot Arc with a pre-allocated one shared with `SkillInvokeExecutor`.
+    ///
+    /// Call this when building the executor chain before `Agent::new_with_registry_arc` so that
+    /// both the executor and the agent share the same `Arc` — the agent writes to it once per
+    /// turn and the executor reads from it without hitting `SQLite`.
+    #[must_use]
+    pub fn with_trust_snapshot(
+        mut self,
+        snapshot: std::sync::Arc<
+            parking_lot::RwLock<std::collections::HashMap<String, zeph_common::SkillTrustLevel>>,
+        >,
+    ) -> Self {
+        self.skill_state.trust_snapshot = snapshot;
+        self
+    }
+
     /// Configure skill matching parameters (disambiguation, two-stage, confusability).
     #[must_use]
     pub fn with_skill_matching_config(

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -1094,6 +1094,15 @@ impl<C: Channel> Agent<C> {
                 .collect();
             (all, active)
         };
+        let trust_map = self.build_skill_trust_map().await;
+
+        // Write the per-turn trust snapshot so SkillInvokeExecutor can resolve trust
+        // without re-querying the store on every tool call.
+        self.skill_state
+            .trust_snapshot
+            .write()
+            .clone_from(&trust_map);
+
         let remaining_skills: Vec<Skill> = all_skills
             .iter()
             .filter(|s| {
@@ -1102,10 +1111,15 @@ impl<C: Channel> Agent<C> {
                     .active_skill_names
                     .contains(&s.name().to_string())
             })
+            .filter(|s| match trust_map.get(s.name()) {
+                Some(zeph_common::SkillTrustLevel::Blocked) => {
+                    tracing::debug!(skill = s.name(), "excluded from catalog: trust=blocked");
+                    false
+                }
+                _ => true,
+            })
             .cloned()
             .collect();
-
-        let trust_map = self.build_skill_trust_map().await;
 
         // Apply the most restrictive trust level among active skills to the executor gate.
         let effective_trust = if self.skill_state.active_skill_names.is_empty() {
@@ -1821,5 +1835,51 @@ mod tests {
             2,
             "partial prefixes must not be treated as policy markers"
         );
+    }
+
+    // ── Blocked-skill catalog filter (GAP-1) ────────────────────────────────
+
+    #[test]
+    fn blocked_skill_excluded_from_catalog_filter() {
+        use std::collections::HashMap;
+        use zeph_common::SkillTrustLevel;
+        use zeph_skills::loader::SkillMeta;
+
+        // Simulate the catalog filter: skills whose trust level is Blocked are dropped.
+        let mut trust_map: HashMap<String, SkillTrustLevel> = HashMap::new();
+        trust_map.insert("blocked-skill".to_owned(), SkillTrustLevel::Blocked);
+        trust_map.insert("allowed-skill".to_owned(), SkillTrustLevel::Trusted);
+
+        // Two minimal SkillMeta stubs.
+        let make_meta = |name: &str| SkillMeta {
+            name: name.to_owned(),
+            description: "desc".to_owned(),
+            compatibility: None,
+            license: None,
+            metadata: vec![],
+            allowed_tools: vec![],
+            requires_secrets: vec![],
+            skill_dir: std::path::PathBuf::new(),
+            source_url: None,
+            git_hash: None,
+            category: None,
+        };
+        let skills = vec![make_meta("blocked-skill"), make_meta("allowed-skill")];
+
+        // Apply the same filter logic used in the catalog-building path.
+        let catalog: Vec<_> = skills
+            .iter()
+            .filter(|s| match trust_map.get(s.name.as_str()) {
+                Some(SkillTrustLevel::Blocked) => false,
+                _ => true,
+            })
+            .collect();
+
+        assert_eq!(
+            catalog.len(),
+            1,
+            "blocked skill must be excluded from catalog"
+        );
+        assert_eq!(catalog[0].name, "allowed-skill");
     }
 }

--- a/crates/zeph-core/src/agent/slash_commands.rs
+++ b/crates/zeph-core/src/agent/slash_commands.rs
@@ -339,6 +339,80 @@ impl<C: crate::channel::Channel> Agent<C> {
     ///
     /// Used by the `AgentAccess::handle_skills` implementation to satisfy the `Send` bound
     /// on the returned future.
+    /// Handle `/plugins [subcommand] [args]` slash command.
+    ///
+    /// Returns a user-visible string result. This is a sync helper — plugin operations
+    /// are blocking filesystem calls, so they run in the current thread.
+    pub(super) fn handle_plugins_as_string(&self, args: &str) -> String {
+        // Use the canonical default so CLI and TUI always reference the same directory.
+        let plugins_dir = zeph_plugins::PluginManager::default_plugins_dir();
+        // Fall back to the canonical default managed skills dir so the conflict check is
+        // never silently disabled by an empty path (M5 fix).
+        let managed_dir = self
+            .skill_state
+            .managed_dir
+            .clone()
+            .unwrap_or_else(|| zeph_config::defaults::default_vault_dir().join("skills"));
+        let mcp_allowed: Vec<String> = self.mcp.allowed_commands.clone();
+        let mgr = zeph_plugins::PluginManager::new(plugins_dir, managed_dir, mcp_allowed);
+
+        let (subcmd, rest) = args.trim().split_once(' ').unwrap_or((args.trim(), ""));
+        match subcmd {
+            "" | "list" => match mgr.list_installed() {
+                Ok(plugins) if plugins.is_empty() => "No plugins installed.".to_owned(),
+                Ok(plugins) => plugins
+                    .iter()
+                    .map(|p| format!("{} v{} — {}", p.name, p.version, p.description))
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+                Err(e) => format!("plugin list failed: {e}"),
+            },
+            "add" => {
+                use std::fmt::Write as _;
+                if rest.is_empty() {
+                    return "Usage: /plugins add <source>".to_owned();
+                }
+                match mgr.add(rest.trim()) {
+                    Ok(r) => {
+                        let mut out = format!("Installed plugin \"{}\"", r.name);
+                        if !r.installed_skills.is_empty() {
+                            let _ = write!(out, "\n  Skills: {}", r.installed_skills.join(", "));
+                        }
+                        if !r.mcp_server_ids.is_empty() {
+                            let _ = write!(
+                                out,
+                                "\n  MCP servers (restart required): {}",
+                                r.mcp_server_ids.join(", ")
+                            );
+                        }
+                        out
+                    }
+                    Err(e) => format!("plugin add failed: {e}"),
+                }
+            }
+            "remove" => {
+                use std::fmt::Write as _;
+                if rest.is_empty() {
+                    return "Usage: /plugins remove <name>".to_owned();
+                }
+                match mgr.remove(rest.trim()) {
+                    Ok(r) => {
+                        let mut out = format!("Removed plugin \"{}\"", rest.trim());
+                        if !r.removed_skills.is_empty() {
+                            let _ =
+                                write!(out, "\n  Removed skills: {}", r.removed_skills.join(", "));
+                        }
+                        out
+                    }
+                    Err(e) => format!("plugin remove failed: {e}"),
+                }
+            }
+            other => {
+                format!("Unknown /plugins subcommand: '{other}'. Available: list, add, remove")
+            }
+        }
+    }
+
     pub(super) async fn handle_skills_as_string(
         &mut self,
         subcommand: &str,

--- a/crates/zeph-core/src/agent/speculative/mod.rs
+++ b/crates/zeph-core/src/agent/speculative/mod.rs
@@ -281,8 +281,10 @@ mod tests {
     #[tokio::test]
     async fn dispatch_and_commit_succeeds() {
         let exec: Arc<dyn ErasedToolExecutor> = Arc::new(AlwaysOkExecutor);
-        let mut config = SpeculativeConfig::default();
-        config.mode = SpeculationMode::Decoding;
+        let config = SpeculativeConfig {
+            mode: SpeculationMode::Decoding,
+            ..Default::default()
+        };
         let engine = SpeculationEngine::new(exec, config);
 
         let pred = Prediction {
@@ -299,8 +301,10 @@ mod tests {
     #[tokio::test]
     async fn untrusted_skill_skips_dispatch() {
         let exec: Arc<dyn ErasedToolExecutor> = Arc::new(AlwaysOkExecutor);
-        let mut config = SpeculativeConfig::default();
-        config.mode = SpeculationMode::Decoding;
+        let config = SpeculativeConfig {
+            mode: SpeculationMode::Decoding,
+            ..Default::default()
+        };
         let engine = SpeculationEngine::new(exec, config);
 
         let pred = Prediction {
@@ -320,8 +324,10 @@ mod tests {
     #[tokio::test]
     async fn cancel_for_removes_handle() {
         let exec: Arc<dyn ErasedToolExecutor> = Arc::new(AlwaysOkExecutor);
-        let mut config = SpeculativeConfig::default();
-        config.mode = SpeculationMode::Decoding;
+        let config = SpeculativeConfig {
+            mode: SpeculationMode::Decoding,
+            ..Default::default()
+        };
         let engine = SpeculationEngine::new(exec, config);
 
         let pred = Prediction {

--- a/crates/zeph-core/src/agent/speculative/partial_json.rs
+++ b/crates/zeph-core/src/agent/speculative/partial_json.rs
@@ -480,9 +480,9 @@ mod tests {
                 assert_eq!(known_leaves["x"], 42);
             }
             PrefixState::Incomplete => {} // also acceptable
-            other => panic!("unexpected: {other:?}"),
+            other @ PrefixState::Malformed => panic!("unexpected: {other:?}"),
         }
-        let done = p.push(r#"}"#);
+        let done = p.push("}");
         assert!(matches!(done, PrefixState::ValidPrefix { .. }));
     }
 
@@ -490,7 +490,7 @@ mod tests {
     #[test]
     fn fixture_malformed_input() {
         let mut p = PartialJsonParser::new();
-        let state = p.push(r#"not-json"#);
+        let state = p.push("not-json");
         assert!(matches!(state, PrefixState::Malformed));
     }
 
@@ -564,10 +564,10 @@ mod tests {
                 assert!(missing_required.contains(&"b".to_string()));
             }
             PrefixState::Incomplete => {} // also acceptable before 'b' is fully parsed
-            other => panic!("unexpected s1: {other:?}"),
+            other @ PrefixState::Malformed => panic!("unexpected s1: {other:?}"),
         }
         // Second push: completes 'b'
-        let s2 = p.push(r#"2}"#);
+        let s2 = p.push("2}");
         match s2 {
             PrefixState::ValidPrefix {
                 known_leaves,

--- a/crates/zeph-core/src/agent/speculative/paste.rs
+++ b/crates/zeph-core/src/agent/speculative/paste.rs
@@ -482,7 +482,7 @@ mod tests {
 
     #[test]
     fn wilson_zero_observations() {
-        assert_eq!(wilson_lower_bound(0, 0), 0.0);
+        assert!((wilson_lower_bound(0, 0) - 0.0_f64).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -76,6 +76,10 @@ pub(crate) struct MemoryState {
 
 pub(crate) struct SkillState {
     pub(crate) registry: Arc<RwLock<SkillRegistry>>,
+    /// Per-turn trust snapshot written by `prepare_context` after `build_skill_trust_map`.
+    /// Shared with `SkillInvokeExecutor` so it can resolve trust without hitting `SQLite`
+    /// on every tool call. Refreshed once per turn — stale by at most one turn.
+    pub(crate) trust_snapshot: Arc<RwLock<HashMap<String, zeph_common::SkillTrustLevel>>>,
     pub(crate) skill_paths: Vec<PathBuf>,
     pub(crate) managed_dir: Option<PathBuf>,
     pub(crate) trust_config: crate::config::TrustConfig,
@@ -845,6 +849,7 @@ impl SkillState {
     ) -> Self {
         Self {
             registry,
+            trust_snapshot: Arc::new(RwLock::new(HashMap::new())),
             skill_paths: Vec::new(),
             managed_dir: None,
             trust_config: crate::config::TrustConfig::default(),

--- a/crates/zeph-core/src/agent/vigil.rs
+++ b/crates/zeph-core/src/agent/vigil.rs
@@ -307,7 +307,7 @@ mod tests {
         );
         match verdict {
             VigilVerdict::Flagged { risk, .. } => assert_eq!(risk, VigilRiskLevel::High),
-            _ => panic!("expected Flagged"),
+            VigilVerdict::Clean => panic!("expected Flagged"),
         }
     }
 

--- a/crates/zeph-core/src/lib.rs
+++ b/crates/zeph-core/src/lib.rs
@@ -92,6 +92,7 @@ pub mod memory_tools;
 pub mod overflow_tools;
 pub mod runtime_context;
 pub mod runtime_layer;
+pub mod skill_invoker;
 pub mod skill_loader;
 pub mod task_supervisor;
 pub use zeph_common::text;
@@ -111,6 +112,7 @@ pub use channel::{
 };
 pub use config::{Config, ConfigError};
 pub use runtime_context::RuntimeContext;
+pub use skill_invoker::{InvokeSkillParams, SkillInvokeExecutor};
 pub use skill_loader::SkillLoaderExecutor;
 pub use task_supervisor::{
     BlockingError, BlockingHandle, MAX_RESTART_DELAY, RestartPolicy, TaskDescriptor, TaskHandle,

--- a/crates/zeph-core/src/skill_invoker.rs
+++ b/crates/zeph-core/src/skill_invoker.rs
@@ -1,0 +1,396 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Tool executor that returns a skill body as tool output with trust-aware sanitization.
+//!
+//! [`SkillInvokeExecutor`] implements `invoke_skill` — a native tool the LLM can call to
+//! retrieve and immediately act under a skill's instructions. Unlike `load_skill` (which is
+//! intent-neutral preview), `invoke_skill` carries intent-to-apply semantics: the next turn
+//! is expected to follow the returned skill body.
+//!
+//! The executor applies the same defense-in-depth pipeline as `format_skills_prompt`:
+//! - Non-Trusted bodies pass through [`sanitize_skill_text`].
+//! - Quarantined bodies are additionally wrapped with [`wrap_quarantined`].
+//! - Blocked skills are refused before any body read.
+//! - `args` are always sanitized regardless of trust level (LLM-chosen text).
+//!
+//! `invoke_skill` and `load_skill` are both listed in `QUARANTINE_DENIED`, so when a
+//! Quarantined skill is active the trust gate refuses both before this executor is reached.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use zeph_common::SkillTrustLevel;
+use zeph_skills::prompt::{sanitize_skill_text, wrap_quarantined};
+use zeph_skills::registry::SkillRegistry;
+use zeph_tools::executor::{
+    ToolCall, ToolError, ToolExecutor, ToolOutput, deserialize_params, truncate_tool_output,
+};
+use zeph_tools::registry::{InvocationHint, ToolDef};
+
+/// Parameters for the `invoke_skill` tool call.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct InvokeSkillParams {
+    /// Exact skill name from the `<other_skills>` catalog.
+    pub skill_name: String,
+    /// Optional free-form arguments forwarded verbatim to the skill body as a trailing
+    /// `<args>…</args>` block. Capped at 4096 characters.
+    #[serde(default)]
+    pub args: String,
+}
+
+/// Tool executor that returns a skill body by name with trust-aware sanitization.
+///
+/// Holds a shared reference to the skill registry and a per-turn trust snapshot
+/// refreshed by the agent loop. Both are cheap `Arc` clones — no allocation on hot path.
+#[derive(Clone, Debug)]
+pub struct SkillInvokeExecutor {
+    registry: Arc<RwLock<SkillRegistry>>,
+    /// Per-skill trust snapshot refreshed once per turn by the agent.
+    /// Absence of an entry means no trust row exists — treat as Quarantined
+    /// (see `SkillTrustLevel::default`).
+    trust_snapshot: Arc<RwLock<HashMap<String, SkillTrustLevel>>>,
+}
+
+impl SkillInvokeExecutor {
+    /// Create a new executor with shared registry and trust snapshot.
+    ///
+    /// Both `Arc`s must be the same instances held by the agent so updates are
+    /// visible without re-constructing the executor.
+    #[must_use]
+    pub fn new(
+        registry: Arc<RwLock<SkillRegistry>>,
+        trust_snapshot: Arc<RwLock<HashMap<String, SkillTrustLevel>>>,
+    ) -> Self {
+        Self {
+            registry,
+            trust_snapshot,
+        }
+    }
+
+    /// Resolve the trust level for a skill from the snapshot.
+    ///
+    /// Returns `SkillTrustLevel::default()` (Quarantined) when no row exists — fail-closed.
+    fn resolve_trust(&self, skill_name: &str) -> SkillTrustLevel {
+        self.trust_snapshot
+            .read()
+            .get(skill_name)
+            .copied()
+            .unwrap_or_default()
+    }
+}
+
+impl ToolExecutor for SkillInvokeExecutor {
+    async fn execute(&self, _response: &str) -> Result<Option<ToolOutput>, ToolError> {
+        Ok(None)
+    }
+
+    fn tool_definitions(&self) -> Vec<ToolDef> {
+        vec![ToolDef {
+            id: "invoke_skill".into(),
+            description: "Invoke a skill by name. Returns the skill body as tool output; the \
+                next turn should act under those instructions. Parameters: \
+                skill_name (required) — exact name from <other_skills>; \
+                args (optional) — <=4096 chars appended as <args>...</args>. \
+                Use when a cataloged skill clearly matches the current task and you \
+                intend to follow it in the next turn."
+                .into(),
+            schema: schemars::schema_for!(InvokeSkillParams),
+            invocation: InvocationHint::ToolCall,
+            output_schema: None,
+        }]
+    }
+
+    async fn execute_tool_call(&self, call: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
+        if call.tool_id != "invoke_skill" {
+            return Ok(None);
+        }
+        let params: InvokeSkillParams = deserialize_params(&call.params)?;
+        let skill_name: String = params.skill_name.chars().take(128).collect();
+
+        let trust = self.resolve_trust(&skill_name);
+        // Sanitize skill_name before it appears in any tool output: it originates from the LLM
+        // and could carry injection markers (e.g. `<|im_start|>`).
+        let skill_name_safe = sanitize_skill_text(&skill_name);
+
+        // Blocked skills are refused before any body read — executor defense layer.
+        if trust == SkillTrustLevel::Blocked {
+            return Ok(Some(make_output(format!(
+                "skill is blocked by policy: {skill_name_safe}"
+            ))));
+        }
+
+        // Clone body out of the read guard before any .await — never hold lock across await.
+        let body = {
+            let guard = self.registry.read();
+            guard.get_body(&skill_name).map(str::to_owned)
+        };
+
+        let summary = match body {
+            Ok(raw_body) => {
+                // Apply the same pipeline as `format_skills_prompt:194-204`:
+                // sanitize for non-Trusted, additionally wrap for Quarantined.
+                let sanitized = if trust == SkillTrustLevel::Trusted {
+                    raw_body
+                } else {
+                    sanitize_skill_text(&raw_body)
+                };
+                let wrapped = if trust == SkillTrustLevel::Quarantined {
+                    wrap_quarantined(&skill_name_safe, &sanitized)
+                } else {
+                    sanitized
+                };
+                let full = if params.args.trim().is_empty() {
+                    wrapped
+                } else {
+                    let args = params.args.chars().take(4096).collect::<String>();
+                    // args originate from LLM text — sanitize regardless of trust.
+                    let args_safe = sanitize_skill_text(&args);
+                    format!("{wrapped}\n\n<args>\n{args_safe}\n</args>")
+                };
+                truncate_tool_output(&full)
+            }
+            Err(_) => format!("skill not found: {skill_name_safe}"),
+        };
+
+        Ok(Some(make_output(summary)))
+    }
+}
+
+fn make_output(summary: String) -> ToolOutput {
+    ToolOutput {
+        tool_name: zeph_common::ToolName::new("invoke_skill"),
+        summary,
+        blocks_executed: 1,
+        filter_stats: None,
+        diff: None,
+        streamed: false,
+        terminal_id: None,
+        locations: None,
+        raw_response: None,
+        claim_source: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+
+    fn make_registry_with_skill(dir: &Path, name: &str, body: &str) -> SkillRegistry {
+        let skill_dir = dir.join(name);
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: test skill\n---\n{body}"),
+        )
+        .unwrap();
+        SkillRegistry::load(&[dir.to_path_buf()])
+    }
+
+    fn make_executor(
+        registry: SkillRegistry,
+        trust_map: HashMap<String, SkillTrustLevel>,
+    ) -> SkillInvokeExecutor {
+        SkillInvokeExecutor::new(
+            Arc::new(RwLock::new(registry)),
+            Arc::new(RwLock::new(trust_map)),
+        )
+    }
+
+    fn make_call(skill_name: &str) -> ToolCall {
+        ToolCall {
+            tool_id: zeph_common::ToolName::new("invoke_skill"),
+            params: serde_json::json!({"skill_name": skill_name})
+                .as_object()
+                .unwrap()
+                .clone(),
+            caller_id: None,
+        }
+    }
+
+    fn make_call_with_args(skill_name: &str, args: &str) -> ToolCall {
+        ToolCall {
+            tool_id: zeph_common::ToolName::new("invoke_skill"),
+            params: serde_json::json!({"skill_name": skill_name, "args": args})
+                .as_object()
+                .unwrap()
+                .clone(),
+            caller_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn trusted_skill_returns_body_verbatim() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = "## Instructions\nDo trusted things";
+        let registry = make_registry_with_skill(dir.path(), "my-skill", body);
+        let trust = HashMap::from([("my-skill".to_owned(), SkillTrustLevel::Trusted)]);
+        let executor = make_executor(registry, trust);
+        let result = executor
+            .execute_tool_call(&make_call("my-skill"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(result.summary.contains("## Instructions"));
+        assert!(result.summary.contains("Do trusted things"));
+    }
+
+    #[tokio::test]
+    async fn verified_skill_is_sanitized() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = "Normal body <|im_start|>injected";
+        let registry = make_registry_with_skill(dir.path(), "verified-skill", body);
+        let trust = HashMap::from([("verified-skill".to_owned(), SkillTrustLevel::Verified)]);
+        let executor = make_executor(registry, trust);
+        let result = executor
+            .execute_tool_call(&make_call("verified-skill"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(result.summary.contains("Normal body"));
+        assert!(result.summary.contains("[BLOCKED:<|im_start|>]"));
+        // The raw marker must only appear inside the [BLOCKED:...] wrapper, never standalone.
+        assert!(
+            !result
+                .summary
+                .replace("[BLOCKED:<|im_start|>]", "")
+                .contains("<|im_start|>")
+        );
+    }
+
+    #[tokio::test]
+    async fn quarantined_skill_is_sanitized_and_wrapped() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = "Quarantined content";
+        let registry = make_registry_with_skill(dir.path(), "quarantined-skill", body);
+        let trust = HashMap::from([("quarantined-skill".to_owned(), SkillTrustLevel::Quarantined)]);
+        let executor = make_executor(registry, trust);
+        let result = executor
+            .execute_tool_call(&make_call("quarantined-skill"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(result.summary.contains("QUARANTINED"));
+        assert!(result.summary.contains("Quarantined content"));
+    }
+
+    #[tokio::test]
+    async fn blocked_skill_is_refused_without_body_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = "secret body that should not be returned";
+        let registry = make_registry_with_skill(dir.path(), "blocked-skill", body);
+        let trust = HashMap::from([("blocked-skill".to_owned(), SkillTrustLevel::Blocked)]);
+        let executor = make_executor(registry, trust);
+        let result = executor
+            .execute_tool_call(&make_call("blocked-skill"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(result.summary.contains("blocked by policy"));
+        assert!(!result.summary.contains("secret body"));
+    }
+
+    #[tokio::test]
+    async fn no_trust_row_defaults_to_quarantined_behavior() {
+        // Default trust is Quarantined — fail-closed.
+        let dir = tempfile::tempdir().unwrap();
+        let body = "Some body";
+        let registry = make_registry_with_skill(dir.path(), "unknown-skill", body);
+        let executor = make_executor(registry, HashMap::new());
+        let result = executor
+            .execute_tool_call(&make_call("unknown-skill"))
+            .await
+            .unwrap()
+            .unwrap();
+        // Quarantined path: body is wrapped.
+        assert!(result.summary.contains("QUARANTINED"));
+    }
+
+    #[tokio::test]
+    async fn nonexistent_skill_returns_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
+        let executor = make_executor(registry, HashMap::new());
+        let result = executor
+            .execute_tool_call(&make_call("nonexistent"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(result.summary.contains("skill not found"));
+    }
+
+    #[tokio::test]
+    async fn wrong_tool_id_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
+        let executor = make_executor(registry, HashMap::new());
+        let call = ToolCall {
+            tool_id: zeph_common::ToolName::new("bash"),
+            params: serde_json::Map::new(),
+            caller_id: None,
+        };
+        let result = executor.execute_tool_call(&call).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn execute_always_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
+        let executor = make_executor(registry, HashMap::new());
+        let result = executor.execute("any text").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn args_are_appended_to_trusted_body() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = make_registry_with_skill(dir.path(), "argskill", "Body text");
+        let trust = HashMap::from([("argskill".to_owned(), SkillTrustLevel::Trusted)]);
+        let executor = make_executor(registry, trust);
+        let result = executor
+            .execute_tool_call(&make_call_with_args("argskill", "user arg"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(result.summary.contains("Body text"));
+        assert!(result.summary.contains("<args>"));
+        assert!(result.summary.contains("user arg"));
+    }
+
+    #[tokio::test]
+    async fn args_are_sanitized_regardless_of_trust() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = make_registry_with_skill(dir.path(), "trustskill", "Body");
+        let trust = HashMap::from([("trustskill".to_owned(), SkillTrustLevel::Trusted)]);
+        let executor = make_executor(registry, trust);
+        let result = executor
+            .execute_tool_call(&make_call_with_args("trustskill", "<|im_start|>injected"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(result.summary.contains("[BLOCKED:<|im_start|>]"));
+        // The raw marker must only appear inside the [BLOCKED:...] wrapper, never standalone.
+        assert!(
+            !result
+                .summary
+                .replace("[BLOCKED:<|im_start|>]", "")
+                .contains("<|im_start|>")
+        );
+    }
+
+    #[tokio::test]
+    async fn tool_definitions_returns_invoke_skill() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
+        let executor = make_executor(registry, HashMap::new());
+        let defs = executor.tool_definitions();
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].id.as_ref(), "invoke_skill");
+    }
+}

--- a/crates/zeph-index/src/store.rs
+++ b/crates/zeph-index/src/store.rs
@@ -645,8 +645,8 @@ mod tests {
         assert!(files.contains(&"src/b.rs".to_string()));
     }
 
-    /// Verifies that inserting the same (file_path, content_hash) twice does not
-    /// produce a duplicate row — the ON CONFLICT(file_path, content_hash) clause
+    /// Verifies that inserting the same (`file_path`, `content_hash`) twice does not
+    /// produce a duplicate row — the `ON CONFLICT(file_path, content_hash)` clause
     /// must perform an UPDATE, not a second INSERT.
     #[tokio::test]
     async fn upsert_same_file_path_and_hash_is_idempotent() {

--- a/crates/zeph-plugins/Cargo.toml
+++ b/crates/zeph-plugins/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "zeph-plugins"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+publish.workspace = true
+description = "Plugin packaging, installation, and management for Zeph"
+readme = "README.md"
+
+[dependencies]
+dirs.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+thiserror.workspace = true
+toml.workspace = true
+tracing.workspace = true
+walkdir = { workspace = true }
+zeph-common.workspace = true
+zeph-config.workspace = true
+zeph-skills.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[lints]
+workspace = true

--- a/crates/zeph-plugins/src/error.rs
+++ b/crates/zeph-plugins/src/error.rs
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Error types for plugin operations.
+
+use std::path::PathBuf;
+
+/// Errors that can occur during plugin install, remove, or list operations.
+#[derive(Debug, thiserror::Error)]
+pub enum PluginError {
+    /// The plugin manifest (`plugin.toml`) is missing or cannot be parsed.
+    #[error("invalid plugin manifest: {0}")]
+    InvalidManifest(String),
+
+    /// The plugin name is invalid (empty, contains path separators, or reserved).
+    #[error("invalid plugin name {name:?}: {reason}")]
+    InvalidName { name: String, reason: String },
+
+    /// A plugin MCP entry declares a command not in `mcp.allowed_commands`.
+    #[error(
+        "plugin MCP server {id:?} spawns command {command:?}, which is not in mcp.allowed_commands"
+    )]
+    DisallowedMcpCommand { id: String, command: String },
+
+    /// A plugin skill name conflicts with an existing managed (user) skill.
+    #[error("plugin skill {name:?} conflicts with an existing managed skill")]
+    SkillNameConflictWithManaged { name: String },
+
+    /// A plugin skill name conflicts with a compile-time bundled skill.
+    #[error("plugin skill {name:?} conflicts with a bundled skill")]
+    SkillNameConflictWithBundled { name: String },
+
+    /// A plugin skill name conflicts with a skill from another installed plugin.
+    #[error("plugin skill {name:?} conflicts with skill from plugin {plugin:?}")]
+    SkillNameConflictWithPlugin { name: String, plugin: String },
+
+    /// A plugin's `[config]` section contains a key not in the tighten-only safelist.
+    #[error(
+        "plugin config overlay key {key:?} is not allowed; only tools.blocked_commands, tools.allowed_commands, and skills.disambiguation_threshold may be overridden"
+    )]
+    UnsafeOverlay { key: String },
+
+    /// A `[[skills]] path` entry does not contain a valid `SKILL.md` file.
+    #[error("plugin skill entry at {path:?} does not contain a SKILL.md file")]
+    SkillEntryMissing { path: PathBuf },
+
+    /// The plugin directory does not exist or cannot be read.
+    #[error("plugin not found: {name}")]
+    NotFound { name: String },
+
+    /// The plugin source path or URL is invalid.
+    #[error("invalid plugin source {path:?}: {reason}")]
+    InvalidSource { path: String, reason: String },
+
+    /// A filesystem operation failed.
+    #[error("filesystem error at {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// TOML serialization/deserialization error.
+    #[error("TOML error: {0}")]
+    Toml(#[from] toml::de::Error),
+
+    /// TOML serialization error.
+    #[error("TOML serialization error: {0}")]
+    TomlSer(#[from] toml::ser::Error),
+}

--- a/crates/zeph-plugins/src/lib.rs
+++ b/crates/zeph-plugins/src/lib.rs
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Plugin packaging and management for Zeph.
+//!
+//! A plugin is a directory (local or remote git) containing:
+//! - `plugin.toml` — manifest describing the plugin (name, version, skills, MCP servers, config overlay)
+//! - one or more skill directories with `SKILL.md` files
+//! - optional MCP server declarations
+//!
+//! Plugins are installed to `~/.local/share/zeph/plugins/<name>/` and loaded at agent startup.
+//!
+//! # Security Model
+//!
+//! - Plugin config overlays are **tighten-only**: they can add to `blocked_commands`,
+//!   narrow `allowed_commands`, or raise `disambiguation_threshold` — never loosen constraints.
+//! - Plugin MCP entries are validated against `mcp.allowed_commands` at install time.
+//! - `.bundled` markers are stripped recursively from all plugin skill trees.
+//! - Skill name conflicts with managed, bundled, or other plugin skills are hard-errors at install.
+
+pub mod error;
+pub mod manager;
+pub mod manifest;
+
+pub use error::PluginError;
+pub use manager::{AddResult, InstalledPlugin, PluginManager, RemoveResult};
+pub use manifest::PluginManifest;

--- a/crates/zeph-plugins/src/manager.rs
+++ b/crates/zeph-plugins/src/manager.rs
@@ -1,0 +1,934 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Plugin lifecycle management: add, remove, list.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use walkdir::WalkDir;
+use zeph_skills::bundled::bundled_skill_names;
+use zeph_skills::registry::SkillRegistry;
+
+use crate::PluginError;
+use crate::manifest::{PluginManifest, PluginMcpServer};
+
+/// The tighten-only config overlay safelist. Any key outside this list causes
+/// [`PluginError::UnsafeOverlay`] at install time.
+const CONFIG_SAFELIST: &[&str] = &[
+    "tools.blocked_commands",
+    "tools.allowed_commands",
+    "skills.disambiguation_threshold",
+];
+
+/// Result of a successful `plugin add` operation.
+#[derive(Debug)]
+pub struct AddResult {
+    /// Installed plugin name.
+    pub name: String,
+    /// Absolute path to the installed plugin root.
+    ///
+    /// Callers should pass each entry in `installed_skill_dirs` to
+    /// [`zeph_skills::registry::SkillRegistry::register_hub_dir`] so the registry treats plugin
+    /// subtrees as non-bundled regardless of any residual `.bundled` markers (S2 defense).
+    pub plugin_root: PathBuf,
+    /// Skill names registered from this plugin.
+    pub installed_skills: Vec<String>,
+    /// MCP server IDs declared by this plugin (require agent restart).
+    pub mcp_server_ids: Vec<String>,
+    /// Non-fatal warnings (e.g. config overlay value narrowed by tighten semantics).
+    pub warnings: Vec<String>,
+}
+
+/// Result of a successful `plugin remove` operation.
+#[derive(Debug, Default)]
+pub struct RemoveResult {
+    /// Skill names unregistered.
+    pub removed_skills: Vec<String>,
+    /// MCP server IDs that were declared (require agent restart).
+    pub removed_mcp_ids: Vec<String>,
+}
+
+/// Installed plugin metadata as returned by `plugin list`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstalledPlugin {
+    /// Plugin name.
+    pub name: String,
+    /// Plugin version.
+    pub version: String,
+    /// Plugin description.
+    pub description: String,
+    /// Absolute path to the installed plugin root.
+    pub path: PathBuf,
+}
+
+/// Manages plugin lifecycle: install, remove, list.
+///
+/// All operations are synchronous. Plugin watchers and agent config overlays are
+/// applied separately by the agent bootstrap layer.
+pub struct PluginManager {
+    /// Root directory where plugins are installed (`~/.local/share/zeph/plugins/`).
+    plugins_dir: PathBuf,
+    /// Directory where managed (user-installed) skills live.
+    managed_skills_dir: PathBuf,
+    /// `mcp.allowed_commands` from the agent config. Used to validate plugin MCP entries.
+    mcp_allowed_commands: Vec<String>,
+}
+
+impl PluginManager {
+    /// Returns the canonical default plugins directory: `~/.local/share/zeph/plugins/`.
+    ///
+    /// Both the CLI and TUI must use this helper so they always point to the same directory.
+    #[must_use]
+    pub fn default_plugins_dir() -> PathBuf {
+        dirs::data_local_dir()
+            .unwrap_or_else(|| PathBuf::from("~/.local/share"))
+            .join("zeph")
+            .join("plugins")
+    }
+
+    /// Create a new manager.
+    ///
+    /// # Parameters
+    ///
+    /// - `plugins_dir` — root installation directory for plugins.
+    /// - `managed_skills_dir` — directory for user-managed skills (conflict detection).
+    /// - `mcp_allowed_commands` — allowlist for MCP server commands from agent config.
+    #[must_use]
+    pub fn new(
+        plugins_dir: PathBuf,
+        managed_skills_dir: PathBuf,
+        mcp_allowed_commands: Vec<String>,
+    ) -> Self {
+        Self {
+            plugins_dir,
+            managed_skills_dir,
+            mcp_allowed_commands,
+        }
+    }
+
+    /// Install a plugin from a local directory path.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PluginError`] if the manifest is invalid, the source cannot be read,
+    /// there are skill name conflicts, MCP commands are not allowlisted, or config
+    /// overlay keys are not in the tighten-only safelist.
+    pub fn add(&self, source: &str) -> Result<AddResult, PluginError> {
+        let source_path = PathBuf::from(source);
+        if !source_path.exists() {
+            return Err(PluginError::InvalidSource {
+                path: source.to_owned(),
+                reason: "path does not exist".to_owned(),
+            });
+        }
+
+        let manifest_path = source_path.join("plugin.toml");
+        let manifest_bytes = std::fs::read(&manifest_path).map_err(|e| PluginError::Io {
+            path: manifest_path.clone(),
+            source: e,
+        })?;
+        let manifest: PluginManifest = toml::from_str(&String::from_utf8_lossy(&manifest_bytes))
+            .map_err(|e| PluginError::InvalidManifest(format!("{e}")))?;
+
+        // Validate plugin name.
+        validate_plugin_name(&manifest.plugin.name)?;
+
+        // Validate each [[skills]] entry: path must stay within source root and SKILL.md must exist.
+        for entry in &manifest.skills {
+            let skill_path = source_path.join(&entry.path);
+            // Reject path traversal: resolved path must be inside source_path.
+            let canonical_source = source_path.canonicalize().map_err(|e| PluginError::Io {
+                path: source_path.clone(),
+                source: e,
+            })?;
+            let canonical_skill = skill_path
+                .canonicalize()
+                .unwrap_or_else(|_| skill_path.clone());
+            if !canonical_skill.starts_with(&canonical_source) {
+                return Err(PluginError::InvalidSource {
+                    path: entry.path.clone(),
+                    reason: "skill path escapes plugin source root".to_owned(),
+                });
+            }
+            // Ensure the skill directory contains a SKILL.md file.
+            if !skill_path.join("SKILL.md").is_file() {
+                return Err(PluginError::SkillEntryMissing { path: skill_path });
+            }
+        }
+
+        // Validate config overlay keys.
+        validate_config_overlay(&manifest.config)?;
+
+        // Validate MCP command allowlist.
+        validate_mcp_commands(&manifest.mcp.servers, &self.mcp_allowed_commands)?;
+
+        // Collect skill names from the plugin source.
+        let skill_names = collect_skill_names(&source_path, &manifest);
+
+        // Check for name conflicts.
+        self.check_skill_conflicts(&skill_names, &manifest.plugin.name)?;
+
+        let dest = self.plugins_dir.join(&manifest.plugin.name);
+
+        // Copy source to destination.
+        copy_dir_all(&source_path, &dest)?;
+
+        // Recursively strip all .bundled markers from the installed tree.
+        strip_bundled_markers(&dest);
+
+        // Write manifest copy at plugin root for future reference.
+        let installed_manifest_path = dest.join(".plugin.toml");
+        let manifest_str = toml::to_string(&manifest)?;
+        std::fs::write(&installed_manifest_path, manifest_str).map_err(|e| PluginError::Io {
+            path: installed_manifest_path,
+            source: e,
+        })?;
+
+        let mcp_server_ids: Vec<String> =
+            manifest.mcp.servers.iter().map(|s| s.id.clone()).collect();
+
+        tracing::info!(
+            plugin = %manifest.plugin.name,
+            skills = ?skill_names,
+            mcp_servers = ?mcp_server_ids,
+            "plugin installed"
+        );
+
+        Ok(AddResult {
+            name: manifest.plugin.name,
+            plugin_root: dest,
+            installed_skills: skill_names,
+            mcp_server_ids,
+            warnings: Vec::new(),
+        })
+    }
+
+    /// Remove an installed plugin by name.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PluginError::NotFound`] if the plugin is not installed.
+    pub fn remove(&self, name: &str) -> Result<RemoveResult, PluginError> {
+        validate_plugin_name(name)?;
+        let plugin_dir = self.plugins_dir.join(name);
+        if !plugin_dir.exists() {
+            return Err(PluginError::NotFound {
+                name: name.to_owned(),
+            });
+        }
+
+        let manifest_path = plugin_dir.join(".plugin.toml");
+        let (removed_skills, removed_mcp_ids) = if manifest_path.exists() {
+            let bytes = std::fs::read(&manifest_path).map_err(|e| PluginError::Io {
+                path: manifest_path,
+                source: e,
+            })?;
+            let manifest: PluginManifest = toml::from_str(&String::from_utf8_lossy(&bytes))
+                .map_err(|e| PluginError::InvalidManifest(format!("{e}")))?;
+            let skills = collect_skill_names(&plugin_dir, &manifest);
+            let mcp = manifest.mcp.servers.iter().map(|s| s.id.clone()).collect();
+            (skills, mcp)
+        } else {
+            (Vec::new(), Vec::new())
+        };
+
+        std::fs::remove_dir_all(&plugin_dir).map_err(|e| PluginError::Io {
+            path: plugin_dir,
+            source: e,
+        })?;
+
+        tracing::info!(plugin = %name, "plugin removed");
+
+        Ok(RemoveResult {
+            removed_skills,
+            removed_mcp_ids,
+        })
+    }
+
+    /// List all installed plugins.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PluginError`] if the plugins directory cannot be read.
+    pub fn list_installed(&self) -> Result<Vec<InstalledPlugin>, PluginError> {
+        if !self.plugins_dir.exists() {
+            return Ok(Vec::new());
+        }
+
+        let mut plugins = Vec::new();
+        let entries = std::fs::read_dir(&self.plugins_dir).map_err(|e| PluginError::Io {
+            path: self.plugins_dir.clone(),
+            source: e,
+        })?;
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let manifest_path = path.join(".plugin.toml");
+            if !manifest_path.exists() {
+                continue;
+            }
+            let Ok(bytes) = std::fs::read(&manifest_path) else {
+                continue;
+            };
+            let Ok(manifest): Result<PluginManifest, _> =
+                toml::from_str(&String::from_utf8_lossy(&bytes))
+            else {
+                continue;
+            };
+            plugins.push(InstalledPlugin {
+                name: manifest.plugin.name,
+                version: manifest.plugin.version,
+                description: manifest.plugin.description,
+                path,
+            });
+        }
+
+        plugins.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(plugins)
+    }
+
+    /// Returns all skill directory paths from installed plugins.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PluginError`] if the plugins directory cannot be read.
+    pub fn collect_skill_dirs(&self) -> Result<Vec<PathBuf>, PluginError> {
+        if !self.plugins_dir.exists() {
+            return Ok(Vec::new());
+        }
+
+        let mut dirs = Vec::new();
+        let plugins = self.list_installed()?;
+        for plugin in &plugins {
+            let manifest_path = plugin.path.join(".plugin.toml");
+            if let Ok(bytes) = std::fs::read(&manifest_path)
+                && let Ok(manifest) =
+                    toml::from_str::<PluginManifest>(&String::from_utf8_lossy(&bytes))
+            {
+                for entry in &manifest.skills {
+                    let skill_dir = plugin.path.join(&entry.path);
+                    // Reject traversal: dir must stay within the installed plugin root.
+                    let ok = skill_dir
+                        .canonicalize()
+                        .is_ok_and(|c| c.starts_with(&plugin.path));
+                    if ok {
+                        dirs.push(skill_dir);
+                    } else {
+                        tracing::warn!(
+                            plugin = %plugin.name,
+                            path = %entry.path,
+                            "skipping skill path that escapes plugin root"
+                        );
+                    }
+                }
+            }
+        }
+        Ok(dirs)
+    }
+
+    fn check_skill_conflicts(
+        &self,
+        skill_names: &[String],
+        this_plugin: &str,
+    ) -> Result<(), PluginError> {
+        let bundled = bundled_skill_names();
+
+        // Managed skills: any name in the managed skills dir.
+        let managed_registry = {
+            let dirs: Vec<PathBuf> = if self.managed_skills_dir.exists() {
+                vec![self.managed_skills_dir.clone()]
+            } else {
+                vec![]
+            };
+            SkillRegistry::load(&dirs)
+        };
+        let managed_names: std::collections::HashSet<String> = managed_registry
+            .all_meta()
+            .iter()
+            .map(|m| m.name.clone())
+            .collect();
+
+        // Other installed plugins' skill names.
+        let installed = self.list_installed().unwrap_or_default();
+        let mut other_plugin_skills: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        for plugin in &installed {
+            if plugin.name == this_plugin {
+                continue;
+            }
+            let manifest_path = plugin.path.join(".plugin.toml");
+            if let Ok(bytes) = std::fs::read(&manifest_path)
+                && let Ok(manifest) =
+                    toml::from_str::<PluginManifest>(&String::from_utf8_lossy(&bytes))
+            {
+                let names = collect_skill_names(&plugin.path, &manifest);
+                for name in names {
+                    other_plugin_skills.insert(name, plugin.name.clone());
+                }
+            }
+        }
+
+        for name in skill_names {
+            if bundled.contains(name) {
+                return Err(PluginError::SkillNameConflictWithBundled { name: name.clone() });
+            }
+            if managed_names.contains(name) {
+                return Err(PluginError::SkillNameConflictWithManaged { name: name.clone() });
+            }
+            if let Some(other) = other_plugin_skills.get(name) {
+                return Err(PluginError::SkillNameConflictWithPlugin {
+                    name: name.clone(),
+                    plugin: other.clone(),
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Validate that a plugin name is a safe identifier: `[a-z0-9][a-z0-9-]*`.
+fn validate_plugin_name(name: &str) -> Result<(), PluginError> {
+    if name.is_empty() {
+        return Err(PluginError::InvalidName {
+            name: name.to_owned(),
+            reason: "name must not be empty".to_owned(),
+        });
+    }
+    if name.contains('/') || name.contains('\\') || name.contains('.') {
+        return Err(PluginError::InvalidName {
+            name: name.to_owned(),
+            reason: "name must not contain path separators or dots".to_owned(),
+        });
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    {
+        return Err(PluginError::InvalidName {
+            name: name.to_owned(),
+            reason: "name must match [a-z0-9][a-z0-9-]*".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+/// Validate all keys in the `[config]` overlay are in the tighten-only safelist.
+fn validate_config_overlay(config: &toml::Value) -> Result<(), PluginError> {
+    let table = match config.as_table() {
+        Some(t) if !t.is_empty() => t,
+        _ => return Ok(()),
+    };
+
+    for (section, inner) in table {
+        let inner_table = inner.as_table().ok_or_else(|| PluginError::UnsafeOverlay {
+            key: section.clone(),
+        })?;
+        for key in inner_table.keys() {
+            let dotted = format!("{section}.{key}");
+            if !CONFIG_SAFELIST.contains(&dotted.as_str()) {
+                return Err(PluginError::UnsafeOverlay { key: dotted });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Validate that all plugin MCP servers declare commands that are in the allowlist.
+fn validate_mcp_commands(
+    servers: &[PluginMcpServer],
+    allowed: &[String],
+) -> Result<(), PluginError> {
+    for server in servers {
+        if let Some(cmd) = &server.command {
+            // Compare the full command string verbatim — no file_name() fallback.
+            // Basename matching would allow `/tmp/evil/npx` when allowlist contains `npx`.
+            let ok = allowed.iter().any(|a| a == cmd);
+            if !ok {
+                return Err(PluginError::DisallowedMcpCommand {
+                    id: server.id.clone(),
+                    command: cmd.clone(),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Collect skill names from a plugin source tree according to the manifest's `[[skills]]` entries.
+///
+/// Each `[[skills]] path` entry points to a single skill directory that directly contains
+/// `SKILL.md`. `SkillRegistry::load` expects *parent* directories, so we pass each entry's
+/// parent and collect only the skills whose directory matches the declared path.
+fn collect_skill_names(root: &Path, manifest: &PluginManifest) -> Vec<String> {
+    // Collect unique parent directories so we can batch-load.
+    let mut parent_dirs: Vec<PathBuf> = manifest
+        .skills
+        .iter()
+        .filter_map(|e| {
+            let p = root.join(&e.path);
+            p.parent().map(Path::to_path_buf)
+        })
+        .collect();
+    parent_dirs.sort();
+    parent_dirs.dedup();
+
+    if parent_dirs.is_empty() {
+        return Vec::new();
+    }
+
+    // Allowed skill directories (resolved absolute paths).
+    let allowed: std::collections::HashSet<PathBuf> =
+        manifest.skills.iter().map(|e| root.join(&e.path)).collect();
+
+    let registry = SkillRegistry::load(&parent_dirs);
+    registry
+        .all_meta()
+        .iter()
+        .filter(|m| allowed.contains(&m.skill_dir))
+        .map(|m| m.name.clone())
+        .collect()
+}
+
+/// Recursively copy `src` directory to `dst`, creating `dst` if needed.
+fn copy_dir_all(src: &Path, dst: &Path) -> Result<(), PluginError> {
+    if dst.exists() {
+        std::fs::remove_dir_all(dst).map_err(|e| PluginError::Io {
+            path: dst.to_path_buf(),
+            source: e,
+        })?;
+    }
+    std::fs::create_dir_all(dst).map_err(|e| PluginError::Io {
+        path: dst.to_path_buf(),
+        source: e,
+    })?;
+
+    for entry in WalkDir::new(src).min_depth(1) {
+        let entry = entry.map_err(|e| PluginError::Io {
+            path: src.to_path_buf(),
+            source: std::io::Error::other(e.to_string()),
+        })?;
+        let rel = entry
+            .path()
+            .strip_prefix(src)
+            .expect("walkdir yields paths under src");
+        let target = dst.join(rel);
+        if entry.file_type().is_dir() {
+            std::fs::create_dir_all(&target).map_err(|e| PluginError::Io {
+                path: target,
+                source: e,
+            })?;
+        } else {
+            if let Some(parent) = target.parent() {
+                std::fs::create_dir_all(parent).map_err(|e| PluginError::Io {
+                    path: parent.to_path_buf(),
+                    source: e,
+                })?;
+            }
+            std::fs::copy(entry.path(), &target).map_err(|e| PluginError::Io {
+                path: target,
+                source: e,
+            })?;
+        }
+    }
+    Ok(())
+}
+
+/// Walk the plugin tree and delete every `.bundled` marker file.
+///
+/// Plugin skills are third-party and must never be treated as bundled by the scanner.
+fn strip_bundled_markers(root: &Path) {
+    for entry in WalkDir::new(root).into_iter().flatten() {
+        if entry.file_type().is_file() && entry.file_name().to_str() == Some(".bundled") {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_plugin(dir: &Path, name: &str, manifest_toml: &str, skills: &[(&str, &str)]) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(dir.join("plugin.toml"), manifest_toml).unwrap();
+        for (skill_name, body) in skills {
+            let skill_dir = dir.join("skills").join(skill_name);
+            std::fs::create_dir_all(&skill_dir).unwrap();
+            std::fs::write(
+                skill_dir.join("SKILL.md"),
+                format!("---\nname: {skill_name}\ndescription: test\n---\n{body}"),
+            )
+            .unwrap();
+            // Write a .bundled marker to test stripping.
+            std::fs::write(skill_dir.join(".bundled"), "").unwrap();
+        }
+        let _ = name;
+    }
+
+    fn simple_manifest(name: &str, skill: &str) -> String {
+        format!(
+            r#"[plugin]
+name = "{name}"
+version = "0.1.0"
+description = "test plugin"
+
+[[skills]]
+path = "skills/{skill}"
+"#
+        )
+    }
+
+    #[test]
+    fn add_and_list_plugin() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source");
+        write_plugin(
+            &source,
+            "test-plugin",
+            &simple_manifest("test-plugin", "my-skill"),
+            &[("my-skill", "Do stuff")],
+        );
+
+        let plugins_dir = tmp.path().join("plugins");
+        let managed_dir = tmp.path().join("managed");
+        let mgr = PluginManager::new(plugins_dir.clone(), managed_dir, vec![]);
+
+        let result = mgr.add(source.to_str().unwrap()).unwrap();
+        assert_eq!(result.name, "test-plugin");
+        assert!(result.installed_skills.contains(&"my-skill".to_owned()));
+
+        let installed = mgr.list_installed().unwrap();
+        assert_eq!(installed.len(), 1);
+        assert_eq!(installed[0].name, "test-plugin");
+    }
+
+    #[test]
+    fn bundled_markers_stripped_on_install() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source");
+        write_plugin(
+            &source,
+            "strip-test",
+            &simple_manifest("strip-test", "my-skill"),
+            &[("my-skill", "Body")],
+        );
+
+        let plugins_dir = tmp.path().join("plugins");
+        let managed_dir = tmp.path().join("managed");
+        let mgr = PluginManager::new(plugins_dir.clone(), managed_dir, vec![]);
+        mgr.add(source.to_str().unwrap()).unwrap();
+
+        // .bundled markers must not exist in the installed tree.
+        let has_bundled = WalkDir::new(&plugins_dir)
+            .into_iter()
+            .flatten()
+            .any(|e| e.file_name().to_str() == Some(".bundled"));
+        assert!(!has_bundled, ".bundled markers were not stripped");
+    }
+
+    #[test]
+    fn mcp_disallowed_command_fails_install() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source");
+        let manifest = r#"[plugin]
+name = "mcp-test"
+version = "0.1.0"
+description = "test"
+
+[[mcp.servers]]
+id = "bad-server"
+command = "dangerous-binary"
+"#;
+        write_plugin(&source, "mcp-test", manifest, &[]);
+
+        let plugins_dir = tmp.path().join("plugins");
+        let managed_dir = tmp.path().join("managed");
+        let mgr = PluginManager::new(plugins_dir, managed_dir, vec!["npx".to_owned()]);
+
+        let err = mgr.add(source.to_str().unwrap()).unwrap_err();
+        assert!(matches!(err, PluginError::DisallowedMcpCommand { .. }));
+    }
+
+    #[test]
+    fn unsafe_config_overlay_fails_install() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source");
+        let manifest = r#"[plugin]
+name = "overlay-test"
+version = "0.1.0"
+description = "test"
+
+[config.llm]
+model = "evil"
+"#;
+        write_plugin(&source, "overlay-test", manifest, &[]);
+
+        let plugins_dir = tmp.path().join("plugins");
+        let managed_dir = tmp.path().join("managed");
+        let mgr = PluginManager::new(plugins_dir, managed_dir, vec![]);
+
+        let err = mgr.add(source.to_str().unwrap()).unwrap_err();
+        assert!(matches!(err, PluginError::UnsafeOverlay { .. }));
+    }
+
+    #[test]
+    fn max_active_skills_overlay_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source");
+        let manifest = r#"[plugin]
+name = "max-skills-test"
+version = "0.1.0"
+description = "test"
+
+[config.skills]
+max_active_skills = 10
+"#;
+        write_plugin(&source, "max-skills-test", manifest, &[]);
+
+        let plugins_dir = tmp.path().join("plugins");
+        let managed_dir = tmp.path().join("managed");
+        let mgr = PluginManager::new(plugins_dir, managed_dir, vec![]);
+
+        let err = mgr.add(source.to_str().unwrap()).unwrap_err();
+        assert!(matches!(err, PluginError::UnsafeOverlay { .. }));
+    }
+
+    #[test]
+    fn safe_config_overlay_is_accepted() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source");
+        let manifest = r#"[plugin]
+name = "safe-overlay"
+version = "0.1.0"
+description = "test"
+
+[config.skills]
+disambiguation_threshold = 0.05
+
+[config.tools]
+blocked_commands = ["rm -rf"]
+"#;
+        write_plugin(&source, "safe-overlay", manifest, &[]);
+
+        let plugins_dir = tmp.path().join("plugins");
+        let managed_dir = tmp.path().join("managed");
+        let mgr = PluginManager::new(plugins_dir, managed_dir, vec![]);
+        let result = mgr.add(source.to_str().unwrap()).unwrap();
+        assert_eq!(result.name, "safe-overlay");
+    }
+
+    #[test]
+    fn remove_plugin() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source");
+        write_plugin(
+            &source,
+            "removable",
+            &simple_manifest("removable", "my-skill"),
+            &[("my-skill", "Body")],
+        );
+
+        let plugins_dir = tmp.path().join("plugins");
+        let managed_dir = tmp.path().join("managed");
+        let mgr = PluginManager::new(plugins_dir.clone(), managed_dir, vec![]);
+        mgr.add(source.to_str().unwrap()).unwrap();
+
+        let result = mgr.remove("removable").unwrap();
+        assert!(result.removed_skills.contains(&"my-skill".to_owned()));
+
+        let installed = mgr.list_installed().unwrap();
+        assert!(installed.is_empty());
+    }
+
+    #[test]
+    fn remove_nonexistent_plugin_returns_not_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        let plugins_dir = tmp.path().join("plugins");
+        let mgr = PluginManager::new(plugins_dir, tmp.path().to_path_buf(), vec![]);
+        let err = mgr.remove("no-such-plugin").unwrap_err();
+        assert!(matches!(err, PluginError::NotFound { .. }));
+    }
+
+    #[test]
+    fn invalid_plugin_name_with_slash_rejected() {
+        let err = validate_plugin_name("foo/bar").unwrap_err();
+        assert!(matches!(err, PluginError::InvalidName { .. }));
+    }
+
+    #[test]
+    fn plugin_name_with_uppercase_rejected() {
+        let err = validate_plugin_name("FooBar").unwrap_err();
+        assert!(matches!(err, PluginError::InvalidName { .. }));
+    }
+
+    #[test]
+    fn valid_plugin_names_accepted() {
+        assert!(validate_plugin_name("foo").is_ok());
+        assert!(validate_plugin_name("foo-bar").is_ok());
+        assert!(validate_plugin_name("foo123").is_ok());
+    }
+
+    #[test]
+    fn bundled_skill_conflict_detected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source");
+
+        // Find a real bundled skill name to trigger conflict.
+        let bundled = bundled_skill_names();
+        if bundled.is_empty() {
+            // No bundled skills compiled in; skip.
+            return;
+        }
+        let conflict_name = &bundled[0];
+
+        let manifest = format!(
+            r#"[plugin]
+name = "conflict-test"
+version = "0.1.0"
+description = "test"
+
+[[skills]]
+path = "skills/{conflict_name}"
+"#
+        );
+        write_plugin(
+            &source,
+            "conflict-test",
+            &manifest,
+            &[(conflict_name, "body")],
+        );
+
+        let plugins_dir = tmp.path().join("plugins");
+        let managed_dir = tmp.path().join("managed");
+        let mgr = PluginManager::new(plugins_dir, managed_dir, vec![]);
+
+        let err = mgr.add(source.to_str().unwrap()).unwrap_err();
+        assert!(matches!(
+            err,
+            PluginError::SkillNameConflictWithBundled { .. }
+        ));
+    }
+
+    #[test]
+    fn path_traversal_in_skill_path_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source");
+        let manifest = r#"[plugin]
+name = "traversal-test"
+version = "0.1.0"
+description = "test"
+
+[[skills]]
+path = "../../../etc/passwd"
+"#;
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::write(source.join("plugin.toml"), manifest).unwrap();
+
+        let plugins_dir = tmp.path().join("plugins");
+        let managed_dir = tmp.path().join("managed");
+        let mgr = PluginManager::new(plugins_dir, managed_dir, vec![]);
+
+        let err = mgr.add(source.to_str().unwrap()).unwrap_err();
+        assert!(
+            matches!(err, PluginError::InvalidSource { .. }),
+            "expected InvalidSource for path traversal, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn mcp_basename_bypass_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source");
+        // allowed_commands = ["npx"] but plugin declares full path "/tmp/evil/npx".
+        // Verbatim match must reject this; the old file_name() fallback would have passed it.
+        let manifest = r#"[plugin]
+name = "basename-bypass"
+version = "0.1.0"
+description = "test"
+
+[[mcp.servers]]
+id = "evil"
+command = "/tmp/evil/npx"
+"#;
+        write_plugin(&source, "basename-bypass", manifest, &[]);
+
+        let plugins_dir = tmp.path().join("plugins");
+        let managed_dir = tmp.path().join("managed");
+        let mgr = PluginManager::new(plugins_dir, managed_dir, vec!["npx".to_owned()]);
+
+        let err = mgr.add(source.to_str().unwrap()).unwrap_err();
+        assert!(
+            matches!(err, PluginError::DisallowedMcpCommand { .. }),
+            "expected DisallowedMcpCommand for basename bypass, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn managed_skill_conflict_detected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let managed_dir = tmp.path().join("managed");
+
+        // Create a managed skill named "my-skill".
+        let managed_skill = managed_dir.join("my-skill");
+        std::fs::create_dir_all(&managed_skill).unwrap();
+        std::fs::write(
+            managed_skill.join("SKILL.md"),
+            "---\nname: my-skill\ndescription: managed\n---\nbody",
+        )
+        .unwrap();
+
+        // Plugin tries to install a skill with the same name.
+        let source = tmp.path().join("source");
+        write_plugin(
+            &source,
+            "conflict-managed",
+            &simple_manifest("conflict-managed", "my-skill"),
+            &[("my-skill", "body")],
+        );
+
+        let plugins_dir = tmp.path().join("plugins");
+        let mgr = PluginManager::new(plugins_dir, managed_dir, vec![]);
+
+        let err = mgr.add(source.to_str().unwrap()).unwrap_err();
+        assert!(
+            matches!(err, PluginError::SkillNameConflictWithManaged { .. }),
+            "expected SkillNameConflictWithManaged, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn cross_plugin_skill_conflict_detected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let plugins_dir = tmp.path().join("plugins");
+        let managed_dir = tmp.path().join("managed");
+        let mgr = PluginManager::new(plugins_dir, managed_dir, vec![]);
+
+        // Install first plugin with "shared-skill".
+        let source_a = tmp.path().join("source_a");
+        write_plugin(
+            &source_a,
+            "plugin-a",
+            &simple_manifest("plugin-a", "shared-skill"),
+            &[("shared-skill", "body")],
+        );
+        mgr.add(source_a.to_str().unwrap()).unwrap();
+
+        // Install second plugin with the same skill name — must conflict.
+        let source_b = tmp.path().join("source_b");
+        write_plugin(
+            &source_b,
+            "plugin-b",
+            &simple_manifest("plugin-b", "shared-skill"),
+            &[("shared-skill", "body")],
+        );
+        let err = mgr.add(source_b.to_str().unwrap()).unwrap_err();
+        assert!(
+            matches!(err, PluginError::SkillNameConflictWithPlugin { .. }),
+            "expected SkillNameConflictWithPlugin, got {err:?}"
+        );
+    }
+}

--- a/crates/zeph-plugins/src/manifest.rs
+++ b/crates/zeph-plugins/src/manifest.rs
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `plugin.toml` manifest schema.
+
+use serde::{Deserialize, Serialize};
+
+fn default_config_table() -> toml::Value {
+    toml::Value::Table(toml::map::Map::new())
+}
+
+/// Top-level `plugin.toml` manifest.
+///
+/// # Example
+///
+/// ```toml
+/// [plugin]
+/// name = "git-workflows"
+/// version = "0.1.0"
+/// description = "Git workflow skills and MCP git server"
+/// zeph-version = ">=0.19"
+///
+/// [[skills]]
+/// path = "skills/git-commit"
+///
+/// [[mcp.servers]]
+/// id = "git"
+/// command = "mcp-git"
+/// args = ["--repo", "."]
+///
+/// [config.tools]
+/// blocked_commands = ["git push --force"]
+/// ```
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PluginManifest {
+    /// Plugin metadata.
+    pub plugin: PluginMeta,
+    /// Skill entries bundled by this plugin.
+    #[serde(default)]
+    pub skills: Vec<SkillEntry>,
+    /// MCP server declarations.
+    #[serde(default)]
+    pub mcp: McpSection,
+    /// Tighten-only config overlay applied at startup.
+    #[serde(default = "default_config_table")]
+    pub config: toml::Value,
+}
+
+/// Plugin metadata from the `[plugin]` table.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PluginMeta {
+    /// Canonical plugin name. Must be a valid identifier: `[a-z0-9][a-z0-9-]*`.
+    pub name: String,
+    /// Plugin version (informational).
+    pub version: String,
+    /// Short description shown in `zeph plugin list`.
+    #[serde(default)]
+    pub description: String,
+    // zeph-version field intentionally omitted: version-gating is deferred to a future release
+    // when the semver crate is added as a workspace dependency.
+}
+
+/// A single skill entry in `[[skills]]`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SkillEntry {
+    /// Relative path from the plugin root to the skill directory containing `SKILL.md`.
+    pub path: String,
+}
+
+/// The `[mcp]` section.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct McpSection {
+    /// MCP server declarations in `[[mcp.servers]]`.
+    #[serde(default)]
+    pub servers: Vec<PluginMcpServer>,
+}
+
+/// A single MCP server declaration in `[[mcp.servers]]`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PluginMcpServer {
+    /// Unique server ID. Used to de-duplicate across plugins.
+    pub id: String,
+    /// Command to spawn (stdio transport). Must be in `mcp.allowed_commands`.
+    #[serde(default)]
+    pub command: Option<String>,
+    /// Arguments passed to `command`.
+    #[serde(default)]
+    pub args: Vec<String>,
+}

--- a/crates/zeph-skills/src/registry.rs
+++ b/crates/zeph-skills/src/registry.rs
@@ -616,7 +616,8 @@ mod tests {
         let hub_dir = tempfile::tempdir().unwrap();
         let path = hub_dir.path().to_path_buf();
 
-        let mut registry = SkillRegistry::load(&[path.clone()]).with_hub_dirs([path.clone()]);
+        let mut registry =
+            SkillRegistry::load(std::slice::from_ref(&path)).with_hub_dirs([path.clone()]);
         registry.register_hub_dir(path.clone());
         registry.register_hub_dir(path);
 

--- a/crates/zeph-tools/src/permissions.rs
+++ b/crates/zeph-tools/src/permissions.rs
@@ -43,6 +43,8 @@ const READONLY_TOOLS: &[&str] = &[
     "list_directory",
     "web_scrape",
     "fetch",
+    "load_skill",
+    "invoke_skill",
 ];
 
 /// Tool permission policy: maps `tool_id` → ordered list of rules.

--- a/crates/zeph-tools/src/sandbox/mod.rs
+++ b/crates/zeph-tools/src/sandbox/mod.rs
@@ -258,6 +258,7 @@ pub fn build_sandbox(strict: bool) -> Result<Box<dyn Sandbox>, SandboxError> {
 
 #[cfg(test)]
 mod tests {
+    #[allow(unused_imports)]
     use super::*;
 
     #[test]

--- a/crates/zeph-tools/src/trust_gate.rs
+++ b/crates/zeph-tools/src/trust_gate.rs
@@ -774,4 +774,17 @@ mod tests {
         assert!(gate.is_mcp_tool("test_tool"));
         assert!(!gate.is_mcp_tool("other_tool"));
     }
+
+    // M9: document that the suffix matcher applies to MCP tools ending with
+    // `_invoke_skill` or `_load_skill`. Future MCP tool authors should be aware.
+    #[test]
+    fn invoke_skill_and_load_skill_suffix_match_is_intentional() {
+        // Exact-match branch: native tool IDs are denied.
+        assert!(is_quarantine_denied("invoke_skill"));
+        assert!(is_quarantine_denied("load_skill"));
+        // Suffix-match branch: hypothetical MCP-prefixed versions are also denied.
+        // This is intentional — prevents a renamed MCP wrapper from bypassing the gate.
+        assert!(is_quarantine_denied("foo_invoke_skill"));
+        assert!(is_quarantine_denied("foo_load_skill"));
+    }
 }

--- a/crates/zeph-tui/src/app.rs
+++ b/crates/zeph-tui/src/app.rs
@@ -1746,6 +1746,11 @@ impl App {
             TuiCommand::MemoryTreeStats => {
                 let _ = self.user_input_tx.try_send("/memory tree".to_owned());
             }
+            TuiCommand::PluginList => {
+                let _ = self.user_input_tx.try_send("/plugins list".to_owned());
+            }
+            TuiCommand::PluginAdd => self.prefill_input("/plugins add "),
+            TuiCommand::PluginRemove => self.prefill_input("/plugins remove "),
             _ => {}
         }
     }

--- a/crates/zeph-tui/src/command.rs
+++ b/crates/zeph-tui/src/command.rs
@@ -98,6 +98,10 @@ pub enum TuiCommand {
     MemoryTreeStats,
     // Task registry panel (#2962)
     TaskPanel,
+    // Plugin management (#2806)
+    PluginList,
+    PluginAdd,
+    PluginRemove,
 }
 
 /// Metadata for a single entry in the command palette.
@@ -143,6 +147,7 @@ pub struct CommandEntry {
 /// assert!(registry.iter().any(|e| e.id == "app:quit"));
 /// ```
 #[must_use]
+#[allow(clippy::too_many_lines)]
 pub fn command_registry() -> &'static [CommandEntry] {
     static COMMANDS: &[CommandEntry] = &[
         CommandEntry {
@@ -235,6 +240,27 @@ pub fn command_registry() -> &'static [CommandEntry] {
             category: "view",
             shortcut: None,
             command: TuiCommand::TaskPanel,
+        },
+        CommandEntry {
+            id: "plugin:list",
+            label: "List installed plugins (/plugins list)",
+            category: "plugin",
+            shortcut: None,
+            command: TuiCommand::PluginList,
+        },
+        CommandEntry {
+            id: "plugin:add",
+            label: "Install a plugin (/plugins add <source>)",
+            category: "plugin",
+            shortcut: None,
+            command: TuiCommand::PluginAdd,
+        },
+        CommandEntry {
+            id: "plugin:remove",
+            label: "Remove an installed plugin (/plugins remove <name>)",
+            category: "plugin",
+            shortcut: None,
+            command: TuiCommand::PluginRemove,
         },
     ];
     COMMANDS
@@ -689,7 +715,7 @@ mod tests {
 
     #[test]
     fn registry_has_twelve_commands() {
-        assert_eq!(command_registry().len(), 13);
+        assert_eq!(command_registry().len(), 16);
     }
 
     #[test]

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -20,6 +20,7 @@ pub use provider::{
 };
 pub use skills::{
     create_embedding_provider, create_skill_matcher, effective_embedding_model, managed_skills_dir,
+    plugins_dir,
 };
 
 use std::path::{Path, PathBuf};
@@ -594,7 +595,21 @@ impl AppBuilder {
         let mut paths: Vec<PathBuf> = self.config.skills.paths.iter().map(PathBuf::from).collect();
         let managed_dir = managed_skills_dir();
         if !paths.contains(&managed_dir) {
-            paths.push(managed_dir);
+            paths.push(managed_dir.clone());
+        }
+        // Append per-plugin skill directories so the registry loads plugin skills at startup.
+        let plugins_dir = plugins_dir();
+        let mgr = zeph_plugins::PluginManager::new(
+            plugins_dir,
+            managed_dir,
+            self.config.mcp.allowed_commands.clone(),
+        );
+        if let Ok(plugin_skill_dirs) = mgr.collect_skill_dirs() {
+            for dir in plugin_skill_dirs {
+                if !paths.contains(&dir) {
+                    paths.push(dir);
+                }
+            }
         }
         paths
     }

--- a/src/bootstrap/skills.rs
+++ b/src/bootstrap/skills.rs
@@ -98,3 +98,11 @@ pub fn create_embedding_provider(config: &Config, primary: &AnyProvider) -> AnyP
 pub fn managed_skills_dir() -> PathBuf {
     zeph_core::vault::default_vault_dir().join("skills")
 }
+
+/// Returns the default plugins directory: `~/.local/share/zeph/plugins/`.
+///
+/// Delegates to [`zeph_plugins::PluginManager::default_plugins_dir`] so there is a single
+/// canonical source of truth used by both the CLI and the TUI path in `zeph-core`.
+pub fn plugins_dir() -> PathBuf {
+    zeph_plugins::PluginManager::default_plugins_dir()
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -213,6 +213,11 @@ pub(crate) enum Command {
         #[command(subcommand)]
         command: SkillCommand,
     },
+    /// Manage plugins (bundled skills + MCP servers)
+    Plugin {
+        #[command(subcommand)]
+        command: PluginCommand,
+    },
     /// Manage memory snapshots
     Memory {
         #[command(subcommand)]
@@ -397,6 +402,30 @@ pub(crate) enum SkillCommand {
     /// Unblock a skill (sets to quarantined)
     Unblock {
         /// Skill name
+        name: String,
+    },
+    /// Preview a skill body with trust-aware sanitization (same pipeline as the agent)
+    Invoke {
+        /// Skill name
+        name: String,
+        /// Optional arguments appended as <args>…</args> block
+        #[arg(long)]
+        args: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+pub(crate) enum PluginCommand {
+    /// List installed plugins
+    List,
+    /// Install a plugin from a local directory path
+    Add {
+        /// Local directory path to the plugin root (must contain plugin.toml)
+        source: String,
+    },
+    /// Remove an installed plugin
+    Remove {
+        /// Plugin name
         name: String,
     },
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod doctor;
 pub(crate) mod ingest;
 pub(crate) mod memory;
 pub(crate) mod migrate;
+pub(crate) mod plugin;
 pub(crate) mod router;
 #[cfg(feature = "scheduler")]
 pub(crate) mod schedule;

--- a/src/commands/plugin.rs
+++ b/src/commands/plugin.rs
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::cli::PluginCommand;
+
+/// Handle `zeph plugin` subcommands.
+///
+/// # Errors
+///
+/// Returns an error if the plugin operation fails (invalid manifest, conflicts, etc.).
+pub(crate) fn handle_plugin_command(
+    cmd: PluginCommand,
+    config_path: Option<&std::path::Path>,
+) -> anyhow::Result<()> {
+    use crate::bootstrap::resolve_config_path;
+
+    let config_file = resolve_config_path(config_path);
+    let config = zeph_core::config::Config::load(&config_file).unwrap_or_default();
+
+    let plugins_dir = crate::bootstrap::plugins_dir();
+    std::fs::create_dir_all(&plugins_dir)
+        .map_err(|e| anyhow::anyhow!("failed to create plugins dir: {e}"))?;
+
+    let managed_skills_dir = crate::bootstrap::managed_skills_dir();
+    let mcp_allowed = config.mcp.allowed_commands.clone();
+
+    let mgr = zeph_plugins::PluginManager::new(plugins_dir, managed_skills_dir, mcp_allowed);
+
+    match cmd {
+        PluginCommand::List => {
+            let installed = mgr.list_installed()?;
+            if installed.is_empty() {
+                println!("No plugins installed.");
+            } else {
+                for p in &installed {
+                    println!("{} v{} — {}", p.name, p.version, p.description);
+                }
+            }
+        }
+
+        PluginCommand::Add { source } => {
+            let result = mgr.add(&source)?;
+            println!("Installed plugin \"{}\".", result.name);
+            if !result.installed_skills.is_empty() {
+                println!("  Skills: {}", result.installed_skills.join(", "));
+            }
+            if !result.mcp_server_ids.is_empty() {
+                println!(
+                    "  MCP servers (restart required): {}",
+                    result.mcp_server_ids.join(", ")
+                );
+            }
+            // Pointer to plugin add for future users.
+            println!(
+                "\nPlugins are managed separately. Run `zeph plugin add <source>` to install more."
+            );
+        }
+
+        PluginCommand::Remove { name } => {
+            let result = mgr.remove(&name)?;
+            println!("Removed plugin \"{name}\".");
+            if !result.removed_skills.is_empty() {
+                println!("  Removed skills: {}", result.removed_skills.join(", "));
+            }
+            if !result.removed_mcp_ids.is_empty() {
+                println!(
+                    "  MCP servers removed (restart required): {}",
+                    result.removed_mcp_ids.join(", ")
+                );
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/commands/skill.rs
+++ b/src/commands/skill.rs
@@ -283,6 +283,57 @@ pub(crate) async fn handle_skill_command(
                 anyhow::bail!("skill \"{name}\" not found in trust database");
             }
         }
+
+        SkillCommand::Invoke { name, args } => {
+            use std::str::FromStr;
+
+            use zeph_common::SkillTrustLevel;
+            use zeph_skills::prompt::{sanitize_skill_text, wrap_quarantined};
+
+            let registry = zeph_skills::registry::SkillRegistry::load(&[managed_dir]);
+
+            // Resolve persisted trust from SQLite. No trust row → Quarantined (fail-closed,
+            // matches `SkillTrustLevel::default`).
+            let trust = {
+                let store = zeph_memory::store::SqliteStore::new(&sqlite_path)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("failed to open SQLite: {e}"))?;
+                store
+                    .load_skill_trust(&name)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{e}"))?
+                    .and_then(|r| SkillTrustLevel::from_str(&r.trust_level).ok())
+                    .unwrap_or_default()
+            };
+
+            if trust == SkillTrustLevel::Blocked {
+                anyhow::bail!("skill is blocked by policy: {name}");
+            }
+
+            let raw = registry
+                .get_body(&name)
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+                .to_owned();
+
+            let sanitized = if trust == SkillTrustLevel::Trusted {
+                raw
+            } else {
+                sanitize_skill_text(&raw)
+            };
+            let body = if trust == SkillTrustLevel::Quarantined {
+                wrap_quarantined(&name, &sanitized)
+            } else {
+                sanitized
+            };
+
+            match args {
+                Some(a) => {
+                    let args_safe = sanitize_skill_text(&a);
+                    println!("{body}\n\n<args>\n{args_safe}\n</args>");
+                }
+                None => println!("{body}"),
+            }
+        }
     }
 
     Ok(())

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -375,6 +375,14 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         Some(Command::Skill { command: skill_cmd }) => {
             return handle_skill_command(skill_cmd, cli.config.as_deref()).await;
         }
+        Some(Command::Plugin {
+            command: plugin_cmd,
+        }) => {
+            return crate::commands::plugin::handle_plugin_command(
+                plugin_cmd,
+                cli.config.as_deref(),
+            );
+        }
         Some(Command::Memory { command: mem_cmd }) => {
             return handle_memory_command(mem_cmd, cli.config.as_deref()).await;
         }
@@ -1269,16 +1277,28 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     .with_conversation(conversation_id.0);
     let skill_loader_executor =
         zeph_core::SkillLoaderExecutor::new(std::sync::Arc::clone(&registry));
+    // Pre-allocate trust snapshot Arc shared between the agent's SkillState and
+    // SkillInvokeExecutor — written once per turn by prepare_context, read by the executor.
+    let trust_snapshot: std::sync::Arc<
+        parking_lot::RwLock<std::collections::HashMap<String, zeph_tools::SkillTrustLevel>>,
+    > = std::sync::Arc::new(parking_lot::RwLock::new(std::collections::HashMap::new()));
+    let skill_invoke_executor = zeph_core::SkillInvokeExecutor::new(
+        std::sync::Arc::clone(&registry),
+        std::sync::Arc::clone(&trust_snapshot),
+    );
     let base: std::sync::Arc<dyn zeph_tools::ErasedToolExecutor> =
         std::sync::Arc::new(tool_setup.executor);
     let inner_executor =
         zeph_tools::DynExecutor(std::sync::Arc::new(zeph_tools::CompositeExecutor::new(
             skill_loader_executor,
             zeph_tools::CompositeExecutor::new(
-                memory_executor,
+                skill_invoke_executor,
                 zeph_tools::CompositeExecutor::new(
-                    overflow_executor,
-                    zeph_tools::DynExecutor(base),
+                    memory_executor,
+                    zeph_tools::CompositeExecutor::new(
+                        overflow_executor,
+                        zeph_tools::DynExecutor(base),
+                    ),
                 ),
             ),
         )));
@@ -1547,6 +1567,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     .with_skill_reload(skill_paths.clone(), reload_rx)
     .with_managed_skills_dir(crate::bootstrap::managed_skills_dir())
     .with_trust_config(config.skills.trust.clone())
+    .with_trust_snapshot(trust_snapshot)
     .with_memory(
         std::sync::Arc::clone(&memory),
         conversation_id,


### PR DESCRIPTION
## Summary

- Adds `invoke_skill` tool (`SkillInvokeExecutor`) in `zeph-core` — the agent can now self-invoke registered skills by name during its reasoning loop, with a trust-aware sanitization pipeline (closes #3105)
- Adds new `zeph-plugins` crate with `PluginManager` for install/remove/list of plugin packages bundling SKILL.md files, MCP server entries, and config overlays (closes #2806)

## Details

**SkillInvokeTool:**
- `crates/zeph-core/src/skill_invoker.rs` — `SkillInvokeExecutor` wired into `CompositeExecutor`
- Blocked skills refused; non-Trusted bodies sanitized; Quarantined bodies wrapped
- `invoke_skill` and `load_skill` added to `QUARANTINE_DENIED`
- Blocked skills filtered from the skill catalog in `assembly.rs` (two-layer defense)
- CLI: `zeph skill invoke <name> [--args ...]`

**Plugin packaging:**
- `crates/zeph-plugins/` — `PluginManager`, `plugin.toml` manifest format
- Tighten-only config overlay validation (union/intersection/max semantics, unknown keys hard-error)
- Path traversal defense: canonicalize + `starts_with(root)` at install and runtime
- MCP command verbatim match only (no basename fallback)
- Recursive watcher on `plugins_dir` root for hot-reload
- CLI: `zeph plugin list|add|remove`; TUI: `/plugins list|add|remove`

**Note:** Runtime merging of plugin config overlays into the live `Config` struct is deferred to a follow-up PR.

## Test plan

- [ ] `cargo nextest run --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 8427/8427 pass
- [ ] `cargo clippy --workspace --features "desktop,ide,server,chat,pdf,scheduler" -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean
- [ ] Live test playbook: `.local/testing/playbooks/skill-invoke-and-plugins.md`
- [ ] P3 follow-ups filed: `register_hub_dir` for plugin trees, `copy_dir_all` symlink handling, runtime config overlay merge