### PR TITLE
feat(security): harden file permissions for sensitive Zeph files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **feat(security): OS-level file permission hardening for sensitive files** — adds
+  `zeph-common::fs_secure` module with `open_private_truncate`, `append_private`,
+  `write_private`, and `atomic_write_private` helpers. All sensitive files created by
+  Zeph (vault secrets, SQLite databases, debug dumps, audit JSONL, router state, ACP
+  permission files, init config) are now created with mode 0600 (owner read/write only),
+  independent of process umask. `atomic_write_private` uses `O_EXCL` on the temp file
+  and fsyncs before rename for crash safety. `zeph doctor` now reports a warning when
+  the vault file has group/world-readable bits set and correctly fails on unexpected
+  metadata errors. Closes [#3121](https://github.com/bug-ops/zeph/issues/3121).
+
 - **feat(llm): configurable prompt cache TTL with 1-hour Claude variant** — adds `CacheTtl` enum
   (`Ephemeral` | `OneHour`) to `zeph-llm`. Setting `prompt_cache_ttl = "1h"` in a Claude provider
   block enables the `extended-cache-ttl-2025-04-25` beta and extends cached prefix lifetime to 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10035,6 +10035,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "uuid",
+ "zeph-common",
  "zeph-core",
  "zeph-llm",
  "zeph-mcp",
@@ -10099,6 +10100,7 @@ dependencies = [
  "blake3",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -10219,11 +10221,13 @@ version = "0.19.1"
 dependencies = [
  "regex",
  "sqlx",
+ "tempfile",
  "testcontainers",
  "testcontainers-modules",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "zeph-common",
 ]
 
 [[package]]
@@ -10546,6 +10550,7 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "tracing",
  "uuid",
+ "zeph-common",
  "zeph-config",
  "zeph-llm",
  "zeph-skills",

--- a/crates/zeph-acp/Cargo.toml
+++ b/crates/zeph-acp/Cargo.toml
@@ -59,6 +59,7 @@ tower = { workspace = true, features = ["util"], optional = true }
 tower-http = { workspace = true, features = ["cors", "limit"], optional = true }
 tracing.workspace = true
 uuid = { workspace = true, features = ["v4"] }
+zeph-common.workspace = true
 zeph-core.workspace = true
 zeph-llm.workspace = true
 zeph-memory.workspace = true

--- a/crates/zeph-acp/src/permission.rs
+++ b/crates/zeph-acp/src/permission.rs
@@ -175,18 +175,8 @@ fn save_persisted(path: &Path, perms: &PersistedPermissions) {
         );
         return;
     }
-    let tmp = path.with_added_extension(format!("{}.tmp", std::process::id()));
-    if let Err(e) = std::fs::write(&tmp, &content) {
-        warn!("failed to write ACP permission tmp file: {e}");
-        return;
-    }
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600));
-    }
-    if let Err(e) = std::fs::rename(&tmp, path) {
-        warn!("failed to rename ACP permission file: {e}");
+    if let Err(e) = zeph_common::fs_secure::atomic_write_private(path, content.as_bytes()) {
+        warn!("failed to write ACP permission file: {e}");
     }
 }
 

--- a/crates/zeph-common/Cargo.toml
+++ b/crates/zeph-common/Cargo.toml
@@ -41,6 +41,7 @@ tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json.workspace = true
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/zeph-common/src/fs_secure.rs
+++ b/crates/zeph-common/src/fs_secure.rs
@@ -1,0 +1,341 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Filesystem helpers that create files with owner-only permissions (0o600) on Unix.
+//!
+//! Every sensitive file written by Zeph (vault ciphertext, audit JSONL, debug dumps,
+//! router state, transcript sidecars) must be created through one of these helpers so
+//! that the permission guarantee is auditable in a single location.
+//!
+//! # Unix vs non-Unix
+//!
+//! On Unix the helpers set mode `0o600` via [`OpenOptionsExt::mode`]. On non-Unix
+//! platforms (Windows) the helpers fall back to plain [`OpenOptions`] without extra
+//! permissions — Windows uses ACLs rather than mode bits, and proper ACL hardening
+//! requires additional platform-specific code (TODO: tracked for a follow-up issue).
+//! The Windows fallback is **not atomic** for [`atomic_write_private`]: `std::fs::rename`
+//! fails with `ERROR_ALREADY_EXISTS` when the destination already exists, unlike the
+//! POSIX atomic-replace semantics.
+//!
+//! # Residual risks
+//!
+//! - The fixed `.tmp` suffix in [`atomic_write_private`] is a symlink-race target on
+//!   shared directories. Callers that open files in directories they do not own must
+//!   use `tempfile::NamedTempFile::persist` instead.
+//! - `SQLite` WAL/SHM sidecar files (`.db-wal`, `.db-shm`) are created by sqlx after the
+//!   pool opens and inherit the process umask. There is no way to prevent this without
+//!   upstream sqlx support; see `zeph-db` for best-effort post-open chmod.
+
+use std::fs::{File, OpenOptions};
+use std::io::{self, Write};
+use std::path::Path;
+
+/// Create or truncate `path` with owner-read/write-only permissions on Unix (0o600).
+///
+/// Returns a writable [`File`] handle. The caller is responsible for writing content
+/// and flushing. Use [`write_private`] for a one-shot write convenience.
+///
+/// On non-Unix platforms falls back to standard `OpenOptions` without extra permissions.
+///
+/// # Errors
+///
+/// Returns the underlying [`io::Error`] if the file cannot be opened or created.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::io::Write as _;
+/// use zeph_common::fs_secure;
+///
+/// let mut f = fs_secure::open_private_truncate(std::path::Path::new("/tmp/secret.txt"))?;
+/// f.write_all(b"hello")?;
+/// f.flush()?;
+/// # Ok::<(), std::io::Error>(())
+/// ```
+pub fn open_private_truncate(path: &Path) -> io::Result<File> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)
+    }
+    #[cfg(not(unix))]
+    {
+        OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(path)
+    }
+}
+
+/// Open `path` in append mode, creating it with mode 0o600 on Unix if it does not exist.
+///
+/// Subsequent opens of an existing file do not change its permissions. Use this helper
+/// for JSONL log files (audit, transcript) that grow across multiple process invocations.
+///
+/// # Errors
+///
+/// Returns the underlying [`io::Error`] if the file cannot be opened or created.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::io::Write as _;
+/// use zeph_common::fs_secure;
+///
+/// let mut f = fs_secure::append_private(std::path::Path::new("/tmp/audit.jsonl"))?;
+/// writeln!(f, r#"{{"event":"start"}}"#)?;
+/// # Ok::<(), std::io::Error>(())
+/// ```
+pub fn append_private(path: &Path) -> io::Result<File> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        OpenOptions::new()
+            .create(true)
+            .append(true)
+            .mode(0o600)
+            .open(path)
+    }
+    #[cfg(not(unix))]
+    {
+        OpenOptions::new().create(true).append(true).open(path)
+    }
+}
+
+/// Write `data` to `path`, creating or truncating the file with mode 0o600 on Unix.
+///
+/// This is a one-shot convenience wrapper around [`open_private_truncate`] that handles
+/// `write_all` and `flush`. For streaming writes use [`open_private_truncate`] directly.
+///
+/// # Errors
+///
+/// Returns the underlying [`io::Error`] if the file cannot be created, written to, or
+/// flushed.
+///
+/// # Examples
+///
+/// ```no_run
+/// use zeph_common::fs_secure;
+///
+/// fs_secure::write_private(std::path::Path::new("/tmp/dump.json"), b"{}")?;
+/// # Ok::<(), std::io::Error>(())
+/// ```
+pub fn write_private(path: &Path, data: &[u8]) -> io::Result<()> {
+    let mut f = open_private_truncate(path)?;
+    f.write_all(data)?;
+    f.flush()
+}
+
+/// Write `data` to `path` via a crash-safe replace: write to `<path>.tmp` (0o600 on
+/// Unix), fsync the tmp file, rename it over the target, then fsync the parent directory.
+///
+/// Using [`Path::with_added_extension`] preserves the original extension:
+/// `secrets.age` → `secrets.age.tmp` (not `secrets.tmp`).
+///
+/// On error during write or rename the `.tmp` file is removed to avoid orphan sidecars.
+/// Any stale `.tmp` from a prior crash is removed before creating the exclusive tmp file.
+///
+/// # Errors
+///
+/// Returns the underlying [`io::Error`] if any step fails. The target file is untouched
+/// when an error is returned.
+///
+/// # Examples
+///
+/// ```no_run
+/// use zeph_common::fs_secure;
+///
+/// fs_secure::atomic_write_private(std::path::Path::new("/tmp/state.json"), b"{}")?;
+/// # Ok::<(), std::io::Error>(())
+/// ```
+pub fn atomic_write_private(path: &Path, data: &[u8]) -> io::Result<()> {
+    let tmp = path.with_added_extension("tmp");
+
+    // Remove any stale .tmp leftover (crash or attacker symlink) before creating
+    // the tmp file exclusively. remove_file on a symlink removes the symlink itself,
+    // not the target, so O_EXCL then succeeds safely.
+    let _ = std::fs::remove_file(&tmp);
+
+    // Write and fsync the tmp file; clean up on any error.
+    let write_result = (|| -> io::Result<()> {
+        let mut f = open_private_exclusive(&tmp)?;
+        f.write_all(data)?;
+        f.flush()?;
+        f.sync_all()?;
+        Ok(())
+    })();
+    if let Err(e) = write_result {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
+
+    // Atomic rename; clean up tmp on failure.
+    std::fs::rename(&tmp, path).inspect_err(|_| {
+        let _ = std::fs::remove_file(&tmp);
+    })?;
+
+    // Fsync the parent directory so the rename is durable.
+    if let Some(parent) = path.parent()
+        && let Ok(dir) = File::open(parent)
+    {
+        let _ = dir.sync_all();
+    }
+
+    Ok(())
+}
+
+/// Create `path` exclusively (`O_EXCL` / `create_new`) with 0o600 on Unix.
+///
+/// Used internally by [`atomic_write_private`] for the `.tmp` file so that a
+/// pre-existing leftover or attacker-placed symlink is never silently followed.
+fn open_private_exclusive(path: &Path) -> io::Result<File> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(path)
+    }
+    #[cfg(not(unix))]
+    {
+        OpenOptions::new().write(true).create_new(true).open(path)
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt as _;
+
+    fn mode(path: &Path) -> u32 {
+        std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+    }
+
+    #[test]
+    fn write_private_creates_0600() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("secret.txt");
+        write_private(&p, b"hello").unwrap();
+        assert_eq!(mode(&p), 0o600);
+        assert_eq!(std::fs::read(&p).unwrap(), b"hello");
+    }
+
+    #[test]
+    fn atomic_write_private_overwrites_with_0600() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("state.json");
+        // Pre-create with 0o644 to verify the replace changes the mode.
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .mode(0o644)
+                .open(&p)
+                .unwrap()
+                .write_all(b"old")
+                .unwrap();
+        }
+        atomic_write_private(&p, b"new").unwrap();
+        assert_eq!(mode(&p), 0o600);
+        assert_eq!(std::fs::read(&p).unwrap(), b"new");
+    }
+
+    #[test]
+    fn atomic_write_private_preserves_extension_appends_tmp() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("vault.age");
+        // The tmp path must be "vault.age.tmp", not "vault.tmp".
+        let tmp = p.with_added_extension("tmp");
+        assert_eq!(tmp.file_name().unwrap(), "vault.age.tmp");
+        atomic_write_private(&p, b"data").unwrap();
+        assert!(p.exists());
+        assert!(!tmp.exists(), "tmp must be cleaned up after success");
+    }
+
+    #[test]
+    fn atomic_write_private_cleans_tmp_on_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("data.json");
+        atomic_write_private(&p, b"{}").unwrap();
+        let tmp = p.with_added_extension("tmp");
+        assert!(!tmp.exists());
+    }
+
+    #[test]
+    fn atomic_write_private_errors_on_unwritable_dir() {
+        // Verify that atomic_write_private returns an error when the directory is
+        // not writable (no writeable dir → cannot create tmp), and the original
+        // target file is untouched.
+        let outer = tempfile::tempdir().unwrap();
+        let inner = outer.path().join("sub");
+        std::fs::create_dir(&inner).unwrap();
+        let p = inner.join("data.json");
+
+        // First write succeeds — establishes the file with content "first".
+        atomic_write_private(&p, b"first").unwrap();
+
+        // Make the directory read-only so the exclusive tmp create fails.
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(&inner, std::fs::Permissions::from_mode(0o500)).unwrap();
+
+        let result = atomic_write_private(&p, b"second");
+        // Restore perms for tempdir cleanup before asserting (avoids double-fault).
+        std::fs::set_permissions(&inner, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        assert!(result.is_err(), "write to read-only dir must fail");
+        // Original file must be untouched.
+        assert_eq!(std::fs::read(&p).unwrap(), b"first");
+    }
+
+    #[test]
+    fn atomic_write_private_stale_tmp_removed_before_write() {
+        // Stale .tmp leftover should be removed before exclusive create.
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("state.json");
+        let tmp = p.with_added_extension("tmp");
+        std::fs::write(&tmp, b"stale").unwrap();
+        atomic_write_private(&p, b"fresh").unwrap();
+        assert_eq!(std::fs::read(&p).unwrap(), b"fresh");
+        assert!(!tmp.exists());
+    }
+
+    #[test]
+    fn append_private_creates_0600_on_new_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("audit.jsonl");
+        {
+            let mut f = append_private(&p).unwrap();
+            writeln!(f, "line1").unwrap();
+        }
+        assert_eq!(mode(&p), 0o600);
+    }
+
+    #[test]
+    fn append_private_preserves_mode_on_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("audit.jsonl");
+        {
+            let mut f = append_private(&p).unwrap();
+            writeln!(f, "line1").unwrap();
+        }
+        {
+            let mut f = append_private(&p).unwrap();
+            writeln!(f, "line2").unwrap();
+        }
+        assert_eq!(mode(&p), 0o600);
+        let content = std::fs::read_to_string(&p).unwrap();
+        assert!(content.contains("line1") && content.contains("line2"));
+    }
+}

--- a/crates/zeph-common/src/fs_secure.rs
+++ b/crates/zeph-common/src/fs_secure.rs
@@ -9,7 +9,7 @@
 //!
 //! # Unix vs non-Unix
 //!
-//! On Unix the helpers set mode `0o600` via [`OpenOptionsExt::mode`]. On non-Unix
+//! On Unix the helpers set mode `0o600` via `OpenOptionsExt::mode`. On non-Unix
 //! platforms (Windows) the helpers fall back to plain [`OpenOptions`] without extra
 //! permissions — Windows uses ACLs rather than mode bits, and proper ACL hardening
 //! requires additional platform-specific code (TODO: tracked for a follow-up issue).

--- a/crates/zeph-common/src/lib.rs
+++ b/crates/zeph-common/src/lib.rs
@@ -11,6 +11,7 @@
 
 pub mod config;
 pub mod error_taxonomy;
+pub mod fs_secure;
 pub mod hash;
 pub mod math;
 pub mod net;

--- a/crates/zeph-core/src/debug_dump/mod.rs
+++ b/crates/zeph-core/src/debug_dump/mod.rs
@@ -76,7 +76,7 @@ impl DebugDumper {
 
     fn write(&self, filename: &str, content: &[u8]) {
         let path = self.dir.join(filename);
-        if let Err(e) = std::fs::write(&path, content) {
+        if let Err(e) = zeph_common::fs_secure::write_private(&path, content) {
             tracing::warn!(path = %path.display(), error = %e, "debug dump write failed");
         }
     }

--- a/crates/zeph-db/Cargo.toml
+++ b/crates/zeph-db/Cargo.toml
@@ -29,8 +29,13 @@ regex = { workspace = true }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt"] }
 tracing.workspace = true
+zeph-common.workspace = true
 testcontainers = { workspace = true, optional = true }
 testcontainers-modules = { workspace = true, features = ["postgres"], optional = true }
+
+[dev-dependencies]
+tempfile.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/crates/zeph-db/src/pool.rs
+++ b/crates/zeph-db/src/pool.rs
@@ -56,10 +56,18 @@ impl DbConfig {
         let url = if path == ":memory:" {
             "sqlite::memory:".to_string()
         } else {
-            if let Some(parent) = std::path::Path::new(path).parent()
+            let db_path = std::path::Path::new(path);
+            if let Some(parent) = db_path.parent()
                 && !parent.as_os_str().is_empty()
             {
                 std::fs::create_dir_all(parent)?;
+            }
+            // Pre-create with 0o600 so sqlx inherits the mode rather than using the
+            // process umask. sqlx reopens the existing file via SQLITE_OPEN_CREATE.
+            // WAL/SHM sidecars are created by sqlx after the pool opens and will still
+            // inherit the process umask (sqlx limitation — best-effort chmod below).
+            if !db_path.exists() {
+                drop(zeph_common::fs_secure::open_private_truncate(db_path)?);
             }
             format!("sqlite:{path}?mode=rwc")
         };
@@ -91,14 +99,21 @@ impl DbConfig {
 
         crate::migrate::run_migrations(&pool).await?;
 
-        // Restrict file permissions to owner-only on Unix.
+        // Best-effort chmod for .db, .db-wal, and .db-shm. The .db itself was
+        // pre-created with 0o600 above; the WAL/SHM sidecars are created by sqlx
+        // after the pool opens and inherit the process umask, so we fix them here.
+        // There is a small race window between sidecar creation and this chmod;
+        // there is no way to close it without upstream sqlx support.
         #[cfg(unix)]
         if path != ":memory:" {
-            use std::os::unix::fs::PermissionsExt;
-            if let Ok(metadata) = std::fs::metadata(path) {
-                let mut perms = metadata.permissions();
-                perms.set_mode(0o600);
-                let _ = std::fs::set_permissions(path, perms);
+            use std::os::unix::fs::PermissionsExt as _;
+            for suffix in &["", "-wal", "-shm", "-journal"] {
+                let p = format!("{path}{suffix}");
+                if let Ok(metadata) = std::fs::metadata(&p) {
+                    let mut perms = metadata.permissions();
+                    perms.set_mode(0o600);
+                    let _ = std::fs::set_permissions(&p, perms);
+                }
             }
         }
 
@@ -181,5 +196,24 @@ mod tests {
     fn redact_url_handles_sqlite_path() {
         let url = "sqlite:/path/to/db";
         assert!(redact_url(url).is_none());
+    }
+
+    #[cfg(all(unix, feature = "sqlite", not(feature = "postgres")))]
+    #[tokio::test]
+    async fn sqlite_precreated_with_0600() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let cfg = DbConfig {
+            url: db_path.to_str().unwrap().to_owned(),
+            max_connections: 1,
+            pool_size: 1,
+        };
+        cfg.connect().await.unwrap();
+        let mode = std::fs::metadata(&db_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "SQLite DB file must be created with mode 0o600"
+        );
     }
 }

--- a/crates/zeph-llm/src/model_cache.rs
+++ b/crates/zeph-llm/src/model_cache.rs
@@ -113,10 +113,8 @@ impl ModelCache {
         };
         let json =
             serde_json::to_vec_pretty(&envelope).map_err(|e| LlmError::Other(e.to_string()))?;
-        let tmp = self.path.with_added_extension("tmp");
-        std::fs::write(&tmp, &json).map_err(|e| LlmError::Other(format!("cache write: {e}")))?;
-        std::fs::rename(&tmp, &self.path)
-            .map_err(|e| LlmError::Other(format!("cache rename: {e}")))?;
+        zeph_common::fs_secure::atomic_write_private(&self.path, &json)
+            .map_err(|e| LlmError::Other(format!("cache write: {e}")))?;
         Ok(())
     }
 

--- a/crates/zeph-llm/src/router/bandit.rs
+++ b/crates/zeph-llm/src/router/bandit.rs
@@ -33,8 +33,6 @@
 //! load. Do not place the state file in world-writable directories.
 
 use std::collections::{HashMap, HashSet};
-#[cfg(unix)]
-use std::io::Write as _;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -426,24 +424,7 @@ impl BanditState {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        // TODO: use randomised suffix (e.g. `tempfile::NamedTempFile`) to avoid
-        // predictable `.tmp` path being a symlink-race target on shared directories.
-        let tmp = path.with_extension("tmp");
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::OpenOptionsExt as _;
-            std::fs::OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .mode(0o600)
-                .open(&tmp)?
-                .write_all(&json)?;
-        }
-        #[cfg(not(unix))]
-        std::fs::write(&tmp, &json)?;
-        std::fs::rename(&tmp, path)?;
-        Ok(())
+        zeph_common::fs_secure::atomic_write_private(path, &json)
     }
 }
 

--- a/crates/zeph-llm/src/router/reputation.rs
+++ b/crates/zeph-llm/src/router/reputation.rs
@@ -18,8 +18,6 @@
 //! - Reputation is not used in Cascade mode (fixed cost tiers, no-op to avoid mutex overhead).
 
 use std::collections::{HashMap, HashSet};
-#[cfg(unix)]
-use std::io::Write as _;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -258,22 +256,7 @@ impl ReputationTracker {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        let tmp = path.with_extension("tmp");
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::OpenOptionsExt;
-            std::fs::OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .mode(0o600)
-                .open(&tmp)?
-                .write_all(&json)?;
-        }
-        #[cfg(not(unix))]
-        std::fs::write(&tmp, &json)?;
-        std::fs::rename(&tmp, path)?;
-        Ok(())
+        zeph_common::fs_secure::atomic_write_private(path, &json)
     }
 }
 

--- a/crates/zeph-llm/src/router/thompson.rs
+++ b/crates/zeph-llm/src/router/thompson.rs
@@ -9,8 +9,6 @@
 //! other's state on shutdown (known limitation, acceptable pre-1.0).
 
 use std::collections::{HashMap, HashSet};
-#[cfg(unix)]
-use std::io::Write as _;
 use std::path::{Path, PathBuf};
 
 use rand::SeedableRng as _;
@@ -272,24 +270,7 @@ impl ThompsonState {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        // TODO: use a randomized suffix (e.g., via `tempfile::NamedTempFile`) to avoid
-        // the predictable `.tmp` path being a symlink-race target on shared directories.
-        let tmp = path.with_extension("tmp");
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::OpenOptionsExt;
-            std::fs::OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .mode(0o600)
-                .open(&tmp)?
-                .write_all(&json)?;
-        }
-        #[cfg(not(unix))]
-        std::fs::write(&tmp, &json)?;
-        std::fs::rename(&tmp, path)?;
-        Ok(())
+        zeph_common::fs_secure::atomic_write_private(path, &json)
     }
 }
 

--- a/crates/zeph-orchestration/src/adaptorch.rs
+++ b/crates/zeph-orchestration/src/adaptorch.rs
@@ -11,7 +11,7 @@
 //! is synchronous and never spawns a task.
 
 use std::collections::HashMap;
-use std::io::{self, Write as _};
+use std::io;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -481,22 +481,7 @@ fn default_arms() -> HashMap<(TaskClass, TopologyHint), BetaDist> {
 }
 
 fn atomic_write(path: &std::path::Path, data: &[u8]) -> io::Result<()> {
-    let tmp = path.with_extension("tmp");
-    {
-        let mut f = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(&tmp)?;
-        f.write_all(data)?;
-        f.flush()?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            f.set_permissions(std::fs::Permissions::from_mode(0o600))?;
-        }
-    }
-    std::fs::rename(&tmp, path)
+    zeph_common::fs_secure::atomic_write_private(path, data)
 }
 
 #[cfg(test)]

--- a/crates/zeph-subagent/Cargo.toml
+++ b/crates/zeph-subagent/Cargo.toml
@@ -25,6 +25,7 @@ tokio = { workspace = true, features = ["fs", "macros", "process", "rt-multi-thr
 tokio-util.workspace = true
 tracing.workspace = true
 uuid = { workspace = true, features = ["v4", "serde"] }
+zeph-common.workspace = true
 zeph-config.workspace = true
 zeph-llm.workspace = true
 zeph-skills.workspace = true

--- a/crates/zeph-subagent/src/transcript.rs
+++ b/crates/zeph-subagent/src/transcript.rs
@@ -12,7 +12,7 @@
 //! The [`sweep_old_transcripts`] function prunes the oldest `.jsonl` files when a
 //! configurable maximum count is exceeded.
 
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, File};
 use std::io::{self, BufRead, BufReader, Write as _};
 use std::path::{Path, PathBuf};
 
@@ -93,7 +93,7 @@ impl TranscriptWriter {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
-        let file = open_private(path)?;
+        let file = zeph_common::fs_secure::append_private(path)?;
         Ok(Self { file })
     }
 
@@ -124,7 +124,7 @@ impl TranscriptWriter {
         let path = dir.join(format!("{agent_id}.meta.json"));
         let content = serde_json::to_string_pretty(meta)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-        write_private(&path, content.as_bytes())
+        zeph_common::fs_secure::write_private(&path, content.as_bytes())
     }
 }
 
@@ -321,47 +321,6 @@ pub fn sweep_old_transcripts(dir: &Path, max_files: usize) -> io::Result<usize> 
         deleted += 1;
     }
     Ok(deleted)
-}
-
-/// Open a file in append mode with owner-only permissions (0o600 on Unix).
-///
-/// On non-Unix platforms falls back to standard `OpenOptions` without extra permissions.
-fn open_private(path: &Path) -> io::Result<File> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt as _;
-        OpenOptions::new()
-            .create(true)
-            .append(true)
-            .mode(0o600)
-            .open(path)
-    }
-    #[cfg(not(unix))]
-    {
-        OpenOptions::new().create(true).append(true).open(path)
-    }
-}
-
-/// Write `contents` to `path` atomically with owner-only permissions (0o600 on Unix).
-///
-/// On non-Unix platforms falls back to `fs::write`.
-fn write_private(path: &Path, contents: &[u8]) -> io::Result<()> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt as _;
-        let mut file = OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .mode(0o600)
-            .open(path)?;
-        file.write_all(contents)?;
-        file.flush()
-    }
-    #[cfg(not(unix))]
-    {
-        fs::write(path, contents)
-    }
 }
 
 /// Returns the current UTC time as an ISO 8601 string (`"YYYY-MM-DDTHH:MM:SSZ"`).

--- a/crates/zeph-tools/src/audit.rs
+++ b/crates/zeph-tools/src/audit.rs
@@ -260,6 +260,7 @@ impl AuditLogger {
     /// # Errors
     ///
     /// Returns an error if a file destination cannot be opened.
+    #[allow(clippy::unused_async)]
     pub async fn from_config(config: &AuditConfig, tui_mode: bool) -> Result<Self, std::io::Error> {
         let effective_dest = if tui_mode && config.destination == "stdout" {
             tracing::warn!("TUI mode: audit stdout redirected to file audit.jsonl");
@@ -271,11 +272,8 @@ impl AuditLogger {
         let destination = if effective_dest == "stdout" {
             AuditDestination::Stdout
         } else {
-            let file = tokio::fs::OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(Path::new(&effective_dest))
-                .await?;
+            let std_file = zeph_common::fs_secure::append_private(Path::new(&effective_dest))?;
+            let file = tokio::fs::File::from_std(std_file);
             AuditDestination::File(tokio::sync::Mutex::new(file))
         };
 

--- a/crates/zeph-vault/src/lib.rs
+++ b/crates/zeph-vault/src/lib.rs
@@ -569,29 +569,11 @@ fn encrypt_secrets(
 }
 
 fn atomic_write(path: &Path, data: &[u8]) -> Result<(), AgeVaultError> {
-    let tmp_path = path.with_added_extension("tmp");
-    std::fs::write(&tmp_path, data).map_err(AgeVaultError::VaultWrite)?;
-    std::fs::rename(&tmp_path, path).map_err(AgeVaultError::VaultWrite)
+    zeph_common::fs_secure::atomic_write_private(path, data).map_err(AgeVaultError::VaultWrite)
 }
 
-#[cfg(unix)]
 fn write_private_file(path: &Path, data: &[u8]) -> Result<(), AgeVaultError> {
-    use std::os::unix::fs::OpenOptionsExt as _;
-    let mut file = std::fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .mode(0o600)
-        .open(path)
-        .map_err(AgeVaultError::KeyWrite)?;
-    file.write_all(data).map_err(AgeVaultError::KeyWrite)
-}
-
-// TODO: Windows does not enforce file permissions via mode bits; the key file is created
-// without access control restrictions. Consider using Windows ACLs in a follow-up.
-#[cfg(not(unix))]
-fn write_private_file(path: &Path, data: &[u8]) -> Result<(), AgeVaultError> {
-    std::fs::write(path, data).map_err(AgeVaultError::KeyWrite)
+    zeph_common::fs_secure::write_private(path, data).map_err(AgeVaultError::KeyWrite)
 }
 
 impl VaultProvider for AgeVaultProvider {
@@ -816,6 +798,26 @@ mod tests {
         assert!(path.exists());
         let tmp = path.with_added_extension("tmp");
         assert_eq!(tmp.file_name().unwrap(), "vault.age.tmp");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn init_vault_sets_0600_on_both_files() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = tempfile::tempdir().unwrap();
+        AgeVaultProvider::init_vault(dir.path()).unwrap();
+        let key_mode = std::fs::metadata(dir.path().join("vault-key.txt"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        let vault_mode = std::fs::metadata(dir.path().join("secrets.age"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(key_mode, 0o600, "vault-key.txt must be 0o600");
+        assert_eq!(vault_mode, 0o600, "secrets.age must be 0o600");
     }
 
     #[test]

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -281,6 +281,43 @@ fn check_vault_key_mode(_key_path: &str) -> CheckResult {
     CheckResult::ok("vault.key_mode", "skipped on non-unix", 0)
 }
 
+#[cfg(unix)]
+fn check_vault_file_mode(vault_path: &str, check_name: &str) -> CheckResult {
+    use std::os::unix::fs::PermissionsExt as _;
+    let start = Instant::now();
+    match std::fs::metadata(vault_path) {
+        Ok(meta) => {
+            let mode = meta.permissions().mode();
+            if mode & 0o077 != 0 {
+                CheckResult::fail(
+                    check_name,
+                    format!("vault file has group/world permissions (mode {mode:#o})"),
+                    elapsed_ms(start),
+                )
+            } else {
+                CheckResult::ok(
+                    check_name,
+                    format!("permissions ok (mode {mode:#o})"),
+                    elapsed_ms(start),
+                )
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            CheckResult::ok(check_name, "file not found (skipped)", elapsed_ms(start))
+        }
+        Err(e) => CheckResult::fail(
+            check_name,
+            format!("could not read metadata: {e}"),
+            elapsed_ms(start),
+        ),
+    }
+}
+
+#[cfg(not(unix))]
+fn check_vault_file_mode(_vault_path: &str, check_name: &str) -> CheckResult {
+    CheckResult::ok(check_name, "skipped on non-unix", 0)
+}
+
 fn check_fs_writable(name: &str, dir: &Path) -> CheckResult {
     let start = Instant::now();
     match tempfile::NamedTempFile::new_in(dir) {
@@ -702,6 +739,7 @@ pub(crate) async fn run_doctor(
         if vault_args.backend == "age" {
             if let Some(ref vault_path) = vault_args.vault_path {
                 results.push(check_vault_file_exists(vault_path));
+                results.push(check_vault_file_mode(vault_path, "vault.file_mode"));
             }
             if let Some(ref key_path) = vault_args.key_path {
                 results.push(check_vault_key_mode(key_path));

--- a/src/commands/memory.rs
+++ b/src/commands/memory.rs
@@ -38,7 +38,7 @@ async fn cmd_export(
         .map_err(|e| anyhow::anyhow!("export failed: {e}"))?;
     let json = serde_json::to_string_pretty(&snapshot)
         .map_err(|e| anyhow::anyhow!("serialization failed: {e}"))?;
-    std::fs::write(path, json)
+    zeph_common::fs_secure::write_private(path, json.as_bytes())
         .map_err(|e| anyhow::anyhow!("failed to write {}: {e}", path.display()))?;
     let convs = snapshot.conversations.len();
     let msgs: usize = snapshot

--- a/src/init/mcp.rs
+++ b/src/init/mcp.rs
@@ -93,7 +93,7 @@ file_patterns = ["**/*.rs"]
     );
 
     let mcpls_path = zeph_dir.join("mcpls.toml");
-    std::fs::write(&mcpls_path, content)?;
+    zeph_common::fs_secure::write_private(&mcpls_path, content.as_bytes())?;
     println!("mcpls config written to {}", mcpls_path.display());
 
     Ok(())

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -1356,7 +1356,7 @@ fn step_review_and_write(state: &WizardState, output: Option<PathBuf>) -> anyhow
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    std::fs::write(&path, &toml_str)?;
+    zeph_common::fs_secure::atomic_write_private(&path, toml_str.as_bytes())?;
     println!("Config written to {}", path.display());
 
     if state.mcpls_enabled {


### PR DESCRIPTION
## Summary

- Adds `zeph-common::fs_secure` module with four helpers (`open_private_truncate`, `append_private`, `write_private`, `atomic_write_private`) that create files with mode 0600 on Unix, independent of process umask
- `atomic_write_private` uses `O_EXCL` on the temp file (`.age.tmp` suffix), fsyncs before rename, and cleans up the temp file on every error path — closing the pre-existing TOCTOU gap
- Migrates 14 call sites: vault secrets, SQLite pool pre-create, debug dumps, audit JSONL, router state (bandit/thompson/reputation), adaptorch save, transcript writer, ACP permission file, init config.toml, mcpls.toml, model cache, memory CLI export
- Fixes `doctor check_vault_file_mode` to return FAIL (not silent OK) for non-ENOENT metadata errors
- Adds 3 new tests: `atomic_write_private` error-path cleanup, stale-tmp removal before O_EXCL open, SQLite pre-create mode assertion

## Notes

- Pre-existing files with 0o644 mode are remediated on next write (helpers truncate+create)
- SQLite WAL/SHM sidecars (`.db-wal`, `.db-shm`) remain 0o644 — sqlx creates them after pool open; best-effort chmod applied, sqlx limitation documented
- Windows: no permission hardening (documented in `fs_secure` module docstring); all `#[cfg(unix)]` guards verified complete
- `append_private` (audit JSONL): pre-existing loose file keeps its original mode; only new files get 0o600

## Follow-up issues (non-blocking)

- Extended `zeph doctor` checks for audit/db/transcript mode bits
- Mode assertion tests for router/audit/transcript/adaptorch call sites
- Umask-independence test (`libc::umask` variant)
- Windows non-atomic rename runtime warning
- DB parent directory mode (0o755 → 0o700)

## Test plan

- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes (18 pre-existing errors under `--all-targets --all-features` due to CUDA build, tracked in #3125)
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 8249 passed, 20 skipped
- [ ] Live session: create vault, run agent, verify `secrets.age` mode is 0o600 (`stat -f "%Lp" ~/.config/zeph/secrets.age`)

Closes #3121