### PR TITLE
fix(skills,tools): exempt invoke_skill from policy gates and fix plugin hot-reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **fix(tools): add `invoke_skill` to adversarial policy, VIGIL, and tool-filter always-on lists** (#3133) —
+  `AdversarialPolicyConfig::default_exempt_tools()`, `vigil::default_exempt_tools()`, and
+  `default_tool_filter_always_on()` now include `"invoke_skill"` alongside the existing `"load_skill"`
+  entry. Without this, tool-schema filtering could silently remove `invoke_skill` from the LLM prompt
+  when `tool_filter.enabled = true`. Both operations are read-only local registry calls with no network
+  or filesystem side effects; the omission was an oversight when `invoke_skill` was introduced in the
+  agent-invocable skills PR.
+
+- **fix(skills): plugin skills installed via `/plugins add` now hot-reload without restart** (#3134) —
+  `AppBuilder::skill_paths()` is replaced by two helpers: `skill_paths_for_registry()` (expanded
+  per-plugin skill dirs, used by the skill registry and `with_skill_reload`) and
+  `skill_paths_for_watcher()` (config paths + managed dir + plugins root, used by `SkillWatcher`).
+  Watching the plugins root recursively covers skills from any plugin installed after startup.
+  A `plugin_dirs_supplier` closure is captured at agent construction and called inside
+  `reload_skills()` so the registry discovers newly installed plugin skill dirs on every watcher
+  event without restarting the agent.
+
 - **fix(sandbox): emit WARN log when canonicalize_paths drops an unresolvable path** (#3117) —
   `SandboxPolicy::canonicalized` now logs `tracing::warn!` with `path` and `error` fields before
   silently dropping paths that fail `fs::canonicalize` (ENOENT, EACCES, ELOOP, etc.).

--- a/crates/zeph-config/src/agent.rs
+++ b/crates/zeph-config/src/agent.rs
@@ -111,6 +111,7 @@ fn default_tool_filter_always_on() -> Vec<String> {
         "memory_search".into(),
         "memory_save".into(),
         "load_skill".into(),
+        "invoke_skill".into(),
         "bash".into(),
         "read".into(),
         "edit".into(),

--- a/crates/zeph-config/src/vigil.rs
+++ b/crates/zeph-config/src/vigil.rs
@@ -32,6 +32,7 @@ fn default_exempt_tools() -> Vec<String> {
         "memory_search".into(),
         "read_overflow".into(),
         "load_skill".into(),
+        "invoke_skill".into(),
         "schedule_deferred".into(),
     ]
 }
@@ -156,6 +157,8 @@ mod tests {
         assert_eq!(cfg.sanitize_max_chars, 2048);
         assert!(cfg.extra_patterns.is_empty());
         assert!(cfg.exempt_tools.contains(&"memory_search".to_owned()));
+        assert!(cfg.exempt_tools.contains(&"load_skill".to_owned()));
+        assert!(cfg.exempt_tools.contains(&"invoke_skill".to_owned()));
     }
 
     #[test]

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -201,6 +201,20 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Set a supplier that returns the current per-plugin skill directories.
+    ///
+    /// Called at the start of every hot-reload cycle so plugins installed after agent startup
+    /// are discovered without restarting. The supplier should call
+    /// `PluginManager::collect_skill_dirs()` and return the resulting paths.
+    #[must_use]
+    pub fn with_plugin_dirs_supplier(
+        mut self,
+        supplier: impl Fn() -> Vec<PathBuf> + Send + Sync + 'static,
+    ) -> Self {
+        self.skill_state.plugin_dirs_supplier = Some(std::sync::Arc::new(supplier));
+        self
+    }
+
     /// Set the directory used by `/skill install` and `/skill remove`.
     #[must_use]
     pub fn with_managed_skills_dir(mut self, dir: PathBuf) -> Self {

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -2128,10 +2128,19 @@ impl<C: Channel> Agent<C> {
     )]
     async fn reload_skills(&mut self) {
         let old_fp = self.skill_state.fingerprint();
-        self.skill_state
-            .registry
-            .write()
-            .reload(&self.skill_state.skill_paths);
+        let reload_paths = if let Some(ref supplier) = self.skill_state.plugin_dirs_supplier {
+            let plugin_dirs = supplier();
+            let mut paths = self.skill_state.skill_paths.clone();
+            for dir in plugin_dirs {
+                if !paths.contains(&dir) {
+                    paths.push(dir);
+                }
+            }
+            paths
+        } else {
+            self.skill_state.skill_paths.clone()
+        };
+        self.skill_state.registry.write().reload(&reload_paths);
         if self.skill_state.fingerprint() == old_fp {
             return;
         }

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -89,6 +89,11 @@ pub(crate) struct SkillState {
     pub(crate) min_injection_score: f32,
     pub(crate) embedding_model: String,
     pub(crate) skill_reload_rx: Option<mpsc::Receiver<SkillEvent>>,
+    /// Resolves the current set of per-plugin skill dirs at reload time.
+    ///
+    /// Called inside `reload_skills()` so that plugins installed via `/plugins add` after
+    /// startup are discovered on the next watcher event without restarting the agent.
+    pub(crate) plugin_dirs_supplier: Option<Arc<dyn Fn() -> Vec<PathBuf> + Send + Sync>>,
     pub(crate) active_skill_names: Vec<String>,
     pub(crate) last_skills_prompt: String,
     pub(crate) prompt_mode: SkillPromptMode,
@@ -878,6 +883,7 @@ impl SkillState {
             min_injection_score: 0.20,
             embedding_model: String::new(),
             skill_reload_rx: None,
+            plugin_dirs_supplier: None,
             active_skill_names: Vec::new(),
             last_skills_prompt,
             prompt_mode: crate::config::SkillPromptMode::Auto,

--- a/crates/zeph-tools/src/config.rs
+++ b/crates/zeph-tools/src/config.rs
@@ -413,6 +413,7 @@ impl AdversarialPolicyConfig {
             "memory_search".into(),
             "read_overflow".into(),
             "load_skill".into(),
+            "invoke_skill".into(),
             "schedule_deferred".into(),
         ]
     }
@@ -1254,5 +1255,18 @@ mod tests {
         ";
         let config: ToolsConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.result_cache.ttl_secs, 0);
+    }
+
+    #[test]
+    fn adversarial_policy_default_exempt_tools_contains_skill_ops() {
+        let exempt = AdversarialPolicyConfig::default_exempt_tools();
+        assert!(
+            exempt.contains(&"load_skill".to_string()),
+            "default exempt_tools must contain load_skill"
+        );
+        assert!(
+            exempt.contains(&"invoke_skill".to_string()),
+            "default exempt_tools must contain invoke_skill"
+        );
     }
 }

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -173,6 +173,8 @@ struct SharedAgentDeps {
     acp_provider_factory: Option<zeph_acp::ProviderFactory>,
     /// Project rule file paths to advertise in session `_meta`.
     acp_project_rules: Vec<PathBuf>,
+    /// Resolves current per-plugin skill dirs at hot-reload time.
+    plugin_dirs_supplier: std::sync::Arc<dyn Fn() -> Vec<PathBuf> + Send + Sync>,
 
     /// Shell overlay snapshot captured at startup for hot-reload divergence detection.
     startup_shell_overlay: zeph_core::ShellOverlaySnapshot,
@@ -376,7 +378,8 @@ async fn build_acp_deps(
     )
     .await;
     let summary_provider = app.build_summary_provider();
-    let skill_paths = app.skill_paths();
+    let skill_paths = app.skill_paths_for_registry();
+    let plugin_dirs_supplier = app.plugin_dirs_supplier();
     let acp_project_rules = collect_project_rules(&skill_paths);
     let crate::bootstrap::WatcherBundle {
         skill_watcher,
@@ -530,6 +533,7 @@ async fn build_acp_deps(
         sqlite_path: crate::db_url::resolve_db_url(config).to_owned(),
         acp_provider_factory: Some(build_acp_provider_factory(config)),
         acp_project_rules,
+        plugin_dirs_supplier: std::sync::Arc::new(plugin_dirs_supplier),
         #[cfg(feature = "scheduler")]
         scheduler_executor,
         #[cfg(feature = "scheduler")]
@@ -574,6 +578,7 @@ async fn spawn_acp_agent(
     let max_active_skills = d.max_active_skills;
     let tool_executor = Arc::clone(&d.tool_executor);
     let skill_paths = d.skill_paths.clone();
+    let plugin_dirs_supplier = Arc::clone(&d.plugin_dirs_supplier);
     let memory = Arc::clone(&d.memory);
     let history_limit = d.history_limit;
     let recall_limit = d.recall_limit;
@@ -725,6 +730,7 @@ async fn spawn_acp_agent(
         .apply_session_config(session_config)
         .with_working_dir(session_ctx.working_dir.clone())
         .with_skill_reload(skill_paths, reload_rx)
+        .with_plugin_dirs_supplier(move || plugin_dirs_supplier())
         .with_managed_skills_dir(managed_skills_dir)
         .with_shutdown(shutdown_rx)
         .with_config_reload(config_path, config_reload_rx)
@@ -1288,7 +1294,7 @@ pub(crate) async fn run_acp_http_server(
         auth_bearer_token,
         discovery_enabled: app.config().acp.discovery_enabled,
         terminal_timeout_secs: 120,
-        project_rules: collect_project_rules(&app.skill_paths()),
+        project_rules: collect_project_rules(&app.skill_paths_for_registry()),
         title_max_chars: app.config().memory.sessions.title_max_chars,
         max_history: app.config().memory.sessions.max_history,
         sqlite_path: Some(crate::db_url::resolve_db_url(app.config()).to_owned()),

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -563,7 +563,7 @@ impl AppBuilder {
             }
         }
 
-        let skill_paths = self.skill_paths();
+        let skill_paths = self.skill_paths_for_registry();
         let registry = SkillRegistry::load(&skill_paths).with_hub_dirs(std::iter::once(managed));
 
         if self.config.skills.trust.scan_on_load {
@@ -605,13 +605,16 @@ impl AppBuilder {
         registry
     }
 
-    pub fn skill_paths(&self) -> Vec<PathBuf> {
+    /// Returns per-plugin skill directories expanded via [`PluginManager::collect_skill_dirs`].
+    ///
+    /// Used by [`Self::build_registry`] and by runner/daemon/acp when constructing the agent
+    /// via `with_skill_reload`. Every entry points directly at a directory containing `SKILL.md`.
+    pub fn skill_paths_for_registry(&self) -> Vec<PathBuf> {
         let mut paths: Vec<PathBuf> = self.config.skills.paths.iter().map(PathBuf::from).collect();
         let managed_dir = managed_skills_dir();
         if !paths.contains(&managed_dir) {
             paths.push(managed_dir.clone());
         }
-        // Append per-plugin skill directories so the registry loads plugin skills at startup.
         let plugins_dir = plugins_dir();
         let mgr = zeph_plugins::PluginManager::new(
             plugins_dir,
@@ -628,6 +631,52 @@ impl AppBuilder {
         paths
     }
 
+    /// Returns paths for the filesystem watcher: config paths + managed dir + plugins root.
+    ///
+    /// Passes the plugins root (not per-plugin subdirs) so that skills added by `/plugins add`
+    /// after startup are covered by the recursive watcher without re-registration.
+    /// Eagerly creates the plugins root directory so [`SkillWatcher::start`] does not fail on a
+    /// clean install where no plugins have been installed yet.
+    pub fn skill_paths_for_watcher(&self) -> Vec<PathBuf> {
+        let mut paths: Vec<PathBuf> = self.config.skills.paths.iter().map(PathBuf::from).collect();
+        let managed_dir = managed_skills_dir();
+        if !paths.contains(&managed_dir) {
+            paths.push(managed_dir);
+        }
+        let plugins_root = plugins_dir();
+        let _ = std::fs::create_dir_all(&plugins_root).map_err(|e| {
+            tracing::warn!(
+                path = %plugins_root.display(),
+                error = %e,
+                "failed to create plugins directory for watcher; skipping"
+            );
+        });
+        if plugins_root.exists() && !paths.contains(&plugins_root) {
+            paths.push(plugins_root);
+        }
+        paths
+    }
+
+    /// Returns a closure that resolves current per-plugin skill directories.
+    ///
+    /// Pass the returned closure to `AgentBuilder::with_plugin_dirs_supplier` so that
+    /// `reload_skills()` picks up plugins installed after agent startup.
+    pub fn plugin_dirs_supplier(
+        &self,
+    ) -> impl Fn() -> Vec<std::path::PathBuf> + Send + Sync + 'static {
+        let plugins_dir = plugins_dir();
+        let managed_dir = managed_skills_dir();
+        let allowed_commands = self.config.mcp.allowed_commands.clone();
+        move || {
+            let mgr = zeph_plugins::PluginManager::new(
+                plugins_dir.clone(),
+                managed_dir.clone(),
+                allowed_commands.clone(),
+            );
+            mgr.collect_skill_dirs().unwrap_or_default()
+        }
+    }
+
     #[allow(dead_code)]
     pub fn managed_skills_dir() -> PathBuf {
         managed_skills_dir()
@@ -636,7 +685,7 @@ impl AppBuilder {
     pub fn build_watchers(&self) -> WatcherBundle {
         use zeph_core::instrumented_channel::instrumented_channel;
 
-        let skill_paths = self.skill_paths();
+        let skill_paths = self.skill_paths_for_watcher();
         let (skill_tx, skill_reload_rx) = instrumented_channel(4, "skill_reload_rx");
         let skill_watcher = match SkillWatcher::start(&skill_paths, skill_tx.into_inner()) {
             Ok(w) => {

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -605,7 +605,7 @@ impl AppBuilder {
         registry
     }
 
-    /// Returns per-plugin skill directories expanded via [`PluginManager::collect_skill_dirs`].
+    /// Returns per-plugin skill directories expanded via `PluginManager::collect_skill_dirs`.
     ///
     /// Used by [`Self::build_registry`] and by runner/daemon/acp when constructing the agent
     /// via `with_skill_reload`. Every entry points directly at a directory containing `SKILL.md`.

--- a/src/bootstrap/tests.rs
+++ b/src/bootstrap/tests.rs
@@ -420,11 +420,11 @@ fn skill_paths_includes_managed_dir() {
         qdrant_ops: None,
         resolved_overlay: zeph_plugins::ResolvedOverlay::default(),
     };
-    let paths = builder.skill_paths();
+    let paths = builder.skill_paths_for_registry();
     let managed = managed_skills_dir();
     assert!(
         paths.contains(&managed),
-        "skill_paths() should include managed_skills_dir, got: {paths:?}"
+        "skill_paths_for_registry() should include managed_skills_dir, got: {paths:?}"
     );
 }
 
@@ -441,12 +441,41 @@ fn skill_paths_does_not_duplicate_managed_dir() {
         qdrant_ops: None,
         resolved_overlay: zeph_plugins::ResolvedOverlay::default(),
     };
-    let paths = builder.skill_paths();
+    let paths = builder.skill_paths_for_registry();
     let count = paths.iter().filter(|p| p == &&managed).count();
     assert_eq!(
         count, 1,
         "managed dir should appear exactly once, got: {paths:?}"
     );
+}
+
+#[test]
+fn skill_paths_for_watcher_includes_plugins_root() {
+    let config = Config::load(Path::new("/nonexistent")).unwrap();
+    let builder = AppBuilder {
+        config,
+        config_path: PathBuf::from("/nonexistent/config.toml"),
+        vault: Box::new(EnvVaultProvider),
+        age_vault: None,
+        qdrant_ops: None,
+    };
+    let paths = builder.skill_paths_for_watcher();
+    let plugins_root = plugins_dir();
+    // The helper must either include the plugins root (created eagerly) or skip it cleanly
+    // when creation fails. On CI where HOME is writable this should always be present.
+    if plugins_root.exists() {
+        assert!(
+            paths.contains(&plugins_root),
+            "skill_paths_for_watcher() should include plugins_root when it exists, got: {paths:?}"
+        );
+    }
+    // Watcher paths must NOT contain per-plugin subdirs — only the root.
+    for p in &paths {
+        assert!(
+            p != &plugins_root.join("some_plugin").join("skills").join("x"),
+            "skill_paths_for_watcher() must not expand per-plugin skill dirs"
+        );
+    }
 }
 
 #[tokio::test]

--- a/src/bootstrap/tests.rs
+++ b/src/bootstrap/tests.rs
@@ -458,6 +458,7 @@ fn skill_paths_for_watcher_includes_plugins_root() {
         vault: Box::new(EnvVaultProvider),
         age_vault: None,
         qdrant_ops: None,
+        resolved_overlay: zeph_plugins::ResolvedOverlay::default(),
     };
     let paths = builder.skill_paths_for_watcher();
     let plugins_root = plugins_dir();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -436,7 +436,8 @@ pub(crate) async fn run_daemon(
     let reload_rx = watchers.skill_reload_rx.into_inner();
     let _config_watcher = watchers.config_watcher;
     let config_reload_rx = watchers.config_reload_rx.into_inner();
-    let skill_paths = app.skill_paths();
+    let skill_paths = app.skill_paths_for_registry();
+    let plugin_dirs_supplier = app.plugin_dirs_supplier();
     let config_path_owned = app.config_path().to_owned();
     let session_config = zeph_core::AgentSessionConfig::from_config(config, budget_tokens);
 
@@ -473,6 +474,7 @@ pub(crate) async fn run_daemon(
             config.skills.confusability_threshold,
         )
         .with_skill_reload(skill_paths, reload_rx)
+        .with_plugin_dirs_supplier(plugin_dirs_supplier)
         .with_managed_skills_dir(crate::bootstrap::managed_skills_dir())
         .with_memory(
             std::sync::Arc::clone(&memory),

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1274,7 +1274,8 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         });
     }
 
-    let skill_paths = app.skill_paths();
+    let skill_paths = app.skill_paths_for_registry();
+    let plugin_dirs_supplier = app.plugin_dirs_supplier();
 
     let memory_executor = zeph_core::memory_tools::MemoryToolExecutor::with_validator(
         std::sync::Arc::clone(&memory),
@@ -1576,7 +1577,8 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         config.skills.two_stage_matching,
         config.skills.confusability_threshold,
     )
-    .with_skill_reload(skill_paths.clone(), reload_rx)
+    .with_skill_reload(skill_paths, reload_rx)
+    .with_plugin_dirs_supplier(plugin_dirs_supplier)
     .with_managed_skills_dir(crate::bootstrap::managed_skills_dir())
     .with_trust_config(config.skills.trust.clone())
     .with_trust_snapshot(trust_snapshot)


### PR DESCRIPTION
## Summary

- **#3133**: `invoke_skill` was missing from all three policy exempt lists (`AdversarialPolicyConfig::default_exempt_tools`, `vigil::default_exempt_tools`, `default_tool_filter_always_on`), causing it to be denied on every call when adversarial policy was enabled.
- **#3134**: Plugin skills installed at runtime via `/plugins add` were not hot-reloaded because `SkillWatcher` received a fixed list of paths captured at startup. Now watches the plugins root directory recursively; a `plugin_dirs_supplier` closure re-invokes `PluginManager::collect_skill_dirs()` on each reload.

## Changes

- `crates/zeph-tools/src/config.rs` — add `invoke_skill` to adversarial exempt list + test
- `crates/zeph-config/src/vigil.rs` — add `invoke_skill` to VIGIL exempt list + test
- `crates/zeph-config/src/agent.rs` — add `invoke_skill` to tool-filter always-on list
- `src/bootstrap/mod.rs` — split `skill_paths()` into `skill_paths_for_registry()` + `skill_paths_for_watcher()`; watcher path includes plugins root
- `crates/zeph-core/src/agent/builder.rs` — add `with_plugin_dirs_supplier()` builder method
- `crates/zeph-core/src/agent/mod.rs` — `reload_skills()` calls supplier before rebuilding registry
- `crates/zeph-core/src/agent/state/mod.rs` — store supplier in `SkillStateBundle`
- `src/runner.rs`, `src/daemon.rs`, `src/acp.rs` — updated call sites to use `skill_paths_for_registry()`

## Test plan

- [ ] `cargo nextest run --workspace --features full --lib --bins` — 8608/8608 passed
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace --lib --bins -- -D warnings` — clean
- [ ] Adversarial policy enabled: `invoke_skill` no longer blocked
- [ ] `/plugins add <path>` while agent running: skills available within debounce window without restart

Closes #3133
Closes #3134