### PR TITLE
fix(llm,cost): suppress WARN log floods from cost tracker, provider_factory, and ASI coherence router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   users to know the XDG-conditional vault path manually.
   Closes [#3137](https://github.com/bug-ops/zeph/issues/3137).
 
+- **fix(cost): suppress false-positive WARN for local Ollama/Candle/Compatible providers** —
+  `CostTracker::record_usage()` now accepts a `provider_kind: &str` parameter and downgrades the
+  "model not found in pricing table" log from `warn!` to `debug!` for local providers (`"ollama"`,
+  `"candle"`, `"local"`). Zero cost is the correct and expected value for local inference; the WARN
+  was misleading. `AnyProvider::provider_kind_str()` added in `zeph-llm` as the discriminator;
+  `Compatible` (LM Studio / vLLM / llama.cpp) and `Router`/`Triage` resolve to `"local"`.
+  `record_usage()` is a breaking API change (pre-1.0).
+  Closes [#3139](https://github.com/bug-ops/zeph/issues/3139).
+
+- **fix(llm): deduplicate forward_output_schema unsupported WARN at startup** — downgraded the
+  `forward_output_schema` capability WARN in `provider_factory.rs` from `warn!` to `debug!` for
+  both Ollama and Gemini providers. The setting is silently and correctly ignored; the WARN fired
+  up to 5 times per startup as multiple subsystems each called `build_provider()` independently.
+  Closes [#3138](https://github.com/bug-ops/zeph/issues/3138).
+
+- **fix(llm): rate-limit ASI coherence WARN to at most once per 60 seconds** — the ASI coherence
+  WARN in `zeph-llm/src/router/mod.rs` previously fired on every `route_next()` call (up to 70/s
+  during normal operation). Now suppressed via an `AtomicU64` CAS rate-limiter with a 60-second
+  window; suppressed-path log is emitted at `trace!` level. Uses the same pattern as the existing
+  Qdrant WARN rate-limiter.
+  Closes [#3129](https://github.com/bug-ops/zeph/issues/3129).
+
 ### Added
 
 - **feat(plugins): plugin config overlay merge** — `zeph-plugins` now exposes

--- a/crates/zeph-core/src/agent/utils.rs
+++ b/crates/zeph-core/src/agent/utils.rs
@@ -245,6 +245,7 @@ impl<C: Channel> Agent<C> {
             };
             tracker.record_usage(
                 provider_name,
+                self.provider.provider_kind_str(),
                 &self.runtime.model_name,
                 input_tokens,
                 cache_read,

--- a/crates/zeph-core/src/cost.rs
+++ b/crates/zeph-core/src/cost.rs
@@ -140,11 +140,18 @@ impl CostTracker {
 
     /// Record token usage for a single LLM call, attributed to `provider_name`.
     ///
+    /// `provider_kind` must be the value returned by `AnyProvider::provider_kind_str()`:
+    /// `"ollama"` or `"candle"` for local providers, `"cloud"` for API providers.
+    /// Local providers always have zero cost by design; the missing-pricing WARN is
+    /// suppressed for them to avoid log floods on every Ollama call.
+    ///
     /// Cache token counts are optional (pass 0 when not available). Cost is computed
     /// using model-specific pricing including cache read/write rates.
+    #[allow(clippy::too_many_arguments)]
     pub fn record_usage(
         &self,
         provider_name: &str,
+        provider_kind: &str,
         model: &str,
         input_tokens: u64,
         cache_read_tokens: u64,
@@ -157,10 +164,15 @@ impl CostTracker {
         let pricing = if let Some(p) = self.pricing.get(model).cloned() {
             p
         } else {
-            tracing::warn!(
-                model,
-                "model not found in pricing table; cost recorded as zero"
-            );
+            let is_local = matches!(provider_kind, "ollama" | "candle" | "local");
+            if is_local {
+                tracing::debug!(model, "local model; cost recorded as zero");
+            } else {
+                tracing::warn!(
+                    model,
+                    "model not found in pricing table; cost recorded as zero"
+                );
+            }
             ModelPricing {
                 prompt_cents_per_1k: 0.0,
                 completion_cents_per_1k: 0.0,
@@ -241,7 +253,7 @@ mod tests {
     use super::*;
 
     fn record(tracker: &CostTracker, provider: &str, model: &str, input: u64, output: u64) {
-        tracker.record_usage(provider, model, input, 0, 0, output);
+        tracker.record_usage(provider, "cloud", model, input, 0, 0, output);
     }
 
     #[test]
@@ -300,6 +312,38 @@ mod tests {
     fn ollama_zero_cost() {
         let tracker = CostTracker::new(true, 100.0);
         record(&tracker, "ollama", "llama3:8b", 10000, 10000);
+        assert!((tracker.current_spend() - 0.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn ollama_unknown_model_no_warn_no_panic() {
+        // Local providers should silently record zero cost for unknown models.
+        let tracker = CostTracker::new(true, 100.0);
+        tracker.record_usage(
+            "local",
+            "ollama",
+            "totally-unknown-ollama-model",
+            5000,
+            0,
+            0,
+            5000,
+        );
+        assert!((tracker.current_spend() - 0.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn cloud_unknown_model_still_records_zero_cost() {
+        // Cloud providers record zero cost for unknown models (WARN emitted separately).
+        let tracker = CostTracker::new(true, 100.0);
+        tracker.record_usage(
+            "openai",
+            "cloud",
+            "totally-unknown-cloud-model",
+            5000,
+            0,
+            0,
+            5000,
+        );
         assert!((tracker.current_spend() - 0.0).abs() < 0.001);
     }
 
@@ -398,7 +442,15 @@ mod tests {
         let tracker = CostTracker::new(true, 1000.0);
         // claude-haiku prompt=0.1, cache_read=0.01 per 1k
         // 1000 cache_read tokens = 0.01 cents; 0 input/output for isolation
-        tracker.record_usage("claude", "claude-haiku-4-5-20251001", 0, 1000, 0, 0);
+        tracker.record_usage(
+            "claude",
+            "cloud",
+            "claude-haiku-4-5-20251001",
+            0,
+            1000,
+            0,
+            0,
+        );
         let spend = tracker.current_spend();
         assert!(spend > 0.0, "cache read should contribute to cost");
     }
@@ -409,7 +461,7 @@ mod tests {
         // Claude pricing: cache_write = 125% of prompt price
         // claude-opus-4-6: prompt = 0.5 cents/1k
         // 1000 cache_write tokens = (0.5 * 1.25 * 1000) / 1000 = 0.625 cents
-        tracker.record_usage("claude-provider", "claude-opus-4-6", 0, 0, 1000, 0);
+        tracker.record_usage("claude-provider", "cloud", "claude-opus-4-6", 0, 0, 1000, 0);
         let cost = tracker.current_spend();
         assert!((cost - 0.625).abs() < 0.001);
     }
@@ -417,7 +469,15 @@ mod tests {
     #[test]
     fn provider_breakdown_empty_when_disabled() {
         let tracker = CostTracker::new(false, 100.0);
-        tracker.record_usage("claude", "claude-haiku-4-5-20251001", 1000, 0, 0, 1000);
+        tracker.record_usage(
+            "claude",
+            "cloud",
+            "claude-haiku-4-5-20251001",
+            1000,
+            0,
+            0,
+            1000,
+        );
         assert!(tracker.provider_breakdown().is_empty());
     }
 }

--- a/crates/zeph-core/src/provider_factory.rs
+++ b/crates/zeph-core/src/provider_factory.rs
@@ -109,7 +109,7 @@ pub fn build_provider_from_entry(
                 provider = provider.with_vision_model(vm.clone());
             }
             if config.mcp.forward_output_schema {
-                tracing::warn!(
+                tracing::debug!(
                     "mcp.forward_output_schema is enabled but Ollama does not support \
                      output schema forwarding; setting ignored for this provider"
                 );
@@ -222,7 +222,7 @@ pub fn build_provider_from_entry(
                 provider = provider.with_include_thoughts(include);
             }
             if config.mcp.forward_output_schema {
-                tracing::warn!(
+                tracing::debug!(
                     "mcp.forward_output_schema is enabled but Gemini does not support \
                      output schema forwarding; setting ignored for this provider"
                 );

--- a/crates/zeph-llm/src/any.rs
+++ b/crates/zeph-llm/src/any.rs
@@ -162,6 +162,25 @@ impl AnyProvider {
         }
     }
 
+    /// Returns a static string identifying the provider kind for cost/logging purposes.
+    ///
+    /// Returns `"ollama"` or `"candle"` for local inference providers (no API cost),
+    /// `"local"` for providers that are always unpriced (Compatible, Router, Triage),
+    /// and `"cloud"` for metered API providers (`Claude`, `OpenAI`, `Gemini`).
+    #[must_use]
+    pub fn provider_kind_str(&self) -> &'static str {
+        match self {
+            Self::Ollama(_) => "ollama",
+            #[cfg(feature = "candle")]
+            Self::Candle(_) => "candle",
+            // Compatible targets LM Studio / vLLM / llama.cpp — always local, never metered.
+            Self::Compatible(_) => "local",
+            // Routers are never directly invoiced; cost attribution flows to child providers.
+            Self::Router(_) | Self::Triage(_) => "local",
+            _ => "cloud",
+        }
+    }
+
     /// Record a quality outcome for reputation-based routing (RAPS).
     ///
     /// Delegates to `RouterProvider::record_quality_outcome`; no-op for all other variants.

--- a/crates/zeph-llm/src/router/mod.rs
+++ b/crates/zeph-llm/src/router/mod.rs
@@ -72,6 +72,9 @@ use bandit::{BanditState, embedding_to_features};
 use cascade::{CascadeState, ClassifierMode, heuristic_score};
 use reputation::ReputationTracker;
 use thompson::ThompsonState;
+
+/// Rate-limits the ASI coherence WARN to at most once per 60 seconds process-wide.
+static ASI_WARN_LAST_SECS: AtomicU64 = AtomicU64::new(0);
 use zeph_common::math::cosine_similarity;
 
 /// Simple bounded embedding cache for bandit feature vectors.
@@ -955,12 +958,30 @@ impl RouterProvider {
                 .map(|(idx, p)| {
                     let coherence = asi.coherence(p.name());
                     if coherence < asi_cfg.coherence_threshold {
-                        tracing::warn!(
-                            provider = p.name(),
-                            coherence,
-                            threshold = asi_cfg.coherence_threshold,
-                            "asi: coherence below threshold"
-                        );
+                        let now = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .unwrap_or(std::time::Duration::MAX)
+                            .as_secs();
+                        let last = ASI_WARN_LAST_SECS.load(Ordering::Relaxed);
+                        if now.saturating_sub(last) >= 60
+                            && ASI_WARN_LAST_SECS
+                                .compare_exchange(last, now, Ordering::Relaxed, Ordering::Relaxed)
+                                .is_ok()
+                        {
+                            tracing::warn!(
+                                provider = p.name(),
+                                coherence,
+                                threshold = asi_cfg.coherence_threshold,
+                                "asi: coherence below threshold"
+                            );
+                        } else {
+                            tracing::trace!(
+                                provider = p.name(),
+                                coherence,
+                                threshold = asi_cfg.coherence_threshold,
+                                "asi: coherence below threshold (warn rate-limited)"
+                            );
+                        }
                     }
                     let base_score = snap
                         .as_ref()
@@ -1024,12 +1045,35 @@ impl RouterProvider {
                     if let (Some(asi), Some(asi_cfg)) = (&asi_guard, &self.asi_config) {
                         let coherence = asi.coherence(name);
                         if coherence < asi_cfg.coherence_threshold {
-                            tracing::warn!(
-                                provider = name.as_str(),
-                                coherence,
-                                threshold = asi_cfg.coherence_threshold,
-                                "asi: coherence below threshold"
-                            );
+                            let now = std::time::SystemTime::now()
+                                .duration_since(std::time::UNIX_EPOCH)
+                                .unwrap_or(std::time::Duration::MAX)
+                                .as_secs();
+                            let last = ASI_WARN_LAST_SECS.load(Ordering::Relaxed);
+                            if now.saturating_sub(last) >= 60
+                                && ASI_WARN_LAST_SECS
+                                    .compare_exchange(
+                                        last,
+                                        now,
+                                        Ordering::Relaxed,
+                                        Ordering::Relaxed,
+                                    )
+                                    .is_ok()
+                            {
+                                tracing::warn!(
+                                    provider = name.as_str(),
+                                    coherence,
+                                    threshold = asi_cfg.coherence_threshold,
+                                    "asi: coherence below threshold"
+                                );
+                            } else {
+                                tracing::trace!(
+                                    provider = name.as_str(),
+                                    coherence,
+                                    threshold = asi_cfg.coherence_threshold,
+                                    "asi: coherence below threshold (warn rate-limited)"
+                                );
+                            }
                             let deficit = asi_cfg.coherence_threshold - coherence;
                             let penalty = f64::from(asi_cfg.penalty_weight * deficit);
                             beta += penalty;


### PR DESCRIPTION
## Summary

- **#3139** — `CostTracker::record_usage()` suppresses "model not found in pricing table" WARN for local providers (Ollama, Candle, Compatible/LM Studio, Router). Adds `AnyProvider::provider_kind_str()` discriminator. Breaking API change (pre-1.0).
- **#3138** — `forward_output_schema` unsupported WARN in `provider_factory.rs` downgraded to `debug!` for Ollama and Gemini. Was firing 5x at startup.
- **#3129** — ASI coherence WARN rate-limited to at most once per 60 seconds via `AtomicU64` CAS gate. Was firing up to 70/second (674 occurrences per day in CI-558 logs). Suppressed path logged at `trace!`.

## No LLM serialization paths touched

No live API gate required.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy -p zeph-core -p zeph-llm -- -D warnings` — clean
- [x] `cargo nextest run -p zeph-core -p zeph-llm --lib` — 2246 passed, 10 skipped
- [ ] Live session with Ollama provider: verify no WARN for `model not found in pricing table`
- [ ] Live session: verify no WARN for `forward_output_schema` at startup
- [ ] Live session with ASI coherence < threshold: verify at most 1 WARN per 60s

Closes #3139
Closes #3138
Closes #3129