### PR TITLE
fix(common,ux): clippy items_after_statements in fs_secure + /recap deduplication on resume

### DIFF
--- a/crates/zeph-common/src/fs_secure.rs
+++ b/crates/zeph-common/src/fs_secure.rs
@@ -275,6 +275,7 @@ mod tests {
 
     #[test]
     fn atomic_write_private_errors_on_unwritable_dir() {
+        use std::os::unix::fs::PermissionsExt as _;
         // Verify that atomic_write_private returns an error when the directory is
         // not writable (no writeable dir → cannot create tmp), and the original
         // target file is untouched.
@@ -287,7 +288,6 @@ mod tests {
         atomic_write_private(&p, b"first").unwrap();
 
         // Make the directory read-only so the exclusive tmp create fails.
-        use std::os::unix::fs::PermissionsExt as _;
         std::fs::set_permissions(&inner, std::fs::Permissions::from_mode(0o500)).unwrap();
 
         let result = atomic_write_private(&p, b"second");

--- a/crates/zeph-core/src/agent/session_digest.rs
+++ b/crates/zeph-core/src/agent/session_digest.rs
@@ -183,6 +183,18 @@ pub(super) async fn generate_and_store_digest(
     }
 }
 
+/// Pure predicate for the `/recap` deduplication check (#3144).
+///
+/// Extracted from `Agent::recap_is_duplicate` so it can be unit-tested without a full `Agent`.
+fn recap_is_duplicate_impl(
+    auto_recap_shown: bool,
+    msg_count_at_resume: usize,
+    current_non_system: usize,
+    has_cached_digest: bool,
+) -> bool {
+    auto_recap_shown && current_non_system == msg_count_at_resume && has_cached_digest
+}
+
 impl<C: Channel> Agent<C> {
     /// Generate and persist a session digest at shutdown when digest is enabled.
     ///
@@ -338,6 +350,17 @@ impl<C: Channel> Agent<C> {
             && self.memory_state.compaction.cached_session_digest.is_some()
     }
 
+    /// Return `true` when `/recap` should skip LLM inference because auto-recap was already
+    /// shown and no new messages have been added since the session was resumed (#3144).
+    pub(super) fn recap_is_duplicate(&self, current_non_system: usize) -> bool {
+        recap_is_duplicate_impl(
+            self.runtime.auto_recap_shown,
+            self.runtime.msg_count_at_resume,
+            current_non_system,
+            self.memory_state.compaction.cached_session_digest.is_some(),
+        )
+    }
+
     /// Generate a recap text for the current session.
     ///
     /// Fast path: returns the cached digest verbatim when available.
@@ -352,6 +375,22 @@ impl<C: Channel> Agent<C> {
     pub(super) async fn build_recap(&mut self) -> Result<String, zeph_commands::CommandError> {
         let max_input = self.runtime.recap_config.max_input_messages.max(1);
         let max_tokens = self.runtime.recap_config.max_tokens.max(10);
+
+        // Fast path: auto-recap was already shown and no new messages since then (#3144).
+        // Return the cached digest without a new LLM call and without saving to DB.
+        let current_non_system = self
+            .msg
+            .messages
+            .iter()
+            .filter(|m| m.role != Role::System)
+            .count();
+        if self.recap_is_duplicate(current_non_system)
+            && let Some((digest, _)) = self.memory_state.compaction.cached_session_digest.clone()
+        {
+            let tc = &self.metrics.token_counter;
+            let text = truncate_digest(&digest, max_tokens, tc);
+            return Ok(format!("(shown at session start)\n{text}"));
+        }
 
         // Fast path: use already-loaded digest, truncated to the recap token budget.
         if let Some((digest, _)) = &self.memory_state.compaction.cached_session_digest {
@@ -440,8 +479,21 @@ impl<C: Channel> Agent<C> {
         match self.build_recap().await {
             Ok(text) if !text.is_empty() => {
                 let recap_msg = format!("── Welcome back ──\n{text}\n──────────────────");
-                if let Err(e) = self.channel.send(&recap_msg).await {
-                    tracing::warn!("session recap: channel send failed: {e:#}");
+                match self.channel.send(&recap_msg).await {
+                    Ok(()) => {
+                        // Mark auto-recap as shown only when the user actually received it (#3144).
+                        let non_system_count = self
+                            .msg
+                            .messages
+                            .iter()
+                            .filter(|m| m.role != Role::System)
+                            .count();
+                        self.runtime.auto_recap_shown = true;
+                        self.runtime.msg_count_at_resume = non_system_count;
+                    }
+                    Err(e) => {
+                        tracing::warn!("session recap: channel send failed: {e:#}");
+                    }
                 }
             }
             Ok(_) => {}
@@ -614,28 +666,28 @@ mod tests {
         );
     }
 
-    // ----- T4: should_auto_recap gate conditions -----
+    // ----- T4: recap_is_duplicate_impl gate conditions -----
+
+    use super::recap_is_duplicate_impl;
 
     #[test]
-    fn should_auto_recap_logic_all_conditions() {
-        // T4: verify the three conditions that gate auto-recap.
-        // We test the boolean logic directly since should_auto_recap reads two fields.
-        // Condition: conversation_id.is_some() && cached_session_digest.is_some()
-        // (on_resume is checked by the caller in maybe_send_resume_recap).
+    fn recap_duplicate_returns_true_when_no_new_messages() {
+        assert!(recap_is_duplicate_impl(true, 2, 2, true));
+    }
 
-        let has_conv = true;
-        let has_digest = true;
+    #[test]
+    fn recap_duplicate_returns_false_when_new_messages_exist() {
+        // one new message added since resume
+        assert!(!recap_is_duplicate_impl(true, 2, 3, true));
+    }
 
-        // All pass.
-        assert!(has_conv && has_digest);
+    #[test]
+    fn recap_duplicate_returns_false_when_flag_not_set() {
+        assert!(!recap_is_duplicate_impl(false, 0, 0, true));
+    }
 
-        // Missing conversation_id.
-        assert!(!(false && has_digest));
-
-        // Missing digest.
-        assert!(!(has_conv && false));
-
-        // Both missing.
-        assert!(!(false && false));
+    #[test]
+    fn recap_duplicate_returns_false_when_no_cached_digest() {
+        assert!(!recap_is_duplicate_impl(true, 0, 0, false));
     }
 }

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -200,6 +200,7 @@ pub struct AdversarialPolicyInfo {
     pub fail_open: bool,
 }
 
+#[allow(clippy::struct_excessive_bools)]
 pub(crate) struct RuntimeConfig {
     pub(crate) security: SecurityConfig,
     pub(crate) timeouts: TimeoutConfig,
@@ -233,6 +234,16 @@ pub(crate) struct RuntimeConfig {
     pub(crate) supervisor_config: crate::config::TaskSupervisorConfig,
     /// Session recap config (#3064).
     pub(crate) recap_config: zeph_config::RecapConfig,
+    /// Set to `true` after the auto-recap is emitted at session resume (#3144).
+    ///
+    /// Used by `/recap` to skip a redundant LLM call when no new messages have
+    /// been added since the auto-recap was shown.
+    pub(crate) auto_recap_shown: bool,
+    /// Number of non-system messages present when the session was resumed (#3144).
+    ///
+    /// Combined with `auto_recap_shown` to detect whether the user has added new
+    /// messages after the auto-recap was shown.
+    pub(crate) msg_count_at_resume: usize,
 }
 
 /// Groups feedback detection subsystems: correction detector, judge detector, and LLM classifier.
@@ -844,6 +855,8 @@ impl Default for RuntimeConfig {
             layers: Vec::new(),
             supervisor_config: crate::config::TaskSupervisorConfig::default(),
             recap_config: zeph_config::RecapConfig::default(),
+            auto_recap_shown: false,
+            msg_count_at_resume: 0,
         }
     }
 }

--- a/crates/zeph-core/src/agent/state/tests.rs
+++ b/crates/zeph-core/src/agent/state/tests.rs
@@ -91,6 +91,8 @@ fn make_runtime_config() -> RuntimeConfig {
         layers: Vec::new(),
         supervisor_config: crate::config::TaskSupervisorConfig::default(),
         recap_config: zeph_config::RecapConfig::default(),
+        auto_recap_shown: false,
+        msg_count_at_resume: 0,
     }
 }
 


### PR DESCRIPTION
## Summary

- **#3143** — `clippy::items_after_statements` in `fs_secure.rs` test: moved `use std::os::unix::fs::PermissionsExt as _` to top of function body before executable statements. Fixes CI `lint-clippy --all-targets` gate.
- **#3144** — `/recap` duplicated auto-recap shown at session start: added `auto_recap_shown`/`msg_count_at_resume` flags to `RuntimeConfig`; `/recap` now returns the cached digest with no LLM call and no DB write when no new messages have been added since resume.

## Changes

| File | Change |
|------|--------|
| `crates/zeph-common/src/fs_secure.rs` | Move `use` to top of test function |
| `crates/zeph-core/src/agent/state/mod.rs` | Add `auto_recap_shown`, `msg_count_at_resume` to `RuntimeConfig` |
| `crates/zeph-core/src/agent/state/tests.rs` | Update `make_runtime_config()` fixture |
| `crates/zeph-core/src/agent/session_digest.rs` | Set flags after successful channel send; extract `recap_is_duplicate_impl`; guard `build_recap` to skip LLM when duplicate |

## Test plan

- [x] `cargo clippy --all-targets --workspace --features full -- -D warnings`: `zeph-common` clean
- [x] `cargo +nightly fmt --check`: clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins`: 8322 passed
- [x] 4 focused unit tests for `recap_is_duplicate_impl` (no new msgs, new msgs exist, flag not set, no cached digest)

> **Note**: `crates/zeph-plugins/src/overlay.rs:348` (`clippy::similar_names`) is a pre-existing failure introduced in #3145 and is not addressed by this PR.

Closes #3143
Closes #3144