### PR TITLE
fix(memory): use effective_embed_provider() in A-MAC admission evaluate() calls

### DIFF
--- a/crates/zeph-memory/src/semantic/recall.rs
+++ b/crates/zeph-memory/src/semantic/recall.rs
@@ -356,7 +356,7 @@ impl SemanticMemory {
                 .evaluate(
                     content,
                     role,
-                    &self.provider,
+                    self.effective_embed_provider(),
                     self.qdrant.as_ref(),
                     goal_text,
                 )
@@ -404,7 +404,7 @@ impl SemanticMemory {
                 .evaluate(
                     content,
                     role,
-                    &self.provider,
+                    self.effective_embed_provider(),
                     self.qdrant.as_ref(),
                     goal_text,
                 )
@@ -452,7 +452,13 @@ impl SemanticMemory {
     ) -> Result<(Option<MessageId>, bool), MemoryError> {
         if let Some(ref admission) = self.admission_control {
             let decision = admission
-                .evaluate(content, role, &self.provider, self.qdrant.as_ref(), None)
+                .evaluate(
+                    content,
+                    role,
+                    self.effective_embed_provider(),
+                    self.qdrant.as_ref(),
+                    None,
+                )
                 .await;
             let preview: String = content.chars().take(100).collect();
             log_admission_decision(&decision, &preview, role, admission.threshold());
@@ -504,7 +510,7 @@ impl SemanticMemory {
                 .evaluate(
                     content,
                     role,
-                    &self.provider,
+                    self.effective_embed_provider(),
                     self.qdrant.as_ref(),
                     goal_text,
                 )


### PR DESCRIPTION
## Summary

- Replaces `&self.provider` with `self.effective_embed_provider()` at all four `admission.evaluate()` call sites in `crates/zeph-memory/src/semantic/recall.rs`
- Eliminates the embed-dimension mismatch that caused `ensure_collection()` to delete-and-recreate the `zeph_conversations` Qdrant collection on every turn when `memory.semantic.embed_provider` was set to a provider with a different vector dimension than the main provider
- Data loss observed 8× in CI-564 and 2× in CI-565 is now resolved

## Root Cause

`SemanticMemory::remember()` passed `&self.provider` to A-MAC admission `evaluate()`, while `embed_and_store_*` correctly used `self.effective_embed_provider()`. With `embed_provider = "ollama-embed"` (768-dim) and OpenAI as main provider (1536-dim), both code paths raced to call `ensure_collection("zeph_conversations", dim)` with conflicting dimensions, each recreating the collection the other just created.

## Test Plan

- [x] `cargo build -p zeph-memory` passes
- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy -p zeph-memory -- -D warnings` passes
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-memory --lib` — 1125 passed, 0 failures

Fixes #3152