### PR TITLE
fix(plugins): rename plugin_dir to entry_dir in overlay.rs test helper

### DIFF
--- a/crates/zeph-plugins/src/overlay.rs
+++ b/crates/zeph-plugins/src/overlay.rs
@@ -345,10 +345,10 @@ mod tests {
     use zeph_config::Config;
 
     fn write_plugin_overlay(plugins_dir: &Path, name: &str, overlay_toml: &str) {
-        let plugin_dir = plugins_dir.join(name);
-        fs::create_dir_all(&plugin_dir).unwrap();
+        let entry_dir = plugins_dir.join(name);
+        fs::create_dir_all(&entry_dir).unwrap();
         fs::write(
-            plugin_dir.join(".plugin.toml"),
+            entry_dir.join(".plugin.toml"),
             format!("[plugin]\nname = \"{name}\"\nversion = \"0.1.0\"\n\n{overlay_toml}"),
         )
         .unwrap();


### PR DESCRIPTION
## Summary

- Renames local binding `plugin_dir` to `entry_dir` in the `write_plugin_overlay` test helper (`crates/zeph-plugins/src/overlay.rs:348`)
- Resolves `clippy::similar_names` violation between the parameter `plugins_dir` and the local binding `plugin_dir`
- Unblocks the CI `cargo clippy --all-targets --workspace --features full -- -D warnings` gate

## Test plan

- [ ] `cargo clippy -p zeph-plugins --all-targets -- -D warnings` passes with zero warnings
- [ ] `cargo +nightly fmt --check` passes
- [ ] `cargo nextest run --workspace --lib --bins` — 8322 tests pass

Closes #3156