### PR TITLE
feat(plugins): add install-time value-level validation for allowed_commands overlay

### DIFF
--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -841,11 +841,12 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
         // spawn_blocking requires 'static, so we cannot borrow &self inside the closure.
         let managed_dir = self.skill_state.managed_dir.clone();
         let mcp_allowed = self.mcp.allowed_commands.clone();
+        let base_shell_allowed = self.lifecycle.startup_shell_overlay.allowed.clone();
         Box::pin(async move {
             // PluginManager performs synchronous filesystem I/O (copy, remove_dir_all,
             // read_dir). Run on a blocking thread to avoid stalling the tokio worker.
             tokio::task::spawn_blocking(move || {
-                Self::run_plugin_command(&args_owned, managed_dir, mcp_allowed)
+                Self::run_plugin_command(&args_owned, managed_dir, mcp_allowed, base_shell_allowed)
             })
             .await
             .map_err(|e| CommandError(format!("plugin task panicked: {e}")))

--- a/crates/zeph-core/src/agent/slash_commands.rs
+++ b/crates/zeph-core/src/agent/slash_commands.rs
@@ -343,6 +343,7 @@ impl<C: crate::channel::Channel> Agent<C> {
         args: &str,
         managed_dir: Option<std::path::PathBuf>,
         mcp_allowed: Vec<String>,
+        base_shell_allowed: Vec<String>,
     ) -> String {
         // Use the canonical default so CLI and TUI always reference the same directory.
         let plugins_dir = zeph_plugins::PluginManager::default_plugins_dir();
@@ -350,7 +351,12 @@ impl<C: crate::channel::Channel> Agent<C> {
         // never silently disabled by an empty path (M5 fix).
         let managed_dir = managed_dir
             .unwrap_or_else(|| zeph_config::defaults::default_vault_dir().join("skills"));
-        let mgr = zeph_plugins::PluginManager::new(plugins_dir, managed_dir, mcp_allowed);
+        let mgr = zeph_plugins::PluginManager::new(
+            plugins_dir,
+            managed_dir,
+            mcp_allowed,
+            base_shell_allowed,
+        );
 
         let (subcmd, rest) = args.trim().split_once(' ').unwrap_or((args.trim(), ""));
         match subcmd {
@@ -380,6 +386,9 @@ impl<C: crate::channel::Channel> Agent<C> {
                                 "\n  MCP servers (restart required): {}",
                                 r.mcp_server_ids.join(", ")
                             );
+                        }
+                        for w in &r.warnings {
+                            let _ = write!(out, "\n  warning: {w}");
                         }
                         out
                     }

--- a/crates/zeph-plugins/src/manager.rs
+++ b/crates/zeph-plugins/src/manager.rs
@@ -36,7 +36,14 @@ pub struct AddResult {
     pub installed_skills: Vec<String>,
     /// MCP server IDs declared by this plugin (require agent restart).
     pub mcp_server_ids: Vec<String>,
-    /// Non-fatal warnings (e.g. config overlay value narrowed by tighten semantics).
+    /// Non-fatal warnings produced at install time.
+    ///
+    /// Currently populated when a plugin's `allowed_commands` overlay will
+    /// have no effect because the host's base `tools.shell.allowed_commands`
+    /// is empty (see issue #3149 — tighten-only semantics mean plugins
+    /// cannot widen an empty base allowlist). Callers should surface these
+    /// to the user alongside the success message (`eprintln!` on the CLI,
+    /// appended to the output string on the TUI).
     pub warnings: Vec<String>,
 }
 
@@ -73,6 +80,10 @@ pub struct PluginManager {
     managed_skills_dir: PathBuf,
     /// `mcp.allowed_commands` from the agent config. Used to validate plugin MCP entries.
     mcp_allowed_commands: Vec<String>,
+    /// Host's base `tools.shell.allowed_commands`. Used to warn when a
+    /// plugin overlay will be silently dropped because the base is empty
+    /// (see issue #3149).
+    base_allowed_commands: Vec<String>,
 }
 
 impl PluginManager {
@@ -94,16 +105,21 @@ impl PluginManager {
     /// - `plugins_dir` — root installation directory for plugins.
     /// - `managed_skills_dir` — directory for user-managed skills (conflict detection).
     /// - `mcp_allowed_commands` — allowlist for MCP server commands from agent config.
+    /// - `base_allowed_commands` — host's `tools.shell.allowed_commands`.
+    ///   Used to emit a non-fatal warning when a plugin overlay would be
+    ///   silently dropped at load time (tighten-only invariant).
     #[must_use]
     pub fn new(
         plugins_dir: PathBuf,
         managed_skills_dir: PathBuf,
         mcp_allowed_commands: Vec<String>,
+        base_allowed_commands: Vec<String>,
     ) -> Self {
         Self {
             plugins_dir,
             managed_skills_dir,
             mcp_allowed_commands,
+            base_allowed_commands,
         }
     }
 
@@ -160,6 +176,16 @@ impl PluginManager {
         // Validate config overlay keys.
         validate_overlay_keys(&manifest.config)?;
 
+        let mut warnings: Vec<String> = Vec::new();
+        if let Some(msg) = check_allowed_commands_overlay_effect(
+            &manifest.config,
+            &self.base_allowed_commands,
+            &manifest.plugin.name,
+        ) {
+            tracing::warn!(plugin = %manifest.plugin.name, "{msg}");
+            warnings.push(msg);
+        }
+
         // Validate MCP command allowlist.
         validate_mcp_commands(&manifest.mcp.servers, &self.mcp_allowed_commands)?;
 
@@ -200,7 +226,7 @@ impl PluginManager {
             plugin_root: dest,
             installed_skills: skill_names,
             mcp_server_ids,
-            warnings: Vec::new(),
+            warnings,
         })
     }
 
@@ -416,6 +442,41 @@ pub(crate) fn validate_plugin_name(name: &str) -> Result<(), PluginError> {
     Ok(())
 }
 
+/// Returns a warning message if the plugin's `allowed_commands` overlay
+/// will be silently dropped because the host's base allowlist is empty.
+///
+/// Returns `None` when the overlay is absent or empty, or when the base
+/// allowlist is non-empty (in which case the overlay will narrow it and
+/// the existing `tracing::info!` in `apply_resolved` already signals the
+/// transition at load time).
+fn check_allowed_commands_overlay_effect(
+    config: &toml::Value,
+    base_allowed: &[String],
+    plugin_name: &str,
+) -> Option<String> {
+    let overlay_has_entries = config
+        .as_table()
+        .and_then(|t| t.get("tools"))
+        .and_then(toml::Value::as_table)
+        .and_then(|t| t.get("allowed_commands"))
+        .and_then(toml::Value::as_array)
+        .is_some_and(|arr| arr.iter().any(toml::Value::is_str));
+
+    if !overlay_has_entries {
+        return None;
+    }
+    if !base_allowed.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "plugin {plugin_name:?} declares allowed_commands overlay but the host \
+         has no tools.shell.allowed_commands configured; overlay will have no effect \
+         at load time (tighten-only: plugins cannot widen an empty base allowlist). \
+         Install proceeds. To use this overlay, set tools.shell.allowed_commands \
+         in your base config."
+    ))
+}
+
 /// Validate all keys in the `[config]` overlay are in the tighten-only safelist.
 pub(crate) fn validate_overlay_keys(config: &toml::Value) -> Result<(), PluginError> {
     let table = match config.as_table() {
@@ -595,7 +656,7 @@ path = "skills/{skill}"
 
         let plugins_dir = tmp.path().join("plugins");
         let managed_dir = tmp.path().join("managed");
-        let mgr = PluginManager::new(plugins_dir.clone(), managed_dir, vec![]);
+        let mgr = PluginManager::new(plugins_dir.clone(), managed_dir, vec![], vec![]);
 
         let result = mgr.add(source.to_str().unwrap()).unwrap();
         assert_eq!(result.name, "test-plugin");
@@ -619,7 +680,7 @@ path = "skills/{skill}"
 
         let plugins_dir = tmp.path().join("plugins");
         let managed_dir = tmp.path().join("managed");
-        let mgr = PluginManager::new(plugins_dir.clone(), managed_dir, vec![]);
+        let mgr = PluginManager::new(plugins_dir.clone(), managed_dir, vec![], vec![]);
         mgr.add(source.to_str().unwrap()).unwrap();
 
         // .bundled markers must not exist in the installed tree.
@@ -647,7 +708,7 @@ command = "dangerous-binary"
 
         let plugins_dir = tmp.path().join("plugins");
         let managed_dir = tmp.path().join("managed");
-        let mgr = PluginManager::new(plugins_dir, managed_dir, vec!["npx".to_owned()]);
+        let mgr = PluginManager::new(plugins_dir, managed_dir, vec!["npx".to_owned()], vec![]);
 
         let err = mgr.add(source.to_str().unwrap()).unwrap_err();
         assert!(matches!(err, PluginError::DisallowedMcpCommand { .. }));
@@ -669,7 +730,7 @@ model = "evil"
 
         let plugins_dir = tmp.path().join("plugins");
         let managed_dir = tmp.path().join("managed");
-        let mgr = PluginManager::new(plugins_dir, managed_dir, vec![]);
+        let mgr = PluginManager::new(plugins_dir, managed_dir, vec![], vec![]);
 
         let err = mgr.add(source.to_str().unwrap()).unwrap_err();
         assert!(matches!(err, PluginError::UnsafeOverlay { .. }));
@@ -691,7 +752,7 @@ max_active_skills = 10
 
         let plugins_dir = tmp.path().join("plugins");
         let managed_dir = tmp.path().join("managed");
-        let mgr = PluginManager::new(plugins_dir, managed_dir, vec![]);
+        let mgr = PluginManager::new(plugins_dir, managed_dir, vec![], vec![]);
 
         let err = mgr.add(source.to_str().unwrap()).unwrap_err();
         assert!(matches!(err, PluginError::UnsafeOverlay { .. }));
@@ -716,7 +777,7 @@ blocked_commands = ["rm -rf"]
 
         let plugins_dir = tmp.path().join("plugins");
         let managed_dir = tmp.path().join("managed");
-        let mgr = PluginManager::new(plugins_dir, managed_dir, vec![]);
+        let mgr = PluginManager::new(plugins_dir, managed_dir, vec![], vec![]);
         let result = mgr.add(source.to_str().unwrap()).unwrap();
         assert_eq!(result.name, "safe-overlay");
     }
@@ -734,7 +795,7 @@ blocked_commands = ["rm -rf"]
 
         let plugins_dir = tmp.path().join("plugins");
         let managed_dir = tmp.path().join("managed");
-        let mgr = PluginManager::new(plugins_dir.clone(), managed_dir, vec![]);
+        let mgr = PluginManager::new(plugins_dir.clone(), managed_dir, vec![], vec![]);
         mgr.add(source.to_str().unwrap()).unwrap();
 
         let result = mgr.remove("removable").unwrap();
@@ -748,7 +809,7 @@ blocked_commands = ["rm -rf"]
     fn remove_nonexistent_plugin_returns_not_found() {
         let tmp = tempfile::tempdir().unwrap();
         let plugins_dir = tmp.path().join("plugins");
-        let mgr = PluginManager::new(plugins_dir, tmp.path().to_path_buf(), vec![]);
+        let mgr = PluginManager::new(plugins_dir, tmp.path().to_path_buf(), vec![], vec![]);
         let err = mgr.remove("no-such-plugin").unwrap_err();
         assert!(matches!(err, PluginError::NotFound { .. }));
     }
@@ -804,7 +865,7 @@ path = "skills/{conflict_name}"
 
         let plugins_dir = tmp.path().join("plugins");
         let managed_dir = tmp.path().join("managed");
-        let mgr = PluginManager::new(plugins_dir, managed_dir, vec![]);
+        let mgr = PluginManager::new(plugins_dir, managed_dir, vec![], vec![]);
 
         let err = mgr.add(source.to_str().unwrap()).unwrap_err();
         assert!(matches!(
@@ -830,7 +891,7 @@ path = "../../../etc/passwd"
 
         let plugins_dir = tmp.path().join("plugins");
         let managed_dir = tmp.path().join("managed");
-        let mgr = PluginManager::new(plugins_dir, managed_dir, vec![]);
+        let mgr = PluginManager::new(plugins_dir, managed_dir, vec![], vec![]);
 
         let err = mgr.add(source.to_str().unwrap()).unwrap_err();
         assert!(
@@ -858,7 +919,7 @@ command = "/tmp/evil/npx"
 
         let plugins_dir = tmp.path().join("plugins");
         let managed_dir = tmp.path().join("managed");
-        let mgr = PluginManager::new(plugins_dir, managed_dir, vec!["npx".to_owned()]);
+        let mgr = PluginManager::new(plugins_dir, managed_dir, vec!["npx".to_owned()], vec![]);
 
         let err = mgr.add(source.to_str().unwrap()).unwrap_err();
         assert!(
@@ -891,7 +952,7 @@ command = "/tmp/evil/npx"
         );
 
         let plugins_dir = tmp.path().join("plugins");
-        let mgr = PluginManager::new(plugins_dir, managed_dir, vec![]);
+        let mgr = PluginManager::new(plugins_dir, managed_dir, vec![], vec![]);
 
         let err = mgr.add(source.to_str().unwrap()).unwrap_err();
         assert!(
@@ -905,7 +966,7 @@ command = "/tmp/evil/npx"
         let tmp = tempfile::tempdir().unwrap();
         let plugins_dir = tmp.path().join("plugins");
         let managed_dir = tmp.path().join("managed");
-        let mgr = PluginManager::new(plugins_dir, managed_dir, vec![]);
+        let mgr = PluginManager::new(plugins_dir, managed_dir, vec![], vec![]);
 
         // Install first plugin with "shared-skill".
         let source_a = tmp.path().join("source_a");
@@ -930,5 +991,88 @@ command = "/tmp/evil/npx"
             matches!(err, PluginError::SkillNameConflictWithPlugin { .. }),
             "expected SkillNameConflictWithPlugin, got {err:?}"
         );
+    }
+
+    #[test]
+    fn allowed_commands_overlay_with_empty_base_warns() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source");
+        let manifest = r#"[plugin]
+name = "warn-test"
+version = "0.1.0"
+description = "test"
+
+[config.tools]
+allowed_commands = ["curl", "git"]
+"#;
+        write_plugin(&source, "warn-test", manifest, &[]);
+
+        let plugins_dir = tmp.path().join("plugins");
+        let managed_dir = tmp.path().join("managed");
+        // base_allowed_commands is empty — overlay will have no effect
+        let mgr = PluginManager::new(plugins_dir, managed_dir, vec![], vec![]);
+
+        let result = mgr.add(source.to_str().unwrap()).unwrap();
+        assert_eq!(result.warnings.len(), 1);
+        let msg = &result.warnings[0];
+        assert!(
+            msg.contains("warn-test"),
+            "warning must contain plugin name"
+        );
+        assert!(
+            msg.contains("allowed_commands"),
+            "warning must mention allowed_commands"
+        );
+        assert!(msg.is_ascii(), "warning message must be ASCII-only");
+    }
+
+    #[test]
+    fn allowed_commands_overlay_with_non_empty_base_no_warn() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source");
+        let manifest = r#"[plugin]
+name = "no-warn-test"
+version = "0.1.0"
+description = "test"
+
+[config.tools]
+allowed_commands = ["curl"]
+"#;
+        write_plugin(&source, "no-warn-test", manifest, &[]);
+
+        let plugins_dir = tmp.path().join("plugins");
+        let managed_dir = tmp.path().join("managed");
+        // base_allowed_commands is non-empty — overlay narrows correctly, no warning
+        let mgr = PluginManager::new(
+            plugins_dir,
+            managed_dir,
+            vec![],
+            vec!["curl".to_owned(), "git".to_owned()],
+        );
+
+        let result = mgr.add(source.to_str().unwrap()).unwrap();
+        assert!(result.warnings.is_empty());
+    }
+
+    #[test]
+    fn empty_allowed_commands_array_no_warn() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source");
+        let manifest = r#"[plugin]
+name = "empty-overlay"
+version = "0.1.0"
+description = "test"
+
+[config.tools]
+allowed_commands = []
+"#;
+        write_plugin(&source, "empty-overlay", manifest, &[]);
+
+        let plugins_dir = tmp.path().join("plugins");
+        let managed_dir = tmp.path().join("managed");
+        let mgr = PluginManager::new(plugins_dir, managed_dir, vec![], vec![]);
+
+        let result = mgr.add(source.to_str().unwrap()).unwrap();
+        assert!(result.warnings.is_empty());
     }
 }

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -620,6 +620,7 @@ impl AppBuilder {
             plugins_dir,
             managed_dir,
             self.config.mcp.allowed_commands.clone(),
+            self.config.tools.shell.allowed_commands.clone(),
         );
         if let Ok(plugin_skill_dirs) = mgr.collect_skill_dirs() {
             for dir in plugin_skill_dirs {
@@ -661,17 +662,23 @@ impl AppBuilder {
     ///
     /// Pass the returned closure to `AgentBuilder::with_plugin_dirs_supplier` so that
     /// `reload_skills()` picks up plugins installed after agent startup.
+    ///
+    /// Both `mcp.allowed_commands` and `tools.shell.allowed_commands` are
+    /// captured by value at construction time. If the operator reloads
+    /// config at runtime, this supplier must be rebuilt.
     pub fn plugin_dirs_supplier(
         &self,
     ) -> impl Fn() -> Vec<std::path::PathBuf> + Send + Sync + 'static {
         let plugins_dir = plugins_dir();
         let managed_dir = managed_skills_dir();
-        let allowed_commands = self.config.mcp.allowed_commands.clone();
+        let mcp_allowed = self.config.mcp.allowed_commands.clone();
+        let base_shell_allowed = self.config.tools.shell.allowed_commands.clone();
         move || {
             let mgr = zeph_plugins::PluginManager::new(
                 plugins_dir.clone(),
                 managed_dir.clone(),
-                allowed_commands.clone(),
+                mcp_allowed.clone(),
+                base_shell_allowed.clone(),
             );
             mgr.collect_skill_dirs().unwrap_or_default()
         }

--- a/src/commands/plugin.rs
+++ b/src/commands/plugin.rs
@@ -23,8 +23,14 @@ pub(crate) fn handle_plugin_command(
 
     let managed_skills_dir = crate::bootstrap::managed_skills_dir();
     let mcp_allowed = config.mcp.allowed_commands.clone();
+    let base_shell_allowed = config.tools.shell.allowed_commands.clone();
 
-    let mgr = zeph_plugins::PluginManager::new(plugins_dir, managed_skills_dir, mcp_allowed);
+    let mgr = zeph_plugins::PluginManager::new(
+        plugins_dir,
+        managed_skills_dir,
+        mcp_allowed,
+        base_shell_allowed,
+    );
 
     match cmd {
         PluginCommand::List => {
@@ -49,6 +55,9 @@ pub(crate) fn handle_plugin_command(
                     "  MCP servers (restart required): {}",
                     result.mcp_server_ids.join(", ")
                 );
+            }
+            for w in &result.warnings {
+                eprintln!("warning: {w}");
             }
             // Pointer to plugin add for future users.
             println!(


### PR DESCRIPTION
## Summary

- Populates `AddResult::warnings` when a plugin ships a non-empty `allowed_commands` overlay but the host's base `tools.shell.allowed_commands` is empty — the overlay would be silently dropped at load time (B2 invariant from PR #3145), and users previously had no feedback.
- Surfaces the warning on all three channels: CLI (stderr), TUI (slash-command output), bootstrap startup (`tracing::warn!`).
- All 4 `PluginManager::new` call sites updated to thread `base_allowed_commands`.
- 3 new unit tests covering the warning edge cases.

## Known limitations (documented, not addressed in this PR)

- **Post-overlay base semantics**: `base_allowed_commands` reflects the host config *after* prior plugin overlays are applied, so the warning text ("base config has no `allowed_commands` configured") may be slightly inaccurate when a prior overlay zeroed the effective list. Low impact; advisory only.
- **Startup snapshot TOCTOU**: `base_allowed_commands` is captured at startup; a hot-reload that changes the base list requires an agent restart before the warning reflects the new state. Pre-existing limitation, not introduced here.
- **Reload-time silent-drop**: `tracing::debug!` at reload time when an installed plugin's overlay has no effect (transplanted plugin dir gap). Follow-up: raise to `warn!` with a once-per-plugin guard.

## Test plan

- [x] `cargo nextest run -p zeph-plugins --lib` — 40/40 pass (3 new tests)
- [x] `cargo nextest run --workspace --lib --bins` — 8322/8322 pass
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean

Closes #3149