### PR TITLE
fix(memory): correct A-MAC admission provider fallback in bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **fix(memory): A-MAC admission control now correctly falls back to embed provider when
+  `admission_provider` is not configured** — `build_admission_control()` previously always
+  called `.with_provider(main_provider)` even when `admission_provider` was empty, causing
+  `evaluate()` to use the 1536-dim main provider and ignore the 768-dim embed provider
+  passed as `fallback_provider` from `recall.rs`. Now `.with_provider()` is only called
+  when `admission_provider` is explicitly set and resolves successfully; otherwise
+  `AdmissionControl.provider = None` and `evaluate()` correctly uses the embed provider.
+  Closes [#3158](https://github.com/bug-ops/zeph/issues/3158).
+
+- **test(memory): regression test for A-MAC admission without dedicated embed provider** —
+  `admission_without_dedicated_provider_uses_embed_provider` verifies that `remember()`
+  succeeds and admits a message when `AdmissionControl` has no dedicated provider set.
+  Closes [#3155](https://github.com/bug-ops/zeph/issues/3155).
+
 - **fix(core): run plugin filesystem I/O on a blocking thread** — `handle_plugins` now
   clones the required state fields (`managed_dir`, `mcp_allowed`) before the async block
   and executes the `PluginManager` call inside `tokio::task::spawn_blocking`. Previously

--- a/crates/zeph-memory/src/semantic/tests/recall.rs
+++ b/crates/zeph-memory/src/semantic/tests/recall.rs
@@ -599,3 +599,30 @@ async fn remember_with_parts_returns_some_when_admission_admits() {
         "remember_with_parts must return Some(id) when admitted"
     );
 }
+
+#[tokio::test]
+async fn admission_without_dedicated_provider_uses_embed_provider() {
+    // Regression test for #3158: AdmissionControl with no dedicated provider (provider = None)
+    // must succeed using the embed provider from SemanticMemory rather than panicking or
+    // falling back to the main 1536-dim provider.
+    let memory = test_semantic_memory(false)
+        .await
+        .with_admission_control(make_always_admit_admission());
+    // make_always_admit_admission() creates AdmissionControl::new(...) with NO .with_provider()
+    // call, which is exactly the unconfigured path fixed in src/bootstrap/mod.rs.
+
+    let cid = memory.sqlite.create_conversation().await.unwrap();
+    let result = memory
+        .remember(
+            cid,
+            "user",
+            "content evaluated without dedicated admission provider",
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(
+        result.is_some(),
+        "admission without dedicated provider must admit when threshold=0.0"
+    );
+}

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -349,7 +349,7 @@ impl AppBuilder {
         }
 
         if self.config.memory.admission.enabled {
-            memory = memory.with_admission_control(self.build_admission_control(provider));
+            memory = memory.with_admission_control(self.build_admission_control());
         }
 
         if let Some(ep) = self.build_memory_embed_provider() {
@@ -423,34 +423,7 @@ pub fn spawn_embed_backfill(
 }
 
 impl AppBuilder {
-    fn build_admission_control(
-        &self,
-        fallback_provider: &AnyProvider,
-    ) -> zeph_memory::AdmissionControl {
-        let admission_provider = if self.config.memory.admission.admission_provider.is_empty() {
-            fallback_provider.clone()
-        } else {
-            match create_named_provider(
-                &self.config.memory.admission.admission_provider,
-                &self.config,
-            ) {
-                Ok(p) => {
-                    tracing::info!(
-                        provider = %self.config.memory.admission.admission_provider,
-                        "A-MAC admission provider configured"
-                    );
-                    p
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        provider = %self.config.memory.admission.admission_provider,
-                        error = %e,
-                        "A-MAC admission provider resolution failed — primary provider will be used"
-                    );
-                    fallback_provider.clone()
-                }
-            }
-        };
+    fn build_admission_control(&self) -> zeph_memory::AdmissionControl {
         let w = &self.config.memory.admission.weights;
         let weights = zeph_memory::AdmissionWeights {
             future_utility: w.future_utility,
@@ -464,8 +437,29 @@ impl AppBuilder {
             self.config.memory.admission.threshold,
             self.config.memory.admission.fast_path_margin,
             weights,
-        )
-        .with_provider(admission_provider);
+        );
+        if !self.config.memory.admission.admission_provider.is_empty() {
+            match create_named_provider(
+                &self.config.memory.admission.admission_provider,
+                &self.config,
+            ) {
+                Ok(p) => {
+                    tracing::info!(
+                        provider = %p.name(),
+                        "A-MAC admission provider configured"
+                    );
+                    control = control.with_provider(p);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        provider = %self.config.memory.admission.admission_provider,
+                        error = %e,
+                        "A-MAC admission provider resolution failed — embed provider will be used as fallback"
+                    );
+                    // intentionally no .with_provider() — evaluate() will use fallback embed provider
+                }
+            }
+        }
 
         if self.config.memory.admission.goal_conditioned_write {
             let goal_provider = if self


### PR DESCRIPTION
## Summary

- `build_admission_control()` previously stored the main LLM provider (e.g. OpenAI 1536-dim) as `AdmissionControl.provider` even when `admission_provider` was not configured, because the unconfigured branch passed `fallback_provider` (main provider) to `.with_provider()`. As a result `evaluate()` always used the 1536-dim provider and ignored the 768-dim embed provider passed as fallback from `recall.rs`, causing vector dimension oscillation on every turn.
- Fix: only call `.with_provider()` when `admission_provider` is explicitly configured and resolves successfully. When unconfigured or resolution fails, leave `AdmissionControl.provider = None` so `evaluate()` correctly uses the embed provider via its `fallback_provider` argument.
- Added regression test `admission_without_dedicated_provider_uses_embed_provider` that exercises the `provider = None` path and would have caught this regression.

## Test plan

- [x] `cargo +nightly fmt --check` — pass
- [x] `cargo clippy -p zeph-memory -p zeph -- -D warnings` — pass
- [x] `cargo nextest run --workspace --lib --bins` — 8323 passed, 20 skipped
- [x] New regression test verifies `remember()` succeeds when `AdmissionControl.provider = None`
- [ ] Live test: configure `embed_provider = "ollama-embed"` with no `admission_provider`, send messages, confirm no `vector dimension mismatch` WARN in logs

Closes #3158
Closes #3155