### PR TITLE
fix(tools): exempt invoke_skill and load_skill from utility gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **fix(tools): `invoke_skill` and `load_skill` are now exempt from the utility gate** —
+  `UtilityScoringConfig::default()` previously set `exempt_tools` to an empty list, causing
+  the utility scorer to block `invoke_skill` calls with `Retrieve` or `Respond` verdicts
+  even though these tools were already exempted from the adversarial and vigil gates in
+  PR #3150. The default now includes both `invoke_skill` and `load_skill`, matching the
+  existing `AdversarialPolicyConfig::default_exempt_tools()` behaviour.
+  Closes [#3163](https://github.com/bug-ops/zeph/issues/3163).
+
 - **fix(memory): A-MAC admission control now correctly falls back to embed provider when
   `admission_provider` is not configured** — `build_admission_control()` previously always
   called `.with_provider(main_provider)` even when `admission_provider` was empty, causing

--- a/crates/zeph-tools/src/config.rs
+++ b/crates/zeph-tools/src/config.rs
@@ -238,7 +238,7 @@ impl Default for UtilityScoringConfig {
             cost_weight: default_utility_cost_weight(),
             redundancy_weight: default_utility_redundancy_weight(),
             uncertainty_bonus: default_utility_uncertainty_bonus(),
-            exempt_tools: Vec::new(),
+            exempt_tools: vec!["invoke_skill".to_string(), "load_skill".to_string()],
         }
     }
 }
@@ -1267,6 +1267,19 @@ mod tests {
         assert!(
             exempt.contains(&"invoke_skill".to_string()),
             "default exempt_tools must contain invoke_skill"
+        );
+    }
+
+    #[test]
+    fn utility_scoring_default_exempt_tools_contains_skill_ops() {
+        let cfg = UtilityScoringConfig::default();
+        assert!(
+            cfg.exempt_tools.contains(&"invoke_skill".to_string()),
+            "UtilityScoringConfig default exempt_tools must contain invoke_skill"
+        );
+        assert!(
+            cfg.exempt_tools.contains(&"load_skill".to_string()),
+            "UtilityScoringConfig default exempt_tools must contain load_skill"
         );
     }
 }


### PR DESCRIPTION
## Summary

- `UtilityScoringConfig::default()` had `exempt_tools: Vec::new()`, causing the utility scorer to block `invoke_skill` and `load_skill` calls with `Retrieve`/`Respond` verdicts
- Added both tools to the default exempt list, matching the existing `AdversarialPolicyConfig::default_exempt_tools()` behaviour from #3150
- Added regression test `utility_scoring_default_exempt_tools_contains_skill_ops`

## Test plan

- [ ] `cargo nextest run -p zeph-tools -E 'test(utility_scoring_default_exempt)'` — passes
- [ ] Live session: `echo "use the /help skill" | cargo run --features full -- --config .local/config/testing.toml` — skill executes without utility gate block

Closes #3163