### PR TITLE
fix(core): clippy violations in test targets and TaskSupervisor shutdown timeout (#3160, #3161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **fix(core): clippy cleanup in test code** — resolved four clippy violations in test-only
+  code: `useless_vec` (array literal instead of `vec!`), `match_like_matches_macro` (`!matches!`
+  macro), `match_wild_err_arm` (named binding in `Err` arm), and `duration_suboptimal_units`
+  (`Duration::from_mins(1)` instead of `from_secs(60)`). No production code changed.
+  Closes [#3160](https://github.com/bug-ops/zeph/issues/3160).
+
+- **fix(core): TaskSupervisor reap driver drains completions after cancel** — the reap driver
+  in `start_reap_driver` previously broke out of its loop after a single `try_recv` when the
+  cancellation token fired, silently dropping completions sent by tasks that observed cancel
+  slightly later. This caused `shutdown_all` to always hit the force-abort timeout
+  (`remaining=1`). The driver now runs a post-cancel drain phase (bounded by
+  `SHUTDOWN_DRAIN_TIMEOUT = 5s`) that continues processing completions until the registry
+  reports no active tasks. `handle_completion` also short-circuits when cancelled to prevent
+  `Restart`-policy tasks from re-registering. The `shutdown timeout` WARN now includes the
+  names of remaining tasks for diagnosis. Closes [#3161](https://github.com/bug-ops/zeph/issues/3161).
+
 - **fix(tools): `invoke_skill` and `load_skill` are now exempt from the utility gate** —
   `UtilityScoringConfig::default()` previously set `exempt_tools` to an empty list, causing
   the utility scorer to block `invoke_skill` calls with `Retrieve` or `Respond` verdicts

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -1869,14 +1869,16 @@ mod tests {
             git_hash: None,
             category: None,
         };
-        let skills = vec![make_meta("blocked-skill"), make_meta("allowed-skill")];
+        let skills = [make_meta("blocked-skill"), make_meta("allowed-skill")];
 
         // Apply the same filter logic used in the catalog-building path.
         let catalog: Vec<_> = skills
             .iter()
-            .filter(|s| match trust_map.get(s.name.as_str()) {
-                Some(SkillTrustLevel::Blocked) => false,
-                _ => true,
+            .filter(|s| {
+                !matches!(
+                    trust_map.get(s.name.as_str()),
+                    Some(SkillTrustLevel::Blocked)
+                )
             })
             .collect();
 

--- a/crates/zeph-core/src/agent/tests.rs
+++ b/crates/zeph-core/src/agent/tests.rs
@@ -2840,7 +2840,7 @@ pub mod agent_tests {
         {
             Ok(Ok(())) => {}
             Ok(Err(e)) => panic!("terminal save failed: {e}"),
-            Err(_) => panic!("terminal save timed out"),
+            Err(e) => panic!("terminal save timed out after 5s: {e}"),
         }
         drop(persistence);
 
@@ -3088,6 +3088,7 @@ mod compaction_e2e {
 
     // ── /plan handler unit tests ─────────────────────────────────────────────
 
+    #[cfg(feature = "scheduler")]
     use zeph_orchestration::{
         GraphStatus, PlanCommand, TaskGraph, TaskNode, TaskResult, TaskStatus,
     };
@@ -3103,6 +3104,7 @@ mod compaction_e2e {
         agent
     }
 
+    #[cfg(feature = "scheduler")]
     fn make_simple_graph(status: GraphStatus) -> TaskGraph {
         let mut g = TaskGraph::new("test goal");
         let mut node = TaskNode::new(0, "task-0", "do something");

--- a/crates/zeph-core/src/agent/tool_execution/tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests.rs
@@ -4861,7 +4861,7 @@ mod pii_ner_circuit_breaker {
             >,
         > {
             Box::pin(async move {
-                tokio::time::sleep(Duration::from_secs(60)).await;
+                tokio::time::sleep(Duration::from_mins(1)).await;
                 Ok(ClassificationResult {
                     label: "O".into(),
                     score: 0.0,

--- a/crates/zeph-core/src/task_supervisor.rs
+++ b/crates/zeph-core/src/task_supervisor.rs
@@ -91,6 +91,12 @@ pub enum RestartPolicy {
 /// Maximum delay between restart attempts (caps exponential backoff).
 pub const MAX_RESTART_DELAY: Duration = Duration::from_mins(1);
 
+/// Safety cap on how long the reap driver drains completions after cancellation.
+///
+/// INVARIANT: must be less than the runner shutdown grace period (runner.rs:2387,
+/// currently 10s). If that constant is reduced, this must be reduced proportionally.
+const SHUTDOWN_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Configuration passed to [`TaskSupervisor::spawn`] to describe a supervised task.
 ///
 /// `F` must be `Fn` (not `FnOnce`) to support restarts: the factory is called once on
@@ -651,20 +657,25 @@ impl TaskSupervisor {
                 break;
             }
             if tokio::time::Instant::now() >= deadline {
-                tracing::warn!(
-                    remaining = active,
-                    "shutdown timeout — aborting remaining tasks"
-                );
-                let mut state = self.inner.state.lock();
-                for entry in state.tasks.values_mut() {
-                    if matches!(
-                        entry.status,
-                        TaskStatus::Running | TaskStatus::Restarting { .. }
-                    ) {
-                        entry.abort_handle.abort();
-                        entry.status = TaskStatus::Aborted;
+                let mut remaining_names: Vec<Arc<str>> = Vec::new();
+                {
+                    let mut state = self.inner.state.lock();
+                    for entry in state.tasks.values_mut() {
+                        if matches!(
+                            entry.status,
+                            TaskStatus::Running | TaskStatus::Restarting { .. }
+                        ) {
+                            remaining_names.push(Arc::clone(&entry.name));
+                            entry.abort_handle.abort();
+                            entry.status = TaskStatus::Aborted;
+                        }
                     }
                 }
+                tracing::warn!(
+                    remaining = active,
+                    tasks = ?remaining_names,
+                    "shutdown timeout — aborting remaining tasks"
+                );
                 break;
             }
             tokio::time::sleep(Duration::from_millis(50)).await;
@@ -767,22 +778,55 @@ impl TaskSupervisor {
         cancel: CancellationToken,
     ) {
         tokio::spawn(async move {
+            // Phase 1: normal operation — process completions until cancel fires.
             loop {
                 tokio::select! {
                     biased;
                     Some(completion) = completion_rx.recv() => {
                         Self::handle_completion(&inner, completion).await;
                     }
-                    () = cancel.cancelled() => {
-                        // Drain any completions that arrived at the same time as the cancel.
-                        while let Ok(completion) = completion_rx.try_recv() {
-                            Self::handle_completion(&inner, completion).await;
-                        }
-                        break;
-                    }
+                    () = cancel.cancelled() => break,
                 }
             }
+
+            // Phase 2: post-cancel drain — keep receiving completions until the
+            // registry reports no active tasks, or the channel closes, or the safety
+            // deadline expires. This prevents losing completions that arrive after
+            // tasks observe cancellation (#3161).
+            let drain_deadline = tokio::time::Instant::now() + SHUTDOWN_DRAIN_TIMEOUT;
+            let active = Self::has_active_tasks(&inner);
+            tracing::debug!(active, "reap driver entered post-cancel drain phase");
+            loop {
+                if !Self::has_active_tasks(&inner) {
+                    break;
+                }
+                let remaining =
+                    drain_deadline.saturating_duration_since(tokio::time::Instant::now());
+                if remaining.is_zero() {
+                    break;
+                }
+                match tokio::time::timeout(remaining, completion_rx.recv()).await {
+                    Ok(Some(completion)) => Self::handle_completion(&inner, completion).await,
+                    // channel closed (unreachable in practice — senders live in Inner), or deadline elapsed
+                    Ok(None) | Err(_) => break,
+                }
+            }
+            tracing::debug!(
+                active = Self::has_active_tasks(&inner),
+                "reap driver drain phase complete"
+            );
         });
+    }
+
+    /// Returns `true` if any task is in `Running` or `Restarting` state.
+    fn has_active_tasks(inner: &Arc<Inner>) -> bool {
+        let state = inner.state.lock();
+        state.tasks.values().any(|e| {
+            matches!(
+                e.status,
+                TaskStatus::Running | TaskStatus::Restarting { .. }
+            )
+        })
     }
 
     /// Process a single task completion event.
@@ -791,6 +835,15 @@ impl TaskSupervisor {
     /// under lock; Phase 2 sleeps with exponential backoff without a lock;
     /// Phase 3 spawns the next instance and updates the registry.
     async fn handle_completion(inner: &Arc<Inner>, completion: Completion) {
+        // Short-circuit: once cancellation has fired, never schedule restarts.
+        // Without this, Restart-policy tasks re-register as Running, causing
+        // has_active_tasks() to stay true and the drain loop to spin until timeout.
+        if inner.cancel.is_cancelled() {
+            let mut state = inner.state.lock();
+            state.tasks.remove(&completion.name);
+            return;
+        }
+
         let Some((attempt, max, delay)) = Self::classify_completion(inner, &completion) else {
             return;
         };
@@ -1507,6 +1560,46 @@ mod tests {
         assert!(
             sup.cancellation_token().is_cancelled(),
             "token must be cancelled after shutdown"
+        );
+    }
+
+    /// Regression test for #3161: after `shutdown_all`, all tasks must be reaped
+    /// even when they complete *after* the cancel signal.
+    ///
+    /// The yield loop forces the reap driver to observe cancel and exit phase-1
+    /// before the tasks send their completions — reliably reproducing the race.
+    #[tokio::test]
+    async fn test_shutdown_drains_post_cancel_completions() {
+        let cancel = CancellationToken::new();
+        let sup = TaskSupervisor::new(cancel.clone());
+
+        for name in [
+            "loop-1", "loop-2", "loop-3", "loop-4", "loop-5", "loop-6", "loop-7",
+        ] {
+            let cancel_inner = cancel.clone();
+            sup.spawn(TaskDescriptor {
+                name,
+                restart: RestartPolicy::RunOnce,
+                factory: move || {
+                    let c = cancel_inner.clone();
+                    async move {
+                        c.cancelled().await;
+                        // Yield multiple times so the reap driver observes cancel first.
+                        for _ in 0..64 {
+                            tokio::task::yield_now().await;
+                        }
+                    }
+                },
+            });
+        }
+        assert_eq!(sup.active_count(), 7);
+
+        sup.shutdown_all(Duration::from_secs(2)).await;
+
+        assert_eq!(
+            sup.active_count(),
+            0,
+            "all tasks must be reaped after shutdown (#3161)"
         );
     }
 


### PR DESCRIPTION
## Summary

- Fixes 4 clippy violations in `zeph-core` test code that blocked `--all-targets` pre-PR gate (#3160)
- Fixes `TaskSupervisor` reap-driver race causing `shutdown timeout` WARN on every CLI session (#3161)

## Changes

### #3160 — clippy violations (test code only)

| File | Lint | Fix |
|------|------|-----|
| `agent/context/assembly.rs:1872` | `useless_vec` | Array literal instead of `vec!` |
| `agent/context/assembly.rs:1877` | `match_like_matches_macro` | `!matches!` macro |
| `agent/tests.rs:2843` | `match_wild_err_arm` | Named `Err(e)` binding with message |
| `agent/tool_execution/tests.rs:4864` | `duration_suboptimal_units` | `Duration::from_mins(1)` |

Also gates pre-existing `PlanCommand` import and `make_simple_graph` fn behind `#[cfg(feature = "scheduler")]`.

### #3161 — TaskSupervisor shutdown timeout

**Root cause:** `start_reap_driver` broke out of its loop immediately after `cancel.cancelled()` fired (single `try_recv` drain). Tasks that observed cancellation slightly later sent their completion events after the reap driver had already exited, so `active_count` never reached zero and `shutdown_all` force-aborted after 10s.

**Fix:**
- Two-phase drain in `start_reap_driver`: phase 2 continues `recv()`-ing completions until `active_count == 0` or `SHUTDOWN_DRAIN_TIMEOUT = 5s` (< 10s runner grace period)
- `handle_completion` short-circuits on `is_cancelled()` to prevent `RestartPolicy::Restart` tasks from re-registering during drain
- `shutdown_all` WARN now logs remaining task names for diagnosis
- Regression test: `test_shutdown_drains_post_cancel_completions` (7 tasks + 64-yield race amplification)

## Test plan

- [x] `cargo clippy --all-targets --workspace --features full -- -D warnings` — zero errors
- [x] `cargo nextest run --workspace --lib --bins` — 8338 passed, 0 failed
- [x] `test_shutdown_drains_post_cancel_completions` passes
- [x] CHANGELOG.md updated under `[Unreleased]`

Closes #3160
Closes #3161