### PR TITLE
release: v0.19.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.19.2] - 2026-04-18
+
 ### Added
 
 - **feat(tui): multi-session groundwork phase-1** (#3130) — introduces `SessionSlot` and
@@ -4482,7 +4484,8 @@ let agent = Agent::new(provider, channel, &skills_prompt, executor);
 - Agent::run() uses tokio::select! to race channel messages against shutdown signal
 
 [0.16.0]: https://github.com/bug-ops/zeph/compare/v0.15.3...v0.16.0
-[Unreleased]: https://github.com/bug-ops/zeph/compare/v0.19.1...HEAD
+[Unreleased]: https://github.com/bug-ops/zeph/compare/v0.19.2...HEAD
+[0.19.2]: https://github.com/bug-ops/zeph/compare/v0.19.1...v0.19.2
 [0.19.1]: https://github.com/bug-ops/zeph/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/bug-ops/zeph/compare/v0.18.6...v0.19.0
 [0.18.6]: https://github.com/bug-ops/zeph/compare/v0.18.5...v0.18.6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,9 +423,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -433,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -472,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core 0.5.6",
  "axum-macros",
@@ -500,7 +500,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
@@ -548,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "axum-macros"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
+checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -649,9 +649,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
@@ -720,7 +720,7 @@ checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bollard-buildkit-proto",
  "bollard-stubs",
  "bytes",
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1114,9 +1114,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1465,7 +1465,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "derive_more 2.1.1",
  "document-features",
@@ -1690,9 +1690,9 @@ dependencies = [
 
 [[package]]
 name = "dary_heap"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
 dependencies = [
  "serde",
 ]
@@ -1909,7 +1909,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "objc2",
 ]
 
@@ -2261,12 +2261,12 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferroid"
-version = "0.8.9"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb330bbd4cb7a5b9f559427f06f98a4f853a137c8298f3bd3f8ca57663e21986"
+checksum = "ee93edf3c501f0035bbeffeccfed0b79e14c311f12195ec0e661e114a0f60da4"
 dependencies = [
  "portable-atomic",
- "rand 0.9.4",
+ "rand 0.10.1",
  "web-time",
 ]
 
@@ -3186,9 +3186,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.8"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
@@ -3197,7 +3197,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -3545,7 +3545,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "inotify-sys",
  "libc",
 ]
@@ -3869,7 +3869,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "libc",
  "plain",
  "redox_syscall 0.7.4",
@@ -3892,7 +3892,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -3935,7 +3935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7184fdea2bc3cd272a1acec4030c321a8f9875e877b3f92a53f2f6033fdc289"
 dependencies = [
  "aes",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cbc",
  "ecb",
  "encoding_rs",
@@ -3958,9 +3958,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -4094,7 +4094,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "block",
  "core-graphics-types",
  "foreign-types",
@@ -4239,7 +4239,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -4252,7 +4252,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -4294,7 +4294,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -4324,7 +4324,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -4525,7 +4525,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "dispatch2",
  "objc2",
 ]
@@ -4542,7 +4542,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "block2",
  "libc",
  "objc2",
@@ -4565,7 +4565,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "block2",
  "dispatch2",
  "objc2",
@@ -4619,7 +4619,7 @@ version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "libc",
  "once_cell",
  "onig_sys",
@@ -5314,7 +5314,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
@@ -5467,7 +5467,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -5787,7 +5787,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "compact_str",
  "hashbrown 0.16.1",
  "indoc",
@@ -5839,7 +5839,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.16.1",
  "indoc",
  "instability",
@@ -5858,14 +5858,14 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -5922,7 +5922,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -5931,7 +5931,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -6036,7 +6036,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -6105,9 +6105,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f542f74cf247da16f19bbc87e298cd201e912314f4083e88cdd671f44f5fcb53"
+checksum = "67d69668de0b0ccd9cc435f700f3b39a7861863cf37a15e1f304ea78688a4826"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6134,9 +6134,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2391e4ae47f314e70eaafb6c7bd82e495e770b935448864446302143019151f"
+checksum = "48fdc01c81097b0aed18633e676e269fefa3a78ec1df56b4fe597c1241b92025"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -6262,7 +6262,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -6536,7 +6536,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -6559,7 +6559,7 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cssparser",
  "derive_more 2.1.1",
  "log",
@@ -7099,7 +7099,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "byteorder",
  "bytes",
  "crc",
@@ -7140,7 +7140,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "byteorder",
  "crc",
  "dotenvy",
@@ -7357,9 +7357,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symbolic-common"
-version = "12.18.0"
+version = "12.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aba7211a1803a826f108af9f4d86d25abe880712f2a6449479279e861b293f8"
+checksum = "b1f3cdeaae6779ecba2567f20bf7716718b8c4ce6717c9def4ced18786bb11ea"
 dependencies = [
  "debugid",
  "memmap2",
@@ -7369,13 +7369,19 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.18.0"
+version = "12.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595bddd9d363c2ef6fc9fb33b98416ff209c5aae8bdca89a7dbbf2ef5e0ecc45"
+checksum = "672c6ad9cb8fce6a1283cc9df9070073cccad00ae241b80e3686328a64e3523b"
 dependencies = [
  "rustc-demangle",
  "symbolic-common",
 ]
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "symphonia"
@@ -7534,7 +7540,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "byteorder",
  "enum-as-inner",
  "libc",
@@ -7562,7 +7568,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -7621,7 +7627,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f7a34ca8e971fa892e633858c07547fe138ef4a02e4a4eaa1d35e517d6e0bc4"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "chrono",
  "derive_more 1.0.0",
@@ -7711,7 +7717,7 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "fancy-regex 0.11.0",
  "filedescriptor",
  "finl_unicode",
@@ -7747,9 +7753,9 @@ dependencies = [
 
 [[package]]
 name = "testcontainers"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd36b06a2a6c0c3c81a83be1ab05fe86460d054d4d51bf513bc56b3e15bdc22"
+checksum = "bfd5785b5483672915ed5fe3cddf9f546802779fc1eceff0a6fb7321fac81c1e"
 dependencies = [
  "astral-tokio-tar",
  "async-trait",
@@ -7963,9 +7969,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -8012,18 +8018,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.28.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
@@ -8035,7 +8029,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite 0.29.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -8155,7 +8149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
- "axum 0.8.8",
+ "axum 0.8.9",
  "base64 0.22.1",
  "bytes",
  "h2",
@@ -8233,7 +8227,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -8273,11 +8267,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
+ "symlink",
  "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
@@ -8525,23 +8520,6 @@ name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
-
-[[package]]
-name = "tungstenite"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
-dependencies = [
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand 0.9.4",
- "sha1",
- "thiserror 2.0.18",
- "utf-8",
-]
 
 [[package]]
 name = "tungstenite"
@@ -8793,7 +8771,7 @@ dependencies = [
  "socks",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -8847,9 +8825,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "atomic",
  "getrandom 0.4.2",
@@ -8933,11 +8911,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -8946,7 +8924,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -9064,7 +9042,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -9104,9 +9082,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -9117,14 +9095,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -9753,6 +9731,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "wit-bindgen-core"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9801,7 +9785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "indexmap 2.14.0",
  "log",
  "serde",
@@ -9908,11 +9892,11 @@ dependencies = [
 
 [[package]]
 name = "zeph"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum 0.8.8",
+ "axum 0.8.9",
  "blake3",
  "chrono",
  "clap",
@@ -9975,9 +9959,9 @@ dependencies = [
 
 [[package]]
 name = "zeph-a2a"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
- "axum 0.8.8",
+ "axum 0.8.9",
  "base64 0.22.1",
  "blake3",
  "eventsource-stream",
@@ -10005,12 +9989,12 @@ dependencies = [
 
 [[package]]
 name = "zeph-acp"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "agent-client-protocol",
  "async-stream",
  "async-trait",
- "axum 0.8.8",
+ "axum 0.8.9",
  "base64 0.22.1",
  "blake3",
  "chrono",
@@ -10028,7 +10012,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite 0.29.0",
+ "tokio-tungstenite",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "tower 0.5.3",
@@ -10045,7 +10029,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-bench"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "clap",
  "serde",
@@ -10060,9 +10044,9 @@ dependencies = [
 
 [[package]]
 name = "zeph-channels"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
- "axum 0.8.8",
+ "axum 0.8.9",
  "criterion",
  "crossterm",
  "futures",
@@ -10076,7 +10060,7 @@ dependencies = [
  "teloxide",
  "tempfile",
  "tokio",
- "tokio-tungstenite 0.29.0",
+ "tokio-tungstenite",
  "tokio-util",
  "tracing",
  "unicode-width",
@@ -10086,7 +10070,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-commands"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "thiserror 2.0.18",
  "tokio",
@@ -10095,7 +10079,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-common"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "blake3",
  "serde",
@@ -10116,7 +10100,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-config"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "dirs",
  "insta",
@@ -10138,7 +10122,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-context"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "futures",
  "parking_lot",
@@ -10155,7 +10139,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-core"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "age",
  "base64 0.22.1",
@@ -10217,7 +10201,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-db"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "regex",
  "sqlx",
@@ -10232,7 +10216,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-experiments"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "futures",
  "ordered-float 5.3.0",
@@ -10255,9 +10239,9 @@ dependencies = [
 
 [[package]]
 name = "zeph-gateway"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
- "axum 0.8.8",
+ "axum 0.8.9",
  "blake3",
  "http-body-util",
  "prometheus-client",
@@ -10274,7 +10258,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-index"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "futures",
  "ignore",
@@ -10308,7 +10292,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-llm"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "async-stream",
  "audioadapter-buffers",
@@ -10350,7 +10334,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-mcp"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "async-trait",
  "blake3",
@@ -10381,7 +10365,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-memory"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "blake3",
  "chrono",
@@ -10415,7 +10399,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-orchestration"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "blake3",
  "dirs",
@@ -10442,7 +10426,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-plugins"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "dirs",
@@ -10464,7 +10448,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-sanitizer"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "proptest",
  "regex",
@@ -10484,7 +10468,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-scheduler"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "chrono",
  "cron",
@@ -10502,7 +10486,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-skills"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "blake3",
@@ -10536,7 +10520,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-subagent"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "dirs",
  "indoc",
@@ -10563,7 +10547,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-tools"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "arc-swap",
  "dirs",
@@ -10605,7 +10589,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-tui"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "chrono",
  "crossterm",
@@ -10642,7 +10626,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-vault"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "age",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 rust-version = "1.94"
-version = "0.19.1"
+version = "0.19.2"
 authors = ["bug-ops"]
 license = "MIT"
 repository = "https://github.com/bug-ops/zeph"
@@ -75,7 +75,7 @@ rand_distr = "0.6"
 ratatui = "0.30"
 regex = "1.12"
 reqwest = { version = "0.13", default-features = false }
-rmcp = "1.4"
+rmcp = "1.5"
 audioadapter-buffers = "3.0"
 rubato = "2.0"
 schemars = "1.2"
@@ -134,31 +134,31 @@ uuid = "1.23"
 walkdir = "2.5"
 wiremock = "0.6.5"
 zeroize = { version = "1", default-features = false }
-zeph-a2a = { path = "crates/zeph-a2a", version = "0.19.1" }
-zeph-bench = { path = "crates/zeph-bench", version = "0.19.1" }
-zeph-acp = { path = "crates/zeph-acp", version = "0.19.1" }
-zeph-db = { path = "crates/zeph-db", default-features = false, version = "0.19.1" }
-zeph-channels = { path = "crates/zeph-channels", version = "0.19.1" }
-zeph-common = { path = "crates/zeph-common", version = "0.19.1" }
-zeph-config = { path = "crates/zeph-config", version = "0.19.1" }
-zeph-commands = { path = "crates/zeph-commands", version = "0.19.1" }
-zeph-context = { path = "crates/zeph-context", version = "0.19.1" }
-zeph-core = { path = "crates/zeph-core", version = "0.19.1" }
-zeph-experiments = { path = "crates/zeph-experiments", version = "0.19.1" }
-zeph-gateway = { path = "crates/zeph-gateway", version = "0.19.1" }
-zeph-index = { path = "crates/zeph-index", version = "0.19.1" }
-zeph-llm = { path = "crates/zeph-llm", version = "0.19.1" }
-zeph-mcp = { path = "crates/zeph-mcp", version = "0.19.1" }
-zeph-memory = { path = "crates/zeph-memory", default-features = false, version = "0.19.1" }
-zeph-scheduler = { path = "crates/zeph-scheduler", version = "0.19.1" }
-zeph-skills = { path = "crates/zeph-skills", version = "0.19.1" }
-zeph-tools = { path = "crates/zeph-tools", version = "0.19.1" }
-zeph-tui = { path = "crates/zeph-tui", version = "0.19.1" }
-zeph-vault = { path = "crates/zeph-vault", version = "0.19.1" }
-zeph-orchestration = { path = "crates/zeph-orchestration", version = "0.19.1" }
-zeph-plugins = { path = "crates/zeph-plugins", version = "0.19.1" }
-zeph-sanitizer = { path = "crates/zeph-sanitizer", version = "0.19.1" }
-zeph-subagent = { path = "crates/zeph-subagent", version = "0.19.1" }
+zeph-a2a = { path = "crates/zeph-a2a", version = "*" }
+zeph-bench = { path = "crates/zeph-bench", version = "0.19.2" }
+zeph-acp = { path = "crates/zeph-acp", version = "0.19.2" }
+zeph-db = { path = "crates/zeph-db", default-features = false, version = "0.19.2" }
+zeph-channels = { path = "crates/zeph-channels", version = "0.19.2" }
+zeph-common = { path = "crates/zeph-common", version = "0.19.2" }
+zeph-config = { path = "crates/zeph-config", version = "0.19.2" }
+zeph-commands = { path = "crates/zeph-commands", version = "0.19.2" }
+zeph-context = { path = "crates/zeph-context", version = "0.19.2" }
+zeph-core = { path = "crates/zeph-core", version = "0.19.2" }
+zeph-experiments = { path = "crates/zeph-experiments", version = "0.19.2" }
+zeph-gateway = { path = "crates/zeph-gateway", version = "0.19.2" }
+zeph-index = { path = "crates/zeph-index", version = "0.19.2" }
+zeph-llm = { path = "crates/zeph-llm", version = "0.19.2" }
+zeph-mcp = { path = "crates/zeph-mcp", version = "0.19.2" }
+zeph-memory = { path = "crates/zeph-memory", default-features = false, version = "0.19.2" }
+zeph-scheduler = { path = "crates/zeph-scheduler", version = "0.19.2" }
+zeph-skills = { path = "crates/zeph-skills", version = "0.19.2" }
+zeph-tools = { path = "crates/zeph-tools", version = "0.19.2" }
+zeph-tui = { path = "crates/zeph-tui", version = "0.19.2" }
+zeph-vault = { path = "crates/zeph-vault", version = "0.19.2" }
+zeph-orchestration = { path = "crates/zeph-orchestration", version = "0.19.2" }
+zeph-plugins = { path = "crates/zeph-plugins", version = "0.19.2" }
+zeph-sanitizer = { path = "crates/zeph-sanitizer", version = "0.19.2" }
+zeph-subagent = { path = "crates/zeph-subagent", version = "0.19.2" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   [![Crates.io](https://img.shields.io/crates/v/zeph)](https://crates.io/crates/zeph)
   [![docs](https://img.shields.io/badge/docs-book-blue)](https://bug-ops.github.io/zeph/)
   [![CI](https://img.shields.io/github/actions/workflow/status/bug-ops/zeph/ci.yml?branch=main&label=CI)](https://github.com/bug-ops/zeph/actions)
-  [![Tests](https://img.shields.io/badge/tests-7973-brightgreen)](https://github.com/bug-ops/zeph/actions)
+  [![Tests](https://img.shields.io/badge/tests-8647-brightgreen)](https://github.com/bug-ops/zeph/actions)
   [![codecov](https://codecov.io/gh/bug-ops/zeph/graph/badge.svg?token=S5O0GR9U6G)](https://codecov.io/gh/bug-ops/zeph)
   [![Crates](https://img.shields.io/badge/crates-25-orange)](https://github.com/bug-ops/zeph/tree/main/crates)
   [![MSRV](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
@@ -55,8 +55,11 @@ zeph               # start the agent
 - [x] **[ACP server](https://bug-ops.github.io/zeph/advanced/acp.html)** — stdio, HTTP+SSE, WebSocket transports for IDE integration (Zed, VS Code, Helix)
 - [x] **[A2A protocol](https://bug-ops.github.io/zeph/advanced/a2a.html)** — agent-to-agent delegation over JSON-RPC 2.0 with IBCT capability tokens
 - [x] **[Sub-agents](https://bug-ops.github.io/zeph/advanced/sub-agents.html)** — isolated agents with scoped tools, zero-trust secret delegation, persistent transcripts
-- [x] **[TUI dashboard](https://bug-ops.github.io/zeph/advanced/tui.html)** — ratatui-based with real-time metrics, security panel, plan view, command palette
+- [x] **[TUI dashboard](https://bug-ops.github.io/zeph/advanced/tui.html)** — ratatui-based with real-time metrics, security panel, plan view, command palette; multi-session support with `/session switch` and `/session close`
 - [x] **[Multi-channel I/O](https://bug-ops.github.io/zeph/advanced/channels.html)** — CLI, Telegram, TUI, Discord, Slack — all with streaming, voice, and vision input
+- [x] **[OS sandbox](https://bug-ops.github.io/zeph/reference/security.html#sandbox)** — macOS Seatbelt + Linux Landlock isolation for tool execution; VIGIL verify-before-commit security gate; egress network logging
+- [x] **[Plugin system](https://bug-ops.github.io/zeph/advanced/plugins.html)** — install/remove skill packages via `zeph plugin add <url>`; runtime config overlay merge with tighten-only safety rules; hub install pipeline with trust escalation filter
+- [x] **[Session recap](https://bug-ops.github.io/zeph/advanced/sessions.html)** — `/recap` command and configurable auto-summary shown on session resume
 - [x] **[LSP integration](https://bug-ops.github.io/zeph/guides/lsp.html)** — compiler-level code intelligence via rust-analyzer, pyright, gopls and others: type info, diagnostics, call hierarchy, safe rename, references — injected automatically into context after file writes and reads
 - [x] **[Code indexing](https://bug-ops.github.io/zeph/advanced/code-indexing.html)** — tree-sitter AST-based indexing (Rust, Python, JS, TS, Go), semantic search, repo map generation
 - [x] **[Document RAG](https://bug-ops.github.io/zeph/advanced/document-loaders.html)** — ingest `.txt`, `.md`, `.pdf` into Qdrant with automatic retrieval per turn
@@ -94,6 +97,7 @@ zeph (binary)
  +-- zeph-a2a             A2A client + server, agent discovery (feature-gated)
  +-- zeph-gateway         HTTP webhook gateway with bearer auth (feature-gated)
  +-- zeph-scheduler       cron-based periodic tasks (feature-gated)
+ +-- zeph-plugins         plugin packaging, installation, and runtime config overlay
  +-- zeph-experiments     autonomous LLM config experimentation engine
 ```
 

--- a/book/src/advanced/tools.md
+++ b/book/src/advanced/tools.md
@@ -42,6 +42,65 @@ Each tool executor declares its definitions via `tool_definitions()`. On every L
 
 See [Security](../reference/security.md#file-executor-sandbox) for details on the path validation mechanism.
 
+## OS-Level Process Sandbox
+
+In addition to file path allowlisting, shell commands executed by the agent run inside a platform-native subprocess isolation sandbox. This provides an additional defense layer against accidental or malicious file access and system calls.
+
+### macOS: Seatbelt Profiles
+
+On macOS, shell commands are wrapped with `sandbox-exec -f <profile>.sb -- <cmd>`. A Seatbelt profile is generated per-command (deny-default, explicit allow rules) from a `SandboxPolicy` configuration. The profile is written to a temporary file, passed to the kernel, and cleaned up after command completion.
+
+**Default policy:**
+- Deny all access
+- Allow read/write only to explicitly configured paths
+- Block `/private/tmp`, `/var/folders`, `/private/etc` (system directories)
+- Optional network access control
+
+**Configuration:**
+
+```toml
+[tools.sandbox]
+allow_read = ["/home/user/projects", "/tmp"]
+allow_write = ["/home/user/projects/build"]
+allow_network = true
+```
+
+### Linux: Bubblewrap + Landlock + seccomp
+
+On Linux (requires `sandbox` feature), commands are wrapped with `bwrap <ns-flags> <bind-mounts> --seccomp <fd> -- <cmd>`. Three isolation layers work together:
+
+1. **Namespace isolation** — unshare UTS, IPC, PID (process tree), and optionally USER with UID/GID mapping
+2. **Bind-mount filtering** — only paths listed in `allow_read`/`allow_write` are bind-mounted into the container; rest of filesystem is inaccessible
+3. **seccomp BPF filter** — blocks 16 privilege-escalation syscalls (ptrace, execve-family variants, bpf, perf_event_open, etc.) via deny-list
+
+Landlock filesystem rules (when available) provide an additional capability-based filter.
+
+**Default policy:**
+- Deny all access except read/write to configured paths
+- Block network by default (enable with `allow_network = true`)
+- Cannot escape via syscalls or ptrace
+
+### Fallback: NoopSandbox
+
+On platforms without support (Windows, or missing required tools), sandboxing is disabled with a warning. Commands run unsandboxed but file path allowlisting still applies via `FileExecutor`.
+
+### Configuration
+
+```toml
+[tools.sandbox]
+# disabled = false             # Set to true to disable sandboxing entirely (default: false)
+# allow_read = []              # Paths/globs readable by commands (default: empty = cwd only)
+# allow_write = []             # Paths/globs writable by commands (default: empty = cwd only)
+# allow_network = true         # Allow outbound network (default: true)
+```
+
+### Best Practices
+
+- **Minimize blast radius**: Configure `allow_read` and `allow_write` as tightly as possible. Empty lists restrict access to the current working directory only.
+- **Project directories**: Allow read access to source trees and write access to build output directories.
+- **Secrets**: Keep vault and config files outside the allowed paths; the sandbox cannot access them.
+- **Debugging**: When sandbox violations occur, Zeph logs the denied syscall or path access. Check logs to refine the policy.
+
 ## WebScrapeExecutor — `fetch` tool
 
 In addition to `web_scrape` (CSS-selector-based extraction), `WebScrapeExecutor` exposes a `fetch` tool that returns plain text from a URL without requiring a selector. SSRF validation (HTTPS-only, private IP block, redirect re-validation) is applied identically to both tools.

--- a/book/src/advanced/tui.md
+++ b/book/src/advanced/tui.md
@@ -88,6 +88,13 @@ When using `--connect`, the TUI renders token-by-token streaming from the remote
 | `Ctrl+K` | Clear message queue |
 | `Ctrl+P` | Open command palette |
 
+**Slash Command Examples:**
+Typing `/` with an empty input shows these and other available commands:
+- `/session next|prev|close` — manage conversations
+- `/recap` — generate a summary of the current discussion
+- `/skills` — list loaded skills
+- `/memory` — show memory statistics
+
 ### Slash-Command Autocomplete
 
 Typing `/` on an empty input line opens an inline autocomplete dropdown above the input area. The dropdown shows up to 8 matching commands and filters in real time as you type more characters.
@@ -140,6 +147,10 @@ Available commands:
 | `view:config` | Show active configuration | |
 | `view:autonomy` | Show autonomy/trust level | |
 | `session:new` | Start new conversation | |
+| `session:switch-next` | Switch to next conversation | |
+| `session:switch-prev` | Switch to previous conversation | |
+| `session:close` | Close current conversation | |
+| `session:recap` | Generate summary of current conversation | |
 | `app:quit` | Quit application | `q` |
 | `app:help` | Show keybindings help | `?` |
 | `app:theme` | Toggle theme (dark/light) | |
@@ -217,9 +228,80 @@ The same `e` key toggles between compact and expanded for tool output blocks as 
 
 When using Ollama models that emit reasoning traces (DeepSeek, Qwen), the `<think>...</think>` segments are rendered in a darker color (DarkGray) to visually separate model reasoning from the final response. Incomplete thinking blocks during streaming are also shown in the darker style.
 
+## Multi-Session Management
+
+Zeph supports multiple independent conversations in a single TUI session. Switch between conversations without losing history or context — each maintains its own message thread, input state, and view position.
+
+### Session Operations
+
+Use the `/session` commands to manage conversations:
+
+| Command | Description |
+|---------|-------------|
+| `/session next` | Switch to the next conversation in creation order |
+| `/session prev` | Switch to the previous conversation |
+| `/session close` | Close the current conversation and revert to the most recent active session |
+| `/session switch <id>` | Jump to a specific conversation by ID |
+
+These commands are also available in the command palette (`Ctrl+P` → search "session").
+
+### Behavior
+
+- **Session switching**: When you switch conversations, the input line is cleared and the chat panel displays the selected conversation's full message history and scroll position.
+- **Single-session mode**: If only one conversation exists, `/session next` and `/session prev` are silent no-ops. `/session close` is refused with a status message.
+- **Blocked switches**: Session switches are prevented while a confirmation modal or elicitation (input prompt) is active. Complete any pending dialog before switching.
+- **Automatic history**: Every conversation's message history, input drafts, and scroll position are automatically saved to SQLite. Closing and reopening Zeph restores the exact state you left.
+
+## Session Recap
+
+When you return to an existing conversation, Zeph automatically generates a brief recap of the prior discussion before accepting new input. The recap is cached and reused across resume sessions unless the conversation history changes.
+
+### Auto-Recap on Resume
+
+When opening a stored conversation that has a cached digest (summary), Zeph displays a recap in the chat panel before the prompt returns focus to the input line. The recap includes:
+
+- Key topics discussed
+- Important decisions or outcomes
+- Links to relevant files or tools mentioned
+
+Recap is automatic and requires no configuration — it uses the same [Session Digest](../reference/configuration.md#sessionrecap) settings as on-demand recap.
+
+### On-Demand Recap with `/recap`
+
+At any time during a conversation, send the `/recap` command to generate a fresh summary of the current discussion. This is useful for:
+
+- Reorienting yourself after a long conversation
+- Getting a summary before making an important decision
+- Explicitly updating the cached digest
+
+### Configuration
+
+Recap behavior is controlled via the `[session.recap]` section in your config:
+
+```toml
+[session.recap]
+# Generate recap automatically when resuming a conversation (default: true)
+on_resume = true
+
+# LLM provider for recap generation; empty uses the primary provider (default: empty)
+# recap_provider = "fast"
+
+# Max tokens to spend on the recap summary (default: 500)
+max_tokens = 500
+
+# Max messages to include in the recap context (default: 50)
+max_input_messages = 50
+```
+
+**Tips:**
+
+- Set `recap_provider` to a fast, cheap model (e.g., `gpt-4o-mini`, `qwen3:8b`) to keep recap generation quick and inexpensive.
+- Increase `max_tokens` for longer or more complex conversations; decrease it for brevity.
+- If auto-recap feels intrusive, set `on_resume = false` and use `/recap` only when you explicitly want a summary.
+
 ## Conversation History
 
-On startup, the TUI loads the latest conversation from SQLite and displays it in the chat panel. This provides continuity across sessions.
+On startup, the TUI loads the latest conversation from SQLite and displays it in the chat panel. This provides continuity across sessions. Use multi-session management and recap to navigate between conversations.
 
 ## Message Queueing
 

--- a/book/src/guides/custom-skills.md
+++ b/book/src/guides/custom-skills.md
@@ -145,6 +145,139 @@ In an active session, use `/skill install <url|path>` and `/skill remove <name>`
 
 See [Skill Trust Levels](../advanced/skill-trust.md) for the full security model.
 
+## Plugin Packages
+
+For distributing and managing multiple related skills, utilities, and configurations together, Zeph supports **plugin packages**. A plugin is a directory containing a `plugin.toml` manifest that bundles:
+
+- Multiple skill directories
+- MCP server entries
+- Configuration overlays (tighten-only: you can only restrict, not expand permissions)
+
+### Plugin Structure
+
+```text
+my-plugin/
+├── plugin.toml                 # Manifest file
+├── skills/
+│   ├── skill-one/
+│   │   └── SKILL.md
+│   └── skill-two/
+│       └── SKILL.md
+└── config/
+    └── overlay.toml            # Optional config tightening rules
+```
+
+### plugin.toml Format
+
+```toml
+[plugin]
+name = "my-plugin"
+version = "1.0.0"
+description = "My plugin description"
+
+# Skills bundled with this plugin (relative paths from plugin root)
+[[plugin.skills]]
+name = "skill-one"
+path = "skills/skill-one"
+
+[[plugin.skills]]
+name = "skill-two"
+path = "skills/skill-two"
+
+# MCP servers managed by this plugin (optional)
+[[plugin.mcp_servers]]
+id = "my-mcp-server"
+command = "python"
+args = ["-m", "my_mcp_module"]
+
+# Configuration overlay — restrictive only (default: empty)
+[plugin.config_overlay]
+# Union of blocked patterns:
+tools.blocked_commands = ["dangerous_pattern"]
+
+# Intersection of allowed patterns (if base is empty, stays empty):
+# tools.allowed_commands = ["safe_pattern"]
+
+# Maximum for numeric fields:
+# skills.disambiguation_threshold = 0.1
+```
+
+### Installing Plugins
+
+Use `zeph plugin add` to install a plugin from a git repository or local path:
+
+```bash
+# From GitHub repository
+zeph plugin add https://github.com/user/zeph-plugin-example.git
+
+# From local directory
+zeph plugin add /path/to/my-plugin
+
+# List installed plugins
+zeph plugin list
+
+# Remove a plugin
+zeph plugin remove my-plugin
+```
+
+Plugins are installed to `~/.local/share/zeph/plugins/<name>/` (XDG standard location). All bundled skills are automatically discovered and hot-reloaded without restart.
+
+**In TUI mode**, use the `/plugins` commands:
+
+```
+/plugins list              # Show installed plugins
+/plugins add <url|path>    # Install a plugin
+/plugins remove <name>     # Remove a plugin
+```
+
+### Plugin Security
+
+- **Path traversal defense**: skill paths in the manifest are canonicalized and must resolve within the plugin root directory
+- **Config overlay validation**: only `tools.blocked_commands`, `tools.allowed_commands`, and `skills.disambiguation_threshold` are permitted; other keys are rejected
+- **Trust escalation filter**: bundled skills are assigned the `Trusted` trust level automatically at startup, bypassing the default `quarantined` level that external skills receive
+
+See [Skill Trust Levels](../advanced/skill-trust.md) for how trust levels control tool access.
+
+## Agent-Invocable Skills
+
+Skills are typically matched to user queries automatically via semantic embedding. With the `invoke_skill` tool, the agent can explicitly fetch and execute any registered skill by name at runtime. This is useful for:
+
+- Skills that should only run when explicitly requested
+- Composing multiple skills in a single response
+- Overriding the default embedding-based matching
+
+### Using invoke_skill in the LLM Response
+
+When the agent needs to reference or use a skill, it calls the `invoke_skill` tool:
+
+```
+I'll use the "git-workflow" skill to help you:
+<invoke_skill>
+{
+  "skill_name": "git-workflow",
+  "args": "--verbose"
+}
+</invoke_skill>
+```
+
+The tool returns the skill body with security-aware sanitization:
+- **Blocked skills**: refused with an error message
+- **Trusted skills**: body returned as-is
+- **Quarantined skills**: body wrapped with a quarantine warning
+
+### CLI Usage
+
+Invoke skills from the command line:
+
+```bash
+zeph skill invoke git-workflow --verbose
+zeph skill invoke deploy-prod --environment staging
+```
+
+### Catalog
+
+The agent sees an `invoke_skill` catalog during context assembly that lists all available skills with their names and descriptions. Use `/skills` in TUI or CLI to see the full registry.
+
 ## Generate a Skill from a Description
 
 Instead of writing SKILL.md manually, use `/skill create` with a natural language description:

--- a/book/src/guides/custom-skills.md
+++ b/book/src/guides/custom-skills.md
@@ -204,17 +204,17 @@ tools.blocked_commands = ["dangerous_pattern"]
 
 ### Installing Plugins
 
-Use `zeph plugin add` to install a plugin from a git repository or local path:
+Use `zeph plugin add` to install a plugin from a local path:
 
 ```bash
-# From GitHub repository
-zeph plugin add https://github.com/user/zeph-plugin-example.git
-
 # From local directory
 zeph plugin add /path/to/my-plugin
 
 # List installed plugins
 zeph plugin list
+
+# Show the active plugin overlay (which plugins are active/skipped and why)
+zeph plugin list --overlay
 
 # Remove a plugin
 zeph plugin remove my-plugin
@@ -226,9 +226,34 @@ Plugins are installed to `~/.local/share/zeph/plugins/<name>/` (XDG standard loc
 
 ```
 /plugins list              # Show installed plugins
-/plugins add <url|path>    # Install a plugin
+/plugins list --overlay    # Show the active plugin overlay
+/plugins overlay           # Show the active plugin overlay (alias)
+/plugins add <path>        # Install a plugin
 /plugins remove <name>     # Remove a plugin
 ```
+
+### Plugin Integrity Check
+
+When you install a plugin, Zeph records a sha256 digest of its `.plugin.toml` manifest in `~/.local/share/zeph/.plugin-integrity.toml`. At startup and when hot-reloading, Zeph verifies this digest to detect if a plugin manifest has been modified outside of Zeph's control.
+
+**If a manifest is tampered with:**
+- The plugin is skipped with an "integrity mismatch" reason
+- You can see the skipped plugin and reason with `zeph plugin list --overlay` or `/plugins overlay`
+- To re-protect the plugin, reinstall it: `zeph plugin remove my-plugin && zeph plugin add /path/to/my-plugin`
+
+This provides basic tampering detection. The integrity check is not cryptographically signed, and concurrent installs may race (last writer wins).
+
+### Hot-Reload Behavior
+
+Plugin config overlays — restrictions on tool access and embedding thresholds — are applied immediately when a plugin is installed or when you reload config mid-session. However, different overlay fields hot-reload differently:
+
+**Hot-reloads live (no restart needed):**
+- `tools.blocked_commands` — shell commands blocked by the agent are updated atomically on the next execution
+
+**Require agent restart:**
+- `tools.allowed_commands` — restrictions on allowed paths are applied at executor setup time. Zeph emits a **RESTART REQUIRED** warning when you change this setting
+
+You do not need to restart Zeph when modifying `blocked_commands` — the agent picks up the new blocklist immediately. If you modify `allowed_commands`, you must restart Zeph for the change to take effect.
 
 ### Plugin Security
 

--- a/book/src/guides/mcp.md
+++ b/book/src/guides/mcp.md
@@ -225,6 +225,43 @@ Timeouts and connection errors automatically map to `transient`. Policy violatio
 
 Tool calls carry an optional `caller_id` field that identifies the originating agent or sub-agent. This field is set automatically when a sub-agent dispatches a tool call and is recorded in the tool audit log. Operators can use `caller_id` to trace which agent issued a specific tool call in multi-agent deployments.
 
+## Tool Output Schema
+
+MCP servers can declare the structure of their tool outputs via the optional `outputSchema` field in a tool definition. Zeph automatically forwards this schema to LLM tool calls (Claude, OpenAI, Gemini, Ollama, and compatible servers), enabling the LLM to better understand and process structured tool results.
+
+**Benefits:**
+
+- LLMs can generate more accurate follow-up tool calls when prior results have known structure
+- Reduces redundant parsing or schema-discovery tool calls
+- Improves multi-step reasoning when output types are known in advance
+
+**Example MCP server output with schema:**
+
+```json
+{
+  "tools": [
+    {
+      "name": "query_database",
+      "description": "Query the database and return structured results",
+      "inputSchema": { ... },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "rows": {
+            "type": "array",
+            "items": { "type": "object" }
+          },
+          "count": { "type": "integer" },
+          "query_time_ms": { "type": "number" }
+        }
+      }
+    }
+  ]
+}
+```
+
+Zeph collects `outputSchema` from all connected servers and includes it in the native `ToolDefinition` sent to the LLM during tool calling. No configuration required — it works automatically.
+
 ## How Matching Works
 
 MCP tools are embedded in Qdrant (`zeph_mcp_tools` collection) with BLAKE3 content-hash delta sync. Unified matching injects both skills and MCP tools into the system prompt by relevance score — keeping prompt size O(K) instead of O(N) where N is total tools across all servers.

--- a/book/src/reference/cli.md
+++ b/book/src/reference/cli.md
@@ -88,6 +88,35 @@ zeph skill trust my-skill trusted
 zeph skill remove my-skill
 ```
 
+### `zeph plugin`
+
+Manage plugin packages (collections of skills, MCP servers, and config overlays). Installed plugins are stored in `~/.local/share/zeph/plugins/`.
+
+| Subcommand | Description |
+|------------|-------------|
+| `plugin list` | List installed plugins with installation timestamps |
+| `plugin list --overlay` | Show which plugins are active and which were skipped (with reasons), including integrity check failures |
+| `plugin add <path>` | Install a plugin from a local directory path (must contain `plugin.toml`) |
+| `plugin remove <name>` | Remove an installed plugin by name |
+
+```bash
+# List installed plugins
+zeph plugin list
+
+# Show the active plugin overlay (useful for diagnosing load failures)
+zeph plugin list --overlay
+
+# Install a plugin from a local directory
+zeph plugin add /path/to/my-plugin
+
+# Remove a plugin
+zeph plugin remove my-plugin
+```
+
+**Overlay flag note:** `--overlay` shows which plugins contributed to the active config and which were skipped (with reasons like "integrity mismatch", "invalid manifest", etc.). This is evaluated against the default config — use `--config <path>` in the agent to see the live intersection with your active config.
+
+**Integrity checks:** When you install a plugin, Zeph records a sha256 digest of its `.plugin.toml`. At startup and hot-reload, the digest is verified. If it doesn't match, the plugin is skipped and the mismatch is visible in `plugin list --overlay`. See [Plugin Manifest Integrity](security.md#plugin-manifest-integrity) for details.
+
 ### `zeph memory`
 
 Manage conversation history and advanced memory subsystems.
@@ -393,6 +422,28 @@ Display the current file logging configuration and recent log entries.
 ```
 
 See [Logging](../concepts/logging.md) for configuration details.
+
+### `/plugins`
+
+Manage installed plugins interactively. Same operations as the `zeph plugin` CLI command, but available mid-session.
+
+| Subcommand | Description |
+|------------|-------------|
+| `/plugins list` | List installed plugins with installation timestamps |
+| `/plugins list --overlay` | Show the active plugin overlay (which plugins are active/skipped and why) |
+| `/plugins overlay` | Alias for `list --overlay` |
+| `/plugins add <path>` | Install a plugin from a local directory path |
+| `/plugins remove <name>` | Remove an installed plugin by name |
+
+```bash
+> /plugins list
+> /plugins list --overlay
+> /plugins overlay
+> /plugins add /path/to/my-plugin
+> /plugins remove my-plugin
+```
+
+Use `overlay` to diagnose why a plugin didn't load (integrity mismatch, invalid manifest, etc.). This is the same information shown by `zeph plugin list --overlay` in the CLI.
 
 ### `/migrate-config`
 

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -201,6 +201,7 @@ embedding_model = "qwen3-embedding"    # model for text embeddings
 # max_tokens = 4096
 # server_compaction = false            # Enable Claude server-side context compaction (compact-2026-01-12 beta)
 # enable_extended_context = false      # Enable Claude 1M context window (context-1m-2025-08-07 beta, Sonnet/Opus 4.6)
+# prompt_cache_ttl = "1h"              # "1h" = extended TTL beta (writes ~2× cost); omit or "ephemeral" for default ~5 min
 # default = true
 
 # [[llm.providers]]
@@ -415,6 +416,12 @@ edge_history_limit = 100               # Max historical edge versions per source
 # inhibition_threshold = 0.8          # Lateral inhibition threshold (default: 0.8)
 # max_activated_nodes = 50            # Cap on activated nodes (default: 50)
 
+[session.recap]
+on_resume = true              # Auto-generate recap when resuming a stored conversation (default: true)
+# recap_provider = ""           # Provider name for recap generation; empty = primary provider (default: "")
+max_tokens = 500              # Max tokens for the recap summary (default: 500)
+max_input_messages = 50       # Max messages included in recap context (default: 50)
+
 [tools]
 enabled = true
 summarize_output = false      # LLM-based summarization for long tool outputs
@@ -434,6 +441,14 @@ allowed_paths = []          # Directories file tools can access (empty = cwd onl
 [tools.scrape]
 timeout = 15
 max_body_bytes = 1048576  # 1MB
+
+[tools.sandbox]
+# OS-level subprocess isolation for shell commands (macOS: Seatbelt, Linux: bubblewrap + Landlock/seccomp)
+# Defaults: deny (no access), opt-in allow for specific paths
+# disabled = false             # Disable sandboxing and run shell commands unsandboxed (default: false)
+# allow_read = []              # Paths/globs readable by sandboxed commands
+# allow_write = []             # Paths/globs writable by sandboxed commands
+# allow_network = true         # Allow outbound network access (default: true)
 
 [tools.filters]
 enabled = true              # Enable smart output filtering for tool results

--- a/book/src/reference/security.md
+++ b/book/src/reference/security.md
@@ -79,6 +79,27 @@ ls -la ~/.zeph/key.txt     # Should show: -rw------- (mode 0600)
 
 Run `zeph doctor` to verify file modes are correct across all sensitive Zeph files.
 
+## Plugin Manifest Integrity
+
+Zeph records a sha256 digest of each installed plugin's `.plugin.toml` manifest and verifies it at startup and during hot-reload. The integrity registry is stored in `~/.local/share/zeph/.plugin-integrity.toml` (outside the plugins directory to prevent TOCTOU races).
+
+**Protection scope:**
+- Detects if a plugin manifest has been modified outside of Zeph's control (e.g., accidentally edited, maliciously replaced)
+- Missing entries from pre-feature installs are permitted with a debug-level log
+- Mismatches cause the plugin to be skipped with an "integrity mismatch" reason visible in `zeph plugin list --overlay`
+
+**To re-protect after a valid change:**
+```bash
+zeph plugin remove <name>
+zeph plugin add /path/to/<name>
+```
+
+This stores a fresh digest, allowing the plugin to load normally.
+
+**Known limits:**
+- Not cryptographically signed — prevents accidental corruption but not determined adversaries
+- Concurrent installs may race (last writer wins on the `.plugin-integrity.toml` file)
+
 ## Shell Command Filtering
 
 All shell commands from LLM responses pass through a security filter before execution. Shell command detection uses a tokenizer-based pipeline that splits input into tokens, handles wrapper commands (e.g., `env`, `nohup`, `timeout`), and applies word-boundary matching against blocked patterns. This replaces the prior substring-based approach for more accurate detection with fewer false positives. Commands matching blocked patterns are rejected with detailed error messages.

--- a/book/src/reference/security.md
+++ b/book/src/reference/security.md
@@ -58,6 +58,27 @@ volumes:
   - ~/.zeph/key.txt:/home/zeph/.zeph/key.txt:ro
 ```
 
+### File Permissions
+
+All sensitive files created by Zeph are now protected with mode `0600` (owner read/write only), independent of the process umask. This ensures your secrets are never accidentally readable by other users on the system.
+
+Protected files include:
+- Vault files (`~/.zeph/vault.age`, `~/.zeph/key.txt`)
+- SQLite databases (conversation history, embeddings, metrics)
+- Debug dumps (when enabled)
+- Audit logs (tool execution records, JSONL format)
+- Configuration files (`config.toml`, router state, ACP permissions)
+- MCP server list (`mcpls.toml`)
+
+**Checking permissions manually:**
+
+```bash
+ls -la ~/.zeph/vault.age   # Should show: -rw------- (mode 0600)
+ls -la ~/.zeph/key.txt     # Should show: -rw------- (mode 0600)
+```
+
+Run `zeph doctor` to verify file modes are correct across all sensitive Zeph files.
+
 ## Shell Command Filtering
 
 All shell commands from LLM responses pass through a security filter before execution. Shell command detection uses a tokenizer-based pipeline that splits input into tokens, handles wrapper commands (e.g., `env`, `nohup`, `timeout`), and applies word-boundary matching against blocked patterns. This replaces the prior substring-based approach for more accurate detection with fewer false positives. Commands matching blocked patterns are rejected with detailed error messages.
@@ -401,6 +422,48 @@ All decrypted values in the in-memory secrets map are stored as `BTreeMap<String
 `Secret` no longer derives `Clone`. This is a deliberate trade-off: preventing accidental cloning reduces the number of live copies of a secret value in memory at any given time.
 
 If you need to pass a secret to a function, accept `&Secret` or extract the inner `&str` directly rather than cloning.
+
+## VIGIL Intent-Anchoring Gate
+
+VIGIL is a pre-sanitizer tripwire that scans tool outputs for prompt injection patterns before they reach the LLM context. It operates independently of the DeBERTa/AlignSentinel/TurnCausalAnalyzer stack and uses regex-based pattern matching for low-latency detection.
+
+### Configuration
+
+```toml
+[security.vigil]
+enabled = true                          # Master switch (default: true)
+strict_mode = false                     # Deny on any pattern match; false = log + sanitize (default: false)
+exempt_tools = ["read_file", "shell"]   # Tools exempt from VIGIL checks (default: ["load_skill", "invoke_skill"])
+extra_patterns = []                     # Additional regex patterns to detect (must compile without ReDoS risk)
+```
+
+### Behavior
+
+- **Block mode** (strict_mode = true): Replace flagged content with a sentinel value and log the event
+- **Sanitize mode** (strict_mode = false, default): Truncate flagged content at the injection point and append an annotation note like `[Injection-flagged content truncated by VIGIL]`
+- **Exempt tools**: Tools in the `exempt_tools` list skip VIGIL checks entirely (useful for tools that legitimately process untrusted content)
+- **Subagents**: Sub-agent responses bypass VIGIL checks to avoid cascading denials
+
+### Pattern Detection
+
+VIGIL scans for common prompt injection markers:
+- Prompt switching cues: "ignore previous instructions", "pretend you are", "you are now"
+- System prompt leaks: "system:", "instructions:", "as an AI assistant"
+- Jailbreak attempts: "DAN", "do anything now", "roleplay"
+- Role assumption: "act as", "respond as if", "in the role of"
+
+User-supplied extra patterns are validated for ReDoS resistance (DFA and regex size limits enforced at config validation time).
+
+### Egress Network Logging
+
+When the web scrape tool makes outbound HTTP requests, Zeph records each request to an audit trail with:
+
+- Request timestamp and correlation ID
+- Target domain and HTTP method
+- Response status code and latency
+- Whether content was flagged by VIGIL
+
+Access the audit trail via `view:cost` command palette entry or manually in the metrics.
 
 ## Indirect Prompt Injection (IPI) Defense
 

--- a/crates/zeph-acp/README.md
+++ b/crates/zeph-acp/README.md
@@ -15,10 +15,10 @@ Implements the [Agent Client Protocol](https://agentclientprotocol.org) server s
 
 ```toml
 [dependencies]
-zeph-acp = "0.18.3"
+zeph-acp = "0.19.2"
 
 # With HTTP+SSE transport
-zeph-acp = { version = "0.18.3", features = ["acp-http"] }
+zeph-acp = { version = "0.19.2", features = ["acp-http"] }
 ```
 
 **Important:**

--- a/crates/zeph-common/README.md
+++ b/crates/zeph-common/README.md
@@ -18,6 +18,7 @@ Provides foundational utilities used across multiple Zeph crates: Unicode-safe s
 | `text` | Unicode-safe string truncation — `truncate_chars`, `truncate_to_chars`, `truncate_to_bytes`, `truncate_to_bytes_ref` |
 | `net` | Network helpers — `is_private_ip()` for IPv4/IPv6 private range detection; used by the SSRF guard in `zeph-tools` and `zeph-acp` |
 | `sanitize` | Low-level sanitization primitives (null byte stripping, control character removal) |
+| `fs_secure` | Secure file I/O helpers — `open_private_truncate`, `append_private`, `write_private`, `atomic_write_private`; all create files with mode `0o600` independent of process umask; `atomic_write_private` uses `O_EXCL` on the temp file and fsyncs before rename for crash safety |
 | `treesitter` | Tree-sitter query constants and parser helpers for Rust, Python, JavaScript, TypeScript, Go (optional, requires `treesitter` feature) |
 
 ## Usage

--- a/crates/zeph-core/README.md
+++ b/crates/zeph-core/README.md
@@ -41,6 +41,8 @@ Core orchestration crate for the Zeph agent. Manages the main agent loop, bootst
 | `vault` | Secret storage and resolution via vault providers (age-encrypted read/write); secrets stored as `BTreeMap` for deterministic JSON serialization on every `vault.save()` call; scans `ZEPH_SECRET_*` keys to build the custom-secrets map used by skill env injection; all secret values are held as `Zeroizing<String>` (zeroize-on-drop) and are not `Clone` |
 | `instructions` | `load_instructions()` — auto-detects and loads provider-specific instruction files (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `zeph.md`) from the working directory; injects content into the volatile system prompt section with symlink boundary check, null byte guard, and 256 KiB per-file size cap. `InstructionWatcher` subscribes to filesystem events via `notify-debouncer-mini` (500 ms debounce) and reloads `instruction_blocks` in-place on any `.md` change — no agent restart required |
 | `skill_loader` | `SkillLoaderExecutor` — `ToolExecutor` that exposes the `load_skill` tool to the LLM; accepts a skill name, looks it up in the shared `Arc<RwLock<SkillRegistry>>`, and returns the full SKILL.md body (truncated to `MAX_TOOL_OUTPUT_CHARS`); skill name is capped at 128 characters; unknown names return a human-readable error message rather than a hard error |
+| `skill_invoke` | `SkillInvokeExecutor` — `ToolExecutor` that exposes the `invoke_skill` tool with trust-aware sanitization; Blocked skills are refused; non-Trusted bodies pass through `sanitize_skill_text`; Quarantined bodies are additionally wrapped with `wrap_quarantined`; exempt from adversarial policy, VIGIL gate, and tool-schema filter |
+| `vigil` | `VigilGate` — regex tripwire that runs before `ContentSanitizer` on every tool output; configurable via `[security.vigil]`; `VigilRiskLevel` recorded in audit entries; `vigil_flags_total` / `vigil_blocks_total` counters in `MetricsSnapshot`; fail-open on invalid config; subagent sessions exempt |
 | `scheduler_executor` | `SchedulerExecutor` — `ToolExecutor` that exposes three LLM-callable tools: `schedule_periodic` (add a recurring cron task), `schedule_deferred` (add a one-shot task at a specific ISO 8601 UTC time), and `cancel_task` (remove a task by name); communicates with the scheduler via `mpsc::Sender<SchedulerMessage>` and validates input lengths and cron expressions before forwarding; only present when the `scheduler` feature is enabled |
 | `debug_dump` | `DebugDumper` — writes numbered `{id:04}-request.json`, `{id:04}-response.txt`, and `{id:04}-tool-{name}.txt` files to a timestamped session directory; request dumps include model, token limit, tools, temperature, cache metadata, and message payloads in both `json` and `raw` formats; enabled via `--debug-dump [PATH]` CLI flag, `[debug] enabled = true` config, or `/debug-dump [path]` slash command; hooks into both streaming and non-streaming LLM paths and before `maybe_summarize_tool_output` |
 | `agent::log_commands` | `/log` slash command handler — displays current `LoggingConfig` (file path, level, rotation, max files) and tails the last 20 lines from the active log file |
@@ -166,6 +168,22 @@ auto_update_check = true   # set to false to disable update notifications
 ```
 
 Set `ZEPH_AUTO_UPDATE_CHECK=false` to disable update notifications without changing the config file.
+
+Key `SessionConfig.recap` fields (TOML section `[session.recap]`):
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `true` | Show a recap of the previous session on resume when a digest is available |
+| `provider` | string | `""` | Provider name (references `[[llm.providers]]`) for recap generation; empty = primary provider |
+
+```toml
+[session.recap]
+enabled  = true
+provider = "fast"   # optional; references [[llm.providers]] name
+```
+
+> [!TIP]
+> Use `/recap` to request a session recap on demand at any time during a session, regardless of the `enabled` setting.
 
 Key `DebugConfig` fields (TOML section `[debug]`):
 

--- a/crates/zeph-llm/README.md
+++ b/crates/zeph-llm/README.md
@@ -178,6 +178,25 @@ thinking = { mode = "extended", budget_tokens = 16000 }
 
 CLI: `--thinking extended:16000` or `--thinking adaptive`. When thinking is enabled and `max_tokens` is below 16000, it is raised automatically. Thinking deltas are parsed from the SSE stream and suppressed from the user-facing output; `MessagePart::ThinkingBlock` variants preserve thinking blocks verbatim across tool-use turns.
 
+## Prompt cache TTL
+
+`ClaudeProvider` supports a configurable prompt cache TTL via the `CacheTtl` enum:
+
+| Variant | TTL | Header |
+|---------|-----|--------|
+| `Ephemeral` (default) | ~5 minutes | standard `cache_control` |
+| `OneHour` | 1 hour | `extended-cache-ttl-2025-04-25` beta |
+
+```toml
+[[llm.providers]]
+type = "claude"
+model = "claude-sonnet-4-6"
+prompt_cache_ttl = "1h"   # "ephemeral" (default) or "1h"
+```
+
+> [!NOTE]
+> The 1-hour TTL costs approximately 2× more per cache write but dramatically reduces repeated-prefix costs for long sessions. Default `"ephemeral"` is byte-identical to the previous wire format — no rollout risk for existing deployments.
+
 ## Gemini configuration
 
 ```toml

--- a/crates/zeph-mcp/README.md
+++ b/crates/zeph-mcp/README.md
@@ -38,6 +38,19 @@ min_score    = 0.55       # minimum similarity threshold
 collection   = "zeph_mcp_tools"
 ```
 
+## outputSchema forwarding
+
+When `mcp.forward_output_schema = true`, Zeph appends a bounded "Expected output schema" hint derived from the MCP tool's `outputSchema` to the tool description sent to the LLM. This enables more accurate tool-result parsing and typed tool chaining. Schema content is sanitized through the injection pipeline; the hint is capped at `mcp.output_schema_hint_bytes` (default: 1024 bytes). The tool cache key covers both `description` and `output_schema` to prevent stale hits on server reconnects.
+
+```toml
+[mcp]
+forward_output_schema    = true
+output_schema_hint_bytes = 1024
+```
+
+> [!NOTE]
+> `forward_output_schema` is supported by Claude and OpenAI backends. Compatible, Gemini, and Ollama providers emit a `WARN` log when the setting is enabled, since those backends do not support structured output schemas.
+
 **Note:**
 > Tool discovery requires an embedding model. Configure `[llm.orchestrator] embedding_model` or set a dedicated `embedding_provider` for the mcp subsystem. When Qdrant is unavailable the index falls back to BM25 keyword matching.
 

--- a/crates/zeph-plugins/README.md
+++ b/crates/zeph-plugins/README.md
@@ -1,0 +1,124 @@
+# zeph-plugins
+
+[![Crates.io](https://img.shields.io/crates/v/zeph-plugins)](https://crates.io/crates/zeph-plugins)
+[![docs.rs](https://img.shields.io/docsrs/zeph-plugins)](https://docs.rs/zeph-plugins)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](../../LICENSE)
+[![MSRV](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
+
+Plugin packaging, installation, and runtime config overlay for Zeph.
+
+## Overview
+
+Manages the full lifecycle of Zeph plugin packages: installing from a path or URL, removing, listing, and applying tighten-only config overlays at bootstrap and on hot-reload. Each plugin lives in a subdirectory under the managed plugins root and may bundle skills, MCP server definitions, and a `.plugin.toml` overlay fragment. Security invariants are enforced at both install time and load time.
+
+## Key types
+
+| Type | Description |
+|------|-------------|
+| `PluginManager` | Install, remove, and list plugins in the managed directory |
+| `PluginMeta` | Parsed `.plugin.toml` manifest (name, version, description, overlay) |
+| `ResolvedOverlay` | Result of merging all installed plugin overlays into the live config |
+| `PluginError` | Typed error enum (Io, Parse, UnsafeOverlay, Conflict, PathTraversal) |
+
+## Key modules
+
+| Module | Description |
+|--------|-------------|
+| `manager` | `PluginManager` — install/remove/list with path-traversal defense (`canonicalize + starts_with(root)`), recursive `.bundled` marker stripping, symlink skip, and atomic install-then-verify |
+| `overlay` | `apply_plugin_config_overlays` — scans installed plugins, validates overlays, and merges tighten-only keys into the live `Config` struct |
+| `validate` | Install-time and load-time safelist validation for overlay keys |
+
+## Plugin format
+
+A plugin is a directory with the following layout:
+
+```
+my-plugin/
+    .plugin.toml          # required: manifest and config overlay
+    skills/               # optional: bundled SKILL.md files
+    mcp.toml              # optional: additional MCP server definitions
+```
+
+Minimal `.plugin.toml`:
+
+```toml
+[plugin]
+name        = "my-plugin"
+version     = "1.0.0"
+description = "Does something useful"
+
+[overlay]
+# All keys are optional. Only tighten-only operations are permitted.
+# tools.blocked_commands is merged via union (plugin can only add to the blocklist)
+# tools.allowed_commands is merged via intersection (plugin can only narrow the allowlist)
+# skills.disambiguation_threshold is merged via max (plugin can only raise the threshold)
+tools.blocked_commands         = ["curl", "wget"]
+skills.disambiguation_threshold = 0.25
+```
+
+> [!IMPORTANT]
+> Keys outside the safelist (`blocked_commands`, `allowed_commands`, `disambiguation_threshold`) are rejected at install time with `PluginError::UnsafeOverlay`. Plugins cannot widen the command allowlist — if the base allowlist is empty, `allowed_commands` intersection is a no-op.
+
+## Install and manage plugins
+
+### CLI
+
+```bash
+# Install a plugin from a local path or URL
+zeph plugin add ./path/to/my-plugin
+zeph plugin add https://example.com/my-plugin.tar.gz
+
+# List installed plugins
+zeph plugin list
+
+# Remove a plugin
+zeph plugin remove my-plugin
+```
+
+### TUI slash commands
+
+```text
+/plugins list            # list installed plugins
+/plugins add <path|url>  # install a plugin
+/plugins remove <name>   # uninstall a plugin
+```
+
+## Config overlay merge
+
+At bootstrap (`AppBuilder::new`) and on hot-reload (`reload_config`), `apply_plugin_config_overlays` is called to merge all installed plugin overlays into the live `Config`. The merge is deterministic: plugins are processed in directory-sorted order to ensure reproducible results.
+
+`ResolvedOverlay` carries diagnostic fields:
+
+| Field | Description |
+|-------|-------------|
+| `source_plugins` | Names of plugins whose overlay was successfully applied |
+| `skipped_plugins` | Names of plugins whose overlay was skipped (validation failure, I/O error) |
+| `merged_blocked_commands` | Final union of all plugin `blocked_commands` contributions |
+| `merged_disambiguation_threshold` | Final max of all `disambiguation_threshold` contributions |
+
+> [!WARNING]
+> Hot-reload applies `skills.disambiguation_threshold` immediately. Changes to `tools.blocked_commands` or `tools.allowed_commands` require an agent restart to take full effect — the live `ShellExecutor` is built once at startup. A banner is emitted in the status channel when a restart is required.
+
+## Security model
+
+- **Install-time validation** — overlay keys are checked against the safelist; unsafe keys abort the install with a clear error.
+- **Load-time re-validation** — the safelist check is re-run at every bootstrap and hot-reload as defence-in-depth against post-install tampering.
+- **`.bundled` marker stripping** — `.bundled` marker files in the installed package are stripped recursively to prevent trust escalation; if stripping fails, the partial install is cleaned up before propagating the error.
+- **Symlink skip** — symlinks in the source package are never copied, preventing symlink-based path traversal.
+- **Path traversal defense** — all install paths are canonicalized and verified to remain inside the managed root.
+
+## Installation
+
+```bash
+cargo add zeph-plugins
+```
+
+Enabled automatically when the `zeph-plugins` crate is a dependency of the root `zeph` binary.
+
+## Documentation
+
+Full documentation: <https://bug-ops.github.io/zeph/>
+
+## License
+
+MIT

--- a/crates/zeph-skills/README.md
+++ b/crates/zeph-skills/README.md
@@ -23,7 +23,7 @@ Parses SKILL.md files (YAML frontmatter + markdown body) from the `.zeph/skills/
 | `trust` | `SkillTrust` — Wilson score Bayesian re-ranking (`posterior_weight`, `posterior_mean`); `check_trust_transition()` for auto-promote/demote; re-exports `TrustLevel` from `zeph-tools` |
 | `watcher` | Filesystem watcher for skill hot-reload |
 | `prompt` | Skill-to-prompt formatting (`full`, `compact`, `auto` modes via `SkillPromptMode`); injects `reliability="N%"` and `uses="N"` health XML attributes |
-| `manager` | `SkillManager` — install, remove, verify, and list external skills (`~/.config/zeph/skills/`) |
+| `manager` | `SkillManager` — install, remove, verify, and list external skills (`~/.config/zeph/skills/`); `install_from_path` / `install_from_url` copy packages with `TrustLevel::Quarantined` default and strip `.bundled` markers to prevent trust escalation |
 | `rl_head` | `RoutingHead` — LinUCB bandit for RL-based skill routing; `ForwardCache` for score memoization; serializable to/from bytes for SQLite persistence |
 | `generator` | `SkillGenerator` — LLM-powered natural language skill generation from user descriptions; `SkillGenerationRequest` / `GeneratedSkill` types |
 | `miner` | `SkillMiner` — GitHub repository mining for skill discovery; `RepoCandidate`, `MinedSkill`, `MiningConfig` |

--- a/crates/zeph-tools/README.md
+++ b/crates/zeph-tools/README.md
@@ -9,7 +9,7 @@ Tool executor trait with shell, web scrape, and composite executors for Zeph.
 
 ## Overview
 
-Defines the `ToolExecutor` trait for sandboxed tool invocation and ships concrete executors for shell commands, file operations, and web scraping. The `CompositeExecutor` chains multiple backends with output filtering, permission checks, trust gating, anomaly detection, audit logging, and TAFC (Think-Augmented Function Calling) for reasoning-enhanced tool selection.
+Defines the `ToolExecutor` trait for sandboxed tool invocation and ships concrete executors for shell commands, file operations, and web scraping. The `CompositeExecutor` chains multiple backends with output filtering, permission checks, trust gating, anomaly detection, audit logging, egress network logging, and TAFC (Think-Augmented Function Calling) for reasoning-enhanced tool selection. Supports OS-level isolation via macOS Seatbelt and Linux Landlock when the `sandbox` feature is enabled.
 
 ## Key modules
 
@@ -22,7 +22,7 @@ Defines the `ToolExecutor` trait for sandboxed tool invocation and ships concret
 | `composite` | `CompositeExecutor` — chains executors with middleware |
 | `filter` | Output filtering pipeline — unified declarative TOML engine with 9 strategy types (`strip_noise`, `truncate`, `keep_matching`, `strip_annotated`, `test_summary`, `group_by_rule`, `git_status`, `git_diff`, `dedup`) and 19 embedded built-in rules; user-configurable via `filters.toml` |
 | `permissions` | Permission checks for tool invocation |
-| `audit` | `AuditLogger` — tool execution audit trail |
+| `audit` | `AuditLogger` — tool execution audit trail; `EgressEvent` with per-hop emission for outbound network requests and JSONL egress records |
 | `registry` | Tool registry and discovery |
 | `trust_level` | `TrustLevel` enum — four-tier trust model (`Trusted`, `Verified`, `Quarantined`, `Blocked`) with severity ordering and `min_trust` helper |
 | `trust_gate` | Trust-based tool access control |
@@ -115,6 +115,10 @@ auto_block = true
 
 TAFC injects a reasoning step before tool selection, allowing the LLM to evaluate which tools are appropriate for the current task. Configure via `[tools.tafc]` in `config.toml`.
 
+## Speculative tool dispatch
+
+`SpeculativeEngine` pre-runs read-only tool calls while the LLM generates its response. Results are cached in `SpeculativeCache` and reused when the model issues the same tool call — eliminating the round-trip latency for deterministic read operations. Non-deterministic or state-mutating tools are excluded from speculation via the `requires_confirmation` policy gate.
+
 ## Dynamic tool schema filtering
 
 `ToolSchemaFilter` uses embedding similarity to select only the top-K most relevant tools for each query, reducing the tool catalog size in the LLM context. Tools marked as `always_on` bypass filtering and are always included.
@@ -166,6 +170,7 @@ Rules are merged into `PolicyEnforcer` at startup. `[tools.policy]` rules always
 | Feature | Description |
 |---------|-------------|
 | `policy-enforcer` | Enables `PolicyEnforcerConfig` and policy-based tool access control |
+| `sandbox` | Enables OS-level tool isolation: macOS Seatbelt (Sandbox framework) and Linux Landlock + seccomp BPF |
 
 ## Installation
 

--- a/crates/zeph-tui/README.md
+++ b/crates/zeph-tui/README.md
@@ -5,11 +5,11 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](../../LICENSE)
 [![MSRV](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
-Ratatui-based TUI dashboard with real-time metrics for Zeph.
+Ratatui-based TUI dashboard with real-time metrics and multi-session support for Zeph.
 
 ## Overview
 
-Provides a terminal UI for monitoring the Zeph agent in real time. Built on ratatui and crossterm, it renders live token usage, latency histograms, conversation history, and skill activity. The skills panel includes Wilson score confidence bars showing each skill's posterior reliability estimate. Feature-gated behind `tui`.
+Provides a terminal UI for monitoring the Zeph agent in real time. Built on ratatui and crossterm, it renders live token usage, latency histograms, conversation history, and skill activity. The skills panel includes Wilson score confidence bars showing each skill's posterior reliability estimate. Supports multiple concurrent sessions via `SessionRegistry` — switch between sessions with `/session switch` and close them with `/session close`. Feature-gated behind `tui`.
 
 ## Key Modules
 
@@ -134,6 +134,8 @@ The command palette is opened with `:` in normal mode. Type to fuzzy-filter entr
 | `debug:dump` | Enable debug dump to the configured output directory (equivalent to `/debug-dump`) |
 | `ingest` | Usage hint for `zeph ingest <path>` |
 | `session:new` | Start a new conversation session |
+| `session:switch` | Switch to another open session |
+| `session:close` | Close the current session (refused when only one session is open) |
 | `session:history` | Browse session history (`H` shortcut) |
 | `daemon:connect` | Attach to a running daemon — requires `daemon` feature |
 | `daemon:disconnect` | Detach from daemon |

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__splash__tests__splash_default.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__splash__tests__splash_default.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/zeph-tui/src/widgets/splash.rs
+assertion_line: 79
 expression: output
 ---
 ┌──────────────────────────────────────────────────────────┐
@@ -14,7 +15,7 @@ expression: output
 │              ███████╗███████╗██║     ██║  ██║            │
 │              ╚══════╝╚══════╝╚═╝     ╚═╝  ╚═╝            │
 │                                                          │
-│                          v0.19.1                         │
+│                          v0.19.2                         │
 │                                                          │
 │                  Type a message to start.                │
 │                                                          │

--- a/crates/zeph-vault/README.md
+++ b/crates/zeph-vault/README.md
@@ -61,7 +61,7 @@ path = "~/.config/zeph/vault.age"         # only used by "age" backend
 The `env` backend resolves secrets directly from environment variables — no file needed. Use `age` for production deployments where secrets must be stored on disk.
 
 > [!IMPORTANT]
-> Age-encrypted vault files are created with `0o600` permissions. Ensure the key file (`~/.config/zeph/age_key`) is kept secure. Losing the key makes the vault unrecoverable.
+> Age-encrypted vault files are created with `0o600` permissions (owner read/write only), independent of the process umask, using `fs_secure` atomic write helpers from `zeph-common`. Ensure the key file (`~/.config/zeph/age_key`) is kept secure. Losing the key makes the vault unrecoverable. Run `zeph doctor` to verify vault file permissions at any time.
 
 ## Features
 

--- a/specs/003-llm-providers/spec.md
+++ b/specs/003-llm-providers/spec.md
@@ -101,6 +101,34 @@ AnyProvider { Claude, OpenAI, Ollama, Compatible, Candle, Gemini }
 - Block 3 (volatile): instruction files, skill context — changes every turn, not cached
 - Max 4 `cache_control` breakpoints per request
 
+### Configurable Prompt Cache TTL
+
+`CacheTtl` controls the lifetime of Claude prompt-cache breakpoints. Configured per `[[llm.providers]]` entry:
+
+```toml
+[[llm.providers]]
+name = "quality"
+type = "claude"
+model = "claude-sonnet-4-6"
+prompt_cache_ttl = "1h"   # "ephemeral" (default) or "1h"
+```
+
+| Value | Description | Beta header required |
+|-------|-------------|---------------------|
+| `"ephemeral"` | Standard Anthropic default cache TTL (~5 minutes). No beta header needed. | No |
+| `"1h"` | Extended 1-hour TTL. Requires `extended-cache-ttl-2025-04-11` beta header. | Yes |
+
+The `prompt_cache_ttl` field defaults to `None` (interpreted as `ephemeral`). Specifying `"1h"` adds the beta header automatically for the duration of that provider's requests.
+
+`--migrate-config` preserves `prompt_cache_ttl = "1h"` and suppresses `ephemeral` (it is the default, so no migration write-back).
+
+#### Key Invariants
+
+- `CacheTtl::OneHour` requires the `extended-cache-ttl-2025-04-11` beta header — it MUST be added automatically whenever `prompt_cache_ttl = "1h"` is configured.
+- `CacheTtl::Ephemeral` MUST NOT add the beta header — the header is only needed for non-default TTL.
+- `prompt_cache_ttl` is a per-provider field. Different providers in `[[llm.providers]]` may have different TTLs.
+- NEVER apply a `1h` TTL header to non-Claude providers — it is Claude API-specific.
+
 ## Orchestrator
 
 `crates/zeph-llm/src/orchestrator.rs` — multi-provider routing:

--- a/specs/004-memory/004-3-admission-control.md
+++ b/specs/004-memory/004-3-admission-control.md
@@ -50,10 +50,13 @@ Implement adaptive admission control that filters noise while preserving critica
 - Admission check returns `Result<Option<MessageId>>` — None means rejected, not error
 - When [memory.admission] enabled=false, ALL messages admitted (pass-through)
 - Scoring failure is fail-open — admit on any error
+- A-MAC must use `effective_embed_provider()` for all embedding calls — never the primary conversational provider directly. This applies to both the admission `evaluate()` path and the A-MAC bootstrap fallback. `effective_embed_provider()` resolves: first `[[llm.providers]]` entry with `embed = true`, then first with `embedding_model`, then primary.
+- All embedding call sites in semantic submodules (`summarization.rs`, `cross_session.rs`, `recall.rs`) must call `effective_embed_provider()`, not `provider` — this is enforced by `#3035` and `#3154`/`#3162`.
 
 ### Never
 - Treat None from remember() as an error
 - Use admission control as security gate (it's for noise filtering only)
+- Call `provider.embed()` directly in any memory submodule — always use `effective_embed_provider()`
 
 ---
 

--- a/specs/005-skills/spec.md
+++ b/specs/005-skills/spec.md
@@ -402,6 +402,61 @@ url_domain_allowlist = []          # domains permitted in skill body URLs
 
 ---
 
+## Hub Skill Install Pipeline
+
+Issue #3043 / #3050. The hub install pipeline fetches SKILL.md files from a configured skill hub (default: https://hub.agentskills.io), validates trust, and installs into the managed directory.
+
+### Trust Escalation Filter for Bundled Skills
+
+Skills installed via the hub that originate from `hub.agentskills.io` **and** are in the set of well-known bundled skill names receive a `.bundled` marker during installation. The `.bundled` marker exempts the skill from `WARN`-level security scan output and grants `Trusted` trust on first load (all other hub-sourced skills start at `Provisional`).
+
+Install-time filtering:
+1. Skill fetched from hub
+2. Injection scan runs on SKILL.md body — hard block if positive
+3. URL domain validation against `[skills.scanner.url_domain_allowlist]`
+4. If skill name matches bundled allowlist AND source is the canonical hub → write `.bundled` marker
+5. Trust set to `Trusted` for `.bundled` skills, `Provisional` for all others
+
+At startup and on hot-reload, `build_registry()` assigns `Trusted` trust to all skills that carry a `.bundled` marker file. This initialization is unconditional — it does not wait for feedback accumulation.
+
+### Key Invariants (Hub Install)
+
+- `.bundled` marker is write-once at install time — never added post-install by the agent
+- NEVER assign `Trusted` trust to a skill without a `.bundled` marker via the startup path
+- Injection scan MUST run before writing `.bundled` — a skill that fails scan is never bundled
+- `build_registry()` MUST assign `Trusted` to `.bundled` skills on every startup, including hot-reload
+
+---
+
+## Agent-Invocable Skills (`invoke_skill`)
+
+Issue #3127. Agents can invoke a named skill by calling the `invoke_skill` native tool. This differs from `load_skill` (preview/read-only) — `invoke_skill` carries intent-to-apply semantics: the active skill for the current turn is updated and the skill's system-prompt injection is applied immediately.
+
+### `invoke_skill` Tool
+
+| Field | Description |
+|-------|-------------|
+| `name` | Skill name to activate |
+| `reason` | Optional free-text rationale for the invocation |
+
+The tool returns a confirmation message with the skill's name and first 200 chars of its description. On failure (skill not found, below trust gate), it returns an error with category `ToolErrorCategory::ToolNotFound` or `PolicyBlocked`.
+
+### Security Gate
+
+`invoke_skill` checks:
+1. Skill exists in the registry
+2. Skill trust level is ≥ `Provisional` — `Quarantined` skills cannot be invoked
+3. Skill is not in the channel blocklist for the current channel
+
+### Key Invariants
+
+- `invoke_skill` is always exempt from the utility gate and the adversarial policy gate — listed in both `UtilityScoringConfig::exempt_tools` and `AdversarialPolicyConfig::exempt_tools` by default
+- `invoke_skill` and `load_skill` are both in `QUARANTINE_DENIED` — they cannot be triggered by quarantined skill content
+- `invoke_skill` carries intent-to-apply semantics: the invoked skill IS injected; `load_skill` is preview-only and does NOT update the active skill
+- NEVER invoke a `Quarantined` skill via this tool — trust gate must check before injection
+
+---
+
 ## SKILL.md Injection Sanitization
 
 

--- a/specs/006-tools/spec.md
+++ b/specs/006-tools/spec.md
@@ -589,6 +589,7 @@ threshold = 0.0   # calls below this score are skipped
 - User-requested tool calls (explicit in turn) bypass the gate unconditionally
 - Scoring errors are fail-closed — uncertain scores do not allow execution
 - NEVER skip `memory_save` or other side-effect tools on pure score alone
+- `invoke_skill` and `load_skill` are ALWAYS exempt from the utility gate — they are skill-orchestration primitives, not reducible to a utility score. Both must appear in the `exempt_tools` list of `UtilityScoringConfig` by default (enforced by a unit test in `config.rs`). This is a hard invariant: a utility gate that skips `invoke_skill` or `load_skill` can silently stall skill-driven turns.
 
 ---
 

--- a/specs/006-tools/spec.md
+++ b/specs/006-tools/spec.md
@@ -81,6 +81,8 @@ CompositeExecutor [
 - Blocked patterns: process substitution `$(...)`, here-strings `<<<`, dangerous builtins
 - `TrustLevel`: `Untrusted` / `Provisional` / `Trusted` — affects which commands are auto-approved
 - Working directory is sandboxed to project root (configurable)
+- `ShellExecutor` holds a `ShellPolicyHandle` (`Arc<ArcSwap<ShellPolicy>>`) rather than a static blocked-commands list. On plugin overlay reload, `handle.rebuild()` swaps the policy atomically — no restart. See [[027-runtime-layer/spec#Hot-Reload Behavior]] for the reload contract.
+- `find_blocked_command()` return type is `Option<String>` (owned) — not `Option<&str>`
 
 ## Structured Shell Output Envelope
 

--- a/specs/009-orchestration/spec.md
+++ b/specs/009-orchestration/spec.md
@@ -380,6 +380,122 @@ tree_optimized_dispatch = false
 
 ---
 
+## VeriMAP Predicate Gate
+
+Issue #3097. `VeriMAP` (Verify, Map, and Prune) is a predicate-gate layer that runs before task dispatch. Each `TaskNode` may carry a TOML-serialized predicate expression evaluated against the current plan state. Tasks whose predicate evaluates to `false` are skipped (not aborted) for the current tick.
+
+### Predicate Expressions
+
+Predicates are boolean expressions over plan state variables:
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `completed(task_id)` | bool | Task completed successfully |
+| `failed(task_id)` | bool | Task failed (any failure) |
+| `running_count` | usize | Number of currently running tasks |
+| `pending_count` | usize | Number of pending tasks |
+
+Expressions combine with `&&`, `||`, `!`, and parentheses.
+
+### Config
+
+```toml
+[orchestration]
+verimap_enabled = false   # opt-in
+```
+
+### Key Invariants
+
+- VeriMAP predicate evaluation runs before topology-based dispatch — a task blocked by predicate is re-evaluated on the next tick
+- Predicate evaluation is pure (no side effects) — it only reads plan state
+- Parse errors at task creation time are hard errors — a task with an invalid predicate expression is rejected at plan construction, not at dispatch
+- NEVER abort a task based on a predicate — only skip for the current tick
+
+---
+
+## AdaptOrch Topology Advisor
+
+Issue #3099. `AdaptOrch` is a bandit-driven topology advisor that runs before `LlmPlanner`. A 16-arm Thompson Beta-bandit (4 task classes × 4 topology hints) learns which topology hint produces better plans for each goal class.
+
+### `TopologyAdvisor`
+
+`TopologyAdvisor::recommend(goal_text)` classifies the goal into a `TaskClass` and samples a `TopologyHint`:
+
+| TaskClass | Description |
+|-----------|-------------|
+| `IndependentBatch` | Fan-out work with no cross-dependencies (research, comparisons) |
+| `SequentialPipeline` | Strict ordering: build→test→deploy, ETL |
+| `HierarchicalDecomp` | Tree decomposition, recursive analysis |
+| `Unknown` | Fallback; defaults to `Hybrid` hint |
+
+| TopologyHint | Prompt sentence injected |
+|--------------|--------------------------|
+| `Parallel` | Prefer maximizing parallel tasks |
+| `Sequential` | Produce a strict linear chain |
+| `Hierarchical` | Decompose into subgoals with 2–3 depth levels |
+| `Hybrid` | No constraint (no sentence injected) |
+
+`record_outcome()` updates the Beta-bandit arm for the (class, hint) pair based on plan quality signals (task completion rate, verifier confidence). State is persisted at shutdown.
+
+### Config
+
+```toml
+[orchestration]
+adapt_orch_enabled = false   # opt-in
+```
+
+### Key Invariants
+
+- `TopologyHint::Hybrid` injects no sentence — `prompt_sentence()` returns `None`
+- Classification failure always produces `TaskClass::Unknown` with `TopologyHint::Hybrid` — no propagated error
+- `record_outcome()` is synchronous — never spawns a background task
+- Bandit state persists between sessions — NEVER reset without explicit user action
+- `TopologyAdvisor` is advisory only — `TopologyClassifier::analyze()` still runs on the produced graph and may override the hint
+
+---
+
+## CoE (Cascade of Experts) Entropy Routing
+
+Issue #3099. `CoE` routes each sub-plan task to the provider whose entropy profile best matches the task's complexity signal. Entropy is estimated from the task description length, dependency depth, and past latency.
+
+### Config
+
+```toml
+[orchestration]
+coe_routing_enabled = false   # opt-in
+coe_routing_provider = ""     # fallback when CoE routing is disabled; empty = planner_provider
+```
+
+### Key Invariants
+
+- `coe_routing_enabled = false` falls back to `planner_provider` for all tasks — no behavioral change
+- CoE routing is per-task, not per-plan — different tasks in the same plan may route to different providers
+
+---
+
+## Graph Persistence in Scheduler Loop
+
+Issue #3107 / #3124. `GraphPersistence::save()` is called from within the `DagScheduler` tick loop after each task state transition. This ensures the graph state is durable across scheduler restarts without requiring a separate flush-on-shutdown step.
+
+### Key Invariants
+
+- `GraphPersistence::save()` is called after every task state transition in `DagScheduler::tick()` — not only at shutdown
+- Save failures are non-fatal — they are logged at `WARN` level and the scheduler continues
+- NEVER call `save()` in the hot path before task dispatch — only after state has actually changed
+
+---
+
+## CascadeDetector Forward Adjacency Cache
+
+Issue #3114. `CascadeDetector` caches the forward adjacency set (direct successors of each task node) to avoid repeated O(E) graph traversal during every tick.
+
+### Key Invariants
+
+- Cache is invalidated on `inject_tasks()` — new task injection resets the adjacency index
+- NEVER use a stale adjacency cache after `inject_tasks()` — must rebuild before next tick
+
+---
+
 ## Cascade Abort Defense
 
 Error cascade defense (arXiv:2603.04474) aborts a DAG when consecutive failures in a

--- a/specs/010-security/010-5-egress-logging.md
+++ b/specs/010-security/010-5-egress-logging.md
@@ -11,7 +11,7 @@ tags:
   - audit
   - observability
 created: 2026-04-17
-status: draft
+status: approved
 related:
   - "[[010-security/spec]]"
   - "[[010-4-audit]]"

--- a/specs/010-security/010-6-vigil-intent-anchoring.md
+++ b/specs/010-security/010-6-vigil-intent-anchoring.md
@@ -12,7 +12,7 @@ tags:
   - agent-loop
   - contract
 created: 2026-04-17
-status: draft
+status: approved
 related:
   - "[[010-security/spec]]"
   - "[[010-2-injection-defense]]"

--- a/specs/010-security/spec.md
+++ b/specs/010-security/spec.md
@@ -378,6 +378,25 @@ ibct_key_rotation_secs = 3600
 
 ---
 
+## Plugin Manifest Integrity (sha256)
+
+Issue #3166. Each `.plugin.toml` is integrity-checked via a sha256 digest to prevent tampering between install and load time.
+
+### Mechanism
+
+1. At install time (`zeph plugin install`), sha256 of the installed `.plugin.toml` is computed and written to `<data_root>/.plugin-integrity.toml` — outside `plugins_dir` to prevent the plugin from overwriting its own recorded digest (TOCTOU prevention).
+2. At startup and on every plugin overlay hot-reload, the digest is recomputed and compared against the stored value.
+3. Manifests whose digest does not match are rejected: the plugin is skipped and recorded in `ResolvedOverlay::skipped_plugins`.
+
+### Key Invariants
+
+- `.plugin-integrity.toml` MUST reside outside `plugins_dir` — placing it inside would allow a plugin to tamper with its own digest entry
+- Integrity check MUST run at both startup and hot-reload — not only at install time
+- A digest mismatch is always a hard rejection; there is no "warn and continue" mode
+- NEVER skip the integrity check when loading a plugin that was previously validated — the file may have been modified on disk between sessions
+
+---
+
 ## Credential Env Var Scrubbing
 
 

--- a/specs/010-security/spec.md
+++ b/specs/010-security/spec.md
@@ -98,6 +98,56 @@ Multiple crates — security is cross-cutting.
 - Blocked: process substitution `$(...)`, here-strings `<<<`, dangerous builtins (`rm -rf`, `mkfs`, etc.)
 - Bypass attempts: passing blocked patterns as arguments is also caught
 
+## File Permission Hardening (`fs_secure`)
+
+Issue #3132. All sensitive files written by Zeph — vault ciphertext, audit JSONL, debug dumps, router state, transcript sidecars — are created with owner-read/write-only permissions (`0o600`) on Unix via the `zeph_common::fs_secure` module.
+
+### `fs_secure` API
+
+| Function | Description |
+|----------|-------------|
+| `open_private_truncate(path)` | Create/truncate with 0o600 mode |
+| `write_private(path, data)` | One-shot write with 0o600 mode |
+| `atomic_write_private(path, data)` | Write to `.tmp` then rename (atomic on POSIX) |
+
+On non-Unix (Windows), helpers fall back to plain `OpenOptions` — Windows uses ACLs. The atomic rename on Windows is NOT atomic (`std::fs::rename` fails if destination exists on some Windows versions).
+
+### Residual Risks (documented)
+
+- `.tmp` suffix in `atomic_write_private` is a symlink-race target in shared directories. Callers in untrusted directories must use `tempfile::NamedTempFile::persist` instead.
+- SQLite WAL/SHM sidecars (`.db-wal`, `.db-shm`) inherit the process umask — not fixable without upstream sqlx support.
+
+### Key Invariants
+
+- All sensitive file creation paths must use `fs_secure` helpers — NEVER create vault, audit, or debug files with `std::fs::OpenOptions` directly
+- `0o600` is the maximum permission — NEVER create sensitive files with group/other read bits
+- `atomic_write_private` is the preferred write path for vault ciphertext — it guarantees partial-write safety on POSIX
+
+---
+
+## Seatbelt Deny-First Rules for Secret Paths
+
+Issue #3103 / #3115. On macOS, the Workspace Seatbelt sandbox profile now includes deny-first rules for well-known secret paths, added before the broad `(allow file-read*)` rule.
+
+### Denied Paths (deny-first)
+
+```
+~/.ssh/id_*
+~/.ssh/id_ed25519
+~/.ssh/id_rsa
+~/.aws/credentials
+~/.config/gh/hosts.yml
+~/Library/Keychains/
+```
+
+For symlinked secret paths (e.g., `~/.aws/credentials` → a real path in `/private/var/…`), deny rules are emitted for **both** the canonical real path and the symlink target to prevent traversal bypasses.
+
+### Key Invariants
+
+- Deny rules are appended BEFORE the broad `(allow file-read*)` rule in the Seatbelt profile — order matters; deny-first is not default Seatbelt behavior
+- Both the symlink and its canonical target must be denied for symlinked paths
+- Seatbelt workspace profile (`--init wizard` and `--migrate-config`) must include these rules
+
 ### Threat Model After #3077
 
 The Workspace Seatbelt profile grants **unconditional read access** to the entire

--- a/specs/011-tui/spec.md
+++ b/specs/011-tui/spec.md
@@ -165,6 +165,53 @@ This prevents logs from being silently discarded when stdout/stderr are suppress
 
 `visible_messages()` returns a borrowed reference (`Cow::Borrowed`) instead of cloning the message list. This eliminates ~20,000 `ChatMessage` clones/sec at 2000-message history, reducing idle CPU usage proportional to history depth.
 
+## Multi-Session `SessionRegistry`
+
+Issue #3164. `SessionRegistry` holds per-session state (chat messages, input composer, scroll offset, render cache, paste state) in typed `SessionSlot` structs, keyed by stable `SlotId(u64)`.
+
+Phase-1 (current): always exactly one slot (`SlotId::FIRST`). All per-session fields that were previously on `App` have been relocated to `SessionSlot`. `App` retains shared state that is not session-specific (`queued_count`, `pending_count`, `subagent_sidebar`).
+
+Phase-2 (future): multi-slot rendering and tab bar.
+
+### `/session` Commands
+
+| Command | Action |
+|---------|--------|
+| `/session next` | Cycle to the next session slot (phase-1: no-op, shows placeholder) |
+| `/session prev` | Cycle to the previous session slot |
+| `/session close` | Close the current session slot (phase-1: no-op if only one slot) |
+
+These commands are intercepted by the TUI app before forwarding to the agent. They do NOT reach the agent loop.
+
+### `SessionSlot` Fields
+
+`SessionSlot` owns: `messages`, `scroll_offset`, `render_cache`, `input`, `cursor_position`, `input_mode`, `input_history`, `history_index`, `draft_input`, `paste_state`, `view_target`, `transcript_cache`, `pending_transcript`, `show_splash`, `plan_view_active`, `status_label`.
+
+### Key Invariants (SessionRegistry)
+
+- `SlotId` is assigned once and never reused within a process lifetime
+- `/session` commands are intercepted in `App` before the agent; the agent never sees them
+- `SessionRegistry::bootstrap()` always creates a slot with `SlotId::FIRST` — the registry is never empty after construction
+- NEVER store conversational LLM state in `SessionRegistry` — only UI rendering state belongs here
+
+---
+
+## Compact Paste Indicator
+
+Issue #3054. When the user pastes multi-line content into the TUI input:
+
+- The input widget shows a compact single-line indicator: `[Paste: N lines]` instead of the raw pasted text
+- The full pasted content is preserved in `PasteState` and used for submission
+- In the chat history, pasted multi-line content is rendered as a collapsible block (collapsed by default, toggleable with a key)
+
+### Key Invariants
+
+- Paste indicator must never truncate or lose content — `PasteState` holds the complete original text
+- Collapsible paste blocks in chat history use the standard render cache (`RenderCache`) — not a separate code path
+- Single-line pastes are NOT shown as a compact indicator — only multi-line pastes (≥2 newlines) trigger the indicator
+
+---
+
 ## Key Invariants
 
 - Metrics updated every turn — not only when a specific event fires

--- a/specs/020-config-loading/spec.md
+++ b/specs/020-config-loading/spec.md
@@ -109,6 +109,24 @@ this early load — `AppBuilder::new()` calls `resolve_config_path()` again inde
 - WHEN config file is not found at the resolved path,
   THE SYSTEM SHALL return an error — no further silent fallback occurs.
 
+## `--migrate-config` Idempotency
+
+Issues #3110 / #3118. `migrate-config --in-place` is fully idempotent: running it multiple times on the same config file produces identical output.
+
+### Idempotency Requirements
+
+- Each migration step checks whether the target key already exists before writing it — no duplicate keys are emitted
+- `--in-place` reads the file, applies all migration transforms, and writes back only if content changed
+- A second invocation on an already-migrated file produces no output diff
+
+### Key Invariants
+
+- NEVER write a key that already exists in the config — check presence before add
+- Migration steps are ordered and composable — running step N twice must be equivalent to running it once
+- `--migrate-config` without `--in-place` writes to stdout and never modifies the source file
+
+---
+
 ## Agent Boundaries
 
 ### Always (without asking)

--- a/specs/027-runtime-layer/spec.md
+++ b/specs/027-runtime-layer/spec.md
@@ -181,6 +181,33 @@ bootstrap based on enabled features. Multiple layers can be composed via a
 
 ---
 
+## 6b. Plugin Config Overlay Merge
+
+Issue #3145. Plugin config overlays (`<plugin>/.plugin.toml`) are merged into the live `Config` at bootstrap, before the agent starts. The merge is tighten-only:
+
+| Key | Merge strategy |
+|-----|---------------|
+| `tools.shell.blocked_commands` | Union (grows monotonically) |
+| `tools.shell.allowed_commands` | Intersection with base (base must be non-empty for intersection to narrow it) |
+| `skills.disambiguation_threshold` | Max across all plugins |
+
+`apply_plugin_config_overlays(config, plugins_dir)` is called from `AppBuilder` after the base config is loaded and before bootstrap completes. `ResolvedOverlay` is returned for diagnostic logging and `zeph plugin list` display.
+
+### Install-Time Value Validation
+
+Issue #3159. When a plugin is installed (via `zeph plugin install`), the values in `.plugin.toml` are validated against the safelisted keys. Invalid values (e.g., a `blocked_commands` entry that is not a valid command name, or `disambiguation_threshold` outside `[0.0, 1.0]`) cause the install to fail with a clear error message.
+
+### Key Invariants
+
+- Plugin overlays are **tighten-only** — plugins cannot weaken security posture
+- `allowed_commands` intersection: if the base config has no `allowed_commands` (empty = unrestricted), the intersection is a no-op — plugins cannot re-enable `DEFAULT_BLOCKED` commands
+- `plugins_dir` missing → silently treated as empty; `plugins_dir` exists but unreadable → `PluginError::Io`
+- Per-plugin failures are recorded in `ResolvedOverlay::skipped_plugins` — a bad plugin skips, it does not abort the entire overlay
+- Plugin I/O operations (reading `.plugin.toml`) run in `spawn_blocking` — never block the async runtime
+- Value validation runs at install time, not at load time — invalid values should never reach `apply_plugin_config_overlays`
+
+---
+
 ## 7. References
 
 - `crates/zeph-core/src/runtime_layer.rs` — trait definition

--- a/specs/027-runtime-layer/spec.md
+++ b/specs/027-runtime-layer/spec.md
@@ -197,10 +197,42 @@ Issue #3145. Plugin config overlays (`<plugin>/.plugin.toml`) are merged into th
 
 Issue #3159. When a plugin is installed (via `zeph plugin install`), the values in `.plugin.toml` are validated against the safelisted keys. Invalid values (e.g., a `blocked_commands` entry that is not a valid command name, or `disambiguation_threshold` outside `[0.0, 1.0]`) cause the install to fail with a clear error message.
 
+### Hot-Reload Behavior
+
+`blocked_commands` changes (union of plugin overlays) take effect **immediately and atomically** on plugin overlay reload. `ShellExecutor` holds an `ArcSwap<ShellPolicy>` handle; `handle.rebuild()` swaps the policy without restarting the agent. `allowed_commands` changes still require a full agent restart and emit a `WARN` banner at reload time.
+
+New types introduced in `zeph-tools` to support atomic reload:
+
+| Type | Role |
+|------|------|
+| `ShellPolicy` | Immutable snapshot of blocked/allowed command rules |
+| `ShellPolicyHandle` | `Arc`-wrapped `ArcSwap<ShellPolicy>` shared across `ShellExecutor`, `LifecycleState`, and `acp/daemon/runner` |
+| `compute_blocked_commands` | Pure fn that rebuilds the policy from a `ResolvedOverlay` |
+
+### Diagnostics: `skipped_plugins` and `source_plugins`
+
+`ResolvedOverlay` surfaces two diagnostic fields:
+
+- `source_plugins` — list of plugins that contributed to the merged overlay
+- `skipped_plugins` — list of plugins skipped due to load/validation errors (non-fatal)
+
+Both fields are exposed in:
+- `zeph plugin list --overlay` (CLI)
+- `/plugins overlay` TUI slash command
+- `PluginListOverlay` TUI palette entry
+
+### Plugin Manifest Integrity (sha256)
+
+At install time, a sha256 digest of each `.plugin.toml` is computed and written to `<data_root>/.plugin-integrity.toml` (outside `plugins_dir` to prevent TOCTOU attacks). At startup and on every hot-reload, the digest is re-computed and compared against the stored value. Manifests whose digest does not match are rejected — the plugin is treated as if it were skipped and recorded in `skipped_plugins`.
+
 ### Key Invariants
 
 - Plugin overlays are **tighten-only** — plugins cannot weaken security posture
 - `allowed_commands` intersection: if the base config has no `allowed_commands` (empty = unrestricted), the intersection is a no-op — plugins cannot re-enable `DEFAULT_BLOCKED` commands
+- `blocked_commands` hot-reload is **atomic** — `ArcSwap` swap is the only permitted update path; no restart required
+- `allowed_commands` changes require restart — emit a `WARN` banner at reload time and do NOT apply dynamically
+- `.plugin-integrity.toml` MUST reside outside `plugins_dir` — storing it inside `plugins_dir` would allow a plugin to tamper with its own digest
+- Integrity check runs at both startup and hot-reload — a tampered manifest is always rejected, never silently accepted
 - `plugins_dir` missing → silently treated as empty; `plugins_dir` exists but unreadable → `PluginError::Io`
 - Per-plugin failures are recorded in `ResolvedOverlay::skipped_plugins` — a bad plugin skips, it does not abort the entire overlay
 - Plugin I/O operations (reading `.plugin.toml`) run in `spawn_blocking` — never block the async runtime

--- a/specs/039-background-task-supervisor/spec.md
+++ b/specs/039-background-task-supervisor/spec.md
@@ -384,7 +384,7 @@ TRACE: background task dropped class=enrichment task=graph-extract limit=4
 - Per-class inflight counters are updated atomically via `Arc<AtomicUsize>`
 - When a task completes, its inflight slot is freed immediately (via `InflightGuard` drop)
 - `reap()` is non-blocking and idempotent — safe to call every turn
-- `shutdown_all(timeout)` drains completions before timeout, then aborts remaining tasks
+- `shutdown_all(timeout)` uses a **two-phase drain**: phase 1 runs the normal completion loop; phase 2 continues draining after the cancellation token fires until the completion channel is empty. This ensures tasks that observe the cancellation token slightly after it is set still have their results collected and are not silently discarded. Only after both phases are exhausted (or the timeout fires) are remaining tasks aborted.
 - Task names are `Arc<str>` — never `&'static str` or `Box::leak`
 - `spawn_blocking` is gated by the blocking semaphore (default capacity 8)
 - `spawn_restartable` uses exponential backoff for `RestartPolicy::Restart`

--- a/specs/042-zeph-commands/spec.md
+++ b/specs/042-zeph-commands/spec.md
@@ -194,6 +194,44 @@ THEN the message is delivered to the underlying channel without the handler know
 
 ---
 
+## 11. Session Recap (`/recap`)
+
+Issue #3136. `/recap` generates an on-demand session summary using the same `SessionDigest` pipeline used for auto-summaries at startup.
+
+### Behavior
+
+- Calls `Agent::build_recap()` which generates a digest from up to `recap.max_input_messages` most recent messages
+- Output sent directly to the user channel via `ChannelSink`
+- **Deduplication**: if an auto-recap was already shown at session resume and no new messages have been added since, `/recap` returns the cached digest without a new LLM inference call (`recap_is_duplicate()` check)
+
+### Auto-Recap on Resume
+
+When `recap.auto_on_resume = true` and the session has a cached digest from a prior session:
+1. The agent shows the digest immediately after the session loads — before the first user turn
+2. `auto_recap_shown` is set to `true` in `DigestRuntime`
+3. Subsequent `/recap` calls within the same resumed session are deduplicated until new messages arrive
+
+### Config
+
+```toml
+[recap]
+enabled = true                # master switch; /recap always available when true
+auto_on_resume = false        # show auto-summary on session resume
+max_input_messages = 50       # max recent messages fed to the digest LLM
+max_tokens = 512              # max tokens in the recap output
+recap_provider = ""           # provider for recap LLM call; empty = primary provider
+```
+
+### Key Invariants
+
+- `/recap` is always available when `recap.enabled = true` — no feature gate
+- Deduplication check (`recap_is_duplicate()`) compares `current_non_system_message_count` at resume time against the count at auto-recap emit — they must match for dedup to fire
+- NEVER deduplicate when new messages have arrived since auto-recap was shown
+- `recap_provider` must resolve via the provider registry — NEVER hardcode a model in the recap path
+- `build_recap()` is fallible — errors return `CommandError`, not panic
+
+---
+
 ## 9. Open Questions
 
 None.

--- a/specs/README.md
+++ b/specs/README.md
@@ -56,17 +56,17 @@ Spec IDs (001–044) follow a logical grouping:
 | Doc | Feature | Crate |
 |---|---|---|
 | `002-agent-loop/spec.md` | Agent loop, turn lifecycle, context pressure, HiAgent subgoal-aware compaction | `zeph-core` |
-| `003-llm-providers/spec.md` | LlmProvider trait, AnyProvider, prompt caching | `zeph-llm` |
+| `003-llm-providers/spec.md` | LlmProvider trait, AnyProvider, prompt caching, configurable `CacheTtl` (ephemeral/1h) | `zeph-llm` |
 | `004-memory/spec.md` | SQLite + Qdrant, compaction, semantic response cache, anchored summarization, compaction probe, importance scoring, A-MAC admission control, MemScene consolidation, multi-vector chunking, GAAMA episode nodes, BATS budget hints, Focus compression, SleepGate forgetting pass, persona memory, trajectory memory, category-aware memory, TiMem tree, microcompact, autoDream, MagicDocs, embed backfill batching | `zeph-memory` |
-| `005-skills/spec.md` | SKILL.md format, registry, matching, hot-reload, skill trust governance, two-stage matching, Wilson score confidence intervals | `zeph-skills` |
-| `006-tools/spec.md` | ToolExecutor, CompositeExecutor, TAFC, schema filter, result cache, dependency graph, tool invocation phase taxonomy, native `tool_use` only | `zeph-tools` |
+| `005-skills/spec.md` | SKILL.md format, registry, matching, hot-reload, skill trust governance, two-stage matching, Wilson score confidence intervals, hub install pipeline, agent-invocable skills (`invoke_skill`) | `zeph-skills` |
+| `006-tools/spec.md` | ToolExecutor, CompositeExecutor, TAFC, schema filter, result cache, dependency graph, tool invocation phase taxonomy, native `tool_use` only; `invoke_skill`/`load_skill` utility-gate exemption | `zeph-tools` |
 | `007-channels/spec.md` | Channel trait, AnyChannel dispatch, streaming, channel feature parity | `zeph-channels` |
 | `008-mcp/spec.md` | MCP client, server lifecycle, semantic tool discovery, per-message pruning cache, injection detection, tool collision detection, caller identity propagation, tool quota, structured error codes, OAP authorization | `zeph-mcp` |
-| `009-orchestration/spec.md` | DAG planner, DagScheduler, AgentRouter, /plan command, plan template cache, VMAO adaptive replanning, cascade-aware DAG routing | `zeph-orchestration` |
-| `010-security/spec.md` | Vault, shell sandbox, content isolation, SSRF protection, IPI defense, PII NER circuit breaker, cross-tool injection correlation, AgentRFC protocol audit, MCP→ACP boundary enforcement, credential env-var scrubbing | cross-cutting |
+| `009-orchestration/spec.md` | DAG planner, DagScheduler, AgentRouter, /plan command, plan template cache, VMAO adaptive replanning, cascade-aware DAG routing, VeriMAP predicate gate, AdaptOrch topology advisor, CoE entropy routing, graph persistence in scheduler loop | `zeph-orchestration` |
+| `010-security/spec.md` | Vault, shell sandbox, content isolation, SSRF protection, IPI defense, PII NER circuit breaker, cross-tool injection correlation, AgentRFC protocol audit, MCP→ACP boundary enforcement, credential env-var scrubbing, file permission hardening (`fs_secure`), Seatbelt deny-first secret-path rules | cross-cutting |
 | `010-security/010-5-egress-logging.md` | Egress logging sub-spec: `EgressEvent` per outbound HTTP call, `AuditEntry.correlation_id`, bounded mpsc telemetry (256 + drop counter), TUI Security panel surface | `zeph-tools`, `zeph-core`, `zeph-tui` |
 | `010-security/010-6-vigil-intent-anchoring.md` | VIGIL verify-before-commit sub-spec: pre-sanitizer regex tripwire with Block/Sanitize action, per-turn `current_turn_intent`, subagent exemption, non-retryable blocks via `error_category="vigil_blocked"` | `zeph-core`, `zeph-tools`, `zeph-config` |
-| `011-tui/spec.md` | ratatui dashboard, spinner rule for background operations, TuiChannel, RenderCache, embed backfill progress | `zeph-tui` |
+| `011-tui/spec.md` | ratatui dashboard, spinner rule for background operations, TuiChannel, RenderCache, embed backfill progress, multi-session `SessionRegistry`, `/session` commands, compact paste indicator | `zeph-tui` |
 | `012-graph-memory/spec.md` | Entity graph, BFS recall, community detection, MAGMA typed edges, SYNAPSE spreading activation | `zeph-memory` |
 | `004-memory/004-6-graph-memory.md` | Graph memory sub-spec (concise reference within 004-memory): MAGMA typed edges, SYNAPSE config, A-MEM link weights, key invariants | `zeph-memory` |
 | `013-acp/spec.md` | ACP transports, session management, permissions, fork/resume, session/close handlers, capability advertisement, /agent.json endpoint | `zeph-acp` |
@@ -76,14 +76,14 @@ Spec IDs (001–044) follow a logical grouping:
 | `017-index/spec.md` | AST indexing, semantic retrieval, repo map generation | `zeph-index` |
 | `018-scheduler/spec.md` | Cron scheduler, SQLite persistence, CLI subcommands (list/add/remove/show) | `zeph-scheduler` |
 | `019-gateway/spec.md` | HTTP webhook ingestion, bearer token authentication | `zeph-gateway` |
-| `020-config-loading/spec.md` | Config resolution order, mode-agnostic defaults, environment overrides | `zeph-core` |
+| `020-config-loading/spec.md` | Config resolution order, mode-agnostic defaults, environment overrides, `--migrate-config --in-place` idempotency | `zeph-core` |
 | `021-zeph-context/spec.md` | `zeph-context` crate: `ContextBudget` token arithmetic, `CompactionState` state machine, `ContextAssembler` parallel fetch, `PreparedContext` output; extracted from `zeph-core` | `zeph-context` |
 | `022-config-simplification/spec.md` | Provider Registry Architecture: canonical `[[llm.providers]]` format, ProviderEntry schema, routing strategies, LinUCB bandit routing, cost-weight dial, memory-augmented routing | `zeph-config`, `zeph-core` |
 | `023-complexity-triage-routing/spec.md` | Pre-inference complexity classification routing, ComplexityTier, TriageRouter, context escalation, metrics | `zeph-llm`, `zeph-config`, `zeph-core` |
 | `024-multi-model-design/spec.md` | Multi-model design principle: complexity tiers, `*_provider` subsystem reference pattern, STT unification | cross-cutting |
 | `025-classifiers/spec.md` | Candle-backed ML classifiers: injection detection, PII detection, LlmClassifier for feedback, unified regex+NER sanitization pipeline | `zeph-classifiers` |
 | `026-tui-subagent-management/spec.md` | Interactive TUI subagent sidebar (a key), j/k navigation, Enter loads transcript, Esc returns, Tab cycling | `zeph-tui` |
-| `027-runtime-layer/spec.md` | RuntimeLayer middleware with before_chat/after_chat/before_tool/after_tool hooks, NoopLayer, LayerContext, unwind guards | `zeph-core` |
+| `027-runtime-layer/spec.md` | RuntimeLayer middleware with before_chat/after_chat/before_tool/after_tool hooks, NoopLayer, LayerContext, unwind guards; plugin config overlay merge (tighten-only) | `zeph-core` |
 | `028-hooks/spec.md` | Reactive hooks: cwd_changed / file_changed events, set_working_directory tool, FileChangeWatcher, ZEPH_* env vars | `zeph-core` |
 | `029-feature-flags/spec.md` | Feature flag decision rules, surviving flag inventory (22 flags), bundle definitions (desktop, ide, server, full) | `Cargo.toml`, cross-cutting |
 | `030-tui-slash-autocomplete/spec.md` | Inline autocomplete dropdown in TUI Insert mode, reuses filter_commands registry, Tab/Enter accepts, Esc dismisses | `zeph-tui` |
@@ -98,7 +98,7 @@ Spec IDs (001–044) follow a logical grouping:
 | `039-background-task-supervisor/spec.md` | (Proposed) Supervised Background Task Manager: AgentTaskSupervisor, task priority classes, queue depth limits, turn-boundary cleanup, metrics (`bg_inflight`, `bg_dropped`) | `zeph-core` |
 | `040-sanitizer/spec.md` | Content Sanitizer: spotlighting pipeline, regex injection detection, PII scrubber, guardrail filter, quarantined summarizer, response verification, exfiltration guards, memory validation, causal analysis (eight-layer defense-in-depth) | `zeph-sanitizer` |
 | `041-experiments/spec.md` | Experiments & Runtime Feature Gating: `[experiments]` config section, ExperimentConfig, rollout percentage, experiment results reporting, CLI subcommands; distinct from compile-time feature flags | `zeph-experiments` |
-| `042-zeph-commands/spec.md` | Slash command registry, `CommandHandler<Ctx>` object-safe trait, `CommandRegistry` with longest-word-boundary dispatch, `ChannelSink` abstraction, static `COMMANDS` list; no dependency on `zeph-core` | `zeph-commands` |
+| `042-zeph-commands/spec.md` | Slash command registry, `CommandHandler<Ctx>` object-safe trait, `CommandRegistry` with longest-word-boundary dispatch, `ChannelSink` abstraction, static `COMMANDS` list; `/recap` command, `/session` TUI commands; no dependency on `zeph-core` | `zeph-commands` |
 | `043-zeph-common/spec.md` | Shared primitives: `Secret` (zeroize-on-drop), `ToolName` (Arc<str>), `SessionId` (UUID v4), `ToolDefinition`, `SkillTrustLevel`, `PolicyLlmClient`; no `zeph-*` peer dependencies | `zeph-common` |
 | `044-subagent-lifecycle/spec.md` | Full `zeph-subagent` crate: `SubAgentDef` parsing, `SubAgentManager` spawning and concurrency cap, `PermissionGrants` TTL, `FilteredToolExecutor` policy gate, transcript JSONL persistence, lifecycle hooks, memory injection | `zeph-subagent` |
 | `045-interop-protocol-gaps/spec.md` | Agent interoperability protocol gap analysis (arXiv:2505.02279): capability matrix for MCP, ACP, A2A, ANP vs. Zeph; protocol selection guidance; ANP as P4 research; ACP re-negotiation as P3 follow-up | cross-cutting |


### PR DESCRIPTION
## Summary

- Bump version from 0.19.1 to 0.19.2
- Update CHANGELOG.md with release section dated 2026-04-18
- Refresh all crate READMEs and root README (test badge: 8647)
- Update user documentation in `book/` for new features (multi-session TUI, /recap, OS sandbox, plugins, VIGIL, egress logging, prompt cache TTL, MCP outputSchema)
- Update 13 specification files in `specs/` to reflect implemented changes
- Accept updated splash widget snapshot for v0.19.2

## Checklist

- [x] Version updated in all manifests
- [x] CHANGELOG.md has release section with date
- [x] All crate READMEs refreshed
- [x] book/ documentation updated
- [x] specs/ updated
- [x] fmt check passed
- [x] clippy passed
- [x] 8338/8338 tests passed
- [ ] Ready for tagging after merge