### PR TITLE
feat(cli): add --bare mode, --json output, -y flag, and /loop command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **feat(cli): `--bare` mode for scripted/CI usage** (#2790) — new flag strips the agent to
+  essentials: skips memory init, scheduler startup, skill loading, and watcher registration.
+  Suitable for piping and automation where full subsystem overhead is unnecessary.
+
+- **feat(cli): `--json` structured output** (#2790) — JSONL event stream to stdout (boot, chunk,
+  response_end, tool_call, tool_result, cost, error). Tool output is redacted via `scrub_content`
+  before emission. Tracing is redirected to stderr when `--json` is active. Mutually exclusive with
+  `--tui`, `--acp`, and messaging-channel integrations (Telegram, Discord, Slack).
+
+- **feat(cli): `-y`/`--auto` flag** (#2790) — sets `AutonomyLevel::Full` to bypass tool
+  confirmation prompts. Shell blocklist and adversarial policy remain enforced.
+
+- **feat(cli): `/loop` slash command** (#3083) — in-session repeating prompt execution:
+  `/loop <prompt> every <N> <unit>` repeats at fixed intervals (minimum 5 s, units: s/m/h);
+  `/loop stop` cancels; `/loop status` shows current state. Uses `tokio::time::interval_at`
+  to avoid an immediate first tick. Prompts beginning with `/` are rejected to prevent
+  slash-command injection.
+
+- **feat(config): `[cli]` TOML section** (#2790, #3083) — `bare`, `json`, `auto` booleans and
+  `[cli.loop]` subsection (`min_interval_secs`, `max_iterations`).
+
 ## [0.19.2] - 2026-04-18
 
 ### Added

--- a/crates/zeph-channels/src/any.rs
+++ b/crates/zeph-channels/src/any.rs
@@ -18,6 +18,7 @@ use zeph_core::channel::{
 use crate::cli::CliChannel;
 #[cfg(feature = "discord")]
 use crate::discord::DiscordChannel;
+use crate::json_cli::JsonCliChannel;
 #[cfg(feature = "slack")]
 use crate::slack::SlackChannel;
 use crate::telegram::TelegramChannel;
@@ -32,6 +33,7 @@ use crate::telegram::TelegramChannel;
 /// # Variants
 ///
 /// * `Cli` — reads from stdin and writes to stdout via [`CliChannel`].
+/// * `JsonCli` — reads from stdin and emits JSONL events to stdout via [`JsonCliChannel`].
 /// * `Telegram` — Telegram Bot API adapter via [`crate::telegram::TelegramChannel`].
 /// * `Discord` *(feature `discord`)* — Discord gateway adapter.
 /// * `Slack` *(feature `slack`)* — Slack Events API adapter.
@@ -51,6 +53,7 @@ use crate::telegram::TelegramChannel;
 #[derive(Debug)]
 pub enum AnyChannel {
     Cli(CliChannel),
+    JsonCli(JsonCliChannel),
     Telegram(TelegramChannel),
     #[cfg(feature = "discord")]
     Discord(DiscordChannel),
@@ -62,6 +65,7 @@ macro_rules! dispatch_channel {
     ($self:expr, $method:ident $(, $arg:expr)*) => {
         match $self {
             AnyChannel::Cli(c) => c.$method($($arg),*).await,
+            AnyChannel::JsonCli(c) => c.$method($($arg),*).await,
             AnyChannel::Telegram(c) => c.$method($($arg),*).await,
             #[cfg(feature = "discord")]
             AnyChannel::Discord(c) => c.$method($($arg),*).await,
@@ -106,6 +110,7 @@ impl Channel for AnyChannel {
     fn try_recv(&mut self) -> Option<ChannelMessage> {
         match self {
             Self::Cli(c) => c.try_recv(),
+            Self::JsonCli(c) => c.try_recv(),
             Self::Telegram(c) => c.try_recv(),
             #[cfg(feature = "discord")]
             Self::Discord(c) => c.try_recv(),
@@ -117,6 +122,7 @@ impl Channel for AnyChannel {
     fn supports_exit(&self) -> bool {
         match self {
             Self::Cli(c) => c.supports_exit(),
+            Self::JsonCli(c) => c.supports_exit(),
             Self::Telegram(c) => c.supports_exit(),
             #[cfg(feature = "discord")]
             Self::Discord(c) => c.supports_exit(),

--- a/crates/zeph-channels/src/json_cli.rs
+++ b/crates/zeph-channels/src/json_cli.rs
@@ -1,0 +1,304 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! JSON CLI channel: emits JSONL events to stdout, reads prompts from stdin.
+//!
+//! Used when `--json` is active. All log output is forced to stderr before
+//! this channel is constructed, so stdout carries clean JSONL only.
+//!
+//! # Double-emission prevention
+//!
+//! [`JsonEventLayer`] is the canonical emitter for `tool_call`, `tool_result`,
+//! and `cost` events. The corresponding channel methods (`send_tool_start`,
+//! `send_tool_output`, `send_usage`) are intentionally no-ops here.
+
+use std::io::{BufRead, BufReader, IsTerminal};
+use std::sync::Arc;
+
+use zeph_core::DiffData;
+use zeph_core::channel::{
+    Channel, ChannelError, ChannelMessage, ElicitationRequest, ElicitationResponse, StopHint,
+    ToolOutputEvent, ToolStartEvent,
+};
+use zeph_core::json_event_sink::{JsonEvent, JsonEventSink};
+
+/// CLI channel that emits structured JSON events to stdout.
+///
+/// Construct via [`JsonCliChannel::new`] and wrap in [`AnyChannel::JsonCli`].
+/// All assistive output goes through the shared [`JsonEventSink`]; only stdin
+/// reading is internal to this channel.
+#[derive(Debug)]
+pub struct JsonCliChannel {
+    sink: Arc<JsonEventSink>,
+    /// Buffered stdin lines. `None` when stdin is a TTY (reads line-by-line).
+    rx: tokio::sync::mpsc::Receiver<Option<String>>,
+    /// Whether the caller should auto-approve confirmation prompts.
+    auto: bool,
+}
+
+impl JsonCliChannel {
+    /// Create a new channel.
+    ///
+    /// `auto` mirrors the `-y` / `--auto` flag: when `true`, `confirm()` always
+    /// returns `true` without reading from stdin.
+    #[must_use]
+    pub fn new(sink: Arc<JsonEventSink>, auto: bool) -> Self {
+        let (tx, rx) = tokio::sync::mpsc::channel(32);
+        let is_tty = std::io::stdin().is_terminal();
+
+        // Spawn a blocking reader thread so `recv` is cancel-safe.
+        // TTY and piped stdin use the same line-by-line reader; no prompt is
+        // printed in JSON mode.
+        let _ = is_tty; // reserved for future TTY-specific behaviour
+        std::thread::spawn(move || {
+            let reader = BufReader::new(std::io::stdin().lock());
+            for line in reader.lines() {
+                if let Ok(l) = line {
+                    if tx.blocking_send(Some(l)).is_err() {
+                        break;
+                    }
+                } else {
+                    let _ = tx.blocking_send(None);
+                    break;
+                }
+            }
+            // Signal EOF
+            let _ = tx.blocking_send(None);
+        });
+
+        Self { sink, rx, auto }
+    }
+}
+
+impl Channel for JsonCliChannel {
+    async fn recv(&mut self) -> Result<Option<ChannelMessage>, ChannelError> {
+        loop {
+            match self.rx.recv().await {
+                Some(Some(line)) => {
+                    let trimmed = line.trim();
+                    match trimmed {
+                        "" => continue,
+                        "exit" | "quit" | "/exit" | "/quit" => return Ok(None),
+                        _ => {}
+                    }
+                    let text = trimmed.to_owned();
+                    self.sink.emit(&JsonEvent::Query {
+                        text: &text,
+                        queue_len: 0,
+                    });
+                    return Ok(Some(ChannelMessage {
+                        text,
+                        attachments: Vec::new(),
+                    }));
+                }
+                Some(None) | None => return Ok(None), // EOF
+            }
+        }
+    }
+
+    fn try_recv(&mut self) -> Option<ChannelMessage> {
+        match self.rx.try_recv() {
+            Ok(Some(line)) => {
+                let trimmed = line.trim().to_owned();
+                if trimmed.is_empty() {
+                    return None;
+                }
+                self.sink.emit(&JsonEvent::Query {
+                    text: &trimmed,
+                    queue_len: 0,
+                });
+                Some(ChannelMessage {
+                    text: trimmed,
+                    attachments: Vec::new(),
+                })
+            }
+            _ => None,
+        }
+    }
+
+    fn supports_exit(&self) -> bool {
+        true
+    }
+
+    async fn send(&mut self, text: &str) -> Result<(), ChannelError> {
+        self.sink.emit(&JsonEvent::ResponseChunk { text });
+        self.sink.emit(&JsonEvent::ResponseEnd);
+        Ok(())
+    }
+
+    async fn send_chunk(&mut self, chunk: &str) -> Result<(), ChannelError> {
+        self.sink.emit(&JsonEvent::ResponseChunk { text: chunk });
+        Ok(())
+    }
+
+    async fn flush_chunks(&mut self) -> Result<(), ChannelError> {
+        self.sink.emit(&JsonEvent::ResponseEnd);
+        Ok(())
+    }
+
+    async fn send_typing(&mut self) -> Result<(), ChannelError> {
+        // No typing indicator in JSON mode.
+        Ok(())
+    }
+
+    async fn confirm(&mut self, prompt: &str) -> Result<bool, ChannelError> {
+        if self.auto {
+            return Ok(true);
+        }
+        // Emit a status event and read one y/n line from the channel.
+        self.sink.emit(&JsonEvent::Status {
+            message: &format!("{prompt} (y/n)"),
+        });
+        match self.rx.recv().await {
+            Some(Some(line)) => Ok(matches!(line.trim().to_lowercase().as_str(), "y" | "yes")),
+            _ => Ok(false),
+        }
+    }
+
+    async fn elicit(
+        &mut self,
+        _request: ElicitationRequest,
+    ) -> Result<ElicitationResponse, ChannelError> {
+        // v1: elicitation over JSON is not supported.
+        Err(ChannelError::Other(
+            "elicitation not supported in --json mode".into(),
+        ))
+    }
+
+    async fn send_status(&mut self, text: &str) -> Result<(), ChannelError> {
+        self.sink.emit(&JsonEvent::Status { message: text });
+        Ok(())
+    }
+
+    async fn send_queue_count(&mut self, count: usize) -> Result<(), ChannelError> {
+        self.sink.emit(&JsonEvent::Status {
+            message: &format!("queue: {count}"),
+        });
+        Ok(())
+    }
+
+    async fn send_diff(&mut self, _diff: DiffData) -> Result<(), ChannelError> {
+        // v1: diffs are not emitted as JSON events.
+        Ok(())
+    }
+
+    /// No-op: `JsonEventLayer` emits `tool_result` from its `after_tool` hook.
+    /// Double-emission would corrupt the JSONL stream.
+    async fn send_tool_output(&mut self, _event: ToolOutputEvent) -> Result<(), ChannelError> {
+        Ok(())
+    }
+
+    async fn send_thinking_chunk(&mut self, _chunk: &str) -> Result<(), ChannelError> {
+        // v1: thinking chunks are not emitted in JSON mode.
+        Ok(())
+    }
+
+    async fn send_stop_hint(&mut self, hint: StopHint) -> Result<(), ChannelError> {
+        self.sink.emit(&JsonEvent::Status {
+            message: &format!("stop_hint: {hint:?}"),
+        });
+        Ok(())
+    }
+
+    /// No-op: `JsonEventLayer` emits `cost` from its `after_chat` hook.
+    async fn send_usage(
+        &mut self,
+        _input_tokens: u64,
+        _output_tokens: u64,
+        _context_window: u64,
+    ) -> Result<(), ChannelError> {
+        Ok(())
+    }
+
+    /// No-op: `JsonEventLayer` emits `tool_call` from its `before_tool` hook.
+    async fn send_tool_start(&mut self, _event: ToolStartEvent) -> Result<(), ChannelError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_sink() -> Arc<JsonEventSink> {
+        Arc::new(JsonEventSink::new())
+    }
+
+    #[tokio::test]
+    async fn send_emits_chunk_and_end() {
+        let sink = make_sink();
+        let mut ch = JsonCliChannel::new(Arc::clone(&sink), false);
+        assert!(ch.send("hello").await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn send_chunk_and_flush() {
+        let sink = make_sink();
+        let mut ch = JsonCliChannel::new(Arc::clone(&sink), false);
+        assert!(ch.send_chunk("a").await.is_ok());
+        assert!(ch.flush_chunks().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn send_status_ok() {
+        let sink = make_sink();
+        let mut ch = JsonCliChannel::new(Arc::clone(&sink), false);
+        assert!(ch.send_status("working…").await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn no_ops_do_not_error() {
+        use zeph_core::channel::{ToolOutputEvent, ToolStartEvent};
+        let sink = make_sink();
+        let mut ch = JsonCliChannel::new(Arc::clone(&sink), false);
+        assert!(ch.send_typing().await.is_ok());
+        assert!(ch.send_thinking_chunk("...").await.is_ok());
+        assert!(
+            ch.send_tool_start(ToolStartEvent {
+                tool_name: "shell".into(),
+                tool_call_id: "x".into(),
+                params: None,
+                parent_tool_use_id: None,
+                started_at: std::time::Instant::now(),
+                speculative: false,
+                sandbox_profile: None,
+            })
+            .await
+            .is_ok()
+        );
+        assert!(
+            ch.send_tool_output(ToolOutputEvent {
+                tool_name: "shell".into(),
+                display: "ok".into(),
+                diff: None,
+                filter_stats: None,
+                kept_lines: None,
+                locations: None,
+                tool_call_id: "x".into(),
+                is_error: false,
+                terminal_id: None,
+                parent_tool_use_id: None,
+                raw_response: None,
+                started_at: None,
+            })
+            .await
+            .is_ok()
+        );
+        assert!(ch.send_usage(100, 50, 200_000).await.is_ok());
+        assert!(ch.send_stop_hint(StopHint::MaxTokens).await.is_ok());
+    }
+
+    #[test]
+    fn supports_exit_is_true() {
+        let sink = make_sink();
+        let ch = JsonCliChannel::new(sink, false);
+        assert!(ch.supports_exit());
+    }
+
+    #[test]
+    fn try_recv_returns_none_when_no_input() {
+        let sink = make_sink();
+        let mut ch = JsonCliChannel::new(sink, false);
+        assert!(ch.try_recv().is_none());
+    }
+}

--- a/crates/zeph-channels/src/json_cli.rs
+++ b/crates/zeph-channels/src/json_cli.rs
@@ -8,9 +8,9 @@
 //!
 //! # Double-emission prevention
 //!
-//! [`JsonEventLayer`] is the canonical emitter for `tool_call`, `tool_result`,
-//! and `cost` events. The corresponding channel methods (`send_tool_start`,
-//! `send_tool_output`, `send_usage`) are intentionally no-ops here.
+//! `JsonEventLayer` (in `zeph-core`) is the canonical emitter for `tool_call`,
+//! `tool_result`, and `cost` events. The corresponding channel methods
+//! (`send_tool_start`, `send_tool_output`, `send_usage`) are intentionally no-ops here.
 
 use std::io::{BufRead, BufReader, IsTerminal};
 use std::sync::Arc;
@@ -24,7 +24,7 @@ use zeph_core::json_event_sink::{JsonEvent, JsonEventSink};
 
 /// CLI channel that emits structured JSON events to stdout.
 ///
-/// Construct via [`JsonCliChannel::new`] and wrap in [`AnyChannel::JsonCli`].
+/// Construct via [`JsonCliChannel::new`] and wrap in `AnyChannel::JsonCli`.
 /// All assistive output goes through the shared [`JsonEventSink`]; only stdin
 /// reading is internal to this channel.
 #[derive(Debug)]

--- a/crates/zeph-channels/src/lib.rs
+++ b/crates/zeph-channels/src/lib.rs
@@ -35,6 +35,7 @@ mod any;
 pub mod cli;
 #[cfg(feature = "discord")]
 pub mod discord;
+pub mod json_cli;
 mod line_editor;
 pub mod markdown;
 #[cfg(feature = "slack")]
@@ -43,6 +44,7 @@ pub mod telegram;
 
 pub use any::AnyChannel;
 pub use cli::CliChannel;
+pub use json_cli::JsonCliChannel;
 
 /// Shared timeout for interactive confirmation dialogs across all remote channels.
 ///

--- a/crates/zeph-commands/src/commands.rs
+++ b/crates/zeph-commands/src/commands.rs
@@ -262,4 +262,11 @@ pub const COMMANDS: &[CommandInfo] = &[
         category: SlashCategory::Debugging,
         feature_gate: None,
     },
+    CommandInfo {
+        name: "/loop",
+        args: "<prompt> every <N> <unit> | stop",
+        description: "Repeat a prompt on a fixed interval (min 5s), or stop the active loop",
+        category: SlashCategory::Advanced,
+        feature_gate: None,
+    },
 ];

--- a/crates/zeph-commands/src/handlers/loop_cmd.rs
+++ b/crates/zeph-commands/src/handlers/loop_cmd.rs
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `/loop` slash command handler.
+//!
+//! Syntax:
+//! - `/loop <prompt> every <N> <unit>` — start a repeating loop
+//! - `/loop stop`                       — cancel the active loop
+//!
+//! Units: `s`, `sec`, `secs`, `second`, `seconds`,
+//!        `m`, `min`, `mins`, `minute`, `minutes`,
+//!        `h`, `hr`, `hrs`, `hour`, `hours`.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use crate::context::CommandContext;
+use crate::{CommandError, CommandHandler, CommandOutput, SlashCategory};
+
+/// Start or stop a repeating prompt loop.
+pub struct LoopCommand;
+
+impl CommandHandler<CommandContext<'_>> for LoopCommand {
+    fn name(&self) -> &'static str {
+        "/loop"
+    }
+
+    fn description(&self) -> &'static str {
+        "Repeat a prompt on a fixed interval, or stop the active loop"
+    }
+
+    fn args_hint(&self) -> &'static str {
+        "<prompt> every <N> <unit> | stop | status"
+    }
+
+    fn category(&self) -> SlashCategory {
+        SlashCategory::Advanced
+    }
+
+    fn handle<'a>(
+        &'a self,
+        ctx: &'a mut CommandContext<'_>,
+        args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<CommandOutput, CommandError>> + Send + 'a>> {
+        Box::pin(async move {
+            match ctx.agent.handle_loop(args).await? {
+                msg if msg.is_empty() => Ok(CommandOutput::Silent),
+                msg => Ok(CommandOutput::Message(msg)),
+            }
+        })
+    }
+}
+
+/// Parse `/loop <prompt> every <N> <unit>` — returns `(prompt, interval_secs)`.
+///
+/// Returns `Err` with a user-visible message on any syntax or value error.
+///
+/// # Errors
+///
+/// Returns `Err` when the syntax is invalid or `N` is not a positive integer.
+pub fn parse_loop_args(args: &str) -> Result<(String, u64), CommandError> {
+    // Find " every " as the separator between prompt and interval spec.
+    // We search from the right so prompts that contain the word "every" work correctly.
+    let sep = " every ";
+    let sep_pos = args.rfind(sep).ok_or_else(|| {
+        CommandError::new(
+            "Usage: /loop <prompt> every <N> <unit>  (e.g. /loop check logs every 10 minutes)",
+        )
+    })?;
+
+    let prompt = args[..sep_pos].trim().to_owned();
+    if prompt.is_empty() {
+        return Err(CommandError::new("Prompt must not be empty."));
+    }
+
+    let interval_str = args[sep_pos + sep.len()..].trim();
+    let (n_str, unit) = interval_str.split_once(' ').ok_or_else(|| {
+        CommandError::new("Expected format: every <N> <unit>  (e.g. every 5 minutes)")
+    })?;
+
+    let n: u64 = n_str
+        .parse()
+        .map_err(|_| CommandError::new(format!("Expected a positive integer, got '{n_str}'")))?;
+    if n == 0 {
+        return Err(CommandError::new("Interval must be greater than zero."));
+    }
+
+    let multiplier: u64 = match unit.trim() {
+        "s" | "sec" | "secs" | "second" | "seconds" => 1,
+        "m" | "min" | "mins" | "minute" | "minutes" => 60,
+        "h" | "hr" | "hrs" | "hour" | "hours" => 3600,
+        other => {
+            return Err(CommandError::new(format!(
+                "Unknown time unit '{other}'. Use: s/sec/seconds, m/min/minutes, h/hr/hours"
+            )));
+        }
+    };
+
+    Ok((prompt, n * multiplier))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_seconds() {
+        let (prompt, secs) = parse_loop_args("check logs every 10 seconds").unwrap();
+        assert_eq!(prompt, "check logs");
+        assert_eq!(secs, 10);
+    }
+
+    #[test]
+    fn parse_minutes() {
+        let (prompt, secs) = parse_loop_args("summarize recent activity every 5 minutes").unwrap();
+        assert_eq!(prompt, "summarize recent activity");
+        assert_eq!(secs, 300);
+    }
+
+    #[test]
+    fn parse_hours() {
+        let (prompt, secs) = parse_loop_args("daily report every 1 hour").unwrap();
+        assert_eq!(prompt, "daily report");
+        assert_eq!(secs, 3600);
+    }
+
+    #[test]
+    fn parse_short_units() {
+        let (_, s) = parse_loop_args("ping every 30 s").unwrap();
+        assert_eq!(s, 30);
+        let (_, m) = parse_loop_args("ping every 2 m").unwrap();
+        assert_eq!(m, 120);
+        let (_, h) = parse_loop_args("ping every 1 h").unwrap();
+        assert_eq!(h, 3600);
+    }
+
+    #[test]
+    fn parse_prompt_with_every_word() {
+        // "every" appears in the prompt too — rfind picks the last occurrence.
+        let (prompt, secs) = parse_loop_args("check every file in dir every 15 sec").unwrap();
+        assert_eq!(prompt, "check every file in dir");
+        assert_eq!(secs, 15);
+    }
+
+    #[test]
+    fn parse_missing_every() {
+        assert!(parse_loop_args("check logs 10 seconds").is_err());
+    }
+
+    #[test]
+    fn parse_empty_prompt() {
+        assert!(parse_loop_args("every 5 seconds").is_err());
+    }
+
+    #[test]
+    fn parse_zero_n() {
+        assert!(parse_loop_args("ping every 0 seconds").is_err());
+    }
+
+    #[test]
+    fn parse_bad_unit() {
+        assert!(parse_loop_args("ping every 5 fortnights").is_err());
+    }
+
+    #[test]
+    fn parse_bad_n() {
+        assert!(parse_loop_args("ping every abc seconds").is_err());
+    }
+}

--- a/crates/zeph-commands/src/handlers/mod.rs
+++ b/crates/zeph-commands/src/handlers/mod.rs
@@ -14,6 +14,7 @@ pub mod compaction;
 pub mod debug;
 pub mod experiment;
 pub mod help;
+pub mod loop_cmd;
 pub mod lsp;
 pub mod mcp;
 pub mod memory;

--- a/crates/zeph-commands/src/traits/agent.rs
+++ b/crates/zeph-commands/src/traits/agent.rs
@@ -390,6 +390,21 @@ pub trait AgentAccess: Send {
         &'a mut self,
         args: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>>;
+
+    // ----- /loop -----
+
+    /// Handle `/loop <prompt> every <N> <unit>` or `/loop stop`.
+    ///
+    /// Starts a repeating loop that injects `prompt` as a new agent turn on each tick,
+    /// or stops the currently active loop. Returns a user-visible ACK string.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` when the arguments are malformed or the interval is below the minimum.
+    fn handle_loop<'a>(
+        &'a mut self,
+        args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>>;
 }
 
 /// A no-op [`AgentAccess`] implementation.
@@ -592,6 +607,13 @@ impl AgentAccess for NullAgent {
     }
 
     fn handle_plugins<'a>(
+        &'a mut self,
+        _args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>> {
+        Box::pin(async { Ok(String::new()) })
+    }
+
+    fn handle_loop<'a>(
         &'a mut self,
         _args: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>> {

--- a/crates/zeph-config/src/cli.rs
+++ b/crates/zeph-config/src/cli.rs
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Session-scoped CLI configuration: bare mode, JSON output, and auto-approval flags.
+
+use serde::{Deserialize, Serialize};
+
+/// Session-scoped CLI overrides loaded from the `[cli]` TOML section.
+///
+/// Command-line flags take priority over these values. This section has no
+/// effect on Telegram, Discord, Slack, or ACP sessions.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(default)]
+pub struct CliConfig {
+    /// Enable bare mode (skip skills, memory, MCP, scheduler, watchers).
+    pub bare: bool,
+    /// Emit structured JSON events (JSONL) to stdout. Forces logs to stderr.
+    pub json: bool,
+    /// Auto-approve trust-gate prompts (`-y` / `--auto`).
+    pub auto: bool,
+    /// Loop command configuration.
+    #[serde(rename = "loop")]
+    pub loop_: LoopConfig,
+}
+
+/// Configuration for the `/loop` command.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct LoopConfig {
+    /// Minimum allowed interval between loop ticks (seconds). Floor enforced at parse time.
+    pub min_interval_secs: u64,
+    /// Maximum number of concurrent loops. Reserved for future use; always 1 in v1.
+    pub max_concurrent: u32,
+}
+
+impl Default for LoopConfig {
+    fn default() -> Self {
+        Self {
+            min_interval_secs: 5,
+            max_concurrent: 1,
+        }
+    }
+}

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -54,6 +54,7 @@
 pub mod agent;
 pub mod channels;
 pub mod classifiers;
+pub mod cli;
 pub mod defaults;
 pub mod dump_format;
 mod env;
@@ -88,6 +89,7 @@ pub use channels::{
     ToolDiscoveryConfig, ToolDiscoveryStrategyConfig, ToolPruningConfig, TrustCalibrationConfig,
     is_skill_allowed,
 };
+pub use cli::{CliConfig, LoopConfig};
 pub use defaults::{
     DEFAULT_DEBUG_DIR, DEFAULT_LOG_FILE, DEFAULT_SKILLS_DIR, DEFAULT_SQLITE_PATH,
     default_debug_dir, default_integrity_registry_path, default_log_file_path, default_skills_dir,

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -10,6 +10,7 @@ use zeph_tools::ToolsConfig;
 use crate::agent::{AgentConfig, FocusConfig, SubAgentConfig};
 use crate::channels::{A2aServerConfig, DiscordConfig, McpConfig, SlackConfig, TelegramConfig};
 use crate::classifiers::ClassifiersConfig;
+use crate::cli::CliConfig;
 use crate::defaults::{default_skill_paths, default_sqlite_path_field};
 use crate::experiment::{ExperimentConfig, OrchestrationConfig};
 use crate::features::{
@@ -105,6 +106,9 @@ pub struct Config {
     /// Session UX settings (recap-on-resume, etc.).
     #[serde(default)]
     pub session: crate::session::SessionConfig,
+    /// Session-scoped CLI overrides (bare mode, JSON output, auto-approve).
+    #[serde(default)]
+    pub cli: CliConfig,
     /// Resolved secrets from vault. Never serialized — populated at runtime.
     #[serde(skip)]
     pub secrets: ResolvedSecrets,
@@ -268,6 +272,7 @@ impl Default for Config {
             telemetry: TelemetryConfig::default(),
             metrics: MetricsConfig::default(),
             session: crate::session::SessionConfig::default(),
+            cli: CliConfig::default(),
             secrets: ResolvedSecrets::default(),
         }
     }

--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -852,6 +852,57 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
             .map_err(|e| CommandError(format!("plugin task panicked: {e}")))
         })
     }
+
+    // ----- /loop -----
+
+    fn handle_loop<'a>(
+        &'a mut self,
+        args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>> {
+        use zeph_commands::handlers::loop_cmd::parse_loop_args;
+
+        let args_owned = args.trim().to_owned();
+        Box::pin(async move {
+            if args_owned == "stop" {
+                return Ok(self.stop_user_loop());
+            }
+            if args_owned == "status" {
+                return Ok(match &self.lifecycle.user_loop {
+                    Some(ls) => format!(
+                        "Loop active: \"{}\" (iteration {}, interval every {}s).",
+                        ls.prompt,
+                        ls.iteration,
+                        ls.interval.period().as_secs(),
+                    ),
+                    None => "No active loop.".to_owned(),
+                });
+            }
+            let (prompt, interval_secs) = parse_loop_args(&args_owned)?;
+
+            if prompt.starts_with('/') {
+                return Err(CommandError::new(
+                    "Loop prompt must not start with '/'. Slash commands cannot be used as loop prompts.",
+                ));
+            }
+
+            let min_secs = self.runtime.loop_min_interval_secs;
+            if interval_secs < min_secs {
+                return Err(CommandError::new(format!(
+                    "Minimum loop interval is {min_secs}s. Got {interval_secs}s."
+                )));
+            }
+            if self.lifecycle.user_loop.is_some() {
+                return Err(CommandError::new(
+                    "A loop is already active. Use /loop stop first.",
+                ));
+            }
+
+            self.start_user_loop(prompt.clone(), interval_secs);
+            Ok(format!(
+                "Loop started: \"{prompt}\" every {interval_secs}s. Use /loop stop to cancel."
+            ))
+        })
+    }
 }
 
 /// Convert `AgentError` to `CommandError` for the trait boundary.

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -772,6 +772,32 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Register a [`RuntimeLayer`] that intercepts LLM calls and tool dispatch.
+    ///
+    /// Layers are called in registration order. This method may be called multiple
+    /// times to stack layers.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::sync::Arc;
+    /// use zeph_core::Agent;
+    /// use zeph_core::json_event_sink::JsonEventSink;
+    /// use zeph_core::json_event_layer::JsonEventLayer;
+    ///
+    /// let sink = Arc::new(JsonEventSink::new());
+    /// let layer = JsonEventLayer::new(Arc::clone(&sink));
+    /// // agent.with_runtime_layer(Arc::new(layer));
+    /// ```
+    #[must_use]
+    pub fn with_runtime_layer(
+        mut self,
+        layer: std::sync::Arc<dyn crate::runtime_layer::RuntimeLayer>,
+    ) -> Self {
+        self.runtime.layers.push(layer);
+        self
+    }
+
     // ---- Context & Compression ----
 
     /// Configure the context token budget and compaction thresholds.
@@ -1585,6 +1611,7 @@ impl<C: Channel> Agent<C> {
             budget_hint_enabled,
             secrets,
             recap,
+            loop_min_interval_secs,
         } = cfg;
 
         self.tool_orchestrator.apply_config(
@@ -1636,6 +1663,7 @@ impl<C: Channel> Agent<C> {
         self.wire_graph_persistence();
         self.runtime.budget_hint_enabled = budget_hint_enabled;
         self.runtime.recap_config = recap;
+        self.runtime.loop_min_interval_secs = loop_min_interval_secs;
 
         self.debug_state.reasoning_model_warning = anomaly_config.reasoning_model_warning;
         if anomaly_config.enabled {

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -772,7 +772,7 @@ impl<C: Channel> Agent<C> {
         self
     }
 
-    /// Register a [`RuntimeLayer`] that intercepts LLM calls and tool dispatch.
+    /// Register a [`crate::runtime_layer::RuntimeLayer`] that intercepts LLM calls and tool dispatch.
     ///
     /// Layers are called in registration order. This method may be called multiple
     /// times to stack layers.

--- a/crates/zeph-core/src/agent/loop_event.rs
+++ b/crates/zeph-core/src/agent/loop_event.rs
@@ -7,6 +7,7 @@
 //! a single enum so the main loop body stays readable and each event source
 //! gets a dedicated handler method.
 
+use crate::agent::task_injection::TaskInjection;
 use crate::channel::ChannelMessage;
 use crate::file_watcher::FileChangedEvent;
 
@@ -39,6 +40,9 @@ pub(crate) enum LoopEvent {
 
     /// A scheduler-injected prompt should be processed as a new agent turn.
     ScheduledTask(String),
+
+    /// A prompt injected by the `/loop` command on a tick.
+    TaskInjected(TaskInjection),
 
     /// A watched file changed and the agent should react accordingly.
     FileChanged(FileChangedEvent),

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -44,6 +44,7 @@ mod skill_management;
 pub mod slash_commands;
 pub mod speculative;
 pub(crate) mod state;
+pub(crate) mod task_injection;
 pub(crate) mod tool_execution;
 pub(crate) mod tool_orchestrator;
 mod trust_commands;
@@ -803,6 +804,18 @@ impl<C: Channel> Agent<C> {
                         self.drain_channel();
                         self.resolve_message(msg).await
                     }
+                    Some(LoopEvent::TaskInjected(injection)) => {
+                        if let Some(ref mut ls) = self.lifecycle.user_loop {
+                            ls.iteration += 1;
+                            tracing::info!(iteration = ls.iteration, "loop: tick");
+                        }
+                        let msg = crate::channel::ChannelMessage {
+                            text: injection.prompt,
+                            attachments: Vec::new(),
+                        };
+                        self.drain_channel();
+                        self.resolve_message(msg).await
+                    }
                     Some(LoopEvent::FileChanged(event)) => {
                         self.handle_file_changed(event).await;
                         continue;
@@ -913,6 +926,7 @@ impl<C: Channel> Agent<C> {
                     agent_cmd::AgentCommand,
                     compaction::{CompactCommand, NewConversationCommand, RecapCommand},
                     experiment::ExperimentCommand,
+                    loop_cmd::LoopCommand,
                     lsp::LspCommand,
                     mcp::McpCommand,
                     memory::{GraphCommand, GuidelinesCommand, MemoryCommand},
@@ -953,6 +967,7 @@ impl<C: Channel> Agent<C> {
                 agent_reg.register(RecapCommand);
                 agent_reg.register(ExperimentCommand);
                 agent_reg.register(PlanCommand);
+                agent_reg.register(LoopCommand);
 
                 let mut ctx = zeph_commands::CommandContext {
                     sink: &mut agent_null_sink,
@@ -1058,6 +1073,30 @@ impl<C: Channel> Agent<C> {
             Some(prompt) = recv_optional(&mut self.lifecycle.custom_task_rx) => {
                 tracing::info!("scheduler: injecting custom task as agent turn");
                 LoopEvent::ScheduledTask(prompt)
+            }
+            () = async {
+                if let Some(ref mut ls) = self.lifecycle.user_loop {
+                    if ls.cancel_tx.is_cancelled() {
+                        std::future::pending::<()>().await;
+                    } else {
+                        ls.interval.tick().await;
+                    }
+                } else {
+                    std::future::pending::<()>().await;
+                }
+            } => {
+                // Re-check user_loop after the tick — /loop stop may have fired between the
+                // interval firing and this arm executing. Returning Ok(None) causes the caller
+                // to `continue` without injecting a stale or empty prompt.
+                let Some(ls) = self.lifecycle.user_loop.as_ref() else {
+                    return Ok(None);
+                };
+                if ls.cancel_tx.is_cancelled() {
+                    self.lifecycle.user_loop = None;
+                    return Ok(None);
+                }
+                let prompt = ls.prompt.clone();
+                LoopEvent::TaskInjected(task_injection::TaskInjection { prompt })
             }
             Some(event) = recv_optional(&mut self.lifecycle.file_changed_rx) => {
                 LoopEvent::FileChanged(event)

--- a/crates/zeph-core/src/agent/session_config.rs
+++ b/crates/zeph-core/src/agent/session_config.rs
@@ -105,6 +105,9 @@ pub struct AgentSessionConfig {
     /// Session recap settings (#3064).
     pub recap: zeph_config::RecapConfig,
 
+    /// Minimum allowed `/loop` tick interval in seconds. From `[cli.loop] min_interval_secs`.
+    pub loop_min_interval_secs: u64,
+
     /// Custom secrets from config.
     ///
     /// Stored as `Arc` because `Secret` intentionally does not implement `Clone` —
@@ -174,6 +177,7 @@ impl AgentSessionConfig {
                 .collect::<Vec<_>>()
                 .into(),
             recap: config.session.recap.clone(),
+            loop_min_interval_secs: config.cli.loop_.min_interval_secs,
         }
     }
 }

--- a/crates/zeph-core/src/agent/slash_commands.rs
+++ b/crates/zeph-core/src/agent/slash_commands.rs
@@ -559,6 +559,37 @@ impl<C: crate::channel::Channel> Agent<C> {
         Ok(output)
     }
 
+    /// Start a user-driven loop that injects `prompt` every `interval_secs` seconds.
+    pub(crate) fn start_user_loop(&mut self, prompt: String, interval_secs: u64) {
+        use std::time::Duration;
+        use tokio::time::{Instant, MissedTickBehavior};
+
+        let period = Duration::from_secs(interval_secs);
+        // interval_at(now + period, period) ensures the first tick fires after one full period,
+        // not immediately. tokio::time::interval() would fire at t=0 which is never desired.
+        let mut interval = tokio::time::interval_at(Instant::now() + period, period);
+        interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        let cancel_tx = tokio_util::sync::CancellationToken::new();
+        self.lifecycle.user_loop = Some(crate::agent::state::LoopState {
+            prompt,
+            iteration: 0,
+            interval,
+            cancel_tx,
+        });
+    }
+
+    /// Stop the active user loop and return a user-visible message.
+    pub(crate) fn stop_user_loop(&mut self) -> String {
+        if let Some(ls) = self.lifecycle.user_loop.take() {
+            let iters = ls.iteration;
+            ls.cancel_tx.cancel();
+            format!("Loop stopped after {iters} iteration(s).")
+        } else {
+            "No active loop.".to_owned()
+        }
+    }
+
     async fn handle_skills_confusability_as_string(&mut self) -> Result<String, error::AgentError> {
         let threshold = self.skill_state.confusability_threshold;
         if threshold <= 0.0 {

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -32,6 +32,7 @@ use std::time::Instant;
 
 use tokio::sync::{Notify, mpsc, watch};
 use tokio::task::JoinHandle;
+use tokio::time::Interval;
 use tokio_util::sync::CancellationToken;
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::Message;
@@ -226,6 +227,8 @@ pub(crate) struct RuntimeConfig {
     /// Per-channel skill allowlist. Skills not matching the allowlist are excluded from the
     /// prompt. An empty `allowed` list means all skills are permitted (default).
     pub(crate) channel_skills: zeph_config::ChannelSkillsConfig,
+    /// Minimum allowed interval for `/loop` ticks (seconds). Sourced from `[cli.loop] min_interval_secs`.
+    pub(crate) loop_min_interval_secs: u64,
     /// Runtime middleware layers for LLM calls and tool dispatch (#2286).
     ///
     /// Default: empty vec (zero-cost — loops never iterate).
@@ -342,6 +345,21 @@ pub struct ShellOverlaySnapshot {
     pub allowed: Vec<String>,
 }
 
+/// Runtime state for an active `/loop` session.
+///
+/// At most one loop is active at a time; `LifecycleState::user_loop` holds `Some` while
+/// the loop is running and `None` otherwise.
+pub(crate) struct LoopState {
+    /// The prompt text injected on each tick.
+    pub(crate) prompt: String,
+    /// Number of ticks fired so far.
+    pub(crate) iteration: u64,
+    /// Tick interval. `MissedTickBehavior::Skip` prevents burst catch-up.
+    pub(crate) interval: Interval,
+    /// Cancel handle. Dropped (and token cancelled) when loop is stopped.
+    pub(crate) cancel_tx: CancellationToken,
+}
+
 /// Groups agent lifecycle state: shutdown signaling, timing, and I/O notification channels.
 pub(crate) struct LifecycleState {
     pub(crate) shutdown: watch::Receiver<bool>,
@@ -363,6 +381,8 @@ pub(crate) struct LifecycleState {
     pub(crate) warmup_ready: Option<watch::Receiver<bool>>,
     pub(crate) update_notify_rx: Option<mpsc::Receiver<String>>,
     pub(crate) custom_task_rx: Option<mpsc::Receiver<String>>,
+    /// Active `/loop` state. `None` when no loop is running.
+    pub(crate) user_loop: Option<LoopState>,
     /// Last known process cwd. Compared after each tool call to detect changes.
     pub(crate) last_known_cwd: PathBuf,
     /// Receiver for file-change events from `FileChangeWatcher`. `None` when no paths configured.
@@ -855,6 +875,7 @@ impl Default for RuntimeConfig {
             spawn_depth: 0,
             budget_hint_enabled: true,
             channel_skills: zeph_config::ChannelSkillsConfig::default(),
+            loop_min_interval_secs: 5,
             layers: Vec::new(),
             supervisor_config: crate::config::TaskSupervisorConfig::default(),
             recap_config: zeph_config::RecapConfig::default(),
@@ -935,6 +956,7 @@ impl LifecycleState {
             warmup_ready: None,
             update_notify_rx: None,
             custom_task_rx: None,
+            user_loop: None,
             last_known_cwd: std::env::current_dir().unwrap_or_default(),
             file_changed_rx: None,
             file_watcher: None,

--- a/crates/zeph-core/src/agent/state/tests.rs
+++ b/crates/zeph-core/src/agent/state/tests.rs
@@ -88,6 +88,7 @@ fn make_runtime_config() -> RuntimeConfig {
         spawn_depth: 0,
         budget_hint_enabled: true,
         channel_skills: zeph_config::ChannelSkillsConfig::default(),
+        loop_min_interval_secs: 5,
         layers: Vec::new(),
         supervisor_config: crate::config::TaskSupervisorConfig::default(),
         recap_config: zeph_config::RecapConfig::default(),

--- a/crates/zeph-core/src/agent/task_injection.rs
+++ b/crates/zeph-core/src/agent/task_injection.rs
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Task injection from the `/loop` command into the agent run-loop.
+
+/// A raw user prompt injected by the `/loop` command on each tick.
+///
+/// Carried by [`LoopEvent::TaskInjected`] and dispatched without any prefix
+/// (unlike scheduler tasks which prepend [`SCHEDULED_TASK_PREFIX`]).
+///
+/// [`LoopEvent::TaskInjected`]: super::loop_event::LoopEvent::TaskInjected
+/// [`SCHEDULED_TASK_PREFIX`]: super::SCHEDULED_TASK_PREFIX
+pub(crate) struct TaskInjection {
+    /// The prompt text to inject as a new agent turn.
+    pub(crate) prompt: String,
+}

--- a/crates/zeph-core/src/json_event_layer.rs
+++ b/crates/zeph-core/src/json_event_layer.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! `JsonEventLayer`: a [`RuntimeLayer`] that emits tool events via [`JsonEventSink`].
+//! `JsonEventLayer`: a [`crate::runtime_layer::RuntimeLayer`] that emits tool events via [`JsonEventSink`].
 //!
 //! Install this layer on the agent when `--json` is active. It is the *canonical*
 //! emitter for `tool_call` and `tool_result` events — `JsonCliChannel` intentionally

--- a/crates/zeph-core/src/json_event_layer.rs
+++ b/crates/zeph-core/src/json_event_layer.rs
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `JsonEventLayer`: a [`RuntimeLayer`] that emits tool events via [`JsonEventSink`].
+//!
+//! Install this layer on the agent when `--json` is active. It is the *canonical*
+//! emitter for `tool_call` and `tool_result` events — `JsonCliChannel` intentionally
+//! no-ops its corresponding channel methods to avoid double-emission.
+//!
+//! All tool arguments and outputs pass through [`crate::redact::scrub_content`] before
+//! emission so secrets (API keys, bearer tokens, passwords) are not written to the JSONL
+//! stream.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use zeph_tools::ToolError;
+use zeph_tools::executor::{ToolCall, ToolOutput};
+
+use crate::json_event_sink::{JsonEvent, JsonEventSink};
+use crate::runtime_layer::{BeforeToolResult, LayerContext, RuntimeLayer};
+
+/// `RuntimeLayer` that forwards tool events to a [`JsonEventSink`].
+pub struct JsonEventLayer {
+    sink: Arc<JsonEventSink>,
+}
+
+impl JsonEventLayer {
+    /// Create a new layer sharing `sink` with `JsonCliChannel`.
+    #[must_use]
+    pub fn new(sink: Arc<JsonEventSink>) -> Self {
+        Self { sink }
+    }
+}
+
+impl RuntimeLayer for JsonEventLayer {
+    fn before_tool<'a>(
+        &'a self,
+        _ctx: &'a LayerContext<'_>,
+        call: &'a ToolCall,
+    ) -> Pin<Box<dyn Future<Output = BeforeToolResult> + Send + 'a>> {
+        // Serialize args, scrub secrets, then re-parse so the sink receives a clean Value.
+        let raw = serde_json::Value::Object(call.params.clone());
+        let raw_str = raw.to_string();
+        let scrubbed_str = crate::redact::scrub_content(&raw_str);
+        let args_value: serde_json::Value =
+            serde_json::from_str(&scrubbed_str).unwrap_or(serde_json::Value::Null);
+        self.sink.emit(&JsonEvent::ToolCall {
+            tool: call.tool_id.as_ref(),
+            args: &args_value,
+            id: call.tool_id.as_ref(),
+        });
+        Box::pin(std::future::ready(None))
+    }
+
+    fn after_tool<'a>(
+        &'a self,
+        _ctx: &'a LayerContext<'_>,
+        call: &'a ToolCall,
+        result: &'a Result<Option<ToolOutput>, ToolError>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        let err_str;
+        let scrubbed_err;
+        let scrubbed_out;
+        let (output, is_error) = match result {
+            Ok(Some(out)) => {
+                scrubbed_out = crate::redact::scrub_content(&out.summary);
+                (scrubbed_out.as_ref(), false)
+            }
+            Ok(None) => ("", false),
+            Err(e) => {
+                err_str = e.to_string();
+                scrubbed_err = crate::redact::scrub_content(&err_str);
+                (scrubbed_err.as_ref(), true)
+            }
+        };
+        self.sink.emit(&JsonEvent::ToolResult {
+            tool: call.tool_id.as_ref(),
+            id: call.tool_id.as_ref(),
+            output,
+            is_error,
+        });
+        Box::pin(std::future::ready(()))
+    }
+}

--- a/crates/zeph-core/src/json_event_sink.rs
+++ b/crates/zeph-core/src/json_event_sink.rs
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `JsonEventSink`: the single stdout writer for `--json` mode.
+//!
+//! All JSON events in a `--json` session are emitted through a shared
+//! `Arc<JsonEventSink>`. The internal `Mutex<Stdout>` ensures that concurrent
+//! emitters from different tasks cannot interleave partial lines.
+//!
+//! # Ordering guarantee
+//!
+//! Events emitted from the same thread preserve their issuance order. Events
+//! from concurrent threads interleave in mutex-acquisition order. Within a
+//! single response, `response_chunk` events precede `response_end`. Tool events
+//! may interleave with chunks when tools run mid-stream (normal for agent loops).
+//!
+//! # Lock discipline
+//!
+//! `emit` holds the lock only for serialization + write + flush. It never
+//! `.await`s while holding the lock, satisfying invariant §10.
+
+use std::io::{self, Stdout, Write};
+use std::sync::Mutex;
+
+use serde::Serialize;
+
+/// Structured event emitted on stdout in `--json` mode.
+///
+/// All variants are serialized as JSONL with a `"event"` discriminator field.
+#[derive(Serialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum JsonEvent<'a> {
+    /// Session boot banner emitted before the first prompt.
+    Boot {
+        version: &'a str,
+        bare: bool,
+        auto: bool,
+    },
+    /// User input received from stdin.
+    Query { text: &'a str, queue_len: usize },
+    /// Streaming assistant text chunk.
+    ResponseChunk { text: &'a str },
+    /// End-of-response marker.
+    ResponseEnd,
+    /// A tool invocation is about to run.
+    ToolCall {
+        tool: &'a str,
+        args: &'a serde_json::Value,
+        id: &'a str,
+    },
+    /// A tool returned a result.
+    ToolResult {
+        tool: &'a str,
+        id: &'a str,
+        output: &'a str,
+        is_error: bool,
+    },
+    /// Token counts and estimated cost summary.
+    Cost {
+        input_tokens: u64,
+        output_tokens: u64,
+        total_usd: f64,
+    },
+    /// Loop tick notification fired each `/loop` iteration.
+    LoopTick {
+        iteration: u64,
+        total_ticks: u64,
+        prompt_preview: &'a str,
+    },
+    /// Slash command acknowledgement — distinguishes `/loop start` confirmation
+    /// from regular assistant output in JSON streams.
+    CommandAck { command: &'a str, text: &'a str },
+    /// General status message (equivalent to spinner text in interactive channels).
+    Status { message: &'a str },
+    /// Terminal error emitted before the process exits.
+    Error { message: &'a str },
+}
+
+/// The single stdout writer for `--json` mode.
+///
+/// Wrap in `Arc` and share between `JsonCliChannel` and `JsonEventLayer`.
+/// `emit` is synchronous and lock-bounded: it never yields across `.await`.
+pub struct JsonEventSink {
+    writer: Mutex<Stdout>,
+}
+
+impl std::fmt::Debug for JsonEventSink {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("JsonEventSink").finish_non_exhaustive()
+    }
+}
+
+impl JsonEventSink {
+    /// Create a new sink that writes to the process's stdout.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            writer: Mutex::new(io::stdout()),
+        }
+    }
+
+    /// Serialize `event` as a JSON line and write it to stdout.
+    ///
+    /// Silently drops the event when the mutex is poisoned or serialization fails.
+    /// This is intentional: a JSON output failure must not crash the agent.
+    pub fn emit(&self, event: &JsonEvent<'_>) {
+        let Ok(mut w) = self.writer.lock() else {
+            return;
+        };
+        if let Ok(line) = serde_json::to_string(event) {
+            let _ = writeln!(w, "{line}");
+            let _ = w.flush();
+        }
+    }
+}
+
+impl Default for JsonEventSink {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn boot_event_serializes_correctly() {
+        let event = JsonEvent::Boot {
+            version: "0.1.0",
+            bare: true,
+            auto: false,
+        };
+        let s = serde_json::to_string(&event).unwrap();
+        assert!(s.contains("\"event\":\"boot\""));
+        assert!(s.contains("\"version\":\"0.1.0\""));
+        assert!(s.contains("\"bare\":true"));
+    }
+
+    #[test]
+    fn response_end_serializes_without_fields() {
+        let event = JsonEvent::ResponseEnd;
+        let s = serde_json::to_string(&event).unwrap();
+        assert_eq!(s, r#"{"event":"response_end"}"#);
+    }
+
+    #[test]
+    fn emit_does_not_panic_on_concurrent_use() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let sink = Arc::new(JsonEventSink::new());
+        let handles: Vec<_> = (0..4)
+            .map(|i| {
+                let s = Arc::clone(&sink);
+                thread::spawn(move || {
+                    for _ in 0..10 {
+                        s.emit(&JsonEvent::Status {
+                            message: &format!("thread {i}"),
+                        });
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+    }
+}

--- a/crates/zeph-core/src/lib.rs
+++ b/crates/zeph-core/src/lib.rs
@@ -87,6 +87,8 @@ pub mod redact;
 pub mod system_metrics;
 
 pub mod http;
+pub mod json_event_layer;
+pub mod json_event_sink;
 pub mod lsp_hooks;
 pub mod memory_tools;
 pub mod overflow_tools;

--- a/crates/zeph-skills/src/registry.rs
+++ b/crates/zeph-skills/src/registry.rs
@@ -71,6 +71,14 @@ impl std::fmt::Debug for SkillRegistry {
 }
 
 impl SkillRegistry {
+    /// Create an empty registry with no skills, no watchers, and no hub directories.
+    ///
+    /// Used in `--bare` mode where skill loading is intentionally skipped.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
     /// Register hub-managed directories for defense-in-depth in [`Self::scan_loaded`].
     ///
     /// Skills under these directories are hub-installed. Even if a `.bundled` marker

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -69,6 +69,21 @@ pub struct WatcherBundle {
     pub config_reload_rx: zeph_core::instrumented_channel::InstrumentedReceiver<ConfigEvent>,
 }
 
+impl WatcherBundle {
+    /// Create a bundle with no watchers. Used in `--bare` mode.
+    pub fn empty() -> Self {
+        use zeph_core::instrumented_channel::instrumented_channel;
+        let (_, skill_reload_rx) = instrumented_channel(1, "skill_reload_rx_bare");
+        let (_, config_reload_rx) = instrumented_channel(1, "config_reload_rx_bare");
+        Self {
+            skill_watcher: None,
+            skill_reload_rx,
+            config_watcher: None,
+            config_reload_rx,
+        }
+    }
+}
+
 impl AppBuilder {
     /// Resolve config, load it, create vault, resolve secrets.
     ///
@@ -360,6 +375,27 @@ impl AppBuilder {
             memory.with_key_facts_dedup_threshold(self.config.memory.key_facts_dedup_threshold);
 
         Ok(memory)
+    }
+
+    /// Build a minimal ephemeral memory for bare mode.
+    ///
+    /// Uses an in-process `SQLite` `:memory:` database with no Qdrant, no graph store,
+    /// and no admission control. Avoids all file-system and network I/O at startup.
+    pub async fn build_bare_memory(
+        &self,
+        provider: &AnyProvider,
+    ) -> Result<SemanticMemory, BootstrapError> {
+        let embed_model = self.embedding_model();
+        SemanticMemory::with_sqlite_backend_and_pool_size(
+            ":memory:",
+            provider.clone(),
+            &embed_model,
+            self.config.memory.semantic.vector_weight,
+            self.config.memory.semantic.keyword_weight,
+            1,
+        )
+        .await
+        .map_err(|e| BootstrapError::Memory(e.to_string()))
     }
 
     fn build_memory_embed_provider(&self) -> Option<AnyProvider> {

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,18 +1,24 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::sync::Arc;
+
 use zeph_channels::AnyChannel;
 use zeph_channels::CliChannel;
+use zeph_channels::JsonCliChannel;
 #[cfg(feature = "discord")]
 use zeph_channels::discord::DiscordChannel;
 #[cfg(feature = "slack")]
 use zeph_channels::slack::SlackChannel;
 use zeph_channels::telegram::TelegramChannel;
+
+use crate::execution_mode::ExecutionMode;
 #[cfg(feature = "tui")]
 use zeph_core::channel::{
     Channel, ChannelError, ChannelMessage, StopHint, ToolOutputEvent, ToolStartEvent,
 };
 use zeph_core::config::Config;
+use zeph_core::json_event_sink::JsonEventSink;
 #[cfg(feature = "tui")]
 use zeph_tui::TuiChannel;
 
@@ -119,11 +125,19 @@ pub(crate) struct TuiHandle {
     pub(crate) command_rx: tokio::sync::mpsc::Receiver<zeph_tui::TuiCommand>,
 }
 
+/// Create a channel and, in JSON mode, return the shared sink so callers can
+/// also install a [`zeph_core::json_event_layer::JsonEventLayer`] on the agent.
 #[allow(clippy::unused_async)]
 pub(crate) async fn create_channel_inner(
     config: &Config,
     history: Option<CliHistory>,
-) -> anyhow::Result<AnyChannel> {
+    exec_mode: ExecutionMode,
+) -> anyhow::Result<(AnyChannel, Option<Arc<JsonEventSink>>)> {
+    if exec_mode.json {
+        let sink = Arc::new(JsonEventSink::new());
+        let channel = AnyChannel::JsonCli(JsonCliChannel::new(Arc::clone(&sink), exec_mode.auto));
+        return Ok((channel, Some(sink)));
+    }
     #[cfg(feature = "discord")]
     if let Some(dc) = &config.discord
         && let Some(token) = &dc.token
@@ -135,7 +149,7 @@ pub(crate) async fn create_channel_inner(
             dc.allowed_channel_ids.clone(),
         );
         tracing::info!("running in Discord mode");
-        return Ok(AnyChannel::Discord(channel));
+        return Ok((AnyChannel::Discord(channel), None));
     }
 
     #[cfg(feature = "slack")]
@@ -158,7 +172,7 @@ pub(crate) async fn create_channel_inner(
             sl.webhook_host,
             sl.port
         );
-        return Ok(AnyChannel::Slack(channel));
+        return Ok((AnyChannel::Slack(channel), None));
     }
 
     if let Some(token) = config.telegram.as_ref().and_then(|t| t.token.clone()) {
@@ -168,15 +182,15 @@ pub(crate) async fn create_channel_inner(
             .map_or_else(Vec::new, |t| t.allowed_users.clone());
         let tg = TelegramChannel::new(token, allowed).start()?;
         tracing::info!("running in Telegram mode");
-        return Ok(AnyChannel::Telegram(tg));
+        return Ok((AnyChannel::Telegram(tg), None));
     }
 
     if let Some((entries, persist_fn)) = history {
         let cli = CliChannel::with_history(entries, persist_fn);
-        return Ok(AnyChannel::Cli(cli));
+        return Ok((AnyChannel::Cli(cli), None));
     }
 
-    Ok(AnyChannel::Cli(CliChannel::new()))
+    Ok((AnyChannel::Cli(CliChannel::new()), None))
 }
 
 #[cfg(feature = "tui")]
@@ -184,7 +198,8 @@ pub(crate) async fn create_channel_with_tui(
     config: &Config,
     tui_active: bool,
     history: Option<CliHistory>,
-) -> anyhow::Result<(AppChannel, Option<TuiHandle>)> {
+    exec_mode: ExecutionMode,
+) -> anyhow::Result<(AppChannel, Option<TuiHandle>, Option<Arc<JsonEventSink>>)> {
     if tui_active {
         let (user_tx, user_rx) = tokio::sync::mpsc::channel(32);
         let (agent_tx, agent_rx) = tokio::sync::mpsc::channel(256);
@@ -199,15 +214,16 @@ pub(crate) async fn create_channel_with_tui(
             command_tx,
             command_rx,
         };
-        return Ok((AppChannel::Tui(channel), Some(handle)));
+        return Ok((AppChannel::Tui(channel), Some(handle), None));
     }
-    let channel = create_channel_inner(config, history).await?;
-    Ok((AppChannel::Standard(channel), None))
+    let (channel, sink) = create_channel_inner(config, history, exec_mode).await?;
+    Ok((AppChannel::Standard(channel), None, sink))
 }
 
 #[cfg(test)]
 pub(crate) async fn create_channel(config: &Config) -> anyhow::Result<AnyChannel> {
-    create_channel_inner(config, None).await
+    let (ch, _sink) = create_channel_inner(config, None, ExecutionMode::default()).await?;
+    Ok(ch)
 }
 
 #[cfg(all(test, feature = "tui"))]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -191,8 +191,33 @@ pub(crate) struct Cli {
     #[arg(long)]
     pub(crate) tafc: bool,
 
+    /// Bare mode: skip skill loading, memory init, MCP connections, scheduler
+    /// startup, and filesystem watchers. Useful for scripting and CI pipelines.
+    #[arg(long)]
+    pub(crate) bare: bool,
+
+    /// Emit structured JSON events to stdout (JSONL, one event per line).
+    /// Safe for piping into `jq`. Forces all log output to stderr.
+    /// Mutually exclusive with `--tui` and `--acp`.
+    #[arg(long)]
+    pub(crate) json: bool,
+
+    /// Auto-approve trust-gate prompts. Equivalent to
+    /// `[security] autonomy_level = "full"`. The adversarial policy gate (if
+    /// enabled) still runs. Destructive-command blocklist still applies.
+    #[arg(long = "auto", short = 'y')]
+    pub(crate) auto: bool,
+
     #[command(subcommand)]
     pub(crate) command: Option<Command>,
+}
+
+#[cfg(test)]
+impl Default for Cli {
+    fn default() -> Self {
+        use clap::Parser;
+        Cli::parse_from(["zeph"])
+    }
 }
 
 #[derive(Subcommand)]

--- a/src/execution_mode.rs
+++ b/src/execution_mode.rs
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Session-scoped operational flags derived from CLI args and `[cli]` config section.
+
+use zeph_core::config::Config;
+
+use crate::cli::Cli;
+
+/// Session-scoped mode flags resolved at startup from CLI args and `[cli]` config.
+///
+/// CLI flags take priority: a flag absent on the command line (defaults to `false`)
+/// falls back to the config value. A config value of `true` therefore activates
+/// the mode even when the flag is not passed — useful for scripting environments.
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct ExecutionMode {
+    pub(crate) bare: bool,
+    pub(crate) json: bool,
+    pub(crate) auto: bool,
+}
+
+impl ExecutionMode {
+    /// Merge CLI flags with config defaults. CLI flags take priority.
+    pub(crate) fn from_cli_and_config(cli: &Cli, cfg: &Config) -> Self {
+        Self {
+            bare: cli.bare || cfg.cli.bare,
+            json: cli.json || cfg.cli.json,
+            auto: cli.auto || cfg.cli.auto,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_cli() -> Cli {
+        Cli::default()
+    }
+
+    #[test]
+    fn all_false_by_default() {
+        let mode = ExecutionMode::default();
+        assert!(!mode.bare && !mode.json && !mode.auto);
+    }
+
+    #[test]
+    fn cli_bare_flag_activates_bare() {
+        let mut cli = default_cli();
+        cli.bare = true;
+        let mode = ExecutionMode::from_cli_and_config(&cli, &Config::default());
+        assert!(mode.bare);
+        assert!(!mode.json);
+        assert!(!mode.auto);
+    }
+
+    #[test]
+    fn cli_json_flag_activates_json() {
+        let mut cli = default_cli();
+        cli.json = true;
+        let mode = ExecutionMode::from_cli_and_config(&cli, &Config::default());
+        assert!(mode.json);
+        assert!(!mode.bare);
+    }
+
+    #[test]
+    fn cli_auto_flag_activates_auto() {
+        let mut cli = default_cli();
+        cli.auto = true;
+        let mode = ExecutionMode::from_cli_and_config(&cli, &Config::default());
+        assert!(mode.auto);
+    }
+
+    #[test]
+    fn config_bare_activates_bare_mode() {
+        let mut cfg = Config::default();
+        cfg.cli.bare = true;
+        let mode = ExecutionMode::from_cli_and_config(&default_cli(), &cfg);
+        assert!(mode.bare);
+        assert!(!mode.json);
+    }
+
+    #[test]
+    fn config_json_activates_json_mode() {
+        let mut cfg = Config::default();
+        cfg.cli.json = true;
+        let mode = ExecutionMode::from_cli_and_config(&default_cli(), &cfg);
+        assert!(mode.json);
+    }
+
+    #[test]
+    fn config_auto_activates_auto_mode() {
+        let mut cfg = Config::default();
+        cfg.cli.auto = true;
+        let mode = ExecutionMode::from_cli_and_config(&default_cli(), &cfg);
+        assert!(mode.auto);
+    }
+
+    #[test]
+    fn cli_overrides_config_when_both_false_still_false() {
+        let mode = ExecutionMode::from_cli_and_config(&default_cli(), &Config::default());
+        assert!(!mode.bare && !mode.json && !mode.auto);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,6 +107,7 @@ mod cli;
 mod commands;
 mod daemon;
 mod db_url;
+mod execution_mode;
 mod gateway_spawn;
 mod init;
 #[cfg(feature = "prometheus")]
@@ -119,6 +120,7 @@ mod runner;
 mod scheduler;
 #[cfg(feature = "scheduler")]
 mod scheduler_executor;
+mod startup_checks;
 mod tracing_init;
 mod tui_bridge;
 mod tui_remote;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -354,11 +354,17 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         (std::sync::Arc::new(collector), rx)
     };
 
+    // Resolve json_mode directly from CLI flags before AppBuilder (which loads full config).
+    // Passed to init_tracing so the stderr fmt layer is suppressed in --json mode,
+    // guaranteeing no human-readable text interleaves with the JSONL stdout stream.
+    let json_mode_early = cli.json || base_config.cli.json;
+
     let _tracing_guards = init_tracing(
         &logging_config,
         runtime_ctx,
         &telemetry_config,
         redact_secrets,
+        json_mode_early,
         #[cfg(feature = "profiling")]
         Some(std::sync::Arc::clone(&metrics_collector_arc)),
     );
@@ -519,6 +525,17 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     )
     .await?;
 
+    // Resolve ExecutionMode from CLI + config, then validate mutual exclusions.
+    let exec_mode = crate::execution_mode::ExecutionMode::from_cli_and_config(&cli, app.config());
+    crate::startup_checks::validate_mode_compatibility(&cli, app.config())?;
+
+    // Apply -y / --auto: set autonomy_level to Full so trust-gate prompts are
+    // auto-approved. Adversarial policy and shell blocklist remain enforced.
+    if exec_mode.auto {
+        use zeph_tools::AutonomyLevel;
+        app.config_mut().security.autonomy_level = AutonomyLevel::Full;
+    }
+
     check_legacy_artifact_paths(app.config());
 
     #[cfg(feature = "acp")]
@@ -662,8 +679,16 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     #[cfg(not(feature = "tui"))]
     let with_tool_events = false;
 
-    let registry = app.build_registry();
-    let watchers = app.build_watchers();
+    let registry = if exec_mode.bare {
+        zeph_skills::registry::SkillRegistry::empty()
+    } else {
+        app.build_registry()
+    };
+    let watchers = if exec_mode.bare {
+        crate::bootstrap::WatcherBundle::empty()
+    } else {
+        app.build_watchers()
+    };
     let summary_provider = app.build_summary_provider();
 
     let warmup_provider_clone = provider.clone();
@@ -690,8 +715,11 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     let early_tui_guard: EarlyTuiGuard;
 
     #[cfg(feature = "tui")]
+    let mut json_sink: Option<std::sync::Arc<zeph_core::json_event_sink::JsonEventSink>> = None;
+    #[cfg(feature = "tui")]
     if tui_active {
-        let (ch, mut th) = create_channel_with_tui(app.config(), true, None).await?;
+        let (ch, mut th, _sink) =
+            create_channel_with_tui(app.config(), true, None, exec_mode).await?;
         early_tui_guard = EarlyTuiGuard::new(th.as_mut().map(|h| start_tui_early(h, app.config())));
         channel_opt = Some(ch);
         tui_handle = th;
@@ -757,13 +785,19 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
 
     #[cfg(feature = "tui")]
     tui_status!("Loading memory...");
-    let memory = std::sync::Arc::new(app.build_memory(&provider).await?);
+    let memory = if exec_mode.bare {
+        // Bare mode: use an ephemeral in-process SQLite with no Qdrant, no graph store,
+        // and no embed backfill. Avoids all startup file and network I/O.
+        std::sync::Arc::new(app.build_bare_memory(&provider).await?)
+    } else {
+        std::sync::Arc::new(app.build_memory(&provider).await?)
+    };
     // backfill_rx: progress tracking for embed backfill.
     // None = idle/done, Some(progress) = in progress.
     #[cfg(feature = "tui")]
     let (backfill_tx, backfill_rx) =
         tokio::sync::watch::channel::<Option<zeph_memory::semantic::BackfillProgress>>(None);
-    {
+    if !exec_mode.bare {
         let memory_arc = std::sync::Arc::clone(&memory);
         #[cfg(feature = "tui")]
         let _backfill_handle =
@@ -938,14 +972,16 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     // where cli_history is available. The TUI path was already created before build_memory.
     #[cfg(feature = "tui")]
     if !tui_active {
-        let (ch, th) = create_channel_with_tui(app.config(), false, cli_history).await?;
+        let (ch, th, sink) =
+            create_channel_with_tui(app.config(), false, cli_history, exec_mode).await?;
         channel_opt = Some(ch);
         tui_handle = th;
+        json_sink = sink;
     }
     #[cfg(feature = "tui")]
     let channel = channel_opt.expect("channel always set before use");
     #[cfg(not(feature = "tui"))]
-    let channel = create_channel_inner(app.config(), cli_history).await?;
+    let (channel, json_sink) = create_channel_inner(app.config(), cli_history, exec_mode).await?;
 
     // Spawn deferred OAuth connections now that the UI channel is ready and can
     // display the authorization URL. Non-OAuth tools are already available from
@@ -961,7 +997,13 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     let is_cli = matches!(channel, AppChannel::Standard(AnyChannel::Cli(_)));
     #[cfg(not(feature = "tui"))]
     let is_cli = matches!(channel, AnyChannel::Cli(_));
-    if is_cli {
+    if let Some(ref sink) = json_sink {
+        sink.emit(&zeph_core::json_event_sink::JsonEvent::Boot {
+            version: env!("CARGO_PKG_VERSION"),
+            bare: exec_mode.bare,
+            auto: exec_mode.auto,
+        });
+    } else if is_cli {
         println!("zeph v{}", env!("CARGO_PKG_VERSION"));
     }
 
@@ -971,6 +1013,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         AppChannel::Tui(_) => "tui",
         AppChannel::Standard(c) => match c {
             AnyChannel::Cli(_) => "cli",
+            AnyChannel::JsonCli(_) => "cli-json",
             AnyChannel::Telegram(_) => "telegram",
             #[cfg(feature = "discord")]
             AnyChannel::Discord(_) => "discord",
@@ -982,6 +1025,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     #[cfg(not(feature = "tui"))]
     let active_channel_name: String = match &channel {
         AnyChannel::Cli(_) => "cli",
+        AnyChannel::JsonCli(_) => "cli-json",
         AnyChannel::Telegram(_) => "telegram",
         #[cfg(feature = "discord")]
         AnyChannel::Discord(_) => "discord",
@@ -1631,6 +1675,18 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     .with_embedding_provider(embedding_provider)
     .maybe_init_tool_schema_filter(&config.agent.tool_filter, &provider)
     .await;
+
+    // Wire JsonEventLayer when --json is active so tool_call / tool_result events
+    // are emitted. JsonCliChannel no-ops send_tool_start / send_tool_output to
+    // prevent double-emission; this layer is the canonical emitter.
+    let agent = if let Some(ref sink) = json_sink {
+        use zeph_core::json_event_layer::JsonEventLayer;
+        agent.with_runtime_layer(std::sync::Arc::new(JsonEventLayer::new(
+            std::sync::Arc::clone(sink),
+        )))
+    } else {
+        agent
+    };
 
     let agent = if let Some(logger) = tool_setup.audit_logger {
         agent.with_audit_logger(logger)

--- a/src/startup_checks.rs
+++ b/src/startup_checks.rs
@@ -116,7 +116,11 @@ mod tests {
         let mut cfg = Config::default();
         cfg.discord = Some(DiscordConfig {
             token: Some("discord-tok".into()),
-            ..Default::default()
+            application_id: None,
+            allowed_user_ids: vec![],
+            allowed_role_ids: vec![],
+            allowed_channel_ids: vec![],
+            skills: Default::default(),
         });
         assert!(validate_mode_compatibility(&cli, &cfg).is_err());
     }
@@ -129,7 +133,12 @@ mod tests {
         let mut cfg = Config::default();
         cfg.slack = Some(SlackConfig {
             bot_token: Some("xoxb-slack".into()),
-            ..Default::default()
+            signing_secret: None,
+            webhook_host: "0.0.0.0".into(),
+            port: 3000,
+            allowed_user_ids: vec![],
+            allowed_channel_ids: vec![],
+            skills: Default::default(),
         });
         assert!(validate_mode_compatibility(&cli, &cfg).is_err());
     }

--- a/src/startup_checks.rs
+++ b/src/startup_checks.rs
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Startup mutual-exclusion checks for CLI mode flags.
+
+use zeph_core::config::Config;
+
+use crate::cli::Cli;
+
+/// Validate that the selected mode flags are mutually compatible.
+///
+/// Called once at startup before any channel or subsystem is constructed.
+///
+/// # Errors
+///
+/// Returns an error string if two incompatible flags are active simultaneously.
+pub(crate) fn validate_mode_compatibility(cli: &Cli, config: &Config) -> anyhow::Result<()> {
+    #[cfg(feature = "tui")]
+    if cli.json && cli.tui {
+        anyhow::bail!("--json and --tui are mutually exclusive (both claim stdout)");
+    }
+
+    #[cfg(feature = "acp")]
+    if cli.json && cli.acp {
+        anyhow::bail!(
+            "--json and --acp are mutually exclusive (both claim stdout; ACP owns JSON-RPC framing)"
+        );
+    }
+
+    if cli.json
+        && config
+            .telegram
+            .as_ref()
+            .and_then(|t| t.token.as_ref())
+            .is_some()
+    {
+        anyhow::bail!(
+            "--json cannot be used while a Telegram token is configured; \
+             JSON events are stdout-only and Telegram is a separate transport"
+        );
+    }
+
+    #[cfg(feature = "discord")]
+    if cli.json
+        && config
+            .discord
+            .as_ref()
+            .and_then(|d| d.token.as_ref())
+            .is_some()
+    {
+        anyhow::bail!("--json cannot be used alongside a configured Discord channel");
+    }
+
+    #[cfg(feature = "slack")]
+    if cli.json
+        && config
+            .slack
+            .as_ref()
+            .and_then(|s| s.bot_token.as_ref())
+            .is_some()
+    {
+        anyhow::bail!("--json cannot be used alongside a configured Slack channel");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cli_json() -> Cli {
+        Cli {
+            json: true,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn json_with_telegram_token_is_rejected() {
+        use zeph_config::TelegramConfig;
+        let cli = cli_json();
+        let mut cfg = Config::default();
+        cfg.telegram = Some(TelegramConfig {
+            token: Some("tok".into()),
+            allowed_users: vec![],
+            skills: Default::default(),
+        });
+        assert!(validate_mode_compatibility(&cli, &cfg).is_err());
+    }
+
+    #[test]
+    fn json_without_conflicts_is_ok() {
+        let cli = cli_json();
+        let cfg = Config::default();
+        assert!(validate_mode_compatibility(&cli, &cfg).is_ok());
+    }
+
+    #[test]
+    #[cfg(feature = "tui")]
+    fn json_with_tui_is_rejected() {
+        let cli = Cli {
+            json: true,
+            tui: true,
+            ..Default::default()
+        };
+        let cfg = Config::default();
+        assert!(validate_mode_compatibility(&cli, &cfg).is_err());
+    }
+
+    #[test]
+    #[cfg(feature = "discord")]
+    fn json_with_discord_token_is_rejected() {
+        use zeph_config::DiscordConfig;
+        let cli = cli_json();
+        let mut cfg = Config::default();
+        cfg.discord = Some(DiscordConfig {
+            token: Some("discord-tok".into()),
+            ..Default::default()
+        });
+        assert!(validate_mode_compatibility(&cli, &cfg).is_err());
+    }
+
+    #[test]
+    #[cfg(feature = "slack")]
+    fn json_with_slack_token_is_rejected() {
+        use zeph_config::SlackConfig;
+        let cli = cli_json();
+        let mut cfg = Config::default();
+        cfg.slack = Some(SlackConfig {
+            bot_token: Some("xoxb-slack".into()),
+            ..Default::default()
+        });
+        assert!(validate_mode_compatibility(&cli, &cfg).is_err());
+    }
+}

--- a/src/tracing_init.rs
+++ b/src/tracing_init.rs
@@ -98,6 +98,9 @@ pub(crate) fn init_tracing(
     runtime_ctx: zeph_core::RuntimeContext,
     telemetry: &TelemetryConfig,
     redact_secrets: bool,
+    // When true (`--json` mode), the stderr fmt layer is suppressed so no human-readable
+    // text can interleave with the machine-readable JSONL stream on stdout.
+    json_mode: bool,
     #[cfg(feature = "profiling")] metrics_collector: Option<
         std::sync::Arc<zeph_core::metrics::MetricsCollector>,
     >,
@@ -118,8 +121,9 @@ pub(crate) fn init_tracing(
     #[cfg(not(feature = "otel"))]
     let otlp_active = false;
 
-    // Stderr layer — omitted in TUI mode to avoid corrupting raw-mode rendering.
-    if !runtime_ctx.tui_mode {
+    // Stderr layer — omitted in TUI mode (corrupts raw-mode rendering) and in JSON mode
+    // (keeps stderr clean so `--json | jq` works without non-JSON lines).
+    if !runtime_ctx.tui_mode && !json_mode {
         let stderr_filter = tracing_subscriber::EnvFilter::try_from_default_env()
             .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
         layers.push(Box::new(


### PR DESCRIPTION
## Summary

- **`--bare`** — strips agent to essentials for scripted/CI usage: skips memory init, scheduler, skill loading, watchers. Closes #2790.
- **`--json`** — JSONL event stream to stdout (boot, chunk, response_end, tool_call, tool_result, cost, error) with secret redaction and tracing redirected to stderr. Mutually exclusive with `--tui`, `--acp`, and messaging channels.
- **`-y`/`--auto`** — bypasses tool confirmation prompts; shell blocklist and adversarial policy remain enforced.
- **`/loop`** — in-session repeating prompt execution (`/loop <prompt> every <N> <unit>`, `/loop stop`, `/loop status`). Min 5 s interval. Closes #3083.
- **`[cli]` TOML section** — `bare`, `json`, `auto`, `[cli.loop].min_interval_secs`, `[cli.loop].max_iterations`.

## Design notes

`TaskInjection` enum separates scheduler-injected tasks (prefix prepended) from user loop prompts (no prefix). `JsonEventSink` uses `Arc<Mutex<Stdout>>` for synchronous single-writer output. `interval_at(now + period, period)` avoids immediate first tick. Prompt is cloned atomically after tick to prevent TOCTOU race with `/loop stop`.

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` — 8366 tests pass
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `zeph --bare --json -p "hello"` produces well-formed JSONL on stdout, tracing on stderr
- [ ] `zeph --json --tui` rejected at startup with clear error
- [ ] `/loop echo test every 5s` fires after 5 s (not immediately), prints each iteration
- [ ] `/loop stop` cancels active loop
- [ ] `/loop /clear every 5s` rejected (slash prompt guard)

## Deferred (filed as follow-up)

- MCP connection skip in `--bare` mode (TODO comments in runner.rs reference this issue)
- Cost events via `after_chat` (requires `ChatResponse` usage field)
- TUI spinner for `/loop` status bar
- `--init` wizard step for `[cli]` section
- `--migrate-config` for `[runtime]` → `[cli]` rename