### PR TITLE
feat(mcp,ux): MCP server-driven elicitation and /recap slash command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **feat(mcp): server-driven elicitation support** (#3141) — MCP servers speaking protocol version
+  2025-06-18 can now pause a tool call and request structured user input (credentials, file paths,
+  confirmations). Elicitation requests are routed to the active channel: CLI prompts interactively,
+  TUI shows a modal-style status prompt, Telegram sends a message and waits for a reply (with
+  configurable timeout). Sensitive fields (password/token/key) trigger a warning before display.
+  URL-type fields are declined in phase 1. Elicitation is disabled for `Sandboxed` trust level and
+  can be toggled globally via `[mcp] elicitation_enabled`. Field names and descriptions are
+  sanitized at display time to prevent ANSI/Markdown injection from malicious servers.
+
+- **feat(ux): `/recap` slash command** (#3140) — on-demand session summary. Invoked as `/recap`,
+  it summarises messages exchanged, tools invoked (with outcomes), and projects the next logical
+  step using a configurable fast LLM provider (`[session.recap] provider`). A dedup gate
+  suppresses redundant calls. Session recap can be automatically shown on session resume via
+  `[session.recap] on_resume = true` (default). Operates on in-session state — distinct from the
+  persistent semantic memory recall shown at startup.
+
 - **feat(cli): `--bare` mode for scripted/CI usage** (#2790) — new flag strips the agent to
   essentials: skips memory init, scheduler startup, skill loading, and watcher registration.
   Suitable for piping and automation where full subsystem overhead is unnecessary.

--- a/config/default.toml
+++ b/config/default.toml
@@ -400,6 +400,16 @@ repo_map_ttl_secs = 300
 allowed_commands = ["npx", "uvx", "node", "python", "python3"]
 # Maximum number of dynamically added MCP servers
 max_dynamic_servers = 10
+# Enable MCP elicitation (servers can request user input mid-task).
+# Default: false — all elicitation requests are auto-declined.
+# Opt-in because it interrupts agent flow and could be abused by malicious servers.
+# elicitation_enabled = false
+# Timeout in seconds for the user to respond to an elicitation request. Default: 120.
+# elicitation_timeout = 120
+# Bounded channel capacity for elicitation events. Requests beyond this are auto-declined.
+# elicitation_queue_capacity = 16
+# When true, warn the user before prompting for sensitive-looking fields (password, token, etc.).
+# elicitation_warn_sensitive_fields = true
 
 [mcp.pruning]
 # Enable dynamic MCP tool pruning (LLM-based relevance filter before main inference)

--- a/crates/zeph-channels/src/json_cli.rs
+++ b/crates/zeph-channels/src/json_cli.rs
@@ -159,10 +159,8 @@ impl Channel for JsonCliChannel {
         &mut self,
         _request: ElicitationRequest,
     ) -> Result<ElicitationResponse, ChannelError> {
-        // v1: elicitation over JSON is not supported.
-        Err(ChannelError::Other(
-            "elicitation not supported in --json mode".into(),
-        ))
+        // Elicitation is not supported in JSON mode; decline quietly to avoid log spam.
+        Ok(ElicitationResponse::Declined)
     }
 
     async fn send_status(&mut self, text: &str) -> Result<(), ChannelError> {

--- a/crates/zeph-channels/src/telegram.rs
+++ b/crates/zeph-channels/src/telegram.rs
@@ -784,7 +784,10 @@ impl Channel for TelegramChannel {
 
             let Some(value) = coerce_telegram_field(&text, &field.field_type) else {
                 let _ = self
-                    .send(&format!("Invalid value for '{}'. Declining.", field.name))
+                    .send(&format!(
+                        "Invalid value for '{}'. Declining.",
+                        sanitize_markdown(&field.name)
+                    ))
                     .await;
                 return Ok(ElicitationResponse::Declined);
             };
@@ -813,6 +816,12 @@ fn sanitize_markdown(s: &str) -> String {
 /// Keeps only alphanumeric characters and underscores to prevent injection via
 /// malicious MCP server field names (e.g. keys with special chars that could
 /// confuse downstream consumers).
+///
+/// Note: this can produce collisions when two field names differ only in stripped
+/// characters (e.g. `"pass word"` and `"pass_word"` both map to `"password"`).
+/// In that case the second field silently overwrites the first in the response map.
+/// This is acceptable because Telegram's callback-data limit (64 bytes) means we
+/// cannot use raw field names; a well-formed MCP server must not send colliding keys.
 fn sanitize_field_key(s: &str) -> String {
     s.chars()
         .filter(|c| c.is_alphanumeric() || *c == '_')
@@ -829,9 +838,10 @@ fn sanitize_field_key(s: &str) -> String {
 /// * `String` — asks for free-form text.
 fn build_telegram_field_prompt(field: &ElicitationField) -> String {
     let req = if field.required { " (required)" } else { "" };
+    let name = sanitize_markdown(&field.name);
     match &field.field_type {
         ElicitationFieldType::Boolean => {
-            format!("*{}*{}: Reply *yes* or *no*", field.name, req)
+            format!("*{name}*{req}: Reply *yes* or *no*")
         }
         ElicitationFieldType::Enum(opts) => {
             // Use short numeric indexes to avoid Telegram 64-byte callback_data limit
@@ -841,16 +851,16 @@ fn build_telegram_field_prompt(field: &ElicitationField) -> String {
                 .map(|(i, o)| format!("{}: {}", i + 1, sanitize_markdown(o)))
                 .collect::<Vec<_>>()
                 .join("\n");
-            format!("*{}*{}: Reply with the number:\n{}", field.name, req, list)
+            format!("*{name}*{req}: Reply with the number:\n{list}")
         }
         ElicitationFieldType::Integer => {
-            format!("*{}*{}: Reply with an integer", field.name, req)
+            format!("*{name}*{req}: Reply with an integer")
         }
         ElicitationFieldType::Number => {
-            format!("*{}*{}: Reply with a number", field.name, req)
+            format!("*{name}*{req}: Reply with a number")
         }
         ElicitationFieldType::String => {
-            format!("*{}*{}: Reply with text", field.name, req)
+            format!("*{name}*{req}: Reply with text")
         }
     }
 }

--- a/crates/zeph-config/src/migrate.rs
+++ b/crates/zeph-config/src/migrate.rs
@@ -2104,6 +2104,88 @@ pub fn migrate_orchestration_persistence(toml_src: &str) -> Result<MigrationResu
     })
 }
 
+/// Add commented-out `[session.recap]` block if absent (#3064).
+///
+/// All recap fields have `#[serde(default)]` so existing configs parse without changes.
+///
+/// # Errors
+///
+/// Returns `MigrateError::Parse` if the TOML cannot be parsed.
+pub fn migrate_session_recap_config(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    // Idempotency: check both active and commented forms.
+    if toml_src.contains("[session.recap]") || toml_src.contains("# [session.recap]") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            added_count: 0,
+            sections_added: Vec::new(),
+        });
+    }
+
+    let comment = "\n# [session.recap] — show a recap when resuming a conversation (#3064).\n\
+         # [session.recap]\n\
+         # on_resume = true\n\
+         # max_tokens = 200\n\
+         # provider = \"\"\n\
+         # max_input_messages = 20\n";
+    let raw = toml_src.parse::<toml_edit::DocumentMut>()?.to_string();
+    let output = format!("{raw}{comment}");
+
+    Ok(MigrationResult {
+        output,
+        added_count: 1,
+        sections_added: vec!["session.recap".to_owned()],
+    })
+}
+
+/// Add commented-out MCP elicitation keys to `[mcp]` section if absent (#3141).
+///
+/// All elicitation fields have `#[serde(default)]` so existing configs parse without changes.
+///
+/// # Errors
+///
+/// Returns `MigrateError::Parse` if the TOML cannot be parsed.
+pub fn migrate_mcp_elicitation_config(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    // Idempotency: check for any elicitation key presence.
+    if toml_src.contains("elicitation_enabled") || toml_src.contains("# elicitation_enabled") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            added_count: 0,
+            sections_added: Vec::new(),
+        });
+    }
+
+    // Only inject under an existing [mcp] section.
+    if !toml_src.contains("[mcp]") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            added_count: 0,
+            sections_added: Vec::new(),
+        });
+    }
+
+    // Guard against configs that have `[mcp]` but with Windows line endings or at EOF.
+    if !toml_src.contains("[mcp]\n") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            added_count: 0,
+            sections_added: Vec::new(),
+        });
+    }
+
+    let comment = "# elicitation_enabled = false          \
+        # opt-in: servers may request user input mid-task (#3141)\n\
+        # elicitation_timeout = 120            # seconds to wait for user response\n\
+        # elicitation_queue_capacity = 16      # beyond this limit requests are auto-declined\n\
+        # elicitation_warn_sensitive_fields = true  # warn before prompting for password/token/etc.\n";
+    let output = toml_src.replacen("[mcp]\n", &format!("[mcp]\n{comment}"), 1);
+
+    Ok(MigrationResult {
+        output,
+        added_count: 1,
+        sections_added: vec!["mcp.elicitation".to_owned()],
+    })
+}
+
 // Helper to create a formatted value (used in tests).
 #[cfg(test)]
 fn make_formatted_str(s: &str) -> Value {
@@ -3290,5 +3372,74 @@ prompt_cache_ttl = "1h"
             first.output, second.output,
             "migration must be idempotent when prompt_cache_ttl = \"1h\" already present"
         );
+    }
+
+    // ── migrate_session_recap_config ──────────────────────────────────────────
+
+    #[test]
+    fn migrate_session_recap_adds_block_when_absent() {
+        let src = "[agent]\nname = \"Zeph\"\n";
+        let result = migrate_session_recap_config(src).expect("migrate");
+        assert_eq!(result.added_count, 1);
+        assert!(result.sections_added.contains(&"session.recap".to_owned()));
+        assert!(result.output.contains("# [session.recap]"));
+        assert!(result.output.contains("on_resume = true"));
+    }
+
+    #[test]
+    fn migrate_session_recap_idempotent_on_commented_block() {
+        let src = "[agent]\nname = \"Zeph\"\n# [session.recap]\n# on_resume = true\n";
+        let result = migrate_session_recap_config(src).expect("migrate");
+        assert_eq!(result.added_count, 0);
+        assert_eq!(result.output, src);
+    }
+
+    #[test]
+    fn migrate_session_recap_idempotent_on_active_section() {
+        let src = "[agent]\nname = \"Zeph\"\n[session.recap]\non_resume = false\n";
+        let result = migrate_session_recap_config(src).expect("migrate");
+        assert_eq!(result.added_count, 0);
+        assert_eq!(result.output, src);
+    }
+
+    // ── migrate_mcp_elicitation_config ────────────────────────────────────────
+
+    #[test]
+    fn migrate_mcp_elicitation_adds_keys_when_absent() {
+        let src = "[mcp]\nallowed_commands = []\n";
+        let result = migrate_mcp_elicitation_config(src).expect("migrate");
+        assert_eq!(result.added_count, 1);
+        assert!(
+            result
+                .sections_added
+                .contains(&"mcp.elicitation".to_owned())
+        );
+        assert!(result.output.contains("# elicitation_enabled = false"));
+        assert!(result.output.contains("# elicitation_timeout = 120"));
+    }
+
+    #[test]
+    fn migrate_mcp_elicitation_idempotent_when_key_present() {
+        let src = "[mcp]\nelicitation_enabled = true\n";
+        let result = migrate_mcp_elicitation_config(src).expect("migrate");
+        assert_eq!(result.added_count, 0);
+        assert_eq!(result.output, src);
+    }
+
+    #[test]
+    fn migrate_mcp_elicitation_skips_when_no_mcp_section() {
+        let src = "[agent]\nname = \"Zeph\"\n";
+        let result = migrate_mcp_elicitation_config(src).expect("migrate");
+        assert_eq!(result.added_count, 0);
+        assert_eq!(result.output, src);
+    }
+
+    #[test]
+    fn migrate_mcp_elicitation_skips_without_trailing_newline() {
+        // Edge case: `[mcp]` at EOF with no `\n` — replacen would be a no-op.
+        let src = "[mcp]";
+        let result = migrate_mcp_elicitation_config(src).expect("migrate");
+        assert_eq!(result.added_count, 0);
+        assert_eq!(result.output, src);
     }
 }

--- a/crates/zeph-core/src/agent/mcp.rs
+++ b/crates/zeph-core/src/agent/mcp.rs
@@ -649,7 +649,7 @@ fn build_elicitation_fields(
             let description = json
                 .get("description")
                 .and_then(|v| v.as_str())
-                .map(String::from);
+                .map(sanitize_elicitation_message);
 
             let field_type = match prop {
                 PrimitiveSchema::Boolean(_) => ElicitationFieldType::Boolean,
@@ -665,7 +665,7 @@ fn build_elicitation_fields(
                         .map(|arr| {
                             arr.iter()
                                 .filter_map(|v| v.as_str())
-                                .map(String::from)
+                                .map(sanitize_elicitation_message)
                                 .collect::<Vec<_>>()
                         })
                         .unwrap_or_default();
@@ -674,6 +674,8 @@ fn build_elicitation_fields(
             };
             let required = schema.required.as_deref().is_some_and(|r| r.contains(name));
             ElicitationField {
+                // Keep the raw schema key intact — it is used verbatim as the response map key.
+                // Channels sanitize it at display time only (see build_field_prompt / build_telegram_field_prompt).
                 name: name.clone(),
                 description,
                 field_type,

--- a/crates/zeph-core/src/agent/persistence.rs
+++ b/crates/zeph-core/src/agent/persistence.rs
@@ -3772,8 +3772,8 @@ mod tests {
 
     // --- #3168 regression tests ---
 
-    /// Round-trip: persist Assistant[tool_use] + User[tool_result], then load_history.
-    /// After sanitize_tool_pairs the pair must be intact — no WARN, both messages present
+    /// Round-trip: persist `Assistant[tool_use]` + `User[tool_result]`, then `load_history`.
+    /// After `sanitize_tool_pairs` the pair must be intact — no WARN, both messages present
     /// with non-empty parts.
     #[tokio::test]
     async fn regression_3168_complete_tool_pair_survives_round_trip() {
@@ -3859,8 +3859,8 @@ mod tests {
         );
     }
 
-    /// A System message between an Assistant[tool_use] and the matching User[tool_result]
-    /// must not cause the tool_use to be treated as an orphan.
+    /// A System message between an `Assistant[tool_use]` and the matching `User[tool_result]`
+    /// must not cause the `tool_use` to be treated as an orphan.
     #[test]
     fn regression_3168_system_between_tool_pair_not_stripped() {
         use zeph_llm::provider::{MessageMetadata, MessagePart};
@@ -3912,10 +3912,10 @@ mod tests {
         );
     }
 
-    /// If parts serialization fails, persist_message must return early and not store
-    /// a row with empty parts that would create an orphaned tool_use on next session load.
-    /// We verify this by writing a row with invalid parts_json directly and confirming
-    /// load_history skips it (empty parts row is not injected into the agent).
+    /// If parts serialization fails, `persist_message` must return early and not store
+    /// a row with empty parts that would create an orphaned `tool_use` on next session load.
+    /// We verify this by writing a row with invalid `parts_json` directly and confirming
+    /// `load_history` skips it (empty parts row is not injected into the agent).
     #[tokio::test]
     async fn regression_3168_corrupt_parts_row_skipped_on_load() {
         use zeph_llm::provider::MessagePart;

--- a/crates/zeph-core/src/channel.rs
+++ b/crates/zeph-core/src/channel.rs
@@ -2,26 +2,81 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 /// A single field in an elicitation form request.
+///
+/// Created by the MCP layer when a server sends an elicitation request; passed to
+/// channels so they can render the field in a channel-appropriate way (CLI prompt,
+/// Telegram inline keyboard, TUI form, etc.).
+///
+/// # Examples
+///
+/// ```
+/// use zeph_core::channel::{ElicitationField, ElicitationFieldType};
+///
+/// let field = ElicitationField {
+///     name: "username".to_owned(),
+///     description: Some("Your login name".to_owned()),
+///     field_type: ElicitationFieldType::String,
+///     required: true,
+/// };
+/// assert_eq!(field.name, "username");
+/// assert!(field.required);
+/// ```
 #[derive(Debug, Clone)]
 pub struct ElicitationField {
+    /// Field key as declared in the server's JSON Schema (sanitized before display).
     pub name: String,
+    /// Optional human-readable description from the server (sanitized before display).
     pub description: Option<String>,
+    /// Value type expected for this field.
     pub field_type: ElicitationFieldType,
+    /// Whether the field must be filled before the form can be submitted.
     pub required: bool,
 }
 
 /// Type of an elicitation form field.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_core::channel::ElicitationFieldType;
+///
+/// let enum_field = ElicitationFieldType::Enum(vec!["low".into(), "medium".into(), "high".into()]);
+/// assert!(matches!(enum_field, ElicitationFieldType::Enum(_)));
+/// ```
 #[derive(Debug, Clone)]
 pub enum ElicitationFieldType {
     String,
     Integer,
     Number,
     Boolean,
-    /// Enum with allowed values.
+    /// Enum with allowed values (sanitized before display).
     Enum(Vec<String>),
 }
 
 /// An elicitation request from an MCP server.
+///
+/// Channels receive this struct and are responsible for rendering the form and
+/// collecting user input. The `server_name` must be shown to help users identify
+/// which server is requesting information (phishing prevention).
+///
+/// # Examples
+///
+/// ```
+/// use zeph_core::channel::{ElicitationField, ElicitationFieldType, ElicitationRequest};
+///
+/// let req = ElicitationRequest {
+///     server_name: "my-server".to_owned(),
+///     message: "Please provide your credentials".to_owned(),
+///     fields: vec![ElicitationField {
+///         name: "api_key".to_owned(),
+///         description: None,
+///         field_type: ElicitationFieldType::String,
+///         required: true,
+///     }],
+/// };
+/// assert_eq!(req.server_name, "my-server");
+/// assert_eq!(req.fields.len(), 1);
+/// ```
 #[derive(Debug, Clone)]
 pub struct ElicitationRequest {
     /// Name of the MCP server making the request (shown for phishing prevention).
@@ -33,6 +88,22 @@ pub struct ElicitationRequest {
 }
 
 /// User's response to an elicitation request.
+///
+/// Channels return this after the user interacts with the form. The MCP layer
+/// maps `Declined` and `Cancelled` to the appropriate protocol responses.
+///
+/// # Examples
+///
+/// ```
+/// use serde_json::json;
+/// use zeph_core::channel::ElicitationResponse;
+///
+/// let accepted = ElicitationResponse::Accepted(json!({"username": "alice"}));
+/// assert!(matches!(accepted, ElicitationResponse::Accepted(_)));
+///
+/// let declined = ElicitationResponse::Declined;
+/// assert!(matches!(declined, ElicitationResponse::Declined));
+/// ```
 #[derive(Debug, Clone)]
 pub enum ElicitationResponse {
     /// User filled in the form and submitted.

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -8,10 +8,11 @@ use zeph_core::config::migrate::{
     ConfigMigrator, migrate_agent_budget_hint, migrate_agent_retry_to_tools_retry,
     migrate_autodream_config, migrate_compression_predictor_config, migrate_database_url,
     migrate_egress_config, migrate_forgetting_config, migrate_magic_docs_config,
-    migrate_mcp_trust_levels, migrate_microcompact_config, migrate_orchestration_persistence,
-    migrate_otel_filter, migrate_planner_model_to_provider, migrate_sandbox_config,
-    migrate_shell_transactional, migrate_stt_to_provider, migrate_supervisor_config,
-    migrate_telemetry_config, migrate_vigil_config,
+    migrate_mcp_elicitation_config, migrate_mcp_trust_levels, migrate_microcompact_config,
+    migrate_orchestration_persistence, migrate_otel_filter, migrate_planner_model_to_provider,
+    migrate_sandbox_config, migrate_session_recap_config, migrate_shell_transactional,
+    migrate_stt_to_provider, migrate_supervisor_config, migrate_telemetry_config,
+    migrate_vigil_config,
 };
 
 /// Handle the `zeph migrate-config` command.
@@ -109,9 +110,17 @@ pub(crate) fn handle_migrate_config(
     let orch_persistence_result = migrate_orchestration_persistence(&after_sandbox)?;
     let after_orch_persistence = orch_persistence_result.output;
 
-    // Step 20: add missing default keys as commented-out entries.
+    // Step 20: add commented-out [session.recap] block if absent (#3064).
+    let session_recap_result = migrate_session_recap_config(&after_orch_persistence)?;
+    let after_session_recap = session_recap_result.output;
+
+    // Step 21: add commented-out MCP elicitation keys under [mcp] if absent (#3141).
+    let mcp_elicitation_result = migrate_mcp_elicitation_config(&after_session_recap)?;
+    let after_mcp_elicitation = mcp_elicitation_result.output;
+
+    // Step 22: add missing default keys as commented-out entries.
     let migrator = ConfigMigrator::new();
-    let result = migrator.migrate(&after_orch_persistence)?;
+    let result = migrator.migrate(&after_mcp_elicitation)?;
 
     if diff {
         print_diff(&input, &result.output);
@@ -184,6 +193,14 @@ pub(crate) fn handle_migrate_config(
             eprintln!(
                 "Orchestration persistence migration: \
                  added commented-out persistence_enabled under [orchestration]."
+            );
+        }
+        if session_recap_result.added_count > 0 {
+            eprintln!("Session recap migration: added commented-out [session.recap] block.");
+        }
+        if mcp_elicitation_result.added_count > 0 {
+            eprintln!(
+                "MCP elicitation migration: added commented-out elicitation keys under [mcp]."
             );
         }
         eprintln!(

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -177,6 +177,9 @@ pub(crate) struct WizardState {
     pub(crate) digest_enabled: bool,
     // Session recap on resume (#3064)
     pub(crate) recap_on_resume: bool,
+    // MCP elicitation (#3141)
+    pub(crate) mcp_elicitation_enabled: bool,
+    pub(crate) mcp_elicitation_warn_sensitive: bool,
     // Context strategy (#2288)
     pub(crate) context_strategy: String,
     // MCP tool discovery (#2321)
@@ -346,6 +349,8 @@ impl Default for WizardState {
             retry_parameter_reformat_provider: String::new(),
             digest_enabled: false,
             recap_on_resume: true,
+            mcp_elicitation_enabled: false,
+            mcp_elicitation_warn_sensitive: true,
             context_strategy: "full_history".to_owned(),
             mcp_discovery_strategy: "none".to_owned(),
             mcp_discovery_top_k: 10,
@@ -697,6 +702,8 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
     config.memory.shutdown_summary = state.shutdown_summary;
     config.memory.digest.enabled = state.digest_enabled;
     config.session.recap.on_resume = state.recap_on_resume;
+    config.mcp.elicitation_enabled = state.mcp_elicitation_enabled;
+    config.mcp.elicitation_warn_sensitive_fields = state.mcp_elicitation_warn_sensitive;
     config.memory.context_strategy = match state.context_strategy.as_str() {
         "memory_first" => zeph_core::config::ContextStrategy::MemoryFirst,
         "adaptive" => zeph_core::config::ContextStrategy::Adaptive,
@@ -1328,11 +1335,29 @@ fn step_prometheus(state: &mut WizardState) -> anyhow::Result<()> {
 }
 
 fn step_session_recap(state: &mut WizardState) -> anyhow::Result<()> {
-    println!("== Session Recap ==\n");
+    println!("== Session Recap & MCP Elicitation ==\n");
     state.recap_on_resume = Confirm::new()
         .with_prompt("Show a recap when resuming a conversation? [Y/n]")
         .default(true)
         .interact()?;
+
+    state.mcp_elicitation_enabled = Confirm::new()
+        .with_prompt(
+            "Allow MCP servers to request user input mid-task (elicitation)? [y/N]\n  \
+             (opt-in; servers with elicitation can interrupt agent flow)",
+        )
+        .default(false)
+        .interact()?;
+
+    if state.mcp_elicitation_enabled {
+        state.mcp_elicitation_warn_sensitive = Confirm::new()
+            .with_prompt(
+                "Warn before prompting for sensitive fields (password, token, etc.)? [Y/n]",
+            )
+            .default(true)
+            .interact()?;
+    }
+
     println!();
     Ok(())
 }


### PR DESCRIPTION
## Summary

- **feat(mcp)**: MCP servers speaking protocol 2025-06-18 can pause a tool call and request structured user input (credentials, file paths, confirmations). Requests are routed to the active channel — CLI prompts interactively, TUI shows a status modal, Telegram sends a message and awaits reply with timeout. Sensitive fields trigger user warning. URL-type fields declined in phase 1. Hard-disabled for `Sandboxed` trust level. Field names sanitized at display time only (raw preserved for response round-trip). Closes #3141.
- **feat(ux)**: `/recap` slash command for on-demand session summary — messages, tools, next step projection. Uses configurable fast LLM provider. Dedup gate prevents redundant calls. Auto-shown on resume via `[session.recap] on_resume`. Closes #3140.

## Changes

| File | Change |
|------|--------|
| `crates/zeph-core/src/channel.rs` | `Channel::elicit` trait method + doc-tests for all 4 channel impls |
| `crates/zeph-core/src/agent/mcp.rs` | Elicitation handler, field sanitization (display only), sandboxed gate |
| `crates/zeph-channels/src/telegram.rs` | Telegram elicitation routing with `sanitize_markdown` on field names |
| `crates/zeph-channels/src/json_cli.rs` | `elicit` returns `Ok(Declined)` instead of `Err` |
| `crates/zeph-config/src/migrate.rs` | Migration steps 20/21 for `[session.recap]` and `[mcp]` elicitation keys (7 new tests) |
| `config/default.toml` | Commented `[mcp]` elicitation keys for discoverability |
| `src/commands/migrate.rs` | Wire steps 20/21 |
| `src/init/mod.rs` | `--init` wizard: elicitation enable/disable prompts |
| `src/startup_checks.rs` | Fix pre-existing clippy violations |
| `CHANGELOG.md` | `[Unreleased]` entries for #3140 and #3141 |

## Test plan

- [ ] 8401 unit tests pass (`cargo nextest run --workspace --lib --bins`)
- [ ] `cargo +nightly fmt --check` clean
- [ ] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [ ] Deadlock regression test #2542 present in `channel.rs`
- [ ] Dedup gate test #3144 present for `/recap`
- [ ] 7 migration unit tests (add/idempotent/no-section/no-trailing-newline)
- [ ] ANSI sanitization unit tests for elicitation field names
- [ ] Live session: invoke `/recap` after multi-turn tool-heavy session
- [ ] Live session: connect elicitation-capable MCP server, verify CLI prompt
- [ ] Live session: Telegram elicitation flow with timeout

## Related

- Tracks #3217 (Telegram `sanitize_field_key` parity gap, P2, filed separately)
- References CI-562 parity scan