### PR TITLE
fix(channels): suppress spurious JSON events and surface /loop errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **fix(json-cli): spurious `response_end` events in `--json` mode** (#3212) — `JsonCliChannel`
+  now tracks whether any `ResponseChunk` has been emitted since the last `ResponseEnd` and only
+  emits `ResponseEnd` when there is at least one preceding chunk. Lifecycle strings (e.g.
+  `"Shutting down..."`) are now routed through `send_status` (emitting `{"event":"status",...}`)
+  instead of `send`, eliminating a spurious `response_chunk`/`response_end` pair at shutdown.
+  `JsonEventSink` gained a `with_writer` constructor for testability; behavioural unit tests added
+  for all emission sequences.
+
+- **fix(agent): slash command errors no longer terminate the agent loop** (#3211) — `CommandError`
+  returned by registry-handled slash commands (e.g. `/loop` with an invalid interval) is now
+  surfaced to the user channel and logged at WARN level, then the loop continues. Previously the
+  agent exited with `AgentError::Other`, producing no visible output on stdout.
+
 ### Added
 
 - **feat(mcp): server-driven elicitation support** (#3141) — MCP servers speaking protocol version

--- a/crates/zeph-channels/src/json_cli.rs
+++ b/crates/zeph-channels/src/json_cli.rs
@@ -34,6 +34,10 @@ pub struct JsonCliChannel {
     rx: tokio::sync::mpsc::Receiver<Option<String>>,
     /// Whether the caller should auto-approve confirmation prompts.
     auto: bool,
+    /// True iff at least one `ResponseChunk` has been emitted since the last
+    /// `ResponseEnd`. `ResponseEnd` must never be emitted when this is `false`.
+    /// Both `send()` and `flush_chunks()` always reset this flag to `false`.
+    pending_chunks: bool,
 }
 
 impl JsonCliChannel {
@@ -66,7 +70,12 @@ impl JsonCliChannel {
             let _ = tx.blocking_send(None);
         });
 
-        Self { sink, rx, auto }
+        Self {
+            sink,
+            rx,
+            auto,
+            pending_chunks: false,
+        }
     }
 }
 
@@ -123,16 +132,21 @@ impl Channel for JsonCliChannel {
     async fn send(&mut self, text: &str) -> Result<(), ChannelError> {
         self.sink.emit(&JsonEvent::ResponseChunk { text });
         self.sink.emit(&JsonEvent::ResponseEnd);
+        self.pending_chunks = false;
         Ok(())
     }
 
     async fn send_chunk(&mut self, chunk: &str) -> Result<(), ChannelError> {
         self.sink.emit(&JsonEvent::ResponseChunk { text: chunk });
+        self.pending_chunks = true;
         Ok(())
     }
 
     async fn flush_chunks(&mut self) -> Result<(), ChannelError> {
-        self.sink.emit(&JsonEvent::ResponseEnd);
+        if self.pending_chunks {
+            self.sink.emit(&JsonEvent::ResponseEnd);
+            self.pending_chunks = false;
+        }
         Ok(())
     }
 
@@ -216,30 +230,125 @@ impl Channel for JsonCliChannel {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use zeph_core::json_event_sink::JsonEventSink;
+
     use super::*;
 
-    fn make_sink() -> Arc<JsonEventSink> {
-        Arc::new(JsonEventSink::new())
+    /// Returns a `(sink, read_output)` pair. `read_output()` returns captured JSONL lines.
+    fn make_test_sink() -> (Arc<JsonEventSink>, impl Fn() -> Vec<String>) {
+        let buf: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let buf_read = Arc::clone(&buf);
+
+        struct BufWriter(Arc<Mutex<Vec<u8>>>);
+        impl std::io::Write for BufWriter {
+            fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(b);
+                Ok(b.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let sink = Arc::new(JsonEventSink::with_writer(BufWriter(buf)));
+        let read = move || {
+            let data = buf_read.lock().unwrap();
+            String::from_utf8(data.clone())
+                .unwrap_or_default()
+                .lines()
+                .filter(|l| !l.is_empty())
+                .map(str::to_owned)
+                .collect::<Vec<_>>()
+        };
+        (sink, read)
+    }
+
+    fn event_field<'a>(line: &'a str, key: &str) -> &'a str {
+        // minimal parse: find `"key":"value"` in the JSONL line
+        let needle = format!("\"{}\":\"", key);
+        line.find(&needle)
+            .map(|i| {
+                let rest = &line[i + needle.len()..];
+                &rest[..rest.find('"').unwrap_or(rest.len())]
+            })
+            .unwrap_or("")
     }
 
     #[tokio::test]
-    async fn send_emits_chunk_and_end() {
-        let sink = make_sink();
+    async fn flush_chunks_is_noop_without_chunks() {
+        let (sink, read) = make_test_sink();
         let mut ch = JsonCliChannel::new(Arc::clone(&sink), false);
-        assert!(ch.send("hello").await.is_ok());
+        ch.flush_chunks().await.unwrap();
+        assert!(
+            read().is_empty(),
+            "flush_chunks must not emit when no chunks were sent"
+        );
     }
 
     #[tokio::test]
-    async fn send_chunk_and_flush() {
-        let sink = make_sink();
+    async fn flush_chunks_emits_end_after_chunk() {
+        let (sink, read) = make_test_sink();
         let mut ch = JsonCliChannel::new(Arc::clone(&sink), false);
-        assert!(ch.send_chunk("a").await.is_ok());
-        assert!(ch.flush_chunks().await.is_ok());
+        ch.send_chunk("hello").await.unwrap();
+        ch.flush_chunks().await.unwrap();
+        let lines = read();
+        assert_eq!(lines.len(), 2);
+        assert_eq!(event_field(&lines[0], "event"), "response_chunk");
+        assert_eq!(event_field(&lines[1], "event"), "response_end");
+    }
+
+    #[tokio::test]
+    async fn send_resets_pending_and_subsequent_flush_is_noop() {
+        // send_chunk then send: ResponseEnd is emitted by send; flush_chunks after must be no-op.
+        let (sink, read) = make_test_sink();
+        let mut ch = JsonCliChannel::new(Arc::clone(&sink), false);
+        ch.send_chunk("a").await.unwrap();
+        ch.send("b").await.unwrap();
+        let before_flush = read().len();
+        ch.flush_chunks().await.unwrap();
+        assert_eq!(
+            read().len(),
+            before_flush,
+            "flush_chunks must be no-op after send()"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_after_send_chunk_emits_single_end() {
+        // send_chunk("a") + send("b") => chunk(a), chunk(b), response_end — no duplicate end.
+        let (sink, read) = make_test_sink();
+        let mut ch = JsonCliChannel::new(Arc::clone(&sink), false);
+        ch.send_chunk("a").await.unwrap();
+        ch.send("b").await.unwrap();
+        let lines = read();
+        assert_eq!(
+            lines.len(),
+            3,
+            "expected chunk(a), chunk(b), response_end; got: {lines:?}"
+        );
+        assert_eq!(event_field(&lines[0], "event"), "response_chunk");
+        assert_eq!(event_field(&lines[1], "event"), "response_chunk");
+        assert_eq!(event_field(&lines[2], "event"), "response_end");
+    }
+
+    #[tokio::test]
+    async fn two_sequential_sends_emit_two_ends() {
+        let (sink, read) = make_test_sink();
+        let mut ch = JsonCliChannel::new(Arc::clone(&sink), false);
+        ch.send("first").await.unwrap();
+        ch.send("second").await.unwrap();
+        let lines = read();
+        // chunk, end, chunk, end
+        assert_eq!(lines.len(), 4);
+        assert_eq!(event_field(&lines[1], "event"), "response_end");
+        assert_eq!(event_field(&lines[3], "event"), "response_end");
     }
 
     #[tokio::test]
     async fn send_status_ok() {
-        let sink = make_sink();
+        let (sink, _read) = make_test_sink();
         let mut ch = JsonCliChannel::new(Arc::clone(&sink), false);
         assert!(ch.send_status("working…").await.is_ok());
     }
@@ -247,7 +356,7 @@ mod tests {
     #[tokio::test]
     async fn no_ops_do_not_error() {
         use zeph_core::channel::{ToolOutputEvent, ToolStartEvent};
-        let sink = make_sink();
+        let (sink, _read) = make_test_sink();
         let mut ch = JsonCliChannel::new(Arc::clone(&sink), false);
         assert!(ch.send_typing().await.is_ok());
         assert!(ch.send_thinking_chunk("...").await.is_ok());
@@ -288,14 +397,14 @@ mod tests {
 
     #[test]
     fn supports_exit_is_true() {
-        let sink = make_sink();
+        let (sink, _) = make_test_sink();
         let ch = JsonCliChannel::new(sink, false);
         assert!(ch.supports_exit());
     }
 
     #[test]
     fn try_recv_returns_none_when_no_input() {
-        let sink = make_sink();
+        let (sink, _) = make_test_sink();
         let mut ch = JsonCliChannel::new(sink, false);
         assert!(ch.try_recv().is_none());
     }

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -598,7 +598,7 @@ impl<C: Channel> Agent<C> {
     ///
     /// Call this before dropping the agent to ensure no data loss.
     pub async fn shutdown(&mut self) {
-        self.channel.send("Shutting down...").await.ok();
+        let _ = self.channel.send_status("Shutting down...").await;
 
         // CRIT-1: persist Thompson state accumulated during this session.
         self.provider.save_router_state();
@@ -877,6 +877,8 @@ impl<C: Channel> Agent<C> {
                 reg.register(DebugDumpCommand);
                 reg.register(DumpFormatCommand);
                 reg.register(HelpCommand);
+                #[cfg(test)]
+                reg.register(test_stubs::TestErrorCommand);
 
                 let mut ctx = zeph_commands::CommandContext {
                     sink: &mut sink_adapter,
@@ -903,7 +905,12 @@ impl<C: Channel> Agent<C> {
                     let _ = self.channel.flush_chunks().await;
                     continue;
                 }
-                Some(Err(e)) => return Err(error::AgentError::Other(e.0)),
+                Some(Err(e)) => {
+                    let _ = self.channel.send(&e.to_string()).await;
+                    let _ = self.channel.flush_chunks().await;
+                    tracing::warn!(command = %trimmed, error = %e.0, "slash command failed");
+                    continue;
+                }
                 None => {
                     // Not handled by the session/debug registry; try agent-command registry.
                 }
@@ -1002,7 +1009,12 @@ impl<C: Channel> Agent<C> {
                     self.maybe_trigger_post_command_learning(trimmed).await;
                     continue;
                 }
-                Some(Err(e)) => return Err(error::AgentError::Other(e.0)),
+                Some(Err(e)) => {
+                    let _ = self.channel.send(&e.to_string()).await;
+                    let _ = self.channel.flush_chunks().await;
+                    tracing::warn!(command = %trimmed, error = %e.0, "slash command failed");
+                    continue;
+                }
                 None => {
                     // Not handled by agent registry; fall through to existing dispatch.
                 }
@@ -2732,3 +2744,43 @@ mod tests;
 
 #[cfg(test)]
 pub(crate) use tests::agent_tests;
+
+#[cfg(test)]
+mod test_stubs {
+    use std::pin::Pin;
+
+    use zeph_commands::{
+        CommandContext, CommandError, CommandHandler, CommandOutput, SlashCategory,
+    };
+
+    /// Stub slash command registered only in `#[cfg(test)]` builds.
+    ///
+    /// Triggers the `Some(Err(CommandError))` arm in the session/debug registry
+    /// dispatch block so the non-fatal error path can be tested without production
+    /// command validation logic.
+    pub(super) struct TestErrorCommand;
+
+    impl CommandHandler<CommandContext<'_>> for TestErrorCommand {
+        fn name(&self) -> &'static str {
+            "/test-error"
+        }
+
+        fn description(&self) -> &'static str {
+            "Test stub: always returns CommandError"
+        }
+
+        fn category(&self) -> SlashCategory {
+            SlashCategory::Session
+        }
+
+        fn handle<'a>(
+            &'a self,
+            _ctx: &'a mut CommandContext<'_>,
+            _args: &'a str,
+        ) -> Pin<
+            Box<dyn std::future::Future<Output = Result<CommandOutput, CommandError>> + Send + 'a>,
+        > {
+            Box::pin(async { Err(CommandError::new("boom")) })
+        }
+    }
+}

--- a/crates/zeph-core/src/agent/tests.rs
+++ b/crates/zeph-core/src/agent/tests.rs
@@ -2905,6 +2905,59 @@ pub mod agent_tests {
             "blocked_commands must be rebuilt live via shell_policy_handle"
         );
     }
+
+    #[tokio::test]
+    async fn slash_command_error_is_non_fatal_session_registry() {
+        // "/test-error" is registered only in test builds into the session/debug registry arm.
+        // Before the fix this arm returned Err(AgentError::Other), terminating the agent.
+        // After the fix the error is sent to the channel and the loop continues; the channel
+        // then reaches EOF and the agent exits cleanly with Ok(()).
+        //
+        // Single message only — avoids MESSAGE_MERGE_WINDOW combining two rapid try_recv calls.
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec!["/test-error".to_string()]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+        let result = agent.run().await;
+
+        assert!(
+            result.is_ok(),
+            "agent must not exit with Err after CommandError: {result:?}"
+        );
+        let sent = agent.channel.sent_messages();
+        assert!(
+            sent.iter().any(|m| m.contains("boom")),
+            "channel must receive the error message; got: {sent:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn slash_command_error_is_non_fatal_agent_registry() {
+        // "/loop every 2s tick" triggers CommandError from LoopCommand (minimum interval is 5s).
+        // Before the fix this arm returned Err(AgentError::Other). After the fix the error is
+        // surfaced to the channel and the loop continues; EOF then causes a clean exit.
+        //
+        // Single message only — avoids MESSAGE_MERGE_WINDOW combining two rapid try_recv calls.
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec!["/loop every 2s tick".to_string()]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+        let result = agent.run().await;
+
+        assert!(
+            result.is_ok(),
+            "agent must not exit with Err after CommandError: {result:?}"
+        );
+        let sent = agent.channel.sent_messages();
+        assert!(
+            !sent.is_empty(),
+            "channel must receive the error message; got: {sent:?}"
+        );
+    }
 }
 
 /// End-to-end tests for M30 resilient compaction: error detection → compact → retry → success.

--- a/crates/zeph-core/src/json_event_sink.rs
+++ b/crates/zeph-core/src/json_event_sink.rs
@@ -19,7 +19,7 @@
 //! `emit` holds the lock only for serialization + write + flush. It never
 //! `.await`s while holding the lock, satisfying invariant §10.
 
-use std::io::{self, Stdout, Write};
+use std::io::{self, Write};
 use std::sync::Mutex;
 
 use serde::Serialize;
@@ -81,7 +81,7 @@ pub enum JsonEvent<'a> {
 /// Wrap in `Arc` and share between `JsonCliChannel` and `JsonEventLayer`.
 /// `emit` is synchronous and lock-bounded: it never yields across `.await`.
 pub struct JsonEventSink {
-    writer: Mutex<Stdout>,
+    writer: Mutex<Box<dyn Write + Send>>,
 }
 
 impl std::fmt::Debug for JsonEventSink {
@@ -95,11 +95,33 @@ impl JsonEventSink {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            writer: Mutex::new(io::stdout()),
+            writer: Mutex::new(Box::new(io::stdout())),
         }
     }
 
-    /// Serialize `event` as a JSON line and write it to stdout.
+    /// Create a sink backed by an arbitrary [`Write`] implementation.
+    ///
+    /// Intended for testing: pass a type that implements [`Write`] + [`Send`] + `'static`,
+    /// such as [`std::io::Cursor`]`<Vec<u8>>`, to capture emitted JSONL lines in memory.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::io::Cursor;
+    /// use std::sync::Arc;
+    /// use zeph_core::json_event_sink::{JsonEvent, JsonEventSink};
+    ///
+    /// let sink = Arc::new(JsonEventSink::with_writer(Cursor::new(Vec::<u8>::new())));
+    /// sink.emit(&JsonEvent::Status { message: "hello" });
+    /// ```
+    #[must_use]
+    pub fn with_writer(w: impl Write + Send + 'static) -> Self {
+        Self {
+            writer: Mutex::new(Box::new(w)),
+        }
+    }
+
+    /// Serialize `event` as a JSON line and write it to the underlying writer.
     ///
     /// Silently drops the event when the mutex is poisoned or serialization fails.
     /// This is intentional: a JSON output failure must not crash the agent.
@@ -117,6 +139,40 @@ impl JsonEventSink {
 impl Default for JsonEventSink {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Returns a `(Arc<JsonEventSink>, captured_output_fn)` pair for use in tests.
+///
+/// The sink writes to an in-memory buffer. Call the returned closure to retrieve
+/// the captured JSONL output as a `String`.
+#[cfg(test)]
+pub(crate) fn test_sink() -> (std::sync::Arc<JsonEventSink>, impl Fn() -> String) {
+    use std::sync::Arc;
+    let buf: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    let buf_clone = Arc::clone(&buf);
+
+    // Use a shared-buffer writer so we can read back later.
+    let writer = SharedBufWriter(Arc::clone(&buf));
+    let sink = Arc::new(JsonEventSink::with_writer(writer));
+    let read_fn = move || {
+        let data = buf_clone.lock().unwrap();
+        String::from_utf8(data.clone()).unwrap_or_default()
+    };
+    (sink, read_fn)
+}
+
+#[cfg(test)]
+struct SharedBufWriter(std::sync::Arc<Mutex<Vec<u8>>>);
+
+#[cfg(test)]
+impl Write for SharedBufWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
     }
 }
 

--- a/crates/zeph-core/src/json_event_sink.rs
+++ b/crates/zeph-core/src/json_event_sink.rs
@@ -142,40 +142,6 @@ impl Default for JsonEventSink {
     }
 }
 
-/// Returns a `(Arc<JsonEventSink>, captured_output_fn)` pair for use in tests.
-///
-/// The sink writes to an in-memory buffer. Call the returned closure to retrieve
-/// the captured JSONL output as a `String`.
-#[cfg(test)]
-pub(crate) fn test_sink() -> (std::sync::Arc<JsonEventSink>, impl Fn() -> String) {
-    use std::sync::Arc;
-    let buf: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
-    let buf_clone = Arc::clone(&buf);
-
-    // Use a shared-buffer writer so we can read back later.
-    let writer = SharedBufWriter(Arc::clone(&buf));
-    let sink = Arc::new(JsonEventSink::with_writer(writer));
-    let read_fn = move || {
-        let data = buf_clone.lock().unwrap();
-        String::from_utf8(data.clone()).unwrap_or_default()
-    };
-    (sink, read_fn)
-}
-
-#[cfg(test)]
-struct SharedBufWriter(std::sync::Arc<Mutex<Vec<u8>>>);
-
-#[cfg(test)]
-impl Write for SharedBufWriter {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.0.lock().unwrap().extend_from_slice(buf);
-        Ok(buf.len())
-    }
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

- Fixes two anomalies in `--json` JSONL output stream (#3212): lifecycle "Shutting down..." message no longer leaks as `response_chunk`; bare `response_end` with no preceding chunk no longer emitted by `flush_chunks`
- Fixes `/loop` `CommandError` being silently swallowed (#3211): validation errors are now sent to the output channel and treated as non-fatal (agent loop continues)

## Changes

**`crates/zeph-channels/src/json_cli.rs`**
- Added `pending_chunks: bool` field to `JsonCliChannel`; `flush_chunks` now only emits `ResponseEnd` when at least one chunk was sent since the last end
- Added `JsonEventSink::with_writer` constructor for testability
- 5 behavioural JSONL tests covering all `pending_chunks` invariants

**`crates/zeph-core/src/agent/mod.rs`**
- `shutdown()`: `send("Shutting down...")` → `send_status(...)` — routes to `{"event":"status"}` in JSON mode
- Both `Some(Err(e)) => return Err(AgentError::Other)` arms (session registry ~906, agent registry ~1010) replaced with `send(&e.to_string()) + flush_chunks + warn + continue`
- 2 new unit tests covering agent-loop continuation after `CommandError`

**`crates/zeph-core/src/json_event_sink.rs`**
- Added `# Examples` doc-test to `JsonEventSink::with_writer`

## Behaviour notes

- Plain CLI mode no longer prints "Zeph: Shutting down..." — this was a side effect of routing the message through `send_status` which `CliChannel` maps to no-op. UX impact: minimal (line was cosmetic).
- Follow-up #3214 filed for deduplicating the two near-identical agent-loop dispatch blocks.

## Test plan

- [x] `cargo +nightly fmt --check` — pass
- [x] `cargo clippy --workspace -- -D warnings` — pass
- [x] `cargo nextest run --workspace --lib --bins` — 8395 passed
- [x] `cargo test --doc -p zeph-core` — 19 passed
- [ ] Live verification: `echo 'what is 2+2' | cargo run --features full -- --config .local/config/testing.toml --json 2>/dev/null | grep '"event":"response'` — requires vault; confirm no spurious events

Closes #3212, #3211