### PR TITLE
feat(quality): MARCH Proposer+Checker self-check pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `[session.recap] on_resume = true` (default). Operates on in-session state — distinct from the
   persistent semantic memory recall shown at startup.
 
+- **feat(quality): MARCH self-check pipeline** (`self-check` feature, #2352) — post-response
+  factual consistency layer. A two-stage Proposer → Checker LLM pipeline extracts assertions
+  from the assistant response and verifies each against retrieved memory evidence. Contradicted
+  or unsupported assertions trigger a configurable flag marker appended to the response. The
+  Checker never sees the original response text (asymmetry invariant enforced at the type level).
+  Enable via `[quality] self_check = true` in `config.toml`. Configurable: `trigger`
+  (`has_retrieval` | `always` | `manual`), `latency_budget_ms`, `per_call_timeout_ms`,
+  `max_assertions`, `min_evidence`, `flag_marker`, and `cache_disabled_for_checker`.
+
 - **feat(cli): `--bare` mode for scripted/CI usage** (#2790) — new flag strips the agent to
   essentials: skips memory init, scheduler startup, skill loading, and watcher registration.
   Suitable for piping and automation where full subsystem overhead is unnecessary.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,9 +190,10 @@ ide     = ["acp", "acp-http"]
 server  = ["gateway", "a2a", "otel", "prometheus"]
 chat    = ["discord", "slack"]
 ml      = ["candle", "pdf"]
-full    = ["desktop", "ide", "server", "chat", "pdf", "scheduler", "classifiers", "profiling", "task-metrics", "sandbox"]
-sandbox = ["zeph-tools/sandbox"]
-bench   = ["dep:zeph-bench"]
+full    = ["desktop", "ide", "server", "chat", "pdf", "scheduler", "classifiers", "profiling", "task-metrics", "sandbox", "self-check"]
+sandbox    = ["zeph-tools/sandbox"]
+self-check = ["zeph-core/self-check"]
+bench      = ["dep:zeph-bench"]
 
 # === Individual feature flags ===
 a2a = ["dep:zeph-a2a", "zeph-a2a?/server", "zeph-a2a?/ibct"]

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -69,6 +69,7 @@ pub mod memory;
 pub mod metrics;
 pub mod migrate;
 pub mod providers;
+pub mod quality;
 pub mod rate_limit;
 pub mod root;
 pub mod sanitizer;
@@ -124,6 +125,7 @@ pub use providers::{
     SttConfig, TierMapping, validate_pool,
 };
 pub use providers::{default_stt_language, default_stt_provider};
+pub use quality::{QualityConfig, TriggerPolicy};
 pub use rate_limit::RateLimitConfig;
 pub use sanitizer::{
     CausalIpiConfig, ContentIsolationConfig, CustomPiiPattern, EmbeddingGuardConfig,

--- a/crates/zeph-config/src/quality.rs
+++ b/crates/zeph-config/src/quality.rs
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Configuration for the MARCH self-check quality pipeline.
+//!
+//! Add a `[quality]` section to `config.toml`:
+//!
+//! ```toml
+//! [quality]
+//! self_check = true
+//! trigger = "has_retrieval"
+//! async_run = false
+//! ```
+
+use serde::{Deserialize, Serialize};
+
+/// When to trigger the self-check pipeline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum TriggerPolicy {
+    /// Run only when the turn has retrieved context.
+    #[default]
+    HasRetrieval,
+    /// Always run regardless of retrieved context.
+    Always,
+    /// Never run automatically.
+    Manual,
+}
+
+/// Configuration for the MARCH self-check quality pipeline.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QualityConfig {
+    /// Enable post-response self-check pipeline.
+    #[serde(default)]
+    pub self_check: bool,
+
+    /// Advisory: preferred provider for the Proposer role (MVP: no-op).
+    #[serde(default)]
+    pub proposer_provider: String,
+
+    /// Advisory: preferred provider for the Checker role (MVP: no-op).
+    #[serde(default)]
+    pub checker_provider: String,
+
+    /// When to trigger the pipeline.
+    #[serde(default)]
+    pub trigger: TriggerPolicy,
+
+    /// Minimum evidence strength to avoid flagging an assertion (0.0–1.0).
+    #[serde(default = "default_min_evidence")]
+    pub min_evidence: f32,
+
+    /// If `false` (default), pipeline blocks response until done.
+    #[serde(default)]
+    pub async_run: bool,
+
+    /// Hard ceiling on total pipeline latency in milliseconds.
+    #[serde(default = "default_latency_budget_ms")]
+    pub latency_budget_ms: u64,
+
+    /// Per-LLM-call timeout in milliseconds.
+    #[serde(default = "default_per_call_timeout_ms")]
+    pub per_call_timeout_ms: u64,
+
+    /// Maximum assertions to extract from one response.
+    #[serde(default = "default_max_assertions")]
+    pub max_assertions: usize,
+
+    /// Skip pipeline when response exceeds this many characters.
+    #[serde(default = "default_max_response_chars")]
+    pub max_response_chars: usize,
+
+    /// Suppress prompt-cache emission on Checker provider.
+    #[serde(default = "default_cache_disabled_for_checker")]
+    pub cache_disabled_for_checker: bool,
+
+    /// Marker appended to response when issues are flagged.
+    #[serde(default = "default_flag_marker")]
+    pub flag_marker: String,
+}
+
+fn default_min_evidence() -> f32 {
+    0.6
+}
+fn default_latency_budget_ms() -> u64 {
+    4_000
+}
+fn default_per_call_timeout_ms() -> u64 {
+    2_000
+}
+fn default_max_assertions() -> usize {
+    12
+}
+fn default_max_response_chars() -> usize {
+    8_000
+}
+fn default_cache_disabled_for_checker() -> bool {
+    true
+}
+fn default_flag_marker() -> String {
+    "[verify]".into()
+}
+
+impl Default for QualityConfig {
+    fn default() -> Self {
+        Self {
+            self_check: false,
+            proposer_provider: String::new(),
+            checker_provider: String::new(),
+            trigger: TriggerPolicy::default(),
+            min_evidence: default_min_evidence(),
+            async_run: false,
+            latency_budget_ms: default_latency_budget_ms(),
+            per_call_timeout_ms: default_per_call_timeout_ms(),
+            max_assertions: default_max_assertions(),
+            max_response_chars: default_max_response_chars(),
+            cache_disabled_for_checker: default_cache_disabled_for_checker(),
+            flag_marker: default_flag_marker(),
+        }
+    }
+}

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -109,6 +109,9 @@ pub struct Config {
     /// Session-scoped CLI overrides (bare mode, JSON output, auto-approve).
     #[serde(default)]
     pub cli: CliConfig,
+    /// MARCH self-check quality pipeline configuration.
+    #[serde(default)]
+    pub quality: crate::quality::QualityConfig,
     /// Resolved secrets from vault. Never serialized — populated at runtime.
     #[serde(skip)]
     pub secrets: ResolvedSecrets,
@@ -273,6 +276,7 @@ impl Default for Config {
             metrics: MetricsConfig::default(),
             session: crate::session::SessionConfig::default(),
             cli: CliConfig::default(),
+            quality: crate::quality::QualityConfig::default(),
             secrets: ResolvedSecrets::default(),
         }
     }

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -23,7 +23,8 @@ classifiers = ["zeph-llm/classifiers", "zeph-sanitizer/classifiers"]
 cuda = ["zeph-llm/cuda"]
 metal = ["zeph-llm/metal"]
 mock = ["zeph-vault/mock"]
-scheduler = []
+scheduler  = []
+self-check = []
 
 [dependencies]
 base64.workspace = true

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1728,6 +1728,34 @@ impl<C: Channel> Agent<C> {
         self.session.status_tx = Some(tx);
         self
     }
+
+    /// Attach a pre-built [`SelfCheckPipeline`] to enable per-turn factual self-check.
+    ///
+    /// When set, the agent runs the MARCH Proposer → Checker pipeline after every assistant
+    /// response and appends a flag marker to the channel output if assertions are contradicted
+    /// or unsupported by retrieved evidence.
+    ///
+    /// Calling this method without the `self-check` feature compiled in is a no-op.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use zeph_core::quality::{QualityConfig, SelfCheckPipeline};
+    /// # use zeph_llm::any::AnyProvider;
+    /// # let provider: AnyProvider = unimplemented!();
+    /// let cfg = QualityConfig::default();
+    /// let pipeline = SelfCheckPipeline::build(&cfg, &provider).unwrap();
+    /// // agent_builder.with_quality_pipeline(Some(pipeline));
+    /// ```
+    #[must_use]
+    #[cfg(feature = "self-check")]
+    pub fn with_quality_pipeline(
+        mut self,
+        pipeline: Option<std::sync::Arc<crate::quality::SelfCheckPipeline>>,
+    ) -> Self {
+        self.quality = pipeline;
+        self
+    }
 }
 
 #[cfg(test)]

--- a/crates/zeph-core/src/agent/context/mod.rs
+++ b/crates/zeph-core/src/agent/context/mod.rs
@@ -3,6 +3,8 @@
 
 pub(super) mod assembler;
 mod assembly;
+#[cfg(feature = "self-check")]
+pub(crate) mod retrieved;
 mod summarization;
 
 #[cfg(test)]

--- a/crates/zeph-core/src/agent/context/retrieved.rs
+++ b/crates/zeph-core/src/agent/context/retrieved.rs
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Extracted retrieved-memory context from the current turn's message list.
+//!
+//! Used by the MARCH self-check pipeline to obtain the evidence set without
+//! giving the pipeline direct access to the full message history.
+
+use zeph_llm::provider::{Message, MessagePart, Role};
+
+use crate::agent::{CROSS_SESSION_PREFIX, GRAPH_FACTS_PREFIX, RECALL_PREFIX, SUMMARY_PREFIX};
+use crate::quality::pipeline::RetrievedContext;
+
+/// Walk the message list and collect all retrieved-memory fragments.
+///
+/// Two paths are supported:
+/// - **Canonical multipart path**: `MessagePart::{Recall, Summary, CrossSession}` attached to any message.
+/// - **Legacy string-prefix path**: `Role::System` messages whose text content begins with a
+///   known prefix constant (used by Ollama and older session restores).
+///
+/// `MessagePart::GraphFacts` does not exist; graph facts flow via `Role::System` messages
+/// with the `GRAPH_FACTS_PREFIX` prefix — they are captured by the legacy path.
+pub fn collect_retrieved_context(messages: &[Message]) -> RetrievedContext<'_> {
+    let mut rc = RetrievedContext::default();
+
+    for msg in messages {
+        // (a) Canonical multipart path
+        for part in &msg.parts {
+            match part {
+                MessagePart::Recall { text } => rc.recall.push(text.as_str()),
+                MessagePart::Summary { text } => rc.summaries.push(text.as_str()),
+                MessagePart::CrossSession { text } => rc.cross_session.push(text.as_str()),
+                _ => {}
+            }
+        }
+
+        // (b) Legacy string-prefix path on System role only
+        if msg.role == Role::System {
+            for part in &msg.parts {
+                if let Some(text) = part.as_plain_text() {
+                    if let Some(body) = text.strip_prefix(RECALL_PREFIX) {
+                        rc.recall.push(body);
+                    } else if let Some(body) = text.strip_prefix(SUMMARY_PREFIX) {
+                        rc.summaries.push(body);
+                    } else if let Some(body) = text.strip_prefix(CROSS_SESSION_PREFIX) {
+                        rc.cross_session.push(body);
+                    } else if let Some(body) = text.strip_prefix(GRAPH_FACTS_PREFIX) {
+                        rc.graph_facts.push(body);
+                    }
+                }
+            }
+            // Also scan legacy content field (Ollama providers set content only, no parts)
+            if msg.parts.is_empty() {
+                let text = msg.content.as_str();
+                if let Some(body) = text.strip_prefix(RECALL_PREFIX) {
+                    rc.recall.push(body);
+                } else if let Some(body) = text.strip_prefix(SUMMARY_PREFIX) {
+                    rc.summaries.push(body);
+                } else if let Some(body) = text.strip_prefix(CROSS_SESSION_PREFIX) {
+                    rc.cross_session.push(body);
+                } else if let Some(body) = text.strip_prefix(GRAPH_FACTS_PREFIX) {
+                    rc.graph_facts.push(body);
+                }
+            }
+        }
+    }
+
+    rc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zeph_llm::provider::MessageMetadata;
+
+    fn sys_msg(content: &str) -> Message {
+        Message {
+            role: Role::System,
+            content: content.to_owned(),
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        }
+    }
+
+    fn msg_with_part(role: Role, part: MessagePart) -> Message {
+        Message {
+            role,
+            content: String::new(),
+            parts: vec![part],
+            metadata: MessageMetadata::default(),
+        }
+    }
+
+    #[test]
+    fn collect_finds_multipart_recall() {
+        let msgs = vec![msg_with_part(
+            Role::User,
+            MessagePart::Recall {
+                text: "recall fragment".into(),
+            },
+        )];
+        let rc = collect_retrieved_context(&msgs);
+        assert_eq!(rc.recall, vec!["recall fragment"]);
+        assert!(rc.summaries.is_empty());
+    }
+
+    #[test]
+    fn collect_finds_legacy_prefix_system() {
+        let msgs = vec![sys_msg(&format!("{RECALL_PREFIX}legacy recall body"))];
+        let rc = collect_retrieved_context(&msgs);
+        assert_eq!(rc.recall, vec!["legacy recall body"]);
+    }
+
+    #[test]
+    fn collect_combines_both_shapes() {
+        let msgs = vec![
+            msg_with_part(
+                Role::User,
+                MessagePart::Recall {
+                    text: "part recall".into(),
+                },
+            ),
+            sys_msg(&format!("{GRAPH_FACTS_PREFIX}graph data")),
+        ];
+        let rc = collect_retrieved_context(&msgs);
+        assert_eq!(rc.recall, vec!["part recall"]);
+        assert_eq!(rc.graph_facts, vec!["graph data"]);
+    }
+
+    #[test]
+    fn collect_skips_non_retrieval_parts() {
+        let msgs = vec![msg_with_part(
+            Role::User,
+            MessagePart::Text {
+                text: "plain user text".into(),
+            },
+        )];
+        let rc = collect_retrieved_context(&msgs);
+        assert!(rc.is_empty());
+    }
+
+    #[test]
+    fn collect_empty_on_plain_user_turn() {
+        let msgs = vec![Message {
+            role: Role::User,
+            content: "hello world".into(),
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        }];
+        let rc = collect_retrieved_context(&msgs);
+        assert!(rc.is_empty());
+    }
+}

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -32,6 +32,8 @@ mod persistence;
 mod plan;
 mod policy_commands;
 mod provider_cmd;
+#[cfg(feature = "self-check")]
+mod quality_hook;
 pub(crate) mod rate_limiter;
 #[cfg(feature = "scheduler")]
 mod scheduler_commands;
@@ -181,6 +183,9 @@ pub struct Agent<C: Channel> {
     pub(super) sidequest: sidequest::SidequestState,
     /// Tool filtering, dependency tracking, and iteration bookkeeping.
     pub(super) tool_state: ToolState,
+    /// MARCH self-check pipeline, built at startup and rebuilt on provider swap.
+    #[cfg(feature = "self-check")]
+    pub(super) quality: Option<std::sync::Arc<crate::quality::SelfCheckPipeline>>,
 }
 
 impl<C: Channel> Agent<C> {
@@ -303,6 +308,8 @@ impl<C: Channel> Agent<C> {
             focus: focus::FocusState::default(),
             sidequest: sidequest::SidequestState::default(),
             tool_state: ToolState::default(),
+            #[cfg(feature = "self-check")]
+            quality: None,
         }
     }
 
@@ -1394,6 +1401,12 @@ impl<C: Channel> Agent<C> {
             self.maybe_update_magic_docs();
         }
         tracing::debug!("turn timing: process_response done");
+
+        // MARCH self-check hook: runs after every successful response, including cache-hit path.
+        #[cfg(feature = "self-check")]
+        if let Some(pipeline) = self.quality.clone() {
+            self.run_self_check_for_turn(pipeline, turn.id().0).await;
+        }
 
         // Collect llm_chat_ms and tool_exec_ms from MetricsState.pending_timings (accumulated
         // by the tool execution chain) into turn.metrics so end_turn can flush them.

--- a/crates/zeph-core/src/agent/quality_hook.rs
+++ b/crates/zeph-core/src/agent/quality_hook.rs
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Turn-level self-check hook for the MARCH quality pipeline.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use zeph_llm::provider::Role;
+
+use super::{Agent, Channel};
+use crate::quality::SelfCheckPipeline;
+
+impl<C: Channel> Agent<C> {
+    /// Run the self-check pipeline for the current turn after `process_response()` completes.
+    ///
+    /// Finds the last assistant message, extracts retrieved context, and runs the pipeline
+    /// synchronously within the configured latency budget.
+    pub(super) async fn run_self_check_for_turn(
+        &mut self,
+        pipeline: Arc<SelfCheckPipeline>,
+        turn_id: u64,
+    ) {
+        let cfg = pipeline.cfg_ref().clone();
+
+        if cfg.async_run {
+            tracing::warn!(
+                turn_id,
+                "self-check: async_run = true is not yet implemented; running synchronously"
+            );
+        }
+
+        let Some(response_text) = self
+            .msg
+            .messages
+            .iter()
+            .rev()
+            .find(|m| m.role == Role::Assistant)
+            .map(|m| m.content.clone())
+            .filter(|t| !t.trim().is_empty())
+        else {
+            tracing::debug!(turn_id, "self-check skipped: no assistant text in turn");
+            return;
+        };
+
+        let response_char_count = response_text.chars().count();
+        if response_char_count > cfg.max_response_chars {
+            tracing::debug!(
+                turn_id,
+                chars = response_char_count,
+                limit = cfg.max_response_chars,
+                "self-check skipped: response too long"
+            );
+            return;
+        }
+
+        let rc = crate::agent::context::retrieved::collect_retrieved_context(&self.msg.messages);
+
+        let user_query = self
+            .msg
+            .messages
+            .iter()
+            .rev()
+            .find(|m| m.role == Role::User)
+            .map(|m| m.content.clone())
+            .unwrap_or_default();
+
+        tracing::debug!(turn_id, "self-check: running pipeline");
+
+        let budget = Duration::from_millis(cfg.latency_budget_ms);
+        let Ok(report) = tokio::time::timeout(
+            budget,
+            pipeline.run(&response_text, rc, &user_query, turn_id),
+        )
+        .await
+        else {
+            tracing::warn!(
+                turn_id,
+                budget_ms = cfg.latency_budget_ms,
+                "self-check timed out at outer budget"
+            );
+            let _ = self.channel.send(" [self-check: skipped (timeout)]").await;
+            return;
+        };
+
+        let flagged = report.flagged_ids.len();
+        let total = report.assertions.len();
+        tracing::debug!(
+            turn_id,
+            flagged,
+            total,
+            latency_ms = report.latency_ms,
+            "self-check complete"
+        );
+
+        if flagged > 0 {
+            let marker = format!(" {}", cfg.flag_marker);
+            let _ = self.channel.send(&marker).await;
+        }
+    }
+}

--- a/crates/zeph-core/src/lib.rs
+++ b/crates/zeph-core/src/lib.rs
@@ -82,6 +82,8 @@ pub mod metrics_bridge;
 pub mod pipeline;
 pub mod project;
 pub mod provider_factory;
+#[cfg(feature = "self-check")]
+pub mod quality;
 pub mod redact;
 #[cfg(feature = "sysinfo")]
 pub mod system_metrics;

--- a/crates/zeph-core/src/quality/checker.rs
+++ b/crates/zeph-core/src/quality/checker.rs
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Checker stage: verify assertions against retrieved evidence.
+//!
+//! # Asymmetry invariant
+//!
+//! The checker prompt functions do NOT accept the original response string.
+//! This is a compile-time enforced correctness property: the Checker must never
+//! see what the assistant said — it judges only against retrieved evidence.
+
+use std::time::Duration;
+
+use serde::Deserialize;
+use zeph_llm::any::AnyProvider;
+
+use super::parser::{ChatJsonError, chat_json};
+use super::prompts::{CHECKER_SYSTEM, checker_user};
+use super::types::{Assertion, AssertionVerdict, StageOutcome};
+
+#[derive(Debug, Deserialize)]
+struct CheckerOutput {
+    verdicts: Vec<AssertionVerdict>,
+}
+
+/// Call the Checker and return verdicts plus stage diagnostics.
+///
+/// The `_response` parameter is intentionally absent — the function signature
+/// enforces the asymmetry invariant at the type level.
+pub async fn run_checker(
+    provider: &AnyProvider,
+    assertions: &[Assertion],
+    evidence: &str,
+    user_query: &str,
+    per_call_timeout: Duration,
+) -> (Vec<AssertionVerdict>, u64, StageOutcome, u32) {
+    let assertions_json = match serde_json::to_string(assertions) {
+        Ok(j) => j,
+        Err(e) => {
+            return (
+                vec![],
+                0,
+                StageOutcome::LlmError {
+                    msg: format!("assertion serialization failed: {e}"),
+                },
+                0,
+            );
+        }
+    };
+
+    let user = checker_user(user_query, evidence, &assertions_json);
+    match chat_json::<CheckerOutput>(provider, CHECKER_SYSTEM, &user, per_call_timeout).await {
+        Ok((out, tokens, attempt)) => {
+            let retries = attempt.saturating_sub(1);
+            (out.verdicts, tokens, StageOutcome::Ok, retries)
+        }
+        Err(ChatJsonError::Llm(e)) => (vec![], 0, StageOutcome::LlmError { msg: e.to_string() }, 0),
+        Err(ChatJsonError::Timeout(ms)) => (vec![], 0, StageOutcome::Timeout { ms }, 0),
+        Err(ChatJsonError::Parse(raw)) => (
+            vec![],
+            0,
+            StageOutcome::ParseError { raw_truncated: raw },
+            1,
+        ),
+    }
+}

--- a/crates/zeph-core/src/quality/config.rs
+++ b/crates/zeph-core/src/quality/config.rs
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Configuration types for the MARCH self-check quality pipeline.
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// When to run the self-check pipeline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum TriggerPolicy {
+    /// Run only when the turn has retrieved context (semantic recall, summaries, cross-session).
+    #[default]
+    HasRetrieval,
+    /// Always run regardless of retrieved context.
+    Always,
+    /// Never run automatically; only via explicit command.
+    Manual,
+}
+
+/// Configuration for the MARCH self-check quality pipeline.
+///
+/// Add a `[quality]` section to your `config.toml` to enable:
+///
+/// ```toml
+/// [quality]
+/// self_check = true
+/// trigger = "has_retrieval"
+/// async_run = false
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QualityConfig {
+    /// Enable post-response self-check pipeline.
+    #[serde(default)]
+    pub self_check: bool,
+
+    /// Advisory: preferred provider for the Proposer role.
+    ///
+    /// In MVP this field is parsed but not acted upon — the main provider is used.
+    /// Tracked as a follow-up issue.
+    #[serde(default)]
+    pub proposer_provider: String,
+
+    /// Advisory: preferred provider for the Checker role.
+    ///
+    /// In MVP this field is parsed but not acted upon — the main provider is used.
+    /// Tracked as a follow-up issue.
+    #[serde(default)]
+    pub checker_provider: String,
+
+    /// When to trigger the self-check pipeline.
+    #[serde(default)]
+    pub trigger: TriggerPolicy,
+
+    /// Minimum evidence strength to consider an assertion supported (0.0–1.0).
+    ///
+    /// Assertions where `status != Irrelevant && evidence < min_evidence` are flagged.
+    #[serde(default = "default_min_evidence")]
+    pub min_evidence: f32,
+
+    /// If `false` (default), self-check blocks the response until complete.
+    /// If `true`, it runs in the background and emits a visible closing marker.
+    #[serde(default)]
+    pub async_run: bool,
+
+    /// Hard ceiling on total pipeline latency in milliseconds (sync mode).
+    #[serde(default = "default_latency_budget_ms")]
+    pub latency_budget_ms: u64,
+
+    /// Per-LLM-call timeout in milliseconds. Must be ≤ `latency_budget_ms` / 2.
+    #[serde(default = "default_per_call_timeout_ms")]
+    pub per_call_timeout_ms: u64,
+
+    /// Maximum number of assertions to extract from one response.
+    #[serde(default = "default_max_assertions")]
+    pub max_assertions: usize,
+
+    /// Skip pipeline when assistant response exceeds this many characters.
+    #[serde(default = "default_max_response_chars")]
+    pub max_response_chars: usize,
+
+    /// If `true`, Checker provider clones without prompt-cache emission (recommended).
+    #[serde(default = "default_cache_disabled_for_checker")]
+    pub cache_disabled_for_checker: bool,
+
+    /// String appended to the assistant response when the pipeline flags issues.
+    #[serde(default = "default_flag_marker")]
+    pub flag_marker: String,
+}
+
+fn default_min_evidence() -> f32 {
+    0.6
+}
+fn default_latency_budget_ms() -> u64 {
+    4_000
+}
+fn default_per_call_timeout_ms() -> u64 {
+    2_000
+}
+fn default_max_assertions() -> usize {
+    12
+}
+fn default_max_response_chars() -> usize {
+    8_000
+}
+fn default_cache_disabled_for_checker() -> bool {
+    true
+}
+fn default_flag_marker() -> String {
+    "[verify]".into()
+}
+
+impl Default for QualityConfig {
+    fn default() -> Self {
+        Self {
+            self_check: false,
+            proposer_provider: String::new(),
+            checker_provider: String::new(),
+            trigger: TriggerPolicy::default(),
+            min_evidence: default_min_evidence(),
+            async_run: false,
+            latency_budget_ms: default_latency_budget_ms(),
+            per_call_timeout_ms: default_per_call_timeout_ms(),
+            max_assertions: default_max_assertions(),
+            max_response_chars: default_max_response_chars(),
+            cache_disabled_for_checker: default_cache_disabled_for_checker(),
+            flag_marker: default_flag_marker(),
+        }
+    }
+}
+
+/// Errors returned by [`QualityConfig::validate`].
+#[derive(Debug, Error)]
+pub enum QualityConfigError {
+    #[error("per_call_timeout_ms ({per_call}) × 2 must be ≤ latency_budget_ms ({budget})")]
+    TimeoutExceedsBudget { per_call: u64, budget: u64 },
+    #[error("min_evidence must be in 0.0..=1.0, got {0}")]
+    InvalidMinEvidence(f32),
+}
+
+impl QualityConfig {
+    /// Validate consistency constraints.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `2 * per_call_timeout_ms > latency_budget_ms` or
+    /// `min_evidence` is outside `[0.0, 1.0]`.
+    pub fn validate(&self) -> Result<(), QualityConfigError> {
+        if 2 * self.per_call_timeout_ms > self.latency_budget_ms {
+            return Err(QualityConfigError::TimeoutExceedsBudget {
+                per_call: self.per_call_timeout_ms,
+                budget: self.latency_budget_ms,
+            });
+        }
+        if !(0.0..=1.0).contains(&self.min_evidence) {
+            return Err(QualityConfigError::InvalidMinEvidence(self.min_evidence));
+        }
+        Ok(())
+    }
+}
+
+impl From<&zeph_config::QualityConfig> for QualityConfig {
+    fn from(c: &zeph_config::QualityConfig) -> Self {
+        Self {
+            self_check: c.self_check,
+            proposer_provider: c.proposer_provider.clone(),
+            checker_provider: c.checker_provider.clone(),
+            trigger: match c.trigger {
+                zeph_config::TriggerPolicy::HasRetrieval => TriggerPolicy::HasRetrieval,
+                zeph_config::TriggerPolicy::Always => TriggerPolicy::Always,
+                zeph_config::TriggerPolicy::Manual => TriggerPolicy::Manual,
+            },
+            min_evidence: c.min_evidence,
+            async_run: c.async_run,
+            latency_budget_ms: c.latency_budget_ms,
+            per_call_timeout_ms: c.per_call_timeout_ms,
+            max_assertions: c.max_assertions,
+            max_response_chars: c.max_response_chars,
+            cache_disabled_for_checker: c.cache_disabled_for_checker,
+            flag_marker: c.flag_marker.clone(),
+        }
+    }
+}

--- a/crates/zeph-core/src/quality/mod.rs
+++ b/crates/zeph-core/src/quality/mod.rs
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! MARCH self-check quality pipeline.
+//!
+//! Provides post-response factual consistency checking via a two-stage
+//! Proposer → Checker pipeline. Enabled by the `self-check` feature flag.
+//!
+//! See [`pipeline::SelfCheckPipeline`] for the entry point.
+
+pub mod checker;
+pub mod config;
+pub mod parser;
+pub mod pipeline;
+pub mod prompts;
+pub mod proposer;
+pub mod types;
+
+#[cfg(test)]
+mod tests;
+
+pub use config::QualityConfig;
+pub use pipeline::{RetrievedContext, SelfCheckPipeline};
+pub use types::SelfCheckReport;

--- a/crates/zeph-core/src/quality/parser.rs
+++ b/crates/zeph-core/src/quality/parser.rs
@@ -1,0 +1,203 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Best-effort JSON parser with one retry for use in the self-check pipeline.
+//!
+//! LLMs frequently wrap JSON output in markdown fences or prepend prose. This module
+//! strips those artifacts before deserializing.
+
+use std::time::Duration;
+
+use serde::de::DeserializeOwned;
+use thiserror::Error;
+use zeph_llm::any::AnyProvider;
+use zeph_llm::provider::{LlmProvider, Message, MessageMetadata, Role};
+
+/// Errors from the parser.
+#[derive(Debug, Error)]
+pub enum ParseError {
+    #[error("no opening brace found in output")]
+    NoBraceSpan,
+    #[error("JSON parse failed: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+/// Errors from `chat_json` (wraps [`ParseError`] and provider/timeout errors).
+#[derive(Debug, Error)]
+pub enum ChatJsonError {
+    #[error("LLM error: {0}")]
+    Llm(#[from] zeph_llm::LlmError),
+    #[error("timed out after {0}ms")]
+    Timeout(u64),
+    #[error("failed to parse JSON after 2 attempts; last raw (truncated): {0}")]
+    Parse(String),
+}
+
+/// Strip markdown code fences from LLM output.
+fn strip_fences(raw: &str) -> &str {
+    let trimmed = raw.trim();
+    if let Some(rest) = trimmed.strip_prefix("```") {
+        let after_lang = if let Some(nl) = rest.find('\n') {
+            &rest[nl + 1..]
+        } else {
+            rest
+        };
+        if let Some(end) = after_lang.rfind("```") {
+            return after_lang[..end].trim();
+        }
+        return after_lang.trim();
+    }
+    trimmed
+}
+
+/// Find the first `{...}` or `[...]` span in the string.
+fn find_first_brace_span(s: &str) -> Option<&str> {
+    let open = s.find(['{', '['])?;
+    let opener = s.as_bytes()[open];
+    let closer = if opener == b'{' { b'}' } else { b']' };
+    let mut depth = 0i32;
+    let bytes = s.as_bytes();
+    let mut close = None;
+    for (i, &b) in bytes.iter().enumerate().skip(open) {
+        if b == opener {
+            depth += 1;
+        } else if b == closer {
+            depth -= 1;
+            if depth == 0 {
+                close = Some(i);
+                break;
+            }
+        }
+    }
+    let close = close?;
+    Some(&s[open..=close])
+}
+
+/// Parse JSON from a raw LLM string, stripping fences and finding the first brace span.
+///
+/// # Errors
+///
+/// Returns [`ParseError`] if no brace span is found or JSON deserialization fails.
+pub fn parse_json<T: DeserializeOwned>(raw: &str) -> Result<T, ParseError> {
+    let stripped = strip_fences(raw);
+    let span = find_first_brace_span(stripped).ok_or(ParseError::NoBraceSpan)?;
+    Ok(serde_json::from_str(span)?)
+}
+
+/// Build a two-message `[system, user]` slice for a provider call.
+fn build_messages(system: &str, user: &str) -> Vec<Message> {
+    vec![
+        Message {
+            role: Role::System,
+            content: system.to_owned(),
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        },
+        Message {
+            role: Role::User,
+            content: user.to_owned(),
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        },
+    ]
+}
+
+/// Approximate token count from raw string (4 chars ≈ 1 token).
+#[must_use]
+pub fn approx_tokens(s: &str) -> u64 {
+    (s.len() as u64).saturating_add(3) / 4
+}
+
+/// Timeout duration in milliseconds, clamped to `u64::MAX`.
+fn timeout_ms(d: Duration) -> u64 {
+    u64::try_from(d.as_millis()).unwrap_or(u64::MAX)
+}
+
+/// Call the provider and parse the JSON result, retrying once on parse failure.
+///
+/// Returns `(value, approx_tokens, attempt_number)` on success.
+///
+/// # Errors
+///
+/// Returns [`ChatJsonError`] if both attempts fail, the provider errors, or timeout is hit.
+pub async fn chat_json<T: DeserializeOwned>(
+    provider: &AnyProvider,
+    system: &str,
+    user: &str,
+    per_call_timeout: Duration,
+) -> Result<(T, u64, u32), ChatJsonError> {
+    let msgs = build_messages(system, user);
+
+    // Attempt 1
+    let first = tokio::time::timeout(per_call_timeout, provider.chat(&msgs)).await;
+    match first {
+        Ok(Ok(raw)) => {
+            if let Ok(v) = parse_json::<T>(&raw) {
+                return Ok((v, approx_tokens(&raw), 1));
+            }
+            // Attempt 2: corrective nudge
+            let retry_user = format!(
+                "{user}\n\nPrevious output was not valid JSON. \
+                 Re-output strict JSON only, no prose, no fences."
+            );
+            let retry_msgs = build_messages(system, &retry_user);
+            let second = tokio::time::timeout(per_call_timeout, provider.chat(&retry_msgs)).await;
+            match second {
+                Ok(Ok(raw2)) => parse_json::<T>(&raw2)
+                    .map(|v| (v, approx_tokens(&raw2), 2))
+                    .map_err(|_| {
+                        let truncated = if raw2.len() > 4096 {
+                            let end = raw2.floor_char_boundary(4096);
+                            format!("{}…", &raw2[..end])
+                        } else {
+                            raw2.clone()
+                        };
+                        ChatJsonError::Parse(truncated)
+                    }),
+                Ok(Err(e)) => Err(ChatJsonError::Llm(e)),
+                Err(_) => Err(ChatJsonError::Timeout(timeout_ms(per_call_timeout))),
+            }
+        }
+        Ok(Err(e)) => Err(ChatJsonError::Llm(e)),
+        Err(_) => Err(ChatJsonError::Timeout(timeout_ms(per_call_timeout))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_json_markdown_fences() {
+        let raw = "```json\n{\"a\":1}\n```";
+        let v: serde_json::Value = parse_json(raw).unwrap();
+        assert_eq!(v["a"], 1);
+    }
+
+    #[test]
+    fn strips_plain_fences() {
+        let raw = "```\n{\"a\":2}\n```";
+        let v: serde_json::Value = parse_json(raw).unwrap();
+        assert_eq!(v["a"], 2);
+    }
+
+    #[test]
+    fn finds_brace_span_in_prose() {
+        let raw = "Here is the JSON: {\"x\":42} as requested.";
+        let v: serde_json::Value = parse_json(raw).unwrap();
+        assert_eq!(v["x"], 42);
+    }
+
+    #[test]
+    fn returns_error_on_no_brace() {
+        let result = parse_json::<serde_json::Value>("no json here");
+        assert!(matches!(result, Err(ParseError::NoBraceSpan)));
+    }
+
+    #[test]
+    fn handles_nested_braces() {
+        let raw = r#"{"outer":{"inner":1}}"#;
+        let v: serde_json::Value = parse_json(raw).unwrap();
+        assert_eq!(v["outer"]["inner"], 1);
+    }
+}

--- a/crates/zeph-core/src/quality/pipeline.rs
+++ b/crates/zeph-core/src/quality/pipeline.rs
@@ -1,0 +1,183 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `SelfCheckPipeline`: orchestrates the Proposer → Checker MARCH pipeline.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use zeph_llm::any::AnyProvider;
+
+use super::checker::run_checker;
+use super::config::{QualityConfig, TriggerPolicy};
+use super::proposer::run_proposer;
+use super::types::{AssertionVerdict, SelfCheckReport, SkipReason, StageOutcome, VerdictStatus};
+
+/// Collected retrieved-memory context for a turn.
+///
+/// All fields hold borrowed slices from message parts so no allocation is needed
+/// beyond the joining step.
+#[derive(Debug, Default)]
+pub struct RetrievedContext<'a> {
+    /// Semantic recall fragments.
+    pub recall: Vec<&'a str>,
+    /// Graph/known-facts fragments.
+    pub graph_facts: Vec<&'a str>,
+    /// Cross-session memory fragments.
+    pub cross_session: Vec<&'a str>,
+    /// Compaction/conversation summaries.
+    pub summaries: Vec<&'a str>,
+}
+
+impl RetrievedContext<'_> {
+    /// Returns `true` when no retrieved context was found for this turn.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.recall.is_empty()
+            && self.graph_facts.is_empty()
+            && self.cross_session.is_empty()
+            && self.summaries.is_empty()
+    }
+
+    /// Concatenate all fragments with the given separator.
+    #[must_use]
+    pub fn joined(&self, sep: &str) -> String {
+        let parts: Vec<&str> = self
+            .recall
+            .iter()
+            .chain(&self.graph_facts)
+            .chain(&self.cross_session)
+            .chain(&self.summaries)
+            .copied()
+            .collect();
+        parts.join(sep)
+    }
+}
+
+/// MARCH self-check pipeline.
+///
+/// Built once per active provider via [`SelfCheckPipeline::build`] and stored on the agent.
+/// Rebuilt whenever the active provider changes.
+pub struct SelfCheckPipeline {
+    pub(crate) cfg: QualityConfig,
+    proposer: AnyProvider,
+    /// Separate instance with prompt-cache emission suppressed (H3).
+    checker: AnyProvider,
+}
+
+impl SelfCheckPipeline {
+    /// Reference to the pipeline config (used by the turn-level hook).
+    pub(crate) fn cfg_ref(&self) -> &QualityConfig {
+        &self.cfg
+    }
+}
+
+impl SelfCheckPipeline {
+    /// Build the pipeline from the given config and main provider.
+    ///
+    /// In MVP, `proposer_provider` / `checker_provider` config fields are advisory no-ops;
+    /// the main provider is used for both roles.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error string if config validation fails.
+    pub fn build(config: &QualityConfig, main_provider: &AnyProvider) -> Result<Arc<Self>, String> {
+        config.validate().map_err(|e| e.to_string())?;
+        let proposer = main_provider.clone();
+        let checker = if config.cache_disabled_for_checker {
+            main_provider.with_prompt_cache_disabled()
+        } else {
+            main_provider.clone()
+        };
+        Ok(Arc::new(Self {
+            cfg: config.clone(),
+            proposer,
+            checker,
+        }))
+    }
+
+    /// Run the full self-check pipeline for one turn.
+    ///
+    /// Returns a [`SelfCheckReport`] whether or not assertions were found or flagged.
+    pub async fn run(
+        &self,
+        response: &str,
+        retrieved_context: RetrievedContext<'_>,
+        user_query: &str,
+        turn_id: u64,
+    ) -> SelfCheckReport {
+        let started = Instant::now();
+        let per_call = Duration::from_millis(self.cfg.per_call_timeout_ms);
+
+        // Apply trigger policy
+        if self.cfg.trigger == TriggerPolicy::HasRetrieval && retrieved_context.is_empty() {
+            return SelfCheckReport {
+                turn_id,
+                assertions: vec![],
+                verdicts: vec![],
+                flagged_ids: vec![],
+                latency_ms: u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+                proposer_tokens: 0,
+                checker_tokens: 0,
+                proposer_outcome: StageOutcome::Skipped(SkipReason::NoRetrievedContext),
+                checker_outcome: StageOutcome::Skipped(SkipReason::NoRetrievedContext),
+                parse_retries: 0,
+            };
+        }
+
+        // Proposer stage
+        let (assertions, p_tokens, p_outcome, p_retries) =
+            run_proposer(&self.proposer, response, self.cfg.max_assertions, per_call).await;
+
+        if assertions.is_empty() {
+            return SelfCheckReport {
+                turn_id,
+                assertions,
+                verdicts: vec![],
+                flagged_ids: vec![],
+                latency_ms: u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+                proposer_tokens: p_tokens,
+                checker_tokens: 0,
+                proposer_outcome: p_outcome,
+                checker_outcome: StageOutcome::Skipped(SkipReason::NoAssistantText),
+                parse_retries: p_retries,
+            };
+        }
+
+        let evidence = retrieved_context.joined("\n\n");
+
+        // Checker stage
+        let (verdicts, c_tokens, c_outcome, c_retries) =
+            run_checker(&self.checker, &assertions, &evidence, user_query, per_call).await;
+
+        let flagged_ids = self.compute_flagged(&verdicts);
+
+        SelfCheckReport {
+            turn_id,
+            assertions,
+            verdicts,
+            flagged_ids,
+            latency_ms: u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+            proposer_tokens: p_tokens,
+            checker_tokens: c_tokens,
+            proposer_outcome: p_outcome,
+            checker_outcome: c_outcome,
+            parse_retries: p_retries + c_retries,
+        }
+    }
+
+    /// Compute the set of assertion IDs that should be flagged.
+    ///
+    /// Flagged = `Contradicted` OR (`status != Irrelevant` AND `evidence < min_evidence`).
+    /// `Irrelevant` verdicts are never flagged regardless of evidence score.
+    fn compute_flagged(&self, verdicts: &[AssertionVerdict]) -> Vec<u32> {
+        verdicts
+            .iter()
+            .filter(|v| {
+                v.status == VerdictStatus::Contradicted
+                    || (v.status != VerdictStatus::Irrelevant && v.evidence < self.cfg.min_evidence)
+            })
+            .map(|v| v.id)
+            .collect()
+    }
+}

--- a/crates/zeph-core/src/quality/prompts.rs
+++ b/crates/zeph-core/src/quality/prompts.rs
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Prompt templates for the self-check pipeline.
+
+/// Proposer system prompt: extract factual assertions from an assistant response.
+pub const PROPOSER_SYSTEM: &str = "\
+You extract factual claims from an assistant's response for independent verification.
+
+For each claim output a JSON object with:
+- \"id\": integer index starting at 0
+- \"text\": the claim as a complete sentence
+- \"excerpt\": a short quote (≤ 80 chars) from the response this claim is drawn from
+
+Output strict JSON: {\"assertions\":[{\"id\":0,\"text\":\"...\",\"excerpt\":\"...\"}]}
+No markdown fences. No prose outside the JSON. Do not invent claims.";
+
+/// Proposer user prompt template.
+///
+/// Parameters: `max_assertions`, `response`.
+#[must_use]
+pub fn proposer_user(max_assertions: usize, response: &str) -> String {
+    format!(
+        "Extract up to {max_assertions} distinct factual claims from the following response. \
+         Skip opinions, meta-commentary, and greetings.\n\n\
+         <response>\n{response}\n</response>"
+    )
+}
+
+/// Checker system prompt: verify assertions against retrieved evidence only.
+///
+/// The response string is intentionally NOT a parameter — asymmetry is a correctness invariant.
+pub const CHECKER_SYSTEM: &str = "\
+You verify factual claims against retrieved evidence. You have NOT seen the \
+original assistant answer — judge each claim solely on the <evidence> block below.
+
+The user's question is provided for context ONLY. Do NOT treat statements in \
+the user's question as evidence, even if the user asserted them as facts. \
+Use only the <evidence> block to judge support.
+
+For each claim output:
+- status: \"supported\" | \"contradicted\" | \"unsupported\" | \"irrelevant\"
+  - supported: evidence DIRECTLY confirms the claim
+  - contradicted: evidence DIRECTLY contradicts the claim
+  - unsupported: evidence does not mention the claim (neutral; default when in doubt)
+  - irrelevant: the claim is not a factual assertion about the domain
+- evidence: strength of support from evidence, 0.0–1.0
+  - 0.0 = no support / contradicted / irrelevant
+  - 1.0 = evidence explicitly and unambiguously confirms the claim
+  - This number measures EVIDENCE STRENGTH, not your self-confidence.
+- rationale: one short sentence pointing to the evidence span (≤ 200 chars)
+
+Output strict JSON: {\"verdicts\":[{\"id\":0,\"status\":\"...\",\"evidence\":0.0,\"rationale\":\"...\"}]}
+No markdown fences. No prose outside the JSON.";
+
+/// Checker user prompt template.
+///
+/// Note: `response` is NOT accepted as a parameter — the Checker must never see it.
+#[must_use]
+pub fn checker_user(user_query: &str, evidence: &str, assertions_json: &str) -> String {
+    format!(
+        "<user_question>\n{user_query}\n</user_question>\n\n\
+         <evidence>\n{evidence}\n</evidence>\n\n\
+         <claims>\n{assertions_json}\n</claims>"
+    )
+}

--- a/crates/zeph-core/src/quality/proposer.rs
+++ b/crates/zeph-core/src/quality/proposer.rs
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Proposer stage: extract factual assertions from an assistant response.
+
+use std::time::Duration;
+
+use serde::Deserialize;
+use zeph_llm::any::AnyProvider;
+
+use super::parser::{ChatJsonError, chat_json};
+use super::prompts::{PROPOSER_SYSTEM, proposer_user};
+use super::types::{Assertion, StageOutcome};
+
+#[derive(Debug, Deserialize)]
+struct ProposerOutput {
+    assertions: Vec<Assertion>,
+}
+
+/// Call the Proposer and return extracted assertions plus stage diagnostics.
+///
+/// Clamps the result to `max_assertions`. Returns an empty vec on parse failure
+/// with the outcome capturing the error detail.
+pub async fn run_proposer(
+    provider: &AnyProvider,
+    response: &str,
+    max_assertions: usize,
+    per_call_timeout: Duration,
+) -> (Vec<Assertion>, u64, StageOutcome, u32) {
+    let user = proposer_user(max_assertions, response);
+    match chat_json::<ProposerOutput>(provider, PROPOSER_SYSTEM, &user, per_call_timeout).await {
+        Ok((mut out, tokens, attempt)) => {
+            out.assertions.truncate(max_assertions);
+            let retries = attempt.saturating_sub(1);
+            (out.assertions, tokens, StageOutcome::Ok, retries)
+        }
+        Err(ChatJsonError::Llm(e)) => (vec![], 0, StageOutcome::LlmError { msg: e.to_string() }, 0),
+        Err(ChatJsonError::Timeout(ms)) => (vec![], 0, StageOutcome::Timeout { ms }, 0),
+        Err(ChatJsonError::Parse(raw)) => (
+            vec![],
+            0,
+            StageOutcome::ParseError { raw_truncated: raw },
+            1,
+        ),
+    }
+}

--- a/crates/zeph-core/src/quality/tests.rs
+++ b/crates/zeph-core/src/quality/tests.rs
@@ -1,0 +1,278 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::time::Duration;
+
+use zeph_llm::any::AnyProvider;
+use zeph_llm::mock::MockProvider;
+
+use super::config::{QualityConfig, TriggerPolicy};
+use super::parser::{chat_json, parse_json};
+use super::pipeline::{RetrievedContext, SelfCheckPipeline};
+use super::proposer::run_proposer;
+
+fn mock_provider(responses: Vec<&str>) -> AnyProvider {
+    AnyProvider::Mock(MockProvider::with_responses(
+        responses.into_iter().map(String::from).collect(),
+    ))
+}
+
+fn default_cfg() -> QualityConfig {
+    QualityConfig::default()
+}
+
+// ─── Parser tests ────────────────────────────────────────────────────────────
+
+#[test]
+fn parse_json_strips_markdown_fences() {
+    let raw = "```json\n{\"assertions\":[]}\n```";
+    let v: serde_json::Value = parse_json(raw).unwrap();
+    assert_eq!(v["assertions"].as_array().unwrap().len(), 0);
+}
+
+#[test]
+fn parse_json_finds_brace_span_in_prose() {
+    let raw = "Here is the result: {\"x\": 99}. Done.";
+    let v: serde_json::Value = parse_json(raw).unwrap();
+    assert_eq!(v["x"], 99);
+}
+
+#[tokio::test]
+async fn chat_json_retries_once_on_parse_failure() {
+    let valid_json = r#"{"assertions":[{"id":0,"text":"Paris is the capital of France.","excerpt":"Paris is the capital"}]}"#;
+    let provider = mock_provider(vec!["not json at all", valid_json]);
+    let result = chat_json::<serde_json::Value>(&provider, "sys", "user", Duration::from_secs(5))
+        .await
+        .unwrap();
+    // attempt=2 means retry happened
+    assert_eq!(result.2, 2);
+    assert!(result.0.get("assertions").is_some());
+}
+
+#[tokio::test]
+async fn chat_json_fails_after_two_parse_attempts() {
+    let provider = mock_provider(vec!["bad1", "bad2"]);
+    let err = chat_json::<serde_json::Value>(&provider, "sys", "user", Duration::from_secs(5))
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("failed to parse JSON"));
+}
+
+// ─── Proposer tests ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn proposer_clamps_assertions_to_max() {
+    // 15 assertions returned, max is 5
+    let mut assertions_raw: Vec<serde_json::Value> = (0..15)
+        .map(|i| {
+            serde_json::json!({
+                "id": i,
+                "text": format!("claim {i}"),
+                "excerpt": format!("ex {i}")
+            })
+        })
+        .collect();
+    let payload = serde_json::json!({ "assertions": assertions_raw }).to_string();
+    let provider = mock_provider(vec![&payload]);
+    let (assertions, _, _, _) =
+        run_proposer(&provider, "some response", 5, Duration::from_secs(5)).await;
+    assert_eq!(assertions.len(), 5);
+    // Suppress unused warning on assertions_raw
+    let _ = assertions_raw.pop();
+}
+
+// ─── Pipeline tests ───────────────────────────────────────────────────────────
+
+fn make_pipeline(cfg: &QualityConfig) -> std::sync::Arc<SelfCheckPipeline> {
+    let provider = mock_provider(vec![]);
+    SelfCheckPipeline::build(cfg, &provider).unwrap()
+}
+
+#[tokio::test]
+async fn pipeline_skips_when_no_retrieved_context_has_retrieval_trigger() {
+    let mut cfg = default_cfg();
+    cfg.trigger = TriggerPolicy::HasRetrieval;
+    cfg.self_check = true;
+    let pipeline = make_pipeline(&cfg);
+    let report = pipeline
+        .run("response text", RetrievedContext::default(), "query", 1)
+        .await;
+    assert!(matches!(
+        report.proposer_outcome,
+        super::types::StageOutcome::Skipped(super::types::SkipReason::NoRetrievedContext)
+    ));
+}
+
+#[tokio::test]
+async fn pipeline_runs_without_retrieval_when_trigger_always() {
+    let proposer_resp = r#"{"assertions":[{"id":0,"text":"Sky is blue","excerpt":"sky is blue"}]}"#;
+    let checker_resp = r#"{"verdicts":[{"id":0,"status":"supported","evidence":0.9,"rationale":"evidence confirms"}]}"#;
+    let provider = mock_provider(vec![proposer_resp, checker_resp]);
+    let mut cfg = default_cfg();
+    cfg.trigger = TriggerPolicy::Always;
+    let pipeline = SelfCheckPipeline::build(&cfg, &provider).unwrap();
+    let report = pipeline
+        .run(
+            "The sky is blue.",
+            RetrievedContext::default(),
+            "what color?",
+            1,
+        )
+        .await;
+    assert!(
+        !report.assertions.is_empty(),
+        "expected at least one assertion"
+    );
+    assert!(matches!(
+        report.proposer_outcome,
+        super::types::StageOutcome::Ok
+    ));
+}
+
+#[tokio::test]
+async fn pipeline_respects_outer_budget() {
+    // Provider with 5000ms delay; budget is 300ms
+    let mut provider = MockProvider::default();
+    provider.delay_ms = 5_000;
+    provider.default_response = r#"{"assertions":[]}"#.into();
+    let provider = AnyProvider::Mock(provider);
+    let mut cfg = default_cfg();
+    cfg.trigger = TriggerPolicy::Always;
+    cfg.latency_budget_ms = 300;
+    cfg.per_call_timeout_ms = 150; // 150 * 2 = 300 = budget
+    let pipeline = SelfCheckPipeline::build(&cfg, &provider).unwrap();
+
+    let start = std::time::Instant::now();
+    let report = pipeline
+        .run("response", RetrievedContext::default(), "query", 1)
+        .await;
+    let elapsed = start.elapsed();
+
+    // Should timeout well within 700ms total (budget + a bit of slack)
+    assert!(
+        elapsed.as_millis() < 700,
+        "expected timeout < 700ms, got {}ms",
+        elapsed.as_millis()
+    );
+    assert!(matches!(
+        report.proposer_outcome,
+        super::types::StageOutcome::Timeout { .. }
+    ));
+}
+
+#[tokio::test]
+async fn irrelevant_verdicts_not_flagged_by_low_evidence() {
+    let proposer_resp =
+        r#"{"assertions":[{"id":0,"text":"How are you?","excerpt":"how are you"}]}"#;
+    let checker_resp = r#"{"verdicts":[{"id":0,"status":"irrelevant","evidence":0.0}]}"#;
+    let provider = mock_provider(vec![proposer_resp, checker_resp]);
+    let mut cfg = default_cfg();
+    cfg.trigger = TriggerPolicy::Always;
+    let pipeline = SelfCheckPipeline::build(&cfg, &provider).unwrap();
+    let report = pipeline
+        .run("text", RetrievedContext::default(), "q", 1)
+        .await;
+    assert!(
+        report.flagged_ids.is_empty(),
+        "irrelevant verdicts must not be flagged"
+    );
+}
+
+#[tokio::test]
+async fn flagged_when_contradicted_regardless_of_evidence() {
+    let proposer_resp =
+        r#"{"assertions":[{"id":0,"text":"Sky is green","excerpt":"sky is green"}]}"#;
+    // High evidence (0.9) but status is contradicted
+    let checker_resp = r#"{"verdicts":[{"id":0,"status":"contradicted","evidence":0.9,"rationale":"evidence shows blue"}]}"#;
+    let provider = mock_provider(vec![proposer_resp, checker_resp]);
+    let mut cfg = default_cfg();
+    cfg.trigger = TriggerPolicy::Always;
+    let pipeline = SelfCheckPipeline::build(&cfg, &provider).unwrap();
+    let report = pipeline
+        .run("text", RetrievedContext::default(), "q", 1)
+        .await;
+    assert_eq!(
+        report.flagged_ids,
+        vec![0],
+        "contradicted assertions must always be flagged"
+    );
+}
+
+// ─── Checker asymmetry test ───────────────────────────────────────────────────
+
+#[test]
+fn checker_prompt_does_not_accept_response_string() {
+    // This test documents the compile-time invariant:
+    // `checker_user(user_query, evidence, assertions)` has no `response: &str` parameter.
+    // The function signature in checker.rs enforces this asymmetry property.
+    use super::prompts::checker_user;
+    let prompt = checker_user("what is x?", "evidence text", "[]");
+    assert!(prompt.contains("<evidence>"));
+    assert!(!prompt.contains("original assistant answer")); // not leaked
+}
+
+// ─── Flagging rule tests ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn unsupported_with_low_evidence_is_flagged() {
+    let proposer_resp =
+        r#"{"assertions":[{"id":0,"text":"Water is wet","excerpt":"water is wet"}]}"#;
+    // evidence = 0.3 < default min_evidence 0.6
+    let checker_resp = r#"{"verdicts":[{"id":0,"status":"unsupported","evidence":0.3}]}"#;
+    let provider = mock_provider(vec![proposer_resp, checker_resp]);
+    let mut cfg = default_cfg();
+    cfg.trigger = TriggerPolicy::Always;
+    let pipeline = SelfCheckPipeline::build(&cfg, &provider).unwrap();
+    let report = pipeline
+        .run("text", RetrievedContext::default(), "q", 1)
+        .await;
+    assert_eq!(report.flagged_ids, vec![0]);
+}
+
+#[tokio::test]
+async fn supported_with_high_evidence_not_flagged() {
+    let proposer_resp = r#"{"assertions":[{"id":0,"text":"Paris is capital","excerpt":"Paris"}]}"#;
+    let checker_resp = r#"{"verdicts":[{"id":0,"status":"supported","evidence":0.9}]}"#;
+    let provider = mock_provider(vec![proposer_resp, checker_resp]);
+    let mut cfg = default_cfg();
+    cfg.trigger = TriggerPolicy::Always;
+    let pipeline = SelfCheckPipeline::build(&cfg, &provider).unwrap();
+    let report = pipeline
+        .run("text", RetrievedContext::default(), "q", 1)
+        .await;
+    assert!(report.flagged_ids.is_empty());
+}
+
+// ─── Config validation tests ──────────────────────────────────────────────────
+
+#[test]
+fn config_validation_rejects_bad_timeout_ratio() {
+    let mut cfg = default_cfg();
+    cfg.latency_budget_ms = 1_000;
+    cfg.per_call_timeout_ms = 600; // 600 * 2 = 1200 > 1000
+    assert!(cfg.validate().is_err());
+}
+
+#[test]
+fn config_validation_accepts_valid_config() {
+    assert!(default_cfg().validate().is_ok());
+}
+
+// ─── RetrievedContext tests ───────────────────────────────────────────────────
+
+#[test]
+fn retrieved_context_is_empty_by_default() {
+    assert!(RetrievedContext::default().is_empty());
+}
+
+#[test]
+fn retrieved_context_joined_concatenates_all_fields() {
+    let ctx = RetrievedContext {
+        recall: vec!["recall text"],
+        graph_facts: vec!["fact"],
+        ..RetrievedContext::default()
+    };
+    let joined = ctx.joined(" | ");
+    assert!(joined.contains("recall text"));
+    assert!(joined.contains("fact"));
+}

--- a/crates/zeph-core/src/quality/types.rs
+++ b/crates/zeph-core/src/quality/types.rs
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Data types for the MARCH self-check pipeline.
+
+use serde::{Deserialize, Serialize};
+
+/// A single factual claim extracted from an assistant response by the Proposer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Assertion {
+    /// Unique claim index within the turn (starts at 0).
+    pub id: u32,
+    /// Full text of the claim as extracted from the response.
+    pub text: String,
+    /// Short excerpt from the original response this claim is derived from.
+    pub excerpt: String,
+}
+
+/// Verdict status for a single assertion returned by the Checker.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum VerdictStatus {
+    /// Evidence directly confirms the claim.
+    Supported,
+    /// Evidence directly contradicts the claim.
+    Contradicted,
+    /// Evidence does not mention the claim (neutral; default when in doubt).
+    Unsupported,
+    /// The claim is not a factual assertion (e.g. small talk, meta-commentary).
+    Irrelevant,
+}
+
+/// Checker verdict for a single assertion.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssertionVerdict {
+    /// Matches [`Assertion::id`].
+    pub id: u32,
+    /// Evidence strength: 0.0 = no support, 1.0 = unambiguous confirmation.
+    ///
+    /// This is evidence strength from the retrieved context, NOT judge self-confidence.
+    pub evidence: f32,
+    /// Verdict classification.
+    pub status: VerdictStatus,
+    /// Short rationale pointing to an evidence span (≤ 200 chars).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rationale: Option<String>,
+}
+
+/// Reason the pipeline was skipped for this turn.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum SkipReason {
+    /// No assistant message found in turn (tool-only turn or error bail-out).
+    NoAssistantText,
+    /// Trigger policy is `has_retrieval` but no retrieved context was found.
+    NoRetrievedContext,
+    /// Response exceeded `max_response_chars`; too large to check.
+    ResponseTooLong { chars: usize },
+    /// Feature is disabled via config.
+    FeatureDisabled,
+    /// Overall latency budget was exhausted before pipeline could run.
+    BudgetExhausted,
+    /// Provider was unavailable (not wired up or error at startup).
+    ProviderUnavailable,
+}
+
+/// Outcome of a single pipeline stage (Proposer or Checker call).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum StageOutcome {
+    /// Stage completed successfully.
+    Ok,
+    /// Stage was skipped.
+    Skipped(SkipReason),
+    /// Stage timed out.
+    Timeout { ms: u64 },
+    /// LLM returned output that could not be parsed after retry.
+    /// Raw text truncated to 4096 chars to keep debug dumps small.
+    ParseError { raw_truncated: String },
+    /// LLM returned an error.
+    LlmError { msg: String },
+}
+
+/// Full self-check report for one turn.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SelfCheckReport {
+    /// Turn identifier (matches the agent turn counter).
+    pub turn_id: u64,
+    /// Assertions extracted by the Proposer.
+    pub assertions: Vec<Assertion>,
+    /// Verdicts from the Checker, one per assertion.
+    pub verdicts: Vec<AssertionVerdict>,
+    /// IDs of assertions that were flagged (contradicted or unsupported with low evidence).
+    pub flagged_ids: Vec<u32>,
+    /// Total wall-clock latency for the pipeline (ms).
+    pub latency_ms: u64,
+    /// Approximate tokens consumed by the Proposer call.
+    pub proposer_tokens: u64,
+    /// Approximate tokens consumed by the Checker call.
+    pub checker_tokens: u64,
+    /// Outcome of the Proposer stage.
+    pub proposer_outcome: StageOutcome,
+    /// Outcome of the Checker stage.
+    pub checker_outcome: StageOutcome,
+    /// Number of JSON parse retries across both stages.
+    pub parse_retries: u32,
+}

--- a/crates/zeph-llm/src/any.rs
+++ b/crates/zeph-llm/src/any.rs
@@ -229,6 +229,28 @@ impl AnyProvider {
         }
     }
 
+    /// Return a clone of this provider with prompt-cache emission suppressed.
+    ///
+    /// For Claude, this disables explicit `cache_control` emission in outgoing requests —
+    /// the Checker's requests will not carry cache-control markers, preventing cache sharing
+    /// with the Solver's requests (MARCH asymmetry invariant).
+    ///
+    /// For `OpenAI`: uses automatic server-side prompt caching triggered by request shape;
+    /// there is no `cache_control` field to suppress in the request body. This method is a
+    /// documented no-op clone for `OpenAI` — cache separation relies on the distinct
+    /// system prompts used by Proposer and Checker, which produce different cache keys.
+    ///
+    /// For Ollama, Candle, Gemini, and all other providers: no-op clone.
+    #[must_use]
+    pub fn with_prompt_cache_disabled(&self) -> Self {
+        match self {
+            Self::Claude(p) => Self::Claude(p.clone().with_cache_user_messages(false)),
+            // OpenAI: no request-body opt-out for server-side automatic caching; no-op clone.
+            // Cache separation is achieved via distinct system prompts (Proposer ≠ Checker).
+            other => other.clone(),
+        }
+    }
+
     /// Propagate a status sender to the inner provider (where supported).
     pub fn set_status_tx(&mut self, tx: StatusTx) {
         match self {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2267,8 +2267,24 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     };
 
     // Wire supervisor config so concurrency limits and turn-boundary abort are applied (#2883).
+    let agent = agent.with_supervisor_config(&config.agent.supervisor);
+
+    #[cfg(feature = "self-check")]
+    let agent = {
+        let pipeline = if config.quality.self_check {
+            zeph_core::quality::SelfCheckPipeline::build(
+                &zeph_core::quality::QualityConfig::from(&config.quality),
+                &provider,
+            )
+            .map_err(|e| anyhow::anyhow!("self-check pipeline init failed: {e}"))
+            .ok()
+        } else {
+            None
+        };
+        agent.with_quality_pipeline(pipeline)
+    };
+
     let agent = agent
-        .with_supervisor_config(&config.agent.supervisor)
         .build()
         .map_err(|e| anyhow::anyhow!("agent construction failed: {e}"))?;
 


### PR DESCRIPTION
## Summary

- Implements a simplified MARCH information-asymmetry self-check pipeline (#2352): after each LLM response, a Proposer sub-agent decomposes the output into atomic assertions, and a Checker validates them against retrieved memory context in isolation (without seeing the original response), breaking confirmation bias
- Updates reliability scoring framework (#2285): `coverage-status.md` gains four reliability columns (C/R/P/S) with `—/WEAK/OK/STRONG` scale and per-dimension thresholds; playbook added at `.local/testing/playbooks/self-check.md`

## Architecture decisions

- New `self-check` feature flag, opt-in, included in `full` bundle — disabled by default (`[quality] self_check = false`)
- Turn-level hook in `process_user_message_inner` covers native loop, cache-hit path, and all future loops
- Checker asymmetry enforced at the type level: `run_checker` has no `response` parameter — compile-time invariant
- `AnyProvider::with_prompt_cache_disabled()`: Claude suppresses `cache_control` markers on Checker calls; OpenAI has no cache_control field (documented no-op)
- `collect_retrieved_context()` dual-path: typed `MessagePart::{Recall,Summary,CrossSession}` variants + legacy `Role::System` prefix-matched messages
- Best-effort JSON parser with 1 retry; `floor_char_boundary(4096)` truncation (UTF-8 safe)
- `async_run = true` emits `tracing::warn!` noting unimplemented state (field kept for schema stability)

## Known limitations (follow-up issues)

- `async_run = true` runs synchronously in MVP — background spawn via `TaskClass::Enrichment` deferred
- `daemon.rs` and `acp.rs` agent construction paths not wired — cross-mode consistency follow-up
- Ollama KV-cache suppression not yet implemented on Checker path

## LLM serialization gate

This PR modifies Claude and OpenAI request builders (`with_prompt_cache_disabled()`). A live-session smoke test is required before merge per `.claude/rules/branching.md`:

```bash
cargo run --features full -- --config .local/config/testing.toml
# Enable: [quality] self_check = true, trigger = "always"
# Verify: no 400/422 errors, debug dump shows well-formed messages array
```

## Test plan

- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --features full --lib --bins` — 8744 tests pass
- [ ] `cargo clippy --all-targets --features full --workspace -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean
- [ ] Live session smoke test with `self_check = true, trigger = "always"` — verify Proposer/Checker calls appear in debug dump, no API errors
- [ ] Verify `self_check = false` (default) produces no pipeline activity
- [ ] Verify timeout path emits `[self-check: skipped (timeout)]` marker

Closes #2352
Closes #2285