### PR TITLE
feat(quality): add migrate-config step 22 and --init step_quality for [quality] section

### DIFF
--- a/crates/zeph-config/src/migrate.rs
+++ b/crates/zeph-config/src/migrate.rs
@@ -2186,6 +2186,52 @@ pub fn migrate_mcp_elicitation_config(toml_src: &str) -> Result<MigrationResult,
     })
 }
 
+/// Add a commented-out `[quality]` block if the config lacks it (#3228).
+///
+/// Introduced alongside the MARCH self-check pipeline (#3226). All `QualityConfig`
+/// fields have `#[serde(default)]` so existing configs parse without changes; this
+/// migration only surfaces the section so users can discover and enable it.
+///
+/// # Errors
+///
+/// This function is infallible in practice; the `Result` return type matches the
+/// migration function convention for use in chained pipelines.
+pub fn migrate_quality_config(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    // Idempotency: line-anchored check avoids false-positives on [quality.foo] subtables.
+    if toml_src
+        .lines()
+        .any(|l| l.trim() == "[quality]" || l.trim() == "# [quality]")
+    {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            added_count: 0,
+            sections_added: Vec::new(),
+        });
+    }
+
+    let comment = "\n# [quality] — MARCH Proposer+Checker self-check pipeline (#3226, #3228).\n\
+         # [quality]\n\
+         # self_check = false                    # enable post-response self-check\n\
+         # trigger = \"has_retrieval\"             # has_retrieval | always | manual\n\
+         # latency_budget_ms = 4000              # hard ceiling for the whole pipeline\n\
+         # proposer_provider = \"\"                # optional: provider name from [[llm.providers]]\n\
+         # checker_provider = \"\"                 # optional: provider name from [[llm.providers]]\n\
+         # min_evidence = 0.6                    # 0.0..1.0; below → flag assertion\n\
+         # async_run = false                     # true = fire-and-forget (non-blocking)\n\
+         # per_call_timeout_ms = 2000            # per-LLM-call timeout\n\
+         # max_assertions = 12                   # maximum assertions extracted from one response\n\
+         # max_response_chars = 8000             # skip pipeline when response exceeds this\n\
+         # cache_disabled_for_checker = true     # suppress prompt-cache on Checker provider\n\
+         # flag_marker = \"[verify]\"              # marker appended when assertions are flagged\n";
+    let output = format!("{toml_src}{comment}");
+
+    Ok(MigrationResult {
+        output,
+        added_count: 1,
+        sections_added: vec!["quality".to_owned()],
+    })
+}
+
 // Helper to create a formatted value (used in tests).
 #[cfg(test)]
 fn make_formatted_str(s: &str) -> Value {
@@ -3439,6 +3485,35 @@ prompt_cache_ttl = "1h"
         // Edge case: `[mcp]` at EOF with no `\n` — replacen would be a no-op.
         let src = "[mcp]";
         let result = migrate_mcp_elicitation_config(src).expect("migrate");
+        assert_eq!(result.added_count, 0);
+        assert_eq!(result.output, src);
+    }
+
+    // ── migrate_quality_config ────────────────────────────────────────────────
+
+    #[test]
+    fn migrate_quality_adds_block_when_absent() {
+        let src = "[agent]\nname = \"Zeph\"\n";
+        let result = migrate_quality_config(src).expect("migrate");
+        assert_eq!(result.added_count, 1);
+        assert!(result.sections_added.contains(&"quality".to_owned()));
+        assert!(result.output.contains("# [quality]"));
+        assert!(result.output.contains("self_check = false"));
+        assert!(result.output.contains("trigger = \"has_retrieval\""));
+    }
+
+    #[test]
+    fn migrate_quality_idempotent_on_commented_block() {
+        let src = "[agent]\nname = \"Zeph\"\n# [quality]\n# self_check = false\n";
+        let result = migrate_quality_config(src).expect("migrate");
+        assert_eq!(result.added_count, 0);
+        assert_eq!(result.output, src);
+    }
+
+    #[test]
+    fn migrate_quality_idempotent_on_active_section() {
+        let src = "[agent]\nname = \"Zeph\"\n[quality]\nself_check = true\n";
+        let result = migrate_quality_config(src).expect("migrate");
         assert_eq!(result.added_count, 0);
         assert_eq!(result.output, src);
     }

--- a/crates/zeph-core/src/config.rs
+++ b/crates/zeph-core/src/config.rs
@@ -30,6 +30,7 @@ pub use zeph_config::{
     MicrocompactConfig, PersonaConfig, TrajectoryConfig, TreeConfig,
 };
 pub use zeph_config::{DiagnosticSeverity, DiagnosticsConfig, HoverConfig, LspConfig};
+pub use zeph_config::{QualityConfig, TriggerPolicy};
 pub use zeph_config::{TelemetryBackend, TelemetryConfig};
 
 pub use zeph_config::{

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -10,9 +10,9 @@ use zeph_core::config::migrate::{
     migrate_egress_config, migrate_forgetting_config, migrate_magic_docs_config,
     migrate_mcp_elicitation_config, migrate_mcp_trust_levels, migrate_microcompact_config,
     migrate_orchestration_persistence, migrate_otel_filter, migrate_planner_model_to_provider,
-    migrate_sandbox_config, migrate_session_recap_config, migrate_shell_transactional,
-    migrate_stt_to_provider, migrate_supervisor_config, migrate_telemetry_config,
-    migrate_vigil_config,
+    migrate_quality_config, migrate_sandbox_config, migrate_session_recap_config,
+    migrate_shell_transactional, migrate_stt_to_provider, migrate_supervisor_config,
+    migrate_telemetry_config, migrate_vigil_config,
 };
 
 /// Handle the `zeph migrate-config` command.
@@ -118,9 +118,13 @@ pub(crate) fn handle_migrate_config(
     let mcp_elicitation_result = migrate_mcp_elicitation_config(&after_session_recap)?;
     let after_mcp_elicitation = mcp_elicitation_result.output;
 
-    // Step 22: add missing default keys as commented-out entries.
+    // Step 22: add commented-out [quality] block if absent (#3228).
+    let quality_result = migrate_quality_config(&after_mcp_elicitation)?;
+    let after_quality = quality_result.output;
+
+    // Step 23: add missing default keys as commented-out entries.
     let migrator = ConfigMigrator::new();
-    let result = migrator.migrate(&after_mcp_elicitation)?;
+    let result = migrator.migrate(&after_quality)?;
 
     if diff {
         print_diff(&input, &result.output);
@@ -202,6 +206,9 @@ pub(crate) fn handle_migrate_config(
             eprintln!(
                 "MCP elicitation migration: added commented-out elicitation keys under [mcp]."
             );
+        }
+        if quality_result.added_count > 0 {
+            eprintln!("Quality migration: added commented-out [quality] block.");
         }
         eprintln!(
             "Migration would add {} entries ({} sections).",

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -8,7 +8,7 @@ use zeph_core::config::{
     AcpConfig, ChannelSkillsConfig, Config, DiscordConfig, LlmConfig, LlmRoutingStrategy,
     McpServerConfig, McpTrustLevel, MemoryConfig, OrchestrationConfig, ProviderEntry, ProviderKind,
     ProviderName, PruningStrategy, SemanticConfig, SessionsConfig, SlackConfig, TelegramConfig,
-    VaultConfig,
+    TriggerPolicy, VaultConfig,
 };
 use zeph_llm::{GeminiThinkingLevel, ThinkingConfig};
 use zeph_subagent::def::{MemoryScope, PermissionMode};
@@ -180,6 +180,10 @@ pub(crate) struct WizardState {
     // MCP elicitation (#3141)
     pub(crate) mcp_elicitation_enabled: bool,
     pub(crate) mcp_elicitation_warn_sensitive: bool,
+    // MARCH self-check pipeline (#3226, #3228)
+    pub(crate) quality_self_check: bool,
+    pub(crate) quality_trigger: String,
+    pub(crate) quality_latency_budget_ms: u64,
     // Context strategy (#2288)
     pub(crate) context_strategy: String,
     // MCP tool discovery (#2321)
@@ -351,6 +355,9 @@ impl Default for WizardState {
             recap_on_resume: true,
             mcp_elicitation_enabled: false,
             mcp_elicitation_warn_sensitive: true,
+            quality_self_check: false,
+            quality_trigger: "has_retrieval".to_owned(),
+            quality_latency_budget_ms: 4_000,
             context_strategy: "full_history".to_owned(),
             mcp_discovery_strategy: "none".to_owned(),
             mcp_discovery_top_k: 10,
@@ -444,6 +451,7 @@ pub fn run(output: Option<PathBuf>) -> anyhow::Result<()> {
     step_telemetry(&mut state)?;
     step_prometheus(&mut state)?;
     step_session_recap(&mut state)?;
+    step_quality(&mut state)?;
     step_review_and_write(&state, output)?;
 
     Ok(())
@@ -704,6 +712,13 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
     config.session.recap.on_resume = state.recap_on_resume;
     config.mcp.elicitation_enabled = state.mcp_elicitation_enabled;
     config.mcp.elicitation_warn_sensitive_fields = state.mcp_elicitation_warn_sensitive;
+    config.quality.self_check = state.quality_self_check;
+    config.quality.trigger = match state.quality_trigger.as_str() {
+        "always" => TriggerPolicy::Always,
+        "manual" => TriggerPolicy::Manual,
+        _ => TriggerPolicy::HasRetrieval,
+    };
+    config.quality.latency_budget_ms = state.quality_latency_budget_ms;
     config.memory.context_strategy = match state.context_strategy.as_str() {
         "memory_first" => zeph_core::config::ContextStrategy::MemoryFirst,
         "adaptive" => zeph_core::config::ContextStrategy::Adaptive,
@@ -1356,6 +1371,58 @@ fn step_session_recap(state: &mut WizardState) -> anyhow::Result<()> {
             )
             .default(true)
             .interact()?;
+    }
+
+    println!();
+    Ok(())
+}
+
+fn step_quality(state: &mut WizardState) -> anyhow::Result<()> {
+    println!("== Quality Self-Check (MARCH) ==\n");
+    println!("Post-response Proposer+Checker pipeline that flags unsupported claims.");
+    println!("Adds LLM latency/cost per turn; off by default.\n");
+
+    state.quality_self_check = Confirm::new()
+        .with_prompt("Enable post-response self-check?")
+        .default(false)
+        .interact()?;
+
+    if state.quality_self_check {
+        println!(
+            "Note: dedicated proposer_provider / checker_provider can be set by editing \
+             `proposer_provider` / `checker_provider` in config.toml; \
+             both default to the primary provider when empty."
+        );
+
+        let triggers = [
+            "has_retrieval (only when the turn used retrieval)",
+            "always",
+            "manual",
+        ];
+        let idx = Select::new()
+            .with_prompt("When to trigger the pipeline")
+            .items(triggers)
+            .default(0)
+            .interact()?;
+        state.quality_trigger = match idx {
+            1 => "always".into(),
+            2 => "manual".into(),
+            _ => "has_retrieval".into(),
+        };
+
+        state.quality_latency_budget_ms = Input::new()
+            .with_prompt("Total pipeline latency budget (ms)")
+            .default(4_000u64)
+            .validate_with(|v: &u64| -> Result<(), &str> {
+                if *v < 2_000 {
+                    Err("must be >= 2000ms (one per-call timeout)")
+                } else if *v > 60_000 {
+                    Err("must be <= 60000ms")
+                } else {
+                    Ok(())
+                }
+            })
+            .interact_text()?;
     }
 
     println!();
@@ -2213,5 +2280,52 @@ mod tests {
             let config = build_config(&state);
             assert_eq!(config.tools.sandbox.profile, expected, "input={input}");
         }
+    }
+
+    #[test]
+    fn build_config_quality_disabled_by_default() {
+        let state = WizardState {
+            vault_backend: "env".into(),
+            ..WizardState::default()
+        };
+        let config = build_config(&state);
+        assert!(!config.quality.self_check);
+        assert_eq!(config.quality.trigger, TriggerPolicy::HasRetrieval);
+    }
+
+    #[test]
+    fn build_config_quality_enabled_with_always() {
+        let state = WizardState {
+            quality_self_check: true,
+            quality_trigger: "always".into(),
+            quality_latency_budget_ms: 6_000,
+            ..single_provider_state()
+        };
+        let config = build_config(&state);
+        assert!(config.quality.self_check);
+        assert_eq!(config.quality.trigger, TriggerPolicy::Always);
+        assert_eq!(config.quality.latency_budget_ms, 6_000);
+    }
+
+    #[test]
+    fn build_config_quality_trigger_manual() {
+        let state = WizardState {
+            quality_self_check: true,
+            quality_trigger: "manual".into(),
+            ..single_provider_state()
+        };
+        let config = build_config(&state);
+        assert_eq!(config.quality.trigger, TriggerPolicy::Manual);
+    }
+
+    #[test]
+    fn build_config_quality_trigger_unknown_falls_back_to_has_retrieval() {
+        let state = WizardState {
+            quality_self_check: true,
+            quality_trigger: "unknown_value".into(),
+            ..single_provider_state()
+        };
+        let config = build_config(&state);
+        assert_eq!(config.quality.trigger, TriggerPolicy::HasRetrieval);
     }
 }


### PR DESCRIPTION
## Summary

Closes #3228.

PR #3226 added the MARCH self-check quality pipeline but two integration points were missing. This PR adds them:

- **`migrate_quality_config`** (`crates/zeph-config/src/migrate.rs`): migration step 22 that appends a commented-out `[quality]` block to configs that lack it. Line-anchored idempotency check (no false-positives on `[quality.foo]` subtables). Direct string append — no `DocumentMut` round-trip that would reformat user config.
- **`step_quality()`** (`src/init/mod.rs`): `--init` wizard step prompting for `self_check` (Confirm), `trigger` (Select: `has_retrieval`/`always`/`manual`), and `latency_budget_ms` (Input, validated `[2000, 60000]`). When `self_check=true`, prints an info note that `proposer_provider` and `checker_provider` must also be configured.
- **Re-export** `QualityConfig` and `TriggerPolicy` from `zeph-core/src/config.rs`.

## Test plan

- [x] `cargo nextest run -p zeph-config -E 'test(migrate_quality)'` — 3/3 pass (absent, commented, active)
- [x] `cargo nextest run -p zeph -E 'test(build_config_quality)'` — 4/4 pass (all 3 TriggerPolicy variants + defaults)
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 8413/8413 pass