### PR TITLE
fix(quality): prevent double response_end when MARCH flag_marker fires in --json mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   key collisions. Keys now use the raw `field.name` as specified by the MCP schema; sanitization
   is retained only for Telegram display labels. Parity restored with the CLI channel.
 
+- **fix(quality): MARCH `flag_marker` no longer emits extra `response_chunk`/`response_end` after `response_end` in `--json` mode** (#3231) — `quality_hook.rs` now calls `channel.send_chunk()` instead of `channel.send()` at the flag-marker injection sites, and `agent/mod.rs` calls `flush_chunks()` after `run_self_check_for_turn()` returns. This ensures the `[verify]` marker is emitted as part of the primary response stream with a single `response_end`.
+
 - **fix(commands): `/plugins` slash command now routed through `CommandRegistry`** (#3215) — added
   `PluginsCommand` handler in `zeph-commands` that delegates to `Agent::handle_plugins` via
   `AgentAccess`. `/plugins overlay|list|add|remove` are now dispatched correctly instead of falling

--- a/crates/zeph-channels/src/json_cli.rs
+++ b/crates/zeph-channels/src/json_cli.rs
@@ -400,6 +400,21 @@ mod tests {
         assert!(ch.supports_exit());
     }
 
+    #[tokio::test]
+    async fn flag_marker_appended_via_send_chunk_has_single_end() {
+        // Simulates: streaming response + self-check appends flag marker, then single flush.
+        let (sink, read) = make_test_sink();
+        let mut ch = JsonCliChannel::new(Arc::clone(&sink), false);
+        ch.send_chunk("The answer is 42.").await.unwrap();
+        ch.send_chunk(" [verify]").await.unwrap();
+        ch.flush_chunks().await.unwrap();
+        let lines = read();
+        assert_eq!(lines.len(), 3, "expected 2 chunks + 1 end; got: {lines:?}");
+        assert_eq!(event_field(&lines[0], "event"), "response_chunk");
+        assert_eq!(event_field(&lines[1], "event"), "response_chunk");
+        assert_eq!(event_field(&lines[2], "event"), "response_end");
+    }
+
     #[test]
     fn try_recv_returns_none_when_no_input() {
         let (sink, _) = make_test_sink();

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -1425,6 +1425,9 @@ impl<C: Channel> Agent<C> {
         #[cfg(feature = "self-check")]
         if let Some(pipeline) = self.quality.clone() {
             self.run_self_check_for_turn(pipeline, turn.id().0).await;
+            // Flush any chunk appended by the self-check hook (e.g. flag_marker).
+            // No-op when the hook did not append anything (pending_chunks = false).
+            let _ = self.channel.flush_chunks().await;
         }
 
         // Collect llm_chat_ms and tool_exec_ms from MetricsState.pending_timings (accumulated

--- a/crates/zeph-core/src/agent/quality_hook.rs
+++ b/crates/zeph-core/src/agent/quality_hook.rs
@@ -79,7 +79,10 @@ impl<C: Channel> Agent<C> {
                 budget_ms = cfg.latency_budget_ms,
                 "self-check timed out at outer budget"
             );
-            let _ = self.channel.send(" [self-check: skipped (timeout)]").await;
+            let _ = self
+                .channel
+                .send_chunk(" [self-check: skipped (timeout)]")
+                .await;
             return;
         };
 
@@ -95,7 +98,7 @@ impl<C: Channel> Agent<C> {
 
         if flagged > 0 {
             let marker = format!(" {}", cfg.flag_marker);
-            let _ = self.channel.send(&marker).await;
+            let _ = self.channel.send_chunk(&marker).await;
         }
     }
 }


### PR DESCRIPTION
## Summary

- `quality_hook.rs` called `channel.send(&marker)` after `process_response()` had already flushed `response_end`
- `JsonCliChannel::send()` unconditionally emits `ResponseChunk + ResponseEnd`, producing a second pair and breaking the `--json` protocol contract
- Fix: change both `channel.send()` call sites in `quality_hook.rs` to `send_chunk()`, then call `flush_chunks()` in `agent/mod.rs` after `run_self_check_for_turn()` returns

## Test plan

- [ ] New regression test `flag_marker_appended_via_send_chunk_has_single_end` in `zeph-channels` verifies chunk+marker+single-end ordering
- [ ] Existing tests `flush_chunks_emits_end_after_chunk`, `send_resets_pending_and_subsequent_flush_is_noop` remain green
- [ ] 8412 workspace tests pass

Closes #3231