### PR TITLE
fix(llm): defer system msg injection during tool call chains (#3235)

### DIFF
--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -719,17 +719,23 @@ impl<C: Channel> Agent<C> {
         // the LLM. Stale notes are cleared unconditionally each iteration so they
         // never accumulate when no new notes were produced.
         // Role::System ensures they are skipped by tool-pair summarization.
+        //
+        // Skip injection when the last non-System message contains ToolResult parts:
+        // OpenAI rejects a System message placed between Assistant(tool_calls) and
+        // User(tool_results) with HTTP 400.
         if self.session.lsp_hooks.is_some() {
             self.remove_lsp_messages();
-            let tc = std::sync::Arc::clone(&self.metrics.token_counter);
-            if let Some(ref mut lsp) = self.session.lsp_hooks
-                && let Some(note_text) = lsp.drain_notes(&tc)
-            {
-                self.push_message(zeph_llm::provider::Message::from_legacy(
-                    zeph_llm::provider::Role::System,
-                    &note_text,
-                ));
-                self.recompute_prompt_tokens();
+            if !last_msg_has_tool_results(&self.msg.messages) {
+                let tc = std::sync::Arc::clone(&self.metrics.token_counter);
+                if let Some(ref mut lsp) = self.session.lsp_hooks
+                    && let Some(note_text) = lsp.drain_notes(&tc)
+                {
+                    self.push_message(zeph_llm::provider::Message::from_legacy(
+                        zeph_llm::provider::Role::System,
+                        &note_text,
+                    ));
+                    self.recompute_prompt_tokens();
+                }
             }
         }
 
@@ -3135,6 +3141,21 @@ fn skipped_output(
     }
 }
 
+/// Returns `true` when the last non-System message in `messages` contains at least one
+/// `ToolResult` part. Used to detect an active pending tool chain: injecting a System message
+/// at that point would violate the `OpenAI` message ordering constraint (HTTP 400).
+fn last_msg_has_tool_results(messages: &[Message]) -> bool {
+    messages
+        .iter()
+        .rev()
+        .find(|m| m.role != Role::System)
+        .is_some_and(|m| {
+            m.parts
+                .iter()
+                .any(|p| matches!(p, MessagePart::ToolResult { .. }))
+        })
+}
+
 // T-CRIT-02: handle_focus_tool tests — happy path, error paths, checkpoint pinning (S5 fix).
 #[cfg(test)]
 mod tests {
@@ -3142,7 +3163,9 @@ mod tests {
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{Duration, Instant};
 
-    use zeph_llm::provider::{ChatResponse, Message, Role};
+    use zeph_llm::provider::{ChatResponse, Message, MessageMetadata, MessagePart, Role};
+
+    use super::last_msg_has_tool_results;
 
     use crate::agent::Agent;
     use crate::agent::tests::agent_tests::{
@@ -3493,6 +3516,84 @@ mod tests {
             recorder.llm_count.load(Ordering::Relaxed),
             1,
             "record_chat_metrics_and_compact must call observe_llm_latency once"
+        );
+    }
+
+    #[test]
+    fn last_msg_has_tool_results_detects_pending_tool_chain() {
+        let tool_result_msg = Message {
+            role: Role::User,
+            content: String::new(),
+            parts: vec![MessagePart::ToolResult {
+                tool_use_id: "id1".to_owned(),
+                content: String::new(),
+                is_error: false,
+            }],
+            metadata: MessageMetadata::default(),
+        };
+        let messages = vec![
+            Message::from_legacy(Role::System, "sys"),
+            Message::from_legacy(Role::User, "hello"),
+            Message::from_legacy(Role::Assistant, "response"),
+            tool_result_msg,
+        ];
+        assert!(
+            last_msg_has_tool_results(&messages),
+            "must return true when last non-System message has ToolResult"
+        );
+    }
+
+    #[test]
+    fn last_msg_has_tool_results_false_when_last_is_text() {
+        let messages = vec![
+            Message::from_legacy(Role::User, "hello"),
+            Message::from_legacy(Role::Assistant, "response"),
+        ];
+        assert!(
+            !last_msg_has_tool_results(&messages),
+            "must return false when last non-System message has no ToolResult"
+        );
+    }
+
+    #[test]
+    fn last_msg_has_tool_results_ignores_trailing_system() {
+        let tool_result_msg = Message {
+            role: Role::User,
+            content: String::new(),
+            parts: vec![MessagePart::ToolResult {
+                tool_use_id: "id2".to_owned(),
+                content: String::new(),
+                is_error: false,
+            }],
+            metadata: MessageMetadata::default(),
+        };
+        let messages = vec![
+            tool_result_msg,
+            Message::from_legacy(Role::System, "lsp note"),
+        ];
+        assert!(
+            last_msg_has_tool_results(&messages),
+            "must look past trailing System messages to find ToolResult"
+        );
+    }
+
+    #[test]
+    fn last_msg_has_tool_results_empty_slice_returns_false() {
+        assert!(
+            !last_msg_has_tool_results(&[]),
+            "empty slice must return false"
+        );
+    }
+
+    #[test]
+    fn last_msg_has_tool_results_only_system_messages_returns_false() {
+        let messages = vec![
+            Message::from_legacy(Role::System, "system prompt"),
+            Message::from_legacy(Role::System, "lsp note"),
+        ];
+        assert!(
+            !last_msg_has_tool_results(&messages),
+            "slice with only System messages must return false"
         );
     }
 }

--- a/crates/zeph-llm/src/mock.rs
+++ b/crates/zeph-llm/src/mock.rs
@@ -38,6 +38,8 @@ pub struct MockProvider {
     pub name_override: Option<String>,
     /// When true, `embed()` returns `LlmError::InvalidInput` regardless of `supports_embeddings`.
     pub embed_invalid_input: bool,
+    /// When true, `chat_with_tools()` returns `LlmError::InvalidInput`.
+    pub tool_chat_invalid_input: bool,
     /// Tracks how many times `embed()` was called. Useful for verifying embed reuse.
     pub embed_call_count: Arc<std::sync::atomic::AtomicU64>,
     /// Milliseconds to sleep inside `embed()` before returning. Used to simulate slow providers.
@@ -63,6 +65,7 @@ impl Default for MockProvider {
             models: vec![],
             name_override: None,
             embed_invalid_input: false,
+            tool_chat_invalid_input: false,
             embed_call_count: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             embed_delay_ms: 0,
             fixed_entropy: None,
@@ -103,6 +106,14 @@ impl MockProvider {
     pub fn with_embed_invalid_input(mut self) -> Self {
         self.embed_invalid_input = true;
         self.supports_embeddings = true;
+        self
+    }
+
+    /// Make `chat_with_tools()` return `LlmError::InvalidInput` (simulates HTTP 400 on a
+    /// malformed message sequence). Enables testing the router's tool fallback loop guard.
+    #[must_use]
+    pub fn with_tool_chat_invalid_input(mut self) -> Self {
+        self.tool_chat_invalid_input = true;
         self
     }
 
@@ -287,6 +298,12 @@ impl LlmProvider for MockProvider {
         _tools: &[ToolDefinition],
     ) -> Result<ChatResponse, crate::LlmError> {
         *self.tool_call_count.lock().unwrap() += 1;
+        if self.tool_chat_invalid_input {
+            return Err(crate::LlmError::InvalidInput {
+                provider: self.name().to_owned(),
+                message: "invalid message sequence".into(),
+            });
+        }
         let queued = self.tool_responses.lock().unwrap().pop_front();
         if let Some(response) = queued {
             return Ok(response);

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -962,6 +962,14 @@ impl LlmProvider for OpenAiProvider {
             return Err(LlmError::RateLimited);
         }
 
+        if status == reqwest::StatusCode::BAD_REQUEST {
+            tracing::warn!("OpenAI tool chat 400 bad request: {text}");
+            return Err(LlmError::InvalidInput {
+                provider: self.name().to_owned(),
+                message: text,
+            });
+        }
+
         if !status.is_success() {
             tracing::error!("OpenAI API error {status}: {text}");
             return Err(LlmError::Other(format!(

--- a/crates/zeph-llm/src/router/mod.rs
+++ b/crates/zeph-llm/src/router/mod.rs
@@ -1845,6 +1845,14 @@ impl LlmProvider for RouterProvider {
                             false,
                             u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
                         );
+                        if e.is_invalid_input() {
+                            tracing::warn!(
+                                provider = p.name(),
+                                error = %e,
+                                "chat_with_tools: invalid input, not retrying on other providers"
+                            );
+                            return Err(e);
+                        }
                         if e.is_rate_limited() {
                             router.record_availability(p.name(), false, 0);
                         }
@@ -3287,6 +3295,53 @@ mod tests {
         let err = r.embed("test").await.unwrap_err();
 
         // The error must carry p1's name, proving p2 was never reached.
+        assert!(
+            matches!(&err, LlmError::InvalidInput { provider, .. } if provider == "p1"),
+            "expected InvalidInput from p1, got {err:?}"
+        );
+    }
+
+    // ── InvalidInput chat_with_tools break tests ───────────────────────────────
+
+    /// When a provider returns `InvalidInput` from `chat_with_tools()`, the router must break
+    /// the fallback loop immediately and return `InvalidInput` — not `NoProviders`.
+    #[tokio::test]
+    async fn chat_with_tools_invalid_input_breaks_loop_and_returns_invalid_input() {
+        use crate::mock::MockProvider;
+        use crate::provider::ToolDefinition;
+
+        let p = AnyProvider::Mock(MockProvider::default().with_tool_chat_invalid_input());
+        let r = RouterProvider::new(vec![p]).with_thompson(None);
+        let err = r
+            .chat_with_tools(&[], &[] as &[ToolDefinition])
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, LlmError::InvalidInput { .. }),
+            "expected InvalidInput, got {err:?}"
+        );
+    }
+
+    /// When a provider returns `InvalidInput` from `chat_with_tools()`, the router must NOT
+    /// fall through to the next provider.
+    #[tokio::test]
+    async fn chat_with_tools_invalid_input_does_not_fall_through_to_second_provider() {
+        use crate::mock::MockProvider;
+        use crate::provider::ToolDefinition;
+
+        let p1 = AnyProvider::Mock(
+            MockProvider::default()
+                .with_tool_chat_invalid_input()
+                .with_name("p1"),
+        );
+        let p2 = AnyProvider::Mock(MockProvider::default().with_name("p2"));
+
+        let r = RouterProvider::new(vec![p1, p2]);
+        let err = r
+            .chat_with_tools(&[], &[] as &[ToolDefinition])
+            .await
+            .unwrap_err();
+
         assert!(
             matches!(&err, LlmError::InvalidInput { provider, .. } if provider == "p1"),
             "expected InvalidInput from p1, got {err:?}"


### PR DESCRIPTION
## Summary

- Add `last_msg_has_tool_results` predicate in `native.rs`; skip LSP system note injection when inside an active tool call chain (assistant→tool response sequence)
- Map HTTP 400 to `LlmError::InvalidInput` in `openai/mod.rs` `chat_with_tools` so the router's `is_invalid_input()` guard is live for OpenAI
- Add `is_invalid_input()` early-return guard in `chat_with_tools` fallback loop in `router/mod.rs` to avoid wasting retries on structural errors
- Add mock support (`tool_chat_invalid_input`) and two router unit tests

## Root cause

OpenAI requires `assistant[tool_calls]` to be immediately followed by the corresponding `tool` response messages. LSP diagnostic notes (`Role::System`) were appended unconditionally at the start of each tool loop iteration, breaking that invariant. The router then retried all providers before returning `LlmError::NoProviders`, masking the real error.

## Test plan

- [ ] `last_msg_has_tool_results` predicate: 5 unit tests covering empty slice, all-system, positive, negative, and trailing-system cases
- [ ] Router `chat_with_tools` invalid-input guard: 2 unit tests (breaks loop, does not fall through to second provider)
- [ ] `cargo nextest run --workspace --lib --bins`: 8426 passed, 20 skipped
- [ ] Live API session test required per LLM serialization gate (openai/mod.rs touched)

Closes #3235