### PR TITLE
fix(index): wire CodeRetriever into IndexState for automatic code RAG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **fix(index): wire `CodeRetriever` into `IndexState` for automatic code RAG injection** (#3236) —
+  `IndexState.retriever` was always `None` because no call path ever set it; added
+  `AgentBuilder::with_code_retriever` and `apply_code_rag_retriever` helper wired from `runner.rs`.
+  Code RAG context injection is now active when `index.enabled = true`, `budget_ratio > 0`, a
+  Qdrant backend is available, and `mcp_enabled = false`.
+
 - **fix(channels): Telegram elicitation response map uses raw field names** (#3217) — the
   `sanitize_field_key` transformation was incorrectly applied to MCP elicitation response map keys
   in the Telegram channel, causing field names with spaces or dashes to be remapped (e.g.

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -979,6 +979,42 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Wire a shared [`zeph_index::retriever::CodeRetriever`] used by the context assembler to
+    /// inject retrieved code chunks into the agent prompt.
+    ///
+    /// When unset, `fetch_code_rag` returns `Ok(None)` and no code RAG context is added to
+    /// prompts. Typically called by the binary's agent setup after the semantic code store has
+    /// been initialised.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// # use std::sync::Arc;
+    /// # use zeph_core::agent::AgentBuilder;
+    /// # fn demo(builder: AgentBuilder<impl zeph_core::Channel>,
+    /// #        retriever: Arc<zeph_index::retriever::CodeRetriever>) {
+    /// let _ = builder.with_code_retriever(retriever);
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn with_code_retriever(
+        mut self,
+        retriever: std::sync::Arc<zeph_index::retriever::CodeRetriever>,
+    ) -> Self {
+        self.index.retriever = Some(retriever);
+        self
+    }
+
+    /// Returns `true` when a [`zeph_index::retriever::CodeRetriever`] has been wired via
+    /// [`Self::with_code_retriever`].
+    ///
+    /// Primarily used by tests in external crates to assert wiring without accessing the
+    /// `pub(crate)` `IndexState` field directly.
+    #[must_use]
+    pub fn has_code_retriever(&self) -> bool {
+        self.index.retriever.is_some()
+    }
+
     // ---- Debug & Diagnostics ----
 
     /// Enable debug dump mode, writing LLM requests/responses and raw tool output to `dumper`.

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -663,6 +663,7 @@ impl McpState {
 }
 
 impl IndexState {
+    #[tracing::instrument(name = "core.index.fetch_code_rag", skip(self), fields(%query, token_budget))]
     pub(crate) async fn fetch_code_rag(
         &self,
         query: &str,

--- a/crates/zeph-index/src/error.rs
+++ b/crates/zeph-index/src/error.rs
@@ -88,6 +88,13 @@ pub enum IndexError {
     #[error("integer conversion failed: {0}")]
     IntConversion(#[from] TryFromIntError),
 
+    /// Embedding call timed out.
+    ///
+    /// Raised by [`crate::retriever::CodeRetriever`] when `provider.embed()` does not
+    /// complete within the configured `embed_timeout_secs`.
+    #[error("embedding timed out after {0}s")]
+    EmbedTimeout(u64),
+
     /// Generic catch-all error for cases that do not fit the variants above.
     ///
     /// Used internally for errors like a panicking background thread (e.g., the

--- a/crates/zeph-index/src/retriever.rs
+++ b/crates/zeph-index/src/retriever.rs
@@ -82,6 +82,9 @@ pub struct RetrievalConfig {
     pub score_threshold: f32,
     /// Maximum fraction of `available_tokens` allocated to code chunks (0.0–1.0).
     pub budget_ratio: f32,
+    /// Maximum seconds to wait for `provider.embed()` before returning
+    /// [`crate::error::IndexError::EmbedTimeout`]. Defaults to `10`.
+    pub embed_timeout_secs: u64,
 }
 
 impl Default for RetrievalConfig {
@@ -90,6 +93,7 @@ impl Default for RetrievalConfig {
             max_chunks: 12,
             score_threshold: 0.25,
             budget_ratio: 0.40,
+            embed_timeout_secs: 10,
         }
     }
 }
@@ -166,6 +170,7 @@ impl CodeRetriever {
     /// # Errors
     ///
     /// Returns an error if the embedding call or Qdrant search fails.
+    #[tracing::instrument(name = "index.retriever.retrieve", skip(self), fields(%query, available_tokens))]
     pub async fn retrieve(&self, query: &str, available_tokens: usize) -> Result<RetrievedCode> {
         let strategy = classify_query(query);
 
@@ -235,13 +240,23 @@ impl CodeRetriever {
         })
     }
 
+    #[tracing::instrument(name = "index.retriever.semantic_search", skip(self), fields(%query, token_budget))]
     async fn semantic_search(
         &self,
         query: &str,
         token_budget: usize,
         language_filter: Option<String>,
     ) -> Result<Vec<SearchHit>> {
-        let query_vector = self.provider.embed(query).await?;
+        let timeout = std::time::Duration::from_secs(self.config.embed_timeout_secs);
+        let query_vector = tokio::time::timeout(timeout, self.provider.embed(query))
+            .await
+            .map_err(|_| {
+                tracing::warn!(
+                    embed_timeout_secs = self.config.embed_timeout_secs,
+                    "embedding timed out"
+                );
+                crate::error::IndexError::EmbedTimeout(self.config.embed_timeout_secs)
+            })??;
 
         let mut hits = self
             .store

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -1064,7 +1064,7 @@ pub(crate) fn apply_code_retrieval<C: Channel>(agent: Agent<C>, config: &IndexCo
 }
 
 /// Construct a [`zeph_index::retriever::CodeRetriever`] and wire it onto the agent so
-/// [`zeph_core::agent::state::IndexState::fetch_code_rag`] returns hits.
+/// automatic code RAG context injection returns results on every agent turn.
 ///
 /// Returns the agent unchanged when any of:
 /// - `config.enabled = false`

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -1063,6 +1063,54 @@ pub(crate) fn apply_code_retrieval<C: Channel>(agent: Agent<C>, config: &IndexCo
     }
 }
 
+/// Construct a [`zeph_index::retriever::CodeRetriever`] and wire it onto the agent so
+/// [`zeph_core::agent::state::IndexState::fetch_code_rag`] returns hits.
+///
+/// Returns the agent unchanged when any of:
+/// - `config.enabled = false`
+/// - `config.mcp_enabled = true` (MCP pull-based mode replaces static injection)
+/// - `qdrant_ops.is_none()` (no vector backend available)
+/// - `config.budget_ratio <= 0.0`
+pub(crate) fn apply_code_rag_retriever<C: Channel>(
+    agent: zeph_core::agent::Agent<C>,
+    config: &IndexConfig,
+    qdrant_ops: Option<QdrantOps>,
+    provider: zeph_llm::any::AnyProvider,
+    pool: zeph_db::DbPool,
+) -> zeph_core::agent::Agent<C> {
+    if !config.enabled || config.budget_ratio <= 0.0 {
+        return agent;
+    }
+    if config.mcp_enabled {
+        tracing::debug!("code RAG retriever skipped: mcp_enabled=true, using MCP pull-based mode");
+        return agent;
+    }
+    let Some(ops) = qdrant_ops else {
+        tracing::debug!("code RAG retriever skipped: no qdrant ops");
+        return agent;
+    };
+
+    let store = CodeStore::with_ops(ops, pool);
+    let retrieval_config = zeph_index::retriever::RetrievalConfig {
+        max_chunks: config.max_chunks,
+        score_threshold: config.score_threshold,
+        budget_ratio: config.budget_ratio,
+        ..zeph_index::retriever::RetrievalConfig::default()
+    };
+    let retriever = std::sync::Arc::new(zeph_index::retriever::CodeRetriever::new(
+        store,
+        std::sync::Arc::new(provider),
+        retrieval_config,
+    ));
+    tracing::info!(
+        max_chunks = config.max_chunks,
+        score_threshold = config.score_threshold,
+        budget_ratio = config.budget_ratio,
+        "code RAG retriever wired"
+    );
+    agent.with_code_retriever(retriever)
+}
+
 pub(crate) fn build_search_code_executor(
     config: &Config,
     qdrant_ops: Option<QdrantOps>,
@@ -1460,5 +1508,61 @@ mod tests {
         };
         let result = apply_code_retrieval(agent, &config);
         drop(result);
+    }
+
+    #[tokio::test]
+    async fn apply_code_rag_retriever_disabled_is_noop() {
+        let pool = zeph_db::sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .unwrap();
+        let agent = make_agent();
+        let config = IndexConfig {
+            enabled: false,
+            ..IndexConfig::default()
+        };
+        let result = apply_code_rag_retriever(agent, &config, None, offline_provider(), pool);
+        assert!(
+            !result.has_code_retriever(),
+            "disabled index must leave retriever None"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_code_rag_retriever_no_qdrant_is_noop() {
+        let pool = zeph_db::sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .unwrap();
+        let agent = make_agent();
+        let config = IndexConfig {
+            enabled: true,
+            budget_ratio: 0.4,
+            ..IndexConfig::default()
+        };
+        let result = apply_code_rag_retriever(agent, &config, None, offline_provider(), pool);
+        assert!(
+            !result.has_code_retriever(),
+            "missing qdrant ops must leave retriever None"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_code_rag_retriever_mcp_enabled_is_noop() {
+        let pool = zeph_db::sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .unwrap();
+        let agent = make_agent();
+        let config = IndexConfig {
+            enabled: true,
+            mcp_enabled: true,
+            budget_ratio: 0.4,
+            ..IndexConfig::default()
+        };
+        let qdrant = QdrantOps::new("http://127.0.0.1:1").unwrap();
+        let result =
+            apply_code_rag_retriever(agent, &config, Some(qdrant), offline_provider(), pool);
+        assert!(
+            !result.has_code_retriever(),
+            "mcp_enabled must leave retriever None"
+        );
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1906,6 +1906,13 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     #[cfg(not(feature = "tui"))]
     let _ = index_progress_rx;
     let agent = agent_setup::apply_code_retrieval(agent, &config.index);
+    let agent = agent_setup::apply_code_rag_retriever(
+        agent,
+        &config.index,
+        app.qdrant_ops().cloned(),
+        provider.clone(),
+        memory.sqlite().pool().clone(),
+    );
     let agent = if let Some(search_executor) = agent_setup::build_search_code_executor(
         config,
         app.qdrant_ops().cloned(),


### PR DESCRIPTION
## Summary

- `IndexState.retriever` was never initialized — `fetch_code_rag` always returned `Ok(None)`, silently skipping code context injection on every agent turn despite the indexing pipeline running successfully
- Added `AgentBuilder::with_code_retriever` builder method and `apply_code_rag_retriever` helper wired from `runner.rs`
- Added tracing spans on all newly-activated I/O paths and embed timeout to bound hung providers

## Changes

- `crates/zeph-core/src/agent/builder.rs` — `with_code_retriever` + `has_code_retriever` methods
- `crates/zeph-core/src/agent/state/mod.rs` — `#[tracing::instrument]` on `fetch_code_rag`
- `crates/zeph-index/src/retriever.rs` — spans on `retrieve`/`semantic_search`; `embed_timeout_secs` field + `IndexError::EmbedTimeout`
- `src/agent_setup.rs` — `apply_code_rag_retriever` with 4 guards + 3 unit tests with assertions
- `src/runner.rs` — call site after `apply_code_retrieval`

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` — 8429/8429 pass
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --all-targets --workspace -- -D warnings` — clean
- [ ] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-core` — clean
- [ ] Live session: start agent with `--config .local/config/testing.toml`, send code symbol query, verify `<code_context>` block appears in debug dump

Closes #3236