### PR TITLE
fix(index): pass index_provider to apply_code_rag_retriever

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1890,7 +1890,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         agent_setup::apply_code_indexer(
             &config.index,
             index_qdrant_ops,
-            index_provider,
+            index_provider.clone(),
             index_pool,
             is_cli,
             Some(agent_status_tx.clone()),
@@ -1910,7 +1910,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         agent,
         &config.index,
         app.qdrant_ops().cloned(),
-        provider.clone(),
+        index_provider.clone(),
         memory.sqlite().pool().clone(),
     );
     let agent = if let Some(search_executor) = agent_setup::build_search_code_executor(


### PR DESCRIPTION
## Summary

- `apply_code_rag_retriever` in `src/runner.rs` was receiving `provider.clone()` (main chat provider) instead of `index_provider` (the dedicated embed provider from `config.index.embed_provider`)
- When the two providers use different embedding dimensions (e.g., OpenAI 1536 vs nomic-embed-text 768), every code RAG retrieval attempt failed with a Qdrant dimension mismatch, silently falling back to no code context injection
- Fix: clone `index_provider` before passing it to `apply_code_indexer`, then pass `index_provider.clone()` to `apply_code_rag_retriever` — both now share the same embed provider, consistent with how the index collection was populated

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] 294 unit tests pass (`cargo nextest run -p zeph --bins`)
- [ ] Live session test with `index.embed_provider = "ollama-embed"` and main provider OpenAI — verify no dimension mismatch errors in logs

Closes #3239