### PR TITLE
fix(index): pass index_provider to build_search_code_executor

### DIFF
--- a/src/acp.rs
+++ b/src/acp.rs
@@ -352,6 +352,25 @@ async fn build_acp_deps(
             zeph_tools::CompositeExecutor::new(scrape_executor, cwd_executor),
         ),
     );
+    let index_provider = config
+        .index
+        .embed_provider
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .and_then(|name| match crate::bootstrap::create_named_provider(name, config) {
+            Ok(p) => {
+                tracing::info!(provider = %name, "Using dedicated embed provider for indexer (acp)");
+                Some(p)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    provider = %name,
+                    "Index embed_provider resolution failed, using main provider (acp): {e:#}"
+                );
+                None
+            }
+        })
+        .unwrap_or_else(|| provider.clone());
     let tool_executor: std::sync::Arc<dyn zeph_tools::ErasedToolExecutor> = {
         let base: std::sync::Arc<dyn zeph_tools::ErasedToolExecutor> = std::sync::Arc::new(
             zeph_tools::CompositeExecutor::new(base_executor, mcp_executor),
@@ -359,7 +378,7 @@ async fn build_acp_deps(
         if let Some(search_executor) = crate::agent_setup::build_search_code_executor(
             config,
             app.qdrant_ops().cloned(),
-            provider.clone(),
+            index_provider,
             memory.sqlite().pool().clone(),
             Some(std::sync::Arc::clone(&mcp_manager)),
         ) {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1916,7 +1916,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     let agent = if let Some(search_executor) = agent_setup::build_search_code_executor(
         config,
         app.qdrant_ops().cloned(),
-        provider.clone(),
+        index_provider.clone(),
         memory.sqlite().pool().clone(),
         Some(std::sync::Arc::clone(&mcp_manager)),
     ) {


### PR DESCRIPTION
## Summary

- `runner.rs:1919`: replace `provider.clone()` with `index_provider.clone()` in `build_search_code_executor` call
- `acp.rs`: resolve `index_provider` from `config.index.embed_provider` (same pattern as `runner.rs`) and pass it to `build_search_code_executor`

Fixes the dimension mismatch error (`expected dim: 768, got 1536`) that occurred when `index.embed_provider` used a different model than the main chat provider.

Closes #3241

## Test plan

- [x] `cargo build --features full` — clean build
- [x] `cargo clippy --features full --workspace -- -D warnings` — zero warnings
- [x] `cargo nextest run --features full --workspace --lib --bins` — 8786 passed