### PR TITLE
fix(tools): restore exempt_tools defaults when partial [tools.utility] TOML is parsed

### DIFF
--- a/crates/zeph-tools/src/config.rs
+++ b/crates/zeph-tools/src/config.rs
@@ -177,6 +177,10 @@ impl TafcConfig {
     }
 }
 
+fn default_utility_exempt_tools() -> Vec<String> {
+    vec!["invoke_skill".to_string(), "load_skill".to_string()]
+}
+
 fn default_utility_threshold() -> f32 {
     0.1
 }
@@ -225,7 +229,7 @@ pub struct UtilityScoringConfig {
     /// Tool names that bypass the utility gate unconditionally (case-insensitive).
     /// Auto-populated with file-read tools when `MagicDocs` is enabled. User-specified
     /// entries are preserved and merged additively with any auto-populated names.
-    #[serde(default)]
+    #[serde(default = "default_utility_exempt_tools")]
     pub exempt_tools: Vec<String>,
 }
 
@@ -238,7 +242,7 @@ impl Default for UtilityScoringConfig {
             cost_weight: default_utility_cost_weight(),
             redundancy_weight: default_utility_redundancy_weight(),
             uncertainty_bonus: default_utility_uncertainty_bonus(),
-            exempt_tools: vec!["invoke_skill".to_string(), "load_skill".to_string()],
+            exempt_tools: default_utility_exempt_tools(),
         }
     }
 }
@@ -1280,6 +1284,32 @@ mod tests {
         assert!(
             cfg.exempt_tools.contains(&"load_skill".to_string()),
             "UtilityScoringConfig default exempt_tools must contain load_skill"
+        );
+    }
+
+    #[test]
+    fn utility_partial_toml_exempt_tools_uses_default_not_empty_vec() {
+        // Regression: #[serde(default)] on exempt_tools called Vec::default() (empty)
+        // instead of the struct-level Default which sets ["invoke_skill", "load_skill"].
+        let toml_str = r"
+            [utility]
+            enabled = true
+            threshold = 0.1
+        ";
+        let config: ToolsConfig = toml::from_str(toml_str).unwrap();
+        assert!(
+            config
+                .utility
+                .exempt_tools
+                .contains(&"invoke_skill".to_string()),
+            "partial [tools.utility] TOML must populate exempt_tools with invoke_skill"
+        );
+        assert!(
+            config
+                .utility
+                .exempt_tools
+                .contains(&"load_skill".to_string()),
+            "partial [tools.utility] TOML must populate exempt_tools with load_skill"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Replace `#[serde(default)]` on `UtilityScoringConfig.exempt_tools` with `#[serde(default = "default_utility_exempt_tools")]` so the named function (returning `["invoke_skill", "load_skill"]`) is used even when `[tools.utility]` is partially specified in config
- Update `impl Default` to call the same function instead of duplicating the literal
- Add regression test `utility_partial_toml_exempt_tools_uses_default_not_empty_vec`

## Root Cause

`#[serde(default)]` on a `Vec<String>` field calls `Vec::default()` (empty vec), not the struct-level `impl Default`. This caused `invoke_skill` and `load_skill` to be blocked by the utility gate whenever any `[tools.utility]` key was present in the config.

## Test Plan

- [x] `cargo nextest run -p zeph-tools --lib` — 1054 passed
- [x] `cargo clippy -p zeph-tools -- -D warnings` — clean
- [x] `cargo +nightly fmt --check` — clean

Closes #3245