### PR TITLE
fix(quality): remove redundant flush_chunks before MARCH self-check

### DIFF
--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -799,7 +799,6 @@ impl<C: Channel> Agent<C> {
             if cleaned.contains(MAX_TOKENS_TRUNCATION_MARKER) {
                 let _ = self.channel.send_stop_hint(StopHint::MaxTokens).await;
             }
-            self.channel.flush_chunks().await?;
             return Ok(Some(()));
         }
 


### PR DESCRIPTION
## Summary

- Removes `self.channel.flush_chunks().await?` from `native.rs:802` (ChatResponse::Text branch)
- The canonical `flush_chunks()` at `mod.rs:1433` already covers all exit paths after self-check
- When `self_check = true` and the response is flagged, the premature call produced two `response_end` events in `--json` mode

## Root Cause

PR #3244 moved the canonical `flush_chunks()` to after the quality hook in `mod.rs:1433`, but did not remove the earlier call in `native.rs:802`. When `flagged > 0`, the execution path was:
1. `native.rs:802` → `flush_chunks()` → emits `response_end` ①
2. `quality_hook.rs:101` → `send_chunk(" [verify]")` → pending_chunks=true
3. `mod.rs:1433` → `flush_chunks()` → emits `response_end` ②

## Test Plan

- [x] `send_then_marker_chunk_then_flush_emits_single_end` (json_cli.rs:417) — PASS
- [x] `flag_marker_appended_via_send_chunk_has_single_end` (json_cli.rs:437) — PASS
- [x] Full workspace: 8506 tests passed
- [x] clippy: clean
- [x] fmt: clean

Note: pre-existing P3 gap — no zeph-core unit test for `quality_hook flagged > 0` path. Tracked separately.

Closes #3259