### PR TITLE
feat(acp): add handler scaffolding and unstable feature flags for 0.11 migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Add `zeph-acp` handler module scaffolding for ACP 0.11 migration (PR 1, epic #3265)
+- Add `unstable-auth-methods`, `unstable-message-id`, `unstable-session-add-dirs`, `unstable-boolean-config` optional features to `zeph-acp`
+
 ## [0.19.3] - 2026-04-19
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,7 +198,7 @@ bench      = ["dep:zeph-bench"]
 
 # === Individual feature flags ===
 a2a = ["dep:zeph-a2a", "zeph-a2a?/server", "zeph-a2a?/ibct"]
-acp = ["dep:zeph-acp", "zeph-acp/unstable-session-close", "zeph-acp/unstable-session-fork", "zeph-acp/unstable-session-resume", "zeph-acp/unstable-elicitation", "zeph-acp/unstable-logout"]
+acp = ["dep:zeph-acp", "zeph-acp/unstable-session-close", "zeph-acp/unstable-session-fork", "zeph-acp/unstable-session-resume", "zeph-acp/unstable-elicitation", "zeph-acp/unstable-logout", "zeph-acp/unstable-auth-methods", "zeph-acp/unstable-message-id", "zeph-acp/unstable-session-add-dirs"]
 acp-http = ["acp", "dep:axum", "zeph-acp/acp-http"]
 candle = ["zeph-llm/candle", "zeph-core/candle"]
 classifiers = ["candle", "zeph-llm/classifiers", "zeph-sanitizer/classifiers", "zeph-core/classifiers"]

--- a/crates/zeph-acp/Cargo.toml
+++ b/crates/zeph-acp/Cargo.toml
@@ -31,6 +31,10 @@ unstable-session-model = ["agent-client-protocol/unstable_session_model"]
 # Exposes schema types (ElicitationRequest, etc.); SDK methods not yet wired in agent-client-protocol 0.10.3.
 unstable-elicitation = ["agent-client-protocol/unstable_elicitation"]
 unstable-logout = ["agent-client-protocol/unstable_logout"]
+unstable-auth-methods = ["agent-client-protocol/unstable_auth_methods"]
+unstable-boolean-config = ["agent-client-protocol/unstable_boolean_config"]
+unstable-message-id = ["agent-client-protocol/unstable_message_id"]
+unstable-session-add-dirs = ["agent-client-protocol/unstable_session_additional_directories"]
 
 [dependencies]
 agent-client-protocol = { workspace = true }

--- a/crates/zeph-acp/src/agent/handlers/authenticate.rs
+++ b/crates/zeph-acp/src/agent/handlers/authenticate.rs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Handler for `authenticate` (ACP method `"authenticate"`).
+//!
+//! # PR 2 contract
+//!
+//! ```ignore
+//! pub(crate) async fn handle_authenticate(
+//!     req: acp::schema::AuthenticateRequest,
+//!     responder: acp::Responder<acp::schema::AuthenticateResponse>,
+//!     cx: acp::ConnectionTo<acp::Client>,
+//!     state: Arc<ZephAcpAgentState>,
+//! ) -> acp::Result<()>
+//! ```
+//!
+//! Validates credentials supplied by the client and responds with an
+//! authentication token or an error if authentication fails.

--- a/crates/zeph-acp/src/agent/handlers/cancel.rs
+++ b/crates/zeph-acp/src/agent/handlers/cancel.rs
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Handler for `session/cancel` (ACP notification, no response).
+//!
+//! # PR 2 contract
+//!
+//! ```ignore
+//! pub(crate) async fn handle_cancel(
+//!     notif: acp::schema::CancelNotification,
+//!     cx: acp::ConnectionTo<acp::Client>,
+//!     state: Arc<ZephAcpAgentState>,
+//! ) -> acp::Result<()>
+//! ```
+//!
+//! Sends an abort signal to the active session task and waits for clean shutdown.

--- a/crates/zeph-acp/src/agent/handlers/close_session.rs
+++ b/crates/zeph-acp/src/agent/handlers/close_session.rs
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Handler for `session/close` (ACP method `"session/close"`).
+//!
+//! Enabled by feature `unstable-session-close`.
+//!
+//! # PR 2 contract
+//!
+//! ```ignore
+//! pub(crate) async fn handle_close_session(
+//!     req: acp::schema::CloseSessionRequest,
+//!     responder: acp::Responder<acp::schema::CloseSessionResponse>,
+//!     cx: acp::ConnectionTo<acp::Client>,
+//!     state: Arc<ZephAcpAgentState>,
+//! ) -> acp::Result<()>
+//! ```
+//!
+//! Terminates the specified session, persists final state if requested,
+//! and frees all associated resources.

--- a/crates/zeph-acp/src/agent/handlers/dispatch.rs
+++ b/crates/zeph-acp/src/agent/handlers/dispatch.rs
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Handler for extension method dispatch (ACP `on_receive_dispatch`).
+//!
+//! Receives all unrecognised methods as `acp::Dispatch` and routes them
+//! to the custom extension handler in `custom.rs`.
+//!
+//! # PR 2 contract
+//!
+//! ```ignore
+//! pub(crate) async fn handle_dispatch(
+//!     message: acp::Dispatch,
+//!     cx: acp::ConnectionTo<acp::Client>,
+//!     state: Arc<ZephAcpAgentState>,
+//! ) -> acp::Result<()>
+//! ```
+//!
+//! Forwards the raw `acp::Dispatch` message to the extension handler;
+//! responds with an internal error for unknown methods.

--- a/crates/zeph-acp/src/agent/handlers/fork_session.rs
+++ b/crates/zeph-acp/src/agent/handlers/fork_session.rs
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Handler for `session/fork` (ACP method `"session/fork"`).
+//!
+//! Enabled by feature `unstable-session-fork`.
+//!
+//! # PR 2 contract
+//!
+//! ```ignore
+//! pub(crate) async fn handle_fork_session(
+//!     req: acp::schema::ForkSessionRequest,
+//!     responder: acp::Responder<acp::schema::ForkSessionResponse>,
+//!     cx: acp::ConnectionTo<acp::Client>,
+//!     state: Arc<ZephAcpAgentState>,
+//! ) -> acp::Result<()>
+//! ```
+//!
+//! Creates a copy of an existing session at a specified history checkpoint,
+//! returning the new session's ID and metadata.

--- a/crates/zeph-acp/src/agent/handlers/initialize.rs
+++ b/crates/zeph-acp/src/agent/handlers/initialize.rs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Handler for `initialize` (ACP method `"initialize"`).
+//!
+//! # PR 2 contract
+//!
+//! ```ignore
+//! pub(crate) async fn handle_initialize(
+//!     req: acp::schema::InitializeRequest,
+//!     responder: acp::Responder<acp::schema::InitializeResponse>,
+//!     cx: acp::ConnectionTo<acp::Client>,
+//!     state: Arc<ZephAcpAgentState>,
+//! ) -> acp::Result<()>
+//! ```
+//!
+//! Validates client capabilities, persists them in `state.client_caps`,
+//! and responds with the agent's capabilities and available models.

--- a/crates/zeph-acp/src/agent/handlers/list_sessions.rs
+++ b/crates/zeph-acp/src/agent/handlers/list_sessions.rs
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Handler for `session/list` (ACP method `"session/list"`).
+//!
+//! # PR 2 contract
+//!
+//! ```ignore
+//! pub(crate) async fn handle_list_sessions(
+//!     req: acp::schema::ListSessionsRequest,
+//!     responder: acp::Responder<acp::schema::ListSessionsResponse>,
+//!     cx: acp::ConnectionTo<acp::Client>,
+//!     state: Arc<ZephAcpAgentState>,
+//! ) -> acp::Result<()>
+//! ```
+//!
+//! Returns the list of all active and persisted sessions for the connected client.

--- a/crates/zeph-acp/src/agent/handlers/load_session.rs
+++ b/crates/zeph-acp/src/agent/handlers/load_session.rs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Handler for `session/load` (ACP method `"session/load"`).
+//!
+//! # PR 2 contract
+//!
+//! ```ignore
+//! pub(crate) async fn handle_load_session(
+//!     req: acp::schema::LoadSessionRequest,
+//!     responder: acp::Responder<acp::schema::LoadSessionResponse>,
+//!     cx: acp::ConnectionTo<acp::Client>,
+//!     state: Arc<ZephAcpAgentState>,
+//! ) -> acp::Result<()>
+//! ```
+//!
+//! Loads a previously persisted session from storage and restores its
+//! agent loop state, responding with the session metadata.

--- a/crates/zeph-acp/src/agent/handlers/logout.rs
+++ b/crates/zeph-acp/src/agent/handlers/logout.rs
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Handler for `logout` (ACP notification, no response).
+//!
+//! Enabled by feature `unstable-logout`.
+//!
+//! # PR 2 contract
+//!
+//! ```ignore
+//! pub(crate) async fn handle_logout(
+//!     notif: acp::schema::LogoutRequest,
+//!     cx: acp::ConnectionTo<acp::Client>,
+//!     state: Arc<ZephAcpAgentState>,
+//! ) -> acp::Result<()>
+//! ```
+//!
+//! Terminates all active sessions for the connected client and clears
+//! authentication state, triggering a clean connection close.

--- a/crates/zeph-acp/src/agent/handlers/mod.rs
+++ b/crates/zeph-acp/src/agent/handlers/mod.rs
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+// Handler stubs for ACP 0.11 migration. Implementations land in PR 2 (#3267).
+// See .local/plan/acp-migration-plan.md §4 Steps 3–4 for the full contract.
+
+pub(crate) mod authenticate;
+pub(crate) mod cancel;
+#[cfg(feature = "unstable-session-close")]
+pub(crate) mod close_session;
+pub(crate) mod dispatch;
+#[cfg(feature = "unstable-session-fork")]
+pub(crate) mod fork_session;
+pub(crate) mod initialize;
+pub(crate) mod list_sessions;
+pub(crate) mod load_session;
+#[cfg(feature = "unstable-logout")]
+pub(crate) mod logout;
+pub(crate) mod new_session;
+pub(crate) mod prompt;
+#[cfg(feature = "unstable-session-resume")]
+pub(crate) mod resume_session;
+pub(crate) mod set_session_config_option;
+pub(crate) mod set_session_mode;
+#[cfg(feature = "unstable-session-model")]
+pub(crate) mod set_session_model;

--- a/crates/zeph-acp/src/agent/handlers/new_session.rs
+++ b/crates/zeph-acp/src/agent/handlers/new_session.rs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Handler for `session/new` (ACP method `"session/new"`).
+//!
+//! # PR 2 contract
+//!
+//! ```ignore
+//! pub(crate) async fn handle_new_session(
+//!     req: acp::schema::NewSessionRequest,
+//!     responder: acp::Responder<acp::schema::NewSessionResponse>,
+//!     cx: acp::ConnectionTo<acp::Client>,
+//!     state: Arc<ZephAcpAgentState>,
+//! ) -> acp::Result<()>
+//! ```
+//!
+//! Creates a new agent session, spawns the agent loop on a `LoopbackChannel`,
+//! and responds with the session ID and initial session metadata.

--- a/crates/zeph-acp/src/agent/handlers/prompt.rs
+++ b/crates/zeph-acp/src/agent/handlers/prompt.rs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Handler for `session/prompt` (ACP method `"session/prompt"`).
+//!
+//! # PR 2 contract
+//!
+//! ```ignore
+//! pub(crate) async fn handle_prompt(
+//!     req: acp::schema::PromptRequest,
+//!     responder: acp::Responder<acp::schema::PromptResponse>,
+//!     cx: acp::ConnectionTo<acp::Client>,
+//!     state: Arc<ZephAcpAgentState>,
+//! ) -> acp::Result<()>
+//! ```
+//!
+//! Forwards the user prompt to the active session's agent loop, streams
+//! output events back to the client, and responds with the final result.

--- a/crates/zeph-acp/src/agent/handlers/resume_session.rs
+++ b/crates/zeph-acp/src/agent/handlers/resume_session.rs
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Handler for `session/resume` (ACP method `"session/resume"`).
+//!
+//! Enabled by feature `unstable-session-resume`.
+//!
+//! # PR 2 contract
+//!
+//! ```ignore
+//! pub(crate) async fn handle_resume_session(
+//!     req: acp::schema::ResumeSessionRequest,
+//!     responder: acp::Responder<acp::schema::ResumeSessionResponse>,
+//!     cx: acp::ConnectionTo<acp::Client>,
+//!     state: Arc<ZephAcpAgentState>,
+//! ) -> acp::Result<()>
+//! ```
+//!
+//! Re-attaches the client to a previously detached session, restoring
+//! the streaming output channel and returning current session state.

--- a/crates/zeph-acp/src/agent/handlers/set_session_config_option.rs
+++ b/crates/zeph-acp/src/agent/handlers/set_session_config_option.rs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Handler for `session/set_config_option` (ACP method `"session/set_config_option"`).
+//!
+//! # PR 2 contract
+//!
+//! ```ignore
+//! pub(crate) async fn handle_set_session_config_option(
+//!     req: acp::schema::SetSessionConfigOptionRequest,
+//!     responder: acp::Responder<acp::schema::SetSessionConfigOptionResponse>,
+//!     cx: acp::ConnectionTo<acp::Client>,
+//!     state: Arc<ZephAcpAgentState>,
+//! ) -> acp::Result<()>
+//! ```
+//!
+//! Applies a single named configuration option to the active session,
+//! persisting the change without restarting the agent loop.

--- a/crates/zeph-acp/src/agent/handlers/set_session_mode.rs
+++ b/crates/zeph-acp/src/agent/handlers/set_session_mode.rs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Handler for `session/set_mode` (ACP method `"session/set_mode"`).
+//!
+//! # PR 2 contract
+//!
+//! ```ignore
+//! pub(crate) async fn handle_set_session_mode(
+//!     req: acp::schema::SetSessionModeRequest,
+//!     responder: acp::Responder<acp::schema::SetSessionModeResponse>,
+//!     cx: acp::ConnectionTo<acp::Client>,
+//!     state: Arc<ZephAcpAgentState>,
+//! ) -> acp::Result<()>
+//! ```
+//!
+//! Updates the active session's operating mode (e.g., `auto`, `manual`)
+//! and persists the change in `state.sessions`.

--- a/crates/zeph-acp/src/agent/handlers/set_session_model.rs
+++ b/crates/zeph-acp/src/agent/handlers/set_session_model.rs
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Handler for `session/set_model` (ACP method `"session/set_model"`).
+//!
+//! Enabled by feature `unstable-session-model`.
+//!
+//! # PR 2 contract
+//!
+//! ```ignore
+//! pub(crate) async fn handle_set_session_model(
+//!     req: acp::schema::SetSessionModelRequest,
+//!     responder: acp::Responder<acp::schema::SetSessionModelResponse>,
+//!     cx: acp::ConnectionTo<acp::Client>,
+//!     state: Arc<ZephAcpAgentState>,
+//! ) -> acp::Result<()>
+//! ```
+//!
+//! Switches the active session to a different LLM model, updating
+//! `state.sessions` and applying the change to subsequent prompt turns.

--- a/crates/zeph-acp/src/agent/mod.rs
+++ b/crates/zeph-acp/src/agent/mod.rs
@@ -2282,5 +2282,7 @@ use helpers::{
     session_update_to_event, xml_escape,
 };
 
+pub(crate) mod handlers;
+
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
## Summary

PR 1 of the ACP SDK migration epic (#3265, closes #3266).

Additive-only scaffolding — no existing files broken, no dep bump. The workspace
continues to build against `agent-client-protocol 0.10.4`. All breaking changes
(trait rewrite, dep bump, transport rewire) land in PR 2 (#3267).

- Create `crates/zeph-acp/src/agent/handlers/` with 16 files: one module
  aggregator (`mod.rs`) and 15 doc-only stub files, one per ACP method.
  Each stub documents the PR 2 handler contract in `ignore`-fenced blocks
  so the 0.11 API surface is captured as contract evidence without introducing
  any compile-time dependency on the new SDK version.
- Add `pub(crate) mod handlers;` to `crates/zeph-acp/src/agent/mod.rs`.
- Add four new optional features to `zeph-acp` (`unstable-auth-methods`,
  `unstable-message-id`, `unstable-session-add-dirs`, `unstable-boolean-config`),
  verified against both `agent-client-protocol 0.10.4` and `0.11.1` manifests.
- Wire three of them into the root `acp` feature (`unstable-boolean-config`
  excluded — no current IDE use case, skip for MVP).

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 8507 passed, 0 failed
- [x] `cargo build -p zeph-acp --features "unstable-auth-methods,unstable-message-id,unstable-session-add-dirs"` — clean
- [x] `cargo build --features full` — clean
- [x] All 16 handler files present under `crates/zeph-acp/src/agent/handlers/`

## Notes

- Pre-existing `E0609` under `unstable-session-model` is a pre-existing issue
  unrelated to this PR (confirmed by impl-critic — does not reproduce on clean check).
- Pre-existing `RUSTSEC-2025-0134` (rustls-pemfile, tracked in #2347) — not
  affected by this PR.
- `unstable_elicitation` removal in 0.11.1 is flagged for PR 2 when the dep bumps.