### PR TITLE
docs(acp): add 0.11 migration playbook, coverage-status rows, spec update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- ACP: migrated to agent-client-protocol 0.11.1 builder API (`Agent.builder()` / `run_agent()` pattern); `Rc<RefCell>` replaced with `Arc`; added handler tracing spans; config schema extensions (additional_directories, auth_methods, message_ids_enabled)
+
 - **`zeph-acp`**: integration tests rewritten for ACP 0.11 builder API using `acp::Client.connect_with`
   and `serve_connection`; `#[cfg(any())]` gate removed; 6 real loopback tests cover initialize,
   new_session, cancel, unknown ext method, load_session error, and session list (#3269, PR 3).

--- a/specs/013-acp/spec.md
+++ b/specs/013-acp/spec.md
@@ -18,7 +18,7 @@ related:
 
 > [!info]
 > ACP transports, session management, permissions, fork/resume,
-> capability advertisement, agent-client-protocol 0.11.x / schema 0.12.0 compatibility.
+> capability advertisement, agent-client-protocol 0.11.1 / schema 0.12.0 compatibility.
 
 ## Sources
 
@@ -69,6 +69,15 @@ AcpSessionManager
 - **LRU eviction**: oldest unused session is dropped when capacity is reached
 - Session fork: create a new session branching from an existing session at a given turn
 - Session resume: reconnect to an existing session by ID
+
+### Agent Spawner Contract (0.11.1)
+
+Agent sessions use the `Agent.builder()` / `run_agent()` pattern introduced in
+`agent-client-protocol 0.11.1`. Session state that was previously `Rc<RefCell<...>>` is now
+`Arc`-wrapped, but session tasks are still launched via `tokio::task::spawn_local` inside a
+`LocalSet` — the `AgentSpawner` closure returns `Pin<Box<dyn Future<Output = ()> + 'static>>`
+(`!Send`). The 0.11.1 migration changed the external builder API shape, not the LocalSet
+concurrency model.
 
 ## Permission Model
 
@@ -214,7 +223,7 @@ ACP server advertises its capabilities in the `initialize` response and via the 
 
 ### Protocol Version
 
-Uses `agent-client-protocol 0.11.x` / `schema 0.12.0`.
+Uses `agent-client-protocol 0.11.1` / `schema 0.12.0`.
 
 ### Current Model in SessionInfoUpdate
 
@@ -235,7 +244,7 @@ Cross-reference: `specs/045-interop-protocol-gaps/spec.md`
 
 ### ACP Baseline vs. arXiv:2505.02279 Survey
 
-Zeph's ACP implementation is based on `agent-client-protocol = "0.11"` (workspace `Cargo.toml`).
+Zeph's ACP implementation is based on `agent-client-protocol = "0.11.1"` (workspace `Cargo.toml`).
 
 The survey (arXiv:2505.02279) describes ACP's capability advertisement and re-negotiation
 model as a differentiating feature vs. MCP and A2A.


### PR DESCRIPTION
Closes #3271

Part of epic #3265 (ACP 0.11 migration), PR 5 of 5. Final deliverable of the migration.

## Summary

- `specs/013-acp/spec.md`: version bumped to 0.11.1; new "Agent Spawner Contract" subsection documenting the `Agent.builder()` / `run_agent()` API shape; clarifies `Rc<RefCell>` → `Arc` migration while `LocalSet`/`spawn_local` remain for `!Send` session futures
- `CHANGELOG.md`: `[Unreleased]` entry covering all 5 PRs of the ACP 0.11 migration (builder API, `Rc` → `Arc`, tracing spans, config schema extensions)
- `.local/testing/playbooks/acp-0-11-migration.md`: 9 concrete test scenarios with steps, expected outcomes, and edge cases (stdio, HTTP+SSE, cancel, fork/resume, elicitation, logout, additional_directories, auth_methods, message_id echo)
- `.local/testing/coverage-status.md`: 7 `Untested` rows for ACP 0.11 migration features

## Rustdoc gate

```
RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features -p zeph-acp
```
✓ No broken intra-doc links. 11 doc-tests pass.

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` — 8242 tests pass
- [ ] Playbook scenarios manually executable against a running Zed session
- [ ] Coverage-status rows updated from `Untested` → `Tested` after live session