### PR TITLE
refactor: remove dead code — LlmRoutingStrategy::Task, coe_enabled/with_coe, assembler.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `transport::http::spawn_agent_connection`; update any direct imports of
   `crate::transport::bridge`.
 
+### Removed
+
+- Remove `LlmRoutingStrategy::Task` unimplemented variant and associated `LlmConfig::routes` field (#3248); `--migrate-config` warns and drops the keys automatically
+- Remove unreachable per-provider `coe_enabled`/`with_coe` logprobs branches from `OllamaProvider`, `OpenAiProvider`, `CompatibleProvider` (#3249)
+- Move test-only context/assembler.rs helpers into `assembler_helpers` test module in `zeph-core` (#3254)
+
 ### Changed
 
 - ACP: migrated to agent-client-protocol 0.11.1 builder API (`Agent.builder()` / `run_agent()` pattern); `Rc<RefCell>` replaced with `Arc`; added handler tracing spans; config schema extensions (additional_directories, auth_methods, message_ids_enabled)

--- a/book/src/advanced/orchestrator.md
+++ b/book/src/advanced/orchestrator.md
@@ -2,14 +2,13 @@
 
 > **Tip:** For simple fallback chains with adaptive routing (Thompson Sampling or EMA), use `routing = "cascade"` or `routing = "thompson"` in `[llm]` instead. See [Adaptive Inference](adaptive-inference.md).
 
-Route tasks to different LLM providers based on content classification. Each task type maps to a provider chain with automatic fallback. Use a multi-provider setup to combine local and cloud models — for example, embeddings via Ollama and chat via Claude.
+> **Note:** `routing = "task"` was removed as unimplemented in #3248. If your config uses it, `--migrate-config` will drop it with a warning and fall back to default single-provider routing.
+
+Use a multi-provider setup to combine local and cloud models — for example, embeddings via Ollama and chat via Claude. Provider selection is controlled via `default = true` and `embed = true` markers.
 
 ## Configuration
 
 ```toml
-[llm]
-routing = "task"   # task-based routing
-
 [[llm.providers]]
 name = "ollama"
 type = "ollama"
@@ -45,27 +44,6 @@ Each `[[llm.providers]]` entry supports:
 
 - `default = true` — provider used for chat when no other routing rule matches
 - `embed = true` — provider used for all embedding operations (skill matching, semantic memory)
-
-## Task Classification
-
-Task types are classified via keyword heuristics:
-
-| Task Type | Keywords |
-|-----------|----------|
-| `coding` | code, function, debug, refactor, implement |
-| `creative` | write, story, poem, creative |
-| `analysis` | analyze, compare, evaluate |
-| `translation` | translate, convert language |
-| `summarization` | summarize, summary, tldr |
-| `general` | everything else |
-
-## Fallback Chains
-
-Routes define provider preference order. If the first provider fails, the next one in the list is tried automatically.
-
-```toml
-coding = ["local", "cloud"]  # try local first, fallback to cloud
-```
 
 ## Capability Delegation
 

--- a/book/src/guides/config-recipes.md
+++ b/book/src/guides/config-recipes.md
@@ -200,9 +200,6 @@ See [Adaptive Inference](../advanced/adaptive-inference.md) for Thompson Samplin
 <strong>Prerequisites:</strong> Ollama running with at least two models pulled (<code>qwen3:8b</code> and <code>qwen3:14b</code>).</summary>
 
 ```toml
-[llm]
-routing = "task"   # route by task type
-
 [[llm.providers]]
 name = "planner"
 type = "ollama"
@@ -228,8 +225,7 @@ confirm_before_execute = true
 backend = "env"
 ```
 
-> **Note:** `[orchestration]` (lowercase) enables `/plan` CLI commands. `routing = "task"` in `[llm]`
-> routes LLM calls between providers by task type. The two settings are independent.
+> **Note:** `[orchestration]` (lowercase) enables `/plan` CLI commands. `routing = "task"` was removed as unimplemented — see [Model Orchestrator](../advanced/orchestrator.md) for current multi-provider setup options.
 
 See [Task Orchestration](../concepts/task-orchestration.md) and [Model Orchestrator](../advanced/orchestrator.md).
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -126,15 +126,7 @@ embedding_model = "qwen3-embedding"
 # chat_template = "chatml"              # llama3, chatml, mistral, phi3, raw
 # device = "cpu"                        # auto, cpu, metal, cuda
 
-# Multi-provider with task-based routing example:
-#
-# [llm]
-# routing = "task"
-#
-# [llm.routes]
-# coding = ["claude", "ollama"]
-# creative = ["claude"]
-# general = ["ollama", "claude"]
+# Multi-provider example:
 #
 # [[llm.providers]]
 # name = "ollama"

--- a/crates/zeph-config/src/migrate.rs
+++ b/crates/zeph-config/src/migrate.rs
@@ -626,17 +626,16 @@ fn migrate_compatible_provider(llm: &toml_edit::Table) -> Vec<String> {
     blocks
 }
 
-// Returns (provider_blocks, routing, routes_block)
+// Returns (provider_blocks, routing)
 #[allow(clippy::format_push_string, clippy::collapsible_if, clippy::ref_option)]
 fn migrate_orchestrator_provider(
     llm: &toml_edit::Table,
     model: &Option<String>,
     base_url: &Option<String>,
     embedding_model: &Option<String>,
-) -> (Vec<String>, Option<String>, Option<String>) {
+) -> (Vec<String>, Option<String>) {
     let mut blocks = Vec::new();
-    let routing = Some("task".to_owned());
-    let mut routes_block = None;
+    let routing = None;
     if let Some(orch) = llm.get("orchestrator").and_then(toml_edit::Item::as_table) {
         let default_name = orch
             .get("default")
@@ -648,20 +647,6 @@ fn migrate_orchestrator_provider(
             .and_then(toml_edit::Item::as_str)
             .unwrap_or("")
             .to_owned();
-        if let Some(routes) = orch.get("routes").and_then(toml_edit::Item::as_table) {
-            let mut rb = "[llm.routes]\n".to_owned();
-            for (key, val) in routes {
-                if let Some(arr) = val.as_array() {
-                    let items: Vec<String> = arr
-                        .iter()
-                        .filter_map(toml_edit::Value::as_str)
-                        .map(|s| format!("\"{s}\""))
-                        .collect();
-                    rb.push_str(&format!("{key} = [{}]\n", items.join(", ")));
-                }
-            }
-            routes_block = Some(rb);
-        }
         if let Some(providers) = orch.get("providers").and_then(toml_edit::Item::as_table) {
             for (name, pcfg_item) in providers {
                 let Some(pcfg) = pcfg_item.as_table() else {
@@ -715,7 +700,7 @@ fn migrate_orchestrator_provider(
             }
         }
     }
-    (blocks, routing, routes_block)
+    (blocks, routing)
 }
 
 // Returns (provider_blocks, routing)
@@ -792,6 +777,35 @@ fn migrate_router_provider(
 /// `[[llm.providers]]` array format.
 ///
 /// If the config does not contain legacy LLM keys, it is returned unchanged.
+/// Removes `routing = "task"` and `[llm.routes]` block lines from a raw TOML string.
+///
+/// Used as a pre-pass before `migrate_llm_to_providers` when the removed variant is detected.
+fn strip_task_routing_keys(toml_src: &str) -> String {
+    let mut in_routes_block = false;
+    let mut out = Vec::new();
+    for line in toml_src.lines() {
+        let trimmed = line.trim();
+        if trimmed == "[llm.routes]" {
+            in_routes_block = true;
+            continue;
+        }
+        if in_routes_block {
+            // Exit the routes block when we hit the next section header.
+            if trimmed.starts_with('[') {
+                in_routes_block = false;
+            } else {
+                continue;
+            }
+        }
+        // Strip bare `routing = "task"` assignment.
+        if trimmed.starts_with("routing") && trimmed.contains("\"task\"") {
+            continue;
+        }
+        out.push(line);
+    }
+    out.join("\n")
+}
+
 /// Creates a `.bak` backup at `backup_path` before writing.
 ///
 /// # Errors
@@ -819,6 +833,25 @@ pub fn migrate_llm_to_providers(toml_src: &str) -> Result<MigrationResult, Migra
             });
         }
     };
+
+    // Pre-check: `routing = "task"` was removed as unimplemented (#3248).
+    // Detect on the input document before any block transforms.
+    if llm.get("routing").and_then(toml_edit::Item::as_str) == Some("task") {
+        let routes_count = llm
+            .get("routes")
+            .and_then(toml_edit::Item::as_table)
+            .map_or(0, toml_edit::Table::len);
+        let msg = format!(
+            "routing = \"task\" is no longer supported and has been removed (#3248). \
+             {routes_count} route(s) in [llm.routes] will be dropped. \
+             Falling back to default single-provider routing."
+        );
+        tracing::warn!("{msg}");
+        eprintln!("WARNING: {msg}");
+        // Strip the removed keys and re-run migration on the cleaned source.
+        let cleaned = strip_task_routing_keys(toml_src);
+        return migrate_llm_to_providers(&cleaned);
+    }
 
     let has_provider_field = llm.contains_key("provider");
     let has_cloud = llm.contains_key("cloud");
@@ -873,7 +906,6 @@ pub fn migrate_llm_to_providers(toml_src: &str) -> Result<MigrationResult, Migra
     // Collect provider entries as inline TOML strings.
     let mut provider_blocks: Vec<String> = Vec::new();
     let mut routing: Option<String> = None;
-    let mut routes_block: Option<String> = None;
 
     match provider_str {
         "ollama" => {
@@ -897,11 +929,10 @@ pub fn migrate_llm_to_providers(toml_src: &str) -> Result<MigrationResult, Migra
             provider_blocks.extend(migrate_compatible_provider(llm));
         }
         "orchestrator" => {
-            let (blocks, r, rb) =
+            let (blocks, r) =
                 migrate_orchestrator_provider(llm, &model, &base_url, &embedding_model);
             provider_blocks.extend(blocks);
             routing = r;
-            routes_block = rb;
         }
         "router" => {
             let (blocks, r) = migrate_router_provider(llm, &model, &base_url, &embedding_model);
@@ -951,11 +982,6 @@ pub fn migrate_llm_to_providers(toml_src: &str) -> Result<MigrationResult, Migra
         }
     }
     new_llm.push('\n');
-
-    if let Some(rb) = routes_block {
-        new_llm.push_str(&rb);
-        new_llm.push('\n');
-    }
 
     for block in &provider_blocks {
         new_llm.push_str(block);

--- a/crates/zeph-config/src/providers.rs
+++ b/crates/zeph-config/src/providers.rs
@@ -304,10 +304,6 @@ pub struct LlmConfig {
     #[serde(default, skip_serializing_if = "is_routing_none")]
     pub routing: LlmRoutingStrategy,
 
-    /// Task-based routes (only used when `routing = "task"`).
-    #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
-    pub routes: std::collections::HashMap<String, Vec<String>>,
-
     #[serde(default = "default_embedding_model_opt")]
     pub embedding_model: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -966,8 +962,6 @@ pub enum LlmRoutingStrategy {
     Thompson,
     /// Cascade: try cheapest provider first, escalate on degenerate output.
     Cascade,
-    /// Task-based routing using `[llm.routes]` map.
-    Task,
     /// Complexity triage routing: pre-classify each request, delegate to appropriate tier.
     Triage,
     /// PILOT: `LinUCB` contextual bandit with online learning and budget-aware reward.

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -156,7 +156,6 @@ impl Default for Config {
             llm: LlmConfig {
                 providers: Vec::new(),
                 routing: crate::providers::LlmRoutingStrategy::None,
-                routes: std::collections::HashMap::new(),
                 embedding_model: get_default_embedding_model(),
                 candle: None,
                 stt: None,

--- a/crates/zeph-core/src/agent/context/assembler_helpers.rs
+++ b/crates/zeph-core/src/agent/context/assembler_helpers.rs
@@ -1,37 +1,23 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Context assembly helpers for the Zeph agent.
-//!
-//! This module provides utility functions for fetching individual context slots
-//! (summaries, cross-session context, semantic recall, etc.) used by
-//! `Agent::prepare_context` and test helpers.
-//!
-//! The top-level gather logic is in [`zeph_context::assembler::ContextAssembler`].
-
-#[cfg(test)]
 use zeph_llm::provider::{Message, MessagePart, Role};
-#[cfg(test)]
 use zeph_memory::TokenCounter;
 
-#[cfg(test)]
-use super::super::error::AgentError;
-#[cfg(test)]
-use super::super::{
+use crate::agent::context::truncate_chars;
+use crate::agent::error::AgentError;
+use crate::agent::{
     CROSS_SESSION_PREFIX, GRAPH_FACTS_PREFIX, MemoryState, RECALL_PREFIX, SUMMARY_PREFIX,
 };
-#[cfg(test)]
 use crate::redact::scrub_content;
 
-#[cfg(test)]
 pub(super) fn format_correction_note(_original_output: &str, correction_text: &str) -> String {
     format!(
         "- Past user correction: \"{}\"",
-        super::truncate_chars(&scrub_content(correction_text), 200)
+        truncate_chars(&scrub_content(correction_text), 200)
     )
 }
 
-#[cfg(test)]
 pub(super) fn effective_recall_timeout_ms(configured: u64) -> u64 {
     if configured == 0 {
         tracing::warn!(
@@ -44,7 +30,6 @@ pub(super) fn effective_recall_timeout_ms(configured: u64) -> u64 {
     }
 }
 
-#[cfg(test)]
 pub(super) async fn fetch_graph_facts(
     memory_state: &MemoryState,
     query: &str,
@@ -150,7 +135,6 @@ pub(super) async fn fetch_graph_facts(
     Ok(Some(Message::from_legacy(Role::System, body)))
 }
 
-#[cfg(test)]
 pub(super) async fn fetch_semantic_recall(
     memory_state: &MemoryState,
     query: &str,
@@ -218,7 +202,6 @@ pub(super) async fn fetch_semantic_recall(
     }
 }
 
-#[cfg(test)]
 pub(super) async fn fetch_summaries(
     memory_state: &MemoryState,
     token_budget: usize,
@@ -264,7 +247,6 @@ pub(super) async fn fetch_summaries(
     }
 }
 
-#[cfg(test)]
 pub(super) async fn fetch_cross_session(
     memory_state: &MemoryState,
     query: &str,

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -98,7 +98,7 @@ impl<C: Channel> Agent<C> {
     ) -> Result<(), super::super::error::AgentError> {
         self.remove_recall_messages();
 
-        let (msg, _score) = super::assembler::fetch_semantic_recall(
+        let (msg, _score) = super::assembler_helpers::fetch_semantic_recall(
             &self.memory_state,
             query,
             token_budget,
@@ -319,7 +319,7 @@ impl<C: Channel> Agent<C> {
     ) -> Result<(), super::super::error::AgentError> {
         self.remove_cross_session_messages();
 
-        if let Some(msg) = super::assembler::fetch_cross_session(
+        if let Some(msg) = super::assembler_helpers::fetch_cross_session(
             &self.memory_state,
             query,
             token_budget,
@@ -342,7 +342,7 @@ impl<C: Channel> Agent<C> {
     ) -> Result<(), super::super::error::AgentError> {
         self.remove_summary_messages();
 
-        if let Some(msg) = super::assembler::fetch_summaries(
+        if let Some(msg) = super::assembler_helpers::fetch_summaries(
             &self.memory_state,
             token_budget,
             &self.metrics.token_counter,
@@ -1533,19 +1533,19 @@ mod tests {
 
     #[test]
     fn effective_recall_timeout_ms_nonzero_returns_unchanged() {
-        let result = crate::agent::context::assembler::effective_recall_timeout_ms(500);
+        let result = crate::agent::context::assembler_helpers::effective_recall_timeout_ms(500);
         assert_eq!(result, 500, "non-zero value must pass through unchanged");
     }
 
     #[test]
     fn effective_recall_timeout_ms_nonzero_large_returns_unchanged() {
-        let result = crate::agent::context::assembler::effective_recall_timeout_ms(5000);
+        let result = crate::agent::context::assembler_helpers::effective_recall_timeout_ms(5000);
         assert_eq!(result, 5000);
     }
 
     #[test]
     fn effective_recall_timeout_ms_zero_clamps_to_100() {
-        let result = crate::agent::context::assembler::effective_recall_timeout_ms(0);
+        let result = crate::agent::context::assembler_helpers::effective_recall_timeout_ms(0);
         assert_eq!(
             result, 100,
             "zero recall_timeout_ms must be clamped to 100ms"
@@ -1556,7 +1556,7 @@ mod tests {
     fn spreading_activation_default_timeout_is_nonzero() {
         // Ensures the default used in production is not accidentally set to zero —
         // which would always trigger the zero-clamp warn path in effective_recall_timeout_ms.
-        let result = crate::agent::context::assembler::effective_recall_timeout_ms(
+        let result = crate::agent::context::assembler_helpers::effective_recall_timeout_ms(
             zeph_config::memory::SpreadingActivationConfig::default().recall_timeout_ms,
         );
         assert!(

--- a/crates/zeph-core/src/agent/context/mod.rs
+++ b/crates/zeph-core/src/agent/context/mod.rs
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-pub(super) mod assembler;
+#[cfg(test)]
+pub(super) mod assembler_helpers;
 mod assembly;
 #[cfg(feature = "self-check")]
 pub(crate) mod retrieved;

--- a/crates/zeph-core/src/agent/context/tests.rs
+++ b/crates/zeph-core/src/agent/context/tests.rs
@@ -1558,7 +1558,7 @@ async fn test_prepare_context_no_scrub_when_redact_disabled() {
 
 #[test]
 fn correction_prompt_does_not_replay_bad_path_commands() {
-    let note = crate::agent::context::assembler::format_correction_note(
+    let note = super::assembler_helpers::format_correction_note(
         "cd /Users/m/dev/zeph && grep -n \"acp\" Cargo.toml | head -40",
         "Use the current repository and avoid hard-coded absolute paths.",
     );
@@ -3208,7 +3208,7 @@ async fn fetch_graph_facts_returns_none_when_graph_config_disabled() {
     let cid = memory.sqlite().create_conversation().await.unwrap();
     let mem_state = make_mem_state(std::sync::Arc::new(memory), cid, false);
     let tc = std::sync::Arc::new(zeph_memory::TokenCounter::new());
-    let result = crate::agent::context::assembler::fetch_graph_facts(&mem_state, "test", 1000, &tc)
+    let result = super::assembler_helpers::fetch_graph_facts(&mem_state, "test", 1000, &tc)
         .await
         .unwrap();
     assert!(result.is_none());
@@ -3220,7 +3220,7 @@ async fn fetch_graph_facts_returns_none_when_budget_zero() {
     let cid = memory.sqlite().create_conversation().await.unwrap();
     let mem_state = make_mem_state(std::sync::Arc::new(memory), cid, true);
     let tc = std::sync::Arc::new(zeph_memory::TokenCounter::new());
-    let result = crate::agent::context::assembler::fetch_graph_facts(&mem_state, "test", 0, &tc)
+    let result = super::assembler_helpers::fetch_graph_facts(&mem_state, "test", 0, &tc)
         .await
         .unwrap();
     assert!(result.is_none());
@@ -3232,7 +3232,7 @@ async fn fetch_graph_facts_returns_none_when_graph_is_empty() {
     let cid = memory.sqlite().create_conversation().await.unwrap();
     let mem_state = make_mem_state(std::sync::Arc::new(memory), cid, true);
     let tc = std::sync::Arc::new(zeph_memory::TokenCounter::new());
-    let result = crate::agent::context::assembler::fetch_graph_facts(&mem_state, "rust", 1000, &tc)
+    let result = super::assembler_helpers::fetch_graph_facts(&mem_state, "rust", 1000, &tc)
         .await
         .unwrap();
     assert!(result.is_none(), "empty graph must return None");
@@ -3592,7 +3592,7 @@ async fn fetch_graph_facts_returns_some_with_entities_and_has_prefix() {
 
     let mem_state = make_mem_state(std::sync::Arc::new(memory), cid, true);
     let tc = std::sync::Arc::new(zeph_memory::TokenCounter::new());
-    let result = crate::agent::context::assembler::fetch_graph_facts(&mem_state, "rust", 2000, &tc)
+    let result = super::assembler_helpers::fetch_graph_facts(&mem_state, "rust", 2000, &tc)
         .await
         .unwrap();
     assert!(result.is_some());

--- a/crates/zeph-llm/src/compatible.rs
+++ b/crates/zeph-llm/src/compatible.rs
@@ -100,13 +100,6 @@ impl CompatibleProvider {
         self
     }
 
-    /// Enable `CoE` logprobs collection for `chat_with_extras`.
-    #[must_use]
-    pub fn with_coe(mut self) -> Self {
-        self.inner = self.inner.with_coe();
-        self
-    }
-
     /// Forward MCP tool output schemas as JSON hints appended to tool descriptions.
     ///
     /// Delegates to the inner [`OpenAiProvider`]. When `enabled` is `false` the call is a no-op.

--- a/crates/zeph-llm/src/ollama.rs
+++ b/crates/zeph-llm/src/ollama.rs
@@ -49,8 +49,6 @@ use ollama_rs::generation::tools::{ToolFunctionInfo, ToolInfo, ToolType};
 use ollama_rs::models::ModelOptions;
 use tokio_stream::StreamExt;
 
-use ollama_rs::generation::parameters::LogprobsData as OllamaLogprobsData;
-
 use crate::provider::{
     ChatExtras, ChatResponse, ChatStream, GenerationOverrides, LlmProvider, Message, MessagePart,
     Role, ToolDefinition, ToolUseRequest,
@@ -82,8 +80,6 @@ pub struct OllamaProvider {
     vision_model: Option<String>,
     generation_overrides: Option<GenerationOverrides>,
     usage: UsageTracker,
-    /// When `true`, `chat_with_extras` requests logprobs and computes entropy.
-    coe_enabled: bool,
 }
 
 #[allow(clippy::cast_possible_truncation)]
@@ -125,15 +121,7 @@ impl OllamaProvider {
             vision_model: None,
             generation_overrides: None,
             usage: UsageTracker::default(),
-            coe_enabled: false,
         }
-    }
-
-    /// Enable `CoE` logprobs collection for `chat_with_extras`.
-    #[must_use]
-    pub fn with_coe(mut self) -> Self {
-        self.coe_enabled = true;
-        self
     }
 
     /// Override generation parameters (temperature, top-p, top-k) for this provider.
@@ -300,32 +288,7 @@ impl LlmProvider for OllamaProvider {
         &self,
         messages: &[Message],
     ) -> Result<(String, ChatExtras), LlmError> {
-        if !self.coe_enabled {
-            return Ok((self.chat(messages).await?, ChatExtras::default()));
-        }
-        let ollama_messages: Vec<ChatMessage> = messages.iter().map(convert_message).collect();
-        let mut request =
-            ChatMessageRequest::new(self.model.clone(), ollama_messages).logprobs(true);
-        if let Some(ref ov) = self.generation_overrides {
-            request = apply_generation_overrides(request, ov);
-        }
-        let response =
-            self.client.send_chat_messages(request).await.map_err(|e| {
-                LlmError::Other(format!("Ollama chat_with_extras request failed: {e}"))
-            })?;
-        if let Some(ref fd) = response.final_data {
-            self.usage.record_usage(fd.prompt_eval_count, fd.eval_count);
-        }
-        let entropy = response
-            .logprobs
-            .as_deref()
-            .filter(|lp| !lp.is_empty())
-            .map(|lp: &[OllamaLogprobsData]| {
-                #[allow(clippy::cast_precision_loss)]
-                let n = lp.len() as f64;
-                -lp.iter().map(|t| t.logprob).sum::<f64>() / n
-            });
-        Ok((response.message.content, ChatExtras { entropy }))
+        Ok((self.chat(messages).await?, ChatExtras::default()))
     }
 
     #[cfg_attr(

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -70,8 +70,6 @@ pub struct OpenAiProvider {
     output_schema_hint_bytes: usize,
     /// Maximum bytes of the combined description (base + hint). `usize::MAX` means no cap.
     max_tool_description_bytes: usize,
-    /// When `true`, `chat_with_extras` requests `logprobs: true` and computes entropy.
-    coe_enabled: bool,
 }
 
 impl fmt::Debug for OpenAiProvider {
@@ -93,7 +91,6 @@ impl fmt::Debug for OpenAiProvider {
                 "max_tool_description_bytes",
                 &self.max_tool_description_bytes,
             )
-            .field("coe_enabled", &self.coe_enabled)
             .finish()
     }
 }
@@ -114,7 +111,6 @@ impl Clone for OpenAiProvider {
             forward_output_schema: self.forward_output_schema,
             output_schema_hint_bytes: self.output_schema_hint_bytes,
             max_tool_description_bytes: self.max_tool_description_bytes,
-            coe_enabled: self.coe_enabled,
         }
     }
 }
@@ -152,18 +148,7 @@ impl OpenAiProvider {
             forward_output_schema: false,
             output_schema_hint_bytes: 1024,
             max_tool_description_bytes: usize::MAX,
-            coe_enabled: false,
         }
-    }
-
-    /// Enable `CoE` logprobs collection for `chat_with_extras`.
-    ///
-    /// When enabled, `chat_with_extras` includes `logprobs: true` in the request
-    /// and computes mean negative log-probability from the response.
-    #[must_use]
-    pub fn with_coe(mut self) -> Self {
-        self.coe_enabled = true;
-        self
     }
 
     /// Override generation parameters (temperature, top-p, frequency/presence penalty).
@@ -444,80 +429,6 @@ impl OpenAiProvider {
 
         Ok(response)
     }
-
-    /// Send a request with `logprobs: true` and return the response text plus computed entropy.
-    async fn send_request_with_logprobs(
-        &self,
-        messages: &[Message],
-    ) -> Result<(String, ChatExtras), LlmError> {
-        let api_messages = convert_messages(messages);
-        let (temperature, top_p, frequency_penalty, presence_penalty) =
-            if let Some(ref ov) = self.generation_overrides {
-                (
-                    ov.temperature,
-                    ov.top_p,
-                    ov.frequency_penalty,
-                    ov.presence_penalty,
-                )
-            } else {
-                (None, None, None, None)
-            };
-        let body = LogprobsChatRequest {
-            model: &self.model,
-            messages: &api_messages,
-            completion_tokens: CompletionTokens::for_model(&self.model, self.max_tokens),
-            logprobs: true,
-            temperature,
-            top_p,
-            frequency_penalty,
-            presence_penalty,
-        };
-        let response = send_with_retry("OpenAI", MAX_RETRIES, self.status_tx.as_ref(), || {
-            self.client
-                .post(format!("{}/chat/completions", self.base_url))
-                .header("Authorization", format!("Bearer {}", self.api_key))
-                .header("Content-Type", "application/json")
-                .json(&body)
-                .send()
-        })
-        .await?;
-
-        let status = response.status();
-        let text = response.text().await.map_err(LlmError::Http)?;
-
-        if !status.is_success() {
-            tracing::error!("OpenAI API error {status}: {text}");
-            return Err(LlmError::Other(format!(
-                "OpenAI API request failed (status {status})"
-            )));
-        }
-
-        let resp: OpenAiChatResponse = serde_json::from_str(&text)?;
-
-        if let Some(ref usage) = resp.usage {
-            self.store_cache_usage(usage);
-        }
-
-        let content = resp
-            .choices
-            .first()
-            .map(|c| c.message.content.clone())
-            .ok_or(LlmError::EmptyResponse {
-                provider: "openai".into(),
-            })?;
-
-        let entropy = resp.choices.first().and_then(|c| {
-            let logprobs = c.logprobs.as_ref()?.content.as_slice();
-            if logprobs.is_empty() {
-                return None;
-            }
-            #[allow(clippy::cast_precision_loss)]
-            let mean = -logprobs.iter().map(|t| t.logprob).sum::<f64>() / logprobs.len() as f64;
-            Some(mean)
-        });
-
-        Ok((content, ChatExtras { entropy }))
-    }
 }
 
 impl LlmProvider for OpenAiProvider {
@@ -549,10 +460,7 @@ impl LlmProvider for OpenAiProvider {
         &self,
         messages: &[Message],
     ) -> Result<(String, ChatExtras), LlmError> {
-        if !self.coe_enabled {
-            return Ok((self.send_request(messages).await?, ChatExtras::default()));
-        }
-        self.send_request_with_logprobs(messages).await
+        Ok((self.send_request(messages).await?, ChatExtras::default()))
     }
 
     #[cfg_attr(
@@ -1179,23 +1087,6 @@ struct ChatRequest<'a> {
 }
 
 #[derive(Serialize)]
-struct LogprobsChatRequest<'a> {
-    model: &'a str,
-    messages: &'a [ApiMessage<'a>],
-    #[serde(flatten)]
-    completion_tokens: CompletionTokens,
-    logprobs: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    temperature: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    top_p: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    frequency_penalty: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    presence_penalty: Option<f64>,
-}
-
-#[derive(Serialize)]
 struct Reasoning<'a> {
     effort: &'a str,
 }
@@ -1232,19 +1123,6 @@ struct PromptTokensDetails {
 #[derive(Deserialize)]
 struct ChatChoice {
     message: ChatMessage,
-    #[serde(default)]
-    logprobs: Option<ChoiceLogprobs>,
-}
-
-#[derive(Deserialize)]
-struct ChoiceLogprobs {
-    #[serde(default)]
-    content: Vec<TokenLogprob>,
-}
-
-#[derive(Deserialize)]
-struct TokenLogprob {
-    logprob: f64,
 }
 
 #[derive(Deserialize)]

--- a/specs/022-config-simplification/spec.md
+++ b/specs/022-config-simplification/spec.md
@@ -25,6 +25,8 @@ related:
 > **Date**: 2026-03-22 (updated 2026-03-26)
 > **Crates**: `zeph-config`, `zeph-core` (bootstrap/provider.rs)
 
+> **Amendment (#3248, 2026-04-23)**: `LlmRoutingStrategy::Task` and `LlmConfig::routes` were removed as unimplemented. Any spec section referencing `routing = "task"` or `[llm.routes]` is superseded — treat those values as unset. The `--migrate-config` command emits a warning and drops the keys automatically.
+
 ## 1. Overview
 
 > This is the **canonical reference** for the `[[llm.providers]]` registry pattern.

--- a/src/bootstrap/provider.rs
+++ b/src/bootstrap/provider.rs
@@ -384,14 +384,6 @@ fn create_provider_from_pool(config: &Config) -> Result<AnyProvider, BootstrapEr
                     .with_embed_concurrency(embed_concurrency),
             )))
         }
-        LlmRoutingStrategy::Task => {
-            // Task-based routing is not yet implemented; fall back to single provider.
-            tracing::warn!(
-                "routing = \"task\" is not yet implemented; \
-                 falling back to single provider from pool"
-            );
-            build_single_provider_from_pool(pool, config)
-        }
         LlmRoutingStrategy::Triage => build_triage_provider(pool, config),
     }
 }

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -624,7 +624,6 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
     config.llm = LlmConfig {
         providers,
         routing,
-        routes: std::collections::HashMap::new(),
         embedding_model: state
             .embedding_model
             .clone()


### PR DESCRIPTION
## Summary

- **#3248**: Remove `LlmRoutingStrategy::Task` unimplemented variant and `LlmConfig::routes` field from `zeph-config`. Config migration detects legacy `routing = "task"` and emits a deprecation warning before stripping it.
- **#3249**: Remove unreachable `coe_enabled`/`with_coe`/logprobs branches from `OllamaProvider`, `OpenAiProvider`, `CompatibleProvider` in `zeph-llm`. `RouterProvider::with_coe` (live path via `CoeRouter`) is preserved.
- **#3254**: Move 316 LOC of `#[cfg(test)]`-only helpers from `zeph-core/src/agent/context/assembler.rs` into `assembler_helpers.rs` gated at the module level. All call sites in `tests.rs` and `assembly.rs` updated to new path.

Net: ~550 LOC removed across three crates.

## Test plan

- [x] `cargo +nightly fmt --check` — pass
- [x] `cargo clippy --workspace --lib --bins -- -D warnings` — pass
- [x] `cargo nextest run --workspace --lib --bins` — 8242 passed, 0 failed
- [x] `cargo build --workspace` — pass
- [ ] **LLM serialization gate**: #3249 touches `ollama.rs`, `openai/mod.rs`, `compatible.rs` — live API round-trip required before merge per CLAUDE.md (leaf provider `chat()` logic unchanged; gate is a process requirement)

## Notes

- `specs/022-config-simplification/spec.md`, `book/src/advanced/orchestrator.md`, `book/src/guides/config-recipes.md`, `config/default.toml` updated to remove references to `routing = "task"`
- Follow-up P3: add unit test for `migrate_llm_to_providers` routing="task" pre-check path (no regression risk; logic is new)

Closes #3248
Closes #3249
Closes #3254
Part of #3247