### PR TITLE
fix(deps): update constant_time_eq to non-yanked version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,9 +1252,9 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.4.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dab3fe76c1571ecd5cfe878b61bce3fedf4adbde5d8a8653b2a7956ffd14628"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"


### PR DESCRIPTION
## Summary

- Runs `cargo update -p constant_time_eq` to resolve v0.4.3 (yanked) to v0.4.2
- Transitive dependency chain: `constant_time_eq` ← `blake3` ← multiple workspace crates
- No source code changes required — only `Cargo.lock` updated

Regarding #3279: clippy violations in `native.rs` were already resolved in a prior commit; the pre-PR check (`cargo clippy --all-targets --features full --workspace -- -D warnings`) passes cleanly.

## Test plan

- [x] `cargo clippy --all-targets --features full --workspace -- -D warnings` — zero errors
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 8244 passed
- [x] `cargo deny check advisories` — no yanked crate warnings after update

Closes #3279
Closes #3280