### PR TITLE
fix(tui): add /acp dirs, /acp auth-methods, /acp status slash-command handlers

### DIFF
--- a/crates/zeph-commands/src/commands.rs
+++ b/crates/zeph-commands/src/commands.rs
@@ -176,6 +176,13 @@ pub const COMMANDS: &[CommandInfo] = &[
         feature_gate: None,
     },
     CommandInfo {
+        name: "/acp",
+        args: "[dirs | auth-methods | status]",
+        description: "Inspect ACP server configuration",
+        category: SlashCategory::Integration,
+        feature_gate: Some("acp"),
+    },
+    CommandInfo {
         name: "/mcp",
         args: "[add|list|tools|remove]",
         description: "Manage MCP servers",

--- a/crates/zeph-commands/src/handlers/acp.rs
+++ b/crates/zeph-commands/src/handlers/acp.rs
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `/acp` slash command handler.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use crate::context::CommandContext;
+use crate::{CommandError, CommandHandler, CommandOutput, SlashCategory};
+
+/// Inspect ACP server configuration (`/acp dirs`, `/acp auth-methods`, `/acp status`).
+pub struct AcpCommand;
+
+impl CommandHandler<CommandContext<'_>> for AcpCommand {
+    fn name(&self) -> &'static str {
+        "/acp"
+    }
+
+    fn description(&self) -> &'static str {
+        "Inspect ACP server configuration (dirs, auth-methods, status)"
+    }
+
+    fn args_hint(&self) -> &'static str {
+        "[dirs | auth-methods | status]"
+    }
+
+    fn category(&self) -> SlashCategory {
+        SlashCategory::Integration
+    }
+
+    fn feature_gate(&self) -> Option<&'static str> {
+        Some("acp")
+    }
+
+    fn handle<'a>(
+        &'a self,
+        ctx: &'a mut CommandContext<'_>,
+        args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<CommandOutput, CommandError>> + Send + 'a>> {
+        Box::pin(async move { Ok(CommandOutput::Message(ctx.agent.handle_acp(args).await?)) })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_matches_slash_acp() {
+        assert_eq!(AcpCommand.name(), "/acp");
+    }
+
+    #[test]
+    fn category_is_integration() {
+        assert_eq!(AcpCommand.category(), SlashCategory::Integration);
+    }
+
+    #[test]
+    fn feature_gate_is_acp() {
+        assert_eq!(AcpCommand.feature_gate(), Some("acp"));
+    }
+
+    #[test]
+    fn description_and_args_hint_non_empty() {
+        assert!(!AcpCommand.description().is_empty());
+        assert!(!AcpCommand.args_hint().is_empty());
+    }
+}

--- a/crates/zeph-commands/src/handlers/mod.rs
+++ b/crates/zeph-commands/src/handlers/mod.rs
@@ -9,6 +9,7 @@
 //! [`CommandHandler<CommandContext>`]: crate::CommandHandler
 //! [`CommandContext`]: crate::context::CommandContext
 
+pub mod acp;
 pub mod agent_cmd;
 pub mod compaction;
 pub mod debug;

--- a/crates/zeph-commands/src/traits/agent.rs
+++ b/crates/zeph-commands/src/traits/agent.rs
@@ -391,6 +391,21 @@ pub trait AgentAccess: Send {
         args: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>>;
 
+    // ----- /acp -----
+
+    /// Handle `/acp [dirs|auth-methods|status]` and return a user-visible result.
+    ///
+    /// Subcommands: `dirs` (`additional_directories` allowlist), `auth-methods`, `status`.
+    /// No subcommand or empty args returns a short help text.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` when an unknown subcommand is passed.
+    fn handle_acp<'a>(
+        &'a mut self,
+        args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>>;
+
     // ----- /loop -----
 
     /// Handle `/loop <prompt> every <N> <unit>` or `/loop stop`.
@@ -607,6 +622,13 @@ impl AgentAccess for NullAgent {
     }
 
     fn handle_plugins<'a>(
+        &'a mut self,
+        _args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>> {
+        Box::pin(async { Ok(String::new()) })
+    }
+
+    fn handle_acp<'a>(
         &'a mut self,
         _args: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>> {

--- a/crates/zeph-config/src/ui.rs
+++ b/crates/zeph-config/src/ui.rs
@@ -106,6 +106,14 @@ impl<'de> serde::Deserialize<'de> for AcpAuthMethod {
     }
 }
 
+impl std::fmt::Display for AcpAuthMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Agent => f.write_str("agent"),
+        }
+    }
+}
+
 fn default_acp_auth_methods() -> Vec<AcpAuthMethod> {
     vec![AcpAuthMethod::Agent]
 }

--- a/crates/zeph-core/src/agent/acp_commands.rs
+++ b/crates/zeph-core/src/agent/acp_commands.rs
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::fmt::Write as _;
+
+use super::{Agent, error::AgentError};
+use crate::channel::Channel;
+
+/// Format the `additional_directories` allowlist for display.
+pub(super) fn format_acp_dirs(cfg: &zeph_config::AcpConfig) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "ACP additional_directories allowlist:");
+    if cfg.additional_directories.is_empty() {
+        let _ = writeln!(out, "  (none configured)");
+    } else {
+        for dir in &cfg.additional_directories {
+            let _ = writeln!(out, "  {dir}");
+        }
+    }
+    out.trim_end().to_owned()
+}
+
+/// Format the `auth_methods` list for display.
+pub(super) fn format_acp_auth_methods(cfg: &zeph_config::AcpConfig) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "ACP auth_methods:");
+    if cfg.auth_methods.is_empty() {
+        let _ = writeln!(out, "  (none configured)");
+    } else {
+        for method in &cfg.auth_methods {
+            let _ = writeln!(out, "  {method}");
+        }
+    }
+    out.trim_end().to_owned()
+}
+
+/// Format the ACP server status summary.
+pub(super) fn format_acp_status(cfg: &zeph_config::AcpConfig, is_acp_session: bool) -> String {
+    let mut out = String::new();
+    let enabled = if cfg.enabled { "enabled" } else { "disabled" };
+    let _ = writeln!(out, "ACP: {enabled}");
+    let _ = writeln!(out, "transport:       {:?}", cfg.transport);
+    let _ = writeln!(out, "agent_name:      {}", cfg.agent_name);
+    let _ = writeln!(out, "agent_version:   {}", cfg.agent_version);
+    let _ = writeln!(out, "max_sessions:    {}", cfg.max_sessions);
+    let _ = writeln!(out, "http_bind:       {}", cfg.http_bind);
+    let _ = writeln!(out, "discovery:       {}", cfg.discovery_enabled);
+    let _ = writeln!(out, "message_ids:     {}", cfg.message_ids_enabled);
+    let _ = writeln!(
+        out,
+        "this session:    {}",
+        if is_acp_session {
+            "ACP client"
+        } else {
+            "non-ACP"
+        }
+    );
+    out.trim_end().to_owned()
+}
+
+/// Pure dispatcher — separated from `Agent` for unit testing.
+pub(super) fn dispatch_acp(
+    cfg: &zeph_config::AcpConfig,
+    is_acp_session: bool,
+    args: &str,
+) -> Result<String, AgentError> {
+    match args.trim() {
+        "dirs" => Ok(format_acp_dirs(cfg)),
+        "auth-methods" => Ok(format_acp_auth_methods(cfg)),
+        "status" => Ok(format_acp_status(cfg, is_acp_session)),
+        "" => Ok(
+            "Usage: /acp <subcommand>\n\nSubcommands:\n  dirs          List additional_directories allowlist\n  auth-methods  List advertised auth methods\n  status        Show ACP server configuration summary"
+                .to_owned(),
+        ),
+        other => Err(AgentError::Other(format!(
+            "Unknown /acp subcommand: {other}. Valid subcommands: dirs, auth-methods, status"
+        ))),
+    }
+}
+
+impl<C: Channel> Agent<C> {
+    /// Dispatch `/acp [dirs|auth-methods|status]` and return a display string.
+    pub(super) fn handle_acp_as_string(&mut self, args: &str) -> Result<String, AgentError> {
+        dispatch_acp(&self.runtime.acp_config, self.security.is_acp_session, args)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg_default() -> zeph_config::AcpConfig {
+        zeph_config::AcpConfig::default()
+    }
+
+    fn cfg_with_dirs(dirs: &[&str]) -> zeph_config::AcpConfig {
+        let mut cfg = cfg_default();
+        cfg.additional_directories = dirs
+            .iter()
+            .map(|p| {
+                zeph_config::AdditionalDir::parse(
+                    std::path::Path::new(p)
+                        .canonicalize()
+                        .unwrap_or_else(|_| std::path::PathBuf::from(p)),
+                )
+                .unwrap_or_else(|_| panic!("failed to parse {p}"))
+            })
+            .collect();
+        cfg
+    }
+
+    #[test]
+    fn dirs_empty() {
+        let out = format_acp_dirs(&cfg_default());
+        assert!(out.contains("(none configured)"), "got: {out}");
+    }
+
+    #[test]
+    fn dirs_populated() {
+        let cfg = cfg_with_dirs(&["/tmp"]);
+        let out = format_acp_dirs(&cfg);
+        assert!(out.contains("/tmp"), "got: {out}");
+        assert!(!out.contains("(none configured)"), "got: {out}");
+    }
+
+    #[test]
+    fn auth_methods_default() {
+        let out = format_acp_auth_methods(&cfg_default());
+        assert!(out.contains("agent"), "got: {out}");
+        assert!(!out.contains("Agent"), "got: {out}");
+    }
+
+    #[test]
+    fn auth_methods_empty() {
+        let mut cfg = cfg_default();
+        cfg.auth_methods.clear();
+        let out = format_acp_auth_methods(&cfg);
+        assert!(out.contains("(none configured)"), "got: {out}");
+    }
+
+    #[test]
+    fn status_disabled() {
+        let out = format_acp_status(&cfg_default(), false);
+        assert!(out.contains("ACP: disabled"), "got: {out}");
+        assert!(out.contains("non-ACP"), "got: {out}");
+    }
+
+    #[test]
+    fn status_enabled_acp_session() {
+        let mut cfg = cfg_default();
+        cfg.enabled = true;
+        let out = format_acp_status(&cfg, true);
+        assert!(out.contains("ACP: enabled"), "got: {out}");
+        assert!(out.contains("ACP client"), "got: {out}");
+    }
+
+    #[test]
+    fn empty_args_returns_help() {
+        let out = dispatch_acp(&cfg_default(), false, "").unwrap();
+        assert!(out.contains("Usage: /acp"), "got: {out}");
+        assert!(out.contains("dirs"), "got: {out}");
+        assert!(out.contains("auth-methods"), "got: {out}");
+        assert!(out.contains("status"), "got: {out}");
+    }
+
+    #[test]
+    fn unknown_subcommand_returns_err() {
+        let err = dispatch_acp(&cfg_default(), false, "bogus").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("bogus"), "got: {msg}");
+        assert!(
+            !msg.contains("\"bogus\""),
+            "should not quote arg, got: {msg}"
+        );
+        assert!(
+            msg.contains("dirs"),
+            "should list valid subcommands, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn whitespace_args_returns_help() {
+        let out = dispatch_acp(&cfg_default(), false, "   ").unwrap();
+        assert!(out.contains("Usage: /acp"), "got: {out}");
+    }
+}

--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -853,6 +853,18 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
         })
     }
 
+    // ----- /acp -----
+
+    fn handle_acp<'a>(
+        &'a mut self,
+        args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>> {
+        Box::pin(async move {
+            self.handle_acp_as_string(args)
+                .map_err(|e| CommandError::new(e.to_string()))
+        })
+    }
+
     // ----- /loop -----
 
     fn handle_loop<'a>(

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1268,6 +1268,13 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Stores the ACP configuration snapshot for `/acp` slash-command display.
+    #[must_use]
+    pub fn with_acp_config(mut self, config: zeph_config::AcpConfig) -> Self {
+        self.runtime.acp_config = config;
+        self
+    }
+
     /// Returns a handle that can cancel the current in-flight operation.
     /// The returned `Notify` is stable across messages — callers invoke
     /// `notify_waiters()` to cancel whatever operation is running.

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+mod acp_commands;
 mod agent_access_impl;
 pub(crate) mod agent_supervisor;
 mod autodream;
@@ -932,6 +933,7 @@ impl<C: Channel> Agent<C> {
             > = if session_reg_missed {
                 use zeph_commands::CommandRegistry;
                 use zeph_commands::handlers::{
+                    acp::AcpCommand,
                     agent_cmd::AgentCommand,
                     compaction::{CompactCommand, NewConversationCommand, RecapCommand},
                     experiment::ExperimentCommand,
@@ -979,6 +981,7 @@ impl<C: Channel> Agent<C> {
                 agent_reg.register(PlanCommand);
                 agent_reg.register(LoopCommand);
                 agent_reg.register(PluginsCommand);
+                agent_reg.register(AcpCommand);
 
                 let mut ctx = zeph_commands::CommandContext {
                     sink: &mut agent_null_sink,

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -237,6 +237,8 @@ pub(crate) struct RuntimeConfig {
     pub(crate) supervisor_config: crate::config::TaskSupervisorConfig,
     /// Session recap config (#3064).
     pub(crate) recap_config: zeph_config::RecapConfig,
+    /// ACP server configuration snapshot for `/acp` slash-command display.
+    pub(crate) acp_config: zeph_config::AcpConfig,
     /// Set to `true` after the auto-recap is emitted at session resume (#3144).
     ///
     /// Used by `/recap` to skip a redundant LLM call when no new messages have
@@ -881,6 +883,7 @@ impl Default for RuntimeConfig {
             layers: Vec::new(),
             supervisor_config: crate::config::TaskSupervisorConfig::default(),
             recap_config: zeph_config::RecapConfig::default(),
+            acp_config: zeph_config::AcpConfig::default(),
             auto_recap_shown: false,
             msg_count_at_resume: 0,
         }

--- a/crates/zeph-core/src/agent/state/tests.rs
+++ b/crates/zeph-core/src/agent/state/tests.rs
@@ -92,6 +92,7 @@ fn make_runtime_config() -> RuntimeConfig {
         layers: Vec::new(),
         supervisor_config: crate::config::TaskSupervisorConfig::default(),
         recap_config: zeph_config::RecapConfig::default(),
+        acp_config: zeph_config::AcpConfig::default(),
         auto_recap_shown: false,
         msg_count_at_resume: 0,
     }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2271,6 +2271,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
 
     // Wire supervisor config so concurrency limits and turn-boundary abort are applied (#2883).
     let agent = agent.with_supervisor_config(&config.agent.supervisor);
+    let agent = agent.with_acp_config(config.acp.clone());
 
     #[cfg(feature = "self-check")]
     let agent = {


### PR DESCRIPTION
## Summary

- Register `AcpCommand` at `/acp` routing three subcommands: `dirs`, `auth-methods`, `status`
- Each produces a short system message without an LLM round-trip, fixing the palette actions that previously fell through to the LLM or were silently dropped
- `AcpConfig` snapshot stored on `RuntimeConfig`; `is_acp_session` read from `SecurityState`
- `Display` impl added for `AcpAuthMethod` (renders `"agent"`, not `"Agent"`)
- 13 unit tests covering all formatters, edge cases (empty lists, no-arg help, unknown subcommand, whitespace args)

## Test plan

- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 8257 tests pass
- [ ] `cargo +nightly fmt --check` — pass
- [ ] `cargo clippy --workspace -- -D warnings` — zero warnings
- [ ] Manual TUI: open command palette → select "ACP: list allowlisted directories" → system message appears without LLM round-trip
- [ ] Manual TUI: `/acp status` → shows ACP flags; `/acp auth-methods` → shows method list; `/acp` → shows help

## Follow-up issues (not in scope for this PR)

- Enforce `CommandHandler::feature_gate()` at dispatch time (pre-existing gap, affects all feature-gated commands)
- Regression test that `/acp status` never surfaces `auth_token`

Closes #3281