### PR TITLE
fix(acp): use http_bind config field when autostarting HTTP server

### DIFF
--- a/src/acp.rs
+++ b/src/acp.rs
@@ -1345,8 +1345,7 @@ pub(crate) async fn run_acp_http_server(
 
     let app = AppBuilder::new(config_path, vault_backend, vault_key, vault_path).await?;
     log_acp_runtime_paths(app.config(), app.config_path());
-    let bind_addr = bind_override
-        .map_or_else(|| app.config().acp.http_bind.clone(), str::to_owned);
+    let bind_addr = bind_override.map_or_else(|| app.config().acp.http_bind.clone(), str::to_owned);
 
     // CLI flag overrides config/env values for auth token.
     let auth_bearer_token = auth_token_override.or(app.config().acp.auth_token.clone());

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -1346,8 +1346,7 @@ pub(crate) async fn run_acp_http_server(
     let app = AppBuilder::new(config_path, vault_backend, vault_key, vault_path).await?;
     log_acp_runtime_paths(app.config(), app.config_path());
     let bind_addr = bind_override
-        .map(str::to_owned)
-        .unwrap_or_else(|| app.config().acp.http_bind.clone());
+        .map_or_else(|| app.config().acp.http_bind.clone(), str::to_owned);
 
     // CLI flag overrides config/env values for auth token.
     let auth_bearer_token = auth_token_override.or(app.config().acp.auth_token.clone());

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -1345,7 +1345,9 @@ pub(crate) async fn run_acp_http_server(
 
     let app = AppBuilder::new(config_path, vault_backend, vault_key, vault_path).await?;
     log_acp_runtime_paths(app.config(), app.config_path());
-    let bind_addr = bind_override.map_or_else(|| "127.0.0.1:9800".to_owned(), str::to_owned);
+    let bind_addr = bind_override
+        .map(str::to_owned)
+        .unwrap_or_else(|| app.config().acp.http_bind.clone());
 
     // CLI flag overrides config/env values for auth token.
     let auth_bearer_token = auth_token_override.or(app.config().acp.auth_token.clone());


### PR DESCRIPTION
## Summary

- `run_acp_http_server` now falls back to `app.config().acp.http_bind` instead of the hardcoded literal `"127.0.0.1:9800"` when no CLI `bind_override` is provided
- The autostart path (`AcpTransport::Http` / `AcpTransport::Both`) now respects `[acp] http_bind` from config
- Existing behaviour is preserved: the serde default for `http_bind` is `"127.0.0.1:9800"`, so configs without the field continue to work unchanged

## Test plan

- [ ] All 8235 unit tests pass (`cargo nextest run --workspace --lib --bins`)
- [ ] Set `[acp] transport = "http"` + `http_bind = "127.0.0.1:9811"` in config, run agent, verify `curl http://127.0.0.1:9811/health` → 200 OK
- [ ] Verify CLI `--acp-http-bind` override still takes precedence over config field

Closes #3290