### PR TITLE
feat(hooks): add reactive env hooks and MCP tool dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Hook actions now support `type = "mcp_tool"` to invoke MCP server tools directly without spawning a subprocess (#3293). Hooks can set `server`, `tool`, and optional `args` fields. Requires the MCP manager to be active; fails according to `fail_closed` if unavailable.
+- New `[hooks.permission_denied]` event fires when a tool execution is short-circuited by a `RuntimeLayer::before_tool` check (#3292). `Command` hooks receive `ZEPH_DENIED_TOOL` and `ZEPH_DENY_REASON` environment variables.
+- `McpDispatch` trait in `zeph-subagent` decouples hook execution from `zeph-mcp` — implementors are wired by `zeph-core` at call sites.
+
+### Changed
+
+- **BREAKING (config):** `HookDef.hook_type + command` fields replaced by `HookDef.action: HookAction` (serde-flattened). Existing TOML with `type = "command"` deserializes correctly — no manual migration needed. Internal Rust code constructing `HookDef` must use `action: HookAction::Command { command: "..." }` (#3293).
+
 ### Removed
 
 - `admission_rl` module (RL-based admission classifier, never wired into production) (#3250). SQLite table `admission_rl_weights` remains (migrations are append-only).

--- a/crates/zeph-config/src/hooks.rs
+++ b/crates/zeph-config/src/hooks.rs
@@ -36,6 +36,9 @@ impl Default for FileChangedConfig {
 }
 
 /// Top-level hooks configuration section.
+///
+/// Each sub-section corresponds to a lifecycle event. All sections default to
+/// empty (no hooks). Events fire in the order hooks are listed.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(default)]
 pub struct HooksConfig {
@@ -43,6 +46,12 @@ pub struct HooksConfig {
     pub cwd_changed: Vec<HookDef>,
     /// File-change watcher configuration with associated hooks.
     pub file_changed: Option<FileChangedConfig>,
+    /// Hooks fired when a tool execution is blocked by a `RuntimeLayer::before_tool` check.
+    ///
+    /// Environment variables set for `Command` hooks:
+    /// - `ZEPH_DENIED_TOOL` — the name of the tool that was blocked.
+    /// - `ZEPH_DENY_REASON` — human-readable reason string from the layer.
+    pub permission_denied: Vec<HookDef>,
 }
 
 impl HooksConfig {
@@ -57,14 +66,26 @@ impl HooksConfig {
     /// ```
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.cwd_changed.is_empty() && self.file_changed.is_none()
+        self.cwd_changed.is_empty()
+            && self.file_changed.is_none()
+            && self.permission_denied.is_empty()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::subagent::HookType;
+    use crate::subagent::HookAction;
+
+    fn cmd_hook(command: &str) -> HookDef {
+        HookDef {
+            action: HookAction::Command {
+                command: command.into(),
+            },
+            timeout_secs: 10,
+            fail_closed: false,
+        }
+    }
 
     #[test]
     fn hooks_config_default_is_empty() {
@@ -97,28 +118,62 @@ type = "command"
 command = "cargo check"
 timeout_secs = 30
 fail_closed = false
+
+[[permission_denied]]
+type = "command"
+command = "echo denied"
+timeout_secs = 5
+fail_closed = false
 "#;
         let cfg: HooksConfig = toml::from_str(toml).unwrap();
         assert_eq!(cfg.cwd_changed.len(), 1);
-        assert_eq!(cfg.cwd_changed[0].command, "echo changed");
-        assert_eq!(cfg.cwd_changed[0].hook_type, HookType::Command);
+        assert!(
+            matches!(&cfg.cwd_changed[0].action, HookAction::Command { command } if command == "echo changed")
+        );
         let fc = cfg.file_changed.as_ref().unwrap();
         assert_eq!(fc.watch_paths.len(), 2);
         assert_eq!(fc.debounce_ms, 300);
         assert_eq!(fc.hooks.len(), 1);
-        assert_eq!(fc.hooks[0].command, "cargo check");
+        assert_eq!(cfg.permission_denied.len(), 1);
+        assert!(
+            matches!(&cfg.permission_denied[0].action, HookAction::Command { command } if command == "echo denied")
+        );
+    }
+
+    #[test]
+    fn hooks_config_parses_mcp_tool_hook() {
+        let toml = r#"
+[[permission_denied]]
+type = "mcp_tool"
+server = "policy"
+tool = "audit"
+[permission_denied.args]
+severity = "high"
+"#;
+        let cfg: HooksConfig = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.permission_denied.len(), 1);
+        assert!(matches!(
+            &cfg.permission_denied[0].action,
+            HookAction::McpTool { server, tool, .. } if server == "policy" && tool == "audit"
+        ));
     }
 
     #[test]
     fn hooks_config_not_empty_with_cwd_hooks() {
         let cfg = HooksConfig {
-            cwd_changed: vec![HookDef {
-                hook_type: HookType::Command,
-                command: "echo hi".into(),
-                timeout_secs: 10,
-                fail_closed: false,
-            }],
+            cwd_changed: vec![cmd_hook("echo hi")],
             file_changed: None,
+            permission_denied: Vec::new(),
+        };
+        assert!(!cfg.is_empty());
+    }
+
+    #[test]
+    fn hooks_config_not_empty_with_permission_denied_hooks() {
+        let cfg = HooksConfig {
+            cwd_changed: Vec::new(),
+            file_changed: None,
+            permission_denied: vec![cmd_hook("echo denied")],
         };
         assert!(!cfg.is_empty());
     }

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -136,7 +136,7 @@ pub use sanitizer::{GuardrailAction, GuardrailConfig, GuardrailFailStrategy};
 pub use security::{ScannerConfig, SecurityConfig, TimeoutConfig, TrustConfig};
 pub use session::{RecapConfig, SessionConfig};
 pub use subagent::{
-    HookDef, HookMatcher, HookType, MemoryScope, PermissionMode, SkillFilter, SubagentHooks,
+    HookAction, HookDef, HookMatcher, MemoryScope, PermissionMode, SkillFilter, SubagentHooks,
     ToolPolicy,
 };
 pub use telemetry::{TelemetryBackend, TelemetryConfig};

--- a/crates/zeph-config/src/subagent.rs
+++ b/crates/zeph-config/src/subagent.rs
@@ -90,13 +90,47 @@ impl SkillFilter {
     }
 }
 
-// ── HookDef / HookType / HookMatcher / SubagentHooks ──────────────────────
+// ── HookDef / HookAction / HookMatcher / SubagentHooks ────────────────────
 
-/// The type of hook — currently only shell command hooks are supported.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum HookType {
-    Command,
+/// The action a hook executes when triggered.
+///
+/// Hooks either run a shell command or invoke an MCP server tool directly.
+///
+/// # Examples
+///
+/// ```toml
+/// # Shell command hook
+/// [[hooks.cwd_changed]]
+/// type = "command"
+/// command = "echo $ZEPH_NEW_CWD"
+/// timeout_secs = 10
+///
+/// # MCP tool hook
+/// [[hooks.permission_denied]]
+/// type = "mcp_tool"
+/// server = "policy-server"
+/// tool = "audit_denied"
+/// [hooks.permission_denied.args]
+/// severity = "high"
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum HookAction {
+    /// Execute a shell command via `sh -c`.
+    Command {
+        /// The shell command to run.
+        command: String,
+    },
+    /// Invoke an MCP server tool directly without spawning a subprocess.
+    McpTool {
+        /// The MCP server ID as declared in `[[mcp.servers]]`.
+        server: String,
+        /// The tool name to call on that server.
+        tool: String,
+        /// Optional JSON arguments passed to the tool. Defaults to `{}`.
+        #[serde(default)]
+        args: serde_json::Value,
+    },
 }
 
 fn default_hook_timeout() -> u64 {
@@ -104,11 +138,25 @@ fn default_hook_timeout() -> u64 {
 }
 
 /// A single hook definition.
+///
+/// Hooks are fired at specific lifecycle points. The `action` field determines
+/// whether the hook runs a shell command or dispatches to an MCP server tool.
+///
+/// # Examples
+///
+/// ```toml
+/// [[hooks.cwd_changed]]
+/// type = "command"
+/// command = "echo changed to $ZEPH_NEW_CWD"
+/// timeout_secs = 10
+/// fail_closed = false
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HookDef {
-    #[serde(rename = "type")]
-    pub hook_type: HookType,
-    pub command: String,
+    /// The action to execute: shell command or MCP tool call.
+    #[serde(flatten)]
+    pub action: HookAction,
+    /// Maximum seconds to wait for the hook before timing out. Default: 30.
     #[serde(default = "default_hook_timeout")]
     pub timeout_secs: u64,
     /// When `true`, a non-zero exit code or timeout causes the calling operation to fail.

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1146,6 +1146,11 @@ impl<C: Channel> Agent<C> {
             .cwd_changed
             .clone_from(&config.cwd_changed);
 
+        self.session
+            .hooks_config
+            .permission_denied
+            .clone_from(&config.permission_denied);
+
         if let Some(ref fc) = config.file_changed {
             self.session
                 .hooks_config

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -2658,6 +2658,14 @@ impl<C: Channel> Agent<C> {
         }
     }
 
+    /// Return an `McpDispatch` adapter backed by the agent's MCP manager, if present.
+    fn mcp_dispatch(&self) -> Option<McpManagerDispatch> {
+        self.mcp
+            .manager
+            .as_ref()
+            .map(|m| McpManagerDispatch(Arc::clone(m)))
+    }
+
     /// Check if the process cwd has changed since last call and fire `CwdChanged` hooks.
     ///
     /// Called after each tool batch completes. The check is a single syscall and has
@@ -2693,7 +2701,11 @@ impl<C: Channel> Agent<C> {
             let mut env = std::collections::HashMap::new();
             env.insert("ZEPH_OLD_CWD".to_owned(), old_cwd.display().to_string());
             env.insert("ZEPH_NEW_CWD".to_owned(), current.display().to_string());
-            if let Err(e) = zeph_subagent::hooks::fire_hooks(&hooks, &env).await {
+            let dispatch = self.mcp_dispatch();
+            let mcp: Option<&dyn zeph_subagent::McpDispatch> = dispatch
+                .as_ref()
+                .map(|d| d as &dyn zeph_subagent::McpDispatch);
+            if let Err(e) = zeph_subagent::hooks::fire_hooks(&hooks, &env, mcp).await {
                 tracing::warn!(error = %e, "CwdChanged hook failed");
             }
         }
@@ -2720,7 +2732,11 @@ impl<C: Channel> Agent<C> {
                 "ZEPH_CHANGED_PATH".to_owned(),
                 event.path.display().to_string(),
             );
-            if let Err(e) = zeph_subagent::hooks::fire_hooks(&hooks, &env).await {
+            let dispatch = self.mcp_dispatch();
+            let mcp: Option<&dyn zeph_subagent::McpDispatch> = dispatch
+                .as_ref()
+                .map(|d| d as &dyn zeph_subagent::McpDispatch);
+            if let Err(e) = zeph_subagent::hooks::fire_hooks(&hooks, &env, mcp).await {
                 tracing::warn!(error = %e, "FileChanged hook failed");
             }
         }
@@ -2728,6 +2744,45 @@ impl<C: Channel> Agent<C> {
         let _ = self.channel.send_status("").await;
     }
 }
+/// Thin wrapper that implements [`zeph_subagent::McpDispatch`] over an [`Arc<zeph_mcp::McpManager>`].
+///
+/// Used to pass MCP tool dispatch capability into `fire_hooks` without coupling
+/// `zeph-subagent` to `zeph-mcp`.
+struct McpManagerDispatch(Arc<zeph_mcp::McpManager>);
+
+impl zeph_subagent::McpDispatch for McpManagerDispatch {
+    fn call_tool<'a>(
+        &'a self,
+        server: &'a str,
+        tool: &'a str,
+        args: serde_json::Value,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<serde_json::Value, String>> + Send + 'a>,
+    > {
+        Box::pin(async move {
+            self.0
+                .call_tool(server, tool, args)
+                .await
+                .map(|result| {
+                    // Extract text content from the MCP response as a JSON value.
+                    let texts: Vec<serde_json::Value> = result
+                        .content
+                        .iter()
+                        .filter_map(|c| {
+                            if let rmcp::model::RawContent::Text(t) = &c.raw {
+                                Some(serde_json::Value::String(t.text.clone()))
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+                    serde_json::Value::Array(texts)
+                })
+                .map_err(|e| e.to_string())
+        })
+    }
+}
+
 pub(crate) async fn shutdown_signal(rx: &mut watch::Receiver<bool>) {
     while !*rx.borrow_and_update() {
         if rx.changed().await.is_err() {

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -607,6 +607,8 @@ pub(crate) struct HooksConfigSnapshot {
     pub(crate) cwd_changed: Vec<zeph_config::HookDef>,
     /// Hooks fired when a watched file changes.
     pub(crate) file_changed_hooks: Vec<zeph_config::HookDef>,
+    /// Hooks fired when a tool execution is blocked by a `RuntimeLayer::before_tool` check.
+    pub(crate) permission_denied: Vec<zeph_config::HookDef>,
 }
 
 // Groups message buffering and image staging state.

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -1890,6 +1890,35 @@ impl<C: Channel> Agent<C> {
                         }
                     }
                     if let Some(r) = sc_result {
+                        // Fire PermissionDenied hooks (fail_open: hook errors are logged, not fatal).
+                        let pd_hooks = self.session.hooks_config.permission_denied.clone();
+                        if !pd_hooks.is_empty() {
+                            let _span = tracing::info_span!(
+                                "core.hooks.permission_denied",
+                                tool = %tc.name,
+                            )
+                            .entered();
+                            let mut env = std::collections::HashMap::new();
+                            env.insert("ZEPH_DENIED_TOOL".to_owned(), tc.name.to_string());
+                            env.insert(
+                                "ZEPH_DENY_REASON".to_owned(),
+                                "blocked by before_tool layer".to_owned(),
+                            );
+                            let dispatch = self.mcp_dispatch();
+                            let mcp: Option<&dyn zeph_subagent::McpDispatch> = dispatch
+                                .as_ref()
+                                .map(|d| d as &dyn zeph_subagent::McpDispatch);
+                            // TODO: implement retry-on-{"retry":true} stdout signal (#3292)
+                            if let Err(e) =
+                                zeph_subagent::hooks::fire_hooks(&pd_hooks, &env, mcp).await
+                            {
+                                tracing::warn!(
+                                    error = %e,
+                                    tool = %tc.name,
+                                    "PermissionDenied hook failed"
+                                );
+                            }
+                        }
                         tier_futs.push((idx, Box::pin(std::future::ready(r))));
                         continue;
                     }

--- a/crates/zeph-core/src/config.rs
+++ b/crates/zeph-core/src/config.rs
@@ -13,7 +13,7 @@ pub use zeph_config::{
     ClassifiersConfig, CompressionConfig, CompressionStrategy, Config, ConfigError, CostConfig,
     DaemonConfig, DebugConfig, DetectorMode, DiscordConfig, DocumentConfig, DumpFormat,
     ExperimentConfig, ExperimentSchedule, FocusConfig, GatewayConfig, GenerationParams,
-    GraphConfig, HookDef, HookMatcher, HookType, IndexConfig, LearningConfig, LlmConfig,
+    GraphConfig, HookAction, HookDef, HookMatcher, IndexConfig, LearningConfig, LlmConfig,
     LlmRoutingStrategy, LogRotation, LoggingConfig, MAX_TOKENS_CAP, McpConfig, McpOAuthConfig,
     McpServerConfig, McpTrustLevel, MemoryConfig, MemoryScope, NoteLinkingConfig,
     OAuthTokenStorage, OrchestrationConfig, PermissionMode, ProviderEntry, ProviderKind,

--- a/crates/zeph-subagent/src/agent_loop.rs
+++ b/crates/zeph-subagent/src/agent_loop.rs
@@ -134,7 +134,8 @@ async fn handle_tool_step(
                     matching_hooks(&hooks.pre_tool_use, tc.name.as_str());
                 if !pre_hooks.is_empty() {
                     let pre_owned: Vec<HookDef> = pre_hooks.into_iter().cloned().collect();
-                    if let Err(e) = fire_hooks(&pre_owned, &hook_env).await {
+                    // MCP dispatch is not available in the subagent execution path.
+                    if let Err(e) = fire_hooks(&pre_owned, &hook_env, None).await {
                         tracing::warn!(error = %e, tool = %tc.name, "PreToolUse hook failed");
                     }
                 }
@@ -175,7 +176,8 @@ async fn handle_tool_step(
                         matching_hooks(&hooks.post_tool_use, tc.name.as_str());
                     if !post_hooks.is_empty() {
                         let post_owned: Vec<HookDef> = post_hooks.into_iter().cloned().collect();
-                        if let Err(e) = fire_hooks(&post_owned, &hook_env).await {
+                        // MCP dispatch is not available in the subagent execution path.
+                        if let Err(e) = fire_hooks(&post_owned, &hook_env, None).await {
                             tracing::warn!(
                                 error = %e,
                                 tool = %tc.name,

--- a/crates/zeph-subagent/src/hooks.rs
+++ b/crates/zeph-subagent/src/hooks.rs
@@ -3,13 +3,19 @@
 
 //! Lifecycle hooks for sub-agents.
 //!
-//! Hooks are shell commands executed at specific points in a sub-agent's lifecycle.
-//! Per-agent frontmatter supports `PreToolUse` and `PostToolUse` hooks via the
-//! `hooks` section. `SubagentStart` and `SubagentStop` are config-level events.
+//! Hooks are shell commands or MCP tool calls executed at specific points in a
+//! sub-agent's or main agent's lifecycle. Per-agent frontmatter supports `PreToolUse`
+//! and `PostToolUse` hooks via the `hooks` section. Config-level events include
+//! `CwdChanged`, `FileChanged`, and `PermissionDenied`.
+//!
+//! # Hook actions
+//!
+//! - `type = "command"` — runs a shell command via `sh -c`.
+//! - `type = "mcp_tool"` — dispatches to an MCP server tool via [`McpDispatch`].
 //!
 //! # Security
 //!
-//! All hook commands are run via `sh -c` with a **cleared** environment. Only `PATH`
+//! All shell hook commands are run via `sh -c` with a **cleared** environment. Only `PATH`
 //! from the parent process is preserved, and the hook-specific `ZEPH_*` variables are
 //! added explicitly. This prevents accidental secret leakage from the parent environment.
 //!
@@ -22,16 +28,15 @@
 //!
 //! ```rust,no_run
 //! use std::collections::HashMap;
-//! use zeph_subagent::{HookDef, HookType, fire_hooks};
+//! use zeph_subagent::{HookDef, HookAction, fire_hooks};
 //!
 //! async fn run() {
 //!     let hooks = vec![HookDef {
-//!         hook_type: HookType::Command,
-//!         command: "true".to_owned(),
+//!         action: HookAction::Command { command: "true".to_owned() },
 //!         timeout_secs: 5,
 //!         fail_closed: false,
 //!     }];
-//!     fire_hooks(&hooks, &HashMap::new()).await.unwrap();
+//!     fire_hooks(&hooks, &HashMap::new(), None).await.unwrap();
 //! }
 //! ```
 
@@ -43,11 +48,35 @@ use thiserror::Error;
 use tokio::process::Command;
 use tokio::time::timeout;
 
-pub use zeph_config::{HookDef, HookMatcher, HookType, SubagentHooks};
+pub use zeph_config::{HookAction, HookDef, HookMatcher, SubagentHooks};
+
+// ── McpDispatch ───────────────────────────────────────────────────────────────
+
+/// Abstraction over MCP tool dispatch used by hooks.
+///
+/// This trait decouples `zeph-subagent` from `zeph-mcp`, allowing the hook
+/// executor to call MCP tools without a direct crate dependency. Implementors
+/// are provided by `zeph-core` at the call site.
+///
+/// # Errors
+///
+/// Returns an error string if the tool call fails for any reason (server not
+/// found, policy violation, timeout, etc.).
+pub trait McpDispatch: Send + Sync {
+    /// Call a tool on the named MCP server with the given JSON arguments.
+    fn call_tool<'a>(
+        &'a self,
+        server: &'a str,
+        tool: &'a str,
+        args: serde_json::Value,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<serde_json::Value, String>> + Send + 'a>,
+    >;
+}
 
 // ── Error ─────────────────────────────────────────────────────────────────────
 
-/// Errors that can occur when executing a lifecycle hook command.
+/// Errors that can occur when executing a lifecycle hook.
 #[derive(Debug, Error)]
 pub enum HookError {
     /// The shell command exited with a non-zero status code.
@@ -65,6 +94,20 @@ pub enum HookError {
         #[source]
         source: std::io::Error,
     },
+
+    /// An `mcp_tool` hook was configured but no MCP manager is available.
+    #[error(
+        "mcp_tool hook requires an MCP manager but none was provided (server={server}, tool={tool})"
+    )]
+    McpUnavailable { server: String, tool: String },
+
+    /// The MCP tool call returned an error.
+    #[error("mcp_tool hook failed (server={server}, tool={tool}): {reason}")]
+    McpToolFailed {
+        server: String,
+        tool: String,
+        reason: String,
+    },
 }
 
 // ── Matching ──────────────────────────────────────────────────────────────────
@@ -79,9 +122,9 @@ pub enum HookError {
 /// # Examples
 ///
 /// ```rust
-/// use zeph_subagent::{HookDef, HookMatcher, HookType, matching_hooks};
+/// use zeph_subagent::{HookDef, HookAction, HookMatcher, matching_hooks};
 ///
-/// let hook = HookDef { hook_type: HookType::Command, command: "echo hi".to_owned(), timeout_secs: 30, fail_closed: false };
+/// let hook = HookDef { action: HookAction::Command { command: "echo hi".to_owned() }, timeout_secs: 30, fail_closed: false };
 /// let matchers = vec![HookMatcher { matcher: "Edit|Write".to_owned(), hooks: vec![hook] }];
 ///
 /// assert_eq!(matching_hooks(&matchers, "Edit").len(), 1);
@@ -111,20 +154,25 @@ pub fn matching_hooks<'a>(matchers: &'a [HookMatcher], tool_name: &str) -> Vec<&
 /// execution stops immediately and `Err` is returned. Otherwise errors are logged
 /// and execution continues.
 ///
+/// The `mcp` parameter provides MCP tool dispatch for `type = "mcp_tool"` hooks.
+/// Pass `None` when no MCP manager is available; `mcp_tool` hooks will fail with
+/// [`HookError::McpUnavailable`] (respecting `fail_closed`).
+///
 /// # Errors
 ///
-/// Returns [`HookError`] if a fail-closed hook exits non-zero or times out.
+/// Returns [`HookError`] if a fail-closed hook exits non-zero, times out, or the
+/// MCP call fails.
 pub async fn fire_hooks<S: BuildHasher>(
     hooks: &[HookDef],
     env: &HashMap<String, String, S>,
+    mcp: Option<&dyn McpDispatch>,
 ) -> Result<(), HookError> {
     for hook in hooks {
-        let result = fire_single_hook(hook, env).await;
+        let result = fire_single_hook(hook, env, mcp).await;
         match result {
             Ok(()) => {}
             Err(e) if hook.fail_closed => {
                 tracing::error!(
-                    command = %hook.command,
                     error = %e,
                     "fail-closed hook failed — aborting"
                 );
@@ -132,7 +180,6 @@ pub async fn fire_hooks<S: BuildHasher>(
             }
             Err(e) => {
                 tracing::warn!(
-                    command = %hook.command,
                     error = %e,
                     "hook failed (fail_open) — continuing"
                 );
@@ -145,9 +192,39 @@ pub async fn fire_hooks<S: BuildHasher>(
 async fn fire_single_hook<S: BuildHasher>(
     hook: &HookDef,
     env: &HashMap<String, String, S>,
+    mcp: Option<&dyn McpDispatch>,
+) -> Result<(), HookError> {
+    match &hook.action {
+        HookAction::Command { command } => fire_shell_hook(command, hook.timeout_secs, env).await,
+        HookAction::McpTool { server, tool, args } => {
+            let dispatcher = mcp.ok_or_else(|| HookError::McpUnavailable {
+                server: server.clone(),
+                tool: tool.clone(),
+            })?;
+            let call_fut = dispatcher.call_tool(server, tool, args.clone());
+            match timeout(Duration::from_secs(hook.timeout_secs), call_fut).await {
+                Ok(Ok(_)) => Ok(()),
+                Ok(Err(reason)) => Err(HookError::McpToolFailed {
+                    server: server.clone(),
+                    tool: tool.clone(),
+                    reason,
+                }),
+                Err(_) => Err(HookError::Timeout {
+                    command: format!("mcp_tool:{server}/{tool}"),
+                    timeout_secs: hook.timeout_secs,
+                }),
+            }
+        }
+    }
+}
+
+async fn fire_shell_hook<S: BuildHasher>(
+    command: &str,
+    timeout_secs: u64,
+    env: &HashMap<String, String, S>,
 ) -> Result<(), HookError> {
     let mut cmd = Command::new("sh");
-    cmd.arg("-c").arg(&hook.command);
+    cmd.arg("-c").arg(command);
     // SEC-H-002: clear inherited env to prevent secret leakage, then set only hook vars.
     cmd.env_clear();
     // Preserve minimal PATH so the shell can find standard tools.
@@ -162,28 +239,28 @@ async fn fire_single_hook<S: BuildHasher>(
     cmd.stderr(std::process::Stdio::null());
 
     let mut child = cmd.spawn().map_err(|e| HookError::Io {
-        command: hook.command.clone(),
+        command: command.to_owned(),
         source: e,
     })?;
 
-    let result = timeout(Duration::from_secs(hook.timeout_secs), child.wait()).await;
+    let result = timeout(Duration::from_secs(timeout_secs), child.wait()).await;
 
     match result {
         Ok(Ok(status)) if status.success() => Ok(()),
         Ok(Ok(status)) => Err(HookError::NonZeroExit {
-            command: hook.command.clone(),
+            command: command.to_owned(),
             code: status.code().unwrap_or(-1),
         }),
         Ok(Err(e)) => Err(HookError::Io {
-            command: hook.command.clone(),
+            command: command.to_owned(),
             source: e,
         }),
         Err(_) => {
             // SEC-H-004: explicitly kill child on timeout to prevent orphan processes.
             let _ = child.kill().await;
             Err(HookError::Timeout {
-                command: hook.command.clone(),
-                timeout_secs: hook.timeout_secs,
+                command: command.to_owned(),
+                timeout_secs,
             })
         }
     }
@@ -195,10 +272,11 @@ async fn fire_single_hook<S: BuildHasher>(
 mod tests {
     use super::*;
 
-    fn make_hook(command: &str, fail_closed: bool, timeout_secs: u64) -> HookDef {
+    fn cmd_hook(command: &str, fail_closed: bool, timeout_secs: u64) -> HookDef {
         HookDef {
-            hook_type: HookType::Command,
-            command: command.to_owned(),
+            action: HookAction::Command {
+                command: command.to_owned(),
+            },
             timeout_secs,
             fail_closed,
         }
@@ -215,16 +293,18 @@ mod tests {
 
     #[test]
     fn matching_hooks_exact_name() {
-        let hook = make_hook("echo hi", false, 30);
+        let hook = cmd_hook("echo hi", false, 30);
         let matchers = vec![make_matcher("Edit", vec![hook.clone()])];
         let result = matching_hooks(&matchers, "Edit");
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].command, "echo hi");
+        assert!(
+            matches!(&result[0].action, HookAction::Command { command } if command == "echo hi")
+        );
     }
 
     #[test]
     fn matching_hooks_substring() {
-        let hook = make_hook("echo sub", false, 30);
+        let hook = cmd_hook("echo sub", false, 30);
         let matchers = vec![make_matcher("Edit", vec![hook.clone()])];
         let result = matching_hooks(&matchers, "EditFile");
         assert_eq!(result.len(), 1);
@@ -232,19 +312,17 @@ mod tests {
 
     #[test]
     fn matching_hooks_pipe_separated() {
-        let h1 = make_hook("echo e", false, 30);
-        let h2 = make_hook("echo w", false, 30);
+        let h1 = cmd_hook("echo e", false, 30);
+        let h2 = cmd_hook("echo w", false, 30);
         let matchers = vec![
             make_matcher("Edit|Write", vec![h1.clone()]),
             make_matcher("Shell", vec![h2.clone()]),
         ];
         let result_edit = matching_hooks(&matchers, "Edit");
         assert_eq!(result_edit.len(), 1);
-        assert_eq!(result_edit[0].command, "echo e");
 
         let result_shell = matching_hooks(&matchers, "Shell");
         assert_eq!(result_shell.len(), 1);
-        assert_eq!(result_shell[0].command, "echo w");
 
         let result_none = matching_hooks(&matchers, "Read");
         assert!(result_none.is_empty());
@@ -252,7 +330,7 @@ mod tests {
 
     #[test]
     fn matching_hooks_no_match() {
-        let hook = make_hook("echo nope", false, 30);
+        let hook = cmd_hook("echo nope", false, 30);
         let matchers = vec![make_matcher("Edit", vec![hook])];
         let result = matching_hooks(&matchers, "Shell");
         assert!(result.is_empty());
@@ -260,7 +338,7 @@ mod tests {
 
     #[test]
     fn matching_hooks_empty_token_ignored() {
-        let hook = make_hook("echo empty", false, 30);
+        let hook = cmd_hook("echo empty", false, 30);
         let matchers = vec![make_matcher("|Edit|", vec![hook])];
         let result = matching_hooks(&matchers, "Edit");
         assert_eq!(result.len(), 1);
@@ -268,8 +346,8 @@ mod tests {
 
     #[test]
     fn matching_hooks_multiple_matchers_both_match() {
-        let h1 = make_hook("echo 1", false, 30);
-        let h2 = make_hook("echo 2", false, 30);
+        let h1 = cmd_hook("echo 1", false, 30);
+        let h2 = cmd_hook("echo 2", false, 30);
         let matchers = vec![
             make_matcher("Shell", vec![h1]),
             make_matcher("Shell", vec![h2]),
@@ -282,26 +360,26 @@ mod tests {
 
     #[tokio::test]
     async fn fire_hooks_success() {
-        let hooks = vec![make_hook("true", false, 5)];
+        let hooks = vec![cmd_hook("true", false, 5)];
         let env = HashMap::new();
-        assert!(fire_hooks(&hooks, &env).await.is_ok());
+        assert!(fire_hooks(&hooks, &env, None).await.is_ok());
     }
 
     #[tokio::test]
     async fn fire_hooks_fail_open_continues() {
         let hooks = vec![
-            make_hook("false", false, 5), // fail open
-            make_hook("true", false, 5),  // should still run
+            cmd_hook("false", false, 5), // fail open
+            cmd_hook("true", false, 5),  // should still run
         ];
         let env = HashMap::new();
-        assert!(fire_hooks(&hooks, &env).await.is_ok());
+        assert!(fire_hooks(&hooks, &env, None).await.is_ok());
     }
 
     #[tokio::test]
     async fn fire_hooks_fail_closed_returns_err() {
-        let hooks = vec![make_hook("false", true, 5)];
+        let hooks = vec![cmd_hook("false", true, 5)];
         let env = HashMap::new();
-        let result = fire_hooks(&hooks, &env).await;
+        let result = fire_hooks(&hooks, &env, None).await;
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(matches!(err, HookError::NonZeroExit { .. }));
@@ -309,9 +387,9 @@ mod tests {
 
     #[tokio::test]
     async fn fire_hooks_timeout() {
-        let hooks = vec![make_hook("sleep 10", true, 1)];
+        let hooks = vec![cmd_hook("sleep 10", true, 1)];
         let env = HashMap::new();
-        let result = fire_hooks(&hooks, &env).await;
+        let result = fire_hooks(&hooks, &env, None).await;
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(matches!(err, HookError::Timeout { .. }));
@@ -319,16 +397,48 @@ mod tests {
 
     #[tokio::test]
     async fn fire_hooks_env_passed() {
-        let hooks = vec![make_hook(r#"test "$ZEPH_TEST_VAR" = "hello""#, true, 5)];
+        let hooks = vec![cmd_hook(r#"test "$ZEPH_TEST_VAR" = "hello""#, true, 5)];
         let mut env = HashMap::new();
         env.insert("ZEPH_TEST_VAR".to_owned(), "hello".to_owned());
-        assert!(fire_hooks(&hooks, &env).await.is_ok());
+        assert!(fire_hooks(&hooks, &env, None).await.is_ok());
     }
 
     #[tokio::test]
     async fn fire_hooks_empty_list_ok() {
         let env = HashMap::new();
-        assert!(fire_hooks(&[], &env).await.is_ok());
+        assert!(fire_hooks(&[], &env, None).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn fire_hooks_mcp_unavailable_fail_open() {
+        let hooks = vec![HookDef {
+            action: HookAction::McpTool {
+                server: "srv".into(),
+                tool: "t".into(),
+                args: serde_json::Value::Null,
+            },
+            timeout_secs: 5,
+            fail_closed: false,
+        }];
+        let env = HashMap::new();
+        // fail_open: should succeed even though MCP is unavailable
+        assert!(fire_hooks(&hooks, &env, None).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn fire_hooks_mcp_unavailable_fail_closed() {
+        let hooks = vec![HookDef {
+            action: HookAction::McpTool {
+                server: "srv".into(),
+                tool: "t".into(),
+                args: serde_json::Value::Null,
+            },
+            timeout_secs: 5,
+            fail_closed: true,
+        }];
+        let env = HashMap::new();
+        let result = fire_hooks(&hooks, &env, None).await;
+        assert!(matches!(result, Err(HookError::McpUnavailable { .. })));
     }
 
     // ── YAML parsing ──────────────────────────────────────────────────────────
@@ -353,7 +463,9 @@ PostToolUse:
         assert_eq!(hooks.pre_tool_use.len(), 1);
         assert_eq!(hooks.pre_tool_use[0].matcher, "Edit|Write");
         assert_eq!(hooks.pre_tool_use[0].hooks.len(), 1);
-        assert_eq!(hooks.pre_tool_use[0].hooks[0].command, "echo pre");
+        assert!(
+            matches!(&hooks.pre_tool_use[0].hooks[0].action, HookAction::Command { command } if command == "echo pre")
+        );
         assert_eq!(hooks.post_tool_use.len(), 1);
     }
 

--- a/crates/zeph-subagent/src/lib.rs
+++ b/crates/zeph-subagent/src/lib.rs
@@ -60,7 +60,8 @@ pub use error::SubAgentError;
 pub use filter::{FilteredToolExecutor, PlanModeExecutor, filter_skills};
 pub use grants::{Grant, GrantKind, PermissionGrants, SecretRequest};
 pub use hooks::{
-    HookDef, HookError, HookMatcher, HookType, SubagentHooks, fire_hooks, matching_hooks,
+    HookAction, HookDef, HookError, HookMatcher, McpDispatch, SubagentHooks, fire_hooks,
+    matching_hooks,
 };
 pub use manager::{SpawnContext, SubAgentHandle, SubAgentManager, SubAgentStatus};
 pub use memory::{ensure_memory_dir, load_memory_content};

--- a/crates/zeph-subagent/src/manager.rs
+++ b/crates/zeph-subagent/src/manager.rs
@@ -765,7 +765,7 @@ impl SubAgentManager {
             let start_hooks = config.hooks.start.clone();
             let start_env = make_hook_env(task_id, def_name, "");
             tokio::spawn(async move {
-                if let Err(e) = fire_hooks(&start_hooks, &start_env).await {
+                if let Err(e) = fire_hooks(&start_hooks, &start_env, None).await {
                     tracing::warn!(error = %e, "SubagentStart hook failed");
                 }
             });
@@ -845,7 +845,7 @@ impl SubAgentManager {
             let stop_hooks = self.stop_hooks.clone();
             let stop_env = make_hook_env(task_id, &handle.def.name, "");
             tokio::spawn(async move {
-                if let Err(e) = fire_hooks(&stop_hooks, &stop_env).await {
+                if let Err(e) = fire_hooks(&stop_hooks, &stop_env, None).await {
                     tracing::warn!(error = %e, "SubagentStop hook failed");
                 }
             });
@@ -987,7 +987,7 @@ impl SubAgentManager {
             let stop_hooks = self.stop_hooks.clone();
             let stop_env = make_hook_env(task_id, &handle.def.name, "");
             tokio::spawn(async move {
-                if let Err(e) = fire_hooks(&stop_hooks, &stop_env).await {
+                if let Err(e) = fire_hooks(&stop_hooks, &stop_env, None).await {
                     tracing::warn!(error = %e, "SubagentStop hook failed");
                 }
             });
@@ -1218,7 +1218,7 @@ impl SubAgentManager {
             let def_name = meta.def_name.clone();
             let start_env = make_hook_env(&new_task_id, &def_name, "");
             tokio::spawn(async move {
-                if let Err(e) = fire_hooks(&start_hooks, &start_env).await {
+                if let Err(e) = fire_hooks(&start_hooks, &start_env, None).await {
                     tracing::warn!(error = %e, "SubagentStart hook failed");
                 }
             });


### PR DESCRIPTION
## Summary

- **#3292**: New `PermissionDenied` hook event fires when `RuntimeLayer::before_tool` blocks a tool call. Hooks receive `ZEPH_DENIED_TOOL` and `ZEPH_DENY_REASON` env vars.
- **#3293**: New `McpTool` hook action dispatches directly to an MCP server tool without spawning a subprocess. New `McpDispatch` trait in `zeph-subagent` decouples hook execution from `zeph-mcp`.
- **BREAKING**: `HookDef.hook_type + command` replaced by `HookDef.action: HookAction` (serde-flattened). Existing TOML configs with `type = "command"` continue to work; Rust code constructing `HookDef` must use `HookAction::Command { command }`.

## Changes

- `zeph-config`: `HookAction` enum (`Command` / `McpTool`), `HooksConfig.permission_denied` field
- `zeph-subagent`: `McpDispatch` trait, `fire_hooks` updated to accept `Option<&dyn McpDispatch>`, new `HookError` variants
- `zeph-core`: `McpManagerDispatch` adapter, `mcp_dispatch()` helper, PermissionDenied hook wiring in `native.rs` with tracing span

## Test plan

- [ ] `cargo nextest run --workspace --features full --lib --bins` — 8612 tests pass
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace --features full -- -D warnings` — clean
- [ ] Live: configure `[[hooks.permission_denied]]` with `type = "command"` and verify it fires when a tool is blocked
- [ ] Live: configure `[[hooks.cwd_changed]]` with `type = "mcp_tool"` and verify MCP server receives the call
- [ ] Live: verify old configs with `type = "command"` / `command = "..."` still load without error

Closes #3292, #3293