### PR TITLE
feat(memory): add multi-strategy graph retrieval and experience memory

### DIFF
--- a/crates/zeph-config/src/memory.rs
+++ b/crates/zeph-config/src/memory.rs
@@ -1263,6 +1263,100 @@ impl Default for SidequestConfig {
     }
 }
 
+/// Graph retrieval strategy for `[memory.graph]`.
+///
+/// Selects the algorithm used to traverse the knowledge graph during recall.
+/// The default (`synapse`) preserves existing SYNAPSE spreading-activation behavior.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GraphRetrievalStrategy {
+    /// SYNAPSE spreading activation (default, existing behavior).
+    #[default]
+    Synapse,
+    /// Hop-limited BFS traversal (pre-SYNAPSE behavior).
+    Bfs,
+    /// A* shortest-path traversal via petgraph.
+    #[serde(rename = "astar")]
+    AStar,
+    /// Concentric BFS expanding outward from seed nodes.
+    WaterCircles,
+    /// Beam search: keep top-K candidates per hop.
+    BeamSearch,
+    /// Dynamic: LLM classifier selects strategy per query.
+    Hybrid,
+}
+
+fn default_beam_width() -> usize {
+    10
+}
+
+/// Beam search retrieval configuration for `[memory.graph.beam_search]`.
+///
+/// Controls the width of the beam during graph traversal: how many top candidates
+/// are retained at each hop.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct BeamSearchConfig {
+    /// Number of top candidates kept per hop. Default: `10`.
+    #[serde(default = "default_beam_width")]
+    pub beam_width: usize,
+}
+
+impl Default for BeamSearchConfig {
+    fn default() -> Self {
+        Self {
+            beam_width: default_beam_width(),
+        }
+    }
+}
+
+/// `WaterCircles` BFS configuration for `[memory.graph.watercircles]`.
+///
+/// Controls ring-by-ring concentric BFS traversal from seed nodes.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct WaterCirclesConfig {
+    /// Max facts per ring (hop). `0` = auto (`limit / max_hops`). Default: `0`.
+    #[serde(default)]
+    pub ring_limit: usize,
+}
+
+fn default_evolution_sweep_interval() -> usize {
+    50
+}
+
+fn default_confidence_prune_threshold() -> f32 {
+    0.1
+}
+
+/// Experience memory configuration for `[memory.graph.experience]`.
+///
+/// Controls recording of tool execution outcomes and graph evolution sweeps.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ExperienceConfig {
+    /// Enable experience memory recording. Default: `false`.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Enable graph evolution sweep (prune self-loops + low-confidence edges). Default: `false`.
+    #[serde(default)]
+    pub evolution_sweep_enabled: bool,
+    /// Confidence threshold below which zero-retrieval edges are pruned. Default: `0.1`.
+    #[serde(default = "default_confidence_prune_threshold")]
+    pub confidence_prune_threshold: f32,
+    /// Number of turns between evolution sweeps. Default: `50`.
+    #[serde(default = "default_evolution_sweep_interval")]
+    pub evolution_sweep_interval: usize,
+}
+
+impl Default for ExperienceConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            evolution_sweep_enabled: false,
+            confidence_prune_threshold: default_confidence_prune_threshold(),
+            evolution_sweep_interval: default_evolution_sweep_interval(),
+        }
+    }
+}
+
 /// Configuration for the knowledge graph memory subsystem (`[memory.graph]` TOML section).
 ///
 /// # Security
@@ -1340,6 +1434,24 @@ pub struct GraphConfig {
     /// with lateral inhibition and temporal decay instead of BFS.
     #[serde(default)]
     pub spreading_activation: SpreadingActivationConfig,
+    /// Graph retrieval strategy. Default: `synapse` (preserves existing behavior).
+    ///
+    /// When `spreading_activation.enabled = true` and `retrieval_strategy` is `synapse`,
+    /// SYNAPSE spreading activation is used. Set to `bfs` to revert to hop-limited BFS.
+    #[serde(default)]
+    pub retrieval_strategy: GraphRetrievalStrategy,
+    /// Named LLM provider for hybrid strategy classification. Empty = use default provider.
+    #[serde(default)]
+    pub strategy_classifier_provider: String,
+    /// Beam search configuration.
+    #[serde(default)]
+    pub beam_search: BeamSearchConfig,
+    /// `WaterCircles` BFS configuration.
+    #[serde(default)]
+    pub watercircles: WaterCirclesConfig,
+    /// Experience memory configuration.
+    #[serde(default)]
+    pub experience: ExperienceConfig,
     /// A-MEM link weight decay: multiplicative factor applied to `retrieval_count`
     /// for un-retrieved edges each decay pass. Range: `(0.0, 1.0]`. Default: `0.95`.
     #[serde(
@@ -1399,6 +1511,11 @@ impl Default for GraphConfig {
             edge_history_limit: default_graph_edge_history_limit(),
             note_linking: NoteLinkingConfig::default(),
             spreading_activation: SpreadingActivationConfig::default(),
+            retrieval_strategy: GraphRetrievalStrategy::default(),
+            strategy_classifier_provider: String::new(),
+            beam_search: BeamSearchConfig::default(),
+            watercircles: WaterCirclesConfig::default(),
+            experience: ExperienceConfig::default(),
             link_weight_decay_lambda: default_link_weight_decay_lambda(),
             link_weight_decay_interval_secs: default_link_weight_decay_interval_secs(),
             belief_revision: BeliefRevisionConfig::default(),

--- a/crates/zeph-core/src/agent/context/assembler_helpers.rs
+++ b/crates/zeph-core/src/agent/context/assembler_helpers.rs
@@ -50,22 +50,40 @@ pub(super) async fn fetch_graph_facts(
     let mut body = String::from(GRAPH_FACTS_PREFIX);
     let mut tokens_so_far = tc.count_tokens(&body);
 
-    if sa_config.enabled {
-        let sa_params = zeph_memory::graph::SpreadingActivationParams {
-            decay_lambda: sa_config.decay_lambda,
-            max_hops: sa_config.max_hops,
-            activation_threshold: sa_config.activation_threshold,
-            inhibition_threshold: sa_config.inhibition_threshold,
-            max_activated_nodes: sa_config.max_activated_nodes,
-            temporal_decay_rate,
-            seed_structural_weight: sa_config.seed_structural_weight,
-            seed_community_cap: sa_config.seed_community_cap,
-        };
-        let timeout_ms = effective_recall_timeout_ms(sa_config.recall_timeout_ms);
-        let recall_fut = memory.recall_graph_activated(query, recall_limit, sa_params, &edge_types);
-        let activated_facts =
-            match tokio::time::timeout(std::time::Duration::from_millis(timeout_ms), recall_fut)
-                .await
+    let max_hops = memory_state.extraction.graph_config.max_hops;
+    let graph_config = &memory_state.extraction.graph_config;
+
+    // Resolve the effective retrieval strategy: spreading_activation.enabled takes precedence
+    // for backward compatibility, then fall through to retrieval_strategy.
+    use zeph_config::memory::GraphRetrievalStrategy;
+    let effective_strategy = if sa_config.enabled {
+        GraphRetrievalStrategy::Synapse
+    } else {
+        graph_config.retrieval_strategy
+    };
+
+    let _span = tracing::info_span!("memory.graph.dispatch", ?effective_strategy).entered();
+
+    match effective_strategy {
+        GraphRetrievalStrategy::Synapse => {
+            let sa_params = zeph_memory::graph::SpreadingActivationParams {
+                decay_lambda: sa_config.decay_lambda,
+                max_hops: sa_config.max_hops,
+                activation_threshold: sa_config.activation_threshold,
+                inhibition_threshold: sa_config.inhibition_threshold,
+                max_activated_nodes: sa_config.max_activated_nodes,
+                temporal_decay_rate,
+                seed_structural_weight: sa_config.seed_structural_weight,
+                seed_community_cap: sa_config.seed_community_cap,
+            };
+            let timeout_ms = effective_recall_timeout_ms(sa_config.recall_timeout_ms);
+            let recall_fut =
+                memory.recall_graph_activated(query, recall_limit, sa_params, &edge_types);
+            let activated_facts = match tokio::time::timeout(
+                std::time::Duration::from_millis(timeout_ms),
+                recall_fut,
+            )
+            .await
             {
                 Ok(Ok(facts)) => facts,
                 Ok(Err(e)) => {
@@ -78,53 +96,247 @@ pub(super) async fn fetch_graph_facts(
                 }
             };
 
-        if activated_facts.is_empty() {
-            return Ok(None);
-        }
-
-        for f in &activated_facts {
-            let fact_text = f.edge.fact.replace(['\n', '\r', '<', '>'], " ");
-            let line = format!(
-                "- {} (confidence: {:.2}, activation: {:.2})\n",
-                fact_text, f.edge.confidence, f.activation_score
-            );
-            let line_tokens = tc.count_tokens(&line);
-            if tokens_so_far + line_tokens > budget_tokens {
-                break;
+            if activated_facts.is_empty() {
+                return Ok(None);
             }
-            body.push_str(&line);
-            tokens_so_far += line_tokens;
+            for f in &activated_facts {
+                let fact_text = f.edge.fact.replace(['\n', '\r', '<', '>'], " ");
+                let line = format!(
+                    "- {} (confidence: {:.2}, activation: {:.2})\n",
+                    fact_text, f.edge.confidence, f.activation_score
+                );
+                let line_tokens = tc.count_tokens(&line);
+                if tokens_so_far + line_tokens > budget_tokens {
+                    break;
+                }
+                body.push_str(&line);
+                tokens_so_far += line_tokens;
+            }
         }
-    } else {
-        let max_hops = memory_state.extraction.graph_config.max_hops;
-        let facts = memory
-            .recall_graph(
-                query,
-                recall_limit,
-                max_hops,
-                None,
-                temporal_decay_rate,
-                &edge_types,
+        GraphRetrievalStrategy::Bfs => {
+            let facts = memory
+                .recall_graph(
+                    query,
+                    recall_limit,
+                    max_hops,
+                    None,
+                    temporal_decay_rate,
+                    &edge_types,
+                )
+                .await
+                .map_err(|e| {
+                    tracing::warn!("graph BFS recall failed: {e:#}");
+                    AgentError::Memory(e)
+                })?;
+            if facts.is_empty() {
+                return Ok(None);
+            }
+            for f in &facts {
+                let fact_text = f.fact.replace(['\n', '\r', '<', '>'], " ");
+                let line = format!("- {} (confidence: {:.2})\n", fact_text, f.confidence);
+                let line_tokens = tc.count_tokens(&line);
+                if tokens_so_far + line_tokens > budget_tokens {
+                    break;
+                }
+                body.push_str(&line);
+                tokens_so_far += line_tokens;
+            }
+        }
+        GraphRetrievalStrategy::AStar => {
+            let facts = memory
+                .recall_graph_astar(
+                    query,
+                    recall_limit,
+                    max_hops,
+                    temporal_decay_rate,
+                    &edge_types,
+                )
+                .await
+                .map_err(|e| {
+                    tracing::warn!("graph A* recall failed: {e:#}");
+                    AgentError::Memory(e)
+                })?;
+            if facts.is_empty() {
+                return Ok(None);
+            }
+            for f in &facts {
+                let fact_text = f.fact.replace(['\n', '\r', '<', '>'], " ");
+                let line = format!("- {} (confidence: {:.2})\n", fact_text, f.confidence);
+                let line_tokens = tc.count_tokens(&line);
+                if tokens_so_far + line_tokens > budget_tokens {
+                    break;
+                }
+                body.push_str(&line);
+                tokens_so_far += line_tokens;
+            }
+        }
+        GraphRetrievalStrategy::WaterCircles => {
+            let ring_limit = graph_config.watercircles.ring_limit;
+            let facts = memory
+                .recall_graph_watercircles(
+                    query,
+                    recall_limit,
+                    max_hops,
+                    ring_limit,
+                    temporal_decay_rate,
+                    &edge_types,
+                )
+                .await
+                .map_err(|e| {
+                    tracing::warn!("graph WaterCircles recall failed: {e:#}");
+                    AgentError::Memory(e)
+                })?;
+            if facts.is_empty() {
+                return Ok(None);
+            }
+            for f in &facts {
+                let fact_text = f.fact.replace(['\n', '\r', '<', '>'], " ");
+                let line = format!("- {} (confidence: {:.2})\n", fact_text, f.confidence);
+                let line_tokens = tc.count_tokens(&line);
+                if tokens_so_far + line_tokens > budget_tokens {
+                    break;
+                }
+                body.push_str(&line);
+                tokens_so_far += line_tokens;
+            }
+        }
+        GraphRetrievalStrategy::BeamSearch => {
+            let beam_width = graph_config.beam_search.beam_width;
+            let facts = memory
+                .recall_graph_beam(
+                    query,
+                    recall_limit,
+                    beam_width,
+                    max_hops,
+                    temporal_decay_rate,
+                    &edge_types,
+                )
+                .await
+                .map_err(|e| {
+                    tracing::warn!("graph beam search recall failed: {e:#}");
+                    AgentError::Memory(e)
+                })?;
+            if facts.is_empty() {
+                return Ok(None);
+            }
+            for f in &facts {
+                let fact_text = f.fact.replace(['\n', '\r', '<', '>'], " ");
+                let line = format!("- {} (confidence: {:.2})\n", fact_text, f.confidence);
+                let line_tokens = tc.count_tokens(&line);
+                if tokens_so_far + line_tokens > budget_tokens {
+                    break;
+                }
+                body.push_str(&line);
+                tokens_so_far += line_tokens;
+            }
+        }
+        GraphRetrievalStrategy::Hybrid => {
+            // LLM classifies the query then dispatches to the selected strategy.
+            // Timeout prevents unbounded wait if the classifier LLM is slow.
+            const CLASSIFIER_TIMEOUT_MS: u64 = 2_000;
+            let classified = tokio::time::timeout(
+                std::time::Duration::from_millis(CLASSIFIER_TIMEOUT_MS),
+                memory.classify_graph_strategy(query),
             )
             .await
+            .unwrap_or_else(|_| {
+                tracing::warn!(
+                    "hybrid strategy classifier timed out after {CLASSIFIER_TIMEOUT_MS}ms, \
+                     falling back to synapse"
+                );
+                "synapse".to_owned()
+            });
+            tracing::debug!(classified_strategy = %classified, "hybrid dispatch: classified");
+            let facts = match classified.as_str() {
+                "astar" => {
+                    memory
+                        .recall_graph_astar(
+                            query,
+                            recall_limit,
+                            max_hops,
+                            temporal_decay_rate,
+                            &edge_types,
+                        )
+                        .await
+                }
+                "watercircles" => {
+                    let ring_limit = graph_config.watercircles.ring_limit;
+                    memory
+                        .recall_graph_watercircles(
+                            query,
+                            recall_limit,
+                            max_hops,
+                            ring_limit,
+                            temporal_decay_rate,
+                            &edge_types,
+                        )
+                        .await
+                }
+                "beam_search" => {
+                    let beam_width = graph_config.beam_search.beam_width;
+                    memory
+                        .recall_graph_beam(
+                            query,
+                            recall_limit,
+                            beam_width,
+                            max_hops,
+                            temporal_decay_rate,
+                            &edge_types,
+                        )
+                        .await
+                }
+                // "synapse" or any fallback
+                _ => {
+                    let sa_params = zeph_memory::graph::SpreadingActivationParams {
+                        decay_lambda: sa_config.decay_lambda,
+                        max_hops: sa_config.max_hops,
+                        activation_threshold: sa_config.activation_threshold,
+                        inhibition_threshold: sa_config.inhibition_threshold,
+                        max_activated_nodes: sa_config.max_activated_nodes,
+                        temporal_decay_rate,
+                        seed_structural_weight: sa_config.seed_structural_weight,
+                        seed_community_cap: sa_config.seed_community_cap,
+                    };
+                    memory
+                        .recall_graph_activated(query, recall_limit, sa_params, &edge_types)
+                        .await
+                        .map(|activated| {
+                            activated
+                                .into_iter()
+                                .map(|f| zeph_memory::graph::types::GraphFact {
+                                    entity_name: f.edge.source_entity_id.to_string(),
+                                    relation: f.edge.relation.clone(),
+                                    target_name: f.edge.target_entity_id.to_string(),
+                                    fact: f.edge.fact.clone(),
+                                    entity_match_score: f.activation_score,
+                                    hop_distance: 0,
+                                    confidence: f.edge.confidence,
+                                    valid_from: Some(f.edge.valid_from.clone()),
+                                    edge_type: f.edge.edge_type,
+                                    retrieval_count: f.edge.retrieval_count,
+                                })
+                                .collect()
+                        })
+                }
+            }
             .map_err(|e| {
-                tracing::warn!("graph recall failed: {e:#}");
+                tracing::warn!("hybrid graph recall failed: {e:#}");
                 AgentError::Memory(e)
             })?;
 
-        if facts.is_empty() {
-            return Ok(None);
-        }
-
-        for f in &facts {
-            let fact_text = f.fact.replace(['\n', '\r', '<', '>'], " ");
-            let line = format!("- {} (confidence: {:.2})\n", fact_text, f.confidence);
-            let line_tokens = tc.count_tokens(&line);
-            if tokens_so_far + line_tokens > budget_tokens {
-                break;
+            if facts.is_empty() {
+                return Ok(None);
             }
-            body.push_str(&line);
-            tokens_so_far += line_tokens;
+            for f in &facts {
+                let fact_text = f.fact.replace(['\n', '\r', '<', '>'], " ");
+                let line = format!("- {} (confidence: {:.2})\n", fact_text, f.confidence);
+                let line_tokens = tc.count_tokens(&line);
+                if tokens_so_far + line_tokens > budget_tokens {
+                    break;
+                }
+                body.push_str(&line);
+                tokens_so_far += line_tokens;
+            }
         }
     }
 

--- a/crates/zeph-db/migrations/sqlite/076_experience_memory.sql
+++ b/crates/zeph-db/migrations/sqlite/076_experience_memory.sql
@@ -1,0 +1,33 @@
+-- SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+-- SPDX-License-Identifier: MIT OR Apache-2.0
+
+-- Experience nodes: records of tool execution outcomes in the agent loop
+CREATE TABLE experience_nodes (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id  TEXT    NOT NULL,
+    turn        INTEGER NOT NULL,
+    tool_name   TEXT    NOT NULL,
+    outcome     TEXT    NOT NULL,
+    detail      TEXT,
+    error_ctx   TEXT,
+    created_at  INTEGER NOT NULL
+);
+
+-- Experience edges: temporal sequence between consecutive experience nodes
+CREATE TABLE experience_edges (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_exp_id   INTEGER NOT NULL REFERENCES experience_nodes(id),
+    target_exp_id   INTEGER NOT NULL REFERENCES experience_nodes(id),
+    relation        TEXT    NOT NULL DEFAULT 'followed_by'
+);
+
+-- Links between experience nodes and knowledge graph entities
+CREATE TABLE experience_entity_links (
+    experience_id   INTEGER NOT NULL REFERENCES experience_nodes(id),
+    entity_id       INTEGER NOT NULL REFERENCES graph_entities(id),
+    PRIMARY KEY (experience_id, entity_id)
+);
+
+CREATE INDEX idx_experience_nodes_session ON experience_nodes(session_id, turn);
+CREATE INDEX idx_experience_nodes_tool    ON experience_nodes(tool_name);
+CREATE INDEX idx_experience_entity_links  ON experience_entity_links(entity_id);

--- a/crates/zeph-memory/src/graph/experience.rs
+++ b/crates/zeph-memory/src/graph/experience.rs
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Experience memory store — records tool execution outcomes and evolution sweeps.
+//!
+//! [`ExperienceStore`] persists agent tool-call outcomes as `experience_nodes` and links
+//! them into a temporal chain (`experience_edges`). The [`EvolutionSweepStats`] type
+//! describes pruning results from [`ExperienceStore::evolution_sweep`].
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use zeph_db::{DbPool, sql};
+
+use crate::error::MemoryError;
+use crate::graph::store::GraphStore;
+
+/// Statistics from a single graph evolution sweep.
+#[derive(Debug, Default)]
+pub struct EvolutionSweepStats {
+    /// Number of self-loop edges removed from the knowledge graph.
+    pub pruned_self_loops: usize,
+    /// Number of low-confidence zero-retrieval edges removed.
+    pub pruned_low_confidence: usize,
+}
+
+/// Persistent store for experience memory nodes and edges.
+///
+/// Wraps the `experience_nodes`, `experience_edges`, and `experience_entity_links`
+/// tables created by migration `076_experience_memory.sql`.
+pub struct ExperienceStore {
+    pool: DbPool,
+}
+
+impl ExperienceStore {
+    /// Create a new experience store using the provided connection pool.
+    #[must_use]
+    pub fn new(pool: DbPool) -> Self {
+        Self { pool }
+    }
+
+    /// Record a tool execution outcome as an experience node.
+    ///
+    /// Returns the row ID of the newly inserted experience node.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError`] if the database insert fails.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use zeph_memory::graph::experience::ExperienceStore;
+    /// # async fn demo(store: &ExperienceStore) -> Result<(), Box<dyn std::error::Error>> {
+    /// let id = store
+    ///     .record_tool_outcome("session-1", 3, "shell", "success", Some("exit 0"), None)
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn record_tool_outcome(
+        &self,
+        session_id: &str,
+        turn: i64,
+        tool_name: &str,
+        outcome: &str,
+        detail: Option<&str>,
+        error_ctx: Option<&str>,
+    ) -> Result<i64, MemoryError> {
+        let _span = tracing::info_span!("memory.experience.record", tool_name, outcome).entered();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |d| d.as_secs().cast_signed());
+        let id: i64 = zeph_db::query_scalar(sql!(
+            "INSERT INTO experience_nodes
+             (session_id, turn, tool_name, outcome, detail, error_ctx, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+             RETURNING id"
+        ))
+        .bind(session_id)
+        .bind(turn)
+        .bind(tool_name)
+        .bind(outcome)
+        .bind(detail)
+        .bind(error_ctx)
+        .bind(now)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(MemoryError::from)?;
+        Ok(id)
+    }
+
+    /// Link an experience node to one or more knowledge graph entities.
+    ///
+    /// Uses `INSERT OR IGNORE` to tolerate duplicate links gracefully.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError`] if any database insert fails.
+    pub async fn link_to_entities(
+        &self,
+        experience_id: i64,
+        entity_ids: &[i64],
+    ) -> Result<(), MemoryError> {
+        let _span = tracing::info_span!("memory.experience.link_entities", experience_id).entered();
+        for &entity_id in entity_ids {
+            zeph_db::query(sql!(
+                "INSERT OR IGNORE INTO experience_entity_links
+                 (experience_id, entity_id) VALUES (?1, ?2)"
+            ))
+            .bind(experience_id)
+            .bind(entity_id)
+            .execute(&self.pool)
+            .await
+            .map_err(MemoryError::from)?;
+        }
+        Ok(())
+    }
+
+    /// Record a sequential `followed_by` link between two experience nodes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError`] if the database insert fails.
+    pub async fn link_sequential(&self, prev: i64, next: i64) -> Result<(), MemoryError> {
+        zeph_db::query(sql!(
+            "INSERT INTO experience_edges
+             (source_exp_id, target_exp_id, relation)
+             VALUES (?1, ?2, 'followed_by')"
+        ))
+        .bind(prev)
+        .bind(next)
+        .execute(&self.pool)
+        .await
+        .map_err(MemoryError::from)?;
+        Ok(())
+    }
+
+    /// Run a graph evolution sweep on the knowledge graph.
+    ///
+    /// Performs two pruning passes on the `graph_edges` table via `graph_store`:
+    /// 1. Removes self-loops (`source_entity_id = target_entity_id`).
+    /// 2. Removes low-confidence edges with zero retrievals that have no expiry set.
+    ///
+    /// This is a maintenance operation; it never blocks the agent loop.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError`] if any database operation fails.
+    pub async fn evolution_sweep(
+        &self,
+        graph_store: &GraphStore,
+        confidence_threshold: f32,
+    ) -> Result<EvolutionSweepStats, MemoryError> {
+        let _span = tracing::info_span!("memory.experience.sweep").entered();
+
+        let self_loops = zeph_db::query(sql!(
+            "DELETE FROM graph_edges WHERE source_entity_id = target_entity_id"
+        ))
+        .execute(graph_store.pool())
+        .await
+        .map_err(MemoryError::from)?
+        .rows_affected();
+
+        let low_conf = zeph_db::query(sql!(
+            "DELETE FROM graph_edges
+             WHERE confidence < ?1 AND retrieval_count = 0 AND valid_to IS NULL"
+        ))
+        .bind(confidence_threshold)
+        .execute(graph_store.pool())
+        .await
+        .map_err(MemoryError::from)?
+        .rows_affected();
+
+        Ok(EvolutionSweepStats {
+            pruned_self_loops: usize::try_from(self_loops).unwrap_or(usize::MAX),
+            pruned_low_confidence: usize::try_from(low_conf).unwrap_or(usize::MAX),
+        })
+    }
+}

--- a/crates/zeph-memory/src/graph/mod.rs
+++ b/crates/zeph-memory/src/graph/mod.rs
@@ -9,11 +9,16 @@ pub mod belief_revision;
 pub mod community;
 pub mod conflict;
 pub mod entity_lock;
+pub mod experience;
 pub mod extractor;
 pub mod ontology;
 pub mod resolver;
 pub mod retrieval;
+pub mod retrieval_astar;
+pub mod retrieval_beam;
+pub mod retrieval_watercircles;
 pub mod rpe;
+pub mod strategy_classifier;
 
 pub use store::GraphStore;
 pub use types::{Community, Edge, EdgeType, Entity, EntityAlias, EntityType, Episode, GraphFact};

--- a/crates/zeph-memory/src/graph/retrieval.rs
+++ b/crates/zeph-memory/src/graph/retrieval.rs
@@ -231,7 +231,7 @@ async fn seed_embedding_fallback(
     true
 }
 
-async fn find_seed_entities(
+pub(crate) async fn find_seed_entities(
     store: &GraphStore,
     embeddings: Option<&EmbeddingStore>,
     provider: &zeph_llm::any::AnyProvider,

--- a/crates/zeph-memory/src/graph/retrieval_astar.rs
+++ b/crates/zeph-memory/src/graph/retrieval_astar.rs
@@ -1,0 +1,287 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! A* shortest-path graph recall via `petgraph`.
+//!
+//! [`graph_recall_astar`] seeds from fuzzy entity matches and uses A* (with a
+//! zero heuristic, degrading to Dijkstra) to collect the shortest paths from
+//! each seed to all reachable nodes within `max_hops`.
+
+use std::collections::{HashMap, HashSet};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use petgraph::algo::astar;
+use petgraph::graph::{NodeIndex, UnGraph};
+
+use crate::embedding_store::EmbeddingStore;
+use crate::error::MemoryError;
+use crate::graph::retrieval::find_seed_entities;
+use crate::graph::store::GraphStore;
+use crate::graph::types::{EdgeType, GraphFact};
+
+const DEFAULT_STRUCTURAL_WEIGHT: f32 = 0.4;
+const DEFAULT_COMMUNITY_CAP: usize = 3;
+
+/// Retrieve graph facts using A* shortest-path traversal.
+///
+/// Algorithm:
+/// 1. Find seed entities via hybrid FTS5 + structural scoring.
+/// 2. Fetch all edges from seeds via BFS (up to `max_hops`).
+/// 3. Build an in-memory `petgraph::UnGraph` from collected edges.
+/// 4. Run A* from each seed; collect path edges.
+/// 5. Convert to [`GraphFact`], dedup, sort by score, truncate to `limit`.
+///
+/// The A* heuristic is always `0.0` (admissible, degrades to Dijkstra when
+/// embedding distances are unavailable). Edge cost = `1.0 - confidence`.
+///
+/// # Errors
+///
+/// Returns an error if any database query fails.
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+pub async fn graph_recall_astar(
+    store: &GraphStore,
+    embeddings: Option<&EmbeddingStore>,
+    provider: &zeph_llm::any::AnyProvider,
+    query: &str,
+    limit: usize,
+    max_hops: u32,
+    edge_types: &[EdgeType],
+    temporal_decay_rate: f64,
+) -> Result<Vec<GraphFact>, MemoryError> {
+    let _span = tracing::info_span!("memory.graph.astar", query_len = query.len()).entered();
+
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+
+    let entity_scores = find_seed_entities(
+        store,
+        embeddings,
+        provider,
+        query,
+        limit,
+        DEFAULT_STRUCTURAL_WEIGHT,
+        DEFAULT_COMMUNITY_CAP,
+    )
+    .await?;
+
+    if entity_scores.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let now_secs: i64 = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs().cast_signed());
+
+    // Gather all edges reachable from all seeds.
+    let mut all_db_edges = Vec::new();
+    let mut entity_name_map: HashMap<i64, String> = HashMap::new();
+
+    for &seed_id in entity_scores.keys() {
+        let (entities, edges, _depth_map) = if edge_types.is_empty() {
+            store.bfs_with_depth(seed_id, max_hops).await?
+        } else {
+            store.bfs_typed(seed_id, max_hops, edge_types).await?
+        };
+        for e in &entities {
+            entity_name_map
+                .entry(e.id)
+                .or_insert_with(|| e.canonical_name.clone());
+        }
+        all_db_edges.extend(edges);
+    }
+
+    if all_db_edges.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Build petgraph: node index ↔ entity_id mapping.
+    let mut node_map: HashMap<i64, NodeIndex> = HashMap::new();
+    let mut id_map: Vec<i64> = Vec::new();
+    let mut graph: UnGraph<i64, f32> = UnGraph::new_undirected();
+
+    let get_or_add = |graph: &mut UnGraph<i64, f32>,
+                      node_map: &mut HashMap<i64, NodeIndex>,
+                      id_map: &mut Vec<i64>,
+                      entity_id: i64|
+     -> NodeIndex {
+        *node_map.entry(entity_id).or_insert_with(|| {
+            let idx = graph.add_node(entity_id);
+            id_map.push(entity_id);
+            idx
+        })
+    };
+
+    for edge in &all_db_edges {
+        let src = get_or_add(
+            &mut graph,
+            &mut node_map,
+            &mut id_map,
+            edge.source_entity_id,
+        );
+        let tgt = get_or_add(
+            &mut graph,
+            &mut node_map,
+            &mut id_map,
+            edge.target_entity_id,
+        );
+        // Cost: low-confidence edges are more expensive.
+        let cost = 1.0 - edge.confidence.clamp(0.0, 1.0);
+        graph.add_edge(src, tgt, cost);
+    }
+
+    // Run A* from each seed; collect path node pairs.
+    let mut path_pairs: HashSet<(NodeIndex, NodeIndex)> = HashSet::new();
+
+    for &seed_id in entity_scores.keys() {
+        let Some(&seed_idx) = node_map.get(&seed_id) else {
+            continue;
+        };
+        for &target_idx in node_map.values() {
+            if target_idx == seed_idx {
+                continue;
+            }
+            if let Some((_cost, path)) = astar(
+                &graph,
+                seed_idx,
+                |n| n == target_idx,
+                |e| *e.weight(),
+                |_| 0.0,
+            ) {
+                for window in path.windows(2) {
+                    let (a, b) = (window[0], window[1]);
+                    let pair = if a.index() < b.index() {
+                        (a, b)
+                    } else {
+                        (b, a)
+                    };
+                    path_pairs.insert(pair);
+                }
+            }
+        }
+    }
+
+    // Build a lookup of db edges by (src_id, tgt_id).
+    let edge_lookup: HashMap<(i64, i64), &crate::graph::types::Edge> = all_db_edges
+        .iter()
+        .map(|e| ((e.source_entity_id, e.target_entity_id), e))
+        .collect();
+
+    let mut facts: Vec<GraphFact> = Vec::new();
+    let mut seen: HashSet<(String, String, String, EdgeType)> = HashSet::new();
+
+    for (a_idx, b_idx) in &path_pairs {
+        let a_id = id_map[a_idx.index()];
+        let b_id = id_map[b_idx.index()];
+
+        // Try both directions (undirected graph, but db edges are directed).
+        for (src_id, tgt_id) in [(a_id, b_id), (b_id, a_id)] {
+            if let Some(&edge) = edge_lookup.get(&(src_id, tgt_id)) {
+                let entity_name = entity_name_map.get(&src_id).cloned().unwrap_or_default();
+                let target_name = entity_name_map.get(&tgt_id).cloned().unwrap_or_default();
+                if entity_name.is_empty() || target_name.is_empty() {
+                    continue;
+                }
+                let key = (
+                    entity_name.clone(),
+                    edge.relation.clone(),
+                    target_name.clone(),
+                    edge.edge_type,
+                );
+                if seen.insert(key) {
+                    let seed_score = entity_scores.get(&src_id).copied().unwrap_or(0.5);
+                    facts.push(GraphFact {
+                        entity_name,
+                        relation: edge.relation.clone(),
+                        target_name,
+                        fact: edge.fact.clone(),
+                        entity_match_score: seed_score,
+                        hop_distance: 1,
+                        confidence: edge.confidence,
+                        valid_from: Some(edge.valid_from.clone()),
+                        edge_type: edge.edge_type,
+                        retrieval_count: edge.retrieval_count,
+                    });
+                }
+            }
+        }
+    }
+
+    // Sort by decayed score descending, truncate to limit.
+    facts.sort_by(|a, b| {
+        let sa = a.score_with_decay(temporal_decay_rate, now_secs);
+        let sb = b.score_with_decay(temporal_decay_rate, now_secs);
+        sb.total_cmp(&sa)
+    });
+    facts.truncate(limit);
+
+    // Record retrievals fire-and-forget.
+    let edge_ids: Vec<i64> = all_db_edges.iter().map(|e| e.id).collect();
+    if let Err(e) = store.record_edge_retrieval(&edge_ids).await {
+        tracing::warn!(error = %e, "graph_recall_astar: failed to record edge retrieval");
+    }
+
+    Ok(facts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::store::GraphStore;
+    use crate::graph::types::EntityType;
+    use crate::store::SqliteStore;
+    use zeph_llm::any::AnyProvider;
+    use zeph_llm::mock::MockProvider;
+
+    async fn setup_store() -> GraphStore {
+        let store = SqliteStore::new(":memory:").await.unwrap();
+        GraphStore::new(store.pool().clone())
+    }
+
+    fn mock_provider() -> AnyProvider {
+        AnyProvider::Mock(MockProvider::default())
+    }
+
+    #[tokio::test]
+    async fn astar_empty_graph_returns_empty() {
+        let store = setup_store().await;
+        let provider = mock_provider();
+        let result = graph_recall_astar(&store, None, &provider, "anything", 10, 2, &[], 0.0)
+            .await
+            .unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn astar_zero_limit_returns_empty() {
+        let store = setup_store().await;
+        let provider = mock_provider();
+        let result = graph_recall_astar(&store, None, &provider, "anything", 0, 2, &[], 0.0)
+            .await
+            .unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn astar_finds_direct_edge() {
+        let store = setup_store().await;
+        let a = store
+            .upsert_entity("Alice", "alice", EntityType::Person, None)
+            .await
+            .unwrap();
+        let b = store
+            .upsert_entity("Bob", "bob", EntityType::Person, None)
+            .await
+            .unwrap();
+        store
+            .insert_edge(a, b, "knows", "Alice knows Bob", 0.9, None)
+            .await
+            .unwrap();
+
+        let provider = mock_provider();
+        let result = graph_recall_astar(&store, None, &provider, "Alice", 10, 2, &[], 0.0)
+            .await
+            .unwrap();
+        assert!(!result.is_empty());
+    }
+}

--- a/crates/zeph-memory/src/graph/retrieval_beam.rs
+++ b/crates/zeph-memory/src/graph/retrieval_beam.rs
@@ -1,0 +1,257 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Beam search graph recall.
+//!
+//! [`graph_recall_beam`] keeps only the top-K candidate entities at each hop,
+//! enabling multi-hop reasoning paths to be explored efficiently without
+//! unbounded BFS expansion.
+
+use std::collections::{HashMap, HashSet};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::embedding_store::EmbeddingStore;
+use crate::error::MemoryError;
+use crate::graph::retrieval::find_seed_entities;
+use crate::graph::store::GraphStore;
+use crate::graph::types::{EdgeType, GraphFact};
+
+const DEFAULT_STRUCTURAL_WEIGHT: f32 = 0.4;
+const DEFAULT_COMMUNITY_CAP: usize = 3;
+
+/// Retrieve graph facts using beam search.
+///
+/// Algorithm:
+/// 1. Find seed entities via hybrid FTS5 + structural scoring; take top `beam_width` as initial beam.
+/// 2. Per hop: fetch edges for beam entities, score each neighbour, keep top `beam_width` entity IDs.
+/// 3. Collect all traversed edges; convert to [`GraphFact`]; dedup; sort; truncate.
+///
+/// # Errors
+///
+/// Returns an error if any database query fails.
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+pub async fn graph_recall_beam(
+    store: &GraphStore,
+    embeddings: Option<&EmbeddingStore>,
+    provider: &zeph_llm::any::AnyProvider,
+    query: &str,
+    limit: usize,
+    beam_width: usize,
+    max_hops: u32,
+    edge_types: &[EdgeType],
+    temporal_decay_rate: f64,
+) -> Result<Vec<GraphFact>, MemoryError> {
+    let _span = tracing::info_span!("memory.graph.beam", query_len = query.len()).entered();
+
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+
+    let entity_scores = find_seed_entities(
+        store,
+        embeddings,
+        provider,
+        query,
+        limit,
+        DEFAULT_STRUCTURAL_WEIGHT,
+        DEFAULT_COMMUNITY_CAP,
+    )
+    .await?;
+
+    if entity_scores.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let now_secs: i64 = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs().cast_signed());
+
+    // Initial beam: top-`beam_width` seeds by score.
+    let mut beam_scores: Vec<(i64, f32)> = entity_scores.into_iter().collect();
+    beam_scores.sort_by(|(_, sa), (_, sb)| sb.total_cmp(sa));
+    beam_scores.truncate(beam_width);
+
+    let mut beam_ids: Vec<i64> = beam_scores.iter().map(|(id, _)| *id).collect();
+    let mut beam_score_map: HashMap<i64, f32> = beam_scores.into_iter().collect();
+
+    let mut all_db_edges: Vec<crate::graph::types::Edge> = Vec::new();
+    let mut entity_name_map: HashMap<i64, String> = HashMap::new();
+
+    for _hop in 0..max_hops {
+        if beam_ids.is_empty() {
+            break;
+        }
+
+        let edges = store.edges_for_entities(&beam_ids, edge_types).await?;
+        if edges.is_empty() {
+            break;
+        }
+
+        // Collect entity IDs from edges to resolve names.
+        let new_entity_ids: Vec<i64> = edges
+            .iter()
+            .flat_map(|e| [e.source_entity_id, e.target_entity_id])
+            .filter(|id| !entity_name_map.contains_key(id))
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
+
+        for id in new_entity_ids {
+            if let Ok(Some(entity)) = store.find_entity_by_id(id).await {
+                entity_name_map.insert(id, entity.canonical_name.clone());
+            }
+        }
+
+        // Score each neighbour by edge confidence (proxy for traversal quality).
+        let mut neighbour_scores: HashMap<i64, f32> = HashMap::new();
+        for edge in &edges {
+            let edge_conf = edge.confidence;
+            neighbour_scores
+                .entry(edge.target_entity_id)
+                .and_modify(|s| *s = s.max(edge_conf))
+                .or_insert(edge_conf);
+            neighbour_scores
+                .entry(edge.source_entity_id)
+                .and_modify(|s| *s = s.max(edge_conf))
+                .or_insert(edge_conf);
+        }
+
+        // Next beam: top-`beam_width` by score (excluding current beam members).
+        let mut candidates: Vec<(i64, f32)> = neighbour_scores
+            .into_iter()
+            .filter(|(id, _)| !beam_score_map.contains_key(id))
+            .collect();
+        candidates.sort_by(|(_, sa), (_, sb)| sb.total_cmp(sa));
+        candidates.truncate(beam_width);
+
+        beam_ids = candidates.iter().map(|(id, _)| *id).collect();
+        for (id, cand_score) in candidates {
+            beam_score_map.insert(id, cand_score);
+        }
+
+        all_db_edges.extend(edges);
+    }
+
+    if all_db_edges.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Record retrievals fire-and-forget.
+    let edge_ids: Vec<i64> = all_db_edges.iter().map(|e| e.id).collect();
+    if let Err(e) = store.record_edge_retrieval(&edge_ids).await {
+        tracing::warn!(error = %e, "graph_recall_beam: failed to record edge retrieval");
+    }
+
+    // Convert to GraphFact, dedup, sort, truncate.
+    let mut facts: Vec<GraphFact> = Vec::new();
+    let mut seen: HashSet<(String, String, String, EdgeType)> = HashSet::new();
+
+    for edge in &all_db_edges {
+        let entity_name = entity_name_map
+            .get(&edge.source_entity_id)
+            .cloned()
+            .unwrap_or_default();
+        let target_name = entity_name_map
+            .get(&edge.target_entity_id)
+            .cloned()
+            .unwrap_or_default();
+        if entity_name.is_empty() || target_name.is_empty() {
+            continue;
+        }
+        let key = (
+            entity_name.clone(),
+            edge.relation.clone(),
+            target_name.clone(),
+            edge.edge_type,
+        );
+        if seen.insert(key) {
+            let seed_score = beam_score_map
+                .get(&edge.source_entity_id)
+                .copied()
+                .unwrap_or(0.5);
+            facts.push(GraphFact {
+                entity_name,
+                relation: edge.relation.clone(),
+                target_name,
+                fact: edge.fact.clone(),
+                entity_match_score: seed_score,
+                hop_distance: 1,
+                confidence: edge.confidence,
+                valid_from: Some(edge.valid_from.clone()),
+                edge_type: edge.edge_type,
+                retrieval_count: edge.retrieval_count,
+            });
+        }
+    }
+
+    facts.sort_by(|a, b| {
+        let sa = a.score_with_decay(temporal_decay_rate, now_secs);
+        let sb = b.score_with_decay(temporal_decay_rate, now_secs);
+        sb.total_cmp(&sa)
+    });
+    facts.truncate(limit);
+
+    Ok(facts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::store::GraphStore;
+    use crate::graph::types::EntityType;
+    use crate::store::SqliteStore;
+    use zeph_llm::any::AnyProvider;
+    use zeph_llm::mock::MockProvider;
+
+    async fn setup_store() -> GraphStore {
+        let store = SqliteStore::new(":memory:").await.unwrap();
+        GraphStore::new(store.pool().clone())
+    }
+
+    fn mock_provider() -> AnyProvider {
+        AnyProvider::Mock(MockProvider::default())
+    }
+
+    #[tokio::test]
+    async fn beam_empty_graph_returns_empty() {
+        let store = setup_store().await;
+        let provider = mock_provider();
+        let result = graph_recall_beam(&store, None, &provider, "anything", 10, 5, 2, &[], 0.0)
+            .await
+            .unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn beam_zero_limit_returns_empty() {
+        let store = setup_store().await;
+        let provider = mock_provider();
+        let result = graph_recall_beam(&store, None, &provider, "anything", 0, 5, 2, &[], 0.0)
+            .await
+            .unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn beam_finds_direct_edge() {
+        let store = setup_store().await;
+        let a = store
+            .upsert_entity("Alice", "alice", EntityType::Person, None)
+            .await
+            .unwrap();
+        let b = store
+            .upsert_entity("Bob", "bob", EntityType::Person, None)
+            .await
+            .unwrap();
+        store
+            .insert_edge(a, b, "knows", "Alice knows Bob", 0.9, None)
+            .await
+            .unwrap();
+
+        let provider = mock_provider();
+        let result = graph_recall_beam(&store, None, &provider, "Alice", 10, 5, 2, &[], 0.0)
+            .await
+            .unwrap();
+        assert!(!result.is_empty());
+    }
+}

--- a/crates/zeph-memory/src/graph/retrieval_watercircles.rs
+++ b/crates/zeph-memory/src/graph/retrieval_watercircles.rs
@@ -1,0 +1,245 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Concentric BFS (`WaterCircles`) graph recall.
+//!
+//! [`graph_recall_watercircles`] performs ring-by-ring BFS from seed entities,
+//! capping facts per ring independently before concatenating rings and truncating
+//! to the global `limit`. This yields a more balanced cross-hop distribution than
+//! plain BFS.
+
+use std::collections::{HashMap, HashSet};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::embedding_store::EmbeddingStore;
+use crate::error::MemoryError;
+use crate::graph::retrieval::find_seed_entities;
+use crate::graph::store::GraphStore;
+use crate::graph::types::{EdgeType, GraphFact};
+
+const DEFAULT_STRUCTURAL_WEIGHT: f32 = 0.4;
+const DEFAULT_COMMUNITY_CAP: usize = 3;
+
+/// Retrieve graph facts using concentric BFS (`WaterCircles`).
+///
+/// Algorithm:
+/// 1. Find seed entities via hybrid FTS5 + structural scoring.
+/// 2. BFS ring by ring: for each hop depth, fetch edges at exactly that depth.
+/// 3. Score edges; cap each ring independently at `ring_limit` (auto when `ring_limit = 0`).
+/// 4. Concatenate rings; dedup; sort by score; truncate to `limit`.
+///
+/// # Errors
+///
+/// Returns an error if any database query fails.
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+pub async fn graph_recall_watercircles(
+    store: &GraphStore,
+    embeddings: Option<&EmbeddingStore>,
+    provider: &zeph_llm::any::AnyProvider,
+    query: &str,
+    limit: usize,
+    max_hops: u32,
+    ring_limit: usize,
+    edge_types: &[EdgeType],
+    temporal_decay_rate: f64,
+) -> Result<Vec<GraphFact>, MemoryError> {
+    let _span = tracing::info_span!("memory.graph.watercircles", query_len = query.len()).entered();
+
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+
+    let entity_scores = find_seed_entities(
+        store,
+        embeddings,
+        provider,
+        query,
+        limit,
+        DEFAULT_STRUCTURAL_WEIGHT,
+        DEFAULT_COMMUNITY_CAP,
+    )
+    .await?;
+
+    if entity_scores.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let now_secs: i64 = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs().cast_signed());
+
+    // Auto ring_limit: distribute limit evenly across hops.
+    let effective_ring_limit = if ring_limit == 0 {
+        let hops = max_hops.max(1) as usize;
+        (limit / hops).max(1)
+    } else {
+        ring_limit
+    };
+
+    let mut all_facts: Vec<GraphFact> = Vec::new();
+    let mut global_seen: HashSet<(String, String, String, EdgeType)> = HashSet::new();
+
+    // Process each hop ring independently per seed.
+    for hop in 1..=max_hops {
+        let mut ring_facts: Vec<(f32, GraphFact)> = Vec::new();
+
+        for (&seed_id, &seed_score) in &entity_scores {
+            let (entities, edges, depth_map) = if edge_types.is_empty() {
+                store.bfs_with_depth(seed_id, hop).await?
+            } else {
+                store.bfs_typed(seed_id, hop, edge_types).await?
+            };
+
+            let name_map: HashMap<i64, &str> = entities
+                .iter()
+                .map(|e| (e.id, e.canonical_name.as_str()))
+                .collect();
+
+            let traversed_ids: Vec<i64> = edges.iter().map(|e| e.id).collect();
+
+            for edge in &edges {
+                // Only include edges that belong exactly to this hop ring.
+                let hop_dist = depth_map
+                    .get(&edge.source_entity_id)
+                    .or_else(|| depth_map.get(&edge.target_entity_id))
+                    .copied();
+                let Some(dist) = hop_dist else { continue };
+                if dist != hop {
+                    continue;
+                }
+
+                let entity_name = name_map
+                    .get(&edge.source_entity_id)
+                    .copied()
+                    .unwrap_or_default();
+                let target_name = name_map
+                    .get(&edge.target_entity_id)
+                    .copied()
+                    .unwrap_or_default();
+                if entity_name.is_empty() || target_name.is_empty() {
+                    continue;
+                }
+
+                let fact = GraphFact {
+                    entity_name: entity_name.to_owned(),
+                    relation: edge.relation.clone(),
+                    target_name: target_name.to_owned(),
+                    fact: edge.fact.clone(),
+                    entity_match_score: seed_score,
+                    hop_distance: dist,
+                    confidence: edge.confidence,
+                    valid_from: Some(edge.valid_from.clone()),
+                    edge_type: edge.edge_type,
+                    retrieval_count: edge.retrieval_count,
+                };
+                let fact_score = fact.score_with_decay(temporal_decay_rate, now_secs);
+                ring_facts.push((fact_score, fact));
+            }
+
+            if !traversed_ids.is_empty()
+                && let Err(e) = store.record_edge_retrieval(&traversed_ids).await
+            {
+                tracing::warn!(
+                    error = %e,
+                    "graph_recall_watercircles: failed to record edge retrieval"
+                );
+            }
+        }
+
+        // Sort ring by score, cap, then add to global list (deduplicating).
+        ring_facts.sort_by(|(sa, _), (sb, _)| sb.total_cmp(sa));
+        ring_facts.truncate(effective_ring_limit);
+
+        for (_, fact) in ring_facts {
+            let key = (
+                fact.entity_name.clone(),
+                fact.relation.clone(),
+                fact.target_name.clone(),
+                fact.edge_type,
+            );
+            if global_seen.insert(key) {
+                all_facts.push(fact);
+            }
+        }
+    }
+
+    // Final sort and truncation.
+    all_facts.sort_by(|a, b| {
+        let sa = a.score_with_decay(temporal_decay_rate, now_secs);
+        let sb = b.score_with_decay(temporal_decay_rate, now_secs);
+        sb.total_cmp(&sa)
+    });
+    all_facts.truncate(limit);
+
+    Ok(all_facts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::store::GraphStore;
+    use crate::graph::types::EntityType;
+    use crate::store::SqliteStore;
+    use zeph_llm::any::AnyProvider;
+    use zeph_llm::mock::MockProvider;
+
+    async fn setup_store() -> GraphStore {
+        let store = SqliteStore::new(":memory:").await.unwrap();
+        GraphStore::new(store.pool().clone())
+    }
+
+    fn mock_provider() -> AnyProvider {
+        AnyProvider::Mock(MockProvider::default())
+    }
+
+    #[tokio::test]
+    async fn watercircles_empty_graph_returns_empty() {
+        let store = setup_store().await;
+        let provider = mock_provider();
+        let result =
+            graph_recall_watercircles(&store, None, &provider, "anything", 10, 2, 0, &[], 0.0)
+                .await
+                .unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn watercircles_zero_limit_returns_empty() {
+        let store = setup_store().await;
+        let provider = mock_provider();
+        let result =
+            graph_recall_watercircles(&store, None, &provider, "anything", 0, 2, 0, &[], 0.0)
+                .await
+                .unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn watercircles_ring_limit_auto_respects_limit() {
+        let store = setup_store().await;
+        let root = store
+            .upsert_entity("Root", "root", EntityType::Concept, None)
+            .await
+            .unwrap();
+        for i in 0..10usize {
+            let target = store
+                .upsert_entity(
+                    &format!("T{i}"),
+                    &format!("t{i}"),
+                    EntityType::Concept,
+                    None,
+                )
+                .await
+                .unwrap();
+            store
+                .insert_edge(root, target, "has", &format!("Root has T{i}"), 0.8, None)
+                .await
+                .unwrap();
+        }
+        let provider = mock_provider();
+        let result = graph_recall_watercircles(&store, None, &provider, "Root", 5, 2, 0, &[], 0.0)
+            .await
+            .unwrap();
+        assert!(result.len() <= 5, "limit must be respected");
+    }
+}

--- a/crates/zeph-memory/src/graph/strategy_classifier.rs
+++ b/crates/zeph-memory/src/graph/strategy_classifier.rs
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! LLM-based retrieval strategy classifier for hybrid graph recall.
+//!
+//! [`classify_retrieval_strategy`] sends a one-shot prompt to the configured LLM
+//! provider and returns the name of the selected strategy. On any error the
+//! function silently returns `"synapse"` — it never propagates LLM failures to the caller.
+
+use zeph_llm::any::AnyProvider;
+use zeph_llm::provider::{LlmProvider as _, Message, Role};
+
+const CLASSIFY_PROMPT: &str = r#"Classify this query into one retrieval strategy. Reply with exactly one word.
+
+Strategies:
+- astar: factual lookups ("who is X", "what does X do", "find X")
+- watercircles: exploratory ("tell me about X", "what relates to X", "overview of X")
+- beam_search: multi-hop reasoning ("how does X connect to Y", "path from X to Z")
+- synapse: default/unclear
+
+Query: "#;
+
+/// Classify a query's intent to select the best graph retrieval strategy.
+///
+/// Returns one of: `"astar"`, `"watercircles"`, `"beam_search"`, or `"synapse"`.
+/// On any LLM error or unrecognised response, returns `"synapse"` as a safe fallback.
+/// This function never propagates errors.
+///
+/// # Examples
+///
+/// ```no_run
+/// # use zeph_memory::graph::strategy_classifier::classify_retrieval_strategy;
+/// # use zeph_llm::any::AnyProvider;
+/// # use zeph_llm::mock::MockProvider;
+/// # async fn demo() {
+/// let provider = AnyProvider::Mock(MockProvider::default());
+/// let strategy = classify_retrieval_strategy(&provider, "who is Alice?").await;
+/// assert!(["astar", "watercircles", "beam_search", "synapse"].contains(&strategy.as_str()));
+/// # }
+/// ```
+pub async fn classify_retrieval_strategy(provider: &AnyProvider, query: &str) -> String {
+    let _span = tracing::info_span!("memory.graph.classify_strategy").entered();
+
+    let prompt = format!("{CLASSIFY_PROMPT}{query}");
+    let messages = [Message {
+        role: Role::User,
+        content: prompt,
+        ..Default::default()
+    }];
+
+    let response = match provider.chat(&messages).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "strategy classifier: LLM error, falling back to synapse"
+            );
+            return "synapse".to_owned();
+        }
+    };
+
+    let word = response.trim().to_lowercase();
+    match word.as_str() {
+        "astar" | "watercircles" | "beam_search" | "synapse" => word,
+        _ => "synapse".to_owned(),
+    }
+}

--- a/crates/zeph-memory/src/semantic/recall.rs
+++ b/crates/zeph-memory/src/semantic/recall.rs
@@ -1330,6 +1330,111 @@ impl SemanticMemory {
         Ok(results)
     }
 
+    /// Retrieve graph facts via A* shortest-path traversal.
+    ///
+    /// Delegates to [`crate::graph::retrieval_astar::graph_recall_astar`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the underlying graph query fails.
+    pub async fn recall_graph_astar(
+        &self,
+        query: &str,
+        limit: usize,
+        max_hops: u32,
+        temporal_decay_rate: f64,
+        edge_types: &[crate::graph::EdgeType],
+    ) -> Result<Vec<crate::graph::types::GraphFact>, MemoryError> {
+        let Some(store) = &self.graph_store else {
+            return Ok(Vec::new());
+        };
+        crate::graph::retrieval_astar::graph_recall_astar(
+            store,
+            self.qdrant.as_deref(),
+            &self.provider,
+            query,
+            limit,
+            max_hops,
+            edge_types,
+            temporal_decay_rate,
+        )
+        .await
+    }
+
+    /// Retrieve graph facts via `WaterCircles` concentric BFS.
+    ///
+    /// Delegates to [`crate::graph::retrieval_watercircles::graph_recall_watercircles`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the underlying graph query fails.
+    pub async fn recall_graph_watercircles(
+        &self,
+        query: &str,
+        limit: usize,
+        max_hops: u32,
+        ring_limit: usize,
+        temporal_decay_rate: f64,
+        edge_types: &[crate::graph::EdgeType],
+    ) -> Result<Vec<crate::graph::types::GraphFact>, MemoryError> {
+        let Some(store) = &self.graph_store else {
+            return Ok(Vec::new());
+        };
+        crate::graph::retrieval_watercircles::graph_recall_watercircles(
+            store,
+            self.qdrant.as_deref(),
+            &self.provider,
+            query,
+            limit,
+            max_hops,
+            ring_limit,
+            edge_types,
+            temporal_decay_rate,
+        )
+        .await
+    }
+
+    /// Retrieve graph facts via beam search.
+    ///
+    /// Delegates to [`crate::graph::retrieval_beam::graph_recall_beam`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the underlying graph query fails.
+    pub async fn recall_graph_beam(
+        &self,
+        query: &str,
+        limit: usize,
+        beam_width: usize,
+        max_hops: u32,
+        temporal_decay_rate: f64,
+        edge_types: &[crate::graph::EdgeType],
+    ) -> Result<Vec<crate::graph::types::GraphFact>, MemoryError> {
+        let Some(store) = &self.graph_store else {
+            return Ok(Vec::new());
+        };
+        crate::graph::retrieval_beam::graph_recall_beam(
+            store,
+            self.qdrant.as_deref(),
+            &self.provider,
+            query,
+            limit,
+            beam_width,
+            max_hops,
+            edge_types,
+            temporal_decay_rate,
+        )
+        .await
+    }
+
+    /// Classify query intent and return the strategy name for hybrid dispatch.
+    ///
+    /// Returns one of: `"astar"`, `"watercircles"`, `"beam_search"`, `"synapse"`.
+    /// Falls back to `"synapse"` on any LLM error.
+    pub async fn classify_graph_strategy(&self, query: &str) -> String {
+        crate::graph::strategy_classifier::classify_retrieval_strategy(&self.provider, query).await
+    }
+
     /// Increment access count and update `last_accessed` for a batch of message IDs.
     ///
     /// Skips the update if `message_ids` is empty to avoid an invalid `IN ()` clause.


### PR DESCRIPTION
## Summary

- **#3296**: Add A*, WaterCircles, beam search, and hybrid retrieval strategies alongside SYNAPSE for MAGMA graph recall. New `retrieval_strategy` config field (default: `synapse`) preserves backward compatibility.
- **#2220**: Add experience memory — SQLite tables for recording tool execution outcomes as graph nodes, with temporal chaining and an evolution sweep that prunes self-loops and low-confidence edges.

## Changes

### Multi-strategy retrieval (#3296)

- `crates/zeph-config/src/memory.rs` — `GraphRetrievalStrategy` enum, `BeamSearchConfig`, `WaterCirclesConfig`, `ExperienceConfig` added to `GraphConfig`
- `crates/zeph-memory/src/graph/retrieval_astar.rs` — A* via petgraph (zero heuristic = Dijkstra fallback)
- `crates/zeph-memory/src/graph/retrieval_watercircles.rs` — ring-by-ring BFS with per-ring cap
- `crates/zeph-memory/src/graph/retrieval_beam.rs` — beam search keeping top-K entities per hop
- `crates/zeph-memory/src/graph/strategy_classifier.rs` — LLM intent classifier with synapse fallback
- `crates/zeph-core/src/agent/context/assembler_helpers.rs` — strategy dispatch with 2 s classifier timeout

### Experience memory (#2220)

- `crates/zeph-db/migrations/sqlite/076_experience_memory.sql` — `experience_nodes`, `experience_edges`, `experience_entity_links` tables
- `crates/zeph-memory/src/graph/experience.rs` — `ExperienceStore` with record, link, and evolution sweep

## Test plan

- [ ] 1144 unit tests pass (`cargo nextest run -p zeph-memory --lib`)
- [ ] `cargo clippy -p zeph-config -p zeph-memory -p zeph-core -- -D warnings` clean
- [ ] `cargo +nightly fmt --check` clean
- [ ] Set `retrieval_strategy = "astar"` in config, run session, verify graph recall section appears
- [ ] Set `retrieval_strategy = "hybrid"`, verify LLM classifier selects strategy and falls back to synapse on timeout
- [ ] Verify `experience_nodes` table populated after tool calls with `[memory.graph.experience] enabled = true`
- [ ] Verify evolution sweep removes self-loop edges from `graph_edges`

Closes #3296
Closes #2220