### PR TITLE
fix(config): add missing migrate-config steps for acp.subagents, hooks.permission_denied, memory.graph

### DIFF
--- a/crates/zeph-config/src/migrate.rs
+++ b/crates/zeph-config/src/migrate.rs
@@ -2269,6 +2269,130 @@ pub fn migrate_quality_config(toml_src: &str) -> Result<MigrationResult, Migrate
     })
 }
 
+/// Add a commented-out `[acp.subagents]` block if the config lacks it (#3304).
+///
+/// Introduced alongside the ACP sub-agent delegation feature (#3289). All `AcpSubagentsConfig`
+/// fields have `#[serde(default)]` so existing configs parse without changes; this migration
+/// only surfaces the section so users can discover and enable it.
+///
+/// # Errors
+///
+/// This function is infallible in practice; the `Result` return type matches the
+/// migration function convention for use in chained pipelines.
+pub fn migrate_acp_subagents_config(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    if toml_src
+        .lines()
+        .any(|l| l.trim() == "[acp.subagents]" || l.trim() == "# [acp.subagents]")
+    {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let comment = "\n# [acp.subagents] — sub-agent delegation via ACP protocol (#3289).\n\
+         # [acp.subagents]\n\
+         # enabled = false\n\
+         #\n\
+         # [[acp.subagents.presets]]\n\
+         # name = \"inner\"                         # identifier used in /subagent commands\n\
+         # command = \"cargo run --quiet -- --acp\" # shell command to spawn the sub-agent\n\
+         # # cwd = \"/path/to/agent\"              # optional working directory\n\
+         # # handshake_timeout_secs = 30          # initialize+session/new timeout\n\
+         # # prompt_timeout_secs = 600            # single round-trip timeout\n";
+    let output = format!("{toml_src}{comment}");
+
+    Ok(MigrationResult {
+        output,
+        changed_count: 1,
+        sections_changed: vec!["acp.subagents".to_owned()],
+    })
+}
+
+/// Add a commented-out `[[hooks.permission_denied]]` block if the config lacks it (#3309).
+///
+/// Introduced alongside the reactive env hooks and MCP tool dispatch feature (#3303).
+/// All hook arrays have `#[serde(default)]` so existing configs parse without changes;
+/// this migration surfaces the section for discoverability.
+///
+/// # Errors
+///
+/// This function is infallible in practice; the `Result` return type matches the
+/// migration function convention for use in chained pipelines.
+pub fn migrate_hooks_permission_denied_config(
+    toml_src: &str,
+) -> Result<MigrationResult, MigrateError> {
+    if toml_src.lines().any(|l| {
+        l.trim() == "[[hooks.permission_denied]]" || l.trim() == "# [[hooks.permission_denied]]"
+    }) {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let comment = "\n# [[hooks.permission_denied]] — hook fired when a tool call is denied (#3303).\n\
+         # Available env vars: ZEPH_TOOL, ZEPH_DENY_REASON, ZEPH_TOOL_INPUT_JSON.\n\
+         # [[hooks.permission_denied]]\n\
+         # [hooks.permission_denied.action]\n\
+         # type = \"command\"\n\
+         # command = \"echo denied: $ZEPH_TOOL\"\n";
+    let output = format!("{toml_src}{comment}");
+
+    Ok(MigrationResult {
+        output,
+        changed_count: 1,
+        sections_changed: vec!["hooks.permission_denied".to_owned()],
+    })
+}
+
+/// Add commented-out `[memory.graph]` retrieval strategy options if the config lacks them (#3317).
+///
+/// Introduced alongside the multi-strategy graph retrieval and experience memory feature (#3311).
+/// All `MemoryGraphConfig` fields have `#[serde(default)]` so existing configs parse without
+/// changes; this migration surfaces the new options for discoverability.
+///
+/// # Errors
+///
+/// This function is infallible in practice; the `Result` return type matches the
+/// migration function convention for use in chained pipelines.
+pub fn migrate_memory_graph_config(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    if toml_src.contains("retrieval_strategy")
+        || toml_src.contains("[memory.graph.beam_search]")
+        || toml_src.contains("# [memory.graph.beam_search]")
+    {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let comment = "\n# [memory.graph] retrieval strategy options (#3311).\n\
+         # retrieval_strategy = \"synapse\"    # synapse | bfs | astar | watercircles | beam_search | hybrid\n\
+         #\n\
+         # [memory.graph.beam_search]        # active when retrieval_strategy = \"beam_search\"\n\
+         # beam_width = 10                   # top-K candidates kept per hop\n\
+         #\n\
+         # [memory.graph.watercircles]       # active when retrieval_strategy = \"watercircles\"\n\
+         # ring_limit = 0                    # max facts per ring; 0 = auto\n\
+         #\n\
+         # [memory.graph.experience]         # experience memory recording\n\
+         # enabled = false\n\
+         # evolution_sweep_enabled = false\n\
+         # confidence_prune_threshold = 0.1  # prune edges below this threshold\n\
+         # evolution_sweep_interval = 50     # turns between sweeps\n";
+    let output = format!("{toml_src}{comment}");
+
+    Ok(MigrationResult {
+        output,
+        changed_count: 1,
+        sections_changed: vec!["memory.graph.retrieval".to_owned()],
+    })
+}
+
 // Helper to create a formatted value (used in tests).
 #[cfg(test)]
 fn make_formatted_str(s: &str) -> Value {

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -5,14 +5,15 @@ use std::path::Path;
 
 use similar::{ChangeTag, TextDiff};
 use zeph_core::config::migrate::{
-    ConfigMigrator, migrate_agent_budget_hint, migrate_agent_retry_to_tools_retry,
-    migrate_autodream_config, migrate_compression_predictor_config, migrate_database_url,
-    migrate_egress_config, migrate_forgetting_config, migrate_magic_docs_config,
-    migrate_mcp_elicitation_config, migrate_mcp_trust_levels, migrate_microcompact_config,
-    migrate_orchestration_persistence, migrate_otel_filter, migrate_planner_model_to_provider,
-    migrate_quality_config, migrate_sandbox_config, migrate_session_recap_config,
-    migrate_shell_transactional, migrate_stt_to_provider, migrate_supervisor_config,
-    migrate_telemetry_config, migrate_vigil_config,
+    ConfigMigrator, migrate_acp_subagents_config, migrate_agent_budget_hint,
+    migrate_agent_retry_to_tools_retry, migrate_autodream_config,
+    migrate_compression_predictor_config, migrate_database_url, migrate_egress_config,
+    migrate_forgetting_config, migrate_hooks_permission_denied_config, migrate_magic_docs_config,
+    migrate_mcp_elicitation_config, migrate_mcp_trust_levels, migrate_memory_graph_config,
+    migrate_microcompact_config, migrate_orchestration_persistence, migrate_otel_filter,
+    migrate_planner_model_to_provider, migrate_quality_config, migrate_sandbox_config,
+    migrate_session_recap_config, migrate_shell_transactional, migrate_stt_to_provider,
+    migrate_supervisor_config, migrate_telemetry_config, migrate_vigil_config,
 };
 
 /// Handle the `zeph migrate-config` command.
@@ -122,9 +123,21 @@ pub(crate) fn handle_migrate_config(
     let quality_result = migrate_quality_config(&after_mcp_elicitation)?;
     let after_quality = quality_result.output;
 
-    // Step 23: add missing default keys as commented-out entries.
+    // Step 23: add commented-out [acp.subagents] block if absent (#3304).
+    let acp_subagents_result = migrate_acp_subagents_config(&after_quality)?;
+    let after_acp_subagents = acp_subagents_result.output;
+
+    // Step 24: add commented-out [[hooks.permission_denied]] block if absent (#3309).
+    let hooks_perm_denied_result = migrate_hooks_permission_denied_config(&after_acp_subagents)?;
+    let after_hooks_perm_denied = hooks_perm_denied_result.output;
+
+    // Step 25: add commented-out [memory.graph] retrieval strategy options if absent (#3317).
+    let memory_graph_result = migrate_memory_graph_config(&after_hooks_perm_denied)?;
+    let after_memory_graph = memory_graph_result.output;
+
+    // Step 26: add missing default keys as commented-out entries.
     let migrator = ConfigMigrator::new();
-    let result = migrator.migrate(&after_quality)?;
+    let result = migrator.migrate(&after_memory_graph)?;
 
     if diff {
         print_diff(&input, &result.output);
@@ -209,6 +222,20 @@ pub(crate) fn handle_migrate_config(
         }
         if quality_result.changed_count > 0 {
             eprintln!("Quality migration: added commented-out [quality] block.");
+        }
+        if acp_subagents_result.changed_count > 0 {
+            eprintln!("ACP subagents migration: added commented-out [acp.subagents] block.");
+        }
+        if hooks_perm_denied_result.changed_count > 0 {
+            eprintln!(
+                "Hooks permission_denied migration: \
+                 added commented-out [[hooks.permission_denied]] block."
+            );
+        }
+        if memory_graph_result.changed_count > 0 {
+            eprintln!(
+                "Memory graph migration: added commented-out [memory.graph] retrieval options."
+            );
         }
         eprintln!(
             "Migration would add {} entries ({} sections).",


### PR DESCRIPTION
## Summary

Three config sections introduced in recent PRs had no corresponding `migrate-config` hints, violating Dev Rule §5 (migration step required for every new config parameter).

- **#3304** `migrate_acp_subagents_config`: commented-out `[acp.subagents]` block with `enabled` flag and `[[acp.subagents.presets]]` template (introduced in #3289)
- **#3309** `migrate_hooks_permission_denied_config`: commented-out `[[hooks.permission_denied]]` example with env var documentation (introduced in #3303)
- **#3317** `migrate_memory_graph_config`: commented-out `retrieval_strategy`, `[memory.graph.beam_search]`, `[memory.graph.watercircles]`, and `[memory.graph.experience]` blocks (introduced in #3311)

## Changes

- `crates/zeph-config/src/migrate.rs`: three new pub migration functions with idempotency guards
- `src/commands/migrate.rs`: import and chain the new steps (23, 24, 25) before the `ConfigMigrator` pass; `--diff` output extended with change notices

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` — 8261 passed
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo run --features full -- --config .local/config/testing.toml migrate-config --diff` shows new sections for acp.subagents, hooks.permission_denied, memory.graph retrieval options

Closes #3304, #3309, #3317.