### PR TITLE
feat(cost): add CPS metric to CostTracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- CPS (cost per successful task) metric in `CostTracker`: `record_successful_task()`, `cps()`,
+  and `successful_tasks()` methods; daily reset consistent with existing cost reset (#2194).
+- `cost_cps_cents: Option<f64>` and `cost_successful_tasks: u64` fields in `AgentMetrics`;
+  updated after each successful turn in `native.rs` and `plan.rs` (#2194).
+- Qwen-2.5-7B Ollama provider entry (commented) in `.local/config/testing.toml` as `slm-medium`
+  for cost-optimised medium-complexity tasks per arXiv:2510.03847 (#2194).
+- Spec `specs/048-slm-cost-metrics/spec.md` documenting SLM survey findings and CPS metric
+  contract (#2194).
 - Hook actions now support `type = "mcp_tool"` to invoke MCP server tools directly without spawning a subprocess (#3293). Hooks can set `server`, `tool`, and optional `args` fields. Requires the MCP manager to be active; fails according to `fail_closed` if unavailable.
 - New `[hooks.permission_denied]` event fires when a tool execution is short-circuited by a `RuntimeLayer::before_tool` check (#3292). `Command` hooks receive `ZEPH_DENIED_TOOL` and `ZEPH_DENY_REASON` environment variables.
 - `McpDispatch` trait in `zeph-subagent` decouples hook execution from `zeph-mcp` — implementors are wired by `zeph-core` at call sites.

--- a/crates/zeph-core/src/agent/plan.rs
+++ b/crates/zeph-core/src/agent/plan.rs
@@ -488,6 +488,7 @@ impl<C: crate::channel::Channel> Agent<C> {
                             m.total_tokens = m.prompt_tokens + m.completion_tokens;
                         });
                         self.record_cost_and_cache(aggr_prompt, aggr_completion);
+                        self.record_successful_task();
                         self.channel.send(&synthesis).await?;
                     }
                     Err(e) => {
@@ -724,6 +725,7 @@ impl<C: crate::channel::Channel> Agent<C> {
             m.orchestration_graph = Some(snapshot);
         });
         self.record_cost_and_cache(planner_prompt, planner_completion);
+        self.record_successful_task();
 
         let summary = format_plan_summary(&graph);
         if confirm_before_execute {

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -376,6 +376,7 @@ impl<C: Channel> Agent<C> {
                     m.total_tokens = m.prompt_tokens + m.completion_tokens;
                 });
                 self.record_cost_and_cache(final_prompt, final_completion);
+                self.record_successful_task();
                 if let Some(ref recorder) = self.metrics.histogram_recorder {
                     recorder.observe_llm_latency(elapsed);
                 }
@@ -1029,6 +1030,7 @@ impl<C: Channel> Agent<C> {
             }
         });
         self.record_cost_and_cache(final_prompt, final_completion);
+        self.record_successful_task();
 
         if let Some(ref recorder) = self.metrics.histogram_recorder {
             recorder.observe_llm_latency(elapsed);

--- a/crates/zeph-core/src/agent/utils.rs
+++ b/crates/zeph-core/src/agent/utils.rs
@@ -267,6 +267,16 @@ impl<C: Channel> Agent<C> {
         }
     }
 
+    pub(crate) fn record_successful_task(&self) {
+        if let Some(ref tracker) = self.metrics.cost_tracker {
+            tracker.record_successful_task();
+            self.update_metrics(|m| {
+                m.cost_cps_cents = tracker.cps();
+                m.cost_successful_tasks = tracker.successful_tasks();
+            });
+        }
+    }
+
     /// Inject pre-formatted code context into the message list.
     /// The caller is responsible for retrieving and formatting the text.
     pub fn inject_code_context(&mut self, text: &str) {

--- a/crates/zeph-core/src/cost.rs
+++ b/crates/zeph-core/src/cost.rs
@@ -42,6 +42,7 @@ struct CostState {
     spent_cents: f64,
     day: u32,
     providers: HashMap<String, ProviderUsage>,
+    successful_tasks: u64,
 }
 
 pub struct CostTracker {
@@ -114,6 +115,7 @@ fn reset_if_new_day(state: &mut CostState) {
         state.spent_cents = 0.0;
         state.day = today;
         state.providers.clear();
+        state.successful_tasks = 0;
     }
 }
 
@@ -126,6 +128,7 @@ impl CostTracker {
                 spent_cents: 0.0,
                 day: current_day(),
                 providers: HashMap::new(),
+                successful_tasks: 0,
             })),
             max_daily_cents,
             enabled,
@@ -228,6 +231,35 @@ impl CostTracker {
     pub fn current_spend(&self) -> f64 {
         let state = self.state.lock();
         state.spent_cents
+    }
+
+    /// Increment the successful-task counter.
+    ///
+    /// Call after each turn that completes without error and produces a usable agent response.
+    pub fn record_successful_task(&self) {
+        if !self.enabled {
+            return;
+        }
+        let mut state = self.state.lock();
+        reset_if_new_day(&mut state);
+        state.successful_tasks += 1;
+    }
+
+    /// Returns cost-per-successful-task in cents, or `None` if no tasks recorded yet.
+    #[must_use]
+    pub fn cps(&self) -> Option<f64> {
+        let state = self.state.lock();
+        if state.successful_tasks == 0 {
+            return None;
+        }
+        #[allow(clippy::cast_precision_loss)]
+        Some(state.spent_cents / state.successful_tasks as f64)
+    }
+
+    /// Returns total number of successful tasks recorded today.
+    #[must_use]
+    pub fn successful_tasks(&self) -> u64 {
+        self.state.lock().successful_tasks
     }
 
     /// Returns per-provider breakdown sorted by cost descending.
@@ -479,5 +511,42 @@ mod tests {
             1000,
         );
         assert!(tracker.provider_breakdown().is_empty());
+    }
+
+    #[test]
+    fn cps_none_when_no_tasks() {
+        let tracker = CostTracker::new(true, 100.0);
+        assert!(tracker.cps().is_none());
+        assert_eq!(tracker.successful_tasks(), 0);
+    }
+
+    #[test]
+    fn cps_calculated_correctly() {
+        let tracker = CostTracker::new(true, 100.0);
+        // 0.25 (input) + 1.0 (output) = 1.25 cents
+        record(&tracker, "openai", "gpt-4o", 1000, 1000);
+        tracker.record_successful_task();
+        tracker.record_successful_task();
+        assert_eq!(tracker.successful_tasks(), 2);
+        let cps = tracker.cps().expect("cps should be Some after tasks");
+        // 1.25 / 2 = 0.625
+        assert!((cps - 0.625).abs() < 0.001, "cps={cps}");
+    }
+
+    #[test]
+    fn cps_resets_on_new_day() {
+        let tracker = CostTracker::new(true, 100.0);
+        record(&tracker, "openai", "gpt-4o", 1000, 1000);
+        tracker.record_successful_task();
+        assert_eq!(tracker.successful_tasks(), 1);
+        // Force day change
+        {
+            let mut state = tracker.state.lock();
+            state.day = 0;
+        }
+        // Any state-touching call triggers reset
+        assert!(tracker.check_budget().is_ok());
+        assert_eq!(tracker.successful_tasks(), 0);
+        assert!(tracker.cps().is_none());
     }
 }

--- a/crates/zeph-core/src/metrics.rs
+++ b/crates/zeph-core/src/metrics.rs
@@ -272,6 +272,10 @@ pub struct MetricsSnapshot {
     pub cache_read_tokens: u64,
     pub cache_creation_tokens: u64,
     pub cost_spent_cents: f64,
+    /// Cost per successful task in cents. `None` until at least one task completes.
+    pub cost_cps_cents: Option<f64>,
+    /// Number of successful tasks recorded today.
+    pub cost_successful_tasks: u64,
     /// Per-provider cost breakdown, sorted by cost descending.
     pub provider_cost_breakdown: Vec<(String, crate::cost::ProviderUsage)>,
     pub filter_raw_tokens: u64,

--- a/specs/048-slm-cost-metrics/spec.md
+++ b/specs/048-slm-cost-metrics/spec.md
@@ -1,0 +1,90 @@
+# Spec 048 — SLM Cost Metrics
+
+**Source:** arXiv:2510.03847 — "Small Language Models for Agentic Systems" (October 2025)
+
+## Overview
+
+Small Language Models (1–12B parameters) are sufficient and often superior for schema-constrained
+and API-constrained agentic tasks: tool calling, structured extraction, and RAG retrieval. The
+capability gap with GPT-4-class models closes when guided decoding + strict JSON Schema output +
+validator-first execution is applied. Cost reduction: 10x–100x lower token cost with materially
+better latency and energy efficiency.
+
+Applicable to Zeph in three areas:
+
+1. **Orchestration** — `LlmPlanner` / task decomposition can use Qwen-2.5-7B or Phi-4-Mini as
+   `planner_provider` at 10x lower cost with comparable quality on structured outputs.
+2. **Compaction** — `fast` provider (GPT-4o-mini) can be replaced by locally-hosted Llama-3.2-3B
+   via Ollama for zero-cost summarization.
+3. **Sub-agent tool calling** — sub-agents running on Qwen-2.5-7B with guided decoding reduce
+   cost significantly in orchestration-heavy workflows.
+
+Surveyed models: Phi-4-Mini, Qwen-2.5-7B, Gemma-2-9B, Llama-3.2-1B/3B, Ministral-3B/8B,
+DeepSeek-R1-Distill.
+
+## CPS Metric
+
+**Cost Per Successful Task (CPS)** measures the average cost in cents to complete one agent turn
+that produces a usable response.
+
+```
+CPS = total_spent_cents / successful_tasks_today
+```
+
+A "successful task" is any agent turn that completes the LLM inference and returns a response
+without error. The counter is incremented by `CostTracker::record_successful_task()`, which is
+called immediately after `record_cost_and_cache()` at each turn completion point.
+
+### API surface (`zeph-core::cost`)
+
+| Method | Description |
+|--------|-------------|
+| `record_successful_task()` | Increments today's successful-task counter |
+| `cps() -> Option<f64>` | Returns CPS in cents; `None` until first task recorded |
+| `successful_tasks() -> u64` | Returns count of successful tasks today |
+
+### Metrics fields (`AgentMetrics`)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cost_cps_cents` | `Option<f64>` | Current CPS value |
+| `cost_successful_tasks` | `u64` | Successful task count today |
+
+Both fields are updated in `record_cost_and_cache` → `record_successful_task` call chain inside
+`utils.rs`.
+
+## Key Invariants
+
+- CPS and successful-task count reset at UTC day boundary, consistent with `spent_cents` reset.
+- When `CostTracker` is disabled, `record_successful_task()` is a no-op; `cps()` returns `None`.
+- A turn that errors before `record_cost_and_cache` is called is NOT counted as successful.
+- Per-provider CPS is not tracked; only the global daily counter is maintained.
+
+## SLM Provider Configuration
+
+Add to `[[llm.providers]]` in config when Ollama is available locally:
+
+```toml
+[[llm.providers]]
+name = "slm-medium"
+type = "ollama"
+base_url = "http://localhost:11434"
+model = "qwen2.5:7b"
+max_tokens = 8192
+```
+
+Reference this provider via `planner_provider = "slm-medium"` in `[orchestration]` or
+`compaction_provider = "slm-medium"` in `[memory.compression]` for cost-optimised deployments.
+
+## NEVER
+
+- Never increment `successful_tasks` for turns that returned an LLM error or budget exhaustion.
+- Never count turns that completed compaction or background tasks only (no user-facing response).
+- Never remove the daily reset for `successful_tasks` — CPS is a daily operational metric, not a
+  session-lifetime metric.
+
+## Related Issues
+
+- #2192 — SLMs are the Future of Agentic AI
+- #2165 — Unified routing+cascading framework
+- #2185 — Candle-backed lightweight classifiers


### PR DESCRIPTION
## Summary

- Adds `record_successful_task()`, `cps() -> Option<f64>`, and `successful_tasks() -> u64` to `CostTracker` in `zeph-core` — tracks Cost Per Successful Task (CPS) per day, resets at UTC midnight alongside existing cost counters.
- Wires `record_successful_task()` after every `record_cost_and_cache()` call site in `native.rs` and `plan.rs`.
- Adds `cost_cps_cents: Option<f64>` and `cost_successful_tasks: u64` to `AgentMetrics`.
- Adds commented-out `slm-medium` Qwen-2.5-7B Ollama provider entry to `.local/config/testing.toml`.
- Adds spec `048-slm-cost-metrics` documenting SLM survey findings (arXiv:2510.03847) and CPS metric contract.

Based on SLM survey findings: SLMs (1–12B params) are sufficient for tool calling/RAG at 10x–100x lower cost; CPS is the production metric that makes this cost reduction measurable per turn.

## Test plan

- [ ] `cargo nextest run -p zeph-core -E 'test(cps)'` — 3 new CPS tests pass
- [ ] `cargo nextest run -p zeph-core --lib` — all 23 cost tests pass
- [ ] Live session: send 3 turns, verify `cost_successful_tasks = 3` and `cost_cps_cents` is non-None
- [ ] Disabled tracker: verify `cps()` returns None and counter stays 0

Closes #2194