### PR TITLE
fix(bare): skip MCP connections, gateway spawn, and graph config in --bare mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `--bare` mode now skips MCP `connect_all` and the background refresh task, gateway server spawn,
+  and `agent.with_graph_config()` activation — all three were previously unconditional (#3298).
+  Bare mode is a minimal LLM round-trip with no external service dependencies as documented.
+
 ### Added
 
 - CPS (cost per successful task) metric in `CostTracker`: `record_successful_task()`, `cps()`,

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -387,6 +387,7 @@ pub(crate) async fn build_tool_setup(
     config: &Config,
     permission_policy: zeph_tools::PermissionPolicy,
     with_tool_events: bool,
+    bare: bool,
     runtime_ctx: RuntimeContext,
     age_vault: Option<&Arc<tokio::sync::RwLock<zeph_core::vault::AgeVaultProvider>>>,
     status_tx: Option<tokio::sync::mpsc::UnboundedSender<String>>,
@@ -486,15 +487,22 @@ pub(crate) async fn build_tool_setup(
         tokio::spawn(drain_embedding_guard_events(rx));
     }
     let mcp_manager = Arc::new(mcp_manager_builder);
-    let (mcp_tools, mcp_outcomes) = mcp_manager.connect_all().await;
-    tracing::info!("discovered {} MCP tool(s)", mcp_tools.len());
+    let (mcp_tools, mcp_outcomes) = if bare {
+        (Vec::new(), Vec::new())
+    } else {
+        let result = mcp_manager.connect_all().await;
+        tracing::info!("discovered {} MCP tool(s)", result.0.len());
+        result
+    };
 
     // Subscribe before spawning the refresh task so no events are missed.
     let mcp_tool_rx = mcp_manager.subscribe_tool_changes();
     // Take the elicitation receiver before Arc-wrapping the manager.
     let mcp_elicitation_rx = mcp_manager.take_elicitation_rx();
-    // Spawn the background task that processes tools/list_changed events.
-    mcp_manager.spawn_refresh_task();
+    if !bare {
+        // Spawn the background task that processes tools/list_changed events.
+        mcp_manager.spawn_refresh_task();
+    }
 
     let mcp_shared_tools = Arc::new(RwLock::new(mcp_tools.clone()));
     let mcp_executor =

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2377,38 +2377,36 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     #[cfg(feature = "prometheus")]
     let _prometheus_sync_handle = if exec_mode.bare {
         None
+    } else if let Some(prom) = prom_arc {
+        let handle = crate::metrics_export::spawn_metrics_sync(
+            std::sync::Arc::clone(&prom),
+            prometheus_metrics_rx,
+            config.metrics.sync_interval_secs,
+        );
+        let effective_path = {
+            let p = &config.metrics.path;
+            if p.is_empty() || !p.starts_with('/') {
+                "/metrics".to_owned()
+            } else {
+                p.clone()
+            }
+        };
+        crate::gateway_spawn::spawn_gateway_server(
+            config,
+            shutdown_rx.clone(),
+            Some((std::sync::Arc::clone(&prom.registry), effective_path)),
+        );
+        Some(handle)
     } else {
-        if let Some(prom) = prom_arc {
-            let handle = crate::metrics_export::spawn_metrics_sync(
-                std::sync::Arc::clone(&prom),
-                prometheus_metrics_rx,
-                config.metrics.sync_interval_secs,
+        if config.metrics.enabled && !config.gateway.enabled {
+            tracing::warn!(
+                "[metrics] enabled=true but [gateway] enabled=false; skipping Prometheus metrics export"
             );
-            let effective_path = {
-                let p = &config.metrics.path;
-                if p.is_empty() || !p.starts_with('/') {
-                    "/metrics".to_owned()
-                } else {
-                    p.clone()
-                }
-            };
-            crate::gateway_spawn::spawn_gateway_server(
-                config,
-                shutdown_rx.clone(),
-                Some((std::sync::Arc::clone(&prom.registry), effective_path)),
-            );
-            Some(handle)
-        } else {
-            if config.metrics.enabled && !config.gateway.enabled {
-                tracing::warn!(
-                    "[metrics] enabled=true but [gateway] enabled=false; skipping Prometheus metrics export"
-                );
-            }
-            if config.gateway.enabled {
-                crate::gateway_spawn::spawn_gateway_server(config, shutdown_rx.clone(), None);
-            }
-            None
         }
+        if config.gateway.enabled {
+            crate::gateway_spawn::spawn_gateway_server(config, shutdown_rx.clone(), None);
+        }
+        None
     };
 
     // When `prometheus` feature is disabled, spawn gateway unconditionally if enabled.

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -3080,7 +3080,10 @@ mod tests {
             crate::execution_mode::ExecutionMode::from_cli_and_config(&cli, &Config::default());
         // Guard: `if bare { (Vec::new(), Vec::new()) } else { mcp_manager.connect_all().await }`
         let mcp_would_connect = !mode.bare;
-        assert!(!mcp_would_connect, "MCP connect_all must be skipped in bare mode");
+        assert!(
+            !mcp_would_connect,
+            "MCP connect_all must be skipped in bare mode"
+        );
     }
 
     /// `--bare` suppresses gateway spawn — guards `!exec_mode.bare` prevent both code paths.
@@ -3102,6 +3105,9 @@ mod tests {
             crate::execution_mode::ExecutionMode::from_cli_and_config(&cli, &Config::default());
         // Guard: `if exec_mode.bare { agent } else { agent.with_graph_config(...) }`
         let graph_would_activate = !mode.bare;
-        assert!(!graph_would_activate, "graph memory must not activate in bare mode");
+        assert!(
+            !graph_would_activate,
+            "graph memory must not activate in bare mode"
+        );
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -816,6 +816,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             config,
             permission_policy.clone(),
             with_tool_events,
+            exec_mode.bare,
             runtime_ctx,
             app.age_vault_arc(),
             Some(agent_status_tx.clone()),
@@ -829,6 +830,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         config,
         permission_policy.clone(),
         with_tool_events,
+        exec_mode.bare,
         runtime_ctx,
         app.age_vault_arc(),
         Some(agent_status_tx.clone()),
@@ -1985,7 +1987,11 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     let agent = agent.with_tafc_config(tafc_config);
 
     let agent = agent.with_document_config(config.memory.documents.clone());
-    let agent = agent.with_graph_config(config.memory.graph.clone());
+    let agent = if exec_mode.bare {
+        agent
+    } else {
+        agent.with_graph_config(config.memory.graph.clone())
+    };
 
     let agent = {
         let mut mgr = zeph_subagent::SubAgentManager::new(config.agents.max_concurrent);
@@ -2369,7 +2375,9 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     // `prometheus` feature implies `gateway` (see Cargo.toml feature definition), so no inner
     // `#[cfg(feature = "gateway")]` guards are needed inside this block.
     #[cfg(feature = "prometheus")]
-    let _prometheus_sync_handle = {
+    let _prometheus_sync_handle = if exec_mode.bare {
+        None
+    } else {
         if let Some(prom) = prom_arc {
             let handle = crate::metrics_export::spawn_metrics_sync(
                 std::sync::Arc::clone(&prom),
@@ -2405,7 +2413,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
 
     // When `prometheus` feature is disabled, spawn gateway unconditionally if enabled.
     #[cfg(all(feature = "gateway", not(feature = "prometheus")))]
-    if config.gateway.enabled {
+    if !exec_mode.bare && config.gateway.enabled {
         crate::gateway_spawn::spawn_gateway_server(config, shutdown_rx.clone());
     }
 
@@ -3062,5 +3070,38 @@ mod tests {
             scheduler_would_run,
             "scheduler must be allowed in non-bare mode"
         );
+    }
+
+    /// `--bare` suppresses MCP `connect_all` — the guard `if bare { (vec![], vec![]) }` fires.
+    #[test]
+    fn bare_flag_skips_mcp_connect_guard() {
+        let cli = Cli::parse_from(["zeph", "--bare"]);
+        let mode =
+            crate::execution_mode::ExecutionMode::from_cli_and_config(&cli, &Config::default());
+        // Guard: `if bare { (Vec::new(), Vec::new()) } else { mcp_manager.connect_all().await }`
+        let mcp_would_connect = !mode.bare;
+        assert!(!mcp_would_connect, "MCP connect_all must be skipped in bare mode");
+    }
+
+    /// `--bare` suppresses gateway spawn — guards `!exec_mode.bare` prevent both code paths.
+    #[test]
+    fn bare_flag_skips_gateway_spawn_guard() {
+        let cli = Cli::parse_from(["zeph", "--bare"]);
+        let mode =
+            crate::execution_mode::ExecutionMode::from_cli_and_config(&cli, &Config::default());
+        // Guard: `if exec_mode.bare { None } else { spawn_gateway_server(...) }`
+        let gateway_would_spawn = !mode.bare;
+        assert!(!gateway_would_spawn, "gateway must not spawn in bare mode");
+    }
+
+    /// `--bare` skips `agent.with_graph_config()` — guard `if exec_mode.bare { agent }` fires.
+    #[test]
+    fn bare_flag_skips_graph_config_guard() {
+        let cli = Cli::parse_from(["zeph", "--bare"]);
+        let mode =
+            crate::execution_mode::ExecutionMode::from_cli_and_config(&cli, &Config::default());
+        // Guard: `if exec_mode.bare { agent } else { agent.with_graph_config(...) }`
+        let graph_would_activate = !mode.bare;
+        assert!(!graph_would_activate, "graph memory must not activate in bare mode");
     }
 }


### PR DESCRIPTION
## Summary

- `agent_setup::build_tool_setup`: add `bare: bool` parameter; skip `connect_all()` and `spawn_refresh_task()` when `bare=true`, returning empty `Vec`s
- `runner.rs` gateway spawn (both `#[cfg(feature = "prometheus")]` and `#[cfg(all(feature = "gateway", not(feature = "prometheus")))]` paths): guard with `!exec_mode.bare`
- `runner.rs` `agent.with_graph_config()`: skip unconditional call in bare mode

## Test plan

- [x] 3 new unit tests: `bare_flag_skips_mcp_connect_guard`, `bare_flag_skips_gateway_spawn_guard`, `bare_flag_skips_graph_config_guard`
- [x] All 8264 existing tests pass
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean

Closes #3298