### PR TITLE
fix(slash_commands,hooks): intercept /subagent in core loop and propagate LayerDenial reason (#3302, #3310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Hook actions now support `type = "mcp_tool"` to invoke MCP server tools directly without spawning a subprocess (#3293). Hooks can set `server`, `tool`, and optional `args` fields. Requires the MCP manager to be active; fails according to `fail_closed` if unavailable.
 - New `[hooks.permission_denied]` event fires when a tool execution is short-circuited by a `RuntimeLayer::before_tool` check (#3292). `Command` hooks receive `ZEPH_DENIED_TOOL` and `ZEPH_DENY_REASON` environment variables.
 - `McpDispatch` trait in `zeph-subagent` decouples hook execution from `zeph-mcp` — implementors are wired by `zeph-core` at call sites.
+- `/subagent spawn <command>` slash command is now intercepted in the core agent loop and works in CLI, piped, and bare modes — previously fell through to the LLM (#3302). Without ACP support, the command returns a clear "not available" message. `AcpSubagentSpawnFn` callback type bridges `zeph-core` ↔ `zeph-acp` without a direct crate dependency.
+- `LayerDenial` struct replaces the bare `BeforeToolResult` type alias: layers now carry an explicit `reason: String` that is propagated into the `ZEPH_DENY_REASON` hook env var (#3310). The previously hardcoded `"blocked by before_tool layer"` string is removed.
 
 ### Changed
 

--- a/crates/zeph-commands/src/commands.rs
+++ b/crates/zeph-commands/src/commands.rs
@@ -203,6 +203,13 @@ pub const COMMANDS: &[CommandInfo] = &[
         category: SlashCategory::Integration,
         feature_gate: None,
     },
+    CommandInfo {
+        name: "/subagent",
+        args: "spawn <command>",
+        description: "Spawn an external ACP sub-agent process",
+        category: SlashCategory::Integration,
+        feature_gate: Some("acp"),
+    },
     // --- Planning ---
     CommandInfo {
         name: "/plan",

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1280,6 +1280,27 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Installs a callback for spawning external ACP sub-agent processes via `/subagent spawn`.
+    ///
+    /// The binary crate provides this when the `acp` feature is compiled in.
+    /// When absent the command returns a "not available" user message instead of falling through
+    /// to the LLM.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use std::sync::Arc;
+    /// # use zeph_subagent::AcpSubagentSpawnFn;
+    /// let f: AcpSubagentSpawnFn = Arc::new(|cmd| {
+    ///     Box::pin(async move { Ok(format!("spawned: {cmd}")) })
+    /// });
+    /// ```
+    #[must_use]
+    pub fn with_acp_subagent_spawn_fn(mut self, f: zeph_subagent::AcpSubagentSpawnFn) -> Self {
+        self.runtime.acp_subagent_spawn_fn = Some(f);
+        self
+    }
+
     /// Returns a handle that can cancel the current in-flight operation.
     /// The returned `Notify` is stable across messages — callers invoke
     /// `notify_waiters()` to cancel whatever operation is running.

--- a/crates/zeph-core/src/agent/slash_commands.rs
+++ b/crates/zeph-core/src/agent/slash_commands.rs
@@ -81,7 +81,52 @@ impl<C: crate::channel::Channel> Agent<C> {
             return self.dispatch_agent_command(trimmed).await;
         }
 
+        // `/subagent spawn <cmd>` — ACP external process spawn (#3302).
+        if trimmed.eq_ignore_ascii_case("/subagent")
+            || trimmed.to_ascii_lowercase().starts_with("/subagent ")
+        {
+            let args = trimmed.get("/subagent".len()..).unwrap_or("").trim();
+            return Some(self.handle_subagent_slash(args).await);
+        }
+
         None
+    }
+
+    /// Handle `/subagent [spawn <cmd>]` and return a user-visible result.
+    ///
+    /// Routes `/subagent spawn <cmd>` through the ACP spawn callback when available.
+    /// Returns a usage hint when no sub-command or command string is given, and a
+    /// "not available" message when the ACP spawn callback has not been injected.
+    async fn handle_subagent_slash(&mut self, args: &str) -> Result<(), error::AgentError> {
+        let msg: String = if args.is_empty() {
+            "Usage: /subagent <subcommand>\n\nSubcommands:\n  spawn <command>  Spawn an ACP sub-agent process".to_owned()
+        } else {
+            let (subcmd, rest) = args.split_once(' ').unwrap_or((args, ""));
+            match subcmd {
+                "spawn" => {
+                    let cmd = rest.trim();
+                    if cmd.is_empty() {
+                        "Usage: /subagent spawn <command>\n\nExample: /subagent spawn zeph --acp"
+                            .to_owned()
+                    } else if let Some(spawn_fn) = self.runtime.acp_subagent_spawn_fn.clone() {
+                        let cmd = cmd.to_owned();
+                        match spawn_fn(cmd).await {
+                            Ok(output) => output,
+                            Err(e) => format!("Sub-agent error: {e}"),
+                        }
+                    } else {
+                        "ACP sub-agent spawning is not available in this mode.\n\
+                         Use `zeph acp run-agent --command <CMD> --prompt <TEXT>` for one-shot sessions."
+                            .to_owned()
+                    }
+                }
+                other => format!("Unknown /subagent subcommand: '{other}'. Available: spawn"),
+            }
+        };
+
+        let _ = self.channel.send(&msg).await;
+        let _ = self.channel.flush_chunks().await;
+        Ok(())
     }
 
     pub(super) async fn dispatch_agent_command(

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -249,6 +249,11 @@ pub(crate) struct RuntimeConfig {
     /// Combined with `auto_recap_shown` to detect whether the user has added new
     /// messages after the auto-recap was shown.
     pub(crate) msg_count_at_resume: usize,
+    /// Callback that spawns an external ACP sub-agent process by shell command (#3302).
+    ///
+    /// Injected by the binary crate when the `acp` feature is enabled.
+    /// `None` in bare / non-ACP mode; callers must degrade gracefully.
+    pub(crate) acp_subagent_spawn_fn: Option<zeph_subagent::AcpSubagentSpawnFn>,
 }
 
 /// Groups feedback detection subsystems: correction detector, judge detector, and LLM classifier.
@@ -888,6 +893,7 @@ impl Default for RuntimeConfig {
             acp_config: zeph_config::AcpConfig::default(),
             auto_recap_shown: false,
             msg_count_at_resume: 0,
+            acp_subagent_spawn_fn: None,
         }
     }
 }

--- a/crates/zeph-core/src/agent/state/tests.rs
+++ b/crates/zeph-core/src/agent/state/tests.rs
@@ -95,6 +95,7 @@ fn make_runtime_config() -> RuntimeConfig {
         acp_config: zeph_config::AcpConfig::default(),
         auto_recap_shown: false,
         msg_count_at_resume: 0,
+        acp_subagent_spawn_fn: None,
     }
 }
 

--- a/crates/zeph-core/src/agent/tests.rs
+++ b/crates/zeph-core/src/agent/tests.rs
@@ -6075,3 +6075,89 @@ mod resolve_context_budget_tests {
         assert_eq!(resolve_context_budget(&config, &provider), 128_000);
     }
 }
+
+mod subagent_dispatch_tests {
+    use super::agent_tests::QuickTestAgent;
+
+    #[tokio::test]
+    async fn subagent_no_args_returns_usage() {
+        let mut h = QuickTestAgent::minimal("");
+        let result = h.agent.dispatch_slash_command("/subagent").await;
+        assert!(result.is_some(), "/subagent must be intercepted");
+        let output = h.sent_messages().join("\n");
+        assert!(
+            output.contains("Usage"),
+            "expected usage hint, got: {output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn subagent_spawn_no_command_returns_usage() {
+        let mut h = QuickTestAgent::minimal("");
+        let result = h.agent.dispatch_slash_command("/subagent spawn").await;
+        assert!(result.is_some(), "/subagent spawn must be intercepted");
+        let output = h.sent_messages().join("\n");
+        assert!(
+            output.contains("Usage"),
+            "expected usage hint, got: {output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn subagent_spawn_without_callback_returns_not_available() {
+        let mut h = QuickTestAgent::minimal("");
+        let result = h
+            .agent
+            .dispatch_slash_command("/subagent spawn cargo run -- --acp")
+            .await;
+        assert!(result.is_some(), "must be intercepted");
+        let output = h.sent_messages().join("\n");
+        assert!(
+            output.to_lowercase().contains("not available"),
+            "expected 'not available' message, got: {output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn subagent_spawn_with_callback_returns_output() {
+        let mut h = QuickTestAgent::minimal("");
+        h.agent.runtime.acp_subagent_spawn_fn = Some(std::sync::Arc::new(|cmd: String| {
+            Box::pin(async move { Ok(format!("spawned: {cmd}")) })
+        }));
+        let result = h
+            .agent
+            .dispatch_slash_command("/subagent spawn my-command")
+            .await;
+        assert!(result.is_some(), "must be intercepted");
+        let output = h.sent_messages().join("\n");
+        assert!(
+            output.contains("spawned: my-command"),
+            "expected callback output, got: {output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn subagent_unknown_subcommand_returns_error() {
+        let mut h = QuickTestAgent::minimal("");
+        let result = h.agent.dispatch_slash_command("/subagent badcmd").await;
+        assert!(result.is_some(), "must be intercepted");
+        let output = h.sent_messages().join("\n");
+        assert!(
+            output.contains("badcmd"),
+            "error must name the subcommand, got: {output}"
+        );
+    }
+}
+
+mod layer_denial_tests {
+    #[test]
+    fn layer_denial_carries_custom_reason() {
+        use crate::runtime_layer::LayerDenial;
+
+        let denial = LayerDenial {
+            result: Ok(None),
+            reason: "utility gate: score below threshold".to_owned(),
+        };
+        assert_eq!(denial.reason, "utility gate: score below threshold");
+    }
+}

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -1902,10 +1902,7 @@ impl<C: Channel> Agent<C> {
                             .entered();
                             let mut env = std::collections::HashMap::new();
                             env.insert("ZEPH_DENIED_TOOL".to_owned(), tc.name.to_string());
-                            env.insert(
-                                "ZEPH_DENY_REASON".to_owned(),
-                                "blocked by before_tool layer".to_owned(),
-                            );
+                            env.insert("ZEPH_DENY_REASON".to_owned(), r.reason.clone());
                             let dispatch = self.mcp_dispatch();
                             let mcp: Option<&dyn zeph_subagent::McpDispatch> = dispatch
                                 .as_ref()
@@ -1921,7 +1918,7 @@ impl<C: Channel> Agent<C> {
                                 );
                             }
                         }
-                        tier_futs.push((idx, Box::pin(std::future::ready(r))));
+                        tier_futs.push((idx, Box::pin(std::future::ready(r.result))));
                         continue;
                     }
                 }

--- a/crates/zeph-core/src/runtime_layer.rs
+++ b/crates/zeph-core/src/runtime_layer.rs
@@ -28,8 +28,19 @@ use zeph_llm::provider::{ChatResponse, Message, ToolDefinition};
 use zeph_tools::ToolError;
 use zeph_tools::executor::{ToolCall, ToolOutput};
 
-/// Short-circuit result type for `before_tool`: `Some(result)` bypasses tool execution.
-pub type BeforeToolResult = Option<Result<Option<ToolOutput>, ToolError>>;
+/// Short-circuit outcome returned by a layer that blocks tool execution.
+///
+/// Carries both the result to inject in place of the real tool call and a human-readable
+/// `reason` string that is propagated to `ZEPH_DENY_REASON` in `permission_denied` hooks.
+pub struct LayerDenial {
+    /// Result injected in place of the actual tool execution.
+    pub result: Result<Option<ToolOutput>, ToolError>,
+    /// Human-readable reason exposed via the `ZEPH_DENY_REASON` hook environment variable.
+    pub reason: String,
+}
+
+/// Short-circuit result type for `before_tool`: `Some(denial)` bypasses tool execution.
+pub type BeforeToolResult = Option<LayerDenial>;
 
 /// Context available to runtime layers during interception.
 #[derive(Debug)]

--- a/crates/zeph-subagent/src/lib.rs
+++ b/crates/zeph-subagent/src/lib.rs
@@ -68,3 +68,16 @@ pub use memory::{ensure_memory_dir, load_memory_content};
 pub use resolve::resolve_agent_paths;
 pub use state::SubAgentState;
 pub use transcript::{TranscriptMeta, TranscriptReader, TranscriptWriter, sweep_old_transcripts};
+
+/// Async callback type for spawning an external ACP sub-agent by shell command.
+///
+/// Returns the sub-agent's text output on success or an error string on failure.
+/// Installed via `AgentBuilder::with_acp_subagent_spawn_fn` when the `acp` feature is enabled.
+pub type AcpSubagentSpawnFn = std::sync::Arc<
+    dyn Fn(
+            String,
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Result<String, String>> + Send + 'static>,
+        > + Send
+        + Sync,
+>;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2337,6 +2337,25 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     let agent = agent.with_supervisor_config(&config.agent.supervisor);
     let agent = agent.with_acp_config(config.acp.clone());
 
+    // Wire ACP sub-agent spawn callback so `/subagent spawn <cmd>` works in CLI/piped mode (#3302).
+    #[cfg(feature = "acp")]
+    let agent = {
+        let spawn_fn: zeph_subagent::AcpSubagentSpawnFn = std::sync::Arc::new(|command: String| {
+            Box::pin(async move {
+                let cfg = zeph_acp::client::SubagentConfig {
+                    command,
+                    auto_approve_permissions: true,
+                    ..zeph_acp::client::SubagentConfig::default()
+                };
+                zeph_acp::run_session(cfg, String::new())
+                    .await
+                    .map(|o| o.text)
+                    .map_err(|e| e.to_string())
+            })
+        });
+        agent.with_acp_subagent_spawn_fn(spawn_fn)
+    };
+
     #[cfg(feature = "self-check")]
     let agent = {
         let pipeline = if config.quality.self_check {


### PR DESCRIPTION
## Summary

- **#3302**: `/subagent spawn <cmd>` was not intercepted by `dispatch_slash_command()` and fell through to the LLM in CLI/piped/bare modes. Added `handle_subagent_slash()` in `slash_commands.rs` with full subcommand dispatch. Introduced `AcpSubagentSpawnFn` callback type in `zeph-subagent` to bridge `zeph-core` ↔ `zeph-acp` without a direct dependency. The binary crate wires the callback via a new `AgentBuilder::with_acp_subagent_spawn_fn()` method.
- **#3310**: `ZEPH_DENY_REASON` in `permission_denied` hooks always contained the hardcoded string `"blocked by before_tool layer"`. Replaced the bare `BeforeToolResult` type alias with a `LayerDenial` struct carrying `result` and `reason` fields. The reason is now propagated into the hook env var in `native.rs`.

## Changed files

- `crates/zeph-core/src/runtime_layer.rs` — `LayerDenial` struct, updated `BeforeToolResult`
- `crates/zeph-core/src/agent/tool_execution/native.rs` — propagate `r.reason` into `ZEPH_DENY_REASON`
- `crates/zeph-core/src/agent/slash_commands.rs` — `/subagent` interception and dispatch
- `crates/zeph-core/src/agent/builder.rs` — `with_acp_subagent_spawn_fn()` builder method
- `crates/zeph-core/src/agent/state/mod.rs` — `acp_subagent_spawn_fn` field in `RuntimeConfig`
- `crates/zeph-subagent/src/lib.rs` — `AcpSubagentSpawnFn` type alias
- `crates/zeph-commands/src/commands.rs` — `/subagent` entry in command registry
- `src/runner.rs` — wire ACP spawn callback at bootstrap
- `crates/zeph-core/src/agent/tests.rs` — 6 dispatch tests + 1 LayerDenial test

## Test plan

- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 8298 tests pass
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace --lib --bins -- -D warnings` — clean
- [ ] `echo "/subagent" | cargo run -- --bare` — returns usage hint, no LLM call
- [ ] `echo "/subagent spawn echo hi" | cargo run -- --bare` — returns output or "not available" (no ACP)
- [ ] Live `permission_denied` hook: `ZEPH_DENY_REASON` contains layer-provided reason, not generic string

Closes #3302
Closes #3310