### PR TITLE
docs(config): add commented hook examples for permission_denied and mcp_tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `McpDispatch` trait in `zeph-subagent` decouples hook execution from `zeph-mcp` — implementors are wired by `zeph-core` at call sites.
 - `/subagent spawn <command>` slash command is now intercepted in the core agent loop and works in CLI, piped, and bare modes — previously fell through to the LLM (#3302). Without ACP support, the command returns a clear "not available" message. `AcpSubagentSpawnFn` callback type bridges `zeph-core` ↔ `zeph-acp` without a direct crate dependency.
 - `LayerDenial` struct replaces the bare `BeforeToolResult` type alias: layers now carry an explicit `reason: String` that is propagated into the `ZEPH_DENY_REASON` hook env var (#3310). The previously hardcoded `"blocked by before_tool layer"` string is removed.
+- `config/default.toml` now includes commented examples for all lifecycle hook events: `[[hooks.cwd_changed]]`, `[[hooks.permission_denied]]`, and `[hooks.file_changed]`, covering both `type = "command"` and `type = "mcp_tool"` action variants (#3323).
 
 ### Changed
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -1141,3 +1141,70 @@ sweep_batch_size = 100
 # provider = ""
 # Maximum recent messages included for fresh-generation path (no cached digest)
 # max_input_messages = 20
+
+# ── Lifecycle hooks ────────────────────────────────────────────────────────────
+# Hooks fire at named lifecycle points. Each hook specifies an action (shell
+# command or MCP tool dispatch) plus timeout and fail_closed settings.
+#
+# action types:
+#   type = "command"  — run a shell command via sh -c
+#   type = "mcp_tool" — call an MCP server tool directly (no subprocess)
+#
+# Available events:
+#   [[hooks.cwd_changed]]      — agent's working directory changed
+#   [[hooks.permission_denied]] — a tool call was blocked by a RuntimeLayer check
+#   [hooks.file_changed]       — watched filesystem paths changed (see watch_paths)
+
+# ── hooks.cwd_changed ─────────────────────────────────────────────────────────
+# Fired each time the agent changes its working directory.
+# Env vars set for command hooks: ZEPH_NEW_CWD (new path), ZEPH_OLD_CWD (previous path).
+#
+# [[hooks.cwd_changed]]
+# type = "command"
+# command = "echo 'cwd changed to $ZEPH_NEW_CWD'"
+# timeout_secs = 10
+# fail_closed = false
+#
+# MCP tool dispatch variant — call a server tool instead of a subprocess:
+# [[hooks.cwd_changed]]
+# type = "mcp_tool"
+# server = "my-server"   # must match a name in [[mcp.servers]]
+# tool = "on_cwd_changed"
+# timeout_secs = 10
+# fail_closed = false
+
+# ── hooks.permission_denied ───────────────────────────────────────────────────
+# Fired when a tool call is blocked by a RuntimeLayer::before_tool check (#3303).
+# Env vars set for command hooks:
+#   ZEPH_DENIED_TOOL  — name of the blocked tool
+#   ZEPH_DENY_REASON  — human-readable reason string from the layer
+#
+# [[hooks.permission_denied]]
+# type = "command"
+# command = "echo 'denied: $ZEPH_DENIED_TOOL ($ZEPH_DENY_REASON)'"
+# timeout_secs = 5
+# fail_closed = false
+#
+# MCP tool dispatch variant — log denials to an audit server without a subprocess:
+# [[hooks.permission_denied]]
+# type = "mcp_tool"
+# server = "policy-server"  # must match a name in [[mcp.servers]]
+# tool = "audit_denied"
+# timeout_secs = 10
+# fail_closed = false
+# # Optional static arguments passed to the tool as JSON:
+# [hooks.permission_denied.args]
+# severity = "high"
+
+# ── hooks.file_changed ────────────────────────────────────────────────────────
+# Watches paths on disk and fires hooks when changes are detected.
+# Paths are resolved relative to the working directory at startup.
+#
+# [hooks.file_changed]
+# watch_paths = ["src/", "Cargo.toml"]
+# debounce_ms = 500   # default: 500
+# [[hooks.file_changed.hooks]]
+# type = "command"
+# command = "cargo check"
+# timeout_secs = 30
+# fail_closed = false


### PR DESCRIPTION
## Summary

- Adds a `[hooks]` section to `config/default.toml` with commented examples for all three lifecycle events: `cwd_changed`, `permission_denied`, and `file_changed`
- Covers both action types: `type = "command"` (shell) and `type = "mcp_tool"` (MCP dispatch)
- Documents environment variables available to command hooks (`ZEPH_DENIED_TOOL`, `ZEPH_DENY_REASON`, `ZEPH_NEW_CWD`, `ZEPH_OLD_CWD`)
- No code changes — documentation only

Closes #3323

## Test plan

- [x] \`cargo +nightly fmt --check\` — clean
- [x] \`cargo clippy --workspace --lib --bins -- -D warnings\` — clean
- [x] \`cargo nextest run -p zeph-config --lib\` — 297 tests pass