### PR TITLE
docs(specs): memory research — MemMachine, HeLa-Mem, ReasoningBank

### DIFF
--- a/specs/004-memory/004-10-memory-memmachine-retrieval.md
+++ b/specs/004-memory/004-10-memory-memmachine-retrieval.md
@@ -1,0 +1,155 @@
+---
+aliases:
+  - MemMachine
+  - Retrieval-Depth-First Memory
+tags:
+  - sdd
+  - spec
+  - memory
+  - retrieval
+  - research
+created: 2026-04-24
+status: draft
+related:
+  - "[[MOC-specs]]"
+  - "[[constitution]]"
+  - "[[004-memory/spec]]"
+  - "[[004-4-embeddings]]"
+  - "[[024-multi-model-design/spec]]"
+---
+
+# Spec: MemMachine — Retrieval-Depth-First Personalized Memory
+
+> Research analysis of MemMachine (arXiv:2604.04853). Resolves GitHub issues
+> [#3325](https://github.com/bug-ops/zeph/issues/3325).
+
+## Sources
+
+### External
+- **MemMachine: Ground-Truth-Preserving Personalized Memory** (arXiv:2604.04853)
+- Benchmark: LongMemEvalS (93% accuracy reported)
+
+### Internal
+| File | Contents |
+|---|---|
+| `crates/zeph-memory/src/semantic/` | SemanticMemory orchestrator, MMR reranking |
+| `crates/zeph-memory/src/retrieval.rs` | ANN search, candidate fetch |
+| `crates/zeph-memory/src/config.rs` | Memory config structs |
+| `crates/zeph-core/src/agent/context/` | ContextBuilder, memory injection |
+
+---
+
+## 1. Overview
+
+### Problem Statement
+
+Zeph's memory subsystem currently applies most optimization effort at **ingestion time** (summarization, chunking, graph extraction). MemMachine's empirical findings demonstrate that retrieval-stage improvements yield 11× higher accuracy gains than ingestion-stage improvements (9.5% vs 0.8% on LongMemEvalS), indicating a systematic under-investment in the retrieval path.
+
+### Key Research Findings
+
+| Optimization | Accuracy Gain |
+|---|---|
+| Retrieval depth tuning | +4.2% |
+| Context formatting | +2.0% |
+| Search prompt design | +1.8% |
+| Query bias correction | +1.4% |
+| Sentence chunking (ingestion) | +0.8% |
+
+**Conclusion**: retrieval-stage improvements dominate. Current Zeph architecture is inverted — it invests heavily in ingestion (summarization pipeline) while retrieval uses fixed depth and generic prompts.
+
+### Three-Layer Memory Model
+
+1. **Short-term** — in-context window (already implemented)
+2. **Long-term episodic** — full conversation episodes preserved verbatim alongside summaries
+3. **Profile memory** — distilled user model updated incrementally
+
+---
+
+## 2. Requirements
+
+### Functional
+
+| ID | Requirement |
+|---|---|
+| MM-F1 | `[memory.retrieval]` config section with `depth` field (number of ANN candidates fetched before MMR/reranking, default 20) |
+| MM-F2 | Configurable search prompt templates for memory queries (`search_prompt_template` field) |
+| MM-F3 | Query bias correction: detect first-person queries vs. topic queries and apply separate embedding adjustment coefficients |
+| MM-F4 | Episode preservation: store raw conversation episodes alongside existing summaries (non-destructive) |
+| MM-F5 | Context formatting: structured output format for injected memory snippets (timestamp, source type, relevance score) |
+
+### Non-Functional
+
+| ID | Requirement |
+|---|---|
+| MM-NF1 | Retrieval depth increase from 10→20 must not increase p95 retrieval latency by more than 30% |
+| MM-NF2 | Episode storage must not duplicate data already present in SQLite episode table |
+| MM-NF3 | Query bias correction must add < 2ms overhead per query |
+
+---
+
+## 3. Design
+
+### 3.1 Config Schema
+
+```toml
+[memory.retrieval]
+depth = 20                          # ANN candidates before MMR
+search_prompt_template = ""         # empty = built-in default
+query_bias_correction = true        # first-person vs topic detection
+context_format = "structured"       # "structured" | "plain"
+
+[memory.episodes]
+preserve_raw = true                 # store verbatim episodes alongside summaries
+```
+
+### 3.2 Query Bias Correction
+
+Classify query intent at retrieval time using a lightweight heuristic (regex + token prefix check, no LLM call):
+
+- **First-person query** (`I`, `me`, `my`, `we`): bias embedding toward profile memory vectors
+- **Topic query** (noun-phrase dominant): bias toward episodic store
+
+Implementation: weighted linear combination of raw query embedding and stored profile centroid.
+
+### 3.3 Retrieval Depth
+
+Current `SemanticMemory::search()` fetches a fixed number of candidates. Expose `retrieval_depth` as a runtime parameter resolved from config, replacing the hardcoded constant.
+
+### 3.4 Context Formatting
+
+Structured injection format:
+
+```
+[Memory | episodic | 2026-03-15 | relevance: 0.87]
+User mentioned preference for concise code responses and dislikes verbose explanations.
+```
+
+---
+
+## 4. Key Invariants
+
+- **NEVER** delete raw episodes once stored — append-only for episodes
+- **NEVER** apply query bias correction when `query_bias_correction = false` in config
+- Search prompt template substitution must be injection-safe (no LLM-controlled template execution)
+
+---
+
+## 5. Acceptance Criteria
+
+- [ ] `depth` config field respected; ANN fetch count matches configured value
+- [ ] Query bias correction active by default; measurable embedding shift for first-person queries vs topic queries
+- [ ] Raw episodes stored when `preserve_raw = true`; existing summarization pipeline unaffected
+- [ ] Structured context format renders correctly in CLI and TUI memory recall output
+- [ ] `cargo nextest run -p zeph-memory` passes with no regressions
+
+---
+
+## 6. Implementation Priority
+
+**P2 — Medium priority.** Retrieval depth and search prompt improvements are low-risk, high-return. Query bias correction and episode preservation are medium complexity. Recommend implementing in order: depth config → search prompt template → context formatting → query bias correction → episode preservation.
+
+---
+
+## 7. Related Issues
+
+- Closes #3325

--- a/specs/004-memory/004-11-memory-hela-mem.md
+++ b/specs/004-memory/004-11-memory-hela-mem.md
@@ -1,0 +1,181 @@
+---
+aliases:
+  - HeLa-Mem
+  - Hebbian Memory
+  - Episodic-Semantic Graph
+tags:
+  - sdd
+  - spec
+  - memory
+  - graph
+  - research
+created: 2026-04-24
+status: draft
+related:
+  - "[[MOC-specs]]"
+  - "[[constitution]]"
+  - "[[004-memory/spec]]"
+  - "[[004-6-graph-memory]]"
+  - "[[004-7-memory-apex-magma]]"
+  - "[[024-multi-model-design/spec]]"
+---
+
+# Spec: HeLa-Mem — Hebbian Learning Episodic-Semantic Memory
+
+> Research analysis of HeLa-Mem (arXiv:2604.16839). Resolves GitHub issue
+> [#3324](https://github.com/bug-ops/zeph/issues/3324).
+
+## Sources
+
+### External
+- **HeLa-Mem: Hebbian Learning and Associative Memory for LLM Agents** (arXiv:2604.16839)
+- Benchmark: LoCoMo (long-conversation memory)
+- Inspired by: Hebbian learning rule, spreading activation theory (cognitive neuroscience)
+
+### Internal
+| File | Contents |
+|---|---|
+| `crates/zeph-memory/src/graph/store.rs` | Edge CRUD, petgraph-backed graph |
+| `crates/zeph-memory/src/graph/types.rs` | `Edge`, `EdgeType`, weight fields |
+| `crates/zeph-memory/src/semantic/graph.rs` | SYNAPSE spreading activation |
+| `crates/zeph-memory/src/semantic/mod.rs` | SemanticMemory orchestrator |
+| `crates/zeph-skills/src/registry.rs` | Skill storage — target for Hebbian promotion |
+
+---
+
+## 1. Overview
+
+### Problem Statement
+
+Zeph's episodic memory graph stores edges with static weights — there is no mechanism for reinforcing edges that are repeatedly co-activated, nor for automatically promoting densely connected memory clusters to the skills/rules layer. This means frequently accessed knowledge remains in the same retrieval tier as rarely accessed knowledge, and valuable patterns must be manually extracted as skills.
+
+### Key Research Approach
+
+HeLa-Mem introduces three bio-inspired mechanisms:
+
+1. **Association** — when memory nodes are co-activated during retrieval, the edge between them is strengthened (Hebbian rule: "neurons that fire together wire together")
+2. **Consolidation** — a periodic pass identifies densely connected clusters (high edge weight × high degree) and promotes them into semantic knowledge (skills or persistent rules)
+3. **Spreading Activation** — retrieval propagates from the query anchor node through weighted edges, preferring highly reinforced paths over flat cosine ANN
+
+### Why This Matters for Zeph
+
+- Zeph already uses `petgraph` for the memory graph and has a SYNAPSE spreading activation module — this spec extends both
+- Current retrieval is cosine-ANN only; spreading activation would leverage the existing graph structure
+- Automatic promotion of hot clusters to skills reduces the dependency on manual `SKILL.md` authoring for recurring patterns
+
+---
+
+## 2. Requirements
+
+### Functional
+
+| ID | Requirement |
+|---|---|
+| HL-F1 | `Edge` struct gains a `weight: f32` field (default 1.0); stored in SQLite alongside existing temporal fields |
+| HL-F2 | On each memory retrieval: increment `weight` for all edges between co-activated node pairs by a configurable `hebbian_lr` (default 0.1) |
+| HL-F3 | Periodic consolidation task (configurable interval): identify nodes with `degree × avg_weight > consolidation_threshold`; emit consolidation candidates as structured events |
+| HL-F4 | Consolidation candidates are passed to a mid-tier LLM provider for strategy extraction and stored as `PersistentRule` entries (existing type) or new skill drafts |
+| HL-F5 | Spreading activation retrieval mode: optional alternative to cosine-ANN, propagates from top-1 ANN match through weighted edges up to `spread_depth` hops |
+| HL-F6 | Config section `[memory.hebbian]` controlling all parameters |
+
+### Non-Functional
+
+| ID | Requirement |
+|---|---|
+| HL-NF1 | Weight increment must be a single `UPDATE` statement per edge pair, batched at end of retrieval — no per-node round-trips |
+| HL-NF2 | Consolidation pass runs in background task; must not block the agent turn |
+| HL-NF3 | Spreading activation adds ≤ 10ms to retrieval p95 at graph size < 10k nodes |
+
+---
+
+## 3. Design
+
+### 3.1 Config Schema
+
+```toml
+[memory.hebbian]
+enabled = false                  # opt-in; false until validated
+hebbian_lr = 0.1                 # weight increment per co-activation
+consolidation_interval_secs = 3600
+consolidation_threshold = 5.0    # degree × avg_weight
+consolidate_provider = "fast"    # provider name for strategy distillation
+spreading_activation = false     # opt-in spreading activation retrieval
+spread_depth = 2                 # BFS hops from anchor node
+```
+
+### 3.2 Edge Weight Field
+
+Extend `Edge` in `graph/types.rs`:
+
+```rust
+pub struct Edge {
+    // existing fields ...
+    pub weight: f32,  // Hebbian reinforcement weight, default 1.0
+}
+```
+
+Migration: `ALTER TABLE graph_edges ADD COLUMN weight REAL NOT NULL DEFAULT 1.0`.
+
+### 3.3 Hebbian Update
+
+After retrieval returns a set of activated nodes `{n₁, n₂, ..., nₖ}`:
+
+```sql
+UPDATE graph_edges
+SET weight = weight + ?
+WHERE (source_id IN (?) AND target_id IN (?))
+   OR (target_id IN (?) AND source_id IN (?))
+```
+
+Batched single statement; `hebbian_lr` as the increment parameter.
+
+### 3.4 Consolidation Pass
+
+Periodic background task:
+
+1. Query: `SELECT node_id, degree, AVG(weight) FROM ... GROUP BY node_id HAVING degree * AVG(weight) > threshold`
+2. For each candidate cluster: collect neighboring node summaries → pass to `consolidate_provider` LLM
+3. LLM output: structured strategy summary → stored as `PersistentRule` or enqueued as skill draft
+4. Mark consolidated nodes with a `consolidated_at` timestamp to avoid re-consolidation within cooldown period
+
+### 3.5 Spreading Activation
+
+When `spreading_activation = true`:
+
+1. Fetch top-1 node via cosine ANN as anchor
+2. BFS from anchor up to `spread_depth` hops, scoring nodes by `weight × cosine_sim`
+3. Return ranked node set as retrieval result
+
+Falls back to pure ANN when graph has no edges from anchor node.
+
+---
+
+## 4. Key Invariants
+
+- **NEVER** enable Hebbian updates or consolidation without `[memory.hebbian] enabled = true` — both are opt-in
+- **NEVER** perform consolidation on the agent turn thread — must be background task only
+- Weight increments must be idempotent under retry (use `weight + delta`, not `weight = value`)
+- Consolidation must not delete source episodic nodes — promotion is additive
+
+---
+
+## 5. Acceptance Criteria
+
+- [ ] `graph_edges` table has `weight` column after migration; existing rows default to 1.0
+- [ ] Co-activated node pairs show incremented weights after retrieval when `hebbian.enabled = true`
+- [ ] Consolidation pass runs on background task, does not block turns
+- [ ] Spreading activation retrieval returns plausible results on a small synthetic graph (integration test)
+- [ ] All config fields respected; `enabled = false` disables all side effects
+- [ ] `cargo nextest run -p zeph-memory` passes
+
+---
+
+## 6. Implementation Priority
+
+**P3 — Research-grade, opt-in.** Both Hebbian update and consolidation are gated behind `enabled = false`. The `weight` field migration is the only mandatory schema change. Spreading activation is the highest-risk component and should be the last sub-feature implemented.
+
+---
+
+## 7. Related Issues
+
+- Closes #3324

--- a/specs/004-memory/004-12-memory-reasoning-bank.md
+++ b/specs/004-memory/004-12-memory-reasoning-bank.md
@@ -1,0 +1,204 @@
+---
+aliases:
+  - ReasoningBank
+  - Reasoning Memory
+  - Strategy Memory
+tags:
+  - sdd
+  - spec
+  - memory
+  - reasoning
+  - research
+created: 2026-04-24
+status: draft
+related:
+  - "[[MOC-specs]]"
+  - "[[constitution]]"
+  - "[[004-memory/spec]]"
+  - "[[024-multi-model-design/spec]]"
+  - "[[004-10-memory-memmachine-retrieval]]"
+---
+
+# Spec: ReasoningBank — Distilled Reasoning Strategy Memory
+
+> Research analysis of ReasoningBank (arXiv:2509.25140). Resolves GitHub issue
+> [#3312](https://github.com/bug-ops/zeph/issues/3312).
+
+## Sources
+
+### External
+- **ReasoningBank: Distilling Generalizable Reasoning Strategies from Agent Experience** (arXiv:2509.25140)
+- Benchmarks: WebArena (web browsing), SWE-bench (software engineering)
+- Related: MaTTS — Memory-Aware Test-Time Scaling for diverse experience generation
+
+### Internal
+| File | Contents |
+|---|---|
+| `crates/zeph-memory/src/` | Memory orchestrator, SQLite storage |
+| `crates/zeph-memory/src/semantic/` | Qdrant-backed semantic retrieval |
+| `crates/zeph-core/src/agent/context/` | ContextBuilder, memory injection |
+| `crates/zeph-skills/src/learning.rs` | Self-learning: `successful_patterns`, `failure_patterns` |
+| `crates/zeph-core/src/config.rs` | Agent config structs |
+
+---
+
+## 1. Overview
+
+### Problem Statement
+
+Zeph's SKILL.md self-learning captures coarse tool-usage patterns (`successful_patterns`, `failure_patterns`) but does not capture **why a reasoning approach worked or failed** at a finer granularity. Raw episodic memory stores trajectories verbatim — expensive to retrieve and hard to generalize. There is no structured middle layer between coarse skill patterns and raw episodes.
+
+### Key Research Findings
+
+ReasoningBank introduces a three-stage pipeline:
+
+1. **Self-judgment** — after each completed task, the agent evaluates success/failure using a fast model
+2. **Distillation** — successful and failed reasoning chains are compressed into short, generalizable strategy summaries (not raw trajectories)
+3. **Retrieval** — at query time, embedding search returns top-k strategy summaries, which are injected into the context preamble before the LLM call
+
+Contrastive signals from failures sharpen strategy boundaries. MaTTS extends this by allocating more compute per task to generate more diverse experience signals.
+
+**Empirical results**: outperforms raw trajectory storage and success-only memory banks on both WebArena and SWE-bench benchmarks.
+
+### Why This Complements Existing Zeph Memory
+
+| Layer | Granularity | Current Zeph |
+|---|---|---|
+| Skills (`SKILL.md`) | Tool invocation patterns | Implemented |
+| ReasoningBank | Reasoning strategy summaries | **Missing** |
+| Episodic memory | Raw conversation episodes | Implemented |
+| Semantic memory | Factual knowledge graph | Implemented |
+
+---
+
+## 2. Requirements
+
+### Functional
+
+| ID | Requirement |
+|---|---|
+| RB-F1 | `ReasoningMemory` store in `zeph-memory`: SQLite table for strategy summaries + Qdrant collection for strategy embeddings |
+| RB-F2 | Self-judge step (configurable `extract_provider`): after each completed agent turn, evaluate success/failure and extract reasoning chain |
+| RB-F3 | Distillation step (configurable `distill_provider`): compress reasoning chain into ≤ 3-sentence generalizable strategy summary |
+| RB-F4 | Retrieval: top-k (`top_k`, default 3) strategy summaries fetched by embedding similarity to current task description |
+| RB-F5 | Injection: retrieved strategies injected into `ContextBuilder` preamble before LLM call, with `[Reasoning Strategy]` prefix |
+| RB-F6 | `[memory.reasoning]` config section with `enabled`, `extract_provider`, `distill_provider`, `top_k`, `store_limit` |
+| RB-F7 | `store_limit` (default 1000): evict oldest strategies when limit reached (LRU by last-retrieval timestamp) |
+
+### Non-Functional
+
+| ID | Requirement |
+|---|---|
+| RB-NF1 | Self-judge + distillation run asynchronously after turn completion — must not add latency to the turn response |
+| RB-NF2 | Strategy retrieval adds ≤ 5ms to context build time |
+| RB-NF3 | Total injected strategy text ≤ 500 tokens (enforced by ContextBuilder token budget) |
+
+---
+
+## 3. Design
+
+### 3.1 Config Schema
+
+```toml
+[memory.reasoning]
+enabled = false                  # opt-in
+extract_provider = "fast"        # fast model for self-judgment
+distill_provider = "fast"        # mid-tier for distillation
+top_k = 3                        # strategies injected per turn
+store_limit = 1000               # max stored strategies (LRU eviction)
+```
+
+### 3.2 Data Model
+
+```sql
+CREATE TABLE reasoning_strategies (
+    id           TEXT PRIMARY KEY,   -- UUID v4
+    summary      TEXT NOT NULL,      -- distilled strategy (≤ 3 sentences)
+    outcome      TEXT NOT NULL,      -- "success" | "failure"
+    task_hint    TEXT NOT NULL,      -- short task description fingerprint
+    created_at   INTEGER NOT NULL,
+    last_used_at INTEGER NOT NULL,
+    use_count    INTEGER NOT NULL DEFAULT 0
+);
+```
+
+Qdrant collection `reasoning_strategies`: vector = embedding of `task_hint || summary`.
+
+### 3.3 Self-Judge Prompt (extract_provider)
+
+```
+Given the following agent turn transcript, determine:
+1. Did the agent successfully complete the user's request? (yes/no)
+2. Extract the key reasoning steps the agent took.
+3. Summarize the task in one sentence.
+
+Respond in JSON: {"success": bool, "reasoning_chain": str, "task_hint": str}
+```
+
+### 3.4 Distillation Prompt (distill_provider)
+
+```
+Given this reasoning chain from a {success/failure} attempt:
+{reasoning_chain}
+
+Distill a generalizable strategy (≤ 3 sentences) that could help an agent
+facing a similar task. Focus on the transferable principle, not the specific instance.
+```
+
+### 3.5 Context Injection
+
+`ContextBuilder` fetches strategies before assembling the prompt:
+
+```
+[Reasoning Strategy — success]
+When decomposing multi-file refactoring tasks, first map all call sites before
+making any edits. This prevents cascading failures from missed dependencies.
+
+[Reasoning Strategy — failure]
+Avoid calling external APIs without checking rate limits first. Implement
+exponential backoff before retry loops.
+```
+
+Token budget enforced by existing `ContextBudget` mechanism.
+
+### 3.6 Integration Points
+
+- `zeph-memory`: new `ReasoningMemory` struct, SQLite table, Qdrant collection
+- `zeph-core/agent/context`: `ContextBuilder` gains `with_reasoning_strategies()` method
+- `zeph-core/agent/loop`: post-turn hook calls `reasoning_memory.process_turn(transcript)`
+- Config: `[memory.reasoning]` parsed into `ReasoningConfig` in existing `MemoryConfig`
+- TUI: spinner `Distilling reasoning strategy…` during background distillation
+
+---
+
+## 4. Key Invariants
+
+- **NEVER** run self-judge or distillation on the agent turn thread — async background only
+- **NEVER** inject strategies that exceed the `ContextBudget` token allocation
+- Strategy extraction must be graceful-fail: if `extract_provider` returns malformed JSON, skip silently and log a warning
+- LRU eviction must not delete strategies with `use_count > 10` (high-value strategies are protected)
+
+---
+
+## 5. Acceptance Criteria
+
+- [ ] `reasoning_strategies` SQLite table created on first run when `enabled = true`
+- [ ] After a completed turn, self-judge runs asynchronously (log entry visible)
+- [ ] Strategy retrieved by embedding similarity for a related task description
+- [ ] Strategy injected into context preamble with `[Reasoning Strategy]` prefix
+- [ ] `store_limit` respected; oldest unused strategies evicted when limit reached
+- [ ] `enabled = false` produces zero side effects
+- [ ] TUI shows `Distilling reasoning strategy…` spinner during background distillation
+- [ ] `cargo nextest run -p zeph-memory` passes
+
+---
+
+## 6. Implementation Priority
+
+**P2 — Medium priority.** Core read/write path is 2 weeks estimated complexity. MaTTS scaling variant (more compute per task for diverse experiences) is a separate follow-up sprint. Recommend: SQLite table + distillation pipeline first, Qdrant retrieval second, context injection third.
+
+---
+
+## 7. Related Issues
+
+- Closes #3312

--- a/specs/README.md
+++ b/specs/README.md
@@ -64,6 +64,9 @@ Spec IDs (001–044) follow a logical grouping:
 | `004-memory/004-7-memory-apex-magma.md` | APEX-MEM append-only MAGMA: edge supersession, ontology normalization, SYNAPSE conflict resolution (#3223) | `zeph-memory` |
 | `004-memory/004-8-memory-typed-pages.md` | ClawVM typed page compaction: PageType classification, minimum-fidelity invariants, compaction audit log (#3221) | `zeph-context`, `zeph-memory` |
 | `004-memory/004-9-memory-write-gate.md` | MemReader write quality gate: three-signal scorer, rule-based MVP, optional LLM scoring (#3222) | `zeph-memory` |
+| `004-memory/004-10-memory-memmachine-retrieval.md` | MemMachine retrieval-depth-first memory: retrieval depth config, search prompt templates, query bias correction, episode preservation (#3325) | `zeph-memory` |
+| `004-memory/004-11-memory-hela-mem.md` | HeLa-Mem Hebbian learning: edge weight reinforcement, periodic consolidation, spreading activation retrieval (#3324) | `zeph-memory` |
+| `004-memory/004-12-memory-reasoning-bank.md` | ReasoningBank: self-judge + distillation pipeline, strategy embedding store, context preamble injection (#3312) | `zeph-memory`, `zeph-core` |
 | `005-skills/spec.md` | SKILL.md format, registry, matching, hot-reload, skill trust governance, two-stage matching, Wilson score confidence intervals, hub install pipeline, agent-invocable skills (`invoke_skill`) | `zeph-skills` |
 | `006-tools/spec.md` | ToolExecutor, CompositeExecutor, TAFC, schema filter, result cache, dependency graph, tool invocation phase taxonomy, native `tool_use` only; `invoke_skill`/`load_skill` utility-gate exemption | `zeph-tools` |
 | `007-channels/spec.md` | Channel trait, AnyChannel dispatch, streaming, channel feature parity | `zeph-channels` |


### PR DESCRIPTION
## Summary

- Adds spec `004-10` for MemMachine (arXiv:2604.04853): retrieval-depth-first memory with depth config, search prompt templates, query bias correction, episode preservation
- Adds spec `004-11` for HeLa-Mem (arXiv:2604.16839): Hebbian learning with edge weight reinforcement, periodic consolidation pass, optional spreading activation retrieval
- Adds spec `004-12` for ReasoningBank (arXiv:2509.25140): async self-judge + distillation pipeline, Qdrant strategy store, ContextBuilder preamble injection
- Updates `specs/README.md` index
- Adds `.local/testing/playbooks/memory-research.md` with priority matrix and test scenarios
- Adds 12 rows to `coverage-status.md` (all `Untested`)

## Closes

- Closes #3325
- Closes #3324
- Closes #3312

## Test plan

- [ ] Verify spec files render correctly in Obsidian (frontmatter + links)
- [ ] Verify `specs/README.md` entries are accurate
- [ ] No Rust source changes — `cargo nextest run` not required