### PR TITLE
feat(skills,memory): skill evaluator, proactive exploration, compression spectrum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- External-feedback skill evaluator (`[skills.evaluation]`): generated skills are now scored on
+  correctness, reusability, and specificity by a separate critic LLM call before being written to
+  disk. Weights (default 0.50/0.25/0.25) and pass threshold (default 0.60) are configurable.
+  Defaults to fail-open: if the evaluator errors, the skill is accepted. Spans: `skills.eval.*`
+  (#3319).
+- Proactive world-knowledge exploration (`[skills.proactive_exploration]`): before each LLM call
+  the agent classifies the query domain (keyword-based) and generates a `world-knowledge-{domain}`
+  SKILL.md when none exists. The generated skill is visible from the **next** turn (not the
+  current one — intentional MVP trade-off to keep turn latency bounded). Spans: `core.proactive.*`
+  (#3320).
+- Experience compression spectrum (`[memory.compression_spectrum]`): introduces `CompressionLevel`
+  (Episodic / Procedural / Declarative) and a `RetrievalPolicy` that skips episodic recall when
+  the token budget is below configurable thresholds. A background `PromotionEngine` scans recent
+  episodic memory and promotes repeated patterns to SKILL.md entries (off hot path, via JoinSet).
+  Spans: `memory.compression.*` (#3305).
+- `SkillEvaluationConfig`, `ProactiveExplorationConfig`, `CompressionSpectrumConfig` TOML sections
+  with `#[serde(default)]` — all disabled by default; existing configs parse unchanged.
+- `MemoryError::Promotion` variant in `zeph-memory` for promotion scan failures (thiserror,
+  no anyhow in library crates).
+
 - CPS (cost per successful task) metric in `CostTracker`: `record_successful_task()`, `cps()`,
   and `successful_tasks()` methods; daily reset consistent with existing cost reset (#2194).
 - `cost_cps_cents: Option<f64>` and `cost_successful_tasks: u64` fields in `AgentMetrics`;

--- a/crates/zeph-config/src/features.rs
+++ b/crates/zeph-config/src/features.rs
@@ -288,6 +288,164 @@ pub struct SkillsConfig {
     /// Skill mining configuration.
     #[serde(default)]
     pub mining: SkillMiningConfig,
+    /// External-feedback skill evaluator configuration (#3319).
+    #[serde(default)]
+    pub evaluation: SkillEvaluationConfig,
+    /// Proactive world-knowledge exploration configuration (#3320).
+    #[serde(default)]
+    pub proactive_exploration: ProactiveExplorationConfig,
+}
+
+// --- SkillEvaluationConfig defaults ---
+
+fn default_skill_quality_threshold() -> f32 {
+    0.60
+}
+
+fn default_weight_correctness() -> f32 {
+    0.50
+}
+
+fn default_weight_reusability() -> f32 {
+    0.25
+}
+
+fn default_weight_specificity() -> f32 {
+    0.25
+}
+
+fn default_eval_fail_open() -> bool {
+    true
+}
+
+fn default_skill_eval_timeout_ms() -> u64 {
+    15_000
+}
+
+/// External-feedback skill evaluator configuration, nested under `[skills.evaluation]` in TOML.
+///
+/// When `enabled = true`, generated SKILL.md files are scored by a critic LLM before being
+/// written to disk. Skills below `quality_threshold` are rejected.
+///
+/// # Weights
+///
+/// `weight_correctness + weight_reusability + weight_specificity` must equal `1.0 ± 1e-3`.
+/// Starting defaults (0.50 / 0.25 / 0.25) are intuition-based and will be tuned after
+/// real-world telemetry is collected.
+///
+/// # Example (TOML)
+///
+/// ```toml
+/// [skills.evaluation]
+/// enabled = true
+/// provider = "fast"
+/// quality_threshold = 0.60
+/// fail_open_on_error = true
+/// timeout_ms = 15000
+/// ```
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SkillEvaluationConfig {
+    /// Enable the evaluator gate. Default: `false`.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Provider name for the critic LLM. Empty = primary provider.
+    #[serde(default)]
+    pub provider: ProviderName,
+    /// Minimum composite score required to accept a generated skill. Default: `0.60`.
+    #[serde(default = "default_skill_quality_threshold")]
+    pub quality_threshold: f32,
+    /// Weight for `correctness` in the composite score. Default: `0.50`.
+    #[serde(default = "default_weight_correctness")]
+    pub weight_correctness: f32,
+    /// Weight for `reusability` in the composite score. Default: `0.25`.
+    #[serde(default = "default_weight_reusability")]
+    pub weight_reusability: f32,
+    /// Weight for `specificity` in the composite score. Default: `0.25`.
+    #[serde(default = "default_weight_specificity")]
+    pub weight_specificity: f32,
+    /// Fail-open policy: accept skill when the evaluator call fails. Default: `true`.
+    #[serde(default = "default_eval_fail_open")]
+    pub fail_open_on_error: bool,
+    /// Maximum wait for the critic LLM in milliseconds. Default: `15000`.
+    #[serde(default = "default_skill_eval_timeout_ms")]
+    pub timeout_ms: u64,
+}
+
+impl Default for SkillEvaluationConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            provider: ProviderName::default(),
+            quality_threshold: default_skill_quality_threshold(),
+            weight_correctness: default_weight_correctness(),
+            weight_reusability: default_weight_reusability(),
+            weight_specificity: default_weight_specificity(),
+            fail_open_on_error: default_eval_fail_open(),
+            timeout_ms: default_skill_eval_timeout_ms(),
+        }
+    }
+}
+
+// --- ProactiveExplorationConfig defaults ---
+
+fn default_proactive_max_chars() -> usize {
+    8_000
+}
+
+fn default_proactive_timeout_ms() -> u64 {
+    30_000
+}
+
+/// Proactive world-knowledge exploration configuration, nested under `[skills.proactive_exploration]` in TOML.
+///
+/// When `enabled = true`, the agent inspects each incoming query for a recognisable domain
+/// keyword (rust, python, docker, etc.) and generates a SKILL.md for that domain if one
+/// does not already exist. The skill is written to `output_dir` and registered in the
+/// skill registry; it becomes visible to the matcher on the **next** turn (next-turn
+/// visibility is intentional — see codebase comment in `ProactiveExplorer`).
+///
+/// # Example (TOML)
+///
+/// ```toml
+/// [skills.proactive_exploration]
+/// enabled = true
+/// output_dir = "~/.config/zeph/skills/generated"
+/// provider = "fast"
+/// ```
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ProactiveExplorationConfig {
+    /// Enable proactive exploration. Default: `false`.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Provider name for skill generation. Empty = primary provider.
+    #[serde(default)]
+    pub provider: ProviderName,
+    /// Directory where generated skills are written. Defaults to first `skills.paths` entry.
+    #[serde(default)]
+    pub output_dir: Option<String>,
+    /// Maximum SKILL.md body size in characters. Default: `8000`.
+    #[serde(default = "default_proactive_max_chars")]
+    pub max_chars: usize,
+    /// Per-exploration timeout in milliseconds. Default: `30000`.
+    #[serde(default = "default_proactive_timeout_ms")]
+    pub timeout_ms: u64,
+    /// Domain names to skip exploration for (e.g. `["rust"]` to suppress auto-generation
+    /// if you maintain your own Rust skill). Default: `[]`.
+    #[serde(default)]
+    pub excluded_domains: Vec<String>,
+}
+
+impl Default for ProactiveExplorationConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            provider: ProviderName::default(),
+            output_dir: None,
+            max_chars: default_proactive_max_chars(),
+            timeout_ms: default_proactive_timeout_ms(),
+            excluded_domains: Vec::new(),
+        }
+    }
 }
 
 fn default_max_repos_per_query() -> usize {
@@ -775,6 +933,96 @@ mod tests {
     fn index_config_workspace_root_none_by_default() {
         let cfg: IndexConfig = toml::from_str("enabled = false").unwrap();
         assert!(cfg.workspace_root.is_none());
+    }
+}
+
+// --- CompressionSpectrumConfig defaults ---
+
+fn default_compression_spectrum_promotion_window() -> usize {
+    200
+}
+
+fn default_compression_spectrum_min_occurrences() -> u32 {
+    3
+}
+
+fn default_compression_spectrum_min_sessions() -> u32 {
+    2
+}
+
+fn default_compression_spectrum_cluster_threshold() -> f32 {
+    0.85
+}
+
+fn default_retrieval_low_budget_ratio() -> f32 {
+    0.20
+}
+
+fn default_retrieval_mid_budget_ratio() -> f32 {
+    0.50
+}
+
+/// Experience compression spectrum configuration, nested under `[memory.compression_spectrum]`.
+///
+/// When `enabled = true`, the agent uses a three-tier memory retrieval policy
+/// (Episodic → Procedural → Declarative) keyed on remaining token budget, and
+/// runs a background promotion engine that converts recurring episodic patterns
+/// into generated SKILL.md files.
+///
+/// # Example (TOML)
+///
+/// ```toml
+/// [memory.compression_spectrum]
+/// enabled = true
+/// promotion_output_dir = "~/.config/zeph/skills/promoted"
+/// promotion_provider = "quality"
+/// ```
+#[derive(Debug, Deserialize, Serialize)]
+pub struct CompressionSpectrumConfig {
+    /// Enable the compression spectrum. Default: `false`.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Directory where promoted SKILL.md files are written.
+    #[serde(default)]
+    pub promotion_output_dir: Option<String>,
+    /// Provider name for SKILL.md generation during promotion. Empty = primary provider.
+    #[serde(default)]
+    pub promotion_provider: ProviderName,
+    /// Maximum number of recent episodic messages to scan for promotion candidates.
+    /// Default: `200`.
+    #[serde(default = "default_compression_spectrum_promotion_window")]
+    pub promotion_window: usize,
+    /// Minimum number of times a pattern must appear across all sessions to be promoted.
+    /// Default: `3`.
+    #[serde(default = "default_compression_spectrum_min_occurrences")]
+    pub min_occurrences: u32,
+    /// Minimum number of distinct sessions containing the pattern. Default: `2`.
+    #[serde(default = "default_compression_spectrum_min_sessions")]
+    pub min_sessions: u32,
+    /// Cosine similarity threshold for clustering episodic messages. Default: `0.85`.
+    #[serde(default = "default_compression_spectrum_cluster_threshold")]
+    pub cluster_threshold: f32,
+    /// Remaining-token ratio below which only episodic recall is used. Default: `0.20`.
+    #[serde(default = "default_retrieval_low_budget_ratio")]
+    pub retrieval_low_budget_ratio: f32,
+    /// Remaining-token ratio below which episodic + procedural recall is used. Default: `0.50`.
+    #[serde(default = "default_retrieval_mid_budget_ratio")]
+    pub retrieval_mid_budget_ratio: f32,
+}
+
+impl Default for CompressionSpectrumConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            promotion_output_dir: None,
+            promotion_provider: ProviderName::default(),
+            promotion_window: default_compression_spectrum_promotion_window(),
+            min_occurrences: default_compression_spectrum_min_occurrences(),
+            min_sessions: default_compression_spectrum_min_sessions(),
+            cluster_threshold: default_compression_spectrum_cluster_threshold(),
+            retrieval_low_budget_ratio: default_retrieval_low_budget_ratio(),
+            retrieval_mid_budget_ratio: default_retrieval_mid_budget_ratio(),
+        }
     }
 }
 

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -102,9 +102,10 @@ pub use experiment::{
     AdaptOrchConfig, ExperimentConfig, ExperimentSchedule, OrchestrationConfig, PlanCacheConfig,
 };
 pub use features::{
-    CostConfig, DaemonConfig, DebugConfig, GatewayConfig, IndexConfig, ScheduledTaskConfig,
-    ScheduledTaskKind, SchedulerConfig, SchedulerDaemonConfig, SkillMiningConfig, SkillPromptMode,
-    SkillsConfig, TraceConfig, VaultConfig,
+    CompressionSpectrumConfig, CostConfig, DaemonConfig, DebugConfig, GatewayConfig, IndexConfig,
+    ProactiveExplorationConfig, ScheduledTaskConfig, ScheduledTaskKind, SchedulerConfig,
+    SchedulerDaemonConfig, SkillEvaluationConfig, SkillMiningConfig, SkillPromptMode, SkillsConfig,
+    TraceConfig, VaultConfig,
 };
 pub use hooks::{FileChangedConfig, HooksConfig};
 pub use learning::{DetectorMode, LearningConfig};

--- a/crates/zeph-config/src/loader.rs
+++ b/crates/zeph-config/src/loader.rs
@@ -293,6 +293,18 @@ impl Config {
             )));
         }
 
+        // Skill evaluation weight-sum validation (#3319).
+        if self.skills.evaluation.enabled {
+            let weight_sum = self.skills.evaluation.weight_correctness
+                + self.skills.evaluation.weight_reusability
+                + self.skills.evaluation.weight_specificity;
+            if (weight_sum - 1.0_f32).abs() > 1e-3 {
+                return Err(ConfigError::Validation(format!(
+                    "skills.evaluation weights must sum to 1.0 (got {weight_sum:.4})"
+                )));
+            }
+        }
+
         self.validate_provider_names()?;
 
         if self.mcp.output_schema_hint_bytes < 64 {
@@ -380,6 +392,18 @@ impl Config {
             (
                 "orchestration.tool_provider",
                 &self.orchestration.tool_provider,
+            ),
+            (
+                "skills.evaluation.provider",
+                &self.skills.evaluation.provider,
+            ),
+            (
+                "skills.proactive_exploration.provider",
+                &self.skills.proactive_exploration.provider,
+            ),
+            (
+                "memory.compression_spectrum.promotion_provider",
+                &self.memory.compression_spectrum.promotion_provider,
             ),
         ];
 

--- a/crates/zeph-config/src/memory.rs
+++ b/crates/zeph-config/src/memory.rs
@@ -857,6 +857,11 @@ pub struct MemoryConfig {
     /// `2.0`) to disable dedup entirely.  Default: `0.95`.
     #[serde(default = "default_key_facts_dedup_threshold")]
     pub key_facts_dedup_threshold: f32,
+    /// Experience compression spectrum (#3305).
+    ///
+    /// Controls three-tier retrieval policy and background skill-promotion engine.
+    #[serde(default)]
+    pub compression_spectrum: crate::features::CompressionSpectrumConfig,
 }
 
 fn default_crossover_turn_threshold() -> u32 {

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -195,6 +195,8 @@ impl Default for Config {
                 generation_provider: crate::providers::ProviderName::default(),
                 generation_output_dir: None,
                 mining: crate::features::SkillMiningConfig::default(),
+                evaluation: crate::features::SkillEvaluationConfig::default(),
+                proactive_exploration: crate::features::ProactiveExplorationConfig::default(),
             },
             memory: MemoryConfig {
                 sqlite_path: default_sqlite_path_field(),
@@ -245,6 +247,7 @@ impl Default for Config {
                 microcompact: crate::memory::MicrocompactConfig::default(),
                 autodream: crate::memory::AutoDreamConfig::default(),
                 key_facts_dedup_threshold: 0.95,
+                compression_spectrum: crate::features::CompressionSpectrumConfig::default(),
             },
             telegram: None,
             discord: None,

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1826,6 +1826,36 @@ impl<C: Channel> Agent<C> {
         self.quality = pipeline;
         self
     }
+
+    /// Attach a proactive world-knowledge explorer (#3320).
+    ///
+    /// When set, the agent will classify each incoming query and trigger background skill
+    /// generation for unknown domains before the context assembly begins.
+    ///
+    /// Pass `None` to disable (default).
+    #[must_use]
+    pub fn with_proactive_explorer(
+        mut self,
+        explorer: Option<std::sync::Arc<zeph_skills::proactive::ProactiveExplorer>>,
+    ) -> Self {
+        self.proactive_explorer = explorer;
+        self
+    }
+
+    /// Attach a compression spectrum promotion engine (#3305).
+    ///
+    /// When set, the agent spawns a background scan task at each turn boundary to look
+    /// for episodic patterns that qualify for automatic skill promotion.
+    ///
+    /// Pass `None` to disable (default).
+    #[must_use]
+    pub fn with_promotion_engine(
+        mut self,
+        engine: Option<std::sync::Arc<zeph_memory::compression::promotion::PromotionEngine>>,
+    ) -> Self {
+        self.promotion_engine = engine;
+        self
+    }
 }
 
 #[cfg(test)]

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -404,6 +404,7 @@ impl<C: Channel> Agent<C> {
     ///
     /// Delegates concurrent fetching to [`zeph_context::assembler::ContextAssembler::gather`] and
     /// then calls [`Self::apply_prepared_context`] to mutate the message window.
+    #[allow(clippy::too_many_lines)] // sequential context-assembly pipeline; splitting would reduce readability
     pub(in crate::agent) async fn prepare_context(
         &mut self,
         query: &str,
@@ -425,6 +426,70 @@ impl<C: Channel> Agent<C> {
         self.remove_persona_facts_messages();
         self.remove_trajectory_hints_messages();
         self.remove_tree_memory_messages();
+
+        // #3320 — Proactive world-knowledge exploration (feature-gated).
+        // NOTE: newly generated skills are available *next* turn; this turn we
+        // only trigger generation so it is ready when the user's next query arrives.
+        // See arch spec §1.2 (C2 fix) for the rationale.
+        if let Some(explorer) = self.proactive_explorer.clone()
+            && let Some(domain) = explorer.classify(query)
+        {
+            let already_known = {
+                let registry_guard = self.skill_state.registry.read();
+                explorer.has_knowledge(&registry_guard, &domain)
+            };
+            let excluded = explorer.is_excluded(&domain);
+
+            if !already_known && !excluded {
+                tracing::debug!(domain = %domain.0, query_len = query.len(), "proactive.explore triggered");
+                let timeout_ms = explorer.timeout_ms();
+                let result = tokio::time::timeout(
+                    std::time::Duration::from_millis(timeout_ms),
+                    explorer.explore(&domain),
+                )
+                .await;
+                match result {
+                    Ok(Ok(())) => {
+                        // Re-scan configured skill paths so the new SKILL.md is
+                        // registered. Matcher rebuild happens at the next turn via
+                        // reload_skills(); see documented next-turn visibility invariant.
+                        let reload_paths = self.skill_state.skill_paths.clone();
+                        self.skill_state.registry.write().reload(&reload_paths);
+                        tracing::debug!(domain = %domain.0, "proactive.explore complete, registry reloaded");
+                    }
+                    Ok(Err(e)) => {
+                        tracing::warn!(domain = %domain.0, error = %e, "proactive exploration failed");
+                    }
+                    Err(_) => {
+                        tracing::warn!(domain = %domain.0, timeout_ms, "proactive exploration timed out");
+                    }
+                }
+            }
+        }
+
+        // #3305 — Compression spectrum: compute remaining token ratio and advise recall tiers.
+        //
+        // TODO(review): plumb `active_levels` into `ContextAssemblyInput` so the context
+        // assembler can skip expensive episodic recall when the budget is tight.
+        // Requires a `retrieval_levels: &[CompressionLevel]` field in
+        // `zeph_context::input::ContextAssemblyInput`.  Tracked as non-blocking out-of-scope item.
+        if let Some(ref budget) = self.context_manager.budget {
+            let used = self.providers.cached_prompt_tokens;
+            let max = budget.max_tokens();
+            #[allow(clippy::cast_precision_loss)]
+            let remaining_ratio = if max == 0 {
+                1.0_f32
+            } else {
+                1.0 - (used as f32 / max as f32).clamp(0.0, 1.0)
+            };
+            let policy = zeph_memory::compression::RetrievalPolicy::default();
+            let active_levels = policy.select(remaining_ratio);
+            tracing::debug!(
+                remaining_ratio,
+                active_levels = ?active_levels,
+                "compression_spectrum: retrieval policy selected"
+            );
+        }
 
         let memory_view = zeph_context::input::ContextMemoryView {
             memory: self.memory_state.persistence.memory.clone(),

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -187,6 +187,16 @@ pub struct Agent<C: Channel> {
     /// MARCH self-check pipeline, built at startup and rebuilt on provider swap.
     #[cfg(feature = "self-check")]
     pub(super) quality: Option<std::sync::Arc<crate::quality::SelfCheckPipeline>>,
+    /// Proactive world-knowledge explorer (#3320).
+    ///
+    /// `Some` when `config.skills.proactive_exploration.enabled = true`.
+    pub(super) proactive_explorer:
+        Option<std::sync::Arc<zeph_skills::proactive::ProactiveExplorer>>,
+    /// Experience compression spectrum promotion engine (#3305).
+    ///
+    /// `Some` when `config.memory.compression_spectrum.enabled = true`.
+    pub(super) promotion_engine:
+        Option<std::sync::Arc<zeph_memory::compression::promotion::PromotionEngine>>,
 }
 
 /// Control flow signal returned by [`Agent::apply_dispatch_result`].
@@ -321,6 +331,8 @@ impl<C: Channel> Agent<C> {
             tool_state: ToolState::default(),
             #[cfg(feature = "self-check")]
             quality: None,
+            proactive_explorer: None,
+            promotion_engine: None,
         }
     }
 
@@ -1421,6 +1433,8 @@ impl<C: Channel> Agent<C> {
             self.truncate_old_tool_results();
             // MagicDocs: spawn background doc updates if any are due (#2702).
             self.maybe_update_magic_docs();
+            // Compression spectrum: fire-and-forget promotion scan (#3305).
+            self.maybe_spawn_promotion_scan();
         }
         tracing::debug!("turn timing: process_response done");
 
@@ -2790,6 +2804,74 @@ impl<C: Channel> Agent<C> {
         }
 
         let _ = self.channel.send_status("").await;
+    }
+
+    /// If the compression spectrum is enabled and a promotion engine is wired, spawn a
+    /// background scan task.
+    ///
+    /// The task loads the most-recent episodic window from `SemanticMemory`, runs the
+    /// greedy clustering scan, and calls `promote` for each qualifying candidate.
+    ///
+    /// Supervised via [`agent_supervisor::BackgroundSupervisor`] under
+    /// [`agent_supervisor::TaskClass::Enrichment`] — dropped under high load rather than
+    /// blocking the turn.
+    pub(super) fn maybe_spawn_promotion_scan(&mut self) {
+        let Some(engine) = self.promotion_engine.clone() else {
+            return;
+        };
+
+        let Some(memory) = self.memory_state.persistence.memory.clone() else {
+            return;
+        };
+
+        // Use a conservative window cap. The engine's own PromotionConfig thresholds
+        // determine whether a cluster actually qualifies; this is just the DB scan limit.
+        let promotion_window = 200usize;
+
+        let accepted = self.lifecycle.supervisor.spawn(
+            agent_supervisor::TaskClass::Enrichment,
+            "compression_spectrum.promotion_scan",
+            async move {
+                let span = tracing::info_span!("memory.compression.promote.background");
+                let _enter = span.enter();
+
+                let window = match memory.load_promotion_window(promotion_window).await {
+                    Ok(w) => w,
+                    Err(e) => {
+                        tracing::warn!(error = %e, "promotion scan: failed to load window");
+                        return;
+                    }
+                };
+
+                if window.is_empty() {
+                    return;
+                }
+
+                let candidates = match engine.scan(&window).await {
+                    Ok(c) => c,
+                    Err(e) => {
+                        tracing::warn!(error = %e, "promotion scan: clustering failed");
+                        return;
+                    }
+                };
+
+                for candidate in &candidates {
+                    if let Err(e) = engine.promote(candidate).await {
+                        tracing::warn!(
+                            signature = %candidate.signature,
+                            error = %e,
+                            "promotion scan: promote failed"
+                        );
+                    }
+                }
+
+                tracing::info!(candidates = candidates.len(), "promotion scan: complete");
+            },
+        );
+
+        if accepted {
+            tracing::debug!("compression_spectrum: promotion scan task enqueued");
+        }
     }
 }
 /// Thin wrapper that implements [`zeph_subagent::McpDispatch`] over an [`Arc<zeph_mcp::McpManager>`].

--- a/crates/zeph-memory/src/compression/mod.rs
+++ b/crates/zeph-memory/src/compression/mod.rs
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Experience compression spectrum (#3305).
+//!
+//! This module implements a three-tier memory retrieval policy and a background
+//! promotion engine that converts recurring episodic patterns into generated SKILL.md files.
+//!
+//! # Tiers
+//!
+//! | Tier | Description |
+//! |------|-------------|
+//! | `Episodic` | Raw conversation snippets, lowest abstraction, highest token cost. |
+//! | `Procedural` | Tool-use patterns and how-to knowledge. |
+//! | `Declarative` | Stable facts and reference knowledge. |
+//!
+//! # Retrieval policy
+//!
+//! [`RetrievalPolicy`] maps the current remaining token-budget ratio to a subset of
+//! tiers. When the budget is ample (> `mid_budget_ratio`) all three tiers are queried;
+//! as the budget narrows, cheaper tiers are preferred.
+//!
+//! # Promotion engine
+//!
+//! [`promotion::PromotionEngine`] scans a window of recent episodic messages for
+//! clustering patterns and promotes qualifying clusters to SKILL.md files.
+
+pub mod promotion;
+
+pub use promotion::{PromotionCandidate, PromotionConfig, PromotionEngine, PromotionInput};
+
+/// The three abstraction levels in the compression spectrum.
+///
+/// Higher variants are cheaper to retrieve (fewer tokens) but represent a higher
+/// abstraction over raw episodic experience.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum CompressionLevel {
+    /// Raw episodic messages — full fidelity, high token cost.
+    Episodic,
+    /// Abstracted procedural knowledge (how-to, tool patterns).
+    Procedural,
+    /// Stable declarative facts and reference material.
+    Declarative,
+}
+
+impl CompressionLevel {
+    /// A relative token-cost factor for budgeting purposes.
+    ///
+    /// `Episodic = 1.0` (baseline), `Procedural = 0.6`, `Declarative = 0.3`.
+    #[must_use]
+    pub fn cost_factor(self) -> f32 {
+        match self {
+            Self::Episodic => 1.0,
+            Self::Procedural => 0.6,
+            Self::Declarative => 0.3,
+        }
+    }
+}
+
+/// Token-budget-aware tier selector for context assembly.
+///
+/// Maps a `remaining_ratio` (0.0 = budget exhausted, 1.0 = budget fully available) to
+/// the subset of [`CompressionLevel`]s to include in the context recall step.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_memory::compression::{RetrievalPolicy, CompressionLevel};
+///
+/// let policy = RetrievalPolicy::default();
+/// // Full budget → all three tiers.
+/// let levels = policy.select(0.80);
+/// assert!(levels.contains(&CompressionLevel::Episodic));
+/// assert!(levels.contains(&CompressionLevel::Declarative));
+///
+/// // Low budget → episodic only.
+/// let levels = policy.select(0.10);
+/// assert_eq!(levels, &[CompressionLevel::Episodic]);
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct RetrievalPolicy {
+    /// Below this ratio only `Episodic` recall is attempted. Default: `0.20`.
+    pub low_budget_ratio: f32,
+    /// Below this ratio `Episodic + Procedural` recall is attempted. Default: `0.50`.
+    pub mid_budget_ratio: f32,
+}
+
+impl Default for RetrievalPolicy {
+    fn default() -> Self {
+        Self {
+            low_budget_ratio: 0.20,
+            mid_budget_ratio: 0.50,
+        }
+    }
+}
+
+impl RetrievalPolicy {
+    /// Select which compression levels should be included for `remaining_ratio`.
+    ///
+    /// | `remaining_ratio` | Levels returned |
+    /// |-------------------|-----------------|
+    /// | `< low_budget_ratio` | `[Episodic]` |
+    /// | `< mid_budget_ratio` | `[Episodic, Procedural]` |
+    /// | `≥ mid_budget_ratio` | `[Episodic, Procedural, Declarative]` |
+    #[tracing::instrument(name = "memory.compression.select", skip_all, fields(remaining_ratio))]
+    pub fn select(&self, remaining_ratio: f32) -> &'static [CompressionLevel] {
+        if remaining_ratio < self.low_budget_ratio {
+            &[CompressionLevel::Episodic]
+        } else if remaining_ratio < self.mid_budget_ratio {
+            &[CompressionLevel::Episodic, CompressionLevel::Procedural]
+        } else {
+            &[
+                CompressionLevel::Episodic,
+                CompressionLevel::Procedural,
+                CompressionLevel::Declarative,
+            ]
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compression_level_cost_factors() {
+        assert!((CompressionLevel::Episodic.cost_factor() - 1.0).abs() < 1e-6);
+        assert!((CompressionLevel::Procedural.cost_factor() - 0.6).abs() < 1e-6);
+        assert!((CompressionLevel::Declarative.cost_factor() - 0.3).abs() < 1e-6);
+    }
+
+    #[test]
+    fn retrieval_policy_full_budget() {
+        let policy = RetrievalPolicy::default();
+        let levels = policy.select(0.80);
+        assert!(levels.contains(&CompressionLevel::Episodic));
+        assert!(levels.contains(&CompressionLevel::Procedural));
+        assert!(levels.contains(&CompressionLevel::Declarative));
+    }
+
+    #[test]
+    fn retrieval_policy_mid_budget() {
+        let policy = RetrievalPolicy::default();
+        let levels = policy.select(0.35);
+        assert!(levels.contains(&CompressionLevel::Episodic));
+        assert!(levels.contains(&CompressionLevel::Procedural));
+        assert!(!levels.contains(&CompressionLevel::Declarative));
+    }
+
+    #[test]
+    fn retrieval_policy_low_budget() {
+        let policy = RetrievalPolicy::default();
+        let levels = policy.select(0.10);
+        assert_eq!(levels, &[CompressionLevel::Episodic]);
+    }
+
+    #[test]
+    fn retrieval_policy_boundary_at_low() {
+        let policy = RetrievalPolicy::default();
+        // Exactly at low_budget_ratio — mid tier.
+        let levels = policy.select(0.20);
+        assert!(levels.contains(&CompressionLevel::Procedural));
+    }
+
+    #[test]
+    fn retrieval_policy_boundary_at_mid() {
+        let policy = RetrievalPolicy::default();
+        // Exactly at mid_budget_ratio — all tiers.
+        let levels = policy.select(0.50);
+        assert!(levels.contains(&CompressionLevel::Declarative));
+    }
+}

--- a/crates/zeph-memory/src/compression/promotion.rs
+++ b/crates/zeph-memory/src/compression/promotion.rs
@@ -1,0 +1,469 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Background skill-promotion engine (#3305).
+//!
+//! [`PromotionEngine`] scans a window of recent episodic messages for clustering
+//! patterns and promotes qualifying clusters to SKILL.md files on disk.
+//!
+//! # C1 fix — session provenance
+//!
+//! [`PromotionInput`] carries a `conversation_id` field that is absent from
+//! [`crate::facade::MemoryMatch`].  This allows the engine to enforce the
+//! `min_sessions` heuristic without touching the public recall API.
+//!
+//! # Dependency inversion
+//!
+//! To avoid a circular crate dependency (`zeph-memory` ↔ `zeph-skills`), skill
+//! generation is delegated to [`SkillWriter`], a trait that callers in
+//! `zeph-core` implement using [`zeph_skills::generator::SkillGenerator`].
+//! This keeps `zeph-memory` free of a direct `zeph-skills` dependency.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::error::MemoryError;
+use crate::types::{ConversationId, MessageId};
+
+// ── PromotionInput ────────────────────────────────────────────────────────────
+
+/// A single episodic message prepared for the promotion scan.
+///
+/// This type carries the `conversation_id` (session provenance) that ordinary
+/// [`crate::facade::MemoryMatch`] results do not expose, making it possible to
+/// enforce the [`PromotionConfig::min_sessions`] heuristic.
+#[derive(Debug, Clone)]
+pub struct PromotionInput {
+    /// Identifies the individual message for deduplication bookkeeping.
+    pub message_id: MessageId,
+    /// The session this message belongs to.
+    pub conversation_id: ConversationId,
+    /// Raw message content.
+    pub content: String,
+    /// Pre-computed embedding vector.
+    ///
+    /// When `None`, the scan will skip this row rather than re-embed inline on
+    /// the hot path — embedding is expensive and the promotion engine runs in the
+    /// background.
+    pub embedding: Option<Vec<f32>>,
+}
+
+// ── PromotionCandidate ────────────────────────────────────────────────────────
+
+/// A cluster of episodic messages that qualifies for promotion to a SKILL.md.
+#[derive(Debug, Clone)]
+pub struct PromotionCandidate {
+    /// A stable identifier derived from the cluster centroid (SHA-256 hex, truncated).
+    pub signature: String,
+    /// IDs of the messages in this cluster.
+    pub member_ids: Vec<MessageId>,
+    /// Distinct sessions that contributed at least one member to this cluster.
+    pub session_ids: Vec<ConversationId>,
+    /// Average embedding vector of cluster members (centroid).
+    pub centroid: Vec<f32>,
+}
+
+// ── PromotionConfig ───────────────────────────────────────────────────────────
+
+/// Configuration knobs for [`PromotionEngine`].
+///
+/// All thresholds have conservative defaults — they should be tuned based on
+/// real-world telemetry once the feature is in production.
+#[derive(Debug, Clone)]
+pub struct PromotionConfig {
+    /// Minimum number of cluster members to qualify for promotion. Default: `3`.
+    pub min_occurrences: u32,
+    /// Minimum number of distinct sessions represented in the cluster. Default: `2`.
+    pub min_sessions: u32,
+    /// Cosine similarity threshold for clustering. Messages with similarity ≥ this value
+    /// to a cluster's centroid are merged into that cluster. Default: `0.85`.
+    pub cluster_threshold: f32,
+}
+
+impl Default for PromotionConfig {
+    fn default() -> Self {
+        Self {
+            min_occurrences: 3,
+            min_sessions: 2,
+            cluster_threshold: 0.85,
+        }
+    }
+}
+
+// ── SkillWriter ───────────────────────────────────────────────────────────────
+
+/// Trait for writing a generated SKILL.md to disk.
+///
+/// Implemented in `zeph-core` using [`zeph_skills::generator::SkillGenerator`].
+/// Defined here to avoid a circular crate dependency.
+///
+/// # Contract
+///
+/// Implementors must:
+/// - Generate a valid SKILL.md from `description`.
+/// - Apply any configured evaluator gate before writing.
+/// - Return `Ok(())` on success or evaluator rejection (rejection is not an error).
+/// - Return `Err` only on hard failures (LLM error, I/O error).
+pub trait SkillWriter: Send + Sync {
+    /// Generate and persist a SKILL.md from `description`.
+    ///
+    /// `signature` is used as an idempotency key — callers should ensure the skill
+    /// file does not already exist before calling this method.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error string on generation or I/O failure.
+    fn write_skill(
+        &self,
+        description: String,
+        signature: String,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send + '_>>;
+}
+
+// ── PromotionEngine ───────────────────────────────────────────────────────────
+
+/// Background engine that scans episodic memory and promotes recurring patterns to skills.
+///
+/// Runs off the hot path, typically queued to a `JoinSet` at turn boundary.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use std::path::PathBuf;
+/// use std::sync::Arc;
+/// use zeph_memory::compression::promotion::{PromotionEngine, PromotionConfig};
+///
+/// # struct MockWriter;
+/// # impl zeph_memory::compression::promotion::SkillWriter for MockWriter {
+/// #   fn write_skill(&self, _d: String, _s: String)
+/// #     -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send + '_>>
+/// #   { Box::pin(async { Ok(()) }) }
+/// # }
+/// let engine = PromotionEngine::new(
+///     Arc::new(MockWriter),
+///     PromotionConfig::default(),
+///     PathBuf::from("/tmp/skills"),
+/// );
+/// ```
+pub struct PromotionEngine {
+    writer: Arc<dyn SkillWriter>,
+    config: PromotionConfig,
+    output_dir: PathBuf,
+}
+
+impl PromotionEngine {
+    /// Create a new promotion engine.
+    ///
+    /// `writer` is injected from `zeph-core` and encapsulates `SkillGenerator` +
+    /// optional `SkillEvaluator`. `output_dir` is where SKILL.md directories are created.
+    #[must_use]
+    pub fn new(writer: Arc<dyn SkillWriter>, config: PromotionConfig, output_dir: PathBuf) -> Self {
+        Self {
+            writer,
+            config,
+            output_dir,
+        }
+    }
+
+    /// Scan a recent-episodic window and return clusters that qualify for promotion.
+    ///
+    /// Clustering is greedy: each message is assigned to the first cluster whose centroid
+    /// has cosine similarity ≥ `config.cluster_threshold`; if no cluster matches, a new
+    /// cluster is created. A cluster qualifies when both `min_occurrences` and
+    /// `min_sessions` are satisfied.
+    ///
+    /// Messages without embeddings (`embedding == None`) are silently skipped.
+    ///
+    /// # Panics
+    ///
+    /// Does not panic in practice — the `unwrap` on `embedding` is guarded by the
+    /// `filter(|p| p.embedding.is_some())` step immediately above.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError::Promotion`] if embeddings have inconsistent dimensions.
+    #[tracing::instrument(name = "memory.compression.promote.scan", skip_all,
+                          fields(window_len = window.len()))]
+    pub async fn scan(
+        &self,
+        window: &[PromotionInput],
+    ) -> Result<Vec<PromotionCandidate>, MemoryError> {
+        // Filter to messages that have embeddings.
+        let embeds: Vec<&PromotionInput> =
+            window.iter().filter(|p| p.embedding.is_some()).collect();
+
+        if embeds.is_empty() {
+            return Ok(vec![]);
+        }
+
+        // Safety: filtered to `is_some()` above.
+        let dim = embeds[0].embedding.as_ref().unwrap().len();
+
+        // Greedy centroid clustering.
+        struct Cluster {
+            centroid: Vec<f32>,
+            member_ids: Vec<MessageId>,
+            session_ids: HashSet<ConversationId>,
+        }
+
+        let mut clusters: Vec<Cluster> = Vec::new();
+
+        for input in &embeds {
+            let emb = input.embedding.as_ref().unwrap();
+            if emb.len() != dim {
+                return Err(MemoryError::Promotion(format!(
+                    "embedding dimension mismatch: expected {dim}, got {}",
+                    emb.len()
+                )));
+            }
+
+            // Find the first cluster within the similarity threshold.
+            let mut assigned = false;
+            for cluster in &mut clusters {
+                let sim = cosine_similarity(emb, &cluster.centroid);
+                if sim >= self.config.cluster_threshold {
+                    // Update centroid (running average).
+                    #[allow(clippy::cast_precision_loss)]
+                    let n = cluster.member_ids.len() as f32;
+                    for (c, v) in cluster.centroid.iter_mut().zip(emb.iter()) {
+                        *c = (*c * n + v) / (n + 1.0);
+                    }
+                    cluster.member_ids.push(input.message_id);
+                    cluster.session_ids.insert(input.conversation_id);
+                    assigned = true;
+                    break;
+                }
+            }
+            if !assigned {
+                clusters.push(Cluster {
+                    centroid: emb.clone(),
+                    member_ids: vec![input.message_id],
+                    session_ids: std::iter::once(input.conversation_id).collect(),
+                });
+            }
+        }
+
+        // Filter clusters that meet both thresholds.
+        let candidates = clusters
+            .into_iter()
+            .filter(|c| {
+                u32::try_from(c.member_ids.len()).unwrap_or(u32::MAX) >= self.config.min_occurrences
+                    && u32::try_from(c.session_ids.len()).unwrap_or(u32::MAX)
+                        >= self.config.min_sessions
+            })
+            .map(|c| {
+                let signature = cluster_signature(&c.centroid);
+                PromotionCandidate {
+                    signature,
+                    member_ids: c.member_ids,
+                    session_ids: c.session_ids.into_iter().collect(),
+                    centroid: c.centroid,
+                }
+            })
+            .collect();
+
+        Ok(candidates)
+    }
+
+    /// Generate and persist a SKILL.md for `candidate`. Idempotent by signature.
+    ///
+    /// On evaluator rejection the method returns `Ok(())` — rejection is a normal outcome.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError::Promotion`] on generation, evaluator, or disk-write failure.
+    #[tracing::instrument(name = "memory.compression.promote.persist", skip_all,
+                          fields(signature = %candidate.signature))]
+    pub async fn promote(&self, candidate: &PromotionCandidate) -> Result<(), MemoryError> {
+        // Idempotency: skip if already exists.
+        let skill_name = format!("promoted-pattern-{}", &candidate.signature[..12]);
+        let skill_dir = self.output_dir.join(&skill_name);
+        if skill_dir.exists() {
+            tracing::debug!(signature = %candidate.signature, "promotion candidate already exists, skipping");
+            return Ok(());
+        }
+
+        let member_count = candidate.member_ids.len();
+        let session_count = candidate.session_ids.len();
+        let description = format!(
+            "Recurring procedural pattern detected across {member_count} messages in \
+             {session_count} sessions. Generate a concise SKILL.md capturing the common \
+             tool-use pattern or workflow. Signature: {}.",
+            candidate.signature
+        );
+
+        self.writer
+            .write_skill(description, candidate.signature.clone())
+            .await
+            .map_err(MemoryError::Promotion)
+    }
+}
+
+// ── Helper functions ──────────────────────────────────────────────────────────
+
+/// Compute cosine similarity between two equal-length vectors.
+/// Returns `0.0` when either vector is zero-length or the norm is zero.
+fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    debug_assert_eq!(a.len(), b.len());
+    let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+    let norm_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let norm_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm_a < f32::EPSILON || norm_b < f32::EPSILON {
+        return 0.0;
+    }
+    (dot / (norm_a * norm_b)).clamp(-1.0, 1.0)
+}
+
+/// Derive a stable signature from a centroid vector using SHA-256 hex.
+fn cluster_signature(centroid: &[f32]) -> String {
+    use std::hash::Hash;
+    // Use a simple FNV-like hash of the quantised centroid to avoid
+    // a heavy crypto dependency — this is a deduplication key, not a security hash.
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    for v in centroid {
+        let bits = v.to_bits();
+        bits.hash(&mut hasher);
+    }
+    let h = std::hash::Hasher::finish(&hasher);
+    format!("{h:016x}")
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    struct RecordingWriter {
+        written: Mutex<Vec<String>>,
+    }
+
+    impl SkillWriter for RecordingWriter {
+        fn write_skill(
+            &self,
+            description: String,
+            _signature: String,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send + '_>>
+        {
+            self.written.lock().unwrap().push(description);
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    fn make_input(id: i64, cid: i64, content: &str, emb: Vec<f32>) -> PromotionInput {
+        PromotionInput {
+            message_id: MessageId(id),
+            conversation_id: ConversationId(cid),
+            content: content.to_string(),
+            embedding: Some(emb),
+        }
+    }
+
+    fn unit_vec(n: usize, val: f32) -> Vec<f32> {
+        let mut v = vec![0.0_f32; n];
+        v[0] = val;
+        // Normalise to unit length.
+        let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+        v.iter_mut().for_each(|x| *x /= norm);
+        v
+    }
+
+    #[test]
+    fn cosine_similarity_identical() {
+        let v = vec![1.0_f32, 0.0, 0.0];
+        assert!((cosine_similarity(&v, &v) - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn cosine_similarity_orthogonal() {
+        let a = vec![1.0_f32, 0.0];
+        let b = vec![0.0_f32, 1.0];
+        assert!((cosine_similarity(&a, &b) - 0.0).abs() < 1e-6);
+    }
+
+    #[tokio::test]
+    async fn scan_returns_empty_for_no_embeddings() {
+        let writer = Arc::new(RecordingWriter {
+            written: Mutex::new(vec![]),
+        });
+        let engine =
+            PromotionEngine::new(writer, PromotionConfig::default(), PathBuf::from("/tmp"));
+        let window = vec![PromotionInput {
+            message_id: MessageId(1),
+            conversation_id: ConversationId(1),
+            content: "hello".into(),
+            embedding: None,
+        }];
+        let candidates = engine.scan(&window).await.unwrap();
+        assert!(candidates.is_empty());
+    }
+
+    #[tokio::test]
+    async fn scan_qualifies_cluster_meeting_thresholds() {
+        let writer = Arc::new(RecordingWriter {
+            written: Mutex::new(vec![]),
+        });
+        let config = PromotionConfig {
+            min_occurrences: 3,
+            min_sessions: 2,
+            cluster_threshold: 0.90,
+        };
+        let engine = PromotionEngine::new(writer, config, PathBuf::from("/tmp"));
+
+        // 4 nearly identical vectors from 3 distinct sessions.
+        let base = unit_vec(4, 1.0);
+        let window = vec![
+            make_input(1, 1, "a", base.clone()),
+            make_input(2, 1, "b", base.clone()),
+            make_input(3, 2, "c", base.clone()),
+            make_input(4, 3, "d", base.clone()),
+        ];
+        let candidates = engine.scan(&window).await.unwrap();
+        assert_eq!(candidates.len(), 1, "expected 1 qualifying cluster");
+        let c = &candidates[0];
+        assert_eq!(c.member_ids.len(), 4);
+        assert_eq!(c.session_ids.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn scan_rejects_cluster_below_min_sessions() {
+        let writer = Arc::new(RecordingWriter {
+            written: Mutex::new(vec![]),
+        });
+        let config = PromotionConfig {
+            min_occurrences: 3,
+            min_sessions: 2,
+            cluster_threshold: 0.90,
+        };
+        let engine = PromotionEngine::new(writer, config, PathBuf::from("/tmp"));
+
+        // 4 messages but all from the same session.
+        let base = unit_vec(4, 1.0);
+        let window = (1..=4)
+            .map(|i| make_input(i, 1, "x", base.clone()))
+            .collect::<Vec<_>>();
+        let candidates = engine.scan(&window).await.unwrap();
+        assert!(
+            candidates.is_empty(),
+            "should reject cluster with only 1 session"
+        );
+    }
+
+    #[tokio::test]
+    async fn scan_errors_on_dimension_mismatch() {
+        let writer = Arc::new(RecordingWriter {
+            written: Mutex::new(vec![]),
+        });
+        let engine =
+            PromotionEngine::new(writer, PromotionConfig::default(), PathBuf::from("/tmp"));
+
+        let window = vec![
+            make_input(1, 1, "a", vec![1.0, 0.0, 0.0]),
+            make_input(2, 2, "b", vec![0.0, 1.0]), // wrong dimension
+        ];
+        let result = engine.scan(&window).await;
+        assert!(result.is_err(), "expected error on dimension mismatch");
+    }
+}

--- a/crates/zeph-memory/src/compression/promotion.rs
+++ b/crates/zeph-memory/src/compression/promotion.rs
@@ -16,7 +16,7 @@
 //!
 //! To avoid a circular crate dependency (`zeph-memory` ↔ `zeph-skills`), skill
 //! generation is delegated to [`SkillWriter`], a trait that callers in
-//! `zeph-core` implement using [`zeph_skills::generator::SkillGenerator`].
+//! `zeph-core` implement using `zeph_skills::generator::SkillGenerator`.
 //! This keeps `zeph-memory` free of a direct `zeph-skills` dependency.
 
 use std::collections::HashSet;
@@ -95,7 +95,7 @@ impl Default for PromotionConfig {
 
 /// Trait for writing a generated SKILL.md to disk.
 ///
-/// Implemented in `zeph-core` using [`zeph_skills::generator::SkillGenerator`].
+/// Implemented in `zeph-core` using `zeph_skills::generator::SkillGenerator`.
 /// Defined here to avoid a circular crate dependency.
 ///
 /// # Contract

--- a/crates/zeph-memory/src/error.rs
+++ b/crates/zeph-memory/src/error.rs
@@ -63,4 +63,10 @@ pub enum MemoryError {
     /// Returned when the supersede chain depth would exceed [`crate::graph::conflict::SUPERSEDE_DEPTH_CAP`].
     #[error("supersede chain depth cap exceeded at edge id={0}")]
     SupersedeDepthExceeded(i64),
+
+    /// A promotion-scan or promote error (Feature A, #3305).
+    ///
+    /// Wraps errors from clustering, skill generation, evaluator calls, or disk writes.
+    #[error("promotion scan failed: {0}")]
+    Promotion(String),
 }

--- a/crates/zeph-memory/src/lib.rs
+++ b/crates/zeph-memory/src/lib.rs
@@ -66,6 +66,7 @@
 pub mod admission;
 pub mod anchored_summary;
 pub mod compaction_probe;
+pub mod compression;
 pub mod compression_guidelines;
 pub mod consolidation;
 pub mod document;
@@ -102,6 +103,12 @@ pub use compaction_probe::{
     CategoryScore, CompactionProbeConfig, CompactionProbeResult, ProbeCategory, ProbeQuestion,
     ProbeVerdict, answer_probe_questions, generate_probe_questions, score_answers,
     validate_compaction,
+};
+pub use compression::{
+    CompressionLevel, RetrievalPolicy,
+    promotion::{
+        PromotionCandidate, PromotionConfig, PromotionEngine, PromotionInput, SkillWriter,
+    },
 };
 pub use compression_guidelines::CompressionGuidelinesConfig;
 pub use compression_guidelines::{

--- a/crates/zeph-memory/src/semantic/mod.rs
+++ b/crates/zeph-memory/src/semantic/mod.rs
@@ -588,4 +588,54 @@ impl SemanticMemory {
             .count_messages_after(conversation_id, after_id)
             .await
     }
+
+    /// Load recent episodic messages for the promotion-scan window.
+    ///
+    /// Returns up to `max_items` of the most recent non-deleted messages across all
+    /// conversations, with their `conversation_id` for session-count heuristics.
+    ///
+    /// # Embedding note
+    ///
+    /// `embedding` is returned as `None` in this MVP implementation. A future pass
+    /// will join with the Qdrant payload to populate embeddings inline.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError`] if the underlying `SQLite` query fails.
+    // TODO(review): populate embeddings by fetching from Qdrant when available.
+    pub async fn load_promotion_window(
+        &self,
+        max_items: usize,
+    ) -> Result<Vec<crate::compression::promotion::PromotionInput>, MemoryError> {
+        use zeph_db::sql;
+
+        let limit = i64::try_from(max_items).unwrap_or(i64::MAX);
+        let rows: Vec<(
+            crate::types::MessageId,
+            crate::types::ConversationId,
+            String,
+        )> = zeph_db::query_as(sql!(
+            "SELECT id, conversation_id, content \
+                 FROM messages \
+                 WHERE deleted_at IS NULL \
+                 ORDER BY id DESC \
+                 LIMIT ?"
+        ))
+        .bind(limit)
+        .fetch_all(self.sqlite.pool())
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|(message_id, conversation_id, content)| {
+                crate::compression::promotion::PromotionInput {
+                    message_id,
+                    conversation_id,
+                    content,
+                    // Embeddings not wired yet — scan will skip rows with None.
+                    embedding: None,
+                }
+            })
+            .collect())
+    }
 }

--- a/crates/zeph-skills/src/evaluator.rs
+++ b/crates/zeph-skills/src/evaluator.rs
@@ -1,0 +1,495 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! External-feedback skill evaluator (#3319).
+//!
+//! [`SkillEvaluator`] calls a critic LLM to score a generated SKILL.md across three
+//! dimensions — correctness, reusability, and specificity — and returns an accept/reject
+//! verdict. This module is Feature B of the skills-compression-spectrum initiative.
+//!
+//! # Design notes
+//!
+//! The evaluator gate is a **quality heuristic**, not a safety boundary. A misbehaving
+//! critic LLM should not block users from generating skills; they can always inspect and
+//! delete a bad SKILL.md manually. For this reason the default policy is **fail-open**:
+//! evaluator errors (timeout, JSON parse failure) produce [`SkillVerdict::AcceptOnEvalError`]
+//! rather than a rejection. Operators who want strict quality enforcement can set
+//! `fail_open_on_error = false` in config.
+//!
+//! Weights (`correctness`, `reusability`, `specificity`) must sum to 1.0 ± 1e-3; this is
+//! enforced at config validation time. Defaults (0.50 / 0.25 / 0.25) and threshold (0.60)
+//! are starting points based on intuition and will be tuned once real-world telemetry is
+//! available.
+
+use std::time::Duration;
+
+use zeph_llm::any::AnyProvider;
+use zeph_llm::provider::{LlmProvider, Message, Role};
+
+use crate::error::SkillError;
+
+/// A request to evaluate a generated SKILL.md through the critic LLM.
+///
+/// All fields are borrowed from the caller — no allocation.
+pub struct SkillEvaluationRequest<'a> {
+    /// The human-readable skill name (as parsed from frontmatter).
+    pub name: &'a str,
+    /// The description field from the skill frontmatter.
+    pub description: &'a str,
+    /// The full SKILL.md content (frontmatter + body).
+    pub body: &'a str,
+    /// The original natural-language intent that triggered generation.
+    pub original_intent: &'a str,
+}
+
+/// Three-dimensional score returned by the critic LLM.
+///
+/// Each dimension is a value in `[0.0, 1.0]`. Use [`composite`](Self::composite) to
+/// combine them into a single scalar for threshold comparison.
+#[derive(Debug, Clone)]
+pub struct SkillQualityScore {
+    /// How likely is the skill body to produce correct results? (0.0–1.0)
+    pub correctness: f32,
+    /// How well does the skill generalise beyond the exact original request? (0.0–1.0)
+    pub reusability: f32,
+    /// Is the skill tightly scoped (not too broad, not too narrow)? (0.0–1.0)
+    pub specificity: f32,
+    /// Free-text rationale from the critic.
+    pub rationale: String,
+}
+
+impl SkillQualityScore {
+    /// Compute the weighted composite score.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_skills::evaluator::{SkillQualityScore, EvaluationWeights};
+    ///
+    /// let score = SkillQualityScore {
+    ///     correctness: 0.9,
+    ///     reusability: 0.8,
+    ///     specificity: 0.7,
+    ///     rationale: String::new(),
+    /// };
+    /// let weights = EvaluationWeights::default();
+    /// let composite = score.composite(&weights);
+    /// assert!((composite - 0.825_f32).abs() < 1e-4, "expected ~0.825, got {composite}");
+    /// ```
+    #[must_use]
+    pub fn composite(&self, w: &EvaluationWeights) -> f32 {
+        w.correctness * self.correctness
+            + w.reusability * self.reusability
+            + w.specificity * self.specificity
+    }
+}
+
+/// Weights used to combine the three quality dimensions into a single composite score.
+///
+/// Weights must sum to 1.0 ± 1e-3; this is enforced at config validation time.
+#[derive(Debug, Clone, Copy)]
+pub struct EvaluationWeights {
+    /// Weight for correctness (default 0.50).
+    pub correctness: f32,
+    /// Weight for reusability (default 0.25).
+    pub reusability: f32,
+    /// Weight for specificity (default 0.25).
+    pub specificity: f32,
+}
+
+impl Default for EvaluationWeights {
+    fn default() -> Self {
+        Self {
+            correctness: 0.50,
+            reusability: 0.25,
+            specificity: 0.25,
+        }
+    }
+}
+
+/// The outcome of an evaluation run.
+#[derive(Debug, Clone)]
+pub enum SkillVerdict {
+    /// Skill meets the quality threshold.
+    Accept(SkillQualityScore),
+    /// Skill is below threshold or was explicitly rejected.
+    Reject {
+        /// The score that caused rejection.
+        score: SkillQualityScore,
+        /// Human-readable reason.
+        reason: String,
+    },
+    /// The evaluator encountered an error (timeout or parse failure) but
+    /// `fail_open_on_error = true`, so the skill is accepted anyway.
+    AcceptOnEvalError(String),
+}
+
+/// Evaluates generated SKILL.md files through a critic LLM.
+///
+/// Constructed from [`SkillEvaluationConfig`](zeph_config::SkillEvaluationConfig) by the
+/// agent builder. A single instance is shared across all skill-generating paths
+/// (`SkillGenerator`, `ProactiveExplorer`, `PromotionEngine`) via `Arc<SkillEvaluator>`.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use std::sync::Arc;
+/// use zeph_skills::evaluator::{SkillEvaluator, EvaluationWeights, SkillEvaluationRequest};
+///
+/// async fn demo(provider: zeph_llm::any::AnyProvider) {
+///     let evaluator = SkillEvaluator::new(provider, EvaluationWeights::default(), 0.60, true, 15_000);
+///     let req = SkillEvaluationRequest {
+///         name: "fetch-weather",
+///         description: "Fetch weather data from wttr.in",
+///         body: "---\nname: fetch-weather\n...",
+///         original_intent: "I need to get weather information",
+///     };
+///     let verdict = evaluator.evaluate(&req).await;
+///     println!("{verdict:?}");
+/// }
+/// ```
+pub struct SkillEvaluator {
+    critic: AnyProvider,
+    weights: EvaluationWeights,
+    threshold: f32,
+    /// When `true`, evaluator errors produce `AcceptOnEvalError` instead of `Reject`.
+    fail_open: bool,
+    /// Timeout in milliseconds for the LLM call.
+    timeout_ms: u64,
+}
+
+impl SkillEvaluator {
+    /// Create a new evaluator.
+    ///
+    /// `fail_open`: when `true` (recommended default), evaluator errors accept the skill.
+    /// `timeout_ms`: maximum wait for the critic LLM response.
+    #[must_use]
+    pub fn new(
+        critic: AnyProvider,
+        weights: EvaluationWeights,
+        threshold: f32,
+        fail_open: bool,
+        timeout_ms: u64,
+    ) -> Self {
+        Self {
+            critic,
+            weights,
+            threshold,
+            fail_open,
+            timeout_ms,
+        }
+    }
+
+    /// Evaluate a generated skill through the critic LLM.
+    ///
+    /// Returns a [`SkillVerdict`]. Never returns `Err` unless the skill violates a
+    /// hard constraint (currently unused — all LLM errors are handled by the fail-open
+    /// policy). The `Err` variant is reserved for future hard-error scenarios.
+    ///
+    /// # Errors
+    ///
+    /// Currently always returns `Ok(_)`. Error propagation is reserved for future use.
+    #[tracing::instrument(name = "skills.eval.evaluate", skip_all, fields(skill_name = %req.name))]
+    pub async fn evaluate(
+        &self,
+        req: &SkillEvaluationRequest<'_>,
+    ) -> Result<SkillVerdict, SkillError> {
+        let prompt = build_eval_prompt(req);
+        let messages = vec![
+            Message::from_legacy(Role::System, EVAL_SYSTEM_PROMPT),
+            Message::from_legacy(Role::User, &prompt),
+        ];
+
+        let llm_result = tokio::time::timeout(Duration::from_millis(self.timeout_ms), async {
+            let span = tracing::info_span!("skills.eval.llm_call");
+            let _enter = span.enter();
+            self.critic.chat(&messages).await
+        })
+        .await;
+
+        let raw = match llm_result {
+            Ok(Ok(text)) => text,
+            Ok(Err(e)) => {
+                let msg = format!("critic LLM error: {e}");
+                tracing::warn!(error = %e, "skill evaluator LLM call failed");
+                return Ok(self.handle_error(msg));
+            }
+            Err(_timeout) => {
+                let msg = format!("critic LLM timed out after {}ms", self.timeout_ms);
+                tracing::warn!(timeout_ms = self.timeout_ms, "skill evaluator timed out");
+                return Ok(self.handle_error(msg));
+            }
+        };
+
+        match parse_eval_response(&raw) {
+            Ok(score) => {
+                let composite = score.composite(&self.weights);
+                if composite >= self.threshold {
+                    Ok(SkillVerdict::Accept(score))
+                } else {
+                    let reason = format!(
+                        "composite score {composite:.3} below threshold {:.3}: {}",
+                        self.threshold, score.rationale
+                    );
+                    Ok(SkillVerdict::Reject { score, reason })
+                }
+            }
+            Err(parse_err) => {
+                let msg = format!("failed to parse evaluator JSON: {parse_err}");
+                tracing::warn!(error = %parse_err, "skill evaluator JSON parse failed");
+                Ok(self.handle_error(msg))
+            }
+        }
+    }
+
+    fn handle_error(&self, msg: String) -> SkillVerdict {
+        if self.fail_open {
+            tracing::info!(%msg, "skills.eval.fail_open_triggered: accepting skill despite evaluator error");
+            SkillVerdict::AcceptOnEvalError(msg)
+        } else {
+            SkillVerdict::Reject {
+                score: zero_score(msg.clone()),
+                reason: format!("evaluator error, fail-closed: {msg}"),
+            }
+        }
+    }
+}
+
+/// System prompt given to the critic LLM.
+const EVAL_SYSTEM_PROMPT: &str = "\
+You are a strict quality reviewer for SKILL.md files used by AI agents. \
+Evaluate the skill on three dimensions and return ONLY a JSON object, no extra text.\n\n\
+JSON schema:\n\
+{\n  \"correctness\": <float 0.0-1.0>,\n  \"reusability\": <float 0.0-1.0>,\n  \
+\"specificity\": <float 0.0-1.0>,\n  \"rationale\": \"<one sentence>\"\n}\n\n\
+Dimension definitions:\n\
+- correctness: Is the skill body likely to produce correct, safe, and useful results?\n\
+- reusability: Does the skill generalise beyond the exact original request (not over-fitted)?\n\
+- specificity: Is the skill tightly scoped — not too broad to be useless, not so narrow it helps only once?\n";
+
+fn build_eval_prompt(req: &SkillEvaluationRequest<'_>) -> String {
+    format!(
+        "Original intent: {}\n\nSkill name: {}\n\nDescription: {}\n\nSKILL.md body:\n```\n{}\n```",
+        req.original_intent, req.name, req.description, req.body
+    )
+}
+
+fn zero_score(rationale: String) -> SkillQualityScore {
+    SkillQualityScore {
+        correctness: 0.0,
+        reusability: 0.0,
+        specificity: 0.0,
+        rationale,
+    }
+}
+
+fn parse_eval_response(raw: &str) -> Result<SkillQualityScore, serde_json::Error> {
+    #[derive(serde::Deserialize)]
+    struct EvalResponse {
+        correctness: f32,
+        reusability: f32,
+        specificity: f32,
+        rationale: String,
+    }
+
+    let trimmed = raw.trim();
+    // Strip markdown code fences if present.
+    let json_str = if let Some(inner) = trimmed
+        .strip_prefix("```json")
+        .or_else(|| trimmed.strip_prefix("```"))
+        .and_then(|s| s.trim_start_matches('\n').rsplit_once("```"))
+    {
+        inner.0.trim()
+    } else {
+        trimmed
+    };
+
+    let resp: EvalResponse = serde_json::from_str(json_str)?;
+    Ok(SkillQualityScore {
+        correctness: resp.correctness.clamp(0.0, 1.0),
+        reusability: resp.reusability.clamp(0.0, 1.0),
+        specificity: resp.specificity.clamp(0.0, 1.0),
+        rationale: resp.rationale,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn composite_score_default_weights() {
+        let score = SkillQualityScore {
+            correctness: 0.9,
+            reusability: 0.8,
+            specificity: 0.7,
+            rationale: String::new(),
+        };
+        let w = EvaluationWeights::default();
+        let c = score.composite(&w);
+        // 0.9*0.5 + 0.8*0.25 + 0.7*0.25 = 0.45 + 0.20 + 0.175 = 0.825
+        assert!((c - 0.825_f32).abs() < 1e-4, "expected ~0.825, got {c}");
+    }
+
+    #[test]
+    fn composite_score_custom_weights() {
+        let score = SkillQualityScore {
+            correctness: 1.0,
+            reusability: 0.0,
+            specificity: 0.0,
+            rationale: String::new(),
+        };
+        let w = EvaluationWeights {
+            correctness: 1.0,
+            reusability: 0.0,
+            specificity: 0.0,
+        };
+        assert!((score.composite(&w) - 1.0_f32).abs() < 1e-6);
+    }
+
+    #[test]
+    fn parse_eval_response_valid_json() {
+        let raw =
+            r#"{"correctness": 0.9, "reusability": 0.8, "specificity": 0.7, "rationale": "good"}"#;
+        let score = parse_eval_response(raw).unwrap();
+        assert!((score.correctness - 0.9).abs() < 1e-6);
+        assert!((score.reusability - 0.8).abs() < 1e-6);
+        assert!((score.specificity - 0.7).abs() < 1e-6);
+        assert_eq!(score.rationale, "good");
+    }
+
+    #[test]
+    fn parse_eval_response_strips_code_fence() {
+        let raw = "```json\n{\"correctness\": 0.5, \"reusability\": 0.5, \"specificity\": 0.5, \"rationale\": \"ok\"}\n```";
+        let score = parse_eval_response(raw).unwrap();
+        assert!((score.correctness - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn parse_eval_response_clamps_out_of_range() {
+        let raw =
+            r#"{"correctness": 1.5, "reusability": -0.1, "specificity": 0.5, "rationale": "x"}"#;
+        let score = parse_eval_response(raw).unwrap();
+        assert!(
+            (score.correctness - 1.0).abs() < 1e-6,
+            "should clamp to 1.0"
+        );
+        assert!(
+            (score.reusability - 0.0).abs() < 1e-6,
+            "should clamp to 0.0"
+        );
+    }
+
+    #[test]
+    fn parse_eval_response_invalid_returns_err() {
+        let raw = "not json at all";
+        assert!(parse_eval_response(raw).is_err());
+    }
+
+    #[tokio::test]
+    async fn evaluator_fail_open_on_llm_error() {
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+
+        let mock = MockProvider::failing();
+        let ev = SkillEvaluator::new(
+            AnyProvider::Mock(mock),
+            EvaluationWeights::default(),
+            0.60,
+            true,
+            5_000,
+        );
+        let req = SkillEvaluationRequest {
+            name: "test-skill",
+            description: "A test skill.",
+            body: "---\nname: test-skill\n---\n\n## Usage\n\nTest.",
+            original_intent: "test",
+        };
+        let verdict = ev.evaluate(&req).await.unwrap();
+        assert!(
+            matches!(verdict, SkillVerdict::AcceptOnEvalError(_)),
+            "expected AcceptOnEvalError, got {verdict:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn evaluator_fail_closed_on_llm_error() {
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+
+        let mock = MockProvider::failing();
+        let ev = SkillEvaluator::new(
+            AnyProvider::Mock(mock),
+            EvaluationWeights::default(),
+            0.60,
+            false, // fail-closed
+            5_000,
+        );
+        let req = SkillEvaluationRequest {
+            name: "test-skill",
+            description: "A test skill.",
+            body: "---\nname: test-skill\n---\n\n## Usage\n\nTest.",
+            original_intent: "test",
+        };
+        let verdict = ev.evaluate(&req).await.unwrap();
+        assert!(
+            matches!(verdict, SkillVerdict::Reject { .. }),
+            "expected Reject, got {verdict:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn evaluator_accept_high_score() {
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+
+        let response = r#"{"correctness": 0.9, "reusability": 0.8, "specificity": 0.9, "rationale": "excellent"}"#;
+        let mock = MockProvider::with_responses(vec![response.to_string()]);
+        let ev = SkillEvaluator::new(
+            AnyProvider::Mock(mock),
+            EvaluationWeights::default(),
+            0.60,
+            true,
+            5_000,
+        );
+        let req = SkillEvaluationRequest {
+            name: "fetch-weather",
+            description: "Fetch weather data.",
+            body: "---\nname: fetch-weather\n---\n## Usage\n\nFetch it.",
+            original_intent: "get weather",
+        };
+        let verdict = ev.evaluate(&req).await.unwrap();
+        assert!(
+            matches!(verdict, SkillVerdict::Accept(_)),
+            "expected Accept, got {verdict:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn evaluator_reject_low_score() {
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+
+        let response =
+            r#"{"correctness": 0.2, "reusability": 0.1, "specificity": 0.1, "rationale": "poor"}"#;
+        let mock = MockProvider::with_responses(vec![response.to_string()]);
+        let ev = SkillEvaluator::new(
+            AnyProvider::Mock(mock),
+            EvaluationWeights::default(),
+            0.60,
+            true,
+            5_000,
+        );
+        let req = SkillEvaluationRequest {
+            name: "bad-skill",
+            description: "Bad skill.",
+            body: "---\nname: bad-skill\n---\n## Usage\n\nBad.",
+            original_intent: "do something bad",
+        };
+        let verdict = ev.evaluate(&req).await.unwrap();
+        assert!(
+            matches!(verdict, SkillVerdict::Reject { .. }),
+            "expected Reject, got {verdict:?}"
+        );
+    }
+}

--- a/crates/zeph-skills/src/generator.rs
+++ b/crates/zeph-skills/src/generator.rs
@@ -7,11 +7,13 @@
 //! validates the result, and optionally writes it to disk for hot-reload pickup.
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::{LlmProvider, Message, Role};
 
 use crate::error::SkillError;
+use crate::evaluator::{EvaluationWeights, SkillEvaluationRequest, SkillEvaluator, SkillVerdict};
 use crate::loader::{SkillMeta, load_skill_meta_from_str};
 use crate::scanner::scan_skill_body;
 
@@ -121,6 +123,13 @@ pub struct GeneratedSkill {
 pub struct SkillGenerator {
     pub(crate) provider: AnyProvider,
     output_dir: PathBuf,
+    /// Optional evaluator gate. When `Some`, `approve_and_save` runs evaluation
+    /// before writing to disk and returns `Err(SkillError::Invalid)` on rejection.
+    evaluator: Option<Arc<SkillEvaluator>>,
+    /// Weights passed to the evaluator composite calculation.
+    eval_weights: EvaluationWeights,
+    /// Minimum composite score required to accept a generated skill.
+    eval_threshold: f32,
 }
 
 impl SkillGenerator {
@@ -130,7 +139,28 @@ impl SkillGenerator {
         Self {
             provider,
             output_dir,
+            evaluator: None,
+            eval_weights: EvaluationWeights::default(),
+            eval_threshold: 0.60,
         }
+    }
+
+    /// Attach an evaluator gate to this generator.
+    ///
+    /// When set, [`Self::approve_and_save`] will call `evaluator.evaluate` before
+    /// writing the skill to disk. Skills that score below `threshold` are rejected
+    /// with [`SkillError::Invalid`].
+    #[must_use]
+    pub fn with_evaluator(
+        mut self,
+        eval: Arc<SkillEvaluator>,
+        weights: EvaluationWeights,
+        threshold: f32,
+    ) -> Self {
+        self.evaluator = Some(eval);
+        self.eval_weights = weights;
+        self.eval_threshold = threshold;
+        self
     }
 
     /// Generate a SKILL.md candidate from a natural language description.
@@ -192,18 +222,55 @@ impl SkillGenerator {
 
     /// Write an approved `GeneratedSkill` to `output_dir/<name>/SKILL.md`.
     ///
-    /// # Errors
-    ///
-    /// Returns `SkillError::AlreadyExists` if the target directory already exists.
-    /// Returns `SkillError::Io` on filesystem errors.
+    /// When an evaluator is configured (via [`Self::with_evaluator`]), the skill is scored
+    /// before writing. Skills below the threshold are rejected with [`SkillError::Invalid`].
     ///
     /// # Errors
     ///
     /// Returns `SkillError::AlreadyExists` if the skill directory already exists.
+    /// Returns `SkillError::Invalid` if the evaluator rejects the skill.
     /// Returns `SkillError::Io` on filesystem errors.
     pub async fn approve_and_save(&self, skill: &GeneratedSkill) -> Result<PathBuf, SkillError> {
         // Validate name (paranoia — already validated during generation).
         validate_generated_name(&skill.name)?;
+
+        // Evaluator gate (Feature B, #3319).
+        if let Some(ref evaluator) = self.evaluator {
+            let req = SkillEvaluationRequest {
+                name: &skill.name,
+                description: &skill.meta.description,
+                body: &skill.content,
+                original_intent: &skill.meta.description,
+            };
+            match evaluator.evaluate(&req).await? {
+                SkillVerdict::Accept(score) => {
+                    tracing::debug!(
+                        name = %skill.name,
+                        composite = %(score.composite(&self.eval_weights)),
+                        "evaluator accepted skill"
+                    );
+                }
+                SkillVerdict::AcceptOnEvalError(reason) => {
+                    tracing::info!(
+                        name = %skill.name,
+                        %reason,
+                        "evaluator error (fail-open): proceeding with skill write"
+                    );
+                }
+                SkillVerdict::Reject { score, reason } => {
+                    tracing::info!(
+                        name = %skill.name,
+                        composite = %(score.composite(&self.eval_weights)),
+                        %reason,
+                        "evaluator rejected skill"
+                    );
+                    return Err(SkillError::Invalid(format!(
+                        "skill '{name}' rejected by evaluator: {reason}",
+                        name = skill.name
+                    )));
+                }
+            }
+        }
 
         let skill_dir = self.output_dir.join(&skill.name);
         if skill_dir.exists() {

--- a/crates/zeph-skills/src/lib.rs
+++ b/crates/zeph-skills/src/lib.rs
@@ -32,7 +32,7 @@
 //! | [`stem`] | STEM: automatic detection of recurring tool-use patterns |
 //! | [`rl_head`] | 2-layer MLP routing head trained with REINFORCE for skill re-ranking |
 //! | [`resource`] | Skill-local resource file discovery and loading |
-//! | [`qdrant_matcher`] | Qdrant-backed vector store for skill matching at scale |
+//! | `qdrant_matcher` | Qdrant-backed vector store for skill matching at scale (feature `qdrant`) |
 //!
 //! # Quick Start
 //!

--- a/crates/zeph-skills/src/lib.rs
+++ b/crates/zeph-skills/src/lib.rs
@@ -55,12 +55,14 @@ pub mod bm25;
 pub mod bundled;
 pub mod erl;
 pub mod error;
+pub mod evaluator;
 pub mod evolution;
 pub mod generator;
 pub mod loader;
 pub mod manager;
 pub mod matcher;
 pub mod miner;
+pub mod proactive;
 pub mod prompt;
 #[cfg(feature = "qdrant")]
 pub mod qdrant_matcher;
@@ -75,6 +77,10 @@ pub mod watcher;
 
 pub use bundled::bundled_skill_names;
 pub use error::SkillError;
+pub use evaluator::{
+    EvaluationWeights, SkillEvaluationRequest, SkillEvaluator, SkillQualityScore, SkillVerdict,
+};
 pub use generator::{GeneratedSkill, SkillGenerationRequest, SkillGenerator};
 pub use matcher::{IntentClassification, MatchResult, ScoredMatch};
+pub use proactive::{DomainLabel, ProactiveExplorer};
 pub use trust::{SkillSource, SkillTrust, SkillTrustLevel, compute_skill_hash};

--- a/crates/zeph-skills/src/proactive.rs
+++ b/crates/zeph-skills/src/proactive.rs
@@ -6,7 +6,7 @@
 //! [`ProactiveExplorer`] classifies incoming queries against a keyword map of recognisable
 //! technology domains and, for domains with no existing SKILL.md, generates one. The skill
 //! is written to disk and registered in the [`SkillRegistry`] immediately, but becomes
-//! **visible to [`SkillMatcher`]** only on the next turn — this is an intentional MVP
+//! **visible to [`crate::matcher::SkillMatcher`]** only on the next turn — this is an intentional MVP
 //! trade-off that avoids an expensive synchronous re-embed on the hot path.
 //!
 //! # Domain keyword map (MVP)

--- a/crates/zeph-skills/src/proactive.rs
+++ b/crates/zeph-skills/src/proactive.rs
@@ -1,0 +1,367 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Proactive world-knowledge exploration (#3320).
+//!
+//! [`ProactiveExplorer`] classifies incoming queries against a keyword map of recognisable
+//! technology domains and, for domains with no existing SKILL.md, generates one. The skill
+//! is written to disk and registered in the [`SkillRegistry`] immediately, but becomes
+//! **visible to [`SkillMatcher`]** only on the next turn — this is an intentional MVP
+//! trade-off that avoids an expensive synchronous re-embed on the hot path.
+//!
+//! # Domain keyword map (MVP)
+//!
+//! The classifier uses a static keyword → domain table. Any query word that is an exact
+//! lowercase match for an entry in the table produces a [`DomainLabel`]. Only the first
+//! matching domain is returned; no disambiguation is attempted.
+//!
+//! # Evaluator gate
+//!
+//! When constructed with an `Option<Arc<SkillEvaluator>>`, each generated skill is scored
+//! before being written to disk. On evaluator rejection the method returns `Ok(())` with
+//! a `tracing::info!` log — rejection is a normal outcome, not a fault.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::error::SkillError;
+use crate::evaluator::{SkillEvaluationRequest, SkillEvaluator, SkillVerdict};
+use crate::generator::{SkillGenerationRequest, SkillGenerator};
+use crate::registry::SkillRegistry;
+
+/// Keyword → domain mapping used by [`ProactiveExplorer::classify`].
+///
+/// Each entry is `(keyword, domain_slug)`. Keyword matching is case-insensitive
+/// and performed on whitespace-separated tokens in the query.
+static DOMAIN_KEYWORDS: &[(&str, &str)] = &[
+    ("rust", "rust"),
+    ("python", "python"),
+    ("docker", "docker"),
+    ("git", "git"),
+    ("sql", "sql"),
+    ("http", "http"),
+    ("kubernetes", "kubernetes"),
+    ("k8s", "kubernetes"),
+    ("typescript", "typescript"),
+    ("go", "go"),
+    ("golang", "go"),
+    ("terraform", "terraform"),
+    ("react", "react"),
+    ("postgres", "postgres"),
+    ("postgresql", "postgres"),
+    ("bash", "bash"),
+    ("shell", "bash"),
+    ("yaml", "yaml"),
+    ("json", "json"),
+    ("toml", "toml"),
+    ("grpc", "grpc"),
+    ("redis", "redis"),
+    ("kafka", "kafka"),
+    ("aws", "aws"),
+    ("gcp", "gcp"),
+    ("azure", "azure"),
+];
+
+/// A canonical domain identifier produced by [`ProactiveExplorer::classify`].
+///
+/// Wraps a lowercase slug like `"rust"` or `"kubernetes"`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DomainLabel(pub String);
+
+impl DomainLabel {
+    /// Return the canonical skill name for this domain: `"world-knowledge-{slug}"`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_skills::proactive::DomainLabel;
+    /// let d = DomainLabel("rust".into());
+    /// assert_eq!(d.to_skill_name(), "world-knowledge-rust");
+    /// ```
+    #[must_use]
+    pub fn to_skill_name(&self) -> String {
+        format!("world-knowledge-{}", self.0)
+    }
+}
+
+/// Classifies queries and generates world-knowledge SKILL.md files on demand.
+///
+/// Constructed by the agent builder when
+/// `config.skills.proactive_exploration.enabled = true`. Attach an evaluator via the
+/// constructor to apply the quality gate (Feature B, #3319) to generated skills.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use std::path::PathBuf;
+/// use std::sync::Arc;
+/// use zeph_skills::proactive::ProactiveExplorer;
+/// use zeph_skills::generator::SkillGenerator;
+///
+/// # async fn demo(provider: zeph_llm::any::AnyProvider, registry: &zeph_skills::registry::SkillRegistry) {
+/// let gen = SkillGenerator::new(provider, PathBuf::from("/tmp/skills"));
+/// let explorer = ProactiveExplorer::new(gen, None, PathBuf::from("/tmp/skills"), 8_000, 30_000, vec![]);
+/// if let Some(domain) = explorer.classify("how do I use docker volumes?") {
+///     if !explorer.has_knowledge(registry, &domain) {
+///         explorer.explore(&domain).await.ok();
+///     }
+/// }
+/// # }
+/// ```
+pub struct ProactiveExplorer {
+    generator: SkillGenerator,
+    evaluator: Option<Arc<SkillEvaluator>>,
+    output_dir: PathBuf,
+    max_chars: usize,
+    timeout_ms: u64,
+    excluded_domains: Vec<String>,
+}
+
+impl ProactiveExplorer {
+    /// Create a new explorer.
+    ///
+    /// - `generator`: drives SKILL.md generation.
+    /// - `evaluator`: optional quality gate (Feature B).
+    /// - `output_dir`: where generated skills are written.
+    /// - `max_chars`: approximate target size hint passed in the generation prompt.
+    /// - `timeout_ms`: per-exploration timeout covering the full generate → write path.
+    /// - `excluded_domains`: domain slugs to skip (e.g. `["rust"]`).
+    #[must_use]
+    pub fn new(
+        generator: SkillGenerator,
+        evaluator: Option<Arc<SkillEvaluator>>,
+        output_dir: PathBuf,
+        max_chars: usize,
+        timeout_ms: u64,
+        excluded_domains: Vec<String>,
+    ) -> Self {
+        Self {
+            generator,
+            evaluator,
+            output_dir,
+            max_chars,
+            timeout_ms,
+            excluded_domains,
+        }
+    }
+
+    /// Expose the configured timeout so callers can set `tokio::time::timeout` correctly.
+    #[must_use]
+    pub fn timeout_ms(&self) -> u64 {
+        self.timeout_ms
+    }
+
+    /// Classify `query` against the keyword map.
+    ///
+    /// Returns `None` when no keyword in the query matches a known domain.
+    /// Returns the first matching [`DomainLabel`] otherwise.
+    #[tracing::instrument(name = "core.proactive.classify", skip_all)]
+    pub fn classify(&self, query: &str) -> Option<DomainLabel> {
+        let lower = query.to_lowercase();
+        for token in lower.split_whitespace() {
+            // Strip trailing punctuation from tokens.
+            let token = token.trim_end_matches(|c: char| !c.is_alphanumeric());
+            for &(keyword, domain) in DOMAIN_KEYWORDS {
+                if token == keyword {
+                    return Some(DomainLabel(domain.to_string()));
+                }
+            }
+        }
+        None
+    }
+
+    /// Return `true` if the registry already contains a skill for `domain`.
+    #[must_use]
+    pub fn has_knowledge(&self, registry: &SkillRegistry, domain: &DomainLabel) -> bool {
+        let name = domain.to_skill_name();
+        registry.all_meta().iter().any(|m| m.name == name)
+    }
+
+    /// Return `true` if `domain` is in the configured exclusion list.
+    #[must_use]
+    pub fn is_excluded(&self, domain: &DomainLabel) -> bool {
+        self.excluded_domains.iter().any(|e| e == &domain.0)
+    }
+
+    /// Generate and persist a SKILL.md for `domain`.
+    ///
+    /// Applies the evaluator gate when configured. On evaluator rejection returns
+    /// `Ok(())` with an info-level log — rejection is not an error.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SkillError`] if SKILL.md generation or the filesystem write fails.
+    #[tracing::instrument(name = "core.proactive.explore", skip_all, fields(domain = %domain.0))]
+    pub async fn explore(&self, domain: &DomainLabel) -> Result<(), SkillError> {
+        let description = format!(
+            "World-knowledge reference skill for {domain}. \
+             Provide concise, authoritative quick-reference information about {domain}: \
+             key commands, idioms, and best practices. Keep the body under {max_chars} characters.",
+            domain = domain.0,
+            max_chars = self.max_chars,
+        );
+
+        let req = SkillGenerationRequest {
+            description: description.clone(),
+            category: Some("dev".into()),
+            allowed_tools: vec![],
+        };
+
+        let skill = self.generator.generate(req).await?;
+
+        // Evaluator gate (S3 fix — see arch spec §2.3).
+        if let Some(ref evaluator) = self.evaluator {
+            let eval_req = SkillEvaluationRequest {
+                name: &skill.name,
+                description: &skill.meta.description,
+                body: &skill.content,
+                original_intent: &description,
+            };
+            match evaluator.evaluate(&eval_req).await? {
+                SkillVerdict::Accept(_) | SkillVerdict::AcceptOnEvalError(_) => {}
+                SkillVerdict::Reject { score: _, reason } => {
+                    tracing::info!(
+                        domain = %domain.0,
+                        %reason,
+                        "proactive skill rejected by evaluator — skipping write"
+                    );
+                    return Ok(());
+                }
+            }
+        }
+
+        // Write SKILL.md to disk. Skip if already exists (idempotent).
+        let skill_dir = self.output_dir.join(&skill.name);
+        if skill_dir.exists() {
+            tracing::debug!(
+                domain = %domain.0,
+                skill = %skill.name,
+                "proactive skill already exists, skipping"
+            );
+            return Ok(());
+        }
+        tokio::fs::create_dir_all(&skill_dir).await?;
+        let skill_path = skill_dir.join("SKILL.md");
+        tokio::fs::write(&skill_path, &skill.content).await?;
+        tracing::info!(
+            domain = %domain.0,
+            skill = %skill.name,
+            path = %skill_path.display(),
+            "proactive skill written to disk"
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_rust_query() {
+        let generator = SkillGenerator::new(
+            zeph_llm::any::AnyProvider::Mock(zeph_llm::mock::MockProvider::default()),
+            PathBuf::from("/tmp"),
+        );
+        let explorer = ProactiveExplorer::new(
+            generator,
+            None,
+            PathBuf::from("/tmp"),
+            8_000,
+            30_000,
+            vec![],
+        );
+
+        let label = explorer.classify("how do I use rust async");
+        assert_eq!(label, Some(DomainLabel("rust".into())));
+    }
+
+    #[test]
+    fn classify_returns_none_for_unknown_domain() {
+        let generator = SkillGenerator::new(
+            zeph_llm::any::AnyProvider::Mock(zeph_llm::mock::MockProvider::default()),
+            PathBuf::from("/tmp"),
+        );
+        let explorer = ProactiveExplorer::new(
+            generator,
+            None,
+            PathBuf::from("/tmp"),
+            8_000,
+            30_000,
+            vec![],
+        );
+
+        assert_eq!(explorer.classify("how are you today"), None);
+    }
+
+    #[test]
+    fn classify_docker_with_punctuation() {
+        let generator = SkillGenerator::new(
+            zeph_llm::any::AnyProvider::Mock(zeph_llm::mock::MockProvider::default()),
+            PathBuf::from("/tmp"),
+        );
+        let explorer = ProactiveExplorer::new(
+            generator,
+            None,
+            PathBuf::from("/tmp"),
+            8_000,
+            30_000,
+            vec![],
+        );
+
+        // Token "docker," with trailing comma — should still match.
+        let label = explorer.classify("docker, how do I mount volumes?");
+        assert_eq!(label, Some(DomainLabel("docker".into())));
+    }
+
+    #[test]
+    fn is_excluded_matches_configured_domains() {
+        let generator = SkillGenerator::new(
+            zeph_llm::any::AnyProvider::Mock(zeph_llm::mock::MockProvider::default()),
+            PathBuf::from("/tmp"),
+        );
+        let explorer = ProactiveExplorer::new(
+            generator,
+            None,
+            PathBuf::from("/tmp"),
+            8_000,
+            30_000,
+            vec!["rust".into(), "go".into()],
+        );
+
+        assert!(explorer.is_excluded(&DomainLabel("rust".into())));
+        assert!(explorer.is_excluded(&DomainLabel("go".into())));
+        assert!(!explorer.is_excluded(&DomainLabel("python".into())));
+    }
+
+    #[test]
+    fn domain_label_to_skill_name() {
+        assert_eq!(
+            DomainLabel("rust".into()).to_skill_name(),
+            "world-knowledge-rust"
+        );
+        assert_eq!(
+            DomainLabel("kubernetes".into()).to_skill_name(),
+            "world-knowledge-kubernetes"
+        );
+    }
+
+    #[test]
+    fn has_knowledge_empty_registry() {
+        let registry = SkillRegistry::load(&[] as &[std::path::PathBuf]);
+        let generator = SkillGenerator::new(
+            zeph_llm::any::AnyProvider::Mock(zeph_llm::mock::MockProvider::default()),
+            PathBuf::from("/tmp"),
+        );
+        let explorer = ProactiveExplorer::new(
+            generator,
+            None,
+            PathBuf::from("/tmp"),
+            8_000,
+            30_000,
+            vec![],
+        );
+
+        assert!(!explorer.has_knowledge(&registry, &DomainLabel("rust".into())));
+    }
+}

--- a/crates/zeph-skills/src/proactive.rs
+++ b/crates/zeph-skills/src/proactive.rs
@@ -99,8 +99,8 @@ impl DomainLabel {
 /// use zeph_skills::generator::SkillGenerator;
 ///
 /// # async fn demo(provider: zeph_llm::any::AnyProvider, registry: &zeph_skills::registry::SkillRegistry) {
-/// let gen = SkillGenerator::new(provider, PathBuf::from("/tmp/skills"));
-/// let explorer = ProactiveExplorer::new(gen, None, PathBuf::from("/tmp/skills"), 8_000, 30_000, vec![]);
+/// let generator = SkillGenerator::new(provider, PathBuf::from("/tmp/skills"));
+/// let explorer = ProactiveExplorer::new(generator, None, PathBuf::from("/tmp/skills"), 8_000, 30_000, vec![]);
 /// if let Some(domain) = explorer.classify("how do I use docker volumes?") {
 ///     if !explorer.has_knowledge(registry, &domain) {
 ///         explorer.explore(&domain).await.ok();


### PR DESCRIPTION
## Summary

- **#3319** — `SkillEvaluator`: external critic LLM scores generated skills on correctness/reusability/specificity before disk write. Configurable weights/threshold; fail-open by default. Wired into all skill-producing paths (generator, proactive explorer, promotion engine).
- **#3320** — `ProactiveExplorer`: classifies query domain (keyword-based) and generates a `world-knowledge-{domain}` SKILL.md when none exists. Runs before context assembly; new skill visible from the **next** turn (intentional MVP bound).
- **#3305** — `CompressionLevel` + `RetrievalPolicy` + `PromotionEngine`: budget-aware retrieval granularity and background episodic→skill promotion.

All three features are **disabled by default** (`enabled = false`); existing configs parse unchanged (`#[serde(default)]` on every new field).

## Architecture

- `crates/zeph-skills/src/evaluator.rs` — `SkillEvaluator`, `SkillQualityScore`, `SkillVerdict`
- `crates/zeph-skills/src/proactive.rs` — `ProactiveExplorer`, `DomainLabel`
- `crates/zeph-memory/src/compression/mod.rs` — `CompressionLevel`, `RetrievalPolicy`
- `crates/zeph-memory/src/compression/promotion.rs` — `PromotionEngine`, `PromotionInput`
- `crates/zeph-config/src/features.rs` — `SkillEvaluationConfig`, `ProactiveExplorationConfig`, `CompressionSpectrumConfig`

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` — 8326 tests pass
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean
- [ ] Live testing playbook: `.local/testing/playbooks/skills-compression.md`
- [ ] Coverage status rows added: `skill-eval`, `proactive-explore`, `compression-spectrum` (status: Untested)

## Notable design decisions

- Proactive skill is visible next turn only — synchronous matcher rebuild on hot path would add an unbounded embed `.await`; next-turn rebuild is triggered by `matcher_dirty` flag.
- Evaluator defaults to fail-open: a critic error should not block skill generation; operators can set `fail_open_on_error = false` for strict enforcement.
- `PromotionEngine::scan` takes `PromotionInput` (not `MemoryMatch`) because `MemoryMatch` lacks session_id required for the `min_sessions` heuristic.
- `MemoryError::Promotion` with `thiserror` — no `anyhow` in library crates.

Closes #3319, #3320, #3305