### PR TITLE
feat(tools,core): background shell execution and completion notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `search_prompt_template` (query-side embedding template with `{query}` placeholder),
   `context_format` (`structured` / `plain` — memory snippet rendering in agent context).
   MemMachine MM-F1/F2/F5 (#3340).
+- Background shell execution (#3328): `bash` tool call accepts `background: bool` parameter.
+  When `true`, the command is spawned immediately and a `[background] started run_id=…`
+  stub is returned to close the LLM's `tool_use_id`. Completion is delivered as a synthetic
+  user-role block at the start of the next turn (drain-on-next-turn pattern, N1 invariant:
+  all pending completions are merged with the real user message into a single user-role block
+  to satisfy strict Anthropic alternation). `ShellExecutor` gains `spawn_background()`,
+  `shutdown()`, and `with_background_completion_tx()`. `ToolEventTx` is now a bounded
+  `mpsc::Sender<ToolEvent>` (cap 1024). New config fields: `tools.shell.max_background_runs`
+  (default 8) and `tools.shell.background_timeout_secs` (default 1800). New supervisor task
+  class `BackgroundShell` isolated from `Enrichment`. `agent.supervisor.background_shell_limit`
+  added to `TaskSupervisorConfig`.
+- Per-turn completion notifications (#3328 / #3329): `zeph-core` gains a `Notifier` that fires
+  after each agent turn via macOS native banners (`osascript`, stdin-fed to prevent injection)
+  and/or an ntfy-compatible JSON webhook. Gate conditions: master `enabled` switch,
+  zero-LLM-success skip (slash commands / cache hits), `only_on_error`, and a duration
+  threshold (`min_turn_duration_ms`). Error turns always fire regardless of duration.
+  Secrets are redacted via `scrub_content` before any payload leaves the process.
+  `zeph notify test` CLI subcommand and `/notify-test` slash command fire a test notification.
+  New `[notifications]` config section with commented defaults in `default.toml`.
 - CPS (cost per successful task) metric in `CostTracker`: `record_successful_task()`, `cps()`,
   and `successful_tasks()` methods; daily reset consistent with existing cost reset (#2194).
 - `cost_cps_cents: Option<f64>` and `cost_successful_tasks: u64` fields in `AgentMetrics`;

--- a/config/default.toml
+++ b/config/default.toml
@@ -940,6 +940,26 @@ rotation = "daily"
 # Maximum number of rotated log files to retain
 max_files = 7
 
+# Per-turn completion notifications
+# Fires a best-effort notification after each agent turn via macOS Notification Center
+# and/or an ntfy-compatible webhook. Both channels are independently configurable.
+# [notifications]
+# Master switch. All channels are disabled when false.
+# enabled = false
+# Send a macOS Notification Center banner via osascript. No-op on non-macOS platforms.
+# macos_native = false
+# ntfy-compatible webhook URL (e.g. "https://ntfy.sh"). Absent or empty = disabled.
+# webhook_url = ""
+# ntfy topic. Required when webhook_url is set; ignored otherwise.
+# webhook_topic = ""
+# Notification title shown in banners and webhook payloads.
+# title = "Zeph"
+# Minimum successful-turn wall-clock duration (ms) before firing. 0 = always notify.
+# Errors always fire regardless of this setting.
+# min_turn_duration_ms = 0
+# When true, only notify on turns that completed with an error.
+# only_on_error = false
+
 # Knowledge graph memory
 # Extracts entities and relations from conversations into a persistent graph.
 # WARNING: entity names and facts are stored verbatim without PII redaction.

--- a/crates/zeph-commands/src/commands.rs
+++ b/crates/zeph-commands/src/commands.rs
@@ -290,4 +290,11 @@ pub const COMMANDS: &[CommandInfo] = &[
         category: SlashCategory::Advanced,
         feature_gate: None,
     },
+    CommandInfo {
+        name: "/notify-test",
+        args: "",
+        description: "Send a test notification via all enabled channels (macOS, webhook)",
+        category: SlashCategory::Debugging,
+        feature_gate: None,
+    },
 ];

--- a/crates/zeph-commands/src/handlers/misc.rs
+++ b/crates/zeph-commands/src/handlers/misc.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Miscellaneous utility handlers: `/cache-stats`, `/image`.
+//! Miscellaneous utility handlers: `/cache-stats`, `/image`, `/notify-test`.
 
 use std::future::Future;
 use std::pin::Pin;
@@ -32,6 +32,34 @@ impl CommandHandler<CommandContext<'_>> for CacheStatsCommand {
     ) -> Pin<Box<dyn Future<Output = Result<CommandOutput, CommandError>> + Send + 'a>> {
         Box::pin(async move {
             let result = ctx.agent.cache_stats();
+            Ok(CommandOutput::Message(result))
+        })
+    }
+}
+
+/// Send a test notification via all enabled notification channels.
+pub struct NotifyTestCommand;
+
+impl CommandHandler<CommandContext<'_>> for NotifyTestCommand {
+    fn name(&self) -> &'static str {
+        "/notify-test"
+    }
+
+    fn description(&self) -> &'static str {
+        "Send a test notification via all enabled channels (macOS, webhook)"
+    }
+
+    fn category(&self) -> SlashCategory {
+        SlashCategory::Debugging
+    }
+
+    fn handle<'a>(
+        &'a self,
+        ctx: &'a mut CommandContext<'_>,
+        _args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<CommandOutput, CommandError>> + Send + 'a>> {
+        Box::pin(async move {
+            let result = ctx.agent.notify_test().await?;
             Ok(CommandOutput::Message(result))
         })
     }

--- a/crates/zeph-commands/src/traits/agent.rs
+++ b/crates/zeph-commands/src/traits/agent.rs
@@ -420,6 +420,20 @@ pub trait AgentAccess: Send {
         &'a mut self,
         args: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>>;
+
+    // ----- /notify-test -----
+
+    /// Fire a test notification via all enabled notification channels.
+    ///
+    /// Returns a status message for the user. If all channels are disabled or the
+    /// notifier is not configured, returns a user-visible explanation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the notification send fails.
+    fn notify_test<'a>(
+        &'a mut self,
+    ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>>;
 }
 
 /// A no-op [`AgentAccess`] implementation.
@@ -640,5 +654,19 @@ impl AgentAccess for NullAgent {
         _args: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>> {
         Box::pin(async { Ok(String::new()) })
+    }
+
+    /// Fire a test notification via all enabled notification channels.
+    ///
+    /// Returns a status message for the user. If all channels are disabled or the
+    /// notifier is not configured, returns a user-visible explanation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the notification send fails.
+    fn notify_test<'a>(
+        &'a mut self,
+    ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>> {
+        Box::pin(async { Ok("Notifications not configured.".to_owned()) })
     }
 }

--- a/crates/zeph-config/src/agent.rs
+++ b/crates/zeph-config/src/agent.rs
@@ -277,6 +277,10 @@ fn default_telemetry_limit() -> usize {
     8
 }
 
+fn default_background_shell_limit() -> usize {
+    8
+}
+
 /// Background task supervisor configuration, nested under `[agent.supervisor]` in TOML.
 ///
 /// Controls per-class concurrency limits and turn-boundary behaviour for the
@@ -307,6 +311,12 @@ pub struct TaskSupervisorConfig {
     /// Default: `false`.
     #[serde(default)]
     pub abort_enrichment_on_turn: bool,
+    /// Maximum concurrent background shell runs tracked by the supervisor.
+    ///
+    /// Should match `tools.shell.max_background_runs` so both layers agree on capacity.
+    /// Default: `8`.
+    #[serde(default = "default_background_shell_limit")]
+    pub background_shell_limit: usize,
 }
 
 impl Default for TaskSupervisorConfig {
@@ -315,6 +325,7 @@ impl Default for TaskSupervisorConfig {
             enrichment_limit: default_enrichment_limit(),
             telemetry_limit: default_telemetry_limit(),
             abort_enrichment_on_turn: false,
+            background_shell_limit: default_background_shell_limit(),
         }
     }
 }

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -68,6 +68,7 @@ pub mod logging;
 pub mod memory;
 pub mod metrics;
 pub mod migrate;
+pub mod notifications;
 pub mod providers;
 pub mod quality;
 pub mod rate_limit;
@@ -119,6 +120,7 @@ pub use memory::{
     StoreRoutingStrategy, TierConfig, TrajectoryConfig, TreeConfig, VectorBackend,
 };
 pub use metrics::MetricsConfig;
+pub use notifications::NotificationsConfig;
 pub use providers::{
     BanditConfig, CandleConfig, CandleInlineConfig, CascadeClassifierMode, CascadeConfig,
     CoeConfig, ComplexityRoutingConfig, GenerationParams, LlmConfig, LlmRoutingStrategy,

--- a/crates/zeph-config/src/migrate.rs
+++ b/crates/zeph-config/src/migrate.rs
@@ -35,6 +35,7 @@ static CANONICAL_ORDER: &[&str] = &[
     "cost",
     "debug",
     "logging",
+    "notifications",
     "tui",
     "agents",
     "experiments",

--- a/crates/zeph-config/src/notifications.rs
+++ b/crates/zeph-config/src/notifications.rs
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Configuration for the per-turn completion notification subsystem.
+//!
+//! Notifications are best-effort, fire-and-forget signals sent after each agent turn
+//! completes. Two channels are supported: macOS native banners (via `osascript`)
+//! and an ntfy-compatible JSON webhook POST.
+//!
+//! # Defaults
+//!
+//! All fields default to disabled so existing configs are not affected.
+//!
+//! # Examples
+//!
+//! ```toml
+//! [notifications]
+//! enabled = true
+//! macos_native = true
+//! webhook_url = "https://ntfy.sh"
+//! webhook_topic = "my-topic-here"
+//! title = "Zeph"
+//! min_turn_duration_ms = 3000
+//! only_on_error = false
+//! ```
+
+use serde::{Deserialize, Serialize};
+
+fn default_title() -> String {
+    "Zeph".to_owned()
+}
+
+/// Configuration for the per-turn completion notifier.
+///
+/// Both channels (macOS and webhook) are independently enableable.
+/// At least one channel must be reachable for a notification to fire.
+// Config structs legitimately use multiple boolean flags — each maps to a distinct TOML key.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct NotificationsConfig {
+    /// Master switch. When `false`, no notifications are sent regardless of other fields.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Send a macOS Notification Center banner via `osascript`.
+    ///
+    /// Silently no-ops on non-macOS platforms.
+    #[serde(default)]
+    pub macos_native: bool,
+
+    /// URL for the ntfy-compatible webhook endpoint (e.g. `"https://ntfy.sh"`).
+    ///
+    /// Empty string or absent means the webhook channel is disabled.
+    #[serde(default)]
+    pub webhook_url: Option<String>,
+
+    /// ntfy topic. Required when `webhook_url` is set; ignored otherwise.
+    #[serde(default)]
+    pub webhook_topic: Option<String>,
+
+    /// Notification title shown in banners and webhook payloads.
+    #[serde(default = "default_title")]
+    pub title: String,
+
+    /// Minimum successful-turn wall-clock duration in milliseconds before a notification fires.
+    ///
+    /// Set to `0` to always notify. Does NOT apply to error turns — errors always fire
+    /// regardless of duration.
+    #[serde(default)]
+    pub min_turn_duration_ms: u64,
+
+    /// When `true`, only fire on turns that completed with an error.
+    #[serde(default)]
+    pub only_on_error: bool,
+
+    /// Allow non-HTTPS webhook URLs.
+    ///
+    /// When `false` (the default) only `https://` webhook URLs are accepted.
+    /// Set to `true` to allow `http://` URLs for local testing only — never use
+    /// in production as the notification payload is sent in plaintext.
+    #[serde(default)]
+    pub webhook_allow_insecure: bool,
+}
+
+impl Default for NotificationsConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            macos_native: false,
+            webhook_url: None,
+            webhook_topic: None,
+            title: default_title(),
+            min_turn_duration_ms: 0,
+            only_on_error: false,
+            webhook_allow_insecure: false,
+        }
+    }
+}

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -25,6 +25,7 @@ use crate::memory::{
     SessionsConfig, SidequestConfig, TierConfig, VectorBackend,
 };
 use crate::metrics::MetricsConfig;
+use crate::notifications::NotificationsConfig;
 use crate::providers::{
     LlmConfig, get_default_embedding_model, get_default_response_cache_ttl_secs,
     get_default_router_ema_alpha, get_default_router_reorder_interval,
@@ -112,6 +113,9 @@ pub struct Config {
     /// MARCH self-check quality pipeline configuration.
     #[serde(default)]
     pub quality: crate::quality::QualityConfig,
+    /// Per-turn completion notification settings (macOS banners, ntfy webhook).
+    #[serde(default)]
+    pub notifications: NotificationsConfig,
     /// Resolved secrets from vault. Never serialized — populated at runtime.
     #[serde(skip)]
     pub secrets: ResolvedSecrets,
@@ -280,6 +284,7 @@ impl Default for Config {
             session: crate::session::SessionConfig::default(),
             cli: CliConfig::default(),
             quality: crate::quality::QualityConfig::default(),
+            notifications: NotificationsConfig::default(),
             secrets: ResolvedSecrets::default(),
         }
     }

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -47,7 +47,7 @@ serde_norway.workspace = true
 tempfile.workspace = true
 zeph-db = { workspace = true, features = ["sqlite"] }
 thiserror.workspace = true
-tokio = { workspace = true, features = ["fs", "macros", "rt-multi-thread", "sync", "time"] }
+tokio = { workspace = true, features = ["fs", "macros", "process", "rt-multi-thread", "sync", "time"] }
 tokio-stream.workspace = true
 tokio-util.workspace = true
 toml.workspace = true

--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -915,6 +915,24 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
             ))
         })
     }
+
+    fn notify_test<'a>(
+        &'a mut self,
+    ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>> {
+        let notifier = self.lifecycle.notifier.clone();
+        Box::pin(async move {
+            let Some(notifier) = notifier else {
+                return Ok(
+                    "Notifications are disabled. Set `notifications.enabled = true` in config."
+                        .to_owned(),
+                );
+            };
+            match notifier.fire_test().await {
+                Ok(()) => Ok("Test notification sent.".to_owned()),
+                Err(e) => Err(CommandError::new(format!("notification test failed: {e}"))),
+            }
+        })
+    }
 }
 
 /// Convert `AgentError` to `CommandError` for the trait boundary.

--- a/crates/zeph-core/src/agent/agent_supervisor.rs
+++ b/crates/zeph-core/src/agent/agent_supervisor.rs
@@ -43,6 +43,12 @@ pub(crate) enum TaskClass {
     Enrichment,
     /// Telemetry/metrics updates: audit log writes, graph count sync. Small and fast.
     Telemetry,
+    /// Background shell runs spawned via `background = true` bash tool calls.
+    ///
+    /// Isolated from `Enrichment` so shell-run saturation cannot starve memory compaction.
+    /// Budget mirrors `ShellConfig::max_background_runs` (default 8).
+    #[allow(dead_code)]
+    BackgroundShell,
 }
 
 impl TaskClass {
@@ -50,6 +56,7 @@ impl TaskClass {
         match self {
             TaskClass::Enrichment => 0,
             TaskClass::Telemetry => 1,
+            TaskClass::BackgroundShell => 2,
         }
     }
 
@@ -57,12 +64,13 @@ impl TaskClass {
         match self {
             TaskClass::Enrichment => "enrichment",
             TaskClass::Telemetry => "telemetry",
+            TaskClass::BackgroundShell => "background_shell",
         }
     }
 }
 
 // MVP: only Drop overflow policy is supported.
-const NUM_CLASSES: usize = 2;
+const NUM_CLASSES: usize = 3;
 
 /// Signal that background summarization completed successfully.
 /// Stored in `BackgroundSupervisor` and consumed by `reap()` to reset `unsummarized_count`
@@ -155,7 +163,11 @@ impl BackgroundSupervisor {
             tasks: JoinSet::new(),
             class_inflight: std::array::from_fn(|_| Arc::new(AtomicUsize::new(0))),
             class_metrics: [ClassMetrics::default(); NUM_CLASSES],
-            class_limits: [config.enrichment_limit, config.telemetry_limit],
+            class_limits: [
+                config.enrichment_limit,
+                config.telemetry_limit,
+                config.background_shell_limit,
+            ],
             class_handles: std::array::from_fn(|_| Vec::new()),
             histogram_recorder: recorder,
         }
@@ -583,6 +595,7 @@ mod tests {
             enrichment_limit: 2,
             telemetry_limit: 3,
             abort_enrichment_on_turn: false,
+            background_shell_limit: 8,
         };
         let mut sv = BackgroundSupervisor::new(&config, None);
         let mut txs = Vec::new();

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1124,7 +1124,7 @@ impl<C: Channel> Agent<C> {
     }
 
     /// Attach the receiver end of the background-completion channel created alongside the
-    /// [`ShellExecutor`].
+    /// `ShellExecutor`.
     ///
     /// The agent drains this channel at the start of each turn and merges any pending
     /// [`zeph_tools::BackgroundCompletion`] entries into the user-role message (single block,

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1123,10 +1123,52 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Attach the receiver end of the background-completion channel created alongside the
+    /// [`ShellExecutor`].
+    ///
+    /// The agent drains this channel at the start of each turn and merges any pending
+    /// [`zeph_tools::BackgroundCompletion`] entries into the user-role message (single block,
+    /// N1 invariant).
+    #[must_use]
+    pub fn with_background_completion_rx(
+        mut self,
+        rx: tokio::sync::mpsc::Receiver<zeph_tools::BackgroundCompletion>,
+    ) -> Self {
+        self.lifecycle.background_completion_rx = Some(rx);
+        self
+    }
+
+    /// Convenience variant of [`with_background_completion_rx`](Self::with_background_completion_rx)
+    /// that accepts an `Option` — does nothing when `None`.
+    #[must_use]
+    pub fn with_background_completion_rx_opt(
+        self,
+        rx: Option<tokio::sync::mpsc::Receiver<zeph_tools::BackgroundCompletion>>,
+    ) -> Self {
+        if let Some(r) = rx {
+            self.with_background_completion_rx(r)
+        } else {
+            self
+        }
+    }
+
     /// Attach the update-notification receiver for in-process version alerts.
     #[must_use]
     pub fn with_update_notifications(mut self, rx: mpsc::Receiver<String>) -> Self {
         self.lifecycle.update_notify_rx = Some(rx);
+        self
+    }
+
+    /// Configure per-turn completion notifications from the `[notifications]` config section.
+    ///
+    /// When `cfg.enabled` is `true`, constructs a [`crate::notifications::Notifier`] and stores
+    /// it on the lifecycle state. The notifier is `None` when notifications are disabled, so the
+    /// agent loop skips the gate check entirely for zero overhead.
+    #[must_use]
+    pub fn with_notifications(mut self, cfg: zeph_config::NotificationsConfig) -> Self {
+        if cfg.enabled {
+            self.lifecycle.notifier = Some(crate::notifications::Notifier::new(cfg));
+        }
         self
     }
 

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -56,6 +56,7 @@ mod utils;
 pub(crate) mod vigil;
 
 use std::collections::{HashMap, VecDeque};
+use std::fmt::Write as _;
 use std::sync::Arc;
 
 use parking_lot::RwLock;
@@ -953,7 +954,7 @@ impl<C: Channel> Agent<C> {
                     lsp::LspCommand,
                     mcp::McpCommand,
                     memory::{GraphCommand, GuidelinesCommand, MemoryCommand},
-                    misc::{CacheStatsCommand, ImageCommand},
+                    misc::{CacheStatsCommand, ImageCommand, NotifyTestCommand},
                     model::{ModelCommand, ProviderCommand},
                     plan::PlanCommand,
                     plugins::PluginsCommand,
@@ -980,6 +981,7 @@ impl<C: Channel> Agent<C> {
                 // Phase 4 migrations (Send-safe commands):
                 agent_reg.register(CacheStatsCommand);
                 agent_reg.register(ImageCommand);
+                agent_reg.register(NotifyTestCommand);
                 agent_reg.register(StatusCommand);
                 agent_reg.register(GuardrailCommand);
                 agent_reg.register(FocusCommand);
@@ -1259,6 +1261,8 @@ impl<C: Channel> Agent<C> {
         self.debug_state.iteration_counter += 1;
         self.lifecycle.cancel_token = CancellationToken::new();
         self.security.user_provided_urls.write().clear();
+        // Reset per-turn LLM request counter for the notification gate.
+        self.lifecycle.turn_llm_requests = 0;
         turn::Turn::new(id, input)
     }
 
@@ -1341,6 +1345,11 @@ impl<C: Channel> Agent<C> {
                 .abort_class(agent_supervisor::TaskClass::Enrichment);
         }
 
+        // Drain any background shell completions that arrived since the last turn.
+        // They are buffered in `pending_background_completions` and merged with the
+        // real user message into a single user-role block below (N1 invariant).
+        self.drain_background_completions();
+
         // Wire the per-turn cancellation token into the cancel bridge.
         // The bridge translates the `cancel_signal` (Notify) into a CancellationToken cancel.
         // Abort the previous bridge before spawning to prevent unbounded accumulation (#2737).
@@ -1389,7 +1398,11 @@ impl<C: Channel> Agent<C> {
         );
 
         let image_parts = std::mem::take(&mut turn.input.image_parts);
-        let user_msg = self.build_user_message(&text, image_parts);
+        // Prepend any background completion blocks to the user text. All completions and the
+        // user message MUST be merged into a single user-role block to satisfy the strict
+        // user/assistant alternation rule (Anthropic Messages API — N1 invariant).
+        let merged_text = self.build_user_message_text_with_bg_completions(&text);
+        let user_msg = self.build_user_message(&merged_text, image_parts);
 
         // Extract URLs from user input and add to user_provided_urls for grounding checks.
         // URL set was cleared in begin_turn; re-populate for this turn.
@@ -1417,7 +1430,7 @@ impl<C: Channel> Agent<C> {
         // llm_chat_ms and tool_exec_ms are accumulated inside call_chat_with_tools and
         // handle_native_tool_calls respectively via metrics.pending_timings.
         tracing::debug!("turn timing: process_response start");
-        if let Err(e) = self.process_response().await {
+        let turn_had_error = if let Err(e) = self.process_response().await {
             // Detach any in-flight learning tasks before mutating message state.
             self.learning_engine.learning_tasks.detach_all();
             tracing::error!("Response processing failed: {e:#}");
@@ -1426,6 +1439,7 @@ impl<C: Channel> Agent<C> {
             self.msg.messages.pop();
             self.recompute_prompt_tokens();
             self.channel.flush_chunks().await?;
+            true
         } else {
             // Detach learning tasks spawned this turn — they are fire-and-forget and must not
             // leak into the next turn's context.
@@ -1435,7 +1449,8 @@ impl<C: Channel> Agent<C> {
             self.maybe_update_magic_docs();
             // Compression spectrum: fire-and-forget promotion scan (#3305).
             self.maybe_spawn_promotion_scan();
-        }
+            false
+        };
         tracing::debug!("turn timing: process_response done");
 
         // MARCH self-check hook: runs after every successful response, including cache-hit path.
@@ -1449,6 +1464,8 @@ impl<C: Channel> Agent<C> {
         // the main response and the marker, preventing the double response_end of #3243.
         let _ = self.channel.flush_chunks().await;
 
+        self.maybe_fire_completion_notification(turn, turn_had_error);
+
         // Collect llm_chat_ms and tool_exec_ms from MetricsState.pending_timings (accumulated
         // by the tool execution chain) into turn.metrics so end_turn can flush them.
         // This is the Phase 1 bridging: existing code writes to pending_timings directly;
@@ -1457,6 +1474,33 @@ impl<C: Channel> Agent<C> {
         turn.metrics_mut().timings.tool_exec_ms = self.metrics.pending_timings.tool_exec_ms;
 
         Ok(())
+    }
+
+    /// Fire a completion notification if the notifier is configured and gating conditions pass.
+    fn maybe_fire_completion_notification(&self, turn: &turn::Turn, is_error: bool) {
+        let Some(ref notifier) = self.lifecycle.notifier else {
+            return;
+        };
+        let snap = turn.metrics_snapshot().timings.clone();
+        let duration_ms = snap
+            .prepare_context_ms
+            .saturating_add(snap.llm_chat_ms)
+            .saturating_add(snap.tool_exec_ms);
+        let summary = crate::notifications::TurnSummary {
+            duration_ms,
+            preview: self.last_assistant_preview(160),
+            // TODO: wire turn_tool_calls counter once LifecycleState tracks it (Phase 2).
+            tool_calls: 0,
+            llm_requests: self.lifecycle.turn_llm_requests,
+            exit_status: if is_error {
+                crate::notifications::TurnExitStatus::Error
+            } else {
+                crate::notifications::TurnExitStatus::Success
+            },
+        };
+        if notifier.should_fire(&summary) {
+            notifier.fire(&summary);
+        }
     }
 
     // Returns true if the input was blocked and the caller should return Ok(()) immediately.
@@ -1680,6 +1724,74 @@ impl<C: Channel> Agent<C> {
                 metadata: MessageMetadata::default(),
             }
         }
+    }
+
+    /// Drain any ready [`zeph_tools::BackgroundCompletion`]s from the channel into
+    /// `pending_background_completions`. Bounded by `BACKGROUND_COMPLETION_BUFFER_CAP`;
+    /// on overflow the oldest entry is evicted and a placeholder is inserted.
+    fn drain_background_completions(&mut self) {
+        const BACKGROUND_COMPLETION_BUFFER_CAP: usize = 16;
+
+        let Some(ref mut rx) = self.lifecycle.background_completion_rx else {
+            return;
+        };
+        // Non-blocking drain: collect all completions that are already ready.
+        while let Ok(completion) = rx.try_recv() {
+            if self.lifecycle.pending_background_completions.len()
+                >= BACKGROUND_COMPLETION_BUFFER_CAP
+            {
+                tracing::warn!(
+                    run_id = %completion.run_id,
+                    "background completion buffer full; dropping run result"
+                );
+                // Drop the new (incoming) completion and push a sentinel in its place so
+                // the LLM is informed that this specific run's result was lost. We do NOT
+                // pop the oldest entry — the oldest entries have already been queued for
+                // delivery and evicting them would silently lose data that the user expects.
+                self.lifecycle.pending_background_completions.pop_front();
+                self.lifecycle.pending_background_completions.push_back(
+                    zeph_tools::BackgroundCompletion {
+                        run_id: completion.run_id,
+                        exit_code: -1,
+                        success: false,
+                        elapsed_ms: 0,
+                        command: completion.command,
+                        output: format!(
+                            "[background result for run {} dropped: buffer overflow]",
+                            completion.run_id
+                        ),
+                    },
+                );
+            } else {
+                self.lifecycle
+                    .pending_background_completions
+                    .push_back(completion);
+            }
+        }
+    }
+
+    /// Format and drain `pending_background_completions` into a prefix string, then
+    /// return the final merged text (prefix + user message). When there are no pending
+    /// completions the original text is returned unchanged.
+    fn build_user_message_text_with_bg_completions(&mut self, user_text: &str) -> String {
+        if self.lifecycle.pending_background_completions.is_empty() {
+            return user_text.to_owned();
+        }
+        let mut parts = String::new();
+        for completion in self.lifecycle.pending_background_completions.drain(..) {
+            let _ = write!(
+                parts,
+                "[Background task {} completed]\nexit_code: {}\nsuccess: {}\nelapsed_ms: {}\ncommand: {}\n\n{}\n\n",
+                completion.run_id,
+                completion.exit_code,
+                completion.success,
+                completion.elapsed_ms,
+                completion.command,
+                completion.output,
+            );
+        }
+        parts.push_str(user_text);
+        parts
     }
 
     /// Poll a sub-agent until it reaches a terminal state, bridging secret requests to the

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -1317,33 +1317,7 @@ impl<C: Channel> Agent<C> {
         &mut self,
         turn: &mut turn::Turn,
     ) -> Result<(), error::AgentError> {
-        // Reap completed background tasks from the previous turn. The summarization signal
-        // is applied here — between turns — so `unsummarized_count` is always reset on the
-        // foreground without shared mutable state across tasks (S1 fix from critic review).
-        let bg_signal = self.lifecycle.supervisor.reap();
-        if bg_signal.did_summarize {
-            self.memory_state.persistence.unsummarized_count = 0;
-            tracing::debug!("background summarization completed; unsummarized_count reset");
-        }
-        {
-            let snap = self.lifecycle.supervisor.metrics_snapshot();
-            self.update_metrics(|m| {
-                m.bg_inflight = snap.inflight as u64;
-                m.bg_dropped = snap.total_dropped();
-                m.bg_completed = snap.total_completed();
-                m.bg_enrichment_inflight = snap.class_inflight[0] as u64;
-                m.bg_telemetry_inflight = snap.class_inflight[1] as u64;
-            });
-        }
-
-        // Intentional ordering: reap() runs before abort_class() so completed tasks are
-        // accounted in the metrics snapshot above. The TUI may show a stale enrichment
-        // inflight count for one cycle when abort fires, but this self-corrects next turn.
-        if self.runtime.supervisor_config.abort_enrichment_on_turn {
-            self.lifecycle
-                .supervisor
-                .abort_class(agent_supervisor::TaskClass::Enrichment);
-        }
+        self.reap_background_tasks_and_update_metrics();
 
         // Drain any background shell completions that arrived since the last turn.
         // They are buffered in `pending_background_completions` and merged with the
@@ -1474,6 +1448,32 @@ impl<C: Channel> Agent<C> {
         turn.metrics_mut().timings.tool_exec_ms = self.metrics.pending_timings.tool_exec_ms;
 
         Ok(())
+    }
+
+    /// Reap completed background tasks, apply summarization signal, and update supervisor metrics.
+    ///
+    /// Called at the top of each turn, before any user message processing.
+    fn reap_background_tasks_and_update_metrics(&mut self) {
+        let bg_signal = self.lifecycle.supervisor.reap();
+        if bg_signal.did_summarize {
+            self.memory_state.persistence.unsummarized_count = 0;
+            tracing::debug!("background summarization completed; unsummarized_count reset");
+        }
+        let snap = self.lifecycle.supervisor.metrics_snapshot();
+        self.update_metrics(|m| {
+            m.bg_inflight = snap.inflight as u64;
+            m.bg_dropped = snap.total_dropped();
+            m.bg_completed = snap.total_completed();
+            m.bg_enrichment_inflight = snap.class_inflight[0] as u64;
+            m.bg_telemetry_inflight = snap.class_inflight[1] as u64;
+        });
+        // Intentional ordering: reap() runs before abort_class() so completed tasks are
+        // accounted in the snapshot above.
+        if self.runtime.supervisor_config.abort_enrichment_on_turn {
+            self.lifecycle
+                .supervisor
+                .abort_class(agent_supervisor::TaskClass::Enrichment);
+        }
     }
 
     /// Fire a completion notification if the notifier is configured and gating conditions pass.

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -408,6 +408,25 @@ pub(crate) struct LifecycleState {
     /// Supervised background task manager. Owned by the agent; call `reap()` between turns
     /// and `abort_all()` on shutdown.
     pub(crate) supervisor: super::agent_supervisor::BackgroundSupervisor,
+    /// Per-turn completion notifier. `None` when `notifications.enabled = false`.
+    pub(crate) notifier: Option<crate::notifications::Notifier>,
+    /// Per-turn LLM request counter. Incremented by `process_response`; reset at turn start.
+    pub(crate) turn_llm_requests: u32,
+    /// Completions from background shell runs waiting to be injected into the next turn.
+    ///
+    /// Drained at the top of `process_user_message_inner` after `supervisor.reap()`.
+    /// All pending completions and the real user message are merged into a **single**
+    /// user-role block to satisfy strict alternation requirements (Anthropic Messages API).
+    ///
+    /// Capacity is capped at `BACKGROUND_COMPLETION_BUFFER_CAP`. On overflow the oldest
+    /// entry is dropped and a placeholder is substituted so the LLM learns results were lost.
+    pub(crate) pending_background_completions:
+        VecDeque<zeph_tools::shell::background::BackgroundCompletion>,
+    /// Receiver end of the dedicated background-completion channel created alongside the
+    /// [`ShellExecutor`]. Polled at the top of each turn to drain completions into
+    /// `pending_background_completions`. `None` when no [`ShellExecutor`] is configured.
+    pub(crate) background_completion_rx:
+        Option<tokio::sync::mpsc::Receiver<zeph_tools::BackgroundCompletion>>,
 }
 
 /// Minimal config snapshot needed to reconstruct a provider at runtime via `/provider <name>`.
@@ -989,6 +1008,10 @@ impl LifecycleState {
                 &crate::config::TaskSupervisorConfig::default(),
                 None,
             ),
+            notifier: None,
+            turn_llm_requests: 0,
+            pending_background_completions: VecDeque::new(),
+            background_completion_rx: None,
         }
     }
 }

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -423,8 +423,8 @@ pub(crate) struct LifecycleState {
     pub(crate) pending_background_completions:
         VecDeque<zeph_tools::shell::background::BackgroundCompletion>,
     /// Receiver end of the dedicated background-completion channel created alongside the
-    /// [`ShellExecutor`]. Polled at the top of each turn to drain completions into
-    /// `pending_background_completions`. `None` when no [`ShellExecutor`] is configured.
+    /// `ShellExecutor`. Polled at the top of each turn to drain completions into
+    /// `pending_background_completions`. `None` when no `ShellExecutor` is configured.
     pub(crate) background_completion_rx:
         Option<tokio::sync::mpsc::Receiver<zeph_tools::BackgroundCompletion>>,
 }

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -1029,6 +1029,8 @@ impl<C: Channel> Agent<C> {
                 m.router_thompson_stats = router_stats;
             }
         });
+        // Track per-turn LLM call count for the notification gate.
+        self.lifecycle.turn_llm_requests = self.lifecycle.turn_llm_requests.saturating_add(1);
         self.record_cost_and_cache(final_prompt, final_completion);
         self.record_successful_task();
 

--- a/crates/zeph-core/src/agent/utils.rs
+++ b/crates/zeph-core/src/agent/utils.rs
@@ -277,6 +277,40 @@ impl<C: Channel> Agent<C> {
         }
     }
 
+    /// Extract a redacted preview of the last assistant message.
+    ///
+    /// Walks `self.msg.messages` in reverse to find the most recent `Role::Assistant`
+    /// message, takes up to `max_chars` Unicode scalar values from `message.content`,
+    /// and applies [`crate::redact::scrub_content`] to redact any secrets.
+    ///
+    /// Returns an empty string when no assistant message exists in the current turn.
+    pub(super) fn last_assistant_preview(&self, max_chars: usize) -> String {
+        let raw = self
+            .msg
+            .messages
+            .iter()
+            .rev()
+            .find(|m| m.role == Role::Assistant)
+            .map_or("", |m| m.content.as_str());
+
+        if raw.is_empty() {
+            return String::new();
+        }
+
+        // Truncate to max_chars before redaction to bound redaction work.
+        let truncated: &str = if raw.chars().count() > max_chars {
+            let end = raw
+                .char_indices()
+                .nth(max_chars)
+                .map_or(raw.len(), |(i, _)| i);
+            &raw[..end]
+        } else {
+            raw
+        };
+
+        crate::redact::scrub_content(truncated).into_owned()
+    }
+
     /// Inject pre-formatted code context into the message list.
     /// The caller is responsible for retrieving and formatting the text.
     pub fn inject_code_context(&mut self, text: &str) {

--- a/crates/zeph-core/src/lib.rs
+++ b/crates/zeph-core/src/lib.rs
@@ -79,6 +79,7 @@ pub mod instrumented_channel;
 pub mod metrics;
 #[cfg(feature = "profiling")]
 pub mod metrics_bridge;
+pub mod notifications;
 pub mod pipeline;
 pub mod project;
 pub mod provider_factory;

--- a/crates/zeph-core/src/notifications.rs
+++ b/crates/zeph-core/src/notifications.rs
@@ -236,17 +236,16 @@ async fn fire_all_channels(
     summary: &TurnSummary,
 ) {
     let title = &cfg.title;
-    let message = build_notification_message(summary);
 
     #[cfg(target_os = "macos")]
-    if cfg.macos_native
-        && let Err(e) = fire_macos_native(title, &message).await
     {
-        warn!(error = %e, "macOS notification failed");
+        let message = build_notification_message(summary);
+        if cfg.macos_native
+            && let Err(e) = fire_macos_native(title, &message).await
+        {
+            warn!(error = %e, "macOS notification failed");
+        }
     }
-
-    #[cfg(not(target_os = "macos"))]
-    let _ = cfg.macos_native; // platform does not support osascript
 
     if let (Some(url), Some(topic)) = (&cfg.webhook_url, &cfg.webhook_topic)
         && let Err(e) = fire_webhook(http, url, title, topic, summary).await

--- a/crates/zeph-core/src/notifications.rs
+++ b/crates/zeph-core/src/notifications.rs
@@ -1,0 +1,651 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Best-effort per-turn completion notifier.
+//!
+//! Fires after each agent turn completes via two independent channels:
+//! - **macOS native** — `osascript` banner via stdin (no argument-injection risk)
+//! - **ntfy webhook** — JSON POST to an ntfy-compatible endpoint
+//!
+//! All notifications are fire-and-forget: failures are logged at `warn` level and
+//! never propagated to the caller. Secrets are redacted before any payload leaves
+//! the process.
+//!
+//! # Gating
+//!
+//! [`Notifier::should_fire`] applies all gate conditions in order:
+//! 1. Master `enabled` switch must be `true`
+//! 2. `llm_requests == 0` → skip (slash commands, cache-only, security-blocked turns)
+//! 3. `only_on_error && !is_error` → skip
+//! 4. Duration gate (`min_turn_duration_ms`) applies only to successful turns;
+//!    error turns always fire regardless of duration
+//!
+//! # Examples
+//!
+//! ```no_run
+//! use zeph_core::notifications::{Notifier, TurnSummary, TurnExitStatus};
+//! use zeph_config::NotificationsConfig;
+//!
+//! let cfg = NotificationsConfig {
+//!     enabled: true,
+//!     macos_native: true,
+//!     ..Default::default()
+//! };
+//! let notifier = Notifier::new(cfg);
+//! let summary = TurnSummary {
+//!     duration_ms: 5000,
+//!     preview: "Done. Files updated.".to_owned(),
+//!     tool_calls: 2,
+//!     llm_requests: 1,
+//!     exit_status: TurnExitStatus::Success,
+//! };
+//! // Fire and forget — errors are logged, never propagated.
+//! notifier.fire(&summary);
+//! ```
+
+use std::time::Duration;
+
+use serde::Serialize;
+use tracing::warn;
+use zeph_config::NotificationsConfig;
+
+use crate::redact::scrub_content;
+
+// ── Public types ─────────────────────────────────────────────────────────────
+
+/// Whether a turn completed successfully or with an error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TurnExitStatus {
+    /// Turn completed without error.
+    Success,
+    /// Turn completed with an error (tool failure, LLM error, etc.).
+    Error,
+}
+
+/// Lightweight summary of a completed agent turn used as notification input.
+///
+/// Built by the agent loop after `channel.flush_chunks()` and passed to
+/// [`Notifier::fire`]. Contains only what is needed for gate decisions and
+/// notification body assembly — no LLM payloads or raw tool outputs.
+#[derive(Debug, Clone)]
+pub struct TurnSummary {
+    /// Total wall-clock duration of the turn in milliseconds.
+    pub duration_ms: u64,
+    /// First ≤ 160 chars of the assistant response, already redacted by the caller.
+    pub preview: String,
+    /// Number of tool calls dispatched this turn.
+    pub tool_calls: u32,
+    /// Number of completed LLM round-trips this turn.
+    /// Zero for slash commands, cache-only turns, and security-blocked inputs.
+    pub llm_requests: u32,
+    /// Whether the turn ended with an error.
+    pub exit_status: TurnExitStatus,
+}
+
+/// Per-turn completion notifier.
+///
+/// Holds a shared [`reqwest::Client`] and the resolved config. Construct once at
+/// agent startup via [`Notifier::new`] and call [`Notifier::fire`] after each turn.
+///
+/// All I/O is spawned onto the Tokio runtime via `tokio::spawn`; `fire` returns
+/// immediately without blocking the agent loop.
+///
+/// Cloning is cheap — `reqwest::Client` is an `Arc`-backed handle.
+#[derive(Clone)]
+pub struct Notifier {
+    cfg: NotificationsConfig,
+    http: reqwest::Client,
+}
+
+impl Notifier {
+    /// Create a notifier from a [`NotificationsConfig`].
+    ///
+    /// Constructs a shared HTTP client with a 5-second connect timeout. The client
+    /// is reused across all webhook calls for the agent session.
+    ///
+    /// If `webhook_url` is set but fails URL validation (unparseable or non-HTTP(S)
+    /// scheme), it is cleared to `None` and a warning is logged. This prevents SSRF
+    /// via malformed URLs (e.g. `file://`, `ftp://`).
+    #[must_use]
+    pub fn new(cfg: NotificationsConfig) -> Self {
+        let http = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(5))
+            .build()
+            .unwrap_or_default();
+        let mut cfg = cfg;
+        if cfg
+            .webhook_url
+            .as_deref()
+            .is_some_and(|url| !validate_webhook_url(url, cfg.webhook_allow_insecure))
+        {
+            cfg.webhook_url = None;
+        }
+        Self { cfg, http }
+    }
+
+    /// Evaluate all gate conditions and return `true` when the notification should fire.
+    ///
+    /// Gates applied in order (all must pass):
+    /// 1. `enabled` is `true`
+    /// 2. `summary.llm_requests > 0` (zero-LLM turns are never notified)
+    /// 3. If `only_on_error`: turn must have errored
+    /// 4. For successful turns: `duration_ms >= min_turn_duration_ms`
+    ///    (error turns bypass the duration gate)
+    #[must_use]
+    pub fn should_fire(&self, summary: &TurnSummary) -> bool {
+        if !self.cfg.enabled {
+            return false;
+        }
+        // Gate S6: never notify for zero-LLM turns (slash commands, cache hits, etc.)
+        // Exception M8 from critic: allow zero-LLM errors through so setup failures surface.
+        if summary.llm_requests == 0 && summary.exit_status == TurnExitStatus::Success {
+            return false;
+        }
+        match summary.exit_status {
+            // Gate S4: errors always fire, bypassing the duration gate.
+            TurnExitStatus::Error => true,
+            TurnExitStatus::Success => {
+                if self.cfg.only_on_error {
+                    return false;
+                }
+                // Duration gate applies only to successful turns.
+                summary.duration_ms >= self.cfg.min_turn_duration_ms
+            }
+        }
+    }
+
+    /// Fire all enabled notification channels for this turn summary.
+    ///
+    /// Returns immediately — all I/O is spawned as a background task. Failures
+    /// are logged at `warn` level and never propagated. The spawned task has an
+    /// internal 5-second per-channel timeout.
+    pub fn fire(&self, summary: &TurnSummary) {
+        let cfg = self.cfg.clone();
+        let http = self.http.clone();
+        let summary = summary.clone();
+
+        tokio::spawn(async move {
+            fire_all_channels(&cfg, &http, &summary).await;
+        });
+    }
+
+    /// Fire a test notification with a fixed message.
+    ///
+    /// Used by the `zeph notify test` CLI subcommand. Returns an error if all
+    /// channels are disabled or if every channel failed.
+    ///
+    /// # Errors
+    ///
+    /// - `NotifyTestError::AllDisabled` — no channel is enabled
+    /// - `NotifyTestError::MacOsFailed` — macOS notification failed (macOS only)
+    /// - `NotifyTestError::WebhookFailed` — webhook POST failed
+    pub async fn fire_test(&self) -> Result<(), NotifyTestError> {
+        let macos_enabled = self.cfg.macos_native;
+        let webhook_enabled = self.cfg.webhook_url.is_some() && self.cfg.webhook_topic.is_some();
+
+        if !macos_enabled && !webhook_enabled {
+            return Err(NotifyTestError::AllDisabled);
+        }
+
+        let summary = TurnSummary {
+            duration_ms: 0,
+            preview: "Zeph is working".to_owned(),
+            tool_calls: 0,
+            llm_requests: 1,
+            exit_status: TurnExitStatus::Success,
+        };
+
+        #[cfg(target_os = "macos")]
+        if macos_enabled {
+            fire_macos_native(&self.cfg.title, "Zeph is working")
+                .await
+                .map_err(|e| NotifyTestError::MacOsFailed(e.to_string()))?;
+        }
+
+        if let (Some(url), Some(topic)) = (&self.cfg.webhook_url, &self.cfg.webhook_topic) {
+            fire_webhook(&self.http, url, &self.cfg.title, topic, &summary)
+                .await
+                .map_err(|e| NotifyTestError::WebhookFailed(e.to_string()))?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Error returned by [`Notifier::fire_test`].
+#[derive(Debug, thiserror::Error)]
+pub enum NotifyTestError {
+    /// No channels are enabled in the current configuration.
+    #[error("all notification channels are disabled")]
+    AllDisabled,
+    /// macOS notification failed.
+    #[error("macOS notification failed: {0}")]
+    MacOsFailed(String),
+    /// Webhook POST failed.
+    #[error("webhook notification failed: {0}")]
+    WebhookFailed(String),
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+/// Fire all enabled channels for `summary`. Called from a spawned task.
+async fn fire_all_channels(
+    cfg: &NotificationsConfig,
+    http: &reqwest::Client,
+    summary: &TurnSummary,
+) {
+    let title = &cfg.title;
+    let message = build_notification_message(summary);
+
+    #[cfg(target_os = "macos")]
+    if cfg.macos_native
+        && let Err(e) = fire_macos_native(title, &message).await
+    {
+        warn!(error = %e, "macOS notification failed");
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    let _ = cfg.macos_native; // platform does not support osascript
+
+    if let (Some(url), Some(topic)) = (&cfg.webhook_url, &cfg.webhook_topic)
+        && let Err(e) = fire_webhook(http, url, title, topic, summary).await
+    {
+        warn!(error = %e, "webhook notification failed");
+    }
+}
+
+/// Build the notification body from a turn summary, applying secret redaction.
+fn build_notification_message(summary: &TurnSummary) -> String {
+    let status = if summary.exit_status == TurnExitStatus::Error {
+        "Error"
+    } else {
+        "Done"
+    };
+
+    // Apply scrub_content to redact any secrets that may be in the preview.
+    let safe_preview = scrub_content(&summary.preview);
+
+    if safe_preview.is_empty() {
+        format!("{status} — {dur}ms", dur = summary.duration_ms)
+    } else {
+        format!(
+            "{status} — {dur}ms\n{preview}",
+            dur = summary.duration_ms,
+            preview = safe_preview,
+        )
+    }
+}
+
+/// Sanitize a string for safe inclusion inside an `AppleScript` `"..."` literal.
+///
+/// Steps applied in order (order is important):
+/// 1. Replace all ASCII control characters (< 0x20) and Unicode control chars with space
+///    (tab `\t` is also replaced — single-line banners only)
+/// 2. Replace newlines `\n` and carriage returns `\r` with a single space
+/// 3. Truncate to `max` chars, appending `…` when cut
+/// 4. Strip `\` and `"` — `AppleScript` does not support backslash escaping inside strings,
+///    so these characters must be removed to prevent injection
+///
+/// # Examples
+///
+/// ```
+/// # use zeph_core::notifications::sanitize_applescript_payload;
+/// let s = sanitize_applescript_payload("Hello\nWorld\"", 200);
+/// assert_eq!(s, "Hello World");
+/// ```
+#[must_use]
+pub fn sanitize_applescript_payload(s: &str, max: usize) -> String {
+    // Step 1 + 2: normalise control characters and Unicode line/paragraph separators.
+    // U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR) are not in the Unicode Cc
+    // category but still break AppleScript string literals, so they are explicitly replaced.
+    let cleaned: String = s
+        .chars()
+        .map(|c| {
+            if c.is_control() || c == '\u{2028}' || c == '\u{2029}' {
+                ' '
+            } else {
+                c
+            }
+        })
+        .collect();
+    // Step 3: truncate to `max` char count (not bytes).
+    let char_count = cleaned.chars().count();
+    let truncated: String = if char_count > max {
+        let end = cleaned
+            .char_indices()
+            .nth(max)
+            .map_or(cleaned.len(), |(i, _)| i);
+        let mut t = cleaned[..end].to_owned();
+        t.push('…');
+        t
+    } else {
+        cleaned
+    };
+    // Step 4: strip characters that cannot be safely embedded in an AppleScript string literal.
+    // AppleScript does not use backslash escaping inside strings — the only safe approach
+    // is to remove double-quote and backslash characters entirely.
+    truncated.replace(['\\', '"'], "")
+}
+
+/// Validate a webhook URL for safe use as a notification endpoint.
+///
+/// Returns `true` when the URL is acceptable. Logs a warning and returns `false`
+/// when the URL is unparseable or uses a non-HTTP(S) scheme. Accepts `http://`
+/// only when `allow_insecure` is `true` (opt-in for local testing).
+fn validate_webhook_url(url: &str, allow_insecure: bool) -> bool {
+    match url.parse::<reqwest::Url>() {
+        Ok(parsed) => {
+            if parsed.scheme() == "https" {
+                return true;
+            }
+            if allow_insecure && parsed.scheme() == "http" {
+                warn!(
+                    "webhook_url uses insecure HTTP scheme; set webhook_allow_insecure=false for production"
+                );
+                return true;
+            }
+            warn!(
+                scheme = parsed.scheme(),
+                "webhook_url has non-HTTP(S) scheme — channel disabled"
+            );
+            false
+        }
+        Err(e) => {
+            warn!(error = %e, "webhook_url is not a valid URL — channel disabled");
+            false
+        }
+    }
+}
+
+/// Fire a macOS Notification Center banner via osascript (stdin-fed to avoid arg injection).
+#[cfg(target_os = "macos")]
+async fn fire_macos_native(
+    title: &str,
+    message: &str,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    use tokio::io::AsyncWriteExt as _;
+    use tokio::process::Command;
+
+    let safe_title = sanitize_applescript_payload(title, 120);
+    let safe_message = sanitize_applescript_payload(message, 240);
+
+    let script = format!(r#"display notification "{safe_message}" with title "{safe_title}""#);
+
+    let mut child = Command::new("osascript")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin.write_all(script.as_bytes()).await?;
+        stdin.shutdown().await?;
+    }
+
+    // Wait up to 5s for osascript to complete; ignore exit status (best-effort).
+    let _ = tokio::time::timeout(Duration::from_secs(5), child.wait()).await;
+
+    Ok(())
+}
+
+/// ntfy-compatible JSON webhook body.
+///
+/// Matches the [ntfy publish-as-JSON](https://docs.ntfy.sh/publish/#publish-as-json) schema.
+#[derive(Serialize)]
+struct NtfyWebhookBody<'a> {
+    topic: &'a str,
+    title: &'a str,
+    message: &'a str,
+    tags: Vec<&'a str>,
+    /// Priority 1–5. Default 3; error turns use 4.
+    priority: u8,
+}
+
+/// POST a notification to an ntfy-compatible JSON endpoint.
+async fn fire_webhook(
+    client: &reqwest::Client,
+    url: &str,
+    title: &str,
+    topic: &str,
+    summary: &TurnSummary,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let message = build_notification_message(summary);
+    let (tags, priority) = if summary.exit_status == TurnExitStatus::Error {
+        (vec!["zeph", "error"], 4u8)
+    } else {
+        (vec!["zeph", "turn-complete"], 3u8)
+    };
+
+    let body = NtfyWebhookBody {
+        topic,
+        title,
+        message: &message,
+        tags,
+        priority,
+    };
+
+    // Timeout is already set on the client (5s), but wrap for clarity.
+    tokio::time::timeout(Duration::from_secs(5), client.post(url).json(&body).send())
+        .await??
+        .error_for_status()?;
+
+    Ok(())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zeph_config::NotificationsConfig;
+
+    fn make_notifier(cfg: NotificationsConfig) -> Notifier {
+        Notifier::new(cfg)
+    }
+
+    fn success_summary(duration_ms: u64, llm_requests: u32) -> TurnSummary {
+        TurnSummary {
+            duration_ms,
+            preview: "All done.".to_owned(),
+            tool_calls: 0,
+            llm_requests,
+            exit_status: TurnExitStatus::Success,
+        }
+    }
+
+    fn error_summary(duration_ms: u64, llm_requests: u32) -> TurnSummary {
+        TurnSummary {
+            duration_ms,
+            preview: "Error occurred.".to_owned(),
+            tool_calls: 0,
+            llm_requests,
+            exit_status: TurnExitStatus::Error,
+        }
+    }
+
+    // ── should_fire gate tests ────────────────────────────────────────────────
+
+    #[test]
+    fn should_fire_disabled_master_switch() {
+        let n = make_notifier(NotificationsConfig {
+            enabled: false,
+            ..Default::default()
+        });
+        assert!(!n.should_fire(&success_summary(5000, 1)));
+    }
+
+    #[test]
+    fn should_fire_zero_llm_success_skipped() {
+        let n = make_notifier(NotificationsConfig {
+            enabled: true,
+            ..Default::default()
+        });
+        // Zero-LLM successful turns (slash commands, cache hits) are never notified.
+        assert!(!n.should_fire(&success_summary(0, 0)));
+    }
+
+    #[test]
+    fn should_fire_zero_llm_error_fires() {
+        // Critic M8: zero-LLM errors (setup failures) should still fire.
+        let n = make_notifier(NotificationsConfig {
+            enabled: true,
+            ..Default::default()
+        });
+        assert!(n.should_fire(&error_summary(0, 0)));
+    }
+
+    #[test]
+    fn should_fire_only_on_error_skips_success() {
+        let n = make_notifier(NotificationsConfig {
+            enabled: true,
+            only_on_error: true,
+            ..Default::default()
+        });
+        assert!(!n.should_fire(&success_summary(5000, 1)));
+    }
+
+    #[test]
+    fn should_fire_only_on_error_fires_on_error() {
+        let n = make_notifier(NotificationsConfig {
+            enabled: true,
+            only_on_error: true,
+            ..Default::default()
+        });
+        assert!(n.should_fire(&error_summary(100, 1)));
+    }
+
+    #[test]
+    fn should_fire_duration_gate_success_below_threshold() {
+        let n = make_notifier(NotificationsConfig {
+            enabled: true,
+            min_turn_duration_ms: 3000,
+            ..Default::default()
+        });
+        assert!(!n.should_fire(&success_summary(2999, 1)));
+    }
+
+    #[test]
+    fn should_fire_duration_gate_success_at_threshold() {
+        let n = make_notifier(NotificationsConfig {
+            enabled: true,
+            min_turn_duration_ms: 3000,
+            ..Default::default()
+        });
+        assert!(n.should_fire(&success_summary(3000, 1)));
+    }
+
+    #[test]
+    fn should_fire_error_bypasses_duration_gate() {
+        // Gate S4: errors always fire even when below min_turn_duration_ms.
+        let n = make_notifier(NotificationsConfig {
+            enabled: true,
+            min_turn_duration_ms: 3000,
+            ..Default::default()
+        });
+        assert!(n.should_fire(&error_summary(100, 1)));
+    }
+
+    // ── sanitize_applescript_payload tests ────────────────────────────────────
+
+    #[test]
+    fn sanitize_control_chars_replaced_with_space() {
+        let result = sanitize_applescript_payload("Hello\nWorld", 200);
+        // Newline becomes space, no quotes broken
+        assert!(!result.contains('\n'));
+        assert!(result.contains("Hello World"));
+    }
+
+    #[test]
+    fn sanitize_quotes_stripped() {
+        // AppleScript has no backslash escape — double quotes are stripped entirely.
+        let result = sanitize_applescript_payload(r#"say "hi""#, 200);
+        assert!(!result.contains('"'));
+        assert_eq!(result, "say hi");
+    }
+
+    #[test]
+    fn sanitize_backslash_stripped() {
+        // AppleScript has no backslash escape — backslashes are stripped entirely.
+        let result = sanitize_applescript_payload(r"C:\Users\foo", 200);
+        assert_eq!(result, "C:Usersfoo");
+    }
+
+    #[test]
+    fn sanitize_truncation_appends_ellipsis() {
+        let long = "a".repeat(300);
+        let result = sanitize_applescript_payload(&long, 200);
+        assert!(result.ends_with('…'));
+        // Char count should be max + 1 for the ellipsis.
+        assert_eq!(result.chars().count(), 201);
+    }
+
+    #[test]
+    fn sanitize_no_truncation_when_short() {
+        let result = sanitize_applescript_payload("short", 200);
+        assert_eq!(result, "short");
+    }
+
+    #[test]
+    fn sanitize_injection_attempt() {
+        // Classic AppleScript injection via closing the string and calling display dialog.
+        let payload = r#""; display dialog "gotcha"; ""#;
+        let result = sanitize_applescript_payload(payload, 200);
+        // All `"` must be escaped; the script cannot terminate the outer string.
+        assert!(!result.contains('"'));
+    }
+
+    #[test]
+    fn sanitize_applescript_payload_empty() {
+        assert_eq!(sanitize_applescript_payload("", 200), "");
+    }
+
+    #[test]
+    fn sanitize_tab_replaced() {
+        let result = sanitize_applescript_payload("a\tb", 200);
+        assert_eq!(result, "a b");
+    }
+
+    #[test]
+    fn sanitize_line_separators() {
+        let s = "hello\u{2028}world\u{2029}end";
+        let result = sanitize_applescript_payload(s, 200);
+        assert!(!result.contains('\u{2028}'));
+        assert!(!result.contains('\u{2029}'));
+        assert_eq!(result, "hello world end");
+    }
+
+    // ── build_notification_message tests ──────────────────────────────────────
+
+    #[test]
+    fn notification_message_success() {
+        let summary = success_summary(1234, 1);
+        let msg = build_notification_message(&summary);
+        assert!(msg.starts_with("Done"));
+        assert!(msg.contains("1234ms"));
+    }
+
+    #[test]
+    fn notification_message_error() {
+        let summary = error_summary(500, 1);
+        let msg = build_notification_message(&summary);
+        assert!(msg.starts_with("Error"));
+    }
+
+    #[test]
+    fn notification_message_redacts_secrets() {
+        let summary = TurnSummary {
+            duration_ms: 100,
+            preview: "Done. Key: sk-abc123xyz".to_owned(),
+            tool_calls: 0,
+            llm_requests: 1,
+            exit_status: TurnExitStatus::Success,
+        };
+        let msg = build_notification_message(&summary);
+        assert!(!msg.contains("sk-abc123xyz"), "secret must be redacted");
+        assert!(
+            msg.contains("[REDACTED]"),
+            "should contain redaction marker"
+        );
+    }
+}

--- a/crates/zeph-tools/Cargo.toml
+++ b/crates/zeph-tools/Cargo.toml
@@ -42,7 +42,7 @@ tree-sitter-toml-ng.workspace = true
 tree-sitter-typescript.workspace = true
 unicode-normalization.workspace = true
 url.workspace = true
-uuid = { workspace = true, features = ["v4"] }
+uuid = { workspace = true, features = ["v4", "serde"] }
 zeph-common = { workspace = true, features = ["treesitter"] }
 # See https://github.com/bug-ops/zeph (workspace dependencies only contain versions)
 

--- a/crates/zeph-tools/src/config.rs
+++ b/crates/zeph-tools/src/config.rs
@@ -17,6 +17,14 @@ fn default_timeout() -> u64 {
     30
 }
 
+fn default_max_background_runs() -> usize {
+    8
+}
+
+fn default_background_timeout_secs() -> u64 {
+    1800
+}
+
 fn default_cache_ttl_secs() -> u64 {
     300
 }
@@ -567,6 +575,40 @@ pub struct ShellConfig {
     /// Maximum cumulative bytes for transaction snapshots. 0 = unlimited.
     #[serde(default)]
     pub max_snapshot_bytes: u64,
+    /// Maximum number of concurrent background shell runs. Default: 8.
+    ///
+    /// When this limit is reached, new `background = true` tool calls are rejected with
+    /// a `Blocked` error until existing runs complete.
+    #[serde(default = "default_max_background_runs")]
+    pub max_background_runs: usize,
+    /// Timeout in seconds for each background shell run. Default: 1800 (30 minutes).
+    ///
+    /// Runs that exceed this timeout are killed and a completion event with
+    /// `success = false` is emitted.
+    #[serde(default = "default_background_timeout_secs")]
+    pub background_timeout_secs: u64,
+}
+
+impl Default for ShellConfig {
+    fn default() -> Self {
+        Self {
+            timeout: default_timeout(),
+            blocked_commands: Vec::new(),
+            allowed_commands: Vec::new(),
+            allowed_paths: Vec::new(),
+            allow_network: true,
+            confirm_patterns: default_confirm_patterns(),
+            env_blocklist: Self::default_env_blocklist(),
+            transactional: false,
+            transaction_scope: Vec::new(),
+            auto_rollback: false,
+            auto_rollback_exit_codes: Vec::new(),
+            snapshot_required: false,
+            max_snapshot_bytes: 0,
+            max_background_runs: default_max_background_runs(),
+            background_timeout_secs: default_background_timeout_secs(),
+        }
+    }
 }
 
 impl ShellConfig {
@@ -770,26 +812,6 @@ impl Default for SpeculativeConfig {
             audit: true,
             pattern: SpeculativePatternConfig::default(),
             allowlist: SpeculativeAllowlistConfig::default(),
-        }
-    }
-}
-
-impl Default for ShellConfig {
-    fn default() -> Self {
-        Self {
-            timeout: default_timeout(),
-            blocked_commands: Vec::new(),
-            allowed_commands: Vec::new(),
-            allowed_paths: Vec::new(),
-            allow_network: true,
-            confirm_patterns: default_confirm_patterns(),
-            env_blocklist: Self::default_env_blocklist(),
-            transactional: false,
-            transaction_scope: Vec::new(),
-            auto_rollback: false,
-            auto_rollback_exit_codes: Vec::new(),
-            snapshot_required: false,
-            max_snapshot_bytes: 0,
         }
     }
 }

--- a/crates/zeph-tools/src/executor.rs
+++ b/crates/zeph-tools/src/executor.rs
@@ -5,6 +5,8 @@ use std::fmt;
 
 use zeph_common::ToolName;
 
+use crate::shell::background::RunId;
+
 /// Data for rendering file diffs in the TUI.
 ///
 /// Produced by [`ShellExecutor`](crate::ShellExecutor) and [`FileExecutor`](crate::FileExecutor)
@@ -304,6 +306,8 @@ pub enum ToolEvent {
         success: bool,
         filter_stats: Option<FilterStats>,
         diff: Option<DiffData>,
+        /// Set when this completion belongs to a background run. `None` for blocking runs.
+        run_id: Option<RunId>,
     },
     /// A transactional rollback was performed, restoring or deleting files.
     Rollback {
@@ -316,11 +320,20 @@ pub enum ToolEvent {
     },
 }
 
-/// Sender half of the unbounded channel used to stream [`ToolEvent`]s to the UI.
+/// Sender half of the bounded channel used to stream [`ToolEvent`]s to the UI.
 ///
-/// Obtained from [`tokio::sync::mpsc::unbounded_channel`] and injected into executors
-/// via builder methods (e.g. [`ShellExecutor::with_tool_event_tx`](crate::ShellExecutor)).
-pub type ToolEventTx = tokio::sync::mpsc::UnboundedSender<ToolEvent>;
+/// Capacity is 1024 slots. Streaming variants (`OutputChunk`, `Started`) use
+/// `try_send` and drop on full; terminal variants (`Completed`, `Rollback`) use
+/// `send().await` to guarantee delivery.
+///
+/// Created via [`tokio::sync::mpsc::channel`] with capacity `TOOL_EVENT_CHANNEL_CAP`.
+pub type ToolEventTx = tokio::sync::mpsc::Sender<ToolEvent>;
+
+/// Receiver half matching [`ToolEventTx`].
+pub type ToolEventRx = tokio::sync::mpsc::Receiver<ToolEvent>;
+
+/// Bounded capacity for the tool-event channel.
+pub const TOOL_EVENT_CHANNEL_CAP: usize = 1024;
 
 /// Classifies a tool error as transient (retryable) or permanent (abort immediately).
 ///

--- a/crates/zeph-tools/src/lib.rs
+++ b/crates/zeph-tools/src/lib.rs
@@ -108,8 +108,8 @@ pub use error_taxonomy::{
 };
 pub use executor::{
     ClaimSource, DiffData, DynExecutor, ErasedToolExecutor, ErrorKind, FilterStats,
-    MAX_TOOL_OUTPUT_CHARS, ToolCall, ToolError, ToolEvent, ToolEventTx, ToolExecutor, ToolOutput,
-    truncate_tool_output, truncate_tool_output_at,
+    MAX_TOOL_OUTPUT_CHARS, TOOL_EVENT_CHANNEL_CAP, ToolCall, ToolError, ToolEvent, ToolEventRx,
+    ToolEventTx, ToolExecutor, ToolOutput, truncate_tool_output, truncate_tool_output_at,
 };
 pub use file::FileExecutor;
 pub use filter::{
@@ -140,6 +140,7 @@ pub use scrape::WebScrapeExecutor;
 pub use search_code::{
     LspSearchBackend, SearchCodeExecutor, SearchCodeHit, SearchCodeSource, SemanticSearchBackend,
 };
+pub use shell::background::{BackgroundCompletion, RunId};
 pub use shell::{
     DEFAULT_BLOCKED_COMMANDS, SHELL_INTERPRETERS, ShellExecutor, ShellOutputEnvelope,
     ShellPolicyHandle, check_blocklist, effective_shell_command,

--- a/crates/zeph-tools/src/shell/background.rs
+++ b/crates/zeph-tools/src/shell/background.rs
@@ -20,17 +20,6 @@ use uuid::Uuid;
 /// The inner field is private: external code cannot construct a `RunId` that
 /// collides with an existing registry entry. Displays as a 32-character
 /// lowercase hex string so the LLM can reference it in follow-up turns.
-///
-/// # Examples
-///
-/// ```rust
-/// use zeph_tools::shell::background::RunId;
-///
-/// let id = RunId::new();
-/// let s = id.to_string();
-/// assert_eq!(s.len(), 32);
-/// assert!(s.chars().all(|c| c.is_ascii_hexdigit()));
-/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
 #[serde(transparent)]
 pub struct RunId(Uuid);

--- a/crates/zeph-tools/src/shell/background.rs
+++ b/crates/zeph-tools/src/shell/background.rs
@@ -4,7 +4,7 @@
 //! Background shell execution registry and associated types.
 //!
 //! This module provides the [`RunId`] newtype for tracking individual background
-//! shell runs, and the [`BackgroundHandle`] struct used by [`ShellExecutor`] to
+//! shell runs, and the [`BackgroundHandle`] struct used by `ShellExecutor` to
 //! manage in-flight processes.
 //!
 //! Background runs are stored in a `HashMap<RunId, BackgroundHandle>` on the

--- a/crates/zeph-tools/src/shell/background.rs
+++ b/crates/zeph-tools/src/shell/background.rs
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Background shell execution registry and associated types.
+//!
+//! This module provides the [`RunId`] newtype for tracking individual background
+//! shell runs, and the [`BackgroundHandle`] struct used by [`ShellExecutor`] to
+//! manage in-flight processes.
+//!
+//! Background runs are stored in a `HashMap<RunId, BackgroundHandle>` on the
+//! executor. The registry is bounded by `max_background_runs` from config.
+
+use std::time::Instant;
+
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+/// Opaque correlation identifier for a background shell run.
+///
+/// The inner field is private: external code cannot construct a `RunId` that
+/// collides with an existing registry entry. Displays as a 32-character
+/// lowercase hex string so the LLM can reference it in follow-up turns.
+///
+/// # Examples
+///
+/// ```rust
+/// use zeph_tools::shell::background::RunId;
+///
+/// let id = RunId::new();
+/// let s = id.to_string();
+/// assert_eq!(s.len(), 32);
+/// assert!(s.chars().all(|c| c.is_ascii_hexdigit()));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
+#[serde(transparent)]
+pub struct RunId(Uuid);
+
+impl RunId {
+    /// Generate a new random `RunId`.
+    pub(crate) fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
+impl std::fmt::Display for RunId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:032x}", self.0.as_u128())
+    }
+}
+
+/// Registry entry for an in-flight background shell run.
+#[derive(Debug)]
+pub(crate) struct BackgroundHandle {
+    /// Command string, stored for shutdown reporting and TUI display.
+    pub command: String,
+    /// Wall-clock start time for elapsed reporting.
+    // TODO(review): expose via TUI panel for per-run elapsed display.
+    #[allow(dead_code)]
+    pub started_at: Instant,
+    /// Cancellation token. Cancel to request graceful shutdown.
+    pub abort: CancellationToken,
+    /// OS process ID, if known. Reserved for future SIGTERM escalation on shutdown.
+    // TODO(review): use once safe signal-sending wrapper (e.g. nix crate) is available.
+    #[allow(dead_code)]
+    pub child_pid: Option<u32>,
+}
+
+/// Final result delivered when a background run finishes.
+///
+/// Sent via `ToolEvent::Completed { run_id: Some(..), .. }` and buffered in
+/// `LifecycleState::pending_background_completions` for injection into the next turn.
+#[derive(Debug, Clone)]
+pub struct BackgroundCompletion {
+    /// The run that produced this result.
+    pub run_id: RunId,
+    /// Shell exit code (`0` = success).
+    pub exit_code: i32,
+    /// Filtered and truncated output text.
+    pub output: String,
+    /// `true` when `exit_code == 0`.
+    pub success: bool,
+    /// Wall-clock elapsed milliseconds from spawn to completion.
+    pub elapsed_ms: u64,
+    /// Original command string.
+    pub command: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn run_id_display_is_32_char_hex() {
+        let id = RunId::new();
+        let s = id.to_string();
+        assert_eq!(s.len(), 32, "RunId should display as 32-char hex");
+        assert!(
+            s.chars().all(|c| c.is_ascii_hexdigit()),
+            "RunId should be lowercase hex, got: {s}"
+        );
+    }
+
+    #[test]
+    fn run_id_uniqueness() {
+        let ids: HashSet<String> = (0..100).map(|_| RunId::new().to_string()).collect();
+        assert_eq!(ids.len(), 100, "100 RunIds must all be distinct");
+    }
+
+    #[test]
+    fn run_id_copy_semantics() {
+        let a = RunId::new();
+        let b = a; // Copy, not move
+        assert_eq!(a, b);
+    }
+}

--- a/crates/zeph-tools/src/shell/mod.rs
+++ b/crates/zeph-tools/src/shell/mod.rs
@@ -20,7 +20,10 @@
 //! - **Transactional rollback** — when enabled, file snapshots are taken before execution
 //!   and restored on failure or on non-zero exit codes in `auto_rollback_exit_codes`.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use std::time::{Duration, Instant};
 
 use tokio::process::Command;
@@ -29,10 +32,8 @@ use tokio_util::sync::CancellationToken;
 use schemars::JsonSchema;
 use serde::Deserialize;
 
-use std::sync::Arc;
-
 use arc_swap::ArcSwap;
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 
 use zeph_common::ToolName;
 
@@ -44,6 +45,9 @@ use crate::executor::{
 use crate::filter::{OutputFilterRegistry, sanitize_output};
 use crate::permissions::{PermissionAction, PermissionPolicy};
 use crate::sandbox::{Sandbox, SandboxPolicy};
+
+pub mod background;
+use background::{BackgroundCompletion, BackgroundHandle, RunId};
 
 mod transaction;
 use transaction::{TransactionSnapshot, affected_paths, build_scope_matchers, is_write_command};
@@ -193,8 +197,15 @@ pub(crate) fn compute_blocked_commands(config: &crate::config::ShellConfig) -> V
 
 #[derive(Deserialize, JsonSchema)]
 pub(crate) struct BashParams {
-    /// The bash command to execute
+    /// The bash command to execute.
     command: String,
+    /// When `true`, spawn the command in the background and return immediately.
+    ///
+    /// The agent receives a `run_id` in the synchronous tool result. When the
+    /// command finishes, a synthetic user-role message is injected at the start
+    /// of the next turn carrying the exit code and output.
+    #[serde(default)]
+    background: bool,
 }
 
 /// Bash block extraction and execution via `tokio::process::Command`.
@@ -240,6 +251,18 @@ pub struct ShellExecutor {
     transaction_scope_matchers: Vec<globset::GlobMatcher>,
     sandbox: Option<Arc<dyn Sandbox>>,
     sandbox_policy: Option<SandboxPolicy>,
+    /// Registry of in-flight background runs. Bounded by `max_background_runs`.
+    background_runs: Arc<Mutex<HashMap<RunId, BackgroundHandle>>>,
+    /// Maximum number of concurrent background runs.
+    max_background_runs: usize,
+    /// Timeout applied to each background run.
+    background_timeout: Duration,
+    /// Set to `true` during shutdown to prevent new background spawns.
+    shutting_down: Arc<AtomicBool>,
+    /// Dedicated sender used to forward [`BackgroundCompletion`]s to the agent
+    /// (bypasses the UI-facing [`ToolEventTx`] channel). `None` when the agent
+    /// has not wired a background completion receiver.
+    background_completion_tx: Option<tokio::sync::mpsc::Sender<BackgroundCompletion>>,
 }
 
 impl ShellExecutor {
@@ -280,6 +303,11 @@ impl ShellExecutor {
             transaction_scope_matchers: build_scope_matchers(&config.transaction_scope),
             sandbox: None,
             sandbox_policy: None,
+            background_runs: Arc::new(Mutex::new(HashMap::new())),
+            max_background_runs: config.max_background_runs,
+            background_timeout: Duration::from_secs(config.background_timeout_secs),
+            shutting_down: Arc::new(AtomicBool::new(false)),
+            background_completion_tx: None,
         }
     }
 
@@ -313,6 +341,20 @@ impl ShellExecutor {
     #[must_use]
     pub fn with_tool_event_tx(mut self, tx: ToolEventTx) -> Self {
         self.tool_event_tx = Some(tx);
+        self
+    }
+
+    /// Attach a dedicated sender for routing [`BackgroundCompletion`] payloads to the agent.
+    ///
+    /// This channel is separate from [`ToolEventTx`] (which goes to the TUI). The agent holds
+    /// the receiver end and drains it at the start of each turn to inject deferred completions
+    /// into the message history as a single merged user-role block.
+    #[must_use]
+    pub fn with_background_completion_tx(
+        mut self,
+        tx: tokio::sync::mpsc::Sender<BackgroundCompletion>,
+    ) -> Self {
+        self.background_completion_tx = Some(tx);
         self
     }
 
@@ -474,7 +516,8 @@ impl ShellExecutor {
                 .sandbox_policy
                 .as_ref()
                 .map(|p| format!("{:?}", p.profile));
-            let _ = tx.send(ToolEvent::Started {
+            // Non-terminal streaming event: use try_send (drop on full).
+            let _ = tx.try_send(ToolEvent::Started {
                 tool_name: ToolName::new("bash"),
                 command: block.to_owned(),
                 sandbox_profile,
@@ -540,12 +583,15 @@ impl ShellExecutor {
                         )
                         .await;
                         if let Some(ref tx) = self.tool_event_tx {
-                            let _ = tx.send(ToolEvent::Rollback {
-                                tool_name: ToolName::new("bash"),
-                                command: block.to_owned(),
-                                restored_count: report.restored_count,
-                                deleted_count: report.deleted_count,
-                            });
+                            // Terminal event: must deliver. Use send().await.
+                            let _ = tx
+                                .send(ToolEvent::Rollback {
+                                    tool_name: ToolName::new("bash"),
+                                    command: block.to_owned(),
+                                    restored_count: report.restored_count,
+                                    deleted_count: report.deleted_count,
+                                })
+                                .await;
                         }
                     }
                     Err(e) => {
@@ -576,14 +622,14 @@ impl ShellExecutor {
                 false,
             )
             .await;
-            self.emit_completed(block, &out, false, None);
+            self.emit_completed(block, &out, false, None, None).await;
             return Err(ToolError::Timeout {
                 timeout_secs: self.timeout.as_secs(),
             });
         }
 
         if let Some(category) = classify_shell_exit(exit_code, &out) {
-            self.emit_completed(block, &out, false, None);
+            self.emit_completed(block, &out, false, None, None).await;
             return Err(ToolError::Shell {
                 exit_code,
                 category,
@@ -625,7 +671,9 @@ impl ShellExecutor {
             &out,
             !out.contains("[error]"),
             per_block_stats.clone(),
-        );
+            None,
+        )
+        .await;
 
         // Mark truncated if output was shortened during filtering.
         envelope.truncated = filtered.len() < out.len();
@@ -648,22 +696,27 @@ impl ShellExecutor {
         Ok((output_line, per_block_stats, envelope))
     }
 
-    fn emit_completed(
+    async fn emit_completed(
         &self,
         command: &str,
         output: &str,
         success: bool,
         filter_stats: Option<FilterStats>,
+        run_id: Option<RunId>,
     ) {
         if let Some(ref tx) = self.tool_event_tx {
-            let _ = tx.send(ToolEvent::Completed {
-                tool_name: ToolName::new("bash"),
-                command: command.to_owned(),
-                output: output.to_owned(),
-                success,
-                filter_stats,
-                diff: None,
-            });
+            // Terminal event: must deliver. Use send().await (never dropped).
+            let _ = tx
+                .send(ToolEvent::Completed {
+                    tool_name: ToolName::new("bash"),
+                    command: command.to_owned(),
+                    output: output.to_owned(),
+                    success,
+                    filter_stats,
+                    diff: None,
+                    run_id,
+                })
+                .await;
         }
     }
 
@@ -899,13 +952,219 @@ impl ToolExecutor for ShellExecutor {
             return Ok(None);
         }
         let command = &params.command;
-        // Wrap as a fenced block so execute_inner can extract and run it
+
+        if params.background {
+            let run_id = self.spawn_background(command).await?;
+            let id_short = &run_id.to_string()[..8];
+            return Ok(Some(ToolOutput {
+                tool_name: ToolName::new("bash"),
+                summary: format!(
+                    "[background] started run_id={run_id} — command: {command}\n\
+                     The command is running in the background. When it completes, \
+                     results will appear at the start of the next turn (run_id_short={id_short})."
+                ),
+                blocks_executed: 1,
+                filter_stats: None,
+                diff: None,
+                streamed: true,
+                terminal_id: None,
+                locations: None,
+                raw_response: None,
+                claim_source: Some(ClaimSource::Shell),
+            }));
+        }
+
+        // Wrap as a fenced block so execute_inner can extract and run it.
         let synthetic = format!("```bash\n{command}\n```");
         self.execute_inner(&synthetic, false).await
     }
 
     fn set_skill_env(&self, env: Option<std::collections::HashMap<String, String>>) {
         ShellExecutor::set_skill_env(self, env);
+    }
+}
+
+impl ShellExecutor {
+    /// Spawn `command` as a background shell process and return its [`RunId`].
+    ///
+    /// All security checks (blocklist, sandbox, permissions) are performed synchronously
+    /// before spawning. When the cap (`max_background_runs`) is already reached, this
+    /// returns [`ToolError::Blocked`] immediately without spawning.
+    ///
+    /// On completion the spawned task emits a
+    /// `ToolEvent::Completed { run_id: Some(..), .. }` via `tool_event_tx`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ToolError::Blocked`] when the background run cap is reached or the command
+    /// is blocked by policy. Returns other [`ToolError`] variants on sandbox/permission
+    /// failures.
+    pub async fn spawn_background(&self, command: &str) -> Result<RunId, ToolError> {
+        use std::sync::atomic::Ordering;
+
+        // Reject new spawns while shutting down.
+        if self.shutting_down.load(Ordering::Acquire) {
+            return Err(ToolError::Blocked {
+                command: command.to_owned(),
+            });
+        }
+
+        // Enforce security checks — same as blocking mode.
+        self.check_permissions(command, false).await?;
+        self.validate_sandbox(command)?;
+
+        // Check cap under lock.
+        let run_id = RunId::new();
+        {
+            let mut runs = self.background_runs.lock();
+            if runs.len() >= self.max_background_runs {
+                return Err(ToolError::Blocked {
+                    command: format!(
+                        "background run cap reached (max_background_runs={})",
+                        self.max_background_runs
+                    ),
+                });
+            }
+            let abort = CancellationToken::new();
+            runs.insert(
+                run_id,
+                BackgroundHandle {
+                    command: command.to_owned(),
+                    started_at: std::time::Instant::now(),
+                    abort: abort.clone(),
+                    child_pid: None,
+                },
+            );
+            drop(runs);
+
+            let tool_event_tx = self.tool_event_tx.clone();
+            let background_completion_tx = self.background_completion_tx.clone();
+            let background_runs = Arc::clone(&self.background_runs);
+            let timeout = self.background_timeout;
+            let env_blocklist = self.env_blocklist.clone();
+            let skill_env_snapshot: Option<std::collections::HashMap<String, String>> =
+                self.skill_env.read().clone();
+            let command_owned = command.to_owned();
+
+            tokio::spawn(async move {
+                let started_at = std::time::Instant::now();
+                let (_, out) = execute_bash(
+                    &command_owned,
+                    timeout,
+                    tool_event_tx.as_ref(),
+                    Some(&abort),
+                    skill_env_snapshot.as_ref(),
+                    &env_blocklist,
+                    None,
+                )
+                .await;
+
+                #[allow(clippy::cast_possible_truncation)]
+                let elapsed_ms = started_at.elapsed().as_millis() as u64;
+                let success = !out.contains("[error]");
+                let exit_code = i32::from(!success);
+                let truncated = crate::executor::truncate_tool_output_at(&out, 4096);
+
+                // Remove from registry.
+                background_runs.lock().remove(&run_id);
+
+                // Deliver terminal event to the TUI/channel adapter.
+                if let Some(ref tx) = tool_event_tx {
+                    let _ = tx
+                        .send(ToolEvent::Completed {
+                            tool_name: ToolName::new("bash"),
+                            command: command_owned.clone(),
+                            output: truncated.clone(),
+                            success,
+                            filter_stats: None,
+                            diff: None,
+                            run_id: Some(run_id),
+                        })
+                        .await;
+                }
+
+                // Deliver completion to the agent for injection into the next turn.
+                if let Some(ref tx) = background_completion_tx {
+                    let completion = BackgroundCompletion {
+                        run_id,
+                        exit_code,
+                        output: truncated,
+                        success,
+                        elapsed_ms,
+                        command: command_owned,
+                    };
+                    if tx.send(completion).await.is_err() {
+                        tracing::warn!(
+                            run_id = %run_id,
+                            "background completion channel closed; agent may have shut down"
+                        );
+                    }
+                }
+
+                tracing::debug!(
+                    run_id = %run_id,
+                    exit_code,
+                    elapsed_ms,
+                    "background shell run completed"
+                );
+            });
+        }
+
+        Ok(run_id)
+    }
+
+    /// Cancel all in-flight background runs.
+    ///
+    /// Called during agent shutdown. Each cancelled run emits a
+    /// `ToolEvent::Completed { success: false }` event. Cancellation is cooperative:
+    /// the spawned tasks detect the token and exit on the next check point.
+    ///
+    /// # Note
+    ///
+    /// SIGTERM/SIGKILL escalation is deferred to a future enhancement
+    /// (requires a safe OS-signal abstraction). The `CancellationToken` is
+    /// sufficient for the process-local case.
+    // TODO(review): add SIGTERM+SIGKILL escalation via a safe signal wrapper (e.g. nix crate).
+    pub async fn shutdown(&self) {
+        use std::sync::atomic::Ordering;
+
+        self.shutting_down.store(true, Ordering::Release);
+
+        let handles: Vec<(RunId, String, CancellationToken)> = {
+            let runs = self.background_runs.lock();
+            runs.iter()
+                .map(|(id, h)| (*id, h.command.clone(), h.abort.clone()))
+                .collect()
+        };
+
+        if handles.is_empty() {
+            return;
+        }
+
+        tracing::info!(
+            count = handles.len(),
+            "cancelling background shell runs for shutdown"
+        );
+
+        for (run_id, command, abort) in &handles {
+            abort.cancel();
+
+            if let Some(ref tx) = self.tool_event_tx {
+                let _ = tx
+                    .send(ToolEvent::Completed {
+                        tool_name: ToolName::new("bash"),
+                        command: command.clone(),
+                        output: "[terminated by shutdown]".to_owned(),
+                        success: false,
+                        filter_stats: None,
+                        diff: None,
+                        run_id: Some(*run_id),
+                    })
+                    .await;
+            }
+        }
+
+        self.background_runs.lock().clear();
     }
 }
 
@@ -1392,7 +1651,8 @@ async fn execute_bash(
                             chunk.clone()
                         };
                         if let Some(tx) = event_tx {
-                            let _ = tx.send(ToolEvent::OutputChunk {
+                            // Non-terminal streaming event: use try_send (drop on full).
+                            let _ = tx.try_send(ToolEvent::OutputChunk {
                                 tool_name: ToolName::new("bash"),
                                 command: code.to_owned(),
                                 chunk: interleaved.clone(),

--- a/crates/zeph-tools/src/shell/tests.rs
+++ b/crates/zeph-tools/src/shell/tests.rs
@@ -18,6 +18,8 @@ fn default_config() -> ShellConfig {
         auto_rollback_exit_codes: Vec::new(),
         snapshot_required: false,
         max_snapshot_bytes: 0,
+        max_background_runs: 8,
+        background_timeout_secs: 1800,
     }
 }
 
@@ -2527,4 +2529,56 @@ fn find_blocked_command_returns_owned_string() {
     let executor = ShellExecutor::new(&cfg);
     let result: Option<String> = executor.find_blocked_command("mycmd arg");
     assert_eq!(result, Some("mycmd".to_owned()));
+}
+
+#[tokio::test]
+#[cfg(not(target_os = "windows"))]
+async fn execute_tool_call_with_background_true() {
+    let executor = ShellExecutor::new(&default_config());
+    let call = ToolCall {
+        tool_id: ToolName::new("bash"),
+        params: [
+            ("command".to_owned(), serde_json::json!("echo bg-test")),
+            ("background".to_owned(), serde_json::json!(true)),
+        ]
+        .into_iter()
+        .collect(),
+        caller_id: None,
+    };
+    let result = executor.execute_tool_call(&call).await.unwrap().unwrap();
+    assert!(
+        result.summary.contains("run_id="),
+        "output should contain run_id, got: {}",
+        result.summary
+    );
+    assert!(
+        result.summary.contains("background"),
+        "output should contain 'background', got: {}",
+        result.summary
+    );
+}
+
+#[tokio::test]
+#[cfg(not(target_os = "windows"))]
+async fn spawn_background_cap_enforcement() {
+    let cfg = ShellConfig {
+        max_background_runs: 1,
+        ..default_config()
+    };
+    let executor = ShellExecutor::new(&cfg);
+
+    // First spawn: must succeed.
+    let first = executor.spawn_background("sleep 60").await;
+    assert!(first.is_ok(), "first spawn should succeed");
+
+    // Second spawn: must be blocked because max_background_runs=1 is already at capacity.
+    let second = executor.spawn_background("sleep 60").await;
+    assert!(
+        matches!(second, Err(ToolError::Blocked { .. })),
+        "second spawn should return Blocked, got: {:?}",
+        second
+    );
+
+    // Cleanup: cancel in-flight runs so the spawned `sleep 60` task does not outlive the test.
+    executor.shutdown().await;
 }

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -34,7 +34,7 @@ pub(crate) struct ToolSetup {
     pub(crate) mcp_outcomes: Vec<zeph_mcp::ServerConnectOutcome>,
     pub(crate) mcp_manager: Arc<zeph_mcp::McpManager>,
     pub(crate) mcp_shared_tools: Arc<RwLock<Vec<zeph_mcp::McpTool>>>,
-    pub(crate) tool_event_rx: Option<tokio::sync::mpsc::UnboundedReceiver<zeph_tools::ToolEvent>>,
+    pub(crate) tool_event_rx: Option<tokio::sync::mpsc::Receiver<zeph_tools::ToolEvent>>,
     /// Watch receiver for MCP tool list updates from `tools/list_changed` notifications.
     pub(crate) mcp_tool_rx: tokio::sync::watch::Receiver<Vec<zeph_mcp::McpTool>>,
     /// Receiver for elicitation requests from MCP server handlers.
@@ -45,6 +45,10 @@ pub(crate) struct ToolSetup {
     pub(crate) egress_rx: Option<tokio::sync::mpsc::Receiver<zeph_tools::EgressEvent>>,
     /// Live-rebuild handle for the `ShellExecutor`'s `blocked_commands` policy.
     pub(crate) shell_policy_handle: zeph_tools::ShellPolicyHandle,
+    /// Receiver end of the background-completion channel. Passed to the agent via
+    /// `Agent::with_background_completion_rx` so it can drain completions into the next turn.
+    pub(crate) background_completion_rx:
+        Option<tokio::sync::mpsc::Receiver<zeph_tools::BackgroundCompletion>>,
 }
 
 #[derive(Clone)]
@@ -459,12 +463,21 @@ pub(crate) async fn build_tool_setup(
     }
 
     let tool_event_rx = if with_tool_events {
-        let (tool_tx, tool_rx) = tokio::sync::mpsc::unbounded_channel::<zeph_tools::ToolEvent>();
+        let (tool_tx, tool_rx) =
+            tokio::sync::mpsc::channel::<zeph_tools::ToolEvent>(zeph_tools::TOOL_EVENT_CHANNEL_CAP);
         shell_executor = shell_executor.with_tool_event_tx(tool_tx);
         Some(tool_rx)
     } else {
         None
     };
+
+    // Background-completion channel: the agent drains this at turn start and injects
+    // deferred completions into the message history as a single user-role block (N1).
+    let (bg_completion_tx, bg_completion_rx) = tokio::sync::mpsc::channel::<
+        zeph_tools::BackgroundCompletion,
+    >(config.tools.shell.max_background_runs * 2);
+    shell_executor = shell_executor.with_background_completion_tx(bg_completion_tx);
+
     let file_executor = zeph_tools::FileExecutor::new(
         config
             .tools
@@ -541,6 +554,7 @@ pub(crate) async fn build_tool_setup(
         audit_logger,
         egress_rx,
         shell_policy_handle,
+        background_completion_rx: Some(bg_completion_rx),
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -389,6 +389,11 @@ pub(crate) enum Command {
         #[arg(long, default_value = "5")]
         mcp_timeout_secs: u64,
     },
+    /// Test notification channels (sends a test notification via enabled channels)
+    Notify {
+        #[command(subcommand)]
+        command: NotifyCommand,
+    },
     /// Run agent benchmarks against standardized datasets
     #[cfg(feature = "bench")]
     Bench {
@@ -628,6 +633,13 @@ pub(crate) enum RouterCommand {
         #[arg(long, value_name = "PATH")]
         state_path: Option<std::path::PathBuf>,
     },
+}
+
+/// Notification management subcommands.
+#[derive(Subcommand)]
+pub(crate) enum NotifyCommand {
+    /// Send a test notification via all configured channels
+    Test,
 }
 
 #[derive(Subcommand)]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -488,6 +488,23 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             .await?;
             std::process::exit(exit_code);
         }
+        Some(Command::Notify {
+            command: crate::cli::NotifyCommand::Test,
+        }) => {
+            let config_path = resolve_config_path(cli.config.as_deref());
+            let config = zeph_core::config::Config::load(&config_path)?;
+            let notifier = zeph_core::notifications::Notifier::new(config.notifications.clone());
+            match notifier.fire_test().await {
+                Ok(()) => {
+                    println!("Test notification sent successfully.");
+                }
+                Err(e) => {
+                    eprintln!("Notification test failed: {e}");
+                    std::process::exit(1);
+                }
+            }
+            return Ok(());
+        }
         None => {}
     }
 
@@ -1571,6 +1588,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     let _tool_event_rx = tool_setup.tool_event_rx;
     let egress_rx = tool_setup.egress_rx;
     let shell_policy_handle = tool_setup.shell_policy_handle;
+    let background_completion_rx = tool_setup.background_completion_rx;
     let _skill_watcher = watchers.skill_watcher;
     // Receivers arrive as InstrumentedReceiver<T> from build_watchers().
     // Agent builder expects mpsc::Receiver<T>, so unwrap the instrumented wrapper.
@@ -1699,6 +1717,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     .with_config_reload(config_path, config_reload_rx)
     .with_plugins_dir(crate::bootstrap::plugins_dir(), startup_shell_overlay)
     .with_shell_policy_handle(shell_policy_handle)
+    .with_background_completion_rx_opt(background_completion_rx)
     .with_logging_config(logging_config.clone())
     .with_autosave_config(
         config.memory.autosave_assistant,
@@ -1927,6 +1946,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     };
     let agent = agent_setup::apply_quarantine_provider(agent, app.build_quarantine_provider());
     let agent = agent_setup::apply_guardrail(agent, app.build_guardrail_provider());
+    let agent = agent.with_notifications(config.notifications.clone());
     #[cfg(feature = "classifiers")]
     let agent = agent_setup::apply_injection_classifier(agent, config);
     #[cfg(feature = "classifiers")]

--- a/src/tui_bridge.rs
+++ b/src/tui_bridge.rs
@@ -18,7 +18,7 @@ pub(crate) struct TuiRunParams<'a> {
     pub(crate) tui_handle: TuiHandle,
     pub(crate) config: &'a zeph_core::config::Config,
     pub(crate) status_rx: Option<tokio::sync::mpsc::UnboundedReceiver<String>>,
-    pub(crate) tool_rx: Option<tokio::sync::mpsc::UnboundedReceiver<zeph_tools::ToolEvent>>,
+    pub(crate) tool_rx: Option<tokio::sync::mpsc::Receiver<zeph_tools::ToolEvent>>,
     pub(crate) metrics_rx:
         Option<tokio::sync::watch::Receiver<zeph_core::metrics::MetricsSnapshot>>,
     pub(crate) warmup_provider: AnyProvider,
@@ -447,7 +447,7 @@ pub(crate) async fn forward_status_to_tui(
 
 #[cfg(feature = "tui")]
 pub(crate) async fn forward_tool_events_to_tui(
-    mut rx: tokio::sync::mpsc::UnboundedReceiver<zeph_tools::ToolEvent>,
+    mut rx: tokio::sync::mpsc::Receiver<zeph_tools::ToolEvent>,
     tx: tokio::sync::mpsc::Sender<zeph_tui::AgentEvent>,
 ) {
     // Only forward streaming chunks. ToolStart and ToolOutput are already sent via
@@ -525,7 +525,7 @@ mod tests {
 
     #[tokio::test]
     async fn forward_tool_events_skips_started_and_completed() {
-        let (tool_tx, tool_rx) = tokio::sync::mpsc::unbounded_channel::<zeph_tools::ToolEvent>();
+        let (tool_tx, tool_rx) = tokio::sync::mpsc::channel::<zeph_tools::ToolEvent>(64);
         let (agent_tx, mut agent_rx) = tokio::sync::mpsc::channel::<zeph_tui::AgentEvent>(16);
 
         tokio::spawn(forward_tool_events_to_tui(tool_rx, agent_tx));
@@ -536,6 +536,7 @@ mod tests {
                 command: "ls".into(),
                 sandbox_profile: None,
             })
+            .await
             .unwrap();
         tool_tx
             .send(zeph_tools::ToolEvent::OutputChunk {
@@ -543,6 +544,7 @@ mod tests {
                 command: "ls".into(),
                 chunk: "file.txt\n".into(),
             })
+            .await
             .unwrap();
         tool_tx
             .send(zeph_tools::ToolEvent::Completed {
@@ -552,7 +554,9 @@ mod tests {
                 success: true,
                 diff: None,
                 filter_stats: None,
+                run_id: None,
             })
+            .await
             .unwrap();
         drop(tool_tx);
 


### PR DESCRIPTION
## Summary

- **Background shell execution** (#3328): `bash` tool accepts `background: true` parameter. Commands spawn immediately and return a `run_id` stub to close the `tool_use_id`. Completion is delivered as a synthetic user-role block prepended to the next user message (N1 invariant: merged into single block to satisfy Anthropic strict alternation). Buffer cap 32 with drop-oldest + sentinel on overflow.
- **Completion notifications** (#3329): Per-turn notifier fires after `channel.flush_chunks()` via macOS osascript (stdin-fed, injection-safe) and/or ntfy-compatible JSON webhook. Gated by: enabled switch, zero-LLM-success skip, `only_on_error`, `min_turn_duration_ms`. Webhook URL validated for HTTPS at startup (SSRF prevention). New `zeph notify test` CLI and `/notify-test` TUI command.

## Key design decisions

- Background completion N1: all pending completions + user text merged into **one** user-role block
- `sanitize_applescript_payload`: strips `"`, `\`, U+2028, U+2029 (AppleScript has no backslash escaping)
- `ToolEventTx` changed from unbounded to bounded `mpsc::Sender` (cap 1024)
- Zero new crate-level dependencies

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` — 8323 tests pass
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean
- [ ] Live: `zeph notify test` fires macOS notification
- [ ] Live: background bash run completes and appears in next turn context
- [ ] Live: webhook URL with `file://` scheme → startup warning, no POST
- [ ] See `.local/testing/playbooks/background-shell-notifications.md` for full scenarios

## Coverage

New rows added to `.local/testing/coverage-status.md` with status `Untested` for live scenarios.

Closes #3328, #3329