### PR TITLE
fix(skills,memory): wire SkillEvaluator, ProactiveExplorer, and PromotionEngine in bootstrap

### DIFF
--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1838,6 +1838,26 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Attach a quality-gate evaluator for generated SKILL.md files (#3319).
+    ///
+    /// When set, every `SkillGenerator` used by the agent (including `/skill create`) scores
+    /// generated skills through the critic LLM before writing them to disk. Skills below the
+    /// configured threshold are rejected.
+    ///
+    /// Pass `None` to disable (default).
+    #[must_use]
+    pub fn with_skill_evaluator(
+        mut self,
+        evaluator: Option<std::sync::Arc<zeph_skills::evaluator::SkillEvaluator>>,
+        weights: zeph_skills::evaluator::EvaluationWeights,
+        threshold: f32,
+    ) -> Self {
+        self.skill_state.skill_evaluator = evaluator;
+        self.skill_state.eval_weights = weights;
+        self.skill_state.eval_threshold = threshold;
+        self
+    }
+
     /// Attach a proactive world-knowledge explorer (#3320).
     ///
     /// When set, the agent will classify each incoming query and trigger background skill

--- a/crates/zeph-core/src/agent/learning/skill_commands.rs
+++ b/crates/zeph-core/src/agent/learning/skill_commands.rs
@@ -128,6 +128,15 @@ impl<C: Channel> Agent<C> {
         let generation_provider =
             self.resolve_background_provider(&self.skill_state.generation_provider_name.clone());
         let generator = zeph_skills::SkillGenerator::new(generation_provider, output_dir.clone());
+        let generator = if let Some(ref eval) = self.skill_state.skill_evaluator {
+            generator.with_evaluator(
+                std::sync::Arc::clone(eval),
+                self.skill_state.eval_weights,
+                self.skill_state.eval_threshold,
+            )
+        } else {
+            generator
+        };
         let request = zeph_skills::SkillGenerationRequest {
             description: description.to_owned(),
             category: None,

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -118,6 +118,15 @@ pub(crate) struct SkillState {
     pub(crate) generation_output_dir: Option<std::path::PathBuf>,
     /// Provider name for `/skill create` generation. Empty = primary.
     pub(crate) generation_provider_name: String,
+    /// Optional quality-gate evaluator for generated SKILL.md files (#3319).
+    ///
+    /// When `Some`, the evaluator is attached to every `SkillGenerator` instance so that
+    /// generated skills are scored before being written to disk.
+    pub(crate) skill_evaluator: Option<std::sync::Arc<zeph_skills::evaluator::SkillEvaluator>>,
+    /// Weights for the evaluator composite score — forwarded to `SkillGenerator::with_evaluator`.
+    pub(crate) eval_weights: zeph_skills::evaluator::EvaluationWeights,
+    /// Minimum composite score required to accept a generated skill (forwarded to the generator).
+    pub(crate) eval_threshold: f32,
 }
 
 pub(crate) struct McpState {
@@ -948,6 +957,9 @@ impl SkillState {
             rl_warmup_updates: 50,
             generation_output_dir: None,
             generation_provider_name: String::new(),
+            skill_evaluator: None,
+            eval_weights: zeph_skills::evaluator::EvaluationWeights::default(),
+            eval_threshold: 0.60,
         }
     }
 }

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -1326,6 +1326,113 @@ pub(crate) fn apply_mcp_discovery<C: Channel>(
     agent.with_mcp_discovery(strategy, params, discovery_provider)
 }
 
+/// Wire a [`zeph_skills::proactive::ProactiveExplorer`] onto the agent from config.
+///
+/// Resolves the generation provider, builds the explorer, and calls
+/// [`Agent::with_proactive_explorer`]. Returns the agent unchanged when
+/// `config.skills.proactive_exploration.enabled = false`.
+pub(crate) fn apply_proactive_explorer<C: zeph_core::channel::Channel>(
+    agent: zeph_core::agent::Agent<C>,
+    config: &zeph_core::config::Config,
+    primary: &zeph_llm::any::AnyProvider,
+    evaluator: Option<std::sync::Arc<zeph_skills::evaluator::SkillEvaluator>>,
+    skills_paths: &[std::path::PathBuf],
+) -> zeph_core::agent::Agent<C> {
+    let exp_cfg = &config.skills.proactive_exploration;
+    if !exp_cfg.enabled {
+        return agent;
+    }
+
+    let output_dir = if let Some(ref dir) = exp_cfg.output_dir {
+        std::path::PathBuf::from(dir)
+    } else if let Some(first) = skills_paths.first() {
+        first.join("generated")
+    } else {
+        crate::bootstrap::skills::managed_skills_dir().join("generated")
+    };
+
+    let provider = if exp_cfg.provider.is_empty() {
+        primary.clone()
+    } else {
+        match crate::bootstrap::create_named_provider(&exp_cfg.provider, config) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!(
+                    provider = %exp_cfg.provider,
+                    error = %e,
+                    "proactive exploration provider resolution failed, falling back to primary"
+                );
+                primary.clone()
+            }
+        }
+    };
+
+    let generator = zeph_skills::SkillGenerator::new(provider, output_dir.clone());
+    let explorer = zeph_skills::proactive::ProactiveExplorer::new(
+        generator,
+        evaluator,
+        output_dir,
+        exp_cfg.max_chars,
+        exp_cfg.timeout_ms,
+        exp_cfg.excluded_domains.clone(),
+    );
+    tracing::info!("skills.proactive_exploration: enabled");
+    agent.with_proactive_explorer(Some(std::sync::Arc::new(explorer)))
+}
+
+/// Wire a [`zeph_memory::compression::promotion::PromotionEngine`] onto the agent from config.
+///
+/// Resolves the output directory and skill writer, then calls
+/// [`Agent::with_promotion_engine`]. Returns the agent unchanged when
+/// `config.memory.compression_spectrum.enabled = false` or when no `SkillWriter`
+/// could be built (missing provider or skills paths).
+pub(crate) fn apply_promotion_engine<C: zeph_core::channel::Channel>(
+    agent: zeph_core::agent::Agent<C>,
+    config: &zeph_core::config::Config,
+    primary: &zeph_llm::any::AnyProvider,
+    evaluator: Option<std::sync::Arc<zeph_skills::evaluator::SkillEvaluator>>,
+    eval_weights: zeph_skills::evaluator::EvaluationWeights,
+    eval_threshold: f32,
+    skills_paths: &[std::path::PathBuf],
+) -> zeph_core::agent::Agent<C> {
+    let spectrum_cfg = &config.memory.compression_spectrum;
+    if !spectrum_cfg.enabled {
+        return agent;
+    }
+
+    let output_dir = if let Some(ref dir) = spectrum_cfg.promotion_output_dir {
+        std::path::PathBuf::from(dir)
+    } else if let Some(first) = skills_paths.first() {
+        first.join("promoted")
+    } else {
+        crate::bootstrap::skills::managed_skills_dir().join("promoted")
+    };
+
+    let Some(writer) = crate::bootstrap::skills::build_skill_writer(
+        config,
+        primary,
+        evaluator,
+        eval_weights,
+        eval_threshold,
+        skills_paths,
+    ) else {
+        return agent;
+    };
+
+    let promotion_config = zeph_memory::compression::promotion::PromotionConfig {
+        min_occurrences: spectrum_cfg.min_occurrences,
+        min_sessions: spectrum_cfg.min_sessions,
+        cluster_threshold: spectrum_cfg.cluster_threshold,
+    };
+    let engine = zeph_memory::compression::promotion::PromotionEngine::new(
+        writer,
+        promotion_config,
+        output_dir,
+    );
+    tracing::info!("memory.compression_spectrum: enabled");
+    agent.with_promotion_engine(Some(std::sync::Arc::new(engine)))
+}
+
 /// Build a `SandboxPolicy` from the TOML `[tools.sandbox]` config section.
 pub(crate) fn sandbox_policy_from_config(
     cfg: &zeph_tools::config::SandboxConfig,

--- a/src/bootstrap/skills.rs
+++ b/src/bootstrap/skills.rs
@@ -4,6 +4,8 @@
 pub use zeph_core::provider_factory::effective_embedding_model;
 
 use std::path::PathBuf;
+use std::pin::Pin;
+use std::sync::Arc;
 use zeph_llm::any::AnyProvider;
 use zeph_memory::QdrantOps;
 use zeph_memory::semantic::SemanticMemory;
@@ -105,4 +107,167 @@ pub fn managed_skills_dir() -> PathBuf {
 /// canonical source of truth used by both the CLI and the TUI path in `zeph-core`.
 pub fn plugins_dir() -> PathBuf {
     zeph_plugins::PluginManager::default_plugins_dir()
+}
+
+/// Build a [`zeph_skills::evaluator::SkillEvaluator`] from `[skills.evaluation]` config.
+///
+/// Returns `None` when `config.skills.evaluation.enabled = false`.
+/// On provider resolution failure falls back to `primary` and logs a warning.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// # use zeph_llm::any::AnyProvider;
+/// # use zeph_core::config::Config;
+/// # use std::path::Path;
+/// # let config = Config::load(Path::new("/nonexistent")).unwrap();
+/// # let provider = AnyProvider::Mock(zeph_llm::mock::MockProvider::default());
+/// let evaluator = crate::bootstrap::skills::build_skill_evaluator(&config, &provider);
+/// ```
+pub fn build_skill_evaluator(
+    config: &Config,
+    primary: &AnyProvider,
+) -> Option<Arc<zeph_skills::evaluator::SkillEvaluator>> {
+    let eval_cfg = &config.skills.evaluation;
+    if !eval_cfg.enabled {
+        return None;
+    }
+
+    let critic = if eval_cfg.provider.is_empty() {
+        primary.clone()
+    } else {
+        match crate::bootstrap::create_named_provider(&eval_cfg.provider, config) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!(
+                    provider = %eval_cfg.provider,
+                    error = %e,
+                    "skill evaluator provider resolution failed, falling back to primary"
+                );
+                primary.clone()
+            }
+        }
+    };
+
+    let weights = zeph_skills::evaluator::EvaluationWeights {
+        correctness: eval_cfg.weight_correctness,
+        reusability: eval_cfg.weight_reusability,
+        specificity: eval_cfg.weight_specificity,
+    };
+
+    Some(Arc::new(zeph_skills::evaluator::SkillEvaluator::new(
+        critic,
+        weights,
+        eval_cfg.quality_threshold,
+        eval_cfg.fail_open_on_error,
+        eval_cfg.timeout_ms,
+    )))
+}
+
+/// `SkillWriter` implementation that delegates to a `SkillGenerator`.
+///
+/// Bridges `zeph-memory`'s `SkillWriter` trait (which cannot depend on `zeph-skills`)
+/// to the concrete `SkillGenerator` in `zeph-skills`. Defined in the binary crate to
+/// avoid the circular dependency `zeph-memory` ↔ `zeph-skills`.
+struct GeneratorSkillWriter {
+    /// Provider used to build a fresh `SkillGenerator` per call.
+    provider: AnyProvider,
+    /// Output directory for generated SKILL.md files.
+    output_dir: PathBuf,
+    /// Optional quality gate — forwarded to the generator via `with_evaluator`.
+    evaluator: Option<Arc<zeph_skills::evaluator::SkillEvaluator>>,
+    /// Evaluation weights forwarded to `with_evaluator`.
+    eval_weights: zeph_skills::evaluator::EvaluationWeights,
+    /// Evaluation threshold forwarded to `with_evaluator`.
+    eval_threshold: f32,
+}
+
+impl zeph_memory::compression::promotion::SkillWriter for GeneratorSkillWriter {
+    fn write_skill(
+        &self,
+        description: String,
+        signature: String,
+    ) -> Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send + '_>> {
+        Box::pin(async move {
+            let generator =
+                zeph_skills::SkillGenerator::new(self.provider.clone(), self.output_dir.clone());
+            let generator = if let Some(ref eval) = self.evaluator {
+                generator.with_evaluator(Arc::clone(eval), self.eval_weights, self.eval_threshold)
+            } else {
+                generator
+            };
+
+            let req = zeph_skills::SkillGenerationRequest {
+                description: description.clone(),
+                category: None,
+                allowed_tools: vec![],
+            };
+            let generated = generator.generate(req).await.map_err(|e| e.to_string())?;
+
+            // Use the signature as idempotency key: skip write if skill dir already exists.
+            let skill_dir = self.output_dir.join(format!(
+                "promoted-pattern-{}",
+                &signature[..12.min(signature.len())]
+            ));
+            if skill_dir.exists() {
+                return Ok(());
+            }
+
+            generator
+                .approve_and_save(&generated)
+                .await
+                .map(|_| ())
+                .map_err(|e| e.to_string())
+        })
+    }
+}
+
+/// Build an `Arc<dyn SkillWriter>` backed by a `SkillGenerator`.
+///
+/// Returns `None` when the promotion engine is disabled or the output directory cannot be
+/// determined. On provider resolution failure falls back to `primary`.
+pub fn build_skill_writer(
+    config: &Config,
+    primary: &AnyProvider,
+    evaluator: Option<Arc<zeph_skills::evaluator::SkillEvaluator>>,
+    eval_weights: zeph_skills::evaluator::EvaluationWeights,
+    eval_threshold: f32,
+    skills_paths: &[PathBuf],
+) -> Option<Arc<dyn zeph_memory::compression::promotion::SkillWriter>> {
+    let spectrum_cfg = &config.memory.compression_spectrum;
+    if !spectrum_cfg.enabled {
+        return None;
+    }
+
+    let output_dir = if let Some(ref dir) = spectrum_cfg.promotion_output_dir {
+        PathBuf::from(dir)
+    } else if let Some(first) = skills_paths.first() {
+        first.join("promoted")
+    } else {
+        managed_skills_dir().join("promoted")
+    };
+
+    let provider = if spectrum_cfg.promotion_provider.is_empty() {
+        primary.clone()
+    } else {
+        match crate::bootstrap::create_named_provider(&spectrum_cfg.promotion_provider, config) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!(
+                    provider = %spectrum_cfg.promotion_provider,
+                    error = %e,
+                    "promotion provider resolution failed, falling back to primary"
+                );
+                primary.clone()
+            }
+        }
+    };
+
+    Some(Arc::new(GeneratorSkillWriter {
+        provider,
+        output_dir,
+        evaluator,
+        eval_weights,
+        eval_threshold,
+    }))
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1375,6 +1375,9 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     }
 
     let skill_paths = app.skill_paths_for_registry();
+    // Cloned so the original can be moved into `with_skill_reload` while the copy is used
+    // later for proactive exploration and promotion engine output directory resolution.
+    let skill_paths_for_features = skill_paths.clone();
     let plugin_dirs_supplier = app.plugin_dirs_supplier();
 
     let memory_executor = zeph_core::memory_tools::MemoryToolExecutor::with_validator(
@@ -2004,6 +2007,62 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     let agent = agent.with_hooks_config(&config.hooks);
     let agent = agent.with_channel_skills(channel_skills_config);
     let agent = agent.with_learning(config.skills.learning.clone());
+
+    // Wire SkillEvaluator — enabled in both normal and bare mode (quality gate only).
+    let skill_evaluator = crate::bootstrap::skills::build_skill_evaluator(config, &provider);
+    let (eval_weights, eval_threshold) = if let Some(ref _eval) = skill_evaluator {
+        let eval_cfg = &config.skills.evaluation;
+        (
+            zeph_skills::evaluator::EvaluationWeights {
+                correctness: eval_cfg.weight_correctness,
+                reusability: eval_cfg.weight_reusability,
+                specificity: eval_cfg.weight_specificity,
+            },
+            eval_cfg.quality_threshold,
+        )
+    } else {
+        (
+            zeph_skills::evaluator::EvaluationWeights::default(),
+            0.60_f32,
+        )
+    };
+    if skill_evaluator.is_some() {
+        tracing::info!(
+            threshold = eval_threshold,
+            "skills.evaluation: enabled (threshold={threshold})",
+            threshold = eval_threshold
+        );
+    }
+    let agent = agent.with_skill_evaluator(skill_evaluator.clone(), eval_weights, eval_threshold);
+
+    // Wire ProactiveExplorer — gated on !bare to avoid background tasks in minimal sessions.
+    let agent = if exec_mode.bare {
+        agent
+    } else {
+        agent_setup::apply_proactive_explorer(
+            agent,
+            config,
+            &provider,
+            skill_evaluator.clone(),
+            &skill_paths_for_features,
+        )
+    };
+
+    // Wire PromotionEngine — gated on !bare to avoid background tasks in minimal sessions.
+    let agent = if exec_mode.bare {
+        agent
+    } else {
+        agent_setup::apply_promotion_engine(
+            agent,
+            config,
+            &provider,
+            skill_evaluator,
+            eval_weights,
+            eval_threshold,
+            &skill_paths_for_features,
+        )
+    };
+
     let judge_provider = app.build_judge_provider();
     let agent = if let Some(jp) = judge_provider {
         agent.with_judge_provider(jp)


### PR DESCRIPTION
## Summary

- **SkillEvaluator** — added `skill_evaluator`/`eval_weights`/`eval_threshold` to `SkillState`; added `with_skill_evaluator()` to `AgentBuilder`; evaluator now attached to `SkillGenerator` in `/skill create` flow; `build_skill_evaluator()` in `src/bootstrap/skills.rs` resolves critic provider from config and constructs the evaluator; wired in `runner.rs`
- **ProactiveExplorer** — `apply_proactive_explorer()` added to `agent_setup.rs`; resolves provider and output directory from `config.skills.proactive_exploration`; wired after `with_learning()` in `runner.rs`, gated on `!exec_mode.bare`
- **PromotionEngine** — `GeneratorSkillWriter` implemented in `src/bootstrap/skills.rs` as the `SkillWriter` bridge (avoids circular deps between `zeph-memory` and `zeph-skills`); `apply_promotion_engine()` added to `agent_setup.rs`; wired in `runner.rs`, gated on `!exec_mode.bare`

Each feature logs at INFO when enabled at startup.

## Test plan

- [ ] `cargo build --features full` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — 0 warnings
- [ ] `cargo nextest run --workspace --lib --bins` — 8328 passed
- [ ] Manual: enable all three features in config, verify INFO log lines appear at startup
- [ ] Manual: generate a skill with `[skills.evaluation] enabled = true` — verify evaluator gate applied
- [ ] Manual: send a domain query with `[skills.proactive_exploration] enabled = true` — verify background skill generation triggers
- [ ] Manual: enable `[memory.compression_spectrum]` — verify no startup error and background scan runs

Closes #3355