### PR TITLE
fix(mcp): log tool collisions after OAuth connect and guard bare mode spawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `config/default.toml` `[tools.shell]` section now documents the two background execution
   fields (`max_background_runs`, `background_timeout_secs`) added in #3328 as commented-out
   entries, matching the documented defaults (#3363).
-
+- `connect_oauth_deferred` now collects committed tools and calls `log_tool_collisions` after the
+  drain loop, matching the behavior of `connect_all`. Previously, tool ID collisions introduced via
+  the OAuth path were silently accepted (#3359).
+- OAuth deferred MCP connection is no longer spawned in `--bare` mode. The spawn guard in
+  `runner.rs` now checks `!exec_mode.bare` before calling `connect_oauth_deferred`, preventing
+  live MCP connections from being established when no external services should be contacted (#3358).
 - Wire `ExperienceStore` into the agent tool loop and per-turn evolution sweep (#3318): tool
   outcomes are recorded fire-and-forget via `TaskClass::Telemetry`; evolution sweep runs every N
   user turns; both gates on `memory.graph.experience.enabled` with zero overhead when disabled.

--- a/crates/zeph-mcp/src/manager.rs
+++ b/crates/zeph-mcp/src/manager.rs
@@ -947,6 +947,7 @@ impl McpManager {
 
         // Batch-commit to shared maps in separate guarded blocks — never hold one
         // lock across another .await (same pattern as connect_all).
+        let all_tools: Vec<McpTool> = outputs.iter().flat_map(|o| o.tools.iter().cloned()).collect();
         let mut pending_instructions: Vec<(String, String)> = Vec::new();
         let mut pending_clients: Vec<(String, McpClient)> = Vec::new();
         let mut pending_tools: Vec<(String, Vec<McpTool>)> = Vec::new();
@@ -983,6 +984,7 @@ impl McpManager {
         if !updated.is_empty() {
             let _ = self.tools_watch_tx.send(updated);
         }
+        self.log_tool_collisions(&all_tools).await;
     }
 
     /// Log warnings for all `sanitized_id` collisions in `tools`.

--- a/crates/zeph-mcp/src/manager.rs
+++ b/crates/zeph-mcp/src/manager.rs
@@ -947,7 +947,10 @@ impl McpManager {
 
         // Batch-commit to shared maps in separate guarded blocks — never hold one
         // lock across another .await (same pattern as connect_all).
-        let all_tools: Vec<McpTool> = outputs.iter().flat_map(|o| o.tools.iter().cloned()).collect();
+        let all_tools: Vec<McpTool> = outputs
+            .iter()
+            .flat_map(|o| o.tools.iter().cloned())
+            .collect();
         let mut pending_instructions: Vec<(String, String)> = Vec::new();
         let mut pending_clients: Vec<(String, McpClient)> = Vec::new();
         let mut pending_tools: Vec<(String, Vec<McpTool>)> = Vec::new();

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1059,7 +1059,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     // Spawn deferred OAuth connections now that the UI channel is ready and can
     // display the authorization URL. Non-OAuth tools are already available from
     // connect_all(); OAuth tools arrive via tools_watch_tx when authorized.
-    if tool_setup.mcp_manager.has_oauth_servers() {
+    if !exec_mode.bare && tool_setup.mcp_manager.has_oauth_servers() {
         let mgr = std::sync::Arc::clone(&tool_setup.mcp_manager);
         tokio::spawn(async move {
             mgr.connect_oauth_deferred().await;


### PR DESCRIPTION
## Summary

- `connect_oauth_deferred` now collects committed tools across all OAuth servers and calls `log_tool_collisions` after the drain loop, matching `connect_all` behavior. Previously, tool ID collisions introduced via the OAuth path were silently accepted with non-deterministic dispatch. Closes #3359.
- The OAuth deferred spawn guard in `runner.rs` now checks `!exec_mode.bare` before spawning `connect_oauth_deferred`. Previously a background tokio task established a live MCP connection even in `--bare` mode. Closes #3358.

## Changes

- `crates/zeph-mcp/src/manager.rs`: collect `all_tools` vec during OAuth drain loop; call `log_tool_collisions` before `drop(outcomes)`
- `src/runner.rs`: add `!exec_mode.bare &&` to the OAuth spawn guard

## Test plan

- [x] `cargo +nightly fmt --check` — pass
- [x] `cargo clippy --workspace -- -D warnings` — pass
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 8389 passed, 20 skipped