### PR TITLE
fix(bare,tools): skip file watcher in bare mode; document bg shell config fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `--bare` mode now skips the file change watcher: `with_hooks_config` is no longer called
+  unconditionally in `runner.rs` — it is guarded by `!exec_mode.bare`, preventing background
+  filesystem watch threads from starting in minimal sessions (#3362).
+- `config/default.toml` `[tools.shell]` section now documents the two background execution
+  fields (`max_background_runs`, `background_timeout_secs`) added in #3328 as commented-out
+  entries, matching the documented defaults (#3363).
+
 - Wire `ExperienceStore` into the agent tool loop and per-turn evolution sweep (#3318): tool
   outcomes are recorded fire-and-forget via `TaskClass::Telemetry`; evolution sweep runs every N
   user turns; both gates on `memory.graph.experience.enabled` with zero overhead when disabled.

--- a/config/default.toml
+++ b/config/default.toml
@@ -542,6 +542,10 @@ allowed_paths = []
 allow_network = true
 # Commands that require user confirmation before execution
 confirm_patterns = ["rm ", "git push -f", "git push --force", "drop table", "drop database", "truncate "]
+# Maximum number of concurrent background shell runs (background = true parameter)
+# max_background_runs = 8
+# Timeout for background runs in seconds (30 min default)
+# background_timeout_secs = 1800
 
 # [tools.file]
 # Per-path read sandbox using glob patterns. Evaluation: deny first, then allow overrides.

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2024,7 +2024,11 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     } else {
         agent
     };
-    let agent = agent.with_hooks_config(&config.hooks);
+    let agent = if exec_mode.bare {
+        agent
+    } else {
+        agent.with_hooks_config(&config.hooks)
+    };
     let agent = agent.with_channel_skills(channel_skills_config);
     let agent = agent.with_learning(config.skills.learning.clone());
 


### PR DESCRIPTION
## Summary

- Guard `with_hooks_config` in `src/runner.rs` behind `!exec_mode.bare` — the file change watcher no longer starts during `--bare` sessions, matching the documented behavior of `--help`
- Add commented-out `max_background_runs` and `background_timeout_secs` entries to `config/default.toml` under `[tools.shell]` so `migrate-config` and new users can discover these fields

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 8389 passed, 20 skipped
- [x] Verified `src/runner.rs` diff: bare guard wraps `with_hooks_config` correctly
- [x] Verified `config/default.toml`: new commented entries appear under `[tools.shell]`

Closes #3362
Closes #3363