### PR TITLE
fix(config): add migrate-config step for [memory.reasoning] and correct default.toml

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -1146,10 +1146,11 @@ sweep_batch_size = 100
 # top_k = 3               # strategies injected per turn
 # store_limit = 1000       # max rows in reasoning_strategies table
 # context_budget_tokens = 500
-# extraction_timeout_secs = 10
-# distill_timeout_secs = 10
+# extraction_timeout_secs = 30
+# distill_timeout_secs = 30
 # max_messages = 6
 # min_messages = 2
+# max_message_chars = 2000
 #
 # [learning]
 # feedback_provider = "fast" # SLM: three-class classification

--- a/crates/zeph-config/src/migrate.rs
+++ b/crates/zeph-config/src/migrate.rs
@@ -2527,6 +2527,50 @@ pub fn migrate_memory_retrieval_config(toml_src: &str) -> Result<MigrationResult
     })
 }
 
+/// Add a commented-out `[memory.reasoning]` block if the config lacks it (#3369).
+///
+/// `ReasoningBank` distilled strategy memory was added in v0.19.3 (commit b99b2d30).
+/// All fields have defaults so existing configs parse unchanged; this migration
+/// surfaces the section for discoverability.
+///
+/// # Errors
+///
+/// This function is infallible in practice; the `Result` return type matches the migration
+/// function convention for use in chained pipelines.
+pub fn migrate_memory_reasoning_config(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    if toml_src
+        .lines()
+        .any(|l| l.trim() == "[memory.reasoning]" || l.trim() == "# [memory.reasoning]")
+    {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let comment = "\n# [memory.reasoning] — ReasoningBank: distilled strategy memory (#3369).\n\
+         # [memory.reasoning]\n\
+         # enabled = false\n\
+         # extract_provider = \"\"         # SLM: self-judge (JSON response) — leave blank to use primary\n\
+         # distill_provider = \"\"         # SLM: strategy distillation — leave blank to use primary\n\
+         # top_k = 3                      # strategies injected per turn\n\
+         # store_limit = 1000             # max rows in reasoning_strategies table\n\
+         # context_budget_tokens = 500\n\
+         # extraction_timeout_secs = 30\n\
+         # distill_timeout_secs = 30\n\
+         # max_messages = 6\n\
+         # min_messages = 2\n\
+         # max_message_chars = 2000\n";
+    let output = format!("{toml_src}{comment}");
+
+    Ok(MigrationResult {
+        output,
+        changed_count: 1,
+        sections_changed: vec!["memory.reasoning".to_owned()],
+    })
+}
+
 // Helper to create a formatted value (used in tests).
 #[cfg(test)]
 fn make_formatted_str(s: &str) -> Value {
@@ -3996,5 +4040,31 @@ prompt_cache_ttl = "1h"
             "expected commented message_ids_enabled; got:\n{}",
             out.output
         );
+    }
+
+    // ── migrate_memory_reasoning_config ──────────────────────────────────────
+
+    #[test]
+    fn migrate_memory_reasoning_adds_block_when_absent() {
+        let input = "[agent]\nmodel = \"gpt-4o\"\n";
+        let result = migrate_memory_reasoning_config(input).unwrap();
+        assert_eq!(result.changed_count, 1);
+        assert!(
+            result
+                .sections_changed
+                .contains(&"memory.reasoning".to_owned())
+        );
+        assert!(result.output.contains("# [memory.reasoning]"));
+        assert!(result.output.contains("extraction_timeout_secs = 30"));
+        assert!(result.output.contains("max_message_chars = 2000"));
+    }
+
+    #[test]
+    fn migrate_memory_reasoning_idempotent_on_existing_block() {
+        let input = "[agent]\nmodel = \"gpt-4o\"\n# [memory.reasoning]\n# enabled = false\n";
+        let result = migrate_memory_reasoning_config(input).unwrap();
+        assert_eq!(result.changed_count, 0);
+        assert!(result.sections_changed.is_empty());
+        assert_eq!(result.output, input);
     }
 }

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -10,7 +10,7 @@ use zeph_core::config::migrate::{
     migrate_compression_predictor_config, migrate_database_url, migrate_egress_config,
     migrate_forgetting_config, migrate_hooks_permission_denied_config, migrate_magic_docs_config,
     migrate_mcp_elicitation_config, migrate_mcp_trust_levels, migrate_memory_graph_config,
-    migrate_memory_retrieval_config, migrate_microcompact_config,
+    migrate_memory_reasoning_config, migrate_memory_retrieval_config, migrate_microcompact_config,
     migrate_orchestration_persistence, migrate_otel_filter, migrate_planner_model_to_provider,
     migrate_quality_config, migrate_sandbox_config, migrate_sandbox_egress_filter,
     migrate_scheduler_daemon_config, migrate_session_recap_config, migrate_shell_transactional,
@@ -149,9 +149,13 @@ pub(crate) fn handle_migrate_config(
     let memory_retrieval_result = migrate_memory_retrieval_config(&after_scheduler_daemon)?;
     let after_memory_retrieval = memory_retrieval_result.output;
 
-    // Step 29: add missing default keys as commented-out entries.
+    // Step 29: add commented-out [memory.reasoning] block if absent (#3369).
+    let memory_reasoning_result = migrate_memory_reasoning_config(&after_memory_retrieval)?;
+    let after_memory_reasoning = memory_reasoning_result.output;
+
+    // Step 30: add missing default keys as commented-out entries.
     let migrator = ConfigMigrator::new();
-    let result = migrator.migrate(&after_memory_retrieval)?;
+    let result = migrator.migrate(&after_memory_reasoning)?;
 
     if diff {
         print_diff(&input, &result.output);


### PR DESCRIPTION
## Summary

- Add `migrate_memory_reasoning_config` (Step 29) in `crates/zeph-config/src/migrate.rs`, wired after the `memory.retrieval` step. Upgrades from pre-v0.19.3 configs now receive a commented-out `[memory.reasoning]` block via `--migrate-config`.
- Fix `config/default.toml`: `extraction_timeout_secs` and `distill_timeout_secs` corrected from `10` to `30` (matching `ReasoningConfig::default()`); add missing `max_message_chars = 2000`.

## Test plan

- [ ] `cargo nextest run -p zeph-config -E 'test(migrate_memory_reasoning)'` — 2 new tests pass
- [ ] `cargo nextest run --workspace --lib --bins` — 8391 tests pass (0 failures)
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] Run `--migrate-config --diff` on a pre-0.19.3 config and confirm `[memory.reasoning]` block appears in diff output

Closes #3369, closes #3370.