### PR TITLE
fix(core): add context-prep timeout and NoProviders backoff to agent loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - OAuth deferred MCP connection is no longer spawned in `--bare` mode. The spawn guard in
   `runner.rs` now checks `!exec_mode.bare` before calling `connect_oauth_deferred`, preventing
   live MCP connections from being established when no external services should be contacted (#3358).
+- Agent no longer stalls for 14+ seconds when embed providers are rate-limited or unavailable
+  during context preparation (#3357). `advance_context_lifecycle` is now wrapped with a
+  configurable wall-clock timeout (`[timeouts] context_prep_timeout_secs`, default 30 s);
+  the turn proceeds with a degraded (cached) context when it expires instead of blocking.
+- Prevent busy-wait loop when all LLM backends return `no providers available` (#3357).
+  After a `NoProviders` error the agent records the failure timestamp and sleeps for
+  `[timeouts] no_providers_backoff_secs` (default 2 s) before returning the error to the
+  channel. On the next turn, context preparation is skipped if providers are still within
+  the backoff window, avoiding a full re-run of memory recall / embedding against known-down
+  backends.
+- Background indexer chunk tasks no longer compete with the agent's async worker threads
+  (#3357). `spawn_blocking_named` through `TaskSupervisor` was wrapping each chunk task in
+  an async `tokio::spawn` semaphore-waiter, flooding the async thread pool for large repos.
+  The indexer now falls back to plain `tokio::task::spawn_blocking`, routing CPU-heavy
+  chunk work to the dedicated blocking thread pool.
 - Wire `ExperienceStore` into the agent tool loop and per-turn evolution sweep (#3318): tool
   outcomes are recorded fire-and-forget via `TaskClass::Telemetry`; evolution sweep runs every N
   user turns; both gates on `memory.graph.experience.enabled` with zero overhead when disabled.

--- a/crates/zeph-config/src/security.rs
+++ b/crates/zeph-config/src/security.rs
@@ -80,6 +80,14 @@ fn default_llm_request_timeout() -> u64 {
     600
 }
 
+fn default_context_prep_timeout() -> u64 {
+    30
+}
+
+fn default_no_providers_backoff_secs() -> u64 {
+    2
+}
+
 /// Skill trust policy configuration, nested under `[skills.trust]` in TOML.
 ///
 /// Controls how trust levels are assigned to skills at load time based on their
@@ -245,6 +253,19 @@ pub struct TimeoutConfig {
     /// Default: `8`.
     #[serde(default = "default_max_parallel_tools")]
     pub max_parallel_tools: usize,
+    /// Maximum wall-clock time (seconds) allowed for `advance_context_lifecycle` (memory recall,
+    /// graph retrieval, proactive compression, context assembly) before it is aborted and the
+    /// agent proceeds with a degraded (cached) context.
+    ///
+    /// Setting this too low may skip useful memory recall; setting it too high blocks the agent
+    /// when embed providers are rate-limited or unavailable. Default: `30`.
+    #[serde(default = "default_context_prep_timeout")]
+    pub context_prep_timeout_secs: u64,
+    /// How long to wait (seconds) before retrying a turn after the previous turn ended with
+    /// `no providers available`. Prevents a busy-wait loop when all LLM backends are down.
+    /// Default: `2`.
+    #[serde(default = "default_no_providers_backoff_secs")]
+    pub no_providers_backoff_secs: u64,
 }
 
 impl Default for TimeoutConfig {
@@ -255,6 +276,8 @@ impl Default for TimeoutConfig {
             embedding_seconds: default_embedding_timeout(),
             a2a_seconds: default_a2a_timeout(),
             max_parallel_tools: default_max_parallel_tools(),
+            context_prep_timeout_secs: default_context_prep_timeout(),
+            no_providers_backoff_secs: default_no_providers_backoff_secs(),
         }
     }
 }
@@ -349,5 +372,46 @@ hash_mismatch_level = "quarantined"
         let config: TrustConfig = toml::from_str(toml).expect("deserialize");
         assert!(config.scanner.injection_patterns);
         assert!(!config.scanner.capability_escalation_check);
+    }
+
+    // ------------------------------------------------------------------
+    // TimeoutConfig — new fields added in #3357
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn timeout_config_context_prep_timeout_default() {
+        let cfg = TimeoutConfig::default();
+        assert_eq!(
+            cfg.context_prep_timeout_secs, 30,
+            "context_prep_timeout_secs default must be 30s (#3357)"
+        );
+    }
+
+    #[test]
+    fn timeout_config_no_providers_backoff_default() {
+        let cfg = TimeoutConfig::default();
+        assert_eq!(
+            cfg.no_providers_backoff_secs, 2,
+            "no_providers_backoff_secs default must be 2s (#3357)"
+        );
+    }
+
+    #[test]
+    fn timeout_config_new_fields_deserialize_from_toml() {
+        let toml = r#"
+context_prep_timeout_secs = 60
+no_providers_backoff_secs = 10
+"#;
+        let cfg: TimeoutConfig = toml::from_str(toml).expect("deserialize");
+        assert_eq!(cfg.context_prep_timeout_secs, 60);
+        assert_eq!(cfg.no_providers_backoff_secs, 10);
+    }
+
+    #[test]
+    fn timeout_config_new_fields_default_when_missing_from_toml() {
+        // An empty TOML section must produce the same values as TimeoutConfig::default().
+        let cfg: TimeoutConfig = toml::from_str("").expect("deserialize empty");
+        assert_eq!(cfg.context_prep_timeout_secs, 30);
+        assert_eq!(cfg.no_providers_backoff_secs, 2);
     }
 }

--- a/crates/zeph-core/src/agent/error.rs
+++ b/crates/zeph-core/src/agent/error.rs
@@ -59,6 +59,12 @@ impl AgentError {
         }
         false
     }
+
+    /// Returns true if this error is `LlmError::NoProviders` (all configured backends unavailable).
+    #[must_use]
+    pub fn is_no_providers(&self) -> bool {
+        matches!(self, Self::Llm(zeph_llm::LlmError::NoProviders))
+    }
 }
 
 #[cfg(test)]
@@ -121,5 +127,17 @@ mod tests {
     fn agent_error_non_llm_variant_not_beta_rejected() {
         let e = AgentError::Other("something went wrong".into());
         assert!(!e.is_beta_header_rejected());
+    }
+
+    #[test]
+    fn agent_error_detects_no_providers() {
+        let e = AgentError::Llm(zeph_llm::LlmError::NoProviders);
+        assert!(e.is_no_providers());
+    }
+
+    #[test]
+    fn agent_error_non_no_providers_returns_false() {
+        let e = AgentError::Other("other".into());
+        assert!(!e.is_no_providers());
     }
 }

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -1363,7 +1363,7 @@ impl<C: Channel> Agent<C> {
 
         let t_ctx = std::time::Instant::now();
         tracing::debug!("turn timing: prepare_context start");
-        self.advance_context_lifecycle(&text, trimmed).await;
+        self.advance_context_lifecycle_guarded(&text, trimmed).await;
         turn.metrics_mut().timings.prepare_context_ms =
             u64::try_from(t_ctx.elapsed().as_millis()).unwrap_or(u64::MAX);
         tracing::debug!(
@@ -1408,6 +1408,19 @@ impl<C: Channel> Agent<C> {
             // Detach any in-flight learning tasks before mutating message state.
             self.learning_engine.learning_tasks.detach_all();
             tracing::error!("Response processing failed: {e:#}");
+
+            // Record provider failure timestamp so the next turn can skip
+            // expensive context preparation while providers are known-down.
+            if e.is_no_providers() {
+                self.lifecycle.last_no_providers_at = Some(std::time::Instant::now());
+                let backoff_secs = self.runtime.timeouts.no_providers_backoff_secs;
+                tracing::warn!(
+                    backoff_secs,
+                    "no providers available; backing off before next turn"
+                );
+                tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)).await;
+            }
+
             let user_msg = format!("Error: {e:#}");
             self.channel.send(&user_msg).await?;
             self.msg.messages.pop();
@@ -1573,6 +1586,43 @@ impl<C: Channel> Agent<C> {
         self.push_classifier_metrics();
 
         Ok(false)
+    }
+
+    /// Run `advance_context_lifecycle` with provider-health gating and a wall-clock timeout.
+    ///
+    /// Skips context preparation entirely when providers failed on the previous turn and the
+    /// `no_providers_backoff_secs` window has not yet elapsed. When providers are available,
+    /// wraps the call with `context_prep_timeout_secs` to prevent a stall when embed backends
+    /// are rate-limited or unavailable (#3357).
+    async fn advance_context_lifecycle_guarded(&mut self, text: &str, trimmed: &str) {
+        let backoff_secs = self.runtime.timeouts.no_providers_backoff_secs;
+        let prep_timeout_secs = self.runtime.timeouts.context_prep_timeout_secs;
+
+        // Skip expensive memory recall / embedding when providers are known-down.
+        let providers_recently_failed = self
+            .lifecycle
+            .last_no_providers_at
+            .is_some_and(|t| t.elapsed().as_secs() < backoff_secs);
+
+        if providers_recently_failed {
+            tracing::warn!(
+                backoff_secs,
+                "skipping context preparation: providers were unavailable on last turn"
+            );
+            return;
+        }
+
+        let timeout_dur = std::time::Duration::from_secs(prep_timeout_secs);
+        match tokio::time::timeout(timeout_dur, self.advance_context_lifecycle(text, trimmed)).await
+        {
+            Ok(()) => {}
+            Err(_elapsed) => {
+                tracing::warn!(
+                    timeout_secs = prep_timeout_secs,
+                    "context preparation timed out; proceeding with degraded context"
+                );
+            }
+        }
     }
 
     #[cfg_attr(

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -412,6 +412,11 @@ pub(crate) struct LifecycleState {
     pub(crate) notifier: Option<crate::notifications::Notifier>,
     /// Per-turn LLM request counter. Incremented by `process_response`; reset at turn start.
     pub(crate) turn_llm_requests: u32,
+    /// Timestamp of the last turn that ended with `LlmError::NoProviders`.
+    ///
+    /// Used to gate `advance_context_lifecycle`: when all providers are down, context preparation
+    /// is skipped (degraded mode) until `no_providers_backoff_secs` has elapsed.
+    pub(crate) last_no_providers_at: Option<Instant>,
     /// Completions from background shell runs waiting to be injected into the next turn.
     ///
     /// Drained at the top of `process_user_message_inner` after `supervisor.reap()`.
@@ -1010,6 +1015,7 @@ impl LifecycleState {
             ),
             notifier: None,
             turn_llm_requests: 0,
+            last_no_providers_at: None,
             pending_background_completions: VecDeque::new(),
             background_completion_rx: None,
         }

--- a/crates/zeph-core/src/agent/state/tests.rs
+++ b/crates/zeph-core/src/agent/state/tests.rs
@@ -205,6 +205,56 @@ fn feedback_state_detector_returns_none_for_neutral_input() {
 }
 
 // ------------------------------------------------------------------
+// LifecycleState — no_providers backoff field added in #3357
+// ------------------------------------------------------------------
+
+#[test]
+fn lifecycle_state_last_no_providers_at_starts_none() {
+    use crate::agent::state::LifecycleState;
+    let state = LifecycleState::new();
+    assert!(
+        state.last_no_providers_at.is_none(),
+        "last_no_providers_at must be None at startup — backoff is inactive until a NoProviders error occurs (#3357)"
+    );
+}
+
+#[test]
+fn lifecycle_state_last_no_providers_at_elapsed_check() {
+    use std::time::{Duration, Instant};
+    // Simulate the backoff gate logic used in advance_context_lifecycle_guarded.
+    // When last_no_providers_at was set very recently, providers_recently_failed must be true.
+    let backoff_secs = 2u64;
+    let last_no_providers_at: Option<Instant> = Some(Instant::now());
+    let providers_recently_failed =
+        last_no_providers_at.is_some_and(|t| t.elapsed().as_secs() < backoff_secs);
+    assert!(
+        providers_recently_failed,
+        "a just-set last_no_providers_at must trigger the backoff gate"
+    );
+
+    // When last_no_providers_at is old enough, the gate must be open.
+    let old_instant = Instant::now() - Duration::from_secs(backoff_secs + 1);
+    let old_no_providers: Option<Instant> = Some(old_instant);
+    let gate_open = !old_no_providers.is_some_and(|t| t.elapsed().as_secs() < backoff_secs);
+    assert!(
+        gate_open,
+        "an expired last_no_providers_at must not block context preparation"
+    );
+}
+
+#[test]
+fn lifecycle_state_last_no_providers_at_none_means_gate_open() {
+    let backoff_secs = 2u64;
+    let last_no_providers_at: Option<std::time::Instant> = None;
+    let providers_recently_failed =
+        last_no_providers_at.is_some_and(|t| t.elapsed().as_secs() < backoff_secs);
+    assert!(
+        !providers_recently_failed,
+        "None last_no_providers_at must not trigger the backoff gate"
+    );
+}
+
+// ------------------------------------------------------------------
 // CompressionState (context-compression feature gate)
 // ------------------------------------------------------------------
 #[test]

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -933,12 +933,15 @@ pub(crate) async fn apply_code_indexer(
                 ..IndexerConfig::default()
             },
         );
-        let base_indexer = if let Some(ref sup) = supervisor {
-            base_indexer.with_spawner(std::sync::Arc::new(sup.clone())
-                as std::sync::Arc<dyn zeph_common::BlockingSpawner>)
-        } else {
-            base_indexer
-        };
+        // NOTE: intentionally NOT attaching the TaskSupervisor as BlockingSpawner for the
+        // indexer's per-file chunk tasks. The supervisor's `spawn_blocking_named` wraps each
+        // blocking task in a `tokio::spawn(async { semaphore.acquire().await; ... })` — with
+        // 971+ files this queues up hundreds of async tasks competing with the agent turn
+        // for tokio worker threads (#3357).
+        // Plain `tokio::task::spawn_blocking` (the fallback when spawner = None) routes
+        // CPU-heavy chunk work to the dedicated blocking thread pool, keeping async workers free.
+        // TODO(review): re-enable via a lightweight atomic counter rather than BlockingSpawner
+        // once the dependency cycle is resolved (#2961).
         let indexer = std::sync::Arc::new(base_indexer);
         anyhow::Ok(indexer)
     };


### PR DESCRIPTION
## Summary

- Add `advance_context_lifecycle_guarded`: wraps context preparation with `tokio::time::timeout` (default 30 s, configurable via `[timeouts] context_prep_timeout_secs`) to prevent 14+ second stalls when embed backends are rate-limited or unavailable
- Add NoProviders backoff: after a `NoProviders` error, record the failure timestamp, sleep `no_providers_backoff_secs` (default 2 s), and skip context prep on the next turn while still within the backoff window
- Add `AgentError::is_no_providers()` predicate used by the backoff guard
- Remove `TaskSupervisor` `BlockingSpawner` attachment from `CodeIndexer` in `agent_setup.rs` to prevent flooding the async worker pool with 971+ concurrent chunk tasks during active agent turns

## Root Cause (from investigation)

The "150+/s agent.turn" and "128-call prepare_context burst" reported in #3357 were async tracing artifacts (`#[tracing::instrument]` emits B/E events at every tokio poll boundary). The real issue was a single turn stalling for 14 seconds in `advance_context_lifecycle` due to 1006 embed calls against rate-limited/unavailable providers, compounded by 971 concurrent background indexer tasks saturating the tokio worker pool.

## Test plan

- [ ] 8372 unit tests pass (`cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins`)
- [ ] 7 new tests added: `TimeoutConfig` defaults/deserialization, `LifecycleState` backoff gate logic, `is_no_providers()` predicate
- [ ] `cargo +nightly fmt --check` clean
- [ ] `cargo clippy --workspace -- -D warnings` clean

Closes #3357