### PR TITLE
fix(core,notifications): fix three P3 bugs — notify master switch, overflow comment, dead BackgroundShell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `Notifier::fire_test()` now checks the master `notifications.enabled` switch first; if
+  disabled, it returns an error instead of silently firing a test notification (#3364).
+- Fixed misleading comment in `drain_background_completions()`: the overflow branch drops
+  the oldest queued completion (not the incoming one) and pushes a sentinel for the new run.
+  Comment now matches the code (#3365).
+- Removed dead `TaskClass::BackgroundShell` enum variant from the agent supervisor; `NUM_CLASSES`
+  reduced from 3 to 2. Background shell tasks currently use `tokio::spawn` directly (deferred
+  to a follow-up, tracked via TODO comment in source) (#3366).
+
 - `--bare` mode now skips the file change watcher: `with_hooks_config` is no longer called
   unconditionally in `runner.rs` — it is guarded by `!exec_mode.bare`, preventing background
   filesystem watch threads from starting in minimal sessions (#3362).

--- a/crates/zeph-core/src/agent/agent_supervisor.rs
+++ b/crates/zeph-core/src/agent/agent_supervisor.rs
@@ -14,6 +14,8 @@
 //! | `Enrichment` | configurable (default 4) | Drop | summarization, graph/persona/trajectory extraction |
 //! | `Telemetry` | configurable (default 8) | Drop | audit log writes, graph count sync |
 //!
+//! Background shell runs are not yet routed through the supervisor; see issue #3366.
+//!
 //! # Critic-driven design decisions
 //!
 //! - **S1**: `unsummarized_count` is NOT shared via `AtomicUsize`. Background summarization
@@ -36,6 +38,8 @@ use crate::config::TaskSupervisorConfig;
 use crate::metrics::HistogramRecorder;
 
 /// Identifies the class of a background task.
+///
+// TODO: route background shell spawns through the supervisor (see issue #3366)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TaskClass {
     /// Enrichment tasks spawned from `persist_message`: summarization, graph/persona/trajectory
@@ -43,12 +47,6 @@ pub(crate) enum TaskClass {
     Enrichment,
     /// Telemetry/metrics updates: audit log writes, graph count sync. Small and fast.
     Telemetry,
-    /// Background shell runs spawned via `background = true` bash tool calls.
-    ///
-    /// Isolated from `Enrichment` so shell-run saturation cannot starve memory compaction.
-    /// Budget mirrors `ShellConfig::max_background_runs` (default 8).
-    #[allow(dead_code)]
-    BackgroundShell,
 }
 
 impl TaskClass {
@@ -56,7 +54,6 @@ impl TaskClass {
         match self {
             TaskClass::Enrichment => 0,
             TaskClass::Telemetry => 1,
-            TaskClass::BackgroundShell => 2,
         }
     }
 
@@ -64,13 +61,12 @@ impl TaskClass {
         match self {
             TaskClass::Enrichment => "enrichment",
             TaskClass::Telemetry => "telemetry",
-            TaskClass::BackgroundShell => "background_shell",
         }
     }
 }
 
 // MVP: only Drop overflow policy is supported.
-const NUM_CLASSES: usize = 3;
+const NUM_CLASSES: usize = 2;
 
 /// Signal that background summarization completed successfully.
 /// Stored in `BackgroundSupervisor` and consumed by `reap()` to reset `unsummarized_count`
@@ -163,11 +159,7 @@ impl BackgroundSupervisor {
             tasks: JoinSet::new(),
             class_inflight: std::array::from_fn(|_| Arc::new(AtomicUsize::new(0))),
             class_metrics: [ClassMetrics::default(); NUM_CLASSES],
-            class_limits: [
-                config.enrichment_limit,
-                config.telemetry_limit,
-                config.background_shell_limit,
-            ],
+            class_limits: [config.enrichment_limit, config.telemetry_limit],
             class_handles: std::array::from_fn(|_| Vec::new()),
             histogram_recorder: recorder,
         }
@@ -595,7 +587,7 @@ mod tests {
             enrichment_limit: 2,
             telemetry_limit: 3,
             abort_enrichment_on_turn: false,
-            background_shell_limit: 8,
+            background_shell_limit: 8, // retained in config; unused by supervisor until #3366
         };
         let mut sv = BackgroundSupervisor::new(&config, None);
         let mut txs = Vec::new();

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -1744,10 +1744,8 @@ impl<C: Channel> Agent<C> {
                     run_id = %completion.run_id,
                     "background completion buffer full; dropping run result"
                 );
-                // Drop the new (incoming) completion and push a sentinel in its place so
-                // the LLM is informed that this specific run's result was lost. We do NOT
-                // pop the oldest entry — the oldest entries have already been queued for
-                // delivery and evicting them would silently lose data that the user expects.
+                // Buffer is full: drop the oldest queued completion and push a sentinel
+                // for the new (incoming) run so the LLM is informed its result was lost.
                 self.lifecycle.pending_background_completions.pop_front();
                 self.lifecycle.pending_background_completions.push_back(
                     zeph_tools::BackgroundCompletion {

--- a/crates/zeph-core/src/notifications.rs
+++ b/crates/zeph-core/src/notifications.rs
@@ -181,6 +181,10 @@ impl Notifier {
     /// - `NotifyTestError::MacOsFailed` — macOS notification failed (macOS only)
     /// - `NotifyTestError::WebhookFailed` — webhook POST failed
     pub async fn fire_test(&self) -> Result<(), NotifyTestError> {
+        if !self.cfg.enabled {
+            return Err(NotifyTestError::MasterSwitchDisabled);
+        }
+
         let macos_enabled = self.cfg.macos_native;
         let webhook_enabled = self.cfg.webhook_url.is_some() && self.cfg.webhook_topic.is_some();
 
@@ -216,6 +220,9 @@ impl Notifier {
 /// Error returned by [`Notifier::fire_test`].
 #[derive(Debug, thiserror::Error)]
 pub enum NotifyTestError {
+    /// The master `notifications.enabled` switch is `false`.
+    #[error("notifications are disabled (set notifications.enabled = true to enable)")]
+    MasterSwitchDisabled,
     /// No channels are enabled in the current configuration.
     #[error("all notification channels are disabled")]
     AllDisabled,


### PR DESCRIPTION
## Summary

- **#3364**: `fire_test()` now checks `notifications.enabled` first; returns `NotifyTestError::MasterSwitchDisabled` when the master switch is off, preventing confusing "test succeeded" output while notifications are globally disabled.
- **#3365**: Corrected misleading comment in `drain_background_completions()` overflow branch — the comment said "we do NOT pop the oldest entry" but the code does `pop_front()`. Comment now accurately describes drop-oldest + sentinel-for-new behaviour.
- **#3366**: Removed dead `TaskClass::BackgroundShell` enum variant (was annotated `#[allow(dead_code)]`). `NUM_CLASSES` reduced 3→2. Routing shell spawns through the supervisor is deferred; TODO comment added in source.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy -p zeph-core -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 8389 passed, 20 skipped

Closes #3364, #3365, #3366