### PR TITLE
fix(bootstrap): pass embed provider to attach_reasoning_memory for Qdrant probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Removed dead `TaskClass::BackgroundShell` enum variant from the agent supervisor; `NUM_CLASSES`
   reduced from 3 to 2. Background shell tasks currently use `tokio::spawn` directly (deferred
   to a follow-up, tracked via TODO comment in source) (#3366).
+- `attach_reasoning_memory` now resolves the dedicated embed provider before performing the Qdrant
+  dimension probe. Previously it used the primary LLM router, which excludes `embed = true`
+  entries, causing the probe to fail and `ensure_collection("reasoning_strategies")` to never be
+  called. The fix passes `build_memory_embed_provider()` result into `attach_reasoning_memory` and
+  falls back to the primary provider when no dedicated embed provider is configured (#3375).
 
 - `--bare` mode now skips the file change watcher: `with_hooks_config` is no longer called
   unconditionally in `runner.rs` — it is guarded by `!exec_mode.bare`, preventing background

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -363,13 +363,20 @@ impl AppBuilder {
             memory = self.attach_graph_stores(memory, db_path).await?;
         }
 
-        memory = self.attach_reasoning_memory(memory, provider).await;
+        // Build the dedicated embed provider before attach_reasoning_memory so the
+        // Qdrant collection probe uses it. The primary router excludes embed-only entries
+        // (build_all_pool_providers skips `embed = true`), so passing only `provider`
+        // here would fail the probe with "no providers available" (#3375).
+        let embed_provider = self.build_memory_embed_provider();
+        memory = self
+            .attach_reasoning_memory(memory, provider, embed_provider.as_ref())
+            .await;
 
         if self.config.memory.admission.enabled {
             memory = memory.with_admission_control(self.build_admission_control());
         }
 
-        if let Some(ep) = self.build_memory_embed_provider() {
+        if let Some(ep) = embed_provider {
             memory = memory.with_embed_provider(ep);
         }
 
@@ -433,11 +440,14 @@ impl AppBuilder {
     /// Uses the main `SQLite` pool from `SemanticMemory` so no additional pool is needed.
     /// When Qdrant is configured, the `QdrantOps` is cloned and passed as the vector store
     /// for embedding-similarity retrieval. The `reasoning_strategies` collection is created
-    /// at startup with the correct vector dimension probed from `provider`.
+    /// at startup with the correct vector dimension probed from `embed_provider` when present,
+    /// falling back to `provider`. The dedicated embed provider must be passed here because the
+    /// primary router excludes `embed = true` pool entries and cannot produce embeddings (#3375).
     pub async fn attach_reasoning_memory(
         &self,
         memory: SemanticMemory,
         provider: &AnyProvider,
+        embed_provider: Option<&AnyProvider>,
     ) -> SemanticMemory {
         if !self.config.memory.reasoning.enabled {
             return memory;
@@ -451,10 +461,15 @@ impl AppBuilder {
         {
             let ops_arc: std::sync::Arc<dyn zeph_memory::VectorStore> = Arc::new(ops.clone());
 
+            // Use the dedicated embed provider for the dimension probe when available.
+            // The primary router skips embed-only pool entries, so it cannot produce
+            // embeddings when the config uses a separate embedder (#3375).
+            let probe_provider = embed_provider.unwrap_or(provider);
+
             // Ensure the reasoning_strategies collection exists with the correct vector size.
             // Best-effort: a failure here is logged and Qdrant falls back to SQLite-only mode.
-            if provider.supports_embeddings() {
-                match provider.embed("dimension probe").await {
+            if probe_provider.supports_embeddings() {
+                match probe_provider.embed("dimension probe").await {
                     Ok(probe) => {
                         let vector_size = u64::try_from(probe.len()).unwrap_or(1536);
                         if let Err(e) = ops


### PR DESCRIPTION
## Summary

- Resolves the root cause of #3375: `attach_reasoning_memory` was called with the primary LLM router provider, which excludes `embed = true` entries by design (`build_all_pool_providers` skips them). The embed dimension probe failed with "no providers available", so `ensure_collection("reasoning_strategies")` was never called, silently disabling ReasoningBank for the entire session when a dedicated embed provider is configured.
- Confirmed #3369 already resolved in bfff17fd (`migrate_memory_reasoning_config` present in `crates/zeph-config/src/migrate.rs:2540`, wired as step 29 in `src/commands/migrate.rs`).

## Changes

**`src/bootstrap/mod.rs`**
- `build_memory_embed_provider()` is now called before `attach_reasoning_memory`, eliminating the duplicate call that followed it
- `attach_reasoning_memory` signature extended with `embed_provider: Option<&AnyProvider>`; the probe uses this provider when available and falls back to the primary provider for single-provider configs (`unwrap_or(provider)`)

**`CHANGELOG.md`** — entry added to `[Unreleased] → Fixed`

## Test Plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --features full -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 8391 passed, 20 skipped
- [x] Code review: APPROVED (no critical or important issues)
- [ ] Live test with dedicated embed provider config — playbook: `.local/testing/playbooks/reasoning-bank-embed-fix.md`

Closes #3375