### PR TITLE
fix(config): document missing timeout tunables in default.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `config/default.toml` `[timeouts]` section now documents all three previously hidden tunables:
+  `llm_request_timeout_secs` (600 s), `context_prep_timeout_secs` (30 s), and
+  `no_providers_backoff_secs` (2 s). `migrate-config --diff` will now surface these fields for
+  existing configs (#3377).
 - `Notifier::fire_test()` now checks the master `notifications.enabled` switch first; if
   disabled, it returns an error instead of silently firing a test notification (#3364).
 - Fixed misleading comment in `drain_background_completions()`: the overflow branch drops

--- a/config/default.toml
+++ b/config/default.toml
@@ -761,12 +761,20 @@ model = "claude"
 [timeouts]
 # LLM chat completion timeout in seconds
 llm_seconds = 120
+# Per-request LLM timeout in seconds (applies at the HTTP client level; overrides llm_seconds for
+# individual requests). Increase for slow providers or very long generations.
+llm_request_timeout_secs = 600
 # Embedding generation timeout in seconds
 embedding_seconds = 30
 # A2A remote call timeout in seconds
 a2a_seconds = 30
 # Maximum number of tool calls to execute in parallel
 max_parallel_tools = 8
+# Timeout for context preparation (memory search + embedding) before each agent turn, in seconds.
+# If exceeded, the turn proceeds with whatever context was assembled so far.
+context_prep_timeout_secs = 30
+# Backoff delay in seconds when all LLM providers are unavailable before retrying.
+no_providers_backoff_secs = 2
 
 [debug]
 # Enable debug dump: write every LLM request/response pair to timestamped files.


### PR DESCRIPTION
## Summary

- Add `llm_request_timeout_secs`, `context_prep_timeout_secs`, and `no_providers_backoff_secs` to `[timeouts]` in `config/default.toml` with descriptive comments
- These fields were added to the runtime in #3373 but omitted from the reference config, making them invisible to `migrate-config --diff` and undiscoverable without reading source code

## Test plan

- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo nextest run --workspace --lib --bins` — 8416 passed, 0 failed
- [x] `zeph migrate-config --diff` will now include all three fields for configs missing `[timeouts]`

Closes #3377