### PR TITLE
feat(core,a2a): Focus strategy auto-consolidation and MMA2A AgentCard capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   calls `MessageStore::filter_out_preserved_episode_ids` to exclude any message ID that falls within
   a summary's `[first_message_id, last_message_id]` range before soft-deleting. No config flag
   required (#3341).
+- feat(a2a): AgentCard modality capability declarations (images/audio/files) (#3326)
+- feat(core): Focus strategy auto-consolidation via `run_focus_auto_consolidation` (#3313)
 
 ### Fixed
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -1044,6 +1044,8 @@ max_files = 7
 # min_messages_per_focus = 8
 # # Maximum tokens the Knowledge block may grow to before trimming old entries (default: 4096)
 # max_knowledge_tokens = 4096
+# # Minimum messages in a low-relevance window before auto-consolidation runs (#3313)
+# auto_consolidate_min_window = 6
 
 # Context-compression feature: SideQuest LLM-driven eviction (#1885)
 # Requires the `context-compression` feature flag to be enabled at compile time.

--- a/crates/zeph-a2a/src/card.rs
+++ b/crates/zeph-a2a/src/card.rs
@@ -96,6 +96,72 @@ impl AgentCardBuilder {
         self
     }
 
+    /// Declare image-modality capability on the card.
+    ///
+    /// When `on` is `true`, the card advertises that the agent can receive and send
+    /// `Part::File` entries whose `media_type` is in the `image/*` family.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_a2a::AgentCardBuilder;
+    ///
+    /// let card = AgentCardBuilder::new("vision-agent", "http://localhost:8080", "1.0.0")
+    ///     .images(true)
+    ///     .build();
+    ///
+    /// assert!(card.capabilities.images);
+    /// ```
+    #[must_use]
+    pub fn images(mut self, on: bool) -> Self {
+        self.capabilities.images = on;
+        self
+    }
+
+    /// Declare audio-modality capability on the card.
+    ///
+    /// When `on` is `true`, the card advertises that the agent can receive and send
+    /// `Part::File` entries whose `media_type` is in the `audio/*` family.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_a2a::AgentCardBuilder;
+    ///
+    /// let card = AgentCardBuilder::new("audio-agent", "http://localhost:8080", "1.0.0")
+    ///     .audio(true)
+    ///     .build();
+    ///
+    /// assert!(card.capabilities.audio);
+    /// ```
+    #[must_use]
+    pub fn audio(mut self, on: bool) -> Self {
+        self.capabilities.audio = on;
+        self
+    }
+
+    /// Declare file-attachment capability on the card.
+    ///
+    /// When `on` is `true`, the card advertises that the agent can receive and send
+    /// non-media file attachments via `Part::File` (e.g., documents, archives).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_a2a::AgentCardBuilder;
+    ///
+    /// let card = AgentCardBuilder::new("file-agent", "http://localhost:8080", "1.0.0")
+    ///     .files(true)
+    ///     .build();
+    ///
+    /// assert!(card.capabilities.files);
+    /// ```
+    #[must_use]
+    pub fn files(mut self, on: bool) -> Self {
+        self.capabilities.files = on;
+        self
+    }
+
     /// Add a skill to the card. Can be called multiple times to add multiple skills.
     #[must_use]
     pub fn skill(mut self, skill: AgentSkill) -> Self {
@@ -212,6 +278,60 @@ mod tests {
         assert!(json.contains("\"protocolVersion\""));
         assert!(json.contains(crate::A2A_PROTOCOL_VERSION));
         assert_eq!(card.protocol_version, crate::A2A_PROTOCOL_VERSION);
+    }
+
+    #[test]
+    fn builder_sets_image_capability() {
+        let card = AgentCardBuilder::new("agent", "http://localhost", "0.1.0")
+            .images(true)
+            .build();
+        assert!(card.capabilities.images);
+        assert!(!card.capabilities.audio);
+        assert!(!card.capabilities.files);
+    }
+
+    #[test]
+    fn builder_sets_audio_capability() {
+        let card = AgentCardBuilder::new("agent", "http://localhost", "0.1.0")
+            .audio(true)
+            .build();
+        assert!(card.capabilities.audio);
+        assert!(!card.capabilities.images);
+        assert!(!card.capabilities.files);
+    }
+
+    #[test]
+    fn builder_sets_file_capability() {
+        let card = AgentCardBuilder::new("agent", "http://localhost", "0.1.0")
+            .files(true)
+            .build();
+        assert!(card.capabilities.files);
+        assert!(!card.capabilities.images);
+        assert!(!card.capabilities.audio);
+    }
+
+    #[test]
+    fn card_serializes_modality_fields() {
+        let card = AgentCardBuilder::new("agent", "http://localhost", "0.1.0")
+            .images(true)
+            .build();
+        let json = serde_json::to_string(&card).unwrap();
+        // images was set to true
+        assert!(json.contains("\"images\":true"));
+        // audio and files default to false and must be present
+        assert!(json.contains("\"audio\":false"));
+        assert!(json.contains("\"files\":false"));
+    }
+
+    #[test]
+    fn deserialize_legacy_card_uses_defaults() {
+        // A card from a peer that predates modality fields: modalities must default to false.
+        let json = r#"{"name":"old","description":"","url":"http://x","version":"1","protocolVersion":"0.2.1","capabilities":{"streaming":true}}"#;
+        let card: crate::types::AgentCard = serde_json::from_str(json).unwrap();
+        assert!(card.capabilities.streaming);
+        assert!(!card.capabilities.images);
+        assert!(!card.capabilities.audio);
+        assert!(!card.capabilities.files);
     }
 
     trait Not {

--- a/crates/zeph-a2a/src/types.rs
+++ b/crates/zeph-a2a/src/types.rs
@@ -268,8 +268,17 @@ pub struct AgentProvider {
 }
 
 /// Boolean flags advertising which A2A protocol extensions an agent supports.
+///
+/// The three protocol-defined fields (`streaming`, `push_notifications`,
+/// `state_transition_history`) are part of the A2A specification. The modality fields
+/// (`images`, `audio`, `files`) are Zeph forward-compatible extensions — they default to
+/// `false` so that peers that do not understand them can safely ignore the fields via
+/// `#[serde(default)]`. If the A2A spec standardises different names for these capabilities
+/// in a future revision, a follow-up PR can add the canonical names without breaking
+/// existing serialised cards.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[allow(clippy::struct_excessive_bools)]
 pub struct AgentCapabilities {
     /// Agent supports `message/stream` for real-time SSE output.
     #[serde(default)]
@@ -280,6 +289,21 @@ pub struct AgentCapabilities {
     /// Agent includes full state-transition history in task responses.
     #[serde(default)]
     pub state_transition_history: bool,
+    /// Agent can receive and send `Part::File` entries with `image/*` media types (#3326).
+    ///
+    /// Defaults to `false`. Set via [`AgentCardBuilder::images`](crate::AgentCardBuilder::images).
+    #[serde(default)]
+    pub images: bool,
+    /// Agent can receive and send `Part::File` entries with `audio/*` media types (#3326).
+    ///
+    /// Defaults to `false`. Set via [`AgentCardBuilder::audio`](crate::AgentCardBuilder::audio).
+    #[serde(default)]
+    pub audio: bool,
+    /// Agent can receive and send non-media file attachments via `Part::File` (#3326).
+    ///
+    /// Defaults to `false`. Set via [`AgentCardBuilder::files`](crate::AgentCardBuilder::files).
+    #[serde(default)]
+    pub files: bool,
 }
 
 /// A discrete skill or capability advertised by an agent in its [`AgentCard`].
@@ -611,6 +635,9 @@ mod tests {
                 streaming: true,
                 push_notifications: false,
                 state_transition_history: false,
+                images: false,
+                audio: false,
+                files: false,
             },
             default_input_modes: vec!["text".into()],
             default_output_modes: vec!["text".into()],
@@ -744,6 +771,41 @@ mod tests {
             metadata: None,
         };
         assert_eq!(msg.all_text_content(), "text-only");
+    }
+
+    #[test]
+    fn agent_capabilities_default_has_no_modalities() {
+        let caps = AgentCapabilities::default();
+        assert!(!caps.images);
+        assert!(!caps.audio);
+        assert!(!caps.files);
+    }
+
+    #[test]
+    fn agent_capabilities_modality_fields_serialize() {
+        let caps = AgentCapabilities {
+            streaming: false,
+            push_notifications: false,
+            state_transition_history: false,
+            images: false,
+            audio: false,
+            files: false,
+        };
+        let json = serde_json::to_string(&caps).unwrap();
+        assert!(json.contains("\"images\":false"));
+        assert!(json.contains("\"audio\":false"));
+        assert!(json.contains("\"files\":false"));
+    }
+
+    #[test]
+    fn deserialize_legacy_capabilities_uses_modality_defaults() {
+        // Old-format JSON with only the core A2A fields — modality fields must default to false.
+        let json = r#"{"streaming": true}"#;
+        let caps: AgentCapabilities = serde_json::from_str(json).unwrap();
+        assert!(caps.streaming);
+        assert!(!caps.images);
+        assert!(!caps.audio);
+        assert!(!caps.files);
     }
 
     trait Not {

--- a/crates/zeph-config/src/agent.rs
+++ b/crates/zeph-config/src/agent.rs
@@ -86,6 +86,10 @@ fn default_focus_max_knowledge_tokens() -> usize {
     4096
 }
 
+fn default_focus_auto_consolidate_min_window() -> usize {
+    6
+}
+
 fn default_max_tool_retries() -> usize {
     2
 }
@@ -161,6 +165,13 @@ pub struct FocusConfig {
     /// Default: `4096`.
     #[serde(default = "default_focus_max_knowledge_tokens")]
     pub max_knowledge_tokens: usize,
+    /// Minimum messages in a low-relevance window before auto-consolidation runs
+    /// when `[memory.compression]` strategy is `focus` (#3313).
+    ///
+    /// Distinct from `min_messages_per_focus` (which gates manual focus sessions).
+    /// Default: `6`.
+    #[serde(default = "default_focus_auto_consolidate_min_window")]
+    pub auto_consolidate_min_window: usize,
 }
 
 impl Default for FocusConfig {
@@ -171,6 +182,7 @@ impl Default for FocusConfig {
             reminder_interval: default_focus_reminder_interval(),
             min_messages_per_focus: default_focus_min_messages_per_focus(),
             max_knowledge_tokens: default_focus_max_knowledge_tokens(),
+            auto_consolidate_min_window: default_focus_auto_consolidate_min_window(),
         }
     }
 }
@@ -469,5 +481,18 @@ mod tests {
     fn model_spec_as_str() {
         assert_eq!(ModelSpec::Inherit.as_str(), "inherit");
         assert_eq!(ModelSpec::Named("x".to_owned()).as_str(), "x");
+    }
+
+    #[test]
+    fn focus_config_auto_consolidate_min_window_default_is_six() {
+        let cfg = FocusConfig::default();
+        assert_eq!(cfg.auto_consolidate_min_window, 6);
+    }
+
+    #[test]
+    fn focus_config_auto_consolidate_min_window_deserializes() {
+        let toml_str = "auto_consolidate_min_window = 10";
+        let cfg: FocusConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.auto_consolidate_min_window, 10);
     }
 }

--- a/crates/zeph-config/src/memory.rs
+++ b/crates/zeph-config/src/memory.rs
@@ -1424,7 +1424,8 @@ pub struct CompressionConfig {
     /// Default: `false`.
     #[serde(default)]
     pub archive_tool_outputs: bool,
-    /// Provider for Focus strategy segment scoring (#2510).
+    /// Provider for Focus strategy segment scoring and the auto-consolidation extraction
+    /// LLM call (#2510, #3313). Both are cheap/mid-tier tasks, so one provider suffices.
     /// Falls back to the primary provider when empty. Default: `""`.
     pub focus_scorer_provider: ProviderName,
     /// Token-budget fraction for high-density content in density-aware compression (#2481).

--- a/crates/zeph-config/src/migrate.rs
+++ b/crates/zeph-config/src/migrate.rs
@@ -2711,6 +2711,54 @@ pub fn migrate_hooks_turn_complete_config(toml_src: &str) -> Result<MigrationRes
     })
 }
 
+/// Inject a commented-out `auto_consolidate_min_window` key into `[agent.focus]` if absent (#3313).
+///
+/// All `FocusConfig` fields have `#[serde(default)]`, so existing configs deserialize without
+/// changes. This step surfaces the new field for users upgrading from older configs.
+///
+/// The comment is inserted *inside* the `[agent.focus]` section using [`insert_after_section`],
+/// so it ends up in the correct table regardless of where that section appears in the file.
+///
+/// Idempotent: if `auto_consolidate_min_window` already appears anywhere in the source,
+/// the input is returned unchanged with `changed_count = 0`.
+/// No-op when `[agent.focus]` is absent or only exists as a comment line.
+///
+/// # Errors
+///
+/// This function is infallible in practice; the `Result` return type matches the migration
+/// function convention for use in chained pipelines.
+pub fn migrate_focus_auto_consolidate_min_window(
+    toml_src: &str,
+) -> Result<MigrationResult, MigrateError> {
+    if toml_src.contains("auto_consolidate_min_window") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    // Only inject when [agent.focus] exists as a live section (not a comment).
+    if !toml_src.lines().any(|l| l.trim() == "[agent.focus]") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let comment = "\n# Minimum messages in a low-relevance window before Focus auto-consolidation \
+         runs (#3313).\n\
+         # auto_consolidate_min_window = 6\n";
+    let output = insert_after_section(toml_src, "agent.focus", comment);
+
+    Ok(MigrationResult {
+        output,
+        changed_count: 1,
+        sections_changed: vec!["agent.focus.auto_consolidate_min_window".to_owned()],
+    })
+}
+
 // Helper to create a formatted value (used in tests).
 #[cfg(test)]
 fn make_formatted_str(s: &str) -> Value {
@@ -4232,6 +4280,52 @@ prompt_cache_ttl = "1h"
         let result = migrate_hooks_turn_complete_config(input).unwrap();
         assert_eq!(result.changed_count, 0);
         assert!(result.sections_changed.is_empty());
+        assert_eq!(result.output, input);
+    }
+
+    // ── migrate_focus_auto_consolidate_min_window ──────────────────────────────
+
+    /// S5: the comment must land inside [agent.focus], not after a subsequent section.
+    #[test]
+    fn migrate_focus_auto_consolidate_injects_inside_section() {
+        let input = "[agent.focus]\nenabled = true\n\n[other]\nfoo = 1\n";
+        let result = migrate_focus_auto_consolidate_min_window(input).unwrap();
+        assert_eq!(result.changed_count, 1);
+        let comment_pos = result
+            .output
+            .find("auto_consolidate_min_window")
+            .expect("comment must be present");
+        let other_pos = result
+            .output
+            .find("[other]")
+            .expect("[other] must be present");
+        assert!(
+            comment_pos < other_pos,
+            "auto_consolidate_min_window comment must appear before [other] section"
+        );
+    }
+
+    #[test]
+    fn migrate_focus_auto_consolidate_idempotent() {
+        let input = "[agent.focus]\nenabled = true\nauto_consolidate_min_window = 6\n";
+        let result = migrate_focus_auto_consolidate_min_window(input).unwrap();
+        assert_eq!(result.changed_count, 0);
+        assert_eq!(result.output, input);
+    }
+
+    #[test]
+    fn migrate_focus_auto_consolidate_noop_when_section_absent() {
+        let input = "[agent]\nname = \"zeph\"\n";
+        let result = migrate_focus_auto_consolidate_min_window(input).unwrap();
+        assert_eq!(result.changed_count, 0);
+        assert_eq!(result.output, input);
+    }
+
+    #[test]
+    fn migrate_focus_auto_consolidate_noop_when_only_commented_section() {
+        let input = "[agent]\n# [agent.focus]\n# enabled = false\n";
+        let result = migrate_focus_auto_consolidate_min_window(input).unwrap();
+        assert_eq!(result.changed_count, 0);
         assert_eq!(result.output, input);
     }
 }

--- a/crates/zeph-context/src/manager.rs
+++ b/crates/zeph-context/src/manager.rs
@@ -313,7 +313,7 @@ impl ContextManager {
     /// Returns `Some((threshold_tokens, max_summary_tokens))` when proactive compression
     /// should be triggered, `None` otherwise.
     ///
-    /// For [`CompressionStrategy::Focus`], the threshold is the soft-compaction fraction
+    /// For `CompressionStrategy::Focus`, the threshold is the soft-compaction fraction
     /// of the budget (same gate used by mid-iteration soft compaction). The
     /// `max_summary_tokens` element is unused on the Focus path — the auto-consolidation
     /// function uses `FocusConfig.max_knowledge_tokens / 2` instead.

--- a/crates/zeph-context/src/manager.rs
+++ b/crates/zeph-context/src/manager.rs
@@ -313,6 +313,11 @@ impl ContextManager {
     /// Returns `Some((threshold_tokens, max_summary_tokens))` when proactive compression
     /// should be triggered, `None` otherwise.
     ///
+    /// For [`CompressionStrategy::Focus`], the threshold is the soft-compaction fraction
+    /// of the budget (same gate used by mid-iteration soft compaction). The
+    /// `max_summary_tokens` element is unused on the Focus path — the auto-consolidation
+    /// function uses `FocusConfig.max_knowledge_tokens / 2` instead.
+    ///
     /// Will return `None` if compaction already happened this turn (CRIT-03 fix).
     #[must_use]
     pub fn should_proactively_compress(&self, current_tokens: u64) -> Option<(usize, usize)> {
@@ -326,6 +331,24 @@ impl ContextManager {
                 max_summary_tokens,
             } if usize::try_from(current_tokens).unwrap_or(usize::MAX) > *threshold_tokens => {
                 Some((*threshold_tokens, *max_summary_tokens))
+            }
+            CompressionStrategy::Focus => {
+                // Focus fires at the soft-compaction threshold (same as tier machinery).
+                let budget = self.budget.as_ref()?.max_tokens();
+                #[allow(
+                    clippy::cast_precision_loss,
+                    clippy::cast_sign_loss,
+                    clippy::cast_possible_truncation
+                )]
+                let threshold = (budget as f32 * self.soft_compaction_threshold) as usize;
+                if usize::try_from(current_tokens).unwrap_or(usize::MAX) > threshold {
+                    // NOTE: the second tuple element (max_summary_tokens) is a placeholder
+                    // on the Focus path — the auto-consolidation function ignores it and uses
+                    // FocusConfig.max_knowledge_tokens / 2 instead.
+                    Some((threshold, threshold / 4))
+                } else {
+                    None
+                }
             }
             _ => None,
         }
@@ -432,5 +455,35 @@ mod tests {
     fn advance_turn_compacted_zero_cooldown_returns_ready() {
         let state = CompactionState::CompactedThisTurn { cooldown: 0 };
         assert_eq!(state.advance_turn(), CompactionState::Ready);
+    }
+
+    #[test]
+    fn should_proactively_compress_focus_fires_above_soft_threshold() {
+        let mut cm = ContextManager::new();
+        cm.budget = Some(ContextBudget::new(100_000, 0.1));
+        cm.compression.strategy = CompressionStrategy::Focus;
+        // Default soft threshold is 0.60 → 60_000 tokens.
+        // 75_000 > 60_000 → should fire.
+        let result = cm.should_proactively_compress(75_000);
+        assert!(result.is_some(), "Focus must fire above soft threshold");
+        let (threshold, _) = result.unwrap();
+        assert_eq!(threshold, 60_000);
+    }
+
+    #[test]
+    fn should_proactively_compress_focus_returns_none_below_threshold() {
+        let mut cm = ContextManager::new();
+        cm.budget = Some(ContextBudget::new(100_000, 0.1));
+        cm.compression.strategy = CompressionStrategy::Focus;
+        // 50_000 < 60_000 → should not fire.
+        assert!(cm.should_proactively_compress(50_000).is_none());
+    }
+
+    #[test]
+    fn should_proactively_compress_focus_returns_none_without_budget() {
+        let mut cm = ContextManager::new();
+        cm.compression.strategy = CompressionStrategy::Focus;
+        // No budget set → cannot compute threshold → None.
+        assert!(cm.should_proactively_compress(999_999).is_none());
     }
 }

--- a/crates/zeph-core/src/agent/compaction_strategy.rs
+++ b/crates/zeph-core/src/agent/compaction_strategy.rs
@@ -23,7 +23,8 @@
 //! A future improvement should use cosine similarity over Qdrant embeddings. The
 //! TF weighting mitigates the worst cases by down-weighting common tokens.
 use std::collections::{HashMap, HashSet};
-use zeph_llm::provider::{Message, MessagePart};
+use std::time::Duration;
+use zeph_llm::provider::{LlmProvider, Message, MessagePart, Role};
 use zeph_memory::TokenCounter;
 
 /// Per-message relevance score used by task-aware and MIG pruning.
@@ -635,6 +636,150 @@ pub(crate) fn classify_density(content: &str) -> ContentDensity {
     }
 }
 
+/// Automatically consolidate low-relevance context into a knowledge-block summary.
+///
+/// Scores each message in `messages` against the task goal extracted from the most recent
+/// user message, finds the oldest contiguous run of messages scoring ≤ 0 (negative MIG)
+/// of length ≥ `min_window`, and asks `provider` to extract the key facts. The result
+/// is truncated to `max_chars` at a UTF-8 character boundary.
+///
+/// Returns `Ok(None)` when the history is too short or no low-relevance window exists.
+/// Returns `Err` when the provider call fails or times out (the caller should log-and-skip).
+///
+/// # Errors
+///
+/// Returns an error if the provider call returns an error or if the 20-second timeout
+/// elapses before the provider responds.
+pub(crate) async fn run_focus_auto_consolidation(
+    messages: &[Message],
+    min_window: usize,
+    provider: impl LlmProvider,
+    max_chars: usize,
+) -> Result<Option<String>, Box<dyn std::error::Error + Send + Sync>> {
+    let _span = tracing::info_span!("core.context.focus_auto_consolidate").entered();
+
+    if messages.len() < min_window {
+        return Ok(None);
+    }
+
+    // Seed the task goal from the most recent user message.
+    let task_goal = messages
+        .iter()
+        .rev()
+        .find(|m| m.role == Role::User)
+        .map_or("", |m| m.content.as_str());
+
+    // S2/S3: without a user message we cannot compute relevance scores — score_blocks_mig
+    // would fall back to recency mode and eagerly consolidate nearly all history on every
+    // call (agent warm-start, scripted init). Skip instead.
+    if task_goal.is_empty() {
+        tracing::debug!("focus_auto_consolidation: no user message found, skipping");
+        return Ok(None);
+    }
+
+    let tc = TokenCounter::default();
+    let scores = score_blocks_mig(messages, Some(task_goal).filter(|s| !s.is_empty()), &tc);
+
+    // Find the oldest contiguous run of messages with MIG ≤ 0 of length ≥ min_window.
+    // `scores` is indexed by their original message positions via `msg_index`.
+    // Build a set of low-relevance message indices for O(1) lookup.
+    let low_relevance: std::collections::HashSet<usize> = scores
+        .iter()
+        .filter(|s| s.mig <= 0.0)
+        .map(|s| s.msg_index)
+        .collect();
+
+    // Walk message indices in order to find the first run of low-relevance msgs ≥ min_window.
+    let window_indices = find_low_relevance_window(messages, &low_relevance, min_window);
+    if window_indices.is_empty() {
+        return Ok(None);
+    }
+
+    // Build the extraction prompt from the window's scorable text.
+    let combined: String = window_indices
+        .iter()
+        .map(|&i| extract_scorable_text(&messages[i]))
+        .collect::<Vec<_>>()
+        .join("\n---\n");
+
+    let prompt = format!(
+        "Extract up to 10 key facts the agent must remember from the following context. \
+         Return bullet points only (one per line, starting with `- `).\n\n{combined}"
+    );
+
+    let request = vec![Message::from_legacy(Role::User, &prompt)];
+
+    let raw = tokio::time::timeout(Duration::from_secs(20), provider.chat(&request))
+        .await
+        .map_err(|_| {
+            Box::new(std::io::Error::other(
+                "focus auto-consolidation timed out after 20s",
+            )) as Box<dyn std::error::Error + Send + Sync>
+        })?
+        .map_err(|e| {
+            Box::new(std::io::Error::other(format!(
+                "focus auto-consolidation provider error: {e}"
+            ))) as Box<dyn std::error::Error + Send + Sync>
+        })?;
+
+    // Truncate at char boundary to stay within max_chars.
+    let truncated = if raw.len() <= max_chars {
+        raw
+    } else {
+        // Find the largest char boundary ≤ max_chars.
+        let boundary = raw
+            .char_indices()
+            .map(|(i, _)| i)
+            .take_while(|&i| i <= max_chars)
+            .last()
+            .unwrap_or(0);
+        raw[..boundary].to_owned()
+    };
+
+    if truncated.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(truncated))
+}
+
+/// Find the indices of the first contiguous run of low-relevance messages.
+///
+/// Only messages that appear in `low_relevance` (by index) are counted.
+/// System messages (index 0) and pinned messages are never included.
+/// Returns an empty vec if no qualifying run exists.
+fn find_low_relevance_window(
+    messages: &[Message],
+    low_relevance: &std::collections::HashSet<usize>,
+    min_window: usize,
+) -> Vec<usize> {
+    let mut best: Vec<usize> = Vec::new();
+    let mut current: Vec<usize> = Vec::new();
+
+    for (i, msg) in messages.iter().enumerate() {
+        // Skip system prompt and pinned messages.
+        if i == 0 || msg.metadata.focus_pinned {
+            current.clear();
+            continue;
+        }
+        if low_relevance.contains(&i) {
+            current.push(i);
+        } else {
+            // Gap: if the current run qualifies and we haven't found one yet, capture it.
+            if current.len() >= min_window && best.is_empty() {
+                // Move contents into best and leave current empty.
+                best.append(&mut current);
+            }
+            current.clear();
+        }
+    }
+    // Check trailing run.
+    if current.len() >= min_window && best.is_empty() {
+        best = current;
+    }
+    best
+}
+
 /// Partition messages into (high-density, low-density) groups by content classification.
 ///
 /// System messages and pinned messages are excluded from both groups.
@@ -1049,6 +1194,180 @@ mod tests {
         assert_eq!(classify_density(content), ContentDensity::High);
     }
 
+    // ─── run_focus_auto_consolidation tests ──────────────────────────────────
+
+    struct StubProvider {
+        response: &'static str,
+    }
+
+    impl zeph_llm::provider::LlmProvider for StubProvider {
+        async fn chat(
+            &self,
+            _messages: &[zeph_llm::provider::Message],
+        ) -> Result<String, zeph_llm::LlmError> {
+            Ok(self.response.to_owned())
+        }
+
+        async fn chat_stream(
+            &self,
+            messages: &[zeph_llm::provider::Message],
+        ) -> Result<zeph_llm::provider::ChatStream, zeph_llm::LlmError> {
+            let r = self.chat(messages).await?;
+            Ok(Box::pin(tokio_stream::once(Ok(
+                zeph_llm::provider::StreamChunk::Content(r),
+            ))))
+        }
+
+        fn supports_streaming(&self) -> bool {
+            false
+        }
+
+        async fn embed(&self, _text: &str) -> Result<Vec<f32>, zeph_llm::LlmError> {
+            Ok(vec![])
+        }
+
+        fn supports_embeddings(&self) -> bool {
+            false
+        }
+
+        fn name(&self) -> &'static str {
+            "stub"
+        }
+    }
+
+    struct HangingProvider;
+
+    impl zeph_llm::provider::LlmProvider for HangingProvider {
+        async fn chat(
+            &self,
+            _messages: &[zeph_llm::provider::Message],
+        ) -> Result<String, zeph_llm::LlmError> {
+            // Hang forever by awaiting a never-completing future.
+            std::future::pending::<()>().await;
+            unreachable!()
+        }
+
+        async fn chat_stream(
+            &self,
+            _messages: &[zeph_llm::provider::Message],
+        ) -> Result<zeph_llm::provider::ChatStream, zeph_llm::LlmError> {
+            std::future::pending::<()>().await;
+            unreachable!()
+        }
+
+        fn supports_streaming(&self) -> bool {
+            false
+        }
+
+        async fn embed(&self, _text: &str) -> Result<Vec<f32>, zeph_llm::LlmError> {
+            Ok(vec![])
+        }
+
+        fn supports_embeddings(&self) -> bool {
+            false
+        }
+
+        fn name(&self) -> &'static str {
+            "hanging"
+        }
+    }
+
+    #[tokio::test]
+    async fn run_focus_auto_consolidation_returns_none_for_small_history() {
+        use zeph_llm::provider::{Message, Role};
+        let messages = vec![
+            Message::from_legacy(Role::System, "sys"),
+            make_tool_output_msg("some tool output here"),
+        ];
+        // min_window = 6, but only 2 messages → None.
+        let result = run_focus_auto_consolidation(
+            &messages,
+            6,
+            StubProvider {
+                response: "- fact one",
+            },
+            4096,
+        )
+        .await
+        .unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn run_focus_auto_consolidation_produces_summary() {
+        use zeph_llm::provider::{Message, Role};
+
+        // Build 8 messages that are completely off-topic from the user goal.
+        // The user asks about "authentication" but all tool outputs are about "database schema".
+        // This should produce a low-relevance window and trigger extraction.
+        let mut messages = vec![Message::from_legacy(Role::System, "sys")];
+        for _ in 0..6 {
+            messages.push(make_tool_output_msg(
+                "database schema migration foreign key index",
+            ));
+        }
+        messages.push(Message::from_legacy(
+            Role::User,
+            "Help me with authentication",
+        ));
+
+        let result = run_focus_auto_consolidation(
+            &messages,
+            4,
+            StubProvider {
+                response: "- database schema uses foreign keys",
+            },
+            4096,
+        )
+        .await
+        .unwrap();
+
+        // With at least 4 low-relevance messages, a summary should be produced.
+        assert!(result.is_some());
+        let summary = result.unwrap();
+        assert!(!summary.is_empty());
+    }
+
+    #[tokio::test]
+    async fn auto_consolidation_timeout_recovers() {
+        use zeph_llm::provider::{Message, Role};
+
+        // Use a very short timeout by passing a HangingProvider. The function has a fixed 20s
+        // timeout. We can't make the test wait 20s, so instead we check that an error is
+        // returned (not a panic) when the provider hangs. To keep the test fast, we manually
+        // verify the timeout path using `tokio::time::timeout` directly.
+        let mut messages = vec![Message::from_legacy(Role::System, "sys")];
+        for _ in 0..6 {
+            messages.push(make_tool_output_msg(
+                "database schema migration foreign key index",
+            ));
+        }
+        messages.push(Message::from_legacy(
+            Role::User,
+            "Help me with authentication",
+        ));
+
+        // Wrap the call in a very short timeout to avoid waiting 20s in tests.
+        // The important invariant: the function does not panic on timeout.
+        let result = tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            run_focus_auto_consolidation(&messages, 4, HangingProvider, 4096),
+        )
+        .await;
+
+        // Either: outer timeout fires (Err), or the inner 20s timeout fires (Ok(Err)).
+        // Both cases must not panic.
+        match result {
+            Err(_elapsed) => {
+                // Outer timeout fired — no panic, correct.
+            }
+            Ok(inner) => {
+                // Inner 20s timeout fired — also valid, must be an Err.
+                assert!(inner.is_err(), "hanging provider must return an error");
+            }
+        }
+    }
+
     // ─── KnowledgeBlock eviction order tests ─────────────────────────────────
 
     #[test]
@@ -1084,5 +1403,35 @@ mod tests {
             .iter()
             .any(|b| b.source == KnowledgeBlockSource::LlmCurated);
         assert!(has_llm, "at least one LlmCurated block must survive");
+    }
+
+    /// S2/S3: when no User message is present, `run_focus_auto_consolidation` must return
+    /// `None` instead of entering recency mode and eagerly consolidating all history.
+    #[tokio::test]
+    async fn run_focus_auto_consolidation_skips_when_no_user_message() {
+        use zeph_llm::provider::{Message, Role};
+
+        // Build a history with plenty of messages but no User turn (scripted init / warm-start).
+        let mut messages = vec![Message::from_legacy(Role::System, "sys")];
+        for i in 0..8 {
+            messages.push(make_tool_output_msg(&format!("tool output {i}")));
+        }
+        // No Role::User message — task_goal will be empty.
+
+        let result = run_focus_auto_consolidation(
+            &messages,
+            4,
+            StubProvider {
+                response: "- should not be reached",
+            },
+            4096,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            result.is_none(),
+            "must return None when no user message is present (S2/S3)"
+        );
     }
 }

--- a/crates/zeph-core/src/agent/context/summarization.rs
+++ b/crates/zeph-core/src/agent/context/summarization.rs
@@ -2051,6 +2051,87 @@ impl<C: Channel> Agent<C> {
         );
     }
 
+    /// Run the Focus strategy auto-consolidation pass.
+    ///
+    /// Acquires the compression guard, clones the relevant message slice, calls
+    /// `run_focus_auto_consolidation`, and appends any resulting summary as an
+    /// `AutoConsolidated` knowledge block. Always releases the guard on exit.
+    /// This is a helper extracted from `maybe_proactive_compress` to stay within the
+    /// 100-line function limit.
+    async fn run_focus_auto_consolidation_pass(
+        &mut self,
+    ) -> Result<(), super::super::error::AgentError> {
+        use crate::agent::compaction_strategy::run_focus_auto_consolidation;
+
+        if !self.focus.try_acquire_compression() {
+            tracing::debug!("focus auto-consolidation skipped — compression already in progress");
+            return Ok(());
+        }
+        // RAII guard: releases the compression lock on drop, even on cancellation or panic.
+        // Clones the Arc so FocusState can still be mutably borrowed later in this scope.
+        let _compression_guard =
+            crate::agent::focus::CompressionGuard(self.focus.compressing.clone());
+
+        let _ = self.channel.send_status("consolidating knowledge...").await;
+
+        let focus_scorer_provider_name = self
+            .context_manager
+            .compression
+            .focus_scorer_provider
+            .as_str()
+            .to_owned();
+
+        // S4: if a provider name is configured but not resolvable, skip rather than silently
+        // burning premium tokens on the primary provider.
+        if !focus_scorer_provider_name.is_empty()
+            && !self.providers.provider_pool.iter().any(|e| {
+                e.effective_name()
+                    .eq_ignore_ascii_case(&focus_scorer_provider_name)
+            })
+        {
+            tracing::error!(
+                provider = %focus_scorer_provider_name,
+                "focus_scorer_provider not found in [[llm.providers]], skipping auto-consolidation"
+            );
+            return Ok(());
+        }
+
+        let focus_provider = self.resolve_background_provider(&focus_scorer_provider_name);
+
+        // Clone a bounded message slice before the await point (Await Discipline §6).
+        let preserve_tail = self.context_manager.compaction_preserve_tail;
+        let slice_end = self.msg.messages.len().saturating_sub(preserve_tail);
+        let messages: Vec<_> = self.msg.messages[..slice_end].to_vec();
+        let max_chars = self.focus.config.max_knowledge_tokens.saturating_mul(4);
+        let min_window = self.focus.config.auto_consolidate_min_window;
+
+        tracing::debug!(
+            min_window,
+            max_chars,
+            cached_tokens = self.providers.cached_prompt_tokens,
+            "focus auto-consolidation starting"
+        );
+
+        let outcome =
+            run_focus_auto_consolidation(&messages, min_window, focus_provider, max_chars).await;
+
+        match outcome {
+            Ok(Some(summary)) => {
+                tracing::info!(
+                    chars = summary.len(),
+                    "focus auto-consolidation produced summary"
+                );
+                self.focus.append_auto_knowledge(summary);
+                self.update_metrics(|m| m.compression_events += 1);
+            }
+            Ok(None) => tracing::debug!("focus auto-consolidation: no qualifying window found"),
+            Err(e) => tracing::warn!("focus auto-consolidation failed: {e}"),
+        }
+
+        let _ = self.channel.send_status("").await;
+        Ok(())
+    }
+
     /// Proactive context compression: fires before reactive compaction when context exceeds
     /// the configured `threshold_tokens`. Mutually exclusive with reactive compaction per turn
     /// (guarded by `compacted_this_turn`).
@@ -2085,6 +2166,17 @@ impl<C: Channel> Agent<C> {
         else {
             return Ok(());
         };
+
+        // Branch on compression strategy: Focus augments with auto-consolidation;
+        // all other proactive-eligible strategies use the LLM compaction path.
+        if matches!(
+            self.context_manager.compression.strategy,
+            crate::config::CompressionStrategy::Focus
+        ) {
+            self.run_focus_auto_consolidation_pass().await?;
+            // Focus augments context — do NOT set compacted_this_turn so reactive may still fire.
+            return Ok(());
+        }
 
         let tokens_before = self.providers.cached_prompt_tokens;
         let _ = self.channel.send_status("compressing context...").await;

--- a/crates/zeph-core/src/agent/context/tests.rs
+++ b/crates/zeph-core/src/agent/context/tests.rs
@@ -4388,3 +4388,42 @@ async fn rebuild_system_prompt_omits_memory_save_hint_when_tool_not_used() {
         "session hint must NOT be present when memory_save was not used"
     );
 }
+
+/// Verify that `maybe_proactive_compress` routes to `run_focus_auto_consolidation_pass`
+/// when the strategy is `CompressionStrategy::Focus` and `should_proactively_compress`
+/// returns `Some`.
+///
+/// Because `run_focus_auto_consolidation_pass` immediately returns when
+/// `focus.try_acquire_compression()` succeeds and the message history is shorter than
+/// `min_window`, we can observe routing by confirming: (a) no panic, (b) `Ok(())` returned,
+/// and (c) `compacted_this_turn` is NOT set (Focus does not set it).
+#[tokio::test]
+async fn maybe_proactive_compress_focus_strategy_routes_to_focus_pass() {
+    use zeph_config::CompressionStrategy;
+
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+    // Configure Focus strategy with a budget so should_proactively_compress fires.
+    agent.context_manager.compression.strategy = CompressionStrategy::Focus;
+    agent.context_manager.budget = Some(ContextBudget::new(100_000, 0.10));
+    // Soft threshold is 60% of 100_000 = 60_000; set tokens above that.
+    agent.providers.cached_prompt_tokens = 70_000;
+
+    // min_window defaults to 6; with only the system message, the pass returns None immediately.
+    let result = agent.maybe_proactive_compress().await;
+
+    assert!(
+        result.is_ok(),
+        "Focus route must not error on small history"
+    );
+    // Focus strategy must NOT set compacted_this_turn (reactive may still fire).
+    assert!(
+        !agent.context_manager.compaction.is_compacted_this_turn(),
+        "Focus must not set compacted_this_turn"
+    );
+}

--- a/crates/zeph-core/src/agent/focus.rs
+++ b/crates/zeph-core/src/agent/focus.rs
@@ -236,8 +236,7 @@ impl FocusState {
         self.append_knowledge(summary, KnowledgeBlockSource::LlmCurated)
     }
 
-    // TODO(#2510): wire Focus strategy Phase 2 — auto-consolidation path
-    #[cfg_attr(not(test), allow(dead_code))]
+    /// Append an auto-consolidated summary (from the Focus strategy auto-consolidation path).
     pub(crate) fn append_auto_knowledge(&mut self, summary: String) -> bool {
         self.append_knowledge(summary, KnowledgeBlockSource::AutoConsolidated)
     }
@@ -288,6 +287,23 @@ impl FocusState {
 impl Default for FocusState {
     fn default() -> Self {
         Self::new(FocusConfig::default())
+    }
+}
+
+/// RAII guard that releases the compression lock on drop.
+///
+/// Holds a clone of the `Arc<AtomicBool>` flag so it can release the lock without
+/// holding a borrow on the parent `FocusState`. This avoids borrow-checker conflicts
+/// when the rest of the function requires `&mut FocusState` (e.g. `append_auto_knowledge`).
+///
+/// Prevents the `compressing` flag from being permanently set to `true` when the
+/// future holding the lock is cancelled at an `.await` point or if a panic propagates
+/// before `release_compression()` is explicitly called.
+pub(crate) struct CompressionGuard(pub(crate) Arc<AtomicBool>);
+
+impl Drop for CompressionGuard {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::Release);
     }
 }
 

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -166,25 +166,19 @@ pub(crate) fn handle_migrate_config(
         migrate_memory_hebbian_consolidation_config(&after_memory_hebbian)?;
     let after_hebbian_consolidation = hebbian_consolidation_result.output;
 
-<<<<<<< HEAD
     // Step 32: add commented-out [[hooks.turn_complete]] block if absent (#3308).
     let hooks_turn_complete_result =
         migrate_hooks_turn_complete_config(&after_hebbian_consolidation)?;
     let after_hooks_turn_complete = hooks_turn_complete_result.output;
 
-    // Step 33: add missing default keys as commented-out entries.
-    let migrator = ConfigMigrator::new();
-    let result = migrator.migrate(&after_hooks_turn_complete)?;
-=======
-    // Step 32: inject auto_consolidate_min_window into [agent.focus] if absent (#3313).
+    // Step 33: inject auto_consolidate_min_window into [agent.focus] if absent (#3313).
     let focus_window_result =
-        migrate_focus_auto_consolidate_min_window(&after_hebbian_consolidation)?;
+        migrate_focus_auto_consolidate_min_window(&after_hooks_turn_complete)?;
     let after_focus_window = focus_window_result.output;
 
-    // Step 33: add missing default keys as commented-out entries.
+    // Step 34: add missing default keys as commented-out entries.
     let migrator = ConfigMigrator::new();
     let result = migrator.migrate(&after_focus_window)?;
->>>>>>> 4a167f7e (feat(core,a2a): Focus strategy auto-consolidation and MMA2A AgentCard capabilities)
 
     if diff {
         print_diff(&input, &result.output);
@@ -307,17 +301,16 @@ pub(crate) fn handle_migrate_config(
                  spliced HL-F3/F4 consolidation fields into [memory.hebbian] (#3345)."
             );
         }
-<<<<<<< HEAD
         if hooks_turn_complete_result.changed_count > 0 {
             eprintln!(
                 "Hooks turn_complete migration: \
                  added commented-out [[hooks.turn_complete]] block (#3308)."
-=======
+            );
+        }
         if focus_window_result.changed_count > 0 {
             eprintln!(
                 "Focus migration: added commented-out \
                  auto_consolidate_min_window to [agent.focus] (#3313)."
->>>>>>> 4a167f7e (feat(core,a2a): Focus strategy auto-consolidation and MMA2A AgentCard capabilities)
             );
         }
         eprintln!(

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -8,9 +8,10 @@ use zeph_core::config::migrate::{
     ConfigMigrator, migrate_acp_subagents_config, migrate_agent_budget_hint,
     migrate_agent_retry_to_tools_retry, migrate_autodream_config,
     migrate_compression_predictor_config, migrate_database_url, migrate_egress_config,
-    migrate_forgetting_config, migrate_hooks_permission_denied_config,
-    migrate_hooks_turn_complete_config, migrate_magic_docs_config, migrate_mcp_elicitation_config,
-    migrate_mcp_trust_levels, migrate_memory_graph_config, migrate_memory_hebbian_config,
+    migrate_focus_auto_consolidate_min_window, migrate_forgetting_config,
+    migrate_hooks_permission_denied_config, migrate_hooks_turn_complete_config,
+    migrate_magic_docs_config, migrate_mcp_elicitation_config, migrate_mcp_trust_levels,
+    migrate_memory_graph_config, migrate_memory_hebbian_config,
     migrate_memory_hebbian_consolidation_config, migrate_memory_reasoning_config,
     migrate_memory_retrieval_config, migrate_microcompact_config,
     migrate_orchestration_persistence, migrate_otel_filter, migrate_planner_model_to_provider,
@@ -165,6 +166,7 @@ pub(crate) fn handle_migrate_config(
         migrate_memory_hebbian_consolidation_config(&after_memory_hebbian)?;
     let after_hebbian_consolidation = hebbian_consolidation_result.output;
 
+<<<<<<< HEAD
     // Step 32: add commented-out [[hooks.turn_complete]] block if absent (#3308).
     let hooks_turn_complete_result =
         migrate_hooks_turn_complete_config(&after_hebbian_consolidation)?;
@@ -173,6 +175,16 @@ pub(crate) fn handle_migrate_config(
     // Step 33: add missing default keys as commented-out entries.
     let migrator = ConfigMigrator::new();
     let result = migrator.migrate(&after_hooks_turn_complete)?;
+=======
+    // Step 32: inject auto_consolidate_min_window into [agent.focus] if absent (#3313).
+    let focus_window_result =
+        migrate_focus_auto_consolidate_min_window(&after_hebbian_consolidation)?;
+    let after_focus_window = focus_window_result.output;
+
+    // Step 33: add missing default keys as commented-out entries.
+    let migrator = ConfigMigrator::new();
+    let result = migrator.migrate(&after_focus_window)?;
+>>>>>>> 4a167f7e (feat(core,a2a): Focus strategy auto-consolidation and MMA2A AgentCard capabilities)
 
     if diff {
         print_diff(&input, &result.output);
@@ -295,10 +307,17 @@ pub(crate) fn handle_migrate_config(
                  spliced HL-F3/F4 consolidation fields into [memory.hebbian] (#3345)."
             );
         }
+<<<<<<< HEAD
         if hooks_turn_complete_result.changed_count > 0 {
             eprintln!(
                 "Hooks turn_complete migration: \
                  added commented-out [[hooks.turn_complete]] block (#3308)."
+=======
+        if focus_window_result.changed_count > 0 {
+            eprintln!(
+                "Focus migration: added commented-out \
+                 auto_consolidate_min_window to [agent.focus] (#3313)."
+>>>>>>> 4a167f7e (feat(core,a2a): Focus strategy auto-consolidation and MMA2A AgentCard capabilities)
             );
         }
         eprintln!(


### PR DESCRIPTION
## Summary

- **#3313 (Focus)**: wires the previously-declared `CompressionStrategy::Focus` into the proactive compaction pipeline. When active, the agent identifies the oldest low-relevance message window via TF-Jaccard scoring and extracts key facts into an `AutoConsolidated` `KnowledgeBlock` using `focus_scorer_provider`. AtomicBool guard is now RAII (`CompressionGuard`) — safe under future cancellation and panic.
- **#3326 (MMA2A)**: adds `images`/`audio`/`files` capability fields to `AgentCard` with full backward-compatible `#[serde(default)]` and fluent builder helpers. Bootstrap wiring deferred to #3378.

## Changes

**zeph-core:**
- `run_focus_auto_consolidation` — TF-Jaccard scoring + LLM extraction with 20s timeout
- `run_focus_auto_consolidation_pass` — Focus branch in `maybe_proactive_compress`
- `CompressionGuard` RAII struct — releases `compressing` AtomicBool on drop
- Skips consolidation when no User message exists or `focus_scorer_provider` is misconfigured

**zeph-config:**
- `FocusConfig.auto_consolidate_min_window` (default 6)
- `migrate-config` step 31 via `toml_edit`

**zeph-context:**
- `should_proactively_compress` handles `CompressionStrategy::Focus`

**zeph-a2a:**
- `AgentCapabilities.{images,audio,files}` fields
- `AgentCardBuilder.{images,audio,files}()` helpers

## Test Plan

- [ ] `cargo nextest run -p zeph-config -p zeph-a2a --lib --bins` — 409 tests pass
- [ ] `cargo nextest run -p zeph-core --lib --bins` — 1488 tests pass
- [ ] `cargo nextest run -p zeph-context -E 'test(focus)' --lib` — 3 tests pass
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy -p zeph-core -p zeph-config -p zeph-context -p zeph-a2a -- -D warnings` — clean
- [ ] Live test with `[memory.compression] strategy = "focus"` config — playbook: `.local/testing/playbooks/focus-auto-consolidation.md`
- [ ] Live test for AgentCard modality fields — playbook: `.local/testing/playbooks/mma2a-capabilities.md`

## Follow-up Issues Filed

- #3378 — wire AgentCard modality at A2A bootstrap (deferred from #3326)
- #3386 — offload `score_blocks_mig` O(K²) to `spawn_blocking`
- #3387 — validate `auto_consolidate_min_window` rejects zero

Closes #3313
Closes #3326