### PR TITLE
fix(memory): pass embed provider to ReasoningBank extraction pipeline and narrow self-judge window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   entries, causing the probe to fail and `ensure_collection("reasoning_strategies")` to never be
   called. The fix passes `build_memory_embed_provider()` result into `attach_reasoning_memory` and
   falls back to the primary provider when no dedicated embed provider is configured (#3375).
+- ReasoningBank extraction pipeline now passes the dedicated embed provider (from
+  `SemanticMemory::effective_embed_provider()`) to `process_reasoning_turn` instead of the primary
+  routing provider. This eliminates the Qdrant dimension mismatch (768 vs 1536) that caused every
+  upsert to fail and left `embedded_at = NULL` indefinitely (#3382).
+- ReasoningBank self-judge now evaluates only the last `self_judge_window` messages (default: 2,
+  i.e. the final user+assistant exchange) instead of the full conversation tail. Added a
+  `min_assistant_chars` guard (default: 50) to skip trivial short responses. Together these
+  changes eliminate false `Failure` outcomes caused by multi-session context confusing the
+  evaluator model (#3383).
 
 - `--bare` mode now skips the file change watcher: `with_hooks_config` is no longer called
   unconditionally in `runner.rs` — it is guarded by `!exec_mode.bare`, preventing background

--- a/config/default.toml
+++ b/config/default.toml
@@ -1169,6 +1169,8 @@ sweep_batch_size = 100
 # max_messages = 6
 # min_messages = 2
 # max_message_chars = 2000
+# self_judge_window = 2    # max recent messages to self-judge evaluator (#3383)
+# min_assistant_chars = 50 # skip self-judge for short replies (#3383)
 #
 # [learning]
 # feedback_provider = "fast" # SLM: three-class classification

--- a/crates/zeph-config/src/memory.rs
+++ b/crates/zeph-config/src/memory.rs
@@ -2660,6 +2660,13 @@ pub struct ReasoningConfig {
     pub extraction_timeout_secs: u64,
     /// Timeout in seconds for the distillation LLM call. Default: `30`.
     pub distill_timeout_secs: u64,
+    /// Maximum number of recent messages passed to the self-judge evaluator.
+    /// Narrowing to the last user+assistant pair improves classification accuracy.
+    /// Default: `2`.
+    pub self_judge_window: usize,
+    /// Minimum characters in the assistant response to trigger self-judge.
+    /// Short or trivial responses are skipped. Default: `50`.
+    pub min_assistant_chars: usize,
 }
 
 impl Default for ReasoningConfig {
@@ -2676,6 +2683,8 @@ impl Default for ReasoningConfig {
             min_messages: 2,
             extraction_timeout_secs: 30,
             distill_timeout_secs: 30,
+            self_judge_window: 2,
+            min_assistant_chars: 50,
         }
     }
 }

--- a/crates/zeph-config/src/migrate.rs
+++ b/crates/zeph-config/src/migrate.rs
@@ -2574,6 +2574,100 @@ pub fn migrate_memory_reasoning_config(toml_src: &str) -> Result<MigrationResult
     })
 }
 
+/// Insert commented-out `self_judge_window` and `min_assistant_chars` keys under an existing
+/// `[memory.reasoning]` block when they are absent (#3383).
+///
+/// Configs that lack a `[memory.reasoning]` section are returned unchanged (the
+/// [`migrate_memory_reasoning_config`] step is responsible for adding the section).
+/// Idempotent when either key is already present.
+///
+/// # Errors
+///
+/// This function is infallible in practice; the `Result` return type matches the migration
+/// function convention for use in chained pipelines.
+pub fn migrate_memory_reasoning_judge_config(
+    toml_src: &str,
+) -> Result<MigrationResult, MigrateError> {
+    let has_section = toml_src.lines().any(|l| l.trim() == "[memory.reasoning]");
+    if !has_section {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    // Check if both keys are already present (active or commented).
+    let has_window = toml_src.lines().any(|l| {
+        let t = l.trim().trim_start_matches('#').trim();
+        t.starts_with("self_judge_window")
+    });
+    let has_min_chars = toml_src.lines().any(|l| {
+        let t = l.trim().trim_start_matches('#').trim();
+        t.starts_with("min_assistant_chars")
+    });
+    if has_window && has_min_chars {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    // Append the new keys after the last line belonging to [memory.reasoning].
+    // Strategy: find the last line of the [memory.reasoning] block (before the next section
+    // header) and insert the commented-out keys after it.
+    let lines: Vec<&str> = toml_src.lines().collect();
+    let mut section_start = None;
+    let mut insert_after = None;
+
+    for (i, line) in lines.iter().enumerate() {
+        if line.trim() == "[memory.reasoning]" {
+            section_start = Some(i);
+        }
+        if let Some(start) = section_start {
+            let trimmed = line.trim();
+            // A new top-level section header ends the current section.
+            if i > start && trimmed.starts_with('[') && !trimmed.starts_with("[[") {
+                break;
+            }
+            insert_after = Some(i);
+        }
+    }
+
+    let Some(insert_idx) = insert_after else {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    };
+
+    let mut new_lines: Vec<String> = lines.iter().map(|l| (*l).to_owned()).collect();
+    let mut additions = Vec::new();
+    if !has_window {
+        additions.push(
+            "# self_judge_window = 2   # max recent messages passed to self-judge (#3383)"
+                .to_owned(),
+        );
+    }
+    if !has_min_chars {
+        additions.push(
+            "# min_assistant_chars = 50  # skip self-judge for short replies (#3383)".to_owned(),
+        );
+    }
+    for (offset, line) in additions.iter().enumerate() {
+        new_lines.insert(insert_idx + 1 + offset, line.clone());
+    }
+
+    let output = new_lines.join("\n") + if toml_src.ends_with('\n') { "\n" } else { "" };
+    Ok(MigrationResult {
+        output,
+        changed_count: additions.len(),
+        sections_changed: vec!["memory.reasoning".to_owned()],
+    })
+}
+
 /// Append a commented-out `[memory.hebbian]` block to `toml_src` when it is absent (HL-F1/F2, #3344).
 ///
 /// Idempotent: if a `[memory.hebbian]` or `# [memory.hebbian]` line already exists,

--- a/crates/zeph-core/src/agent/persistence.rs
+++ b/crates/zeph-core/src/agent/persistence.rs
@@ -1064,10 +1064,12 @@ impl<C: Channel> Agent<C> {
 
         let extract_provider = self.resolve_background_provider(cfg.extract_provider.as_str());
         let distill_provider = self.resolve_background_provider(cfg.distill_provider.as_str());
-        let embed_provider = self.provider.clone();
+        let embed_provider = memory.effective_embed_provider().clone();
         let store_limit = cfg.store_limit;
         let extraction_timeout = std::time::Duration::from_secs(cfg.extraction_timeout_secs);
         let distill_timeout = std::time::Duration::from_secs(cfg.distill_timeout_secs);
+        let self_judge_window = cfg.self_judge_window;
+        let min_assistant_chars = cfg.min_assistant_chars;
 
         self.lifecycle.supervisor.spawn(
             super::agent_supervisor::TaskClass::Enrichment,
@@ -1083,6 +1085,8 @@ impl<C: Channel> Agent<C> {
                         store_limit,
                         extraction_timeout,
                         distill_timeout,
+                        self_judge_window,
+                        min_assistant_chars,
                     },
                 )
                 .await

--- a/crates/zeph-memory/src/reasoning.rs
+++ b/crates/zeph-memory/src/reasoning.rs
@@ -621,6 +621,13 @@ pub struct ProcessTurnConfig {
     pub extraction_timeout: Duration,
     /// Timeout for the distillation LLM call.
     pub distill_timeout: Duration,
+    /// Maximum number of recent messages sliced from the turn history before passing
+    /// to the self-judge evaluator. Narrowing the window prevents digest/recap messages
+    /// from prior sessions from confusing the classifier. Default: `2`.
+    pub self_judge_window: usize,
+    /// Minimum character count in the last assistant message to trigger self-judge.
+    /// Short or trivial responses (greetings, one-word answers) are skipped. Default: `50`.
+    pub min_assistant_chars: usize,
 }
 
 /// Run the full extraction pipeline for a single turn.
@@ -646,8 +653,30 @@ pub async fn process_turn(
         store_limit,
         extraction_timeout,
         distill_timeout,
+        self_judge_window,
+        min_assistant_chars,
     } = cfg;
-    let Some(outcome) = run_self_judge(extract_provider, messages, extraction_timeout).await else {
+
+    // Narrow the message window to reduce noise from session digests and welcome-back
+    // messages that span prior sessions, which can confuse the self-judge classifier.
+    let judge_messages = if messages.len() > self_judge_window {
+        &messages[messages.len() - self_judge_window..]
+    } else {
+        messages
+    };
+
+    // Skip self-judge when the last assistant response is too short to be meaningful.
+    let last_assistant_chars = judge_messages
+        .iter()
+        .rev()
+        .find(|m| m.role == Role::Assistant)
+        .map_or(0, |m| m.content.len());
+    if last_assistant_chars < min_assistant_chars {
+        return Ok(());
+    }
+
+    let Some(outcome) = run_self_judge(extract_provider, judge_messages, extraction_timeout).await
+    else {
         return Ok(());
     };
 
@@ -1154,6 +1183,8 @@ mod tests {
             store_limit: 100,
             extraction_timeout: std::time::Duration::from_secs(1),
             distill_timeout: std::time::Duration::from_secs(1),
+            self_judge_window: 2,
+            min_assistant_chars: 0,
         };
         let result = process_turn(&mem, &provider, &provider, &provider, &[], cfg).await;
         assert!(

--- a/crates/zeph-memory/src/semantic/mod.rs
+++ b/crates/zeph-memory/src/semantic/mod.rs
@@ -749,7 +749,7 @@ impl SemanticMemory {
     /// Returns the provider to use for embedding calls.
     ///
     /// Returns the dedicated embed provider when configured, falling back to the main provider.
-    pub(crate) fn effective_embed_provider(&self) -> &AnyProvider {
+    pub fn effective_embed_provider(&self) -> &AnyProvider {
         self.embed_provider.as_ref().unwrap_or(&self.provider)
     }
 

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -13,12 +13,12 @@ use zeph_core::config::migrate::{
     migrate_magic_docs_config, migrate_mcp_elicitation_config, migrate_mcp_trust_levels,
     migrate_memory_graph_config, migrate_memory_hebbian_config,
     migrate_memory_hebbian_consolidation_config, migrate_memory_reasoning_config,
-    migrate_memory_retrieval_config, migrate_microcompact_config,
-    migrate_orchestration_persistence, migrate_otel_filter, migrate_planner_model_to_provider,
-    migrate_quality_config, migrate_sandbox_config, migrate_sandbox_egress_filter,
-    migrate_scheduler_daemon_config, migrate_session_recap_config, migrate_shell_transactional,
-    migrate_stt_to_provider, migrate_supervisor_config, migrate_telemetry_config,
-    migrate_vigil_config,
+    migrate_memory_reasoning_judge_config, migrate_memory_retrieval_config,
+    migrate_microcompact_config, migrate_orchestration_persistence, migrate_otel_filter,
+    migrate_planner_model_to_provider, migrate_quality_config, migrate_sandbox_config,
+    migrate_sandbox_egress_filter, migrate_scheduler_daemon_config, migrate_session_recap_config,
+    migrate_shell_transactional, migrate_stt_to_provider, migrate_supervisor_config,
+    migrate_telemetry_config, migrate_vigil_config,
 };
 
 /// Handle the `zeph migrate-config` command.
@@ -156,8 +156,13 @@ pub(crate) fn handle_migrate_config(
     let memory_reasoning_result = migrate_memory_reasoning_config(&after_memory_retrieval)?;
     let after_memory_reasoning = memory_reasoning_result.output;
 
+    // Step 29b: inject self_judge_window / min_assistant_chars into existing [memory.reasoning] (#3383).
+    let memory_reasoning_judge_result =
+        migrate_memory_reasoning_judge_config(&after_memory_reasoning)?;
+    let after_memory_reasoning_judge = memory_reasoning_judge_result.output;
+
     // Step 30: add commented-out [memory.hebbian] block if absent (#3344, HL-F1/F2).
-    let memory_hebbian_result = migrate_memory_hebbian_config(&after_memory_reasoning)?;
+    let memory_hebbian_result = migrate_memory_hebbian_config(&after_memory_reasoning_judge)?;
     let after_memory_hebbian = memory_hebbian_result.output;
 
     // Step 31: splice HL-F3/F4 consolidation fields into an existing [memory.hebbian] section
@@ -290,6 +295,12 @@ pub(crate) fn handle_migrate_config(
         if memory_retrieval_result.changed_count > 0 {
             eprintln!(
                 "Memory retrieval migration: added commented-out [memory.retrieval] block (#3340)."
+            );
+        }
+        if memory_reasoning_judge_result.changed_count > 0 {
+            eprintln!(
+                "Reasoning judge migration: added commented-out self_judge_window / \
+                 min_assistant_chars to [memory.reasoning] (#3383)."
             );
         }
         if memory_hebbian_result.changed_count > 0 {


### PR DESCRIPTION
## Summary

- **#3382**: `enqueue_reasoning_extraction_task` was cloning `self.provider` (the primary routing provider, 1536-dim) as the embed provider for Qdrant upserts, while the collection was created at 768 dims using the dedicated embed provider. Every upsert failed with `Wrong input: Vector dimension error: expected dim: 768, got 1536`, leaving `embedded_at = NULL` permanently and making Qdrant retrieval return empty results. Fixed by using `memory.effective_embed_provider()` from `SemanticMemory`, which routes to the dedicated embed provider when configured. Also changed `effective_embed_provider` visibility from `pub(crate)` to `pub` to allow access from `zeph-core`.

- **#3383**: The self-judge LLM call was receiving the full `max_messages` tail (up to 6 messages including welcome-back digest from prior sessions). This context confused `gpt-4o-mini` into classifying correct responses as failures. Fixed by adding `self_judge_window: usize` (default 2) and `min_assistant_chars: usize` (default 50) to `ReasoningConfig` and `ProcessTurnConfig`. Self-judge now evaluates only the final user+assistant exchange and skips trivial short responses.

- Added migrate-config step 29b to insert `self_judge_window` and `min_assistant_chars` into existing `[memory.reasoning]` blocks automatically.

## Test plan

- [ ] `cargo clippy --workspace -- -D warnings` — zero warnings
- [ ] `cargo nextest run --config-file .github/nextest.toml -p zeph-memory -p zeph-config -p zeph-core` — 3007 tests pass
- [ ] Verify Qdrant upserts succeed after fix: `reasoning_strategies` collection gets points, `embedded_at` is set
- [ ] Verify self-judge classifies correct step-by-step explanations as success with `self_judge_window = 2`

Closes #3382
Closes #3383