### PR TITLE
fix(core): bypass ML classifier for internal tool outputs (#3384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `FocusConfig.auto_consolidate_min_window = 0` no longer triggers LLM on every compress call:
   `Config::validate()` now rejects zero with a clear error, and `FocusState::should_auto_consolidate()`
   returns `false` until the configured number of turns has elapsed (default 4) (#3387).
+- ML injection classifier no longer fires false positives on internal Zeph tool outputs
+  (`invoke_skill`, `load_skill`, `memory_save`, `memory_search`, `compress_context`,
+  `complete_focus`, `start_focus`, `schedule_periodic`, `schedule_deferred`, `cancel_task`).
+  These tools produce only Zeph-generated text; the DeBERTa ML classifier is now bypassed
+  for them while the pattern-based sanitizer continues to run for telemetry. An adversarial-
+  MCP guard ensures that colon-namespaced tool names (e.g. `server:invoke_skill`) are never
+  matched against the allowlist (#3384).
 - `Notifier::fire_test()` now checks the master `notifications.enabled` switch first; if
   disabled, it returns an error instead of silently firing a test notification (#3364).
 - Fixed misleading comment in `drain_background_completions()`: the overflow branch drops

--- a/crates/zeph-core/src/agent/tool_execution/sanitize.rs
+++ b/crates/zeph-core/src/agent/tool_execution/sanitize.rs
@@ -11,6 +11,45 @@ fn is_policy_blocked_output(body: &str) -> bool {
     body.contains("[tool_error]") && body.contains("category: policy_blocked")
 }
 
+/// Tools whose outputs are produced exclusively by Zeph's own code paths and cannot
+/// carry attacker-controlled injection payloads. The `DeBERTa` ML classifier is bypassed
+/// for these tools because innocuous internal error strings (e.g. "skill not found: exit")
+/// trigger high-confidence false positives (#3384).
+///
+/// Safety invariant: only non-namespaced names are listed here. MCP tools use a
+/// `server:tool` format and are routed to `ContentSourceKind::McpResponse` before this
+/// check is reached, so they are never mistakenly matched.
+///
+/// `read_overflow` is intentionally excluded: its success path replays stored external
+/// tool output and must remain subject to ML classification.
+///
+/// NOTE: if you add a new first-party tool, update this list. See also the overlapping
+/// lists in `zeph-tools/src/config.rs::AdversarialPolicyConfig::default_exempt_tools`,
+/// `zeph-config/src/vigil.rs`, and `zeph-common/src/quarantine.rs` — each serves a
+/// different policy but must stay consistent.
+#[cfg(feature = "classifiers")]
+const INTERNAL_TOOLS: &[&str] = &[
+    "invoke_skill",
+    "load_skill",
+    "memory_save",
+    "memory_search",
+    "compress_context",
+    "complete_focus",
+    "start_focus",
+    "schedule_periodic",
+    "schedule_deferred",
+    "cancel_task",
+];
+
+/// Returns `true` only for non-MCP, Zeph-internal tools that cannot carry injection payloads.
+///
+/// The colon guard ensures a malicious MCP server cannot register a bare `invoke_skill`
+/// tool name and bypass ML classification — MCP tools always use `server:tool` naming.
+#[cfg(feature = "classifiers")]
+fn is_internal_tool(tool_name: &str) -> bool {
+    !tool_name.contains(':') && INTERNAL_TOOLS.contains(&tool_name)
+}
+
 impl<C: Channel> Agent<C> {
     /// Sanitize tool output body before inserting it into the LLM message history.
     ///
@@ -93,7 +132,8 @@ impl<C: Channel> Agent<C> {
                         | zeph_sanitizer::MemorySourceHint::LlmSummary
                 )
             ) || is_policy_blocked_output(body)
-                || is_utility_gate_synthetic;
+                || is_utility_gate_synthetic
+                || is_internal_tool(tool_name);
             if !skip_ml && self.security.sanitizer.has_classifier_backend() {
                 let ml_verdict = self.security.sanitizer.classify_injection(body).await;
                 match ml_verdict {
@@ -236,5 +276,58 @@ impl<C: Channel> Agent<C> {
         let body = self.apply_guardrail_to_tool_output(body, tool_name).await;
 
         (body, has_injection_flags)
+    }
+}
+
+#[cfg(all(test, feature = "classifiers"))]
+mod tests {
+    use super::is_internal_tool;
+
+    #[test]
+    fn internal_tool_allowlist_covers_all_zeph_tools() {
+        for name in [
+            "invoke_skill",
+            "load_skill",
+            "memory_save",
+            "memory_search",
+            "compress_context",
+            "complete_focus",
+            "start_focus",
+            "schedule_periodic",
+            "schedule_deferred",
+            "cancel_task",
+        ] {
+            assert!(
+                is_internal_tool(name),
+                "{name} must be in internal allowlist"
+            );
+        }
+    }
+
+    #[test]
+    fn external_and_mcp_tools_not_in_allowlist() {
+        for name in [
+            "shell",
+            "web-scrape",
+            "fetch",
+            "read_overflow",
+            "github:list_issues",
+            "my-server:invoke_skill",
+            "mcp:invoke_skill",
+        ] {
+            assert!(
+                !is_internal_tool(name),
+                "{name} must NOT be in internal allowlist"
+            );
+        }
+    }
+
+    #[test]
+    fn colon_namespaced_names_always_excluded() {
+        // An adversarial MCP server cannot bypass classification by registering a tool
+        // with the same bare name as an internal tool.
+        assert!(!is_internal_tool("server:invoke_skill"));
+        assert!(!is_internal_tool("attacker:memory_save"));
+        assert!(!is_internal_tool("x:cancel_task"));
     }
 }


### PR DESCRIPTION
## Summary

- Add `INTERNAL_TOOLS` allowlist (10 names) in `sanitize.rs` so the DeBERTa ML classifier is skipped for outputs generated entirely by the Zeph tool system
- Add colon guard (`!tool_name.contains(':')`) to prevent adversarial MCP servers from impersonating internal tool names and bypassing classification
- Pattern-based sanitization, exfiltration detection, PII scrubbing, and `injection_flags` telemetry remain fully active

## Root cause

The classifier scored `"skill not found: exit"` (emitted by `invoke_skill`) as `INJECTION=0.9999`, above the `0.80` threshold. Internal tool outputs are entirely Zeph-generated and cannot contain external injection payloads.

## Not addressed in this PR

- **#3386** (`score_blocks_mig` O(K²) in `spawn_blocking`): `run_focus_auto_consolidation` does not exist on `main` — it lives on unmerged PR #3388. This fix will be applied as a follow-up after #3388 merges.

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace --features full -- -D warnings` — 0 warnings
- [ ] `cargo nextest run --workspace --lib --bins` — 8416 passed
- [ ] 3 new unit tests cover: allowlist membership, MCP/external exclusion, colon-guard invariant
- [ ] Follow-up issue #3393 (P2) filed for integration test proving `skip_ml` path fires at `sanitize_tool_output` call site

Closes #3384