### PR TITLE
fix(skills): skip skill matcher in bare mode and stabilize embed model name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `min_assistant_chars` guard (default: 50) to skip trivial short responses. Together these
   changes eliminate false `Failure` outcomes caused by multi-session context confusing the
   evaluator model (#3383).
+- skills: skip `build_skill_matcher` in `--bare` mode to prevent `zeph_skills` Qdrant collection
+  destruction on CI startup (#3390).
+- skills: use stable embed provider model name for Qdrant collection versioning to prevent
+  collection oscillation and near-zero cosine scores (#3391).
 
 - `--bare` mode now skips the file change watcher: `with_hooks_config` is no longer called
   unconditionally in `runner.rs` — it is guarded by `!exec_mode.bare`, preventing background

--- a/crates/zeph-core/src/provider_factory.rs
+++ b/crates/zeph-core/src/provider_factory.rs
@@ -402,6 +402,40 @@ pub fn effective_embedding_model(config: &Config) -> String {
     config.llm.embedding_model.clone()
 }
 
+/// Resolve the stable embedding model name for skill-matcher collection versioning.
+///
+/// This uses the same entry resolution as the embedding provider itself: the entry
+/// with `embed = true`, preferring its `embedding_model` field and falling back to
+/// its `model` field. Using the actual provider's model name prevents the
+/// `model_has_changed` check in [`zeph_memory::embedding_registry`] from triggering
+/// false positives that would rebuild the `zeph_skills` collection on every startup.
+///
+/// Falls back to [`effective_embedding_model`] when no dedicated embed entry exists.
+#[must_use]
+pub fn stable_skill_embedding_model(config: &Config) -> String {
+    // Find the dedicated embed entry (same lookup as `create_embedding_provider`).
+    let embed_entry = config.llm.providers.iter().find(|e| e.embed).or_else(|| {
+        config
+            .llm
+            .providers
+            .iter()
+            .find(|e| e.embedding_model.is_some())
+    });
+
+    if let Some(entry) = embed_entry {
+        // Prefer the explicit `embedding_model` field; fall back to the `model` field.
+        if let Some(em) = entry.embedding_model.as_ref().filter(|s| !s.is_empty()) {
+            return em.clone();
+        }
+        if let Some(m) = entry.model.as_ref().filter(|s| !s.is_empty()) {
+            return m.clone();
+        }
+    }
+
+    // No dedicated embed entry — fall back to the general embedding model resolution.
+    effective_embedding_model(config)
+}
+
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "candle")]
@@ -447,5 +481,70 @@ mod tests {
                 | zeph_llm::candle_provider::Device::Cuda(_)
                 | zeph_llm::candle_provider::Device::Metal(_)
         ));
+    }
+
+    use super::{effective_embedding_model, stable_skill_embedding_model};
+    use crate::config::{Config, ProviderKind};
+    use zeph_config::providers::ProviderEntry;
+
+    fn make_provider_entry(
+        embed: bool,
+        model: Option<&str>,
+        embedding_model: Option<&str>,
+    ) -> ProviderEntry {
+        ProviderEntry {
+            provider_type: ProviderKind::Ollama,
+            embed,
+            model: model.map(str::to_owned),
+            embedding_model: embedding_model.map(str::to_owned),
+            ..ProviderEntry::default()
+        }
+    }
+
+    #[test]
+    fn stable_skill_embedding_model_prefers_embedding_model_field() {
+        let mut config = Config::default();
+        config.llm.providers = vec![make_provider_entry(
+            true,
+            Some("chat-model"),
+            Some("embed-v2"),
+        )];
+        assert_eq!(stable_skill_embedding_model(&config), "embed-v2");
+    }
+
+    #[test]
+    fn stable_skill_embedding_model_falls_back_to_model_field() {
+        let mut config = Config::default();
+        config.llm.providers = vec![make_provider_entry(
+            true,
+            Some("nomic-embed-text-v2-moe:latest"),
+            None,
+        )];
+        assert_eq!(
+            stable_skill_embedding_model(&config),
+            "nomic-embed-text-v2-moe:latest"
+        );
+    }
+
+    #[test]
+    fn stable_skill_embedding_model_finds_embed_flag_entry() {
+        let mut config = Config::default();
+        config.llm.providers = vec![
+            make_provider_entry(false, Some("chat-model"), None),
+            make_provider_entry(true, Some("embed-model"), Some("text-embed-3")),
+        ];
+        assert_eq!(stable_skill_embedding_model(&config), "text-embed-3");
+    }
+
+    #[test]
+    fn stable_skill_embedding_model_falls_back_to_effective_when_no_embed_entry() {
+        let mut config = Config::default();
+        config.llm.embedding_model = "global-embed-model".to_owned();
+        // No embed=true entry, no embedding_model field set — falls back to effective_embedding_model.
+        config.llm.providers = vec![make_provider_entry(false, Some("chat"), None)];
+        assert_eq!(
+            stable_skill_embedding_model(&config),
+            effective_embedding_model(&config)
+        );
     }
 }

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -20,7 +20,7 @@ pub use provider::{
 };
 pub use skills::{
     create_embedding_provider, create_skill_matcher, effective_embedding_model, managed_skills_dir,
-    plugins_dir,
+    plugins_dir, stable_skill_embedding_model,
 };
 
 use std::path::{Path, PathBuf};
@@ -692,7 +692,10 @@ impl AppBuilder {
         meta: &[&SkillMeta],
         memory: &SemanticMemory,
     ) -> Option<SkillMatcherBackend> {
-        let embed_model = self.embedding_model();
+        // Use the stable model name derived from the resolved embed provider entry so that
+        // `model_has_changed` in `EmbeddingRegistry` does not trigger a collection rebuild on
+        // every restart when `effective_embedding_model` returns an unstable or empty string.
+        let embed_model = stable_skill_embedding_model(&self.config);
         create_skill_matcher(
             &self.config,
             provider,

--- a/src/bootstrap/skills.rs
+++ b/src/bootstrap/skills.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-pub use zeph_core::provider_factory::effective_embedding_model;
+pub use zeph_core::provider_factory::{effective_embedding_model, stable_skill_embedding_model};
 
 use std::path::PathBuf;
 use std::pin::Pin;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1032,7 +1032,14 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     #[cfg(feature = "tui")]
     tui_status!("Loading skills...");
     let (matcher, cli_history) = tokio::join!(
-        app.build_skill_matcher(&embedding_provider, &all_meta_refs, &memory),
+        async {
+            if exec_mode.bare {
+                None
+            } else {
+                app.build_skill_matcher(&embedding_provider, &all_meta_refs, &memory)
+                    .await
+            }
+        },
         build_cli_history(&memory),
     );
     if matcher.is_some() {


### PR DESCRIPTION
## Summary

- **#3390**: `--bare` mode was calling `build_skill_matcher` with an empty meta slice (from `SkillRegistry::empty()`), causing `EmbeddingRegistry::sync` to delete all 124 existing `zeph_skills` Qdrant points as orphans on every CI startup. Fixed by guarding `build_skill_matcher` behind `exec_mode.bare` in `runner.rs`.

- **#3391**: `build_skill_matcher` used `self.embedding_model()` (backed by `effective_embedding_model`) as the Qdrant collection version key. This string could be empty or unstable across restarts, causing `model_has_changed` in `EmbeddingRegistry` to trigger a full collection rebuild every session. After rebuild the stored model name remained unstable, creating an oscillation that produced near-zero cosine scores (~0.022) at query time. Fixed by introducing `stable_skill_embedding_model()` that resolves the embed provider entry directly to a stable model name.

## Changes

- `src/runner.rs` — bare-mode guard around `build_skill_matcher`
- `crates/zeph-core/src/provider_factory.rs` — new `stable_skill_embedding_model()` function with 4 unit tests
- `src/bootstrap/skills.rs`, `src/bootstrap/mod.rs` — re-export and use `stable_skill_embedding_model`
- `CHANGELOG.md` — entries in `[Unreleased]`

## Test plan

- [ ] 8780 unit tests pass (`cargo nextest run --workspace --features full --lib --bins`)
- [ ] `cargo +nightly fmt --check` clean
- [ ] `cargo clippy -p zeph-core -p zeph -- -D warnings` clean
- [ ] Live test: run `--bare` mode, then full mode — verify `zeph_skills` collection count is unchanged after bare run (`curl http://localhost:6333/collections/zeph_skills`)
- [ ] Live test: verify skill injection fires for matching queries (max_score > 0.20 in logs)

Closes #3390
Closes #3391