### PR TITLE
feat(memory): HeLa-Mem spreading activation retrieval and query-bias tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- HL-F5 HeLa-Mem spreading activation retrieval (#3346). `hela_spreading_recall` performs BFS
+  from the top-1 ANN anchor in `zeph_graph_entities`, propagating multiplicative edge weights
+  (`path_weight = Π edge.weight`). Each visited node is scored as `path_weight × cosine(query,
+  entity)` with negative cosine clamped to 0.0. Multi-path convergence keeps the maximum
+  `path_weight`. Isolated anchor fallback returns a single synthetic `HelaFact` (edge id=0)
+  scored by the real anchor cosine. Per-step 8 ms circuit breaker emits WARN and returns empty
+  on budget exhaustion. Hebbian reinforcement increments edge weights on truncated top-k kept
+  edges. Dim-mismatch guard via `OnceLock<String>` prevents repeated Qdrant probes after
+  detection. New config fields under `[memory.hebbian]`: `spreading_activation`, `spread_depth`,
+  `spread_edge_types`, `step_budget_ms`. New `HelaSpreadRuntime` struct on `SemanticMemory`
+  attached via `with_hebbian_spread()`. Config migration step 31b splices the four fields into
+  existing configs. WARN logged for unrecognised edge type strings in `spread_edge_types`.
+- `VectorStore::get_points` default trait method returning `Err(Unsupported)` for backends that
+  cannot return raw vectors; Qdrant impl via `GetPointsBuilder::new(...).with_vectors(true)`.
+- `GraphStore::qdrant_point_ids_for_entities` SQL helper (490-entity batch chunks).
+- `Edge::synthetic_anchor(entity_id)` marker constructor for the isolated-anchor fallback path.
+- `EmbeddingStore::get_vectors_from_collection` batched vector retrieval helper.
+- Tracing spans on `apply_query_bias` (`memory.query_bias.apply`) and `profile_centroid_cached`
+  (`memory.query_bias.centroid`) with structured debug events for bias applied/skipped,
+  centroid computed, and centroid cache hits (#3379).
 - Provider preference persistence per channel (#3308). The last-used provider (set via
   `/provider <name>`) is now saved to `SQLite` after each successful switch and automatically
   restored on the next session start. Identity is keyed by `(channel_type, channel_id)` —

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10462,6 +10462,7 @@ dependencies = [
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
+ "tracing-test",
  "uuid",
  "zeph-common",
  "zeph-db",

--- a/config/default.toml
+++ b/config/default.toml
@@ -367,6 +367,10 @@ importance_weight = 0.15
 # [memory.hebbian]                       # HL-F1/F2 (#3344) Hebbian edge reinforcement
 # enabled = false                        # opt-in master switch; no DB writes when false
 # hebbian_lr = 0.1                       # weight increment per co-activation (typical range 0.01–0.5)
+# spreading_activation = false           # HL-F5 (#3346): BFS from top-1 ANN anchor; requires enabled=true
+# spread_depth = 2                       # BFS hops for spreading activation, clamped [1, 6]
+# spread_edge_types = []                 # MAGMA edge types to traverse; empty = all types
+# step_budget_ms = 8                     # per-step circuit-breaker (anchor ANN / edges batch / vectors batch)
 
 # Code RAG: AST-based code indexing and hybrid retrieval
 # Requires Qdrant for semantic retrieval; tree-sitter grammars are always available

--- a/crates/zeph-config/src/memory.rs
+++ b/crates/zeph-config/src/memory.rs
@@ -1232,6 +1232,23 @@ pub struct HebbianConfig {
     /// Maximum number of neighbouring entity summaries passed to the LLM per candidate
     /// (HL-F4, #3345). Default: `20`.
     pub consolidation_max_neighbors: usize,
+    /// Enable HL-F5 spreading activation from the top-1 ANN anchor (HL-F5, #3346).
+    ///
+    /// When `true` and `enabled = true`, `recall_graph_hela` performs BFS from the
+    /// nearest entity anchor, scoring nodes by `path_weight × cosine`. Default: `false`.
+    pub spreading_activation: bool,
+    /// BFS depth for HL-F5 spreading activation. Clamped to `[1, 6]`. Default: `2`.
+    pub spread_depth: u32,
+    /// MAGMA edge-type filter for HL-F5 spreading activation.
+    ///
+    /// Accepted values: `"semantic"`, `"temporal"`, `"causal"`, `"entity"`.
+    /// Empty = traverse all edge types. Default: `[]`.
+    pub spread_edge_types: Vec<String>,
+    /// Per-step circuit-breaker timeout for HL-F5 in milliseconds.
+    ///
+    /// Any internal step (anchor ANN, edges batch, vectors batch) that exceeds this
+    /// duration triggers an `Ok(Vec::new())` fallback with a `WARN`. Default: `8`.
+    pub step_budget_ms: u64,
 }
 
 impl Default for HebbianConfig {
@@ -1246,6 +1263,10 @@ impl Default for HebbianConfig {
             consolidation_cooldown_secs: 86_400,
             consolidation_prompt_timeout_secs: 30,
             consolidation_max_neighbors: 20,
+            spreading_activation: false,
+            spread_depth: 2,
+            spread_edge_types: Vec::new(),
+            step_budget_ms: 8,
         }
     }
 }

--- a/crates/zeph-config/src/migrate.rs
+++ b/crates/zeph-config/src/migrate.rs
@@ -2762,6 +2762,63 @@ pub fn migrate_memory_hebbian_consolidation_config(
     })
 }
 
+/// Splice missing HL-F5 spreading-activation fields into an existing `[memory.hebbian]` section
+/// (HL-F5, #3346).
+///
+/// Three branches:
+/// - Section absent → no-op (handled by `migrate_memory_hebbian_config`).
+/// - Section present but missing HL-F5 fields → append commented-out defaults.
+/// - Section present with all fields → no-op.
+///
+/// # Errors
+///
+/// Infallible in practice; `Result` matches the migration convention.
+pub fn migrate_memory_hebbian_spread_config(
+    toml_src: &str,
+) -> Result<MigrationResult, MigrateError> {
+    let has_section = toml_src.lines().any(|l| l.trim() == "[memory.hebbian]");
+
+    if !has_section {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    // Check if all HL-F5 fields are already present (active or commented).
+    let has_spreading = toml_src
+        .lines()
+        .any(|l| l.trim().starts_with("spreading_activation"));
+    let has_depth = toml_src
+        .lines()
+        .any(|l| l.trim().starts_with("spread_depth"));
+    let has_budget = toml_src
+        .lines()
+        .any(|l| l.trim().starts_with("step_budget_ms"));
+
+    if has_spreading && has_depth && has_budget {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let extra = "\n# HL-F5 spreading-activation fields (#3346) — splice into existing [memory.hebbian] section:\n\
+        # spreading_activation = false   # opt-in BFS from top-1 ANN anchor; requires enabled=true\n\
+        # spread_depth = 2               # BFS hops, clamped [1,6]\n\
+        # spread_edge_types = []         # MAGMA edge types to traverse; empty = all\n\
+        # step_budget_ms = 8             # per-step circuit-breaker timeout (anchor ANN / edges / vectors)\n";
+
+    let output = format!("{toml_src}{extra}");
+    Ok(MigrationResult {
+        output,
+        changed_count: 1,
+        sections_changed: vec!["memory.hebbian.spreading_activation".to_owned()],
+    })
+}
+
 /// Append a commented-out `[[hooks.turn_complete]]` block to `toml_src` when it is absent (#3308).
 ///
 /// Idempotent: if a `[[hooks.turn_complete]]` or `# [[hooks.turn_complete]]` line already exists,

--- a/crates/zeph-memory/Cargo.toml
+++ b/crates/zeph-memory/Cargo.toml
@@ -59,6 +59,7 @@ tempfile.workspace = true
 testcontainers.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 toml.workspace = true
+tracing-test.workspace = true
 zeph-llm.workspace = true
 
 [lints]

--- a/crates/zeph-memory/src/embedding_store.rs
+++ b/crates/zeph-memory/src/embedding_store.rs
@@ -557,6 +557,30 @@ impl EmbeddingStore {
         Ok(results)
     }
 
+    /// Retrieve raw vectors for the given Qdrant point IDs from `collection`.
+    ///
+    /// Returns a map of `point_id → embedding`. Missing ids are silently dropped.
+    /// Returns an empty map when the backend does not support vector retrieval
+    /// (e.g. `DbVectorStore` / `InMemoryVectorStore` without an override).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the underlying store returns a non-`Unsupported` error.
+    pub async fn get_vectors_from_collection(
+        &self,
+        collection: &str,
+        point_ids: &[String],
+    ) -> Result<std::collections::HashMap<String, Vec<f32>>, MemoryError> {
+        if point_ids.is_empty() {
+            return Ok(std::collections::HashMap::new());
+        }
+        match self.ops.get_points(collection, point_ids.to_vec()).await {
+            Ok(points) => Ok(points.into_iter().map(|p| (p.id, p.vector)).collect()),
+            Err(crate::VectorStoreError::Unsupported(_)) => Ok(std::collections::HashMap::new()),
+            Err(e) => Err(MemoryError::VectorStore(e)),
+        }
+    }
+
     /// Fetch raw vectors for the given message IDs from the `SQLite` vector store.
     ///
     /// Returns an empty map when using Qdrant backend (vectors not locally stored).

--- a/crates/zeph-memory/src/graph/activation.rs
+++ b/crates/zeph-memory/src/graph/activation.rs
@@ -14,10 +14,12 @@
 //! - MAGMA edge type filtering via `edge_types` parameter
 
 use std::collections::HashMap;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::sync::OnceLock;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 #[allow(unused_imports)]
 use zeph_db::sql;
 
+use crate::embedding_store::EmbeddingStore;
 use crate::error::MemoryError;
 use crate::graph::store::GraphStore;
 use crate::graph::types::{Edge, EdgeType, edge_type_weight, evolved_weight};
@@ -57,6 +59,398 @@ pub struct SpreadingActivationParams {
     /// Maximum seeds per community ID. 0 = unlimited. Default: 3.
     pub seed_community_cap: usize,
 }
+
+// ── HL-F5: HeLa-Mem spreading activation (#3346) ─────────────────────────────
+
+/// A graph edge surfaced by HL-F5 spreading activation (#3346), scored by
+/// `path_weight × max(cosine_query_to_endpoint, 0.0)`.
+///
+/// Mirrors [`ActivatedFact`] so callers can dispatch over a single
+/// `Vec<HelaFact>` ↔ `Vec<ActivatedFact>` ↔ `Vec<GraphFact>` shape at the
+/// strategy-selection site.
+#[derive(Debug, Clone)]
+pub struct HelaFact {
+    /// The edge by which the higher-scored endpoint was reached.
+    pub edge: Edge,
+    /// Final HL-F5 score: `path_weight × cosine_clamped`. Range: `[0.0, +∞)`.
+    pub score: f32,
+    /// BFS depth at which `edge` was traversed (`1..=spread_depth`).
+    /// `0` is reserved for the synthetic anchor edge in the isolated-anchor fallback.
+    pub depth: u32,
+    /// Multiplicative product of edge weights along the BFS path that reached
+    /// this edge's far endpoint. Range: `[0.0, +∞)`.
+    pub path_weight: f32,
+    /// Clamped cosine similarity of the far endpoint's entity embedding
+    /// to the query embedding, in `[0.0, 1.0]`. `None` when the endpoint
+    /// has no stored embedding (skipped from results in that case).
+    pub cosine: Option<f32>,
+}
+
+/// Parameters for HL-F5 spreading activation retrieval.
+///
+/// Build via [`Default`] and override individual fields:
+///
+/// ```rust
+/// use zeph_memory::graph::activation::HelaSpreadParams;
+///
+/// let params = HelaSpreadParams { spread_depth: 3, ..Default::default() };
+/// ```
+#[derive(Debug, Clone)]
+pub struct HelaSpreadParams {
+    /// BFS hops. Clamped to `[1, 6]` at runtime. Default: `2`.
+    pub spread_depth: u32,
+    /// MAGMA edge-type filter. Empty = all types. Default: `[]`.
+    pub edge_types: Vec<EdgeType>,
+    /// Soft upper bound on the visited-node set. Default: `200`.
+    pub max_visited: usize,
+    /// Per-step circuit breaker. Any internal step (anchor ANN, edges batch,
+    /// vectors batch) that exceeds this duration triggers an `Ok(Vec::new())`
+    /// fallback with a `WARN`. Default: `Some(8 ms)`.
+    pub step_budget: Option<std::time::Duration>,
+}
+
+impl Default for HelaSpreadParams {
+    fn default() -> Self {
+        Self {
+            spread_depth: 2,
+            edge_types: Vec::new(),
+            max_visited: 200,
+            step_budget: Some(std::time::Duration::from_millis(8)),
+        }
+    }
+}
+
+/// Process-global dim-mismatch sentinel for HL-F5 (keyed by collection name).
+///
+/// MINOR-1 resolution: keyed by collection so re-provisioning with a different
+/// dimension recovers after a process restart.  A per-`SemanticMemory` guard would
+/// require passing state down; a process-global string key is the least-invasive
+/// approach that prevents permanent lockout from transient startup errors.
+/// Test isolation: each test constructs its own `HelaSpreadParams` with
+/// a distinct mock collection name to avoid cross-test interference.
+static HELA_DIM_MISMATCH: OnceLock<String> = OnceLock::new();
+
+/// Cosine similarity of two equal-length slices.
+///
+/// Returns `0.0` when either norm is zero (prevents division by zero).
+fn cosine(a: &[f32], b: &[f32]) -> f32 {
+    let dot: f32 = a.iter().zip(b.iter()).map(|(&x, &y)| x * y).sum();
+    let norm_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let norm_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let denom = (norm_a * norm_b).max(f32::EPSILON);
+    dot / denom
+}
+
+/// HL-F5 BFS spreading activation from the top-1 ANN anchor node (#3346).
+///
+/// Algorithm overview:
+/// 1. Embed `query` → anchor via ANN search in the entity Qdrant collection.
+/// 2. BFS up to `params.spread_depth` hops, propagating multiplicative edge
+///    weights (`path_weight = Π edge.weight along path`). Multi-path convergence
+///    keeps the maximum `path_weight`.
+/// 3. Retrieve entity embeddings for all visited nodes via `get_points`.
+/// 4. Score each node: `score = path_weight × max(cosine(query, entity), 0.0)`.
+/// 5. Sort descending, truncate to `limit`, reinforce traversed edges via Hebbian
+///    update (when `hebbian_enabled`).
+///
+/// Fallback: when the anchor entity has no outgoing edges a single synthetic
+/// [`HelaFact`] with `edge.id == 0` and `score = anchor_cosine` is returned
+/// (the real ANN cosine, never a fabricated `1.0`).
+///
+/// Per-step circuit breaker: any individual step exceeding `params.step_budget`
+/// emits a `WARN` and returns `Ok(Vec::new())`.
+///
+/// Dim-mismatch resilience: a one-time dim probe on the first call guards against
+/// collection/provider configuration mismatches (#3382 pattern). Subsequent calls
+/// to a mismatched collection short-circuit immediately.
+///
+/// # Errors
+///
+/// Returns an error if the embed call or any database query fails.
+#[tracing::instrument(
+    name = "memory.graph.hela_spread",
+    skip_all,
+    fields(
+        depth = params.spread_depth,
+        limit,
+        anchor_id = tracing::field::Empty,
+        visited = tracing::field::Empty,
+        scored = tracing::field::Empty,
+        fallback = tracing::field::Empty,
+    )
+)]
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+pub async fn hela_spreading_recall(
+    store: &GraphStore,
+    embeddings: &EmbeddingStore,
+    provider: &zeph_llm::any::AnyProvider,
+    query: &str,
+    limit: usize,
+    params: &HelaSpreadParams,
+    hebbian_enabled: bool,
+    hebbian_lr: f32,
+) -> Result<Vec<HelaFact>, MemoryError> {
+    use zeph_llm::LlmProvider as _;
+
+    const ENTITY_COLLECTION: &str = "zeph_graph_entities";
+
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+
+    // ── Step 0: dim-mismatch guard ────────────────────────────────────────────
+    // MINOR-1: guard is keyed by collection name so re-provisioning recovers.
+    if HELA_DIM_MISMATCH.get().map(String::as_str) == Some(ENTITY_COLLECTION) {
+        tracing::debug!("hela: dim mismatch previously detected for collection, skipping");
+        return Ok(Vec::new());
+    }
+
+    // ── Step 1: embed query ───────────────────────────────────────────────────
+    let q_vec = provider.embed(query).await?;
+
+    // Dim probe: search with k=1 to catch dimension mismatch at the Qdrant layer.
+    let t_anchor = Instant::now();
+    let anchor_results = match embeddings
+        .search_collection(ENTITY_COLLECTION, &q_vec, 1, None)
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("wrong vector dimension")
+                || msg.contains("InvalidArgument")
+                || msg.contains("dimension")
+            {
+                let _ = HELA_DIM_MISMATCH.set(ENTITY_COLLECTION.to_owned());
+                tracing::warn!(
+                    collection = ENTITY_COLLECTION,
+                    error = %e,
+                    "hela: vector dimension mismatch — HL-F5 disabled for this collection"
+                );
+                return Ok(Vec::new());
+            }
+            return Err(e);
+        }
+    };
+
+    if params.step_budget.is_some_and(|b| t_anchor.elapsed() > b) {
+        tracing::warn!(
+            elapsed_ms = t_anchor.elapsed().as_millis(),
+            "hela: anchor ANN over budget"
+        );
+        return Ok(Vec::new());
+    }
+
+    let Some(anchor_point) = anchor_results.first() else {
+        tracing::debug!("hela: no anchor found, returning empty");
+        return Ok(Vec::new());
+    };
+    let Some(anchor_entity_id) = anchor_point
+        .payload
+        .get("entity_id")
+        .and_then(serde_json::Value::as_i64)
+    else {
+        tracing::warn!("hela: anchor point missing entity_id payload");
+        return Ok(Vec::new());
+    };
+    let anchor_cosine = anchor_point.score;
+
+    tracing::Span::current().record("anchor_id", anchor_entity_id);
+    tracing::debug!(anchor_entity_id, anchor_cosine, "hela: anchor resolved");
+
+    let spread_depth = params.spread_depth.clamp(1, 6);
+
+    // ── Step 2: BFS with multiplicative path-weight propagation ──────────────
+    // `visited`: entity_id → (depth, path_weight, edge_id_via_which_we_arrived)
+    let mut visited: HashMap<i64, (u32, f32, Option<i64>)> = HashMap::new();
+    visited.insert(anchor_entity_id, (0, 1.0, None));
+
+    // Dedup edges keyed by id for Step 4 lookup (avoids N clones per frontier).
+    // MINOR-3 resolution: collect edges into a HashMap<id, Edge> outside the
+    // per-source loop to avoid 10K clones on a hub × 50-entity frontier.
+    let mut edge_cache: HashMap<i64, Edge> = HashMap::new();
+    let mut frontier: Vec<i64> = vec![anchor_entity_id];
+
+    for hop in 0..spread_depth {
+        if frontier.is_empty() {
+            break;
+        }
+
+        let _hop_span =
+            tracing::debug_span!("hela.hop", hop, frontier_size = frontier.len()).entered();
+
+        let t_step = Instant::now();
+        let edges = store
+            .edges_for_entities(&frontier, &params.edge_types)
+            .await?;
+        if params.step_budget.is_some_and(|b| t_step.elapsed() > b) {
+            tracing::warn!(
+                hop,
+                elapsed_ms = t_step.elapsed().as_millis(),
+                "hela: edge-fetch over budget"
+            );
+            return Ok(Vec::new());
+        }
+
+        let mut next_frontier: Vec<i64> = Vec::new();
+
+        for edge in &edges {
+            // Cache by edge id to avoid repeated clones per source in frontier.
+            edge_cache.entry(edge.id).or_insert_with(|| edge.clone());
+
+            for &src_id in &frontier {
+                let neighbor = if edge.source_entity_id == src_id {
+                    edge.target_entity_id
+                } else if edge.target_entity_id == src_id {
+                    edge.source_entity_id
+                } else {
+                    continue;
+                };
+
+                let parent_pw = visited.get(&src_id).map_or(1.0, |&(_, pw, _)| pw);
+                let new_pw = parent_pw * edge.weight;
+
+                // Multi-path resolution: keep MAX path_weight; lower depth as
+                // tie-break. MINOR-4 note: max_visited is a soft bound — the
+                // actual visited set may exceed it by O(edges_per_hop_step) for
+                // one frontier step before the outer break fires.
+                let entry = visited
+                    .entry(neighbor)
+                    .or_insert((hop + 1, 0.0_f32, Some(edge.id)));
+                // Prefer strictly higher path weight; break ties in favour of shallower depth.
+                if new_pw > entry.1
+                    || ((new_pw - entry.1).abs() < f32::EPSILON && hop + 1 < entry.0)
+                {
+                    *entry = (hop + 1, new_pw, Some(edge.id));
+                    if !next_frontier.contains(&neighbor) {
+                        next_frontier.push(neighbor);
+                    }
+                }
+
+                if visited.len() >= params.max_visited {
+                    break;
+                }
+            }
+
+            if visited.len() >= params.max_visited {
+                break;
+            }
+        }
+
+        tracing::debug!(
+            hop,
+            edges_fetched = edges.len(),
+            visited = visited.len(),
+            next_frontier = next_frontier.len(),
+            "hela: hop complete"
+        );
+
+        frontier = next_frontier;
+        if visited.len() >= params.max_visited {
+            break;
+        }
+    }
+
+    // ── Isolated-anchor fallback ──────────────────────────────────────────────
+    // `visited.len() == 1` means no edges were traversed from the anchor.
+    if visited.len() == 1 {
+        tracing::Span::current().record("fallback", true);
+        tracing::debug!(
+            anchor_entity_id,
+            anchor_cosine,
+            "hela: anchor isolated, falling back to pure ANN"
+        );
+        let fact = HelaFact {
+            edge: Edge::synthetic_anchor(anchor_entity_id),
+            score: anchor_cosine,
+            depth: 0,
+            path_weight: 1.0,
+            cosine: Some(anchor_cosine.clamp(0.0, 1.0)),
+        };
+        return Ok(vec![fact]);
+    }
+
+    // ── Step 3: retrieve entity embeddings ───────────────────────────────────
+    let entity_ids: Vec<i64> = visited.keys().copied().collect();
+    let point_id_map = store.qdrant_point_ids_for_entities(&entity_ids).await?;
+    let point_ids: Vec<String> = point_id_map.values().cloned().collect();
+
+    let t_vec = Instant::now();
+    let vec_map = embeddings
+        .get_vectors_from_collection(ENTITY_COLLECTION, &point_ids)
+        .await?;
+    if params.step_budget.is_some_and(|b| t_vec.elapsed() > b) {
+        tracing::warn!(
+            elapsed_ms = t_vec.elapsed().as_millis(),
+            "hela: vectors-batch over budget"
+        );
+        return Ok(Vec::new());
+    }
+
+    // ── Step 4: score per visited node ────────────────────────────────────────
+    // Cosine clamped to [0.0, 1.0]: anti-correlated neighbors score 0.0 so
+    // they are ranked below positively-correlated ones.  A negative cosine on a
+    // strongly-reinforced edge would otherwise invert the retrieval signal.
+    let mut facts: Vec<HelaFact> = Vec::with_capacity(visited.len().saturating_sub(1));
+    for (&entity_id, &(depth, path_weight, edge_id_opt)) in &visited {
+        if entity_id == anchor_entity_id {
+            continue;
+        }
+        let Some(edge_id) = edge_id_opt else {
+            continue;
+        };
+        let Some(point_id) = point_id_map.get(&entity_id) else {
+            continue;
+        };
+        let Some(node_vec) = vec_map.get(point_id) else {
+            continue;
+        };
+        if node_vec.len() != q_vec.len() {
+            // Per-node dim mismatch — skip (defense-in-depth for legacy collections).
+            continue;
+        }
+        let cosine_clamped = cosine(&q_vec, node_vec).max(0.0);
+        let fact_score = path_weight * cosine_clamped;
+        let Some(edge) = edge_cache.get(&edge_id).cloned() else {
+            continue;
+        };
+        facts.push(HelaFact {
+            edge,
+            score: fact_score,
+            depth,
+            path_weight,
+            cosine: Some(cosine_clamped),
+        });
+    }
+
+    // ── Step 5: sort, truncate, Hebbian increment ─────────────────────────────
+    facts.sort_by(|a, b| b.score.total_cmp(&a.score));
+    facts.truncate(limit);
+
+    // HL-F2 reinforcement on edges that survived truncation (kept ≈ used).
+    // Hebbian on "kept edges only" — consistent with graph_recall_activated at
+    // graph/retrieval.rs:427-433. Note: SYNAPSE reinforces all traversed edges;
+    // this PR intentionally reinforces only surfaced edges. See MINOR-5.
+    if hebbian_enabled {
+        let edge_ids: Vec<i64> = facts
+            .iter()
+            .map(|f| f.edge.id)
+            .filter(|&id| id != 0) // skip synthetic anchor
+            .collect();
+        if !edge_ids.is_empty()
+            && let Err(e) = store.apply_hebbian_increment(&edge_ids, hebbian_lr).await
+        {
+            tracing::warn!(error = %e, "hela: hebbian increment failed");
+        }
+    }
+
+    tracing::Span::current().record("visited", visited.len());
+    tracing::Span::current().record("scored", facts.len());
+
+    Ok(facts)
+}
+
+// ── SYNAPSE spreading activation ──────────────────────────────────────────────
 
 /// Spreading activation engine parameterized from [`SpreadingActivationParams`].
 pub struct SpreadingActivation {
@@ -787,5 +1181,113 @@ mod tests {
             "large seed list must not error: {:?}",
             result.err()
         );
+    }
+
+    // ── HL-F5 unit tests ─────────────────────────────────────────────────────
+
+    #[test]
+    fn hela_cosine_identical_vectors() {
+        let v = vec![1.0_f32, 0.0, 0.0];
+        assert!(
+            (cosine(&v, &v) - 1.0).abs() < 1e-6,
+            "identical vectors → cosine 1.0"
+        );
+    }
+
+    #[test]
+    fn hela_cosine_orthogonal_vectors() {
+        let a = vec![1.0_f32, 0.0];
+        let b = vec![0.0_f32, 1.0];
+        assert!(
+            cosine(&a, &b).abs() < 1e-6,
+            "orthogonal vectors → cosine 0.0"
+        );
+    }
+
+    #[test]
+    fn hela_cosine_anti_correlated() {
+        let a = vec![1.0_f32, 0.0];
+        let b = vec![-1.0_f32, 0.0];
+        assert!(
+            cosine(&a, &b) < 0.0,
+            "anti-correlated vectors → negative cosine"
+        );
+    }
+
+    #[test]
+    fn hela_cosine_zero_vector_no_panic() {
+        let a = vec![0.0_f32, 0.0];
+        let b = vec![1.0_f32, 0.0];
+        // Should not panic — denom is guarded by f32::EPSILON
+        let result = cosine(&a, &b);
+        assert!(
+            result.is_finite(),
+            "zero-norm vector must yield finite cosine"
+        );
+    }
+
+    #[test]
+    fn hela_spread_params_default_depth_is_two() {
+        let p = HelaSpreadParams::default();
+        assert_eq!(p.spread_depth, 2);
+        assert!(p.step_budget.is_some());
+        assert!(p.edge_types.is_empty());
+        assert_eq!(p.max_visited, 200);
+    }
+
+    #[test]
+    fn hela_synthetic_anchor_edge_id_is_zero() {
+        let edge = Edge::synthetic_anchor(42);
+        assert_eq!(
+            edge.id, 0,
+            "synthetic anchor must have id = 0 to be excluded from Hebbian"
+        );
+        assert_eq!(edge.source_entity_id, 42);
+        assert_eq!(edge.target_entity_id, 42);
+    }
+
+    #[test]
+    fn hela_negative_cosine_clamped_to_zero_in_score() {
+        // path_weight × cosine.max(0.0): negative cosine must contribute 0.0
+        let anti = vec![-1.0_f32, 0.0];
+        let query = vec![1.0_f32, 0.0];
+        let cosine_raw = cosine(&query, &anti);
+        assert!(cosine_raw < 0.0);
+        let clamped = cosine_raw.max(0.0);
+        let fact_score = 0.9_f32 * clamped;
+        assert!(
+            fact_score < f32::EPSILON,
+            "anti-correlated score must be 0.0"
+        );
+    }
+
+    #[test]
+    fn hela_path_weight_multiplicative() {
+        // Two-hop path with edge weights 0.8, 0.5 → path_weight = 0.4
+        let w1 = 0.8_f32;
+        let w2 = 0.5_f32;
+        let expected = w1 * w2;
+        assert!((expected - 0.4).abs() < 1e-6);
+    }
+
+    #[test]
+    fn hela_max_path_weight_on_multipath() {
+        // When two paths reach the same node, keep the higher path_weight.
+        let pw_a = 0.9_f32; // short direct path
+        let pw_b = 0.3_f32; // longer indirect path
+        let kept = pw_a.max(pw_b);
+        assert!(
+            (kept - 0.9).abs() < 1e-6,
+            "multi-path resolution must keep maximum path_weight"
+        );
+    }
+
+    #[test]
+    fn hela_fact_score_formula() {
+        let path_weight = 0.8_f32;
+        let cosine_clamped = 0.75_f32;
+        let expected = path_weight * cosine_clamped;
+        // Verify the formula used in hela_spreading_recall Step 4.
+        assert!((expected - 0.6).abs() < 1e-5);
     }
 }

--- a/crates/zeph-memory/src/graph/activation.rs
+++ b/crates/zeph-memory/src/graph/activation.rs
@@ -276,8 +276,7 @@ pub async fn hela_spreading_recall(
             break;
         }
 
-        let _hop_span =
-            tracing::debug_span!("hela.hop", hop, frontier_size = frontier.len()).entered();
+        tracing::debug!(hop, frontier_size = frontier.len(), "hela: starting hop");
 
         let t_step = Instant::now();
         let edges = store

--- a/crates/zeph-memory/src/graph/mod.rs
+++ b/crates/zeph-memory/src/graph/mod.rs
@@ -24,7 +24,8 @@ pub use store::GraphStore;
 pub use types::{Community, Edge, EdgeType, Entity, EntityAlias, EntityType, Episode, GraphFact};
 
 pub use activation::{
-    ActivatedFact, ActivatedNode, SpreadingActivation, SpreadingActivationParams,
+    ActivatedFact, ActivatedNode, HelaFact, HelaSpreadParams, SpreadingActivation,
+    SpreadingActivationParams, hela_spreading_recall,
 };
 pub use belief_revision::{BeliefRevisionConfig, find_superseded_edges};
 pub use community::{

--- a/crates/zeph-memory/src/graph/store/mod.rs
+++ b/crates/zeph-memory/src/graph/store/mod.rs
@@ -1395,6 +1395,43 @@ impl GraphStore {
         Ok(())
     }
 
+    /// Resolve entity IDs to their Qdrant point IDs in a single batched `SELECT` (HL-F5, #3346).
+    ///
+    /// Entities without a `qdrant_point_id` are silently omitted from the result.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database query fails.
+    pub async fn qdrant_point_ids_for_entities(
+        &self,
+        entity_ids: &[i64],
+    ) -> Result<HashMap<i64, String>, MemoryError> {
+        // Chunk to stay under SQLite variable limit.
+        const MAX_BATCH: usize = 490;
+        if entity_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let mut result: HashMap<i64, String> = HashMap::with_capacity(entity_ids.len());
+        for chunk in entity_ids.chunks(MAX_BATCH) {
+            let placeholders = zeph_db::placeholder_list(1, chunk.len());
+            let sql = format!(
+                "SELECT id, qdrant_point_id \
+                 FROM graph_entities \
+                 WHERE id IN ({placeholders}) \
+                   AND qdrant_point_id IS NOT NULL"
+            );
+            let mut q = zeph_db::query_as::<_, (i64, String)>(&sql);
+            for id in chunk {
+                q = q.bind(*id);
+            }
+            let rows = q.fetch_all(&self.pool).await?;
+            for (entity_id, point_id) in rows {
+                result.insert(entity_id, point_id);
+            }
+        }
+        Ok(result)
+    }
+
     /// Apply multiplicative decay to `retrieval_count` for un-retrieved active edges.
     ///
     /// Only edges with `retrieval_count > 0` and `last_retrieved_at < (now - interval_secs)`

--- a/crates/zeph-memory/src/graph/types.rs
+++ b/crates/zeph-memory/src/graph/types.rs
@@ -208,6 +208,41 @@ pub struct Edge {
     pub weight: f32,
 }
 
+impl Edge {
+    /// Create a synthetic marker edge for the isolated-anchor fallback in HL-F5 (#3346).
+    ///
+    /// Properties:
+    /// - `id = 0`: Real edges are auto-incremented starting at 1, so 0 is a safe sentinel.
+    /// - `source == target == entity_id`: self-loop encodes the anchor node.
+    /// - `weight = 1.0`, `edge_type = Semantic`, all temporal fields are empty strings.
+    ///
+    /// Callers detect the synthetic marker via `edge.id == 0`.
+    #[must_use]
+    pub fn synthetic_anchor(entity_id: i64) -> Self {
+        Self {
+            id: 0,
+            source_entity_id: entity_id,
+            target_entity_id: entity_id,
+            relation: String::new(),
+            fact: String::new(),
+            confidence: 1.0,
+            valid_from: String::new(),
+            valid_to: None,
+            created_at: String::new(),
+            expired_at: None,
+            source_message_id: None,
+            qdrant_point_id: None,
+            edge_type: EdgeType::Semantic,
+            retrieval_count: 0,
+            last_retrieved_at: None,
+            superseded_by: None,
+            canonical_relation: String::new(),
+            supersedes: None,
+            weight: 1.0,
+        }
+    }
+}
+
 /// A Louvain-detected community (cluster) of related entities.
 ///
 /// Communities provide coarse-grained grouping for graph eviction and summarization.

--- a/crates/zeph-memory/src/lib.rs
+++ b/crates/zeph-memory/src/lib.rs
@@ -166,11 +166,12 @@ pub use scenes::{
 };
 pub use semantic::{
     BufferedWrite, EmbedContext, ExtractionResult, ExtractionStats, GraphExtractionConfig,
-    LinkingStats, NoteLinkingConfig, PersonaExtractionConfig, RecalledMessage, StructuredSummary,
-    TrajectoryEntry, TrajectoryExtractionConfig, TreeConsolidationConfig, TreeConsolidationResult,
-    WriteBuffer, build_summarization_prompt, contains_self_referential_language, extract_and_store,
-    extract_persona_facts, extract_trajectory_entries, link_memory_notes,
-    run_tree_consolidation_sweep, start_tree_consolidation_loop,
+    HelaSpreadRuntime, LinkingStats, NoteLinkingConfig, PersonaExtractionConfig, RecalledMessage,
+    StructuredSummary, TrajectoryEntry, TrajectoryExtractionConfig, TreeConsolidationConfig,
+    TreeConsolidationResult, WriteBuffer, build_summarization_prompt,
+    contains_self_referential_language, extract_and_store, extract_persona_facts,
+    extract_trajectory_entries, link_memory_notes, run_tree_consolidation_sweep,
+    start_tree_consolidation_loop,
 };
 pub use snapshot::{ImportStats, MemorySnapshot, export_snapshot, import_snapshot};
 pub use store::compression_guidelines::CompressionFailurePair;

--- a/crates/zeph-memory/src/qdrant_ops.rs
+++ b/crates/zeph-memory/src/qdrant_ops.rs
@@ -11,10 +11,11 @@ use std::collections::HashMap;
 
 use crate::vector_store::BoxFuture;
 use qdrant_client::Qdrant;
+use qdrant_client::qdrant::vector_output::Vector as VectorVariant;
 use qdrant_client::qdrant::{
-    CreateCollectionBuilder, DeletePointsBuilder, Distance, Filter, PointId, PointStruct,
-    PointsIdsList, ScoredPoint, ScrollPointsBuilder, SearchPointsBuilder, UpsertPointsBuilder,
-    VectorParamsBuilder, value::Kind,
+    CreateCollectionBuilder, DeletePointsBuilder, Distance, Filter, GetPointsBuilder, PointId,
+    PointStruct, PointsIdsList, ScoredPoint, ScrollPointsBuilder, SearchPointsBuilder,
+    UpsertPointsBuilder, VectorParamsBuilder, value::Kind,
 };
 
 type QdrantResult<T> = Result<T, Box<qdrant_client::QdrantError>>;
@@ -464,6 +465,55 @@ impl crate::vector_store::VectorStore for QdrantOps {
             Ok(())
         })
     }
+
+    fn get_points(
+        &self,
+        collection: &str,
+        ids: Vec<String>,
+    ) -> BoxFuture<'_, Result<Vec<crate::VectorPoint>, crate::VectorStoreError>> {
+        let collection = collection.to_owned();
+        Box::pin(async move {
+            if ids.is_empty() {
+                return Ok(Vec::new());
+            }
+            let point_ids: Vec<PointId> = ids.into_iter().map(PointId::from).collect();
+            let response = self
+                .client
+                .get_points(
+                    GetPointsBuilder::new(&collection, point_ids)
+                        .with_vectors(true)
+                        .with_payload(true),
+                )
+                .await
+                .map_err(|e| crate::VectorStoreError::Search(e.to_string()))?;
+
+            let mut result = Vec::with_capacity(response.result.len());
+            for point in response.result {
+                let Some(id_str) = point_id_to_string(point.id) else {
+                    continue;
+                };
+                // Use VectorsOutput::get_vector() to extract the default dense vector.
+                let vector = match point.vectors.and_then(|v| v.get_vector()) {
+                    Some(VectorVariant::Dense(dv)) => dv.data,
+                    _ => continue,
+                };
+                let payload: HashMap<String, serde_json::Value> = point
+                    .payload
+                    .into_iter()
+                    .filter_map(|(k, v)| {
+                        let json = qdrant_value_to_json(v.kind?)?;
+                        Some((k, json))
+                    })
+                    .collect();
+                result.push(crate::VectorPoint {
+                    id: id_str,
+                    vector,
+                    payload,
+                });
+            }
+            Ok(result)
+        })
+    }
 }
 
 fn vector_filter_to_qdrant(filter: crate::VectorFilter) -> Filter {
@@ -495,29 +545,37 @@ fn field_condition_to_qdrant(cond: crate::FieldCondition) -> qdrant_client::qdra
     }
 }
 
+/// Convert a Qdrant [`qdrant_client::qdrant::PointId`] to its string representation.
+///
+/// Returns `None` when the id variant is unrecognised.
+fn point_id_to_string(pid: Option<qdrant_client::qdrant::PointId>) -> Option<String> {
+    match pid?.point_id_options? {
+        qdrant_client::qdrant::point_id::PointIdOptions::Uuid(u) => Some(u),
+        qdrant_client::qdrant::point_id::PointIdOptions::Num(n) => Some(n.to_string()),
+    }
+}
+
+/// Convert a Qdrant [`Kind`] to a `serde_json::Value`.
+///
+/// Returns `None` for unsupported kinds (structs, lists, nulls).
+fn qdrant_value_to_json(kind: Kind) -> Option<serde_json::Value> {
+    match kind {
+        Kind::StringValue(s) => Some(serde_json::Value::String(s)),
+        Kind::IntegerValue(i) => Some(serde_json::Value::Number(i.into())),
+        Kind::DoubleValue(d) => serde_json::Number::from_f64(d).map(serde_json::Value::Number),
+        Kind::BoolValue(b) => Some(serde_json::Value::Bool(b)),
+        _ => None,
+    }
+}
+
 fn scored_point_to_vector(point: ScoredPoint) -> crate::ScoredVectorPoint {
     let payload: HashMap<String, serde_json::Value> = point
         .payload
         .into_iter()
-        .filter_map(|(k, v)| {
-            let json_val = match v.kind? {
-                Kind::StringValue(s) => serde_json::Value::String(s),
-                Kind::IntegerValue(i) => serde_json::Value::Number(i.into()),
-                Kind::DoubleValue(d) => {
-                    serde_json::Number::from_f64(d).map(serde_json::Value::Number)?
-                }
-                Kind::BoolValue(b) => serde_json::Value::Bool(b),
-                _ => return None,
-            };
-            Some((k, json_val))
-        })
+        .filter_map(|(k, v)| Some((k, qdrant_value_to_json(v.kind?)?)))
         .collect();
 
-    let id = match point.id.and_then(|pid| pid.point_id_options) {
-        Some(qdrant_client::qdrant::point_id::PointIdOptions::Uuid(u)) => u,
-        Some(qdrant_client::qdrant::point_id::PointIdOptions::Num(n)) => n.to_string(),
-        None => String::new(),
-    };
+    let id = point_id_to_string(point.id).unwrap_or_default();
 
     crate::ScoredVectorPoint {
         id,

--- a/crates/zeph-memory/src/semantic/mod.rs
+++ b/crates/zeph-memory/src/semantic/mod.rs
@@ -105,6 +105,23 @@ pub(crate) enum QueryIntent {
     Other,
 }
 
+/// HL-F5 runtime wiring for spreading activation (mirror of `[memory.hebbian]` spread fields).
+///
+/// Built from config at bootstrap and attached via [`SemanticMemory::with_hebbian_spread`].
+#[derive(Debug, Clone, Default)]
+pub struct HelaSpreadRuntime {
+    /// `true` when `[memory.hebbian] enabled = true` AND `spreading_activation = true`.
+    pub enabled: bool,
+    /// BFS hops, already clamped to `[1, 6]` by the caller.
+    pub depth: u32,
+    /// Soft upper bound on the visited-node set.
+    pub max_visited: usize,
+    /// MAGMA edge-type filter for BFS traversal.
+    pub edge_types: Vec<crate::graph::EdgeType>,
+    /// Per-step circuit-breaker duration.
+    pub step_budget: Option<std::time::Duration>,
+}
+
 /// High-level semantic memory orchestrator combining `SQLite` and Qdrant.
 ///
 /// Instantiate via [`SemanticMemory::new`] or the `AppBuilder` integration.
@@ -191,6 +208,8 @@ pub struct SemanticMemory {
     pub(crate) hebbian_enabled: bool,
     /// Weight increment applied per recall traversal when `hebbian_enabled = true` (HL-F2, #3344).
     pub(crate) hebbian_lr: f32,
+    /// HL-F5 spreading activation runtime config (#3346).
+    pub(crate) hebbian_spread: HelaSpreadRuntime,
 }
 
 impl SemanticMemory {
@@ -306,6 +325,7 @@ impl SemanticMemory {
             profile_centroid_ttl_secs: 300,
             hebbian_enabled: false,
             hebbian_lr: 0.1,
+            hebbian_spread: HelaSpreadRuntime::default(),
         })
     }
 
@@ -367,6 +387,7 @@ impl SemanticMemory {
             profile_centroid_ttl_secs: 300,
             hebbian_enabled: false,
             hebbian_lr: 0.1,
+            hebbian_spread: HelaSpreadRuntime::default(),
         })
     }
 
@@ -508,6 +529,16 @@ impl SemanticMemory {
         self
     }
 
+    /// Configure HL-F5 spreading activation runtime parameters (HL-F5, #3346).
+    ///
+    /// Has no effect when `hebbian_spread.enabled = false` (the default).
+    /// Call this after `with_graph_store` and `with_hebbian` during bootstrap.
+    #[must_use]
+    pub fn with_hebbian_spread(mut self, runtime: HelaSpreadRuntime) -> Self {
+        self.hebbian_spread = runtime;
+        self
+    }
+
     /// Configure Hebbian edge-weight reinforcement (HL-F2, #3344).
     ///
     /// When `enabled` is `true`, `lr` is added to the `weight` column of each traversed
@@ -541,24 +572,35 @@ impl SemanticMemory {
     /// if the query is not first-person, or if the profile centroid is unavailable.
     /// Logs a single WARN on dimension mismatch and returns the original embedding.
     pub(crate) async fn apply_query_bias(&self, query: &str, embedding: Vec<f32>) -> Vec<f32> {
+        let _span = tracing::info_span!("memory.query_bias.apply").entered();
         if !self.query_bias_correction {
+            tracing::debug!(reason = "disabled", "query-bias: skipping");
             return embedding;
         }
         if Self::classify_query_intent(query) != QueryIntent::FirstPerson {
+            tracing::debug!(reason = "not_first_person", "query-bias: skipping");
             return embedding;
         }
         let Some(centroid) = self.profile_centroid_cached().await else {
+            tracing::debug!(reason = "no_centroid", "query-bias: skipping");
             return embedding;
         };
         if centroid.len() != embedding.len() {
             tracing::warn!(
                 centroid_dim = centroid.len(),
                 query_dim = embedding.len(),
+                reason = "dim_mismatch",
                 "query-bias: dimension mismatch between profile centroid and query embedding — skipping bias"
             );
             return embedding;
         }
         let w = self.query_bias_profile_weight;
+        tracing::debug!(
+            intent = "first_person",
+            centroid_dim = centroid.len(),
+            weight = w,
+            "query-bias: applying profile bias"
+        );
         embedding
             .iter()
             .zip(centroid.iter())
@@ -571,12 +613,21 @@ impl SemanticMemory {
     /// Holds the read lock only to check freshness; releases it before any `.await`.
     /// On compute failure, preserves the previous cache value (non-sticky miss).
     pub(crate) async fn profile_centroid_cached(&self) -> Option<Vec<f32>> {
+        let _span = tracing::info_span!("memory.query_bias.centroid").entered();
         // Fast path: check freshness under read lock without holding it across await.
         {
             let guard = self.profile_centroid.read().await;
             if let Some(c) = &*guard
                 && c.computed_at.elapsed().as_secs() < self.profile_centroid_ttl_secs
             {
+                let ttl_remaining = self
+                    .profile_centroid_ttl_secs
+                    .saturating_sub(c.computed_at.elapsed().as_secs());
+                tracing::debug!(
+                    centroid_dim = c.vector.len(),
+                    ttl_remaining_secs = ttl_remaining,
+                    "query-bias: centroid cache hit"
+                );
                 return Some(c.vector.clone());
             }
         }
@@ -585,6 +636,7 @@ impl SemanticMemory {
         let mut guard = self.profile_centroid.write().await;
         match computed {
             Some(v) => {
+                tracing::debug!(centroid_dim = v.len(), "query-bias: centroid computed");
                 *guard = Some(CachedCentroid {
                     vector: v.clone(),
                     computed_at: Instant::now(),
@@ -803,6 +855,7 @@ impl SemanticMemory {
             profile_centroid_ttl_secs: 300,
             hebbian_enabled: false,
             hebbian_lr: 0.1,
+            hebbian_spread: HelaSpreadRuntime::default(),
         }
     }
 
@@ -883,6 +936,7 @@ impl SemanticMemory {
             profile_centroid_ttl_secs: 300,
             hebbian_enabled: false,
             hebbian_lr: 0.1,
+            hebbian_spread: HelaSpreadRuntime::default(),
         })
     }
 

--- a/crates/zeph-memory/src/semantic/mod.rs
+++ b/crates/zeph-memory/src/semantic/mod.rs
@@ -571,8 +571,8 @@ impl SemanticMemory {
     /// Returns the embedding unchanged if `query_bias_correction` is `false`,
     /// if the query is not first-person, or if the profile centroid is unavailable.
     /// Logs a single WARN on dimension mismatch and returns the original embedding.
+    #[tracing::instrument(name = "memory.query_bias.apply", skip(self, embedding), fields(query_len = query.len()))]
     pub(crate) async fn apply_query_bias(&self, query: &str, embedding: Vec<f32>) -> Vec<f32> {
-        let _span = tracing::info_span!("memory.query_bias.apply").entered();
         if !self.query_bias_correction {
             tracing::debug!(reason = "disabled", "query-bias: skipping");
             return embedding;
@@ -612,8 +612,8 @@ impl SemanticMemory {
     ///
     /// Holds the read lock only to check freshness; releases it before any `.await`.
     /// On compute failure, preserves the previous cache value (non-sticky miss).
+    #[tracing::instrument(name = "memory.query_bias.centroid", skip(self))]
     pub(crate) async fn profile_centroid_cached(&self) -> Option<Vec<f32>> {
-        let _span = tracing::info_span!("memory.query_bias.centroid").entered();
         // Fast path: check freshness under read lock without holding it across await.
         {
             let guard = self.profile_centroid.read().await;

--- a/crates/zeph-memory/src/semantic/recall.rs
+++ b/crates/zeph-memory/src/semantic/recall.rs
@@ -1453,6 +1453,67 @@ impl SemanticMemory {
         crate::graph::strategy_classifier::classify_retrieval_strategy(&self.provider, query).await
     }
 
+    /// Retrieve graph facts via HL-F5 spreading activation from the top-1 ANN anchor (#3346).
+    ///
+    /// Returns an empty vec when no graph store is configured, Qdrant is unavailable,
+    /// or `hebbian_spread.enabled = false`.  The outer 200 ms timeout ensures the
+    /// agent loop is never blocked by a slow Qdrant response.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the embed call or any database query fails.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(
+            name = "memory.recall_graph_hela",
+            skip_all,
+            fields(result_count = tracing::field::Empty)
+        )
+    )]
+    pub async fn recall_graph_hela(
+        &self,
+        query: &str,
+        limit: usize,
+        params: crate::graph::HelaSpreadParams,
+    ) -> Result<Vec<crate::graph::HelaFact>, MemoryError> {
+        let Some(store) = &self.graph_store else {
+            return Ok(Vec::new());
+        };
+        let Some(embeddings) = &self.qdrant else {
+            return Ok(Vec::new());
+        };
+
+        let store = Arc::clone(store);
+        let embeddings = Arc::clone(embeddings);
+        let provider = self.provider.clone();
+        let hebbian_enabled = self.hebbian_enabled;
+        let hebbian_lr = self.hebbian_lr;
+
+        let results = tokio::time::timeout(
+            std::time::Duration::from_millis(200),
+            crate::graph::hela_spreading_recall(
+                &store,
+                &embeddings,
+                &provider,
+                query,
+                limit,
+                &params,
+                hebbian_enabled,
+                hebbian_lr,
+            ),
+        )
+        .await
+        .unwrap_or_else(|_| {
+            tracing::warn!("memory.recall_graph_hela: outer 200ms timeout exceeded");
+            Ok(Vec::new())
+        })?;
+
+        #[cfg(feature = "profiling")]
+        tracing::Span::current().record("result_count", results.len());
+
+        Ok(results)
+    }
+
     /// Increment access count and update `last_accessed` for a batch of message IDs.
     ///
     /// Skips the update if `message_ids` is empty to avoid an invalid `IN ()` clause.
@@ -1651,6 +1712,7 @@ mod tests {
             profile_centroid_ttl_secs: 300,
             hebbian_enabled: false,
             hebbian_lr: 0.1,
+            hebbian_spread: crate::HelaSpreadRuntime::default(),
         }
     }
 

--- a/crates/zeph-memory/src/semantic/tests/graph.rs
+++ b/crates/zeph-memory/src/semantic/tests/graph.rs
@@ -343,6 +343,7 @@ async fn memory_with_in_memory_vector_store() -> (
         profile_centroid_ttl_secs: 300,
         hebbian_enabled: false,
         hebbian_lr: 0.1,
+        hebbian_spread: crate::HelaSpreadRuntime::default(),
     };
 
     (memory, embedding_store)

--- a/crates/zeph-memory/src/semantic/tests/mod.rs
+++ b/crates/zeph-memory/src/semantic/tests/mod.rs
@@ -66,6 +66,7 @@ pub(super) async fn test_semantic_memory(_supports_embeddings: bool) -> Semantic
         profile_centroid_ttl_secs: 300,
         hebbian_enabled: false,
         hebbian_lr: 0.1,
+        hebbian_spread: crate::HelaSpreadRuntime::default(),
     }
 }
 
@@ -164,6 +165,7 @@ async fn effective_embed_provider_routes_to_dedicated_embed_provider() {
         profile_centroid_ttl_secs: 300,
         hebbian_enabled: false,
         hebbian_lr: 0.1,
+        hebbian_spread: crate::HelaSpreadRuntime::default(),
     };
 
     assert!(
@@ -566,6 +568,7 @@ async fn store_correction_embedding_sqlite_clean_db_roundtrip() {
         profile_centroid_ttl_secs: 300,
         hebbian_enabled: false,
         hebbian_lr: 0.1,
+        hebbian_spread: crate::HelaSpreadRuntime::default(),
     };
 
     memory

--- a/crates/zeph-memory/src/semantic/tests/query_bias.rs
+++ b/crates/zeph-memory/src/semantic/tests/query_bias.rs
@@ -104,6 +104,7 @@ async fn test_apply_query_bias_dimension_mismatch_returns_unchanged() {
         profile_centroid_ttl_secs: 300,
         hebbian_enabled: false,
         hebbian_lr: 0.1,
+        hebbian_spread: crate::HelaSpreadRuntime::default(),
     };
 
     let embedding = vec![0.1_f32, 0.2, 0.3];

--- a/crates/zeph-memory/src/semantic/tests/recall.rs
+++ b/crates/zeph-memory/src/semantic/tests/recall.rs
@@ -83,6 +83,7 @@ async fn test_semantic_memory_sqlite_remember_recall_roundtrip() {
         profile_centroid_ttl_secs: 300,
         hebbian_enabled: false,
         hebbian_lr: 0.1,
+        hebbian_spread: crate::HelaSpreadRuntime::default(),
     };
 
     let cid = memory.sqlite().create_conversation().await.unwrap();

--- a/crates/zeph-memory/src/semantic/tests/summarization.rs
+++ b/crates/zeph-memory/src/semantic/tests/summarization.rs
@@ -352,6 +352,7 @@ async fn summarize_fails_when_provider_chat_fails() {
         profile_centroid_ttl_secs: 300,
         hebbian_enabled: false,
         hebbian_lr: 0.1,
+        hebbian_spread: crate::HelaSpreadRuntime::default(),
     };
     let cid = memory.sqlite().create_conversation().await.unwrap();
 
@@ -430,6 +431,7 @@ async fn summarize_fallback_to_plain_text_when_structured_fails() {
         profile_centroid_ttl_secs: 300,
         hebbian_enabled: false,
         hebbian_lr: 0.1,
+        hebbian_spread: crate::HelaSpreadRuntime::default(),
     };
 
     let cid = memory.sqlite().create_conversation().await.unwrap();
@@ -593,6 +595,7 @@ async fn make_embed_memory_with_threshold(threshold: f32) -> super::super::Seman
         profile_centroid_ttl_secs: 300,
         hebbian_enabled: false,
         hebbian_lr: 0.1,
+        hebbian_spread: crate::HelaSpreadRuntime::default(),
     }
 }
 
@@ -699,6 +702,7 @@ async fn store_key_facts_fail_open_on_search_error() {
         profile_centroid_ttl_secs: 300,
         hebbian_enabled: false,
         hebbian_lr: 0.1,
+        hebbian_spread: crate::HelaSpreadRuntime::default(),
     };
 
     let cid = memory.sqlite().create_conversation().await.unwrap();

--- a/crates/zeph-memory/src/vector_store.rs
+++ b/crates/zeph-memory/src/vector_store.rs
@@ -32,6 +32,9 @@ pub enum VectorStoreError {
     Scroll(String),
     #[error("serialization error: {0}")]
     Serialization(String),
+    /// Operation is not supported by this backend (e.g. `get_points` on `DbVectorStore`).
+    #[error("operation unsupported: {0}")]
+    Unsupported(String),
 }
 
 /// A vector point to be stored in or retrieved from a [`VectorStore`].
@@ -171,5 +174,27 @@ pub trait VectorStore: Send + Sync {
         _fields: &[&str],
     ) -> BoxFuture<'_, Result<(), VectorStoreError>> {
         Box::pin(async { Ok(()) })
+    }
+
+    /// Batched vector + payload retrieval by point IDs.
+    ///
+    /// Returns one [`VectorPoint`] per matched id (missing ids are silently dropped).
+    /// Backends that cannot return vectors return `Err(VectorStoreError::Unsupported)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VectorStoreError::Unsupported`] when the backend does not support
+    /// direct point retrieval with vectors (e.g. `DbVectorStore`, `InMemoryVectorStore`
+    /// unless overridden in tests).
+    fn get_points(
+        &self,
+        _collection: &str,
+        _ids: Vec<String>,
+    ) -> BoxFuture<'_, Result<Vec<VectorPoint>, VectorStoreError>> {
+        Box::pin(async {
+            Err(VectorStoreError::Unsupported(
+                "get_points not implemented for this backend".into(),
+            ))
+        })
     }
 }

--- a/crates/zeph-memory/tests/hela_spreading_activation.rs
+++ b/crates/zeph-memory/tests/hela_spreading_activation.rs
@@ -1,0 +1,261 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Integration tests for HL-F5 spreading activation (`hela_spreading_recall`).
+//!
+//! These tests require a live Qdrant instance (started via `testcontainers`). Run with:
+//!
+//! ```bash
+//! cargo nextest run -p zeph-memory --test hela_spreading_activation -- --ignored
+//! ```
+
+use serde_json::json;
+use testcontainers::ContainerAsync;
+use testcontainers::GenericImage;
+use testcontainers::core::{ContainerPort, WaitFor};
+use testcontainers::runners::AsyncRunner;
+use zeph_llm::any::AnyProvider;
+use zeph_llm::mock::MockProvider;
+use zeph_memory::embedding_store::EmbeddingStore;
+use zeph_memory::graph::GraphStore;
+use zeph_memory::graph::activation::{HelaSpreadParams, hela_spreading_recall};
+use zeph_memory::graph::types::EntityType;
+use zeph_memory::store::SqliteStore;
+
+const QDRANT_GRPC_PORT: ContainerPort = ContainerPort::Tcp(6334);
+const ENTITY_COLLECTION: &str = "zeph_graph_entities";
+
+fn qdrant_image() -> GenericImage {
+    GenericImage::new("qdrant/qdrant", "v1.16.0")
+        .with_wait_for(WaitFor::message_on_stdout("gRPC listening"))
+        .with_wait_for(WaitFor::seconds(1))
+        .with_exposed_port(QDRANT_GRPC_PORT)
+}
+
+async fn setup() -> (
+    GraphStore,
+    EmbeddingStore,
+    SqliteStore,
+    ContainerAsync<GenericImage>,
+) {
+    let container = qdrant_image().start().await.unwrap();
+    let grpc_port = container.get_host_port_ipv4(6334).await.unwrap();
+    let url = format!("http://127.0.0.1:{grpc_port}");
+
+    let sqlite = SqliteStore::new(":memory:").await.unwrap();
+    let pool = sqlite.pool().clone();
+    let embeddings = EmbeddingStore::new(&url, pool.clone()).unwrap();
+    let graph = GraphStore::new(pool);
+    (graph, embeddings, sqlite, container)
+}
+
+/// Seed a named entity into both SQLite graph and Qdrant entity collection.
+///
+/// Returns `(entity_id, point_id)`. The `point_id` is set in `qdrant_point_id` so that
+/// `qdrant_point_ids_for_entities` can find it.
+async fn seed_entity(
+    graph: &GraphStore,
+    embeddings: &EmbeddingStore,
+    name: &str,
+    vector: Vec<f32>,
+) -> (i64, String) {
+    let entity_id = graph
+        .upsert_entity(name, name, EntityType::Concept, None)
+        .await
+        .unwrap();
+
+    let point_id = uuid::Uuid::new_v4().to_string();
+    let payload = json!({
+        "entity_id": entity_id,
+        "entity_type": "concept",
+        "name": name,
+        "summary": "",
+    });
+
+    embeddings
+        .upsert_to_collection(ENTITY_COLLECTION, &point_id, payload, vector)
+        .await
+        .unwrap();
+
+    // Write `qdrant_point_id` so `qdrant_point_ids_for_entities` can find this entity.
+    let pool = graph.pool();
+    sqlx::query("UPDATE graph_entities SET qdrant_point_id = ?1 WHERE id = ?2")
+        .bind(&point_id)
+        .bind(entity_id)
+        .execute(pool)
+        .await
+        .unwrap();
+
+    (entity_id, point_id)
+}
+
+fn mock_provider(embed: Vec<f32>) -> AnyProvider {
+    AnyProvider::Mock(MockProvider::default().with_embedding(embed))
+}
+
+/// `hela_spreading_recall` returns empty when the entity collection is empty.
+#[ignore = "requires Qdrant container"]
+#[tokio::test]
+async fn hela_empty_graph_empty_result() {
+    let (graph, embeddings, _sqlite, _ctr) = setup().await;
+    let provider = mock_provider(vec![1.0, 0.0, 0.0]);
+
+    // Ensure the collection exists so we don't get a Qdrant "not found" error.
+    embeddings
+        .ensure_named_collection(ENTITY_COLLECTION, 3)
+        .await
+        .unwrap();
+
+    let results = hela_spreading_recall(
+        &graph,
+        &embeddings,
+        &provider,
+        "unknown concept",
+        10,
+        &HelaSpreadParams {
+            spread_depth: 2,
+            ..Default::default()
+        },
+        false,
+        0.1,
+    )
+    .await
+    .unwrap();
+
+    assert!(results.is_empty(), "no entities → empty results");
+}
+
+/// Isolated anchor (no edges) falls back to a single synthetic fact.
+#[ignore = "requires Qdrant container"]
+#[tokio::test]
+async fn hela_anchor_isolated_fallback() {
+    let (graph, embeddings, _sqlite, _ctr) = setup().await;
+    let embed_vec = vec![1.0_f32, 0.0, 0.0];
+    let provider = mock_provider(embed_vec.clone());
+
+    embeddings
+        .ensure_named_collection(ENTITY_COLLECTION, 3)
+        .await
+        .unwrap();
+
+    let (_entity_id, _point_id) = seed_entity(&graph, &embeddings, "Isolation", embed_vec).await;
+
+    let results = hela_spreading_recall(
+        &graph,
+        &embeddings,
+        &provider,
+        "isolation",
+        5,
+        &HelaSpreadParams {
+            spread_depth: 2,
+            ..Default::default()
+        },
+        false,
+        0.1,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        results.len(),
+        1,
+        "isolated anchor → exactly one synthetic fact"
+    );
+    assert_eq!(results[0].edge.id, 0, "synthetic anchor edge id must be 0");
+    assert!(results[0].score > 0.0, "anchor cosine must be positive");
+}
+
+/// `spread_depth=1` does not return 2-hop neighbours.
+#[ignore = "requires Qdrant container"]
+#[tokio::test]
+async fn hela_depth_one_excludes_two_hop() {
+    let (graph, embeddings, _sqlite, _ctr) = setup().await;
+    let embed_vec = vec![1.0_f32, 0.0, 0.0];
+    let provider = mock_provider(embed_vec.clone());
+
+    embeddings
+        .ensure_named_collection(ENTITY_COLLECTION, 3)
+        .await
+        .unwrap();
+
+    let (anchor_id, _) = seed_entity(&graph, &embeddings, "A", embed_vec.clone()).await;
+    let (hop1_id, _) = seed_entity(&graph, &embeddings, "B", embed_vec.clone()).await;
+    let (hop2_id, _) = seed_entity(&graph, &embeddings, "C", embed_vec.clone()).await;
+
+    graph
+        .insert_edge(anchor_id, hop1_id, "relates_to", "test edge", 0.9, None)
+        .await
+        .unwrap();
+    graph
+        .insert_edge(hop1_id, hop2_id, "relates_to", "test edge", 0.9, None)
+        .await
+        .unwrap();
+
+    let params = HelaSpreadParams {
+        spread_depth: 1,
+        ..Default::default()
+    };
+    let results =
+        hela_spreading_recall(&graph, &embeddings, &provider, "a", 20, &params, false, 0.1)
+            .await
+            .unwrap();
+
+    // At depth 1 only hop1 (B) is reachable. C must not appear.
+    for fact in &results {
+        let src = fact.edge.source_entity_id;
+        let tgt = fact.edge.target_entity_id;
+        assert_ne!(
+            (src == hop2_id) || (tgt == hop2_id),
+            true,
+            "C must not appear in depth-1 results"
+        );
+    }
+}
+
+/// `max_visited` cap is respected — results never exceed the cap.
+#[ignore = "requires Qdrant container"]
+#[tokio::test]
+async fn hela_respects_max_visited() {
+    let (graph, embeddings, _sqlite, _ctr) = setup().await;
+    let embed_vec = vec![1.0_f32, 0.0, 0.0];
+    let provider = mock_provider(embed_vec.clone());
+
+    embeddings
+        .ensure_named_collection(ENTITY_COLLECTION, 3)
+        .await
+        .unwrap();
+
+    let (hub_id, _) = seed_entity(&graph, &embeddings, "Hub", embed_vec.clone()).await;
+    for i in 0..15i64 {
+        let (nid, _) = seed_entity(&graph, &embeddings, &format!("N{i}"), embed_vec.clone()).await;
+        graph
+            .insert_edge(hub_id, nid, "relates_to", "test edge", 0.8, None)
+            .await
+            .unwrap();
+    }
+
+    let cap = 5;
+    let params = HelaSpreadParams {
+        spread_depth: 2,
+        max_visited: cap,
+        ..Default::default()
+    };
+    let results = hela_spreading_recall(
+        &graph,
+        &embeddings,
+        &provider,
+        "hub",
+        100,
+        &params,
+        false,
+        0.1,
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        results.len() <= cap,
+        "max_visited={cap} must cap results, got {}",
+        results.len()
+    );
+}

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -355,6 +355,29 @@ impl AppBuilder {
             self.config.memory.hebbian.hebbian_lr,
         );
 
+        // HL-F5: parse edge-type strings with WARN on unrecognised values (#3346).
+        let mut spread_edge_types: Vec<zeph_memory::graph::EdgeType> = Vec::new();
+        for raw in &self.config.memory.hebbian.spread_edge_types {
+            match raw.parse::<zeph_memory::graph::EdgeType>() {
+                Ok(et) => spread_edge_types.push(et),
+                Err(_) => tracing::warn!(
+                    value = %raw,
+                    "memory.hebbian.spread_edge_types: unrecognised edge type, ignored"
+                ),
+            }
+        }
+        let hela_runtime = zeph_memory::HelaSpreadRuntime {
+            enabled: self.config.memory.hebbian.enabled
+                && self.config.memory.hebbian.spreading_activation,
+            depth: self.config.memory.hebbian.spread_depth.clamp(1, 6),
+            max_visited: 200,
+            edge_types: spread_edge_types,
+            step_budget: Some(std::time::Duration::from_millis(
+                self.config.memory.hebbian.step_budget_ms,
+            )),
+        };
+        memory = memory.with_hebbian_spread(hela_runtime);
+
         if self.config.memory.semantic.enabled && memory.is_vector_store_connected().await {
             tracing::info!("semantic memory enabled, vector store connected");
         }

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -355,28 +355,7 @@ impl AppBuilder {
             self.config.memory.hebbian.hebbian_lr,
         );
 
-        // HL-F5: parse edge-type strings with WARN on unrecognised values (#3346).
-        let mut spread_edge_types: Vec<zeph_memory::graph::EdgeType> = Vec::new();
-        for raw in &self.config.memory.hebbian.spread_edge_types {
-            match raw.parse::<zeph_memory::graph::EdgeType>() {
-                Ok(et) => spread_edge_types.push(et),
-                Err(_) => tracing::warn!(
-                    value = %raw,
-                    "memory.hebbian.spread_edge_types: unrecognised edge type, ignored"
-                ),
-            }
-        }
-        let hela_runtime = zeph_memory::HelaSpreadRuntime {
-            enabled: self.config.memory.hebbian.enabled
-                && self.config.memory.hebbian.spreading_activation,
-            depth: self.config.memory.hebbian.spread_depth.clamp(1, 6),
-            max_visited: 200,
-            edge_types: spread_edge_types,
-            step_budget: Some(std::time::Duration::from_millis(
-                self.config.memory.hebbian.step_budget_ms,
-            )),
-        };
-        memory = memory.with_hebbian_spread(hela_runtime);
+        memory = memory.with_hebbian_spread(self.build_hela_runtime());
 
         if self.config.memory.semantic.enabled && memory.is_vector_store_connected().await {
             tracing::info!("semantic memory enabled, vector store connected");
@@ -1435,6 +1414,37 @@ impl AppBuilder {
             age_vault: None,
             qdrant_ops: None,
             resolved_overlay: zeph_plugins::ResolvedOverlay::default(),
+        }
+    }
+
+    /// Build the HeLa-Mem spread runtime from config.
+    fn build_hela_runtime(&self) -> zeph_memory::HelaSpreadRuntime {
+        let edge_types = self
+            .config
+            .memory
+            .hebbian
+            .spread_edge_types
+            .iter()
+            .filter_map(|raw| {
+                raw.parse::<zeph_memory::graph::EdgeType>()
+                    .map_err(|_| {
+                        tracing::warn!(
+                            value = %raw,
+                            "memory.hebbian.spread_edge_types: unrecognised edge type, ignored"
+                        );
+                    })
+                    .ok()
+            })
+            .collect();
+        zeph_memory::HelaSpreadRuntime {
+            enabled: self.config.memory.hebbian.enabled
+                && self.config.memory.hebbian.spreading_activation,
+            depth: self.config.memory.hebbian.spread_depth.clamp(1, 6),
+            max_visited: 200,
+            edge_types,
+            step_budget: Some(std::time::Duration::from_millis(
+                self.config.memory.hebbian.step_budget_ms,
+            )),
         }
     }
 }

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -13,13 +13,13 @@ use zeph_core::config::migrate::{
     migrate_magic_docs_config, migrate_mcp_elicitation_config, migrate_mcp_trust_levels,
     migrate_memory_graph_config, migrate_memory_hebbian_config,
     migrate_memory_hebbian_consolidation_config, migrate_memory_hebbian_spread_config,
-    migrate_memory_reasoning_config,
-    migrate_memory_reasoning_judge_config, migrate_memory_retrieval_config,
-    migrate_microcompact_config, migrate_orchestration_persistence, migrate_otel_filter,
-    migrate_planner_model_to_provider, migrate_quality_config, migrate_sandbox_config,
-    migrate_sandbox_egress_filter, migrate_scheduler_daemon_config, migrate_session_recap_config,
-    migrate_shell_transactional, migrate_stt_to_provider, migrate_supervisor_config,
-    migrate_telemetry_config, migrate_vigil_config,
+    migrate_memory_reasoning_config, migrate_memory_reasoning_judge_config,
+    migrate_memory_retrieval_config, migrate_microcompact_config,
+    migrate_orchestration_persistence, migrate_otel_filter, migrate_planner_model_to_provider,
+    migrate_quality_config, migrate_sandbox_config, migrate_sandbox_egress_filter,
+    migrate_scheduler_daemon_config, migrate_session_recap_config, migrate_shell_transactional,
+    migrate_stt_to_provider, migrate_supervisor_config, migrate_telemetry_config,
+    migrate_vigil_config,
 };
 
 /// Handle the `zeph migrate-config` command.
@@ -173,13 +173,11 @@ pub(crate) fn handle_migrate_config(
     let after_hebbian_consolidation = hebbian_consolidation_result.output;
 
     // Step 31b: splice HL-F5 spreading-activation fields into [memory.hebbian] if absent (#3346).
-    let hebbian_spread_result =
-        migrate_memory_hebbian_spread_config(&after_hebbian_consolidation)?;
+    let hebbian_spread_result = migrate_memory_hebbian_spread_config(&after_hebbian_consolidation)?;
     let after_hebbian_spread = hebbian_spread_result.output;
 
     // Step 32: add commented-out [[hooks.turn_complete]] block if absent (#3308).
-    let hooks_turn_complete_result =
-        migrate_hooks_turn_complete_config(&after_hebbian_spread)?;
+    let hooks_turn_complete_result = migrate_hooks_turn_complete_config(&after_hebbian_spread)?;
     let after_hooks_turn_complete = hooks_turn_complete_result.output;
 
     // Step 33: inject auto_consolidate_min_window into [agent.focus] if absent (#3313).

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -12,7 +12,8 @@ use zeph_core::config::migrate::{
     migrate_hooks_permission_denied_config, migrate_hooks_turn_complete_config,
     migrate_magic_docs_config, migrate_mcp_elicitation_config, migrate_mcp_trust_levels,
     migrate_memory_graph_config, migrate_memory_hebbian_config,
-    migrate_memory_hebbian_consolidation_config, migrate_memory_reasoning_config,
+    migrate_memory_hebbian_consolidation_config, migrate_memory_hebbian_spread_config,
+    migrate_memory_reasoning_config,
     migrate_memory_reasoning_judge_config, migrate_memory_retrieval_config,
     migrate_microcompact_config, migrate_orchestration_persistence, migrate_otel_filter,
     migrate_planner_model_to_provider, migrate_quality_config, migrate_sandbox_config,
@@ -171,9 +172,14 @@ pub(crate) fn handle_migrate_config(
         migrate_memory_hebbian_consolidation_config(&after_memory_hebbian)?;
     let after_hebbian_consolidation = hebbian_consolidation_result.output;
 
+    // Step 31b: splice HL-F5 spreading-activation fields into [memory.hebbian] if absent (#3346).
+    let hebbian_spread_result =
+        migrate_memory_hebbian_spread_config(&after_hebbian_consolidation)?;
+    let after_hebbian_spread = hebbian_spread_result.output;
+
     // Step 32: add commented-out [[hooks.turn_complete]] block if absent (#3308).
     let hooks_turn_complete_result =
-        migrate_hooks_turn_complete_config(&after_hebbian_consolidation)?;
+        migrate_hooks_turn_complete_config(&after_hebbian_spread)?;
     let after_hooks_turn_complete = hooks_turn_complete_result.output;
 
     // Step 33: inject auto_consolidate_min_window into [agent.focus] if absent (#3313).


### PR DESCRIPTION
## Summary

- **#3346** — Implements HL-F5 spreading activation retrieval for HeLa-Mem: BFS from top-1 ANN anchor with multiplicative path weights, cosine clamping to [0,1], per-step circuit breaker, Hebbian reinforcement on traversed edges, dim-probe at startup, ANN fallback when anchor has no edges. Opt-in via `[memory.hebbian] spreading_activation = false` (zero-change invariant preserved).
- **#3379** — Adds `tracing::info_span!` and structured `debug!` events to `apply_query_bias()` and `profile_centroid_cached()`: all four skip branches (disabled, not_first_person, no_centroid, dim_mismatch), apply branch with centroid dim and weight, and three centroid branches (computed, cache hit with TTL, stale).

## New public surface

- `graph::activation::{HelaFact, HelaSpreadParams, hela_spreading_recall}`
- `VectorStore::get_points` default trait method + Qdrant implementation
- `EmbeddingStore::get_vectors_from_collection`
- `GraphStore::qdrant_point_ids_for_entities`
- `SemanticMemory::with_hebbian_spread` + `recall_graph_hela` in `semantic::recall`
- Config migration step 31b for four new `[memory.hebbian]` fields

## Test plan

- [ ] `cargo nextest run --config-file .github/nextest.toml -p zeph-memory -p zeph-config --lib --no-fail-fast` — 1546 unit tests pass
- [ ] `cargo +nightly fmt --check -p zeph-memory -p zeph-config` — clean
- [ ] `cargo clippy -p zeph-memory -p zeph-config -- -D warnings` — clean
- [ ] Integration tests in `crates/zeph-memory/tests/hela_spreading_activation.rs` — require Qdrant container, marked `#[ignore]`
- [ ] Coverage-status rows added for `hela-mem-spread` and `query-bias-tracing` (status: Untested)
- [ ] Playbook at `.local/testing/playbooks/hela-mem-spreading.md`

Closes #3346, #3379