### PR TITLE
perf(core): offload score_blocks_mig O(K²) loop to spawn_blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- `run_focus_auto_consolidation` now offloads the O(K²) pairwise MIG scoring loop to
+  `tokio::task::spawn_blocking`, preventing long-session consolidation passes from
+  stalling the async executor (#3386).
+
 ### Added
 
 - HL-F5 HeLa-Mem spreading activation retrieval (#3346). `hela_spreading_recall` performs BFS

--- a/crates/zeph-core/src/agent/compaction_strategy.rs
+++ b/crates/zeph-core/src/agent/compaction_strategy.rs
@@ -677,8 +677,20 @@ pub(crate) async fn run_focus_auto_consolidation(
         return Ok(None);
     }
 
-    let tc = TokenCounter::default();
-    let scores = score_blocks_mig(messages, Some(task_goal).filter(|s| !s.is_empty()), &tc);
+    // Clone inputs so the O(K²) pairwise loop can run on a blocking thread without
+    // stalling the async executor during long sessions.
+    let messages_owned: Vec<Message> = messages.to_vec();
+    let task_goal_owned = task_goal.to_string();
+    let scores = tokio::task::spawn_blocking(move || {
+        let tc = TokenCounter::default();
+        score_blocks_mig(
+            &messages_owned,
+            Some(task_goal_owned.as_str()).filter(|s| !s.is_empty()),
+            &tc,
+        )
+    })
+    .await
+    .map_err(|e| format!("score_blocks_mig panicked: {e}"))?;
 
     // Find the oldest contiguous run of messages with MIG ≤ 0 of length ≥ min_window.
     // `scores` is indexed by their original message positions via `msg_index`.


### PR DESCRIPTION
## Summary

- Wraps the O(K²) pairwise MIG scoring loop in `run_focus_auto_consolidation` with `tokio::task::spawn_blocking` to prevent blocking the async executor during long-session consolidation passes.
- Messages and task goal are cloned before entering the blocking closure; a fresh `TokenCounter` is constructed inside it.
- No change to `score_blocks_mig` signature or the sync call site in `prune_tool_outputs_mig` (which is already a sync `fn`).

Closes #3386

## Test plan

- [x] `cargo build -p zeph-core` — compiles cleanly
- [x] `cargo +nightly fmt --check` — no formatting issues
- [x] `cargo clippy -p zeph-core -- -D warnings` — zero warnings
- [x] `cargo nextest run --workspace --lib --bins` — 8475 tests pass, 0 failures