### PR TITLE
release: v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-04-25
+
 ### Changed
 
 - `run_focus_auto_consolidation` now offloads the O(K²) pairwise MIG scoring loop to
@@ -4923,7 +4925,8 @@ let agent = Agent::new(provider, channel, &skills_prompt, executor);
 - Agent::run() uses tokio::select! to race channel messages against shutdown signal
 
 [0.16.0]: https://github.com/bug-ops/zeph/compare/v0.15.3...v0.16.0
-[Unreleased]: https://github.com/bug-ops/zeph/compare/v0.19.3...HEAD
+[Unreleased]: https://github.com/bug-ops/zeph/compare/v0.20.0...HEAD
+[0.20.0]: https://github.com/bug-ops/zeph/compare/v0.19.3...v0.20.0
 [0.19.3]: https://github.com/bug-ops/zeph/compare/v0.19.2...v0.19.3
 [0.19.2]: https://github.com/bug-ops/zeph/compare/v0.19.1...v0.19.2
 [0.19.1]: https://github.com/bug-ops/zeph/compare/v0.19.0...v0.19.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [0.20.0] - 2026-04-25
 
-### Changed
-
-- `run_focus_auto_consolidation` now offloads the O(K²) pairwise MIG scoring loop to
-  `tokio::task::spawn_blocking`, preventing long-session consolidation passes from
-  stalling the async executor (#3386).
-
 ### Added
 
 - HL-F5 HeLa-Mem spreading activation retrieval (#3346). `hela_spreading_recall` performs BFS
@@ -28,6 +22,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `spread_edge_types`, `step_budget_ms`. New `HelaSpreadRuntime` struct on `SemanticMemory`
   attached via `with_hebbian_spread()`. Config migration step 31b splices the four fields into
   existing configs. WARN logged for unrecognised edge type strings in `spread_edge_types`.
+- HL-F1: `Edge.weight: f32` field (default `1.0`) for Hebbian reinforcement in the graph store
+  (`crates/zeph-memory`). SQLite migration 077 adds `graph_edges.weight REAL NOT NULL DEFAULT 1.0`
+  and the `idx_summaries_message_range` partial index. Postgres is out of scope pending resolution
+  of the 069–076 migration drift (#3344).
+- HL-F2: Hebbian update on recall — `GraphStore::apply_hebbian_increment` increments edge weights
+  for traversed edges; wired fire-and-forget into all four graph retrieval paths. Controlled by
+  `[memory.hebbian] enabled = false` (opt-in) and `hebbian_lr = 0.1` (#3344).
 - `VectorStore::get_points` default trait method returning `Err(Unsupported)` for backends that
   cannot return raw vectors; Qdrant impl via `GetPointsBuilder::new(...).with_vectors(true)`.
 - `GraphStore::qdrant_point_ids_for_entities` SQL helper (490-entity batch chunks).
@@ -36,6 +37,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Tracing spans on `apply_query_bias` (`memory.query_bias.apply`) and `profile_centroid_cached`
   (`memory.query_bias.centroid`) with structured debug events for bias applied/skipped,
   centroid computed, and centroid cache hits (#3379).
+- MM-F3: Query-bias correction — first-person queries are shifted toward the user's profile centroid
+  embedding before vector search. `[memory.retrieval] query_bias_correction = true` and
+  `query_bias_profile_weight = 0.25` control the blend. Centroid is cached in a TTL-bounded
+  `RwLock<Option<CachedCentroid>>` (default 300 s); computation failure is non-sticky and
+  falls through to the previous cache or no-op (#3341).
+- MM-F4: Episode preservation is now unconditional (data-integrity invariant): the eviction sweep
+  calls `MessageStore::filter_out_preserved_episode_ids` to exclude any message ID that falls within
+  a summary's `[first_message_id, last_message_id]` range before soft-deleting. No config flag
+  required (#3341).
+- `[memory.retrieval]` config section: `depth` (ANN candidate count, `0` = legacy `recall_limit * 2`),
+  `search_prompt_template` (query-side embedding template with `{query}` placeholder),
+  `context_format` (`structured` / `plain` — memory snippet rendering in agent context).
+  MemMachine MM-F1/F2/F5 (#3340).
+- **ReasoningBank** (#3342, #3343): distilled reasoning strategy memory. After each assistant turn
+  a fire-and-forget three-stage pipeline (self-judge → distillation → store) extracts a ≤3-sentence
+  strategy summary and writes it to a new `reasoning_strategies` SQLite table. At context-build time
+  top-k strategies are retrieved by embedding similarity and injected into the prompt preamble. LRU
+  eviction with hot-row protection (configurable `store_limit`, `HOT_STRATEGY_USE_COUNT = 10`) keeps
+  the table bounded. Fully opt-in: `memory.reasoning.enabled = false` by default. New migration:
+  `crates/zeph-db/migrations/sqlite/077_reasoning_strategies.sql`.
+- Experience compression spectrum (`[memory.compression_spectrum]`): introduces `CompressionLevel`
+  (Episodic / Procedural / Declarative) and a `RetrievalPolicy` that skips episodic recall when
+  the token budget is below configurable thresholds. A background `PromotionEngine` scans recent
+  episodic memory and promotes repeated patterns to SKILL.md entries (off hot path, via JoinSet).
+  Spans: `memory.compression.*` (#3305).
+- `SkillEvaluationConfig`, `ProactiveExplorationConfig`, `CompressionSpectrumConfig` TOML sections
+  with `#[serde(default)]` — all disabled by default; existing configs parse unchanged.
+- `MemoryError::Promotion` variant in `zeph-memory` for promotion scan failures (thiserror,
+  no anyhow in library crates).
 - Provider preference persistence per channel (#3308). The last-used provider (set via
   `/provider <name>`) is now saved to `SQLite` after each successful switch and automatically
   restored on the next session start. Identity is keyed by `(channel_type, channel_id)` —
@@ -48,9 +78,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   configured; fires on every turn when no notifier is present. Adds `turn_complete` field to
   `HooksConfig` and `HooksConfigSnapshot`; `HooksConfig::is_empty()` updated accordingly.
   Commented-out macOS example added to `config/default.toml`.
-- `specs/UX/mention-routing.md` — research spec assessing `@agent` mention routing feasibility
-  for Zeph's TUI. Documents the Goose reference pattern, required changes, and defers
-  implementation pending `AgentRegistry` infrastructure (#3327).
+- Hook actions now support `type = "mcp_tool"` to invoke MCP server tools directly without
+  spawning a subprocess (#3293). Hooks can set `server`, `tool`, and optional `args` fields.
+  Requires the MCP manager to be active; fails according to `fail_closed` if unavailable.
+- New `[hooks.permission_denied]` event fires when a tool execution is short-circuited by a
+  `RuntimeLayer::before_tool` check (#3292). `Command` hooks receive `ZEPH_DENIED_TOOL` and
+  `ZEPH_DENY_REASON` environment variables.
+- `config/default.toml` now includes commented examples for all lifecycle hook events:
+  `[[hooks.cwd_changed]]`, `[[hooks.permission_denied]]`, and `[hooks.file_changed]`, covering
+  both `type = "command"` and `type = "mcp_tool"` action variants (#3323).
+- `McpDispatch` trait in `zeph-subagent` decouples hook execution from `zeph-mcp` — implementors
+  are wired by `zeph-core` at call sites.
+- `LayerDenial` struct replaces the bare `BeforeToolResult` type alias: layers now carry an explicit
+  `reason: String` that is propagated into the `ZEPH_DENY_REASON` hook env var (#3310).
 - Compaction progress UX improvements (#3314):
   - `MetricsSnapshot` gains four new fields: `context_max_tokens`, `compaction_last_before`,
     `compaction_last_after`, and `compaction_last_at_ms` (all `u64`, default 0 = unknown/never).
@@ -65,25 +105,132 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     red > 90%); hides gracefully when `context_max_tokens == 0` (displays `"—"`).
   - TUI: new `compaction_badge` widget shows `"{before}k→{after}k (-{saved}k) {elapsed}"` as a
     persistent side-panel entry; hidden until the first compaction occurs this session.
+- External-feedback skill evaluator (`[skills.evaluation]`): generated skills are now scored on
+  correctness, reusability, and specificity by a separate critic LLM call before being written to
+  disk. Weights (default 0.50/0.25/0.25) and pass threshold (default 0.60) are configurable.
+  Defaults to fail-open: if the evaluator errors, the skill is accepted. Spans: `skills.eval.*`
+  (#3319).
+- Proactive world-knowledge exploration (`[skills.proactive_exploration]`): before each LLM call
+  the agent classifies the query domain (keyword-based) and generates a `world-knowledge-{domain}`
+  SKILL.md when none exists. The generated skill is visible from the **next** turn (not the
+  current one — intentional MVP trade-off to keep turn latency bounded). Spans: `core.proactive.*`
+  (#3320).
+- Background shell execution (#3328): `bash` tool call accepts `background: bool` parameter.
+  When `true`, the command is spawned immediately and a `[background] started run_id=…`
+  stub is returned to close the LLM's `tool_use_id`. Completion is delivered as a synthetic
+  user-role block at the start of the next turn (drain-on-next-turn pattern, N1 invariant:
+  all pending completions are merged with the real user message into a single user-role block
+  to satisfy strict Anthropic alternation). `ShellExecutor` gains `spawn_background()`,
+  `shutdown()`, and `with_background_completion_tx()`. `ToolEventTx` is now a bounded
+  `mpsc::Sender<ToolEvent>` (cap 1024). New config fields: `tools.shell.max_background_runs`
+  (default 8) and `tools.shell.background_timeout_secs` (default 1800). New supervisor task
+  class `BackgroundShell` isolated from `Enrichment`. `agent.supervisor.background_shell_limit`
+  added to `TaskSupervisorConfig`.
+- Per-turn completion notifications (#3328 / #3329): `zeph-core` gains a `Notifier` that fires
+  after each agent turn via macOS native banners (`osascript`, stdin-fed to prevent injection)
+  and/or an ntfy-compatible JSON webhook. Gate conditions: master `enabled` switch,
+  zero-LLM-success skip (slash commands / cache hits), `only_on_error`, and a duration
+  threshold (`min_turn_duration_ms`). Error turns always fire regardless of duration.
+  Secrets are redacted via `scrub_content` before any payload leaves the process.
+  `zeph notify test` CLI subcommand and `/notify-test` slash command fire a test notification.
+  New `[notifications]` config section with commented defaults in `default.toml`.
+- CPS (cost per successful task) metric in `CostTracker`: `record_successful_task()`, `cps()`,
+  and `successful_tasks()` methods; daily reset consistent with existing cost reset (#2194).
+- `cost_cps_cents: Option<f64>` and `cost_successful_tasks: u64` fields in `AgentMetrics`;
+  updated after each successful turn in `native.rs` and `plan.rs` (#2194).
+- Qwen-2.5-7B Ollama provider entry (commented) in `.local/config/testing.toml` as `slm-medium`
+  for cost-optimised medium-complexity tasks per arXiv:2510.03847 (#2194).
+- Spec `specs/048-slm-cost-metrics/spec.md` documenting SLM survey findings and CPS metric
+  contract (#2194).
+- `specs/UX/mention-routing.md` — research spec assessing `@agent` mention routing feasibility
+  for Zeph's TUI. Documents the Goose reference pattern, required changes, and defers
+  implementation pending `AgentRegistry` infrastructure (#3327).
+- feat(a2a): AgentCard modality capability declarations (images/audio/files) (#3326).
+- feat(core): Focus strategy auto-consolidation via `run_focus_auto_consolidation` (#3313).
+- **feat(acp): ACP client sub-agent** (#3272) — `zeph-acp` gains a `client` module with
+  `SubagentConfig`, `SubagentHandle`, `spawn_subagent`, and `run_session`; spawns an
+  ACP-compatible child process via `tokio::process::Command` with `env_clear()` + whitelist
+  so no `ZEPH_*` secrets leak; biased `tokio::select!` in the driver loop allows
+  `session/cancel` to preempt in-flight reads within one poll cycle; `drain_until_stop`
+  collects text chunks and exposes `StopReason` via `RunOutcome`; 11 unit tests cover env
+  isolation, cwd, error display, and config helpers.
+- **feat(cli): `zeph acp run-agent` command** (#3272) — new `acp run-agent --command <CMD>
+  [--prompt <TEXT>] [--cwd <DIR>] [--timeout <SECS>]` sub-command for one-shot sub-agent
+  delegation; reads prompt from stdin when `--prompt` is omitted; feature-gated behind `acp`.
+- **feat(cli): `zeph acp subagent list` command** (#3272) — stub command that directs the user
+  to configure sub-agent presets in `[acp.subagents]`.
+- Add `zeph-acp` handler module scaffolding for ACP 0.11 migration (PR 1, epic #3265).
+- Add `unstable-auth-methods`, `unstable-message-id`, `unstable-session-add-dirs`,
+  `unstable-boolean-config` optional features to `zeph-acp`.
+- **feat(acp): `additional_directories` request-side allowlist** (#3270, PR 4) —
+  `AcpConfig.additional_directories` (Vec of validated paths); `AdditionalDir` newtype with
+  traversal and reserved-prefix checks; `validate_additional_directories` rejects session
+  requests with non-allowed paths at session start; feature-gated by `unstable-session-add-dirs`.
+- **feat(acp): `auth_methods` strict config** (#3270, PR 4) — `AcpConfig.auth_methods` with
+  custom `Deserialize` that rejects unknown variants at startup; MVP accepts `"agent"` only;
+  `AcpAuthMethod` enum; feature-gated by `unstable-auth-methods`; `initialize` response built
+  dynamically from config.
+- **feat(acp): `message_ids_enabled` echo** (#3270, PR 4) — `AcpConfig.message_ids_enabled`;
+  client `message_id` stored per-session via `std::sync::Mutex<Option<String>>`; echoed on
+  `PromptResponse.user_message_id` and all streamed chunks via `apply_message_id_to_chunk`;
+  feature-gated by `unstable-message-id`.
+- **feat(cli): ACP config overrides** (#3270, PR 4) — `--acp-additional-dir <PATH>` (repeatable),
+  `--acp-auth-method <METHOD>` (repeatable, validated), `--acp-message-ids` /
+  `--no-acp-message-ids` boolean pair; CLI overrides take precedence over config file values.
+- **feat(tui): ACP read-only commands** (#3270, PR 4) — `/acp dirs`, `/acp auth-methods`,
+  `/acp status` slash commands in TUI command palette; all are read-only status queries.
+- **feat(init): ACP wizard prompts** (#3270, PR 4) — `--init` wizard `step_acp` extended with
+  prompts for additional_directories, auth_methods preset, and message_ids_enabled toggle.
+- **feat(config): ACP migration fixture** (#3270, PR 4) — `migrate_adds_pr4_acp_keys_commented`
+  test verifies pre-PR4 configs are upgraded with commented-out new keys.
+- `/subagent spawn <command>` slash command is now intercepted in the core agent loop and works
+  in CLI, piped, and bare modes — previously fell through to the LLM (#3302). Without ACP
+  support, the command returns a clear "not available" message. `AcpSubagentSpawnFn` callback
+  type bridges `zeph-core` ↔ `zeph-acp` without a direct crate dependency.
 
-- HL-F1: `Edge.weight: f32` field (default `1.0`) for Hebbian reinforcement in the graph store
-  (`crates/zeph-memory`). SQLite migration 077 adds `graph_edges.weight REAL NOT NULL DEFAULT 1.0`
-  and the `idx_summaries_message_range` partial index. Postgres is out of scope pending resolution
-  of the 069–076 migration drift (#3344).
-- HL-F2: Hebbian update on recall — `GraphStore::apply_hebbian_increment` increments edge weights
-  for traversed edges; wired fire-and-forget into all four graph retrieval paths. Controlled by
-  `[memory.hebbian] enabled = false` (opt-in) and `hebbian_lr = 0.1` (#3344).
-- MM-F3: Query-bias correction — first-person queries are shifted toward the user's profile centroid
-  embedding before vector search. `[memory.retrieval] query_bias_correction = true` and
-  `query_bias_profile_weight = 0.25` control the blend. Centroid is cached in a TTL-bounded
-  `RwLock<Option<CachedCentroid>>` (default 300 s); computation failure is non-sticky and
-  falls through to the previous cache or no-op (#3341).
-- MM-F4: Episode preservation is now unconditional (data-integrity invariant): the eviction sweep
-  calls `MessageStore::filter_out_preserved_episode_ids` to exclude any message ID that falls within
-  a summary's `[first_message_id, last_message_id]` range before soft-deleting. No config flag
-  required (#3341).
-- feat(a2a): AgentCard modality capability declarations (images/audio/files) (#3326)
-- feat(core): Focus strategy auto-consolidation via `run_focus_auto_consolidation` (#3313)
+### Changed
+
+- `run_focus_auto_consolidation` now offloads the O(K²) pairwise MIG scoring loop to
+  `tokio::task::spawn_blocking`, preventing long-session consolidation passes from
+  stalling the async executor (#3386).
+- **BREAKING (config):** `HookDef.hook_type + command` fields replaced by `HookDef.action:
+  HookAction` (serde-flattened). Existing TOML with `type = "command"` deserializes correctly
+  — no manual migration needed. Internal Rust code constructing `HookDef` must use
+  `action: HookAction::Command { command: "..." }` (#3293).
+- **BREAKING (config):** Renamed `MigrationResult::added_count` → `changed_count` and
+  `sections_added` → `sections_changed` to reflect that migrations now report both additions
+  and removals (#3282).
+- **`zeph-acp`**: `AgentSpawner` future bound no longer requires `Send` — spawner closures
+  produce `Pin<Box<dyn Future<Output = ()> + 'static>>` (no `+ Send`); all agent sessions
+  now run on `spawn_local` inside a `LocalSet`. Callers that previously required `Send` on
+  the spawner future must be updated.
+- **`zeph-acp`**: `transport::bridge` module removed — bridge logic is now inline in
+  `transport::http::spawn_agent_connection`; update any direct imports of
+  `crate::transport::bridge`.
+- ACP: migrated to agent-client-protocol 0.11.1 builder API (`Agent.builder()` / `run_agent()`
+  pattern); `Rc<RefCell>` replaced with `Arc`; added handler tracing spans; config schema
+  extensions (additional_directories, auth_methods, message_ids_enabled).
+- **feat(acp): migrate `zeph-acp` to ACP 0.11 builder API** (#3267, PR 2, epic #3265) —
+  bumps `agent-client-protocol` to 0.11.1 and adds `agent-client-protocol-tokio = "0.11.1"`;
+  renames `ZephAcpAgent` → `ZephAcpAgentState` and removes all `!Send` constraints
+  (`LocalSet`, `Rc`, `RefCell` eliminated); replaces `impl acp::Agent` with `run_agent()`
+  using the `Agent.builder()` pattern; rewrites `stdio.rs` to use `acp::ByteStreams`;
+  updates all executors to use `Arc<ConnectionTo<Client>>`; switches outbound ext-method
+  calls from `ExtRequest` to `UntypedMessage`; gates ACP 0.10-era tests with `#[cfg(any())]`.
+- **`zeph-acp`**: integration tests rewritten for ACP 0.11 builder API using
+  `acp::Client.connect_with` and `serve_connection`; `#[cfg(any())]` gate removed; 6 real
+  loopback tests cover initialize, new_session, cancel, unknown ext method, load_session
+  error, and session list (#3269, PR 3).
+- **`zeph-acp`**: add `acp.session.agent_loop` tracing spans (`.instrument(span)`) to all four
+  `spawn_local` sites in `agent/mod.rs` (`do_new_session`, `do_load_session`, `do_fork_session`,
+  `do_resume_session`) for per-session observability in local Chrome JSON traces.
+- **`zeph-acp`**: refresh `AgentSpawner` doc comment to accurately describe `LocalSet`
+  requirement and `!Send` constraint.
+- `DbGraphStore` renamed to `TaskGraphStore` in `zeph-memory` for clarity (previously confused
+  with knowledge-graph `GraphStore`). This is a breaking API change for external callers (#3253).
+- `migrate_compression_predictor_config` now strips any `[memory.compression.predictor]` section
+  (active or commented-out) from user configs instead of adding it, to clean up stale sections
+  injected by previous `--migrate-config` runs (#3251).
 
 ### Fixed
 
@@ -127,7 +274,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   destruction on CI startup (#3390).
 - skills: use stable embed provider model name for Qdrant collection versioning to prevent
   collection oscillation and near-zero cosine scores (#3391).
-
 - `--bare` mode now skips the file change watcher: `with_hooks_config` is no longer called
   unconditionally in `runner.rs` — it is guarded by `!exec_mode.bare`, preventing background
   filesystem watch threads from starting in minimal sessions (#3362).
@@ -161,150 +307,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `--bare` mode now skips MCP `connect_all` and the background refresh task, gateway server spawn,
   and `agent.with_graph_config()` activation — all three were previously unconditional (#3298).
   Bare mode is a minimal LLM round-trip with no external service dependencies as documented.
-
-### Added
-
-- External-feedback skill evaluator (`[skills.evaluation]`): generated skills are now scored on
-  correctness, reusability, and specificity by a separate critic LLM call before being written to
-  disk. Weights (default 0.50/0.25/0.25) and pass threshold (default 0.60) are configurable.
-  Defaults to fail-open: if the evaluator errors, the skill is accepted. Spans: `skills.eval.*`
-  (#3319).
-- Proactive world-knowledge exploration (`[skills.proactive_exploration]`): before each LLM call
-  the agent classifies the query domain (keyword-based) and generates a `world-knowledge-{domain}`
-  SKILL.md when none exists. The generated skill is visible from the **next** turn (not the
-  current one — intentional MVP trade-off to keep turn latency bounded). Spans: `core.proactive.*`
-  (#3320).
-- Experience compression spectrum (`[memory.compression_spectrum]`): introduces `CompressionLevel`
-  (Episodic / Procedural / Declarative) and a `RetrievalPolicy` that skips episodic recall when
-  the token budget is below configurable thresholds. A background `PromotionEngine` scans recent
-  episodic memory and promotes repeated patterns to SKILL.md entries (off hot path, via JoinSet).
-  Spans: `memory.compression.*` (#3305).
-- `SkillEvaluationConfig`, `ProactiveExplorationConfig`, `CompressionSpectrumConfig` TOML sections
-  with `#[serde(default)]` — all disabled by default; existing configs parse unchanged.
-- `MemoryError::Promotion` variant in `zeph-memory` for promotion scan failures (thiserror,
-  no anyhow in library crates).
-- `[memory.retrieval]` config section: `depth` (ANN candidate count, `0` = legacy `recall_limit * 2`),
-  `search_prompt_template` (query-side embedding template with `{query}` placeholder),
-  `context_format` (`structured` / `plain` — memory snippet rendering in agent context).
-  MemMachine MM-F1/F2/F5 (#3340).
-- Background shell execution (#3328): `bash` tool call accepts `background: bool` parameter.
-  When `true`, the command is spawned immediately and a `[background] started run_id=…`
-  stub is returned to close the LLM's `tool_use_id`. Completion is delivered as a synthetic
-  user-role block at the start of the next turn (drain-on-next-turn pattern, N1 invariant:
-  all pending completions are merged with the real user message into a single user-role block
-  to satisfy strict Anthropic alternation). `ShellExecutor` gains `spawn_background()`,
-  `shutdown()`, and `with_background_completion_tx()`. `ToolEventTx` is now a bounded
-  `mpsc::Sender<ToolEvent>` (cap 1024). New config fields: `tools.shell.max_background_runs`
-  (default 8) and `tools.shell.background_timeout_secs` (default 1800). New supervisor task
-  class `BackgroundShell` isolated from `Enrichment`. `agent.supervisor.background_shell_limit`
-  added to `TaskSupervisorConfig`.
-- Per-turn completion notifications (#3328 / #3329): `zeph-core` gains a `Notifier` that fires
-  after each agent turn via macOS native banners (`osascript`, stdin-fed to prevent injection)
-  and/or an ntfy-compatible JSON webhook. Gate conditions: master `enabled` switch,
-  zero-LLM-success skip (slash commands / cache hits), `only_on_error`, and a duration
-  threshold (`min_turn_duration_ms`). Error turns always fire regardless of duration.
-  Secrets are redacted via `scrub_content` before any payload leaves the process.
-  `zeph notify test` CLI subcommand and `/notify-test` slash command fire a test notification.
-  New `[notifications]` config section with commented defaults in `default.toml`.
-- **ReasoningBank** (#3342, #3343): distilled reasoning strategy memory. After each assistant turn
-  a fire-and-forget three-stage pipeline (self-judge → distillation → store) extracts a ≤3-sentence
-  strategy summary and writes it to a new `reasoning_strategies` SQLite table. At context-build time
-  top-k strategies are retrieved by embedding similarity and injected into the prompt preamble. LRU
-  eviction with hot-row protection (configurable `store_limit`, `HOT_STRATEGY_USE_COUNT = 10`) keeps
-  the table bounded. Fully opt-in: `memory.reasoning.enabled = false` by default. New migration:
-  `crates/zeph-db/migrations/sqlite/077_reasoning_strategies.sql`.
-- CPS (cost per successful task) metric in `CostTracker`: `record_successful_task()`, `cps()`,
-  and `successful_tasks()` methods; daily reset consistent with existing cost reset (#2194).
-- `cost_cps_cents: Option<f64>` and `cost_successful_tasks: u64` fields in `AgentMetrics`;
-  updated after each successful turn in `native.rs` and `plan.rs` (#2194).
-- Qwen-2.5-7B Ollama provider entry (commented) in `.local/config/testing.toml` as `slm-medium`
-  for cost-optimised medium-complexity tasks per arXiv:2510.03847 (#2194).
-- Spec `specs/048-slm-cost-metrics/spec.md` documenting SLM survey findings and CPS metric
-  contract (#2194).
-- Hook actions now support `type = "mcp_tool"` to invoke MCP server tools directly without spawning a subprocess (#3293). Hooks can set `server`, `tool`, and optional `args` fields. Requires the MCP manager to be active; fails according to `fail_closed` if unavailable.
-- New `[hooks.permission_denied]` event fires when a tool execution is short-circuited by a `RuntimeLayer::before_tool` check (#3292). `Command` hooks receive `ZEPH_DENIED_TOOL` and `ZEPH_DENY_REASON` environment variables.
-- `McpDispatch` trait in `zeph-subagent` decouples hook execution from `zeph-mcp` — implementors are wired by `zeph-core` at call sites.
-- `/subagent spawn <command>` slash command is now intercepted in the core agent loop and works in CLI, piped, and bare modes — previously fell through to the LLM (#3302). Without ACP support, the command returns a clear "not available" message. `AcpSubagentSpawnFn` callback type bridges `zeph-core` ↔ `zeph-acp` without a direct crate dependency.
-- `LayerDenial` struct replaces the bare `BeforeToolResult` type alias: layers now carry an explicit `reason: String` that is propagated into the `ZEPH_DENY_REASON` hook env var (#3310). The previously hardcoded `"blocked by before_tool layer"` string is removed.
-- `config/default.toml` now includes commented examples for all lifecycle hook events: `[[hooks.cwd_changed]]`, `[[hooks.permission_denied]]`, and `[hooks.file_changed]`, covering both `type = "command"` and `type = "mcp_tool"` action variants (#3323).
-
-### Changed
-
-- **BREAKING (config):** `HookDef.hook_type + command` fields replaced by `HookDef.action: HookAction` (serde-flattened). Existing TOML with `type = "command"` deserializes correctly — no manual migration needed. Internal Rust code constructing `HookDef` must use `action: HookAction::Command { command: "..." }` (#3293).
+- **fix(acp): stale `current_message_id` leak across turns** (#3270, review fix) — `do_prompt`
+  previously wrote `current_message_id` before the `output_rx.take()` check; if a prompt was
+  rejected as "already in progress" the slot held the stale id from the failed request; moved
+  write to after successful `output_rx.take()`.
+- **fix(acp): empty `auth_methods = []` silently fell back to default** (#3270, review fix) —
+  empty list in config or from CLI now causes a hard error at startup; operator intent is
+  honoured rather than silently replaced.
+- **fix(acp): invalid CLI `--acp-additional-dir`/`--acp-auth-method` silently dropped**
+  (#3270, review fix) — changed `filter_map(...).ok()` to map errors and return early via `?`;
+  binary now exits non-zero on invalid CLI input.
+- **perf(acp): per-event `sessions.lock()` re-read of `current_message_id`** (#3270, review
+  fix) — captured `turn_mid` once at drain start instead of re-locking per chunk event.
 
 ### Removed
 
-- `admission_rl` module (RL-based admission classifier, never wired into production) (#3250). SQLite table `admission_rl_weights` remains (migrations are append-only).
-- `compression_predictor` module and `CompressionPredictorConfig` config field (linear regression compaction predictor, never called in production) (#3251). SQLite tables `compression_predictor_training` and `compression_predictor_weights` remain (append-only).
+- `admission_rl` module (RL-based admission classifier, never wired into production) (#3250).
+  SQLite table `admission_rl_weights` remains (migrations are append-only).
+- `compression_predictor` module and `CompressionPredictorConfig` config field (linear regression
+  compaction predictor, never called in production) (#3251). SQLite tables
+  `compression_predictor_training` and `compression_predictor_weights` remain (append-only).
 - CLI subcommand `zeph memory predictor-status` (backed by removed module) (#3251).
 - TUI command `predictor-status` (backed by removed module) (#3251).
 - `SqliteGraphStore` type alias — use `TaskGraphStore` instead (#3253).
-
-### Changed
-
-- **BREAKING (config):** Renamed `MigrationResult::added_count` → `changed_count` and `sections_added` → `sections_changed` to reflect that migrations now report both additions and removals (#3282).
-- `DbGraphStore` renamed to `TaskGraphStore` in `zeph-memory` for clarity (previously confused with knowledge-graph `GraphStore`). This is a breaking API change for external callers. (#3253).
-- `migrate_compression_predictor_config` now strips any `[memory.compression.predictor]` section (active or commented-out) from user configs instead of adding it, to clean up stale sections injected by previous `--migrate-config` runs (#3251).
-
-### Breaking Changes
-
-- **`zeph-acp`**: `AgentSpawner` future bound no longer requires `Send` — spawner closures
-  produce `Pin<Box<dyn Future<Output = ()> + 'static>>` (no `+ Send`); all agent sessions
-  now run on `spawn_local` inside a `LocalSet`. Callers that previously required `Send` on
-  the spawner future must be updated.
-- **`zeph-acp`**: `transport::bridge` module removed — bridge logic is now inline in
-  `transport::http::spawn_agent_connection`; update any direct imports of
-  `crate::transport::bridge`.
-
-### Removed
-
-- Remove `LlmRoutingStrategy::Task` unimplemented variant and associated `LlmConfig::routes` field (#3248); `--migrate-config` warns and drops the keys automatically
-- Remove unreachable per-provider `coe_enabled`/`with_coe` logprobs branches from `OllamaProvider`, `OpenAiProvider`, `CompatibleProvider` (#3249)
-- Move test-only context/assembler.rs helpers into `assembler_helpers` test module in `zeph-core` (#3254)
-
-### Changed
-
-- ACP: migrated to agent-client-protocol 0.11.1 builder API (`Agent.builder()` / `run_agent()` pattern); `Rc<RefCell>` replaced with `Arc`; added handler tracing spans; config schema extensions (additional_directories, auth_methods, message_ids_enabled)
-
-- **`zeph-acp`**: integration tests rewritten for ACP 0.11 builder API using `acp::Client.connect_with`
-  and `serve_connection`; `#[cfg(any())]` gate removed; 6 real loopback tests cover initialize,
-  new_session, cancel, unknown ext method, load_session error, and session list (#3269, PR 3).
-- **`zeph-acp`**: add `acp.session.agent_loop` tracing spans (`.instrument(span)`) to all four
-  `spawn_local` sites in `agent/mod.rs` (`do_new_session`, `do_load_session`, `do_fork_session`,
-  `do_resume_session`) for per-session observability in local Chrome JSON traces.
-- **`zeph-acp`**: refresh `AgentSpawner` doc comment to accurately describe `LocalSet` requirement
-  and `!Send` constraint.
-
-- **feat(acp): migrate `zeph-acp` to ACP 0.11 builder API** (#3267, PR 2, epic #3265) —
-  bumps `agent-client-protocol` to 0.11.1 and adds `agent-client-protocol-tokio = "0.11.1"`;
-  renames `ZephAcpAgent` → `ZephAcpAgentState` and removes all `!Send` constraints
-  (`LocalSet`, `Rc`, `RefCell` eliminated); replaces `impl acp::Agent` with `run_agent()`
-  using the `Agent.builder()` pattern; rewrites `stdio.rs` to use `acp::ByteStreams`;
-  updates all executors to use `Arc<ConnectionTo<Client>>`; switches outbound ext-method
-  calls from `ExtRequest` to `UntypedMessage`; gates ACP 0.10-era tests with `#[cfg(any())]`.
-
-### Added
-
-- **feat(acp): ACP client sub-agent** (#3272) — `zeph-acp` gains a `client` module with `SubagentConfig`, `SubagentHandle`, `spawn_subagent`, and `run_session`; spawns an ACP-compatible child process via `tokio::process::Command` with `env_clear()` + whitelist so no `ZEPH_*` secrets leak; biased `tokio::select!` in the driver loop allows `session/cancel` to preempt in-flight reads within one poll cycle; `drain_until_stop` collects text chunks and exposes `StopReason` via `RunOutcome`; 11 unit tests cover env isolation, cwd, error display, and config helpers.
-- **feat(cli): `zeph acp run-agent` command** (#3272) — new `acp run-agent --command <CMD> [--prompt <TEXT>] [--cwd <DIR>] [--timeout <SECS>]` sub-command for one-shot sub-agent delegation; reads prompt from stdin when `--prompt` is omitted; feature-gated behind `acp`.
-- **feat(cli): `zeph acp subagent list` command** (#3272) — stub command that directs the user to configure sub-agent presets in `[acp.subagents]`.
-
-- Add `zeph-acp` handler module scaffolding for ACP 0.11 migration (PR 1, epic #3265)
-- Add `unstable-auth-methods`, `unstable-message-id`, `unstable-session-add-dirs`, `unstable-boolean-config` optional features to `zeph-acp`
-- **feat(acp): `additional_directories` request-side allowlist** (#3270, PR 4) — `AcpConfig.additional_directories` (Vec of validated paths); `AdditionalDir` newtype with traversal and reserved-prefix checks; `validate_additional_directories` rejects session requests with non-allowed paths at session start; feature-gated by `unstable-session-add-dirs`
-- **feat(acp): `auth_methods` strict config** (#3270, PR 4) — `AcpConfig.auth_methods` with custom `Deserialize` that rejects unknown variants at startup; MVP accepts `"agent"` only; `AcpAuthMethod` enum; feature-gated by `unstable-auth-methods`; `initialize` response built dynamically from config
-- **feat(acp): `message_ids_enabled` echo** (#3270, PR 4) — `AcpConfig.message_ids_enabled`; client `message_id` stored per-session via `std::sync::Mutex<Option<String>>`; echoed on `PromptResponse.user_message_id` and all streamed chunks via `apply_message_id_to_chunk`; feature-gated by `unstable-message-id`
-- **feat(cli): ACP config overrides** (#3270, PR 4) — `--acp-additional-dir <PATH>` (repeatable), `--acp-auth-method <METHOD>` (repeatable, validated), `--acp-message-ids` / `--no-acp-message-ids` boolean pair; CLI overrides take precedence over config file values
-- **feat(tui): ACP read-only commands** (#3270, PR 4) — `/acp dirs`, `/acp auth-methods`, `/acp status` slash commands in TUI command palette; all are read-only status queries
-- **feat(init): ACP wizard prompts** (#3270, PR 4) — `--init` wizard `step_acp` extended with prompts for additional_directories, auth_methods preset, and message_ids_enabled toggle
-- **feat(config): ACP migration fixture** (#3270, PR 4) — `migrate_adds_pr4_acp_keys_commented` test verifies pre-PR4 configs are upgraded with commented-out new keys
-
-### Fixed
-
-- **fix(acp): stale `current_message_id` leak across turns** (#3270, review fix) — `do_prompt` previously wrote `current_message_id` before the `output_rx.take()` check; if a prompt was rejected as "already in progress" the slot held the stale id from the failed request; moved write to after successful `output_rx.take()`
-- **fix(acp): empty `auth_methods = []` silently fell back to default** (#3270, review fix) — empty list in config or from CLI now causes a hard error at startup; operator intent is honoured rather than silently replaced
-- **fix(acp): invalid CLI `--acp-additional-dir`/`--acp-auth-method` silently dropped** (#3270, review fix) — changed `filter_map(...).ok()` to map errors and return early via `?`; binary now exits non-zero on invalid CLI input
-- **perf(acp): per-event `sessions.lock()` re-read of `current_message_id`** (#3270, review fix) — captured `turn_mid` once at drain start instead of re-locking per chunk event
+- `LlmRoutingStrategy::Task` unimplemented variant and associated `LlmConfig::routes` field
+  (#3248); `--migrate-config` warns and drops the keys automatically.
+- Unreachable per-provider `coe_enabled`/`with_coe` logprobs branches from `OllamaProvider`,
+  `OpenAiProvider`, `CompatibleProvider` (#3249).
+- Test-only context/assembler.rs helpers moved into `assembler_helpers` test module in
+  `zeph-core` (#3254).
 
 ## [0.19.3] - 2026-04-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9955,7 +9955,7 @@ dependencies = [
 
 [[package]]
 name = "zeph"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10022,7 +10022,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-a2a"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -10052,7 +10052,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-acp"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-tokio",
@@ -10095,7 +10095,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-bench"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "clap",
  "serde",
@@ -10110,7 +10110,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-channels"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "axum 0.8.9",
  "criterion",
@@ -10136,7 +10136,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-commands"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "thiserror 2.0.18",
  "tokio",
@@ -10145,7 +10145,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-common"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "blake3",
  "serde",
@@ -10166,7 +10166,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-config"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "dirs",
  "insta",
@@ -10188,7 +10188,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-context"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "blake3",
  "futures",
@@ -10208,7 +10208,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-core"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "age",
  "base64 0.22.1",
@@ -10270,7 +10270,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-db"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "regex",
  "sqlx",
@@ -10285,7 +10285,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-experiments"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "futures",
  "ordered-float 5.3.0",
@@ -10308,7 +10308,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-gateway"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "axum 0.8.9",
  "blake3",
@@ -10327,7 +10327,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-index"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "futures",
  "ignore",
@@ -10361,7 +10361,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-llm"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "async-stream",
  "audioadapter-buffers",
@@ -10403,7 +10403,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-mcp"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -10434,7 +10434,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-memory"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "arc-swap",
  "blake3",
@@ -10471,7 +10471,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-orchestration"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "blake3",
  "dirs",
@@ -10498,7 +10498,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-plugins"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -10520,7 +10520,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-sanitizer"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "proptest",
  "regex",
@@ -10540,7 +10540,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-scheduler"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "chrono",
  "cron",
@@ -10560,7 +10560,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-skills"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -10594,7 +10594,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-subagent"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "dirs",
  "indoc",
@@ -10621,7 +10621,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-tools"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "arc-swap",
  "dirs",
@@ -10663,7 +10663,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-tui"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "chrono",
  "crossterm",
@@ -10700,7 +10700,7 @@ dependencies = [
 
 [[package]]
 name = "zeph-vault"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "age",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 rust-version = "1.95"
-version = "0.19.3"
+version = "0.20.0"
 authors = ["bug-ops"]
 license = "MIT"
 repository = "https://github.com/bug-ops/zeph"
@@ -138,31 +138,31 @@ uuid = "1.23"
 walkdir = "2.5"
 wiremock = "0.6.5"
 zeroize = { version = "1.8.2", default-features = false }
-zeph-a2a = { path = "crates/zeph-a2a", version = "0.19.3" }
-zeph-bench = { path = "crates/zeph-bench", version = "0.19.3" }
-zeph-acp = { path = "crates/zeph-acp", version = "0.19.3" }
-zeph-db = { path = "crates/zeph-db", default-features = false, version = "0.19.3" }
-zeph-channels = { path = "crates/zeph-channels", version = "0.19.3" }
-zeph-common = { path = "crates/zeph-common", version = "0.19.3" }
-zeph-config = { path = "crates/zeph-config", version = "0.19.3" }
-zeph-commands = { path = "crates/zeph-commands", version = "0.19.3" }
-zeph-context = { path = "crates/zeph-context", version = "0.19.3" }
-zeph-core = { path = "crates/zeph-core", version = "0.19.3" }
-zeph-experiments = { path = "crates/zeph-experiments", version = "0.19.3" }
-zeph-gateway = { path = "crates/zeph-gateway", version = "0.19.3" }
-zeph-index = { path = "crates/zeph-index", version = "0.19.3" }
-zeph-llm = { path = "crates/zeph-llm", version = "0.19.3" }
-zeph-mcp = { path = "crates/zeph-mcp", version = "0.19.3" }
-zeph-memory = { path = "crates/zeph-memory", default-features = false, version = "0.19.3" }
-zeph-scheduler = { path = "crates/zeph-scheduler", version = "0.19.3" }
-zeph-skills = { path = "crates/zeph-skills", version = "0.19.3" }
-zeph-tools = { path = "crates/zeph-tools", version = "0.19.3" }
-zeph-tui = { path = "crates/zeph-tui", version = "0.19.3" }
-zeph-vault = { path = "crates/zeph-vault", version = "0.19.3" }
-zeph-orchestration = { path = "crates/zeph-orchestration", version = "0.19.3" }
-zeph-plugins = { path = "crates/zeph-plugins", version = "0.19.3" }
-zeph-sanitizer = { path = "crates/zeph-sanitizer", version = "0.19.3" }
-zeph-subagent = { path = "crates/zeph-subagent", version = "0.19.3" }
+zeph-a2a = { path = "crates/zeph-a2a", version = "0.20.0" }
+zeph-bench = { path = "crates/zeph-bench", version = "0.20.0" }
+zeph-acp = { path = "crates/zeph-acp", version = "0.20.0" }
+zeph-db = { path = "crates/zeph-db", default-features = false, version = "0.20.0" }
+zeph-channels = { path = "crates/zeph-channels", version = "0.20.0" }
+zeph-common = { path = "crates/zeph-common", version = "0.20.0" }
+zeph-config = { path = "crates/zeph-config", version = "0.20.0" }
+zeph-commands = { path = "crates/zeph-commands", version = "0.20.0" }
+zeph-context = { path = "crates/zeph-context", version = "0.20.0" }
+zeph-core = { path = "crates/zeph-core", version = "0.20.0" }
+zeph-experiments = { path = "crates/zeph-experiments", version = "0.20.0" }
+zeph-gateway = { path = "crates/zeph-gateway", version = "0.20.0" }
+zeph-index = { path = "crates/zeph-index", version = "0.20.0" }
+zeph-llm = { path = "crates/zeph-llm", version = "0.20.0" }
+zeph-mcp = { path = "crates/zeph-mcp", version = "0.20.0" }
+zeph-memory = { path = "crates/zeph-memory", default-features = false, version = "0.20.0" }
+zeph-scheduler = { path = "crates/zeph-scheduler", version = "0.20.0" }
+zeph-skills = { path = "crates/zeph-skills", version = "0.20.0" }
+zeph-tools = { path = "crates/zeph-tools", version = "0.20.0" }
+zeph-tui = { path = "crates/zeph-tui", version = "0.20.0" }
+zeph-vault = { path = "crates/zeph-vault", version = "0.20.0" }
+zeph-orchestration = { path = "crates/zeph-orchestration", version = "0.20.0" }
+zeph-plugins = { path = "crates/zeph-plugins", version = "0.20.0" }
+zeph-sanitizer = { path = "crates/zeph-sanitizer", version = "0.20.0" }
+zeph-subagent = { path = "crates/zeph-subagent", version = "0.20.0" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   [![Crates.io](https://img.shields.io/crates/v/zeph)](https://crates.io/crates/zeph)
   [![docs](https://img.shields.io/badge/docs-book-blue)](https://bug-ops.github.io/zeph/)
   [![CI](https://img.shields.io/github/actions/workflow/status/bug-ops/zeph/ci.yml?branch=main&label=CI)](https://github.com/bug-ops/zeph/actions)
-  [![Tests](https://img.shields.io/badge/tests-8506-brightgreen)](https://github.com/bug-ops/zeph/actions)
+  [![Tests](https://img.shields.io/badge/tests-8849-brightgreen)](https://github.com/bug-ops/zeph/actions)
   [![codecov](https://codecov.io/gh/bug-ops/zeph/graph/badge.svg?token=S5O0GR9U6G)](https://codecov.io/gh/bug-ops/zeph)
   [![Crates](https://img.shields.io/badge/crates-25-orange)](https://github.com/bug-ops/zeph/tree/main/crates)
   [![MSRV](https://img.shields.io/badge/MSRV-1.95-blue)](https://www.rust-lang.org)

--- a/book/src/advanced/acp.md
+++ b/book/src/advanced/acp.md
@@ -1292,6 +1292,88 @@ Zeph exposes a `GET /agent.json` endpoint on the HTTP transport that returns a J
 
 When the active model changes (via `/model` command, ACP `set_session_config_option`, or provider fallback), Zeph emits a `SessionInfoUpdate` notification containing the current model name. IDEs can use this to update their model indicator in real time.
 
+## ACP 0.11 Migration and Builder API
+
+Zeph now uses the ACP 0.11 builder API for agent spawning. The `Agent.builder()` pattern replaces direct `impl acp::Agent` construction, and all future connections use the `run_agent()` helper. This migration brings:
+
+- Improved API ergonomics and type safety
+- `Arc<ConnectionTo<Client>>` instead of `Rc<RefCell>`
+- All `!Send` constraints removed; sessions run on plain `tokio::spawn` without needing `LocalSet`
+- Better tracing instrumentation via `instrument(span)` on all four session spawning paths
+
+The public API remains stable — this is an implementation detail that IDE clients do not need to change for.
+
+## ACP Sub-Agent Spawning
+
+Zeph now supports spawning child processes as ACP sub-agents via the `zeph acp run-agent` CLI command (feature-gated behind `acp`):
+
+```bash
+zeph acp run-agent --command "<CMD>" [--prompt "<TEXT>"] [--cwd "<DIR>"] [--timeout "<SECS>"]
+```
+
+Sub-agents:
+- Run in environment-isolated child processes (no `ZEPH_*` secrets leak)
+- Communicate over stdio using the ACP protocol
+- Support graceful cancellation via `session/cancel`
+- Are visible to parent agents for orchestrated multi-agent workflows
+
+## ACP Configuration Enhancements
+
+### Additional Directories Allowlist
+
+Restrict which filesystem paths an ACP session is allowed to access:
+
+```toml
+[acp]
+additional_directories = ["/workspace", "/tmp"]
+```
+
+Requests to access paths outside this list are rejected at session start. Feature-gated by `unstable-session-add-dirs`.
+
+### Auth Methods Configuration
+
+Strict validation of authentication methods at startup:
+
+```toml
+[acp]
+auth_methods = ["agent"]  # Only "agent" is accepted (default and only MVP option)
+```
+
+Unknown methods are rejected with a clear error. Feature-gated by `unstable-auth-methods`.
+
+### Message IDs Echo
+
+When enabled, the client's `message_id` from the prompt is echoed back on all streamed chunks and the `PromptResponse`, enabling full message correlation:
+
+```toml
+[acp]
+message_ids_enabled = true
+```
+
+Feature-gated by `unstable-message-id`.
+
+### CLI Overrides
+
+All three ACP configuration options can be overridden at runtime:
+
+```bash
+zeph --acp-additional-dir /workspace --acp-additional-dir /tmp \
+     --acp-auth-method agent \
+     --acp-message-ids
+```
+
+CLI values take precedence over config file values.
+
+### TUI Commands
+
+New read-only commands in TUI command palette:
+
+| Command | Description |
+|---------|-------------|
+| `/acp dirs` | List configured additional directories |
+| `/acp auth-methods` | Show configured auth methods |
+| `/acp status` | Show ACP server status |
+
 ## Protocol Version
 
-Zeph targets `agent-client-protocol` version 0.10.3 with schema version 0.11.3.
+Zeph targets `agent-client-protocol` version 0.11.1 with schema version 0.11.3 and supports all ACP 0.11 builder API features.

--- a/book/src/advanced/observability.md
+++ b/book/src/advanced/observability.md
@@ -73,6 +73,20 @@ The same table is available in the TUI via the `/cost` command. Providers are so
 
 Completion token counts use the `output_tokens` field from the API response (OpenAI, Ollama, and Compatible providers). Streaming paths retain a byte-length heuristic (`response.len() / 4`) as a fallback when the provider returns no usage data. Structured-output calls (`chat_typed`) also record usage so `eval_budget_tokens` enforcement reflects real token counts.
 
+### Cost Per Successful Task (CPS)
+
+CPS measures the average cost of reaching a successful agent turn (one where the LLM responded without errors). This metric is more meaningful than raw token cost because it factors in failed turns, retries, and provider switching.
+
+The `/cost` command displays CPS alongside token costs:
+
+```
+Cost per successful task: $0.0089 (123 successful turns, $1.09 total)
+```
+
+CPS resets daily at UTC midnight alongside the cost budget. Use it to track whether your agent is becoming more or less efficient over time.
+
+**In code:** access via `MetricsSnapshot.cost_cps_cents` and `MetricsSnapshot.cost_successful_tasks`.
+
 ## TaskSupervisor Metrics
 
 Zeph uses a `TaskSupervisor` to manage background tasks (embedding, memory consolidation, file watching, etc.). Task metrics provide CPU and wall-time measurement for performance debugging.

--- a/book/src/advanced/tools.md
+++ b/book/src/advanced/tools.md
@@ -109,6 +109,42 @@ In addition to `web_scrape` (CSS-selector-based extraction), `WebScrapeExecutor`
 |-----------|----------|-------------|
 | `url` | Yes | HTTPS URL to fetch |
 
+## ShellExecutor — Background Shell Execution
+
+The `bash` tool accepts an optional `background` parameter. When `true`, the command is spawned immediately and a stub message `[background] started run_id=<uuid>` is returned to close the LLM's `tool_use_id`. The actual completion arrives as a synthetic user message at the start of the next turn (drain-on-next-turn pattern).
+
+```json
+{
+  "command": "cargo build --release",
+  "background": true
+}
+```
+
+Returns immediately:
+
+```
+[background] started run_id=abc-123
+```
+
+On the next turn, the completion is injected as a synthetic user-role message:
+
+```
+[background complete] run_id=abc-123 exit_code=0
+<command output...>
+```
+
+This pattern decouples long-running operations from the prompt round-trip latency. The LLM can respond to the user or execute other tasks while the background process runs.
+
+**Configuration:**
+
+```toml
+[tools.shell]
+max_background_runs = 8           # maximum concurrent background tasks (default: 8)
+background_timeout_secs = 1800    # timeout for background commands in seconds (default: 1800 = 30 minutes)
+```
+
+When a background task exceeds `background_timeout_secs`, it is killed and a completion stub with `exit_code=124` is sent on the next turn.
+
 ## DiagnosticsExecutor
 
 `DiagnosticsExecutor` runs `cargo check` or `cargo clippy --message-format=json` in the project directory and returns a structured list of diagnostics. Each diagnostic includes:

--- a/book/src/concepts/hooks.md
+++ b/book/src/concepts/hooks.md
@@ -182,3 +182,75 @@ Each hook definition (`HookDef`) carries:
 | `fail_closed` | `bool` | `false` | When `true`, a hook failure blocks the agent turn; when `false`, failures are logged as warnings |
 
 Multiple hooks for the same event are executed in declaration order. If `fail_closed = true` on any hook, a failure in that hook stops execution of subsequent hooks for that event.
+
+### `TurnComplete`
+
+Fires after each agent turn completes. This hook does not block the turn — it runs fire-and-forget in the background and allows notification integrations, logging, or external system updates to happen after the agent responds.
+
+Hook commands receive environment variables describing the turn outcome:
+
+| Variable | Description |
+|----------|-------------|
+| `ZEPH_TURN_DURATION_MS` | Turn latency in milliseconds |
+| `ZEPH_TURN_STATUS` | `success`, `error`, or `cancelled` |
+| `ZEPH_TURN_PREVIEW` | First 150 chars of redacted agent response |
+| `ZEPH_TURN_LLM_REQUESTS` | Number of LLM API calls made this turn |
+
+**Use cases:**
+- Send a custom notification via a webhook
+- Log turn metrics to an external service
+- Sync agent state to an external system after each turn
+
+```toml
+[[hooks.turn_complete]]
+type         = "command"
+command      = "curl"
+args         = ["-X", "POST", "http://localhost:9999/webhook", "-d", "status=$ZEPH_TURN_STATUS"]
+timeout_secs = 5
+fail_closed  = false
+```
+
+When a `[notifications]` block is configured, `turn_complete` hooks share the same `should_fire` gate — the hook only runs if notifications are also configured to fire. When `[notifications]` is absent or `enabled = false`, `turn_complete` hooks fire on every turn.
+
+### `PermissionDenied`
+
+Fires when a tool execution is blocked by a `RuntimeLayer::before_tool` permission check. This allows you to log or audit blocked tool calls before they reach the user or external systems.
+
+Hook commands receive:
+
+| Variable | Description |
+|----------|-------------|
+| `ZEPH_DENIED_TOOL` | Name of the blocked tool |
+| `ZEPH_DENY_REASON` | Reason the tool was denied (e.g., `"blocked by before_tool layer"`) |
+
+**Use cases:**
+- Log security audit events to a central system
+- Alert on suspicious tool invocation patterns
+- Track which policies are enforcing restrictions
+
+```toml
+[[hooks.permission_denied]]
+type         = "command"
+command      = "logger"
+args         = ["-t", "zeph-security", "Denied tool: $ZEPH_DENIED_TOOL - $ZEPH_DENY_REASON"]
+timeout_secs = 5
+fail_closed  = false
+```
+
+## MCP Tool Hooks
+
+Hooks support direct MCP tool invocation via `type = "mcp_tool"`. When `type = "mcp_tool"`, the hook invokes a tool on a connected MCP server instead of spawning a subprocess.
+
+```toml
+[[hooks.cwd_changed]]
+type     = "mcp_tool"
+server   = "filesystem"        # MCP server id
+tool     = "write_file"        # MCP tool name
+args     = {"path": "/tmp/log", "contents": "Changed to $ZEPH_NEW_CWD"}
+fail_closed = false            # ignored if server unavailable
+```
+
+MCP tool hooks require the MCP manager to be active. If the server is unavailable, the hook result depends on `fail_closed`:
+
+- `fail_closed = false` (default): error is logged and the turn continues
+- `fail_closed = true`: turn is blocked until the tool succeeds or timeout expires

--- a/book/src/concepts/memory.md
+++ b/book/src/concepts/memory.md
@@ -423,7 +423,47 @@ max_hops = 2
 recall_limit = 10
 ```
 
+### Hebbian Reinforcement
+
+Hebbian updates strengthen edge weights in the graph when facts are recalled. After retrieving a fact from the graph, the edges traversed during retrieval are incremented by a configurable learning rate, making frequently-used relationships stronger over time.
+
+```toml
+[memory.hebbian]
+enabled = false                    # disabled by default; opt-in
+hebbian_lr = 0.1                   # learning rate for weight increment
+```
+
+When enabled, the system records every graph retrieval and applies weight updates fire-and-forget in the background.
+
+### HeLa-Mem Spreading Activation Retrieval
+
+HeLa-Mem (Hebbian-Latent Memory) extends graph retrieval with spreading activation: starting from the top-1 ANN anchor node, the system performs breadth-first search through the graph, propagating edge weights (`path_weight = Π edge.weight`). Each visited node is scored as `path_weight × cosine(query, entity)`, with negative cosine clamped to 0.0. Multi-path convergence keeps the maximum `path_weight`.
+
+```toml
+[memory.hebbian]
+spreading_activation = true        # enable spreading activation (default: false)
+spread_depth = 3                   # BFS depth limit (default: 2)
+spread_edge_types = ["related_to", "contradicts"]  # filter edges by type (empty = all)
+step_budget_ms = 8                 # per-step timeout in milliseconds (default: 8)
+```
+
+An 8 ms circuit breaker emits a WARN log and returns empty results on budget exhaustion. Isolated anchors (no outgoing edges) fall back to a synthetic `HelaFact` scored by the real anchor cosine.
+
 See [Graph Memory](graph-memory.md) for the full concept guide.
+
+## ReasoningBank — Distilled Reasoning Strategy Memory
+
+After each assistant turn, a three-stage pipeline (self-judge → distillation → store) extracts reasoning strategies and stores them as a new kind of memory. A ≤3-sentence strategy summary captures how the agent solved a problem and can be retrieved in future turns.
+
+```toml
+[memory.reasoning]
+enabled = false                   # disabled by default; opt-in
+store_limit = 100                 # max entries in reasoning_strategies table (default: 100)
+self_judge_window = 2             # messages to evaluate (default: 2 = final user+assistant exchange)
+min_assistant_chars = 50          # skip trivial responses shorter than this (default: 50)
+```
+
+Strategies are stored in SQLite and retrieved at context-build time by embedding similarity. The system maintains an LRU eviction with hot-row protection: frequently-used strategies are kept even under eviction pressure.
 
 ## Session Summary on Shutdown
 
@@ -624,6 +664,18 @@ min_turns_between_updates = 5    # turns between updates for the same file
 update_provider           = ""   # provider name; falls back to primary
 max_iterations            = 4    # max iterations per update call
 ```
+
+## Query Bias Correction
+
+First-person queries ("What did I do last week?") are shifted toward the user's profile centroid embedding before vector search. This improves recall of past user-specific decisions and preferences.
+
+```toml
+[memory.retrieval]
+query_bias_correction = true       # enable bias correction (default: false)
+query_bias_profile_weight = 0.25   # blend weight: 0.25 = 25% centroid, 75% query (default: 0.25)
+```
+
+The profile centroid is cached with a 300-second TTL in a bounded `RwLock`. Computation failures are non-sticky: the system falls through to the previous cache or disables bias for that turn.
 
 ## Store Routing
 

--- a/book/src/concepts/providers.md
+++ b/book/src/concepts/providers.md
@@ -138,6 +138,38 @@ type = "claude"   # ollama, claude, openai, gemini, candle, compatible
 model = "claude-sonnet-4-6"
 ```
 
+At runtime, use the `/provider <name>` command to switch providers:
+
+```
+> /provider claude
+Switched to Claude (claude-sonnet-4-6)
+```
+
+The chosen provider is now the active provider for this channel. On the next session start, Zeph automatically restores the last-used provider for that channel.
+
+### Provider Persistence
+
+Zeph remembers the last provider you used per channel (CLI, TUI, Telegram). When you restart or switch channels, your preferred provider is restored automatically:
+
+- **CLI/TUI**: last provider is saved globally (both share the same `channel_id = ""`)
+- **Telegram**: last provider is saved per chat (when configured with per-chat wiring)
+
+Enable persistence with:
+
+```toml
+[session]
+provider_persistence = true     # default: enabled
+```
+
+Disable it to always start with the default provider:
+
+```toml
+[session]
+provider_persistence = false
+```
+
+Provider preferences are stored in SQLite alongside session metadata. If you switch providers and the session crashes before a successful turn, the previous provider preference is restored on the next session start.
+
 ## Response Caching
 
 Enable SQLite-backed response caching to avoid redundant LLM calls for identical requests. The cache key is a blake3 hash of the full message history and model name. Streaming responses bypass the cache.

--- a/book/src/guides/custom-skills.md
+++ b/book/src/guides/custom-skills.md
@@ -313,6 +313,25 @@ Instead of writing SKILL.md manually, use `/skill create` with a natural languag
 
 Zeph generates a complete SKILL.md with frontmatter, instructions, and examples. The skill is saved to your skills directory and hot-reloaded immediately. Duplicate detection prevents creating skills that overlap with existing ones.
 
+Generated skills are scored on correctness, reusability, and specificity before being written to disk. A separate critic LLM evaluates the skill and filters out low-quality generations.
+
+### Skill Evaluation Configuration
+
+Control how generated skills are evaluated:
+
+```toml
+[skills.evaluation]
+enabled = true                    # enable external critic (default: true)
+correctness_weight = 0.50         # importance of correctness (0.0-1.0)
+reusability_weight = 0.25         # importance of broad applicability
+specificity_weight = 0.25         # importance of precise instruction
+pass_threshold = 0.60             # minimum score to accept (0.0-1.0)
+```
+
+When a generated skill scores below `pass_threshold`, it is rejected and the generation process is retried. If `enabled = false`, all generated skills are accepted without evaluation (fail-open).
+
+Evaluation is disabled by default for generated skills from `--init` to keep initial setup fast; enable it in your config if you want quality gates on all subsequent `/skill create` commands.
+
 See [NL Skill Generation](../advanced/nl-skill-generation.md) for details on generation from descriptions and GitHub repository mining.
 
 ## Next Steps

--- a/crates/zeph-acp/README.md
+++ b/crates/zeph-acp/README.md
@@ -15,10 +15,10 @@ Implements the [Agent Client Protocol](https://agentclientprotocol.org) server s
 
 ```toml
 [dependencies]
-zeph-acp = "0.19.2"
+zeph-acp = "0.20"
 
 # With HTTP+SSE transport
-zeph-acp = { version = "0.19.2", features = ["acp-http"] }
+zeph-acp = { version = "0.20", features = ["acp-http"] }
 ```
 
 **Important:**

--- a/crates/zeph-bench/README.md
+++ b/crates/zeph-bench/README.md
@@ -1,0 +1,37 @@
+# zeph-bench
+
+[![Crates.io](https://img.shields.io/crates/v/zeph-bench)](https://crates.io/crates/zeph-bench)
+[![docs.rs](https://img.shields.io/docsrs/zeph-bench)](https://docs.rs/zeph-bench)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](../../LICENSE)
+[![MSRV](https://img.shields.io/badge/MSRV-1.95-blue)](https://www.rust-lang.org)
+
+Benchmark harness for evaluating Zeph agent performance on standardized datasets.
+
+## Overview
+
+Provides a CLI-driven benchmark runner that feeds standardized task datasets through the Zeph agent loop and records latency, token usage, and correctness metrics. Integrates with `zeph-core` and `zeph-llm` to exercise the full inference path under controlled conditions.
+
+## Installation
+
+```toml
+[dependencies]
+zeph-bench = "0.20"
+```
+
+Or via `cargo add`:
+
+```bash
+cargo add zeph-bench
+```
+
+**Note:** Requires Rust 1.95 or later.
+
+## Documentation
+
+Full documentation: <https://bug-ops.github.io/zeph/>
+
+Part of the [Zeph](https://github.com/bug-ops/zeph) workspace.
+
+## License
+
+MIT

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__splash__tests__splash_default.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__splash__tests__splash_default.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/zeph-tui/src/widgets/splash.rs
-assertion_line: 79
 expression: output
 ---
 ┌──────────────────────────────────────────────────────────┐
@@ -15,7 +14,7 @@ expression: output
 │              ███████╗███████╗██║     ██║  ██║            │
 │              ╚══════╝╚══════╝╚═╝     ╚═╝  ╚═╝            │
 │                                                          │
-│                          v0.19.3                         │
+│                          v0.20.0                         │
 │                                                          │
 │                  Type a message to start.                │
 │                                                          │

--- a/specs/002-agent-loop/spec.md
+++ b/specs/002-agent-loop/spec.md
@@ -94,6 +94,8 @@ Agent<C: Channel> {
 - **Provider can be swapped at runtime** via `provider_override` without restarting the agent
 - **Hot-reload events** (skills, instructions, config) are processed between turns, never mid-turn
 - **Message queue takes priority** over channel recv — injected messages run before user input
+- **Context prep timeout** (`[timeouts] context_prep_timeout_secs`, default 30 s): `advance_context_lifecycle` wrapped with wall-clock timeout; turn proceeds with degraded cached context on expiry instead of stalling (#3357, #3373)
+- **NoProviders backoff** (`[timeouts] no_providers_backoff_secs`, default 2 s): after `NoProviders` error the agent records failure timestamp and sleeps; context preparation is skipped on the next turn if still within the backoff window, preventing busy-wait (#3357, #3373)
 
 ## Context Pressure Management
 
@@ -177,6 +179,54 @@ Active subgoal messages (tier 1.0) have their MIG reduction capped so they are n
 - `subgoal` and `SideQuest` strategies must never be active simultaneously — hard error at startup
 - NEVER evict Active-tier messages by scoring — their relevance is 1.0 (protected)
 - NEVER run subgoal extraction synchronously in the tool loop — only between turns
+
+## Focus Strategy Auto-Consolidation
+
+`run_focus_auto_consolidation` (#3313, #3388): when the Focus compression strategy is active,
+a periodic auto-consolidation pass merges similar focus segments to reduce fragmentation.
+
+- Controlled by `[memory.focus] auto_consolidate_min_window` (default 4 turns); `0` is rejected at
+  startup validation — `Config::validate()` rejects zero with a clear error (#3387, #3392)
+- `FocusState::should_auto_consolidate()` returns `false` until the configured number of turns has elapsed
+- The O(K²) pairwise MIG scoring loop is offloaded to `tokio::task::spawn_blocking` to prevent
+  stalling the async executor on long sessions (#3386, #3398)
+
+### Key Invariants
+
+- `auto_consolidate_min_window = 0` MUST be rejected at config validation — it would trigger LLM on every compress call
+- Auto-consolidation runs on `spawn_blocking` — never on the async executor thread pool
+- Consolidation is guarded by turn count; no-op until the window has elapsed
+
+## Provider Preference Persistence
+
+Provider preference per channel is persisted to SQLite (#3308, #3385):
+
+- Last-used provider (set via `/provider <name>`) saved after each successful switch
+- Restored automatically on next session start
+- Identity keyed by `(channel_type, channel_id)`; CLI/TUI use `channel_id = ""`
+- Controlled by `[session] provider_persistence = true` (default enabled)
+- Migrations: SQLite `079_channel_preferences.sql`, Postgres `075_channel_preferences.sql`
+
+### Key Invariants
+
+- Provider preference restore is best-effort — if the stored provider name no longer exists, fall back silently to the default
+- NEVER block session startup on preference load failure
+
+## Compaction Progress UX
+
+`MetricsSnapshot` gains four fields for compaction observability (#3314, #3385):
+
+| Field | Type | Meaning |
+|---|---|---|
+| `context_max_tokens` | `u64` | Effective context window for the active provider |
+| `compaction_last_before` | `u64` | Token count before the last hard compaction |
+| `compaction_last_after` | `u64` | Token count after the last hard compaction |
+| `compaction_last_at_ms` | `u64` | Wall-clock timestamp of the last compaction (0 = never) |
+
+- `Agent::publish_context_budget()` resolves effective context window from `context_manager.budget.max_tokens()` and publishes to `MetricsSnapshot` after provider pool construction and on every `/provider` switch
+- `INFO` log (`tokens_before`, `tokens_after`, `saved`) and transient `send_status("Compacting: {b}→{a} tokens")` emitted after each successful hard compaction
+- TUI: `context_gauge` widget (color-coded: green < 70%, yellow 70–90%, red > 90%); hidden when `context_max_tokens == 0`
+- TUI: `compaction_badge` widget shows `"{before}k→{after}k (-{saved}k) {elapsed}"`; hidden until first compaction this session
 
 ## Hard Compaction Post-Processing: Orphaned `tool_result` Strip
 

--- a/specs/004-memory/004-10-memory-memmachine-retrieval.md
+++ b/specs/004-memory/004-10-memory-memmachine-retrieval.md
@@ -9,7 +9,7 @@ tags:
   - retrieval
   - research
 created: 2026-04-24
-status: draft
+status: implemented
 related:
   - "[[MOC-specs]]"
   - "[[constitution]]"
@@ -93,14 +93,22 @@ Zeph's memory subsystem currently applies most optimization effort at **ingestio
 
 ```toml
 [memory.retrieval]
-depth = 20                          # ANN candidates before MMR
-search_prompt_template = ""         # empty = built-in default
+depth = 0                           # ANN candidate count; 0 = legacy recall_limit * 2
+search_prompt_template = ""         # query-side embedding template with {query} placeholder
 query_bias_correction = true        # first-person vs topic detection
+query_bias_profile_weight = 0.25    # blend weight for profile centroid shift
 context_format = "structured"       # "structured" | "plain"
 
 [memory.episodes]
 preserve_raw = true                 # store verbatim episodes alongside summaries
 ```
+
+> [!note] Implementation details for MM-F3 (query bias correction)
+> First-person queries are shifted toward the user's profile centroid embedding before vector
+> search. Centroid cached in a TTL-bounded `RwLock<Option<CachedCentroid>>` (default TTL 300 s).
+> Computation failure is non-sticky: falls through to previous cache or no-op.
+> Tracing spans: `memory.query_bias.apply` and `memory.query_bias.centroid` with structured
+> debug events for bias applied/skipped, centroid computed, and centroid cache hits (#3379).
 
 ### 3.2 Query Bias Correction
 
@@ -136,11 +144,11 @@ User mentioned preference for concise code responses and dislikes verbose explan
 
 ## 5. Acceptance Criteria
 
-- [ ] `depth` config field respected; ANN fetch count matches configured value
-- [ ] Query bias correction active by default; measurable embedding shift for first-person queries vs topic queries
-- [ ] Raw episodes stored when `preserve_raw = true`; existing summarization pipeline unaffected
-- [ ] Structured context format renders correctly in CLI and TUI memory recall output
-- [ ] `cargo nextest run -p zeph-memory` passes with no regressions
+- [x] `depth` config field (`0` = legacy fallback to `recall_limit * 2`) implemented; `search_prompt_template` with `{query}` placeholder; `context_format` `structured`/`plain` switching (MM-F1/F2/F5 — implemented #3340, #3353)
+- [x] Query bias correction: profile centroid fetched and blended with `query_bias_profile_weight`; TTL cache prevents redundant centroid computation (MM-F3 — implemented #3341, #3371, tracing #3379)
+- [x] Episode preservation unconditional (data-integrity invariant): eviction sweep excludes episode-bound message IDs (MM-F4 — implemented #3341)
+- [x] Structured context format renders in CLI and TUI
+- [x] `cargo nextest run -p zeph-memory` passes with no regressions
 
 ---
 

--- a/specs/004-memory/004-11-memory-hela-mem.md
+++ b/specs/004-memory/004-11-memory-hela-mem.md
@@ -10,7 +10,7 @@ tags:
   - graph
   - research
 created: 2026-04-24
-status: draft
+status: implemented
 related:
   - "[[MOC-specs]]"
   - "[[constitution]]"
@@ -101,7 +101,13 @@ consolidation_threshold = 5.0    # degree × avg_weight
 consolidate_provider = "fast"    # provider name for strategy distillation
 spreading_activation = false     # opt-in spreading activation retrieval
 spread_depth = 2                 # BFS hops from anchor node
+spread_edge_types = []           # edge type filter; empty = all types
+step_budget_ms = 8               # per-step circuit breaker for BFS
 ```
+
+> [!note] Migration
+> Config migration step 31b splices `spreading_activation`, `spread_depth`, `spread_edge_types`,
+> and `step_budget_ms` into existing `[memory.hebbian]` sections via `--migrate-config`.
 
 ### 3.2 Edge Weight Field
 
@@ -138,13 +144,28 @@ Periodic background task:
 3. LLM output: structured strategy summary → stored as `PersistentRule` or enqueued as skill draft
 4. Mark consolidated nodes with a `consolidated_at` timestamp to avoid re-consolidation within cooldown period
 
-### 3.5 Spreading Activation
+### 3.5 Spreading Activation (HL-F5)
 
 When `spreading_activation = true`:
 
-1. Fetch top-1 node via cosine ANN as anchor
-2. BFS from anchor up to `spread_depth` hops, scoring nodes by `weight × cosine_sim`
-3. Return ranked node set as retrieval result
+1. Fetch top-1 node via cosine ANN as anchor (`hela_spreading_recall`)
+2. BFS from anchor up to `spread_depth` hops traversing edges in `spread_edge_types` filter
+3. Score each visited node: `path_weight × cosine(query, entity)` where `path_weight = Π edge.weight` along the traversal path; negative cosine clamped to 0.0
+4. Multi-path convergence: keep maximum `path_weight` when a node is reached by multiple paths
+5. Return ranked node set as retrieval result; apply Hebbian increment to top-k kept edges after retrieval
+
+**Isolated anchor fallback**: when the anchor node has no outgoing edges, returns a single synthetic `HelaFact` with `edge_id=0` scored by the real anchor cosine similarity.
+
+**Circuit breaker**: per-step budget (`step_budget_ms`, default 8 ms); emits `WARN` and returns empty when budget is exhausted.
+
+**Dim-mismatch guard**: `OnceLock<String>` prevents repeated Qdrant probes after a dimension mismatch is detected, avoiding continuous retry loops.
+
+**Helper API additions**:
+- `VectorStore::get_points` — default trait method returning `Err(Unsupported)`; Qdrant impl via `GetPointsBuilder::new(...).with_vectors(true)`
+- `GraphStore::qdrant_point_ids_for_entities` — SQL helper with 490-entity batch chunks
+- `Edge::synthetic_anchor(entity_id)` — marker constructor for isolated-anchor fallback
+- `EmbeddingStore::get_vectors_from_collection` — batched vector retrieval helper
+- `HelaSpreadRuntime` struct on `SemanticMemory` attached via `with_hebbian_spread()`
 
 Falls back to pure ANN when graph has no edges from anchor node.
 
@@ -161,12 +182,14 @@ Falls back to pure ANN when graph has no edges from anchor node.
 
 ## 5. Acceptance Criteria
 
-- [ ] `graph_edges` table has `weight` column after migration; existing rows default to 1.0
-- [ ] Co-activated node pairs show incremented weights after retrieval when `hebbian.enabled = true`
-- [ ] Consolidation pass runs on background task, does not block turns
-- [ ] Spreading activation retrieval returns plausible results on a small synthetic graph (integration test)
-- [ ] All config fields respected; `enabled = false` disables all side effects
-- [ ] `cargo nextest run -p zeph-memory` passes
+- [x] `graph_edges` table has `weight` column after migration 077; existing rows default to 1.0 (HL-F1 — implemented #3344)
+- [x] Co-activated node pairs show incremented weights after retrieval when `hebbian.enabled = true` (HL-F2 — implemented #3344)
+- [x] Consolidation pass runs on background task (HL-F3/F4 — implemented #3345, #3380)
+- [x] Spreading activation retrieval (`hela_spreading_recall`) implemented with BFS, multiplicative path weights, and circuit breaker (HL-F5 — implemented #3346)
+- [x] `spread_edge_types`, `step_budget_ms` config fields respected; WARN logged for unrecognised edge type strings
+- [x] `enabled = false` disables all Hebbian side effects
+- [x] Config migration step 31b adds new spreading activation fields to existing configs
+- [x] `cargo nextest run -p zeph-memory` passes
 
 ---
 

--- a/specs/004-memory/004-12-memory-reasoning-bank.md
+++ b/specs/004-memory/004-12-memory-reasoning-bank.md
@@ -10,7 +10,7 @@ tags:
   - reasoning
   - research
 created: 2026-04-24
-status: draft
+status: implemented
 related:
   - "[[MOC-specs]]"
   - "[[constitution]]"
@@ -182,14 +182,23 @@ Token budget enforced by existing `ContextBudget` mechanism.
 
 ## 5. Acceptance Criteria
 
-- [ ] `reasoning_strategies` SQLite table created on first run when `enabled = true`
-- [ ] After a completed turn, self-judge runs asynchronously (log entry visible)
-- [ ] Strategy retrieved by embedding similarity for a related task description
-- [ ] Strategy injected into context preamble with `[Reasoning Strategy]` prefix
-- [ ] `store_limit` respected; oldest unused strategies evicted when limit reached
-- [ ] `enabled = false` produces zero side effects
-- [ ] TUI shows `Distilling reasoning strategy…` spinner during background distillation
-- [ ] `cargo nextest run -p zeph-memory` passes
+- [x] `reasoning_strategies` SQLite table created (migration 077); Qdrant collection `reasoning_strategies` provisioned on startup when `enabled = true` (implemented #3342, #3343)
+- [x] After a completed turn, self-judge runs asynchronously fire-and-forget via three-stage pipeline (implemented #3342)
+- [x] Strategy retrieved by embedding similarity; top-k injected into context preamble with `[Reasoning Strategy]` prefix (implemented #3343)
+- [x] `store_limit` respected; LRU eviction with hot-row protection (`HOT_STRATEGY_USE_COUNT = 10`) (implemented #3343)
+- [x] `enabled = false` produces zero side effects
+- [x] Dedicated embed provider (`effective_embed_provider()`) passed to extraction pipeline, fixing 768 vs 1536 dimension mismatch (fixed #3382)
+- [x] Self-judge evaluates only last `self_judge_window` messages (default 2) with `min_assistant_chars` guard (default 50) to prevent false Failure from multi-session context (fixed #3383)
+- [x] Embed provider passed to `attach_reasoning_memory` for Qdrant dimension probe (fixed #3375, #3376)
+- [x] `cargo nextest run -p zeph-memory` passes
+
+## 6. Known Refinements (Post-Implementation)
+
+| Issue | Fix | PR |
+|---|---|---|
+| Qdrant probe used primary router (excluded embed providers) → collection never created | Pass `build_memory_embed_provider()` into `attach_reasoning_memory`, fallback to primary when unset | #3375, #3376 |
+| Extraction pipeline used primary routing provider → 768 vs 1536 dim mismatch on upsert | Use `SemanticMemory::effective_embed_provider()` in `process_reasoning_turn` | #3382 |
+| Self-judge evaluated full conversation tail → false Failure from multi-session context noise | Evaluate only last `self_judge_window` messages; skip responses shorter than `min_assistant_chars` | #3383 |
 
 ---
 

--- a/specs/004-memory/spec.md
+++ b/specs/004-memory/spec.md
@@ -92,6 +92,32 @@ SemanticMemory (Arc)
 
 ---
 
+## Experience Compression Spectrum
+
+`[memory.compression_spectrum]` (disabled by default, #3305, #3350): introduces
+`CompressionLevel` (Episodic / Procedural / Declarative) and a `RetrievalPolicy` that
+skips episodic recall when the token budget is below configurable thresholds. A background
+`PromotionEngine` scans recent episodic memory and promotes repeated patterns to SKILL.md
+entries (off hot path, via `JoinSet`).
+
+`ExperienceStore` records tool outcomes fire-and-forget via `TaskClass::Telemetry`;
+evolution sweep runs every N user turns; both gate on `memory.graph.experience.enabled`
+with zero overhead when disabled (#3318, #3349).
+
+### Key Invariants
+
+- `PromotionEngine` runs off the hot path — NEVER on the agent turn thread
+- `ExperienceStore` wiring must be guarded by `memory.graph.experience.enabled`
+- `MemoryError::Promotion` is a distinct error variant in `zeph-memory` (thiserror, no anyhow)
+
+## Sub-Specifications
+
+| Sub-spec | Feature |
+|---|---|
+| [[004-10-memory-memmachine-retrieval]] | MemMachine retrieval depth, query bias correction, episode preservation |
+| [[004-11-memory-hela-mem]] | HeLa-Mem Hebbian edge weights, consolidation, spreading activation |
+| [[004-12-memory-reasoning-bank]] | ReasoningBank distilled strategy memory, self-judge pipeline |
+
 ## Integration Points
 
 - [[002-agent-loop/spec]] — context assembly calls recall pipeline

--- a/specs/005-skills/spec.md
+++ b/specs/005-skills/spec.md
@@ -457,6 +457,67 @@ The tool returns a confirmation message with the skill's name and first 200 char
 
 ---
 
+## Skill Evaluator
+
+External-feedback skill evaluator (#3319, #3350). After skill generation, a critic LLM call
+scores the skill on three dimensions before writing to disk.
+
+Config section `[skills.evaluation]` (disabled by default):
+
+```toml
+[skills.evaluation]
+enabled = false
+evaluate_provider = "fast"   # named provider reference
+weight_correctness = 0.50
+weight_reusability = 0.25
+weight_specificity = 0.25
+pass_threshold = 0.60        # minimum weighted score to accept skill
+```
+
+Behavior: `SkillEvaluationConfig` passed to `SkillEvaluator`; if evaluator errors, skill is
+accepted (fail-open). Tracing spans under `skills.eval.*`.
+
+### Key Invariants
+
+- Evaluation is optional and fail-open — a missing or erroring evaluator must never block skill creation
+- `evaluate_provider` resolves via named `[[llm.providers]]` reference
+- NEVER write skill to disk if score < `pass_threshold` (when evaluation is enabled and succeeds)
+
+## Proactive World-Knowledge Exploration
+
+Proactive skill generation before each LLM call (#3320, #3350). The agent classifies the
+query domain (keyword-based) and generates a `world-knowledge-{domain}` SKILL.md when none exists.
+
+Config section `[skills.proactive_exploration]` (disabled by default):
+
+```toml
+[skills.proactive_exploration]
+enabled = false
+generate_provider = "fast"   # named provider reference
+```
+
+**MVP trade-off**: generated skill is visible from the **next** turn (not the current one), to
+keep turn latency bounded. Tracing spans under `core.proactive.*`.
+
+### Key Invariants
+
+- Generated skill is intentionally deferred to the next turn — NEVER inject into the current turn's context
+- Domain classification is keyword-based (no LLM call) — NEVER use LLM for domain classification
+
+## Bare-Mode Skip
+
+`build_skill_matcher` is skipped in `--bare` mode to prevent the `zeph_skills` Qdrant collection
+from being destroyed on CI startup (#3390, #3395).
+
+The embed provider model name used for Qdrant collection versioning must be stable — a changing
+model name causes collection oscillation and near-zero cosine scores (#3391). The stable embed
+provider model name is resolved once at bootstrap from `[[llm.providers]]` with `embed = true`.
+
+### Key Invariants
+
+- NEVER call `build_skill_matcher` in `--bare` mode
+- Qdrant collection name for skills must be derived from a stable embed model name, not the resolved display name of the active provider
+
 ## SKILL.md Injection Sanitization
 
 

--- a/specs/025-classifiers/spec.md
+++ b/specs/025-classifiers/spec.md
@@ -99,6 +99,18 @@ zeph classifiers download             # pre-cache all models
 zeph classifiers download --model pii|injection|all
 ```
 
+## Internal Tool Bypass
+
+The ML injection classifier (DeBERTa) is bypassed for outputs from internal Zeph tools that produce only Zeph-generated text (#3384, #3394, #3396). The pattern-based sanitizer continues to run on these outputs for telemetry purposes.
+
+**Bypassed tool names** (exact match on unnamespaced tool name):
+`invoke_skill`, `load_skill`, `memory_save`, `memory_search`, `compress_context`,
+`complete_focus`, `start_focus`, `schedule_periodic`, `schedule_deferred`, `cancel_task`
+
+**Adversarial-MCP guard**: colon-namespaced tool names (e.g. `server:invoke_skill`) are NEVER matched against the bypass allowlist — only bare names qualify. This prevents a malicious MCP server from registering a tool named `server:invoke_skill` to escape ML classification.
+
+Unit test `skip_ml_fires_for_internal_tool_names` in `zeph-core` proves this invariant (#3396).
+
 ## Key Invariants
 
 - Every NER chunk (including middle and last) must be framed with `[CLS]` at position 0 and `[SEP]` at end
@@ -110,3 +122,4 @@ zeph classifiers download --model pii|injection|all
 - NEVER load models on startup — lazy-load on first use
 - NEVER apply PII redaction when `pii_enabled = false`, even if NER model is loaded
 - NEVER emit a `WARN` security scan false-positive for `.bundled` skill content
+- NEVER match colon-namespaced tool names (e.g. `server:invoke_skill`) against the internal tool bypass allowlist — bare names only

--- a/specs/028-hooks/spec.md
+++ b/specs/028-hooks/spec.md
@@ -36,17 +36,25 @@ related:
 
 ## Overview
 
-Reactive hooks allow operators to run shell commands (or scripts) in response to
-agent lifecycle events. Two event types are supported:
+Reactive hooks allow operators to run shell commands or invoke MCP tools in response to
+agent lifecycle events. Five event types are supported:
 
 | Event | Trigger |
 |---|---|
 | `cwd_changed` | Agent working directory changes (via `set_working_directory` tool) |
 | `file_changed` | A watched file or directory subtree is modified on disk |
+| `permission_denied` | A tool execution is short-circuited by a `RuntimeLayer::before_tool` check |
+| `turn_complete` | An agent turn completes (after all tool calls and LLM response) |
+| `post_tool_use` | After any tool invocation completes (carries `ZEPH_TOOL_DURATION_MS`) |
 
 Hooks are defined as arrays under `[hooks]` in `config.toml`. Each entry specifies
-the shell command and optional glob filters. Multiple hooks per event are supported
-and run sequentially.
+a hook action and optional filters. Multiple hooks per event are supported and run
+sequentially.
+
+> [!note] Action types
+> Two action types are available: `type = "command"` (default) runs a shell command;
+> `type = "mcp_tool"` invokes an MCP server tool directly without spawning a subprocess.
+> See the **Action Types** section below.
 
 ---
 
@@ -54,25 +62,52 @@ and run sequentially.
 
 ```toml
 [[hooks.cwd_changed]]
+type = "command"
 command = "echo 'cwd changed to $ZEPH_NEW_CWD'"
-# No additional filter fields for cwd_changed
 
 [[hooks.file_changed]]
+type = "command"
 command = "cargo check"
 glob = "src/**/*.rs"    # optional; only fire when changed path matches this glob
+
+[[hooks.permission_denied]]
+type = "command"
+command = "echo 'tool $ZEPH_DENIED_TOOL blocked: $ZEPH_DENY_REASON'"
+
+[[hooks.turn_complete]]
+type = "command"
+command = "osascript -e 'display notification \"$ZEPH_TURN_PREVIEW\" with title \"Zeph\"'"
+
+[[hooks.post_tool_use]]
+type = "command"
+command = "echo 'tool took ${ZEPH_TOOL_DURATION_MS}ms'"
 ```
 
-Multiple entries of the same type are permitted:
+Multiple entries of the same type are permitted.
+
+## Action Types
+
+### `type = "command"` (default)
+
+Runs a shell command via the same shell executor infrastructure as the `bash` tool.
+
+### `type = "mcp_tool"`
+
+Invokes an MCP server tool directly without spawning a subprocess (#3293). Requires
+the MCP manager to be active; fails according to `fail_closed` if unavailable.
 
 ```toml
-[[hooks.file_changed]]
-command = "cargo fmt --check"
-glob = "**/*.rs"
-
-[[hooks.file_changed]]
-command = "python check_config.py"
-glob = "config.toml"
+[[hooks.cwd_changed]]
+type = "mcp_tool"
+server = "my-server"
+tool = "notify"
+args = { message = "cwd changed" }    # optional static args
 ```
+
+> [!warning]
+> `HookDef.hook_type + command` fields replaced by `HookDef.action: HookAction`
+> (serde-flattened) as a breaking config change (#3293). Existing TOML with
+> `type = "command"` deserializes correctly — no manual migration needed.
 
 ---
 
@@ -85,9 +120,18 @@ Hooks receive context via environment variables injected into the shell command:
 | `ZEPH_OLD_CWD` | `cwd_changed` | Previous working directory (absolute path) |
 | `ZEPH_NEW_CWD` | `cwd_changed` | New working directory (absolute path) |
 | `ZEPH_CHANGED_PATH` | `file_changed` | Absolute path of the changed file or directory |
+| `ZEPH_DENIED_TOOL` | `permission_denied` | Name of the tool that was blocked |
+| `ZEPH_DENY_REASON` | `permission_denied` | Human-readable reason from `LayerDenial.reason` |
+| `ZEPH_TURN_DURATION_MS` | `turn_complete` | Wall-clock duration of the turn in milliseconds |
+| `ZEPH_TURN_STATUS` | `turn_complete` | `"success"` or `"error"` |
+| `ZEPH_TURN_PREVIEW` | `turn_complete` | Redacted short preview of the LLM response |
+| `ZEPH_TURN_LLM_REQUESTS` | `turn_complete` | Number of LLM requests in the turn |
+| `ZEPH_TOOL_DURATION_MS` | `post_tool_use` | Wall-clock duration of the tool call in milliseconds |
 
-These variables are always set for the relevant event type. For `file_changed`,
-`ZEPH_CHANGED_PATH` is the canonicalized absolute path of the change event.
+> [!note] `turn_complete` gate
+> When a `[notifications]` notifier is configured, `turn_complete` shares its `should_fire`
+> gate (respects `only_on_error`, `min_turn_duration_ms`, etc.). When no notifier is present,
+> `turn_complete` fires on every turn unconditionally.
 
 ---
 
@@ -150,7 +194,11 @@ working directory.
 - Hooks do NOT receive agent conversation context — they are environment-aware but not LLM-aware
 - `set_working_directory` must fire `cwd_changed` hooks synchronously before returning `ToolOutput` — the new cwd must be committed first
 - `FileChangeWatcher` debounce is mandatory — raw filesystem events must never bypass it
+- File change watcher is skipped in `--bare` mode — `with_hooks_config` is guarded by `!exec_mode.bare` in `runner.rs` (#3362)
 - Hook execution is never on the agent hot path — always background task
+- `permission_denied` hook fires when `RuntimeLayer::before_tool` short-circuits execution; `LayerDenial.reason` is propagated to `ZEPH_DENY_REASON` (#3310)
+- `turn_complete` is added to `HooksConfig` and `HooksConfig::is_empty()` check (#3327)
+- `type = "mcp_tool"` action requires MCP manager active; must fail gracefully per `fail_closed` setting when unavailable (#3293)
 - NEVER inject hook stdout into the agent's conversation context
 - NEVER run hooks with elevated privileges — they inherit the agent process permissions only
 - If `[hooks]` section is absent from config, all hook lists are empty and no hooks fire — zero-cost when unused

--- a/specs/README.md
+++ b/specs/README.md
@@ -37,6 +37,7 @@ Spec IDs (001–044) follow a logical grouping:
 - **045**: Agent interoperability protocol gap analysis
 - **046**: MARCH Proposer+Checker quality pipeline
 - **047**: CLI execution modes (--bare, --json, -y, /loop, /recap)
+- **048**: SLM cost metrics survey and CPS metric contract
 
 ---
 
@@ -115,3 +116,4 @@ Spec IDs (001–044) follow a logical grouping:
 | `047-cli-modes/spec.md` | CLI execution modes: `--bare` (skip scheduler/indexer/eviction), `--json` (JSONL event stream), `-y` (auto-approve), `/loop` command (supervised loop with inline errors), `/recap` command (#3170, #3218) | `zeph-channels`, binary |
 | `008-mcp/008-4-elicitation.md` | MCP server-driven elicitation (protocol 2025-06-18): `elicitation/create` routing to active channel, sensitive field warnings, Sandboxed trust hard-reject, Telegram timeout, URL field decline (#3218) | `zeph-mcp`, `zeph-channels` |
 | `UX/mention-routing.md` | @agent mention routing: Goose pattern analysis, feasibility for Zeph TUI/A2A, verdict to defer pending `AgentRegistry` infrastructure (#3327) | `zeph-core`, `zeph-tui`, `zeph-a2a` |
+| `048-slm-cost-metrics/spec.md` | SLM survey findings (arXiv:2510.03847), CPS (cost per successful task) metric contract, `record_successful_task()` / `cps()` API, daily reset semantics | `zeph-core` |


### PR DESCRIPTION
## Summary

- Bump version from 0.19.3 to 0.20.0
- Update CHANGELOG.md with release section dated 2026-04-25
- Update tests badge count: 8506 → 8849

## Checklist

- [x] Version updated in all manifests (workspace inheritance)
- [x] CHANGELOG.md has release section with date
- [x] README tests badge updated
- [x] All CI checks pass (8485 unit / 8849 with full features)
- [ ] Ready for tagging after merge