### PR TITLE
fix(bench): enable zeph-llm testing feature for zeph-bench dev-dependencies

### DIFF
--- a/crates/zeph-bench/Cargo.toml
+++ b/crates/zeph-bench/Cargo.toml
@@ -23,6 +23,7 @@ zeph-llm.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+zeph-llm = { workspace = true, features = ["testing"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

- `AnyProvider::Mock` in `zeph-llm` is gated behind `cfg(any(test, feature = "testing"))`. The `cfg(test)` flag is not transitive across crates, so `cargo test -p zeph-bench` failed with 6 compilation errors in `deterministic.rs`.
- Fix: add `zeph-llm = { workspace = true, features = ["testing"] }` to `[dev-dependencies]` in `crates/zeph-bench/Cargo.toml`.
- All 91 `zeph-bench` unit tests now pass.

## Benchmark run results (2026-04-25)

All criterion benchmarks verified working — results saved to `.local/testing/bench-results-2026-04-25.md`.

| Crate | Bench | Status |
|---|---|---|
| zeph-skills | cosine_similarity, cosine_ranking | OK |
| zeph-memory | token_estimation | OK |
| zeph-core | context_building | OK |
| zeph-channels | markdown_performance | OK |
| zeph-llm | classifier (--features classifiers) | OK |

## Test plan

- [ ] `cargo test -p zeph-bench --lib` passes (91 tests)
- [ ] `cargo bench -p zeph-skills` runs without errors
- [ ] `cargo bench -p zeph-memory` runs without errors