### PR TITLE
feat(bench): wire longmemeval and tau-bench into dispatch_run

### DIFF
--- a/crates/zeph-bench/README.md
+++ b/crates/zeph-bench/README.md
@@ -20,6 +20,8 @@ evaluation: no tools, no memory, no MCP — raw model capability only.
 |---------|--------|-----------|------------|-------------|
 | LOCOMO | Token F1 ≥ 0.5 | 11 | **1.0000** | 11/11 |
 | GAIA | GAIA normalized exact | 8 | **1.0000** | 8/8 |
+| LongMemEval | Exact match + Token F1 | 6 | **1.0000** | 6/6 |
+| tau-bench | Task completion (exact) | 5 | **1.0000** | 5/5 |
 
 > [!NOTE]
 > Baseline mode injects a concise-answer system prompt and post-processes responses
@@ -117,8 +119,8 @@ impl Evaluator for MyEvaluator {
 | [LOCOMO](https://github.com/snap-research/locomo) | JSON | Token F1 ≥ 0.5 | Ready |
 | [GAIA](https://huggingface.co/datasets/gaia-benchmark/GAIA) | JSONL | Normalized exact match | Ready |
 | [FRAMES](https://huggingface.co/datasets/google/frames-benchmark) | JSONL | Normalized exact match | Ready |
-| LongMemEval | JSON | Token F1 | Loader ready, CLI not wired |
-| tau-bench | JSON | Pass@1 | Loader ready, CLI not wired |
+| LongMemEval | JSONL | Exact match + Token F1 | Ready |
+| tau-bench | JSON | Task completion (exact) | Ready |
 
 > [!IMPORTANT]
 > Requires Rust 1.95 or later.

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -9,6 +9,7 @@ use zeph_bench::{
     apply_deterministic_overrides,
     loaders::{
         FramesEvaluator, FramesLoader, GaiaEvaluator, GaiaLoader, LocomoEvaluator, LocomoLoader,
+        LongMemEvalEvaluator, LongMemEvalLoader, TauBenchEvaluator, TauBenchLoader,
     },
 };
 use zeph_core::config::{Config, SecretResolver as _};
@@ -191,9 +192,15 @@ async fn dispatch_run(
         "frames" => Ok(runner
             .run_dataset(&FramesLoader, &FramesEvaluator, data_path, opts)
             .await?),
+        "longmemeval" => Ok(runner
+            .run_dataset(&LongMemEvalLoader, &LongMemEvalEvaluator, data_path, opts)
+            .await?),
+        "tau-bench" => Ok(runner
+            .run_dataset(&TauBenchLoader, &TauBenchEvaluator, data_path, opts)
+            .await?),
         other => {
             eprintln!(
-                "error: no built-in runner for dataset '{other}'. Supported: locomo, gaia, frames."
+                "error: no built-in runner for dataset '{other}'. Supported: locomo, gaia, frames, longmemeval, tau-bench."
             );
             std::process::exit(1);
         }


### PR DESCRIPTION
## Summary

- Wires `LongMemEvalLoader`/`LongMemEvalEvaluator` and `TauBenchLoader`/`TauBenchEvaluator` into `dispatch_run` in `src/commands/bench.rs`
- Both datasets now available via `zeph bench run --dataset longmemeval` and `--dataset tau-bench`
- Error message updated to list all 5 supported datasets
- Updates `crates/zeph-bench/README.md` to reflect both datasets as Ready

## Benchmark results (gpt-5.4-mini, 2026-04-25)

| Dataset | Scorer | Scenarios | Mean score | Exact match |
|---------|--------|-----------|------------|-------------|
| LongMemEval | Exact match + Token F1 | 6 | **1.0000** | 6/6 |
| tau-bench | Task completion (exact) | 5 | **1.0000** | 5/5 |

## Test plan

- [x] `cargo check --features bench` — clean
- [x] End-to-end `bench run --dataset longmemeval` with sample data
- [x] End-to-end `bench run --dataset tau-bench` with sample data