### PR TITLE
fix(llm,deps): restore per-crate test compilation and Ollama context-length detection

### DIFF
--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -94,8 +94,8 @@ serial_test.workspace = true
 sqlx.workspace = true
 tempfile.workspace = true
 tracing-subscriber = { workspace = true, features = ["parking_lot", "registry"] }
-zeph-llm.workspace = true
-zeph-memory.workspace = true
+zeph-llm = { workspace = true, features = ["testing"] }
+zeph-memory = { workspace = true, features = ["testing"] }
 zeph-vault = { workspace = true, features = ["mock"] }
 
 [lints]

--- a/crates/zeph-index/Cargo.toml
+++ b/crates/zeph-index/Cargo.toml
@@ -46,6 +46,7 @@ tree-sitter-typescript.workspace = true
 sqlx = { workspace = true, features = ["runtime-tokio-rustls", "sqlite"] }
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+zeph-llm = { workspace = true, features = ["testing"] }
 
 [lints]
 workspace = true

--- a/crates/zeph-llm/src/ollama.rs
+++ b/crates/zeph-llm/src/ollama.rs
@@ -272,11 +272,14 @@ impl LlmProvider for OllamaProvider {
             request = apply_generation_overrides(request, ov);
         }
 
-        let response = self
-            .client
-            .send_chat_messages(request)
-            .await
-            .map_err(|e| LlmError::Other(format!("Ollama chat request failed: {e}")))?;
+        let response = self.client.send_chat_messages(request).await.map_err(|e| {
+            let msg = e.to_string();
+            if crate::error::body_is_context_length_error(&msg) {
+                LlmError::ContextLengthExceeded
+            } else {
+                LlmError::Other(format!("Ollama chat request failed: {msg}"))
+            }
+        })?;
 
         if let Some(ref fd) = response.final_data {
             self.usage.record_usage(fd.prompt_eval_count, fd.eval_count);
@@ -319,7 +322,14 @@ impl LlmProvider for OllamaProvider {
             .client
             .send_chat_messages_stream(request)
             .await
-            .map_err(|e| LlmError::Other(format!("Ollama streaming request failed: {e}")))?;
+            .map_err(|e| {
+                let msg = e.to_string();
+                if crate::error::body_is_context_length_error(&msg) {
+                    LlmError::ContextLengthExceeded
+                } else {
+                    LlmError::Other(format!("Ollama streaming request failed: {msg}"))
+                }
+            })?;
 
         let mapped = stream.map(|item| match item {
             Ok(response) => Ok(crate::provider::StreamChunk::Content(
@@ -408,10 +418,14 @@ impl LlmProvider for OllamaProvider {
             request = apply_generation_overrides(request, ov);
         }
 
-        let response =
-            self.client.send_chat_messages(request).await.map_err(|e| {
-                LlmError::Other(format!("Ollama chat_with_tools request failed: {e}"))
-            })?;
+        let response = self.client.send_chat_messages(request).await.map_err(|e| {
+            let msg = e.to_string();
+            if crate::error::body_is_context_length_error(&msg) {
+                LlmError::ContextLengthExceeded
+            } else {
+                LlmError::Other(format!("Ollama chat_with_tools request failed: {msg}"))
+            }
+        })?;
 
         if let Some(ref fd) = response.final_data {
             self.usage.record_usage(fd.prompt_eval_count, fd.eval_count);
@@ -631,6 +645,23 @@ mod tests {
 
     fn ollama_embed_model() -> String {
         std::env::var("OLLAMA_EMBED_MODEL").unwrap_or_else(|_| "qwen3-embedding".into())
+    }
+
+    #[test]
+    fn context_length_error_keywords_are_detected() {
+        // Verify the helper used at each chat/stream/tools call site works for Ollama error strings.
+        assert!(crate::error::body_is_context_length_error(
+            "context length exceeded for this model"
+        ));
+        assert!(crate::error::body_is_context_length_error(
+            "maximum number of tokens is 4096"
+        ));
+        assert!(crate::error::body_is_context_length_error(
+            "prompt is too long"
+        ));
+        assert!(!crate::error::body_is_context_length_error(
+            "connection refused"
+        ));
     }
 
     #[test]

--- a/crates/zeph-mcp/Cargo.toml
+++ b/crates/zeph-mcp/Cargo.toml
@@ -47,6 +47,7 @@ zeph-tools.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+zeph-llm = { workspace = true, features = ["testing"] }
 
 [lints]
 workspace = true

--- a/crates/zeph-orchestration/Cargo.toml
+++ b/crates/zeph-orchestration/Cargo.toml
@@ -38,6 +38,7 @@ zeph-subagent.workspace = true
 futures.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+zeph-llm = { workspace = true, features = ["testing"] }
 
 [lints]
 workspace = true

--- a/crates/zeph-sanitizer/Cargo.toml
+++ b/crates/zeph-sanitizer/Cargo.toml
@@ -29,7 +29,8 @@ zeph-tools.workspace = true
 proptest.workspace = true
 tempfile.workspace = true
 toml.workspace = true
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
+zeph-llm = { workspace = true, features = ["testing"] }
 
 [features]
 default = []

--- a/crates/zeph-skills/Cargo.toml
+++ b/crates/zeph-skills/Cargo.toml
@@ -60,6 +60,7 @@ proptest.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 tracing-test.workspace = true
+zeph-llm = { workspace = true, features = ["testing"] }
 
 [lints]
 workspace = true

--- a/crates/zeph-subagent/Cargo.toml
+++ b/crates/zeph-subagent/Cargo.toml
@@ -38,7 +38,7 @@ schemars.workspace = true
 serial_test.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-zeph-llm.workspace = true
+zeph-llm = { workspace = true, features = ["testing"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

- Add `features = ["testing"]` to `[dev-dependencies]` in 7 crates (`zeph-skills`, `zeph-sanitizer`, `zeph-orchestration`, `zeph-subagent`, `zeph-core`, `zeph-index`, `zeph-mcp`) so per-crate test builds work without workspace-level feature unification
- Add `features = ["test-util"]` to tokio dev-dep in `zeph-sanitizer` for `tokio::time::pause/advance`
- Update `ollama.rs` to emit `LlmError::ContextLengthExceeded` at all 3 transport sites using `body_is_context_length_error()`, consistent with Claude/OpenAI/Gemini providers

## Test plan

- [ ] `cargo nextest run -p zeph-skills` — was broken, now passes (401 tests)
- [ ] `cargo nextest run -p zeph-sanitizer` — was broken, now passes (223 tests)
- [ ] `cargo nextest run -p zeph-orchestration` — was broken, now passes (343 tests)
- [ ] `cargo nextest run -p zeph-subagent` — was broken, now passes (318 tests)
- [ ] `cargo nextest run -p zeph-index` — was broken, now passes (107 tests)
- [ ] `cargo nextest run -p zeph-mcp` — was broken, now passes (428 tests)
- [ ] `cargo nextest run --workspace --lib --bins` — 8501 tests pass
- [ ] Ollama context-length errors now routed to compaction retry path

Closes #3406
Closes #3405