### PR TITLE
fix(skills): treat absent embedding_model payload field as model mismatch

### DIFF
--- a/crates/zeph-core/src/agent/session_config.rs
+++ b/crates/zeph-core/src/agent/session_config.rs
@@ -140,7 +140,7 @@ impl AgentSessionConfig {
                 .tools
                 .permission_policy(config.security.autonomy_level),
             model_name: config.llm.effective_model().to_owned(),
-            embed_model: crate::provider_factory::effective_embedding_model(config),
+            embed_model: crate::provider_factory::stable_skill_embedding_model(config),
             semantic_cache_enabled: config.llm.semantic_cache_enabled,
             semantic_cache_threshold: config.llm.semantic_cache_threshold,
             semantic_cache_max_candidates: config.llm.semantic_cache_max_candidates,
@@ -209,7 +209,7 @@ mod tests {
         assert_eq!(sc.model_name, config.llm.effective_model());
         assert_eq!(
             sc.embed_model,
-            crate::provider_factory::effective_embedding_model(&config)
+            crate::provider_factory::stable_skill_embedding_model(&config)
         );
         assert_eq!(sc.semantic_cache_enabled, config.llm.semantic_cache_enabled);
         assert!(

--- a/crates/zeph-memory/src/embedding_registry.rs
+++ b/crates/zeph-memory/src/embedding_registry.rs
@@ -95,15 +95,23 @@ fn normalize_model_name(name: &str) -> &str {
 
 /// Returns `true` when any stored point uses a model name that is semantically different
 /// from `config_model` after normalizing `:latest` suffixes.
+///
+/// A missing `embedding_model` field (legacy points from pre-#3395 sessions) is treated as a
+/// mismatch: the vector was produced by an unknown model and must be regenerated.
 fn model_has_changed(
     existing: &HashMap<String, HashMap<String, String>>,
     config_model: &str,
 ) -> bool {
-    existing.values().any(|stored| {
-        stored
-            .get("embedding_model")
-            .is_some_and(|m| normalize_model_name(m) != normalize_model_name(config_model))
-    })
+    if config_model.is_empty() {
+        return false;
+    }
+    existing
+        .values()
+        .any(|stored| match stored.get("embedding_model") {
+            Some(m) => normalize_model_name(m) != normalize_model_name(config_model),
+            // Absent field means the point was written before the model was recorded; treat as mismatch.
+            None => true,
+        })
 }
 
 /// Generic Qdrant-backed embedding registry.
@@ -639,6 +647,25 @@ mod tests {
     #[test]
     fn model_has_changed_empty_existing_is_false() {
         assert!(!model_has_changed(&HashMap::new(), "any-model"));
+    }
+
+    #[test]
+    fn model_has_changed_absent_field_with_config_model_is_true() {
+        // Legacy points have no embedding_model field; treat as mismatch to force recreation.
+        let mut point = HashMap::new();
+        point.insert("content_hash".to_owned(), "abc".to_owned());
+        let mut map = HashMap::new();
+        map.insert("k1".to_owned(), point);
+        assert!(model_has_changed(&map, "nomic-embed-text-v2-moe"));
+    }
+
+    #[test]
+    fn model_has_changed_absent_field_with_empty_config_model_is_false() {
+        let mut point = HashMap::new();
+        point.insert("content_hash".to_owned(), "abc".to_owned());
+        let mut map = HashMap::new();
+        map.insert("k1".to_owned(), point);
+        assert!(!model_has_changed(&map, ""));
     }
 
     // ── concurrency guard ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `model_has_changed` in `zeph-memory` used `is_some_and` which returns `false` for absent `embedding_model` payload fields. Legacy Qdrant points written before #3395 have no such field, so stale vectors from a previous embedding model were permanently retained, producing cosine scores of ~0.022 on every query.
- `AgentSessionConfig::embed_model` used `effective_embedding_model` instead of `stable_skill_embedding_model`, causing the runtime skill-sync to use a different collection version key than startup sync and re-introducing the oscillating rebuild loop.

## Changes

- `crates/zeph-memory/src/embedding_registry.rs`: `None` arm in `model_has_changed` now returns `true` when `config_model` is non-empty, forcing a clean rebuild when any point lacks the `embedding_model` field.
- `crates/zeph-core/src/agent/session_config.rs`: replaced `effective_embedding_model` with `stable_skill_embedding_model` for `embed_model`.

## Test plan

- [ ] All 8502 unit tests pass (`cargo nextest run --workspace --lib --bins`)
- [ ] Two new unit tests cover the absent-field fix: `model_has_changed_absent_field_with_config_model_is_true` and `model_has_changed_absent_field_with_empty_config_model_is_false`
- [ ] Live test: start agent in full mode, send a query, verify skill candidates score ≥ 0.20 and injection fires

Closes #3402