### PR TITLE
fix(config): change HebbianConfig::consolidate_provider default to empty string

### DIFF
--- a/crates/zeph-config/src/memory.rs
+++ b/crates/zeph-config/src/memory.rs
@@ -1258,7 +1258,7 @@ impl Default for HebbianConfig {
             hebbian_lr: 0.1,
             consolidation_interval_secs: 3600,
             consolidation_threshold: 5.0,
-            consolidate_provider: "fast".to_owned(),
+            consolidate_provider: String::new(),
             max_candidates_per_sweep: 10,
             consolidation_cooldown_secs: 86_400,
             consolidation_prompt_timeout_secs: 30,


### PR DESCRIPTION
## Summary

- Changed `HebbianConfig::consolidate_provider` default from `"fast".to_owned()` to `String::new()`
- Eliminates spurious `WARN` on every agent startup when no provider named `"fast"` is configured
- The bootstrap code already handles the empty-string case by returning `None` and silently falling back to the primary provider — no other changes needed

## Test plan

- [ ] `cargo nextest run -p zeph-config --lib` — 327 tests pass
- [ ] Agent startup with `[memory.hebbian] enabled = true` and no `"fast"` provider: no WARN logged

Closes #3403