### PR TITLE
feat(bench): Aggregate stats, Turn-based Scenario, baseline dual-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `zeph-bench`: aggregate `median_score`, `stddev` (population), and `error_count` statistics on
+  `BenchRun.aggregate`; all three fields are persisted in `results.json` and included in
+  `summary.md`.
+- `zeph-bench`: multi-turn `Scenario` via `Vec<Turn>` with `Role::{User,Assistant}`; all built-in
+  loaders construct via the new `Scenario::single` constructor; `primary_prompt()` returns
+  `Result<&str, BenchError>` so malformed scenarios surface immediately.
+- `zeph-bench`: `--baseline` dual-run for memory-relevant datasets (`longmemeval`, `locomo`);
+  runs memory-off and memory-on passes sequentially, writes
+  `baseline/memory-{off,on}/results.json` and `baseline/comparison.json` reusing the existing
+  `baseline::BaselineComparison`; non-memory datasets (`gaia`, `frames`, `tau-bench`) reject
+  `--baseline` with a clear error.
+- `zeph-bench`: `MemoryMode::{Off,On}` and `BenchMemoryParams` on `BenchRunner`; memory-on pass
+  wires a `SQLite`-only `SemanticMemory` per scenario (no Qdrant), with
+  `summarization_threshold = 100_000` to preserve run determinism (FR-003).
+
 ### Fixed
 
 - `zeph-core`, `zeph-llm`: tool schema filter now receives the embedding provider instead of the
@@ -14,6 +31,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `zeph-llm`: `OllamaProvider::embed()` tracing span now records the actual embedding model name
   (`self.embedding_model`) instead of the chat model name (`self.model_identifier()`), making
   `llm.embed` spans in Perfetto/Jaeger unambiguous (fixes #3414).
+
+### Changed
+
+- `zeph-bench`: `Scenario.prompt: String` replaced by `turns: Vec<Turn>`; loaders construct via
+  `Scenario::single`; `runner::RunOptions` gains `memory_mode: MemoryMode` field (default `Off`).
+- `zeph-bench`: `ResultWriter::new` uses `create_dir_all` for nested output directories.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10103,9 +10103,11 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "zeph-config",
  "zeph-core",
  "zeph-llm",
+ "zeph-memory",
  "zeph-skills",
  "zeph-tools",
 ]

--- a/crates/zeph-bench/Cargo.toml
+++ b/crates/zeph-bench/Cargo.toml
@@ -17,9 +17,11 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["time"] }
+tracing.workspace = true
 zeph-config.workspace = true
 zeph-core.workspace = true
 zeph-llm.workspace = true
+zeph-memory.workspace = true
 zeph-skills.workspace = true
 zeph-tools.workspace = true
 

--- a/crates/zeph-bench/README.md
+++ b/crates/zeph-bench/README.md
@@ -20,6 +20,7 @@ evaluation: no tools, no memory, no MCP — raw model capability only.
 |---------|--------|-----------|------------|-------------|
 | LOCOMO | Token F1 ≥ 0.5 | 11 | **1.0000** | 11/11 |
 | GAIA | GAIA normalized exact | 8 | **1.0000** | 8/8 |
+| FRAMES | Normalized exact match | 7 | **1.0000** | 7/7 |
 | LongMemEval | Exact match + Token F1 | 6 | **1.0000** | 6/6 |
 | tau-bench | Task completion (exact) | 5 | **1.0000** | 5/5 |
 

--- a/crates/zeph-bench/src/lib.rs
+++ b/crates/zeph-bench/src/lib.rs
@@ -81,8 +81,8 @@ pub use deterministic::apply_deterministic_overrides;
 pub use error::BenchError;
 pub use isolation::BenchIsolation;
 pub use results::{Aggregate, BenchRun, ResultWriter, RunStatus, ScenarioResult};
-pub use runner::{BenchRunner, RunOptions};
+pub use runner::{BenchMemoryParams, BenchRunner, MemoryMode, RunOptions};
 pub use scenario::{
-    DatasetLoader, EvalResult, Evaluator, Scenario, exact_match, gaia_normalized_exact_match,
-    token_f1,
+    DatasetLoader, EvalResult, Evaluator, Role, Scenario, Turn, exact_match,
+    gaia_normalized_exact_match, token_f1,
 };

--- a/crates/zeph-bench/src/loaders/frames.rs
+++ b/crates/zeph-bench/src/loaders/frames.rs
@@ -78,12 +78,12 @@ impl DatasetLoader for FramesLoader {
 
             let metadata = record.reasoning_types.unwrap_or(serde_json::Value::Null);
 
-            scenarios.push(Scenario {
-                id: format!("frames_{line_number}"),
-                prompt: record.prompt,
-                expected: record.answer,
+            scenarios.push(Scenario::single(
+                format!("frames_{line_number}"),
+                record.prompt,
+                record.answer,
                 metadata,
-            });
+            ));
         }
         Ok(scenarios)
     }
@@ -104,12 +104,7 @@ impl DatasetLoader for FramesLoader {
 /// use zeph_bench::{Scenario, loaders::FramesEvaluator};
 /// use zeph_bench::scenario::Evaluator;
 ///
-/// let scenario = Scenario {
-///     id: "frames_0".into(),
-///     prompt: "Capital of France?".into(),
-///     expected: "Paris".into(),
-///     metadata: serde_json::Value::Null,
-/// };
+/// let scenario = Scenario::single("frames_0", "Capital of France?", "Paris", serde_json::Value::Null);
 ///
 /// // Case-insensitive and punctuation-stripped.
 /// assert!(FramesEvaluator.evaluate(&scenario, "paris").passed);
@@ -162,7 +157,7 @@ mod tests {
     #[test]
     fn load_maps_prompt_and_expected() {
         let scenarios = load_from_str(FIXTURE);
-        assert_eq!(scenarios[0].prompt, "What is 2+2?");
+        assert_eq!(scenarios[0].primary_prompt().unwrap(), "What is 2+2?");
         assert_eq!(scenarios[0].expected, "4");
     }
 

--- a/crates/zeph-bench/src/loaders/gaia.rs
+++ b/crates/zeph-bench/src/loaders/gaia.rs
@@ -139,12 +139,12 @@ impl DatasetLoader for GaiaLoader {
                 "annotator_metadata": record.annotator_metadata,
             });
 
-            scenarios.push(Scenario {
-                id: record.task_id,
-                prompt: record.question,
-                expected: record.final_answer,
+            scenarios.push(Scenario::single(
+                record.task_id,
+                record.question,
+                record.final_answer,
                 metadata,
-            });
+            ));
         }
         Ok(scenarios)
     }
@@ -167,12 +167,7 @@ impl DatasetLoader for GaiaLoader {
 /// use zeph_bench::{Scenario, loaders::GaiaEvaluator};
 /// use zeph_bench::scenario::Evaluator;
 ///
-/// let scenario = Scenario {
-///     id: "t1".into(),
-///     prompt: "Capital of Japan?".into(),
-///     expected: "Tokyo".into(),
-///     metadata: serde_json::json!({"level": 1}),
-/// };
+/// let scenario = Scenario::single("t1", "Capital of Japan?", "Tokyo", serde_json::json!({"level": 1}));
 ///
 /// // Article "The" is stripped before comparison.
 /// assert!(GaiaEvaluator.evaluate(&scenario, "The Tokyo").passed);
@@ -237,7 +232,10 @@ mod tests {
     #[test]
     fn load_maps_prompt_and_expected() {
         let scenarios = load_from_str(FIXTURE, None);
-        assert_eq!(scenarios[0].prompt, "What year did WWII end?");
+        assert_eq!(
+            scenarios[0].primary_prompt().unwrap(),
+            "What year did WWII end?"
+        );
         assert_eq!(scenarios[0].expected, "1945");
     }
 

--- a/crates/zeph-bench/src/loaders/locomo.rs
+++ b/crates/zeph-bench/src/loaders/locomo.rs
@@ -74,12 +74,12 @@ impl DatasetLoader for LocomoLoader {
         let mut scenarios = Vec::new();
         for session in sessions {
             for (idx, qa) in session.qa.iter().enumerate() {
-                scenarios.push(Scenario {
-                    id: format!("{}_{}", session.session_id, idx),
-                    prompt: qa.question.clone(),
-                    expected: qa.answer.clone(),
-                    metadata: serde_json::Value::Null,
-                });
+                scenarios.push(Scenario::single(
+                    format!("{}_{}", session.session_id, idx),
+                    qa.question.clone(),
+                    qa.answer.clone(),
+                    serde_json::Value::Null,
+                ));
             }
         }
         Ok(scenarios)
@@ -98,12 +98,12 @@ impl DatasetLoader for LocomoLoader {
 /// use zeph_bench::{Scenario, loaders::LocomoEvaluator};
 /// use zeph_bench::scenario::Evaluator;
 ///
-/// let scenario = Scenario {
-///     id: "s1_0".into(),
-///     prompt: "What is the capital of France?".into(),
-///     expected: "Paris".into(),
-///     metadata: serde_json::Value::Null,
-/// };
+/// let scenario = Scenario::single(
+///     "s1_0",
+///     "What is the capital of France?",
+///     "Paris",
+///     serde_json::Value::Null,
+/// );
 ///
 /// let result = LocomoEvaluator.evaluate(&scenario, "Paris");
 /// assert!((result.score - 1.0).abs() < f64::EPSILON);
@@ -180,7 +180,7 @@ mod tests {
     #[test]
     fn load_maps_prompt_and_expected() {
         let scenarios = load_from_str(FIXTURE);
-        assert_eq!(scenarios[0].prompt, "What is Rust?");
+        assert_eq!(scenarios[0].primary_prompt().unwrap(), "What is Rust?");
         assert_eq!(scenarios[0].expected, "A systems programming language");
     }
 

--- a/crates/zeph-bench/src/loaders/longmemeval.rs
+++ b/crates/zeph-bench/src/loaders/longmemeval.rs
@@ -77,15 +77,15 @@ impl DatasetLoader for LongMemEvalLoader {
             let item: LongMemEvalItem = serde_json::from_str(trimmed)
                 .map_err(|e| BenchError::InvalidFormat(format!("line {}: {e}", idx + 1)))?;
 
-            scenarios.push(Scenario {
-                id: item.question_id,
-                prompt: item.question,
-                expected: item.answer,
-                metadata: serde_json::json!({
+            scenarios.push(Scenario::single(
+                item.question_id,
+                item.question,
+                item.answer,
+                serde_json::json!({
                     "session_id": item.session_id,
                     "sessions": item.sessions,
                 }),
-            });
+            ));
         }
         Ok(scenarios)
     }
@@ -103,12 +103,7 @@ impl DatasetLoader for LongMemEvalLoader {
 /// use zeph_bench::{Scenario, loaders::LongMemEvalEvaluator};
 /// use zeph_bench::scenario::Evaluator;
 ///
-/// let scenario = Scenario {
-///     id: "q1".into(),
-///     prompt: "What is Rust?".into(),
-///     expected: "A systems language".into(),
-///     metadata: serde_json::Value::Null,
-/// };
+/// let scenario = Scenario::single("q1", "What is Rust?", "A systems language", serde_json::Value::Null);
 ///
 /// let result = LongMemEvalEvaluator.evaluate(&scenario, "A systems language");
 /// assert!(result.passed);
@@ -162,7 +157,7 @@ mod tests {
     #[test]
     fn load_maps_prompt_and_expected() {
         let scenarios = load_from_str(FIXTURE);
-        assert_eq!(scenarios[0].prompt, "What is Rust?");
+        assert_eq!(scenarios[0].primary_prompt().unwrap(), "What is Rust?");
         assert_eq!(scenarios[0].expected, "A systems language");
     }
 

--- a/crates/zeph-bench/src/loaders/tau_bench.rs
+++ b/crates/zeph-bench/src/loaders/tau_bench.rs
@@ -65,14 +65,16 @@ impl DatasetLoader for TauBenchLoader {
 
         let scenarios = tasks
             .into_iter()
-            .map(|t| Scenario {
-                id: t.task_id,
-                prompt: t.instruction,
-                expected: t.ground_truth,
-                metadata: serde_json::json!({
-                    "domain": t.domain,
-                    "expected_actions": t.expected_actions,
-                }),
+            .map(|t| {
+                Scenario::single(
+                    t.task_id,
+                    t.instruction,
+                    t.ground_truth,
+                    serde_json::json!({
+                        "domain": t.domain,
+                        "expected_actions": t.expected_actions,
+                    }),
+                )
             })
             .collect();
         Ok(scenarios)
@@ -91,12 +93,7 @@ impl DatasetLoader for TauBenchLoader {
 /// use zeph_bench::{Scenario, loaders::TauBenchEvaluator};
 /// use zeph_bench::scenario::Evaluator;
 ///
-/// let scenario = Scenario {
-///     id: "retail_001".into(),
-///     prompt: "Find a product".into(),
-///     expected: "found item XYZ".into(),
-///     metadata: serde_json::Value::Null,
-/// };
+/// let scenario = Scenario::single("retail_001", "Find a product", "found item XYZ", serde_json::Value::Null);
 ///
 /// let result = TauBenchEvaluator.evaluate(&scenario, "found item XYZ");
 /// assert!(result.passed);
@@ -160,7 +157,7 @@ mod tests {
     #[test]
     fn load_maps_prompt_and_expected() {
         let scenarios = load_from_str(FIXTURE);
-        assert_eq!(scenarios[0].prompt, "Find product X");
+        assert_eq!(scenarios[0].primary_prompt().unwrap(), "Find product X");
         assert_eq!(scenarios[0].expected, "Product X found");
     }
 

--- a/crates/zeph-bench/src/results.rs
+++ b/crates/zeph-bench/src/results.rs
@@ -316,7 +316,7 @@ impl ResultWriter {
     pub fn new(output_dir: impl Into<PathBuf>) -> Result<Self, BenchError> {
         let output_dir = output_dir.into();
         if !output_dir.exists() {
-            std::fs::create_dir(&output_dir)?;
+            std::fs::create_dir_all(&output_dir)?;
         }
         Ok(Self { output_dir })
     }

--- a/crates/zeph-bench/src/results.rs
+++ b/crates/zeph-bench/src/results.rs
@@ -81,10 +81,15 @@ pub struct ScenarioResult {
 /// let agg = Aggregate {
 ///     total: 100,
 ///     mean_score: 0.72,
+///     median_score: 0.70,
+///     stddev: 0.15,
 ///     exact_match: 55,
+///     error_count: 3,
 ///     total_elapsed_ms: 240_000,
 /// };
 /// assert_eq!(agg.total, 100);
+/// assert_eq!(agg.error_count, 3);
+/// assert!((agg.median_score - 0.70).abs() < f64::EPSILON);
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Aggregate {
@@ -92,8 +97,23 @@ pub struct Aggregate {
     pub total: usize,
     /// Arithmetic mean of all per-scenario scores.
     pub mean_score: f64,
+    /// Median per-scenario score.
+    ///
+    /// For an even number of results, the median is the average of the two middle values.
+    /// Returns `0.0` when `total == 0`.
+    pub median_score: f64,
+    /// Population standard deviation of per-scenario scores (divide by N).
+    ///
+    /// The scenario set is treated as the full population of interest, not a sample.
+    /// Returns `0.0` when `total <= 1`.
+    pub stddev: f64,
     /// Count of scenarios where `score >= 1.0` (exact match).
     pub exact_match: usize,
+    /// Count of scenarios where `score == 0.0` and `error` is `Some(_)`.
+    ///
+    /// A non-zero value indicates the agent failed to produce a response (e.g. timeout,
+    /// LLM API error) rather than simply giving the wrong answer.
+    pub error_count: usize,
     /// Sum of [`ScenarioResult::elapsed_ms`] across all scenarios.
     pub total_elapsed_ms: u64,
 }
@@ -178,21 +198,54 @@ impl BenchRun {
     /// assert_eq!(run.aggregate.total, 1);
     /// assert!((run.aggregate.mean_score - 1.0).abs() < f64::EPSILON);
     /// assert_eq!(run.aggregate.exact_match, 1);
+    /// assert_eq!(run.aggregate.error_count, 0);
     /// ```
     pub fn recompute_aggregate(&mut self) {
         let total = self.results.len();
+
+        if total == 0 {
+            self.aggregate = Aggregate::default();
+            return;
+        }
+
         #[allow(clippy::cast_precision_loss)]
-        let mean_score = if total == 0 {
-            0.0
+        let mean_score = self.results.iter().map(|r| r.score).sum::<f64>() / total as f64;
+
+        // Median: sort scores, average the two middle values for even N.
+        let mut sorted_scores: Vec<f64> = self.results.iter().map(|r| r.score).collect();
+        sorted_scores.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        #[allow(clippy::cast_precision_loss)]
+        let median_score = if total % 2 == 1 {
+            sorted_scores[total / 2]
         } else {
-            self.results.iter().map(|r| r.score).sum::<f64>() / total as f64
+            f64::midpoint(sorted_scores[total / 2 - 1], sorted_scores[total / 2])
         };
+
+        // Population standard deviation (divide by N).
+        #[allow(clippy::cast_precision_loss)]
+        let variance = self
+            .results
+            .iter()
+            .map(|r| (r.score - mean_score).powi(2))
+            .sum::<f64>()
+            / total as f64;
+        let stddev = variance.sqrt();
+
         let exact_match = self.results.iter().filter(|r| r.score >= 1.0).count();
+        let error_count = self
+            .results
+            .iter()
+            .filter(|r| r.score == 0.0 && r.error.is_some())
+            .count();
         let total_elapsed_ms = self.results.iter().map(|r| r.elapsed_ms).sum();
+
         self.aggregate = Aggregate {
             total,
             mean_score,
+            median_score,
+            stddev,
             exact_match,
+            error_count,
             total_elapsed_ms,
         };
     }
@@ -350,8 +403,13 @@ impl ResultWriter {
         }
         let _ = writeln!(
             md,
-            "- **Mean score**: {:.4} ({}/{} exact)\n",
-            run.aggregate.mean_score, run.aggregate.exact_match, run.aggregate.total
+            "- **Mean score**: {:.4} (median: {:.4}, stddev: {:.4})\n",
+            run.aggregate.mean_score, run.aggregate.median_score, run.aggregate.stddev
+        );
+        let _ = writeln!(
+            md,
+            "- **Exact match**: {}/{} | **Errors**: {}\n",
+            run.aggregate.exact_match, run.aggregate.total, run.aggregate.error_count
         );
 
         md.push_str("| scenario_id | score | response_excerpt | error |\n");
@@ -417,8 +475,54 @@ mod tests {
         run.recompute_aggregate();
         assert_eq!(run.aggregate.total, 2);
         assert!((run.aggregate.mean_score - 0.5).abs() < f64::EPSILON);
+        // median for [0.0, 1.0] sorted = average of middle two = 0.5
+        assert!((run.aggregate.median_score - 0.5).abs() < f64::EPSILON);
+        // population stddev: mean=0.5, variance=((1.0-0.5)^2+(0.0-0.5)^2)/2 = 0.25, stddev=0.5
+        assert!((run.aggregate.stddev - 0.5).abs() < f64::EPSILON);
         assert_eq!(run.aggregate.exact_match, 1);
+        // s2 has score=0.0 and error=Some("timeout")
+        assert_eq!(run.aggregate.error_count, 1);
         assert_eq!(run.aggregate.total_elapsed_ms, 6000);
+    }
+
+    #[test]
+    fn recompute_aggregate_single_result() {
+        let mut run = make_run();
+        run.results.retain(|r| r.scenario_id == "s1");
+        run.recompute_aggregate();
+        assert_eq!(run.aggregate.total, 1);
+        assert!((run.aggregate.mean_score - 1.0).abs() < f64::EPSILON);
+        assert!((run.aggregate.median_score - 1.0).abs() < f64::EPSILON);
+        assert!(run.aggregate.stddev.abs() < f64::EPSILON);
+        assert_eq!(run.aggregate.error_count, 0);
+    }
+
+    #[test]
+    fn recompute_aggregate_empty_results() {
+        let mut run = make_run();
+        run.results.clear();
+        run.recompute_aggregate();
+        assert_eq!(run.aggregate.total, 0);
+        assert!(run.aggregate.mean_score.abs() < f64::EPSILON);
+        assert!(run.aggregate.median_score.abs() < f64::EPSILON);
+        assert!(run.aggregate.stddev.abs() < f64::EPSILON);
+        assert_eq!(run.aggregate.error_count, 0);
+    }
+
+    #[test]
+    fn recompute_aggregate_error_count_only_zero_score_with_error() {
+        let mut run = make_run();
+        // Add a scenario with score=0.0 but no error — should NOT count as error
+        run.results.push(ScenarioResult {
+            scenario_id: "s3".into(),
+            score: 0.0,
+            response_excerpt: "wrong answer".into(),
+            error: None,
+            elapsed_ms: 100,
+        });
+        run.recompute_aggregate();
+        // s2 has error, s3 does not — error_count should be 1
+        assert_eq!(run.aggregate.error_count, 1);
     }
 
     #[test]

--- a/crates/zeph-bench/src/runner.rs
+++ b/crates/zeph-bench/src/runner.rs
@@ -28,19 +28,72 @@
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Instant;
 
 use zeph_core::agent::Agent;
 use zeph_core::instructions::InstructionBlock;
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::LlmProvider as _;
+use zeph_memory::semantic::SemanticMemory;
 use zeph_skills::registry::SkillRegistry;
 use zeph_tools::executor::{ToolError, ToolExecutor, ToolOutput};
 
 use crate::channel::BenchmarkChannel;
 use crate::error::BenchError;
 use crate::results::{BenchRun, RunStatus, ScenarioResult};
-use crate::scenario::{DatasetLoader, Evaluator};
+use crate::scenario::{DatasetLoader, Evaluator, Scenario};
+
+/// Controls whether `SemanticMemory` is wired into the agent during a benchmark run.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_bench::runner::MemoryMode;
+///
+/// assert_eq!(MemoryMode::default(), MemoryMode::Off);
+/// ```
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryMode {
+    /// No `SemanticMemory` — current default behaviour.
+    #[default]
+    Off,
+    /// Wire a `SQLite`-backed `SemanticMemory` into the agent via `Agent::with_memory`.
+    On,
+}
+
+/// Parameters required to construct a per-scenario `SQLite`-backed `SemanticMemory`.
+///
+/// Populated by [`BenchRunner::with_memory_params`] and consumed inside
+/// [`BenchRunner::run_one`] when `opts.memory_mode == MemoryMode::On`.
+///
+/// # Examples
+///
+/// ```
+/// use std::path::PathBuf;
+/// use zeph_bench::runner::BenchMemoryParams;
+///
+/// let params = BenchMemoryParams {
+///     data_dir: PathBuf::from("/tmp/bench"),
+///     embedding_model: "nomic-embed-text".into(),
+///     run_id: "bench-abc".into(),
+///     dataset: "locomo".into(),
+/// };
+/// assert!(params.data_dir.to_string_lossy().contains("bench"));
+/// ```
+#[derive(Debug, Clone)]
+pub struct BenchMemoryParams {
+    /// Directory where per-scenario `SQLite` files live (deleted between scenarios).
+    ///
+    /// The derived path always contains the `bench-` segment (NFR-001).
+    pub data_dir: PathBuf,
+    /// Embedding model name passed to `SemanticMemory`.
+    pub embedding_model: String,
+    /// Run ID used to namespace bench artifacts; matches the outer `BenchRun.run_id`.
+    pub run_id: String,
+    /// Dataset name used to namespace bench artifacts.
+    pub dataset: String,
+}
 
 /// Options that control which scenarios are executed and whether to resume a prior run.
 ///
@@ -49,12 +102,13 @@ use crate::scenario::{DatasetLoader, Evaluator};
 /// # Examples
 ///
 /// ```
-/// use zeph_bench::runner::RunOptions;
+/// use zeph_bench::runner::{RunOptions, MemoryMode};
 ///
 /// // Run all scenarios.
 /// let opts = RunOptions::default();
 /// assert!(opts.scenario_filter.is_none());
 /// assert!(opts.completed_ids.is_empty());
+/// assert_eq!(opts.memory_mode, MemoryMode::Off);
 /// ```
 #[derive(Debug, Default)]
 pub struct RunOptions {
@@ -62,6 +116,8 @@ pub struct RunOptions {
     pub scenario_filter: Option<String>,
     /// Set of scenario IDs already completed in a prior run (used for `--resume`).
     pub completed_ids: HashSet<String>,
+    /// Whether to wire a `SemanticMemory` backend into the agent for this run.
+    pub memory_mode: MemoryMode,
 }
 
 /// Minimal no-op tool executor for baseline benchmark runs.
@@ -79,8 +135,8 @@ impl ToolExecutor for NoopExecutor {
 /// Drives [`Agent<BenchmarkChannel>`] over a dataset and collects scored results.
 ///
 /// Each call to [`run_dataset`][BenchRunner::run_dataset] creates a fresh agent per
-/// scenario (baseline mode: no tools, no memory, no MCP). Scenarios can be filtered
-/// and prior runs can be resumed via [`RunOptions`].
+/// scenario (baseline mode: no tools, no MCP). Memory is optionally wired via
+/// [`BenchRunner::with_memory_params`] and [`RunOptions::memory_mode`].
 ///
 /// # Examples
 ///
@@ -93,6 +149,11 @@ impl ToolExecutor for NoopExecutor {
 /// ```
 pub struct BenchRunner {
     provider: AnyProvider,
+    /// Parameters for constructing per-scenario `SQLite`-backed `SemanticMemory`.
+    ///
+    /// Set via [`BenchRunner::with_memory_params`]; required when
+    /// `RunOptions::memory_mode == MemoryMode::On`.
+    memory_params: Option<BenchMemoryParams>,
 }
 
 impl BenchRunner {
@@ -113,7 +174,37 @@ impl BenchRunner {
     /// ```
     #[must_use]
     pub fn new(provider: AnyProvider, _no_deterministic: bool) -> Self {
-        Self { provider }
+        Self {
+            provider,
+            memory_params: None,
+        }
+    }
+
+    /// Attach `SemanticMemory` parameters for memory-on benchmark runs.
+    ///
+    /// When set, a per-scenario `SQLite`-backed `SemanticMemory` is constructed inside
+    /// [`run_one`][BenchRunner::run_one] whenever `opts.memory_mode == MemoryMode::On`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::path::PathBuf;
+    /// use zeph_bench::runner::{BenchRunner, BenchMemoryParams};
+    /// use zeph_llm::{any::AnyProvider, mock::MockProvider};
+    ///
+    /// let provider = AnyProvider::Mock(MockProvider::with_responses(vec![]));
+    /// let params = BenchMemoryParams {
+    ///     data_dir: PathBuf::from("/tmp/bench-data"),
+    ///     embedding_model: "nomic-embed-text".into(),
+    ///     run_id: "bench-abc".into(),
+    ///     dataset: "locomo".into(),
+    /// };
+    /// let runner = BenchRunner::new(provider, false).with_memory_params(params);
+    /// ```
+    #[must_use]
+    pub fn with_memory_params(mut self, params: BenchMemoryParams) -> Self {
+        self.memory_params = Some(params);
+        self
     }
 
     /// Run all matching scenarios from `path` through the agent and return a [`BenchRun`].
@@ -168,7 +259,7 @@ impl BenchRunner {
             }
 
             let t0 = Instant::now();
-            let response_text = Box::pin(self.run_one(scenario.prompt.clone())).await?;
+            let response_text = Box::pin(self.run_one(scenario, opts.memory_mode)).await?;
             let elapsed_ms = u64::try_from(t0.elapsed().as_millis()).unwrap_or(u64::MAX);
 
             let eval = evaluator.evaluate(scenario, &response_text);
@@ -187,15 +278,31 @@ impl BenchRunner {
         Ok(run)
     }
 
-    /// Run a single prompt through a fresh agent and return the last response text.
+    /// Run a single scenario through a fresh agent and return the last response text.
     ///
     /// A concise-answer system prompt is injected via [`InstructionBlock`] so the model
     /// responds with only the final answer (a number, word, or short phrase) rather than
     /// full sentences. The raw response is then post-processed to extract the first
     /// non-empty line and strip markdown formatting, which further reduces noise for
     /// evaluators that perform exact or near-exact matching.
-    async fn run_one(&self, prompt: String) -> Result<String, BenchError> {
+    ///
+    /// When `memory_mode == MemoryMode::On`, a per-scenario `SQLite`-backed
+    /// `SemanticMemory` is constructed and wired into the agent. The database file is
+    /// deleted after the scenario completes (best-effort, NFR-001).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BenchError::InvalidFormat`] when the scenario has no user turn or when
+    /// `SemanticMemory` initialisation fails.
+    async fn run_one(
+        &self,
+        scenario: &Scenario,
+        memory_mode: MemoryMode,
+    ) -> Result<String, BenchError> {
+        let prompt = scenario.primary_prompt()?.to_owned();
         let channel = BenchmarkChannel::new(vec![prompt]);
+        // TODO(multi-turn-history): when loaders emit multiple user turns, push each in
+        // order and seed assistant turns into the channel as captured-history.
         let registry = SkillRegistry::empty();
 
         // Force the model to emit only the shortest possible answer. This is the primary
@@ -213,7 +320,10 @@ impl BenchRunner {
             .to_owned(),
         }];
 
-        let mut agent = Agent::new(
+        // TODO(C-2): wire a real ToolExecutor for baseline runs on tool-driven datasets
+        // (gaia, tau-bench, frames). For now --baseline is gated to longmemeval/locomo
+        // in the CLI dispatcher.
+        let base_agent = Agent::new(
             self.provider.clone(),
             channel,
             registry,
@@ -223,10 +333,73 @@ impl BenchRunner {
         )
         .with_instruction_blocks(blocks);
 
+        // Optionally wire SemanticMemory when the caller requests memory-on mode.
+        let (mut agent, scenario_db) = if memory_mode == MemoryMode::On
+            && let Some(ref params) = self.memory_params
+        {
+            // One SQLite file per scenario gives strict isolation (NFR-001 choice (a)).
+            // This is more files than a per-run DB, but eliminates any cross-scenario
+            // memory bleed and avoids needing BenchIsolation::reset() between scenarios.
+            let scenario_db = params
+                .data_dir
+                .join(format!("bench-{}-{}.db", params.run_id, scenario.id));
+            debug_assert!(
+                scenario_db.to_string_lossy().contains("bench-"),
+                "NFR-001: bench SQLite path must be namespaced with 'bench-'"
+            );
+
+            tracing::debug!(
+                scenario_id = %scenario.id,
+                path = %scenario_db.display(),
+                "bench: memory init start"
+            );
+            let memory = Arc::new(
+                tokio::time::timeout(
+                    std::time::Duration::from_secs(10),
+                    SemanticMemory::with_sqlite_backend(
+                        scenario_db.to_string_lossy().as_ref(),
+                        self.provider.clone(),
+                        &params.embedding_model,
+                        0.7,
+                        0.3,
+                    ),
+                )
+                .await
+                .map_err(|_| {
+                    BenchError::InvalidFormat(format!(
+                        "SemanticMemory init timed out for scenario '{}'",
+                        scenario.id
+                    ))
+                })?
+                .map_err(|e| BenchError::InvalidFormat(format!("SemanticMemory init: {e}")))?,
+            );
+            tracing::debug!(scenario_id = %scenario.id, "bench: memory init done");
+
+            // summarization_threshold = 100_000 deliberately suppresses LLM-driven
+            // compaction during bench runs. Compaction calls another LLM round-trip
+            // with non-deterministic timing/output, which would violate FR-003
+            // (deterministic runs). recall_limit = 20 is generous enough to surface
+            // long-context memory effects without silently capping LongMemEval scores
+            // below their theoretical maximum. history_limit = 200 covers the longest
+            // LongMemEval session without truncation.
+            let wired_agent =
+                base_agent.with_memory(memory, zeph_memory::ConversationId(1), 200, 20, 100_000);
+            (wired_agent, Some(scenario_db))
+        } else {
+            (base_agent, None)
+        };
+
         // Ignore agent errors — a failed LLM call still yields an empty response that
         // the evaluator scores as 0.0 rather than aborting the entire run.
         let _ = agent.run().await;
         let responses = agent.into_channel().into_responses();
+
+        // Best-effort cleanup: delete per-scenario SQLite file after the run.
+        // Failure is intentionally ignored — NFR-001 is hygiene, not correctness.
+        if let Some(ref db_path) = scenario_db {
+            let _ = std::fs::remove_file(db_path);
+        }
+
         let raw = responses
             .into_iter()
             .last()
@@ -324,6 +497,47 @@ mod tests {
         let opts = RunOptions::default();
         assert!(opts.scenario_filter.is_none());
         assert!(opts.completed_ids.is_empty());
+        assert_eq!(opts.memory_mode, MemoryMode::Off);
+    }
+
+    #[test]
+    fn memory_mode_default_is_off() {
+        assert_eq!(MemoryMode::default(), MemoryMode::Off);
+    }
+
+    #[test]
+    fn with_memory_params_sets_isolation() {
+        use zeph_llm::{any::AnyProvider, mock::MockProvider};
+        let provider = AnyProvider::Mock(MockProvider::with_responses(vec![]));
+        let params = BenchMemoryParams {
+            data_dir: std::path::PathBuf::from("/tmp/bench-data"),
+            embedding_model: "nomic-embed-text".into(),
+            run_id: "bench-abc".into(),
+            dataset: "locomo".into(),
+        };
+        let runner = BenchRunner::new(provider, false).with_memory_params(params.clone());
+        assert!(runner.memory_params.is_some());
+        let stored = runner.memory_params.unwrap();
+        assert_eq!(stored.run_id, "bench-abc");
+        assert_eq!(stored.dataset, "locomo");
+    }
+
+    #[test]
+    fn nfr_001_sqlite_path_namespaced() {
+        let params = BenchMemoryParams {
+            data_dir: std::path::PathBuf::from("/tmp/bench-data"),
+            embedding_model: "nomic-embed-text".into(),
+            run_id: "run-xyz".into(),
+            dataset: "locomo".into(),
+        };
+        let scenario_id = "s1_0";
+        let scenario_db = params
+            .data_dir
+            .join(format!("bench-{}-{}.db", params.run_id, scenario_id));
+        assert!(
+            scenario_db.to_string_lossy().contains("bench-"),
+            "NFR-001: SQLite path must contain bench- prefix"
+        );
     }
 
     #[test]

--- a/crates/zeph-bench/src/runner.rs
+++ b/crates/zeph-bench/src/runner.rs
@@ -375,6 +375,13 @@ impl BenchRunner {
             );
             tracing::debug!(scenario_id = %scenario.id, "bench: memory init done");
 
+            // Seed the sessions table so persist_message does not fail with FK violation.
+            let conv_id = memory
+                .sqlite()
+                .create_conversation()
+                .await
+                .map_err(|e| BenchError::InvalidFormat(format!("create_conversation: {e}")))?;
+
             // summarization_threshold = 100_000 deliberately suppresses LLM-driven
             // compaction during bench runs. Compaction calls another LLM round-trip
             // with non-deterministic timing/output, which would violate FR-003
@@ -382,8 +389,7 @@ impl BenchRunner {
             // long-context memory effects without silently capping LongMemEval scores
             // below their theoretical maximum. history_limit = 200 covers the longest
             // LongMemEval session without truncation.
-            let wired_agent =
-                base_agent.with_memory(memory, zeph_memory::ConversationId(1), 200, 20, 100_000);
+            let wired_agent = base_agent.with_memory(memory, conv_id, 200, 20, 100_000);
             (wired_agent, Some(scenario_db))
         } else {
             (base_agent, None)

--- a/crates/zeph-bench/src/scenario.rs
+++ b/crates/zeph-bench/src/scenario.rs
@@ -5,37 +5,139 @@ use std::path::Path;
 
 use crate::error::BenchError;
 
+/// Role of a turn in a multi-turn scenario conversation.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_bench::scenario::Role;
+///
+/// assert!(matches!(Role::User, Role::User));
+/// assert!(matches!(Role::Assistant, Role::Assistant));
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Role {
+    /// A message from the human user.
+    User,
+    /// A message from the AI assistant.
+    Assistant,
+}
+
+/// One turn in a multi-turn scenario conversation.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_bench::scenario::{Role, Turn};
+///
+/// let turn = Turn { role: Role::User, content: "What is the capital of France?".into() };
+/// assert!(matches!(turn.role, Role::User));
+/// ```
+#[derive(Debug, Clone)]
+pub struct Turn {
+    /// Who authored this turn.
+    pub role: Role,
+    /// Text content of the turn.
+    pub content: String,
+}
+
 /// A single benchmark scenario loaded from a dataset file.
 ///
 /// Each scenario represents one question/task that will be presented to the agent.
 /// The `id` field is used to correlate agent responses with ground-truth answers and
 /// to skip already-completed scenarios during a `--resume` run.
 ///
+/// Construct via [`Scenario::single`] for single-turn scenarios (all built-in loaders),
+/// or push [`Turn`]s directly into [`Scenario::turns`] for multi-turn scenarios.
+///
 /// # Examples
 ///
 /// ```
 /// use zeph_bench::Scenario;
 ///
-/// let scenario = Scenario {
-///     id: "gaia_t42".into(),
-///     prompt: "What is the boiling point of water in Celsius?".into(),
-///     expected: "100".into(),
-///     metadata: serde_json::json!({"level": 1}),
-/// };
+/// let scenario = Scenario::single(
+///     "gaia_t42",
+///     "What is the boiling point of water in Celsius?",
+///     "100",
+///     serde_json::json!({"level": 1}),
+/// );
 /// assert_eq!(scenario.id, "gaia_t42");
+/// assert_eq!(scenario.primary_prompt().unwrap(), "What is the boiling point of water in Celsius?");
 /// ```
 #[derive(Debug, Clone)]
 pub struct Scenario {
     /// Unique identifier within the dataset (e.g. `"frames_0"`, `"s1_2"`).
     pub id: String,
-    /// The question or task text fed verbatim to the agent.
-    pub prompt: String,
+    /// Ordered turns in this scenario. Non-empty by contract of [`Scenario::single`].
+    ///
+    /// Direct construction is allowed for multi-turn scenarios; callers must ensure
+    /// at least one [`Role::User`] turn is present before calling [`Scenario::primary_prompt`].
+    pub turns: Vec<Turn>,
     /// The gold-standard answer used for scoring.
     pub expected: String,
     /// Dataset-specific extras such as difficulty level or `reasoning_types`.
     ///
     /// Set to [`serde_json::Value::Null`] when the dataset has no extra metadata.
     pub metadata: serde_json::Value,
+}
+
+impl Scenario {
+    /// Convenience constructor for single-turn scenarios.
+    ///
+    /// Wraps `prompt` in a one-element [`Vec<Turn>`] with [`Role::User`]. All built-in
+    /// dataset loaders use this constructor.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_bench::Scenario;
+    ///
+    /// let s = Scenario::single("id1", "What year?", "2026", serde_json::Value::Null);
+    /// assert_eq!(s.primary_prompt().unwrap(), "What year?");
+    /// ```
+    #[must_use]
+    pub fn single(
+        id: impl Into<String>,
+        prompt: impl Into<String>,
+        expected: impl Into<String>,
+        metadata: serde_json::Value,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            turns: vec![Turn {
+                role: Role::User,
+                content: prompt.into(),
+            }],
+            expected: expected.into(),
+            metadata,
+        }
+    }
+
+    /// Returns the content of the first [`Role::User`] turn.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BenchError::InvalidFormat`] when `turns` is empty or contains no
+    /// [`Role::User`] entry. Loaders must construct via [`Scenario::single`] or push
+    /// at least one user turn.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_bench::Scenario;
+    ///
+    /// let s = Scenario::single("id1", "hello", "world", serde_json::Value::Null);
+    /// assert_eq!(s.primary_prompt().unwrap(), "hello");
+    /// ```
+    pub fn primary_prompt(&self) -> Result<&str, BenchError> {
+        self.turns
+            .iter()
+            .find(|t| matches!(t.role, Role::User))
+            .map(|t| t.content.as_str())
+            .ok_or_else(|| {
+                BenchError::InvalidFormat(format!("scenario '{}' has no user turn", self.id))
+            })
+    }
 }
 
 /// Result of evaluating one agent response against the expected answer.
@@ -324,5 +426,62 @@ mod tests {
     fn gaia_normalized_subscript_digits_match_ascii() {
         // Model may respond with Unicode subscript "H₂O" — must match ASCII "H2O".
         assert!(gaia_normalized_exact_match("H\u{2082}O", "H2O"));
+    }
+
+    #[test]
+    fn single_constructs_one_user_turn() {
+        let s = Scenario::single("id1", "hello", "world", serde_json::Value::Null);
+        assert_eq!(s.turns.len(), 1);
+        assert!(matches!(s.turns[0].role, Role::User));
+        assert_eq!(s.turns[0].content, "hello");
+        assert_eq!(s.expected, "world");
+    }
+
+    #[test]
+    fn primary_prompt_returns_first_user_turn_content() {
+        let s = Scenario::single("id1", "What year?", "2026", serde_json::Value::Null);
+        assert_eq!(s.primary_prompt().unwrap(), "What year?");
+    }
+
+    #[test]
+    fn primary_prompt_skips_leading_assistant_turns() {
+        let s = Scenario {
+            id: "id2".into(),
+            turns: vec![
+                Turn {
+                    role: Role::Assistant,
+                    content: "I am ready.".into(),
+                },
+                Turn {
+                    role: Role::User,
+                    content: "What is Rust?".into(),
+                },
+            ],
+            expected: "A systems language".into(),
+            metadata: serde_json::Value::Null,
+        };
+        assert_eq!(s.primary_prompt().unwrap(), "What is Rust?");
+    }
+
+    #[test]
+    fn primary_prompt_errors_when_no_user_turn() {
+        let s = Scenario {
+            id: "id3".into(),
+            turns: vec![Turn {
+                role: Role::Assistant,
+                content: "assistant only".into(),
+            }],
+            expected: String::new(),
+            metadata: serde_json::Value::Null,
+        };
+        assert!(s.primary_prompt().is_err());
+
+        let empty = Scenario {
+            id: "id4".into(),
+            turns: vec![],
+            expected: String::new(),
+            metadata: serde_json::Value::Null,
+        };
+        assert!(empty.primary_prompt().is_err());
     }
 }

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -5,8 +5,9 @@ use crate::bootstrap::{
     create_named_provider, create_provider, parse_vault_args, resolve_config_path,
 };
 use zeph_bench::{
-    BenchCommand, BenchRunner, DatasetRegistry, ResultWriter, RunOptions, RunStatus,
-    apply_deterministic_overrides,
+    BenchCommand, BenchMemoryParams, BenchRunner, DatasetRegistry, MemoryMode, ResultWriter,
+    RunOptions, RunStatus, apply_deterministic_overrides,
+    baseline::BaselineComparison,
     loaders::{
         FramesEvaluator, FramesLoader, GaiaEvaluator, GaiaLoader, LocomoEvaluator, LocomoLoader,
         LongMemEvalEvaluator, LongMemEvalLoader, TauBenchEvaluator, TauBenchLoader,
@@ -30,24 +31,186 @@ pub(crate) async fn handle_bench_command(
             data_file,
             scenario,
             provider: provider_name,
-            baseline: _,
+            baseline,
             resume,
             no_deterministic,
         } => {
-            handle_run(
-                dataset,
-                output,
-                data_file.as_deref(),
-                scenario.as_deref(),
-                provider_name.as_deref(),
-                *resume,
-                *no_deterministic,
-                config_path,
-            )
-            .await
+            if *baseline {
+                handle_run_baseline(
+                    dataset,
+                    output,
+                    data_file.as_deref(),
+                    scenario.as_deref(),
+                    provider_name.as_deref(),
+                    *resume,
+                    *no_deterministic,
+                    config_path,
+                )
+                .await
+            } else {
+                handle_run(
+                    dataset,
+                    output,
+                    data_file.as_deref(),
+                    scenario.as_deref(),
+                    provider_name.as_deref(),
+                    *resume,
+                    *no_deterministic,
+                    config_path,
+                )
+                .await
+            }
         }
         BenchCommand::Show { results } => handle_show(results),
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn handle_run_baseline(
+    dataset: &str,
+    output: &std::path::Path,
+    data_file: Option<&std::path::Path>,
+    scenario: Option<&str>,
+    provider_name: Option<&str>,
+    resume: bool,
+    no_deterministic: bool,
+    config_path: Option<&std::path::Path>,
+) -> anyhow::Result<()> {
+    // Gate --baseline to memory-relevant datasets only.
+    // Tool-driven datasets (gaia, frames, tau-bench) use NoopExecutor, making
+    // the memory-on pass meaningless (C-2).
+    match dataset {
+        "longmemeval" | "locomo" => {}
+        other => {
+            anyhow::bail!(
+                "--baseline is supported only for memory-relevant datasets (longmemeval, locomo). \
+                 Dataset '{other}' requires tool execution which is not wired in bench mode. \
+                 See the issue tracker for tool-executor support."
+            );
+        }
+    }
+
+    let data_path = resolve_data_path(dataset, data_file);
+    let path = resolve_config_path(config_path);
+    let mut config = Config::load(&path).unwrap_or_default();
+
+    let vault_args = parse_vault_args(&config, None, None, None);
+    if let Some(vault) = crate::bootstrap::build_vault_provider(&vault_args)
+        && let Err(e) = config.resolve_secrets(vault.as_ref()).await
+    {
+        tracing::warn!("vault secret resolution failed: {e}");
+    }
+
+    let raw_provider = if let Some(name) = provider_name {
+        create_named_provider(name, &config)
+            .map_err(|e| anyhow::anyhow!("failed to resolve provider '{name}': {e}"))?
+    } else {
+        create_provider(&config)
+            .map_err(|e| anyhow::anyhow!("failed to create default provider: {e}"))?
+    };
+    let provider = apply_deterministic_overrides(raw_provider, no_deterministic);
+
+    // Completed IDs are shared across both passes to allow partial resume.
+    let base_completed_ids = if resume {
+        let off_writer = ResultWriter::new(output.join("baseline").join("memory-off"))?;
+        off_writer
+            .load_existing()?
+            .map(|r| r.completed_ids())
+            .unwrap_or_default()
+    } else {
+        std::collections::HashSet::new()
+    };
+
+    let base_opts = RunOptions {
+        scenario_filter: scenario.map(ToOwned::to_owned),
+        completed_ids: base_completed_ids,
+        memory_mode: MemoryMode::Off,
+    };
+
+    // Each pass gets a distinct run_id so SQLite paths and result files don't collide.
+    let off_run_id = format!("bench-off-{}", baseline_run_id_suffix());
+    let on_run_id = format!("bench-on-{}", baseline_run_id_suffix());
+
+    let data_dir = output.join("bench-data");
+    std::fs::create_dir_all(&data_dir)?;
+
+    let off_dir = output.join("baseline").join("memory-off");
+    let on_dir = output.join("baseline").join("memory-on");
+
+    // --- Memory-off pass ---
+    let off_runner = BenchRunner::new(provider.clone(), no_deterministic);
+    let off_writer = ResultWriter::new(&off_dir)?;
+    let off_opts = RunOptions {
+        memory_mode: MemoryMode::Off,
+        ..base_opts
+    };
+    let mut off_run = dispatch_run(&off_runner, dataset, &data_path, off_opts).await?;
+    off_run.status = RunStatus::Completed;
+    off_run.finished_at = finished_at_now();
+    off_run.run_id = off_run_id;
+    off_run.recompute_aggregate();
+    off_writer.write(&off_run)?;
+    println!(
+        "Memory-off pass complete: mean score {:.4} ({}/{} exact)",
+        off_run.aggregate.mean_score, off_run.aggregate.exact_match, off_run.aggregate.total
+    );
+
+    // --- Memory-on pass ---
+    let memory_params = BenchMemoryParams {
+        data_dir: data_dir.clone(),
+        embedding_model: config.llm.embedding_model.clone(),
+        run_id: on_run_id.clone(),
+        dataset: dataset.to_owned(),
+    };
+    let on_runner =
+        BenchRunner::new(provider.clone(), no_deterministic).with_memory_params(memory_params);
+    let on_writer = ResultWriter::new(&on_dir)?;
+    let on_opts = RunOptions {
+        scenario_filter: scenario.map(ToOwned::to_owned),
+        completed_ids: std::collections::HashSet::new(),
+        memory_mode: MemoryMode::On,
+    };
+    let mut on_run = dispatch_run(&on_runner, dataset, &data_path, on_opts).await?;
+    on_run.status = RunStatus::Completed;
+    on_run.finished_at = finished_at_now();
+    on_run.run_id = on_run_id;
+    on_run.recompute_aggregate();
+    on_writer.write(&on_run)?;
+    println!(
+        "Memory-on pass complete: mean score {:.4} ({}/{} exact)",
+        on_run.aggregate.mean_score, on_run.aggregate.exact_match, on_run.aggregate.total
+    );
+
+    // --- Comparison (reuse existing baseline::BaselineComparison) ---
+    let cmp = BaselineComparison::compute(&on_run, &off_run);
+    let baseline_dir = output.join("baseline");
+    std::fs::create_dir_all(&baseline_dir)?;
+    cmp.write_comparison_json(&baseline_dir)?;
+    cmp.write_delta_table(&baseline_dir.join("summary.md"))?;
+
+    println!(
+        "Baseline complete: aggregate delta = {:+.4}",
+        cmp.aggregate_delta
+    );
+    println!("Off run: {}", off_writer.results_path().display());
+    println!("On  run: {}", on_writer.results_path().display());
+    println!(
+        "Comparison: {}",
+        baseline_dir.join("comparison.json").display()
+    );
+    Ok(())
+}
+
+/// Generate a short unique suffix for baseline run IDs.
+fn baseline_run_id_suffix() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.subsec_nanos());
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs());
+    format!("{secs:x}-{ns:x}")
 }
 
 fn handle_list() {
@@ -140,6 +303,7 @@ async fn handle_run(
     let opts = RunOptions {
         scenario_filter: scenario.map(ToOwned::to_owned),
         completed_ids,
+        memory_mode: MemoryMode::Off,
     };
 
     let runner = BenchRunner::new(provider, no_deterministic);

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -5,8 +5,8 @@ use crate::bootstrap::{
     create_named_provider, create_provider, parse_vault_args, resolve_config_path,
 };
 use zeph_bench::{
-    BenchCommand, BenchMemoryParams, BenchRunner, DatasetRegistry, MemoryMode, ResultWriter,
-    RunOptions, RunStatus, apply_deterministic_overrides,
+    BenchCommand, BenchMemoryParams, BenchRun, BenchRunner, DatasetRegistry, MemoryMode,
+    ResultWriter, RunOptions, RunStatus, apply_deterministic_overrides,
     baseline::BaselineComparison,
     loaders::{
         FramesEvaluator, FramesLoader, GaiaEvaluator, GaiaLoader, LocomoEvaluator, LocomoLoader,
@@ -76,9 +76,6 @@ async fn handle_run_baseline(
     no_deterministic: bool,
     config_path: Option<&std::path::Path>,
 ) -> anyhow::Result<()> {
-    // Gate --baseline to memory-relevant datasets only.
-    // Tool-driven datasets (gaia, frames, tau-bench) use NoopExecutor, making
-    // the memory-on pass meaningless (C-2).
     match dataset {
         "longmemeval" | "locomo" => {}
         other => {
@@ -110,7 +107,6 @@ async fn handle_run_baseline(
     };
     let provider = apply_deterministic_overrides(raw_provider, no_deterministic);
 
-    // Completed IDs are shared across both passes to allow partial resume.
     let base_completed_ids = if resume {
         let off_writer = ResultWriter::new(output.join("baseline").join("memory-off"))?;
         off_writer
@@ -121,70 +117,35 @@ async fn handle_run_baseline(
         std::collections::HashSet::new()
     };
 
-    let base_opts = RunOptions {
-        scenario_filter: scenario.map(ToOwned::to_owned),
-        completed_ids: base_completed_ids,
-        memory_mode: MemoryMode::Off,
-    };
-
-    // Each pass gets a distinct run_id so SQLite paths and result files don't collide.
-    let off_run_id = format!("bench-off-{}", baseline_run_id_suffix());
-    let on_run_id = format!("bench-on-{}", baseline_run_id_suffix());
-
     let data_dir = output.join("bench-data");
     std::fs::create_dir_all(&data_dir)?;
 
-    let off_dir = output.join("baseline").join("memory-off");
-    let on_dir = output.join("baseline").join("memory-on");
+    let (off_run, off_writer) = run_memory_off_pass(
+        dataset,
+        &data_path,
+        output,
+        scenario,
+        base_completed_ids,
+        provider.clone(),
+        no_deterministic,
+    )
+    .await?;
 
-    // --- Memory-off pass ---
-    let off_runner = BenchRunner::new(provider.clone(), no_deterministic);
-    let off_writer = ResultWriter::new(&off_dir)?;
-    let off_opts = RunOptions {
-        memory_mode: MemoryMode::Off,
-        ..base_opts
-    };
-    let mut off_run = dispatch_run(&off_runner, dataset, &data_path, off_opts).await?;
-    off_run.status = RunStatus::Completed;
-    off_run.finished_at = finished_at_now();
-    off_run.run_id = off_run_id;
-    off_run.recompute_aggregate();
-    off_writer.write(&off_run)?;
-    println!(
-        "Memory-off pass complete: mean score {:.4} ({}/{} exact)",
-        off_run.aggregate.mean_score, off_run.aggregate.exact_match, off_run.aggregate.total
-    );
+    let (on_run, on_writer) = run_memory_on_pass(
+        dataset,
+        &data_path,
+        output,
+        scenario,
+        &data_dir,
+        &config.llm.embedding_model.clone(),
+        provider,
+        no_deterministic,
+    )
+    .await?;
 
-    // --- Memory-on pass ---
-    let memory_params = BenchMemoryParams {
-        data_dir: data_dir.clone(),
-        embedding_model: config.llm.embedding_model.clone(),
-        run_id: on_run_id.clone(),
-        dataset: dataset.to_owned(),
-    };
-    let on_runner =
-        BenchRunner::new(provider.clone(), no_deterministic).with_memory_params(memory_params);
-    let on_writer = ResultWriter::new(&on_dir)?;
-    let on_opts = RunOptions {
-        scenario_filter: scenario.map(ToOwned::to_owned),
-        completed_ids: std::collections::HashSet::new(),
-        memory_mode: MemoryMode::On,
-    };
-    let mut on_run = dispatch_run(&on_runner, dataset, &data_path, on_opts).await?;
-    on_run.status = RunStatus::Completed;
-    on_run.finished_at = finished_at_now();
-    on_run.run_id = on_run_id;
-    on_run.recompute_aggregate();
-    on_writer.write(&on_run)?;
-    println!(
-        "Memory-on pass complete: mean score {:.4} ({}/{} exact)",
-        on_run.aggregate.mean_score, on_run.aggregate.exact_match, on_run.aggregate.total
-    );
-
-    // --- Comparison (reuse existing baseline::BaselineComparison) ---
-    let cmp = BaselineComparison::compute(&on_run, &off_run);
     let baseline_dir = output.join("baseline");
     std::fs::create_dir_all(&baseline_dir)?;
+    let cmp = BaselineComparison::compute(&on_run, &off_run);
     cmp.write_comparison_json(&baseline_dir)?;
     cmp.write_delta_table(&baseline_dir.join("summary.md"))?;
 
@@ -199,6 +160,75 @@ async fn handle_run_baseline(
         baseline_dir.join("comparison.json").display()
     );
     Ok(())
+}
+
+async fn run_memory_off_pass(
+    dataset: &str,
+    data_path: &std::path::Path,
+    output: &std::path::Path,
+    scenario: Option<&str>,
+    completed_ids: std::collections::HashSet<String>,
+    provider: zeph_llm::any::AnyProvider,
+    no_deterministic: bool,
+) -> anyhow::Result<(BenchRun, ResultWriter)> {
+    let dir = output.join("baseline").join("memory-off");
+    let writer = ResultWriter::new(&dir)?;
+    let opts = RunOptions {
+        scenario_filter: scenario.map(ToOwned::to_owned),
+        completed_ids,
+        memory_mode: MemoryMode::Off,
+    };
+    let runner = BenchRunner::new(provider, no_deterministic);
+    let mut run = dispatch_run(&runner, dataset, data_path, opts).await?;
+    run.status = RunStatus::Completed;
+    run.finished_at = finished_at_now();
+    run.run_id = format!("bench-off-{}", baseline_run_id_suffix());
+    run.recompute_aggregate();
+    writer.write(&run)?;
+    println!(
+        "Memory-off pass complete: mean score {:.4} ({}/{} exact)",
+        run.aggregate.mean_score, run.aggregate.exact_match, run.aggregate.total
+    );
+    Ok((run, writer))
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_memory_on_pass(
+    dataset: &str,
+    data_path: &std::path::Path,
+    output: &std::path::Path,
+    scenario: Option<&str>,
+    data_dir: &std::path::Path,
+    embedding_model: &str,
+    provider: zeph_llm::any::AnyProvider,
+    no_deterministic: bool,
+) -> anyhow::Result<(BenchRun, ResultWriter)> {
+    let run_id = format!("bench-on-{}", baseline_run_id_suffix());
+    let memory_params = BenchMemoryParams {
+        data_dir: data_dir.to_path_buf(),
+        embedding_model: embedding_model.to_owned(),
+        run_id: run_id.clone(),
+        dataset: dataset.to_owned(),
+    };
+    let dir = output.join("baseline").join("memory-on");
+    let writer = ResultWriter::new(&dir)?;
+    let opts = RunOptions {
+        scenario_filter: scenario.map(ToOwned::to_owned),
+        completed_ids: std::collections::HashSet::new(),
+        memory_mode: MemoryMode::On,
+    };
+    let runner = BenchRunner::new(provider, no_deterministic).with_memory_params(memory_params);
+    let mut run = dispatch_run(&runner, dataset, data_path, opts).await?;
+    run.status = RunStatus::Completed;
+    run.finished_at = finished_at_now();
+    run.run_id = run_id;
+    run.recompute_aggregate();
+    writer.write(&run)?;
+    println!(
+        "Memory-on pass complete: mean score {:.4} ({}/{} exact)",
+        run.aggregate.mean_score, run.aggregate.exact_match, run.aggregate.total
+    );
+    Ok((run, writer))
 }
 
 /// Generate a short unique suffix for baseline run IDs.


### PR DESCRIPTION
## Summary

- **`Aggregate`** extended with `median_score`, `stddev`, `error_count` (spec 034 §NFR-008)
- **`Scenario`** migrated from `prompt: String` to `turns: Vec<Turn>` with `Role` enum, `Scenario::single()` constructor, and `primary_prompt() -> Result<&str, BenchError>` (§multi-turn)
- **`--baseline` dual-run** (memory-off / memory-on): writes results to `<output>/baseline/{memory-off,memory-on}/` + `comparison.json`; scoped to `longmemeval` and `locomo` (§FR-006)
- All 5 dataset loaders migrated to `Scenario::single()`
- 111 zeph-bench tests pass; 8 520 workspace tests pass

## Test plan

- [x] `cargo nextest run -p zeph-bench` — 111/111 pass
- [x] `cargo nextest run --workspace --lib --bins` — 8 520/8 520 pass
- [x] `cargo test --doc -p zeph-bench` — 58/58 pass
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --lib --bins -- -D warnings` — clean