### PR TITLE
fix(llm,core): use embedding provider for tool schema filter and fix embed span model field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `zeph-core`, `zeph-llm`: tool schema filter now receives the embedding provider instead of the
+  main chat provider in `runner.rs` and `daemon.rs`; eliminates 1536-vs-768-dim mismatch that
+  caused all tool similarity scores to be 0.0 (fixes #3413).
+- `zeph-llm`: `OllamaProvider::embed()` tracing span now records the actual embedding model name
+  (`self.embedding_model`) instead of the chat model name (`self.model_identifier()`), making
+  `llm.embed` spans in Perfetto/Jaeger unambiguous (fixes #3414).
+
 ### Changed
 
 - `zeph-vault`: split 1302-line `lib.rs` into four module files (`age.rs`, `arc.rs`, `env.rs`,

--- a/crates/zeph-llm/src/ollama.rs
+++ b/crates/zeph-llm/src/ollama.rs
@@ -465,7 +465,7 @@ impl LlmProvider for OllamaProvider {
         tracing::instrument(
             name = "llm.embed",
             skip_all,
-            fields(provider = self.name(), model = self.model_identifier())
+            fields(provider = self.name(), model = self.embedding_model)
         )
     )]
     async fn embed(&self, text: &str) -> Result<Vec<f32>, LlmError> {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -517,8 +517,8 @@ pub(crate) async fn run_daemon(
             config.memory.trajectory.clone(),
             config.memory.category.clone(),
         )
-        .with_embedding_provider(embedding_provider)
-        .maybe_init_tool_schema_filter(config.agent.tool_filter.clone(), provider.clone()),
+        .with_embedding_provider(embedding_provider.clone())
+        .maybe_init_tool_schema_filter(config.agent.tool_filter.clone(), embedding_provider),
     )
     .await;
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1792,8 +1792,8 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         config.memory.trajectory.clone(),
         config.memory.category.clone(),
     )
-    .with_embedding_provider(embedding_provider)
-    .maybe_init_tool_schema_filter(config.agent.tool_filter.clone(), provider.clone())
+    .with_embedding_provider(embedding_provider.clone())
+    .maybe_init_tool_schema_filter(config.agent.tool_filter.clone(), embedding_provider)
     .await;
 
     // Wire JsonEventLayer when --json is active so tool_call / tool_result events


### PR DESCRIPTION
## Summary

- Pass `embedding_provider` to `maybe_init_tool_schema_filter` in `src/runner.rs` and `src/daemon.rs`; the main chat provider (OpenAI, 1536-dim) was being used to build stored tool embeddings while the embedding provider (Ollama nomic, 768-dim) was used at query time — `cosine_similarity` returned 0.0 for all tools as a result.
- Fix `OllamaProvider::embed()` tracing span to record `self.embedding_model` instead of `self.model_identifier()` so `llm.embed` spans in Perfetto/Jaeger show the actual embedding model.

## Test plan

- [ ] All 8513 unit tests pass (`cargo nextest run --workspace --lib --bins`)
- [ ] `cargo +nightly fmt --check` passes
- [ ] `cargo clippy --workspace -- -D warnings` passes (0 new warnings)
- [ ] Manually verify tool similarity scores are non-zero with mixed-provider config (ollama-embed + OpenAI chat)

Closes #3413, Closes #3414