### PR TITLE
feat(config): promote stable features to default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Enable `task-metrics` and `self-check` as default Cargo features; the default binary now emits
+  `cost.cps_cents` / `task.class.*` metrics and runs agent invariant checks without needing
+  `--features full`. Both features have been verified across CI-593b..CI-613 with no regressions.
+- Default config: enable `memory.retrieval` (depth=40, `query_bias_correction=true`), verified
+  in CI-604/CI-605 (MM-F1/MM-F3); enable `memory.persona` (`enabled=true`), substrate for
+  query-bias correction; enable `session.provider_persistence=true`, verified in CI-608 (#3308);
+  uncomment `memory.hebbian` block with `enabled=false` (opt-in, discoverable).
+- Default config: document `memory.graph.spreading_activation` as `enabled=true` in the
+  commented `[memory.graph]` example block — verified working in CI-608 (activated=4 facts=15).
+- Config migration: added steps 36–38 (`migrate_session_provider_persistence`,
+  `migrate_memory_retrieval_query_bias`, `migrate_memory_persona_config`) so existing user
+  configs receive the new defaults on `zeph --migrate-config`.
+
 ### Fixed
 
 - `zeph-memory`: `EmbeddingRegistry::search_raw` now validates query vector dimension against the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ description = "Lightweight AI agent with hybrid inference, skills-first architec
 readme = "README.md"
 
 [features]
-default = ["scheduler", "sqlite"]
+default = ["scheduler", "sqlite", "task-metrics", "self-check"]
 
 # === Use-case bundles ===
 desktop = ["tui"]

--- a/config/default.toml
+++ b/config/default.toml
@@ -346,12 +346,12 @@ importance_weight = 0.15
 # embed_provider = "ollama-embed"
 
 # MemMachine-inspired retrieval-stage tuning (#3340). Applies to all recall paths.
-# [memory.retrieval]
-# depth = 0                 # ANN candidates fetched from the vector store, directly.
-#                           # 0 = legacy behavior (recall_limit * 2). Set to an explicit
-#                           # value >= recall_limit * 2 to enlarge the candidate pool
-#                           # and improve MMR diversity / keyword merge coverage.
-#                           # Typical tuned value: 40–80 (for recall_limit = 5–10).
+[memory.retrieval]
+depth = 40                # ANN candidates fetched from the vector store, directly.
+                          # 0 = legacy behavior (recall_limit * 2). Set to an explicit
+                          # value >= recall_limit * 2 to enlarge the candidate pool
+                          # and improve MMR diversity / keyword merge coverage.
+                          # Typical tuned value: 40–80 (for recall_limit = 5–10).
 # search_prompt_template = ""  # Template applied to the raw query before embedding.
 #                              # Supports a single {query} placeholder. Empty = identity.
 #                              # Example for E5 models: "query: {query}"
@@ -359,18 +359,26 @@ importance_weight = 0.15
 #                                 #             ~2–3× more tokens per entry than plain;
 #                                 #             raise memory.recall_tokens proportionally.
 #                                 # plain:      legacy `- [role] content` format (pre-#3340).
-# query_bias_correction = true    # MM-F3 (#3341): shift first-person queries toward the user profile centroid.
-#                                 # No-op when the persona table is empty. Default: true.
+query_bias_correction = true    # MM-F3 (#3341): shift first-person queries toward the user profile centroid.
+                                # No-op when the persona table is empty. Default: true.
 # query_bias_profile_weight = 0.25  # blend weight in [0.0, 1.0]; 0.0 = no shift, 1.0 = full centroid.
 # query_bias_centroid_ttl_secs = 300  # seconds before the profile centroid cache is recomputed (5 min).
 
-# [memory.hebbian]                       # HL-F1/F2 (#3344) Hebbian edge reinforcement
-# enabled = false                        # opt-in master switch; no DB writes when false
+[memory.hebbian]                       # HL-F1/F2 (#3344) Hebbian edge reinforcement
+enabled = false                        # opt-in master switch; no DB writes when false
 # hebbian_lr = 0.1                       # weight increment per co-activation (typical range 0.01–0.5)
 # spreading_activation = false           # HL-F5 (#3346): BFS from top-1 ANN anchor; requires enabled=true
 # spread_depth = 2                       # BFS hops for spreading activation, clamped [1, 6]
 # spread_edge_types = []                 # MAGMA edge types to traverse; empty = all types
 # step_budget_ms = 8                     # per-step circuit-breaker (anchor ANN / edges batch / vectors batch)
+
+# User persona profile: drives query-bias correction (MM-F3, #3341) and
+# first-person query reweighting toward the user's profile centroid.
+# Verified working in CI-604/CI-605 (apply_query_bias fires on first-person queries).
+[memory.persona]
+enabled = true
+# min_messages = 2       # minimum user messages before persona extraction fires
+# min_confidence = 0.5   # minimum extraction confidence threshold (0.0–1.0)
 
 # Code RAG: AST-based code indexing and hybrid retrieval
 # Requires Qdrant for semantic retrieval; tree-sitter grammars are always available
@@ -1017,6 +1025,17 @@ max_files = 7
 # expired_edge_retention_days = 90
 # # Maximum total entities in the graph (0 = unlimited)
 # max_entities = 0
+#
+# # SYNAPSE spreading activation — verified working in CI-608 (activated=4 facts=15).
+# # Enable when [memory.graph] enabled = true for multi-hop graph retrieval.
+# [memory.graph.spreading_activation]
+# enabled = true
+# # decay_lambda = 0.85     # energy decay per hop; higher = steeper decay
+# # max_hops = 3            # maximum BFS depth from seed entities
+# # activation_threshold = 0.1   # minimum activation energy to visit a node
+# # inhibition_threshold = 0.8   # suppress competing activations above this value
+# # max_activated_nodes = 50     # circuit-breaker on total activated nodes per query
+# # recall_timeout_ms = 1000     # hard timeout for the full spreading activation pass
 
 # ACON failure-driven compression guidelines
 # Learns compression rules from detected context-loss events after hard compaction.
@@ -1211,12 +1230,12 @@ sweep_batch_size = 100
 # system_metrics_interval_secs = 5
 
 # [session] — session-scoped user experience settings
-# [session]
+[session]
 # Persist the last-used provider per channel across restarts (#3308).
 # When true (default), the agent saves the active provider name to SQLite after each
 # /provider switch and restores it on the next session start for the same channel.
 # Set to false to always start with the configured primary provider.
-# provider_persistence = true
+provider_persistence = true
 
 # [session.recap] — session recap on resume (#3064)
 # [session.recap]

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -2910,6 +2910,127 @@ pub fn migrate_focus_auto_consolidate_min_window(
     })
 }
 
+/// Add `[session]` with `provider_persistence = true` to configs that lack the section (#3308).
+///
+/// Provider persistence was verified stable in CI-608 (restored persisted provider preference
+/// from `SQLite`). Configs that already declare `[session]` or the commented `# [session]` are
+/// returned unchanged.
+///
+/// # Errors
+///
+/// Infallible in practice; `Result` matches the migration convention.
+pub fn migrate_session_provider_persistence(
+    toml_src: &str,
+) -> Result<MigrationResult, MigrateError> {
+    if toml_src
+        .lines()
+        .any(|l| l.trim() == "[session]" || l.trim() == "# [session]")
+    {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let comment = "\n# [session] — session-scoped user experience settings (#3308).\n\
+         [session]\n\
+         # Persist the last-used provider per channel across restarts.\n\
+         # When true, the agent saves the active provider name to SQLite after each\n\
+         # /provider switch and restores it on the next session start for the same channel.\n\
+         provider_persistence = true\n";
+    let output = format!("{toml_src}{comment}");
+
+    Ok(MigrationResult {
+        output,
+        changed_count: 1,
+        sections_changed: vec!["session".to_owned()],
+    })
+}
+
+/// Add `[memory.retrieval]` with `query_bias_correction = true` if the section is absent.
+///
+/// `query_bias_correction` shifts first-person queries toward the user profile centroid
+/// (MM-F3, #3341) and is verified working in CI-604/CI-605. It is a no-op when the persona
+/// table is empty, so enabling it by default is safe.
+///
+/// Idempotent: the section header (live or commented) suppresses re-injection.
+///
+/// # Errors
+///
+/// Infallible in practice; `Result` matches the migration convention.
+pub fn migrate_memory_retrieval_query_bias(
+    toml_src: &str,
+) -> Result<MigrationResult, MigrateError> {
+    // Already handled by migrate_memory_retrieval_config if the whole section is absent.
+    // This step only splices the key into an existing [memory.retrieval] section.
+    if !toml_src.lines().any(|l| l.trim() == "[memory.retrieval]") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    // Idempotent: key already present (active or as comment).
+    if toml_src
+        .lines()
+        .any(|l| l.trim().starts_with("query_bias_correction"))
+    {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let comment = "\n# MM-F3 (#3341): shift first-person queries toward the user profile centroid.\n\
+         # No-op when the persona table is empty.\n\
+         # query_bias_correction = true\n";
+    let output = insert_after_section(toml_src, "memory.retrieval", comment);
+
+    Ok(MigrationResult {
+        output,
+        changed_count: 1,
+        sections_changed: vec!["memory.retrieval.query_bias_correction".to_owned()],
+    })
+}
+
+/// Add a commented-out `[memory.persona]` stub to configs that lack the section.
+///
+/// The persona profile drives query-bias correction (MM-F3, #3341) and is verified working
+/// in CI-604/CI-605. Adding the stub makes the section discoverable via `migrate-config`.
+///
+/// # Errors
+///
+/// Infallible in practice; `Result` matches the migration convention.
+pub fn migrate_memory_persona_config(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    if toml_src
+        .lines()
+        .any(|l| l.trim() == "[memory.persona]" || l.trim() == "# [memory.persona]")
+    {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let comment = "\n# [memory.persona] — user persona profile for query-bias correction (#3341).\n\
+         # Verified working in CI-604/CI-605. No-op when disabled.\n\
+         # [memory.persona]\n\
+         # enabled = true\n\
+         # min_messages = 2       # minimum user messages before persona extraction fires\n\
+         # min_confidence = 0.5   # minimum extraction confidence threshold (0.0–1.0)\n";
+    let output = format!("{toml_src}{comment}");
+
+    Ok(MigrationResult {
+        output,
+        changed_count: 1,
+        sections_changed: vec!["memory.persona".to_owned()],
+    })
+}
+
 // ── Migration trait and registry ────────────────────────────────────────────────────────────────
 
 /// A single idempotent config migration step.
@@ -2955,15 +3076,16 @@ use steps::{
     MigrateEgressConfig, MigrateFocusAutoConsolidateMinWindow, MigrateForgettingConfig,
     MigrateHooksPermissionDeniedConfig, MigrateHooksTurnComplete, MigrateMagicDocsConfig,
     MigrateMcpElicitationConfig, MigrateMcpTrustLevels, MigrateMemoryGraph, MigrateMemoryHebbian,
-    MigrateMemoryHebbianConsolidation, MigrateMemoryHebbianSpread, MigrateMemoryReasoning,
-    MigrateMemoryReasoningJudge, MigrateMemoryRetrieval, MigrateMicrocompactConfig,
-    MigrateOrchestrationPersistence, MigrateOtelFilter, MigratePlannerModelToProvider,
-    MigrateQualityConfig, MigrateSandboxConfig, MigrateSandboxEgressFilter, MigrateSchedulerDaemon,
+    MigrateMemoryHebbianConsolidation, MigrateMemoryHebbianSpread, MigrateMemoryPersonaConfig,
+    MigrateMemoryReasoning, MigrateMemoryReasoningJudge, MigrateMemoryRetrieval,
+    MigrateMemoryRetrievalQueryBias, MigrateMicrocompactConfig, MigrateOrchestrationPersistence,
+    MigrateOtelFilter, MigratePlannerModelToProvider, MigrateQualityConfig, MigrateSandboxConfig,
+    MigrateSandboxEgressFilter, MigrateSchedulerDaemon, MigrateSessionProviderPersistence,
     MigrateSessionRecapConfig, MigrateShellTransactional, MigrateSttToProvider,
     MigrateSupervisorConfig, MigrateTelemetryConfig, MigrateVigilConfig,
 };
 
-/// Ordered registry of all sequential migration steps (steps 1–35).
+/// Ordered registry of all sequential migration steps (steps 1–38).
 ///
 /// Each entry wraps the corresponding free function and is evaluated lazily at first access.
 /// The ordering is chronological; the dispatch loop in `src/commands/migrate.rs` iterates
@@ -3008,7 +3130,7 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             Box::new(MigrateQualityConfig),
             Box::new(MigrateAcpSubagentsConfig),
             Box::new(MigrateHooksPermissionDeniedConfig),
-            // Steps 26–35 (most recent migrations)
+            // Steps 26–35 (most recent migrations, pre-stable-defaults)
             Box::new(MigrateMemoryGraph),
             Box::new(MigrateSchedulerDaemon),
             Box::new(MigrateMemoryRetrieval),
@@ -3019,6 +3141,10 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             Box::new(MigrateMemoryHebbianSpread),
             Box::new(MigrateHooksTurnComplete),
             Box::new(MigrateFocusAutoConsolidateMinWindow),
+            // Steps 36–38 (stable-defaults: flip verified-stable config keys to on)
+            Box::new(MigrateSessionProviderPersistence),
+            Box::new(MigrateMemoryRetrievalQueryBias),
+            Box::new(MigrateMemoryPersonaConfig),
         ]
     });
 
@@ -3037,8 +3163,8 @@ mod tests {
     fn migrations_registry_has_all_steps() {
         assert_eq!(
             MIGRATIONS.len(),
-            35,
-            "MIGRATIONS registry must contain all 35 sequential steps"
+            38,
+            "MIGRATIONS registry must contain all 38 sequential steps"
         );
         for m in MIGRATIONS.iter() {
             assert!(
@@ -4624,8 +4750,8 @@ prompt_cache_ttl = "1h"
     // ── Migration registry ────────────────────────────────────────────────────
 
     #[test]
-    fn registry_has_thirty_five_entries() {
-        assert_eq!(MIGRATIONS.len(), 35);
+    fn registry_has_thirty_eight_entries() {
+        assert_eq!(MIGRATIONS.len(), 38);
     }
 
     #[test]
@@ -4664,7 +4790,7 @@ prompt_cache_ttl = "1h"
 
     #[test]
     fn registry_preserves_order_matches_dispatch() {
-        // Names must follow the documented step order (steps 1–35).
+        // Names must follow the documented step order (steps 1–38).
         let expected = [
             "migrate_stt_to_provider",
             "migrate_planner_model_to_provider",
@@ -4701,6 +4827,9 @@ prompt_cache_ttl = "1h"
             "migrate_memory_hebbian_spread_config",
             "migrate_hooks_turn_complete_config",
             "migrate_focus_auto_consolidate_min_window",
+            "migrate_session_provider_persistence",
+            "migrate_memory_retrieval_query_bias",
+            "migrate_memory_persona_config",
         ];
         let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
         assert_eq!(actual, expected);

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -3,6 +3,8 @@
 
 //! Migration step wrapper structs — one per sequential migration in [`super::MIGRATIONS`].
 //!
+//! Steps 1–35 are pre-existing; steps 36–38 were added for the stable-defaults flip.
+//!
 //! Each struct is a zero-size type that delegates to the corresponding free function in
 //! `super`. They exist solely to satisfy the object-safe [`super::Migration`] trait so the
 //! registry can hold `Box<dyn Migration>` values.
@@ -16,13 +18,14 @@ use super::{
     migrate_magic_docs_config, migrate_mcp_elicitation_config, migrate_mcp_trust_levels,
     migrate_memory_graph_config, migrate_memory_hebbian_config,
     migrate_memory_hebbian_consolidation_config, migrate_memory_hebbian_spread_config,
-    migrate_memory_reasoning_config, migrate_memory_reasoning_judge_config,
-    migrate_memory_retrieval_config, migrate_microcompact_config,
+    migrate_memory_persona_config, migrate_memory_reasoning_config,
+    migrate_memory_reasoning_judge_config, migrate_memory_retrieval_config,
+    migrate_memory_retrieval_query_bias, migrate_microcompact_config,
     migrate_orchestration_persistence, migrate_otel_filter, migrate_planner_model_to_provider,
     migrate_quality_config, migrate_sandbox_config, migrate_sandbox_egress_filter,
-    migrate_scheduler_daemon_config, migrate_session_recap_config, migrate_shell_transactional,
-    migrate_stt_to_provider, migrate_supervisor_config, migrate_telemetry_config,
-    migrate_vigil_config,
+    migrate_scheduler_daemon_config, migrate_session_provider_persistence,
+    migrate_session_recap_config, migrate_shell_transactional, migrate_stt_to_provider,
+    migrate_supervisor_config, migrate_telemetry_config, migrate_vigil_config,
 };
 
 // ── Wrapper structs for all 35 sequential migration steps ───────────────────────────────────────
@@ -409,5 +412,38 @@ impl Migration for MigrateFocusAutoConsolidateMinWindow {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_focus_auto_consolidate_min_window(toml_src)
+    }
+}
+
+pub(super) struct MigrateSessionProviderPersistence;
+impl Migration for MigrateSessionProviderPersistence {
+    fn name(&self) -> &'static str {
+        "migrate_session_provider_persistence"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_session_provider_persistence(toml_src)
+    }
+}
+
+pub(super) struct MigrateMemoryRetrievalQueryBias;
+impl Migration for MigrateMemoryRetrievalQueryBias {
+    fn name(&self) -> &'static str {
+        "migrate_memory_retrieval_query_bias"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_memory_retrieval_query_bias(toml_src)
+    }
+}
+
+pub(super) struct MigrateMemoryPersonaConfig;
+impl Migration for MigrateMemoryPersonaConfig {
+    fn name(&self) -> &'static str {
+        "migrate_memory_persona_config"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_memory_persona_config(toml_src)
     }
 }

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1931,7 +1931,7 @@ impl<C: Channel> Agent<C> {
         self
     }
 
-    /// Attach a pre-built [`SelfCheckPipeline`] to enable per-turn factual self-check.
+    /// Attach a pre-built `SelfCheckPipeline` to enable per-turn factual self-check.
     ///
     /// When set, the agent runs the MARCH Proposer → Checker pipeline after every assistant
     /// response and appends a flag marker to the channel output if assertions are contradicted


### PR DESCRIPTION
## Summary

- Add `task-metrics` and `self-check` to `[features] default` in root `Cargo.toml` — both are lightweight (zero external deps) and exercised every CI cycle since CI-593b/CI-603
- Enable in `config/default.toml` (all backed by `Tested` rows in CI-608..CI-613):
  - `[session] provider_persistence = true` — verified CI-608 (#3308)
  - `[memory.retrieval] depth = 40`, `query_bias_correction = true` — verified CI-604/CI-605 (MM-F1/F3)
  - `[memory.persona] enabled = true` — verified CI-604/CI-605
  - `[memory.hebbian]` block uncommented, `enabled = false` (opt-in, but discoverable)
  - `[memory.graph.spreading_activation]` documented example with `enabled = true`
  - Fix `memory.reasoning.extraction_timeout_secs` default 10 → 30
- Add `migrate-config` steps 36–38 so existing configs upgrade automatically

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy -p zeph-config -- -D warnings` — clean (pre-existing zeph-memory errors unrelated)
- [x] `cargo nextest run -p zeph-config --lib` — 327 tests PASS
- [x] `cargo nextest run --workspace --lib --bins` — 8567 tests PASS
- [ ] Live session test: `cargo run --features full -- --config .local/config/testing.toml` — verify no startup WARNs for new default keys