### PR TITLE
refactor(llm): DRY router fallback error path and fix spawn_blocking for state saves

### DIFF
--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -667,7 +667,7 @@ impl<C: Channel> Agent<C> {
         let _ = self.channel.send_status("Shutting down...").await;
 
         // CRIT-1: persist Thompson state accumulated during this session.
-        self.provider.save_router_state();
+        self.provider.save_router_state().await;
 
         // Persist AdaptOrch Beta-arm table alongside Thompson state.
         if let Some(ref advisor) = self.orchestration.topology_advisor

--- a/crates/zeph-llm/src/any.rs
+++ b/crates/zeph-llm/src/any.rs
@@ -179,14 +179,18 @@ impl AnyProvider {
         }
     }
 
-    /// Persist router state to disk if this provider is a `RouterProvider` with Thompson strategy.
+    /// Persist router state to disk if this provider is a `RouterProvider`.
     ///
-    /// No-op for all other provider variants.
-    pub fn save_router_state(&self) {
+    /// Saves Thompson, reputation, and bandit state concurrently using
+    /// [`tokio::task::spawn_blocking`]. No-op for all other provider variants.
+    pub async fn save_router_state(&self) {
         if let Self::Router(p) = self {
-            p.save_thompson_state();
-            p.save_reputation_state();
-            p.save_bandit_state();
+            // Run all three saves concurrently — each is independent I/O.
+            tokio::join!(
+                p.save_thompson_state(),
+                p.save_reputation_state(),
+                p.save_bandit_state(),
+            );
         }
     }
 

--- a/crates/zeph-llm/src/router/mod.rs
+++ b/crates/zeph-llm/src/router/mod.rs
@@ -546,14 +546,22 @@ impl RouterProvider {
     }
 
     /// Persist current bandit state to disk. No-op if bandit strategy is not active.
-    pub fn save_bandit_state(&self) {
+    ///
+    /// Uses [`tokio::task::spawn_blocking`] so it is safe to call from any async context.
+    pub async fn save_bandit_state(&self) {
         let (Some(bandit), Some(path)) = (&self.bandit, &self.bandit_state_path) else {
             return;
         };
-        let state = bandit.lock();
-        if let Err(e) = state.save(path) {
-            tracing::warn!(error = %e, "failed to save bandit state");
-        }
+        let bandit = Arc::clone(bandit);
+        let path = path.clone();
+        tokio::task::spawn_blocking(move || {
+            let state = bandit.lock();
+            if let Err(e) = state.save(&path) {
+                tracing::warn!(error = %e, "failed to save bandit state");
+            }
+        })
+        .await
+        .unwrap_or_else(|e| tracing::warn!(error = %e, "bandit state save task panicked"));
     }
 
     /// Return bandit diagnostic stats: `(provider_name, pulls, mean_reward)`.
@@ -644,14 +652,21 @@ impl RouterProvider {
     }
 
     /// Persist current reputation state to disk. No-op if reputation is disabled.
-    pub fn save_reputation_state(&self) {
+    /// Uses [`tokio::task::spawn_blocking`] so it is safe to call from any async context.
+    pub async fn save_reputation_state(&self) {
         let (Some(reputation), Some(path)) = (&self.reputation, &self.reputation_state_path) else {
             return;
         };
-        let state = reputation.lock();
-        if let Err(e) = state.save(path) {
-            tracing::warn!(error = %e, "failed to save reputation state");
-        }
+        let reputation = Arc::clone(reputation);
+        let path = path.clone();
+        tokio::task::spawn_blocking(move || {
+            let state = reputation.lock();
+            if let Err(e) = state.save(&path) {
+                tracing::warn!(error = %e, "failed to save reputation state");
+            }
+        })
+        .await
+        .unwrap_or_else(|e| tracing::warn!(error = %e, "reputation state save task panicked"));
     }
 
     /// Return reputation stats for all tracked providers: (name, alpha, beta, mean, observations).
@@ -726,19 +741,22 @@ impl RouterProvider {
     ///
     /// No-op if Thompson strategy is not active.
     ///
-    /// # Note
-    ///
-    /// This performs synchronous I/O. Called at agent shutdown from an async context;
-    /// acceptable since it runs after all in-flight requests have completed.
-    // FIXME: if called mid-request, use `tokio::task::spawn_blocking` instead.
-    pub fn save_thompson_state(&self) {
+    /// Uses [`tokio::task::spawn_blocking`] so it is safe to call from any async context,
+    /// including mid-request paths.
+    pub async fn save_thompson_state(&self) {
         let (Some(thompson), Some(path)) = (&self.thompson, &self.thompson_state_path) else {
             return;
         };
-        let state = thompson.lock();
-        if let Err(e) = state.save(path) {
-            tracing::warn!(error = %e, "failed to save Thompson router state");
-        }
+        let thompson = Arc::clone(thompson);
+        let path = path.clone();
+        tokio::task::spawn_blocking(move || {
+            let state = thompson.lock();
+            if let Err(e) = state.save(&path) {
+                tracing::warn!(error = %e, "failed to save Thompson router state");
+            }
+        })
+        .await
+        .unwrap_or_else(|e| tracing::warn!(error = %e, "Thompson state save task panicked"));
     }
 
     /// Hash a query string to a `u64` cache key.
@@ -1365,6 +1383,28 @@ impl RouterProvider {
     }
 }
 
+/// Record a provider error during the fallback loop and emit a warning log.
+///
+/// Shared by [`RouterProvider::chat`] and [`RouterProvider::chat_stream`] to avoid
+/// duplicating error-path bookkeeping. Not part of the public API.
+fn record_fallback_error(
+    router: &RouterProvider,
+    provider_name: &str,
+    error: &LlmError,
+    elapsed_ms: u64,
+    status_tx: Option<&StatusTx>,
+    log_msg: &'static str,
+) {
+    router.record_availability(provider_name, false, elapsed_ms);
+    if error.is_rate_limited() {
+        router.record_availability(provider_name, false, 0);
+    }
+    if let Some(tx) = status_tx {
+        let _ = tx.send(format!("router: {provider_name} failed, falling back"));
+    }
+    tracing::warn!(provider = provider_name, error = %error, "{}", log_msg);
+}
+
 impl LlmProvider for RouterProvider {
     fn context_window(&self) -> Option<usize> {
         self.state
@@ -1381,8 +1421,9 @@ impl LlmProvider for RouterProvider {
         let status_tx = self.status_tx.clone();
         let messages = messages.to_vec();
         let router = self.clone();
-        // TODO: DRY — `chat` and `chat_stream` share the same fallback loop pattern.
-        // Refactor into a shared helper once the API stabilizes.
+        // NOTE: `chat` and `chat_stream` share error-path logic via `record_fallback_error`.
+        // Their success paths diverge (quality gate + CoE vs. plain stream-open), so a
+        // shared loop helper would reduce clarity without removing significant duplication.
         Box::pin(async move {
             // Increment turn counter once per top-level chat() call. All concurrent sub-calls
             // (tool schema fetches, embed probes) that re-enter chat() will see the same
@@ -1517,18 +1558,14 @@ impl LlmProvider for RouterProvider {
                         return Ok(r);
                     }
                     Err(e) => {
-                        router.record_availability(
+                        record_fallback_error(
+                            &router,
                             p.name(),
-                            false,
+                            &e,
                             u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
+                            status_tx.as_ref(),
+                            "router fallback",
                         );
-                        if e.is_rate_limited() {
-                            router.record_availability(p.name(), false, 0);
-                        }
-                        if let Some(ref tx) = status_tx {
-                            let _ = tx.send(format!("router: {} failed, falling back", p.name()));
-                        }
-                        tracing::warn!(provider = p.name(), error = %e, "router fallback");
                     }
                 }
             }
@@ -1550,6 +1587,8 @@ impl LlmProvider for RouterProvider {
         let messages = messages.to_vec();
         let router = self.clone();
         Box::pin(async move {
+            // NOTE: see DRY design decision above `chat()` — error path shared via
+            // `record_fallback_error`; success paths diverge intentionally.
             if router.strategy == RouterStrategy::Cascade {
                 // Cascade: pass Arc slice directly — no Vec allocation on the hot path.
                 return router
@@ -1589,18 +1628,14 @@ impl LlmProvider for RouterProvider {
                         return Ok(r);
                     }
                     Err(e) => {
-                        router.record_availability(
+                        record_fallback_error(
+                            &router,
                             p.name(),
-                            false,
+                            &e,
                             u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
+                            status_tx.as_ref(),
+                            "router stream fallback",
                         );
-                        if e.is_rate_limited() {
-                            router.record_availability(p.name(), false, 0);
-                        }
-                        if let Some(ref tx) = status_tx {
-                            let _ = tx.send(format!("router: {} failed, falling back", p.name()));
-                        }
-                        tracing::warn!(provider = p.name(), error = %e, "router stream fallback");
                     }
                 }
             }
@@ -2515,10 +2550,10 @@ mod tests {
         assert!(r.thompson.is_some());
     }
 
-    #[test]
-    fn save_thompson_state_noop_without_thompson() {
+    #[tokio::test]
+    async fn save_thompson_state_noop_without_thompson() {
         let r = RouterProvider::new(vec![]);
-        r.save_thompson_state(); // should not panic
+        r.save_thompson_state().await; // should not panic
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Extract `record_fallback_error` private helper to deduplicate the error-arm logic shared by `chat` and `chat_stream` fallback loops. The success paths diverge intentionally (quality gate + CoE vs plain stream) and are kept separate; a NOTE in both methods documents the decision.
- Convert `save_thompson_state`, `save_bandit_state`, `save_reputation_state` to `pub async fn` wrapping `tokio::task::spawn_blocking` — resolves the FIXME for CPU-bound work on the async executor.
- `AnyProvider::save_router_state` now runs all three saves concurrently via `tokio::join!`.
- Single caller in `zeph-core::agent::mod` updated with `.await`.

## Motivation

Part of the m48 architectural cleanup plan (PR 2 of 8). Router was the highest bug-density file (5 follow-up PRs in recent history). Deduplicating the error path and offloading blocking I/O reduces future regression surface.

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace --all-features -- -D warnings` — 0 warnings
- [ ] `cargo nextest run --config-file .github/nextest.toml -p zeph-llm -p zeph-core --lib --bins` — 847 + 1502 passed