### PR TITLE
fix(bench): fix airline tool schemas, scenario filter error, and router model_identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `zeph-bench`: `BookReservationParams`, `UpdateReservationFlightsParams`, and
+  `UpdateReservationPassengersParams` used `Vec<serde_json::Value>` for `flights` and
+  `passengers` fields. `schemars` emits an `array` schema without `items` for `Value`,
+  which OpenAI rejects with HTTP 400. Replaced with typed structs `FlightSegment` and
+  `Passenger`; the tau2-bench-airline dataset now produces valid tool schemas. (#3426)
+- `zeph-bench`: `bench run --scenario <id>` silently exited 0 with "Benchmark complete:
+  0/0 exact" when the ID matched no scenarios. Now returns an error with a descriptive
+  message and non-zero exit code. (#3427)
+- `zeph-llm`: `RouterProvider::model_identifier()` fell through to the default empty-string
+  implementation, causing `results.json` to record `model: ""` when the router was used as
+  the bench provider. Overridden to return `"router"`. (#3430)
+
 ### Changed
 
 - Enable `task-metrics` and `self-check` as default Cargo features; the default binary now emits

--- a/crates/zeph-bench/src/loaders/tau2_bench/envs/tools.rs
+++ b/crates/zeph-bench/src/loaders/tau2_bench/envs/tools.rs
@@ -11,8 +11,30 @@
 #![allow(dead_code)]
 
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use zeph_tools::registry::{InvocationHint, ToolDef};
+
+// ─── Airline nested types ────────────────────────────────────────────────────
+
+/// A single flight leg in a reservation (flight number + departure date).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct FlightSegment {
+    /// IATA or internal flight number (e.g. `"AA123"`).
+    pub flight_number: String,
+    /// Departure date in `YYYY-MM-DD` format.
+    pub date: String,
+}
+
+/// Passenger identity data required when booking or updating a reservation.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct Passenger {
+    /// Passenger's given name.
+    pub first_name: String,
+    /// Passenger's family name.
+    pub last_name: String,
+    /// Date of birth in `YYYY-MM-DD` format.
+    pub dob: String,
+}
 
 // ─── Retail shared params ────────────────────────────────────────────────────
 
@@ -297,10 +319,10 @@ pub(super) struct BookReservationParams {
     pub flight_type: String,
     /// Cabin class: `basic_economy`, `economy`, `business`.
     pub cabin: String,
-    /// List of flights to include (each has `flight_number` and `date`).
-    pub flights: Vec<serde_json::Value>,
-    /// List of passenger objects with `first_name`, `last_name`, `dob`.
-    pub passengers: Vec<serde_json::Value>,
+    /// List of flights to include.
+    pub flights: Vec<FlightSegment>,
+    /// List of passengers.
+    pub passengers: Vec<Passenger>,
     /// Payment method id.
     pub payment_method_id: String,
     /// Total number of checked bags.
@@ -376,7 +398,7 @@ pub(super) struct UpdateReservationFlightsParams {
     /// Cabin class for the updated flights.
     pub cabin: String,
     /// New list of flights.
-    pub flights: Vec<serde_json::Value>,
+    pub flights: Vec<FlightSegment>,
     /// Payment method id.
     pub payment_method_id: String,
 }
@@ -386,7 +408,7 @@ pub(super) struct UpdateReservationPassengersParams {
     /// Reservation id.
     pub reservation_id: String,
     /// Updated passenger list.
-    pub passengers: Vec<serde_json::Value>,
+    pub passengers: Vec<Passenger>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]

--- a/crates/zeph-bench/src/runner.rs
+++ b/crates/zeph-bench/src/runner.rs
@@ -250,6 +250,17 @@ impl BenchRunner {
         E: Evaluator,
     {
         let scenarios = loader.load(path)?;
+
+        if let Some(ref filter) = opts.scenario_filter
+            && !scenarios.iter().any(|s| &s.id == filter)
+        {
+            return Err(BenchError::InvalidFormat(format!(
+                "scenario '{}' not found in dataset '{}'",
+                filter,
+                loader.name()
+            )));
+        }
+
         let model_id = self.provider.model_identifier().to_owned();
 
         let mut run = BenchRun {
@@ -320,6 +331,17 @@ impl BenchRunner {
         X: ToolExecutor + Send + Sync + 'static,
     {
         let scenarios = loader.load(path)?;
+
+        if let Some(ref filter) = opts.scenario_filter
+            && !scenarios.iter().any(|s| &s.id == filter)
+        {
+            return Err(BenchError::InvalidFormat(format!(
+                "scenario '{}' not found in dataset '{}'",
+                filter,
+                loader.name()
+            )));
+        }
+
         let model_id = self.provider.model_identifier().to_owned();
 
         let mut run = BenchRun {

--- a/crates/zeph-llm/src/router/mod.rs
+++ b/crates/zeph-llm/src/router/mod.rs
@@ -1842,6 +1842,11 @@ impl LlmProvider for RouterProvider {
         "router"
     }
 
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn model_identifier(&self) -> &str {
+        "router"
+    }
+
     fn supports_tool_use(&self) -> bool {
         self.state
             .providers


### PR DESCRIPTION
## Summary

- Fix tau2-bench-airline OpenAI 400 errors by replacing `Vec<serde_json::Value>` with typed `FlightSegment`/`Passenger` structs — `schemars` now emits valid `array` schemas with `items`
- Return error with non-zero exit when `--scenario` filter matches no scenarios, instead of silent 0/0 success
- Override `RouterProvider::model_identifier()` to return `"router"` instead of empty string, so `results.json` records a meaningful model field

## Test plan

- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --all-features --lib --bins` — all tests pass
- [ ] `cargo clippy --all-targets --all-features --workspace -- -D warnings` — no warnings
- [ ] tau2-bench-airline live run: `bench run --dataset tau2-bench-airline` should complete without HTTP 400 errors
- [ ] `bench run --scenario NONEXISTENT_ID` should exit non-zero with descriptive error message
- [ ] `results.json` from router-based bench run should contain `"model": "router"` instead of `"model": ""`

Closes #3426
Closes #3427
Closes #3430