### PR TITLE
fix(core): increase shutdown summary timeout and drain cancelled tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   dropped below the `min_injection_score` threshold and making skill injection non-functional.
   A cached dimension (populated at sync time) is checked first; on cache miss the collection is
   probed once and the result cached for subsequent calls. (#3418)
+- `zeph-core`: shutdown summary LLM calls no longer timeout on multi-turn sessions. Increased
+  `shutdown_summary_timeout_secs` default from 10 to 30 (matching `extraction_timeout_secs`) and
+  added a cooperative yield loop between `abort_all()` and `maybe_store_shutdown_summary()` so
+  cancelled enrichment tasks can release their HTTP connections before the summary LLM call
+  competes for the API rate-limit budget. (#3431)
 
 ### Added
 

--- a/crates/zeph-config/src/memory.rs
+++ b/crates/zeph-config/src/memory.rs
@@ -219,7 +219,7 @@ fn default_shutdown_summary_max_messages() -> usize {
 }
 
 fn default_shutdown_summary_timeout_secs() -> u64 {
-    10
+    30
 }
 
 fn validate_tier_similarity_threshold<'de, D>(deserializer: D) -> Result<f32, D::Error>

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -234,7 +234,7 @@ impl Default for Config {
                 shutdown_summary: true,
                 shutdown_summary_min_messages: 4,
                 shutdown_summary_max_messages: 20,
-                shutdown_summary_timeout_secs: 10,
+                shutdown_summary_timeout_secs: 30,
                 structured_summaries: false,
                 tiers: TierConfig::default(),
                 admission: crate::memory::AdmissionConfig::default(),

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -747,6 +747,14 @@ impl<C: Channel> Agent<C> {
         // Abort learning tasks (JoinSet detached at turn boundaries but not on shutdown).
         self.learning_engine.learning_tasks.abort_all();
 
+        // Allow cancelled tasks to release their HTTP connections before the summary LLM call.
+        // abort_all() posts cancellation signals but does not drain tasks; aborted futures only
+        // observe cancellation at their next .await point. Without yielding here the summary
+        // call races in-flight enrichment HTTP connections for the same API rate-limit budget.
+        for _ in 0..4 {
+            tokio::task::yield_now().await;
+        }
+
         self.maybe_store_shutdown_summary().await;
         self.maybe_store_session_digest().await;
 

--- a/crates/zeph-core/src/agent/state/compaction.rs
+++ b/crates/zeph-core/src/agent/state/compaction.rs
@@ -45,7 +45,7 @@ impl Default for MemoryCompactionState {
             shutdown_summary: true,
             shutdown_summary_min_messages: 4,
             shutdown_summary_max_messages: 20,
-            shutdown_summary_timeout_secs: 10,
+            shutdown_summary_timeout_secs: 30,
             structured_summaries: false,
             digest_config: crate::config::DigestConfig::default(),
             cached_session_digest: None,

--- a/crates/zeph-core/src/agent/tests.rs
+++ b/crates/zeph-core/src/agent/tests.rs
@@ -5315,8 +5315,8 @@ mod shutdown_summary_tests {
             "default max_messages must be 20"
         );
         assert_eq!(
-            agent.memory_state.compaction.shutdown_summary_timeout_secs, 10,
-            "default timeout_secs must be 10"
+            agent.memory_state.compaction.shutdown_summary_timeout_secs, 30,
+            "default timeout_secs must be 30"
         );
     }
 


### PR DESCRIPTION
## Summary

- Increase `shutdown_summary_timeout_secs` default from 10 to 30 (matches `extraction_timeout_secs`) in all three locations: `zeph-config/src/memory.rs`, `zeph-config/src/root.rs`, `zeph-core/src/agent/state/compaction.rs`
- Add a 4-iteration `tokio::task::yield_now()` loop between `abort_all()` and `maybe_store_shutdown_summary()` so cancelled enrichment tasks can release HTTP connections before the summary LLM call competes for the API rate-limit budget
- Update test assertion for the new default value

## Root Cause

`abort_all()` posts cancellation signals but does not drain tasks. Aborted enrichment futures (graph/persona/reasoning extraction) keep their in-flight HTTP connections alive until the Tokio scheduler gives them a turn. Without yielding, `maybe_store_shutdown_summary()` starts immediately and races those connections for the OpenAI rate-limit budget — causing both the structured and plain-text LLM calls to timeout at 10s each.

## Test plan

- [ ] `cargo nextest run --config-file .github/nextest.toml -p zeph-core -E 'test(shutdown_summary)'` passes with the updated `timeout_secs == 30` assertion
- [ ] Live session with ≥4 messages: `/exit` should log `shutdown summary stored` within 30s, not timeout

Closes #3431