### PR TITLE
refactor(llm): migrate router and cascade storage to Arc<dyn LlmProviderDyn>

### DIFF
--- a/crates/zeph-llm/src/provider_dyn.rs
+++ b/crates/zeph-llm/src/provider_dyn.rs
@@ -70,7 +70,7 @@ mod private {
 ///
 /// All async methods return [`BoxFuture`] rather than `impl Future + Send`, making this
 /// trait dyn-compatible and usable behind `Arc<dyn LlmProviderDyn>`.
-pub trait LlmProviderDyn: private::Sealed + Send + Sync {
+pub trait LlmProviderDyn: private::Sealed + std::fmt::Debug + Send + Sync {
     /// Report the model's context window size in tokens. `None` if unknown.
     fn context_window(&self) -> Option<usize>;
 
@@ -174,7 +174,7 @@ pub trait LlmProviderDyn: private::Sealed + Send + Sync {
     fn supports_structured_output(&self) -> bool;
 }
 
-impl<T: LlmProvider + Send + Sync + 'static> LlmProviderDyn for T {
+impl<T: LlmProvider + std::fmt::Debug + Send + Sync + 'static> LlmProviderDyn for T {
     fn context_window(&self) -> Option<usize> {
         LlmProvider::context_window(self)
     }
@@ -367,6 +367,7 @@ mod tests {
     use super::*;
     use crate::provider::{ChatStream, StreamChunk};
 
+    #[derive(Debug)]
     struct StubProvider {
         response: String,
     }

--- a/crates/zeph-llm/src/router/cascade.rs
+++ b/crates/zeph-llm/src/router/cascade.rs
@@ -29,8 +29,8 @@ use std::collections::VecDeque;
 
 use serde::{Deserialize, Serialize};
 
-use crate::any::AnyProvider;
-use crate::provider::{LlmProvider, Message, Role};
+use crate::provider::{Message, Role};
+use crate::provider_dyn::LlmProviderDyn;
 
 /// Controls the quality classification strategy.
 ///
@@ -266,7 +266,7 @@ fn coherence_signal(response: &str) -> f64 {
 /// # Errors
 ///
 /// Any `LlmError` from the judge call is swallowed and represented as `None`.
-pub async fn judge_score(judge: &AnyProvider, response: &str) -> Option<f64> {
+pub async fn judge_score(judge: &dyn LlmProviderDyn, response: &str) -> Option<f64> {
     let prompt = format!(
         "Rate the following AI response on a scale from 0 to 10, \
          where 0 is completely useless or degenerate and 10 is high quality and coherent. \

--- a/crates/zeph-llm/src/router/coe.rs
+++ b/crates/zeph-llm/src/router/coe.rs
@@ -15,9 +15,9 @@ use std::time::Duration;
 
 use zeph_common::math::cosine_similarity;
 
-use crate::any::AnyProvider;
 use crate::error::LlmError;
-use crate::provider::{LlmProvider, Message};
+use crate::provider::Message;
+use crate::provider_dyn::LlmProviderDyn;
 
 /// Configuration for the `CoE` subsystem (mirrors `[llm.coe]` in TOML).
 #[derive(Debug, Clone)]
@@ -54,13 +54,13 @@ pub struct CoeMetrics {
 }
 
 /// Runtime `CoE` state bundled into `RouterProvider`.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct CoeRouter {
     pub config: CoeConfig,
     /// The provider used as the secondary/escalation target.
-    pub secondary: AnyProvider,
+    pub secondary: Arc<dyn LlmProviderDyn>,
     /// Provider used for computing inter-divergence embeddings.
-    pub embed: AnyProvider,
+    pub embed: Arc<dyn LlmProviderDyn>,
     pub metrics: Arc<CoeMetrics>,
 }
 
@@ -71,9 +71,11 @@ const MIN_INTER_LEN: usize = 50;
 ///
 /// Returns `None` when either text is shorter than the minimum guard or embedding fails.
 /// `0.0` = identical, `0.5` = orthogonal, `1.0` = opposite.
-pub async fn inter_divergence(primary: &str, secondary: &str, embed: &AnyProvider) -> Option<f32> {
-    use crate::provider::LlmProvider;
-
+pub async fn inter_divergence(
+    primary: &str,
+    secondary: &str,
+    embed: &dyn LlmProviderDyn,
+) -> Option<f32> {
     if primary.len().min(secondary.len()) < MIN_INTER_LEN {
         return None;
     }
@@ -162,7 +164,7 @@ pub async fn run_coe(
     };
 
     // Compute inter-divergence.
-    let divergence = inter_divergence(&primary_text, &secondary_text, &coe.embed).await;
+    let divergence = inter_divergence(&primary_text, &secondary_text, &*coe.embed).await;
 
     let decision = decide(entropy, divergence, &coe.config);
 
@@ -249,8 +251,8 @@ mod tests {
                 inter_threshold: 0.20,
                 shadow_sample_rate: 0.0, // disable random shadow unless explicitly set
             },
-            secondary,
-            embed,
+            secondary: Arc::new(secondary) as Arc<dyn LlmProviderDyn>,
+            embed: Arc::new(embed) as Arc<dyn LlmProviderDyn>,
             metrics: Arc::new(CoeMetrics::default()),
         }
     }

--- a/crates/zeph-llm/src/router/mod.rs
+++ b/crates/zeph-llm/src/router/mod.rs
@@ -238,7 +238,7 @@ pub struct CascadeRouterConfig {
     pub max_cascade_tokens: Option<u32>,
     /// LLM provider used for judge-mode quality scoring.
     /// Required when `classifier_mode = Judge`; falls back to heuristic if `None`.
-    pub summary_provider: Option<AnyProvider>,
+    pub summary_provider: Option<Arc<dyn crate::provider_dyn::LlmProviderDyn>>,
     /// Explicit cost ordering of provider names (cheapest first).
     /// When set, providers are sorted by their position in this list at construction time.
     /// Providers not listed are appended after listed ones in original chain order.
@@ -299,7 +299,7 @@ pub struct RouterProvider {
     bandit_config: Option<BanditRouterConfig>,
     /// Dedicated embedding provider for bandit feature vectors.
     /// When `None`, bandit falls back to Thompson/uniform on embed failure.
-    bandit_embedding_provider: Option<AnyProvider>,
+    bandit_embedding_provider: Option<Arc<dyn crate::provider_dyn::LlmProviderDyn>>,
     /// LRU embedding cache: maps query-string hash to feature vector.
     /// Shared across requests; keyed by `u64` hash of query text.
     bandit_embed_cache: Arc<Mutex<BanditEmbedCache>>,
@@ -401,8 +401,8 @@ impl RouterProvider {
         }
         self.coe = Some(Arc::new(CoeRouter {
             config,
-            secondary,
-            embed,
+            secondary: Arc::new(secondary) as Arc<dyn crate::provider_dyn::LlmProviderDyn>,
+            embed: Arc::new(embed) as Arc<dyn crate::provider_dyn::LlmProviderDyn>,
             metrics: Arc::new(coe::CoeMetrics::default()),
         }));
         self
@@ -537,7 +537,8 @@ impl RouterProvider {
         self.bandit = Some(Arc::new(Mutex::new(state)));
         self.bandit_state_path = Some(path);
         self.bandit_embed_cache = Arc::new(Mutex::new(BanditEmbedCache::new(cache_size)));
-        self.bandit_embedding_provider = embedding_provider;
+        self.bandit_embedding_provider =
+            embedding_provider.map(|p| Arc::new(p) as Arc<dyn crate::provider_dyn::LlmProviderDyn>);
         // Initialize Thompson state for cold-start fallback (total_updates < warmup_queries).
         // Uses default uniform priors; no persistence path needed since it's a fallback only.
         self.thompson = Some(Arc::new(Mutex::new(ThompsonState::default())));
@@ -1261,7 +1262,7 @@ impl RouterProvider {
         response: &str,
         threshold: f64,
         mode: ClassifierMode,
-        summary_provider: Option<&AnyProvider>,
+        summary_provider: Option<&dyn crate::provider_dyn::LlmProviderDyn>,
     ) -> cascade::QualityVerdict {
         if mode == ClassifierMode::Judge {
             if let Some(judge) = summary_provider {
@@ -2051,7 +2052,7 @@ async fn cascade_evaluate_response(
         response,
         cfg.quality_threshold,
         cfg.classifier_mode,
-        cfg.summary_provider.as_ref(),
+        cfg.summary_provider.as_deref(),
     )
     .await;
 

--- a/src/bootstrap/provider.rs
+++ b/src/bootstrap/provider.rs
@@ -3,8 +3,11 @@
 
 pub use zeph_core::provider_factory::{BootstrapError, build_provider_from_entry};
 
+use std::sync::Arc;
+
 use zeph_llm::any::AnyProvider;
 use zeph_llm::ollama::OllamaProvider;
+use zeph_llm::provider_dyn::LlmProviderDyn;
 use zeph_llm::router::cascade::ClassifierMode;
 use zeph_llm::router::coe::CoeConfig as RouterCoeConfig;
 use zeph_llm::router::triage::{ComplexityTier, TriageRouter};
@@ -60,28 +63,29 @@ fn build_cascade_router_config(
         );
     }
     // Build summary provider for judge mode.
-    let summary_provider = if classifier_mode == ClassifierMode::Judge {
-        if let Some(model_spec) = config.llm.summary_model.as_deref() {
-            match create_summary_provider(model_spec, config) {
-                Ok(p) => Some(p),
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        "cascade: failed to build judge provider, falling back to heuristic"
-                    );
-                    None
+    let summary_provider: Option<Arc<dyn LlmProviderDyn>> =
+        if classifier_mode == ClassifierMode::Judge {
+            if let Some(model_spec) = config.llm.summary_model.as_deref() {
+                match create_summary_provider(model_spec, config) {
+                    Ok(p) => Some(Arc::new(p) as Arc<dyn LlmProviderDyn>),
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            "cascade: failed to build judge provider, falling back to heuristic"
+                        );
+                        None
+                    }
                 }
+            } else {
+                tracing::warn!(
+                    "cascade: classifier_mode=judge requires [llm] summary_model to \
+                     be configured; falling back to heuristic"
+                );
+                None
             }
         } else {
-            tracing::warn!(
-                "cascade: classifier_mode=judge requires [llm] summary_model to \
-                 be configured; falling back to heuristic"
-            );
             None
-        }
-    } else {
-        None
-    };
+        };
     CascadeRouterConfig {
         quality_threshold,
         max_escalations: cascade_cfg.max_escalations,


### PR DESCRIPTION
## Summary

Migrates the router and cascade hot-path storage from `AnyProvider` to `Arc<dyn LlmProviderDyn>`. Builds on #3461.

- `CascadeRouterConfig::summary_provider` → `Arc<dyn LlmProviderDyn>`
- `RouterProvider::bandit_embedding_provider` → `Arc<dyn LlmProviderDyn>`
- `CoeRouter::{secondary,embed}` → `Arc<dyn LlmProviderDyn>`
- `cascade.rs: judge_score` parameter → `&dyn LlmProviderDyn`
- Public constructors wrap `AnyProvider` internally so callers require no changes
- Full `AnyProvider→dyn` migration (~880 remaining sites) deferred to `epic/m49+/anyprovider-deprecation`

## Test plan

- [ ] `cargo check --workspace` clean
- [ ] `cargo clippy -p zeph-llm -- -D warnings` clean
- [ ] 8608 workspace tests pass