### PR TITLE
chore: replace TODO(review) markers with tracked GitHub issue refs

### DIFF
--- a/crates/zeph-acp/src/agent/mod.rs
+++ b/crates/zeph-acp/src/agent/mod.rs
@@ -1042,7 +1042,7 @@ impl ZephAcpAgentState {
 
     #[allow(clippy::too_many_lines)]
     // TODO(B2): extract sub-functions or move logic to reduce function length
-    // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    // long function; decomposition would require extracting state into additional structs — TODO(#3459): decompose into smaller helpers
     #[tracing::instrument(skip_all, name = "acp.handler.new_session")]
     pub(crate) async fn do_new_session(
         &self,
@@ -1165,7 +1165,7 @@ impl ZephAcpAgentState {
     }
 
     #[tracing::instrument(skip_all, name = "acp.handler.prompt", fields(session_id = %args.session_id))]
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3459): decompose into smaller helpers
     pub(crate) async fn do_prompt(
         &self,
         args: acp::schema::PromptRequest,
@@ -2707,7 +2707,7 @@ pub(crate) mod handlers;
 /// ).await
 /// # }
 /// ```
-#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3459): decompose into smaller helpers
 pub async fn run_agent(
     state: Arc<ZephAcpAgentState>,
     transport: impl acp::ConnectTo<acp::Agent>,

--- a/crates/zeph-channels/src/telegram.rs
+++ b/crates/zeph-channels/src/telegram.rs
@@ -173,7 +173,7 @@ impl TelegramChannel {
     /// # Errors
     ///
     /// Returns an error if the bot cannot be initialized.
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3445): decompose into smaller helpers
     pub fn start(mut self) -> Result<Self, ChannelError> {
         if self.allowed_users.is_empty() {
             tracing::error!("telegram.allowed_users is empty; refusing to start an open bot");

--- a/crates/zeph-config/src/loader.rs
+++ b/crates/zeph-config/src/loader.rs
@@ -61,7 +61,7 @@ impl Config {
     /// # Errors
     ///
     /// Returns an error if any value is out of range.
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3438): decompose into smaller helpers
     pub fn validate(&self) -> Result<(), ConfigError> {
         if self.memory.history_limit > 10_000 {
             return Err(ConfigError::Validation(format!(
@@ -325,7 +325,7 @@ impl Config {
         Ok(())
     }
 
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3438): decompose into smaller helpers
     fn validate_provider_names(&self) -> Result<(), ConfigError> {
         use std::collections::HashSet;
         let known: HashSet<String> = self

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -1102,7 +1102,7 @@ fn replace_llm_section(toml_str: &str, new_llm_section: &str) -> String {
 /// Returns `MigrateError::Parse` if the input TOML is invalid.
 /// Returns `MigrateError::InvalidStructure` if `[llm.stt].model` is present but the `[llm]`
 /// key is absent or not a table, making mutation impossible.
-#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3438): decompose into smaller helpers
 pub fn migrate_stt_to_provider(toml_src: &str) -> Result<MigrationResult, MigrateError> {
     let mut doc = toml_src.parse::<toml_edit::DocumentMut>()?;
 

--- a/crates/zeph-context/src/assembler.rs
+++ b/crates/zeph-context/src/assembler.rs
@@ -87,7 +87,7 @@ impl ContextAssembler {
     /// # Errors
     ///
     /// Propagates errors from any async fetch operation.
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3442): decompose into smaller helpers
     pub async fn gather(input: &ContextAssemblyInput<'_>) -> Result<PreparedContext, ContextError> {
         type CtxFuture<'a> =
             Pin<Box<dyn Future<Output = Result<ContextSlot, ContextError>> + Send + 'a>>;

--- a/crates/zeph-context/src/summarization.rs
+++ b/crates/zeph-context/src/summarization.rs
@@ -129,7 +129,7 @@ pub async fn single_pass_summary(
 ///
 /// # Errors
 /// Returns [`zeph_llm::LlmError`] when all summarization attempts fail.
-#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3442): decompose into smaller helpers
 pub async fn summarize_with_llm(
     deps: &SummarizationDeps,
     messages: &[Message],

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -481,7 +481,7 @@ impl<C: Channel> Agent<C> {
 
         // #3305 — Compression spectrum: compute remaining token ratio and advise recall tiers.
         //
-        // TODO(review): plumb `active_levels` into `ContextAssemblyInput` so the context
+        // TODO(#3455): plumb `active_levels` into `ContextAssemblyInput` so the context
         // assembler can skip expensive episodic recall when the budget is tight.
         // Requires a `retrieval_levels: &[CompressionLevel]` field in
         // `zeph_context::input::ContextAssemblyInput`.  Tracked as non-blocking out-of-scope item.

--- a/crates/zeph-core/src/agent/context/summarization/compaction.rs
+++ b/crates/zeph-core/src/agent/context/summarization/compaction.rs
@@ -8,7 +8,7 @@ use crate::agent::context::CompactionOutcome;
 use crate::channel::Channel;
 
 impl<C: Channel> Agent<C> {
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3456): decompose into smaller helpers
     pub(in crate::agent) async fn compact_context(
         &mut self,
     ) -> Result<CompactionOutcome, crate::agent::error::AgentError> {

--- a/crates/zeph-core/src/agent/context/summarization/scheduling.rs
+++ b/crates/zeph-core/src/agent/context/summarization/scheduling.rs
@@ -783,7 +783,7 @@ impl<C: Channel> Agent<C> {
     ///
     /// This eliminates the 5-second latency spike on every Soft tier compaction that made
     /// `task_aware`/`mig` strategies non-functional for cloud LLM providers.
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3456): decompose into smaller helpers
     pub(in crate::agent) fn maybe_refresh_task_goal(&mut self) {
         use std::hash::Hash as _;
 
@@ -969,7 +969,7 @@ impl<C: Channel> Agent<C> {
     /// Transition detection: the LLM's `COMPLETED:` signal drives transitions (S3 fix).
     /// When `COMPLETED: NONE`, the same subgoal continues (`extend_active`).
     /// When `COMPLETED:` is non-NONE, a new subgoal is created (`complete_active` + `push_active`).
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3456): decompose into smaller helpers
     pub(in crate::agent) fn maybe_refresh_subgoal(&mut self) {
         use std::hash::Hash as _;
 

--- a/crates/zeph-core/src/agent/corrections.rs
+++ b/crates/zeph-core/src/agent/corrections.rs
@@ -90,7 +90,7 @@ impl<C: crate::channel::Channel> Agent<C> {
     /// Tasks are supervised via [`BackgroundSupervisor`] (`TaskClass::Enrichment`).
     /// If the concurrency limit is reached, the correction check is silently dropped —
     /// corrections are non-critical lossy data.
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3453): decompose into smaller helpers
     pub(super) fn spawn_judge_correction_check(
         &mut self,
         trimmed: &str,
@@ -219,7 +219,7 @@ impl<C: crate::channel::Channel> Agent<C> {
     /// regex result is borderline, the LLM judge runs in a background task (non-blocking).
     /// When `DetectorMode::Model` and an `LlmClassifier` is attached, the LLM classifier is
     /// used instead of `JudgeDetector`, sharing the same adaptive thresholds and rate limiter.
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3453): decompose into smaller helpers
     pub(super) async fn detect_and_record_corrections(
         &mut self,
         trimmed: &str,

--- a/crates/zeph-core/src/agent/learning/skill_commands.rs
+++ b/crates/zeph-core/src/agent/learning/skill_commands.rs
@@ -72,7 +72,7 @@ impl<C: Channel> Agent<C> {
     /// Non-interactive: the skill is saved immediately with quarantined trust level.
     /// The generated preview is returned in the output so the user can review it.
     /// Use `/skill remove <name>` to discard an unwanted skill.
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3457): decompose into smaller helpers
     async fn handle_skill_create_as_string(
         &mut self,
         description: &str,

--- a/crates/zeph-core/src/agent/learning/trust.rs
+++ b/crates/zeph-core/src/agent/learning/trust.rs
@@ -18,7 +18,7 @@ impl<C: Channel> Agent<C> {
         }
     }
 
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3457): decompose into smaller helpers
     async fn check_trust_transition_inner(&self, skill_name: &str) {
         let Some(memory) = &self.memory_state.persistence.memory else {
             return;

--- a/crates/zeph-core/src/agent/mcp.rs
+++ b/crates/zeph-core/src/agent/mcp.rs
@@ -25,7 +25,7 @@ impl<C: Channel> Agent<C> {
         }
     }
 
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3453): decompose into smaller helpers
     async fn handle_mcp_add(&mut self, args: &[&str]) -> Result<String, super::error::AgentError> {
         if args.len() < 2 {
             return Ok("Usage: /mcp add <id> <command> [args...] | /mcp add <id> <url>".to_owned());

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -2173,7 +2173,7 @@ impl<C: Channel> Agent<C> {
         }
     }
 
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3453): decompose into smaller helpers
     async fn handle_agent_command(&mut self, cmd: zeph_subagent::AgentCommand) -> Option<String> {
         use zeph_subagent::AgentCommand;
 
@@ -2862,7 +2862,7 @@ impl<C: Channel> Agent<C> {
     /// Phase 2 (schedule, this turn): rebuild cursors and spawn a background `tokio::spawn`
     /// task for the LLM call. The result is stored in `pending_sidequest_result` and applied
     /// next turn, so the current agent turn is never blocked by the LLM call.
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3453): decompose into smaller helpers
     fn maybe_sidequest_eviction(&mut self) {
         use zeph_llm::provider::{Message, MessageMetadata, Role};
 

--- a/crates/zeph-core/src/agent/persistence.rs
+++ b/crates/zeph-core/src/agent/persistence.rs
@@ -438,7 +438,7 @@ impl<C: Channel> Agent<C> {
     /// is saved for conversation continuity but will not pollute semantic search (M2, D2).
     #[allow(clippy::too_many_lines)]
     // TODO(B2): extract sub-functions or move logic to reduce function length
-    // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    // long function; decomposition would require extracting state into additional structs — TODO(#3453): decompose into smaller helpers
     #[cfg_attr(
         feature = "profiling",
         tracing::instrument(name = "agent.persist_message", skip_all)
@@ -666,7 +666,7 @@ impl<C: Channel> Agent<C> {
     ///
     /// Guards (enabled check, injection/tool-result skip) stay on the foreground path.
     /// The RPE check and actual extraction run in background (S2: no `send_status`).
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3453): decompose into smaller helpers
     async fn enqueue_graph_extraction_task(
         &mut self,
         content: &str,

--- a/crates/zeph-core/src/agent/plan.rs
+++ b/crates/zeph-core/src/agent/plan.rs
@@ -435,7 +435,7 @@ impl<C: crate::channel::Channel> Agent<C> {
         }
     }
 
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3453): decompose into smaller helpers
     pub(super) async fn finalize_plan_execution(
         &mut self,
         completed_graph: zeph_orchestration::TaskGraph,
@@ -624,7 +624,7 @@ impl<C: crate::channel::Channel> Agent<C> {
 
     // ----- _as_string variants (used by AgentAccess / CommandHandler) -----
 
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3453): decompose into smaller helpers
     pub(super) async fn handle_plan_goal_as_string(
         &mut self,
         goal: &str,
@@ -805,7 +805,7 @@ impl<C: crate::channel::Channel> Agent<C> {
     }
 
     // too_many_lines: sequential status×action dispatch table; branching is inherent
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3453): decompose into smaller helpers
     pub(super) async fn handle_plan_resume_as_string(&mut self, graph_id: Option<&str>) -> String {
         use zeph_orchestration::{GraphId, GraphStatus, TaskStatus};
 

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -233,7 +233,7 @@ impl<C: crate::channel::Channel> Agent<C> {
     // cannot be split without introducing shared mutable state across async boundaries.
     #[allow(clippy::too_many_lines)]
     // TODO(B2): extract sub-functions or move logic to reduce function length
-    // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    // long function; decomposition would require extracting state into additional structs — TODO(#3453): decompose into smaller helpers
     /// Drive the [`DagScheduler`] tick loop until it emits `SchedulerAction::Done`.
     ///
     /// Each iteration yields at `wait_event()`, during which `channel.recv()` is polled

--- a/crates/zeph-core/src/agent/slash_commands.rs
+++ b/crates/zeph-core/src/agent/slash_commands.rs
@@ -164,7 +164,7 @@ impl<C: crate::channel::Channel> Agent<C> {
     }
 
     /// Return formatted session status string for use via [`AgentAccess::session_status`].
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3453): decompose into smaller helpers
     pub(super) fn handle_status_as_string(&mut self) -> String {
         use std::fmt::Write;
         use zeph_llm::provider::Role;

--- a/crates/zeph-core/src/agent/state/security.rs
+++ b/crates/zeph-core/src/agent/state/security.rs
@@ -71,7 +71,7 @@ impl SecurityState {
     /// Returns a [`PiiScrubResult`] with the scrubbed text and metric side-effects.
     /// The caller is responsible for applying metrics updates from the result.
     #[cfg_attr(not(feature = "classifiers"), allow(clippy::unused_async))]
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3457): decompose into smaller helpers
     pub(crate) async fn scrub_pii(&mut self, text: &str, tool_name: &str) -> PiiScrubResult {
         use zeph_sanitizer::pii::{merge_spans, redact_spans};
 

--- a/crates/zeph-core/src/agent/tests.rs
+++ b/crates/zeph-core/src/agent/tests.rs
@@ -5465,7 +5465,7 @@ mod shutdown_summary_tests {
     // tool_a returns [error], triggering self-reflection which calls chat() → Text.
     // tool_b returns success with FilterStats. The remaining-tools loop processes tool_b.
     #[tokio::test]
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3453): decompose into smaller helpers
     async fn filter_stats_metrics_recorded_in_self_reflection_remaining_tools_loop() {
         use crate::config::LearningConfig;
         use crate::metrics::MetricsSnapshot;

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -510,7 +510,7 @@ impl<C: Channel> Agent<C> {
     }
 
     #[cfg(test)]
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3454): decompose into smaller helpers
     async fn process_successful_tool_output(
         &mut self,
         output: zeph_tools::executor::ToolOutput,
@@ -830,7 +830,7 @@ impl<C: Channel> Agent<C> {
         Ok(None)
     }
 
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3454): decompose into smaller helpers
     async fn call_chat_with_tools(
         &mut self,
         tool_defs: &[ToolDefinition],
@@ -1119,7 +1119,7 @@ impl<C: Channel> Agent<C> {
 
     #[allow(clippy::too_many_lines)]
     // TODO(B2): extract sub-functions or move logic to reduce function length
-    // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    // long function; decomposition would require extracting state into additional structs — TODO(#3454): decompose into smaller helpers
     // parallel tool execution with DAG scheduling, retry, self-reflection, cancellation — inherently sequential control flow
     #[cfg_attr(
         feature = "profiling",
@@ -2886,7 +2886,7 @@ impl<C: Channel> Agent<C> {
     /// If `complete_focus` is called without an active focus session, or the checkpoint marker
     /// is not found in the message history, an `[error]` result is returned to the LLM so it
     /// knows the state is invalid rather than silently succeeding.
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3454): decompose into smaller helpers
     pub(crate) fn handle_focus_tool(
         &mut self,
         tool_name: &str,
@@ -3053,7 +3053,7 @@ impl<C: Channel> Agent<C> {
     /// Guards:
     /// - Returns error if a focus session is active (would interfere with focus boundaries).
     /// - Returns error if a compression is already in progress (concurrency guard).
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3454): decompose into smaller helpers
     pub(crate) async fn handle_compress_context(&mut self) -> String {
         use zeph_llm::provider::LlmProvider as _;
 

--- a/crates/zeph-core/src/agent/tool_execution/sanitize.rs
+++ b/crates/zeph-core/src/agent/tool_execution/sanitize.rs
@@ -58,7 +58,7 @@ impl<C: Channel> Agent<C> {
     ///
     /// This is the SOLE sanitization point for tool output data flows. Do not add
     /// redundant sanitization in leaf crates (zeph-tools, zeph-mcp).
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3454): decompose into smaller helpers
     pub(super) async fn sanitize_tool_output(
         &mut self,
         body: &str,

--- a/crates/zeph-core/src/agent/tool_execution/tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests.rs
@@ -2897,7 +2897,7 @@ async fn self_reflection_single_tool_failure_produces_one_tool_result() {
 // Second tool fails → reflection fires → early return must append ToolResult for 2nd (is_error)
 // and a synthetic [skipped] ToolResult for the 3rd. Total: 3 ToolResults for 3 ToolUses.
 #[tokio::test]
-#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3454): decompose into smaller helpers
 async fn self_reflection_middle_tool_failure_no_orphans() {
     use std::sync::{Arc, Mutex};
 
@@ -3566,7 +3566,7 @@ async fn transient_error_on_non_retryable_executor_is_not_retried() {
 // tool[2] is non-retryable-transient-always-fail. Verifies all three complete with
 // the correct outcome and the retry fires only for tool[1].
 #[tokio::test]
-#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3454): decompose into smaller helpers
 async fn mixed_retryable_and_non_retryable_batch() {
     use super::super::agent_tests::{MockChannel, create_test_registry, mock_provider};
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -4290,7 +4290,7 @@ async fn sanitize_tool_output_memory_save_still_uses_tool_result() {
 // After the fix, both ToolResults must be present in a single User message that immediately
 // follows the Assistant{ToolUse} message, with no interleaved messages in between.
 #[tokio::test]
-#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3454): decompose into smaller helpers
 async fn test_parallel_tool_calls_permanent_error_emits_tool_result() {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};

--- a/crates/zeph-core/src/provider_factory.rs
+++ b/crates/zeph-core/src/provider_factory.rs
@@ -88,7 +88,7 @@ pub fn build_provider_for_switch(
 ///
 /// Returns `BootstrapError::Provider` when a required secret is missing or an entry is
 /// misconfigured (e.g. compatible provider without a name).
-#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3452): decompose into smaller helpers
 pub fn build_provider_from_entry(
     entry: &ProviderEntry,
     config: &Config,

--- a/crates/zeph-index/src/indexer.rs
+++ b/crates/zeph-index/src/indexer.rs
@@ -244,7 +244,7 @@ impl CodeIndexer {
     /// # Errors
     ///
     /// Returns an error if the embedding probe or collection setup fails.
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3458): decompose into smaller helpers
     pub async fn index_project(
         &self,
         root: &Path,

--- a/crates/zeph-llm/src/classifier/ner.rs
+++ b/crates/zeph-llm/src/classifier/ner.rs
@@ -215,7 +215,7 @@ impl CandleNerClassifier {
     /// - `S-X` is a single-token span of type X.
     /// - `E-X` closes an open span of type X.
     /// - `O` closes any open span.
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3440): decompose into smaller helpers
     fn decode_bio_spans(
         id2label: &[String],
         token_labels: &[(usize, f32)],

--- a/crates/zeph-mcp/src/manager.rs
+++ b/crates/zeph-mcp/src/manager.rs
@@ -645,7 +645,7 @@ impl McpManager {
         feature = "profiling",
         tracing::instrument(name = "mcp.connect_all", skip_all, fields(connected = tracing::field::Empty, failed = tracing::field::Empty))
     )]
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3451): decompose into smaller helpers
     pub async fn connect_all(&self) -> (Vec<McpTool>, Vec<ServerConnectOutcome>) {
         let allowed = self.allowed_commands.clone();
         let suppress = self.suppress_stderr;
@@ -773,7 +773,7 @@ impl McpManager {
     ///
     /// # Panics
     ///
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3451): decompose into smaller helpers
     pub async fn connect_oauth_deferred(&self) {
         let last_refresh = Arc::clone(&self.last_refresh);
         let limits = IngestLimits {
@@ -1197,7 +1197,7 @@ impl McpManager {
     ///
     /// # Panics
     ///
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3451): decompose into smaller helpers
     pub async fn add_server(&self, entry: &ServerEntry) -> Result<Vec<McpTool>, McpError> {
         // Early check under read lock (fast path for duplicates)
         {

--- a/crates/zeph-memory/src/consolidation.rs
+++ b/crates/zeph-memory/src/consolidation.rs
@@ -144,7 +144,7 @@ pub async fn start_consolidation_loop(
     feature = "profiling",
     tracing::instrument(name = "memory.consolidation_loop", skip_all)
 )]
-#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3443): decompose into smaller helpers
 pub async fn run_consolidation_sweep(
     store: &SqliteStore,
     provider: &AnyProvider,

--- a/crates/zeph-memory/src/embedding_registry.rs
+++ b/crates/zeph-memory/src/embedding_registry.rs
@@ -167,7 +167,7 @@ impl EmbeddingRegistry {
     /// # Errors
     ///
     /// Returns [`EmbeddingRegistryError`] on Qdrant or embedding failures.
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3443): decompose into smaller helpers
     pub async fn sync<T: Embeddable>(
         &mut self,
         items: &[T],

--- a/crates/zeph-memory/src/graph/activation.rs
+++ b/crates/zeph-memory/src/graph/activation.rs
@@ -481,7 +481,7 @@ impl SpreadingActivation {
     /// # Errors
     ///
     /// Returns an error if any database query fails.
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3443): decompose into smaller helpers
     pub async fn spread(
         &self,
         store: &GraphStore,

--- a/crates/zeph-memory/src/graph/store/mod.rs
+++ b/crates/zeph-memory/src/graph/store/mod.rs
@@ -1079,7 +1079,7 @@ impl GraphStore {
     /// # Errors
     ///
     /// Returns an error if the database query fails.
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3443): decompose into smaller helpers
     pub async fn find_entities_ranked(
         &self,
         query: &str,
@@ -2436,7 +2436,7 @@ impl GraphStore {
     #[allow(clippy::too_many_arguments)]
     // TODO(B3): refactor into a builder or config struct to reduce argument count
     // function with many required inputs; a *Params struct would be more verbose without simplifying the call site
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3443): decompose into smaller helpers
     pub async fn insert_or_supersede_with_metrics(
         &self,
         source_entity_id: i64,

--- a/crates/zeph-memory/src/graph/store/tests.rs
+++ b/crates/zeph-memory/src/graph/store/tests.rs
@@ -863,7 +863,7 @@ async fn orphan_alias_cleanup_on_entity_delete() {
 /// - `graph_edges` survive (FK cascade did not wipe them)
 #[tokio::test]
 #[cfg(feature = "sqlite")]
-#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3443): decompose into smaller helpers
 async fn migration_024_backfill_preserves_entities_and_edges() {
     use sqlx::Acquire as _;
     use sqlx::ConnectOptions as _;

--- a/crates/zeph-memory/src/semantic/graph.rs
+++ b/crates/zeph-memory/src/semantic/graph.rs
@@ -125,7 +125,7 @@ struct EntityWorkItem {
 ///    directions is only inserted once, keeping `edges_created` accurate.
 ///
 /// Errors are logged and not propagated — this is a best-effort background enrichment step.
-#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3443): decompose into smaller helpers
 pub async fn link_memory_notes(
     entity_ids: &[i64],
     pool: DbPool,
@@ -289,7 +289,7 @@ pub async fn link_memory_notes(
     feature = "profiling",
     tracing::instrument(name = "memory.graph_extract", skip_all, fields(entities = tracing::field::Empty, edges = tracing::field::Empty))
 )]
-#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3443): decompose into smaller helpers
 pub async fn extract_and_store(
     content: String,
     context_messages: Vec<String>,
@@ -472,7 +472,7 @@ impl SemanticMemory {
     /// When `config.note_linking.enabled` is `true` and an embedding store is available,
     /// `link_memory_notes` runs after successful extraction inside the same task, bounded
     /// by `config.note_linking.timeout_secs`.
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3443): decompose into smaller helpers
     pub fn spawn_graph_extraction(
         &self,
         content: String,

--- a/crates/zeph-memory/src/semantic/mod.rs
+++ b/crates/zeph-memory/src/semantic/mod.rs
@@ -1156,7 +1156,7 @@ impl SemanticMemory {
     /// # Errors
     ///
     /// Returns [`MemoryError`] if the underlying `SQLite` query fails.
-    // TODO(review): populate embeddings by fetching from Qdrant when available.
+    // TODO(#3444): populate embeddings by fetching from Qdrant when available.
     pub async fn load_promotion_window(
         &self,
         max_items: usize,

--- a/crates/zeph-orchestration/src/scheduler.rs
+++ b/crates/zeph-orchestration/src/scheduler.rs
@@ -815,7 +815,7 @@ impl DagScheduler {
     /// Process pending events and produce actions for the caller.
     ///
     /// Call `wait_event` after processing all actions to block until the next event.
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3441): decompose into smaller helpers
     pub fn tick(&mut self) -> Vec<SchedulerAction> {
         if self.graph.status != GraphStatus::Running {
             return vec![SchedulerAction::Done {
@@ -1338,7 +1338,7 @@ impl DagScheduler {
 
 impl DagScheduler {
     /// Process a single `TaskEvent` and return any cancel actions needed.
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3441): decompose into smaller helpers
     fn process_event(&mut self, event: TaskEvent) -> Vec<SchedulerAction> {
         let TaskEvent {
             task_id,

--- a/crates/zeph-sanitizer/src/sanitizer.rs
+++ b/crates/zeph-sanitizer/src/sanitizer.rs
@@ -553,7 +553,7 @@ impl ContentSanitizer {
     ///
     /// When no classifier backend is attached, also falls back to regex detection.
     #[cfg(feature = "classifiers")]
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3439): decompose into smaller helpers
     pub async fn classify_injection(&self, text: &str) -> InjectionVerdict {
         if !self.enabled {
             if Self::detect_injections(text).is_empty() {

--- a/crates/zeph-subagent/src/agent_loop.rs
+++ b/crates/zeph-subagent/src/agent_loop.rs
@@ -198,7 +198,7 @@ async fn handle_tool_step(
     }
 }
 
-#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3447): decompose into smaller helpers
 pub(super) async fn run_agent_loop(
     args: AgentLoopArgs,
 ) -> Result<String, super::error::SubAgentError> {

--- a/crates/zeph-tools/src/scrape.rs
+++ b/crates/zeph-tools/src/scrape.rs
@@ -318,7 +318,7 @@ impl ToolExecutor for WebScrapeExecutor {
         feature = "profiling",
         tracing::instrument(name = "tool.web_scrape", skip_all)
     )]
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3450): decompose into smaller helpers
     async fn execute_tool_call(&self, call: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
         match call.tool_id.as_str() {
             "web_scrape" => {

--- a/crates/zeph-tools/src/shell/background.rs
+++ b/crates/zeph-tools/src/shell/background.rs
@@ -43,13 +43,13 @@ pub(crate) struct BackgroundHandle {
     /// Command string, stored for shutdown reporting and TUI display.
     pub command: String,
     /// Wall-clock start time for elapsed reporting.
-    // TODO(review): expose via TUI panel for per-run elapsed display.
+    // TODO(#3448): expose via TUI panel for per-run elapsed display.
     #[allow(dead_code)]
     pub started_at: Instant,
     /// Cancellation token. Cancel to request graceful shutdown.
     pub abort: CancellationToken,
     /// OS process ID, if known. Reserved for future SIGTERM escalation on shutdown.
-    // TODO(review): use once safe signal-sending wrapper (e.g. nix crate) is available.
+    // TODO(#3449): use once safe signal-sending wrapper (e.g. nix crate) is available.
     #[allow(dead_code)]
     pub child_pid: Option<u32>,
 }

--- a/crates/zeph-tools/src/shell/mod.rs
+++ b/crates/zeph-tools/src/shell/mod.rs
@@ -469,7 +469,7 @@ impl ShellExecutor {
         }))
     }
 
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3450): decompose into smaller helpers
     async fn execute_block(
         &self,
         block: &str,
@@ -1124,7 +1124,7 @@ impl ShellExecutor {
     /// SIGTERM/SIGKILL escalation is deferred to a future enhancement
     /// (requires a safe OS-signal abstraction). The `CancellationToken` is
     /// sufficient for the process-local case.
-    // TODO(review): add SIGTERM+SIGKILL escalation via a safe signal wrapper (e.g. nix crate).
+    // TODO(#3449): add SIGTERM+SIGKILL escalation via a safe signal wrapper (e.g. nix crate).
     pub async fn shutdown(&self) {
         use std::sync::atomic::Ordering;
 
@@ -1542,7 +1542,7 @@ pub struct ShellOutputEnvelope {
     pub truncated: bool,
 }
 
-#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3450): decompose into smaller helpers
 async fn execute_bash(
     code: &str,
     timeout: Duration,

--- a/crates/zeph-tui/src/app/keys.rs
+++ b/crates/zeph-tui/src/app/keys.rs
@@ -237,7 +237,7 @@ impl App {
         }
     }
 
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3446): decompose into smaller helpers
     fn execute_plan_graph_command(&mut self, cmd: TuiCommand) {
         match cmd {
             TuiCommand::PlanStatus => {
@@ -804,7 +804,7 @@ impl App {
         }
     }
 
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3446): decompose into smaller helpers
     fn handle_insert_key(&mut self, key: KeyEvent) {
         if self.slash_autocomplete.is_some() {
             self.handle_slash_autocomplete_key(key);

--- a/crates/zeph-tui/src/command.rs
+++ b/crates/zeph-tui/src/command.rs
@@ -159,7 +159,7 @@ pub struct CommandEntry {
 /// assert!(registry.iter().any(|e| e.id == "app:quit"));
 /// ```
 #[must_use]
-#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3446): decompose into smaller helpers
 pub fn command_registry() -> &'static [CommandEntry] {
     static COMMANDS: &[CommandEntry] = &[
         CommandEntry {

--- a/crates/zeph-tui/src/widgets/resources.rs
+++ b/crates/zeph-tui/src/widgets/resources.rs
@@ -9,7 +9,7 @@ use ratatui::widgets::{Block, Borders, Paragraph};
 use crate::metrics::MetricsSnapshot;
 use crate::theme::Theme;
 
-#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3446): decompose into smaller helpers
 pub fn render(metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect) {
     let theme = Theme::default();
 

--- a/crates/zeph-tui/src/widgets/security.rs
+++ b/crates/zeph-tui/src/widgets/security.rs
@@ -57,7 +57,7 @@ pub fn render(metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect) {
     frame.render_widget(list, inner);
 }
 
-#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3446): decompose into smaller helpers
 fn build_metric_items<'a>(
     metrics: &MetricsSnapshot,
     base: Style,

--- a/crates/zeph-tui/src/widgets/status.rs
+++ b/crates/zeph-tui/src/widgets/status.rs
@@ -11,7 +11,7 @@ use crate::app::{App, InputMode};
 use crate::metrics::MetricsSnapshot;
 use crate::theme::Theme;
 
-#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(review): file a tracking issue for this decomposition
+#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3446): decompose into smaller helpers
 pub fn render(app: &App, metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect) {
     let theme = Theme::default();
 


### PR DESCRIPTION
## Summary

Converts all 70 `TODO(review)` markers in the codebase to `TODO(#N)` references.

- Filed 22 GitHub issues (#3438–#3459) labeled `tech-debt,P3`
- Related markers in the same subsystem are consolidated into a single issue
- Zero `TODO(review)` markers remain in codebase

## Issue mapping

| Issues | Subsystem |
|--------|-----------|
| #3438–#3442 | config, sanitizer, llm-NER, orchestration, context |
| #3443–#3447 | memory, channels, tui, subagent |
| #3448–#3454 | functional improvements (shell, tools, mcp, provider_factory, agent) |
| #3455–#3459 | context assembly, learning, index, acp |

## Test plan

- [ ] `grep -rn "TODO(review)" crates/` returns empty
- [ ] `cargo check --workspace` clean