### PR TITLE
feat(a2a): wire AgentCard modality capabilities at bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- A2A: `AgentCard` served at `/.well-known/agent.json` now accurately reflects the agent's
+  modality capabilities. `capabilities.images` is set from `provider.supports_vision()`;
+  `capabilities.audio` is set when an STT provider is configured (`[llm.stt]`);
+  `capabilities.files` is controlled by the new `[a2a] advertise_files = false` config field
+  (opt-in, default `false` — set `true` only when skills or MCP tools can ingest file parts).
+  Card construction is extracted into a private `build_default_card` helper in `daemon.rs`
+  for testability. (#3378)
+
 ### Fixed
 
 - `zeph-bench`: `BookReservationParams`, `UpdateReservationFlightsParams`, and

--- a/crates/zeph-config/src/channels.rs
+++ b/crates/zeph-config/src/channels.rs
@@ -290,6 +290,11 @@ fn default_ibct_ttl() -> u64 {
     300
 }
 
+/// A2A server configuration, nested under `[a2a]` in TOML.
+///
+/// Controls the Agent-to-Agent HTTP server that exposes the agent via the A2A protocol.
+/// The `AgentCard` served at `/.well-known/agent.json` is built from these settings combined
+/// with runtime-detected capabilities (`images`, `audio`) and the opt-in `advertise_files` flag.
 #[derive(Deserialize, Serialize)]
 #[allow(clippy::struct_excessive_bools)] // config struct — boolean flags are idiomatic here
 pub struct A2aServerConfig {
@@ -334,6 +339,21 @@ pub struct A2aServerConfig {
     /// TTL (seconds) for issued IBCT tokens. Default: 300 (5 minutes).
     #[serde(default = "default_ibct_ttl")]
     pub ibct_ttl_secs: u64,
+    /// Advertise non-media file attachment capability on the `AgentCard`.
+    ///
+    /// When `true`, the served `/.well-known/agent.json` sets `capabilities.files = true`,
+    /// signalling to peer agents that this agent can receive `Part::File` entries that are
+    /// not image or audio (e.g., documents, archives).
+    ///
+    /// Default `false` because generic file attachments have no built-in ingestion path in
+    /// the current agent loop. Set to `true` only when the deployed agent has skills or MCP
+    /// tools that can consume file parts; otherwise the card would advertise a capability
+    /// the agent silently drops.
+    ///
+    /// Note: `images` and `audio` capability flags are auto-detected from the active LLM
+    /// provider and STT configuration — no manual override is needed for those.
+    #[serde(default)]
+    pub advertise_files: bool,
 }
 
 impl std::fmt::Debug for A2aServerConfig {
@@ -359,6 +379,7 @@ impl std::fmt::Debug for A2aServerConfig {
                 &self.ibct_signing_key_vault_ref,
             )
             .field("ibct_ttl_secs", &self.ibct_ttl_secs)
+            .field("advertise_files", &self.advertise_files)
             .finish()
     }
 }
@@ -380,6 +401,7 @@ impl Default for A2aServerConfig {
             ibct_keys: Vec::new(),
             ibct_signing_key_vault_ref: None,
             ibct_ttl_secs: default_ibct_ttl(),
+            advertise_files: false,
         }
     }
 }

--- a/crates/zeph-core/config/default.toml
+++ b/crates/zeph-core/config/default.toml
@@ -370,6 +370,12 @@ require_tls = true
 ssrf_protection = true
 # Maximum request body size in bytes (1MB)
 max_body_size = 1048576
+# Advertise non-media file attachment capability on the AgentCard.
+# images and audio capabilities are auto-detected (from the active LLM provider vision support
+# and STT configuration respectively) — no manual override is needed for those.
+# Set advertise_files = true only when the agent has skills or MCP tools that ingest file parts;
+# leaving it false (default) prevents advertising a capability the agent would silently drop.
+advertise_files = false
 
 [tools]
 # Enable tool execution (bash commands)

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -14,6 +14,31 @@ use crate::gateway_spawn::spawn_gateway_server;
 use tokio::sync::watch;
 use zeph_core::agent::Agent;
 use zeph_core::config::Config;
+use zeph_llm::LlmProvider as _;
+
+/// Build the [`zeph_a2a::types::AgentCard`] for the daemon's A2A server.
+///
+/// Derives capability flags from runtime-available signals so the served
+/// `/.well-known/agent.json` accurately reflects what the running agent can handle:
+///
+/// - `images`: `provider.supports_vision()` — only the active LLM can consume image parts.
+/// - `audio`: `config.llm.stt_provider_entry().is_some()` — STT presence is the
+///   precondition for the agent loop to transcribe audio attachments rather than drop them.
+/// - `files`: `config.a2a.advertise_files` — opt-in, because generic file attachments have
+///   no built-in ingestion path; set `true` only when skills or MCP tools consume file parts.
+fn build_default_card(
+    config: &Config,
+    public_url: &str,
+    provider: &zeph_llm::any::AnyProvider,
+) -> zeph_a2a::AgentCard {
+    zeph_a2a::AgentCardBuilder::new(&config.agent.name, public_url, env!("CARGO_PKG_VERSION"))
+        .description("Zeph AI agent")
+        .streaming(true)
+        .images(provider.supports_vision())
+        .audio(config.llm.stt_provider_entry().is_some())
+        .files(config.a2a.advertise_files)
+        .build()
+}
 
 fn spawn_a2a_server(
     config: &Config,
@@ -26,6 +51,7 @@ fn spawn_a2a_server(
     // are also excluded — they are either fire-and-forget one-shots or
     // lifecycle-managed by DaemonSupervisor.
     supervisor: Option<zeph_core::TaskSupervisor>,
+    provider: &zeph_llm::any::AnyProvider,
 ) {
     let public_url = if config.a2a.public_url.is_empty() {
         format!("http://{}:{}", config.a2a.host, config.a2a.port)
@@ -33,11 +59,7 @@ fn spawn_a2a_server(
         config.a2a.public_url.clone()
     };
 
-    let card =
-        zeph_a2a::AgentCardBuilder::new(&config.agent.name, &public_url, env!("CARGO_PKG_VERSION"))
-            .description("Zeph AI agent")
-            .streaming(true)
-            .build();
+    let card = build_default_card(config, &public_url, provider);
 
     let processor: std::sync::Arc<dyn zeph_a2a::TaskProcessor> =
         std::sync::Arc::new(AgentTaskProcessor {
@@ -638,6 +660,7 @@ pub(crate) async fn run_daemon(
         loopback_handle,
         a2a_sanitizer,
         Some(task_supervisor),
+        &provider,
     );
 
     #[cfg(feature = "gateway")]
@@ -705,4 +728,98 @@ pub(crate) async fn run_daemon(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zeph_config::channels::A2aServerConfig;
+    use zeph_config::providers::{ProviderEntry, ProviderKind, SttConfig};
+    use zeph_llm::any::AnyProvider;
+    use zeph_llm::mock::MockProvider;
+
+    fn mock_provider() -> AnyProvider {
+        AnyProvider::Mock(MockProvider::default())
+    }
+
+    fn config_with_a2a(advertise_files: bool) -> Config {
+        let mut cfg = Config::default();
+        cfg.a2a = A2aServerConfig {
+            advertise_files,
+            ..A2aServerConfig::default()
+        };
+        cfg
+    }
+
+    /// Build a config that has an STT provider entry wired up, so `stt_provider_entry()` returns `Some`.
+    fn config_with_stt(advertise_files: bool) -> Config {
+        let mut cfg = config_with_a2a(advertise_files);
+        cfg.llm.providers = vec![ProviderEntry {
+            name: Some("stt-provider".into()),
+            provider_type: ProviderKind::Ollama,
+            stt_model: Some("whisper".into()),
+            ..ProviderEntry::default()
+        }];
+        cfg.llm.stt = Some(SttConfig {
+            provider: "stt-provider".into(),
+            language: "en".into(),
+        });
+        cfg
+    }
+
+    #[test]
+    fn build_default_card_no_capabilities_by_default() {
+        let cfg = config_with_a2a(false);
+        let provider = mock_provider();
+        // MockProvider::supports_vision() returns false; no STT; advertise_files=false
+        let card = build_default_card(&cfg, "http://localhost:8080", &provider);
+        assert!(
+            !card.capabilities.images,
+            "images must be false without vision support"
+        );
+        assert!(!card.capabilities.audio, "audio must be false without STT");
+        assert!(
+            !card.capabilities.files,
+            "files must be false when advertise_files=false"
+        );
+        assert!(card.capabilities.streaming, "streaming must always be true");
+    }
+
+    #[test]
+    fn build_default_card_audio_from_stt_config() {
+        let cfg = config_with_stt(false);
+        let provider = mock_provider();
+        let card = build_default_card(&cfg, "http://localhost:8080", &provider);
+        assert!(
+            card.capabilities.audio,
+            "audio must be true when STT provider is configured"
+        );
+        assert!(!card.capabilities.images);
+        assert!(!card.capabilities.files);
+    }
+
+    #[test]
+    fn build_default_card_files_from_advertise_files_flag() {
+        let cfg = config_with_a2a(true);
+        let provider = mock_provider();
+        let card = build_default_card(&cfg, "http://localhost:8080", &provider);
+        assert!(
+            card.capabilities.files,
+            "files must be true when advertise_files=true"
+        );
+        assert!(!card.capabilities.images);
+        assert!(!card.capabilities.audio);
+    }
+
+    #[test]
+    fn build_default_card_audio_and_files_without_images() {
+        let cfg = config_with_stt(true);
+        let provider = mock_provider();
+        let card = build_default_card(&cfg, "http://localhost:8080", &provider);
+        // images is still false because MockProvider::supports_vision() returns false
+        assert!(!card.capabilities.images);
+        assert!(card.capabilities.audio);
+        assert!(card.capabilities.files);
+        assert!(card.capabilities.streaming);
+    }
 }


### PR DESCRIPTION
## Summary

- Derives `images`/`audio`/`files` flags on the default `AgentCard` from runtime signals at A2A server bootstrap
- Extracts `build_default_card()` helper in `src/daemon.rs` to keep the bootstrap clean
- Adds `advertise_files: bool` (default `false`) to `A2aServerConfig` in `zeph-config`

## Detection logic

| Capability | Signal |
|---|---|
| `images` | `provider.supports_vision()` |
| `audio` | `config.llm.stt_provider_entry().is_some()` |
| `files` | `config.a2a.advertise_files` (opt-in, default `false`) |

## Known limitation

Daemon mode does not wire STT at runtime yet, so `audio=true` may be advertised even though audio parts are silently dropped. A separate P3 issue should track STT wiring in `run_daemon`.

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` — 8602 tests pass
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] Manual: run agent with `[a2a]` enabled and vision-capable provider; verify `GET /` AgentCard response shows `"images": true`
- [ ] Manual: run with `advertise_files = true`; verify `"files": true` in AgentCard

Closes #3378