### PR TITLE
refactor: decompose long functions in zeph-config, zeph-llm, zeph-sanitizer

### DIFF
--- a/crates/zeph-config/src/loader.rs
+++ b/crates/zeph-config/src/loader.rs
@@ -61,8 +61,30 @@ impl Config {
     /// # Errors
     ///
     /// Returns an error if any value is out of range.
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3438): decompose into smaller helpers
     pub fn validate(&self) -> Result<(), ConfigError> {
+        self.validate_scalar_bounds()?;
+        self.validate_memory_compression()?;
+        self.validate_memory_probe_and_graph()?;
+        self.validate_mcp_servers()?;
+        self.experiments
+            .validate()
+            .map_err(ConfigError::Validation)?;
+        if self.orchestration.plan_cache.enabled {
+            self.orchestration
+                .plan_cache
+                .validate()
+                .map_err(ConfigError::Validation)?;
+        }
+        self.validate_orchestration()?;
+        self.validate_focus_and_sidequest()?;
+        self.validate_llm_and_skills()?;
+        self.validate_provider_names()?;
+        self.validate_mcp_misc()?;
+        Ok(())
+    }
+
+    /// Validate scalar bounds for memory, agent, a2a, and gateway fields.
+    fn validate_scalar_bounds(&self) -> Result<(), ConfigError> {
         if self.memory.history_limit > 10_000 {
             return Err(ConfigError::Validation(format!(
                 "history_limit must be <= 10000, got {}",
@@ -106,6 +128,11 @@ impl Config {
                 "tool_call_cutoff must be >= 1".into(),
             ));
         }
+        Ok(())
+    }
+
+    /// Validate memory compression strategy bounds and compaction thresholds.
+    fn validate_memory_compression(&self) -> Result<(), ConfigError> {
         if let crate::memory::CompressionStrategy::Proactive {
             threshold_tokens,
             max_summary_tokens,
@@ -146,6 +173,11 @@ impl Config {
                 self.memory.soft_compaction_threshold, self.memory.hard_compaction_threshold,
             )));
         }
+        Ok(())
+    }
+
+    /// Validate memory probe thresholds and graph temporal decay rate.
+    fn validate_memory_probe_and_graph(&self) -> Result<(), ConfigError> {
         if self.memory.graph.temporal_decay_rate < 0.0
             || self.memory.graph.temporal_decay_rate > 10.0
         {
@@ -189,50 +221,44 @@ impl Config {
                 ));
             }
         }
-        // MCP server validation
-        {
-            use std::collections::HashSet;
-            let mut seen_oauth_vault_keys: HashSet<String> = HashSet::new();
-            for s in &self.mcp.servers {
-                // headers and oauth are mutually exclusive
-                if !s.headers.is_empty() && s.oauth.as_ref().is_some_and(|o| o.enabled) {
+        Ok(())
+    }
+
+    /// Validate MCP server entries for header/oauth exclusivity and vault key uniqueness.
+    fn validate_mcp_servers(&self) -> Result<(), ConfigError> {
+        use std::collections::HashSet;
+        let mut seen_oauth_vault_keys: HashSet<String> = HashSet::new();
+        for s in &self.mcp.servers {
+            // headers and oauth are mutually exclusive
+            if !s.headers.is_empty() && s.oauth.as_ref().is_some_and(|o| o.enabled) {
+                return Err(ConfigError::Validation(format!(
+                    "MCP server '{}': cannot use both 'headers' and 'oauth' simultaneously",
+                    s.id
+                )));
+            }
+            // vault key collision detection
+            if s.oauth.as_ref().is_some_and(|o| o.enabled) {
+                let key = format!("ZEPH_MCP_OAUTH_{}", s.id.to_uppercase().replace('-', "_"));
+                if !seen_oauth_vault_keys.insert(key.clone()) {
                     return Err(ConfigError::Validation(format!(
-                        "MCP server '{}': cannot use both 'headers' and 'oauth' simultaneously",
+                        "MCP server '{}' has vault key collision ('{key}'): another server \
+                         with the same normalized ID already uses this key",
                         s.id
                     )));
                 }
-                // vault key collision detection
-                if s.oauth.as_ref().is_some_and(|o| o.enabled) {
-                    let key = format!("ZEPH_MCP_OAUTH_{}", s.id.to_uppercase().replace('-', "_"));
-                    if !seen_oauth_vault_keys.insert(key.clone()) {
-                        return Err(ConfigError::Validation(format!(
-                            "MCP server '{}' has vault key collision ('{key}'): another server \
-                             with the same normalized ID already uses this key",
-                            s.id
-                        )));
-                    }
-                }
             }
         }
+        Ok(())
+    }
 
-        self.experiments
-            .validate()
-            .map_err(ConfigError::Validation)?;
-
-        if self.orchestration.plan_cache.enabled {
-            self.orchestration
-                .plan_cache
-                .validate()
-                .map_err(ConfigError::Validation)?;
-        }
-
+    /// Validate orchestration thresholds and cascade settings.
+    fn validate_orchestration(&self) -> Result<(), ConfigError> {
         let ct = self.orchestration.completeness_threshold;
         if !ct.is_finite() || !(0.0..=1.0).contains(&ct) {
             return Err(ConfigError::Validation(format!(
                 "orchestration.completeness_threshold must be in [0.0, 1.0], got {ct}"
             )));
         }
-
         // Cascade chain threshold must not be 1 — that would abort on every single failure.
         if self.orchestration.cascade_chain_threshold == 1 {
             return Err(ConfigError::Validation(
@@ -241,14 +267,12 @@ impl Config {
                     .into(),
             ));
         }
-
         let cfrat = self.orchestration.cascade_failure_rate_abort_threshold;
         if !cfrat.is_finite() || !(0.0..=1.0).contains(&cfrat) {
             return Err(ConfigError::Validation(format!(
                 "orchestration.cascade_failure_rate_abort_threshold must be in [0.0, 1.0], got {cfrat}"
             )));
         }
-
         if self.orchestration.lineage_ttl_secs == 0 {
             return Err(ConfigError::Validation(
                 "orchestration.lineage_ttl_secs must be > 0; \
@@ -256,8 +280,11 @@ impl Config {
                     .into(),
             ));
         }
+        Ok(())
+    }
 
-        // Focus config validation
+    /// Validate focus and sidequest interval and ratio constraints.
+    fn validate_focus_and_sidequest(&self) -> Result<(), ConfigError> {
         if self.agent.focus.compression_interval == 0 {
             return Err(ConfigError::Validation(
                 "agent.focus.compression_interval must be >= 1".into(),
@@ -275,8 +302,6 @@ impl Config {
                     .into(),
             ));
         }
-
-        // SideQuest config validation
         if self.memory.sidequest.interval_turns == 0 {
             return Err(ConfigError::Validation(
                 "memory.sidequest.interval_turns must be >= 1".into(),
@@ -291,7 +316,11 @@ impl Config {
                 self.memory.sidequest.max_eviction_ratio
             )));
         }
+        Ok(())
+    }
 
+    /// Validate LLM semantic cache threshold and skill evaluation weight sum.
+    fn validate_llm_and_skills(&self) -> Result<(), ConfigError> {
         let sct = self.llm.semantic_cache_threshold;
         if !(sct.is_finite() && (0.0..=1.0).contains(&sct)) {
             return Err(ConfigError::Validation(format!(
@@ -299,7 +328,6 @@ impl Config {
                  (override via ZEPH_LLM_SEMANTIC_CACHE_THRESHOLD env var)"
             )));
         }
-
         // Skill evaluation weight-sum validation (#3319).
         if self.skills.evaluation.enabled {
             let weight_sum = self.skills.evaluation.weight_correctness
@@ -311,9 +339,11 @@ impl Config {
                 )));
             }
         }
+        Ok(())
+    }
 
-        self.validate_provider_names()?;
-
+    /// Validate miscellaneous MCP output schema hint size.
+    fn validate_mcp_misc(&self) -> Result<(), ConfigError> {
         if self.mcp.output_schema_hint_bytes < 64 {
             return Err(ConfigError::Validation(format!(
                 "mcp.output_schema_hint_bytes must be >= 64, got {}; \
@@ -321,20 +351,33 @@ impl Config {
                 self.mcp.output_schema_hint_bytes
             )));
         }
-
         Ok(())
     }
 
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3438): decompose into smaller helpers
     fn validate_provider_names(&self) -> Result<(), ConfigError> {
-        use std::collections::HashSet;
-        let known: HashSet<String> = self
-            .llm
+        let known = self.known_provider_names();
+        self.validate_named_provider_refs(&known)?;
+        self.validate_optional_provider_refs(&known)?;
+        Ok(())
+    }
+
+    /// Build the set of declared provider names from all `[[llm.providers]]` entries.
+    fn known_provider_names(&self) -> std::collections::HashSet<String> {
+        self.llm
             .providers
             .iter()
             .map(super::providers::ProviderEntry::effective_name)
-            .collect();
+            .collect()
+    }
 
+    /// Validate every required `*_provider` field references a declared provider.
+    ///
+    /// The field table lists all 19 subsystem provider references. Each non-empty value must
+    /// match a name in `known`.
+    fn validate_named_provider_refs(
+        &self,
+        known: &std::collections::HashSet<String>,
+    ) -> Result<(), ConfigError> {
         let fields: &[(&str, &crate::providers::ProviderName)] = &[
             (
                 "memory.tiers.scene_provider",
@@ -422,7 +465,14 @@ impl Config {
                 )));
             }
         }
+        Ok(())
+    }
 
+    /// Validate optional provider references in complexity routing and router bandit config.
+    fn validate_optional_provider_refs(
+        &self,
+        known: &std::collections::HashSet<String>,
+    ) -> Result<(), ConfigError> {
         if let Some(triage) = self
             .llm
             .complexity_routing

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -1084,6 +1084,179 @@ fn replace_llm_section(toml_str: &str, new_llm_section: &str) -> String {
     out
 }
 
+/// Fields extracted from `[llm.stt]` that drive the migration decision.
+struct SttFields {
+    model: Option<String>,
+    base_url: Option<String>,
+    provider_hint: String,
+}
+
+/// Extract migration-relevant fields from `[llm.stt]` in the parsed document.
+fn extract_stt_fields(doc: &toml_edit::DocumentMut) -> SttFields {
+    let stt_table = doc
+        .get("llm")
+        .and_then(toml_edit::Item::as_table)
+        .and_then(|llm| llm.get("stt"))
+        .and_then(toml_edit::Item::as_table);
+
+    let model = stt_table
+        .and_then(|stt| stt.get("model"))
+        .and_then(toml_edit::Item::as_str)
+        .map(ToOwned::to_owned);
+
+    let base_url = stt_table
+        .and_then(|stt| stt.get("base_url"))
+        .and_then(toml_edit::Item::as_str)
+        .map(ToOwned::to_owned);
+
+    let provider_hint = stt_table
+        .and_then(|stt| stt.get("provider"))
+        .and_then(toml_edit::Item::as_str)
+        .map(ToOwned::to_owned)
+        .unwrap_or_default();
+
+    SttFields {
+        model,
+        base_url,
+        provider_hint,
+    }
+}
+
+/// Find the index of the first `[[llm.providers]]` entry that matches `target_type` or
+/// `provider_hint`, giving priority to explicit name/type matches over type-only matches.
+fn find_matching_provider_index(
+    doc: &toml_edit::DocumentMut,
+    target_type: &str,
+    provider_hint: &str,
+) -> Option<usize> {
+    let providers = doc
+        .get("llm")
+        .and_then(toml_edit::Item::as_table)
+        .and_then(|llm| llm.get("providers"))
+        .and_then(toml_edit::Item::as_array_of_tables)?;
+
+    providers.iter().enumerate().find_map(|(i, t)| {
+        let name = t
+            .get("name")
+            .and_then(toml_edit::Item::as_str)
+            .unwrap_or("");
+        let ptype = t
+            .get("type")
+            .and_then(toml_edit::Item::as_str)
+            .unwrap_or("");
+        // Match by explicit name hint or by type when hint is a legacy backend string.
+        let name_match =
+            !provider_hint.is_empty() && (name == provider_hint || ptype == provider_hint);
+        let type_match = ptype == target_type;
+        if name_match || type_match {
+            Some(i)
+        } else {
+            None
+        }
+    })
+}
+
+/// Attach `stt_model` (and optionally `base_url`) to an existing `[[llm.providers]]` entry
+/// at `idx`. Ensures the entry has an explicit `name` (W2 guard) and returns that name.
+fn attach_stt_to_existing_provider(
+    doc: &mut toml_edit::DocumentMut,
+    idx: usize,
+    stt_model: &str,
+    stt_base_url: Option<&str>,
+) -> Result<String, MigrateError> {
+    let llm_mut = doc
+        .get_mut("llm")
+        .and_then(toml_edit::Item::as_table_mut)
+        .ok_or(MigrateError::InvalidStructure(
+            "[llm] table not accessible for mutation",
+        ))?;
+    let providers_mut = llm_mut
+        .get_mut("providers")
+        .and_then(toml_edit::Item::as_array_of_tables_mut)
+        .ok_or(MigrateError::InvalidStructure(
+            "[[llm.providers]] array not accessible for mutation",
+        ))?;
+    let entry = providers_mut
+        .iter_mut()
+        .nth(idx)
+        .ok_or(MigrateError::InvalidStructure(
+            "[[llm.providers]] entry index out of range during mutation",
+        ))?;
+
+    // W2: ensure explicit name.
+    let existing_name = entry
+        .get("name")
+        .and_then(toml_edit::Item::as_str)
+        .map(ToOwned::to_owned);
+    let entry_name = existing_name.unwrap_or_else(|| {
+        let t = entry
+            .get("type")
+            .and_then(toml_edit::Item::as_str)
+            .unwrap_or("openai");
+        format!("{t}-stt")
+    });
+    entry.insert("name", toml_edit::value(entry_name.clone()));
+    entry.insert("stt_model", toml_edit::value(stt_model));
+    if let Some(url) = stt_base_url
+        && entry.get("base_url").is_none()
+    {
+        entry.insert("base_url", toml_edit::value(url));
+    }
+    Ok(entry_name)
+}
+
+/// Append a new `[[llm.providers]]` entry carrying `stt_model`, creating the array if absent.
+/// Returns the name assigned to the new entry.
+fn append_new_stt_provider(
+    doc: &mut toml_edit::DocumentMut,
+    target_type: &str,
+    stt_model: &str,
+    stt_base_url: Option<&str>,
+) -> Result<String, MigrateError> {
+    let new_name = if target_type == "candle" {
+        "local-whisper".to_owned()
+    } else {
+        "openai-stt".to_owned()
+    };
+    let mut new_entry = toml_edit::Table::new();
+    new_entry.insert("name", toml_edit::value(new_name.clone()));
+    new_entry.insert("type", toml_edit::value(target_type));
+    new_entry.insert("stt_model", toml_edit::value(stt_model));
+    if let Some(url) = stt_base_url {
+        new_entry.insert("base_url", toml_edit::value(url));
+    }
+    let llm_mut = doc
+        .get_mut("llm")
+        .and_then(toml_edit::Item::as_table_mut)
+        .ok_or(MigrateError::InvalidStructure(
+            "[llm] table not accessible for mutation",
+        ))?;
+    if let Some(item) = llm_mut.get_mut("providers") {
+        if let Some(arr) = item.as_array_of_tables_mut() {
+            arr.push(new_entry);
+        }
+    } else {
+        let mut arr = toml_edit::ArrayOfTables::new();
+        arr.push(new_entry);
+        llm_mut.insert("providers", toml_edit::Item::ArrayOfTables(arr));
+    }
+    Ok(new_name)
+}
+
+/// Update `[llm.stt]`: set `provider` to `resolved_provider_name` and strip `model`/`base_url`.
+fn rewrite_stt_section(doc: &mut toml_edit::DocumentMut, resolved_provider_name: &str) {
+    if let Some(stt_table) = doc
+        .get_mut("llm")
+        .and_then(toml_edit::Item::as_table_mut)
+        .and_then(|llm| llm.get_mut("stt"))
+        .and_then(toml_edit::Item::as_table_mut)
+    {
+        stt_table.insert("provider", toml_edit::value(resolved_provider_name));
+        stt_table.remove("model");
+        stt_table.remove("base_url");
+    }
+}
+
 /// Migrate an old `[llm.stt]` section (with `model` / `base_url` fields) to the new format
 /// where those fields live on a `[[llm.providers]]` entry via `stt_model`.
 ///
@@ -1102,41 +1275,12 @@ fn replace_llm_section(toml_str: &str, new_llm_section: &str) -> String {
 /// Returns `MigrateError::Parse` if the input TOML is invalid.
 /// Returns `MigrateError::InvalidStructure` if `[llm.stt].model` is present but the `[llm]`
 /// key is absent or not a table, making mutation impossible.
-#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3438): decompose into smaller helpers
 pub fn migrate_stt_to_provider(toml_src: &str) -> Result<MigrationResult, MigrateError> {
     let mut doc = toml_src.parse::<toml_edit::DocumentMut>()?;
-
-    // Extract fields from [llm.stt] if present.
-    let stt_model = doc
-        .get("llm")
-        .and_then(toml_edit::Item::as_table)
-        .and_then(|llm| llm.get("stt"))
-        .and_then(toml_edit::Item::as_table)
-        .and_then(|stt| stt.get("model"))
-        .and_then(toml_edit::Item::as_str)
-        .map(ToOwned::to_owned);
-
-    let stt_base_url = doc
-        .get("llm")
-        .and_then(toml_edit::Item::as_table)
-        .and_then(|llm| llm.get("stt"))
-        .and_then(toml_edit::Item::as_table)
-        .and_then(|stt| stt.get("base_url"))
-        .and_then(toml_edit::Item::as_str)
-        .map(ToOwned::to_owned);
-
-    let stt_provider_hint = doc
-        .get("llm")
-        .and_then(toml_edit::Item::as_table)
-        .and_then(|llm| llm.get("stt"))
-        .and_then(toml_edit::Item::as_table)
-        .and_then(|stt| stt.get("provider"))
-        .and_then(toml_edit::Item::as_str)
-        .map(ToOwned::to_owned)
-        .unwrap_or_default();
+    let stt = extract_stt_fields(&doc);
 
     // Nothing to migrate if [llm.stt] does not exist or already lacks the old fields.
-    if stt_model.is_none() && stt_base_url.is_none() {
+    if stt.model.is_none() && stt.base_url.is_none() {
         return Ok(MigrationResult {
             output: toml_src.to_owned(),
             changed_count: 0,
@@ -1144,133 +1288,24 @@ pub fn migrate_stt_to_provider(toml_src: &str) -> Result<MigrationResult, Migrat
         });
     }
 
-    let stt_model = stt_model.unwrap_or_else(|| "whisper-1".to_owned());
+    let stt_model = stt.model.unwrap_or_else(|| "whisper-1".to_owned());
 
     // Determine the target provider type based on provider hint.
-    let target_type = match stt_provider_hint.as_str() {
+    let target_type = match stt.provider_hint.as_str() {
         "candle-whisper" | "candle" => "candle",
         _ => "openai",
     };
 
-    // Find or create a [[llm.providers]] entry to attach stt_model to.
-    // Priority: entry whose effective name matches the hint, else first entry of matching type.
-    let providers = doc
-        .get("llm")
-        .and_then(toml_edit::Item::as_table)
-        .and_then(|llm| llm.get("providers"))
-        .and_then(toml_edit::Item::as_array_of_tables);
-
-    let matching_idx = providers.and_then(|arr| {
-        arr.iter().enumerate().find_map(|(i, t)| {
-            let name = t
-                .get("name")
-                .and_then(toml_edit::Item::as_str)
-                .unwrap_or("");
-            let ptype = t
-                .get("type")
-                .and_then(toml_edit::Item::as_str)
-                .unwrap_or("");
-            // Match by explicit name hint or by type when hint is a legacy backend string.
-            let name_match = !stt_provider_hint.is_empty()
-                && (name == stt_provider_hint || ptype == stt_provider_hint);
-            let type_match = ptype == target_type;
-            if name_match || type_match {
-                Some(i)
-            } else {
-                None
-            }
-        })
-    });
-
-    // Determine the final provider name to write into [llm.stt].provider.
-    let resolved_provider_name: String;
-
-    if let Some(idx) = matching_idx {
-        // Attach stt_model to the existing entry.
-        let llm_mut = doc
-            .get_mut("llm")
-            .and_then(toml_edit::Item::as_table_mut)
-            .ok_or(MigrateError::InvalidStructure(
-                "[llm] table not accessible for mutation",
-            ))?;
-        let providers_mut = llm_mut
-            .get_mut("providers")
-            .and_then(toml_edit::Item::as_array_of_tables_mut)
-            .ok_or(MigrateError::InvalidStructure(
-                "[[llm.providers]] array not accessible for mutation",
-            ))?;
-        let entry = providers_mut
-            .iter_mut()
-            .nth(idx)
-            .ok_or(MigrateError::InvalidStructure(
-                "[[llm.providers]] entry index out of range during mutation",
-            ))?;
-
-        // W2: ensure explicit name.
-        let existing_name = entry
-            .get("name")
-            .and_then(toml_edit::Item::as_str)
-            .map(ToOwned::to_owned);
-        let entry_name = existing_name.unwrap_or_else(|| {
-            let t = entry
-                .get("type")
-                .and_then(toml_edit::Item::as_str)
-                .unwrap_or("openai");
-            format!("{t}-stt")
-        });
-        entry.insert("name", toml_edit::value(entry_name.clone()));
-        entry.insert("stt_model", toml_edit::value(stt_model.clone()));
-        if stt_base_url.is_some() && entry.get("base_url").is_none() {
-            entry.insert(
-                "base_url",
-                toml_edit::value(stt_base_url.as_deref().unwrap_or_default()),
-            );
+    let resolved_name = match find_matching_provider_index(&doc, target_type, &stt.provider_hint) {
+        Some(idx) => {
+            attach_stt_to_existing_provider(&mut doc, idx, &stt_model, stt.base_url.as_deref())?
         }
-        resolved_provider_name = entry_name;
-    } else {
-        // No matching entry — append a new [[llm.providers]] block.
-        let new_name = if target_type == "candle" {
-            "local-whisper".to_owned()
-        } else {
-            "openai-stt".to_owned()
-        };
-        let mut new_entry = toml_edit::Table::new();
-        new_entry.insert("name", toml_edit::value(new_name.clone()));
-        new_entry.insert("type", toml_edit::value(target_type));
-        new_entry.insert("stt_model", toml_edit::value(stt_model.clone()));
-        if let Some(ref url) = stt_base_url {
-            new_entry.insert("base_url", toml_edit::value(url.clone()));
+        None => {
+            append_new_stt_provider(&mut doc, target_type, &stt_model, stt.base_url.as_deref())?
         }
-        // Ensure [[llm.providers]] array exists.
-        let llm_mut = doc
-            .get_mut("llm")
-            .and_then(toml_edit::Item::as_table_mut)
-            .ok_or(MigrateError::InvalidStructure(
-                "[llm] table not accessible for mutation",
-            ))?;
-        if let Some(item) = llm_mut.get_mut("providers") {
-            if let Some(arr) = item.as_array_of_tables_mut() {
-                arr.push(new_entry);
-            }
-        } else {
-            let mut arr = toml_edit::ArrayOfTables::new();
-            arr.push(new_entry);
-            llm_mut.insert("providers", toml_edit::Item::ArrayOfTables(arr));
-        }
-        resolved_provider_name = new_name;
-    }
+    };
 
-    // Update [llm.stt]: set provider name, remove old fields.
-    if let Some(stt_table) = doc
-        .get_mut("llm")
-        .and_then(toml_edit::Item::as_table_mut)
-        .and_then(|llm| llm.get_mut("stt"))
-        .and_then(toml_edit::Item::as_table_mut)
-    {
-        stt_table.insert("provider", toml_edit::value(resolved_provider_name.clone()));
-        stt_table.remove("model");
-        stt_table.remove("base_url");
-    }
+    rewrite_stt_section(&mut doc, &resolved_name);
 
     Ok(MigrationResult {
         output: doc.to_string(),

--- a/crates/zeph-llm/src/classifier/ner.rs
+++ b/crates/zeph-llm/src/classifier/ner.rs
@@ -76,6 +76,150 @@ impl std::fmt::Debug for CandleNerClassifier {
     }
 }
 
+/// Mutable state machine for BIO/BIOES span decoding.
+///
+/// Encapsulates the cursor fields and span accumulator that were previously local variables
+/// in `decode_bio_spans`. Each `handle_*` method corresponds to one BIO/BIOES prefix token.
+struct BioDecoderState {
+    spans: Vec<NerSpan>,
+    current_label: Option<String>,
+    current_start: usize,
+    current_end: usize,
+    current_score_sum: f32,
+    current_token_count: usize,
+}
+
+impl BioDecoderState {
+    fn new(capacity_hint: usize) -> Self {
+        Self {
+            spans: Vec::with_capacity(capacity_hint),
+            current_label: None,
+            current_start: 0,
+            current_end: 0,
+            current_score_sum: 0.0,
+            current_token_count: 0,
+        }
+    }
+
+    /// Push the currently open span (if any) into `self.spans` and reset cursor state.
+    ///
+    /// Mirrors the `close_span` closure at original `ner.rs:231-248`. The reset is folded
+    /// in here so callers (`handle_b`, `handle_i`, `handle_s`, `handle_e`, `handle_o`)
+    /// don't need to zero fields manually — they overwrite them immediately after if needed.
+    fn close_current(&mut self) {
+        if self.current_end > self.current_start && self.current_token_count > 0 {
+            // count is always small (sequence length), f32 precision loss is acceptable.
+            #[allow(clippy::cast_precision_loss)]
+            let avg_score = self.current_score_sum / self.current_token_count as f32;
+            self.spans.push(NerSpan {
+                label: self.current_label.clone().unwrap_or_default(),
+                score: avg_score,
+                start: self.current_start,
+                end: self.current_end,
+            });
+        }
+        self.current_label = None;
+        self.current_score_sum = 0.0;
+        self.current_token_count = 0;
+    }
+
+    /// Handle a `B-X` token: close any open span, then start a new one. (ner.rs:268-285)
+    fn handle_b(&mut self, entity_type: &str, offset_start: usize, offset_end: usize, score: f32) {
+        self.close_current();
+        self.current_label = Some(entity_type.to_owned());
+        self.current_start = offset_start;
+        self.current_end = offset_end;
+        self.current_score_sum = score;
+        self.current_token_count = 1;
+    }
+
+    /// Handle an `I-X` token: extend the current span if types match, otherwise start new.
+    /// (ner.rs:286-310)
+    fn handle_i(&mut self, entity_type: &str, offset_start: usize, offset_end: usize, score: f32) {
+        if self.current_label.as_deref() == Some(entity_type) {
+            // Continue current span.
+            self.current_end = offset_end;
+            self.current_score_sum += score;
+            self.current_token_count += 1;
+        } else {
+            // Mismatch or no open span: close previous and start new.
+            self.close_current();
+            self.current_label = Some(entity_type.to_owned());
+            self.current_start = offset_start;
+            self.current_end = offset_end;
+            self.current_score_sum = score;
+            self.current_token_count = 1;
+        }
+    }
+
+    /// Handle an `S-X` token: close any open span, emit this token as a single-token span.
+    /// (ner.rs:311-331)
+    fn handle_s(&mut self, entity_type: &str, offset_start: usize, offset_end: usize, score: f32) {
+        self.close_current();
+        if offset_end > offset_start {
+            self.spans.push(NerSpan {
+                label: entity_type.to_owned(),
+                score,
+                start: offset_start,
+                end: offset_end,
+            });
+        }
+    }
+
+    /// Handle an `E-X` token: close the current span if types match, otherwise treat as
+    /// an unexpected end token (close previous, emit this token as its own span). (ner.rs:332-370)
+    ///
+    /// Ordering is critical: increment the E-token's contribution to score and count
+    /// BEFORE calling `close_current`, so the closed span includes this token's weight.
+    fn handle_e(&mut self, entity_type: &str, offset_start: usize, offset_end: usize, score: f32) {
+        if self.current_label.as_deref() == Some(entity_type) {
+            // Increment first so the E-token's score and count are included in the closed span.
+            self.current_end = offset_end;
+            self.current_score_sum += score;
+            self.current_token_count += 1;
+            self.close_current();
+        } else {
+            // Unexpected E-X: close previous, emit this token as a span.
+            self.close_current();
+            if offset_end > offset_start {
+                self.spans.push(NerSpan {
+                    label: entity_type.to_owned(),
+                    score,
+                    start: offset_start,
+                    end: offset_end,
+                });
+            }
+        }
+    }
+
+    /// Handle an `O` or unknown token: close any open span. (ner.rs:371-386)
+    fn handle_o(&mut self) {
+        self.close_current();
+    }
+
+    fn into_spans(self) -> Vec<NerSpan> {
+        self.spans
+    }
+}
+
+/// Parse a BIO/BIOES label string into `(prefix, entity_type)`.
+///
+/// Mirrors the inline prefix-parsing block at original `ner.rs:255-265`.
+/// Returns `("O", "")` for the `O` label and any unrecognised strings.
+fn parse_bio_label(label_str: &str) -> (&'static str, &str) {
+    if let Some(rest) = label_str.strip_prefix("B-") {
+        ("B", rest)
+    } else if let Some(rest) = label_str.strip_prefix("I-") {
+        ("I", rest)
+    } else if let Some(rest) = label_str.strip_prefix("S-") {
+        ("S", rest)
+    } else if let Some(rest) = label_str.strip_prefix("E-") {
+        ("E", rest)
+    } else {
+        ("O", "")
+    }
+}
+
 impl CandleNerClassifier {
     /// Create a new NER classifier that will load `repo_id` from `HuggingFace` Hub on first use.
     #[must_use]
@@ -215,190 +359,26 @@ impl CandleNerClassifier {
     /// - `S-X` is a single-token span of type X.
     /// - `E-X` closes an open span of type X.
     /// - `O` closes any open span.
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3440): decompose into smaller helpers
     fn decode_bio_spans(
         id2label: &[String],
         token_labels: &[(usize, f32)],
         offsets: &[(usize, usize)],
     ) -> Vec<NerSpan> {
-        let mut spans: Vec<NerSpan> = Vec::new();
-        let mut current_label: Option<String> = None;
-        let mut current_start: usize = 0;
-        let mut current_end: usize = 0;
-        let mut current_score_sum: f32 = 0.0;
-        let mut current_token_count: usize = 0;
-
-        let close_span = |spans: &mut Vec<NerSpan>,
-                          label: &str,
-                          start: usize,
-                          end: usize,
-                          score_sum: f32,
-                          count: usize| {
-            if end > start && count > 0 {
-                // count is always small (sequence length), f32 precision loss is acceptable.
-                #[allow(clippy::cast_precision_loss)]
-                let avg_score = score_sum / count as f32;
-                spans.push(NerSpan {
-                    label: label.to_owned(),
-                    score: avg_score,
-                    start,
-                    end,
-                });
-            }
-        };
-
+        let mut state = BioDecoderState::new(token_labels.len() / 2);
         for (pos, &(label_idx, score)) in token_labels.iter().enumerate() {
             let label_str = id2label.get(label_idx).map_or("O", String::as_str);
             let (offset_start, offset_end) = offsets.get(pos).copied().unwrap_or((0, 0));
-
-            // Parse BIO/BIOES prefix and entity type.
-            let (prefix, entity_type) = if let Some(rest) = label_str.strip_prefix("B-") {
-                ("B", rest)
-            } else if let Some(rest) = label_str.strip_prefix("I-") {
-                ("I", rest)
-            } else if let Some(rest) = label_str.strip_prefix("S-") {
-                ("S", rest)
-            } else if let Some(rest) = label_str.strip_prefix("E-") {
-                ("E", rest)
-            } else {
-                ("O", "")
-            };
-
+            let (prefix, entity_type) = parse_bio_label(label_str);
             match prefix {
-                "B" => {
-                    // Close any open span before starting a new one.
-                    if let Some(ref lbl) = current_label.take() {
-                        close_span(
-                            &mut spans,
-                            lbl,
-                            current_start,
-                            current_end,
-                            current_score_sum,
-                            current_token_count,
-                        );
-                    }
-                    current_label = Some(entity_type.to_owned());
-                    current_start = offset_start;
-                    current_end = offset_end;
-                    current_score_sum = score;
-                    current_token_count = 1;
-                }
-                "I" => {
-                    if current_label.as_deref() == Some(entity_type) {
-                        // Continue current span.
-                        current_end = offset_end;
-                        current_score_sum += score;
-                        current_token_count += 1;
-                    } else {
-                        // Mismatch or no open span: close previous and start new.
-                        if let Some(ref lbl) = current_label.take() {
-                            close_span(
-                                &mut spans,
-                                lbl,
-                                current_start,
-                                current_end,
-                                current_score_sum,
-                                current_token_count,
-                            );
-                        }
-                        current_label = Some(entity_type.to_owned());
-                        current_start = offset_start;
-                        current_end = offset_end;
-                        current_score_sum = score;
-                        current_token_count = 1;
-                    }
-                }
-                "S" => {
-                    // Single-token span: close previous and emit immediately.
-                    if let Some(ref lbl) = current_label.take() {
-                        close_span(
-                            &mut spans,
-                            lbl,
-                            current_start,
-                            current_end,
-                            current_score_sum,
-                            current_token_count,
-                        );
-                    }
-                    if offset_end > offset_start {
-                        spans.push(NerSpan {
-                            label: entity_type.to_owned(),
-                            score,
-                            start: offset_start,
-                            end: offset_end,
-                        });
-                    }
-                }
-                "E" => {
-                    // End of span: close if type matches.
-                    if current_label.as_deref() == Some(entity_type) {
-                        current_end = offset_end;
-                        current_score_sum += score;
-                        current_token_count += 1;
-                        let lbl = current_label.take().unwrap_or_default();
-                        close_span(
-                            &mut spans,
-                            &lbl,
-                            current_start,
-                            current_end,
-                            current_score_sum,
-                            current_token_count,
-                        );
-                        current_score_sum = 0.0;
-                        current_token_count = 0;
-                    } else {
-                        // Unexpected E-X: close previous, emit this token as a span.
-                        if let Some(ref lbl) = current_label.take() {
-                            close_span(
-                                &mut spans,
-                                lbl,
-                                current_start,
-                                current_end,
-                                current_score_sum,
-                                current_token_count,
-                            );
-                        }
-                        if offset_end > offset_start {
-                            spans.push(NerSpan {
-                                label: entity_type.to_owned(),
-                                score,
-                                start: offset_start,
-                                end: offset_end,
-                            });
-                        }
-                    }
-                }
-                _ => {
-                    // "O" or unknown: close any open span.
-                    if let Some(ref lbl) = current_label.take() {
-                        close_span(
-                            &mut spans,
-                            lbl,
-                            current_start,
-                            current_end,
-                            current_score_sum,
-                            current_token_count,
-                        );
-                    }
-                    current_score_sum = 0.0;
-                    current_token_count = 0;
-                }
+                "B" => state.handle_b(entity_type, offset_start, offset_end, score),
+                "I" => state.handle_i(entity_type, offset_start, offset_end, score),
+                "S" => state.handle_s(entity_type, offset_start, offset_end, score),
+                "E" => state.handle_e(entity_type, offset_start, offset_end, score),
+                _ => state.handle_o(),
             }
         }
-
-        // Close any span still open at end of sequence.
-        if let Some(ref lbl) = current_label {
-            close_span(
-                &mut spans,
-                lbl,
-                current_start,
-                current_end,
-                current_score_sum,
-                current_token_count,
-            );
-        }
-
-        spans
+        state.close_current();
+        state.into_spans()
     }
 
     /// Tokenize, chunk, run NER, decode spans, and aggregate across chunks.

--- a/crates/zeph-sanitizer/src/sanitizer.rs
+++ b/crates/zeph-sanitizer/src/sanitizer.rs
@@ -107,6 +107,19 @@ pub struct ContentSanitizer {
     classifier_metrics: Option<std::sync::Arc<zeph_llm::ClassifierMetrics>>,
 }
 
+/// Outcome of Stage 1 (binary classifier) in `classify_injection`.
+///
+/// `Refine` means Stage 2 may further refine the verdict.
+/// `Final` means the verdict is already settled and Stage 2 must be skipped
+/// (regex fallback path on error or timeout).
+#[cfg(feature = "classifiers")]
+enum BinaryStageOutcome {
+    /// Stage 1 succeeded; Stage 2 may still refine `v`.
+    Refine(InjectionVerdict),
+    /// Stage 1 hit an error or timeout; `v` is the regex fallback and Stage 2 must not run.
+    Final(InjectionVerdict),
+}
+
 impl ContentSanitizer {
     /// Build a sanitizer from the given configuration.
     ///
@@ -535,6 +548,154 @@ impl ContentSanitizer {
         }
     }
 
+    /// Run the regex injection detector and return the appropriate verdict.
+    ///
+    /// Returns `Clean` when no patterns match; otherwise returns the configured
+    /// enforcement-mode verdict. Collapses four byte-identical inline blocks from
+    /// the original `classify_injection` body (lines 558-562, 565-570, 605-610, 612-620).
+    #[cfg(feature = "classifiers")]
+    fn regex_fallback_verdict(&self, text: &str) -> InjectionVerdict {
+        if Self::detect_injections(text).is_empty() {
+            InjectionVerdict::Clean
+        } else {
+            self.regex_verdict()
+        }
+    }
+
+    /// Map a binary classifier score to an [`InjectionVerdict`].
+    ///
+    /// `is_positive` gates both threshold branches: a high-confidence negative-class
+    /// result always returns `Clean`, regardless of score. This mirrors the original
+    /// guard at `sanitizer.rs:586, 598`.
+    #[cfg(feature = "classifiers")]
+    fn binary_score_to_verdict(
+        &self,
+        score: f32,
+        label: &str,
+        is_positive: bool,
+    ) -> InjectionVerdict {
+        if is_positive && score >= self.injection_threshold {
+            tracing::warn!(
+                label = %label,
+                score = score,
+                threshold = self.injection_threshold,
+                "ML classifier hard-threshold hit"
+            );
+            // enforcement_mode determines whether hard threshold blocks or just warns
+            match self.enforcement_mode {
+                zeph_config::InjectionEnforcementMode::Block => InjectionVerdict::Blocked,
+                zeph_config::InjectionEnforcementMode::Warn => InjectionVerdict::Suspicious,
+            }
+        } else if is_positive && score >= self.injection_threshold_soft {
+            tracing::warn!(score = score, "injection_classifier soft_signal");
+            InjectionVerdict::Suspicious
+        } else {
+            InjectionVerdict::Clean
+        }
+    }
+
+    /// Run Stage 1 (binary classifier) within the shared deadline.
+    ///
+    /// Returns [`BinaryStageOutcome::Refine`] on a successful classifier call; the
+    /// caller may then pass the verdict to Stage 2.
+    ///
+    /// Returns [`BinaryStageOutcome::Final`] on classifier error or timeout; the
+    /// verdict is the regex fallback and the caller **must not** invoke Stage 2.
+    #[cfg(feature = "classifiers")]
+    async fn run_binary_stage(
+        &self,
+        backend: &dyn zeph_llm::classifier::ClassifierBackend,
+        text: &str,
+        deadline: std::time::Instant,
+    ) -> BinaryStageOutcome {
+        let t0 = std::time::Instant::now();
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        match tokio::time::timeout(remaining, backend.classify(text)).await {
+            Ok(Ok(result)) => {
+                if let Some(ref m) = self.classifier_metrics {
+                    m.record(
+                        zeph_llm::classifier::ClassifierTask::Injection,
+                        t0.elapsed(),
+                    );
+                }
+                BinaryStageOutcome::Refine(self.binary_score_to_verdict(
+                    result.score,
+                    &result.label,
+                    result.is_positive,
+                ))
+            }
+            Ok(Err(e)) => {
+                tracing::error!(error = %e, "classifier inference error, falling back to regex");
+                BinaryStageOutcome::Final(self.regex_fallback_verdict(text))
+            }
+            Err(_) => {
+                tracing::error!(
+                    timeout_ms = self.classifier_timeout_ms,
+                    "classifier timed out, falling back to regex"
+                );
+                BinaryStageOutcome::Final(self.regex_fallback_verdict(text))
+            }
+        }
+    }
+
+    /// Run Stage 2 (three-class `AlignSentinel` refinement) within the shared deadline.
+    ///
+    /// Downgrades `binary_verdict` to `Clean` when the three-class model returns
+    /// `AlignedInstruction` (above threshold) or `NoInstruction`.
+    ///
+    /// Returns `binary_verdict` unchanged on deadline exhaustion, classifier error,
+    /// classifier timeout, `MisalignedInstruction`, `Unknown`, or
+    /// `AlignedInstruction` below threshold.
+    #[cfg(feature = "classifiers")]
+    async fn refine_with_three_class(
+        &self,
+        text: &str,
+        deadline: std::time::Instant,
+        binary_verdict: InjectionVerdict,
+    ) -> InjectionVerdict {
+        let Some(ref tc_backend) = self.three_class_backend else {
+            return binary_verdict;
+        };
+
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            tracing::warn!("three-class refinement skipped: shared timeout budget exhausted");
+            return binary_verdict;
+        }
+
+        match tokio::time::timeout(remaining, tc_backend.classify(text)).await {
+            Ok(Ok(result)) => {
+                let class = InstructionClass::from_label(&result.label);
+                match class {
+                    InstructionClass::AlignedInstruction
+                        if result.score >= self.three_class_threshold =>
+                    {
+                        tracing::debug!(
+                            label = %result.label,
+                            score = result.score,
+                            "three-class: aligned instruction, downgrading to Clean"
+                        );
+                        InjectionVerdict::Clean
+                    }
+                    InstructionClass::NoInstruction => {
+                        tracing::debug!("three-class: no instruction, downgrading to Clean");
+                        InjectionVerdict::Clean
+                    }
+                    // MisalignedInstruction, Unknown, or AlignedInstruction below threshold
+                    _ => binary_verdict,
+                }
+            }
+            Ok(Err(e)) => {
+                tracing::warn!(error = %e, "three-class classifier error, keeping binary verdict");
+                binary_verdict
+            }
+            Err(_) => {
+                tracing::warn!("three-class classifier timed out, keeping binary verdict");
+                binary_verdict
+            }
+        }
+    }
+
     /// ML-backed injection detection (async, separate from the sync [`sanitize`](Self::sanitize) pipeline).
     ///
     /// Stage 1: binary `DeBERTa` classifier with dual-threshold scoring.
@@ -553,116 +714,32 @@ impl ContentSanitizer {
     ///
     /// When no classifier backend is attached, also falls back to regex detection.
     #[cfg(feature = "classifiers")]
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3439): decompose into smaller helpers
     pub async fn classify_injection(&self, text: &str) -> InjectionVerdict {
         if !self.enabled {
-            if Self::detect_injections(text).is_empty() {
-                return InjectionVerdict::Clean;
-            }
-            return self.regex_verdict();
+            return self.regex_fallback_verdict(text);
         }
 
         let Some(ref backend) = self.classifier else {
-            if Self::detect_injections(text).is_empty() {
-                return InjectionVerdict::Clean;
-            }
-            return self.regex_verdict();
+            return self.regex_fallback_verdict(text);
         };
 
         let deadline = std::time::Instant::now()
             + std::time::Duration::from_millis(self.classifier_timeout_ms);
 
         // Stage 1: binary classifier
-        let t0 = std::time::Instant::now();
-        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-        let binary_verdict = match tokio::time::timeout(remaining, backend.classify(text)).await {
-            Ok(Ok(result)) => {
-                if let Some(ref m) = self.classifier_metrics {
-                    m.record(
-                        zeph_llm::classifier::ClassifierTask::Injection,
-                        t0.elapsed(),
-                    );
-                }
-                if result.is_positive && result.score >= self.injection_threshold {
-                    tracing::warn!(
-                        label = %result.label,
-                        score = result.score,
-                        threshold = self.injection_threshold,
-                        "ML classifier hard-threshold hit"
-                    );
-                    // enforcement_mode determines whether hard threshold blocks or just warns
-                    match self.enforcement_mode {
-                        zeph_config::InjectionEnforcementMode::Block => InjectionVerdict::Blocked,
-                        zeph_config::InjectionEnforcementMode::Warn => InjectionVerdict::Suspicious,
-                    }
-                } else if result.is_positive && result.score >= self.injection_threshold_soft {
-                    tracing::warn!(score = result.score, "injection_classifier soft_signal");
-                    InjectionVerdict::Suspicious
-                } else {
-                    InjectionVerdict::Clean
-                }
-            }
-            Ok(Err(e)) => {
-                tracing::error!(error = %e, "classifier inference error, falling back to regex");
-                if Self::detect_injections(text).is_empty() {
-                    return InjectionVerdict::Clean;
-                }
-                return self.regex_verdict();
-            }
-            Err(_) => {
-                tracing::error!(
-                    timeout_ms = self.classifier_timeout_ms,
-                    "classifier timed out, falling back to regex"
-                );
-                if Self::detect_injections(text).is_empty() {
-                    return InjectionVerdict::Clean;
-                }
-                return self.regex_verdict();
-            }
+        let binary_verdict = match self
+            .run_binary_stage(backend.as_ref(), text, deadline)
+            .await
+        {
+            BinaryStageOutcome::Final(v) => return v, // regex fallback — skip Stage 2
+            BinaryStageOutcome::Refine(v) => v,
         };
 
         // Stage 2: three-class refinement on flagged content
-        if binary_verdict != InjectionVerdict::Clean
-            && let Some(ref tc_backend) = self.three_class_backend
-        {
-            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-            if remaining.is_zero() {
-                tracing::warn!("three-class refinement skipped: shared timeout budget exhausted");
-                return binary_verdict;
-            }
-            match tokio::time::timeout(remaining, tc_backend.classify(text)).await {
-                Ok(Ok(result)) => {
-                    let class = InstructionClass::from_label(&result.label);
-                    match class {
-                        InstructionClass::AlignedInstruction
-                            if result.score >= self.three_class_threshold =>
-                        {
-                            tracing::debug!(
-                                label = %result.label,
-                                score = result.score,
-                                "three-class: aligned instruction, downgrading to Clean"
-                            );
-                            return InjectionVerdict::Clean;
-                        }
-                        InstructionClass::NoInstruction => {
-                            tracing::debug!("three-class: no instruction, downgrading to Clean");
-                            return InjectionVerdict::Clean;
-                        }
-                        _ => {
-                            // MisalignedInstruction, Unknown, or AlignedInstruction below threshold
-                        }
-                    }
-                }
-                Ok(Err(e)) => {
-                    tracing::warn!(
-                        error = %e,
-                        "three-class classifier error, keeping binary verdict"
-                    );
-                }
-                Err(_) => {
-                    tracing::warn!("three-class classifier timed out, keeping binary verdict");
-                }
-            }
+        if binary_verdict != InjectionVerdict::Clean && self.three_class_backend.is_some() {
+            return self
+                .refine_with_three_class(text, deadline, binary_verdict)
+                .await;
         }
 
         binary_verdict


### PR DESCRIPTION
## Summary

- **zeph-config** (`#3438`): split `Config::validate` into 8 phase helpers; split `validate_provider_names` into 3 helpers; split `migrate_stt_to_provider` into 5 free fns + `SttFields` struct
- **zeph-llm** (`#3440`): introduce `BioDecoderState` struct with `handle_b/i/s/e/o` methods and `parse_bio_label`; `decode_bio_spans` signature unchanged
- **zeph-sanitizer** (`#3439`): extract 4 helpers + `BinaryStageOutcome` enum; `run_binary_stage` returns `Final` on error/timeout, preventing Stage 2 from running on Stage 1 fallback

All five `#[allow(clippy::too_many_lines)]` suppressions removed.

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — 0 errors
- [ ] `cargo nextest run --workspace --lib --bins` — 8602 passed, 0 failed
- [ ] Behavior verified: `BinaryStageOutcome::Final` type-enforces Stage 2 skip; `binary_score_to_verdict(is_positive=false)` returns `Clean`; `BioDecoderState::handle_e` increments before close

Closes #3438
Closes #3440
Closes #3439