### PR TITLE
refactor(tui): decompose long functions and surface shell background elapsed time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `zeph-tui`: removed all `#[allow(clippy::too_many_lines)]` suppressions in `command.rs`,
+  `app/keys.rs`, `widgets/security.rs`, `widgets/status.rs`, and `widgets/resources.rs` by
+  decomposing each long function into focused private helpers. `command_registry()` migrated to a
+  `OnceLock<Vec<CommandEntry>>` pattern. (#3446)
+- `zeph-tools`, `zeph-core`, `zeph-tui`: wire `BackgroundTask` elapsed time to the TUI resources
+  panel. `BackgroundHandle` gains `elapsed()`, `ShellExecutor` gains `background_runs_snapshot()`,
+  `MetricsSnapshot` gains `shell_background_runs: Vec<ShellBackgroundRunRow>`. The agent captures
+  an `Arc<ShellExecutor>` and refreshes the snapshot on each metrics update. Active runs are
+  rendered under a `Background Shell (n)` header in the resources panel and as `sh:N` in the
+  status bar. (#3448)
+
 - `zeph-tools`: replaced shell-out signal sending with safe `nix`-based SIGTERM/SIGKILL
   escalation in the shell executor. `kill_process_tree` now sends SIGTERM, waits 250 ms,
   reaps child processes via `pkill`, then sends SIGKILL. `ShellExecutor::shutdown` also

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1188,6 +1188,21 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Attach a shared reference to the `ShellExecutor` for background-run TUI metrics.
+    ///
+    /// The agent queries [`zeph_tools::ShellExecutor::background_runs_snapshot`] during
+    /// `reap_background_tasks_and_update_metrics` to populate
+    /// [`crate::metrics::MetricsSnapshot::shell_background_runs`].
+    /// `None` is valid (test harnesses, daemon-only modes without a shell executor).
+    #[must_use]
+    pub fn with_shell_executor_handle(
+        mut self,
+        h: Option<std::sync::Arc<zeph_tools::ShellExecutor>>,
+    ) -> Self {
+        self.lifecycle.shell_executor_handle = h;
+        self
+    }
+
     /// Attach the warmup-ready signal (fires after background init completes).
     #[must_use]
     pub fn with_warmup_ready(mut self, rx: watch::Receiver<bool>) -> Self {

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -1572,6 +1572,27 @@ impl<C: Channel> Agent<C> {
             m.bg_enrichment_inflight = snap.class_inflight[0] as u64;
             m.bg_telemetry_inflight = snap.class_inflight[1] as u64;
         });
+
+        // Update shell background run rows for TUI panel.
+        if self.lifecycle.shell_executor_handle.is_some() {
+            let shell_rows: Vec<crate::metrics::ShellBackgroundRunRow> = self
+                .lifecycle
+                .shell_executor_handle
+                .as_ref()
+                .map(|e| e.background_runs_snapshot())
+                .unwrap_or_default()
+                .into_iter()
+                .map(|s| crate::metrics::ShellBackgroundRunRow {
+                    run_id: truncate_shell_run_id(&s.run_id),
+                    command: truncate_shell_command(&s.command),
+                    elapsed_secs: s.elapsed_ms / 1000,
+                })
+                .collect();
+            self.update_metrics(|m| {
+                m.shell_background_runs = shell_rows;
+            });
+        }
+
         // Intentional ordering: reap() runs before abort_class() so completed tasks are
         // accounted in the snapshot above.
         if self.runtime.supervisor_config.abort_enrichment_on_turn {
@@ -3250,6 +3271,20 @@ pub(crate) async fn recv_optional<T>(rx: &mut Option<mpsc::Receiver<T>>) -> Opti
 /// Mirrors `AppBuilder::auto_budget_tokens` so hot-reload and initial startup use the same
 /// logic: if `auto_budget = true` and `context_budget_tokens == 0`, query the provider's
 /// context window; if still 0, fall back to 128 000 tokens.
+/// Truncate a background run command to at most 80 characters for TUI display.
+fn truncate_shell_command(cmd: &str) -> String {
+    if cmd.len() <= 80 {
+        return cmd.to_owned();
+    }
+    let end = cmd.floor_char_boundary(79);
+    format!("{}…", &cmd[..end])
+}
+
+/// Take the first 8 characters of a run-id hex string for compact TUI display.
+fn truncate_shell_run_id(id: &str) -> String {
+    id.chars().take(8).collect()
+}
+
 pub(crate) fn resolve_context_budget(config: &Config, provider: &AnyProvider) -> usize {
     let tokens = if config.memory.auto_budget && config.memory.context_budget_tokens == 0 {
         if let Some(ctx_size) = provider.context_window() {

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -442,6 +442,9 @@ pub(crate) struct LifecycleState {
     /// `pending_background_completions`. `None` when no `ShellExecutor` is configured.
     pub(crate) background_completion_rx:
         Option<tokio::sync::mpsc::Receiver<zeph_tools::BackgroundCompletion>>,
+    /// Shared reference to the `ShellExecutor` used to query in-flight background run snapshots
+    /// for TUI metrics display. `None` when no `ShellExecutor` is wired (test harnesses, etc.).
+    pub(crate) shell_executor_handle: Option<std::sync::Arc<zeph_tools::ShellExecutor>>,
 }
 
 /// Minimal config snapshot needed to reconstruct a provider at runtime via `/provider <name>`.
@@ -1036,6 +1039,7 @@ impl LifecycleState {
             last_no_providers_at: None,
             pending_background_completions: VecDeque::new(),
             background_completion_rx: None,
+            shell_executor_handle: None,
         }
     }
 }

--- a/crates/zeph-core/src/metrics.rs
+++ b/crates/zeph-core/src/metrics.rs
@@ -382,6 +382,8 @@ pub struct MetricsSnapshot {
     pub bg_enrichment_inflight: u64,
     /// Background supervisor: inflight telemetry tasks.
     pub bg_telemetry_inflight: u64,
+    /// In-flight background shell runs. Empty when none are running or no `ShellExecutor` is wired.
+    pub shell_background_runs: Vec<ShellBackgroundRunRow>,
     /// Whether self-learning (skill evolution) is enabled.
     pub self_learning_enabled: bool,
     /// Whether the semantic response cache is enabled.
@@ -420,6 +422,21 @@ pub struct MetricsSnapshot {
     pub compaction_last_after: u64,
     /// Unix epoch milliseconds when the most recent compaction occurred. `0` = never compacted.
     pub compaction_last_at_ms: u64,
+}
+
+/// Snapshot of a single in-flight background shell run for TUI display.
+///
+/// Populated from [`zeph_tools::BackgroundRunSnapshot`] during the per-turn metrics update in
+/// `reap_background_tasks_and_update_metrics`. The `run_id` is truncated to 8 hex chars for
+/// compact TUI rendering.
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct ShellBackgroundRunRow {
+    /// First 8 hex characters of the run's UUID, sufficient for unique identification in TUI.
+    pub run_id: String,
+    /// Original command, truncated to 80 characters.
+    pub command: String,
+    /// Wall-clock elapsed seconds since spawn.
+    pub elapsed_secs: u64,
 }
 
 /// Configuration-derived fields of [`MetricsSnapshot`] that are known at agent startup and do

--- a/crates/zeph-tools/src/lib.rs
+++ b/crates/zeph-tools/src/lib.rs
@@ -143,7 +143,7 @@ pub use scrape::WebScrapeExecutor;
 pub use search_code::{
     LspSearchBackend, SearchCodeExecutor, SearchCodeHit, SearchCodeSource, SemanticSearchBackend,
 };
-pub use shell::background::{BackgroundCompletion, RunId};
+pub use shell::background::{BackgroundCompletion, BackgroundRunSnapshot, RunId};
 pub use shell::{
     DEFAULT_BLOCKED_COMMANDS, SHELL_INTERPRETERS, ShellExecutor, ShellOutputEnvelope,
     ShellPolicyHandle, check_blocklist, effective_shell_command,

--- a/crates/zeph-tools/src/shell/background.rs
+++ b/crates/zeph-tools/src/shell/background.rs
@@ -43,13 +43,32 @@ pub(crate) struct BackgroundHandle {
     /// Command string, stored for shutdown reporting and TUI display.
     pub command: String,
     /// Wall-clock start time for elapsed reporting.
-    // TODO(#3448): expose via TUI panel for per-run elapsed display.
-    #[allow(dead_code)]
     pub started_at: Instant,
     /// Cancellation token. Cancel to request graceful shutdown.
     pub abort: CancellationToken,
     /// OS process ID, if known. Used for SIGTERM/SIGKILL escalation on Unix during shutdown.
     pub child_pid: Option<u32>,
+}
+
+impl BackgroundHandle {
+    /// Returns the wall-clock elapsed time since this run was spawned.
+    pub(crate) fn elapsed(&self) -> std::time::Duration {
+        self.started_at.elapsed()
+    }
+}
+
+/// Lightweight snapshot of a single in-flight background shell run.
+///
+/// Produced by [`super::ShellExecutor::background_runs_snapshot`] and consumed
+/// by the TUI resources panel and the metrics snapshot update path.
+#[derive(Debug, Clone)]
+pub struct BackgroundRunSnapshot {
+    /// Opaque run identifier, encoded as a 32-character lowercase hex string.
+    pub run_id: String,
+    /// Original command string, already stored on the handle.
+    pub command: String,
+    /// Wall-clock milliseconds since spawn.
+    pub elapsed_ms: u64,
 }
 
 /// Final result delivered when a background run finishes.

--- a/crates/zeph-tools/src/shell/mod.rs
+++ b/crates/zeph-tools/src/shell/mod.rs
@@ -47,6 +47,7 @@ use crate::permissions::{PermissionAction, PermissionPolicy};
 use crate::sandbox::{Sandbox, SandboxPolicy};
 
 pub mod background;
+pub use background::BackgroundRunSnapshot;
 use background::{BackgroundCompletion, BackgroundHandle, RunId};
 
 mod transaction;
@@ -386,6 +387,27 @@ impl ShellExecutor {
     pub fn with_output_filters(mut self, registry: OutputFilterRegistry) -> Self {
         self.output_filter_registry = Some(registry);
         self
+    }
+
+    /// Snapshot all in-flight background runs.
+    ///
+    /// Acquires the lock once, maps each [`BackgroundHandle`] to a
+    /// [`BackgroundRunSnapshot`], then drops the guard before returning.
+    /// Safe to call from any thread.
+    #[must_use]
+    pub fn background_runs_snapshot(&self) -> Vec<background::BackgroundRunSnapshot> {
+        let runs = self.background_runs.lock();
+        runs.iter()
+            .map(|(id, h)| {
+                #[allow(clippy::cast_possible_truncation)]
+                let elapsed_ms = h.elapsed().as_millis() as u64;
+                background::BackgroundRunSnapshot {
+                    run_id: id.to_string(),
+                    command: h.command.clone(),
+                    elapsed_ms,
+                }
+            })
+            .collect()
     }
 
     /// Return a clonable handle for live policy rebuilds on hot-reload.
@@ -960,6 +982,24 @@ impl ShellExecutor {
             };
             logger.log(&entry).await;
         }
+    }
+}
+
+impl ToolExecutor for std::sync::Arc<ShellExecutor> {
+    async fn execute(&self, response: &str) -> Result<Option<ToolOutput>, ToolError> {
+        self.as_ref().execute(response).await
+    }
+
+    fn tool_definitions(&self) -> Vec<crate::registry::ToolDef> {
+        self.as_ref().tool_definitions()
+    }
+
+    async fn execute_tool_call(&self, call: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
+        self.as_ref().execute_tool_call(call).await
+    }
+
+    fn set_skill_env(&self, env: Option<std::collections::HashMap<String, String>>) {
+        self.as_ref().set_skill_env(env);
     }
 }
 

--- a/crates/zeph-tools/src/shell/tests.rs
+++ b/crates/zeph-tools/src/shell/tests.rs
@@ -2666,3 +2666,33 @@ async fn shutdown_terminates_long_running_background() {
     // We verify by trying to spawn background again — the slot should be free.
     let _ = run_id; // used to capture the ID for the assertion context above
 }
+
+#[tokio::test]
+async fn background_runs_snapshot_returns_active_run() {
+    use std::time::Duration;
+
+    let executor = ShellExecutor::new(&default_config());
+    let _run_id = executor
+        .spawn_background("sleep 60")
+        .await
+        .expect("spawn_background failed");
+
+    // Allow the process to start before snapshotting.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let snapshot = executor.background_runs_snapshot();
+    assert_eq!(
+        snapshot.len(),
+        1,
+        "expected exactly one active background run"
+    );
+
+    let row = &snapshot[0];
+    assert_eq!(
+        row.command, "sleep 60",
+        "snapshot command must match spawned command"
+    );
+    assert!(!row.run_id.is_empty(), "snapshot run_id must be non-empty");
+
+    executor.shutdown().await;
+}

--- a/crates/zeph-tui/src/app/keys.rs
+++ b/crates/zeph-tui/src/app/keys.rs
@@ -253,9 +253,7 @@ impl App {
         if self.handle_plugin_command(&cmd) {
             return;
         }
-        if self.handle_acp_command(cmd) {
-            return;
-        }
+        self.handle_acp_command(cmd);
     }
 
     fn handle_plan_command(&mut self, cmd: &TuiCommand) -> bool {

--- a/crates/zeph-tui/src/app/keys.rs
+++ b/crates/zeph-tui/src/app/keys.rs
@@ -237,8 +237,28 @@ impl App {
         }
     }
 
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3446): decompose into smaller helpers
     fn execute_plan_graph_command(&mut self, cmd: TuiCommand) {
+        if self.handle_plan_command(&cmd) {
+            return;
+        }
+        if self.handle_graph_command(&cmd) {
+            return;
+        }
+        if self.handle_experiment_command(&cmd) {
+            return;
+        }
+        if self.handle_memory_command(&cmd) {
+            return;
+        }
+        if self.handle_plugin_command(&cmd) {
+            return;
+        }
+        if self.handle_acp_command(cmd) {
+            return;
+        }
+    }
+
+    fn handle_plan_command(&mut self, cmd: &TuiCommand) -> bool {
         match cmd {
             TuiCommand::PlanStatus => {
                 let _ = self.user_input_tx.try_send("/plan status".to_owned());
@@ -256,6 +276,13 @@ impl App {
                 self.sessions.current_mut().plan_view_active =
                     !self.sessions.current().plan_view_active;
             }
+            _ => return false,
+        }
+        true
+    }
+
+    fn handle_graph_command(&mut self, cmd: &TuiCommand) -> bool {
+        match cmd {
             TuiCommand::GraphStats => {
                 self.push_system_message("Loading graph stats...".to_owned());
                 let _ = self.user_input_tx.try_send("/graph".to_owned());
@@ -270,6 +297,13 @@ impl App {
             }
             TuiCommand::GraphFactsPrompt => self.prefill_input("/graph facts "),
             TuiCommand::GraphBackfillPrompt => self.prefill_input("/graph backfill"),
+            _ => return false,
+        }
+        true
+    }
+
+    fn handle_experiment_command(&mut self, cmd: &TuiCommand) -> bool {
+        match cmd {
             TuiCommand::ExperimentStart => self.prefill_input("/experiment start "),
             TuiCommand::ExperimentStop => {
                 let _ = self.user_input_tx.try_send("/experiment stop".to_owned());
@@ -283,20 +317,13 @@ impl App {
             TuiCommand::ExperimentBest => {
                 let _ = self.user_input_tx.try_send("/experiment best".to_owned());
             }
-            TuiCommand::LspStatus => {
-                self.push_system_message("Checking LSP context injection status...".to_owned());
-                let _ = self.user_input_tx.try_send("/lsp".to_owned());
-            }
-            TuiCommand::ViewLog => {
-                let _ = self.user_input_tx.try_send("/log".to_owned());
-            }
-            TuiCommand::MigrateConfig => {
-                self.push_system_message(
-                    "To preview missing config parameters, run:\n  zeph migrate-config --diff\n\
-                     To apply changes in-place:\n  zeph migrate-config --in-place"
-                        .to_owned(),
-                );
-            }
+            _ => return false,
+        }
+        true
+    }
+
+    fn handle_memory_command(&mut self, cmd: &TuiCommand) -> bool {
+        match cmd {
             TuiCommand::ServerCompactionStatus => {
                 let _ = self.user_input_tx.try_send("/server-compaction".to_owned());
             }
@@ -312,17 +339,31 @@ impl App {
             TuiCommand::MemoryTreeStats => {
                 let _ = self.user_input_tx.try_send("/memory tree".to_owned());
             }
+            _ => return false,
+        }
+        true
+    }
+
+    fn handle_plugin_command(&mut self, cmd: &TuiCommand) -> bool {
+        match cmd {
             TuiCommand::PluginList => {
                 let _ = self.user_input_tx.try_send("/plugins list".to_owned());
             }
             TuiCommand::PluginAdd => self.prefill_input("/plugins add "),
             TuiCommand::PluginRemove => self.prefill_input("/plugins remove "),
-            TuiCommand::SessionSwitchNext
-            | TuiCommand::SessionSwitchPrev
-            | TuiCommand::SessionClose => self.try_switch(&cmd),
             TuiCommand::PluginListOverlay => {
                 let _ = self.user_input_tx.try_send("/plugins overlay".to_owned());
             }
+            TuiCommand::SessionSwitchNext
+            | TuiCommand::SessionSwitchPrev
+            | TuiCommand::SessionClose => self.try_switch(cmd),
+            _ => return false,
+        }
+        true
+    }
+
+    fn handle_acp_command(&mut self, cmd: TuiCommand) -> bool {
+        match cmd {
             TuiCommand::AcpDirsList => {
                 self.push_system_message("Querying ACP runtime...".to_owned());
                 let _ = self.user_input_tx.try_send("/acp dirs".to_owned());
@@ -344,8 +385,23 @@ impl App {
                         .try_send(format!("/subagent spawn {command}"));
                 }
             }
-            _ => {}
+            TuiCommand::LspStatus => {
+                self.push_system_message("Checking LSP context injection status...".to_owned());
+                let _ = self.user_input_tx.try_send("/lsp".to_owned());
+            }
+            TuiCommand::ViewLog => {
+                let _ = self.user_input_tx.try_send("/log".to_owned());
+            }
+            TuiCommand::MigrateConfig => {
+                self.push_system_message(
+                    "To preview missing config parameters, run:\n  zeph migrate-config --diff\n\
+                     To apply changes in-place:\n  zeph migrate-config --in-place"
+                        .to_owned(),
+                );
+            }
+            _ => return false,
         }
+        true
     }
 
     /// Handle a session switch or close command, blocking when a modal with a response channel
@@ -804,28 +860,59 @@ impl App {
         }
     }
 
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3446): decompose into smaller helpers
     fn handle_insert_key(&mut self, key: KeyEvent) {
         if self.slash_autocomplete.is_some() {
             self.handle_slash_autocomplete_key(key);
             return;
         }
+        if self.handle_insert_text_keys(key) {
+            return;
+        }
+        if self.handle_insert_delete_keys(key) {
+            return;
+        }
+        if self.handle_insert_history_keys(key) {
+            return;
+        }
+        if self.handle_insert_cursor_keys(key) {
+            return;
+        }
+        self.handle_insert_control_keys(key);
+    }
+
+    /// Insert a newline character at the current cursor position.
+    ///
+    /// Shared body for `Shift+Enter` and `Ctrl+J`.
+    fn insert_newline_at_cursor(&mut self) {
+        self.sessions.current_mut().paste_state = None;
+        let byte_offset = self.byte_offset_of_char(self.sessions.current().cursor_position);
+        self.sessions.current_mut().input.insert(byte_offset, '\n');
+        self.sessions.current_mut().cursor_position += 1;
+    }
+
+    /// Handle text insertion keys: Enter (submit), Shift+Enter / Ctrl+J (newline), Esc.
+    ///
+    /// Returns `true` when the key was handled.
+    fn handle_insert_text_keys(&mut self, key: KeyEvent) -> bool {
         match key.code {
             KeyCode::Enter if key.modifiers.contains(KeyModifiers::SHIFT) => {
-                // First edit keystroke after paste reveals raw text; clear indicator.
-                self.sessions.current_mut().paste_state = None;
-                let byte_offset = self.byte_offset_of_char(self.sessions.current().cursor_position);
-                self.sessions.current_mut().input.insert(byte_offset, '\n');
-                self.sessions.current_mut().cursor_position += 1;
+                self.insert_newline_at_cursor();
             }
             KeyCode::Char('j') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                self.sessions.current_mut().paste_state = None;
-                let byte_offset = self.byte_offset_of_char(self.sessions.current().cursor_position);
-                self.sessions.current_mut().input.insert(byte_offset, '\n');
-                self.sessions.current_mut().cursor_position += 1;
+                self.insert_newline_at_cursor();
             }
             KeyCode::Enter => self.submit_input(),
             KeyCode::Esc => self.sessions.current_mut().input_mode = InputMode::Normal,
+            _ => return false,
+        }
+        true
+    }
+
+    /// Handle delete keys: Backspace (with or without Alt), Delete.
+    ///
+    /// Returns `true` when the key was handled.
+    fn handle_insert_delete_keys(&mut self, key: KeyEvent) -> bool {
+        match key.code {
             KeyCode::Backspace if key.modifiers.contains(KeyModifiers::ALT) => {
                 // First edit keystroke after paste reveals raw text; subsequent keystrokes edit normally.
                 self.sessions.current_mut().paste_state = None;
@@ -856,13 +943,23 @@ impl App {
                     self.sessions.current_mut().input.remove(byte_offset);
                 }
             }
+            _ => return false,
+        }
+        true
+    }
+
+    /// Handle history navigation keys: Up, Down.
+    ///
+    /// Returns `true` when the key was handled.
+    fn handle_insert_history_keys(&mut self, key: KeyEvent) -> bool {
+        match key.code {
             KeyCode::Up => {
                 self.handle_history_up();
             }
             KeyCode::Down => {
                 self.sessions.current_mut().paste_state = None;
                 let Some(i) = self.sessions.current().history_index else {
-                    return;
+                    return true;
                 };
                 let prefix = &self.sessions.current().draft_input;
                 let found = self.sessions.current().input_history[i + 1..]
@@ -880,6 +977,16 @@ impl App {
                 }
                 self.sessions.current_mut().cursor_position = self.char_count();
             }
+            _ => return false,
+        }
+        true
+    }
+
+    /// Handle cursor movement keys: Left, Right (with optional Alt), Home, End.
+    ///
+    /// Returns `true` when the key was handled.
+    fn handle_insert_cursor_keys(&mut self, key: KeyEvent) -> bool {
+        match key.code {
             KeyCode::Left if key.modifiers.contains(KeyModifiers::ALT) => {
                 self.sessions.current_mut().paste_state = None;
                 self.sessions.current_mut().cursor_position = self.prev_word_boundary();
@@ -907,6 +1014,16 @@ impl App {
                 self.sessions.current_mut().paste_state = None;
                 self.sessions.current_mut().cursor_position = self.char_count();
             }
+            _ => return false,
+        }
+        true
+    }
+
+    /// Handle Ctrl-key shortcuts and character insertion (including slash autocomplete trigger).
+    ///
+    /// Returns `true` when the key was handled; `false` for unrecognised keys.
+    fn handle_insert_control_keys(&mut self, key: KeyEvent) -> bool {
+        match key.code {
             KeyCode::Char('a') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 self.sessions.current_mut().paste_state = None;
                 self.sessions.current_mut().cursor_position = 0;
@@ -937,8 +1054,9 @@ impl App {
                     self.slash_autocomplete = Some(SlashAutocompleteState::new());
                 }
             }
-            _ => {}
+            _ => return false,
         }
+        true
     }
 
     fn handle_slash_autocomplete_key(&mut self, key: KeyEvent) {

--- a/crates/zeph-tui/src/command.rs
+++ b/crates/zeph-tui/src/command.rs
@@ -149,6 +149,8 @@ pub struct CommandEntry {
 /// actions. Extended commands (agent, plan, graph, experiment, infra) are in
 /// [`extra_command_registry`] and daemon commands in [`daemon_command_registry`].
 ///
+/// Lazily initialised on first call and then shared for the process lifetime.
+///
 /// # Examples
 ///
 /// ```rust
@@ -159,9 +161,13 @@ pub struct CommandEntry {
 /// assert!(registry.iter().any(|e| e.id == "app:quit"));
 /// ```
 #[must_use]
-#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3446): decompose into smaller helpers
 pub fn command_registry() -> &'static [CommandEntry] {
-    static COMMANDS: &[CommandEntry] = &[
+    static COMMANDS: std::sync::OnceLock<Vec<CommandEntry>> = std::sync::OnceLock::new();
+    COMMANDS.get_or_init(build_core_commands)
+}
+
+fn build_view_commands() -> Vec<CommandEntry> {
+    vec![
         CommandEntry {
             id: "skill:list",
             label: "List loaded skills",
@@ -212,6 +218,18 @@ pub fn command_registry() -> &'static [CommandEntry] {
             command: TuiCommand::ViewAutonomy,
         },
         CommandEntry {
+            id: "tasks",
+            label: "Toggle task registry panel",
+            category: "view",
+            shortcut: None,
+            command: TuiCommand::TaskPanel,
+        },
+    ]
+}
+
+fn build_session_commands() -> Vec<CommandEntry> {
+    vec![
+        CommandEntry {
             id: "session:new",
             label: "Start new conversation",
             category: "session",
@@ -224,55 +242,6 @@ pub fn command_registry() -> &'static [CommandEntry] {
             category: "session",
             shortcut: Some("H"),
             command: TuiCommand::SessionBrowser,
-        },
-        CommandEntry {
-            id: "app:quit",
-            label: "Quit application",
-            category: "app",
-            shortcut: Some("q"),
-            command: TuiCommand::Quit,
-        },
-        CommandEntry {
-            id: "app:help",
-            label: "Show keybindings help",
-            category: "app",
-            shortcut: Some("?"),
-            command: TuiCommand::Help,
-        },
-        CommandEntry {
-            id: "app:theme",
-            label: "Toggle theme (dark/light)",
-            category: "app",
-            shortcut: None,
-            command: TuiCommand::ToggleTheme,
-        },
-        CommandEntry {
-            id: "tasks",
-            label: "Toggle task registry panel",
-            category: "view",
-            shortcut: None,
-            command: TuiCommand::TaskPanel,
-        },
-        CommandEntry {
-            id: "plugin:list",
-            label: "List installed plugins (/plugins list)",
-            category: "plugin",
-            shortcut: None,
-            command: TuiCommand::PluginList,
-        },
-        CommandEntry {
-            id: "plugin:add",
-            label: "Install a plugin (/plugins add <source>)",
-            category: "plugin",
-            shortcut: None,
-            command: TuiCommand::PluginAdd,
-        },
-        CommandEntry {
-            id: "plugin:remove",
-            label: "Remove an installed plugin (/plugins remove <name>)",
-            category: "plugin",
-            shortcut: None,
-            command: TuiCommand::PluginRemove,
         },
         CommandEntry {
             id: "session:next",
@@ -295,6 +264,58 @@ pub fn command_registry() -> &'static [CommandEntry] {
             shortcut: None,
             command: TuiCommand::SessionClose,
         },
+    ]
+}
+
+fn build_app_commands() -> Vec<CommandEntry> {
+    vec![
+        CommandEntry {
+            id: "app:quit",
+            label: "Quit application",
+            category: "app",
+            shortcut: Some("q"),
+            command: TuiCommand::Quit,
+        },
+        CommandEntry {
+            id: "app:help",
+            label: "Show keybindings help",
+            category: "app",
+            shortcut: Some("?"),
+            command: TuiCommand::Help,
+        },
+        CommandEntry {
+            id: "app:theme",
+            label: "Toggle theme (dark/light)",
+            category: "app",
+            shortcut: None,
+            command: TuiCommand::ToggleTheme,
+        },
+    ]
+}
+
+fn build_plugin_commands() -> Vec<CommandEntry> {
+    vec![
+        CommandEntry {
+            id: "plugin:list",
+            label: "List installed plugins (/plugins list)",
+            category: "plugin",
+            shortcut: None,
+            command: TuiCommand::PluginList,
+        },
+        CommandEntry {
+            id: "plugin:add",
+            label: "Install a plugin (/plugins add <source>)",
+            category: "plugin",
+            shortcut: None,
+            command: TuiCommand::PluginAdd,
+        },
+        CommandEntry {
+            id: "plugin:remove",
+            label: "Remove an installed plugin (/plugins remove <name>)",
+            category: "plugin",
+            shortcut: None,
+            command: TuiCommand::PluginRemove,
+        },
         CommandEntry {
             id: "plugin:overlay",
             label: "Plugin overlay status — source and skipped plugins (/plugins overlay)",
@@ -302,8 +323,15 @@ pub fn command_registry() -> &'static [CommandEntry] {
             shortcut: None,
             command: TuiCommand::PluginListOverlay,
         },
-    ];
-    COMMANDS
+    ]
+}
+
+fn build_core_commands() -> Vec<CommandEntry> {
+    let mut cmds = build_view_commands();
+    cmds.extend(build_session_commands());
+    cmds.extend(build_app_commands());
+    cmds.extend(build_plugin_commands());
+    cmds
 }
 
 /// Returns the static registry of daemon / remote-connection commands.

--- a/crates/zeph-tui/src/widgets/resources.rs
+++ b/crates/zeph-tui/src/widgets/resources.rs
@@ -50,11 +50,7 @@ fn append_llm_section(lines: &mut Vec<Line<'_>>, metrics: &MetricsSnapshot) {
     }
 }
 
-fn append_session_section(
-    lines: &mut Vec<Line<'_>>,
-    metrics: &MetricsSnapshot,
-    collapsed: bool,
-) {
+fn append_session_section(lines: &mut Vec<Line<'_>>, metrics: &MetricsSnapshot, collapsed: bool) {
     if collapsed {
         lines.push(Line::from(format!(
             "  Session: {} tok | {} calls",

--- a/crates/zeph-tui/src/widgets/resources.rs
+++ b/crates/zeph-tui/src/widgets/resources.rs
@@ -28,7 +28,7 @@ pub fn render(metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect) {
     frame.render_widget(resources, area);
 }
 
-fn append_llm_section<'a>(lines: &mut Vec<Line<'a>>, metrics: &MetricsSnapshot) {
+fn append_llm_section(lines: &mut Vec<Line<'_>>, metrics: &MetricsSnapshot) {
     lines.push(Line::from("  LLM"));
     lines.push(Line::from(format!(
         "    Provider: {}",
@@ -50,8 +50,8 @@ fn append_llm_section<'a>(lines: &mut Vec<Line<'a>>, metrics: &MetricsSnapshot) 
     }
 }
 
-fn append_session_section<'a>(
-    lines: &mut Vec<Line<'a>>,
+fn append_session_section(
+    lines: &mut Vec<Line<'_>>,
     metrics: &MetricsSnapshot,
     collapsed: bool,
 ) {
@@ -106,7 +106,7 @@ fn append_session_section<'a>(
     }
 }
 
-fn append_infra_section<'a>(lines: &mut Vec<Line<'a>>, metrics: &MetricsSnapshot, collapsed: bool) {
+fn append_infra_section(lines: &mut Vec<Line<'_>>, metrics: &MetricsSnapshot, collapsed: bool) {
     if collapsed {
         let mut infra_parts: Vec<String> = Vec::new();
         if !metrics.vault_backend.is_empty() {
@@ -151,7 +151,7 @@ fn append_infra_section<'a>(lines: &mut Vec<Line<'a>>, metrics: &MetricsSnapshot
     }
 }
 
-fn append_shell_background_section<'a>(lines: &mut Vec<Line<'a>>, metrics: &MetricsSnapshot) {
+fn append_shell_background_section(lines: &mut Vec<Line<'_>>, metrics: &MetricsSnapshot) {
     if metrics.shell_background_runs.is_empty() {
         return;
     }
@@ -176,7 +176,7 @@ fn append_shell_background_section<'a>(lines: &mut Vec<Line<'a>>, metrics: &Metr
     }
 }
 
-fn append_turn_latency_section<'a>(lines: &mut Vec<Line<'a>>, metrics: &MetricsSnapshot) {
+fn append_turn_latency_section(lines: &mut Vec<Line<'_>>, metrics: &MetricsSnapshot) {
     if metrics.timing_sample_count == 0 {
         return;
     }
@@ -200,7 +200,7 @@ fn append_turn_latency_section<'a>(lines: &mut Vec<Line<'a>>, metrics: &MetricsS
     }
 }
 
-fn append_classifier_section<'a>(lines: &mut Vec<Line<'a>>, metrics: &MetricsSnapshot) {
+fn append_classifier_section(lines: &mut Vec<Line<'_>>, metrics: &MetricsSnapshot) {
     let clf = &metrics.classifier;
     let has_data =
         clf.injection.call_count > 0 || clf.pii.call_count > 0 || clf.feedback.call_count > 0;

--- a/crates/zeph-tui/src/widgets/resources.rs
+++ b/crates/zeph-tui/src/widgets/resources.rs
@@ -9,15 +9,26 @@ use ratatui::widgets::{Block, Borders, Paragraph};
 use crate::metrics::MetricsSnapshot;
 use crate::theme::Theme;
 
-#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3446): decompose into smaller helpers
 pub fn render(metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect) {
     let theme = Theme::default();
-
     let collapsed = area.height < 30;
-
     let mut lines: Vec<Line<'_>> = Vec::new();
+    append_llm_section(&mut lines, metrics);
+    append_session_section(&mut lines, metrics, collapsed);
+    append_infra_section(&mut lines, metrics, collapsed);
+    append_shell_background_section(&mut lines, metrics);
+    append_turn_latency_section(&mut lines, metrics);
+    append_classifier_section(&mut lines, metrics);
+    let resources = Paragraph::new(lines).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(theme.panel_border)
+            .title(" Resources "),
+    );
+    frame.render_widget(resources, area);
+}
 
-    // LLM section
+fn append_llm_section<'a>(lines: &mut Vec<Line<'a>>, metrics: &MetricsSnapshot) {
     lines.push(Line::from("  LLM"));
     lines.push(Line::from(format!(
         "    Provider: {}",
@@ -37,60 +48,65 @@ pub fn render(metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect) {
     if metrics.extended_context {
         lines.push(Line::from("    Max context: 1M"));
     }
+}
 
-    // Session section
+fn append_session_section<'a>(
+    lines: &mut Vec<Line<'a>>,
+    metrics: &MetricsSnapshot,
+    collapsed: bool,
+) {
     if collapsed {
         lines.push(Line::from(format!(
             "  Session: {} tok | {} calls",
             metrics.total_tokens, metrics.api_calls
         )));
-    } else {
-        lines.push(Line::from("  Session"));
-        lines.push(Line::from(format!(
-            "    Tokens: {} | API: {}",
-            metrics.total_tokens, metrics.api_calls
-        )));
-        if let Some(budget) = metrics.token_budget {
-            if let Some(threshold) = metrics.compaction_threshold {
-                lines.push(Line::from(format!(
-                    "    Budget: {budget} | Compact: {threshold}"
-                )));
-            } else {
-                lines.push(Line::from(format!("    Budget: {budget}")));
-            }
-        }
-        if metrics.cache_creation_tokens > 0 || metrics.cache_read_tokens > 0 {
+        return;
+    }
+    lines.push(Line::from("  Session"));
+    lines.push(Line::from(format!(
+        "    Tokens: {} | API: {}",
+        metrics.total_tokens, metrics.api_calls
+    )));
+    if let Some(budget) = metrics.token_budget {
+        if let Some(threshold) = metrics.compaction_threshold {
             lines.push(Line::from(format!(
-                "    Cache W:{} R:{}",
-                metrics.cache_creation_tokens, metrics.cache_read_tokens
+                "    Budget: {budget} | Compact: {threshold}"
             )));
-        }
-        if metrics.filter_applications > 0 {
-            #[allow(clippy::cast_precision_loss)]
-            let hit_pct = if metrics.filter_total_commands > 0 {
-                metrics.filter_filtered_commands as f64 / metrics.filter_total_commands as f64
-                    * 100.0
-            } else {
-                0.0
-            };
-            lines.push(Line::from(format!(
-                "    Filter: {}/{} ({hit_pct:.0}% hit)",
-                metrics.filter_filtered_commands, metrics.filter_total_commands,
-            )));
-            #[allow(clippy::cast_precision_loss)]
-            let pct = if metrics.filter_raw_tokens > 0 {
-                metrics.filter_saved_tokens as f64 / metrics.filter_raw_tokens as f64 * 100.0
-            } else {
-                0.0
-            };
-            lines.push(Line::from(format!(
-                "    Filter saved: {} tok ({pct:.0}%)",
-                metrics.filter_saved_tokens,
-            )));
+        } else {
+            lines.push(Line::from(format!("    Budget: {budget}")));
         }
     }
+    if metrics.cache_creation_tokens > 0 || metrics.cache_read_tokens > 0 {
+        lines.push(Line::from(format!(
+            "    Cache W:{} R:{}",
+            metrics.cache_creation_tokens, metrics.cache_read_tokens
+        )));
+    }
+    if metrics.filter_applications > 0 {
+        #[allow(clippy::cast_precision_loss)]
+        let hit_pct = if metrics.filter_total_commands > 0 {
+            metrics.filter_filtered_commands as f64 / metrics.filter_total_commands as f64 * 100.0
+        } else {
+            0.0
+        };
+        lines.push(Line::from(format!(
+            "    Filter: {}/{} ({hit_pct:.0}% hit)",
+            metrics.filter_filtered_commands, metrics.filter_total_commands,
+        )));
+        #[allow(clippy::cast_precision_loss)]
+        let pct = if metrics.filter_raw_tokens > 0 {
+            metrics.filter_saved_tokens as f64 / metrics.filter_raw_tokens as f64 * 100.0
+        } else {
+            0.0
+        };
+        lines.push(Line::from(format!(
+            "    Filter saved: {} tok ({pct:.0}%)",
+            metrics.filter_saved_tokens,
+        )));
+    }
+}
 
-    // Infra section
+fn append_infra_section<'a>(lines: &mut Vec<Line<'a>>, metrics: &MetricsSnapshot, collapsed: bool) {
     if collapsed {
         let mut infra_parts: Vec<String> = Vec::new();
         if !metrics.vault_backend.is_empty() {
@@ -102,90 +118,110 @@ pub fn render(metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect) {
         if !infra_parts.is_empty() {
             lines.push(Line::from(format!("  Infra: {}", infra_parts.join(" | "))));
         }
-    } else {
-        lines.push(Line::from("  Infra"));
-        match (
-            metrics.vault_backend.as_str(),
-            metrics.active_channel.as_str(),
-        ) {
-            ("", "") => {}
-            (v, "") => lines.push(Line::from(format!("    Vault: {v}"))),
-            ("", c) => lines.push(Line::from(format!("    Channel: {c}"))),
-            (v, c) => lines.push(Line::from(format!("    Vault: {v} | Channel: {c}"))),
-        }
-
-        let mut flags: Vec<&str> = Vec::new();
-        if metrics.self_learning_enabled {
-            flags.push("Learning: ON");
-        }
-        if metrics.cache_enabled {
-            flags.push("Cache: ON");
-        }
-        if metrics.autosave_enabled {
-            flags.push("Autosave: ON");
-        }
-        if !flags.is_empty() {
-            lines.push(Line::from(format!("    {}", flags.join(" | "))));
-        }
-        if metrics.mcp_server_count > 0 {
-            lines.push(Line::from(format!(
-                "    MCP: {}/{} connected, {} tools",
-                metrics.mcp_connected_count, metrics.mcp_server_count, metrics.mcp_tool_count
-            )));
-        }
+        return;
     }
-
-    // Turn latency section — only shown after at least one turn has completed (#2820).
-    if metrics.timing_sample_count > 0 {
-        let last = &metrics.last_turn_timings;
-        let avg = &metrics.avg_turn_timings;
-        let max = &metrics.max_turn_timings;
-        lines.push(Line::from("  Turn Latency"));
+    lines.push(Line::from("  Infra"));
+    match (
+        metrics.vault_backend.as_str(),
+        metrics.active_channel.as_str(),
+    ) {
+        ("", "") => {}
+        (v, "") => lines.push(Line::from(format!("    Vault: {v}"))),
+        ("", c) => lines.push(Line::from(format!("    Channel: {c}"))),
+        (v, c) => lines.push(Line::from(format!("    Vault: {v} | Channel: {c}"))),
+    }
+    let mut flags: Vec<&str> = Vec::new();
+    if metrics.self_learning_enabled {
+        flags.push("Learning: ON");
+    }
+    if metrics.cache_enabled {
+        flags.push("Cache: ON");
+    }
+    if metrics.autosave_enabled {
+        flags.push("Autosave: ON");
+    }
+    if !flags.is_empty() {
+        lines.push(Line::from(format!("    {}", flags.join(" | "))));
+    }
+    if metrics.mcp_server_count > 0 {
         lines.push(Line::from(format!(
-            "    ctx:{}ms llm:{}ms tool:{}ms persist:{}ms",
-            last.prepare_context_ms, last.llm_chat_ms, last.tool_exec_ms, last.persist_message_ms,
+            "    MCP: {}/{} connected, {} tools",
+            metrics.mcp_connected_count, metrics.mcp_server_count, metrics.mcp_tool_count
         )));
-        if metrics.timing_sample_count > 1 {
-            lines.push(Line::from(format!(
-                "    avg ctx:{}ms llm:{}ms (n={})",
-                avg.prepare_context_ms, avg.llm_chat_ms, metrics.timing_sample_count,
-            )));
-            lines.push(Line::from(format!(
-                "    max ctx:{}ms llm:{}ms tool:{}ms",
-                max.prepare_context_ms, max.llm_chat_ms, max.tool_exec_ms,
-            )));
-        }
     }
+}
 
-    // Classifier latency section — only shown when at least one task has been called.
+fn append_shell_background_section<'a>(lines: &mut Vec<Line<'a>>, metrics: &MetricsSnapshot) {
+    if metrics.shell_background_runs.is_empty() {
+        return;
+    }
+    lines.push(Line::from(format!(
+        "  Background Shell ({})",
+        metrics.shell_background_runs.len()
+    )));
+    for run in &metrics.shell_background_runs {
+        let elapsed_secs = run.elapsed_secs;
+        let mm = elapsed_secs / 60;
+        let ss = elapsed_secs % 60;
+        let cmd = if run.command.chars().count() > 60 {
+            let end = run.command.floor_char_boundary(59);
+            format!("{}…", &run.command[..end])
+        } else {
+            run.command.clone()
+        };
+        lines.push(Line::from(format!(
+            "  [{}] {:02}:{:02}  {}",
+            run.run_id, mm, ss, cmd
+        )));
+    }
+}
+
+fn append_turn_latency_section<'a>(lines: &mut Vec<Line<'a>>, metrics: &MetricsSnapshot) {
+    if metrics.timing_sample_count == 0 {
+        return;
+    }
+    let last = &metrics.last_turn_timings;
+    let avg = &metrics.avg_turn_timings;
+    let max = &metrics.max_turn_timings;
+    lines.push(Line::from("  Turn Latency"));
+    lines.push(Line::from(format!(
+        "    ctx:{}ms llm:{}ms tool:{}ms persist:{}ms",
+        last.prepare_context_ms, last.llm_chat_ms, last.tool_exec_ms, last.persist_message_ms,
+    )));
+    if metrics.timing_sample_count > 1 {
+        lines.push(Line::from(format!(
+            "    avg ctx:{}ms llm:{}ms (n={})",
+            avg.prepare_context_ms, avg.llm_chat_ms, metrics.timing_sample_count,
+        )));
+        lines.push(Line::from(format!(
+            "    max ctx:{}ms llm:{}ms tool:{}ms",
+            max.prepare_context_ms, max.llm_chat_ms, max.tool_exec_ms,
+        )));
+    }
+}
+
+fn append_classifier_section<'a>(lines: &mut Vec<Line<'a>>, metrics: &MetricsSnapshot) {
     let clf = &metrics.classifier;
-    let has_classifier_data =
+    let has_data =
         clf.injection.call_count > 0 || clf.pii.call_count > 0 || clf.feedback.call_count > 0;
-    if has_classifier_data {
-        lines.push(Line::from("  Classifiers"));
-        for (name, snap) in [
-            ("injection", &clf.injection),
-            ("pii", &clf.pii),
-            ("feedback", &clf.feedback),
-        ] {
-            if snap.call_count > 0 {
-                lines.push(Line::from(format!(
-                    "    [{name}] calls:{} p50:{}ms p95:{}ms",
-                    snap.call_count,
-                    snap.p50_ms.unwrap_or(0),
-                    snap.p95_ms.unwrap_or(0),
-                )));
-            }
+    if !has_data {
+        return;
+    }
+    lines.push(Line::from("  Classifiers"));
+    for (name, snap) in [
+        ("injection", &clf.injection),
+        ("pii", &clf.pii),
+        ("feedback", &clf.feedback),
+    ] {
+        if snap.call_count > 0 {
+            lines.push(Line::from(format!(
+                "    [{name}] calls:{} p50:{}ms p95:{}ms",
+                snap.call_count,
+                snap.p50_ms.unwrap_or(0),
+                snap.p95_ms.unwrap_or(0),
+            )));
         }
     }
-
-    let resources = Paragraph::new(lines).block(
-        Block::default()
-            .borders(Borders::ALL)
-            .border_style(theme.panel_border)
-            .title(" Resources "),
-    );
-    frame.render_widget(resources, area);
 }
 
 #[cfg(test)]
@@ -332,6 +368,35 @@ mod tests {
             "expected learning flag; got: {output:?}"
         );
         assert_snapshot!(output);
+    }
+
+    #[test]
+    fn resources_shows_background_run_when_present() {
+        use zeph_core::metrics::ShellBackgroundRunRow;
+
+        let metrics = MetricsSnapshot {
+            shell_background_runs: vec![ShellBackgroundRunRow {
+                run_id: "a1b2c3d4".into(),
+                command: "cargo build --workspace".into(),
+                elapsed_secs: 75,
+            }],
+            ..MetricsSnapshot::default()
+        };
+        let output = render_to_string(50, 30, |frame, area| {
+            super::render(&metrics, frame, area);
+        });
+        assert!(
+            output.contains("Background Shell"),
+            "resources panel must show Background Shell header; got: {output:?}"
+        );
+        assert!(
+            output.contains("a1b2c3d"),
+            "resources panel must show run_id prefix; got: {output:?}"
+        );
+        assert!(
+            output.contains("01:15"),
+            "resources panel must show elapsed mm:ss; got: {output:?}"
+        );
     }
 
     #[test]

--- a/crates/zeph-tui/src/widgets/security.rs
+++ b/crates/zeph-tui/src/widgets/security.rs
@@ -57,116 +57,137 @@ pub fn render(metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect) {
     frame.render_widget(list, inner);
 }
 
-#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3446): decompose into smaller helpers
-fn build_metric_items<'a>(
+/// Build a `ListItem` with a plain styled label and value, using `base` style for both.
+fn plain_metric_item(
+    label: &'static str,
+    value: impl std::fmt::Display,
+    base: Style,
+) -> ListItem<'static> {
+    ListItem::new(Line::from(Span::styled(format!("{label}{value}"), base)))
+}
+
+/// Build a `ListItem` whose value span switches to `alert_style` when the value is non-zero.
+fn styled_counter_item<'a>(
+    label: &'static str,
+    value: u64,
+    base: Style,
+    alert_style: Style,
+) -> ListItem<'a> {
+    ListItem::new(Line::from(vec![
+        Span::styled(label, base),
+        Span::styled(
+            value.to_string(),
+            if value > 0 { alert_style } else { base },
+        ),
+    ]))
+}
+
+fn build_sanitizer_items<'a>(
+    metrics: &MetricsSnapshot,
+    base: Style,
+    flag_style: Style,
+) -> Vec<ListItem<'a>> {
+    vec![
+        plain_metric_item("Sanitizer runs:    ", metrics.sanitizer_runs, base),
+        styled_counter_item(
+            "Inj flags:         ",
+            metrics.sanitizer_injection_flags,
+            base,
+            flag_style,
+        ),
+        plain_metric_item("Truncations:       ", metrics.sanitizer_truncations, base),
+        plain_metric_item("Quarantine calls:  ", metrics.quarantine_invocations, base),
+        plain_metric_item("Quarantine fails:  ", metrics.quarantine_failures, base),
+    ]
+}
+
+fn build_exfiltration_items<'a>(
+    metrics: &MetricsSnapshot,
+    base: Style,
+    block_style: Style,
+) -> Vec<ListItem<'a>> {
+    vec![
+        styled_counter_item(
+            "Exfil images:      ",
+            metrics.exfiltration_images_blocked,
+            base,
+            block_style,
+        ),
+        styled_counter_item(
+            "Exfil URLs:        ",
+            metrics.exfiltration_tool_urls_flagged,
+            base,
+            block_style,
+        ),
+        plain_metric_item(
+            "Memory guards:     ",
+            metrics.exfiltration_memory_guards,
+            base,
+        ),
+    ]
+}
+
+fn build_pre_execution_items<'a>(
     metrics: &MetricsSnapshot,
     base: Style,
     flag_style: Style,
     block_style: Style,
 ) -> Vec<ListItem<'a>> {
     vec![
-        ListItem::new(Line::from(Span::styled(
-            format!("Sanitizer runs:    {}", metrics.sanitizer_runs),
+        styled_counter_item(
+            "Verify blocks:     ",
+            metrics.pre_execution_blocks,
             base,
-        ))),
-        ListItem::new(Line::from(vec![
-            Span::styled("Inj flags:         ", base),
-            Span::styled(
-                metrics.sanitizer_injection_flags.to_string(),
-                if metrics.sanitizer_injection_flags > 0 {
-                    flag_style
-                } else {
-                    base
-                },
-            ),
-        ])),
-        ListItem::new(Line::from(Span::styled(
-            format!("Truncations:       {}", metrics.sanitizer_truncations),
+            block_style,
+        ),
+        styled_counter_item(
+            "Verify warnings:   ",
+            metrics.pre_execution_warnings,
             base,
-        ))),
-        ListItem::new(Line::from(Span::styled(
-            format!("Quarantine calls:  {}", metrics.quarantine_invocations),
-            base,
-        ))),
-        ListItem::new(Line::from(Span::styled(
-            format!("Quarantine fails:  {}", metrics.quarantine_failures),
-            base,
-        ))),
-        ListItem::new(Line::from(vec![
-            Span::styled("Exfil images:      ", base),
-            Span::styled(
-                metrics.exfiltration_images_blocked.to_string(),
-                if metrics.exfiltration_images_blocked > 0 {
-                    block_style
-                } else {
-                    base
-                },
-            ),
-        ])),
-        ListItem::new(Line::from(vec![
-            Span::styled("Exfil URLs:        ", base),
-            Span::styled(
-                metrics.exfiltration_tool_urls_flagged.to_string(),
-                if metrics.exfiltration_tool_urls_flagged > 0 {
-                    block_style
-                } else {
-                    base
-                },
-            ),
-        ])),
-        ListItem::new(Line::from(Span::styled(
-            format!("Memory guards:     {}", metrics.exfiltration_memory_guards),
-            base,
-        ))),
-        ListItem::new(Line::from(vec![
-            Span::styled("Verify blocks:     ", base),
-            Span::styled(
-                metrics.pre_execution_blocks.to_string(),
-                if metrics.pre_execution_blocks > 0 {
-                    block_style
-                } else {
-                    base
-                },
-            ),
-        ])),
-        ListItem::new(Line::from(vec![
-            Span::styled("Verify warnings:   ", base),
-            Span::styled(
-                metrics.pre_execution_warnings.to_string(),
-                if metrics.pre_execution_warnings > 0 {
-                    flag_style
-                } else {
-                    base
-                },
-            ),
-        ])),
-        ListItem::new(Line::from(Span::styled(
-            format!("Egress requests:   {}", metrics.egress_requests_total),
-            base,
-        ))),
-        ListItem::new(Line::from(vec![
-            Span::styled("Egress blocked:    ", base),
-            Span::styled(
-                metrics.egress_blocked_total.to_string(),
-                if metrics.egress_blocked_total > 0 {
-                    block_style
-                } else {
-                    base
-                },
-            ),
-        ])),
-        ListItem::new(Line::from(vec![
-            Span::styled("Egress dropped:    ", base),
-            Span::styled(
-                metrics.egress_dropped_total.to_string(),
-                if metrics.egress_dropped_total > 0 {
-                    flag_style
-                } else {
-                    base
-                },
-            ),
-        ])),
+            flag_style,
+        ),
     ]
+}
+
+fn build_egress_items<'a>(
+    metrics: &MetricsSnapshot,
+    base: Style,
+    flag_style: Style,
+    block_style: Style,
+) -> Vec<ListItem<'a>> {
+    vec![
+        plain_metric_item("Egress requests:   ", metrics.egress_requests_total, base),
+        styled_counter_item(
+            "Egress blocked:    ",
+            metrics.egress_blocked_total,
+            base,
+            block_style,
+        ),
+        styled_counter_item(
+            "Egress dropped:    ",
+            metrics.egress_dropped_total,
+            base,
+            flag_style,
+        ),
+    ]
+}
+
+fn build_metric_items<'a>(
+    metrics: &MetricsSnapshot,
+    base: Style,
+    flag_style: Style,
+    block_style: Style,
+) -> Vec<ListItem<'a>> {
+    let mut items = build_sanitizer_items(metrics, base, flag_style);
+    items.extend(build_exfiltration_items(metrics, base, block_style));
+    items.extend(build_pre_execution_items(
+        metrics,
+        base,
+        flag_style,
+        block_style,
+    ));
+    items.extend(build_egress_items(metrics, base, flag_style, block_style));
+    items
 }
 
 fn append_event_items<'a>(

--- a/crates/zeph-tui/src/widgets/status.rs
+++ b/crates/zeph-tui/src/widgets/status.rs
@@ -11,43 +11,46 @@ use crate::app::{App, InputMode};
 use crate::metrics::MetricsSnapshot;
 use crate::theme::Theme;
 
-#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3446): decompose into smaller helpers
 pub fn render(app: &App, metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect) {
     let theme = Theme::default();
-
     let mode = match app.input_mode() {
         InputMode::Normal => "Normal",
         InputMode::Insert => "Insert",
     };
-
-    let uptime = format_uptime(metrics.uptime_seconds);
-
-    let plan_mode_segment = plan_mode_segment(app, metrics);
-    let subagent_view_segment = subagent_view_segment(app);
     let cancel_hint = if app.is_agent_busy() && app.input_mode() == InputMode::Normal {
         " | [Esc to cancel]"
     } else {
         ""
     };
+    let uptime = format_uptime(metrics.uptime_seconds);
+    let main_text = build_main_text(app, metrics, mode);
+    let mut spans: Vec<Span<'_>> = vec![Span::styled(main_text, theme.status_bar)];
+    append_security_spans(&mut spans, metrics, &theme);
+    append_compaction_segment(&mut spans, metrics, &theme);
+    let suffix = build_suffix(metrics, cancel_hint, &uptime);
+    spans.push(Span::styled(suffix, theme.status_bar));
+    let line = Line::from(spans);
+    let paragraph = Paragraph::new(line).style(theme.status_bar);
+    frame.render_widget(paragraph, area);
+}
 
+fn build_main_text(app: &App, metrics: &MetricsSnapshot, mode: &str) -> String {
+    let plan_mode_seg = plan_mode_segment(app, metrics);
+    let subagent_view_seg = subagent_view_segment(app);
     let qdrant_segment = if metrics.qdrant_available {
         format!(" | {}: OK", metrics.vector_backend)
     } else {
         String::new()
     };
-
     let filter_segment = build_filter_segment(metrics);
-
     let channel_segment = if metrics.active_channel.is_empty() {
         String::new()
     } else {
         format!(" | ch:{}", metrics.active_channel)
     };
-
     let bg_segment = build_bg_segment(metrics);
-
-    let main_text = format!(
-        " [{mode}]{model}{channel_segment}{plan_mode_segment}{subagent_view_segment} | Skills: {active} active / {total} loaded | Tokens: {tok}{qdrant_segment}{filter_segment}{bg_segment}",
+    format!(
+        " [{mode}]{model}{channel_segment}{plan_mode_seg}{subagent_view_seg} | Skills: {active} active / {total} loaded | Tokens: {tok}{qdrant_segment}{filter_segment}{bg_segment}",
         model = if metrics.model_name.is_empty() {
             String::new()
         } else {
@@ -56,11 +59,10 @@ pub fn render(app: &App, metrics: &MetricsSnapshot, frame: &mut Frame, area: Rec
         active = metrics.active_skills.len(),
         total = metrics.total_skills,
         tok = format_tokens(metrics.total_tokens),
-    );
+    )
+}
 
-    let mut spans: Vec<Span<'_>> = vec![Span::styled(main_text, theme.status_bar)];
-    append_security_spans(&mut spans, metrics, &theme);
-
+fn append_compaction_segment(spans: &mut Vec<Span<'_>>, metrics: &MetricsSnapshot, theme: &Theme) {
     if metrics.server_compaction_events > 0 {
         spans.push(Span::styled(" | ", theme.status_bar));
         spans.push(Span::styled(
@@ -68,16 +70,18 @@ pub fn render(app: &App, metrics: &MetricsSnapshot, frame: &mut Frame, area: Rec
             Style::default().fg(Color::Cyan),
         ));
     }
+}
 
-    let suffix = format!(
-        " | API: {api} | {uptime}{cancel_hint}",
-        api = metrics.api_calls
-    );
-    spans.push(Span::styled(suffix, theme.status_bar));
-
-    let line = Line::from(spans);
-    let paragraph = Paragraph::new(line).style(theme.status_bar);
-    frame.render_widget(paragraph, area);
+fn build_suffix(metrics: &MetricsSnapshot, cancel_hint: &str, uptime: &str) -> String {
+    let sh_seg = if metrics.shell_background_runs.is_empty() {
+        String::new()
+    } else {
+        format!(", sh:{}", metrics.shell_background_runs.len())
+    };
+    format!(
+        " | API: {api} | {uptime}{sh_seg}{cancel_hint}",
+        api = metrics.api_calls,
+    )
 }
 
 fn subagent_view_segment(app: &App) -> String {

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -18,7 +18,7 @@ type ToolExecutor = zeph_tools::CompositeExecutor<
     zeph_tools::CompositeExecutor<
         zeph_tools::FileExecutor,
         zeph_tools::CompositeExecutor<
-            zeph_tools::ShellExecutor,
+            std::sync::Arc<zeph_tools::ShellExecutor>,
             zeph_tools::CompositeExecutor<
                 zeph_tools::WebScrapeExecutor,
                 zeph_tools::SetCwdExecutor,
@@ -49,6 +49,8 @@ pub(crate) struct ToolSetup {
     /// `Agent::with_background_completion_rx` so it can drain completions into the next turn.
     pub(crate) background_completion_rx:
         Option<tokio::sync::mpsc::Receiver<zeph_tools::BackgroundCompletion>>,
+    /// Shared reference to the `ShellExecutor` for background-run TUI metrics.
+    pub(crate) shell_executor_handle: Option<Arc<zeph_tools::ShellExecutor>>,
 }
 
 #[derive(Clone)]
@@ -538,6 +540,8 @@ pub(crate) async fn build_tool_setup(
     let mcp_executor =
         zeph_mcp::McpToolExecutor::new(mcp_manager.clone(), mcp_shared_tools.clone());
     let shell_policy_handle = shell_executor.policy_handle();
+    let shell_executor = Arc::new(shell_executor);
+    let shell_executor_handle = Some(Arc::clone(&shell_executor));
     let cwd_executor = zeph_tools::SetCwdExecutor;
     let base_executor = zeph_tools::CompositeExecutor::new(
         file_executor,
@@ -561,6 +565,7 @@ pub(crate) async fn build_tool_setup(
         egress_rx,
         shell_policy_handle,
         background_completion_rx: Some(bg_completion_rx),
+        shell_executor_handle,
     }
 }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1630,6 +1630,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     let egress_rx = tool_setup.egress_rx;
     let shell_policy_handle = tool_setup.shell_policy_handle;
     let background_completion_rx = tool_setup.background_completion_rx;
+    let shell_executor_handle = tool_setup.shell_executor_handle;
     let _skill_watcher = watchers.skill_watcher;
     // Receivers arrive as InstrumentedReceiver<T> from build_watchers().
     // Agent builder expects mpsc::Receiver<T>, so unwrap the instrumented wrapper.
@@ -1758,6 +1759,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     .with_config_reload(config_path, config_reload_rx)
     .with_plugins_dir(crate::bootstrap::plugins_dir(), startup_shell_overlay)
     .with_shell_policy_handle(shell_policy_handle)
+    .with_shell_executor_handle(shell_executor_handle)
     .with_background_completion_rx_opt(background_completion_rx)
     .with_logging_config(logging_config.clone())
     .with_autosave_config(


### PR DESCRIPTION
## Summary

- Remove six `#[allow(clippy::too_many_lines)]` suppressions in `zeph-tui` by extracting private helpers in `command.rs`, `app/keys.rs`, and widgets `security`, `status`, `resources` (closes #3446)
- Wire `BackgroundHandle::elapsed()` through `ShellExecutor::background_runs_snapshot()` → `MetricsSnapshot::shell_background_runs` → TUI Resources panel, showing in-flight shell tasks with per-run elapsed time and a `sh:N` status-bar indicator (closes #3448)

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --all-targets --features "tui,scheduler,gateway,a2a" --workspace -- -D warnings` — clean
- [ ] `cargo nextest run --workspace --lib --bins` — 8607 passed, 0 failed
- [ ] `cargo insta test --workspace --features "tui,scheduler,gateway,a2a" --check --lib --bins` — no snapshot changes
- [ ] Live TUI test: spawn background shell task, observe Resources panel shows row with incrementing elapsed, status bar shows `sh:1` (playbook: `tui-widgets.md`)