### PR TITLE
refactor: decompose long functions in zeph-mcp, zeph-index, zeph-subagent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Decomposed long functions in `zeph-mcp` (`connect_all`, `connect_oauth_deferred`, `add_server`),
+  `zeph-index` (`index_project`), and `zeph-subagent` (`run_agent_loop`) into focused private
+  helpers; removed all `#[allow(clippy::too_many_lines)]` suppressions. (#3451, #3458, #3447)
+
 - `zeph-tools`: replaced shell-out signal sending with safe `nix`-based SIGTERM/SIGKILL
   escalation in the shell executor. `kill_process_tree` now sends SIGTERM, waits 250 ms,
   reaps child processes via `pkill`, then sends SIGKILL. `ShellExecutor::shutdown` also

--- a/crates/zeph-index/src/indexer.rs
+++ b/crates/zeph-index/src/indexer.rs
@@ -244,7 +244,6 @@ impl CodeIndexer {
     /// # Errors
     ///
     /// Returns an error if the embedding probe or collection setup fails.
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3458): decompose into smaller helpers
     pub async fn index_project(
         &self,
         root: &Path,
@@ -263,14 +262,46 @@ impl CodeIndexer {
         let start = std::time::Instant::now();
         let mut report = IndexReport::default();
 
+        self.ensure_collection_for_provider().await?;
+        let (entries, current_files) = self.walk_project_files(root).await?;
+        let total = entries.len();
+        tracing::info!(total, "indexing started");
+
+        let memory_batch_size = self.config.memory_batch_size.max(1);
+        let mut files_done = 0usize;
+        for batch in entries.chunks(memory_batch_size) {
+            self.index_batch(
+                batch,
+                root,
+                total,
+                &mut files_done,
+                &mut report,
+                progress_tx,
+            )
+            .await;
+        }
+
+        self.cleanup_removed_files(&current_files, &mut report)
+            .await?;
+
+        report.duration_ms = start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+        Ok(report)
+    }
+
+    async fn ensure_collection_for_provider(&self) -> Result<()> {
         let probe = self.provider.embed("probe").await?;
         let vector_size = u64::try_from(probe.len())?;
-        self.store.ensure_collection(vector_size).await?;
+        self.store.ensure_collection(vector_size).await
+    }
 
+    async fn walk_project_files(
+        &self,
+        root: &Path,
+    ) -> Result<(Vec<ignore::DirEntry>, HashSet<String>)> {
         let root_buf = root.to_path_buf();
         // TODO(#2978-walk): directory walk is left as raw spawn_blocking; routing it
         // through BlockingSpawner is out of scope (single short-lived operation per run).
-        let (entries, current_files) = tokio::task::spawn_blocking(move || {
+        tokio::task::spawn_blocking(move || {
             let entries: Vec<_> = ignore::WalkBuilder::new(&root_buf)
                 .hidden(true)
                 .git_ignore(true)
@@ -292,91 +323,86 @@ impl CodeIndexer {
             (entries, current_files)
         })
         .await
-        .map_err(|e| IndexError::Other(format!("directory walk panicked: {e:#}")))?;
+        .map_err(|e| IndexError::Other(format!("directory walk panicked: {e:#}")))
+    }
 
-        let total = entries.len();
-        tracing::info!(total, "indexing started");
-
+    #[allow(clippy::too_many_arguments)]
+    async fn index_batch(
+        &self,
+        batch: &[ignore::DirEntry],
+        root: &Path,
+        total: usize,
+        files_done: &mut usize,
+        report: &mut IndexReport,
+        progress_tx: Option<&watch::Sender<IndexProgress>>,
+    ) {
+        let store = self.store.clone();
+        let provider = Arc::clone(&self.provider);
+        let config = self.config.clone();
+        let spawner = self.spawner.clone();
         let concurrency = self.config.embed_concurrency.max(1);
-        let memory_batch_size = self.config.memory_batch_size.max(1);
-        let mut files_done = 0usize;
 
-        for batch in entries.chunks(memory_batch_size) {
-            let store = self.store.clone();
-            let provider = Arc::clone(&self.provider);
-            let config = self.config.clone();
-            let spawner = self.spawner.clone();
+        let file_pairs = make_file_pairs(batch, root);
 
-            // Resolve paths eagerly so the async closures below have no lifetime dependency on
-            // `entries` or `root`.
-            let file_pairs: Vec<(String, std::path::PathBuf)> = batch
-                .iter()
-                .map(|entry| {
-                    let rel = entry
-                        .path()
-                        .strip_prefix(root)
-                        .unwrap_or(entry.path())
-                        .to_string_lossy()
-                        .to_string();
-                    let abs = entry.path().to_path_buf();
-                    (rel, abs)
-                })
-                .collect();
-
-            let mut stream =
-                futures::stream::iter(file_pairs.into_iter().map(|(rel_path, abs_path)| {
-                    let store = store.clone();
-                    let provider = Arc::clone(&provider);
-                    let config = config.clone();
-                    let spawner = spawner.clone();
-                    async move {
-                        let worker = FileIndexWorker {
-                            store,
-                            provider,
-                            config,
-                            spawner,
-                        };
-                        let result = worker.index_file(&abs_path, &rel_path).await;
-                        (rel_path, result)
-                    }
-                }))
-                .buffer_unordered(concurrency);
-
-            while let Some((rel_path, outcome)) = stream.next().await {
-                report.files_scanned += 1;
-                files_done += 1;
-                match outcome {
-                    Ok((created, skipped)) => {
-                        if created > 0 {
-                            report.files_indexed += 1;
-                        }
-                        report.chunks_created += created;
-                        report.chunks_skipped += skipped;
-                        tracing::info!(
-                            file = %rel_path,
-                            progress = format_args!("{files_done}/{total}"),
-                            created,
-                            skipped,
-                        );
-                    }
-                    Err(e) => {
-                        report.errors.push(format!("{rel_path}: {e:#}"));
-                    }
+        let mut stream =
+            futures::stream::iter(file_pairs.into_iter().map(|(rel_path, abs_path)| {
+                let store = store.clone();
+                let provider = Arc::clone(&provider);
+                let config = config.clone();
+                let spawner = spawner.clone();
+                async move {
+                    let worker = FileIndexWorker {
+                        store,
+                        provider,
+                        config,
+                        spawner,
+                    };
+                    let result = worker.index_file(&abs_path, &rel_path).await;
+                    (rel_path, result)
                 }
-                if let Some(tx) = progress_tx {
-                    let _ = tx.send(IndexProgress {
-                        files_done,
-                        files_total: total,
-                        chunks_created: report.chunks_created,
-                    });
+            }))
+            .buffer_unordered(concurrency);
+
+        while let Some((rel_path, outcome)) = stream.next().await {
+            report.files_scanned += 1;
+            *files_done += 1;
+            match outcome {
+                Ok((created, skipped)) => {
+                    if created > 0 {
+                        report.files_indexed += 1;
+                    }
+                    report.chunks_created += created;
+                    report.chunks_skipped += skipped;
+                    tracing::info!(
+                        file = %rel_path,
+                        progress = format_args!("{files_done}/{total}"),
+                        created,
+                        skipped,
+                    );
+                }
+                Err(e) => {
+                    report.errors.push(format!("{rel_path}: {e:#}"));
                 }
             }
-
-            // Drop stream to release all in-flight future state before the next batch.
-            drop(stream);
-            tokio::task::yield_now().await;
+            if let Some(tx) = progress_tx {
+                let _ = tx.send(IndexProgress {
+                    files_done: *files_done,
+                    files_total: total,
+                    chunks_created: report.chunks_created,
+                });
+            }
         }
 
+        // Drop stream to release all in-flight future state before the next batch.
+        drop(stream);
+        tokio::task::yield_now().await;
+    }
+
+    async fn cleanup_removed_files(
+        &self,
+        current_files: &HashSet<String>,
+        report: &mut IndexReport,
+    ) -> Result<()> {
         let indexed = self.store.indexed_files().await?;
         for old_file in &indexed {
             if !current_files.contains(old_file) {
@@ -386,9 +412,7 @@ impl CodeIndexer {
                 }
             }
         }
-
-        report.duration_ms = start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
-        Ok(report)
+        Ok(())
     }
 
     /// Re-index a specific file (for file watcher).
@@ -530,6 +554,22 @@ impl FileIndexWorker {
 
         Ok((created, skipped))
     }
+}
+
+fn make_file_pairs(batch: &[ignore::DirEntry], root: &Path) -> Vec<(String, std::path::PathBuf)> {
+    batch
+        .iter()
+        .map(|entry| {
+            let rel = entry
+                .path()
+                .strip_prefix(root)
+                .unwrap_or(entry.path())
+                .to_string_lossy()
+                .to_string();
+            let abs = entry.path().to_path_buf();
+            (rel, abs)
+        })
+        .collect()
 }
 
 fn chunk_to_insert(chunk: &CodeChunk) -> ChunkInsert<'_> {

--- a/crates/zeph-mcp/src/manager.rs
+++ b/crates/zeph-mcp/src/manager.rs
@@ -645,11 +645,26 @@ impl McpManager {
         feature = "profiling",
         tracing::instrument(name = "mcp.connect_all", skip_all, fields(connected = tracing::field::Empty, failed = tracing::field::Empty))
     )]
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3451): decompose into smaller helpers
     pub async fn connect_all(&self) -> (Vec<McpTool>, Vec<ServerConnectOutcome>) {
+        let join_set = self.spawn_non_oauth_connections(&self.last_refresh);
+        let raw = drain_connect_results(join_set).await;
+        let limits = IngestLimits {
+            description_bytes: self.max_description_bytes,
+            instructions_bytes: self.max_instructions_bytes,
+        };
+        let outputs = self.process_connect_results(raw, limits).await;
+        let (all_tools, outcomes) = self.commit_connect_outputs(outputs).await;
+        self.log_tool_collisions(&all_tools).await;
+        (all_tools, outcomes)
+    }
+
+    fn spawn_non_oauth_connections(
+        &self,
+        last_refresh: &Arc<DashMap<String, Instant>>,
+    ) -> JoinSet<(String, Result<McpClient, McpError>)> {
         let allowed = self.allowed_commands.clone();
         let suppress = self.suppress_stderr;
-        let last_refresh = Arc::clone(&self.last_refresh);
+        let cloned_status_tx = self.status_tx.clone();
 
         let non_oauth: Vec<_> = self
             .configs
@@ -658,11 +673,10 @@ impl McpManager {
             .cloned()
             .collect();
 
-        let cloned_status_tx = self.status_tx.clone();
         let mut join_set = JoinSet::new();
         for config in non_oauth {
             let allowed = allowed.clone();
-            let last_refresh = Arc::clone(&last_refresh);
+            let last_refresh = Arc::clone(last_refresh);
             let Some(tx) = self.clone_refresh_tx() else {
                 continue;
             };
@@ -684,32 +698,28 @@ impl McpManager {
                 (config.id, result)
             });
         }
+        join_set
+    }
 
-        // Drain join_set without holding any locks, then process each result through
-        // handle_connect_result — which also holds no locks. All async work (network
-        // calls, probing, lock-free reads) happens here with zero contention on the
-        // shared maps.
-        let mut raw_results = Vec::new();
-        while let Some(result) = join_set.join_next().await {
-            let Ok((server_id, connect_result)) = result else {
-                tracing::warn!("MCP connection task panicked");
-                continue;
-            };
-            raw_results.push((server_id, connect_result));
-        }
-
-        let limits = IngestLimits {
-            description_bytes: self.max_description_bytes,
-            instructions_bytes: self.max_instructions_bytes,
-        };
-        let mut outputs = Vec::with_capacity(raw_results.len());
-        for (server_id, connect_result) in raw_results {
+    async fn process_connect_results(
+        &self,
+        raw: Vec<(String, Result<McpClient, McpError>)>,
+        limits: IngestLimits,
+    ) -> Vec<ConnectOutput> {
+        let mut outputs = Vec::with_capacity(raw.len());
+        for (server_id, connect_result) in raw {
             outputs.push(
                 self.handle_connect_result(server_id, connect_result, limits)
                     .await,
             );
         }
+        outputs
+    }
 
+    async fn commit_connect_outputs(
+        &self,
+        outputs: Vec<ConnectOutput>,
+    ) -> (Vec<McpTool>, Vec<ServerConnectOutcome>) {
         // All async work is done. Collect into vecs first, then commit each lock
         // in its own guarded block — never hold one lock across another .await.
         let mut pending_instructions: Vec<(String, String)> = Vec::new();
@@ -748,10 +758,6 @@ impl McpManager {
                 g.insert(sid, tools);
             }
         }
-
-        // Detect sanitized_id collisions across the aggregated tool list (SF-6/MF-1).
-        self.log_tool_collisions(&all_tools).await;
-
         (all_tools, outcomes)
     }
 
@@ -773,14 +779,26 @@ impl McpManager {
     ///
     /// # Panics
     ///
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3451): decompose into smaller helpers
     pub async fn connect_oauth_deferred(&self) {
-        let last_refresh = Arc::clone(&self.last_refresh);
         let limits = IngestLimits {
             description_bytes: self.max_description_bytes,
             instructions_bytes: self.max_instructions_bytes,
         };
+        let join_set = self.spawn_oauth_connections(&self.last_refresh);
+        let raw = drain_oauth_results(join_set).await;
+        let outputs = self.process_oauth_results(raw, limits).await;
+        let all_tools: Vec<McpTool> = outputs
+            .iter()
+            .flat_map(|o| o.tools.iter().cloned())
+            .collect();
+        self.commit_oauth_outputs(outputs).await;
+        self.log_tool_collisions(&all_tools).await;
+    }
 
+    fn spawn_oauth_connections(
+        &self,
+        last_refresh: &Arc<DashMap<String, Instant>>,
+    ) -> JoinSet<(String, Result<McpClient, String>)> {
         let oauth_configs: Vec<_> = self
             .configs
             .iter()
@@ -826,101 +844,34 @@ impl McpManager {
             let timeout = config.timeout;
             let handler_cfg = self.handler_cfg_for(&config);
             let status_tx = self.status_tx.clone();
-            let last_refresh = Arc::clone(&last_refresh);
+            let last_refresh = Arc::clone(last_refresh);
 
-            join_set.spawn(async move {
-                let connect_result = McpClient::connect_url_oauth(
-                    &server_id,
-                    &url,
-                    &scopes,
-                    callback_port,
-                    &client_name,
-                    credential_store,
-                    trusted,
-                    tx,
-                    last_refresh,
-                    timeout,
-                    handler_cfg,
-                )
-                .await;
-
-                let client_result = match connect_result {
-                    Ok(OAuthConnectResult::Connected(client)) => Ok(client),
-                    Ok(OAuthConnectResult::AuthorizationRequired(pending_box)) => {
-                        let mut pending = *pending_box;
-                        tracing::info!(
-                            server_id,
-                            auth_url = pending.auth_url,
-                            callback_port = pending.actual_port,
-                            "OAuth authorization required — open this URL to authorize"
-                        );
-                        let auth_msg = format!(
-                            "MCP OAuth: Open this URL to authorize '{}': {}",
-                            server_id, pending.auth_url
-                        );
-                        if let Some(ref stx) = status_tx {
-                            let _ = stx.send(format!("Waiting for OAuth: {server_id}"));
-                            let _ = stx.send(auth_msg.clone());
-                        } else {
-                            eprintln!("{auth_msg}");
-                        }
-                        // open::that_in_background spawns an OS thread; ignore the handle —
-                        // we don't need to wait for the browser to open.
-                        let _ = open::that_in_background(pending.auth_url.clone());
-
-                        let callback_timeout = std::time::Duration::from_mins(5);
-                        let listener = pending
-                            .listener
-                            .take()
-                            .expect("listener always set by connect_url_oauth");
-                        match crate::oauth::await_oauth_callback(
-                            listener,
-                            callback_timeout,
-                            &server_id,
-                        )
-                        .await
-                        {
-                            Ok((code, csrf_token)) => {
-                                if let Some(ref stx) = status_tx {
-                                    let _ = stx.send(String::new());
-                                }
-                                McpClient::complete_oauth(pending, &code, &csrf_token)
-                                    .await
-                                    .map_err(|e| format!("OAuth token exchange failed: {e:#}"))
-                            }
-                            Err(e) => {
-                                if let Some(ref stx) = status_tx {
-                                    let _ = stx.send(String::new());
-                                }
-                                tracing::warn!(server_id, "OAuth callback failed: {e:#}");
-                                Err(format!("OAuth callback failed: {e:#}"))
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        tracing::warn!(server_id, "OAuth connection failed: {e:#}");
-                        Err(format!("{e:#}"))
-                    }
-                };
-
-                (server_id, client_result)
-            });
+            join_set.spawn(run_oauth_handshake(
+                server_id,
+                url,
+                scopes,
+                callback_port,
+                client_name,
+                credential_store,
+                trusted,
+                tx,
+                last_refresh,
+                timeout,
+                handler_cfg,
+                status_tx,
+            ));
         }
+        join_set
+    }
 
-        // Drain all tasks before touching shared state — no locks held here.
-        let mut raw_results: Vec<(String, Result<McpClient, String>)> =
-            Vec::with_capacity(join_set.len());
-        while let Some(res) = join_set.join_next().await {
-            if let Ok(item) = res {
-                raw_results.push(item);
-            } else {
-                tracing::warn!("MCP OAuth connection task panicked");
-            }
-        }
-
+    async fn process_oauth_results(
+        &self,
+        raw: Vec<(String, Result<McpClient, String>)>,
+        limits: IngestLimits,
+    ) -> Vec<ConnectOutput> {
         // Process each result through handle_connect_result (no locks held).
-        let mut outputs = Vec::with_capacity(raw_results.len());
-        for (server_id, client_result) in raw_results {
+        let mut outputs = Vec::with_capacity(raw.len());
+        for (server_id, client_result) in raw {
             match client_result {
                 Ok(client) => {
                     outputs.push(
@@ -944,13 +895,12 @@ impl McpManager {
                 }
             }
         }
+        outputs
+    }
 
+    async fn commit_oauth_outputs(&self, outputs: Vec<ConnectOutput>) {
         // Batch-commit to shared maps in separate guarded blocks — never hold one
         // lock across another .await (same pattern as connect_all).
-        let all_tools: Vec<McpTool> = outputs
-            .iter()
-            .flat_map(|o| o.tools.iter().cloned())
-            .collect();
         let mut pending_instructions: Vec<(String, String)> = Vec::new();
         let mut pending_clients: Vec<(String, McpClient)> = Vec::new();
         let mut pending_tools: Vec<(String, Vec<McpTool>)> = Vec::new();
@@ -987,7 +937,6 @@ impl McpManager {
         if !updated.is_empty() {
             let _ = self.tools_watch_tx.send(updated);
         }
-        self.log_tool_collisions(&all_tools).await;
     }
 
     /// Log warnings for all `sanitized_id` collisions in `tools`.
@@ -1197,17 +1146,8 @@ impl McpManager {
     ///
     /// # Panics
     ///
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3451): decompose into smaller helpers
     pub async fn add_server(&self, entry: &ServerEntry) -> Result<Vec<McpTool>, McpError> {
-        // Early check under read lock (fast path for duplicates)
-        {
-            let clients = self.clients.read().await;
-            if clients.contains_key(&entry.id) {
-                return Err(McpError::ServerAlreadyConnected {
-                    server_id: entry.id.clone(),
-                });
-            }
-        }
+        self.check_not_already_connected(&entry.id).await?;
 
         let tx = self
             .clone_refresh_tx()
@@ -1215,6 +1155,71 @@ impl McpManager {
                 server_id: entry.id.clone(),
                 message: "manager is shutting down".into(),
             })?;
+
+        let (client, raw_tools) = self.connect_and_list_tools(entry, tx).await?;
+
+        if let Err(e) = self.probe_or_cleanup(entry, &client).await {
+            client.shutdown().await;
+            return Err(e);
+        }
+
+        self.store_server_instructions(entry, &client).await;
+
+        let (tools, sanitize_result) = ingest_tools(
+            raw_tools,
+            &entry.id,
+            entry.trust_level,
+            entry.tool_allowlist.as_deref(),
+            &entry.expected_tools,
+            self.status_tx.as_ref(),
+            self.max_description_bytes,
+            &entry.tool_metadata,
+        );
+        apply_injection_penalties(
+            self.trust_store.as_ref(),
+            &entry.id,
+            &sanitize_result,
+            &self.server_trust,
+        )
+        .await;
+
+        self.commit_added_server(entry, client, tools.clone())
+            .await?;
+
+        // Detect collisions against the full current tool list (SF-1: add_server path).
+        let all_tools: Vec<McpTool> = self
+            .server_tools
+            .read()
+            .await
+            .values()
+            .flatten()
+            .cloned()
+            .collect();
+        self.log_tool_collisions(&all_tools).await;
+
+        tracing::info!(
+            server_id = entry.id,
+            tools = tools.len(),
+            "dynamically added MCP server"
+        );
+        Ok(tools)
+    }
+
+    async fn check_not_already_connected(&self, server_id: &str) -> Result<(), McpError> {
+        let clients = self.clients.read().await;
+        if clients.contains_key(server_id) {
+            return Err(McpError::ServerAlreadyConnected {
+                server_id: server_id.to_owned(),
+            });
+        }
+        Ok(())
+    }
+
+    async fn connect_and_list_tools(
+        &self,
+        entry: &ServerEntry,
+        tx: mpsc::UnboundedSender<ToolRefreshEvent>,
+    ) -> Result<(McpClient, Vec<McpTool>), McpError> {
         // MF-2: insert lock BEFORE connecting so no refresh can slip through before the lock is set.
         if self.lock_tool_list {
             self.tool_list_locked.insert(entry.id.clone(), ());
@@ -1244,14 +1249,22 @@ impl McpManager {
                 return Err(e);
             }
         };
-        // Phase 1: run pre-connect probe if configured.
-        if let Err(e) = self.run_probe(&entry.id, &client).await {
+        Ok((client, raw_tools))
+    }
+
+    async fn probe_or_cleanup(
+        &self,
+        entry: &ServerEntry,
+        client: &McpClient,
+    ) -> Result<(), McpError> {
+        if let Err(e) = self.run_probe(&entry.id, client).await {
             self.tool_list_locked.remove(&entry.id);
-            client.shutdown().await;
             return Err(e);
         }
+        Ok(())
+    }
 
-        // Capture server instructions from handshake and apply cap.
+    async fn store_server_instructions(&self, entry: &ServerEntry, client: &McpClient) {
         if let Some(ref instructions) = client.server_instructions() {
             let truncated = crate::sanitize::truncate_instructions(
                 instructions,
@@ -1263,24 +1276,19 @@ impl McpManager {
                 .await
                 .insert(entry.id.clone(), truncated);
         }
+    }
 
-        let (tools, sanitize_result) = ingest_tools(
-            raw_tools,
-            &entry.id,
-            entry.trust_level,
-            entry.tool_allowlist.as_deref(),
-            &entry.expected_tools,
-            self.status_tx.as_ref(),
-            self.max_description_bytes,
-            &entry.tool_metadata,
-        );
-        apply_injection_penalties(
-            self.trust_store.as_ref(),
-            &entry.id,
-            &sanitize_result,
-            &self.server_trust,
-        )
-        .await;
+    async fn commit_added_server(
+        &self,
+        entry: &ServerEntry,
+        client: McpClient,
+        tools: Vec<McpTool>,
+    ) -> Result<(), McpError> {
+        // TODO(critic): commit_added_server holds `clients` write guard across
+        // `server_trust.write().await` and `server_tools.write().await`. This
+        // violates Await Discipline §4 (.claude/rules/rust-code.md). Preserved
+        // verbatim during the #3451 decomposition; file a follow-up issue to
+        // drop the guard before subsequent writes.
 
         // Re-check under write lock to prevent TOCTOU race
         let mut clients = self.clients.write().await;
@@ -1307,25 +1315,9 @@ impl McpManager {
         self.server_tools
             .write()
             .await
-            .insert(entry.id.clone(), tools.clone());
+            .insert(entry.id.clone(), tools);
 
-        // Detect collisions against the full current tool list (SF-1: add_server path).
-        let all_tools: Vec<McpTool> = self
-            .server_tools
-            .read()
-            .await
-            .values()
-            .flatten()
-            .cloned()
-            .collect();
-        self.log_tool_collisions(&all_tools).await;
-
-        tracing::info!(
-            server_id = entry.id,
-            tools = tools.len(),
-            "dynamically added MCP server"
-        );
-        Ok(tools)
+        Ok(())
     }
 
     /// Disconnect and remove a server by ID.
@@ -1517,10 +1509,132 @@ async fn apply_injection_penalties(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
+async fn run_oauth_handshake(
+    server_id: String,
+    url: String,
+    scopes: Vec<String>,
+    callback_port: u16,
+    client_name: String,
+    credential_store: Arc<dyn CredentialStore>,
+    trusted: bool,
+    tx: mpsc::UnboundedSender<ToolRefreshEvent>,
+    last_refresh: Arc<DashMap<String, Instant>>,
+    timeout: Duration,
+    handler_cfg: crate::client::HandlerConfig,
+    status_tx: Option<StatusTx>,
+) -> (String, Result<McpClient, String>) {
+    let connect_result = McpClient::connect_url_oauth(
+        &server_id,
+        &url,
+        &scopes,
+        callback_port,
+        &client_name,
+        credential_store,
+        trusted,
+        tx,
+        last_refresh,
+        timeout,
+        handler_cfg,
+    )
+    .await;
+
+    let client_result = match connect_result {
+        Ok(OAuthConnectResult::Connected(client)) => Ok(client),
+        Ok(OAuthConnectResult::AuthorizationRequired(pending_box)) => {
+            let mut pending = *pending_box;
+            tracing::info!(
+                server_id,
+                auth_url = pending.auth_url,
+                callback_port = pending.actual_port,
+                "OAuth authorization required — open this URL to authorize"
+            );
+            let auth_msg = format!(
+                "MCP OAuth: Open this URL to authorize '{}': {}",
+                server_id, pending.auth_url
+            );
+            if let Some(ref stx) = status_tx {
+                let _ = stx.send(format!("Waiting for OAuth: {server_id}"));
+                let _ = stx.send(auth_msg.clone());
+            } else {
+                eprintln!("{auth_msg}");
+            }
+            // open::that_in_background spawns an OS thread; ignore the handle —
+            // we don't need to wait for the browser to open.
+            let _ = open::that_in_background(pending.auth_url.clone());
+
+            let callback_timeout = std::time::Duration::from_mins(5);
+            let listener = pending
+                .listener
+                .take()
+                .expect("listener always set by connect_url_oauth");
+            match crate::oauth::await_oauth_callback(listener, callback_timeout, &server_id).await {
+                Ok((code, csrf_token)) => {
+                    if let Some(ref stx) = status_tx {
+                        let _ = stx.send(String::new());
+                    }
+                    McpClient::complete_oauth(pending, &code, &csrf_token)
+                        .await
+                        .map_err(|e| format!("OAuth token exchange failed: {e:#}"))
+                }
+                Err(e) => {
+                    if let Some(ref stx) = status_tx {
+                        let _ = stx.send(String::new());
+                    }
+                    tracing::warn!(server_id, "OAuth callback failed: {e:#}");
+                    Err(format!("OAuth callback failed: {e:#}"))
+                }
+            }
+        }
+        Err(e) => {
+            tracing::warn!(server_id, "OAuth connection failed: {e:#}");
+            Err(format!("{e:#}"))
+        }
+    };
+
+    (server_id, client_result)
+}
+
+async fn drain_connect_results(
+    mut join_set: JoinSet<(String, Result<McpClient, McpError>)>,
+) -> Vec<(String, Result<McpClient, McpError>)> {
+    // Drain join_set without holding any locks, then process each result through
+    // handle_connect_result — which also holds no locks. All async work (network
+    // calls, probing, lock-free reads) happens here with zero contention on the
+    // shared maps.
+    let mut raw_results = Vec::new();
+    while let Some(result) = join_set.join_next().await {
+        let Ok((server_id, connect_result)) = result else {
+            tracing::warn!("MCP connection task panicked");
+            continue;
+        };
+        raw_results.push((server_id, connect_result));
+    }
+    raw_results
+}
+
+async fn drain_oauth_results(
+    mut join_set: JoinSet<(String, Result<McpClient, String>)>,
+) -> Vec<(String, Result<McpClient, String>)> {
+    let mut raw_results: Vec<(String, Result<McpClient, String>)> =
+        Vec::with_capacity(join_set.len());
+    while let Some(res) = join_set.join_next().await {
+        if let Ok(item) = res {
+            raw_results.push(item);
+        } else {
+            tracing::warn!("MCP OAuth connection task panicked");
+        }
+    }
+    raw_results
+}
+
 /// Always sanitizes first (security invariant), then assigns security metadata,
 /// then runs attestation against `expected_tools`, then applies allowlist filtering.
 ///
 /// Returns the filtered tool list and the sanitization result (for injection feedback).
+// TODO(critic): ingest_tools has both too_many_arguments and too_many_lines
+// suppressed; not in scope for #3451. File a separate issue to decompose
+// with an IngestParams struct.
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)] // complex algorithm function; both suppressions justified until the function is decomposed in a future refactor
 fn ingest_tools(
     mut tools: Vec<McpTool>,

--- a/crates/zeph-subagent/src/agent_loop.rs
+++ b/crates/zeph-subagent/src/agent_loop.rs
@@ -20,6 +20,12 @@ use super::transcript::TranscriptWriter;
 
 const SECRET_REQUEST_PREFIX: &str = "[REQUEST_SECRET:";
 
+enum SecretRequestOutcome {
+    NotASecretRequest,
+    Handled,
+    Cancelled,
+}
+
 fn make_hook_env(
     task_id: &str,
     agent_name: &str,
@@ -90,6 +96,338 @@ fn tool_def_to_definition(
         parameters: params,
         output_schema: def.output_schema.clone(),
     }
+}
+
+fn build_effective_system_prompt(
+    system_prompt: String,
+    skills: Option<Vec<String>>,
+    mcp_tool_names: &[String],
+) -> String {
+    let mut effective = if let Some(skill_bodies) = skills.filter(|s| !s.is_empty()) {
+        let skill_block = skill_bodies.join("\n\n");
+        format!("{system_prompt}\n\n```skills\n{skill_block}\n```")
+    } else {
+        system_prompt
+    };
+
+    if !mcp_tool_names.is_empty() {
+        let mcp_annotation = format!(
+            "\n\n## Available MCP Tools\n{}",
+            mcp_tool_names
+                .iter()
+                .map(|n| format!("- {n}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+        effective.push_str(&mcp_annotation);
+    }
+
+    effective
+}
+
+async fn call_provider_with_status(
+    provider: &AnyProvider,
+    messages: &[Message],
+    tool_defs: &[ToolDefinition],
+    status_tx: &watch::Sender<SubAgentStatus>,
+    turns: u32,
+    started_at: Instant,
+) -> Result<ChatResponse, super::error::SubAgentError> {
+    let llm_result = provider.chat_with_tools(messages, tool_defs).await;
+    match llm_result {
+        Ok(r) => Ok(r),
+        Err(e) => {
+            tracing::error!(error = %e, "sub-agent LLM call failed");
+            let _ = status_tx.send(SubAgentStatus {
+                state: SubAgentState::Failed,
+                last_message: Some(e.to_string()),
+                turns_used: turns,
+                started_at,
+            });
+            Err(super::error::SubAgentError::Llm(e.to_string()))
+        }
+    }
+}
+
+fn emit_working_status(
+    status_tx: &watch::Sender<SubAgentStatus>,
+    response_text: &str,
+    turns: u32,
+    started_at: Instant,
+) {
+    let _ = status_tx.send(SubAgentStatus {
+        state: SubAgentState::Working,
+        last_message: Some(response_text.chars().take(120).collect()),
+        turns_used: turns,
+        started_at,
+    });
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn handle_secret_request(
+    transcript_writer: &mut Option<TranscriptWriter>,
+    seq: &mut u32,
+    messages: &mut Vec<Message>,
+    secret_request_tx: &mpsc::Sender<SecretRequest>,
+    secret_rx: &mut mpsc::Receiver<Option<String>>,
+    cancel: &CancellationToken,
+    background: bool,
+    is_text_response: bool,
+    response_text: &str,
+) -> SecretRequestOutcome {
+    if !is_text_response {
+        return SecretRequestOutcome::NotASecretRequest;
+    }
+    let Some(rest) = response_text.strip_prefix(SECRET_REQUEST_PREFIX) else {
+        return SecretRequestOutcome::NotASecretRequest;
+    };
+
+    let raw_key = rest.split(']').next().unwrap_or("").trim().to_owned();
+    let key_name = if raw_key
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        && !raw_key.is_empty()
+        && raw_key.len() <= 100
+    {
+        raw_key
+    } else {
+        tracing::warn!("sub-agent emitted invalid secret key name — ignoring request");
+        String::new()
+    };
+
+    if key_name.is_empty() {
+        return SecretRequestOutcome::NotASecretRequest;
+    }
+
+    tracing::debug!("sub-agent requested secret [key redacted]");
+
+    if background {
+        tracing::warn!("background sub-agent secret request auto-denied (no interactive prompt)");
+        let reply = format!("[secret:{key_name}] request denied");
+        let assistant_msg = make_message(Role::Assistant, response_text.to_owned());
+        let user_msg = make_message(Role::User, reply);
+        append_transcript(transcript_writer, seq, &assistant_msg);
+        append_transcript(transcript_writer, seq, &user_msg);
+        messages.push(assistant_msg);
+        messages.push(user_msg);
+        return SecretRequestOutcome::Handled;
+    }
+
+    let req = SecretRequest {
+        secret_key: key_name.clone(),
+        reason: None,
+    };
+    if secret_request_tx.send(req).await.is_ok() {
+        let outcome = tokio::select! {
+            msg = secret_rx.recv() => msg,
+            () = cancel.cancelled() => {
+                tracing::debug!("sub-agent cancelled while waiting for secret approval");
+                return SecretRequestOutcome::Cancelled;
+            }
+        };
+        let reply = match outcome {
+            Some(Some(_)) => {
+                format!("[secret:{key_name} approved — value available via grants]")
+            }
+            Some(None) | None => {
+                format!("[secret:{key_name}] request denied")
+            }
+        };
+        let assistant_msg = make_message(Role::Assistant, response_text.to_owned());
+        let user_msg = make_message(Role::User, reply);
+        append_transcript(transcript_writer, seq, &assistant_msg);
+        append_transcript(transcript_writer, seq, &user_msg);
+        messages.push(assistant_msg);
+        messages.push(user_msg);
+        return SecretRequestOutcome::Handled;
+    }
+
+    SecretRequestOutcome::NotASecretRequest
+}
+
+/// What the agent loop should do after a no-tool (text-only) response.
+enum NoToolAction {
+    /// Send nudge and continue the loop.
+    Nudge,
+    /// No nudge needed — break the loop.
+    Break,
+}
+
+/// Handle the case where the LLM responded with plain text (no tool calls).
+///
+/// Appends new messages to the transcript, and optionally sends a one-time
+/// nudge on the first turn when no tools have been called yet.
+fn handle_no_tool_response(
+    transcript_writer: &mut Option<TranscriptWriter>,
+    seq: &mut u32,
+    messages: &[Message],
+    prev_len: usize,
+    turns: u32,
+    any_tool_called: bool,
+    nudge_messages: &mut Vec<Message>,
+) -> NoToolAction {
+    for msg in &messages[prev_len..] {
+        append_transcript(transcript_writer, seq, msg);
+    }
+    if turns == 1 && !any_tool_called {
+        tracing::debug!("sub-agent text-only first turn — sending nudge to use tools");
+        let nudge = make_message(
+            Role::User,
+            "Please use the available tools to complete the task. \
+             Do not announce intentions — execute them."
+                .into(),
+        );
+        append_transcript(transcript_writer, seq, &nudge);
+        nudge_messages.push(nudge);
+        NoToolAction::Nudge
+    } else {
+        NoToolAction::Break
+    }
+}
+
+/// Initialise per-loop state: send the initial Working status, build the
+/// message list from history + task prompt, write the task message to the
+/// transcript, and collect tool definitions.
+fn init_loop_state(
+    status_tx: &watch::Sender<SubAgentStatus>,
+    started_at: Instant,
+    effective_system_prompt: String,
+    initial_messages: Vec<Message>,
+    task_prompt: String,
+    executor: &FilteredToolExecutor,
+    transcript_writer: &mut Option<TranscriptWriter>,
+) -> (Vec<Message>, u32, Vec<ToolDefinition>) {
+    let _ = status_tx.send(SubAgentStatus {
+        state: SubAgentState::Working,
+        last_message: None,
+        turns_used: 0,
+        started_at,
+    });
+
+    let mut messages = vec![make_message(Role::System, effective_system_prompt)];
+    let history_len = initial_messages.len();
+    messages.extend(initial_messages);
+    messages.push(make_message(Role::User, task_prompt));
+
+    #[allow(clippy::cast_possible_truncation)]
+    let mut seq: u32 = history_len as u32;
+
+    if let Some(writer) = transcript_writer
+        && let Some(task_msg) = messages.last()
+    {
+        if let Err(e) = writer.append(seq, task_msg) {
+            tracing::warn!(error = %e, "failed to write transcript entry");
+        }
+        seq += 1;
+    }
+
+    let tool_defs: Vec<ToolDefinition> = executor
+        .tool_definitions_erased()
+        .iter()
+        .map(tool_def_to_definition)
+        .collect();
+
+    (messages, seq, tool_defs)
+}
+
+/// Outcome of a single agent turn.
+enum TurnOutcome {
+    /// Tool was called; the loop should continue.
+    ToolCalled,
+    /// No tool was called and a nudge was added; the loop should continue.
+    NudgeSent,
+    /// No tool was called and no nudge is needed; the loop should break.
+    Done,
+    /// A secret request was handled; the loop should continue.
+    SecretHandled,
+    /// The agent was cancelled; the loop should break.
+    Cancelled,
+}
+
+/// Execute a single LLM turn: call the provider, handle secret requests,
+/// dispatch tool calls, and write transcript entries.
+///
+/// Returns a [`TurnOutcome`] that drives the loop control flow in
+/// [`run_agent_loop`].
+#[allow(clippy::too_many_arguments)]
+async fn run_turn(
+    provider: &AnyProvider,
+    executor: &FilteredToolExecutor,
+    messages: &mut Vec<Message>,
+    tool_defs: &[ToolDefinition],
+    hooks: &SubagentHooks,
+    task_id: &str,
+    agent_name: &str,
+    status_tx: &watch::Sender<SubAgentStatus>,
+    transcript_writer: &mut Option<TranscriptWriter>,
+    seq: &mut u32,
+    turns: &mut u32,
+    last_result: &mut String,
+    any_tool_called: bool,
+    cancel: &CancellationToken,
+    background: bool,
+    started_at: Instant,
+    secret_request_tx: &mpsc::Sender<SecretRequest>,
+    secret_rx: &mut mpsc::Receiver<Option<String>>,
+) -> Result<TurnOutcome, super::error::SubAgentError> {
+    let response =
+        call_provider_with_status(provider, messages, tool_defs, status_tx, *turns, started_at)
+            .await?;
+
+    let response_text = match &response {
+        ChatResponse::Text(t) => t.clone(),
+        ChatResponse::ToolUse { text, .. } => text.as_deref().unwrap_or_default().to_owned(),
+    };
+
+    *turns += 1;
+    last_result.clone_from(&response_text);
+    emit_working_status(status_tx, &response_text, *turns, started_at);
+
+    let is_text_response = matches!(&response, ChatResponse::Text(_));
+    match handle_secret_request(
+        transcript_writer,
+        seq,
+        messages,
+        secret_request_tx,
+        secret_rx,
+        cancel,
+        background,
+        is_text_response,
+        &response_text,
+    )
+    .await
+    {
+        SecretRequestOutcome::Handled => return Ok(TurnOutcome::SecretHandled),
+        SecretRequestOutcome::Cancelled => return Ok(TurnOutcome::Cancelled),
+        SecretRequestOutcome::NotASecretRequest => {}
+    }
+
+    let prev_len = messages.len();
+    let no_tool = handle_tool_step(executor, response, messages, hooks, task_id, agent_name).await;
+
+    if no_tool {
+        let mut nudge_messages = Vec::new();
+        match handle_no_tool_response(
+            transcript_writer,
+            seq,
+            messages,
+            prev_len,
+            *turns,
+            any_tool_called,
+            &mut nudge_messages,
+        ) {
+            NoToolAction::Nudge => {
+                messages.extend(nudge_messages);
+                return Ok(TurnOutcome::NudgeSent);
+            }
+            NoToolAction::Break => return Ok(TurnOutcome::Done),
+        }
+    }
+
+    for msg in &messages[prev_len..] {
+        append_transcript(transcript_writer, seq, msg);
+    }
+    Ok(TurnOutcome::ToolCalled)
 }
 
 // Returns `true` if no tool was called (loop should break).
@@ -198,7 +536,6 @@ async fn handle_tool_step(
     }
 }
 
-#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3447): decompose into smaller helpers
 pub(super) async fn run_agent_loop(
     args: AgentLoopArgs,
 ) -> Result<String, super::error::SubAgentError> {
@@ -223,54 +560,19 @@ pub(super) async fn run_agent_loop(
         spawn_depth: _spawn_depth,
         mcp_tool_names,
     } = args;
-    let _ = status_tx.send(SubAgentStatus {
-        state: SubAgentState::Working,
-        last_message: None,
-        turns_used: 0,
+
+    let effective_system_prompt =
+        build_effective_system_prompt(system_prompt, skills, &mcp_tool_names);
+
+    let (mut messages, mut seq, tool_defs) = init_loop_state(
+        &status_tx,
         started_at,
-    });
-
-    let mut effective_system_prompt = if let Some(skill_bodies) = skills.filter(|s| !s.is_empty()) {
-        let skill_block = skill_bodies.join("\n\n");
-        format!("{system_prompt}\n\n```skills\n{skill_block}\n```")
-    } else {
-        system_prompt
-    };
-
-    if !mcp_tool_names.is_empty() {
-        let mcp_annotation = format!(
-            "\n\n## Available MCP Tools\n{}",
-            mcp_tool_names
-                .iter()
-                .map(|n| format!("- {n}"))
-                .collect::<Vec<_>>()
-                .join("\n")
-        );
-        effective_system_prompt.push_str(&mcp_annotation);
-    }
-
-    let mut messages = vec![make_message(Role::System, effective_system_prompt)];
-    let history_len = initial_messages.len();
-    messages.extend(initial_messages);
-    messages.push(make_message(Role::User, task_prompt));
-
-    #[allow(clippy::cast_possible_truncation)]
-    let mut seq: u32 = history_len as u32;
-
-    if let Some(writer) = &mut transcript_writer
-        && let Some(task_msg) = messages.last()
-    {
-        if let Err(e) = writer.append(seq, task_msg) {
-            tracing::warn!(error = %e, "failed to write transcript entry");
-        }
-        seq += 1;
-    }
-
-    let tool_defs: Vec<ToolDefinition> = executor
-        .tool_definitions_erased()
-        .iter()
-        .map(tool_def_to_definition)
-        .collect();
+        effective_system_prompt,
+        initial_messages,
+        task_prompt,
+        &executor,
+        &mut transcript_writer,
+    );
 
     let mut turns: u32 = 0;
     let mut last_result = String::new();
@@ -286,130 +588,31 @@ pub(super) async fn run_agent_loop(
             break;
         }
 
-        let llm_result = provider.chat_with_tools(&messages, &tool_defs).await;
-        let response = match llm_result {
-            Ok(r) => r,
-            Err(e) => {
-                tracing::error!(error = %e, "sub-agent LLM call failed");
-                let _ = status_tx.send(SubAgentStatus {
-                    state: SubAgentState::Failed,
-                    last_message: Some(e.to_string()),
-                    turns_used: turns,
-                    started_at,
-                });
-                return Err(super::error::SubAgentError::Llm(e.to_string()));
-            }
-        };
-
-        let response_text = match &response {
-            ChatResponse::Text(t) => t.clone(),
-            ChatResponse::ToolUse { text, .. } => text.as_deref().unwrap_or_default().to_owned(),
-        };
-
-        turns += 1;
-        last_result.clone_from(&response_text);
-        let _ = status_tx.send(SubAgentStatus {
-            state: SubAgentState::Working,
-            last_message: Some(response_text.chars().take(120).collect()),
-            turns_used: turns,
-            started_at,
-        });
-
-        if let ChatResponse::Text(_) = &response
-            && let Some(rest) = response_text.strip_prefix(SECRET_REQUEST_PREFIX)
-        {
-            let raw_key = rest.split(']').next().unwrap_or("").trim().to_owned();
-            let key_name = if raw_key
-                .chars()
-                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
-                && !raw_key.is_empty()
-                && raw_key.len() <= 100
-            {
-                raw_key
-            } else {
-                tracing::warn!("sub-agent emitted invalid secret key name — ignoring request");
-                String::new()
-            };
-            if !key_name.is_empty() {
-                tracing::debug!("sub-agent requested secret [key redacted]");
-
-                if background {
-                    tracing::warn!(
-                        "background sub-agent secret request auto-denied (no interactive prompt)"
-                    );
-                    let reply = format!("[secret:{key_name}] request denied");
-                    let assistant_msg = make_message(Role::Assistant, response_text);
-                    let user_msg = make_message(Role::User, reply);
-                    append_transcript(&mut transcript_writer, &mut seq, &assistant_msg);
-                    append_transcript(&mut transcript_writer, &mut seq, &user_msg);
-                    messages.push(assistant_msg);
-                    messages.push(user_msg);
-                    continue;
-                }
-
-                let req = SecretRequest {
-                    secret_key: key_name.clone(),
-                    reason: None,
-                };
-                if secret_request_tx.send(req).await.is_ok() {
-                    let outcome = tokio::select! {
-                        msg = secret_rx.recv() => msg,
-                        () = cancel.cancelled() => {
-                            tracing::debug!("sub-agent cancelled while waiting for secret approval");
-                            break;
-                        }
-                    };
-                    let reply = match outcome {
-                        Some(Some(_)) => {
-                            format!("[secret:{key_name} approved — value available via grants]")
-                        }
-                        Some(None) | None => {
-                            format!("[secret:{key_name}] request denied")
-                        }
-                    };
-                    let assistant_msg = make_message(Role::Assistant, response_text);
-                    let user_msg = make_message(Role::User, reply);
-                    append_transcript(&mut transcript_writer, &mut seq, &assistant_msg);
-                    append_transcript(&mut transcript_writer, &mut seq, &user_msg);
-                    messages.push(assistant_msg);
-                    messages.push(user_msg);
-                    continue;
-                }
-            }
-        }
-
-        let prev_len = messages.len();
-        let no_tool = handle_tool_step(
+        match run_turn(
+            &provider,
             &executor,
-            response,
             &mut messages,
+            &tool_defs,
             &hooks,
             &loop_task_id,
             &agent_name,
+            &status_tx,
+            &mut transcript_writer,
+            &mut seq,
+            &mut turns,
+            &mut last_result,
+            any_tool_called,
+            &cancel,
+            background,
+            started_at,
+            &secret_request_tx,
+            &mut secret_rx,
         )
-        .await;
-
-        if no_tool {
-            for msg in &messages[prev_len..] {
-                append_transcript(&mut transcript_writer, &mut seq, msg);
-            }
-            if turns == 1 && !any_tool_called {
-                tracing::debug!("sub-agent text-only first turn — sending nudge to use tools");
-                let nudge = make_message(
-                    Role::User,
-                    "Please use the available tools to complete the task. \
-                     Do not announce intentions — execute them."
-                        .into(),
-                );
-                append_transcript(&mut transcript_writer, &mut seq, &nudge);
-                messages.push(nudge);
-                continue;
-            }
-            break;
-        }
-        any_tool_called = true;
-        for msg in &messages[prev_len..] {
-            append_transcript(&mut transcript_writer, &mut seq, msg);
+        .await?
+        {
+            TurnOutcome::ToolCalled => any_tool_called = true,
+            TurnOutcome::NudgeSent | TurnOutcome::SecretHandled => {}
+            TurnOutcome::Done | TurnOutcome::Cancelled => break,
         }
     }
 


### PR DESCRIPTION
## Summary

- Decomposed `connect_all`, `connect_oauth_deferred`, `add_server` in `zeph-mcp/src/manager.rs` into focused private helpers
- Decomposed `index_project` in `zeph-index/src/indexer.rs` into `ensure_collection_for_provider`, `walk_project_files`, `index_batch`, `cleanup_removed_files`
- Decomposed `run_agent_loop` in `zeph-subagent/src/agent_loop.rs` into `build_effective_system_prompt`, `call_provider_with_status`, `emit_working_status`, `handle_secret_request`, `handle_no_tool_response`, `init_loop_state`, `run_turn` with `TurnOutcome`/`NoToolAction`/`SecretRequestOutcome` enums for explicit control flow
- Removed all `#[allow(clippy::too_many_lines)]` suppressions from the target functions

Pure refactoring — no behavior changes, no public API changes, no new dependencies.

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 8605 passed, 0 failed
- [x] `cargo +nightly fmt --check` — clean

Closes #3451, #3458, #3447