### PR TITLE
refactor: decompose long functions in zeph-orchestration, zeph-context, zeph-channels

### DIFF
--- a/crates/zeph-channels/src/telegram.rs
+++ b/crates/zeph-channels/src/telegram.rs
@@ -173,7 +173,6 @@ impl TelegramChannel {
     /// # Errors
     ///
     /// Returns an error if the bot cannot be initialized.
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3445): decompose into smaller helpers
     pub fn start(mut self) -> Result<Self, ChannelError> {
         if self.allowed_users.is_empty() {
             tracing::error!("telegram.allowed_users is empty; refusing to start an open bot");
@@ -201,87 +200,7 @@ impl TelegramChannel {
                 let handler = Update::filter_message().endpoint(move |msg: Message, bot: Bot| {
                     let tx = tx.clone();
                     let allowed = allowed.clone();
-                    async move {
-                        let username = msg.from.as_ref().and_then(|u| u.username.clone());
-
-                        if !allowed.is_empty() {
-                            let is_allowed = username
-                                .as_deref()
-                                .is_some_and(|u| allowed.iter().any(|a| a == u));
-                            if !is_allowed {
-                                tracing::warn!(
-                                    "rejected message from unauthorized user: {:?}",
-                                    username
-                                );
-                                return respond(());
-                            }
-                        }
-
-                        let text = msg.text().unwrap_or_default().to_string();
-                        let mut attachments = Vec::new();
-
-                        let audio_file_id = msg
-                            .voice()
-                            .map(|v| (v.file.id.0.clone(), v.file.size))
-                            .or_else(|| msg.audio().map(|a| (a.file.id.0.clone(), a.file.size)));
-
-                        if let Some((file_id, file_size)) = audio_file_id {
-                            match download_file(&bot, file_id, file_size).await {
-                                Ok(data) => {
-                                    attachments.push(Attachment {
-                                        kind: AttachmentKind::Audio,
-                                        data,
-                                        filename: msg.audio().and_then(|a| a.file_name.clone()),
-                                    });
-                                }
-                                Err(e) => {
-                                    tracing::warn!("failed to download audio attachment: {e}");
-                                }
-                            }
-                        }
-
-                        // Handle photo attachments (pick the largest available size)
-                        if let Some(photos) = msg.photo()
-                            && let Some(photo) = photos.iter().max_by_key(|p| p.file.size)
-                        {
-                            if photo.file.size > MAX_IMAGE_BYTES {
-                                tracing::warn!(
-                                    size = photo.file.size,
-                                    max = MAX_IMAGE_BYTES,
-                                    "photo exceeds size limit, skipping"
-                                );
-                            } else {
-                                match download_file(&bot, photo.file.id.0.clone(), photo.file.size)
-                                    .await
-                                {
-                                    Ok(data) => {
-                                        attachments.push(Attachment {
-                                            kind: AttachmentKind::Image,
-                                            data,
-                                            filename: None,
-                                        });
-                                    }
-                                    Err(e) => {
-                                        tracing::warn!("failed to download photo attachment: {e}");
-                                    }
-                                }
-                            }
-                        }
-
-                        if text.is_empty() && attachments.is_empty() {
-                            return respond(());
-                        }
-
-                        let _ = tx
-                            .send(IncomingMessage {
-                                chat_id: msg.chat.id,
-                                text,
-                                attachments,
-                            })
-                            .await;
-
-                        respond(())
-                    }
+                    async move { handle_telegram_message(bot, msg, tx, allowed).await }
                 });
 
                 Dispatcher::builder(bot, handler)
@@ -459,6 +378,108 @@ impl TelegramChannel {
         self.last_edit = Some(Instant::now());
         Ok(())
     }
+}
+
+/// Returns `true` when `username` appears in `allowed`.
+///
+/// An empty `allowed` list is treated as "no restriction" and always returns
+/// `true`, but `start()` rejects empty lists before the listener is spawned,
+/// so in practice `allowed` is never empty at call time.
+fn is_user_authorized(username: Option<&str>, allowed: &[String]) -> bool {
+    allowed.is_empty() || username.is_some_and(|u| allowed.iter().any(|a| a == u))
+}
+
+/// Extract the audio file identifier and byte size from a message, if present.
+///
+/// Prefers a voice note over an audio file when both are present.
+fn extract_audio_attachment(msg: &Message) -> Option<(String, u32)> {
+    msg.voice()
+        .map(|v| (v.file.id.0.clone(), v.file.size))
+        .or_else(|| msg.audio().map(|a| (a.file.id.0.clone(), a.file.size)))
+}
+
+/// Extract the largest photo's file identifier and byte size from a message.
+///
+/// Returns `None` when the message contains no photo or the largest available
+/// size exceeds [`MAX_IMAGE_BYTES`].
+fn extract_photo_attachment(msg: &Message) -> Option<(String, u32)> {
+    let photos = msg.photo()?;
+    let photo = photos.iter().max_by_key(|p| p.file.size)?;
+    if photo.file.size > MAX_IMAGE_BYTES {
+        tracing::warn!(
+            size = photo.file.size,
+            max = MAX_IMAGE_BYTES,
+            "photo exceeds size limit, skipping"
+        );
+        return None;
+    }
+    Some((photo.file.id.0.clone(), photo.file.size))
+}
+
+/// Process one incoming Telegram update inside the dispatcher endpoint.
+///
+/// Checks authorization, downloads any media attachments, and forwards the
+/// assembled [`IncomingMessage`] to the agent via `tx`.  Returns
+/// `respond(())` in all branches so teloxide considers the update handled.
+async fn handle_telegram_message(
+    bot: Bot,
+    msg: Message,
+    tx: mpsc::Sender<IncomingMessage>,
+    allowed: Vec<String>,
+) -> Result<(), teloxide::RequestError> {
+    let username = msg.from.as_ref().and_then(|u| u.username.as_deref());
+
+    if !is_user_authorized(username, &allowed) {
+        tracing::warn!("rejected message from unauthorized user: {:?}", username);
+        return respond(());
+    }
+
+    let text = msg.text().unwrap_or_default().to_string();
+    let mut attachments = Vec::new();
+
+    if let Some((file_id, file_size)) = extract_audio_attachment(&msg) {
+        match download_file(&bot, file_id, file_size).await {
+            Ok(data) => {
+                attachments.push(Attachment {
+                    kind: AttachmentKind::Audio,
+                    data,
+                    filename: msg.audio().and_then(|a| a.file_name.clone()),
+                });
+            }
+            Err(e) => {
+                tracing::warn!("failed to download audio attachment: {e}");
+            }
+        }
+    }
+
+    if let Some((file_id, file_size)) = extract_photo_attachment(&msg) {
+        match download_file(&bot, file_id, file_size).await {
+            Ok(data) => {
+                attachments.push(Attachment {
+                    kind: AttachmentKind::Image,
+                    data,
+                    filename: None,
+                });
+            }
+            Err(e) => {
+                tracing::warn!("failed to download photo attachment: {e}");
+            }
+        }
+    }
+
+    if text.is_empty() && attachments.is_empty() {
+        return respond(());
+    }
+
+    let _ = tx
+        .send(IncomingMessage {
+            chat_id: msg.chat.id,
+            text,
+            attachments,
+        })
+        .await;
+
+    respond(())
 }
 
 async fn download_file(bot: &Bot, file_id: String, capacity: u32) -> Result<Vec<u8>, String> {
@@ -955,6 +976,26 @@ mod tests {
     // ---------------------------------------------------------------------------
     // Pure-function unit tests (no async, no network)
     // ---------------------------------------------------------------------------
+
+    #[test]
+    fn is_user_authorized_empty_allowed_permits_all() {
+        assert!(is_user_authorized(None, &[]));
+        assert!(is_user_authorized(Some("anyone"), &[]));
+    }
+
+    #[test]
+    fn is_user_authorized_known_user_is_permitted() {
+        let allowed = vec!["alice".to_string(), "bob".to_string()];
+        assert!(is_user_authorized(Some("alice"), &allowed));
+        assert!(is_user_authorized(Some("bob"), &allowed));
+    }
+
+    #[test]
+    fn is_user_authorized_unknown_user_is_rejected() {
+        let allowed = vec!["alice".to_string()];
+        assert!(!is_user_authorized(Some("eve"), &allowed));
+        assert!(!is_user_authorized(None, &allowed));
+    }
 
     #[test]
     fn is_command_detection() {

--- a/crates/zeph-context/src/assembler.rs
+++ b/crates/zeph-context/src/assembler.rs
@@ -79,6 +79,193 @@ pub struct PreparedContext {
 /// All logic is in [`ContextAssembler::gather`]. No state is stored on this type.
 pub struct ContextAssembler;
 
+type CtxFuture<'a> = Pin<Box<dyn Future<Output = Result<ContextSlot, ContextError>> + Send + 'a>>;
+
+fn empty_prepared_context() -> PreparedContext {
+    PreparedContext {
+        graph_facts: None,
+        doc_rag: None,
+        corrections: None,
+        recall: None,
+        recall_confidence: None,
+        cross_session: None,
+        summaries: None,
+        code_context: None,
+        persona_facts: None,
+        trajectory_hints: None,
+        tree_memory: None,
+        reasoning_hints: None,
+        memory_first: false,
+        recent_history_budget: 0,
+    }
+}
+
+// TODO(critic): consider impl Default for PreparedContext to make this constructor obsolete (#3442 follow-up).
+
+fn resolve_effective_strategy(
+    memory: &crate::input::ContextMemoryView,
+    sidequest_turn_counter: u64,
+) -> zeph_config::ContextStrategy {
+    match memory.context_strategy {
+        zeph_config::ContextStrategy::FullHistory => zeph_config::ContextStrategy::FullHistory,
+        zeph_config::ContextStrategy::MemoryFirst => zeph_config::ContextStrategy::MemoryFirst,
+        zeph_config::ContextStrategy::Adaptive => {
+            if sidequest_turn_counter >= u64::from(memory.crossover_turn_threshold) {
+                zeph_config::ContextStrategy::MemoryFirst
+            } else {
+                zeph_config::ContextStrategy::FullHistory
+            }
+        }
+    }
+}
+
+fn correction_params(cfg: Option<&crate::input::CorrectionConfig>) -> (usize, f32) {
+    cfg.filter(|c| c.correction_detection)
+        .map_or((3, 0.75), |c| {
+            (
+                c.correction_recall_limit as usize,
+                c.correction_min_similarity,
+            )
+        })
+}
+
+/// Schedules all enabled context fetchers and returns them as a set of concurrent futures.
+///
+/// `router_ref` borrows from `router`, which is a local owned by `gather`. Using a separate
+/// lifetime `'r` for `router_ref` avoids tying it to `'a` (the input lifetime), which would
+/// require `router` to outlive `input`. All `usize` budget values are passed by copy so the
+/// returned futures do not borrow from `alloc`.
+#[allow(clippy::too_many_arguments)]
+fn schedule_context_fetchers<'r>(
+    memory: &'r crate::input::ContextMemoryView,
+    tc: &'r zeph_memory::TokenCounter,
+    query: &'r str,
+    scrub: fn(&str) -> std::borrow::Cow<'_, str>,
+    index: Option<&'r dyn crate::input::IndexAccess>,
+    router_ref: &'r dyn zeph_memory::AsyncMemoryRouter,
+    summaries_budget: usize,
+    cross_session_budget: usize,
+    semantic_recall_budget: usize,
+    code_context_budget: usize,
+    graph_facts_budget: usize,
+    recall_limit: usize,
+    min_sim: f32,
+) -> FuturesUnordered<CtxFuture<'r>> {
+    let fetchers: FuturesUnordered<CtxFuture<'r>> = FuturesUnordered::new();
+
+    if summaries_budget > 0 {
+        fetchers.push(Box::pin(async move {
+            fetch_summaries(memory, summaries_budget, tc)
+                .await
+                .map(ContextSlot::Summaries)
+        }));
+    }
+    if cross_session_budget > 0 {
+        fetchers.push(Box::pin(async move {
+            fetch_cross_session(memory, query, cross_session_budget, tc)
+                .await
+                .map(ContextSlot::CrossSession)
+        }));
+    }
+    if semantic_recall_budget > 0 {
+        fetchers.push(Box::pin(async move {
+            fetch_semantic_recall(memory, query, semantic_recall_budget, tc, Some(router_ref))
+                .await
+                .map(|(msg, score)| ContextSlot::SemanticRecall(msg, score))
+        }));
+        fetchers.push(Box::pin(async move {
+            fetch_document_rag(memory, query, semantic_recall_budget, tc)
+                .await
+                .map(ContextSlot::DocumentRag)
+        }));
+    }
+    // Corrections are safety-critical and never budget-gated.
+    fetchers.push(Box::pin(async move {
+        fetch_corrections(memory, query, recall_limit, min_sim, scrub)
+            .await
+            .map(ContextSlot::Corrections)
+    }));
+    if code_context_budget > 0
+        && let Some(idx) = index
+    {
+        fetchers.push(Box::pin(async move {
+            let result: Result<Option<String>, ContextError> =
+                idx.fetch_code_rag(query, code_context_budget).await;
+            result.map(ContextSlot::CodeContext)
+        }));
+    }
+    if graph_facts_budget > 0 {
+        fetchers.push(Box::pin(async move {
+            fetch_graph_facts(memory, query, graph_facts_budget, tc)
+                .await
+                .map(ContextSlot::GraphFacts)
+        }));
+    }
+    if memory.persona_config.context_budget_tokens > 0 {
+        fetchers.push(Box::pin(async move {
+            let persona_budget = memory.persona_config.context_budget_tokens;
+            fetch_persona_facts(memory, persona_budget, tc)
+                .await
+                .map(ContextSlot::PersonaFacts)
+        }));
+    }
+    if memory.trajectory_config.context_budget_tokens > 0 {
+        fetchers.push(Box::pin(async move {
+            let tbudget = memory.trajectory_config.context_budget_tokens;
+            fetch_trajectory_hints(memory, tbudget, tc)
+                .await
+                .map(ContextSlot::TrajectoryHints)
+        }));
+    }
+    if memory.tree_config.context_budget_tokens > 0 {
+        fetchers.push(Box::pin(async move {
+            let tbudget = memory.tree_config.context_budget_tokens;
+            fetch_tree_memory(memory, tbudget, tc)
+                .await
+                .map(ContextSlot::TreeMemory)
+        }));
+    }
+    if memory.reasoning_config.enabled && memory.reasoning_config.context_budget_tokens > 0 {
+        fetchers.push(Box::pin(async move {
+            let rbudget = memory.reasoning_config.context_budget_tokens;
+            let top_k = memory.reasoning_config.top_k;
+            fetch_reasoning_strategies(memory, query, rbudget, top_k, tc)
+                .await
+                .map(ContextSlot::ReasoningStrategies)
+        }));
+    }
+
+    fetchers
+}
+
+async fn drive_fetchers(
+    mut fetchers: FuturesUnordered<CtxFuture<'_>>,
+    prepared: &mut PreparedContext,
+) -> Result<(), ContextError> {
+    while let Some(result) = fetchers.next().await {
+        match result {
+            Ok(slot) => match slot {
+                ContextSlot::Summaries(msg) => prepared.summaries = msg,
+                ContextSlot::CrossSession(msg) => prepared.cross_session = msg,
+                ContextSlot::SemanticRecall(msg, score) => {
+                    prepared.recall = msg;
+                    prepared.recall_confidence = score;
+                }
+                ContextSlot::DocumentRag(msg) => prepared.doc_rag = msg,
+                ContextSlot::Corrections(msg) => prepared.corrections = msg,
+                ContextSlot::CodeContext(text) => prepared.code_context = text,
+                ContextSlot::GraphFacts(msg) => prepared.graph_facts = msg,
+                ContextSlot::PersonaFacts(msg) => prepared.persona_facts = msg,
+                ContextSlot::TrajectoryHints(msg) => prepared.trajectory_hints = msg,
+                ContextSlot::TreeMemory(msg) => prepared.tree_memory = msg,
+                ContextSlot::ReasoningStrategies(msg) => prepared.reasoning_hints = msg,
+            },
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(())
+}
+
 impl ContextAssembler {
     /// Gather all context sources concurrently and return a [`PreparedContext`].
     ///
@@ -87,44 +274,15 @@ impl ContextAssembler {
     /// # Errors
     ///
     /// Propagates errors from any async fetch operation.
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3442): decompose into smaller helpers
     pub async fn gather(input: &ContextAssemblyInput<'_>) -> Result<PreparedContext, ContextError> {
-        type CtxFuture<'a> =
-            Pin<Box<dyn Future<Output = Result<ContextSlot, ContextError>> + Send + 'a>>;
-
         let Some(ref budget) = input.context_manager.budget else {
-            return Ok(PreparedContext {
-                graph_facts: None,
-                doc_rag: None,
-                corrections: None,
-                recall: None,
-                recall_confidence: None,
-                cross_session: None,
-                summaries: None,
-                code_context: None,
-                persona_facts: None,
-                trajectory_hints: None,
-                tree_memory: None,
-                reasoning_hints: None,
-                memory_first: false,
-                recent_history_budget: 0,
-            });
+            return Ok(empty_prepared_context());
         };
 
         let memory = input.memory;
         let tc = input.token_counter;
 
-        let effective_strategy = match memory.context_strategy {
-            zeph_config::ContextStrategy::FullHistory => zeph_config::ContextStrategy::FullHistory,
-            zeph_config::ContextStrategy::MemoryFirst => zeph_config::ContextStrategy::MemoryFirst,
-            zeph_config::ContextStrategy::Adaptive => {
-                if input.sidequest_turn_counter >= u64::from(memory.crossover_turn_threshold) {
-                    zeph_config::ContextStrategy::MemoryFirst
-                } else {
-                    zeph_config::ContextStrategy::FullHistory
-                }
-            }
-        };
+        let effective_strategy = resolve_effective_strategy(memory, input.sidequest_turn_counter);
         let memory_first = effective_strategy == zeph_config::ContextStrategy::MemoryFirst;
 
         let system_prompt = input
@@ -138,162 +296,46 @@ impl ContextAssembler {
             .as_ref()
             .map_or(0, |(_, tokens)| *tokens);
 
-        let graph_enabled = memory.graph_config.enabled;
-
         let alloc = budget.allocate_with_opts(
             system_prompt,
             input.skills_prompt,
             tc,
-            graph_enabled,
+            memory.graph_config.enabled,
             digest_tokens,
             memory_first,
         );
 
-        let correction_params = input
-            .correction_config
-            .filter(|c| c.correction_detection)
-            .map(|c| {
-                (
-                    c.correction_recall_limit as usize,
-                    c.correction_min_similarity,
-                )
-            });
-        let (recall_limit, min_sim) = correction_params.unwrap_or((3, 0.75));
+        let (recall_limit, min_sim) = correction_params(input.correction_config.as_ref());
 
         let router = input.context_manager.build_router();
         let router_ref: &dyn zeph_memory::AsyncMemoryRouter = router.as_ref();
-        let query = input.query;
-        let scrub = input.scrub;
-
-        let mut fetchers: FuturesUnordered<CtxFuture<'_>> = FuturesUnordered::new();
 
         tracing::debug!(
             active_sources = alloc.active_sources(),
             "context budget allocated"
         );
 
-        if alloc.summaries > 0 {
-            fetchers.push(Box::pin(async {
-                fetch_summaries(memory, alloc.summaries, tc)
-                    .await
-                    .map(ContextSlot::Summaries)
-            }));
-        }
-        if alloc.cross_session > 0 {
-            fetchers.push(Box::pin(async {
-                fetch_cross_session(memory, query, alloc.cross_session, tc)
-                    .await
-                    .map(ContextSlot::CrossSession)
-            }));
-        }
-        if alloc.semantic_recall > 0 {
-            fetchers.push(Box::pin(async {
-                fetch_semantic_recall(memory, query, alloc.semantic_recall, tc, Some(router_ref))
-                    .await
-                    .map(|(msg, score)| ContextSlot::SemanticRecall(msg, score))
-            }));
-            fetchers.push(Box::pin(async {
-                fetch_document_rag(memory, query, alloc.semantic_recall, tc)
-                    .await
-                    .map(ContextSlot::DocumentRag)
-            }));
-        }
-        // Corrections are safety-critical and never budget-gated.
-        fetchers.push(Box::pin(async {
-            fetch_corrections(memory, query, recall_limit, min_sim, scrub)
-                .await
-                .map(ContextSlot::Corrections)
-        }));
-        if alloc.code_context > 0
-            && let Some(index) = input.index
-        {
-            let budget = alloc.code_context;
-            fetchers.push(Box::pin(async move {
-                let result: Result<Option<String>, ContextError> =
-                    index.fetch_code_rag(query, budget).await;
-                result.map(ContextSlot::CodeContext)
-            }));
-        }
-        if alloc.graph_facts > 0 {
-            fetchers.push(Box::pin(async {
-                fetch_graph_facts(memory, query, alloc.graph_facts, tc)
-                    .await
-                    .map(ContextSlot::GraphFacts)
-            }));
-        }
-        if memory.persona_config.context_budget_tokens > 0 {
-            fetchers.push(Box::pin(async {
-                let persona_budget = memory.persona_config.context_budget_tokens;
-                fetch_persona_facts(memory, persona_budget, tc)
-                    .await
-                    .map(ContextSlot::PersonaFacts)
-            }));
-        }
-        if memory.trajectory_config.context_budget_tokens > 0 {
-            fetchers.push(Box::pin(async {
-                let tbudget = memory.trajectory_config.context_budget_tokens;
-                fetch_trajectory_hints(memory, tbudget, tc)
-                    .await
-                    .map(ContextSlot::TrajectoryHints)
-            }));
-        }
-        if memory.tree_config.context_budget_tokens > 0 {
-            fetchers.push(Box::pin(async {
-                let tbudget = memory.tree_config.context_budget_tokens;
-                fetch_tree_memory(memory, tbudget, tc)
-                    .await
-                    .map(ContextSlot::TreeMemory)
-            }));
-        }
-        if memory.reasoning_config.enabled && memory.reasoning_config.context_budget_tokens > 0 {
-            fetchers.push(Box::pin(async {
-                let rbudget = memory.reasoning_config.context_budget_tokens;
-                let top_k = memory.reasoning_config.top_k;
-                fetch_reasoning_strategies(memory, query, rbudget, top_k, tc)
-                    .await
-                    .map(ContextSlot::ReasoningStrategies)
-            }));
-        }
+        let fetchers = schedule_context_fetchers(
+            memory,
+            tc,
+            input.query,
+            input.scrub,
+            input.index,
+            router_ref,
+            alloc.summaries,
+            alloc.cross_session,
+            alloc.semantic_recall,
+            alloc.code_context,
+            alloc.graph_facts,
+            recall_limit,
+            min_sim,
+        );
 
-        let mut prepared = PreparedContext {
-            graph_facts: None,
-            doc_rag: None,
-            corrections: None,
-            recall: None,
-            recall_confidence: None,
-            cross_session: None,
-            summaries: None,
-            code_context: None,
-            persona_facts: None,
-            trajectory_hints: None,
-            tree_memory: None,
-            reasoning_hints: None,
-            memory_first,
-            recent_history_budget: alloc.recent_history,
-        };
+        let mut prepared = empty_prepared_context();
+        prepared.memory_first = memory_first;
+        prepared.recent_history_budget = alloc.recent_history;
 
-        while let Some(result) = fetchers.next().await {
-            match result {
-                Ok(slot) => match slot {
-                    ContextSlot::Summaries(msg) => prepared.summaries = msg,
-                    ContextSlot::CrossSession(msg) => prepared.cross_session = msg,
-                    ContextSlot::SemanticRecall(msg, score) => {
-                        prepared.recall = msg;
-                        prepared.recall_confidence = score;
-                    }
-                    ContextSlot::DocumentRag(msg) => prepared.doc_rag = msg,
-                    ContextSlot::Corrections(msg) => prepared.corrections = msg,
-                    ContextSlot::CodeContext(text) => prepared.code_context = text,
-                    ContextSlot::GraphFacts(msg) => prepared.graph_facts = msg,
-                    ContextSlot::PersonaFacts(msg) => prepared.persona_facts = msg,
-                    ContextSlot::TrajectoryHints(msg) => prepared.trajectory_hints = msg,
-                    ContextSlot::TreeMemory(msg) => prepared.tree_memory = msg,
-                    ContextSlot::ReasoningStrategies(msg) => prepared.reasoning_hints = msg,
-                },
-                Err(e) => return Err(e),
-            }
-        }
-
+        drive_fetchers(fetchers, &mut prepared).await?;
         Ok(prepared)
     }
 }

--- a/crates/zeph-context/src/summarization.rs
+++ b/crates/zeph-context/src/summarization.rs
@@ -129,7 +129,6 @@ pub async fn single_pass_summary(
 ///
 /// # Errors
 /// Returns [`zeph_llm::LlmError`] when all summarization attempts fail.
-#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3442): decompose into smaller helpers
 pub async fn summarize_with_llm(
     deps: &SummarizationDeps,
     messages: &[Message],
@@ -149,10 +148,34 @@ pub async fn summarize_with_llm(
         return single_pass_summary(deps, messages, guidelines).await;
     }
 
-    // Summarize chunks with bounded concurrency to prevent runaway API calls
+    let partial_summaries = run_chunk_summaries(deps, chunks, guidelines).await;
+
+    if partial_summaries.is_empty() {
+        return single_pass_summary(deps, messages, guidelines).await;
+    }
+
+    let numbered = join_partial_summaries(&partial_summaries);
+
+    if deps.structured_summaries
+        && let Some(result) = try_structured_consolidation(deps, &numbered).await
+    {
+        return Ok(result);
+    }
+
+    prose_consolidation(deps, &numbered).await
+}
+
+/// Summarizes each chunk concurrently with bounded parallelism. Any chunk error discards all
+/// partials and forces single-pass fallback.
+async fn run_chunk_summaries(
+    deps: &SummarizationDeps,
+    chunks: Vec<Vec<Message>>,
+    guidelines: &str,
+) -> Vec<String> {
     let provider = deps.provider.clone();
     let guidelines_owned = guidelines.to_string();
     let timeout = deps.llm_timeout;
+
     let results: Vec<_> = futures::stream::iter(chunks.into_iter().map(|chunk| {
         let guidelines_ref = guidelines_owned.clone();
         let prompt = build_chunk_prompt(&chunk, &guidelines_ref);
@@ -175,7 +198,7 @@ pub async fn summarize_with_llm(
     .collect()
     .await;
 
-    let partial_summaries: Vec<String> = results
+    results
         .into_iter()
         .collect::<Result<Vec<_>, zeph_llm::LlmError>>()
         .unwrap_or_else(|e| {
@@ -183,78 +206,83 @@ pub async fn summarize_with_llm(
                 "chunked compaction: one or more chunks failed: {e:#}, falling back to single-pass"
             );
             Vec::new()
-        });
+        })
+}
 
-    if partial_summaries.is_empty() {
-        return single_pass_summary(deps, messages, guidelines).await;
-    }
-
-    // Consolidate partial summaries
-    let numbered = {
-        let cap: usize = partial_summaries.iter().map(|s| s.len() + 8).sum();
-        let mut buf = String::with_capacity(cap);
-        for (i, s) in partial_summaries.iter().enumerate() {
-            if i > 0 {
-                buf.push_str("\n\n");
-            }
-            let _ = write!(buf, "{}. {s}", i + 1);
+fn join_partial_summaries(partials: &[String]) -> String {
+    let cap: usize = partials.iter().map(|s| s.len() + 8).sum();
+    let mut buf = String::with_capacity(cap);
+    for (i, s) in partials.iter().enumerate() {
+        if i > 0 {
+            buf.push_str("\n\n");
         }
-        buf
-    };
+        let _ = write!(buf, "{}. {s}", i + 1);
+    }
+    buf
+}
 
-    if deps.structured_summaries {
-        let anchored_prompt = format!(
-            "<analysis>\n\
-             Merge these partial conversation summaries into a single structured summary.\n\
-             </analysis>\n\
-             \n\
-             Produce a JSON object with exactly these 5 fields:\n\
-             - session_intent: string — what the user is trying to accomplish\n\
-             - files_modified: string[] — file paths, function names, structs touched\n\
-             - decisions_made: string[] — each entry: \"Decision: X — Reason: Y\"\n\
-             - open_questions: string[] — unresolved questions or blockers\n\
-             - next_steps: string[] — concrete next actions\n\
-             \n\
-             Partial summaries:\n{numbered}"
-        );
-        let anchored_msgs = [Message {
-            role: Role::User,
-            content: anchored_prompt,
-            parts: vec![],
-            metadata: MessageMetadata::default(),
-        }];
-        match tokio::time::timeout(
-            timeout,
-            deps.provider
-                .chat_typed_erased::<AnchoredSummary>(&anchored_msgs),
-        )
-        .await
-        {
-            Ok(Ok(anchored)) if anchored.is_complete() => {
-                if let Some(ref cb) = deps.on_anchored_summary {
-                    cb(&anchored, false);
-                }
-                return Ok(crate::slot::cap_summary(anchored.to_markdown(), 16_000));
+async fn try_structured_consolidation(deps: &SummarizationDeps, numbered: &str) -> Option<String> {
+    let timeout = deps.llm_timeout;
+    let anchored_prompt = format!(
+        "<analysis>\n\
+         Merge these partial conversation summaries into a single structured summary.\n\
+         </analysis>\n\
+         \n\
+         Produce a JSON object with exactly these 5 fields:\n\
+         - session_intent: string — what the user is trying to accomplish\n\
+         - files_modified: string[] — file paths, function names, structs touched\n\
+         - decisions_made: string[] — each entry: \"Decision: X — Reason: Y\"\n\
+         - open_questions: string[] — unresolved questions or blockers\n\
+         - next_steps: string[] — concrete next actions\n\
+         \n\
+         Partial summaries:\n{numbered}"
+    );
+    let anchored_msgs = [Message {
+        role: Role::User,
+        content: anchored_prompt,
+        parts: vec![],
+        metadata: MessageMetadata::default(),
+    }];
+    match tokio::time::timeout(
+        timeout,
+        deps.provider
+            .chat_typed_erased::<AnchoredSummary>(&anchored_msgs),
+    )
+    .await
+    {
+        Ok(Ok(anchored)) if anchored.is_complete() => {
+            if let Some(ref cb) = deps.on_anchored_summary {
+                cb(&anchored, false);
             }
-            Ok(Ok(anchored)) => {
-                tracing::warn!(
-                    "chunked consolidation: structured summary incomplete, falling back to prose"
-                );
-                if let Some(ref cb) = deps.on_anchored_summary {
-                    cb(&anchored, true);
-                }
+            Some(crate::slot::cap_summary(anchored.to_markdown(), 16_000))
+        }
+        Ok(Ok(anchored)) => {
+            tracing::warn!(
+                "chunked consolidation: structured summary incomplete, falling back to prose"
+            );
+            if let Some(ref cb) = deps.on_anchored_summary {
+                cb(&anchored, true);
             }
-            Ok(Err(e)) => {
-                tracing::warn!(error = %e, "chunked consolidation: structured output failed, falling back to prose");
-            }
-            Err(_) => {
-                tracing::warn!(
-                    "chunked consolidation: structured output timed out, falling back to prose"
-                );
-            }
+            None
+        }
+        Ok(Err(e)) => {
+            tracing::warn!(error = %e, "chunked consolidation: structured output failed, falling back to prose");
+            None
+        }
+        Err(_) => {
+            tracing::warn!(
+                "chunked consolidation: structured output timed out, falling back to prose"
+            );
+            None
         }
     }
+}
 
+async fn prose_consolidation(
+    deps: &SummarizationDeps,
+    numbered: &str,
+) -> Result<String, zeph_llm::LlmError> {
+    let timeout = deps.llm_timeout;
     let consolidation_prompt = format!(
         "<analysis>\n\
          Merge these partial conversation summaries into a single structured compaction note.\n\
@@ -264,7 +292,6 @@ pub async fn summarize_with_llm(
          </analysis>\n\n\
          Partial summaries:\n{numbered}"
     );
-
     let consolidation_msgs = [Message {
         role: Role::User,
         content: consolidation_prompt,

--- a/crates/zeph-orchestration/src/scheduler/tick.rs
+++ b/crates/zeph-orchestration/src/scheduler/tick.rs
@@ -16,7 +16,6 @@ impl DagScheduler {
     /// Process pending events and produce actions for the caller.
     ///
     /// Call `wait_event` after processing all actions to block until the next event.
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3441): decompose into smaller helpers
     pub fn tick(&mut self) -> Vec<SchedulerAction> {
         if self.graph.status != GraphStatus::Running {
             return vec![SchedulerAction::Done {
@@ -26,23 +25,12 @@ impl DagScheduler {
 
         self.reanalyze_topology_if_dirty();
 
-        let mut actions = Vec::new();
-
-        // Drain events buffered by wait_event, then any new ones in the channel.
-        while let Some(event) = self.buffered_events.pop_front() {
-            let cancel_actions = self.process_event(event);
-            actions.extend(cancel_actions);
-        }
-        while let Ok(event) = self.event_rx.try_recv() {
-            let cancel_actions = self.process_event(event);
-            actions.extend(cancel_actions);
-        }
+        let mut actions = self.drain_events_into_actions();
 
         if self.graph.status != GraphStatus::Running {
             return actions;
         }
 
-        // Check for timed-out tasks.
         let timeout_actions = self.check_timeouts();
         actions.extend(timeout_actions);
 
@@ -50,16 +38,38 @@ impl DagScheduler {
             return actions;
         }
 
-        // Dispatch ready tasks up to max_parallel slots. Concurrency is pre-enforced here
-        // (topology-aware cap) and also enforced by SubAgentManager::spawn() returning
-        // ConcurrencyLimit when active + reserved >= max_concurrent.
-        // Non-transient spawn failures are handled by record_spawn_failure(); optimistic
-        // Running marks are reverted to Ready for ConcurrencyLimit errors.
+        let ready = self.ordered_ready_tasks();
+        let dispatch_actions = self.dispatch_ready_tasks(ready);
+        actions.extend(dispatch_actions);
+
+        actions.extend(self.emit_pending_predicate_actions());
+        actions.extend(self.check_graph_completion());
+
+        actions
+    }
+
+    /// Drain buffered and channel events, returning all resulting actions.
+    fn drain_events_into_actions(&mut self) -> Vec<SchedulerAction> {
+        let mut actions = Vec::new();
+        while let Some(event) = self.buffered_events.pop_front() {
+            actions.extend(self.process_event(event));
+        }
+        while let Ok(event) = self.event_rx.try_recv() {
+            actions.extend(self.process_event(event));
+        }
+        actions
+    }
+
+    /// Return ready task IDs ordered according to the active dispatch strategy.
+    ///
+    /// `CascadeAware` partitions tasks into preferred (healthy region) and deferred
+    /// (cascading region). `TreeOptimized` sorts by critical-path distance descending.
+    /// Sequential tasks are never reordered.
+    fn ordered_ready_tasks(&mut self) -> Vec<TaskId> {
         let raw_ready = dag::ready_tasks(&self.graph);
 
-        // CascadeAware: partition ready tasks into preferred (healthy region) and deferred
-        // (cascading region). Deferred tasks still run when no preferred tasks remain.
-        // Skip for Sequential tasks — they must not be reordered relative to each other.
+        // CascadeAware: preferred (healthy) tasks first, deferred (cascading) tasks last.
+        // Sequential tasks are exempt from reordering.
         let ready: Vec<TaskId> = if self.topology.strategy == DispatchStrategy::CascadeAware {
             if let Some(ref mut detector) = self.cascade_detector {
                 let graph = &self.graph;
@@ -71,7 +81,6 @@ impl DagScheduler {
                         raw_ready.into_iter().partition(|id| {
                             let is_sequential = self.graph.tasks[id.index()].execution_mode
                                 == ExecutionMode::Sequential;
-                            // Sequential tasks are never reordered.
                             is_sequential || !deprioritized.contains(id)
                         });
                     preferred.into_iter().chain(deferred).collect()
@@ -83,29 +92,32 @@ impl DagScheduler {
             raw_ready
         };
 
-        // TreeOptimized: sort ready tasks by critical-path distance descending
-        // (tasks deepest in the DAG go first — shortest distance to sinks).
-        // Skip for Sequential tasks to preserve their ordering invariant.
-        let ready: Vec<TaskId> = if self.topology.strategy == DispatchStrategy::TreeOptimized {
+        // TreeOptimized: sort by critical-path distance descending (deepest tasks first).
+        if self.topology.strategy == DispatchStrategy::TreeOptimized {
             let max_depth = self.topology.depth;
             let mut sortable = ready;
             sortable.sort_by_key(|id| {
                 let task_depth = self.topology.depths.get(id).copied().unwrap_or(0);
-                // Deeper tasks have smaller key → dispatched first.
                 max_depth.saturating_sub(task_depth)
             });
             sortable
         } else {
             ready
-        };
+        }
+    }
 
+    /// Dispatch ready tasks up to the available concurrency slots.
+    ///
+    /// Concurrency is pre-enforced here (topology-aware cap) and also enforced by
+    /// `SubAgentManager::spawn()` returning `ConcurrencyLimit` when slots are exhausted.
+    /// Non-transient spawn failures are handled by `record_spawn_failure()`; optimistic
+    /// Running marks are reverted to Ready for `ConcurrencyLimit` errors.
+    fn dispatch_ready_tasks(&mut self, ready: Vec<TaskId>) -> Vec<SchedulerAction> {
         self.advance_level_barrier_if_needed();
 
-        // Available dispatch slots for this tick.
+        let mut actions = Vec::new();
         let mut slots = self.max_parallel.saturating_sub(self.running.len());
 
-        // For sequential dispatch: track whether we already scheduled one sequential task
-        // this tick AND whether any sequential task is currently running.
         let mut sequential_spawned_this_tick = false;
         let has_running_sequential = self
             .running
@@ -168,12 +180,23 @@ impl DagScheduler {
             slots -= 1;
         }
 
-        // Idempotent predicate gate emission (S9): for every Completed task whose
-        // verify_predicate is set but predicate_outcome is None, emit VerifyPredicate.
-        // Re-emitted every tick until record_predicate_outcome() populates predicate_outcome.
-        // The caller must deduplicate in-flight evaluations (per-process HashSet in scheduler_loop.rs).
-        if self.verify_predicate_enabled {
-            for task in &self.graph.tasks {
+        actions
+    }
+
+    /// Emit `VerifyPredicate` actions for completed tasks whose predicate is unresolved.
+    ///
+    /// Idempotent — re-emitted every tick until `record_predicate_outcome()` populates
+    /// `predicate_outcome`. The caller deduplicates in-flight evaluations (per-process
+    /// `HashSet` in `scheduler_loop.rs`). S9 invariant: observation must not be gated on
+    /// the replan budget — `max_replans=0` still emits `Verify`.
+    fn emit_pending_predicate_actions(&self) -> Vec<SchedulerAction> {
+        if !self.verify_predicate_enabled {
+            return Vec::new();
+        }
+        self.graph
+            .tasks
+            .iter()
+            .filter_map(|task| {
                 if task.status == TaskStatus::Completed
                     && let (Some(predicate), None) =
                         (&task.verify_predicate, &task.predicate_outcome)
@@ -182,18 +205,16 @@ impl DagScheduler {
                         .result
                         .as_ref()
                         .map_or_else(String::new, |r| r.output.clone());
-                    actions.push(SchedulerAction::VerifyPredicate {
+                    Some(SchedulerAction::VerifyPredicate {
                         task_id: task.id,
                         predicate: predicate.clone(),
                         output,
-                    });
+                    })
+                } else {
+                    None
                 }
-            }
-        }
-
-        actions.extend(self.check_graph_completion());
-
-        actions
+            })
+            .collect()
     }
 
     /// Wait for the next event from a running sub-agent.
@@ -384,7 +405,7 @@ impl DagScheduler {
     /// Compute the current deferral backoff with exponential growth capped at 5 seconds.
     ///
     /// Each consecutive spawn failure due to concurrency limits doubles the base backoff.
-    pub(super) fn current_deferral_backoff(&self) -> Duration {
+    fn current_deferral_backoff(&self) -> Duration {
         const MAX_BACKOFF: Duration = Duration::from_secs(5);
         let multiplier = 1u32
             .checked_shl(self.consecutive_spawn_failures.min(10))
@@ -395,16 +416,42 @@ impl DagScheduler {
     }
 
     /// Process a single `TaskEvent` and return any cancel actions needed.
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3441): decompose into smaller helpers
-    pub(super) fn process_event(&mut self, event: TaskEvent) -> Vec<SchedulerAction> {
+    fn process_event(&mut self, event: TaskEvent) -> Vec<SchedulerAction> {
         let TaskEvent {
             task_id,
             agent_handle_id,
             outcome,
         } = event;
 
-        // Guard against stale events from previous incarnations (e.g. after timeout+retry).
-        // A timed-out agent's event_tx outlives the timeout and may send a completion later.
+        let Some((duration_ms, agent_def_name)) =
+            self.consume_running_for_event(task_id, &agent_handle_id)
+        else {
+            return Vec::new();
+        };
+
+        match outcome {
+            TaskOutcome::Completed { output, artifacts } => self.handle_completed_outcome(
+                task_id,
+                agent_handle_id,
+                agent_def_name,
+                duration_ms,
+                output,
+                artifacts,
+            ),
+            TaskOutcome::Failed { error } => self.handle_failed_outcome(task_id, &error),
+        }
+    }
+
+    /// Validate and remove a task from the running map; return duration and agent def name.
+    ///
+    /// Returns `None` and logs a warning when the event is stale (wrong handle) or the
+    /// task is not in the running map at all. The C1 fix: duration is computed before
+    /// the running entry is removed.
+    fn consume_running_for_event(
+        &mut self,
+        task_id: TaskId,
+        agent_handle_id: &str,
+    ) -> Option<(u64, Option<String>)> {
         match self.running.get(&task_id) {
             Some(running) if running.agent_handle_id != agent_handle_id => {
                 tracing::warn!(
@@ -413,7 +460,7 @@ impl DagScheduler {
                     got = %agent_handle_id,
                     "discarding stale event from previous agent incarnation"
                 );
-                return Vec::new();
+                return None;
             }
             None => {
                 tracing::debug!(
@@ -421,12 +468,11 @@ impl DagScheduler {
                     agent_handle_id = %agent_handle_id,
                     "ignoring event for task not in running map"
                 );
-                return Vec::new();
+                return None;
             }
             Some(_) => {}
         }
 
-        // Compute duration BEFORE removing from running map (C1 fix).
         let duration_ms = self.running.get(&task_id).map_or(0, |r| {
             u64::try_from(r.started_at.elapsed().as_millis()).unwrap_or(u64::MAX)
         });
@@ -434,142 +480,148 @@ impl DagScheduler {
 
         self.running.remove(&task_id);
 
-        match outcome {
-            TaskOutcome::Completed { output, artifacts } => {
-                self.graph.tasks[task_id.index()].status = TaskStatus::Completed;
-                self.graph.tasks[task_id.index()].result = Some(TaskResult {
-                    output: output.clone(),
-                    artifacts,
-                    duration_ms,
-                    agent_id: Some(agent_handle_id),
-                    agent_def: agent_def_name,
-                });
+        Some((duration_ms, agent_def_name))
+    }
 
-                // Completed tasks need no lineage chain going forward.
-                self.lineage_chains.remove(&task_id);
+    /// Apply the Completed outcome branch: update graph, unblock downstream tasks, emit actions.
+    fn handle_completed_outcome(
+        &mut self,
+        task_id: TaskId,
+        agent_handle_id: String,
+        agent_def_name: Option<String>,
+        duration_ms: u64,
+        output: String,
+        artifacts: Vec<std::path::PathBuf>,
+    ) -> Vec<SchedulerAction> {
+        self.graph.tasks[task_id.index()].status = TaskStatus::Completed;
+        self.graph.tasks[task_id.index()].result = Some(TaskResult {
+            output: output.clone(),
+            artifacts,
+            duration_ms,
+            agent_id: Some(agent_handle_id),
+            agent_def: agent_def_name,
+        });
 
-                // Record success in cascade detector.
-                if let Some(ref mut detector) = self.cascade_detector {
-                    detector.record_outcome(task_id, true, &self.graph);
-                }
+        self.lineage_chains.remove(&task_id);
 
-                // Mark newly unblocked tasks as Ready.
-                // Downstream tasks are unblocked immediately — verification does not gate dispatch.
-                let newly_ready = dag::ready_tasks(&self.graph);
-                for ready_id in newly_ready {
-                    if self.graph.tasks[ready_id.index()].status == TaskStatus::Pending {
-                        self.graph.tasks[ready_id.index()].status = TaskStatus::Ready;
-                    }
-                }
+        if let Some(ref mut detector) = self.cascade_detector {
+            detector.record_outcome(task_id, true, &self.graph);
+        }
 
-                // Emit Verify action when verify_completeness is enabled.
-                // The replan budget is enforced inside inject_tasks() — the observation
-                // (emitting Verify) must not be gated on the mutation budget, or tasks
-                // after budget exhaustion never receive verification at all.
-                // max_replans=0 still emits Verify; gaps are logged only (no inject_tasks call).
-                if self.verify_completeness {
-                    vec![SchedulerAction::Verify { task_id, output }]
-                } else {
-                    Vec::new()
-                }
-            }
-
-            TaskOutcome::Failed { error } => {
-                // SEC-ORCH-04: truncate error to avoid logging sensitive internal details.
-                let error_excerpt: String = error.chars().take(512).collect();
-                tracing::warn!(
-                    task_id = %task_id,
-                    error = %error_excerpt,
-                    "task failed"
-                );
-                self.graph.tasks[task_id.index()].status = TaskStatus::Failed;
-
-                // Record failure in cascade detector.
-                if let Some(ref mut detector) = self.cascade_detector {
-                    detector.record_outcome(task_id, false, &self.graph);
-                }
-
-                // Build error lineage chain from parent chains (S4 side-table).
-                // BEFORE propagate_failure so we can read the graph topology.
-                let deps: Vec<TaskId> = self.graph.tasks[task_id.index()].depends_on.clone();
-                let mut chain = ErrorLineage::default();
-                for parent_id in &deps {
-                    if let Some(parent_chain) = self.lineage_chains.get(parent_id) {
-                        chain.merge(parent_chain, self.lineage_ttl_secs);
-                    }
-                }
-                chain.push(LineageEntry {
-                    task_id,
-                    kind: LineageKind::Failed {
-                        error_class: classify_error(&error),
-                    },
-                    ts_ms: now_ms(),
-                });
-                self.lineage_chains.insert(task_id, chain.clone());
-
-                // Prune stale lineage entries to bound memory usage.
-                let ttl = self.lineage_ttl_secs;
-                self.lineage_chains.retain(|_, c| c.is_recent(ttl));
-
-                // Check fan-out abort signal from CascadeDetector.
-                let graph = &self.graph;
-                let threshold = self.cascade_failure_rate_abort_threshold;
-                if let Some(ref mut detector) = self.cascade_detector {
-                    match detector.evaluate_abort(graph, task_id, threshold) {
-                        crate::cascade::AbortDecision::FanOutCascade {
-                            region_root,
-                            failure_rate,
-                            region_size,
-                        } => {
-                            tracing::error!(
-                                root = %region_root,
-                                failure_rate = failure_rate,
-                                region_size = region_size,
-                                cause = "fan_out_rate",
-                                "cascade abort: fan-out failure rate threshold exceeded"
-                            );
-                            return self.abort_dag_with_lineage(region_root, chain.entries());
-                        }
-                        crate::cascade::AbortDecision::None => {}
-                    }
-                }
-
-                // Check linear-chain abort signal (consecutive failures in depends_on path).
-                if self.cascade_chain_threshold > 0
-                    && chain.consecutive_failed_len() >= self.cascade_chain_threshold
-                {
-                    let root_id = chain.first_entry().map_or(task_id, |e| e.task_id);
-                    tracing::error!(
-                        root = %root_id,
-                        chain_depth = chain.consecutive_failed_len(),
-                        threshold = self.cascade_chain_threshold,
-                        cause = "chain_threshold",
-                        "cascade abort: consecutive failure chain threshold exceeded"
-                    );
-                    return self.abort_dag_with_lineage(root_id, chain.entries());
-                }
-
-                let cancel_ids = dag::propagate_failure(&mut self.graph, task_id);
-                let mut actions = Vec::new();
-
-                for cancel_task_id in cancel_ids {
-                    if let Some(running) = self.running.remove(&cancel_task_id) {
-                        actions.push(SchedulerAction::Cancel {
-                            agent_handle_id: running.agent_handle_id,
-                        });
-                    }
-                }
-
-                if self.graph.status != GraphStatus::Running {
-                    self.graph.finished_at = Some(crate::graph::chrono_now());
-                    actions.push(SchedulerAction::Done {
-                        status: self.graph.status,
-                    });
-                }
-
-                actions
+        // Mark newly unblocked tasks as Ready.
+        // Downstream tasks are unblocked immediately — verification does not gate dispatch.
+        let newly_ready = dag::ready_tasks(&self.graph);
+        for ready_id in newly_ready {
+            if self.graph.tasks[ready_id.index()].status == TaskStatus::Pending {
+                self.graph.tasks[ready_id.index()].status = TaskStatus::Ready;
             }
         }
+
+        // Emit Verify action when verify_completeness is enabled.
+        // The replan budget is enforced inside inject_tasks() — the observation
+        // (emitting Verify) must not be gated on the mutation budget, or tasks
+        // after budget exhaustion never receive verification at all.
+        // max_replans=0 still emits Verify; gaps are logged only (no inject_tasks call).
+        if self.verify_completeness {
+            vec![SchedulerAction::Verify { task_id, output }]
+        } else {
+            Vec::new()
+        }
+    }
+
+    /// Apply the Failed outcome branch: build lineage, evaluate cascade abort, propagate failure.
+    fn handle_failed_outcome(&mut self, task_id: TaskId, error: &str) -> Vec<SchedulerAction> {
+        // SEC-ORCH-04: truncate error to avoid logging sensitive internal details.
+        let error_excerpt: String = error.chars().take(512).collect();
+        tracing::warn!(
+            task_id = %task_id,
+            error = %error_excerpt,
+            "task failed"
+        );
+        self.graph.tasks[task_id.index()].status = TaskStatus::Failed;
+
+        if let Some(ref mut detector) = self.cascade_detector {
+            detector.record_outcome(task_id, false, &self.graph);
+        }
+
+        // Build error lineage chain from parent chains (S4 side-table).
+        // BEFORE propagate_failure so we can read the graph topology.
+        let deps: Vec<TaskId> = self.graph.tasks[task_id.index()].depends_on.clone();
+        let mut chain = ErrorLineage::default();
+        for parent_id in &deps {
+            if let Some(parent_chain) = self.lineage_chains.get(parent_id) {
+                chain.merge(parent_chain, self.lineage_ttl_secs);
+            }
+        }
+        chain.push(LineageEntry {
+            task_id,
+            kind: LineageKind::Failed {
+                error_class: classify_error(error),
+            },
+            ts_ms: now_ms(),
+        });
+        self.lineage_chains.insert(task_id, chain.clone());
+
+        let ttl = self.lineage_ttl_secs;
+        self.lineage_chains.retain(|_, c| c.is_recent(ttl));
+
+        // Check fan-out abort signal from CascadeDetector.
+        let graph = &self.graph;
+        let threshold = self.cascade_failure_rate_abort_threshold;
+        if let Some(ref mut detector) = self.cascade_detector {
+            match detector.evaluate_abort(graph, task_id, threshold) {
+                crate::cascade::AbortDecision::FanOutCascade {
+                    region_root,
+                    failure_rate,
+                    region_size,
+                } => {
+                    tracing::error!(
+                        root = %region_root,
+                        failure_rate = failure_rate,
+                        region_size = region_size,
+                        cause = "fan_out_rate",
+                        "cascade abort: fan-out failure rate threshold exceeded"
+                    );
+                    return self.abort_dag_with_lineage(region_root, chain.entries());
+                }
+                crate::cascade::AbortDecision::None => {}
+            }
+        }
+
+        // Check linear-chain abort signal (consecutive failures in depends_on path).
+        if self.cascade_chain_threshold > 0
+            && chain.consecutive_failed_len() >= self.cascade_chain_threshold
+        {
+            let root_id = chain.first_entry().map_or(task_id, |e| e.task_id);
+            tracing::error!(
+                root = %root_id,
+                chain_depth = chain.consecutive_failed_len(),
+                threshold = self.cascade_chain_threshold,
+                cause = "chain_threshold",
+                "cascade abort: consecutive failure chain threshold exceeded"
+            );
+            return self.abort_dag_with_lineage(root_id, chain.entries());
+        }
+
+        let cancel_ids = dag::propagate_failure(&mut self.graph, task_id);
+        let mut actions = Vec::new();
+
+        for cancel_task_id in cancel_ids {
+            if let Some(running) = self.running.remove(&cancel_task_id) {
+                actions.push(SchedulerAction::Cancel {
+                    agent_handle_id: running.agent_handle_id,
+                });
+            }
+        }
+
+        if self.graph.status != GraphStatus::Running {
+            self.graph.finished_at = Some(crate::graph::chrono_now());
+            actions.push(SchedulerAction::Done {
+                status: self.graph.status,
+            });
+        }
+
+        actions
     }
 
     /// Abort the DAG due to cascade failure; cancel all running tasks.
@@ -577,7 +629,7 @@ impl DagScheduler {
     /// Sets graph status to `Failed`, records `finished_at`, emits `Cancel` for all
     /// running tasks, and appends `Done`. The `chain` is logged here for the audit record.
     /// Callers must emit `tracing::error!` with root/cause before calling this.
-    pub(super) fn abort_dag_with_lineage(
+    fn abort_dag_with_lineage(
         &mut self,
         root: TaskId,
         chain: &[crate::lineage::LineageEntry],
@@ -614,7 +666,7 @@ impl DagScheduler {
     /// Cancel actions emitted here signal agents cooperatively. Tool operations in progress
     /// at the time of cancellation complete before the agent loop checks the cancellation
     /// token. Partially-written artifacts may remain on disk after cancellation.
-    pub(super) fn check_timeouts(&mut self) -> Vec<SchedulerAction> {
+    fn check_timeouts(&mut self) -> Vec<SchedulerAction> {
         let timed_out: Vec<(TaskId, String)> = self
             .running
             .iter()


### PR DESCRIPTION
## Summary

Removes all `#[allow(clippy::too_many_lines)]` suppressions from three crates by extracting private helper functions. Pure structural refactoring — no behavior change.

**zeph-orchestration** (`scheduler/tick.rs`) — closes #3441
- `DagScheduler::tick` → `drain_events_into_actions`, `ordered_ready_tasks`, `dispatch_ready_tasks`, `emit_pending_predicate_actions`
- `DagScheduler::process_event` → `consume_running_for_event`, `handle_completed_outcome`, `handle_failed_outcome`

**zeph-context** (`assembler.rs`, `summarization.rs`) — closes #3442
- `ContextAssembler::gather` → `empty_prepared_context`, `resolve_effective_strategy`, `correction_params`, `schedule_context_fetchers`, `drive_fetchers`
- `summarize_with_llm` → `run_chunk_summaries`, `join_partial_summaries`, `try_structured_consolidation`, `prose_consolidation`

**zeph-channels** (`telegram.rs`) — closes #3445
- `TelegramChannel::start` → `handle_telegram_message`, `is_user_authorized`, `extract_audio_attachment`, `extract_photo_attachment`

## Validation

- `cargo clippy --all-targets --all-features -p zeph-orchestration -p zeph-context -p zeph-channels -- -D warnings` — clean
- `cargo nextest run -p zeph-orchestration` — 337 passed
- `cargo nextest run -p zeph-context` — 109 passed
- `cargo nextest run -p zeph-channels` — 175 passed
- Security audit: 0 findings; auth gate, SEC-ORCH-04 truncation, no-unsafe invariants preserved
- Performance: neutral — no new allocations, no hot-path inlining risk

## Test plan

- [ ] CI passes on all three platforms
- [ ] `cargo clippy --workspace -- -D warnings` clean
- [ ] All tests pass (existing tests serve as regression net)