### PR TITLE
refactor(core): decompose long functions in zeph-core to remove clippy suppressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- refactor(zeph-core): decompose long functions in `agent/tool_execution/` (#3457).
+  All `#[allow(clippy::too_many_lines)]` suppressions removed from `native.rs`,
+  `sanitize.rs`, and `tests.rs` by extracting private helpers:
+  `check_exfiltration_urls`, `preprocess_focus_compress_calls`,
+  `stamp_and_send_tier_start`, `check_call_gates`, `handle_utility_gate`,
+  `run_before_tool_hooks`, `build_tier_call_futures`, `execute_tier_join`,
+  `apply_tier_results`, `run_causal_ipi_post_probe`, `classify_tool_result`,
+  `record_tool_execution_telemetry`, `handle_tool_failure_outcomes`,
+  `fire_vigil_audit_entry`, `record_tool_experience`, `process_one_tool_result`.
+  Pure structural refactoring — no behavioral changes.
+
 ### Added
 
 - A2A: `AgentCard` served at `/.well-known/agent.json` now accurately reflects the agent's
@@ -27,6 +40,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   reaps child processes via `pkill`, then sends SIGKILL. `ShellExecutor::shutdown` also
   applies this escalation against captured process IDs. Gated with `#[cfg(unix)]`;
   Windows falls back to `child.kill()` as before. (#3449)
+- `zeph-core`: decompose long functions in the learning and security-state subsystems to remove
+  `#[allow(clippy::too_many_lines)]` suppressions. Extracted private helpers in
+  `agent/learning/skill_commands.rs` (`validate_skill_create_input`,
+  `resolve_generation_output_dir`, `dedup_check_against_registry`,
+  `format_generated_skill_blocked`, `save_and_quarantine_generated_skill`),
+  `agent/learning/trust.rs` (`cross_session_rollout_ok_for_promote`,
+  `cross_session_rollout_ok_for_demote`, `try_auto_promote`, `try_auto_demote`), and
+  `agent/state/security.rs` (`run_ner_classifier`). No behavioral changes. (#3457)
 
 ### Refactored
 

--- a/crates/zeph-core/src/agent/context/summarization/compaction.rs
+++ b/crates/zeph-core/src/agent/context/summarization/compaction.rs
@@ -1,35 +1,31 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::ops::ControlFlow;
+
 use zeph_llm::provider::{Message, MessageMetadata, Role};
 
 use crate::agent::Agent;
 use crate::agent::context::CompactionOutcome;
 use crate::channel::Channel;
 
+/// Partitioned message slices produced by [`Agent::partition_messages_for_compaction`].
+struct CompactionPartition {
+    /// Focus-pinned knowledge block messages that survive compaction.
+    pinned_messages: Vec<Message>,
+    /// Active-subgoal messages protected from summarization (only populated when a subgoal
+    /// strategy is active).
+    active_subgoal_messages: Vec<Message>,
+    /// Messages to be summarized by the LLM.
+    to_compact: Vec<Message>,
+}
+
 impl<C: Channel> Agent<C> {
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3456): decompose into smaller helpers
-    pub(in crate::agent) async fn compact_context(
-        &mut self,
-    ) -> Result<CompactionOutcome, crate::agent::error::AgentError> {
-        // Force-apply any pending deferred summaries before draining to avoid losing them (CRIT-01).
-        let _ = self.apply_deferred_summaries();
-
-        let preserve_tail = self.context_manager.compaction_preserve_tail;
-
-        if self.msg.messages.len() <= preserve_tail + 1 {
-            return Ok(CompactionOutcome::NoChange);
-        }
-
-        let compact_end = {
-            let raw = self.msg.messages.len() - preserve_tail;
-            Self::adjust_compact_end_for_tool_pairs(&self.msg.messages, raw)
-        };
-
-        if compact_end <= 1 {
-            return Ok(CompactionOutcome::NoChange);
-        }
-
+    /// Partition the compaction range into pinned, active-subgoal, and to-compact slices.
+    ///
+    /// Extracts `messages[1..compact_end]` into three disjoint sets so that focus-pinned
+    /// and active-subgoal messages survive compaction without being fed to the LLM.
+    fn partition_messages_for_compaction(&self, compact_end: usize) -> CompactionPartition {
         // S1 fix: extract focus-pinned messages before draining so they survive compaction.
         // These are Knowledge block messages created by the Focus Agent (#1850).
         let pinned_messages: Vec<Message> = self.msg.messages[1..compact_end]
@@ -97,6 +93,215 @@ impl<C: Channel> Agent<C> {
                     .collect()
             }
         };
+
+        CompactionPartition {
+            pinned_messages,
+            active_subgoal_messages,
+            to_compact,
+        }
+    }
+
+    /// Validate summary quality via the compaction probe before committing the summary.
+    ///
+    /// All four probe metric counters (`compaction_probe_failures`, `compaction_probe_soft_failures`,
+    /// `compaction_probe_passes`, `compaction_probe_errors`) and `last_probe_*` state are updated
+    /// exclusively inside this helper. The caller MUST NOT duplicate any metric increment
+    /// (cross-cutting constraint #6).
+    ///
+    /// Returns:
+    /// - `Ok(ControlFlow::Break(CompactionOutcome::ProbeRejected))` — hard fail; caller should
+    ///   return the rejected outcome immediately.
+    /// - `Ok(ControlFlow::Continue(()))` — probe passed (or was disabled); caller may proceed.
+    async fn apply_compaction_probe(
+        &mut self,
+        to_compact: &[Message],
+        summary: &str,
+    ) -> Result<ControlFlow<CompactionOutcome, ()>, crate::agent::error::AgentError> {
+        if !self.context_manager.compression.probe.enabled {
+            return Ok(ControlFlow::Continue(()));
+        }
+
+        let probe_config = self.context_manager.compression.probe.clone();
+        let probe_provider = self.probe_or_summary_provider().clone();
+        let probe_result = match zeph_memory::validate_compaction(
+            probe_provider,
+            to_compact.to_vec(),
+            summary.to_owned(),
+            &probe_config,
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(e) => {
+                tracing::warn!("compaction probe error (non-blocking): {e:#}");
+                self.update_metrics(|m| {
+                    m.compaction_probe_errors += 1;
+                    m.last_probe_verdict = Some(zeph_memory::ProbeVerdict::Error);
+                    m.last_probe_score = None;
+                    m.last_probe_category_scores = None;
+                });
+                return Ok(ControlFlow::Continue(()));
+            }
+        };
+
+        if let Some(ref result) = probe_result {
+            if let Some(ref d) = self.debug_state.debug_dumper {
+                d.dump_compaction_probe(result);
+            }
+
+            let cat_scores = result.category_scores.clone();
+            let probe_threshold = result.threshold;
+            let probe_hard_fail_threshold = result.hard_fail_threshold;
+            match result.verdict {
+                zeph_memory::ProbeVerdict::HardFail => {
+                    tracing::warn!(
+                        score = result.score,
+                        threshold = result.hard_fail_threshold,
+                        "compaction probe HARD FAIL — keeping original messages"
+                    );
+                    self.update_metrics(|m| {
+                        m.compaction_probe_failures += 1;
+                        m.last_probe_verdict = Some(zeph_memory::ProbeVerdict::HardFail);
+                        m.last_probe_score = Some(result.score);
+                        m.last_probe_category_scores = Some(cat_scores.clone());
+                        m.compaction_probe_threshold = probe_threshold;
+                        m.compaction_probe_hard_fail_threshold = probe_hard_fail_threshold;
+                    });
+                    return Ok(ControlFlow::Break(CompactionOutcome::ProbeRejected));
+                }
+                zeph_memory::ProbeVerdict::SoftFail => {
+                    tracing::warn!(
+                        score = result.score,
+                        threshold = result.threshold,
+                        "compaction probe SOFT FAIL — proceeding with warning"
+                    );
+                    self.update_metrics(|m| {
+                        m.compaction_probe_soft_failures += 1;
+                        m.last_probe_verdict = Some(zeph_memory::ProbeVerdict::SoftFail);
+                        m.last_probe_score = Some(result.score);
+                        m.last_probe_category_scores = Some(cat_scores.clone());
+                        m.compaction_probe_threshold = probe_threshold;
+                        m.compaction_probe_hard_fail_threshold = probe_hard_fail_threshold;
+                    });
+                }
+                zeph_memory::ProbeVerdict::Pass => {
+                    tracing::info!(score = result.score, "compaction probe passed");
+                    self.update_metrics(|m| {
+                        m.compaction_probe_passes += 1;
+                        m.last_probe_verdict = Some(zeph_memory::ProbeVerdict::Pass);
+                        m.last_probe_score = Some(result.score);
+                        m.last_probe_category_scores = Some(cat_scores.clone());
+                        m.compaction_probe_threshold = probe_threshold;
+                        m.compaction_probe_hard_fail_threshold = probe_hard_fail_threshold;
+                    });
+                }
+                zeph_memory::ProbeVerdict::Error => {
+                    // Unreachable: validate_compaction returns Err on errors, not Ok(Error).
+                    // If this fires, the error-handling path in validate_compaction changed.
+                    debug_assert!(false, "ProbeVerdict::Error reached inside Ok path");
+                }
+            }
+        }
+
+        Ok(ControlFlow::Continue(()))
+    }
+
+    /// Drain the compaction range and re-insert the summary plus protected messages.
+    ///
+    /// Drains `messages[1..compact_end]`, inserts the summary at position 1, then
+    /// re-inserts pinned knowledge blocks and active-subgoal messages after the summary.
+    /// Rebuilds the subgoal index map when a subgoal strategy is active (S1 fix #2022).
+    ///
+    /// `summary` is the raw LLM output (without the header prefix) used for token-count
+    /// logging. `summary_content` is the fully formatted message text inserted into the
+    /// message list.
+    fn finalize_compacted_messages(
+        &mut self,
+        compact_end: usize,
+        pinned: Vec<Message>,
+        active_subgoal: Vec<Message>,
+        summary_content: String,
+        compacted_count: usize,
+        summary: &str,
+    ) {
+        // Drain the original range (includes pinned, active-subgoal, and non-pinned messages).
+        self.msg.messages.drain(1..compact_end);
+        // Insert the compaction summary at position 1.
+        self.msg.messages.insert(
+            1,
+            Message {
+                role: Role::System,
+                content: summary_content,
+                parts: vec![],
+                metadata: MessageMetadata::agent_only(),
+            },
+        );
+        // Re-insert pinned messages right after the summary (position 2+).
+        // They are placed before the preserved tail so the LLM always sees them.
+        let pinned_count = pinned.len();
+        for (i, pinned_msg) in pinned.into_iter().enumerate() {
+            self.msg.messages.insert(2 + i, pinned_msg);
+        }
+        // Re-insert active-subgoal messages after pinned messages (#2022 S2 fix).
+        // Active-subgoal messages are protected from summarization — they carry the current
+        // working context and must not be lost during compaction.
+        for (i, active_msg) in active_subgoal.into_iter().enumerate() {
+            self.msg.messages.insert(2 + pinned_count + i, active_msg);
+        }
+
+        // S1 fix (#2022): rebuild subgoal index map from scratch after drain + reinsert.
+        // Arithmetic offset is fragile because the final positions depend on pinned_count
+        // and active_subgoal_count. Rebuild is O(subgoals * avg_span) — negligible.
+        if self
+            .context_manager
+            .compression
+            .pruning_strategy
+            .is_subgoal()
+        {
+            self.compression
+                .subgoal_registry
+                .rebuild_after_compaction(&self.msg.messages, compact_end);
+        }
+
+        tracing::info!(
+            compacted_count,
+            summary_tokens = self.metrics.token_counter.count_tokens(summary),
+            "compacted context"
+        );
+
+        self.recompute_prompt_tokens();
+        self.update_metrics(|m| {
+            m.context_compactions += 1;
+        });
+    }
+
+    pub(in crate::agent) async fn compact_context(
+        &mut self,
+    ) -> Result<CompactionOutcome, crate::agent::error::AgentError> {
+        // Force-apply any pending deferred summaries before draining to avoid losing them (CRIT-01).
+        let _ = self.apply_deferred_summaries();
+
+        let preserve_tail = self.context_manager.compaction_preserve_tail;
+
+        if self.msg.messages.len() <= preserve_tail + 1 {
+            return Ok(CompactionOutcome::NoChange);
+        }
+
+        let compact_end = {
+            let raw = self.msg.messages.len() - preserve_tail;
+            Self::adjust_compact_end_for_tool_pairs(&self.msg.messages, raw)
+        };
+
+        if compact_end <= 1 {
+            return Ok(CompactionOutcome::NoChange);
+        }
+
+        let CompactionPartition {
+            pinned_messages,
+            active_subgoal_messages,
+            to_compact,
+        } = self.partition_messages_for_compaction(compact_end);
+
         if to_compact.is_empty() {
             return Ok(CompactionOutcome::NoChange);
         }
@@ -144,89 +349,11 @@ impl<C: Channel> Agent<C> {
         };
 
         // Compaction probe: validate summary quality before committing it.
-        // Extract all &self references before .await so no &self is held across the boundary.
-        if self.context_manager.compression.probe.enabled {
-            let probe_config = self.context_manager.compression.probe.clone();
-            let probe_provider = self.probe_or_summary_provider().clone();
-            let probe_result = match zeph_memory::validate_compaction(
-                probe_provider,
-                to_compact.clone(),
-                summary.clone(),
-                &probe_config,
-            )
-            .await
-            {
-                Ok(result) => result,
-                Err(e) => {
-                    tracing::warn!("compaction probe error (non-blocking): {e:#}");
-                    self.update_metrics(|m| {
-                        m.compaction_probe_errors += 1;
-                        m.last_probe_verdict = Some(zeph_memory::ProbeVerdict::Error);
-                        m.last_probe_score = None;
-                        m.last_probe_category_scores = None;
-                    });
-                    None
-                }
-            };
-
-            if let Some(ref result) = probe_result {
-                if let Some(ref d) = self.debug_state.debug_dumper {
-                    d.dump_compaction_probe(result);
-                }
-
-                let cat_scores = result.category_scores.clone();
-                let probe_threshold = result.threshold;
-                let probe_hard_fail_threshold = result.hard_fail_threshold;
-                match result.verdict {
-                    zeph_memory::ProbeVerdict::HardFail => {
-                        tracing::warn!(
-                            score = result.score,
-                            threshold = result.hard_fail_threshold,
-                            "compaction probe HARD FAIL — keeping original messages"
-                        );
-                        self.update_metrics(|m| {
-                            m.compaction_probe_failures += 1;
-                            m.last_probe_verdict = Some(zeph_memory::ProbeVerdict::HardFail);
-                            m.last_probe_score = Some(result.score);
-                            m.last_probe_category_scores = Some(cat_scores.clone());
-                            m.compaction_probe_threshold = probe_threshold;
-                            m.compaction_probe_hard_fail_threshold = probe_hard_fail_threshold;
-                        });
-                        return Ok(CompactionOutcome::ProbeRejected);
-                    }
-                    zeph_memory::ProbeVerdict::SoftFail => {
-                        tracing::warn!(
-                            score = result.score,
-                            threshold = result.threshold,
-                            "compaction probe SOFT FAIL — proceeding with warning"
-                        );
-                        self.update_metrics(|m| {
-                            m.compaction_probe_soft_failures += 1;
-                            m.last_probe_verdict = Some(zeph_memory::ProbeVerdict::SoftFail);
-                            m.last_probe_score = Some(result.score);
-                            m.last_probe_category_scores = Some(cat_scores.clone());
-                            m.compaction_probe_threshold = probe_threshold;
-                            m.compaction_probe_hard_fail_threshold = probe_hard_fail_threshold;
-                        });
-                    }
-                    zeph_memory::ProbeVerdict::Pass => {
-                        tracing::info!(score = result.score, "compaction probe passed");
-                        self.update_metrics(|m| {
-                            m.compaction_probe_passes += 1;
-                            m.last_probe_verdict = Some(zeph_memory::ProbeVerdict::Pass);
-                            m.last_probe_score = Some(result.score);
-                            m.last_probe_category_scores = Some(cat_scores.clone());
-                            m.compaction_probe_threshold = probe_threshold;
-                            m.compaction_probe_hard_fail_threshold = probe_hard_fail_threshold;
-                        });
-                    }
-                    zeph_memory::ProbeVerdict::Error => {
-                        // Unreachable: validate_compaction returns Err on errors, not Ok(Error).
-                        // If this fires, the error-handling path in validate_compaction changed.
-                        debug_assert!(false, "ProbeVerdict::Error reached inside Ok path");
-                    }
-                }
-            }
+        // All metric updates live exclusively inside apply_compaction_probe.
+        if let ControlFlow::Break(outcome) =
+            self.apply_compaction_probe(&to_compact, &summary).await?
+        {
+            return Ok(outcome);
         }
 
         let compacted_count = to_compact.len();
@@ -241,55 +368,15 @@ impl<C: Channel> Agent<C> {
         let summary_content = format!(
             "[conversation summary — {compacted_count} messages compacted]\n{summary}{archive_postfix}"
         );
-        // Drain the original range (includes pinned, active-subgoal, and non-pinned messages).
-        self.msg.messages.drain(1..compact_end);
-        // Insert the compaction summary at position 1.
-        self.msg.messages.insert(
-            1,
-            Message {
-                role: Role::System,
-                content: summary_content.clone(),
-                parts: vec![],
-                metadata: MessageMetadata::agent_only(),
-            },
-        );
-        // Re-insert pinned messages right after the summary (position 2+).
-        // They are placed before the preserved tail so the LLM always sees them.
-        let pinned_count = pinned_messages.len();
-        for (i, pinned) in pinned_messages.into_iter().enumerate() {
-            self.msg.messages.insert(2 + i, pinned);
-        }
-        // Re-insert active-subgoal messages after pinned messages (#2022 S2 fix).
-        // Active-subgoal messages are protected from summarization — they carry the current
-        // working context and must not be lost during compaction.
-        for (i, active_msg) in active_subgoal_messages.into_iter().enumerate() {
-            self.msg.messages.insert(2 + pinned_count + i, active_msg);
-        }
 
-        // S1 fix (#2022): rebuild subgoal index map from scratch after drain + reinsert.
-        // Arithmetic offset is fragile because the final positions depend on pinned_count
-        // and active_subgoal_count. Rebuild is O(subgoals * avg_span) — negligible.
-        if self
-            .context_manager
-            .compression
-            .pruning_strategy
-            .is_subgoal()
-        {
-            self.compression
-                .subgoal_registry
-                .rebuild_after_compaction(&self.msg.messages, compact_end);
-        }
-
-        tracing::info!(
+        self.finalize_compacted_messages(
+            compact_end,
+            pinned_messages,
+            active_subgoal_messages,
+            summary_content.clone(),
             compacted_count,
-            summary_tokens = self.metrics.token_counter.count_tokens(&summary),
-            "compacted context"
+            &summary,
         );
-
-        self.recompute_prompt_tokens();
-        self.update_metrics(|m| {
-            m.context_compactions += 1;
-        });
 
         // Extract memory params before .await so no &self is held across the persist boundary.
         let (persist_failed, qdrant_fut) = {

--- a/crates/zeph-core/src/agent/context/summarization/scheduling.rs
+++ b/crates/zeph-core/src/agent/context/summarization/scheduling.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::{LlmProvider, Message, Role};
 use zeph_memory::AnchoredSummary;
 
@@ -16,8 +17,7 @@ impl<C: Channel> Agent<C> {
     #[allow(
         clippy::cast_precision_loss,
         clippy::cast_possible_truncation,
-        clippy::cast_sign_loss,
-        clippy::too_many_lines
+        clippy::cast_sign_loss
     )]
     pub(in crate::agent) async fn maybe_compact(
         &mut self,
@@ -51,309 +51,383 @@ impl<C: Channel> Agent<C> {
 
         // S1: skip client-side compaction when server compaction is active — unless context
         // has grown past 95% of the budget without a server compaction event (safety fallback).
-        if self.providers.server_compaction_active {
-            let budget = self
-                .context_manager
-                .budget
-                .as_ref()
-                .map_or(0, ContextBudget::max_tokens);
-            if budget > 0 {
-                let total_tokens: usize = self
-                    .msg
-                    .messages
-                    .iter()
-                    .map(|m| self.metrics.token_counter.count_message_tokens(m))
-                    .sum();
-                let fallback_threshold = budget * 95 / 100;
-                if total_tokens < fallback_threshold {
-                    return Ok(());
-                }
-                tracing::warn!(
-                    total_tokens,
-                    fallback_threshold,
-                    "server compaction active but context at 95%+ — falling back to client-side"
-                );
-            } else {
-                return Ok(());
-            }
+        if self.apply_server_compaction_skip_guard() {
+            return Ok(());
         }
+
         // Skip if hard compaction already ran this turn (CRIT-03).
         if self.context_manager.compaction.is_compacted_this_turn() {
             return Ok(());
         }
+
         // Guard 1 — Cooldown: skip Hard-tier LLM compaction for N turns after the last successful
         // compaction. Soft compaction (pruning only) is still allowed during cooldown.
-        let in_cooldown = self.context_manager.compaction.cooldown_remaining() > 0;
-        if in_cooldown {
-            // Decrement the Cooling counter in place.
-            if let crate::agent::context_manager::CompactionState::Cooling {
-                ref mut turns_remaining,
-            } = self.context_manager.compaction
-            {
-                *turns_remaining -= 1;
-                if *turns_remaining == 0 {
-                    self.context_manager.compaction =
-                        crate::agent::context_manager::CompactionState::Ready;
-                }
-            }
-        }
+        let in_cooldown = self.decrement_cooldown_counter();
 
         match self.compaction_tier() {
             CompactionTier::None => Ok(()),
-            CompactionTier::Soft => {
-                let _ = self.channel.send_status("soft compacting context...").await;
+            CompactionTier::Soft => self.do_soft_compaction().await,
+            CompactionTier::Hard => self.do_hard_compaction(in_cooldown).await,
+        }
+    }
 
-                // Step 0 (context-compression): apply any completed background goal extraction
-                // and schedule a new one if the user message has changed (#1909, #2022).
-                {
-                    use crate::config::PruningStrategy;
-                    match &self.context_manager.compression.pruning_strategy {
-                        PruningStrategy::Subgoal | PruningStrategy::SubgoalMig => {
-                            self.maybe_refresh_subgoal();
-                        }
-                        _ => self.maybe_refresh_task_goal(),
-                    }
-                }
-
-                // Step 1: apply deferred tool summaries (free tokens without LLM).
-                let applied = self.apply_deferred_summaries();
-                let _ = self.apply_deferred_summaries();
-
-                // Step 1b (S5 fix): rebuild subgoal index map if deferred summaries were applied.
-                // Deferred summaries insert messages (shifting indices), invalidating msg_to_subgoal.
-                if applied > 0
-                    && self
-                        .context_manager
-                        .compression
-                        .pruning_strategy
-                        .is_subgoal()
-                {
-                    self.compression.subgoal_registry.rebuild_after_compaction(
-                        &self.msg.messages,
-                        0, // 0 = no drain, just repair shifted indices
-                    );
-                }
-
-                // Step 2: prune tool outputs down to soft threshold.
-                let budget = self
-                    .context_manager
-                    .budget
-                    .as_ref()
-                    .map_or(0, ContextBudget::max_tokens);
-                let soft_threshold =
-                    (budget as f32 * self.context_manager.soft_compaction_threshold) as usize;
-                let cached =
-                    usize::try_from(self.providers.cached_prompt_tokens).unwrap_or(usize::MAX);
-                let min_to_free = cached.saturating_sub(soft_threshold);
-                if min_to_free > 0 {
-                    self.prune_tool_outputs(min_to_free);
-                }
-
-                let _ = self.channel.send_status("").await;
-                tracing::info!(
-                    cached_tokens = self.providers.cached_prompt_tokens,
-                    soft_threshold,
-                    "soft compaction complete"
-                );
-                // Soft compaction does NOT set compacted_this_turn, allowing Hard to fire
-                // in the same turn if context is still above the hard threshold.
-                Ok(())
+    /// Returns `true` if caller should `return Ok(())` due to active server compaction.
+    ///
+    /// Skips client-side compaction when server compaction is active, unless context has grown
+    /// past 95% of the budget without a server compaction event (safety fallback).
+    fn apply_server_compaction_skip_guard(&self) -> bool {
+        if !self.providers.server_compaction_active {
+            return false;
+        }
+        let budget = self
+            .context_manager
+            .budget
+            .as_ref()
+            .map_or(0, ContextBudget::max_tokens);
+        if budget > 0 {
+            let total_tokens: usize = self
+                .msg
+                .messages
+                .iter()
+                .map(|m| self.metrics.token_counter.count_message_tokens(m))
+                .sum();
+            let fallback_threshold = budget * 95 / 100;
+            if total_tokens < fallback_threshold {
+                return true;
             }
-            CompactionTier::Hard => {
-                // Track hard compaction event: finalize the previous segment's turn count
-                // and start a new one. Counted regardless of cooldown — captures pressure,
-                // not just action. When compaction_hard_count == 0, compaction_turns_after_hard
-                // is expected to be empty.
-                if let Some(turns) = self.context_manager.turns_since_last_hard_compaction {
-                    self.update_metrics(|m| {
-                        m.compaction_turns_after_hard.push(turns);
-                    });
+            tracing::warn!(
+                total_tokens,
+                fallback_threshold,
+                "server compaction active but context at 95%+ — falling back to client-side"
+            );
+            false
+        } else {
+            true
+        }
+    }
+
+    /// Decrements the cooldown counter when in Cooling state.
+    ///
+    /// Returns `true` if compaction is currently in cooldown (caller should skip hard
+    /// LLM summarization). Transitions state to `Ready` when the counter reaches zero.
+    fn decrement_cooldown_counter(&mut self) -> bool {
+        let in_cooldown = self.context_manager.compaction.cooldown_remaining() > 0;
+        if in_cooldown
+            && let crate::agent::context_manager::CompactionState::Cooling {
+                ref mut turns_remaining,
+            } = self.context_manager.compaction
+        {
+            *turns_remaining -= 1;
+            if *turns_remaining == 0 {
+                self.context_manager.compaction =
+                    crate::agent::context_manager::CompactionState::Ready;
+            }
+        }
+        in_cooldown
+    }
+
+    /// Execute the Soft compaction tier: apply deferred summaries and prune tool outputs.
+    ///
+    /// Never triggers an LLM call. Does not set `compacted_this_turn`, so Hard tier may still
+    /// fire in the same turn if context remains above the hard threshold.
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss
+    )]
+    async fn do_soft_compaction(&mut self) -> Result<(), crate::agent::error::AgentError> {
+        let _ = self.channel.send_status("soft compacting context...").await;
+
+        // Step 0 (context-compression): apply any completed background goal extraction
+        // and schedule a new one if the user message has changed (#1909, #2022).
+        {
+            use crate::config::PruningStrategy;
+            match &self.context_manager.compression.pruning_strategy {
+                PruningStrategy::Subgoal | PruningStrategy::SubgoalMig => {
+                    self.maybe_refresh_subgoal();
                 }
-                self.context_manager.turns_since_last_hard_compaction = Some(0);
-                self.update_metrics(|m| {
-                    m.compaction_hard_count += 1;
-                });
+                _ => self.maybe_refresh_task_goal(),
+            }
+        }
 
-                // Cooldown guard: skip LLM summarization while cooling down.
-                if in_cooldown {
-                    tracing::debug!(
-                        turns_remaining = self.context_manager.compaction.cooldown_remaining(),
-                        "hard compaction skipped: cooldown active"
-                    );
-                    return Ok(());
-                }
+        // Step 1: apply deferred tool summaries (free tokens without LLM).
+        let applied = self.apply_deferred_summaries();
+        let _ = self.apply_deferred_summaries();
 
-                let budget = self
-                    .context_manager
-                    .budget
-                    .as_ref()
-                    .map_or(0, ContextBudget::max_tokens);
-                let hard_threshold =
-                    (budget as f32 * self.context_manager.hard_compaction_threshold) as usize;
-                let cached =
-                    usize::try_from(self.providers.cached_prompt_tokens).unwrap_or(usize::MAX);
-                let min_to_free = cached.saturating_sub(hard_threshold);
+        // Step 1b (S5 fix): rebuild subgoal index map if deferred summaries were applied.
+        // Deferred summaries insert messages (shifting indices), invalidating msg_to_subgoal.
+        if applied > 0
+            && self
+                .context_manager
+                .compression
+                .pruning_strategy
+                .is_subgoal()
+        {
+            self.compression.subgoal_registry.rebuild_after_compaction(
+                &self.msg.messages,
+                0, // 0 = no drain, just repair shifted indices
+            );
+        }
 
-                let _ = self.channel.send_status("compacting context...").await;
+        // Step 2: prune tool outputs down to soft threshold.
+        let budget = self
+            .context_manager
+            .budget
+            .as_ref()
+            .map_or(0, ContextBudget::max_tokens);
+        let soft_threshold =
+            (budget as f32 * self.context_manager.soft_compaction_threshold) as usize;
+        let cached = usize::try_from(self.providers.cached_prompt_tokens).unwrap_or(usize::MAX);
+        let min_to_free = cached.saturating_sub(soft_threshold);
+        if min_to_free > 0 {
+            self.prune_tool_outputs(min_to_free);
+        }
 
-                // Step 1: apply deferred summaries first (free tokens without LLM).
-                self.apply_deferred_summaries();
+        let _ = self.channel.send_status("").await;
+        tracing::info!(
+            cached_tokens = self.providers.cached_prompt_tokens,
+            soft_threshold,
+            "soft compaction complete"
+        );
+        // Soft compaction does NOT set compacted_this_turn, allowing Hard to fire
+        // in the same turn if context is still above the hard threshold.
+        Ok(())
+    }
 
-                // Step 2: prune tool outputs.
-                let freed = self.prune_tool_outputs(min_to_free);
-                if freed >= min_to_free {
-                    tracing::info!(freed, "hard compaction: pruning sufficient");
-                    self.context_manager.compaction =
-                        crate::agent::context_manager::CompactionState::CompactedThisTurn {
-                            cooldown: self.context_manager.compaction_cooldown_turns,
-                        };
-                    self.flush_deferred_summaries().await;
-                    let _ = self.channel.send_status("").await;
-                    return Ok(());
-                }
+    /// Execute the Hard compaction tier: prune tool outputs and fall back to LLM summarization.
+    ///
+    /// Respects the cooldown guard: when `in_cooldown` is `true`, skips LLM summarization
+    /// and returns immediately after tracking the compaction event.
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss
+    )]
+    async fn do_hard_compaction(
+        &mut self,
+        in_cooldown: bool,
+    ) -> Result<(), crate::agent::error::AgentError> {
+        // Track hard compaction event: finalize the previous segment's turn count
+        // and start a new one. Counted regardless of cooldown — captures pressure,
+        // not just action. When compaction_hard_count == 0, compaction_turns_after_hard
+        // is expected to be empty.
+        if let Some(turns) = self.context_manager.turns_since_last_hard_compaction {
+            self.update_metrics(|m| {
+                m.compaction_turns_after_hard.push(turns);
+            });
+        }
+        self.context_manager.turns_since_last_hard_compaction = Some(0);
+        self.update_metrics(|m| {
+            m.compaction_hard_count += 1;
+        });
 
-                // Step 3: Guard 2 — Counterproductive: check if there are enough messages
-                // to make LLM summarization worthwhile.
-                let preserve_tail = self.context_manager.compaction_preserve_tail;
-                let compactable = self.msg.messages.len().saturating_sub(preserve_tail + 1);
-                if compactable <= 1 {
-                    tracing::warn!(
-                        compactable,
-                        "hard compaction: too few messages to compact, marking exhausted"
-                    );
-                    // Only reachable from Ready state (Cooling is guarded by in_cooldown above).
+        // Cooldown guard: skip LLM summarization while cooling down.
+        if in_cooldown {
+            tracing::debug!(
+                turns_remaining = self.context_manager.compaction.cooldown_remaining(),
+                "hard compaction skipped: cooldown active"
+            );
+            return Ok(());
+        }
+
+        let budget = self
+            .context_manager
+            .budget
+            .as_ref()
+            .map_or(0, ContextBudget::max_tokens);
+        let hard_threshold =
+            (budget as f32 * self.context_manager.hard_compaction_threshold) as usize;
+        let cached = usize::try_from(self.providers.cached_prompt_tokens).unwrap_or(usize::MAX);
+        let min_to_free = cached.saturating_sub(hard_threshold);
+
+        let _ = self.channel.send_status("compacting context...").await;
+
+        // Step 1: apply deferred summaries first (free tokens without LLM).
+        self.apply_deferred_summaries();
+
+        // Step 2: prune tool outputs.
+        if self.try_pruning_only_hard_compaction(min_to_free).await? {
+            return Ok(());
+        }
+
+        // Step 3: Guard 2 — Counterproductive: check if there are enough messages
+        // to make LLM summarization worthwhile.
+        let preserve_tail = self.context_manager.compaction_preserve_tail;
+        let compactable = self.msg.messages.len().saturating_sub(preserve_tail + 1);
+        if compactable <= 1 {
+            tracing::warn!(
+                compactable,
+                "hard compaction: too few messages to compact, marking exhausted"
+            );
+            // Only reachable from Ready state (Cooling is guarded by in_cooldown above).
+            self.context_manager.compaction =
+                crate::agent::context_manager::CompactionState::Exhausted { warned: false };
+            let _ = self.channel.send_status("").await;
+            return Ok(());
+        }
+
+        // Step 4: fall back to full LLM summarization.
+        tracing::info!(
+            min_to_free,
+            "hard compaction: pruning insufficient, falling back to LLM summarization"
+        );
+        let tokens_before = self.providers.cached_prompt_tokens;
+        let outcome = self.compact_context().await?;
+
+        if self
+            .record_hard_compaction_outcome(outcome, tokens_before)
+            .await?
+        {
+            return Ok(());
+        }
+
+        self.emit_compaction_status_signal(tokens_before).await;
+        Ok(())
+    }
+
+    /// Attempt to satisfy the hard compaction budget with pruning alone (no LLM).
+    ///
+    /// Returns `Ok(true)` if pruning was sufficient and the caller should return early.
+    async fn try_pruning_only_hard_compaction(
+        &mut self,
+        min_to_free: usize,
+    ) -> Result<bool, crate::agent::error::AgentError> {
+        let freed = self.prune_tool_outputs(min_to_free);
+        if freed >= min_to_free {
+            tracing::info!(freed, "hard compaction: pruning sufficient");
+            self.context_manager.compaction =
+                crate::agent::context_manager::CompactionState::CompactedThisTurn {
+                    cooldown: self.context_manager.compaction_cooldown_turns,
+                };
+            self.flush_deferred_summaries().await;
+            let _ = self.channel.send_status("").await;
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    /// Record the outcome of the LLM-based hard compaction pass and update state.
+    ///
+    /// Returns `Ok(true)` if the caller should return early (exhausted state reached or
+    /// probe rejected). Returns `Ok(false)` to proceed to the status signal emission.
+    async fn record_hard_compaction_outcome(
+        &mut self,
+        outcome: CompactionOutcome,
+        tokens_before: u64,
+    ) -> Result<bool, crate::agent::error::AgentError> {
+        match outcome {
+            CompactionOutcome::ProbeRejected => {
+                // Probe rejected the summary. This is NOT exhaustion — the compactor
+                // can still summarize, but the summary was too lossy.
+                // Set cooldown to prevent immediate retry, but do NOT mark Exhausted.
+                tracing::info!("compaction probe rejected summary — setting cooldown");
+                self.context_manager.compaction =
+                    crate::agent::context_manager::CompactionState::CompactedThisTurn {
+                        cooldown: self.context_manager.compaction_cooldown_turns,
+                    };
+                let _ = self
+                    .channel
+                    .send("Context compaction skipped this turn — will retry.")
+                    .await;
+                return Ok(true);
+            }
+            CompactionOutcome::CompactedWithPersistError => {
+                tracing::warn!(
+                    "compaction succeeded but persist failed — in-memory state is \
+                     correct, storage may be inconsistent"
+                );
+                // Fall through to the same handling as Compacted.
+                let freed_tokens =
+                    tokens_before.saturating_sub(self.providers.cached_prompt_tokens);
+                if freed_tokens == 0 {
                     self.context_manager.compaction =
                         crate::agent::context_manager::CompactionState::Exhausted { warned: false };
                     let _ = self.channel.send_status("").await;
-                    return Ok(());
+                    return Ok(true);
                 }
-
-                // Step 4: fall back to full LLM summarization.
-                tracing::info!(
-                    freed,
-                    min_to_free,
-                    "hard compaction: pruning insufficient, falling back to LLM summarization"
-                );
-                let tokens_before = self.providers.cached_prompt_tokens;
-                let outcome = self.compact_context().await?;
-                match outcome {
-                    CompactionOutcome::ProbeRejected => {
-                        // Probe rejected the summary. This is NOT exhaustion — the compactor
-                        // can still summarize, but the summary was too lossy.
-                        // Set cooldown to prevent immediate retry, but do NOT mark Exhausted.
-                        tracing::info!("compaction probe rejected summary — setting cooldown");
-                        self.context_manager.compaction =
-                            crate::agent::context_manager::CompactionState::CompactedThisTurn {
-                                cooldown: self.context_manager.compaction_cooldown_turns,
-                            };
-                        let _ = self
-                            .channel
-                            .send("Context compaction skipped this turn — will retry.")
-                            .await;
-                    }
-                    CompactionOutcome::CompactedWithPersistError => {
-                        tracing::warn!(
-                            "compaction succeeded but persist failed — in-memory state is \
-                             correct, storage may be inconsistent"
-                        );
-                        // Fall through to the same handling as Compacted.
-                        let freed_tokens =
-                            tokens_before.saturating_sub(self.providers.cached_prompt_tokens);
-                        if freed_tokens == 0 {
-                            self.context_manager.compaction =
-                                crate::agent::context_manager::CompactionState::Exhausted {
-                                    warned: false,
-                                };
-                            let _ = self.channel.send_status("").await;
-                            return Ok(());
-                        }
-                        if matches!(self.compaction_tier(), CompactionTier::Hard) {
-                            self.context_manager.compaction =
-                                crate::agent::context_manager::CompactionState::Exhausted {
-                                    warned: false,
-                                };
-                            let _ = self.channel.send_status("").await;
-                            return Ok(());
-                        }
-                        self.context_manager.compaction =
-                            crate::agent::context_manager::CompactionState::CompactedThisTurn {
-                                cooldown: self.context_manager.compaction_cooldown_turns,
-                            };
-                    }
-                    CompactionOutcome::Compacted => {
-                        // Guard 2 — Counterproductive: net freed tokens is zero (summary ate all
-                        // freed space — no net reduction).
-                        let freed_tokens =
-                            tokens_before.saturating_sub(self.providers.cached_prompt_tokens);
-                        if freed_tokens == 0 {
-                            tracing::warn!(
-                                "hard compaction: summary consumed all freed tokens — no net \
-                                 reduction, marking exhausted"
-                            );
-                            // Only reachable from Ready state (Cooling is guarded by in_cooldown).
-                            self.context_manager.compaction =
-                                crate::agent::context_manager::CompactionState::Exhausted {
-                                    warned: false,
-                                };
-                            let _ = self.channel.send_status("").await;
-                            return Ok(());
-                        }
-                        // Guard 3 — Still above threshold: compaction freed some tokens but context
-                        // remains above the hard threshold; further LLM attempts are unlikely to help.
-                        if matches!(self.compaction_tier(), CompactionTier::Hard) {
-                            tracing::warn!(
-                                freed_tokens,
-                                "hard compaction: context still above hard threshold after \
-                                 compaction, marking exhausted"
-                            );
-                            // Only reachable from Ready state (Cooling is guarded by in_cooldown).
-                            self.context_manager.compaction =
-                                crate::agent::context_manager::CompactionState::Exhausted {
-                                    warned: false,
-                                };
-                            let _ = self.channel.send_status("").await;
-                            return Ok(());
-                        }
-                        self.context_manager.compaction =
-                            crate::agent::context_manager::CompactionState::CompactedThisTurn {
-                                cooldown: self.context_manager.compaction_cooldown_turns,
-                            };
-                    }
-                    CompactionOutcome::NoChange => {
-                        // compact_context() decided there was nothing to compact.
-                        // The compactable <= 1 guard above should have caught this, but handle
-                        // it gracefully if the messages changed during the async call.
-                    }
+                if matches!(self.compaction_tier(), CompactionTier::Hard) {
+                    self.context_manager.compaction =
+                        crate::agent::context_manager::CompactionState::Exhausted { warned: false };
+                    let _ = self.channel.send_status("").await;
+                    return Ok(true);
                 }
-                // Emit compaction UX signal when tokens were actually freed (#3314).
-                // The `send_status` call below clears the spinner immediately, so we emit the
-                // status notification here while the status line is still visible.
-                let tokens_after = self.providers.cached_prompt_tokens;
-                if tokens_after < tokens_before {
-                    let now_ms = std::time::SystemTime::UNIX_EPOCH
-                        .elapsed()
-                        .unwrap_or_default()
-                        .as_millis() as u64;
-                    tracing::info!(
-                        tokens_before,
-                        tokens_after,
-                        saved = tokens_before.saturating_sub(tokens_after),
-                        "context compaction complete"
-                    );
-                    let _ = self
-                        .channel
-                        .send_status(&format!(
-                            "Compacting: {tokens_before}→{tokens_after} tokens"
-                        ))
-                        .await;
-                    self.update_metrics(|m| {
-                        m.compaction_last_before = tokens_before;
-                        m.compaction_last_after = tokens_after;
-                        m.compaction_last_at_ms = now_ms;
-                    });
-                }
-                Ok(())
+                self.context_manager.compaction =
+                    crate::agent::context_manager::CompactionState::CompactedThisTurn {
+                        cooldown: self.context_manager.compaction_cooldown_turns,
+                    };
             }
+            CompactionOutcome::Compacted => {
+                // Guard 2 — Counterproductive: net freed tokens is zero (summary ate all
+                // freed space — no net reduction).
+                let freed_tokens =
+                    tokens_before.saturating_sub(self.providers.cached_prompt_tokens);
+                if freed_tokens == 0 {
+                    tracing::warn!(
+                        "hard compaction: summary consumed all freed tokens — no net \
+                         reduction, marking exhausted"
+                    );
+                    // Only reachable from Ready state (Cooling is guarded by in_cooldown).
+                    self.context_manager.compaction =
+                        crate::agent::context_manager::CompactionState::Exhausted { warned: false };
+                    let _ = self.channel.send_status("").await;
+                    return Ok(true);
+                }
+                // Guard 3 — Still above threshold: compaction freed some tokens but context
+                // remains above the hard threshold; further LLM attempts are unlikely to help.
+                if matches!(self.compaction_tier(), CompactionTier::Hard) {
+                    tracing::warn!(
+                        freed_tokens,
+                        "hard compaction: context still above hard threshold after \
+                         compaction, marking exhausted"
+                    );
+                    // Only reachable from Ready state (Cooling is guarded by in_cooldown).
+                    self.context_manager.compaction =
+                        crate::agent::context_manager::CompactionState::Exhausted { warned: false };
+                    let _ = self.channel.send_status("").await;
+                    return Ok(true);
+                }
+                self.context_manager.compaction =
+                    crate::agent::context_manager::CompactionState::CompactedThisTurn {
+                        cooldown: self.context_manager.compaction_cooldown_turns,
+                    };
+            }
+            CompactionOutcome::NoChange => {
+                // compact_context() decided there was nothing to compact.
+                // The compactable <= 1 guard above should have caught this, but handle
+                // it gracefully if the messages changed during the async call.
+            }
+        }
+        Ok(false)
+    }
+
+    /// Emit a UX status signal when tokens were actually freed by compaction (#3314).
+    async fn emit_compaction_status_signal(&mut self, tokens_before: u64) {
+        let tokens_after = self.providers.cached_prompt_tokens;
+        if tokens_after < tokens_before {
+            let now_ms = u64::try_from(
+                std::time::SystemTime::UNIX_EPOCH
+                    .elapsed()
+                    .unwrap_or_default()
+                    .as_millis(),
+            )
+            .unwrap_or(u64::MAX);
+            tracing::info!(
+                tokens_before,
+                tokens_after,
+                saved = tokens_before.saturating_sub(tokens_after),
+                "context compaction complete"
+            );
+            let _ = self
+                .channel
+                .send_status(&format!(
+                    "Compacting: {tokens_before}→{tokens_after} tokens"
+                ))
+                .await;
+            self.update_metrics(|m| {
+                m.compaction_last_before = tokens_before;
+                m.compaction_last_after = tokens_after;
+                m.compaction_last_at_ms = now_ms;
+            });
         }
     }
 
@@ -771,6 +845,21 @@ impl<C: Channel> Agent<C> {
         self.summarize_messages(messages, &guidelines).await
     }
 
+    /// Apply a completed background task-goal extraction result to `current_task_goal`.
+    fn apply_completed_task_goal(&mut self) {
+        use futures::FutureExt as _;
+        if let Some(handle) = self.compression.pending_task_goal.take() {
+            if let Some(Ok(Some(goal))) = handle.now_or_never() {
+                tracing::debug!("extract_task_goal: background result applied");
+                self.compression.current_task_goal = Some(goal);
+            }
+            // Clear spinner on ALL completion paths (success, None result, or task panic).
+            if let Some(ref tx) = self.session.status_tx {
+                let _ = tx.send(String::new());
+            }
+        }
+    }
+
     /// Refresh the cached task goal when the last user message has changed (#1850, #1909).
     ///
     /// Two-phase non-blocking design (mirrors `maybe_sidequest_eviction`):
@@ -783,10 +872,7 @@ impl<C: Channel> Agent<C> {
     ///
     /// This eliminates the 5-second latency spike on every Soft tier compaction that made
     /// `task_aware`/`mig` strategies non-functional for cloud LLM providers.
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3456): decompose into smaller helpers
     pub(in crate::agent) fn maybe_refresh_task_goal(&mut self) {
-        use std::hash::Hash as _;
-
         use crate::config::PruningStrategy;
 
         // Only needed when a task-aware or MIG strategy is active.
@@ -804,17 +890,7 @@ impl<C: Channel> Agent<C> {
             .as_ref()
             .is_some_and(tokio::task::JoinHandle::is_finished)
         {
-            use futures::FutureExt as _;
-            if let Some(handle) = self.compression.pending_task_goal.take() {
-                if let Some(Ok(Some(goal))) = handle.now_or_never() {
-                    tracing::debug!("extract_task_goal: background result applied");
-                    self.compression.current_task_goal = Some(goal);
-                }
-                // Clear spinner on ALL completion paths (success, None result, or task panic).
-                if let Some(ref tx) = self.session.status_tx {
-                    let _ = tx.send(String::new());
-                }
-            }
+            self.apply_completed_task_goal();
         }
 
         // Phase 2: do not spawn a second task while one is already in-flight.
@@ -822,25 +898,8 @@ impl<C: Channel> Agent<C> {
             return;
         }
 
-        // Find the last user message content.
-        let last_user_content = self
-            .msg
-            .messages
-            .iter()
-            .rev()
-            .find(|m| m.role == zeph_llm::provider::Role::User)
-            .map(|m| m.content.as_str())
-            .unwrap_or_default();
-
-        if last_user_content.is_empty() {
+        let Some(hash) = last_user_content_hash(&self.msg.messages) else {
             return;
-        }
-
-        // Compute a hash of the last user message to detect changes (S5).
-        let hash = {
-            let mut hasher = std::collections::hash_map::DefaultHasher::new();
-            last_user_content.hash(&mut hasher);
-            std::hash::Hasher::finish(&hasher)
         };
 
         // Cache hit: extraction already scheduled or completed for this user message.
@@ -851,100 +910,10 @@ impl<C: Channel> Agent<C> {
         // Cache miss: update hash and spawn background extraction.
         self.compression.task_goal_user_msg_hash = Some(hash);
 
-        // Clone only the data needed by the background task (avoids borrowing self).
-        let recent: Vec<(zeph_llm::provider::Role, String)> = self
-            .msg
-            .messages
-            .iter()
-            .filter(|m| {
-                matches!(
-                    m.role,
-                    zeph_llm::provider::Role::User | zeph_llm::provider::Role::Assistant
-                )
-            })
-            .rev()
-            .take(10)
-            .collect::<Vec<_>>()
-            .into_iter()
-            .rev()
-            .map(|m| (m.role, m.content.clone()))
-            .collect();
-
+        let recent = recent_user_assistant_excerpt(&self.msg.messages, 10, false);
         let provider = self.summary_or_primary_provider().clone();
 
-        // intentionally untracked: returns a typed JoinHandle<Option<String>> stored in
-        // compression.pending_task_goal and polled non-blocking next turn.
-        // BackgroundSupervisor does not support typed result retrieval.
-        let handle = tokio::spawn(async move {
-            use zeph_llm::provider::{Message, MessageMetadata, Role};
-
-            if recent.is_empty() {
-                return None;
-            }
-
-            let mut context_text = String::new();
-            for (role, content) in &recent {
-                let role_str = match role {
-                    Role::User => "user",
-                    Role::Assistant => "assistant",
-                    Role::System => "system",
-                };
-                let preview = if content.len() > 300 {
-                    let end = content.floor_char_boundary(300);
-                    &content[..end]
-                } else {
-                    content.as_str()
-                };
-                let _ =
-                    std::fmt::write(&mut context_text, format_args!("[{role_str}]: {preview}\n"));
-            }
-
-            let prompt = format!(
-                "Extract the current task goal from this conversation excerpt in one concise \
-                 sentence.\nFocus on what the user is trying to accomplish right now.\n\
-                 Respond with only the goal sentence, no preamble.\n\n\
-                 <conversation>\n{context_text}</conversation>"
-            );
-
-            let msgs = [Message {
-                role: Role::User,
-                content: prompt,
-                parts: vec![],
-                metadata: MessageMetadata::default(),
-            }];
-
-            match tokio::time::timeout(std::time::Duration::from_secs(30), provider.chat(&msgs))
-                .await
-            {
-                Ok(Ok(goal)) => {
-                    let trimmed = goal.trim();
-                    if trimmed.is_empty() {
-                        None
-                    } else {
-                        const MAX_GOAL_CHARS: usize = 500;
-                        let capped = if trimmed.len() > MAX_GOAL_CHARS {
-                            tracing::warn!(
-                                len = trimmed.len(),
-                                "extract_task_goal: LLM returned oversized goal; truncating to {MAX_GOAL_CHARS} chars"
-                            );
-                            let end = trimmed.floor_char_boundary(MAX_GOAL_CHARS);
-                            &trimmed[..end]
-                        } else {
-                            trimmed
-                        };
-                        Some(capped.to_string())
-                    }
-                }
-                Ok(Err(e)) => {
-                    tracing::debug!("extract_task_goal: LLM error: {e:#}");
-                    None
-                }
-                Err(_) => {
-                    tracing::debug!("extract_task_goal: timed out");
-                    None
-                }
-            }
-        });
+        let handle = spawn_task_goal_extraction(provider, recent);
 
         // TODO(I3): this JoinHandle is never `.abort()`ed on agent shutdown. The background task
         // will run to completion (or until the 30-second timeout) even after the agent is dropped.
@@ -954,6 +923,91 @@ impl<C: Channel> Agent<C> {
         tracing::debug!("extract_task_goal: background task spawned");
         if let Some(ref tx) = self.session.status_tx {
             let _ = tx.send("Extracting task goal...".into());
+        }
+    }
+
+    /// Apply a completed background subgoal extraction result to the subgoal registry.
+    fn apply_completed_subgoal(&mut self, msg_len: usize) {
+        use futures::FutureExt as _;
+        if let Some(handle) = self.compression.pending_subgoal.take() {
+            if let Some(Ok(Some(result))) = handle.now_or_never() {
+                let is_transition = result.completed.is_some();
+                if is_transition {
+                    self.register_subgoal_transition(&result, msg_len);
+                } else {
+                    self.register_subgoal_continuation(&result, msg_len);
+                }
+            }
+            // Clear spinner on ALL completion paths (success, None, or panic).
+            if let Some(ref tx) = self.session.status_tx {
+                let _ = tx.send(String::new());
+            }
+        }
+    }
+
+    /// Register a subgoal transition: complete the current active subgoal and start a new one.
+    fn register_subgoal_transition(
+        &mut self,
+        result: &crate::agent::state::SubgoalExtractionResult,
+        msg_len: usize,
+    ) {
+        if let Some(completed_desc) = &result.completed {
+            tracing::debug!(
+                completed = completed_desc.as_str(),
+                "subgoal transition detected"
+            );
+        }
+        self.compression
+            .subgoal_registry
+            .complete_active(msg_len.saturating_sub(1));
+        let new_id = self
+            .compression
+            .subgoal_registry
+            .push_active(result.current.clone(), msg_len.saturating_sub(1));
+        self.compression
+            .subgoal_registry
+            .extend_active(msg_len.saturating_sub(1));
+        tracing::debug!(
+            current = result.current.as_str(),
+            id = new_id.0,
+            "new active subgoal registered"
+        );
+    }
+
+    /// Register a subgoal continuation: extend or create the first subgoal.
+    fn register_subgoal_continuation(
+        &mut self,
+        result: &crate::agent::state::SubgoalExtractionResult,
+        msg_len: usize,
+    ) {
+        let is_first = self.compression.subgoal_registry.subgoals.is_empty();
+        if is_first {
+            // First extraction result: create initial subgoal.
+            let id = self
+                .compression
+                .subgoal_registry
+                .push_active(result.current.clone(), msg_len.saturating_sub(1));
+            // S4 fix: retroactively tag all pre-extraction messages [1..msg_len-1].
+            if msg_len > 2 {
+                self.compression
+                    .subgoal_registry
+                    .tag_range(1, msg_len - 2, id);
+            }
+            self.compression
+                .subgoal_registry
+                .extend_active(msg_len.saturating_sub(1));
+            tracing::debug!(
+                current = result.current.as_str(),
+                id = id.0,
+                retroactive_msgs = msg_len.saturating_sub(2),
+                "first subgoal registered with retroactive tagging"
+            );
+        } else {
+            // Extend existing active subgoal.
+            self.compression
+                .subgoal_registry
+                .extend_active(msg_len.saturating_sub(1));
+            tracing::debug!(current = result.current.as_str(), "active subgoal extended");
         }
     }
 
@@ -969,10 +1023,7 @@ impl<C: Channel> Agent<C> {
     /// Transition detection: the LLM's `COMPLETED:` signal drives transitions (S3 fix).
     /// When `COMPLETED: NONE`, the same subgoal continues (`extend_active`).
     /// When `COMPLETED:` is non-NONE, a new subgoal is created (`complete_active` + `push_active`).
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3456): decompose into smaller helpers
     pub(in crate::agent) fn maybe_refresh_subgoal(&mut self) {
-        use std::hash::Hash as _;
-
         use crate::config::PruningStrategy;
 
         // Only needed when a subgoal-aware strategy is active.
@@ -990,76 +1041,7 @@ impl<C: Channel> Agent<C> {
             .as_ref()
             .is_some_and(tokio::task::JoinHandle::is_finished)
         {
-            use futures::FutureExt as _;
-            if let Some(handle) = self.compression.pending_subgoal.take() {
-                if let Some(Ok(Some(result))) = handle.now_or_never() {
-                    // Detect subgoal transition via LLM signal (S3 fix).
-                    let is_transition = result.completed.is_some();
-
-                    if is_transition {
-                        // Complete the current active subgoal and start a new one.
-                        if let Some(completed_desc) = &result.completed {
-                            tracing::debug!(
-                                completed = completed_desc.as_str(),
-                                "subgoal transition detected"
-                            );
-                        }
-                        self.compression
-                            .subgoal_registry
-                            .complete_active(msg_len.saturating_sub(1));
-                        let new_id = self
-                            .compression
-                            .subgoal_registry
-                            .push_active(result.current.clone(), msg_len.saturating_sub(1));
-                        self.compression
-                            .subgoal_registry
-                            .extend_active(msg_len.saturating_sub(1));
-                        tracing::debug!(
-                            current = result.current.as_str(),
-                            id = new_id.0,
-                            "new active subgoal registered"
-                        );
-                    } else {
-                        // Same subgoal continues — extend or create first subgoal.
-                        let is_first = self.compression.subgoal_registry.subgoals.is_empty();
-                        if is_first {
-                            // First extraction result: create initial subgoal.
-                            let id = self
-                                .compression
-                                .subgoal_registry
-                                .push_active(result.current.clone(), msg_len.saturating_sub(1));
-                            // S4 fix: retroactively tag all pre-extraction messages [1..msg_len-1].
-                            if msg_len > 2 {
-                                self.compression
-                                    .subgoal_registry
-                                    .tag_range(1, msg_len - 2, id);
-                            }
-                            self.compression
-                                .subgoal_registry
-                                .extend_active(msg_len.saturating_sub(1));
-                            tracing::debug!(
-                                current = result.current.as_str(),
-                                id = id.0,
-                                retroactive_msgs = msg_len.saturating_sub(2),
-                                "first subgoal registered with retroactive tagging"
-                            );
-                        } else {
-                            // Extend existing active subgoal.
-                            self.compression
-                                .subgoal_registry
-                                .extend_active(msg_len.saturating_sub(1));
-                            tracing::debug!(
-                                current = result.current.as_str(),
-                                "active subgoal extended"
-                            );
-                        }
-                    }
-                }
-                // Clear spinner on ALL completion paths (success, None, or panic).
-                if let Some(ref tx) = self.session.status_tx {
-                    let _ = tx.send(String::new());
-                }
-            }
+            self.apply_completed_subgoal(msg_len);
         }
 
         // Phase 2: do not spawn a second task while one is in-flight.
@@ -1067,7 +1049,7 @@ impl<C: Channel> Agent<C> {
             return;
         }
 
-        // Find the last user message content and check for hash change.
+        // Find the last agent-visible user message content and check for hash change.
         let last_user_content = self
             .msg
             .messages
@@ -1084,6 +1066,7 @@ impl<C: Channel> Agent<C> {
         }
 
         let hash = {
+            use std::hash::Hash as _;
             let mut hasher = std::collections::hash_map::DefaultHasher::new();
             last_user_content.hash(&mut hasher);
             std::hash::Hasher::finish(&hasher)
@@ -1096,78 +1079,217 @@ impl<C: Channel> Agent<C> {
 
         // Clone the last 6 agent-visible messages (M2 fix: only agent_visible, not invisible
         // [tool summary] placeholders) for the extraction prompt.
-        let recent: Vec<(zeph_llm::provider::Role, String)> = self
-            .msg
-            .messages
-            .iter()
-            .filter(|m| {
-                m.metadata.visibility.is_agent_visible()
-                    && matches!(
-                        m.role,
-                        zeph_llm::provider::Role::User | zeph_llm::provider::Role::Assistant
-                    )
-            })
-            .rev()
-            .take(6)
-            .collect::<Vec<_>>()
-            .into_iter()
-            .rev()
-            .map(|m| (m.role, m.content.clone()))
-            .collect();
-
+        let recent = recent_user_assistant_excerpt(&self.msg.messages, 6, true);
         let provider = self.summary_or_primary_provider().clone();
+
+        let handle = spawn_subgoal_extraction(provider, recent);
 
         // intentionally untracked: returns a typed JoinHandle<Option<SubgoalExtractionResult>>
         // stored in compression.pending_subgoal and polled non-blocking next turn.
         // BackgroundSupervisor does not support typed result retrieval.
-        let handle = tokio::spawn(async move {
-            use zeph_llm::provider::{Message, MessageMetadata, Role};
+        self.compression.pending_subgoal = Some(handle);
+        tracing::debug!("subgoal_extraction: background task spawned");
+        if let Some(ref tx) = self.session.status_tx {
+            let _ = tx.send("Tracking subgoal...".into());
+        }
+    }
+}
 
-            if recent.is_empty() {
-                return None;
-            }
+/// Compute a hash of the last user message in `messages`.
+///
+/// Returns `None` if there is no user message or the content is empty.
+/// Reusable by both `maybe_refresh_task_goal` and `maybe_refresh_subgoal`.
+fn last_user_content_hash(messages: &[Message]) -> Option<u64> {
+    use std::hash::Hash as _;
 
-            let mut context_text = String::new();
-            for (role, content) in &recent {
-                let role_str = match role {
-                    Role::User => "user",
-                    Role::Assistant => "assistant",
-                    Role::System => "system",
-                };
-                let preview = if content.len() > 300 {
-                    let end = content.floor_char_boundary(300);
-                    &content[..end]
-                } else {
-                    content.as_str()
-                };
-                let _ =
-                    std::fmt::write(&mut context_text, format_args!("[{role_str}]: {preview}\n"));
-            }
+    let content = messages
+        .iter()
+        .rev()
+        .find(|m| m.role == zeph_llm::provider::Role::User)
+        .map(|m| m.content.as_str())
+        .unwrap_or_default();
 
-            let prompt = format!(
-                "Given this conversation excerpt, identify the agent's CURRENT subgoal in one \
-                 sentence. A subgoal is the immediate objective the agent is working toward right \
-                 now, not the overall task.\n\n\
-                 If the agent just completed a subgoal (answered a question, finished a subtask), \
-                 also state the COMPLETED subgoal.\n\n\
-                 Respond in this exact format:\n\
-                 CURRENT: <one sentence describing current subgoal>\n\
-                 COMPLETED: <one sentence describing just-completed subgoal, or NONE>\n\n\
-                 <conversation>\n{context_text}</conversation>"
+    if content.is_empty() {
+        return None;
+    }
+
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    content.hash(&mut hasher);
+    Some(std::hash::Hasher::finish(&hasher))
+}
+
+/// Collect recent user/assistant messages for LLM extraction prompts.
+///
+/// Takes up to `take` messages from the tail of `messages`, reversed so newest is last.
+/// When `agent_visible_only` is `true`, only messages with
+/// [`MessageVisibility::is_agent_visible`] are included (used by subgoal extraction to
+/// exclude invisible `[tool summary]` placeholders).
+fn recent_user_assistant_excerpt(
+    messages: &[Message],
+    take: usize,
+    agent_visible_only: bool,
+) -> Vec<(Role, String)> {
+    messages
+        .iter()
+        .filter(|m| {
+            let role_ok = matches!(
+                m.role,
+                zeph_llm::provider::Role::User | zeph_llm::provider::Role::Assistant
             );
+            let visible_ok = !agent_visible_only || m.metadata.visibility.is_agent_visible();
+            role_ok && visible_ok
+        })
+        .rev()
+        .take(take)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .map(|m| (m.role, m.content.clone()))
+        .collect()
+}
 
-            let msgs = [Message {
-                role: Role::User,
-                content: prompt,
-                parts: vec![],
-                metadata: MessageMetadata::default(),
-            }];
+/// Spawn a background task-goal extraction task.
+///
+/// Returns the `JoinHandle`; the caller stores it in `compression.pending_task_goal` and
+/// polls it non-blocking on the next turn.
+///
+/// # Note
+///
+/// This handle is intentionally untracked — `BackgroundSupervisor` does not support typed
+/// result retrieval. The handle is stored and polled via `JoinHandle::is_finished` +
+/// `FutureExt::now_or_never`.
+fn spawn_task_goal_extraction(
+    provider: AnyProvider,
+    recent: Vec<(Role, String)>,
+) -> tokio::task::JoinHandle<Option<String>> {
+    tokio::spawn(async move {
+        use zeph_llm::provider::{Message, MessageMetadata, Role};
 
-            let response = match tokio::time::timeout(
-                std::time::Duration::from_secs(30),
-                provider.chat(&msgs),
-            )
-            .await
+        if recent.is_empty() {
+            return None;
+        }
+
+        let mut context_text = String::new();
+        for (role, content) in &recent {
+            let role_str = match role {
+                Role::User => "user",
+                Role::Assistant => "assistant",
+                Role::System => "system",
+            };
+            let preview = if content.len() > 300 {
+                let end = content.floor_char_boundary(300);
+                &content[..end]
+            } else {
+                content.as_str()
+            };
+            let _ = std::fmt::write(&mut context_text, format_args!("[{role_str}]: {preview}\n"));
+        }
+
+        let prompt = format!(
+            "Extract the current task goal from this conversation excerpt in one concise \
+             sentence.\nFocus on what the user is trying to accomplish right now.\n\
+             Respond with only the goal sentence, no preamble.\n\n\
+             <conversation>\n{context_text}</conversation>"
+        );
+
+        let msgs = [Message {
+            role: Role::User,
+            content: prompt,
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        }];
+
+        match tokio::time::timeout(std::time::Duration::from_secs(30), provider.chat(&msgs)).await {
+            Ok(Ok(goal)) => {
+                let trimmed = goal.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    const MAX_GOAL_CHARS: usize = 500;
+                    let capped = if trimmed.len() > MAX_GOAL_CHARS {
+                        tracing::warn!(
+                            len = trimmed.len(),
+                            "extract_task_goal: LLM returned oversized goal; truncating to {MAX_GOAL_CHARS} chars"
+                        );
+                        let end = trimmed.floor_char_boundary(MAX_GOAL_CHARS);
+                        &trimmed[..end]
+                    } else {
+                        trimmed
+                    };
+                    Some(capped.to_string())
+                }
+            }
+            Ok(Err(e)) => {
+                tracing::debug!("extract_task_goal: LLM error: {e:#}");
+                None
+            }
+            Err(_) => {
+                tracing::debug!("extract_task_goal: timed out");
+                None
+            }
+        }
+    })
+}
+
+/// Spawn a background subgoal extraction task.
+///
+/// Returns the `JoinHandle`; the caller stores it in `compression.pending_subgoal` and
+/// polls it non-blocking on the next turn.
+///
+/// # Note
+///
+/// This handle is intentionally untracked — `BackgroundSupervisor` does not support typed
+/// result retrieval. The handle is stored and polled via `JoinHandle::is_finished` +
+/// `FutureExt::now_or_never`.
+fn spawn_subgoal_extraction(
+    provider: AnyProvider,
+    recent: Vec<(Role, String)>,
+) -> tokio::task::JoinHandle<Option<crate::agent::state::SubgoalExtractionResult>> {
+    tokio::spawn(async move {
+        use zeph_llm::provider::{Message, MessageMetadata, Role};
+
+        if recent.is_empty() {
+            return None;
+        }
+
+        let mut context_text = String::new();
+        for (role, content) in &recent {
+            let role_str = match role {
+                Role::User => "user",
+                Role::Assistant => "assistant",
+                Role::System => "system",
+            };
+            let preview = if content.len() > 300 {
+                let end = content.floor_char_boundary(300);
+                &content[..end]
+            } else {
+                content.as_str()
+            };
+            let _ = std::fmt::write(&mut context_text, format_args!("[{role_str}]: {preview}\n"));
+        }
+
+        let prompt = format!(
+            "Given this conversation excerpt, identify the agent's CURRENT subgoal in one \
+             sentence. A subgoal is the immediate objective the agent is working toward right \
+             now, not the overall task.\n\n\
+             If the agent just completed a subgoal (answered a question, finished a subtask), \
+             also state the COMPLETED subgoal.\n\n\
+             Respond in this exact format:\n\
+             CURRENT: <one sentence describing current subgoal>\n\
+             COMPLETED: <one sentence describing just-completed subgoal, or NONE>\n\n\
+             <conversation>\n{context_text}</conversation>"
+        );
+
+        let msgs = [Message {
+            role: Role::User,
+            content: prompt,
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        }];
+
+        let response =
+            match tokio::time::timeout(std::time::Duration::from_secs(30), provider.chat(&msgs))
+                .await
             {
                 Ok(Ok(r)) => r,
                 Ok(Err(e)) => {
@@ -1180,15 +1302,8 @@ impl<C: Channel> Agent<C> {
                 }
             };
 
-            Some(parse_subgoal_extraction_response(&response))
-        });
-
-        self.compression.pending_subgoal = Some(handle);
-        tracing::debug!("subgoal_extraction: background task spawned");
-        if let Some(ref tx) = self.session.status_tx {
-            let _ = tx.send("Tracking subgoal...".into());
-        }
-    }
+        Some(parse_subgoal_extraction_response(&response))
+    })
 }
 
 /// Parse the structured LLM response for subgoal extraction.

--- a/crates/zeph-core/src/agent/learning/skill_commands.rs
+++ b/crates/zeph-core/src/agent/learning/skill_commands.rs
@@ -72,58 +72,18 @@ impl<C: Channel> Agent<C> {
     /// Non-interactive: the skill is saved immediately with quarantined trust level.
     /// The generated preview is returned in the output so the user can review it.
     /// Use `/skill remove <name>` to discard an unwanted skill.
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3457): decompose into smaller helpers
     async fn handle_skill_create_as_string(
         &mut self,
         description: &str,
     ) -> Result<String, super::super::error::AgentError> {
-        if description.trim().is_empty() {
-            return Ok(
-                "Usage: /skill create <description>\n\nExample:\n  /skill create fetch weather data from wttr.in and display current conditions".to_owned()
-            );
+        if let Err(msg) = validate_skill_create_input(description) {
+            return Ok(msg);
         }
 
-        if description.chars().count() > 2048 {
-            return Ok("Description too long (max 2048 characters).".to_owned());
-        }
-
-        let input_scan = zeph_skills::scanner::scan_skill_body(description);
-        if input_scan.has_matches() {
-            return Ok("Input blocked: injection patterns detected in description.".to_owned());
-        }
-
-        // Determine output directory: generation_output_dir > managed_dir > first skill_path.
-        let output_dir = if let Some(ref dir) = self.skill_state.generation_output_dir {
-            dir.clone()
-        } else if let Some(ref dir) = self.skill_state.managed_dir {
-            dir.clone()
-        } else if let Some(first) = self.skill_state.skill_paths.first() {
-            first.clone()
-        } else {
-            return Ok(
-                "No skill output directory configured. Set skills.generation_output_dir or skills.paths.".to_owned()
-            );
+        let (output_dir, mut output) = match self.resolve_generation_output_dir() {
+            Ok(pair) => pair,
+            Err(msg) => return Ok(msg),
         };
-
-        let mut output = String::new();
-
-        // Warn if output_dir is not in watched skill_paths (hot-reload may miss the new skill).
-        let is_watched = self
-            .skill_state
-            .skill_paths
-            .iter()
-            .any(|p| output_dir.starts_with(p) || p == &output_dir);
-        if !is_watched {
-            tracing::warn!(
-                output_dir = %output_dir.display(),
-                "generation_output_dir is not in skills.paths — hot-reload may not pick up the new skill"
-            );
-            let _ = write!(
-                output,
-                "Warning: {} is not listed in skills.paths. The generated skill may not be hot-reloaded automatically.\n\n",
-                output_dir.display()
-            );
-        }
 
         let generation_provider =
             self.resolve_background_provider(&self.skill_state.generation_provider_name.clone());
@@ -149,61 +109,114 @@ impl<C: Channel> Agent<C> {
         };
 
         // Dedup check: compare against existing registry embeddings.
-        if let Some(ref matcher) = self.skill_state.matcher {
-            let skill_text = format!("{} {}", generated.meta.description, generated.content);
-            let all_meta_owned: Vec<zeph_skills::loader::SkillMeta> = {
-                let registry = self.skill_state.registry.read();
-                registry.all_meta().into_iter().cloned().collect()
-            };
-            let all_meta_refs: Vec<&zeph_skills::loader::SkillMeta> =
-                all_meta_owned.iter().collect();
-            let embed_provider = self.embedding_provider.clone();
-            let embed_fn = move |text: &str| -> zeph_skills::matcher::EmbedFuture {
-                let owned = text.to_owned();
-                let p = embed_provider.clone();
-                Box::pin(async move { p.embed(&owned).await })
-            };
-            let matches = match matcher
-                .match_skills(&all_meta_refs, &skill_text, 1, false, embed_fn)
-                .await
-            {
-                zeph_skills::MatchResult::Scored(v) => v,
-                zeph_skills::MatchResult::InfraError => Vec::new(),
-            };
-            if let Some(best) = matches.first()
-                && best.score > 0.85
-                && let Some(meta) = all_meta_refs.get(best.index)
-            {
-                generated.warnings.push(format!(
-                    "Similar skill exists: **{}** (similarity: {:.2}). Consider using the existing skill instead.",
-                    meta.name, best.score
-                ));
-            }
-        }
+        self.dedup_check_against_registry(&mut generated).await;
 
         if generated.has_injection_patterns {
-            output.push_str("Injection patterns detected in generated skill. Skipping save.\n\n");
-            let _ = write!(
-                output,
-                "Generated skill **{}** (NOT saved):\n\n```\n{}\n```",
-                generated.name, generated.content
-            );
-            if !generated.warnings.is_empty() {
-                output.push_str("\n\n**Warnings:**");
-                for w in &generated.warnings {
-                    output.push('\n');
-                    output.push_str("- ");
-                    output.push_str(w);
-                }
-            }
+            output.push_str(&format_generated_skill_blocked(&generated));
             return Ok(output);
         }
 
         // Auto-save with quarantined trust (non-interactive path).
-        match generator.approve_and_save(&generated).await {
+        self.save_and_quarantine_generated_skill(&generator, &generated, &mut output)
+            .await;
+
+        Ok(output)
+    }
+
+    /// Pick the skill output directory and build the initial warning prefix for the output string.
+    ///
+    /// Returns `(dir, output_prefix)` where `output_prefix` may be empty or contain a hot-reload
+    /// warning. Returns `Err(message)` when no directory is configured at all.
+    fn resolve_generation_output_dir(&self) -> Result<(std::path::PathBuf, String), String> {
+        let output_dir = if let Some(ref dir) = self.skill_state.generation_output_dir {
+            dir.clone()
+        } else if let Some(ref dir) = self.skill_state.managed_dir {
+            dir.clone()
+        } else if let Some(first) = self.skill_state.skill_paths.first() {
+            first.clone()
+        } else {
+            return Err(
+                "No skill output directory configured. Set skills.generation_output_dir or skills.paths.".to_owned()
+            );
+        };
+
+        let mut output = String::new();
+
+        // Warn if output_dir is not in watched skill_paths (hot-reload may miss the new skill).
+        let is_watched = self
+            .skill_state
+            .skill_paths
+            .iter()
+            .any(|p| output_dir.starts_with(p) || p == &output_dir);
+        if !is_watched {
+            tracing::warn!(
+                output_dir = %output_dir.display(),
+                "generation_output_dir is not in skills.paths — hot-reload may not pick up the new skill"
+            );
+            let _ = write!(
+                output,
+                "Warning: {} is not listed in skills.paths. The generated skill may not be hot-reloaded automatically.\n\n",
+                output_dir.display()
+            );
+        }
+
+        Ok((output_dir, output))
+    }
+
+    /// Run embedding-based similarity check and append a warning to `generated.warnings` if a
+    /// similar skill already exists.
+    ///
+    /// The registry read guard is released before `match_skills(...).await` to avoid holding a
+    /// lock across an await point.
+    async fn dedup_check_against_registry(&mut self, generated: &mut zeph_skills::GeneratedSkill) {
+        let Some(ref matcher) = self.skill_state.matcher else {
+            return;
+        };
+        let skill_text = format!("{} {}", generated.meta.description, generated.content);
+        // Clone registry meta before .await — read guard must be dropped before the embed call.
+        let all_meta_owned: Vec<zeph_skills::loader::SkillMeta> = {
+            let registry = self.skill_state.registry.read();
+            registry.all_meta().into_iter().cloned().collect()
+        };
+        let all_meta_refs: Vec<&zeph_skills::loader::SkillMeta> = all_meta_owned.iter().collect();
+        let embed_provider = self.embedding_provider.clone();
+        let embed_fn = move |text: &str| -> zeph_skills::matcher::EmbedFuture {
+            let owned = text.to_owned();
+            let p = embed_provider.clone();
+            Box::pin(async move { p.embed(&owned).await })
+        };
+        let scored = match matcher
+            .match_skills(&all_meta_refs, &skill_text, 1, false, embed_fn)
+            .await
+        {
+            zeph_skills::MatchResult::Scored(v) => v,
+            zeph_skills::MatchResult::InfraError => Vec::new(),
+        };
+        if let Some(best) = scored.first()
+            && best.score > 0.85
+            && let Some(meta) = all_meta_refs.get(best.index)
+        {
+            generated.warnings.push(format!(
+                "Similar skill exists: **{}** (similarity: {:.2}). Consider using the existing skill instead.",
+                meta.name, best.score
+            ));
+        }
+    }
+
+    /// Auto-save the generated skill and register quarantined trust, appending status text to
+    /// `output`.
+    async fn save_and_quarantine_generated_skill(
+        &mut self,
+        generator: &zeph_skills::SkillGenerator,
+        generated: &zeph_skills::GeneratedSkill,
+        output: &mut String,
+    ) {
+        // Clone Arc before .await to avoid holding &self across suspension points.
+        let memory = self.memory_state.persistence.memory.clone();
+        match generator.approve_and_save(generated).await {
             Ok(path) => {
                 // Register quarantined trust so hot-reload does not grant implicit trust.
-                if let Some(ref memory) = self.memory_state.persistence.memory {
+                if let Some(ref memory) = memory {
                     let _ = memory
                         .sqlite()
                         .set_skill_trust_level(&generated.name, "quarantined")
@@ -233,8 +246,6 @@ impl<C: Channel> Agent<C> {
                 let _ = write!(output, "Failed to save skill: {e}");
             }
         }
-
-        Ok(output)
     }
 
     async fn handle_skill_reject_as_string(
@@ -469,4 +480,44 @@ impl<C: Channel> Agent<C> {
 
         Ok(format!("Reset \"{name}\" to original v1."))
     }
+}
+
+/// Validate the `/skill create` description input.
+///
+/// Returns `Err(user-facing message)` if the description is empty, too long, or contains
+/// injection patterns. Returns `Ok(())` otherwise.
+fn validate_skill_create_input(description: &str) -> Result<(), String> {
+    if description.trim().is_empty() {
+        return Err(
+            "Usage: /skill create <description>\n\nExample:\n  /skill create fetch weather data from wttr.in and display current conditions".to_owned()
+        );
+    }
+    if description.chars().count() > 2048 {
+        return Err("Description too long (max 2048 characters).".to_owned());
+    }
+    let input_scan = zeph_skills::scanner::scan_skill_body(description);
+    if input_scan.has_matches() {
+        return Err("Input blocked: injection patterns detected in description.".to_owned());
+    }
+    Ok(())
+}
+
+/// Build the output string for a generated skill that was blocked due to injection patterns.
+fn format_generated_skill_blocked(generated: &zeph_skills::GeneratedSkill) -> String {
+    let mut output =
+        String::from("Injection patterns detected in generated skill. Skipping save.\n\n");
+    let _ = write!(
+        output,
+        "Generated skill **{}** (NOT saved):\n\n```\n{}\n```",
+        generated.name, generated.content
+    );
+    if !generated.warnings.is_empty() {
+        output.push_str("\n\n**Warnings:**");
+        for w in &generated.warnings {
+            output.push('\n');
+            output.push_str("- ");
+            output.push_str(w);
+        }
+    }
+    output
 }

--- a/crates/zeph-core/src/agent/learning/trust.rs
+++ b/crates/zeph-core/src/agent/learning/trust.rs
@@ -18,7 +18,6 @@ impl<C: Channel> Agent<C> {
         }
     }
 
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3457): decompose into smaller helpers
     async fn check_trust_transition_inner(&self, skill_name: &str) {
         let Some(memory) = &self.memory_state.persistence.memory else {
             return;
@@ -35,97 +34,139 @@ impl<C: Channel> Agent<C> {
         let posterior = zeph_skills::trust_score::posterior_mean(successes, failures);
 
         if total >= config.auto_promote_min_uses && posterior > config.auto_promote_threshold {
-            if config.cross_session_rollout {
-                match memory.sqlite().distinct_session_count(skill_name).await {
-                    Ok(sessions) if sessions < i64::from(config.min_sessions_before_promote) => {
-                        tracing::debug!(
-                            skill = skill_name,
-                            sessions,
-                            required = config.min_sessions_before_promote,
-                            "cross-session rollout: insufficient sessions for promotion"
-                        );
-                        return;
-                    }
-                    Ok(_) => {}
-                    Err(e) => {
-                        tracing::warn!("cross-session count query failed for {skill_name}: {e:#}");
-                    }
-                }
+            if !cross_session_rollout_ok_for_promote(memory, config, skill_name).await {
+                return;
             }
-
-            let trust_level = memory
-                .sqlite()
-                .load_skill_trust(skill_name)
-                .await
-                .ok()
-                .flatten()
-                .map(|r| r.trust_level);
-            // Skip promotion only if explicitly blocked; promote even if no record exists.
-            if trust_level.as_deref() != Some("trusted")
-                && trust_level.as_deref() != Some("blocked")
-            {
-                tracing::info!(
-                    skill = skill_name,
-                    posterior = format!("{posterior:.3}"),
-                    total,
-                    "auto-promoting skill to trusted"
-                );
-                if trust_level.is_none() {
-                    // No existing record — create one via upsert.
-                    let _ = memory
-                        .sqlite()
-                        .upsert_skill_trust(
-                            skill_name,
-                            "trusted",
-                            zeph_memory::store::SourceKind::Local,
-                            None,
-                            None,
-                            "",
-                        )
-                        .await;
-                } else {
-                    let _ = memory
-                        .sqlite()
-                        .set_skill_trust_level(skill_name, "trusted")
-                        .await;
-                }
-            }
+            try_auto_promote(memory, skill_name, posterior, total).await;
         }
 
         if total >= config.auto_demote_min_uses && posterior < config.auto_demote_threshold {
-            if config.cross_session_rollout {
-                match memory.sqlite().distinct_session_count(skill_name).await {
-                    Ok(sessions) if sessions < i64::from(config.min_sessions_before_demote) => {
-                        tracing::debug!(
-                            skill = skill_name,
-                            sessions,
-                            required = config.min_sessions_before_demote,
-                            "cross-session rollout: insufficient sessions for demotion"
-                        );
-                        return;
-                    }
-                    Ok(_) => {}
-                    Err(e) => {
-                        tracing::warn!("cross-session count query failed for {skill_name}: {e:#}");
-                    }
-                }
-            }
-
-            let Ok(Some(trust_row)) = memory.sqlite().load_skill_trust(skill_name).await else {
+            if !cross_session_rollout_ok_for_demote(memory, config, skill_name).await {
                 return;
-            };
-            if trust_row.trust_level == "trusted" || trust_row.trust_level == "verified" {
-                tracing::warn!(
-                    skill = skill_name,
-                    posterior = format!("{posterior:.3}"),
-                    total,
-                    "auto-demoting skill to quarantined"
-                );
-                let _ = memory
-                    .sqlite()
-                    .set_skill_trust_level(skill_name, "quarantined")
-                    .await;
             }
+            try_auto_demote(memory, skill_name, posterior, total).await;
         }
+    }
+}
+
+/// Returns `true` when cross-session rollout is disabled or enough sessions exist for promotion.
+async fn cross_session_rollout_ok_for_promote(
+    memory: &zeph_memory::semantic::SemanticMemory,
+    config: &crate::config::LearningConfig,
+    skill_name: &str,
+) -> bool {
+    if !config.cross_session_rollout {
+        return true;
+    }
+    match memory.sqlite().distinct_session_count(skill_name).await {
+        Ok(sessions) if sessions < i64::from(config.min_sessions_before_promote) => {
+            tracing::debug!(
+                skill = skill_name,
+                sessions,
+                required = config.min_sessions_before_promote,
+                "cross-session rollout: insufficient sessions for promotion"
+            );
+            false
+        }
+        Ok(_) => true,
+        Err(e) => {
+            tracing::warn!("cross-session count query failed for {skill_name}: {e:#}");
+            true
+        }
+    }
+}
+
+/// Returns `true` when cross-session rollout is disabled or enough sessions exist for demotion.
+async fn cross_session_rollout_ok_for_demote(
+    memory: &zeph_memory::semantic::SemanticMemory,
+    config: &crate::config::LearningConfig,
+    skill_name: &str,
+) -> bool {
+    if !config.cross_session_rollout {
+        return true;
+    }
+    match memory.sqlite().distinct_session_count(skill_name).await {
+        Ok(sessions) if sessions < i64::from(config.min_sessions_before_demote) => {
+            tracing::debug!(
+                skill = skill_name,
+                sessions,
+                required = config.min_sessions_before_demote,
+                "cross-session rollout: insufficient sessions for demotion"
+            );
+            false
+        }
+        Ok(_) => true,
+        Err(e) => {
+            tracing::warn!("cross-session count query failed for {skill_name}: {e:#}");
+            true
+        }
+    }
+}
+
+/// Promote a skill to trusted if it is not already trusted or blocked.
+async fn try_auto_promote(
+    memory: &zeph_memory::semantic::SemanticMemory,
+    skill_name: &str,
+    posterior: f64,
+    total: u32,
+) {
+    let trust_level = memory
+        .sqlite()
+        .load_skill_trust(skill_name)
+        .await
+        .ok()
+        .flatten()
+        .map(|r| r.trust_level);
+    // Skip promotion only if explicitly blocked; promote even if no record exists.
+    if trust_level.as_deref() != Some("trusted") && trust_level.as_deref() != Some("blocked") {
+        tracing::info!(
+            skill = skill_name,
+            posterior = format!("{posterior:.3}"),
+            total,
+            "auto-promoting skill to trusted"
+        );
+        if trust_level.is_none() {
+            // No existing record — create one via upsert.
+            let _ = memory
+                .sqlite()
+                .upsert_skill_trust(
+                    skill_name,
+                    "trusted",
+                    zeph_memory::store::SourceKind::Local,
+                    None,
+                    None,
+                    "",
+                )
+                .await;
+        } else {
+            let _ = memory
+                .sqlite()
+                .set_skill_trust_level(skill_name, "trusted")
+                .await;
+        }
+    }
+}
+
+/// Demote a skill to quarantined if it is currently trusted or verified.
+async fn try_auto_demote(
+    memory: &zeph_memory::semantic::SemanticMemory,
+    skill_name: &str,
+    posterior: f64,
+    total: u32,
+) {
+    let Ok(Some(trust_row)) = memory.sqlite().load_skill_trust(skill_name).await else {
+        return;
+    };
+    if trust_row.trust_level == "trusted" || trust_row.trust_level == "verified" {
+        tracing::warn!(
+            skill = skill_name,
+            posterior = format!("{posterior:.3}"),
+            total,
+            "auto-demoting skill to quarantined"
+        );
+        let _ = memory
+            .sqlite()
+            .set_skill_trust_level(skill_name, "quarantined")
+            .await;
     }
 }

--- a/crates/zeph-core/src/agent/state/security.rs
+++ b/crates/zeph-core/src/agent/state/security.rs
@@ -71,7 +71,6 @@ impl SecurityState {
     /// Returns a [`PiiScrubResult`] with the scrubbed text and metric side-effects.
     /// The caller is responsible for applying metrics updates from the result.
     #[cfg_attr(not(feature = "classifiers"), allow(clippy::unused_async))]
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3457): decompose into smaller helpers
     pub(crate) async fn scrub_pii(&mut self, text: &str, tool_name: &str) -> PiiScrubResult {
         use zeph_sanitizer::pii::{merge_spans, redact_spans};
 
@@ -92,77 +91,14 @@ impl SecurityState {
         let mut circuit_breaker_tripped = false;
 
         #[cfg(feature = "classifiers")]
-        if let Some(ref backend) = self.pii_ner_backend {
-            use zeph_sanitizer::pii::build_char_to_byte_map;
-
-            if self.pii_ner_tripped {
-                tracing::debug!(tool = %tool_name, "PII NER circuit breaker open, regex only");
-            } else {
-                let timeout_ms = self.pii_ner_timeout_ms;
-                let ner_input = if text.len() > self.pii_ner_max_chars {
-                    let boundary = text.floor_char_boundary(self.pii_ner_max_chars);
-                    &text[..boundary]
-                } else {
-                    text
-                };
-                match tokio::time::timeout(
-                    std::time::Duration::from_millis(timeout_ms),
-                    backend.classify(ner_input),
-                )
-                .await
-                {
-                    Ok(Ok(result)) if result.is_positive => {
-                        let char_to_byte = build_char_to_byte_map(ner_input);
-                        for ner_span in &result.spans {
-                            let byte_start = char_to_byte
-                                .get(ner_span.start)
-                                .copied()
-                                .unwrap_or(ner_input.len());
-                            let byte_end = char_to_byte
-                                .get(ner_span.end)
-                                .copied()
-                                .unwrap_or(ner_input.len());
-                            if byte_end > byte_start {
-                                spans.push(zeph_sanitizer::pii::PiiSpan {
-                                    label: ner_span.label.clone(),
-                                    start: byte_start,
-                                    end: byte_end,
-                                });
-                            }
-                        }
-                        self.pii_ner_consecutive_timeouts = 0;
-                    }
-                    Ok(Ok(_)) => {
-                        self.pii_ner_consecutive_timeouts = 0;
-                    }
-                    Ok(Err(e)) => {
-                        tracing::warn!(error = %e, tool = %tool_name, "PII NER failed, regex only");
-                    }
-                    Err(_) => {
-                        ner_timeouts += 1;
-                        self.pii_ner_consecutive_timeouts += 1;
-                        let threshold = self.pii_ner_circuit_breaker_threshold;
-                        if threshold > 0 && self.pii_ner_consecutive_timeouts >= threshold {
-                            self.pii_ner_tripped = true;
-                            circuit_breaker_tripped = true;
-                            tracing::warn!(
-                                consecutive_timeouts = self.pii_ner_consecutive_timeouts,
-                                threshold = threshold,
-                                tool = %tool_name,
-                                "PII NER circuit breaker tripped — NER disabled for this session, falling back to regex-only PII detection"
-                            );
-                        } else {
-                            tracing::warn!(
-                                timeout_ms = timeout_ms,
-                                tool = %tool_name,
-                                consecutive = self.pii_ner_consecutive_timeouts,
-                                "PII NER timed out, regex only"
-                            );
-                        }
-                    }
-                }
-            }
-        }
+        self.run_ner_classifier(
+            text,
+            tool_name,
+            &mut spans,
+            &mut ner_timeouts,
+            &mut circuit_breaker_tripped,
+        )
+        .await;
 
         let merged = merge_spans(spans);
         if merged.is_empty() {
@@ -180,6 +116,95 @@ impl SecurityState {
             scrubbed: true,
             ner_timeouts,
             circuit_breaker_tripped,
+        }
+    }
+
+    /// Run the NER classifier backend and append any detected spans.
+    ///
+    /// Updates `ner_timeouts` and `circuit_breaker_tripped` accumulators in place.
+    /// No-op when the circuit breaker is already tripped or no backend is configured.
+    #[cfg(feature = "classifiers")]
+    async fn run_ner_classifier(
+        &mut self,
+        text: &str,
+        tool_name: &str,
+        spans: &mut Vec<zeph_sanitizer::pii::PiiSpan>,
+        ner_timeouts: &mut u32,
+        circuit_breaker_tripped: &mut bool,
+    ) {
+        use zeph_sanitizer::pii::build_char_to_byte_map;
+
+        let Some(ref backend) = self.pii_ner_backend else {
+            return;
+        };
+
+        if self.pii_ner_tripped {
+            tracing::debug!(tool = %tool_name, "PII NER circuit breaker open, regex only");
+            return;
+        }
+
+        let timeout_ms = self.pii_ner_timeout_ms;
+        let ner_input = if text.len() > self.pii_ner_max_chars {
+            let boundary = text.floor_char_boundary(self.pii_ner_max_chars);
+            &text[..boundary]
+        } else {
+            text
+        };
+        match tokio::time::timeout(
+            std::time::Duration::from_millis(timeout_ms),
+            backend.classify(ner_input),
+        )
+        .await
+        {
+            Ok(Ok(result)) if result.is_positive => {
+                let char_to_byte = build_char_to_byte_map(ner_input);
+                for ner_span in &result.spans {
+                    let byte_start = char_to_byte
+                        .get(ner_span.start)
+                        .copied()
+                        .unwrap_or(ner_input.len());
+                    let byte_end = char_to_byte
+                        .get(ner_span.end)
+                        .copied()
+                        .unwrap_or(ner_input.len());
+                    if byte_end > byte_start {
+                        spans.push(zeph_sanitizer::pii::PiiSpan {
+                            label: ner_span.label.clone(),
+                            start: byte_start,
+                            end: byte_end,
+                        });
+                    }
+                }
+                self.pii_ner_consecutive_timeouts = 0;
+            }
+            Ok(Ok(_)) => {
+                self.pii_ner_consecutive_timeouts = 0;
+            }
+            Ok(Err(e)) => {
+                tracing::warn!(error = %e, tool = %tool_name, "PII NER failed, regex only");
+            }
+            Err(_) => {
+                *ner_timeouts += 1;
+                self.pii_ner_consecutive_timeouts += 1;
+                let threshold = self.pii_ner_circuit_breaker_threshold;
+                if threshold > 0 && self.pii_ner_consecutive_timeouts >= threshold {
+                    self.pii_ner_tripped = true;
+                    *circuit_breaker_tripped = true;
+                    tracing::warn!(
+                        consecutive_timeouts = self.pii_ner_consecutive_timeouts,
+                        threshold = threshold,
+                        tool = %tool_name,
+                        "PII NER circuit breaker tripped — NER disabled for this session, falling back to regex-only PII detection"
+                    );
+                } else {
+                    tracing::warn!(
+                        timeout_ms = timeout_ms,
+                        tool = %tool_name,
+                        consecutive = self.pii_ner_consecutive_timeouts,
+                        "PII NER timed out, regex only"
+                    );
+                }
+            }
         }
     }
 

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -26,6 +26,49 @@ type ToolExecFut = futures::future::BoxFuture<
     Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>,
 >;
 
+/// Output produced by the tier execution loop (Phase 1).
+///
+/// `None` signals that the loop was cancelled by the user; `Some` carries the
+/// collected tool results and deferred data that the results phase needs.
+type TierLoopOutput = Option<TierLoopData>;
+
+struct TierLoopData {
+    tool_results: Vec<Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>>,
+    pending_focus_checkpoint: Option<zeph_llm::provider::Message>,
+    pending_system_hints: Vec<String>,
+}
+
+/// Per-call computed context produced by `Agent::prepare_tool_dispatch`.
+///
+/// Bundles the gating results (pre-exec block, utility action, repeat/quota/cache checks)
+/// alongside the canonical call list so the tier execution loop has a single, coherent view.
+struct ToolDispatchContext {
+    calls: Vec<ToolCall>,
+    tool_call_ids: Vec<String>,
+    tool_started_ats: Vec<std::time::Instant>,
+    pre_exec_blocked: Vec<bool>,
+    utility_actions: Vec<zeph_tools::UtilityAction>,
+    quota_blocked: bool,
+    args_hashes: Vec<u64>,
+    repeat_blocked: Vec<bool>,
+    cache_hits: Vec<Option<zeph_tools::ToolOutput>>,
+}
+
+/// Output of `Agent::classify_tool_result`: all fields derived from the raw `ToolResult`.
+///
+/// Returned by value so `process_one_tool_result` can unpack it without borrow issues.
+struct ToolResultClassification {
+    output: String,
+    is_error: bool,
+    diff: Option<zeph_tools::DiffData>,
+    inline_stats: Option<String>,
+    kept_lines: Option<Vec<usize>>,
+    locations: Option<Vec<String>>,
+    anomaly_outcome: AnomalyOutcome,
+    is_quality_failure: bool,
+    tool_err_category: Option<zeph_tools::error_taxonomy::ToolErrorCategory>,
+}
+
 impl<C: Channel> Agent<C> {
     pub(super) async fn call_chat_with_tools_retry(
         &mut self,
@@ -80,7 +123,6 @@ impl<C: Channel> Agent<C> {
         self.process_response_native_tools().await
     }
 
-    #[allow(clippy::too_many_lines)] // tool loop with dependency gate, filter, and doom-loop checks
     pub(super) async fn process_response_native_tools(
         &mut self,
     ) -> Result<(), super::super::error::AgentError> {
@@ -152,51 +194,13 @@ impl<C: Channel> Agent<C> {
             // Iteration 0 uses filtered tool_defs (schema filter + dependency gates).
             // Iterations 1+ expand to the full set but still apply hard dependency gates
             // so tools with unmet `requires` cannot re-enter through the expansion path (#2024).
-            let gated_iter1_defs: Vec<ToolDefinition>;
+            let defs_for_iter: Vec<ToolDefinition>;
             let defs_for_turn: &[ToolDefinition] = if iteration == 0 {
                 &tool_defs
-            } else if let Some(ref dep_graph) = self.tool_state.dependency_graph
-                && !dep_graph.is_empty()
-            {
-                let names: Vec<&str> = all_tool_defs.iter().map(|d| d.name.as_str()).collect();
-                let allowed = dep_graph.filter_tool_names(
-                    &names,
-                    &self.tool_state.completed_tool_ids,
-                    &self.tool_state.dependency_always_on,
-                );
-                let allowed_set: std::collections::HashSet<&str> = allowed.into_iter().collect();
-                // Deadlock fallback: if all non-always-on tools would be blocked,
-                // use the full set for this iteration.
-                let non_ao_allowed = allowed_set
-                    .iter()
-                    .filter(|n| !self.tool_state.dependency_always_on.contains(**n))
-                    .count();
-                let non_ao_total = all_tool_defs
-                    .iter()
-                    .filter(|d| {
-                        !self
-                            .tool_state
-                            .dependency_always_on
-                            .contains(d.name.as_str())
-                    })
-                    .count();
-                if non_ao_allowed == 0 && non_ao_total > 0 {
-                    tracing::warn!(
-                        iteration,
-                        "tool dependency graph: all non-always-on tools gated on iter 1+; \
-                         disabling hard gates for this iteration"
-                    );
-                    &all_tool_defs
-                } else {
-                    gated_iter1_defs = all_tool_defs
-                        .iter()
-                        .filter(|d| allowed_set.contains(d.name.as_str()))
-                        .cloned()
-                        .collect();
-                    &gated_iter1_defs
-                }
             } else {
-                &all_tool_defs
+                defs_for_iter =
+                    build_gated_defs_for_iteration(iteration, &all_tool_defs, &self.tool_state);
+                &defs_for_iter
             };
             // None = continue loop, Some(()) = return Ok, Err = propagate
             if self
@@ -509,15 +513,15 @@ impl<C: Channel> Agent<C> {
         }
     }
 
+    /// Record skill learning outcomes for a tool output and optionally trigger self-reflection.
+    ///
+    /// Returns `Ok(true)` when the caller should return early (reflection consumed the turn),
+    /// `Ok(false)` to continue, or `Err` on a hard error.
     #[cfg(test)]
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3454): decompose into smaller helpers
-    async fn process_successful_tool_output(
+    async fn record_tool_output_outcome(
         &mut self,
-        output: zeph_tools::executor::ToolOutput,
+        output: &zeph_tools::executor::ToolOutput,
     ) -> Result<bool, super::super::error::AgentError> {
-        use super::super::format_tool_output;
-        use crate::channel::{ToolOutputEvent, ToolStartEvent};
-        use zeph_llm::provider::{Message, MessagePart, Role};
         use zeph_skills::evolution::FailureKind;
 
         if let Some(ref fs) = output.filter_stats {
@@ -526,23 +530,36 @@ impl<C: Channel> Agent<C> {
         if output.summary.trim().is_empty() {
             tracing::warn!("tool execution returned empty output");
             self.record_skill_outcomes("success", None, None).await;
-            return Ok(false);
+            return Ok(true);
         }
-
         if output.summary.contains("[error]") || output.summary.contains("[exit code") {
             let kind = FailureKind::from_error(&output.summary);
             self.record_skill_outcomes("tool_failure", Some(&output.summary), Some(kind.as_str()))
                 .await;
-
             if !self.learning_engine.was_reflection_used()
                 && self
                     .attempt_self_reflection(&output.summary, &output.summary)
                     .await?
             {
-                return Ok(false);
+                return Ok(true);
             }
         } else {
             self.record_skill_outcomes("success", None, None).await;
+        }
+        Ok(false)
+    }
+
+    #[cfg(test)]
+    async fn process_successful_tool_output(
+        &mut self,
+        output: zeph_tools::executor::ToolOutput,
+    ) -> Result<bool, super::super::error::AgentError> {
+        use super::super::format_tool_output;
+        use crate::channel::{ToolOutputEvent, ToolStartEvent};
+        use zeph_llm::provider::{Message, MessagePart, Role};
+
+        if self.record_tool_output_outcome(&output).await? {
+            return Ok(false);
         }
 
         let tool_call_id = uuid::Uuid::new_v4().to_string();
@@ -830,7 +847,6 @@ impl<C: Channel> Agent<C> {
         Ok(None)
     }
 
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3454): decompose into smaller helpers
     async fn call_chat_with_tools(
         &mut self,
         tool_defs: &[ToolDefinition],
@@ -852,54 +868,11 @@ impl<C: Channel> Agent<C> {
         let llm_timeout = std::time::Duration::from_secs(self.runtime.timeouts.llm_seconds);
         let start = std::time::Instant::now();
 
-        let dump_id =
-            self.debug_state
-                .debug_dumper
-                .as_ref()
-                .map(|d: &crate::debug_dump::DebugDumper| {
-                    // Skip expensive serialization when Trace format returns early without using it.
-                    let provider_request = if d.is_trace_format() {
-                        serde_json::Value::Null
-                    } else {
-                        self.provider
-                            .debug_request_json(&self.msg.messages, tool_defs, false) // lgtm[rust/cleartext-logging]
-                    };
-                    d.dump_request(&crate::debug_dump::RequestDebugDump {
-                        model_name: &self.runtime.model_name,
-                        messages: &self.msg.messages,
-                        tools: tool_defs,
-                        provider_request,
-                    })
-                });
+        let dump_id = self.prepare_chat_debug_dump(tool_defs);
 
         // RuntimeLayer before_chat hooks (MVP: empty vec = zero iterations).
-        if !self.runtime.layers.is_empty() {
-            let conv_id_str = self
-                .memory_state
-                .persistence
-                .conversation_id
-                .map(|id| id.0.to_string());
-            let ctx = crate::runtime_layer::LayerContext {
-                conversation_id: conv_id_str.as_deref(),
-                turn_number: u32::try_from(self.sidequest.turn_counter).unwrap_or(u32::MAX),
-            };
-            for layer in &self.runtime.layers {
-                let hook_result = std::panic::AssertUnwindSafe(layer.before_chat(
-                    &ctx,
-                    &self.msg.messages,
-                    tool_defs,
-                ))
-                .catch_unwind()
-                .await;
-                match hook_result {
-                    Ok(Some(sc)) => {
-                        tracing::debug!("RuntimeLayer short-circuited LLM call");
-                        return Ok(Some(sc));
-                    }
-                    Ok(None) => {}
-                    Err(_) => tracing::warn!("RuntimeLayer::before_chat panicked, continuing"),
-                }
-            }
+        if let Some(sc) = self.run_before_chat_layers(tool_defs).await? {
+            return Ok(Some(sc));
         }
 
         // CR-01: open LLM span before the call.
@@ -945,7 +918,108 @@ impl<C: Channel> Agent<C> {
             .saturating_add(llm_ms);
 
         // CR-01: close LLM span after the call completes.
-        if let Some(guard) = trace_guard
+        self.record_llm_trace_span_close(trace_guard, start);
+
+        self.debug_state
+            .write_chat_debug_dump(dump_id, &result, &self.security.pii_filter);
+
+        // RuntimeLayer after_chat hooks (MVP: empty vec = zero iterations).
+        self.run_after_chat_layers(&result).await;
+
+        Ok(Some(result))
+    }
+
+    /// Prepare and dump the request debug payload, returning the dump ID for the response dump.
+    fn prepare_chat_debug_dump(&self, tool_defs: &[ToolDefinition]) -> Option<u32> {
+        self.debug_state
+            .debug_dumper
+            .as_ref()
+            .map(|d: &crate::debug_dump::DebugDumper| {
+                // Skip expensive serialization when Trace format returns early without using it.
+                let provider_request = if d.is_trace_format() {
+                    serde_json::Value::Null
+                } else {
+                    self.provider
+                        .debug_request_json(&self.msg.messages, tool_defs, false) // lgtm[rust/cleartext-logging]
+                };
+                d.dump_request(&crate::debug_dump::RequestDebugDump {
+                    model_name: &self.runtime.model_name,
+                    messages: &self.msg.messages,
+                    tools: tool_defs,
+                    provider_request,
+                })
+            })
+    }
+
+    /// Run `RuntimeLayer::before_chat` hooks. Returns `Ok(Some(sc))` when a layer short-circuits
+    /// the LLM call, `Ok(None)` when all hooks pass through.
+    async fn run_before_chat_layers(
+        &self,
+        tool_defs: &[ToolDefinition],
+    ) -> Result<Option<ChatResponse>, super::super::error::AgentError> {
+        if self.runtime.layers.is_empty() {
+            return Ok(None);
+        }
+        let conv_id_str = self
+            .memory_state
+            .persistence
+            .conversation_id
+            .map(|id| id.0.to_string());
+        let ctx = crate::runtime_layer::LayerContext {
+            conversation_id: conv_id_str.as_deref(),
+            turn_number: u32::try_from(self.sidequest.turn_counter).unwrap_or(u32::MAX),
+        };
+        for layer in &self.runtime.layers {
+            let hook_result = std::panic::AssertUnwindSafe(layer.before_chat(
+                &ctx,
+                &self.msg.messages,
+                tool_defs,
+            ))
+            .catch_unwind()
+            .await;
+            match hook_result {
+                Ok(Some(sc)) => {
+                    tracing::debug!("RuntimeLayer short-circuited LLM call");
+                    return Ok(Some(sc));
+                }
+                Ok(None) => {}
+                Err(_) => tracing::warn!("RuntimeLayer::before_chat panicked, continuing"),
+            }
+        }
+        Ok(None)
+    }
+
+    /// Run `RuntimeLayer::after_chat` hooks. Panics in hooks are logged and swallowed.
+    async fn run_after_chat_layers(&self, result: &ChatResponse) {
+        if self.runtime.layers.is_empty() {
+            return;
+        }
+        let conv_id_str = self
+            .memory_state
+            .persistence
+            .conversation_id
+            .map(|id| id.0.to_string());
+        let ctx = crate::runtime_layer::LayerContext {
+            conversation_id: conv_id_str.as_deref(),
+            turn_number: u32::try_from(self.sidequest.turn_counter).unwrap_or(u32::MAX),
+        };
+        for layer in &self.runtime.layers {
+            let hook_result = std::panic::AssertUnwindSafe(layer.after_chat(&ctx, result))
+                .catch_unwind()
+                .await;
+            if hook_result.is_err() {
+                tracing::warn!("RuntimeLayer::after_chat panicked, continuing");
+            }
+        }
+    }
+
+    /// Close the CR-01 LLM trace span after the chat call completes.
+    fn record_llm_trace_span_close(
+        &mut self,
+        guard: Option<crate::debug_dump::trace::SpanGuard>,
+        start: std::time::Instant,
+    ) {
+        if let Some(guard) = guard
             && let Some(ref mut tc) = self.debug_state.trace_collector
         {
             let latency = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
@@ -962,32 +1036,6 @@ impl<C: Channel> Agent<C> {
                 },
             );
         }
-
-        self.debug_state
-            .write_chat_debug_dump(dump_id, &result, &self.security.pii_filter);
-
-        // RuntimeLayer after_chat hooks (MVP: empty vec = zero iterations).
-        if !self.runtime.layers.is_empty() {
-            let conv_id_str = self
-                .memory_state
-                .persistence
-                .conversation_id
-                .map(|id| id.0.to_string());
-            let ctx = crate::runtime_layer::LayerContext {
-                conversation_id: conv_id_str.as_deref(),
-                turn_number: u32::try_from(self.sidequest.turn_counter).unwrap_or(u32::MAX),
-            };
-            for layer in &self.runtime.layers {
-                let hook_result = std::panic::AssertUnwindSafe(layer.after_chat(&ctx, &result))
-                    .catch_unwind()
-                    .await;
-                if hook_result.is_err() {
-                    tracing::warn!("RuntimeLayer::after_chat panicked, continuing");
-                }
-            }
-        }
-
-        Ok(Some(result))
     }
 
     async fn record_chat_metrics_and_compact(
@@ -1117,10 +1165,428 @@ impl<C: Channel> Agent<C> {
         }
     }
 
-    #[allow(clippy::too_many_lines)]
-    // TODO(B2): extract sub-functions or move logic to reduce function length
-    // long function; decomposition would require extracting state into additional structs — TODO(#3454): decompose into smaller helpers
-    // parallel tool execution with DAG scheduling, retry, self-reflection, cancellation — inherently sequential control flow
+    /// Handle phases 2a / 2 / 3 of the tool dispatch cycle after the tier join completes.
+    ///
+    /// - **Phase 2a**: Interactive confirmation prompts for `ConfirmationRequired` results.
+    /// - **Phase 2**: Sequential retry with exponential backoff for transient errors on retryable
+    ///   executors. Shell/non-idempotent tools keep their error result unchanged.
+    /// - **Phase 3**: Parameter-reformat placeholder path (future LLM-based reformat).
+    ///
+    /// Each phase checks the cancellation token and returns `Ok(())` on early cancel, persisting
+    /// tombstone `ToolResult` entries to satisfy the `TOOL_RESULT_GUARANTEE` invariant.
+    /// Phases 2a / 2 / 3 of the tool dispatch cycle (confirmation, retry, reformat).
+    async fn run_post_dispatch_phases(
+        &mut self,
+        tool_calls: &[zeph_llm::provider::ToolUseRequest],
+        calls: &[ToolCall],
+        tool_results: &mut [Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>],
+        max_retries: usize,
+        cancel: &tokio_util::sync::CancellationToken,
+    ) -> Result<(), super::super::error::AgentError> {
+        self.handle_confirmation_phase(tool_calls, calls, tool_results, cancel)
+            .await?;
+        self.handle_retry_phase(tool_calls, calls, tool_results, max_retries, cancel)
+            .await?;
+        self.handle_reformat_phase(tool_calls, tool_results, cancel)
+            .await?;
+        Ok(())
+    }
+
+    /// Phase 2a: resolve `ConfirmationRequired` results via interactive channel prompt.
+    async fn handle_confirmation_phase(
+        &mut self,
+        tool_calls: &[zeph_llm::provider::ToolUseRequest],
+        calls: &[ToolCall],
+        tool_results: &mut [Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>],
+        cancel: &tokio_util::sync::CancellationToken,
+    ) -> Result<(), super::super::error::AgentError> {
+        for idx in 0..tool_results.len() {
+            if cancel.is_cancelled() {
+                self.tool_executor.set_skill_env(None);
+                tracing::info!("tool execution cancelled by user");
+                self.update_metrics(|m| m.cancellations += 1);
+                self.channel.send("[Cancelled]").await?;
+                self.persist_cancelled_tool_results(tool_calls).await;
+                return Ok(());
+            }
+            let new_result =
+                if let Err(zeph_tools::ToolError::ConfirmationRequired { ref command }) =
+                    tool_results[idx]
+                {
+                    let tc = &tool_calls[idx];
+                    let prompt = if command.is_empty() {
+                        format!("Allow tool: {}?", tc.name)
+                    } else {
+                        format!("Allow command: {command}?")
+                    };
+                    Some(if self.channel.confirm(&prompt).await? {
+                        // execute_tool_call_confirmed_erased bypasses check_trust; a second
+                        // ConfirmationRequired here indicates a misconfigured executor stack.
+                        self.tool_executor
+                            .execute_tool_call_confirmed_erased(&calls[idx])
+                            .await
+                    } else {
+                        Ok(Some(zeph_tools::ToolOutput {
+                            tool_name: tc.name.clone(),
+                            summary: "[cancelled by user]".to_owned(),
+                            blocks_executed: 0,
+                            filter_stats: None,
+                            diff: None,
+                            streamed: false,
+                            terminal_id: None,
+                            locations: None,
+                            raw_response: None,
+                            claim_source: None,
+                        }))
+                    })
+                } else {
+                    None
+                };
+            if let Some(result) = new_result {
+                if let Err(ref e) = result
+                    && let Some(ref d) = self.debug_state.debug_dumper
+                {
+                    d.dump_tool_error(tool_calls[idx].name.as_str(), e);
+                }
+                tool_results[idx] = result;
+            }
+        }
+        Ok(())
+    }
+
+    /// Phase 2: sequential retry with exponential backoff for transient errors on retryable tools.
+    async fn handle_retry_phase(
+        &mut self,
+        tool_calls: &[zeph_llm::provider::ToolUseRequest],
+        calls: &[ToolCall],
+        tool_results: &mut [Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>],
+        max_retries: usize,
+        cancel: &tokio_util::sync::CancellationToken,
+    ) -> Result<(), super::super::error::AgentError> {
+        if max_retries == 0 {
+            return Ok(());
+        }
+        let max_retry_duration_secs = self.tool_orchestrator.max_retry_duration_secs;
+        let retry_base_ms = self.tool_orchestrator.retry_base_ms;
+        let retry_max_ms = self.tool_orchestrator.retry_max_ms;
+        for idx in 0..tool_results.len() {
+            if cancel.is_cancelled() {
+                self.tool_executor.set_skill_env(None);
+                tracing::info!("tool execution cancelled by user");
+                self.update_metrics(|m| m.cancellations += 1);
+                self.channel.send("[Cancelled]").await?;
+                self.persist_cancelled_tool_results(tool_calls).await;
+                return Ok(());
+            }
+            let is_transient = matches!(
+                tool_results[idx],
+                Err(ref e) if e.kind() == zeph_tools::ErrorKind::Transient
+            );
+            if !is_transient {
+                continue;
+            }
+            let tc = &tool_calls[idx];
+            if !self
+                .tool_executor
+                .is_tool_retryable_erased(tc.name.as_str())
+            {
+                continue;
+            }
+            let call = &calls[idx];
+            let mut attempt = 0_usize;
+            let retry_start = std::time::Instant::now();
+            let result = loop {
+                let exec_result = tokio::select! {
+                    r = self.tool_executor.execute_tool_call_erased(call).instrument(
+                        tracing::info_span!("tool_exec_retry", tool_name = %tc.name, idx = %tc.id)
+                    ) => r,
+                    () = cancel.cancelled() => {
+                        self.tool_executor.set_skill_env(None);
+                        tracing::info!("tool retry cancelled by user");
+                        self.update_metrics(|m| m.cancellations += 1);
+                        self.channel.send("[Cancelled]").await?;
+                        self.persist_cancelled_tool_results(tool_calls).await;
+                        return Ok(());
+                    }
+                };
+                match exec_result {
+                    Err(ref e)
+                        if e.kind() == zeph_tools::ErrorKind::Transient
+                            && attempt < max_retries =>
+                    {
+                        let elapsed_secs = retry_start.elapsed().as_secs();
+                        if max_retry_duration_secs > 0 && elapsed_secs >= max_retry_duration_secs {
+                            tracing::warn!(
+                                tool = %tc.name, elapsed_secs, max_retry_duration_secs,
+                                "tool retry budget exceeded, aborting retries"
+                            );
+                            break exec_result;
+                        }
+                        attempt += 1;
+                        let delay_ms = retry_backoff_ms(attempt - 1, retry_base_ms, retry_max_ms);
+                        tracing::warn!(
+                            tool = %tc.name, attempt, delay_ms, error = %e,
+                            "transient tool error, retrying with backoff"
+                        );
+                        let _ = self
+                            .channel
+                            .send_status(&format!("Retrying {}...", tc.name))
+                            .await;
+                        // Interruptible backoff sleep: cancelled if agent shuts down.
+                        tokio::select! {
+                            () = tokio::time::sleep(std::time::Duration::from_millis(delay_ms)) => {}
+                            () = cancel.cancelled() => {
+                                self.tool_executor.set_skill_env(None);
+                                tracing::info!("retry backoff interrupted by cancellation");
+                                self.update_metrics(|m| m.cancellations += 1);
+                                self.channel.send("[Cancelled]").await?;
+                                return Ok(());
+                            }
+                        }
+                        let _ = self.channel.send_status("").await;
+                        // NOTE: retry re-executions are NOT recorded in repeat-detection (CRIT-3).
+                    }
+                    result => break result,
+                }
+            };
+            tool_results[idx] = result;
+        }
+        Ok(())
+    }
+
+    /// Phase 3: parameter-reformat placeholder path (future LLM-based reformat).
+    ///
+    /// Currently logs and skips; original error is propagated unchanged to the LLM.
+    async fn handle_reformat_phase(
+        &mut self,
+        tool_calls: &[zeph_llm::provider::ToolUseRequest],
+        tool_results: &mut [Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>],
+        cancel: &tokio_util::sync::CancellationToken,
+    ) -> Result<(), super::super::error::AgentError> {
+        if self
+            .tool_orchestrator
+            .parameter_reformat_provider
+            .is_empty()
+        {
+            return Ok(());
+        }
+        let budget_secs = self.tool_orchestrator.max_retry_duration_secs;
+        for idx in 0..tool_results.len() {
+            if cancel.is_cancelled() {
+                self.tool_executor.set_skill_env(None);
+                tracing::info!("parameter reformat phase cancelled by user");
+                self.update_metrics(|m| m.cancellations += 1);
+                self.channel.send("[Cancelled]").await?;
+                self.persist_cancelled_tool_results(tool_calls).await;
+                return Ok(());
+            }
+            let needs_reformat = matches!(
+                tool_results[idx],
+                Err(ref e) if e.category().needs_parameter_reformat()
+            );
+            if !needs_reformat {
+                continue;
+            }
+            let tc = &tool_calls[idx];
+            tracing::warn!(
+                tool = %tc.name,
+                "parameter error detected; parameter reformat path is reserved for future \
+                 LLM-based reformat implementation"
+            );
+            // Budget check: a newly created instant always has ~0 elapsed, so this guard
+            // is effectively a no-op today. Kept for structural parity with the planned
+            // LLM-based reformat implementation that will run actual work here.
+            let reformat_start = std::time::Instant::now();
+            if budget_secs > 0 && reformat_start.elapsed().as_secs() >= budget_secs {
+                tracing::warn!(tool = %tc.name, "parameter reformat budget exhausted, skipping");
+                continue;
+            }
+            let _ = self
+                .channel
+                .send_status(&format!(
+                    "Reformat for {} pending provider integration…",
+                    tc.name
+                ))
+                .await;
+            let _ = self.channel.send_status("").await;
+        }
+        Ok(())
+    }
+
+    /// Run all registered pre-execution verifiers against each tool call.
+    ///
+    /// Returns a `Vec<bool>` where `true` at index `i` means call `i` was blocked.
+    /// Blocking fires an audit log entry via the supervisor (fire-and-forget).
+    fn run_pre_execution_verifiers(&mut self, calls: &[ToolCall]) -> Vec<bool> {
+        let mut pre_exec_blocked = vec![false; calls.len()];
+        if self.tool_orchestrator.pre_execution_verifiers.is_empty() {
+            return pre_exec_blocked;
+        }
+        for (idx, call) in calls.iter().enumerate() {
+            let args_value = serde_json::Value::Object(call.params.clone());
+            for verifier in &self.tool_orchestrator.pre_execution_verifiers {
+                match verifier.verify(call.tool_id.as_str(), &args_value) {
+                    zeph_tools::VerificationResult::Allow => {}
+                    zeph_tools::VerificationResult::Block { reason } => {
+                        tracing::warn!(
+                            tool = %call.tool_id,
+                            verifier = verifier.name(),
+                            %reason,
+                            "pre-execution verifier blocked tool call"
+                        );
+                        self.update_metrics(|m| m.pre_execution_blocks += 1);
+                        self.push_security_event(
+                            crate::metrics::SecurityEventCategory::PreExecutionBlock,
+                            call.tool_id.as_str(),
+                            format!("{}: {}", verifier.name(), reason),
+                        );
+                        if let Some(ref logger) = self.tool_orchestrator.audit_logger {
+                            let args_json = serde_json::to_string(&args_value).unwrap_or_default();
+                            let entry = zeph_tools::AuditEntry {
+                                timestamp: zeph_tools::chrono_now(),
+                                tool: call.tool_id.clone(),
+                                command: args_json,
+                                result: zeph_tools::AuditResult::Blocked {
+                                    reason: format!("{}: {}", verifier.name(), reason),
+                                },
+                                duration_ms: 0,
+                                error_category: Some("pre_execution_block".to_owned()),
+                                error_domain: Some("security".to_owned()),
+                                error_phase: Some(
+                                    zeph_tools::error_taxonomy::ToolInvocationPhase::Setup
+                                        .label()
+                                        .to_owned(),
+                                ),
+                                claim_source: None,
+                                mcp_server_id: None,
+                                injection_flagged: false,
+                                embedding_anomalous: false,
+                                cross_boundary_mcp_to_acp: false,
+                                adversarial_policy_decision: None,
+                                exit_code: None,
+                                truncated: false,
+                                caller_id: call.caller_id.clone(),
+                                policy_match: None,
+                                correlation_id: None,
+                                vigil_risk: None,
+                            };
+                            let logger = std::sync::Arc::clone(logger);
+                            self.lifecycle.supervisor.spawn(
+                                super::super::agent_supervisor::TaskClass::Telemetry,
+                                "audit-log",
+                                async move { logger.log(&entry).await },
+                            );
+                        }
+                        pre_exec_blocked[idx] = true;
+                        break;
+                    }
+                    zeph_tools::VerificationResult::Warn { message } => {
+                        tracing::warn!(
+                            tool = %call.tool_id,
+                            verifier = verifier.name(),
+                            %message,
+                            "pre-execution verifier warning (not blocked)"
+                        );
+                        self.update_metrics(|m| m.pre_execution_warnings += 1);
+                        self.push_security_event(
+                            crate::metrics::SecurityEventCategory::PreExecutionWarn,
+                            call.tool_id.as_str(),
+                            format!("{}: {}", verifier.name(), message),
+                        );
+                    }
+                }
+            }
+        }
+        pre_exec_blocked
+    }
+
+    /// Score each tool call with the utility gate and return a recommended action per call.
+    ///
+    /// Pre-exec-blocked calls are returned as `ToolCall` to avoid double-counting. Exempt tools
+    /// bypass scoring entirely. For all others, the scorer recommends an action based on context
+    /// (token budget, call history, explicit user request).
+    fn compute_utility_actions(
+        &mut self,
+        calls: &[ToolCall],
+        pre_exec_blocked: &[bool],
+    ) -> Vec<zeph_tools::UtilityAction> {
+        #[allow(clippy::cast_possible_truncation)]
+        let tokens_consumed =
+            usize::try_from(self.providers.cached_prompt_tokens).unwrap_or(usize::MAX);
+        // token_budget = 0 signals "unknown" to UtilityContext — cost component is zeroed.
+        let token_budget: usize = 0;
+        let tool_calls_this_turn = self.tool_orchestrator.recent_tool_calls.len();
+        // Detect explicit tool request from the last user message text only.
+        // We only read MessagePart::Text parts so tool outputs/thinking blocks are excluded.
+        let explicit_request = self
+            .msg
+            .messages
+            .iter()
+            .rfind(|m| m.role == zeph_llm::provider::Role::User)
+            .is_some_and(|m| {
+                let text = if m.parts.is_empty() {
+                    m.content.clone()
+                } else {
+                    m.parts
+                        .iter()
+                        .filter_map(|p| {
+                            if let zeph_llm::provider::MessagePart::Text { text } = p {
+                                Some(text.as_str())
+                            } else {
+                                None
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                };
+                zeph_tools::has_explicit_tool_request(&text)
+            });
+        calls
+            .iter()
+            .enumerate()
+            .map(|(idx, call)| {
+                if pre_exec_blocked[idx] {
+                    return zeph_tools::UtilityAction::ToolCall;
+                }
+                if self
+                    .tool_orchestrator
+                    .utility_scorer
+                    .is_exempt(call.tool_id.as_str())
+                {
+                    return zeph_tools::UtilityAction::ToolCall;
+                }
+                let ctx = zeph_tools::UtilityContext {
+                    tool_calls_this_turn: tool_calls_this_turn + idx,
+                    tokens_consumed,
+                    token_budget,
+                    user_requested: explicit_request,
+                };
+                let score = self.tool_orchestrator.utility_scorer.score(call, &ctx);
+                let action = self
+                    .tool_orchestrator
+                    .utility_scorer
+                    .recommend_action(score.as_ref(), &ctx);
+                tracing::debug!(
+                    tool = %call.tool_id,
+                    score = ?score.as_ref().map(|s| s.total),
+                    threshold = self.tool_orchestrator.utility_scorer.threshold(),
+                    action = ?action,
+                    "utility gate: action recommended"
+                );
+                if action != zeph_tools::UtilityAction::ToolCall {
+                    tracing::info!(
+                        tool = %call.tool_id,
+                        action = ?action,
+                        "utility gate: non-execute action"
+                    );
+                }
+                // Record call regardless so subsequent calls in this batch see it as prior.
+                self.tool_orchestrator.utility_scorer.record_call(call);
+                action
+            })
+            .collect()
+    }
+
     #[cfg_attr(
         feature = "profiling",
         tracing::instrument(name = "agent.tool_loop", skip_all)
@@ -1132,6 +1598,103 @@ impl<C: Channel> Agent<C> {
     ) -> Result<(), super::super::error::AgentError> {
         let t_tool_exec = std::time::Instant::now();
         tracing::debug!("turn timing: tool_exec start");
+        // Scan for image-exfiltration in accompanying text, send to channel, persist
+        // the assistant ToolUse message.
+        self.push_assistant_tool_use_message(text, tool_calls)
+            .await?;
+
+        // Build calls, assign IDs, run exfiltration guard, gate checks (pre-exec/utility/
+        // quota/repeat/cache), and inject skill env. Extracted to keep this function under
+        // the clippy line limit.
+        let ToolDispatchContext {
+            calls,
+            tool_call_ids,
+            mut tool_started_ats,
+            pre_exec_blocked,
+            utility_actions,
+            quota_blocked,
+            args_hashes,
+            repeat_blocked,
+            cache_hits,
+        } = self.prepare_tool_dispatch(tool_calls);
+
+        let max_retries = self.tool_orchestrator.max_tool_retries;
+        // Clamp to 1 to prevent Semaphore(0) deadlock when config is set to 0.
+        let max_parallel = self.runtime.timeouts.max_parallel_tools.max(1);
+        let cancel = self.lifecycle.cancel_token.clone();
+
+        // Causal IPI pre-probe: record behavioral baseline before tool batch dispatch.
+        let causal_pre_response = self.run_causal_pre_probe().await;
+
+        // Phase 1: Tiered parallel execution bounded by a shared semaphore.
+        // Extracted to run_tier_execution_loop to satisfy the line-count limit.
+        // Returns None when the user cancelled (caller must return Ok(())).
+        let tier_data = self
+            .run_tier_execution_loop(
+                tool_calls,
+                &calls,
+                &pre_exec_blocked,
+                &utility_actions,
+                quota_blocked,
+                &args_hashes,
+                &repeat_blocked,
+                &cache_hits,
+                max_parallel,
+                &cancel,
+                &tool_call_ids,
+                &mut tool_started_ats,
+            )
+            .await?;
+
+        // Unpack tier execution output. None means the user cancelled — return early.
+        let Some(TierLoopData {
+            mut tool_results,
+            pending_focus_checkpoint,
+            pending_system_hints,
+        }) = tier_data
+        else {
+            return Ok(());
+        };
+
+        // Phases 2a / 2 / 3: confirmation, transient retry, parameter reformat.
+        // Each phase may return early on cancellation (Ok(())) or propagate channel errors.
+        self.run_post_dispatch_phases(tool_calls, &calls, &mut tool_results, max_retries, &cancel)
+            .await?;
+
+        // Process results, persist messages, run LSP hooks, fire deferred reflection.
+        // Also clears skill env and syncs cache counters after execution.
+        // Extracted to process_tool_result_batch to satisfy the line-count limit.
+        self.process_tool_result_batch(
+            tool_calls,
+            &tool_call_ids,
+            &tool_started_ats,
+            tool_results,
+            causal_pre_response,
+            pending_focus_checkpoint,
+            pending_system_hints,
+        )
+        .await?;
+
+        let tool_exec_ms = u64::try_from(t_tool_exec.elapsed().as_millis()).unwrap_or(u64::MAX);
+        tracing::debug!(ms = tool_exec_ms, "turn timing: tool_exec done");
+        self.metrics.pending_timings.tool_exec_ms = self
+            .metrics
+            .pending_timings
+            .tool_exec_ms
+            .saturating_add(tool_exec_ms);
+
+        Ok(())
+    }
+
+    /// Scan the optional text accompanying a `ToolUse` LLM response for injection patterns,
+    /// send it to the channel, then persist the assistant `ToolUse` message to history.
+    ///
+    /// Separated from `handle_native_tool_calls` to keep that function under the line limit.
+    async fn push_assistant_tool_use_message(
+        &mut self,
+        text: Option<&str>,
+        tool_calls: &[zeph_llm::provider::ToolUseRequest],
+    ) -> Result<(), super::super::error::AgentError> {
         // S4: scan text accompanying ToolUse responses for markdown image exfiltration.
         let cleaned_text: Option<String> = if let Some(t) = text
             && !t.is_empty()
@@ -1176,8 +1739,18 @@ impl<C: Channel> Agent<C> {
         ) {
             last.metadata.db_id = Some(id);
         }
+        Ok(())
+    }
 
-        // Build tool calls for all requests, stripping TAFC think fields before execution.
+    /// Build the canonical call list from `tool_calls`, assign stable IDs, run the exfiltration
+    /// guard, and compute all per-call gate results (pre-exec block, utility action, quota,
+    /// repeat detection, cache lookup). Injects active skill secrets before returning.
+    ///
+    /// Separated from `handle_native_tool_calls` to keep that function under the line limit.
+    fn prepare_tool_dispatch(
+        &mut self,
+        tool_calls: &[zeph_llm::provider::ToolUseRequest],
+    ) -> ToolDispatchContext {
         let tafc_enabled = self.tool_orchestrator.tafc.enabled;
         let calls: Vec<ToolCall> = tool_calls
             .iter()
@@ -1207,206 +1780,22 @@ impl<C: Channel> Agent<C> {
             .collect();
         // tool_started_ats is populated per-tier just before each tier's join_all so that
         // audit timestamps reflect actual execution start rather than pre-build time.
-        let mut tool_started_ats: Vec<std::time::Instant> =
+        let tool_started_ats: Vec<std::time::Instant> =
             vec![std::time::Instant::now(); tool_calls.len()];
 
-        // Validate tool call arguments against URLs seen in flagged untrusted content (flag-only).
-        for tc in tool_calls {
-            let args_json = tc.input.to_string();
-            let url_events = self.security.exfiltration_guard.validate_tool_call(
-                tc.name.as_str(),
-                &args_json,
-                &self.security.flagged_urls,
-            );
-            if !url_events.is_empty() {
-                tracing::warn!(
-                    tool = %tc.name,
-                    count = url_events.len(),
-                    "exfiltration guard: suspicious URLs in tool arguments (flag-only, not blocked)"
-                );
-                self.update_metrics(|m| {
-                    m.exfiltration_tool_urls_flagged += url_events.len() as u64;
-                });
-                self.push_security_event(
-                    crate::metrics::SecurityEventCategory::ExfiltrationBlock,
-                    tc.name.as_str(),
-                    format!(
-                        "{} suspicious URL(s) flagged in tool args",
-                        url_events.len()
-                    ),
-                );
-            }
-        }
+        self.check_exfiltration_urls(tool_calls);
 
         // Pre-execution verification (TrustBench pattern, issue #1630).
         // Runs after exfiltration guard (flag-only) and before repeat-detection.
         // Block: return synthetic error result for this call without executing.
         // Warn: log + emit security event + continue execution.
-        let mut pre_exec_blocked: Vec<bool> = vec![false; calls.len()];
-        if !self.tool_orchestrator.pre_execution_verifiers.is_empty() {
-            for (idx, call) in calls.iter().enumerate() {
-                let args_value = serde_json::Value::Object(call.params.clone());
-                for verifier in &self.tool_orchestrator.pre_execution_verifiers {
-                    match verifier.verify(call.tool_id.as_str(), &args_value) {
-                        zeph_tools::VerificationResult::Allow => {}
-                        zeph_tools::VerificationResult::Block { reason } => {
-                            tracing::warn!(
-                                tool = %call.tool_id,
-                                verifier = verifier.name(),
-                                %reason,
-                                "pre-execution verifier blocked tool call"
-                            );
-                            self.update_metrics(|m| m.pre_execution_blocks += 1);
-                            self.push_security_event(
-                                crate::metrics::SecurityEventCategory::PreExecutionBlock,
-                                call.tool_id.as_str(),
-                                format!("{}: {}", verifier.name(), reason),
-                            );
-                            if let Some(ref logger) = self.tool_orchestrator.audit_logger {
-                                let args_json =
-                                    serde_json::to_string(&args_value).unwrap_or_default();
-                                let entry = zeph_tools::AuditEntry {
-                                    timestamp: zeph_tools::chrono_now(),
-                                    tool: call.tool_id.clone(),
-                                    command: args_json,
-                                    result: zeph_tools::AuditResult::Blocked {
-                                        reason: format!("{}: {}", verifier.name(), reason),
-                                    },
-                                    duration_ms: 0,
-                                    error_category: Some("pre_execution_block".to_owned()),
-                                    error_domain: Some("security".to_owned()),
-                                    error_phase: Some(
-                                        zeph_tools::error_taxonomy::ToolInvocationPhase::Setup
-                                            .label()
-                                            .to_owned(),
-                                    ),
-                                    claim_source: None,
-                                    mcp_server_id: None,
-                                    injection_flagged: false,
-                                    embedding_anomalous: false,
-                                    cross_boundary_mcp_to_acp: false,
-                                    adversarial_policy_decision: None,
-                                    exit_code: None,
-                                    truncated: false,
-                                    caller_id: call.caller_id.clone(),
-                                    policy_match: None,
-                                    correlation_id: None,
-                                    vigil_risk: None,
-                                };
-                                let logger = std::sync::Arc::clone(logger);
-                                self.lifecycle.supervisor.spawn(
-                                    super::super::agent_supervisor::TaskClass::Telemetry,
-                                    "audit-log",
-                                    async move { logger.log(&entry).await },
-                                );
-                            }
-                            pre_exec_blocked[idx] = true;
-                            break;
-                        }
-                        zeph_tools::VerificationResult::Warn { message } => {
-                            tracing::warn!(
-                                tool = %call.tool_id,
-                                verifier = verifier.name(),
-                                %message,
-                                "pre-execution verifier warning (not blocked)"
-                            );
-                            self.update_metrics(|m| m.pre_execution_warnings += 1);
-                            self.push_security_event(
-                                crate::metrics::SecurityEventCategory::PreExecutionWarn,
-                                call.tool_id.as_str(),
-                                format!("{}: {}", verifier.name(), message),
-                            );
-                        }
-                    }
-                }
-            }
-        }
+        let pre_exec_blocked = self.run_pre_execution_verifiers(&calls);
 
         // Utility gate: score each call and recommend an action (#2477).
-        // Fail-closed on scoring errors (None when scoring produces invalid result).
-        // user_requested is set when the user message explicitly requests tool invocation
-        // (e.g. "using a tool", "call the X tool"). Detected from the last user message only —
-        // never from LLM call content or tool outputs to prevent prompt-injection bypass (C2 fix).
-        let utility_actions: Vec<zeph_tools::UtilityAction> = {
-            #[allow(clippy::cast_possible_truncation)]
-            let tokens_consumed =
-                usize::try_from(self.providers.cached_prompt_tokens).unwrap_or(usize::MAX);
-            // token_budget = 0 signals "unknown" to UtilityContext — cost component is zeroed.
-            let token_budget: usize = 0;
-            let tool_calls_this_turn = self.tool_orchestrator.recent_tool_calls.len();
-            // Extract the last user message text for explicit-request detection.
-            // We only read MessagePart::Text parts so tool outputs/thinking blocks are excluded.
-            let explicit_request = self
-                .msg
-                .messages
-                .iter()
-                .rfind(|m| m.role == zeph_llm::provider::Role::User)
-                .is_some_and(|m| {
-                    let text = if m.parts.is_empty() {
-                        m.content.clone()
-                    } else {
-                        m.parts
-                            .iter()
-                            .filter_map(|p| {
-                                if let zeph_llm::provider::MessagePart::Text { text } = p {
-                                    Some(text.as_str())
-                                } else {
-                                    None
-                                }
-                            })
-                            .collect::<Vec<_>>()
-                            .join(" ")
-                    };
-                    zeph_tools::has_explicit_tool_request(&text)
-                });
-            calls
-                .iter()
-                .enumerate()
-                .map(|(idx, call)| {
-                    if pre_exec_blocked[idx] {
-                        // Already blocked upstream — treat as ToolCall to avoid double-counting.
-                        return zeph_tools::UtilityAction::ToolCall;
-                    }
-                    if self
-                        .tool_orchestrator
-                        .utility_scorer
-                        .is_exempt(call.tool_id.as_str())
-                    {
-                        return zeph_tools::UtilityAction::ToolCall;
-                    }
-                    let ctx = zeph_tools::UtilityContext {
-                        tool_calls_this_turn: tool_calls_this_turn + idx,
-                        tokens_consumed,
-                        token_budget,
-                        user_requested: explicit_request,
-                    };
-                    let score = self.tool_orchestrator.utility_scorer.score(call, &ctx);
-                    let action = self
-                        .tool_orchestrator
-                        .utility_scorer
-                        .recommend_action(score.as_ref(), &ctx);
-                    tracing::debug!(
-                        tool = %call.tool_id,
-                        score = ?score.as_ref().map(|s| s.total),
-                        threshold = self.tool_orchestrator.utility_scorer.threshold(),
-                        action = ?action,
-                        "utility gate: action recommended"
-                    );
-                    if action != zeph_tools::UtilityAction::ToolCall {
-                        tracing::info!(
-                            tool = %call.tool_id,
-                            action = ?action,
-                            "utility gate: non-execute action"
-                        );
-                    }
-                    // Record call regardless so subsequent calls in this batch see it as prior.
-                    self.tool_orchestrator.utility_scorer.record_call(call);
-                    action
-                })
-                .collect()
-        };
-        // Repeat-detection (CRIT-3): record LLM-initiated calls BEFORE execution.
-        // Retry re-executions must NOT be pushed here — they are handled inside the retry loop.
+        // user_requested is detected from the last user message only — never from LLM content or
+        // tool outputs to prevent prompt-injection bypass (C2 fix).
+        let utility_actions = self.compute_utility_actions(&calls, &pre_exec_blocked);
+
         // Per-session quota check. Counted once per logical dispatch batch (M3: retries do not
         // consume additional quota slots). When exceeded, all calls in this batch are quota-blocked.
         let quota_blocked = if let Some(max) = self.tool_orchestrator.check_quota() {
@@ -1443,7 +1832,7 @@ impl<C: Channel> Agent<C> {
                 blocked
             })
             .collect();
-        // Push LLM-initiated calls into the repeat-detection window (even if blocked).
+        // Repeat-detection (CRIT-3): push LLM-initiated calls BEFORE execution.
         // Cache hits are also pushed here (P1 invariant): a cached tool called N times must
         // still trigger repeat-detection to prevent infinite loops if the LLM keeps requesting it.
         for (call, &hash) in calls.iter().zip(args_hashes.iter()) {
@@ -1466,36 +1855,96 @@ impl<C: Channel> Agent<C> {
             })
             .collect();
 
-        // Inject active skill secrets before tool execution
+        // Inject active skill secrets before tool execution.
         self.inject_active_skill_env();
 
-        // Execute tool calls with retry for transient errors.
-        // Retries do NOT produce a new LLM turn and therefore do NOT consume the outer
-        // max_tool_iterations budget — the budget only decrements on LLM round-trips.
-        // The retry budget per tool call is bounded independently by max_tool_retries.
-        let max_retries = self.tool_orchestrator.max_tool_retries;
-        // Clamp to 1 to prevent Semaphore(0) deadlock when config is set to 0.
-        let max_parallel = self.runtime.timeouts.max_parallel_tools.max(1);
-        let cancel = self.lifecycle.cancel_token.clone();
+        ToolDispatchContext {
+            calls,
+            tool_call_ids,
+            tool_started_ats,
+            pre_exec_blocked,
+            utility_actions,
+            quota_blocked,
+            args_hashes,
+            repeat_blocked,
+            cache_hits,
+        }
+    }
 
-        // Causal IPI pre-probe: record behavioral baseline before tool batch dispatch.
-        // Per-batch (not per-tool): 1 LLM call for the entire batch.
-        // On error: log WARN + skip causal analysis for this batch. Never block dispatch.
-        let causal_pre_response = if let Some(ref analyzer) = self.security.causal_analyzer {
-            let context_summary = self.build_causal_context_summary();
-            match analyzer.probe(&context_summary).await {
-                Ok(resp) => Some((resp, context_summary)),
-                Err(e) => {
-                    tracing::warn!(error = %e, "causal IPI pre-probe failed, skipping analysis");
-                    None
-                }
+    /// Validate tool call arguments against URLs seen in flagged untrusted content.
+    ///
+    /// This is a flag-only check — suspicious URLs are logged and metered but do not block
+    /// execution. Extracted from `prepare_tool_dispatch` to keep that function under the
+    /// clippy line limit.
+    fn check_exfiltration_urls(&mut self, tool_calls: &[zeph_llm::provider::ToolUseRequest]) {
+        for tc in tool_calls {
+            let args_json = tc.input.to_string();
+            let url_events = self.security.exfiltration_guard.validate_tool_call(
+                tc.name.as_str(),
+                &args_json,
+                &self.security.flagged_urls,
+            );
+            if !url_events.is_empty() {
+                tracing::warn!(
+                    tool = %tc.name,
+                    count = url_events.len(),
+                    "exfiltration guard: suspicious URLs in tool arguments (flag-only, not blocked)"
+                );
+                self.update_metrics(|m| {
+                    m.exfiltration_tool_urls_flagged += url_events.len() as u64;
+                });
+                self.push_security_event(
+                    crate::metrics::SecurityEventCategory::ExfiltrationBlock,
+                    tc.name.as_str(),
+                    format!(
+                        "{} suspicious URL(s) flagged in tool args",
+                        url_events.len()
+                    ),
+                );
             }
-        } else {
-            None
-        };
+        }
+    }
 
-        // Phase 1: Tiered parallel execution bounded by a shared semaphore.
-        //
+    /// Run the causal IPI pre-probe to record the behavioral baseline before tool dispatch.
+    ///
+    /// Returns the probe response paired with the context summary so the post-probe can
+    /// compare the two. Returns `None` when the analyzer is not configured or the probe fails.
+    async fn run_causal_pre_probe(&mut self) -> Option<(String, String)> {
+        let analyzer = self.security.causal_analyzer.as_ref()?;
+        let context_summary = self.build_causal_context_summary();
+        match analyzer.probe(&context_summary).await {
+            Ok(resp) => Some((resp, context_summary)),
+            Err(e) => {
+                tracing::warn!(error = %e, "causal IPI pre-probe failed, skipping analysis");
+                None
+            }
+        }
+    }
+
+    /// Execute tool calls in topological tiers (Phase 1).
+    ///
+    /// Builds a dependency DAG, partitions into tiers, and runs each tier with bounded
+    /// concurrency via a shared semaphore. MCP elicitation events are drained during the
+    /// join to prevent deadlocks.
+    ///
+    /// Returns `None` when the user cancelled (the caller must return `Ok(())`), or
+    /// `Some(TierLoopData)` with the collected results on success.
+    #[allow(clippy::too_many_arguments)]
+    async fn run_tier_execution_loop(
+        &mut self,
+        tool_calls: &[zeph_llm::provider::ToolUseRequest],
+        calls: &[ToolCall],
+        pre_exec_blocked: &[bool],
+        utility_actions: &[zeph_tools::UtilityAction],
+        quota_blocked: bool,
+        args_hashes: &[u64],
+        repeat_blocked: &[bool],
+        cache_hits: &[Option<zeph_tools::ToolOutput>],
+        max_parallel: usize,
+        cancel: &tokio_util::sync::CancellationToken,
+        tool_call_ids: &[String],
+        tool_started_ats: &mut [std::time::Instant],
+    ) -> Result<TierLoopOutput, super::super::error::AgentError> {
         // Build a dependency DAG over tool_use_id references in call arguments. When the
         // DAG is trivial (no dependencies — the common case), we execute all calls in a
         // single tier with zero overhead. When dependencies exist, we partition calls into
@@ -1523,38 +1972,9 @@ impl<C: Channel> Agent<C> {
         // Pre-process focus tool calls (#1850) and compress_context (#2218).
         // These need &mut self and cannot run inside the parallel tier futures.
         // Pre-populate their results so the tier loop skips them.
-        let mut pending_focus_checkpoint: Option<zeph_llm::provider::Message> = None;
-        {
-            for (idx, tc) in tool_calls.iter().enumerate() {
-                let is_focus_tool = self.focus.config.enabled
-                    && (tc.name == "start_focus" || tc.name == "complete_focus");
-                let is_compress = tc.name == "compress_context";
-                if is_focus_tool || is_compress {
-                    let result = if is_compress {
-                        self.handle_compress_context().await
-                    } else {
-                        let (text, maybe_checkpoint) =
-                            self.handle_focus_tool(tc.name.as_str(), &tc.input);
-                        if let Some(cp) = maybe_checkpoint {
-                            pending_focus_checkpoint = Some(cp);
-                        }
-                        text
-                    };
-                    tool_results[idx] = Ok(Some(zeph_tools::ToolOutput {
-                        tool_name: tc.name.clone(),
-                        summary: result,
-                        blocks_executed: 1,
-                        filter_stats: None,
-                        diff: None,
-                        streamed: false,
-                        terminal_id: None,
-                        locations: None,
-                        raw_response: None,
-                        claim_source: None,
-                    }));
-                }
-            }
-        }
+        let pending_focus_checkpoint = self
+            .preprocess_focus_compress_calls(tool_calls, &mut tool_results)
+            .await;
 
         // Track which indices have a failed/ConfirmationRequired prerequisite so that
         // dependent calls in later tiers receive a synthetic error instead of executing.
@@ -1572,7 +1992,7 @@ impl<C: Channel> Agent<C> {
                 self.update_metrics(|m| m.cancellations += 1);
                 self.channel.send("[Cancelled]").await?;
                 self.persist_cancelled_tool_results(tool_calls).await;
-                return Ok(());
+                return Ok(None);
             }
 
             if tier_count > 1 {
@@ -1586,475 +2006,51 @@ impl<C: Channel> Agent<C> {
                     .await;
             }
 
-            // Mark execution start time for this tier before sending ToolStartEvent.
-            let tier_start = std::time::Instant::now();
-            for &idx in &tier.indices {
-                tool_started_ats[idx] = tier_start;
-            }
+            // Stamp execution start time and send ToolStartEvent per-tier (§3.7).
+            self.stamp_and_send_tier_start(
+                &tier.indices,
+                tool_calls,
+                tool_call_ids,
+                tool_started_ats,
+            )
+            .await?;
 
-            // Send ToolStartEvent per-tier (section 3.7): accurate timing for TUI.
-            for &idx in &tier.indices {
-                let tc = &tool_calls[idx];
-                let tool_call_id = &tool_call_ids[idx];
-                self.channel
-                    .send_tool_start(ToolStartEvent {
-                        tool_name: tc.name.clone(),
-                        tool_call_id: tool_call_id.clone(),
-                        params: Some(tc.input.clone()),
-                        parent_tool_use_id: self.session.parent_tool_use_id.clone(),
-                        started_at: std::time::Instant::now(),
-                        speculative: false,
-                        sandbox_profile: None,
-                    })
-                    .await?;
-            }
+            // Build futures for this tier, applying all gate checks per call.
+            let tier_futs = self
+                .build_tier_call_futures(
+                    tool_calls,
+                    calls,
+                    &tier.indices,
+                    &dag,
+                    &failed_ids,
+                    quota_blocked,
+                    pre_exec_blocked,
+                    utility_actions,
+                    repeat_blocked,
+                    cache_hits,
+                    &semaphore,
+                    &mut pending_system_hints,
+                )
+                .await?;
 
-            // Build futures for this tier. Calls whose prerequisite failed get a synthetic
-            // error result immediately (IMP-02: includes ConfirmationRequired dependencies).
-            let mut tier_futs: Vec<(usize, ToolExecFut)> = Vec::with_capacity(tier.indices.len());
-
-            // Rate limiter: atomic batch-reserve for this tier (S5 fix).
-            // check_batch() reserves slots before any future is dispatched, preventing
-            // parallel calls from all passing the check before any records the use.
-            let tier_tool_names: Vec<&str> = tier
-                .indices
-                .iter()
-                .map(|&i| tool_calls[i].name.as_str())
-                .collect();
-            let rate_results = self.runtime.rate_limiter.check_batch(&tier_tool_names);
-
-            for (tier_local_idx, &idx) in tier.indices.iter().enumerate() {
-                let tc = &tool_calls[idx];
-                let call = &calls[idx];
-
-                // Skip focus tools and compress_context pre-handled above (they already have results).
-                if tc.name == "compress_context"
-                    || (self.focus.config.enabled
-                        && (tc.name == "start_focus" || tc.name == "complete_focus"))
-                {
-                    continue;
-                }
-
-                // Check if this call has a failed/blocked prerequisite.
-                // We look up which tool_use_ids this call references using values
-                // pre-extracted during DAG construction (no redundant JSON traversal).
-                let has_failed_dep = dag
-                    .string_values_for(idx)
-                    .iter()
-                    .any(|v| failed_ids.contains(v));
-
-                if has_failed_dep {
-                    // IMP-02: inject synthetic error so the LLM learns the dependency chain broke.
-                    let msg =
-                        "[error] Skipped: a prerequisite tool failed or requires confirmation"
-                            .to_string();
-                    let out = zeph_tools::ToolOutput {
-                        tool_name: tc.name.clone(),
-                        summary: msg,
-                        blocks_executed: 0,
-                        filter_stats: None,
-                        diff: None,
-                        streamed: false,
-                        terminal_id: None,
-                        locations: None,
-                        raw_response: None,
-                        claim_source: None,
-                    };
-                    tier_futs.push((idx, Box::pin(std::future::ready(Ok(Some(out))))));
-                    continue;
-                }
-
-                if quota_blocked {
-                    let max = self
-                        .tool_orchestrator
-                        .max_tool_calls_per_session
-                        .unwrap_or(0);
-                    let out = zeph_tools::ToolOutput {
-                        tool_name: tc.name.clone(),
-                        summary: format!(
-                            "[error] Tool call quota exceeded (session limit: {max} calls). \
-                             No further tool calls are allowed this session."
-                        ),
-                        blocks_executed: 0,
-                        filter_stats: None,
-                        diff: None,
-                        streamed: false,
-                        terminal_id: None,
-                        locations: None,
-                        raw_response: None,
-                        claim_source: None,
-                    };
-                    tier_futs.push((idx, Box::pin(std::future::ready(Ok(Some(out))))));
-                    continue;
-                }
-
-                if pre_exec_blocked[idx] {
-                    let msg = format!(
-                        "[error] Tool call to {} was blocked by pre-execution verifier. \
-                         The requested operation is not permitted.",
-                        tc.name
-                    );
-                    let out = zeph_tools::ToolOutput {
-                        tool_name: tc.name.clone(),
-                        summary: msg,
-                        blocks_executed: 0,
-                        filter_stats: None,
-                        diff: None,
-                        streamed: false,
-                        terminal_id: None,
-                        locations: None,
-                        raw_response: None,
-                        claim_source: None,
-                    };
-                    tier_futs.push((idx, Box::pin(std::future::ready(Ok(Some(out))))));
-                    continue;
-                }
-
-                match utility_actions[idx] {
-                    zeph_tools::UtilityAction::ToolCall => {}
-                    zeph_tools::UtilityAction::Respond => {
-                        let _ = self
-                            .channel
-                            .send_status(&format!("Utility action: Respond ({})", tc.name))
-                            .await;
-                        let out = skipped_output(
-                            tc.name.to_string(),
-                            format!(
-                                "[skipped] Tool call to {} skipped — utility policy recommends a \
-                                 direct response without further tool use.",
-                                tc.name
-                            ),
-                        );
-                        tier_futs.push((idx, Box::pin(std::future::ready(Ok(Some(out))))));
-                        continue;
-                    }
-                    zeph_tools::UtilityAction::Retrieve => {
-                        let _ = self
-                            .channel
-                            .send_status(&format!("Utility action: Retrieve ({})", tc.name))
-                            .await;
-                        // Inject a system message directing the LLM to retrieve context first,
-                        // then re-invoke the original tool. Without the explicit re-dispatch
-                        // instruction the LLM tends to treat the skipped result as a hard
-                        // block and responds in text instead of calling the tool again (#2620).
-                        let hint = format!(
-                            "[utility:retrieve] Before executing the '{}' tool, retrieve \
-                             relevant context via memory_search or a related lookup to ensure \
-                             the call is well-targeted. After retrieving context, you MUST call \
-                             the '{}' tool again with the same arguments.",
-                            tc.name, tc.name
-                        );
-                        pending_system_hints.push(hint);
-                        let out = skipped_output(
-                            tc.name.to_string(),
-                            format!(
-                                "[skipped] Tool call to {} skipped — utility policy recommends \
-                                 retrieving additional context first.",
-                                tc.name
-                            ),
-                        );
-                        tier_futs.push((idx, Box::pin(std::future::ready(Ok(Some(out))))));
-                        continue;
-                    }
-                    zeph_tools::UtilityAction::Verify => {
-                        let _ = self
-                            .channel
-                            .send_status(&format!("Utility action: Verify ({})", tc.name))
-                            .await;
-                        // Inject a system message directing the LLM to verify the prior result.
-                        let hint = format!(
-                            "[utility:verify] Before executing the '{}' tool again, verify \
-                             the result of the previous tool call to confirm it is correct \
-                             and that further tool use is necessary.",
-                            tc.name
-                        );
-                        pending_system_hints.push(hint);
-                        let out = skipped_output(
-                            tc.name.to_string(),
-                            format!(
-                                "[skipped] Tool call to {} skipped — utility policy recommends \
-                                 verifying the previous result first.",
-                                tc.name
-                            ),
-                        );
-                        tier_futs.push((idx, Box::pin(std::future::ready(Ok(Some(out))))));
-                        continue;
-                    }
-                    zeph_tools::UtilityAction::Stop => {
-                        let _ = self
-                            .channel
-                            .send_status(&format!("Utility action: Stop ({})", tc.name))
-                            .await;
-                        let threshold = self.tool_orchestrator.utility_scorer.threshold();
-                        let out = skipped_output(
-                            tc.name.to_string(),
-                            format!(
-                                "[stopped] Tool call to {} halted by the utility gate — \
-                                 budget exhausted or score below threshold {threshold:.2}.",
-                                tc.name
-                            ),
-                        );
-                        tier_futs.push((idx, Box::pin(std::future::ready(Ok(Some(out))))));
-                        continue;
-                    }
-                }
-
-                if repeat_blocked[idx] {
-                    let msg = format!(
-                        "[error] Repeated identical call to {} detected. \
-                         Use different arguments or a different approach.",
-                        tc.name
-                    );
-                    let out = zeph_tools::ToolOutput {
-                        tool_name: tc.name.clone(),
-                        summary: msg,
-                        blocks_executed: 0,
-                        filter_stats: None,
-                        diff: None,
-                        streamed: false,
-                        terminal_id: None,
-                        locations: None,
-                        raw_response: None,
-                        claim_source: None,
-                    };
-                    tier_futs.push((idx, Box::pin(std::future::ready(Ok(Some(out))))));
-                    continue;
-                }
-
-                // Cache hit: return pre-computed result without executing the tool.
-                // TUI events (ToolStartEvent already sent above) will still be emitted for cache
-                // hits in the result processing loop below, maintaining Start/Output pairing.
-                if let Some(cached_output) = cache_hits[idx].clone() {
-                    tracing::debug!(
-                        tool = %tc.name,
-                        "[tool-cache] returning cached result, skipping execution"
-                    );
-                    tier_futs.push((idx, Box::pin(std::future::ready(Ok(Some(cached_output))))));
-                    continue;
-                }
-
-                // Rate limiter: check the pre-computed batch result for this call.
-                if let Some(ref exceeded) = rate_results[tier_local_idx] {
-                    tracing::warn!(
-                        tool = %tc.name,
-                        category = exceeded.category.as_str(),
-                        limit = exceeded.limit,
-                        "tool rate limiter: blocking call"
-                    );
-                    self.update_metrics(|m| m.rate_limit_trips += 1);
-                    self.push_security_event(
-                        crate::metrics::SecurityEventCategory::RateLimit,
-                        tc.name.as_str(),
-                        format!(
-                            "{} calls exceeded {}/min",
-                            exceeded.category.as_str(),
-                            exceeded.limit
-                        ),
-                    );
-                    let out = zeph_tools::ToolOutput {
-                        tool_name: tc.name.clone(),
-                        summary: exceeded.to_error_message(),
-                        blocks_executed: 0,
-                        filter_stats: None,
-                        diff: None,
-                        streamed: false,
-                        terminal_id: None,
-                        locations: None,
-                        raw_response: None,
-                        claim_source: None,
-                    };
-                    tier_futs.push((idx, Box::pin(std::future::ready(Ok(Some(out))))));
-                    continue;
-                }
-
-                // RuntimeLayer before_tool hooks: may short-circuit execution.
-                if !self.runtime.layers.is_empty() {
-                    let conv_id_str = self
-                        .memory_state
-                        .persistence
-                        .conversation_id
-                        .map(|id| id.0.to_string());
-                    let ctx = crate::runtime_layer::LayerContext {
-                        conversation_id: conv_id_str.as_deref(),
-                        turn_number: u32::try_from(self.sidequest.turn_counter).unwrap_or(u32::MAX),
-                    };
-                    let mut sc_result: crate::runtime_layer::BeforeToolResult = None;
-                    for layer in &self.runtime.layers {
-                        let hook_result =
-                            std::panic::AssertUnwindSafe(layer.before_tool(&ctx, call))
-                                .catch_unwind()
-                                .await;
-                        match hook_result {
-                            Ok(Some(r)) => {
-                                sc_result = Some(r);
-                                break;
-                            }
-                            Ok(None) => {}
-                            Err(_) => {
-                                tracing::warn!("RuntimeLayer::before_tool panicked, continuing");
-                            }
-                        }
-                    }
-                    if let Some(r) = sc_result {
-                        // Fire PermissionDenied hooks (fail_open: hook errors are logged, not fatal).
-                        let pd_hooks = self.session.hooks_config.permission_denied.clone();
-                        if !pd_hooks.is_empty() {
-                            let _span = tracing::info_span!(
-                                "core.hooks.permission_denied",
-                                tool = %tc.name,
-                            )
-                            .entered();
-                            let mut env = std::collections::HashMap::new();
-                            env.insert("ZEPH_DENIED_TOOL".to_owned(), tc.name.to_string());
-                            env.insert("ZEPH_DENY_REASON".to_owned(), r.reason.clone());
-                            let dispatch = self.mcp_dispatch();
-                            let mcp: Option<&dyn zeph_subagent::McpDispatch> = dispatch
-                                .as_ref()
-                                .map(|d| d as &dyn zeph_subagent::McpDispatch);
-                            // TODO: implement retry-on-{"retry":true} stdout signal (#3292)
-                            if let Err(e) =
-                                zeph_subagent::hooks::fire_hooks(&pd_hooks, &env, mcp).await
-                            {
-                                tracing::warn!(
-                                    error = %e,
-                                    tool = %tc.name,
-                                    "PermissionDenied hook failed"
-                                );
-                            }
-                        }
-                        tier_futs.push((idx, Box::pin(std::future::ready(r.result))));
-                        continue;
-                    }
-                }
-
-                let sem = std::sync::Arc::clone(&semaphore);
-                let executor = std::sync::Arc::clone(&self.tool_executor);
-                let call = call.clone();
-                let tool_name = tc.name.clone();
-                let tool_id = tc.id.clone();
-                let fut = async move {
-                    let _permit = sem.acquire().await.map_err(|_| {
-                        zeph_tools::ToolError::Execution(std::io::Error::other(
-                            "semaphore closed during tool execution",
-                        ))
-                    })?;
-                    executor
-                        .execute_tool_call_erased(&call)
-                        .instrument(tracing::info_span!(
-                            "tool_exec",
-                            tool_name = %tool_name,
-                            idx = %tool_id
-                        ))
-                        .await
-                };
-                tier_futs.push((idx, Box::pin(fut)));
-            }
-
-            // Execute all futures in this tier concurrently via join_all.
-            // Note: join_all provides cooperative (tokio task) concurrency, not OS-thread
-            // parallelism. Futures yield at .await points and are scheduled by the tokio
-            // runtime. For CPU-bound tool work, the semaphore limits oversubscription.
+            // Execute futures concurrently with cancellation and MCP elicitation drain.
             let (indices, futs): (Vec<usize>, Vec<ToolExecFut>) = tier_futs.into_iter().unzip();
-
-            // Poll tier futures, cancellation, and MCP elicitation requests concurrently.
-            // Elicitation events arrive from MCP server handlers that are blocked waiting on a
-            // oneshot response. Without draining them here the tier join never completes (deadlock).
-            let tier_results = {
-                let mut join_fut = std::pin::pin!(futures::future::join_all(futs));
-                // Take elicitation_rx out of self so we can hold &mut self for handling.
-                let mut elicitation_rx = self.mcp.elicitation_rx.take();
-                let result = loop {
-                    tokio::select! {
-                        results = &mut join_fut => break results,
-                        () = cancel.cancelled() => {
-                            self.mcp.elicitation_rx = elicitation_rx;
-                            self.tool_executor.set_skill_env(None);
-                            tracing::info!("tool execution cancelled by user");
-                            self.update_metrics(|m| m.cancellations += 1);
-                            self.channel.send("[Cancelled]").await?;
-                            // Persist tombstone ToolResult for all tool_calls so the assistant ToolUse
-                            // persisted above is always paired in the DB (prevents cross-session orphan).
-                            self.persist_cancelled_tool_results(tool_calls).await;
-                            return Ok(());
-                        }
-                        event = recv_elicitation(&mut elicitation_rx) => {
-                            if let Some(ev) = event {
-                                self.handle_elicitation_event(ev).await;
-                            } else {
-                                // Channel closed — stop polling it
-                                tracing::debug!("elicitation channel closed during tier exec");
-                                elicitation_rx = None;
-                            }
-                        }
-                    }
-                };
-                self.mcp.elicitation_rx = elicitation_rx;
-                result
+            let Some(tier_results) = self.execute_tier_join(futs, cancel, tool_calls).await? else {
+                return Ok(None);
             };
 
-            // Store results and collect failed tool_use_ids for dependency propagation.
-            for (idx, result) in indices.into_iter().zip(tier_results) {
-                // IMP-02: Err(_) covers all error variants including ConfirmationRequired —
-                // no need to match individual variants. Ok(Some(out)) with "[error]" prefix
-                // covers synthetic/blocked results that arrived as Ok but signal failure.
-                let is_failed = match &result {
-                    Err(_) => true,
-                    Ok(Some(out)) => out.summary.starts_with("[error]"),
-                    Ok(None) => false,
-                };
-                if is_failed {
-                    failed_ids.insert(tool_calls[idx].id.clone());
-                }
-
-                // Store successful, non-cached results in the tool result cache.
-                // Skip if this was already a cache hit (no point caching a cached result).
-                if !is_failed
-                    && cache_hits[idx].is_none()
-                    && zeph_tools::is_cacheable(tool_calls[idx].name.as_str())
-                    && let Ok(Some(ref out)) = result
-                {
-                    let key = zeph_tools::CacheKey::new(
-                        tool_calls[idx].name.to_string(),
-                        args_hashes[idx],
-                    );
-                    self.tool_orchestrator.result_cache.put(key, out.clone());
-                }
-
-                // Record successful tool completions for the dependency graph (#2024).
-                // Only record on success (non-error) so `requires` chains work correctly.
-                if !is_failed && self.tool_state.dependency_graph.is_some() {
-                    self.tool_state
-                        .completed_tool_ids
-                        .insert(tool_calls[idx].name.to_string());
-                }
-
-                // RuntimeLayer after_tool hooks.
-                if !self.runtime.layers.is_empty() {
-                    let conv_id_str = self
-                        .memory_state
-                        .persistence
-                        .conversation_id
-                        .map(|id| id.0.to_string());
-                    let ctx = crate::runtime_layer::LayerContext {
-                        conversation_id: conv_id_str.as_deref(),
-                        turn_number: u32::try_from(self.sidequest.turn_counter).unwrap_or(u32::MAX),
-                    };
-                    for layer in &self.runtime.layers {
-                        let hook_result = std::panic::AssertUnwindSafe(layer.after_tool(
-                            &ctx,
-                            &calls[idx],
-                            &result,
-                        ))
-                        .catch_unwind()
-                        .await;
-                        if hook_result.is_err() {
-                            tracing::warn!("RuntimeLayer::after_tool panicked, continuing");
-                        }
-                    }
-                }
-
-                tool_results[idx] = result;
-            }
+            // Store results, update dependency graph, and run after_tool hooks.
+            self.apply_tier_results(
+                indices,
+                tier_results,
+                tool_calls,
+                calls,
+                cache_hits,
+                args_hashes,
+                &mut failed_ids,
+                &mut tool_results,
+            )
+            .await;
 
             if tier_count > 1 {
                 let _ = self.channel.send_status("").await;
@@ -2066,236 +2062,638 @@ impl<C: Channel> Agent<C> {
             tool_results.push(Ok(None));
         }
 
-        // Phase 2a: Handle ConfirmationRequired results.
-        // ConfirmationRequired requires an interactive channel.confirm() prompt which needs
-        // &mut self — it cannot run inside the parallel Phase 1 futures. Handled here
-        // sequentially after join_all, same as transient retry in Phase 2.
-        for idx in 0..tool_results.len() {
-            if cancel.is_cancelled() {
-                self.tool_executor.set_skill_env(None);
-                tracing::info!("tool execution cancelled by user");
-                self.update_metrics(|m| m.cancellations += 1);
-                self.channel.send("[Cancelled]").await?;
-                self.persist_cancelled_tool_results(tool_calls).await;
-                return Ok(());
-            }
+        Ok(Some(TierLoopData {
+            tool_results,
+            pending_focus_checkpoint,
+            pending_system_hints,
+        }))
+    }
 
-            let new_result =
-                if let Err(zeph_tools::ToolError::ConfirmationRequired { ref command }) =
-                    tool_results[idx]
-                {
-                    let tc = &tool_calls[idx];
-                    let prompt = if command.is_empty() {
-                        format!("Allow tool: {}?", tc.name)
-                    } else {
-                        format!("Allow command: {command}?")
-                    };
-                    Some(if self.channel.confirm(&prompt).await? {
-                        // execute_tool_call_confirmed_erased bypasses check_trust; a second
-                        // ConfirmationRequired here indicates a misconfigured executor stack
-                        // and is treated as a regular tool error.
-                        self.tool_executor
-                            .execute_tool_call_confirmed_erased(&calls[idx])
-                            .await
-                    } else {
-                        // User declined — not an error, just a cancellation.
-                        Ok(Some(zeph_tools::ToolOutput {
-                            tool_name: tc.name.clone(),
-                            summary: "[cancelled by user]".to_owned(),
-                            blocks_executed: 0,
-                            filter_stats: None,
-                            diff: None,
-                            streamed: false,
-                            terminal_id: None,
-                            locations: None,
-                            raw_response: None,
-                            claim_source: None,
-                        }))
-                    })
+    /// Pre-process focus and `compress_context` tool calls before the tier loop.
+    ///
+    /// These tools require `&mut self` and cannot run inside spawned tier futures.
+    /// Results are pre-populated in `tool_results` so the tier loop skips them.
+    /// Returns the pending focus checkpoint message, if one was produced.
+    async fn preprocess_focus_compress_calls(
+        &mut self,
+        tool_calls: &[zeph_llm::provider::ToolUseRequest],
+        tool_results: &mut [Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>],
+    ) -> Option<zeph_llm::provider::Message> {
+        let mut pending_focus_checkpoint: Option<zeph_llm::provider::Message> = None;
+        for (idx, tc) in tool_calls.iter().enumerate() {
+            let is_focus_tool = self.focus.config.enabled
+                && (tc.name == "start_focus" || tc.name == "complete_focus");
+            let is_compress = tc.name == "compress_context";
+            if is_focus_tool || is_compress {
+                let result = if is_compress {
+                    self.handle_compress_context().await
                 } else {
-                    None
+                    let (text, maybe_checkpoint) =
+                        self.handle_focus_tool(tc.name.as_str(), &tc.input);
+                    if let Some(cp) = maybe_checkpoint {
+                        pending_focus_checkpoint = Some(cp);
+                    }
+                    text
                 };
-            if let Some(result) = new_result {
-                if let Err(ref e) = result
-                    && let Some(ref d) = self.debug_state.debug_dumper
-                {
-                    d.dump_tool_error(tool_calls[idx].name.as_str(), e);
-                }
-                tool_results[idx] = result;
+                tool_results[idx] = Ok(Some(skipped_output(tc.name.clone(), result)));
             }
         }
+        pending_focus_checkpoint
+    }
 
-        // Phase 2: Sequential retry for transient failures on retryable executors.
-        // Only idempotent operations (e.g. HTTP GET via WebScrapeExecutor) are retried.
-        // Shell commands and other non-idempotent tools keep their error result as-is.
-        // Multiple transient failures are retried sequentially; parallel retry adds complexity
-        // for minimal gain in the rare case of multiple simultaneous transient failures.
-        if max_retries > 0 {
-            let max_retry_duration_secs = self.tool_orchestrator.max_retry_duration_secs;
-            let retry_base_ms = self.tool_orchestrator.retry_base_ms;
-            let retry_max_ms = self.tool_orchestrator.retry_max_ms;
-            for idx in 0..tool_results.len() {
-                if cancel.is_cancelled() {
+    /// Mark the execution start time for each call in the tier and send `ToolStartEvent`s.
+    ///
+    /// Called once per tier before futures are dispatched so that TUI timing is accurate.
+    async fn stamp_and_send_tier_start(
+        &mut self,
+        tier_indices: &[usize],
+        tool_calls: &[zeph_llm::provider::ToolUseRequest],
+        tool_call_ids: &[String],
+        tool_started_ats: &mut [std::time::Instant],
+    ) -> Result<(), super::super::error::AgentError> {
+        let tier_start = std::time::Instant::now();
+        for &idx in tier_indices {
+            tool_started_ats[idx] = tier_start;
+        }
+        for &idx in tier_indices {
+            let tc = &tool_calls[idx];
+            self.channel
+                .send_tool_start(ToolStartEvent {
+                    tool_name: tc.name.clone(),
+                    tool_call_id: tool_call_ids[idx].clone(),
+                    params: Some(tc.input.clone()),
+                    parent_tool_use_id: self.session.parent_tool_use_id.clone(),
+                    started_at: std::time::Instant::now(),
+                    speculative: false,
+                    sandbox_profile: None,
+                })
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Apply the utility gate decision for a single tool call.
+    ///
+    /// Returns `Some((idx, fut))` when the gate fires and the call should be short-circuited
+    /// (the caller must push the future and `continue`), or `None` to proceed normally.
+    /// Mutates `pending_system_hints` for Retrieve/Verify actions.
+    async fn handle_utility_gate(
+        &mut self,
+        idx: usize,
+        tc: &zeph_llm::provider::ToolUseRequest,
+        utility_actions: &[zeph_tools::UtilityAction],
+        pending_system_hints: &mut Vec<String>,
+    ) -> Result<Option<(usize, ToolExecFut)>, super::super::error::AgentError> {
+        match utility_actions[idx] {
+            zeph_tools::UtilityAction::ToolCall => Ok(None),
+            zeph_tools::UtilityAction::Respond => {
+                let _ = self
+                    .channel
+                    .send_status(&format!("Utility action: Respond ({})", tc.name))
+                    .await;
+                Ok(Some(ready_fut(
+                    idx,
+                    skipped_output(
+                        tc.name.clone(),
+                        format!(
+                            "[skipped] Tool call to {} skipped — utility policy recommends a \
+                             direct response without further tool use.",
+                            tc.name
+                        ),
+                    ),
+                )))
+            }
+            zeph_tools::UtilityAction::Retrieve => {
+                let _ = self
+                    .channel
+                    .send_status(&format!("Utility action: Retrieve ({})", tc.name))
+                    .await;
+                // Inject a system message directing the LLM to retrieve context first (#2620).
+                pending_system_hints.push(format!(
+                    "[utility:retrieve] Before executing the '{}' tool, retrieve \
+                     relevant context via memory_search or a related lookup to ensure \
+                     the call is well-targeted. After retrieving context, you MUST call \
+                     the '{}' tool again with the same arguments.",
+                    tc.name, tc.name
+                ));
+                Ok(Some(ready_fut(
+                    idx,
+                    skipped_output(
+                        tc.name.clone(),
+                        format!(
+                            "[skipped] Tool call to {} skipped — utility policy recommends \
+                             retrieving additional context first.",
+                            tc.name
+                        ),
+                    ),
+                )))
+            }
+            zeph_tools::UtilityAction::Verify => {
+                let _ = self
+                    .channel
+                    .send_status(&format!("Utility action: Verify ({})", tc.name))
+                    .await;
+                pending_system_hints.push(format!(
+                    "[utility:verify] Before executing the '{}' tool again, verify \
+                     the result of the previous tool call to confirm it is correct \
+                     and that further tool use is necessary.",
+                    tc.name
+                ));
+                Ok(Some(ready_fut(
+                    idx,
+                    skipped_output(
+                        tc.name.clone(),
+                        format!(
+                            "[skipped] Tool call to {} skipped — utility policy recommends \
+                             verifying the previous result first.",
+                            tc.name
+                        ),
+                    ),
+                )))
+            }
+            zeph_tools::UtilityAction::Stop => {
+                let _ = self
+                    .channel
+                    .send_status(&format!("Utility action: Stop ({})", tc.name))
+                    .await;
+                let threshold = self.tool_orchestrator.utility_scorer.threshold();
+                Ok(Some(ready_fut(
+                    idx,
+                    skipped_output(
+                        tc.name.clone(),
+                        format!(
+                            "[stopped] Tool call to {} halted by the utility gate — \
+                             budget exhausted or score below threshold {threshold:.2}.",
+                            tc.name
+                        ),
+                    ),
+                )))
+            }
+        }
+    }
+
+    /// Run `RuntimeLayer::before_tool` hooks for a single call.
+    ///
+    /// Returns `Some((idx, fut))` when a hook short-circuits execution (the caller must push and
+    /// `continue`), or `None` when all hooks pass and execution should proceed normally.
+    /// `PermissionDenied` hooks are fired asynchronously when a layer blocks the call.
+    async fn run_before_tool_hooks(
+        &mut self,
+        idx: usize,
+        tc: &zeph_llm::provider::ToolUseRequest,
+        call: &ToolCall,
+    ) -> Option<(usize, ToolExecFut)> {
+        if self.runtime.layers.is_empty() {
+            return None;
+        }
+        let conv_id_str = self
+            .memory_state
+            .persistence
+            .conversation_id
+            .map(|id| id.0.to_string());
+        let ctx = crate::runtime_layer::LayerContext {
+            conversation_id: conv_id_str.as_deref(),
+            turn_number: u32::try_from(self.sidequest.turn_counter).unwrap_or(u32::MAX),
+        };
+        let mut sc_result: crate::runtime_layer::BeforeToolResult = None;
+        for layer in &self.runtime.layers {
+            let hook_result = std::panic::AssertUnwindSafe(layer.before_tool(&ctx, call))
+                .catch_unwind()
+                .await;
+            match hook_result {
+                Ok(Some(r)) => {
+                    sc_result = Some(r);
+                    break;
+                }
+                Ok(None) => {}
+                Err(_) => {
+                    tracing::warn!("RuntimeLayer::before_tool panicked, continuing");
+                }
+            }
+        }
+        let r = sc_result?;
+        // Fire PermissionDenied hooks (fail_open: hook errors are logged, not fatal).
+        let pd_hooks = self.session.hooks_config.permission_denied.clone();
+        if !pd_hooks.is_empty() {
+            let _span =
+                tracing::info_span!("core.hooks.permission_denied", tool = %tc.name).entered();
+            let mut env = std::collections::HashMap::new();
+            env.insert("ZEPH_DENIED_TOOL".to_owned(), tc.name.to_string());
+            env.insert("ZEPH_DENY_REASON".to_owned(), r.reason.clone());
+            let dispatch = self.mcp_dispatch();
+            let mcp: Option<&dyn zeph_subagent::McpDispatch> = dispatch
+                .as_ref()
+                .map(|d| d as &dyn zeph_subagent::McpDispatch);
+            // TODO: implement retry-on-{"retry":true} stdout signal (#3292)
+            if let Err(e) = zeph_subagent::hooks::fire_hooks(&pd_hooks, &env, mcp).await {
+                tracing::warn!(error = %e, tool = %tc.name, "PermissionDenied hook failed");
+            }
+        }
+        Some((idx, Box::pin(std::future::ready(r.result))))
+    }
+
+    /// Check the static per-call gates in order: dependency failure, quota, pre-exec block,
+    /// utility gate action, and repeat detection.
+    ///
+    /// Returns `Some((idx, fut))` when any gate fires (the caller must push and `continue`),
+    /// or `None` when all gates pass and execution should proceed.
+    #[allow(clippy::too_many_arguments)]
+    async fn check_call_gates(
+        &mut self,
+        idx: usize,
+        tc: &zeph_llm::provider::ToolUseRequest,
+        has_failed_dep: bool,
+        quota_blocked: bool,
+        pre_exec_blocked: &[bool],
+        utility_actions: &[zeph_tools::UtilityAction],
+        repeat_blocked: &[bool],
+        pending_system_hints: &mut Vec<String>,
+    ) -> Result<Option<(usize, ToolExecFut)>, super::super::error::AgentError> {
+        if has_failed_dep {
+            return Ok(Some(ready_fut(
+                idx,
+                skipped_output(
+                    tc.name.clone(),
+                    "[error] Skipped: a prerequisite tool failed or requires confirmation",
+                ),
+            )));
+        }
+        if quota_blocked {
+            let max = self
+                .tool_orchestrator
+                .max_tool_calls_per_session
+                .unwrap_or(0);
+            return Ok(Some(ready_fut(
+                idx,
+                skipped_output(
+                    tc.name.clone(),
+                    format!(
+                        "[error] Tool call quota exceeded (session limit: {max} calls). \
+                         No further tool calls are allowed this session."
+                    ),
+                ),
+            )));
+        }
+        if pre_exec_blocked[idx] {
+            return Ok(Some(ready_fut(
+                idx,
+                skipped_output(
+                    tc.name.clone(),
+                    format!(
+                        "[error] Tool call to {} was blocked by pre-execution verifier. \
+                         The requested operation is not permitted.",
+                        tc.name
+                    ),
+                ),
+            )));
+        }
+        if let Some(fut) = self
+            .handle_utility_gate(idx, tc, utility_actions, pending_system_hints)
+            .await?
+        {
+            return Ok(Some(fut));
+        }
+        if repeat_blocked[idx] {
+            return Ok(Some(ready_fut(
+                idx,
+                skipped_output(
+                    tc.name.clone(),
+                    format!(
+                        "[error] Repeated identical call to {} detected. \
+                         Use different arguments or a different approach.",
+                        tc.name
+                    ),
+                ),
+            )));
+        }
+        Ok(None)
+    }
+
+    /// Build the execution futures for one DAG tier, applying all per-call gate checks.
+    ///
+    /// For each call in `tier_indices`, the function checks (in order): DAG dependency
+    /// failure, session quota, pre-exec block, utility gate, repeat detection, result cache,
+    /// rate limiter, and `RuntimeLayer::before_tool` hooks. Any gate that fires returns a
+    /// pre-resolved synthetic future. Calls that pass all gates get a semaphore-guarded
+    /// executor future. Returns `Err` only for channel errors from utility-gate status sends.
+    #[allow(clippy::too_many_arguments, clippy::ptr_arg)]
+    async fn build_tier_call_futures(
+        &mut self,
+        tool_calls: &[zeph_llm::provider::ToolUseRequest],
+        calls: &[ToolCall],
+        tier_indices: &[usize],
+        dag: &super::tool_call_dag::ToolCallDag,
+        failed_ids: &std::collections::HashSet<String>,
+        quota_blocked: bool,
+        pre_exec_blocked: &[bool],
+        utility_actions: &[zeph_tools::UtilityAction],
+        repeat_blocked: &[bool],
+        cache_hits: &[Option<zeph_tools::ToolOutput>],
+        semaphore: &std::sync::Arc<tokio::sync::Semaphore>,
+        pending_system_hints: &mut Vec<String>,
+    ) -> Result<Vec<(usize, ToolExecFut)>, super::super::error::AgentError> {
+        let tier_tool_names: Vec<&str> = tier_indices
+            .iter()
+            .map(|&i| tool_calls[i].name.as_str())
+            .collect();
+        let rate_results = self.runtime.rate_limiter.check_batch(&tier_tool_names);
+
+        let mut tier_futs: Vec<(usize, ToolExecFut)> = Vec::with_capacity(tier_indices.len());
+        for (tier_local_idx, &idx) in tier_indices.iter().enumerate() {
+            let tc = &tool_calls[idx];
+            let call = &calls[idx];
+
+            // Skip focus tools and compress_context — pre-handled before the tier loop.
+            if tc.name == "compress_context"
+                || (self.focus.config.enabled
+                    && (tc.name == "start_focus" || tc.name == "complete_focus"))
+            {
+                continue;
+            }
+
+            // Check static gates: dep failure, quota, pre-exec block, utility gate, repeat.
+            let has_failed_dep = dag
+                .string_values_for(idx)
+                .iter()
+                .any(|v| failed_ids.contains(v));
+            if let Some(fut) = self
+                .check_call_gates(
+                    idx,
+                    tc,
+                    has_failed_dep,
+                    quota_blocked,
+                    pre_exec_blocked,
+                    utility_actions,
+                    repeat_blocked,
+                    pending_system_hints,
+                )
+                .await?
+            {
+                tier_futs.push(fut);
+                continue;
+            }
+
+            // Cache hit: return pre-computed result without executing the tool.
+            if let Some(cached_output) = cache_hits[idx].clone() {
+                tracing::debug!(
+                    tool = %tc.name,
+                    "[tool-cache] returning cached result, skipping execution"
+                );
+                tier_futs.push((idx, Box::pin(std::future::ready(Ok(Some(cached_output))))));
+                continue;
+            }
+
+            // Rate limiter: check the pre-computed batch result for this call.
+            if let Some(ref exceeded) = rate_results[tier_local_idx] {
+                tracing::warn!(
+                    tool = %tc.name,
+                    category = exceeded.category.as_str(),
+                    limit = exceeded.limit,
+                    "tool rate limiter: blocking call"
+                );
+                self.update_metrics(|m| m.rate_limit_trips += 1);
+                self.push_security_event(
+                    crate::metrics::SecurityEventCategory::RateLimit,
+                    tc.name.as_str(),
+                    format!(
+                        "{} calls exceeded {}/min",
+                        exceeded.category.as_str(),
+                        exceeded.limit
+                    ),
+                );
+                tier_futs.push(ready_fut(
+                    idx,
+                    skipped_output(tc.name.clone(), exceeded.to_error_message()),
+                ));
+                continue;
+            }
+
+            if let Some(fut) = self.run_before_tool_hooks(idx, tc, call).await {
+                tier_futs.push(fut);
+                continue;
+            }
+
+            let sem = std::sync::Arc::clone(semaphore);
+            let executor = std::sync::Arc::clone(&self.tool_executor);
+            let call = call.clone();
+            let tool_name = tc.name.clone();
+            let tool_id = tc.id.clone();
+            let fut = async move {
+                let _permit = sem.acquire().await.map_err(|_| {
+                    zeph_tools::ToolError::Execution(std::io::Error::other(
+                        "semaphore closed during tool execution",
+                    ))
+                })?;
+                executor
+                    .execute_tool_call_erased(&call)
+                    .instrument(tracing::info_span!(
+                        "tool_exec",
+                        tool_name = %tool_name,
+                        idx = %tool_id
+                    ))
+                    .await
+            };
+            tier_futs.push((idx, Box::pin(fut)));
+        }
+        Ok(tier_futs)
+    }
+
+    /// Poll tier futures concurrently with cancellation and MCP elicitation drain.
+    ///
+    /// Returns `Ok(None)` when the user cancelled (the tier loop must `return Ok(None)`),
+    /// or `Ok(Some(results))` on completion.
+    async fn execute_tier_join(
+        &mut self,
+        futs: Vec<ToolExecFut>,
+        cancel: &tokio_util::sync::CancellationToken,
+        tool_calls: &[zeph_llm::provider::ToolUseRequest],
+    ) -> Result<
+        Option<Vec<Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>>>,
+        super::super::error::AgentError,
+    > {
+        let mut join_fut = std::pin::pin!(futures::future::join_all(futs));
+        // Take elicitation_rx out of self so we can hold &mut self for handling.
+        let mut elicitation_rx = self.mcp.elicitation_rx.take();
+        let result = loop {
+            tokio::select! {
+                results = &mut join_fut => break results,
+                () = cancel.cancelled() => {
+                    self.mcp.elicitation_rx = elicitation_rx;
                     self.tool_executor.set_skill_env(None);
                     tracing::info!("tool execution cancelled by user");
                     self.update_metrics(|m| m.cancellations += 1);
                     self.channel.send("[Cancelled]").await?;
                     self.persist_cancelled_tool_results(tool_calls).await;
-                    return Ok(());
+                    return Ok(None);
                 }
-
-                let is_transient = matches!(
-                    tool_results[idx],
-                    Err(ref e) if e.kind() == zeph_tools::ErrorKind::Transient
-                );
-                if !is_transient {
-                    continue;
-                }
-
-                let tc = &tool_calls[idx];
-                if !self
-                    .tool_executor
-                    .is_tool_retryable_erased(tc.name.as_str())
-                {
-                    continue;
-                }
-
-                let call = &calls[idx];
-                let mut attempt = 0_usize;
-                let retry_start = std::time::Instant::now();
-                let result = loop {
-                    let exec_result = tokio::select! {
-                        r = self.tool_executor.execute_tool_call_erased(call).instrument(
-                            tracing::info_span!("tool_exec_retry", tool_name = %tc.name, idx = %tc.id)
-                        ) => r,
-                        () = cancel.cancelled() => {
-                            self.tool_executor.set_skill_env(None);
-                            tracing::info!("tool retry cancelled by user");
-                            self.update_metrics(|m| m.cancellations += 1);
-                            self.channel.send("[Cancelled]").await?;
-                            self.persist_cancelled_tool_results(tool_calls).await;
-                            return Ok(());
-                        }
-                    };
-
-                    match exec_result {
-                        Err(ref e)
-                            if e.kind() == zeph_tools::ErrorKind::Transient
-                                && attempt < max_retries =>
-                        {
-                            let elapsed_secs = retry_start.elapsed().as_secs();
-                            if max_retry_duration_secs > 0
-                                && elapsed_secs >= max_retry_duration_secs
-                            {
-                                tracing::warn!(
-                                    tool = %tc.name,
-                                    elapsed_secs,
-                                    max_retry_duration_secs,
-                                    "tool retry budget exceeded, aborting retries"
-                                );
-                                break exec_result;
-                            }
-                            attempt += 1;
-                            let delay_ms =
-                                retry_backoff_ms(attempt - 1, retry_base_ms, retry_max_ms);
-                            tracing::warn!(
-                                tool = %tc.name,
-                                attempt,
-                                delay_ms,
-                                error = %e,
-                                "transient tool error, retrying with backoff"
-                            );
-                            let _ = self
-                                .channel
-                                .send_status(&format!("Retrying {}...", tc.name))
-                                .await;
-                            // Interruptible backoff sleep: cancelled if agent shuts down.
-                            tokio::select! {
-                                () = tokio::time::sleep(std::time::Duration::from_millis(delay_ms)) => {}
-                                () = cancel.cancelled() => {
-                                    self.tool_executor.set_skill_env(None);
-                                    tracing::info!("retry backoff interrupted by cancellation");
-                                    self.update_metrics(|m| m.cancellations += 1);
-                                    self.channel.send("[Cancelled]").await?;
-                                    return Ok(());
-                                }
-                            }
-                            let _ = self.channel.send_status("").await;
-                            // NOTE: retry re-executions are NOT recorded in repeat-detection (CRIT-3).
-                        }
-                        result => break result,
+                event = recv_elicitation(&mut elicitation_rx) => {
+                    if let Some(ev) = event {
+                        self.handle_elicitation_event(ev).await;
+                    } else {
+                        tracing::debug!("elicitation channel closed during tier exec");
+                        elicitation_rx = None;
                     }
+                }
+            }
+        };
+        self.mcp.elicitation_rx = elicitation_rx;
+        Ok(Some(result))
+    }
+
+    /// Store tier execution results, update the dependency-failure set, prime the result cache,
+    /// update the dependency graph, and run `RuntimeLayer::after_tool` hooks.
+    #[allow(clippy::too_many_arguments)]
+    async fn apply_tier_results(
+        &mut self,
+        indices: Vec<usize>,
+        tier_results: Vec<Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>>,
+        tool_calls: &[zeph_llm::provider::ToolUseRequest],
+        calls: &[ToolCall],
+        cache_hits: &[Option<zeph_tools::ToolOutput>],
+        args_hashes: &[u64],
+        failed_ids: &mut std::collections::HashSet<String>,
+        tool_results: &mut [Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>],
+    ) {
+        for (idx, result) in indices.into_iter().zip(tier_results) {
+            // IMP-02: Err(_) covers all error variants including ConfirmationRequired.
+            // Ok(Some(out)) with "[error]" prefix covers synthetic/blocked results.
+            let is_failed = match &result {
+                Err(_) => true,
+                Ok(Some(out)) => out.summary.starts_with("[error]"),
+                Ok(None) => false,
+            };
+            if is_failed {
+                failed_ids.insert(tool_calls[idx].id.clone());
+            }
+
+            // Store successful, non-cached results in the tool result cache.
+            if !is_failed
+                && cache_hits[idx].is_none()
+                && zeph_tools::is_cacheable(tool_calls[idx].name.as_str())
+                && let Ok(Some(ref out)) = result
+            {
+                let key =
+                    zeph_tools::CacheKey::new(tool_calls[idx].name.to_string(), args_hashes[idx]);
+                self.tool_orchestrator.result_cache.put(key, out.clone());
+            }
+
+            // Record successful tool completions for the dependency graph (#2024).
+            if !is_failed && self.tool_state.dependency_graph.is_some() {
+                self.tool_state
+                    .completed_tool_ids
+                    .insert(tool_calls[idx].name.to_string());
+            }
+
+            // RuntimeLayer after_tool hooks.
+            if !self.runtime.layers.is_empty() {
+                let conv_id_str = self
+                    .memory_state
+                    .persistence
+                    .conversation_id
+                    .map(|id| id.0.to_string());
+                let ctx = crate::runtime_layer::LayerContext {
+                    conversation_id: conv_id_str.as_deref(),
+                    turn_number: u32::try_from(self.sidequest.turn_counter).unwrap_or(u32::MAX),
                 };
-                tool_results[idx] = result;
+                for layer in &self.runtime.layers {
+                    let hook_result =
+                        std::panic::AssertUnwindSafe(layer.after_tool(&ctx, &calls[idx], &result))
+                            .catch_unwind()
+                            .await;
+                    if hook_result.is_err() {
+                        tracing::warn!("RuntimeLayer::after_tool panicked, continuing");
+                    }
+                }
             }
+
+            tool_results[idx] = result;
         }
+    }
 
-        // Phase 3: Parameter reformat path for InvalidParameters / TypeMismatch errors.
-        //
-        // When `parameter_reformat_provider` is configured, ask a (cheap) LLM provider to
-        // reformat the tool arguments and retry ONCE. If the reformat call or the retry fails,
-        // the original error is kept. This path is budget-aware: we check the same
-        // `budget_secs` wall-clock limit that applies to transient retries.
-        //
-        // Cancellation safety (B3): both the reformat LLM call and the retry execution are
-        // wrapped in `tokio::select!` with the cancellation token, matching the pattern from
-        // Phase 2. On cancellation, a synthetic error `tool_result` is persisted before returning
-        // so the TOOL_RESULT_GUARANTEE invariant is upheld for every `tool_call_id`.
-        if !self
-            .tool_orchestrator
-            .parameter_reformat_provider
-            .is_empty()
-        {
-            let budget_secs = self.tool_orchestrator.max_retry_duration_secs;
-            for idx in 0..tool_results.len() {
-                if cancel.is_cancelled() {
-                    self.tool_executor.set_skill_env(None);
-                    tracing::info!("parameter reformat phase cancelled by user");
-                    self.update_metrics(|m| m.cancellations += 1);
-                    self.channel.send("[Cancelled]").await?;
-                    self.persist_cancelled_tool_results(tool_calls).await;
-                    return Ok(());
+    /// Run the causal IPI post-probe after tool batch execution.
+    ///
+    /// Collects sanitized snippets from `result_parts`, runs the behavioral post-probe,
+    /// and logs a security event if the deviation exceeds the analyzer threshold.
+    /// No-op when `causal_pre_response` is `None` or no causal analyzer is configured.
+    async fn run_causal_ipi_post_probe(
+        &mut self,
+        causal_pre_response: Option<(String, String)>,
+        result_parts: &[MessagePart],
+    ) {
+        let Some((pre_response, context_summary)) = causal_pre_response else {
+            return;
+        };
+        let snippets: Vec<String> = result_parts
+            .iter()
+            .filter_map(|p| {
+                if let MessagePart::ToolResult {
+                    content, is_error, ..
+                } = p
+                {
+                    if *is_error {
+                        Some(zeph_sanitizer::causal_ipi::format_error_snippet(content))
+                    } else {
+                        Some(zeph_sanitizer::causal_ipi::format_tool_snippet(content))
+                    }
+                } else {
+                    None
                 }
-
-                let needs_reformat = matches!(
-                    tool_results[idx],
-                    Err(ref e) if e.category().needs_parameter_reformat()
-                );
-                if !needs_reformat {
-                    continue;
-                }
-
-                let tc = &tool_calls[idx];
-                let reformat_start = std::time::Instant::now();
-                tracing::warn!(
-                    tool = %tc.name,
-                    "parameter error detected; parameter reformat path is reserved for future LLM-based reformat implementation"
-                );
-
-                // Budget check: if the wall-clock budget is already exhausted, skip.
-                if budget_secs > 0 && reformat_start.elapsed().as_secs() >= budget_secs {
+            })
+            .collect();
+        let tool_snippets = if snippets.is_empty() {
+            "[empty]".to_owned()
+        } else {
+            snippets.join("---")
+        };
+        let Some(ref analyzer) = self.security.causal_analyzer else {
+            return;
+        };
+        match analyzer.post_probe(&context_summary, &tool_snippets).await {
+            Ok(post_response) => {
+                let analysis = analyzer.analyze(&pre_response, &post_response);
+                if analysis.is_flagged {
+                    let pre_excerpt = &pre_response[..pre_response.floor_char_boundary(100)];
+                    let post_excerpt = &post_response[..post_response.floor_char_boundary(100)];
                     tracing::warn!(
-                        tool = %tc.name,
-                        "parameter reformat budget exhausted, skipping"
+                        deviation_score = analysis.deviation_score,
+                        threshold = analyzer.threshold(),
+                        pre = %pre_excerpt,
+                        post = %post_excerpt,
+                        "causal IPI: behavioral deviation detected at tool-return boundary"
                     );
-                    continue;
+                    self.update_metrics(|m| m.causal_ipi_flags += 1);
+                    self.push_security_event(
+                        crate::metrics::SecurityEventCategory::CausalIpiFlag,
+                        "tool_batch",
+                        format!("deviation={:.3}", analysis.deviation_score),
+                    );
                 }
-
-                // The reformat LLM call and retry are placeholders — the actual provider
-                // resolution and prompt construction will be implemented in a follow-up once
-                // the provider registry lookup API stabilizes. For now, we log and skip
-                // so the original error is propagated unchanged to the LLM as structured feedback.
-                let _ = self
-                    .channel
-                    .send_status(&format!(
-                        "Reformat for {} pending provider integration…",
-                        tc.name
-                    ))
-                    .await;
-                let _ = self.channel.send_status("").await;
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "causal IPI post-probe failed, skipping analysis");
             }
         }
+    }
 
+    /// Process tool results after all tiers have completed.
+    ///
+    /// Clears skill env, syncs cache counters, processes each result (metrics, channel
+    /// display, VIGIL gate, sanitization, skill outcomes), flushes outcomes, runs causal
+    /// post-probe, persists the `User{ToolResults}` message, fires deferred self-reflection,
+    /// runs LSP hooks, and checks for cwd changes.
+    ///
+    /// Separated from `handle_native_tool_calls` to keep that function under the line limit.
+    #[allow(clippy::too_many_arguments)]
+    async fn process_tool_result_batch(
+        &mut self,
+        tool_calls: &[zeph_llm::provider::ToolUseRequest],
+        tool_call_ids: &[String],
+        tool_started_ats: &[std::time::Instant],
+        mut tool_results: Vec<Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>>,
+        causal_pre_response: Option<(String, String)>,
+        pending_focus_checkpoint: Option<zeph_llm::provider::Message>,
+        pending_system_hints: Vec<String>,
+    ) -> Result<(), super::super::error::AgentError> {
         self.tool_executor.set_skill_env(None);
 
         // Sync cache counters to metrics after all tool execution is complete.
@@ -2332,381 +2730,18 @@ impl<C: Channel> Agent<C> {
             let tool_call_id = &tool_call_ids[idx];
             let started_at = &tool_started_ats[idx];
             let tool_result = std::mem::replace(&mut tool_results[idx], Ok(None));
-            let anomaly_outcome;
-            // True only for InvalidParams errors — semantic failures attributable to model quality.
-            // Network, transient, timeout, and policy errors are excluded.
-            let is_quality_failure;
-            // Set to true when tool completes without error; deferred past VIGIL gate so that
-            // a VIGIL block suppresses the success outcome (CR-5: no double skill-outcome).
-            let mut tool_succeeded = false;
-            let mut tool_err_category: Option<zeph_tools::error_taxonomy::ToolErrorCategory> = None;
-            let (output, mut is_error, diff, inline_stats, _, kept_lines, locations) =
-                match tool_result {
-                    Ok(Some(out)) => {
-                        is_quality_failure = false;
-                        anomaly_outcome = if out.summary.contains("[error]")
-                            || out.summary.contains("[stderr]")
-                        {
-                            AnomalyOutcome::Error
-                        } else {
-                            AnomalyOutcome::Success
-                        };
-                        if let Some(ref fs) = out.filter_stats {
-                            self.record_filter_metrics(fs);
-                        }
-                        let inline_stats = out.filter_stats.as_ref().and_then(|fs| {
-                            (fs.filtered_chars < fs.raw_chars)
-                                .then(|| fs.format_inline(tc.name.as_str()))
-                        });
-                        let kept = out.filter_stats.as_ref().and_then(|fs| {
-                            (!fs.kept_lines.is_empty()).then(|| fs.kept_lines.clone())
-                        });
-                        let streamed = out.streamed;
-                        let locations = out.locations;
-                        (
-                            out.summary,
-                            false,
-                            out.diff,
-                            inline_stats,
-                            streamed,
-                            kept,
-                            locations,
-                        )
-                    }
-                    Ok(None) => {
-                        is_quality_failure = false;
-                        anomaly_outcome = AnomalyOutcome::Success;
-                        (
-                            "(no output)".to_owned(),
-                            false,
-                            None,
-                            None,
-                            false,
-                            None,
-                            None,
-                        )
-                    }
-                    Err(ref e) => {
-                        let category = e.category();
-                        // Quality failures are errors attributable to LLM output (invalid params,
-                        // type mismatch, tool not found). Infrastructure errors (network, timeout,
-                        // server, rate limit) are not the model's fault.
-                        is_quality_failure = category.is_quality_failure();
-                        tool_err_category = Some(category);
-                        anomaly_outcome = if matches!(e, zeph_tools::ToolError::Blocked { .. }) {
-                            AnomalyOutcome::Blocked
-                        } else if is_quality_failure
-                            && zeph_tools::is_reasoning_model(self.provider.name())
-                        {
-                            AnomalyOutcome::ReasoningQualityFailure {
-                                model: self.provider.name().to_owned(),
-                                tool: tc.name.to_string(),
-                            }
-                        } else {
-                            AnomalyOutcome::Error
-                        };
-                        if let Some(ref d) = self.debug_state.debug_dumper {
-                            d.dump_tool_error(tc.name.as_str(), e);
-                        }
-                        // Count memory write validation rejections.
-                        if tc.name == "memory_save"
-                            && matches!(e, zeph_tools::ToolError::InvalidParams { .. })
-                            && e.to_string().contains("memory write rejected")
-                        {
-                            self.update_metrics(|m| m.memory_validation_failures += 1);
-                            self.push_security_event(
-                                crate::metrics::SecurityEventCategory::MemoryValidation,
-                                "memory_save",
-                                e.to_string(),
-                            );
-                        }
-                        let feedback = zeph_tools::ToolErrorFeedback {
-                            category,
-                            message: e.to_string(),
-                            retryable: category.is_retryable(),
-                        };
-                        (
-                            feedback.format_for_llm(),
-                            true,
-                            None,
-                            None,
-                            false,
-                            None,
-                            None,
-                        )
-                    }
-                };
-
-            if let Some(ref recorder) = self.metrics.histogram_recorder {
-                recorder.observe_tool_execution(started_at.elapsed());
-            }
-
-            // CR-01: emit a tool span for each completed tool call.
-            if let Some(ref mut trace_coll) = self.debug_state.trace_collector
-                && let Some(iter_span_id) = self.debug_state.current_iteration_span_id
-            {
-                let latency = u64::try_from(started_at.elapsed().as_millis()).unwrap_or(u64::MAX);
-                let guard =
-                    trace_coll.begin_tool_call_at(tc.name.as_str(), iter_span_id, started_at);
-                let error_kind = if is_error {
-                    Some(output.chars().take(200).collect::<String>())
-                } else {
-                    None
-                };
-                trace_coll.end_tool_call(
-                    guard,
-                    tc.name.as_str(),
-                    crate::debug_dump::trace::ToolAttributes {
-                        latency_ms: latency,
-                        is_error,
-                        error_kind,
-                    },
-                );
-            }
-
-            // Record skill learning outcomes for the native tool path (mirrors legacy path in
-            // handle_tool_result). Capture the first eligible error for deferred self_reflection
-            // (called after user_msg is pushed to history to preserve API message ordering).
-            if output.contains("[error]") || output.contains("[exit code") {
-                let kind = tool_err_category
-                    .take()
-                    .map_or_else(|| FailureKind::from_error(&output), FailureKind::from);
-                pending_outcomes.push(crate::agent::learning::PendingSkillOutcome {
-                    outcome: "tool_failure".into(),
-                    error_context: Some(output.clone()),
-                    outcome_detail: Some(kind.as_str().into()),
-                });
-                // Record quality failure for reputation scoring only when the model produced
-                // invalid tool arguments (semantic failure). Network errors and transient
-                // failures are not attributable to model quality.
-                if is_quality_failure {
-                    self.provider
-                        .record_quality_outcome(self.provider.name(), false);
-                }
-                // Self-reflection is only useful for quality failures (LLM produced wrong params,
-                // used wrong tool name, etc.). Infrastructure errors (network, timeout, server,
-                // rate limit) are not attributable to LLM output — reflecting on them wastes
-                // tokens without improving future behavior. This is a behavioral change from the
-                // prior implementation which triggered reflection for any [error]-prefixed output.
-                if pending_reflection.is_none()
-                    && !self.learning_engine.was_reflection_used()
-                    && is_quality_failure
-                {
-                    // Sanitize before passing to self_reflection: tool output from native calls
-                    // can contain untrusted content with injection patterns.
-                    let sanitized_out = self
-                        .security
-                        .sanitizer
-                        .sanitize(&output, ContentSource::new(ContentSourceKind::ToolResult))
-                        .body;
-                    pending_reflection = Some(sanitized_out);
-                }
-            } else {
-                tool_succeeded = true;
-            }
-            // Ignore channel errors so ToolResult assembly is never abandoned (#2197 secondary).
-            let _ = self.record_anomaly_outcome(anomaly_outcome).await;
-
-            // read_overflow returns the full stored content and must not be re-overflowed.
-            let processed = if tc.name == OverflowToolExecutor::TOOL_NAME {
-                output.clone()
-            } else {
-                self.maybe_summarize_tool_output(&output).await
-            };
-            let body = if let Some(ref stats) = inline_stats {
-                format!("{stats}\n{processed}")
-            } else {
-                processed.clone()
-            };
-            let body_display = self.maybe_redact(&body);
-            self.channel
-                .send_tool_output(ToolOutputEvent {
-                    tool_name: tc.name.clone(),
-                    display: body_display.into_owned(),
-                    diff,
-                    filter_stats: inline_stats,
-                    kept_lines,
-                    locations,
-                    tool_call_id: tool_call_id.clone(),
-                    is_error,
-                    terminal_id: None,
-                    parent_tool_use_id: self.session.parent_tool_use_id.clone(),
-                    raw_response: None,
-                    started_at: Some(*started_at),
-                })
-                .await?;
-
-            // VIGIL pre-sanitizer gate: check tool output for injection patterns before
-            // inserting into LLM context. Subagents (parent_tool_use_id.is_some()) are
-            // exempt — the gate is also absent for subagents (SecurityState::vigil = None).
-            let (processed, vigil_outcome) = self.run_vigil_gate(tc.name.as_str(), processed);
-
-            // Emit audit entry for VIGIL block/sanitize so the operator has a correlated
-            // record in the JSONL trail (CR-4). error_category = "vigil_blocked" is
-            // intentionally non-retryable — the retry gate skips non-transient errors.
-            if let (Some(vo), Some(logger)) = (
-                vigil_outcome
-                    .as_ref()
-                    .filter(|v| !matches!(v, super::VigilOutcome::Clean)),
-                self.tool_orchestrator.audit_logger.as_ref(),
-            ) {
-                let (vigil_risk, audit_result, err_cat) = if vo.is_blocked() {
-                    (
-                        Some(zeph_tools::VigilRiskLevel::High),
-                        zeph_tools::AuditResult::Blocked {
-                            reason: "vigil_blocked".into(),
-                        },
-                        "vigil_blocked",
-                    )
-                } else {
-                    (
-                        Some(zeph_tools::VigilRiskLevel::Medium),
-                        zeph_tools::AuditResult::Success,
-                        "vigil_sanitized",
-                    )
-                };
-                let entry = zeph_tools::AuditEntry {
-                    timestamp: zeph_tools::chrono_now(),
-                    tool: tc.name.clone(),
-                    command: String::new(),
-                    result: audit_result,
-                    duration_ms: 0,
-                    error_category: Some(err_cat.to_owned()),
-                    error_domain: Some("security".to_owned()),
-                    error_phase: None,
-                    claim_source: None,
-                    mcp_server_id: None,
-                    injection_flagged: false,
-                    embedding_anomalous: false,
-                    cross_boundary_mcp_to_acp: false,
-                    adversarial_policy_decision: None,
-                    exit_code: None,
-                    truncated: false,
-                    caller_id: None,
-                    policy_match: None,
-                    correlation_id: None,
-                    vigil_risk,
-                };
-                let logger = std::sync::Arc::clone(logger);
-                self.lifecycle.supervisor.spawn(
-                    super::super::agent_supervisor::TaskClass::Telemetry,
-                    "vigil-audit-log",
-                    async move { logger.log(&entry).await },
-                );
-            }
-
-            // Sanitize tool output before inserting into LLM message history (Bug #1490 fix).
-            // sanitize_tool_output is the sole sanitization point for tool output data flows.
-            // channel send above uses body_display (redacted for privacy); LLM sees sanitize_tool_output output.
-            let (llm_content, tool_had_injection_flags) = match &vigil_outcome {
-                Some(super::VigilOutcome::Blocked { sentinel, .. }) => {
-                    // Block path: early return — ContentSanitizer is bypassed (injection_flags
-                    // counter NOT incremented; VIGIL already emitted VigilFlag event).
-                    is_error = true;
-                    (sentinel.clone(), false)
-                }
-                _ => {
-                    self.sanitize_tool_output(&processed, tc.name.as_str())
-                        .await
-                }
-            };
-            has_any_injection_flags |= tool_had_injection_flags;
-
-            // Capture tool call details for LSP hooks before building result part.
-            // Blocked outputs are excluded (FR-012: skip LSP, skill self-learning, response cache).
-            let vigil_blocked = vigil_outcome
-                .as_ref()
-                .is_some_and(super::VigilOutcome::is_blocked);
-            if !is_error && !vigil_blocked {
-                lsp_tool_calls.push((tc.name.to_string(), tc.input.clone(), llm_content.clone()));
-            }
-
-            // Emit skill outcome after VIGIL gate so a block suppresses the success outcome.
-            if vigil_blocked {
-                // SecurityBlocked must not pollute skill quality scores (FR-006).
-                pending_outcomes.push(crate::agent::learning::PendingSkillOutcome {
-                    outcome: FailureKind::SecurityBlocked.as_str().into(),
-                    error_context: Some("VIGIL blocked tool output".into()),
-                    outcome_detail: None,
-                });
-            } else if tool_succeeded {
-                pending_outcomes.push(crate::agent::learning::PendingSkillOutcome {
-                    outcome: "success".into(),
-                    error_context: None,
-                    outcome_detail: None,
-                });
-                self.provider
-                    .record_quality_outcome(self.provider.name(), true);
-            }
-
-            // Experience memory: record tool outcome (fire-and-forget). Skip when
-            // conversation_id is None (pre-persistence turn) to avoid collisions on a
-            // synthetic session_id across agent starts.
-            if let Some(memory) = self.memory_state.persistence.memory.as_ref()
-                && let Some(experience) = memory.experience.as_ref()
-                && let Some(conversation_id) = self.memory_state.persistence.conversation_id
-            {
-                let (outcome, detail, error_ctx): (&'static str, Option<String>, Option<String>) =
-                    if vigil_blocked {
-                        (
-                            "blocked",
-                            Some("vigil".to_owned()),
-                            Some(truncate_utf8(&llm_content, 256)),
-                        )
-                    } else if is_error {
-                        (
-                            "error",
-                            tool_err_category.as_ref().map(|c| format!("{c:?}")),
-                            Some(truncate_utf8(&llm_content, 256)),
-                        )
-                    } else if tool_succeeded {
-                        ("success", None, None)
-                    } else {
-                        ("unknown", None, None)
-                    };
-
-                let exp = std::sync::Arc::clone(experience);
-                let session_id = conversation_id.0.to_string();
-                let turn = i64::try_from(self.sidequest.turn_counter).unwrap_or(i64::MAX);
-                let tool_name = tc.name.to_string();
-                let accepted = self.lifecycle.supervisor.spawn(
-                    super::super::agent_supervisor::TaskClass::Telemetry,
-                    "experience-record",
-                    async move {
-                        if let Err(e) = exp
-                            .record_tool_outcome(
-                                &session_id,
-                                turn,
-                                &tool_name,
-                                outcome,
-                                detail.as_deref(),
-                                error_ctx.as_deref(),
-                            )
-                            .await
-                        {
-                            tracing::warn!(
-                                tool = %tool_name,
-                                outcome = %outcome,
-                                error = %e,
-                                "experience: record_tool_outcome failed",
-                            );
-                        }
-                    },
-                );
-                if !accepted {
-                    tracing::warn!(
-                        tool = %tc.name,
-                        outcome = %outcome,
-                        "experience-record dropped (telemetry class at capacity)",
-                    );
-                }
-            }
-
-            result_parts.push(MessagePart::ToolResult {
-                tool_use_id: tc.id.clone(),
-                content: llm_content,
-                is_error,
-            });
+            self.process_one_tool_result(
+                tc,
+                tool_call_id,
+                started_at,
+                tool_result,
+                &mut result_parts,
+                &mut lsp_tool_calls,
+                &mut has_any_injection_flags,
+                &mut pending_reflection,
+                &mut pending_outcomes,
+            )
+            .await?;
         }
 
         // Flush all accumulated skill outcomes from the tool batch in a single pass.
@@ -2714,62 +2749,8 @@ impl<C: Channel> Agent<C> {
         // SQLite awaits (#2770).
         self.flush_skill_outcomes(pending_outcomes).await;
 
-        // Causal IPI post-probe: compare behavioral state after tool batch results.
-        // Uses tool output snippets (first 200 chars each) — never the full sanitized content.
-        if let Some((pre_response, context_summary)) = causal_pre_response {
-            // Collect snippets from the sanitized content in result_parts.
-            let snippets: Vec<String> = result_parts
-                .iter()
-                .filter_map(|p| {
-                    if let MessagePart::ToolResult {
-                        content, is_error, ..
-                    } = p
-                    {
-                        if *is_error {
-                            Some(zeph_sanitizer::causal_ipi::format_error_snippet(content))
-                        } else {
-                            Some(zeph_sanitizer::causal_ipi::format_tool_snippet(content))
-                        }
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-            let tool_snippets = if snippets.is_empty() {
-                "[empty]".to_owned()
-            } else {
-                snippets.join("---")
-            };
-            if let Some(ref analyzer) = self.security.causal_analyzer {
-                match analyzer.post_probe(&context_summary, &tool_snippets).await {
-                    Ok(post_response) => {
-                        let analysis = analyzer.analyze(&pre_response, &post_response);
-                        if analysis.is_flagged {
-                            let pre_excerpt =
-                                &pre_response[..pre_response.floor_char_boundary(100)];
-                            let post_excerpt =
-                                &post_response[..post_response.floor_char_boundary(100)];
-                            tracing::warn!(
-                                deviation_score = analysis.deviation_score,
-                                threshold = analyzer.threshold(),
-                                pre = %pre_excerpt,
-                                post = %post_excerpt,
-                                "causal IPI: behavioral deviation detected at tool-return boundary"
-                            );
-                            self.update_metrics(|m| m.causal_ipi_flags += 1);
-                            self.push_security_event(
-                                crate::metrics::SecurityEventCategory::CausalIpiFlag,
-                                "tool_batch",
-                                format!("deviation={:.3}", analysis.deviation_score),
-                            );
-                        }
-                    }
-                    Err(e) => {
-                        tracing::warn!(error = %e, "causal IPI post-probe failed, skipping analysis");
-                    }
-                }
-            }
-        }
+        self.run_causal_ipi_post_probe(causal_pre_response, &result_parts)
+            .await;
 
         let user_msg = Message::from_parts(Role::User, result_parts);
         // flagged_urls accumulates across ALL tools in this batch (cross-tool trust boundary).
@@ -2866,14 +2847,436 @@ impl<C: Channel> Agent<C> {
         // future code path that calls set_current_dir.
         self.check_cwd_changed().await;
 
-        let tool_exec_ms = u64::try_from(t_tool_exec.elapsed().as_millis()).unwrap_or(u64::MAX);
-        tracing::debug!(ms = tool_exec_ms, "turn timing: tool_exec done");
-        self.metrics.pending_timings.tool_exec_ms = self
-            .metrics
-            .pending_timings
-            .tool_exec_ms
-            .saturating_add(tool_exec_ms);
+        Ok(())
+    }
 
+    /// Spawn an audit log entry for a non-clean VIGIL verdict on a tool output.
+    ///
+    /// No-op when the verdict is `Clean` or no audit logger is configured.
+    fn fire_vigil_audit_entry(
+        &mut self,
+        tool_name: &str,
+        vigil_outcome: Option<&super::VigilOutcome>,
+    ) {
+        let (Some(vo), Some(logger)) = (
+            vigil_outcome.filter(|v| !matches!(v, super::VigilOutcome::Clean)),
+            self.tool_orchestrator.audit_logger.as_ref(),
+        ) else {
+            return;
+        };
+        let (vigil_risk, audit_result, err_cat) = if vo.is_blocked() {
+            (
+                Some(zeph_tools::VigilRiskLevel::High),
+                zeph_tools::AuditResult::Blocked {
+                    reason: "vigil_blocked".into(),
+                },
+                "vigil_blocked",
+            )
+        } else {
+            (
+                Some(zeph_tools::VigilRiskLevel::Medium),
+                zeph_tools::AuditResult::Success,
+                "vigil_sanitized",
+            )
+        };
+        let entry = zeph_tools::AuditEntry {
+            timestamp: zeph_tools::chrono_now(),
+            tool: tool_name.to_owned().into(),
+            command: String::new(),
+            result: audit_result,
+            duration_ms: 0,
+            error_category: Some(err_cat.to_owned()),
+            error_domain: Some("security".to_owned()),
+            error_phase: None,
+            claim_source: None,
+            mcp_server_id: None,
+            injection_flagged: false,
+            embedding_anomalous: false,
+            cross_boundary_mcp_to_acp: false,
+            adversarial_policy_decision: None,
+            exit_code: None,
+            truncated: false,
+            caller_id: None,
+            policy_match: None,
+            correlation_id: None,
+            vigil_risk,
+        };
+        let logger = std::sync::Arc::clone(logger);
+        self.lifecycle.supervisor.spawn(
+            super::super::agent_supervisor::TaskClass::Telemetry,
+            "vigil-audit-log",
+            async move { logger.log(&entry).await },
+        );
+    }
+
+    /// Spawn a fire-and-forget task to record this tool call's outcome in the experience store.
+    ///
+    /// No-op when experience memory is not configured or no active conversation ID exists.
+    fn record_tool_experience(
+        &mut self,
+        tool_name: &str,
+        vigil_blocked: bool,
+        is_error: bool,
+        tool_succeeded: bool,
+        tool_err_category: Option<&zeph_tools::error_taxonomy::ToolErrorCategory>,
+        llm_content: &str,
+    ) {
+        let Some(memory) = self.memory_state.persistence.memory.as_ref() else {
+            return;
+        };
+        let Some(experience) = memory.experience.as_ref() else {
+            return;
+        };
+        let Some(conversation_id) = self.memory_state.persistence.conversation_id else {
+            return;
+        };
+        let (outcome, detail, error_ctx): (&'static str, Option<String>, Option<String>) =
+            if vigil_blocked {
+                (
+                    "blocked",
+                    Some("vigil".to_owned()),
+                    Some(truncate_utf8(llm_content, 256)),
+                )
+            } else if is_error {
+                (
+                    "error",
+                    tool_err_category.map(|c| format!("{c:?}")),
+                    Some(truncate_utf8(llm_content, 256)),
+                )
+            } else if tool_succeeded {
+                ("success", None, None)
+            } else {
+                ("unknown", None, None)
+            };
+        let exp = std::sync::Arc::clone(experience);
+        let session_id = conversation_id.0.to_string();
+        let turn = i64::try_from(self.sidequest.turn_counter).unwrap_or(i64::MAX);
+        let tool_name_owned = tool_name.to_owned();
+        let accepted = self.lifecycle.supervisor.spawn(
+            super::super::agent_supervisor::TaskClass::Telemetry,
+            "experience-record",
+            async move {
+                if let Err(e) = exp
+                    .record_tool_outcome(
+                        &session_id,
+                        turn,
+                        &tool_name_owned,
+                        outcome,
+                        detail.as_deref(),
+                        error_ctx.as_deref(),
+                    )
+                    .await
+                {
+                    tracing::warn!(
+                        tool = %tool_name_owned, outcome = %outcome, error = %e,
+                        "experience: record_tool_outcome failed",
+                    );
+                }
+            },
+        );
+        if !accepted {
+            tracing::warn!(
+                tool = %tool_name, outcome = %outcome,
+                "experience-record dropped (telemetry class at capacity)",
+            );
+        }
+    }
+
+    /// Record histogram and trace-collector telemetry for a completed tool call.
+    ///
+    /// No-op when no histogram recorder or trace collector is configured.
+    fn record_tool_execution_telemetry(
+        &mut self,
+        tool_name: &str,
+        started_at: &std::time::Instant,
+        is_error: bool,
+        output: &str,
+    ) {
+        if let Some(ref recorder) = self.metrics.histogram_recorder {
+            recorder.observe_tool_execution(started_at.elapsed());
+        }
+        if let Some(ref mut trace_coll) = self.debug_state.trace_collector
+            && let Some(iter_span_id) = self.debug_state.current_iteration_span_id
+        {
+            let latency = u64::try_from(started_at.elapsed().as_millis()).unwrap_or(u64::MAX);
+            let guard = trace_coll.begin_tool_call_at(tool_name, iter_span_id, started_at);
+            let error_kind = is_error.then(|| output.chars().take(200).collect::<String>());
+            trace_coll.end_tool_call(
+                guard,
+                tool_name,
+                crate::debug_dump::trace::ToolAttributes {
+                    latency_ms: latency,
+                    is_error,
+                    error_kind,
+                },
+            );
+        }
+    }
+
+    /// Record failure-path skill outcomes and set up deferred self-reflection.
+    ///
+    /// Returns `true` if the tool succeeded (no `[error]` / `[exit code]` in output),
+    /// `false` if the failure path was taken. `tool_err_category` is consumed via `take()`
+    /// so subsequent callers see `None` after this call.
+    fn handle_tool_failure_outcomes(
+        &mut self,
+        output: &str,
+        tool_err_category: &mut Option<zeph_tools::error_taxonomy::ToolErrorCategory>,
+        is_quality_failure: bool,
+        pending_outcomes: &mut Vec<crate::agent::learning::PendingSkillOutcome>,
+        pending_reflection: &mut Option<String>,
+    ) -> bool {
+        if output.contains("[error]") || output.contains("[exit code") {
+            let kind = tool_err_category
+                .take()
+                .map_or_else(|| FailureKind::from_error(output), FailureKind::from);
+            pending_outcomes.push(crate::agent::learning::PendingSkillOutcome {
+                outcome: "tool_failure".into(),
+                error_context: Some(output.to_owned()),
+                outcome_detail: Some(kind.as_str().into()),
+            });
+            if is_quality_failure {
+                self.provider
+                    .record_quality_outcome(self.provider.name(), false);
+            }
+            if pending_reflection.is_none()
+                && !self.learning_engine.was_reflection_used()
+                && is_quality_failure
+            {
+                let sanitized_out = self
+                    .security
+                    .sanitizer
+                    .sanitize(output, ContentSource::new(ContentSourceKind::ToolResult))
+                    .body;
+                *pending_reflection = Some(sanitized_out);
+            }
+            false
+        } else {
+            true
+        }
+    }
+
+    /// Classify a raw tool execution result into structured outcome fields.
+    ///
+    /// Extracts the output string, error flag, display metadata (diff, filter stats, locations),
+    /// and outcome classification (anomaly, quality failure, error category) from the `Result`.
+    /// Side effects: records filter metrics for successful outputs and fires security events for
+    /// invalid memory writes.
+    fn classify_tool_result(
+        &mut self,
+        tc: &zeph_llm::provider::ToolUseRequest,
+        tool_result: Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>,
+    ) -> ToolResultClassification {
+        match tool_result {
+            Ok(Some(out)) => {
+                let anomaly_outcome =
+                    if out.summary.contains("[error]") || out.summary.contains("[stderr]") {
+                        AnomalyOutcome::Error
+                    } else {
+                        AnomalyOutcome::Success
+                    };
+                if let Some(ref fs) = out.filter_stats {
+                    self.record_filter_metrics(fs);
+                }
+                let inline_stats = out.filter_stats.as_ref().and_then(|fs| {
+                    (fs.filtered_chars < fs.raw_chars).then(|| fs.format_inline(tc.name.as_str()))
+                });
+                let kept_lines = out
+                    .filter_stats
+                    .as_ref()
+                    .and_then(|fs| (!fs.kept_lines.is_empty()).then(|| fs.kept_lines.clone()));
+                ToolResultClassification {
+                    output: out.summary,
+                    is_error: false,
+                    diff: out.diff,
+                    inline_stats,
+                    kept_lines,
+                    locations: out.locations,
+                    anomaly_outcome,
+                    is_quality_failure: false,
+                    tool_err_category: None,
+                }
+            }
+            Ok(None) => ToolResultClassification {
+                output: "(no output)".to_owned(),
+                is_error: false,
+                diff: None,
+                inline_stats: None,
+                kept_lines: None,
+                locations: None,
+                anomaly_outcome: AnomalyOutcome::Success,
+                is_quality_failure: false,
+                tool_err_category: None,
+            },
+            Err(ref e) => {
+                let category = e.category();
+                let is_quality_failure = category.is_quality_failure();
+                let anomaly_outcome = if matches!(e, zeph_tools::ToolError::Blocked { .. }) {
+                    AnomalyOutcome::Blocked
+                } else if is_quality_failure && zeph_tools::is_reasoning_model(self.provider.name())
+                {
+                    AnomalyOutcome::ReasoningQualityFailure {
+                        model: self.provider.name().to_owned(),
+                        tool: tc.name.to_string(),
+                    }
+                } else {
+                    AnomalyOutcome::Error
+                };
+                if let Some(ref d) = self.debug_state.debug_dumper {
+                    d.dump_tool_error(tc.name.as_str(), e);
+                }
+                if tc.name == "memory_save"
+                    && matches!(e, zeph_tools::ToolError::InvalidParams { .. })
+                    && e.to_string().contains("memory write rejected")
+                {
+                    self.update_metrics(|m| m.memory_validation_failures += 1);
+                    self.push_security_event(
+                        crate::metrics::SecurityEventCategory::MemoryValidation,
+                        "memory_save",
+                        e.to_string(),
+                    );
+                }
+                let feedback = zeph_tools::ToolErrorFeedback {
+                    category,
+                    message: e.to_string(),
+                    retryable: category.is_retryable(),
+                };
+                ToolResultClassification {
+                    output: feedback.format_for_llm(),
+                    is_error: true,
+                    diff: None,
+                    inline_stats: None,
+                    kept_lines: None,
+                    locations: None,
+                    anomaly_outcome,
+                    is_quality_failure,
+                    tool_err_category: Some(category),
+                }
+            }
+        }
+    }
+
+    /// Process the result of a single tool execution within the batch result loop.
+    ///
+    /// Handles metrics, trace spans, skill learning, channel display, VIGIL gate, sanitization,
+    /// experience memory recording, and appends a `MessagePart::ToolResult` to `result_parts`.
+    /// Returns `Err` only on hard channel errors (e.g., broken pipe on `send_tool_output`).
+    #[allow(clippy::too_many_arguments)]
+    async fn process_one_tool_result(
+        &mut self,
+        tc: &zeph_llm::provider::ToolUseRequest,
+        tool_call_id: &str,
+        started_at: &std::time::Instant,
+        tool_result: Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>,
+        result_parts: &mut Vec<MessagePart>,
+        lsp_tool_calls: &mut Vec<(String, serde_json::Value, String)>,
+        has_any_injection_flags: &mut bool,
+        pending_reflection: &mut Option<String>,
+        pending_outcomes: &mut Vec<crate::agent::learning::PendingSkillOutcome>,
+    ) -> Result<(), super::super::error::AgentError> {
+        let ToolResultClassification {
+            output,
+            mut is_error,
+            diff,
+            inline_stats,
+            kept_lines,
+            locations,
+            anomaly_outcome,
+            is_quality_failure,
+            mut tool_err_category,
+        } = self.classify_tool_result(tc, tool_result);
+
+        self.record_tool_execution_telemetry(tc.name.as_str(), started_at, is_error, &output);
+
+        let tool_succeeded = self.handle_tool_failure_outcomes(
+            &output,
+            &mut tool_err_category,
+            is_quality_failure,
+            pending_outcomes,
+            pending_reflection,
+        );
+        let _ = self.record_anomaly_outcome(anomaly_outcome).await;
+
+        let processed = if tc.name == OverflowToolExecutor::TOOL_NAME {
+            output.clone()
+        } else {
+            self.maybe_summarize_tool_output(&output).await
+        };
+        let body = if let Some(ref stats) = inline_stats {
+            format!("{stats}\n{processed}")
+        } else {
+            processed.clone()
+        };
+        let body_display = self.maybe_redact(&body);
+        self.channel
+            .send_tool_output(ToolOutputEvent {
+                tool_name: tc.name.clone(),
+                display: body_display.into_owned(),
+                diff,
+                filter_stats: inline_stats,
+                kept_lines,
+                locations,
+                tool_call_id: tool_call_id.to_owned(),
+                is_error,
+                terminal_id: None,
+                parent_tool_use_id: self.session.parent_tool_use_id.clone(),
+                raw_response: None,
+                started_at: Some(*started_at),
+            })
+            .await?;
+
+        let (processed, vigil_outcome) = self.run_vigil_gate(tc.name.as_str(), processed);
+        self.fire_vigil_audit_entry(tc.name.as_str(), vigil_outcome.as_ref());
+
+        let (llm_content, tool_had_injection_flags) = match &vigil_outcome {
+            Some(super::VigilOutcome::Blocked { sentinel, .. }) => {
+                is_error = true;
+                (sentinel.clone(), false)
+            }
+            _ => {
+                self.sanitize_tool_output(&processed, tc.name.as_str())
+                    .await
+            }
+        };
+        *has_any_injection_flags |= tool_had_injection_flags;
+
+        let vigil_blocked = vigil_outcome
+            .as_ref()
+            .is_some_and(super::VigilOutcome::is_blocked);
+        if !is_error && !vigil_blocked {
+            lsp_tool_calls.push((tc.name.to_string(), tc.input.clone(), llm_content.clone()));
+        }
+
+        if vigil_blocked {
+            pending_outcomes.push(crate::agent::learning::PendingSkillOutcome {
+                outcome: FailureKind::SecurityBlocked.as_str().into(),
+                error_context: Some("VIGIL blocked tool output".into()),
+                outcome_detail: None,
+            });
+        } else if tool_succeeded {
+            pending_outcomes.push(crate::agent::learning::PendingSkillOutcome {
+                outcome: "success".into(),
+                error_context: None,
+                outcome_detail: None,
+            });
+            self.provider
+                .record_quality_outcome(self.provider.name(), true);
+        }
+
+        self.record_tool_experience(
+            tc.name.as_str(),
+            vigil_blocked,
+            is_error,
+            tool_succeeded,
+            tool_err_category.as_ref(),
+            &llm_content,
+        );
+
+        result_parts.push(MessagePart::ToolResult {
+            tool_use_id: tc.id.clone(),
+            content: llm_content,
+            is_error,
+        });
         Ok(())
     }
 
@@ -2886,163 +3289,166 @@ impl<C: Channel> Agent<C> {
     /// If `complete_focus` is called without an active focus session, or the checkpoint marker
     /// is not found in the message history, an `[error]` result is returned to the LLM so it
     /// knows the state is invalid rather than silently succeeding.
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3454): decompose into smaller helpers
     pub(crate) fn handle_focus_tool(
         &mut self,
         tool_name: &str,
         input: &serde_json::Value,
     ) -> (String, Option<zeph_llm::provider::Message>) {
         match tool_name {
-            "start_focus" => {
-                let scope = input
-                    .get("scope")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("(unspecified)")
-                    .to_string();
-
-                if self.focus.is_active() {
-                    return (
-                        "[error] A focus session is already active. Call complete_focus first."
-                            .to_string(),
-                        None,
-                    );
-                }
-
-                let marker = self.focus.start(scope.clone());
-
-                // Build a checkpoint message carrying the marker UUID so complete_focus can
-                // locate the boundary even after intervening compaction.
-                // S5 fix: focus_pinned=true ensures compaction never evicts this message.
-                // Returned as a pending side-effect so it is inserted AFTER the tool-result
-                // User message, maintaining valid OpenAI message ordering (#3262).
-                let checkpoint_msg = zeph_llm::provider::Message {
-                    role: zeph_llm::provider::Role::System,
-                    content: format!("[focus checkpoint: {scope}]"),
-                    parts: vec![],
-                    metadata: zeph_llm::provider::MessageMetadata {
-                        focus_pinned: true,
-                        focus_marker_id: Some(marker),
-                        ..zeph_llm::provider::MessageMetadata::agent_only()
-                    },
-                };
-
-                (
-                    format!("Focus session started. Checkpoint ID: {marker}. Scope: {scope}"),
-                    Some(checkpoint_msg),
-                )
-            }
-
-            "complete_focus" => {
-                let summary = input
-                    .get("summary")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
-
-                // S4: verify focus session is active.
-                if !self.focus.is_active() {
-                    return (
-                        "[error] No active focus session. Call start_focus first.".to_string(),
-                        None,
-                    );
-                }
-
-                let Some(marker) = self.focus.active_marker else {
-                    return (
-                        "[error] Internal error: active_marker is None.".to_string(),
-                        None,
-                    );
-                };
-
-                // S4: find the checkpoint message by marker UUID.
-                let checkpoint_pos = self
-                    .msg
-                    .messages
-                    .iter()
-                    .position(|m| m.metadata.focus_marker_id == Some(marker));
-                let Some(checkpoint_pos) = checkpoint_pos else {
-                    return (
-                        format!(
-                            "[error] Checkpoint marker {marker} not found in message history. \
-                             The focus session may have been evicted by compaction."
-                        ),
-                        None,
-                    );
-                };
-
-                // Collect messages since the checkpoint (exclusive of the checkpoint itself)
-                // up to the end, minus any messages added in this very tool call turn.
-                // The checkpoint itself and the bracketed messages are removed from history.
-                let messages_to_summarize = self.msg.messages[checkpoint_pos + 1..].to_vec();
-
-                // Sanitize the LLM-supplied summary before storing it to the pinned Knowledge
-                // block. The summary may summarize transitive external content (web scrapes,
-                // MCP responses), so use WebScrape (ExternalUntrusted trust level) for stricter
-                // spotlighting than ToolResult (SEC-CC-03).
-                let sanitized_summary = self
-                    .security
-                    .sanitizer
-                    .sanitize(
-                        &summary,
-                        zeph_sanitizer::ContentSource::new(
-                            zeph_sanitizer::ContentSourceKind::WebScrape,
-                        ),
-                    )
-                    .body;
-
-                // The LLM-supplied summary is the primary knowledge entry; the bracketed messages
-                // are removed to free context (not re-summarized here to avoid LLM overhead).
-                let _ = messages_to_summarize; // messages available for future semantic use
-                self.focus.append_llm_knowledge(sanitized_summary.clone());
-                if let Some(ref d) = self.debug_state.debug_dumper {
-                    let kb = self
-                        .focus
-                        .knowledge_blocks
-                        .iter()
-                        .map(|b| b.content.as_str())
-                        .collect::<Vec<_>>()
-                        .join("\n---\n");
-                    d.dump_focus_knowledge(&kb);
-                }
-                self.focus.complete();
-
-                // Remove the checkpoint and all messages after it (bracketed phase cleanup).
-                self.msg.messages.truncate(checkpoint_pos);
-                self.recompute_prompt_tokens();
-                // C1 fix: mark compacted so maybe_compact() does not double-fire this turn.
-                // cooldown=0: focus truncation does not impose post-compaction cooldown.
-                self.context_manager.compaction =
-                    crate::agent::context_manager::CompactionState::CompactedThisTurn {
-                        cooldown: 0,
-                    };
-
-                // Rebuild/insert the pinned Knowledge block message.
-                // Remove any existing Knowledge block (focus_pinned=true, no marker_id).
-                // Checkpoints have focus_marker_id set and must be preserved here
-                // (they were already truncated above along with the bracketed messages).
-                self.msg
-                    .messages
-                    .retain(|m| !(m.metadata.focus_pinned && m.metadata.focus_marker_id.is_none()));
-                if let Some(kb_msg) = self.focus.build_knowledge_message() {
-                    // Insert the Knowledge block right after the system prompt (index 1).
-                    if self.msg.messages.is_empty() {
-                        self.msg.messages.push(kb_msg);
-                    } else {
-                        self.msg.messages.insert(1, kb_msg);
-                    }
-                }
-                self.recompute_prompt_tokens();
-
-                (
-                    format!(
-                        "Focus session complete. Knowledge block updated with: {sanitized_summary}"
-                    ),
-                    None,
-                )
-            }
-
+            "start_focus" => self.start_focus_tool(input),
+            "complete_focus" => self.complete_focus_tool(input),
             other => (format!("[error] Unknown focus tool: {other}"), None),
         }
+    }
+
+    /// Execute the `start_focus` branch: activate a focus session and return the checkpoint message.
+    fn start_focus_tool(
+        &mut self,
+        input: &serde_json::Value,
+    ) -> (String, Option<zeph_llm::provider::Message>) {
+        let scope = input
+            .get("scope")
+            .and_then(|v| v.as_str())
+            .unwrap_or("(unspecified)")
+            .to_string();
+
+        if self.focus.is_active() {
+            return (
+                "[error] A focus session is already active. Call complete_focus first.".to_string(),
+                None,
+            );
+        }
+
+        let marker = self.focus.start(scope.clone());
+
+        // Build a checkpoint message carrying the marker UUID so complete_focus can
+        // locate the boundary even after intervening compaction.
+        // S5 fix: focus_pinned=true ensures compaction never evicts this message.
+        // Returned as a pending side-effect so it is inserted AFTER the tool-result
+        // User message, maintaining valid OpenAI message ordering (#3262).
+        let checkpoint_msg = zeph_llm::provider::Message {
+            role: zeph_llm::provider::Role::System,
+            content: format!("[focus checkpoint: {scope}]"),
+            parts: vec![],
+            metadata: zeph_llm::provider::MessageMetadata {
+                focus_pinned: true,
+                focus_marker_id: Some(marker),
+                ..zeph_llm::provider::MessageMetadata::agent_only()
+            },
+        };
+
+        (
+            format!("Focus session started. Checkpoint ID: {marker}. Scope: {scope}"),
+            Some(checkpoint_msg),
+        )
+    }
+
+    /// Execute the `complete_focus` branch: finalize the session and rebuild the knowledge block.
+    fn complete_focus_tool(
+        &mut self,
+        input: &serde_json::Value,
+    ) -> (String, Option<zeph_llm::provider::Message>) {
+        let summary = input
+            .get("summary")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        // S4: verify focus session is active.
+        if !self.focus.is_active() {
+            return (
+                "[error] No active focus session. Call start_focus first.".to_string(),
+                None,
+            );
+        }
+
+        let Some(marker) = self.focus.active_marker else {
+            return (
+                "[error] Internal error: active_marker is None.".to_string(),
+                None,
+            );
+        };
+
+        // S4: find the checkpoint message by marker UUID.
+        let checkpoint_pos = self
+            .msg
+            .messages
+            .iter()
+            .position(|m| m.metadata.focus_marker_id == Some(marker));
+        let Some(checkpoint_pos) = checkpoint_pos else {
+            return (
+                format!(
+                    "[error] Checkpoint marker {marker} not found in message history. \
+                     The focus session may have been evicted by compaction."
+                ),
+                None,
+            );
+        };
+
+        // The checkpoint and bracketed messages are removed from history.
+        // The slice is available for future semantic use but not re-summarized here
+        // to avoid LLM overhead.
+        let _ = self.msg.messages[checkpoint_pos + 1..].to_vec();
+
+        // Sanitize the LLM-supplied summary before storing it to the pinned Knowledge
+        // block. The summary may summarize transitive external content (web scrapes,
+        // MCP responses), so use WebScrape (ExternalUntrusted trust level) for stricter
+        // spotlighting than ToolResult (SEC-CC-03).
+        let sanitized_summary = self
+            .security
+            .sanitizer
+            .sanitize(
+                &summary,
+                zeph_sanitizer::ContentSource::new(zeph_sanitizer::ContentSourceKind::WebScrape),
+            )
+            .body;
+
+        self.focus.append_llm_knowledge(sanitized_summary.clone());
+        if let Some(ref d) = self.debug_state.debug_dumper {
+            let kb = self
+                .focus
+                .knowledge_blocks
+                .iter()
+                .map(|b| b.content.as_str())
+                .collect::<Vec<_>>()
+                .join("\n---\n");
+            d.dump_focus_knowledge(&kb);
+        }
+        self.focus.complete();
+
+        // Remove the checkpoint and all messages after it (bracketed phase cleanup).
+        self.msg.messages.truncate(checkpoint_pos);
+        self.recompute_prompt_tokens();
+        // C1 fix: mark compacted so maybe_compact() does not double-fire this turn.
+        // cooldown=0: focus truncation does not impose post-compaction cooldown.
+        self.context_manager.compaction =
+            crate::agent::context_manager::CompactionState::CompactedThisTurn { cooldown: 0 };
+
+        self.rebuild_knowledge_block();
+
+        (
+            format!("Focus session complete. Knowledge block updated with: {sanitized_summary}"),
+            None,
+        )
+    }
+
+    /// Remove any existing (non-checkpoint) Knowledge block and insert an updated one after the
+    /// system prompt. Called after focus completion and context compression.
+    fn rebuild_knowledge_block(&mut self) {
+        // Remove any existing Knowledge block (focus_pinned=true, no marker_id).
+        // Checkpoints have focus_marker_id set and must be preserved.
+        self.msg
+            .messages
+            .retain(|m| !(m.metadata.focus_pinned && m.metadata.focus_marker_id.is_none()));
+        if let Some(kb_msg) = self.focus.build_knowledge_message() {
+            // Insert the Knowledge block right after the system prompt (index 1).
+            if self.msg.messages.is_empty() {
+                self.msg.messages.push(kb_msg);
+            } else {
+                self.msg.messages.insert(1, kb_msg);
+            }
+        }
+        self.recompute_prompt_tokens();
     }
 
     /// Handle the `compress_context` tool call (#2218).
@@ -3053,94 +3459,33 @@ impl<C: Channel> Agent<C> {
     /// Guards:
     /// - Returns error if a focus session is active (would interfere with focus boundaries).
     /// - Returns error if a compression is already in progress (concurrency guard).
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3454): decompose into smaller helpers
     pub(crate) async fn handle_compress_context(&mut self) -> String {
         use zeph_llm::provider::LlmProvider as _;
 
-        // Guard: no active focus session.
         if self.focus.is_active() {
             return "[error] Cannot compress context while a focus session is active. \
                     Call complete_focus first."
                 .to_string();
         }
-
-        // Guard: concurrency — no double compression.
         if !self.focus.try_acquire_compression() {
             return "[error] A context compression is already in progress.".to_string();
         }
 
-        // Collect indices of non-pinned, non-system messages (candidates for compression),
-        // then select the head slice (excluding the preserve tail) as the removal set.
         let preserve_tail = self.context_manager.compaction_preserve_tail;
-        let compressible_indices: Vec<usize> = self
-            .msg
-            .messages
-            .iter()
-            .enumerate()
-            .filter(|(_, m)| !m.metadata.focus_pinned && m.role != zeph_llm::provider::Role::System)
-            .map(|(i, _)| i)
-            .collect();
+        let (to_remove_indices, to_compress) =
+            match self.select_messages_for_compression(preserve_tail) {
+                Ok(pair) => pair,
+                Err(total) => {
+                    self.focus.release_compression();
+                    return format!(
+                        "Not enough messages to compress (found {total}, need at least {}).",
+                        preserve_tail + 4
+                    );
+                }
+            };
 
-        let total = compressible_indices.len();
-        if total <= preserve_tail + 3 {
-            self.focus.release_compression();
-            return format!(
-                "Not enough messages to compress (found {total}, need at least {}).",
-                preserve_tail + 4
-            );
-        }
-
-        let to_remove_indices: std::collections::HashSet<usize> = compressible_indices
-            [..total.saturating_sub(preserve_tail)]
-            .iter()
-            .copied()
-            .collect();
-
-        let to_compress: Vec<zeph_llm::provider::Message> = to_remove_indices
-            .iter()
-            .map(|&i| self.msg.messages[i].clone())
-            .collect();
-
-        // Build summary prompt from the messages to compress.
-        let role_label = |role: &zeph_llm::provider::Role| match role {
-            zeph_llm::provider::Role::User => "user",
-            zeph_llm::provider::Role::Assistant => "assistant",
-            zeph_llm::provider::Role::System => "system",
-        };
-        let bullet_list: String = to_compress
-            .iter()
-            .enumerate()
-            .map(|(i, m)| {
-                format!(
-                    "{}. [{}] {}",
-                    i + 1,
-                    role_label(&m.role),
-                    m.content.chars().take(500).collect::<String>()
-                )
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        let system_content = "You are a context compression agent. \
-            Summarize the following conversation messages into a concise, information-dense summary. \
-            Preserve key facts, decisions, and context. Strip filler and small talk. \
-            Output ONLY the summary — no headers, no preamble.";
-
-        let summary_messages = vec![
-            zeph_llm::provider::Message {
-                role: zeph_llm::provider::Role::System,
-                content: system_content.to_owned(),
-                parts: vec![],
-                metadata: zeph_llm::provider::MessageMetadata::default(),
-            },
-            zeph_llm::provider::Message {
-                role: zeph_llm::provider::Role::User,
-                content: format!("Summarize these {total} conversation messages:\n\n{bullet_list}"),
-                parts: vec![],
-                metadata: zeph_llm::provider::MessageMetadata::default(),
-            },
-        ];
-
+        let compress_total = to_compress.len();
+        let summary_messages = build_compression_prompt(&to_compress);
         let compress_provider = self
             .providers
             .compress_provider
@@ -3173,41 +3518,73 @@ impl<C: Channel> Agent<C> {
             .map(|m| estimate_tokens(&m.content))
             .sum::<usize>();
 
-        // Append summary to Knowledge block (LLM-authored via compress_context).
         self.focus.append_llm_knowledge(summary.trim().to_owned());
+        self.apply_compression_removals(to_remove_indices);
 
-        // Remove compressed messages from in-memory history using their original indices.
-        // Index-based removal avoids false positives when two messages share identical content.
-        let mut remove_idx = to_remove_indices.iter().copied().collect::<Vec<_>>();
-        remove_idx.sort_unstable_by(|a, b| b.cmp(a)); // reverse order to preserve earlier indices
+        self.context_manager.compaction =
+            crate::agent::context_manager::CompactionState::CompactedThisTurn { cooldown: 0 };
+        self.focus.release_compression();
+
+        format!(
+            "Compressed {compress_total} messages into a summary (~{tokens_freed} tokens freed). \
+             Knowledge block updated."
+        )
+    }
+
+    /// Collect the set of message indices and cloned messages eligible for compression.
+    ///
+    /// Returns `None` (with the compressible count) when the history is too short (fewer than
+    /// `preserve_tail + 4` compressible messages). Returns `Some` with the removal set and
+    /// the messages to summarize when compression can proceed.
+    fn select_messages_for_compression(
+        &self,
+        preserve_tail: usize,
+    ) -> Result<
+        (
+            std::collections::HashSet<usize>,
+            Vec<zeph_llm::provider::Message>,
+        ),
+        usize,
+    > {
+        let compressible_indices: Vec<usize> = self
+            .msg
+            .messages
+            .iter()
+            .enumerate()
+            .filter(|(_, m)| !m.metadata.focus_pinned && m.role != zeph_llm::provider::Role::System)
+            .map(|(i, _)| i)
+            .collect();
+
+        let total = compressible_indices.len();
+        if total <= preserve_tail + 3 {
+            return Err(total);
+        }
+
+        let to_remove_indices: std::collections::HashSet<usize> = compressible_indices
+            [..total.saturating_sub(preserve_tail)]
+            .iter()
+            .copied()
+            .collect();
+
+        let to_compress: Vec<zeph_llm::provider::Message> = to_remove_indices
+            .iter()
+            .map(|&i| self.msg.messages[i].clone())
+            .collect();
+
+        Ok((to_remove_indices, to_compress))
+    }
+
+    /// Remove messages at the given indices (in reverse order) then rebuild the Knowledge block.
+    fn apply_compression_removals(&mut self, to_remove_indices: std::collections::HashSet<usize>) {
+        // Reverse-order removal preserves earlier indices.
+        let mut remove_idx = to_remove_indices.into_iter().collect::<Vec<_>>();
+        remove_idx.sort_unstable_by(|a, b| b.cmp(a));
         for idx in remove_idx {
             if idx < self.msg.messages.len() {
                 self.msg.messages.remove(idx);
             }
         }
-
-        // Rebuild Knowledge block message.
-        self.msg
-            .messages
-            .retain(|m| !(m.metadata.focus_pinned && m.metadata.focus_marker_id.is_none()));
-        if let Some(kb_msg) = self.focus.build_knowledge_message() {
-            if self.msg.messages.is_empty() {
-                self.msg.messages.push(kb_msg);
-            } else {
-                self.msg.messages.insert(1, kb_msg);
-            }
-        }
-        self.recompute_prompt_tokens();
-        self.context_manager.compaction =
-            crate::agent::context_manager::CompactionState::CompactedThisTurn { cooldown: 0 };
-
-        self.focus.release_compression();
-
-        format!(
-            "Compressed {compressed_count} messages into a summary (~{tokens_freed} tokens freed). \
-             Knowledge block updated.",
-            compressed_count = to_compress.len()
-        )
+        self.rebuild_knowledge_block();
     }
 
     /// Persist a tombstone `ToolResult` (`is_error=true`) for every tool call in `tool_calls`.
@@ -3232,6 +3609,106 @@ impl<C: Channel> Agent<C> {
             .await;
         self.push_message(user_msg);
     }
+}
+
+/// Build the LLM prompt messages used to summarize a slice of conversation messages.
+///
+/// The returned vec contains a system instruction and a user message with a numbered
+/// bullet list of the messages to summarize (each truncated to 500 chars).
+fn build_compression_prompt(
+    to_compress: &[zeph_llm::provider::Message],
+) -> Vec<zeph_llm::provider::Message> {
+    let role_label = |role: &zeph_llm::provider::Role| match role {
+        zeph_llm::provider::Role::User => "user",
+        zeph_llm::provider::Role::Assistant => "assistant",
+        zeph_llm::provider::Role::System => "system",
+    };
+    let bullet_list: String = to_compress
+        .iter()
+        .enumerate()
+        .map(|(i, m)| {
+            format!(
+                "{}. [{}] {}",
+                i + 1,
+                role_label(&m.role),
+                m.content.chars().take(500).collect::<String>()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let total = to_compress.len();
+    let system_content = "You are a context compression agent. \
+        Summarize the following conversation messages into a concise, information-dense summary. \
+        Preserve key facts, decisions, and context. Strip filler and small talk. \
+        Output ONLY the summary — no headers, no preamble.";
+
+    vec![
+        zeph_llm::provider::Message {
+            role: zeph_llm::provider::Role::System,
+            content: system_content.to_owned(),
+            parts: vec![],
+            metadata: zeph_llm::provider::MessageMetadata::default(),
+        },
+        zeph_llm::provider::Message {
+            role: zeph_llm::provider::Role::User,
+            content: format!("Summarize these {total} conversation messages:\n\n{bullet_list}"),
+            parts: vec![],
+            metadata: zeph_llm::provider::MessageMetadata::default(),
+        },
+    ]
+}
+
+/// Build the tool definition slice for iterations 1+ of the native tool loop.
+///
+/// Applies hard dependency-gate filtering when a dependency graph is configured, ensuring tools
+/// with unmet `requires` cannot re-enter through the expansion path after iteration 0 (#2024).
+///
+/// Returns the allowed set as an owned `Vec`; the caller holds a reference into it.
+/// When no dependency graph is present the full `all_tool_defs` slice is returned as-is (cloned).
+fn build_gated_defs_for_iteration(
+    iteration: usize,
+    all_tool_defs: &[ToolDefinition],
+    tool_state: &crate::agent::state::ToolState,
+) -> Vec<ToolDefinition> {
+    let Some(ref dep_graph) = tool_state.dependency_graph else {
+        return all_tool_defs.to_vec();
+    };
+    if dep_graph.is_empty() {
+        return all_tool_defs.to_vec();
+    }
+
+    let names: Vec<&str> = all_tool_defs.iter().map(|d| d.name.as_str()).collect();
+    let allowed = dep_graph.filter_tool_names(
+        &names,
+        &tool_state.completed_tool_ids,
+        &tool_state.dependency_always_on,
+    );
+    let allowed_set: std::collections::HashSet<&str> = allowed.into_iter().collect();
+
+    // Deadlock fallback: if all non-always-on tools would be blocked, use the full set.
+    let non_ao_allowed = allowed_set
+        .iter()
+        .filter(|n| !tool_state.dependency_always_on.contains(**n))
+        .count();
+    let non_ao_total = all_tool_defs
+        .iter()
+        .filter(|d| !tool_state.dependency_always_on.contains(d.name.as_str()))
+        .count();
+    if non_ao_allowed == 0 && non_ao_total > 0 {
+        tracing::warn!(
+            iteration,
+            "tool dependency graph: all non-always-on tools gated on iter 1+; \
+             disabling hard gates for this iteration"
+        );
+        return all_tool_defs.to_vec();
+    }
+
+    all_tool_defs
+        .iter()
+        .filter(|d| allowed_set.contains(d.name.as_str()))
+        .cloned()
+        .collect()
 }
 
 /// Receive the next elicitation event from an optional channel without blocking.
@@ -3267,6 +3744,12 @@ fn skipped_output(
         raw_response: None,
         claim_source: None,
     }
+}
+
+/// Wrap a pre-built `ToolOutput` as an immediately-ready boxed future suitable for
+/// insertion into the tier futures list.
+fn ready_fut(idx: usize, out: zeph_tools::ToolOutput) -> (usize, ToolExecFut) {
+    (idx, Box::pin(std::future::ready(Ok(Some(out)))))
 }
 
 /// Truncate `s` to at most `max_bytes` bytes on a valid UTF-8 char boundary.

--- a/crates/zeph-core/src/agent/tool_execution/sanitize.rs
+++ b/crates/zeph-core/src/agent/tool_execution/sanitize.rs
@@ -50,6 +50,21 @@ fn is_internal_tool(tool_name: &str) -> bool {
     !tool_name.contains(':') && INTERNAL_TOOLS.contains(&tool_name)
 }
 
+/// Build the `ContentSource` that describes a tool's trust level for the sanitizer.
+fn build_tool_output_source(tool_name: &str) -> ContentSource {
+    if tool_name.contains(':') || tool_name == "mcp" {
+        ContentSource::new(ContentSourceKind::McpResponse).with_identifier(tool_name)
+    } else if tool_name == "web-scrape" || tool_name == "web_scrape" || tool_name == "fetch" {
+        ContentSource::new(ContentSourceKind::WebScrape).with_identifier(tool_name)
+    } else if tool_name == "memory_search" {
+        ContentSource::new(ContentSourceKind::MemoryRetrieval)
+            .with_identifier(tool_name)
+            .with_memory_hint(MemorySourceHint::ConversationHistory)
+    } else {
+        ContentSource::new(ContentSourceKind::ToolResult).with_identifier(tool_name)
+    }
+}
+
 impl<C: Channel> Agent<C> {
     /// Sanitize tool output body before inserting it into the LLM message history.
     ///
@@ -58,23 +73,12 @@ impl<C: Channel> Agent<C> {
     ///
     /// This is the SOLE sanitization point for tool output data flows. Do not add
     /// redundant sanitization in leaf crates (zeph-tools, zeph-mcp).
-    #[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3454): decompose into smaller helpers
     pub(super) async fn sanitize_tool_output(
         &mut self,
         body: &str,
         tool_name: &str,
     ) -> (String, bool) {
-        let source = if tool_name.contains(':') || tool_name == "mcp" {
-            ContentSource::new(ContentSourceKind::McpResponse).with_identifier(tool_name)
-        } else if tool_name == "web-scrape" || tool_name == "web_scrape" || tool_name == "fetch" {
-            ContentSource::new(ContentSourceKind::WebScrape).with_identifier(tool_name)
-        } else if tool_name == "memory_search" {
-            ContentSource::new(ContentSourceKind::MemoryRetrieval)
-                .with_identifier(tool_name)
-                .with_memory_hint(MemorySourceHint::ConversationHistory)
-        } else {
-            ContentSource::new(ContentSourceKind::ToolResult).with_identifier(tool_name)
-        };
+        let source = build_tool_output_source(tool_name);
         let kind = source.kind;
         #[cfg(feature = "classifiers")]
         let memory_hint = source.memory_hint;
@@ -82,33 +86,7 @@ impl<C: Channel> Agent<C> {
         let _ = source.memory_hint;
         let sanitized = self.security.sanitizer.sanitize(body, source);
         let has_injection_flags = !sanitized.injection_flags.is_empty();
-        if has_injection_flags {
-            tracing::warn!(
-                tool = %tool_name,
-                flags = sanitized.injection_flags.len(),
-                "injection patterns detected in tool output"
-            );
-            self.update_metrics(|m| {
-                let flag_count = sanitized.injection_flags.len() as u64;
-                m.sanitizer_injection_flags += flag_count;
-                if sanitized.source.kind == zeph_sanitizer::ContentSourceKind::ToolResult {
-                    m.sanitizer_injection_fp_local += flag_count;
-                }
-            });
-            let detail = sanitized
-                .injection_flags
-                .first()
-                .map_or_else(String::new, |f| {
-                    format!("Detected pattern: {}", f.pattern_name)
-                });
-            self.push_security_event(
-                crate::metrics::SecurityEventCategory::InjectionFlag,
-                tool_name,
-                detail,
-            );
-            let urls = zeph_sanitizer::exfiltration::extract_flagged_urls(&sanitized.body);
-            self.security.flagged_urls.extend(urls);
-        }
+        self.record_injection_flags(&sanitized, tool_name);
         if sanitized.was_truncated {
             self.update_metrics(|m| m.sanitizer_truncations += 1);
             self.push_security_event(
@@ -120,162 +98,261 @@ impl<C: Channel> Agent<C> {
         self.update_metrics(|m| m.sanitizer_runs += 1);
 
         #[cfg(feature = "classifiers")]
+        if let Some(result) = self
+            .apply_classifier_verdict(body, tool_name, memory_hint)
+            .await
         {
-            // Synthetic outputs from the utility gate are trusted internal content — never
-            // classify them. Only real tool output from external sources needs ML inspection.
-            let is_utility_gate_synthetic =
-                body.starts_with("[skipped]") || body.starts_with("[stopped]");
-            let skip_ml = matches!(
-                memory_hint,
-                Some(
-                    zeph_sanitizer::MemorySourceHint::ConversationHistory
-                        | zeph_sanitizer::MemorySourceHint::LlmSummary
-                )
-            ) || is_policy_blocked_output(body)
-                || is_utility_gate_synthetic
-                || is_internal_tool(tool_name);
-            if !skip_ml && self.security.sanitizer.has_classifier_backend() {
-                let ml_verdict = self.security.sanitizer.classify_injection(body).await;
-                match ml_verdict {
-                    zeph_sanitizer::InjectionVerdict::Blocked => {
-                        tracing::warn!(tool = %tool_name, "ML classifier blocked tool output");
-                        self.update_metrics(|m| m.classifier_tool_blocks += 1);
-                        self.push_security_event(
-                            crate::metrics::SecurityEventCategory::InjectionBlocked,
-                            tool_name,
-                            "ML classifier blocked tool output",
-                        );
-                        return (
-                            "[tool output blocked: injection detected by classifier]".into(),
-                            true,
-                        );
-                    }
-                    zeph_sanitizer::InjectionVerdict::Suspicious => {
-                        tracing::warn!(
-                            tool = %tool_name,
-                            "ML classifier: suspicious tool output"
-                        );
-                        self.update_metrics(|m| m.classifier_tool_suspicious += 1);
-                    }
-                    zeph_sanitizer::InjectionVerdict::Clean => {}
-                }
-            }
+            return result;
         }
 
         let is_cross_boundary = self.security.is_acp_session
             && self.runtime.security.content_isolation.mcp_to_acp_boundary
             && kind == ContentSourceKind::McpResponse;
-        if is_cross_boundary {
-            tracing::warn!(
-                tool = %tool_name,
-                mcp_server_id = tool_name.split(':').next().unwrap_or("unknown"),
-                "MCP tool result crossing ACP trust boundary"
-            );
-            self.push_security_event(
-                crate::metrics::SecurityEventCategory::CrossBoundaryMcpToAcp,
-                tool_name,
-                "MCP result force-quarantined for ACP session",
-            );
-            if let Some(ref logger) = self.tool_orchestrator.audit_logger {
-                let entry = zeph_tools::AuditEntry {
-                    timestamp: zeph_tools::chrono_now(),
-                    tool: tool_name.into(),
-                    command: String::new(),
-                    result: zeph_tools::AuditResult::Success,
-                    duration_ms: 0,
-                    error_category: None,
-                    error_domain: Some("security".to_owned()),
-                    error_phase: None,
-                    claim_source: None,
-                    mcp_server_id: tool_name.split(':').next().map(ToOwned::to_owned),
-                    injection_flagged: has_injection_flags,
-                    embedding_anomalous: false,
-                    cross_boundary_mcp_to_acp: true,
-                    adversarial_policy_decision: None,
-                    exit_code: None,
-                    truncated: false,
-                    caller_id: None,
-                    policy_match: None,
-                    correlation_id: None,
-                    vigil_risk: None,
-                };
-                let logger = std::sync::Arc::clone(logger);
-                self.lifecycle.supervisor.spawn(
-                    super::super::agent_supervisor::TaskClass::Telemetry,
-                    "audit-log-sanitize",
-                    async move { logger.log(&entry).await },
-                );
-            }
-            if let Some(ref qs) = self.security.quarantine_summarizer {
-                match qs.extract_facts(&sanitized, &self.security.sanitizer).await {
-                    Ok((facts, flags)) => {
-                        self.update_metrics(|m| m.quarantine_invocations += 1);
-                        let escaped =
-                            zeph_sanitizer::ContentSanitizer::escape_delimiter_tags(&facts);
-                        return (
-                            zeph_sanitizer::ContentSanitizer::apply_spotlight(
-                                &escaped,
-                                &sanitized.source,
-                                &flags,
-                            ),
-                            has_injection_flags,
-                        );
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            tool = %tool_name,
-                            error = %e,
-                            "cross-boundary quarantine failed, using spotlighted output"
-                        );
-                        self.update_metrics(|m| m.quarantine_failures += 1);
-                    }
-                }
-            }
+
+        if is_cross_boundary
+            && let Some(result) = self
+                .handle_cross_boundary_quarantine(&sanitized, tool_name, has_injection_flags)
+                .await
+        {
+            return result;
         }
 
         if !is_cross_boundary
-            && self.security.sanitizer.is_enabled()
-            && let Some(ref qs) = self.security.quarantine_summarizer
-            && qs.should_quarantine(kind)
+            && let Some(result) = self
+                .handle_quarantine_summary(&sanitized, tool_name, kind, has_injection_flags)
+                .await
         {
-            match qs.extract_facts(&sanitized, &self.security.sanitizer).await {
-                Ok((facts, flags)) => {
-                    self.update_metrics(|m| m.quarantine_invocations += 1);
-                    self.push_security_event(
-                        crate::metrics::SecurityEventCategory::Quarantine,
-                        tool_name,
-                        "Content quarantined, facts extracted",
-                    );
-                    let escaped = zeph_sanitizer::ContentSanitizer::escape_delimiter_tags(&facts);
-                    return (
-                        zeph_sanitizer::ContentSanitizer::apply_spotlight(
-                            &escaped,
-                            &sanitized.source,
-                            &flags,
-                        ),
-                        has_injection_flags,
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        tool = %tool_name,
-                        error = %e,
-                        "quarantine failed, using original sanitized output"
-                    );
-                    self.update_metrics(|m| m.quarantine_failures += 1);
-                    self.push_security_event(
-                        crate::metrics::SecurityEventCategory::Quarantine,
-                        tool_name,
-                        format!("Quarantine failed: {e}"),
-                    );
-                }
-            }
+            return result;
         }
 
         let body = self.scrub_pii_union(&sanitized.body, tool_name).await;
         let body = self.apply_guardrail_to_tool_output(body, tool_name).await;
 
         (body, has_injection_flags)
+    }
+
+    /// Record injection-flag metrics and security events for a sanitized output.
+    fn record_injection_flags(
+        &mut self,
+        sanitized: &zeph_sanitizer::SanitizedContent,
+        tool_name: &str,
+    ) {
+        if sanitized.injection_flags.is_empty() {
+            return;
+        }
+        tracing::warn!(
+            tool = %tool_name,
+            flags = sanitized.injection_flags.len(),
+            "injection patterns detected in tool output"
+        );
+        self.update_metrics(|m| {
+            let flag_count = sanitized.injection_flags.len() as u64;
+            m.sanitizer_injection_flags += flag_count;
+            if sanitized.source.kind == zeph_sanitizer::ContentSourceKind::ToolResult {
+                m.sanitizer_injection_fp_local += flag_count;
+            }
+        });
+        let detail = sanitized
+            .injection_flags
+            .first()
+            .map_or_else(String::new, |f| {
+                format!("Detected pattern: {}", f.pattern_name)
+            });
+        self.push_security_event(
+            crate::metrics::SecurityEventCategory::InjectionFlag,
+            tool_name,
+            detail,
+        );
+        let urls = zeph_sanitizer::exfiltration::extract_flagged_urls(&sanitized.body);
+        self.security.flagged_urls.extend(urls);
+    }
+
+    /// Run the ML classifier on `body` and return an early result if the output is blocked
+    /// or if the classification verdict warrants it. Returns `None` to continue normal flow.
+    ///
+    /// Synthetic outputs from the utility gate are trusted internal content and are never
+    /// classified. Memory-hinted outputs and first-party tool outputs are also exempt.
+    #[cfg(feature = "classifiers")]
+    async fn apply_classifier_verdict(
+        &mut self,
+        body: &str,
+        tool_name: &str,
+        memory_hint: Option<zeph_sanitizer::MemorySourceHint>,
+    ) -> Option<(String, bool)> {
+        // Synthetic outputs from the utility gate are trusted internal content — never
+        // classify them. Only real tool output from external sources needs ML inspection.
+        let is_utility_gate_synthetic =
+            body.starts_with("[skipped]") || body.starts_with("[stopped]");
+        let skip_ml = matches!(
+            memory_hint,
+            Some(
+                zeph_sanitizer::MemorySourceHint::ConversationHistory
+                    | zeph_sanitizer::MemorySourceHint::LlmSummary
+            )
+        ) || is_policy_blocked_output(body)
+            || is_utility_gate_synthetic
+            || is_internal_tool(tool_name);
+        if !skip_ml && self.security.sanitizer.has_classifier_backend() {
+            let ml_verdict = self.security.sanitizer.classify_injection(body).await;
+            match ml_verdict {
+                zeph_sanitizer::InjectionVerdict::Blocked => {
+                    tracing::warn!(tool = %tool_name, "ML classifier blocked tool output");
+                    self.update_metrics(|m| m.classifier_tool_blocks += 1);
+                    self.push_security_event(
+                        crate::metrics::SecurityEventCategory::InjectionBlocked,
+                        tool_name,
+                        "ML classifier blocked tool output",
+                    );
+                    return Some((
+                        "[tool output blocked: injection detected by classifier]".into(),
+                        true,
+                    ));
+                }
+                zeph_sanitizer::InjectionVerdict::Suspicious => {
+                    tracing::warn!(
+                        tool = %tool_name,
+                        "ML classifier: suspicious tool output"
+                    );
+                    self.update_metrics(|m| m.classifier_tool_suspicious += 1);
+                }
+                zeph_sanitizer::InjectionVerdict::Clean => {}
+            }
+        }
+        None
+    }
+
+    /// Handle the cross-ACP-boundary quarantine path for MCP tool results.
+    ///
+    /// Logs a trust-boundary warning, fires an audit entry, and attempts fact extraction.
+    /// Returns `Some((body, has_injection_flags))` if quarantine produced an early result,
+    /// or `None` to continue normal processing.
+    async fn handle_cross_boundary_quarantine(
+        &mut self,
+        sanitized: &zeph_sanitizer::SanitizedContent,
+        tool_name: &str,
+        has_injection_flags: bool,
+    ) -> Option<(String, bool)> {
+        tracing::warn!(
+            tool = %tool_name,
+            mcp_server_id = tool_name.split(':').next().unwrap_or("unknown"),
+            "MCP tool result crossing ACP trust boundary"
+        );
+        self.push_security_event(
+            crate::metrics::SecurityEventCategory::CrossBoundaryMcpToAcp,
+            tool_name,
+            "MCP result force-quarantined for ACP session",
+        );
+        if let Some(ref logger) = self.tool_orchestrator.audit_logger {
+            let entry = zeph_tools::AuditEntry {
+                timestamp: zeph_tools::chrono_now(),
+                tool: tool_name.into(),
+                command: String::new(),
+                result: zeph_tools::AuditResult::Success,
+                duration_ms: 0,
+                error_category: None,
+                error_domain: Some("security".to_owned()),
+                error_phase: None,
+                claim_source: None,
+                mcp_server_id: tool_name.split(':').next().map(ToOwned::to_owned),
+                injection_flagged: has_injection_flags,
+                embedding_anomalous: false,
+                cross_boundary_mcp_to_acp: true,
+                adversarial_policy_decision: None,
+                exit_code: None,
+                truncated: false,
+                caller_id: None,
+                policy_match: None,
+                correlation_id: None,
+                vigil_risk: None,
+            };
+            let logger = std::sync::Arc::clone(logger);
+            self.lifecycle.supervisor.spawn(
+                super::super::agent_supervisor::TaskClass::Telemetry,
+                "audit-log-sanitize",
+                async move { logger.log(&entry).await },
+            );
+        }
+        if let Some(ref qs) = self.security.quarantine_summarizer {
+            match qs.extract_facts(sanitized, &self.security.sanitizer).await {
+                Ok((facts, flags)) => {
+                    self.update_metrics(|m| m.quarantine_invocations += 1);
+                    let escaped = zeph_sanitizer::ContentSanitizer::escape_delimiter_tags(&facts);
+                    return Some((
+                        zeph_sanitizer::ContentSanitizer::apply_spotlight(
+                            &escaped,
+                            &sanitized.source,
+                            &flags,
+                        ),
+                        has_injection_flags,
+                    ));
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        tool = %tool_name,
+                        error = %e,
+                        "cross-boundary quarantine failed, using spotlighted output"
+                    );
+                    self.update_metrics(|m| m.quarantine_failures += 1);
+                }
+            }
+        }
+        None
+    }
+
+    /// Handle standard quarantine summarization for non-cross-boundary tool outputs.
+    ///
+    /// Returns `Some((body, has_injection_flags))` if quarantine produced an early result,
+    /// or `None` to continue normal processing.
+    async fn handle_quarantine_summary(
+        &mut self,
+        sanitized: &zeph_sanitizer::SanitizedContent,
+        tool_name: &str,
+        kind: ContentSourceKind,
+        has_injection_flags: bool,
+    ) -> Option<(String, bool)> {
+        if !(self.security.sanitizer.is_enabled()
+            && self
+                .security
+                .quarantine_summarizer
+                .as_ref()
+                .is_some_and(|qs| qs.should_quarantine(kind)))
+        {
+            return None;
+        }
+        let qs = self.security.quarantine_summarizer.as_ref()?;
+        match qs.extract_facts(sanitized, &self.security.sanitizer).await {
+            Ok((facts, flags)) => {
+                self.update_metrics(|m| m.quarantine_invocations += 1);
+                self.push_security_event(
+                    crate::metrics::SecurityEventCategory::Quarantine,
+                    tool_name,
+                    "Content quarantined, facts extracted",
+                );
+                let escaped = zeph_sanitizer::ContentSanitizer::escape_delimiter_tags(&facts);
+                Some((
+                    zeph_sanitizer::ContentSanitizer::apply_spotlight(
+                        &escaped,
+                        &sanitized.source,
+                        &flags,
+                    ),
+                    has_injection_flags,
+                ))
+            }
+            Err(e) => {
+                tracing::warn!(
+                    tool = %tool_name,
+                    error = %e,
+                    "quarantine failed, using original sanitized output"
+                );
+                self.update_metrics(|m| m.quarantine_failures += 1);
+                self.push_security_event(
+                    crate::metrics::SecurityEventCategory::Quarantine,
+                    tool_name,
+                    format!("Quarantine failed: {e}"),
+                );
+                None
+            }
+        }
     }
 }
 

--- a/crates/zeph-core/src/agent/tool_execution/tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests.rs
@@ -2445,6 +2445,161 @@ impl ToolExecutor for FixedOutputExecutor {
     }
 }
 
+/// Returns success for the first `execute_tool_call` invocation and `[error]` output for all
+/// subsequent ones. Used to test batch behavior when one tool in a batch fails.
+struct FirstSuccessExecutor {
+    call_count: std::sync::Arc<std::sync::Mutex<usize>>,
+}
+
+impl ToolExecutor for FirstSuccessExecutor {
+    fn execute(
+        &self,
+        _response: &str,
+    ) -> impl Future<Output = Result<Option<ToolOutput>, ToolError>> + Send {
+        std::future::ready(Ok(None))
+    }
+
+    fn execute_tool_call(
+        &self,
+        call: &ToolCall,
+    ) -> impl Future<Output = Result<Option<ToolOutput>, ToolError>> + Send {
+        let tool_id = call.tool_id.clone();
+        let call_count = std::sync::Arc::clone(&self.call_count);
+        async move {
+            let mut count = call_count.lock().unwrap();
+            let n = *count;
+            *count += 1;
+            drop(count);
+            let summary = if n == 0 {
+                "success output".to_owned()
+            } else {
+                "[error] tool failed".to_owned()
+            };
+            Ok(Some(ToolOutput {
+                tool_name: tool_id,
+                summary,
+                blocks_executed: 1,
+                diff: None,
+                filter_stats: None,
+                streamed: false,
+                terminal_id: None,
+                locations: None,
+                raw_response: None,
+                claim_source: None,
+            }))
+        }
+    }
+}
+
+/// Dispatches by `tool_id` to cover three outcomes in a single batch:
+/// - `"tool-success"`: always succeeds, not retryable.
+/// - `"tool-retryable"`: fails on call index 1 (transient), succeeds otherwise; `is_tool_retryable = true`.
+/// - `"tool-nonretryable"`: always transient error; `is_tool_retryable = false`.
+struct DispatchingExecutor {
+    call_count: AtomicUsize,
+}
+
+impl ToolExecutor for DispatchingExecutor {
+    fn execute(
+        &self,
+        _: &str,
+    ) -> impl Future<Output = Result<Option<ToolOutput>, ToolError>> + Send {
+        std::future::ready(Ok(None))
+    }
+
+    fn execute_tool_call(
+        &self,
+        call: &ToolCall,
+    ) -> impl Future<Output = Result<Option<ToolOutput>, ToolError>> + Send {
+        let idx = self.call_count.fetch_add(1, Ordering::SeqCst);
+        let tool_id = call.tool_id.clone();
+        async move {
+            match tool_id.as_str() {
+                "tool-success" => Ok(Some(ToolOutput {
+                    tool_name: tool_id,
+                    summary: "ok".into(),
+                    blocks_executed: 1,
+                    diff: None,
+                    filter_stats: None,
+                    streamed: false,
+                    terminal_id: None,
+                    locations: None,
+                    raw_response: None,
+                    claim_source: None,
+                })),
+                "tool-retryable" if idx == 1 => Err(ToolError::Execution(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "transient",
+                ))),
+                "tool-retryable" => Ok(Some(ToolOutput {
+                    tool_name: tool_id,
+                    summary: "retried-ok".into(),
+                    blocks_executed: 1,
+                    diff: None,
+                    filter_stats: None,
+                    streamed: false,
+                    terminal_id: None,
+                    locations: None,
+                    raw_response: None,
+                    claim_source: None,
+                })),
+                _ => Err(ToolError::Execution(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "always-transient",
+                ))),
+            }
+        }
+    }
+
+    fn is_tool_retryable(&self, tool_id: &str) -> bool {
+        tool_id == "tool-retryable"
+    }
+}
+
+/// Fails permanently on the first call (index 0) and succeeds on all subsequent calls.
+/// Used to test that a batch with one permanent error still emits `ToolResult` for every call.
+struct FirstFailsExecutor {
+    call_count: std::sync::Arc<AtomicUsize>,
+}
+
+impl ToolExecutor for FirstFailsExecutor {
+    fn execute(
+        &self,
+        _response: &str,
+    ) -> impl Future<Output = Result<Option<ToolOutput>, ToolError>> + Send {
+        std::future::ready(Ok(None))
+    }
+
+    fn execute_tool_call(
+        &self,
+        call: &ToolCall,
+    ) -> impl Future<Output = Result<Option<ToolOutput>, ToolError>> + Send {
+        let idx = self.call_count.fetch_add(1, Ordering::SeqCst);
+        let tool_id = call.tool_id.clone();
+        async move {
+            if idx == 0 {
+                let _ = tool_id;
+                Err(ToolError::InvalidParams {
+                    message: "permanent error".to_owned(),
+                })
+            } else {
+                Ok(Some(ToolOutput {
+                    tool_name: tool_id,
+                    summary: "ok".to_owned(),
+                    blocks_executed: 1,
+                    diff: None,
+                    filter_stats: None,
+                    streamed: false,
+                    terminal_id: None,
+                    locations: None,
+                    raw_response: None,
+                    claim_source: None,
+                }))
+            }
+        }
+    }
+}
+
 /// Builds a minimal `ToolUseRequest` for test use.
 fn make_tool_use_request(id: &str, name: &str) -> zeph_llm::provider::ToolUseRequest {
     zeph_llm::provider::ToolUseRequest {
@@ -2897,58 +3052,12 @@ async fn self_reflection_single_tool_failure_produces_one_tool_result() {
 // Second tool fails → reflection fires → early return must append ToolResult for 2nd (is_error)
 // and a synthetic [skipped] ToolResult for the 3rd. Total: 3 ToolResults for 3 ToolUses.
 #[tokio::test]
-#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3454): decompose into smaller helpers
 async fn self_reflection_middle_tool_failure_no_orphans() {
     use std::sync::{Arc, Mutex};
 
     use super::super::agent_tests::{MockChannel, mock_provider};
     use crate::config::LearningConfig;
     use zeph_llm::provider::MessagePart;
-
-    // Executor that returns success for the first call and error for subsequent calls.
-    struct FirstSuccessExecutor {
-        call_count: Arc<Mutex<usize>>,
-    }
-
-    impl ToolExecutor for FirstSuccessExecutor {
-        fn execute(
-            &self,
-            _response: &str,
-        ) -> impl Future<Output = Result<Option<ToolOutput>, ToolError>> + Send {
-            std::future::ready(Ok(None))
-        }
-
-        fn execute_tool_call(
-            &self,
-            call: &ToolCall,
-        ) -> impl Future<Output = Result<Option<ToolOutput>, ToolError>> + Send {
-            let tool_id = call.tool_id.clone();
-            let call_count = Arc::clone(&self.call_count);
-            async move {
-                let mut count = call_count.lock().unwrap();
-                let n = *count;
-                *count += 1;
-                drop(count);
-                let summary = if n == 0 {
-                    "success output".to_owned()
-                } else {
-                    "[error] tool failed".to_owned()
-                };
-                Ok(Some(ToolOutput {
-                    tool_name: tool_id,
-                    summary,
-                    blocks_executed: 1,
-                    diff: None,
-                    filter_stats: None,
-                    streamed: false,
-                    terminal_id: None,
-                    locations: None,
-                    raw_response: None,
-                    claim_source: None,
-                }))
-            }
-        }
-    }
 
     let executor = FirstSuccessExecutor {
         call_count: Arc::new(Mutex::new(0)),
@@ -3566,75 +3675,9 @@ async fn transient_error_on_non_retryable_executor_is_not_retried() {
 // tool[2] is non-retryable-transient-always-fail. Verifies all three complete with
 // the correct outcome and the retry fires only for tool[1].
 #[tokio::test]
-#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3454): decompose into smaller helpers
 async fn mixed_retryable_and_non_retryable_batch() {
     use super::super::agent_tests::{MockChannel, create_test_registry, mock_provider};
-    use std::sync::atomic::{AtomicUsize, Ordering};
     use zeph_llm::provider::MessagePart;
-
-    // Use a single dispatching executor that branches by tool_id, covering:
-    // - "tool-success": always succeeds, not retryable (default)
-    // - "tool-retryable": first call transient, second call ok; is_tool_retryable=true
-    // - "tool-nonretryable": always transient, is_tool_retryable=false
-    struct DispatchingExecutor {
-        call_count: AtomicUsize,
-    }
-    impl ToolExecutor for DispatchingExecutor {
-        fn execute(
-            &self,
-            _: &str,
-        ) -> impl Future<Output = Result<Option<ToolOutput>, ToolError>> + Send {
-            std::future::ready(Ok(None))
-        }
-        fn execute_tool_call(
-            &self,
-            call: &ToolCall,
-        ) -> impl Future<Output = Result<Option<ToolOutput>, ToolError>> + Send {
-            let idx = self.call_count.fetch_add(1, Ordering::SeqCst);
-            let tool_id = call.tool_id.clone();
-            async move {
-                match tool_id.as_str() {
-                    "tool-success" => Ok(Some(ToolOutput {
-                        tool_name: tool_id,
-                        summary: "ok".into(),
-                        blocks_executed: 1,
-                        diff: None,
-                        filter_stats: None,
-                        streamed: false,
-                        terminal_id: None,
-                        locations: None,
-                        raw_response: None,
-                        claim_source: None,
-                    })),
-                    // tool-retryable: fail on first call (idx 1), succeed after that
-                    "tool-retryable" if idx == 1 => Err(ToolError::Execution(std::io::Error::new(
-                        std::io::ErrorKind::TimedOut,
-                        "transient",
-                    ))),
-                    "tool-retryable" => Ok(Some(ToolOutput {
-                        tool_name: tool_id,
-                        summary: "retried-ok".into(),
-                        blocks_executed: 1,
-                        diff: None,
-                        filter_stats: None,
-                        streamed: false,
-                        terminal_id: None,
-                        locations: None,
-                        raw_response: None,
-                        claim_source: None,
-                    })),
-                    // tool-nonretryable: always transient error
-                    _ => Err(ToolError::Execution(std::io::Error::new(
-                        std::io::ErrorKind::TimedOut,
-                        "always-transient",
-                    ))),
-                }
-            }
-        }
-        fn is_tool_retryable(&self, tool_id: &str) -> bool {
-            tool_id == "tool-retryable"
-        }
-    }
 
     let provider = mock_provider(vec![]);
     let channel = MockChannel::new(vec![]);
@@ -4290,55 +4333,11 @@ async fn sanitize_tool_output_memory_save_still_uses_tool_result() {
 // After the fix, both ToolResults must be present in a single User message that immediately
 // follows the Assistant{ToolUse} message, with no interleaved messages in between.
 #[tokio::test]
-#[allow(clippy::too_many_lines)] // long function; decomposition would require extracting state into additional structs — TODO(#3454): decompose into smaller helpers
 async fn test_parallel_tool_calls_permanent_error_emits_tool_result() {
     use std::sync::Arc;
-    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::super::agent_tests::{MockChannel, create_test_registry, mock_provider};
     use zeph_llm::provider::{MessagePart, Role};
-
-    struct FirstFailsExecutor {
-        call_count: Arc<AtomicUsize>,
-    }
-
-    impl ToolExecutor for FirstFailsExecutor {
-        fn execute(
-            &self,
-            _response: &str,
-        ) -> impl Future<Output = Result<Option<ToolOutput>, ToolError>> + Send {
-            std::future::ready(Ok(None))
-        }
-
-        fn execute_tool_call(
-            &self,
-            call: &ToolCall,
-        ) -> impl Future<Output = Result<Option<ToolOutput>, ToolError>> + Send {
-            let idx = self.call_count.fetch_add(1, Ordering::SeqCst);
-            let tool_id = call.tool_id.clone();
-            async move {
-                if idx == 0 {
-                    let _ = tool_id;
-                    Err(ToolError::InvalidParams {
-                        message: "permanent error".to_owned(),
-                    })
-                } else {
-                    Ok(Some(ToolOutput {
-                        tool_name: tool_id,
-                        summary: "ok".to_owned(),
-                        blocks_executed: 1,
-                        diff: None,
-                        filter_stats: None,
-                        streamed: false,
-                        terminal_id: None,
-                        locations: None,
-                        raw_response: None,
-                        claim_source: None,
-                    }))
-                }
-            }
-        }
-    }
 
     let executor = FirstFailsExecutor {
         call_count: Arc::new(AtomicUsize::new(0)),


### PR DESCRIPTION
## Summary

Removes all `#[allow(clippy::too_many_lines)]` suppressions from `zeph-core` by extracting focused private helpers. Pure structural refactoring — no behavioral changes.

**16 suppressions removed across 7 files:**

- `learning/skill_commands.rs` — `handle_skill_create_as_string` → 5 helpers; registry guard dropped before `.await`
- `learning/trust.rs` — `check_trust_transition_inner` → 4 free functions to avoid `&self` across `.await`
- `state/security.rs` — `scrub_pii` → `run_ner_classifier` cfg-gated helper
- `context/summarization/compaction.rs` — `compact_context` → `partition_messages_for_compaction` + `apply_compaction_probe` (`ControlFlow<CompactionOutcome,()>`) + `finalize_compacted_messages`
- `context/summarization/scheduling.rs` — `maybe_compact` / `maybe_refresh_task_goal` / `maybe_refresh_subgoal` split; shared `last_user_content_hash` / `recent_user_assistant_excerpt` extracted
- `tool_execution/sanitize.rs` — `sanitize_tool_output` pipeline split
- `tool_execution/native.rs` — `TierInputs`/`TierMutables` separation, `ToolResultClassification`, `ProcessedToolResults` DTO, dispatch helpers
- `tool_execution/tests.rs` — large integration tests split into focused helpers

## Checks

- `cargo +nightly fmt --check` ✓
- `cargo clippy --workspace -- -D warnings` ✓
- `cargo nextest run --workspace --lib --bins` ✓ — 8602 passed

Closes #3457
Closes #3456
Closes #3454