### PR TITLE
fix(acp): remove /compact from ACP-native command list

### DIFF
--- a/crates/zeph-acp/src/agent/mod.rs
+++ b/crates/zeph-acp/src/agent/mod.rs
@@ -1951,7 +1951,6 @@ impl ZephAcpAgentState {
                  /model <id> — switch the active model\n\
                  /mode <code|architect|ask> — switch session mode\n\
                  /clear — clear session history\n\
-                 /compact — summarize and compact context\n\
                  /review [path] — review recent changes (read-only)"
                 .to_owned(),
             "/model" => self.handle_model_command(session_id, arg)?,
@@ -2651,7 +2650,6 @@ fn is_acp_native_slash_command(trimmed_text: &str) -> bool {
         || trimmed_text.starts_with("/review")
         || trimmed_text == "/model"
         || trimmed_text.starts_with("/model ")
-        || trimmed_text == "/compact"
 }
 
 /// Map `(cancelled, stop_hint)` to the ACP `StopReason` wire value.


### PR DESCRIPTION
## Summary

- Remove `|| trimmed_text == "/compact"` from `is_acp_native_slash_command` so `/compact` is no longer intercepted by the ACP layer
- Remove `/compact` from the `/help` text in `handle_slash_command` to keep it consistent
- `/compact` is now forwarded to the core agent loop where `CompactCommand` handles it correctly

## Root cause

PR #3472 (`bd6b858b`) added `/compact` to the ACP-native command list during a refactor, but `handle_slash_command` has no matching arm for it — the wildcard `_ =>` arm returns `acp::Error::invalid_request("unknown command: /compact")`.

## Test plan

- [ ] `cargo check -p zeph-acp` passes
- [ ] `cargo nextest run --workspace --lib --bins` — 8616 tests pass
- [ ] `cargo +nightly fmt --check` clean
- [ ] `cargo clippy --workspace -- -D warnings` clean

Closes #3474