### PR TITLE
fix(llm): skip embed-only providers when resolving active_provider_name

### DIFF
--- a/src/bootstrap/provider.rs
+++ b/src/bootstrap/provider.rs
@@ -616,4 +616,29 @@ mod tests {
         let result = build_all_pool_providers(&config.llm.providers, &config);
         assert!(result.is_err());
     }
+
+    #[test]
+    fn active_provider_name_skips_embed_only_first_entry() {
+        let providers = vec![
+            ProviderEntry {
+                provider_type: ProviderKind::Ollama,
+                name: Some("embedder".into()),
+                model: Some("nomic-embed-text".into()),
+                embed: true,
+                ..ProviderEntry::default()
+            },
+            ProviderEntry {
+                provider_type: ProviderKind::Ollama,
+                name: Some("chat".into()),
+                model: Some("qwen3:8b".into()),
+                embed: false,
+                ..ProviderEntry::default()
+            },
+        ];
+        let active = providers
+            .iter()
+            .find(|e| !e.embed)
+            .map_or_else(String::new, ProviderEntry::effective_name);
+        assert_eq!(active, "chat");
+    }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1732,7 +1732,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         tool_executor,
     )
     .apply_session_config(session_config)
-    .with_active_provider_name(config.llm.providers.first().map_or_else(
+    .with_active_provider_name(config.llm.providers.iter().find(|e| !e.embed).map_or_else(
         || provider.name().to_owned(),
         zeph_core::config::ProviderEntry::effective_name,
     ))


### PR DESCRIPTION
## Summary

- `providers.first()` in `src/runner.rs` unconditionally picked the first `[[llm.providers]]` entry at startup, including `embed = true` entries
- With Thompson routing this caused `/provider` and `/status` to display the embed-only provider as active while actual LLM requests correctly bypassed it
- Fix: replace `.first()` with `.iter().find(|e| !e.embed)` so `active_provider_name` resolves to the first chat-capable provider

## Changes

- `src/runner.rs:1735` — one-line fix, mirrors existing guard in `build_all_pool_providers`
- `src/bootstrap/provider.rs` — regression test `active_provider_name_skips_embed_only_first_entry`

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — 0 warnings
- [x] `cargo nextest run --workspace --lib --bins` — 8623 passed

Closes #3483