### PR TITLE
fix(core,bootstrap): gate EnvVaultProvider re-export; skip embed-only fallback in provider pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- fix(core): remove `test` arm from `EnvVaultProvider` re-export cfg gate in `zeph-core/src/lib.rs`
+  so that `cargo nextest run -p zeph-core` (no explicit `--features env-vault`) compiles cleanly
+  (#3485, regressed by #3479).
+- fix(bootstrap): `build_single_provider_from_pool` now skips embed-only entries when selecting
+  the fallback provider index, preventing an embed model from being used for chat when no provider
+  has `default = true` (#3484).
+
 - fix(focus): `complete_focus` called in a batch with other tools no longer orphans the
   current-turn tool results (#3476). The truncation in `complete_focus_tool` now preserves
   the current turn's assistant `tool_calls` message so that the subsequent `User(tool_results)`

--- a/crates/zeph-core/src/lib.rs
+++ b/crates/zeph-core/src/lib.rs
@@ -149,7 +149,7 @@ pub mod vault {
     /// This provider reads secrets from process environment variables and is
     /// intended **exclusively for development and testing**. Never enable this
     /// feature in production builds. Use [`AgeVaultProvider`] instead.
-    #[cfg(any(test, feature = "env-vault"))]
+    #[cfg(feature = "env-vault")]
     pub use zeph_vault::EnvVaultProvider;
 
     #[cfg(any(test, feature = "mock"))]

--- a/src/bootstrap/provider.rs
+++ b/src/bootstrap/provider.rs
@@ -520,7 +520,11 @@ fn build_single_provider_from_pool(
     pool: &[ProviderEntry],
     config: &Config,
 ) -> Result<AnyProvider, BootstrapError> {
-    let primary_idx = pool.iter().position(|e| e.default).unwrap_or(0);
+    let primary_idx = pool
+        .iter()
+        .position(|e| e.default)
+        .or_else(|| pool.iter().position(|e| !e.embed))
+        .unwrap_or(0);
     let primary = &pool[primary_idx];
     match build_provider_from_entry(primary, config) {
         Ok(p) => Ok(p),


### PR DESCRIPTION
## Summary

- **#3485** — Remove `test` arm from `#[cfg(any(test, feature = "env-vault"))]` gate on `EnvVaultProvider` re-export in `zeph-core/src/lib.rs`. The arm caused test builds to include the re-export even when `zeph-vault/env-vault` was not activated, making `cargo nextest run -p zeph-core` fail without explicit `--features env-vault`.
- **#3484** — In `build_single_provider_from_pool`, add an `or_else` fallback that skips embed-only entries when no provider has `default = true`, preventing an embed model from silently being used for chat. Mirrors the existing guard in `build_all_pool_providers`.

## Test plan

- [x] `cargo nextest run -p zeph-core` (no `--features`) — 1508/1508 pass
- [x] `cargo nextest run --workspace --lib --bins` — 8623/8623 pass
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy` (CI feature scope) — 0 warnings

Closes #3485
Closes #3484