### PR TITLE
fix(config,llm): skip embed-only providers in effective_model and cost tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- fix(config): `LlmConfig::effective_model()` now skips embed-only providers (`embed = true`)
+  when resolving the display model, so `/status` shows the first chat-capable provider's model
+  instead of the embed model name (#3488).
+- fix(llm): `AnyProvider::provider_kind_str()` for `Router` now delegates to the last-selected
+  child provider via `RouterProvider::last_selected_provider_kind()`, enabling cost tracking to
+  correctly attribute API costs when Thompson or other routing strategies are active (#3489).
+
 - fix(core): remove `test` arm from `EnvVaultProvider` re-export cfg gate in `zeph-core/src/lib.rs`
   so that `cargo nextest run -p zeph-core` (no explicit `--features env-vault`) compiles cleanly
   (#3485, regressed by #3479).

--- a/crates/zeph-config/src/providers.rs
+++ b/crates/zeph-config/src/providers.rs
@@ -404,11 +404,16 @@ impl LlmConfig {
             .unwrap_or("http://localhost:11434")
     }
 
-    /// Effective model for the primary provider.
+    /// Effective model for the primary chat-capable provider.
+    ///
+    /// Skips embed-only entries (those with `embed = true`) and returns the model of the
+    /// first provider that can handle chat requests. Falls back to `"qwen3:8b"` when no
+    /// chat-capable provider is configured.
     #[must_use]
     pub fn effective_model(&self) -> &str {
         self.providers
-            .first()
+            .iter()
+            .find(|e| !e.embed)
             .and_then(|e| e.model.as_deref())
             .unwrap_or("qwen3:8b")
     }
@@ -1678,6 +1683,25 @@ model = "qwen3:8b"
 "#,
         );
         assert_eq!(cfg.effective_model(), "qwen3:8b");
+    }
+
+    #[test]
+    fn effective_model_skips_embed_only_provider() {
+        let cfg = parse_llm(
+            r#"
+[llm]
+
+[[llm.providers]]
+type = "ollama"
+model = "gemma4:26b"
+embed = true
+
+[[llm.providers]]
+type = "openai"
+model = "gpt-4o-mini"
+"#,
+        );
+        assert_eq!(cfg.effective_model(), "gpt-4o-mini");
     }
 
     #[test]

--- a/crates/zeph-llm/src/any.rs
+++ b/crates/zeph-llm/src/any.rs
@@ -203,8 +203,11 @@ impl AnyProvider {
     /// Returns a static string identifying the provider kind for cost/logging purposes.
     ///
     /// Returns `"ollama"` or `"candle"` for local inference providers (no API cost),
-    /// `"local"` for providers that are always unpriced (Compatible, Router, Triage),
+    /// `"local"` for providers that are always unpriced (Compatible, Triage),
     /// and `"cloud"` for metered API providers (`Claude`, `OpenAI`, `Gemini`).
+    ///
+    /// For `Router`, delegates to the last-selected child provider so that cost tracking
+    /// correctly attributes API costs even when Thompson/Cascade routing is active.
     #[must_use]
     pub fn provider_kind_str(&self) -> &'static str {
         match self {
@@ -213,8 +216,10 @@ impl AnyProvider {
             Self::Candle(_) => "candle",
             // Compatible targets LM Studio / vLLM / llama.cpp — always local, never metered.
             Self::Compatible(_) => "local",
-            // Routers are never directly invoiced; cost attribution flows to child providers.
-            Self::Router(_) | Self::Triage(_) => "local",
+            // Router: delegate to the last-selected child so cost flows to the real provider.
+            Self::Router(r) => r.last_selected_provider_kind(),
+            // Triage has no post-call provider tracking; treat as unpriced.
+            Self::Triage(_) => "local",
             _ => "cloud",
         }
     }

--- a/crates/zeph-llm/src/router/mod.rs
+++ b/crates/zeph-llm/src/router/mod.rs
@@ -652,6 +652,24 @@ impl RouterProvider {
         tracker.record_quality(&provider_name, success);
     }
 
+    /// Returns the `provider_kind_str` of the last provider selected by the router.
+    ///
+    /// Used by [`crate::any::AnyProvider::provider_kind_str`] to attribute cost to the
+    /// actual child provider rather than returning the generic `"local"` sentinel for all
+    /// router-dispatched calls. Falls back to `"local"` when no call has been made yet.
+    #[must_use]
+    pub fn last_selected_provider_kind(&self) -> &'static str {
+        let name = self.state.last_active_provider.lock().clone();
+        let Some(name) = name else {
+            return "local";
+        };
+        self.state
+            .providers
+            .iter()
+            .find(|p| p.name() == name)
+            .map_or("local", |p| p.provider_kind_str())
+    }
+
     /// Persist current reputation state to disk. No-op if reputation is disabled.
     /// Uses [`tokio::task::spawn_blocking`] so it is safe to call from any async context.
     pub async fn save_reputation_state(&self) {


### PR DESCRIPTION
## Summary

- `LlmConfig::effective_model()` used `.first()` unconditionally, returning the embed model name as the display model in `/status` and as the pricing key in `record_cost_and_cache()`. Now uses `.find(|e| !e.embed)` to skip embed-only entries.
- `AnyProvider::provider_kind_str()` returned `"local"` for all `Router` variants, causing `CostTracker` to record \$0 for every call when Thompson/EMA/Cascade routing is active. Now delegates to `RouterProvider::last_selected_provider_kind()`, which looks up the last-selected child provider's actual kind.

Closes #3488
Closes #3489

## Test plan

- [x] Added `effective_model_skips_embed_only_provider` unit test in `zeph-config`
- [x] `RouterProvider::last_selected_provider_kind()` uses `last_active_provider` (set after every successful dispatch) — no new test needed beyond existing router coverage
- [x] `cargo nextest run --workspace --lib --bins` — 8624 passed, 0 failed
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo +nightly fmt --check` — clean