### PR TITLE
fix(ci,tui): fix clippy violations in test targets and compact metrics signal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
         with:
           shared-key: "ci"
       - name: Clippy
-        run: cargo clippy --profile ci --workspace --features ${{ matrix.features }} -- -D warnings
+        run: cargo clippy --profile ci --workspace --all-targets --features ${{ matrix.features }} -- -D warnings
 
   msrv:
     name: MSRV check (1.95, ${{ matrix.label }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fix(llm): `AnyProvider::provider_kind_str()` for `Router` now delegates to the last-selected
   child provider via `RouterProvider::last_selected_provider_kind()`, enabling cost tracking to
   correctly attribute API costs when Thompson or other routing strategies are active (#3489).
+- fix(ci): add `--all-targets` to the clippy step so test-target violations are caught in CI (#3490).
+- fix(tui): `/compact` slash command now updates `compaction_last_*` metrics, making the TUI
+  compaction badge visible after manual compaction (#3493). `emit_compaction_status_signal` is
+  called from `compact_context()` after `finalize_compacted_messages` completes.
 
 - fix(core): remove `test` arm from `EnvVaultProvider` re-export cfg gate in `zeph-core/src/lib.rs`
   so that `cargo nextest run -p zeph-core` (no explicit `--features env-vault`) compiles cleanly

--- a/crates/zeph-core/src/agent/context/summarization/compaction.rs
+++ b/crates/zeph-core/src/agent/context/summarization/compaction.rs
@@ -357,6 +357,7 @@ impl<C: Channel> Agent<C> {
         }
 
         let compacted_count = to_compact.len();
+        let tokens_before = self.providers.cached_prompt_tokens;
         // Inject archived references as a postfix AFTER the LLM summary (fix C1).
         // The LLM summary is unaware of archives; the postfix ensures references survive.
         let archive_postfix = if archived_refs.is_empty() {
@@ -377,6 +378,8 @@ impl<C: Channel> Agent<C> {
             compacted_count,
             &summary,
         );
+
+        self.emit_compaction_status_signal(tokens_before).await;
 
         // Extract memory params before .await so no &self is held across the persist boundary.
         let (persist_failed, qdrant_fut) = {

--- a/crates/zeph-core/src/agent/context/summarization/scheduling.rs
+++ b/crates/zeph-core/src/agent/context/summarization/scheduling.rs
@@ -401,7 +401,7 @@ impl<C: Channel> Agent<C> {
     }
 
     /// Emit a UX status signal when tokens were actually freed by compaction (#3314).
-    async fn emit_compaction_status_signal(&mut self, tokens_before: u64) {
+    pub(in crate::agent) async fn emit_compaction_status_signal(&mut self, tokens_before: u64) {
         let tokens_after = self.providers.cached_prompt_tokens;
         if tokens_after < tokens_before {
             let now_ms = u64::try_from(

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -4067,8 +4067,8 @@ mod tests {
         );
     }
 
-    /// Regression test for #3476: when complete_focus is called in a batch with other
-    /// tools, the current turn's assistant tool_calls message must be preserved after
+    /// Regression test for #3476: when `complete_focus` is called in a batch with other
+    /// tools, the current turn's assistant `tool_calls` message must be preserved after
     /// truncation so the subsequent tool results have a valid parent.
     #[test]
     fn complete_focus_in_batch_preserves_current_turn_assistant_message() {

--- a/crates/zeph-llm/src/provider_dyn.rs
+++ b/crates/zeph-llm/src/provider_dyn.rs
@@ -396,7 +396,7 @@ mod tests {
             false
         }
 
-        fn name(&self) -> &str {
+        fn name(&self) -> &'static str {
             "stub"
         }
     }

--- a/crates/zeph-memory/src/compression/promotion.rs
+++ b/crates/zeph-memory/src/compression/promotion.rs
@@ -366,7 +366,9 @@ mod tests {
         v[0] = val;
         // Normalise to unit length.
         let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
-        v.iter_mut().for_each(|x| *x /= norm);
+        for x in &mut v {
+            *x /= norm;
+        }
         v
     }
 

--- a/crates/zeph-memory/src/graph/store/tests.rs
+++ b/crates/zeph-memory/src/graph/store/tests.rs
@@ -994,6 +994,7 @@ async fn seed_pre_023_fixtures(pool: &sqlx::SqlitePool) -> (i64, i64) {
 ///
 /// Must use a single connection so `PRAGMA foreign_keys = OFF` takes effect on the same
 /// connection that executes DROP TABLE (PRAGMA is per-connection, not per-transaction).
+#[allow(clippy::too_many_lines)]
 async fn apply_migration_024(conn: &mut sqlx::SqliteConnection) {
     sqlx::query(sql!("PRAGMA foreign_keys = OFF"))
         .execute(&mut *conn)

--- a/crates/zeph-memory/src/reasoning.rs
+++ b/crates/zeph-memory/src/reasoning.rs
@@ -1072,7 +1072,7 @@ mod tests {
             mem.insert(&make_strategy(&id), vec![]).await.unwrap();
             // Make hot.
             for _ in 0..=HOT_STRATEGY_USE_COUNT {
-                mem.mark_used(&[id.clone()]).await.unwrap();
+                mem.mark_used(std::slice::from_ref(&id)).await.unwrap();
             }
         }
 

--- a/crates/zeph-memory/tests/hela_spreading_activation.rs
+++ b/crates/zeph-memory/tests/hela_spreading_activation.rs
@@ -49,7 +49,7 @@ async fn setup() -> (
     (graph, embeddings, sqlite, container)
 }
 
-/// Seed a named entity into both SQLite graph and Qdrant entity collection.
+/// Seed a named entity into both `SQLite` graph and Qdrant entity collection.
 ///
 /// Returns `(entity_id, point_id)`. The `point_id` is set in `qdrant_point_id` so that
 /// `qdrant_point_ids_for_entities` can find it.
@@ -204,9 +204,8 @@ async fn hela_depth_one_excludes_two_hop() {
     for fact in &results {
         let src = fact.edge.source_entity_id;
         let tgt = fact.edge.target_entity_id;
-        assert_ne!(
-            (src == hop2_id) || (tgt == hop2_id),
-            true,
+        assert!(
+            !((src == hop2_id) || (tgt == hop2_id)),
             "C must not appear in depth-1 results"
         );
     }

--- a/crates/zeph-skills/src/bm25.rs
+++ b/crates/zeph-skills/src/bm25.rs
@@ -389,6 +389,7 @@ mod tests {
     }
 
     /// All normalized scores must stay in [0, 1].
+    #[allow(clippy::cast_precision_loss)]
     #[test]
     fn rrf_fuse_scores_bounded_zero_to_one() {
         let emb: Vec<ScoredMatch> = (0..10)

--- a/src/bootstrap/provider.rs
+++ b/src/bootstrap/provider.rs
@@ -623,7 +623,7 @@ mod tests {
 
     #[test]
     fn active_provider_name_skips_embed_only_first_entry() {
-        let providers = vec![
+        let providers = [
             ProviderEntry {
                 provider_type: ProviderKind::Ollama,
                 name: Some("embedder".into()),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -743,12 +743,13 @@ mod tests {
     }
 
     fn config_with_a2a(advertise_files: bool) -> Config {
-        let mut cfg = Config::default();
-        cfg.a2a = A2aServerConfig {
-            advertise_files,
-            ..A2aServerConfig::default()
-        };
-        cfg
+        Config {
+            a2a: A2aServerConfig {
+                advertise_files,
+                ..A2aServerConfig::default()
+            },
+            ..Config::default()
+        }
     }
 
     /// Build a config that has an STT provider entry wired up, so `stt_provider_entry()` returns `Some`.


### PR DESCRIPTION
## Summary

- Add `--all-targets` to the CI clippy step so test-target violations are caught going forward (#3490). Fix all 11 pre-existing violations in test code across `zeph-memory`, `zeph-skills`, `zeph-llm`, and the binary crates.
- Fix `/compact` slash command not updating `compaction_last_*` metrics, which kept the TUI compaction badge hidden after manual compaction (#3493). `emit_compaction_status_signal` is now called from `compact_context()` after `finalize_compacted_messages` completes.

## Changes

### Issue #3490 — clippy violations in test targets
- `crates/zeph-memory/tests/hela_spreading_activation.rs` — doc_markdown and bool_assert_comparison fixes
- `crates/zeph-skills/src/bm25.rs` — `#[allow(clippy::cast_precision_loss)]` on bounded test cast
- `crates/zeph-llm/src/provider_dyn.rs` — test mock `name()` returns `&'static str`
- `crates/zeph-memory/src/compression/promotion.rs` — needless_for_each → for loop
- `crates/zeph-memory/src/reasoning.rs` — `std::slice::from_ref` instead of `&[id.clone()]`
- `crates/zeph-memory/src/graph/store/tests.rs` — `#[allow(clippy::too_many_lines)]` on migration test helper
- `src/daemon.rs`, `src/bootstrap/provider.rs`, `crates/zeph-core/src/agent/tool_execution/native.rs` — additional violations surfaced by --all-targets
- `.github/workflows/ci.yml` — add `--all-targets` to clippy step

### Issue #3493 — compact metrics
- `crates/zeph-core/src/agent/context/summarization/scheduling.rs` — `emit_compaction_status_signal` changed to `pub(in crate::agent)`
- `crates/zeph-core/src/agent/context/summarization/compaction.rs` — capture `tokens_before` before `finalize_compacted_messages`, call `emit_compaction_status_signal` after

## Test plan

- [ ] `cargo +nightly fmt --check` — passes
- [ ] `cargo clippy --workspace --features full --all-targets -- -D warnings` — 0 errors (verified locally)
- [ ] `cargo nextest run --workspace --features full --lib --bins` — 8963 passed
- [ ] Manual TUI test: run `/compact` in a session, verify TUI compaction badge appears

Closes #3490
Closes #3493