### PR TITLE
fix(daemon,bootstrap): resolve dedicated MCP embed provider in daemon mode; add unit test

### DIFF
--- a/src/bootstrap/provider.rs
+++ b/src/bootstrap/provider.rs
@@ -516,7 +516,7 @@ fn build_triage_provider(
 }
 
 /// Pick the default (or first) provider from the pool with fallback on failure.
-fn build_single_provider_from_pool(
+pub(crate) fn build_single_provider_from_pool(
     pool: &[ProviderEntry],
     config: &Config,
 ) -> Result<AnyProvider, BootstrapError> {
@@ -644,5 +644,32 @@ mod tests {
             .find(|e| !e.embed)
             .map_or_else(String::new, ProviderEntry::effective_name);
         assert_eq!(active, "chat");
+    }
+
+    #[test]
+    fn build_single_provider_skips_embed_only_first_entry() {
+        use super::build_single_provider_from_pool;
+
+        let mut config = Config::load(Path::new("/nonexistent")).unwrap();
+        config.llm.providers = vec![
+            ProviderEntry {
+                provider_type: ProviderKind::Ollama,
+                name: Some("embedder".into()),
+                model: Some("nomic-embed-text".into()),
+                embed: true,
+                ..ProviderEntry::default()
+            },
+            ProviderEntry {
+                provider_type: ProviderKind::Ollama,
+                name: Some("chat".into()),
+                model: Some("qwen3:8b".into()),
+                embed: false,
+                ..ProviderEntry::default()
+            },
+        ];
+        // build_single_provider_from_pool must select the non-embed entry (index 1) as primary.
+        // For Ollama, provider construction succeeds without a live server.
+        let result = build_single_provider_from_pool(&config.llm.providers, &config);
+        assert!(result.is_ok(), "expected Ok but got: {result:?}");
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -449,9 +449,32 @@ pub(crate) async fn run_daemon(
             ),
         )));
 
+    let mcp_embed_provider = {
+        let discovery = &config.mcp.tool_discovery;
+        if discovery.embedding_provider.is_empty() {
+            provider.clone()
+        } else {
+            match crate::bootstrap::create_named_provider(&discovery.embedding_provider, config) {
+                Ok(p) => {
+                    tracing::info!(
+                        provider = %discovery.embedding_provider,
+                        "Using dedicated embed provider for MCP registry"
+                    );
+                    p
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        provider = %discovery.embedding_provider,
+                        "MCP registry embed_provider resolution failed, using main provider: {e:#}"
+                    );
+                    provider.clone()
+                }
+            }
+        }
+    };
     let mcp_registry = create_mcp_registry(
         config,
-        &provider,
+        &mcp_embed_provider,
         &mcp_tools,
         &embed_model,
         app.qdrant_ops(),


### PR DESCRIPTION
## Summary

- **#3501**: In `--daemon` mode, `create_mcp_registry` was called with the main provider (e.g. `openai-stt`, 1536-dim) instead of the dedicated embed provider configured at `mcp.tool_discovery.embedding_provider` (e.g. `ollama-embed`, 768-dim). This caused a dimension mismatch at startup and MCP tool search failures on every A2A turn. Applied the same provider resolution block already present in `runner.rs:1641-1666` to `daemon.rs`.
- **#3491**: Exposed `build_single_provider_from_pool` as `pub(crate)` and added test `build_single_provider_skips_embed_only_first_entry` to cover the `.or_else(|| pool.iter().position(|e| !e.embed))` fallback introduced in bdd6db76 (#3487).

## Test plan

- [ ] `cargo +nightly fmt --check` — passes
- [ ] `cargo clippy --workspace -- -D warnings` — passes (0 warnings)
- [ ] `cargo nextest run --workspace --lib --bins` — 8625 passed, 21 skipped
- [ ] New test `build_single_provider_skips_embed_only_first_entry` covers the embed-only-first fallback path in `build_single_provider_from_pool`
- [ ] Daemon mode: with `embedding_provider = "ollama-embed"` and main provider `openai-stt`, `create_mcp_registry` now receives the 768-dim embed provider, eliminating the dimension mismatch WARN on startup and every turn

Closes #3501
Closes #3491