### PR TITLE
fix(scheduler,gateway): hydrate CLI jobs at startup and wire webhook forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- fix(scheduler): `Scheduler::init()` now hydrates CLI-added periodic jobs from the DB into
+  `self.tasks` on startup; jobs written via `zeph schedule add` are visible to `tick()` and
+  fire on their cron schedule without requiring a daemon restart (#3499).
+- fix(gateway): `spawn_gateway_server` now forwards webhook payloads to the agent loop via
+  `GatewayChannel<C>` instead of silently draining them; the wrapper merges webhook and
+  interactive input with interactive-first bias so live sessions stay responsive (#3500).
+
 - fix(config): `LlmConfig::effective_model()` now skips embed-only providers (`embed = true`)
   when resolving the display model, so `/status` shows the first chat-capable provider's model
   instead of the embed model name (#3488).

--- a/crates/zeph-scheduler/src/scheduler.rs
+++ b/crates/zeph-scheduler/src/scheduler.rs
@@ -167,7 +167,7 @@ impl Scheduler {
     /// Then all periodic jobs stored in the DB that are not already present in `self.tasks`
     /// (by name) are reconstructed from their persisted `cron_expr` and appended — this ensures
     /// that jobs added via the CLI (which write directly to the store) are visible to
-    /// [`Scheduler::tick`] and [`Scheduler::catch_up_missed`] on the next startup.
+    /// `tick` and [`Scheduler::catch_up_missed`] on the next startup.
     ///
     /// # Errors
     ///

--- a/crates/zeph-scheduler/src/scheduler.rs
+++ b/crates/zeph-scheduler/src/scheduler.rs
@@ -160,12 +160,19 @@ impl Scheduler {
         self.handlers.insert(kind.as_str().to_owned(), handler);
     }
 
-    /// Initialize the store, sync task definitions, and compute initial `next_run` for each task.
+    /// Initialize the store, sync task definitions, compute initial `next_run` for each task,
+    /// and hydrate any CLI-added periodic jobs that live only in the DB back into `self.tasks`.
+    ///
+    /// Static tasks registered via [`Scheduler::add_task`] are upserted into the store first.
+    /// Then all periodic jobs stored in the DB that are not already present in `self.tasks`
+    /// (by name) are reconstructed from their persisted `cron_expr` and appended — this ensures
+    /// that jobs added via the CLI (which write directly to the store) are visible to
+    /// [`Scheduler::tick`] and [`Scheduler::catch_up_missed`] on the next startup.
     ///
     /// # Errors
     ///
-    /// Returns an error if DB init, upsert, or `next_run` persistence fails.
-    pub async fn init(&self) -> Result<(), SchedulerError> {
+    /// Returns an error if DB init, upsert, `next_run` persistence, or job listing fails.
+    pub async fn init(&mut self) -> Result<(), SchedulerError> {
         self.store.init().await?;
         let now = Utc::now();
         for task in &self.tasks {
@@ -212,6 +219,62 @@ impl Scheduler {
                 }
             }
         }
+
+        // Hydrate periodic jobs added via CLI (or other out-of-process writers) that were
+        // persisted in the store but never registered in self.tasks. Without this step,
+        // tick() and catch_up_missed() silently ignore them on every restart.
+        let stored_jobs = self.store.list_jobs_full().await?;
+        // Collect owned strings to release the borrow on self.tasks before mutating it below.
+        let static_names: std::collections::HashSet<String> =
+            self.tasks.iter().map(|t| t.name.clone()).collect();
+
+        for job in stored_jobs {
+            if job.task_mode != "periodic" || static_names.contains(&job.name) {
+                continue;
+            }
+            match ScheduledTask::periodic(
+                job.name.clone(),
+                &job.cron_expr,
+                crate::task::TaskKind::from_str_kind(&job.kind),
+                serde_json::Value::Null,
+            ) {
+                Ok(task) => {
+                    // Compute next_run if not already stored (same logic as for static tasks).
+                    if self.store.get_next_run(&job.name).await?.is_none()
+                        && let Some(schedule) = task.cron_schedule()
+                    {
+                        match schedule.after(&now).next() {
+                            Some(next) => {
+                                if let Err(e) =
+                                    self.store.set_next_run(&job.name, &next.to_rfc3339()).await
+                                {
+                                    tracing::warn!(
+                                        task = %job.name,
+                                        "failed to persist next_run for hydrated job: {e}"
+                                    );
+                                }
+                            }
+                            None => {
+                                tracing::warn!(
+                                    task = %job.name,
+                                    "cron produces no future occurrence, skipping next_run"
+                                );
+                            }
+                        }
+                    }
+                    tracing::debug!(task = %job.name, "hydrated CLI-added periodic job from store");
+                    self.tasks.push(task);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        task = %job.name,
+                        cron_expr = %job.cron_expr,
+                        "skipping persisted job with invalid cron expression: {e}"
+                    );
+                }
+            }
+        }
+
         Ok(())
     }
 
@@ -967,6 +1030,104 @@ mod tests {
             scheduler.tasks.len(),
             0,
             "completed oneshot must be removed from tasks"
+        );
+    }
+
+    /// `init()` hydrates periodic jobs that were written to the store out-of-process
+    /// (e.g. via the CLI) and are NOT present in `self.tasks` at construction time.
+    ///
+    /// Regression test for fix #3499: before the fix, CLI-added jobs were never fired
+    /// because `init()` did not call `store.list_jobs_full()` to backfill `self.tasks`.
+    #[tokio::test]
+    async fn init_hydrates_cli_added_periodic_jobs_from_store() {
+        let pool = test_pool().await;
+        let store = JobStore::new(pool.clone());
+
+        // Simulate CLI insertion: write a periodic job directly to the store
+        // *before* the Scheduler is constructed — mimicking a CLI `schedule add` command
+        // that writes to the DB while the daemon is not running.
+        store.init().await.unwrap();
+        store
+            .upsert_job_with_mode(
+                "cli-job",
+                "0 * * * * *",
+                "health_check",
+                "periodic",
+                None,
+                "",
+            )
+            .await
+            .unwrap();
+
+        // Construct a fresh Scheduler with an empty task list (no add_task calls),
+        // pointing at the same pool that already has the CLI-added job.
+        let store2 = JobStore::new(pool.clone());
+        let (_tx, rx) = watch::channel(false);
+        let (mut scheduler, _msg_tx) = Scheduler::new(store2, rx);
+
+        // Before init() self.tasks is empty.
+        assert_eq!(
+            scheduler.tasks.len(),
+            0,
+            "tasks must be empty before init()"
+        );
+
+        scheduler.init().await.unwrap();
+
+        // After init() the CLI-added periodic job must have been hydrated.
+        assert_eq!(
+            scheduler.tasks.len(),
+            1,
+            "init() must hydrate the CLI-added periodic job from the store"
+        );
+        assert_eq!(
+            scheduler.tasks[0].name, "cli-job",
+            "hydrated task name must match the DB row"
+        );
+
+        // next_run must have been computed and persisted.
+        let next_run = store.get_next_run("cli-job").await.unwrap();
+        assert!(
+            next_run.is_some(),
+            "init() must compute and persist next_run for the hydrated job"
+        );
+        let dt = next_run
+            .unwrap()
+            .parse::<chrono::DateTime<chrono::Utc>>()
+            .expect("next_run must be a valid RFC3339 timestamp");
+        assert!(
+            dt > chrono::Utc::now(),
+            "next_run must be in the future after hydration"
+        );
+    }
+
+    /// `init()` does NOT re-add jobs that are already present in `self.tasks` — avoids
+    /// duplicates when both `add_task()` and a DB record exist for the same name.
+    #[tokio::test]
+    async fn init_does_not_duplicate_static_tasks_already_in_tasks() {
+        let pool = test_pool().await;
+        let store = JobStore::new(pool.clone());
+        let (_tx, rx) = watch::channel(false);
+        let (mut scheduler, _msg_tx) = Scheduler::new(store, rx);
+
+        // Register via add_task (static path).
+        let task = ScheduledTask::new(
+            "static-job",
+            "0 * * * * *",
+            TaskKind::HealthCheck,
+            serde_json::Value::Null,
+        )
+        .unwrap();
+        scheduler.add_task(task);
+
+        // init() upserts the task into the store AND then calls list_jobs_full().
+        // The job will be in both self.tasks AND the DB; hydration must skip it.
+        scheduler.init().await.unwrap();
+
+        assert_eq!(
+            scheduler.tasks.len(),
+            1,
+            "init() must not duplicate a static task that is already in self.tasks"
         );
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -676,6 +676,10 @@ pub(crate) async fn run_daemon(
         .await;
 
     let a2a_sanitizer = zeph_core::ContentSanitizer::new(&config.security.content_isolation);
+    // Clone input_tx before consuming loopback_handle so the gateway can also inject
+    // messages into the agent loop after the A2A server takes ownership of the handle.
+    #[cfg(feature = "gateway")]
+    let gateway_input_tx = loopback_handle.input_tx.clone();
     spawn_a2a_server(
         config,
         shutdown_rx.clone(),
@@ -690,6 +694,7 @@ pub(crate) async fn run_daemon(
         spawn_gateway_server(
             config,
             shutdown_rx.clone(),
+            gateway_input_tx,
             // Daemon mode has no MetricsSnapshot watch channel — skip Prometheus sync.
             #[cfg(feature = "prometheus")]
             None,

--- a/src/gateway_spawn.rs
+++ b/src/gateway_spawn.rs
@@ -1,10 +1,143 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+/// Wraps an existing [`zeph_core::channel::Channel`] and merges in webhook payloads
+/// arriving on a dedicated mpsc receiver.
+///
+/// All output methods (`send`, `send_chunk`, etc.) are forwarded to the inner channel
+/// unchanged. Only the inbound path (`recv`, `try_recv`) also checks the webhook
+/// receiver so the agent sees webhook payloads as regular [`ChannelMessage`]s.
+#[cfg(feature = "gateway")]
+pub(crate) struct GatewayChannel<C> {
+    inner: C,
+    webhook_rx: tokio::sync::mpsc::Receiver<zeph_core::ChannelMessage>,
+}
+
+#[cfg(feature = "gateway")]
+impl<C> GatewayChannel<C> {
+    /// Wrap `inner` and merge webhook messages from `webhook_rx`.
+    pub(crate) fn new(
+        inner: C,
+        webhook_rx: tokio::sync::mpsc::Receiver<zeph_core::ChannelMessage>,
+    ) -> Self {
+        Self { inner, webhook_rx }
+    }
+}
+
+#[cfg(feature = "gateway")]
+impl<C: zeph_core::channel::Channel> zeph_core::channel::Channel for GatewayChannel<C> {
+    async fn recv(
+        &mut self,
+    ) -> Result<Option<zeph_core::ChannelMessage>, zeph_core::channel::ChannelError> {
+        tokio::select! {
+            // Bias toward the inner channel (user input) so interactive sessions feel
+            // responsive. biased = first branch wins when both are ready.
+            biased;
+            result = self.inner.recv() => result,
+            msg = self.webhook_rx.recv() => Ok(msg),
+        }
+    }
+
+    fn try_recv(&mut self) -> Option<zeph_core::ChannelMessage> {
+        self.inner
+            .try_recv()
+            .or_else(|| self.webhook_rx.try_recv().ok())
+    }
+
+    fn supports_exit(&self) -> bool {
+        self.inner.supports_exit()
+    }
+
+    async fn send(&mut self, text: &str) -> Result<(), zeph_core::channel::ChannelError> {
+        self.inner.send(text).await
+    }
+
+    async fn send_chunk(&mut self, chunk: &str) -> Result<(), zeph_core::channel::ChannelError> {
+        self.inner.send_chunk(chunk).await
+    }
+
+    async fn flush_chunks(&mut self) -> Result<(), zeph_core::channel::ChannelError> {
+        self.inner.flush_chunks().await
+    }
+
+    async fn send_typing(&mut self) -> Result<(), zeph_core::channel::ChannelError> {
+        self.inner.send_typing().await
+    }
+
+    async fn send_status(&mut self, text: &str) -> Result<(), zeph_core::channel::ChannelError> {
+        self.inner.send_status(text).await
+    }
+
+    async fn send_thinking_chunk(
+        &mut self,
+        chunk: &str,
+    ) -> Result<(), zeph_core::channel::ChannelError> {
+        self.inner.send_thinking_chunk(chunk).await
+    }
+
+    async fn send_queue_count(
+        &mut self,
+        count: usize,
+    ) -> Result<(), zeph_core::channel::ChannelError> {
+        self.inner.send_queue_count(count).await
+    }
+
+    async fn send_usage(
+        &mut self,
+        input_tokens: u64,
+        output_tokens: u64,
+        context_window: u64,
+    ) -> Result<(), zeph_core::channel::ChannelError> {
+        self.inner
+            .send_usage(input_tokens, output_tokens, context_window)
+            .await
+    }
+
+    async fn send_diff(
+        &mut self,
+        diff: zeph_core::DiffData,
+    ) -> Result<(), zeph_core::channel::ChannelError> {
+        self.inner.send_diff(diff).await
+    }
+
+    async fn send_tool_start(
+        &mut self,
+        event: zeph_core::channel::ToolStartEvent,
+    ) -> Result<(), zeph_core::channel::ChannelError> {
+        self.inner.send_tool_start(event).await
+    }
+
+    async fn send_tool_output(
+        &mut self,
+        event: zeph_core::channel::ToolOutputEvent,
+    ) -> Result<(), zeph_core::channel::ChannelError> {
+        self.inner.send_tool_output(event).await
+    }
+
+    async fn confirm(&mut self, prompt: &str) -> Result<bool, zeph_core::channel::ChannelError> {
+        self.inner.confirm(prompt).await
+    }
+
+    async fn elicit(
+        &mut self,
+        request: zeph_core::channel::ElicitationRequest,
+    ) -> Result<zeph_core::channel::ElicitationResponse, zeph_core::channel::ChannelError> {
+        self.inner.elicit(request).await
+    }
+
+    async fn send_stop_hint(
+        &mut self,
+        hint: zeph_core::channel::StopHint,
+    ) -> Result<(), zeph_core::channel::ChannelError> {
+        self.inner.send_stop_hint(hint).await
+    }
+}
+
 #[cfg(feature = "gateway")]
 pub(crate) fn spawn_gateway_server(
     config: &zeph_core::config::Config,
     shutdown_rx: tokio::sync::watch::Receiver<bool>,
+    agent_input_tx: tokio::sync::mpsc::Sender<zeph_core::ChannelMessage>,
     #[cfg(feature = "prometheus")] metrics_registry: Option<(
         std::sync::Arc<prometheus_client::registry::Registry>,
         String,
@@ -42,13 +175,80 @@ pub(crate) fn spawn_gateway_server(
         }
     });
 
-    // Drain incoming webhooks — full agent loopback wiring tracked in #1026.
     tokio::spawn(async move {
         while let Some(payload) = webhook_rx.recv().await {
-            tracing::debug!(
-                bytes = payload.len(),
-                "webhook received (loopback not wired)"
-            );
+            let msg = zeph_core::ChannelMessage {
+                text: payload,
+                attachments: vec![],
+            };
+            if agent_input_tx.send(msg).await.is_err() {
+                tracing::debug!("gateway: agent input channel closed, stopping webhook forwarder");
+                break;
+            }
         }
     });
+}
+
+#[cfg(all(test, feature = "gateway"))]
+mod tests {
+    use super::*;
+    use zeph_core::channel::Channel as _;
+    use zeph_core::{ChannelMessage, LoopbackChannel};
+
+    /// `GatewayChannel::try_recv` returns a webhook message when the inner channel
+    /// has nothing queued — validates the merge path from fix #3500.
+    #[test]
+    fn try_recv_returns_webhook_message_when_inner_empty() {
+        let (inner, _handle) = LoopbackChannel::pair(8);
+        let (webhook_tx, webhook_rx) = tokio::sync::mpsc::channel::<ChannelMessage>(8);
+
+        let mut ch = GatewayChannel::new(inner, webhook_rx);
+
+        // No message yet — try_recv returns None.
+        assert!(ch.try_recv().is_none(), "must be empty before any send");
+
+        // Send a webhook payload.
+        let msg = ChannelMessage {
+            text: "hello from webhook".into(),
+            attachments: vec![],
+        };
+        webhook_tx.try_send(msg).unwrap();
+
+        // Now try_recv must surface the webhook message.
+        let received = ch
+            .try_recv()
+            .expect("must receive the queued webhook message");
+        assert_eq!(received.text, "hello from webhook");
+    }
+
+    /// `GatewayChannel::recv` resolves with a webhook message when the inner channel
+    /// is closed and only the webhook receiver has a pending message.
+    #[tokio::test]
+    async fn recv_yields_webhook_message() {
+        let (inner, _handle) = LoopbackChannel::pair(8);
+        let (webhook_tx, webhook_rx) = tokio::sync::mpsc::channel::<ChannelMessage>(8);
+
+        let mut ch = GatewayChannel::new(inner, webhook_rx);
+
+        let msg = ChannelMessage {
+            text: "webhook payload".into(),
+            attachments: vec![],
+        };
+        webhook_tx.send(msg).await.unwrap();
+
+        // recv() should return the webhook message.
+        let result = ch.recv().await.expect("recv must not error");
+        let received = result.expect("recv must return Some");
+        assert_eq!(received.text, "webhook payload");
+    }
+
+    /// `GatewayChannel::supports_exit` delegates to the inner channel.
+    #[test]
+    fn supports_exit_delegates_to_inner() {
+        let (inner, _handle) = LoopbackChannel::pair(8);
+        let (_webhook_tx, webhook_rx) = tokio::sync::mpsc::channel::<ChannelMessage>(1);
+        let ch = GatewayChannel::new(inner, webhook_rx);
+        // LoopbackChannel::supports_exit returns false.
+        assert!(!ch.supports_exit());
+    }
 }

--- a/src/gateway_spawn.rs
+++ b/src/gateway_spawn.rs
@@ -6,7 +6,7 @@
 ///
 /// All output methods (`send`, `send_chunk`, etc.) are forwarded to the inner channel
 /// unchanged. Only the inbound path (`recv`, `try_recv`) also checks the webhook
-/// receiver so the agent sees webhook payloads as regular [`ChannelMessage`]s.
+/// receiver so the agent sees webhook payloads as regular `ChannelMessage`s.
 #[cfg(feature = "gateway")]
 pub(crate) struct GatewayChannel<C> {
     inner: C,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1718,6 +1718,16 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         None
     };
 
+    // Create the gateway injection channel before agent construction so the receiver
+    // can be wired into the channel wrapper.  The sender is stored and later passed to
+    // spawn_gateway_server.  When the `gateway` feature is disabled the channel is
+    // never created and `channel` is passed to the agent unchanged.
+    #[cfg(feature = "gateway")]
+    let (gateway_input_tx, gateway_input_rx) =
+        tokio::sync::mpsc::channel::<zeph_core::ChannelMessage>(64);
+    #[cfg(feature = "gateway")]
+    let channel = crate::gateway_spawn::GatewayChannel::new(channel, gateway_input_rx);
+
     let agent = Agent::new_with_registry_arc(
         provider.clone(),
         embedding_provider.clone(),
@@ -2580,6 +2590,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         crate::gateway_spawn::spawn_gateway_server(
             config,
             shutdown_rx.clone(),
+            gateway_input_tx.clone(),
             Some((std::sync::Arc::clone(&prom.registry), effective_path)),
         );
         Some(handle)
@@ -2590,7 +2601,12 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             );
         }
         if config.gateway.enabled {
-            crate::gateway_spawn::spawn_gateway_server(config, shutdown_rx.clone(), None);
+            crate::gateway_spawn::spawn_gateway_server(
+                config,
+                shutdown_rx.clone(),
+                gateway_input_tx.clone(),
+                None,
+            );
         }
         None
     };
@@ -2598,7 +2614,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     // When `prometheus` feature is disabled, spawn gateway unconditionally if enabled.
     #[cfg(all(feature = "gateway", not(feature = "prometheus")))]
     if !exec_mode.bare && config.gateway.enabled {
-        crate::gateway_spawn::spawn_gateway_server(config, shutdown_rx.clone());
+        crate::gateway_spawn::spawn_gateway_server(config, shutdown_rx.clone(), gateway_input_tx);
     }
 
     let mut agent = agent;


### PR DESCRIPTION
## Summary

- **#3499** — `Scheduler::init()` now loads all periodic jobs persisted via `zeph schedule add` (stored in SQLite) back into `self.tasks` before the first tick. Previously, CLI-added jobs lived only in the DB and were invisible to `tick()`, so they never fired. Fix: call `store.list_jobs()` at init time, skip names already registered as static tasks, construct a `ScheduledTask` for each remainder, and persist the computed `next_run`.
- **#3500** — Replace the no-op webhook drain loop in `src/gateway_spawn.rs` with a `GatewayChannel<C>` wrapper that merges webhook payloads into the agent's regular input stream. Interactive turns are prioritised via `biased select!` so live sessions stay responsive. All 13 `Channel` trait methods delegate to the inner channel unchanged.

## Changes

| File | Change |
|------|--------|
| `crates/zeph-scheduler/src/scheduler.rs` | `init()` receiver `&self` → `&mut self`; hydration loop added |
| `src/gateway_spawn.rs` | `GatewayChannel<C>` wrapper + forwarding task replacing drain |
| `src/daemon.rs` | Thread `gateway_input_tx` under `#[cfg(feature = "gateway")]` |
| `src/runner.rs` | Create channel pair; wrap agent channel in `GatewayChannel::new` |
| `CHANGELOG.md` | `[Unreleased]` entries for both fixes |

## Tests

- `init_hydrates_cli_added_periodic_jobs_from_store` — inserts a job directly to store, creates a fresh scheduler, calls `init()`, asserts the job is in `self.tasks` with a valid `next_run`
- `init_does_not_duplicate_static_tasks_already_in_tasks` — guard against double-registration
- `try_recv_returns_webhook_message_when_inner_empty`
- `recv_yields_webhook_message`
- `supports_exit_delegates_to_inner`

8626 tests pass.

Closes #3499
Closes #3500