### PR TITLE
refactor(context): define TurnContext value type for phase-boundary handoff (#3510)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10213,6 +10213,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
  "zeph-common",
  "zeph-config",

--- a/crates/zeph-context/Cargo.toml
+++ b/crates/zeph-context/Cargo.toml
@@ -21,6 +21,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
+tokio-util.workspace = true
 tracing.workspace = true
 zeph-common.workspace = true
 zeph-config.workspace = true

--- a/crates/zeph-context/src/lib.rs
+++ b/crates/zeph-context/src/lib.rs
@@ -16,6 +16,7 @@
 //! - [`input`] — [`input::ContextAssemblyInput`], [`input::ContextMemoryView`], traits
 //! - [`slot`] — [`slot::ContextSlot`], [`slot::CompactionOutcome`], helper functions
 //! - [`summarization`] — pure prompt-building helpers for context compaction
+//! - [`turn_context`] — [`turn_context::TurnId`], [`turn_context::TurnContext`] per-turn carrier
 //! - [`compression_feedback`] — context-loss detection and failure classification
 //! - [`microcompact`] — low-value tool detection helpers for time-based microcompact
 //! - [`error`] — [`error::ContextError`]
@@ -29,4 +30,5 @@ pub mod manager;
 pub mod microcompact;
 pub mod slot;
 pub mod summarization;
+pub mod turn_context;
 pub mod typed_page;

--- a/crates/zeph-context/src/turn_context.rs
+++ b/crates/zeph-context/src/turn_context.rs
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Per-turn execution context shared across agent phases.
+
+use tokio_util::sync::CancellationToken;
+use zeph_config::security::TimeoutConfig;
+
+/// Monotonically increasing per-conversation turn identifier.
+///
+/// Moved from `zeph-core` to `zeph-context` so [`TurnContext`] can be defined here
+/// without creating a forbidden `zeph-context → zeph-core` dependency.
+///
+/// `TurnId(0)` is the first turn in a conversation. Values are strictly increasing by 1.
+/// The counter resets to 0 when a new conversation starts (e.g., via `/new`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TurnId(pub u64);
+
+impl TurnId {
+    /// Return the next turn ID in sequence.
+    ///
+    /// Saturates at `u64::MAX` rather than wrapping or panicking.
+    #[must_use]
+    pub fn next(self) -> TurnId {
+        TurnId(self.0.saturating_add(1))
+    }
+}
+
+impl std::fmt::Display for TurnId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Per-turn execution context shared across phases (`loop`, `compose`, `persist`).
+///
+/// `TurnContext` is `Send + 'static` and cheaply cloneable so it can be passed by value
+/// into subsystems that may outlive a `&mut Turn` borrow (background tasks, sub-services
+/// extracted to other crates in Phase 2 of the agent decomposition).
+///
+/// It carries only data that is (a) immutable for the duration of the turn or (b)
+/// intrinsically `Send + Clone` (the cancellation token).
+///
+/// # Examples
+///
+/// ```
+/// use zeph_context::turn_context::{TurnContext, TurnId};
+/// use zeph_config::security::TimeoutConfig;
+/// use tokio_util::sync::CancellationToken;
+///
+/// let ctx = TurnContext::new(TurnId(0), CancellationToken::new(), TimeoutConfig::default());
+/// assert_eq!(ctx.id, TurnId(0));
+/// ```
+#[derive(Debug, Clone)]
+pub struct TurnContext {
+    /// Monotonically increasing identifier for this turn within the conversation.
+    pub id: TurnId,
+    /// Per-turn cancellation token. A fresh token is created in `Agent::begin_turn`.
+    /// Cancelled when the user aborts the turn or the agent shuts down.
+    pub cancel_token: CancellationToken,
+    /// Effective timeout configuration snapshotted at the start of the turn.
+    ///
+    /// Snapshotting (rather than reading from a shared config) ensures the turn's
+    /// timeout policy is stable even if the live config is reloaded mid-turn.
+    pub timeouts: TimeoutConfig,
+    /// Optional channel-scoped tool allowlist for this turn.
+    ///
+    /// `None` means no channel-level restriction applies (other layers may still gate tool
+    /// access). Always `None` until Phase 2 wires channel config into the agent runtime.
+    ///
+    /// TODO(#3498): populate from active channel config during Phase 2 crate extraction.
+    pub tool_allowlist: Option<Vec<String>>,
+}
+
+impl TurnContext {
+    /// Create a new `TurnContext`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_context::turn_context::{TurnContext, TurnId};
+    /// use zeph_config::security::TimeoutConfig;
+    /// use tokio_util::sync::CancellationToken;
+    ///
+    /// let ctx = TurnContext::new(TurnId(1), CancellationToken::new(), TimeoutConfig::default());
+    /// assert_eq!(ctx.id, TurnId(1));
+    /// ```
+    #[must_use]
+    pub fn new(id: TurnId, cancel_token: CancellationToken, timeouts: TimeoutConfig) -> Self {
+        Self {
+            id,
+            cancel_token,
+            timeouts,
+            tool_allowlist: None,
+        }
+    }
+}
+
+const _: () = {
+    fn assert_send_static<T: Send + 'static>() {}
+    fn check() {
+        assert_send_static::<TurnContext>();
+        assert_send_static::<TurnId>();
+    }
+    let _ = check;
+};
+
+#[cfg(test)]
+mod tests {
+    use tokio_util::sync::CancellationToken;
+    use zeph_config::security::TimeoutConfig;
+
+    use super::*;
+
+    #[test]
+    fn turn_id_next_increments() {
+        assert_eq!(TurnId(3).next(), TurnId(4));
+    }
+
+    #[test]
+    fn turn_id_next_saturates_at_max() {
+        assert_eq!(TurnId(u64::MAX).next(), TurnId(u64::MAX));
+    }
+
+    #[test]
+    fn turn_id_display() {
+        assert_eq!(TurnId(42).to_string(), "42");
+    }
+
+    #[test]
+    fn turn_context_new_fields() {
+        let token = CancellationToken::new();
+        let ctx = TurnContext::new(TurnId(1), token.clone(), TimeoutConfig::default());
+        assert_eq!(ctx.id, TurnId(1));
+        assert!(ctx.tool_allowlist.is_none());
+    }
+
+    #[test]
+    fn turn_context_clone_shares_cancel_token() {
+        let ctx = TurnContext::new(
+            TurnId(0),
+            CancellationToken::new(),
+            TimeoutConfig::default(),
+        );
+        let cloned = ctx.clone();
+        ctx.cancel_token.cancel();
+        assert!(cloned.cancel_token.is_cancelled());
+    }
+}

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -1337,11 +1337,15 @@ impl<C: Channel> Agent<C> {
     fn begin_turn(&mut self, input: turn::TurnInput) -> turn::Turn {
         let id = turn::TurnId(self.runtime.debug.iteration_counter as u64);
         self.runtime.debug.iteration_counter += 1;
-        self.runtime.lifecycle.cancel_token = CancellationToken::new();
+        let cancel_token = CancellationToken::new();
+        // keep agent-wide token in sync with per-turn token — TODO(#3498): consolidate in Phase 2
+        self.runtime.lifecycle.cancel_token = cancel_token.clone();
         self.services.security.user_provided_urls.write().clear();
         // Reset per-turn LLM request counter for the notification gate.
         self.runtime.lifecycle.turn_llm_requests = 0;
-        turn::Turn::new(id, input)
+
+        let context = turn::TurnContext::new(id, cancel_token, self.runtime.config.timeouts);
+        turn::Turn::new(context, input)
     }
 
     /// Finalise a turn: copy accumulated timings into `MetricsState` and flush.
@@ -1403,7 +1407,7 @@ impl<C: Channel> Agent<C> {
         // real user message into a single user-role block below (N1 invariant).
         self.drain_background_completions();
 
-        self.wire_cancel_bridge(&turn.cancel_token);
+        self.wire_cancel_bridge(turn.cancel_token());
 
         // Clone text out of Turn so we can hold both `&str` borrows and mutate turn.metrics.
         let text = turn.input.text.clone();

--- a/crates/zeph-core/src/agent/turn.rs
+++ b/crates/zeph-core/src/agent/turn.rs
@@ -9,37 +9,14 @@
 //!
 //! # Phase 1 scope
 //!
-//! Only input, ID, metrics (timings only), and the cancellation token are tracked.
-//! Fields `context`, `response_text`, and `tool_results` are deferred to Phase 2.
+//! Only input, context, and metrics (timings only) are tracked.
+//! Fields `response_text` and `tool_results` are deferred to Phase 2.
 
 use tokio_util::sync::CancellationToken;
+pub use zeph_context::turn_context::{TurnContext, TurnId};
 use zeph_llm::provider::MessagePart;
 
 use crate::metrics::TurnTimings;
-
-/// Monotonically increasing per-conversation turn identifier.
-///
-/// Wraps `debug_state.iteration_counter` as a proper newtype, enabling turn IDs to be passed
-/// through the turn lifecycle and recorded in metrics and traces.
-///
-/// `TurnId(0)` is the first turn in a conversation. Values are strictly increasing by 1.
-/// The counter resets to 0 when a new conversation starts (e.g., via `/new`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct TurnId(pub u64);
-
-impl TurnId {
-    /// Return the next turn ID in sequence.
-    #[allow(dead_code)]
-    pub(crate) fn next(self) -> TurnId {
-        TurnId(self.0 + 1)
-    }
-}
-
-impl std::fmt::Display for TurnId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
 
 /// Resolved input for a single agent turn.
 ///
@@ -93,48 +70,50 @@ pub(crate) struct ToolOutputRecord {
 /// **Ownership**: `Turn` is stack-owned — created in `begin_turn`, passed through sub-methods
 /// by `&mut Turn`, and consumed in `end_turn`. It is never stored on the `Agent` struct.
 ///
-/// **Phase 1 scope**: carries `id`, `input`, `metrics`, and `cancel_token` only.
+/// **Phase 1 scope**: carries `context` (id, cancel token, timeouts), `input`, and `metrics`.
 pub struct Turn {
-    /// Monotonically increasing identifier for this turn within the conversation.
-    pub id: TurnId,
+    /// Per-turn execution context (id, cancel token, timeouts).
+    pub context: TurnContext,
     /// Resolved user input for this turn.
     pub input: TurnInput,
     /// Per-turn metrics accumulated during the turn lifecycle.
     pub metrics: TurnMetrics,
-    /// Per-turn cancellation token. Cancelled when the user aborts the turn or the agent shuts
-    /// down. Created fresh in [`Turn::new`] so each turn has an independent token.
-    pub cancel_token: CancellationToken,
 }
 
 impl Turn {
-    /// Create a new turn with the given ID and input.
-    ///
-    /// A fresh [`CancellationToken`] is created for each turn so that cancelling one turn
-    /// does not affect subsequent turns.
+    /// Create a new turn with the given context and input.
     ///
     /// # Examples
     ///
     /// ```no_run
-    /// # use zeph_core::agent::turn::{Turn, TurnId, TurnInput};
+    /// # use zeph_core::agent::turn::{Turn, TurnContext, TurnId, TurnInput};
+    /// # use zeph_config::security::TimeoutConfig;
+    /// # use tokio_util::sync::CancellationToken;
     /// # use zeph_llm::provider::MessagePart;
+    /// let ctx = TurnContext::new(TurnId(0), CancellationToken::new(), TimeoutConfig::default());
     /// let input = TurnInput::new("hello".to_owned(), vec![]);
-    /// let turn = Turn::new(TurnId(0), input);
-    /// assert_eq!(turn.id, TurnId(0));
+    /// let turn = Turn::new(ctx, input);
+    /// assert_eq!(turn.id(), TurnId(0));
     /// ```
     #[must_use]
-    pub fn new(id: TurnId, input: TurnInput) -> Self {
+    pub fn new(context: TurnContext, input: TurnInput) -> Self {
         Self {
-            id,
+            context,
             input,
             metrics: TurnMetrics::default(),
-            cancel_token: CancellationToken::new(),
         }
     }
 
     /// Return the turn ID.
     #[must_use]
     pub fn id(&self) -> TurnId {
-        self.id
+        self.context.id
+    }
+
+    /// Return an immutable reference to the per-turn cancellation token.
+    #[must_use]
+    pub fn cancel_token(&self) -> &CancellationToken {
+        &self.context.cancel_token
     }
 
     /// Return an immutable reference to the turn metrics.
@@ -151,13 +130,24 @@ impl Turn {
 
 #[cfg(test)]
 mod tests {
+    use tokio_util::sync::CancellationToken;
+    use zeph_config::security::TimeoutConfig;
+
     use super::*;
+
+    fn make_turn(id: u64, text: &str) -> Turn {
+        let ctx = TurnContext::new(
+            TurnId(id),
+            CancellationToken::new(),
+            TimeoutConfig::default(),
+        );
+        let input = TurnInput::new(text.to_owned(), vec![]);
+        Turn::new(ctx, input)
+    }
 
     #[test]
     fn turn_new_sets_id() {
-        let input = TurnInput::new("hello".to_owned(), vec![]);
-        let turn = Turn::new(TurnId(7), input);
-        assert_eq!(turn.id, TurnId(7));
+        let turn = make_turn(7, "hello");
         assert_eq!(turn.id(), TurnId(7));
     }
 
@@ -187,23 +177,20 @@ mod tests {
 
     #[test]
     fn turn_cancel_token_not_cancelled_on_new() {
-        let input = TurnInput::new("x".to_owned(), vec![]);
-        let turn = Turn::new(TurnId(0), input);
-        assert!(!turn.cancel_token.is_cancelled());
+        let turn = make_turn(0, "x");
+        assert!(!turn.cancel_token().is_cancelled());
     }
 
     #[test]
     fn turn_cancel_token_cancel() {
-        let input = TurnInput::new("x".to_owned(), vec![]);
-        let turn = Turn::new(TurnId(0), input);
-        turn.cancel_token.cancel();
-        assert!(turn.cancel_token.is_cancelled());
+        let turn = make_turn(0, "x");
+        turn.cancel_token().cancel();
+        assert!(turn.cancel_token().is_cancelled());
     }
 
     #[test]
     fn turn_metrics_mut_allows_write() {
-        let input = TurnInput::new("x".to_owned(), vec![]);
-        let mut turn = Turn::new(TurnId(0), input);
+        let mut turn = make_turn(0, "x");
         turn.metrics_mut().timings.prepare_context_ms = 99;
         assert_eq!(turn.metrics_snapshot().timings.prepare_context_ms, 99);
     }

--- a/specs/049-agent-decomposition/turn-context.md
+++ b/specs/049-agent-decomposition/turn-context.md
@@ -1,0 +1,59 @@
+---
+aliases:
+  - TurnContext Spec
+tags:
+  - sdd
+  - agent
+  - refactor
+created: 2026-04-27
+status: permanent
+related:
+  - "[[049-agent-decomposition]]"
+  - "[[002-agent-loop]]"
+---
+
+# TurnContext Value Type
+
+**Issue:** #3510 — P2-prereq-3 for Agent god-object decomposition (#3498)
+
+## Purpose
+
+`TurnContext` is a `Send + 'static` owned value type defined in `zeph-context` that carries
+per-turn invariants needed by every phase of the agent loop (`loop`, `compose`, `persist`).
+It enables the Phase 2 crate extraction (#3498) to accept turn-scoped state without
+passing `&mut Agent<C>` across crate boundaries.
+
+## Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `TurnId` | Monotonically increasing turn identifier within the conversation |
+| `cancel_token` | `CancellationToken` | Per-turn cancellation signal; created fresh each turn |
+| `timeouts` | `TimeoutConfig` | Timeout policy snapshot; stable for the duration of the turn |
+
+## Key Invariants
+
+- `TurnContext` MUST be `Send + 'static` at all times — no borrows, no non-Send fields
+- `TurnId` is defined in `zeph-context`, NOT `zeph-core`, to avoid a forbidden inverted dependency
+- `cancel_token` is created in `Agent::begin_turn` and cloned into `runtime.lifecycle.cancel_token` as a transitional mirror until Phase 2 consolidates the two (TODO #3498)
+- `timeouts` is snapshotted by value (`TimeoutConfig: Copy`) — never a reference to live config
+- NEVER wrap `TurnContext` in `Arc<Mutex<...>>` — it is a value type for a reason
+
+## Ownership Model
+
+```
+Agent::begin_turn()
+  → constructs TurnContext (id + cancel_token + timeouts)
+  → wraps in Turn { context, input, metrics }
+
+Turn lives on the call stack of process_user_message.
+TurnContext is accessible via turn.context.
+In Phase 2: TurnContext will be passed by value (clone) to sub-services in other crates.
+```
+
+## Phase 2 Extensions (deferred to #3498)
+
+The following fields are intentionally NOT in this PR:
+- `tool_allowlist: Option<Vec<String>>` (field scaffolded as `None`; Phase 2 populates from channel config)
+- Provider snapshots — requires Services decomposition to complete first
+- `MessageState` snapshot — requires persistence extraction crate


### PR DESCRIPTION
## Summary

- Defines `TurnContext` in `zeph-context` — a `Send + 'static` owned value type carrying per-turn invariants (`TurnId`, `CancellationToken`, `TimeoutConfig`, `tool_allowlist`) across the `loop`/`compose`/`persist` phase boundary
- Moves `TurnId` from `zeph-core::agent::turn` to `zeph-context::turn_context`; re-exported from `zeph-core` for backward compatibility
- `Turn` in `zeph-core` now embeds `pub context: TurnContext`; `id()` and `cancel_token()` getters delegate to it
- `Agent::begin_turn` constructs `TurnContext` from `runtime.config.timeouts` (Copy) and a fresh `CancellationToken`
- Adds SDD spec at `specs/049-agent-decomposition/turn-context.md`

## Closes

Closes #3510 — P2-prereq-3 for Agent god-object decomposition Phase 2 (#3498)

## Test plan

- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-context -p zeph-core --lib` — 1465 tests pass
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings` — zero errors
- [x] Compile-time `Send + 'static` assertion via `const _: () = { ... }` block
- [x] 5 new unit tests in `turn_context.rs` including `turn_context_clone_shares_cancel_token`