### PR TITLE
feat(core): scaffold zeph-agent-persistence and zeph-agent-tools crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10099,6 +10099,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeph-agent-persistence"
+version = "0.20.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "zeph-common",
+ "zeph-config",
+ "zeph-context",
+ "zeph-llm",
+ "zeph-memory",
+]
+
+[[package]]
+name = "zeph-agent-tools"
+version = "0.20.0"
+dependencies = [
+ "futures",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "zeph-agent-persistence",
+ "zeph-common",
+ "zeph-config",
+ "zeph-context",
+ "zeph-llm",
+ "zeph-mcp",
+ "zeph-orchestration",
+ "zeph-sanitizer",
+ "zeph-skills",
+ "zeph-tools",
+]
+
+[[package]]
 name = "zeph-bench"
 version = "0.20.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,8 @@ wiremock = "0.6.5"
 zeroize = { version = "1.8.2", default-features = false }
 zeph-a2a = { path = "crates/zeph-a2a", version = "0.20.0" }
 zeph-agent-feedback = { path = "crates/zeph-agent-feedback", version = "0.20.0" }
+zeph-agent-persistence = { path = "crates/zeph-agent-persistence", version = "0.20.0" }
+zeph-agent-tools = { path = "crates/zeph-agent-tools", version = "0.20.0" }
 zeph-bench = { path = "crates/zeph-bench", version = "0.20.0" }
 zeph-acp = { path = "crates/zeph-acp", version = "0.20.0" }
 zeph-db = { path = "crates/zeph-db", default-features = false, version = "0.20.0" }

--- a/crates/zeph-agent-persistence/Cargo.toml
+++ b/crates/zeph-agent-persistence/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "zeph-agent-persistence"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+publish.workspace = true
+description = "Agent persistence service for Zeph: history loading, message persistence, tool-pair sanitization, and background extraction enqueueing."
+readme = "README.md"
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }
+tracing.workspace = true
+zeph-common.workspace = true
+zeph-config.workspace = true
+zeph-context.workspace = true
+zeph-llm.workspace = true
+zeph-memory = { workspace = true, features = ["sqlite"] }
+
+[lints]
+workspace = true

--- a/crates/zeph-agent-persistence/README.md
+++ b/crates/zeph-agent-persistence/README.md
@@ -1,0 +1,18 @@
+# zeph-agent-persistence
+
+Agent persistence service for Zeph: history loading, message persistence, tool-pair sanitization, and background extraction enqueueing.
+
+## Overview
+
+This crate provides `PersistenceService` — a stateless facade for agent message persistence. It extracts persistence logic from `zeph-core` so that editing persistence code does not trigger recompilation of the tool dispatcher or context assembly paths.
+
+## Key types
+
+- `PersistenceService` — stateless facade; all inputs via explicit parameters
+- `PersistMessageRequest` — owned request struct (no lifetimes)
+- `PersistMessageOutcome` / `LoadHistoryOutcome` — owned outcome structs
+- `MemoryPersistenceView`, `SecurityView`, `MetricsView` — borrow-lens views constructed at call site
+
+## Design
+
+`zeph-core` depends on this crate. This crate does **not** depend on `zeph-core`. `zeph-agent-tools` depends on this crate for `PersistMessageRequest`.

--- a/crates/zeph-agent-persistence/src/embed.rs
+++ b/crates/zeph-agent-persistence/src/embed.rs
@@ -1,0 +1,207 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Message embedding and memory-write helpers.
+//!
+//! These are pure async functions that operate on `SemanticMemory` and message slices — no
+//! agent state or borrow-lens views required.
+
+use zeph_llm::provider::{MessagePart, Role};
+use zeph_memory::semantic::SemanticMemory;
+use zeph_memory::store::role_str;
+
+/// Decide whether a message should be embedded into Qdrant.
+///
+/// Returns `false` when:
+/// - `skip_embedding` is `true` (exfiltration guard active)
+/// - The message contains `[skipped]` or `[stopped]` `ToolResult` parts (internal policy markers)
+/// - The message is from the assistant and autosave is disabled or content is too short
+///
+/// # Examples
+///
+/// ```
+/// use zeph_agent_persistence::embed::should_embed_message;
+/// use zeph_llm::provider::Role;
+///
+/// assert!(should_embed_message(false, &[], Role::User, false, 0, 100));
+/// assert!(!should_embed_message(true, &[], Role::User, false, 0, 100));
+/// ```
+#[must_use]
+pub fn should_embed_message(
+    skip_embedding: bool,
+    parts: &[MessagePart],
+    role: Role,
+    autosave_assistant: bool,
+    autosave_min_length: usize,
+    content_len: usize,
+) -> bool {
+    if skip_embedding {
+        return false;
+    }
+    // Do not embed [skipped] or [stopped] ToolResult content into Qdrant — these are
+    // internal policy markers that carry no useful semantic information and would
+    // contaminate memory_search results.
+    let has_skipped_tool_result = parts.iter().any(|p| {
+        if let MessagePart::ToolResult { content, .. } = p {
+            content.starts_with("[skipped]") || content.starts_with("[stopped]")
+        } else {
+            false
+        }
+    });
+    if has_skipped_tool_result {
+        return false;
+    }
+    match role {
+        Role::Assistant => autosave_assistant && content_len >= autosave_min_length,
+        _ => true,
+    }
+}
+
+/// Write a single message to `SemanticMemory` (either `remember_with_parts` or `save_only`).
+///
+/// Returns `Some((embedding_stored, message_id))` on success, or `None` when the message was
+/// rejected by the A-MAC admission filter or a DB error occurred.
+///
+/// # Parameters
+///
+/// - `memory` — Semantic memory backend
+/// - `cid` — Active conversation ID
+/// - `role` — Message role
+/// - `content` — Full text content
+/// - `parts_json` — JSON-serialized message parts
+/// - `goal_text` — Optional current conversation goal (used for embedding enrichment)
+/// - `should_embed` — Whether to embed into Qdrant or write to `SQLite` only
+pub async fn write_message_to_memory(
+    memory: &SemanticMemory,
+    cid: zeph_memory::ConversationId,
+    role: Role,
+    content: &str,
+    parts_json: &str,
+    goal_text: Option<&str>,
+    should_embed: bool,
+) -> Option<(bool, i64)> {
+    if should_embed {
+        match memory
+            .remember_with_parts(cid, role_str(role), content, parts_json, goal_text)
+            .await
+        {
+            Ok((Some(message_id), stored)) => Some((stored, message_id.0)),
+            Ok((None, _)) => {
+                // A-MAC admission rejected — skip increment and further processing.
+                None
+            }
+            Err(e) => {
+                tracing::error!("failed to persist message: {e:#}");
+                None
+            }
+        }
+    } else {
+        match memory
+            .save_only(cid, role_str(role), content, parts_json)
+            .await
+        {
+            Ok(message_id) => Some((false, message_id.0)),
+            Err(e) => {
+                tracing::error!("failed to persist message: {e:#}");
+                None
+            }
+        }
+    }
+}
+
+/// Serialize message parts to a JSON string.
+///
+/// Returns `None` and logs an error if serialization fails — callers should skip persistence
+/// to avoid creating orphaned tool-pair records in `SQLite`.
+pub fn serialize_parts_json(parts: &[MessagePart], role: Role) -> Option<String> {
+    if parts.is_empty() {
+        return Some("[]".to_string());
+    }
+    match serde_json::to_string(parts) {
+        Ok(json) => Some(json),
+        Err(e) => {
+            tracing::error!(
+                role = ?role,
+                parts_count = parts.len(),
+                error = %e,
+                "failed to serialize message parts — skipping persist to avoid orphaned tool pair"
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zeph_llm::provider::Role;
+
+    #[test]
+    fn should_embed_user_message() {
+        assert!(should_embed_message(false, &[], Role::User, false, 0, 0));
+    }
+
+    #[test]
+    fn should_not_embed_when_skip_flag_set() {
+        assert!(!should_embed_message(true, &[], Role::User, false, 0, 100));
+    }
+
+    #[test]
+    fn should_embed_assistant_when_autosave_and_length_met() {
+        assert!(should_embed_message(
+            false,
+            &[],
+            Role::Assistant,
+            true,
+            20,
+            50
+        ));
+    }
+
+    #[test]
+    fn should_not_embed_assistant_when_autosave_disabled() {
+        assert!(!should_embed_message(
+            false,
+            &[],
+            Role::Assistant,
+            false,
+            20,
+            50
+        ));
+    }
+
+    #[test]
+    fn should_not_embed_assistant_when_too_short() {
+        assert!(!should_embed_message(
+            false,
+            &[],
+            Role::Assistant,
+            true,
+            100,
+            50
+        ));
+    }
+
+    #[test]
+    fn should_not_embed_skipped_tool_result() {
+        let parts = vec![MessagePart::ToolResult {
+            tool_use_id: "abc".to_owned(),
+            content: "[skipped] tool was blocked".to_owned(),
+            is_error: false,
+        }];
+        assert!(!should_embed_message(
+            false,
+            &parts,
+            Role::User,
+            false,
+            0,
+            100
+        ));
+    }
+
+    #[test]
+    fn serialize_empty_parts() {
+        let result = serialize_parts_json(&[], Role::User);
+        assert_eq!(result.as_deref(), Some("[]"));
+    }
+}

--- a/crates/zeph-agent-persistence/src/error.rs
+++ b/crates/zeph-agent-persistence/src/error.rs
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Error types for the persistence service.
+
+use thiserror::Error;
+
+/// Errors that can occur during agent persistence operations.
+///
+/// The caller in `zeph-core` maps these variants to `AgentError` via `From<PersistenceError>`.
+/// Callers can distinguish degradable errors (Qdrant offline) from fatal errors (`SQLite` corrupt).
+#[derive(Debug, Error)]
+pub enum PersistenceError {
+    /// Qdrant vector store is unavailable. Embedding is skipped; `SQLite` write may still succeed.
+    /// Callers should degrade gracefully and continue the conversation without semantic search.
+    #[error("Qdrant unavailable: {0}")]
+    QdrantUnavailable(String),
+
+    /// `SQLite` database error. This is typically fatal — abort the current operation.
+    #[error("SQLite error: {0}")]
+    SqliteCorrupt(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    /// Memory backend returned a generic error that doesn't fit the categories above.
+    #[error("memory backend error: {0}")]
+    Memory(#[from] zeph_memory::MemoryError),
+
+    /// Failed to serialize message parts to JSON.
+    #[error("serialization error: {0}")]
+    Serialize(#[from] serde_json::Error),
+}

--- a/crates/zeph-agent-persistence/src/graph.rs
+++ b/crates/zeph-agent-persistence/src/graph.rs
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Graph extraction configuration helpers.
+//!
+//! Pure functions that convert `zeph-config` graph settings into `zeph-memory` extraction
+//! configs, and collect context message snapshots for background tasks.
+
+use zeph_llm::provider::{Message, MessagePart, Role};
+
+/// Build a [`zeph_memory::semantic::GraphExtractionConfig`] from a config section.
+///
+/// This is a pure field-mapping function with no side effects.
+///
+/// # Examples
+///
+/// ```no_run
+/// use zeph_agent_persistence::graph::build_graph_extraction_config;
+/// use zeph_config::memory::GraphConfig;
+///
+/// let cfg = GraphConfig::default();
+/// let extraction_cfg = build_graph_extraction_config(&cfg, Some(42));
+/// assert_eq!(extraction_cfg.conversation_id, Some(42));
+/// ```
+#[must_use]
+pub fn build_graph_extraction_config(
+    cfg: &zeph_config::memory::GraphConfig,
+    conversation_id: Option<i64>,
+) -> zeph_memory::semantic::GraphExtractionConfig {
+    zeph_memory::semantic::GraphExtractionConfig {
+        max_entities: cfg.max_entities_per_message,
+        max_edges: cfg.max_edges_per_message,
+        extraction_timeout_secs: cfg.extraction_timeout_secs,
+        community_refresh_interval: cfg.community_refresh_interval,
+        expired_edge_retention_days: cfg.expired_edge_retention_days,
+        max_entities_cap: cfg.max_entities,
+        community_summary_max_prompt_bytes: cfg.community_summary_max_prompt_bytes,
+        community_summary_concurrency: cfg.community_summary_concurrency,
+        lpa_edge_chunk_size: cfg.lpa_edge_chunk_size,
+        note_linking: zeph_memory::NoteLinkingConfig {
+            enabled: cfg.note_linking.enabled,
+            similarity_threshold: cfg.note_linking.similarity_threshold,
+            top_k: cfg.note_linking.top_k,
+            timeout_secs: cfg.note_linking.timeout_secs,
+        },
+        link_weight_decay_lambda: cfg.link_weight_decay_lambda,
+        link_weight_decay_interval_secs: cfg.link_weight_decay_interval_secs,
+        belief_revision_enabled: cfg.belief_revision.enabled,
+        belief_revision_similarity_threshold: cfg.belief_revision.similarity_threshold,
+        conversation_id,
+    }
+}
+
+/// Collect recent user messages (non-tool-result) as context strings for graph extraction.
+///
+/// Takes the four most recent qualifying user messages, truncating each to 2048 characters.
+/// Returned in reverse chronological order (most recent first).
+///
+/// # Examples
+///
+/// ```
+/// use zeph_agent_persistence::graph::collect_context_messages;
+/// use zeph_llm::provider::{Message, MessageMetadata, Role};
+///
+/// let messages = vec![
+///     Message { role: Role::User, content: "hello".into(), parts: vec![], metadata: MessageMetadata::default() },
+/// ];
+/// let ctx = collect_context_messages(&messages);
+/// assert_eq!(ctx, vec!["hello"]);
+/// ```
+#[must_use]
+pub fn collect_context_messages(messages: &[Message]) -> Vec<String> {
+    messages
+        .iter()
+        .rev()
+        .filter(|m| {
+            m.role == Role::User
+                && !m
+                    .parts
+                    .iter()
+                    .any(|p| matches!(p, MessagePart::ToolResult { .. }))
+        })
+        .take(4)
+        .map(|m| {
+            if m.content.len() > 2048 {
+                m.content[..m.content.floor_char_boundary(2048)].to_owned()
+            } else {
+                m.content.clone()
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zeph_llm::provider::MessageMetadata;
+
+    fn user_msg(content: &str) -> Message {
+        Message {
+            role: Role::User,
+            content: content.to_owned(),
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        }
+    }
+
+    fn assistant_msg(content: &str) -> Message {
+        Message {
+            role: Role::Assistant,
+            content: content.to_owned(),
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        }
+    }
+
+    #[test]
+    fn collect_empty_messages() {
+        let ctx = collect_context_messages(&[]);
+        assert!(ctx.is_empty());
+    }
+
+    #[test]
+    fn collect_user_messages_only() {
+        let msgs = vec![
+            user_msg("first"),
+            assistant_msg("reply"),
+            user_msg("second"),
+        ];
+        let ctx = collect_context_messages(&msgs);
+        // Reversed (most recent first), only user messages
+        assert_eq!(ctx, vec!["second", "first"]);
+    }
+
+    #[test]
+    fn collect_at_most_four_messages() {
+        let msgs: Vec<_> = (0..10).map(|i| user_msg(&format!("msg {i}"))).collect();
+        let ctx = collect_context_messages(&msgs);
+        assert_eq!(ctx.len(), 4);
+    }
+
+    #[test]
+    fn skips_tool_result_messages() {
+        let tool_result_msg = Message {
+            role: Role::User,
+            content: String::new(),
+            parts: vec![MessagePart::ToolResult {
+                tool_use_id: "abc".to_owned(),
+                content: "output".to_owned(),
+                is_error: false,
+            }],
+            metadata: zeph_llm::provider::MessageMetadata::default(),
+        };
+        let msgs = vec![user_msg("real message"), tool_result_msg];
+        let ctx = collect_context_messages(&msgs);
+        assert_eq!(ctx, vec!["real message"]);
+    }
+}

--- a/crates/zeph-agent-persistence/src/lib.rs
+++ b/crates/zeph-agent-persistence/src/lib.rs
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Agent persistence service for Zeph.
+//!
+//! This crate provides [`service::PersistenceService`] — a stateless façade for loading
+//! conversation history from and writing messages to the `SemanticMemory` backend
+//! (`SQLite` + Qdrant). It also exposes pure helper functions for:
+//!
+//! - Tool-pair sanitization ([`sanitize`])
+//! - Message embedding decisions and memory writes ([`embed`])
+//! - Graph extraction configuration ([`graph`])
+//!
+//! # Architecture
+//!
+//! `zeph-agent-persistence` depends on `zeph-memory`, `zeph-llm`, `zeph-context`, `zeph-config`,
+//! and `zeph-common`. It does **not** depend on `zeph-core` — this is the core invariant that
+//! allows the persistence and tool-dispatch subsystems to evolve independently.
+//!
+//! `zeph-core` depends on this crate and provides thin shim methods on `Agent<C>` that
+//! construct the borrow-lens views (`MemoryPersistenceView`, `SecurityView`, `MetricsView`)
+//! from their respective `Agent` fields and delegate to `PersistenceService`.
+//!
+//! # TODO(critic): consolidate MockChannel/MockToolExecutor into shared zeph-agent-test-helpers
+//! crate; tracked separately from #3515/#3516
+
+pub mod embed;
+pub mod error;
+pub mod graph;
+pub mod request;
+pub mod sanitize;
+pub mod service;
+pub mod state;
+
+pub use error::PersistenceError;
+pub use request::{LoadHistoryOutcome, PersistMessageOutcome, PersistMessageRequest};
+pub use service::PersistenceService;
+pub use state::{MemoryPersistenceView, MetricsView, ProviderHandles, SecurityView};

--- a/crates/zeph-agent-persistence/src/request.rs
+++ b/crates/zeph-agent-persistence/src/request.rs
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Value types for persistence requests and outcomes.
+
+use zeph_llm::provider::{MessagePart, Role};
+
+/// A request to persist exactly one message to semantic memory and `SQLite`.
+///
+/// Fully owned — no borrow lifetimes — so it can be returned from the tool dispatcher
+/// (which holds many `&mut` borrows of agent state) and drained by a separate
+/// [`crate::service::PersistenceService`] call after those borrows are released.
+///
+/// Clone cost is small: typical message content is less than 10 KB; allocation count
+/// is two (one for `content`, one for `parts`) per persist request.
+///
+/// # TODO(critic): R3 batches persist requests until end of `process_response`.
+/// On panic/cancel mid-response, pending requests are LOST, unlike today's inline
+/// persist. See critic-3515-3516.md F2. File follow-up issue if observed in live testing.
+#[derive(Debug, Clone)]
+pub struct PersistMessageRequest {
+    /// Message role: `User`, `Assistant`, or `System`.
+    pub role: Role,
+    /// Full text content of the message (owned copy).
+    pub content: String,
+    /// Structured message parts (owned copy).
+    pub parts: Vec<MessagePart>,
+    /// When `true`, Qdrant embedding is skipped if `guard_memory_writes` is enabled.
+    /// Set by the exfiltration guard when injection patterns are detected.
+    pub has_injection_flags: bool,
+}
+
+impl PersistMessageRequest {
+    /// Build a persist request by cloning borrowed inputs.
+    ///
+    /// Used at the dispatcher call site where borrowing the source slices is cheaper
+    /// than receiving owned values directly.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_agent_persistence::request::PersistMessageRequest;
+    /// use zeph_llm::provider::Role;
+    ///
+    /// let req = PersistMessageRequest::from_borrowed(
+    ///     Role::User,
+    ///     "hello",
+    ///     &[],
+    ///     false,
+    /// );
+    /// assert_eq!(req.role, Role::User);
+    /// assert_eq!(req.content, "hello");
+    /// ```
+    #[must_use]
+    pub fn from_borrowed(
+        role: Role,
+        content: &str,
+        parts: &[MessagePart],
+        has_injection_flags: bool,
+    ) -> Self {
+        Self {
+            role,
+            content: content.to_owned(),
+            parts: parts.to_vec(),
+            has_injection_flags,
+        }
+    }
+}
+
+/// Outcome of a single [`crate::service::PersistenceService::persist_message`] call.
+#[derive(Debug, Clone)]
+pub struct PersistMessageOutcome {
+    /// Database ID assigned to the persisted message by `SQLite`, if the write succeeded.
+    pub message_id: Option<i64>,
+    /// Whether the message was embedded into Qdrant (as opposed to saved to `SQLite` only).
+    pub embedded: bool,
+    /// Whether a redaction was applied to the content before persistence.
+    pub redaction_applied: bool,
+    /// Number of bytes written to the persistence layer.
+    pub bytes_written: usize,
+}
+
+/// Outcome of a [`crate::service::PersistenceService::load_history`] call.
+#[derive(Debug, Clone)]
+pub struct LoadHistoryOutcome {
+    /// Number of messages successfully loaded from `SQLite` and injected into the buffer.
+    pub messages_loaded: usize,
+    /// Number of orphaned tool-use/tool-result pairs removed during sanitization.
+    pub orphan_pairs_removed: usize,
+    /// Number of message IDs accumulated in `deferred_hide_ids` for later soft-delete.
+    pub deferred_hide_ids_count: usize,
+    /// Total message count in `SQLite` for the active conversation.
+    pub sqlite_total_messages: u64,
+    /// Total semantic fact count in Qdrant for the active conversation.
+    pub semantic_total_messages: u64,
+}

--- a/crates/zeph-agent-persistence/src/sanitize.rs
+++ b/crates/zeph-agent-persistence/src/sanitize.rs
@@ -1,0 +1,391 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Tool-pair sanitization helpers: remove orphaned `ToolUse`/`ToolResult` messages from
+//! restored conversation history.
+//!
+//! These are pure functions operating on `Vec<Message>` slices — no agent state required.
+
+use std::collections::HashSet;
+
+use zeph_llm::provider::{Message, MessagePart, Role};
+
+/// Remove orphaned `ToolUse`/`ToolResult` messages from restored history.
+///
+/// Four failure modes are handled:
+/// 1. **Trailing orphan**: the last message is an assistant with `ToolUse` parts but no
+///    subsequent user message with `ToolResult` — caused by LIMIT boundary splits or
+///    interrupted sessions.
+/// 2. **Leading orphan**: the first message is a user with `ToolResult` parts but no
+///    preceding assistant message with `ToolUse` — caused by LIMIT boundary cuts.
+/// 3. **Mid-history orphaned `ToolUse`**: an assistant message with `ToolUse` parts is not
+///    followed by a user message with matching `ToolResult` parts. The `ToolUse` parts are
+///    stripped; if no content remains the message is removed.
+/// 4. **Mid-history orphaned `ToolResult`**: a user message has `ToolResult` parts whose
+///    `tool_use_id` is not present in the preceding assistant message. Those `ToolResult` parts
+///    are stripped; if no content remains the message is removed.
+///
+/// Returns `(removed_count, db_ids)` where `removed_count` is the number of messages removed
+/// entirely and `db_ids` contains `metadata.db_id` values of those messages for `SQLite`
+/// soft-delete.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_agent_persistence::sanitize::sanitize_tool_pairs;
+/// use zeph_llm::provider::{Message, MessageMetadata, Role};
+///
+/// let mut messages = vec![
+///     Message { role: Role::User, content: "hello".into(), parts: vec![], metadata: MessageMetadata::default() },
+/// ];
+/// let (removed, ids) = sanitize_tool_pairs(&mut messages);
+/// assert_eq!(removed, 0);
+/// assert!(ids.is_empty());
+/// ```
+pub fn sanitize_tool_pairs(messages: &mut Vec<Message>) -> (usize, Vec<i64>) {
+    let mut removed = 0;
+    let mut db_ids: Vec<i64> = Vec::new();
+
+    loop {
+        // Remove trailing orphaned tool_use (assistant message with ToolUse, no following tool_result).
+        if let Some(last) = messages.last()
+            && last.role == Role::Assistant
+            && last
+                .parts
+                .iter()
+                .any(|p| matches!(p, MessagePart::ToolUse { .. }))
+        {
+            let ids: Vec<String> = last
+                .parts
+                .iter()
+                .filter_map(|p| {
+                    if let MessagePart::ToolUse { id, .. } = p {
+                        Some(id.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            tracing::warn!(
+                tool_ids = ?ids,
+                "removing orphaned trailing tool_use message from restored history"
+            );
+            if let Some(db_id) = messages.last().and_then(|m| m.metadata.db_id) {
+                db_ids.push(db_id);
+            }
+            messages.pop();
+            removed += 1;
+            continue;
+        }
+
+        // Remove leading orphaned tool_result (user message with ToolResult, no preceding tool_use).
+        if let Some(first) = messages.first()
+            && first.role == Role::User
+            && first
+                .parts
+                .iter()
+                .any(|p| matches!(p, MessagePart::ToolResult { .. }))
+        {
+            let ids: Vec<String> = first
+                .parts
+                .iter()
+                .filter_map(|p| {
+                    if let MessagePart::ToolResult { tool_use_id, .. } = p {
+                        Some(tool_use_id.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            tracing::warn!(
+                tool_use_ids = ?ids,
+                "removing orphaned leading tool_result message from restored history"
+            );
+            if let Some(db_id) = messages.first().and_then(|m| m.metadata.db_id) {
+                db_ids.push(db_id);
+            }
+            messages.remove(0);
+            removed += 1;
+            continue;
+        }
+
+        break;
+    }
+
+    let (mid_removed, mid_db_ids) = strip_mid_history_orphans(messages);
+    removed += mid_removed;
+    db_ids.extend(mid_db_ids);
+
+    (removed, db_ids)
+}
+
+/// Returns `true` if `content` contains human-readable text beyond legacy tool bracket markers.
+///
+/// Legacy markers produced by `Message::flatten_parts` are:
+/// - `[tool_use: name(id)]` — assistant `ToolUse`
+/// - `[tool_result: id]\nbody` — user `ToolResult`
+/// - `[tool output: name] body` — `ToolOutput`
+///
+/// A message whose content consists solely of such markers (and whitespace) has no
+/// user-visible text and is a candidate for soft-delete.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_agent_persistence::sanitize::has_meaningful_content;
+///
+/// assert!(has_meaningful_content("hello world"));
+/// assert!(!has_meaningful_content("[tool_use: bash(abc123)]"));
+/// assert!(!has_meaningful_content("   [tool_result: abc]\nsome output"));
+/// ```
+#[must_use]
+pub fn has_meaningful_content(content: &str) -> bool {
+    const PREFIXES: [&str; 3] = ["[tool_use: ", "[tool_result: ", "[tool output: "];
+
+    let mut remaining = content.trim();
+
+    loop {
+        let next = PREFIXES
+            .iter()
+            .filter_map(|prefix| remaining.find(prefix).map(|pos| (pos, *prefix)))
+            .min_by_key(|(pos, _)| *pos);
+
+        let Some((start, prefix)) = next else {
+            break;
+        };
+
+        if !remaining[..start].trim().is_empty() {
+            return true;
+        }
+
+        let after_prefix = &remaining[start + prefix.len()..];
+        let Some(close) = after_prefix.find(']') else {
+            return true; // Malformed tag — treat as meaningful.
+        };
+
+        let tag_end = start + prefix.len() + close + 1;
+
+        if prefix == "[tool_result: " || prefix == "[tool output: " {
+            let body = remaining[tag_end..].trim_start_matches('\n');
+            let next_tag = PREFIXES
+                .iter()
+                .filter_map(|p| body.find(p))
+                .min()
+                .unwrap_or(body.len());
+            remaining = &body[next_tag..];
+        } else {
+            remaining = &remaining[tag_end..];
+        }
+    }
+
+    !remaining.trim().is_empty()
+}
+
+/// Collect `tool_use` IDs from `msg` that have no matching `ToolResult` in `next_msg`.
+fn orphaned_tool_use_ids(msg: &Message, next_msg: Option<&Message>) -> HashSet<String> {
+    let matched: HashSet<String> = next_msg
+        .filter(|n| n.role == Role::User)
+        .map(|n| {
+            msg.parts
+                .iter()
+                .filter_map(|p| if let MessagePart::ToolUse { id, .. } = p { Some(id.clone()) } else { None })
+                .filter(|uid| n.parts.iter().any(|np| matches!(np, MessagePart::ToolResult { tool_use_id, .. } if tool_use_id == uid)))
+                .collect()
+        })
+        .unwrap_or_default();
+    msg.parts
+        .iter()
+        .filter_map(|p| {
+            if let MessagePart::ToolUse { id, .. } = p
+                && !matched.contains(id)
+            {
+                Some(id.clone())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Collect `tool_result` IDs from `msg` that have no matching `ToolUse` in `prev_msg`.
+fn orphaned_tool_result_ids(msg: &Message, prev_msg: Option<&Message>) -> HashSet<String> {
+    let avail: HashSet<&str> = prev_msg
+        .filter(|p| p.role == Role::Assistant)
+        .map(|p| {
+            p.parts
+                .iter()
+                .filter_map(|part| {
+                    if let MessagePart::ToolUse { id, .. } = part {
+                        Some(id.as_str())
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    msg.parts
+        .iter()
+        .filter_map(|p| {
+            if let MessagePart::ToolResult { tool_use_id, .. } = p
+                && !avail.contains(tool_use_id.as_str())
+            {
+                Some(tool_use_id.clone())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Scan all messages and strip orphaned `ToolUse`/`ToolResult` parts from mid-history messages.
+fn strip_mid_history_orphans(messages: &mut Vec<Message>) -> (usize, Vec<i64>) {
+    let mut removed = 0;
+    let mut db_ids: Vec<i64> = Vec::new();
+    let mut i = 0;
+    while i < messages.len() {
+        if messages[i].role == Role::Assistant
+            && messages[i]
+                .parts
+                .iter()
+                .any(|p| matches!(p, MessagePart::ToolUse { .. }))
+        {
+            let next_non_system = (i + 1..messages.len())
+                .find(|&j| messages[j].role != Role::System)
+                .and_then(|j| messages.get(j));
+            let orphaned_ids = orphaned_tool_use_ids(&messages[i], next_non_system);
+            if !orphaned_ids.is_empty() {
+                tracing::warn!(
+                    tool_ids = ?orphaned_ids,
+                    index = i,
+                    "stripping orphaned mid-history tool_use parts from assistant message"
+                );
+                messages[i].parts.retain(
+                    |p| !matches!(p, MessagePart::ToolUse { id, .. } if orphaned_ids.contains(id)),
+                );
+                let is_empty =
+                    !has_meaningful_content(&messages[i].content) && messages[i].parts.is_empty();
+                if is_empty {
+                    if let Some(db_id) = messages[i].metadata.db_id {
+                        db_ids.push(db_id);
+                    }
+                    messages.remove(i);
+                    removed += 1;
+                    continue;
+                }
+            }
+        }
+
+        if messages[i].role == Role::User
+            && messages[i]
+                .parts
+                .iter()
+                .any(|p| matches!(p, MessagePart::ToolResult { .. }))
+        {
+            let prev_non_system = (0..i)
+                .rev()
+                .find(|&j| messages[j].role != Role::System)
+                .and_then(|j| messages.get(j));
+            let orphaned_ids = orphaned_tool_result_ids(&messages[i], prev_non_system);
+            if !orphaned_ids.is_empty() {
+                tracing::warn!(
+                    tool_use_ids = ?orphaned_ids,
+                    index = i,
+                    "stripping orphaned mid-history tool_result parts from user message"
+                );
+                messages[i].parts.retain(|p| {
+                    !matches!(p, MessagePart::ToolResult { tool_use_id, .. } if orphaned_ids.contains(tool_use_id.as_str()))
+                });
+
+                let is_empty =
+                    !has_meaningful_content(&messages[i].content) && messages[i].parts.is_empty();
+                if is_empty {
+                    if let Some(db_id) = messages[i].metadata.db_id {
+                        db_ids.push(db_id);
+                    }
+                    messages.remove(i);
+                    removed += 1;
+                    continue;
+                }
+            }
+        }
+
+        i += 1;
+    }
+    (removed, db_ids)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zeph_llm::provider::MessageMetadata;
+
+    fn msg(role: Role, content: &str) -> Message {
+        Message {
+            role,
+            content: content.to_owned(),
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        }
+    }
+
+    fn msg_with_parts(role: Role, content: &str, parts: Vec<MessagePart>) -> Message {
+        Message {
+            role,
+            content: content.to_owned(),
+            parts,
+            metadata: MessageMetadata::default(),
+        }
+    }
+
+    #[test]
+    fn empty_messages_unchanged() {
+        let mut msgs: Vec<Message> = vec![];
+        let (removed, ids) = sanitize_tool_pairs(&mut msgs);
+        assert_eq!(removed, 0);
+        assert!(ids.is_empty());
+    }
+
+    #[test]
+    fn clean_conversation_unchanged() {
+        let mut msgs = vec![msg(Role::User, "hello"), msg(Role::Assistant, "hi")];
+        let (removed, _) = sanitize_tool_pairs(&mut msgs);
+        assert_eq!(removed, 0);
+        assert_eq!(msgs.len(), 2);
+    }
+
+    #[test]
+    fn trailing_orphan_tool_use_removed() {
+        let tool_use = MessagePart::ToolUse {
+            id: "abc".to_owned(),
+            name: "bash".to_owned(),
+            input: serde_json::json!({}),
+        };
+        let mut msgs = vec![
+            msg(Role::User, "run something"),
+            msg_with_parts(Role::Assistant, "[tool_use: bash(abc)]", vec![tool_use]),
+        ];
+        let (removed, _) = sanitize_tool_pairs(&mut msgs);
+        assert_eq!(removed, 1);
+        assert_eq!(msgs.len(), 1);
+    }
+
+    #[test]
+    fn has_meaningful_content_with_text() {
+        assert!(has_meaningful_content("hello world"));
+        assert!(has_meaningful_content(
+            "some text [tool_use: bash(abc)] more text"
+        ));
+    }
+
+    #[test]
+    fn has_meaningful_content_only_markers() {
+        assert!(!has_meaningful_content("[tool_use: bash(abc123)]"));
+        assert!(!has_meaningful_content("  "));
+    }
+
+    #[test]
+    fn has_meaningful_content_empty() {
+        assert!(!has_meaningful_content(""));
+    }
+}

--- a/crates/zeph-agent-persistence/src/service.rs
+++ b/crates/zeph-agent-persistence/src/service.rs
@@ -1,0 +1,278 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! [`PersistenceService`] — stateless façade for agent message persistence.
+
+use zeph_llm::provider::{Message, MessagePart, Role};
+
+use crate::embed::{serialize_parts_json, should_embed_message, write_message_to_memory};
+use crate::error::PersistenceError;
+use crate::request::{LoadHistoryOutcome, PersistMessageOutcome, PersistMessageRequest};
+use crate::sanitize::sanitize_tool_pairs;
+use crate::state::{MemoryPersistenceView, MetricsView, SecurityView};
+
+/// Stateless façade for agent message persistence operations.
+///
+/// This struct has no fields. All inputs flow through method parameters, which allows the
+/// borrow checker to see disjoint `&mut` borrows at the call site without hiding them inside
+/// an opaque bundle.
+///
+/// Methods are `&self` — the type exists only to namespace the operations and to give callers
+/// a single import.
+///
+/// # Examples
+///
+/// ```no_run
+/// use zeph_agent_persistence::service::PersistenceService;
+///
+/// let svc = PersistenceService::new();
+/// // call svc.persist_message(...) or svc.load_history(...)
+/// ```
+#[derive(Debug, Default)]
+pub struct PersistenceService;
+
+impl PersistenceService {
+    /// Create a new stateless `PersistenceService`.
+    ///
+    /// This is a zero-cost constructor — the struct has no fields.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Load conversation history from `SemanticMemory` into `messages`.
+    ///
+    /// Sanitizes orphaned tool-use/tool-result pairs and soft-deletes their `SQLite` rows.
+    /// Updates `last_persisted_message_id` and populates `deferred_hide_ids` with IDs to be
+    /// soft-deleted in a subsequent call.
+    ///
+    /// Returns counts and `SQLite`/semantic totals.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PersistenceError`] if `SQLite` fails during history load or soft-delete.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn load_history(
+        &self,
+        messages: &mut Vec<Message>,
+        last_persisted_message_id: &mut Option<i64>,
+        deferred_hide_ids: &mut Vec<i64>,
+        _deferred_summaries: &mut Vec<String>,
+        memory_view: &MemoryPersistenceView<'_>,
+        _config: &zeph_config::Config,
+        _metrics: &mut MetricsView<'_>,
+    ) -> Result<LoadHistoryOutcome, PersistenceError> {
+        let (Some(memory), Some(cid)) = (memory_view.memory, memory_view.conversation_id) else {
+            return Ok(LoadHistoryOutcome {
+                messages_loaded: 0,
+                orphan_pairs_removed: 0,
+                deferred_hide_ids_count: 0,
+                sqlite_total_messages: 0,
+                semantic_total_messages: 0,
+            });
+        };
+
+        let history = memory
+            .sqlite()
+            .load_history_filtered(cid, 50, Some(true), None)
+            .await?;
+
+        if history.is_empty() {
+            return Ok(LoadHistoryOutcome {
+                messages_loaded: 0,
+                orphan_pairs_removed: 0,
+                deferred_hide_ids_count: 0,
+                sqlite_total_messages: 0,
+                semantic_total_messages: 0,
+            });
+        }
+
+        let mut loaded = 0;
+        let mut skipped = 0;
+
+        for msg in history {
+            use crate::sanitize::has_meaningful_content;
+            if !has_meaningful_content(&msg.content) && msg.parts.is_empty() {
+                tracing::warn!("skipping empty message from history (role: {:?})", msg.role);
+                skipped += 1;
+                continue;
+            }
+            messages.push(msg);
+            loaded += 1;
+        }
+
+        let history_start = messages.len() - loaded;
+        let mut restored_slice = messages.split_off(history_start);
+        let (orphans, orphan_db_ids) = sanitize_tool_pairs(&mut restored_slice);
+        skipped += orphans;
+        let loaded = loaded.saturating_sub(orphans);
+        messages.append(&mut restored_slice);
+
+        if !orphan_db_ids.is_empty() {
+            let ids: Vec<zeph_memory::types::MessageId> = orphan_db_ids
+                .iter()
+                .map(|&id| zeph_memory::types::MessageId(id))
+                .collect();
+            if let Err(e) = memory.sqlite().soft_delete_messages(&ids).await {
+                tracing::warn!(
+                    count = ids.len(),
+                    error = %e,
+                    "failed to soft-delete orphaned tool-pair messages from DB"
+                );
+            } else {
+                deferred_hide_ids.extend(orphan_db_ids.iter().copied());
+                tracing::debug!(
+                    count = ids.len(),
+                    "soft-deleted orphaned tool-pair messages from DB"
+                );
+            }
+        }
+
+        tracing::info!("restored {loaded} message(s) from conversation {cid}");
+        if skipped > 0 {
+            tracing::warn!("skipped {skipped} empty/orphaned message(s) from history");
+        }
+
+        // Update last_persisted_message_id from the last loaded message.
+        if let Some(db_id) = messages.last().and_then(|m| m.metadata.db_id) {
+            *last_persisted_message_id = Some(db_id);
+        }
+
+        let sqlite_total = memory.message_count(cid).await.unwrap_or(0);
+        let sqlite_total_u64 = u64::try_from(sqlite_total).unwrap_or(0);
+        let semantic_total = memory.sqlite().count_semantic_facts().await.unwrap_or(0);
+        let semantic_total_u64 = u64::try_from(semantic_total).unwrap_or(0);
+
+        Ok(LoadHistoryOutcome {
+            messages_loaded: loaded,
+            orphan_pairs_removed: orphans,
+            deferred_hide_ids_count: deferred_hide_ids.len(),
+            sqlite_total_messages: sqlite_total_u64,
+            semantic_total_messages: semantic_total_u64,
+        })
+    }
+
+    /// Persist exactly one message to `SemanticMemory`.
+    ///
+    /// Embedding is decided by `request.has_injection_flags` AND `security.guard_memory_writes`.
+    /// Updates `last_persisted_message_id`, `memory_view.unsummarized_count`, and metrics counters.
+    ///
+    /// Returns a [`PersistMessageOutcome`] even on write failure (the outcome's `message_id`
+    /// will be `None`). Callers should log failures but continue — conversation continuity
+    /// is more important than individual message persistence.
+    pub async fn persist_message(
+        &self,
+        request: PersistMessageRequest,
+        last_persisted_message_id: &mut Option<i64>,
+        memory_view: &mut MemoryPersistenceView<'_>,
+        security: &SecurityView<'_>,
+        _config: &zeph_config::Config,
+        metrics: &mut MetricsView<'_>,
+    ) -> PersistMessageOutcome {
+        let (Some(memory), Some(cid)) = (memory_view.memory, memory_view.conversation_id) else {
+            return PersistMessageOutcome {
+                message_id: None,
+                embedded: false,
+                redaction_applied: false,
+                bytes_written: 0,
+            };
+        };
+
+        let Some(parts_json) = serialize_parts_json(&request.parts, request.role) else {
+            return PersistMessageOutcome {
+                message_id: None,
+                embedded: false,
+                redaction_applied: false,
+                bytes_written: 0,
+            };
+        };
+
+        let guard_active = security.guard_memory_writes && request.has_injection_flags;
+        if guard_active {
+            tracing::warn!("exfiltration guard: skipping Qdrant embedding for flagged content");
+            *metrics.exfiltration_memory_guards += 1;
+        }
+
+        let should_embed = should_embed_message(
+            guard_active,
+            &request.parts,
+            request.role,
+            memory_view.autosave_assistant,
+            memory_view.autosave_min_length,
+            request.content.len(),
+        );
+
+        let goal_text = memory_view.goal_text.clone();
+
+        tracing::debug!(
+            "persist_message: calling remember_with_parts, embed dispatched to background"
+        );
+
+        let Some((embedding_stored, message_id)) = write_message_to_memory(
+            memory,
+            cid,
+            request.role,
+            &request.content,
+            &parts_json,
+            goal_text.as_deref(),
+            should_embed,
+        )
+        .await
+        else {
+            return PersistMessageOutcome {
+                message_id: None,
+                embedded: false,
+                redaction_applied: false,
+                bytes_written: 0,
+            };
+        };
+
+        *last_persisted_message_id = Some(message_id);
+        *memory_view.unsummarized_count += 1;
+
+        *metrics.sqlite_message_count += 1;
+        if embedding_stored {
+            *metrics.embeddings_generated += 1;
+        }
+
+        tracing::debug!("persist_message: db insert complete, embedding running in background");
+        memory.reap_embed_tasks();
+
+        PersistMessageOutcome {
+            message_id: Some(message_id),
+            embedded: embedding_stored,
+            redaction_applied: false,
+            bytes_written: request.content.len() + parts_json.len(),
+        }
+    }
+}
+
+/// Trait allowing `zeph-core` to provide a thin bridge type for parts that the
+/// `PersistenceService` needs from the agent's `SecurityState`.
+///
+/// Callers build a [`SecurityView`] from their own private types — this trait is
+/// a convenience for the construction pattern.
+pub trait IntoSecurityView {
+    /// Convert `self` into a [`SecurityView`] borrow-lens.
+    fn as_security_view(&self) -> SecurityView<'_>;
+}
+
+/// Trait allowing `zeph-core` to provide a thin bridge type for the metrics state.
+pub trait IntoMetricsView {
+    /// Convert `self` into a [`MetricsView`] borrow-lens.
+    fn as_metrics_view(&mut self) -> MetricsView<'_>;
+}
+
+// Convenience so callers can drop role/parts into a request with minimal syntax.
+impl PersistMessageRequest {
+    /// Build from a role string as used by the legacy `persist_message` signature.
+    #[must_use]
+    pub fn from_role_parts(
+        role: Role,
+        content: &str,
+        parts: &[MessagePart],
+        has_injection_flags: bool,
+    ) -> Self {
+        Self::from_borrowed(role, content, parts, has_injection_flags)
+    }
+}

--- a/crates/zeph-agent-persistence/src/state.rs
+++ b/crates/zeph-agent-persistence/src/state.rs
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Borrow-lens view types used by [`crate::service::PersistenceService`].
+//!
+//! These structs hold `&`/`&mut` references to the exact sub-fields that the persistence
+//! service needs. By accepting lenses instead of `&mut Agent<C>`, the new crate avoids
+//! depending on `zeph-core` while still letting the call site in `zeph-core` construct them
+//! from disjoint field projections.
+//!
+//! Each view is constructed at the call site in `zeph-core` using one literal struct expression.
+//! The borrow checker can prove disjointness at that level without additional helper methods.
+
+use std::sync::Arc;
+
+use zeph_llm::any::AnyProvider;
+use zeph_memory::semantic::SemanticMemory;
+
+/// Borrow-lens view over the agent's memory persistence state fields.
+///
+/// Aggregates the exact fields that [`crate::service::PersistenceService`] reads and writes
+/// from `MemoryPersistenceState`. Constructed by the `zeph-core` shim with one literal expression.
+pub struct MemoryPersistenceView<'a> {
+    /// Semantic memory backend (`SQLite` + Qdrant). `None` when memory is disabled.
+    pub memory: Option<&'a Arc<SemanticMemory>>,
+    /// Active conversation ID. `None` before the first message.
+    pub conversation_id: Option<zeph_memory::ConversationId>,
+    /// When `true`, assistant messages are auto-saved to Qdrant.
+    pub autosave_assistant: bool,
+    /// Minimum length (chars) for assistant autosave.
+    pub autosave_min_length: usize,
+    /// Mutable count of messages added since last compaction.
+    pub unsummarized_count: &'a mut usize,
+    /// Optional current goal text for embedding enrichment.
+    pub goal_text: Option<String>,
+}
+
+/// Borrow-lens view over the agent's security state fields used during persistence.
+///
+/// Read-only — no mutation needed in the persistence service.
+pub struct SecurityView<'a> {
+    /// When `true`, Qdrant embedding is skipped for messages with injection flags.
+    pub guard_memory_writes: bool,
+    /// Phantom to bind the lifetime of the borrow to the parent.
+    pub _phantom: std::marker::PhantomData<&'a ()>,
+}
+
+/// Borrow-lens view over the agent's metrics state fields used during persistence.
+pub struct MetricsView<'a> {
+    /// Mutable total `SQLite` message count.
+    pub sqlite_message_count: &'a mut u64,
+    /// Mutable total embeddings generated counter.
+    pub embeddings_generated: &'a mut u64,
+    /// Mutable exfiltration guard event counter.
+    pub exfiltration_memory_guards: &'a mut u64,
+}
+
+/// Bundle of provider handles needed by background extraction tasks.
+///
+/// Each handle is an `Arc`-backed clone, suitable for moving into spawned tasks.
+pub struct ProviderHandles {
+    /// Primary LLM provider (used as fallback for background tasks).
+    pub primary: AnyProvider,
+    /// Dedicated embedding provider.
+    pub embedding: AnyProvider,
+}

--- a/crates/zeph-agent-tools/Cargo.toml
+++ b/crates/zeph-agent-tools/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "zeph-agent-tools"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+publish.workspace = true
+description = "Agent tool dispatcher for Zeph: native tool loop, retry, confirmation, batch tool-result processing."
+readme = "README.md"
+
+[dependencies]
+futures.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }
+tracing.workspace = true
+zeph-agent-persistence.workspace = true
+zeph-common.workspace = true
+zeph-config.workspace = true
+zeph-context.workspace = true
+zeph-llm.workspace = true
+zeph-mcp.workspace = true
+zeph-orchestration.workspace = true
+zeph-sanitizer.workspace = true
+zeph-skills.workspace = true
+zeph-tools.workspace = true
+
+[lints]
+workspace = true

--- a/crates/zeph-agent-tools/src/channel.rs
+++ b/crates/zeph-agent-tools/src/channel.rs
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! [`AgentChannel`] trait — minimal async sink the tool dispatcher needs from a channel.
+//!
+//! This trait is sealed: only types declared in `zeph-core` can implement it. The single
+//! implementor is `AgentChannelView<'a, C>` in `crates/zeph-core/src/agent/channel_impl.rs`.
+//!
+//! # Design rationale
+//!
+//! `zeph-agent-tools` cannot depend on `zeph-channels` (which depends on `zeph-core`), so it
+//! defines its own minimal channel trait rather than reusing `zeph_core::channel::Channel`.
+//! This avoids a circular dependency while keeping the dispatcher generic over the channel type.
+//!
+//! `zeph-core` provides the impl via:
+//! ```text
+//! impl<C: zeph_core::channel::Channel> AgentChannel for AgentChannelView<'_, C>
+//! ```
+//! which is orphan-safe because `AgentChannelView` is a local type in `zeph-core`.
+//!
+//! # TODO(critic): `send_stop_hint` takes a primitive `&str` reason instead of an enum.
+//! Any new variant added to `zeph_core::channel::StopHint` MUST be mirrored at dispatcher
+//! emit-sites AND at `AgentChannelView::send_stop_hint` match arms.
+//! See `critic-3515-3516.md` F3.
+
+use std::future::Future;
+
+use crate::sealed::Sealed;
+
+/// Error returned by every [`AgentChannel`] method.
+///
+/// Concrete because the trait is sealed and there is exactly one implementor
+/// (`AgentChannelView<'_, C>`).
+#[derive(Debug, thiserror::Error)]
+#[error("agent channel error: {0}")]
+pub struct ChannelSinkError(String);
+
+impl ChannelSinkError {
+    /// Construct a [`ChannelSinkError`] from any message.
+    pub fn new(msg: impl Into<String>) -> Self {
+        Self(msg.into())
+    }
+}
+
+/// Borrowed payload for a tool-start event.
+///
+/// Mirrors the relevant fields of `zeph_core::channel::ToolStartEvent` but uses borrowed
+/// strings to avoid per-call allocation in the dispatcher hot path. The `AgentChannelView`
+/// impl converts this to the canonical event before forwarding.
+#[derive(Debug, Clone, Copy)]
+pub struct ToolEventStart<'a> {
+    /// Name of the tool being started.
+    pub tool_name: &'a str,
+    /// Unique ID for this tool use invocation.
+    pub tool_use_id: &'a str,
+    /// Parent tool use ID for nested invocations, if any.
+    pub parent_id: Option<&'a str>,
+    /// Short human-readable summary of the tool arguments.
+    pub args_summary: Option<&'a str>,
+}
+
+/// Borrowed payload for a tool-output event.
+///
+/// `body` uses `&'a str` to borrow from the already-owned `String` in the dispatcher.
+/// F4 note: for large tool outputs this avoids an allocation + copy through the seam;
+/// callers can pass the full `String`'s borrow without cloning.
+#[derive(Debug, Clone, Copy)]
+pub struct ToolEventOutput<'a> {
+    /// Name of the tool that produced the output.
+    pub tool_name: &'a str,
+    /// Tool use ID this output belongs to.
+    pub tool_use_id: &'a str,
+    /// Full body of the tool output (may be large — KB to MB for shell/grep results).
+    pub body: &'a str,
+    /// Whether the output represents an error condition.
+    pub is_error: bool,
+    /// Whether the output was streamed incrementally.
+    pub streamed: bool,
+}
+
+/// Minimal async sink the tool dispatcher needs from an agent channel implementation.
+///
+/// **Implementor side:** `zeph-core` provides exactly one impl —
+/// `impl<C: Channel> AgentChannel for AgentChannelView<'_, C>` — which forwards through the
+/// wrapped `&mut C`. The trait is intentionally narrow so the impl is mechanical and the
+/// surface area for breakage is small.
+///
+/// **Caller side:** the dispatcher takes `Ch: AgentChannel` as a generic parameter (NOT
+/// `&mut dyn AgentChannel`). Generic dispatch keeps the per-token hot path free of
+/// `Box`/`Pin` allocations. The trait is not dyn-safe because `impl Future` return types
+/// require monomorphization.
+///
+/// **Sealing:** this trait is sealed via [`Sealed`]. External crates cannot implement it.
+/// Adding a method to `AgentChannel` is non-breaking for downstream — there are no
+/// downstream impls.
+pub trait AgentChannel: Sealed + Send {
+    /// Send free-form assistant text to the user surface.
+    fn send(&mut self, text: &str) -> impl Future<Output = Result<(), ChannelSinkError>> + Send;
+
+    /// Emit a transient status line (TUI spinner / CLI dim line / Telegram typing-then-edit).
+    fn send_status(
+        &mut self,
+        text: &str,
+    ) -> impl Future<Output = Result<(), ChannelSinkError>> + Send;
+
+    /// Best-effort typing indicator. No-op on channels that don't support it.
+    fn send_typing(&mut self) -> impl Future<Output = Result<(), ChannelSinkError>> + Send;
+
+    /// Flush any per-token chunks accumulated during streaming.
+    fn flush_chunks(&mut self) -> impl Future<Output = Result<(), ChannelSinkError>> + Send;
+
+    /// Ask the user a yes/no confirmation question.
+    fn confirm(
+        &mut self,
+        prompt: &str,
+    ) -> impl Future<Output = Result<bool, ChannelSinkError>> + Send;
+
+    /// Notify the channel that the assistant turn stopped for `reason`.
+    ///
+    /// `reason` is a primitive string code such as `"max_tokens"`, `"cancelled"`,
+    /// `"max_turn_requests"`, or `"timeout"`. The `AgentChannelView` impl maps these to the
+    /// concrete `zeph_core::channel::StopHint` enum and forwards.
+    fn send_stop_hint(
+        &mut self,
+        reason: &str,
+    ) -> impl Future<Output = Result<(), ChannelSinkError>> + Send;
+
+    /// Emit a tool-start event.
+    ///
+    /// The payload is [`ToolEventStart`] — a small borrowed struct local to this crate.
+    /// The `AgentChannelView` impl converts this to the canonical `zeph_core::channel::ToolStartEvent`
+    /// before forwarding to `Channel::send_tool_start`.
+    fn send_tool_start(
+        &mut self,
+        event: ToolEventStart<'_>,
+    ) -> impl Future<Output = Result<(), ChannelSinkError>> + Send;
+
+    /// Emit a tool-output event.
+    ///
+    /// Same conversion contract as [`send_tool_start`](Self::send_tool_start).
+    fn send_tool_output(
+        &mut self,
+        event: ToolEventOutput<'_>,
+    ) -> impl Future<Output = Result<(), ChannelSinkError>> + Send;
+}

--- a/crates/zeph-agent-tools/src/doom_loop.rs
+++ b/crates/zeph-agent-tools/src/doom_loop.rs
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Doom-loop detection: hash message content while normalizing volatile tool IDs.
+
+/// Hash message content for doom-loop detection, skipping volatile IDs in-place.
+///
+/// Normalizes `[tool_result: <id>]` → `[tool_result]` and
+/// `[tool_use: <name>(<id>)]` → `[tool_use: <name>]` by feeding only stable segments
+/// into the hasher without materializing the normalized string.
+///
+/// # Notes
+///
+/// `DefaultHasher` output is **not** stable across Rust versions — do not persist or
+/// serialize these hashes. They are valid only for within-session equality comparison.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_agent_tools::doom_loop::doom_loop_hash;
+///
+/// let h1 = doom_loop_hash("hello world");
+/// let h2 = doom_loop_hash("hello world");
+/// assert_eq!(h1, h2);
+///
+/// // Volatile IDs are normalized
+/// let h3 = doom_loop_hash("[tool_result: abc123] output");
+/// let h4 = doom_loop_hash("[tool_result: xyz789] output");
+/// assert_eq!(h3, h4);
+/// ```
+#[must_use]
+pub fn doom_loop_hash(content: &str) -> u64 {
+    use std::hash::{DefaultHasher, Hasher};
+    let mut hasher = DefaultHasher::new();
+    let mut rest = content;
+    while !rest.is_empty() {
+        let r_pos = rest.find("[tool_result: ");
+        let u_pos = rest.find("[tool_use: ");
+        match (r_pos, u_pos) {
+            (Some(r), Some(u)) if u < r => hash_tool_use_in_place(&mut hasher, &mut rest, u),
+            (Some(r), _) => hash_tool_result_in_place(&mut hasher, &mut rest, r),
+            (_, Some(u)) => hash_tool_use_in_place(&mut hasher, &mut rest, u),
+            _ => {
+                hasher.write(rest.as_bytes());
+                break;
+            }
+        }
+    }
+    hasher.finish()
+}
+
+fn hash_tool_result_in_place(hasher: &mut impl std::hash::Hasher, rest: &mut &str, start: usize) {
+    hasher.write(&rest.as_bytes()[..start]);
+    if let Some(end) = rest[start..].find(']') {
+        hasher.write(b"[tool_result]");
+        *rest = &rest[start + end + 1..];
+    } else {
+        hasher.write(&rest.as_bytes()[start..]);
+        *rest = "";
+    }
+}
+
+fn hash_tool_use_in_place(hasher: &mut impl std::hash::Hasher, rest: &mut &str, start: usize) {
+    hasher.write(&rest.as_bytes()[..start]);
+    let tag = &rest[start..];
+    // Format: "[tool_use: name(id)]" or "[tool_use: name]"
+    // We want to emit "[tool_use: name]" stripping the ID.
+    if let Some(paren) = tag.find('(') {
+        if let Some(bracket) = tag.find(']') {
+            // Emit "[tool_use: name]" (name is between ": " and "(")
+            hasher.write(b"[tool_use: ");
+            hasher.write(&tag.as_bytes()["[tool_use: ".len()..paren]);
+            hasher.write(b"]");
+            *rest = &rest[start + bracket + 1..];
+        } else {
+            hasher.write(&rest.as_bytes()[start..]);
+            *rest = "";
+        }
+    } else if let Some(bracket) = tag.find(']') {
+        // No parens — already in canonical form
+        hasher.write(&tag.as_bytes()[..=bracket]);
+        *rest = &rest[start + bracket + 1..];
+    } else {
+        hasher.write(&rest.as_bytes()[start..]);
+        *rest = "";
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_content_same_hash() {
+        assert_eq!(doom_loop_hash("hello"), doom_loop_hash("hello"));
+    }
+
+    #[test]
+    fn different_tool_result_ids_same_hash() {
+        let h1 = doom_loop_hash("[tool_result: abc] output");
+        let h2 = doom_loop_hash("[tool_result: xyz] output");
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn different_content_different_hash() {
+        let h1 = doom_loop_hash("content A");
+        let h2 = doom_loop_hash("content B");
+        assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn empty_string_is_stable() {
+        assert_eq!(doom_loop_hash(""), doom_loop_hash(""));
+    }
+}

--- a/crates/zeph-agent-tools/src/error.rs
+++ b/crates/zeph-agent-tools/src/error.rs
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Error types for the tool dispatcher.
+
+use thiserror::Error;
+
+/// Errors that can occur during tool dispatch.
+///
+/// The caller in `zeph-core` maps these to `AgentError` via `From<ToolDispatchError>`.
+#[derive(Debug, Error)]
+pub enum ToolDispatchError {
+    /// LLM provider returned an error during tool-loop inference.
+    #[error("LLM provider error: {0}")]
+    Llm(#[from] zeph_llm::LlmError),
+
+    /// Tool executor returned an error.
+    #[error("tool execution error: {0}")]
+    Tool(#[from] zeph_tools::ToolError),
+
+    /// MCP server returned an error during tool dispatch.
+    #[error("MCP error: {0}")]
+    Mcp(String),
+
+    /// The turn was cancelled by the user or a cancellation token.
+    #[error("turn cancelled")]
+    Cancelled,
+
+    /// Context length exceeded even after compaction.
+    #[error("context length exceeded after compaction")]
+    ContextOverflow,
+
+    /// An operation timed out.
+    #[error("timeout: {0}")]
+    Timeout(String),
+
+    /// Channel sink returned an error while emitting events to the user surface.
+    #[error("channel error: {0}")]
+    Channel(#[from] crate::channel::ChannelSinkError),
+}

--- a/crates/zeph-agent-tools/src/lib.rs
+++ b/crates/zeph-agent-tools/src/lib.rs
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Agent tool dispatcher for Zeph.
+//!
+//! This crate provides the [`AgentChannel`] trait, borrowed event carriers, and doom-loop
+//! detection utilities used by the tool dispatch loop in `zeph-core`.
+//!
+//! # Architecture
+//!
+//! `zeph-agent-tools` does **not** depend on `zeph-core` or `zeph-channels`. It defines its
+//! own minimal [`AgentChannel`] trait (sealed) which `zeph-core` implements via a local adapter
+//! type `AgentChannelView<'a, C>`. This avoids the circular dependency that would arise from
+//! using `zeph-core::channel::Channel` directly.
+//!
+//! # Crate status
+//!
+//! Phase 2 scaffolding (issue #3516). The `AgentChannel` trait and borrowed event carriers
+//! are complete. Full `ToolDispatcher` extraction from `zeph-core` is tracked as a follow-up
+//! once the persistence extraction (#3515) lands and integration tests are stable.
+
+pub mod channel;
+pub mod doom_loop;
+pub mod error;
+#[doc(hidden)]
+pub mod sealed;
+
+pub use channel::{AgentChannel, ChannelSinkError, ToolEventOutput, ToolEventStart};
+pub use doom_loop::doom_loop_hash;
+pub use error::ToolDispatchError;
+pub use sealed::Sealed;

--- a/crates/zeph-agent-tools/src/sealed.rs
+++ b/crates/zeph-agent-tools/src/sealed.rs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Sealed trait token for [`crate::channel::AgentChannel`].
+//!
+//! `Sealed` must be `pub` so `zeph-core` can implement it on `AgentChannelView`, but it is
+//! placed in this module and re-exported with `#[doc(hidden)]` to discourage external use.
+//! Downstream crates should not implement `AgentChannel` — the trait is intentionally sealed.
+
+/// Sealing supertrait for [`crate::channel::AgentChannel`].
+///
+/// # Stability
+///
+/// This trait is `#[doc(hidden)]`. External crates MUST NOT implement it.
+/// Adding methods to `AgentChannel` is a non-breaking change precisely because no external
+/// impls exist.
+#[doc(hidden)]
+pub trait Sealed {}


### PR DESCRIPTION
## Summary

Phase 2 scaffolding for the Agent god-object decomposition epic (#3498). Two new crates are introduced, each independent of `zeph-core`:

- **`zeph-agent-persistence`** (closes part of #3515) — `PersistenceService` façade, sanitize/embed/graph helpers, borrow-lens view types, `PersistMessageRequest` owned value type
- **`zeph-agent-tools`** (closes part of #3516) — `AgentChannel` sealed trait, borrowed event carriers, doom-loop hash, `ToolDispatchError`

Both crates compile without `zeph-core` in the dependency tree. Orphan-rule-safe design: `AgentChannel` is sealed with `impl` on a local `AgentChannelView<'_, C>` adapter in `zeph-core` (wired in the follow-up PR).

## What is NOT in this PR

Full wiring of `zeph-core` to delegate to these crates (removing the original `persistence.rs` and `tool_execution/` code) is the next step, tracked in #3515 and #3516 which remain open. This PR provides the foundation that follow-up can build on.

## Test plan

- [x] `cargo build -p zeph-agent-persistence` — succeeds without `zeph-core`
- [x] `cargo build -p zeph-agent-tools` — succeeds without `zeph-core`
- [x] `cargo build --workspace` — 0 errors
- [x] `cargo clippy -p zeph-agent-persistence -p zeph-agent-tools -- -D warnings` — 0 errors
- [x] `cargo nextest run --workspace --lib --bins` — 8656 passed, 21 skipped, 0 failed
- [x] `cargo +nightly fmt --check` — clean
- [x] SPDX headers present in all new files
- [x] No `unwrap`/`expect` in production code paths