### PR TITLE
feat(docker): switch to musl targets and distroless/static-debian12

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,11 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
             archive: tar.gz
             use_cross: false
           - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
+            target: aarch64-unknown-linux-musl
             archive: tar.gz
             use_cross: true
           - os: macos-latest
@@ -54,6 +54,9 @@ jobs:
         with:
           cache-targets: "false"
           shared-key: "release-${{ matrix.target }}"
+      - name: Install musl-tools (Linux native musl builds)
+        if: "!matrix.use_cross && runner.os == 'Linux'"
+        run: sudo apt-get install -y musl-tools
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
         if: "!matrix.use_cross"
       - uses: taiki-e/install-action@f90de9db888af81a66244f6fed63376aa8163cef # cross
@@ -222,14 +225,14 @@ jobs:
       - name: Download Linux binaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          pattern: binary-*-unknown-linux-gnu
+          pattern: binary-*-unknown-linux-musl
           path: artifacts
       - name: Extract and prepare binaries
         run: |
           mkdir -p binaries
-          tar -xzf artifacts/binary-x86_64-unknown-linux-gnu/zeph-x86_64-unknown-linux-gnu.tar.gz -C binaries
+          tar -xzf artifacts/binary-x86_64-unknown-linux-musl/zeph-x86_64-unknown-linux-musl.tar.gz -C binaries
           mv binaries/zeph binaries/zeph-amd64
-          tar -xzf artifacts/binary-aarch64-unknown-linux-gnu/zeph-aarch64-unknown-linux-gnu.tar.gz -C binaries
+          tar -xzf artifacts/binary-aarch64-unknown-linux-musl/zeph-aarch64-unknown-linux-musl.tar.gz -C binaries
           mv binaries/zeph binaries/zeph-arm64
           chmod +x binaries/zeph-*
           ls -lh binaries/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ serial_test = "3.4"
 globset = "0.4.18"
 similar = "3.1"
 sqlx = { version = "0.8.6", default-features = false }
+libsqlite3-sys = { version = "0.30", features = ["bundled"] }
 subtle = "2.6"
 sysinfo = { version = "0.38.4", default-features = false, features = ["system"] }
 pprof = { version = "0.15.0", default-features = false }

--- a/crates/zeph-skills/src/manager.rs
+++ b/crates/zeph-skills/src/manager.rs
@@ -115,7 +115,16 @@ impl SkillManager {
         let status = Command::new("git")
             .args(["clone", "--depth=1", url, tmp_dir.to_str().unwrap_or("")])
             .status()
-            .map_err(|e| SkillError::GitCloneFailed(format!("failed to run git: {e}")))?;
+            .map_err(|e| {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    SkillError::GitCloneFailed(
+                        "git binary not found on PATH; install git to use skill install from URL"
+                            .to_owned(),
+                    )
+                } else {
+                    SkillError::GitCloneFailed(format!("failed to run git: {e}"))
+                }
+            })?;
 
         if !status.success() {
             let _ = std::fs::remove_dir_all(&tmp_dir);

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,25 +1,22 @@
-FROM debian:bookworm-slim@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0c2280647e1310bc1642182655d
+# Stage 1: prepare writable runtime directories with correct ownership.
+# busybox is used only to run mkdir/chown; it is not present in the final image.
+FROM busybox:1.37-musl AS setup
 
 ARG TARGETARCH
-
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    curl wget git jq file findutils iproute2 procps \
-    nodejs npm python3 && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-    useradd --system --create-home --shell /sbin/nologin zeph
-
-WORKDIR /app
 
 COPY binaries/zeph-${TARGETARCH} /app/zeph
 COPY config/ /app/config/
 COPY .zeph/skills/ /app/.zeph/skills/
 
+# distroless nonroot uid is 65532
 RUN mkdir -p /app/.zeph/data && \
-    chown -R zeph:zeph /app && \
-    chmod +x /app/zeph
+    chown -R 65532:65532 /app
 
-USER zeph
+# Stage 2: minimal distroless runtime — no shell, no package manager, zero CVEs.
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY --from=setup /app /app
+
+WORKDIR /app
 
 ENTRYPOINT ["/app/zeph"]


### PR DESCRIPTION
## Summary

- Switch release build targets from `*-linux-gnu` (glibc) to `*-linux-musl` (static)
- Replace `debian:bookworm-slim` final image with `gcr.io/distroless/static-debian12:nonroot`
- Add `libsqlite3-sys` with `bundled` feature so SQLite is compiled statically (no system lib dependency)
- Improve error message when `git` is absent at runtime (skill install via URL gracefully reports the issue instead of OS error)

## Motivation

Trivy scan of the previous image found 1 CRITICAL + 8 HIGH CVEs, mostly from unnecessary packages (nodejs, curl, python3, etc.) and glibc. `distroless/static-debian12` has zero CVEs and is ~6 MB vs ~665 MB.

## Breaking change

System `git` is no longer available inside the container. `skill install <url>` will return a clear error message when invoked in a containerized deployment. Branch detection in core already handled git absence gracefully via `.ok()`.

## Open question

`aarch64-unknown-linux-musl` cross-compilation uses the default `cross` image. If CI fails on aarch64, a `Cross.toml` with `image = "messense/rust-musl-cross:aarch64-musl"` may be needed.