### PR TITLE
fix(acp): restore notification routing and suppress large_futures (#3520, #3521)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(acp): restore session/update notification routing in run-agent client (#3520). Removed
+  no-op `on_receive_notification` handler from `spawn_subagent_inner` that was silently
+  discarding all `agent_message_chunk` notifications before they could reach `drain_until_stop`,
+  causing `zeph acp run-agent` to always produce empty output.
+- fix(acp,bench): box `agent.run()` future to suppress `clippy::large_futures` with
+  `--features full` (#3521). Changed `agent.run().await` to `Box::pin(agent.run()).await`
+  at `src/acp.rs:901` and `crates/zeph-bench/src/runner.rs:532` to keep the 17 400-byte
+  future on the heap rather than the stack.
+
 ### Changed
 
 - refactor(context): fix workspace compilation errors introduced during context migration

--- a/crates/zeph-acp/src/client/mod.rs
+++ b/crates/zeph-acp/src/client/mod.rs
@@ -55,10 +55,10 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use agent_client_protocol::{
-    Agent, Client, SessionMessage, on_receive_notification, on_receive_request,
+    Agent, Client, SessionMessage, on_receive_request,
     schema::{
         RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
-        SelectedPermissionOutcome, SessionId, SessionNotification, StopReason,
+        SelectedPermissionOutcome, SessionId, StopReason,
     },
 };
 use futures::channel::mpsc;
@@ -373,10 +373,6 @@ async fn spawn_subagent_inner(cfg: SubagentConfig) -> Result<SubagentHandle, Acp
         tokio::spawn(async move {
             let result = Client
             .builder()
-            .on_receive_notification(
-                async move |_notif: SessionNotification, _cx| Ok(()),
-                on_receive_notification!(),
-            )
             .on_receive_request(
                 async move |req: RequestPermissionRequest,
                       responder: agent_client_protocol::Responder<RequestPermissionResponse>,

--- a/crates/zeph-bench/src/runner.rs
+++ b/crates/zeph-bench/src/runner.rs
@@ -529,7 +529,7 @@ impl BenchRunner {
 
         // Ignore agent errors — a failed LLM call still yields an empty response that
         // the evaluator scores as 0.0 rather than aborting the entire run.
-        let _ = agent.run().await;
+        let _ = Box::pin(agent.run()).await;
         let responses = agent.into_channel().into_responses();
 
         // Best-effort cleanup: delete per-scenario SQLite file after the run.

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -898,7 +898,7 @@ async fn spawn_acp_agent(
         tracing::error!("failed to load agent history: {e:#}");
     }
 
-    if let Err(e) = agent.run().await {
+    if let Err(e) = Box::pin(agent.run()).await {
         tracing::error!("ACP agent loop error: {e:#}");
     }
 


### PR DESCRIPTION
## Summary

- Remove no-op `on_receive_notification` handler from `spawn_subagent_inner` in `crates/zeph-acp/src/client/mod.rs`. The handler was intercepting all `session/update` messages at the connection level and discarding them before `ActiveSessionHandler` could route them into `update_rx`. As a result, `drain_until_stop` never received text chunks and `zeph acp run-agent` always produced empty stdout.
- Box `agent.run()` at two call sites (`src/acp.rs:901`, `crates/zeph-bench/src/runner.rs:532`) to move the 17 400-byte future onto the heap, eliminating the `clippy::large_futures` error triggered when building with `--features full` (includes `classifiers`).

## Test plan

- [x] `cargo build --features full` — compiles without errors
- [x] `cargo clippy --workspace --features full -- -D warnings` — zero warnings/errors (large_futures gone)
- [x] `cargo +nightly fmt --check` — no formatting issues
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 8653 tests pass

Closes #3520
Closes #3521