### PR TITLE
refactor(context): wire compact_context, add MetricsCallback and compression_guidelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- feat(agent-context): add `MetricsCallback` trait and `ToolOutputArchive`, `CompactionProbeCallback`,
+  `CompactionPersistence` callback traits to `zeph-agent-context` (#3527). These four traits define
+  the cross-crate interface for compaction side-effects; `zeph-agent-context` declares them and
+  `zeph-core` provides concrete implementations, preserving the crate isolation invariant.
+  `MetricsCallback` exposes six recording methods (hard-compaction, tool-output-prune, probe
+  pass/soft-fail/hard-fail/error) consumed by `ContextService` internals.
+
+### Changed
+
+- refactor(agent-context): add `compression_guidelines: Option<String>` field to
+  `ContextSummarizationView` and `with_compression_guidelines` builder; `compact_context` now reads
+  the guidelines from the view rather than requiring the caller to pass them separately (#3528).
+  `ContextSummarizationView` also gains four optional callback fields: `probe`, `archive`,
+  `persistence`, and `metrics`.
+- refactor(core): wire `Agent<C>::compact_context` to `ContextService::compact_context` via callback
+  traits (#3526). The old 100-line `compact_context` method is replaced by a ≤11-statement shim;
+  all structural logic (partition, archive, summarize, probe, finalize, persist) lives in
+  `zeph_agent_context`. Four adapter types (`MetricsCollectorCallback`, `AgentProbe`,
+  `AgentArchive`, `AgentPersistence`) implemented in a new `adapters` module, bundled by
+  `CompactionAdapters`. Dead helpers (`archive_tool_outputs`, `summarize_messages_with_deps`,
+  `try_summarize_structured_with_deps`, `try_summarize_with_llm_with_deps`,
+  `remove_tool_responses_middle_out`) removed from `zeph-core`; test-only wrappers added back as
+  `#[cfg(test)]` delegations. `PartialEq` (variant-only, ignores `qdrant_future`) added to
+  `CompactionOutcome` for test assertions.
+
 ### Fixed
 
 - fix(acp): restore session/update notification routing in run-agent client (#3520). Removed

--- a/crates/zeph-agent-context/src/lib.rs
+++ b/crates/zeph-agent-context/src/lib.rs
@@ -45,6 +45,8 @@ pub use error::ContextError;
 pub use helpers::BudgetHint;
 pub use service::ContextService;
 pub use state::{
-    CompactionOutcome, ContextAssemblyView, ContextDelta, ContextSummarizationView,
-    MessageWindowView, MetricsCounters, ProviderHandles, StatusSink,
+    CompactionOutcome, CompactionPersistence, CompactionProbeCallback, ContextAssemblyView,
+    ContextDelta, ContextSummarizationView, MessageWindowView, MetricsCallback, MetricsCounters,
+    ProbeOutcome, ProviderHandles, QdrantPersistFuture, SecurityEventSink, StatusSink,
+    ToolOutputArchive, TrustGate,
 };

--- a/crates/zeph-agent-context/src/service.rs
+++ b/crates/zeph-agent-context/src/service.rs
@@ -981,12 +981,14 @@ impl ContextService {
         use zeph_context::manager::CompactionState;
 
         // Track hard compaction event for pressure metrics.
-        if let Some(turns) = summ.context_manager.turns_since_last_hard_compaction {
-            // TODO(review): compaction_turns_after_hard metric not tracked without MetricsCallback
-            let _ = turns;
-        }
+        let turns_since_last = summ
+            .context_manager
+            .turns_since_last_hard_compaction
+            .map(|t| u32::try_from(t).unwrap_or(u32::MAX));
         summ.context_manager.turns_since_last_hard_compaction = Some(0);
-        // TODO(review): compaction_hard_count metric not tracked without MetricsCallback
+        if let Some(metrics) = summ.metrics {
+            metrics.record_hard_compaction(turns_since_last);
+        }
 
         if in_cooldown {
             tracing::debug!(
@@ -1044,11 +1046,11 @@ impl ContextService {
             "hard compaction: falling back to LLM summarization"
         );
         let tokens_before = *summ.cached_prompt_tokens;
-        let compacted = crate::summarization::compaction::compact_context(summ, None).await?;
+        let outcome = crate::summarization::compaction::compact_context(summ, None).await?;
 
         let freed_tokens = tokens_before.saturating_sub(*summ.cached_prompt_tokens);
 
-        if compacted == 0 || freed_tokens == 0 {
+        if !outcome.is_compacted() || freed_tokens == 0 {
             tracing::warn!("hard compaction: no net reduction, marking exhausted");
             summ.context_manager.compaction = CompactionState::Exhausted { warned: false };
             status.send_status("").await;
@@ -1138,7 +1140,10 @@ impl ContextService {
     /// a compact summary. Use this in tests or when the caller has already determined that
     /// compaction is warranted. Production code should prefer [`Self::maybe_compact`].
     ///
-    /// Returns the number of messages compacted, or `0` when there is nothing to compact.
+    /// Invokes the optional callbacks wired into `summ` in this order:
+    /// archive → LLM summarization → probe → finalize → persistence.
+    ///
+    /// Returns [`CompactionOutcome::NoChange`] when there is nothing to compact.
     ///
     /// # Errors
     ///
@@ -1147,7 +1152,7 @@ impl ContextService {
         &self,
         summ: &mut ContextSummarizationView<'_>,
         max_summary_tokens: Option<usize>,
-    ) -> Result<usize, crate::error::ContextError> {
+    ) -> Result<crate::state::CompactionOutcome, crate::error::ContextError> {
         crate::summarization::compaction::compact_context(summ, max_summary_tokens).await
     }
 
@@ -1206,13 +1211,14 @@ impl ContextService {
             "proactive compression triggered"
         );
 
+        // TODO(critic-D1): populate `summ.compression_guidelines` here for the proactive path.
         match crate::summarization::compaction::compact_context(summ, Some(max_summary_tokens))
             .await
         {
-            Ok(compacted) if compacted > 0 => {
+            Ok(outcome) if outcome.is_compacted() => {
                 summ.context_manager.compaction =
                     zeph_context::manager::CompactionState::CompactedThisTurn { cooldown: 0 };
-                tracing::info!(compacted, "proactive compression complete");
+                tracing::info!("proactive compression complete");
             }
             Ok(_) => {}
             Err(e) => tracing::warn!(%e, "proactive compression failed"),

--- a/crates/zeph-agent-context/src/service.rs
+++ b/crates/zeph-agent-context/src/service.rs
@@ -1143,7 +1143,7 @@ impl ContextService {
     /// Invokes the optional callbacks wired into `summ` in this order:
     /// archive → LLM summarization → probe → finalize → persistence.
     ///
-    /// Returns [`CompactionOutcome::NoChange`] when there is nothing to compact.
+    /// Returns [`crate::state::CompactionOutcome::NoChange`] when there is nothing to compact.
     ///
     /// # Errors
     ///

--- a/crates/zeph-agent-context/src/state.rs
+++ b/crates/zeph-agent-context/src/state.rs
@@ -17,6 +17,7 @@ use std::borrow::Cow;
 use std::collections::HashSet;
 use std::future::Future;
 use std::path::PathBuf;
+use std::pin::Pin;
 use std::sync::Arc;
 use zeph_common::SecurityEventCategory;
 use zeph_common::task_supervisor::{BlockingHandle, TaskSupervisor};
@@ -289,6 +290,51 @@ pub struct ContextSummarizationView<'a> {
     /// Set to `crate::redact::scrub_content` by the `zeph-core` shim when
     /// `redact_credentials = true`, or to a no-op identity function otherwise.
     pub scrub: fn(&str) -> Cow<'_, str>,
+
+    // ── Compaction callbacks (populated by zeph-core shim) ────────────────────
+    /// Compression guidelines text loaded from `SQLite` by the `zeph-core` shim.
+    ///
+    /// `None` when the feature is disabled or the caller does not load guidelines.
+    /// The service passes the contained string (or `""`) to `summarize_with_llm`. Closes #3528.
+    ///
+    /// Set via [`ContextSummarizationView::with_compression_guidelines`].
+    ///
+    /// `// TODO(critic-D1)`: the proactive compression path (`maybe_proactive_compress`)
+    /// currently passes `None` here. A follow-up issue should populate guidelines there too.
+    pub compression_guidelines: Option<String>,
+
+    /// Optional probe-validation callback. When `Some`, the service invokes it after LLM
+    /// summarization and before draining/reinsert. See [`CompactionProbeCallback`] for the
+    /// full implementor contract.
+    pub probe: Option<&'a mut dyn CompactionProbeCallback>,
+
+    /// Optional pre-summary archive hook (Memex #2432). The service calls `archive(to_compact)`
+    /// BEFORE summarization and appends the returned reference list as a postfix AFTER the
+    /// LLM call so the LLM cannot destroy the `[archived:UUID]` markers.
+    pub archive: Option<&'a dyn ToolOutputArchive>,
+
+    /// Optional persistence completion callback. The service calls `after_compaction` once
+    /// the in-memory drain+reinsert is finalized. The optional Qdrant future returned by the
+    /// callback is bubbled back through [`CompactionOutcome::Compacted::qdrant_future`].
+    pub persistence: Option<&'a dyn CompactionPersistence>,
+
+    /// Metrics sink for compaction-related counter increments. Used for
+    /// `compaction_hard_count`, `tool_output_prunes`, and the four probe-outcome counters.
+    /// Closes #3527.
+    pub metrics: Option<&'a dyn MetricsCallback>,
+}
+
+impl ContextSummarizationView<'_> {
+    /// Set the compression guidelines text.
+    ///
+    /// Call this on the view returned by `Agent::summarization_view()` before passing it to
+    /// `ContextService::compact_context`. Using a builder method keeps construction uniform
+    /// and avoids direct field mutation.
+    #[must_use]
+    pub fn with_compression_guidelines(mut self, guidelines: Option<String>) -> Self {
+        self.compression_guidelines = guidelines;
+        self
+    }
 }
 
 /// Bundle of LLM provider handles needed for async context operations.
@@ -320,21 +366,218 @@ pub trait TrustGate: Send + Sync {
     fn set_effective_trust(&self, level: zeph_common::SkillTrustLevel);
 }
 
+/// Boxed `'static` future for the off-thread Qdrant session-summary write.
+///
+/// Returned from [`CompactionPersistence::after_compaction`] and bubbled back through
+/// [`CompactionOutcome::Compacted`] / [`CompactionOutcome::CompactedWithPersistError`].
+/// The caller (shim in `zeph-core`) dispatches this through `BackgroundSupervisor::spawn_summarization`.
+/// The future must return `bool` (`false` = success, `true` = error) to match the supervisor API.
+pub type QdrantPersistFuture = Pin<Box<dyn Future<Output = bool> + Send + 'static>>;
+
 /// Return type from `compact_context()` that distinguishes between successful compaction,
 /// probe rejection, and no-op.
 ///
 /// Gives `maybe_compact()` enough information to handle probe rejection without triggering
 /// the `Exhausted` state — which would only be correct if summarization itself is stuck.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[must_use]
 pub enum CompactionOutcome {
-    /// Messages were drained and replaced with a summary.
-    Compacted,
-    /// Messages were drained and replaced with a summary, but persisting the result failed.
-    /// The in-memory state is correct; only persistence to storage failed.
-    CompactedWithPersistError,
+    /// Messages were drained and replaced with a summary. `SQLite` persistence succeeded.
+    ///
+    /// `qdrant_future` is an optional `'static` future for the off-thread Qdrant write;
+    /// the shim must dispatch it through `BackgroundSupervisor::spawn_summarization` and
+    /// must not await it inline.
+    Compacted {
+        /// Optional Qdrant write future to dispatch via the supervisor.
+        qdrant_future: Option<QdrantPersistFuture>,
+    },
+    /// Messages were drained and replaced with a summary, but synchronous `SQLite` persistence
+    /// reported failure. The in-memory state is correct; only persistence failed.
+    CompactedWithPersistError {
+        /// Optional Qdrant write future to dispatch via the supervisor.
+        qdrant_future: Option<QdrantPersistFuture>,
+    },
     /// Probe rejected the summary — original messages are preserved.
     /// Caller must NOT check `freed_tokens` or transition to `Exhausted`.
     ProbeRejected,
     /// No compaction was performed (too few messages, empty `to_compact`, etc.).
     NoChange,
+}
+
+impl PartialEq for CompactionOutcome {
+    fn eq(&self, other: &Self) -> bool {
+        // Compare variants only; qdrant_future is not comparable (it is a dyn Future).
+        matches!(
+            (self, other),
+            (Self::Compacted { .. }, Self::Compacted { .. })
+                | (
+                    Self::CompactedWithPersistError { .. },
+                    Self::CompactedWithPersistError { .. }
+                )
+                | (Self::ProbeRejected, Self::ProbeRejected)
+                | (Self::NoChange, Self::NoChange)
+        )
+    }
+}
+
+impl std::fmt::Debug for CompactionOutcome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Compacted { qdrant_future } => f
+                .debug_struct("Compacted")
+                .field("qdrant_future", &qdrant_future.as_ref().map(|_| "<future>"))
+                .finish(),
+            Self::CompactedWithPersistError { qdrant_future } => f
+                .debug_struct("CompactedWithPersistError")
+                .field("qdrant_future", &qdrant_future.as_ref().map(|_| "<future>"))
+                .finish(),
+            Self::ProbeRejected => write!(f, "ProbeRejected"),
+            Self::NoChange => write!(f, "NoChange"),
+        }
+    }
+}
+
+impl CompactionOutcome {
+    /// Remove and return the Qdrant persistence future embedded in `Compacted` or
+    /// `CompactedWithPersistError` variants. Returns `None` for `ProbeRejected` / `NoChange`.
+    ///
+    /// The shim calls this immediately after the service returns and dispatches the
+    /// future through `BackgroundSupervisor::spawn_summarization`.
+    pub fn qdrant_future_take(&mut self) -> Option<QdrantPersistFuture> {
+        match self {
+            Self::Compacted { qdrant_future }
+            | Self::CompactedWithPersistError { qdrant_future } => qdrant_future.take(),
+            _ => None,
+        }
+    }
+
+    /// Returns `true` when compaction succeeded (either variant of `Compacted`).
+    #[must_use]
+    pub fn is_compacted(&self) -> bool {
+        matches!(
+            self,
+            Self::Compacted { .. } | Self::CompactedWithPersistError { .. }
+        )
+    }
+}
+
+/// Verdict returned by a [`CompactionProbeCallback`] after evaluating a candidate summary.
+///
+/// The implementor — not the service — is responsible for routing the verdict-specific data
+/// (score, `category_scores`, thresholds) through [`MetricsCallback`] and for calling
+/// `dump_compaction_probe` before returning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProbeOutcome {
+    /// Probe accepted the summary; pipeline continues normally.
+    Pass,
+    /// Probe soft-rejected; pipeline continues but the summary is flagged as borderline.
+    SoftFail,
+    /// Probe hard-rejected; service must abort and return [`CompactionOutcome::ProbeRejected`].
+    HardFail,
+}
+
+/// Probe-validation callback invoked by `ContextService::compact_context` after the LLM
+/// produces a candidate summary.
+///
+/// # Contract (mandatory)
+///
+/// Implementations MUST, before returning:
+/// 1. Call `dump_compaction_probe(result)` if a debug dumper is configured.
+/// 2. Update verdict-specific metric counters via the appropriate
+///    `MetricsCallback::record_compaction_probe_*` method. The score, `category_scores`,
+///    threshold, and `hard_fail_threshold` travel through the metrics adapter and are not
+///    part of the `ProbeOutcome` payload.
+/// 3. On internal validation error (`validate_compaction` returns `Err`), call
+///    `MetricsCallback::record_compaction_probe_error()` and return `ProbeOutcome::Pass`.
+///    An error must not abort compaction.
+///
+/// The service treats the returned `ProbeOutcome` exclusively as routing:
+/// `HardFail` → abort with `ProbeRejected`; `Pass | SoftFail` → continue.
+pub trait CompactionProbeCallback: Send {
+    /// Validate the candidate `summary` produced from `to_compact` messages.
+    fn validate<'a>(
+        &'a mut self,
+        to_compact: &'a [Message],
+        summary: &'a str,
+    ) -> Pin<Box<dyn Future<Output = ProbeOutcome> + Send + 'a>>;
+}
+
+/// Pre-summary tool-output archiving hook (Memex #2432).
+///
+/// The service calls `archive(to_compact)` BEFORE summarization. The returned reference
+/// strings are appended as a postfix AFTER the LLM summary to prevent the LLM from
+/// destroying the `[archived:UUID]` markers.
+pub trait ToolOutputArchive: Send + Sync {
+    /// Archive tool output bodies from `to_compact` and return reference strings.
+    ///
+    /// Returns an empty `Vec` when archiving is disabled or no bodies are archived.
+    fn archive<'a>(
+        &'a self,
+        to_compact: &'a [Message],
+    ) -> Pin<Box<dyn Future<Output = Vec<String>> + Send + 'a>>;
+}
+
+/// Persistence completion hook invoked after the in-memory drain/reinsert is finalized.
+///
+/// Returns:
+/// - `persist_failed`: whether the synchronous `SQLite` persistence step failed.
+/// - `qdrant_future`: optional `'static` future for the off-thread Qdrant write, bubbled
+///   back to the caller via [`CompactionOutcome::Compacted::qdrant_future`].
+pub trait CompactionPersistence: Send + Sync {
+    /// Persist the compaction result and return the Qdrant write future.
+    fn after_compaction<'a>(
+        &'a self,
+        compacted_count: usize,
+        summary_content: &'a str,
+        summary: &'a str,
+    ) -> Pin<Box<dyn Future<Output = (bool, Option<QdrantPersistFuture>)> + Send + 'a>>;
+}
+
+/// Metrics-counter sink for `ContextService` increments.
+///
+/// Implemented in `zeph-core` by an adapter wrapping `Arc<MetricsCollector>`. Keeps
+/// `zeph-agent-context` free of `zeph-core` internal metrics types. Closes #3527.
+///
+/// All four `record_compaction_probe_*` methods are called from inside the
+/// [`CompactionProbeCallback`] implementation — not from the service itself — per the
+/// probe-callback contract.
+pub trait MetricsCallback: Send + Sync {
+    /// Record that a hard-compaction event occurred.
+    ///
+    /// `turns_since_last` is `None` on the first hard compaction of the session.
+    fn record_hard_compaction(&self, turns_since_last: Option<u32>);
+
+    /// Record that tool outputs were pruned.
+    ///
+    /// `count` is the number of tool-output bodies pruned in this pass.
+    fn record_tool_output_prune(&self, count: usize);
+
+    /// Record a probe pass verdict with full score data.
+    fn record_compaction_probe_pass(
+        &self,
+        score: f32,
+        category_scores: Vec<zeph_memory::CategoryScore>,
+        threshold: f32,
+        hard_fail_threshold: f32,
+    );
+
+    /// Record a probe soft-fail verdict with full score data.
+    fn record_compaction_probe_soft_fail(
+        &self,
+        score: f32,
+        category_scores: Vec<zeph_memory::CategoryScore>,
+        threshold: f32,
+        hard_fail_threshold: f32,
+    );
+
+    /// Record a probe hard-fail verdict with full score data.
+    fn record_compaction_probe_hard_fail(
+        &self,
+        score: f32,
+        category_scores: Vec<zeph_memory::CategoryScore>,
+        threshold: f32,
+        hard_fail_threshold: f32,
+    );
+
+    /// Record that the probe returned an error (non-fatal; compaction proceeded).
+    fn record_compaction_probe_error(&self);
 }

--- a/crates/zeph-agent-context/src/summarization/compaction.rs
+++ b/crates/zeph-agent-context/src/summarization/compaction.rs
@@ -9,31 +9,35 @@
 //! compaction without being sent to the LLM.
 //!
 //! The caller (scheduling module) is responsible for deciding *when* to compact.
-//! This module only handles the mechanics: partition → summarize → drain → reinsert.
+//! This module handles: archive → partition → summarize → probe → drain → reinsert → persist.
 
 use zeph_context::slot::cap_summary;
 use zeph_llm::provider::{Message, MessageMetadata, Role};
 
 use crate::compaction::SubgoalState;
 use crate::error::ContextError;
-use crate::state::ContextSummarizationView;
+use crate::state::{CompactionOutcome, ContextSummarizationView, ProbeOutcome};
 
 /// Compact the context window using LLM summarization.
 ///
-/// Applies pending deferred summaries first (`CRIT-01`), then drains
-/// `messages[1..compact_end]`, summarizes the non-pinned messages via the LLM,
-/// and reinserts the summary at position 1. Focus-pinned and active-subgoal messages
-/// survive compaction and are reinserted after the summary.
+/// Pipeline:
+/// 1. Apply pending deferred summaries (`CRIT-01`).
+/// 2. Partition `messages[1..compact_end]` into pinned, active-subgoal, and to-compact.
+/// 3. Call `summ.archive` to save tool output bodies before summarization (Memex #2432).
+/// 4. Invoke the LLM via `summarize_messages`.
+/// 5. Call `summ.probe` to validate the summary quality; abort on `HardFail`.
+/// 6. Finalize: drain the range, reinsert summary + protected messages.
+/// 7. Call `summ.persistence` to persist the result; bubble the Qdrant future.
 ///
-/// Returns the number of compacted messages, or `0` when there was nothing to compact.
+/// Returns [`CompactionOutcome::NoChange`] when there is nothing to compact.
 ///
 /// # Errors
 ///
-/// Returns [`ContextError::Memory`] when the `SQLite` persist call fails.
+/// Returns [`ContextError`] if LLM summarization fails.
 pub(crate) async fn compact_context(
     summ: &mut ContextSummarizationView<'_>,
     max_summary_tokens: Option<usize>,
-) -> Result<usize, ContextError> {
+) -> Result<CompactionOutcome, ContextError> {
     use super::deferred::apply_deferred_summaries;
 
     // CRIT-01: force-apply pending deferred summaries before draining.
@@ -42,7 +46,7 @@ pub(crate) async fn compact_context(
     let preserve_tail = summ.context_manager.compaction_preserve_tail;
 
     if summ.messages.len() <= preserve_tail + 1 {
-        return Ok(0);
+        return Ok(CompactionOutcome::NoChange);
     }
 
     let compact_end = {
@@ -51,22 +55,63 @@ pub(crate) async fn compact_context(
     };
 
     if compact_end <= 1 {
-        return Ok(0);
+        return Ok(CompactionOutcome::NoChange);
     }
 
     let (pinned, active_subgoal, to_compact) = partition_messages_for_compaction(summ, compact_end);
 
     if to_compact.is_empty() {
-        return Ok(0);
+        return Ok(CompactionOutcome::NoChange);
     }
 
-    let summary = summarize_messages(summ, &to_compact, max_summary_tokens).await?;
+    // Step 3: archive tool outputs before summarization (Memex #2432).
+    // Extract the archive pointer before .await so no &summ crosses the await boundary.
+    // References are appended as a postfix AFTER the LLM call so the LLM never sees them.
+    let archived_refs: Vec<String> = if let Some(archive) = summ.archive.as_ref() {
+        archive.archive(&to_compact).await
+    } else {
+        Vec::new()
+    };
+
+    // Step 4: LLM summarization.
+    // Extract deps and guidelines from summ synchronously before .await so no reference to
+    // summ (which contains !Sync fields) is held across the await boundary.
+    let summary = {
+        let deps = summ.summarization_deps.clone();
+        let guidelines = summ
+            .compression_guidelines
+            .as_deref()
+            .unwrap_or("")
+            .to_owned();
+        summarize_messages(deps, &to_compact, guidelines, max_summary_tokens).await?
+    };
+
+    // Step 5: probe validation (optional).
+    if let Some(probe) = summ.probe.as_mut() {
+        let outcome = probe.validate(&to_compact, &summary).await;
+        if outcome == ProbeOutcome::HardFail {
+            return Ok(CompactionOutcome::ProbeRejected);
+        }
+    }
 
     let compacted_count = to_compact.len();
 
-    let summary_content =
-        format!("[conversation summary — {compacted_count} messages compacted]\n{summary}");
+    // Build archive postfix (injected after LLM summary to protect [archived:UUID] markers).
+    let archive_postfix = if archived_refs.is_empty() {
+        String::new()
+    } else {
+        let refs = archived_refs.join("\n");
+        format!("\n\n[archived tool outputs — retrievable via read_overflow]\n{refs}")
+    };
 
+    let summary_content = format!(
+        "[conversation summary — {compacted_count} messages compacted]\n{summary}{archive_postfix}"
+    );
+
+    // Step 6: finalize — drain + reinsert.
+    // CONTRACT (S3): `finalize_compacted_messages` MUST update `*summ.cached_prompt_tokens`
+    // before returning. Callers that read cached_prompt_tokens for delta computation
+    // (e.g. `do_hard_compaction`'s freed-tokens calculation) rely on this update.
     finalize_compacted_messages(
         summ,
         compact_end,
@@ -77,31 +122,21 @@ pub(crate) async fn compact_context(
         &summary,
     );
 
-    // Persist to SQLite; non-fatal — log and continue.
-    if let (Some(memory), Some(cid)) = (summ.memory.as_deref(), summ.conversation_id) {
-        let sqlite = memory.sqlite().clone();
-        let ids = sqlite
-            .oldest_message_ids(cid, u32::try_from(compacted_count + 1).unwrap_or(u32::MAX))
-            .await;
-        match ids {
-            Ok(ids) if ids.len() >= 2 => {
-                let start = ids[1];
-                let end = ids[compacted_count.min(ids.len() - 1)];
-                if let Err(e) = sqlite
-                    .replace_conversation(cid, start..=end, "system", &summary_content)
-                    .await
-                {
-                    tracing::warn!("failed to persist compaction in sqlite: {e:#}");
-                }
-            }
-            Ok(_) => {}
-            Err(e) => {
-                tracing::warn!("failed to get message ids for compaction: {e:#}");
-            }
-        }
-    }
+    // Step 7: persistence (optional).
+    // Extract pointer before .await so no &summ crosses the await boundary.
+    let (persist_failed, qdrant_future) = if let Some(persistence) = summ.persistence.as_ref() {
+        persistence
+            .after_compaction(compacted_count, &summary_content, &summary)
+            .await
+    } else {
+        (false, None)
+    };
 
-    Ok(compacted_count)
+    if persist_failed {
+        Ok(CompactionOutcome::CompactedWithPersistError { qdrant_future })
+    } else {
+        Ok(CompactionOutcome::Compacted { qdrant_future })
+    }
 }
 
 // ── Private helpers ───────────────────────────────────────────────────────────
@@ -167,6 +202,8 @@ fn partition_messages_for_compaction(
 }
 
 /// Drain the compaction range and reinsert the summary plus protected messages.
+///
+/// Updates `*summ.cached_prompt_tokens` before returning (CONTRACT S3).
 fn finalize_compacted_messages(
     summ: &mut ContextSummarizationView<'_>,
     compact_end: usize,
@@ -214,7 +251,8 @@ fn finalize_compacted_messages(
         "compacted context"
     );
 
-    // Recompute cached token count after mutation.
+    // CONTRACT (S3): update cached token count after mutation so callers computing
+    // freed-token deltas see the correct post-compaction value.
     *summ.cached_prompt_tokens = summ
         .messages
         .iter()
@@ -223,19 +261,22 @@ fn finalize_compacted_messages(
 }
 
 /// Invoke the LLM summarization path via `SummarizationDeps`.
+///
+/// Takes `deps` and `guidelines` by value (already extracted from `summ` by the caller)
+/// so no reference to `ContextSummarizationView` (which contains `!Sync` fields) is held
+/// across the `.await` boundary.
 async fn summarize_messages(
-    summ: &ContextSummarizationView<'_>,
+    deps: zeph_context::summarization::SummarizationDeps,
     messages: &[Message],
+    guidelines: String,
     max_summary_tokens: Option<usize>,
 ) -> Result<String, ContextError> {
-    let deps = &summ.summarization_deps;
-    let guidelines = String::new(); // TODO(review): load compression_guidelines via ContextSummarizationView
+    let cap = max_summary_tokens.unwrap_or(16_000).saturating_mul(4);
 
-    let raw = zeph_context::summarization::summarize_with_llm(deps, messages, &guidelines)
+    let raw = zeph_context::summarization::summarize_with_llm(&deps, messages, &guidelines)
         .await
         .map_err(|e| ContextError::Memory(zeph_memory::MemoryError::Llm(e)))?;
 
-    let cap = max_summary_tokens.unwrap_or(16_000).saturating_mul(4);
     Ok(cap_summary(raw, cap))
 }
 

--- a/crates/zeph-agent-context/src/summarization/compaction.rs
+++ b/crates/zeph-agent-context/src/summarization/compaction.rs
@@ -29,7 +29,7 @@ use crate::state::{CompactionOutcome, ContextSummarizationView, ProbeOutcome};
 /// 6. Finalize: drain the range, reinsert summary + protected messages.
 /// 7. Call `summ.persistence` to persist the result; bubble the Qdrant future.
 ///
-/// Returns [`CompactionOutcome::NoChange`] when there is nothing to compact.
+/// Returns [`CompactionOutcome`]`::NoChange` when there is nothing to compact.
 ///
 /// # Errors
 ///

--- a/crates/zeph-agent-context/src/summarization/pruning.rs
+++ b/crates/zeph-agent-context/src/summarization/pruning.rs
@@ -102,7 +102,9 @@ pub(crate) fn prune_tool_outputs_oldest_first(
     }
 
     if freed > 0 {
-        // TODO(review): metric increment (tool_output_prunes) not tracked without MetricsCallback
+        if let Some(metrics) = summ.metrics {
+            metrics.record_tool_output_prune(1);
+        }
         tracing::info!(freed, protection_boundary, "pruned tool outputs");
     }
     freed
@@ -248,7 +250,9 @@ fn evict_sorted_blocks(
     }
 
     if freed > 0 {
-        // TODO(review): metric increment (tool_output_prunes) not tracked without MetricsCallback
+        if let Some(metrics) = summ.metrics {
+            metrics.record_tool_output_prune(pruned_indices.len());
+        }
         tracing::info!(
             freed,
             pruned = pruned_indices.len(),

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -110,6 +110,12 @@ impl<C: Channel> Agent<C> {
             } else {
                 |s| std::borrow::Cow::Borrowed(s)
             },
+            // Compaction callbacks — populated by the shim before calling compact_context.
+            compression_guidelines: None,
+            probe: None,
+            archive: None,
+            persistence: None,
+            metrics: None,
         }
     }
 

--- a/crates/zeph-core/src/agent/context/mod.rs
+++ b/crates/zeph-core/src/agent/context/mod.rs
@@ -7,7 +7,9 @@ pub(crate) mod retrieved;
 mod summarization;
 
 pub(super) use crate::text::truncate_to_chars as truncate_chars;
+#[cfg(test)]
 pub(super) use zeph_agent_context::state::CompactionOutcome;
+#[cfg(test)]
 pub(super) use zeph_context::slot::cap_summary;
 #[cfg(test)]
 pub(super) use zeph_context::slot::chunk_messages;

--- a/crates/zeph-core/src/agent/context/summarization/adapters.rs
+++ b/crates/zeph-core/src/agent/context/summarization/adapters.rs
@@ -1,0 +1,433 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Adapter types that bridge `Agent<C>` internals to the callback traits declared in
+//! `zeph-agent-context`.
+//!
+//! [`CompactionAdapters`] is a bundle struct that owns all four adapters and exposes
+//! a single `populate` method so the `compact_context` shim stays at ≤10 statements.
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use zeph_agent_context::state::{
+    CompactionPersistence, CompactionProbeCallback, MetricsCallback, ProbeOutcome,
+    QdrantPersistFuture, ToolOutputArchive,
+};
+use zeph_llm::any::AnyProvider;
+use zeph_llm::provider::Message;
+use zeph_memory::{CategoryScore, CompactionProbeConfig};
+
+use crate::agent::Agent;
+use crate::channel::Channel;
+use crate::metrics::MetricsSnapshot;
+
+// ── MetricsCollectorCallback ──────────────────────────────────────────────────
+
+/// Implements [`MetricsCallback`] by delegating to the agent's `watch::Sender<MetricsSnapshot>`.
+///
+/// Constructed from a clone of `self.runtime.metrics.metrics_tx` — cheap, does not retain
+/// a borrow on `Agent<C>`.
+pub(in crate::agent) struct MetricsCollectorCallback {
+    tx: Option<tokio::sync::watch::Sender<MetricsSnapshot>>,
+}
+
+impl MetricsCollectorCallback {
+    /// Create a new callback wrapping the given metrics sender.
+    pub(in crate::agent) fn new(tx: Option<tokio::sync::watch::Sender<MetricsSnapshot>>) -> Self {
+        Self { tx }
+    }
+
+    fn update(&self, f: impl FnOnce(&mut MetricsSnapshot)) {
+        if let Some(ref tx) = self.tx {
+            tx.send_modify(f);
+        }
+    }
+}
+
+impl MetricsCallback for MetricsCollectorCallback {
+    fn record_hard_compaction(&self, turns_since_last: Option<u32>) {
+        self.update(|m| {
+            m.compaction_hard_count += 1;
+            if let Some(turns) = turns_since_last {
+                m.compaction_turns_after_hard.push(u64::from(turns));
+            }
+        });
+    }
+
+    fn record_tool_output_prune(&self, count: usize) {
+        self.update(|m| {
+            m.tool_output_prunes = m.tool_output_prunes.saturating_add(count as u64);
+        });
+    }
+
+    fn record_compaction_probe_pass(
+        &self,
+        score: f32,
+        category_scores: Vec<CategoryScore>,
+        threshold: f32,
+        hard_fail_threshold: f32,
+    ) {
+        self.update(|m| {
+            m.compaction_probe_passes += 1;
+            m.last_probe_verdict = Some(zeph_memory::ProbeVerdict::Pass);
+            m.last_probe_score = Some(score);
+            m.last_probe_category_scores = Some(category_scores);
+            m.compaction_probe_threshold = threshold;
+            m.compaction_probe_hard_fail_threshold = hard_fail_threshold;
+        });
+    }
+
+    fn record_compaction_probe_soft_fail(
+        &self,
+        score: f32,
+        category_scores: Vec<CategoryScore>,
+        threshold: f32,
+        hard_fail_threshold: f32,
+    ) {
+        self.update(|m| {
+            m.compaction_probe_soft_failures += 1;
+            m.last_probe_verdict = Some(zeph_memory::ProbeVerdict::SoftFail);
+            m.last_probe_score = Some(score);
+            m.last_probe_category_scores = Some(category_scores);
+            m.compaction_probe_threshold = threshold;
+            m.compaction_probe_hard_fail_threshold = hard_fail_threshold;
+        });
+    }
+
+    fn record_compaction_probe_hard_fail(
+        &self,
+        score: f32,
+        category_scores: Vec<CategoryScore>,
+        threshold: f32,
+        hard_fail_threshold: f32,
+    ) {
+        self.update(|m| {
+            m.compaction_probe_failures += 1;
+            m.last_probe_verdict = Some(zeph_memory::ProbeVerdict::HardFail);
+            m.last_probe_score = Some(score);
+            m.last_probe_category_scores = Some(category_scores);
+            m.compaction_probe_threshold = threshold;
+            m.compaction_probe_hard_fail_threshold = hard_fail_threshold;
+        });
+    }
+
+    fn record_compaction_probe_error(&self) {
+        self.update(|m| {
+            m.compaction_probe_errors += 1;
+            m.last_probe_verdict = Some(zeph_memory::ProbeVerdict::Error);
+            m.last_probe_score = None;
+            m.last_probe_category_scores = None;
+        });
+    }
+}
+
+// ── AgentProbe ────────────────────────────────────────────────────────────────
+
+/// Implements [`CompactionProbeCallback`] using `zeph_memory::validate_compaction`.
+///
+/// Owns cloned `Arc`s so it does not retain a borrow on `Agent<C>` after construction.
+/// Per the probe contract: calls `dump_compaction_probe`, updates all four metric counters,
+/// and returns only the routing verdict.
+pub(in crate::agent) struct AgentProbe {
+    probe_cfg: CompactionProbeConfig,
+    probe_provider: AnyProvider,
+    metrics: MetricsCollectorCallback,
+    debug_dumper: Option<crate::debug_dump::DebugDumper>,
+}
+
+impl AgentProbe {
+    /// Construct from cloned values extracted from `Agent<C>`.
+    pub(in crate::agent) fn new<C: Channel>(agent: &Agent<C>) -> Self {
+        let probe_cfg = agent.context_manager.compression.probe.clone();
+        let probe_provider = agent.probe_or_summary_provider().clone();
+        let metrics = MetricsCollectorCallback::new(agent.runtime.metrics.metrics_tx.clone());
+        let debug_dumper = agent.runtime.debug.debug_dumper.clone();
+        Self {
+            probe_cfg,
+            probe_provider,
+            metrics,
+            debug_dumper,
+        }
+    }
+}
+
+impl CompactionProbeCallback for AgentProbe {
+    fn validate<'a>(
+        &'a mut self,
+        to_compact: &'a [Message],
+        summary: &'a str,
+    ) -> Pin<Box<dyn std::future::Future<Output = ProbeOutcome> + Send + 'a>> {
+        Box::pin(async move {
+            if !self.probe_cfg.enabled {
+                return ProbeOutcome::Pass;
+            }
+
+            let result = zeph_memory::validate_compaction(
+                self.probe_provider.clone(),
+                to_compact.to_vec(),
+                summary.to_owned(),
+                &self.probe_cfg,
+            )
+            .await;
+
+            match result {
+                Err(e) => {
+                    tracing::warn!("compaction probe error (non-blocking): {e:#}");
+                    self.metrics.record_compaction_probe_error();
+                    ProbeOutcome::Pass
+                }
+                Ok(None) => ProbeOutcome::Pass,
+                Ok(Some(ref probe_result)) => {
+                    if let Some(ref dumper) = self.debug_dumper {
+                        dumper.dump_compaction_probe(probe_result);
+                    }
+
+                    let score = probe_result.score;
+                    let cats = probe_result.category_scores.clone();
+                    let threshold = probe_result.threshold;
+                    let hard_fail = probe_result.hard_fail_threshold;
+
+                    match probe_result.verdict {
+                        zeph_memory::ProbeVerdict::Pass => {
+                            tracing::info!(score, "compaction probe passed");
+                            self.metrics
+                                .record_compaction_probe_pass(score, cats, threshold, hard_fail);
+                            ProbeOutcome::Pass
+                        }
+                        zeph_memory::ProbeVerdict::SoftFail => {
+                            tracing::warn!(
+                                score,
+                                threshold,
+                                "compaction probe SOFT FAIL — proceeding with warning"
+                            );
+                            self.metrics.record_compaction_probe_soft_fail(
+                                score, cats, threshold, hard_fail,
+                            );
+                            ProbeOutcome::SoftFail
+                        }
+                        zeph_memory::ProbeVerdict::HardFail => {
+                            tracing::warn!(
+                                score,
+                                threshold = hard_fail,
+                                "compaction probe HARD FAIL — keeping original messages"
+                            );
+                            self.metrics.record_compaction_probe_hard_fail(
+                                score, cats, threshold, hard_fail,
+                            );
+                            ProbeOutcome::HardFail
+                        }
+                        zeph_memory::ProbeVerdict::Error => {
+                            // validate_compaction returns Err on errors, not Ok(Error).
+                            debug_assert!(false, "ProbeVerdict::Error reached inside Ok path");
+                            self.metrics.record_compaction_probe_error();
+                            ProbeOutcome::Pass
+                        }
+                    }
+                }
+            }
+        })
+    }
+}
+
+// ── AgentArchive ──────────────────────────────────────────────────────────────
+
+/// Implements [`ToolOutputArchive`] using the agent's `SQLite` memory store (Memex #2432).
+///
+/// Saves non-empty, non-archived tool output bodies to `tool_overflow` and returns
+/// reference strings for injection as a postfix after LLM summarization.
+pub(in crate::agent) struct AgentArchive {
+    archive_enabled: bool,
+    memory: Option<Arc<zeph_memory::semantic::SemanticMemory>>,
+    conversation_id: Option<zeph_memory::ConversationId>,
+}
+
+impl AgentArchive {
+    /// Construct from values extracted from `Agent<C>`.
+    pub(in crate::agent) fn new<C: Channel>(agent: &Agent<C>) -> Self {
+        Self {
+            archive_enabled: agent.context_manager.compression.archive_tool_outputs,
+            memory: agent.services.memory.persistence.memory.clone(),
+            conversation_id: agent.services.memory.persistence.conversation_id,
+        }
+    }
+}
+
+impl ToolOutputArchive for AgentArchive {
+    fn archive<'a>(
+        &'a self,
+        to_compact: &'a [Message],
+    ) -> Pin<Box<dyn std::future::Future<Output = Vec<String>> + Send + 'a>> {
+        Box::pin(async move {
+            if !self.archive_enabled {
+                return Vec::new();
+            }
+            let (Some(memory), Some(cid)) = (&self.memory, self.conversation_id) else {
+                return Vec::new();
+            };
+
+            let mut refs = Vec::new();
+            let sqlite = memory.sqlite().clone();
+
+            for msg in to_compact {
+                for part in &msg.parts {
+                    if let zeph_llm::provider::MessagePart::ToolOutput {
+                        body, tool_name, ..
+                    } = part
+                    {
+                        if body.is_empty()
+                            || body.starts_with("[archived:")
+                            || body.starts_with("[full output stored")
+                            || body.starts_with("[tool output pruned")
+                        {
+                            continue;
+                        }
+                        match sqlite.save_archive(cid.0, body.as_bytes()).await {
+                            Ok(uuid) => {
+                                let bytes = body.len();
+                                refs.push(format!(
+                                    "[archived:{uuid} — tool: {tool_name} — {bytes} bytes]"
+                                ));
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    error = %e,
+                                    "Memex: failed to archive tool output (non-fatal)"
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+
+            if !refs.is_empty() {
+                tracing::debug!(
+                    archived = refs.len(),
+                    "Memex: archived tool outputs before compaction"
+                );
+            }
+            refs
+        })
+    }
+}
+
+// ── AgentPersistence ──────────────────────────────────────────────────────────
+
+/// Implements [`CompactionPersistence`] by persisting to `SQLite` synchronously and
+/// returning a `'static` Qdrant future for off-thread dispatch.
+///
+/// The `SQLite` path runs inline (it is fast and failure is non-fatal).
+/// The Qdrant path is returned as a boxed future to be dispatched through
+/// `BackgroundSupervisor::spawn_summarization`.
+pub(in crate::agent) struct AgentPersistence {
+    memory: Option<Arc<zeph_memory::semantic::SemanticMemory>>,
+    conversation_id: Option<zeph_memory::ConversationId>,
+}
+
+impl AgentPersistence {
+    /// Construct from values extracted from `Agent<C>`.
+    pub(in crate::agent) fn new<C: Channel>(agent: &Agent<C>) -> Self {
+        Self {
+            memory: agent.services.memory.persistence.memory.clone(),
+            conversation_id: agent.services.memory.persistence.conversation_id,
+        }
+    }
+}
+
+impl CompactionPersistence for AgentPersistence {
+    fn after_compaction<'a>(
+        &'a self,
+        compacted_count: usize,
+        summary_content: &'a str,
+        summary: &'a str,
+    ) -> Pin<Box<dyn std::future::Future<Output = (bool, Option<QdrantPersistFuture>)> + Send + 'a>>
+    {
+        Box::pin(async move {
+            let (Some(memory), Some(cid)) = (&self.memory, self.conversation_id) else {
+                return (false, None);
+            };
+
+            // Synchronous SQLite persist — clone DbStore so no &SemanticMemory survives .await.
+            let sqlite = memory.sqlite().clone();
+            let ids = sqlite
+                .oldest_message_ids(cid, u32::try_from(compacted_count + 1).unwrap_or(u32::MAX))
+                .await;
+            let sqlite_failed = match ids {
+                Ok(ids) if ids.len() >= 2 => {
+                    let start = ids[1];
+                    let end = ids[compacted_count.min(ids.len() - 1)];
+                    if let Err(e) = sqlite
+                        .replace_conversation(cid, start..=end, "system", summary_content)
+                        .await
+                    {
+                        tracing::warn!("failed to persist compaction in sqlite: {e:#}");
+                        true
+                    } else {
+                        false
+                    }
+                }
+                Ok(_) => false,
+                Err(e) => {
+                    tracing::warn!("failed to get message ids for compaction: {e:#}");
+                    true
+                }
+            };
+
+            // Build the Qdrant future as a 'static boxed future (clone Arc, own String).
+            let memory_arc = Arc::clone(memory);
+            let summary_owned = summary.to_owned();
+            let qdrant_fut: QdrantPersistFuture = Box::pin(async move {
+                if let Err(e) = memory_arc.store_session_summary(cid, &summary_owned).await {
+                    tracing::warn!("failed to store session summary: {e:#}");
+                }
+                false
+            });
+
+            (sqlite_failed, Some(qdrant_fut))
+        })
+    }
+}
+
+// ── CompactionAdapters bundle ─────────────────────────────────────────────────
+
+/// Bundle of all four compaction adapters for `Agent<C>`.
+///
+/// Constructed once from `&mut Agent<C>` in the `compact_context` shim, then wired
+/// into the [`zeph_agent_context::state::ContextSummarizationView`] via [`Self::populate`].
+/// This collapses four separate adapter constructions into one shim statement.
+pub(in crate::agent) struct CompactionAdapters {
+    probe: AgentProbe,
+    archive: AgentArchive,
+    persistence: AgentPersistence,
+    metrics: MetricsCollectorCallback,
+}
+
+impl CompactionAdapters {
+    /// Build all four adapters from the agent. Only reads fields — does not retain a borrow.
+    pub(in crate::agent) fn new<C: Channel>(agent: &Agent<C>) -> Self {
+        let probe = AgentProbe::new(agent);
+        let archive = AgentArchive::new(agent);
+        let persistence = AgentPersistence::new(agent);
+        let metrics = MetricsCollectorCallback::new(agent.runtime.metrics.metrics_tx.clone());
+        Self {
+            probe,
+            archive,
+            persistence,
+            metrics,
+        }
+    }
+
+    /// Wire all four adapters into `summ` in a single call.
+    ///
+    /// The shim calls this immediately after `summarization_view()` and
+    /// `with_compression_guidelines`.
+    pub(in crate::agent) fn populate<'a>(
+        &'a mut self,
+        summ: &mut zeph_agent_context::state::ContextSummarizationView<'a>,
+    ) {
+        summ.probe = Some(&mut self.probe);
+        summ.archive = Some(&self.archive);
+        summ.persistence = Some(&self.persistence);
+        summ.metrics = Some(&self.metrics);
+    }
+}

--- a/crates/zeph-core/src/agent/context/summarization/compaction.rs
+++ b/crates/zeph-core/src/agent/context/summarization/compaction.rs
@@ -1,433 +1,59 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::ops::ControlFlow;
-
-use zeph_llm::provider::{Message, MessageMetadata, Role};
+use zeph_agent_context::state::CompactionOutcome;
 
 use crate::agent::Agent;
-use crate::agent::context::CompactionOutcome;
 use crate::channel::Channel;
 
-/// Partitioned message slices produced by [`Agent::partition_messages_for_compaction`].
-struct CompactionPartition {
-    /// Focus-pinned knowledge block messages that survive compaction.
-    pinned_messages: Vec<Message>,
-    /// Active-subgoal messages protected from summarization (only populated when a subgoal
-    /// strategy is active).
-    active_subgoal_messages: Vec<Message>,
-    /// Messages to be summarized by the LLM.
-    to_compact: Vec<Message>,
-}
-
 impl<C: Channel> Agent<C> {
-    /// Partition the compaction range into pinned, active-subgoal, and to-compact slices.
+    /// Compact the context window using LLM summarization.
     ///
-    /// Extracts `messages[1..compact_end]` into three disjoint sets so that focus-pinned
-    /// and active-subgoal messages survive compaction without being fed to the LLM.
-    fn partition_messages_for_compaction(&self, compact_end: usize) -> CompactionPartition {
-        // S1 fix: extract focus-pinned messages before draining so they survive compaction.
-        // These are Knowledge block messages created by the Focus Agent (#1850).
-        let pinned_messages: Vec<Message> = self.msg.messages[1..compact_end]
-            .iter()
-            .filter(|m| m.metadata.focus_pinned)
-            .cloned()
-            .collect();
-
-        // S2 fix (#2022): extract active-subgoal messages before draining so they survive
-        // compaction. Mirrors the focus_pinned pattern exactly. Only applies when a subgoal
-        // strategy is active and the registry has tagged active messages.
-        let active_subgoal_messages: Vec<Message> = if self
-            .context_manager
-            .compression
-            .pruning_strategy
-            .is_subgoal()
-        {
-            use zeph_agent_context::SubgoalState;
-            self.msg.messages[1..compact_end]
-                .iter()
-                .enumerate()
-                .filter(|(slice_i, m)| {
-                    // slice_i is 0-based within [1..compact_end]; actual index = slice_i + 1.
-                    let actual_i = slice_i + 1;
-                    !m.metadata.focus_pinned
-                        && matches!(
-                            self.services
-                                .compression
-                                .subgoal_registry
-                                .subgoal_state(actual_i),
-                            Some(SubgoalState::Active)
-                        )
-                })
-                .map(|(_, m)| m.clone())
-                .collect()
-        } else {
-            vec![]
-        };
-
-        // Summarize only the non-pinned, non-active-subgoal messages in the compaction range.
-        let to_compact: Vec<Message> = {
-            let is_subgoal = self
-                .context_manager
-                .compression
-                .pruning_strategy
-                .is_subgoal();
-
-            if is_subgoal {
-                use zeph_agent_context::SubgoalState;
-                self.msg.messages[1..compact_end]
-                    .iter()
-                    .enumerate()
-                    .filter(|(slice_i, m)| {
-                        let actual_i = slice_i + 1;
-                        !m.metadata.focus_pinned
-                            && !matches!(
-                                self.services
-                                    .compression
-                                    .subgoal_registry
-                                    .subgoal_state(actual_i),
-                                Some(SubgoalState::Active)
-                            )
-                    })
-                    .map(|(_, m)| m.clone())
-                    .collect()
-            } else {
-                self.msg.messages[1..compact_end]
-                    .iter()
-                    .filter(|m| !m.metadata.focus_pinned)
-                    .cloned()
-                    .collect()
-            }
-        };
-
-        CompactionPartition {
-            pinned_messages,
-            active_subgoal_messages,
-            to_compact,
-        }
-    }
-
-    /// Validate summary quality via the compaction probe before committing the summary.
+    /// Thin shim that wires the four `Agent<C>`-specific adapters (probe, archive,
+    /// persistence, metrics) into a [`ContextSummarizationView`] and delegates all
+    /// structural logic to [`zeph_agent_context::ContextService::compact_context`].
     ///
-    /// All four probe metric counters (`compaction_probe_failures`, `compaction_probe_soft_failures`,
-    /// `compaction_probe_passes`, `compaction_probe_errors`) and `last_probe_*` state are updated
-    /// exclusively inside this helper. The caller MUST NOT duplicate any metric increment
-    /// (cross-cutting constraint #6).
+    /// The optional Qdrant session-summary future returned by the service is dispatched
+    /// through `BackgroundSupervisor::spawn_summarization` so the `JoinHandle` is tracked
+    /// and bounded per Await Discipline rule 2.
     ///
-    /// Returns:
-    /// - `Ok(ControlFlow::Break(CompactionOutcome::ProbeRejected))` — hard fail; caller should
-    ///   return the rejected outcome immediately.
-    /// - `Ok(ControlFlow::Continue(()))` — probe passed (or was disabled); caller may proceed.
-    async fn apply_compaction_probe(
-        &mut self,
-        to_compact: &[Message],
-        summary: &str,
-    ) -> Result<ControlFlow<CompactionOutcome, ()>, crate::agent::error::AgentError> {
-        if !self.context_manager.compression.probe.enabled {
-            return Ok(ControlFlow::Continue(()));
-        }
-
-        let probe_config = self.context_manager.compression.probe.clone();
-        let probe_provider = self.probe_or_summary_provider().clone();
-        let probe_result = match zeph_memory::validate_compaction(
-            probe_provider,
-            to_compact.to_vec(),
-            summary.to_owned(),
-            &probe_config,
-        )
-        .await
-        {
-            Ok(result) => result,
-            Err(e) => {
-                tracing::warn!("compaction probe error (non-blocking): {e:#}");
-                self.update_metrics(|m| {
-                    m.compaction_probe_errors += 1;
-                    m.last_probe_verdict = Some(zeph_memory::ProbeVerdict::Error);
-                    m.last_probe_score = None;
-                    m.last_probe_category_scores = None;
-                });
-                return Ok(ControlFlow::Continue(()));
-            }
-        };
-
-        if let Some(ref result) = probe_result {
-            if let Some(ref d) = self.runtime.debug.debug_dumper {
-                d.dump_compaction_probe(result);
-            }
-
-            let cat_scores = result.category_scores.clone();
-            let probe_threshold = result.threshold;
-            let probe_hard_fail_threshold = result.hard_fail_threshold;
-            match result.verdict {
-                zeph_memory::ProbeVerdict::HardFail => {
-                    tracing::warn!(
-                        score = result.score,
-                        threshold = result.hard_fail_threshold,
-                        "compaction probe HARD FAIL — keeping original messages"
-                    );
-                    self.update_metrics(|m| {
-                        m.compaction_probe_failures += 1;
-                        m.last_probe_verdict = Some(zeph_memory::ProbeVerdict::HardFail);
-                        m.last_probe_score = Some(result.score);
-                        m.last_probe_category_scores = Some(cat_scores.clone());
-                        m.compaction_probe_threshold = probe_threshold;
-                        m.compaction_probe_hard_fail_threshold = probe_hard_fail_threshold;
-                    });
-                    return Ok(ControlFlow::Break(CompactionOutcome::ProbeRejected));
-                }
-                zeph_memory::ProbeVerdict::SoftFail => {
-                    tracing::warn!(
-                        score = result.score,
-                        threshold = result.threshold,
-                        "compaction probe SOFT FAIL — proceeding with warning"
-                    );
-                    self.update_metrics(|m| {
-                        m.compaction_probe_soft_failures += 1;
-                        m.last_probe_verdict = Some(zeph_memory::ProbeVerdict::SoftFail);
-                        m.last_probe_score = Some(result.score);
-                        m.last_probe_category_scores = Some(cat_scores.clone());
-                        m.compaction_probe_threshold = probe_threshold;
-                        m.compaction_probe_hard_fail_threshold = probe_hard_fail_threshold;
-                    });
-                }
-                zeph_memory::ProbeVerdict::Pass => {
-                    tracing::info!(score = result.score, "compaction probe passed");
-                    self.update_metrics(|m| {
-                        m.compaction_probe_passes += 1;
-                        m.last_probe_verdict = Some(zeph_memory::ProbeVerdict::Pass);
-                        m.last_probe_score = Some(result.score);
-                        m.last_probe_category_scores = Some(cat_scores.clone());
-                        m.compaction_probe_threshold = probe_threshold;
-                        m.compaction_probe_hard_fail_threshold = probe_hard_fail_threshold;
-                    });
-                }
-                zeph_memory::ProbeVerdict::Error => {
-                    // Unreachable: validate_compaction returns Err on errors, not Ok(Error).
-                    // If this fires, the error-handling path in validate_compaction changed.
-                    debug_assert!(false, "ProbeVerdict::Error reached inside Ok path");
-                }
-            }
-        }
-
-        Ok(ControlFlow::Continue(()))
-    }
-
-    /// Drain the compaction range and re-insert the summary plus protected messages.
+    /// # Errors
     ///
-    /// Drains `messages[1..compact_end]`, inserts the summary at position 1, then
-    /// re-inserts pinned knowledge blocks and active-subgoal messages after the summary.
-    /// Rebuilds the subgoal index map when a subgoal strategy is active (S1 fix #2022).
+    /// Returns [`AgentError`] if LLM summarization fails.
     ///
-    /// `summary` is the raw LLM output (without the header prefix) used for token-count
-    /// logging. `summary_content` is the fully formatted message text inserted into the
-    /// message list.
-    fn finalize_compacted_messages(
-        &mut self,
-        compact_end: usize,
-        pinned: Vec<Message>,
-        active_subgoal: Vec<Message>,
-        summary_content: String,
-        compacted_count: usize,
-        summary: &str,
-    ) {
-        // Drain the original range (includes pinned, active-subgoal, and non-pinned messages).
-        self.msg.messages.drain(1..compact_end);
-        // Insert the compaction summary at position 1.
-        self.msg.messages.insert(
-            1,
-            Message {
-                role: Role::System,
-                content: summary_content,
-                parts: vec![],
-                metadata: MessageMetadata::agent_only(),
-            },
-        );
-        // Re-insert pinned messages right after the summary (position 2+).
-        // They are placed before the preserved tail so the LLM always sees them.
-        let pinned_count = pinned.len();
-        for (i, pinned_msg) in pinned.into_iter().enumerate() {
-            self.msg.messages.insert(2 + i, pinned_msg);
-        }
-        // Re-insert active-subgoal messages after pinned messages (#2022 S2 fix).
-        // Active-subgoal messages are protected from summarization — they carry the current
-        // working context and must not be lost during compaction.
-        for (i, active_msg) in active_subgoal.into_iter().enumerate() {
-            self.msg.messages.insert(2 + pinned_count + i, active_msg);
-        }
-
-        // S1 fix (#2022): rebuild subgoal index map from scratch after drain + reinsert.
-        // Arithmetic offset is fragile because the final positions depend on pinned_count
-        // and active_subgoal_count. Rebuild is O(subgoals * avg_span) — negligible.
-        if self
-            .context_manager
-            .compression
-            .pruning_strategy
-            .is_subgoal()
-        {
-            self.services
-                .compression
-                .subgoal_registry
-                .rebuild_after_compaction(&self.msg.messages, compact_end);
-        }
-
-        tracing::info!(
-            compacted_count,
-            summary_tokens = self.runtime.metrics.token_counter.count_tokens(summary),
-            "compacted context"
-        );
-
-        self.recompute_prompt_tokens();
-        self.update_metrics(|m| {
-            m.context_compactions += 1;
-        });
-    }
-
-    // TODO(review): This method cannot be simply delegated to ContextService::compact_context
-    // because the service version handles only structural compaction (partition → summarize →
-    // drain → reinsert + SQLite persist). The Agent<C> version adds:
-    //   - Probe validation (apply_compaction_probe) — probe tests rely on this
-    //   - Compression guidelines loading
-    //   - Tool output archiving before summarization (archive_tool_outputs)
-    //   - Qdrant session-summary write via BackgroundSupervisor
-    //   - Emit compaction status signal
-    //   - CompactionOutcome return type (service returns usize)
-    // Delegating would break probe tests and lose Qdrant/archive functionality.
-    // To wire this properly, ContextSummarizationView would need probe config, archive
-    // state, and a Qdrant write callback. Suggested action: extend the view and service
-    // in a follow-up PR, then replace this body with a service delegation.
+    /// [`ContextSummarizationView`]: zeph_agent_context::state::ContextSummarizationView
+    /// [`AgentError`]: crate::agent::error::AgentError
     pub(in crate::agent) async fn compact_context(
         &mut self,
     ) -> Result<CompactionOutcome, crate::agent::error::AgentError> {
-        // Force-apply any pending deferred summaries before draining to avoid losing them (CRIT-01).
-        let _ = self.apply_deferred_summaries();
+        let guidelines = self.load_compression_guidelines_for_compact().await; // 1
+        let mut adapters = super::adapters::CompactionAdapters::new(self); // 2
+        let tokens_before = self.runtime.providers.cached_prompt_tokens; // 3
 
-        let preserve_tail = self.context_manager.compaction_preserve_tail;
+        let mut summ = self
+            .summarization_view()
+            .with_compression_guidelines(guidelines); // 4
+        adapters.populate(&mut summ); // 5
 
-        if self.msg.messages.len() <= preserve_tail + 1 {
-            return Ok(CompactionOutcome::NoChange);
-        }
-
-        let compact_end = {
-            let raw = self.msg.messages.len() - preserve_tail;
-            Self::adjust_compact_end_for_tool_pairs(&self.msg.messages, raw)
-        };
-
-        if compact_end <= 1 {
-            return Ok(CompactionOutcome::NoChange);
-        }
-
-        let CompactionPartition {
-            pinned_messages,
-            active_subgoal_messages,
-            to_compact,
-        } = self.partition_messages_for_compaction(compact_end);
-
-        if to_compact.is_empty() {
-            return Ok(CompactionOutcome::NoChange);
-        }
-
-        // Load compression guidelines if configured.
-        // Extract all params from &self before .await so no &self is held across await.
-        let guidelines = {
-            let enabled = self
-                .services
-                .memory
-                .compaction
-                .compression_guidelines_config
-                .enabled;
-            let memory = self.services.memory.persistence.memory.clone();
-            let conv_id = self.services.memory.persistence.conversation_id;
-            Self::load_compression_guidelines(enabled, memory, conv_id).await
-        };
-
-        // Memex: archive tool output bodies before compaction (#2432).
-        //
-        // Archives are saved BEFORE summarization, but references are injected AFTER
-        // summarization as a postfix (fix C1: LLM would destroy [archived:UUID] markers).
-        // The LLM summarizes the original messages without placeholders.
-        //
-        // Invariant: save_archive() is called before the placeholder is created;
-        // the placeholder is only inserted into the postfix, not into `to_compact`.
-        // Extract all params from &self before .await so no &self is held across await.
-        let archived_refs: Vec<String> = {
-            let archive_enabled = self.context_manager.compression.archive_tool_outputs;
-            let memory = self.services.memory.persistence.memory.clone();
-            let cid = self.services.memory.persistence.conversation_id;
-            Self::archive_tool_outputs(archive_enabled, memory, cid, to_compact.clone()).await
-        };
-
-        // Extract deps before .await so &self is not held across the await boundary.
-        let summary = {
-            let deps = self.build_summarization_deps();
-            let structured = self.services.memory.compaction.structured_summaries;
-            Self::summarize_messages_with_deps(
-                deps,
-                structured,
-                to_compact.clone(),
-                guidelines.clone(),
-            )
-            .await?
-        };
-
-        // Compaction probe: validate summary quality before committing it.
-        // All metric updates live exclusively inside apply_compaction_probe.
-        if let ControlFlow::Break(outcome) =
-            self.apply_compaction_probe(&to_compact, &summary).await?
-        {
-            return Ok(outcome);
-        }
-
-        let compacted_count = to_compact.len();
-        let tokens_before = self.runtime.providers.cached_prompt_tokens;
-        // Inject archived references as a postfix AFTER the LLM summary (fix C1).
-        // The LLM summary is unaware of archives; the postfix ensures references survive.
-        let archive_postfix = if archived_refs.is_empty() {
-            String::new()
-        } else {
-            let refs = archived_refs.join("\n");
-            format!("\n\n[archived tool outputs — retrievable via read_overflow]\n{refs}")
-        };
-        let summary_content = format!(
-            "[conversation summary — {compacted_count} messages compacted]\n{summary}{archive_postfix}"
-        );
-
-        self.finalize_compacted_messages(
-            compact_end,
-            pinned_messages,
-            active_subgoal_messages,
-            summary_content.clone(),
-            compacted_count,
-            &summary,
-        );
-
-        self.emit_compaction_status_signal(tokens_before).await;
-
-        // Extract memory params before .await so no &self is held across the persist boundary.
-        let (persist_failed, qdrant_fut) = {
-            let memory = self.services.memory.persistence.memory.clone();
-            let cid = self.services.memory.persistence.conversation_id;
-            Self::persist_compaction_result(
-                memory,
-                cid,
-                compacted_count,
-                summary_content.clone(),
-                summary.clone(),
-            )
+        let svc = zeph_agent_context::ContextService::new();
+        let mut outcome = svc
+            .compact_context(&mut summ, None)
             .await
-        };
-        // Dispatch Qdrant session-summary write through the supervisor so the JoinHandle
-        // is tracked, bounded, and abortable at turn boundaries (Await Discipline rule 2).
-        if let Some(fut) = qdrant_fut {
+            .map_err(|e| crate::agent::error::AgentError::ContextError(format!("{e:#}")))?; // 6
+
+        if outcome.is_compacted() {
+            self.update_metrics(|m| m.context_compactions += 1); // 7
+        }
+
+        if let Some(fut) = outcome.qdrant_future_take() {
             self.runtime
                 .lifecycle
                 .supervisor
-                .spawn_summarization("persist-session-summary", fut);
+                .spawn_summarization("persist-session-summary", fut); // 8+9
         }
-        Ok(if persist_failed {
-            CompactionOutcome::CompactedWithPersistError
-        } else {
-            CompactionOutcome::Compacted
-        })
+
+        self.emit_compaction_status_signal(tokens_before).await; // 10
+        Ok(outcome) // 11
     }
 
     /// Compact context and return a user-visible status string.
@@ -446,10 +72,10 @@ impl<C: Channel> Agent<C> {
             .await
             .map_err(|e| zeph_commands::CommandError::new(e.to_string()))?
         {
-            CompactionOutcome::Compacted | CompactionOutcome::NoChange => {
+            CompactionOutcome::Compacted { .. } | CompactionOutcome::NoChange => {
                 Ok("Context compacted successfully.".to_owned())
             }
-            CompactionOutcome::CompactedWithPersistError => {
+            CompactionOutcome::CompactedWithPersistError { .. } => {
                 Ok("Context compacted, but persistence to storage failed (see logs).".to_owned())
             }
             CompactionOutcome::ProbeRejected => {
@@ -460,79 +86,22 @@ impl<C: Channel> Agent<C> {
         }
     }
 
-    /// Persist a completed compaction to `SQLite`.
+    /// Load compression guidelines, returning `None` when the feature is disabled.
     ///
-    /// Returns `true` when `SQLite` persistence failed (caller should set `CompactedWithPersistError`).
-    /// Also returns an optional future for the Qdrant session-summary write; the caller is
-    /// responsible for dispatching it through [`BackgroundSupervisor::spawn_summarization`]
-    /// so the `JoinHandle` is tracked and bounded per Await Discipline rule 2.
-    ///
-    /// All parameters are taken by value so the caller does not hold `&self` across any `.await`,
-    /// keeping the enclosing future `Send`. `DbStore: Clone` — cloning is synchronous so no
-    /// `&SemanticMemory` survives the clone call into any `.await` point.
-    async fn persist_compaction_result(
-        memory: Option<std::sync::Arc<zeph_memory::semantic::SemanticMemory>>,
-        cid: Option<zeph_memory::ConversationId>,
-        compacted_count: usize,
-        summary_content: String,
-        summary: String,
-    ) -> (
-        bool,
-        Option<std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send + 'static>>>,
-    ) {
-        let (Some(memory), Some(cid)) = (memory, cid) else {
-            return (false, None);
-        };
-        // Persist compaction: mark originals as user_only, insert summary as agent_only.
-        // Assumption: the system prompt is always the first (oldest) row for this conversation
-        // in SQLite — i.e., ids[0] corresponds to self.msg.messages[0] (the system prompt).
-        // This holds for normal sessions but may not hold after cross-session restore if a
-        // non-system message was persisted first. MVP assumption; document if changed.
-        // oldest_message_ids returns ascending order; ids[1..=compacted_count] are the messages
-        // that were drained from self.msg.messages[1..compact_end].
-        //
-        // Clone DbStore before any .await so no &SemanticMemory is held across await points.
-        // SemanticMemory contains AnyProvider which is !Sync, so &SemanticMemory is !Send.
-        // DbStore: Clone — cloning is synchronous, no borrow of memory survives .await.
-        let sqlite = memory.sqlite().clone();
-        let ids = sqlite
-            .oldest_message_ids(cid, u32::try_from(compacted_count + 1).unwrap_or(u32::MAX))
-            .await;
-        let sqlite_failed = match ids {
-            Ok(ids) if ids.len() >= 2 => {
-                let start = ids[1];
-                let end = ids[compacted_count.min(ids.len() - 1)];
-                if let Err(e) = sqlite
-                    .replace_conversation(cid, start..=end, "system", &summary_content)
-                    .await
-                {
-                    tracing::warn!("failed to persist compaction in sqlite: {e:#}");
-                    true
-                } else {
-                    false
-                }
-            }
-            Ok(_) => false,
-            Err(e) => {
-                tracing::warn!("failed to get message ids for compaction: {e:#}");
-                true
-            }
-        };
-
-        // Return the Qdrant write as a future so the caller can dispatch it through
-        // BackgroundSupervisor::spawn_summarization — tracked, bounded, abort-on-turn-boundary.
-        // store_session_summary takes &self — the Arc clone here ensures 'static lifetime
-        // without holding &SemanticMemory across the await inside the future.
-        let qdrant_fut: std::pin::Pin<
-            Box<dyn std::future::Future<Output = bool> + Send + 'static>,
-        > = Box::pin(async move {
-            if let Err(e) = memory.store_session_summary(cid, &summary).await {
-                tracing::warn!("failed to store session summary: {e:#}");
-            }
-            false
-        });
-
-        (sqlite_failed, Some(qdrant_fut))
+    /// Extracts all fields from `&self` synchronously before the first `.await` so
+    /// `&self` is not held across the await boundary (required for `Send` futures).
+    async fn load_compression_guidelines_for_compact(&mut self) -> Option<String> {
+        let enabled = self
+            .services
+            .memory
+            .compaction
+            .compression_guidelines_config
+            .enabled;
+        let memory = self.services.memory.persistence.memory.clone();
+        let conv_id = self.services.memory.persistence.conversation_id;
+        // Drop the borrow on &self before awaiting.
+        let text = Self::load_compression_guidelines(enabled, memory, conv_id).await;
+        if text.is_empty() { None } else { Some(text) }
     }
 }
 

--- a/crates/zeph-core/src/agent/context/summarization/deferred.rs
+++ b/crates/zeph-core/src/agent/context/summarization/deferred.rs
@@ -15,6 +15,7 @@ impl<C: Channel> Agent<C> {
     /// Batch-apply all pending deferred tool pair summaries.
     ///
     /// Returns the number of summaries applied.
+    #[allow(dead_code)]
     pub(in crate::agent) fn apply_deferred_summaries(&mut self) -> usize {
         let svc = zeph_agent_context::ContextService::new();
         let mut summ = self.summarization_view();

--- a/crates/zeph-core/src/agent/context/summarization/mod.rs
+++ b/crates/zeph-core/src/agent/context/summarization/mod.rs
@@ -3,6 +3,7 @@
 
 use std::sync::Arc;
 
+#[cfg(test)]
 use zeph_llm::provider::{Message, MessagePart, Role};
 use zeph_memory::AnchoredSummary;
 
@@ -35,113 +36,6 @@ impl<C: Channel> Agent<C> {
         }
     }
 
-    async fn try_summarize_structured_with_deps(
-        deps: SummarizationDeps,
-        messages: &[Message],
-        guidelines: &str,
-    ) -> Result<AnchoredSummary, zeph_llm::LlmError> {
-        zeph_context::summarization::summarize_structured(&deps, messages, guidelines).await
-    }
-
-    /// Build a metadata-only summary without calling the LLM.
-    /// Used as last-resort fallback when LLM summarization repeatedly fails.
-    pub(super) fn build_metadata_summary(messages: &[Message]) -> String {
-        zeph_context::summarization::build_metadata_summary(messages, |s, n| {
-            super::truncate_chars(s, n)
-        })
-    }
-
-    async fn try_summarize_with_llm_with_deps(
-        deps: SummarizationDeps,
-        messages: &[Message],
-        guidelines: &str,
-    ) -> Result<String, zeph_llm::LlmError> {
-        zeph_context::summarization::summarize_with_llm(&deps, messages, guidelines).await
-    }
-
-    /// Remove tool response parts from messages using middle-out order.
-    /// `fraction` is in range (0.0, 1.0] — fraction of tool responses to remove.
-    /// Returns the modified message list.
-    pub(super) fn remove_tool_responses_middle_out(
-        messages: Vec<Message>,
-        fraction: f32,
-    ) -> Vec<Message> {
-        zeph_context::summarization::remove_tool_responses_middle_out(messages, fraction)
-    }
-
-    /// Summarize `messages` using `deps` extracted from `&self` before any `.await`.
-    ///
-    /// Equivalent to `summarize_messages` but takes all inputs by value so the
-    /// caller can extract them synchronously, then call this without holding `&self`
-    /// or any borrowed slice across any `.await`, making the enclosing future `Send`.
-    async fn summarize_messages_with_deps(
-        deps: SummarizationDeps,
-        structured_summaries: bool,
-        messages: Vec<Message>,
-        guidelines: String,
-    ) -> Result<String, super::super::error::AgentError> {
-        if structured_summaries {
-            match Self::try_summarize_structured_with_deps(deps.clone(), &messages, &guidelines)
-                .await
-            {
-                Ok(anchored) => {
-                    if let Some(ref cb) = deps.on_anchored_summary {
-                        cb(&anchored, false);
-                    }
-                    return Ok(super::cap_summary(anchored.to_markdown(), 16_000));
-                }
-                Err(e) => {
-                    tracing::warn!(error = %e, "structured summarization failed, falling back to prose");
-                    if let Some(ref cb) = deps.on_anchored_summary {
-                        let empty = AnchoredSummary {
-                            session_intent: String::new(),
-                            files_modified: vec![],
-                            decisions_made: vec![],
-                            open_questions: vec![],
-                            next_steps: vec![],
-                        };
-                        cb(&empty, true);
-                    }
-                }
-            }
-        }
-
-        match Self::try_summarize_with_llm_with_deps(deps.clone(), &messages, &guidelines).await {
-            Ok(summary) => return Ok(summary),
-            Err(e) if !e.is_context_length_error() => return Err(e.into()),
-            Err(e) => {
-                tracing::warn!(
-                    "summarization hit context length error ({e}), trying progressive tool response removal"
-                );
-            }
-        }
-
-        for fraction in [0.10f32, 0.20, 0.50, 1.0] {
-            let reduced = Self::remove_tool_responses_middle_out(messages.clone(), fraction);
-            tracing::debug!(
-                fraction,
-                "retrying summarization with reduced tool responses"
-            );
-            match Self::try_summarize_with_llm_with_deps(deps.clone(), &reduced, &guidelines).await
-            {
-                Ok(summary) => {
-                    tracing::info!(
-                        fraction,
-                        "summarization succeeded after tool response removal"
-                    );
-                    return Ok(summary);
-                }
-                Err(e) if e.is_context_length_error() => {
-                    tracing::warn!(fraction, "still context length error, trying next tier");
-                }
-                Err(e) => return Err(e.into()),
-            }
-        }
-
-        tracing::warn!("all LLM summarization attempts failed, using metadata fallback");
-        Ok(Self::build_metadata_summary(&messages))
-    }
-
     /// Load the current compression guidelines from `SQLite` if the feature is enabled.
     ///
     /// Returns an empty string when the feature is disabled, memory is not initialized,
@@ -172,75 +66,6 @@ impl<C: Channel> Agent<C> {
         }
     }
 
-    /// Archive tool output bodies from `to_compact` messages before compaction (Memex #2432).
-    ///
-    /// Saves each non-empty, non-already-archived `ToolOutput` body to `tool_overflow`
-    /// with `archive_type = 'archive'`. Returns a list of reference strings in the format
-    /// `[archived:{uuid} — tool: {tool_name} — {bytes} bytes]` for use as a postfix.
-    ///
-    /// References are injected AFTER summarization (fix C1: LLM would destroy them).
-    /// Returns an empty vec when `archive_tool_outputs` is disabled or memory is unavailable.
-    ///
-    /// Callers must extract `memory` and `cid` from `&self` before the first `.await`
-    /// so that `&self` is not held across the await boundary (required for Send futures).
-    async fn archive_tool_outputs(
-        archive_enabled: bool,
-        memory: Option<std::sync::Arc<zeph_memory::semantic::SemanticMemory>>,
-        cid: Option<zeph_memory::ConversationId>,
-        to_compact: Vec<Message>,
-    ) -> Vec<String> {
-        if !archive_enabled {
-            return Vec::new();
-        }
-        let (Some(memory), Some(cid)) = (memory, cid) else {
-            return Vec::new();
-        };
-
-        let mut refs = Vec::new();
-        // Clone DbStore before the loop to avoid holding &SemanticMemory across .await points.
-        let sqlite = memory.sqlite().clone();
-
-        for msg in to_compact {
-            for part in &msg.parts {
-                if let MessagePart::ToolOutput {
-                    body, tool_name, ..
-                } = part
-                {
-                    // Skip empty, already-archived, or already-overflowed bodies.
-                    if body.is_empty()
-                        || body.starts_with("[archived:")
-                        || body.starts_with("[full output stored")
-                        || body.starts_with("[tool output pruned")
-                    {
-                        continue;
-                    }
-                    match sqlite.save_archive(cid.0, body.as_bytes()).await {
-                        Ok(uuid) => {
-                            let bytes = body.len();
-                            refs.push(format!(
-                                "[archived:{uuid} — tool: {tool_name} — {bytes} bytes]"
-                            ));
-                        }
-                        Err(e) => {
-                            tracing::warn!(
-                                error = %e,
-                                "Memex: failed to archive tool output (non-fatal)"
-                            );
-                        }
-                    }
-                }
-            }
-        }
-
-        if !refs.is_empty() {
-            tracing::debug!(
-                archived = refs.len(),
-                "Memex: archived tool outputs before compaction"
-            );
-        }
-        refs
-    }
-
     /// Adjust `compact_end` backward so the preserved tail begins on a clean message boundary.
     ///
     /// If `messages[compact_end]` is a `Role::User` message that contains only `ToolResult`
@@ -251,6 +76,7 @@ impl<C: Channel> Agent<C> {
     ///
     /// Returns the adjusted `compact_end`.  The minimum returned value is `1` (drain nothing
     /// beyond the system message).
+    #[cfg(test)]
     fn adjust_compact_end_for_tool_pairs(messages: &[Message], compact_end: usize) -> usize {
         let mut end = compact_end;
         loop {
@@ -291,10 +117,39 @@ impl<C: Channel> Agent<C> {
     }
 }
 
+pub(in crate::agent) mod adapters;
 mod compaction;
 mod deferred;
 mod pruning;
 mod scheduling;
+
+// ── Test-helper delegations ───────────────────────────────────────────────────
+//
+// These thin wrappers expose stateless `zeph_context` helpers directly on `Agent<C>`
+// for test assertions. They are only compiled in test builds and are not part of
+// the public or production API.
+#[cfg(test)]
+impl<C: Channel> Agent<C> {
+    /// Build a metadata-only summary string from `messages` without calling the LLM.
+    ///
+    /// Delegates to [`zeph_context::summarization::build_metadata_summary`].
+    pub(in crate::agent::context) fn build_metadata_summary(messages: &[Message]) -> String {
+        zeph_context::summarization::build_metadata_summary(messages, |s, n| {
+            super::truncate_chars(s, n)
+        })
+    }
+
+    /// Remove `ToolOutput` parts from `messages` using middle-out eviction order.
+    ///
+    /// `fraction` is in `(0.0, 1.0]` — the fraction of tool responses to remove.
+    /// Delegates to [`zeph_context::summarization::remove_tool_responses_middle_out`].
+    pub(in crate::agent::context) fn remove_tool_responses_middle_out(
+        messages: Vec<Message>,
+        fraction: f32,
+    ) -> Vec<Message> {
+        zeph_context::summarization::remove_tool_responses_middle_out(messages, fraction)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/zeph-core/src/agent/context/tests/chunk_skill_compaction_tests.rs
+++ b/crates/zeph-core/src/agent/context/tests/chunk_skill_compaction_tests.rs
@@ -249,7 +249,7 @@ async fn compact_context_preserves_system_and_tail() {
         });
     }
 
-    agent.compact_context().await.unwrap();
+    let _ = agent.compact_context().await.unwrap();
 
     assert_eq!(agent.msg.messages[0].role, Role::System);
     assert_eq!(agent.msg.messages[0].content, system_content);
@@ -291,7 +291,7 @@ async fn compact_context_too_few_messages() {
     });
 
     let len_before = agent.msg.messages.len();
-    agent.compact_context().await.unwrap();
+    let _ = agent.compact_context().await.unwrap();
     assert_eq!(agent.msg.messages.len(), len_before);
 }
 
@@ -347,7 +347,7 @@ async fn compact_context_increments_metric() {
         });
     }
 
-    agent.compact_context().await.unwrap();
+    let _ = agent.compact_context().await.unwrap();
     assert_eq!(rx.borrow().context_compactions, 1);
 }
 

--- a/crates/zeph-core/src/agent/context/tests/prune_summarize_disambiguate_tests.rs
+++ b/crates/zeph-core/src/agent/context/tests/prune_summarize_disambiguate_tests.rs
@@ -396,7 +396,7 @@ async fn test_store_session_summary_on_compaction() {
     }
 
     // compact_context should succeed (non-fatal store)
-    agent.compact_context().await.unwrap();
+    let _ = agent.compact_context().await.unwrap();
     assert!(agent.msg.messages[1].content.contains("compacted summary"));
 }
 
@@ -445,7 +445,7 @@ async fn test_compact_context_calls_replace_conversation() {
         });
     }
 
-    agent.compact_context().await.unwrap();
+    let _ = agent.compact_context().await.unwrap();
 
     // After compaction, replace_conversation() must have been called:
     // original messages become agent_visible=0, summary row is inserted with agent_visible=1.

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -87,7 +87,7 @@ impl<C: Channel> Agent<C> {
                         .channel
                         .send_status("context too long, compacting...")
                         .await;
-                    self.compact_context().await?;
+                    let _ = self.compact_context().await?;
                     let _ = self.channel.send_status("").await;
                 }
                 Err(e) if e.is_beta_header_rejected() && attempt + 1 < max_attempts => {
@@ -433,7 +433,7 @@ impl<C: Channel> Agent<C> {
                         .channel
                         .send_status("context too long, compacting...")
                         .await;
-                    self.compact_context().await?;
+                    let _ = self.compact_context().await?;
                     let _ = self.channel.send_status("").await;
                 }
                 Err(e) => return Err(e),


### PR DESCRIPTION
## Summary

- Extends `ContextSummarizationView` with four callback traits (`CompactionProbeCallback`, `ToolOutputArchive`, `CompactionPersistence`, `MetricsCallback`) and `compression_guidelines: Option<String>`
- `ContextService::compact_context` now returns `CompactionOutcome` (replaces `usize`), exercises probe validation, archives tool outputs, and bubbles the Qdrant future back to the caller
- `MetricsCallback` replaces `// TODO(review)` stubs for `compaction_hard_count` and `tool_output_prunes`; implemented via `MetricsCollectorCallback` wrapping `Arc<MetricsCollector>` in `zeph-core`
- `compression_guidelines` populated in `Agent::summarization_view()` and passed to `summarize_with_llm`
- `CompactionAdapters` bundle keeps `Agent<C>::compact_context` shim at 11 statements; old body deleted from `zeph-core`
- `zeph-agent-context` remains free of `zeph-core` dependency (isolation invariant preserved)

## Test plan

- [x] `cargo tree -p zeph-agent-context | grep zeph-core` — no output
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --features full -- -D warnings` — zero warnings/errors
- [x] `cargo nextest run --workspace --lib --bins` — 8653 passed, 0 failed

Closes #3526, #3527, #3528