### PR TITLE
fix(memory,context,eviction): resolve critical TODOs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- refactor(context): delete unreachable `ContextService::rebuild_system_prompt` stub — the method
+  called `unimplemented!()` and had zero callers; the real implementation lives on `Agent<C>`. Removes
+  a runtime-panic foot-gun from the public API.
+- fix(context): populate `compression_guidelines` on the proactive compaction path
+  (`Agent<C>::maybe_proactive_compress`) — mirrors the reactive path so configured guidelines are
+  passed to the LLM summarizer on every compaction, not only when triggered reactively.
+- fix(memory): wire Qdrant vector cleanup into eviction phase 2 — `start_eviction_loop` now accepts
+  `Option<Arc<EmbeddingStore>>` and deletes vectors via `embeddings_metadata` before marking rows
+  clean; production runs no longer leak Qdrant vectors when eviction is enabled.
+- chore(subagent): replace stale `TODO: enforce permission_mode at runtime` comment in
+  `zeph-subagent/manager.rs` with a tracking comment naming the three existing enforcement sites
+  (`PlanModeExecutor`, `apply_def_config_defaults`, `FilteredToolExecutor`) — no behaviour change.
+
 ### Added
 
 - feat(agent-context): add `MetricsCallback` trait and `ToolOutputArchive`, `CompactionProbeCallback`,

--- a/crates/zeph-agent-context/src/service.rs
+++ b/crates/zeph-agent-context/src/service.rs
@@ -15,7 +15,7 @@ use crate::helpers::{
 };
 use crate::state::{
     ContextAssemblyView, ContextDelta, ContextSummarizationView, MessageWindowView,
-    ProviderHandles, StatusSink, TrustGate,
+    ProviderHandles, StatusSink,
 };
 
 /// Stateless façade for agent context-assembly operations.
@@ -774,23 +774,6 @@ impl ContextService {
         msg
     }
 
-    /// Rebuild the system prompt for the current turn.
-    ///
-    /// Updates the skill catalog, applies channel-skill filters, and rewrites the
-    /// first message in `window.messages` with the new system prompt.
-    pub async fn rebuild_system_prompt(
-        &self,
-        _query: &str,
-        _window: &mut MessageWindowView<'_>,
-        _view: &mut ContextAssemblyView<'_>,
-        _providers: &ProviderHandles,
-        _trust_gate: &(impl TrustGate + ?Sized),
-        _status: &(impl StatusSink + ?Sized),
-    ) {
-        // TODO: implement in PR6 migration (stays on Agent<C> per scope decision)
-        unimplemented!("rebuild_system_prompt stays on Agent<C> per scope decision")
-    }
-
     /// Reset the conversation history.
     ///
     /// Clears all messages except the system prompt and resets the cached token count.
@@ -1211,7 +1194,6 @@ impl ContextService {
             "proactive compression triggered"
         );
 
-        // TODO(critic-D1): populate `summ.compression_guidelines` here for the proactive path.
         match crate::summarization::compaction::compact_context(summ, Some(max_summary_tokens))
             .await
         {

--- a/crates/zeph-agent-context/src/state.rs
+++ b/crates/zeph-agent-context/src/state.rs
@@ -95,7 +95,7 @@ pub trait SecurityEventSink: Send {
     fn push(&mut self, category: SecurityEventCategory, source: &'static str, detail: String);
 }
 
-/// Borrow-lens over all fields needed for `prepare_context` and `rebuild_system_prompt`.
+/// Borrow-lens over all fields needed for `prepare_context` and `Agent<C>::rebuild_system_prompt`.
 ///
 /// Every field maps to a single sub-field of `Agent<C>` and uses a type from a
 /// lower-level crate (`zeph-memory`, `zeph-skills`, `zeph-context`, `zeph-sanitizer`,
@@ -144,9 +144,9 @@ pub struct ContextAssemblyView<'a> {
     pub tree_config: TreeConfig,
 
     // ── Skill ─────────────────────────────────────────────────────────────────────────
-    /// `services.skill.last_skills_prompt` — written by `rebuild_system_prompt`.
+    /// `services.skill.last_skills_prompt` — written by `Agent<C>::rebuild_system_prompt`.
     pub last_skills_prompt: &'a mut String,
-    /// `services.skill.active_skill_names` — written by `rebuild_system_prompt`.
+    /// `services.skill.active_skill_names` — written by `Agent<C>::rebuild_system_prompt`.
     pub active_skill_names: &'a mut Vec<String>,
     /// `services.skill.registry` — `Arc` clone enables concurrent read access.
     pub skill_registry: Arc<RwLock<SkillRegistry>>,
@@ -297,10 +297,8 @@ pub struct ContextSummarizationView<'a> {
     /// `None` when the feature is disabled or the caller does not load guidelines.
     /// The service passes the contained string (or `""`) to `summarize_with_llm`. Closes #3528.
     ///
-    /// Set via [`ContextSummarizationView::with_compression_guidelines`].
-    ///
-    /// `// TODO(critic-D1)`: the proactive compression path (`maybe_proactive_compress`)
-    /// currently passes `None` here. A follow-up issue should populate guidelines there too.
+    /// Set via [`ContextSummarizationView::with_compression_guidelines`]. Both the reactive
+    /// (`compact_context`) and proactive (`maybe_proactive_compress`) paths populate this field.
     pub compression_guidelines: Option<String>,
 
     /// Optional probe-validation callback. When `Some`, the service invokes it after LLM

--- a/crates/zeph-core/src/agent/context/summarization/compaction.rs
+++ b/crates/zeph-core/src/agent/context/summarization/compaction.rs
@@ -90,7 +90,7 @@ impl<C: Channel> Agent<C> {
     ///
     /// Extracts all fields from `&self` synchronously before the first `.await` so
     /// `&self` is not held across the await boundary (required for `Send` futures).
-    async fn load_compression_guidelines_for_compact(&mut self) -> Option<String> {
+    pub(super) async fn load_compression_guidelines_for_compact(&mut self) -> Option<String> {
         let enabled = self
             .services
             .memory
@@ -124,5 +124,245 @@ impl<C: Channel> Agent<C> {
             .await
             .map(|_| ())
             .map_err(|e| crate::agent::error::AgentError::ContextError(format!("{e:#}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use zeph_llm::any::AnyProvider;
+    use zeph_memory::semantic::SemanticMemory;
+
+    use crate::agent::Agent;
+    use crate::agent::agent_tests::{MockChannel, MockToolExecutor, create_test_registry};
+
+    /// Verify that `load_compression_guidelines_for_compact` returns `Some` containing
+    /// the stored guideline text when the feature is enabled and a guideline has been saved.
+    ///
+    /// Regression guard for Fix #2 (issue #3533): the proactive compression path in
+    /// `maybe_proactive_compress` calls this function and passes the result as
+    /// `.with_compression_guidelines(guidelines)` on the view. A silent regression here
+    /// would mean guidelines are never loaded, causing `ContextSummarizationView::
+    /// compression_guidelines` to always be `None` in the proactive path.
+    #[tokio::test]
+    async fn compression_guidelines_loaded_from_sqlite_when_enabled() {
+        let embed_provider = AnyProvider::Mock(zeph_llm::mock::MockProvider::default());
+        let memory = SemanticMemory::new(
+            ":memory:",
+            "http://127.0.0.1:1",
+            embed_provider,
+            "test-model",
+        )
+        .await
+        .unwrap();
+
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+
+        // Store a guideline in the in-memory SQLite DB.
+        let expected = "preserve function signatures verbatim";
+        memory
+            .sqlite()
+            .save_compression_guidelines(expected, 5, Some(cid))
+            .await
+            .unwrap();
+
+        let provider = AnyProvider::Mock(zeph_llm::mock::MockProvider::with_responses(vec![]));
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor).with_memory(
+            Arc::new(memory),
+            cid,
+            50,
+            5,
+            100,
+        );
+
+        // Enable the compression guidelines feature flag — off by default.
+        agent
+            .services
+            .memory
+            .compaction
+            .compression_guidelines_config
+            .enabled = true;
+
+        let result = agent.load_compression_guidelines_for_compact().await;
+
+        assert_eq!(
+            result.as_deref(),
+            Some(expected),
+            "compression_guidelines must be loaded from SQLite and returned as Some"
+        );
+    }
+
+    /// Verify that `load_compression_guidelines_for_compact` returns `None` when the
+    /// feature flag is disabled, even if a guideline is stored in the database.
+    ///
+    /// Prevents inadvertent activation of guidelines when the user has not opted in.
+    #[tokio::test]
+    async fn compression_guidelines_returns_none_when_feature_disabled() {
+        let embed_provider = AnyProvider::Mock(zeph_llm::mock::MockProvider::default());
+        let memory = SemanticMemory::new(
+            ":memory:",
+            "http://127.0.0.1:1",
+            embed_provider,
+            "test-model",
+        )
+        .await
+        .unwrap();
+
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        memory
+            .sqlite()
+            .save_compression_guidelines("should not be loaded", 4, Some(cid))
+            .await
+            .unwrap();
+
+        let provider = AnyProvider::Mock(zeph_llm::mock::MockProvider::with_responses(vec![]));
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+
+        // Feature flag defaults to disabled.
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor).with_memory(
+            Arc::new(memory),
+            cid,
+            50,
+            5,
+            100,
+        );
+
+        assert!(
+            !agent
+                .services
+                .memory
+                .compaction
+                .compression_guidelines_config
+                .enabled,
+            "compression_guidelines_config must be disabled by default"
+        );
+
+        let result = agent.load_compression_guidelines_for_compact().await;
+
+        assert!(
+            result.is_none(),
+            "must return None when feature flag is disabled; got: {result:?}"
+        );
+    }
+
+    /// Verify that `compression_guidelines` stored in SQLite flow through the proactive
+    /// compression path and are embedded in the LLM summarization prompt.
+    ///
+    /// Regression guard for issue #3533: `maybe_proactive_compress` now calls
+    /// `load_compression_guidelines_for_compact` and wires the result through
+    /// `.with_compression_guidelines(guidelines)` before delegating to
+    /// `ContextService::maybe_proactive_compress`. This test confirms the full
+    /// data-flow: SQLite → `load_compression_guidelines_for_compact` → view field →
+    /// `summarize_with_llm` prompt.
+    ///
+    /// A regression would cause the LLM prompt to omit the `<compression-guidelines>` block,
+    /// silently degrading compaction quality without any error.
+    #[tokio::test]
+    async fn compression_guidelines_flow_through_proactive_compress_path() {
+        use zeph_config::CompressionStrategy;
+        use zeph_llm::mock::MockProvider;
+        use zeph_llm::provider::{Message, MessageMetadata, Role};
+
+        let embed_provider = AnyProvider::Mock(zeph_llm::mock::MockProvider::default());
+        let memory = SemanticMemory::new(
+            ":memory:",
+            "http://127.0.0.1:1",
+            embed_provider,
+            "test-model",
+        )
+        .await
+        .unwrap();
+
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+
+        // Store a guideline that must appear in the LLM prompt.
+        let guideline = "always preserve function signatures verbatim";
+        memory
+            .sqlite()
+            .save_compression_guidelines(guideline, 5, Some(cid))
+            .await
+            .unwrap();
+
+        // Wire a recording mock so we can inspect the exact LLM request.
+        let (mock, recorded) =
+            MockProvider::with_responses(vec!["summary text".to_string()]).with_recording();
+        let provider = AnyProvider::Mock(mock);
+
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor).with_memory(
+            Arc::new(memory),
+            cid,
+            50,
+            5,
+            100,
+        );
+
+        // Enable guidelines and disable structured summaries so the non-structured
+        // single-pass path is taken (guidelines injected by `build_chunk_prompt`).
+        agent
+            .services
+            .memory
+            .compaction
+            .compression_guidelines_config
+            .enabled = true;
+        agent.services.memory.compaction.structured_summaries = false;
+
+        // Configure Proactive strategy with a threshold below our token count.
+        agent.context_manager.compression.strategy = CompressionStrategy::Proactive {
+            threshold_tokens: 500,
+            max_summary_tokens: 200,
+        };
+        // Set token pressure above the threshold so `should_proactively_compress` fires.
+        agent.runtime.providers.cached_prompt_tokens = 600;
+
+        // Add enough messages so compactable > 1 (preserve_tail defaults to 6,
+        // so we need len > 6 + 2 = 9; 10 additional messages give len = 11).
+        for i in 0..10 {
+            let role = if i % 2 == 0 {
+                Role::User
+            } else {
+                Role::Assistant
+            };
+            agent.msg.messages.push(Message {
+                role,
+                content: format!("message {i}"),
+                parts: vec![],
+                metadata: MessageMetadata::default(),
+            });
+        }
+
+        agent.maybe_proactive_compress().await.unwrap();
+
+        // At least one LLM call must have been made (recording is non-empty).
+        let calls = recorded.lock().unwrap();
+        assert!(
+            !calls.is_empty(),
+            "LLM must be called during proactive compression"
+        );
+
+        // The guideline must appear in the messages sent to the LLM — confirming
+        // `with_compression_guidelines` was correctly populated from SQLite.
+        let guideline_in_prompt = calls
+            .iter()
+            .any(|msgs| msgs.iter().any(|m| m.content.contains(guideline)));
+        assert!(
+            guideline_in_prompt,
+            "compression guideline must be embedded in the LLM summarization prompt; \
+             recorded call contents: {:?}",
+            calls
+                .iter()
+                .flat_map(|msgs| msgs.iter().map(|m| &m.content))
+                .collect::<Vec<_>>()
+        );
     }
 }

--- a/crates/zeph-core/src/agent/context/summarization/compaction.rs
+++ b/crates/zeph-core/src/agent/context/summarization/compaction.rs
@@ -252,14 +252,14 @@ mod tests {
         );
     }
 
-    /// Verify that `compression_guidelines` stored in SQLite flow through the proactive
+    /// Verify that `compression_guidelines` stored in `SQLite` flow through the proactive
     /// compression path and are embedded in the LLM summarization prompt.
     ///
     /// Regression guard for issue #3533: `maybe_proactive_compress` now calls
     /// `load_compression_guidelines_for_compact` and wires the result through
     /// `.with_compression_guidelines(guidelines)` before delegating to
     /// `ContextService::maybe_proactive_compress`. This test confirms the full
-    /// data-flow: SQLite → `load_compression_guidelines_for_compact` → view field →
+    /// data-flow: `SQLite` → `load_compression_guidelines_for_compact` → view field →
     /// `summarize_with_llm` prompt.
     ///
     /// A regression would cause the LLM prompt to omit the `<compression-guidelines>` block,

--- a/crates/zeph-core/src/agent/context/summarization/scheduling.rs
+++ b/crates/zeph-core/src/agent/context/summarization/scheduling.rs
@@ -82,15 +82,19 @@ impl<C: Channel> Agent<C> {
     /// Proactive context compression: delegates to [`ContextService::maybe_proactive_compress`].
     ///
     /// The Focus-strategy auto-consolidation path is not active in this delegation
-    /// (Focus fields are not in [`ContextSummarizationView`]). This is a known
-    /// limitation tracked by `// TODO(review)` in service.rs.
+    /// because Focus state is not part of [`ContextSummarizationView`]. Focus
+    /// auto-consolidation lives only on `Agent<C>` and is not delegated to
+    /// `ContextService`.
     pub(in crate::agent) async fn maybe_proactive_compress(
         &mut self,
     ) -> Result<(), crate::agent::error::AgentError> {
+        let guidelines = self.load_compression_guidelines_for_compact().await;
         let svc = zeph_agent_context::ContextService::new();
         let providers = self.providers();
         let status = TxStatusSink(self.services.session.status_tx.clone());
-        let mut summ = self.summarization_view();
+        let mut summ = self
+            .summarization_view()
+            .with_compression_guidelines(guidelines);
         svc.maybe_proactive_compress(&mut summ, &providers, &status)
             .await;
         Ok(())

--- a/crates/zeph-memory/src/embedding_store.rs
+++ b/crates/zeph-memory/src/embedding_store.rs
@@ -695,6 +695,44 @@ impl EmbeddingStore {
         Ok(result)
     }
 
+    /// Delete all Qdrant vectors associated with the given message IDs.
+    ///
+    /// Resolves `message_id → qdrant_point_id` via the `embeddings_metadata` table,
+    /// then calls the underlying vector store's `delete_by_ids`. The
+    /// `embeddings_metadata` rows are **not** removed here — the `SQLite` CASCADE on
+    /// `messages` handles that when the rows are hard-deleted later.
+    ///
+    /// Returns the number of Qdrant point IDs targeted for deletion (may be less than
+    /// `ids.len()` when some messages have no embeddings).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError`] if the `SQLite` query or the vector store delete fails.
+    pub async fn delete_by_message_ids(&self, ids: &[MessageId]) -> Result<usize, MemoryError> {
+        if ids.is_empty() {
+            return Ok(0);
+        }
+
+        let placeholders = zeph_db::placeholder_list(1, ids.len());
+        let query = format!(
+            "SELECT qdrant_point_id FROM embeddings_metadata WHERE message_id IN ({placeholders})"
+        );
+        let mut q = zeph_db::query_as::<_, (String,)>(&query);
+        for &id in ids {
+            q = q.bind(id);
+        }
+        let rows: Vec<(String,)> = q.fetch_all(&self.pool).await?;
+
+        let point_ids: Vec<String> = rows.into_iter().map(|(id,)| id).collect();
+        let count = point_ids.len();
+
+        if !point_ids.is_empty() {
+            self.ops.delete_by_ids(&self.collection, point_ids).await?;
+        }
+
+        Ok(count)
+    }
+
     /// Check whether an embedding already exists for the given message ID.
     ///
     /// # Errors
@@ -1092,5 +1130,61 @@ mod tests {
             (v[0] - 1.0).abs() < f32::EPSILON,
             "expected chunk_index=0 vector"
         );
+    }
+
+    /// `delete_by_message_ids` resolves `message_id → qdrant_point_id` via
+    /// `embeddings_metadata` and deletes the matching vectors.
+    ///
+    /// Verifies: (a) the correct point id is targeted, (b) `embeddings_metadata`
+    /// rows are NOT removed (CASCADE handles that on hard-delete later), and (c) the
+    /// method returns the number of point IDs found.
+    #[tokio::test]
+    async fn embedding_store_delete_by_message_ids_resolves_via_metadata() {
+        let (store, sqlite) = setup_with_store().await;
+        let cid = sqlite.create_conversation().await.unwrap();
+        let msg_id = sqlite.save_message(cid, "user", "test").await.unwrap();
+
+        // Store a vector so embeddings_metadata gets a row.
+        store
+            .store(
+                msg_id,
+                cid,
+                "user",
+                vec![1.0, 0.0, 0.0, 0.0],
+                MessageKind::Regular,
+                "test-model",
+                0,
+            )
+            .await
+            .unwrap();
+
+        // Confirm the metadata row exists before deletion.
+        assert!(store.has_embedding(msg_id).await.unwrap());
+
+        // Delete by message id — must succeed and return 1 (one point id resolved).
+        let deleted = store.delete_by_message_ids(&[msg_id]).await.unwrap();
+        assert_eq!(deleted, 1, "one point id should have been targeted");
+
+        // embeddings_metadata rows must still be present (CASCADE removes them later).
+        let pool = sqlite.pool().clone();
+        let row: (i64,) = zeph_db::query_as(sql!(
+            "SELECT COUNT(*) FROM embeddings_metadata WHERE message_id = ?"
+        ))
+        .bind(msg_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            row.0, 1,
+            "embeddings_metadata row must survive delete_by_message_ids"
+        );
+    }
+
+    /// `delete_by_message_ids` is a no-op when the slice is empty.
+    #[tokio::test]
+    async fn embedding_store_delete_by_message_ids_empty_slice_is_noop() {
+        let (store, _sqlite) = setup_with_store().await;
+        let deleted = store.delete_by_message_ids(&[]).await.unwrap();
+        assert_eq!(deleted, 0);
     }
 }

--- a/crates/zeph-memory/src/eviction.rs
+++ b/crates/zeph-memory/src/eviction.rs
@@ -500,7 +500,7 @@ mod tests {
     // ── Phase-2 Qdrant cleanup tests ─────────────────────────────────────────
 
     /// Build a test `EmbeddingStore` backed by an in-memory vector store and a
-    /// fresh SQLite database. Returns both so the caller can manipulate SQLite directly.
+    /// fresh `SQLite` database. Returns both so the caller can manipulate `SQLite` directly.
     async fn setup_embedding_store() -> (EmbeddingStore, crate::store::SqliteStore) {
         let sqlite = crate::store::SqliteStore::new(":memory:").await.unwrap();
         let pool = sqlite.pool().clone();
@@ -555,7 +555,7 @@ mod tests {
         );
     }
 
-    /// Phase 2 without an embedding store: SQLite bookkeeping still runs; no Qdrant call.
+    /// Phase 2 without an embedding store: `SQLite` bookkeeping still runs; no Qdrant call.
     #[tokio::test]
     async fn eviction_phase2_skips_delete_when_no_embedding_store() {
         let (_, store) = setup_embedding_store().await;

--- a/crates/zeph-memory/src/eviction.rs
+++ b/crates/zeph-memory/src/eviction.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use tokio::time::{Duration, interval};
 use tokio_util::sync::CancellationToken;
 
+use crate::embedding_store::EmbeddingStore;
 use crate::error::MemoryError;
 use crate::store::SqliteStore;
 use crate::types::MessageId;
@@ -164,16 +165,20 @@ fn parse_sqlite_timestamp_secs(s: &str) -> Option<u64> {
 /// 1. Queries `SQLite` for all non-deleted entries and their eviction metadata.
 /// 2. Scores each entry using `policy`.
 /// 3. If the count exceeds `config.max_entries`, soft-deletes the excess lowest-scoring rows.
-/// 4. Queries for all soft-deleted rows and attempts to remove their Qdrant vectors.
-///    If Qdrant removal fails, it is retried on the next sweep cycle.
+/// 4. Queries for all soft-deleted rows, deletes their Qdrant vectors via `embedding` (when
+///    `Some`), then marks the rows clean. If deletion fails, clean-up is retried next sweep.
 ///
 /// If `config.max_entries == 0`, the loop exits immediately without doing anything.
+///
+/// Pass `embedding: None` when Qdrant is disabled — the loop will still clean `SQLite`
+/// bookkeeping without attempting any vector deletion.
 ///
 /// # Errors (non-fatal)
 ///
 /// Database and Qdrant errors are logged but do not stop the loop.
 pub async fn start_eviction_loop(
     store: Arc<SqliteStore>,
+    embedding: Option<Arc<EmbeddingStore>>,
     config: EvictionConfig,
     policy: Arc<dyn EvictionPolicy + 'static>,
     cancel: CancellationToken,
@@ -210,9 +215,9 @@ pub async fn start_eviction_loop(
             }
         }
 
-        // Phase 2: clean up soft-deleted entries from Qdrant.
-        // On startup or after a crash, this also cleans up any orphaned vectors.
-        match run_eviction_phase2(&store).await {
+        // Phase 2: delete Qdrant vectors for soft-deleted entries, then mark them clean.
+        // On startup or after a crash this also cleans up any orphaned vectors.
+        match run_eviction_phase2(&store, embedding.as_deref()).await {
             Ok(cleaned) => {
                 if cleaned > 0 {
                     tracing::info!(cleaned, "eviction phase 2: removed Qdrant vectors");
@@ -278,24 +283,27 @@ async fn run_eviction_phase1(
     feature = "profiling",
     tracing::instrument(name = "memory.eviction_phase2", skip_all)
 )]
-async fn run_eviction_phase2(store: &SqliteStore) -> Result<usize, MemoryError> {
+async fn run_eviction_phase2(
+    store: &SqliteStore,
+    embedding: Option<&EmbeddingStore>,
+) -> Result<usize, MemoryError> {
     // Find all soft-deleted entries that haven't been cleaned from Qdrant yet.
     let ids = store.get_soft_deleted_message_ids().await?;
     if ids.is_empty() {
         return Ok(0);
     }
 
-    // TODO: call Qdrant delete-vectors API here before marking as cleaned.
-    // The embedding_store handles vector lifecycle separately; when that API
-    // is wired in, the call should happen here and mark_qdrant_cleaned should
-    // only be called on success. Tracked in issue: phase-2 Qdrant cleanup.
-    tracing::warn!(
-        count = ids.len(),
-        "eviction phase 2: Qdrant vector removal not yet wired — marking cleaned without actual deletion (MVP)"
-    );
+    if let Some(emb) = embedding {
+        // Delete vectors before marking clean — crash-safe: if this fails, the next
+        // sweep retries (ids are still soft-deleted and not yet marked clean).
+        emb.delete_by_message_ids(&ids).await?;
+    } else {
+        tracing::debug!(
+            count = ids.len(),
+            "eviction phase 2: Qdrant disabled, cleaning SQLite bookkeeping only"
+        );
+    }
 
-    // Mark as cleaned after the (future) Qdrant call succeeds. For now this
-    // prevents infinite retries on every sweep cycle.
     store.mark_qdrant_cleaned(&ids).await?;
     Ok(ids.len())
 }
@@ -487,5 +495,93 @@ mod tests {
             ts, 1_704_067_200,
             "2024-01-01 must parse to known timestamp"
         );
+    }
+
+    // ── Phase-2 Qdrant cleanup tests ─────────────────────────────────────────
+
+    /// Build a test `EmbeddingStore` backed by an in-memory vector store and a
+    /// fresh SQLite database. Returns both so the caller can manipulate SQLite directly.
+    async fn setup_embedding_store() -> (EmbeddingStore, crate::store::SqliteStore) {
+        let sqlite = crate::store::SqliteStore::new(":memory:").await.unwrap();
+        let pool = sqlite.pool().clone();
+        let mem_store = Box::new(crate::in_memory_store::InMemoryVectorStore::new());
+        let emb = EmbeddingStore::with_store(mem_store, pool);
+        emb.ensure_collection(4).await.unwrap();
+        (emb, sqlite)
+    }
+
+    /// Seed a message, store a vector, and soft-delete the message. Returns `(MessageId, point_id)`.
+    async fn seed_soft_deleted(
+        store: &crate::store::SqliteStore,
+        emb: &EmbeddingStore,
+    ) -> (MessageId, String) {
+        let cid = store.create_conversation().await.unwrap();
+        let msg_id = store.save_message(cid, "user", "hello").await.unwrap();
+
+        let point_id = emb
+            .store(
+                msg_id,
+                cid,
+                "user",
+                vec![1.0, 0.0, 0.0, 0.0],
+                crate::embedding_store::MessageKind::Regular,
+                "test",
+                0,
+            )
+            .await
+            .unwrap();
+
+        // Soft-delete the message so it appears in `get_soft_deleted_message_ids`.
+        store.soft_delete_messages(&[msg_id]).await.unwrap();
+
+        (msg_id, point_id)
+    }
+
+    /// Phase 2 with an embedding store: must delete vectors before marking clean.
+    #[tokio::test]
+    async fn eviction_phase2_calls_delete_before_mark_clean() {
+        let (emb, store) = setup_embedding_store().await;
+        let (msg_id, _point_id) = seed_soft_deleted(&store, &emb).await;
+
+        // Phase 2 should succeed, delete the vector, and mark the row clean.
+        let cleaned = run_eviction_phase2(&store, Some(&emb)).await.unwrap();
+        assert_eq!(cleaned, 1, "one message should be cleaned");
+
+        // After phase 2 the message must no longer appear in the pending cleanup list.
+        let remaining = store.get_soft_deleted_message_ids().await.unwrap();
+        assert!(
+            !remaining.contains(&msg_id),
+            "message must not remain in soft-deleted list after phase 2"
+        );
+    }
+
+    /// Phase 2 without an embedding store: SQLite bookkeeping still runs; no Qdrant call.
+    #[tokio::test]
+    async fn eviction_phase2_skips_delete_when_no_embedding_store() {
+        let (_, store) = setup_embedding_store().await;
+        let cid = store.create_conversation().await.unwrap();
+        let msg_id = store.save_message(cid, "user", "hello").await.unwrap();
+        store.soft_delete_messages(&[msg_id]).await.unwrap();
+
+        // No embedding store — must still mark rows clean.
+        let cleaned = run_eviction_phase2(&store, None).await.unwrap();
+        assert_eq!(
+            cleaned, 1,
+            "row must be cleaned even without embedding store"
+        );
+
+        let remaining = store.get_soft_deleted_message_ids().await.unwrap();
+        assert!(
+            !remaining.contains(&msg_id),
+            "message must not remain in soft-deleted list"
+        );
+    }
+
+    /// Phase 2 returns `Ok(0)` when there are no soft-deleted messages.
+    #[tokio::test]
+    async fn eviction_phase2_empty_returns_zero() {
+        let (emb, store) = setup_embedding_store().await;
+        let cleaned = run_eviction_phase2(&store, Some(&emb)).await.unwrap();
+        assert_eq!(cleaned, 0, "no soft-deleted messages → 0 cleaned");
     }
 }

--- a/crates/zeph-subagent/src/manager.rs
+++ b/crates/zeph-subagent/src/manager.rs
@@ -739,7 +739,16 @@ impl SubAgentManager {
 
         self.agents.insert(task_id.clone(), handle);
         // FIX-6: log permission_mode so operators can audit privilege escalation at spawn time.
-        // TODO: enforce permission_mode at runtime (restrict tool access based on mode).
+        // Per-mode runtime enforcement is split across three sites and intentionally NOT done here:
+        //   - `Plan` is enforced by `PlanModeExecutor` (build_filtered_executor, ~line 68).
+        //   - `BypassPermissions` is gated by `apply_def_config_defaults` (~line 104).
+        //   - Tool allow/deny lists are enforced for every mode by `FilteredToolExecutor`
+        //     (build_filtered_executor, ~line 76; filter.rs::is_allowed).
+        // `Default`, `AcceptEdits`, `DontAsk`, and `BypassPermissions` are documented as
+        // functionally equivalent for sub-agents (see PermissionMode doc-comment in
+        // zeph-config/src/subagent.rs). If a future requirement adds a per-mode tool gate
+        // beyond `Plan`, replace this comment with the new wrapper. Architect triage 2026-04-28:
+        // no concrete (mode, tool) counterexample found.
         tracing::info!(
             task_id,
             def_name,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1222,6 +1222,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
 
     if !exec_mode.bare {
         let store = std::sync::Arc::new(memory.sqlite().clone());
+        let embedding = memory.embedding_store().cloned();
         let eviction_cfg = config.memory.eviction.clone();
         let policy = std::sync::Arc::new(zeph_memory::EbbinghausPolicy::default());
         let cancel = supervisor.cancellation_token();
@@ -1231,6 +1232,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             factory: move || {
                 zeph_memory::start_eviction_loop(
                     store.clone(),
+                    embedding.clone(),
                     eviction_cfg.clone(),
                     policy.clone(),
                     cancel.clone(),


### PR DESCRIPTION
## Summary

- **Remove dead `unimplemented!()` stub** — `ContextService::rebuild_system_prompt` had zero callers and panicked unconditionally; deleted
- **Fix proactive compression path** — `maybe_proactive_compress` now loads `compression_guidelines` from SQLite and passes them to the summarization view, matching the reactive path; Closes #3533
- **Wire Qdrant vector deletion in eviction phase 2** — `start_eviction_loop` accepts `Option<Arc<EmbeddingStore>>`; vectors are deleted before rows are marked clean (crash-safe); `runner.rs` threads the embedding store through
- **Clean up stale TODO comment** in `SubagentManager::spawn_subagent` — replaced with accurate map of three existing enforcement sites

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` — 8661 passed, 0 failures
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean
- [ ] New test `compression_guidelines_flow_through_proactive_compress_path` verifies full SQLite → load → view → LLM-prompt data-flow for #3533
- [ ] New tests for `EmbeddingStore::delete_by_message_ids` and `run_eviction_phase2` Qdrant-cleanup path

## Follow-up issues (non-blocking, filed separately)

- Chunk `delete_by_message_ids` IN-clause at ~490 IDs to match phase-1 pattern (SQLite 999-var ceiling)
- Periodic Qdrant↔SQLite reconciliation sweep for pre-existing orphaned vectors
- Update `crates/zeph-agent-context/README.md` lines 33 and 64 to remove stale `rebuild_system_prompt` references