### PR TITLE
fix(mcp,core): resolve critical TODOs — MCP Await Discipline violation + stale comments

### DIFF
--- a/crates/zeph-core/src/agent/context/tests/mod.rs
+++ b/crates/zeph-core/src/agent/context/tests/mod.rs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-// TODO(critic): #3497 follow-up — replace remaining super::super::* with absolute crate::agent::* paths for clarity
-
 mod chunk_skill_compaction_tests;
 mod compaction_guards_and_consolidation_tests;
 mod prompt_tooling_summary_tests;

--- a/crates/zeph-core/src/agent/tests/mod.rs
+++ b/crates/zeph-core/src/agent/tests/mod.rs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-// TODO(critic): #3497 follow-up — replace remaining super:: paths with absolute crate:: paths for clarity
-
 pub mod agent_tests; // path-preserving — DO NOT rename (used by 24+ modules via crate::agent::agent_tests::*)
 
 #[cfg(test)]

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -8,6 +8,7 @@ use zeph_llm::provider::{
     ToolDefinition,
 };
 
+// TODO(refactor): migrate super::super::* uses to crate::agent::* (follow-up to #3497, ~30 instances in this file)
 use super::super::Agent;
 use super::{
     AnomalyOutcome, retry_backoff_ms, strip_tafc_fields, tool_args_hash,

--- a/crates/zeph-core/src/agent/tool_execution/tests/mod.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/mod.rs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-// TODO(critic): #3497 follow-up — replace remaining super::super::* with absolute crate::agent::* paths for clarity
-
 mod boundary_and_classifier_tests;
 mod parallel_and_handle_tests;
 mod pure_helpers_tests;

--- a/crates/zeph-mcp/src/client.rs
+++ b/crates/zeph-mcp/src/client.rs
@@ -970,6 +970,36 @@ impl McpClient {
         }
     }
 
+    /// Create a stub `McpClient` backed by a dropped in-memory duplex transport.
+    ///
+    /// The service task will exit immediately because the remote half of the duplex is
+    /// dropped. Safe to call `shutdown()` on the returned client — `cancel()` simply
+    /// signals the cancellation token.
+    ///
+    /// Only available in `#[cfg(test)]` contexts.
+    #[cfg(test)]
+    pub(crate) fn new_disconnected_for_test(server_id: impl Into<String>) -> Self {
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel::<ToolRefreshEvent>();
+        let handler = ToolListChangedHandler::new(
+            "test",
+            tx,
+            Arc::new(DashMap::new()),
+            Arc::new(vec![]),
+            1024,
+            None,
+            Duration::from_secs(5),
+        );
+        // The server half is immediately dropped — the service task will exit after
+        // the first I/O error, which is fine for tests that only exercise state logic.
+        let (client_rw, _server_rw) = tokio::io::duplex(64);
+        let service = rmcp::service::serve_directly(handler, client_rw, None);
+        Self {
+            server_id: server_id.into(),
+            service: Arc::new(service),
+            timeout: Duration::from_secs(5),
+        }
+    }
+
     /// Graceful shutdown.
     #[cfg_attr(
         feature = "profiling",

--- a/crates/zeph-mcp/src/manager.rs
+++ b/crates/zeph-mcp/src/manager.rs
@@ -1260,25 +1260,32 @@ impl McpManager {
         client: McpClient,
         tools: Vec<McpTool>,
     ) -> Result<(), McpError> {
-        // TODO(critic): commit_added_server holds `clients` write guard across
-        // `server_trust.write().await` and `server_tools.write().await`. This
-        // violates Await Discipline §4 (.claude/rules/rust-code.md). Preserved
-        // verbatim during the #3451 decomposition; file a follow-up issue to
-        // drop the guard before subsequent writes.
+        // TOCTOU check + insert under clients guard. No awaits while the guard is held,
+        // satisfying Await Discipline rule #4 (.claude/rules/rust-code.md).
+        {
+            let mut clients = self.clients.write().await;
+            if clients.contains_key(&entry.id) {
+                drop(clients);
+                client.shutdown().await;
+                return Err(McpError::ServerAlreadyConnected {
+                    server_id: entry.id.clone(),
+                });
+            }
+            clients.insert(entry.id.clone(), client);
+            self.connected_server_ids.write().insert(entry.id.clone());
+        } // clients guard dropped here
 
-        // Re-check under write lock to prevent TOCTOU race
-        let mut clients = self.clients.write().await;
-        if clients.contains_key(&entry.id) {
-            drop(clients);
-            client.shutdown().await;
-            return Err(McpError::ServerAlreadyConnected {
-                server_id: entry.id.clone(),
-            });
-        }
-        clients.insert(entry.id.clone(), client);
-        self.connected_server_ids.write().insert(entry.id.clone());
+        // TODO(bug): narrow race window — if `remove_server` runs between here and the
+        // `server_trust`/`server_tools` writes below, those maps will retain orphaned entries
+        // until `shutdown_all`. The three-RwLock design makes full atomicity without a
+        // serialization mutex impossible. Tracked in #3536.
 
-        // Register trust config for the refresh task.
+        // Register trust and tools after the client is visible.
+        // Each guard is acquired and dropped independently — no guard crosses an .await.
+        //
+        // Invariant: the refresh task cannot deliver events for entry.id before this function
+        // returns Ok, because the refresh channel is wired through the client's notification
+        // handler which is not active until after connect_and_list_tools completes.
         self.server_trust.write().await.insert(
             entry.id.clone(),
             (
@@ -1287,7 +1294,6 @@ impl McpManager {
                 entry.expected_tools.clone(),
             ),
         );
-
         self.server_tools
             .write()
             .await
@@ -2156,6 +2162,58 @@ mod tests {
             self.connected_server_ids
                 .write()
                 .insert(server_id.to_owned());
+        }
+    }
+
+    // --- commit_added_server ---
+
+    #[tokio::test]
+    async fn commit_added_server_rejects_duplicate() {
+        let mgr = McpManager::new(vec![], vec![], PolicyEnforcer::new(vec![]));
+        let entry = ServerEntry {
+            id: "srv1".into(),
+            trust_level: McpTrustLevel::Trusted,
+            ..make_entry("srv1")
+        };
+        let tool = make_tool("srv1", "t1");
+
+        // First call succeeds.
+        let first = McpClient::new_disconnected_for_test("srv1");
+        mgr.commit_added_server(&entry, first, vec![tool.clone()])
+            .await
+            .expect("first commit must succeed");
+
+        // Second call with same id must be rejected.
+        let second = McpClient::new_disconnected_for_test("srv1");
+        let err = mgr
+            .commit_added_server(&entry, second, vec![make_tool("srv1", "t2")])
+            .await
+            .expect_err("duplicate commit must fail");
+        assert!(
+            matches!(err, McpError::ServerAlreadyConnected { ref server_id } if server_id == "srv1"),
+            "unexpected error: {err:?}"
+        );
+
+        // The winner's trust and tools must be intact — not overwritten or cleared by the loser.
+        {
+            let trust_guard = mgr.server_trust.read().await;
+            assert_eq!(trust_guard.len(), 1, "exactly one trust entry must survive");
+            let (level, _, _) = trust_guard["srv1"];
+            assert_eq!(
+                level,
+                McpTrustLevel::Trusted,
+                "winner's trust level must be preserved"
+            );
+        }
+        {
+            let tools_guard = mgr.server_tools.read().await;
+            assert_eq!(tools_guard.len(), 1, "exactly one tools entry must survive");
+            let tools = &tools_guard["srv1"];
+            assert_eq!(tools.len(), 1);
+            assert_eq!(
+                tools[0].name, "t1",
+                "winner's tools must be preserved, not replaced by loser's"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

- **Fix `commit_added_server` Await Discipline §4 violation** (`zeph-mcp`): the previous code held the `clients` write guard across two `.await` points (`server_trust.write().await`, `server_tools.write().await`), creating a potential deadlock if another task held `server_trust` write while waiting for `clients`. Fixed by releasing the `clients` guard before all subsequent awaits; TOCTOU protection preserved.
- **Remove 3 stale `TODO(critic)` comments** in `zeph-core` test aggregator files where the `super::super::*` → `crate::` migration was already complete.
- **Add deferred migration marker** in `tool_execution/native.rs` for ~30 remaining `super::super::*` occurrences (separate follow-up, not part of original TODOs).

## New issues filed

- #3536 — narrow concurrent `commit_added_server` + `remove_server` race (documented with TODO in code; separate fix tracked there)

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — 0 warnings
- [x] `cargo nextest run -p zeph-mcp --lib` — 429/429 passed
- [x] `cargo nextest run -p zeph-core --lib` — 1302/1302 passed
- [x] New test `commit_added_server_rejects_duplicate` covers sequential duplicate rejection and winner-state preservation

Closes #3534 (partial — the Await Discipline TODO is now resolved)