### PR TITLE
fix(gateway): return application/json for all POST /webhook error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- fix(gateway): `POST /webhook` error responses now return `application/json` with a structured
+  `{"error": "...", "status": <code>}` body instead of `text/plain`; covers both JSON deserialization
+  failures (axum `JsonRejection`) and field-length validation failures (#3540).
+
 - refactor(context): delete unreachable `ContextService::rebuild_system_prompt` stub — the method
   called `unimplemented!()` and had zero callers; the real implementation lives on `Agent<C>`. Removes
   a runtime-panic foot-gun from the public API.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -265,7 +265,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -330,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
+checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
 dependencies = [
  "filetime",
  "futures-core",
@@ -1174,7 +1174,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1923,7 +1923,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2146,7 +2146,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3263,7 +3263,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4399,7 +4399,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5628,7 +5628,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5666,7 +5666,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6323,7 +6323,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6391,7 +6391,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7024,7 +7024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7295,7 +7295,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7748,7 +7748,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9334,7 +9334,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/zeph-gateway/src/handlers.rs
+++ b/crates/zeph-gateway/src/handlers.rs
@@ -3,10 +3,18 @@
 
 use axum::Json;
 use axum::extract::State;
+use axum::extract::rejection::JsonRejection;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 
 use super::server::AppState;
+
+/// JSON body returned for all error responses from `POST /webhook`.
+#[derive(serde::Serialize)]
+struct ErrorResponse {
+    error: String,
+    status: u16,
+}
 
 /// JSON body expected on `POST /webhook`.
 ///
@@ -78,10 +86,30 @@ struct HealthResponse {
 /// | 503 | Internal channel is closed (agent shut down) |
 pub(crate) async fn webhook_handler(
     State(state): State<AppState>,
-    Json(payload): Json<WebhookPayload>,
+    payload: Result<Json<WebhookPayload>, JsonRejection>,
 ) -> impl IntoResponse {
+    let Json(payload) = match payload {
+        Ok(p) => p,
+        Err(e) => {
+            return (
+                e.status(),
+                Json(ErrorResponse {
+                    error: e.body_text(),
+                    status: e.status().as_u16(),
+                }),
+            )
+                .into_response();
+        }
+    };
     if let Err(e) = payload.validate() {
-        return (StatusCode::UNPROCESSABLE_ENTITY, e).into_response();
+        return (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(ErrorResponse {
+                error: e.to_string(),
+                status: StatusCode::UNPROCESSABLE_ENTITY.as_u16(),
+            }),
+        )
+            .into_response();
     }
     let sender = zeph_common::sanitize::strip_control_chars_preserve_whitespace(&payload.sender);
     let channel = zeph_common::sanitize::strip_control_chars_preserve_whitespace(&payload.channel);

--- a/crates/zeph-gateway/src/router.rs
+++ b/crates/zeph-gateway/src/router.rs
@@ -335,6 +335,67 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn webhook_missing_field_returns_json_error() {
+        let (app, _rx) = make_router(None, 0);
+        // Missing "sender" field
+        let body = serde_json::json!({"channel": "ci643", "body": "test"});
+        let req = Request::builder()
+            .method("POST")
+            .uri("/webhook")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), 422);
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(
+            ct.contains("application/json"),
+            "expected JSON content-type, got: {ct}"
+        );
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json.get("error").is_some());
+        assert_eq!(json["status"], 422);
+    }
+
+    #[tokio::test]
+    async fn webhook_validation_failure_returns_json_error() {
+        let (app, _rx) = make_router(None, 0);
+        let body = serde_json::json!({
+            "channel": "ci643",
+            "sender": "a".repeat(257),
+            "body": "hello"
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/webhook")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), 422);
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(
+            ct.contains("application/json"),
+            "expected JSON content-type, got: {ct}"
+        );
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json.get("error").is_some());
+        assert_eq!(json["status"], 422);
+    }
+
+    #[tokio::test]
     async fn body_size_limit() {
         let (state, _rx) = test_state();
         let app = build_router(state, None, 0, 64);


### PR DESCRIPTION
## Summary

- Both `POST /webhook` error paths previously returned `text/plain; charset=utf-8`, making automated error handling require content-type sniffing
- `axum::extract::rejection::JsonRejection` (deserialization failures) now handled explicitly instead of relying on axum's default text response
- `payload.validate()` validation failures now return `Json(ErrorResponse)` instead of `(StatusCode, &str)`
- All error responses are now `application/json` with `{"error": "...", "status": <code>}` body

## Test plan

- [x] Two new integration tests in `router::tests`: `webhook_missing_field_returns_json_error` and `webhook_validation_failure_returns_json_error` — verify `content-type: application/json` and JSON shape
- [x] All 25 `zeph-gateway` tests pass
- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy -p zeph-gateway --all-features -- -D warnings` passes

Closes #3540