### PR TITLE
fix(gateway): return application/json for POST /webhook 503 response

### DIFF
--- a/crates/zeph-gateway/src/handlers.rs
+++ b/crates/zeph-gateway/src/handlers.rs
@@ -116,7 +116,14 @@ pub(crate) async fn webhook_handler(
     let msg = format!("[{}@{}] {}", sender, channel, payload.body);
     match state.webhook_tx.send(msg).await {
         Ok(()) => Json(WebhookResponse { status: "accepted" }).into_response(),
-        Err(_) => StatusCode::SERVICE_UNAVAILABLE.into_response(),
+        Err(_) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorResponse {
+                error: "agent unavailable".to_string(),
+                status: StatusCode::SERVICE_UNAVAILABLE.as_u16(),
+            }),
+        )
+            .into_response(),
     }
 }
 

--- a/crates/zeph-gateway/src/router.rs
+++ b/crates/zeph-gateway/src/router.rs
@@ -396,6 +396,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn webhook_503_returns_json_error() {
+        // Build a state whose channel is already closed (rx dropped) so that
+        // the send in webhook_handler will fail immediately.
+        let (tx, rx) = tokio::sync::mpsc::channel::<String>(1);
+        drop(rx);
+        let state = AppState {
+            webhook_tx: tx,
+            started_at: Instant::now(),
+        };
+        let app = build_router(state, None, 0, 1_048_576);
+
+        let body = serde_json::json!({"channel": "c", "sender": "s", "body": "b"});
+        let req = Request::builder()
+            .method("POST")
+            .uri("/webhook")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), 503);
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(
+            ct.contains("application/json"),
+            "expected application/json content-type for 503, got: {ct}"
+        );
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["status"], 503);
+        assert!(json.get("error").is_some());
+    }
+
+    #[tokio::test]
     async fn body_size_limit() {
         let (state, _rx) = test_state();
         let app = build_router(state, None, 0, 64);


### PR DESCRIPTION
## Summary

- Replaces `StatusCode::SERVICE_UNAVAILABLE.into_response()` with a JSON `ErrorResponse` body, making the 503 path consistent with all 422 paths introduced in #3542.
- Adds `webhook_503_returns_json_error` regression test that drops the receiver before the request, verifying status 503, `Content-Type: application/json`, and `{error, status}` body shape.

## Test plan

- [x] `cargo nextest run -p zeph-gateway --lib` — 26 tests pass
- [x] `cargo +nightly fmt --check` — no diff
- [x] `cargo clippy -p zeph-gateway --all-targets -- -D warnings` — no warnings

Closes #3544