### PR TITLE
fix(sanitizer): skip ML classifier for bash and shell tool outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- fix(sanitizer): `"bash"` and `"shell"` tool outputs no longer trigger false-positive ML injection
+  classifier warnings when the output contains shell special characters (single quotes, asterisks,
+  arithmetic expressions). Both tools are now in the `INTERNAL_TOOLS` allowlist; only ML
+  classification is skipped — regex-based injection detection continues to run (#3547).
+
 - fix(gateway): `POST /webhook` error responses now return `application/json` with a structured
   `{"error": "...", "status": <code>}` body instead of `text/plain`; covers both JSON deserialization
   failures (axum `JsonRejection`) and field-length validation failures (#3540).

--- a/crates/zeph-core/src/agent/tool_execution/sanitize.rs
+++ b/crates/zeph-core/src/agent/tool_execution/sanitize.rs
@@ -29,6 +29,8 @@ fn is_policy_blocked_output(body: &str) -> bool {
 /// different policy but must stay consistent.
 #[cfg(feature = "classifiers")]
 const INTERNAL_TOOLS: &[&str] = &[
+    "bash",
+    "shell",
     "invoke_skill",
     "load_skill",
     "memory_save",
@@ -380,6 +382,8 @@ mod tests {
     #[test]
     fn internal_tool_allowlist_covers_all_zeph_tools() {
         for name in [
+            "bash",
+            "shell",
             "invoke_skill",
             "load_skill",
             "memory_save",
@@ -401,7 +405,6 @@ mod tests {
     #[test]
     fn external_and_mcp_tools_not_in_allowlist() {
         for name in [
-            "shell",
             "web-scrape",
             "fetch",
             "read_overflow",

--- a/crates/zeph-core/src/agent/tool_execution/tests/boundary_and_classifier_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/boundary_and_classifier_tests.rs
@@ -1084,4 +1084,33 @@ mod skip_ml_internal_tools {
             "invoke_skill is an internal tool — classify_injection must be skipped"
         );
     }
+
+    // #3547: DeBERTa fires false positives on bash output containing shell metacharacters
+    // such as `$ expr 15 '*' 3` (the `$ <cmd>` prefix added by ShellExecutor).
+    // Both "bash" and "shell" must be in INTERNAL_TOOLS so the ML path is bypassed.
+    #[tokio::test]
+    async fn sanitize_tool_output_bash_tool_skips_ml_classifier() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+        let cfg = zeph_sanitizer::ContentIsolationConfig {
+            enabled: true,
+            flag_injection_patterns: true,
+            ..Default::default()
+        };
+        agent.services.security.sanitizer = zeph_sanitizer::ContentSanitizer::new(&cfg)
+            .with_classifier(Arc::new(BlockedBackend), 5_000, 0.5)
+            .with_enforcement_mode(zeph_config::InjectionEnforcementMode::Block);
+
+        for tool in ["bash", "shell"] {
+            let body = "$ expr 15 '*' 3\n45";
+            let (result, _) = agent.sanitize_tool_output(body, tool).await;
+            assert_ne!(
+                result, "[tool output blocked: injection detected by classifier]",
+                "'{tool}' output with shell metacharacters must bypass the ML classifier (#3547)"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Added `"bash"` and `"shell"` to `INTERNAL_TOOLS` in `sanitize.rs` so the DeBERTa ML classifier is bypassed for local shell tool output
- Regex-based injection detection continues to run unchanged
- The existing colon guard in `is_internal_tool()` prevents MCP tools (e.g. `mcp_server:bash`) from matching the allowlist

## Root Cause

The `ShellExecutor` formats bash output with a `$ <cmd>` prefix (e.g. `$ expr 15 '*' 3\n45`). The DeBERTa v3 prompt injection model overfits to this pattern when the command contains shell metacharacters, producing an INJECTION score of 0.9999 on entirely benign output.

## Test plan

- [ ] `cargo nextest run --config-file .github/nextest.toml -p zeph-core --lib` — 1311 tests pass
- [ ] New regression test `sanitize_tool_output_bash_tool_skips_ml_classifier` in `boundary_and_classifier_tests.rs` uses a `BlockedBackend` that always returns INJECTION/score=1.0; confirms both `"bash"` and `"shell"` bypass ML classification for input containing `$ expr 15 '*' 3\n45`
- [ ] `internal_tool_allowlist_covers_all_zeph_tools` updated to assert both names
- [ ] `external_and_mcp_tools_not_in_allowlist` retains colon-namespaced guard; `"shell"` removed from external list (it is now internal)

Closes #3547