### PR TITLE
feat(memory): wire optional Qdrant API key end-to-end

### DIFF
--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -49,6 +49,9 @@
 //! | `ZEPH_SQLITE_PATH` | `memory.sqlite_path` |
 //! | `ZEPH_QDRANT_URL` | `memory.qdrant_url` |
 //!
+//! The Qdrant API key is vault-only (not an env-var override):
+//! `zeph vault set ZEPH_QDRANT_API_KEY "<key>"` → `memory.qdrant_api_key`.
+//!
 //! # Config migration
 //!
 //! Use [`migrate::ConfigMigrator`] to upgrade existing TOML configs with newly-added

--- a/crates/zeph-config/src/memory.rs
+++ b/crates/zeph-config/src/memory.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use zeph_common::secret::Secret;
 
 use crate::defaults::{default_sqlite_path_field, default_true};
 use crate::providers::ProviderName;
@@ -703,6 +704,16 @@ pub struct MemoryConfig {
     pub history_limit: u32,
     #[serde(default = "default_qdrant_url")]
     pub qdrant_url: String,
+    /// Optional API key for authenticating to a remote or managed Qdrant cluster.
+    ///
+    /// Required when `qdrant_url` points to a non-localhost host (e.g. Qdrant Cloud).
+    /// Leave `None` for local dev instances. The actual key is resolved from the vault:
+    /// `zeph vault set ZEPH_QDRANT_API_KEY "<key>"`.
+    ///
+    /// The value is wrapped in [`Secret`] to prevent accidental logging.
+    /// `skip_serializing` prevents the key from being written back to TOML on config save.
+    #[serde(default, skip_serializing)]
+    pub qdrant_api_key: Option<Secret>,
     #[serde(default)]
     pub semantic: SemanticConfig,
     #[serde(default = "default_summarization_threshold")]

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -3066,6 +3066,43 @@ pub fn migrate_memory_persona_config(toml_src: &str) -> Result<MigrationResult, 
     })
 }
 
+/// No-op migration for the optional `qdrant_api_key` field added in #3543.
+///
+/// The field has `#[serde(default)]` so existing configs parse as `None` without changes.
+/// This step adds a commented-out hint under `[memory]` if not already present.
+///
+/// # Errors
+///
+/// Returns `MigrateError` if the TOML cannot be parsed or `[memory]` is malformed.
+pub fn migrate_qdrant_api_key(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    if toml_src.contains("qdrant_api_key") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let mut doc = toml_src.parse::<toml_edit::DocumentMut>()?;
+
+    if !doc.contains_key("memory") {
+        doc.insert("memory", toml_edit::Item::Table(toml_edit::Table::new()));
+    }
+
+    let comment = "\n# Qdrant API key (optional; required when connecting to remote/managed Qdrant clusters).\n\
+         # Leave empty for local Qdrant instances. Store the actual key in the vault:\n\
+         #   zeph vault set ZEPH_QDRANT_API_KEY \"<key>\"\n\
+         # qdrant_api_key = \"\"\n";
+    let raw = doc.to_string();
+    let output = format!("{raw}{comment}");
+
+    Ok(MigrationResult {
+        output,
+        changed_count: 1,
+        sections_changed: vec!["memory.qdrant_api_key".to_owned()],
+    })
+}
+
 // ── Migration trait and registry ────────────────────────────────────────────────────────────────
 
 /// A single idempotent config migration step.
@@ -3114,13 +3151,13 @@ use steps::{
     MigrateMemoryHebbianConsolidation, MigrateMemoryHebbianSpread, MigrateMemoryPersonaConfig,
     MigrateMemoryReasoning, MigrateMemoryReasoningJudge, MigrateMemoryRetrieval,
     MigrateMemoryRetrievalQueryBias, MigrateMicrocompactConfig, MigrateOrchestrationPersistence,
-    MigrateOtelFilter, MigratePlannerModelToProvider, MigrateQualityConfig, MigrateSandboxConfig,
-    MigrateSandboxEgressFilter, MigrateSchedulerDaemon, MigrateSessionProviderPersistence,
-    MigrateSessionRecapConfig, MigrateShellTransactional, MigrateSttToProvider,
-    MigrateSupervisorConfig, MigrateTelemetryConfig, MigrateVigilConfig,
+    MigrateOtelFilter, MigratePlannerModelToProvider, MigrateQdrantApiKey, MigrateQualityConfig,
+    MigrateSandboxConfig, MigrateSandboxEgressFilter, MigrateSchedulerDaemon,
+    MigrateSessionProviderPersistence, MigrateSessionRecapConfig, MigrateShellTransactional,
+    MigrateSttToProvider, MigrateSupervisorConfig, MigrateTelemetryConfig, MigrateVigilConfig,
 };
 
-/// Ordered registry of all sequential migration steps (steps 1–38).
+/// Ordered registry of all sequential migration steps (steps 1–39).
 ///
 /// Each entry wraps the corresponding free function and is evaluated lazily at first access.
 /// The ordering is chronological; the dispatch loop in `src/commands/migrate.rs` iterates
@@ -3180,6 +3217,8 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             Box::new(MigrateSessionProviderPersistence),
             Box::new(MigrateMemoryRetrievalQueryBias),
             Box::new(MigrateMemoryPersonaConfig),
+            // Step 39 — optional Qdrant API key (#3543)
+            Box::new(MigrateQdrantApiKey),
         ]
     });
 
@@ -3198,8 +3237,8 @@ mod tests {
     fn migrations_registry_has_all_steps() {
         assert_eq!(
             MIGRATIONS.len(),
-            38,
-            "MIGRATIONS registry must contain all 38 sequential steps"
+            39,
+            "MIGRATIONS registry must contain all 39 sequential steps"
         );
         for m in MIGRATIONS.iter() {
             assert!(
@@ -4785,8 +4824,8 @@ prompt_cache_ttl = "1h"
     // ── Migration registry ────────────────────────────────────────────────────
 
     #[test]
-    fn registry_has_thirty_eight_entries() {
-        assert_eq!(MIGRATIONS.len(), 38);
+    fn registry_has_thirty_nine_entries() {
+        assert_eq!(MIGRATIONS.len(), 39);
     }
 
     #[test]
@@ -4825,7 +4864,7 @@ prompt_cache_ttl = "1h"
 
     #[test]
     fn registry_preserves_order_matches_dispatch() {
-        // Names must follow the documented step order (steps 1–38).
+        // Names must follow the documented step order (steps 1–39).
         let expected = [
             "migrate_stt_to_provider",
             "migrate_planner_model_to_provider",
@@ -4865,8 +4904,52 @@ prompt_cache_ttl = "1h"
             "migrate_session_provider_persistence",
             "migrate_memory_retrieval_query_bias",
             "migrate_memory_persona_config",
+            "migrate_qdrant_api_key",
         ];
         let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
         assert_eq!(actual, expected);
+    }
+
+    // ── migrate_qdrant_api_key tests (#3543) ─────────────────────────────────
+
+    #[test]
+    fn migrate_qdrant_api_key_adds_comment_when_absent() {
+        let src = "[memory]\nqdrant_url = \"http://localhost:6334\"\n";
+        let result = migrate_qdrant_api_key(src).expect("migrate");
+        assert_eq!(result.changed_count, 1);
+        assert!(
+            result
+                .sections_changed
+                .contains(&"memory.qdrant_api_key".to_owned())
+        );
+        assert!(result.output.contains("# qdrant_api_key = \"\""));
+    }
+
+    #[test]
+    fn migrate_qdrant_api_key_is_noop_when_present() {
+        let src =
+            "[memory]\nqdrant_url = \"https://xyz.cloud.qdrant.io\"\nqdrant_api_key = \"secret\"\n";
+        let result = migrate_qdrant_api_key(src).expect("migrate");
+        assert_eq!(result.changed_count, 0);
+        assert!(result.sections_changed.is_empty());
+        assert_eq!(result.output, src);
+    }
+
+    #[test]
+    fn migrate_qdrant_api_key_creates_memory_section_when_absent() {
+        let src = "[agent]\nname = \"Zeph\"\n";
+        let result = migrate_qdrant_api_key(src).expect("migrate");
+        assert_eq!(result.changed_count, 1);
+        assert!(result.output.contains("# qdrant_api_key = \"\""));
+    }
+
+    #[test]
+    fn migrate_qdrant_api_key_idempotent_on_commented_output() {
+        let base = "[memory]\nqdrant_url = \"http://localhost:6334\"\n";
+        let first = migrate_qdrant_api_key(base).unwrap();
+        assert_eq!(first.changed_count, 1);
+        let second = migrate_qdrant_api_key(&first.output).unwrap();
+        assert_eq!(second.changed_count, 0, "second run must not double-append");
+        assert_eq!(second.output, first.output);
     }
 }

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -22,10 +22,11 @@ use super::{
     migrate_memory_reasoning_judge_config, migrate_memory_retrieval_config,
     migrate_memory_retrieval_query_bias, migrate_microcompact_config,
     migrate_orchestration_persistence, migrate_otel_filter, migrate_planner_model_to_provider,
-    migrate_quality_config, migrate_sandbox_config, migrate_sandbox_egress_filter,
-    migrate_scheduler_daemon_config, migrate_session_provider_persistence,
-    migrate_session_recap_config, migrate_shell_transactional, migrate_stt_to_provider,
-    migrate_supervisor_config, migrate_telemetry_config, migrate_vigil_config,
+    migrate_qdrant_api_key, migrate_quality_config, migrate_sandbox_config,
+    migrate_sandbox_egress_filter, migrate_scheduler_daemon_config,
+    migrate_session_provider_persistence, migrate_session_recap_config,
+    migrate_shell_transactional, migrate_stt_to_provider, migrate_supervisor_config,
+    migrate_telemetry_config, migrate_vigil_config,
 };
 
 // ── Wrapper structs for all 35 sequential migration steps ───────────────────────────────────────
@@ -445,5 +446,16 @@ impl Migration for MigrateMemoryPersonaConfig {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_memory_persona_config(toml_src)
+    }
+}
+
+pub(super) struct MigrateQdrantApiKey;
+impl Migration for MigrateQdrantApiKey {
+    fn name(&self) -> &'static str {
+        "migrate_qdrant_api_key"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_qdrant_api_key(toml_src)
     }
 }

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -207,6 +207,7 @@ impl Default for Config {
                 sqlite_path: default_sqlite_path_field(),
                 history_limit: 50,
                 qdrant_url: "http://localhost:6334".into(),
+                qdrant_api_key: None,
                 semantic: SemanticConfig::default(),
                 summarization_threshold: 50,
                 context_budget_tokens: 0,

--- a/crates/zeph-core/src/agent/context/summarization/compaction.rs
+++ b/crates/zeph-core/src/agent/context/summarization/compaction.rs
@@ -151,6 +151,7 @@ mod tests {
         let memory = SemanticMemory::new(
             ":memory:",
             "http://127.0.0.1:1",
+            None,
             embed_provider,
             "test-model",
         )
@@ -207,6 +208,7 @@ mod tests {
         let memory = SemanticMemory::new(
             ":memory:",
             "http://127.0.0.1:1",
+            None,
             embed_provider,
             "test-model",
         )
@@ -274,6 +276,7 @@ mod tests {
         let memory = SemanticMemory::new(
             ":memory:",
             "http://127.0.0.1:1",
+            None,
             embed_provider,
             "test-model",
         )

--- a/crates/zeph-core/src/agent/context/tests/chunk_skill_compaction_tests.rs
+++ b/crates/zeph-core/src/agent/context/tests/chunk_skill_compaction_tests.rs
@@ -19,7 +19,7 @@ async fn create_memory_with_summaries(
     provider: zeph_llm::any::AnyProvider,
     summaries: &[&str],
 ) -> (SemanticMemory, zeph_memory::ConversationId) {
-    let memory = SemanticMemory::new(":memory:", "http://127.0.0.1:1", provider, "test")
+    let memory = SemanticMemory::new(":memory:", "http://127.0.0.1:1", None, provider, "test")
         .await
         .unwrap();
     let cid = memory.sqlite().create_conversation().await.unwrap();

--- a/crates/zeph-core/src/agent/context/tests/prompt_tooling_summary_tests.rs
+++ b/crates/zeph-core/src/agent/context/tests/prompt_tooling_summary_tests.rs
@@ -69,6 +69,7 @@ async fn build_graph_memory() -> zeph_memory::semantic::SemanticMemory {
     let mem = zeph_memory::semantic::SemanticMemory::new(
         ":memory:",
         "http://127.0.0.1:1",
+        None,
         AnyProvider::Mock(zeph_llm::mock::MockProvider::default()),
         "test-model",
     )

--- a/crates/zeph-core/src/agent/context/tests/prune_summarize_disambiguate_tests.rs
+++ b/crates/zeph-core/src/agent/context/tests/prune_summarize_disambiguate_tests.rs
@@ -20,7 +20,7 @@ async fn create_memory_with_summaries(
     provider: zeph_llm::any::AnyProvider,
     summaries: &[&str],
 ) -> (SemanticMemory, zeph_memory::ConversationId) {
-    let memory = SemanticMemory::new(":memory:", "http://127.0.0.1:1", provider, "test")
+    let memory = SemanticMemory::new(":memory:", "http://127.0.0.1:1", None, provider, "test")
         .await
         .unwrap();
     let cid = memory.sqlite().create_conversation().await.unwrap();

--- a/crates/zeph-core/src/agent/learning/tests.rs
+++ b/crates/zeph-core/src/agent/learning/tests.rs
@@ -16,9 +16,15 @@ use zeph_skills::registry::SkillRegistry;
 
 async fn test_memory() -> SemanticMemory {
     let provider = AnyProvider::Mock(zeph_llm::mock::MockProvider::default());
-    SemanticMemory::new(":memory:", "http://127.0.0.1:1", provider, "test-model")
-        .await
-        .unwrap()
+    SemanticMemory::new(
+        ":memory:",
+        "http://127.0.0.1:1",
+        None,
+        provider,
+        "test-model",
+    )
+    .await
+    .unwrap()
 }
 
 /// Creates a registry with a "test-skill" and returns both the registry and the `TempDir`.

--- a/crates/zeph-core/src/agent/persistence.rs
+++ b/crates/zeph-core/src/agent/persistence.rs
@@ -746,6 +746,7 @@ mod tests {
         SemanticMemory::new(
             ":memory:",
             "http://127.0.0.1:1",
+            None,
             provider.clone(),
             "test-model",
         )

--- a/crates/zeph-core/src/agent/tests/agent_tests/model_help_status_exit_tests.rs
+++ b/crates/zeph-core/src/agent/tests/agent_tests/model_help_status_exit_tests.rs
@@ -503,9 +503,15 @@ async fn bare_image_command_sends_usage() {
 #[tokio::test]
 async fn feedback_positive_records_user_approval() {
     let provider = mock_provider(vec![]);
-    let memory = SemanticMemory::new(":memory:", "http://127.0.0.1:1", provider.clone(), "test")
-        .await
-        .unwrap();
+    let memory = SemanticMemory::new(
+        ":memory:",
+        "http://127.0.0.1:1",
+        None,
+        provider.clone(),
+        "test",
+    )
+    .await
+    .unwrap();
     let cid = memory.sqlite().create_conversation().await.unwrap();
     let memory = std::sync::Arc::new(memory);
 
@@ -540,9 +546,15 @@ async fn feedback_positive_records_user_approval() {
 #[tokio::test]
 async fn feedback_negative_records_user_rejection() {
     let provider = mock_provider(vec![]);
-    let memory = SemanticMemory::new(":memory:", "http://127.0.0.1:1", provider.clone(), "test")
-        .await
-        .unwrap();
+    let memory = SemanticMemory::new(
+        ":memory:",
+        "http://127.0.0.1:1",
+        None,
+        provider.clone(),
+        "test",
+    )
+    .await
+    .unwrap();
     let cid = memory.sqlite().create_conversation().await.unwrap();
     let memory = std::sync::Arc::new(memory);
 
@@ -577,9 +589,15 @@ async fn feedback_negative_records_user_rejection() {
 #[tokio::test]
 async fn feedback_neutral_records_user_approval() {
     let provider = mock_provider(vec![]);
-    let memory = SemanticMemory::new(":memory:", "http://127.0.0.1:1", provider.clone(), "test")
-        .await
-        .unwrap();
+    let memory = SemanticMemory::new(
+        ":memory:",
+        "http://127.0.0.1:1",
+        None,
+        provider.clone(),
+        "test",
+    )
+    .await
+    .unwrap();
     let cid = memory.sqlite().create_conversation().await.unwrap();
     let memory = std::sync::Arc::new(memory);
 

--- a/crates/zeph-core/src/agent/tests/flush_orphaned_tests.rs
+++ b/crates/zeph-core/src/agent/tests/flush_orphaned_tests.rs
@@ -11,9 +11,15 @@ use crate::agent::agent_tests::{
 
 async fn flush_test_memory() -> SemanticMemory {
     let provider = AnyProvider::Mock(zeph_llm::mock::MockProvider::default());
-    SemanticMemory::new(":memory:", "http://127.0.0.1:1", provider, "test-model")
-        .await
-        .unwrap()
+    SemanticMemory::new(
+        ":memory:",
+        "http://127.0.0.1:1",
+        None,
+        provider,
+        "test-model",
+    )
+    .await
+    .unwrap()
 }
 
 /// FO1: no-op when the message list has no assistant message.

--- a/crates/zeph-core/src/agent/tests/shutdown_summary_tests.rs
+++ b/crates/zeph-core/src/agent/tests/shutdown_summary_tests.rs
@@ -83,6 +83,7 @@ async fn shutdown_summary_too_few_user_messages_skips_llm() {
     let memory = SemanticMemory::new(
         ":memory:",
         "http://127.0.0.1:1",
+        None,
         AnyProvider::Mock(MockProvider::default()),
         "test-model",
     )
@@ -137,6 +138,7 @@ async fn shutdown_summary_only_counts_user_role_messages() {
     let memory = SemanticMemory::new(
         ":memory:",
         "http://127.0.0.1:1",
+        None,
         AnyProvider::Mock(MockProvider::default()),
         "test-model",
     )
@@ -536,10 +538,15 @@ async fn correction_stored_when_learning_disabled() {
 
     let mock = MockProvider::default();
     let provider = AnyProvider::Mock(mock);
-    let memory: SemanticMemory =
-        SemanticMemory::new(":memory:", "http://127.0.0.1:1", provider, "test-model")
-            .await
-            .expect("in-memory SQLite must init");
+    let memory: SemanticMemory = SemanticMemory::new(
+        ":memory:",
+        "http://127.0.0.1:1",
+        None,
+        provider,
+        "test-model",
+    )
+    .await
+    .expect("in-memory SQLite must init");
     let memory = Arc::new(memory);
 
     let agent_provider = mock_provider(vec![]);

--- a/crates/zeph-core/src/agent/tool_execution/tests/sanitize_and_native_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/sanitize_and_native_tests.rs
@@ -462,6 +462,7 @@ async fn sanitize_tool_output_text_only_injection_guards_memory_write() {
     let memory = SemanticMemory::new(
         ":memory:",
         "http://127.0.0.1:1",
+        None,
         zeph_llm::any::AnyProvider::Mock(zeph_llm::mock::MockProvider::default()),
         "test-model",
     )

--- a/crates/zeph-core/src/config.rs
+++ b/crates/zeph-core/src/config.rs
@@ -76,6 +76,9 @@ pub trait SecretResolver {
     ) -> impl std::future::Future<Output = Result<(), ConfigError>> + Send;
 }
 
+// TODO(critic): vault values are inserted verbatim into typed config fields.
+// Consider centralizing whitespace trimming and empty-string normalization
+// here so every consumer (qdrant client, claude, openai, etc.) sees a clean value.
 impl SecretResolver for Config {
     async fn resolve_secrets(&mut self, vault: &dyn VaultProvider) -> Result<(), ConfigError> {
         if let Some(val) = vault.get_secret("ZEPH_CLAUDE_API_KEY").await? {
@@ -118,6 +121,9 @@ impl SecretResolver for Config {
         }
         if let Some(val) = vault.get_secret("ZEPH_DATABASE_URL").await? {
             self.memory.database_url = Some(val);
+        }
+        if let Some(val) = vault.get_secret("ZEPH_QDRANT_API_KEY").await? {
+            self.memory.qdrant_api_key = Some(Secret::new(val));
         }
         if let Some(val) = vault.get_secret("ZEPH_DISCORD_TOKEN").await?
             && let Some(dc) = self.discord.as_mut()

--- a/crates/zeph-index/src/indexer.rs
+++ b/crates/zeph-index/src/indexer.rs
@@ -764,7 +764,7 @@ mod tests {
             .unwrap();
         }
 
-        let ops = QdrantOps::new("http://127.0.0.1:1").unwrap();
+        let ops = QdrantOps::new("http://127.0.0.1:1", None).unwrap();
         let store = crate::store::CodeStore::with_ops(ops, pool);
         let provider = Arc::new(AnyProvider::Mock(
             MockProvider::default().with_embedding(vec![0.0_f32; 384]),
@@ -825,7 +825,7 @@ mod tests {
         .await
         .unwrap();
 
-        let ops = QdrantOps::new("http://127.0.0.1:1").unwrap();
+        let ops = QdrantOps::new("http://127.0.0.1:1", None).unwrap();
         let store = crate::store::CodeStore::with_ops(ops, pool);
         let provider = Arc::new(AnyProvider::Mock(
             MockProvider::default().with_embedding(vec![0.0_f32; 384]),

--- a/crates/zeph-index/src/store.rs
+++ b/crates/zeph-index/src/store.rs
@@ -111,7 +111,7 @@ impl CodeStore {
     /// # async fn example() -> zeph_index::Result<()> {
     /// # let pool: zeph_db::DbPool = panic!("placeholder");
     ///
-    /// let ops = QdrantOps::new("http://localhost:6334").unwrap();
+    /// let ops = QdrantOps::new("http://localhost:6334", None).unwrap();
     /// let store = CodeStore::with_ops(ops, pool);
     /// store.ensure_collection(1536).await?;
     /// # Ok(())
@@ -717,7 +717,7 @@ mod tests {
     #[tokio::test]
     async fn existing_hashes_empty_input_returns_empty_set() {
         let pool = setup_pool().await;
-        let ops = zeph_memory::QdrantOps::new("http://127.0.0.1:1").unwrap();
+        let ops = zeph_memory::QdrantOps::new("http://127.0.0.1:1", None).unwrap();
         let store = CodeStore::with_ops(ops, pool);
         let result = store.existing_hashes(&[]).await.unwrap();
         assert!(result.is_empty());
@@ -749,7 +749,7 @@ mod tests {
         let all_hashes: Vec<String> = (0..901).map(|i| format!("hash{i:04}")).collect();
         let refs: Vec<&str> = all_hashes.iter().map(String::as_str).collect();
 
-        let ops = zeph_memory::QdrantOps::new("http://127.0.0.1:1").unwrap();
+        let ops = zeph_memory::QdrantOps::new("http://127.0.0.1:1", None).unwrap();
         let store = CodeStore::with_ops(ops, pool);
         let result = store.existing_hashes(&refs).await.unwrap();
 

--- a/crates/zeph-index/src/watcher.rs
+++ b/crates/zeph-index/src/watcher.rs
@@ -202,7 +202,7 @@ mod tests {
     }
 
     async fn create_test_indexer() -> Arc<CodeIndexer> {
-        let ops = QdrantOps::new("http://localhost:6334").unwrap();
+        let ops = QdrantOps::new("http://localhost:6334", None).unwrap();
         let store = crate::store::CodeStore::with_ops(ops, create_test_pool().await);
         let provider = AnyProvider::Ollama(OllamaProvider::new(
             "http://127.0.0.1:1",

--- a/crates/zeph-mcp/src/registry.rs
+++ b/crates/zeph-mcp/src/registry.rs
@@ -101,7 +101,7 @@ fn compute_hash(tool: &McpTool) -> String {
 /// use zeph_memory::QdrantOps;
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// let ops = QdrantOps::new("http://localhost:6334")?;
+/// let ops = QdrantOps::new("http://localhost:6334", None)?;
 /// let mut registry = McpToolRegistry::with_ops(ops);
 /// // Sync tools after connect_all():
 /// // registry.sync(&tools, "nomic-embed-text", embed_fn).await?;
@@ -316,7 +316,7 @@ mod tests {
     }
 
     fn make_registry(url: &str) -> McpToolRegistry {
-        let ops = QdrantOps::new(url).unwrap();
+        let ops = QdrantOps::new(url, None).unwrap();
         McpToolRegistry::with_ops(ops)
     }
 

--- a/crates/zeph-memory/src/document/pipeline.rs
+++ b/crates/zeph-memory/src/document/pipeline.rs
@@ -119,7 +119,7 @@ mod tests {
     async fn ingest_empty_document_returns_zero() {
         // Empty document should short-circuit before calling Qdrant.
         // We use an invalid Qdrant URL; the early-return path won't reach it.
-        let qdrant = crate::QdrantOps::new("http://127.0.0.1:1").unwrap();
+        let qdrant = crate::QdrantOps::new("http://127.0.0.1:1", None).unwrap();
         let splitter = TextSplitter::new(SplitterConfig::default());
         let pipeline = IngestionPipeline::new(splitter, qdrant, "col", noop_embed());
 
@@ -131,7 +131,7 @@ mod tests {
     #[tokio::test]
     async fn ingest_document_embedding_error_propagates() {
         // Embedding failure should return DocumentError without reaching Qdrant.
-        let qdrant = crate::QdrantOps::new("http://127.0.0.1:1").unwrap();
+        let qdrant = crate::QdrantOps::new("http://127.0.0.1:1", None).unwrap();
         let splitter = TextSplitter::new(SplitterConfig::default());
         let pipeline = IngestionPipeline::new(splitter, qdrant, "col", error_embed());
 

--- a/crates/zeph-memory/src/embedding_registry.rs
+++ b/crates/zeph-memory/src/embedding_registry.rs
@@ -667,7 +667,7 @@ mod tests {
 
     #[test]
     fn registry_new_valid_url() {
-        let ops = QdrantOps::new("http://localhost:6334").unwrap();
+        let ops = QdrantOps::new("http://localhost:6334", None).unwrap();
         let ns = uuid::Uuid::from_bytes([0u8; 16]);
         let reg = EmbeddingRegistry::new(ops, "test_col", ns);
         let dbg = format!("{reg:?}");
@@ -718,7 +718,7 @@ mod tests {
 
     #[tokio::test]
     async fn search_raw_embed_fail_returns_error() {
-        let ops = QdrantOps::new("http://localhost:6334").unwrap();
+        let ops = QdrantOps::new("http://localhost:6334", None).unwrap();
         let ns = uuid::Uuid::from_bytes([0u8; 16]);
         let reg = EmbeddingRegistry::new(ops, "test", ns);
         let embed_fn = |_: &str| -> EmbedFuture {
@@ -738,7 +738,7 @@ mod tests {
     /// issuing a gRPC search that would silently return near-zero cosine scores.
     #[tokio::test]
     async fn search_raw_dimension_mismatch_returns_error() {
-        let ops = QdrantOps::new("http://localhost:6334").unwrap();
+        let ops = QdrantOps::new("http://localhost:6334", None).unwrap();
         let ns = uuid::Uuid::from_bytes([0u8; 16]);
         let reg = EmbeddingRegistry::new(ops, "test_dim_guard", ns);
 
@@ -760,7 +760,7 @@ mod tests {
     /// the error (if any) comes from the Qdrant network call — not from the guard itself.
     #[tokio::test]
     async fn search_raw_matching_dimension_passes_guard() {
-        let ops = QdrantOps::new("http://127.0.0.1:1").unwrap(); // unreachable — forces network error
+        let ops = QdrantOps::new("http://127.0.0.1:1", None).unwrap(); // unreachable — forces network error
         let ns = uuid::Uuid::from_bytes([0u8; 16]);
         let reg = EmbeddingRegistry::new(ops, "test_dim_pass", ns);
 
@@ -779,7 +779,7 @@ mod tests {
 
     #[tokio::test]
     async fn sync_with_unreachable_qdrant_fails() {
-        let ops = QdrantOps::new("http://127.0.0.1:1").unwrap();
+        let ops = QdrantOps::new("http://127.0.0.1:1", None).unwrap();
         let ns = uuid::Uuid::from_bytes([0u8; 16]);
         let mut reg = EmbeddingRegistry::new(ops, "test", ns);
         let items = vec![make_item("k", "text")];
@@ -845,7 +845,7 @@ mod tests {
 
     #[test]
     fn concurrency_zero_clamped_to_one() {
-        let ops = QdrantOps::new("http://localhost:6334").unwrap();
+        let ops = QdrantOps::new("http://localhost:6334", None).unwrap();
         let ns = uuid::Uuid::from_bytes([0u8; 16]);
         let mut reg = EmbeddingRegistry::new(ops, "test", ns);
         reg.concurrency = 0;
@@ -876,7 +876,7 @@ mod tests {
             .await
             .unwrap();
         let port = container.get_host_port_ipv4(6334).await.unwrap();
-        let ops = QdrantOps::new(&format!("http://127.0.0.1:{port}")).unwrap();
+        let ops = QdrantOps::new(&format!("http://127.0.0.1:{port}"), None).unwrap();
         let ns = uuid::Uuid::new_v4();
         let mut reg = EmbeddingRegistry::new(ops, "test_progress", ns);
 
@@ -932,7 +932,7 @@ mod tests {
             .await
             .unwrap();
         let port = container.get_host_port_ipv4(6334).await.unwrap();
-        let ops = QdrantOps::new(&format!("http://127.0.0.1:{port}")).unwrap();
+        let ops = QdrantOps::new(&format!("http://127.0.0.1:{port}"), None).unwrap();
         let ns = uuid::Uuid::new_v4();
         let mut reg = EmbeddingRegistry::new(ops, "test_partial", ns);
 
@@ -985,7 +985,7 @@ mod tests {
             .await
             .unwrap();
         let port = container.get_host_port_ipv4(6334).await.unwrap();
-        let ops = QdrantOps::new(&format!("http://127.0.0.1:{port}")).unwrap();
+        let ops = QdrantOps::new(&format!("http://127.0.0.1:{port}"), None).unwrap();
         let ns = uuid::Uuid::new_v4();
         let mut reg = EmbeddingRegistry::new(ops, "test_dim_guard_live", ns);
 

--- a/crates/zeph-memory/src/embedding_store.rs
+++ b/crates/zeph-memory/src/embedding_store.rs
@@ -59,7 +59,7 @@ pub async fn ensure_qdrant_collection(
 
 /// Typed wrapper over a [`VectorStore`] backend for conversation message embeddings.
 ///
-/// Constructed via [`EmbeddingStore::new`] (Qdrant URL) or
+/// Constructed via [`EmbeddingStore::new`] (Qdrant URL + optional API key) or
 /// [`EmbeddingStore::with_store`] (custom backend for testing).
 pub struct EmbeddingStore {
     ops: Box<dyn VectorStore>,
@@ -99,16 +99,17 @@ pub struct SearchResult {
 }
 
 impl EmbeddingStore {
-    /// Create a new `EmbeddingStore` connected to the given Qdrant URL.
+    /// Create a new `EmbeddingStore` connected to the given Qdrant URL with optional API key.
     ///
-    /// The `pool` is used for `SQLite` metadata operations on the `embeddings_metadata`
-    /// table (which must already exist via sqlx migrations).
+    /// `api_key` is forwarded to [`QdrantOps::new`]. The `pool` is used for `SQLite` metadata
+    /// operations on the `embeddings_metadata` table (which must already exist via sqlx
+    /// migrations).
     ///
     /// # Errors
     ///
     /// Returns an error if the Qdrant client cannot be created.
-    pub fn new(url: &str, pool: DbPool) -> Result<Self, MemoryError> {
-        let ops = QdrantOps::new(url).map_err(MemoryError::Qdrant)?;
+    pub fn new(url: &str, api_key: Option<&str>, pool: DbPool) -> Result<Self, MemoryError> {
+        let ops = QdrantOps::new(url, api_key).map_err(MemoryError::Qdrant)?;
 
         Ok(Self {
             ops: Box::new(ops),

--- a/crates/zeph-memory/src/qdrant_ops.rs
+++ b/crates/zeph-memory/src/qdrant_ops.rs
@@ -33,17 +33,24 @@ impl std::fmt::Debug for QdrantOps {
 }
 
 impl QdrantOps {
-    /// Create a new `QdrantOps` connected to the given URL.
+    /// Create a new `QdrantOps` connected to the given URL with optional API key.
+    ///
+    /// When `api_key` is `Some(k)` and `k` is non-empty, the key is attached to the gRPC
+    /// client builder. Empty strings are treated as `None` so callers can pass empty config
+    /// values without accidentally disabling auth.
+    ///
+    /// The key is consumed by `qdrant-client` during `.build()` and is never stored on
+    /// `QdrantOps` itself.
     ///
     /// # Errors
     ///
-    /// Returns an error if the Qdrant client cannot be created.
-    // TODO(critic, #3543): wire optional Qdrant API key end-to-end (MemoryConfig field,
-    // vault key ZEPH_QDRANT_API_KEY, bootstrap resolution, init wizard prompt,
-    // EmbeddingStore mirror, --migrate-config step, WARN log on non-localhost without key,
-    // playbook + coverage-status). Tracked separately from the todo-cleanup epic.
-    pub fn new(url: &str) -> QdrantResult<Self> {
-        let client = Qdrant::from_url(url).build().map_err(Box::new)?;
+    /// Returns an error if the Qdrant client cannot be created (e.g. malformed URL).
+    pub fn new(url: &str, api_key: Option<&str>) -> QdrantResult<Self> {
+        let mut builder = Qdrant::from_url(url);
+        if let Some(key) = api_key.filter(|k| !k.trim().is_empty()) {
+            builder = builder.api_key(key.trim());
+        }
+        let client = builder.build().map_err(Box::new)?;
         Ok(Self { client })
     }
 
@@ -605,19 +612,44 @@ mod tests {
 
     #[test]
     fn new_valid_url() {
-        let ops = QdrantOps::new("http://localhost:6334");
+        let ops = QdrantOps::new("http://localhost:6334", None);
         assert!(ops.is_ok());
     }
 
     #[test]
     fn new_invalid_url() {
-        let ops = QdrantOps::new("not a valid url");
+        let ops = QdrantOps::new("not a valid url", None);
         assert!(ops.is_err());
+    }
+
+    /// Empty `api_key` must be silently treated as `None` — the whitespace guard in
+    /// `QdrantOps::new` must not panic and the client must be built successfully.
+    #[test]
+    fn new_empty_api_key_is_treated_as_none() {
+        let result = QdrantOps::new("http://127.0.0.1:9999", Some(""));
+        assert!(result.is_ok(), "empty key must not cause a build error");
+    }
+
+    /// Whitespace-only keys must be dropped the same way as empty keys.
+    #[test]
+    fn new_whitespace_api_key_is_treated_as_none() {
+        let result = QdrantOps::new("http://127.0.0.1:9999", Some("   "));
+        assert!(
+            result.is_ok(),
+            "whitespace-only key must not cause a build error"
+        );
+    }
+
+    /// A non-empty, non-whitespace key must be accepted without errors.
+    #[test]
+    fn new_with_api_key_constructs_successfully() {
+        let result = QdrantOps::new("http://127.0.0.1:9999", Some("valid-key"));
+        assert!(result.is_ok(), "valid key must not cause a build error");
     }
 
     #[test]
     fn debug_format() {
-        let ops = QdrantOps::new("http://localhost:6334").unwrap();
+        let ops = QdrantOps::new("http://localhost:6334", None).unwrap();
         let dbg = format!("{ops:?}");
         assert!(dbg.contains("QdrantOps"));
     }
@@ -641,7 +673,7 @@ mod tests {
         // Constructing QdrantOps with a valid URL succeeds even without a live server.
         // delete_by_ids with empty list short-circuits before any network call.
         // We validate the early-return logic via the async test below.
-        let ops = QdrantOps::new("http://localhost:6334");
+        let ops = QdrantOps::new("http://localhost:6334", None);
         assert!(ops.is_ok());
     }
 
@@ -649,7 +681,7 @@ mod tests {
     #[tokio::test]
     #[ignore = "requires a live Qdrant instance at localhost:6334"]
     async fn ensure_collection_with_quantization_idempotent() {
-        let ops = QdrantOps::new("http://localhost:6334").unwrap();
+        let ops = QdrantOps::new("http://localhost:6334", None).unwrap();
         let collection = "test_quant_idempotent";
 
         // Clean up from any prior run
@@ -675,7 +707,7 @@ mod tests {
     #[tokio::test]
     #[ignore = "requires a live Qdrant instance at localhost:6334"]
     async fn delete_by_ids_empty_no_network_call() {
-        let ops = QdrantOps::new("http://localhost:6334").unwrap();
+        let ops = QdrantOps::new("http://localhost:6334", None).unwrap();
         // Empty ID list must short-circuit and return Ok without hitting Qdrant.
         let result = ops.delete_by_ids("nonexistent_collection", vec![]).await;
         assert!(result.is_ok());
@@ -685,7 +717,7 @@ mod tests {
     #[tokio::test]
     #[ignore = "requires a live Qdrant instance at localhost:6334"]
     async fn ensure_collection_idempotent_same_size() {
-        let ops = QdrantOps::new("http://localhost:6334").unwrap();
+        let ops = QdrantOps::new("http://localhost:6334", None).unwrap();
         let collection = "test_ensure_idempotent";
 
         let _ = ops.delete_collection(collection).await;
@@ -707,7 +739,7 @@ mod tests {
     #[tokio::test]
     #[ignore = "requires a live Qdrant instance at localhost:6334"]
     async fn ensure_collection_recreates_on_dimension_mismatch() {
-        let ops = QdrantOps::new("http://localhost:6334").unwrap();
+        let ops = QdrantOps::new("http://localhost:6334", None).unwrap();
         let collection = "test_dim_mismatch";
 
         let _ = ops.delete_collection(collection).await;
@@ -736,7 +768,7 @@ mod tests {
     #[tokio::test]
     #[ignore = "requires a live Qdrant instance at localhost:6334"]
     async fn ensure_collection_with_quantization_recreates_on_dimension_mismatch() {
-        let ops = QdrantOps::new("http://localhost:6334").unwrap();
+        let ops = QdrantOps::new("http://localhost:6334", None).unwrap();
         let collection = "test_quant_dim_mismatch";
 
         let _ = ops.delete_collection(collection).await;

--- a/crates/zeph-memory/src/semantic/cross_session.rs
+++ b/crates/zeph-memory/src/semantic/cross_session.rs
@@ -204,6 +204,7 @@ mod tests {
         SemanticMemory::new(
             ":memory:",
             "http://127.0.0.1:1",
+            None,
             AnyProvider::Mock(MockProvider::default()),
             "test-model",
         )

--- a/crates/zeph-memory/src/semantic/mod.rs
+++ b/crates/zeph-memory/src/semantic/mod.rs
@@ -363,10 +363,20 @@ impl SemanticMemory {
     pub async fn new(
         sqlite_path: &str,
         qdrant_url: &str,
+        api_key: Option<&str>,
         provider: AnyProvider,
         embedding_model: &str,
     ) -> Result<Self, MemoryError> {
-        Self::with_weights(sqlite_path, qdrant_url, provider, embedding_model, 0.7, 0.3).await
+        Self::with_weights(
+            sqlite_path,
+            qdrant_url,
+            api_key,
+            provider,
+            embedding_model,
+            0.7,
+            0.3,
+        )
+        .await
     }
 
     /// Create a new `SemanticMemory` with custom vector/keyword weights for hybrid search.
@@ -380,6 +390,7 @@ impl SemanticMemory {
     pub async fn with_weights(
         sqlite_path: &str,
         qdrant_url: &str,
+        api_key: Option<&str>,
         provider: AnyProvider,
         embedding_model: &str,
         vector_weight: f64,
@@ -388,6 +399,7 @@ impl SemanticMemory {
         Self::with_weights_and_pool_size(
             sqlite_path,
             qdrant_url,
+            api_key,
             provider,
             embedding_model,
             vector_weight,
@@ -405,9 +417,11 @@ impl SemanticMemory {
     /// # Errors
     ///
     /// Returns an error if `SQLite` cannot be initialized.
+    #[allow(clippy::too_many_arguments)]
     pub async fn with_weights_and_pool_size(
         sqlite_path: &str,
         qdrant_url: &str,
+        api_key: Option<&str>,
         provider: AnyProvider,
         embedding_model: &str,
         vector_weight: f64,
@@ -417,7 +431,7 @@ impl SemanticMemory {
         let sqlite = SqliteStore::with_pool_size(sqlite_path, pool_size).await?;
         let pool = sqlite.pool().clone();
 
-        let qdrant = match EmbeddingStore::new(qdrant_url, pool) {
+        let qdrant = match EmbeddingStore::new(qdrant_url, api_key, pool) {
             Ok(store) => Some(Arc::new(store)),
             Err(e) => {
                 tracing::warn!("Qdrant unavailable, semantic search disabled: {e:#}");

--- a/crates/zeph-memory/src/semantic/tests/mod.rs
+++ b/crates/zeph-memory/src/semantic/tests/mod.rs
@@ -72,7 +72,7 @@ pub(super) async fn test_semantic_memory(_supports_embeddings: bool) -> Semantic
 
 #[tokio::test]
 async fn with_qdrant_ops_constructs_successfully() {
-    let ops = crate::QdrantOps::new("http://127.0.0.1:1").unwrap();
+    let ops = crate::QdrantOps::new("http://127.0.0.1:1", None).unwrap();
     let provider = test_provider();
     let result =
         SemanticMemory::with_qdrant_ops(":memory:", ops, provider, "test-model", 0.7, 0.3, 1).await;
@@ -423,8 +423,14 @@ async fn new_with_invalid_qdrant_url_graceful() {
     let mut mock = MockProvider::default();
     mock.supports_embeddings = true;
     let provider = AnyProvider::Mock(mock);
-    let result =
-        SemanticMemory::new(":memory:", "http://127.0.0.1:1", provider, "test-model").await;
+    let result = SemanticMemory::new(
+        ":memory:",
+        "http://127.0.0.1:1",
+        None,
+        provider,
+        "test-model",
+    )
+    .await;
     assert!(result.is_ok());
 }
 

--- a/crates/zeph-memory/tests/document_integration.rs
+++ b/crates/zeph-memory/tests/document_integration.rs
@@ -45,7 +45,7 @@ fn make_doc(content: &str) -> Document {
 async fn ingest_single_document() {
     let container = qdrant_image().start().await.unwrap();
     let port = container.get_host_port_ipv4(6334).await.unwrap();
-    let qdrant = QdrantOps::new(&format!("http://127.0.0.1:{port}")).unwrap();
+    let qdrant = QdrantOps::new(&format!("http://127.0.0.1:{port}"), None).unwrap();
     qdrant
         .ensure_collection(COLLECTION, VECTOR_SIZE)
         .await
@@ -73,7 +73,7 @@ async fn ingest_single_document() {
 async fn ingest_empty_document_returns_zero() {
     let container = qdrant_image().start().await.unwrap();
     let port = container.get_host_port_ipv4(6334).await.unwrap();
-    let qdrant = QdrantOps::new(&format!("http://127.0.0.1:{port}")).unwrap();
+    let qdrant = QdrantOps::new(&format!("http://127.0.0.1:{port}"), None).unwrap();
     qdrant
         .ensure_collection(COLLECTION, VECTOR_SIZE)
         .await
@@ -94,7 +94,7 @@ async fn ingest_empty_document_returns_zero() {
 async fn ingest_multi_chunk_document() {
     let container = qdrant_image().start().await.unwrap();
     let port = container.get_host_port_ipv4(6334).await.unwrap();
-    let qdrant = QdrantOps::new(&format!("http://127.0.0.1:{port}")).unwrap();
+    let qdrant = QdrantOps::new(&format!("http://127.0.0.1:{port}"), None).unwrap();
     qdrant
         .ensure_collection(COLLECTION, VECTOR_SIZE)
         .await
@@ -126,7 +126,7 @@ async fn ingest_multi_chunk_document() {
 async fn load_and_ingest_text_file() {
     let container = qdrant_image().start().await.unwrap();
     let port = container.get_host_port_ipv4(6334).await.unwrap();
-    let qdrant = QdrantOps::new(&format!("http://127.0.0.1:{port}")).unwrap();
+    let qdrant = QdrantOps::new(&format!("http://127.0.0.1:{port}"), None).unwrap();
     qdrant
         .ensure_collection(COLLECTION, VECTOR_SIZE)
         .await
@@ -158,7 +158,7 @@ async fn load_and_ingest_text_file() {
 async fn ingested_chunks_have_correct_payload() {
     let container = qdrant_image().start().await.unwrap();
     let port = container.get_host_port_ipv4(6334).await.unwrap();
-    let qdrant = QdrantOps::new(&format!("http://127.0.0.1:{port}")).unwrap();
+    let qdrant = QdrantOps::new(&format!("http://127.0.0.1:{port}"), None).unwrap();
     let collection = "test_payload";
     qdrant
         .ensure_collection(collection, VECTOR_SIZE)

--- a/crates/zeph-memory/tests/hela_spreading_activation.rs
+++ b/crates/zeph-memory/tests/hela_spreading_activation.rs
@@ -44,7 +44,7 @@ async fn setup() -> (
 
     let sqlite = SqliteStore::new(":memory:").await.unwrap();
     let pool = sqlite.pool().clone();
-    let embeddings = EmbeddingStore::new(&url, pool.clone()).unwrap();
+    let embeddings = EmbeddingStore::new(&url, None, pool.clone()).unwrap();
     let graph = GraphStore::new(pool);
     (graph, embeddings, sqlite, container)
 }

--- a/crates/zeph-memory/tests/qdrant_integration.rs
+++ b/crates/zeph-memory/tests/qdrant_integration.rs
@@ -27,7 +27,7 @@ async fn setup_with_qdrant() -> (SqliteStore, EmbeddingStore, ContainerAsync<Gen
 
     let sqlite = SqliteStore::new(":memory:").await.unwrap();
     let pool = sqlite.pool().clone();
-    let store = EmbeddingStore::new(&url, pool).unwrap();
+    let store = EmbeddingStore::new(&url, None, pool).unwrap();
 
     (sqlite, store, container)
 }
@@ -138,7 +138,7 @@ async fn setup_semantic_memory_with_qdrant() -> (SemanticMemory, ContainerAsync<
     mock.embedding = vec![0.1_f32; 384];
     let provider = AnyProvider::Mock(mock);
 
-    let memory = SemanticMemory::new(":memory:", &url, provider, "test-model")
+    let memory = SemanticMemory::new(":memory:", &url, None, provider, "test-model")
         .await
         .unwrap();
 

--- a/crates/zeph-skills/src/qdrant_matcher.rs
+++ b/crates/zeph-skills/src/qdrant_matcher.rs
@@ -216,7 +216,7 @@ mod tests {
     }
 
     fn make_matcher() -> QdrantSkillMatcher {
-        let ops = QdrantOps::new("http://localhost:6334").unwrap();
+        let ops = QdrantOps::new("http://localhost:6334", None).unwrap();
         QdrantSkillMatcher::with_ops(ops)
     }
 

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -1597,7 +1597,7 @@ mod tests {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let db_url = format!("sqlite:{}", tmp.path().display());
         let pool = zeph_db::sqlx::SqlitePool::connect(&db_url).await.unwrap();
-        let qdrant = QdrantOps::new("http://127.0.0.1:1").unwrap();
+        let qdrant = QdrantOps::new("http://127.0.0.1:1", None).unwrap();
 
         let (watcher, _progress_rx) = apply_code_indexer(
             &config,
@@ -1640,7 +1640,7 @@ mod tests {
         let tmp_db = tempfile::NamedTempFile::new().unwrap();
         let db_url = format!("sqlite:{}", tmp_db.path().display());
         let pool = zeph_db::sqlx::SqlitePool::connect(&db_url).await.unwrap();
-        let qdrant = QdrantOps::new("http://127.0.0.1:1").unwrap();
+        let qdrant = QdrantOps::new("http://127.0.0.1:1", None).unwrap();
 
         let (watcher, _) = apply_code_indexer(
             &config,
@@ -1713,7 +1713,7 @@ mod tests {
             budget_ratio: 0.4,
             ..IndexConfig::default()
         };
-        let qdrant = QdrantOps::new("http://127.0.0.1:1").unwrap();
+        let qdrant = QdrantOps::new("http://127.0.0.1:1", None).unwrap();
         let result =
             apply_code_rag_retriever(agent, &config, Some(qdrant), offline_provider(), pool);
         assert!(

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -37,12 +37,27 @@ use zeph_skills::matcher::SkillMatcherBackend;
 use zeph_skills::registry::SkillRegistry;
 use zeph_skills::watcher::{SkillEvent, SkillWatcher};
 
+use url::Url;
 use zeph_core::config::{Config, SecretResolver};
 use zeph_core::config_watcher::{ConfigEvent, ConfigWatcher};
-use zeph_core::vault::AgeVaultProvider;
 #[cfg(any(test, feature = "env-vault"))]
 use zeph_core::vault::EnvVaultProvider;
-use zeph_core::vault::VaultProvider;
+use zeph_core::vault::{AgeVaultProvider, Secret, VaultProvider};
+
+/// Return `true` if the Qdrant URL points to a local development instance.
+///
+/// Used to decide whether to emit a warning about a missing API key — local instances
+/// typically do not require authentication.
+fn is_qdrant_localhost(url: &str) -> bool {
+    let host = Url::parse(url)
+        .ok()
+        .and_then(|u| u.host_str().map(str::to_owned));
+    // `url::Url::host_str()` preserves IPv6 brackets: `http://[::1]:6334` → `"[::1]"`.
+    matches!(
+        host.as_deref(),
+        Some("127.0.0.1" | "localhost" | "[::1]" | "0.0.0.0" | "host.docker.internal")
+    )
+}
 
 pub struct AppBuilder {
     config: Config,
@@ -147,7 +162,17 @@ impl AppBuilder {
 
         let qdrant_ops = match config.memory.vector_backend {
             zeph_core::config::VectorBackend::Qdrant => {
-                let ops = QdrantOps::new(&config.memory.qdrant_url).map_err(|e| {
+                let api_key_str = config.memory.qdrant_api_key.as_ref().map(Secret::expose);
+                if api_key_str.unwrap_or("").trim().is_empty()
+                    && !is_qdrant_localhost(&config.memory.qdrant_url)
+                {
+                    tracing::warn!(
+                        url = %config.memory.qdrant_url,
+                        "qdrant_api_key is not set for non-localhost Qdrant — \
+                         set ZEPH_QDRANT_API_KEY in the vault to authenticate"
+                    );
+                }
+                let ops = QdrantOps::new(&config.memory.qdrant_url, api_key_str).map_err(|e| {
                     BootstrapError::Provider(format!(
                         "invalid qdrant_url '{}': {e}",
                         config.memory.qdrant_url

--- a/src/bootstrap/tests.rs
+++ b/src/bootstrap/tests.rs
@@ -13,6 +13,25 @@ use zeph_core::config::{Config, ProviderEntry, ProviderKind};
 use zeph_llm::claude::ClaudeProvider;
 use zeph_llm::ollama::OllamaProvider;
 
+// ── is_qdrant_localhost ───────────────────────────────────────────────────────
+
+#[test]
+fn localhost_variants_detected() {
+    assert!(is_qdrant_localhost("http://127.0.0.1:6333"));
+    assert!(is_qdrant_localhost("http://localhost:6333"));
+    assert!(is_qdrant_localhost("http://[::1]:6334"));
+    assert!(is_qdrant_localhost("http://0.0.0.0:6333"));
+    assert!(is_qdrant_localhost("http://host.docker.internal:6333"));
+}
+
+#[test]
+fn remote_url_not_localhost() {
+    assert!(!is_qdrant_localhost("https://qdrant.example.com"));
+    assert!(!is_qdrant_localhost("http://10.0.0.5:6333"));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 #[test]
 fn vault_args_defaults_in_test_context() {
     let config = Config::load(Path::new("/nonexistent")).unwrap();
@@ -519,7 +538,7 @@ fn appbuilder_qdrant_ops_invalid_url_returns_err() {
     config.memory.vector_backend = zeph_core::config::VectorBackend::Qdrant;
     config.memory.qdrant_url = "not a valid url".into();
 
-    let result = zeph_memory::QdrantOps::new(&config.memory.qdrant_url);
+    let result = zeph_memory::QdrantOps::new(&config.memory.qdrant_url, None);
     assert!(
         result.is_err(),
         "QdrantOps::new with invalid URL must fail (CRIT-04)"
@@ -528,7 +547,7 @@ fn appbuilder_qdrant_ops_invalid_url_returns_err() {
 
 #[test]
 fn appbuilder_qdrant_ops_valid_url_succeeds() {
-    let result = zeph_memory::QdrantOps::new("http://localhost:6334");
+    let result = zeph_memory::QdrantOps::new("http://localhost:6334", None);
     assert!(result.is_ok(), "QdrantOps::new with valid URL must succeed");
 }
 

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -581,9 +581,15 @@ async fn check_qdrant(config: &zeph_core::config::Config, timeout_secs: u64) -> 
         );
     }
     let url = config.memory.qdrant_url.clone();
+    let api_key: Option<String> = config
+        .memory
+        .qdrant_api_key
+        .as_ref()
+        .map(|s| s.expose().to_owned());
     let result = tokio::time::timeout(Duration::from_secs(timeout_secs), async move {
         use zeph_memory::vector_store::VectorStore as _;
-        let ops = zeph_memory::QdrantOps::new(&url).map_err(|e| e.to_string())?;
+        let ops =
+            zeph_memory::QdrantOps::new(&url, api_key.as_deref()).map_err(|e| e.to_string())?;
         ops.health_check()
             .await
             .map(|_| ())

--- a/src/commands/ingest.rs
+++ b/src/commands/ingest.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use crate::bootstrap::AppBuilder;
+use zeph_core::vault::Secret;
 use zeph_llm::provider::LlmProvider;
 use zeph_memory::{IngestionPipeline, QdrantOps, SplitterConfig, TextLoader, TextSplitter};
 
@@ -18,8 +19,11 @@ pub(crate) async fn handle_ingest(
     let app = AppBuilder::new(config_path, None, None, None).await?;
     let config = app.config();
 
-    let qdrant = QdrantOps::new(&config.memory.qdrant_url)
-        .map_err(|e| anyhow::anyhow!("failed to connect to Qdrant: {e}"))?;
+    let qdrant = QdrantOps::new(
+        &config.memory.qdrant_url,
+        config.memory.qdrant_api_key.as_ref().map(Secret::expose),
+    )
+    .map_err(|e| anyhow::anyhow!("failed to connect to Qdrant: {e}"))?;
 
     let (provider, _status_tx, _status_rx) = app.build_provider().await?;
     let provider = std::sync::Arc::new(provider);

--- a/src/init/memory.rs
+++ b/src/init/memory.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use dialoguer::{Confirm, Input, Select};
+use dialoguer::{Confirm, Input, Password, Select};
 
 use super::WizardState;
 
@@ -58,6 +58,29 @@ pub(super) fn step_memory(state: &mut WizardState) -> anyhow::Result<()> {
                 .default("http://localhost:6334".into())
                 .interact_text()?,
         );
+
+        // The API key is not stored in config.toml — it belongs in the vault only.
+        // Prompt only to detect whether the user has a key to store; if so, print instructions.
+        let has_existing = state.qdrant_api_key;
+        let prompt = if has_existing {
+            "Qdrant API key (optional; press Enter to skip — store via vault command below)"
+                .to_owned()
+        } else {
+            "Qdrant API key (optional; blank for local instances — store via vault command below)"
+                .to_owned()
+        };
+        let raw = Password::new()
+            .with_prompt(prompt)
+            .allow_empty_password(true)
+            .interact()?;
+        if !raw.is_empty() {
+            println!(
+                "\nTo store the Qdrant API key securely, run after init completes:\n  \
+                 zeph vault set ZEPH_QDRANT_API_KEY \"{raw}\"\n"
+            );
+            // Track that a key was provided so re-runs show the correct prompt.
+            state.qdrant_api_key = true;
+        }
     }
 
     state.soft_compaction_threshold = Input::new()

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -39,6 +39,9 @@ pub(crate) struct WizardState {
     pub(crate) sessions_max_history: usize,
     pub(crate) sessions_title_max_chars: usize,
     pub(crate) qdrant_url: Option<String>,
+    /// Tracks whether the user provided a Qdrant API key during a previous wizard run.
+    /// The key itself is never stored here — it must be set via `zeph vault set ZEPH_QDRANT_API_KEY`.
+    pub(crate) qdrant_api_key: bool,
     pub(crate) semantic_enabled: bool,
     pub(crate) channel: ChannelChoice,
     pub(crate) telegram_token: Option<String>,
@@ -248,6 +251,7 @@ impl Default for WizardState {
             sessions_max_history: 0,
             sessions_title_max_chars: 0,
             qdrant_url: None,
+            qdrant_api_key: false,
             semantic_enabled: false,
             channel: ChannelChoice::default(),
             telegram_token: None,
@@ -680,6 +684,9 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
             title_max_chars: state.sessions_title_max_chars,
         },
         database_url: state.database_url.clone(),
+        // Never write the Qdrant API key to config — it lives in the vault only.
+        // The vault key ZEPH_QDRANT_API_KEY is resolved at runtime by resolve_secrets().
+        qdrant_api_key: None,
         ..config.memory
     };
     config.memory.graph.enabled = state.graph_memory_enabled;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -601,6 +601,7 @@ async fn agent_with_memory() {
     let memory = SemanticMemory::new(
         ":memory:",
         "http://invalid:6334", // Will fail gracefully, qdrant=None
+        None,
         provider.clone(),
         "test-model",
     )
@@ -672,9 +673,15 @@ async fn agent_load_history_with_memory() {
     let channel = MockChannel::new(vec![], outputs.clone());
     let executor = MockToolExecutor;
 
-    let memory = SemanticMemory::new(":memory:", "http://invalid:6334", provider.clone(), "test")
-        .await
-        .unwrap();
+    let memory = SemanticMemory::new(
+        ":memory:",
+        "http://invalid:6334",
+        None,
+        provider.clone(),
+        "test",
+    )
+    .await
+    .unwrap();
     let cid = memory.sqlite().create_conversation().await.unwrap();
     memory
         .sqlite()
@@ -1287,9 +1294,15 @@ async fn agent_persist_message_with_memory() {
     let channel = MockChannel::new(vec!["save me"], outputs.clone());
     let executor = MockToolExecutor;
 
-    let memory = SemanticMemory::new(":memory:", "http://invalid:6334", provider.clone(), "test")
-        .await
-        .unwrap();
+    let memory = SemanticMemory::new(
+        ":memory:",
+        "http://invalid:6334",
+        None,
+        provider.clone(),
+        "test",
+    )
+    .await
+    .unwrap();
     let cid = memory.sqlite().create_conversation().await.unwrap();
 
     let mut agent = Agent::new(
@@ -1316,9 +1329,15 @@ async fn agent_check_summarization_triggers() {
     let channel = MockChannel::new(vec!["msg1", "msg2", "msg3"], outputs.clone());
     let executor = MockToolExecutor;
 
-    let memory = SemanticMemory::new(":memory:", "http://invalid:6334", provider.clone(), "test")
-        .await
-        .unwrap();
+    let memory = SemanticMemory::new(
+        ":memory:",
+        "http://invalid:6334",
+        None,
+        provider.clone(),
+        "test",
+    )
+    .await
+    .unwrap();
     let cid = memory.sqlite().create_conversation().await.unwrap();
 
     let mut agent = Agent::new(
@@ -1356,9 +1375,15 @@ async fn agent_skills_command_with_usage_stats() {
 
     let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
 
-    let memory = SemanticMemory::new(":memory:", "http://invalid:6334", provider.clone(), "test")
-        .await
-        .unwrap();
+    let memory = SemanticMemory::new(
+        ":memory:",
+        "http://invalid:6334",
+        None,
+        provider.clone(),
+        "test",
+    )
+    .await
+    .unwrap();
     let cid = memory.sqlite().create_conversation().await.unwrap();
 
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor).with_memory(
@@ -1695,9 +1720,15 @@ async fn agent_persist_messages_verified() {
     let channel = MockChannel::new(vec!["user-input"], outputs.clone());
     let executor = MockToolExecutor;
 
-    let memory = SemanticMemory::new(db_str, "http://invalid:6334", provider.clone(), "test")
-        .await
-        .unwrap();
+    let memory = SemanticMemory::new(
+        db_str,
+        "http://invalid:6334",
+        None,
+        provider.clone(),
+        "test",
+    )
+    .await
+    .unwrap();
     let cid = memory.sqlite().create_conversation().await.unwrap();
 
     let mut agent = Agent::new(
@@ -1727,9 +1758,15 @@ async fn agent_load_history_skips_empty_messages() {
     let channel = MockChannel::new(vec![], outputs.clone());
     let executor = MockToolExecutor;
 
-    let memory = SemanticMemory::new(":memory:", "http://invalid:6334", provider.clone(), "test")
-        .await
-        .unwrap();
+    let memory = SemanticMemory::new(
+        ":memory:",
+        "http://invalid:6334",
+        None,
+        provider.clone(),
+        "test",
+    )
+    .await
+    .unwrap();
     let cid = memory.sqlite().create_conversation().await.unwrap();
     memory
         .sqlite()
@@ -1773,9 +1810,15 @@ async fn agent_persist_multiple_exchanges() {
     let channel = MockChannel::new(vec!["msg1", "msg2"], outputs.clone());
     let executor = MockToolExecutor;
 
-    let memory = SemanticMemory::new(db_str, "http://invalid:6334", provider.clone(), "test")
-        .await
-        .unwrap();
+    let memory = SemanticMemory::new(
+        db_str,
+        "http://invalid:6334",
+        None,
+        provider.clone(),
+        "test",
+    )
+    .await
+    .unwrap();
     let cid = memory.sqlite().create_conversation().await.unwrap();
 
     let mut agent = Agent::new(
@@ -1809,9 +1852,15 @@ async fn agent_tool_output_persisted_in_memory() {
         output: "tool result text".into(),
     };
 
-    let memory = SemanticMemory::new(db_str, "http://invalid:6334", provider.clone(), "test")
-        .await
-        .unwrap();
+    let memory = SemanticMemory::new(
+        db_str,
+        "http://invalid:6334",
+        None,
+        provider.clone(),
+        "test",
+    )
+    .await
+    .unwrap();
     let cid = memory.sqlite().create_conversation().await.unwrap();
 
     let mut agent = Agent::new(
@@ -1884,9 +1933,15 @@ async fn agent_confirmation_approved_with_output_persisted() {
     };
     let executor = ConfirmToolExecutor;
 
-    let memory = SemanticMemory::new(db_str, "http://invalid:6334", provider.clone(), "test")
-        .await
-        .unwrap();
+    let memory = SemanticMemory::new(
+        db_str,
+        "http://invalid:6334",
+        None,
+        provider.clone(),
+        "test",
+    )
+    .await
+    .unwrap();
     let cid = memory.sqlite().create_conversation().await.unwrap();
 
     let mut agent = Agent::new(
@@ -2210,9 +2265,15 @@ async fn agent_records_skill_usage() {
         .expect("matcher must build");
     let backend = Some(SkillMatcherBackend::InMemory(matcher));
 
-    let memory = SemanticMemory::new(db_str, "http://invalid:6334", provider.clone(), "test")
-        .await
-        .unwrap();
+    let memory = SemanticMemory::new(
+        db_str,
+        "http://invalid:6334",
+        None,
+        provider.clone(),
+        "test",
+    )
+    .await
+    .unwrap();
     let cid = memory.sqlite().create_conversation().await.unwrap();
 
     let mut agent = Agent::new(provider.clone(), channel, registry, backend, 5, executor)
@@ -2249,9 +2310,15 @@ async fn agent_no_matcher_skips_skill_usage() {
 
     let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
 
-    let memory = SemanticMemory::new(db_str, "http://invalid:6334", provider.clone(), "test")
-        .await
-        .unwrap();
+    let memory = SemanticMemory::new(
+        db_str,
+        "http://invalid:6334",
+        None,
+        provider.clone(),
+        "test",
+    )
+    .await
+    .unwrap();
     let cid = memory.sqlite().create_conversation().await.unwrap();
 
     // No matcher: all skills fall back to the full set — usage must NOT be recorded.
@@ -2520,10 +2587,15 @@ mod self_learning {
     }
 
     async fn make_memory(provider: &AnyProvider) -> (SemanticMemory, ConversationId) {
-        let memory =
-            SemanticMemory::new(":memory:", "http://invalid:6334", provider.clone(), "test")
-                .await
-                .unwrap();
+        let memory = SemanticMemory::new(
+            ":memory:",
+            "http://invalid:6334",
+            None,
+            provider.clone(),
+            "test",
+        )
+        .await
+        .unwrap();
         let cid = memory.sqlite().create_conversation().await.unwrap();
         (memory, cid)
     }
@@ -2532,9 +2604,15 @@ mod self_learning {
         provider: &AnyProvider,
         db_path: &str,
     ) -> (SemanticMemory, ConversationId) {
-        let memory = SemanticMemory::new(db_path, "http://invalid:6334", provider.clone(), "test")
-            .await
-            .unwrap();
+        let memory = SemanticMemory::new(
+            db_path,
+            "http://invalid:6334",
+            None,
+            provider.clone(),
+            "test",
+        )
+        .await
+        .unwrap();
         let cid = memory.sqlite().create_conversation().await.unwrap();
         (memory, cid)
     }
@@ -3794,10 +3872,15 @@ mod trust_commands {
     }
 
     async fn make_memory(provider: &AnyProvider) -> (SemanticMemory, ConversationId) {
-        let memory =
-            SemanticMemory::new(":memory:", "http://invalid:6334", provider.clone(), "test")
-                .await
-                .unwrap();
+        let memory = SemanticMemory::new(
+            ":memory:",
+            "http://invalid:6334",
+            None,
+            provider.clone(),
+            "test",
+        )
+        .await
+        .unwrap();
         let cid = memory.sqlite().create_conversation().await.unwrap();
         (memory, cid)
     }


### PR DESCRIPTION
## Summary

- Adds `api_key: Option<&str>` to `QdrantOps::new`, mirrored through `EmbeddingStore::new` and all three `SemanticMemory` constructors (~40 call sites)
- `MemoryConfig::qdrant_api_key: Option<Secret>` — uses existing `zeph_common::secret::Secret` (Zeroizing + redacted Debug, no Serialize), matching `claude_api_key` precedent
- Vault resolution via `ZEPH_QDRANT_API_KEY` key, extending `Config::resolve_secrets` (matches `ZEPH_DATABASE_URL` pattern)
- Bootstrap emits `tracing::warn!` when Qdrant URL is non-localhost and no API key is configured
- Init wizard prompts for key but prints vault instructions instead of persisting plaintext to config.toml
- Migration step 39 added (no-op, field has `#[serde(default)]`); both `MIGRATIONS.len() == 39` assertions updated
- `is_qdrant_localhost` uses `url::Url::host_str()` for correct IPv6 bracket handling

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` — 8683 tests pass
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] New unit tests: `QdrantOps::new` api_key paths (3 tests), `is_qdrant_localhost` variants (2 tests)
- [ ] Migration step 39: 4 unit tests (adds-comment, noop-when-present, creates-section, idempotent)
- [ ] Live test with `ZEPH_QDRANT_API_KEY` in vault against authenticated Qdrant instance — see playbook at `.local/testing/playbooks/qdrant-api-key.md`

Closes #3543