### PR TITLE
docs(memory): synthesize MemCoT, OmniMem, OCR-Memory; add APEX-MEM Research Backlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Documentation
+
+- research: synthesize MemCoT, OmniMem, and OCR-Memory memory architecture papers; document integration roadmap and file follow-up issues (#3564, #3566, #3571); add Research Backlog to APEX-MEM spec (see specs §14)
+
 ## [0.20.1] - 2026-04-28
 
 ### Fixed

--- a/specs/004-memory/004-7-memory-apex-magma.md
+++ b/specs/004-memory/004-7-memory-apex-magma.md
@@ -473,3 +473,51 @@ AND the head remains the head (valid_to untouched)
 - [[memory-write-gate/spec]] — upstream quality gate (contradiction_risk signal composes with APEX-MEM conflicts)
 - [[024-multi-model-design/spec]] — provider tier guidance
 - [[MOC-specs]] — all specifications
+
+---
+
+## 14. Research Backlog
+
+Research findings pending implementation review. Each entry links to the originating tracking issue and proposes a concrete integration point.
+
+### 14.1 MemCoT — Test-Time Memory Scaling (arXiv:2604.08216)
+
+**Tracking issue**: #3564
+**Status**: Researched / pending implementation (P3)
+
+MemCoT introduces a training-free multi-view LTM perception layer (Zoom-In for evidence localization, Zoom-Out for causal context expansion) and a task-conditioned dual short-term memory (semantic state + episodic trajectory). Benchmarked on LoCoMo: GPT-4o-mini F1 = 58.03 vs ~30 baseline.
+
+**Proposed Zeph integration**:
+- `SemanticStateAccumulator` in `TurnContext` (new follow-up issue filed)
+- Zoom-In retrieval pass in `ReasoningMemory::recall` before spreading activation (new follow-up issue filed)
+- Config: `memory.memcot.enabled` (default: false)
+
+**Relevance to APEX-MEM**: APEX-MEM canonicalizes facts at the edge layer. MemCoT's Zoom-In retrieval and semantic-state STM operate one layer above — on top of the resolved edge set returned by SYNAPSE. The two are complementary: APEX-MEM decides which edge wins; MemCoT decides how the winning edges are presented to the reasoning model.
+
+### 14.2 OmniMem — Autoresearch-Guided Memory Discovery (arXiv:2604.01007)
+
+**Tracking issue**: #3566
+**Status**: Researched / pending implementation (P3)
+
+OmniMem's autoresearch pipeline runs ~50 self-experiments to discover memory architectural improvements. Top gains: bug fixes (+175%), prompt engineering (+188%), architectural changes (+44%). LoCoMo F1: 0.117 -> 0.598 (+411%).
+
+**Proposed Zeph integration**:
+- Log memory retrieval failures in `skill_outcomes` table (new follow-up issue filed)
+- Periodic micro-benchmark via `zeph-scheduler`
+- SYNAPSE parameter auto-tuning from failure analysis
+
+**Relevance to APEX-MEM**: SYNAPSE has tunable parameters (BFS depth cap, pheromone decay, conflict-resolution thresholds — see §6, §8). OmniMem's closed-loop discovery process suggests these should be optimized against a logged failure dataset rather than hand-set.
+
+### 14.3 OCR-Memory — Visual Trajectory Encoding (arXiv:2604.26622)
+
+**Tracking issue**: #3571
+**Status**: Researched / deferred to P4 (requires VLM provider)
+
+OCR-Memory renders agent trajectories as annotated images and uses a locate-and-transcribe retrieval paradigm, avoiding lossy summarization for long sessions. Requires a multimodal LLM for retrieval transcription.
+
+**Proposed Zeph integration** (deferred):
+- `zeph-memory` episodic store: render sessions exceeding token threshold to PNG
+- Store as Qdrant vector point with image embedding
+- Unblocked when `zeph-llm` gains a VLM provider
+
+**Relevance to APEX-MEM**: low. OCR-Memory targets the episodic-trajectory store, not the semantic graph. APEX-MEM's append-only log is orthogonal — it could feed transcript frames into a visual encoder, but this requires a VLM provider that does not exist in `zeph-llm` today.


### PR DESCRIPTION
## Summary

- Add `## 14. Research Backlog` section to the APEX-MEM spec (`specs/004-memory/004-7-memory-apex-magma.md`) documenting three April 2026 memory architecture papers: MemCoT (§14.1), OmniMem (§14.2), OCR-Memory (§14.3)
- Add CHANGELOG entry under `[Unreleased]` referencing the synthesis and filed follow-up issues
- Write synthesis playbook and update coverage-status in `.local/testing/` (not git-tracked)

## Follow-up Issues Filed

- #3574 — `SemanticStateAccumulator` in `TurnContext` (MemCoT semantic state memory, P3)
- #3575 — `ReasoningMemory` Zoom-In retrieval extension (MemCoT multi-view LTM, P3; depends on #3574)
- #3576 — Memory retrieval failure logging in `skill_outcomes` (OmniMem self-improvement loop, P3; independent/parallel to #3574)

## Research Tracking Issues

References #3564, #3566, #3571

## Test Plan

- [ ] Verify `specs/004-memory/004-7-memory-apex-magma.md` builds without broken links: `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps` (no Rust changes in this PR)
- [ ] Verify §1–13 of the APEX-MEM spec are unchanged
- [ ] Verify follow-up issues #3574, #3575, #3576 are open with correct labels (enhancement, memory, P3, research)