### PR TITLE
feat(mcp): MCP server startup auto-retry with exponential backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- feat(mcp): MCP server startup now retries failed initial connections with exponential backoff
+  (`500 ms`, `1 s`, `2 s`, `4 s`, `8 s`, capped at `8 s`). The new `mcp.max_connect_attempts`
+  config key (default `3`, range `1..=10`) controls how many attempts are made. Backoff sleeps are
+  interrupted immediately on agent shutdown via a `CancellationToken`. Status messages
+  (`Connecting to MCP server …` / `Reconnecting … (attempt N/M)`) are sent to the TUI/Telegram
+  status channel throughout. The new `McpError::ManagerShuttingDown` variant is used instead of a
+  generic connection error when shutdown is detected. Dynamic `/mcp add` retains single-attempt
+  behaviour; a follow-up issue tracks extending retry there (#3568).
+
 ### Documentation
 
 - research: synthesize MemCoT, OmniMem, and OCR-Memory memory architecture papers; document integration roadmap and file follow-up issues (#3564, #3566, #3571); add Research Backlog to APEX-MEM spec (see specs §14)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10546,6 +10546,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
  "url",
  "uuid",

--- a/config/default.toml
+++ b/config/default.toml
@@ -437,6 +437,10 @@ max_dynamic_servers = 10
 # elicitation_queue_capacity = 16
 # When true, warn the user before prompting for sensitive-looking fields (password, token, etc.).
 # elicitation_warn_sensitive_fields = true
+# Maximum number of connection attempts per MCP server at startup (1 = no retry, default: 3).
+# Backoff: 500 ms, 1 s, 2 s, 4 s, 8 s, ... (capped at 8 s). Must be in 1..=10.
+# Note: dynamic /mcp add retains single-attempt behaviour; a follow-up tracks retry there.
+# max_connect_attempts = 3
 
 [mcp.pruning]
 # Enable dynamic MCP tool pruning (LLM-based relevance filter before main inference)

--- a/crates/zeph-config/src/channels.rs
+++ b/crates/zeph-config/src/channels.rs
@@ -129,6 +129,47 @@ mod tests {
     }
 
     #[test]
+    fn max_connect_attempts_default_is_3() {
+        let cfg = McpConfig::default();
+        assert_eq!(cfg.max_connect_attempts, 3);
+    }
+
+    #[test]
+    fn max_connect_attempts_accepts_valid_range() {
+        for v in [1u8, 3, 10] {
+            let src = format!("max_connect_attempts = {v}\n");
+            let cfg: McpConfig = toml::from_str(&src)
+                .unwrap_or_else(|e| panic!("max_connect_attempts = {v} should be valid, got: {e}"));
+            assert_eq!(cfg.max_connect_attempts, v);
+        }
+    }
+
+    #[test]
+    fn max_connect_attempts_rejects_zero() {
+        let src = "max_connect_attempts = 0\n";
+        let result = toml::from_str::<McpConfig>(src);
+        assert!(
+            result.is_err(),
+            "max_connect_attempts = 0 should be rejected"
+        );
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("max_connect_attempts"),
+            "error message should mention the field name, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn max_connect_attempts_rejects_eleven() {
+        let src = "max_connect_attempts = 11\n";
+        let result = toml::from_str::<McpConfig>(src);
+        assert!(
+            result.is_err(),
+            "max_connect_attempts = 11 should be rejected"
+        );
+    }
+
+    #[test]
     fn wildcard_star_allows_any_skill() {
         let cfg = allow(&["*"]);
         assert!(is_skill_allowed("anything", &cfg));
@@ -617,6 +658,23 @@ fn default_output_schema_hint_bytes() -> usize {
     1024
 }
 
+fn default_max_connect_attempts() -> u8 {
+    3
+}
+
+fn validate_max_connect_attempts<'de, D>(d: D) -> Result<u8, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let v = u8::deserialize(d)?;
+    if !(1..=10).contains(&v) {
+        return Err(serde::de::Error::custom(format!(
+            "mcp.max_connect_attempts must be in 1..=10 (got {v})"
+        )));
+    }
+    Ok(v)
+}
+
 #[allow(clippy::struct_excessive_bools)] // config struct — boolean flags are idiomatic for TOML-deserialized configuration
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct McpConfig {
@@ -658,6 +716,22 @@ pub struct McpConfig {
     /// patterns (password, token, secret, key, credential, etc.). Default: true.
     #[serde(default = "default_true")]
     pub elicitation_warn_sensitive_fields: bool,
+    /// Maximum number of connection attempts for each MCP server at startup.
+    ///
+    /// Value `1` means one attempt with no retry. Value `3` (default) means up to three
+    /// attempts with exponential backoff: 500 ms then 1 s between attempts.
+    ///
+    /// For `max_connect_attempts = N`, the inter-attempt delay sequence is
+    /// `min(500 * 2^(k-1), 8_000) ms` for k = 1..N-1, giving at most ~47 s total backoff
+    /// at the cap of `10`. Must be in `1..=10`.
+    ///
+    /// Note: dynamic `add_server` calls retain single-attempt behaviour regardless of this
+    /// setting; a follow-up issue tracks extending retry there.
+    #[serde(
+        default = "default_max_connect_attempts",
+        deserialize_with = "validate_max_connect_attempts"
+    )]
+    pub max_connect_attempts: u8,
     /// Lock tool lists after initial connection for all servers.
     ///
     /// When `true`, `tools/list_changed` refresh events are rejected for servers that have
@@ -708,6 +782,7 @@ impl Default for McpConfig {
             default_env_isolation: false,
             forward_output_schema: false,
             output_schema_hint_bytes: default_output_schema_hint_bytes(),
+            max_connect_attempts: default_max_connect_attempts(),
         }
     }
 }

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -2316,6 +2316,43 @@ pub fn migrate_mcp_elicitation_config(toml_src: &str) -> Result<MigrationResult,
     })
 }
 
+/// Add a commented-out `max_connect_attempts` key under `[mcp]` if absent (#3568).
+///
+/// This key was introduced alongside the MCP startup auto-retry feature. All prior
+/// configs omit it and get the default value of `3`. This migration surfaces the key
+/// as a comment so users can discover and tune it.
+///
+/// # Errors
+///
+/// Returns `Ok` with unchanged output when the key is already present or `[mcp]` is absent.
+pub fn migrate_mcp_max_connect_attempts(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    if toml_src.contains("max_connect_attempts") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    if !toml_src.contains("[mcp]\n") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let comment = "# max_connect_attempts = 3  \
+        # startup retry count per server (1 = no retry, 1..=10, backoff: 500ms/1s/2s/...)\n";
+    let output = toml_src.replacen("[mcp]\n", &format!("[mcp]\n{comment}"), 1);
+
+    Ok(MigrationResult {
+        output,
+        changed_count: 1,
+        sections_changed: vec!["mcp".to_owned()],
+    })
+}
+
 /// Add a commented-out `[quality]` block if the config lacks it (#3228).
 ///
 /// Introduced alongside the MARCH self-check pipeline (#3226). All `QualityConfig`
@@ -3147,17 +3184,18 @@ use steps::{
     MigrateAutodreamConfig, MigrateCompressionPredictorConfig, MigrateDatabaseUrl,
     MigrateEgressConfig, MigrateFocusAutoConsolidateMinWindow, MigrateForgettingConfig,
     MigrateHooksPermissionDeniedConfig, MigrateHooksTurnComplete, MigrateMagicDocsConfig,
-    MigrateMcpElicitationConfig, MigrateMcpTrustLevels, MigrateMemoryGraph, MigrateMemoryHebbian,
-    MigrateMemoryHebbianConsolidation, MigrateMemoryHebbianSpread, MigrateMemoryPersonaConfig,
-    MigrateMemoryReasoning, MigrateMemoryReasoningJudge, MigrateMemoryRetrieval,
-    MigrateMemoryRetrievalQueryBias, MigrateMicrocompactConfig, MigrateOrchestrationPersistence,
-    MigrateOtelFilter, MigratePlannerModelToProvider, MigrateQdrantApiKey, MigrateQualityConfig,
-    MigrateSandboxConfig, MigrateSandboxEgressFilter, MigrateSchedulerDaemon,
-    MigrateSessionProviderPersistence, MigrateSessionRecapConfig, MigrateShellTransactional,
-    MigrateSttToProvider, MigrateSupervisorConfig, MigrateTelemetryConfig, MigrateVigilConfig,
+    MigrateMcpElicitationConfig, MigrateMcpMaxConnectAttempts, MigrateMcpTrustLevels,
+    MigrateMemoryGraph, MigrateMemoryHebbian, MigrateMemoryHebbianConsolidation,
+    MigrateMemoryHebbianSpread, MigrateMemoryPersonaConfig, MigrateMemoryReasoning,
+    MigrateMemoryReasoningJudge, MigrateMemoryRetrieval, MigrateMemoryRetrievalQueryBias,
+    MigrateMicrocompactConfig, MigrateOrchestrationPersistence, MigrateOtelFilter,
+    MigratePlannerModelToProvider, MigrateQdrantApiKey, MigrateQualityConfig, MigrateSandboxConfig,
+    MigrateSandboxEgressFilter, MigrateSchedulerDaemon, MigrateSessionProviderPersistence,
+    MigrateSessionRecapConfig, MigrateShellTransactional, MigrateSttToProvider,
+    MigrateSupervisorConfig, MigrateTelemetryConfig, MigrateVigilConfig,
 };
 
-/// Ordered registry of all sequential migration steps (steps 1–39).
+/// Ordered registry of all sequential migration steps (steps 1–40).
 ///
 /// Each entry wraps the corresponding free function and is evaluated lazily at first access.
 /// The ordering is chronological; the dispatch loop in `src/commands/migrate.rs` iterates
@@ -3219,6 +3257,8 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             Box::new(MigrateMemoryPersonaConfig),
             // Step 39 — optional Qdrant API key (#3543)
             Box::new(MigrateQdrantApiKey),
+            // Step 40 — MCP startup auto-retry max_connect_attempts (#3568)
+            Box::new(MigrateMcpMaxConnectAttempts),
         ]
     });
 
@@ -3237,8 +3277,8 @@ mod tests {
     fn migrations_registry_has_all_steps() {
         assert_eq!(
             MIGRATIONS.len(),
-            39,
-            "MIGRATIONS registry must contain all 39 sequential steps"
+            40,
+            "MIGRATIONS registry must contain all 40 sequential steps"
         );
         for m in MIGRATIONS.iter() {
             assert!(
@@ -4825,7 +4865,7 @@ prompt_cache_ttl = "1h"
 
     #[test]
     fn registry_has_thirty_nine_entries() {
-        assert_eq!(MIGRATIONS.len(), 39);
+        assert_eq!(MIGRATIONS.len(), 40);
     }
 
     #[test]
@@ -4864,7 +4904,7 @@ prompt_cache_ttl = "1h"
 
     #[test]
     fn registry_preserves_order_matches_dispatch() {
-        // Names must follow the documented step order (steps 1–39).
+        // Names must follow the documented step order (steps 1–40).
         let expected = [
             "migrate_stt_to_provider",
             "migrate_planner_model_to_provider",
@@ -4905,6 +4945,7 @@ prompt_cache_ttl = "1h"
             "migrate_memory_retrieval_query_bias",
             "migrate_memory_persona_config",
             "migrate_qdrant_api_key",
+            "migrate_mcp_max_connect_attempts",
         ];
         let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
         assert_eq!(actual, expected);
@@ -4951,5 +4992,35 @@ prompt_cache_ttl = "1h"
         let second = migrate_qdrant_api_key(&first.output).unwrap();
         assert_eq!(second.changed_count, 0, "second run must not double-append");
         assert_eq!(second.output, first.output);
+    }
+
+    #[test]
+    fn migrate_mcp_max_connect_attempts_adds_comment_when_absent() {
+        let src = "[mcp]\nallowed_commands = []\n";
+        let result = migrate_mcp_max_connect_attempts(src).expect("migrate");
+        assert_eq!(result.changed_count, 1);
+        assert!(
+            result.output.contains("max_connect_attempts"),
+            "output must mention max_connect_attempts"
+        );
+    }
+
+    #[test]
+    fn migrate_mcp_max_connect_attempts_idempotent_when_present() {
+        let src = "[mcp]\n# max_connect_attempts = 3\nallowed_commands = []\n";
+        let result = migrate_mcp_max_connect_attempts(src).expect("migrate");
+        assert_eq!(
+            result.changed_count, 0,
+            "must not modify already-present key"
+        );
+        assert_eq!(result.output, src);
+    }
+
+    #[test]
+    fn migrate_mcp_max_connect_attempts_skips_when_no_mcp_section() {
+        let src = "[agent]\nname = \"Zeph\"\n";
+        let result = migrate_mcp_max_connect_attempts(src).expect("migrate");
+        assert_eq!(result.changed_count, 0);
+        assert_eq!(result.output, src);
     }
 }

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -3,7 +3,8 @@
 
 //! Migration step wrapper structs — one per sequential migration in [`super::MIGRATIONS`].
 //!
-//! Steps 1–35 are pre-existing; steps 36–38 were added for the stable-defaults flip.
+//! Steps 1–35 are pre-existing; steps 36–38 were added for the stable-defaults flip;
+//! step 39 adds optional Qdrant API key; step 40 adds MCP `max_connect_attempts`.
 //!
 //! Each struct is a zero-size type that delegates to the corresponding free function in
 //! `super`. They exist solely to satisfy the object-safe [`super::Migration`] trait so the
@@ -15,8 +16,8 @@ use super::{
     migrate_compression_predictor_config, migrate_database_url, migrate_egress_config,
     migrate_focus_auto_consolidate_min_window, migrate_forgetting_config,
     migrate_hooks_permission_denied_config, migrate_hooks_turn_complete_config,
-    migrate_magic_docs_config, migrate_mcp_elicitation_config, migrate_mcp_trust_levels,
-    migrate_memory_graph_config, migrate_memory_hebbian_config,
+    migrate_magic_docs_config, migrate_mcp_elicitation_config, migrate_mcp_max_connect_attempts,
+    migrate_mcp_trust_levels, migrate_memory_graph_config, migrate_memory_hebbian_config,
     migrate_memory_hebbian_consolidation_config, migrate_memory_hebbian_spread_config,
     migrate_memory_persona_config, migrate_memory_reasoning_config,
     migrate_memory_reasoning_judge_config, migrate_memory_retrieval_config,
@@ -457,5 +458,16 @@ impl Migration for MigrateQdrantApiKey {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_qdrant_api_key(toml_src)
+    }
+}
+
+pub(super) struct MigrateMcpMaxConnectAttempts;
+impl Migration for MigrateMcpMaxConnectAttempts {
+    fn name(&self) -> &'static str {
+        "migrate_mcp_max_connect_attempts"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_mcp_max_connect_attempts(toml_src)
     }
 }

--- a/crates/zeph-config/tests/default_toml_consistency.rs
+++ b/crates/zeph-config/tests/default_toml_consistency.rs
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Verifies that the `max_connect_attempts` key is present in all three `default.toml` copies.
+//!
+//! The three default config files are not byte-identical (they have different verbosity levels),
+//! but every key added to `McpConfig` must appear in all three as a commented-out default so
+//! users can discover it regardless of which config they start from.
+
+#[test]
+fn default_toml_mcp_section_has_max_connect_attempts() {
+    let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent() // zeph-config → crates
+        .and_then(|p| p.parent()) // crates → workspace root
+        .expect("failed to find workspace root");
+
+    let paths = [
+        "config/default.toml",
+        "crates/zeph-core/config/default.toml",
+        "crates/zeph-config/config/default.toml",
+    ];
+
+    for rel_path in &paths {
+        let full_path = workspace_root.join(rel_path);
+        let content = std::fs::read_to_string(&full_path)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", full_path.display()));
+
+        assert!(
+            content.contains("max_connect_attempts"),
+            "missing 'max_connect_attempts' in {}",
+            full_path.display()
+        );
+    }
+}

--- a/crates/zeph-core/config/default.toml
+++ b/crates/zeph-core/config/default.toml
@@ -316,6 +316,10 @@ repo_map_ttl_secs = 300
 allowed_commands = ["npx", "uvx", "node", "python", "python3"]
 # Maximum number of dynamically added MCP servers
 max_dynamic_servers = 10
+# Maximum number of connection attempts per MCP server at startup (1 = no retry, default: 3).
+# Backoff: 500 ms, 1 s, 2 s, 4 s, 8 s, ... (capped at 8 s). Must be in 1..=10.
+# Note: dynamic /mcp add retains single-attempt behaviour; a follow-up tracks retry there.
+# max_connect_attempts = 3
 
 # Stdio transport (spawn child process):
 # [[mcp.servers]]

--- a/crates/zeph-mcp/Cargo.toml
+++ b/crates/zeph-mcp/Cargo.toml
@@ -36,6 +36,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 zeph-db = { workspace = true, features = ["sqlite"] }
 tokio = { workspace = true, features = ["process", "sync", "time", "rt", "net", "io-util"] }
+tokio-util.workspace = true
 tracing.workspace = true
 url.workspace = true
 uuid = { workspace = true, features = ["v5"] }
@@ -47,7 +48,7 @@ zeph-tools.workspace = true
 # See https://github.com/bug-ops/zeph (workspace dependencies only contain versions)
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 zeph-llm = { workspace = true, features = ["testing"] }
 
 [lints]

--- a/crates/zeph-mcp/src/error.rs
+++ b/crates/zeph-mcp/src/error.rs
@@ -127,6 +127,12 @@ pub enum McpError {
 
     #[error("tool list refresh rejected for '{server_id}': list is locked after initial connect")]
     ToolListLocked { server_id: String },
+
+    /// The MCP manager is shutting down; the connection attempt was aborted.
+    ///
+    /// This is a terminal lifecycle signal, not a transient error. Callers must not retry.
+    #[error("MCP manager is shutting down (server '{server_id}')")]
+    ManagerShuttingDown { server_id: String },
 }
 
 impl McpError {
@@ -148,7 +154,12 @@ impl McpError {
                 Some(McpErrorCode::InvalidInput)
             }
             Self::Embedding(_) => Some(McpErrorCode::ServerError),
-            _ => None,
+            // Lifecycle, infrastructure, and structural errors have no taxonomy code.
+            Self::ManagerShuttingDown { .. }
+            | Self::ServerAlreadyConnected { .. }
+            | Self::Qdrant(_)
+            | Self::Json(_)
+            | Self::IntConversion(_) => None,
         }
     }
 }

--- a/crates/zeph-mcp/src/manager.rs
+++ b/crates/zeph-mcp/src/manager.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use parking_lot::{Mutex as SyncMutex, RwLock as SyncRwLock};
+use tokio_util::sync::CancellationToken;
 
 use dashmap::DashMap;
 use rmcp::model::CallToolResult;
@@ -245,6 +246,15 @@ pub struct McpManager {
     /// `commit_added_server` releases the `clients` guard but before it writes to `server_trust`
     /// and `server_tools`, leaving orphaned trust/tools entries that persist until restart.
     add_remove_lock: tokio::sync::Mutex<()>,
+    /// Cancellation token broadcast to all in-flight startup retry tasks.
+    ///
+    /// Cancelled in `shutdown_all_shared` before any other shutdown work so that retry
+    /// sleeps are interrupted immediately rather than contributing tail latency.
+    shutdown_token: CancellationToken,
+    /// Maximum number of connection attempts per server at startup.
+    ///
+    /// `1` = no retry, `3` = two retries. Validated at config-parse time: `1..=10`.
+    max_connect_attempts: u8,
     /// When `true`, `tools/list_changed` refresh events are rejected for servers whose
     /// initial tool list has been committed (i.e. their ID is in `tool_list_locked`).
     ///
@@ -359,6 +369,8 @@ impl McpManager {
             add_remove_lock: tokio::sync::Mutex::new(()),
             lock_tool_list: false,
             tool_list_locked: Arc::new(DashMap::new()),
+            shutdown_token: CancellationToken::new(),
+            max_connect_attempts: 3,
         }
     }
 
@@ -430,6 +442,17 @@ impl McpManager {
     #[must_use]
     pub fn with_status_tx(mut self, tx: StatusTx) -> Self {
         self.status_tx = Some(tx);
+        self
+    }
+
+    /// Set the maximum number of connection attempts per server at startup.
+    ///
+    /// Value `1` means a single attempt with no retry; value `3` (default) allows two retries.
+    /// Values outside `1..=10` are clamped as defence in depth — prefer validation at the config
+    /// deserialisation boundary so callers get an early, descriptive error.
+    #[must_use]
+    pub fn with_max_connect_attempts(mut self, attempts: u8) -> Self {
+        self.max_connect_attempts = attempts.clamp(1, 10);
         self
     }
 
@@ -648,6 +671,7 @@ impl McpManager {
         let allowed = self.allowed_commands.clone();
         let suppress = self.suppress_stderr;
         let cloned_status_tx = self.status_tx.clone();
+        let max_attempts = self.max_connect_attempts;
 
         let non_oauth: Vec<_> = self
             .configs
@@ -671,13 +695,20 @@ impl McpManager {
                 self.tool_list_locked.insert(config.id.clone(), ());
             }
             let status_tx = cloned_status_tx.clone();
+            let shutdown = self.shutdown_token.clone();
             join_set.spawn(async move {
-                // SECURITY: only config.id is included — never transport URL, headers, or tokens.
-                if let Some(ref stx) = status_tx {
-                    let _ = stx.send(format!("Connecting to {}...", config.id));
-                }
-                let result =
-                    connect_entry(&config, &allowed, suppress, tx, last_refresh, handler_cfg).await;
+                let result = connect_with_retry(
+                    &config,
+                    &allowed,
+                    suppress,
+                    tx,
+                    last_refresh,
+                    &handler_cfg,
+                    max_attempts,
+                    status_tx.as_ref(),
+                    &shutdown,
+                )
+                .await;
                 (config.id, result)
             });
         }
@@ -1132,11 +1163,13 @@ impl McpManager {
     pub async fn add_server(&self, entry: &ServerEntry) -> Result<Vec<McpTool>, McpError> {
         self.check_not_already_connected(&entry.id).await?;
 
+        // NOTE: add_server retains single-attempt behaviour intentionally; retry policy for
+        // dynamic connections requires idempotency review of probe/ingest/commit stages.
+        // A follow-up issue tracks extending retry to this path.
         let tx = self
             .clone_refresh_tx()
-            .ok_or_else(|| McpError::Connection {
+            .ok_or_else(|| McpError::ManagerShuttingDown {
                 server_id: entry.id.clone(),
-                message: "manager is shutting down".into(),
             })?;
 
         let (client, raw_tools) = self.connect_and_list_tools(entry, tx).await?;
@@ -1207,13 +1240,14 @@ impl McpManager {
         if self.lock_tool_list {
             self.tool_list_locked.insert(entry.id.clone(), ());
         }
+        let handler_cfg = self.handler_cfg_for(entry);
         let client = match connect_entry(
             entry,
             &self.allowed_commands,
             self.suppress_stderr,
             tx,
             Arc::clone(&self.last_refresh),
-            self.handler_cfg_for(entry),
+            &handler_cfg,
         )
         .await
         {
@@ -1388,6 +1422,11 @@ impl McpManager {
     /// # Panics
     ///
     pub async fn shutdown_all_shared(&self) {
+        // Signal all in-flight startup retry tasks to stop sleeping and exit immediately.
+        // Must be the very first action so that retry sleeps are interrupted before we
+        // begin draining clients and dropping senders.
+        self.shutdown_token.cancel();
+
         // Drop the manager's sender so the refresh task can terminate once
         // all ToolListChangedHandler senders are also dropped (via client shutdown).
         let _ = self.refresh_tx.lock().take();
@@ -1770,6 +1809,172 @@ fn ingest_tools(
     (filtered, sanitize_result)
 }
 
+/// Compute the sleep duration before retry attempt `attempt + 1`.
+///
+/// Doubling exponential backoff capped at 8 s:
+/// `min(500ms * 2^(attempt - 1), 8_000ms)`.
+///
+/// For `max_connect_attempts = 3` the sequence is **500 ms, 1 s**
+/// (three attempts → two inter-attempt gaps).
+/// For `max_connect_attempts = 10` the full sequence is
+/// 500, 1000, 2000, 4000, 8000, 8000, 8000, 8000, 8000 ms (total ≤ 47 s).
+///
+/// `attempt` is 1-based and corresponds to the just-failed attempt index.
+fn connect_retry_backoff(attempt: u8) -> Duration {
+    const BASE_MS: u64 = 500;
+    const CAP_MS: u64 = 8_000;
+    let exp = u32::from(attempt.saturating_sub(1));
+    let raw = BASE_MS.saturating_mul(2u64.saturating_pow(exp.min(20)));
+    Duration::from_millis(raw.min(CAP_MS))
+}
+
+/// Classify whether a connection error is transient and worth retrying.
+///
+/// Every [`McpError`] variant must be explicitly listed so that adding a new variant
+/// triggers a compile error that forces deliberate classification.
+fn is_retryable_connect_error(err: &McpError) -> bool {
+    match err {
+        // Transient transport / handshake failures.
+        McpError::Connection { .. } | McpError::Timeout { .. } => true,
+        // Permanent / structural failures — never retry.
+        McpError::ManagerShuttingDown { .. }
+        | McpError::CommandNotAllowed { .. }
+        | McpError::EnvVarBlocked { .. }
+        | McpError::SsrfBlocked { .. }
+        | McpError::InvalidUrl { .. }
+        | McpError::PolicyViolation(_)
+        | McpError::OAuthError { .. }
+        | McpError::OAuthCallbackTimeout { .. }
+        | McpError::ServerNotFound { .. }
+        | McpError::ServerAlreadyConnected { .. }
+        | McpError::ToolListLocked { .. }
+        | McpError::ToolCall { .. }
+        | McpError::ToolNotFound { .. }
+        | McpError::Qdrant(_)
+        | McpError::Json(_)
+        | McpError::IntConversion(_)
+        | McpError::Embedding(_) => false,
+    }
+}
+
+/// Retry an async `attempt_fn` up to `max_attempts` times with exponential backoff.
+///
+/// Status messages are emitted via `status_tx` (when present):
+/// - Attempt 1: `"Connecting to MCP server {server_id}..."`
+/// - Attempts 2..max: `"Reconnecting to MCP server {server_id} (attempt {n}/{max})..."`
+///
+/// Cancellation via `shutdown` is checked before every attempt and during backoff sleeps.
+/// On cancellation, returns `Err(McpError::ManagerShuttingDown)` immediately.
+async fn retry_loop<F, Fut>(
+    server_id: &str,
+    max_attempts: u8,
+    status_tx: Option<&StatusTx>,
+    shutdown: &CancellationToken,
+    mut attempt_fn: F,
+) -> Result<McpClient, McpError>
+where
+    F: FnMut(u8) -> Fut,
+    Fut: std::future::Future<Output = Result<McpClient, McpError>>,
+{
+    let mut last_err = McpError::ManagerShuttingDown {
+        server_id: server_id.to_owned(),
+    };
+
+    for attempt in 1..=max_attempts {
+        // Pre-attempt cancellation check.
+        if shutdown.is_cancelled() {
+            return Err(McpError::ManagerShuttingDown {
+                server_id: server_id.to_owned(),
+            });
+        }
+
+        // Emit status message.
+        if let Some(stx) = status_tx {
+            // SECURITY: only server_id is included — never transport URL, headers, or tokens.
+            let msg = if attempt == 1 {
+                format!("Connecting to MCP server {server_id}...")
+            } else {
+                format!(
+                    "Reconnecting to MCP server {server_id} (attempt {attempt}/{max_attempts})..."
+                )
+            };
+            let _ = stx.send(msg);
+        }
+
+        match attempt_fn(attempt).await {
+            Ok(client) => return Ok(client),
+            Err(e) => {
+                let retryable = is_retryable_connect_error(&e);
+                tracing::warn!(
+                    server_id,
+                    attempt,
+                    max_attempts,
+                    retryable,
+                    error = %e,
+                    "MCP server connection attempt failed"
+                );
+                last_err = e;
+                if !retryable || attempt == max_attempts {
+                    break;
+                }
+                // Cancellable backoff sleep.
+                let delay = connect_retry_backoff(attempt);
+                tokio::select! {
+                    biased;
+                    () = shutdown.cancelled() => {
+                        return Err(McpError::ManagerShuttingDown {
+                            server_id: server_id.to_owned(),
+                        });
+                    }
+                    () = tokio::time::sleep(delay) => {}
+                }
+            }
+        }
+    }
+
+    Err(last_err)
+}
+
+/// Connect to a single MCP server with startup retry and exponential backoff.
+///
+/// This is a thin shim over [`retry_loop`] that binds [`connect_entry`] as the attempt
+/// function. `add_server` uses [`connect_entry`] directly (single-attempt, no retry).
+#[allow(clippy::too_many_arguments)]
+async fn connect_with_retry(
+    entry: &ServerEntry,
+    allowed_commands: &[String],
+    suppress_stderr: bool,
+    tx: mpsc::UnboundedSender<ToolRefreshEvent>,
+    last_refresh: Arc<DashMap<String, Instant>>,
+    handler_cfg: &crate::client::HandlerConfig,
+    max_attempts: u8,
+    status_tx: Option<&StatusTx>,
+    shutdown: &CancellationToken,
+) -> Result<McpClient, McpError> {
+    retry_loop(
+        entry.id.as_str(),
+        max_attempts,
+        status_tx,
+        shutdown,
+        |_attempt| {
+            let tx = tx.clone();
+            let last_refresh = Arc::clone(&last_refresh);
+            async move {
+                connect_entry(
+                    entry,
+                    allowed_commands,
+                    suppress_stderr,
+                    tx,
+                    last_refresh,
+                    handler_cfg,
+                )
+                .await
+            }
+        },
+    )
+    .await
+}
+
 #[allow(clippy::too_many_arguments)] // function with many required inputs; a *Params struct would be more verbose without simplifying the call site
 async fn connect_entry(
     entry: &ServerEntry,
@@ -1777,7 +1982,7 @@ async fn connect_entry(
     suppress_stderr: bool,
     tx: mpsc::UnboundedSender<ToolRefreshEvent>,
     last_refresh: Arc<DashMap<String, Instant>>,
-    handler_cfg: crate::client::HandlerConfig,
+    handler_cfg: &crate::client::HandlerConfig,
 ) -> Result<McpClient, McpError> {
     match &entry.transport {
         McpTransport::Stdio { command, args, env } => {
@@ -1792,7 +1997,7 @@ async fn connect_entry(
                 entry.env_isolation,
                 tx,
                 last_refresh,
-                handler_cfg,
+                handler_cfg.clone(),
             )
             .await
         }
@@ -1806,7 +2011,7 @@ async fn connect_entry(
                     trusted,
                     tx,
                     last_refresh,
-                    handler_cfg,
+                    handler_cfg.clone(),
                 )
                 .await
             } else {
@@ -1818,7 +2023,7 @@ async fn connect_entry(
                     trusted,
                     tx,
                     last_refresh,
-                    handler_cfg,
+                    handler_cfg.clone(),
                 )
                 .await
             }
@@ -3146,6 +3351,252 @@ mod tests {
         assert!(
             err.to_string().contains("dup-srv"),
             "error message must contain server id"
+        );
+    }
+
+    // ── Backoff curve ──────────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn connect_retry_backoff_table() {
+        let expected_ms: &[(u8, u64)] = &[
+            (1, 500),
+            (2, 1000),
+            (3, 2000),
+            (4, 4000),
+            (5, 8000),
+            (6, 8000),
+            (7, 8000),
+            (8, 8000),
+            (9, 8000),
+            (10, 8000),
+        ];
+        for &(attempt, expected) in expected_ms {
+            let actual = u64::try_from(connect_retry_backoff(attempt).as_millis())
+                .expect("backoff duration fits u64");
+            assert_eq!(
+                actual, expected,
+                "backoff for attempt {attempt} should be {expected} ms"
+            );
+        }
+    }
+
+    // ── Error classifier ───────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn is_retryable_connect_error_exhaustive() {
+        use crate::error::McpErrorCode;
+        let retryable = vec![
+            McpError::Connection {
+                server_id: "s".into(),
+                message: "refused".into(),
+            },
+            McpError::Timeout {
+                server_id: "s".into(),
+                tool_name: "t".into(),
+                timeout_secs: 30,
+            },
+        ];
+        for err in &retryable {
+            assert!(is_retryable_connect_error(err), "{err} should be retryable");
+        }
+
+        let non_retryable: Vec<McpError> = vec![
+            McpError::ManagerShuttingDown {
+                server_id: "s".into(),
+            },
+            McpError::CommandNotAllowed {
+                command: "sh".into(),
+            },
+            McpError::EnvVarBlocked {
+                var_name: "HOME".into(),
+            },
+            McpError::SsrfBlocked {
+                url: "http://localhost".into(),
+                addr: "127.0.0.1".into(),
+            },
+            McpError::InvalidUrl {
+                url: "bad".into(),
+                message: "nope".into(),
+            },
+            McpError::PolicyViolation("denied".into()),
+            McpError::OAuthError {
+                server_id: "s".into(),
+                message: "e".into(),
+            },
+            McpError::OAuthCallbackTimeout {
+                server_id: "s".into(),
+                timeout_secs: 10,
+            },
+            McpError::ServerNotFound {
+                server_id: "s".into(),
+            },
+            McpError::ServerAlreadyConnected {
+                server_id: "s".into(),
+            },
+            McpError::ToolListLocked {
+                server_id: "s".into(),
+            },
+            McpError::ToolCall {
+                server_id: "s".into(),
+                tool_name: "t".into(),
+                message: "e".into(),
+                code: McpErrorCode::ServerError,
+            },
+            McpError::ToolNotFound {
+                server_id: "s".into(),
+                tool_name: "t".into(),
+            },
+            McpError::Json(serde_json::from_str::<i32>("bad").unwrap_err()),
+            McpError::Embedding("e".into()),
+        ];
+        for err in &non_retryable {
+            assert!(
+                !is_retryable_connect_error(err),
+                "{err} should NOT be retryable"
+            );
+        }
+    }
+
+    // ── retry_loop unit tests ──────────────────────────────────────────────────────────────────
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_loop_attempt_counter_starts_at_one() {
+        let token = CancellationToken::new();
+        let first_attempt = std::sync::Arc::new(std::sync::atomic::AtomicU8::new(0));
+        let first_clone = std::sync::Arc::clone(&first_attempt);
+        let _: Result<McpClient, McpError> = retry_loop("srv", 1, None, &token, |attempt| {
+            let first = std::sync::Arc::clone(&first_clone);
+            async move {
+                first.store(attempt, std::sync::atomic::Ordering::SeqCst);
+                Err(McpError::CommandNotAllowed {
+                    command: "x".into(),
+                })
+            }
+        })
+        .await;
+        assert_eq!(
+            first_attempt.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "first attempt index must be 1"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_loop_cancels_before_first_attempt() {
+        let token = CancellationToken::new();
+        token.cancel();
+        let mut called = false;
+        let result = retry_loop("srv", 3, None, &token, |_attempt| {
+            called = true;
+            async move {
+                Err(McpError::Connection {
+                    server_id: "srv".into(),
+                    message: "should not be called".into(),
+                })
+            }
+        })
+        .await;
+        assert!(
+            !called,
+            "attempt_fn must not be called when shutdown is pre-cancelled"
+        );
+        assert!(
+            matches!(result, Err(McpError::ManagerShuttingDown { .. })),
+            "expected ManagerShuttingDown, got {result:?}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_loop_cancels_during_backoff_sleep() {
+        let token = CancellationToken::new();
+        let token_clone = token.clone();
+        let attempt_count = std::sync::Arc::new(std::sync::atomic::AtomicU8::new(0));
+        let count_clone = std::sync::Arc::clone(&attempt_count);
+
+        // Spawn a task that cancels the token shortly after the first attempt fails and
+        // the retry_loop is sleeping its backoff.
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            token_clone.cancel();
+        });
+
+        let result = retry_loop("srv", 3, None, &token, |_| {
+            let count = std::sync::Arc::clone(&count_clone);
+            async move {
+                count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Err(McpError::Connection {
+                    server_id: "srv".into(),
+                    message: "transient".into(),
+                })
+            }
+        })
+        .await;
+
+        assert_eq!(
+            attempt_count.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "only the first attempt should run before cancellation"
+        );
+        assert!(
+            matches!(result, Err(McpError::ManagerShuttingDown { .. })),
+            "expected ManagerShuttingDown, got {result:?}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_loop_stops_on_non_retryable_error() {
+        let token = CancellationToken::new();
+        let attempt_count = std::sync::Arc::new(std::sync::atomic::AtomicU8::new(0));
+        let count_clone = std::sync::Arc::clone(&attempt_count);
+
+        let result = retry_loop("srv", 5, None, &token, |_| {
+            let count = std::sync::Arc::clone(&count_clone);
+            async move {
+                count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Err(McpError::CommandNotAllowed {
+                    command: "rm".into(),
+                })
+            }
+        })
+        .await;
+
+        assert_eq!(
+            attempt_count.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "non-retryable error must stop after first attempt"
+        );
+        assert!(
+            matches!(result, Err(McpError::CommandNotAllowed { .. })),
+            "last error should be propagated"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_loop_exhausts_all_attempts_for_retryable_error() {
+        let token = CancellationToken::new();
+        let attempt_count = std::sync::Arc::new(std::sync::atomic::AtomicU8::new(0));
+        let count_clone = std::sync::Arc::clone(&attempt_count);
+
+        let result = retry_loop("srv", 3, None, &token, |_| {
+            let count = std::sync::Arc::clone(&count_clone);
+            async move {
+                count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Err(McpError::Connection {
+                    server_id: "srv".into(),
+                    message: "refused".into(),
+                })
+            }
+        })
+        .await;
+
+        assert_eq!(
+            attempt_count.load(std::sync::atomic::Ordering::SeqCst),
+            3,
+            "should exhaust all 3 attempts for retryable errors"
+        );
+        assert!(
+            matches!(result, Err(McpError::Connection { .. })),
+            "last error should be propagated"
         );
     }
 }

--- a/src/bootstrap/mcp.rs
+++ b/src/bootstrap/mcp.rs
@@ -81,7 +81,8 @@ pub fn create_mcp_manager_with_vault(
         config.mcp.max_description_bytes,
         config.mcp.max_instructions_bytes,
     )
-    .with_lock_tool_list(config.mcp.lock_tool_list);
+    .with_lock_tool_list(config.mcp.lock_tool_list)
+    .with_max_connect_attempts(config.mcp.max_connect_attempts);
 
     // Register OAuth credential stores
     for s in &config.mcp.servers {


### PR DESCRIPTION
## Summary

- Implements automatic retry logic for MCP server startup connection failures (#3568)
- Retries `Connection` and `Timeout` errors up to `mcp.max_connect_attempts` times (default 3, range 1–10) with exponential backoff (500 ms → 1 s → 2 s, capped at 8 s per interval)
- Shutdown-safe: a `CancellationToken` is threaded through the retry loop; `tokio::select! biased` ensures any in-progress sleep exits within milliseconds of `shutdown_all_shared` being called

## Changes

- `McpError::ManagerShuttingDown { server_id }` — new terminal lifecycle variant, maps to `None` in `code()`, never retried; replaces string-literal guard in manager
- `retry_loop` — generic `CancellationToken`-driven helper with closed-form backoff `min(500 * 2^(n-1), 8000) ms`; unit-testable via `tokio::time::pause()`
- `connect_with_retry` — thin wrapper binding `connect_entry` into `retry_loop`
- `is_retryable_connect_error` — exhaustive match on all `McpError` variants (compile error on new unclassified variants)
- `McpConfig::max_connect_attempts: u8` — validated at deserialization (rejects 0 and >10); migration step 40 renames `max_connect_retries` in existing configs
- TUI spinner messages via existing `status_tx` channel (no TUI code change)
- Integration test enforces `max_connect_attempts` presence across all three `default.toml` copies
- `add_server` retry explicitly out of scope; tracked as follow-up (see security finding F1)

## Test plan

- [ ] `cargo nextest run -p zeph-mcp --lib --bins` — 440 tests pass (7 new retry-specific unit tests)
- [ ] `cargo nextest run -p zeph-config --lib --bins` — 342 tests pass (8 new config/migration tests + default.toml consistency integration test)
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] Live test: configure a slow-starting MCP server subprocess, verify WARN logs with attempt count and TUI spinner appear before eventual connection or failure
- [ ] Follow-up issue to be filed: HTTP 401/403 from remote MCP endpoints wrapped into `McpError::Connection` (classified retryable); recommend adding structured HTTP status to the variant before extending retry to `add_server`

Closes #3568