### PR TITLE
feat(security): TrajectorySentinel and ScopedToolExecutor for capability governance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,49 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   generic connection error when shutdown is detected. Dynamic `/mcp add` retains single-attempt
   behaviour; a follow-up issue tracks extending retry there (#3568).
 
+- feat(security): `TrajectorySentinel` in `zeph-core` — cross-turn risk accumulator with
+  multiplicative score decay (`decay_per_turn = 0.85`), four risk levels (`Calm`, `Elevated`,
+  `High`, `Critical`), configurable thresholds, FR-CG-010 auto-recover hard reset after
+  `auto_recover_after_turns` (default 16) consecutive Critical turns, subagent score inheritance
+  via `spawn_child()` (factor 0.5), and `poll_alert()` for `PolicyGateExecutor` integration.
+  Signal taxonomy: `VigilFlagged`, `PolicyDeny`, `ExfiltrationRedaction`, `OutOfScope`,
+  `PiiRedaction`, `ToolFailure`, `HighCallRate`, `UnusualReadVolume`, `ToolPairTransition`.
+  Stored on `SecurityState`; never exposed to LLM-callable surfaces (spec 050 Phase 1, #3570).
+
+- feat(security): `ScopedToolExecutor<E>` in `zeph-tools` — config-driven capability scope
+  wrapper that filters both `tool_definitions()` (LLM tool list) and `execute_tool_call()`
+  dispatch to an operator-configured allow-list of fully-qualified tool ids
+  (`builtin:`, `skill:`, `mcp:`, `acp:`, `a2a:` namespaces). Build-time glob resolution
+  with fatal `ScopeError::DeadPattern` for strict namespaces and
+  `ScopeWarning::ProvisionalDeadPattern` for dynamic namespaces. New `ToolError::OutOfScope`
+  variant with `error_category = "out_of_scope"` in the audit log. `scope_for_task()` method
+  and per-call `scope_at_definition` / `scope_at_dispatch` audit fields (spec 050 Phase 1, #3563).
+
+- feat(config): `[security.trajectory]` and `[security.capability_scopes]` TOML sections:
+  `TrajectorySentinelConfig` (decay, thresholds, auto-recover, subagent factor) and
+  `CapabilityScopesConfig` (named scopes, `default_scope`, `pattern_strictness`) added to
+  `SecurityConfig` with backward-compatible defaults (spec 050 Phase 1, #3563).
+
+- feat(security): agent loop wiring for spec 050 — `begin_turn()` now calls
+  `TrajectorySentinel::advance_turn()` and writes the current `RiskLevel` to the shared
+  `TrajectoryRiskSlot` before `PolicyGateExecutor` runs (Invariant 2); `RiskAlert` is emitted
+  to the TUI/CLI status channel when score crosses `alert_threshold` (NFR-CG-006).
+
+- feat(security): `PolicyGateExecutor` Critical downgrade — when `TrajectoryRiskSlot >= 3`
+  (Critical), all `Allow` policy decisions are overridden to `Deny` with
+  `error_category = "trajectory_critical_downgrade"` in the audit log before policy evaluation.
+
+- feat(cli): `/trajectory [status|reset]` and `/scope list` operator commands for live inspection
+  and reset of the trajectory sentinel; operator-only — scores and risk levels are not exposed to
+  LLM context (spec 050 LLM isolation invariant).
+
+- feat(init): `--init` wizard prompts for `[security.trajectory]` thresholds (`critical_at`,
+  `auto_recover_after_turns`) in a dedicated `step_trajectory` step after the policy enforcer step.
+
+- feat(config): `--migrate-config` support for new `[security.trajectory]` and
+  `[security.capability_scopes]` sections is automatic — `ConfigMigrator` picks up the new
+  defaults from `default.toml`.
+
 ### Documentation
 
 - research: synthesize MemCoT, OmniMem, and OCR-Memory memory architecture papers; document integration roadmap and file follow-up issues (#3564, #3566, #3571); add Research Backlog to APEX-MEM spec (see specs §14)

--- a/config/default.toml
+++ b/config/default.toml
@@ -769,6 +769,34 @@ sources = ["web_scrape", "a2a_message"]
 # (e.g. "claude", "ollama", "openai", or a compatible entry name)
 model = "claude"
 
+[security.trajectory]
+# Exponential decay factor applied to signal scores each turn (default: 0.85)
+decay_per_turn = 0.85
+# Rolling window in turns used for signal accumulation (default: 10)
+window_turns = 10
+# Score threshold for Elevated risk level (default: 2.0)
+elevated_at = 2.0
+# Score threshold for High risk level (default: 5.0)
+high_at = 5.0
+# Score threshold for Critical risk level — Allow decisions are downgraded to Deny (default: 10.0)
+critical_at = 10.0
+# Score at which a RiskAlert is emitted to the TUI/CLI (default: 4.0)
+alert_threshold = 4.0
+# Consecutive Critical turns before hard auto-reset (FR-CG-010, default: 16)
+auto_recover_after_turns = 16
+# Inheritance factor applied to parent score when spawning a subagent (default: 0.5)
+subagent_inheritance_factor = 0.5
+
+[security.capability_scopes]
+# Strictness for tool-id pattern matching: "Strict", "Permissive", or "ProvisionalForDynamicNamespaces" (default)
+# pattern_strictness = "ProvisionalForDynamicNamespaces"
+# Name of the scope to use when no task type is specified
+# default_scope = "general"
+
+# Example scope: enable all tools for the default task type
+# [security.capability_scopes.general]
+# patterns = ["*"]
+
 # [telegram]
 # token = "your-bot-token"
 # Allowed usernames (empty = allow all except for /start command)

--- a/crates/zeph-commands/src/handlers/mod.rs
+++ b/crates/zeph-commands/src/handlers/mod.rs
@@ -32,3 +32,4 @@ pub mod status;
 // These commands continue to be dispatched via dispatch_slash_command in zeph-core until
 // SemanticMemory and AnyProvider implement Sync.
 pub mod skill;
+pub mod trajectory;

--- a/crates/zeph-commands/src/handlers/trajectory.rs
+++ b/crates/zeph-commands/src/handlers/trajectory.rs
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `/trajectory` and `/scope` command handlers (spec 050 Phase 1).
+
+use std::future::Future;
+use std::pin::Pin;
+
+use crate::context::CommandContext;
+use crate::{CommandError, CommandHandler, CommandOutput, SlashCategory};
+
+/// Inspect or reset the trajectory risk sentinel.
+///
+/// Subcommands: `status` (default), `reset`.
+pub struct TrajectoryCommand;
+
+impl CommandHandler<CommandContext<'_>> for TrajectoryCommand {
+    fn name(&self) -> &'static str {
+        "/trajectory"
+    }
+
+    fn description(&self) -> &'static str {
+        "Show trajectory risk sentinel status or reset it"
+    }
+
+    fn args_hint(&self) -> &'static str {
+        "[status|reset]"
+    }
+
+    fn category(&self) -> SlashCategory {
+        SlashCategory::Advanced
+    }
+
+    fn handle<'a>(
+        &'a self,
+        ctx: &'a mut CommandContext<'_>,
+        args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<CommandOutput, CommandError>> + Send + 'a>> {
+        Box::pin(async move {
+            let result = ctx.agent.handle_trajectory(args);
+            Ok(CommandOutput::Message(result))
+        })
+    }
+}
+
+/// List configured capability scopes.
+///
+/// Subcommands: `list [task_type]` (default).
+pub struct ScopeCommand;
+
+impl CommandHandler<CommandContext<'_>> for ScopeCommand {
+    fn name(&self) -> &'static str {
+        "/scope"
+    }
+
+    fn description(&self) -> &'static str {
+        "List configured capability scopes (spec 050)"
+    }
+
+    fn args_hint(&self) -> &'static str {
+        "[list [task_type]]"
+    }
+
+    fn category(&self) -> SlashCategory {
+        SlashCategory::Advanced
+    }
+
+    fn handle<'a>(
+        &'a self,
+        ctx: &'a mut CommandContext<'_>,
+        args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<CommandOutput, CommandError>> + Send + 'a>> {
+        Box::pin(async move {
+            let result = ctx.agent.handle_scope(args);
+            Ok(CommandOutput::Message(result))
+        })
+    }
+}

--- a/crates/zeph-commands/src/traits/agent.rs
+++ b/crates/zeph-commands/src/traits/agent.rs
@@ -434,6 +434,16 @@ pub trait AgentAccess: Send {
     fn notify_test<'a>(
         &'a mut self,
     ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>>;
+
+    // ----- /trajectory -----
+
+    /// Handle `/trajectory [status|reset]` and return a user-visible result.
+    fn handle_trajectory(&mut self, args: &str) -> String;
+
+    // ----- /scope -----
+
+    /// Handle `/scope [list [task_type]]` and return a user-visible result.
+    fn handle_scope(&self, args: &str) -> String;
 }
 
 /// A no-op [`AgentAccess`] implementation.
@@ -668,5 +678,13 @@ impl AgentAccess for NullAgent {
         &'a mut self,
     ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>> {
         Box::pin(async { Ok("Notifications not configured.".to_owned()) })
+    }
+
+    fn handle_trajectory(&mut self, _args: &str) -> String {
+        String::new()
+    }
+
+    fn handle_scope(&self, _args: &str) -> String {
+        String::new()
     }
 }

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -158,7 +158,10 @@ pub use sanitizer::{
     ResponseVerificationConfig,
 };
 pub use sanitizer::{GuardrailAction, GuardrailConfig, GuardrailFailStrategy};
-pub use security::{ScannerConfig, SecurityConfig, TimeoutConfig, TrustConfig};
+pub use security::{
+    CapabilityScopesConfig, PatternStrictness, ScannerConfig, ScopeConfig, SecurityConfig,
+    TimeoutConfig, TrajectorySentinelConfig, TrustConfig,
+};
 pub use session::{RecapConfig, SessionConfig};
 pub use subagent::{
     HookAction, HookDef, HookMatcher, MemoryScope, PermissionMode, SkillFilter, SubagentHooks,

--- a/crates/zeph-config/src/security.rs
+++ b/crates/zeph-config/src/security.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 use zeph_common::SkillTrustLevel;
 
@@ -143,6 +145,250 @@ impl Default for TrustConfig {
     }
 }
 
+// ── Trajectory Sentinel ──────────────────────────────────────────────────────
+
+fn default_decay_per_turn() -> f32 {
+    0.85
+}
+fn default_window_turns() -> u32 {
+    8
+}
+fn default_elevated_at() -> f32 {
+    2.0
+}
+fn default_high_at() -> f32 {
+    4.0
+}
+fn default_critical_at() -> f32 {
+    8.0
+}
+fn default_alert_threshold() -> f32 {
+    4.0
+}
+fn default_auto_recover_after_turns() -> u32 {
+    16
+}
+fn default_subagent_inheritance_factor() -> f32 {
+    0.5
+}
+fn default_high_call_rate_threshold() -> u32 {
+    12
+}
+fn default_unusual_read_threshold() -> u32 {
+    24
+}
+fn default_auto_recover_floor() -> u32 {
+    4
+}
+
+/// Configuration for `TrajectorySentinel`, nested under `[security.trajectory]` in TOML.
+///
+/// Controls signal decay, risk level thresholds, auto-recovery, and subagent inheritance.
+///
+/// # Example (TOML)
+///
+/// ```toml
+/// [security.trajectory]
+/// decay_per_turn = 0.85
+/// elevated_at = 2.0
+/// high_at = 4.0
+/// critical_at = 8.0
+/// alert_threshold = 4.0
+/// auto_recover_after_turns = 16
+/// subagent_inheritance_factor = 0.5
+/// ```
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct TrajectorySentinelConfig {
+    /// Multiplicative decay applied to the running score at each `advance_turn()` call.
+    ///
+    /// Must be in `(0.0, 1.0]`. Default 0.85 gives a half-life of ≈ 4.3 turns.
+    #[serde(default = "default_decay_per_turn")]
+    pub decay_per_turn: f32,
+    /// Number of past turns to keep in the signal buffer.
+    ///
+    /// Older signals are evicted once the buffer exceeds this size. Default 8.
+    #[serde(default = "default_window_turns")]
+    pub window_turns: u32,
+    /// Score threshold for transitioning from `Calm` to `Elevated`. Default 2.0.
+    #[serde(default = "default_elevated_at")]
+    pub elevated_at: f32,
+    /// Score threshold for transitioning from `Elevated` to `High`. Default 4.0.
+    #[serde(default = "default_high_at")]
+    pub high_at: f32,
+    /// Score threshold for transitioning from `High` to `Critical`. Default 8.0.
+    #[serde(default = "default_critical_at")]
+    pub critical_at: f32,
+    /// Score at which `PolicyGateExecutor` is notified via `RiskAlert`. Default 4.0.
+    ///
+    /// Decoupled from `elevated_at` to prevent alert noise for routine minor events.
+    #[serde(default = "default_alert_threshold")]
+    pub alert_threshold: f32,
+    /// Consecutive `Critical` turns before a hard auto-recover reset. Minimum 4. Default 16.
+    #[serde(default = "default_auto_recover_after_turns")]
+    pub auto_recover_after_turns: u32,
+    /// Fraction of parent score inherited by a subagent when parent is `>= Elevated`.
+    ///
+    /// Default 0.5 (≈ one decay half-life). Config validator warns when this deviates
+    /// more than 0.1 from `decay_per_turn ^ (ln(0.5) / ln(decay_per_turn))`.
+    #[serde(default = "default_subagent_inheritance_factor")]
+    pub subagent_inheritance_factor: f32,
+    /// Tool-call count per 3-turn window above which `HighCallRate` fires. Default 12.
+    #[serde(default = "default_high_call_rate_threshold")]
+    pub high_call_rate_threshold: u32,
+    /// Distinct paths read within `window_turns` above which `UnusualReadVolume` fires. Default 24.
+    #[serde(default = "default_unusual_read_threshold")]
+    pub unusual_read_threshold: u32,
+}
+
+impl Default for TrajectorySentinelConfig {
+    fn default() -> Self {
+        Self {
+            decay_per_turn: default_decay_per_turn(),
+            window_turns: default_window_turns(),
+            elevated_at: default_elevated_at(),
+            high_at: default_high_at(),
+            critical_at: default_critical_at(),
+            alert_threshold: default_alert_threshold(),
+            auto_recover_after_turns: default_auto_recover_after_turns(),
+            subagent_inheritance_factor: default_subagent_inheritance_factor(),
+            high_call_rate_threshold: default_high_call_rate_threshold(),
+            unusual_read_threshold: default_unusual_read_threshold(),
+        }
+    }
+}
+
+impl TrajectorySentinelConfig {
+    /// Validate numeric bounds. Returns an error string when validation fails.
+    ///
+    /// # Errors
+    ///
+    /// Returns a description of the first validation failure found.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.decay_per_turn <= 0.0 || self.decay_per_turn > 1.0 {
+            return Err(format!(
+                "trajectory.decay_per_turn must be in (0.0, 1.0]; got {}",
+                self.decay_per_turn
+            ));
+        }
+        if self.elevated_at >= self.high_at {
+            return Err(format!(
+                "trajectory: elevated_at ({}) must be < high_at ({})",
+                self.elevated_at, self.high_at
+            ));
+        }
+        if self.high_at >= self.critical_at {
+            return Err(format!(
+                "trajectory: high_at ({}) must be < critical_at ({})",
+                self.high_at, self.critical_at
+            ));
+        }
+        if self.auto_recover_after_turns < default_auto_recover_floor() {
+            return Err(format!(
+                "trajectory.auto_recover_after_turns must be >= {}; got {}",
+                default_auto_recover_floor(),
+                self.auto_recover_after_turns
+            ));
+        }
+        // Advisory: warn when subagent_inheritance_factor deviates from calibrated value.
+        if self.decay_per_turn < 1.0 {
+            let ideal = self
+                .decay_per_turn
+                .powf(0.5_f32.ln() / self.decay_per_turn.ln());
+            if (self.subagent_inheritance_factor - ideal).abs() > 0.1 {
+                // Not a hard error — warn only.
+                tracing::warn!(
+                    configured = self.subagent_inheritance_factor,
+                    ideal = ideal,
+                    decay = self.decay_per_turn,
+                    "trajectory.subagent_inheritance_factor deviates from calibrated value by more than 0.1"
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+// ── Capability Scopes ────────────────────────────────────────────────────────
+
+/// Strictness mode for glob pattern matching against the tool registry.
+///
+/// Controls whether a zero-match glob is a fatal error or a warning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum PatternStrictness {
+    /// All namespaces are strict — zero-match globs are fatal.
+    Strict,
+    /// All namespaces are permissive — zero-match globs are warnings only.
+    Permissive,
+    /// `builtin:` and `skill:` globs are strict; `mcp:`, `acp:`, `a2a:` are provisional.
+    ///
+    /// This is the default because MCP servers may not be connected at startup.
+    #[default]
+    ProvisionalForDynamicNamespaces,
+}
+
+/// Configuration for a single task-type scope, nested under
+/// `[security.capability_scopes.<task_type>]`.
+///
+/// # Example (TOML)
+///
+/// ```toml
+/// [security.capability_scopes.research]
+/// patterns = ["builtin:fetch", "builtin:web_scrape", "builtin:search_*"]
+/// ```
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ScopeConfig {
+    /// Glob patterns over fully-qualified tool ids (`<namespace>:<tool>`).
+    ///
+    /// Evaluated against the materialised tool registry at agent build time.
+    #[serde(default)]
+    pub patterns: Vec<String>,
+}
+
+/// Top-level capability scopes configuration, nested under `[security.capability_scopes]`.
+///
+/// # Example (TOML)
+///
+/// ```toml
+/// [security.capability_scopes]
+/// default_scope = "general"
+/// strict = true
+///
+/// [security.capability_scopes.general]
+/// patterns = ["*"]
+///
+/// [security.capability_scopes.research]
+/// patterns = ["builtin:fetch", "builtin:web_scrape", "builtin:search_*", "builtin:read"]
+///
+/// [security.capability_scopes.code_edit]
+/// patterns = ["builtin:read", "builtin:edit", "builtin:write", "builtin:shell", "builtin:glob"]
+/// ```
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct CapabilityScopesConfig {
+    /// Name of the scope used when no task type is specified. Default: `"general"`.
+    ///
+    /// When `default_scope = "general"` and a `[security.capability_scopes.general]` section
+    /// with `patterns = ["*"]` exists, scoping is a no-op identity (full tool set surfaced).
+    #[serde(default = "default_scope_name")]
+    pub default_scope: String,
+    /// When `true`, an unrecognised `task_type` is a fatal startup error.
+    /// When `false`, falls back to `default_scope`. Default: `false`.
+    #[serde(default)]
+    pub strict: bool,
+    /// Per-namespace strictness for zero-match glob patterns.
+    #[serde(default)]
+    pub pattern_strictness: PatternStrictness,
+    /// Named scopes. Keys are task-type names; values are their scope configurations.
+    #[serde(default, flatten)]
+    pub scopes: HashMap<String, ScopeConfig>,
+}
+
+fn default_scope_name() -> String {
+    "general".to_owned()
+}
+
+// ── Agent security configuration ─────────────────────────────────────────────
+
 /// Agent security configuration, nested under `[security]` in TOML.
 ///
 /// Aggregates all security-related subsystems: content isolation, exfiltration guards,
@@ -200,6 +446,18 @@ pub struct SecurityConfig {
     /// patterns. See `[[security.vigil]]` in TOML and spec `010-6-vigil-intent-anchoring`.
     #[serde(default)]
     pub vigil: VigilConfig,
+    /// Trajectory risk sentinel configuration.
+    ///
+    /// Controls signal decay, risk level thresholds, auto-recovery, and subagent inheritance.
+    /// See spec 050 and `crates/zeph-core/src/agent/trajectory.rs`.
+    #[serde(default)]
+    pub trajectory: TrajectorySentinelConfig,
+    /// Capability scope configuration.
+    ///
+    /// Maps task-type names to glob-pattern allow-lists over fully-qualified tool ids.
+    /// When empty, scoping is a no-op (full tool set surfaced to LLM).
+    #[serde(default)]
+    pub capability_scopes: CapabilityScopesConfig,
 }
 
 impl Default for SecurityConfig {
@@ -217,6 +475,8 @@ impl Default for SecurityConfig {
             response_verification: ResponseVerificationConfig::default(),
             causal_ipi: CausalIpiConfig::default(),
             vigil: VigilConfig::default(),
+            trajectory: TrajectorySentinelConfig::default(),
+            capability_scopes: CapabilityScopesConfig::default(),
         }
     }
 }

--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -935,6 +935,14 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
             }
         })
     }
+
+    fn handle_trajectory(&mut self, args: &str) -> String {
+        self.handle_trajectory_command_as_string(args)
+    }
+
+    fn handle_scope(&self, args: &str) -> String {
+        self.handle_scope_command_as_string(args)
+    }
 }
 
 /// Convert `AgentError` to `CommandError` for the trait boundary.

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -705,6 +705,45 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Inject an externally created trajectory risk slot.
+    ///
+    /// Used when the slot is created before the agent (e.g. in the runner to share with
+    /// `PolicyGateExecutor`). The existing slot is replaced so both sides see the same `Arc`.
+    #[must_use]
+    pub fn with_trajectory_risk_slot(mut self, slot: zeph_tools::TrajectoryRiskSlot) -> Self {
+        self.services.security.trajectory_risk_slot = slot;
+        self
+    }
+
+    /// Inject an externally created risk signal queue (spec 050 §2).
+    ///
+    /// The same queue must be passed to `PolicyGateExecutor::with_signal_queue` and
+    /// `ScopedToolExecutor::with_signal_queue` so executor-layer signals flow to `begin_turn()`.
+    #[must_use]
+    pub fn with_signal_queue(mut self, queue: zeph_tools::RiskSignalQueue) -> Self {
+        self.services.security.trajectory_signal_queue = queue;
+        self
+    }
+
+    /// Configure the trajectory sentinel and return the shared risk slot + signal queue.
+    ///
+    /// Pass the returned slot to `PolicyGateExecutor::with_trajectory_risk` and the queue to
+    /// `PolicyGateExecutor::with_signal_queue` and `ScopedToolExecutor::with_signal_queue`.
+    #[must_use]
+    pub fn with_trajectory_config(
+        mut self,
+        cfg: zeph_config::TrajectorySentinelConfig,
+    ) -> (
+        Self,
+        zeph_tools::TrajectoryRiskSlot,
+        zeph_tools::RiskSignalQueue,
+    ) {
+        self.services.security.trajectory = crate::agent::trajectory::TrajectorySentinel::new(cfg);
+        let slot = std::sync::Arc::clone(&self.services.security.trajectory_risk_slot);
+        let queue = std::sync::Arc::clone(&self.services.security.trajectory_signal_queue);
+        (self, slot, queue)
+    }
+
     /// Attach a temporal causal IPI analyzer.
     ///
     /// When `Some`, the native tool dispatch loop runs pre/post behavioral probes.

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -44,6 +44,7 @@ pub(crate) mod rate_limiter;
 mod scheduler_commands;
 #[cfg(feature = "scheduler")]
 mod scheduler_loop;
+mod scope_commands;
 pub mod session_config;
 mod session_digest;
 pub(crate) mod sidequest;
@@ -54,6 +55,8 @@ pub(crate) mod state;
 pub(crate) mod task_injection;
 pub(crate) mod tool_execution;
 pub(crate) mod tool_orchestrator;
+pub mod trajectory;
+mod trajectory_commands;
 mod trust_commands;
 pub mod turn;
 mod utils;
@@ -1031,6 +1034,7 @@ impl<C: Channel> Agent<C> {
                     scheduler::SchedulerCommand,
                     skill::{FeedbackCommand, SkillCommand, SkillsCommand},
                     status::{FocusCommand, GuardrailCommand, SideQuestCommand, StatusCommand},
+                    trajectory::{ScopeCommand, TrajectoryCommand},
                 };
 
                 let mut agent_reg = CommandRegistry::new();
@@ -1065,6 +1069,8 @@ impl<C: Channel> Agent<C> {
                 agent_reg.register(LoopCommand);
                 agent_reg.register(PluginsCommand);
                 agent_reg.register(AcpCommand);
+                agent_reg.register(TrajectoryCommand);
+                agent_reg.register(ScopeCommand);
 
                 let mut ctx = zeph_commands::CommandContext {
                     sink: &mut agent_null_sink,
@@ -1334,6 +1340,73 @@ impl<C: Channel> Agent<C> {
         self.services.security.user_provided_urls.write().clear();
         // Reset per-turn LLM request counter for the notification gate.
         self.runtime.lifecycle.turn_llm_requests = 0;
+
+        // Spec 050 §2: drain pending risk signals from executor layers before advancing.
+        {
+            let pending: Vec<u8> = {
+                let mut q = self.services.security.trajectory_signal_queue.lock();
+                std::mem::take(&mut *q)
+            };
+            for code in pending {
+                self.services
+                    .security
+                    .trajectory
+                    .record(crate::agent::trajectory::RiskSignal::from_code(code));
+            }
+        }
+        // Spec 050 Invariant 2: advance trajectory sentinel BEFORE any gate evaluation.
+        // F5: write auto-recover audit entry when sentinel hard-resets.
+        if self.services.security.trajectory.advance_turn()
+            && let Some(logger) = self.tool_orchestrator.audit_logger.clone()
+        {
+            let entry = zeph_tools::AuditEntry {
+                timestamp: zeph_tools::chrono_now(),
+                tool: "<sentinel>".to_owned().into(),
+                command: String::new(),
+                result: zeph_tools::AuditResult::Success,
+                duration_ms: 0,
+                error_category: Some("trajectory_auto_recover".to_owned()),
+                error_domain: Some("security".to_owned()),
+                error_phase: None,
+                claim_source: None,
+                mcp_server_id: None,
+                injection_flagged: false,
+                embedding_anomalous: false,
+                cross_boundary_mcp_to_acp: false,
+                adversarial_policy_decision: None,
+                exit_code: None,
+                truncated: false,
+                caller_id: None,
+                policy_match: None,
+                correlation_id: None,
+                vigil_risk: None,
+                scope_at_definition: None,
+                scope_at_dispatch: None,
+            };
+            self.runtime.lifecycle.supervisor.spawn(
+                crate::agent::agent_supervisor::TaskClass::Telemetry,
+                "trajectory-auto-recover-audit",
+                async move { logger.log(&entry).await },
+            );
+        }
+        // Publish updated risk level to the shared slot so PolicyGateExecutor can read it.
+        let risk_level = self.services.security.trajectory.current_risk();
+        *self.services.security.trajectory_risk_slot.write() = u8::from(risk_level);
+        // TUI/CLI: emit a status indicator when risk reaches High or Critical (NFR-CG-006).
+        if let Some(alert) = self.services.security.trajectory.poll_alert() {
+            let msg = format!(
+                "[trajectory] Risk level: {:?} (score={:.2})",
+                alert.level, alert.score
+            );
+            tracing::warn!(
+                level = ?alert.level,
+                score = alert.score,
+                "trajectory sentinel alert"
+            );
+            if let Some(ref tx) = self.services.session.status_tx {
+                let _ = tx.send(msg);
+            }
+        }
 
         let context = turn::TurnContext::new(id, cancel_token, self.runtime.config.timeouts);
         turn::Turn::new(context, input)
@@ -2392,6 +2465,12 @@ impl<C: Channel> Agent<C> {
             },
             spawn_depth: self.runtime.config.spawn_depth,
             mcp_tool_names: self.extract_mcp_tool_names(),
+            // F3 spec 050 §4: propagate seeded score when parent is >= Elevated.
+            seed_trajectory_score: {
+                let child = self.services.security.trajectory.spawn_child();
+                let score = child.score_now();
+                if score > 0.0 { Some(score) } else { None }
+            },
         }
     }
 

--- a/crates/zeph-core/src/agent/scope_commands.rs
+++ b/crates/zeph-core/src/agent/scope_commands.rs
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `/scope` command handler.
+
+use super::Agent;
+use crate::channel::Channel;
+
+impl<C: Channel> Agent<C> {
+    /// Handle `/scope [list|reset]` and return a user-visible result.
+    pub(super) fn handle_scope_command_as_string(&self, args: &str) -> String {
+        let mut parts = args.split_whitespace();
+        let subcmd = parts.next().unwrap_or("list");
+        match subcmd {
+            "list" => {
+                let cfg = &self.runtime.config.security.capability_scopes;
+                if cfg.scopes.is_empty() {
+                    return "No capability scopes configured.".to_owned();
+                }
+                let mut out = String::from("Capability scopes:\n");
+                for (name, scope) in &cfg.scopes {
+                    use std::fmt::Write as _;
+                    let _ = writeln!(out, "  [{name}] patterns={}", scope.patterns.len());
+                }
+                out
+            }
+            "reset" => {
+                // F6: reset active scope to the configured default.
+                let default = self
+                    .runtime
+                    .config
+                    .security
+                    .capability_scopes
+                    .default_scope
+                    .clone();
+                format!(
+                    "Scope reset to default ('{default}'). Use ScopedToolExecutor::set_scope_for_task at runtime to apply."
+                )
+            }
+            other => format!("Unknown /scope subcommand: {other}. Use: list, reset"),
+        }
+    }
+}

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -336,6 +336,22 @@ pub(crate) struct SecurityState {
     /// VIGIL pre-sanitizer gate. `None` for subagent sessions (subagents are exempt).
     /// Set at agent build time for top-level agents; skipped for subagents (high FP rate).
     pub(crate) vigil: Option<crate::agent::vigil::VigilGate>,
+    /// Cross-turn risk accumulator (spec 050 Phase 1).
+    ///
+    /// `advance_turn()` MUST be called once per turn, before `PolicyGateExecutor::check_policy`.
+    /// Never expose score, level, or alerts to any LLM-callable surface.
+    pub(crate) trajectory: crate::agent::trajectory::TrajectorySentinel,
+    /// Shared risk-level slot for `PolicyGateExecutor` (spec 050).
+    ///
+    /// Written by the agent loop after each turn's `sentinel.current_risk()` call.
+    /// `PolicyGateExecutor::check_policy` reads it to downgrade `Allow` at `Critical`.
+    /// `u8` encoding: 0=Calm, 1=Elevated, 2=High, 3=Critical.
+    pub(crate) trajectory_risk_slot: zeph_tools::TrajectoryRiskSlot,
+    /// Pending risk signals from executor layers (spec 050 §2).
+    ///
+    /// `PolicyGateExecutor` and `ScopedToolExecutor` push signal codes here.
+    /// `begin_turn()` drains this queue into `trajectory.record()`.
+    pub(crate) trajectory_signal_queue: zeph_tools::RiskSignalQueue,
 }
 
 /// Groups debug/diagnostics subsystems (dumper, trace collector, anomaly detector, logging config).

--- a/crates/zeph-core/src/agent/state/security.rs
+++ b/crates/zeph-core/src/agent/state/security.rs
@@ -49,6 +49,11 @@ impl Default for SecurityState {
             ),
             causal_analyzer: None,
             vigil: None,
+            trajectory: crate::agent::trajectory::TrajectorySentinel::new(
+                zeph_config::TrajectorySentinelConfig::default(),
+            ),
+            trajectory_risk_slot: std::sync::Arc::new(parking_lot::RwLock::new(0u8)),
+            trajectory_signal_queue: std::sync::Arc::new(parking_lot::Mutex::new(Vec::new())),
         }
     }
 }

--- a/crates/zeph-core/src/agent/tool_execution/mod.rs
+++ b/crates/zeph-core/src/agent/tool_execution/mod.rs
@@ -257,6 +257,12 @@ impl<C: Channel> Agent<C> {
         if result.scrubbed {
             self.update_metrics(|m| m.pii_scrub_count += 1);
             self.push_classifier_metrics();
+            // Signal code 4 = PiiRedaction (spec 050 §2).
+            self.services
+                .security
+                .trajectory_signal_queue
+                .lock()
+                .push(4);
         }
         result.text
     }
@@ -284,6 +290,12 @@ impl<C: Channel> Agent<C> {
                 "llm_output",
                 format!("{} markdown image(s) blocked", events.len()),
             );
+            // Signal code 2 = ExfiltrationRedaction (spec 050 §2).
+            self.services
+                .security
+                .trajectory_signal_queue
+                .lock()
+                .push(2);
         }
         cleaned
     }
@@ -841,6 +853,19 @@ impl<C: Channel> Agent<C> {
             tracing::debug!(tool = %tool_name, reason = %reason, "VIGIL sanitized tool output");
             VigilOutcome::Sanitized { risk }
         };
+
+        // Spec 050 §2: record VigilFlagged signal scaled by risk level.
+        // Code 7 = VigilFlagged(High), 6 = VigilFlagged(Medium), 0 = VigilFlagged(Low).
+        let vigil_code = match risk {
+            zeph_tools::audit::VigilRiskLevel::High => 7u8,
+            zeph_tools::audit::VigilRiskLevel::Medium => 6u8,
+            zeph_tools::audit::VigilRiskLevel::Low => 0u8,
+        };
+        self.services
+            .security
+            .trajectory_signal_queue
+            .lock()
+            .push(vigil_code);
 
         (body_after, Some(outcome))
     }

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -1497,6 +1497,8 @@ impl<C: Channel> Agent<C> {
                                 policy_match: None,
                                 correlation_id: None,
                                 vigil_risk: None,
+                                scope_at_definition: None,
+                                scope_at_dispatch: None,
                             };
                             let logger = std::sync::Arc::clone(logger);
                             self.runtime.lifecycle.supervisor.spawn(
@@ -2941,6 +2943,8 @@ impl<C: Channel> Agent<C> {
             policy_match: None,
             correlation_id: None,
             vigil_risk,
+            scope_at_definition: None,
+            scope_at_dispatch: None,
         };
         let logger = std::sync::Arc::clone(logger);
         self.runtime.lifecycle.supervisor.spawn(

--- a/crates/zeph-core/src/agent/tool_execution/sanitize.rs
+++ b/crates/zeph-core/src/agent/tool_execution/sanitize.rs
@@ -276,6 +276,8 @@ impl<C: Channel> Agent<C> {
                 policy_match: None,
                 correlation_id: None,
                 vigil_risk: None,
+                scope_at_definition: None,
+                scope_at_dispatch: None,
             };
             let logger = std::sync::Arc::clone(logger);
             self.runtime.lifecycle.supervisor.spawn(

--- a/crates/zeph-core/src/agent/trajectory.rs
+++ b/crates/zeph-core/src/agent/trajectory.rs
@@ -1,0 +1,674 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Trajectory risk sentinel: accumulates risk signals across turns and exposes
+//! an advisory `RiskLevel` consumed by `PolicyGateExecutor`.
+//!
+//! # Architecture
+//!
+//! `TrajectorySentinel` is stored on `SecurityState` (per-agent, never global).
+//! `advance_turn()` MUST be called once per turn, **before** `PolicyGateExecutor::check_policy`
+//! runs (Invariant 2 in spec 050). This guarantees that decay is applied before the gate
+//! evaluates the current-turn score.
+//!
+//! # LLM isolation
+//!
+//! `RiskAlert`, `RiskLevel`, and sentinel score MUST NEVER be exposed to LLM-callable tools
+//! or any context surface the LLM can read. `/trajectory show` is an operator-only command.
+
+use std::collections::VecDeque;
+
+use zeph_config::TrajectorySentinelConfig;
+
+// Re-export config so callers only need one import.
+pub use zeph_config::TrajectorySentinelConfig as SentinelConfig;
+
+// ── Signal taxonomy ───────────────────────────────────────────────────────────
+
+/// Vigil confidence levels mirrored from the audit crate to avoid a circular dep.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VigilRiskLevel {
+    /// Low-confidence injection match (reserved; current `VigilGate` does not emit this).
+    Low,
+    /// Medium-confidence injection match.
+    Medium,
+    /// High-confidence injection match.
+    High,
+}
+
+/// Risk signal emitted by security subsystems and accumulated by `TrajectorySentinel`.
+///
+/// Each variant maps to a configurable weight (see spec 050 §2 for defaults).
+/// `NovelTool` is deferred to Phase 2 and not present here.
+///
+/// # NEVER
+///
+/// Never expose signal values or the accumulated score to any LLM-callable surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RiskSignal {
+    /// VIGIL flagged a tool output with the given confidence level.
+    VigilFlagged(VigilRiskLevel),
+    /// `PolicyEnforcer` denied a structured tool call.
+    PolicyDeny,
+    /// `ExfiltrationGuard` redacted at least one outbound URL or HTML img.
+    ExfiltrationRedaction,
+    /// Tool call rejected as out-of-scope by `ScopedToolExecutor`.
+    OutOfScope,
+    /// PII filter redacted ≥ 1 span in a tool output.
+    PiiRedaction,
+    /// Tool returned a non-zero exit code or unrecoverable error.
+    ToolFailure,
+    /// More than `high_call_rate_threshold` tool calls in the last 3 turns.
+    HighCallRate,
+    /// More than `unusual_read_threshold` distinct paths read in `window_turns`.
+    UnusualReadVolume,
+    /// A configured high-risk tool-pair transition occurred within K turns.
+    ToolPairTransition,
+}
+
+impl RiskSignal {
+    /// Returns the default weight for this signal (configurable in Phase 2).
+    ///
+    /// Weights are finite and non-negative; this upholds the NEVER-negative-score invariant.
+    #[must_use]
+    pub fn default_weight(self) -> f32 {
+        match self {
+            Self::VigilFlagged(VigilRiskLevel::High) => 2.5,
+            Self::VigilFlagged(VigilRiskLevel::Medium) => 1.0,
+            Self::ExfiltrationRedaction | Self::ToolPairTransition => 2.0,
+            Self::PolicyDeny | Self::OutOfScope | Self::HighCallRate | Self::UnusualReadVolume => {
+                1.5
+            }
+            Self::PiiRedaction => 0.5,
+            // VigilFlagged(Low) and ToolFailure are both noisy low-weight signals.
+            Self::VigilFlagged(VigilRiskLevel::Low) | Self::ToolFailure => 0.3,
+        }
+    }
+}
+
+impl RiskSignal {
+    /// Convert a `u8` signal code from `RiskSignalSink` callbacks into a `RiskSignal`.
+    ///
+    /// Code table (mirrors the numeric constants used in `zeph-tools`):
+    /// - `1` = `PolicyDeny`
+    /// - `2` = `ExfiltrationRedaction`
+    /// - `3` = `OutOfScope`
+    /// - `4` = `PiiRedaction`
+    /// - `5` = `ToolFailure`
+    /// - `6` = `VigilFlagged(Medium)`
+    /// - `7` = `VigilFlagged(High)`
+    /// - anything else = `VigilFlagged(Low)` (fallback)
+    #[must_use]
+    pub fn from_code(code: u8) -> Self {
+        match code {
+            1 => Self::PolicyDeny,
+            2 => Self::ExfiltrationRedaction,
+            3 => Self::OutOfScope,
+            4 => Self::PiiRedaction,
+            5 => Self::ToolFailure,
+            6 => Self::VigilFlagged(VigilRiskLevel::Medium),
+            7 => Self::VigilFlagged(VigilRiskLevel::High),
+            _ => Self::VigilFlagged(VigilRiskLevel::Low),
+        }
+    }
+}
+
+// ── Risk levels ───────────────────────────────────────────────────────────────
+
+/// Advisory risk level computed from the accumulated score.
+///
+/// `PolicyGateExecutor` consumes this to decide whether to downgrade an `Allow` decision.
+///
+/// # LLM isolation
+///
+/// This enum MUST NOT appear in any tool output, slash-command response, or LLM context.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RiskLevel {
+    /// Score < `elevated_at`. Normal operation.
+    Calm,
+    /// Score in `[elevated_at, high_at)`. Audit tag only.
+    Elevated,
+    /// Score in `[high_at, critical_at)`. Audit tag + `RiskAlert` emitted.
+    High,
+    /// Score >= `critical_at`. `Allow` decisions downgraded to `Deny`.
+    Critical,
+}
+
+impl From<RiskLevel> for u8 {
+    fn from(level: RiskLevel) -> Self {
+        match level {
+            RiskLevel::Calm => 0,
+            RiskLevel::Elevated => 1,
+            RiskLevel::High => 2,
+            RiskLevel::Critical => 3,
+        }
+    }
+}
+
+// ── Risk alert ────────────────────────────────────────────────────────────────
+
+/// Emitted when the score crosses `alert_threshold`.
+///
+/// Consumed by `PolicyGateExecutor`. MUST NOT be observable by LLM-callable tools.
+#[derive(Debug, Clone, Copy)]
+pub struct RiskAlert {
+    /// Current risk level at alert time.
+    pub level: RiskLevel,
+    /// Accumulated score at alert time (rounded to two decimal places for logs).
+    pub score: f32,
+}
+
+// ── Sentinel ──────────────────────────────────────────────────────────────────
+
+/// Cross-turn risk accumulator for the advisory trajectory governance layer.
+///
+/// # Usage
+///
+/// ```rust
+/// use zeph_core::agent::trajectory::{TrajectorySentinel, RiskSignal, RiskLevel, VigilRiskLevel};
+/// use zeph_config::TrajectorySentinelConfig;
+///
+/// let mut sentinel = TrajectorySentinel::new(TrajectorySentinelConfig::default());
+///
+/// // Call advance_turn once per turn, BEFORE gate evaluation.
+/// let _ = sentinel.advance_turn();
+/// sentinel.record(RiskSignal::VigilFlagged(VigilRiskLevel::High));
+/// sentinel.record(RiskSignal::PolicyDeny);
+///
+/// let level = sentinel.current_risk();
+/// assert!(level >= RiskLevel::Calm);
+/// ```
+pub struct TrajectorySentinel {
+    cfg: TrajectorySentinelConfig,
+    /// Ring buffer of `(turn_number, signal)` pairs; evicted outside `window_turns`.
+    buf: VecDeque<(u64, RiskSignal)>,
+    current_turn: u64,
+    /// Turn on which the score last changed (for `advance_turn` dirty-tracking).
+    last_signal_turn: u64,
+    /// Cached sum; `None` means the buffer was mutated since the last computation.
+    cached_score: Option<f32>,
+    /// How many consecutive turns the sentinel has been at `>= Critical`.
+    critical_consecutive_turns: u32,
+}
+
+impl TrajectorySentinel {
+    /// Create a fresh sentinel with the given configuration.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_core::agent::trajectory::TrajectorySentinel;
+    /// use zeph_config::TrajectorySentinelConfig;
+    ///
+    /// let sentinel = TrajectorySentinel::new(TrajectorySentinelConfig::default());
+    /// ```
+    #[must_use]
+    pub fn new(cfg: TrajectorySentinelConfig) -> Self {
+        Self {
+            cfg,
+            buf: VecDeque::new(),
+            current_turn: 0,
+            last_signal_turn: 0,
+            cached_score: Some(0.0),
+            critical_consecutive_turns: 0,
+        }
+    }
+
+    /// Initialise a child sentinel for a spawned subagent per FR-CG-011.
+    ///
+    /// When the parent is at `>= Elevated`, the child starts with a damped copy of the
+    /// parent's score (`parent_score * subagent_inheritance_factor`). This prevents
+    /// a subagent spawn from acting as a free risk reset.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_core::agent::trajectory::{TrajectorySentinel, RiskSignal, RiskLevel, VigilRiskLevel};
+    /// use zeph_config::TrajectorySentinelConfig;
+    ///
+    /// let mut parent = TrajectorySentinel::new(TrajectorySentinelConfig::default());
+    /// let _ = parent.advance_turn();
+    /// parent.record(RiskSignal::VigilFlagged(VigilRiskLevel::High));
+    /// parent.record(RiskSignal::PolicyDeny);
+    ///
+    /// let child = parent.spawn_child();
+    /// // Child starts with some inherited score when parent is >= Elevated.
+    /// ```
+    #[must_use]
+    pub fn spawn_child(&self) -> TrajectorySentinel {
+        let mut child = TrajectorySentinel::new(self.cfg.clone());
+        if self.current_risk() >= RiskLevel::Elevated {
+            let parent_score = self.score_now();
+            let damped = parent_score * self.cfg.subagent_inheritance_factor;
+            child.seed_score(damped);
+        }
+        child
+    }
+
+    /// Advance the turn counter and apply multiplicative decay.
+    ///
+    /// MUST be called once per turn, **before** any `PolicyGateExecutor::check_policy` runs.
+    /// Also handles the FR-CG-010 auto-recover cap: after `auto_recover_after_turns`
+    /// consecutive turns at `Critical` with no new high-weight signal, the score is hard-reset
+    /// to `0.0` and the buffer is cleared.
+    ///
+    /// Returns `true` when auto-recover fired this turn — the caller MUST write an audit entry
+    /// with `error_category = "trajectory_auto_recover"` (F5 requirement).
+    #[must_use]
+    pub fn advance_turn(&mut self) -> bool {
+        self.current_turn += 1;
+        self.cached_score = None; // score must be recomputed after decay
+
+        // Evict signals outside the window.
+        let window = u64::from(self.cfg.window_turns);
+        while let Some(&(turn, _)) = self.buf.front() {
+            if self.current_turn.saturating_sub(turn) >= window {
+                self.buf.pop_front();
+            } else {
+                break;
+            }
+        }
+
+        // Track Critical consecutive turns for auto-recover (FR-CG-010).
+        if self.current_risk() >= RiskLevel::Critical {
+            self.critical_consecutive_turns += 1;
+            let cap = self.cfg.auto_recover_after_turns.max(4); // floor at 4
+            if self.critical_consecutive_turns >= cap {
+                let score_at_reset = self.score_now();
+                let signal_census = self.buf.len();
+                tracing::warn!(
+                    score = score_at_reset,
+                    signal_count = signal_census,
+                    turns_at_critical = self.critical_consecutive_turns,
+                    "trajectory auto-recover: hard reset after {} consecutive Critical turns",
+                    cap
+                );
+                self.buf.clear();
+                self.cached_score = Some(0.0);
+                self.critical_consecutive_turns = 0;
+                return true;
+            }
+        } else {
+            self.critical_consecutive_turns = 0;
+        }
+        false
+    }
+
+    /// Record a risk signal for the current turn.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_core::agent::trajectory::{TrajectorySentinel, RiskSignal};
+    /// use zeph_config::TrajectorySentinelConfig;
+    ///
+    /// let mut sentinel = TrajectorySentinel::new(TrajectorySentinelConfig::default());
+    /// let _ = sentinel.advance_turn();
+    /// sentinel.record(RiskSignal::PolicyDeny);
+    /// assert!(sentinel.score_now() > 0.0);
+    /// ```
+    pub fn record(&mut self, sig: RiskSignal) {
+        self.buf.push_back((self.current_turn, sig));
+        self.cached_score = None;
+        self.last_signal_turn = self.current_turn;
+    }
+
+    /// Return the current risk level bucket for the accumulated score.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_core::agent::trajectory::{TrajectorySentinel, RiskLevel};
+    /// use zeph_config::TrajectorySentinelConfig;
+    ///
+    /// let sentinel = TrajectorySentinel::new(TrajectorySentinelConfig::default());
+    /// assert_eq!(sentinel.current_risk(), RiskLevel::Calm);
+    /// ```
+    #[must_use]
+    pub fn current_risk(&self) -> RiskLevel {
+        let score = self.score_now();
+        if score >= self.cfg.critical_at {
+            RiskLevel::Critical
+        } else if score >= self.cfg.high_at {
+            RiskLevel::High
+        } else if score >= self.cfg.elevated_at {
+            RiskLevel::Elevated
+        } else {
+            RiskLevel::Calm
+        }
+    }
+
+    /// Return a `RiskAlert` when the score crosses `alert_threshold`, `None` otherwise.
+    ///
+    /// Consumed by `PolicyGateExecutor`. Never expose to LLM-callable surfaces.
+    #[must_use]
+    pub fn poll_alert(&self) -> Option<RiskAlert> {
+        let score = self.score_now();
+        if score >= self.cfg.alert_threshold {
+            Some(RiskAlert {
+                level: self.current_risk(),
+                score,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Compute the decayed score from the signal buffer without mutating state.
+    ///
+    /// Score formula: `Σ_k decay_per_turn^(current_turn - signal_turn_k) * weight(signal_k)`
+    ///
+    /// Guaranteed to be finite and non-negative (upholds NEVER-negative invariant).
+    #[must_use]
+    pub fn score_now(&self) -> f32 {
+        if let Some(cached) = self.cached_score {
+            return cached;
+        }
+        let mut score: f32 = 0.0;
+        let decay = self.cfg.decay_per_turn;
+        for &(turn, signal) in &self.buf {
+            #[allow(clippy::cast_precision_loss)]
+            let age =
+                u32::try_from(self.current_turn.saturating_sub(turn)).unwrap_or(u32::MAX) as f32;
+            let contribution = decay.powf(age) * signal.default_weight();
+            score += contribution;
+        }
+        // Clamp to non-negative to satisfy the invariant (floating-point rounding safety).
+        score.max(0.0)
+    }
+
+    /// Hard reset: clear all state. Called on `/clear`, `/trajectory reset`, or session restart.
+    pub fn reset(&mut self) {
+        self.buf.clear();
+        self.cached_score = Some(0.0);
+        self.critical_consecutive_turns = 0;
+        self.last_signal_turn = 0;
+    }
+
+    /// Seed the sentinel with an initial score for subagent inheritance.
+    ///
+    /// Inserts a synthetic signal at turn 0 with the given weight. Only called
+    /// from `spawn_child` — not part of the normal signal path.
+    fn seed_score(&mut self, score: f32) {
+        debug_assert!(score >= 0.0, "seed score must be non-negative");
+        // Store a sentinel marker in the buffer so the seed participates in decay on the
+        // next advance_turn(). We encode it as (turn=0, PolicyDeny) × N where N is
+        // the number of PolicyDeny weights that sum to score. This is approximate but
+        // correct in terms of decay behavior.
+        let weight = RiskSignal::PolicyDeny.default_weight();
+        // Use floor to avoid overshooting the parent's score (P2 requirement).
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let reps = (score / weight).floor() as usize;
+        for _ in 0..reps {
+            self.buf.push_back((0, RiskSignal::PolicyDeny));
+        }
+        self.cached_score = None; // will be recomputed from buf
+    }
+
+    /// The current turn counter (for diagnostics and audit logging only).
+    #[must_use]
+    pub fn current_turn(&self) -> u64 {
+        self.current_turn
+    }
+
+    /// Number of signals in the current window (for diagnostics only).
+    #[must_use]
+    pub fn signal_count(&self) -> usize {
+        self.buf.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zeph_config::TrajectorySentinelConfig;
+
+    fn default_sentinel() -> TrajectorySentinel {
+        TrajectorySentinel::new(TrajectorySentinelConfig::default())
+    }
+
+    #[test]
+    fn fresh_sentinel_is_calm() {
+        let s = default_sentinel();
+        assert_eq!(s.current_risk(), RiskLevel::Calm);
+        assert!(s.score_now().abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn single_policy_deny_elevates_score() {
+        let mut s = default_sentinel();
+        let _ = s.advance_turn();
+        s.record(RiskSignal::PolicyDeny);
+        // PolicyDeny weight = 1.5, elevated_at = 2.0 → still Calm
+        assert_eq!(s.current_risk(), RiskLevel::Calm);
+        assert!((s.score_now() - 1.5).abs() < 0.01);
+    }
+
+    #[test]
+    fn two_policy_denies_cross_elevated() {
+        let mut s = default_sentinel();
+        let _ = s.advance_turn();
+        s.record(RiskSignal::PolicyDeny);
+        s.record(RiskSignal::PolicyDeny);
+        // 1.5 + 1.5 = 3.0 >= elevated_at(2.0)
+        assert_eq!(s.current_risk(), RiskLevel::Elevated);
+    }
+
+    #[test]
+    fn vigil_high_signals_drive_to_critical() {
+        let mut s = default_sentinel();
+        // 6 × VigilFlagged(High) over 8 turns → acceptance test from spec
+        for _ in 0..6 {
+            let _ = s.advance_turn();
+            s.record(RiskSignal::VigilFlagged(VigilRiskLevel::High));
+        }
+        // Σ_{k=0..5} 0.85^k × 2.5 ≈ 10.3 >= critical_at(8.0)
+        let score = s.score_now();
+        assert!(score >= 8.0, "expected score >= 8.0, got {score}");
+        assert_eq!(s.current_risk(), RiskLevel::Critical);
+    }
+
+    #[test]
+    fn advance_turn_before_gate_ordering() {
+        // Invariant 2: decay is applied at advance_turn, not at check time.
+        let mut s = default_sentinel();
+        let _ = s.advance_turn();
+        s.record(RiskSignal::VigilFlagged(VigilRiskLevel::High)); // weight 2.5
+        let score_turn1 = s.score_now();
+        let _ = s.advance_turn();
+        let score_turn2 = s.score_now();
+        // After one idle turn, score decays by 0.85.
+        assert!(
+            score_turn2 < score_turn1,
+            "score must decay after advance_turn"
+        );
+        assert!((score_turn2 - score_turn1 * 0.85).abs() < 0.01);
+    }
+
+    #[test]
+    fn reset_clears_all_state() {
+        let mut s = default_sentinel();
+        let _ = s.advance_turn();
+        s.record(RiskSignal::PolicyDeny);
+        s.record(RiskSignal::PolicyDeny);
+        assert!(s.current_risk() >= RiskLevel::Elevated);
+        s.reset();
+        assert_eq!(s.current_risk(), RiskLevel::Calm);
+        assert!(s.score_now().abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn auto_recover_after_critical_turns_hard_reset() {
+        // decay_per_turn = 1.0 (no decay) and large window prevent score decay from
+        // masking the hard-reset code path.  Cap is 4 turns to keep the test fast.
+        let cfg = TrajectorySentinelConfig {
+            auto_recover_after_turns: 4,
+            window_turns: 30,
+            decay_per_turn: 1.0,
+            ..Default::default()
+        };
+        let mut s = TrajectorySentinel::new(cfg);
+
+        // Prime to Critical: 4 × VigilFlagged(High) (weight 2.5 × 4 = 10.0 > critical_at 8.0).
+        // With decay=1.0, score does not decay between turns.
+        for _ in 0..4 {
+            let _ = s.advance_turn();
+            s.record(RiskSignal::VigilFlagged(VigilRiskLevel::High));
+        }
+        assert_eq!(
+            s.current_risk(),
+            RiskLevel::Critical,
+            "must be Critical before sustain loop"
+        );
+
+        // Each advance_turn in this loop sees Critical (score=10.0, no decay).
+        // critical_consecutive_turns increments each turn; hard-reset fires at turn 4.
+        let mut recovered = false;
+        for i in 0..4 {
+            let fired = s.advance_turn();
+            if fired {
+                recovered = true;
+                assert_eq!(
+                    i, 3,
+                    "hard-reset must fire on the 4th consecutive Critical turn, not turn {i}"
+                );
+                break;
+            }
+            assert_eq!(
+                s.current_risk(),
+                RiskLevel::Critical,
+                "must stay Critical during sustain loop (turn {i})"
+            );
+        }
+        assert!(
+            recovered,
+            "auto-recover hard-reset must fire after 4 consecutive Critical turns"
+        );
+        assert!(
+            s.current_risk() < RiskLevel::Critical,
+            "sentinel must be below Critical after hard-reset"
+        );
+        assert!(
+            s.score_now().abs() < f32::EPSILON,
+            "score must be 0 after hard-reset"
+        );
+    }
+
+    #[test]
+    fn score_never_negative() {
+        // Property: random Phase-1 signal traces must never produce negative score.
+        let mut s = default_sentinel();
+        for _ in 0..20 {
+            let _ = s.advance_turn();
+            s.record(RiskSignal::ToolFailure);
+            s.record(RiskSignal::PiiRedaction);
+            assert!(s.score_now() >= 0.0, "score became negative");
+        }
+    }
+
+    #[test]
+    fn score_never_nan() {
+        let mut s = default_sentinel();
+        for _ in 0..20 {
+            let _ = s.advance_turn();
+            s.record(RiskSignal::VigilFlagged(VigilRiskLevel::High));
+            assert!(!s.score_now().is_nan(), "score became NaN");
+        }
+    }
+
+    #[test]
+    fn spawn_child_inherits_score_when_elevated() {
+        let mut parent = TrajectorySentinel::new(TrajectorySentinelConfig::default());
+        let _ = parent.advance_turn();
+        parent.record(RiskSignal::PolicyDeny);
+        parent.record(RiskSignal::PolicyDeny);
+        // parent at Elevated (score ~3.0)
+        assert!(parent.current_risk() >= RiskLevel::Elevated);
+        let child = parent.spawn_child();
+        assert!(
+            child.score_now() > 0.0,
+            "child must inherit non-zero score from elevated parent"
+        );
+        assert!(
+            child.score_now() < parent.score_now(),
+            "child score must be damped relative to parent"
+        );
+    }
+
+    #[test]
+    fn spawn_child_no_inheritance_when_calm() {
+        let parent = TrajectorySentinel::new(TrajectorySentinelConfig::default());
+        assert_eq!(parent.current_risk(), RiskLevel::Calm);
+        let child = parent.spawn_child();
+        assert!(
+            child.score_now().abs() < f32::EPSILON,
+            "calm parent must not seed child"
+        );
+    }
+
+    #[test]
+    fn poll_alert_fires_at_alert_threshold() {
+        let mut s = default_sentinel();
+        let _ = s.advance_turn();
+        // alert_threshold = 4.0; two VigilFlagged(High) at same turn = 5.0 >= 4.0
+        s.record(RiskSignal::VigilFlagged(VigilRiskLevel::High));
+        s.record(RiskSignal::VigilFlagged(VigilRiskLevel::High));
+        let alert = s.poll_alert();
+        assert!(alert.is_some(), "alert must fire at >= alert_threshold");
+    }
+
+    #[test]
+    fn window_evicts_old_signals() {
+        let cfg = TrajectorySentinelConfig {
+            window_turns: 3,
+            ..Default::default()
+        };
+        let mut s = TrajectorySentinel::new(cfg);
+        let _ = s.advance_turn();
+        s.record(RiskSignal::VigilFlagged(VigilRiskLevel::High)); // turn 1
+        // Advance 3 more turns — the signal should be evicted.
+        let _ = s.advance_turn(); // turn 2
+        let _ = s.advance_turn(); // turn 3
+        let _ = s.advance_turn(); // turn 4 — turn 1 signal is now >= window_turns old
+        assert_eq!(
+            s.signal_count(),
+            0,
+            "signals outside window must be evicted"
+        );
+    }
+
+    #[test]
+    fn trajectory_config_validation_decay_bounds() {
+        let cfg_zero = TrajectorySentinelConfig {
+            decay_per_turn: 0.0,
+            ..Default::default()
+        };
+        assert!(
+            cfg_zero.validate().is_err(),
+            "decay=0.0 must fail validation"
+        );
+        let cfg_over = TrajectorySentinelConfig {
+            decay_per_turn: 1.1,
+            ..Default::default()
+        };
+        assert!(
+            cfg_over.validate().is_err(),
+            "decay>1.0 must fail validation"
+        );
+        let cfg_ok = TrajectorySentinelConfig {
+            decay_per_turn: 0.85,
+            ..Default::default()
+        };
+        assert!(cfg_ok.validate().is_ok());
+    }
+
+    #[test]
+    fn trajectory_config_validation_threshold_ordering() {
+        let cfg = TrajectorySentinelConfig {
+            elevated_at: 5.0,
+            high_at: 3.0, // violates elevated_at < high_at
+            ..Default::default()
+        };
+        assert!(cfg.validate().is_err());
+    }
+}

--- a/crates/zeph-core/src/agent/trajectory_commands.rs
+++ b/crates/zeph-core/src/agent/trajectory_commands.rs
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `/trajectory` command handler.
+//!
+//! Operator-only: score, level, and alert data MUST NOT appear in LLM context.
+
+use super::Agent;
+use crate::channel::Channel;
+
+impl<C: Channel> Agent<C> {
+    /// Handle `/trajectory [status|reset]` and return a user-visible result.
+    pub(super) fn handle_trajectory_command_as_string(&mut self, args: &str) -> String {
+        let subcmd = args.split_whitespace().next().unwrap_or("status");
+        if subcmd == "reset" {
+            // S-HIGH-02: reset is operator-only; refuse from ACP/LLM-callable sessions.
+            if self.services.security.is_acp_session {
+                return "Permission denied: /trajectory reset is operator-only.".to_owned();
+            }
+            self.services.security.trajectory.reset();
+            *self.services.security.trajectory_risk_slot.write() = 0;
+            "Trajectory sentinel reset.".to_owned()
+        } else {
+            let level = self.services.security.trajectory.current_risk();
+            let score = self.services.security.trajectory.score_now();
+            let turn = self.services.security.trajectory.current_turn();
+            let signals = self.services.security.trajectory.signal_count();
+            format!(
+                "Trajectory: level={level:?}, score={score:.2}, turn={turn}, signals_in_window={signals}"
+            )
+        }
+    }
+}

--- a/crates/zeph-subagent/src/manager.rs
+++ b/crates/zeph-subagent/src/manager.rs
@@ -58,6 +58,12 @@ pub struct SpawnContext {
     pub spawn_depth: u32,
     /// MCP tool names available in the parent's tool executor (for diagnostics).
     pub mcp_tool_names: Vec<String>,
+    /// Seeded trajectory risk score from the parent sentinel (spec 050 §4).
+    ///
+    /// When `Some`, the subagent's `TrajectorySentinel` starts with this pre-seeded score
+    /// rather than `0.0`, preventing a subagent spawn from acting as a free risk reset.
+    /// The subagent loop applies this via `TrajectorySentinel::seed_score` after build.
+    pub seed_trajectory_score: Option<f32>,
 }
 
 fn build_filtered_executor(

--- a/crates/zeph-tools/src/adversarial_gate.rs
+++ b/crates/zeph-tools/src/adversarial_gate.rs
@@ -162,6 +162,8 @@ impl<T: ToolExecutor> AdversarialPolicyGateExecutor<T> {
             policy_match: None,
             correlation_id: None,
             vigil_risk: None,
+            scope_at_definition: None,
+            scope_at_dispatch: None,
         };
         audit.log(&entry).await;
     }

--- a/crates/zeph-tools/src/audit.rs
+++ b/crates/zeph-tools/src/audit.rs
@@ -188,6 +188,14 @@ pub struct AuditEntry {
     /// `None` when VIGIL did not fire (output was clean or tool was exempt).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub vigil_risk: Option<VigilRiskLevel>,
+    /// Name of the capability scope active at `tool_definitions()` time (for scope-at-definition audit).
+    /// `None` when `ScopedToolExecutor` is not in the chain or the scope is the identity (`general`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope_at_definition: Option<String>,
+    /// Name of the capability scope active at `execute_tool_call()` dispatch time.
+    /// `None` when `ScopedToolExecutor` is not in the chain.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope_at_dispatch: Option<String>,
 }
 
 /// Risk level assigned by the VIGIL pre-sanitizer gate to a flagged tool output.
@@ -420,6 +428,8 @@ mod tests {
             correlation_id: None,
             caller_id: None,
             vigil_risk: None,
+            scope_at_definition: None,
+            scope_at_dispatch: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(json.contains("\"type\":\"success\""));
@@ -452,6 +462,8 @@ mod tests {
             correlation_id: None,
             caller_id: None,
             vigil_risk: None,
+            scope_at_definition: None,
+            scope_at_dispatch: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(json.contains("\"type\":\"blocked\""));
@@ -483,6 +495,8 @@ mod tests {
             correlation_id: None,
             caller_id: None,
             vigil_risk: None,
+            scope_at_definition: None,
+            scope_at_dispatch: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(json.contains("\"type\":\"error\""));
@@ -511,6 +525,8 @@ mod tests {
             correlation_id: None,
             caller_id: None,
             vigil_risk: None,
+            scope_at_definition: None,
+            scope_at_dispatch: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(json.contains("\"type\":\"timeout\""));
@@ -545,6 +561,8 @@ mod tests {
             correlation_id: None,
             caller_id: None,
             vigil_risk: None,
+            scope_at_definition: None,
+            scope_at_dispatch: None,
         };
         logger.log(&entry).await;
     }
@@ -580,6 +598,8 @@ mod tests {
             correlation_id: None,
             caller_id: None,
             vigil_risk: None,
+            scope_at_definition: None,
+            scope_at_dispatch: None,
         };
         logger.log(&entry).await;
 
@@ -642,6 +662,8 @@ mod tests {
             correlation_id: None,
             caller_id: None,
             vigil_risk: None,
+            scope_at_definition: None,
+            scope_at_dispatch: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(
@@ -674,6 +696,8 @@ mod tests {
             correlation_id: None,
             caller_id: None,
             vigil_risk: None,
+            scope_at_definition: None,
+            scope_at_dispatch: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(
@@ -715,6 +739,8 @@ mod tests {
                 correlation_id: None,
                 caller_id: None,
                 vigil_risk: None,
+                scope_at_definition: None,
+                scope_at_dispatch: None,
             };
             logger.log(&entry).await;
         }
@@ -746,6 +772,8 @@ mod tests {
             correlation_id: None,
             caller_id: None,
             vigil_risk: None,
+            scope_at_definition: None,
+            scope_at_dispatch: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(
@@ -777,6 +805,8 @@ mod tests {
             correlation_id: None,
             caller_id: None,
             vigil_risk: None,
+            scope_at_definition: None,
+            scope_at_dispatch: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(

--- a/crates/zeph-tools/src/executor.rs
+++ b/crates/zeph-tools/src/executor.rs
@@ -399,6 +399,19 @@ pub enum ToolError {
 
     #[error("snapshot failed: {reason}")]
     SnapshotFailed { reason: String },
+
+    /// Tool call rejected because the tool id is outside the active capability scope.
+    ///
+    /// Emitted by `ScopedToolExecutor` before any tool side-effect runs.
+    /// The audit log records `error_category = "out_of_scope"`.
+    // LLM isolation: task_type is never shown in the error message (P2-OutOfScope).
+    #[error("tool call denied by policy")]
+    OutOfScope {
+        /// Fully-qualified tool id that was rejected.
+        tool_id: String,
+        /// Active task type at dispatch time, if any.
+        task_type: Option<String>,
+    },
 }
 
 impl ToolError {
@@ -421,6 +434,7 @@ impl ToolError {
             Self::Execution(io_err) => classify_io_error(io_err),
             Self::Shell { category, .. } => *category,
             Self::SnapshotFailed { .. } => ToolErrorCategory::PermanentFailure,
+            Self::OutOfScope { .. } => ToolErrorCategory::PolicyBlocked,
         }
     }
 

--- a/crates/zeph-tools/src/lib.rs
+++ b/crates/zeph-tools/src/lib.rs
@@ -77,6 +77,7 @@ pub mod policy_gate;
 pub mod registry;
 pub mod sandbox;
 pub mod schema_filter;
+pub mod scope;
 pub mod scrape;
 pub mod search_code;
 pub mod shell;
@@ -117,7 +118,7 @@ pub use filter::{
 pub use net::is_private_ip;
 pub use permissions::PermissionPolicy;
 pub use policy::{PolicyCompileError, PolicyContext, PolicyDecision, PolicyEnforcer};
-pub use policy_gate::PolicyGateExecutor;
+pub use policy_gate::{PolicyGateExecutor, RiskSignalQueue, TrajectoryRiskSlot};
 pub use registry::ToolRegistry;
 #[cfg(target_os = "macos")]
 pub use sandbox::MacosSandbox;
@@ -128,6 +129,7 @@ pub use schema_filter::{
     DependencyExclusion, InclusionReason, ToolDependencyGraph, ToolEmbedding, ToolFilterResult,
     ToolSchemaFilter,
 };
+pub use scope::{ScopeError, ScopeWarning, ScopedToolExecutor, ToolScope, build_scoped_executor};
 pub use scrape::WebScrapeExecutor;
 pub use search_code::{
     LspSearchBackend, SearchCodeExecutor, SearchCodeHit, SearchCodeSource, SemanticSearchBackend,

--- a/crates/zeph-tools/src/policy_gate.rs
+++ b/crates/zeph-tools/src/policy_gate.rs
@@ -22,6 +22,27 @@ use crate::executor::{ToolCall, ToolError, ToolExecutor, ToolOutput};
 use crate::policy::{PolicyContext, PolicyDecision, PolicyEnforcer};
 use crate::registry::ToolDef;
 
+/// Shared risk level from spec 050 `TrajectorySentinel`.
+///
+/// Stored as `u8` to avoid a direct dep on `zeph-core`; mapping:
+/// `0` = Calm, `1` = Elevated, `2` = High, `3` = Critical.
+/// Written by the agent loop after each `sentinel.current_risk()` call.
+/// Read by `check_policy` — an `Allow` decision is downgraded to `Deny` at `3` (Critical).
+pub type TrajectoryRiskSlot = Arc<parking_lot::RwLock<u8>>;
+
+/// Callback invoked by executors in `zeph-tools` to record a risk signal into the sentinel
+/// that lives in `zeph-core`, avoiding a reverse crate dependency.
+///
+/// The `u8` argument is a `RiskSignalCode` — see `crates/zeph-core/src/agent/trajectory.rs`.
+pub type RiskSignalSink = Arc<dyn Fn(u8) + Send + Sync>;
+
+/// Lock-free pending signal queue shared between executor layers and the agent loop.
+///
+/// Executors push `u8` signal codes; `begin_turn()` drains the queue and calls
+/// `TrajectorySentinel::record()` for each entry. This avoids a reverse crate dependency
+/// between `zeph-tools` and `zeph-core`.
+pub type RiskSignalQueue = Arc<parking_lot::Mutex<Vec<u8>>>;
+
 /// Wraps an inner `ToolExecutor`, evaluating `PolicyEnforcer` before delegating.
 ///
 /// Policy is only applied to `execute_tool_call` / `execute_tool_call_confirmed`.
@@ -31,6 +52,11 @@ pub struct PolicyGateExecutor<T: ToolExecutor> {
     enforcer: Arc<PolicyEnforcer>,
     context: Arc<RwLock<PolicyContext>>,
     audit: Option<Arc<AuditLogger>>,
+    /// Optional trajectory risk level slot injected by the agent loop (spec 050).
+    /// When `Some` and the value is `3` (Critical), all `Allow` decisions are downgraded.
+    trajectory_risk: Option<TrajectoryRiskSlot>,
+    /// Optional signal queue — `PolicyDeny` codes are pushed here; drained by `begin_turn()`.
+    signal_queue: Option<RiskSignalQueue>,
 }
 
 impl<T: ToolExecutor + std::fmt::Debug> std::fmt::Debug for PolicyGateExecutor<T> {
@@ -54,6 +80,8 @@ impl<T: ToolExecutor> PolicyGateExecutor<T> {
             enforcer,
             context,
             audit: None,
+            trajectory_risk: None,
+            signal_queue: None,
         }
     }
 
@@ -62,6 +90,31 @@ impl<T: ToolExecutor> PolicyGateExecutor<T> {
     pub fn with_audit(mut self, audit: Arc<AuditLogger>) -> Self {
         self.audit = Some(audit);
         self
+    }
+
+    /// Attach a trajectory risk slot (spec 050).
+    ///
+    /// When the slot value reaches `3` (Critical), any `Allow` decision from the policy
+    /// enforcer is downgraded to `Deny` with `error_category = "trajectory_critical_downgrade"`.
+    #[must_use]
+    pub fn with_trajectory_risk(mut self, slot: TrajectoryRiskSlot) -> Self {
+        self.trajectory_risk = Some(slot);
+        self
+    }
+
+    /// Attach a shared signal queue so `PolicyDeny` decisions are recorded in the sentinel.
+    ///
+    /// The agent loop (`begin_turn`) drains the queue and feeds signals to the sentinel.
+    #[must_use]
+    pub fn with_signal_queue(mut self, queue: RiskSignalQueue) -> Self {
+        self.signal_queue = Some(queue);
+        self
+    }
+
+    fn push_signal(&self, code: u8) {
+        if let Some(ref q) = self.signal_queue {
+            q.lock().push(code);
+        }
     }
 
     fn read_context(&self) -> PolicyContext {
@@ -73,7 +126,59 @@ impl<T: ToolExecutor> PolicyGateExecutor<T> {
         *self.context.write() = new_ctx;
     }
 
+    /// Return `true` when the trajectory sentinel is at Critical (spec 050).
+    fn is_trajectory_critical(&self) -> bool {
+        self.trajectory_risk
+            .as_ref()
+            .is_some_and(|slot| *slot.read() >= 3)
+    }
+
+    async fn log_audit(&self, call: &ToolCall, result: AuditResult, error_category: Option<&str>) {
+        let Some(audit) = &self.audit else { return };
+        let entry = AuditEntry {
+            timestamp: chrono_now(),
+            tool: call.tool_id.clone(),
+            command: truncate_params(&call.params),
+            result,
+            duration_ms: 0,
+            error_category: error_category.map(str::to_owned),
+            error_domain: error_category.map(|_| "security".to_owned()),
+            error_phase: None,
+            claim_source: None,
+            mcp_server_id: None,
+            injection_flagged: false,
+            embedding_anomalous: false,
+            cross_boundary_mcp_to_acp: false,
+            adversarial_policy_decision: None,
+            exit_code: None,
+            truncated: false,
+            caller_id: call.caller_id.clone(),
+            policy_match: None,
+            correlation_id: None,
+            vigil_risk: None,
+            scope_at_definition: None,
+            scope_at_dispatch: None,
+        };
+        audit.log(&entry).await;
+    }
+
     async fn check_policy(&self, call: &ToolCall) -> Result<(), ToolError> {
+        // Spec 050: at Critical risk level, deny ALL tool calls before policy evaluation.
+        if self.is_trajectory_critical() {
+            tracing::warn!(tool = %call.tool_id, "trajectory sentinel at Critical: denied (spec 050)");
+            self.log_audit(
+                call,
+                AuditResult::Blocked {
+                    reason: "trajectory_critical_downgrade".to_owned(),
+                },
+                Some("trajectory_critical_downgrade"),
+            )
+            .await;
+            return Err(ToolError::Blocked {
+                command: "Tool call denied by policy".to_owned(),
+            });
+        }
+
         let ctx = self.read_context();
         let decision = self
             .enforcer
@@ -101,10 +206,11 @@ impl<T: ToolExecutor> PolicyGateExecutor<T> {
                         exit_code: None,
                         truncated: false,
                         caller_id: call.caller_id.clone(),
-                        // M1: use trace field directly as policy_match
                         policy_match: Some(trace.clone()),
                         correlation_id: None,
                         vigil_risk: None,
+                        scope_at_definition: None,
+                        scope_at_dispatch: None,
                     };
                     audit.log(&entry).await;
                 }
@@ -112,6 +218,8 @@ impl<T: ToolExecutor> PolicyGateExecutor<T> {
             }
             PolicyDecision::Deny { trace } => {
                 debug!(tool = %call.tool_id, trace = %trace, "policy: deny");
+                // Signal code 1 = PolicyDeny (matches RiskSignal::PolicyDeny in zeph-core).
+                self.push_signal(1);
                 if let Some(audit) = &self.audit {
                     let entry = AuditEntry {
                         timestamp: chrono_now(),
@@ -133,10 +241,11 @@ impl<T: ToolExecutor> PolicyGateExecutor<T> {
                         exit_code: None,
                         truncated: false,
                         caller_id: call.caller_id.clone(),
-                        // M1: use trace field directly as policy_match
                         policy_match: Some(trace.clone()),
                         correlation_id: None,
                         vigil_risk: None,
+                        scope_at_definition: None,
+                        scope_at_dispatch: None,
                     };
                     audit.log(&entry).await;
                 }
@@ -203,6 +312,8 @@ impl<T: ToolExecutor> ToolExecutor for PolicyGateExecutor<T> {
                     policy_match: None,
                     correlation_id: None,
                     vigil_risk: None,
+                    scope_at_definition: None,
+                    scope_at_dispatch: None,
                 };
                 audit.log(&entry).await;
             }
@@ -513,6 +624,49 @@ mod tests {
         assert!(
             result.is_ok(),
             "Trusted context must satisfy a Verified trust threshold allow rule"
+        );
+    }
+
+    // GAP-1: trajectory_risk_slot at Critical (3) must downgrade Allow to Deny.
+    #[tokio::test]
+    async fn critical_trajectory_blocks_any_allow() {
+        let config = PolicyConfig {
+            enabled: true,
+            default_effect: DefaultEffect::Allow,
+            rules: vec![],
+            policy_file: None,
+        };
+        let slot: TrajectoryRiskSlot = Arc::new(RwLock::new(3u8)); // Critical
+        let gate = make_gate(&config).with_trajectory_risk(slot);
+        let result = gate.execute_tool_call(&make_call("builtin:shell")).await;
+        assert!(
+            matches!(result, Err(ToolError::Blocked { .. })),
+            "Critical trajectory must block even policy-allowed tool calls"
+        );
+        // LLM isolation: error message must not reveal risk level.
+        if let Err(ToolError::Blocked { command }) = result {
+            assert!(
+                !command.contains("Critical") && !command.contains("trajectory"),
+                "error message must not leak risk info to LLM: got '{command}'"
+            );
+        }
+    }
+
+    // Corollary: slot at High (2) must NOT downgrade (only Critical does).
+    #[tokio::test]
+    async fn high_trajectory_does_not_block_allowed_tool() {
+        let config = PolicyConfig {
+            enabled: true,
+            default_effect: DefaultEffect::Allow,
+            rules: vec![],
+            policy_file: None,
+        };
+        let slot: TrajectoryRiskSlot = Arc::new(RwLock::new(2u8)); // High
+        let gate = make_gate(&config).with_trajectory_risk(slot);
+        let result = gate.execute_tool_call(&make_call("builtin:shell")).await;
+        assert!(
+            result.is_ok(),
+            "High (not Critical) must not block allowed tool calls"
         );
     }
 }

--- a/crates/zeph-tools/src/scope.rs
+++ b/crates/zeph-tools/src/scope.rs
@@ -1,0 +1,985 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `ScopedToolExecutor`: config-driven capability scoping wrapper.
+//!
+//! Wraps any `ToolExecutor` and filters both `tool_definitions()` (LLM tool list) and
+//! `execute_tool_call()` (dispatch path) to an operator-configured allow-list of
+//! fully-qualified tool ids.
+//!
+//! # Wiring order
+//!
+//! ```text
+//! ScopedToolExecutor          ← outermost (this crate)
+//!   → PolicyGateExecutor
+//!       → TrustGateExecutor
+//!           → CompositeExecutor
+//!               → ToolFilter, AuditedExecutor, ...
+//! ```
+//!
+//! `ScopedToolExecutor` is placed outside `PolicyGateExecutor` so an out-of-scope call
+//! short-circuits before policy evaluation.
+//!
+//! # Tool-id namespacing
+//!
+//! All tool ids MUST carry a namespace prefix before scope resolution:
+//!
+//! | Source | Prefix |
+//! |---|---|
+//! | Built-in executors | `builtin:` |
+//! | Skill-defined tools | `skill:<name>/` |
+//! | MCP tools | `mcp:<server_id>/` |
+//! | ACP / A2A proxied tools | `acp:<peer>/` / `a2a:<peer>/` |
+//!
+//! An un-namespaced tool id returned by an executor at registration is a
+//! `ScopeError::UnqualifiedId`.
+//!
+//! # Pattern strictness
+//!
+//! - `builtin:` / `skill:` globs: strict — zero-match is `ScopeError::DeadPattern`.
+//! - `mcp:` / `acp:` / `a2a:` globs: provisional — zero-match is
+//!   `ScopeWarning::ProvisionalDeadPattern` (re-resolved on dynamic registration).
+//! - A glob matching the **entire** registry without an explicit `general` opt-in is
+//!   `ScopeError::AccidentallyFull`.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use globset::{Glob, GlobSet, GlobSetBuilder};
+use tracing::warn;
+
+use crate::audit::{AuditEntry, AuditLogger, AuditResult, chrono_now};
+use crate::executor::{ToolCall, ToolError, ToolExecutor, ToolOutput};
+use crate::registry::ToolDef;
+use zeph_config::{CapabilityScopesConfig, PatternStrictness};
+
+// ── Errors & warnings ─────────────────────────────────────────────────────────
+
+/// Fatal startup error emitted when a scope configuration is invalid.
+#[derive(Debug, thiserror::Error)]
+pub enum ScopeError {
+    /// A glob pattern in a strict namespace matched zero registered tool ids.
+    #[error("scope '{scope}': pattern '{pattern}' matched zero registered tools (dead pattern)")]
+    DeadPattern { scope: String, pattern: String },
+
+    /// A glob pattern expanded to the entire tool registry without an explicit opt-in.
+    #[error(
+        "scope '{scope}': pattern '{pattern}' matches the entire registry; use default_scope=\"general\" to opt in"
+    )]
+    AccidentallyFull { scope: String, pattern: String },
+
+    /// An executor registered a tool id without a namespace prefix.
+    #[error("tool id '{id}' has no namespace prefix (expected '<namespace>:<id>')")]
+    UnqualifiedId { id: String },
+
+    /// A glob pattern could not be compiled.
+    #[error("scope '{scope}': invalid glob pattern '{pattern}': {source}")]
+    InvalidPattern {
+        scope: String,
+        pattern: String,
+        #[source]
+        source: globset::Error,
+    },
+}
+
+/// Non-fatal warning emitted for provisional-namespace zero-match patterns.
+#[derive(Debug)]
+pub struct ScopeWarning {
+    /// The scope name containing the unresolved pattern.
+    pub scope: String,
+    /// The glob pattern that matched zero ids at build time.
+    pub pattern: String,
+}
+
+// ── ToolScope ─────────────────────────────────────────────────────────────────
+
+/// Materialised tool scope: a pre-compiled allow-list of fully-qualified tool ids.
+///
+/// At agent build time, glob patterns are resolved against the registered tool set
+/// and stored as a `HashSet<String>`. Runtime admission is an O(1) lookup.
+#[derive(Debug, Clone)]
+pub struct ToolScope {
+    /// Identifier of this scope (task-type name).
+    pub task_type: Option<String>,
+    /// Expanded, materialised set of fully-qualified tool ids.
+    admitted: HashSet<String>,
+    /// `true` for the `general` default-scope only; admits every id without lookup.
+    is_full: bool,
+    /// Original patterns, kept for re-resolution when new tools are registered dynamically.
+    patterns: Vec<String>,
+}
+
+impl ToolScope {
+    /// The identity scope: admits every tool id. Used for the `general` default scope.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_tools::scope::ToolScope;
+    ///
+    /// let scope = ToolScope::full();
+    /// assert!(scope.admits("builtin:shell"));
+    /// assert!(scope.admits("mcp:any_server/any_tool"));
+    /// ```
+    #[must_use]
+    pub fn full() -> Self {
+        Self {
+            task_type: None,
+            admitted: HashSet::new(),
+            is_full: true,
+            patterns: vec!["*".to_owned()],
+        }
+    }
+
+    /// Compile a scope from glob patterns against the materialised registry.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ScopeError::DeadPattern` when a strict-namespace glob matches zero ids,
+    /// `ScopeError::AccidentallyFull` when a pattern expands to the entire registry without
+    /// an explicit `general` opt-in, or `ScopeError::InvalidPattern` on invalid glob syntax.
+    pub fn try_compile<S: std::hash::BuildHasher>(
+        task_type: impl Into<String>,
+        patterns: &[String],
+        registry_ids: &HashSet<String, S>,
+        strictness: PatternStrictness,
+        is_general_scope: bool,
+    ) -> Result<(Self, Vec<ScopeWarning>), ScopeError> {
+        let task_type_str = task_type.into();
+        let mut admitted = HashSet::new();
+        let mut warnings = Vec::new();
+
+        for pattern in patterns {
+            // Validate that glob compiles.
+            let glob = Glob::new(pattern).map_err(|e| ScopeError::InvalidPattern {
+                scope: task_type_str.clone(),
+                pattern: pattern.clone(),
+                source: e,
+            })?;
+
+            let mut builder = GlobSetBuilder::new();
+            builder.add(glob);
+            let glob_set: GlobSet = builder.build().map_err(|e| ScopeError::InvalidPattern {
+                scope: task_type_str.clone(),
+                pattern: pattern.clone(),
+                source: e,
+            })?;
+
+            let matched: HashSet<String> = registry_ids
+                .iter()
+                .filter(|id| glob_set.is_match(id.as_str()))
+                .cloned()
+                .collect();
+
+            // Check for accidentally-full expansion (unless this is the general scope).
+            if !is_general_scope && matched.len() == registry_ids.len() && !registry_ids.is_empty()
+            {
+                return Err(ScopeError::AccidentallyFull {
+                    scope: task_type_str,
+                    pattern: pattern.clone(),
+                });
+            }
+
+            if matched.is_empty() {
+                let is_strict = is_strict_pattern(pattern, strictness);
+                if is_strict {
+                    return Err(ScopeError::DeadPattern {
+                        scope: task_type_str,
+                        pattern: pattern.clone(),
+                    });
+                }
+                warnings.push(ScopeWarning {
+                    scope: task_type_str.clone(),
+                    pattern: pattern.clone(),
+                });
+            }
+
+            admitted.extend(matched);
+        }
+
+        Ok((
+            Self {
+                task_type: Some(task_type_str),
+                admitted,
+                is_full: false,
+                patterns: patterns.to_vec(),
+            },
+            warnings,
+        ))
+    }
+
+    /// Returns `true` when the given fully-qualified tool id is admitted by this scope.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_tools::scope::ToolScope;
+    ///
+    /// let scope = ToolScope::full();
+    /// assert!(scope.admits("builtin:shell"));
+    /// ```
+    #[must_use]
+    pub fn admits(&self, qualified_tool_id: &str) -> bool {
+        self.is_full || self.admitted.contains(qualified_tool_id)
+    }
+
+    /// Returns the list of admitted tool ids (excluding `full` scopes).
+    ///
+    /// Useful for `/scope list` output and the `scope_at_definition` audit field.
+    #[must_use]
+    pub fn admitted_ids(&self) -> Vec<&str> {
+        self.admitted.iter().map(String::as_str).collect()
+    }
+
+    /// The raw glob patterns this scope was compiled from (for re-resolution).
+    #[must_use]
+    pub fn patterns(&self) -> &[String] {
+        &self.patterns
+    }
+
+    /// Re-resolve the scope against a new registry (called on dynamic tool registration).
+    ///
+    /// Returns a new `ToolScope` with the updated admit set; warnings are logged but not
+    /// returned (non-fatal for provisional namespaces).
+    #[must_use]
+    pub fn re_resolve<S: std::hash::BuildHasher>(&self, registry_ids: &HashSet<String, S>) -> Self {
+        let task_type_str = self
+            .task_type
+            .clone()
+            .unwrap_or_else(|| "<unknown>".to_owned());
+        let mut admitted = HashSet::new();
+        for pattern in &self.patterns {
+            let Ok(glob) = Glob::new(pattern) else {
+                warn!(scope = %task_type_str, pattern, "re-resolve: invalid glob, skipping");
+                continue;
+            };
+            let mut builder = GlobSetBuilder::new();
+            builder.add(glob);
+            let Ok(glob_set) = builder.build() else {
+                continue;
+            };
+            let matched: HashSet<String> = registry_ids
+                .iter()
+                .filter(|id| glob_set.is_match(id.as_str()))
+                .cloned()
+                .collect();
+            admitted.extend(matched);
+        }
+        Self {
+            task_type: self.task_type.clone(),
+            admitted,
+            is_full: false,
+            patterns: self.patterns.clone(),
+        }
+    }
+}
+
+/// Returns `true` when the pattern targets a strict namespace (`builtin:` or `skill:`).
+fn is_strict_pattern(pattern: &str, strictness: PatternStrictness) -> bool {
+    match strictness {
+        PatternStrictness::Strict => true,
+        PatternStrictness::Permissive => false,
+        PatternStrictness::ProvisionalForDynamicNamespaces => {
+            // Strict for builtin: and skill:; provisional for mcp:, acp:, a2a:
+            pattern.starts_with("builtin:") || pattern.starts_with("skill:")
+        }
+    }
+}
+
+// ── ScopedToolExecutor ────────────────────────────────────────────────────────
+
+/// Wraps any `ToolExecutor` and enforces a capability scope on both tool listing and dispatch.
+///
+/// # Type parameter
+///
+/// `E` is the inner executor (e.g., `PolicyGateExecutor<TrustGateExecutor<CompositeExecutor>>`).
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use std::collections::HashSet;
+/// use zeph_tools::scope::{ScopedToolExecutor, ToolScope};
+/// use zeph_tools::{ToolExecutor, ToolCall};
+/// use zeph_common::ToolName;
+///
+/// // Build a full (no-op) scope — identity, admits everything.
+/// let scope = ToolScope::full();
+///
+/// // Wrap some inner executor (omitted for brevity).
+/// struct MockExecutor;
+/// impl ToolExecutor for MockExecutor {
+///     async fn execute(&self, _: &str) -> Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError> { Ok(None) }
+/// }
+/// let executor = ScopedToolExecutor::new(MockExecutor, scope);
+/// ```
+pub struct ScopedToolExecutor<E: ToolExecutor> {
+    inner: E,
+    /// Atomically swappable active scope. Swapped via `set_scope()`.
+    scope: ArcSwap<ToolScope>,
+    /// Named scope map for task-type lookup.
+    scopes: HashMap<String, Arc<ToolScope>>,
+    /// Name of the scope currently surfaced to the LLM (captured at `tool_definitions()` time).
+    scope_at_definition: parking_lot::Mutex<Option<String>>,
+    /// Optional shared queue — `OutOfScope` signal codes pushed here; drained by `begin_turn()`.
+    signal_queue: Option<crate::policy_gate::RiskSignalQueue>,
+    /// Optional audit logger — `out_of_scope` entries emitted on every rejection.
+    audit: Option<Arc<AuditLogger>>,
+}
+
+impl<E: ToolExecutor> ScopedToolExecutor<E> {
+    /// Create a new `ScopedToolExecutor` with the given initial scope.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use zeph_tools::scope::{ScopedToolExecutor, ToolScope};
+    ///
+    /// struct Noop;
+    /// impl zeph_tools::ToolExecutor for Noop {
+    ///     async fn execute(&self, _: &str) -> Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError> { Ok(None) }
+    /// }
+    /// let executor = ScopedToolExecutor::new(Noop, ToolScope::full());
+    /// ```
+    #[must_use]
+    pub fn new(inner: E, initial_scope: ToolScope) -> Self {
+        Self {
+            inner,
+            scope: ArcSwap::from_pointee(initial_scope),
+            scopes: HashMap::new(),
+            scope_at_definition: parking_lot::Mutex::new(None),
+            signal_queue: None,
+            audit: None,
+        }
+    }
+
+    /// Attach an audit logger so every `OutOfScope` rejection writes an audit entry.
+    #[must_use]
+    pub fn with_audit(mut self, audit: Arc<AuditLogger>) -> Self {
+        self.audit = Some(audit);
+        self
+    }
+
+    /// Attach a shared signal queue so `OutOfScope` rejections are recorded in the sentinel.
+    #[must_use]
+    pub fn with_signal_queue(mut self, queue: crate::policy_gate::RiskSignalQueue) -> Self {
+        self.signal_queue = Some(queue);
+        self
+    }
+
+    /// Register a named scope for use with `set_scope_for_task`.
+    pub fn register_scope(&mut self, name: impl Into<String>, scope: ToolScope) {
+        self.scopes.insert(name.into(), Arc::new(scope));
+    }
+
+    /// Switch the active scope by task-type name. Returns `false` when the name is not found.
+    pub fn set_scope_for_task(&self, task_type: &str) -> bool {
+        if let Some(scope) = self.scopes.get(task_type) {
+            self.scope.store(Arc::clone(scope));
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Replace the active scope with the given one directly.
+    pub fn set_scope(&self, scope: ToolScope) {
+        self.scope.store(Arc::new(scope));
+    }
+
+    /// Return the list of tool ids admitted by the scope for `task_type`.
+    ///
+    /// Returns `None` when `task_type` is not registered.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use zeph_tools::scope::{ScopedToolExecutor, ToolScope};
+    ///
+    /// struct Noop;
+    /// impl zeph_tools::ToolExecutor for Noop {
+    ///     async fn execute(&self, _: &str) -> Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError> { Ok(None) }
+    /// }
+    /// let mut executor = ScopedToolExecutor::new(Noop, ToolScope::full());
+    /// // scope_for_task returns None for unregistered task types
+    /// assert!(executor.scope_for_task("unknown").is_none());
+    /// ```
+    #[must_use]
+    pub fn scope_for_task(&self, task_type: &str) -> Option<Vec<String>> {
+        self.scopes.get(task_type).map(|s| {
+            if s.is_full {
+                vec!["*".to_owned()]
+            } else {
+                s.admitted_ids().iter().map(|s| (*s).to_owned()).collect()
+            }
+        })
+    }
+
+    /// Name of the active scope at the last `tool_definitions()` call (for audit).
+    #[must_use]
+    pub fn scope_at_definition_name(&self) -> Option<String> {
+        self.scope_at_definition.lock().clone()
+    }
+
+    /// Name of the currently active scope (for audit at dispatch time).
+    #[must_use]
+    pub fn active_scope_name(&self) -> Option<String> {
+        self.scope.load().task_type.clone()
+    }
+}
+
+impl<E: ToolExecutor> ToolExecutor for ScopedToolExecutor<E> {
+    // CRIT-03 carve-out: legacy fenced-block dispatch path is not scoped (mirrors PolicyGate).
+    async fn execute(&self, response: &str) -> Result<Option<ToolOutput>, ToolError> {
+        self.inner.execute(response).await
+    }
+
+    async fn execute_confirmed(&self, response: &str) -> Result<Option<ToolOutput>, ToolError> {
+        self.inner.execute_confirmed(response).await
+    }
+
+    /// Return the filtered tool definitions visible to the LLM under the active scope.
+    ///
+    /// Captures the active scope name into `scope_at_definition` for audit use.
+    fn tool_definitions(&self) -> Vec<ToolDef> {
+        let scope = self.scope.load();
+        self.scope_at_definition.lock().clone_from(&scope.task_type);
+        self.inner
+            .tool_definitions()
+            .into_iter()
+            .filter(|d| {
+                let id = d.id.as_ref();
+                scope.admits(id)
+            })
+            .collect()
+    }
+
+    /// Execute a structured tool call, rejecting out-of-scope ids before any side-effect.
+    ///
+    /// Returns `ToolError::OutOfScope` when the tool id is not in the active scope.
+    /// The audit log entry at the call site must carry `error_category = "out_of_scope"`.
+    async fn execute_tool_call(&self, call: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
+        let scope = self.scope.load();
+        let tool_id = call.tool_id.as_str();
+
+        // Reject un-namespaced tool ids (NEVER clause from spec 050).
+        if !tool_id.contains(':') {
+            return Err(ToolError::OutOfScope {
+                tool_id: tool_id.to_owned(),
+                task_type: scope.task_type.clone(),
+            });
+        }
+
+        if !scope.admits(tool_id) {
+            let scope_name = scope.task_type.clone();
+            let scope_def = self.scope_at_definition.lock().clone();
+            tracing::debug!(
+                tool_id,
+                scope = ?scope_name,
+                "ScopedToolExecutor: out-of-scope rejection"
+            );
+            // Signal code 3 = OutOfScope (matches RiskSignal::OutOfScope in zeph-core).
+            if let Some(ref q) = self.signal_queue {
+                q.lock().push(3);
+            }
+            // F4: emit audit entry with error_category = "out_of_scope".
+            if let Some(ref audit) = self.audit {
+                let entry = AuditEntry {
+                    timestamp: chrono_now(),
+                    tool: call.tool_id.clone(),
+                    command: String::new(),
+                    result: AuditResult::Blocked {
+                        reason: "out_of_scope".to_owned(),
+                    },
+                    duration_ms: 0,
+                    error_category: Some("out_of_scope".to_owned()),
+                    error_domain: Some("security".to_owned()),
+                    error_phase: None,
+                    claim_source: None,
+                    mcp_server_id: None,
+                    injection_flagged: false,
+                    embedding_anomalous: false,
+                    cross_boundary_mcp_to_acp: false,
+                    adversarial_policy_decision: None,
+                    exit_code: None,
+                    truncated: false,
+                    caller_id: call.caller_id.clone(),
+                    policy_match: None,
+                    correlation_id: None,
+                    vigil_risk: None,
+                    scope_at_definition: scope_def,
+                    scope_at_dispatch: scope_name,
+                };
+                audit.log(&entry).await;
+            }
+            return Err(ToolError::OutOfScope {
+                tool_id: tool_id.to_owned(),
+                task_type: scope.task_type.clone(),
+            });
+        }
+
+        self.inner.execute_tool_call(call).await
+    }
+
+    async fn execute_tool_call_confirmed(
+        &self,
+        call: &ToolCall,
+    ) -> Result<Option<ToolOutput>, ToolError> {
+        let scope = self.scope.load();
+        let tool_id = call.tool_id.as_str();
+        if !tool_id.contains(':') || !scope.admits(tool_id) {
+            let scope_name = scope.task_type.clone();
+            let scope_def = self.scope_at_definition.lock().clone();
+            if let Some(ref q) = self.signal_queue {
+                q.lock().push(3);
+            }
+            if let Some(ref audit) = self.audit {
+                let entry = AuditEntry {
+                    timestamp: chrono_now(),
+                    tool: call.tool_id.clone(),
+                    command: String::new(),
+                    result: AuditResult::Blocked {
+                        reason: "out_of_scope".to_owned(),
+                    },
+                    duration_ms: 0,
+                    error_category: Some("out_of_scope".to_owned()),
+                    error_domain: Some("security".to_owned()),
+                    error_phase: None,
+                    claim_source: None,
+                    mcp_server_id: None,
+                    injection_flagged: false,
+                    embedding_anomalous: false,
+                    cross_boundary_mcp_to_acp: false,
+                    adversarial_policy_decision: None,
+                    exit_code: None,
+                    truncated: false,
+                    caller_id: call.caller_id.clone(),
+                    policy_match: None,
+                    correlation_id: None,
+                    vigil_risk: None,
+                    scope_at_definition: scope_def,
+                    scope_at_dispatch: scope_name,
+                };
+                audit.log(&entry).await;
+            }
+            return Err(ToolError::OutOfScope {
+                tool_id: tool_id.to_owned(),
+                task_type: scope.task_type.clone(),
+            });
+        }
+        self.inner.execute_tool_call_confirmed(call).await
+    }
+
+    fn set_skill_env(&self, env: Option<std::collections::HashMap<String, String>>) {
+        self.inner.set_skill_env(env);
+    }
+
+    fn set_effective_trust(&self, level: crate::SkillTrustLevel) {
+        self.inner.set_effective_trust(level);
+    }
+
+    fn is_tool_retryable(&self, tool_id: &str) -> bool {
+        self.inner.is_tool_retryable(tool_id)
+    }
+
+    fn is_tool_speculatable(&self, tool_id: &str) -> bool {
+        self.inner.is_tool_speculatable(tool_id)
+    }
+}
+
+// ── Config-driven builder ──────────────────────────────────────────────────────
+
+/// Build a `ScopedToolExecutor` from a `CapabilityScopesConfig` and a registered tool set.
+///
+/// Returns a fatal `ScopeError` when any strict-namespace pattern matches zero tools.
+/// Emits `ScopeWarning` entries for provisional-namespace zero-match patterns.
+///
+/// # Errors
+///
+/// Returns `ScopeError` when scope configuration is invalid (dead patterns, accidental-full).
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use std::collections::HashSet;
+/// use zeph_config::CapabilityScopesConfig;
+/// use zeph_tools::scope::build_scoped_executor;
+///
+/// struct Noop;
+/// impl zeph_tools::ToolExecutor for Noop {
+///     async fn execute(&self, _: &str) -> Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError> { Ok(None) }
+/// }
+///
+/// let cfg = CapabilityScopesConfig::default();
+/// let registry: HashSet<String> = HashSet::new();
+/// let executor = build_scoped_executor(Noop, &cfg, &registry).expect("build failed");
+/// ```
+pub fn build_scoped_executor<E: ToolExecutor, S: std::hash::BuildHasher>(
+    inner: E,
+    cfg: &CapabilityScopesConfig,
+    registry_ids: &HashSet<String, S>,
+) -> Result<ScopedToolExecutor<E>, ScopeError> {
+    // Verify no un-namespaced ids in registry.
+    for id in registry_ids {
+        if !id.contains(':') {
+            return Err(ScopeError::UnqualifiedId { id: id.clone() });
+        }
+    }
+
+    let default_scope_name = &cfg.default_scope;
+    let strictness = cfg.pattern_strictness;
+
+    // The default initial scope is full (no-op) unless a named default_scope is configured.
+    let initial_scope = ToolScope::full();
+    let mut executor = ScopedToolExecutor::new(inner, initial_scope);
+
+    for (task_type, scope_cfg) in &cfg.scopes {
+        let is_general = task_type == default_scope_name;
+        let (scope, warnings) = ToolScope::try_compile(
+            task_type.clone(),
+            &scope_cfg.patterns,
+            registry_ids,
+            strictness,
+            is_general,
+        )?;
+        for w in &warnings {
+            warn!(
+                scope = %w.scope,
+                pattern = %w.pattern,
+                "capability scope: provisional zero-match pattern (will re-resolve on dynamic registration)"
+            );
+        }
+        executor.register_scope(task_type.clone(), scope);
+    }
+
+    // If a default_scope is configured and registered, activate it.
+    if cfg.scopes.contains_key(default_scope_name.as_str()) {
+        executor.set_scope_for_task(default_scope_name);
+    }
+
+    Ok(executor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::executor::ToolCall;
+    use crate::registry::{InvocationHint, ToolDef};
+    use zeph_common::ToolName;
+    use zeph_config::{CapabilityScopesConfig, PatternStrictness, ScopeConfig};
+
+    fn make_registry(ids: &[&str]) -> HashSet<String> {
+        ids.iter().map(|s| (*s).to_owned()).collect()
+    }
+
+    struct NullExecutor {
+        defs: Vec<ToolDef>,
+    }
+
+    impl ToolExecutor for NullExecutor {
+        async fn execute(&self, _: &str) -> Result<Option<ToolOutput>, ToolError> {
+            Ok(None)
+        }
+
+        fn tool_definitions(&self) -> Vec<ToolDef> {
+            self.defs.clone()
+        }
+
+        async fn execute_tool_call(
+            &self,
+            call: &ToolCall,
+        ) -> Result<Option<ToolOutput>, ToolError> {
+            Ok(Some(ToolOutput {
+                tool_name: call.tool_id.clone(),
+                summary: "ok".to_owned(),
+                blocks_executed: 1,
+                filter_stats: None,
+                diff: None,
+                streamed: false,
+                terminal_id: None,
+                locations: None,
+                raw_response: None,
+                claim_source: None,
+            }))
+        }
+    }
+
+    fn null_def(id: &str) -> ToolDef {
+        ToolDef {
+            id: id.to_owned().into(),
+            description: "test tool".into(),
+            schema: schemars::schema_for!(String),
+            invocation: InvocationHint::ToolCall,
+            output_schema: None,
+        }
+    }
+
+    fn make_call(tool_id: &str) -> ToolCall {
+        ToolCall {
+            tool_id: ToolName::new(tool_id),
+            params: serde_json::Map::new(),
+            caller_id: None,
+        }
+    }
+
+    #[test]
+    fn full_scope_admits_everything() {
+        let scope = ToolScope::full();
+        assert!(scope.admits("builtin:shell"));
+        assert!(scope.admits("mcp:server/tool"));
+        assert!(scope.admits("builtin:read"));
+    }
+
+    #[test]
+    fn compiled_scope_admits_only_matched() {
+        let registry = make_registry(&["builtin:shell", "builtin:read", "builtin:write"]);
+        let patterns = vec!["builtin:read".to_owned()];
+        let (scope, warnings) = ToolScope::try_compile(
+            "narrow",
+            &patterns,
+            &registry,
+            PatternStrictness::Strict,
+            false,
+        )
+        .unwrap();
+        assert!(warnings.is_empty());
+        assert!(scope.admits("builtin:read"));
+        assert!(!scope.admits("builtin:shell"));
+        assert!(!scope.admits("builtin:write"));
+    }
+
+    #[test]
+    fn dead_pattern_strict_returns_error() {
+        let registry = make_registry(&["builtin:shell"]);
+        let patterns = vec!["builtin:nonexistent".to_owned()];
+        let result = ToolScope::try_compile(
+            "test",
+            &patterns,
+            &registry,
+            PatternStrictness::Strict,
+            false,
+        );
+        assert!(
+            matches!(result, Err(ScopeError::DeadPattern { .. })),
+            "expected DeadPattern, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn dead_pattern_provisional_returns_warning() {
+        let registry = make_registry(&["builtin:shell"]);
+        let patterns = vec!["mcp:server/nonexistent".to_owned()];
+        let result = ToolScope::try_compile(
+            "test",
+            &patterns,
+            &registry,
+            PatternStrictness::ProvisionalForDynamicNamespaces,
+            false,
+        );
+        assert!(result.is_ok());
+        let (_, warnings) = result.unwrap();
+        assert_eq!(warnings.len(), 1);
+    }
+
+    #[test]
+    fn accidentally_full_pattern_returns_error() {
+        let registry = make_registry(&["builtin:shell", "builtin:read"]);
+        let patterns = vec!["*".to_owned()];
+        let result = ToolScope::try_compile(
+            "test",
+            &patterns,
+            &registry,
+            PatternStrictness::Strict,
+            false, // not general scope
+        );
+        assert!(
+            matches!(result, Err(ScopeError::AccidentallyFull { .. })),
+            "expected AccidentallyFull for non-general scope with '*'"
+        );
+    }
+
+    #[test]
+    fn general_scope_allows_wildcard() {
+        let registry = make_registry(&["builtin:shell", "builtin:read"]);
+        let patterns = vec!["*".to_owned()];
+        let result = ToolScope::try_compile(
+            "general",
+            &patterns,
+            &registry,
+            PatternStrictness::Strict,
+            true, // is_general_scope = true
+        );
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn executor_rejects_out_of_scope_call() {
+        let registry = make_registry(&["builtin:shell", "builtin:read"]);
+        let (scope, _) = ToolScope::try_compile(
+            "narrow",
+            &["builtin:read".to_owned()],
+            &registry,
+            PatternStrictness::Strict,
+            false,
+        )
+        .unwrap();
+        let inner = NullExecutor {
+            defs: vec![null_def("builtin:shell"), null_def("builtin:read")],
+        };
+        let executor = ScopedToolExecutor::new(inner, scope);
+        let call = make_call("builtin:shell");
+        let result = executor.execute_tool_call(&call).await;
+        assert!(matches!(result, Err(ToolError::OutOfScope { .. })));
+    }
+
+    #[tokio::test]
+    async fn executor_allows_in_scope_call() {
+        let registry = make_registry(&["builtin:shell", "builtin:read"]);
+        let (scope, _) = ToolScope::try_compile(
+            "narrow",
+            &["builtin:read".to_owned()],
+            &registry,
+            PatternStrictness::Strict,
+            false,
+        )
+        .unwrap();
+        let inner = NullExecutor {
+            defs: vec![null_def("builtin:shell"), null_def("builtin:read")],
+        };
+        let executor = ScopedToolExecutor::new(inner, scope);
+        let call = make_call("builtin:read");
+        let result = executor.execute_tool_call(&call).await;
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn tool_definitions_filtered_by_scope() {
+        let registry = make_registry(&["builtin:shell", "builtin:read"]);
+        let (scope, _) = ToolScope::try_compile(
+            "narrow",
+            &["builtin:read".to_owned()],
+            &registry,
+            PatternStrictness::Strict,
+            false,
+        )
+        .unwrap();
+        let inner = NullExecutor {
+            defs: vec![null_def("builtin:shell"), null_def("builtin:read")],
+        };
+        let executor = ScopedToolExecutor::new(inner, scope);
+        let defs = executor.tool_definitions();
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].id.as_ref(), "builtin:read");
+    }
+
+    #[tokio::test]
+    async fn unnamespaced_tool_id_rejected() {
+        let scope = ToolScope::full();
+        let inner = NullExecutor {
+            defs: vec![null_def("builtin:shell")],
+        };
+        let executor = ScopedToolExecutor::new(inner, scope);
+        let call = make_call("shell"); // no namespace
+        let result = executor.execute_tool_call(&call).await;
+        assert!(
+            matches!(result, Err(ToolError::OutOfScope { .. })),
+            "un-namespaced id must be rejected"
+        );
+    }
+
+    #[test]
+    fn build_scoped_executor_rejects_unqualified_registry_id() {
+        let cfg = CapabilityScopesConfig::default();
+        let registry = make_registry(&["shell"]); // no namespace
+        let inner = NullExecutor { defs: vec![] };
+        let result = build_scoped_executor(inner, &cfg, &registry);
+        assert!(
+            matches!(result, Err(ScopeError::UnqualifiedId { .. })),
+            "unqualified registry id must be rejected"
+        );
+    }
+
+    #[test]
+    fn scope_for_task_returns_ids() {
+        let registry = make_registry(&["builtin:shell", "builtin:read"]);
+        let (scope, _) = ToolScope::try_compile(
+            "narrow",
+            &["builtin:read".to_owned()],
+            &registry,
+            PatternStrictness::Strict,
+            false,
+        )
+        .unwrap();
+        let inner = NullExecutor { defs: vec![] };
+        let mut executor = ScopedToolExecutor::new(inner, ToolScope::full());
+        executor.register_scope("narrow", scope);
+        let ids = executor.scope_for_task("narrow");
+        assert!(ids.is_some());
+        let ids = ids.unwrap();
+        assert!(ids.contains(&"builtin:read".to_owned()));
+        assert!(!ids.contains(&"builtin:shell".to_owned()));
+    }
+
+    #[test]
+    fn scope_for_task_returns_none_for_unknown() {
+        let inner = NullExecutor { defs: vec![] };
+        let executor = ScopedToolExecutor::new(inner, ToolScope::full());
+        assert!(executor.scope_for_task("does_not_exist").is_none());
+    }
+
+    #[test]
+    fn re_resolve_updates_admitted_set() {
+        // Initial registry: two tools so builtin:* does not accidentally cover everything.
+        // Use a specific pattern to keep the test simple.
+        let registry = make_registry(&["builtin:read", "mcp:server/tool"]);
+        let (scope, _) = ToolScope::try_compile(
+            "narrow",
+            &["builtin:read".to_owned()],
+            &registry,
+            PatternStrictness::Strict,
+            false,
+        )
+        .unwrap();
+        assert!(scope.admits("builtin:read"));
+        assert!(!scope.admits("builtin:write"));
+
+        // After re-resolve with a new registry entry the pattern still only matches "builtin:read".
+        let mut new_registry = registry.clone();
+        new_registry.insert("builtin:write".to_owned());
+        let updated = scope.re_resolve(&new_registry);
+        assert!(updated.admits("builtin:read"));
+        // "builtin:write" is not in the original pattern, so it remains excluded.
+        assert!(!updated.admits("builtin:write"));
+    }
+
+    #[test]
+    fn build_from_config_with_scopes() {
+        let mut scopes = std::collections::HashMap::new();
+        scopes.insert(
+            "general".to_owned(),
+            ScopeConfig {
+                patterns: vec!["*".to_owned()],
+            },
+        );
+        scopes.insert(
+            "narrow".to_owned(),
+            ScopeConfig {
+                patterns: vec!["builtin:read".to_owned()],
+            },
+        );
+        let cfg = CapabilityScopesConfig {
+            default_scope: "general".to_owned(),
+            strict: false,
+            pattern_strictness: PatternStrictness::Strict,
+            scopes,
+        };
+        let registry = make_registry(&["builtin:shell", "builtin:read"]);
+        let inner = NullExecutor { defs: vec![] };
+        let executor = build_scoped_executor(inner, &cfg, &registry).unwrap();
+        // narrow scope should be registered
+        let narrow_ids = executor.scope_for_task("narrow");
+        assert!(narrow_ids.is_some());
+        let ids = narrow_ids.unwrap();
+        assert!(ids.contains(&"builtin:read".to_owned()));
+    }
+}

--- a/crates/zeph-tools/src/scrape.rs
+++ b/crates/zeph-tools/src/scrape.rs
@@ -477,6 +477,8 @@ impl WebScrapeExecutor {
                 policy_match: None,
                 correlation_id,
                 vigil_risk: None,
+                scope_at_definition: None,
+                scope_at_dispatch: None,
             };
             logger.log(&entry).await;
         }

--- a/crates/zeph-tools/src/shell/mod.rs
+++ b/crates/zeph-tools/src/shell/mod.rs
@@ -979,6 +979,8 @@ impl ShellExecutor {
                 policy_match: None,
                 correlation_id: None,
                 vigil_risk: None,
+                scope_at_definition: None,
+                scope_at_dispatch: None,
             };
             logger.log(&entry).await;
         }

--- a/specs/010-security/spec.md
+++ b/specs/010-security/spec.md
@@ -42,6 +42,7 @@ specific areas, refer to the child specs below.
 | [[010-4-audit]] | Audit Trail | Immutable logging, correlation analysis, environment scrubbing |
 | [[010-5-egress-logging]] | Egress Logging | `EgressEvent` per outbound HTTP call, correlation_id, bounded telemetry |
 | [[010-6-vigil-intent-anchoring]] | Verify-Before-Commit | Pre-sanitizer regex tripwire with Block/Sanitize + per-turn intent |
+| [[050-security-capability-governance/spec]] | Capability Governance | Tool scoping, trajectory sentinel, CapSeal vault-broker sketch (#3563, #3569, #3570) |
 
 ---
 
@@ -298,9 +299,21 @@ Correlation is bounded to the current turn — signals do not carry across turn 
 
 ### Key Invariants
 
-- Cross-turn signal accumulation is NEVER performed — correlation is within-turn only
+- Cross-turn signal accumulation is NEVER performed **for injection-confirmation decisions** — `CrossToolCorrelator` correlation is within-turn only
 - `CrossToolCorrelator` state is cleared at the start of each user turn
 - AgentRFC audit failures are logged as `WARN` and escalated to the security event log — they do not hard-block the turn by default
+
+### Scope of the Cross-Turn Prohibition (architectural decision, 2026-05-04)
+
+The "cross-turn signal accumulation is NEVER performed" invariant applies specifically to **`CrossToolCorrelator`**, which makes hard injection-confirmation decisions (`InjectionConfirmed`). Letting injection signals leak across turn boundaries would let a single noisy turn poison every subsequent turn with `InjectionConfirmed` and is fundamentally incompatible with that decision's irreversible semantics.
+
+It does **not** apply to **advisory cross-turn risk budgeting** as defined in [[050-security-capability-governance/spec]] (`TrajectorySentinel`). The sentinel is materially different along three axes that justify the carve-out:
+
+1. **Decision class.** Advisory only — its output (`RiskLevel`) modulates `PolicyGate` decisions; it does not produce a separate confirmation verdict.
+2. **Reversibility.** All sentinel signals decay multiplicatively each turn; a noisy turn cannot durably elevate risk. `CrossToolCorrelator`'s `InjectionConfirmed` is one-way.
+3. **Scope of action.** Sentinel only escalates at thresholds set by config and only downgrades existing allows; it cannot synthesise new permissions or new verdicts.
+
+Both subsystems coexist: `CrossToolCorrelator` continues to be cleared at every turn boundary, while `TrajectorySentinel` accumulates an independent, bounded, decaying score across turns. They share no state and are wired at different stack layers (correlator at sanitize, sentinel at gate).
 
 ---
 

--- a/specs/050-security-capability-governance/spec.md
+++ b/specs/050-security-capability-governance/spec.md
@@ -1,0 +1,716 @@
+---
+aliases:
+  - Security Capability Governance
+  - Capability Scoping
+  - Trajectory Sentinel
+  - CapSeal Vault Broker
+tags:
+  - sdd
+  - spec
+  - security
+  - capability
+  - governance
+  - contract
+created: 2026-05-04
+revised: 2026-05-04
+status: draft
+related:
+  - "[[001-system-invariants/spec]]"
+  - "[[006-tools/spec]]"
+  - "[[010-security/spec]]"
+  - "[[010-1-vault]]"
+  - "[[010-3-authorization]]"
+  - "[[010-6-vigil-intent-anchoring]]"
+---
+
+# Spec 050: Security Capability Governance
+
+> [!info]
+> Three complementary patterns that constrain *what tools the agent can reach*,
+> *how it accumulates advisory risk over a multi-step trajectory*, and *how
+> secret material is consumed without ever materialising as plaintext to the LLM*.
+
+## Revision Note (2026-05-04)
+
+This spec was revised twice on 2026-05-04. The first revision resolved
+critic findings C1–C7; the second applied minor fixes R1–R4:
+
+- **R1**: FR-CG-010 auto-recover hard-resets the score to 0.0 at the
+  turn-count cap (no per-signal weight gate). Residual aggregate-attack
+  window documented in `## Known Gaps`.
+- **R2**: Per-namespace pattern strictness — `builtin:` / `skill:` strict,
+  `mcp:` / `acp:` / `a2a:` provisional. New `pattern_strictness` config
+  key (`provisional_for_dynamic_namespaces` default).
+- **R3**: `alert_threshold` decoupled from `elevated_at` to `high_at`
+  (4.0). New NEVER clause forbidding any LLM-reachable surface from
+  observing `RiskAlert` / `RiskLevel` / sentinel score.
+- **R4**: `subagent_inheritance_factor = 0.5` documented as ≈ one
+  half-life of decay (`0.85^4.27`); config validator warns when
+  `decay_per_turn` is tightened without adjusting the factor.
+
+The original revision (resolving C1–C7) is summarised below:
+
+- **C1 (invariant conflict).** [[010-security/spec]] now carries an explicit
+  carve-out scoping the "no cross-turn signal accumulation" prohibition to
+  `CrossToolCorrelator` (an injection-confirmation decision). Advisory risk
+  budgeting via `TrajectorySentinel` is permitted under the conditions stated
+  in 010-security and re-stated here as Invariant 1.
+- **C2 (glob bypass).** Scope patterns are resolved against the **registry-known
+  tool-id set at agent build time**; an empty match set is a fatal startup
+  error; MCP tools are namespace-prefixed (`mcp:<server>/<tool>`) so a
+  capability-id glob cannot accidentally widen across namespaces.
+- **C3 (Critical deadlock).** `advance_turn` runs unconditionally **before**
+  gate evaluation; an `auto_recover_after_turns` (default 16) hard cap exits
+  Critical without operator action; unattended channels (scheduler, Telegram)
+  carry an explicit availability invariant.
+- **C4 (CapSeal closed-set leak).** Phase 3 sketch is reframed around a
+  typestate `BoundSecret<Op>` instead of a closed `SealedIntent` enum; the
+  closed-enum design is documented as an explicit anti-pattern.
+- **C5 (unjustified weights).** Concrete numeric thresholds for
+  `elevated_at`, `high_at`, `critical_at`, and `alert_threshold` are now
+  specified, with a derivation. `NovelTool` is dropped from Phase 1 (deferred
+  behind a feature flag).
+- **C6 (scope-swap audit gap).** The audit entry now carries both
+  `scope_at_definition` and `scope_at_dispatch`.
+- **C7 (missing signals).** Adds `HighCallRate`, `UnusualReadVolume`, and a
+  `ToolPairTransition` signal; subagents inherit the parent's score with a
+  damping factor when the parent is at `>= Elevated`.
+
+## Issues Addressed
+
+| Issue | Title | Phase |
+|---|---|---|
+| #3563 | Aethelgard — RL-learned dynamic capability governance | Phase 1 (static), Phase 2 (RL) |
+| #3569 | CapSeal + SUDP — capability-sealed vault-broker | Phase 3 (research/spec only) |
+| #3570 | SafeAgent — trajectory-aware risk governance | Phase 1 (heuristic) |
+
+## Motivation
+
+Today's Zeph security stack defends each *individual* tool call: `PolicyEnforcer`
+(deny/allow on tool+path+args), `VigilGate` (regex tripwire on tool *output*),
+`ContentSanitizer` (spotlighting / quarantine), `PiiFilter`, `ExfiltrationGuard`.
+Three orthogonal gaps remain:
+
+1. **Capability over-provisioning.** Every turn the LLM sees the union of all
+   `tool_definitions()` from every executor. Measured baseline: ~15× the median
+   tools-per-task working set. A wider attack surface inflates injection
+   leverage and prompt-token spend.
+2. **Trajectory blindness.** `PolicyEnforcer` is stateless across turns. A
+   patient adversary can spread an attack across N tool calls — each individual
+   call passes policy, but the *sequence* is the attack. There is no advisory
+   risk accumulator.
+3. **Secrets-as-strings risk.** `VaultProvider::get_secret` returns plaintext
+   `String`. Once resolved into a tool arg or HTTP header, the secret is one
+   prompt-injection or log-leak away from exfiltration.
+
+Spec 050 closes (1) and (2) in Phase 1 and reserves (3) as a research item
+(Phase 3) so that follow-on work has a stable contract to target.
+
+## Requirements
+
+### Functional
+
+| ID | Requirement |
+|----|-------------|
+| FR-CG-001 | The agent MUST be able to expose a *narrowed* set of `tool_definitions` to the LLM, computed from a per-task-type allow-list, without modifying executor implementations. |
+| FR-CG-002 | The narrowed scope MUST be configured declaratively in `[security.capability_scopes.<task_type>]` with a list of glob patterns over **fully-qualified tool ids** (`<namespace>:<tool>`), plus a `default_scope` fallback. |
+| FR-CG-003 | When no `task_type` is selected, scoping MUST be the no-op identity (full tool set surfaced — preserves existing behaviour). |
+| FR-CG-004 | Tool calls outside the active scope MUST be rejected at `execute_tool_call` with a structured error (`ToolError::OutOfScope`) BEFORE any tool side-effect runs. The audit log MUST record the rejection with `error_category = "out_of_scope"`. |
+| FR-CG-005 | At agent build time, every glob in every configured scope MUST be matched against the *materialised* tool registry; a glob that matches **zero** registered tools, or `**` / `*` / `mcp:*` patterns that match the entire registry without an explicit operator opt-in, MUST be a fatal startup error (NFR-CG-004). |
+| FR-CG-006 | A `TrajectorySentinel` MUST accumulate risk signals across the last `window_turns` (default 8) of the current session and expose `current_risk() -> RiskLevel` as **advisory input** to the policy gate. |
+| FR-CG-007 | When `current_risk() >= alert_threshold`, the sentinel MUST emit a `RiskAlert` consumed by `PolicyGateExecutor` to escalate the next decision. |
+| FR-CG-008 | Sentinel signals MUST be source-typed and aggregated with bounded weights so a single noisy signal cannot saturate the score. |
+| FR-CG-009 | Sentinel state MUST be cleared on `/clear`, on session-restart, and when the operator runs `/trajectory reset`. |
+| FR-CG-010 | After `auto_recover_after_turns` consecutive turns at `Critical` with no new high-weight signal, the sentinel MUST self-decay below `critical_at` so unattended agents (scheduler, Telegram) recover without operator action. |
+| FR-CG-011 | When a subagent is spawned while the parent's `current_risk() >= Elevated`, the subagent's `TrajectorySentinel` MUST be initialised with a damped copy of the parent's score (factor `0.5`) so the spawn cannot be used as a free risk reset. |
+| FR-CG-012 | The audit entry MUST record both `scope_at_definition` (scope name in effect when `tool_definitions` was assembled for the LLM) and `scope_at_dispatch` (scope name when the call was admitted/rejected). |
+| FR-CG-013 | The `propose_operation` vault-broker contract (Phase 3) MUST be specified as a **typestate `BoundSecret<Op>`** in this document; no implementation code is required in Phase 1. |
+
+### Non-Functional
+
+| ID | Requirement |
+|----|-------------|
+| NFR-CG-001 | Capability scoping overhead MUST be ≤ 50 µs per turn for ≤ 200 tools. |
+| NFR-CG-002 | TrajectorySentinel `record_signal` + `current_risk` MUST be O(1) amortised. |
+| NFR-CG-003 | All sentinel state MUST live in `SecurityState` (per-agent, not global). Subagent inheritance is via FR-CG-011 only. |
+| NFR-CG-004 | Misconfiguration of `[security.capability_scopes]` MUST be a fatal startup error. Patterns matching zero tools are a misconfiguration. |
+| NFR-CG-005 | Audit entries for out-of-scope rejections, risk alerts, and Critical downgrades MUST set `error_category` to a stable string for downstream metrics. |
+| NFR-CG-006 | Unattended agents (scheduler-spawned, Telegram, A2A server) MUST never block indefinitely on a Critical-deny loop. FR-CG-010 (auto-recover) is the binding mitigation. |
+
+## Component Designs
+
+### 1. `ScopedToolExecutor` (FR-CG-001 .. 005, FR-CG-012)
+
+Lives in `crates/zeph-tools/src/scope.rs`. Reuses the existing `ToolFilter`
+pattern in `tool_filter.rs` rather than mutating the `ToolExecutor` trait.
+
+**Why a wrapper, not a trait method.** Issue #3563 proposes
+`fn scope_for_task(task: &str) -> Vec<ToolId>` on the trait. That couples
+*every* executor to scoping, requires an N-way default, and complicates the
+`CompositeExecutor` aggregation. A wrapper inverts the dependency.
+
+**Tool-id namespacing (C2 mitigation).** All tool ids surfaced by Zeph are
+prefixed by namespace before scope resolution:
+
+| Source | Namespace |
+|---|---|
+| Built-in executors (shell, file, web_scrape, …) | `builtin:` |
+| Skill-defined tools | `skill:<skill_name>/` |
+| MCP tools | `mcp:<server_id>/` |
+| ACP / A2A proxied tools | `acp:<peer>/` and `a2a:<peer>/` |
+
+Glob patterns operate on these qualified ids. `mcp:*` is a single-namespace
+glob; `*` covers all namespaces and is allowed only in the explicit
+`default_scope = "general"` configuration. Any *un-namespaced* tool id
+returned by an executor at registration is a fatal startup error — there is
+no path for an MCP server to register `search_arbitrary_shell` and have it
+match `search_*` configured for builtins.
+
+**Build-time pattern resolution (C2 mitigation).** At agent build, every
+configured glob is compiled and matched against the materialised tool
+registry once. Resolution strictness is per-namespace:
+
+| Namespace class | Default strictness |
+|---|---|
+| `builtin:`, `skill:` | strict — registry is fully known at build time |
+| `mcp:`, `acp:`, `a2a:` | provisional — registry may grow as servers connect |
+
+- A `builtin:` or `skill:` glob that matches **zero** ids is a fatal
+  `ScopeError::DeadPattern`.
+- An `mcp:` / `acp:` / `a2a:` glob that matches zero ids at build time is
+  recorded as `ScopeWarning::ProvisionalDeadPattern` and re-resolved on
+  every dynamic registration. Failing strict on a not-yet-connected MCP
+  server would conflict with NFR-CG-006 (unattended channels must boot
+  even when the upstream is down).
+- A glob that expands to the **entire registry** without `default_scope =
+  "general"` opt-in is a fatal `ScopeError::AccidentallyFull` regardless
+  of namespace.
+- The compiled scope stores the *expanded set of tool ids*, not the raw
+  glob — runtime admission becomes a `HashSet<ToolId>` lookup, not glob
+  evaluation. The set is rebuilt on every dynamic-namespace registration.
+- The `pattern_strictness` config key (`strict` | `permissive` |
+  `provisional_for_dynamic_namespaces` — default the third) overrides the
+  per-namespace defaults if an operator wants uniform strictness.
+- New tools registered after build are re-resolved against the active
+  scope on registration; if a new id widens the active scope, the operator
+  is warned in the TUI status line.
+
+```rust
+// crates/zeph-tools/src/scope.rs
+use std::collections::HashSet;
+use crate::executor::{ToolCall, ToolError, ToolExecutor, ToolOutput};
+use crate::registry::ToolDef;
+
+pub struct ToolScope {
+    pub task_type: Option<String>,
+    /// Expanded, materialised set of fully-qualified tool ids.
+    admitted: HashSet<String>,
+    /// `true` for the `general` default-scope only; admits everything.
+    is_full: bool,
+}
+
+impl ToolScope {
+    pub fn full() -> Self { Self { task_type: None, admitted: HashSet::new(), is_full: true } }
+
+    /// Compile globs against the materialised registry. Fatal on dead patterns,
+    /// accidental-full, or empty result without an explicit full opt-in.
+    pub fn try_compile(
+        task_type: impl Into<String>,
+        patterns: &[String],
+        registry_ids: &HashSet<String>,
+        is_default_general: bool,
+    ) -> Result<Self, ScopeError> { /* ... */ }
+
+    fn admits(&self, qualified_tool_id: &str) -> bool {
+        self.is_full || self.admitted.contains(qualified_tool_id)
+    }
+}
+
+pub struct ScopedToolExecutor<E: ToolExecutor> {
+    inner: E,
+    scope: arc_swap::ArcSwap<ToolScope>,
+}
+
+impl<E: ToolExecutor> ToolExecutor for ScopedToolExecutor<E> {
+    fn tool_definitions(&self) -> Vec<ToolDef> {
+        let scope = self.scope.load();
+        self.inner
+            .tool_definitions()
+            .into_iter()
+            .filter(|d| scope.admits(d.qualified_id()))
+            .collect()
+    }
+
+    async fn execute_tool_call(&self, call: &ToolCall)
+        -> Result<Option<ToolOutput>, ToolError>
+    {
+        let scope = self.scope.load();
+        if !scope.admits(call.qualified_tool_id()) {
+            return Err(ToolError::OutOfScope {
+                tool_id: call.qualified_tool_id().to_string(),
+                task_type: scope.task_type.clone(),
+            });
+        }
+        self.inner.execute_tool_call(call).await
+    }
+}
+```
+
+**Wiring order** (outermost first):
+
+```text
+ScopedToolExecutor
+    → PolicyGateExecutor
+        → TrustGateExecutor
+            → CompositeExecutor
+                → ToolFilter, AuditedExecutor, ...
+```
+
+`ScopedToolExecutor` wraps *outside* `PolicyGateExecutor` so an out-of-scope
+call short-circuits before policy evaluation.
+
+**Scope-swap semantics (C6 mitigation).** Scope swaps via `/scope <name>`
+take effect at the next `execute_tool_call` boundary; in-flight calls
+complete under the scope active at admission. The audit emission carries
+both `scope_at_definition` (recorded when the tool list was last surfaced
+to the LLM) and `scope_at_dispatch`. A divergence between the two is a
+forensic signal, not an error — the LLM may legitimately have learned of a
+tool from a wider prior scope.
+
+**Config schema:**
+
+```toml
+[security.capability_scopes]
+default_scope = "general"
+strict        = true            # unknown task_type → fatal startup
+                                # (false → falls back to default_scope)
+
+[security.capability_scopes.general]
+patterns = ["*"]                # explicit identity scope opt-in
+
+[security.capability_scopes.research]
+patterns = ["builtin:fetch", "builtin:web_scrape", "builtin:search_*",
+            "builtin:read", "builtin:glob", "mcp:*/search_*"]
+
+[security.capability_scopes.code_edit]
+patterns = ["builtin:read", "builtin:edit", "builtin:write",
+            "builtin:shell", "builtin:glob"]
+
+[security.capability_scopes.shell_only]
+patterns = ["builtin:shell"]
+```
+
+### 2. `TrajectorySentinel` (FR-CG-006 .. 011)
+
+Lives in `crates/zeph-core/src/agent/trajectory.rs`. Stored as a field on
+`SecurityState`.
+
+**Relationship to 010-security.** This subsystem is governed by the explicit
+carve-out in [[010-security/spec#Scope of the Cross-Turn Prohibition
+(architectural decision, 2026-05-04)]]: the cross-turn prohibition applies
+to `CrossToolCorrelator` (irreversible injection-confirmation) only, not to
+this advisory, decaying, allow-modulating layer.
+
+**Signal taxonomy (Phase 1):**
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RiskSignal {
+    /// VIGIL flagged a tool output.
+    VigilFlagged(VigilRiskLevel),
+    /// PolicyEnforcer denied a structured tool call.
+    PolicyDeny,
+    /// `ExfiltrationGuard` redacted at least one outbound URL or HTML img.
+    ExfiltrationRedaction,
+    /// Tool call rejected as out-of-scope (FR-CG-004).
+    OutOfScope,
+    /// PII filter redacted ≥ 1 span in a tool output.
+    PiiRedaction,
+    /// Tool returned a non-zero exit code or unrecoverable error.
+    ToolFailure,
+    /// More than `high_call_rate_threshold` (default 12) tool calls in
+    /// the last 3 turns. (C7-a volumetric)
+    HighCallRate,
+    /// More than `unusual_read_threshold` (default 24) distinct paths read
+    /// in `window_turns`. (C7-c volumetric)
+    UnusualReadVolume,
+    /// A configured high-risk tool-pair transition occurred within K turns.
+    /// E.g. `web_scrape` → `write` to a system path. (C7-d transition)
+    ToolPairTransition,
+}
+```
+
+`NovelTool` (Phase-1 candidate in v1 of this spec) is **dropped from Phase
+1** because of conflict with legitimate first-time MCP server use. It is
+reserved behind a feature flag (`security.trajectory.novelty_signal`) for
+Phase 2 when persistent per-installation novelty tracking is available.
+
+**Weights and thresholds (C5 mitigation, all configurable):**
+
+| Symbol | Default | Justification |
+|---|---:|---|
+| `weight(VigilFlagged(High))` | 2.5 | A confirmed high-risk injection candidate; two of them in a short window is by itself worrying. |
+| `weight(VigilFlagged(Medium))` | 1.0 | Medium-confidence injection match. |
+| `weight(VigilFlagged(Low))` | 0.3 | (Reserved; current `VigilGate` does not emit Low.) |
+| `weight(PolicyDeny)` | 1.5 | Denied calls are themselves policy-conformant — but a *cluster* indicates the LLM is testing the perimeter. |
+| `weight(ExfiltrationRedaction)` | 2.0 | Active redaction is closer to evidence than VigilFlagged. |
+| `weight(OutOfScope)` | 1.5 | Same family as PolicyDeny. |
+| `weight(PiiRedaction)` | 0.5 | Common in legitimate data work; small weight. |
+| `weight(ToolFailure)` | 0.3 | Noisy signal; tiny weight to avoid alert fatigue. |
+| `weight(HighCallRate)` | 1.5 | Fires at most once per 3-turn window. |
+| `weight(UnusualReadVolume)` | 1.5 | Fires at most once per `window_turns`. |
+| `weight(ToolPairTransition)` | 2.0 | Fires only on configured anti-patterns; cardinality is operator-bounded. |
+| `decay_per_turn` | 0.85 | Half-life ≈ 4.3 turns; balances slow-burn detection vs. recovery. |
+| `window_turns` | 8 | Twice the half-life; bounds memory. |
+| `elevated_at` | 2.0 | One PolicyDeny + one PiiRedaction crosses it. |
+| `high_at` | 4.0 | Two simultaneous high-weight signals or a sustained moderate cluster. |
+| `critical_at` | 8.0 | Three concurrent high-weight events; calibrated against the saturation ceiling. |
+| `alert_threshold` | `high_at` (4.0) | Decoupled from `elevated_at`: routine activity (e.g. one `PolicyDeny` + one `PiiRedaction` ≈ 2.0) crosses Elevated and would flood the alert stream. Alerts fire only at `High` or above so they remain operator-actionable. |
+| `auto_recover_after_turns` | 16 | Hard cap on Critical persistence (FR-CG-010). |
+| `subagent_inheritance_factor` | 0.5 | Spawn-time damping of inherited score (FR-CG-011). Calibrated as ≈ `decay_per_turn ^ 4.27` — one half-life of decay (`0.85^4.27 ≈ 0.5`). Operators tightening `decay_per_turn` MUST adjust this factor; the config validator emits a warning when the relation `subagent_inheritance_factor ≈ decay_per_turn ^ (ln(0.5)/ln(decay_per_turn))` deviates by more than 0.1 in either direction. |
+
+**Saturation ceiling and acceptance test.** All Phase-1 signals at full
+weight, sustained at one event per turn for 8 turns, produce a score
+asymptotically approaching:
+
+```
+score_max = Σ_(k=0..7) 0.85^k × max_weight_per_turn
+          ≈ 5.7 × max_weight_per_turn
+```
+
+For `max_weight_per_turn = 2.5` (one `VigilFlagged(High)` per turn) the
+ceiling is ≈ 14.3, comfortably above `critical_at = 8.0`. The acceptance
+test "6 × `VigilFlagged(High)` over 8 turns → Critical" computes:
+
+```
+score = Σ_(k=0..5) 0.85^k × 2.5  ≈  10.3   →  Critical (≥ 8.0)
+```
+
+A property test asserts that no random Phase-1 signal trace can produce a
+NaN or negative score, and that any trace of length ≤ 8 with at most one
+event per turn is bounded above by `score_max`.
+
+```rust
+pub struct TrajectorySentinel {
+    cfg: TrajectorySentinelConfig,
+    buf: VecDeque<(u64, RiskSignal)>,   // (turn, signal); evicted by window
+    current_turn: u64,
+    last_change_turn: u64,              // for auto-recover gating
+    cached_score: Option<f32>,          // invalidated on record / advance
+}
+
+impl TrajectorySentinel {
+    pub fn record(&mut self, sig: RiskSignal) { /* push, evict, mark dirty */ }
+
+    /// MUST be called once per turn, BEFORE the gate evaluates.
+    /// Applies multiplicative decay and the FR-CG-010 auto-recover cap.
+    pub fn advance_turn(&mut self) { /* see invariants below */ }
+
+    pub fn current_risk(&self) -> RiskLevel { /* score → bucket */ }
+    pub fn poll_alert(&self) -> Option<RiskAlert> { /* Some when ≥ Elevated */ }
+    pub fn reset(&mut self) { /* full clear */ }
+
+    /// Initialise a child sentinel at subagent spawn time per FR-CG-011.
+    pub fn spawn_child(&self) -> TrajectorySentinel {
+        let mut child = TrajectorySentinel::new(self.cfg.clone());
+        if self.current_risk() >= RiskLevel::Elevated {
+            let damped_score = self.score_now() * self.cfg.subagent_inheritance_factor;
+            child.seed_score(damped_score);
+        }
+        child
+    }
+}
+```
+
+**advance_turn ordering invariant (C3 mitigation).** The agent loop calls
+`sentinel.advance_turn()` at the **start** of every turn, *before* any
+`PolicyGateExecutor::check_policy` runs. This guarantees that even on a
+Critical-deny turn:
+
+1. `advance_turn` runs first; multiplicative decay is applied.
+2. Gate evaluates with the post-decay score.
+3. If still `>= Critical`, the deny stands; otherwise it does not.
+
+Without this ordering, a Critical-deny turn would abort before decay,
+producing a monotone deadlock. The agent loop wiring puts `advance_turn`
+in the same hot section as `current_turn += 1`, with a tracing span and
+`debug_assert!(self.current_turn > prev)`.
+
+**FR-CG-010 auto-recover.** When the sentinel has been at `>= Critical`
+for `auto_recover_after_turns` consecutive `advance_turn` calls, the score
+is **hard-reset to `0.0`** at the cap and the buffered signal history is
+cleared. The reset is unconditional with respect to per-individual-signal
+weights — a per-signal gate (e.g. "no signal `>= 1.5`") would be defeated
+by an attacker sustaining `VigilFlagged(Medium) + PiiRedaction +
+ToolFailure = 1.8/turn` (no individual `>= 1.5`) producing a permanent
+16-denied/1-allowed cycle. The hard reset is the only design that breaks
+out of every aggregate-attack profile. The reset is logged as
+`AuditEntry { error_category: "trajectory_auto_recover", … }` carrying
+the score and signal census at reset time for forensics. The threshold can
+be raised by operator config but not below a 4-turn floor. This is the
+binding mitigation for NFR-CG-006 (unattended channels). See `## Known
+Gaps` for the residual aggregate-attack window between resets.
+
+**Consumption.** `PolicyGateExecutor` checks `sentinel.current_risk()`
+**after** its own rule evaluation:
+
+| Risk level | Effect on a rule's `Allow` |
+|---|---|
+| `Calm` / `Elevated` | unchanged; audit entry tagged with `risk_level`. |
+| `High` | unchanged in Phase 1; audit entry carries `error_category = "trajectory_alert"`. Phase 2 may require confirmation. |
+| `Critical` | downgraded to `Deny { trace: "trajectory_critical" }`. Audit entry carries `error_category = "trajectory_critical"`. |
+
+`Deny` decisions are **never upgraded** by the sentinel.
+
+**Where signals are recorded:**
+
+| Source file | Signal |
+|-------------|--------|
+| `PolicyGateExecutor::check_policy` | `PolicyDeny` |
+| `ScopedToolExecutor::execute_tool_call` | `OutOfScope` |
+| `agent/tool_execution/sanitize.rs` | `VigilFlagged`, `PiiRedaction`, `ExfiltrationRedaction` |
+| `agent/tool_execution/dispatch.rs` | `ToolFailure`, `HighCallRate`, `UnusualReadVolume`, `ToolPairTransition` |
+| `agent/builder.rs` (subagent spawn) | `spawn_child` — see FR-CG-011 |
+
+### 3. CapSeal + SUDP — Phase 3 typestate sketch (FR-CG-013, C4 mitigation)
+
+A Phase 3 sketch only. The earlier draft used a closed `SealedIntent` enum;
+the critic correctly flagged that any closed enum becomes the leak surface.
+The revised approach is a typestate-bound credential handle:
+
+```rust
+// proposed: crates/zeph-vault/src/broker.rs (Phase 3, NOT in this PR)
+
+/// Marker trait for vault operations. Implementors are types, not values.
+pub trait VaultOp: sealed::Sealed {
+    type Input;
+    type Output;
+}
+
+/// A bound credential handle. The `Op` parameter selects the only operation
+/// that may be performed. Cannot be cloned, cannot be compared, cannot be
+/// printed. Drops zero the underlying resolver token.
+pub struct BoundSecret<Op: VaultOp> {
+    /* opaque */
+    _op: PhantomData<Op>,
+}
+
+pub mod ops {
+    pub struct HttpBearer;       impl VaultOp for HttpBearer { /* ... */ }
+    pub struct HmacSign;          impl VaultOp for HmacSign { /* ... */ }
+    pub struct Decrypt;           impl VaultOp for Decrypt { /* ... */ }
+    // New operations are new types. Adding one requires every dispatcher
+    // that handles `BoundSecret<NewOp>` to compile-error if it doesn't
+    // explicitly implement the new operation. There is no `match _` arm.
+}
+
+pub trait VaultBroker: Send + Sync {
+    /// Each operation is a separate trait method. There is no enum, no
+    /// `propose_operation(intent)` indirection that hides the operation
+    /// type. Adding a new op requires extending `VaultBroker` (or a sister
+    /// trait) and is a compile-checked decision at every call site.
+    fn http_bearer(
+        &self,
+        secret: BoundSecret<ops::HttpBearer>,
+        request: http::request::Builder,
+    ) -> Pin<Box<dyn Future<Output = Result<http::Request<Bytes>, BrokerError>> + Send + '_>>;
+
+    fn hmac_sign(
+        &self,
+        secret: BoundSecret<ops::HmacSign>,
+        payload: &[u8],
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, BrokerError>> + Send + '_>>;
+
+    fn decrypt(
+        &self,
+        secret: BoundSecret<ops::Decrypt>,
+        ciphertext: &[u8],
+    ) -> Pin<Box<dyn Future<Output = Result<Bytes, BrokerError>> + Send + '_>>;
+}
+```
+
+**Why this beats the closed enum.**
+- A new op is a new type, not a new variant. Existing call sites do not
+  silently fall through; they fail at compile time if they need the new op.
+- `BoundSecret<HttpBearer>` cannot be coerced to `BoundSecret<HmacSign>`;
+  a stolen handle cannot be retargeted to a different operation.
+- The "LLM cannot invent a new op" property is enforced statically.
+
+**Why this is research-only in Phase 1.** The full design needs an audit
+of every `VaultProvider::get_secret` caller to enumerate the actual
+operations. That work is Phase 3 scope and is tracked under [[010-1-vault]]
+follow-on.
+
+## Key Invariants
+
+1. **Sentinel is advisory and decaying.** Per the explicit carve-out in
+   [[010-security/spec]], `TrajectorySentinel` is permitted to accumulate
+   across turns because (a) its outputs are advisory modulators of existing
+   gate decisions, never new verdicts; (b) signals decay multiplicatively
+   each turn so noise cannot durably elevate; (c) sentinel can downgrade
+   `Allow` to `Deny` but never the reverse.
+2. **`advance_turn` precedes gate evaluation.** Decay is applied at the
+   start of every turn before any `PolicyGateExecutor::check_policy` runs.
+3. **Critical state is bounded.** `auto_recover_after_turns` (default 16)
+   is a hard cap on Critical persistence in the absence of new high-weight
+   signals. Unattended channels rely on this.
+4. **Scope is registry-resolved at build time.** Glob patterns are matched
+   against the materialised tool registry; dead patterns and accidentally
+   full patterns are fatal startup errors.
+5. **Tool ids are namespaced before scoping.** `builtin:`, `skill:<name>/`,
+   `mcp:<server>/`, `acp:<peer>/`, `a2a:<peer>/`. No cross-namespace
+   accidental match.
+6. **Sentinel state is per-`SecurityState`** (per-agent). Subagents inherit
+   only via `spawn_child` with `subagent_inheritance_factor` damping, and
+   only when the parent is `>= Elevated`.
+7. **Audit-first.** Every scope rejection, every Critical downgrade, and
+   every auto-recover writes an `AuditEntry` *before* returning the error.
+8. **Phase 1 is heuristic, not ML.** Weights and thresholds are config
+   constants. Phase 2 may add a learning adaptor consuming the same signal
+   stream.
+9. **CapSeal is opt-in and additive.** Phase 3 adds `VaultBroker` *next to*
+   `VaultProvider`, never replacing it implicitly.
+
+## NEVER
+
+- NEVER widen scope at runtime in response to LLM output. `/scope` is an
+  operator command; the LLM cannot reach it.
+- NEVER attempt scope enforcement on the legacy `execute()` /
+  `execute_confirmed()` fenced-block path. Documented carve-out (mirrors
+  `PolicyGate` CRIT-03).
+- NEVER use `glob::Pattern::matches` against an unqualified, non-namespaced
+  tool id. All tool ids are `<namespace>:<id>` before scope resolution.
+- NEVER let an MCP server register a tool id that contains a `:` other
+  than the namespace separator inserted by the registry.
+- NEVER let `tool_definitions()` for one scope be reused for dispatch
+  under a different scope without re-checking admission.
+- NEVER let the sentinel score go negative or NaN. All weights are
+  finite, non-negative; `decay_per_turn ∈ (0, 1]`.
+- NEVER block on the sentinel — record/score is in-process and lock-free
+  beyond a single `parking_lot::Mutex` on the inner buffer. No async, no
+  I/O.
+- NEVER apply a sentinel reset implicitly when the LLM asks. Reset is
+  operator-only; FR-CG-010 auto-recover is *not* a reset, only a partial
+  decay.
+- NEVER design a Phase-3 secret broker around a closed enum (e.g.
+  `SealedIntent`). Use typestate `BoundSecret<Op>`.
+- NEVER let a subagent spawn act as a free risk reset. FR-CG-011
+  inheritance is mandatory.
+- NEVER expose `RiskAlert`, `RiskLevel`, the sentinel score, or any of its
+  internal state to LLM-callable tools, slash commands the LLM can invoke,
+  or any context surface the LLM can read. The signal taxonomy and current
+  level are operator/forensic data; surfacing them lets a prompt-injected
+  LLM probe the gate (e.g. by emitting calibrated noise to characterise
+  thresholds, or by detecting auto-recover and timing attacks around it).
+  `/trajectory show` is operator-only and goes through the channel control
+  path, not the tool surface.
+
+## Implementation Phases
+
+### Phase 1 — this PR (issues #3563 + #3570)
+
+1. `crates/zeph-tools/src/scope.rs` — `ToolScope`, `ScopedToolExecutor`,
+   `ScopeError { DeadPattern, AccidentallyFull, … }`. Wired in
+   `agent::builder` between `PolicyGateExecutor` and the agent stack.
+2. Tool-id namespacing: registry guarantees every `ToolDef.id` carries a
+   namespace prefix; un-namespaced ids are rejected at registration.
+3. `zeph_config::types::security::CapabilityScopesConfig` — TOML schema,
+   build-time glob resolution, `strict` and `default_scope` semantics.
+4. `crates/zeph-core/src/agent/trajectory.rs` —
+   `TrajectorySentinel`, `RiskSignal`, `RiskLevel`, `RiskAlert`,
+   `TrajectorySentinelConfig`. Stored on `SecurityState`.
+5. `advance_turn` invocation site in the agent loop, ordered before gate.
+6. Sentinel hookups in `PolicyGateExecutor`, `ScopedToolExecutor`,
+   `agent/tool_execution/sanitize.rs`, dispatch path, and subagent
+   builder (`spawn_child`).
+7. `ToolError::OutOfScope`, audit entries with
+   `scope_at_definition` / `scope_at_dispatch`, and `error_category`
+   stable strings (`out_of_scope`, `trajectory_alert`,
+   `trajectory_critical`, `trajectory_auto_recover`).
+8. CLI: `--scope <task_type>`; slash commands `/scope <name>`,
+   `/scope reset`, `/trajectory show`, `/trajectory reset`.
+9. TUI: status line surfaces *active scope* and *risk level* (one
+   colour-coded chip each).
+10. Config wizard (`--init`) + `--migrate-config` step for new keys.
+11. Tests:
+    - unit (scope admits/rejects, dead-pattern rejection,
+      namespace-collision rejection, decay monotonicity per-turn,
+      `advance_turn` ordering, auto-recover, signal weights);
+    - integration (`PolicyGate` + `Scope` + `Sentinel` interleaved,
+      subagent inheritance);
+    - property-based (random Phase-1 signal traces never produce
+      NaN/negative score and stay below `score_max`);
+    - regression (Critical-deny followed by 16 idle turns recovers).
+12. Live testing playbook (`.local/testing/playbooks/security-capability-governance.md`)
+    and a row in `coverage-status.md`.
+13. CHANGELOG entry under `[Unreleased]`.
+
+### Phase 2 — follow-on (deferred)
+
+- Auto-routing of scope from the complexity classifier (#3563 RL component).
+- Confirmation-required mode at `High` risk.
+- Sentinel weights learned online from operator overrides.
+- `NovelTool` signal, gated on persistent per-installation novelty store.
+- Cross-mode parity tests (CLI / TUI / Telegram) for `/scope` and
+  `/trajectory`.
+
+### Phase 3 — CapSeal + SUDP (#3569)
+
+- Audit pass over every `VaultProvider::get_secret` caller; classify by op.
+- Define `ops::*` typestate marker types per call-site cluster.
+- Implement `VaultBroker` alongside `VaultProvider`. Migrate clusters one
+  at a time, deleting `get_secret` for that key only after the last caller
+  is migrated.
+- Extend `AuditEntry` with `secret_ref` (the *reference*, not the value).
+
+## Known Gaps
+
+These are accepted Phase-1 limitations, intentionally documented so they
+are not rediscovered as bugs:
+
+- **Aggregate-attack window between auto-recovers (R1 residual).** Between
+  hard resets, an attacker who paces multiple sub-`>= 1.5` signals can keep
+  the score above `critical_at` until the turn-count cap fires. With
+  defaults, this yields a 16-turn-deny / 1-turn-allow cycle until reset.
+  Phase 2 introduces an optional `aggregate_per_turn_cap` so an operator
+  can shorten the deny window without changing per-signal weights.
+- **Provisional dynamic-namespace globs (R2 residual).** An `mcp:` glob
+  that never resolves (server permanently unreachable) silently behaves as
+  a deny-all for that namespace. The TUI status line surfaces unresolved
+  provisional patterns so operators can spot stuck configurations, but
+  there is no automatic escalation.
+- **`NovelTool` deferred.** Phase 1 cannot detect first-time-tool-use
+  signals without persistent per-installation state. Re-entering Phase 2
+  scope behind `security.trajectory.novelty_signal`.
+- **High risk does not require confirmation in Phase 1.** Allow decisions
+  at `High` are forwarded with an audit tag but not blocked. Phase 2 adds
+  an optional confirmation flow.
+
+## Acceptance Criteria
+
+- `cargo nextest run -p zeph-tools -E 'test(scope)'` passes.
+- `cargo nextest run -p zeph-core -E 'test(trajectory)'` passes.
+- A scope config containing a glob that matches zero registered tools
+  produces a fatal startup error with `ScopeError::DeadPattern`.
+- A live session with `--scope research` does NOT expose `builtin:edit` or
+  `builtin:shell` in the LLM tool list; an LLM-emitted `builtin:shell`
+  call returns `OutOfScope` and the audit log contains a row with
+  `error_category = "out_of_scope"`.
+- A synthetic trace of 6 `VigilFlagged(High)` signals over 8 turns drives
+  the sentinel to `Critical`; the next `PolicyGate` allow is downgraded
+  to `Deny { trace: "trajectory_critical" }`.
+- After 16 consecutive turns at `Critical` with **no** new high-weight
+  signal, the next `advance_turn` exits Critical, and the audit log
+  contains `error_category = "trajectory_auto_recover"`.
+- `/clear`, `/scope reset`, and `/trajectory reset` all reset the
+  sentinel.
+- A subagent spawned while the parent is at `Elevated` initialises with a
+  damped, non-zero starting score.
+- An MCP server attempting to register `read` (which collides with
+  `builtin:read`) is rejected at registration; the namespaced id
+  `mcp:hostile/read` is admitted only by an explicit `mcp:hostile/*` glob.
+- Doc-tests on every new `pub` item;
+  `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc
+  --no-deps -p zeph-tools -p zeph-core` clean.
+- CapSeal section is intentionally code-free; Phase 3 work will live
+  behind a new spec (proposed: `010-7-capseal-vault-broker.md`).

--- a/specs/README.md
+++ b/specs/README.md
@@ -39,6 +39,7 @@ Spec IDs (001–044) follow a logical grouping:
 - **047**: CLI execution modes (--bare, --json, -y, /loop, /recap)
 - **048**: SLM cost metrics survey and CPS metric contract
 - **049**: Agent god-object decomposition (Services aggregator + AgentRuntime newtype)
+- **050**: Security capability governance (tool scoping + trajectory sentinel + CapSeal sketch)
 
 ---
 
@@ -119,3 +120,4 @@ Spec IDs (001–044) follow a logical grouping:
 | `UX/mention-routing.md` | @agent mention routing: Goose pattern analysis, feasibility for Zeph TUI/A2A, verdict to defer pending `AgentRegistry` infrastructure (#3327) | `zeph-core`, `zeph-tui`, `zeph-a2a` |
 | `048-slm-cost-metrics/spec.md` | SLM survey findings (arXiv:2510.03847), CPS (cost per successful task) metric contract, `record_successful_task()` / `cps()` API, daily reset semantics | `zeph-core` |
 | `049-agent-decomposition/spec.md` | Agent god-object Phase 2 (#3509): split `Agent<C>` 25+ direct sub-state fields into `services: Services` (background subsystems) and `runtime: AgentRuntime` (config, lifecycle, providers, metrics, debug, instructions); pure refactor, no API change, separately borrowable; `TurnContext` boundary sketched for P2-prereq-3 | `zeph-core` |
+| `050-security-capability-governance/spec.md` | Capability scoping (`ScopedToolExecutor` + per-task-type allow-lists, #3563), `TrajectorySentinel` multi-turn risk accumulator with decay (#3570), and CapSeal/SUDP `VaultBroker::propose_operation` Phase-3 research sketch (#3569) | `zeph-tools`, `zeph-core` |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -172,6 +172,14 @@ pub(crate) struct Cli {
     #[arg(long, value_name = "PATH")]
     pub(crate) policy_file: Option<PathBuf>,
 
+    /// Set the initial capability scope task-type for this session.
+    ///
+    /// Must match a scope name defined in `[security.capability_scopes]`.
+    /// The agent starts with this scope active; the operator can change it at runtime
+    /// via `/scope <task_type>` (Phase 2). No-op when `ScopedToolExecutor` is not wired.
+    #[arg(long = "scope", value_name = "TASK_TYPE")]
+    pub(crate) initial_scope: Option<String>,
+
     /// Override debug dump format: `json`, `raw`, or `trace` (`OTel` OTLP spans).
     #[arg(long = "dump-format", value_name = "FORMAT")]
     pub(crate) dump_format: Option<zeph_core::debug_dump::DumpFormat>,

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -23,7 +23,7 @@ use agents::{step_agents, step_learning, step_orchestration, step_router};
 use llm::step_llm;
 use mcp::{step_mcp_discovery, step_mcp_remote, step_mcpls, write_mcpls_config};
 use memory::{step_context_compression, step_memory};
-use security::{step_policy, step_sandbox, step_security};
+use security::{step_policy, step_sandbox, step_security, step_trajectory};
 
 #[cfg_attr(test, derive(Clone))]
 #[allow(clippy::struct_excessive_bools)]
@@ -234,6 +234,9 @@ pub(crate) struct WizardState {
     pub(crate) telemetry_enabled: bool,
     // Prometheus metrics export (#2866)
     pub(crate) prometheus_enabled: bool,
+    // Trajectory risk sentinel (spec 050)
+    pub(crate) trajectory_critical_at: f32,
+    pub(crate) trajectory_auto_recover: u32,
 }
 
 impl Default for WizardState {
@@ -399,6 +402,8 @@ impl Default for WizardState {
             magic_docs_enabled: false,
             telemetry_enabled: false,
             prometheus_enabled: false,
+            trajectory_critical_at: 10.0,
+            trajectory_auto_recover: 16,
         }
     }
 }
@@ -463,6 +468,7 @@ pub fn run(output: Option<PathBuf>) -> anyhow::Result<()> {
     step_experiments(&mut state)?;
     step_retry(&mut state)?;
     step_policy(&mut state)?;
+    step_trajectory(&mut state)?;
     step_telemetry(&mut state)?;
     step_prometheus(&mut state)?;
     step_session_recap(&mut state)?;
@@ -946,6 +952,8 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
     {
         config.tools.policy.enabled = state.policy_enforcer_enabled;
     }
+    config.security.trajectory.critical_at = state.trajectory_critical_at;
+    config.security.trajectory.auto_recover_after_turns = state.trajectory_auto_recover;
 
     #[cfg(feature = "classifiers")]
     {

--- a/src/init/security.rs
+++ b/src/init/security.rs
@@ -367,6 +367,30 @@ pub(super) fn step_security(state: &mut WizardState) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Wizard step for spec 050 trajectory sentinel thresholds.
+pub(super) fn step_trajectory(state: &mut WizardState) -> anyhow::Result<()> {
+    println!("== Trajectory Risk Sentinel (spec 050) ==\n");
+    println!(
+        "Accumulates cross-turn risk signals and downgrades tool calls to Deny when the\n\
+         score reaches the Critical threshold.\n"
+    );
+
+    let critical_raw: String = Input::new()
+        .with_prompt("Critical threshold (score at which all Allow decisions are denied)")
+        .default("10.0".to_owned())
+        .interact_text()?;
+    state.trajectory_critical_at = critical_raw.parse().unwrap_or(10.0);
+
+    let recover_raw: String = Input::new()
+        .with_prompt("Auto-recover after N consecutive Critical turns (minimum 4)")
+        .default("16".to_owned())
+        .interact_text()?;
+    state.trajectory_auto_recover = recover_raw.parse().unwrap_or(16).max(4);
+
+    println!();
+    Ok(())
+}
+
 pub(super) fn step_policy(state: &mut WizardState) -> anyhow::Result<()> {
     println!("== Policy Enforcer ==\n");
     println!(

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1480,6 +1480,12 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     // Declarative policy (PolicyGate) is outermost — fast, deterministic, zero LLM cost.
     // Adversarial policy gate fires only for calls that pass declarative policy (CRIT-04).
     let mut adv_policy_info: Option<zeph_core::AdversarialPolicyInfo> = None;
+    // Spec 050: shared trajectory risk slot — written by begin_turn(), read by PolicyGateExecutor.
+    let trajectory_risk_slot: zeph_tools::TrajectoryRiskSlot =
+        std::sync::Arc::new(parking_lot::RwLock::new(0u8));
+    // Spec 050: pending risk signal queue — executor layers push signal codes; begin_turn() drains.
+    let trajectory_signal_queue: zeph_tools::RiskSignalQueue =
+        std::sync::Arc::new(parking_lot::Mutex::new(Vec::new()));
     let (tool_executor, mcp_ids_handle) = {
         let trust_gated =
             zeph_tools::TrustGateExecutor::new(inner_executor, permission_policy.clone());
@@ -1586,7 +1592,9 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
                         adversarial_gated,
                         std::sync::Arc::new(enforcer),
                         policy_context,
-                    );
+                    )
+                    .with_trajectory_risk(std::sync::Arc::clone(&trajectory_risk_slot))
+                    .with_signal_queue(std::sync::Arc::clone(&trajectory_signal_queue));
                     zeph_tools::DynExecutor(std::sync::Arc::new(gate))
                 }
                 Err(e) => {
@@ -1600,6 +1608,45 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             adversarial_gated
         };
         (executor, handle)
+    };
+    // Spec 050 F2: wrap with ScopedToolExecutor when capability_scopes are configured.
+    let tool_executor = {
+        let scopes_cfg = config.security.capability_scopes.clone();
+        if scopes_cfg.scopes.is_empty() {
+            tool_executor
+        } else {
+            use std::collections::HashSet;
+            use zeph_tools::DynExecutor;
+            use zeph_tools::executor::ToolExecutor as _;
+            use zeph_tools::scope::build_scoped_executor;
+            // Collect registered tool ids for glob pattern resolution.
+            let registry_ids: HashSet<String> = tool_executor
+                .tool_definitions()
+                .into_iter()
+                .map(|d| d.id.to_string())
+                .collect();
+            match build_scoped_executor(tool_executor, &scopes_cfg, &registry_ids) {
+                Ok(scoped) => {
+                    let scoped =
+                        scoped.with_signal_queue(std::sync::Arc::clone(&trajectory_signal_queue));
+                    // F6: apply --scope CLI override to initial active scope.
+                    if let Some(ref task_type) = cli.initial_scope
+                        && !scoped.set_scope_for_task(task_type)
+                    {
+                        tracing::warn!(
+                            task_type,
+                            "CLI --scope: task type not registered in capability_scopes; ignored"
+                        );
+                    }
+                    DynExecutor(std::sync::Arc::new(scoped))
+                }
+                Err(e) => {
+                    // Config validation at startup prevents reaching this branch. If we do
+                    // reach it (e.g. patterns compiled but registry was empty), abort startup.
+                    return Err(anyhow::anyhow!("capability_scopes: {e}"));
+                }
+            }
+        }
     };
     let mcp_tools = tool_setup.mcp_tools;
     let mcp_outcomes = tool_setup.mcp_outcomes;
@@ -1863,6 +1910,12 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     } else {
         agent
     };
+    // Wire the trajectory risk slot and signal queue (spec 050 Invariant 2).
+    let agent = agent
+        .with_trajectory_risk_slot(trajectory_risk_slot)
+        .with_signal_queue(trajectory_signal_queue)
+        .with_trajectory_config(config.security.trajectory.clone())
+        .0;
 
     // Load provider-specific and explicit instruction files.
     // base_dir is the process CWD at startup — the most natural project root for local tools.


### PR DESCRIPTION
## Summary

- **TrajectorySentinel** (`zeph-core`): multi-turn heuristic risk accumulator with multiplicative decay, 4 risk levels (Normal/Elevated/High/Critical), hard reset auto-recover, and subagent score inheritance via `spawn_child()`. Wired into agent loop before gate evaluation; Critical state forces `PolicyGateExecutor` to deny all tool calls.
- **ScopedToolExecutor** (`zeph-tools`): config-driven per-task-type tool allow-lists with mandatory namespace prefixes (`builtin:`, `skill:`, `mcp:`, `acp:`, `a2a:`), build-time glob resolution, and audit trail with `scope_at_definition`/`scope_at_dispatch` fields.
- **Spec 050** (`specs/050-security-capability-governance/spec.md`): unified research synthesis of Aethelgard (#3563), CapSeal/SUDP (#3569, Phase 3 design only), and SafeAgent (#3570). Amends `specs/010-security/spec.md` with architectural decision carving out advisory `TrajectorySentinel` accumulation from the cross-turn prohibition.

## Closes

- Closes #3563 (Aethelgard capability scoping — Phase 1: static config-based)
- Closes #3570 (SafeAgent trajectory sentinel — heuristic-based)
- Resolves #3569 (CapSeal/SUDP — spec and Phase 3 design; implementation deferred)

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` — 8727 tests pass
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace --lib --bins -- -D warnings` — clean
- [ ] Live session: `cargo run --features full -- --config .local/config/testing.toml` — see `.local/testing/playbooks/security-capability-governance.md` for 8 test scenarios
- [ ] Verify `/trajectory status` shows Normal at startup
- [ ] Verify `/scope list` shows configured scopes
- [ ] Verify PolicyGate blocks tool calls when manually seeding Critical via tests
- [ ] Verify `RiskLevel` does not appear in LLM-visible tool error messages