### PR TITLE
feat(tools): add per-turn ExecutionContext to ShellExecutor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   generic connection error when shutdown is detected. Dynamic `/mcp add` retains single-attempt
   behaviour; a follow-up issue tracks extending retry there (#3568).
 
+- feat(tools): per-turn execution environment selection (#3572)
+  - New `ExecutionContext` type (Arc-backed, cheaply clonable) attached to `ToolCall::context`
+    to specify per-call working directory and environment variable overrides.
+  - `ShellExecutor::with_execution_config` builds a named environment registry from
+    `[execution]` / `[[execution.environments]]` TOML config at agent startup.
+  - `ShellExecutor::resolve_context` implements the 6-step env merge: process env →
+    blocklist filter → skill env → registry (default_env) → registry (named) →
+    call-site overrides → untrusted re-filter.
+  - Trust model: untrusted contexts (LLM-controlled) have env_blocklist re-applied after
+    each merge step; trusted contexts (operator TOML) bypass the final filter pass.
+  - `AuditEntry` extended with `execution_env: Option<String>` and `resolved_cwd: Option<String>`
+    for per-call audit trail enrichment; `resolved_cwd` is `None` for non-shell producers and
+    omitted from serialized JSON (`skip_serializing_if`). **Breaking**: field type changed from
+    `String` to `Option<String>` — consumers reading `resolved_cwd` must handle `None`.
+  - `ToolEvent::Started` extended with `resolved_cwd: Option<String>` and
+    `execution_env: Option<String>` for TUI/channel observability.
+  - New `ExecutionConfig` / `EnvironmentConfig` types in `zeph-config` for the
+    `[execution]` TOML section.
+  - `TaskNode` gains `execution_environment: Option<String>` (serde `default`,
+    `skip_serializing_if`) for the orchestration scheduler to propagate the named
+    environment to inline task tool calls; backward-compatible with stored graphs.
+  - `OrchestrationState` gains `task_execution_env: Option<String>` set by the
+    scheduler around `RunInline` task execution and restored on completion.
+  - `ShellExecutor` gains `spawn_background_with_context` for background commands
+    that inherit the per-turn resolved environment and working directory.
+
 ### Documentation
 
 - research: synthesize MemCoT, OmniMem, and OCR-Memory memory architecture papers; document integration roadmap and file follow-up issues (#3564, #3566, #3571); add Research Backlog to APEX-MEM spec (see specs §14)

--- a/crates/zeph-bench/src/loaders/tau2_bench/envs/airline.rs
+++ b/crates/zeph-bench/src/loaders/tau2_bench/envs/airline.rs
@@ -627,6 +627,7 @@ mod tests {
             tool_id: ToolName::new(tool),
             params: params.as_object().cloned().unwrap_or_default(),
             caller_id: None,
+            context: None,
         }
     }
 

--- a/crates/zeph-bench/src/loaders/tau2_bench/envs/retail.rs
+++ b/crates/zeph-bench/src/loaders/tau2_bench/envs/retail.rs
@@ -746,6 +746,7 @@ mod tests {
             tool_id: ToolName::new(tool),
             params: params.as_object().cloned().unwrap_or_default(),
             caller_id: None,
+            context: None,
         }
     }
 

--- a/crates/zeph-config/src/execution.rs
+++ b/crates/zeph-config/src/execution.rs
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Named execution environment configuration (`[execution]` TOML section).
+//!
+//! Provides [`ExecutionConfig`] — the configuration type for the top-level `[execution]`
+//! section — and [`EnvironmentConfig`] for each `[[execution.environments]]` entry.
+//!
+//! The `ShellExecutor` calls `ExecutionConfig::build_registry` at construction time to
+//! produce a `HashMap<String, ExecutionContext>` that is consulted on every tool call.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Top-level `[execution]` configuration section.
+///
+/// # Config example
+///
+/// ```toml
+/// [execution]
+/// default_env = "repo"
+///
+/// [[execution.environments]]
+/// name = "repo"
+/// cwd = "/Users/me/Dev/myproject"
+/// env = { CARGO_TARGET_DIR = "/tmp/cargo-target" }
+///
+/// [[execution.environments]]
+/// name = "scratch"
+/// cwd = "/tmp/scratch"
+/// ```
+///
+/// # Note on case sensitivity
+///
+/// Environment names are **case-sensitive**. Convention is lowercase (`"repo"`, `"scratch"`).
+/// An unknown `default_env` or `context.name` is a hard error at resolution time.
+#[derive(Debug, Default, Deserialize, Serialize, Clone)]
+pub struct ExecutionConfig {
+    /// Name of the environment applied when a `ToolCall` carries no explicit context
+    /// and no `default_env` would otherwise be used.  This is the least-specific
+    /// fallback layer in the CWD/env precedence stack.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_env: Option<String>,
+
+    /// Named execution environments.  Each entry becomes a registry key that
+    /// `ShellExecutor` consults when `ToolCall::context.name` is set.
+    #[serde(default, rename = "environments")]
+    pub environments: Vec<EnvironmentConfig>,
+}
+
+/// A single named execution environment entry (`[[execution.environments]]`).
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct EnvironmentConfig {
+    /// Registry key.  Case-sensitive; convention is lowercase.
+    pub name: String,
+    /// Absolute or relative working directory for commands using this environment.
+    ///
+    /// Relative paths are resolved relative to the process CWD at registry-build time
+    /// (i.e. agent startup).  Non-existent paths are a hard error.
+    pub cwd: String,
+    /// Extra environment variables injected into the subprocess for this environment.
+    ///
+    /// Because these originate from operator-authored TOML, registry contexts are
+    /// *trusted*: the `env_blocklist` final filter pass is skipped.
+    #[serde(default)]
+    pub env: BTreeMap<String, String>,
+}

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -77,6 +77,7 @@ pub mod defaults;
 pub mod dump_format;
 mod env;
 pub mod error;
+pub mod execution;
 pub mod experiment;
 pub mod features;
 pub mod hooks;
@@ -119,6 +120,7 @@ pub use defaults::{
     is_legacy_default_skills_path, is_legacy_default_sqlite_path,
 };
 pub use dump_format::DumpFormat;
+pub use execution::{EnvironmentConfig, ExecutionConfig};
 pub use experiment::{
     AdaptOrchConfig, ExperimentConfig, ExperimentSchedule, OrchestrationConfig, PlanCacheConfig,
 };

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -13,6 +13,7 @@ use crate::channels::{A2aServerConfig, DiscordConfig, McpConfig, SlackConfig, Te
 use crate::classifiers::ClassifiersConfig;
 use crate::cli::CliConfig;
 use crate::defaults::{default_skill_paths, default_sqlite_path_field};
+use crate::execution::ExecutionConfig;
 use crate::experiment::{ExperimentConfig, OrchestrationConfig};
 use crate::features::{
     CostConfig, DaemonConfig, DebugConfig, GatewayConfig, IndexConfig, SchedulerConfig,
@@ -56,6 +57,11 @@ pub struct Config {
     pub slack: Option<SlackConfig>,
     #[serde(default)]
     pub tools: ToolsConfig,
+    /// Named execution environments for per-turn CWD and env-var selection.
+    ///
+    /// Opt-in — existing configs without `[execution]` deserialise with all defaults.
+    #[serde(default)]
+    pub execution: ExecutionConfig,
     #[serde(default)]
     pub a2a: A2aServerConfig,
     #[serde(default)]
@@ -262,6 +268,7 @@ impl Default for Config {
             discord: None,
             slack: None,
             tools: ToolsConfig::default(),
+            execution: ExecutionConfig::default(),
             a2a: A2aServerConfig::default(),
             mcp: McpConfig::default(),
             index: IndexConfig::default(),

--- a/crates/zeph-core/src/agent/scheduler_commands.rs
+++ b/crates/zeph-core/src/agent/scheduler_commands.rs
@@ -14,6 +14,7 @@ impl<C: Channel> Agent<C> {
             tool_id: zeph_common::ToolName::new("list_tasks"),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
         match self.tool_executor.execute_tool_call_erased(&call).await {
             Ok(Some(output)) => Ok(output.summary),

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -210,6 +210,15 @@ impl<C: crate::channel::Channel> Agent<C> {
         let handle_id = format!("__inline_{task_id}__");
         scheduler.record_spawn(task_id, handle_id.clone(), "__main__".to_string());
 
+        // Inject per-task execution environment so that ToolCalls built inside this
+        // inline loop carry the right named env for ShellExecutor::resolve_context.
+        let prev_task_env = self.services.orchestration.task_execution_env.clone();
+        self.services.orchestration.task_execution_env = scheduler
+            .graph()
+            .tasks
+            .get(task_id.index())
+            .and_then(|t| t.execution_environment.clone());
+
         let event_tx = scheduler.event_sender();
         let max_iter = self.tool_orchestrator.max_iterations;
         let outcome = tokio::select! {
@@ -230,6 +239,9 @@ impl<C: crate::channel::Channel> Agent<C> {
                 }
             }
         };
+        // Restore prior env (supports nested RunInline, though unusual in practice).
+        self.services.orchestration.task_execution_env = prev_task_env;
+
         let event = zeph_orchestration::TaskEvent {
             task_id,
             agent_handle_id: handle_id,
@@ -649,6 +661,7 @@ impl<C: crate::channel::Channel> Agent<C> {
                                 _ => serde_json::Map::new(),
                             },
                             caller_id: None,
+                            context: None,
                         };
                         let output = loop {
                             tokio::select! {

--- a/crates/zeph-core/src/agent/speculative/cache.rs
+++ b/crates/zeph-core/src/agent/speculative/cache.rs
@@ -17,13 +17,16 @@ use parking_lot::Mutex;
 use tokio_util::sync::CancellationToken;
 use zeph_common::ToolName;
 use zeph_common::task_supervisor::{BlockingError, BlockingHandle};
-use zeph_tools::{ToolError, ToolOutput};
+use zeph_tools::{ExecutionContext, ToolError, ToolOutput};
 
-/// Unique key for a speculative handle: tool name + BLAKE3 hash of normalized args.
+/// Unique key for a speculative handle: tool name + BLAKE3 hash of normalized args + context.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct HandleKey {
     pub tool_id: ToolName,
     pub args_hash: blake3::Hash,
+    /// Hash of the [`ExecutionContext`] fields. Two calls with different contexts must not share
+    /// a speculative result — the resolved env/cwd would differ.
+    pub context_hash: blake3::Hash,
 }
 
 /// An in-flight speculative execution handle.
@@ -152,16 +155,18 @@ impl SpeculativeCache {
         }
     }
 
-    /// Find and remove a handle matching `tool_id` + `args_hash`.
+    /// Find and remove a handle matching `tool_id` + `args_hash` + `context_hash`.
     #[must_use]
     pub fn take_match(
         &self,
         tool_id: &ToolName,
         args_hash: &blake3::Hash,
+        context_hash: &blake3::Hash,
     ) -> Option<SpeculativeHandle> {
         let key = HandleKey {
             tool_id: tool_id.clone(),
             args_hash: *args_hash,
+            context_hash: *context_hash,
         };
         self.inner.lock().handles.remove(&key)
     }
@@ -222,6 +227,42 @@ pub fn hash_args(args: &serde_json::Map<String, serde_json::Value>) -> blake3::H
         hasher.update(v.as_bytes());
         hasher.update(b"\x00");
     }
+    hasher.finalize()
+}
+
+/// Compute a BLAKE3 hash over the fields of an [`ExecutionContext`] that affect execution.
+///
+/// Two `ToolCall`s with the same args but different contexts must produce different keys so
+/// the speculative cache does not serve a result resolved under the wrong env/cwd.
+#[must_use]
+pub fn hash_context(ctx: Option<&ExecutionContext>) -> blake3::Hash {
+    let mut hasher = blake3::Hasher::new();
+    if let Some(ctx) = ctx {
+        if let Some(name) = ctx.name() {
+            hasher.update(b"name\x00");
+            hasher.update(name.as_bytes());
+            hasher.update(b"\x00");
+        }
+        if let Some(cwd) = ctx.cwd() {
+            hasher.update(b"cwd\x00");
+            hasher.update(cwd.as_os_str().as_encoded_bytes());
+            hasher.update(b"\x00");
+        }
+        // env_overrides is a BTreeMap so iteration order is already deterministic.
+        for (k, v) in ctx.env_overrides() {
+            hasher.update(b"env\x00");
+            hasher.update(k.as_bytes());
+            hasher.update(b"\x00");
+            hasher.update(v.as_bytes());
+            hasher.update(b"\x00");
+        }
+        hasher.update(if ctx.is_trusted() {
+            b"trusted"
+        } else {
+            b"untrusted"
+        });
+    }
+    // No context → all-zeros input → distinct hash from any populated context.
     hasher.finalize()
 }
 

--- a/crates/zeph-core/src/agent/speculative/mod.rs
+++ b/crates/zeph-core/src/agent/speculative/mod.rs
@@ -44,7 +44,7 @@ use tracing::debug;
 use zeph_common::SkillTrustLevel;
 use zeph_tools::{ErasedToolExecutor, ToolCall, ToolError, ToolOutput};
 
-use cache::{HandleKey, SpeculativeCache, SpeculativeHandle, hash_args};
+use cache::{HandleKey, SpeculativeCache, SpeculativeHandle, hash_args, hash_context};
 use prediction::Prediction;
 
 pub use zeph_config::tools::{SpeculationMode, SpeculativeConfig};
@@ -208,6 +208,7 @@ impl SpeculationEngine {
 
         let call = prediction.to_tool_call(format!("spec-{}", uuid::Uuid::new_v4()));
         let args_hash = hash_args(&call.params);
+        let context_hash = hash_context(call.context.as_ref());
 
         // Policy check: skip if the tool would require user confirmation.
         // This is a pure metadata query — no execution, no side-effects (C1).
@@ -256,6 +257,7 @@ impl SpeculationEngine {
             key: HandleKey {
                 tool_id: tool_id.clone(),
                 args_hash,
+                context_hash,
             },
             join,
             cancel,
@@ -277,7 +279,11 @@ impl SpeculationEngine {
         call: &ToolCall,
     ) -> Option<Result<Option<ToolOutput>, ToolError>> {
         let args_hash = hash_args(&call.params);
-        if let Some(handle) = self.cache.take_match(&call.tool_id, &args_hash) {
+        let context_hash = hash_context(call.context.as_ref());
+        if let Some(handle) = self
+            .cache
+            .take_match(&call.tool_id, &args_hash, &context_hash)
+        {
             {
                 let mut m = self.metrics.lock();
                 m.committed += 1;

--- a/crates/zeph-core/src/agent/speculative/prediction.rs
+++ b/crates/zeph-core/src/agent/speculative/prediction.rs
@@ -48,6 +48,7 @@ impl Prediction {
             tool_id: self.tool_id.clone(),
             params: self.args.clone(),
             caller_id: Some(call_id.into()),
+            context: None,
         }
     }
 }

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -558,6 +558,13 @@ pub(crate) struct OrchestrationState {
     pub(crate) graph_persistence: Option<
         zeph_orchestration::GraphPersistence<zeph_memory::store::graph_store::TaskGraphStore>,
     >,
+    /// Named execution environment for the current orchestration task.
+    ///
+    /// Set by the scheduler when dispatching a `TaskNode` that has
+    /// `execution_environment: Some(name)`. Cleared between tasks. When `Some`,
+    /// `prepare_tool_dispatch` injects an [`ExecutionContext`] named `name` into
+    /// every `ToolCall` so that `ShellExecutor::resolve_context` uses the right env.
+    pub(crate) task_execution_env: Option<String>,
 }
 
 /// Groups instruction hot-reload state.

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -19,6 +19,7 @@ use tracing::Instrument;
 use zeph_llm::provider::MAX_TOKENS_TRUNCATION_MARKER;
 use zeph_sanitizer::{ContentSource, ContentSourceKind};
 use zeph_skills::evolution::FailureKind;
+use zeph_tools::ExecutionContext;
 use zeph_tools::executor::ToolCall;
 
 type ToolExecFut = futures::future::BoxFuture<
@@ -1497,6 +1498,8 @@ impl<C: Channel> Agent<C> {
                                 policy_match: None,
                                 correlation_id: None,
                                 vigil_risk: None,
+                                execution_env: None,
+                                resolved_cwd: None,
                             };
                             let logger = std::sync::Arc::clone(logger);
                             self.runtime.lifecycle.supervisor.spawn(
@@ -1781,6 +1784,15 @@ impl<C: Channel> Agent<C> {
         tool_calls: &[zeph_llm::provider::ToolUseRequest],
     ) -> ToolDispatchContext {
         let tafc_enabled = self.tool_orchestrator.tafc.enabled;
+        // When the orchestration scheduler has set a named execution environment for the
+        // current task, inject it into every ToolCall so ShellExecutor::resolve_context
+        // uses the right env/cwd without the LLM having to supply it.
+        let task_ctx: Option<ExecutionContext> = self
+            .services
+            .orchestration
+            .task_execution_env
+            .as_deref()
+            .map(|name| ExecutionContext::default().with_name(name));
         let calls: Vec<ToolCall> = tool_calls
             .iter()
             .filter_map(|tc| {
@@ -1798,6 +1810,7 @@ impl<C: Channel> Agent<C> {
                     tool_id: tc.name.clone(),
                     params,
                     caller_id: None,
+                    context: task_ctx.clone(),
                 })
             })
             .collect();
@@ -2941,6 +2954,8 @@ impl<C: Channel> Agent<C> {
             policy_match: None,
             correlation_id: None,
             vigil_risk,
+            execution_env: None,
+            resolved_cwd: None,
         };
         let logger = std::sync::Arc::clone(logger);
         self.runtime.lifecycle.supervisor.spawn(
@@ -4252,6 +4267,7 @@ mod tests {
             tool_id: zeph_common::ToolName::new("bash"),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
         let ctx = UtilityContext {
             tool_calls_this_turn: 0,

--- a/crates/zeph-core/src/agent/tool_execution/sanitize.rs
+++ b/crates/zeph-core/src/agent/tool_execution/sanitize.rs
@@ -276,6 +276,8 @@ impl<C: Channel> Agent<C> {
                 policy_match: None,
                 correlation_id: None,
                 vigil_risk: None,
+                execution_env: None,
+                resolved_cwd: None,
             };
             let logger = std::sync::Arc::clone(logger);
             self.runtime.lifecycle.supervisor.spawn(

--- a/crates/zeph-core/src/agent/tool_execution/tests/parallel_and_handle_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/parallel_and_handle_tests.rs
@@ -100,6 +100,7 @@ fn make_calls(n: usize) -> Vec<ToolCall> {
             tool_id: zeph_common::ToolName::new(format!("tool-{i}")),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         })
         .collect()
 }

--- a/crates/zeph-core/src/memory_tools.rs
+++ b/crates/zeph-core/src/memory_tools.rs
@@ -274,6 +274,7 @@ mod tests {
             tool_id: zeph_common::ToolName::new("unknown_tool"),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
         let result = executor.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());
@@ -292,6 +293,7 @@ mod tests {
             tool_id: zeph_common::ToolName::new("memory_search"),
             params,
             caller_id: None,
+            context: None,
         };
         let result = executor.execute_tool_call(&call).await.unwrap();
         assert!(result.is_some());
@@ -319,6 +321,7 @@ mod tests {
             tool_id: zeph_common::ToolName::new("memory_save"),
             params,
             caller_id: None,
+            context: None,
         };
         let result = executor.execute_tool_call(&call).await.unwrap();
         assert!(result.is_some());
@@ -337,6 +340,7 @@ mod tests {
             tool_id: zeph_common::ToolName::new("memory_save"),
             params,
             caller_id: None,
+            context: None,
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(result.is_err());
@@ -355,6 +359,7 @@ mod tests {
             tool_id: zeph_common::ToolName::new("memory_save"),
             params,
             caller_id: None,
+            context: None,
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(result.is_err());

--- a/crates/zeph-core/src/overflow_tools.rs
+++ b/crates/zeph-core/src/overflow_tools.rs
@@ -126,6 +126,7 @@ mod tests {
             tool_id: zeph_common::ToolName::new("read_overflow"),
             params,
             caller_id: None,
+            context: None,
         }
     }
 
@@ -154,6 +155,7 @@ mod tests {
             tool_id: zeph_common::ToolName::new("other_tool"),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
         let result = exec.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());

--- a/crates/zeph-core/src/runtime_layer.rs
+++ b/crates/zeph-core/src/runtime_layer.rs
@@ -189,6 +189,7 @@ mod tests {
             tool_id: "shell".into(),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
         let result = layer.before_tool(&ctx, &call).await;
         assert!(result.is_none());
@@ -411,6 +412,7 @@ mod tests {
             tool_id: "shell".into(),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
         let result: Result<Option<ToolOutput>, ToolError> = Ok(None);
 
@@ -446,6 +448,7 @@ mod tests {
             tool_id: "shell".into(),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
         let result: Result<Option<ToolOutput>, zeph_tools::ToolError> = Ok(None);
         layer.after_tool(&ctx, &call, &result).await;

--- a/crates/zeph-core/src/skill_invoker.rs
+++ b/crates/zeph-core/src/skill_invoker.rs
@@ -210,6 +210,7 @@ mod tests {
                 .unwrap()
                 .clone(),
             caller_id: None,
+            context: None,
         }
     }
 
@@ -221,6 +222,7 @@ mod tests {
                 .unwrap()
                 .clone(),
             caller_id: None,
+            context: None,
         }
     }
 
@@ -333,6 +335,7 @@ mod tests {
             tool_id: zeph_common::ToolName::new("bash"),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
         let result = executor.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());

--- a/crates/zeph-core/src/skill_loader.rs
+++ b/crates/zeph-core/src/skill_loader.rs
@@ -108,6 +108,7 @@ mod tests {
                 .unwrap()
                 .clone(),
             caller_id: None,
+            context: None,
         };
         let result = executor.execute_tool_call(&call).await.unwrap().unwrap();
         assert!(result.summary.contains("## Instructions"));
@@ -126,6 +127,7 @@ mod tests {
                 .unwrap()
                 .clone(),
             caller_id: None,
+            context: None,
         };
         let result = executor.execute_tool_call(&call).await.unwrap().unwrap();
         assert!(result.summary.contains("skill not found"));
@@ -151,6 +153,7 @@ mod tests {
             tool_id: zeph_common::ToolName::new("bash"),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
         let result = executor.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());
@@ -170,6 +173,7 @@ mod tests {
                 .unwrap()
                 .clone(),
             caller_id: None,
+            context: None,
         };
         let result = executor.execute_tool_call(&call).await.unwrap().unwrap();
         assert!(result.summary.contains("truncated"));
@@ -188,6 +192,7 @@ mod tests {
                 .unwrap()
                 .clone(),
             caller_id: None,
+            context: None,
         };
         let result = executor.execute_tool_call(&call).await.unwrap().unwrap();
         assert!(result.summary.contains("skill not found"));
@@ -222,6 +227,7 @@ mod tests {
                             .unwrap()
                             .clone(),
                         caller_id: None,
+                        context: None,
                     };
                     ex.execute_tool_call(&call).await
                 })
@@ -247,6 +253,7 @@ mod tests {
                 .unwrap()
                 .clone(),
             caller_id: None,
+            context: None,
         };
         let result = executor.execute_tool_call(&call).await.unwrap().unwrap();
         assert!(result.summary.contains("skill not found"));
@@ -262,6 +269,7 @@ mod tests {
             tool_id: zeph_common::ToolName::new("load_skill"),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(result.is_err());

--- a/crates/zeph-index/src/mcp_server.rs
+++ b/crates/zeph-index/src/mcp_server.rs
@@ -676,6 +676,7 @@ impl Foo {
                 _ => serde_json::Map::new(),
             },
             caller_id: None,
+            context: None,
         }
     }
 

--- a/crates/zeph-mcp/src/executor.rs
+++ b/crates/zeph-mcp/src/executor.rs
@@ -182,6 +182,7 @@ impl ToolExecutor for McpToolExecutor {
                     _ => serde_json::Map::new(),
                 },
                 caller_id: None,
+                context: None,
             };
             if let Some(output) = self.execute_tool_call(&call).await? {
                 outputs.push(output.summary);
@@ -443,6 +444,7 @@ mod tests {
             tool_id: ToolName::new("no_colon_here"),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
         let result = executor.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());
@@ -455,6 +457,7 @@ mod tests {
             tool_id: ToolName::new("unknown_server:tool"),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
         let result = executor.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());
@@ -482,6 +485,7 @@ mod tests {
             tool_id: ToolName::new("gh_list_issues"),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
         let result = executor.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());
@@ -507,6 +511,7 @@ mod tests {
             tool_id: ToolName::new("missing_server_some_tool"),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(result.is_err(), "expected Err when server is not connected");

--- a/crates/zeph-mcp/src/testing.rs
+++ b/crates/zeph-mcp/src/testing.rs
@@ -214,6 +214,7 @@ mod tests {
             tool_id: "srv:echo".into(),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
         let result = mock.execute_tool_call(&call).await.unwrap();
         assert!(result.is_some());
@@ -227,6 +228,7 @@ mod tests {
             tool_id: "srv:unknown".into(),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
         let result = mock.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());
@@ -242,6 +244,7 @@ mod tests {
             tool_id: "srv:fail".into(),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
         let result = mock.execute_tool_call(&call).await;
         assert!(result.is_err());
@@ -257,6 +260,7 @@ mod tests {
             tool_id: "srv:ping".into(),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
         mock.execute_tool_call(&call).await.unwrap();
 
@@ -275,6 +279,7 @@ mod tests {
             tool_id: "srv:once".into(),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
 
         // First call succeeds.

--- a/crates/zeph-orchestration/src/graph.rs
+++ b/crates/zeph-orchestration/src/graph.rs
@@ -376,6 +376,10 @@ pub struct TaskNode {
     /// on every tick while this is `None` and `verify_predicate.is_some()`.
     #[serde(default)]
     pub predicate_outcome: Option<PredicateOutcome>,
+    /// Named execution environment from `[[execution.environments]]` to use when
+    /// dispatching shell tool calls for this task. `None` inherits the executor default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_environment: Option<String>,
 }
 
 impl TaskNode {
@@ -398,6 +402,7 @@ impl TaskNode {
             execution_mode: ExecutionMode::default(),
             verify_predicate: None,
             predicate_outcome: None,
+            execution_environment: None,
         }
     }
 }

--- a/crates/zeph-orchestration/src/router.rs
+++ b/crates/zeph-orchestration/src/router.rs
@@ -159,6 +159,7 @@ mod tests {
             execution_mode: crate::graph::ExecutionMode::default(),
             verify_predicate: None,
             predicate_outcome: None,
+            execution_environment: None,
         }
     }
 

--- a/crates/zeph-subagent/src/agent_loop.rs
+++ b/crates/zeph-subagent/src/agent_loop.rs
@@ -488,6 +488,7 @@ async fn handle_tool_step(
                     tool_id: tc.name.clone(),
                     params,
                     caller_id: None,
+                    context: None,
                 };
                 let tool_start = Instant::now();
                 let (content, is_error) = match executor.execute_tool_call_erased(&call).await {

--- a/crates/zeph-subagent/src/filter.rs
+++ b/crates/zeph-subagent/src/filter.rs
@@ -533,6 +533,7 @@ mod tests {
             tool_id: "shell".into(),
             params: serde_json::Map::default(),
             caller_id: None,
+            context: None,
         };
         let res = exec.execute_tool_call_erased(&call).await.unwrap();
         assert!(res.is_some());
@@ -548,6 +549,7 @@ mod tests {
             tool_id: "web".into(),
             params: serde_json::Map::default(),
             caller_id: None,
+            context: None,
         };
         let res = exec.execute_tool_call_erased(&call).await;
         assert!(res.is_err());
@@ -563,6 +565,7 @@ mod tests {
             tool_id: "shell".into(),
             params: serde_json::Map::default(),
             caller_id: None,
+            context: None,
         };
         let res = exec.execute_tool_call_erased(&call).await;
         assert!(res.is_err());
@@ -575,6 +578,7 @@ mod tests {
             tool_id: "shell".into(),
             params: serde_json::Map::default(),
             caller_id: None,
+            context: None,
         };
         let res = exec.execute_tool_call_erased(&call).await.unwrap();
         assert!(res.is_some());
@@ -649,6 +653,7 @@ mod tests {
             tool_id: "web".into(), // not in deny list → allowed
             params: serde_json::Map::default(),
             caller_id: None,
+            context: None,
         };
         let res = exec.execute_tool_call_erased(&call).await.unwrap();
         assert!(res.is_some());
@@ -780,6 +785,7 @@ mod tests {
             tool_id: "shell".into(),
             params: serde_json::Map::default(),
             caller_id: None,
+            context: None,
         };
         let res = exec.execute_tool_call_erased(&call).await;
         assert!(
@@ -799,6 +805,7 @@ mod tests {
             tool_id: "web".into(),
             params: serde_json::Map::default(),
             caller_id: None,
+            context: None,
         };
         let res = exec.execute_tool_call_erased(&call).await;
         assert!(res.is_ok(), "non-disallowed tool must be allowed");
@@ -873,6 +880,7 @@ mod tests {
             tool_id: "shell".into(),
             params: serde_json::Map::default(),
             caller_id: None,
+            context: None,
         };
         let res = exec.execute_tool_call_erased(&call).await;
         assert!(res.is_err(), "plan mode must block all tool execution");

--- a/crates/zeph-tools/src/adversarial_gate.rs
+++ b/crates/zeph-tools/src/adversarial_gate.rs
@@ -162,6 +162,8 @@ impl<T: ToolExecutor> AdversarialPolicyGateExecutor<T> {
             policy_match: None,
             correlation_id: None,
             vigil_risk: None,
+            execution_env: None,
+            resolved_cwd: None,
         };
         audit.log(&entry).await;
     }
@@ -327,6 +329,7 @@ mod tests {
             tool_id: tool_id.into(),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         }
     }
 

--- a/crates/zeph-tools/src/audit.rs
+++ b/crates/zeph-tools/src/audit.rs
@@ -188,6 +188,14 @@ pub struct AuditEntry {
     /// `None` when VIGIL did not fire (output was clean or tool was exempt).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub vigil_risk: Option<VigilRiskLevel>,
+    /// Name of the resolved execution environment (from `[[execution.environments]]`).
+    /// `None` when no named environment was selected for this invocation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub execution_env: Option<String>,
+    /// Canonical absolute working directory actually used for this shell invocation.
+    /// `None` for non-shell tools or legacy path without a resolved context.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolved_cwd: Option<String>,
 }
 
 /// Risk level assigned by the VIGIL pre-sanitizer gate to a flagged tool output.
@@ -420,6 +428,8 @@ mod tests {
             correlation_id: None,
             caller_id: None,
             vigil_risk: None,
+            execution_env: None,
+            resolved_cwd: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(json.contains("\"type\":\"success\""));
@@ -452,6 +462,8 @@ mod tests {
             correlation_id: None,
             caller_id: None,
             vigil_risk: None,
+            execution_env: None,
+            resolved_cwd: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(json.contains("\"type\":\"blocked\""));
@@ -483,6 +495,8 @@ mod tests {
             correlation_id: None,
             caller_id: None,
             vigil_risk: None,
+            execution_env: None,
+            resolved_cwd: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(json.contains("\"type\":\"error\""));
@@ -511,6 +525,8 @@ mod tests {
             correlation_id: None,
             caller_id: None,
             vigil_risk: None,
+            execution_env: None,
+            resolved_cwd: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(json.contains("\"type\":\"timeout\""));
@@ -545,6 +561,8 @@ mod tests {
             correlation_id: None,
             caller_id: None,
             vigil_risk: None,
+            execution_env: None,
+            resolved_cwd: None,
         };
         logger.log(&entry).await;
     }
@@ -580,6 +598,8 @@ mod tests {
             correlation_id: None,
             caller_id: None,
             vigil_risk: None,
+            execution_env: None,
+            resolved_cwd: None,
         };
         logger.log(&entry).await;
 
@@ -642,6 +662,8 @@ mod tests {
             correlation_id: None,
             caller_id: None,
             vigil_risk: None,
+            execution_env: None,
+            resolved_cwd: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(
@@ -674,6 +696,8 @@ mod tests {
             correlation_id: None,
             caller_id: None,
             vigil_risk: None,
+            execution_env: None,
+            resolved_cwd: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(
@@ -715,6 +739,8 @@ mod tests {
                 correlation_id: None,
                 caller_id: None,
                 vigil_risk: None,
+                execution_env: None,
+                resolved_cwd: None,
             };
             logger.log(&entry).await;
         }
@@ -746,6 +772,8 @@ mod tests {
             correlation_id: None,
             caller_id: None,
             vigil_risk: None,
+            execution_env: None,
+            resolved_cwd: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(
@@ -777,6 +805,8 @@ mod tests {
             correlation_id: None,
             caller_id: None,
             vigil_risk: None,
+            execution_env: None,
+            resolved_cwd: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(

--- a/crates/zeph-tools/src/composite.rs
+++ b/crates/zeph-tools/src/composite.rs
@@ -265,6 +265,7 @@ mod tests {
             tool_id: ToolName::new("read"),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
         let result = composite.execute_tool_call(&call).await.unwrap().unwrap();
         assert_eq!(result.summary, "file_handler");
@@ -277,6 +278,7 @@ mod tests {
             tool_id: ToolName::new("bash"),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
         let result = composite.execute_tool_call(&call).await.unwrap().unwrap();
         assert_eq!(result.summary, "shell_handler");
@@ -289,6 +291,7 @@ mod tests {
             tool_id: ToolName::new("unknown"),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
         let result = composite.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());

--- a/crates/zeph-tools/src/cwd.rs
+++ b/crates/zeph-tools/src/cwd.rs
@@ -103,6 +103,7 @@ mod tests {
             tool_id: ToolName::new(TOOL_NAME),
             params,
             caller_id: None,
+            context: None,
         }
     }
 
@@ -129,6 +130,7 @@ mod tests {
             tool_id: ToolName::new("other_tool"),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
         let result = executor.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());

--- a/crates/zeph-tools/src/diagnostics.rs
+++ b/crates/zeph-tools/src/diagnostics.rs
@@ -349,6 +349,7 @@ mod tests {
             tool_id: ToolName::new("diagnostics"),
             params: make_params(&[("path", serde_json::json!("/etc"))]),
             caller_id: None,
+            context: None,
         };
         let result = exec.execute_tool_call(&call).await;
         assert!(result.is_err());
@@ -361,6 +362,7 @@ mod tests {
             tool_id: ToolName::new("other"),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
         let result = exec.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());

--- a/crates/zeph-tools/src/execution_context.rs
+++ b/crates/zeph-tools/src/execution_context.rs
@@ -1,0 +1,294 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Per-turn execution environment for tool calls.
+//!
+//! An [`ExecutionContext`] is attached to a [`crate::ToolCall`] to specify the working
+//! directory and environment variable overrides for that specific call. When absent,
+//! `ShellExecutor` uses the process CWD and inherited process environment — identical to
+//! the behaviour before this module existed.
+//!
+//! # Trust model
+//!
+//! Contexts are either *untrusted* (the default, built via the public API) or *trusted*
+//! (only constructible inside `zeph-tools` / `zeph-config` via [`ExecutionContext::trusted_from_parts`]).
+//!
+//! Untrusted contexts have their env overrides re-filtered through the executor's
+//! `env_blocklist` after every merge step, so LLM-controlled callers cannot reintroduce
+//! a blocked variable.  Trusted contexts bypass that final filter — the operator who
+//! authored the TOML `[[execution.environments]]` table is the trust root.
+//!
+//! # Example
+//!
+//! ```rust
+//! use zeph_tools::ExecutionContext;
+//!
+//! let ctx = ExecutionContext::new()
+//!     .with_name("repo")
+//!     .with_cwd("/workspace/myproject")
+//!     .with_env("CARGO_TARGET_DIR", "/tmp/cargo-target");
+//!
+//! assert_eq!(ctx.name(), Some("repo"));
+//! assert!(ctx.cwd().is_some());
+//! assert_eq!(ctx.env_overrides().get("CARGO_TARGET_DIR").map(String::as_str), Some("/tmp/cargo-target"));
+//! assert!(!ctx.is_trusted());
+//! ```
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// Per-turn execution environment for a tool call.
+///
+/// When attached to a [`crate::ToolCall`], executors that honour it (currently
+/// [`crate::ShellExecutor`]) use these values instead of the process-level CWD and
+/// skill env.  `None` on `ToolCall::context` means "use the executor default" —
+/// identical to today's behaviour.
+///
+/// Cheaply clonable (single `Arc`) so the same context can be shared across
+/// parallel tool calls in one DAG layer without copying the underlying data.
+///
+/// # Precedence
+///
+/// When the `ShellExecutor` resolves the effective `(cwd, env)` for a call, the
+/// highest-priority source wins for each dimension:
+///
+/// | Source | CWD priority | Env priority |
+/// |---|---|---|
+/// | `ToolCall.context.cwd` / `env_overrides` | 1 (highest) | 1 (highest) |
+/// | Named registry entry (looked up by `name`) | 2 | 2 |
+/// | Skill env (`set_skill_env`) | — | 3 |
+/// | `default_env` registry entry (when set) | 3 | 4 |
+/// | Process CWD | 4 | — |
+/// | Inherited process env (minus blocklist) | — | 5 (lowest) |
+///
+/// Attaching a context for telemetry tagging via `env_overrides` never silently
+/// disables `default_env` — a more specific source simply overrides a less specific one.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ExecutionContext {
+    inner: Arc<ExecutionContextInner>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct ExecutionContextInner {
+    /// Logical name matching `[[execution.environments]]` in config. Used for audit/log
+    /// lines and to look up unspecified fields from the named registry entry.
+    name: Option<String>,
+    /// Working directory override. May be relative — `resolve_context` joins it with the
+    /// process CWD before sandbox validation.
+    cwd: Option<PathBuf>,
+    /// Extra environment variables to inject. `BTreeMap` for deterministic audit output
+    /// and stable hashing.
+    env_overrides: BTreeMap<String, String>,
+    /// `true` when built via [`ExecutionContext::trusted_from_parts`]. Trusted contexts
+    /// bypass the executor's final `env_blocklist` filter pass (step 6 of the env merge).
+    trusted: bool,
+}
+
+// ── Public untrusted builder API ──────────────────────────────────────────────
+
+impl ExecutionContext {
+    /// Construct an empty, untrusted context.
+    ///
+    /// Env overrides supplied via [`with_env`](Self::with_env) are subject to the
+    /// executor's blocklist filter before reaching the subprocess.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the logical environment name.
+    ///
+    /// The name is matched against `[[execution.environments]]` in the agent config.
+    /// An unknown name produces a [`crate::ToolError::Execution`] at dispatch time.
+    #[must_use]
+    pub fn with_name(self, name: impl Into<String>) -> Self {
+        let mut inner = Arc::unwrap_or_clone(self.inner);
+        inner.name = Some(name.into());
+        Self {
+            inner: Arc::new(inner),
+        }
+    }
+
+    /// Set the working directory override.
+    ///
+    /// Relative paths are joined with the process CWD inside `resolve_context` before
+    /// sandbox validation. Non-existent paths are a hard error — no fallback to the
+    /// process CWD.
+    #[must_use]
+    pub fn with_cwd(self, cwd: impl Into<PathBuf>) -> Self {
+        let mut inner = Arc::unwrap_or_clone(self.inner);
+        inner.cwd = Some(cwd.into());
+        Self {
+            inner: Arc::new(inner),
+        }
+    }
+
+    /// Add a single environment variable override.
+    ///
+    /// Overwrites any prior value for the same key.  Untrusted contexts have the final
+    /// env re-filtered through the executor's `env_blocklist` — blocklisted keys are
+    /// stripped regardless of their source.
+    #[must_use]
+    pub fn with_env(self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        let mut inner = Arc::unwrap_or_clone(self.inner);
+        inner.env_overrides.insert(key.into(), value.into());
+        Self {
+            inner: Arc::new(inner),
+        }
+    }
+
+    /// Add multiple environment variable overrides from an iterator.
+    ///
+    /// Equivalent to calling [`with_env`](Self::with_env) for each pair.
+    #[must_use]
+    pub fn with_envs<K, V, I>(self, iter: I) -> Self
+    where
+        K: Into<String>,
+        V: Into<String>,
+        I: IntoIterator<Item = (K, V)>,
+    {
+        let mut inner = Arc::unwrap_or_clone(self.inner);
+        for (k, v) in iter {
+            inner.env_overrides.insert(k.into(), v.into());
+        }
+        Self {
+            inner: Arc::new(inner),
+        }
+    }
+}
+
+// ── Accessors ─────────────────────────────────────────────────────────────────
+
+impl ExecutionContext {
+    /// The logical environment name, if set.
+    #[must_use]
+    pub fn name(&self) -> Option<&str> {
+        self.inner.name.as_deref()
+    }
+
+    /// The working directory override, if set.
+    #[must_use]
+    pub fn cwd(&self) -> Option<&Path> {
+        self.inner.cwd.as_deref()
+    }
+
+    /// The environment variable overrides.
+    #[must_use]
+    pub fn env_overrides(&self) -> &BTreeMap<String, String> {
+        &self.inner.env_overrides
+    }
+
+    /// Whether this context was built via the trusted constructor.
+    ///
+    /// Trusted contexts bypass the executor's final `env_blocklist` pass.
+    /// Only contexts built from operator-authored TOML (via `build_registry`) are trusted.
+    ///
+    /// # Trust downgrade
+    ///
+    /// When a call-site context wraps a trusted registry entry by name (via
+    /// [`ExecutionContext::with_name`]) but the call-site context itself is untrusted,
+    /// `resolve_context` downgrades the effective trust flag to `false`. This prevents
+    /// LLM-authored wrappers from escalating privilege by naming a trusted registry entry.
+    #[must_use]
+    pub fn is_trusted(&self) -> bool {
+        self.inner.trusted
+    }
+}
+
+// ── Trusted constructor (pub(crate) inside zeph-tools) ────────────────────────
+
+impl ExecutionContext {
+    /// Construct a trusted context from raw parts.
+    ///
+    /// Env overrides in trusted contexts bypass the executor's `env_blocklist` final pass.
+    ///
+    /// **Trust contract**: callers must ensure the values do not originate from LLM output,
+    /// plugin code, or any user-controllable source.  The only in-tree producers are:
+    /// - `ExecutionConfig::build_registry` (operator-authored TOML via `[[execution.environments]]`).
+    /// - Tests that explicitly opt in.
+    ///
+    /// Marked `pub(crate)` inside `zeph-tools`; re-exported as `pub(crate)` via
+    /// `zeph_tools::execution_context` so `zeph-config` can build registry entries without
+    /// exposing the constructor to plugins or external crates.
+    pub(crate) fn trusted_from_parts(
+        name: Option<String>,
+        cwd: Option<PathBuf>,
+        env_overrides: BTreeMap<String, String>,
+    ) -> Self {
+        Self {
+            inner: Arc::new(ExecutionContextInner {
+                name,
+                cwd,
+                env_overrides,
+                trusted: true,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_untrusted_and_empty() {
+        let ctx = ExecutionContext::new();
+        assert!(ctx.name().is_none());
+        assert!(ctx.cwd().is_none());
+        assert!(ctx.env_overrides().is_empty());
+        assert!(!ctx.is_trusted());
+    }
+
+    #[test]
+    fn builder_methods_chain() {
+        let ctx = ExecutionContext::new()
+            .with_name("test")
+            .with_cwd("/tmp")
+            .with_env("FOO", "bar");
+        assert_eq!(ctx.name(), Some("test"));
+        assert_eq!(ctx.cwd(), Some(Path::new("/tmp")));
+        assert_eq!(
+            ctx.env_overrides().get("FOO").map(String::as_str),
+            Some("bar")
+        );
+        assert!(!ctx.is_trusted());
+    }
+
+    #[test]
+    fn with_envs_adds_multiple() {
+        let ctx = ExecutionContext::new().with_envs([("A", "1"), ("B", "2")]);
+        assert_eq!(ctx.env_overrides().len(), 2);
+        assert_eq!(ctx.env_overrides()["A"], "1");
+        assert_eq!(ctx.env_overrides()["B"], "2");
+    }
+
+    #[test]
+    fn trusted_from_parts_is_trusted() {
+        let ctx = ExecutionContext::trusted_from_parts(
+            Some("ops".to_owned()),
+            Some(PathBuf::from("/workspace")),
+            [("SECRET_KEY".to_owned(), "val".to_owned())]
+                .into_iter()
+                .collect(),
+        );
+        assert!(ctx.is_trusted());
+        assert_eq!(ctx.name(), Some("ops"));
+    }
+
+    #[test]
+    fn clone_shares_arc() {
+        let ctx = ExecutionContext::new().with_name("shared");
+        let cloned = ctx.clone();
+        assert_eq!(ctx, cloned);
+        assert!(Arc::ptr_eq(&ctx.inner, &cloned.inner));
+    }
+
+    #[test]
+    fn with_env_overwrites_existing() {
+        let ctx = ExecutionContext::new()
+            .with_env("KEY", "first")
+            .with_env("KEY", "second");
+        assert_eq!(ctx.env_overrides()["KEY"], "second");
+    }
+}

--- a/crates/zeph-tools/src/executor.rs
+++ b/crates/zeph-tools/src/executor.rs
@@ -29,7 +29,7 @@ pub struct DiffData {
 /// # Example
 ///
 /// ```rust
-/// use zeph_tools::ToolCall;
+/// use zeph_tools::{ToolCall, ExecutionContext};
 /// use zeph_common::ToolName;
 ///
 /// let call = ToolCall {
@@ -40,6 +40,7 @@ pub struct DiffData {
 ///         m
 ///     },
 ///     caller_id: Some("user-42".to_owned()),
+///     context: Some(ExecutionContext::new().with_name("repo")),
 /// };
 /// assert_eq!(call.tool_id, "bash");
 /// ```
@@ -52,6 +53,9 @@ pub struct ToolCall {
     /// Opaque caller identifier propagated from the channel (user ID, session ID, etc.).
     /// `None` for system-initiated calls (scheduler, self-learning, internal).
     pub caller_id: Option<String>,
+    /// Per-turn execution environment. `None` means use the executor default (process CWD
+    /// and inherited env), which is identical to the behaviour before this field existed.
+    pub context: Option<crate::ExecutionContext>,
 }
 
 /// Cumulative filter statistics for a single tool execution.
@@ -289,6 +293,12 @@ pub enum ToolEvent {
         command: String,
         /// Active sandbox profile, if any. `None` when sandbox is disabled.
         sandbox_profile: Option<String>,
+        /// Canonical absolute working directory the command will run in.
+        /// `None` for executors that do not resolve a per-turn CWD.
+        resolved_cwd: Option<String>,
+        /// Name of the resolved execution environment (from `[[execution.environments]]`),
+        /// or `None` when no named environment was selected.
+        execution_env: Option<String>,
     },
     /// A chunk of streaming output was produced (e.g. from a long-running command).
     OutputChunk {
@@ -1171,6 +1181,7 @@ mod tests {
             tool_id: ToolName::new("anything"),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
         let result = exec.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());
@@ -1315,6 +1326,7 @@ mod tests {
             tool_id: ToolName::new("bash"),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
         let result = exec.execute_tool_call(&call).await.unwrap();
         assert!(result.is_some());

--- a/crates/zeph-tools/src/file.rs
+++ b/crates/zeph-tools/src/file.rs
@@ -1030,6 +1030,7 @@ mod tests {
             tool_id: ToolName::new("read"),
             params: make_params(&[("path", serde_json::json!(file.to_str().unwrap()))]),
             caller_id: None,
+            context: None,
         };
         let result = exec.execute_tool_call(&call).await.unwrap().unwrap();
         assert_eq!(result.tool_name, "read");

--- a/crates/zeph-tools/src/lib.rs
+++ b/crates/zeph-tools/src/lib.rs
@@ -66,6 +66,7 @@ pub mod cwd;
 pub mod diagnostics;
 pub mod domain_match;
 pub mod error_taxonomy;
+pub mod execution_context;
 pub mod executor;
 pub mod file;
 pub mod filter;
@@ -104,6 +105,7 @@ pub use error_taxonomy::{
     ErrorDomain, ToolErrorCategory, ToolErrorFeedback, ToolInvocationPhase, classify_http_status,
     classify_io_error,
 };
+pub use execution_context::ExecutionContext;
 pub use executor::{
     ClaimSource, DiffData, DynExecutor, ErasedToolExecutor, ErrorKind, FilterStats,
     MAX_TOOL_OUTPUT_CHARS, TOOL_EVENT_CHANNEL_CAP, ToolCall, ToolError, ToolEvent, ToolEventRx,

--- a/crates/zeph-tools/src/policy_gate.rs
+++ b/crates/zeph-tools/src/policy_gate.rs
@@ -105,6 +105,8 @@ impl<T: ToolExecutor> PolicyGateExecutor<T> {
                         policy_match: Some(trace.clone()),
                         correlation_id: None,
                         vigil_risk: None,
+                        execution_env: None,
+                        resolved_cwd: None,
                     };
                     audit.log(&entry).await;
                 }
@@ -137,6 +139,8 @@ impl<T: ToolExecutor> PolicyGateExecutor<T> {
                         policy_match: Some(trace.clone()),
                         correlation_id: None,
                         vigil_risk: None,
+                        execution_env: None,
+                        resolved_cwd: None,
                     };
                     audit.log(&entry).await;
                 }
@@ -203,6 +207,8 @@ impl<T: ToolExecutor> ToolExecutor for PolicyGateExecutor<T> {
                     policy_match: None,
                     correlation_id: None,
                     vigil_risk: None,
+                    execution_env: None,
+                    resolved_cwd: None,
                 };
                 audit.log(&entry).await;
             }
@@ -295,6 +301,7 @@ mod tests {
             tool_id: tool_id.into(),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         }
     }
 
@@ -305,6 +312,7 @@ mod tests {
             tool_id: tool_id.into(),
             params,
             caller_id: None,
+            context: None,
         }
     }
 

--- a/crates/zeph-tools/src/scrape.rs
+++ b/crates/zeph-tools/src/scrape.rs
@@ -477,6 +477,8 @@ impl WebScrapeExecutor {
                 policy_match: None,
                 correlation_id,
                 vigil_risk: None,
+                execution_env: None,
+                resolved_cwd: None,
             };
             logger.log(&entry).await;
         }
@@ -2140,6 +2142,7 @@ mod tests {
                 m
             },
             caller_id: None,
+            context: None,
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(matches!(result, Err(ToolError::Blocked { .. })));
@@ -2160,6 +2163,7 @@ mod tests {
                 m
             },
             caller_id: None,
+            context: None,
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(matches!(result, Err(ToolError::Blocked { .. })));
@@ -2180,6 +2184,7 @@ mod tests {
                 m
             },
             caller_id: None,
+            context: None,
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(matches!(result, Err(ToolError::Blocked { .. })));
@@ -2193,6 +2198,7 @@ mod tests {
             tool_id: ToolName::new("unknown_tool"),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(result.unwrap().is_none());
@@ -2421,6 +2427,7 @@ mod tests {
                 m
             },
             caller_id: None,
+            context: None,
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(matches!(result, Err(ToolError::Blocked { .. })));
@@ -2533,6 +2540,7 @@ mod tests {
                 m
             },
             caller_id: None,
+            context: None,
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(matches!(result, Err(ToolError::Blocked { .. })));
@@ -2562,6 +2570,7 @@ mod tests {
                 m
             },
             caller_id: None,
+            context: None,
         };
         // Must not panic even without an audit logger
         let result = executor.execute_tool_call(&call).await;

--- a/crates/zeph-tools/src/scrape.rs
+++ b/crates/zeph-tools/src/scrape.rs
@@ -146,6 +146,7 @@ impl ExtractMode {
 ///         m
 ///     },
 ///     caller_id: None,
+///     context: None,
 /// };
 /// let _ = executor.execute_tool_call(&call).await;
 /// # }

--- a/crates/zeph-tools/src/search_code.rs
+++ b/crates/zeph-tools/src/search_code.rs
@@ -686,6 +686,7 @@ mod tests {
             tool_id: "search_code".into(),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
         let err = exec.execute_tool_call(&call).await.unwrap_err();
         assert!(matches!(err, ToolError::InvalidParams { .. }));
@@ -704,6 +705,7 @@ mod tests {
                 .unwrap()
                 .clone(),
             caller_id: None,
+            context: None,
         };
         let out = exec.execute_tool_call(&call).await.unwrap().unwrap();
         assert!(out.summary.contains("retry_backoff_ms"));
@@ -724,6 +726,7 @@ mod tests {
                 .unwrap()
                 .clone(),
             caller_id: None,
+            context: None,
         };
         let out = exec.execute_tool_call(&call).await.unwrap().unwrap();
         assert!(out.summary.contains("grep fallback"));

--- a/crates/zeph-tools/src/shell/mod.rs
+++ b/crates/zeph-tools/src/shell/mod.rs
@@ -39,6 +39,7 @@ use zeph_common::ToolName;
 
 use crate::audit::{AuditEntry, AuditLogger, AuditResult, chrono_now};
 use crate::config::ShellConfig;
+use crate::execution_context::ExecutionContext;
 use crate::executor::{
     ClaimSource, FilterStats, ToolCall, ToolError, ToolEvent, ToolEventTx, ToolExecutor, ToolOutput,
 };
@@ -239,7 +240,6 @@ pub(crate) struct BashParams {
 pub struct ShellExecutor {
     timeout: Duration,
     policy: Arc<ArcSwap<ShellPolicy>>,
-    allowed_paths: Vec<PathBuf>,
     confirm_patterns: Vec<String>,
     env_blocklist: Vec<String>,
     audit_logger: Option<Arc<AuditLogger>>,
@@ -268,6 +268,33 @@ pub struct ShellExecutor {
     /// (bypasses the UI-facing [`ToolEventTx`] channel). `None` when the agent
     /// has not wired a background completion receiver.
     background_completion_tx: Option<tokio::sync::mpsc::Sender<BackgroundCompletion>>,
+    /// Named execution environment registry built from `[execution]` config.
+    /// Keys are case-sensitive environment names; values are trusted `ExecutionContext`s.
+    environments: Arc<HashMap<String, ExecutionContext>>,
+    /// Pre-canonicalized `allowed_paths`. Built once at construction to avoid TOCTOU
+    /// between the canonicalize call and the prefix check at `resolve_context` time.
+    allowed_paths_canonical: Vec<PathBuf>,
+    /// Optional default environment name (from `[execution] default_env`).
+    default_env: Option<String>,
+}
+
+/// Fully resolved execution context for a single shell invocation.
+///
+/// Produced by [`ShellExecutor::resolve_context`] and passed to the inner execute
+/// functions. The canonical `cwd` is what `cmd.current_dir` receives — identical to
+/// the path that was validated against `allowed_paths`.
+#[derive(Debug)]
+pub(crate) struct ResolvedContext {
+    /// Canonical absolute working directory (follows all symlinks).
+    pub(crate) cwd: PathBuf,
+    /// Final merged environment (post-blocklist filter).
+    pub(crate) env: HashMap<String, String>,
+    /// Resolved environment name, for logs and audit entries.
+    pub(crate) name: Option<String>,
+    /// Whether the context originated from a trusted source (operator TOML).
+    /// Reserved for future audit log enrichment.
+    #[allow(dead_code)]
+    pub(crate) trusted: bool,
 }
 
 impl ShellExecutor {
@@ -282,16 +309,19 @@ impl ShellExecutor {
             blocked_commands: compute_blocked_commands(config),
         }));
 
-        let allowed_paths = if config.allowed_paths.is_empty() {
+        let allowed_paths: Vec<PathBuf> = if config.allowed_paths.is_empty() {
             vec![std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))]
         } else {
             config.allowed_paths.iter().map(PathBuf::from).collect()
         };
+        let allowed_paths_canonical: Vec<PathBuf> = allowed_paths
+            .iter()
+            .map(|p| p.canonicalize().unwrap_or_else(|_| p.clone()))
+            .collect();
 
         Self {
             timeout: Duration::from_secs(config.timeout),
             policy,
-            allowed_paths,
             confirm_patterns: config.confirm_patterns.clone(),
             env_blocklist: config.env_blocklist.clone(),
             audit_logger: None,
@@ -313,6 +343,9 @@ impl ShellExecutor {
             background_timeout: Duration::from_secs(config.background_timeout_secs),
             shutting_down: Arc::new(AtomicBool::new(false)),
             background_completion_tx: None,
+            environments: Arc::new(HashMap::new()),
+            allowed_paths_canonical,
+            default_env: None,
         }
     }
 
@@ -325,6 +358,75 @@ impl ShellExecutor {
         self.sandbox = Some(sandbox);
         self.sandbox_policy = Some(policy);
         self
+    }
+
+    /// Build the environment registry from `[execution]` config and wire it in one step.
+    ///
+    /// Convenience wrapper for agent startup. Converts [`zeph_config::ExecutionConfig`]
+    /// entries into trusted [`ExecutionContext`] instances and passes them to
+    /// [`Self::with_environments`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error string when any registry entry's `cwd` cannot be canonicalized
+    /// or escapes `allowed_paths`.
+    pub fn with_execution_config(
+        self,
+        config: &zeph_config::ExecutionConfig,
+    ) -> Result<Self, String> {
+        let registry: HashMap<String, ExecutionContext> = config
+            .environments
+            .iter()
+            .map(|e| {
+                let ctx = ExecutionContext::trusted_from_parts(
+                    Some(e.name.clone()),
+                    Some(std::path::PathBuf::from(&e.cwd)),
+                    e.env.clone(),
+                );
+                (e.name.clone(), ctx)
+            })
+            .collect();
+        self.with_environments(registry, config.default_env.clone())
+    }
+
+    /// Wire the named execution environment registry from `[execution]` config.
+    ///
+    /// Builds trusted [`ExecutionContext`] instances from the operator-authored TOML
+    /// entries and canonicalizes their `cwd` paths at construction time.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error string (surfaced at agent startup) when a registry entry's
+    /// `cwd` path does not exist, cannot be canonicalized, or escapes `allowed_paths`.
+    pub fn with_environments(
+        mut self,
+        environments: HashMap<String, ExecutionContext>,
+        default_env: Option<String>,
+    ) -> Result<Self, String> {
+        // Validate that all registered cwds exist and are under allowed_paths.
+        for (name, ctx) in &environments {
+            if let Some(cwd) = ctx.cwd() {
+                let canonical = cwd.canonicalize().map_err(|e| {
+                    format!(
+                        "execution environment '{name}': cwd '{}' cannot be canonicalized: {e}",
+                        cwd.display()
+                    )
+                })?;
+                if !self
+                    .allowed_paths_canonical
+                    .iter()
+                    .any(|p| canonical.starts_with(p))
+                {
+                    return Err(format!(
+                        "execution environment '{name}': cwd '{}' is outside allowed_paths",
+                        cwd.display()
+                    ));
+                }
+            }
+        }
+        self.environments = Arc::new(environments);
+        self.default_env = default_env;
+        Ok(self)
     }
 
     /// Set environment variables to inject when executing the active skill's bash blocks.
@@ -445,6 +547,10 @@ impl ShellExecutor {
             return Ok(None);
         }
 
+        // Resolve with no call-site context so legacy path gets the same CWD/env
+        // treatment as the structured-tool-call path (default_env, skill_env, blocklist).
+        let resolved = self.resolve_context(None)?;
+
         let mut outputs = Vec::with_capacity(blocks.len());
         let mut cumulative_filter_stats: Option<FilterStats> = None;
         let mut last_envelope: Option<ShellOutputEnvelope> = None;
@@ -453,7 +559,7 @@ impl ShellExecutor {
 
         for block in &blocks {
             let (output_line, per_block_stats, envelope) =
-                self.execute_block(block, skip_confirm).await?;
+                self.execute_block(block, skip_confirm, &resolved).await?;
             if let Some(fs) = per_block_stats {
                 let stats = cumulative_filter_stats.get_or_insert_with(FilterStats::default);
                 stats.raw_chars += fs.raw_chars;
@@ -499,9 +605,10 @@ impl ShellExecutor {
         &self,
         block: &str,
         skip_confirm: bool,
+        resolved: &ResolvedContext,
     ) -> Result<(String, Option<FilterStats>, ShellOutputEnvelope), ToolError> {
         self.check_permissions(block, skip_confirm).await?;
-        self.validate_sandbox(block)?;
+        self.validate_sandbox_with_cwd(block, &resolved.cwd)?;
 
         let (snapshot, snapshot_warning) = self.capture_snapshot_for(block)?;
 
@@ -515,24 +622,23 @@ impl ShellExecutor {
                 tool_name: ToolName::new("bash"),
                 command: block.to_owned(),
                 sandbox_profile,
+                resolved_cwd: Some(resolved.cwd.display().to_string()),
+                execution_env: resolved.name.clone(),
             });
         }
 
         let start = Instant::now();
-        let skill_env_snapshot: Option<std::collections::HashMap<String, String>> =
-            self.skill_env.read().clone();
         let sandbox_pair = self
             .sandbox
             .as_ref()
             .zip(self.sandbox_policy.as_ref())
             .map(|(sb, pol)| (sb.as_ref(), pol));
-        let (mut envelope, out) = execute_bash(
+        let (mut envelope, out) = execute_bash_with_context(
             block,
             self.timeout,
             self.tool_event_tx.as_ref(),
             self.cancel_token.as_ref(),
-            skill_env_snapshot.as_ref(),
-            &self.env_blocklist,
+            resolved,
             sandbox_pair,
         )
         .await;
@@ -582,13 +688,14 @@ impl ShellExecutor {
         } else {
             AuditResult::Success
         };
-        self.log_audit(
+        self.log_audit_with_context(
             block,
             audit_result,
             duration_ms,
             None,
             Some(exit_code),
             envelope.truncated,
+            resolved,
         )
         .await;
 
@@ -597,6 +704,126 @@ impl ShellExecutor {
             None => format!("$ {block}\n{filtered}"),
         };
         Ok((output_line, per_block_stats, envelope))
+    }
+
+    /// Execute `command` using a pre-resolved [`ResolvedContext`] (from `resolve_context`).
+    ///
+    /// This is the structured-tool-call path — it uses the resolved CWD and env directly
+    /// instead of re-reading process state on every call.
+    #[tracing::instrument(name = "tool.shell.execute_block", skip(self, resolved), level = "info",
+        fields(cwd = %resolved.cwd.display(), env_name = resolved.name.as_deref().unwrap_or("")))]
+    async fn execute_block_with_context(
+        &self,
+        command: &str,
+        skip_confirm: bool,
+        resolved: &ResolvedContext,
+    ) -> Result<Option<ToolOutput>, ToolError> {
+        self.check_permissions(command, skip_confirm).await?;
+        self.validate_sandbox_with_cwd(command, &resolved.cwd)?;
+
+        let (snapshot, snapshot_warning) = self.capture_snapshot_for(command)?;
+
+        if let Some(ref tx) = self.tool_event_tx {
+            let sandbox_profile = self
+                .sandbox_policy
+                .as_ref()
+                .map(|p| format!("{:?}", p.profile));
+            let _ = tx.try_send(ToolEvent::Started {
+                tool_name: ToolName::new("bash"),
+                command: command.to_owned(),
+                sandbox_profile,
+                resolved_cwd: Some(resolved.cwd.display().to_string()),
+                execution_env: resolved.name.clone(),
+            });
+        }
+
+        let start = Instant::now();
+        let sandbox_pair = self
+            .sandbox
+            .as_ref()
+            .zip(self.sandbox_policy.as_ref())
+            .map(|(sb, pol)| (sb.as_ref(), pol));
+        let (mut envelope, out) = execute_bash_with_context(
+            command,
+            self.timeout,
+            self.tool_event_tx.as_ref(),
+            self.cancel_token.as_ref(),
+            resolved,
+            sandbox_pair,
+        )
+        .await;
+        let exit_code = envelope.exit_code;
+        if exit_code == 130
+            && self
+                .cancel_token
+                .as_ref()
+                .is_some_and(CancellationToken::is_cancelled)
+        {
+            return Err(ToolError::Cancelled);
+        }
+        #[allow(clippy::cast_possible_truncation)]
+        let duration_ms = start.elapsed().as_millis() as u64;
+
+        if let Some(snap) = snapshot {
+            self.maybe_rollback(snap, command, exit_code, duration_ms)
+                .await;
+        }
+
+        if let Some(err) = self
+            .classify_and_audit(command, &out, exit_code, duration_ms)
+            .await
+        {
+            self.emit_completed(command, &out, false, None, None).await;
+            return Err(err);
+        }
+
+        let (filtered, per_block_stats) = self.apply_output_filter(command, &out, exit_code);
+
+        self.emit_completed(
+            command,
+            &out,
+            !out.contains("[error]"),
+            per_block_stats.clone(),
+            None,
+        )
+        .await;
+
+        envelope.truncated = filtered.len() < out.len();
+
+        let audit_result = if out.contains("[error]") || out.contains("[stderr]") {
+            AuditResult::Error {
+                message: out.clone(),
+            }
+        } else {
+            AuditResult::Success
+        };
+        self.log_audit_with_context(
+            command,
+            audit_result,
+            duration_ms,
+            None,
+            Some(exit_code),
+            envelope.truncated,
+            resolved,
+        )
+        .await;
+
+        let output_line = match snapshot_warning {
+            Some(warn) => format!("{warn}\n$ {command}\n{filtered}"),
+            None => format!("$ {command}\n{filtered}"),
+        };
+        Ok(Some(ToolOutput {
+            tool_name: ToolName::new("bash"),
+            summary: output_line,
+            blocks_executed: 1,
+            filter_stats: per_block_stats,
+            diff: None,
+            streamed: false,
+            terminal_id: None,
+            locations: None,
+            raw_response: None,
+            claim_source: Some(ClaimSource::Shell),
+        }))
     }
 
     fn capture_snapshot_for(
@@ -835,12 +1062,152 @@ impl ShellExecutor {
         Ok(())
     }
 
-    fn validate_sandbox(&self, code: &str) -> Result<(), ToolError> {
-        let cwd = std::env::current_dir().unwrap_or_default();
+    /// Resolve the effective `(cwd, env, name, trusted)` for a single tool call.
+    ///
+    /// Implements the 6-step merge defined in the per-turn env spec:
+    /// 1. Base = inherited process env.
+    /// 2. Filter `env_blocklist`.
+    /// 3. Apply `skill_env` overrides.
+    /// 4. If `ctx` or `default_env` points to a named registry entry, apply its overrides.
+    /// 5. Apply call-site `ctx.env_overrides`.
+    /// 6. If context is untrusted, re-apply `env_blocklist` to strip any re-introduced keys.
+    ///
+    /// CWD precedence (highest wins): call-site `ctx.cwd` → named registry `cwd` → `default_env`
+    /// registry `cwd` → `std::env::current_dir()`.
+    #[tracing::instrument(name = "tools.shell.resolve_context", skip(self, ctx), level = "info")]
+    pub(crate) fn resolve_context(
+        &self,
+        ctx: Option<&ExecutionContext>,
+    ) -> Result<ResolvedContext, ToolError> {
+        // Step 1: base env = process env.
+        let mut env: HashMap<String, String> = std::env::vars().collect();
 
+        // Step 2: filter env_blocklist (prefix match, consistent with build_bash_command).
+        env.retain(|k, _| {
+            !self
+                .env_blocklist
+                .iter()
+                .any(|prefix| k.starts_with(prefix.as_str()))
+        });
+
+        // Step 3: apply skill_env.
+        if let Some(skill) = self.skill_env.read().as_ref() {
+            for (k, v) in skill {
+                env.insert(k.clone(), v.clone());
+            }
+        }
+
+        // Determine the resolved name, cwd_override, and trusted flag.
+        let mut resolved_name: Option<String> = None;
+        let mut cwd_override: Option<PathBuf> = None;
+        let mut trusted = false;
+
+        // Resolve via default_env registry entry (lowest priority named layer).
+        if let Some(default_name) = &self.default_env
+            && let Some(default_ctx) = self.environments.get(default_name.as_str())
+        {
+            resolved_name.get_or_insert_with(|| default_name.clone());
+            if cwd_override.is_none() {
+                cwd_override = default_ctx.cwd().map(ToOwned::to_owned);
+            }
+            trusted = default_ctx.is_trusted();
+            for (k, v) in default_ctx.env_overrides() {
+                env.insert(k.clone(), v.clone());
+            }
+        }
+
+        // Step 4: if call-site ctx names a registry entry, apply its overrides.
+        if let Some(ctx) = ctx {
+            if let Some(name) = ctx.name() {
+                if let Some(reg_ctx) = self.environments.get(name) {
+                    resolved_name = Some(name.to_owned());
+                    if let Some(cwd) = reg_ctx.cwd() {
+                        cwd_override = Some(cwd.to_owned());
+                    }
+                    trusted = reg_ctx.is_trusted();
+                    for (k, v) in reg_ctx.env_overrides() {
+                        env.insert(k.clone(), v.clone());
+                    }
+                } else {
+                    return Err(ToolError::Execution(std::io::Error::other(format!(
+                        "unknown execution environment '{name}'"
+                    ))));
+                }
+            }
+
+            // Step 5: apply call-site cwd and env overrides (highest priority).
+            if let Some(cwd) = ctx.cwd() {
+                cwd_override = Some(cwd.to_owned());
+            }
+            if !ctx.is_trusted() {
+                trusted = false;
+            }
+            for (k, v) in ctx.env_overrides() {
+                env.insert(k.clone(), v.clone());
+            }
+        }
+
+        // Step 6: re-apply blocklist for untrusted contexts (prefix match).
+        if !trusted {
+            env.retain(|k, _| {
+                !self
+                    .env_blocklist
+                    .iter()
+                    .any(|prefix| k.starts_with(prefix.as_str()))
+            });
+        }
+
+        // Resolve final CWD: override (canonicalized) or process CWD.
+        let cwd = if let Some(raw) = cwd_override {
+            // Make relative paths absolute before canonicalize so they resolve
+            // correctly regardless of the process working directory.
+            let raw = if raw.is_absolute() {
+                raw
+            } else {
+                std::env::current_dir()
+                    .unwrap_or_else(|_| PathBuf::from("."))
+                    .join(raw)
+            };
+            let canonical = raw
+                .canonicalize()
+                .map_err(|_| ToolError::SandboxViolation {
+                    path: raw.display().to_string(),
+                })?;
+            // Validate against allowed_paths.
+            if !self
+                .allowed_paths_canonical
+                .iter()
+                .any(|p| canonical.starts_with(p))
+            {
+                return Err(ToolError::SandboxViolation {
+                    path: canonical.display().to_string(),
+                });
+            }
+            canonical
+        } else {
+            std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+        };
+
+        Ok(ResolvedContext {
+            cwd,
+            env,
+            name: resolved_name,
+            trusted,
+        })
+    }
+
+    fn validate_sandbox_with_cwd(
+        &self,
+        code: &str,
+        cwd: &std::path::Path,
+    ) -> Result<(), ToolError> {
         for token in extract_paths(code) {
             if has_traversal(&token) {
                 return Err(ToolError::SandboxViolation { path: token });
+            }
+
+            if self.allowed_paths_canonical.is_empty() {
+                continue;
             }
 
             let path = if token.starts_with('/') {
@@ -848,12 +1215,34 @@ impl ShellExecutor {
             } else {
                 cwd.join(&token)
             };
-            let canonical = path
-                .canonicalize()
-                .or_else(|_| std::path::absolute(&path))
-                .unwrap_or(path);
+            // For existing paths, canonicalize to resolve symlinks before the prefix
+            // check — `std::path::absolute` does NOT collapse `..` or follow symlinks.
+            // For non-existent paths, canonicalize the nearest existing ancestor and
+            // reattach the suffix: this rejects `allowed/../../etc/shadow` while
+            // allowing references to not-yet-created files within allowed dirs.
+            let canonical = if let Ok(c) = path.canonicalize() {
+                c
+            } else {
+                // Collect path components so we can walk up from the full path.
+                let components: Vec<_> = path.components().collect();
+                let mut base_len = components.len();
+                let canonical_base = loop {
+                    if base_len == 0 {
+                        break PathBuf::new();
+                    }
+                    let candidate: PathBuf = components[..base_len].iter().collect();
+                    if let Ok(c) = candidate.canonicalize() {
+                        break c;
+                    }
+                    base_len -= 1;
+                };
+                // Reattach the non-existent suffix (components after base_len).
+                components[base_len..]
+                    .iter()
+                    .fold(canonical_base, |acc, c| acc.join(c))
+            };
             if !self
-                .allowed_paths
+                .allowed_paths_canonical
                 .iter()
                 .any(|allowed| canonical.starts_with(allowed))
             {
@@ -863,6 +1252,11 @@ impl ShellExecutor {
             }
         }
         Ok(())
+    }
+
+    fn validate_sandbox(&self, code: &str) -> Result<(), ToolError> {
+        let cwd = std::env::current_dir().unwrap_or_default();
+        self.validate_sandbox_with_cwd(code, &cwd)
     }
 
     /// Scan `code` for commands that match the configured blocklist.
@@ -979,6 +1373,57 @@ impl ShellExecutor {
                 policy_match: None,
                 correlation_id: None,
                 vigil_risk: None,
+                execution_env: None,
+                resolved_cwd: None,
+            };
+            logger.log(&entry).await;
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn log_audit_with_context(
+        &self,
+        command: &str,
+        result: AuditResult,
+        duration_ms: u64,
+        error: Option<&ToolError>,
+        exit_code: Option<i32>,
+        truncated: bool,
+        resolved: &ResolvedContext,
+    ) {
+        if let Some(ref logger) = self.audit_logger {
+            let (error_category, error_domain, error_phase) =
+                error.map_or((None, None, None), |e| {
+                    let cat = e.category();
+                    (
+                        Some(cat.label().to_owned()),
+                        Some(cat.domain().label().to_owned()),
+                        Some(cat.phase().label().to_owned()),
+                    )
+                });
+            let entry = AuditEntry {
+                timestamp: chrono_now(),
+                tool: "shell".into(),
+                command: command.into(),
+                result,
+                duration_ms,
+                error_category,
+                error_domain,
+                error_phase,
+                claim_source: Some(ClaimSource::Shell),
+                mcp_server_id: None,
+                injection_flagged: false,
+                embedding_anomalous: false,
+                cross_boundary_mcp_to_acp: false,
+                adversarial_policy_decision: None,
+                exit_code,
+                truncated,
+                caller_id: None,
+                policy_match: None,
+                correlation_id: None,
+                vigil_risk: None,
+                execution_env: resolved.name.clone(),
+                resolved_cwd: Some(resolved.cwd.display().to_string()),
             };
             logger.log(&entry).await;
         }
@@ -1019,6 +1464,8 @@ impl ToolExecutor for ShellExecutor {
         }]
     }
 
+    #[tracing::instrument(name = "tool.shell.execute_tool_call", skip(self, call), level = "info",
+        fields(tool_id = %call.tool_id, env = call.context.as_ref().and_then(|c| c.name()).unwrap_or("")))]
     async fn execute_tool_call(&self, call: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
         if call.tool_id != "bash" {
             return Ok(None);
@@ -1029,8 +1476,14 @@ impl ToolExecutor for ShellExecutor {
         }
         let command = &params.command;
 
+        // Resolve per-turn execution context — done before the background branch so that
+        // background tasks also receive the correct env and CWD (spec §6).
+        let resolved = self.resolve_context(call.context.as_ref())?;
+
         if params.background {
-            let run_id = self.spawn_background(command).await?;
+            let run_id = self
+                .spawn_background_with_context(command, &resolved)
+                .await?;
             let id_short = &run_id.to_string()[..8];
             return Ok(Some(ToolOutput {
                 tool_name: ToolName::new("bash"),
@@ -1050,9 +1503,8 @@ impl ToolExecutor for ShellExecutor {
             }));
         }
 
-        // Wrap as a fenced block so execute_inner can extract and run it.
-        let synthetic = format!("```bash\n{command}\n```");
-        self.execute_inner(&synthetic, false).await
+        self.execute_block_with_context(command, false, &resolved)
+            .await
     }
 
     fn set_skill_env(&self, env: Option<std::collections::HashMap<String, String>>) {
@@ -1131,6 +1583,75 @@ impl ShellExecutor {
             background_completion_tx,
             skill_env_snapshot,
             env_blocklist,
+        ));
+
+        Ok(run_id)
+    }
+
+    /// Spawn `command` as a background process using an already-resolved [`ResolvedContext`].
+    ///
+    /// Like [`spawn_background`](Self::spawn_background) but uses the pre-resolved env and CWD
+    /// instead of reading `skill_env`/process-env at spawn time.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`spawn_background`](Self::spawn_background).
+    async fn spawn_background_with_context(
+        &self,
+        command: &str,
+        resolved: &ResolvedContext,
+    ) -> Result<RunId, ToolError> {
+        use std::sync::atomic::Ordering;
+
+        if self.shutting_down.load(Ordering::Acquire) {
+            return Err(ToolError::Blocked {
+                command: command.to_owned(),
+            });
+        }
+
+        self.check_permissions(command, false).await?;
+        self.validate_sandbox_with_cwd(command, &resolved.cwd)?;
+
+        let run_id = RunId::new();
+        let mut runs = self.background_runs.lock();
+        if runs.len() >= self.max_background_runs {
+            return Err(ToolError::Blocked {
+                command: format!(
+                    "background run cap reached (max_background_runs={})",
+                    self.max_background_runs
+                ),
+            });
+        }
+        let abort = CancellationToken::new();
+        runs.insert(
+            run_id,
+            BackgroundHandle {
+                command: command.to_owned(),
+                started_at: std::time::Instant::now(),
+                abort: abort.clone(),
+                child_pid: None,
+            },
+        );
+        drop(runs);
+
+        let tool_event_tx = self.tool_event_tx.clone();
+        let background_completion_tx = self.background_completion_tx.clone();
+        let background_runs = Arc::clone(&self.background_runs);
+        let timeout = self.background_timeout;
+        let env = resolved.env.clone();
+        let cwd = resolved.cwd.clone();
+        let command_owned = command.to_owned();
+
+        tokio::spawn(run_background_task_with_env(
+            run_id,
+            command_owned,
+            timeout,
+            abort,
+            background_runs,
+            tool_event_tx,
+            background_completion_tx,
+            env,
+            cwd,
         ));
 
         Ok(run_id)
@@ -1331,6 +1852,137 @@ async fn run_background_task(
     }
 
     tracing::debug!(run_id = %run_id, exit_code, elapsed_ms, "background shell run completed");
+}
+
+/// Like [`run_background_task`] but uses a pre-resolved `env` and `cwd` from
+/// `resolve_context` instead of reading `skill_env`/process-env at spawn time.
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+async fn run_background_task_with_env(
+    run_id: RunId,
+    command: String,
+    timeout: Duration,
+    abort: CancellationToken,
+    background_runs: Arc<Mutex<HashMap<RunId, BackgroundHandle>>>,
+    tool_event_tx: Option<ToolEventTx>,
+    background_completion_tx: Option<tokio::sync::mpsc::Sender<BackgroundCompletion>>,
+    env: HashMap<String, String>,
+    cwd: PathBuf,
+) {
+    use std::process::Stdio;
+
+    let started_at = std::time::Instant::now();
+
+    let mut cmd = build_bash_command_with_context(&command, &env, &cwd);
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(ref e) => {
+            let (_, out) = spawn_error_envelope(e);
+            background_runs.lock().remove(&run_id);
+            emit_completed(tool_event_tx.as_ref(), &command, out.clone(), false, run_id).await;
+            if let Some(ref tx) = background_completion_tx {
+                let _ = tx
+                    .send(BackgroundCompletion {
+                        run_id,
+                        exit_code: 1,
+                        output: out,
+                        success: false,
+                        elapsed_ms: 0,
+                        command,
+                    })
+                    .await;
+            }
+            return;
+        }
+    };
+
+    if let Some(pid) = child.id()
+        && let Some(handle) = background_runs.lock().get_mut(&run_id)
+    {
+        handle.child_pid = Some(pid);
+    }
+
+    let stdout = child.stdout.take().expect("stdout piped");
+    let stderr = child.stderr.take().expect("stderr piped");
+    let mut line_rx = spawn_output_readers(stdout, stderr);
+
+    let mut combined = String::new();
+    let mut stdout_buf = String::new();
+    let mut stderr_buf = String::new();
+    let deadline = tokio::time::Instant::now() + timeout;
+    let timeout_secs = timeout.as_secs();
+
+    let (_, out) = match run_bash_stream(
+        &command,
+        deadline,
+        Some(&abort),
+        tool_event_tx.as_ref(),
+        &mut line_rx,
+        &mut combined,
+        &mut stdout_buf,
+        &mut stderr_buf,
+        &mut child,
+    )
+    .await
+    {
+        BashLoopOutcome::TimedOut => (
+            ShellOutputEnvelope {
+                stdout: stdout_buf,
+                stderr: format!("{stderr_buf}command timed out after {timeout_secs}s"),
+                exit_code: 1,
+                truncated: false,
+            },
+            format!("[error] command timed out after {timeout_secs}s"),
+        ),
+        BashLoopOutcome::Cancelled => (
+            ShellOutputEnvelope {
+                stdout: stdout_buf,
+                stderr: stderr_buf,
+                exit_code: 130,
+                truncated: false,
+            },
+            "[cancelled] operation aborted".to_string(),
+        ),
+        BashLoopOutcome::StreamClosed => {
+            finalize_envelope(&mut child, combined, stdout_buf, stderr_buf).await
+        }
+    };
+
+    #[allow(clippy::cast_possible_truncation)]
+    let elapsed_ms = started_at.elapsed().as_millis() as u64;
+    let success = !out.contains("[error]");
+    let exit_code = i32::from(!success);
+    let truncated = crate::executor::truncate_tool_output_at(&out, 4096);
+
+    background_runs.lock().remove(&run_id);
+    emit_completed(
+        tool_event_tx.as_ref(),
+        &command,
+        truncated.clone(),
+        success,
+        run_id,
+    )
+    .await;
+
+    if let Some(ref tx) = background_completion_tx {
+        let completion = BackgroundCompletion {
+            run_id,
+            exit_code,
+            output: truncated,
+            success,
+            elapsed_ms,
+            command,
+        };
+        if tx.send(completion).await.is_err() {
+            tracing::warn!(
+                run_id = %run_id,
+                "background completion channel closed; agent may have shut down"
+            );
+        }
+    }
+
+    tracing::debug!(run_id = %run_id, exit_code, elapsed_ms, "background shell run (with context) completed");
 }
 
 /// Emit a `ToolEvent::Completed` to `tool_event_tx` if it is set.
@@ -1773,6 +2425,8 @@ pub struct ShellOutputEnvelope {
     pub truncated: bool,
 }
 
+// Used only in cfg(test) blocks; dead_code analysis does not see test imports.
+#[allow(dead_code)]
 async fn execute_bash(
     code: &str,
     timeout: Duration,
@@ -1866,6 +2520,100 @@ fn build_bash_command(
         cmd.envs(env);
     }
     cmd
+}
+
+/// Build a `Command` using a pre-resolved env map and explicit cwd.
+///
+/// Clears the process env and applies only `resolved_env` — no blocklist re-apply needed
+/// because the caller (`resolve_context`) has already done that.
+fn build_bash_command_with_context(
+    code: &str,
+    resolved_env: &HashMap<String, String>,
+    cwd: &std::path::Path,
+) -> Command {
+    let mut cmd = Command::new("bash");
+    cmd.arg("-c").arg(code);
+    cmd.env_clear();
+    cmd.envs(resolved_env);
+    cmd.current_dir(cwd);
+    cmd
+}
+
+/// Execute `code` using a pre-resolved [`ResolvedContext`].
+///
+/// Unlike [`execute_bash`], this function receives the *final merged env* from
+/// `resolve_context` and sets `current_dir` to the resolved CWD.
+async fn execute_bash_with_context(
+    code: &str,
+    timeout: Duration,
+    event_tx: Option<&ToolEventTx>,
+    cancel_token: Option<&CancellationToken>,
+    resolved: &ResolvedContext,
+    sandbox: Option<(&dyn Sandbox, &SandboxPolicy)>,
+) -> (ShellOutputEnvelope, String) {
+    use std::process::Stdio;
+
+    let timeout_secs = timeout.as_secs();
+    let mut cmd = build_bash_command_with_context(code, &resolved.env, &resolved.cwd);
+
+    if let Err(envelope_err) = apply_sandbox(&mut cmd, sandbox) {
+        return envelope_err;
+    }
+
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(ref e) => return spawn_error_envelope(e),
+    };
+
+    let stdout = child.stdout.take().expect("stdout piped");
+    let stderr = child.stderr.take().expect("stderr piped");
+    let mut line_rx = spawn_output_readers(stdout, stderr);
+
+    let mut combined = String::new();
+    let mut stdout_buf = String::new();
+    let mut stderr_buf = String::new();
+    let deadline = tokio::time::Instant::now() + timeout;
+
+    match run_bash_stream(
+        code,
+        deadline,
+        cancel_token,
+        event_tx,
+        &mut line_rx,
+        &mut combined,
+        &mut stdout_buf,
+        &mut stderr_buf,
+        &mut child,
+    )
+    .await
+    {
+        BashLoopOutcome::TimedOut => {
+            let msg = format!("[error] command timed out after {timeout_secs}s");
+            (
+                ShellOutputEnvelope {
+                    stdout: stdout_buf,
+                    stderr: format!("{stderr_buf}command timed out after {timeout_secs}s"),
+                    exit_code: 1,
+                    truncated: false,
+                },
+                msg,
+            )
+        }
+        BashLoopOutcome::Cancelled => (
+            ShellOutputEnvelope {
+                stdout: stdout_buf,
+                stderr: format!("{stderr_buf}operation aborted"),
+                exit_code: 130,
+                truncated: false,
+            },
+            "[cancelled] operation aborted".to_string(),
+        ),
+        BashLoopOutcome::StreamClosed => {
+            finalize_envelope(&mut child, combined, stdout_buf, stderr_buf).await
+        }
+    }
 }
 
 fn apply_sandbox(

--- a/crates/zeph-tools/src/shell/tests.rs
+++ b/crates/zeph-tools/src/shell/tests.rs
@@ -1223,6 +1223,7 @@ async fn execute_tool_call_valid_command() {
             .into_iter()
             .collect(),
         caller_id: None,
+        context: None,
     };
     let result = executor.execute_tool_call(&call).await.unwrap().unwrap();
     assert!(result.summary.contains("hi"));
@@ -1235,6 +1236,7 @@ async fn execute_tool_call_missing_command_returns_invalid_params() {
         tool_id: ToolName::new("bash"),
         params: serde_json::Map::new(),
         caller_id: None,
+        context: None,
     };
     let result = executor.execute_tool_call(&call).await;
     assert!(matches!(result, Err(ToolError::InvalidParams { .. })));
@@ -1249,6 +1251,7 @@ async fn execute_tool_call_empty_command_returns_none() {
             .into_iter()
             .collect(),
         caller_id: None,
+        context: None,
     };
     let result = executor.execute_tool_call(&call).await.unwrap();
     assert!(result.is_none());
@@ -2544,6 +2547,7 @@ async fn execute_tool_call_with_background_true() {
         .into_iter()
         .collect(),
         caller_id: None,
+        context: None,
     };
     let result = executor.execute_tool_call(&call).await.unwrap().unwrap();
     assert!(
@@ -2695,4 +2699,439 @@ async fn background_runs_snapshot_returns_active_run() {
     assert!(!row.run_id.is_empty(), "snapshot run_id must be non-empty");
 
     executor.shutdown().await;
+}
+
+// ============================================================
+// §13 — resolve_context: CWD / blocklist / trust tests
+// ============================================================
+
+mod resolve_context {
+    use std::collections::{BTreeMap, HashMap};
+
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::ExecutionContext;
+    use crate::executor::ToolCall;
+
+    /// Build a `ShellExecutor` whose only `allowed_path` is `dir`, so sandbox checks
+    /// are deterministic. `env_blocklist` blocks `"SECRET_"`.
+    fn executor_for_dir(dir: &TempDir) -> ShellExecutor {
+        let path = dir.path().to_string_lossy().into_owned();
+        ShellExecutor::new(&ShellConfig {
+            allowed_paths: vec![path],
+            env_blocklist: vec!["SECRET_".to_owned()],
+            ..default_config()
+        })
+    }
+
+    // --- CWD resolution ---
+
+    #[test]
+    fn no_context_uses_process_cwd() {
+        let dir = tempfile::tempdir().unwrap();
+        let executor = executor_for_dir(&dir);
+        let resolved = executor.resolve_context(None).unwrap();
+        assert_eq!(resolved.cwd, std::env::current_dir().unwrap());
+    }
+
+    #[test]
+    fn context_with_cwd_overrides_process_cwd() {
+        let dir = tempfile::tempdir().unwrap();
+        let executor = executor_for_dir(&dir);
+        let canonical = dir.path().canonicalize().unwrap();
+        let ctx = ExecutionContext::new().with_cwd(canonical.clone());
+        let resolved = executor.resolve_context(Some(&ctx)).unwrap();
+        assert_eq!(resolved.cwd, canonical);
+    }
+
+    #[test]
+    fn nonexistent_cwd_is_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let executor = executor_for_dir(&dir);
+        let ctx = ExecutionContext::new().with_cwd("/this/path/does/not/exist/at/all");
+        let result = executor.resolve_context(Some(&ctx));
+        assert!(
+            result.is_err(),
+            "non-existent cwd must return Err, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn cwd_outside_allowed_paths_is_sandbox_violation() {
+        let allowed = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let executor = executor_for_dir(&allowed);
+        let outside_canonical = outside.path().canonicalize().unwrap();
+        let ctx = ExecutionContext::new().with_cwd(outside_canonical);
+        let result = executor.resolve_context(Some(&ctx));
+        assert!(
+            matches!(
+                result,
+                Err(crate::executor::ToolError::SandboxViolation { .. })
+            ),
+            "cwd outside allowed_paths must be SandboxViolation, got: {result:?}"
+        );
+    }
+
+    // --- named registry lookup ---
+
+    #[test]
+    fn unknown_context_name_is_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let executor = executor_for_dir(&dir);
+        let ctx = ExecutionContext::new().with_name("nonexistent-env");
+        let result = executor.resolve_context(Some(&ctx));
+        assert!(
+            result.is_err(),
+            "unknown named env must be Err, got: {result:?}"
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("nonexistent-env"),
+            "error must name the missing env, got: {err}"
+        );
+    }
+
+    #[test]
+    fn named_registry_entry_provides_cwd() {
+        let dir = tempfile::tempdir().unwrap();
+        let canonical = dir.path().canonicalize().unwrap();
+        let mut registry = HashMap::new();
+        registry.insert(
+            "repo".to_owned(),
+            ExecutionContext::trusted_from_parts(
+                Some("repo".to_owned()),
+                Some(canonical.clone()),
+                BTreeMap::default(),
+            ),
+        );
+        let executor = executor_for_dir(&dir)
+            .with_environments(registry, None)
+            .unwrap();
+        let ctx = ExecutionContext::new().with_name("repo");
+        let resolved = executor.resolve_context(Some(&ctx)).unwrap();
+        assert_eq!(resolved.cwd, canonical);
+        assert_eq!(resolved.name.as_deref(), Some("repo"));
+    }
+
+    #[test]
+    fn call_site_cwd_overrides_registry_cwd() {
+        let dir = tempfile::tempdir().unwrap();
+        let subdir = dir.path().join("sub");
+        std::fs::create_dir_all(&subdir).unwrap();
+        let canonical_sub = subdir.canonicalize().unwrap();
+        let canonical_root = dir.path().canonicalize().unwrap();
+
+        let mut registry = HashMap::new();
+        registry.insert(
+            "repo".to_owned(),
+            ExecutionContext::trusted_from_parts(
+                Some("repo".to_owned()),
+                Some(canonical_root.clone()),
+                BTreeMap::default(),
+            ),
+        );
+        let executor = executor_for_dir(&dir)
+            .with_environments(registry, None)
+            .unwrap();
+
+        // Call-site CWD is subdir — must win over registry cwd (root).
+        let ctx = ExecutionContext::new()
+            .with_name("repo")
+            .with_cwd(canonical_sub.clone());
+        let resolved = executor.resolve_context(Some(&ctx)).unwrap();
+        assert_eq!(resolved.cwd, canonical_sub);
+    }
+
+    #[test]
+    fn default_env_provides_cwd_when_no_ctx() {
+        let dir = tempfile::tempdir().unwrap();
+        let canonical = dir.path().canonicalize().unwrap();
+        let mut registry = HashMap::new();
+        registry.insert(
+            "default".to_owned(),
+            ExecutionContext::trusted_from_parts(
+                Some("default".to_owned()),
+                Some(canonical.clone()),
+                BTreeMap::default(),
+            ),
+        );
+        let executor = executor_for_dir(&dir)
+            .with_environments(registry, Some("default".to_owned()))
+            .unwrap();
+        let resolved = executor.resolve_context(None).unwrap();
+        assert_eq!(resolved.cwd, canonical);
+        assert_eq!(resolved.name.as_deref(), Some("default"));
+    }
+
+    // --- env_blocklist filtering ---
+
+    #[cfg(unix)]
+    #[allow(unsafe_code)]
+    #[test]
+    fn blocklist_strips_process_env_in_base() {
+        unsafe { std::env::set_var("SECRET_TEST_KEY", "leaked") };
+        let dir = tempfile::tempdir().unwrap();
+        let executor = executor_for_dir(&dir);
+        let resolved = executor.resolve_context(None).unwrap();
+        unsafe { std::env::remove_var("SECRET_TEST_KEY") };
+        assert!(
+            !resolved.env.contains_key("SECRET_TEST_KEY"),
+            "blocklist must strip SECRET_ from process env"
+        );
+    }
+
+    #[cfg(unix)]
+    #[allow(unsafe_code)]
+    #[test]
+    fn untrusted_ctx_cannot_reintroduce_blocked_var() {
+        // Untrusted call-site env_overrides with a blocklisted key must be stripped (step 6).
+        unsafe { std::env::set_var("SECRET_INJECTED", "should-not-appear") };
+        let dir = tempfile::tempdir().unwrap();
+        let executor = executor_for_dir(&dir);
+        // Untrusted context explicitly sets a SECRET_ var.
+        let ctx = ExecutionContext::new().with_env("SECRET_INJECTED", "injected-by-llm");
+        let resolved = executor.resolve_context(Some(&ctx)).unwrap();
+        unsafe { std::env::remove_var("SECRET_INJECTED") };
+        assert!(
+            !resolved.env.contains_key("SECRET_INJECTED"),
+            "step-6 re-apply must strip SECRET_ re-introduced by untrusted ctx"
+        );
+    }
+
+    #[test]
+    fn trusted_default_env_preserves_blocked_var() {
+        // When the default_env is a trusted registry entry and no call-site ctx is
+        // supplied, the resolved context is trusted and step 6 is skipped — so a
+        // SECRET_* var set by the operator TOML survives in the final env map.
+        let dir = tempfile::tempdir().unwrap();
+        let mut registry = HashMap::new();
+        registry.insert(
+            "ops".to_owned(),
+            ExecutionContext::trusted_from_parts(
+                Some("ops".to_owned()),
+                Some(dir.path().canonicalize().unwrap()),
+                {
+                    let mut e = std::collections::BTreeMap::new();
+                    e.insert("SECRET_ALLOWED".to_owned(), "operator-value".to_owned());
+                    e
+                },
+            ),
+        );
+        let executor = executor_for_dir(&dir)
+            .with_environments(registry, Some("ops".to_owned()))
+            .unwrap();
+        // No call-site ctx → default_env used → trusted = true → SECRET_ALLOWED survives.
+        let resolved = executor.resolve_context(None).unwrap();
+        assert_eq!(
+            resolved.env.get("SECRET_ALLOWED").map(String::as_str),
+            Some("operator-value"),
+            "trusted default_env registry env must bypass step-6 blocklist"
+        );
+        assert!(
+            resolved.trusted,
+            "resolved.trusted must be true when only default_env (trusted) is active"
+        );
+    }
+
+    #[test]
+    fn untrusted_named_ctx_strips_registry_blocked_var() {
+        // When a named registry entry sets a SECRET_ var but the call-site ctx is
+        // untrusted, step 6 must strip it — the untrusted ctx forces trusted = false.
+        let dir = tempfile::tempdir().unwrap();
+        let mut registry = HashMap::new();
+        registry.insert(
+            "ops".to_owned(),
+            ExecutionContext::trusted_from_parts(
+                Some("ops".to_owned()),
+                Some(dir.path().canonicalize().unwrap()),
+                {
+                    let mut e = std::collections::BTreeMap::new();
+                    e.insert("SECRET_INJECTED".to_owned(), "from-registry".to_owned());
+                    e
+                },
+            ),
+        );
+        let executor = executor_for_dir(&dir)
+            .with_environments(registry, None)
+            .unwrap();
+        // Untrusted call-site ctx → trusted = false → step 6 strips SECRET_.
+        let ctx = ExecutionContext::new().with_name("ops");
+        let resolved = executor.resolve_context(Some(&ctx)).unwrap();
+        assert!(
+            !resolved.env.contains_key("SECRET_INJECTED"),
+            "untrusted call-site ctx must cause step-6 to strip registry SECRET_ vars"
+        );
+    }
+
+    #[test]
+    fn untrusted_ctx_forces_trusted_false_even_with_named_registry() {
+        // When a named registry entry is trusted but the call-site ctx is untrusted,
+        // the resolved context must NOT be trusted (ctx.is_trusted() == false dominates).
+        let dir = tempfile::tempdir().unwrap();
+        let canonical = dir.path().canonicalize().unwrap();
+        let mut registry = HashMap::new();
+        registry.insert(
+            "ops".to_owned(),
+            ExecutionContext::trusted_from_parts(
+                Some("ops".to_owned()),
+                Some(canonical),
+                BTreeMap::default(),
+            ),
+        );
+        let executor = executor_for_dir(&dir)
+            .with_environments(registry, None)
+            .unwrap();
+        // Untrusted call-site ctx forces trusted = false.
+        let ctx = ExecutionContext::new().with_name("ops");
+        let resolved = executor.resolve_context(Some(&ctx)).unwrap();
+        assert!(
+            !resolved.trusted,
+            "untrusted call-site ctx must override registry trusted flag"
+        );
+    }
+
+    // --- skill_env layer ---
+
+    #[cfg(unix)]
+    #[test]
+    fn skill_env_applied_before_call_site() {
+        // skill_env is step 3; call-site env_overrides is step 5 → call-site wins on conflict.
+        let dir = tempfile::tempdir().unwrap();
+        let executor = executor_for_dir(&dir);
+        let mut skill = HashMap::new();
+        skill.insert("MY_VAR".to_owned(), "from-skill".to_owned());
+        executor.set_skill_env(Some(skill));
+
+        // No call-site override → skill_env value present.
+        let resolved = executor.resolve_context(None).unwrap();
+        assert_eq!(
+            resolved.env.get("MY_VAR").map(String::as_str),
+            Some("from-skill"),
+            "skill_env must be applied (step 3)"
+        );
+
+        // Call-site override beats skill_env.
+        let ctx = ExecutionContext::new().with_env("MY_VAR", "from-callsite");
+        let resolved2 = executor.resolve_context(Some(&ctx)).unwrap();
+        assert_eq!(
+            resolved2.env.get("MY_VAR").map(String::as_str),
+            Some("from-callsite"),
+            "call-site env_override must beat skill_env"
+        );
+    }
+
+    // --- with_environments validation ---
+
+    #[test]
+    fn with_environments_rejects_cwd_outside_allowed_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let outside_canonical = outside.path().canonicalize().unwrap();
+        let mut registry = HashMap::new();
+        registry.insert(
+            "bad".to_owned(),
+            ExecutionContext::trusted_from_parts(
+                Some("bad".to_owned()),
+                Some(outside_canonical),
+                BTreeMap::default(),
+            ),
+        );
+        let result = executor_for_dir(&dir).with_environments(registry, None);
+        assert!(
+            result.is_err(),
+            "with_environments must reject cwd outside allowed_paths"
+        );
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("bad"),
+            "error must name the offending env: {msg}"
+        );
+    }
+
+    #[test]
+    fn with_environments_rejects_nonexistent_cwd() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut registry = HashMap::new();
+        registry.insert(
+            "ghost".to_owned(),
+            ExecutionContext::trusted_from_parts(
+                Some("ghost".to_owned()),
+                Some(std::path::PathBuf::from("/nonexistent/path/for/test")),
+                BTreeMap::default(),
+            ),
+        );
+        let result = executor_for_dir(&dir).with_environments(registry, None);
+        assert!(
+            result.is_err(),
+            "with_environments must reject non-existent cwd"
+        );
+    }
+
+    // --- ToolCall dispatch ---
+
+    #[tokio::test]
+    #[cfg(not(target_os = "windows"))]
+    async fn tool_call_with_context_cwd_used_for_execution() {
+        use crate::executor::ToolExecutor;
+        use zeph_common::ToolName;
+
+        let dir = tempfile::tempdir().unwrap();
+        let canonical = dir.path().canonicalize().unwrap();
+        let executor = executor_for_dir(&dir);
+
+        let ctx = ExecutionContext::new().with_cwd(canonical.clone());
+        let call = ToolCall {
+            tool_id: ToolName::new("bash"),
+            params: {
+                let mut m = serde_json::Map::new();
+                m.insert(
+                    "command".to_owned(),
+                    serde_json::Value::String("pwd".to_owned()),
+                );
+                m
+            },
+            caller_id: None,
+            context: Some(ctx),
+        };
+        let output = executor.execute_tool_call(&call).await.unwrap().unwrap();
+        assert!(
+            output
+                .summary
+                .contains(canonical.to_string_lossy().as_ref()),
+            "pwd output must reflect context cwd, got: {}",
+            output.summary
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(not(target_os = "windows"))]
+    async fn tool_call_without_context_uses_process_cwd() {
+        use crate::executor::ToolExecutor;
+        use zeph_common::ToolName;
+
+        let dir = tempfile::tempdir().unwrap();
+        let executor = executor_for_dir(&dir);
+        let call = ToolCall {
+            tool_id: ToolName::new("bash"),
+            params: {
+                let mut m = serde_json::Map::new();
+                m.insert(
+                    "command".to_owned(),
+                    serde_json::Value::String("pwd".to_owned()),
+                );
+                m
+            },
+            caller_id: None,
+            context: None,
+        };
+        let output = executor.execute_tool_call(&call).await.unwrap().unwrap();
+        let expected = std::env::current_dir().unwrap();
+        assert!(
+            output.summary.contains(expected.to_string_lossy().as_ref()),
+            "pwd without context must reflect process cwd, got: {}",
+            output.summary
+        );
+    }
 }

--- a/crates/zeph-tools/src/tool_filter.rs
+++ b/crates/zeph-tools/src/tool_filter.rs
@@ -119,6 +119,7 @@ mod tests {
             tool_id: ToolName::new("read"),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
         let result = filter.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());
@@ -131,6 +132,7 @@ mod tests {
             tool_id: ToolName::new("edit"),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         };
         let result = filter.execute_tool_call(&call).await.unwrap();
         assert!(result.is_some());

--- a/crates/zeph-tools/src/trust_gate.rs
+++ b/crates/zeph-tools/src/trust_gate.rs
@@ -270,6 +270,7 @@ mod tests {
             tool_id: tool_id.into(),
             params: serde_json::Map::new(),
             caller_id: None,
+            context: None,
         }
     }
 
@@ -280,6 +281,7 @@ mod tests {
             tool_id: tool_id.into(),
             params,
             caller_id: None,
+            context: None,
         }
     }
 
@@ -514,6 +516,7 @@ mod tests {
             tool_id: "mcp_filesystem__read_file".into(),
             params,
             caller_id: None,
+            context: None,
         };
         let result = gate.execute_tool_call(&call).await;
         assert!(

--- a/crates/zeph-tools/src/utility.rs
+++ b/crates/zeph-tools/src/utility.rs
@@ -317,6 +317,7 @@ mod tests {
                 serde_json::Map::new()
             },
             caller_id: None,
+            context: None,
         }
     }
 

--- a/src/scheduler_executor.rs
+++ b/src/scheduler_executor.rs
@@ -459,6 +459,7 @@ impl ToolExecutor for SchedulerExecutor {
                     tool_id: tool_id.into(),
                     params,
                     caller_id: None,
+                    context: None,
                 };
                 return self.execute_tool_call(&call).await;
             }
@@ -559,6 +560,7 @@ mod tests {
             tool_id: zeph_tools::ToolName::new(tool_id),
             params,
             caller_id: None,
+            context: None,
         }
     }
 

--- a/src/tui_bridge.rs
+++ b/src/tui_bridge.rs
@@ -535,6 +535,8 @@ mod tests {
                 tool_name: "shell".into(),
                 command: "ls".into(),
                 sandbox_profile: None,
+                resolved_cwd: None,
+                execution_env: None,
             })
             .await
             .unwrap();


### PR DESCRIPTION
## Summary

- Adds `ExecutionContext` (named environment, cwd, env_overrides, trusted flag) to `ToolCall` so each DAG subtask can target a different working directory and env set without restarting the session
- `ShellExecutor::resolve_context` is the single dispatch chokepoint with explicit precedence: call-site > named registry > skill env > process default
- Speculative cache `HandleKey` gains `context_hash` to prevent cross-environment result reuse in parallel subagent scenarios
- `validate_sandbox_with_cwd` uses ancestor-walk for not-yet-created paths and rejects `..` traversal without unsafe `std::path::absolute` fallback (security fix)
- `env_blocklist` applied to final merged env for untrusted contexts (prefix-match, not exact-match)
- New `[execution]` config section with `[[execution.environments]]` named registry
- 18 unit tests covering resolution precedence, sandbox enforcement, blocklist, trust model

## Breaking changes

- `AuditEntry::resolved_cwd` changed from `String` to `Option<String>` with `skip_serializing_if` — non-shell tool producers now emit `null` instead of `""`

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --all-targets --workspace -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 8719 passed
- [x] Security: path traversal test (`allowed/../../etc/shadow` rejected)
- [x] Trust: untrusted context cannot bypass blocklist via env_overrides or skill_env
- [x] Cache: parallel tool calls with different execution contexts get isolated cache keys
- [ ] Live session: `cargo run --features full -- --config .local/config/testing.toml` (LLM serialization gate — required before merge per branching.md)

Closes #3572