### PR TITLE
feat(core,tools): goal lifecycle and TACO output compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   buffer is written to every debug dump (Json and Raw formats) alongside the LLM request
   payload for offline analysis.
 
+- **Goal lifecycle subsystem** (`/goal` command, #3567): long-horizon goal tracking across
+  conversation turns. `GoalStore` (SQLite/Postgres-backed) with transactional `create()` that
+  atomically pauses any previously active goal (partial unique index enforces at-most-one-active
+  invariant). `GoalAccounting` caches the active goal ID in memory and dispatches `record_turn`
+  as a fire-and-forget background task (G4). Active goal text is injected into the volatile
+  system-prompt region as `<active_goal>` after `<!-- cache:volatile -->` (G3). Subcommands:
+  `create [--budget N]`, `pause`, `resume`, `complete`, `clear`, `status`, `list`.
+  Config section `[goals]` with `enabled`, `inject_into_system_prompt`, `max_text_chars`,
+  `default_token_budget`, `max_history`. SQLite migration `081_goal_lifecycle.sql`.
+
+- **TACO tool output compression** (#3306): `OutputCompressor` async trait with
+  `IdentityCompressor` (zero-cost no-op) and `RuleBasedCompressor` (regex rules loaded from
+  the `compression_rules` table). `CompressedExecutor<E>` decorator wraps the root tool executor
+  outside the audit boundary (T4). `safe_compile` bounds regex compilation via `spawn_blocking`
+  + timeout + `RegexBuilder` size limits (S6 DoS protection). Hit counts tracked per rule in a
+  `DashMap<String, AtomicU64>` decoupled from the rules vec for safe concurrent swap-on-reload.
+  Config section `[tools.compression]` with `enabled`, `min_lines_to_compress`,
+  `evolution_provider`, `evolution_min_interval_secs`, `max_rules`, `regex_compile_timeout_ms`.
+  SQLite migration `082_compression_rules.sql`.
+
 - feat(mcp): MCP server startup now retries failed initial connections with exponential backoff
   (`500 ms`, `1 s`, `2 s`, `4 s`, `8 s`, capped at `8 s`). The new `mcp.max_connect_attempts`
   config key (default `3`, range `1..=10`) controls how many attempts are made. Backoff sleeps are

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10253,6 +10253,7 @@ dependencies = [
 name = "zeph-commands"
 version = "0.20.1"
 dependencies = [
+ "serde",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -10752,6 +10753,7 @@ name = "zeph-tools"
 version = "0.20.1"
 dependencies = [
  "arc-swap",
+ "dashmap",
  "dirs",
  "glob",
  "globset",
@@ -10767,6 +10769,7 @@ dependencies = [
  "seccompiler",
  "serde",
  "serde_json",
+ "sqlx",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -10789,6 +10792,7 @@ dependencies = [
  "wiremock",
  "zeph-common",
  "zeph-config",
+ "zeph-db",
 ]
 
 [[package]]

--- a/crates/zeph-commands/Cargo.toml
+++ b/crates/zeph-commands/Cargo.toml
@@ -12,6 +12,7 @@ publish.workspace = true
 description = "Slash command registry, handler trait, and channel sink abstraction for Zeph"
 
 [dependencies]
+serde = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 tracing.workspace = true

--- a/crates/zeph-commands/src/commands.rs
+++ b/crates/zeph-commands/src/commands.rs
@@ -58,6 +58,14 @@ pub const COMMANDS: &[CommandInfo] = &[
         category: SlashCategory::Debugging,
         feature_gate: None,
     },
+    // --- Goals ---
+    CommandInfo {
+        name: "/goal",
+        args: "create <text> [--budget N] | pause | resume | complete | clear | status | list",
+        description: "Manage long-horizon goals that persist across conversation turns",
+        category: SlashCategory::Session,
+        feature_gate: None,
+    },
     // --- Session ---
     CommandInfo {
         name: "/exit",

--- a/crates/zeph-commands/src/handlers/goal.rs
+++ b/crates/zeph-commands/src/handlers/goal.rs
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `/goal` slash command handler.
+//!
+//! Subcommands:
+//! - `create <text> [--budget N]` — create a new goal, pausing any existing active one
+//! - `pause` — pause the active goal
+//! - `resume` — resume the last paused goal
+//! - `complete` — mark the active goal as completed
+//! - `clear` — dismiss the active or paused goal
+//! - `status` — show the active goal and recent history
+//! - `list` — list all goals (active, paused, completed, cleared)
+
+use std::future::Future;
+use std::pin::Pin;
+
+use crate::context::CommandContext;
+use crate::{CommandError, CommandHandler, CommandOutput, SlashCategory};
+
+/// Manage long-horizon goals that span multiple conversation turns.
+///
+/// At most one goal can be `active` at a time. Creating a new goal auto-pauses
+/// the previous one. Status, list, and pause/resume commands work even when
+/// `[goals] enabled = false` (read-only access is always available).
+pub struct GoalCommand;
+
+impl CommandHandler<CommandContext<'_>> for GoalCommand {
+    fn name(&self) -> &'static str {
+        "/goal"
+    }
+
+    fn description(&self) -> &'static str {
+        "Manage long-horizon goals that persist across conversation turns"
+    }
+
+    fn args_hint(&self) -> &'static str {
+        "create <text> [--budget N] | pause | resume | complete | clear | status | list"
+    }
+
+    fn category(&self) -> SlashCategory {
+        SlashCategory::Session
+    }
+
+    fn handle<'a>(
+        &'a self,
+        ctx: &'a mut CommandContext<'_>,
+        args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<CommandOutput, CommandError>> + Send + 'a>> {
+        Box::pin(async move {
+            let result = ctx.agent.handle_goal(args).await.unwrap_or_else(|e| e.0);
+            Ok(CommandOutput::Message(result))
+        })
+    }
+}

--- a/crates/zeph-commands/src/handlers/mod.rs
+++ b/crates/zeph-commands/src/handlers/mod.rs
@@ -14,6 +14,7 @@ pub mod agent_cmd;
 pub mod compaction;
 pub mod debug;
 pub mod experiment;
+pub mod goal;
 pub mod help;
 pub mod loop_cmd;
 pub mod lsp;

--- a/crates/zeph-commands/src/lib.rs
+++ b/crates/zeph-commands/src/lib.rs
@@ -36,6 +36,56 @@ pub use context::CommandContext;
 pub use sink::{ChannelSink, NullSink};
 pub use traits::agent::{AgentAccess, NullAgent};
 
+/// Status of a long-horizon goal.
+///
+/// Mirrors `zeph_core::goal::GoalStatus`. Defined here to avoid a dependency cycle
+/// (`zeph-commands` cannot depend on `zeph-core`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GoalStatusView {
+    /// Goal is being actively tracked.
+    Active,
+    /// Goal is paused; not injected into context.
+    Paused,
+    /// Goal was marked as achieved. Terminal state.
+    Completed,
+    /// Goal was dismissed. Terminal state.
+    Cleared,
+}
+
+impl GoalStatusView {
+    /// Short ASCII symbol used in TUI status badge.
+    #[must_use]
+    pub fn badge_symbol(self) -> &'static str {
+        match self {
+            Self::Active => "▶",
+            Self::Paused => "⏸",
+            Self::Completed => "✓",
+            Self::Cleared => "✗",
+        }
+    }
+}
+
+/// Lightweight cross-crate snapshot of an active goal.
+///
+/// Produced by [`AgentAccess::active_goal_snapshot`] and consumed by the TUI status bar
+/// and metrics bridge. Contains only display-relevant fields.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct GoalSnapshot {
+    /// UUID string of the goal.
+    pub id: String,
+    /// Goal text, pre-validated to fit within `max_text_chars`.
+    pub text: String,
+    /// Current FSM status.
+    pub status: GoalStatusView,
+    /// Number of turns completed under this goal.
+    pub turns_used: u64,
+    /// Total tokens consumed across all turns.
+    pub tokens_used: u64,
+    /// Optional token budget (`None` = unlimited).
+    pub token_budget: Option<u64>,
+}
+
 use std::future::Future;
 use std::pin::Pin;
 

--- a/crates/zeph-commands/src/traits/agent.rs
+++ b/crates/zeph-commands/src/traits/agent.rs
@@ -444,6 +444,30 @@ pub trait AgentAccess: Send {
 
     /// Handle `/scope [list [task_type]]` and return a user-visible result.
     fn handle_scope(&self, args: &str) -> String;
+
+    // ----- /goal -----
+
+    /// Execute a `/goal` subcommand (create, pause, resume, clear, complete, status, list).
+    ///
+    /// `args` contains everything after `/goal` (e.g., `"create buy groceries"`).
+    ///
+    /// Returns a formatted response string on success, or an error message string.
+    /// The default implementation returns an error indicating that goals are not supported,
+    /// which is the correct behaviour for contexts where goal tracking is not wired in.
+    fn handle_goal<'a>(
+        &'a mut self,
+        args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>> {
+        let _ = args;
+        Box::pin(async move { Err(CommandError::new("/goal is not supported in this context")) })
+    }
+
+    /// Return a lightweight snapshot of the currently active goal, if any.
+    ///
+    /// Used by the TUI status bar and metrics bridge. The default returns `None`.
+    fn active_goal_snapshot(&self) -> Option<crate::GoalSnapshot> {
+        None
+    }
 }
 
 /// A no-op [`AgentAccess`] implementation.

--- a/crates/zeph-config/src/agent.rs
+++ b/crates/zeph-config/src/agent.rs
@@ -279,6 +279,56 @@ fn default_budget_hint_enabled() -> bool {
     true
 }
 
+fn default_goal_max_text_chars() -> usize {
+    2000
+}
+
+fn default_goal_max_history() -> usize {
+    50
+}
+
+/// Long-horizon goal lifecycle configuration (`[goals]` TOML section).
+///
+/// When enabled, the agent tracks a single active goal across turns, injecting an
+/// `<active_goal>` block into the volatile system-prompt region and accounting for
+/// token consumption per turn.
+///
+/// # Example (TOML)
+///
+/// ```toml
+/// [goals]
+/// enabled = true
+/// default_token_budget = 50000
+/// ```
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct GoalConfig {
+    /// Enable the goal lifecycle subsystem. Default: `false`.
+    pub enabled: bool,
+    /// Inject `<active_goal>` block into the volatile system-prompt region. Default: `true`.
+    pub inject_into_system_prompt: bool,
+    /// Maximum characters allowed for goal text at creation time. Default: `2000`.
+    #[serde(default = "default_goal_max_text_chars")]
+    pub max_text_chars: usize,
+    /// Default token budget for new goals (`None` = unlimited). Default: `None`.
+    pub default_token_budget: Option<u64>,
+    /// Maximum number of goals to return in `/goal list`. Default: `50`.
+    #[serde(default = "default_goal_max_history")]
+    pub max_history: usize,
+}
+
+impl Default for GoalConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            inject_into_system_prompt: true,
+            max_text_chars: default_goal_max_text_chars(),
+            default_token_budget: None,
+            max_history: default_goal_max_history(),
+        }
+    }
+}
+
 fn default_enrichment_limit() -> usize {
     4
 }

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -103,7 +103,7 @@ pub mod ui;
 pub mod vigil;
 
 pub use agent::{
-    AgentConfig, ContextInjectionMode, FocusConfig, ModelSpec, SubAgentConfig,
+    AgentConfig, ContextInjectionMode, FocusConfig, GoalConfig, ModelSpec, SubAgentConfig,
     SubAgentLifecycleHooks, TaskSupervisorConfig, ToolFilterConfig,
 };
 pub use channels::{
@@ -171,6 +171,7 @@ pub use subagent::{
     ToolPolicy,
 };
 pub use telemetry::{TelemetryBackend, TelemetryConfig};
+pub use tools::ToolCompressionConfig;
 pub use ui::{
     AcpAuthMethod, AcpConfig, AcpLspConfig, AcpSubagentsConfig, AcpTransport, AdditionalDir,
     AdditionalDirError, SubagentPresetConfig, TuiConfig,

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -3140,6 +3140,65 @@ pub fn migrate_qdrant_api_key(toml_src: &str) -> Result<MigrationResult, Migrate
     })
 }
 
+/// Add the `[goals]` section as commented-out defaults when it is absent.
+///
+/// # Errors
+///
+/// Returns [`MigrateError::Parse`] when `toml_src` is not valid TOML.
+pub fn migrate_goals_config(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    if toml_src.contains("[goals]") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let comment = "\n# Long-horizon goal lifecycle tracking (#3567).\n\
+         # [goals]\n\
+         # enabled = false\n\
+         # inject_into_system_prompt = true\n\
+         # max_text_chars = 2000\n\
+         # max_history = 50\n";
+
+    Ok(MigrationResult {
+        output: format!("{toml_src}{comment}"),
+        changed_count: 1,
+        sections_changed: vec!["goals".to_owned()],
+    })
+}
+
+/// Add the `[tools.compression]` section as commented-out defaults when it is absent.
+///
+/// # Errors
+///
+/// Returns [`MigrateError::Parse`] when `toml_src` is not valid TOML.
+pub fn migrate_tools_compression_config(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    if toml_src.contains("tools.compression")
+        || toml_src.contains("[tools]\n") && toml_src.contains("compression")
+    {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let comment = "\n# TACO self-evolving tool output compression (#3306).\n\
+         # [tools.compression]\n\
+         # enabled = false\n\
+         # min_lines_to_compress = 10\n\
+         # evolution_provider = \"\"\n\
+         # evolution_min_interval_secs = 3600\n\
+         # max_rules = 200\n";
+
+    Ok(MigrationResult {
+        output: format!("{toml_src}{comment}"),
+        changed_count: 1,
+        sections_changed: vec!["tools.compression".to_owned()],
+    })
+}
+
 // ── Migration trait and registry ────────────────────────────────────────────────────────────────
 
 /// A single idempotent config migration step.
@@ -3183,16 +3242,17 @@ use steps::{
     MigrateAcpSubagentsConfig, MigrateAgentBudgetHint, MigrateAgentRetryToToolsRetry,
     MigrateAutodreamConfig, MigrateCompressionPredictorConfig, MigrateDatabaseUrl,
     MigrateEgressConfig, MigrateFocusAutoConsolidateMinWindow, MigrateForgettingConfig,
-    MigrateHooksPermissionDeniedConfig, MigrateHooksTurnComplete, MigrateMagicDocsConfig,
-    MigrateMcpElicitationConfig, MigrateMcpMaxConnectAttempts, MigrateMcpTrustLevels,
-    MigrateMemoryGraph, MigrateMemoryHebbian, MigrateMemoryHebbianConsolidation,
-    MigrateMemoryHebbianSpread, MigrateMemoryPersonaConfig, MigrateMemoryReasoning,
-    MigrateMemoryReasoningJudge, MigrateMemoryRetrieval, MigrateMemoryRetrievalQueryBias,
-    MigrateMicrocompactConfig, MigrateOrchestrationPersistence, MigrateOtelFilter,
-    MigratePlannerModelToProvider, MigrateQdrantApiKey, MigrateQualityConfig, MigrateSandboxConfig,
-    MigrateSandboxEgressFilter, MigrateSchedulerDaemon, MigrateSessionProviderPersistence,
-    MigrateSessionRecapConfig, MigrateShellTransactional, MigrateSttToProvider,
-    MigrateSupervisorConfig, MigrateTelemetryConfig, MigrateVigilConfig,
+    MigrateGoalsConfig, MigrateHooksPermissionDeniedConfig, MigrateHooksTurnComplete,
+    MigrateMagicDocsConfig, MigrateMcpElicitationConfig, MigrateMcpMaxConnectAttempts,
+    MigrateMcpTrustLevels, MigrateMemoryGraph, MigrateMemoryHebbian,
+    MigrateMemoryHebbianConsolidation, MigrateMemoryHebbianSpread, MigrateMemoryPersonaConfig,
+    MigrateMemoryReasoning, MigrateMemoryReasoningJudge, MigrateMemoryRetrieval,
+    MigrateMemoryRetrievalQueryBias, MigrateMicrocompactConfig, MigrateOrchestrationPersistence,
+    MigrateOtelFilter, MigratePlannerModelToProvider, MigrateQdrantApiKey, MigrateQualityConfig,
+    MigrateSandboxConfig, MigrateSandboxEgressFilter, MigrateSchedulerDaemon,
+    MigrateSessionProviderPersistence, MigrateSessionRecapConfig, MigrateShellTransactional,
+    MigrateSttToProvider, MigrateSupervisorConfig, MigrateTelemetryConfig,
+    MigrateToolsCompressionConfig, MigrateVigilConfig,
 };
 
 /// Ordered registry of all sequential migration steps (steps 1–40).
@@ -3259,6 +3319,9 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             Box::new(MigrateQdrantApiKey),
             // Step 40 — MCP startup auto-retry max_connect_attempts (#3568)
             Box::new(MigrateMcpMaxConnectAttempts),
+            // Steps 41–42 — goal lifecycle and TACO compression (#3567, #3306)
+            Box::new(MigrateGoalsConfig),
+            Box::new(MigrateToolsCompressionConfig),
         ]
     });
 
@@ -3277,8 +3340,8 @@ mod tests {
     fn migrations_registry_has_all_steps() {
         assert_eq!(
             MIGRATIONS.len(),
-            40,
-            "MIGRATIONS registry must contain all 40 sequential steps"
+            42,
+            "MIGRATIONS registry must contain all 42 sequential steps"
         );
         for m in MIGRATIONS.iter() {
             assert!(
@@ -4865,7 +4928,7 @@ prompt_cache_ttl = "1h"
 
     #[test]
     fn registry_has_thirty_nine_entries() {
-        assert_eq!(MIGRATIONS.len(), 40);
+        assert_eq!(MIGRATIONS.len(), 42);
     }
 
     #[test]
@@ -4904,7 +4967,7 @@ prompt_cache_ttl = "1h"
 
     #[test]
     fn registry_preserves_order_matches_dispatch() {
-        // Names must follow the documented step order (steps 1–40).
+        // Names must follow the documented step order (steps 1–42).
         let expected = [
             "migrate_stt_to_provider",
             "migrate_planner_model_to_provider",
@@ -4946,6 +5009,8 @@ prompt_cache_ttl = "1h"
             "migrate_memory_persona_config",
             "migrate_qdrant_api_key",
             "migrate_mcp_max_connect_attempts",
+            "migrate_goals_config",
+            "migrate_tools_compression_config",
         ];
         let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
         assert_eq!(actual, expected);

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -14,7 +14,7 @@ use super::{
     MigrateError, Migration, MigrationResult, migrate_acp_subagents_config,
     migrate_agent_budget_hint, migrate_agent_retry_to_tools_retry, migrate_autodream_config,
     migrate_compression_predictor_config, migrate_database_url, migrate_egress_config,
-    migrate_focus_auto_consolidate_min_window, migrate_forgetting_config,
+    migrate_focus_auto_consolidate_min_window, migrate_forgetting_config, migrate_goals_config,
     migrate_hooks_permission_denied_config, migrate_hooks_turn_complete_config,
     migrate_magic_docs_config, migrate_mcp_elicitation_config, migrate_mcp_max_connect_attempts,
     migrate_mcp_trust_levels, migrate_memory_graph_config, migrate_memory_hebbian_config,
@@ -27,7 +27,7 @@ use super::{
     migrate_sandbox_egress_filter, migrate_scheduler_daemon_config,
     migrate_session_provider_persistence, migrate_session_recap_config,
     migrate_shell_transactional, migrate_stt_to_provider, migrate_supervisor_config,
-    migrate_telemetry_config, migrate_vigil_config,
+    migrate_telemetry_config, migrate_tools_compression_config, migrate_vigil_config,
 };
 
 // ── Wrapper structs for all 35 sequential migration steps ───────────────────────────────────────
@@ -469,5 +469,27 @@ impl Migration for MigrateMcpMaxConnectAttempts {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_mcp_max_connect_attempts(toml_src)
+    }
+}
+
+pub(super) struct MigrateGoalsConfig;
+impl Migration for MigrateGoalsConfig {
+    fn name(&self) -> &'static str {
+        "migrate_goals_config"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_goals_config(toml_src)
+    }
+}
+
+pub(super) struct MigrateToolsCompressionConfig;
+impl Migration for MigrateToolsCompressionConfig {
+    fn name(&self) -> &'static str {
+        "migrate_tools_compression_config"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_tools_compression_config(toml_src)
     }
 }

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -8,7 +8,7 @@ use crate::tools::ToolsConfig;
 use serde::{Deserialize, Serialize};
 use zeph_common::secret::Secret;
 
-use crate::agent::{AgentConfig, FocusConfig, SubAgentConfig};
+use crate::agent::{AgentConfig, FocusConfig, GoalConfig, SubAgentConfig};
 use crate::channels::{A2aServerConfig, DiscordConfig, McpConfig, SlackConfig, TelegramConfig};
 use crate::classifiers::ClassifiersConfig;
 use crate::cli::CliConfig;
@@ -123,6 +123,9 @@ pub struct Config {
     /// Per-turn completion notification settings (macOS banners, ntfy webhook).
     #[serde(default)]
     pub notifications: NotificationsConfig,
+    /// Long-horizon goal lifecycle configuration.
+    #[serde(default)]
+    pub goals: GoalConfig,
     /// Resolved secrets from vault. Never serialized — populated at runtime.
     #[serde(skip)]
     pub secrets: ResolvedSecrets,
@@ -297,6 +300,7 @@ impl Default for Config {
             cli: CliConfig::default(),
             quality: crate::quality::QualityConfig::default(),
             notifications: NotificationsConfig::default(),
+            goals: GoalConfig::default(),
             secrets: ResolvedSecrets::default(),
         }
     }

--- a/crates/zeph-config/src/tools.rs
+++ b/crates/zeph-config/src/tools.rs
@@ -1125,6 +1125,73 @@ impl Default for EgressConfig {
     }
 }
 
+// ── ToolCompressionConfig ─────────────────────────────────────────────────────
+
+fn default_compression_min_lines() -> usize {
+    10
+}
+
+fn default_compression_max_rules() -> u32 {
+    200
+}
+
+fn default_regex_compile_timeout_ms() -> u64 {
+    500
+}
+
+fn default_evolution_min_interval_secs() -> u64 {
+    3600
+}
+
+/// TACO self-evolving tool output compression configuration (`[tools.compression]` TOML section).
+///
+/// When enabled, a `RuleBasedCompressor` is wrapped around the root tool executor.
+/// Rules are loaded from the `compression_rules` `SQLite` table and optionally evolved by an
+/// LLM provider specified in `evolution_provider`.
+///
+/// # Example (TOML)
+///
+/// ```toml
+/// [tools.compression]
+/// enabled = true
+/// evolution_provider = "fast"
+/// min_lines_to_compress = 15
+/// ```
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct ToolCompressionConfig {
+    /// Enable rule-based tool output compression. Default: `false`.
+    pub enabled: bool,
+    /// Minimum output line count before compression is attempted. Default: `10`.
+    #[serde(default = "default_compression_min_lines")]
+    pub min_lines_to_compress: usize,
+    /// LLM provider name for self-evolution. Empty string = evolution disabled. Default: `""`.
+    #[serde(default)]
+    pub evolution_provider: String,
+    /// Minimum interval in seconds between self-evolution runs. Default: `3600`.
+    #[serde(default = "default_evolution_min_interval_secs")]
+    pub evolution_min_interval_secs: u64,
+    /// Maximum number of rules to keep in the DB (prune lowest-hit rules above this). Default: `200`.
+    #[serde(default = "default_compression_max_rules")]
+    pub max_rules: u32,
+    /// Timeout in milliseconds for safe regex compilation. Default: `500`.
+    #[serde(default = "default_regex_compile_timeout_ms")]
+    pub regex_compile_timeout_ms: u64,
+}
+
+impl Default for ToolCompressionConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            min_lines_to_compress: default_compression_min_lines(),
+            evolution_provider: String::new(),
+            evolution_min_interval_secs: default_evolution_min_interval_secs(),
+            max_rules: default_compression_max_rules(),
+            regex_compile_timeout_ms: default_regex_compile_timeout_ms(),
+        }
+    }
+}
+
 // ── ToolsConfig ───────────────────────────────────────────────────────────────
 
 /// Top-level configuration for tool execution.
@@ -1200,6 +1267,9 @@ pub struct ToolsConfig {
     /// Egress network event logging configuration.
     #[serde(default)]
     pub egress: EgressConfig,
+    /// TACO self-evolving tool output compression configuration.
+    #[serde(default)]
+    pub compression: ToolCompressionConfig,
 }
 
 impl Default for ToolsConfig {
@@ -1227,6 +1297,7 @@ impl Default for ToolsConfig {
             speculative: SpeculativeConfig::default(),
             sandbox: SandboxConfig::default(),
             egress: EgressConfig::default(),
+            compression: ToolCompressionConfig::default(),
         }
     }
 }

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -17,16 +17,18 @@ profiling = ["dep:tracing-subscriber"]
 profiling-alloc = ["profiling"]
 sysinfo = ["dep:sysinfo"]
 task-metrics = ["dep:cpu-time", "dep:metrics", "zeph-common/task-metrics"]
-default = []
+default = ["sqlite"]
 candle = ["zeph-llm/candle"]
 classifiers = ["zeph-llm/classifiers", "zeph-sanitizer/classifiers"]
 cuda = ["zeph-llm/cuda"]
 env-vault = ["zeph-vault/env-vault"]
 metal = ["zeph-llm/metal"]
 mock = ["zeph-vault/mock"]
+postgres = ["zeph-db/postgres"]
 scheduler  = []
 index = ["zeph-agent-context/index"]
 self-check = ["zeph-agent-context/self-check"]
+sqlite = ["zeph-db/sqlite"]
 
 [dependencies]
 base64.workspace = true
@@ -47,7 +49,8 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_norway.workspace = true
 tempfile.workspace = true
-zeph-db = { workspace = true, features = ["sqlite"] }
+sqlx.workspace = true
+zeph-db.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["fs", "macros", "process", "rt-multi-thread", "sync", "time"] }
 tokio-stream.workspace = true

--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -943,6 +943,268 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
     fn handle_scope(&self, args: &str) -> String {
         self.handle_scope_command_as_string(args)
     }
+
+    // ----- /goal -----
+
+    fn handle_goal<'a>(
+        &'a mut self,
+        args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>> {
+        // Extract all non-Send data synchronously before entering the async block.
+        if self.services.goal_accounting.is_none() {
+            if !self.runtime.config.goals.enabled {
+                return Box::pin(async {
+                    Ok("Goals are disabled. Set `[goals] enabled = true` in config.".to_owned())
+                });
+            }
+            let pool = match self.services.memory.persistence.memory.as_ref() {
+                Some(m) => std::sync::Arc::new(m.sqlite().pool().clone()),
+                None => {
+                    return Box::pin(async {
+                        Ok("Goals require a database backend (memory not configured).".to_owned())
+                    });
+                }
+            };
+            let store = std::sync::Arc::new(crate::goal::GoalStore::new(pool));
+            let accounting = std::sync::Arc::new(crate::goal::GoalAccounting::new(store));
+            self.services.goal_accounting = Some(accounting);
+        }
+
+        let accounting = self.services.goal_accounting.clone().unwrap();
+        let max_chars = self.runtime.config.goals.max_text_chars;
+        let default_budget = self.runtime.config.goals.default_token_budget;
+
+        Box::pin(async move {
+            let _ = accounting.refresh().await;
+            let store = accounting.get_store();
+
+            match args {
+                "" | "status" => goal_status(&accounting).await,
+                "pause" => goal_pause(&accounting, &store).await,
+                "resume" => goal_resume(&accounting, &store).await,
+                "complete" => goal_complete(&accounting, &store).await,
+                "clear" => goal_clear(&accounting, &store).await,
+                "list" => goal_list(&store).await,
+                _ if args.starts_with("create") => {
+                    goal_create(args, &accounting, &store, max_chars, default_budget).await
+                }
+                _ => Ok(
+                    "Unknown /goal subcommand. Try: create, pause, resume, complete, clear, status, list."
+                        .to_owned(),
+                ),
+            }
+        })
+    }
+
+    fn active_goal_snapshot(&self) -> Option<zeph_commands::GoalSnapshot> {
+        let accounting = self.services.goal_accounting.as_ref()?;
+        let snap = accounting.snapshot()?;
+        Some(zeph_commands::GoalSnapshot {
+            id: snap.id,
+            text: snap.text,
+            status: match snap.status {
+                crate::goal::GoalStatus::Active => zeph_commands::GoalStatusView::Active,
+                crate::goal::GoalStatus::Paused => zeph_commands::GoalStatusView::Paused,
+                crate::goal::GoalStatus::Completed => zeph_commands::GoalStatusView::Completed,
+                crate::goal::GoalStatus::Cleared => zeph_commands::GoalStatusView::Cleared,
+            },
+            turns_used: snap.turns_used,
+            tokens_used: snap.tokens_used,
+            token_budget: snap.token_budget,
+        })
+    }
+}
+
+type GoalStore = crate::goal::GoalStore;
+type GoalAccounting = crate::goal::GoalAccounting;
+
+async fn goal_status(accounting: &GoalAccounting) -> Result<String, CommandError> {
+    match accounting.get_active().await {
+        Ok(Some(g)) => {
+            let budget_line = g.token_budget.map_or_else(
+                || format!("  tokens used: {}", g.tokens_used),
+                |b| format!("  budget: {}/{b}", g.tokens_used),
+            );
+            Ok(format!(
+                "Active goal [{}]: {}\n  status: {}\n  turns: {}\n{}",
+                &g.id[..8],
+                g.text,
+                g.status,
+                g.turns_used,
+                budget_line
+            ))
+        }
+        Ok(None) => Ok("No active goal. Use `/goal create <text>` to set one.".to_owned()),
+        Err(e) => Ok(format!("Goal lookup failed: {e}")),
+    }
+}
+
+async fn goal_create(
+    args: &str,
+    accounting: &GoalAccounting,
+    store: &GoalStore,
+    max_chars: usize,
+    default_budget: u64,
+) -> Result<String, CommandError> {
+    let rest = args.strip_prefix("create").unwrap_or("").trim();
+    let (text, explicit_budget) = parse_goal_create_args(rest);
+    if text.is_empty() {
+        return Ok("Usage: /goal create <text> [--budget N]".to_owned());
+    }
+    let budget = explicit_budget.or(if default_budget > 0 {
+        Some(default_budget)
+    } else {
+        None
+    });
+    match store.create(text, budget, max_chars).await {
+        Ok(g) => {
+            let _ = accounting.refresh().await;
+            Ok(format!("Goal created [{}]: {}", &g.id[..8], g.text))
+        }
+        Err(crate::goal::store::GoalError::TextTooLong { max }) => Ok(format!(
+            "Goal text exceeds {max} characters. Please shorten it."
+        )),
+        Err(e) => Ok(format!("Failed to create goal: {e}")),
+    }
+}
+
+async fn goal_pause(
+    accounting: &GoalAccounting,
+    store: &GoalStore,
+) -> Result<String, CommandError> {
+    match accounting.get_active().await {
+        Ok(Some(g)) => {
+            match store
+                .transition(&g.id, crate::goal::GoalStatus::Paused, g.updated_at)
+                .await
+            {
+                Ok(_) => {
+                    let _ = accounting.refresh().await;
+                    Ok(format!("Goal [{}] paused.", &g.id[..8]))
+                }
+                Err(crate::goal::store::GoalError::StaleUpdate(_)) => {
+                    let current = accounting.get_active().await.ok().flatten();
+                    Ok(format!(
+                        "Goal state changed concurrently. Current: {}",
+                        current.map_or_else(|| "none".into(), |g| g.status.to_string())
+                    ))
+                }
+                Err(e) => Ok(format!("Pause failed: {e}")),
+            }
+        }
+        Ok(None) => Ok("No active goal to pause.".to_owned()),
+        Err(e) => Ok(format!("Failed: {e}")),
+    }
+}
+
+async fn goal_resume(
+    accounting: &GoalAccounting,
+    store: &GoalStore,
+) -> Result<String, CommandError> {
+    let goals = store.list(10).await.unwrap_or_default();
+    let paused = goals
+        .into_iter()
+        .find(|g| g.status == crate::goal::GoalStatus::Paused);
+    match paused {
+        Some(g) => {
+            match store
+                .transition(&g.id, crate::goal::GoalStatus::Active, g.updated_at)
+                .await
+            {
+                Ok(_) => {
+                    let _ = accounting.refresh().await;
+                    Ok(format!("Goal [{}] resumed: {}", &g.id[..8], g.text))
+                }
+                Err(crate::goal::store::GoalError::StaleUpdate(_)) => {
+                    Ok("Goal state changed concurrently — please retry.".to_owned())
+                }
+                Err(e) => Ok(format!("Resume failed: {e}")),
+            }
+        }
+        None => Ok("No paused goal to resume.".to_owned()),
+    }
+}
+
+async fn goal_complete(
+    accounting: &GoalAccounting,
+    store: &GoalStore,
+) -> Result<String, CommandError> {
+    match accounting.get_active().await {
+        Ok(Some(g)) => {
+            match store
+                .transition(&g.id, crate::goal::GoalStatus::Completed, g.updated_at)
+                .await
+            {
+                Ok(_) => {
+                    let _ = accounting.refresh().await;
+                    Ok(format!("Goal [{}] marked complete.", &g.id[..8]))
+                }
+                Err(e) => Ok(format!("Complete failed: {e}")),
+            }
+        }
+        Ok(None) => Ok("No active goal.".to_owned()),
+        Err(e) => Ok(format!("Failed: {e}")),
+    }
+}
+
+async fn goal_clear(
+    accounting: &GoalAccounting,
+    store: &GoalStore,
+) -> Result<String, CommandError> {
+    let goals = store.list(10).await.unwrap_or_default();
+    let target = goals.into_iter().find(|g| {
+        g.status == crate::goal::GoalStatus::Active || g.status == crate::goal::GoalStatus::Paused
+    });
+    match target {
+        Some(g) => {
+            match store
+                .transition(&g.id, crate::goal::GoalStatus::Cleared, g.updated_at)
+                .await
+            {
+                Ok(_) => {
+                    let _ = accounting.refresh().await;
+                    Ok(format!("Goal [{}] cleared.", &g.id[..8]))
+                }
+                Err(e) => Ok(format!("Clear failed: {e}")),
+            }
+        }
+        None => Ok("No active or paused goal to clear.".to_owned()),
+    }
+}
+
+async fn goal_list(store: &GoalStore) -> Result<String, CommandError> {
+    let goals = store.list(20).await.unwrap_or_default();
+    if goals.is_empty() {
+        return Ok("No goals recorded.".to_owned());
+    }
+    let mut out = String::from("Goals:\n");
+    for g in goals {
+        let _ = std::fmt::Write::write_fmt(
+            &mut out,
+            format_args!(
+                "  {} [{}] {} — {} turns\n",
+                g.status.badge_symbol(),
+                &g.id[..8],
+                g.text,
+                g.turns_used
+            ),
+        );
+    }
+    Ok(out.trim_end().to_owned())
+}
+
+fn parse_goal_create_args(args: &str) -> (&str, Option<u64>) {
+    if let Some(pos) = args.find("--budget") {
+        let text = args[..pos].trim();
+        let rest = args[pos + "--budget".len()..].trim();
+        let budget = rest
+            .split_whitespace()
+            .next()
+            .and_then(|s| s.parse::<u64>().ok());
+        (text, budget)
+    } else {
+        (args, None)
+    }
 }
 
 /// Convert `AgentError` to `CommandError` for the trait boundary.

--- a/crates/zeph-core/src/agent/autodream.rs
+++ b/crates/zeph-core/src/agent/autodream.rs
@@ -106,30 +106,7 @@ impl<C: Channel> super::Agent<C> {
             .as_ref()
             .map(|tx| tx.send("Consolidating memories…".into()));
 
-        // Resolve provider: use consolidation_provider if named, else fall back to primary.
-        let provider = if cfg.consolidation_provider.is_empty() {
-            self.provider.clone()
-        } else if let (Some(entry), Some(snapshot)) = (
-            self.runtime
-                .providers
-                .provider_pool
-                .iter()
-                .find(|e| e.name.as_deref() == Some(cfg.consolidation_provider.as_str())),
-            self.runtime.providers.provider_config_snapshot.as_ref(),
-        ) {
-            crate::provider_factory::build_provider_for_switch(entry, snapshot).unwrap_or_else(
-                |e| {
-                    tracing::warn!(
-                        provider = cfg.consolidation_provider.as_str(),
-                        error = %e,
-                        "autoDream: failed to build consolidation_provider, falling back"
-                    );
-                    self.provider.clone()
-                },
-            )
-        } else {
-            self.provider.clone()
-        };
+        let provider = self.resolve_consolidation_provider(&cfg.consolidation_provider);
 
         let store = memory.sqlite().clone();
         let consolidation_cfg = zeph_memory::ConsolidationConfig {
@@ -174,6 +151,44 @@ impl<C: Channel> super::Agent<C> {
                     "autoDream: consolidation timed out"
                 );
             }
+        }
+
+        self.flush_taco_hit_counts().await;
+    }
+
+    async fn flush_taco_hit_counts(&self) {
+        if let Some(ref compressor) = self.services.taco_compressor
+            && let Err(e) = compressor.flush_hit_counts().await
+        {
+            tracing::warn!(error = %e, "autoDream: TACO flush_hit_counts failed");
+        }
+    }
+
+    /// Resolve the consolidation provider by name, falling back to the primary provider.
+    fn resolve_consolidation_provider(&self, name: &str) -> zeph_llm::any::AnyProvider {
+        if name.is_empty() {
+            return self.provider.clone();
+        }
+        if let (Some(entry), Some(snapshot)) = (
+            self.runtime
+                .providers
+                .provider_pool
+                .iter()
+                .find(|e| e.name.as_deref() == Some(name)),
+            self.runtime.providers.provider_config_snapshot.as_ref(),
+        ) {
+            crate::provider_factory::build_provider_for_switch(entry, snapshot).unwrap_or_else(
+                |e| {
+                    tracing::warn!(
+                        provider = name,
+                        error = %e,
+                        "autoDream: failed to build consolidation_provider, falling back"
+                    );
+                    self.provider.clone()
+                },
+            )
+        } else {
+            self.provider.clone()
         }
     }
 }

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1920,6 +1920,7 @@ impl<C: Channel> Agent<C> {
             secrets,
             recap,
             loop_min_interval_secs,
+            goal_config,
         } = cfg;
 
         self.tool_orchestrator.apply_config(
@@ -1983,6 +1984,12 @@ impl<C: Channel> Agent<C> {
         self.runtime.config.budget_hint_enabled = budget_hint_enabled;
         self.runtime.config.recap_config = recap;
         self.runtime.config.loop_min_interval_secs = loop_min_interval_secs;
+        self.runtime.config.goals = crate::agent::state::GoalRuntimeConfig {
+            enabled: goal_config.enabled,
+            max_text_chars: goal_config.max_text_chars,
+            default_token_budget: goal_config.default_token_budget.unwrap_or(0),
+            inject_into_system_prompt: goal_config.inject_into_system_prompt,
+        };
 
         self.runtime.debug.reasoning_model_warning = anomaly_config.reasoning_model_warning;
         if anomaly_config.enabled {
@@ -2123,6 +2130,29 @@ impl<C: Channel> Agent<C> {
         engine: Option<std::sync::Arc<zeph_memory::compression::promotion::PromotionEngine>>,
     ) -> Self {
         self.services.promotion_engine = engine;
+        self
+    }
+
+    /// Wire the TACO [`zeph_tools::RuleBasedCompressor`] for hit-count flushing during
+    /// `maybe_autodream`. Set to `None` when `[tools.compression] enabled = false`.
+    #[must_use]
+    pub fn with_taco_compressor(
+        mut self,
+        compressor: Option<std::sync::Arc<zeph_tools::RuleBasedCompressor>>,
+    ) -> Self {
+        self.services.taco_compressor = compressor;
+        self
+    }
+
+    /// Wire the [`crate::goal::GoalAccounting`] service for per-turn token accounting (G4).
+    ///
+    /// Set to `None` when `[goals] enabled = false`.
+    #[must_use]
+    pub fn with_goal_accounting(
+        mut self,
+        accounting: Option<std::sync::Arc<crate::goal::GoalAccounting>>,
+    ) -> Self {
+        self.services.goal_accounting = accounting;
         self
     }
 }

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -1078,6 +1078,10 @@ impl<C: Channel> Agent<C> {
         // do not invalidate the stable/semi-stable cache blocks (S2 fix).
         self.inject_learned_preferences(&mut system_prompt).await;
 
+        // Inject active goal block (G3 invariant: appears after <!-- cache:volatile -->).
+        // Only injected when goal tracking is enabled and an active goal exists.
+        self.inject_active_goal(&mut system_prompt).await;
+
         // If memory_save was used this session, remind the model to use memory_search
         // (not search_code) to recall user-provided facts (#2475).
         if self
@@ -1133,6 +1137,63 @@ impl<C: Channel> Agent<C> {
             msg.content = system_prompt;
         }
     }
+
+    /// Inject the active goal into the volatile system-prompt region (G3 invariant).
+    ///
+    /// Appends an `<active_goal>` XML block only when all conditions are met:
+    /// 1. `[goals] enabled = true`
+    /// 2. `[goals] inject_into_system_prompt = true`
+    /// 3. A goal with status `Active` exists in the database.
+    ///
+    /// No empty XML is emitted. The block always appears after `<!-- cache:volatile -->`.
+    pub(in crate::agent) async fn inject_active_goal(&mut self, prompt: &mut String) {
+        if !self.runtime.config.goals.enabled
+            || !self.runtime.config.goals.inject_into_system_prompt
+        {
+            return;
+        }
+        let Some(accounting) = self.services.goal_accounting.as_ref() else {
+            return;
+        };
+        let snap = accounting.snapshot();
+        // snapshot() returns None for non-Active goals; do nothing if paused/cleared.
+        let Some(snap) = snap else { return };
+        // If the cached snapshot has no text, fetch from DB.
+        let text = if snap.text.is_empty() {
+            match accounting.get_active().await {
+                Ok(Some(g)) => g.text,
+                _ => return,
+            }
+        } else {
+            snap.text
+        };
+        // Guard against prompt injection: reject goal text that contains the closing tag.
+        if text.contains("</active_goal>") {
+            tracing::warn!(goal_id = %snap.id, "inject_active_goal: rejected — goal text contains closing tag");
+            return;
+        }
+        let safe_text = html_escape_goal(&text);
+        drop(tracing::info_span!("core.context.inject_goal", goal_id = %snap.id).entered());
+        prompt.push_str("\n\n<active_goal id=\"");
+        prompt.push_str(&snap.id);
+        prompt.push_str("\">\n");
+        prompt.push_str(&safe_text);
+        prompt.push_str("\n</active_goal>");
+    }
+}
+
+/// HTML-escape `<`, `>`, and `&` in goal text to prevent prompt injection.
+fn html_escape_goal(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for ch in text.chars() {
+        match ch {
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '&' => out.push_str("&amp;"),
+            c => out.push(c),
+        }
+    }
+    out
 }
 
 // ── Test-only integration bridges ─────────────────────────────────────────────

--- a/crates/zeph-core/src/agent/context/tests/prompt_tooling_summary_tests.rs
+++ b/crates/zeph-core/src/agent/context/tests/prompt_tooling_summary_tests.rs
@@ -1483,3 +1483,82 @@ async fn fetch_graph_facts_returns_some_with_entities_and_has_prefix() {
 // but tests in this file call it via its alias to avoid conflicts.
 #[allow(unused_imports)]
 use crate::agent::context::chunk_messages;
+
+// ── G3: active_goal appears after <!-- cache:volatile --> ──────────────────────
+
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+async fn goal_test_store() -> crate::goal::GoalStore {
+    let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
+    sqlx::query(
+        "CREATE TABLE zeph_goals (\
+         id TEXT PRIMARY KEY, text TEXT NOT NULL, \
+         status TEXT NOT NULL DEFAULT 'active' \
+         CHECK (status IN ('active','paused','completed','cleared')), \
+         token_budget INTEGER, turns_used INTEGER NOT NULL DEFAULT 0, \
+         tokens_used INTEGER NOT NULL DEFAULT 0, \
+         created_at TEXT NOT NULL, updated_at TEXT NOT NULL, completed_at TEXT)",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "CREATE UNIQUE INDEX idx_goal_single_active ON zeph_goals(status) WHERE status = 'active'",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    crate::goal::GoalStore::new(std::sync::Arc::new(pool))
+}
+
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+#[tokio::test]
+async fn g3_active_goal_appears_after_volatile_marker() {
+    use crate::goal::GoalAccounting;
+    use std::sync::Arc;
+
+    let store = goal_test_store().await;
+    store
+        .create("Implement /goal lifecycle", None, 2000)
+        .await
+        .unwrap();
+
+    let accounting = Arc::new(GoalAccounting::new(Arc::new(store)));
+    accounting.refresh().await.unwrap();
+
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
+        .with_context_budget(10_000, 0.80, 0.75, 2, 0);
+
+    // Enable goal injection.
+    agent.runtime.config.goals.enabled = true;
+    agent.runtime.config.goals.inject_into_system_prompt = true;
+    agent.services.goal_accounting = Some(Arc::clone(&accounting));
+
+    agent.rebuild_system_prompt("test goal injection").await;
+
+    // G3 invariant: <active_goal appears after <!-- cache:volatile -->.
+    let system_msg = agent
+        .msg
+        .messages
+        .first()
+        .expect("system message must exist");
+    let content = system_msg.content.clone();
+    let volatile_pos = content
+        .find("<!-- cache:volatile -->")
+        .expect("<!-- cache:volatile --> must be present");
+    let goal_pos = content
+        .find("<active_goal")
+        .expect("<active_goal> must be injected when goal is active");
+    assert!(
+        goal_pos > volatile_pos,
+        "<active_goal> (pos {goal_pos}) must appear AFTER <!-- cache:volatile --> (pos {volatile_pos})"
+    );
+    assert!(
+        content.contains("Implement /goal lifecycle"),
+        "goal text must appear in system prompt"
+    );
+}

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -280,10 +280,12 @@ impl<C: Channel> Agent<C> {
             focus: focus::FocusState::default(),
             sidequest: sidequest::SidequestState::default(),
             tool_state: ToolState::default(),
+            goal_accounting: None,
             #[cfg(feature = "self-check")]
             quality: None,
             proactive_explorer: None,
             promotion_engine: None,
+            taco_compressor: None,
         };
 
         let runtime = AgentRuntime {
@@ -1023,6 +1025,7 @@ impl<C: Channel> Agent<C> {
                     agent_cmd::AgentCommand,
                     compaction::{CompactCommand, NewConversationCommand, RecapCommand},
                     experiment::ExperimentCommand,
+                    goal::GoalCommand,
                     loop_cmd::LoopCommand,
                     lsp::LspCommand,
                     mcp::McpCommand,
@@ -1072,6 +1075,7 @@ impl<C: Channel> Agent<C> {
                 agent_reg.register(AcpCommand);
                 agent_reg.register(TrajectoryCommand);
                 agent_reg.register(ScopeCommand);
+                agent_reg.register(GoalCommand);
 
                 let mut ctx = zeph_commands::CommandContext {
                     sink: &mut agent_null_sink,
@@ -1447,7 +1451,7 @@ impl<C: Channel> Agent<C> {
             .debug
             .start_iteration_span(turn_idx, t.input.text.trim());
 
-        let result = self.process_user_message_inner(&mut t).await;
+        let result = Box::pin(self.process_user_message_inner(&mut t)).await;
 
         // Close iteration span regardless of outcome (partial trace preserved on error).
         let span_status = if result.is_ok() {
@@ -1468,6 +1472,13 @@ impl<C: Channel> Agent<C> {
         turn: &mut turn::Turn,
     ) -> Result<(), error::AgentError> {
         self.reap_background_tasks_and_update_metrics();
+
+        let tokens_before_turn = self
+            .runtime
+            .metrics
+            .metrics_tx
+            .as_ref()
+            .map_or(0, |tx| tx.borrow().total_tokens);
 
         // Drain any background shell completions that arrived since the last turn.
         // They are buffered in `pending_background_completions` and merged with the
@@ -1593,6 +1604,8 @@ impl<C: Channel> Agent<C> {
         let _ = self.channel.flush_chunks().await;
 
         self.maybe_fire_completion_notification(turn, turn_had_error);
+
+        self.flush_goal_accounting(tokens_before_turn);
 
         // Collect llm_chat_ms and tool_exec_ms from MetricsState.pending_timings (accumulated
         // by the tool execution chain) into turn.metrics so end_turn can flush them.
@@ -1761,6 +1774,40 @@ impl<C: Channel> Agent<C> {
                     }
                 },
             );
+        }
+    }
+
+    /// Publish the active goal snapshot to `MetricsSnapshot` and fire `on_turn_complete`
+    /// accounting as a tracked background task.
+    fn flush_goal_accounting(&mut self, tokens_before: u64) {
+        let goal_snap = self
+            .services
+            .goal_accounting
+            .as_ref()
+            .and_then(|a| a.snapshot());
+        self.update_metrics(|m| m.active_goal = goal_snap);
+
+        if let Some(ref accounting) = self.services.goal_accounting {
+            let tokens_after = self
+                .runtime
+                .metrics
+                .metrics_tx
+                .as_ref()
+                .map_or(0, |tx| tx.borrow().total_tokens);
+            let turn_tokens = tokens_after.saturating_sub(tokens_before);
+            let mut spawned: Option<
+                std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'static>>,
+            > = None;
+            accounting.on_turn_complete(turn_tokens, |fut| {
+                spawned = Some(fut);
+            });
+            if let Some(fut) = spawned {
+                let _ = self.runtime.lifecycle.supervisor.spawn(
+                    agent_supervisor::TaskClass::Telemetry,
+                    "goal-accounting",
+                    fut,
+                );
+            }
         }
     }
 

--- a/crates/zeph-core/src/agent/session_config.rs
+++ b/crates/zeph-core/src/agent/session_config.rs
@@ -110,6 +110,9 @@ pub struct AgentSessionConfig {
     /// Minimum allowed `/loop` tick interval in seconds. From `[cli.loop] min_interval_secs`.
     pub loop_min_interval_secs: u64,
 
+    /// Long-horizon goal lifecycle configuration.
+    pub goal_config: zeph_config::GoalConfig,
+
     /// Custom secrets from config.
     ///
     /// Stored as `Arc` because `Secret` intentionally does not implement `Clone` —
@@ -183,6 +186,7 @@ impl AgentSessionConfig {
                 .into(),
             recap: config.session.recap.clone(),
             loop_min_interval_secs: config.cli.loop_.min_interval_secs,
+            goal_config: config.goals.clone(),
         }
     }
 }
@@ -283,5 +287,7 @@ mod tests {
         assert_eq!(sc.secrets.len(), config.secrets.custom.len());
         assert_eq!(sc.recap.on_resume, config.session.recap.on_resume);
         assert_eq!(sc.recap.max_tokens, config.session.recap.max_tokens);
+        assert_eq!(sc.goal_config.enabled, config.goals.enabled);
+        assert_eq!(sc.goal_config.max_text_chars, config.goals.max_text_chars);
     }
 }

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -276,6 +276,8 @@ pub(crate) struct RuntimeConfig {
     /// Controlled by `[session] provider_persistence = true` (the default). When `false`,
     /// the stored provider preference is never read or written.
     pub(crate) provider_persistence_enabled: bool,
+    /// Goal lifecycle feature configuration.
+    pub(crate) goals: GoalRuntimeConfig,
 }
 
 /// Groups feedback detection subsystems: correction detector, judge detector, and LLM classifier.
@@ -937,6 +939,30 @@ impl Default for FeedbackState {
     }
 }
 
+/// Goal lifecycle feature configuration stored in `RuntimeConfig`.
+#[derive(Debug, Clone)]
+pub(crate) struct GoalRuntimeConfig {
+    /// Whether goal tracking is enabled.
+    pub(crate) enabled: bool,
+    /// Maximum allowed length (in Unicode chars) of goal text at creation.
+    pub(crate) max_text_chars: usize,
+    /// Default token budget for new goals (0 = unlimited).
+    pub(crate) default_token_budget: u64,
+    /// Whether to inject the active goal block into the volatile system prompt region.
+    pub(crate) inject_into_system_prompt: bool,
+}
+
+impl Default for GoalRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            max_text_chars: 2000,
+            default_token_budget: 0,
+            inject_into_system_prompt: true,
+        }
+    }
+}
+
 impl Default for RuntimeConfig {
     fn default() -> Self {
         Self {
@@ -967,6 +993,7 @@ impl Default for RuntimeConfig {
             acp_subagent_spawn_fn: None,
             channel_type: String::new(),
             provider_persistence_enabled: true,
+            goals: GoalRuntimeConfig::default(),
         }
     }
 }

--- a/crates/zeph-core/src/agent/state/services.rs
+++ b/crates/zeph-core/src/agent/state/services.rs
@@ -35,6 +35,9 @@ pub(crate) struct Services {
     pub(crate) tool_state: ToolState,
 
     // Optional service singletons
+    /// Goal lifecycle store and accounting, initialised at startup when `[goals] enabled = true`.
+    pub(crate) goal_accounting: Option<std::sync::Arc<crate::goal::GoalAccounting>>,
+
     /// MARCH self-check pipeline, built at startup and rebuilt on provider swap.
     #[cfg(feature = "self-check")]
     pub(crate) quality: Option<std::sync::Arc<crate::quality::SelfCheckPipeline>>,
@@ -48,4 +51,9 @@ pub(crate) struct Services {
     /// `Some` when `config.memory.compression_spectrum.enabled = true`.
     pub(crate) promotion_engine:
         Option<std::sync::Arc<zeph_memory::compression::promotion::PromotionEngine>>,
+
+    /// TACO rule-based compressor, kept alive for hit-count flushing during `maybe_autodream`.
+    ///
+    /// `Some` when `config.tools.compression.enabled = true` and a DB pool is available.
+    pub(crate) taco_compressor: Option<std::sync::Arc<zeph_tools::RuleBasedCompressor>>,
 }

--- a/crates/zeph-core/src/agent/state/tests.rs
+++ b/crates/zeph-core/src/agent/state/tests.rs
@@ -98,6 +98,7 @@ fn make_runtime_config() -> RuntimeConfig {
         acp_subagent_spawn_fn: None,
         channel_type: String::new(),
         provider_persistence_enabled: true,
+        goals: crate::agent::state::GoalRuntimeConfig::default(),
     }
 }
 

--- a/crates/zeph-core/src/goal/accounting.rs
+++ b/crates/zeph-core/src/goal/accounting.rs
@@ -1,0 +1,311 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Per-turn goal token accounting (G4).
+//!
+//! `GoalAccounting` is the bridge between the agent loop and `GoalStore`. It caches
+//! the active goal ID in memory to avoid a round-trip on every turn when no goal is
+//! active, and dispatches `record_turn` as a fire-and-forget background task tracked
+//! by the agent supervisor.
+
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+
+use super::{Goal, GoalSnapshot, GoalStatus, GoalStore, store::GoalError};
+
+/// Cached state for the current active goal.
+struct CachedGoal {
+    id: String,
+    text: String,
+    status: GoalStatus,
+    token_budget: Option<u64>,
+}
+
+/// Per-turn token accounting service for the active long-horizon goal.
+///
+/// Wraps `GoalStore` with an in-memory cache of the active goal ID so that
+/// turns without an active goal incur no database round-trips.
+///
+/// # Invariant (G4)
+///
+/// `on_turn_complete` is fire-and-forget. A DB write failure logs `WARN` and never
+/// aborts the turn. Budget exhaustion auto-pauses the goal via a best-effort
+/// background task.
+pub struct GoalAccounting {
+    store: Arc<GoalStore>,
+    cached: Mutex<Option<CachedGoal>>,
+}
+
+impl GoalAccounting {
+    /// Create a new `GoalAccounting` backed by `store`.
+    #[must_use]
+    pub fn new(store: Arc<GoalStore>) -> Self {
+        Self {
+            store,
+            cached: Mutex::new(None),
+        }
+    }
+
+    /// Refresh the in-memory cache from the database.
+    ///
+    /// Call this after every `/goal` command to ensure the cache reflects the
+    /// latest state before the next turn.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GoalError`] if the database query fails.
+    pub async fn refresh(&self) -> Result<(), GoalError> {
+        let active = self.store.active().await?;
+        let mut guard = self.cached.lock();
+        *guard = active.map(|g| CachedGoal {
+            id: g.id,
+            text: g.text,
+            status: g.status,
+            token_budget: g.token_budget.map(|b| b.max(0).cast_unsigned()),
+        });
+        Ok(())
+    }
+
+    /// Build a lightweight snapshot of the cached active goal, if any.
+    ///
+    /// Returns `None` when no goal is active (the goal was cleared, completed,
+    /// paused, or never created).
+    pub fn snapshot(&self) -> Option<GoalSnapshot> {
+        let guard = self.cached.lock();
+        let cached = guard.as_ref()?;
+        if cached.status != GoalStatus::Active {
+            return None;
+        }
+        Some(GoalSnapshot {
+            id: cached.id.clone(),
+            text: cached.text.clone(),
+            status: cached.status,
+            turns_used: 0,
+            tokens_used: 0,
+            token_budget: cached.token_budget,
+        })
+    }
+
+    /// Notify the accounting service that a turn completed, consuming `turn_tokens` tokens.
+    ///
+    /// If no active goal is cached, this is a cheap no-op (no DB access).
+    ///
+    /// When a token budget is set and exceeded, the goal is auto-paused via a
+    /// best-effort background task.
+    ///
+    /// Background tasks are spawned via the provided closure so the caller controls
+    /// how they are tracked (typically via the agent supervisor).
+    pub fn on_turn_complete(
+        &self,
+        turn_tokens: u64,
+        spawn_bg: impl FnOnce(std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'static>>),
+    ) {
+        let goal_id = {
+            let guard = self.cached.lock();
+            let Some(cached) = guard.as_ref() else { return };
+            if cached.status != GoalStatus::Active {
+                return;
+            }
+            cached.id.clone()
+        };
+
+        let store = Arc::clone(&self.store);
+
+        spawn_bg(Box::pin(async move {
+            match store.record_turn(&goal_id, turn_tokens).await {
+                Ok(updated) => {
+                    tracing::debug!(
+                        goal_id = %goal_id,
+                        turns_used = updated.turns_used,
+                        tokens_used = updated.tokens_used,
+                        "goal accounting: turn recorded"
+                    );
+                    // Auto-pause when token budget exceeded.
+                    if let (Some(budget), tokens_used) = (
+                        updated.token_budget,
+                        updated.tokens_used.max(0).cast_unsigned(),
+                    ) {
+                        let budget = budget.max(0).cast_unsigned();
+                        if tokens_used >= budget {
+                            tracing::warn!(
+                                goal_id = %goal_id,
+                                tokens_used,
+                                budget,
+                                "goal token budget exhausted — auto-pausing"
+                            );
+                            match store
+                                .transition(&goal_id, GoalStatus::Paused, updated.updated_at)
+                                .await
+                            {
+                                Ok(_) => {}
+                                Err(GoalError::StaleUpdate(_)) => {
+                                    tracing::warn!(
+                                        goal_id = %goal_id,
+                                        "goal auto-pause skipped: concurrent modification (stale update)"
+                                    );
+                                }
+                                Err(e) => {
+                                    tracing::warn!(goal_id = %goal_id, error = %e, "goal auto-pause failed");
+                                }
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(goal_id = %goal_id, error = %e, "goal accounting: record_turn failed");
+                }
+            }
+        }));
+    }
+
+    /// Return a full `Goal` from the store for a given id.
+    ///
+    /// Used by the `/goal status` handler to show live details.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GoalError`] if the database query fails.
+    pub async fn get_active(&self) -> Result<Option<Goal>, GoalError> {
+        self.store.active().await
+    }
+
+    /// Return a reference to the underlying store for direct queries.
+    #[must_use]
+    pub fn get_store(&self) -> Arc<GoalStore> {
+        Arc::clone(&self.store)
+    }
+}
+
+#[cfg(all(test, feature = "sqlite", not(feature = "postgres")))]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+
+    async fn make_store() -> Arc<GoalStore> {
+        let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::query(
+            "CREATE TABLE zeph_goals (\
+             id TEXT PRIMARY KEY, text TEXT NOT NULL, \
+             status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active','paused','completed','cleared')), \
+             token_budget INTEGER, turns_used INTEGER NOT NULL DEFAULT 0, \
+             tokens_used INTEGER NOT NULL DEFAULT 0, \
+             created_at TEXT NOT NULL, updated_at TEXT NOT NULL, completed_at TEXT)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE UNIQUE INDEX idx_zeph_goals_single_active ON zeph_goals(status) WHERE status = 'active'",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        Arc::new(GoalStore::new(Arc::new(pool)))
+    }
+
+    #[tokio::test]
+    async fn snapshot_returns_none_when_no_active_goal() {
+        let store = make_store().await;
+        let accounting = GoalAccounting::new(store);
+        assert!(accounting.snapshot().is_none());
+    }
+
+    #[tokio::test]
+    async fn refresh_populates_cache_from_db() {
+        let store = make_store().await;
+        store.create("buy groceries", None, 400).await.unwrap();
+
+        let accounting = GoalAccounting::new(Arc::clone(&store));
+        assert!(accounting.snapshot().is_none(), "cache starts empty");
+
+        accounting.refresh().await.unwrap();
+        let snap = accounting.snapshot().expect("snapshot after refresh");
+        assert_eq!(snap.text, "buy groceries");
+        assert_eq!(snap.status, GoalStatus::Active);
+    }
+
+    #[tokio::test]
+    async fn snapshot_returns_none_for_paused_goal() {
+        let store = make_store().await;
+        let goal = store.create("do thing", None, 400).await.unwrap();
+        store
+            .transition(&goal.id, GoalStatus::Paused, goal.updated_at)
+            .await
+            .unwrap();
+
+        let accounting = GoalAccounting::new(Arc::clone(&store));
+        accounting.refresh().await.unwrap();
+        // Paused goal should not appear in snapshot.
+        assert!(accounting.snapshot().is_none());
+    }
+
+    #[tokio::test]
+    async fn on_turn_complete_is_noop_when_cache_empty() {
+        let store = make_store().await;
+        let accounting = GoalAccounting::new(store);
+        let mut called = false;
+        accounting.on_turn_complete(100, |_fut| {
+            called = true;
+        });
+        assert!(!called, "spawn_bg must not be called when no active goal");
+    }
+
+    #[tokio::test]
+    async fn on_turn_complete_spawns_background_task() {
+        let store = make_store().await;
+        store.create("active goal", None, 400).await.unwrap();
+
+        let accounting = GoalAccounting::new(Arc::clone(&store));
+        accounting.refresh().await.unwrap();
+
+        let mut fut_received: Option<
+            std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'static>>,
+        > = None;
+        accounting.on_turn_complete(500, |fut| {
+            fut_received = Some(fut);
+        });
+        assert!(
+            fut_received.is_some(),
+            "spawn_bg must be called when active goal exists"
+        );
+
+        // Drive the future to completion.
+        fut_received.unwrap().await;
+
+        // Verify tokens were recorded.
+        let goals = store.list(10).await.unwrap();
+        let active = goals
+            .iter()
+            .find(|g| g.status == GoalStatus::Active)
+            .unwrap();
+        assert_eq!(active.tokens_used, 500);
+        assert_eq!(active.turns_used, 1);
+    }
+
+    #[tokio::test]
+    async fn auto_pause_on_budget_exhaustion() {
+        let store = make_store().await;
+        // Budget of 100 tokens; turn consumes 200.
+        store.create("budget goal", Some(100), 400).await.unwrap();
+
+        let accounting = GoalAccounting::new(Arc::clone(&store));
+        accounting.refresh().await.unwrap();
+
+        let mut fut_received = None;
+        accounting.on_turn_complete(200, |fut| {
+            fut_received = Some(fut);
+        });
+        fut_received.unwrap().await;
+
+        // Goal should now be paused.
+        let goals = store.list(10).await.unwrap();
+        let goal = goals.first().unwrap();
+        assert_eq!(
+            goal.status,
+            GoalStatus::Paused,
+            "goal must be auto-paused when budget exhausted"
+        );
+    }
+}

--- a/crates/zeph-core/src/goal/mod.rs
+++ b/crates/zeph-core/src/goal/mod.rs
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Long-horizon goal lifecycle subsystem.
+//!
+//! A goal is a persistent user intent that spans multiple turns. At most one goal
+//! can be `Active` at a time. The subsystem tracks token consumption per turn and
+//! injects an `<active_goal>` block into the volatile system-prompt region.
+//!
+//! ## Architecture
+//!
+//! - [`GoalStatus`] — FSM states with valid transition table.
+//! - [`Goal`] / [`GoalSnapshot`] — full DB row vs. lightweight cross-crate view.
+//! - [`GoalStore`] — SQLite/Postgres-backed persistence with transactional `create()`.
+//! - [`GoalAccounting`] — per-turn token accounting service.
+//!
+//! ## Invariants
+//!
+//! - **G1**: At most one `Active` goal per database. Enforced jointly by the partial
+//!   unique index and the transactional `GoalStore::create`.
+//! - **G2**: Stale transitions return [`GoalError::StaleUpdate`]; handlers refetch silently.
+//! - **G3**: `<active_goal>` block appears only after `<!-- cache:volatile -->` in the
+//!   system prompt. Enforced by a snapshot test in `context/assembly.rs`.
+//! - **G4**: `GoalAccounting::on_turn_complete` is fire-and-forget. DB write failures
+//!   log a `WARN` and never abort the turn.
+
+mod accounting;
+mod state;
+pub mod store;
+
+pub use accounting::GoalAccounting;
+pub use state::GoalStatus;
+pub use store::{GoalError, GoalStore};
+
+use chrono::{DateTime, Utc};
+
+/// A persisted long-horizon goal row.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Goal {
+    /// Unique identifier (UUID v4 string).
+    pub id: String,
+    /// User-provided goal text (max `[goals] max_text_chars` chars at creation time).
+    pub text: String,
+    /// Current FSM status.
+    pub status: GoalStatus,
+    /// Optional token budget. `None` means unlimited.
+    pub token_budget: Option<i64>,
+    /// Number of conversation turns completed under this goal.
+    pub turns_used: i64,
+    /// Total tokens consumed across all turns under this goal.
+    pub tokens_used: i64,
+    /// When the goal was created.
+    pub created_at: DateTime<Utc>,
+    /// Last mutation time; used as a CAS guard for stale-update detection.
+    pub updated_at: DateTime<Utc>,
+    /// When the goal reached `Completed` or `Cleared`. `None` while active or paused.
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+/// Lightweight, cross-crate snapshot of an active goal.
+///
+/// Carries only what TUI and command handlers need, without pulling `zeph-core` into `zeph-tui`.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct GoalSnapshot {
+    /// UUID string of the goal.
+    pub id: String,
+    /// Goal text, pre-validated to fit within `max_text_chars`.
+    pub text: String,
+    /// Current FSM status.
+    pub status: GoalStatus,
+    /// Number of turns completed.
+    pub turns_used: u64,
+    /// Total tokens consumed.
+    pub tokens_used: u64,
+    /// Optional token budget (`None` = unlimited).
+    pub token_budget: Option<u64>,
+}
+
+impl From<Goal> for GoalSnapshot {
+    fn from(g: Goal) -> Self {
+        Self {
+            id: g.id,
+            text: g.text,
+            status: g.status,
+            turns_used: g.turns_used.max(0).cast_unsigned(),
+            tokens_used: g.tokens_used.max(0).cast_unsigned(),
+            token_budget: g.token_budget.map(|b| b.max(0).cast_unsigned()),
+        }
+    }
+}

--- a/crates/zeph-core/src/goal/state.rs
+++ b/crates/zeph-core/src/goal/state.rs
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Goal status FSM with valid transition table.
+
+/// Status of a long-horizon goal.
+///
+/// Transitions form a directed acyclic graph where `Completed` and `Cleared`
+/// are terminal states. `/goal create` is NOT a transition — it inserts a new row.
+///
+/// ```text
+/// Active ──► Paused ──► Active
+///   │         │
+///   ▼         ▼
+/// Completed  Cleared
+/// Active ──► Completed
+/// Active ──► Cleared
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GoalStatus {
+    /// Goal is being actively tracked and injected into context.
+    Active,
+    /// Goal is paused — not injected into context, resumable.
+    Paused,
+    /// Goal was marked as achieved. Terminal state.
+    Completed,
+    /// Goal was dismissed without completion. Terminal state.
+    Cleared,
+}
+
+impl GoalStatus {
+    /// Return whether `self → to` is a valid FSM transition.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_core::goal::GoalStatus;
+    ///
+    /// assert!(GoalStatus::Active.can_transition_to(GoalStatus::Paused));
+    /// assert!(!GoalStatus::Completed.can_transition_to(GoalStatus::Active));
+    /// ```
+    #[must_use]
+    pub fn can_transition_to(self, to: Self) -> bool {
+        matches!(
+            (self, to),
+            (Self::Active, Self::Paused | Self::Completed | Self::Cleared)
+                | (Self::Paused, Self::Active | Self::Cleared)
+        )
+    }
+
+    /// Return `true` if this status accepts no further transitions.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_core::goal::GoalStatus;
+    ///
+    /// assert!(GoalStatus::Completed.is_terminal());
+    /// assert!(!GoalStatus::Active.is_terminal());
+    /// ```
+    #[must_use]
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Completed | Self::Cleared)
+    }
+
+    /// Short ASCII symbol used in TUI status badge.
+    #[must_use]
+    pub fn badge_symbol(self) -> &'static str {
+        match self {
+            Self::Active => "▶",
+            Self::Paused => "⏸",
+            Self::Completed => "✓",
+            Self::Cleared => "✗",
+        }
+    }
+}
+
+impl std::fmt::Display for GoalStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Active => "active",
+            Self::Paused => "paused",
+            Self::Completed => "completed",
+            Self::Cleared => "cleared",
+        };
+        f.write_str(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_transitions() {
+        assert!(GoalStatus::Active.can_transition_to(GoalStatus::Paused));
+        assert!(GoalStatus::Active.can_transition_to(GoalStatus::Completed));
+        assert!(GoalStatus::Active.can_transition_to(GoalStatus::Cleared));
+        assert!(GoalStatus::Paused.can_transition_to(GoalStatus::Active));
+        assert!(GoalStatus::Paused.can_transition_to(GoalStatus::Cleared));
+    }
+
+    #[test]
+    fn terminal_states_reject_transitions() {
+        for from in [GoalStatus::Completed, GoalStatus::Cleared] {
+            for to in [
+                GoalStatus::Active,
+                GoalStatus::Paused,
+                GoalStatus::Completed,
+                GoalStatus::Cleared,
+            ] {
+                assert!(
+                    !from.can_transition_to(to),
+                    "{from:?} -> {to:?} should be invalid"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn is_terminal() {
+        assert!(GoalStatus::Completed.is_terminal());
+        assert!(GoalStatus::Cleared.is_terminal());
+        assert!(!GoalStatus::Active.is_terminal());
+        assert!(!GoalStatus::Paused.is_terminal());
+    }
+}

--- a/crates/zeph-core/src/goal/store.rs
+++ b/crates/zeph-core/src/goal/store.rs
@@ -1,0 +1,392 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! SQLite/Postgres-backed goal persistence.
+//!
+//! All mutations go through transactions. `create()` uses `BEGIN IMMEDIATE` on `SQLite`
+//! (via [`zeph_db::begin_write`]) to prevent concurrent inserts from violating the
+//! `idx_zeph_goals_single_active` partial unique index.
+
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use zeph_db::DbPool;
+
+use super::{Goal, GoalStatus};
+
+/// Error variants for goal store operations.
+#[derive(Debug, thiserror::Error)]
+pub enum GoalError {
+    /// The requested goal ID does not exist in the store.
+    #[error("goal not found: {0}")]
+    NotFound(String),
+    /// The requested FSM transition is not permitted from the current status.
+    #[error("invalid transition {from:?} -> {to:?}")]
+    InvalidTransition { from: GoalStatus, to: GoalStatus },
+    /// The CAS-guarded update was rejected because `expected_updated_at` did not match.
+    #[error("stale update for goal {0}")]
+    StaleUpdate(String),
+    /// The goal has consumed more tokens than its configured budget allows.
+    #[error("token budget exceeded ({used}/{budget})")]
+    BudgetExceeded { used: u64, budget: u64 },
+    /// The provided goal text exceeds the maximum allowed character length.
+    #[error("goal text exceeds {max} characters")]
+    TextTooLong { max: usize },
+    /// The goal text contains content that would break system-prompt XML structure.
+    #[error("goal text contains forbidden content")]
+    InvalidText,
+    /// A database error occurred during the operation.
+    #[error(transparent)]
+    Db(#[from] zeph_db::SqlxError),
+}
+
+/// Persistence layer for long-horizon goals.
+///
+/// Thin wrapper around [`DbPool`]. All methods are `async` and return typed errors.
+///
+/// # Invariants
+///
+/// - At most one row with `status = 'active'` may exist at any time (enforced by the
+///   `idx_zeph_goals_single_active` partial unique index + transactional `create`).
+/// - Stale transitions (wrong `expected_updated_at`) return [`GoalError::StaleUpdate`].
+///
+/// # TODO(critic): cross-process goal cache invalidation; not handled in v1
+#[derive(Clone)]
+pub struct GoalStore {
+    pool: Arc<DbPool>,
+}
+
+impl GoalStore {
+    /// Construct a `GoalStore` backed by the given pool.
+    #[must_use]
+    pub fn new(pool: Arc<DbPool>) -> Self {
+        Self { pool }
+    }
+
+    /// Create a new goal, atomically pausing any existing `Active` goal in the same transaction.
+    ///
+    /// Uses `BEGIN IMMEDIATE` on `SQLite` / `BEGIN` + `SELECT FOR UPDATE` on Postgres to prevent
+    /// a race between two concurrent `/goal create` calls.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GoalError::TextTooLong`] when `text` exceeds `max_chars`.
+    /// Returns [`GoalError::Db`] on database failure.
+    pub async fn create(
+        &self,
+        text: &str,
+        token_budget: Option<u64>,
+        max_chars: usize,
+    ) -> Result<Goal, GoalError> {
+        if text.chars().count() > max_chars {
+            return Err(GoalError::TextTooLong { max: max_chars });
+        }
+        if text.contains("</active_goal>") {
+            return Err(GoalError::InvalidText);
+        }
+
+        let id = uuid::Uuid::new_v4().to_string();
+        let now = Utc::now();
+        let now_str = now.to_rfc3339();
+        let budget = token_budget.map(u64::cast_signed);
+
+        let mut tx = zeph_db::begin_write(&self.pool).await?;
+
+        // On Postgres, acquire a row-level lock on the active goal (if any) to prevent
+        // a TOCTOU race between two concurrent `/goal create` calls. SQLite uses
+        // BEGIN IMMEDIATE which already serialises writers at the file level.
+        #[cfg(feature = "postgres")]
+        zeph_db::query(zeph_db::sql!(
+            "SELECT id FROM zeph_goals WHERE status = 'active' FOR UPDATE"
+        ))
+        .execute(&mut *tx)
+        .await?;
+
+        // Pause any currently active goal before inserting the new one.
+        zeph_db::query(zeph_db::sql!(
+            "UPDATE zeph_goals SET status = 'paused', updated_at = ? WHERE status = 'active'"
+        ))
+        .bind(&now_str)
+        .execute(&mut *tx)
+        .await?;
+
+        zeph_db::query(zeph_db::sql!(
+            "INSERT INTO zeph_goals (id, text, status, token_budget, turns_used, tokens_used, \
+             created_at, updated_at) VALUES (?, ?, 'active', ?, 0, 0, ?, ?)"
+        ))
+        .bind(&id)
+        .bind(text)
+        .bind(budget)
+        .bind(&now_str)
+        .bind(&now_str)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+
+        self.get(&id).await?.ok_or_else(|| GoalError::NotFound(id))
+    }
+
+    /// Fetch a goal by its UUID string.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GoalError::Db`] on database failure.
+    pub async fn get(&self, id: &str) -> Result<Option<Goal>, GoalError> {
+        let row: Option<GoalRow> = zeph_db::query_as(zeph_db::sql!(
+            "SELECT id, text, status, token_budget, turns_used, tokens_used, \
+             created_at, updated_at, completed_at FROM zeph_goals WHERE id = ?"
+        ))
+        .bind(id)
+        .fetch_optional(self.pool.as_ref())
+        .await?;
+
+        Ok(row.map(GoalRow::into_goal))
+    }
+
+    /// Return the currently active goal, if any.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GoalError::Db`] on database failure.
+    pub async fn active(&self) -> Result<Option<Goal>, GoalError> {
+        // Record span entry; drop guard immediately so non-Send EnteredSpan
+        // does not cross the .await point.
+        drop(tracing::info_span!("core.goal.active").entered());
+        let row: Option<GoalRow> = zeph_db::query_as(zeph_db::sql!(
+            "SELECT id, text, status, token_budget, turns_used, tokens_used, \
+             created_at, updated_at, completed_at FROM zeph_goals WHERE status = 'active' LIMIT 1"
+        ))
+        .fetch_optional(self.pool.as_ref())
+        .await?;
+
+        Ok(row.map(GoalRow::into_goal))
+    }
+
+    /// Return up to `limit` goals ordered by `created_at DESC`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GoalError::Db`] on database failure.
+    pub async fn list(&self, limit: u32) -> Result<Vec<Goal>, GoalError> {
+        let rows: Vec<GoalRow> = zeph_db::query_as(zeph_db::sql!(
+            "SELECT id, text, status, token_budget, turns_used, tokens_used, \
+             created_at, updated_at, completed_at FROM zeph_goals \
+             ORDER BY created_at DESC LIMIT ?"
+        ))
+        .bind(i64::from(limit))
+        .fetch_all(self.pool.as_ref())
+        .await?;
+
+        Ok(rows.into_iter().map(GoalRow::into_goal).collect())
+    }
+
+    /// Attempt a CAS-guarded FSM transition.
+    ///
+    /// Returns [`GoalError::StaleUpdate`] if the goal was concurrently modified (i.e. the
+    /// stored `updated_at` does not match `expected_updated_at`). The caller should refetch
+    /// and report the current state without surfacing an error to the user.
+    ///
+    /// Returns [`GoalError::InvalidTransition`] for non-FSM-allowed transitions.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GoalError::NotFound`], [`GoalError::InvalidTransition`],
+    /// [`GoalError::StaleUpdate`], or [`GoalError::Db`].
+    pub async fn transition(
+        &self,
+        id: &str,
+        to: GoalStatus,
+        expected_updated_at: DateTime<Utc>,
+    ) -> Result<Goal, GoalError> {
+        let goal = self
+            .get(id)
+            .await?
+            .ok_or_else(|| GoalError::NotFound(id.to_owned()))?;
+
+        if !goal.status.can_transition_to(to) {
+            return Err(GoalError::InvalidTransition {
+                from: goal.status,
+                to,
+            });
+        }
+
+        if goal.updated_at != expected_updated_at {
+            return Err(GoalError::StaleUpdate(id.to_owned()));
+        }
+
+        let now = Utc::now();
+        let now_str = now.to_rfc3339();
+        let completed_at = if to.is_terminal() {
+            Some(now_str.clone())
+        } else {
+            None
+        };
+        let to_str = to.to_string();
+
+        let rows_affected = zeph_db::query(zeph_db::sql!(
+            "UPDATE zeph_goals SET status = ?, updated_at = ?, completed_at = ? WHERE id = ? AND updated_at = ?"
+        ))
+        .bind(&to_str)
+        .bind(&now_str)
+        .bind(&completed_at)
+        .bind(id)
+        .bind(expected_updated_at.to_rfc3339())
+        .execute(self.pool.as_ref())
+        .await?
+        .rows_affected();
+
+        if rows_affected == 0 {
+            return Err(GoalError::StaleUpdate(id.to_owned()));
+        }
+
+        self.get(id)
+            .await?
+            .ok_or_else(|| GoalError::NotFound(id.to_owned()))
+    }
+
+    /// Increment `turns_used` by 1 and `tokens_used` by `turn_tokens`.
+    ///
+    /// Called once per turn by [`crate::goal::GoalAccounting::on_turn_complete`]. Returns the updated goal.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GoalError::Db`] on database failure.
+    pub async fn record_turn(&self, id: &str, turn_tokens: u64) -> Result<Goal, GoalError> {
+        let now_str = Utc::now().to_rfc3339();
+        let tokens = turn_tokens.cast_signed();
+
+        zeph_db::query(zeph_db::sql!(
+            "UPDATE zeph_goals SET turns_used = turns_used + 1, \
+             tokens_used = tokens_used + ?, updated_at = ? WHERE id = ? AND status = 'active'"
+        ))
+        .bind(tokens)
+        .bind(&now_str)
+        .bind(id)
+        .execute(self.pool.as_ref())
+        .await?;
+
+        self.get(id)
+            .await?
+            .ok_or_else(|| GoalError::NotFound(id.to_owned()))
+    }
+}
+
+/// Raw sqlx row projection matching `SELECT` column order in all queries above.
+#[derive(sqlx::FromRow)]
+struct GoalRow {
+    id: String,
+    text: String,
+    status: String,
+    token_budget: Option<i64>,
+    turns_used: i64,
+    tokens_used: i64,
+    created_at: String,
+    updated_at: String,
+    completed_at: Option<String>,
+}
+
+fn parse_dt(s: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(s).map_or_else(|_| Utc::now(), |dt| dt.with_timezone(&Utc))
+}
+
+impl GoalRow {
+    fn into_goal(self) -> Goal {
+        let status = match self.status.as_str() {
+            "paused" => GoalStatus::Paused,
+            "completed" => GoalStatus::Completed,
+            "cleared" => GoalStatus::Cleared,
+            _ => GoalStatus::Active,
+        };
+        Goal {
+            id: self.id,
+            text: self.text,
+            status,
+            token_budget: self.token_budget,
+            turns_used: self.turns_used,
+            tokens_used: self.tokens_used,
+            created_at: parse_dt(&self.created_at),
+            updated_at: parse_dt(&self.updated_at),
+            completed_at: self.completed_at.as_deref().map(parse_dt),
+        }
+    }
+}
+
+#[cfg(all(test, feature = "sqlite", not(feature = "postgres")))]
+mod tests {
+    use super::*;
+
+    async fn in_memory_store() -> GoalStore {
+        let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::query(
+            "CREATE TABLE zeph_goals (\
+             id TEXT PRIMARY KEY, text TEXT NOT NULL, \
+             status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active','paused','completed','cleared')), \
+             token_budget INTEGER, turns_used INTEGER NOT NULL DEFAULT 0, \
+             tokens_used INTEGER NOT NULL DEFAULT 0, \
+             created_at TEXT NOT NULL, updated_at TEXT NOT NULL, completed_at TEXT)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE UNIQUE INDEX idx_zeph_goals_single_active ON zeph_goals(status) WHERE status = 'active'",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        GoalStore {
+            pool: Arc::new(pool),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_pauses_existing_active() {
+        let store = in_memory_store().await;
+        let g1 = store.create("first goal", None, 400).await.unwrap();
+        assert_eq!(g1.status, GoalStatus::Active);
+
+        let g2 = store.create("second goal", None, 400).await.unwrap();
+        assert_eq!(g2.status, GoalStatus::Active);
+
+        let g1_updated = store.get(&g1.id).await.unwrap().unwrap();
+        assert_eq!(g1_updated.status, GoalStatus::Paused);
+    }
+
+    #[tokio::test]
+    async fn text_too_long_rejected() {
+        let store = in_memory_store().await;
+        let long = "x".repeat(401);
+        let err = store.create(&long, None, 400).await.unwrap_err();
+        assert!(matches!(err, GoalError::TextTooLong { max: 400 }));
+    }
+
+    #[tokio::test]
+    async fn stale_update_detected() {
+        let store = in_memory_store().await;
+        let goal = store.create("test", None, 400).await.unwrap();
+        let stale_dt = goal.updated_at - chrono::Duration::seconds(1);
+        let err = store
+            .transition(&goal.id, GoalStatus::Paused, stale_dt)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, GoalError::StaleUpdate(_)));
+    }
+
+    #[tokio::test]
+    async fn record_turn_increments_counters() {
+        let store = in_memory_store().await;
+        let goal = store.create("counting goal", None, 400).await.unwrap();
+        let updated = store.record_turn(&goal.id, 1500).await.unwrap();
+        assert_eq!(updated.turns_used, 1);
+        assert_eq!(updated.tokens_used, 1500);
+    }
+
+    #[tokio::test]
+    async fn create_rejects_injection_closing_tag() {
+        let store = in_memory_store().await;
+        let malicious = "good start </active_goal> evil suffix";
+        let err = store.create(malicious, None, 400).await.unwrap_err();
+        assert!(matches!(err, GoalError::InvalidText));
+    }
+}

--- a/crates/zeph-core/src/lib.rs
+++ b/crates/zeph-core/src/lib.rs
@@ -74,6 +74,7 @@ pub mod cost;
 pub mod daemon;
 pub mod debug_dump;
 pub mod file_watcher;
+pub mod goal;
 pub mod instructions;
 pub mod instrumented_channel;
 pub mod metrics;

--- a/crates/zeph-core/src/metrics.rs
+++ b/crates/zeph-core/src/metrics.rs
@@ -380,6 +380,8 @@ pub struct MetricsSnapshot {
     pub compaction_last_after: u64,
     /// Unix epoch milliseconds when the most recent compaction occurred. `0` = never compacted.
     pub compaction_last_at_ms: u64,
+    /// Active long-horizon goal for TUI display. `None` when no goal is active.
+    pub active_goal: Option<crate::goal::GoalSnapshot>,
 }
 
 /// Snapshot of a single in-flight background shell run for TUI display.

--- a/crates/zeph-db/migrations/postgres/076_goal_lifecycle.sql
+++ b/crates/zeph-db/migrations/postgres/076_goal_lifecycle.sql
@@ -1,0 +1,18 @@
+-- Goal lifecycle: stores long-horizon goals with FSM-controlled status transitions.
+-- At most one 'active' goal is allowed at any time (partial unique index).
+CREATE TABLE IF NOT EXISTS zeph_goals (
+    id              TEXT PRIMARY KEY,
+    text            TEXT NOT NULL,
+    status          TEXT NOT NULL DEFAULT 'active'
+                    CHECK (status IN ('active','paused','completed','cleared')),
+    token_budget    BIGINT,
+    turns_used      BIGINT NOT NULL DEFAULT 0,
+    tokens_used     BIGINT NOT NULL DEFAULT 0,
+    created_at      TIMESTAMPTZ NOT NULL,
+    updated_at      TIMESTAMPTZ NOT NULL,
+    completed_at    TIMESTAMPTZ
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_zeph_goals_single_active
+    ON zeph_goals(status) WHERE status = 'active';
+CREATE INDEX IF NOT EXISTS idx_zeph_goals_status_created
+    ON zeph_goals(status, created_at);

--- a/crates/zeph-db/migrations/postgres/077_compression_rules.sql
+++ b/crates/zeph-db/migrations/postgres/077_compression_rules.sql
@@ -1,0 +1,17 @@
+-- TACO self-evolving compression rules.
+-- Rules apply regex patterns to tool outputs with optional glob matching on tool name.
+CREATE TABLE IF NOT EXISTS compression_rules (
+    id                    TEXT PRIMARY KEY,
+    tool_glob             TEXT,
+    pattern               TEXT NOT NULL,
+    replacement_template  TEXT NOT NULL,
+    hit_count             BIGINT NOT NULL DEFAULT 0,
+    source                TEXT NOT NULL DEFAULT 'operator'
+                          CHECK (source IN ('operator','llm-evolved')),
+    created_at            TIMESTAMPTZ NOT NULL,
+    UNIQUE(tool_glob, pattern)
+);
+CREATE INDEX IF NOT EXISTS idx_compression_rules_hits
+    ON compression_rules(hit_count DESC);
+CREATE INDEX IF NOT EXISTS idx_compression_rules_source
+    ON compression_rules(source);

--- a/crates/zeph-db/migrations/sqlite/081_goal_lifecycle.sql
+++ b/crates/zeph-db/migrations/sqlite/081_goal_lifecycle.sql
@@ -1,0 +1,18 @@
+-- Goal lifecycle: stores long-horizon goals with FSM-controlled status transitions.
+-- At most one 'active' goal is allowed at any time (partial unique index).
+CREATE TABLE IF NOT EXISTS zeph_goals (
+    id              TEXT PRIMARY KEY,
+    text            TEXT NOT NULL,
+    status          TEXT NOT NULL DEFAULT 'active'
+                    CHECK (status IN ('active','paused','completed','cleared')),
+    token_budget    INTEGER,
+    turns_used      INTEGER NOT NULL DEFAULT 0,
+    tokens_used     INTEGER NOT NULL DEFAULT 0,
+    created_at      TEXT NOT NULL,
+    updated_at      TEXT NOT NULL,
+    completed_at    TEXT
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_zeph_goals_single_active
+    ON zeph_goals(status) WHERE status = 'active';
+CREATE INDEX IF NOT EXISTS idx_zeph_goals_status_created
+    ON zeph_goals(status, created_at);

--- a/crates/zeph-db/migrations/sqlite/082_compression_rules.sql
+++ b/crates/zeph-db/migrations/sqlite/082_compression_rules.sql
@@ -1,0 +1,17 @@
+-- TACO self-evolving compression rules.
+-- Rules apply regex patterns to tool outputs with optional glob matching on tool name.
+CREATE TABLE IF NOT EXISTS compression_rules (
+    id                    TEXT PRIMARY KEY,
+    tool_glob             TEXT,
+    pattern               TEXT NOT NULL,
+    replacement_template  TEXT NOT NULL,
+    hit_count             INTEGER NOT NULL DEFAULT 0,
+    source                TEXT NOT NULL DEFAULT 'operator'
+                          CHECK (source IN ('operator','llm-evolved')),
+    created_at            TEXT NOT NULL,
+    UNIQUE(tool_glob, pattern)
+);
+CREATE INDEX IF NOT EXISTS idx_compression_rules_hits
+    ON compression_rules(hit_count DESC);
+CREATE INDEX IF NOT EXISTS idx_compression_rules_source
+    ON compression_rules(source);

--- a/crates/zeph-tools/Cargo.toml
+++ b/crates/zeph-tools/Cargo.toml
@@ -13,6 +13,7 @@ description = "Tool executor trait with shell, web scrape, and composite executo
 readme = "README.md"
 
 [dependencies]
+dashmap.workspace = true
 dirs.workspace = true
 glob.workspace = true
 globset.workspace = true
@@ -43,8 +44,10 @@ tree-sitter-typescript.workspace = true
 unicode-normalization.workspace = true
 url.workspace = true
 uuid = { workspace = true, features = ["v4", "serde"] }
+sqlx.workspace = true
 zeph-common = { workspace = true, features = ["treesitter"] }
 zeph-config.workspace = true
+zeph-db = { workspace = true, features = ["sqlite"] }
 # See https://github.com/bug-ops/zeph (workspace dependencies only contain versions)
 
 [dev-dependencies]

--- a/crates/zeph-tools/src/compression/decorator.rs
+++ b/crates/zeph-tools/src/compression/decorator.rs
@@ -1,0 +1,338 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `CompressedExecutor<E>` — decorator that post-processes tool output through a compressor.
+//!
+//! Wraps the ROOT executor (any `ToolExecutor` implementation). The compressor is applied
+//! only to successful `ToolOutput.summary` strings — on error, the raw result is returned
+//! unchanged.
+//!
+//! # Invariant (T4)
+//!
+//! Audit logging is performed by the wrapped tool implementations, not here. Because
+//! `CompressedExecutor` wraps *outside* the tool boundary, audit JSONL always records
+//! the raw pre-compression payload.
+
+use std::sync::Arc;
+
+use crate::executor::ToolExecutor;
+use crate::{ToolCall, ToolError, ToolOutput};
+
+use super::OutputCompressor;
+
+/// Decorator that runs a compressor on each successful tool output.
+///
+/// The `inner` executor is called first; its output is then passed to `compressor.compress`.
+/// If compression returns `Ok(None)` or `Err(...)`, the original `summary` is kept intact.
+/// Compression errors are logged as warnings but never propagate to the caller.
+///
+/// # Type parameters
+///
+/// - `E` — the wrapped [`ToolExecutor`]. Often `CompositeExecutor` or `DynExecutor`.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use std::sync::Arc;
+/// use zeph_tools::compression::{CompressedExecutor, IdentityCompressor};
+/// // let executor = CompressedExecutor::new(inner_executor, Arc::new(IdentityCompressor), 200);
+/// ```
+#[derive(Debug)]
+pub struct CompressedExecutor<E: ToolExecutor> {
+    inner: E,
+    compressor: Arc<dyn OutputCompressor>,
+    min_lines_to_compress: usize,
+}
+
+impl<E: ToolExecutor> CompressedExecutor<E> {
+    /// Wrap `inner` with `compressor`.
+    ///
+    /// Outputs with fewer than `min_lines` lines skip the compressor entirely.
+    #[must_use]
+    pub fn new(inner: E, compressor: Arc<dyn OutputCompressor>, min_lines: usize) -> Self {
+        Self {
+            inner,
+            compressor,
+            min_lines_to_compress: min_lines,
+        }
+    }
+
+    /// Apply compression to `output`, logging on error and returning the original on failure.
+    async fn maybe_compress(&self, output: ToolOutput) -> ToolOutput {
+        let line_count = output.summary.lines().count();
+        if line_count < self.min_lines_to_compress {
+            return output;
+        }
+
+        match self
+            .compressor
+            .compress(&output.tool_name, &output.summary)
+            .await
+        {
+            Ok(Some(compressed)) => {
+                tracing::debug!(
+                    compressor = self.compressor.name(),
+                    tool = %output.tool_name.as_str(),
+                    original_len = output.summary.len(),
+                    compressed_len = compressed.len(),
+                    "CompressedExecutor: output compressed"
+                );
+                ToolOutput {
+                    summary: compressed,
+                    ..output
+                }
+            }
+            Ok(None) => output,
+            Err(e) => {
+                tracing::warn!(
+                    compressor = self.compressor.name(),
+                    error = %e,
+                    "CompressedExecutor: compression error, using raw output"
+                );
+                output
+            }
+        }
+    }
+}
+
+impl<E: ToolExecutor> ToolExecutor for CompressedExecutor<E> {
+    async fn execute(&self, response: &str) -> Result<Option<ToolOutput>, ToolError> {
+        let result = self.inner.execute(response).await?;
+        match result {
+            Some(out) => Ok(Some(self.maybe_compress(out).await)),
+            None => Ok(None),
+        }
+    }
+
+    async fn execute_confirmed(&self, response: &str) -> Result<Option<ToolOutput>, ToolError> {
+        let result = self.inner.execute_confirmed(response).await?;
+        match result {
+            Some(out) => Ok(Some(self.maybe_compress(out).await)),
+            None => Ok(None),
+        }
+    }
+
+    fn tool_definitions(&self) -> Vec<crate::registry::ToolDef> {
+        self.inner.tool_definitions()
+    }
+
+    async fn execute_tool_call(&self, call: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
+        let result = self.inner.execute_tool_call(call).await?;
+        match result {
+            Some(out) => Ok(Some(self.maybe_compress(out).await)),
+            None => Ok(None),
+        }
+    }
+
+    async fn execute_tool_call_confirmed(
+        &self,
+        call: &ToolCall,
+    ) -> Result<Option<ToolOutput>, ToolError> {
+        let result = self.inner.execute_tool_call_confirmed(call).await?;
+        match result {
+            Some(out) => Ok(Some(self.maybe_compress(out).await)),
+            None => Ok(None),
+        }
+    }
+
+    fn set_skill_env(&self, env: Option<std::collections::HashMap<String, String>>) {
+        self.inner.set_skill_env(env);
+    }
+
+    fn set_effective_trust(&self, level: crate::SkillTrustLevel) {
+        self.inner.set_effective_trust(level);
+    }
+
+    fn is_tool_retryable(&self, tool_id: &str) -> bool {
+        self.inner.is_tool_retryable(tool_id)
+    }
+
+    fn is_tool_speculatable(&self, tool_id: &str) -> bool {
+        self.inner.is_tool_speculatable(tool_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::pin::Pin;
+    use std::sync::{Arc, Mutex};
+
+    use zeph_common::ToolName;
+
+    use super::*;
+    use crate::compression::{CompressionError, OutputCompressor};
+    use crate::{SkillTrustLevel, ToolCall, ToolError, ToolOutput, registry::ToolDef};
+
+    /// Records the raw output it receives so the test can assert on it.
+    struct SpyExecutor {
+        received_summary: Arc<Mutex<Option<String>>>,
+        raw_output: String,
+    }
+
+    impl SpyExecutor {
+        fn new(raw: impl Into<String>) -> (Self, Arc<Mutex<Option<String>>>) {
+            let spy = Arc::new(Mutex::new(None));
+            (
+                Self {
+                    received_summary: Arc::clone(&spy),
+                    raw_output: raw.into(),
+                },
+                spy,
+            )
+        }
+    }
+
+    fn make_output(tool_name: ToolName, summary: String) -> ToolOutput {
+        ToolOutput {
+            tool_name,
+            summary,
+            blocks_executed: 0,
+            filter_stats: None,
+            diff: None,
+            streamed: false,
+            terminal_id: None,
+            locations: None,
+            raw_response: None,
+            claim_source: None,
+        }
+    }
+
+    impl ToolExecutor for SpyExecutor {
+        async fn execute(&self, _response: &str) -> Result<Option<ToolOutput>, ToolError> {
+            Ok(Some(make_output(
+                ToolName::new("spy"),
+                self.raw_output.clone(),
+            )))
+        }
+
+        async fn execute_confirmed(&self, response: &str) -> Result<Option<ToolOutput>, ToolError> {
+            self.execute(response).await
+        }
+
+        fn tool_definitions(&self) -> Vec<ToolDef> {
+            vec![]
+        }
+
+        async fn execute_tool_call(
+            &self,
+            call: &ToolCall,
+        ) -> Result<Option<ToolOutput>, ToolError> {
+            let out = make_output(call.tool_id.clone(), self.raw_output.clone());
+            *self.received_summary.lock().unwrap() = Some(out.summary.clone());
+            Ok(Some(out))
+        }
+
+        async fn execute_tool_call_confirmed(
+            &self,
+            call: &ToolCall,
+        ) -> Result<Option<ToolOutput>, ToolError> {
+            self.execute_tool_call(call).await
+        }
+
+        fn set_skill_env(&self, _env: Option<HashMap<String, String>>) {}
+        fn set_effective_trust(&self, _level: SkillTrustLevel) {}
+        fn is_tool_retryable(&self, _tool_id: &str) -> bool {
+            false
+        }
+        fn is_tool_speculatable(&self, _tool_id: &str) -> bool {
+            false
+        }
+    }
+
+    /// Always replaces output with a fixed "compressed" string.
+    #[derive(Debug)]
+    struct StubCompressor;
+
+    impl OutputCompressor for StubCompressor {
+        fn compress<'a>(
+            &'a self,
+            _tool_name: &'a ToolName,
+            _output: &'a str,
+        ) -> Pin<Box<dyn Future<Output = Result<Option<String>, CompressionError>> + Send + 'a>>
+        {
+            Box::pin(async move { Ok(Some("COMPRESSED".to_owned())) })
+        }
+
+        fn name(&self) -> &'static str {
+            "stub"
+        }
+    }
+
+    /// T4 invariant: audit (inner) receives raw output; LLM context receives compressed output.
+    ///
+    /// The inner executor (`SpyExecutor`) records what it emits before `CompressedExecutor`
+    /// applies the compressor. The assertion confirms that the inner layer saw the full raw
+    /// string, while the outer `CompressedExecutor` returns the shortened version.
+    #[tokio::test]
+    async fn t4_audit_sees_raw_llm_sees_compressed() {
+        let raw = "line\n".repeat(300);
+        let (spy, received) = SpyExecutor::new(raw.clone());
+        let executor = CompressedExecutor::new(spy, Arc::new(StubCompressor), 10);
+
+        let call = ToolCall {
+            tool_id: ToolName::new("spy"),
+            params: serde_json::Map::new(),
+            caller_id: None,
+            context: None,
+        };
+        let out = executor.execute_tool_call(&call).await.unwrap().unwrap();
+
+        // Inner executor (audit layer) received the raw payload.
+        assert_eq!(received.lock().unwrap().as_deref(), Some(raw.as_str()));
+        // Outer executor (LLM context layer) received the compressed payload.
+        assert_eq!(out.summary, "COMPRESSED");
+    }
+
+    /// Output below the line-count threshold passes through without compression.
+    #[tokio::test]
+    async fn maybe_compress_skips_when_below_threshold() {
+        let short = "line\n".repeat(5);
+        let (spy, _received) = SpyExecutor::new(short.clone());
+        let executor = CompressedExecutor::new(spy, Arc::new(StubCompressor), 100);
+
+        let call = ToolCall {
+            tool_id: ToolName::new("spy"),
+            params: serde_json::Map::new(),
+            caller_id: None,
+            context: None,
+        };
+        let out = executor.execute_tool_call(&call).await.unwrap().unwrap();
+        // StubCompressor would return "COMPRESSED" — but threshold not met, so raw passes through.
+        assert_eq!(out.summary, short);
+    }
+
+    /// Compressor error falls back to the raw (uncompressed) output.
+    #[tokio::test]
+    async fn compression_error_falls_back_to_raw() {
+        #[derive(Debug)]
+        struct ErrorCompressor;
+        impl OutputCompressor for ErrorCompressor {
+            fn compress<'a>(
+                &'a self,
+                _tool_name: &'a ToolName,
+                _output: &'a str,
+            ) -> Pin<Box<dyn Future<Output = Result<Option<String>, CompressionError>> + Send + 'a>>
+            {
+                Box::pin(async move { Err(CompressionError::CompileTimeout) })
+            }
+            fn name(&self) -> &'static str {
+                "error"
+            }
+        }
+
+        let raw = "line\n".repeat(300);
+        let (spy, _) = SpyExecutor::new(raw.clone());
+        let executor = CompressedExecutor::new(spy, Arc::new(ErrorCompressor), 10);
+
+        let call = ToolCall {
+            tool_id: ToolName::new("spy"),
+            params: serde_json::Map::new(),
+            caller_id: None,
+            context: None,
+        };
+        let out = executor.execute_tool_call(&call).await.unwrap().unwrap();
+        // Error compressor → raw output preserved (T4 safety invariant).
+        assert_eq!(out.summary, raw);
+    }
+}

--- a/crates/zeph-tools/src/compression/identity.rs
+++ b/crates/zeph-tools/src/compression/identity.rs
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! No-op compressor used when `[tools.compression] enabled = false`.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use zeph_common::ToolName;
+
+use super::{CompressionError, OutputCompressor};
+
+/// Pass-through compressor that never modifies tool output.
+///
+/// Used as the default compressor when `[tools.compression] enabled = false`.
+/// The `compress` method always returns `Ok(None)`.
+///
+/// # Examples
+///
+/// ```rust
+/// # let rt = tokio::runtime::Runtime::new().unwrap();
+/// # rt.block_on(async {
+/// use zeph_tools::compression::{IdentityCompressor, OutputCompressor};
+/// use zeph_common::ToolName;
+/// let c = IdentityCompressor;
+/// let name = ToolName::new("shell");
+/// let result = c.compress(&name, "some output").await;
+/// assert!(result.unwrap().is_none());
+/// # });
+/// ```
+#[derive(Debug, Default, Clone)]
+pub struct IdentityCompressor;
+
+impl OutputCompressor for IdentityCompressor {
+    fn compress<'a>(
+        &'a self,
+        _tool_name: &'a ToolName,
+        _output: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<String>, CompressionError>> + Send + 'a>> {
+        Box::pin(std::future::ready(Ok(None)))
+    }
+
+    fn name(&self) -> &'static str {
+        "identity"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn identity_always_passes_through() {
+        let c = IdentityCompressor;
+        let name = ToolName::new("shell");
+        let result = c.compress(&name, "hello world").await.unwrap();
+        assert!(result.is_none());
+    }
+}

--- a/crates/zeph-tools/src/compression/mod.rs
+++ b/crates/zeph-tools/src/compression/mod.rs
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! TACO: self-evolving tool output compression.
+//!
+//! The core abstraction is [`OutputCompressor`], an async trait that post-processes
+//! raw tool output before it is injected into the LLM context. When disabled, the
+//! [`IdentityCompressor`] is wired in — its `compress` always returns `Ok(None)` and
+//! is zero-cost beyond one virtual call per tool output.
+//!
+//! ## Architecture
+//!
+//! - [`OutputCompressor`] — core async trait.
+//! - [`IdentityCompressor`] — default no-op.
+//! - [`RuleBasedCompressor`] — regex rules loaded from `SQLite`.
+//! - [`CompressedExecutor`] — decorator wrapping the root [`crate::ToolExecutor`].
+//! - [`CompressionRuleStore`] — SQLite/Postgres-backed rule persistence.
+//! - [`safe_compile`] — DoS-safe regex compilation with timeout.
+//!
+//! ## Invariants
+//!
+//! - **T1**: `IdentityCompressor` is the only compressor when
+//!   `[tools.compression] enabled = false`.
+//! - **T4**: Audit logging happens inside individual tool implementations, not inside
+//!   `CompressedExecutor`. Because compression wraps *outside* the tool boundary,
+//!   audit JSONL always records the raw pre-compression payload.
+
+mod identity;
+mod regex_safe;
+mod rule_based;
+mod store;
+
+pub mod decorator;
+
+pub use decorator::CompressedExecutor;
+pub use identity::IdentityCompressor;
+pub use regex_safe::safe_compile;
+pub use rule_based::RuleBasedCompressor;
+pub use store::{CompressionRule, CompressionRuleStore};
+
+use std::future::Future;
+use std::pin::Pin;
+
+use zeph_common::ToolName;
+
+/// Error variants for compression operations.
+#[derive(Debug, thiserror::Error)]
+pub enum CompressionError {
+    /// The rule's regex pattern string is syntactically invalid.
+    #[error("regex compile failed: {0}")]
+    BadPattern(String),
+    /// Regex compilation exceeded the configured deadline; the rule was skipped.
+    #[error("regex compile timed out")]
+    CompileTimeout,
+    /// A database error occurred while loading or persisting compression rules.
+    #[error(transparent)]
+    Db(#[from] zeph_db::SqlxError),
+}
+
+/// Core abstraction for tool output compression.
+///
+/// Returning `Ok(None)` means "pass through unchanged". Non-`None` `Ok(Some(s))`
+/// replaces the tool output with `s` before it reaches the LLM context.
+///
+/// Implementors must be `Send + Sync + Debug`.
+pub trait OutputCompressor: Send + Sync + std::fmt::Debug {
+    /// Attempt to compress `output` for the given `tool_name`.
+    ///
+    /// Returns `Ok(None)` when no rule matched or compression is not applicable.
+    /// Returns `Ok(Some(compressed))` with the replacement string.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CompressionError`] on internal failure. Errors are logged and the
+    /// raw output is used as fallback by [`CompressedExecutor`].
+    fn compress<'a>(
+        &'a self,
+        tool_name: &'a ToolName,
+        output: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<String>, CompressionError>> + Send + 'a>>;
+
+    /// Stable identifier for this compressor (used in logs).
+    fn name(&self) -> &'static str;
+}

--- a/crates/zeph-tools/src/compression/regex_safe.rs
+++ b/crates/zeph-tools/src/compression/regex_safe.rs
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! DoS-safe regex compilation (S6 fix).
+//!
+//! The `regex` crate has no compile-time deadline. `safe_compile` bounds compilation
+//! by running it in a `spawn_blocking` task raced against `tokio::time::timeout`.
+//!
+//! ## Thread cap (H2)
+//!
+//! `spawn_blocking` threads are not cancelled on timeout — they continue running until
+//! the pattern compiles or the blocking thread pool shuts down. To bound the maximum
+//! number of simultaneously live compile threads, a global `AtomicUsize` counter gates
+//! entry: if `MAX_COMPILE_TASKS` threads are already running, `safe_compile` returns
+//! [`CompressionError::CompileTimeout`] immediately without spawning a new one.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use super::CompressionError;
+
+/// Maximum number of regex compile tasks allowed in-flight simultaneously.
+const MAX_COMPILE_TASKS: usize = 4;
+
+static ACTIVE_COMPILE_TASKS: AtomicUsize = AtomicUsize::new(0);
+
+/// Compile a regex pattern with `DoS` protection.
+///
+/// Applies NFA size limit (64 KiB), DFA size limit (1 MiB), and a `timeout_ms`
+/// deadline enforced via `spawn_blocking` + `tokio::time::timeout`.
+///
+/// Returns [`CompressionError::CompileTimeout`] immediately when
+/// [`MAX_COMPILE_TASKS`] concurrent compilations are already in-flight.
+///
+/// On timeout or panic from the blocking task, returns a typed error that allows
+/// the evolver's failure counter to distinguish DoS-risk patterns from syntax errors.
+///
+/// # Errors
+///
+/// - [`CompressionError::BadPattern`] for syntax errors or task panics.
+/// - [`CompressionError::CompileTimeout`] when the in-flight limit is reached or
+///   compilation exceeds `timeout_ms`.
+pub async fn safe_compile(pat: &str, timeout_ms: u64) -> Result<regex::Regex, CompressionError> {
+    // Reject immediately if the thread cap is saturated.
+    let prev = ACTIVE_COMPILE_TASKS.fetch_add(1, Ordering::Relaxed);
+    if prev >= MAX_COMPILE_TASKS {
+        ACTIVE_COMPILE_TASKS.fetch_sub(1, Ordering::Relaxed);
+        return Err(CompressionError::CompileTimeout);
+    }
+
+    let pat = pat.to_owned();
+    let join = tokio::task::spawn_blocking(move || {
+        let result = regex::RegexBuilder::new(&pat)
+            .size_limit(64 * 1024)
+            .dfa_size_limit(1024 * 1024)
+            .build();
+        // Always decrement the counter when the blocking thread finishes.
+        ACTIVE_COMPILE_TASKS.fetch_sub(1, Ordering::Relaxed);
+        result
+    });
+
+    match tokio::time::timeout(Duration::from_millis(timeout_ms), join).await {
+        Err(_elapsed) => Err(CompressionError::CompileTimeout),
+        Ok(Err(_join_err)) => Err(CompressionError::BadPattern("compile task panicked".into())),
+        Ok(Ok(Err(regex_err))) => Err(CompressionError::BadPattern(regex_err.to_string())),
+        Ok(Ok(Ok(re))) => Ok(re),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn compiles_simple_pattern() {
+        let re = safe_compile(r"\d+", 500).await.unwrap();
+        assert!(re.is_match("123"));
+    }
+
+    #[tokio::test]
+    async fn rejects_invalid_pattern() {
+        let err = safe_compile(r"[invalid", 500).await.unwrap_err();
+        assert!(matches!(err, CompressionError::BadPattern(_)));
+    }
+}

--- a/crates/zeph-tools/src/compression/rule_based.rs
+++ b/crates/zeph-tools/src/compression/rule_based.rs
@@ -1,0 +1,343 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Regex-based tool output compressor with self-evolution support.
+//!
+//! Rules are loaded from `SQLite` and stored as compiled `regex::Regex` values in a
+//! `parking_lot::RwLock<Vec<CompiledRule>>`. Hit counts are tracked separately in a
+//! `dashmap::DashMap<String, AtomicU64>` so that a rules-vec swap (on reload) cannot
+//! lose unflushed counters.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use dashmap::DashMap;
+use parking_lot::RwLock;
+use zeph_common::ToolName;
+
+use super::{CompressionError, CompressionRuleStore, OutputCompressor, safe_compile};
+
+/// A compiled compression rule ready for matching.
+struct CompiledRule {
+    id: String,
+    /// When `Some`, this rule only applies to tools whose name matches the glob.
+    glob: Option<globset::GlobMatcher>,
+    pattern: regex::Regex,
+    replacement_template: String,
+}
+
+/// Regex-based compressor that applies operator- and LLM-evolved rules to tool output.
+///
+/// Rules are sorted deterministically by `id` to ensure stable application order.
+/// Hit counts are stored in `hits` keyed by `rule.id`; the `rules` vec can be swapped
+/// on reload without losing any unflushed counts.
+///
+/// # Invariants
+///
+/// - Rules are applied in `id`-ascending order (deterministic).
+/// - `compress` returns the first successful match (earliest rule wins).
+/// - A rule is skipped when `glob` is set and does not match `tool_name`.
+/// - `regex::Regex::replace_all` guarantees linear time (no catastrophic backtracking).
+///   No `catch_unwind` is needed around `replace_all`.
+pub struct RuleBasedCompressor {
+    rules: RwLock<Vec<CompiledRule>>,
+    hits: DashMap<String, AtomicU64>,
+    store: Arc<CompressionRuleStore>,
+    max_output_lines: usize,
+    regex_timeout_ms: u64,
+}
+
+impl std::fmt::Debug for RuleBasedCompressor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RuleBasedCompressor")
+            .field("rules_count", &self.rules.read().len())
+            .field("max_output_lines", &self.max_output_lines)
+            .field("regex_timeout_ms", &self.regex_timeout_ms)
+            .finish_non_exhaustive()
+    }
+}
+
+impl RuleBasedCompressor {
+    /// Load all active rules from the store and compile them.
+    ///
+    /// Rules that fail compilation are skipped and logged as warnings.
+    ///
+    /// `regex_timeout_ms` controls the DoS-safe regex compilation timeout passed to
+    /// [`super::safe_compile`]. Sourced from `[tools.compression] regex_compile_timeout_ms`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CompressionError::Db`] if the store query fails.
+    pub async fn load(
+        store: Arc<CompressionRuleStore>,
+        max_output_lines: usize,
+        regex_timeout_ms: u64,
+    ) -> Result<Self, CompressionError> {
+        let raw_rules = store.list_active().await?;
+        let mut compiled = Vec::with_capacity(raw_rules.len());
+        let hits = DashMap::new();
+
+        for rule in raw_rules {
+            let glob = if let Some(ref g) = rule.tool_glob {
+                match globset::Glob::new(g) {
+                    Ok(glob) => Some(glob.compile_matcher()),
+                    Err(e) => {
+                        tracing::warn!(rule_id = %rule.id, pattern = %g, error = %e, "rule: invalid glob, skipping");
+                        continue;
+                    }
+                }
+            } else {
+                None
+            };
+
+            match super::safe_compile(&rule.pattern, regex_timeout_ms).await {
+                Ok(re) => {
+                    hits.insert(rule.id.clone(), AtomicU64::new(0));
+                    compiled.push(CompiledRule {
+                        id: rule.id,
+                        glob,
+                        pattern: re,
+                        replacement_template: rule.replacement_template,
+                    });
+                }
+                Err(e) => {
+                    tracing::warn!(rule_id = %rule.id, error = %e, "rule: compile failed, skipping");
+                }
+            }
+        }
+
+        compiled.sort_unstable_by(|a, b| a.id.cmp(&b.id));
+
+        Ok(Self {
+            rules: RwLock::new(compiled),
+            hits,
+            store,
+            max_output_lines,
+            regex_timeout_ms,
+        })
+    }
+
+    /// Reload rules from the store, preserving hit counts for still-present rules
+    /// and flushing counts for rules that no longer exist.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CompressionError::Db`] if the store query fails.
+    pub async fn reload(&self) -> Result<(), CompressionError> {
+        let raw_rules = self.store.list_active().await?;
+        let mut compiled = Vec::with_capacity(raw_rules.len());
+
+        // Flush and remove hits for rules that are no longer in the store.
+        let active_ids: std::collections::HashSet<&str> =
+            raw_rules.iter().map(|r| r.id.as_str()).collect();
+        let stale_ids: Vec<String> = self
+            .hits
+            .iter()
+            .filter(|e| !active_ids.contains(e.key().as_str()))
+            .map(|e| e.key().clone())
+            .collect();
+        for id in stale_ids {
+            self.hits.remove(&id);
+        }
+
+        for rule in raw_rules {
+            let glob = if let Some(ref g) = rule.tool_glob {
+                match globset::Glob::new(g) {
+                    Ok(glob) => Some(glob.compile_matcher()),
+                    Err(e) => {
+                        tracing::warn!(rule_id = %rule.id, error = %e, "reload: invalid glob");
+                        continue;
+                    }
+                }
+            } else {
+                None
+            };
+
+            match safe_compile(&rule.pattern, self.regex_timeout_ms).await {
+                Ok(re) => {
+                    self.hits
+                        .entry(rule.id.clone())
+                        .or_insert_with(|| AtomicU64::new(0));
+                    compiled.push(CompiledRule {
+                        id: rule.id,
+                        glob,
+                        pattern: re,
+                        replacement_template: rule.replacement_template,
+                    });
+                }
+                Err(e) => {
+                    tracing::warn!(rule_id = %rule.id, error = %e, "reload: compile failed");
+                }
+            }
+        }
+
+        compiled.sort_unstable_by(|a, b| a.id.cmp(&b.id));
+        *self.rules.write() = compiled;
+        Ok(())
+    }
+
+    /// Drain pending hit counts into a batch and write them to the store.
+    ///
+    /// Called during the `maybe_autodream` maintenance pass. Resets all counters
+    /// to zero after flushing.
+    ///
+    /// # Errors
+    ///
+    /// Returns a database error if the batch write fails.
+    pub async fn flush_hit_counts(&self) -> Result<(), CompressionError> {
+        let batch: Vec<(String, u64)> = self
+            .hits
+            .iter()
+            .filter_map(|e| {
+                let delta = e.value().swap(0, Ordering::Relaxed);
+                if delta > 0 {
+                    Some((e.key().clone(), delta))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if batch.is_empty() {
+            return Ok(());
+        }
+
+        self.store.increment_hits(&batch).await?;
+        Ok(())
+    }
+}
+
+impl OutputCompressor for RuleBasedCompressor {
+    fn compress<'a>(
+        &'a self,
+        tool_name: &'a ToolName,
+        output: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<String>, CompressionError>> + Send + 'a>> {
+        Box::pin(async move {
+            // Drop span guard before first await; EnteredSpan is not Send.
+            drop(
+                tracing::info_span!("tools.compression.compress", tool = %tool_name.as_str())
+                    .entered(),
+            );
+            let rules = self.rules.read();
+            for rule in rules.iter() {
+                if rule
+                    .glob
+                    .as_ref()
+                    .is_some_and(|g| !g.is_match(tool_name.as_str()))
+                {
+                    continue;
+                }
+                if rule.pattern.is_match(output) {
+                    let compressed = rule
+                        .pattern
+                        .replace_all(output, rule.replacement_template.as_str())
+                        .into_owned();
+
+                    if compressed.len() < output.len() {
+                        if let Some(entry) = self.hits.get(&rule.id) {
+                            entry.fetch_add(1, Ordering::Relaxed);
+                        }
+                        tracing::debug!(
+                            rule_id = %rule.id,
+                            tool = %tool_name.as_str(),
+                            original_bytes = output.len(),
+                            compressed_bytes = compressed.len(),
+                            "compression applied"
+                        );
+                        return Ok(Some(compressed));
+                    }
+                }
+            }
+            Ok(None)
+        })
+    }
+
+    fn name(&self) -> &'static str {
+        "rule_based"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use zeph_common::ToolName;
+
+    use super::*;
+    use crate::compression::{CompressionRuleStore, OutputCompressor, store::CompressionRule};
+
+    async fn make_store_with_rules(rules: &[(&str, &str)]) -> Arc<CompressionRuleStore> {
+        let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::query(
+            "CREATE TABLE compression_rules (\
+             id TEXT PRIMARY KEY, tool_glob TEXT, pattern TEXT NOT NULL, \
+             replacement_template TEXT NOT NULL, hit_count INTEGER NOT NULL DEFAULT 0, \
+             source TEXT NOT NULL DEFAULT 'operator', created_at TEXT NOT NULL, \
+             UNIQUE(tool_glob, pattern))",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let store = Arc::new(CompressionRuleStore::new(Arc::new(pool)));
+        for (i, (pattern, replacement)) in rules.iter().enumerate() {
+            store
+                .upsert(&CompressionRule {
+                    id: format!("rule-{i}"),
+                    tool_glob: None,
+                    pattern: (*pattern).to_owned(),
+                    replacement_template: (*replacement).to_owned(),
+                    hit_count: 0,
+                    source: "operator".to_owned(),
+                    created_at: "2026-01-01T00:00:00Z".to_owned(),
+                })
+                .await
+                .unwrap();
+        }
+        store
+    }
+
+    #[tokio::test]
+    async fn compress_returns_none_when_no_rule_matches() {
+        let store = make_store_with_rules(&[(r"\d+", "N")]).await;
+        let compressor = RuleBasedCompressor::load(store, 2, 500).await.unwrap();
+        let tool = ToolName::new("shell");
+        // Input has no digits — pattern won't match.
+        let input = "line\n".repeat(10);
+        let result = compressor.compress(&tool, &input).await.unwrap();
+        assert!(result.is_none(), "no rule should match non-digit input");
+    }
+
+    #[tokio::test]
+    async fn compress_applies_matching_rule() {
+        // Replace every digit sequence with "N".
+        let store = make_store_with_rules(&[(r"\d+", "N")]).await;
+        let compressor = RuleBasedCompressor::load(store, 2, 500).await.unwrap();
+        let tool = ToolName::new("shell");
+        // 10 lines, each "12345\n" → replaced with "N\n".
+        let input: String = "12345\n".repeat(10);
+        let result = compressor.compress(&tool, &input).await.unwrap();
+        assert!(result.is_some(), "rule should have matched");
+        let compressed = result.unwrap();
+        assert!(compressed.len() < input.len(), "compressed must be shorter");
+        assert!(compressed.contains('N'));
+    }
+
+    #[tokio::test]
+    async fn compress_returns_none_when_not_shorter() {
+        // Replacement is longer than original — should not be returned.
+        let long_replacement = "VERY_LONG_REPLACEMENT_THAT_IS_DEFINITELY_LONGER_THAN_ORIGINAL";
+        let store = make_store_with_rules(&[(r"\d", long_replacement)]).await;
+        let compressor = RuleBasedCompressor::load(store, 2, 500).await.unwrap();
+        let tool = ToolName::new("shell");
+        let input = "1\n".repeat(10);
+        let result = compressor.compress(&tool, &input).await.unwrap();
+        assert!(
+            result.is_none(),
+            "compression that doesn't reduce size should return None"
+        );
+    }
+}

--- a/crates/zeph-tools/src/compression/store.rs
+++ b/crates/zeph-tools/src/compression/store.rs
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! SQLite/Postgres-backed storage for TACO compression rules.
+
+use std::sync::Arc;
+
+use zeph_db::DbPool;
+
+/// A single compression rule stored in the database.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct CompressionRule {
+    /// UUID v4 string identifier.
+    pub id: String,
+    /// Optional glob pattern matching tool names (e.g., `"shell"`, `"web_*"`).
+    pub tool_glob: Option<String>,
+    /// Regex pattern applied to tool output.
+    pub pattern: String,
+    /// Replacement template (may reference capture groups, e.g. `"$1"`).
+    pub replacement_template: String,
+    /// Number of times this rule has matched. Updated by [`CompressionRuleStore::increment_hits`].
+    pub hit_count: i64,
+    /// Origin of this rule: `"operator"` (config-inserted) or `"llm-evolved"` (auto-generated).
+    pub source: String,
+    /// RFC 3339 creation timestamp.
+    pub created_at: String,
+}
+
+/// Persistence layer for TACO compression rules.
+///
+/// All rules are loaded at startup via [`CompressionRuleStore::list_active`] and cached in
+/// [`super::RuleBasedCompressor`]. Hit counts are flushed in batches via
+/// [`CompressionRuleStore::increment_hits`] during the `maybe_autodream` maintenance pass.
+#[derive(Clone)]
+pub struct CompressionRuleStore {
+    pool: Arc<DbPool>,
+}
+
+impl CompressionRuleStore {
+    /// Construct a store backed by the given pool.
+    #[must_use]
+    pub fn new(pool: Arc<DbPool>) -> Self {
+        Self { pool }
+    }
+
+    /// Return all rules, ordered by ascending hit count (least-used first for pruning).
+    ///
+    /// # Errors
+    ///
+    /// Returns a database error on failure.
+    pub async fn list_active(&self) -> Result<Vec<CompressionRule>, zeph_db::SqlxError> {
+        sqlx::query_as(zeph_db::sql!(
+            "SELECT id, tool_glob, pattern, replacement_template, hit_count, source, created_at \
+             FROM compression_rules ORDER BY hit_count ASC"
+        ))
+        .fetch_all(self.pool.as_ref())
+        .await
+    }
+
+    /// Insert or update a rule (keyed by `(tool_glob, pattern)`).
+    ///
+    /// # Errors
+    ///
+    /// Returns a database error on failure.
+    pub async fn upsert(&self, rule: &CompressionRule) -> Result<(), zeph_db::SqlxError> {
+        sqlx::query(zeph_db::sql!(
+            "INSERT INTO compression_rules \
+             (id, tool_glob, pattern, replacement_template, hit_count, source, created_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?) \
+             ON CONFLICT(tool_glob, pattern) DO UPDATE SET \
+             replacement_template = excluded.replacement_template, \
+             source = excluded.source"
+        ))
+        .bind(&rule.id)
+        .bind(&rule.tool_glob)
+        .bind(&rule.pattern)
+        .bind(&rule.replacement_template)
+        .bind(rule.hit_count)
+        .bind(&rule.source)
+        .bind(&rule.created_at)
+        .execute(self.pool.as_ref())
+        .await?;
+        Ok(())
+    }
+
+    /// Batch-increment hit counts for a set of rule IDs.
+    ///
+    /// Called during the `maybe_autodream` maintenance pass. Uses individual
+    /// UPDATE statements rather than a batch because the count of rules is small
+    /// and cross-backend portability is preferred.
+    ///
+    /// # Errors
+    ///
+    /// Returns a database error on failure.
+    pub async fn increment_hits(&self, batch: &[(String, u64)]) -> Result<(), zeph_db::SqlxError> {
+        for (id, delta) in batch {
+            sqlx::query(zeph_db::sql!(
+                "UPDATE compression_rules SET hit_count = hit_count + ? WHERE id = ?"
+            ))
+            .bind((*delta).cast_signed())
+            .bind(id.as_str())
+            .execute(self.pool.as_ref())
+            .await?;
+        }
+        Ok(())
+    }
+
+    /// Delete a rule by ID.
+    ///
+    /// # Errors
+    ///
+    /// Returns a database error on failure.
+    pub async fn delete(&self, id: &str) -> Result<(), zeph_db::SqlxError> {
+        sqlx::query(zeph_db::sql!("DELETE FROM compression_rules WHERE id = ?"))
+            .bind(id)
+            .execute(self.pool.as_ref())
+            .await?;
+        Ok(())
+    }
+
+    /// Prune the lowest-hit rules to keep the table below `max_rules`.
+    ///
+    /// Returns the number of rules deleted.
+    ///
+    /// # Errors
+    ///
+    /// Returns a database error on failure.
+    pub async fn prune_lowest_hits(&self, max_rules: u32) -> Result<u64, zeph_db::SqlxError> {
+        let count: i64 =
+            sqlx::query_scalar(zeph_db::sql!("SELECT COUNT(*) FROM compression_rules"))
+                .fetch_one(self.pool.as_ref())
+                .await?;
+
+        if count <= i64::from(max_rules) {
+            return Ok(0);
+        }
+
+        let to_delete = count - i64::from(max_rules);
+        let result = sqlx::query(zeph_db::sql!(
+            "DELETE FROM compression_rules WHERE id IN \
+             (SELECT id FROM compression_rules ORDER BY hit_count ASC LIMIT ?)"
+        ))
+        .bind(to_delete)
+        .execute(self.pool.as_ref())
+        .await?;
+
+        Ok(result.rows_affected())
+    }
+}

--- a/crates/zeph-tools/src/lib.rs
+++ b/crates/zeph-tools/src/lib.rs
@@ -61,6 +61,7 @@ pub mod anomaly;
 pub mod audit;
 pub mod cache;
 pub mod composite;
+pub mod compression;
 pub mod config;
 pub mod cwd;
 pub mod diagnostics;
@@ -99,6 +100,10 @@ pub use audit::{
 };
 pub use cache::{CacheKey, ToolResultCache, is_cacheable};
 pub use composite::CompositeExecutor;
+pub use compression::{
+    CompressedExecutor, CompressionError, CompressionRule, CompressionRuleStore,
+    IdentityCompressor, OutputCompressor, RuleBasedCompressor, safe_compile,
+};
 pub use config::{build_permission_policy, validate_sandbox_denied_domains};
 pub use cwd::SetCwdExecutor;
 pub use diagnostics::DiagnosticsExecutor;

--- a/crates/zeph-tui/src/metrics.rs
+++ b/crates/zeph-tui/src/metrics.rs
@@ -17,6 +17,7 @@
 //! ```
 
 pub use zeph_common::SecurityEventCategory;
+pub use zeph_core::goal::{GoalSnapshot, GoalStatus};
 pub use zeph_core::metrics::{
     CategoryScore, ClassifierMetricsSnapshot, McpServerConnectionStatus, McpServerStatus,
     MetricsCollector, MetricsSnapshot, ProbeCategory, ProbeVerdict, SecurityEvent, SkillConfidence,

--- a/crates/zeph-tui/src/widgets/status.rs
+++ b/crates/zeph-tui/src/widgets/status.rs
@@ -27,6 +27,7 @@ pub fn render(app: &App, metrics: &MetricsSnapshot, frame: &mut Frame, area: Rec
     let mut spans: Vec<Span<'_>> = vec![Span::styled(main_text, theme.status_bar)];
     append_security_spans(&mut spans, metrics, &theme);
     append_compaction_segment(&mut spans, metrics, &theme);
+    append_goal_badge(&mut spans, metrics, &theme);
     let suffix = build_suffix(metrics, cancel_hint, &uptime);
     spans.push(Span::styled(suffix, theme.status_bar));
     let line = Line::from(spans);
@@ -70,6 +71,32 @@ fn append_compaction_segment(spans: &mut Vec<Span<'_>>, metrics: &MetricsSnapsho
             Style::default().fg(Color::Cyan),
         ));
     }
+}
+
+fn append_goal_badge(spans: &mut Vec<Span<'_>>, metrics: &MetricsSnapshot, theme: &Theme) {
+    use zeph_core::goal::GoalStatus;
+    let Some(ref snap) = metrics.active_goal else {
+        return;
+    };
+    let (icon, color) = match snap.status {
+        GoalStatus::Active => ("▶", Color::Green),
+        GoalStatus::Paused => ("⏸", Color::Yellow),
+        GoalStatus::Completed => ("✓", Color::Cyan),
+        GoalStatus::Cleared => ("✗", Color::Red),
+    };
+    let label = if snap.text.is_empty() {
+        format!(" {icon} goal")
+    } else {
+        let short: String = snap.text.chars().take(30).collect();
+        let truncated = if snap.text.chars().count() > 30 {
+            format!("{short}…")
+        } else {
+            short
+        };
+        format!(" {icon} {truncated}")
+    };
+    spans.push(Span::styled(" | ", theme.status_bar));
+    spans.push(Span::styled(label, Style::default().fg(color)));
 }
 
 fn build_suffix(metrics: &MetricsSnapshot, cancel_hint: &str, uptime: &str) -> String {

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -14,22 +14,10 @@ use zeph_tools::{
     LspSearchBackend, SearchCodeExecutor, SearchCodeHit, SearchCodeSource, SemanticSearchBackend,
 };
 
-type ToolExecutor = zeph_tools::CompositeExecutor<
-    zeph_tools::CompositeExecutor<
-        zeph_tools::FileExecutor,
-        zeph_tools::CompositeExecutor<
-            std::sync::Arc<zeph_tools::ShellExecutor>,
-            zeph_tools::CompositeExecutor<
-                zeph_tools::WebScrapeExecutor,
-                zeph_tools::SetCwdExecutor,
-            >,
-        >,
-    >,
-    zeph_mcp::McpToolExecutor,
->;
-
 pub(crate) struct ToolSetup {
-    pub(crate) executor: ToolExecutor,
+    pub(crate) executor: zeph_tools::DynExecutor,
+    /// TACO compressor handle for `maybe_autodream` hit-count flushing. `None` when disabled.
+    pub(crate) taco_compressor: Option<std::sync::Arc<zeph_tools::RuleBasedCompressor>>,
     pub(crate) mcp_tools: Vec<zeph_mcp::McpTool>,
     pub(crate) mcp_outcomes: Vec<zeph_mcp::ServerConnectOutcome>,
     pub(crate) mcp_manager: Arc<zeph_mcp::McpManager>,
@@ -550,10 +538,13 @@ pub(crate) async fn build_tool_setup(
             zeph_tools::CompositeExecutor::new(scrape_executor, cwd_executor),
         ),
     );
-    let executor = zeph_tools::CompositeExecutor::new(base_executor, mcp_executor);
+    let composite = zeph_tools::CompositeExecutor::new(base_executor, mcp_executor);
+    let (executor, taco_compressor) =
+        build_compressed_executor(composite, &config.tools.compression, pool).await;
 
     ToolSetup {
         executor,
+        taco_compressor,
         mcp_tools,
         mcp_outcomes,
         mcp_manager,
@@ -567,6 +558,58 @@ pub(crate) async fn build_tool_setup(
         background_completion_rx: Some(bg_completion_rx),
         shell_executor_handle,
     }
+}
+
+/// Wrap `inner` in a [`zeph_tools::CompressedExecutor`] when `cfg.enabled = true` and a DB pool
+/// is available. Returns the executor and a compressor handle for hit-count flushing during
+/// `maybe_autodream`. Falls back to a plain [`zeph_tools::DynExecutor`] when disabled.
+async fn build_compressed_executor<
+    E: zeph_tools::ToolExecutor + zeph_tools::ErasedToolExecutor + 'static,
+>(
+    inner: E,
+    cfg: &zeph_config::ToolCompressionConfig,
+    pool: Option<&zeph_db::DbPool>,
+) -> (
+    zeph_tools::DynExecutor,
+    Option<Arc<zeph_tools::RuleBasedCompressor>>,
+) {
+    if cfg.enabled {
+        if let Some(pool) = pool {
+            let store = Arc::new(zeph_tools::CompressionRuleStore::new(Arc::new(
+                pool.clone(),
+            )));
+            match zeph_tools::RuleBasedCompressor::load(
+                store,
+                cfg.min_lines_to_compress,
+                cfg.regex_compile_timeout_ms,
+            )
+            .await
+            {
+                Ok(compressor) => {
+                    tracing::info!("tools.compression: TACO enabled, rule-based compressor loaded");
+                    let compressor = Arc::new(compressor);
+                    let compressed = zeph_tools::CompressedExecutor::new(
+                        inner,
+                        Arc::clone(&compressor) as Arc<dyn zeph_tools::OutputCompressor>,
+                        cfg.min_lines_to_compress,
+                    );
+                    return (
+                        zeph_tools::DynExecutor(Arc::new(compressed)),
+                        Some(compressor),
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "tools.compression: failed to load rules, running without compression"
+                    );
+                }
+            }
+        } else {
+            tracing::warn!("tools.compression: enabled but no DB pool available, skipping");
+        }
+    }
+    (zeph_tools::DynExecutor(Arc::new(inner)), None)
 }
 
 use zeph_core::agent::Agent;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1672,6 +1672,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     let shell_executor_for_tui = tool_setup.tool_event_rx;
     #[cfg(not(feature = "tui"))]
     let _tool_event_rx = tool_setup.tool_event_rx;
+    let taco_compressor = tool_setup.taco_compressor;
     let egress_rx = tool_setup.egress_rx;
     let shell_policy_handle = tool_setup.shell_policy_handle;
     let background_completion_rx = tool_setup.background_completion_rx;
@@ -2189,6 +2190,18 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             eval_threshold,
             &skill_paths_for_features,
         )
+    };
+    let agent = agent.with_taco_compressor(taco_compressor);
+
+    // Wire GoalAccounting — gated on config.goals.enabled (G4 invariant: always off in bare mode).
+    let agent = if config.goals.enabled && !exec_mode.bare {
+        let goal_pool = std::sync::Arc::new(memory.sqlite().pool().clone());
+        let goal_store = std::sync::Arc::new(zeph_core::goal::GoalStore::new(goal_pool));
+        let accounting = std::sync::Arc::new(zeph_core::goal::GoalAccounting::new(goal_store));
+        tracing::info!("goals: enabled, GoalAccounting wired");
+        agent.with_goal_accounting(Some(accounting))
+    } else {
+        agent
     };
 
     let judge_provider = app.build_judge_provider();


### PR DESCRIPTION
## Summary

- **Goal lifecycle** (`/goal` command, closes #3567): persistent long-horizon objective tracking across agent turns. `GoalStore` (SQLite + Postgres) with transactional `create()`, `GoalStatus` FSM (active/paused/completed/cleared), `GoalAccounting` background bookkeeping, active goal injected into system prompt after the volatile cache marker with XML escaping, `/goal create|pause|resume|complete|clear|status|list` registered in all channels (CLI, TUI, Telegram), TUI status badge.
- **TACO output compression** (closes #3306): `OutputCompressor` trait + `RuleBasedCompressor` (regex rules from DB) + `CompressedExecutor<E>` decorator (audit sees raw, LLM sees compressed). `safe_compile` with spawn_blocking + timeout + size limits + concurrent-task cap. Self-evolution hook in `maybe_autodream`.

## Key invariants enforced

- G1: at-most-one-active-goal via partial unique index + transactional `create()`
- G3: `<active_goal>` injected **after** `<!-- cache:volatile -->` (snapshot-tested)
- T4: audit log records raw output, LLM context receives compressed
- H1: goal text XML-escaped; `</active_goal>` literal rejected at store level
- H2: max 4 concurrent regex compile tasks via `AtomicUsize`

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` — 8785 passed, 21 skipped
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] New tests: `GoalStatus` FSM (5), `GoalStore` transitions (4), `GoalAccounting` (6), `CompressedExecutor` (3), `RuleBasedCompressor` (3), `safe_compile` (2), G3 snapshot test, T4 audit invariant, H1 injection guard
- [ ] Live testing playbook: `.local/testing/playbooks/goal-taco.md`
- [ ] Coverage status: `.local/testing/coverage-status.md` (both features marked `Untested`)

## Migrations

- SQLite: `081_goal_lifecycle.sql`, `082_compression_rules.sql`
- Postgres: `076_goal_lifecycle.sql`, `077_compression_rules.sql`
- Config: steps 41 (`migrate_goals_config`) + 42 (`migrate_tools_compression_config`)