### PR TITLE
feat(memory): log memory retrieval failures for OmniMem self-improvement loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- feat(memory): `RetrievalFailureLogger` — async fire-and-forget logger for memory retrieval
+  failures in `zeph-memory`. Records no-hit turns, low-confidence recalls, timeouts, and errors
+  into a new `memory_retrieval_failures` SQLite table (migration 083). The write path uses a
+  bounded mpsc channel (256 cap) with a background batch writer (16 records / 100 ms flush),
+  keeping `try_send` on the hot path with zero latency impact. Integrated at
+  `fetch_graph_facts_raw` and `fetch_semantic_recall_raw` in `zeph-agent-context`. Configured
+  via `[memory.retrieval_failures]` with `enabled` (default `false`),
+  `low_confidence_threshold` (default `0.3`), and `retention_days` (default `90`). Implements
+  the minimum viable failure dataset required by the OmniMem self-improvement loop (issue #3576,
+  ref arXiv:2604.01007).
+
 - feat(memory): `SemanticStateAccumulator` — cost-gated background distillation of assistant
   responses into a rolling semantic state buffer (`memory.memcot.enabled`, issues #3574/#3575).
   The state is prepended as `[state] <buf>` to graph recall queries to improve retrieval

--- a/crates/zeph-agent-context/src/helpers.rs
+++ b/crates/zeph-agent-context/src/helpers.rs
@@ -11,10 +11,11 @@
 //! `zeph-core`-internal `MemoryState`, keeping this crate free of `zeph-core` types.
 
 use std::fmt::Write as _;
+use std::time::Instant;
 
 use zeph_config::ContextFormat;
 use zeph_llm::provider::{Message, MessagePart, Role};
-use zeph_memory::TokenCounter;
+use zeph_memory::{RetrievalFailureRecord, RetrievalFailureType, TokenCounter};
 
 use crate::error::ContextError;
 use crate::state::ContextAssemblyView;
@@ -152,6 +153,31 @@ pub async fn fetch_graph_facts_raw(
     };
 
     let _span = tracing::info_span!("memory.graph.dispatch", ?effective_strategy).entered();
+    let strategy_str = format!("{effective_strategy:?}").to_lowercase();
+    let edge_types_json = serde_json::to_string(&edge_types).ok();
+
+    /// Append graph facts to `body` respecting the token budget; returns result count.
+    fn append_graph_facts(
+        facts: &[zeph_memory::graph::types::GraphFact],
+        body: &mut String,
+        tokens_so_far: &mut usize,
+        budget_tokens: usize,
+        tc: &TokenCounter,
+    ) -> usize {
+        let mut count = 0;
+        for f in facts {
+            let fact_text = f.fact.replace(['\n', '\r', '<', '>'], " ");
+            let line = format!("- {} (confidence: {:.2})\n", fact_text, f.confidence);
+            let line_tokens = tc.count_tokens(&line);
+            if *tokens_so_far + line_tokens > budget_tokens {
+                break;
+            }
+            body.push_str(&line);
+            *tokens_so_far += line_tokens;
+            count += 1;
+        }
+        count
+    }
 
     match effective_strategy {
         GraphRetrievalStrategy::Synapse => {
@@ -166,6 +192,7 @@ pub async fn fetch_graph_facts_raw(
                 seed_community_cap: sa_config.seed_community_cap,
             };
             let timeout_ms = effective_recall_timeout_ms(sa_config.recall_timeout_ms);
+            let t0 = Instant::now();
             let activated_facts = match tokio::time::timeout(
                 std::time::Duration::from_millis(timeout_ms),
                 memory.recall_graph_activated(query, recall_limit, sa_params, &edge_types),
@@ -174,15 +201,63 @@ pub async fn fetch_graph_facts_raw(
             {
                 Ok(Ok(facts)) => facts,
                 Ok(Err(e)) => {
+                    let latency_ms = t0.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
                     tracing::warn!("spreading activation recall failed: {e:#}");
+                    // TODO(#3576): conversation_id and turn_index not yet propagated into
+                    // context helpers; tracked for future enhancement when
+                    // ContextAssemblyView exposes them.
+                    memory.log_retrieval_failure(RetrievalFailureRecord {
+                        conversation_id: None,
+                        turn_index: 0,
+                        failure_type: RetrievalFailureType::Error,
+                        retrieval_strategy: strategy_str.clone(),
+                        query_text: query.to_owned(),
+                        query_len: query.len(),
+                        top_score: None,
+                        confidence_threshold: None,
+                        result_count: 0,
+                        latency_ms,
+                        edge_types: edge_types_json.clone(),
+                        error_context: Some(format!("{e:#}")),
+                    });
                     Vec::new()
                 }
                 Err(_) => {
+                    let latency_ms = t0.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
                     tracing::warn!("spreading activation recall timed out ({timeout_ms}ms)");
+                    memory.log_retrieval_failure(RetrievalFailureRecord {
+                        conversation_id: None,
+                        turn_index: 0,
+                        failure_type: RetrievalFailureType::Timeout,
+                        retrieval_strategy: strategy_str.clone(),
+                        query_text: query.to_owned(),
+                        query_len: query.len(),
+                        top_score: None,
+                        confidence_threshold: None,
+                        result_count: 0,
+                        latency_ms,
+                        edge_types: edge_types_json.clone(),
+                        error_context: Some(format!("timeout after {timeout_ms}ms")),
+                    });
                     Vec::new()
                 }
             };
+            let latency_ms = t0.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
             if activated_facts.is_empty() {
+                memory.log_retrieval_failure(RetrievalFailureRecord {
+                    conversation_id: None,
+                    turn_index: 0,
+                    failure_type: RetrievalFailureType::NoHit,
+                    retrieval_strategy: strategy_str,
+                    query_text: query.to_owned(),
+                    query_len: query.len(),
+                    top_score: None,
+                    confidence_threshold: None,
+                    result_count: 0,
+                    latency_ms,
+                    edge_types: edge_types_json,
+                    error_context: None,
+                });
                 return Ok(None);
             }
             for f in &activated_facts {
@@ -200,7 +275,8 @@ pub async fn fetch_graph_facts_raw(
             }
         }
         GraphRetrievalStrategy::Bfs => {
-            let facts = memory
+            let t0 = Instant::now();
+            let facts = match memory
                 .recall_graph(
                     query,
                     recall_limit,
@@ -209,23 +285,51 @@ pub async fn fetch_graph_facts_raw(
                     temporal_decay_rate,
                     &edge_types,
                 )
-                .await?;
+                .await
+            {
+                Ok(f) => f,
+                Err(e) => {
+                    let latency_ms = t0.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                    memory.log_retrieval_failure(RetrievalFailureRecord {
+                        conversation_id: None,
+                        turn_index: 0,
+                        failure_type: RetrievalFailureType::Error,
+                        retrieval_strategy: strategy_str,
+                        query_text: query.to_owned(),
+                        query_len: query.len(),
+                        top_score: None,
+                        confidence_threshold: None,
+                        result_count: 0,
+                        latency_ms,
+                        edge_types: edge_types_json,
+                        error_context: Some(format!("{e:#}")),
+                    });
+                    return Err(e);
+                }
+            };
+            let latency_ms = t0.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
             if facts.is_empty() {
+                memory.log_retrieval_failure(RetrievalFailureRecord {
+                    conversation_id: None,
+                    turn_index: 0,
+                    failure_type: RetrievalFailureType::NoHit,
+                    retrieval_strategy: strategy_str,
+                    query_text: query.to_owned(),
+                    query_len: query.len(),
+                    top_score: None,
+                    confidence_threshold: None,
+                    result_count: 0,
+                    latency_ms,
+                    edge_types: edge_types_json,
+                    error_context: None,
+                });
                 return Ok(None);
             }
-            for f in &facts {
-                let fact_text = f.fact.replace(['\n', '\r', '<', '>'], " ");
-                let line = format!("- {} (confidence: {:.2})\n", fact_text, f.confidence);
-                let line_tokens = tc.count_tokens(&line);
-                if tokens_so_far + line_tokens > budget_tokens {
-                    break;
-                }
-                body.push_str(&line);
-                tokens_so_far += line_tokens;
-            }
+            append_graph_facts(&facts, &mut body, &mut tokens_so_far, budget_tokens, tc);
         }
         GraphRetrievalStrategy::AStar => {
-            let facts = memory
+            let t0 = Instant::now();
+            let facts = match memory
                 .recall_graph_astar(
                     query,
                     recall_limit,
@@ -233,24 +337,52 @@ pub async fn fetch_graph_facts_raw(
                     temporal_decay_rate,
                     &edge_types,
                 )
-                .await?;
+                .await
+            {
+                Ok(f) => f,
+                Err(e) => {
+                    let latency_ms = t0.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                    memory.log_retrieval_failure(RetrievalFailureRecord {
+                        conversation_id: None,
+                        turn_index: 0,
+                        failure_type: RetrievalFailureType::Error,
+                        retrieval_strategy: strategy_str,
+                        query_text: query.to_owned(),
+                        query_len: query.len(),
+                        top_score: None,
+                        confidence_threshold: None,
+                        result_count: 0,
+                        latency_ms,
+                        edge_types: edge_types_json,
+                        error_context: Some(format!("{e:#}")),
+                    });
+                    return Err(e);
+                }
+            };
+            let latency_ms = t0.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
             if facts.is_empty() {
+                memory.log_retrieval_failure(RetrievalFailureRecord {
+                    conversation_id: None,
+                    turn_index: 0,
+                    failure_type: RetrievalFailureType::NoHit,
+                    retrieval_strategy: strategy_str,
+                    query_text: query.to_owned(),
+                    query_len: query.len(),
+                    top_score: None,
+                    confidence_threshold: None,
+                    result_count: 0,
+                    latency_ms,
+                    edge_types: edge_types_json,
+                    error_context: None,
+                });
                 return Ok(None);
             }
-            for f in &facts {
-                let fact_text = f.fact.replace(['\n', '\r', '<', '>'], " ");
-                let line = format!("- {} (confidence: {:.2})\n", fact_text, f.confidence);
-                let line_tokens = tc.count_tokens(&line);
-                if tokens_so_far + line_tokens > budget_tokens {
-                    break;
-                }
-                body.push_str(&line);
-                tokens_so_far += line_tokens;
-            }
+            append_graph_facts(&facts, &mut body, &mut tokens_so_far, budget_tokens, tc);
         }
         GraphRetrievalStrategy::WaterCircles => {
             let ring_limit = graph_config.watercircles.ring_limit;
-            let facts = memory
+            let t0 = Instant::now();
+            let facts = match memory
                 .recall_graph_watercircles(
                     query,
                     recall_limit,
@@ -259,24 +391,52 @@ pub async fn fetch_graph_facts_raw(
                     temporal_decay_rate,
                     &edge_types,
                 )
-                .await?;
+                .await
+            {
+                Ok(f) => f,
+                Err(e) => {
+                    let latency_ms = t0.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                    memory.log_retrieval_failure(RetrievalFailureRecord {
+                        conversation_id: None,
+                        turn_index: 0,
+                        failure_type: RetrievalFailureType::Error,
+                        retrieval_strategy: strategy_str,
+                        query_text: query.to_owned(),
+                        query_len: query.len(),
+                        top_score: None,
+                        confidence_threshold: None,
+                        result_count: 0,
+                        latency_ms,
+                        edge_types: edge_types_json,
+                        error_context: Some(format!("{e:#}")),
+                    });
+                    return Err(e);
+                }
+            };
+            let latency_ms = t0.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
             if facts.is_empty() {
+                memory.log_retrieval_failure(RetrievalFailureRecord {
+                    conversation_id: None,
+                    turn_index: 0,
+                    failure_type: RetrievalFailureType::NoHit,
+                    retrieval_strategy: strategy_str,
+                    query_text: query.to_owned(),
+                    query_len: query.len(),
+                    top_score: None,
+                    confidence_threshold: None,
+                    result_count: 0,
+                    latency_ms,
+                    edge_types: edge_types_json,
+                    error_context: None,
+                });
                 return Ok(None);
             }
-            for f in &facts {
-                let fact_text = f.fact.replace(['\n', '\r', '<', '>'], " ");
-                let line = format!("- {} (confidence: {:.2})\n", fact_text, f.confidence);
-                let line_tokens = tc.count_tokens(&line);
-                if tokens_so_far + line_tokens > budget_tokens {
-                    break;
-                }
-                body.push_str(&line);
-                tokens_so_far += line_tokens;
-            }
+            append_graph_facts(&facts, &mut body, &mut tokens_so_far, budget_tokens, tc);
         }
         GraphRetrievalStrategy::BeamSearch => {
             let beam_width = graph_config.beam_search.beam_width;
-            let facts = memory
+            let t0 = Instant::now();
+            let facts = match memory
                 .recall_graph_beam(
                     query,
                     recall_limit,
@@ -285,39 +445,91 @@ pub async fn fetch_graph_facts_raw(
                     temporal_decay_rate,
                     &edge_types,
                 )
-                .await?;
+                .await
+            {
+                Ok(f) => f,
+                Err(e) => {
+                    let latency_ms = t0.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                    memory.log_retrieval_failure(RetrievalFailureRecord {
+                        conversation_id: None,
+                        turn_index: 0,
+                        failure_type: RetrievalFailureType::Error,
+                        retrieval_strategy: strategy_str,
+                        query_text: query.to_owned(),
+                        query_len: query.len(),
+                        top_score: None,
+                        confidence_threshold: None,
+                        result_count: 0,
+                        latency_ms,
+                        edge_types: edge_types_json,
+                        error_context: Some(format!("{e:#}")),
+                    });
+                    return Err(e);
+                }
+            };
+            let latency_ms = t0.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
             if facts.is_empty() {
+                memory.log_retrieval_failure(RetrievalFailureRecord {
+                    conversation_id: None,
+                    turn_index: 0,
+                    failure_type: RetrievalFailureType::NoHit,
+                    retrieval_strategy: strategy_str,
+                    query_text: query.to_owned(),
+                    query_len: query.len(),
+                    top_score: None,
+                    confidence_threshold: None,
+                    result_count: 0,
+                    latency_ms,
+                    edge_types: edge_types_json,
+                    error_context: None,
+                });
                 return Ok(None);
             }
-            for f in &facts {
-                let fact_text = f.fact.replace(['\n', '\r', '<', '>'], " ");
-                let line = format!("- {} (confidence: {:.2})\n", fact_text, f.confidence);
-                let line_tokens = tc.count_tokens(&line);
-                if tokens_so_far + line_tokens > budget_tokens {
-                    break;
-                }
-                body.push_str(&line);
-                tokens_so_far += line_tokens;
-            }
+            append_graph_facts(&facts, &mut body, &mut tokens_so_far, budget_tokens, tc);
         }
         GraphRetrievalStrategy::Hybrid => {
             const CLASSIFIER_TIMEOUT_MS: u64 = 2_000;
-            let classified = tokio::time::timeout(
+            let classifier_t0 = Instant::now();
+            let classified = if let Ok(s) = tokio::time::timeout(
                 std::time::Duration::from_millis(CLASSIFIER_TIMEOUT_MS),
                 memory.classify_graph_strategy(query),
             )
             .await
-            .unwrap_or_else(|_| {
+            {
+                s
+            } else {
+                let latency_ms = classifier_t0
+                    .elapsed()
+                    .as_millis()
+                    .try_into()
+                    .unwrap_or(u64::MAX);
                 tracing::warn!(
                     "hybrid strategy classifier timed out after {CLASSIFIER_TIMEOUT_MS}ms, \
                      falling back to synapse"
                 );
+                memory.log_retrieval_failure(RetrievalFailureRecord {
+                    conversation_id: None,
+                    turn_index: 0,
+                    failure_type: RetrievalFailureType::Timeout,
+                    retrieval_strategy: "hybrid_classifier".to_owned(),
+                    query_text: query.to_owned(),
+                    query_len: query.len(),
+                    top_score: None,
+                    confidence_threshold: None,
+                    result_count: 0,
+                    latency_ms,
+                    edge_types: edge_types_json.clone(),
+                    error_context: Some(format!(
+                        "classifier timeout after {CLASSIFIER_TIMEOUT_MS}ms"
+                    )),
+                });
                 "synapse".to_owned()
-            });
+            };
             tracing::debug!(classified_strategy = %classified, "hybrid dispatch: classified");
+            let t0 = Instant::now();
             let facts = match classified.as_str() {
                 "astar" => {
-                    memory
+                    match memory
                         .recall_graph_astar(
                             query,
                             recall_limit,
@@ -325,11 +537,33 @@ pub async fn fetch_graph_facts_raw(
                             temporal_decay_rate,
                             &edge_types,
                         )
-                        .await?
+                        .await
+                    {
+                        Ok(f) => f,
+                        Err(e) => {
+                            let latency_ms =
+                                t0.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                            memory.log_retrieval_failure(RetrievalFailureRecord {
+                                conversation_id: None,
+                                turn_index: 0,
+                                failure_type: RetrievalFailureType::Error,
+                                retrieval_strategy: strategy_str,
+                                query_text: query.to_owned(),
+                                query_len: query.len(),
+                                top_score: None,
+                                confidence_threshold: None,
+                                result_count: 0,
+                                latency_ms,
+                                edge_types: edge_types_json,
+                                error_context: Some(format!("{e:#}")),
+                            });
+                            return Err(e);
+                        }
+                    }
                 }
                 "watercircles" => {
                     let ring_limit = graph_config.watercircles.ring_limit;
-                    memory
+                    match memory
                         .recall_graph_watercircles(
                             query,
                             recall_limit,
@@ -338,11 +572,33 @@ pub async fn fetch_graph_facts_raw(
                             temporal_decay_rate,
                             &edge_types,
                         )
-                        .await?
+                        .await
+                    {
+                        Ok(f) => f,
+                        Err(e) => {
+                            let latency_ms =
+                                t0.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                            memory.log_retrieval_failure(RetrievalFailureRecord {
+                                conversation_id: None,
+                                turn_index: 0,
+                                failure_type: RetrievalFailureType::Error,
+                                retrieval_strategy: strategy_str,
+                                query_text: query.to_owned(),
+                                query_len: query.len(),
+                                top_score: None,
+                                confidence_threshold: None,
+                                result_count: 0,
+                                latency_ms,
+                                edge_types: edge_types_json,
+                                error_context: Some(format!("{e:#}")),
+                            });
+                            return Err(e);
+                        }
+                    }
                 }
                 "beam_search" => {
                     let beam_width = graph_config.beam_search.beam_width;
-                    memory
+                    match memory
                         .recall_graph_beam(
                             query,
                             recall_limit,
@@ -351,7 +607,29 @@ pub async fn fetch_graph_facts_raw(
                             temporal_decay_rate,
                             &edge_types,
                         )
-                        .await?
+                        .await
+                    {
+                        Ok(f) => f,
+                        Err(e) => {
+                            let latency_ms =
+                                t0.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                            memory.log_retrieval_failure(RetrievalFailureRecord {
+                                conversation_id: None,
+                                turn_index: 0,
+                                failure_type: RetrievalFailureType::Error,
+                                retrieval_strategy: strategy_str,
+                                query_text: query.to_owned(),
+                                query_len: query.len(),
+                                top_score: None,
+                                confidence_threshold: None,
+                                result_count: 0,
+                                latency_ms,
+                                edge_types: edge_types_json,
+                                error_context: Some(format!("{e:#}")),
+                            });
+                            return Err(e);
+                        }
+                    }
                 }
                 _ => {
                     let sa_params = zeph_memory::graph::SpreadingActivationParams {
@@ -364,39 +642,67 @@ pub async fn fetch_graph_facts_raw(
                         seed_structural_weight: sa_config.seed_structural_weight,
                         seed_community_cap: sa_config.seed_community_cap,
                     };
-                    memory
+                    match memory
                         .recall_graph_activated(query, recall_limit, sa_params, &edge_types)
-                        .await?
-                        .into_iter()
-                        .map(|f| zeph_memory::graph::types::GraphFact {
-                            entity_name: f.edge.source_entity_id.to_string(),
-                            relation: f.edge.relation.clone(),
-                            target_name: f.edge.target_entity_id.to_string(),
-                            fact: f.edge.fact.clone(),
-                            entity_match_score: f.activation_score,
-                            hop_distance: 0,
-                            confidence: f.edge.confidence,
-                            valid_from: Some(f.edge.valid_from.clone()),
-                            edge_type: f.edge.edge_type,
-                            retrieval_count: f.edge.retrieval_count,
-                            edge_id: Some(f.edge.id),
-                        })
-                        .collect()
+                        .await
+                    {
+                        Ok(activated) => activated
+                            .into_iter()
+                            .map(|f| zeph_memory::graph::types::GraphFact {
+                                entity_name: f.edge.source_entity_id.to_string(),
+                                relation: f.edge.relation.clone(),
+                                target_name: f.edge.target_entity_id.to_string(),
+                                fact: f.edge.fact.clone(),
+                                entity_match_score: f.activation_score,
+                                hop_distance: 0,
+                                confidence: f.edge.confidence,
+                                valid_from: Some(f.edge.valid_from.clone()),
+                                edge_type: f.edge.edge_type,
+                                retrieval_count: f.edge.retrieval_count,
+                                edge_id: Some(f.edge.id),
+                            })
+                            .collect(),
+                        Err(e) => {
+                            let latency_ms =
+                                t0.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                            memory.log_retrieval_failure(RetrievalFailureRecord {
+                                conversation_id: None,
+                                turn_index: 0,
+                                failure_type: RetrievalFailureType::Error,
+                                retrieval_strategy: strategy_str,
+                                query_text: query.to_owned(),
+                                query_len: query.len(),
+                                top_score: None,
+                                confidence_threshold: None,
+                                result_count: 0,
+                                latency_ms,
+                                edge_types: edge_types_json,
+                                error_context: Some(format!("{e:#}")),
+                            });
+                            return Err(e);
+                        }
+                    }
                 }
             };
+            let latency_ms = t0.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
             if facts.is_empty() {
+                memory.log_retrieval_failure(RetrievalFailureRecord {
+                    conversation_id: None,
+                    turn_index: 0,
+                    failure_type: RetrievalFailureType::NoHit,
+                    retrieval_strategy: strategy_str,
+                    query_text: query.to_owned(),
+                    query_len: query.len(),
+                    top_score: None,
+                    confidence_threshold: None,
+                    result_count: 0,
+                    latency_ms,
+                    edge_types: edge_types_json,
+                    error_context: None,
+                });
                 return Ok(None);
             }
-            for f in &facts {
-                let fact_text = f.fact.replace(['\n', '\r', '<', '>'], " ");
-                let line = format!("- {} (confidence: {:.2})\n", fact_text, f.confidence);
-                let line_tokens = tc.count_tokens(&line);
-                if tokens_so_far + line_tokens > budget_tokens {
-                    break;
-                }
-                body.push_str(&line);
-                tokens_so_far += line_tokens;
-            }
+            append_graph_facts(&facts, &mut body, &mut tokens_so_far, budget_tokens, tc);
         }
     }
 
@@ -411,9 +717,13 @@ pub async fn fetch_graph_facts_raw(
 ///
 /// Raw-args variant used by `zeph-core` test bridge methods and by [`fetch_semantic_recall`].
 ///
+/// When `low_confidence_threshold` is `Some(t)`, results with a top score below `t` are
+/// classified as low-confidence and logged via the memory's retrieval failure logger.
+///
 /// # Errors
 ///
 /// Returns [`zeph_memory::MemoryError`] when the memory backend returns an error.
+#[allow(clippy::too_many_arguments)]
 pub async fn fetch_semantic_recall_raw(
     memory: Option<&zeph_memory::semantic::SemanticMemory>,
     recall_limit: usize,
@@ -422,6 +732,7 @@ pub async fn fetch_semantic_recall_raw(
     token_budget: usize,
     tc: &TokenCounter,
     router: Option<&dyn zeph_memory::AsyncMemoryRouter>,
+    low_confidence_threshold: Option<f32>,
 ) -> Result<(Option<Message>, Option<f32>), zeph_memory::MemoryError> {
     let Some(memory) = memory else {
         return Ok((None, None));
@@ -430,6 +741,7 @@ pub async fn fetch_semantic_recall_raw(
         return Ok((None, None));
     }
 
+    let t0 = Instant::now();
     let recalled = if let Some(r) = router {
         memory
             .recall_routed_async(query, recall_limit, None, r)
@@ -437,11 +749,46 @@ pub async fn fetch_semantic_recall_raw(
     } else {
         memory.recall(query, recall_limit, None).await?
     };
+    let latency_ms = t0.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+
     if recalled.is_empty() {
+        memory.log_retrieval_failure(RetrievalFailureRecord {
+            conversation_id: None,
+            turn_index: 0,
+            failure_type: RetrievalFailureType::NoHit,
+            retrieval_strategy: "semantic".to_owned(),
+            query_text: query.to_owned(),
+            query_len: query.len(),
+            top_score: None,
+            confidence_threshold: low_confidence_threshold,
+            result_count: 0,
+            latency_ms,
+            edge_types: None,
+            error_context: None,
+        });
         return Ok((None, None));
     }
 
     let top_score = recalled.first().map(|r| r.score);
+
+    if let (Some(score), Some(threshold)) = (top_score, low_confidence_threshold)
+        && score < threshold
+    {
+        memory.log_retrieval_failure(RetrievalFailureRecord {
+            conversation_id: None,
+            turn_index: 0,
+            failure_type: RetrievalFailureType::LowConfidence,
+            retrieval_strategy: "semantic".to_owned(),
+            query_text: query.to_owned(),
+            query_len: query.len(),
+            top_score: Some(score),
+            confidence_threshold: Some(threshold),
+            result_count: recalled.len(),
+            latency_ms,
+            edge_types: None,
+            error_context: None,
+        });
+    }
     let initial_cap = (recall_limit * 512).min(token_budget * 3);
     let mut recall_text = String::with_capacity(initial_cap);
     recall_text.push_str(RECALL_PREFIX);
@@ -611,6 +958,7 @@ pub async fn fetch_semantic_recall(
         token_budget,
         tc,
         router,
+        None,
     )
     .await
     .map_err(ContextError::Memory)

--- a/crates/zeph-agent-context/src/service.rs
+++ b/crates/zeph-agent-context/src/service.rs
@@ -217,6 +217,7 @@ impl ContextService {
             token_budget,
             &view.token_counter,
             None,
+            None,
         )
         .await?;
 

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -139,9 +139,9 @@ pub use memory::{
     CategoryConfig, CompressionConfig, CompressionStrategy, ContextFormat, ContextStrategy,
     DigestConfig, DocumentConfig, ForgettingConfig, GraphConfig, HebbianConfig, MagicDocsConfig,
     MemCotConfig, MemoryConfig, MicrocompactConfig, NoteLinkingConfig, PersonaConfig,
-    PruningStrategy, ReasoningConfig, RecallViewConfig, RetrievalConfig, RpeConfig, SemanticConfig,
-    SessionsConfig, SidequestConfig, StoreRoutingConfig, StoreRoutingStrategy, TierConfig,
-    TrajectoryConfig, TreeConfig, VectorBackend,
+    PruningStrategy, ReasoningConfig, RecallViewConfig, RetrievalConfig, RetrievalFailuresConfig,
+    RpeConfig, SemanticConfig, SessionsConfig, SidequestConfig, StoreRoutingConfig,
+    StoreRoutingStrategy, TierConfig, TrajectoryConfig, TreeConfig, VectorBackend,
 };
 pub use metrics::MetricsConfig;
 pub use notifications::NotificationsConfig;

--- a/crates/zeph-config/src/memory.rs
+++ b/crates/zeph-config/src/memory.rs
@@ -933,6 +933,41 @@ pub struct MemoryConfig {
     /// ```
     #[serde(default)]
     pub memcot: MemCotConfig,
+    /// `OmniMem` retrieval failure tracking (issue #3576).
+    ///
+    /// When `enabled = true`, no-hit and low-confidence recall events are logged
+    /// asynchronously to `memory_retrieval_failures` for closed-loop parameter tuning.
+    ///
+    /// # Example (TOML)
+    ///
+    /// ```toml
+    /// [memory.retrieval_failures]
+    /// enabled = true
+    /// low_confidence_threshold = 0.3
+    /// retention_days = 90
+    /// ```
+    #[serde(default)]
+    pub retrieval_failures: RetrievalFailuresConfig,
+}
+
+fn default_retrieval_failures_low_confidence_threshold() -> f32 {
+    0.3
+}
+
+fn default_retrieval_failures_retention_days() -> u32 {
+    90
+}
+
+fn default_retrieval_failures_channel_capacity() -> usize {
+    256
+}
+
+fn default_retrieval_failures_batch_size() -> usize {
+    16
+}
+
+fn default_retrieval_failures_flush_interval_ms() -> u64 {
+    100
 }
 
 fn default_crossover_turn_threshold() -> u32 {
@@ -2974,6 +3009,49 @@ impl Default for MemCotConfig {
             recall_view: RecallViewConfig::Head,
             zoom_out_neighbor_cap: 3,
             fast_tier_models: Vec::new(),
+        }
+    }
+}
+
+/// `OmniMem` retrieval failure tracking configuration (issue #3576).
+///
+/// Controls the async logger that records no-hit and low-confidence recall events
+/// to `memory_retrieval_failures` for closed-loop memory parameter tuning.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct RetrievalFailuresConfig {
+    /// Enable retrieval failure logging. Default: `false`.
+    pub enabled: bool,
+    /// Composite recall score below which a result is classified as low-confidence.
+    ///
+    /// The threshold applies to the post-reranking composite score (which incorporates
+    /// MMR, temporal decay, importance weighting, and tier boost). Calibrate against
+    /// the scoring pipeline in use. Default: `0.3`.
+    #[serde(default = "default_retrieval_failures_low_confidence_threshold")]
+    pub low_confidence_threshold: f32,
+    /// Days to retain failure records before automatic cleanup. Default: `90`.
+    #[serde(default = "default_retrieval_failures_retention_days")]
+    pub retention_days: u32,
+    /// Bounded mpsc channel capacity for the fire-and-forget write path. Default: `256`.
+    #[serde(default = "default_retrieval_failures_channel_capacity")]
+    pub channel_capacity: usize,
+    /// Maximum records collected before flushing a batch INSERT. Default: `16`.
+    #[serde(default = "default_retrieval_failures_batch_size")]
+    pub batch_size: usize,
+    /// Maximum milliseconds to wait before flushing a partial batch. Default: `100`.
+    #[serde(default = "default_retrieval_failures_flush_interval_ms")]
+    pub flush_interval_ms: u64,
+}
+
+impl Default for RetrievalFailuresConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            low_confidence_threshold: default_retrieval_failures_low_confidence_threshold(),
+            retention_days: default_retrieval_failures_retention_days(),
+            channel_capacity: default_retrieval_failures_channel_capacity(),
+            batch_size: default_retrieval_failures_batch_size(),
+            flush_interval_ms: default_retrieval_failures_flush_interval_ms(),
         }
     }
 }

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -267,6 +267,7 @@ impl Default for Config {
                 reasoning: crate::memory::ReasoningConfig::default(),
                 hebbian: crate::memory::HebbianConfig::default(),
                 memcot: crate::memory::MemCotConfig::default(),
+                retrieval_failures: crate::memory::RetrievalFailuresConfig::default(),
             },
             telegram: None,
             discord: None,

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -1230,6 +1230,7 @@ impl<C: Channel> Agent<C> {
             token_budget,
             &self.runtime.metrics.token_counter,
             None,
+            None,
         )
         .await
         .map_err(|e| super::super::error::AgentError::ContextError(format!("{e:#}")))?;

--- a/crates/zeph-db/migrations/postgres/078_memory_retrieval_failures.sql
+++ b/crates/zeph-db/migrations/postgres/078_memory_retrieval_failures.sql
@@ -1,0 +1,23 @@
+-- Memory retrieval failure log for OmniMem self-improvement loop (issue #3576).
+-- Records no-hit and low-confidence recall events for closed-loop parameter tuning.
+CREATE TABLE IF NOT EXISTS memory_retrieval_failures (
+    id                   BIGSERIAL PRIMARY KEY,
+    conversation_id      BIGINT,
+    turn_index           BIGINT NOT NULL DEFAULT 0,
+    failure_type         TEXT NOT NULL
+                         CHECK (failure_type IN ('no_hit','low_confidence','timeout','error')),
+    retrieval_strategy   TEXT NOT NULL,
+    query_text           TEXT NOT NULL,
+    query_len            BIGINT NOT NULL DEFAULT 0,
+    top_score            REAL,
+    confidence_threshold REAL,
+    result_count         BIGINT NOT NULL DEFAULT 0,
+    latency_ms           BIGINT NOT NULL DEFAULT 0,
+    edge_types           TEXT,
+    error_context        TEXT,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_mrf_type     ON memory_retrieval_failures(failure_type);
+CREATE INDEX IF NOT EXISTS idx_mrf_strategy ON memory_retrieval_failures(retrieval_strategy);
+CREATE INDEX IF NOT EXISTS idx_mrf_created  ON memory_retrieval_failures(created_at);

--- a/crates/zeph-db/migrations/sqlite/083_memory_retrieval_failures.sql
+++ b/crates/zeph-db/migrations/sqlite/083_memory_retrieval_failures.sql
@@ -1,0 +1,23 @@
+-- Memory retrieval failure log for OmniMem self-improvement loop (issue #3576).
+-- Records no-hit and low-confidence recall events for closed-loop parameter tuning.
+CREATE TABLE IF NOT EXISTS memory_retrieval_failures (
+    id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+    conversation_id      INTEGER,
+    turn_index           INTEGER NOT NULL DEFAULT 0,
+    failure_type         TEXT NOT NULL
+                         CHECK (failure_type IN ('no_hit','low_confidence','timeout','error')),
+    retrieval_strategy   TEXT NOT NULL,
+    query_text           TEXT NOT NULL,
+    query_len            INTEGER NOT NULL DEFAULT 0,
+    top_score            REAL,
+    confidence_threshold REAL,
+    result_count         INTEGER NOT NULL DEFAULT 0,
+    latency_ms           INTEGER NOT NULL DEFAULT 0,
+    edge_types           TEXT,
+    error_context        TEXT,
+    created_at           TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_mrf_type     ON memory_retrieval_failures(failure_type);
+CREATE INDEX IF NOT EXISTS idx_mrf_strategy ON memory_retrieval_failures(retrieval_strategy);
+CREATE INDEX IF NOT EXISTS idx_mrf_created  ON memory_retrieval_failures(created_at);

--- a/crates/zeph-memory/src/lib.rs
+++ b/crates/zeph-memory/src/lib.rs
@@ -76,6 +76,7 @@ pub mod forgetting;
 pub mod hebbian_consolidation;
 pub mod reasoning;
 pub mod recall_view;
+pub mod retrieval_failure_logger;
 pub mod scenes;
 pub mod tiers;
 
@@ -157,6 +158,7 @@ pub use reasoning::{
 };
 pub use recall_view::{RecallView, RecalledFact};
 pub use response_cache::ResponseCache;
+pub use retrieval_failure_logger::RetrievalFailureLogger;
 pub use router::{
     AsyncMemoryRouter, HeuristicRouter, HybridRouter, LlmRouter, MemoryRoute, MemoryRouter,
     RoutingDecision, TemporalRange, classify_graph_subgraph, parse_route_str,
@@ -181,6 +183,7 @@ pub use store::corrections::UserCorrectionRow;
 pub use store::experiments::{ExperimentResultRow, NewExperimentResult, SessionSummaryRow};
 pub use store::memory_tree::MemoryTreeRow;
 pub use store::persona::PersonaFactRow;
+pub use store::retrieval_failures::{RetrievalFailureRecord, RetrievalFailureType};
 pub use store::session_digest::SessionDigest;
 pub use store::trajectory::{NewTrajectoryEntry, TrajectoryEntryRow};
 pub use tiers::{TierPromotionConfig, start_tier_promotion_loop};

--- a/crates/zeph-memory/src/retrieval_failure_logger.rs
+++ b/crates/zeph-memory/src/retrieval_failure_logger.rs
@@ -269,7 +269,7 @@ mod tests {
         let sqlite = SqliteStore::new(":memory:").await.unwrap();
         // capacity = 1 so the second send will be dropped
         let logger =
-            RetrievalFailureLogger::new(sqlite.clone(), 1, 16, Duration::from_secs(60), 90);
+            RetrievalFailureLogger::new(sqlite.clone(), 1, 16, Duration::from_mins(1), 90);
         // First log fills the channel (capacity 1).
         logger.log(no_hit_record());
         // Second log must not block — try_send drops the record silently.

--- a/crates/zeph-memory/src/retrieval_failure_logger.rs
+++ b/crates/zeph-memory/src/retrieval_failure_logger.rs
@@ -1,0 +1,347 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Async fire-and-forget logger for memory retrieval failure events.
+//!
+//! [`RetrievalFailureLogger`] owns a bounded mpsc sender. Callers invoke
+//! [`RetrievalFailureLogger::log`] on the hot path without blocking. A
+//! background task coalesces records into batches and flushes them to `SQLite`.
+
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+use tracing::Instrument as _;
+
+use crate::store::SqliteStore;
+use crate::store::retrieval_failures::RetrievalFailureRecord;
+
+const QUERY_TEXT_MAX_CHARS: usize = 512;
+const ERROR_CONTEXT_MAX_CHARS: usize = 256;
+/// How often to check for a cleanup opportunity (every N flushes).
+const CLEANUP_FLUSH_INTERVAL: u32 = 500;
+
+/// Async background writer that batches retrieval failure records to `SQLite`.
+///
+/// Construct with [`RetrievalFailureLogger::new`] and call [`RetrievalFailureLogger::log`]
+/// from the recall hot path. Records are sent via a bounded channel; if the channel is
+/// full the record is silently dropped (zero hot-path latency, per INV-1).
+///
+/// Fields are `Option` so that [`shutdown`](Self::shutdown) can take them without a
+/// move-out-of-`Drop` conflict, and so the `Drop` impl can abort any task not yet drained.
+/// `tx` is declared before `handle` to ensure the channel is closed before the handle is
+/// dropped, which allows the background task to exit cleanly when `Drop` fires.
+pub struct RetrievalFailureLogger {
+    // tx MUST be declared before handle — drop order closes the channel before the handle.
+    tx: Option<mpsc::Sender<RetrievalFailureRecord>>,
+    handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl RetrievalFailureLogger {
+    /// Spawn the background writer task and return a logger handle.
+    ///
+    /// `batch_size` records are flushed at once, or after `flush_interval` elapses,
+    /// whichever comes first. Old records are purged every `CLEANUP_FLUSH_INTERVAL`
+    /// batch flushes according to `retention_days`.
+    #[must_use]
+    pub fn new(
+        sqlite: SqliteStore,
+        channel_capacity: usize,
+        batch_size: usize,
+        flush_interval: Duration,
+        retention_days: u32,
+    ) -> Self {
+        let (tx, rx) = mpsc::channel(channel_capacity);
+        let handle = tokio::spawn(writer_task(
+            sqlite,
+            rx,
+            batch_size,
+            flush_interval,
+            retention_days,
+        ));
+        Self {
+            tx: Some(tx),
+            handle: Some(handle),
+        }
+    }
+
+    /// Queue a retrieval failure record for async persistence.
+    ///
+    /// Both `query_text` (512 chars) and `error_context` (256 chars) are truncated
+    /// before enqueueing to bound in-channel memory usage (INV-3). If the channel is
+    /// full the record is dropped and a debug message is emitted (INV-1).
+    pub fn log(&self, mut record: RetrievalFailureRecord) {
+        let _span = tracing::debug_span!("memory.retrieval_failure.log").entered();
+        if record.query_text.chars().count() > QUERY_TEXT_MAX_CHARS {
+            record.query_text = record
+                .query_text
+                .chars()
+                .take(QUERY_TEXT_MAX_CHARS)
+                .collect();
+        }
+        if let Some(ref mut ctx) = record.error_context
+            && ctx.chars().count() > ERROR_CONTEXT_MAX_CHARS
+        {
+            *ctx = ctx.chars().take(ERROR_CONTEXT_MAX_CHARS).collect();
+        }
+        if let Some(tx) = &self.tx
+            && tx.try_send(record).is_err()
+        {
+            tracing::debug!("retrieval_failure_logger: channel full, dropping record");
+        }
+    }
+
+    /// Shut down the background writer, draining any queued records.
+    ///
+    /// Closes the sender and waits for the background task to complete. Drop is
+    /// best-effort only; call this method for a clean drain on process exit.
+    pub async fn shutdown(mut self) {
+        drop(self.tx.take());
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.await;
+        }
+    }
+}
+
+impl Drop for RetrievalFailureLogger {
+    /// Abort the background writer task on drop.
+    ///
+    /// For a clean drain (flushing queued records) call [`RetrievalFailureLogger::shutdown`]
+    /// explicitly before dropping. This impl ensures the task is not silently detached.
+    fn drop(&mut self) {
+        if let Some(handle) = &self.handle {
+            handle.abort();
+        }
+    }
+}
+
+async fn writer_task(
+    sqlite: SqliteStore,
+    mut rx: mpsc::Receiver<RetrievalFailureRecord>,
+    batch_size: usize,
+    flush_interval: Duration,
+    retention_days: u32,
+) {
+    let mut batch: Vec<RetrievalFailureRecord> = Vec::with_capacity(batch_size);
+    let mut flush_counter: u32 = 0;
+
+    loop {
+        // Collect up to `batch_size` records or until the flush interval elapses.
+        let deadline = tokio::time::sleep(flush_interval);
+        tokio::pin!(deadline);
+
+        loop {
+            tokio::select! {
+                biased;
+                msg = rx.recv() => {
+                    if let Some(record) = msg {
+                        batch.push(record);
+                        if batch.len() >= batch_size {
+                            break;
+                        }
+                    } else {
+                        // Sender dropped — drain remaining and exit.
+                        flush_batch(&sqlite, &mut batch, &mut flush_counter, retention_days).await;
+                        return;
+                    }
+                }
+                () = &mut deadline => break,
+            }
+        }
+
+        flush_batch(&sqlite, &mut batch, &mut flush_counter, retention_days).await;
+    }
+}
+
+async fn flush_batch(
+    sqlite: &SqliteStore,
+    batch: &mut Vec<RetrievalFailureRecord>,
+    flush_counter: &mut u32,
+    retention_days: u32,
+) {
+    if batch.is_empty() {
+        return;
+    }
+    let count = batch.len();
+    tracing::debug!(count, "retrieval_failure_logger: flushing batch");
+    let span = tracing::info_span!("memory.retrieval_failure.flush", count);
+    let result = sqlite
+        .record_retrieval_failures_batch(batch)
+        .instrument(span)
+        .await;
+    if let Err(e) = result {
+        tracing::warn!("retrieval_failure_logger: batch write failed: {e:#}");
+    }
+    batch.clear();
+
+    *flush_counter = flush_counter.wrapping_add(1);
+    if (*flush_counter).is_multiple_of(CLEANUP_FLUSH_INTERVAL)
+        && let Err(e) = sqlite.purge_old_retrieval_failures(retention_days).await
+    {
+        tracing::debug!("retrieval_failure_logger: cleanup failed: {e:#}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+    use crate::store::SqliteStore;
+    use crate::store::retrieval_failures::{RetrievalFailureRecord, RetrievalFailureType};
+
+    fn no_hit_record() -> RetrievalFailureRecord {
+        RetrievalFailureRecord {
+            conversation_id: None,
+            turn_index: 0,
+            failure_type: RetrievalFailureType::NoHit,
+            retrieval_strategy: "semantic".into(),
+            query_text: "hello world".into(),
+            query_len: 11,
+            top_score: None,
+            confidence_threshold: None,
+            result_count: 0,
+            latency_ms: 5,
+            edge_types: None,
+            error_context: None,
+        }
+    }
+
+    fn low_confidence_record(score: f32, threshold: f32) -> RetrievalFailureRecord {
+        RetrievalFailureRecord {
+            conversation_id: None,
+            turn_index: 0,
+            failure_type: RetrievalFailureType::LowConfidence,
+            retrieval_strategy: "semantic".into(),
+            query_text: "low confidence query".into(),
+            query_len: 20,
+            top_score: Some(score),
+            confidence_threshold: Some(threshold),
+            result_count: 3,
+            latency_ms: 10,
+            edge_types: None,
+            error_context: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn no_hit_failure_is_persisted() {
+        let sqlite = SqliteStore::new(":memory:").await.unwrap();
+        let logger =
+            RetrievalFailureLogger::new(sqlite.clone(), 256, 16, Duration::from_millis(10), 90);
+        logger.log(no_hit_record());
+        logger.shutdown().await;
+
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "SELECT failure_type FROM memory_retrieval_failures WHERE failure_type = 'no_hit'",
+        )
+        .fetch_all(sqlite.pool())
+        .await
+        .unwrap();
+        assert_eq!(rows.len(), 1, "no_hit record must be persisted");
+    }
+
+    #[tokio::test]
+    async fn low_confidence_failure_is_persisted() {
+        let sqlite = SqliteStore::new(":memory:").await.unwrap();
+        let logger =
+            RetrievalFailureLogger::new(sqlite.clone(), 256, 16, Duration::from_millis(10), 90);
+        logger.log(low_confidence_record(0.3, 0.7));
+        logger.shutdown().await;
+
+        let rows: Vec<(String, f32, f32)> = sqlx::query_as(
+            "SELECT failure_type, top_score, confidence_threshold \
+             FROM memory_retrieval_failures WHERE failure_type = 'low_confidence'",
+        )
+        .fetch_all(sqlite.pool())
+        .await
+        .unwrap();
+        assert_eq!(rows.len(), 1, "low_confidence record must be persisted");
+        let (_, top_score, threshold) = &rows[0];
+        assert!((*top_score - 0.3_f32).abs() < 1e-5, "top_score must match");
+        assert!(
+            (*threshold - 0.7_f32).abs() < 1e-5,
+            "confidence_threshold must match"
+        );
+    }
+
+    #[tokio::test]
+    async fn log_does_not_block_when_channel_is_full() {
+        let sqlite = SqliteStore::new(":memory:").await.unwrap();
+        // capacity = 1 so the second send will be dropped
+        let logger =
+            RetrievalFailureLogger::new(sqlite.clone(), 1, 16, Duration::from_secs(60), 90);
+        // First log fills the channel (capacity 1).
+        logger.log(no_hit_record());
+        // Second log must not block — try_send drops the record silently.
+        let start = std::time::Instant::now();
+        logger.log(no_hit_record());
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < Duration::from_millis(100),
+            "log() must be non-blocking even when channel is full, elapsed={elapsed:?}"
+        );
+        logger.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn query_text_truncated_to_512_chars() {
+        let sqlite = SqliteStore::new(":memory:").await.unwrap();
+        let logger =
+            RetrievalFailureLogger::new(sqlite.clone(), 256, 16, Duration::from_millis(10), 90);
+        let long_query = "x".repeat(1000);
+        let mut record = no_hit_record();
+        record.query_text = long_query;
+        record.query_len = 1000;
+        logger.log(record);
+        logger.shutdown().await;
+
+        let rows: Vec<(String,)> =
+            sqlx::query_as("SELECT query_text FROM memory_retrieval_failures")
+                .fetch_all(sqlite.pool())
+                .await
+                .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].0.chars().count(),
+            512,
+            "query_text must be truncated to 512 chars"
+        );
+    }
+
+    #[tokio::test]
+    async fn logger_disabled_when_option_is_none() {
+        let sqlite = SqliteStore::new(":memory:").await.unwrap();
+        // No logger constructed — simulate the disabled path via Option<RetrievalFailureLogger>.
+        let logger: Option<RetrievalFailureLogger> = None;
+        if let Some(l) = &logger {
+            l.log(no_hit_record());
+        }
+        // Nothing written to the store.
+        let rows: Vec<(i64,)> = sqlx::query_as("SELECT COUNT(*) FROM memory_retrieval_failures")
+            .fetch_all(sqlite.pool())
+            .await
+            .unwrap();
+        assert_eq!(
+            rows[0].0, 0,
+            "no records must be written when logger is None"
+        );
+    }
+
+    #[tokio::test]
+    async fn multiple_records_batch_flushed() {
+        let sqlite = SqliteStore::new(":memory:").await.unwrap();
+        let logger =
+            RetrievalFailureLogger::new(sqlite.clone(), 256, 16, Duration::from_millis(10), 90);
+        for _ in 0..5 {
+            logger.log(no_hit_record());
+        }
+        logger.log(low_confidence_record(0.2, 0.8));
+        logger.shutdown().await;
+
+        let rows: Vec<(i64,)> = sqlx::query_as("SELECT COUNT(*) FROM memory_retrieval_failures")
+            .fetch_all(sqlite.pool())
+            .await
+            .unwrap();
+        assert_eq!(rows[0].0, 6, "all 6 records must be persisted in batch");
+    }
+}

--- a/crates/zeph-memory/src/retrieval_failure_logger.rs
+++ b/crates/zeph-memory/src/retrieval_failure_logger.rs
@@ -268,8 +268,7 @@ mod tests {
     async fn log_does_not_block_when_channel_is_full() {
         let sqlite = SqliteStore::new(":memory:").await.unwrap();
         // capacity = 1 so the second send will be dropped
-        let logger =
-            RetrievalFailureLogger::new(sqlite.clone(), 1, 16, Duration::from_mins(1), 90);
+        let logger = RetrievalFailureLogger::new(sqlite.clone(), 1, 16, Duration::from_mins(1), 90);
         // First log fills the channel (capacity 1).
         logger.log(no_hit_record());
         // Second log must not block — try_send drops the record silently.

--- a/crates/zeph-memory/src/semantic/mod.rs
+++ b/crates/zeph-memory/src/semantic/mod.rs
@@ -47,7 +47,9 @@ use zeph_llm::provider::LlmProvider as _;
 use crate::admission::AdmissionControl;
 use crate::embedding_store::EmbeddingStore;
 use crate::error::MemoryError;
+use crate::retrieval_failure_logger::RetrievalFailureLogger;
 use crate::store::SqliteStore;
+use crate::store::retrieval_failures::RetrievalFailureRecord;
 use crate::token_counter::TokenCounter;
 
 pub(crate) const SESSION_SUMMARIES_COLLECTION: &str = "zeph_session_summaries";
@@ -347,6 +349,10 @@ pub struct SemanticMemory {
     pub(crate) hebbian_lr: f32,
     /// HL-F5 spreading activation runtime config (#3346).
     pub(crate) hebbian_spread: HelaSpreadRuntime,
+    /// `OmniMem` retrieval failure logger (issue #3576).
+    ///
+    /// `Some` when `memory.retrieval_failures.enabled = true` at bootstrap.
+    pub(crate) retrieval_failure_logger: Option<RetrievalFailureLogger>,
 }
 
 impl SemanticMemory {
@@ -477,6 +483,7 @@ impl SemanticMemory {
             hebbian_reinforcement: HebbianReinforcement::Disabled,
             hebbian_lr: 0.1,
             hebbian_spread: HelaSpreadRuntime::default(),
+            retrieval_failure_logger: None,
         })
     }
 
@@ -539,6 +546,7 @@ impl SemanticMemory {
             hebbian_reinforcement: HebbianReinforcement::Disabled,
             hebbian_lr: 0.1,
             hebbian_spread: HelaSpreadRuntime::default(),
+            retrieval_failure_logger: None,
         })
     }
 
@@ -575,6 +583,27 @@ impl SemanticMemory {
     pub fn with_reasoning(mut self, store: Arc<crate::reasoning::ReasoningMemory>) -> Self {
         self.reasoning = Some(store);
         self
+    }
+
+    /// Attach a [`RetrievalFailureLogger`] for `OmniMem` self-improvement data collection.
+    ///
+    /// When attached, [`SemanticMemory::log_retrieval_failure`] records events
+    /// asynchronously. When absent, `log_retrieval_failure` is a no-op.
+    #[must_use]
+    pub fn with_retrieval_failure_logger(mut self, logger: RetrievalFailureLogger) -> Self {
+        self.retrieval_failure_logger = Some(logger);
+        self
+    }
+
+    /// Log a retrieval failure event asynchronously.
+    ///
+    /// No-op when retrieval failure logging is disabled (`retrieval_failure_logger` is `None`).
+    /// On the hot path this method never blocks — records are sent via a bounded mpsc channel
+    /// and dropped silently when the channel is full.
+    pub fn log_retrieval_failure(&self, record: RetrievalFailureRecord) {
+        if let Some(logger) = &self.retrieval_failure_logger {
+            logger.log(record);
+        }
     }
 
     /// Returns the cumulative count of community detection failures since startup.
@@ -1008,6 +1037,7 @@ impl SemanticMemory {
             hebbian_reinforcement: HebbianReinforcement::Disabled,
             hebbian_lr: 0.1,
             hebbian_spread: HelaSpreadRuntime::default(),
+            retrieval_failure_logger: None,
         }
     }
 
@@ -1089,6 +1119,7 @@ impl SemanticMemory {
             hebbian_reinforcement: HebbianReinforcement::Disabled,
             hebbian_lr: 0.1,
             hebbian_spread: HelaSpreadRuntime::default(),
+            retrieval_failure_logger: None,
         })
     }
 

--- a/crates/zeph-memory/src/semantic/recall.rs
+++ b/crates/zeph-memory/src/semantic/recall.rs
@@ -1978,6 +1978,7 @@ mod tests {
             hebbian_reinforcement: crate::semantic::HebbianReinforcement::Disabled,
             hebbian_lr: 0.1,
             hebbian_spread: crate::HelaSpreadRuntime::default(),
+            retrieval_failure_logger: None,
         }
     }
 

--- a/crates/zeph-memory/src/semantic/tests/graph.rs
+++ b/crates/zeph-memory/src/semantic/tests/graph.rs
@@ -344,6 +344,7 @@ async fn memory_with_in_memory_vector_store() -> (
         hebbian_reinforcement: HebbianReinforcement::Disabled,
         hebbian_lr: 0.1,
         hebbian_spread: crate::HelaSpreadRuntime::default(),
+        retrieval_failure_logger: None,
     };
 
     (memory, embedding_store)

--- a/crates/zeph-memory/src/semantic/tests/mod.rs
+++ b/crates/zeph-memory/src/semantic/tests/mod.rs
@@ -67,6 +67,7 @@ pub(super) async fn test_semantic_memory(_supports_embeddings: bool) -> Semantic
         hebbian_reinforcement: HebbianReinforcement::Disabled,
         hebbian_lr: 0.1,
         hebbian_spread: crate::HelaSpreadRuntime::default(),
+        retrieval_failure_logger: None,
     }
 }
 
@@ -166,6 +167,7 @@ async fn effective_embed_provider_routes_to_dedicated_embed_provider() {
         hebbian_reinforcement: HebbianReinforcement::Disabled,
         hebbian_lr: 0.1,
         hebbian_spread: crate::HelaSpreadRuntime::default(),
+        retrieval_failure_logger: None,
     };
 
     assert!(
@@ -575,6 +577,7 @@ async fn store_correction_embedding_sqlite_clean_db_roundtrip() {
         hebbian_reinforcement: HebbianReinforcement::Disabled,
         hebbian_lr: 0.1,
         hebbian_spread: crate::HelaSpreadRuntime::default(),
+        retrieval_failure_logger: None,
     };
 
     memory
@@ -694,6 +697,7 @@ async fn load_promotion_window_populates_embeddings_from_qdrant() {
         hebbian_reinforcement: HebbianReinforcement::Disabled,
         hebbian_lr: 0.1,
         hebbian_spread: crate::HelaSpreadRuntime::default(),
+        retrieval_failure_logger: None,
     };
 
     let window = memory.load_promotion_window(10).await.unwrap();

--- a/crates/zeph-memory/src/semantic/tests/query_bias.rs
+++ b/crates/zeph-memory/src/semantic/tests/query_bias.rs
@@ -105,6 +105,7 @@ async fn test_apply_query_bias_dimension_mismatch_returns_unchanged() {
         hebbian_reinforcement: super::super::HebbianReinforcement::Disabled,
         hebbian_lr: 0.1,
         hebbian_spread: crate::HelaSpreadRuntime::default(),
+        retrieval_failure_logger: None,
     };
 
     let embedding = vec![0.1_f32, 0.2, 0.3];

--- a/crates/zeph-memory/src/semantic/tests/recall.rs
+++ b/crates/zeph-memory/src/semantic/tests/recall.rs
@@ -84,6 +84,7 @@ async fn test_semantic_memory_sqlite_remember_recall_roundtrip() {
         hebbian_reinforcement: super::super::HebbianReinforcement::Disabled,
         hebbian_lr: 0.1,
         hebbian_spread: crate::HelaSpreadRuntime::default(),
+        retrieval_failure_logger: None,
     };
 
     let cid = memory.sqlite().create_conversation().await.unwrap();

--- a/crates/zeph-memory/src/semantic/tests/summarization.rs
+++ b/crates/zeph-memory/src/semantic/tests/summarization.rs
@@ -361,6 +361,7 @@ async fn summarize_fails_when_provider_chat_fails() {
         hebbian_reinforcement: HebbianReinforcement::Disabled,
         hebbian_lr: 0.1,
         hebbian_spread: crate::HelaSpreadRuntime::default(),
+        retrieval_failure_logger: None,
     };
     let cid = memory.sqlite().create_conversation().await.unwrap();
 
@@ -440,6 +441,7 @@ async fn summarize_fallback_to_plain_text_when_structured_fails() {
         hebbian_reinforcement: HebbianReinforcement::Disabled,
         hebbian_lr: 0.1,
         hebbian_spread: crate::HelaSpreadRuntime::default(),
+        retrieval_failure_logger: None,
     };
 
     let cid = memory.sqlite().create_conversation().await.unwrap();
@@ -604,6 +606,7 @@ async fn make_embed_memory_with_threshold(threshold: f32) -> super::super::Seman
         hebbian_reinforcement: HebbianReinforcement::Disabled,
         hebbian_lr: 0.1,
         hebbian_spread: crate::HelaSpreadRuntime::default(),
+        retrieval_failure_logger: None,
     }
 }
 
@@ -711,6 +714,7 @@ async fn store_key_facts_fail_open_on_search_error() {
         hebbian_reinforcement: HebbianReinforcement::Disabled,
         hebbian_lr: 0.1,
         hebbian_spread: crate::HelaSpreadRuntime::default(),
+        retrieval_failure_logger: None,
     };
 
     let cid = memory.sqlite().create_conversation().await.unwrap();

--- a/crates/zeph-memory/src/store/mod.rs
+++ b/crates/zeph-memory/src/store/mod.rs
@@ -41,6 +41,7 @@ pub(crate) mod messages;
 pub mod overflow;
 pub mod persona;
 pub mod preferences;
+pub mod retrieval_failures;
 pub mod session_digest;
 mod skills;
 mod summaries;

--- a/crates/zeph-memory/src/store/retrieval_failures.rs
+++ b/crates/zeph-memory/src/store/retrieval_failures.rs
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Persistent store for memory retrieval failure records.
+//!
+//! Failures are written via [`RetrievalFailureLogger`], which batches records
+//! asynchronously and inserts them in the background to avoid blocking the
+//! recall hot path.
+
+use super::SqliteStore;
+use crate::error::MemoryError;
+use zeph_db::sql;
+
+/// Classification of a memory retrieval failure event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetrievalFailureType {
+    /// No results were returned for the query.
+    NoHit,
+    /// Results were returned but the top score was below the confidence threshold.
+    LowConfidence,
+    /// The recall operation did not complete within the configured timeout.
+    Timeout,
+    /// The recall backend returned an error.
+    Error,
+}
+
+impl RetrievalFailureType {
+    /// Returns the canonical string representation stored in the database.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::NoHit => "no_hit",
+            Self::LowConfidence => "low_confidence",
+            Self::Timeout => "timeout",
+            Self::Error => "error",
+        }
+    }
+}
+
+/// A single retrieval failure event to be persisted.
+#[derive(Debug, Clone)]
+pub struct RetrievalFailureRecord {
+    /// Conversation this failure occurred in. `None` when persistence is not yet
+    /// initialized (first-turn edge case).
+    pub conversation_id: Option<crate::types::ConversationId>,
+    /// Turn counter within the conversation. Use `0` when unavailable.
+    pub turn_index: i64,
+    /// How the recall failed.
+    pub failure_type: RetrievalFailureType,
+    /// Name of the retrieval strategy that was attempted.
+    pub retrieval_strategy: String,
+    /// The query text (truncated to 512 chars by [`RetrievalFailureLogger::log`]).
+    pub query_text: String,
+    /// Byte length of the original query before any truncation.
+    ///
+    /// Note: `query_text` is truncated to 512 *chars* by [`RetrievalFailureLogger::log`],
+    /// so `query_len` may exceed `query_text.len()` for multibyte inputs.
+    pub query_len: usize,
+    /// Top score returned, if any results were produced.
+    pub top_score: Option<f32>,
+    /// Configured confidence threshold at failure time.
+    pub confidence_threshold: Option<f32>,
+    /// Number of results returned (0 for `NoHit`).
+    pub result_count: usize,
+    /// Wall-clock duration of the recall operation in milliseconds.
+    pub latency_ms: u64,
+    /// JSON-serialized list of graph edge types used (graph recall only).
+    pub edge_types: Option<String>,
+    /// Error message or timeout context for `Error`/`Timeout` variants.
+    ///
+    /// Truncated to 256 chars by [`RetrievalFailureLogger::log`] to bound channel memory.
+    pub error_context: Option<String>,
+}
+
+impl SqliteStore {
+    /// Insert a single retrieval failure record.
+    ///
+    /// Prefer [`RetrievalFailureLogger`] for hot-path inserts — this method is
+    /// intended for tests and one-off writes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError`] if the INSERT fails.
+    pub async fn record_retrieval_failure(
+        &self,
+        r: &RetrievalFailureRecord,
+    ) -> Result<(), MemoryError> {
+        self.record_retrieval_failures_batch(std::slice::from_ref(r))
+            .await
+    }
+
+    /// Batch-insert retrieval failure records in a single transaction.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError`] if any INSERT fails.
+    pub async fn record_retrieval_failures_batch(
+        &self,
+        records: &[RetrievalFailureRecord],
+    ) -> Result<(), MemoryError> {
+        if records.is_empty() {
+            return Ok(());
+        }
+        let mut tx = zeph_db::begin_write(self.pool()).await?;
+        for r in records {
+            let conversation_id = r.conversation_id.map(|c| c.0);
+            let failure_type = r.failure_type.as_str();
+            #[allow(clippy::cast_possible_wrap)]
+            let query_len = r.query_len as i64;
+            #[allow(clippy::cast_possible_wrap)]
+            let result_count = r.result_count as i64;
+            let latency_ms = r.latency_ms.cast_signed();
+            zeph_db::query(sql!(
+                "INSERT INTO memory_retrieval_failures
+                    (conversation_id, turn_index, failure_type, retrieval_strategy,
+                     query_text, query_len, top_score, confidence_threshold,
+                     result_count, latency_ms, edge_types, error_context)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            ))
+            .bind(conversation_id)
+            .bind(r.turn_index)
+            .bind(failure_type)
+            .bind(&r.retrieval_strategy)
+            .bind(&r.query_text)
+            .bind(query_len)
+            .bind(r.top_score)
+            .bind(r.confidence_threshold)
+            .bind(result_count)
+            .bind(latency_ms)
+            .bind(&r.edge_types)
+            .bind(&r.error_context)
+            .execute(&mut *tx)
+            .await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Delete records older than `retention_days` days.
+    ///
+    /// Called periodically by [`RetrievalFailureLogger`]'s background task.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError`] if the DELETE fails.
+    pub async fn purge_old_retrieval_failures(
+        &self,
+        retention_days: u32,
+    ) -> Result<u64, MemoryError> {
+        let cutoff = format!(
+            "{}",
+            (chrono::Utc::now() - chrono::Duration::days(i64::from(retention_days)))
+                .format("%Y-%m-%d %H:%M:%S")
+        );
+        let rows = zeph_db::query(sql!(
+            "DELETE FROM memory_retrieval_failures WHERE created_at < ?"
+        ))
+        .bind(cutoff)
+        .execute(self.pool())
+        .await?;
+        Ok(rows.rows_affected())
+    }
+}

--- a/crates/zeph-memory/src/store/retrieval_failures.rs
+++ b/crates/zeph-memory/src/store/retrieval_failures.rs
@@ -3,7 +3,7 @@
 
 //! Persistent store for memory retrieval failure records.
 //!
-//! Failures are written via [`RetrievalFailureLogger`], which batches records
+//! Failures are written via [`crate::RetrievalFailureLogger`], which batches records
 //! asynchronously and inserts them in the background to avoid blocking the
 //! recall hot path.
 
@@ -49,11 +49,11 @@ pub struct RetrievalFailureRecord {
     pub failure_type: RetrievalFailureType,
     /// Name of the retrieval strategy that was attempted.
     pub retrieval_strategy: String,
-    /// The query text (truncated to 512 chars by [`RetrievalFailureLogger::log`]).
+    /// The query text (truncated to 512 chars by [`crate::RetrievalFailureLogger::log`]).
     pub query_text: String,
     /// Byte length of the original query before any truncation.
     ///
-    /// Note: `query_text` is truncated to 512 *chars* by [`RetrievalFailureLogger::log`],
+    /// Note: `query_text` is truncated to 512 *chars* by [`crate::RetrievalFailureLogger::log`],
     /// so `query_len` may exceed `query_text.len()` for multibyte inputs.
     pub query_len: usize,
     /// Top score returned, if any results were produced.
@@ -68,14 +68,14 @@ pub struct RetrievalFailureRecord {
     pub edge_types: Option<String>,
     /// Error message or timeout context for `Error`/`Timeout` variants.
     ///
-    /// Truncated to 256 chars by [`RetrievalFailureLogger::log`] to bound channel memory.
+    /// Truncated to 256 chars by [`crate::RetrievalFailureLogger::log`] to bound channel memory.
     pub error_context: Option<String>,
 }
 
 impl SqliteStore {
     /// Insert a single retrieval failure record.
     ///
-    /// Prefer [`RetrievalFailureLogger`] for hot-path inserts — this method is
+    /// Prefer [`crate::RetrievalFailureLogger`] for hot-path inserts — this method is
     /// intended for tests and one-off writes.
     ///
     /// # Errors
@@ -138,7 +138,7 @@ impl SqliteStore {
 
     /// Delete records older than `retention_days` days.
     ///
-    /// Called periodically by [`RetrievalFailureLogger`]'s background task.
+    /// Called periodically by [`crate::RetrievalFailureLogger`]'s background task.
     ///
     /// # Errors
     ///

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -413,7 +413,30 @@ impl AppBuilder {
         memory =
             memory.with_key_facts_dedup_threshold(self.config.memory.key_facts_dedup_threshold);
 
+        if let Some(logger) = self.build_retrieval_failure_logger(memory.sqlite()) {
+            memory = memory.with_retrieval_failure_logger(logger);
+        }
+
         Ok(memory)
+    }
+
+    fn build_retrieval_failure_logger(
+        &self,
+        sqlite: &zeph_memory::store::DbStore,
+    ) -> Option<zeph_memory::RetrievalFailureLogger> {
+        if !self.config.memory.retrieval_failures.enabled {
+            return None;
+        }
+        let rf_cfg = &self.config.memory.retrieval_failures;
+        let logger = zeph_memory::RetrievalFailureLogger::new(
+            sqlite.clone(),
+            rf_cfg.channel_capacity,
+            rf_cfg.batch_size,
+            std::time::Duration::from_millis(rf_cfg.flush_interval_ms),
+            rf_cfg.retention_days,
+        );
+        tracing::info!("retrieval failure logging enabled");
+        Some(logger)
     }
 
     /// Attach `GraphStore` and optionally `ExperienceStore` to the in-progress `SemanticMemory`.


### PR DESCRIPTION
## Summary

- Adds `RetrievalFailureLogger` — async fire-and-forget subsystem that records memory retrieval failures (no-hit, low-confidence, timeout, error) into a new `memory_retrieval_failures` SQLite table (migration 083)
- Integrates at `fetch_graph_facts_raw` and `fetch_semantic_recall_raw` in `zeph-agent-context`
- Implements the minimum viable failure dataset for the OmniMem self-improvement loop (arXiv:2604.01007); scheduler-driven SYNAPSE tuning is out of scope and tracked separately

## Design

- **Write path**: bounded mpsc channel (256 cap) + background batch writer (16 records / 100 ms flush); `try_send` on hot path — zero latency impact
- **Four failure types**: `no_hit`, `low_confidence`, `timeout`, `error`
- **Config** (`[memory.retrieval_failures]`): `enabled = false` by default (privacy-safe opt-in), `low_confidence_threshold = 0.3`, `retention_days = 90`
- **Cleanup**: automatic DELETE of rows older than `retention_days` every 500 flushes
- **Shutdown**: `tx`/`handle` wrapped in `Option<_>`; `shutdown()` drains cleanly; `Drop` aborts background task

## Test plan

- [x] 6 unit tests: `no_hit_failure_is_persisted`, `low_confidence_failure_is_persisted`, `log_does_not_block_when_channel_is_full`, `query_text_truncated_to_512_chars`, `logger_disabled_when_option_is_none`, `multiple_records_batch_flushed`
- [x] 8841 workspace tests pass
- [ ] Live session: enable `[memory.retrieval_failures] enabled = true` and verify >100 rows after standard test session (see playbook `.local/testing/playbooks/memory-retrieval-failures.md`)

## References

- Closes #3576
- Research synthesis: #3566
- APEX-MEM spec: `/specs/004-memory/004-7-memory-apex-magma.md` §14.2