### PR TITLE
fix(cli): return user-friendly error when project purge stdin is not a terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- fix(cli): `zeph project purge` now returns a clear error message when stdin is not a terminal
+  and neither `--dry-run` nor `-y` was provided: `Aborted: stdin is not a terminal. Use --dry-run
+  to preview or -y to confirm non-interactively.` Previously the raw `IO error: not a terminal`
+  from `dialoguer` was propagated with no guidance. (#3599)
+
 - fix(lsp): LSP diagnostics context injection now works with mcpls v0.3.6+. Previously
   `fetch_diagnostics` silently returned `None` on every call because it expected a bare JSON array
   from `get_diagnostics`, but mcpls changed the response shape to `{"diagnostics": [...]}`.

--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -227,7 +227,17 @@ async fn run_purge(
         let proceed = Confirm::new()
             .with_prompt("This will permanently delete all project data. Continue?")
             .default(false)
-            .interact()?;
+            .interact()
+            .map_err(|e| {
+                if e.to_string().contains("not a terminal") {
+                    anyhow::anyhow!(
+                        "Aborted: stdin is not a terminal. \
+                         Use --dry-run to preview or -y to confirm non-interactively."
+                    )
+                } else {
+                    anyhow::anyhow!(e)
+                }
+            })?;
         if !proceed {
             println!("Aborted.");
             return Ok(());


### PR DESCRIPTION
## Summary

- `zeph project purge` without `--dry-run` or `-y` previously crashed with `Error: IO error: not a terminal` when stdin is not a TTY (pipe, CI, script context)
- The raw `dialoguer` IO error is now caught and replaced with an actionable message: `Aborted: stdin is not a terminal. Use --dry-run to preview or -y to confirm non-interactively.`
- Exit code is 1 (error), which is correct for an aborted non-interactive invocation

## Test plan

- [ ] `echo '' | cargo run --features full -- --config .local/config/testing.toml project purge` — should print the new message and exit with code 1, not `IO error: not a terminal`
- [ ] `cargo run --features full -- --config .local/config/testing.toml project purge --dry-run` — should still work normally
- [ ] `cargo run --features full -- --config .local/config/testing.toml project purge -y` — should still work normally
- [ ] Interactive terminal invocation — confirm prompt still works as before

Closes #3599