### PR TITLE
fix(memory.graph): add extract_provider to bypass quality_gate for extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- fix(memory.graph): add `extract_provider` to `[memory.graph]` config. Graph extraction tasks
+  produce low prompt/response similarity, causing systematic quality gate false positives. Setting
+  `extract_provider` to a named provider from `[[llm.providers]]` routes extraction through a
+  provider without the quality gate. **Action required**: set `extract_provider = "<name>"` in
+  `[memory.graph]` to activate the fix; the default (empty) preserves existing behavior (#3601).
+
 - fix(cli): `zeph project purge` now returns a clear error message when stdin is not a terminal
   and neither `--dry-run` nor `-y` was provided: `Aborted: stdin is not a terminal. Use --dry-run
   to preview or -y to confirm non-interactively.` Previously the raw `IO error: not a terminal`

--- a/config/default.toml
+++ b/config/default.toml
@@ -1035,6 +1035,11 @@ max_files = 7
 # # Do NOT use 8B local models (qwen3:8b, llama3.1:8b) without constrained decoding —
 # # they frequently produce malformed JSON and miss implicit entities (see #2192).
 # extract_model = "claude-sonnet-4-5-20250929"
+# # Named provider from [[llm.providers]] used for graph extraction.
+# # When set, bypasses the quality_gate that fires on JSON-structured tasks (#3601).
+# # Set to match the provider used by extract_model (e.g. "fast" for a gpt-4o-mini provider).
+# # Leave empty to use the primary provider (default behavior).
+# extract_provider = ""
 # # Maximum entities extracted per message
 # max_entities_per_message = 10
 # # Maximum edges (relations) extracted per message

--- a/crates/zeph-config/src/memory.rs
+++ b/crates/zeph-config/src/memory.rs
@@ -1754,6 +1754,19 @@ pub struct GraphConfig {
     /// SYNAPSE spreading activation is used. Set to `bfs` to revert to hop-limited BFS.
     #[serde(default)]
     pub retrieval_strategy: GraphRetrievalStrategy,
+    /// Named LLM provider from `[[llm.providers]]` for graph entity/relation extraction.
+    ///
+    /// When non-empty, graph extraction (and downstream note linking and community
+    /// summarization) use this provider instead of the primary `SemanticMemory.provider`.
+    /// This is the recommended fix for `quality_gate` false positives (#3601): JSON
+    /// extraction tasks produce structurally low prompt/response similarity (~0.55–0.70),
+    /// which causes systematic quality gate rejections. A named provider built via
+    /// `resolve_background_provider` bypasses `apply_routing_signals()` and therefore
+    /// has no quality gate attached.
+    ///
+    /// Falls back to the primary provider when empty. Default: `""` (use primary).
+    #[serde(default)]
+    pub extract_provider: ProviderName,
     /// Named LLM provider for hybrid strategy classification.
     /// Falls back to the default provider when `None`.
     #[serde(default)]
@@ -1827,6 +1840,7 @@ impl Default for GraphConfig {
             note_linking: NoteLinkingConfig::default(),
             spreading_activation: SpreadingActivationConfig::default(),
             retrieval_strategy: GraphRetrievalStrategy::default(),
+            extract_provider: ProviderName::default(),
             strategy_classifier_provider: None,
             beam_search: BeamSearchConfig::default(),
             watercircles: WaterCirclesConfig::default(),

--- a/crates/zeph-core/src/agent/persistence.rs
+++ b/crates/zeph-core/src/agent/persistence.rs
@@ -339,6 +339,9 @@ impl<C: Channel> Agent<C> {
                 .conversation_id
                 .map(|c| c.0),
         );
+        // Resolve a clean provider that bypasses quality_gate for JSON extraction tasks.
+        // When extract_provider is empty, falls back to the primary provider (existing behavior).
+        let extract_provider_name = cfg.extract_provider.as_str().to_owned();
 
         // RPE check: embed + compute surprise score. Stays on foreground to avoid
         // capturing the rpe_router mutex in a background task.
@@ -364,12 +367,19 @@ impl<C: Channel> Agent<C> {
                 None
             };
 
+        let provider_override = if extract_provider_name.is_empty() {
+            None
+        } else {
+            Some(self.resolve_background_provider(&extract_provider_name))
+        };
+
         self.spawn_graph_extraction_task(
             memory,
             content,
             context_messages,
             extraction_cfg,
             validator,
+            provider_override,
         );
 
         // Sync community failures and extraction metrics (cheap, foreground-safe).
@@ -385,6 +395,7 @@ impl<C: Channel> Agent<C> {
         context_messages: Vec<String>,
         extraction_cfg: zeph_memory::semantic::GraphExtractionConfig,
         validator: zeph_memory::semantic::PostExtractValidator,
+        provider_override: Option<zeph_llm::any::AnyProvider>,
     ) {
         let content_owned = content.to_owned();
         let graph_store = memory.graph_store.clone();
@@ -400,6 +411,7 @@ impl<C: Channel> Agent<C> {
                     context_messages,
                     extraction_cfg,
                     validator,
+                    provider_override,
                 );
 
                 // After extraction completes, refresh graph count metrics.

--- a/crates/zeph-memory/src/semantic/graph.rs
+++ b/crates/zeph-memory/src/semantic/graph.rs
@@ -558,10 +558,19 @@ impl SemanticMemory {
         context_messages: Vec<String>,
         config: GraphExtractionConfig,
         post_extract_validator: PostExtractValidator,
+        provider_override: Option<AnyProvider>,
     ) -> tokio::task::JoinHandle<()> {
+        let using_override = provider_override.is_some();
+        let provider = provider_override.unwrap_or_else(|| self.provider.clone());
+        if using_override {
+            tracing::debug!(
+                extract_provider = provider.name(),
+                "graph extraction using override provider (quality_gate bypassed)"
+            );
+        }
         let ctx = GraphExtractionTaskCtx {
             pool: self.sqlite.pool().clone(),
-            provider: self.provider.clone(),
+            provider,
             failure_counter: self.community_detection_failures.clone(),
             extraction_count: self.graph_extraction_count.clone(),
             extraction_failures: self.graph_extraction_failures.clone(),

--- a/crates/zeph-memory/src/semantic/tests/graph.rs
+++ b/crates/zeph-memory/src/semantic/tests/graph.rs
@@ -255,6 +255,28 @@ async fn spawn_graph_extraction_zero_timeout_returns_without_panic() {
         vec![],
         cfg,
         None,
+        None,
+    );
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+}
+
+#[tokio::test]
+async fn spawn_graph_extraction_with_provider_override_does_not_panic() {
+    use zeph_llm::mock::MockProvider;
+    let memory = graph_memory().await;
+    let cfg = GraphExtractionConfig {
+        max_entities: 5,
+        max_edges: 5,
+        extraction_timeout_secs: 0,
+        ..Default::default()
+    };
+    let override_provider = AnyProvider::Mock(MockProvider::with_responses(vec![]));
+    memory.spawn_graph_extraction(
+        "I use Rust for systems programming".to_owned(),
+        vec![],
+        cfg,
+        None,
+        Some(override_provider),
     );
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 }


### PR DESCRIPTION
## Summary

- `[llm.router] quality_gate` fired on every graph extraction call because JSON extraction responses have structurally low cosine similarity to the extraction prompt (~0.55–0.70), below the 0.75 threshold
- Added `extract_provider` field to `GraphConfig`, matching the existing pattern in `ReasoningConfig` and `CompressionConfig`
- When set, graph extraction (and downstream note linking and community summarization) use a clean provider built via `resolve_background_provider` that bypasses `apply_routing_signals()` and the quality gate

## Test plan

- [ ] Set `[memory.graph] extract_provider = "<name>"` in `.local/config/testing.toml` and run a multi-turn session with `[memory.graph] enabled = true`
- [ ] Verify no `thompson_quality_fallback` log entries for `memory.graph_extract`
- [ ] Verify graph extraction completes without provider cycling
- [ ] Verify default (empty `extract_provider`) preserves existing behavior — no regressions

Closes #3601