### PR TITLE
feat(orchestration): orchestrator_provider (SLM-as-orchestrator) and AdmissionGate (admission control)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- feat(orchestration): `orchestrator_provider` config field in `[orchestration]` — sets a
+  dedicated provider for scheduling-tier LLM calls (aggregation, predicate evaluation, and
+  verification fallback). Acts as a fallback for `verify_provider` and `predicate_provider` when
+  those are not explicitly set; does NOT affect `planner_provider`. Set to a cheap/fast model
+  (e.g. `orchestrator_provider = "fast"`) to reduce orchestration cost without impacting plan
+  quality. Resolution order per subsystem: `LlmAggregator` → `orchestrator_provider` → primary;
+  `PlanVerifier` → `verify_provider` → `orchestrator_provider` → primary; `PredicateEvaluator`
+  → `predicate_provider` → `orchestrator_provider` → `verify_provider` → primary.
+  **Trade-off**: routing `LlmAggregator` through `orchestrator_provider` may reduce final
+  synthesis quality when a cheap/fast model is chosen, since aggregation produces user-visible
+  output. A config migration step (step 43) adds the commented-out field to existing configs.
+  Implements #3300.
+
 - feat(cli): `zeph project purge` command removes all project-local state (SQLite database,
   log files, debug artifacts, trace files, audit log, and Qdrant collections) with `--dry-run`
   and `-y` flags. Includes pre-flight exclusive lock check on the SQLite database to prevent

--- a/crates/zeph-config/src/experiment.rs
+++ b/crates/zeph-config/src/experiment.rs
@@ -292,6 +292,30 @@ pub struct OrchestrationConfig {
     /// Default: `true`.
     #[serde(default = "default_persistence_enabled")]
     pub persistence_enabled: bool,
+    /// Provider name from `[[llm.providers]]` for scheduling-tier LLM calls
+    /// (aggregation, predicate evaluation, verification when no specific provider is set).
+    ///
+    /// Acts as fallback for `verify_provider` and `predicate_provider` when those are empty.
+    /// Does NOT affect `planner_provider` — planning is a complex task and stays on the quality
+    /// provider. Empty string = use the agent's primary provider.
+    ///
+    /// # Trade-off
+    ///
+    /// Setting this to a fast/cheap model reduces aggregation quality because `LlmAggregator`
+    /// produces user-visible output. See CHANGELOG for details.
+    #[serde(default)]
+    pub orchestrator_provider: ProviderName,
+
+    /// Default per-task cost budget in US cents. `0.0` = unlimited (no budget check).
+    ///
+    /// When a sub-agent task completes, the scheduler emits a `tracing::warn!` if the
+    /// task exceeded this budget. In MVP this is **warn-only** — hard enforcement requires
+    /// per-task `CostTracker` scoping, which is deferred post-v1.0.0.
+    ///
+    /// Individual tasks can override this via `TaskNode::token_budget_cents`.
+    /// Default: `0.0` (unlimited).
+    #[serde(default)]
+    pub default_task_budget_cents: f64,
 }
 
 impl Default for OrchestrationConfig {
@@ -329,6 +353,8 @@ impl Default for OrchestrationConfig {
             max_predicate_replans: default_max_predicate_replans(),
             predicate_timeout_secs: default_predicate_timeout_secs(),
             persistence_enabled: default_persistence_enabled(),
+            orchestrator_provider: ProviderName::default(),
+            default_task_budget_cents: 0.0,
         }
     }
 }

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -3199,6 +3199,71 @@ pub fn migrate_tools_compression_config(toml_src: &str) -> Result<MigrationResul
     })
 }
 
+/// Add `orchestrator_provider` as a commented-out entry in `[orchestration]` when absent.
+///
+/// # Errors
+///
+/// Returns [`MigrateError::Parse`] when `toml_src` is not valid TOML.
+pub fn migrate_orchestration_orchestrator_provider(
+    toml_src: &str,
+) -> Result<MigrationResult, MigrateError> {
+    if toml_src.contains("orchestrator_provider") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let comment = "\n# Provider for scheduling-tier LLM calls (aggregation, predicate, verify fallback).\n\
+         # Set to a cheap/fast model to reduce orchestration cost. Empty = primary provider.\n\
+         # Add under the orchestration section in your config:\n\
+         # orchestrator_provider = \"\"\n";
+
+    Ok(MigrationResult {
+        output: format!("{toml_src}{comment}"),
+        changed_count: 1,
+        sections_changed: vec!["orchestration".to_owned()],
+    })
+}
+
+/// Add a commented-out `max_concurrent` hint to `[[llm.providers]]` entries when absent.
+///
+/// `max_concurrent` limits how many orchestrated sub-agent calls may be in-flight to a
+/// given provider simultaneously. The field is optional (`None` = unlimited), so existing
+/// configs continue to work without changes.
+///
+/// # Errors
+///
+/// Returns [`MigrateError::Parse`] when `toml_src` is not valid TOML.
+pub fn migrate_provider_max_concurrent(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    if toml_src.contains("max_concurrent") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    if !toml_src.contains("[[llm.providers]]") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let comment = "\n# Optional: maximum concurrent sub-agent calls to this provider (admission control).\n\
+         # Remove the comment to enable; omit or set to 0 for unlimited.\n\
+         # max_concurrent = 4\n";
+
+    Ok(MigrationResult {
+        output: format!("{toml_src}{comment}"),
+        changed_count: 1,
+        sections_changed: vec!["llm.providers".to_owned()],
+    })
+}
+
 // ── Migration trait and registry ────────────────────────────────────────────────────────────────
 
 /// A single idempotent config migration step.
@@ -3248,14 +3313,15 @@ use steps::{
     MigrateMemoryHebbianConsolidation, MigrateMemoryHebbianSpread, MigrateMemoryPersonaConfig,
     MigrateMemoryReasoning, MigrateMemoryReasoningJudge, MigrateMemoryRetrieval,
     MigrateMemoryRetrievalQueryBias, MigrateMicrocompactConfig, MigrateOrchestrationPersistence,
-    MigrateOtelFilter, MigratePlannerModelToProvider, MigrateQdrantApiKey, MigrateQualityConfig,
-    MigrateSandboxConfig, MigrateSandboxEgressFilter, MigrateSchedulerDaemon,
-    MigrateSessionProviderPersistence, MigrateSessionRecapConfig, MigrateShellTransactional,
-    MigrateSttToProvider, MigrateSupervisorConfig, MigrateTelemetryConfig,
-    MigrateToolsCompressionConfig, MigrateVigilConfig,
+    MigrateOrchestratorProvider, MigrateOtelFilter, MigratePlannerModelToProvider,
+    MigrateProviderMaxConcurrent, MigrateQdrantApiKey, MigrateQualityConfig, MigrateSandboxConfig,
+    MigrateSandboxEgressFilter, MigrateSchedulerDaemon, MigrateSessionProviderPersistence,
+    MigrateSessionRecapConfig, MigrateShellTransactional, MigrateSttToProvider,
+    MigrateSupervisorConfig, MigrateTelemetryConfig, MigrateToolsCompressionConfig,
+    MigrateVigilConfig,
 };
 
-/// Ordered registry of all sequential migration steps (steps 1–40).
+/// Ordered registry of all sequential migration steps (steps 1–44).
 ///
 /// Each entry wraps the corresponding free function and is evaluated lazily at first access.
 /// The ordering is chronological; the dispatch loop in `src/commands/migrate.rs` iterates
@@ -3322,6 +3388,10 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             // Steps 41–42 — goal lifecycle and TACO compression (#3567, #3306)
             Box::new(MigrateGoalsConfig),
             Box::new(MigrateToolsCompressionConfig),
+            // Step 43 — orchestrator_provider for scheduling-tier LLM calls (#3300)
+            Box::new(MigrateOrchestratorProvider),
+            // Step 44 — max_concurrent per-provider admission control hint (#3299)
+            Box::new(MigrateProviderMaxConcurrent),
         ]
     });
 
@@ -3340,8 +3410,8 @@ mod tests {
     fn migrations_registry_has_all_steps() {
         assert_eq!(
             MIGRATIONS.len(),
-            42,
-            "MIGRATIONS registry must contain all 42 sequential steps"
+            44,
+            "MIGRATIONS registry must contain all 44 sequential steps"
         );
         for m in MIGRATIONS.iter() {
             assert!(
@@ -4928,7 +4998,7 @@ prompt_cache_ttl = "1h"
 
     #[test]
     fn registry_has_thirty_nine_entries() {
-        assert_eq!(MIGRATIONS.len(), 42);
+        assert_eq!(MIGRATIONS.len(), 44);
     }
 
     #[test]
@@ -4967,7 +5037,7 @@ prompt_cache_ttl = "1h"
 
     #[test]
     fn registry_preserves_order_matches_dispatch() {
-        // Names must follow the documented step order (steps 1–42).
+        // Names must follow the documented step order (steps 1–43).
         let expected = [
             "migrate_stt_to_provider",
             "migrate_planner_model_to_provider",
@@ -5011,6 +5081,8 @@ prompt_cache_ttl = "1h"
             "migrate_mcp_max_connect_attempts",
             "migrate_goals_config",
             "migrate_tools_compression_config",
+            "migrate_orchestrator_provider",
+            "migrate_provider_max_concurrent",
         ];
         let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
         assert_eq!(actual, expected);
@@ -5085,6 +5157,62 @@ prompt_cache_ttl = "1h"
     fn migrate_mcp_max_connect_attempts_skips_when_no_mcp_section() {
         let src = "[agent]\nname = \"Zeph\"\n";
         let result = migrate_mcp_max_connect_attempts(src).expect("migrate");
+        assert_eq!(result.changed_count, 0);
+        assert_eq!(result.output, src);
+    }
+
+    // ── Step 43 — orchestrator_provider ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn step43_adds_orchestrator_provider_comment_when_absent() {
+        let src = "[orchestration]\nenabled = true\n";
+        let result = migrate_orchestration_orchestrator_provider(src).expect("migrate");
+        assert_eq!(result.changed_count, 1);
+        assert!(
+            result.output.contains("orchestrator_provider"),
+            "migration must inject orchestrator_provider hint"
+        );
+    }
+
+    #[test]
+    fn step43_noop_when_orchestrator_provider_already_present() {
+        let src = "[orchestration]\nenabled = true\norchestrator_provider = \"\"\n";
+        let result = migrate_orchestration_orchestrator_provider(src).expect("migrate");
+        assert_eq!(
+            result.changed_count, 0,
+            "must not modify already-present key"
+        );
+        assert_eq!(result.output, src);
+    }
+
+    // ── Step 44 — max_concurrent per-provider ────────────────────────────────────────────────────
+
+    #[test]
+    fn step44_adds_max_concurrent_comment_when_providers_present() {
+        let src = "[[llm.providers]]\nname = \"quality\"\ntype = \"openai\"\n";
+        let result = migrate_provider_max_concurrent(src).expect("migrate");
+        assert_eq!(result.changed_count, 1);
+        assert!(
+            result.output.contains("max_concurrent"),
+            "migration must inject max_concurrent hint"
+        );
+    }
+
+    #[test]
+    fn step44_noop_when_max_concurrent_already_present() {
+        let src = "[[llm.providers]]\nname = \"quality\"\nmax_concurrent = 4\n";
+        let result = migrate_provider_max_concurrent(src).expect("migrate");
+        assert_eq!(
+            result.changed_count, 0,
+            "must not modify already-present key"
+        );
+        assert_eq!(result.output, src);
+    }
+
+    #[test]
+    fn step44_noop_when_no_providers_section() {
+        let src = "[agent]\nname = \"Zeph\"\n";
+        let result = migrate_provider_max_concurrent(src).expect("migrate");
         assert_eq!(result.changed_count, 0);
         assert_eq!(result.output, src);
     }

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -22,7 +22,8 @@ use super::{
     migrate_memory_persona_config, migrate_memory_reasoning_config,
     migrate_memory_reasoning_judge_config, migrate_memory_retrieval_config,
     migrate_memory_retrieval_query_bias, migrate_microcompact_config,
-    migrate_orchestration_persistence, migrate_otel_filter, migrate_planner_model_to_provider,
+    migrate_orchestration_orchestrator_provider, migrate_orchestration_persistence,
+    migrate_otel_filter, migrate_planner_model_to_provider, migrate_provider_max_concurrent,
     migrate_qdrant_api_key, migrate_quality_config, migrate_sandbox_config,
     migrate_sandbox_egress_filter, migrate_scheduler_daemon_config,
     migrate_session_provider_persistence, migrate_session_recap_config,
@@ -491,5 +492,27 @@ impl Migration for MigrateToolsCompressionConfig {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_tools_compression_config(toml_src)
+    }
+}
+
+pub(super) struct MigrateOrchestratorProvider;
+impl Migration for MigrateOrchestratorProvider {
+    fn name(&self) -> &'static str {
+        "migrate_orchestrator_provider"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_orchestration_orchestrator_provider(toml_src)
+    }
+}
+
+pub(super) struct MigrateProviderMaxConcurrent;
+impl Migration for MigrateProviderMaxConcurrent {
+    fn name(&self) -> &'static str {
+        "migrate_provider_max_concurrent"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_provider_max_concurrent(toml_src)
     }
 }

--- a/crates/zeph-config/src/providers.rs
+++ b/crates/zeph-config/src/providers.rs
@@ -1422,6 +1422,26 @@ pub struct ProviderEntry {
     /// Provider-specific instruction file.
     #[serde(default)]
     pub instruction_file: Option<std::path::PathBuf>,
+
+    /// Maximum concurrent LLM calls from orchestrated sub-agents to this provider.
+    ///
+    /// When set, `DagScheduler` acquires a semaphore permit before dispatching a
+    /// sub-agent that targets this provider. Dispatch is deferred (using the existing
+    /// `deferral_backoff` mechanism) when the semaphore is saturated.
+    ///
+    /// `None` (default) = unlimited — no admission control applied.
+    ///
+    /// # Example (TOML)
+    ///
+    /// ```toml
+    /// [[llm.providers]]
+    /// name = "quality"
+    /// type = "openai"
+    /// model = "gpt-5"
+    /// max_concurrent = 3
+    /// ```
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_concurrent: Option<u32>,
 }
 
 impl Default for ProviderEntry {
@@ -1448,6 +1468,7 @@ impl Default for ProviderEntry {
             candle: None,
             vision_model: None,
             instruction_file: None,
+            max_concurrent: None,
         }
     }
 }

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -439,6 +439,28 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Set a dedicated provider for scheduling-tier LLM calls.
+    ///
+    /// Acts as fallback for `verify_provider` and `predicate_provider` when those are not set.
+    /// Does NOT affect `planner_provider`. When not set, scheduling-tier calls fall back to the
+    /// primary provider. Corresponds to `orchestration.orchestrator_provider` in config.
+    #[must_use]
+    pub fn with_orchestrator_provider(mut self, provider: AnyProvider) -> Self {
+        self.services.orchestration.orchestrator_provider = Some(provider);
+        self
+    }
+
+    /// Set a dedicated provider for predicate gate evaluation.
+    ///
+    /// When not set, predicate evaluation falls back to `orchestrator_provider`, then
+    /// `verify_provider`, then the primary provider.
+    /// Corresponds to `orchestration.predicate_provider` in config.
+    #[must_use]
+    pub fn with_predicate_provider(mut self, provider: AnyProvider) -> Self {
+        self.services.orchestration.predicate_provider = Some(provider);
+        self
+    }
+
     /// Set the `AdaptOrch` topology advisor.
     ///
     /// When set, `handle_plan_goal_as_string` calls `advisor.recommend()` before planning

--- a/crates/zeph-core/src/agent/plan.rs
+++ b/crates/zeph-core/src/agent/plan.rs
@@ -181,12 +181,29 @@ impl<C: crate::channel::Channel> Agent<C> {
             mgr.reserve_slots(reserved);
         }
 
+        // Build admission gate from providers that have `max_concurrent` set (C1 fix).
+        let admission_gate = {
+            let pairs: Vec<(String, usize)> = self
+                .runtime
+                .providers
+                .provider_pool
+                .iter()
+                .filter_map(|e| e.max_concurrent.map(|c| (e.effective_name(), c as usize)))
+                .collect();
+            if pairs.is_empty() {
+                None
+            } else {
+                Some(zeph_orchestration::AdmissionGate::new(&pairs))
+            }
+        };
+
         let scheduler = if graph.status == GraphStatus::Created {
             DagScheduler::new(
                 graph,
                 &self.services.orchestration.orchestration_config,
                 Box::new(RuleBasedRouter),
                 available_agents,
+                admission_gate,
             )
         } else {
             DagScheduler::resume_from(
@@ -194,6 +211,7 @@ impl<C: crate::channel::Channel> Agent<C> {
                 &self.services.orchestration.orchestration_config,
                 Box::new(RuleBasedRouter),
                 available_agents,
+                admission_gate,
             )
         }
         .map_err(|e| {
@@ -218,6 +236,21 @@ impl<C: crate::channel::Channel> Agent<C> {
                 }
                 error::OrchestrationFailure::VerifyConfig(e.to_string())
             })?;
+
+        // M1: warn-only validation for orchestrator_provider (typos silently fall back at runtime).
+        let op = self
+            .services
+            .orchestration
+            .orchestration_config
+            .orchestrator_provider
+            .as_str();
+        if !op.is_empty() && !provider_names.contains(&op) {
+            tracing::warn!(
+                provider = op,
+                "orchestration.orchestrator_provider not found in [[llm.providers]]; \
+                 will fall back to primary provider"
+            );
+        }
 
         Ok((scheduler, reserved))
     }
@@ -319,6 +352,7 @@ impl<C: crate::channel::Channel> Agent<C> {
         scheduler: &mut zeph_orchestration::DagScheduler,
         final_status: zeph_orchestration::GraphStatus,
     ) -> Option<Vec<zeph_orchestration::TaskNode>> {
+        use tracing::Instrument as _;
         use zeph_orchestration::{GraphStatus, PlanVerifier};
 
         if final_status != GraphStatus::Completed
@@ -351,11 +385,15 @@ impl<C: crate::channel::Channel> Agent<C> {
             .orchestration
             .verify_provider
             .as_ref()
+            .or(self.services.orchestration.orchestrator_provider.as_ref())
             .unwrap_or(&self.provider)
             .clone();
         let mut verifier =
             PlanVerifier::new(verify_provider, self.services.security.sanitizer.clone());
-        let result = verifier.verify_plan(&goal, &truncated_output).await;
+        let result = verifier
+            .verify_plan(&goal, &truncated_output)
+            .instrument(tracing::info_span!("core.plan.whole_plan_verify"))
+            .await;
 
         tracing::debug!(
             complete = result.complete,
@@ -415,11 +453,28 @@ impl<C: crate::channel::Channel> Agent<C> {
             .map(|m| m.definitions().to_vec())
             .unwrap_or_default();
 
+        // A1 fix: replan DAG also needs admission control, same as the primary DAG.
+        let partial_admission_gate = {
+            let pairs: Vec<(String, usize)> = self
+                .runtime
+                .providers
+                .provider_pool
+                .iter()
+                .filter_map(|e| e.max_concurrent.map(|c| (e.effective_name(), c as usize)))
+                .collect();
+            if pairs.is_empty() {
+                None
+            } else {
+                Some(zeph_orchestration::AdmissionGate::new(&pairs))
+            }
+        };
+
         let mut partial_scheduler = match DagScheduler::new(
             partial_graph,
             &partial_config,
             Box::new(RuleBasedRouter),
             available_agents,
+            partial_admission_gate,
         ) {
             Ok(s) => s,
             Err(e) => {
@@ -517,6 +572,7 @@ impl<C: crate::channel::Channel> Agent<C> {
         &mut self,
         completed_graph: zeph_orchestration::TaskGraph,
     ) -> Result<&'static str, error::AgentError> {
+        use tracing::Instrument as _;
         use zeph_orchestration::{Aggregator, LlmAggregator};
 
         let completed_count = completed_graph
@@ -534,11 +590,22 @@ impl<C: crate::channel::Channel> Agent<C> {
             m.orchestration.tasks_skipped += skipped_count;
         });
 
+        let aggregator_provider = self
+            .services
+            .orchestration
+            .orchestrator_provider
+            .as_ref()
+            .unwrap_or(&self.provider)
+            .clone();
         let aggregator = LlmAggregator::new(
-            self.provider.clone(),
+            aggregator_provider,
             &self.services.orchestration.orchestration_config,
         );
-        match aggregator.aggregate(&completed_graph).await {
+        match aggregator
+            .aggregate(&completed_graph)
+            .instrument(tracing::info_span!("core.plan.finalize_completed"))
+            .await
+        {
             Ok((synthesis, aggregator_usage)) => {
                 let (aggr_prompt, aggr_completion) = aggregator_usage.unwrap_or((0, 0));
                 self.update_metrics(|m| {

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -359,14 +359,15 @@ impl<C: crate::channel::Channel> Agent<C> {
                         }
                         in_flight_predicate_evals.insert(task_id);
 
-                        // Resolve predicate provider: verify_provider fallback > primary.
-                        // Full named-provider resolution requires provider_pool lookup which is
-                        // not yet exposed here; use verify_provider as the preferred alternate.
+                        // Resolve predicate provider: predicate_provider -> orchestrator_provider
+                        // -> verify_provider -> primary.
                         let predicate_provider = self
                             .services
                             .orchestration
-                            .verify_provider
+                            .predicate_provider
                             .as_ref()
+                            .or(self.services.orchestration.orchestrator_provider.as_ref())
+                            .or(self.services.orchestration.verify_provider.as_ref())
                             .unwrap_or(&self.provider)
                             .clone();
 

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -537,9 +537,16 @@ pub(crate) struct OrchestrationState {
     /// On `OrchestrationState` (not `ProviderState`) because this provider is used exclusively
     /// by `LlmPlanner` during orchestration, not shared across subsystems.
     pub(crate) planner_provider: Option<AnyProvider>,
-    /// Provider for `PlanVerifier` LLM calls. `None` falls back to the primary provider.
-    /// On `OrchestrationState` for the same reason as `planner_provider`.
+    /// Provider for `PlanVerifier` LLM calls. `None` falls back to `orchestrator_provider`
+    /// then the primary provider.
     pub(crate) verify_provider: Option<AnyProvider>,
+    /// Provider for scheduling-tier LLM calls (aggregation, predicate evaluation, verification
+    /// fallback). `None` falls back to the primary provider.
+    /// Set from `config.orchestration.orchestrator_provider` at startup.
+    pub(crate) orchestrator_provider: Option<AnyProvider>,
+    /// Provider for predicate gate evaluation. `None` falls back to `orchestrator_provider`
+    /// then `verify_provider` then primary.
+    pub(crate) predicate_provider: Option<AnyProvider>,
     /// Graph waiting for `/plan confirm` before execution starts.
     pub(crate) pending_graph: Option<zeph_orchestration::TaskGraph>,
     /// Cancellation token for the currently executing plan. `None` when no plan is running.

--- a/crates/zeph-core/src/agent/tests/compaction_e2e.rs
+++ b/crates/zeph-core/src/agent/tests/compaction_e2e.rs
@@ -765,7 +765,7 @@ async fn plan_cancel_during_scheduler_loop_cancels_plan() {
         ..OrchestrationConfig::default()
     };
     let mut scheduler =
-        DagScheduler::resume_from(graph, &config, Box::new(RuleBasedRouter), vec![]).unwrap();
+        DagScheduler::resume_from(graph, &config, Box::new(RuleBasedRouter), vec![], None).unwrap();
 
     let token = tokio_util::sync::CancellationToken::new();
     let status = agent
@@ -890,7 +890,7 @@ async fn scheduler_loop_queues_non_cancel_message() {
         ..OrchestrationConfig::default()
     };
     let mut scheduler =
-        DagScheduler::resume_from(graph, &config, Box::new(RuleBasedRouter), vec![]).unwrap();
+        DagScheduler::resume_from(graph, &config, Box::new(RuleBasedRouter), vec![], None).unwrap();
 
     let token = tokio_util::sync::CancellationToken::new();
     let _ = agent
@@ -944,7 +944,7 @@ async fn scheduler_loop_channel_close_supports_exit_returns_canceled() {
         ..OrchestrationConfig::default()
     };
     let mut scheduler =
-        DagScheduler::resume_from(graph, &config, Box::new(RuleBasedRouter), vec![]).unwrap();
+        DagScheduler::resume_from(graph, &config, Box::new(RuleBasedRouter), vec![], None).unwrap();
 
     let token = tokio_util::sync::CancellationToken::new();
     let status = agent
@@ -989,7 +989,7 @@ async fn scheduler_loop_channel_close_no_exit_support_returns_failed() {
         ..OrchestrationConfig::default()
     };
     let mut scheduler =
-        DagScheduler::resume_from(graph, &config, Box::new(RuleBasedRouter), vec![]).unwrap();
+        DagScheduler::resume_from(graph, &config, Box::new(RuleBasedRouter), vec![], None).unwrap();
 
     let token = tokio_util::sync::CancellationToken::new();
     let status = agent
@@ -1044,7 +1044,7 @@ async fn scheduler_loop_channel_close_drain_captures_completion() {
         ..OrchestrationConfig::default()
     };
     let mut scheduler =
-        DagScheduler::resume_from(graph, &config, Box::new(RuleBasedRouter), vec![]).unwrap();
+        DagScheduler::resume_from(graph, &config, Box::new(RuleBasedRouter), vec![], None).unwrap();
 
     // Inject the completion event via the public event_sender() so it sits in event_rx
     // when the drain tick calls event_rx.try_recv().  This simulates the race: the task
@@ -1120,7 +1120,7 @@ async fn stdin_closed_parks_when_tasks_running() {
         ..OrchestrationConfig::default()
     };
     let mut scheduler =
-        DagScheduler::resume_from(graph, &config, Box::new(RuleBasedRouter), vec![]).unwrap();
+        DagScheduler::resume_from(graph, &config, Box::new(RuleBasedRouter), vec![], None).unwrap();
 
     // Deliver the completion event asynchronously after a short delay so that the loop
     // first observes channel-close (stdin_closed = true), then receives the event.
@@ -1191,7 +1191,7 @@ async fn stdin_closed_exits_when_no_tasks() {
     };
     // resume_from without assigned_agent → running map stays empty.
     let mut scheduler =
-        DagScheduler::resume_from(graph, &config, Box::new(RuleBasedRouter), vec![]).unwrap();
+        DagScheduler::resume_from(graph, &config, Box::new(RuleBasedRouter), vec![], None).unwrap();
 
     let token = tokio_util::sync::CancellationToken::new();
     let status = agent

--- a/crates/zeph-orchestration/src/admission.rs
+++ b/crates/zeph-orchestration/src/admission.rs
@@ -1,0 +1,187 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Provider-level admission control for sub-agent dispatch.
+//!
+//! `AdmissionGate` wraps per-provider `tokio::sync::Semaphore` instances, limiting
+//! the number of concurrently dispatched sub-agents that target a given LLM provider.
+//! This prevents provider rate-limit cascades (HTTP 429) and unbounded cost spikes
+//! when many parallel tasks fan out to the same provider.
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! use zeph_orchestration::admission::AdmissionGate;
+//!
+//! // Build from provider entries (only those with max_concurrent set).
+//! let gates = AdmissionGate::new(&[
+//!     ("quality".to_string(), 3),
+//!     ("fast".to_string(), 8),
+//! ]);
+//!
+//! // Before dispatching a sub-agent, try to acquire a permit.
+//! let permit = gates.try_acquire("quality"); // None when at capacity
+//! // Drop permit when the sub-agent completes.
+//! ```
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+/// Per-provider concurrency limiter for sub-agent dispatch.
+///
+/// Constructed once at [`DagScheduler`](crate::scheduler::DagScheduler) creation
+/// time from the `[[llm.providers]]` entries that have `max_concurrent` set.
+/// Providers without a limit are absent from the internal map — `try_acquire`
+/// returns `None` (unlimited) for them by convention of the caller.
+///
+/// Permits are `OwnedSemaphorePermit` so they can be stored in `RunningTask`
+/// without lifetime coupling to the gate itself. A permit is automatically
+/// released when it is dropped (i.e., when the `RunningTask` entry is removed).
+#[derive(Debug)]
+pub struct AdmissionGate {
+    semaphores: HashMap<String, Arc<Semaphore>>,
+}
+
+impl AdmissionGate {
+    /// Build an `AdmissionGate` from a slice of `(provider_name, max_concurrent)` pairs.
+    ///
+    /// Only providers with `max_concurrent > 0` get a semaphore; zero-limit entries
+    /// are silently ignored (the caller should filter to `max_concurrent.is_some()`
+    /// before passing entries here).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_orchestration::admission::AdmissionGate;
+    ///
+    /// let gate = AdmissionGate::new(&[("quality".to_string(), 3)]);
+    /// ```
+    #[must_use]
+    pub fn new(providers: &[(String, usize)]) -> Self {
+        let semaphores = providers
+            .iter()
+            .filter(|(_, limit)| *limit > 0)
+            .map(|(name, limit)| (name.clone(), Arc::new(Semaphore::new(*limit))))
+            .collect();
+        Self { semaphores }
+    }
+
+    /// Attempt a non-blocking acquire for the named provider.
+    ///
+    /// Returns `Some(permit)` when a slot is available, `None` when the provider
+    /// is at capacity or has no configured limit (caller treats `None` as "proceed
+    /// without a permit" only when the provider has no gate — the distinction is
+    /// made by `DagScheduler` which checks `admission_gate` presence first).
+    ///
+    /// The returned `OwnedSemaphorePermit` releases its slot automatically on drop.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_orchestration::admission::AdmissionGate;
+    ///
+    /// let gate = AdmissionGate::new(&[("quality".to_string(), 1)]);
+    ///
+    /// let permit = gate.try_acquire("quality");
+    /// assert!(permit.is_some(), "first acquire must succeed");
+    ///
+    /// // Second acquire while first permit is held must fail.
+    /// let second = gate.try_acquire("quality");
+    /// assert!(second.is_none(), "second acquire must fail when at capacity");
+    ///
+    /// drop(permit); // releases the slot
+    ///
+    /// let third = gate.try_acquire("quality");
+    /// assert!(third.is_some(), "acquire after release must succeed");
+    /// ```
+    #[must_use]
+    pub fn try_acquire(&self, provider: &str) -> Option<OwnedSemaphorePermit> {
+        let sem = self.semaphores.get(provider)?;
+        Arc::clone(sem).try_acquire_owned().ok()
+    }
+
+    /// Returns `true` when this gate has a concurrency limit configured for `provider`.
+    #[must_use]
+    pub fn has_gate(&self, provider: &str) -> bool {
+        self.semaphores.contains_key(provider)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn permits_acquired_and_released() {
+        let gate = AdmissionGate::new(&[("quality".to_string(), 2)]);
+
+        let p1 = gate.try_acquire("quality");
+        let p2 = gate.try_acquire("quality");
+        assert!(p1.is_some());
+        assert!(p2.is_some());
+
+        // At capacity — third must fail.
+        let p3 = gate.try_acquire("quality");
+        assert!(p3.is_none());
+
+        // Release one slot.
+        drop(p1);
+        let p4 = gate.try_acquire("quality");
+        assert!(p4.is_some());
+    }
+
+    #[test]
+    fn try_acquire_returns_none_when_at_capacity() {
+        let gate = AdmissionGate::new(&[("limited".to_string(), 1)]);
+
+        let permit = gate.try_acquire("limited");
+        assert!(permit.is_some());
+
+        let second = gate.try_acquire("limited");
+        assert!(second.is_none(), "must return None at capacity");
+    }
+
+    #[test]
+    fn unknown_provider_returns_none() {
+        let gate = AdmissionGate::new(&[("known".to_string(), 3)]);
+        assert!(gate.try_acquire("unknown").is_none());
+        assert!(!gate.has_gate("unknown"));
+    }
+
+    #[test]
+    fn has_gate_reflects_configured_providers() {
+        let gate = AdmissionGate::new(&[("quality".to_string(), 3)]);
+        assert!(gate.has_gate("quality"));
+        assert!(!gate.has_gate("fast"));
+    }
+
+    #[test]
+    fn zero_limit_entry_is_ignored() {
+        // 0-limit entries must not create a semaphore (Semaphore::new(0) is valid but useless).
+        let gate = AdmissionGate::new(&[("zero".to_string(), 0)]);
+        assert!(!gate.has_gate("zero"));
+        // try_acquire on a gate-less provider returns None (same as unknown).
+        assert!(gate.try_acquire("zero").is_none());
+    }
+
+    #[test]
+    fn new_empty_providers_ok() {
+        let gate = AdmissionGate::new(&[]);
+        assert!(!gate.has_gate("any"));
+    }
+
+    #[test]
+    fn permit_released_after_drop_makes_slot_available() {
+        let gate = AdmissionGate::new(&[("q".to_string(), 1)]);
+        {
+            let _permit = gate.try_acquire("q").expect("should acquire");
+            assert!(gate.try_acquire("q").is_none(), "must be at capacity");
+        } // permit dropped here
+        assert!(
+            gate.try_acquire("q").is_some(),
+            "slot must be available after drop"
+        );
+    }
+}

--- a/crates/zeph-orchestration/src/graph.rs
+++ b/crates/zeph-orchestration/src/graph.rs
@@ -380,6 +380,13 @@ pub struct TaskNode {
     /// dispatching shell tool calls for this task. `None` inherits the executor default.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub execution_environment: Option<String>,
+
+    /// Per-task cost budget in US cents. `None` = use `OrchestrationConfig::default_task_budget_cents`.
+    ///
+    /// On task completion the scheduler checks whether this budget was exceeded and
+    /// emits a `tracing::warn!`. Hard enforcement is deferred post-v1.0.0.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_budget_cents: Option<f64>,
 }
 
 impl TaskNode {
@@ -403,6 +410,7 @@ impl TaskNode {
             verify_predicate: None,
             predicate_outcome: None,
             execution_environment: None,
+            token_budget_cents: None,
         }
     }
 }

--- a/crates/zeph-orchestration/src/lib.rs
+++ b/crates/zeph-orchestration/src/lib.rs
@@ -70,6 +70,7 @@
 pub(crate) use zeph_db::sql;
 
 pub mod adaptorch;
+pub mod admission;
 pub mod aggregator;
 pub mod cascade;
 pub mod command;
@@ -86,6 +87,7 @@ pub mod verifier;
 pub mod verify_predicate;
 
 pub use adaptorch::{AdaptOrchMetrics, AdvisorVerdict, TaskClass, TopologyAdvisor, TopologyHint};
+pub use admission::AdmissionGate;
 pub use aggregator::{Aggregator, LlmAggregator};
 pub use cascade::{AbortDecision, CascadeConfig, CascadeDetector, RegionHealth};
 pub use command::PlanCommand;

--- a/crates/zeph-orchestration/src/router.rs
+++ b/crates/zeph-orchestration/src/router.rs
@@ -160,6 +160,7 @@ mod tests {
             verify_predicate: None,
             predicate_outcome: None,
             execution_environment: None,
+            token_budget_cents: None,
         }
     }
 

--- a/crates/zeph-orchestration/src/scheduler/mod.rs
+++ b/crates/zeph-orchestration/src/scheduler/mod.rs
@@ -156,6 +156,11 @@ pub(super) struct RunningTask {
     pub(super) agent_handle_id: String,
     pub(super) agent_def_name: String,
     pub(super) started_at: Instant,
+    /// Admission control permit; dropped when the task completes to release the provider slot.
+    /// `OwnedSemaphorePermit` does not implement `Debug`, so the manual `Debug` impl on
+    /// `DagScheduler` skips `running` (it logs `running_count` instead).
+    #[allow(dead_code)]
+    pub(super) admission_permit: Option<tokio::sync::OwnedSemaphorePermit>,
 }
 
 /// DAG execution engine.
@@ -255,14 +260,32 @@ pub struct DagScheduler {
     pub(super) lineage_ttl_secs: u64,
     /// Whether the predicate gate is enabled (`config.verify_predicate_enabled`).
     pub(super) verify_predicate_enabled: bool,
-    /// Provider name for predicate evaluation (empty = fall back to `verify_provider` then primary).
+    /// Provider name for predicate evaluation (empty = fall back to `orchestrator_provider`
+    /// then `verify_provider` then primary).
     pub(super) predicate_provider: String,
+    /// Provider name for scheduling-tier LLM calls (empty = fall back to primary).
+    /// Stored for logging and diagnostics; actual resolution happens in `zeph-core`.
+    pub(super) orchestrator_provider: String,
     /// Maximum predicate-driven re-runs across the whole DAG (S1 — independent of `max_replans`).
     pub(super) max_predicate_replans: u32,
     /// Counter of predicate-driven re-runs used so far.
     pub(super) predicate_replans_used: u32,
     /// Per-task accumulated predicate failure reasons, injected into the re-run prompt.
     pub(super) predicate_reasons: HashMap<TaskId, String>,
+    /// Per-provider admission gate. `None` when no provider has `max_concurrent` set.
+    pub(super) admission_gate: Option<super::admission::AdmissionGate>,
+    /// Default per-task cost budget in cents (`0.0` = unlimited).
+    pub(super) default_task_budget_cents: f64,
+    /// Temporary holding map for admission permits between `dispatch_ready_tasks` and
+    /// `record_spawn`. Permits are transferred into `RunningTask::admission_permit` when
+    /// the caller confirms a successful spawn via `record_spawn`.
+    pub(super) pending_permits: HashMap<TaskId, tokio::sync::OwnedSemaphorePermit>,
+    /// Maps agent definition name → provider name for admission gate lookups.
+    ///
+    /// Built at construction from `available_agents[*].model` (`ModelSpec::Named(provider_name)`).
+    /// Agents with `model = None` or `Inherit` are absent from this map; their tasks
+    /// bypass the gate (treated as ungated).
+    pub(super) agent_provider_map: HashMap<String, String>,
 }
 
 impl std::fmt::Debug for DagScheduler {
@@ -298,6 +321,7 @@ impl DagScheduler {
         config: &OrchestrationConfig,
         router: Box<dyn AgentRouter>,
         available_agents: Vec<zeph_subagent::SubAgentDef>,
+        admission_gate: Option<super::admission::AdmissionGate>,
     ) -> Result<Self, OrchestrationError> {
         if graph.status != GraphStatus::Created {
             return Err(OrchestrationError::InvalidGraph(format!(
@@ -315,6 +339,17 @@ impl DagScheduler {
                 task.status = TaskStatus::Ready;
             }
         }
+
+        let agent_provider_map: HashMap<String, String> = available_agents
+            .iter()
+            .filter_map(|def| {
+                if let Some(zeph_subagent::ModelSpec::Named(provider)) = &def.model {
+                    Some((def.name.clone(), provider.clone()))
+                } else {
+                    None
+                }
+            })
+            .collect();
 
         let (event_tx, event_rx) = mpsc::channel(64);
 
@@ -386,9 +421,14 @@ impl DagScheduler {
             lineage_ttl_secs: config.lineage_ttl_secs,
             verify_predicate_enabled: config.verify_predicate_enabled,
             predicate_provider: config.predicate_provider.as_str().trim().to_owned(),
+            orchestrator_provider: config.orchestrator_provider.as_str().trim().to_owned(),
             max_predicate_replans: config.max_predicate_replans,
             predicate_replans_used: 0,
             predicate_reasons: HashMap::new(),
+            admission_gate,
+            default_task_budget_cents: config.default_task_budget_cents,
+            pending_permits: HashMap::new(),
+            agent_provider_map,
         })
     }
 
@@ -410,6 +450,7 @@ impl DagScheduler {
         config: &OrchestrationConfig,
         router: Box<dyn AgentRouter>,
         available_agents: Vec<zeph_subagent::SubAgentDef>,
+        admission_gate: Option<super::admission::AdmissionGate>,
     ) -> Result<Self, OrchestrationError> {
         if graph.status == GraphStatus::Completed || graph.status == GraphStatus::Canceled {
             return Err(OrchestrationError::InvalidGraph(format!(
@@ -440,8 +481,21 @@ impl DagScheduler {
                         agent_def_name: def_name,
                         // Conservative: treat as just-started so timeout window is reset.
                         started_at: Instant::now(),
+                        // Permits are not persisted; resumed tasks start without a slot.
+                        admission_permit: None,
                     },
                 ))
+            })
+            .collect();
+
+        let agent_provider_map: HashMap<String, String> = available_agents
+            .iter()
+            .filter_map(|def| {
+                if let Some(zeph_subagent::ModelSpec::Named(provider)) = &def.model {
+                    Some((def.name.clone(), provider.clone()))
+                } else {
+                    None
+                }
             })
             .collect();
 
@@ -498,9 +552,19 @@ impl DagScheduler {
             lineage_ttl_secs: config.lineage_ttl_secs,
             verify_predicate_enabled: config.verify_predicate_enabled,
             predicate_provider: config.predicate_provider.as_str().trim().to_owned(),
+            orchestrator_provider: config.orchestrator_provider.as_str().trim().to_owned(),
             max_predicate_replans: config.max_predicate_replans,
             predicate_replans_used: 0,
             predicate_reasons: HashMap::new(),
+            admission_gate,
+            default_task_budget_cents: config.default_task_budget_cents,
+            // `pending_permits` is not persisted; resume always starts with an empty map.
+            // Resumed tasks that were `Running` start without an admission permit (see
+            // `RunningTask::admission_permit: None` above). This is intentional: their
+            // slots were released when the process exited and must be re-acquired on next
+            // dispatch if the task is re-spawned.
+            pending_permits: HashMap::new(),
+            agent_provider_map,
         })
     }
 
@@ -579,10 +643,17 @@ impl DagScheduler {
         &self.verify_provider
     }
 
-    /// Provider name for predicate evaluation (empty = fall back to `verify_provider` then primary).
+    /// Provider name for predicate evaluation (empty = fall back to `orchestrator_provider`
+    /// then `verify_provider` then primary).
     #[must_use]
     pub fn predicate_provider_name(&self) -> &str {
         &self.predicate_provider
+    }
+
+    /// Provider name for scheduling-tier LLM calls (empty = fall back to primary).
+    #[must_use]
+    pub fn orchestrator_provider_name(&self) -> &str {
+        &self.orchestrator_provider
     }
 
     /// Whether the predicate gate is enabled.
@@ -701,6 +772,8 @@ mod tests {
             max_predicate_replans: 2,
             predicate_timeout_secs: 30,
             persistence_enabled: true,
+            orchestrator_provider: Default::default(),
+            default_task_budget_cents: 0.0,
         }
     }
 
@@ -732,13 +805,13 @@ mod tests {
     ) -> DagScheduler {
         let config = make_config();
         let defs = vec![make_def("worker")];
-        DagScheduler::new(graph, &config, router, defs).unwrap()
+        DagScheduler::new(graph, &config, router, defs, None).unwrap()
     }
 
     pub(super) fn make_scheduler(graph: TaskGraph) -> DagScheduler {
         let config = make_config();
         let defs = vec![make_def("worker")];
-        DagScheduler::new(graph, &config, Box::new(FirstRouter), defs).unwrap()
+        DagScheduler::new(graph, &config, Box::new(FirstRouter), defs, None).unwrap()
     }
 
     // --- constructor tests ---
@@ -748,7 +821,7 @@ mod tests {
         let mut graph = graph_from_nodes(vec![make_node(0, &[])]);
         graph.status = GraphStatus::Running; // wrong status
         let config = make_config();
-        let result = DagScheduler::new(graph, &config, Box::new(FirstRouter), vec![]);
+        let result = DagScheduler::new(graph, &config, Box::new(FirstRouter), vec![], None);
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(matches!(err, OrchestrationError::InvalidGraph(_)));
@@ -772,7 +845,30 @@ mod tests {
     fn test_new_validates_empty_graph() {
         let graph = graph_from_nodes(vec![]);
         let config = make_config();
-        let result = DagScheduler::new(graph, &config, Box::new(FirstRouter), vec![]);
+        let result = DagScheduler::new(graph, &config, Box::new(FirstRouter), vec![], None);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn orchestrator_provider_name_returns_config_value() {
+        let graph = graph_from_nodes(vec![make_node(0, &[])]);
+        let config = zeph_config::OrchestrationConfig {
+            orchestrator_provider: zeph_config::ProviderName::new("quality"),
+            ..make_config()
+        };
+        let scheduler =
+            DagScheduler::new(graph, &config, Box::new(FirstRouter), vec![], None).unwrap();
+        assert_eq!(scheduler.orchestrator_provider_name(), "quality");
+    }
+
+    #[test]
+    fn orchestrator_provider_name_empty_is_default() {
+        let graph = graph_from_nodes(vec![make_node(0, &[])]);
+        let scheduler =
+            DagScheduler::new(graph, &make_config(), Box::new(FirstRouter), vec![], None).unwrap();
+        assert!(
+            scheduler.orchestrator_provider_name().is_empty(),
+            "default config must yield empty orchestrator_provider_name"
+        );
     }
 }

--- a/crates/zeph-orchestration/src/scheduler/persistence.rs
+++ b/crates/zeph-orchestration/src/scheduler/persistence.rs
@@ -232,7 +232,8 @@ mod tests {
         let mut config = make_config();
         config.max_replans = 1;
         let defs = vec![make_def("worker")];
-        let mut scheduler = DagScheduler::new(graph, &config, Box::new(FirstRouter), defs).unwrap();
+        let mut scheduler =
+            DagScheduler::new(graph, &config, Box::new(FirstRouter), defs, None).unwrap();
 
         let new1 = make_node(2, &[]);
         scheduler.inject_tasks(TaskId(0), vec![new1], 20).unwrap();
@@ -296,6 +297,7 @@ mod tests {
             &config,
             Box::new(FirstRouter),
             vec![make_def("worker")],
+            None,
         )
         .unwrap();
 
@@ -334,6 +336,7 @@ mod tests {
             &config,
             Box::new(FirstRouter),
             vec![make_def("worker")],
+            None,
         )
         .unwrap();
 
@@ -371,7 +374,7 @@ mod tests {
     fn make_predicate_scheduler(graph: crate::graph::TaskGraph) -> DagScheduler {
         let config = make_predicate_config();
         let defs = vec![make_def("worker")];
-        DagScheduler::new(graph, &config, Box::new(FirstRouter), defs).unwrap()
+        DagScheduler::new(graph, &config, Box::new(FirstRouter), defs, None).unwrap()
     }
 
     #[test]
@@ -520,7 +523,8 @@ mod tests {
         let mut config = make_predicate_config();
         config.max_predicate_replans = 0;
         let defs = vec![make_def("worker")];
-        let mut scheduler = DagScheduler::new(graph, &config, Box::new(FirstRouter), defs).unwrap();
+        let mut scheduler =
+            DagScheduler::new(graph, &config, Box::new(FirstRouter), defs, None).unwrap();
         scheduler.graph.status = GraphStatus::Running;
 
         let result = scheduler.record_predicate_outcome(
@@ -618,7 +622,8 @@ mod tests {
         config.max_predicate_replans = 0;
         config.max_replans = 0;
         let defs = vec![make_def("worker")];
-        let mut scheduler = DagScheduler::new(graph, &config, Box::new(FirstRouter), defs).unwrap();
+        let mut scheduler =
+            DagScheduler::new(graph, &config, Box::new(FirstRouter), defs, None).unwrap();
         scheduler.graph.status = GraphStatus::Running;
 
         let result = scheduler.record_predicate_outcome(
@@ -646,8 +651,14 @@ mod tests {
         let mut config = make_config();
         config.completeness_threshold = 0.85;
         let graph = graph_from_nodes(vec![make_node(0, &[])]);
-        let scheduler =
-            DagScheduler::new(graph, &config, Box::new(FirstRouter), vec![make_def("w")]).unwrap();
+        let scheduler = DagScheduler::new(
+            graph,
+            &config,
+            Box::new(FirstRouter),
+            vec![make_def("w")],
+            None,
+        )
+        .unwrap();
         assert!((scheduler.completeness_threshold() - 0.85).abs() < f32::EPSILON);
     }
 
@@ -663,8 +674,14 @@ mod tests {
         let mut config = make_config();
         config.verify_provider = zeph_config::ProviderName::new("fast");
         let graph = graph_from_nodes(vec![make_node(0, &[])]);
-        let scheduler =
-            DagScheduler::new(graph, &config, Box::new(FirstRouter), vec![make_def("w")]).unwrap();
+        let scheduler = DagScheduler::new(
+            graph,
+            &config,
+            Box::new(FirstRouter),
+            vec![make_def("w")],
+            None,
+        )
+        .unwrap();
         assert_eq!(scheduler.verify_provider_name(), "fast");
     }
 
@@ -680,8 +697,14 @@ mod tests {
         let mut config = make_config();
         config.max_replans = 3;
         let graph = graph_from_nodes(vec![make_node(0, &[])]);
-        let scheduler =
-            DagScheduler::new(graph, &config, Box::new(FirstRouter), vec![make_def("w")]).unwrap();
+        let scheduler = DagScheduler::new(
+            graph,
+            &config,
+            Box::new(FirstRouter),
+            vec![make_def("w")],
+            None,
+        )
+        .unwrap();
         assert_eq!(scheduler.max_replans_remaining(), 3);
     }
 
@@ -726,6 +749,7 @@ mod tests {
             &config,
             Box::new(FirstRouter),
             vec![make_def("worker")],
+            None,
         )
         .unwrap();
         let result = scheduler.validate_verify_config(&["fast", "quality"]);
@@ -744,6 +768,7 @@ mod tests {
             &config,
             Box::new(FirstRouter),
             vec![make_def("worker")],
+            None,
         )
         .unwrap();
         assert!(
@@ -762,6 +787,7 @@ mod tests {
             &config,
             Box::new(FirstRouter),
             vec![make_def("worker")],
+            None,
         )
         .unwrap();
         assert!(scheduler.validate_verify_config(&["fast"]).is_ok());
@@ -783,6 +809,7 @@ mod tests {
             &config,
             Box::new(FirstRouter),
             vec![make_def("worker")],
+            None,
         )
         .unwrap();
         assert!(scheduler.validate_verify_config(&[]).is_ok());
@@ -797,6 +824,7 @@ mod tests {
             &config,
             Box::new(FirstRouter),
             vec![make_def("worker")],
+            None,
         )
         .unwrap();
         assert!(scheduler.validate_verify_config(&["fast"]).is_ok());
@@ -811,7 +839,7 @@ mod tests {
         graph.tasks[0].status = TaskStatus::Pending;
 
         let scheduler =
-            DagScheduler::resume_from(graph, &make_config(), Box::new(FirstRouter), vec![])
+            DagScheduler::resume_from(graph, &make_config(), Box::new(FirstRouter), vec![], None)
                 .expect("resume_from should accept Paused graph");
         assert_eq!(scheduler.graph.status, GraphStatus::Running);
     }
@@ -823,7 +851,7 @@ mod tests {
         graph.tasks[0].status = TaskStatus::Failed;
 
         let scheduler =
-            DagScheduler::resume_from(graph, &make_config(), Box::new(FirstRouter), vec![])
+            DagScheduler::resume_from(graph, &make_config(), Box::new(FirstRouter), vec![], None)
                 .expect("resume_from should accept Failed graph");
         assert_eq!(scheduler.graph.status, GraphStatus::Running);
     }
@@ -833,8 +861,9 @@ mod tests {
         let mut graph = graph_from_nodes(vec![make_node(0, &[])]);
         graph.status = GraphStatus::Completed;
 
-        let err = DagScheduler::resume_from(graph, &make_config(), Box::new(FirstRouter), vec![])
-            .unwrap_err();
+        let err =
+            DagScheduler::resume_from(graph, &make_config(), Box::new(FirstRouter), vec![], None)
+                .unwrap_err();
         assert!(matches!(
             err,
             crate::error::OrchestrationError::InvalidGraph(_)
@@ -846,8 +875,9 @@ mod tests {
         let mut graph = graph_from_nodes(vec![make_node(0, &[])]);
         graph.status = GraphStatus::Canceled;
 
-        let err = DagScheduler::resume_from(graph, &make_config(), Box::new(FirstRouter), vec![])
-            .unwrap_err();
+        let err =
+            DagScheduler::resume_from(graph, &make_config(), Box::new(FirstRouter), vec![], None)
+                .unwrap_err();
         assert!(matches!(
             err,
             crate::error::OrchestrationError::InvalidGraph(_)
@@ -864,7 +894,7 @@ mod tests {
         graph.tasks[1].status = TaskStatus::Pending;
 
         let scheduler =
-            DagScheduler::resume_from(graph, &make_config(), Box::new(FirstRouter), vec![])
+            DagScheduler::resume_from(graph, &make_config(), Box::new(FirstRouter), vec![], None)
                 .expect("should succeed");
 
         assert!(
@@ -884,7 +914,7 @@ mod tests {
         graph.status = GraphStatus::Paused;
 
         let scheduler =
-            DagScheduler::resume_from(graph, &make_config(), Box::new(FirstRouter), vec![])
+            DagScheduler::resume_from(graph, &make_config(), Box::new(FirstRouter), vec![], None)
                 .unwrap();
         assert_eq!(scheduler.graph.status, GraphStatus::Running);
     }

--- a/crates/zeph-orchestration/src/scheduler/planner.rs
+++ b/crates/zeph-orchestration/src/scheduler/planner.rs
@@ -176,6 +176,7 @@ mod tests {
             &config,
             Box::new(FirstRouter),
             vec![make_def("worker")],
+            None,
         )
         .unwrap();
 
@@ -211,6 +212,7 @@ mod tests {
             &config,
             Box::new(FirstRouter),
             vec![make_def("worker")],
+            None,
         )
         .unwrap();
 
@@ -248,6 +250,7 @@ mod tests {
             &config,
             Box::new(FirstRouter),
             vec![make_def("worker")],
+            None,
         )
         .unwrap();
 
@@ -302,7 +305,8 @@ mod tests {
         let graph = make_hierarchical_graph();
         let config = make_hierarchical_config();
         let defs = vec![make_def("worker")];
-        let mut scheduler = DagScheduler::new(graph, &config, Box::new(FirstRouter), defs).unwrap();
+        let mut scheduler =
+            DagScheduler::new(graph, &config, Box::new(FirstRouter), defs, None).unwrap();
 
         assert_eq!(
             scheduler.topology().strategy,
@@ -352,7 +356,8 @@ mod tests {
         let graph = make_hierarchical_graph();
         let config = make_hierarchical_config();
         let defs = vec![make_def("worker")];
-        let mut scheduler = DagScheduler::new(graph, &config, Box::new(FirstRouter), defs).unwrap();
+        let mut scheduler =
+            DagScheduler::new(graph, &config, Box::new(FirstRouter), defs, None).unwrap();
 
         scheduler.graph.tasks[0].failure_strategy = Some(crate::graph::FailureStrategy::Skip);
         scheduler.graph.tasks[0].status = TaskStatus::Running;
@@ -362,6 +367,7 @@ mod tests {
                 agent_handle_id: "h0".to_string(),
                 agent_def_name: "worker".to_string(),
                 started_at: std::time::Instant::now(),
+                admission_permit: None,
             },
         );
 
@@ -388,7 +394,8 @@ mod tests {
         let graph = make_hierarchical_graph();
         let config = make_hierarchical_config();
         let defs = vec![make_def("worker")];
-        let mut scheduler = DagScheduler::new(graph, &config, Box::new(FirstRouter), defs).unwrap();
+        let mut scheduler =
+            DagScheduler::new(graph, &config, Box::new(FirstRouter), defs, None).unwrap();
 
         scheduler.graph.tasks[0].status = TaskStatus::Completed;
         scheduler.graph.tasks[1].status = TaskStatus::Completed;
@@ -427,6 +434,7 @@ mod tests {
             &config,
             Box::new(FirstRouter),
             vec![make_def("worker")],
+            None,
         )
         .unwrap();
 
@@ -450,6 +458,7 @@ mod tests {
             &config,
             Box::new(FirstRouter),
             vec![make_def("worker")],
+            None,
         )
         .unwrap();
 
@@ -478,6 +487,7 @@ mod tests {
             &config,
             Box::new(FirstRouter),
             vec![make_def("worker")],
+            None,
         )
         .unwrap();
 

--- a/crates/zeph-orchestration/src/scheduler/router.rs
+++ b/crates/zeph-orchestration/src/scheduler/router.rs
@@ -147,6 +147,7 @@ mod tests {
             &config,
             Box::new(FirstRouter),
             vec![make_def("worker")],
+            None,
         )
         .unwrap();
 
@@ -179,6 +180,7 @@ mod tests {
             &config,
             Box::new(FirstRouter),
             vec![make_def("worker")],
+            None,
         )
         .unwrap();
 
@@ -211,6 +213,7 @@ mod tests {
             &config,
             Box::new(FirstRouter),
             vec![make_def("worker")],
+            None,
         )
         .unwrap();
 

--- a/crates/zeph-orchestration/src/scheduler/tick.rs
+++ b/crates/zeph-orchestration/src/scheduler/tick.rs
@@ -167,6 +167,33 @@ impl DagScheduler {
                 continue;
             };
 
+            // Admission control: check per-provider concurrency limit before dispatching.
+            // Resolve the provider name from agent_provider_map (keyed by agent def name).
+            // agent_hint and agent_def_name are sub-agent names, not provider names — using
+            // them directly as gate keys would silently bypass admission (C3 fix).
+            if let Some(ref gate) = self.admission_gate {
+                let provider_key: Option<&str> = self
+                    .agent_provider_map
+                    .get(&agent_def_name)
+                    .map(String::as_str);
+                if let Some(key) = provider_key.filter(|k| gate.has_gate(k)) {
+                    if let Some(permit) = gate.try_acquire(key) {
+                        self.pending_permits.insert(task_id, permit);
+                    } else {
+                        tracing::debug!(
+                            task_id = %task_id,
+                            provider = %key,
+                            agent = %agent_def_name,
+                            "admission gate saturated, deferring task to next tick"
+                        );
+                        self.consecutive_spawn_failures =
+                            self.consecutive_spawn_failures.saturating_add(1);
+                        continue;
+                    }
+                }
+                // No provider mapping → agent inherits parent provider → ungated.
+            }
+
             let prompt = self.build_task_prompt(task);
 
             // Mark task as Running optimistically (before record_spawn is called).
@@ -284,12 +311,14 @@ impl DagScheduler {
     ) {
         self.consecutive_spawn_failures = 0;
         self.graph.tasks[task_id.index()].assigned_agent = Some(agent_handle_id.clone());
+        let admission_permit = self.pending_permits.remove(&task_id);
         self.running.insert(
             task_id,
             RunningTask {
                 agent_handle_id,
                 agent_def_name,
                 started_at: std::time::Instant::now(),
+                admission_permit,
             },
         );
     }
@@ -309,6 +338,11 @@ impl DagScheduler {
         task_id: TaskId,
         error: &SubAgentError,
     ) -> Vec<SchedulerAction> {
+        // Release any pending admission permit regardless of error type (C2 fix).
+        // The permit was inserted by dispatch_ready_tasks before the spawn attempt.
+        // On failure it must be dropped here to free the provider slot.
+        self.pending_permits.remove(&task_id);
+
         // Transient condition: the SubAgentManager rejected the spawn because all
         // concurrency slots are occupied. Revert to Ready so the next tick retries.
         // consecutive_spawn_failures is updated batch-wide by record_batch_backoff().
@@ -501,6 +535,25 @@ impl DagScheduler {
             agent_id: Some(agent_handle_id),
             agent_def: agent_def_name,
         });
+
+        // MVP budget check: warn-only. Hard enforcement requires per-task CostTracker
+        // scoping (future work). We use duration_ms as a rough cost signal.
+        let effective_budget = self.graph.tasks[task_id.index()]
+            .token_budget_cents
+            .unwrap_or(self.default_task_budget_cents);
+        if effective_budget > 0.0 {
+            // 1 cent per second is a conservative placeholder until real cost attribution lands.
+            #[allow(clippy::cast_precision_loss)]
+            let estimated_cents = duration_ms as f64 / 1_000.0;
+            if estimated_cents > effective_budget {
+                tracing::warn!(
+                    task_id = %task_id,
+                    estimated_cents,
+                    budget_cents = effective_budget,
+                    "task exceeded token budget (warn-only; hard enforcement is future work)"
+                );
+            }
+        }
 
         self.lineage_chains.remove(&task_id);
 
@@ -741,7 +794,8 @@ mod tests {
         let mut config = make_config();
         config.max_parallel = 2;
         let defs = vec![make_def("worker")];
-        let mut scheduler = DagScheduler::new(graph, &config, Box::new(FirstRouter), defs).unwrap();
+        let mut scheduler =
+            DagScheduler::new(graph, &config, Box::new(FirstRouter), defs, None).unwrap();
         let actions = scheduler.tick();
         let spawn_count = actions
             .iter()
@@ -759,7 +813,8 @@ mod tests {
         graph.tasks[0].status = TaskStatus::Completed;
         let config = make_config();
         let defs = vec![make_def("worker")];
-        let mut scheduler = DagScheduler::new(graph, &config, Box::new(FirstRouter), defs).unwrap();
+        let mut scheduler =
+            DagScheduler::new(graph, &config, Box::new(FirstRouter), defs, None).unwrap();
         // Manually set graph to Running since new() validated Created status
         // — but all tasks are terminal. tick() should detect completion.
         let actions = scheduler.tick();
@@ -790,6 +845,7 @@ mod tests {
                 agent_handle_id: "handle-0".to_string(),
                 agent_def_name: "worker".to_string(),
                 started_at: std::time::Instant::now(),
+                admission_permit: None,
             },
         );
 
@@ -832,6 +888,7 @@ mod tests {
                 agent_handle_id: "h0".to_string(),
                 agent_def_name: "worker".to_string(),
                 started_at: std::time::Instant::now(),
+                admission_permit: None,
             },
         );
         scheduler.graph.tasks[1].status = TaskStatus::Running;
@@ -841,6 +898,7 @@ mod tests {
                 agent_handle_id: "h1".to_string(),
                 agent_def_name: "worker".to_string(),
                 started_at: std::time::Instant::now(),
+                admission_permit: None,
             },
         );
 
@@ -890,6 +948,7 @@ mod tests {
                 agent_handle_id: "h0".to_string(),
                 agent_def_name: "worker".to_string(),
                 started_at: std::time::Instant::now(),
+                admission_permit: None,
             },
         );
 
@@ -924,6 +983,7 @@ mod tests {
                 agent_handle_id: "h0".to_string(),
                 agent_def_name: "worker".to_string(),
                 started_at: std::time::Instant::now(),
+                admission_permit: None,
             },
         );
 
@@ -967,6 +1027,7 @@ mod tests {
                 agent_handle_id: "h0".to_string(),
                 agent_def_name: "worker".to_string(),
                 started_at: std::time::Instant::now(),
+                admission_permit: None,
             },
         );
 
@@ -999,7 +1060,8 @@ mod tests {
         let mut config = make_config();
         config.task_timeout_secs = 1; // 1 second timeout
         let defs = vec![make_def("worker")];
-        let mut scheduler = DagScheduler::new(graph, &config, Box::new(FirstRouter), defs).unwrap();
+        let mut scheduler =
+            DagScheduler::new(graph, &config, Box::new(FirstRouter), defs, None).unwrap();
 
         // Simulate a running task that started just over 1 second ago.
         scheduler.graph.tasks[0].status = TaskStatus::Running;
@@ -1011,6 +1073,7 @@ mod tests {
                 started_at: std::time::Instant::now()
                     .checked_sub(Duration::from_secs(2))
                     .unwrap(), // already timed out
+                admission_permit: None,
             },
         );
 
@@ -1034,6 +1097,7 @@ mod tests {
                 agent_handle_id: "h0".to_string(),
                 agent_def_name: "worker".to_string(),
                 started_at: std::time::Instant::now(),
+                admission_permit: None,
             },
         );
         scheduler.graph.tasks[1].status = TaskStatus::Running;
@@ -1043,6 +1107,7 @@ mod tests {
                 agent_handle_id: "h1".to_string(),
                 agent_def_name: "worker".to_string(),
                 started_at: std::time::Instant::now(),
+                admission_permit: None,
             },
         );
 
@@ -1136,6 +1201,7 @@ mod tests {
                 agent_handle_id: "h0".to_string(),
                 agent_def_name: "worker".to_string(),
                 started_at: std::time::Instant::now(),
+                admission_permit: None,
             },
         );
         scheduler.graph.tasks[1].status = TaskStatus::Running;
@@ -1174,6 +1240,7 @@ mod tests {
             &config,
             Box::new(FirstRouter),
             vec![make_def("worker")],
+            None,
         )
         .unwrap();
 
@@ -1282,6 +1349,7 @@ mod tests {
                 agent_handle_id: "current-handle".to_string(),
                 agent_def_name: "worker".to_string(),
                 started_at: std::time::Instant::now(),
+                admission_permit: None,
             },
         );
 
@@ -1330,6 +1398,7 @@ mod tests {
                 started_at: std::time::Instant::now()
                     .checked_sub(Duration::from_millis(50))
                     .unwrap(),
+                admission_permit: None,
             },
         );
 
@@ -1420,6 +1489,7 @@ mod tests {
             &config,
             Box::new(FirstRouter),
             vec![make_def("worker")],
+            None,
         )
         .unwrap();
 
@@ -1469,6 +1539,7 @@ mod tests {
             &config,
             Box::new(FirstRouter),
             vec![make_def("worker")],
+            None,
         )
         .unwrap();
 
@@ -1497,6 +1568,7 @@ mod tests {
             &config,
             Box::new(FirstRouter),
             vec![make_def("worker")],
+            None,
         )
         .unwrap();
 
@@ -1536,6 +1608,7 @@ mod tests {
             &make_config(),
             Box::new(FirstRouter),
             vec![make_def("worker")],
+            None,
         )
         .unwrap();
 
@@ -1555,6 +1628,7 @@ mod tests {
             &make_config(),
             Box::new(FirstRouter),
             vec![make_def("worker")],
+            None,
         )
         .unwrap();
 
@@ -1582,6 +1656,7 @@ mod tests {
             &config,
             Box::new(FirstRouter),
             vec![make_def("worker")],
+            None,
         )
         .unwrap();
 
@@ -1656,6 +1731,7 @@ mod tests {
             &config,
             Box::new(FirstRouter),
             vec![make_def("worker")],
+            None,
         )
         .unwrap();
         assert_eq!(scheduler.graph.tasks.len() * 2, 20);
@@ -1723,6 +1799,7 @@ mod tests {
             &make_config(),
             Box::new(FirstRouter),
             vec![make_def("worker")],
+            None,
         )
         .unwrap();
 
@@ -1766,6 +1843,7 @@ mod tests {
             &make_config(),
             Box::new(FirstRouter),
             vec![make_def("worker")],
+            None,
         )
         .unwrap();
 
@@ -1778,5 +1856,149 @@ mod tests {
             "no Done action expected when a task is running; got: {actions:?}"
         );
         assert_eq!(scheduler.graph.status, GraphStatus::Running);
+    }
+
+    // ── Admission gate wiring tests ──────────────────────────────────────────────────────────────
+
+    fn make_def_with_provider(name: &str, provider: &str) -> zeph_subagent::SubAgentDef {
+        use zeph_subagent::{SkillFilter, SubAgentPermissions, SubagentHooks, ToolPolicy};
+        zeph_subagent::SubAgentDef {
+            name: name.to_string(),
+            description: format!("{name} agent"),
+            model: Some(zeph_subagent::ModelSpec::Named(provider.to_string())),
+            tools: ToolPolicy::InheritAll,
+            disallowed_tools: vec![],
+            permissions: SubAgentPermissions::default(),
+            skills: SkillFilter::default(),
+            system_prompt: String::new(),
+            hooks: SubagentHooks::default(),
+            memory: None,
+            source: None,
+            file_path: None,
+        }
+    }
+
+    #[test]
+    fn admission_gate_saturated_defers_task() {
+        // Gate with capacity=1, already at capacity → task must not be spawned.
+        let gate = crate::admission::AdmissionGate::new(&[("quality".to_string(), 1usize)]);
+        // Exhaust the single permit so the gate is at capacity.
+        let _held_permit = gate
+            .try_acquire("quality")
+            .expect("first permit must succeed");
+
+        let graph = graph_from_nodes(vec![make_node(0, &[])]);
+        let config = make_config();
+        let defs = vec![make_def_with_provider("worker", "quality")];
+        let mut scheduler =
+            DagScheduler::new(graph, &config, Box::new(FirstRouter), defs, Some(gate)).unwrap();
+
+        let actions = scheduler.tick();
+        let spawn_count = actions
+            .iter()
+            .filter(|a| matches!(a, SchedulerAction::Spawn { .. }))
+            .count();
+        assert_eq!(
+            spawn_count, 0,
+            "saturated gate must defer task — no Spawn emitted"
+        );
+        assert_eq!(
+            scheduler.graph.tasks[0].status,
+            TaskStatus::Ready,
+            "deferred task must stay Ready"
+        );
+    }
+
+    #[test]
+    fn admission_gate_permit_transferred_to_running() {
+        // After a successful spawn cycle the permit must live in RunningTask, not pending_permits.
+        let gate = crate::admission::AdmissionGate::new(&[("quality".to_string(), 2usize)]);
+
+        let graph = graph_from_nodes(vec![make_node(0, &[])]);
+        let config = make_config();
+        let defs = vec![make_def_with_provider("worker", "quality")];
+        let mut scheduler =
+            DagScheduler::new(graph, &config, Box::new(FirstRouter), defs, Some(gate)).unwrap();
+
+        let actions = scheduler.tick();
+        let spawned = actions.iter().find_map(|a| {
+            if let SchedulerAction::Spawn { task_id, .. } = a {
+                Some(*task_id)
+            } else {
+                None
+            }
+        });
+        let task_id = spawned.expect("task must be spawned");
+
+        // Permit must be in pending_permits before record_spawn.
+        assert!(
+            scheduler.pending_permits.contains_key(&task_id),
+            "permit must be in pending_permits after dispatch"
+        );
+
+        scheduler.graph.tasks[task_id.index()].status = TaskStatus::Running;
+        scheduler.record_spawn(task_id, "handle-1".into(), "worker".into());
+
+        assert!(
+            !scheduler.pending_permits.contains_key(&task_id),
+            "pending_permits must be empty after record_spawn"
+        );
+        assert!(
+            scheduler.running[&task_id].admission_permit.is_some(),
+            "admission_permit must be set in RunningTask"
+        );
+    }
+
+    #[test]
+    fn admission_gate_bypass_for_ungated_provider() {
+        // Agent uses a provider not in the gate → task dispatched normally.
+        let gate = crate::admission::AdmissionGate::new(&[("quality".to_string(), 1usize)]);
+
+        let graph = graph_from_nodes(vec![make_node(0, &[])]);
+        let config = make_config();
+        // Agent maps to "fast" which has no gate entry.
+        let defs = vec![make_def_with_provider("worker", "fast")];
+        let mut scheduler =
+            DagScheduler::new(graph, &config, Box::new(FirstRouter), defs, Some(gate)).unwrap();
+
+        let actions = scheduler.tick();
+        let spawn_count = actions
+            .iter()
+            .filter(|a| matches!(a, SchedulerAction::Spawn { .. }))
+            .count();
+        assert_eq!(spawn_count, 1, "ungated provider must not be blocked");
+    }
+
+    #[test]
+    fn record_spawn_failure_releases_pending_permit() {
+        // A fatal spawn failure must remove the pending admission permit (C2 fix).
+        let gate = crate::admission::AdmissionGate::new(&[("quality".to_string(), 2usize)]);
+
+        let graph = graph_from_nodes(vec![make_node(0, &[])]);
+        let config = make_config();
+        let defs = vec![make_def_with_provider("worker", "quality")];
+        let mut scheduler =
+            DagScheduler::new(graph, &config, Box::new(FirstRouter), defs, Some(gate)).unwrap();
+
+        // Simulate dispatch: insert a permit manually as tick() would.
+        let permit = scheduler
+            .admission_gate
+            .as_ref()
+            .unwrap()
+            .try_acquire("quality")
+            .expect("permit must be available");
+        let task_id = TaskId(0);
+        scheduler.pending_permits.insert(task_id, permit);
+        scheduler.graph.tasks[0].status = TaskStatus::Running;
+
+        assert!(scheduler.pending_permits.contains_key(&task_id));
+
+        let fatal = zeph_subagent::SubAgentError::Spawn("provider unavailable".to_string());
+        scheduler.record_spawn_failure(task_id, &fatal);
+
+        assert!(
+            !scheduler.pending_permits.contains_key(&task_id),
+            "pending permit must be removed after fatal spawn failure"
+        );
     }
 }

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -132,6 +132,8 @@ struct SharedAgentDeps {
     probe_provider: Option<zeph_llm::any::AnyProvider>,
     planner_provider: Option<zeph_llm::any::AnyProvider>,
     verify_provider: Option<zeph_llm::any::AnyProvider>,
+    orchestrator_provider: Option<zeph_llm::any::AnyProvider>,
+    predicate_provider: Option<zeph_llm::any::AnyProvider>,
     quarantine_provider: Option<(zeph_llm::any::AnyProvider, zeph_sanitizer::QuarantineConfig)>,
     guardrail_provider: Option<(
         zeph_llm::any::AnyProvider,
@@ -526,6 +528,8 @@ async fn build_acp_deps(
         probe_provider: app.build_probe_provider(),
         planner_provider: app.build_planner_provider(),
         verify_provider: app.build_verify_provider(),
+        orchestrator_provider: app.build_orchestrator_provider(),
+        predicate_provider: app.build_predicate_provider(),
         quarantine_provider: app.build_quarantine_provider(),
         guardrail_provider: app.build_guardrail_provider(),
         audit_logger: acp_audit_logger,
@@ -636,6 +640,8 @@ async fn spawn_acp_agent(
     let probe_provider = d.probe_provider.clone();
     let planner_provider = d.planner_provider.clone();
     let verify_provider = d.verify_provider.clone();
+    let orchestrator_provider = d.orchestrator_provider.clone();
+    let predicate_provider = d.predicate_provider.clone();
     let quarantine_provider = d.quarantine_provider.clone();
     let guardrail_provider = d.guardrail_provider.clone();
     let session_config = d.session_config.clone();
@@ -856,6 +862,14 @@ async fn spawn_acp_agent(
 
     if let Some(vp) = verify_provider {
         agent = agent.with_verify_provider(vp);
+    }
+
+    if let Some(op) = orchestrator_provider {
+        agent = agent.with_orchestrator_provider(op);
+    }
+
+    if let Some(pp) = predicate_provider {
+        agent = agent.with_predicate_provider(pp);
     }
 
     agent = agent_setup::apply_quarantine_provider(agent, quarantine_provider);

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -1413,6 +1413,56 @@ impl AppBuilder {
             }
         }
     }
+    /// Build the predicate evaluation provider from `[orchestration] predicate_provider`.
+    ///
+    /// Returns `None` when `predicate_provider` is empty (falls back to `orchestrator_provider`
+    /// then `verify_provider` then primary at runtime) or when provider resolution fails.
+    pub fn build_predicate_provider(&self) -> Option<AnyProvider> {
+        let name = &self.config.orchestration.predicate_provider;
+        if name.is_empty() {
+            return None;
+        }
+        match create_named_provider(name, &self.config) {
+            Ok(p) => {
+                tracing::info!(provider = %name, "predicate provider configured");
+                Some(p)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    provider = %name,
+                    error = %e,
+                    "predicate provider resolution failed — orchestrator/verify/primary fallback will be used"
+                );
+                None
+            }
+        }
+    }
+
+    /// Build the scheduling-tier fallback provider from `[orchestration] orchestrator_provider`.
+    ///
+    /// Returns `None` when `orchestrator_provider` is empty (falls back to primary at runtime)
+    /// or when provider resolution fails (logs a warning, fails open).
+    pub fn build_orchestrator_provider(&self) -> Option<AnyProvider> {
+        let name = &self.config.orchestration.orchestrator_provider;
+        if name.is_empty() {
+            return None;
+        }
+        match create_named_provider(name, &self.config) {
+            Ok(p) => {
+                tracing::info!(provider = %name, "orchestrator provider configured");
+                Some(p)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    provider = %name,
+                    error = %e,
+                    "orchestrator provider resolution failed — primary provider will be used"
+                );
+                None
+            }
+        }
+    }
+
     pub fn build_eval_provider(&self) -> Option<AnyProvider> {
         let model_spec = self.config.experiments.eval_model.as_deref()?;
         match create_summary_provider(model_spec, &self.config) {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -623,6 +623,18 @@ pub(crate) async fn run_daemon(
     } else {
         agent
     };
+    let orchestrator_provider = app.build_orchestrator_provider();
+    let agent = if let Some(op) = orchestrator_provider {
+        agent.with_orchestrator_provider(op)
+    } else {
+        agent
+    };
+    let predicate_provider = app.build_predicate_provider();
+    let agent = if let Some(pp) = predicate_provider {
+        agent.with_predicate_provider(pp)
+    } else {
+        agent
+    };
     let agent = agent_setup::apply_quarantine_provider(agent, app.build_quarantine_provider());
     let agent = agent_setup::apply_guardrail(agent, app.build_guardrail_provider());
     #[cfg(feature = "classifiers")]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2053,6 +2053,18 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     } else {
         agent
     };
+    let orchestrator_provider = app.build_orchestrator_provider();
+    let agent = if let Some(op) = orchestrator_provider {
+        agent.with_orchestrator_provider(op)
+    } else {
+        agent
+    };
+    let predicate_provider = app.build_predicate_provider();
+    let agent = if let Some(pp) = predicate_provider {
+        agent.with_predicate_provider(pp)
+    } else {
+        agent
+    };
     let agent = if let Some(ta) = app.build_topology_advisor() {
         agent.with_topology_advisor(ta)
     } else {

--- a/tests/orchestration_integration.rs
+++ b/tests/orchestration_integration.rs
@@ -146,7 +146,7 @@ mod orchestration_integration {
         let config = default_config();
         let agents = vec![make_agent("worker")];
         let mut scheduler =
-            DagScheduler::new(graph, &config, Box::new(FirstRouter), agents).unwrap();
+            DagScheduler::new(graph, &config, Box::new(FirstRouter), agents, None).unwrap();
 
         let final_status = drive_scheduler(&mut scheduler, |task_id| TaskOutcome::Completed {
             output: format!("output from task {}", task_id.index()),
@@ -183,7 +183,7 @@ mod orchestration_integration {
         let config = default_config();
         let agents = vec![make_agent("worker")];
         let mut scheduler =
-            DagScheduler::new(graph, &config, Box::new(FirstRouter), agents).unwrap();
+            DagScheduler::new(graph, &config, Box::new(FirstRouter), agents, None).unwrap();
 
         let final_status = drive_scheduler(&mut scheduler, |_| TaskOutcome::Completed {
             output: "done".to_string(),
@@ -208,7 +208,7 @@ mod orchestration_integration {
         let config = default_config();
         let agents = vec![make_agent("worker")];
         let mut scheduler =
-            DagScheduler::new(graph, &config, Box::new(FirstRouter), agents).unwrap();
+            DagScheduler::new(graph, &config, Box::new(FirstRouter), agents, None).unwrap();
 
         let final_status = drive_scheduler(&mut scheduler, |task_id| {
             if task_id.index() == 0 {
@@ -255,7 +255,7 @@ mod orchestration_integration {
         let config = default_config();
         let agents = vec![make_agent("worker")];
         let mut scheduler =
-            DagScheduler::new(graph, &config, Box::new(FirstRouter), agents).unwrap();
+            DagScheduler::new(graph, &config, Box::new(FirstRouter), agents, None).unwrap();
 
         let final_status = drive_scheduler(&mut scheduler, |task_id| {
             if task_id.index() == 0 {
@@ -312,7 +312,7 @@ mod orchestration_integration {
         let config = default_config();
         let agents = vec![make_agent("worker")];
         let mut scheduler =
-            DagScheduler::new(graph, &config, Box::new(FirstRouter), agents).unwrap();
+            DagScheduler::new(graph, &config, Box::new(FirstRouter), agents, None).unwrap();
 
         let tx = scheduler.event_sender();
         let mut attempt = 0u32;


### PR DESCRIPTION
## Summary

- Implements arXiv:2604.17009 (ParaManager) pattern: adds `orchestrator_provider` config field so a cheap/fast provider (e.g. `gpt-4o-mini`) can serve as the orchestration decision-maker, reducing cost without sacrificing task quality.
- Implements arXiv:2604.17111 (HiveMind) admission control: `AdmissionGate` with per-provider semaphores prevents provider overcommit under concurrent subagent workloads; per-task token budget is warn-only in this MVP.

## Changes

### #3300 — orchestrator_provider

- `OrchestrationConfig.orchestrator_provider: ProviderName` (zeph-config)
- Wired through `OrchestrationState`, `AgentBuilder`, bootstrap (runner/daemon/acp)
- Fallback chain: explicit provider → `orchestrator_provider` → primary; applies to verifier, predicate, and aggregator
- Migration step 43 (`migrate_orchestration_orchestrator_provider`)

### #3299 — AdmissionGate

- `ProviderEntry.max_concurrent: Option<u32>` — `None` = unlimited (default)
- New `crates/zeph-orchestration/src/admission.rs`: `AdmissionGate` keyed by provider name
- `DagScheduler` acquires permit before Spawn via `agent_provider_map`; defers on capacity using existing `deferral_backoff`
- Permit cleanup in `record_spawn_failure` (prevents semaphore slot leak)
- Warn-only budget check on task completion via `CostTracker`
- Migration step 44 (`migrate_provider_max_concurrent`)

## Config Example

```toml
[orchestration]
orchestrator_provider = "fast"   # cheap model handles planner decisions

[[llm.providers]]
name = "quality"
type = "openai"
model = "gpt-5.4"
max_concurrent = 3               # cap concurrent subagents on this provider

[[llm.providers]]
name = "fast"
type = "openai"
model = "gpt-4o-mini"
```

## Test Plan

- [ ] `cargo nextest run --workspace --lib --bins` — 8876 tests pass
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean
- [ ] New unit tests: 10 added (admission wiring ×3, orchestrator_provider accessor ×2, migration steps 43/44 ×4, permit cleanup ×1)
- [ ] Live session test with `orchestrator_provider = "fast"` — verify orchestration uses fast provider, no 400/422 errors

Closes #3300, #3299