### PR TITLE
feat(zeph-llm): RequestSigner and EndpointPool for Gonka native inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- feat(zeph-llm): `RequestSigner` for Gonka-compatible signed-request headers (#3609).
+  Produces ECDSA/secp256k1 signatures over `sha256(sha256(body) || timestamp_ns || transfer_address)`
+  with k256 RFC6979 deterministic signing. Address derivation uses `bech32(prefix, ripemd160(sha256(pubkey)))`.
+  Three fixture-verified test vectors included. Feature-gated under `gonka`.
+
+- feat(zeph-llm): `EndpointPool` round-robin pool with fail-skip cooldown (#3610).
+  Atomic-only implementation (`AtomicUsize` cursor + `Vec<AtomicU64>` for cooldown timestamps).
+  Skips endpoints in cooldown, falls back to least-recently-failed when all are unavailable.
+  URL scheme validation (http/https only) in constructor. Feature-gated under `gonka`.
+
 - feat(orchestration): `orchestrator_provider` config field in `[orchestration]` — sets a
   dedicated provider for scheduling-tier LLM calls (aggregation, predicate evaluation, and
   verification fallback). Acts as a fallback for `verify_provider` and `predicate_provider` when

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,6 +596,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1510,6 +1516,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2036,12 +2054,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2270,6 +2321,16 @@ dependencies = [
  "portable-atomic",
  "rand 0.10.1",
  "web-time",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -2872,6 +2933,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -2947,6 +3009,17 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -3814,6 +3887,19 @@ checksum = "6d833a15225c779251e13929203518c2ff26e2fe0f322d584b213f4f4dad37bd"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -6148,6 +6234,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6168,6 +6264,15 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd4211456b4172d7e44261920c25acf07367c4f04bb5f5d54fc21b090d9b159"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -6578,6 +6683,20 @@ name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "seccompiler"
@@ -10489,6 +10608,7 @@ dependencies = [
  "async-stream",
  "audioadapter-buffers",
  "base64 0.22.1",
+ "bech32",
  "candle-core",
  "candle-nn",
  "candle-transformers",
@@ -10500,12 +10620,14 @@ dependencies = [
  "hex",
  "hf-hub",
  "insta",
+ "k256",
  "ollama-rs",
  "parking_lot",
  "proptest",
  "rand 0.10.1",
  "rand_distr 0.6.0",
  "reqwest 0.13.3",
+ "ripemd",
  "rubato",
  "schemars 1.2.1",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ async-stream = "0.3.6"
 async-trait = "0.1.89"
 axum = "0.8.9"
 base64 = "0.22.1"
+bech32 = "0.9.1"
 blake3 = "1.8.5"
 bytemuck = "1.25"
 candle-core = { version = "0.10.2", default-features = false }
@@ -46,6 +47,7 @@ glob = "0.3.3"
 hf-hub = { version = "0.5", default-features = false }
 hex = "0.4.3"
 http = "1.4"
+k256 = { version = "0.13", default-features = false }
 http-body-util = "0.1.3"
 ignore = "0.4.25"
 include_dir = { version = "0.7.4", features = ["glob"] }
@@ -78,6 +80,7 @@ rand_distr = "0.6"
 ratatui = "0.30"
 regex = "1.12.3"
 reqwest = { version = "0.13.3", default-features = false }
+ripemd = "0.2"
 rmcp = "1.6.0"
 rustix = { version = "1.1.4", default-features = false }
 audioadapter-buffers = "3.0"
@@ -200,7 +203,7 @@ ide     = ["acp", "acp-http"]
 server  = ["gateway", "a2a", "otel", "prometheus"]
 chat    = ["discord", "slack"]
 ml      = ["candle", "pdf"]
-full    = ["desktop", "ide", "server", "chat", "pdf", "scheduler", "classifiers", "profiling", "task-metrics", "sandbox", "self-check"]
+full    = ["desktop", "ide", "server", "chat", "pdf", "scheduler", "classifiers", "profiling", "task-metrics", "sandbox", "self-check", "gonka"]
 testing = ["zeph-llm/testing"]
 env-vault  = ["zeph-core/env-vault"]
 sandbox    = ["zeph-tools/sandbox"]
@@ -243,6 +246,7 @@ task-metrics = ["zeph-core/task-metrics"]
 # Database backend selection — mutually exclusive. Default includes sqlite.
 # NOTE: --all-features activates both, triggering compile_error! in zeph-db.
 # Use --features full or --features full,postgres instead.
+gonka = ["zeph-llm/gonka"]
 index = ["zeph-core/index"]
 sqlite = ["zeph-db/sqlite", "zeph-memory/sqlite"]
 postgres = ["zeph-db/postgres", "zeph-memory/postgres"]

--- a/crates/zeph-llm/Cargo.toml
+++ b/crates/zeph-llm/Cargo.toml
@@ -17,12 +17,14 @@ profiling = []
 candle = ["dep:audioadapter-buffers", "dep:candle-core", "dep:candle-nn", "dep:candle-transformers", "dep:hf-hub", "dep:tokenizers", "dep:symphonia", "dep:rubato"]
 classifiers = ["candle", "dep:hex", "dep:sha2"]
 cuda = ["candle", "candle-core/cuda", "candle-nn/cuda", "candle-transformers/cuda"]
+gonka = ["dep:bech32", "dep:k256", "dep:ripemd", "dep:hex", "dep:sha2"]
 metal = ["candle", "candle-core/metal", "candle-nn/metal", "candle-transformers/metal"]
 testing = []
 
 [dependencies]
 async-stream.workspace = true
 audioadapter-buffers = { workspace = true, optional = true }
+bech32 = { workspace = true, optional = true }
 base64.workspace = true
 candle-core = { workspace = true, optional = true }
 candle-nn = { workspace = true, optional = true }
@@ -30,6 +32,7 @@ candle-transformers = { workspace = true, optional = true }
 dirs.workspace = true
 eventsource-stream.workspace = true
 hex = { workspace = true, optional = true }
+k256 = { workspace = true, optional = true, features = ["ecdsa", "std", "sha256"] }
 futures.workspace = true
 futures-core.workspace = true
 hf-hub = { workspace = true, optional = true, features = ["tokio", "rustls-tls", "ureq"] }
@@ -37,6 +40,7 @@ ollama-rs = { workspace = true, features = ["rustls", "stream"] }
 parking_lot.workspace = true
 rand.workspace = true
 rand_distr.workspace = true
+ripemd = { workspace = true, optional = true }
 reqwest = { workspace = true, features = ["json", "multipart", "rustls", "stream"] }
 rubato = { workspace = true, optional = true }
 schemars = { workspace = true }

--- a/crates/zeph-llm/src/gonka/endpoints.rs
+++ b/crates/zeph-llm/src/gonka/endpoints.rs
@@ -1,0 +1,398 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Round-robin endpoint pool for Gonka network nodes.
+//!
+//! The pool provides lock-free, atomic selection of the next healthy endpoint
+//! and automatically skips nodes that have been marked failed within their cooldown
+//! window. When all nodes are in cooldown, the least-recently-failed node is chosen
+//! so callers never receive an error just from endpoint selection.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use zeph_llm::gonka::endpoints::{EndpointPool, GonkaEndpoint};
+//! use std::time::Duration;
+//!
+//! let nodes = vec![
+//!     GonkaEndpoint { base_url: "https://node1.gonka.ai".into(), address: "addr1".into() },
+//!     GonkaEndpoint { base_url: "https://node2.gonka.ai".into(), address: "addr2".into() },
+//! ];
+//! let pool = EndpointPool::new(nodes).expect("non-empty pool");
+//! let ep = pool.next();
+//! println!("selected: {}", ep.base_url);
+//! ```
+
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use url::Url;
+
+use crate::error::LlmError;
+
+/// A single Gonka network node endpoint.
+///
+/// Holds the HTTP base URL used for API requests and the on-chain address
+/// that identifies the signer node in the Gonka network.
+#[derive(Debug, Clone)]
+pub struct GonkaEndpoint {
+    /// Base HTTP URL of the node (e.g. `https://node1.gonka.ai`).
+    pub base_url: String,
+    /// On-chain address of the signer node.
+    pub address: String,
+}
+
+/// Round-robin pool of Gonka endpoints with fail-skip cooldown.
+///
+/// The pool is safe to share across threads (`Sync + Send`) — all internal
+/// state uses atomic operations with `Relaxed` ordering, which is sufficient
+/// because the worst consequence of a torn read is routing one extra request
+/// to a recently-failed node.
+///
+/// # Fail-skip behaviour
+///
+/// When [`mark_failed`](Self::mark_failed) is called for an endpoint, that
+/// endpoint is skipped by [`next`](Self::next) until its cooldown expires.
+/// If *all* endpoints are in cooldown simultaneously, [`next`](Self::next)
+/// returns the least-recently-failed node so callers always receive a valid
+/// reference and never need to handle a missing-endpoint error.
+pub struct EndpointPool {
+    nodes: Vec<GonkaEndpoint>,
+    cursor: AtomicUsize,
+    /// Stores the absolute deadline (unix nanoseconds) after which the node
+    /// is considered healthy again. Zero means the node is currently healthy.
+    failed_until: Vec<AtomicU64>,
+}
+
+impl std::fmt::Debug for EndpointPool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EndpointPool")
+            .field("nodes", &self.nodes)
+            .field("cursor", &self.cursor.load(Ordering::Relaxed))
+            .finish_non_exhaustive()
+    }
+}
+
+impl EndpointPool {
+    /// Create a new pool from the given list of nodes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LlmError::Other`] if `nodes` is empty — a pool without
+    /// endpoints cannot serve any requests.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_llm::gonka::endpoints::{EndpointPool, GonkaEndpoint};
+    ///
+    /// let result = EndpointPool::new(vec![]);
+    /// assert!(result.is_err());
+    ///
+    /// let pool = EndpointPool::new(vec![
+    ///     GonkaEndpoint { base_url: "https://n1.example".into(), address: "a1".into() },
+    /// ]).unwrap();
+    /// assert_eq!(pool.len(), 1);
+    /// ```
+    pub fn new(nodes: Vec<GonkaEndpoint>) -> Result<Self, LlmError> {
+        if nodes.is_empty() {
+            return Err(LlmError::Other(
+                "EndpointPool requires at least one node".into(),
+            ));
+        }
+        for node in &nodes {
+            let parsed = Url::parse(&node.base_url).map_err(|e| {
+                LlmError::Other(format!("invalid endpoint URL '{}': {e}", node.base_url))
+            })?;
+            if !matches!(parsed.scheme(), "http" | "https") {
+                return Err(LlmError::Other(format!(
+                    "endpoint URL '{}' must use http or https scheme",
+                    node.base_url
+                )));
+            }
+        }
+        let n = nodes.len();
+        let failed_until = (0..n).map(|_| AtomicU64::new(0)).collect();
+        Ok(Self {
+            nodes,
+            cursor: AtomicUsize::new(0),
+            failed_until,
+        })
+    }
+
+    /// Return the next non-failed endpoint using round-robin selection.
+    ///
+    /// The cursor is advanced atomically on every call regardless of whether
+    /// the selected node is healthy. Up to `nodes.len()` candidates are
+    /// checked in order. If all candidates are still within their cooldown,
+    /// the node with the smallest (earliest) `failed_until` deadline is
+    /// returned as a fallback so the caller always receives a valid reference.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_llm::gonka::endpoints::{EndpointPool, GonkaEndpoint};
+    ///
+    /// let pool = EndpointPool::new(vec![
+    ///     GonkaEndpoint { base_url: "https://n1".into(), address: "a1".into() },
+    ///     GonkaEndpoint { base_url: "https://n2".into(), address: "a2".into() },
+    /// ]).unwrap();
+    ///
+    /// // First two calls return different nodes.
+    /// let ep1 = pool.next();
+    /// let ep2 = pool.next();
+    /// assert_ne!(ep1.base_url, ep2.base_url);
+    /// ```
+    pub fn next(&self) -> &GonkaEndpoint {
+        let _span = tracing::info_span!("llm.gonka.endpoint_next").entered();
+        let n = self.nodes.len();
+        let now_ns = now_ns();
+
+        // Scan at most `n` candidates starting from the current cursor position.
+        for _ in 0..n {
+            let idx = self.cursor.fetch_add(1, Ordering::Relaxed) % n;
+            if self.failed_until[idx].load(Ordering::Relaxed) <= now_ns {
+                return &self.nodes[idx];
+            }
+        }
+
+        // All nodes are in cooldown — return the least-recently-failed one.
+        let best = self
+            .failed_until
+            .iter()
+            .enumerate()
+            .min_by_key(|(_, a)| a.load(Ordering::Relaxed))
+            .map_or(0, |(i, _)| i);
+        &self.nodes[best]
+    }
+
+    /// Mark the endpoint at `idx` as failed for the given `cooldown` duration.
+    ///
+    /// After the cooldown expires, the endpoint becomes eligible for selection
+    /// again. Calling with `Duration::ZERO` immediately clears the failure.
+    ///
+    /// # Panics
+    ///
+    /// Does not panic — if `idx >= len()` the call is a no-op (the index
+    /// simply does not match any slot).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_llm::gonka::endpoints::{EndpointPool, GonkaEndpoint};
+    /// use std::time::Duration;
+    ///
+    /// let pool = EndpointPool::new(vec![
+    ///     GonkaEndpoint { base_url: "https://n1".into(), address: "a1".into() },
+    ///     GonkaEndpoint { base_url: "https://n2".into(), address: "a2".into() },
+    /// ]).unwrap();
+    ///
+    /// pool.mark_failed(0, Duration::from_secs(60));
+    /// // Subsequent calls will skip node 0 for the next 60 seconds.
+    /// let ep = pool.next();
+    /// assert_eq!(ep.base_url, "https://n2");
+    /// ```
+    pub fn mark_failed(&self, idx: usize, cooldown: Duration) {
+        if idx >= self.nodes.len() {
+            return;
+        }
+        let cooldown_ns = u64::try_from(cooldown.as_nanos()).unwrap_or(u64::MAX);
+        let deadline = now_ns().saturating_add(cooldown_ns);
+        self.failed_until[idx].store(deadline, Ordering::Relaxed);
+    }
+
+    /// Number of endpoints in the pool.
+    ///
+    /// Always at least 1 after successful construction.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Returns `true` if the pool has no endpoints.
+    ///
+    /// This always returns `false` after a successful [`EndpointPool::new`]
+    /// call, because the constructor rejects empty slices.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+}
+
+/// Current time in unix nanoseconds, saturating to 0 on pre-epoch clocks.
+#[inline]
+fn now_ns() -> u64 {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    u64::try_from(nanos).unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::Ordering;
+    use std::time::Duration;
+
+    fn make_pool(n: usize) -> EndpointPool {
+        let nodes = (0..n)
+            .map(|i| GonkaEndpoint {
+                base_url: format!("https://node{i}.example"),
+                address: format!("addr{i}"),
+            })
+            .collect();
+        EndpointPool::new(nodes).expect("non-empty pool")
+    }
+
+    /// Derive the index that `next()` will return without advancing the cursor,
+    /// by reading the last-advanced position post-call via `base_url` comparison.
+    fn url_to_idx(url: &str, n: usize) -> usize {
+        for i in 0..n {
+            if url == format!("https://node{i}.example") {
+                return i;
+            }
+        }
+        panic!("unrecognised url: {url}");
+    }
+
+    /// 1. Round-robin rotates through all 3 nodes and then repeats.
+    #[test]
+    fn gonka_endpoint_round_robin_three_nodes() {
+        let pool = make_pool(3);
+        let calls: Vec<usize> = (0..6)
+            .map(|_| url_to_idx(pool.next().base_url.as_str(), 3))
+            .collect();
+        // First 3 must be a permutation of 0,1,2 (each exactly once).
+        let mut first = calls[..3].to_vec();
+        first.sort_unstable();
+        assert_eq!(first, vec![0, 1, 2]);
+        // Second 3 must be the same cycle.
+        let mut second = calls[3..].to_vec();
+        second.sort_unstable();
+        assert_eq!(second, vec![0, 1, 2]);
+    }
+
+    /// 2. A node with a long cooldown is never returned when healthy alternatives exist.
+    #[test]
+    fn gonka_endpoint_failed_node_skipped_during_cooldown() {
+        let pool = make_pool(3);
+        // Mark node 0 failed for an hour.
+        pool.mark_failed(0, Duration::from_hours(1));
+
+        for _ in 0..9 {
+            let idx = url_to_idx(pool.next().base_url.as_str(), 3);
+            assert_ne!(idx, 0, "failed node 0 must not be returned");
+        }
+    }
+
+    /// 3. A node recovers immediately when marked with `Duration::ZERO`.
+    #[test]
+    fn gonka_endpoint_failed_node_restored_after_cooldown() {
+        let pool = make_pool(2);
+        // Mark node 0 as immediately-expired (zero cooldown ⇒ deadline = now, already passed).
+        pool.mark_failed(0, Duration::ZERO);
+
+        // Node 0 must appear at some point in 6 calls.
+        let seen: Vec<usize> = (0..6)
+            .map(|_| url_to_idx(pool.next().base_url.as_str(), 2))
+            .collect();
+        assert!(
+            seen.contains(&0),
+            "recovered node 0 must be selectable; got: {seen:?}"
+        );
+    }
+
+    /// 4. When all nodes are in cooldown, `next()` still returns a valid endpoint (no panic).
+    #[test]
+    fn gonka_endpoint_all_failed_fallback_no_panic() {
+        let pool = make_pool(3);
+        for i in 0..3 {
+            pool.mark_failed(i, Duration::from_hours(1));
+        }
+        // Must not panic and must return one of the 3 valid indices.
+        for _ in 0..6 {
+            let idx = url_to_idx(pool.next().base_url.as_str(), 3);
+            assert!(idx < 3, "index out of range: {idx}");
+        }
+    }
+
+    /// 5a. Constructor rejects invalid URL scheme.
+    #[test]
+    fn gonka_endpoint_invalid_scheme_returns_err() {
+        let result = EndpointPool::new(vec![GonkaEndpoint {
+            base_url: "ftp://node.example".into(),
+            address: "addr".into(),
+        }]);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("http or https scheme"),
+            "unexpected error message: {msg}"
+        );
+    }
+
+    /// 5b. Constructor rejects unparseable URL.
+    #[test]
+    fn gonka_endpoint_invalid_url_returns_err() {
+        let result = EndpointPool::new(vec![GonkaEndpoint {
+            base_url: "not a url".into(),
+            address: "addr".into(),
+        }]);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("invalid endpoint URL"),
+            "unexpected error message: {msg}"
+        );
+    }
+
+    /// 5. Constructor rejects an empty node list.
+    #[test]
+    fn gonka_endpoint_empty_constructor_returns_err() {
+        let result = EndpointPool::new(vec![]);
+        match result {
+            Err(e) => {
+                let msg = e.to_string();
+                assert!(
+                    msg.contains("EndpointPool requires at least one node"),
+                    "unexpected error message: {msg}"
+                );
+            }
+            Ok(_) => panic!("expected Err for empty pool, got Ok"),
+        }
+    }
+
+    /// `len()` and `is_empty()` reflect pool size.
+    #[test]
+    fn gonka_endpoint_len_and_is_empty() {
+        let pool = make_pool(4);
+        assert_eq!(pool.len(), 4);
+        assert!(!pool.is_empty());
+    }
+
+    /// `mark_failed` with out-of-range index is a no-op (must not panic).
+    #[test]
+    fn gonka_endpoint_mark_failed_out_of_range_noop() {
+        let pool = make_pool(2);
+        pool.mark_failed(99, Duration::from_secs(10)); // must not panic
+    }
+
+    /// Clearing a failure by writing a zero deadline makes the node immediately available.
+    #[test]
+    fn gonka_endpoint_clear_failure_via_atomic_store() {
+        let pool = make_pool(2);
+        pool.mark_failed(0, Duration::from_hours(1));
+        // Manually clear via zero duration (deadline = now() + 0 which may still be in the future
+        // by a nanosecond — use the internal atomic directly for a deterministic zero).
+        pool.failed_until[0].store(0, Ordering::Relaxed);
+
+        let seen: Vec<usize> = (0..6)
+            .map(|_| url_to_idx(pool.next().base_url.as_str(), 2))
+            .collect();
+        assert!(
+            seen.contains(&0),
+            "node 0 must be selectable after atomic clear"
+        );
+    }
+}

--- a/crates/zeph-llm/src/gonka/fixtures.json
+++ b/crates/zeph-llm/src/gonka/fixtures.json
@@ -1,0 +1,29 @@
+[
+  {
+    "private_key_hex": "0000000000000000000000000000000000000000000000000000000000000001",
+    "chain_prefix": "gonka",
+    "body": "hello",
+    "timestamp_ns": 1000000000,
+    "transfer_address": "gonka1test",
+    "expected_address": "gonka1w508d6qejxtdg4y5r3zarvary0c5xw7k2gsyg6",
+    "expected_signature": "/x6JuvqXWpT9YNgjYt0eNLxK8nDjccY/VyJrDn4bGjNbWWu3Px9doIlUQUOOf2Eu7SqyZ4oyGlDoY+4XpGA2JQ=="
+  },
+  {
+    "private_key_hex": "0000000000000000000000000000000000000000000000000000000000000001",
+    "chain_prefix": "gonka",
+    "body": "",
+    "timestamp_ns": 0,
+    "transfer_address": "",
+    "expected_address": "gonka1w508d6qejxtdg4y5r3zarvary0c5xw7k2gsyg6",
+    "expected_signature": "NyKMAuRc/FRjptcjm94Q3Fqeevcl2fJUeb0Dxwh1HZpH7sgFk7ajJdBPt8FVa1mxG5OY623oKNb6xkGerdqIiw=="
+  },
+  {
+    "private_key_hex": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+    "chain_prefix": "gonka",
+    "body": "hello",
+    "timestamp_ns": 1000000000,
+    "transfer_address": "gonka1test",
+    "expected_address": "gonka14h0ycu78h88wzldxc7e79vhw5xsde0n85evmum",
+    "expected_signature": "jtbBiX1nUgLiIH7FjLxy7Nn1Ckp3jq+8t6iLNjCKliJPXKOGHoo997xqbo3R9FNsTK8TmCyQW3PPvRJQFKhRXg=="
+  }
+]

--- a/crates/zeph-llm/src/gonka/mod.rs
+++ b/crates/zeph-llm/src/gonka/mod.rs
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Gonka AI gateway integration: endpoint pool and request signer.
+//!
+//! The [`RequestSigner`] authenticates HTTP requests using a secp256k1 key,
+//! and the [`endpoints`] module manages a rotating pool of gateway nodes.
+
+pub mod endpoints;
+#[cfg(feature = "gonka")]
+pub mod signer;
+
+#[cfg(feature = "gonka")]
+pub use signer::RequestSigner;

--- a/crates/zeph-llm/src/gonka/signer.rs
+++ b/crates/zeph-llm/src/gonka/signer.rs
@@ -1,0 +1,291 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! ECDSA request signer for the Gonka AI gateway protocol.
+//!
+//! `RequestSigner` holds a secp256k1 signing key and produces deterministic
+//! base64-encoded signatures for Gonka HTTP requests. Signatures bind the
+//! request body, a nanosecond timestamp, and the target transfer address so
+//! that each request is non-replayable.
+//!
+//! # Examples
+//!
+//! ```rust,no_run
+//! use zeph_llm::gonka::RequestSigner;
+//!
+//! # fn example() -> Result<(), zeph_llm::LlmError> {
+//! let signer = RequestSigner::from_hex(
+//!     "0000000000000000000000000000000000000000000000000000000000000001",
+//!     "gonka",
+//! )?;
+//! println!("address: {}", signer.address());
+//! let sig = signer.sign(b"hello", 1_000_000_000u128, "gonka1test")?;
+//! println!("signature: {sig}");
+//! # Ok(())
+//! # }
+//! ```
+
+use base64::Engine as _;
+use k256::ecdsa::signature::hazmat::PrehashSigner as _;
+use k256::elliptic_curve::sec1::ToEncodedPoint as _;
+use ripemd::Digest as _;
+
+use crate::error::LlmError;
+
+/// Gonka request signer backed by a secp256k1 private key.
+///
+/// Derives a bech32 address from the compressed public key (Bitcoin-style
+/// SHA-256 → RIPEMD-160 hash) and produces RFC6979-deterministic ECDSA
+/// signatures over a SHA-256 prehash of each request.
+pub struct RequestSigner {
+    signing_key: k256::ecdsa::SigningKey,
+    address: String,
+}
+
+impl std::fmt::Debug for RequestSigner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RequestSigner")
+            .field("address", &self.address)
+            .finish_non_exhaustive()
+    }
+}
+
+impl RequestSigner {
+    /// Constructs a signer from a 32-byte private key encoded as lowercase hex.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LlmError::Other`] if `priv_hex` is not valid hex or does not
+    /// decode to a valid secp256k1 scalar.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # use zeph_llm::gonka::RequestSigner;
+    /// # fn example() -> Result<(), zeph_llm::LlmError> {
+    /// let signer = RequestSigner::from_hex(
+    ///     "0000000000000000000000000000000000000000000000000000000000000001",
+    ///     "gonka",
+    /// )?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn from_hex(priv_hex: &str, chain_prefix: &str) -> Result<Self, LlmError> {
+        let key_bytes =
+            hex::decode(priv_hex).map_err(|e| LlmError::Other(format!("invalid hex key: {e}")))?;
+        let signing_key = k256::ecdsa::SigningKey::from_slice(&key_bytes)
+            .map_err(|e| LlmError::Other(format!("invalid secp256k1 key: {e}")))?;
+        let pubkey = k256::PublicKey::from(signing_key.verifying_key());
+        let address = derive_address(&pubkey, chain_prefix);
+        Ok(Self {
+            signing_key,
+            address,
+        })
+    }
+
+    /// Returns the bech32 address derived from this signer's public key.
+    #[must_use]
+    pub fn address(&self) -> &str {
+        &self.address
+    }
+
+    /// Signs a Gonka request and returns a base64-encoded (STANDARD, with padding) signature.
+    ///
+    /// The signing input is:
+    /// ```text
+    /// SHA-256( hex(SHA-256(body)) || decimal(timestamp_ns) || transfer_address )
+    /// ```
+    ///
+    /// This binds the body content, the timestamp, and the destination address
+    /// into a single prehash that is then signed with RFC6979-deterministic ECDSA.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LlmError::Other`] if the underlying ECDSA signing operation fails.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # use zeph_llm::gonka::RequestSigner;
+    /// # fn example() -> Result<(), zeph_llm::LlmError> {
+    /// let signer = RequestSigner::from_hex(
+    ///     "0000000000000000000000000000000000000000000000000000000000000001",
+    ///     "gonka",
+    /// )?;
+    /// let sig = signer.sign(b"hello", 1_000_000_000u128, "gonka1test")?;
+    /// assert_eq!(sig.len(), 88); // base64 STANDARD encoding of 64 bytes
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn sign(
+        &self,
+        body_bytes: &[u8],
+        timestamp_ns: u128,
+        transfer_address: &str,
+    ) -> Result<String, LlmError> {
+        let _span =
+            tracing::info_span!("llm.gonka.sign", transfer_address = %transfer_address).entered();
+        let payload_hash_hex = hex::encode(sha2::Sha256::digest(body_bytes));
+        let input = format!("{payload_hash_hex}{timestamp_ns}{transfer_address}");
+        let digest = sha2::Sha256::digest(input.as_bytes());
+        let sig: k256::ecdsa::Signature = self
+            .signing_key
+            .sign_prehash(digest.as_ref())
+            .map_err(|e| LlmError::Other(format!("signing failed: {e}")))?;
+        // Use STANDARD (with padding) as specified in the Gonka gateway protocol.
+        // Note: the spec document says STANDARD_NO_PAD (86 chars) but the issue
+        // description and confirmed test vectors use STANDARD (88 chars). The issue
+        // overrides the spec here.
+        Ok(base64::engine::general_purpose::STANDARD.encode(sig.to_bytes()))
+    }
+}
+
+/// Derives a bech32 address from a secp256k1 public key.
+///
+/// Algorithm: SHA-256(compressed_pubkey) → RIPEMD-160 → `bech32(chain_prefix, data)`.
+/// This matches the Bitcoin/Cosmos address derivation standard.
+fn derive_address(pubkey: &k256::PublicKey, chain_prefix: &str) -> String {
+    use bech32::ToBase32 as _;
+
+    let compressed = pubkey.to_encoded_point(true);
+    let sha_hash = sha2::Sha256::digest(compressed.as_bytes());
+    let sha_bytes: &[u8] = &sha_hash[..];
+    let ripe_hash = ripemd::Ripemd160::digest(sha_bytes);
+    let ripe_bytes: &[u8] = &ripe_hash[..];
+    let data5 = ripe_bytes.to_base32();
+    // bech32::encode only fails on invalid HRP characters, which chain_prefix
+    // is guaranteed to avoid in practice (lowercase ASCII letters only).
+    bech32::encode(chain_prefix, data5, bech32::Variant::Bech32)
+        .unwrap_or_else(|e| panic!("bech32 encode failed for prefix '{chain_prefix}': {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PRIV_KEY_1: &str = "0000000000000000000000000000000000000000000000000000000000000001";
+    const PRIV_KEY_N_MINUS_1: &str =
+        "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140";
+
+    #[test]
+    fn address_key_1_matches_fixture() {
+        let signer = RequestSigner::from_hex(PRIV_KEY_1, "gonka").unwrap();
+        assert_eq!(
+            signer.address(),
+            "gonka1w508d6qejxtdg4y5r3zarvary0c5xw7k2gsyg6"
+        );
+    }
+
+    #[test]
+    fn address_key_n_minus_1_matches_fixture() {
+        let signer = RequestSigner::from_hex(PRIV_KEY_N_MINUS_1, "gonka").unwrap();
+        assert_eq!(
+            signer.address(),
+            "gonka14h0ycu78h88wzldxc7e79vhw5xsde0n85evmum"
+        );
+    }
+
+    #[test]
+    fn sign_known_vector_1() {
+        let signer = RequestSigner::from_hex(PRIV_KEY_1, "gonka").unwrap();
+        let sig = signer
+            .sign(b"hello", 1_000_000_000u128, "gonka1test")
+            .unwrap();
+        assert_eq!(
+            sig,
+            "/x6JuvqXWpT9YNgjYt0eNLxK8nDjccY/VyJrDn4bGjNbWWu3Px9doIlUQUOOf2Eu7SqyZ4oyGlDoY+4XpGA2JQ=="
+        );
+    }
+
+    #[test]
+    fn sign_known_vector_empty_body() {
+        let signer = RequestSigner::from_hex(PRIV_KEY_1, "gonka").unwrap();
+        let sig = signer.sign(b"", 0u128, "").unwrap();
+        assert_eq!(
+            sig,
+            "NyKMAuRc/FRjptcjm94Q3Fqeevcl2fJUeb0Dxwh1HZpH7sgFk7ajJdBPt8FVa1mxG5OY623oKNb6xkGerdqIiw=="
+        );
+    }
+
+    #[test]
+    fn sign_known_vector_key_n_minus_1() {
+        let signer = RequestSigner::from_hex(PRIV_KEY_N_MINUS_1, "gonka").unwrap();
+        let sig = signer
+            .sign(b"hello", 1_000_000_000u128, "gonka1test")
+            .unwrap();
+        assert_eq!(
+            sig,
+            "jtbBiX1nUgLiIH7FjLxy7Nn1Ckp3jq+8t6iLNjCKliJPXKOGHoo997xqbo3R9FNsTK8TmCyQW3PPvRJQFKhRXg=="
+        );
+    }
+
+    #[test]
+    fn sign_returns_88_char_base64() {
+        let signer = RequestSigner::from_hex(PRIV_KEY_1, "gonka").unwrap();
+        let sig = signer.sign(b"test", 42u128, "gonka1addr").unwrap();
+        assert_eq!(sig.len(), 88);
+    }
+
+    #[test]
+    fn sign_is_deterministic() {
+        let signer = RequestSigner::from_hex(PRIV_KEY_1, "gonka").unwrap();
+        let sig1 = signer.sign(b"data", 999u128, "gonka1addr").unwrap();
+        let sig2 = signer.sign(b"data", 999u128, "gonka1addr").unwrap();
+        assert_eq!(sig1, sig2);
+    }
+
+    #[test]
+    fn sign_different_inputs_produce_different_signatures() {
+        let signer = RequestSigner::from_hex(PRIV_KEY_1, "gonka").unwrap();
+        let sig1 = signer.sign(b"a", 1u128, "addr").unwrap();
+        let sig2 = signer.sign(b"b", 1u128, "addr").unwrap();
+        assert_ne!(sig1, sig2);
+    }
+
+    #[test]
+    fn from_hex_odd_length_returns_error() {
+        let result = RequestSigner::from_hex("abc", "gonka");
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("invalid hex key"), "unexpected: {msg}");
+    }
+
+    #[test]
+    fn from_hex_invalid_chars_returns_error() {
+        let result = RequestSigner::from_hex(
+            "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+            "gonka",
+        );
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("invalid hex key"), "unexpected: {msg}");
+    }
+
+    #[test]
+    fn from_hex_all_zeros_returns_error() {
+        // Scalar 0 is not a valid secp256k1 private key.
+        let result = RequestSigner::from_hex(
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "gonka",
+        );
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("invalid secp256k1 key"), "unexpected: {msg}");
+    }
+
+    #[test]
+    fn sign_with_unicode_transfer_address_does_not_panic() {
+        let signer = RequestSigner::from_hex(PRIV_KEY_1, "gonka").unwrap();
+        // Unicode in transfer_address is allowed by the API; bech32 addresses are
+        // ASCII-only in practice but the signer must not panic on arbitrary input.
+        let result = signer.sign(b"body", 1u128, "gonka1\u{1F600}test");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn sign_u128_max_timestamp() {
+        let signer = RequestSigner::from_hex(PRIV_KEY_1, "gonka").unwrap();
+        let result = signer.sign(b"", u128::MAX, "addr");
+        assert!(result.is_ok());
+    }
+}

--- a/crates/zeph-llm/src/lib.rs
+++ b/crates/zeph-llm/src/lib.rs
@@ -82,6 +82,7 @@ pub(crate) mod embed;
 pub mod error;
 pub mod extractor;
 pub mod gemini;
+pub mod gonka;
 pub mod http;
 #[cfg(any(test, feature = "testing"))]
 pub mod mock;

--- a/crates/zeph-llm/src/lib.rs
+++ b/crates/zeph-llm/src/lib.rs
@@ -82,6 +82,7 @@ pub(crate) mod embed;
 pub mod error;
 pub mod extractor;
 pub mod gemini;
+#[cfg(feature = "gonka")]
 pub mod gonka;
 pub mod http;
 #[cfg(any(test, feature = "testing"))]


### PR DESCRIPTION
## Summary

- Implements `RequestSigner` (#3609): ECDSA/secp256k1 signed request headers for Gonka nodes, using k256 RFC6979 determinism and bech32 address derivation from compressed pubkey
- Implements `EndpointPool` (#3610): atomic round-robin pool with per-node fail-skip cooldown, http/https URL validation, and least-recently-failed fallback
- Both components are feature-gated under the new `gonka` feature (included in `full`)
- Part of epic #3602 — unblocks `GonkaProvider` implementation in #3611

## Changes

- `crates/zeph-llm/src/gonka/signer.rs` — `RequestSigner` with fixture-verified signing
- `crates/zeph-llm/src/gonka/endpoints.rs` — `EndpointPool` with atomic implementation
- `crates/zeph-llm/src/gonka/fixtures.json` — 3 pre-computed test vectors
- `crates/zeph-llm/src/gonka/mod.rs` — module wiring with `pub use` re-exports
- Root `Cargo.toml` — `gonka` feature added to `full`; `bech32`, `k256`, `ripemd` promoted to workspace deps
- `crates/zeph-llm/Cargo.toml` — new deps: k256 0.13, ripemd 0.2, url (scheme validation)

## Test plan

- [x] `cargo nextest run -p zeph-llm --features gonka -E 'test(gonka)'` — 23/23 pass
- [x] `cargo nextest run --workspace --lib --bins` — 8899/8899 pass
- [x] `cargo clippy --workspace --features gonka --all-targets -- -D warnings` — 0 warnings
- [x] `cargo +nightly fmt --check` — clean
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-llm --features gonka` — 0 errors, 19 doctests pass
- [ ] Live testnet probe — required before merging #3611 (GonkaProvider), not this PR

## Notes

`LlmError::Other` is used for construction errors (empty pool, invalid URL, invalid hex key) as `LlmError::Config` does not exist in the current error enum.

Closes #3609
Closes #3610