### PR TITLE
feat(init): add GonkaGate option to --init wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   output. A config migration step (step 43) adds the commented-out field to existing configs.
   Implements #3300.
 
+- feat(init): add GonkaGate option to `--init` wizard (index 5 in provider select). Sets
+  `provider = compatible`, `name = "gonkagate"`, `base_url = "https://api.gonkagate.com/v1"`,
+  offers a model picker (default: `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8`), and routes vault
+  key setup through `ZEPH_COMPATIBLE_GONKAGATE_API_KEY`. A commented-out provider template is
+  appended to `config/default.toml` for manual setup. (#3604, #3605, #3606)
+
 - feat(config): add `ProviderKind::Gonka` with `GonkaNode { url, name }` struct, node pool
   validation (non-empty, http/https scheme), and `effective_gonka_chain_prefix()` helper
   (defaults to `"gonka"`). `GonkaNode` re-exported from both `zeph-config` and `zeph-core`.

--- a/config/default.toml
+++ b/config/default.toml
@@ -116,6 +116,16 @@ embedding_model = "qwen3-embedding"
 # model = "llama-3.3-70b-versatile"
 # max_tokens = 4096
 
+# GonkaGate — OpenAI-compatible decentralized inference gateway (USD billing).
+# Sign up at https://gonkagate.com/en/register, create an API key, then:
+#   zeph vault set ZEPH_COMPATIBLE_GONKAGATE_API_KEY gp-...
+# [[llm.providers]]
+# name = "gonkagate"
+# type = "compatible"
+# base_url = "https://api.gonkagate.com/v1"
+# model = "Qwen/Qwen3-235B-A22B-Instruct-2507-FP8"
+# max_tokens = 4096
+
 # Candle local inference (feature-gated: --features candle)
 # [[llm.providers]]
 # type = "candle"

--- a/src/init/llm.rs
+++ b/src/init/llm.rs
@@ -48,6 +48,7 @@ pub(super) fn step_llm_provider(state: &mut WizardState, use_age: bool) -> anyho
         "OpenAI (API)",
         "Gemini (API)",
         "Compatible (custom)",
+        "Gonka (decentralized \u{2014} via GonkaGate)",
     ];
     let selection = Select::new()
         .with_prompt("Select LLM provider")
@@ -184,6 +185,29 @@ pub(super) fn step_llm_provider(state: &mut WizardState, use_age: bool) -> anyho
                         .allow_empty_password(true)
                         .interact()?,
                 );
+            }
+        }
+        5 => {
+            state.provider = Some(ProviderKind::Compatible);
+            state.compatible_name = Some("gonkagate".into());
+            state.base_url = Some("https://api.gonkagate.com/v1".into());
+
+            let models = ["Qwen/Qwen3-235B-A22B-Instruct-2507-FP8", "Custom..."];
+            let model_sel = Select::new()
+                .with_prompt("Select model")
+                .items(models)
+                .default(0)
+                .interact()?;
+            state.model = Some(match model_sel {
+                0 => models[0].to_owned(),
+                _ => Input::new().with_prompt("Model name").interact_text()?,
+            });
+
+            if !use_age {
+                let raw = Password::new()
+                    .with_prompt("GonkaGate API key (starts with gp-...)")
+                    .interact()?;
+                state.api_key = Some(raw);
             }
         }
         _ => unreachable!(),

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -2435,4 +2435,48 @@ mod tests {
         let config = build_config(&state);
         assert_eq!(config.quality.trigger, TriggerPolicy::HasRetrieval);
     }
+
+    #[test]
+    fn build_config_gonkagate_provider() {
+        let state = WizardState {
+            provider: Some(ProviderKind::Compatible),
+            compatible_name: Some("gonkagate".into()),
+            base_url: Some("https://api.gonkagate.com/v1".into()),
+            model: Some("Qwen/Qwen3-235B-A22B-Instruct-2507-FP8".into()),
+            embedding_model: Some("qwen3-embedding".into()),
+            vault_backend: "age".into(),
+            ..WizardState::default()
+        };
+        let config = build_config(&state);
+        assert_eq!(config.llm.providers.len(), 1);
+        let p = &config.llm.providers[0];
+        assert_eq!(p.provider_type, ProviderKind::Compatible);
+        assert_eq!(p.name.as_deref(), Some("gonkagate"));
+        assert_eq!(p.base_url.as_deref(), Some("https://api.gonkagate.com/v1"));
+        assert_eq!(
+            p.model.as_deref(),
+            Some("Qwen/Qwen3-235B-A22B-Instruct-2507-FP8")
+        );
+    }
+
+    #[test]
+    fn api_key_env_var_gonkagate() {
+        assert_eq!(
+            api_key_env_var(ProviderKind::Compatible, Some("gonkagate")),
+            Some("ZEPH_COMPATIBLE_GONKAGATE_API_KEY".to_owned())
+        );
+    }
+
+    #[test]
+    fn collect_provider_secret_gonkagate_non_age_sets_key() {
+        let mut secrets = Vec::new();
+        collect_provider_secret(
+            &mut secrets,
+            Some(ProviderKind::Compatible),
+            Some(&"gp-test-key".to_owned()),
+            Some("gonkagate"),
+            false,
+        );
+        assert_eq!(secrets, vec!["ZEPH_COMPATIBLE_GONKAGATE_API_KEY"]);
+    }
 }


### PR DESCRIPTION
## Summary

Implements Gonka.ai Phase 1 Gateway MVP (epic #3602):

- **Wizard branch (#3604)**: adds "Gonka (decentralized — via GonkaGate)" to the `--init` LLM provider picker. Sets `ProviderKind::Compatible`, `name = "gonkagate"`, `base_url = "https://api.gonkagate.com/v1"`. Model picker defaults to `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8` with a custom... escape hatch. Age vault backend prints a `vault set` instruction; non-age backend prompts for the `gp-...` key via masked Password input (`ZEPH_COMPATIBLE_GONKAGATE_API_KEY`).
- **Config template (#3605)**: commented-out `[[llm.providers]]` gonkagate stanza added to `config/default.toml` with signup URL and vault key instruction.
- **Playbook + coverage (#3606)**: new `.local/testing/playbooks/gonka-gateway.md` with 10 live-test scenarios; two `Untested` rows added to `.local/testing/coverage-status.md`.

No runtime code changes — reuses `CompatibleProvider` end-to-end.

## Test plan

- [x] `cargo +nightly fmt --check` — PASS
- [x] `cargo clippy --workspace --features full -- -D warnings` — PASS
- [x] `cargo nextest run --workspace --features full --lib --bins` — 9236/9236 passed
- [x] 3 new unit tests: `build_config_gonkagate_provider`, `api_key_env_var_gonkagate`, `collect_provider_secret_gonkagate_non_age_sets_key`
- [ ] Live test: run `zeph init`, pick GonkaGate, verify TOML output (scenario 1 in playbook)

Closes #3604
Closes #3605
Closes #3606