### PR TITLE
feat(zeph-llm): GonkaProvider chat/chat_stream/embed via signed transport (#3611)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- feat(zeph-llm): add `GonkaProvider` for chat, streaming, and embeddings via signed transport.
+  `GonkaProvider` uses a secp256k1-signed request loop over an `EndpointPool`, delegating OpenAI-compatible
+  body construction to an inner `OpenAiProvider`. Includes `chat`, `chat_stream`, `embed`, and `embed_batch`
+  with automatic endpoint rotation and mark-failed cooldown on errors. Tool-calling deferred to #3612.
+  `EndpointPool::next_indexed()` added to enable correct per-index mark-failed in retry loops. (#3611)
+
 ### Changed
 
 - docs(readme): reposition the project README around memory-first operation, low-resource

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10646,6 +10646,7 @@ dependencies = [
  "wiremock",
  "zeph-common",
  "zeph-config",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/zeph-llm/Cargo.toml
+++ b/crates/zeph-llm/Cargo.toml
@@ -17,7 +17,7 @@ profiling = []
 candle = ["dep:audioadapter-buffers", "dep:candle-core", "dep:candle-nn", "dep:candle-transformers", "dep:hf-hub", "dep:tokenizers", "dep:symphonia", "dep:rubato"]
 classifiers = ["candle", "dep:hex", "dep:sha2"]
 cuda = ["candle", "candle-core/cuda", "candle-nn/cuda", "candle-transformers/cuda"]
-gonka = ["dep:bech32", "dep:k256", "dep:ripemd", "dep:hex", "dep:sha2"]
+gonka = ["dep:bech32", "dep:k256", "dep:ripemd", "dep:hex", "dep:sha2", "dep:zeroize"]
 metal = ["candle", "candle-core/metal", "candle-nn/metal", "candle-transformers/metal"]
 testing = []
 
@@ -55,6 +55,7 @@ tokio-stream.workspace = true
 tracing.workspace = true
 url.workspace = true
 uuid = { workspace = true, features = ["v4", "serde"] }
+zeroize = { workspace = true, optional = true }
 zeph-common.workspace = true
 zeph-config.workspace = true
 # See https://github.com/bug-ops/zeph (workspace dependencies only contain versions)

--- a/crates/zeph-llm/src/gonka/endpoints.rs
+++ b/crates/zeph-llm/src/gonka/endpoints.rs
@@ -144,7 +144,7 @@ impl EndpointPool {
     /// assert_ne!(ep1.base_url, ep2.base_url);
     /// ```
     pub fn next(&self) -> &GonkaEndpoint {
-        let _span = tracing::info_span!("llm.gonka.endpoint_next").entered();
+        let _span = tracing::trace_span!("llm.gonka.endpoint_next").entered();
         let n = self.nodes.len();
         let now_ns = now_ns();
 
@@ -217,11 +217,54 @@ impl EndpointPool {
     pub fn is_empty(&self) -> bool {
         self.nodes.is_empty()
     }
+
+    /// Like [`next`](Self::next) but also returns the internal node index.
+    ///
+    /// The index can be passed directly to [`mark_failed`](Self::mark_failed) so
+    /// the correct pool slot is penalised when a request fails. Using [`next`](Self::next)
+    /// alone does not expose the selected index, which makes it impossible to call
+    /// `mark_failed` correctly in a retry loop.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_llm::gonka::endpoints::{EndpointPool, GonkaEndpoint};
+    /// use std::time::Duration;
+    ///
+    /// let pool = EndpointPool::new(vec![
+    ///     GonkaEndpoint { base_url: "https://n1".into(), address: "a1".into() },
+    ///     GonkaEndpoint { base_url: "https://n2".into(), address: "a2".into() },
+    /// ]).unwrap();
+    ///
+    /// let (idx, ep) = pool.next_indexed();
+    /// assert!(idx < pool.len());
+    /// assert!(!ep.base_url.is_empty());
+    /// ```
+    pub fn next_indexed(&self) -> (usize, &GonkaEndpoint) {
+        let _span = tracing::trace_span!("llm.gonka.endpoint_next").entered();
+        let n = self.nodes.len();
+        let now_ns = now_ns();
+
+        for _ in 0..n {
+            let idx = self.cursor.fetch_add(1, Ordering::Relaxed) % n;
+            if self.failed_until[idx].load(Ordering::Relaxed) <= now_ns {
+                return (idx, &self.nodes[idx]);
+            }
+        }
+
+        let best = self
+            .failed_until
+            .iter()
+            .enumerate()
+            .min_by_key(|(_, a)| a.load(Ordering::Relaxed))
+            .map_or(0, |(i, _)| i);
+        (best, &self.nodes[best])
+    }
 }
 
 /// Current time in unix nanoseconds, saturating to 0 on pre-epoch clocks.
 #[inline]
-fn now_ns() -> u64 {
+pub(crate) fn now_ns() -> u64 {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()

--- a/crates/zeph-llm/src/gonka/mod.rs
+++ b/crates/zeph-llm/src/gonka/mod.rs
@@ -8,7 +8,13 @@
 
 pub mod endpoints;
 #[cfg(feature = "gonka")]
+mod provider;
+#[cfg(feature = "gonka")]
 pub mod signer;
+#[cfg(all(test, feature = "gonka"))]
+mod tests;
 
+#[cfg(feature = "gonka")]
+pub use provider::GonkaProvider;
 #[cfg(feature = "gonka")]
 pub use signer::RequestSigner;

--- a/crates/zeph-llm/src/gonka/provider.rs
+++ b/crates/zeph-llm/src/gonka/provider.rs
@@ -1,0 +1,483 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! [`GonkaProvider`]: an OpenAI-compatible LLM backend over the Gonka signed transport.
+//!
+//! All outgoing HTTP requests are signed with a secp256k1 key via [`RequestSigner`] and
+//! routed through an [`EndpointPool`] that skips failed nodes automatically.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::embed::truncate_for_embed;
+use crate::error::LlmError;
+use crate::gonka::endpoints::{EndpointPool, now_ns};
+use crate::gonka::signer::RequestSigner;
+use crate::openai::OpenAiProvider;
+use crate::provider::{ChatStream, LlmProvider, Message, ToolDefinition};
+use crate::sse::openai_sse_to_stream;
+use crate::usage::UsageTracker;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Wire types shared with openai (local copies to avoid re-exporting private types)
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct OpenAiChatResponse {
+    choices: Vec<ChatChoice>,
+    #[serde(default)]
+    usage: Option<OpenAiUsage>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiUsage {
+    #[serde(default)]
+    prompt_tokens: u64,
+    #[serde(default)]
+    completion_tokens: u64,
+    #[serde(default)]
+    prompt_tokens_details: Option<PromptTokensDetails>,
+}
+
+#[derive(Deserialize)]
+struct PromptTokensDetails {
+    #[serde(default)]
+    cached_tokens: u64,
+}
+
+#[derive(Deserialize)]
+struct ChatChoice {
+    message: ChatMessage,
+}
+
+#[derive(Deserialize)]
+struct ChatMessage {
+    content: String,
+}
+
+#[derive(Deserialize)]
+struct EmbeddingResponse {
+    data: Vec<EmbeddingData>,
+}
+
+#[derive(Deserialize)]
+struct EmbeddingData {
+    #[serde(default)]
+    index: usize,
+    embedding: Vec<f32>,
+}
+
+#[derive(Serialize)]
+struct EmbeddingRequest<'a> {
+    input: &'a str,
+    model: &'a str,
+}
+
+#[derive(Serialize)]
+struct EmbeddingBatchRequest<'a> {
+    model: &'a str,
+    input: Vec<&'a str>,
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// GonkaProvider
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// LLM provider that routes requests through the Gonka network via ECDSA-signed transport.
+///
+/// Request bodies are constructed by an inner [`OpenAiProvider`] (the Gonka gateway
+/// accepts the same wire format), then signed with a secp256k1 key and sent to the
+/// next healthy endpoint from an [`EndpointPool`].
+///
+/// Tool-calling support is planned for issue #3612 and is currently disabled
+/// (`supports_tool_use` returns `false`).
+pub struct GonkaProvider {
+    /// Used only for body construction and capability flags — never called directly.
+    inner: OpenAiProvider,
+    signer: Arc<RequestSigner>,
+    pool: Arc<EndpointPool>,
+    client: reqwest::Client,
+    timeout: Duration,
+    /// Embedding model name, separate from the chat model stored in `inner`.
+    embedding_model: Option<String>,
+    usage: UsageTracker,
+}
+
+impl std::fmt::Debug for GonkaProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GonkaProvider")
+            .field("model", &self.inner.model_identifier())
+            .field("embedding_model", &self.embedding_model)
+            .field("timeout", &self.timeout)
+            .finish_non_exhaustive()
+    }
+}
+
+impl GonkaProvider {
+    /// Construct a new `GonkaProvider`.
+    ///
+    /// - `model` — chat model name sent in the request body (e.g. `"gpt-4o"`).
+    /// - `max_tokens` — upper bound on completion tokens.
+    /// - `embedding_model` — if `Some`, enables embedding support via `/embeddings`.
+    /// - `timeout` — per-request deadline; wraps every outbound `.await`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::sync::Arc;
+    /// use std::time::Duration;
+    /// use zeph_llm::gonka::endpoints::{EndpointPool, GonkaEndpoint};
+    /// use zeph_llm::gonka::RequestSigner;
+    /// use zeph_llm::gonka::GonkaProvider;
+    ///
+    /// # fn example() -> Result<(), zeph_llm::LlmError> {
+    /// let signer = Arc::new(RequestSigner::from_hex(
+    ///     "0000000000000000000000000000000000000000000000000000000000000001",
+    ///     "gonka",
+    /// )?);
+    /// let pool = Arc::new(EndpointPool::new(vec![GonkaEndpoint {
+    ///     base_url: "https://node1.gonka.ai".into(),
+    ///     address: "gonka1w508d6qejxtdg4y5r3zarvary0c5xw7k2gsyg6".into(),
+    /// }])?);
+    /// let provider = GonkaProvider::new(
+    ///     signer,
+    ///     pool,
+    ///     "gpt-4o",
+    ///     4096,
+    ///     Some("text-embedding-3-small".into()),
+    ///     Duration::from_secs(30),
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn new(
+        signer: Arc<RequestSigner>,
+        pool: Arc<EndpointPool>,
+        model: impl Into<String>,
+        max_tokens: u32,
+        embedding_model: Option<String>,
+        timeout: Duration,
+    ) -> Self {
+        let model = model.into();
+        let inner = OpenAiProvider::new(
+            String::new(),
+            String::new(),
+            model,
+            max_tokens,
+            embedding_model.clone(),
+            None,
+        );
+        // HTTP client timeout is generous to avoid double-timeout with tokio::time::timeout.
+        let client = crate::http::llm_client(timeout.as_secs().saturating_add(30));
+        Self {
+            inner,
+            signer,
+            pool,
+            client,
+            timeout,
+            embedding_model,
+            usage: UsageTracker::default(),
+        }
+    }
+
+    /// Sign `body_bytes` and send a POST to `{endpoint}{path}`, retrying across pool nodes.
+    ///
+    /// Returns the first successful [`reqwest::Response`] (2xx or 400, which is surfaced
+    /// to callers for context-length detection). All other statuses cause the endpoint to
+    /// be marked failed and the loop to continue.
+    async fn signed_request(
+        &self,
+        path: &str,
+        body_bytes: &[u8],
+    ) -> Result<reqwest::Response, LlmError> {
+        let max_retries = self.pool.len().min(3);
+        let mut last_err = None;
+        // Pre-allocate once to avoid a heap allocation on every retry attempt.
+        let body_owned: Vec<u8> = body_bytes.to_vec();
+
+        for _ in 0..max_retries {
+            let (idx, endpoint) = self.pool.next_indexed();
+            let url = format!("{}{path}", endpoint.base_url);
+
+            tracing::debug!(endpoint = %endpoint.base_url, "gonka POST {url}");
+
+            // Fresh timestamp on every attempt — non-replayable signatures.
+            let timestamp_ns = u128::from(now_ns());
+            // Signing is synchronous and completes before the await boundary.
+            let signature = self
+                .signer
+                .sign(body_bytes, timestamp_ns, &endpoint.address)?;
+
+            let fut = self
+                .client
+                .post(&url)
+                .header("Content-Type", "application/json")
+                .header("X-Gonka-Timestamp", timestamp_ns.to_string())
+                .header("X-Gonka-Signature", &signature)
+                .header("X-Gonka-Sender", self.signer.address())
+                .body(body_owned.clone())
+                .send();
+
+            match tokio::time::timeout(self.timeout, fut).await {
+                Ok(Ok(resp)) if resp.status().is_success() || resp.status().as_u16() == 400 => {
+                    tracing::debug!(
+                        status = resp.status().as_u16(),
+                        endpoint = %endpoint.base_url,
+                        "gonka response received"
+                    );
+                    return Ok(resp);
+                }
+                Ok(Ok(resp)) => {
+                    let status = resp.status().as_u16();
+                    tracing::warn!(status, endpoint = %endpoint.base_url, "gonka endpoint error");
+                    self.pool.mark_failed(idx, Duration::from_secs(30));
+                    last_err = Some(LlmError::ApiError {
+                        provider: "gonka".into(),
+                        status,
+                    });
+                }
+                Ok(Err(e)) => {
+                    tracing::warn!(error = %e, endpoint = %endpoint.base_url, "gonka HTTP error");
+                    self.pool.mark_failed(idx, Duration::from_secs(30));
+                    last_err = Some(LlmError::Http(e));
+                }
+                Err(_) => {
+                    tracing::warn!(endpoint = %endpoint.base_url, "gonka request timed out");
+                    self.pool.mark_failed(idx, Duration::from_mins(1));
+                    last_err = Some(LlmError::Timeout);
+                }
+            }
+        }
+
+        Err(last_err.unwrap_or(LlmError::Unavailable))
+    }
+
+    fn store_usage(&self, usage: &OpenAiUsage) {
+        self.usage
+            .record_usage(usage.prompt_tokens, usage.completion_tokens);
+        let cached = usage
+            .prompt_tokens_details
+            .as_ref()
+            .map_or(0, |d| d.cached_tokens);
+        if cached > 0 {
+            self.usage.record_cache(0, cached);
+        }
+        tracing::debug!(
+            prompt_tokens = usage.prompt_tokens,
+            cached_tokens = cached,
+            completion_tokens = usage.completion_tokens,
+            "gonka API usage"
+        );
+    }
+}
+
+impl LlmProvider for GonkaProvider {
+    fn name(&self) -> &'static str {
+        "gonka"
+    }
+
+    fn model_identifier(&self) -> &str {
+        self.inner.model_identifier()
+    }
+
+    fn supports_streaming(&self) -> bool {
+        true
+    }
+
+    fn supports_embeddings(&self) -> bool {
+        self.embedding_model.is_some()
+    }
+
+    fn supports_vision(&self) -> bool {
+        false
+    }
+
+    fn supports_tool_use(&self) -> bool {
+        // Tool-calling is deferred to issue #3612.
+        false
+    }
+
+    fn supports_structured_output(&self) -> bool {
+        false
+    }
+
+    fn last_usage(&self) -> Option<(u64, u64)> {
+        self.usage.last_usage()
+    }
+
+    fn last_cache_usage(&self) -> Option<(u64, u64)> {
+        self.usage.last_cache_usage()
+    }
+
+    fn debug_request_json(
+        &self,
+        messages: &[Message],
+        tools: &[ToolDefinition],
+        stream: bool,
+    ) -> serde_json::Value {
+        self.inner.debug_request_json(messages, tools, stream)
+    }
+
+    async fn chat(&self, messages: &[Message]) -> Result<String, LlmError> {
+        tracing::debug!(model = self.model_identifier(), "llm.gonka.chat start");
+        let body = self.inner.debug_request_json(messages, &[], false);
+        let body_bytes = serde_json::to_vec(&body)
+            .map_err(|e| LlmError::Other(format!("body serialization: {e}")))?;
+
+        let response = self
+            .signed_request("/chat/completions", &body_bytes)
+            .await?;
+
+        let status = response.status();
+        let text = response.text().await.map_err(LlmError::Http)?;
+
+        if !status.is_success() {
+            tracing::error!("gonka API error {status}: {text}");
+            if status == reqwest::StatusCode::BAD_REQUEST
+                && crate::error::body_is_context_length_error(&text)
+            {
+                return Err(LlmError::ContextLengthExceeded);
+            }
+            return Err(LlmError::ApiError {
+                provider: "gonka".into(),
+                status: status.as_u16(),
+            });
+        }
+
+        let resp: OpenAiChatResponse = serde_json::from_str(&text)?;
+        if let Some(ref usage) = resp.usage {
+            self.store_usage(usage);
+        }
+        resp.choices
+            .into_iter()
+            .next()
+            .map(|c| c.message.content)
+            .ok_or(LlmError::EmptyResponse {
+                provider: "gonka".into(),
+            })
+    }
+
+    async fn chat_stream(&self, messages: &[Message]) -> Result<ChatStream, LlmError> {
+        tracing::debug!(
+            model = self.model_identifier(),
+            "llm.gonka.chat_stream start"
+        );
+        let body = self.inner.debug_request_json(messages, &[], true);
+        let body_bytes = serde_json::to_vec(&body)
+            .map_err(|e| LlmError::Other(format!("body serialization: {e}")))?;
+
+        let response = self
+            .signed_request("/chat/completions", &body_bytes)
+            .await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let text = response.text().await.map_err(LlmError::Http)?;
+            tracing::error!("gonka streaming error {status}: {text}");
+            if status == reqwest::StatusCode::BAD_REQUEST
+                && crate::error::body_is_context_length_error(&text)
+            {
+                return Err(LlmError::ContextLengthExceeded);
+            }
+            return Err(LlmError::ApiError {
+                provider: "gonka".into(),
+                status: status.as_u16(),
+            });
+        }
+
+        Ok(openai_sse_to_stream(response))
+    }
+
+    async fn embed(&self, text: &str) -> Result<Vec<f32>, LlmError> {
+        tracing::debug!("llm.gonka.embed start");
+        let model = self
+            .embedding_model
+            .as_deref()
+            .ok_or(LlmError::EmbedUnsupported {
+                provider: "gonka".into(),
+            })?;
+
+        let text = truncate_for_embed(text);
+        let body = EmbeddingRequest {
+            input: &text,
+            model,
+        };
+        let body_bytes = serde_json::to_vec(&body)
+            .map_err(|e| LlmError::Other(format!("embed body serialization: {e}")))?;
+
+        let response = self.signed_request("/embeddings", &body_bytes).await?;
+
+        let status = response.status();
+        let body_text = response.text().await.map_err(LlmError::Http)?;
+
+        if !status.is_success() {
+            tracing::error!("gonka embed error {status}: {body_text}");
+            return Err(LlmError::ApiError {
+                provider: "gonka".into(),
+                status: status.as_u16(),
+            });
+        }
+
+        let resp: EmbeddingResponse = serde_json::from_str(&body_text)?;
+        resp.data
+            .into_iter()
+            .next()
+            .map(|d| d.embedding)
+            .ok_or(LlmError::EmptyResponse {
+                provider: "gonka".into(),
+            })
+    }
+
+    async fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, LlmError> {
+        tracing::debug!(count = texts.len(), "llm.gonka.embed_batch start");
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let model = self
+            .embedding_model
+            .as_deref()
+            .ok_or(LlmError::EmbedUnsupported {
+                provider: "gonka".into(),
+            })?;
+
+        let truncated: Vec<std::borrow::Cow<'_, str>> =
+            texts.iter().map(|t| truncate_for_embed(t)).collect();
+        let refs: Vec<&str> = truncated.iter().map(std::convert::AsRef::as_ref).collect();
+
+        let body = EmbeddingBatchRequest { model, input: refs };
+        let body_bytes = serde_json::to_vec(&body)
+            .map_err(|e| LlmError::Other(format!("embed_batch body serialization: {e}")))?;
+
+        let response = self.signed_request("/embeddings", &body_bytes).await?;
+
+        let status = response.status();
+        let body_text = response.text().await.map_err(LlmError::Http)?;
+
+        if !status.is_success() {
+            tracing::error!("gonka embed_batch error {status}: {body_text}");
+            return Err(LlmError::ApiError {
+                provider: "gonka".into(),
+                status: status.as_u16(),
+            });
+        }
+
+        let resp: EmbeddingResponse = serde_json::from_str(&body_text)?;
+
+        if resp.data.len() != texts.len() {
+            return Err(LlmError::Other(format!(
+                "gonka returned {} embeddings for {} inputs",
+                resp.data.len(),
+                texts.len()
+            )));
+        }
+
+        let mut data = resp.data;
+        data.sort_unstable_by_key(|d| d.index);
+
+        Ok(data.into_iter().map(|d| d.embedding).collect())
+    }
+}

--- a/crates/zeph-llm/src/gonka/signer.rs
+++ b/crates/zeph-llm/src/gonka/signer.rs
@@ -29,6 +29,7 @@ use base64::Engine as _;
 use k256::ecdsa::signature::hazmat::PrehashSigner as _;
 use k256::elliptic_curve::sec1::ToEncodedPoint as _;
 use ripemd::Digest as _;
+use zeroize::Zeroizing;
 
 use crate::error::LlmError;
 
@@ -71,8 +72,9 @@ impl RequestSigner {
     /// # }
     /// ```
     pub fn from_hex(priv_hex: &str, chain_prefix: &str) -> Result<Self, LlmError> {
-        let key_bytes =
-            hex::decode(priv_hex).map_err(|e| LlmError::Other(format!("invalid hex key: {e}")))?;
+        let key_bytes: Zeroizing<Vec<u8>> = Zeroizing::new(
+            hex::decode(priv_hex).map_err(|e| LlmError::Other(format!("invalid hex key: {e}")))?,
+        );
         let signing_key = k256::ecdsa::SigningKey::from_slice(&key_bytes)
             .map_err(|e| LlmError::Other(format!("invalid secp256k1 key: {e}")))?;
         let pubkey = k256::PublicKey::from(signing_key.verifying_key());

--- a/crates/zeph-llm/src/gonka/tests.rs
+++ b/crates/zeph-llm/src/gonka/tests.rs
@@ -1,0 +1,401 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio_stream::StreamExt;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use crate::gonka::endpoints::{EndpointPool, GonkaEndpoint};
+use crate::gonka::provider::GonkaProvider;
+use crate::gonka::signer::RequestSigner;
+use crate::provider::{LlmProvider, Message, MessageMetadata, Role, StreamChunk};
+
+const PRIV_KEY: &str = "0000000000000000000000000000000000000000000000000000000000000001";
+
+fn make_signer() -> Arc<RequestSigner> {
+    Arc::new(RequestSigner::from_hex(PRIV_KEY, "gonka").unwrap())
+}
+
+fn make_provider(base_url: &str) -> GonkaProvider {
+    let signer = make_signer();
+    let pool = Arc::new(
+        EndpointPool::new(vec![GonkaEndpoint {
+            base_url: base_url.to_owned(),
+            address: "gonka1w508d6qejxtdg4y5r3zarvary0c5xw7k2gsyg6".to_owned(),
+        }])
+        .unwrap(),
+    );
+    GonkaProvider::new(
+        signer,
+        pool,
+        "gpt-4o",
+        1024,
+        Some("text-embedding-3-small".to_owned()),
+        Duration::from_secs(10),
+    )
+}
+
+fn user_message(text: &str) -> Vec<Message> {
+    vec![Message {
+        role: Role::User,
+        content: text.to_owned(),
+        parts: vec![],
+        metadata: MessageMetadata::default(),
+    }]
+}
+
+const CHAT_RESPONSE: &str = r#"{
+    "choices": [{"message": {"role": "assistant", "content": "hello"}, "finish_reason": "stop"}],
+    "usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8}
+}"#;
+
+const EMBED_RESPONSE: &str =
+    r#"{"data": [{"index": 0, "embedding": [0.1, 0.2, 0.3]}], "model": "text-embedding-3-small"}"#;
+
+/// Test 1: Happy path chat — verifies signing headers are present and response is extracted.
+#[tokio::test]
+async fn gonka_chat_signed_request() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "application/json")
+                .set_body_string(CHAT_RESPONSE),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let provider = make_provider(&server.uri());
+    let messages = user_message("hi");
+    let result = provider.chat(&messages).await.unwrap();
+    assert_eq!(result, "hello");
+
+    // Verify signature headers were sent.
+    let reqs = server.received_requests().await.unwrap();
+    assert_eq!(reqs.len(), 1);
+    let req = &reqs[0];
+    assert!(
+        req.headers.get("x-gonka-signature").is_some(),
+        "X-Gonka-Signature header missing"
+    );
+    assert!(
+        req.headers.get("x-gonka-timestamp").is_some(),
+        "X-Gonka-Timestamp header missing"
+    );
+    assert!(
+        req.headers.get("x-gonka-sender").is_some(),
+        "X-Gonka-Sender header missing"
+    );
+    // Verify the sender address matches the known address for PRIV_KEY_1.
+    let sender = req.headers.get("x-gonka-sender").unwrap().to_str().unwrap();
+    assert_eq!(sender, "gonka1w508d6qejxtdg4y5r3zarvary0c5xw7k2gsyg6");
+
+    // Verify signature is 88-char base64 (ECDSA 64 bytes STANDARD encoded).
+    let sig = req
+        .headers
+        .get("x-gonka-signature")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert_eq!(sig.len(), 88, "signature must be 88-char base64");
+}
+
+/// Test 2: Happy path streaming — SSE response is consumed and text assembled correctly.
+#[tokio::test]
+async fn gonka_chat_stream() {
+    let sse_body = concat!(
+        "data: {\"choices\":[{\"delta\":{\"content\":\"hel\"},\"finish_reason\":null}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{\"content\":\"lo\"},\"finish_reason\":null}]}\n\n",
+        "data: [DONE]\n\n",
+    );
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(sse_body),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let provider = make_provider(&server.uri());
+    let messages = user_message("stream test");
+    let stream = provider.chat_stream(&messages).await.unwrap();
+
+    let chunks: Vec<_> = stream.collect::<Vec<_>>().await;
+    let text: String = chunks
+        .into_iter()
+        .filter_map(|c| match c {
+            Ok(StreamChunk::Content(t)) => Some(t),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(text, "hello");
+}
+
+/// Test 3: Happy path embed — single embedding vector is returned.
+#[tokio::test]
+async fn gonka_embed_happy_path() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/embeddings"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "application/json")
+                .set_body_string(EMBED_RESPONSE),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let provider = make_provider(&server.uri());
+    let embedding = provider.embed("hello world").await.unwrap();
+    assert_eq!(embedding, vec![0.1f32, 0.2f32, 0.3f32]);
+}
+
+/// Test 4: `embed_batch` — multiple embeddings returned in index order.
+#[tokio::test]
+async fn gonka_embed_batch_happy_path() {
+    // Return embeddings in reverse order to test sort-by-index.
+    let batch_response = r#"{
+        "data": [
+            {"index": 1, "embedding": [0.4, 0.5]},
+            {"index": 0, "embedding": [0.1, 0.2]}
+        ]
+    }"#;
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/embeddings"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "application/json")
+                .set_body_string(batch_response),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let provider = make_provider(&server.uri());
+    let texts = ["first", "second"];
+    let embeddings = provider.embed_batch(&texts).await.unwrap();
+    assert_eq!(embeddings.len(), 2);
+    assert_eq!(embeddings[0], vec![0.1f32, 0.2f32]);
+    assert_eq!(embeddings[1], vec![0.4f32, 0.5f32]);
+}
+
+/// Test 5: retry on 503 — first endpoint fails, second succeeds.
+#[tokio::test]
+async fn gonka_retry_on_endpoint_failure() {
+    let server1 = MockServer::start().await;
+    let server2 = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(503))
+        .expect(1)
+        .mount(&server1)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "application/json")
+                .set_body_string(CHAT_RESPONSE),
+        )
+        .expect(1)
+        .mount(&server2)
+        .await;
+
+    let signer = make_signer();
+    let pool = Arc::new(
+        EndpointPool::new(vec![
+            GonkaEndpoint {
+                base_url: server1.uri(),
+                address: "gonka1w508d6qejxtdg4y5r3zarvary0c5xw7k2gsyg6".to_owned(),
+            },
+            GonkaEndpoint {
+                base_url: server2.uri(),
+                address: "gonka1w508d6qejxtdg4y5r3zarvary0c5xw7k2gsyg6".to_owned(),
+            },
+        ])
+        .unwrap(),
+    );
+    let provider = GonkaProvider::new(signer, pool, "gpt-4o", 1024, None, Duration::from_secs(10));
+    let messages = user_message("retry test");
+    let result = provider.chat(&messages).await.unwrap();
+    assert_eq!(result, "hello");
+}
+
+/// Test 6: all endpoints fail — [`LlmError`] returned after exhausting retries.
+#[tokio::test]
+async fn gonka_all_endpoints_fail() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(503))
+        .mount(&server)
+        .await;
+
+    let provider = make_provider(&server.uri());
+    let messages = user_message("fail test");
+    let result = provider.chat(&messages).await;
+    assert!(result.is_err(), "expected error when all endpoints fail");
+}
+
+/// Test 7: context length error via 400 response.
+#[tokio::test]
+async fn gonka_context_length_error_on_400() {
+    let body_400 = r#"{"error": {"message": "context length exceeded"}}"#;
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(400)
+                .insert_header("content-type", "application/json")
+                .set_body_string(body_400),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let provider = make_provider(&server.uri());
+    let messages = user_message("very long text");
+    let result = provider.chat(&messages).await;
+    assert!(
+        matches!(result, Err(crate::error::LlmError::ContextLengthExceeded)),
+        "expected ContextLengthExceeded, got: {result:?}"
+    );
+}
+
+/// Test 8: fresh timestamp on each retry attempt (non-replayable signatures).
+#[tokio::test]
+async fn gonka_fresh_timestamp_on_retry() {
+    let server1 = MockServer::start().await;
+    let server2 = MockServer::start().await;
+
+    // First endpoint always returns 503.
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(503))
+        .mount(&server1)
+        .await;
+
+    // Second endpoint returns success.
+    Mock::given(method("POST"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "application/json")
+                .set_body_string(CHAT_RESPONSE),
+        )
+        .mount(&server2)
+        .await;
+
+    let signer = make_signer();
+    let pool = Arc::new(
+        EndpointPool::new(vec![
+            GonkaEndpoint {
+                base_url: server1.uri(),
+                address: "gonka1w508d6qejxtdg4y5r3zarvary0c5xw7k2gsyg6".to_owned(),
+            },
+            GonkaEndpoint {
+                base_url: server2.uri(),
+                address: "gonka1w508d6qejxtdg4y5r3zarvary0c5xw7k2gsyg6".to_owned(),
+            },
+        ])
+        .unwrap(),
+    );
+    let provider = GonkaProvider::new(signer, pool, "gpt-4o", 1024, None, Duration::from_secs(10));
+    let messages = user_message("timestamp test");
+    let result = provider.chat(&messages).await.unwrap();
+    assert_eq!(result, "hello");
+
+    // Collect timestamps from both servers.
+    let ts1_reqs = server1.received_requests().await.unwrap();
+    let ts2_reqs = server2.received_requests().await.unwrap();
+
+    let ts1 = ts1_reqs[0]
+        .headers
+        .get("x-gonka-timestamp")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .parse::<u128>()
+        .unwrap();
+    let ts2 = ts2_reqs[0]
+        .headers
+        .get("x-gonka-timestamp")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .parse::<u128>()
+        .unwrap();
+
+    // Timestamps must be valid nanosecond values (non-zero).
+    assert!(ts1 > 0, "timestamp on first attempt must be non-zero");
+    assert!(ts2 > 0, "timestamp on second attempt must be non-zero");
+    // Both are fresh timestamps; they may or may not differ depending on clock resolution,
+    // but both must be recent (within 10 seconds of each other).
+    let diff = ts2.abs_diff(ts1);
+    let ten_sec_ns = 10_u128 * 1_000_000_000;
+    assert!(
+        diff < ten_sec_ns,
+        "timestamps should be within 10s of each other"
+    );
+}
+
+/// Test 9: `embed_batch` returns error when count mismatches.
+#[tokio::test]
+async fn gonka_embed_batch_count_mismatch_returns_error() {
+    // Return 1 embedding for 2 inputs.
+    let mismatch_response = r#"{"data": [{"index": 0, "embedding": [0.1]}]}"#;
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/embeddings"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "application/json")
+                .set_body_string(mismatch_response),
+        )
+        .mount(&server)
+        .await;
+
+    let provider = make_provider(&server.uri());
+    let texts = ["first", "second"];
+    let result = provider.embed_batch(&texts).await;
+    assert!(result.is_err(), "expected error for count mismatch");
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains('2') && (msg.contains('1') || msg.contains("gonka")),
+        "unexpected error message: {msg}"
+    );
+}
+
+/// Test 10: `embed` returns `EmbedUnsupported` when no embedding model is configured.
+#[tokio::test]
+async fn gonka_embed_unsupported_without_model() {
+    let signer = make_signer();
+    let pool = Arc::new(
+        EndpointPool::new(vec![GonkaEndpoint {
+            base_url: "https://dummy.example".to_owned(),
+            address: "gonka1w508d6qejxtdg4y5r3zarvary0c5xw7k2gsyg6".to_owned(),
+        }])
+        .unwrap(),
+    );
+    // No embedding model configured.
+    let provider = GonkaProvider::new(signer, pool, "gpt-4o", 1024, None, Duration::from_secs(5));
+    assert!(!provider.supports_embeddings());
+
+    let result = provider.embed("test").await;
+    assert!(
+        matches!(result, Err(crate::error::LlmError::EmbedUnsupported { .. })),
+        "expected EmbedUnsupported, got: {result:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- Add `GonkaProvider` implementing `LlmProvider::chat`, `chat_stream`, `embed`, `embed_batch` over secp256k1-signed HTTP
- Body construction delegates to an inner `OpenAiProvider`; each request is signed with a fresh nanosecond timestamp and routed through `EndpointPool` with automatic mark-failed cooldown on errors
- Streaming reuses `openai_sse_to_stream` after the signed POST
- Add `EndpointPool::next_indexed()` for correct per-slot mark-failed in retry loops
- Wrap `key_bytes` in `Zeroizing<Vec<u8>>` in `RequestSigner::from_hex` to zero intermediate heap allocation
- 10 wiremock integration tests: chat, streaming, embed, embed_batch, retry, exhaustion, context-length 400, timestamp freshness on retry

Tool-calling (`chat_with_tools`, `chat_typed`) deferred to #3612.

## Test plan

- [ ] `cargo nextest run -p zeph-llm --features "zeph-llm/gonka" --config-file .github/nextest.toml` — all 33 gonka tests pass
- [ ] `cargo nextest run --workspace --features full --lib --bins --config-file .github/nextest.toml` — 9269 tests pass
- [ ] `cargo clippy --workspace --features full -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean

Closes #3611
Part of epic #3602