### PR TITLE
perf(tracing): add llm.turn_call span to main-turn LLM call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- perf(tracing): rename `llm_call` span to `llm.turn_call` with `provider` field for main-turn
+  LLM call visibility; avoids naming collision with existing `llm.chat_stream` spans at the
+  provider layer (#3619).
+
 - docs(readme): reposition the project README around memory-first operation, low-resource
   deployment, multi-provider routing, and the current Gonka.ai integration path.
 

--- a/book/src/advanced/observability.md
+++ b/book/src/advanced/observability.md
@@ -20,7 +20,7 @@ endpoint = "http://localhost:4317"       # OTLP gRPC endpoint
 
 | Span | Attributes |
 |------|------------|
-| `llm_call` | `model` |
+| `llm.turn_call` | `model`, `provider` |
 | `tool_exec` | `tool_name` |
 
 Traces flush gracefully on shutdown. Point `endpoint` at any OTLP-compatible collector (Jaeger, Grafana Tempo, etc.).

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -318,7 +318,11 @@ impl<C: Channel> Agent<C> {
                 .map(|id| tc.begin_llm_request(id))
         });
 
-        let llm_span = tracing::info_span!("llm_call", model = %self.runtime.config.model_name);
+        let llm_span = tracing::info_span!(
+            "llm.turn_call",
+            model = %self.runtime.config.model_name,
+            provider = self.provider.name(),
+        );
         let result = self
             .call_llm_non_streaming(
                 llm_timeout,
@@ -905,7 +909,11 @@ impl<C: Channel> Agent<C> {
                 .map(|id| tc.begin_llm_request(id))
         });
 
-        let llm_span = tracing::info_span!("llm_call", model = %self.runtime.config.model_name);
+        let llm_span = tracing::info_span!(
+            "llm.turn_call",
+            model = %self.runtime.config.model_name,
+            provider = self.provider.name(),
+        );
         let chat_fut = tokio::time::timeout(
             llm_timeout,
             self.provider


### PR DESCRIPTION
## Summary

- Rename `llm_call` tracing span to `llm.turn_call` in `native.rs` (both production and test paths)
- Add `provider` field to the span so traces identify the active LLM backend
- Avoid naming collision with existing `llm.chat_stream` spans at the provider layer (`compatible.rs`, `ollama.rs`)
- Update `book/src/advanced/observability.md` span reference table

## Motivation

The main-turn LLM call was a silent gap in local Chrome traces — ~15 s of unattributed latency inside `agent.turn`. This change makes the span visible as `llm.turn_call` with `model` and `provider` attributes, enabling bottleneck detection in Perfetto / chrome://tracing.

## Test plan

- [x] All 1350 `zeph-core` tests pass
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler" -- -D warnings` — 0 warnings
- [x] Docs build without broken intra-doc links
- [x] No sensitive data in span fields (security audit passed)
- [x] Zero measurable performance overhead (span already existed, only renamed + one `&'static str` field added)

Closes #3619