### PR TITLE
feat(zeph-llm): GonkaProvider chat_with_tools and chat_typed (#3612)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - feat(zeph-llm): add `GonkaProvider` for chat, streaming, and embeddings via signed transport.
   `GonkaProvider` uses a secp256k1-signed request loop over an `EndpointPool`, delegating OpenAI-compatible
   body construction to an inner `OpenAiProvider`. Includes `chat`, `chat_stream`, `embed`, and `embed_batch`
-  with automatic endpoint rotation and mark-failed cooldown on errors. Tool-calling deferred to #3612.
+  with automatic endpoint rotation and mark-failed cooldown on errors.
   `EndpointPool::next_indexed()` added to enable correct per-index mark-failed in retry loops. (#3611)
+
+- `GonkaProvider::chat_with_tools` and `chat_typed` — tool use and structured output over the Gonka signed transport (#3612)
 
 ### Changed
 

--- a/crates/zeph-llm/src/gonka/provider.rs
+++ b/crates/zeph-llm/src/gonka/provider.rs
@@ -16,7 +16,7 @@ use crate::error::LlmError;
 use crate::gonka::endpoints::{EndpointPool, now_ns};
 use crate::gonka::signer::RequestSigner;
 use crate::openai::OpenAiProvider;
-use crate::provider::{ChatStream, LlmProvider, Message, ToolDefinition};
+use crate::provider::{ChatResponse, ChatStream, LlmProvider, Message, ToolDefinition};
 use crate::sse::openai_sse_to_stream;
 use crate::usage::UsageTracker;
 
@@ -90,9 +90,6 @@ struct EmbeddingBatchRequest<'a> {
 /// Request bodies are constructed by an inner [`OpenAiProvider`] (the Gonka gateway
 /// accepts the same wire format), then signed with a secp256k1 key and sent to the
 /// next healthy endpoint from an [`EndpointPool`].
-///
-/// Tool-calling support is planned for issue #3612 and is currently disabled
-/// (`supports_tool_use` returns `false`).
 pub struct GonkaProvider {
     /// Used only for body construction and capability flags — never called directly.
     inner: OpenAiProvider,
@@ -296,12 +293,11 @@ impl LlmProvider for GonkaProvider {
     }
 
     fn supports_tool_use(&self) -> bool {
-        // Tool-calling is deferred to issue #3612.
-        false
+        true
     }
 
     fn supports_structured_output(&self) -> bool {
-        false
+        true
     }
 
     fn last_usage(&self) -> Option<(u64, u64)> {
@@ -479,5 +475,112 @@ impl LlmProvider for GonkaProvider {
         data.sort_unstable_by_key(|d| d.index);
 
         Ok(data.into_iter().map(|d| d.embedding).collect())
+    }
+
+    async fn chat_with_tools(
+        &self,
+        messages: &[Message],
+        tools: &[ToolDefinition],
+    ) -> Result<ChatResponse, LlmError> {
+        tracing::debug!(
+            model = self.model_identifier(),
+            "llm.gonka.chat_with_tools start"
+        );
+        let body = serde_json::to_vec(&self.inner.debug_request_json(messages, tools, false))
+            .map_err(|e| LlmError::Other(format!("body serialization: {e}")))?;
+
+        let response = self.signed_request("/chat/completions", &body).await?;
+
+        let status = response.status();
+        let text = response.text().await.map_err(LlmError::Http)?;
+
+        if status == reqwest::StatusCode::BAD_REQUEST {
+            let truncated: String = text.chars().take(256).collect();
+            tracing::warn!("gonka tool chat 400 bad request: {truncated}");
+            if crate::error::body_is_context_length_error(&text) {
+                return Err(LlmError::ContextLengthExceeded);
+            }
+            return Err(LlmError::InvalidInput {
+                provider: "gonka".into(),
+                message: text.chars().take(512).collect(),
+            });
+        }
+
+        if !status.is_success() {
+            let truncated: String = text.chars().take(256).collect();
+            tracing::error!("gonka API error {status}: {truncated}");
+            return Err(LlmError::ApiError {
+                provider: "gonka".into(),
+                status: status.as_u16(),
+            });
+        }
+
+        let result = self.inner.decode_tool_chat_response(&text, "gonka")?;
+
+        // Sync usage from inner tracker to our own tracker.
+        if let Some((prompt, completion)) = self.inner.last_usage() {
+            self.usage.record_usage(prompt, completion);
+        }
+        if let Some((write, cached)) = self.inner.last_cache_usage() {
+            self.usage.record_cache(write, cached);
+        }
+
+        Ok(result)
+    }
+
+    async fn chat_typed<T>(&self, messages: &[Message]) -> Result<T, LlmError>
+    where
+        T: serde::de::DeserializeOwned + schemars::JsonSchema + 'static,
+        Self: Sized,
+    {
+        tracing::debug!(
+            model = self.model_identifier(),
+            "llm.gonka.chat_typed start"
+        );
+        let body_bytes = self.inner.build_typed_chat_body::<T>(messages)?;
+
+        let response = self
+            .signed_request("/chat/completions", &body_bytes)
+            .await?;
+
+        let status = response.status();
+        let text = response.text().await.map_err(LlmError::Http)?;
+
+        if status == reqwest::StatusCode::BAD_REQUEST {
+            let truncated: String = text.chars().take(256).collect();
+            tracing::warn!("gonka chat_typed 400 bad request: {truncated}");
+            if crate::error::body_is_context_length_error(&text) {
+                return Err(LlmError::ContextLengthExceeded);
+            }
+            return Err(LlmError::InvalidInput {
+                provider: "gonka".into(),
+                message: text.chars().take(512).collect(),
+            });
+        }
+
+        if !status.is_success() {
+            let truncated: String = text.chars().take(256).collect();
+            tracing::error!("gonka API error {status}: {truncated}");
+            return Err(LlmError::ApiError {
+                provider: "gonka".into(),
+                status: status.as_u16(),
+            });
+        }
+
+        let resp: OpenAiChatResponse = serde_json::from_str(&text)?;
+        if let Some(ref usage) = resp.usage {
+            self.store_usage(usage);
+        }
+
+        let content = resp
+            .choices
+            .into_iter()
+            .next()
+            .map(|c| c.message.content)
+            .ok_or(LlmError::EmptyResponse {
+                provider: "gonka".into(),
+            })?;
+
+        serde_json::from_str::<T>(&content).map_err(|e| LlmError::StructuredParse(e.to_string()))
     }
 }

--- a/crates/zeph-llm/src/gonka/tests.rs
+++ b/crates/zeph-llm/src/gonka/tests.rs
@@ -8,10 +8,15 @@ use tokio_stream::StreamExt;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+use schemars::JsonSchema;
+use serde::Deserialize;
+
 use crate::gonka::endpoints::{EndpointPool, GonkaEndpoint};
 use crate::gonka::provider::GonkaProvider;
 use crate::gonka::signer::RequestSigner;
-use crate::provider::{LlmProvider, Message, MessageMetadata, Role, StreamChunk};
+use crate::provider::{
+    ChatResponse, LlmProvider, Message, MessageMetadata, Role, StreamChunk, ToolDefinition,
+};
 
 const PRIV_KEY: &str = "0000000000000000000000000000000000000000000000000000000000000001";
 
@@ -398,4 +403,108 @@ async fn gonka_embed_unsupported_without_model() {
         matches!(result, Err(crate::error::LlmError::EmbedUnsupported { .. })),
         "expected EmbedUnsupported, got: {result:?}"
     );
+}
+
+/// Test 11: `chat_with_tools` returns `ChatResponse::ToolUse` with correct call ID and arguments.
+#[tokio::test]
+async fn gonka_tools_chat_with_tools_returns_tool_use() {
+    let tool_response = r#"{
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_abc123",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": "{\"location\":\"London\"}"
+                    }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": {"prompt_tokens": 20, "completion_tokens": 10, "total_tokens": 30}
+    }"#;
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "application/json")
+                .set_body_string(tool_response),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let provider = make_provider(&server.uri());
+    let messages = user_message("What is the weather in London?");
+
+    let tool = ToolDefinition {
+        name: "get_weather".into(),
+        description: "Get weather for a location".into(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "location": {"type": "string"}
+            },
+            "required": ["location"]
+        }),
+        output_schema: None,
+    };
+
+    let result = provider.chat_with_tools(&messages, &[tool]).await.unwrap();
+
+    match result {
+        ChatResponse::ToolUse { tool_calls, .. } => {
+            assert_eq!(tool_calls.len(), 1);
+            assert_eq!(tool_calls[0].id, "call_abc123");
+            assert_eq!(tool_calls[0].name.as_ref(), "get_weather");
+            assert_eq!(tool_calls[0].input["location"], "London");
+        }
+        other => panic!("expected ToolUse, got: {other:?}"),
+    }
+}
+
+/// Test 12: `chat_typed` returns a deserialized struct from JSON content.
+#[tokio::test]
+async fn gonka_tools_chat_typed_returns_struct() {
+    #[derive(Debug, Deserialize, JsonSchema)]
+    struct CityInfo {
+        name: String,
+        population: u64,
+    }
+
+    let typed_response = r#"{
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": "{\"name\":\"London\",\"population\":9000000}"
+            },
+            "finish_reason": "stop"
+        }],
+        "usage": {"prompt_tokens": 15, "completion_tokens": 8, "total_tokens": 23}
+    }"#;
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "application/json")
+                .set_body_string(typed_response),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let provider = make_provider(&server.uri());
+    let messages = user_message("Give me info about London");
+
+    let result: CityInfo = provider.chat_typed(&messages).await.unwrap();
+
+    assert_eq!(result.name, "London");
+    assert_eq!(result.population, 9_000_000);
 }

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -910,12 +910,20 @@ impl LlmProvider for OpenAiProvider {
             });
         }
 
-        self.decode_tool_chat_response(&text)
+        self.decode_tool_chat_response(&text, "openai")
     }
 }
 
 impl OpenAiProvider {
-    fn decode_tool_chat_response(&self, text: &str) -> Result<ChatResponse, LlmError> {
+    /// Decode a raw tool-chat JSON response body into a [`ChatResponse`].
+    ///
+    /// Records usage via `store_cache_usage`.  Pass `provider_name` so that
+    /// `EmptyResponse` errors carry the correct provider label.
+    pub(crate) fn decode_tool_chat_response(
+        &self,
+        text: &str,
+        provider_name: &str,
+    ) -> Result<ChatResponse, LlmError> {
         let resp: ToolChatResponse = serde_json::from_str(text)?;
 
         if let Some(ref usage) = resp.usage {
@@ -927,7 +935,7 @@ impl OpenAiProvider {
             .into_iter()
             .next()
             .ok_or(LlmError::EmptyResponse {
-                provider: "openai".into(),
+                provider: provider_name.into(),
             })?;
 
         if let Some(tool_calls) = choice.message.tool_calls
@@ -975,6 +983,43 @@ impl OpenAiProvider {
             choice.message.content
         };
         Ok(ChatResponse::Text(content))
+    }
+
+    /// Build a serialized `TypedChatRequest` body for `chat_typed`.
+    ///
+    /// Extracts and normalises the JSON Schema for `T`, wraps it in
+    /// `response_format: json_schema`, and returns the raw bytes ready for an
+    /// HTTP POST body.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LlmError::StructuredParse`] if schema extraction or serialisation fails.
+    pub(crate) fn build_typed_chat_body<T>(&self, messages: &[Message]) -> Result<Vec<u8>, LlmError>
+    where
+        T: serde::de::DeserializeOwned + schemars::JsonSchema + 'static,
+    {
+        let (raw_schema, _) = crate::provider::cached_schema::<T>()?;
+        let mut schema_value = raw_schema;
+        inline_refs_openai(&mut schema_value, 8);
+        normalize_for_openai_strict(&mut schema_value, 16);
+        let type_name = crate::provider::short_type_name::<T>();
+
+        let api_messages = convert_messages(messages);
+        let body = TypedChatRequest {
+            model: &self.model,
+            messages: &api_messages,
+            completion_tokens: CompletionTokens::for_model(&self.model, self.max_tokens),
+            response_format: ResponseFormat {
+                r#type: "json_schema",
+                json_schema: JsonSchemaFormat {
+                    name: type_name,
+                    schema: schema_value,
+                    strict: true,
+                },
+            },
+        };
+
+        serde_json::to_vec(&body).map_err(|e| LlmError::StructuredParse(e.to_string()))
     }
 }
 

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -994,6 +994,7 @@ impl OpenAiProvider {
     /// # Errors
     ///
     /// Returns [`LlmError::StructuredParse`] if schema extraction or serialisation fails.
+    #[cfg(feature = "gonka")]
     pub(crate) fn build_typed_chat_body<T>(&self, messages: &[Message]) -> Result<Vec<u8>, LlmError>
     where
         T: serde::de::DeserializeOwned + schemars::JsonSchema + 'static,


### PR DESCRIPTION
## Summary

- Extends `GonkaProvider` with `chat_with_tools` and `chat_typed<T>` over the Gonka ECDSA-signed transport
- Promotes `decode_tool_chat_response` to `pub(crate)` on `OpenAiProvider` with a `provider_name` parameter
- Adds `pub(crate) build_typed_chat_body<T>` helper extracted from `OpenAiProvider::chat_typed`
- Error bodies truncated before logging (256 chars) and `InvalidInput` messages (512 chars) to prevent unbounded memory from malicious nodes
- 2 new wiremock tests; all 35 gonka tests pass; `test(gonka_tools)` filter matches 2 tests per acceptance criterion

## Test plan

- [x] `cargo nextest run -p zeph-llm --features gonka -E 'test(gonka_tools)'` — 2 tests pass
- [x] `cargo nextest run -p zeph-llm --features gonka -E 'test(gonka)'` — 35 tests pass
- [x] `cargo clippy --workspace --features full -- -D warnings` — clean
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 8892 tests pass
- [x] `cargo doc --no-deps --features gonka -p zeph-llm` — no broken intra-doc links
- [ ] Live API round-trip (LLM serialization gate) — requires Gonka testnet credentials; to be verified by CI cycle before merge

## Notes

- `signed_request` swallows 429 inside the retry loop (converts to `ApiError { status: 429 }`), so `RateLimited` path is intentionally not present in these methods
- Usage tracking syncs from `inner` tracker to `self.usage` after `decode_tool_chat_response` via `last_usage()`/`last_cache_usage()`

Closes #3612