### PR TITLE
fix(zeph-llm): name wildcard match arm in gonka/tests.rs:467

### DIFF
--- a/crates/zeph-llm/src/gonka/tests.rs
+++ b/crates/zeph-llm/src/gonka/tests.rs
@@ -464,7 +464,7 @@ async fn gonka_tools_chat_with_tools_returns_tool_use() {
             assert_eq!(tool_calls[0].name.as_ref(), "get_weather");
             assert_eq!(tool_calls[0].input["location"], "London");
         }
-        other => panic!("expected ToolUse, got: {other:?}"),
+        other @ ChatResponse::Text(_) => panic!("expected ToolUse, got: {other:?}"),
     }
 }
 


### PR DESCRIPTION
## Summary

- Replaces bare wildcard `other =>` with `other @ ChatResponse::Text(_) =>` in the `gonka_tools_chat_with_tools` test
- Fixes `clippy::match_wildcard_for_single_variants` error that was breaking `cargo clippy --workspace --features full -- -D warnings`

## Test plan

- [x] `cargo clippy -p zeph-llm --all-targets -- -D warnings` passes
- [x] `cargo +nightly fmt --check -p zeph-llm` passes
- [x] `cargo nextest run -p zeph-llm --lib --bins` — 852 tests pass, 10 skipped

Closes #3626