### PR TITLE
fix(hooks): add tracing instrumentation and propagate hooks in reload_config

### DIFF
--- a/crates/zeph-config/src/hooks.rs
+++ b/crates/zeph-config/src/hooks.rs
@@ -235,7 +235,7 @@ fail_closed = false
         assert!(cfg.permission_denied.is_empty());
     }
 
-    /// Exercises the full testing.toml hooks pattern: cwd_changed + file_changed + permission_denied
+    /// Exercises the full testing.toml hooks pattern: `cwd_changed` + `file_changed` + `permission_denied`
     /// all in one TOML document, in the order they appear in testing.toml. Prevents regression of
     /// issue #3625 where hooks appeared empty despite correct TOML config.
     #[test]

--- a/crates/zeph-config/src/hooks.rs
+++ b/crates/zeph-config/src/hooks.rs
@@ -234,4 +234,50 @@ fail_closed = false
         assert!(cfg.cwd_changed.is_empty());
         assert!(cfg.permission_denied.is_empty());
     }
+
+    /// Exercises the full testing.toml hooks pattern: cwd_changed + file_changed + permission_denied
+    /// all in one TOML document, in the order they appear in testing.toml. Prevents regression of
+    /// issue #3625 where hooks appeared empty despite correct TOML config.
+    #[test]
+    fn hooks_config_parses_all_sections_in_sequence() {
+        let toml = r#"
+[[cwd_changed]]
+type = "command"
+command = "echo 'CWD_CHANGED_HOOK_FIRED'"
+timeout_secs = 10
+fail_closed = false
+
+[file_changed]
+watch_paths = ["src/", "Cargo.toml"]
+debounce_ms = 500
+[[file_changed.hooks]]
+type = "command"
+command = "cargo check"
+timeout_secs = 30
+fail_closed = false
+
+[[permission_denied]]
+type = "command"
+command = "echo 'PERMISSION_DENIED_HOOK_FIRED'"
+timeout_secs = 5
+fail_closed = false
+"#;
+        let cfg: HooksConfig = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.cwd_changed.len(), 1, "expected 1 cwd_changed hook");
+        assert!(
+            matches!(&cfg.cwd_changed[0].action, HookAction::Command { command } if command == "echo 'CWD_CHANGED_HOOK_FIRED'")
+        );
+        let fc = cfg
+            .file_changed
+            .as_ref()
+            .expect("file_changed must be Some");
+        assert_eq!(fc.hooks.len(), 1, "expected 1 file_changed hook");
+        assert_eq!(fc.debounce_ms, 500);
+        assert_eq!(
+            cfg.permission_denied.len(),
+            1,
+            "expected 1 permission_denied hook"
+        );
+        assert!(!cfg.is_empty(), "hooks config must not be empty");
+    }
 }

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -2960,6 +2960,23 @@ impl<C: Channel> Agent<C> {
         self.services.index.repo_map_ttl =
             std::time::Duration::from_secs(config.index.repo_map_ttl_secs);
 
+        self.services
+            .session
+            .hooks_config
+            .cwd_changed
+            .clone_from(&config.hooks.cwd_changed);
+        self.services
+            .session
+            .hooks_config
+            .permission_denied
+            .clone_from(&config.hooks.permission_denied);
+        self.services
+            .session
+            .hooks_config
+            .turn_complete
+            .clone_from(&config.hooks.turn_complete);
+        // file_changed_hooks require watcher restart to take effect — skipped here.
+
         tracing::info!("config reloaded");
     }
 
@@ -3277,7 +3294,10 @@ impl<C: Channel> Agent<C> {
             .await;
 
         let hooks = self.services.session.hooks_config.cwd_changed.clone();
-        if !hooks.is_empty() {
+        if hooks.is_empty() {
+            tracing::debug!("CwdChanged: no hooks configured, skipping");
+        } else {
+            tracing::debug!(count = hooks.len(), "CwdChanged: firing hooks");
             let mut env = std::collections::HashMap::new();
             env.insert("ZEPH_OLD_CWD".to_owned(), old_cwd.display().to_string());
             env.insert("ZEPH_NEW_CWD".to_owned(), current.display().to_string());
@@ -3287,6 +3307,8 @@ impl<C: Channel> Agent<C> {
                 .map(|d| d as &dyn zeph_subagent::McpDispatch);
             if let Err(e) = zeph_subagent::hooks::fire_hooks(&hooks, &env, mcp).await {
                 tracing::warn!(error = %e, "CwdChanged hook failed");
+            } else {
+                tracing::info!(count = hooks.len(), "CwdChanged: hooks fired");
             }
         }
 
@@ -3311,7 +3333,10 @@ impl<C: Channel> Agent<C> {
             .hooks_config
             .file_changed_hooks
             .clone();
-        if !hooks.is_empty() {
+        if hooks.is_empty() {
+            tracing::debug!(path = %event.path.display(), "FileChanged: no hooks configured, skipping");
+        } else {
+            tracing::debug!(count = hooks.len(), path = %event.path.display(), "FileChanged: firing hooks");
             let mut env = std::collections::HashMap::new();
             env.insert(
                 "ZEPH_CHANGED_PATH".to_owned(),
@@ -3323,6 +3348,8 @@ impl<C: Channel> Agent<C> {
                 .map(|d| d as &dyn zeph_subagent::McpDispatch);
             if let Err(e) = zeph_subagent::hooks::fire_hooks(&hooks, &env, mcp).await {
                 tracing::warn!(error = %e, "FileChanged hook failed");
+            } else {
+                tracing::info!(count = hooks.len(), path = %event.path.display(), "FileChanged: hooks fired");
             }
         }
 


### PR DESCRIPTION
## Summary

Fixes #3625.

Investigation found no deserialization or dispatch bug — hooks were firing correctly but silently. Root causes:

- No `tracing::info!/debug!` around `fire_hooks` calls in `check_cwd_changed` / `handle_file_changed`, making it impossible to observe whether hooks fired
- `reload_config` did not propagate `[hooks]` changes to the runtime `hooks_config`, so live config reload had no effect on hook commands

## Changes

- `crates/zeph-core/src/agent/mod.rs`: add `tracing::debug!` before each `fire_hooks` call and `tracing::info!` on success in `check_cwd_changed` and `handle_file_changed`; propagate `cwd_changed`, `permission_denied`, `turn_complete` in `reload_config` (file_changed requires watcher restart — skipped with comment)
- `crates/zeph-config/src/hooks.rs`: regression test covering the full `cwd_changed` + `file_changed` + `permission_denied` TOML structure

## Test plan

- [ ] `cargo nextest run -E 'test(hooks)'` — 74/74 pass including new regression test
- [ ] Full workspace: 8893/8893 pass, no regressions
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — clean