### PR TITLE
feat(core+wizard): wire GonkaProvider end-to-end with native wizard branch (#3613, #3603)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- feat(zeph-core): wire `GonkaProvider` end-to-end as `AnyProvider::Gonka`. Adds `build_gonka_provider`
+  factory with private key resolution from vault, optional address verification (case-insensitive bech32),
+  and `EndpointPool` construction from `[[llm.providers]]` node list. `GonkaProvider` now implements
+  manual `Clone` and `with_generation_overrides` for use with the orchestrator and `/provider` switching.
+  `GonkaNode` gains a mandatory `address` field. Vault snapshot fields `gonka_private_key` /
+  `gonka_address` added to `ProviderConfigSnapshot` for runtime provider switching. (#3613)
+
+- feat(init): native Gonka provider option in `--init` wizard. Detects `inferenced` CLI, guides through
+  key selection or manual hex input, derives bech32 address, configures seed nodes, stores secrets in
+  age vault. Refuses to proceed without age vault backend. (#3613)
+
+- feat(config): migration step 45 — `migrate_gonkagate_to_gonka`. Injects an advisory comment above
+  `type = "compatible" / name = "gonkagate"` entries in existing configs, pointing to the native
+  Gonka provider. No data is modified; idempotent. (#3613)
+
 - feat(zeph-llm): add `GonkaProvider` for chat, streaming, and embeddings via signed transport.
   `GonkaProvider` uses a secp256k1-signed request loop over an `EndpointPool`, delegating OpenAI-compatible
   body construction to an inner `OpenAiProvider`. Includes `chat`, `chat_stream`, `embed`, and `embed_batch`
@@ -15,6 +30,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `EndpointPool::next_indexed()` added to enable correct per-index mark-failed in retry loops. (#3611)
 
 - `GonkaProvider::chat_with_tools` and `chat_typed` — tool use and structured output over the Gonka signed transport (#3612)
+
+- Gonka AI integration guide covering GonkaGate and native inference paths (#3603)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10171,6 +10171,7 @@ dependencies = [
  "zeph-subagent",
  "zeph-tools",
  "zeph-tui",
+ "zeroize",
 ]
 
 [[package]]
@@ -10508,6 +10509,7 @@ dependencies = [
  "zeph-subagent",
  "zeph-tools",
  "zeph-vault",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -246,7 +246,7 @@ task-metrics = ["zeph-core/task-metrics"]
 # Database backend selection — mutually exclusive. Default includes sqlite.
 # NOTE: --all-features activates both, triggering compile_error! in zeph-db.
 # Use --features full or --features full,postgres instead.
-gonka = ["zeph-llm/gonka"]
+gonka = ["zeph-llm/gonka", "zeph-core/gonka"]
 index = ["zeph-core/index"]
 sqlite = ["zeph-db/sqlite", "zeph-memory/sqlite"]
 postgres = ["zeph-db/postgres", "zeph-memory/postgres"]
@@ -291,6 +291,7 @@ pprof = { workspace = true, optional = true, features = ["prost-codec"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 url.workspace = true
 uuid = { workspace = true, optional = true, features = ["v4"] }
+zeroize.workspace = true
 zeph-a2a = { workspace = true, optional = true }
 zeph-acp = { workspace = true, optional = true }
 zeph-channels.workspace = true

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -31,6 +31,7 @@
 # Guides
 
 - [Use a Cloud Provider](guides/cloud-provider.md)
+- [Gonka Provider](guides/gonka.md)
 - [Configuration Recipes](guides/config-recipes.md)
 - [Run via Telegram](guides/telegram.md)
 - [Add Custom Skills](guides/custom-skills.md)

--- a/book/src/guides/gonka.md
+++ b/book/src/guides/gonka.md
@@ -1,0 +1,92 @@
+# Gonka AI Provider
+
+[Gonka](https://gonka.ai) is a decentralized AI inference network built on a Cosmos-SDK chain that routes LLM requests to a peer-to-peer pool of GPU operators. Zeph supports two access paths.
+
+## Path A: GonkaGate (Recommended for quick start)
+
+GonkaGate is a hosted gateway to the Gonka network with USD-denominated billing — no token staking required.
+
+**Setup:**
+
+1. Sign up at <https://gonkagate.com/en/register> and create a `gp-...` API key.
+2. Store the key in the Zeph vault:
+   ```bash
+   zeph vault set ZEPH_COMPATIBLE_GONKAGATE_API_KEY gp-...
+   ```
+3. Run `zeph init` and select **"Gonka (decentralized — via GonkaGate)"** when prompted for a provider.
+
+**Resulting config:**
+
+```toml
+[[llm.providers]]
+type = "compatible"
+name = "gonkagate"
+base_url = "https://api.gonkagate.com/v1"
+model = "gpt-4o"
+```
+
+**Pricing:** USD-denominated. Top up at <https://gonkagate.com>.
+
+## Path B: Native Gonka Network (Requires GNK staking)
+
+The native path connects directly to Gonka inference nodes over a signed transport. Requests are authenticated with a secp256k1 key and GNK tokens are consumed per inference.
+
+**Prerequisites:**
+
+- Download and install `inferenced` CLI from <https://github.com/gonka-ai/gonka/releases>.
+- Acquire GNK tokens and fund your address.
+
+**Setup:**
+
+1. Create a key with `inferenced`:
+   ```bash
+   inferenced keys add zeph
+   ```
+2. Store the signing key in the Zeph vault:
+   ```bash
+   zeph vault set ZEPH_GONKA_PRIVATE_KEY <your-hex-encoded-secp256k1-key>
+   zeph vault set ZEPH_GONKA_ADDRESS <your-bech32-address>  # optional, for validation
+   ```
+3. Run `zeph init` and select **"Gonka (native — requires GNK staking)"**.
+
+**Resulting config:**
+
+```toml
+[[llm.providers]]
+type = "gonka"
+name = "gonka-mainnet"
+model = "gpt-4o"
+gonka_chain_prefix = "gonka"
+
+[[llm.providers.gonka_nodes]]
+url = "https://node1.gonka.ai"
+address = "gonka1..."
+
+[[llm.providers.gonka_nodes]]
+url = "https://node2.gonka.ai"
+address = "gonka1..."
+
+[[llm.providers.gonka_nodes]]
+url = "https://node3.gonka.ai"
+address = "gonka1..."
+```
+
+**Pricing:** GNK token consumption per inference.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| 401 / signature error | Invalid key format or address mismatch | Verify `ZEPH_GONKA_PRIVATE_KEY` is hex-encoded secp256k1; confirm address matches key |
+| 401 with "clock skew" | System time out of sync | Sync your clock via NTP |
+| "ZEPH_GONKA_PRIVATE_KEY not found in vault" | Key not stored | Run `zeph vault set ZEPH_GONKA_PRIVATE_KEY <key>` |
+| "ZEPH_GONKA_ADDRESS does not match address derived from private key" | Address/key mismatch | Either unset `ZEPH_GONKA_ADDRESS` or correct it to match the key |
+| `inferenced` not found | CLI not installed | Download from <https://github.com/gonka-ai/gonka/releases> |
+
+## Migrating from GonkaGate to Native
+
+Run `zeph migrate-config` — it will add advisory comments to your config pointing to the fields that need updating. Then:
+
+1. Install `inferenced` and fund your GNK address.
+2. Store `ZEPH_GONKA_PRIVATE_KEY` in the vault.
+3. Update `[[llm.providers]]` in your config: change `type = "compatible"` to `type = "gonka"` and add `[[llm.providers.gonka_nodes]]` entries.

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -3307,9 +3307,9 @@ use steps::{
     MigrateAcpSubagentsConfig, MigrateAgentBudgetHint, MigrateAgentRetryToToolsRetry,
     MigrateAutodreamConfig, MigrateCompressionPredictorConfig, MigrateDatabaseUrl,
     MigrateEgressConfig, MigrateFocusAutoConsolidateMinWindow, MigrateForgettingConfig,
-    MigrateGoalsConfig, MigrateHooksPermissionDeniedConfig, MigrateHooksTurnComplete,
-    MigrateMagicDocsConfig, MigrateMcpElicitationConfig, MigrateMcpMaxConnectAttempts,
-    MigrateMcpTrustLevels, MigrateMemoryGraph, MigrateMemoryHebbian,
+    MigrateGoalsConfig, MigrateGonkagateToGonka, MigrateHooksPermissionDeniedConfig,
+    MigrateHooksTurnComplete, MigrateMagicDocsConfig, MigrateMcpElicitationConfig,
+    MigrateMcpMaxConnectAttempts, MigrateMcpTrustLevels, MigrateMemoryGraph, MigrateMemoryHebbian,
     MigrateMemoryHebbianConsolidation, MigrateMemoryHebbianSpread, MigrateMemoryPersonaConfig,
     MigrateMemoryReasoning, MigrateMemoryReasoningJudge, MigrateMemoryRetrieval,
     MigrateMemoryRetrievalQueryBias, MigrateMicrocompactConfig, MigrateOrchestrationPersistence,
@@ -3321,7 +3321,76 @@ use steps::{
     MigrateVigilConfig,
 };
 
-/// Ordered registry of all sequential migration steps (steps 1–44).
+/// Step 45: add an advisory comment above `GonkaGate` provider entries pointing users to
+/// the native Gonka provider option.
+///
+/// This is advisory only — no automatic conversion is performed. The comment informs
+/// users that a native Gonka provider is now available and links to migration docs.
+pub(crate) fn migrate_gonkagate_to_gonka(toml_src: &str) -> MigrationResult {
+    // Advisory-only: add a comment before GonkaGate provider entries when found.
+    const MARKER: &str = "# [migration] GonkaGate detected: consider migrating to type = \"gonka\"";
+
+    if !toml_src.contains("gonkagate") {
+        return MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: vec![],
+        };
+    }
+
+    let mut changed_count = 0;
+    let mut lines: Vec<String> = toml_src.lines().map(str::to_owned).collect();
+
+    // Walk backwards from each line containing "gonkagate" to find the nearest preceding
+    // [[llm.providers]] table header and insert the advisory comment before it.
+    // We iterate indices in reverse so that inserting at a position does not shift later targets.
+    let indices: Vec<usize> = lines
+        .iter()
+        .enumerate()
+        .filter(|(_, l)| l.contains("gonkagate"))
+        .map(|(i, _)| i)
+        .rev()
+        .collect();
+
+    for gonka_idx in indices {
+        // Find the most recent [[...]] header at or before gonka_idx.
+        let header_idx = (0..=gonka_idx)
+            .rev()
+            .find(|&i| lines[i].starts_with("[["))
+            .unwrap_or(gonka_idx);
+
+        // Skip if the comment is already present just before the header.
+        let already_marked = header_idx > 0 && lines[header_idx - 1].contains(MARKER);
+        if already_marked {
+            continue;
+        }
+
+        lines.insert(
+            header_idx,
+            format!("{MARKER} (see docs/guides/gonka-native.md)"),
+        );
+        changed_count += 1;
+    }
+
+    let output = lines.join("\n");
+    let output = if toml_src.ends_with('\n') {
+        format!("{output}\n")
+    } else {
+        output
+    };
+
+    MigrationResult {
+        output,
+        changed_count,
+        sections_changed: if changed_count > 0 {
+            vec!["llm".into()]
+        } else {
+            vec![]
+        },
+    }
+}
+
+/// Ordered registry of all sequential migration steps (steps 1–45).
 ///
 /// Each entry wraps the corresponding free function and is evaluated lazily at first access.
 /// The ordering is chronological; the dispatch loop in `src/commands/migrate.rs` iterates
@@ -3392,6 +3461,8 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             Box::new(MigrateOrchestratorProvider),
             // Step 44 — max_concurrent per-provider admission control hint (#3299)
             Box::new(MigrateProviderMaxConcurrent),
+            // Step 45 — advisory notice for GonkaGate → native Gonka upgrade path (#3613)
+            Box::new(MigrateGonkagateToGonka),
         ]
     });
 
@@ -3410,8 +3481,8 @@ mod tests {
     fn migrations_registry_has_all_steps() {
         assert_eq!(
             MIGRATIONS.len(),
-            44,
-            "MIGRATIONS registry must contain all 44 sequential steps"
+            45,
+            "MIGRATIONS registry must contain all 45 sequential steps"
         );
         for m in MIGRATIONS.iter() {
             assert!(
@@ -4997,8 +5068,8 @@ prompt_cache_ttl = "1h"
     // ── Migration registry ────────────────────────────────────────────────────
 
     #[test]
-    fn registry_has_thirty_nine_entries() {
-        assert_eq!(MIGRATIONS.len(), 44);
+    fn registry_has_forty_five_entries() {
+        assert_eq!(MIGRATIONS.len(), 45);
     }
 
     #[test]
@@ -5037,7 +5108,7 @@ prompt_cache_ttl = "1h"
 
     #[test]
     fn registry_preserves_order_matches_dispatch() {
-        // Names must follow the documented step order (steps 1–43).
+        // Names must follow the documented step order (steps 1–45).
         let expected = [
             "migrate_stt_to_provider",
             "migrate_planner_model_to_provider",
@@ -5083,6 +5154,7 @@ prompt_cache_ttl = "1h"
             "migrate_tools_compression_config",
             "migrate_orchestrator_provider",
             "migrate_provider_max_concurrent",
+            "migrate_gonkagate_to_gonka",
         ];
         let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
         assert_eq!(actual, expected);
@@ -5215,5 +5287,45 @@ prompt_cache_ttl = "1h"
         let result = migrate_provider_max_concurrent(src).expect("migrate");
         assert_eq!(result.changed_count, 0);
         assert_eq!(result.output, src);
+    }
+
+    // ── Step 45 — migrate_gonkagate_to_gonka ─────────────────────────────────
+
+    #[test]
+    fn step45_adds_advisory_comment_when_gonkagate_present() {
+        let src = "[[llm.providers]]\ntype = \"compatible\"\nname = \"gonkagate\"\n";
+        let result = migrate_gonkagate_to_gonka(src);
+        assert!(result.changed_count > 0, "must detect gonkagate entry");
+        assert!(
+            result.output.contains("[migration] GonkaGate detected"),
+            "advisory comment must be added"
+        );
+        // Comment must appear before the [[llm.providers]] table header, not inside it.
+        let comment_pos = result
+            .output
+            .find("[migration] GonkaGate detected")
+            .unwrap();
+        let header_pos = result.output.find("[[llm.providers]]").unwrap();
+        assert!(
+            comment_pos < header_pos,
+            "advisory comment must precede the [[llm.providers]] header"
+        );
+    }
+
+    #[test]
+    fn step45_noop_when_no_gonkagate() {
+        let src = "[[llm.providers]]\ntype = \"openai\"\nname = \"quality\"\n";
+        let result = migrate_gonkagate_to_gonka(src);
+        assert_eq!(result.changed_count, 0);
+        assert_eq!(result.output, src);
+    }
+
+    #[test]
+    fn step45_does_not_double_insert_comment() {
+        let src = "[[llm.providers]]\ntype = \"compatible\"\nname = \"gonkagate\"\n";
+        let first = migrate_gonkagate_to_gonka(src);
+        let second = migrate_gonkagate_to_gonka(&first.output);
+        // Second run must not add another comment line.
+        assert_eq!(second.changed_count, 0, "idempotent on second run");
     }
 }

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -516,3 +516,14 @@ impl Migration for MigrateProviderMaxConcurrent {
         migrate_provider_max_concurrent(toml_src)
     }
 }
+
+pub(super) struct MigrateGonkagateToGonka;
+impl Migration for MigrateGonkagateToGonka {
+    fn name(&self) -> &'static str {
+        "migrate_gonkagate_to_gonka"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        Ok(super::migrate_gonkagate_to_gonka(toml_src))
+    }
+}

--- a/crates/zeph-config/src/providers.rs
+++ b/crates/zeph-config/src/providers.rs
@@ -1304,6 +1304,11 @@ impl Default for CoeConfig {
 pub struct GonkaNode {
     /// HTTP(S) URL of the Gonka node (e.g. `"https://node1.gonka.ai"`).
     pub url: String,
+    /// On-chain bech32 address of this node (e.g. `"gonka1w508d6qejxtdg4y5r3zarvary0c5xw7k2gsyg6"`).
+    ///
+    /// Required for signature construction: every signed request binds to the target node's
+    /// on-chain address, making signatures non-replayable across different nodes.
+    pub address: String,
     /// Optional human-readable label for `zeph gonka doctor` output.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -2441,14 +2446,17 @@ alpha = 1.5
         vec![
             GonkaNode {
                 url: "https://node1.gonka.ai".into(),
+                address: "gonka1w508d6qejxtdg4y5r3zarvary0c5xw7k2gsyg6".into(),
                 name: Some("node1".into()),
             },
             GonkaNode {
                 url: "https://node2.gonka.ai".into(),
+                address: "gonka14h0ycu78h88wzldxc7e79vhw5xsde0n85evmum".into(),
                 name: Some("node2".into()),
             },
             GonkaNode {
                 url: "http://node3.internal".into(),
+                address: "gonka1qyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqg".into(),
                 name: None,
             },
         ]
@@ -2474,6 +2482,7 @@ alpha = 1.5
     fn validate_gonka_node_empty_url_errors() {
         let entry = gonka_entry_with_nodes(vec![GonkaNode {
             url: String::new(),
+            address: "gonka1test".into(),
             name: None,
         }]);
         let err = entry.validate().unwrap_err();
@@ -2484,6 +2493,7 @@ alpha = 1.5
     fn validate_gonka_node_invalid_scheme_errors() {
         let entry = gonka_entry_with_nodes(vec![GonkaNode {
             url: "ftp://node.gonka.ai".into(),
+            address: "gonka1test".into(),
             name: None,
         }]);
         let err = entry.validate().unwrap_err();
@@ -2514,14 +2524,17 @@ gonka_chain_prefix = "custom-chain"
 
 [[llm.providers.gonka_nodes]]
 url = "https://node1.gonka.ai"
+address = "gonka1w508d6qejxtdg4y5r3zarvary0c5xw7k2gsyg6"
 name = "node1"
 
 [[llm.providers.gonka_nodes]]
 url = "https://node2.gonka.ai"
+address = "gonka14h0ycu78h88wzldxc7e79vhw5xsde0n85evmum"
 name = "node2"
 
 [[llm.providers.gonka_nodes]]
 url = "https://node3.gonka.ai"
+address = "gonka1qyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqg"
 "#;
         let cfg = parse_llm(toml);
         assert_eq!(cfg.providers.len(), 1);
@@ -2531,6 +2544,10 @@ url = "https://node3.gonka.ai"
         let nodes = &entry.gonka_nodes;
         assert_eq!(nodes.len(), 3);
         assert_eq!(nodes[0].url, "https://node1.gonka.ai");
+        assert_eq!(
+            nodes[0].address,
+            "gonka1w508d6qejxtdg4y5r3zarvary0c5xw7k2gsyg6"
+        );
         assert_eq!(nodes[0].name.as_deref(), Some("node1"));
         assert_eq!(nodes[2].name, None);
         assert_eq!(entry.gonka_chain_prefix.as_deref(), Some("custom-chain"));

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -20,6 +20,7 @@ task-metrics = ["dep:cpu-time", "dep:metrics", "zeph-common/task-metrics"]
 default = ["sqlite"]
 candle = ["zeph-llm/candle"]
 classifiers = ["zeph-llm/classifiers", "zeph-sanitizer/classifiers"]
+gonka = ["zeph-llm/gonka"]
 cuda = ["zeph-llm/cuda"]
 env-vault = ["zeph-vault/env-vault"]
 metal = ["zeph-llm/metal"]
@@ -64,6 +65,7 @@ cpu-time = { workspace = true, optional = true }
 metrics = { workspace = true, optional = true }
 tree-sitter.workspace = true
 uuid = { workspace = true, features = ["v4", "serde"] }
+zeroize.workspace = true
 zeph-agent-context.workspace = true
 zeph-agent-feedback.workspace = true
 zeph-agent-persistence.workspace = true

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -2497,6 +2497,8 @@ mod tests {
             compatible_api_keys: std::collections::HashMap::new(),
             llm_request_timeout_secs: 30,
             embedding_model: String::new(),
+            gonka_private_key: None,
+            gonka_address: None,
         };
         let agent = make_agent()
             .with_shutdown(rx)

--- a/crates/zeph-core/src/agent/provider_cmd.rs
+++ b/crates/zeph-core/src/agent/provider_cmd.rs
@@ -376,6 +376,8 @@ mod tests {
             compatible_api_keys: HashMap::default(),
             llm_request_timeout_secs: 30,
             embedding_model: "nomic-embed-text".to_owned(),
+            gonka_private_key: None,
+            gonka_address: None,
         }
     }
 
@@ -510,6 +512,8 @@ mod tests {
             compatible_api_keys: HashMap::default(),
             llm_request_timeout_secs: 60,
             embedding_model: "nomic-embed-text".to_owned(),
+            gonka_private_key: None,
+            gonka_address: None,
         };
         assert_eq!(snap.claude_api_key.as_deref(), Some("key-claude"));
         assert_eq!(snap.openai_api_key.as_deref(), Some("key-openai"));

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -56,6 +56,7 @@ use zeph_sanitizer::quarantine::QuarantinedSummarizer;
 use zeph_skills::matcher::SkillMatcherBackend;
 use zeph_skills::registry::SkillRegistry;
 use zeph_skills::watcher::SkillEvent;
+use zeroize::Zeroizing;
 
 use super::message_queue::QueuedMessage;
 
@@ -486,6 +487,8 @@ pub struct ProviderConfigSnapshot {
     pub compatible_api_keys: std::collections::HashMap<String, String>,
     pub llm_request_timeout_secs: u64,
     pub embedding_model: String,
+    pub gonka_private_key: Option<Zeroizing<String>>,
+    pub gonka_address: Option<String>,
 }
 
 /// Groups provider-related state: alternate providers, runtime switching, and compaction flags.

--- a/crates/zeph-core/src/provider_factory.rs
+++ b/crates/zeph-core/src/provider_factory.rs
@@ -594,9 +594,7 @@ mod tests {
         ));
     }
 
-    use super::{
-        build_provider_from_entry, effective_embedding_model, stable_skill_embedding_model,
-    };
+    use super::{effective_embedding_model, stable_skill_embedding_model};
     use crate::config::{Config, ProviderKind};
     use zeph_config::providers::ProviderEntry;
 

--- a/crates/zeph-core/src/provider_factory.rs
+++ b/crates/zeph-core/src/provider_factory.rs
@@ -12,9 +12,15 @@ use zeph_llm::any::AnyProvider;
 use zeph_llm::claude::ClaudeProvider;
 use zeph_llm::compatible::CompatibleProvider;
 use zeph_llm::gemini::GeminiProvider;
+#[cfg(feature = "gonka")]
+use zeph_llm::gonka::endpoints::{EndpointPool, GonkaEndpoint};
+#[cfg(feature = "gonka")]
+use zeph_llm::gonka::{GonkaProvider, RequestSigner};
 use zeph_llm::http::llm_client;
 use zeph_llm::ollama::OllamaProvider;
 use zeph_llm::openai::OpenAiProvider;
+#[cfg(feature = "gonka")]
+use zeroize::Zeroizing;
 
 use crate::agent::state::ProviderConfigSnapshot;
 use crate::config::{Config, ProviderEntry, ProviderKind};
@@ -71,6 +77,11 @@ pub fn build_provider_for_switch(
         .iter()
         .map(|(k, v)| (k.clone(), Secret::new(v.as_str())))
         .collect();
+    config.secrets.gonka_private_key = snapshot
+        .gonka_private_key
+        .as_ref()
+        .map(|z| Secret::new(z.as_str()));
+    config.secrets.gonka_address = snapshot.gonka_address.as_deref().map(Secret::new);
     config.timeouts.llm_request_timeout_secs = snapshot.llm_request_timeout_secs;
     config
         .llm
@@ -104,8 +115,11 @@ pub fn build_provider_from_entry(
         ProviderKind::Candle => Err(BootstrapError::Provider(
             "candle feature is not enabled".into(),
         )),
+        #[cfg(feature = "gonka")]
+        ProviderKind::Gonka => build_gonka_provider(entry, config),
+        #[cfg(not(feature = "gonka"))]
         ProviderKind::Gonka => Err(BootstrapError::Provider(
-            "gonka provider is not yet implemented".into(),
+            "gonka feature is not enabled; rebuild with --features gonka".into(),
         )),
     }
 }
@@ -293,6 +307,82 @@ fn build_compatible_provider(
         "mcp.output_schema.forwarding_configured"
     );
     Ok(AnyProvider::Compatible(provider))
+}
+
+#[cfg(feature = "gonka")]
+fn build_gonka_provider(
+    entry: &ProviderEntry,
+    config: &Config,
+) -> Result<AnyProvider, BootstrapError> {
+    let _span = tracing::info_span!("core.provider_factory.build_gonka").entered();
+
+    let private_key_hex: Zeroizing<String> = Zeroizing::new(
+        config
+            .secrets
+            .gonka_private_key
+            .as_ref()
+            .ok_or_else(|| {
+                BootstrapError::Provider(
+                    "ZEPH_GONKA_PRIVATE_KEY not found in vault; set it with: zeph vault set ZEPH_GONKA_PRIVATE_KEY <hex>".into(),
+                )
+            })?
+            .expose()
+            .to_owned(),
+    );
+
+    let chain_prefix = entry.effective_gonka_chain_prefix().to_owned();
+    let signer = RequestSigner::from_hex(&private_key_hex, &chain_prefix)
+        .map_err(|e| BootstrapError::Provider(format!("invalid Gonka private key: {e}")))?;
+
+    if let Some(ref configured_address) = config.secrets.gonka_address {
+        let configured = configured_address.expose().to_lowercase();
+        let derived = signer.address().to_lowercase();
+        if configured != derived {
+            return Err(BootstrapError::Provider(format!(
+                "ZEPH_GONKA_ADDRESS does not match address derived from private key \
+                 (configured: {configured}, derived: {derived})"
+            )));
+        }
+    } else {
+        tracing::info!(
+            address = signer.address(),
+            "Gonka: using address derived from private key (ZEPH_GONKA_ADDRESS not set)"
+        );
+    }
+
+    if entry.gonka_nodes.is_empty() {
+        return Err(BootstrapError::Provider(
+            "Gonka provider entry must have at least one node in gonka_nodes".into(),
+        ));
+    }
+
+    let endpoints: Vec<GonkaEndpoint> = entry
+        .gonka_nodes
+        .iter()
+        .map(|n| GonkaEndpoint {
+            base_url: n.url.clone(),
+            address: n.address.clone(),
+        })
+        .collect();
+
+    let pool = EndpointPool::new(endpoints).map_err(|e| {
+        BootstrapError::Provider(format!("failed to build Gonka endpoint pool: {e}"))
+    })?;
+
+    let model = entry.model.clone().unwrap_or_else(|| "gpt-4o".to_owned());
+    let max_tokens = entry.max_tokens.unwrap_or(4096);
+    let timeout = std::time::Duration::from_secs(config.timeouts.llm_request_timeout_secs);
+
+    let provider = GonkaProvider::new(
+        std::sync::Arc::new(signer),
+        std::sync::Arc::new(pool),
+        model,
+        max_tokens,
+        entry.embedding_model.clone(),
+        timeout,
+    );
+
+    Ok(AnyProvider::Gonka(provider))
 }
 
 #[cfg(feature = "candle")]
@@ -504,9 +594,94 @@ mod tests {
         ));
     }
 
-    use super::{effective_embedding_model, stable_skill_embedding_model};
+    use super::{
+        build_provider_from_entry, effective_embedding_model, stable_skill_embedding_model,
+    };
     use crate::config::{Config, ProviderKind};
     use zeph_config::providers::ProviderEntry;
+
+    #[cfg(feature = "gonka")]
+    mod gonka_tests {
+        use super::*;
+        use zeph_common::secret::Secret;
+        use zeph_config::GonkaNode;
+        use zeph_llm::LlmProvider;
+
+        fn gonka_entry_with_nodes(nodes: Vec<GonkaNode>) -> ProviderEntry {
+            ProviderEntry {
+                provider_type: ProviderKind::Gonka,
+                name: Some("gonka".into()),
+                model: Some("gpt-4o".into()),
+                gonka_nodes: nodes,
+                ..ProviderEntry::default()
+            }
+        }
+
+        fn valid_nodes() -> Vec<GonkaNode> {
+            vec![GonkaNode {
+                url: "https://node1.gonka.ai".into(),
+                address: "gonka1w508d6qejxtdg4y5r3zarvary0c5xw7k2gsyg6".into(),
+                name: Some("node1".into()),
+            }]
+        }
+
+        const VALID_PRIV_KEY: &str =
+            "0000000000000000000000000000000000000000000000000000000000000001";
+
+        #[test]
+        fn build_gonka_provider_missing_key_returns_error() {
+            let entry = gonka_entry_with_nodes(valid_nodes());
+            let config = Config::default();
+            let result = build_provider_from_entry(&entry, &config);
+            assert!(result.is_err());
+            let msg = result.unwrap_err().to_string();
+            assert!(
+                msg.contains("ZEPH_GONKA_PRIVATE_KEY"),
+                "error must mention missing key: {msg}"
+            );
+        }
+
+        #[test]
+        fn build_gonka_provider_empty_nodes_returns_error() {
+            let entry = gonka_entry_with_nodes(vec![]);
+            let mut config = Config::default();
+            config.secrets.gonka_private_key = Some(Secret::new(VALID_PRIV_KEY));
+            let result = build_provider_from_entry(&entry, &config);
+            assert!(result.is_err());
+            let msg = result.unwrap_err().to_string();
+            assert!(
+                msg.contains("gonka_nodes") || msg.contains("node"),
+                "error must mention empty nodes: {msg}"
+            );
+        }
+
+        #[test]
+        fn build_gonka_provider_address_mismatch_returns_error() {
+            let entry = gonka_entry_with_nodes(valid_nodes());
+            let mut config = Config::default();
+            config.secrets.gonka_private_key = Some(Secret::new(VALID_PRIV_KEY));
+            config.secrets.gonka_address =
+                Some(Secret::new("gonka1wrongaddress000000000000000000000000000"));
+            let result = build_provider_from_entry(&entry, &config);
+            assert!(result.is_err());
+            let msg = result.unwrap_err().to_string();
+            assert!(
+                msg.contains("does not match"),
+                "error must mention address mismatch: {msg}"
+            );
+        }
+
+        #[test]
+        fn build_gonka_provider_happy_path() {
+            let entry = gonka_entry_with_nodes(valid_nodes());
+            let mut config = Config::default();
+            config.secrets.gonka_private_key = Some(Secret::new(VALID_PRIV_KEY));
+            let result = build_provider_from_entry(&entry, &config);
+            assert!(result.is_ok(), "expected Ok, got: {:?}", result.err());
+            let provider = result.unwrap();
+            assert_eq!(provider.name(), "gonka");
+        }
+    }
 
     fn make_provider_entry(
         embed: bool,

--- a/crates/zeph-llm/src/any.rs
+++ b/crates/zeph-llm/src/any.rs
@@ -30,6 +30,8 @@ use crate::candle_provider::CandleProvider;
 use crate::claude::ClaudeProvider;
 use crate::compatible::CompatibleProvider;
 use crate::gemini::GeminiProvider;
+#[cfg(feature = "gonka")]
+use crate::gonka::GonkaProvider;
 #[cfg(any(test, feature = "testing"))]
 use crate::mock::MockProvider;
 use crate::ollama::OllamaProvider;
@@ -58,6 +60,8 @@ macro_rules! delegate_provider {
             AnyProvider::Compatible($p) => $expr,
             AnyProvider::Router($p) => $expr,
             AnyProvider::Triage($p) => $expr,
+            #[cfg(feature = "gonka")]
+            AnyProvider::Gonka($p) => $expr,
             #[cfg(any(test, feature = "testing"))]
             AnyProvider::Mock($p) => $expr,
         }
@@ -84,6 +88,11 @@ pub enum AnyProvider {
     Router(Box<RouterProvider>),
     /// Complexity triage router: pre-classifies each request and delegates to the appropriate tier.
     Triage(Box<TriageRouter>),
+    /// Gonka native inference provider — routes signed requests through the Gonka network.
+    ///
+    /// Only available when the `gonka` feature is enabled.
+    #[cfg(feature = "gonka")]
+    Gonka(GonkaProvider),
     /// A mock provider for use in tests and benchmarks.
     ///
     /// Only available with the `testing` feature or in `#[cfg(test)]` contexts.
@@ -180,6 +189,9 @@ impl AnyProvider {
                 .unwrap_or_default()),
             #[cfg(feature = "candle")]
             AnyProvider::Candle(_) => Ok(vec![]),
+            // Gonka nodes have no model discovery API.
+            #[cfg(feature = "gonka")]
+            AnyProvider::Gonka(_) => Ok(vec![]),
             #[cfg(any(test, feature = "testing"))]
             AnyProvider::Mock(p) => Ok(p.models.clone()),
         }
@@ -220,6 +232,9 @@ impl AnyProvider {
             Self::Router(r) => r.last_selected_provider_kind(),
             // Triage has no post-call provider tracking; treat as unpriced.
             Self::Triage(_) => "local",
+            // Gonka is a metered network — treat as cloud for cost tracking.
+            #[cfg(feature = "gonka")]
+            Self::Gonka(_) => "cloud",
             _ => "cloud",
         }
     }
@@ -276,6 +291,8 @@ impl AnyProvider {
                 tracing::warn!("generation overrides not supported for Candle provider");
                 Self::Candle(p)
             }
+            #[cfg(feature = "gonka")]
+            Self::Gonka(p) => Self::Gonka(p.with_generation_overrides(overrides)),
             Self::Router(_) | Self::Triage(_) => {
                 tracing::warn!("generation overrides not supported for this provider variant");
                 self
@@ -329,6 +346,10 @@ impl AnyProvider {
             Self::Ollama(_) => {}
             #[cfg(feature = "candle")]
             Self::Candle(_) => {}
+            #[cfg(feature = "gonka")]
+            Self::Gonka(p) => {
+                p.set_status_tx(tx);
+            }
             #[cfg(any(test, feature = "testing"))]
             Self::Mock(_) => {}
         }
@@ -782,6 +803,53 @@ mod tests {
             "embed".into(),
         ));
         assert!(provider.supports_vision());
+    }
+
+    #[cfg(feature = "gonka")]
+    fn make_gonka() -> AnyProvider {
+        use crate::gonka::endpoints::{EndpointPool, GonkaEndpoint};
+        use crate::gonka::{GonkaProvider, RequestSigner};
+        use std::sync::Arc;
+        let signer = Arc::new(
+            RequestSigner::from_hex(
+                "0000000000000000000000000000000000000000000000000000000000000001",
+                "gonka",
+            )
+            .unwrap(),
+        );
+        let pool = Arc::new(
+            EndpointPool::new(vec![GonkaEndpoint {
+                base_url: "https://node1.example.com".into(),
+                address: "gonka1w508d6qejxtdg4y5r3zarvary0c5xw7k2gsyg6".into(),
+            }])
+            .unwrap(),
+        );
+        AnyProvider::Gonka(GonkaProvider::new(
+            signer,
+            pool,
+            "gpt-4o",
+            4096,
+            None,
+            std::time::Duration::from_secs(30),
+        ))
+    }
+
+    #[cfg(feature = "gonka")]
+    #[test]
+    fn any_gonka_name() {
+        assert_eq!(make_gonka().name(), "gonka");
+    }
+
+    #[cfg(feature = "gonka")]
+    #[test]
+    fn any_gonka_supports_streaming() {
+        assert!(make_gonka().supports_streaming());
+    }
+
+    #[cfg(feature = "gonka")]
+    #[test]
+    fn any_gonka_provider_kind_str() {
+        assert_eq!(make_gonka().provider_kind_str(), "cloud");
     }
 
     #[test]

--- a/crates/zeph-llm/src/gonka/provider.rs
+++ b/crates/zeph-llm/src/gonka/provider.rs
@@ -16,7 +16,7 @@ use crate::error::LlmError;
 use crate::gonka::endpoints::{EndpointPool, now_ns};
 use crate::gonka::signer::RequestSigner;
 use crate::openai::OpenAiProvider;
-use crate::provider::{ChatResponse, ChatStream, LlmProvider, Message, ToolDefinition};
+use crate::provider::{ChatResponse, ChatStream, LlmProvider, Message, StatusTx, ToolDefinition};
 use crate::sse::openai_sse_to_stream;
 use crate::usage::UsageTracker;
 
@@ -100,6 +100,8 @@ pub struct GonkaProvider {
     /// Embedding model name, separate from the chat model stored in `inner`.
     embedding_model: Option<String>,
     usage: UsageTracker,
+    /// Optional TUI status sender; when set, key lifecycle events are forwarded.
+    pub(crate) status_tx: Option<StatusTx>,
 }
 
 impl std::fmt::Debug for GonkaProvider {
@@ -109,6 +111,21 @@ impl std::fmt::Debug for GonkaProvider {
             .field("embedding_model", &self.embedding_model)
             .field("timeout", &self.timeout)
             .finish_non_exhaustive()
+    }
+}
+
+impl Clone for GonkaProvider {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            signer: Arc::clone(&self.signer),
+            pool: Arc::clone(&self.pool),
+            client: self.client.clone(),
+            timeout: self.timeout,
+            embedding_model: self.embedding_model.clone(),
+            usage: UsageTracker::default(),
+            status_tx: self.status_tx.clone(),
+        }
     }
 }
 
@@ -177,7 +194,13 @@ impl GonkaProvider {
             timeout,
             embedding_model,
             usage: UsageTracker::default(),
+            status_tx: None,
         }
+    }
+
+    /// Set the TUI status sender; when set, key lifecycle events are forwarded to the TUI.
+    pub fn set_status_tx(&mut self, tx: StatusTx) {
+        self.status_tx = Some(tx);
     }
 
     /// Sign `body_bytes` and send a POST to `{endpoint}{path}`, retrying across pool nodes.
@@ -200,6 +223,9 @@ impl GonkaProvider {
             let url = format!("{}{path}", endpoint.base_url);
 
             tracing::debug!(endpoint = %endpoint.base_url, "gonka POST {url}");
+            if let Some(ref tx) = self.status_tx {
+                let _ = tx.send(format!("Gonka: signing request to {}", endpoint.base_url));
+            }
 
             // Fresh timestamp on every attempt — non-replayable signatures.
             let timestamp_ns = u128::from(now_ns());
@@ -250,6 +276,18 @@ impl GonkaProvider {
         }
 
         Err(last_err.unwrap_or(LlmError::Unavailable))
+    }
+
+    /// Return a clone of this provider with generation parameter overrides applied.
+    ///
+    /// Delegates to the inner [`OpenAiProvider`] which carries the generation parameters.
+    #[must_use]
+    pub fn with_generation_overrides(
+        mut self,
+        overrides: crate::provider::GenerationOverrides,
+    ) -> Self {
+        self.inner = self.inner.with_generation_overrides(overrides);
+        self
     }
 
     fn store_usage(&self, usage: &OpenAiUsage) {

--- a/crates/zeph-llm/src/gonka/tests.rs
+++ b/crates/zeph-llm/src/gonka/tests.rs
@@ -508,3 +508,34 @@ async fn gonka_tools_chat_typed_returns_struct() {
     assert_eq!(result.name, "London");
     assert_eq!(result.population, 9_000_000);
 }
+
+#[test]
+fn gonka_provider_clone_independence() {
+    let provider = make_provider("https://node1.gonka.ai");
+    let cloned = provider.clone();
+    // Both clones must have the same model identifier (shared via Arc<RequestSigner>).
+    assert_eq!(provider.model_identifier(), cloned.model_identifier());
+    assert!(provider.supports_streaming());
+    assert!(cloned.supports_streaming());
+    assert!(provider.supports_embeddings());
+    assert!(cloned.supports_embeddings());
+    // Usage trackers are independent after clone.
+    assert_eq!(provider.last_usage(), None);
+    assert_eq!(cloned.last_usage(), None);
+}
+
+#[test]
+fn gonka_provider_with_generation_overrides_returns_self() {
+    use crate::provider::GenerationOverrides;
+    let provider = make_provider("https://node1.gonka.ai");
+    let overrides = GenerationOverrides {
+        temperature: Some(0.5),
+        top_p: None,
+        top_k: None,
+        frequency_penalty: None,
+        presence_penalty: None,
+    };
+    let patched = provider.with_generation_overrides(overrides);
+    assert_eq!(patched.model_identifier(), "gpt-4o");
+    assert!(patched.supports_streaming());
+}

--- a/src/init/llm.rs
+++ b/src/init/llm.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use dialoguer::{Confirm, Input, Password, Select};
-use zeph_config::{GeminiThinkingLevel, ThinkingConfig, ThinkingEffort};
+use zeph_config::{GeminiThinkingLevel, GonkaNode, ThinkingConfig, ThinkingEffort};
 use zeph_core::config::ProviderKind;
+use zeroize::Zeroizing;
 
 use super::WizardState;
 
@@ -49,6 +50,7 @@ pub(super) fn step_llm_provider(state: &mut WizardState, use_age: bool) -> anyho
         "Gemini (API)",
         "Compatible (custom)",
         "Gonka (decentralized \u{2014} via GonkaGate)",
+        "Gonka (native \u{2014} requires GNK staking)",
     ];
     let selection = Select::new()
         .with_prompt("Select LLM provider")
@@ -210,7 +212,203 @@ pub(super) fn step_llm_provider(state: &mut WizardState, use_age: bool) -> anyho
                 state.api_key = Some(raw);
             }
         }
+        6 => {
+            step_gonka_native(state, use_age)?;
+        }
         _ => unreachable!(),
     }
     Ok(())
+}
+
+fn step_gonka_native(state: &mut WizardState, use_age: bool) -> anyhow::Result<()> {
+    if !use_age {
+        anyhow::bail!(
+            "Gonka native provider requires the age vault backend for secure key storage.\n\
+             Please re-run the wizard and select the age vault backend first."
+        );
+    }
+
+    state.provider = Some(ProviderKind::Gonka);
+
+    let hex_key = pick_hex_key()?;
+
+    // Validate hex length.
+    if hex_key.len() != 64 || !hex_key.chars().all(|c| c.is_ascii_hexdigit()) {
+        anyhow::bail!("Private key must be exactly 64 lowercase hex characters");
+    }
+
+    // Derive address to show the user.
+    #[cfg(feature = "gonka")]
+    let derived_address = {
+        use zeph_llm::gonka::RequestSigner;
+        let signer = RequestSigner::from_hex(&hex_key, "gonka")
+            .map_err(|e| anyhow::anyhow!("invalid private key: {e}"))?;
+        signer.address().to_owned()
+    };
+    #[cfg(not(feature = "gonka"))]
+    let derived_address = String::from("<gonka feature not compiled in>");
+
+    println!("\n  Derived address: {derived_address}");
+
+    let nodes = configure_gonka_nodes()?;
+
+    state.model = Some(
+        Input::new()
+            .with_prompt("Model name")
+            .default("gpt-4o".into())
+            .interact_text()?,
+    );
+
+    state.gonka_private_key = Some(hex_key);
+    state.gonka_address = Some(derived_address);
+    state.gonka_nodes = nodes;
+
+    Ok(())
+}
+
+fn pick_hex_key() -> anyhow::Result<Zeroizing<String>> {
+    let inferenced_available = std::process::Command::new("which")
+        .arg("inferenced")
+        .output()
+        .is_ok_and(|o| o.status.success());
+
+    if !inferenced_available {
+        println!(
+            "\n  inferenced CLI not found. Download from:\n  \
+             https://github.com/gonka-ai/gonka/releases\n"
+        );
+        println!("Alternatively, you can paste a raw hex private key (64 hex characters).");
+    }
+
+    if inferenced_available {
+        let key_names = get_inferenced_keys()?;
+        let key_name = if key_names.is_empty() {
+            let name: String = Input::new()
+                .with_prompt("New key name")
+                .default("zeph".into())
+                .interact_text()?;
+            create_inferenced_key(&name)?;
+            name
+        } else {
+            let create_new = Confirm::new()
+                .with_prompt("Create a new key?")
+                .default(false)
+                .interact()?;
+            if create_new {
+                let name: String = Input::new()
+                    .with_prompt("New key name")
+                    .default("zeph".into())
+                    .interact_text()?;
+                create_inferenced_key(&name)?;
+                name
+            } else {
+                let items: Vec<&str> = key_names.iter().map(String::as_str).collect();
+                let idx = Select::new()
+                    .with_prompt("Select existing key")
+                    .items(&items)
+                    .default(0)
+                    .interact()?;
+                key_names[idx].clone()
+            }
+        };
+        export_inferenced_key_hex(&key_name).map(Zeroizing::new)
+    } else {
+        let raw = Password::new()
+            .with_prompt("Private key hex (64 hex chars, input hidden)")
+            .interact()?;
+        Ok(Zeroizing::new(raw.trim().to_owned()))
+    }
+}
+
+fn configure_gonka_nodes() -> anyhow::Result<Vec<GonkaNode>> {
+    println!("\nConfigure Gonka nodes (press Enter to use default seed nodes):");
+    let default_seeds = vec![
+        (
+            "https://node1.gonka.ai".to_owned(),
+            "gonka1node1placeholder000000000000000000000000".to_owned(),
+        ),
+        (
+            "https://node2.gonka.ai".to_owned(),
+            "gonka1node2placeholder000000000000000000000000".to_owned(),
+        ),
+        (
+            "https://node3.gonka.ai".to_owned(),
+            "gonka1node3placeholder000000000000000000000000".to_owned(),
+        ),
+    ];
+    let use_defaults = Confirm::new()
+        .with_prompt("Use default seed nodes?")
+        .default(true)
+        .interact()?;
+
+    if use_defaults {
+        return Ok(default_seeds
+            .into_iter()
+            .map(|(url, address)| GonkaNode {
+                url,
+                address,
+                name: None,
+            })
+            .collect());
+    }
+
+    let mut nodes = Vec::new();
+    loop {
+        let url: String = Input::new()
+            .with_prompt("Node URL (leave empty to finish)")
+            .allow_empty(true)
+            .interact_text()?;
+        if url.is_empty() {
+            break;
+        }
+        let address: String = Input::new()
+            .with_prompt("Node on-chain address (bech32)")
+            .interact_text()?;
+        nodes.push(GonkaNode {
+            url,
+            address,
+            name: None,
+        });
+    }
+    if nodes.is_empty() {
+        anyhow::bail!("At least one Gonka node is required");
+    }
+    Ok(nodes)
+}
+
+fn get_inferenced_keys() -> anyhow::Result<Vec<String>> {
+    let output = std::process::Command::new("inferenced")
+        .args(["keys", "list"])
+        .output()?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let names: Vec<String> = stdout
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| l.trim().to_owned())
+        .collect();
+    Ok(names)
+}
+
+fn create_inferenced_key(name: &str) -> anyhow::Result<()> {
+    let status = std::process::Command::new("inferenced")
+        .args(["keys", "add", name])
+        .status()?;
+    if !status.success() {
+        anyhow::bail!("inferenced keys add failed");
+    }
+    Ok(())
+}
+
+fn export_inferenced_key_hex(name: &str) -> anyhow::Result<String> {
+    let output = std::process::Command::new("inferenced")
+        .args(["keys", "export", name, "--unarmored-hex", "--unsafe"])
+        .output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("inferenced keys export failed: {stderr}");
+    }
+    let hex = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .to_lowercase();
+    Ok(hex)
 }

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -1705,7 +1705,6 @@ fn print_next_steps(state: &WizardState, path: &std::path::Path) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use insta;
 
     fn single_provider_state() -> WizardState {
         WizardState {

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -12,6 +12,7 @@ use zeph_core::config::{
     TriggerPolicy, VaultConfig,
 };
 use zeph_subagent::def::{MemoryScope, PermissionMode};
+use zeroize::Zeroizing;
 
 pub(super) mod agents;
 pub(super) mod llm;
@@ -237,6 +238,10 @@ pub(crate) struct WizardState {
     // Trajectory risk sentinel (spec 050)
     pub(crate) trajectory_critical_at: f32,
     pub(crate) trajectory_auto_recover: u32,
+    // Gonka native provider (#3613)
+    pub(crate) gonka_private_key: Option<Zeroizing<String>>,
+    pub(crate) gonka_address: Option<String>,
+    pub(crate) gonka_nodes: Vec<zeph_config::GonkaNode>,
 }
 
 impl Default for WizardState {
@@ -404,6 +409,9 @@ impl Default for WizardState {
             prometheus_enabled: false,
             trajectory_critical_at: 10.0,
             trajectory_auto_recover: 16,
+            gonka_private_key: None,
+            gonka_address: None,
+            gonka_nodes: Vec::new(),
         }
     }
 }
@@ -626,6 +634,7 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
             enable_extended_context: state.enable_extended_context,
             thinking_level: state.gemini_thinking_level,
             vision_model: state.vision_model.clone().filter(|s| !s.is_empty()),
+            gonka_nodes: state.gonka_nodes.clone(),
             ..ProviderEntry::default()
         }]
     };
@@ -1626,6 +1635,12 @@ fn print_secrets_instructions(state: &WizardState) {
         use_age,
     );
 
+    // Gonka native provider: private key and address are stored in vault (never in config file).
+    if state.provider == Some(ProviderKind::Gonka) && state.gonka_private_key.is_some() {
+        secrets.push("ZEPH_GONKA_PRIVATE_KEY".into());
+        secrets.push("ZEPH_GONKA_ADDRESS".into());
+    }
+
     let include_telegram = use_age && matches!(state.channel, ChannelChoice::Telegram)
         || state.telegram_token.is_some();
     if include_telegram {
@@ -1690,6 +1705,7 @@ fn print_next_steps(state: &WizardState, path: &std::path::Path) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use insta;
 
     fn single_provider_state() -> WizardState {
         WizardState {
@@ -2478,5 +2494,44 @@ mod tests {
             false,
         );
         assert_eq!(secrets, vec!["ZEPH_COMPATIBLE_GONKAGATE_API_KEY"]);
+    }
+
+    #[test]
+    fn build_config_gonka_provider_snapshot() {
+        let state = WizardState {
+            provider: Some(ProviderKind::Gonka),
+            model: Some("gpt-4o".into()),
+            embedding_model: Some("text-embedding-3-small".into()),
+            vault_backend: "age".into(),
+            gonka_nodes: vec![
+                zeph_config::GonkaNode {
+                    url: "https://node1.gonka.ai".into(),
+                    address: "gonka1node1placeholder000000000000000000000000".into(),
+                    name: None,
+                },
+                zeph_config::GonkaNode {
+                    url: "https://node2.gonka.ai".into(),
+                    address: "gonka1node2placeholder000000000000000000000000".into(),
+                    name: Some("backup".into()),
+                },
+            ],
+            ..WizardState::default()
+        };
+        let config = build_config(&state);
+        let providers = &config.llm.providers;
+        assert_eq!(providers.len(), 1);
+        let p = &providers[0];
+        assert_eq!(p.provider_type, ProviderKind::Gonka);
+        assert_eq!(p.model.as_deref(), Some("gpt-4o"));
+        assert_eq!(p.gonka_nodes.len(), 2);
+        assert_eq!(p.gonka_nodes[0].url, "https://node1.gonka.ai");
+        assert_eq!(
+            p.gonka_nodes[0].address,
+            "gonka1node1placeholder000000000000000000000000"
+        );
+        assert_eq!(p.gonka_nodes[1].name.as_deref(), Some("backup"));
+        // Snapshot the serialized TOML shape for regression detection.
+        let toml_str = toml::to_string_pretty(p).expect("serialize provider entry");
+        insta::assert_snapshot!("gonka_provider_entry_toml", toml_str);
     }
 }

--- a/src/init/snapshots/zeph__init__tests__gonka_provider_entry_toml.snap
+++ b/src/init/snapshots/zeph__init__tests__gonka_provider_entry_toml.snap
@@ -1,0 +1,20 @@
+---
+source: src/init/mod.rs
+expression: toml_str
+---
+type = "gonka"
+model = "gpt-4o"
+embedding_model = "text-embedding-3-small"
+embed = false
+default = false
+server_compaction = false
+enable_extended_context = false
+
+[[gonka_nodes]]
+url = "https://node1.gonka.ai"
+address = "gonka1node1placeholder000000000000000000000000"
+
+[[gonka_nodes]]
+url = "https://node2.gonka.ai"
+address = "gonka1node2placeholder000000000000000000000000"
+name = "backup"

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2532,6 +2532,16 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             .collect(),
         llm_request_timeout_secs: config.timeouts.llm_request_timeout_secs,
         embedding_model: config.llm.embedding_model.clone(),
+        gonka_private_key: config
+            .secrets
+            .gonka_private_key
+            .as_ref()
+            .map(|s| zeroize::Zeroizing::new(s.expose().to_owned())),
+        gonka_address: config
+            .secrets
+            .gonka_address
+            .as_ref()
+            .map(|s| s.expose().to_owned()),
     };
     let agent = agent
         .with_extended_context(extended_context)


### PR DESCRIPTION
## Summary

- Wire `GonkaProvider` end-to-end: `AnyProvider::Gonka` variant, `build_gonka_provider` factory, native wizard branch, config migration step, and integration docs
- Add mandatory `address: String` field to `GonkaNode` config struct (required for ECDSA signature target)
- All private key material wrapped in `Zeroizing<String>` across factory, wizard state, and provider snapshot
- `GonkaProvider` gains `status_tx` support — TUI status indicators now work during native Gonka inference
- Integration guide at `book/src/guides/gonka.md` covering both GonkaGate and native paths

## Changes

| Area | File(s) |
|------|---------|
| `AnyProvider::Gonka` variant + tests | `crates/zeph-llm/src/any.rs` |
| `GonkaProvider` Clone, `status_tx`, overrides | `crates/zeph-llm/src/gonka/provider.rs` |
| `build_gonka_provider` factory (Zeroizing, tracing span) | `crates/zeph-core/src/provider_factory.rs` |
| `GonkaNode.address` field | `crates/zeph-config/src/providers.rs` |
| Native wizard branch | `src/init/llm.rs`, `src/init/mod.rs` |
| Config migration step 45 | `crates/zeph-config/src/migrate/` |
| Provider snapshot Gonka secrets | `crates/zeph-core/src/agent/state/mod.rs` |
| Integration guide | `book/src/guides/gonka.md`, `book/src/SUMMARY.md` |
| Insta snapshot | `src/init/snapshots/zeph__init__tests__gonka_provider_entry_toml.snap` |

## Test plan

- [ ] `cargo +nightly fmt --check` — PASS
- [ ] `cargo clippy --workspace --features full -- -D warnings` — PASS
- [ ] `cargo nextest run --workspace --features full --lib --bins` — 9284/9284 PASS
- [ ] `cargo insta test --workspace --features full --check --lib --bins` — no new snapshots
- [ ] Live testnet round-trip blocked pending `ZEPH_GONKA_PRIVATE_KEY` in age vault + GNK staking — tracked in CI playbook `.local/testing/playbooks/gonka-native.md`

Closes #3613
Closes #3603