### PR TITLE
fix(core): import build_provider_from_entry in mod tests so gonka_tests can resolve it

### DIFF
--- a/crates/zeph-core/src/provider_factory.rs
+++ b/crates/zeph-core/src/provider_factory.rs
@@ -594,7 +594,9 @@ mod tests {
         ));
     }
 
-    use super::{effective_embedding_model, stable_skill_embedding_model};
+    use super::{
+        build_provider_from_entry, effective_embedding_model, stable_skill_embedding_model,
+    };
     use crate::config::{Config, ProviderKind};
     use zeph_config::providers::ProviderEntry;
 

--- a/crates/zeph-core/src/provider_factory.rs
+++ b/crates/zeph-core/src/provider_factory.rs
@@ -594,9 +594,9 @@ mod tests {
         ));
     }
 
-    use super::{
-        build_provider_from_entry, effective_embedding_model, stable_skill_embedding_model,
-    };
+    #[cfg(feature = "gonka")]
+    use super::build_provider_from_entry;
+    use super::{effective_embedding_model, stable_skill_embedding_model};
     use crate::config::{Config, ProviderKind};
     use zeph_config::providers::ProviderEntry;
 


### PR DESCRIPTION
## Summary

- Adds `build_provider_from_entry` to the `use super::` import in `mod tests` in `provider_factory.rs`
- `mod gonka_tests` uses `use super::*`, which resolves to `mod tests`; since `build_provider_from_entry` was not imported there, all 4 gonka tests failed to compile under `--features gonka`

## Test plan

- [ ] `cargo nextest run --workspace --features gonka --lib -p zeph-core` — all 4 `gonka_tests::*` tests pass
- [ ] `cargo +nightly fmt --check` — no diff
- [ ] `cargo clippy --workspace --features gonka -- -D warnings` — zero errors

Closes #3633