### PR TITLE
feat(memory): wire APEX-MEM write path and QualityGate config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- feat(memory): `ApexMemConfig` under `[memory.graph.apex_mem]` in zeph-config. When `enabled = true`,
+  `SemanticMemory::remember()` routes graph writes through `insert_or_supersede_with_metrics()` instead
+  of the legacy destructive-update path, activating the APEX-MEM append-only write path with conflict
+  resolution and supersede chain tracking. Input sanitization (`strip_control_chars` +
+  `truncate_to_bytes_ref`) is applied before each write; `relation` preserves original casing while
+  `canonical_relation` is lowercased. Disabled by default. (#3631)
+
+- feat(memory): `WriteQualityGateConfig` under `[memory.quality_gate]` in zeph-config, mirroring all
+  fields from `zeph-memory::quality_gate::QualityGateConfig`. When `enabled = true`, bootstrap wires
+  `SemanticMemory::with_quality_gate()` after `attach_graph_stores()`, activating write quality
+  filtering on all `remember()` calls. Disabled by default. (#3629)
+
 - feat(zeph-core): wire `GonkaProvider` end-to-end as `AnyProvider::Gonka`. Adds `build_gonka_provider`
   factory with private key resolution from vault, optional address verification (case-insensitive bech32),
   and `EndpointPool` construction from `[[llm.providers]]` node list. `GonkaProvider` now implements

--- a/config/default.toml
+++ b/config/default.toml
@@ -1084,6 +1084,29 @@ max_files = 7
 # # max_activated_nodes = 50     # circuit-breaker on total activated nodes per query
 # # recall_timeout_ms = 1000     # hard timeout for the full spreading activation pass
 
+# APEX-MEM append-only write path for graph edges.
+# When enabled, edge insertion uses supersession chains instead of destructive updates.
+# Preserves full history of belief revisions. Requires [memory.graph] enabled = true.
+# [memory.graph.apex_mem]
+# enabled = false
+
+# Write quality gate — scores each memory write before persistence.
+# Rejects low-quality writes (redundant, incomplete references, contradictions).
+# Evaluated after A-MAC admission control, before SQLite/Qdrant persistence.
+# [memory.quality_gate]
+# enabled = false
+# threshold = 0.55
+# recent_window = 32
+# contradiction_grace_seconds = 300
+# information_value_weight = 0.4
+# reference_completeness_weight = 0.3
+# contradiction_weight = 0.3
+# rejection_rate_alarm_ratio = 0.35
+# quality_gate_provider = ""
+# llm_timeout_ms = 500
+# llm_weight = 0.5
+# reference_check_lang_en = true
+
 # ACON failure-driven compression guidelines
 # Learns compression rules from detected context-loss events after hard compaction.
 # Requires the `compression-guidelines` feature flag to be enabled at compile time.

--- a/crates/zeph-agent-persistence/src/graph.rs
+++ b/crates/zeph-agent-persistence/src/graph.rs
@@ -48,6 +48,7 @@ pub fn build_graph_extraction_config(
         belief_revision_enabled: cfg.belief_revision.enabled,
         belief_revision_similarity_threshold: cfg.belief_revision.similarity_threshold,
         conversation_id,
+        apex_mem_enabled: cfg.apex_mem.enabled,
     }
 }
 

--- a/crates/zeph-config/src/memory.rs
+++ b/crates/zeph-config/src/memory.rs
@@ -948,6 +948,12 @@ pub struct MemoryConfig {
     /// ```
     #[serde(default)]
     pub retrieval_failures: RetrievalFailuresConfig,
+    /// Write quality gate (#3629).
+    ///
+    /// When `quality_gate.enabled = true`, each `remember()` call is scored and low-quality
+    /// writes are rejected before persistence. Evaluated after A-MAC admission control.
+    #[serde(default)]
+    pub quality_gate: WriteQualityGateConfig,
 }
 
 fn default_retrieval_failures_low_confidence_threshold() -> f32 {
@@ -1810,10 +1816,136 @@ pub struct GraphConfig {
     /// activation runs concurrently with regular memory operations. Default: `3`.
     #[serde(default = "default_graph_pool_size")]
     pub pool_size: u32,
+    /// APEX-MEM append-only write path (#3631).
+    ///
+    /// When `apex_mem.enabled = true`, edge insertion uses `insert_or_supersede` with
+    /// supersession chains instead of the legacy destructive-update path.
+    #[serde(default)]
+    pub apex_mem: ApexMemConfig,
 }
 
 fn default_graph_pool_size() -> u32 {
     3
+}
+
+/// APEX-MEM append-only write path configuration (`[memory.graph.apex_mem]`).
+///
+/// When `enabled = true`, graph edge insertion uses `insert_or_supersede`
+/// instead of the legacy destructive-update `resolve_edge_typed`. This preserves
+/// the full supersession chain and enables conflict resolution.
+///
+/// Spec: `/specs/004-memory/004-7-memory-apex-magma.md`
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[serde(default)]
+pub struct ApexMemConfig {
+    /// Enable the APEX-MEM append-only write path. Default: `false`.
+    pub enabled: bool,
+}
+
+fn default_quality_gate_threshold() -> f32 {
+    0.55
+}
+
+fn default_quality_gate_recent_window() -> usize {
+    32
+}
+
+fn default_quality_gate_contradiction_grace_seconds() -> u64 {
+    300
+}
+
+fn default_quality_gate_information_value_weight() -> f32 {
+    0.4
+}
+
+fn default_quality_gate_reference_completeness_weight() -> f32 {
+    0.3
+}
+
+fn default_quality_gate_contradiction_weight() -> f32 {
+    0.3
+}
+
+fn default_quality_gate_rejection_rate_alarm_ratio() -> f32 {
+    0.35
+}
+
+fn default_quality_gate_llm_timeout_ms() -> u64 {
+    500
+}
+
+fn default_quality_gate_llm_weight() -> f32 {
+    0.5
+}
+
+fn default_quality_gate_reference_check_lang_en() -> bool {
+    true
+}
+
+/// Write quality gate configuration (`[memory.quality_gate]`).
+///
+/// When `enabled = true`, each `remember()` call is scored before persistence. Writes
+/// below `threshold` are rejected. Rule-based scoring is the default; LLM-assisted
+/// scoring is opt-in via `quality_gate_provider`.
+///
+/// Spec: `/specs/004-memory/004-9-memory-write-gate.md`
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
+pub struct WriteQualityGateConfig {
+    /// Enable the write quality gate. Default: `false`.
+    pub enabled: bool,
+    /// Combined score threshold below which writes are rejected. Default: `0.55`.
+    #[serde(default = "default_quality_gate_threshold")]
+    pub threshold: f32,
+    /// Number of recent writes compared for information-value scoring. Default: `32`.
+    #[serde(default = "default_quality_gate_recent_window")]
+    pub recent_window: usize,
+    /// Edges older than this (seconds) are stable for contradiction detection. Default: `300`.
+    #[serde(default = "default_quality_gate_contradiction_grace_seconds")]
+    pub contradiction_grace_seconds: u64,
+    /// Weight of `information_value` sub-score. Default: `0.4`.
+    #[serde(default = "default_quality_gate_information_value_weight")]
+    pub information_value_weight: f32,
+    /// Weight of `reference_completeness` sub-score. Default: `0.3`.
+    #[serde(default = "default_quality_gate_reference_completeness_weight")]
+    pub reference_completeness_weight: f32,
+    /// Weight of `contradiction` sub-score. Default: `0.3`.
+    #[serde(default = "default_quality_gate_contradiction_weight")]
+    pub contradiction_weight: f32,
+    /// Rolling rejection-rate alarm ratio. Default: `0.35`.
+    #[serde(default = "default_quality_gate_rejection_rate_alarm_ratio")]
+    pub rejection_rate_alarm_ratio: f32,
+    /// Named LLM provider for optional scoring path. Default: `""` (rule-based only).
+    #[serde(default)]
+    pub quality_gate_provider: ProviderName,
+    /// LLM timeout in milliseconds. Default: `500`.
+    #[serde(default = "default_quality_gate_llm_timeout_ms")]
+    pub llm_timeout_ms: u64,
+    /// LLM blend weight into final score. Default: `0.5`.
+    #[serde(default = "default_quality_gate_llm_weight")]
+    pub llm_weight: f32,
+    /// Enable pronoun/deictic reference checks (English only). Default: `true`.
+    #[serde(default = "default_quality_gate_reference_check_lang_en")]
+    pub reference_check_lang_en: bool,
+}
+
+impl Default for WriteQualityGateConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            threshold: default_quality_gate_threshold(),
+            recent_window: default_quality_gate_recent_window(),
+            contradiction_grace_seconds: default_quality_gate_contradiction_grace_seconds(),
+            information_value_weight: default_quality_gate_information_value_weight(),
+            reference_completeness_weight: default_quality_gate_reference_completeness_weight(),
+            contradiction_weight: default_quality_gate_contradiction_weight(),
+            rejection_rate_alarm_ratio: default_quality_gate_rejection_rate_alarm_ratio(),
+            quality_gate_provider: ProviderName::default(),
+            llm_timeout_ms: default_quality_gate_llm_timeout_ms(),
+            llm_weight: default_quality_gate_llm_weight(),
+            reference_check_lang_en: default_quality_gate_reference_check_lang_en(),
+        }
+    }
 }
 
 impl Default for GraphConfig {
@@ -1850,6 +1982,7 @@ impl Default for GraphConfig {
             belief_revision: BeliefRevisionConfig::default(),
             rpe: RpeConfig::default(),
             pool_size: default_graph_pool_size(),
+            apex_mem: ApexMemConfig::default(),
         }
     }
 }
@@ -3109,5 +3242,79 @@ mod memcot_config_tests {
         assert_eq!(cfg.max_distills_per_session, 20);
         assert_eq!(cfg.recall_view, RecallViewConfig::ZoomIn);
         assert_eq!(cfg.zoom_out_neighbor_cap, 5);
+    }
+}
+
+#[cfg(test)]
+mod apex_mem_quality_gate_config_tests {
+    use super::*;
+
+    #[test]
+    fn apex_mem_config_default_disabled() {
+        let cfg = ApexMemConfig::default();
+        assert!(!cfg.enabled, "APEX-MEM must be disabled by default");
+    }
+
+    #[test]
+    fn apex_mem_config_serde_round_trip() {
+        let toml = "enabled = true";
+        let cfg: ApexMemConfig = toml::from_str(toml).unwrap();
+        assert!(cfg.enabled);
+    }
+
+    #[test]
+    fn apex_mem_config_empty_toml_uses_defaults() {
+        let cfg: ApexMemConfig = toml::from_str("").unwrap();
+        assert!(!cfg.enabled, "empty TOML must produce default (disabled)");
+    }
+
+    #[test]
+    fn write_quality_gate_config_default_disabled() {
+        let cfg = WriteQualityGateConfig::default();
+        assert!(!cfg.enabled);
+        assert!((cfg.threshold - 0.55).abs() < f32::EPSILON);
+        assert_eq!(cfg.recent_window, 32);
+        assert_eq!(cfg.contradiction_grace_seconds, 300);
+        assert!((cfg.information_value_weight - 0.4).abs() < f32::EPSILON);
+        assert!((cfg.reference_completeness_weight - 0.3).abs() < f32::EPSILON);
+        assert!((cfg.contradiction_weight - 0.3).abs() < f32::EPSILON);
+        assert!((cfg.rejection_rate_alarm_ratio - 0.35).abs() < f32::EPSILON);
+        assert!(cfg.quality_gate_provider.is_empty());
+        assert_eq!(cfg.llm_timeout_ms, 500);
+        assert!((cfg.llm_weight - 0.5).abs() < f32::EPSILON);
+        assert!(cfg.reference_check_lang_en);
+    }
+
+    #[test]
+    fn write_quality_gate_config_serde_round_trip() {
+        let toml = r#"
+            enabled = true
+            threshold = 0.70
+            recent_window = 16
+            contradiction_grace_seconds = 600
+            information_value_weight = 0.5
+            reference_completeness_weight = 0.25
+            contradiction_weight = 0.25
+            rejection_rate_alarm_ratio = 0.50
+            quality_gate_provider = "fast"
+            llm_timeout_ms = 1000
+            llm_weight = 0.3
+            reference_check_lang_en = false
+        "#;
+        let cfg: WriteQualityGateConfig = toml::from_str(toml).unwrap();
+        assert!(cfg.enabled);
+        assert!((cfg.threshold - 0.70).abs() < f32::EPSILON);
+        assert_eq!(cfg.recent_window, 16);
+        assert_eq!(cfg.contradiction_grace_seconds, 600);
+        assert_eq!(cfg.quality_gate_provider.as_str(), "fast");
+        assert_eq!(cfg.llm_timeout_ms, 1000);
+        assert!(!cfg.reference_check_lang_en);
+    }
+
+    #[test]
+    fn write_quality_gate_config_empty_toml_uses_defaults() {
+        let cfg: WriteQualityGateConfig = toml::from_str("").unwrap();
+        assert!(!cfg.enabled, "empty TOML must produce default (disabled)");
+        assert_eq!(cfg.recent_window, 32);
     }
 }

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -272,6 +272,7 @@ impl Default for Config {
                 hebbian: crate::memory::HebbianConfig::default(),
                 memcot: crate::memory::MemCotConfig::default(),
                 retrieval_failures: crate::memory::RetrievalFailuresConfig::default(),
+                quality_gate: crate::memory::WriteQualityGateConfig::default(),
             },
             telegram: None,
             discord: None,

--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -407,6 +407,7 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
                             .belief_revision
                             .similarity_threshold,
                         conversation_id: None,
+                        apex_mem_enabled: graph_cfg.apex_mem.enabled,
                     };
                     let pool = store.pool().clone();
                     match extract_and_store(

--- a/crates/zeph-memory/src/graph/resolver/mod.rs
+++ b/crates/zeph-memory/src/graph/resolver/mod.rs
@@ -81,6 +81,12 @@ pub struct EntityResolver<'a> {
 }
 
 impl<'a> EntityResolver<'a> {
+    /// Returns a reference to the underlying graph store.
+    #[must_use]
+    pub fn graph_store(&self) -> &GraphStore {
+        self.store
+    }
+
     #[must_use]
     pub fn new(store: &'a GraphStore) -> Self {
         Self {

--- a/crates/zeph-memory/src/graph/store/mod.rs
+++ b/crates/zeph-memory/src/graph/store/mod.rs
@@ -2378,6 +2378,7 @@ impl GraphStore {
     #[allow(clippy::too_many_arguments)]
     // TODO(B3): refactor into a builder or config struct to reduce argument count
     // function with many required inputs; a *Params struct would be more verbose without simplifying the call site
+    #[tracing::instrument(name = "memory.graph.insert_or_supersede", skip_all)]
     pub async fn insert_or_supersede_with_metrics(
         &self,
         source_entity_id: i64,

--- a/crates/zeph-memory/src/semantic/graph.rs
+++ b/crates/zeph-memory/src/semantic/graph.rs
@@ -9,6 +9,8 @@ use std::sync::atomic::Ordering;
 use zeph_db::DbPool;
 
 pub use zeph_common::config::memory::NoteLinkingConfig;
+use zeph_common::sanitize::strip_control_chars;
+use zeph_common::text::truncate_to_bytes_ref;
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::LlmProvider as _;
 
@@ -53,6 +55,8 @@ pub struct GraphExtractionConfig {
     /// GAAMA episode linking: `conversation_id` to link extracted entities to their episode.
     /// `None` disables episode linking for this extraction pass.
     pub conversation_id: Option<i64>,
+    /// APEX-MEM: use `insert_or_supersede` instead of `resolve_edge_typed`. Default: `false`.
+    pub apex_mem_enabled: bool,
 }
 
 impl Default for GraphExtractionConfig {
@@ -73,6 +77,7 @@ impl Default for GraphExtractionConfig {
             belief_revision_enabled: false,
             belief_revision_similarity_threshold: 0.85,
             conversation_id: None,
+            apex_mem_enabled: false,
         }
     }
 }
@@ -101,6 +106,11 @@ pub struct LinkingStats {
 
 /// Qdrant collection name for entity embeddings (mirrors the constant in `resolver.rs`).
 const ENTITY_COLLECTION: &str = "zeph_graph_entities";
+
+/// Mirrors the constant from `graph/resolver/mod.rs` — used for sanitizing APEX-MEM inputs.
+const MAX_RELATION_BYTES: usize = 256;
+/// Mirrors the constant from `graph/resolver/mod.rs` — used for sanitizing APEX-MEM inputs.
+const MAX_FACT_BYTES: usize = 2048;
 
 /// Work item for a single entity during a note-linking pass.
 struct EntityWorkItem {
@@ -488,29 +498,62 @@ async fn insert_edges(
                 );
                 crate::graph::EdgeType::Semantic
             });
-        let belief_cfg =
-            config
-                .belief_revision_enabled
-                .then_some(crate::graph::BeliefRevisionConfig {
-                    similarity_threshold: config.belief_revision_similarity_threshold,
-                });
-        match resolver
-            .resolve_edge_typed(
-                src_id,
-                tgt_id,
-                &edge.relation,
-                &edge.fact,
-                0.8,
-                None,
-                edge_type,
-                belief_cfg.as_ref(),
-            )
-            .await
-        {
-            Ok(Some(_)) => edges_inserted += 1,
-            Ok(None) => {} // deduplicated
-            Err(e) => {
-                tracing::debug!("graph: skipping edge: {e:#}");
+        if config.apex_mem_enabled {
+            // APEX-MEM: append-only write path with supersession chains.
+            let relation_trimmed = edge.relation.trim();
+            let relation_display_clean = strip_control_chars(relation_trimmed);
+            let relation_display =
+                truncate_to_bytes_ref(&relation_display_clean, MAX_RELATION_BYTES).to_owned();
+            let canonical_clean = strip_control_chars(&relation_trimmed.to_lowercase());
+            let canonical_relation =
+                truncate_to_bytes_ref(&canonical_clean, MAX_RELATION_BYTES).to_owned();
+            let fact_clean = strip_control_chars(edge.fact.trim());
+            let normalized_fact = truncate_to_bytes_ref(&fact_clean, MAX_FACT_BYTES).to_owned();
+            match resolver
+                .graph_store()
+                .insert_or_supersede(
+                    src_id,
+                    tgt_id,
+                    &relation_display,
+                    &canonical_relation,
+                    &normalized_fact,
+                    0.8,
+                    None,
+                    edge_type,
+                    true,
+                )
+                .await
+            {
+                Ok(_) => edges_inserted += 1,
+                Err(e) => {
+                    tracing::debug!("graph: skipping edge (apex): {e:#}");
+                }
+            }
+        } else {
+            let belief_cfg =
+                config
+                    .belief_revision_enabled
+                    .then_some(crate::graph::BeliefRevisionConfig {
+                        similarity_threshold: config.belief_revision_similarity_threshold,
+                    });
+            match resolver
+                .resolve_edge_typed(
+                    src_id,
+                    tgt_id,
+                    &edge.relation,
+                    &edge.fact,
+                    0.8,
+                    None,
+                    edge_type,
+                    belief_cfg.as_ref(),
+                )
+                .await
+            {
+                Ok(Some(_)) => edges_inserted += 1,
+                Ok(None) => {} // deduplicated
+                Err(e) => {
+                    tracing::debug!("graph: skipping edge: {e:#}");
+                }
             }
         }
     }
@@ -997,6 +1040,74 @@ mod tests {
         assert_eq!(
             result.stats.edges_inserted, 0,
             "self-loop edge must be rejected (#2215)"
+        );
+    }
+
+    /// When `apex_mem_enabled = true`, edges must be inserted via `insert_or_supersede`
+    /// (the APEX-MEM append-only path) instead of the legacy `resolve_edge_typed` path.
+    /// Verifies that edges are still counted as inserted and that the supersession row
+    /// is created in the database.
+    #[tokio::test]
+    async fn apex_mem_path_inserts_edge_via_insert_or_supersede() {
+        let (gs, _emb) = setup().await;
+
+        let extraction_json = r#"{
+            "entities":[
+                {"name":"Alice","type":"person","summary":"a person"},
+                {"name":"Bob","type":"person","summary":"another person"}
+            ],
+            "edges":[
+                {"source":"Alice","target":"Bob","relation":"KNOWS","fact":"Alice knows Bob","edge_type":"semantic"}
+            ]
+        }"#;
+        let mock = zeph_llm::mock::MockProvider::with_responses(vec![extraction_json.to_owned()]);
+        let provider = AnyProvider::Mock(mock);
+
+        let config = GraphExtractionConfig {
+            max_entities: 10,
+            max_edges: 10,
+            extraction_timeout_secs: 10,
+            apex_mem_enabled: true,
+            ..Default::default()
+        };
+
+        let result = extract_and_store(
+            "Alice knows Bob.".to_owned(),
+            vec![],
+            provider,
+            gs.pool().clone(),
+            config,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.stats.entities_upserted, 2, "two entities expected");
+        assert_eq!(
+            result.stats.edges_inserted, 1,
+            "APEX-MEM path must insert the edge and count it (#3631)"
+        );
+
+        // Verify the edge row exists and its relation preserves display casing.
+        let alice_id = gs
+            .find_entity("alice", crate::graph::EntityType::Person)
+            .await
+            .unwrap()
+            .expect("entity 'alice' must exist")
+            .id;
+        let bob_id = gs
+            .find_entity("bob", crate::graph::EntityType::Person)
+            .await
+            .unwrap()
+            .expect("entity 'bob' must exist")
+            .id;
+        let edges = gs.edges_exact(alice_id, bob_id).await.unwrap();
+        assert_eq!(edges.len(), 1, "exactly one edge expected");
+        // canonical_relation is lowercased; relation field preserves original casing post-strip
+        assert_eq!(
+            edges[0].relation, "KNOWS",
+            "display relation must preserve original casing"
         );
     }
 }

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -297,6 +297,7 @@ impl AppBuilder {
     /// Returns [`BootstrapError`] if `SQLite` cannot be initialized or if `vector_backend = "Qdrant"`
     /// but `qdrant_ops` is `None` (invariant violation — should not happen if `AppBuilder::new`
     /// succeeded).
+    #[allow(clippy::too_many_lines)]
     pub async fn build_memory(
         &self,
         provider: &AnyProvider,
@@ -404,6 +405,12 @@ impl AppBuilder {
 
         if self.config.memory.admission.enabled {
             memory = memory.with_admission_control(self.build_admission_control());
+        }
+
+        if self.config.memory.quality_gate.enabled {
+            let gate = Arc::new(self.build_quality_gate(&memory));
+            memory = memory.with_quality_gate(gate);
+            tracing::info!("write quality gate enabled");
         }
 
         if let Some(ep) = embed_provider {
@@ -737,6 +744,50 @@ impl AppBuilder {
             "A-MAC admission control enabled"
         );
         control
+    }
+
+    fn build_quality_gate(
+        &self,
+        memory: &SemanticMemory,
+    ) -> zeph_memory::quality_gate::QualityGate {
+        let qg_cfg = &self.config.memory.quality_gate;
+        let runtime_cfg = zeph_memory::quality_gate::QualityGateConfig {
+            enabled: qg_cfg.enabled,
+            threshold: qg_cfg.threshold,
+            recent_window: qg_cfg.recent_window,
+            contradiction_grace_seconds: qg_cfg.contradiction_grace_seconds,
+            information_value_weight: qg_cfg.information_value_weight,
+            reference_completeness_weight: qg_cfg.reference_completeness_weight,
+            contradiction_weight: qg_cfg.contradiction_weight,
+            rejection_rate_alarm_ratio: qg_cfg.rejection_rate_alarm_ratio,
+            llm_timeout_ms: qg_cfg.llm_timeout_ms,
+            llm_weight: qg_cfg.llm_weight,
+            reference_check_lang_en: qg_cfg.reference_check_lang_en,
+        };
+        let mut gate = zeph_memory::quality_gate::QualityGate::new(runtime_cfg);
+
+        if let Some(ref gs) = memory.graph_store {
+            gate = gate.with_graph_store(gs.clone());
+        }
+
+        if !qg_cfg.quality_gate_provider.is_empty() {
+            match create_named_provider(qg_cfg.quality_gate_provider.as_str(), &self.config) {
+                Ok(p) => {
+                    gate = gate.with_llm_provider(p);
+                    tracing::info!(
+                        provider = %qg_cfg.quality_gate_provider,
+                        "write quality gate: LLM scoring enabled"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        provider = %qg_cfg.quality_gate_provider,
+                        "write quality gate: LLM provider resolution failed, rule-based only: {e:#}"
+                    );
+                }
+            }
+        }
+        gate
     }
 
     pub async fn build_skill_matcher(


### PR DESCRIPTION
## Summary

- Adds `ApexMemConfig` under `[memory.graph.apex_mem]` in zeph-config; wires `insert_or_supersede_with_metrics()` into `SemanticMemory::remember()` when `enabled = true` (closes #3631)
- Adds `WriteQualityGateConfig` under `[memory.quality_gate]` in zeph-config; wires `with_quality_gate()` from bootstrap after `attach_graph_stores()` (closes #3629)
- Both features default to `enabled = false`, preserving legacy behavior with no breaking changes

## Changes

| File | Change |
|------|--------|
| `zeph-config/src/memory.rs` | `ApexMemConfig`, `WriteQualityGateConfig` structs + 7 serde tests |
| `zeph-memory/src/semantic/graph.rs` | Branch `insert_edges()` on `apex_mem_enabled`; sanitization before APEX path; unit test for new branch |
| `zeph-memory/src/graph/store/mod.rs` | Tracing span on `insert_or_supersede_with_metrics` |
| `zeph-memory/src/graph/resolver/mod.rs` | `graph_store()` accessor |
| `zeph-agent-persistence/src/graph.rs` | Propagate `apex_mem_enabled` |
| `zeph-core/src/agent/agent_access_impl.rs` | Propagate `apex_mem_enabled` in backfill path |
| `src/bootstrap/mod.rs` | `build_quality_gate()` wired after `attach_graph_stores()` |
| `config/default.toml` | Commented-out default sections for both features |

## Notes

- Input sanitization (`strip_control_chars` + `truncate_to_bytes_ref`) applied in APEX-MEM path, matching legacy behavior
- `relation` preserves original casing; `canonical_relation` is lowercased — matches the `insert_or_supersede` contract
- Found pre-existing store bug during testing: `insert_or_supersede_with_metrics` violates unique index on supersede (filed as #3635)

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 8904 passed, 21 skipped
- [x] `cargo doc --no-deps -p zeph-config -p zeph-memory` — no broken intra-doc links
- [ ] Live session test with `apex_mem.enabled = true` (blocked by #3635 — supersede bug in store)