### PR TITLE
fix(memory): prevent unique index violation in insert_or_supersede

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(memory): `insert_or_supersede_with_metrics` no longer violates `uq_graph_edges_active_head`.
+  SQLite enforces unique indexes at statement level; the prior fix inserted the new row before
+  deactivating the old head. Split `invalidate_prior_head` into `expire_prior_head` (sets
+  `valid_to`/`expired_at` before INSERT) and `set_superseded_by` (back-fills `superseded_by`
+  after INSERT), both within the same transaction. (#3635)
+
 ### Added
 
 - feat(memory): `ApexMemConfig` under `[memory.graph.apex_mem]` in zeph-config. When `enabled = true`,

--- a/crates/zeph-memory/src/graph/store/mod.rs
+++ b/crates/zeph-memory/src/graph/store/mod.rs
@@ -2428,6 +2428,13 @@ impl GraphStore {
             check_supersede_depth_in_tx(&mut tx, head_id).await?;
         }
 
+        // Expire the prior head BEFORE inserting the new row so that the partial unique index
+        // uq_graph_edges_active_head is not violated. SQLite enforces unique indexes at statement
+        // level, not at transaction commit, so the deactivation must precede the INSERT.
+        if let Some(head_id) = prior_head {
+            expire_prior_head(&mut tx, head_id).await?;
+        }
+
         let supersedes_val: Option<i64> = if set_supersedes { prior_head } else { None };
         let new_id = insert_new_edge(
             &mut tx,
@@ -2444,7 +2451,7 @@ impl GraphStore {
         .await?;
 
         if let Some(head_id) = prior_head {
-            invalidate_prior_head(&mut tx, head_id, new_id).await?;
+            set_superseded_by(&mut tx, head_id, new_id).await?;
             if let Some(m) = metrics {
                 m.supersedes_total
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -2832,18 +2839,27 @@ async fn insert_new_edge(
     .await?)
 }
 
-/// Mark the prior head edge as superseded by `new_id`.
-async fn invalidate_prior_head(
-    tx: &mut Tx<'_>,
-    head_id: i64,
-    new_id: i64,
-) -> Result<(), MemoryError> {
+/// Deactivate the prior head by setting `valid_to` and `expired_at`, leaving `superseded_by`
+/// unset. Must be called **before** inserting the new row to avoid violating
+/// `uq_graph_edges_active_head` — the unique index is enforced at statement level, not at commit.
+async fn expire_prior_head(tx: &mut Tx<'_>, head_id: i64) -> Result<(), MemoryError> {
     zeph_db::query(sql!(
         "UPDATE graph_edges
          SET valid_to = CURRENT_TIMESTAMP,
-             expired_at = CURRENT_TIMESTAMP,
-             superseded_by = ?
+             expired_at = CURRENT_TIMESTAMP
          WHERE id = ?"
+    ))
+    .bind(head_id)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+/// Back-fill `superseded_by` on the already-expired prior head after the new row has been
+/// inserted and its ID is known.
+async fn set_superseded_by(tx: &mut Tx<'_>, head_id: i64, new_id: i64) -> Result<(), MemoryError> {
+    zeph_db::query(sql!(
+        "UPDATE graph_edges SET superseded_by = ? WHERE id = ?"
     ))
     .bind(new_id)
     .bind(head_id)

--- a/crates/zeph-memory/src/graph/store/tests.rs
+++ b/crates/zeph-memory/src/graph/store/tests.rs
@@ -3832,6 +3832,101 @@ async fn check_supersede_depth_returns_zero_for_root_edge() {
     assert_eq!(depth, 0, "root edge with no supersedes pointer has depth 0");
 }
 
+/// Regression test for #3635: superseding an edge with the same (src, tgt, `canonical_relation`,
+/// `edge_type`) must not violate `uq_graph_edges_active_head`. Previously `insert_new_edge` ran before
+/// `invalidate_prior_head`, which briefly had two active rows for the same tuple and triggered
+/// `SQLITE_CONSTRAINT_UNIQUE`.
+#[tokio::test]
+async fn insert_or_supersede_same_tuple_no_unique_index_violation() {
+    let gs = setup().await;
+    let src = gs
+        .upsert_entity("Eve", "Eve", EntityType::Person, None)
+        .await
+        .unwrap();
+    let tgt = gs
+        .upsert_entity("SameCo", "SameCo", EntityType::Organization, None)
+        .await
+        .unwrap();
+
+    let first_id = gs
+        .insert_or_supersede(
+            src,
+            tgt,
+            "works_at",
+            "works_at",
+            "Eve works at SameCo v1",
+            0.7,
+            None,
+            EdgeType::Semantic,
+            true,
+        )
+        .await
+        .unwrap();
+
+    // Second insert has same (src, tgt, canonical_relation, edge_type) but different fact —
+    // this is NOT a reassertion and must supersede the prior head without hitting the unique index.
+    let second_id = gs
+        .insert_or_supersede(
+            src,
+            tgt,
+            "works_at",
+            "works_at",
+            "Eve works at SameCo v2",
+            0.9,
+            None,
+            EdgeType::Semantic,
+            true,
+        )
+        .await
+        .unwrap();
+
+    assert_ne!(
+        first_id, second_id,
+        "supersession must create a new edge row"
+    );
+
+    // Prior head must be deactivated.
+    let prior_valid_to: Option<String> =
+        sqlx::query_scalar("SELECT valid_to FROM graph_edges WHERE id = ?")
+            .bind(first_id)
+            .fetch_one(&gs.pool)
+            .await
+            .unwrap();
+    assert!(
+        prior_valid_to.is_some(),
+        "prior head must have valid_to set after supersession"
+    );
+
+    // superseded_by must point to the new edge.
+    let prior_superseded_by: Option<i64> =
+        sqlx::query_scalar("SELECT superseded_by FROM graph_edges WHERE id = ?")
+            .bind(first_id)
+            .fetch_one(&gs.pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        prior_superseded_by,
+        Some(second_id),
+        "prior head must have superseded_by = new edge id"
+    );
+
+    // Exactly one active head must remain.
+    let active_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM graph_edges
+         WHERE source_entity_id = ?
+           AND target_entity_id = ?
+           AND canonical_relation = 'works_at'
+           AND valid_to IS NULL
+           AND expired_at IS NULL",
+    )
+    .bind(src)
+    .bind(tgt)
+    .fetch_one(&gs.pool)
+    .await
+    .unwrap();
+    assert_eq!(active_count, 1, "exactly one active head must remain");
+}
+
 // ── HL-F1: Edge.weight field ──────────────────────────────────────────────────
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- `insert_or_supersede_with_metrics` violated `uq_graph_edges_active_head` (partial unique index on `(source_entity_id, target_entity_id, canonical_relation, edge_type) WHERE valid_to IS NULL AND expired_at IS NULL`) because `insert_new_edge` ran before the prior head was deactivated
- SQLite enforces unique indexes at statement level, not at transaction commit — a DEFERRED transaction does not help
- Fix: split `invalidate_prior_head` into `expire_prior_head` (sets `valid_to`/`expired_at` **before** INSERT) and `set_superseded_by` (back-fills `superseded_by` **after** INSERT), both within the same transaction

## Root cause

```
// Before (buggy):
insert_new_edge(...)          -- unique index violated if old head still active
invalidate_prior_head(...)    -- too late

// After (correct):
expire_prior_head(...)        -- deactivates old head; index now clear
insert_new_edge(...)          -- no conflict
set_superseded_by(...)        -- back-fills superseded_by with new row ID
```

## Test plan

- [ ] `cargo nextest run -p zeph-memory --lib` — 1272 passed, regression test `insert_or_supersede_same_tuple_no_unique_index_violation` covers the exact bug scenario
- [ ] `cargo +nightly fmt --check` — CLEAN
- [ ] `cargo clippy -p zeph-memory --tests -- -D warnings` — CLEAN

Closes #3635