### PR TITLE
feat(core): wire SpeculationEngine into agent loop via SpeculativeConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- feat(core): `SpeculationEngine` is now wired into the agent loop via `SpeculativeConfig`. When
+  `[tools.speculative] mode` is set to `Decoding` or `Pattern`, the engine is instantiated at
+  startup (gated on `!bare` mode), turn-boundary metrics are logged, and the
+  `#![allow(dead_code)]` guard is removed from `crates/zeph-core/src/agent/speculative/`. (#3636)
+
 - feat(memory): `ApexMemConfig` under `[memory.graph.apex_mem]` in zeph-config. When `enabled = true`,
   `SemanticMemory::remember()` routes graph writes through `insert_or_supersede_with_metrics()` instead
   of the legacy destructive-update path, activating the APEX-MEM append-only write path with conflict

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -2190,6 +2190,29 @@ impl<C: Channel> Agent<C> {
         self.services.goal_accounting = accounting;
         self
     }
+
+    /// Wire the [`crate::agent::speculative::SpeculationEngine`] for speculative tool dispatch.
+    ///
+    /// Set to `None` when `[tools.speculative] mode = "off"` or in bare mode.
+    #[must_use]
+    pub fn with_speculation_engine(
+        mut self,
+        engine: Option<std::sync::Arc<crate::agent::speculative::SpeculationEngine>>,
+    ) -> Self {
+        self.services.speculation_engine = engine;
+        self
+    }
+
+    /// Returns a clone of the tool executor [`Arc`] for external wiring (e.g. `SpeculationEngine`).
+    ///
+    /// Always call this **after** all [`Self::add_tool_executor`] invocations to ensure the
+    /// returned Arc includes the fully composed tool chain.
+    #[must_use]
+    pub fn tool_executor_arc(
+        &self,
+    ) -> std::sync::Arc<dyn zeph_tools::executor::ErasedToolExecutor> {
+        std::sync::Arc::clone(&self.tool_executor)
+    }
 }
 
 #[cfg(test)]
@@ -2605,6 +2628,64 @@ mod tests {
                 "cache_enabled must equal semantic_cache_enabled when false"
             );
         }
+    }
+
+    #[test]
+    fn default_speculation_engine_is_none() {
+        let agent = make_agent();
+        assert!(
+            agent.services.speculation_engine.is_none(),
+            "speculation_engine must default to None"
+        );
+    }
+
+    #[test]
+    fn with_speculation_engine_none_keeps_none() {
+        let agent = make_agent().with_speculation_engine(None);
+        assert!(
+            agent.services.speculation_engine.is_none(),
+            "with_speculation_engine(None) must leave field as None"
+        );
+    }
+
+    #[tokio::test]
+    async fn with_speculation_engine_some_wires_engine() {
+        use crate::agent::speculative::{SpeculationEngine, SpeculationMode, SpeculativeConfig};
+
+        let exec = Arc::new(MockToolExecutor::no_tools());
+        let config = SpeculativeConfig {
+            mode: SpeculationMode::Decoding,
+            ..Default::default()
+        };
+        let engine = Arc::new(SpeculationEngine::new(exec, config));
+        let agent = make_agent().with_speculation_engine(Some(Arc::clone(&engine)));
+        assert!(
+            agent.services.speculation_engine.is_some(),
+            "with_speculation_engine(Some(...)) must wire the engine"
+        );
+        assert!(
+            Arc::ptr_eq(agent.services.speculation_engine.as_ref().unwrap(), &engine),
+            "stored Arc must be the same instance"
+        );
+    }
+
+    #[test]
+    fn tool_executor_arc_returns_same_arc() {
+        let executor = MockToolExecutor::no_tools();
+        let agent = Agent::new(
+            mock_provider(vec![]),
+            MockChannel::new(vec![]),
+            create_test_registry(),
+            None,
+            5,
+            executor,
+        );
+        let arc1 = agent.tool_executor_arc();
+        let arc2 = agent.tool_executor_arc();
+        assert!(
+            Arc::ptr_eq(&arc1, &arc2),
+            "tool_executor_arc must return clones of the same inner Arc"
+        );
     }
 
     /// Verify that `with_managed_skills_dir` registers the hub dir so that

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -286,6 +286,7 @@ impl<C: Channel> Agent<C> {
             proactive_explorer: None,
             promotion_engine: None,
             taco_compressor: None,
+            speculation_engine: None,
         };
 
         let runtime = AgentRuntime {
@@ -1430,6 +1431,18 @@ impl<C: Channel> Agent<C> {
         self.flush_turn_timings();
         // Clear per-turn intent (FR-008): must not persist across turns.
         self.services.session.current_turn_intent = None;
+        // Cancel all in-flight speculative handles at turn boundary.
+        if let Some(ref engine) = self.services.speculation_engine {
+            let metrics = engine.end_turn();
+            if metrics.committed > 0 || metrics.cancelled > 0 {
+                tracing::debug!(
+                    committed = metrics.committed,
+                    cancelled = metrics.cancelled,
+                    wasted_ms = metrics.wasted_ms,
+                    "speculation: turn boundary metrics"
+                );
+            }
+        }
     }
 
     #[cfg_attr(

--- a/crates/zeph-core/src/agent/speculative/mod.rs
+++ b/crates/zeph-core/src/agent/speculative/mod.rs
@@ -28,8 +28,6 @@
 //! - Per-handle TTL (default 30 s) is enforced by a background sweeper that shares
 //!   the same cache instance (C2: no separate empty cache in the sweeper).
 
-#![allow(dead_code)]
-
 pub mod cache;
 pub mod partial_json;
 pub mod paste;
@@ -308,9 +306,7 @@ impl SpeculationEngine {
     /// Cancel all in-flight handles at turn boundary and return metrics snapshot.
     pub fn end_turn(&self) -> SpeculativeMetrics {
         self.cache.cancel_all();
-        let m = self.metrics.lock().clone();
-        *self.metrics.lock() = SpeculativeMetrics::default();
-        m
+        std::mem::take(&mut *self.metrics.lock())
     }
 
     /// Snapshot current metrics without resetting.
@@ -429,6 +425,66 @@ mod tests {
         assert!(
             engine.cache.is_empty(),
             "cancel_for must remove handle from cache"
+        );
+    }
+
+    #[tokio::test]
+    async fn end_turn_cancels_handles_and_resets_metrics() {
+        let exec: Arc<dyn ErasedToolExecutor> = Arc::new(AlwaysOkExecutor);
+        let config = SpeculativeConfig {
+            mode: SpeculationMode::Decoding,
+            ..Default::default()
+        };
+        let engine = SpeculationEngine::new(exec, config);
+
+        let pred = Prediction {
+            tool_id: zeph_common::ToolName::new("test"),
+            args: serde_json::Map::new(),
+            confidence: 0.9,
+            source: prediction::PredictionSource::StreamPartial,
+        };
+
+        engine.try_dispatch(&pred, SkillTrustLevel::Trusted);
+        assert!(
+            !engine.cache.is_empty(),
+            "precondition: handle must be in cache before end_turn"
+        );
+
+        let _metrics = engine.end_turn();
+        assert!(
+            engine.cache.is_empty(),
+            "end_turn must cancel all in-flight handles"
+        );
+
+        // After end_turn, metrics are reset to zero.
+        let snapshot = engine.metrics_snapshot();
+        assert_eq!(snapshot.committed, 0, "metrics must reset after end_turn");
+        assert_eq!(snapshot.cancelled, 0, "metrics must reset after end_turn");
+    }
+
+    #[tokio::test]
+    async fn is_active_reflects_mode() {
+        let exec: Arc<dyn ErasedToolExecutor> = Arc::new(AlwaysOkExecutor);
+
+        let engine_off = SpeculationEngine::new(
+            Arc::clone(&exec),
+            SpeculativeConfig {
+                mode: SpeculationMode::Off,
+                ..Default::default()
+            },
+        );
+        assert!(!engine_off.is_active(), "mode=Off means is_active()=false");
+
+        let engine_on = SpeculationEngine::new(
+            exec,
+            SpeculativeConfig {
+                mode: SpeculationMode::Decoding,
+                ..Default::default()
+            },
+        );
+        assert!(
+            engine_on.is_active(),
+            "mode=Decoding means is_active()=true"
         );
     }
 }

--- a/crates/zeph-core/src/agent/state/services.rs
+++ b/crates/zeph-core/src/agent/state/services.rs
@@ -56,4 +56,10 @@ pub(crate) struct Services {
     ///
     /// `Some` when `config.tools.compression.enabled = true` and a DB pool is available.
     pub(crate) taco_compressor: Option<std::sync::Arc<zeph_tools::RuleBasedCompressor>>,
+
+    /// Speculative tool execution engine (#3636).
+    ///
+    /// `Some` when `config.tools.speculative.mode != Off` and not in bare mode.
+    pub(crate) speculation_engine:
+        Option<std::sync::Arc<crate::agent::speculative::SpeculationEngine>>,
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2398,6 +2398,29 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         }
     };
 
+    // Wire SpeculationEngine after all add_tool_executor calls so the captured executor Arc
+    // includes the fully composed tool chain (search + scheduler + any future executors).
+    // Gated on mode != Off and !bare to avoid background sweeper tasks in minimal sessions.
+    let agent = if config.tools.speculative.mode != zeph_config::tools::SpeculationMode::Off
+        && !exec_mode.bare
+    {
+        let spec_executor = agent.tool_executor_arc();
+        let engine = std::sync::Arc::new(
+            zeph_core::agent::speculative::SpeculationEngine::new_with_supervisor(
+                spec_executor,
+                config.tools.speculative.clone(),
+                Some(std::sync::Arc::clone(&supervisor)),
+            ),
+        );
+        tracing::info!(
+            mode = ?config.tools.speculative.mode,
+            "speculation: enabled, SpeculationEngine wired"
+        );
+        agent.with_speculation_engine(Some(engine))
+    } else {
+        agent
+    };
+
     // Wire debug dump: CLI flag takes priority over [debug] config section.
     // --dump-format CLI override takes priority over config.debug.format.
     let effective_format = cli.dump_format.unwrap_or(config.debug.format);


### PR DESCRIPTION
## Summary

- `SpeculationEngine` was fully implemented in `crates/zeph-core/src/agent/speculative/` but never instantiated; `SpeculativeConfig` was read from TOML but silently ignored (#3636)
- Add `speculation_engine: Option<Arc<SpeculationEngine>>` to `Services` (same pattern as `taco_compressor`, `goal_accounting`)
- Add `with_speculation_engine()` builder method and `tool_executor_arc()` getter on `Agent<C>`
- Bootstrap in `src/runner.rs` **after all `add_tool_executor` calls** (critical: ensures the captured executor Arc includes the full tool chain including scheduler); gated on `mode != Off && !exec_mode.bare`
- Call `engine.end_turn()` at every turn boundary using `std::mem::take` (single lock, no TOCTOU)
- Remove `#![allow(dead_code)]` from `crates/zeph-core/src/agent/speculative/mod.rs`
- 6 new unit tests; 8913/8913 tests pass

## Deferred to follow-up PRs

- `try_dispatch` integration (decoding-level streaming hook into SSE `ToolStream` events)
- PASTE pattern dispatch at skill activation
- `ToolStartEvent.speculative: true` for committed handles
- TUI spinner integration

## Follow-up issues to file

- `requires_confirmation_erased` unsafe default (security finding — deferred)
- Sweeper fallback broken abort path (security finding — deferred)

## Test plan

- [x] `cargo +nightly fmt --check` — PASS
- [x] `cargo clippy --all-targets --workspace -- -D warnings` — PASS
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 8913/8913 PASS
- [x] `cargo build --features full` — PASS
- [x] `git diff origin/main --name-only` — only 6 files, all related to #3636

Closes #3636