### PR TITLE
fix(core): replace production unwrap() calls with expect() in zeph-core

### DIFF
--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -971,7 +971,10 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
             self.services.goal_accounting = Some(accounting);
         }
 
-        let accounting = self.services.goal_accounting.clone().unwrap();
+        let accounting =
+            self.services.goal_accounting.clone().expect(
+                "invariant: goal_accounting is always Some at this point (initialized above)",
+            );
         let max_chars = self.runtime.config.goals.max_text_chars;
         let default_budget = self.runtime.config.goals.default_token_budget;
 

--- a/crates/zeph-core/src/agent/context/summarization/scheduling.rs
+++ b/crates/zeph-core/src/agent/context/summarization/scheduling.rs
@@ -159,13 +159,21 @@ struct CollectStatusSink(Arc<Mutex<Vec<String>>>);
 impl CollectStatusSink {
     /// Drain and return all collected status messages.
     fn take(&self) -> Vec<String> {
-        std::mem::take(&mut self.0.lock().unwrap())
+        std::mem::take(
+            &mut self
+                .0
+                .lock()
+                .expect("invariant: CollectStatusSink mutex is not poisoned"),
+        )
     }
 }
 
 impl zeph_agent_context::StatusSink for CollectStatusSink {
     fn send_status(&self, msg: &str) -> impl std::future::Future<Output = ()> + Send + '_ {
-        self.0.lock().unwrap().push(msg.to_owned());
+        self.0
+            .lock()
+            .expect("invariant: CollectStatusSink mutex is not poisoned")
+            .push(msg.to_owned());
         std::future::ready(())
     }
 }

--- a/crates/zeph-core/src/agent/tool_execution/native.rs
+++ b/crates/zeph-core/src/agent/tool_execution/native.rs
@@ -972,7 +972,10 @@ impl<C: Channel> Agent<C> {
                 .chat_with_tools_stream(&self.msg.messages, tool_defs)
                 .await
         {
-            let engine = std::sync::Arc::clone(self.services.speculation_engine.as_ref().unwrap());
+            let engine =
+                std::sync::Arc::clone(self.services.speculation_engine.as_ref().expect(
+                    "invariant: speculation_engine is Some (checked via is_some_and on L961)",
+                ));
             let threshold = engine.confidence_threshold();
             let drainer = crate::agent::speculative::stream_drainer::SpeculativeStreamDrainer::new(
                 stream, engine, threshold,


### PR DESCRIPTION
## Summary

- Eliminates all 4 production `unwrap()` calls in `crates/zeph-core/src/` (constitution Section IV violation)
- Replaces each with `.expect("invariant: ...")` carrying a descriptive message that documents the static guarantee
- No logic changes — pure invariant documentation of guaranteed-Some/Ok values

## Changes

| File | Callsite | Fix |
|------|----------|-----|
| `agent/tool_execution/native.rs` | `speculation_engine.as_ref().unwrap()` | guaranteed `Some` inside `use_speculative_stream` guard |
| `agent/agent_access_impl.rs` | `goal_accounting.clone().unwrap()` | guaranteed `Some` after initialization block |
| `agent/context/summarization/scheduling.rs` | `Mutex::lock().unwrap()` ×2 | no panics in critical section; mutex is not poisoned |

## Notes

The original issue estimated ~203 production `unwrap()` calls. The corrected count is **4** — the inflated estimate included test code (`agent/tests/`, `#[cfg(test)]` modules, etc.).

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy -p zeph-core -- -D warnings` — clean
- [x] `cargo nextest run -p zeph-core --lib --bins` — 1385 tests passed, 0 failed

Closes #3663