### PR TITLE
feat(config): add Cocoon provider config validation, wizard, and migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10422,6 +10422,7 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "toml_edit",
  "tracing",
+ "url",
  "zeph-common",
 ]
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -126,6 +126,16 @@ embedding_model = "qwen3-embedding"
 # model = "Qwen/Qwen3-235B-A22B-Instruct-2507-FP8"
 # max_tokens = 4096
 
+# Cocoon — decentralized AI inference via local TEE sidecar (https://cocoon.tg)
+# Requires the Cocoon client runner at localhost:10000 (--features cocoon).
+# Set access hash in vault: zeph vault set ZEPH_COCOON_ACCESS_HASH <hash>
+# [[llm.providers]]
+# name = "cocoon"
+# type = "cocoon"
+# model = "Qwen/Qwen3-0.6B"
+# cocoon_client_url = "http://localhost:10000"
+# cocoon_access_hash = ""   # empty = resolve from vault
+
 # Candle local inference (feature-gated: --features candle)
 # [[llm.providers]]
 # type = "candle"

--- a/crates/zeph-config/Cargo.toml
+++ b/crates/zeph-config/Cargo.toml
@@ -26,6 +26,7 @@ thiserror.workspace = true
 toml.workspace = true
 toml_edit.workspace = true
 tracing.workspace = true
+url.workspace = true
 zeph-common.workspace = true
 
 [dev-dependencies]

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -3305,20 +3305,20 @@ pub trait Migration: Send + Sync {
 mod steps;
 use steps::{
     MigrateAcpSubagentsConfig, MigrateAgentBudgetHint, MigrateAgentRetryToToolsRetry,
-    MigrateAutodreamConfig, MigrateCompressionPredictorConfig, MigrateDatabaseUrl,
-    MigrateEgressConfig, MigrateFocusAutoConsolidateMinWindow, MigrateForgettingConfig,
-    MigrateGoalsConfig, MigrateGonkagateToGonka, MigrateHooksPermissionDeniedConfig,
-    MigrateHooksTurnComplete, MigrateMagicDocsConfig, MigrateMcpElicitationConfig,
-    MigrateMcpMaxConnectAttempts, MigrateMcpTrustLevels, MigrateMemoryGraph, MigrateMemoryHebbian,
-    MigrateMemoryHebbianConsolidation, MigrateMemoryHebbianSpread, MigrateMemoryPersonaConfig,
-    MigrateMemoryReasoning, MigrateMemoryReasoningJudge, MigrateMemoryRetrieval,
-    MigrateMemoryRetrievalQueryBias, MigrateMicrocompactConfig, MigrateOrchestrationPersistence,
-    MigrateOrchestratorProvider, MigrateOtelFilter, MigratePlannerModelToProvider,
-    MigrateProviderMaxConcurrent, MigrateQdrantApiKey, MigrateQualityConfig, MigrateSandboxConfig,
-    MigrateSandboxEgressFilter, MigrateSchedulerDaemon, MigrateSessionProviderPersistence,
-    MigrateSessionRecapConfig, MigrateShellTransactional, MigrateSttToProvider,
-    MigrateSupervisorConfig, MigrateTelemetryConfig, MigrateToolsCompressionConfig,
-    MigrateVigilConfig,
+    MigrateAutodreamConfig, MigrateCocoonProviderNotice, MigrateCompressionPredictorConfig,
+    MigrateDatabaseUrl, MigrateEgressConfig, MigrateFocusAutoConsolidateMinWindow,
+    MigrateForgettingConfig, MigrateGoalsConfig, MigrateGonkagateToGonka,
+    MigrateHooksPermissionDeniedConfig, MigrateHooksTurnComplete, MigrateMagicDocsConfig,
+    MigrateMcpElicitationConfig, MigrateMcpMaxConnectAttempts, MigrateMcpTrustLevels,
+    MigrateMemoryGraph, MigrateMemoryHebbian, MigrateMemoryHebbianConsolidation,
+    MigrateMemoryHebbianSpread, MigrateMemoryPersonaConfig, MigrateMemoryReasoning,
+    MigrateMemoryReasoningJudge, MigrateMemoryRetrieval, MigrateMemoryRetrievalQueryBias,
+    MigrateMicrocompactConfig, MigrateOrchestrationPersistence, MigrateOrchestratorProvider,
+    MigrateOtelFilter, MigratePlannerModelToProvider, MigrateProviderMaxConcurrent,
+    MigrateQdrantApiKey, MigrateQualityConfig, MigrateSandboxConfig, MigrateSandboxEgressFilter,
+    MigrateSchedulerDaemon, MigrateSessionProviderPersistence, MigrateSessionRecapConfig,
+    MigrateShellTransactional, MigrateSttToProvider, MigrateSupervisorConfig,
+    MigrateTelemetryConfig, MigrateToolsCompressionConfig, MigrateVigilConfig,
 };
 
 /// Step 45: add an advisory comment above `GonkaGate` provider entries pointing users to
@@ -3390,7 +3390,23 @@ pub(crate) fn migrate_gonkagate_to_gonka(toml_src: &str) -> MigrationResult {
     }
 }
 
-/// Ordered registry of all sequential migration steps (steps 1–45).
+/// Advisory-only no-op step for Cocoon provider introduction.
+///
+/// Returns the input unchanged. Exists so the migration registry stays sequential
+/// and `--migrate-config` informs users that Cocoon is now available.
+///
+/// # Errors
+///
+/// This function never returns an error.
+pub fn migrate_cocoon_provider_notice(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    Ok(MigrationResult {
+        output: toml_src.to_owned(),
+        changed_count: 0,
+        sections_changed: vec![],
+    })
+}
+
+/// Ordered registry of all sequential migration steps (steps 1–46).
 ///
 /// Each entry wraps the corresponding free function and is evaluated lazily at first access.
 /// The ordering is chronological; the dispatch loop in `src/commands/migrate.rs` iterates
@@ -3463,6 +3479,8 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             Box::new(MigrateProviderMaxConcurrent),
             // Step 45 — advisory notice for GonkaGate → native Gonka upgrade path (#3613)
             Box::new(MigrateGonkagateToGonka),
+            // Step 46 — advisory notice for Cocoon decentralized inference provider (#3671)
+            Box::new(MigrateCocoonProviderNotice),
         ]
     });
 
@@ -3481,8 +3499,8 @@ mod tests {
     fn migrations_registry_has_all_steps() {
         assert_eq!(
             MIGRATIONS.len(),
-            45,
-            "MIGRATIONS registry must contain all 45 sequential steps"
+            46,
+            "MIGRATIONS registry must contain all 46 sequential steps"
         );
         for m in MIGRATIONS.iter() {
             assert!(
@@ -5068,8 +5086,8 @@ prompt_cache_ttl = "1h"
     // ── Migration registry ────────────────────────────────────────────────────
 
     #[test]
-    fn registry_has_forty_five_entries() {
-        assert_eq!(MIGRATIONS.len(), 45);
+    fn registry_has_forty_six_entries() {
+        assert_eq!(MIGRATIONS.len(), 46);
     }
 
     #[test]
@@ -5155,6 +5173,7 @@ prompt_cache_ttl = "1h"
             "migrate_orchestrator_provider",
             "migrate_provider_max_concurrent",
             "migrate_gonkagate_to_gonka",
+            "migrate_cocoon_provider_notice",
         ];
         let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
         assert_eq!(actual, expected);
@@ -5327,5 +5346,32 @@ prompt_cache_ttl = "1h"
         let second = migrate_gonkagate_to_gonka(&first.output);
         // Second run must not add another comment line.
         assert_eq!(second.changed_count, 0, "idempotent on second run");
+    }
+
+    // ── Step 46 — Cocoon provider notice ──────────────────────────────────────
+
+    #[test]
+    fn migrate_cocoon_noop_empty_config() {
+        let src = "";
+        let result = migrate_cocoon_provider_notice(src).unwrap();
+        assert_eq!(result.changed_count, 0);
+        assert_eq!(result.output, src);
+    }
+
+    #[test]
+    fn migrate_cocoon_noop_existing_config() {
+        let src = "[agent]\nname = \"zeph\"\n\n[[llm.providers]]\ntype = \"ollama\"\n";
+        let result = migrate_cocoon_provider_notice(src).unwrap();
+        assert_eq!(result.changed_count, 0);
+        assert_eq!(result.output, src);
+    }
+
+    #[test]
+    fn migrate_cocoon_idempotent() {
+        let src = "[[llm.providers]]\ntype = \"cocoon\"\nname = \"tee\"\n";
+        let first = migrate_cocoon_provider_notice(src).unwrap();
+        let second = migrate_cocoon_provider_notice(&first.output).unwrap();
+        assert_eq!(second.output, first.output);
+        assert_eq!(second.changed_count, 0);
     }
 }

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -4,7 +4,9 @@
 //! Migration step wrapper structs — one per sequential migration in [`super::MIGRATIONS`].
 //!
 //! Steps 1–35 are pre-existing; steps 36–38 were added for the stable-defaults flip;
-//! step 39 adds optional Qdrant API key; step 40 adds MCP `max_connect_attempts`.
+//! step 39 adds optional Qdrant API key; step 40 adds MCP `max_connect_attempts`;
+//! steps 41–45 add goal lifecycle, TACO compression, orchestrator provider, per-provider
+//! admission control, and `GonkaGate` advisory notice; step 46 is an advisory notice for Cocoon.
 //!
 //! Each struct is a zero-size type that delegates to the corresponding free function in
 //! `super`. They exist solely to satisfy the object-safe [`super::Migration`] trait so the
@@ -13,19 +15,19 @@
 use super::{
     MigrateError, Migration, MigrationResult, migrate_acp_subagents_config,
     migrate_agent_budget_hint, migrate_agent_retry_to_tools_retry, migrate_autodream_config,
-    migrate_compression_predictor_config, migrate_database_url, migrate_egress_config,
-    migrate_focus_auto_consolidate_min_window, migrate_forgetting_config, migrate_goals_config,
-    migrate_hooks_permission_denied_config, migrate_hooks_turn_complete_config,
-    migrate_magic_docs_config, migrate_mcp_elicitation_config, migrate_mcp_max_connect_attempts,
-    migrate_mcp_trust_levels, migrate_memory_graph_config, migrate_memory_hebbian_config,
-    migrate_memory_hebbian_consolidation_config, migrate_memory_hebbian_spread_config,
-    migrate_memory_persona_config, migrate_memory_reasoning_config,
-    migrate_memory_reasoning_judge_config, migrate_memory_retrieval_config,
-    migrate_memory_retrieval_query_bias, migrate_microcompact_config,
-    migrate_orchestration_orchestrator_provider, migrate_orchestration_persistence,
-    migrate_otel_filter, migrate_planner_model_to_provider, migrate_provider_max_concurrent,
-    migrate_qdrant_api_key, migrate_quality_config, migrate_sandbox_config,
-    migrate_sandbox_egress_filter, migrate_scheduler_daemon_config,
+    migrate_cocoon_provider_notice, migrate_compression_predictor_config, migrate_database_url,
+    migrate_egress_config, migrate_focus_auto_consolidate_min_window, migrate_forgetting_config,
+    migrate_goals_config, migrate_hooks_permission_denied_config,
+    migrate_hooks_turn_complete_config, migrate_magic_docs_config, migrate_mcp_elicitation_config,
+    migrate_mcp_max_connect_attempts, migrate_mcp_trust_levels, migrate_memory_graph_config,
+    migrate_memory_hebbian_config, migrate_memory_hebbian_consolidation_config,
+    migrate_memory_hebbian_spread_config, migrate_memory_persona_config,
+    migrate_memory_reasoning_config, migrate_memory_reasoning_judge_config,
+    migrate_memory_retrieval_config, migrate_memory_retrieval_query_bias,
+    migrate_microcompact_config, migrate_orchestration_orchestrator_provider,
+    migrate_orchestration_persistence, migrate_otel_filter, migrate_planner_model_to_provider,
+    migrate_provider_max_concurrent, migrate_qdrant_api_key, migrate_quality_config,
+    migrate_sandbox_config, migrate_sandbox_egress_filter, migrate_scheduler_daemon_config,
     migrate_session_provider_persistence, migrate_session_recap_config,
     migrate_shell_transactional, migrate_stt_to_provider, migrate_supervisor_config,
     migrate_telemetry_config, migrate_tools_compression_config, migrate_vigil_config,
@@ -525,5 +527,16 @@ impl Migration for MigrateGonkagateToGonka {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         Ok(super::migrate_gonkagate_to_gonka(toml_src))
+    }
+}
+
+pub(super) struct MigrateCocoonProviderNotice;
+impl Migration for MigrateCocoonProviderNotice {
+    fn name(&self) -> &'static str {
+        "migrate_cocoon_provider_notice"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_cocoon_provider_notice(toml_src)
     }
 }

--- a/crates/zeph-config/src/providers.rs
+++ b/crates/zeph-config/src/providers.rs
@@ -1592,6 +1592,36 @@ impl ProviderEntry {
             ));
         }
 
+        // B5: cocoon URL must be valid http/https; cocoon model must not be empty.
+        if self.provider_type == ProviderKind::Cocoon {
+            let name = self.effective_name();
+            if let Some(ref url_str) = self.cocoon_client_url {
+                match url::Url::parse(url_str) {
+                    Err(_) => {
+                        return Err(ConfigError::Validation(format!(
+                            "[[llm.providers]] entry '{name}': cocoon_client_url \
+                             '{url_str}' is not a valid URL; expected format: \
+                             http://localhost:10000"
+                        )));
+                    }
+                    Ok(u) if u.scheme() != "http" && u.scheme() != "https" => {
+                        return Err(ConfigError::Validation(format!(
+                            "[[llm.providers]] entry '{name}': cocoon_client_url \
+                             scheme must be http or https, got '{}'",
+                            u.scheme()
+                        )));
+                    }
+                    _ => {}
+                }
+            }
+            if self.model.as_deref().is_some_and(|m| m.trim().is_empty()) {
+                return Err(ConfigError::Validation(format!(
+                    "[[llm.providers]] entry '{name}': model must not be empty \
+                     for cocoon provider"
+                )));
+            }
+        }
+
         // B1: warn on irrelevant fields.
         self.warn_irrelevant_fields();
 
@@ -2640,5 +2670,86 @@ model = "claude-sonnet-4-6"
         assert_eq!(cfg.providers.len(), 2);
         assert_eq!(cfg.providers[0].provider_type, ProviderKind::Ollama);
         assert_eq!(cfg.providers[1].provider_type, ProviderKind::Claude);
+    }
+
+    // ── ProviderEntry::validate — Cocoon URL and model validation ─────────────
+
+    fn cocoon_entry(url: Option<&str>, model: Option<&str>) -> ProviderEntry {
+        ProviderEntry {
+            provider_type: ProviderKind::Cocoon,
+            name: Some("cocoon".into()),
+            cocoon_client_url: url.map(str::to_owned),
+            model: model.map(str::to_owned),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_cocoon_url_validation_accepts_http() {
+        assert!(
+            cocoon_entry(Some("http://localhost:10000"), Some("Qwen/Qwen3-0.6B"))
+                .validate()
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_cocoon_url_validation_accepts_https() {
+        assert!(
+            cocoon_entry(Some("https://example.com:10000"), Some("Qwen/Qwen3-0.6B"))
+                .validate()
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_cocoon_url_validation_rejects_non_http_scheme() {
+        let err = cocoon_entry(Some("ftp://server"), Some("Qwen/Qwen3-0.6B"))
+            .validate()
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("ftp"),
+            "error should mention the bad scheme: {err}"
+        );
+    }
+
+    #[test]
+    fn test_cocoon_url_validation_rejects_invalid_url() {
+        let err = cocoon_entry(Some("not-a-url"), Some("Qwen/Qwen3-0.6B"))
+            .validate()
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("not-a-url"),
+            "error should mention the bad value: {err}"
+        );
+    }
+
+    #[test]
+    fn test_cocoon_url_none_passes() {
+        assert!(
+            cocoon_entry(None, Some("Qwen/Qwen3-0.6B"))
+                .validate()
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_cocoon_model_empty_rejected() {
+        let err = cocoon_entry(Some("http://localhost:10000"), Some(""))
+            .validate()
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("empty"),
+            "error should mention 'empty': {err}"
+        );
+    }
+
+    #[test]
+    fn test_cocoon_model_none_passes() {
+        assert!(
+            cocoon_entry(Some("http://localhost:10000"), None)
+                .validate()
+                .is_ok()
+        );
     }
 }

--- a/crates/zeph-core/src/provider_factory.rs
+++ b/crates/zeph-core/src/provider_factory.rs
@@ -394,6 +394,15 @@ fn build_gonka_provider(
     Ok(AnyProvider::Gonka(provider))
 }
 
+/// Build a [`CocoonProvider`] from a `[[llm.providers]]` entry.
+///
+/// Resolves the access hash from the age vault when `cocoon_access_hash` is `Some(_)` in the
+/// entry. If the vault key is absent an explicit, actionable error is returned.
+///
+/// # Errors
+///
+/// Returns [`BootstrapError::Provider`] when the vault key `ZEPH_COCOON_ACCESS_HASH` is
+/// expected (field is `Some`) but not present in the resolved secrets.
 #[cfg(feature = "cocoon")]
 fn build_cocoon_provider(
     entry: &ProviderEntry,
@@ -421,11 +430,19 @@ fn build_cocoon_provider(
         );
     }
 
-    let access_hash = if entry
+    if entry
         .cocoon_access_hash
-        .as_ref()
-        .is_some_and(|s| !s.is_empty())
+        .as_deref()
+        .is_some_and(|v| !v.is_empty())
     {
+        tracing::warn!(
+            "cocoon_access_hash in config file appears to contain a raw value; \
+             this field should be empty — the actual hash must be stored in the vault: \
+             zeph vault set ZEPH_COCOON_ACCESS_HASH <hash>"
+        );
+    }
+
+    let access_hash = if entry.cocoon_access_hash.is_some() {
         let hash = config
             .secrets
             .cocoon_access_hash
@@ -690,7 +707,7 @@ mod tests {
         ));
     }
 
-    #[cfg(feature = "gonka")]
+    #[cfg(any(feature = "gonka", feature = "cocoon"))]
     use super::build_provider_from_entry;
     use super::{effective_embedding_model, stable_skill_embedding_model};
     use crate::config::{Config, ProviderKind};
@@ -838,5 +855,52 @@ mod tests {
             stable_skill_embedding_model(&config),
             effective_embedding_model(&config)
         );
+    }
+
+    #[cfg(feature = "cocoon")]
+    mod cocoon_tests {
+        use super::*;
+
+        fn cocoon_entry(access_hash: Option<&str>) -> ProviderEntry {
+            ProviderEntry {
+                provider_type: ProviderKind::Cocoon,
+                name: Some("cocoon".into()),
+                model: Some("Qwen/Qwen3-0.6B".into()),
+                cocoon_client_url: Some("http://localhost:10000".into()),
+                cocoon_access_hash: access_hash.map(str::to_owned),
+                cocoon_health_check: false,
+                ..ProviderEntry::default()
+            }
+        }
+
+        /// `cocoon_access_hash = Some("")` sentinel with no vault key must return an error.
+        #[test]
+        fn cocoon_access_hash_gate_vault_miss_errors() {
+            let entry = cocoon_entry(Some(""));
+            let config = Config::default(); // secrets.cocoon_access_hash = None
+            let result = build_provider_from_entry(&entry, &config);
+            assert!(
+                result.is_err(),
+                "expected error when vault key is absent but sentinel is set"
+            );
+            let err_str = result.unwrap_err().to_string();
+            assert!(
+                err_str.contains("ZEPH_COCOON_ACCESS_HASH"),
+                "error should mention the vault key: {err_str}"
+            );
+        }
+
+        /// `cocoon_access_hash = None` must succeed without touching the vault (health check off).
+        #[test]
+        fn cocoon_no_access_hash_gate_succeeds_without_vault() {
+            let entry = cocoon_entry(None);
+            let config = Config::default();
+            let result = build_provider_from_entry(&entry, &config);
+            assert!(
+                result.is_ok(),
+                "expected success when no access hash requested: {:?}",
+                result.err()
+            );
+        }
     }
 }

--- a/specs/055-cocoon/spec.md
+++ b/specs/055-cocoon/spec.md
@@ -351,7 +351,7 @@ impl LlmProvider for CocoonProvider {
 | Proxy connected | `/stats` JSON | `proxy_connected: true` |
 | Workers available | `/stats` JSON | `worker_count > 0` |
 | Model listed | `GET /v1/models` | Configured model ID appears in response |
-| Vault key | age vault | `ZEPH_COCOON_ACCESS_HASH` present (checked only if `cocoon_access_hash` is non-empty in config) |
+| Vault key | age vault | `ZEPH_COCOON_ACCESS_HASH` present (checked only if `cocoon_access_hash` is **present** in config, i.e. `Some(_)`) |
 
 Exit code: 0 if all applicable checks pass, 1 otherwise.
 

--- a/src/init/llm.rs
+++ b/src/init/llm.rs
@@ -51,6 +51,7 @@ pub(super) fn step_llm_provider(state: &mut WizardState, use_age: bool) -> anyho
         "Compatible (custom)",
         "Gonka (decentralized \u{2014} via GonkaGate)",
         "Gonka (native \u{2014} requires GNK staking)",
+        "Cocoon (decentralized TEE inference via TON \u{2014} requires local sidecar)",
     ];
     let selection = Select::new()
         .with_prompt("Select LLM provider")
@@ -215,6 +216,9 @@ pub(super) fn step_llm_provider(state: &mut WizardState, use_age: bool) -> anyho
         6 => {
             step_gonka_native(state, use_age)?;
         }
+        7 => {
+            step_cocoon(state, use_age)?;
+        }
         _ => unreachable!(),
     }
     Ok(())
@@ -262,6 +266,92 @@ fn step_gonka_native(state: &mut WizardState, use_age: bool) -> anyhow::Result<(
     state.gonka_private_key = Some(hex_key);
     state.gonka_address = Some(derived_address);
     state.gonka_nodes = nodes;
+
+    Ok(())
+}
+
+fn probe_cocoon_reachable(url: &str) -> bool {
+    let Ok(parsed) = url::Url::parse(url) else {
+        return false;
+    };
+    let host = parsed.host_str().unwrap_or("localhost");
+    // Only probe localhost targets — the Cocoon sidecar is always local.
+    if host != "localhost" && host != "127.0.0.1" && host != "::1" {
+        return false;
+    }
+    let port = parsed.port().unwrap_or(10000);
+    let addr_str = format!("{host}:{port}");
+    let socket_addr = match std::net::ToSocketAddrs::to_socket_addrs(addr_str.as_str()) {
+        Ok(mut addrs) => match addrs.next() {
+            Some(a) => a,
+            None => return false,
+        },
+        Err(_) => return false,
+    };
+    std::net::TcpStream::connect_timeout(&socket_addr, std::time::Duration::from_secs(3)).is_ok()
+}
+
+fn step_cocoon(state: &mut WizardState, use_age: bool) -> anyhow::Result<()> {
+    state.provider = Some(ProviderKind::Cocoon);
+
+    let sidecar_url: String = Input::new()
+        .with_prompt("Cocoon sidecar URL")
+        .default("http://localhost:10000".into())
+        .validate_with(|input: &String| -> Result<(), String> {
+            match url::Url::parse(input) {
+                Ok(u) if u.scheme() == "http" || u.scheme() == "https" => Ok(()),
+                Ok(u) => Err(format!(
+                    "scheme must be http or https, got '{}'",
+                    u.scheme()
+                )),
+                Err(e) => Err(format!("invalid URL: {e}")),
+            }
+        })
+        .interact_text()?;
+
+    // Informational note when port is absent (sidecar default is 10000, HTTP default is 80).
+    if url::Url::parse(&sidecar_url).is_ok_and(|u| u.port().is_none()) {
+        println!("  Note: no port specified; Cocoon sidecar typically runs on port 10000");
+    }
+
+    if probe_cocoon_reachable(&sidecar_url) {
+        println!("  Sidecar at {sidecar_url} is reachable.");
+    } else {
+        println!(
+            "  Warning: sidecar at {sidecar_url} is not reachable. \
+             You can still configure the provider and start the sidecar later."
+        );
+    }
+
+    state.cocoon_client_url = Some(sidecar_url);
+
+    let model: String = Input::new()
+        .with_prompt("Default model")
+        .default("Qwen/Qwen3-0.6B".into())
+        .validate_with(|input: &String| -> Result<(), String> {
+            if input.trim().is_empty() {
+                Err("model name must not be empty".into())
+            } else {
+                Ok(())
+            }
+        })
+        .interact_text()?;
+    state.model = Some(model);
+
+    let wants_access_hash = use_age
+        && Confirm::new()
+            .with_prompt("Do you have an access hash for this Cocoon network?")
+            .default(false)
+            .interact()?;
+
+    if wants_access_hash {
+        println!(
+            "  Access hash will not be stored in config. After setup, run:\n  \
+             zeph vault set ZEPH_COCOON_ACCESS_HASH <your-hash>\n  \
+             Then set cocoon_access_hash = \"\" in config to enable vault lookup."
+        );
+    }
+    state.cocoon_wants_access_hash = wants_access_hash;
 
     Ok(())
 }

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -242,6 +242,11 @@ pub(crate) struct WizardState {
     pub(crate) gonka_private_key: Option<Zeroizing<String>>,
     pub(crate) gonka_address: Option<String>,
     pub(crate) gonka_nodes: Vec<zeph_config::GonkaNode>,
+    // Cocoon provider (#3671)
+    /// Sidecar URL provided by the wizard (e.g. `http://localhost:10000`).
+    pub(crate) cocoon_client_url: Option<String>,
+    /// `true` when the user confirmed they have an access hash stored in the vault.
+    pub(crate) cocoon_wants_access_hash: bool,
 }
 
 impl Default for WizardState {
@@ -412,6 +417,8 @@ impl Default for WizardState {
             gonka_private_key: None,
             gonka_address: None,
             gonka_nodes: Vec::new(),
+            cocoon_client_url: None,
+            cocoon_wants_access_hash: false,
         }
     }
 }
@@ -635,6 +642,12 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
             thinking_level: state.gemini_thinking_level,
             vision_model: state.vision_model.clone().filter(|s| !s.is_empty()),
             gonka_nodes: state.gonka_nodes.clone(),
+            cocoon_client_url: state.cocoon_client_url.clone(),
+            cocoon_access_hash: if state.cocoon_wants_access_hash {
+                Some(String::new()) // empty sentinel: resolve from vault
+            } else {
+                None
+            },
             ..ProviderEntry::default()
         }]
     };
@@ -1641,6 +1654,11 @@ fn print_secrets_instructions(state: &WizardState) {
         secrets.push("ZEPH_GONKA_ADDRESS".into());
     }
 
+    // Cocoon provider: access hash is stored in vault (never in config file).
+    if state.provider == Some(ProviderKind::Cocoon) && state.cocoon_wants_access_hash {
+        secrets.push("ZEPH_COCOON_ACCESS_HASH".into());
+    }
+
     let include_telegram = use_age && matches!(state.channel, ChannelChoice::Telegram)
         || state.telegram_token.is_some();
     if include_telegram {
@@ -2532,5 +2550,56 @@ mod tests {
         // Snapshot the serialized TOML shape for regression detection.
         let toml_str = toml::to_string_pretty(p).expect("serialize provider entry");
         insta::assert_snapshot!("gonka_provider_entry_toml", toml_str);
+    }
+
+    // ── Cocoon wizard state → build_config ───────────────────────────────────
+
+    #[test]
+    fn build_config_cocoon_provider() {
+        let state = WizardState {
+            provider: Some(ProviderKind::Cocoon),
+            model: Some("Qwen/Qwen3-0.6B".into()),
+            cocoon_client_url: Some("http://localhost:10000".into()),
+            cocoon_wants_access_hash: false,
+            ..WizardState::default()
+        };
+        let config = build_config(&state);
+        let p = &config.llm.providers[0];
+        assert_eq!(p.provider_type, ProviderKind::Cocoon);
+        assert_eq!(p.model.as_deref(), Some("Qwen/Qwen3-0.6B"));
+        assert_eq!(
+            p.cocoon_client_url.as_deref(),
+            Some("http://localhost:10000")
+        );
+        assert!(p.cocoon_access_hash.is_none());
+    }
+
+    #[test]
+    fn build_config_cocoon_access_hash_sentinel() {
+        let state = WizardState {
+            provider: Some(ProviderKind::Cocoon),
+            model: Some("Qwen/Qwen3-0.6B".into()),
+            cocoon_client_url: Some("http://localhost:10000".into()),
+            cocoon_wants_access_hash: true,
+            ..WizardState::default()
+        };
+        let config = build_config(&state);
+        let p = &config.llm.providers[0];
+        // Sentinel: Some("") signals "use vault".
+        assert_eq!(p.cocoon_access_hash.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn build_config_cocoon_no_access_hash() {
+        let state = WizardState {
+            provider: Some(ProviderKind::Cocoon),
+            model: Some("Qwen/Qwen3-0.6B".into()),
+            cocoon_client_url: Some("http://localhost:10000".into()),
+            cocoon_wants_access_hash: false,
+            ..WizardState::default()
+        };
+        let config = build_config(&state);
+        let p = &config.llm.providers[0];
+        assert!(p.cocoon_access_hash.is_none());
     }
 }


### PR DESCRIPTION
## Summary

- **Config validation**: `cocoon_client_url` validated for http/https scheme and well-formed URL at config load time; model field validated non-empty
- **`--init` wizard**: new option [7] Cocoon with TCP reachability probe (`std::net::TcpStream`, zero new deps), manual model entry (default `Qwen/Qwen3-0.6B`), vault instructions for access hash (hash never written to config); localhost-only TCP probe guard against SSRF
- **Vault sentinel fix**: `build_cocoon_provider` gate changed from `is_some_and(|s| !s.is_empty())` → `is_some()` so the empty-string wizard sentinel correctly triggers vault lookup for `ZEPH_COCOON_ACCESS_HASH`; `warn!` added when non-empty raw value found in config
- **`--migrate-config`**: step 46 `migrate_cocoon_provider_notice` (no-op advisory)
- **`default.toml`**: commented-out Cocoon provider stanza with vault setup instructions
- **`url` crate**: added as explicit dependency in `zeph-config`

## Test plan

- [ ] `cargo build --features cocoon` passes
- [ ] `cargo +nightly fmt --check` passes
- [ ] `cargo clippy --workspace --features "desktop,ide,server,chat,pdf,scheduler,cocoon" -- -D warnings` passes
- [ ] `cargo nextest run --workspace --lib --bins` passes (9190 tests)
- [ ] `zeph --init` → select Cocoon → wizard completes with unreachable sidecar
- [ ] `zeph --migrate-config` runs without errors on existing configs

Closes #3671