### PR TITLE
fix(cli): validate cocoon_client_url scheme in cocoon doctor config check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(cli): `zeph cocoon doctor` now reports `[FAIL]` for `cocoon_client_url` with an invalid scheme
+  (e.g. `ftp://`). `check_config_present` previously returned `[OK]` without calling
+  `entry.validate()`, silently accepting any URL scheme. The fix adds a `validate()` guard that
+  pushes a `CheckResult::fail` with the scheme error and returns early. (#3694)
+
 ### Added
 
 - feat(llm): Cocoon live integration tests — 6 `#[ignore]`-gated tests covering `health_check`,

--- a/src/commands/cocoon.rs
+++ b/src/commands/cocoon.rs
@@ -58,6 +58,14 @@ fn check_config_present(
         .cloned();
 
     if let Some(e) = entry {
+        if let Err(err) = e.validate() {
+            results.push(CheckResult::fail(
+                "cocoon.config",
+                err.to_string(),
+                elapsed_ms(start),
+            ));
+            return None;
+        }
         let url = e
             .cocoon_client_url
             .as_deref()
@@ -549,6 +557,49 @@ mod tests {
             elapsed_ms: 5,
         };
         assert!(!report.has_failures());
+    }
+
+    fn write_cocoon_config(dir: &tempfile::TempDir, url: &str) -> std::path::PathBuf {
+        use zeph_config::{ProviderEntry, ProviderKind};
+
+        let mut config = zeph_core::config::Config::default();
+        config.llm.providers.push(ProviderEntry {
+            provider_type: ProviderKind::Cocoon,
+            name: Some("test".into()),
+            cocoon_client_url: Some(url.to_owned()),
+            ..ProviderEntry::default()
+        });
+        let toml = toml::to_string_pretty(&config).expect("serialize");
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, toml).unwrap();
+        path
+    }
+
+    #[test]
+    fn check_config_present_rejects_ftp_scheme() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = write_cocoon_config(&dir, "ftp://localhost:10000");
+        let mut results = Vec::new();
+        let outcome = check_config_present(&config_path, &mut results);
+        assert!(outcome.is_none(), "ftp:// URL must not return Some");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].status, CheckStatus::Fail);
+        assert!(
+            results[0].detail.contains("ftp"),
+            "error must mention the bad scheme, got: {}",
+            results[0].detail
+        );
+    }
+
+    #[test]
+    fn check_config_present_accepts_http_scheme() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = write_cocoon_config(&dir, "http://localhost:10000");
+        let mut results = Vec::new();
+        let outcome = check_config_present(&config_path, &mut results);
+        assert!(outcome.is_some(), "http:// URL must return Some");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].status, CheckStatus::Ok);
     }
 
     #[cfg(feature = "cocoon")]


### PR DESCRIPTION
## Summary

- `check_config_present()` in `src/commands/cocoon.rs` now calls `entry.validate()` before emitting `[OK]`
- Invalid URL schemes (e.g. `ftp://`) produce `[FAIL] cocoon.config — ...scheme must be http or https, got 'ftp'` and return `None` early
- Added 2 unit tests: `check_config_present_rejects_ftp_scheme` and `check_config_present_accepts_http_scheme`

## Root cause

`check_config_present` found the Cocoon `ProviderEntry` but never called `entry.validate()`, so the URL scheme check in `ProviderEntry::validate()` was silently skipped. `doctor.rs` correctly calls `config.validate()` — the cocoon doctor path did not follow the same pattern.

## Test plan

- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 8950 passed, 0 failed
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] New test `check_config_present_rejects_ftp_scheme` confirms `[FAIL]` for `ftp://`
- [x] New test `check_config_present_accepts_http_scheme` confirms `[OK]` for `http://`

Closes #3694