### PR TITLE
fix(tui): thread tool_call_id through shell executor to fix parallel tool output corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   lookup when `tool_call_id` is non-empty; on miss it drops the chunk with a `warn!` log
   instead of falling back to the last streaming message (which was the source of the bug).
   The legacy empty-id path retains the old `rposition` fallback for backwards compatibility.
-  Closes #3688. (#3692)
+  Closes #3688. (#3708)
 
 - fix(cli): `zeph cocoon doctor` now reports `[FAIL]` for `cocoon_client_url` with an invalid scheme
   (e.g. `ftp://`). `check_config_present` previously returned `[OK]` without calling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- fix(tui): parallel tool call output no longer gets cross-contaminated in the TUI. `tool_call_id`
+  is now threaded from `ToolCall` through `ShellExecutor` → `ToolEvent::OutputChunk` →
+  `tui_bridge` → `AgentEvent::ToolOutputChunk/ToolStart/ToolOutput`. The TUI uses id-based
+  lookup when `tool_call_id` is non-empty; on miss it drops the chunk with a `warn!` log
+  instead of falling back to the last streaming message (which was the source of the bug).
+  The legacy empty-id path retains the old `rposition` fallback for backwards compatibility.
+  Closes #3688. (#3692)
+
 - fix(cli): `zeph cocoon doctor` now reports `[FAIL]` for `cocoon_client_url` with an invalid scheme
   (e.g. `ftp://`). `check_config_present` previously returned `[OK]` without calling
   `entry.validate()`, silently accepting any URL scheme. The fix adds a `validate()` guard that

--- a/crates/zeph-bench/src/loaders/tau2_bench/envs/airline.rs
+++ b/crates/zeph-bench/src/loaders/tau2_bench/envs/airline.rs
@@ -628,6 +628,8 @@ mod tests {
             params: params.as_object().cloned().unwrap_or_default(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         }
     }
 

--- a/crates/zeph-bench/src/loaders/tau2_bench/envs/retail.rs
+++ b/crates/zeph-bench/src/loaders/tau2_bench/envs/retail.rs
@@ -747,6 +747,8 @@ mod tests {
             params: params.as_object().cloned().unwrap_or_default(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         }
     }
 

--- a/crates/zeph-core/src/agent/scheduler_commands.rs
+++ b/crates/zeph-core/src/agent/scheduler_commands.rs
@@ -15,6 +15,8 @@ impl<C: Channel> Agent<C> {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         match self.tool_executor.execute_tool_call_erased(&call).await {
             Ok(Some(output)) => Ok(output.summary),

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -663,6 +663,8 @@ impl<C: crate::channel::Channel> Agent<C> {
                             },
                             caller_id: None,
                             context: None,
+
+                            tool_call_id: String::new(),
                         };
                         let output = loop {
                             tokio::select! {

--- a/crates/zeph-core/src/agent/speculative/prediction.rs
+++ b/crates/zeph-core/src/agent/speculative/prediction.rs
@@ -49,6 +49,8 @@ impl Prediction {
             params: self.args.clone(),
             caller_id: Some(call_id.into()),
             context: None,
+
+            tool_call_id: String::new(),
         }
     }
 }

--- a/crates/zeph-core/src/agent/tool_execution/tests/native_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/native_tests.rs
@@ -394,6 +394,8 @@ fn clear_utility_state_resets_per_turn_redundancy_tracking() {
         params: serde_json::Map::new(),
         caller_id: None,
         context: None,
+
+        tool_call_id: String::new(),
     };
     let ctx = UtilityContext {
         tool_calls_this_turn: 0,
@@ -724,6 +726,8 @@ fn test_tool_call(tool_id: &str) -> ToolCall {
         params: serde_json::Map::new(),
         caller_id: None,
         context: None,
+
+        tool_call_id: String::new(),
     }
 }
 

--- a/crates/zeph-core/src/agent/tool_execution/tests/parallel_and_handle_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/parallel_and_handle_tests.rs
@@ -101,6 +101,8 @@ fn make_calls(n: usize) -> Vec<ToolCall> {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         })
         .collect()
 }

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -607,9 +607,17 @@ impl<C: Channel> Agent<C> {
             .task_execution_env
             .as_deref()
             .map(|name| ExecutionContext::default().with_name(name));
+        // Assign stable IDs before execution so ToolStart, ToolOutputChunk, and ToolOutput
+        // all share the same ID, enabling correct per-tool routing in parallel execution.
+        let tool_call_ids: Vec<String> = tool_calls
+            .iter()
+            .map(|_| uuid::Uuid::new_v4().to_string())
+            .collect();
+
         let calls: Vec<ToolCall> = tool_calls
             .iter()
-            .filter_map(|tc| {
+            .enumerate()
+            .filter_map(|(idx, tc)| {
                 let mut params: serde_json::Map<String, serde_json::Value> =
                     if let serde_json::Value::Object(map) = &tc.input {
                         map.clone()
@@ -625,16 +633,9 @@ impl<C: Channel> Agent<C> {
                     params,
                     caller_id: None,
                     context: task_ctx.clone(),
-
-                    tool_call_id: String::new(),
+                    tool_call_id: tool_call_ids[idx].clone(),
                 })
             })
-            .collect();
-
-        // Assign stable IDs before execution so ToolStart and ToolOutput share the same ID.
-        let tool_call_ids: Vec<String> = tool_calls
-            .iter()
-            .map(|_| uuid::Uuid::new_v4().to_string())
             .collect();
         // tool_started_ats is populated per-tier just before each tier's join_all so that
         // audit timestamps reflect actual execution start rather than pre-build time.

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -625,6 +625,8 @@ impl<C: Channel> Agent<C> {
                     params,
                     caller_id: None,
                     context: task_ctx.clone(),
+
+                    tool_call_id: String::new(),
                 })
             })
             .collect();

--- a/crates/zeph-core/src/memory_tools.rs
+++ b/crates/zeph-core/src/memory_tools.rs
@@ -275,6 +275,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = executor.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());
@@ -294,6 +296,8 @@ mod tests {
             params,
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = executor.execute_tool_call(&call).await.unwrap();
         assert!(result.is_some());
@@ -322,6 +326,8 @@ mod tests {
             params,
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = executor.execute_tool_call(&call).await.unwrap();
         assert!(result.is_some());
@@ -341,6 +347,8 @@ mod tests {
             params,
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(result.is_err());
@@ -360,6 +368,8 @@ mod tests {
             params,
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(result.is_err());

--- a/crates/zeph-core/src/overflow_tools.rs
+++ b/crates/zeph-core/src/overflow_tools.rs
@@ -127,6 +127,8 @@ mod tests {
             params,
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         }
     }
 
@@ -156,6 +158,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = exec.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());

--- a/crates/zeph-core/src/runtime_layer.rs
+++ b/crates/zeph-core/src/runtime_layer.rs
@@ -190,6 +190,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = layer.before_tool(&ctx, &call).await;
         assert!(result.is_none());
@@ -413,6 +415,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result: Result<Option<ToolOutput>, ToolError> = Ok(None);
 
@@ -449,6 +453,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result: Result<Option<ToolOutput>, zeph_tools::ToolError> = Ok(None);
         layer.after_tool(&ctx, &call, &result).await;

--- a/crates/zeph-core/src/skill_invoker.rs
+++ b/crates/zeph-core/src/skill_invoker.rs
@@ -211,6 +211,8 @@ mod tests {
                 .clone(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         }
     }
 
@@ -223,6 +225,8 @@ mod tests {
                 .clone(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         }
     }
 
@@ -336,6 +340,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = executor.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());

--- a/crates/zeph-core/src/skill_loader.rs
+++ b/crates/zeph-core/src/skill_loader.rs
@@ -109,6 +109,8 @@ mod tests {
                 .clone(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = executor.execute_tool_call(&call).await.unwrap().unwrap();
         assert!(result.summary.contains("## Instructions"));
@@ -128,6 +130,8 @@ mod tests {
                 .clone(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = executor.execute_tool_call(&call).await.unwrap().unwrap();
         assert!(result.summary.contains("skill not found"));
@@ -154,6 +158,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = executor.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());
@@ -174,6 +180,8 @@ mod tests {
                 .clone(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = executor.execute_tool_call(&call).await.unwrap().unwrap();
         assert!(result.summary.contains("truncated"));
@@ -193,6 +201,8 @@ mod tests {
                 .clone(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = executor.execute_tool_call(&call).await.unwrap().unwrap();
         assert!(result.summary.contains("skill not found"));
@@ -228,6 +238,8 @@ mod tests {
                             .clone(),
                         caller_id: None,
                         context: None,
+
+                        tool_call_id: String::new(),
                     };
                     ex.execute_tool_call(&call).await
                 })
@@ -254,6 +266,8 @@ mod tests {
                 .clone(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = executor.execute_tool_call(&call).await.unwrap().unwrap();
         assert!(result.summary.contains("skill not found"));
@@ -270,6 +284,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(result.is_err());

--- a/crates/zeph-index/src/mcp_server.rs
+++ b/crates/zeph-index/src/mcp_server.rs
@@ -677,6 +677,8 @@ impl Foo {
             },
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         }
     }
 

--- a/crates/zeph-mcp/src/executor.rs
+++ b/crates/zeph-mcp/src/executor.rs
@@ -183,6 +183,7 @@ impl ToolExecutor for McpToolExecutor {
                 },
                 caller_id: None,
                 context: None,
+                tool_call_id: String::new(),
             };
             if let Some(output) = self.execute_tool_call(&call).await? {
                 outputs.push(output.summary);
@@ -445,6 +446,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = executor.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());
@@ -458,6 +461,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = executor.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());
@@ -486,6 +491,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = executor.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());
@@ -512,6 +519,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(result.is_err(), "expected Err when server is not connected");

--- a/crates/zeph-mcp/src/testing.rs
+++ b/crates/zeph-mcp/src/testing.rs
@@ -215,6 +215,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = mock.execute_tool_call(&call).await.unwrap();
         assert!(result.is_some());
@@ -229,6 +231,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = mock.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());
@@ -245,6 +249,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = mock.execute_tool_call(&call).await;
         assert!(result.is_err());
@@ -261,6 +267,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         mock.execute_tool_call(&call).await.unwrap();
 
@@ -280,6 +288,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
 
         // First call succeeds.

--- a/crates/zeph-subagent/src/agent_loop.rs
+++ b/crates/zeph-subagent/src/agent_loop.rs
@@ -489,6 +489,8 @@ async fn handle_tool_step(
                     params,
                     caller_id: None,
                     context: None,
+
+                    tool_call_id: String::new(),
                 };
                 let tool_start = Instant::now();
                 let (content, is_error) = match executor.execute_tool_call_erased(&call).await {

--- a/crates/zeph-subagent/src/filter.rs
+++ b/crates/zeph-subagent/src/filter.rs
@@ -550,6 +550,8 @@ mod tests {
             params: serde_json::Map::default(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let res = exec.execute_tool_call_erased(&call).await.unwrap();
         assert!(res.is_some());
@@ -566,6 +568,8 @@ mod tests {
             params: serde_json::Map::default(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let res = exec.execute_tool_call_erased(&call).await;
         assert!(res.is_err());
@@ -582,6 +586,8 @@ mod tests {
             params: serde_json::Map::default(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let res = exec.execute_tool_call_erased(&call).await;
         assert!(res.is_err());
@@ -595,6 +601,8 @@ mod tests {
             params: serde_json::Map::default(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let res = exec.execute_tool_call_erased(&call).await.unwrap();
         assert!(res.is_some());
@@ -670,6 +678,8 @@ mod tests {
             params: serde_json::Map::default(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let res = exec.execute_tool_call_erased(&call).await.unwrap();
         assert!(res.is_some());
@@ -802,6 +812,8 @@ mod tests {
             params: serde_json::Map::default(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let res = exec.execute_tool_call_erased(&call).await;
         assert!(
@@ -822,6 +834,8 @@ mod tests {
             params: serde_json::Map::default(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let res = exec.execute_tool_call_erased(&call).await;
         assert!(res.is_ok(), "non-disallowed tool must be allowed");
@@ -897,6 +911,8 @@ mod tests {
             params: serde_json::Map::default(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let res = exec.execute_tool_call_erased(&call).await;
         assert!(res.is_err(), "plan mode must block all tool execution");

--- a/crates/zeph-tools/src/adversarial_gate.rs
+++ b/crates/zeph-tools/src/adversarial_gate.rs
@@ -332,6 +332,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         }
     }
 

--- a/crates/zeph-tools/src/composite.rs
+++ b/crates/zeph-tools/src/composite.rs
@@ -270,6 +270,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = composite.execute_tool_call(&call).await.unwrap().unwrap();
         assert_eq!(result.summary, "file_handler");
@@ -283,6 +285,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = composite.execute_tool_call(&call).await.unwrap().unwrap();
         assert_eq!(result.summary, "shell_handler");
@@ -296,6 +300,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = composite.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());

--- a/crates/zeph-tools/src/compression/decorator.rs
+++ b/crates/zeph-tools/src/compression/decorator.rs
@@ -275,6 +275,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let out = executor.execute_tool_call(&call).await.unwrap().unwrap();
 
@@ -296,6 +298,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let out = executor.execute_tool_call(&call).await.unwrap().unwrap();
         // StubCompressor would return "COMPRESSED" — but threshold not met, so raw passes through.
@@ -330,6 +334,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let out = executor.execute_tool_call(&call).await.unwrap().unwrap();
         // Error compressor → raw output preserved (T4 safety invariant).

--- a/crates/zeph-tools/src/cwd.rs
+++ b/crates/zeph-tools/src/cwd.rs
@@ -104,6 +104,8 @@ mod tests {
             params,
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         }
     }
 
@@ -131,6 +133,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = executor.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());

--- a/crates/zeph-tools/src/diagnostics.rs
+++ b/crates/zeph-tools/src/diagnostics.rs
@@ -350,6 +350,8 @@ mod tests {
             params: make_params(&[("path", serde_json::json!("/etc"))]),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = exec.execute_tool_call(&call).await;
         assert!(result.is_err());
@@ -363,6 +365,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = exec.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());

--- a/crates/zeph-tools/src/executor.rs
+++ b/crates/zeph-tools/src/executor.rs
@@ -41,6 +41,7 @@ pub struct DiffData {
 ///     },
 ///     caller_id: Some("user-42".to_owned()),
 ///     context: Some(ExecutionContext::new().with_name("repo")),
+///     tool_call_id: String::new(),
 /// };
 /// assert_eq!(call.tool_id, "bash");
 /// ```
@@ -56,6 +57,9 @@ pub struct ToolCall {
     /// Per-turn execution environment. `None` means use the executor default (process CWD
     /// and inherited env), which is identical to the behaviour before this field existed.
     pub context: Option<crate::ExecutionContext>,
+    /// Opaque tool call ID used to correlate [`ToolEvent::OutputChunk`] events with
+    /// their originating tool call in the TUI. Empty when not set by the agent loop.
+    pub tool_call_id: String,
 }
 
 /// Cumulative filter statistics for a single tool execution.
@@ -305,6 +309,9 @@ pub enum ToolEvent {
         tool_name: ToolName,
         command: String,
         chunk: String,
+        /// Opaque tool call ID matching the corresponding [`ToolEvent::Started`] event.
+        /// Empty string when the executor does not have access to the call ID.
+        tool_call_id: String,
     },
     /// The tool finished. Contains the full output and optional filter/diff data.
     Completed {
@@ -1216,6 +1223,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = exec.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());
@@ -1361,6 +1370,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = exec.execute_tool_call(&call).await.unwrap();
         assert!(result.is_some());
@@ -1696,6 +1707,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         }
     }
 

--- a/crates/zeph-tools/src/file.rs
+++ b/crates/zeph-tools/src/file.rs
@@ -1031,6 +1031,8 @@ mod tests {
             params: make_params(&[("path", serde_json::json!(file.to_str().unwrap()))]),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = exec.execute_tool_call(&call).await.unwrap().unwrap();
         assert_eq!(result.tool_name, "read");

--- a/crates/zeph-tools/src/policy_gate.rs
+++ b/crates/zeph-tools/src/policy_gate.rs
@@ -419,6 +419,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         }
     }
 
@@ -430,6 +432,8 @@ mod tests {
             params,
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         }
     }
 

--- a/crates/zeph-tools/src/scope.rs
+++ b/crates/zeph-tools/src/scope.rs
@@ -724,6 +724,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         }
     }
 

--- a/crates/zeph-tools/src/scrape.rs
+++ b/crates/zeph-tools/src/scrape.rs
@@ -147,6 +147,7 @@ impl ExtractMode {
 ///     },
 ///     caller_id: None,
 ///     context: None,
+///     tool_call_id: String::new(),
 /// };
 /// let _ = executor.execute_tool_call(&call).await;
 /// # }
@@ -2146,6 +2147,8 @@ mod tests {
             },
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(matches!(result, Err(ToolError::Blocked { .. })));
@@ -2167,6 +2170,8 @@ mod tests {
             },
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(matches!(result, Err(ToolError::Blocked { .. })));
@@ -2188,6 +2193,8 @@ mod tests {
             },
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(matches!(result, Err(ToolError::Blocked { .. })));
@@ -2202,6 +2209,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(result.unwrap().is_none());
@@ -2431,6 +2440,8 @@ mod tests {
             },
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(matches!(result, Err(ToolError::Blocked { .. })));
@@ -2544,6 +2555,8 @@ mod tests {
             },
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = executor.execute_tool_call(&call).await;
         assert!(matches!(result, Err(ToolError::Blocked { .. })));
@@ -2574,6 +2587,8 @@ mod tests {
             },
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         // Must not panic even without an audit logger
         let result = executor.execute_tool_call(&call).await;

--- a/crates/zeph-tools/src/search_code.rs
+++ b/crates/zeph-tools/src/search_code.rs
@@ -687,6 +687,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let err = exec.execute_tool_call(&call).await.unwrap_err();
         assert!(matches!(err, ToolError::InvalidParams { .. }));
@@ -706,6 +708,8 @@ mod tests {
                 .clone(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let out = exec.execute_tool_call(&call).await.unwrap().unwrap();
         assert!(out.summary.contains("retry_backoff_ms"));
@@ -727,6 +731,8 @@ mod tests {
                 .clone(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let out = exec.execute_tool_call(&call).await.unwrap().unwrap();
         assert!(out.summary.contains("grep fallback"));

--- a/crates/zeph-tools/src/shell/mod.rs
+++ b/crates/zeph-tools/src/shell/mod.rs
@@ -637,6 +637,7 @@ impl ShellExecutor {
             block,
             self.timeout,
             self.tool_event_tx.as_ref(),
+            "",
             self.cancel_token.as_ref(),
             resolved,
             sandbox_pair,
@@ -717,6 +718,7 @@ impl ShellExecutor {
         command: &str,
         skip_confirm: bool,
         resolved: &ResolvedContext,
+        tool_call_id: &str,
     ) -> Result<Option<ToolOutput>, ToolError> {
         self.check_permissions(command, skip_confirm).await?;
         self.validate_sandbox_with_cwd(command, &resolved.cwd)?;
@@ -747,6 +749,7 @@ impl ShellExecutor {
             command,
             self.timeout,
             self.tool_event_tx.as_ref(),
+            tool_call_id,
             self.cancel_token.as_ref(),
             resolved,
             sandbox_pair,
@@ -1507,7 +1510,7 @@ impl ToolExecutor for ShellExecutor {
             }));
         }
 
-        self.execute_block_with_context(command, false, &resolved)
+        self.execute_block_with_context(command, false, &resolved, &call.tool_call_id)
             .await
     }
 
@@ -1791,6 +1794,7 @@ async fn run_background_task(
         deadline,
         Some(&abort),
         tool_event_tx.as_ref(),
+        "",
         &mut line_rx,
         &mut combined,
         &mut stdout_buf,
@@ -1922,6 +1926,7 @@ async fn run_background_task_with_env(
         deadline,
         Some(&abort),
         tool_event_tx.as_ref(),
+        "",
         &mut line_rx,
         &mut combined,
         &mut stdout_buf,
@@ -2430,7 +2435,7 @@ pub struct ShellOutputEnvelope {
 }
 
 // Used only in cfg(test) blocks; dead_code analysis does not see test imports.
-#[allow(dead_code)]
+#[allow(dead_code, clippy::too_many_arguments)]
 async fn execute_bash(
     code: &str,
     timeout: Duration,
@@ -2439,6 +2444,7 @@ async fn execute_bash(
     extra_env: Option<&std::collections::HashMap<String, String>>,
     env_blocklist: &[String],
     sandbox: Option<(&dyn Sandbox, &SandboxPolicy)>,
+    tool_call_id: &str,
 ) -> (ShellOutputEnvelope, String) {
     use std::process::Stdio;
 
@@ -2470,6 +2476,7 @@ async fn execute_bash(
         deadline,
         cancel_token,
         event_tx,
+        tool_call_id,
         &mut line_rx,
         &mut combined,
         &mut stdout_buf,
@@ -2551,6 +2558,7 @@ async fn execute_bash_with_context(
     code: &str,
     timeout: Duration,
     event_tx: Option<&ToolEventTx>,
+    tool_call_id: &str,
     cancel_token: Option<&CancellationToken>,
     resolved: &ResolvedContext,
     sandbox: Option<(&dyn Sandbox, &SandboxPolicy)>,
@@ -2585,6 +2593,7 @@ async fn execute_bash_with_context(
         deadline,
         cancel_token,
         event_tx,
+        tool_call_id,
         &mut line_rx,
         &mut combined,
         &mut stdout_buf,
@@ -2703,6 +2712,7 @@ async fn run_bash_stream(
     deadline: tokio::time::Instant,
     cancel_token: Option<&CancellationToken>,
     event_tx: Option<&ToolEventTx>,
+    tool_call_id: &str,
     line_rx: &mut tokio::sync::mpsc::Receiver<(bool, String)>,
     combined: &mut String,
     stdout_buf: &mut String,
@@ -2725,6 +2735,7 @@ async fn run_bash_stream(
                                 tool_name: ToolName::new("bash"),
                                 command: code.to_owned(),
                                 chunk: interleaved.clone(),
+                                tool_call_id: tool_call_id.to_owned(),
                             });
                         }
                         combined.push_str(&interleaved);

--- a/crates/zeph-tools/src/shell/tests.rs
+++ b/crates/zeph-tools/src/shell/tests.rs
@@ -76,6 +76,7 @@ async fn execute_simple_command() {
         None,
         &[],
         None,
+        "",
     )
     .await;
     assert!(result.contains("hello"));
@@ -93,6 +94,7 @@ async fn execute_stderr_output() {
         None,
         &[],
         None,
+        "",
     )
     .await;
     assert!(result.contains("[stderr]"));
@@ -111,6 +113,7 @@ async fn execute_stdout_and_stderr_combined() {
         None,
         &[],
         None,
+        "",
     )
     .await;
     assert!(result.contains("out"));
@@ -124,8 +127,17 @@ async fn execute_stdout_and_stderr_combined() {
 #[tokio::test]
 #[cfg(not(target_os = "windows"))]
 async fn execute_empty_output() {
-    let (envelope, result) =
-        execute_bash("true", Duration::from_secs(30), None, None, None, &[], None).await;
+    let (envelope, result) = execute_bash(
+        "true",
+        Duration::from_secs(30),
+        None,
+        None,
+        None,
+        &[],
+        None,
+        "",
+    )
+    .await;
     assert_eq!(result, "(no output)");
     assert_eq!(envelope.exit_code, 0);
 }
@@ -943,6 +955,7 @@ async fn execute_bash_injects_extra_env() {
         Some(&env),
         &[],
         None,
+        "",
     )
     .await;
     assert_eq!(envelope.exit_code, 0);
@@ -976,8 +989,17 @@ async fn shell_executor_set_skill_env_injects_vars() {
 #[cfg(unix)]
 #[tokio::test]
 async fn execute_bash_error_handling() {
-    let (envelope, result) =
-        execute_bash("false", Duration::from_secs(5), None, None, None, &[], None).await;
+    let (envelope, result) = execute_bash(
+        "false",
+        Duration::from_secs(5),
+        None,
+        None,
+        None,
+        &[],
+        None,
+        "",
+    )
+    .await;
     assert_eq!(result, "(no output)");
     assert_eq!(envelope.exit_code, 1);
 }
@@ -993,6 +1015,7 @@ async fn execute_bash_command_not_found() {
         None,
         &[],
         None,
+        "",
     )
     .await;
     assert!(result.contains("[stderr]") || result.contains("[error]"));
@@ -1143,6 +1166,7 @@ async fn cancel_token_kills_child_process() {
         None,
         &[],
         None,
+        "",
     )
     .await;
     assert_eq!(envelope.exit_code, 130);
@@ -1160,6 +1184,7 @@ async fn cancel_token_none_does_not_cancel() {
         None,
         &[],
         None,
+        "",
     )
     .await;
     assert_eq!(envelope.exit_code, 0);
@@ -1186,6 +1211,7 @@ async fn cancel_kills_child_process_group() {
         None,
         &[],
         None,
+        "",
     )
     .await;
     assert_eq!(envelope.exit_code, 130);
@@ -1224,6 +1250,8 @@ async fn execute_tool_call_valid_command() {
             .collect(),
         caller_id: None,
         context: None,
+
+        tool_call_id: String::new(),
     };
     let result = executor.execute_tool_call(&call).await.unwrap().unwrap();
     assert!(result.summary.contains("hi"));
@@ -1237,6 +1265,8 @@ async fn execute_tool_call_missing_command_returns_invalid_params() {
         params: serde_json::Map::new(),
         caller_id: None,
         context: None,
+
+        tool_call_id: String::new(),
     };
     let result = executor.execute_tool_call(&call).await;
     assert!(matches!(result, Err(ToolError::InvalidParams { .. })));
@@ -1252,6 +1282,8 @@ async fn execute_tool_call_empty_command_returns_none() {
             .collect(),
         caller_id: None,
         context: None,
+
+        tool_call_id: String::new(),
     };
     let result = executor.execute_tool_call(&call).await.unwrap();
     assert!(result.is_none());
@@ -1678,6 +1710,7 @@ async fn env_blocklist_strips_sensitive_vars() {
         None,
         &blocklist,
         None,
+        "",
     )
     .await;
     unsafe { std::env::remove_var("ZEPH_SECRET_TEST_VAR") };
@@ -1701,6 +1734,7 @@ async fn env_blocklist_preserves_safe_vars() {
         None,
         &blocklist,
         None,
+        "",
     )
     .await;
     assert_eq!(envelope.exit_code, 0);
@@ -1725,6 +1759,7 @@ async fn env_blocklist_extra_env_still_injected() {
         Some(&extra),
         &blocklist,
         None,
+        "",
     )
     .await;
     assert_eq!(envelope.exit_code, 0);
@@ -1751,6 +1786,7 @@ async fn env_blocklist_multiple_prefixes() {
         None,
         &blocklist,
         None,
+        "",
     )
     .await;
     unsafe {
@@ -1781,6 +1817,7 @@ async fn empty_env_blocklist_passes_all_vars() {
         None,
         &[],
         None,
+        "",
     )
     .await;
     unsafe { std::env::remove_var("ZEPH_EMPTY_BLOCKLIST_TEST") };
@@ -2332,6 +2369,7 @@ async fn shell_output_envelope_separates_streams() {
         None,
         &[],
         None,
+        "",
     )
     .await;
     assert!(
@@ -2392,6 +2430,7 @@ async fn shell_output_envelope_nonzero_exit_code() {
         None,
         &[],
         None,
+        "",
     )
     .await;
     assert_eq!(
@@ -2548,6 +2587,8 @@ async fn execute_tool_call_with_background_true() {
         .collect(),
         caller_id: None,
         context: None,
+
+        tool_call_id: String::new(),
     };
     let result = executor.execute_tool_call(&call).await.unwrap().unwrap();
     assert!(
@@ -3094,6 +3135,8 @@ mod resolve_context {
             },
             caller_id: None,
             context: Some(ctx),
+
+            tool_call_id: String::new(),
         };
         let output = executor.execute_tool_call(&call).await.unwrap().unwrap();
         assert!(
@@ -3125,6 +3168,8 @@ mod resolve_context {
             },
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let output = executor.execute_tool_call(&call).await.unwrap().unwrap();
         let expected = std::env::current_dir().unwrap();

--- a/crates/zeph-tools/src/tool_filter.rs
+++ b/crates/zeph-tools/src/tool_filter.rs
@@ -120,6 +120,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = filter.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());
@@ -133,6 +135,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = filter.execute_tool_call(&call).await.unwrap();
         assert!(result.is_some());

--- a/crates/zeph-tools/src/trust_gate.rs
+++ b/crates/zeph-tools/src/trust_gate.rs
@@ -296,6 +296,8 @@ mod tests {
             params: serde_json::Map::new(),
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         }
     }
 
@@ -307,6 +309,8 @@ mod tests {
             params,
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         }
     }
 
@@ -542,6 +546,8 @@ mod tests {
             params,
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         };
         let result = gate.execute_tool_call(&call).await;
         assert!(

--- a/crates/zeph-tools/src/utility.rs
+++ b/crates/zeph-tools/src/utility.rs
@@ -318,6 +318,8 @@ mod tests {
             },
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         }
     }
 

--- a/crates/zeph-tui/src/app/events.rs
+++ b/crates/zeph-tui/src/app/events.rs
@@ -324,3 +324,107 @@ impl App {
         self.confirm_state.as_ref()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::mpsc;
+
+    use crate::event::AgentEvent;
+    use crate::types::MessageRole;
+
+    use super::super::{App, ChatMessage};
+
+    fn make_app() -> App {
+        let (user_tx, user_rx) = mpsc::channel(16);
+        let (_, agent_rx) = mpsc::channel(16);
+        let mut app = App::new(user_tx, agent_rx);
+        let _ = user_rx;
+        app.sessions.current_mut().messages.clear();
+        app
+    }
+
+    /// Push a streaming Tool message with a specific tool_call_id directly onto the session.
+    fn push_tool_msg(app: &mut App, id: &str) {
+        let msg = ChatMessage::new(MessageRole::Tool, format!("$ cmd_{id}\n"))
+            .streaming()
+            .with_tool_call_id(id.to_owned());
+        app.sessions.current_mut().messages.push(msg);
+    }
+
+    #[test]
+    fn tool_output_chunk_routes_by_id_out_of_order() {
+        let mut app = make_app();
+        push_tool_msg(&mut app, "a");
+        push_tool_msg(&mut app, "b");
+        push_tool_msg(&mut app, "c");
+
+        // Deliver chunks out of order: c, a, b, a, c
+        for (id, chunk) in [
+            ("c", "c1"),
+            ("a", "a1"),
+            ("b", "b1"),
+            ("a", "a2"),
+            ("c", "c2"),
+        ] {
+            app.handle_agent_event(AgentEvent::ToolOutputChunk {
+                tool_name: "bash".into(),
+                command: String::new(),
+                chunk: chunk.to_owned(),
+                tool_call_id: id.to_owned(),
+            });
+        }
+
+        let msgs = app.messages();
+        assert_eq!(msgs.len(), 3);
+        // Message order: a=0, b=1, c=2
+        assert_eq!(msgs[0].content, "$ cmd_a\na1a2");
+        assert_eq!(msgs[1].content, "$ cmd_b\nb1");
+        assert_eq!(msgs[2].content, "$ cmd_c\nc1c2");
+    }
+
+    #[test]
+    fn tool_output_chunk_with_unknown_id_is_dropped() {
+        let mut app = make_app();
+        push_tool_msg(&mut app, "known");
+
+        // Chunk for an id that has no matching message — must be silently dropped.
+        app.handle_agent_event(AgentEvent::ToolOutputChunk {
+            tool_name: "bash".into(),
+            command: String::new(),
+            chunk: "should-not-appear".to_owned(),
+            tool_call_id: "unknown-xyz".to_owned(),
+        });
+
+        // The known message must be unchanged.
+        assert_eq!(app.messages().len(), 1);
+        assert_eq!(app.messages()[0].content, "$ cmd_known\n");
+    }
+
+    #[test]
+    fn tool_output_finalizes_correct_message_by_id() {
+        let mut app = make_app();
+        push_tool_msg(&mut app, "t1");
+        push_tool_msg(&mut app, "t2");
+
+        // Finalize t1 with ToolOutput.
+        app.handle_agent_event(AgentEvent::ToolOutput {
+            tool_name: "bash".into(),
+            command: "$ cmd_t1\n".into(),
+            output: "final-output-t1".to_owned(),
+            success: true,
+            diff: None,
+            filter_stats: None,
+            kept_lines: None,
+            tool_call_id: "t1".to_owned(),
+        });
+
+        let msgs = app.messages();
+        assert_eq!(msgs.len(), 2);
+        // t1 must be finalized (not streaming) with the canonical output.
+        assert!(!msgs[0].streaming);
+        assert!(msgs[0].content.contains("final-output-t1"));
+        // t2 must still be streaming and unchanged.
+        assert!(msgs[1].streaming);
+        assert_eq!(msgs[1].content, "$ cmd_t2\n");
+    }
+}

--- a/crates/zeph-tui/src/app/events.rs
+++ b/crates/zeph-tui/src/app/events.rs
@@ -115,24 +115,47 @@ impl App {
                     if text.is_empty() { None } else { Some(text) };
                 self.auto_scroll();
             }
-            AgentEvent::ToolStart { tool_name, command } => {
+            AgentEvent::ToolStart {
+                tool_name,
+                command,
+                tool_call_id,
+            } => {
                 self.sessions.current_mut().status_label = None;
                 self.sessions.current_mut().messages.push(
                     ChatMessage::new(MessageRole::Tool, format!("$ {command}\n"))
                         .streaming()
-                        .with_tool(tool_name),
+                        .with_tool(tool_name)
+                        .with_tool_call_id(tool_call_id),
                 );
                 self.trim_messages();
                 self.auto_scroll();
             }
-            AgentEvent::ToolOutputChunk { chunk, .. } => {
-                if let Some(pos) = self
-                    .sessions
-                    .current_mut()
-                    .messages
-                    .iter()
-                    .rposition(|m| m.role == MessageRole::Tool && m.streaming)
-                {
+            AgentEvent::ToolOutputChunk {
+                chunk,
+                tool_call_id,
+                ..
+            } => {
+                let pos = if tool_call_id.is_empty() {
+                    // Legacy path: no tool_call_id, fall back to rposition.
+                    self.sessions
+                        .current()
+                        .messages
+                        .iter()
+                        .rposition(|m| m.role == MessageRole::Tool && m.streaming)
+                } else {
+                    let found =
+                        self.sessions.current().messages.iter().rposition(|m| {
+                            m.tool_call_id.as_deref() == Some(tool_call_id.as_str())
+                        });
+                    if found.is_none() {
+                        tracing::warn!(
+                            %tool_call_id,
+                            "ToolOutputChunk: no message with matching tool_call_id — dropping chunk"
+                        );
+                    }
+                    found
+                };
+                if let Some(pos) = pos {
                     self.sessions.current_mut().messages[pos]
                         .content
                         .push_str(&chunk);
@@ -146,9 +169,17 @@ impl App {
                 diff,
                 filter_stats,
                 kept_lines,
+                tool_call_id,
                 ..
             } => {
-                self.handle_tool_output_event(tool_name, output, diff, filter_stats, kept_lines);
+                self.handle_tool_output_event(
+                    tool_name,
+                    output,
+                    diff,
+                    filter_stats,
+                    kept_lines,
+                    &tool_call_id,
+                );
             }
             AgentEvent::ConfirmRequest {
                 prompt,
@@ -212,6 +243,7 @@ impl App {
         diff: Option<zeph_core::DiffData>,
         filter_stats: Option<String>,
         kept_lines: Option<Vec<usize>>,
+        tool_call_id: &str,
     ) {
         debug!(
             %tool_name,
@@ -220,13 +252,30 @@ impl App {
             output_len = output.len(),
             "TUI ToolOutput event received"
         );
-        if let Some(pos) = self
-            .sessions
-            .current_mut()
-            .messages
-            .iter()
-            .rposition(|m| m.role == MessageRole::Tool && m.streaming)
-        {
+        // Locate the streaming tool message: prefer id-based lookup, fall back to rposition
+        // for legacy paths where tool_call_id is empty.
+        let pos = if tool_call_id.is_empty() {
+            self.sessions
+                .current()
+                .messages
+                .iter()
+                .rposition(|m| m.role == MessageRole::Tool && m.streaming)
+        } else {
+            let found = self
+                .sessions
+                .current()
+                .messages
+                .iter()
+                .rposition(|m| m.tool_call_id.as_deref() == Some(tool_call_id));
+            if found.is_none() {
+                tracing::warn!(
+                    tool_call_id,
+                    "ToolOutput: no message with matching tool_call_id — skipping finalization"
+                );
+            }
+            found
+        };
+        if let Some(pos) = pos {
             // Finalize existing streaming tool message (shell or native path with ToolStart).
             // Replace content after the header line ("$ cmd\n") with the canonical body_display
             // from ToolOutputEvent. Streaming chunks (Path B) may already occupy that space;

--- a/crates/zeph-tui/src/app/events.rs
+++ b/crates/zeph-tui/src/app/events.rs
@@ -343,7 +343,7 @@ mod tests {
         app
     }
 
-    /// Push a streaming Tool message with a specific tool_call_id directly onto the session.
+    /// Push a streaming Tool message with a specific `tool_call_id` directly onto the session.
     fn push_tool_msg(app: &mut App, id: &str) {
         let msg = ChatMessage::new(MessageRole::Tool, format!("$ cmd_{id}\n"))
             .streaming()

--- a/crates/zeph-tui/src/app/mod.rs
+++ b/crates/zeph-tui/src/app/mod.rs
@@ -1955,6 +1955,7 @@ mod tests {
             diff: Some(diff),
             filter_stats: None,
             kept_lines: None,
+            tool_call_id: String::new(),
         });
 
         assert_eq!(app.messages().len(), 1);
@@ -1975,6 +1976,7 @@ mod tests {
             diff: None,
             filter_stats: None,
             kept_lines: None,
+            tool_call_id: String::new(),
         });
 
         // No prior ToolStart and no diff/filter_stats: nothing to display.
@@ -3276,6 +3278,7 @@ mod tests {
         app.handle_agent_event(AgentEvent::ToolStart {
             tool_name: "bash".into(),
             command: "ls -la".into(),
+            tool_call_id: String::new(),
         });
         // Path C: ToolOutput arrives with no prior chunks.
         app.handle_agent_event(AgentEvent::ToolOutput {
@@ -3286,6 +3289,7 @@ mod tests {
             diff: None,
             filter_stats: None,
             kept_lines: None,
+            tool_call_id: String::new(),
         });
 
         assert_eq!(app.messages().len(), 1);
@@ -3301,12 +3305,14 @@ mod tests {
         app.handle_agent_event(AgentEvent::ToolStart {
             tool_name: "bash".into(),
             command: "echo hello".into(),
+            tool_call_id: String::new(),
         });
         // Path B: streaming chunks arrive.
         app.handle_agent_event(AgentEvent::ToolOutputChunk {
             tool_name: "bash".into(),
             command: "echo hello".into(),
             chunk: "hello\n".into(),
+            tool_call_id: String::new(),
         });
         // Path C: ToolOutput with canonical body_display (same content as chunks).
         app.handle_agent_event(AgentEvent::ToolOutput {
@@ -3317,6 +3323,7 @@ mod tests {
             diff: None,
             filter_stats: None,
             kept_lines: None,
+            tool_call_id: String::new(),
         });
 
         assert_eq!(app.messages().len(), 1);

--- a/crates/zeph-tui/src/channel.rs
+++ b/crates/zeph-tui/src/channel.rs
@@ -536,6 +536,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn send_tool_start_forwards_tool_call_id_value() {
+        use zeph_core::channel::ToolStartEvent;
+        let (mut ch, _user_tx, mut agent_rx) = make_channel();
+        ch.send_tool_start(ToolStartEvent {
+            tool_name: "bash".into(),
+            tool_call_id: "uuid-abc-123".into(),
+            params: Some(serde_json::json!({"command": "echo hi"})),
+            parent_tool_use_id: None,
+            started_at: std::time::Instant::now(),
+            speculative: false,
+            sandbox_profile: None,
+        })
+        .await
+        .unwrap();
+        let evt = agent_rx.recv().await.unwrap();
+        match evt {
+            AgentEvent::ToolStart { tool_call_id, .. } => {
+                assert_eq!(tool_call_id, "uuid-abc-123");
+            }
+            other => panic!("expected ToolStart, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
     async fn send_tool_output_bundles_diff_atomically() {
         use zeph_core::channel::ToolOutputEvent;
         let (mut ch, _user_tx, mut agent_rx) = make_channel();

--- a/crates/zeph-tui/src/channel.rs
+++ b/crates/zeph-tui/src/channel.rs
@@ -233,6 +233,7 @@ impl Channel for TuiChannel {
         let _ = self.agent_event_tx.try_send(AgentEvent::ToolStart {
             tool_name: event.tool_name,
             command,
+            tool_call_id: event.tool_call_id,
         });
         Ok(())
     }
@@ -254,6 +255,7 @@ impl Channel for TuiChannel {
             diff: event.diff,
             filter_stats: event.filter_stats,
             kept_lines: event.kept_lines,
+            tool_call_id: event.tool_call_id,
         };
         match tokio::time::timeout(
             std::time::Duration::from_millis(100),
@@ -504,7 +506,7 @@ mod tests {
         .unwrap();
         let evt = agent_rx.recv().await.unwrap();
         assert!(
-            matches!(evt, AgentEvent::ToolStart { ref tool_name, ref command }
+            matches!(evt, AgentEvent::ToolStart { ref tool_name, ref command, .. }
                 if tool_name == "bash" && command == "ls -la"),
             "expected ToolStart with command from params"
         );
@@ -527,7 +529,7 @@ mod tests {
         .unwrap();
         let evt = agent_rx.recv().await.unwrap();
         assert!(
-            matches!(evt, AgentEvent::ToolStart { ref tool_name, ref command }
+            matches!(evt, AgentEvent::ToolStart { ref tool_name, ref command, .. }
                 if tool_name == "memory_search" && command == "memory_search"),
             "expected ToolStart with tool_name as fallback command"
         );

--- a/crates/zeph-tui/src/event.rs
+++ b/crates/zeph-tui/src/event.rs
@@ -154,6 +154,8 @@ pub enum AgentEvent {
         tool_name: zeph_common::ToolName,
         /// The primary command or argument string shown in the status bar.
         command: String,
+        /// Opaque tool call ID used to correlate streaming chunks with this call.
+        tool_call_id: String,
     },
     /// An incremental output chunk from a long-running tool (e.g. streaming shell output).
     ToolOutputChunk {
@@ -163,6 +165,8 @@ pub enum AgentEvent {
         command: String,
         /// The chunk text to append.
         chunk: String,
+        /// Opaque tool call ID matching the corresponding [`AgentEvent::ToolStart`].
+        tool_call_id: String,
     },
     /// Final tool output, replacing any in-progress chunks for this call.
     ToolOutput {
@@ -180,6 +184,8 @@ pub enum AgentEvent {
         filter_stats: Option<String>,
         /// Indices of lines retained by the filter.
         kept_lines: Option<Vec<usize>>,
+        /// Opaque tool call ID matching the corresponding [`AgentEvent::ToolStart`].
+        tool_call_id: String,
     },
     /// The agent requests a boolean confirmation from the user.
     ConfirmRequest {

--- a/crates/zeph-tui/src/types.rs
+++ b/crates/zeph-tui/src/types.rs
@@ -106,6 +106,10 @@ pub struct ChatMessage {
     /// from a paste. `Some(n)` (n >= 2) enables collapsible display in the
     /// chat renderer; `None` means normal display.
     pub paste_line_count: Option<usize>,
+    /// Opaque tool call ID. `Some` for [`MessageRole::Tool`] messages; `None` otherwise.
+    /// Used to route [`crate::event::AgentEvent::ToolOutputChunk`] to the correct message
+    /// when multiple tools execute concurrently.
+    pub tool_call_id: Option<String>,
 }
 
 impl ChatMessage {
@@ -131,6 +135,7 @@ impl ChatMessage {
             kept_lines: None,
             timestamp: format_local_time(),
             paste_line_count: None,
+            tool_call_id: None,
         }
     }
 
@@ -167,6 +172,26 @@ impl ChatMessage {
     #[must_use]
     pub fn with_tool(mut self, name: zeph_common::ToolName) -> Self {
         self.tool_name = Some(name);
+        self
+    }
+
+    /// Set the tool call ID for this message.
+    ///
+    /// Used to correlate streaming [`crate::event::AgentEvent::ToolOutputChunk`] events
+    /// with their originating tool call when multiple tools execute concurrently.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_tui::{ChatMessage, MessageRole};
+    ///
+    /// let msg = ChatMessage::new(MessageRole::Tool, "")
+    ///     .with_tool_call_id("tc-1".to_string());
+    /// assert_eq!(msg.tool_call_id.as_deref(), Some("tc-1"));
+    /// ```
+    #[must_use]
+    pub fn with_tool_call_id(mut self, id: String) -> Self {
+        self.tool_call_id = Some(id);
         self
     }
 }

--- a/src/scheduler_executor.rs
+++ b/src/scheduler_executor.rs
@@ -460,6 +460,8 @@ impl ToolExecutor for SchedulerExecutor {
                     params,
                     caller_id: None,
                     context: None,
+
+                    tool_call_id: String::new(),
                 };
                 return self.execute_tool_call(&call).await;
             }
@@ -561,6 +563,8 @@ mod tests {
             params,
             caller_id: None,
             context: None,
+
+            tool_call_id: String::new(),
         }
     }
 

--- a/src/tui_bridge.rs
+++ b/src/tui_bridge.rs
@@ -544,6 +544,7 @@ mod tests {
             .unwrap();
         tool_tx
             .send(zeph_tools::ToolEvent::OutputChunk {
+                tool_call_id: String::new(),
                 tool_name: "shell".into(),
                 command: "ls".into(),
                 chunk: "file.txt\n".into(),

--- a/src/tui_bridge.rs
+++ b/src/tui_bridge.rs
@@ -462,10 +462,12 @@ pub(crate) async fn forward_tool_events_to_tui(
                 tool_name,
                 command,
                 chunk,
+                tool_call_id,
             } => zeph_tui::AgentEvent::ToolOutputChunk {
                 tool_name,
                 command,
                 chunk: zeph_tools::strip_ansi(&chunk),
+                tool_call_id,
             },
             zeph_tools::ToolEvent::Rollback {
                 restored_count,


### PR DESCRIPTION
## Summary

Fixes the TUI parallel tool call rendering bug (#3688): tool outputs from concurrent tool calls were being cross-contaminated because `tool_call_id` was dropped at the TUI boundary.

- Thread `tool_call_id` from `ToolCall` → `ShellExecutor` → `ToolEvent::OutputChunk` → `tui_bridge` → all three `AgentEvent` tool variants (`ToolStart`, `ToolOutputChunk`, `ToolOutput`)
- Assign real UUIDs from `tool_call_ids[idx]` to each `ToolCall` before dispatch in `tier_loop.rs` (was `String::new()` — the actual root cause)
- TUI `app/events.rs` uses id-based lookup when `tool_call_id` is non-empty; on miss drops the chunk with `tracing::warn!` (no fallback re-route)
- Legacy empty-id path retains `rposition` fallback for backwards compatibility
- Fix `tui_bridge.rs` test fixture: add missing `tool_call_id` field to `ToolEvent::OutputChunk` construction
- Correct CHANGELOG PR reference (#3692 → #3708)

## Tests

4 new tests added:
- `app/events.rs`: out-of-order chunk routing (3 concurrent tools, interleaved chunks), unknown-id drop, `ToolOutput` id-based finalization
- `channel.rs`: assert forwarded `tool_call_id` value matches source event

476 zeph-tui tests pass, 8950 workspace tests pass.

## Out of scope

- #3686 (tool grouping, `ToolDensity`, two-tier rendering) — separate PR
- `handle_diff_ready` parallel safety — tracked in #3711

Closes #3688