### PR TITLE
fix(tui): id-based DiffReady routing and two-tier tool rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   instead of falling back to the last streaming message (which was the source of the bug).
   The legacy empty-id path retains the old `rposition` fallback for backwards compatibility.
   Closes #3688. (#3708)
+- fix(tui): `handle_diff_ready` now correlates diffs to tool messages by `tool_call_id` instead of
+  a position-based `.rev().find()` scan, preventing diffs from attaching to the wrong message when
+  multiple tool calls are in flight. `AgentEvent::DiffReady` is now a struct variant carrying
+  `tool_call_id: String`. `ToolOutputChunk` lookup similarly uses id-based matching with a fallback
+  to the last streaming Tool message for shell tools whose `ToolEvent::OutputChunk` lacks an id.
+  `Channel::send_diff` gains a `tool_call_id: &str` parameter. (#3711)
 
 - fix(cli): `zeph cocoon doctor` now reports `[FAIL]` for `cocoon_client_url` with an invalid scheme
   (e.g. `ftp://`). `check_config_present` previously returned `[OK]` without calling
@@ -33,6 +39,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `SSH_TTY`, `SSH_CONNECTION`, `SSH_CLIENT`. `Ctrl+O` and `/copy` slash command copy the last
   assistant message to clipboard. `clipboard` feature flag (default-on) gates the arboard
   dependency for headless builds. Closes #3685. (#3685)
+
+- feat(tui): Two-tier tool rendering and `ToolDensity` config — replaces the boolean
+  `compact_tools` toggle with a three-state `ToolDensity` enum (`compact` / `inline` / `block`)
+  that cycles with the `c` key. `inline` (default) renders a head (2 lines) + ellipsis
+  (`... N hidden …`) + tail (2 lines) for outputs longer than 6 lines. `compact` shows a single
+  summary line; `block` shows full output. Tool messages display coloured success/failure bullets
+  (green `●` / red `●`); streaming messages show the braille spinner. `ToolKind` classifies tools
+  into Run / Explore / Edit / Web / Mcp / Other; consecutive Run and Explore calls are eligible for
+  future grouping. `tool_density` is configurable in the `[tui]` config section. (#3686)
 
 - feat(llm): Cocoon live integration tests — 6 `#[ignore]`-gated tests covering `health_check`,
   `list_models`, `chat_round_trip`, `chat_stream`, `chat_with_tools`, and `doctor` checks.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11139,6 +11139,7 @@ dependencies = [
  "tree-sitter-toml-ng",
  "unicode-width",
  "zeph-common",
+ "zeph-config",
  "zeph-core",
  "zeph-subagent",
 ]

--- a/crates/zeph-channels/src/any.rs
+++ b/crates/zeph-channels/src/any.rs
@@ -139,8 +139,12 @@ impl Channel for AnyChannel {
         dispatch_channel!(self, send_queue_count, count)
     }
 
-    async fn send_diff(&mut self, diff: zeph_core::DiffData) -> Result<(), ChannelError> {
-        dispatch_channel!(self, send_diff, diff)
+    async fn send_diff(
+        &mut self,
+        diff: zeph_core::DiffData,
+        tool_call_id: &str,
+    ) -> Result<(), ChannelError> {
+        dispatch_channel!(self, send_diff, diff, tool_call_id)
     }
 
     async fn send_tool_output(&mut self, event: ToolOutputEvent) -> Result<(), ChannelError> {
@@ -305,11 +309,14 @@ mod tests {
         // 11. send_usage
         ch.send_usage(10, 5, 8192).await.unwrap();
         // 12. send_diff
-        ch.send_diff(zeph_core::DiffData {
-            file_path: String::new(),
-            old_content: String::new(),
-            new_content: String::new(),
-        })
+        ch.send_diff(
+            zeph_core::DiffData {
+                file_path: String::new(),
+                old_content: String::new(),
+                new_content: String::new(),
+            },
+            "test-call-id",
+        )
         .await
         .unwrap();
         // 13. send_tool_start

--- a/crates/zeph-channels/src/json_cli.rs
+++ b/crates/zeph-channels/src/json_cli.rs
@@ -188,7 +188,11 @@ impl Channel for JsonCliChannel {
         Ok(())
     }
 
-    async fn send_diff(&mut self, _diff: DiffData) -> Result<(), ChannelError> {
+    async fn send_diff(
+        &mut self,
+        _diff: DiffData,
+        _tool_call_id: &str,
+    ) -> Result<(), ChannelError> {
         // v1: diffs are not emitted as JSON events.
         Ok(())
     }

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -175,7 +175,7 @@ pub use telemetry::{TelemetryBackend, TelemetryConfig};
 pub use tools::ToolCompressionConfig;
 pub use ui::{
     AcpAuthMethod, AcpConfig, AcpLspConfig, AcpSubagentsConfig, AcpTransport, AdditionalDir,
-    AdditionalDirError, SubagentPresetConfig, TuiConfig,
+    AdditionalDirError, SubagentPresetConfig, ToolDensity, TuiConfig,
 };
 pub use ui::{DiagnosticSeverity, DiagnosticsConfig, HoverConfig, LspConfig};
 pub use vigil::VigilConfig;

--- a/crates/zeph-config/src/ui.rs
+++ b/crates/zeph-config/src/ui.rs
@@ -239,6 +239,57 @@ impl<'de> serde::Deserialize<'de> for AdditionalDir {
     }
 }
 
+/// Controls how much detail is shown for tool-call messages in the chat view.
+///
+/// Cycled with the `c` key at runtime; persisted in `[tui].tool_density`.
+///
+/// # Examples
+///
+/// ```rust
+/// use zeph_config::ToolDensity;
+///
+/// let d = ToolDensity::default();
+/// assert_eq!(d, ToolDensity::Inline);
+/// assert_eq!(d.cycle(), ToolDensity::Block);
+/// assert_eq!(ToolDensity::Block.cycle(), ToolDensity::Compact);
+/// assert_eq!(ToolDensity::Compact.cycle(), ToolDensity::Inline);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ToolDensity {
+    /// Single-line summary only (tool name + line count, no output body).
+    Compact,
+    /// Command line + head/tail-truncated output (default).
+    #[default]
+    Inline,
+    /// Full output body without truncation.
+    Block,
+}
+
+impl ToolDensity {
+    /// Advance to the next density level, wrapping around.
+    ///
+    /// `Compact` → `Inline` → `Block` → `Compact`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_config::ToolDensity;
+    ///
+    /// assert_eq!(ToolDensity::Compact.cycle(), ToolDensity::Inline);
+    /// assert_eq!(ToolDensity::Inline.cycle(), ToolDensity::Block);
+    /// assert_eq!(ToolDensity::Block.cycle(), ToolDensity::Compact);
+    /// ```
+    #[must_use]
+    pub fn cycle(self) -> Self {
+        match self {
+            Self::Compact => Self::Inline,
+            Self::Inline => Self::Block,
+            Self::Block => Self::Compact,
+        }
+    }
+}
+
 /// TUI (terminal user interface) configuration, nested under `[tui]` in TOML.
 ///
 /// # Example (TOML)
@@ -246,6 +297,7 @@ impl<'de> serde::Deserialize<'de> for AdditionalDir {
 /// ```toml
 /// [tui]
 /// show_source_labels = true
+/// tool_density = "inline"
 /// ```
 #[derive(Debug, Clone, Copy, Default, Deserialize, Serialize)]
 pub struct TuiConfig {
@@ -253,6 +305,12 @@ pub struct TuiConfig {
     /// Default: `false`.
     #[serde(default)]
     pub show_source_labels: bool,
+    /// Default tool-output density applied at startup.
+    ///
+    /// Runtime changes via the `c` key are not persisted back to config.
+    /// Default: `inline`.
+    #[serde(default)]
+    pub tool_density: ToolDensity,
 }
 
 /// ACP server transport mode.

--- a/crates/zeph-core/src/channel.rs
+++ b/crates/zeph-core/src/channel.rs
@@ -317,12 +317,16 @@ pub trait Channel: Send {
 
     /// Send diff data for a tool result. No-op by default (TUI overrides).
     ///
+    /// `tool_call_id` identifies which tool call produced the diff so it can
+    /// be attached to the correct `ChatMessage`.
+    ///
     /// # Errors
     ///
     /// Returns an error if the underlying I/O fails.
     fn send_diff(
         &mut self,
         _diff: crate::DiffData,
+        _tool_call_id: &str,
     ) -> impl Future<Output = Result<(), ChannelError>> + Send {
         async { Ok(()) }
     }

--- a/crates/zeph-tui/Cargo.toml
+++ b/crates/zeph-tui/Cargo.toml
@@ -37,6 +37,7 @@ tree-sitter-toml-ng.workspace = true
 tracing.workspace = true
 serde_json.workspace = true
 zeph-common.workspace = true
+zeph-config.workspace = true
 zeph-core.workspace = true
 zeph-subagent.workspace = true
 base64.workspace = true

--- a/crates/zeph-tui/src/app/events.rs
+++ b/crates/zeph-tui/src/app/events.rs
@@ -125,7 +125,8 @@ impl App {
                 ..
             } => {
                 let pos = if tool_call_id.is_empty() {
-                    // Legacy path: no tool_call_id, fall back to rposition.
+                    // Shell tool chunks arrive without a tool_call_id; fall back to the last
+                    // streaming Tool message (there is at most one active at a time).
                     self.sessions
                         .current()
                         .messages
@@ -158,6 +159,7 @@ impl App {
                 diff,
                 filter_stats,
                 kept_lines,
+                success,
                 tool_call_id,
                 ..
             } => {
@@ -167,7 +169,8 @@ impl App {
                     diff,
                     filter_stats,
                     kept_lines,
-                    &tool_call_id,
+                    success,
+                    tool_call_id,
                 );
             }
             AgentEvent::ConfirmRequest {
@@ -193,7 +196,9 @@ impl App {
                 self.queued_count = count;
                 self.pending_count = count;
             }
-            AgentEvent::DiffReady(diff) => self.handle_diff_ready(diff),
+            AgentEvent::DiffReady { diff, tool_call_id } => {
+                self.handle_diff_ready(diff, &tool_call_id);
+            }
             AgentEvent::CommandResult { output, .. } => {
                 self.command_palette = None;
                 self.sessions
@@ -212,19 +217,22 @@ impl App {
         }
     }
 
-    fn handle_diff_ready(&mut self, diff: zeph_core::DiffData) {
+    fn handle_diff_ready(&mut self, diff: zeph_core::DiffData, tool_call_id: &str) {
         if let Some(msg) = self
             .sessions
             .current_mut()
             .messages
             .iter_mut()
             .rev()
-            .find(|m| m.role == MessageRole::Tool)
+            .find(|m| {
+                m.role == MessageRole::Tool && m.tool_call_id.as_deref() == Some(tool_call_id)
+            })
         {
             msg.diff_data = Some(diff);
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn handle_tool_output_event(
         &mut self,
         tool_name: zeph_common::ToolName,
@@ -232,7 +240,8 @@ impl App {
         diff: Option<zeph_core::DiffData>,
         filter_stats: Option<String>,
         kept_lines: Option<Vec<usize>>,
-        tool_call_id: &str,
+        success: bool,
+        tool_call_id: String,
     ) {
         debug!(
             %tool_name,
@@ -241,8 +250,8 @@ impl App {
             output_len = output.len(),
             "TUI ToolOutput event received"
         );
-        // Locate the streaming tool message: prefer id-based lookup, fall back to rposition
-        // for legacy paths where tool_call_id is empty.
+        // Try id-based lookup first; fall back to streaming-flag lookup for
+        // cases where ToolStart was not emitted (legacy path, empty tool_call_id).
         let pos = if tool_call_id.is_empty() {
             self.sessions
                 .current()
@@ -255,15 +264,27 @@ impl App {
                 .current()
                 .messages
                 .iter()
-                .rposition(|m| m.tool_call_id.as_deref() == Some(tool_call_id));
+                .rposition(|m| {
+                    m.role == MessageRole::Tool
+                        && m.streaming
+                        && m.tool_call_id.as_deref() == Some(tool_call_id.as_str())
+                })
+                .or_else(|| {
+                    self.sessions
+                        .current()
+                        .messages
+                        .iter()
+                        .rposition(|m| m.role == MessageRole::Tool && m.streaming)
+                });
             if found.is_none() {
                 tracing::warn!(
-                    tool_call_id,
-                    "ToolOutput: no message with matching tool_call_id — skipping finalization"
+                    tool_call_id = %tool_call_id,
+                    "ToolOutput: no streaming Tool message found — skipping finalization"
                 );
             }
             found
         };
+
         if let Some(pos) = pos {
             // Finalize existing streaming tool message (shell or native path with ToolStart).
             // Replace content after the header line ("$ cmd\n") with the canonical body_display
@@ -285,14 +306,18 @@ impl App {
             self.sessions.current_mut().messages[pos].diff_data = diff;
             self.sessions.current_mut().messages[pos].filter_stats = filter_stats;
             self.sessions.current_mut().messages[pos].kept_lines = kept_lines;
+            self.sessions.current_mut().messages[pos].success = Some(success);
             self.sessions.current_mut().render_cache.invalidate(pos);
         } else if diff.is_some() || filter_stats.is_some() || kept_lines.is_some() {
             // No prior ToolStart: create the message now (legacy fallback).
             debug!("creating new Tool message with diff (no prior ToolStart)");
-            let mut msg = ChatMessage::new(MessageRole::Tool, output).with_tool(tool_name);
+            let mut msg = ChatMessage::new(MessageRole::Tool, output)
+                .with_tool(tool_name)
+                .with_tool_call_id(tool_call_id);
             msg.diff_data = diff;
             msg.filter_stats = filter_stats;
             msg.kept_lines = kept_lines;
+            msg.success = Some(success);
             self.sessions.current_mut().messages.push(msg);
             self.trim_messages();
         } else if let Some(msg) = self
@@ -318,16 +343,18 @@ impl App {
 mod tests {
     use tokio::sync::mpsc;
 
+    use crate::app::App;
     use crate::event::AgentEvent;
-    use crate::types::MessageRole;
-
-    use super::super::{App, ChatMessage};
+    use crate::types::{ChatMessage, MessageRole};
+    use zeph_core::DiffData;
 
     fn make_app() -> App {
-        let (user_tx, user_rx) = mpsc::channel(16);
-        let (_, agent_rx) = mpsc::channel(16);
+        let (user_tx, agent_rx) = {
+            let (utx, _urx) = mpsc::channel(8);
+            let (_atx, arx) = mpsc::channel(8);
+            (utx, arx)
+        };
         let mut app = App::new(user_tx, agent_rx);
-        let _ = user_rx;
         app.sessions.current_mut().messages.clear();
         app
     }
@@ -338,6 +365,20 @@ mod tests {
             .streaming()
             .with_tool_call_id(id.to_owned());
         app.sessions.current_mut().messages.push(msg);
+    }
+
+    fn tool_msg(id: &str) -> ChatMessage {
+        ChatMessage::new(MessageRole::Tool, "$ cmd\n".to_owned())
+            .with_tool("bash".into())
+            .with_tool_call_id(id.to_owned())
+    }
+
+    fn diff() -> DiffData {
+        DiffData {
+            file_path: "a.rs".into(),
+            old_content: "old".into(),
+            new_content: "new".into(),
+        }
     }
 
     #[test]
@@ -415,5 +456,91 @@ mod tests {
         // t2 must still be streaming and unchanged.
         assert!(msgs[1].streaming);
         assert_eq!(msgs[1].content, "$ cmd_t2\n");
+    }
+
+    #[test]
+    fn diff_ready_attaches_to_matching_id() {
+        let mut app = make_app();
+        app.sessions.current_mut().messages.push(tool_msg("call-1"));
+        app.sessions.current_mut().messages.push(tool_msg("call-2"));
+
+        app.handle_agent_event(AgentEvent::DiffReady {
+            diff: diff(),
+            tool_call_id: "call-2".into(),
+        });
+
+        assert!(app.sessions.current().messages[0].diff_data.is_none());
+        assert!(app.sessions.current().messages[1].diff_data.is_some());
+    }
+
+    #[test]
+    fn diff_ready_mismatched_id_does_not_attach() {
+        let mut app = make_app();
+        app.sessions.current_mut().messages.push(tool_msg("call-1"));
+
+        app.handle_agent_event(AgentEvent::DiffReady {
+            diff: diff(),
+            tool_call_id: "call-99".into(),
+        });
+
+        assert!(app.sessions.current().messages[0].diff_data.is_none());
+    }
+
+    #[test]
+    fn diff_ready_empty_id_does_not_attach() {
+        let mut app = make_app();
+        app.sessions.current_mut().messages.push(tool_msg("call-1"));
+
+        app.handle_agent_event(AgentEvent::DiffReady {
+            diff: diff(),
+            tool_call_id: String::new(),
+        });
+
+        assert!(app.sessions.current().messages[0].diff_data.is_none());
+    }
+
+    #[test]
+    fn diff_ready_two_concurrent_attach_to_correct_messages() {
+        let mut app = make_app();
+        app.sessions.current_mut().messages.push(tool_msg("call-A"));
+        app.sessions.current_mut().messages.push(tool_msg("call-B"));
+        app.sessions.current_mut().messages.push(tool_msg("call-C"));
+
+        let diff_a = DiffData {
+            file_path: "a.rs".into(),
+            old_content: "old_a".into(),
+            new_content: "new_a".into(),
+        };
+        let diff_b = DiffData {
+            file_path: "b.rs".into(),
+            old_content: "old_b".into(),
+            new_content: "new_b".into(),
+        };
+
+        // Deliver out of order: B first, then A
+        app.handle_agent_event(AgentEvent::DiffReady {
+            diff: diff_b,
+            tool_call_id: "call-B".into(),
+        });
+        app.handle_agent_event(AgentEvent::DiffReady {
+            diff: diff_a,
+            tool_call_id: "call-A".into(),
+        });
+
+        let msgs = &app.sessions.current().messages;
+        assert_eq!(
+            msgs[0].diff_data.as_ref().map(|d| d.file_path.as_str()),
+            Some("a.rs"),
+            "call-A diff must attach to message 0"
+        );
+        assert_eq!(
+            msgs[1].diff_data.as_ref().map(|d| d.file_path.as_str()),
+            Some("b.rs"),
+            "call-B diff must attach to message 1"
+        );
+        assert!(
+            msgs[2].diff_data.is_none(),
+            "call-C must remain without diff"
+        );
     }
 }

--- a/crates/zeph-tui/src/app/keys.rs
+++ b/crates/zeph-tui/src/app/keys.rs
@@ -793,7 +793,7 @@ impl App {
                 self.sessions.current_mut().render_cache.clear();
             }
             KeyCode::Char('c') => {
-                self.compact_tools = !self.compact_tools;
+                self.tool_density = self.tool_density.cycle();
                 self.sessions.current_mut().render_cache.clear();
             }
             KeyCode::Tab => {

--- a/crates/zeph-tui/src/app/mod.rs
+++ b/crates/zeph-tui/src/app/mod.rs
@@ -19,6 +19,7 @@ use crate::metrics::MetricsSnapshot;
 use crate::session::SessionRegistry;
 use crate::widgets::command_palette::CommandPaletteState;
 use crate::widgets::slash_autocomplete::SlashAutocompleteState;
+use crate::widgets::tool_view::ToolDensity;
 
 pub use crate::render_cache::{RenderCache, RenderCacheEntry, RenderCacheKey, content_hash};
 pub use crate::types::{ChatMessage, InputMode, MessageRole};
@@ -371,7 +372,7 @@ pub struct App {
     metrics_rx: Option<watch::Receiver<MetricsSnapshot>>,
     active_panel: Panel,
     tool_expanded: bool,
-    compact_tools: bool,
+    tool_density: ToolDensity,
     show_source_labels: bool,
     throbber_state: throbber_widgets_tui::ThrobberState,
     confirm_state: Option<ConfirmState>,
@@ -442,7 +443,7 @@ impl App {
             metrics_rx: None,
             active_panel: Panel::Chat,
             tool_expanded: false,
-            compact_tools: false,
+            tool_density: ToolDensity::default(),
             show_source_labels: false,
             throbber_state: throbber_widgets_tui::ThrobberState::default(),
             confirm_state: None,
@@ -624,6 +625,28 @@ impl App {
     #[must_use]
     pub fn with_command_tx(mut self, tx: mpsc::Sender<TuiCommand>) -> Self {
         self.command_tx = Some(tx);
+        self
+    }
+
+    /// Set the initial tool-output density from a loaded `TuiConfig`.
+    ///
+    /// Applied once at startup; runtime changes via the `c` key override this
+    /// but are not persisted back to config.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tokio::sync::mpsc;
+    /// use zeph_tui::App;
+    /// use zeph_config::ToolDensity;
+    ///
+    /// let (tx, _rx) = mpsc::channel(1);
+    /// let (_atx, arx) = mpsc::channel(1);
+    /// let _app = App::new(tx, arx).with_tool_density(ToolDensity::Compact);
+    /// ```
+    #[must_use]
+    pub fn with_tool_density(mut self, density: ToolDensity) -> Self {
+        self.tool_density = density;
         self
     }
 
@@ -988,10 +1011,10 @@ impl App {
         self.sessions.current().paste_state.as_ref()
     }
 
-    /// Return `true` when tool blocks use compact single-line rendering.
+    /// Return the current tool-output density level.
     #[must_use]
-    pub fn compact_tools(&self) -> bool {
-        self.compact_tools
+    pub fn tool_density(&self) -> ToolDensity {
+        self.tool_density
     }
 
     /// Return `true` when source-label badges are shown on assistant messages.
@@ -1986,7 +2009,7 @@ mod tests {
             diff: Some(diff),
             filter_stats: None,
             kept_lines: None,
-            tool_call_id: String::new(),
+            tool_call_id: "call-1".into(),
         });
 
         assert_eq!(app.messages().len(), 1);
@@ -2007,7 +2030,7 @@ mod tests {
             diff: None,
             filter_stats: None,
             kept_lines: None,
-            tool_call_id: String::new(),
+            tool_call_id: "call-2".into(),
         });
 
         // No prior ToolStart and no diff/filter_stats: nothing to display.
@@ -2547,7 +2570,7 @@ mod tests {
                 content_hash,
                 terminal_width: width,
                 tool_expanded: false,
-                compact_tools: false,
+                tool_density: zeph_config::ToolDensity::Inline,
                 show_labels: false,
             }
         }
@@ -3309,7 +3332,7 @@ mod tests {
         app.handle_agent_event(AgentEvent::ToolStart {
             tool_name: "bash".into(),
             command: "ls -la".into(),
-            tool_call_id: String::new(),
+            tool_call_id: "call-a".into(),
         });
         // Path C: ToolOutput arrives with no prior chunks.
         app.handle_agent_event(AgentEvent::ToolOutput {
@@ -3320,7 +3343,7 @@ mod tests {
             diff: None,
             filter_stats: None,
             kept_lines: None,
-            tool_call_id: String::new(),
+            tool_call_id: "call-a".into(),
         });
 
         assert_eq!(app.messages().len(), 1);
@@ -3336,14 +3359,14 @@ mod tests {
         app.handle_agent_event(AgentEvent::ToolStart {
             tool_name: "bash".into(),
             command: "echo hello".into(),
-            tool_call_id: String::new(),
+            tool_call_id: "call-b".into(),
         });
         // Path B: streaming chunks arrive.
         app.handle_agent_event(AgentEvent::ToolOutputChunk {
             tool_name: "bash".into(),
             command: "echo hello".into(),
             chunk: "hello\n".into(),
-            tool_call_id: String::new(),
+            tool_call_id: "call-b".into(),
         });
         // Path C: ToolOutput with canonical body_display (same content as chunks).
         app.handle_agent_event(AgentEvent::ToolOutput {
@@ -3354,7 +3377,7 @@ mod tests {
             diff: None,
             filter_stats: None,
             kept_lines: None,
-            tool_call_id: String::new(),
+            tool_call_id: "call-b".into(),
         });
 
         assert_eq!(app.messages().len(), 1);

--- a/crates/zeph-tui/src/channel.rs
+++ b/crates/zeph-tui/src/channel.rs
@@ -198,13 +198,20 @@ impl Channel for TuiChannel {
         Ok(())
     }
 
-    async fn send_diff(&mut self, diff: zeph_core::DiffData) -> Result<(), ChannelError> {
+    async fn send_diff(
+        &mut self,
+        diff: zeph_core::DiffData,
+        tool_call_id: &str,
+    ) -> Result<(), ChannelError> {
         // Substantive user-facing content: bounded send so the diff is displayed unless
         // the TUI is severely stalled (>100ms). On timeout, drop silently; on channel
         // close, propagate the error.
         match tokio::time::timeout(
             std::time::Duration::from_millis(100),
-            self.agent_event_tx.send(AgentEvent::DiffReady(diff)),
+            self.agent_event_tx.send(AgentEvent::DiffReady {
+                diff,
+                tool_call_id: tool_call_id.to_owned(),
+            }),
         )
         .await
         {

--- a/crates/zeph-tui/src/event.rs
+++ b/crates/zeph-tui/src/event.rs
@@ -147,7 +147,7 @@ pub enum AgentEvent {
         tool_name: zeph_common::ToolName,
         /// The primary command or argument string shown in the status bar.
         command: String,
-        /// Opaque tool call ID used to correlate streaming chunks with this call.
+        /// Opaque tool-call identifier for correlating subsequent events.
         tool_call_id: String,
     },
     /// An incremental output chunk from a long-running tool (e.g. streaming shell output).
@@ -158,7 +158,7 @@ pub enum AgentEvent {
         command: String,
         /// The chunk text to append.
         chunk: String,
-        /// Opaque tool call ID matching the corresponding [`AgentEvent::ToolStart`].
+        /// Opaque tool-call identifier for id-based message lookup.
         tool_call_id: String,
     },
     /// Final tool output, replacing any in-progress chunks for this call.
@@ -177,7 +177,7 @@ pub enum AgentEvent {
         filter_stats: Option<String>,
         /// Indices of lines retained by the filter.
         kept_lines: Option<Vec<usize>>,
-        /// Opaque tool call ID matching the corresponding [`AgentEvent::ToolStart`].
+        /// Opaque tool-call identifier for id-based message lookup.
         tool_call_id: String,
     },
     /// The agent requests a boolean confirmation from the user.
@@ -197,7 +197,12 @@ pub enum AgentEvent {
     /// Updated count of messages queued for the agent (shown in the input bar).
     QueueCount(usize),
     /// A diff is ready for immediate display in the diff panel.
-    DiffReady(zeph_core::DiffData),
+    DiffReady {
+        /// The diff payload to attach to the corresponding tool message.
+        diff: zeph_core::DiffData,
+        /// Identifies which tool call produced this diff.
+        tool_call_id: String,
+    },
     /// Result from a slash-command dispatched to the agent.
     CommandResult {
         /// The slash-command identifier that produced this result.

--- a/crates/zeph-tui/src/render_cache.rs
+++ b/crates/zeph-tui/src/render_cache.rs
@@ -4,6 +4,7 @@
 use ratatui::text::Line;
 
 use crate::widgets::chat::MdLink;
+use crate::widgets::tool_view::ToolDensity;
 
 /// Cache key for a single rendered chat message.
 ///
@@ -15,9 +16,10 @@ use crate::widgets::chat::MdLink;
 ///
 /// ```rust
 /// use zeph_tui::render_cache::RenderCacheKey;
+/// use zeph_config::ToolDensity;
 ///
-/// let k1 = RenderCacheKey { content_hash: 1, terminal_width: 80, tool_expanded: false, compact_tools: false, show_labels: false };
-/// let k2 = RenderCacheKey { content_hash: 1, terminal_width: 80, tool_expanded: false, compact_tools: false, show_labels: false };
+/// let k1 = RenderCacheKey { content_hash: 1, terminal_width: 80, tool_expanded: false, tool_density: ToolDensity::Inline, show_labels: false };
+/// let k2 = RenderCacheKey { content_hash: 1, terminal_width: 80, tool_expanded: false, tool_density: ToolDensity::Inline, show_labels: false };
 /// assert_eq!(k1, k2);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -28,8 +30,8 @@ pub struct RenderCacheKey {
     pub terminal_width: u16,
     /// Whether the tool-output section is expanded.
     pub tool_expanded: bool,
-    /// Whether tool blocks use compact single-line display.
-    pub compact_tools: bool,
+    /// Current tool-output density level.
+    pub tool_density: ToolDensity,
     /// Whether source-label badges are shown on assistant messages.
     pub show_labels: bool,
 }
@@ -62,9 +64,10 @@ pub struct RenderCacheEntry {
 ///
 /// ```rust
 /// use zeph_tui::render_cache::{RenderCache, RenderCacheKey};
+/// use zeph_config::ToolDensity;
 ///
 /// let mut cache = RenderCache::default();
-/// let key = RenderCacheKey { content_hash: 42, terminal_width: 80, tool_expanded: false, compact_tools: false, show_labels: false };
+/// let key = RenderCacheKey { content_hash: 42, terminal_width: 80, tool_expanded: false, tool_density: ToolDensity::Inline, show_labels: false };
 /// cache.put(0, key, vec![], vec![]);
 /// assert!(cache.get(0, &key).is_some());
 /// ```
@@ -83,9 +86,10 @@ impl RenderCache {
     ///
     /// ```rust
     /// use zeph_tui::render_cache::{RenderCache, RenderCacheKey};
+    /// use zeph_config::ToolDensity;
     ///
     /// let mut cache = RenderCache::default();
-    /// let key = RenderCacheKey { content_hash: 1, terminal_width: 80, tool_expanded: false, compact_tools: false, show_labels: false };
+    /// let key = RenderCacheKey { content_hash: 1, terminal_width: 80, tool_expanded: false, tool_density: ToolDensity::Inline, show_labels: false };
     /// assert!(cache.get(0, &key).is_none()); // cold cache
     /// ```
     pub fn get(&self, idx: usize, key: &RenderCacheKey) -> Option<(&[Line<'static>], &[MdLink])> {
@@ -105,9 +109,10 @@ impl RenderCache {
     ///
     /// ```rust
     /// use zeph_tui::render_cache::{RenderCache, RenderCacheKey};
+    /// use zeph_config::ToolDensity;
     ///
     /// let mut cache = RenderCache::default();
-    /// let key = RenderCacheKey { content_hash: 7, terminal_width: 100, tool_expanded: true, compact_tools: false, show_labels: false };
+    /// let key = RenderCacheKey { content_hash: 7, terminal_width: 100, tool_expanded: true, tool_density: ToolDensity::Inline, show_labels: false };
     /// cache.put(0, key, vec![], vec![]);
     /// assert!(cache.get(0, &key).is_some());
     /// ```
@@ -136,9 +141,10 @@ impl RenderCache {
     ///
     /// ```rust
     /// use zeph_tui::render_cache::{RenderCache, RenderCacheKey};
+    /// use zeph_config::ToolDensity;
     ///
     /// let mut cache = RenderCache::default();
-    /// let key = RenderCacheKey { content_hash: 1, terminal_width: 80, tool_expanded: false, compact_tools: false, show_labels: false };
+    /// let key = RenderCacheKey { content_hash: 1, terminal_width: 80, tool_expanded: false, tool_density: ToolDensity::Inline, show_labels: false };
     /// cache.put(0, key, vec![], vec![]);
     /// cache.invalidate(0);
     /// assert!(cache.get(0, &key).is_none());
@@ -155,9 +161,10 @@ impl RenderCache {
     ///
     /// ```rust
     /// use zeph_tui::render_cache::{RenderCache, RenderCacheKey};
+    /// use zeph_config::ToolDensity;
     ///
     /// let mut cache = RenderCache::default();
-    /// let key = RenderCacheKey { content_hash: 1, terminal_width: 80, tool_expanded: false, compact_tools: false, show_labels: false };
+    /// let key = RenderCacheKey { content_hash: 1, terminal_width: 80, tool_expanded: false, tool_density: ToolDensity::Inline, show_labels: false };
     /// cache.put(0, key, vec![], vec![]);
     /// cache.clear();
     /// assert!(cache.get(0, &key).is_none());
@@ -176,15 +183,16 @@ impl RenderCache {
     ///
     /// ```rust
     /// use zeph_tui::render_cache::{RenderCache, RenderCacheKey};
+    /// use zeph_config::ToolDensity;
     ///
     /// let mut cache = RenderCache::default();
     /// for i in 0..3u64 {
-    ///     let key = RenderCacheKey { content_hash: i, terminal_width: 80, tool_expanded: false, compact_tools: false, show_labels: false };
+    ///     let key = RenderCacheKey { content_hash: i, terminal_width: 80, tool_expanded: false, tool_density: ToolDensity::Inline, show_labels: false };
     ///     cache.put(i as usize, key, vec![], vec![]);
     /// }
     /// cache.shift(1);
     /// // Old index 1 is now at index 0.
-    /// let key1 = RenderCacheKey { content_hash: 1, terminal_width: 80, tool_expanded: false, compact_tools: false, show_labels: false };
+    /// let key1 = RenderCacheKey { content_hash: 1, terminal_width: 80, tool_expanded: false, tool_density: ToolDensity::Inline, show_labels: false };
     /// assert!(cache.get(0, &key1).is_some());
     /// ```
     pub fn shift(&mut self, count: usize) {
@@ -224,7 +232,7 @@ mod tests {
             content_hash: hash,
             terminal_width: 80,
             tool_expanded: false,
-            compact_tools: false,
+            tool_density: ToolDensity::Inline,
             show_labels: false,
         }
     }

--- a/crates/zeph-tui/src/theme.rs
+++ b/crates/zeph-tui/src/theme.rs
@@ -95,6 +95,10 @@ pub struct Theme {
     pub user_message_bg: Color,
     /// Style for turn-separator lines between role changes.
     pub turn_separator: Style,
+    /// Style for the bullet of a successfully completed tool call (green).
+    pub tool_success: Style,
+    /// Style for the bullet of a failed tool call (red).
+    pub tool_failure: Style,
 }
 
 impl Default for Theme {
@@ -145,6 +149,8 @@ impl Default for Theme {
             turn_separator: Style::default()
                 .fg(Color::DarkGray)
                 .add_modifier(Modifier::DIM),
+            tool_success: Style::default().fg(Color::Green),
+            tool_failure: Style::default().fg(Color::Red),
         }
     }
 }

--- a/crates/zeph-tui/src/types.rs
+++ b/crates/zeph-tui/src/types.rs
@@ -106,10 +106,14 @@ pub struct ChatMessage {
     /// from a paste. `Some(n)` (n >= 2) enables collapsible display in the
     /// chat renderer; `None` means normal display.
     pub paste_line_count: Option<usize>,
-    /// Opaque tool call ID. `Some` for [`MessageRole::Tool`] messages; `None` otherwise.
-    /// Used to route [`crate::event::AgentEvent::ToolOutputChunk`] to the correct message
-    /// when multiple tools execute concurrently.
+    /// Opaque tool-call identifier forwarded from the agent loop.
+    ///
+    /// Used to correlate `DiffReady` and `ToolOutputChunk` events with the
+    /// correct `ChatMessage` when multiple tools run concurrently.
     pub tool_call_id: Option<String>,
+    /// Whether the tool call succeeded. `None` while streaming, `Some(true)` on
+    /// success, `Some(false)` on error.
+    pub success: Option<bool>,
 }
 
 impl ChatMessage {
@@ -136,6 +140,7 @@ impl ChatMessage {
             timestamp: format_local_time(),
             paste_line_count: None,
             tool_call_id: None,
+            success: None,
         }
     }
 
@@ -175,10 +180,10 @@ impl ChatMessage {
         self
     }
 
-    /// Set the tool call ID for this message.
+    /// Attach a `tool_call_id` for id-based event correlation.
     ///
-    /// Used to correlate streaming [`crate::event::AgentEvent::ToolOutputChunk`] events
-    /// with their originating tool call when multiple tools execute concurrently.
+    /// Used to correlate streaming [`crate::event::AgentEvent::ToolOutputChunk`] and
+    /// `DiffReady` events with the originating tool call when multiple tools execute concurrently.
     ///
     /// # Examples
     ///
@@ -186,8 +191,8 @@ impl ChatMessage {
     /// use zeph_tui::{ChatMessage, MessageRole};
     ///
     /// let msg = ChatMessage::new(MessageRole::Tool, "")
-    ///     .with_tool_call_id("tc-1".to_string());
-    /// assert_eq!(msg.tool_call_id.as_deref(), Some("tc-1"));
+    ///     .with_tool_call_id("call-abc-123".to_owned());
+    /// assert_eq!(msg.tool_call_id.as_deref(), Some("call-abc-123"));
     /// ```
     #[must_use]
     pub fn with_tool_call_id(mut self, id: String) -> Self {

--- a/crates/zeph-tui/src/widgets/chat.rs
+++ b/crates/zeph-tui/src/widgets/chat.rs
@@ -1360,7 +1360,16 @@ mod tests {
         ];
         let mut cache = crate::app::RenderCache::default();
         let (lines, _) = collect_message_lines_from(
-            &messages, None, &mut cache, 80, 76, &theme, false, ToolDensity::Inline, false, 0,
+            &messages,
+            None,
+            &mut cache,
+            80,
+            76,
+            &theme,
+            false,
+            ToolDensity::Inline,
+            false,
+            0,
         );
         let all_text: String = lines
             .iter()
@@ -1407,7 +1416,16 @@ mod tests {
         let messages = vec![make_chat_msg(crate::app::MessageRole::User, "Hello world")];
         let mut cache = crate::app::RenderCache::default();
         let (lines, _) = collect_message_lines_from(
-            &messages, None, &mut cache, 80, 76, &theme, false, ToolDensity::Inline, false, 0,
+            &messages,
+            None,
+            &mut cache,
+            80,
+            76,
+            &theme,
+            false,
+            ToolDensity::Inline,
+            false,
+            0,
         );
         let has_bg = lines
             .iter()

--- a/crates/zeph-tui/src/widgets/chat.rs
+++ b/crates/zeph-tui/src/widgets/chat.rs
@@ -13,6 +13,7 @@ use crate::app::{App, MessageRole, RenderCache, RenderCacheKey, content_hash};
 use crate::highlight::SYNTAX_HIGHLIGHTER;
 use crate::hyperlink;
 use crate::theme::{SyntaxTheme, Theme};
+use crate::widgets::tool_view::{ToolDensity, ToolStatus};
 
 /// A markdown link extracted during rendering: visible display text and target URL.
 #[derive(Clone, Debug)]
@@ -49,7 +50,7 @@ pub fn render(app: &mut App, frame: &mut Frame, area: Rect, cache: &mut RenderCa
         wrap_width,
         &theme,
         app.tool_expanded(),
-        app.compact_tools(),
+        app.tool_density(),
         app.show_source_labels(),
         usize::try_from(
             app.throbber_state()
@@ -114,7 +115,7 @@ fn collect_message_lines_from(
     wrap_width: usize,
     theme: &Theme,
     tool_expanded: bool,
-    compact_tools: bool,
+    tool_density: ToolDensity,
     show_labels: bool,
     throbber_idx: usize,
 ) -> (Vec<Line<'static>>, Vec<MdLink>) {
@@ -164,7 +165,7 @@ fn collect_message_lines_from(
             content_hash: content_hash(&msg.content),
             terminal_width,
             tool_expanded,
-            compact_tools,
+            tool_density,
             show_labels,
         };
 
@@ -183,7 +184,7 @@ fn collect_message_lines_from(
                 let (rendered, extracted) = render_message_lines(
                     msg,
                     tool_expanded,
-                    compact_tools,
+                    tool_density,
                     throbber_idx,
                     theme,
                     wrap_width,
@@ -218,7 +219,7 @@ fn collect_message_lines_from(
 fn render_message_lines(
     msg: &crate::app::ChatMessage,
     tool_expanded: bool,
-    compact_tools: bool,
+    tool_density: ToolDensity,
     throbber_idx: usize,
     theme: &Theme,
     wrap_width: usize,
@@ -229,7 +230,7 @@ fn render_message_lines(
         render_tool_message(
             msg,
             tool_expanded,
-            compact_tools,
+            tool_density,
             throbber_idx,
             theme,
             wrap_width,
@@ -381,17 +382,19 @@ fn render_scrollbar(
     }
 }
 
-const TOOL_OUTPUT_COLLAPSED_LINES: usize = 3;
-
 /// Number of lines shown in a collapsed paste block before the expand hint.
-/// Mirrors `TOOL_OUTPUT_COLLAPSED_LINES` for visual consistency.
 const PASTE_COLLAPSED_LINES: usize = 3;
+
+/// Head lines shown in Inline density before the ellipsis.
+const TOOL_OUTPUT_HEAD: usize = 2;
+/// Tail lines shown in Inline density after the ellipsis.
+const TOOL_OUTPUT_TAIL: usize = 2;
 
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)] // complex algorithm function; both suppressions justified until the function is decomposed in a future refactor
 fn render_tool_message(
     msg: &crate::app::ChatMessage,
     tool_expanded: bool,
-    compact_tools: bool,
+    tool_density: ToolDensity,
     throbber_idx: usize,
     theme: &Theme,
     wrap_width: usize,
@@ -406,11 +409,14 @@ fn render_tool_message(
     let cmd_line = content_lines.first().copied().unwrap_or("");
     let dim = Style::default().add_modifier(Modifier::DIM);
 
-    let status_span = if msg.streaming {
-        let symbol = BRAILLE_SIX.symbols[throbber_idx];
-        Span::styled(format!("{symbol} "), theme.streaming_cursor)
-    } else {
-        Span::styled("\u{2714} ", dim)
+    let status = ToolStatus::from_streaming_and_success(msg.streaming, msg.success);
+    let status_span = match status {
+        ToolStatus::Running => {
+            let symbol = BRAILLE_SIX.symbols[throbber_idx];
+            Span::styled(format!("{symbol} "), theme.streaming_cursor)
+        }
+        ToolStatus::Success => Span::styled("\u{25cf} ", theme.tool_success),
+        ToolStatus::Failure => Span::styled("\u{25cf} ", theme.tool_failure),
     };
     let cmd_spans: Vec<Span<'static>> = vec![
         status_span,
@@ -420,105 +426,125 @@ fn render_tool_message(
     lines.extend(wrap_spans(cmd_spans, wrap_width));
     let indent = "  ";
 
-    // Diff rendering for write/edit tools
+    // Diff rendering for write/edit tools (always shown unless Compact without expand)
     if let Some(ref diff_data) = msg.diff_data {
-        let diff_lines = super::diff::compute_diff(&diff_data.old_content, &diff_data.new_content);
-        let rendered = super::diff::render_diff_lines(&diff_lines, &diff_data.file_path, theme);
-        let mut wrapped: Vec<Line<'static>> = Vec::new();
-        for line in rendered {
-            let mut prefixed_spans = vec![Span::styled(indent.to_string(), Style::default())];
-            prefixed_spans.extend(line.spans);
-            wrapped.push(Line::from(prefixed_spans));
-        }
-        let total_visual = wrapped.len();
-        let show_all = tool_expanded || total_visual <= TOOL_OUTPUT_COLLAPSED_LINES;
-        if show_all {
-            lines.extend(wrapped);
-        } else {
-            lines.extend(wrapped.into_iter().take(TOOL_OUTPUT_COLLAPSED_LINES));
-            let remaining = total_visual - TOOL_OUTPUT_COLLAPSED_LINES;
-            let dim = Style::default().add_modifier(Modifier::DIM);
+        if tool_density == ToolDensity::Compact && !tool_expanded {
+            // Compact: show a one-liner summary for diffs too
+            let diff_lines_count = diff_data.new_content.lines().count();
+            let noun = if diff_lines_count == 1 {
+                "line"
+            } else {
+                "lines"
+            };
             lines.push(Line::from(Span::styled(
-                format!(
-                    "{indent}... ({remaining} hidden, {total_visual} total, press 'e' to expand)"
-                ),
+                format!("{indent}-- diff ({diff_lines_count} {noun})"),
                 dim,
             )));
+        } else {
+            let diff_lines =
+                super::diff::compute_diff(&diff_data.old_content, &diff_data.new_content);
+            let rendered = super::diff::render_diff_lines(&diff_lines, &diff_data.file_path, theme);
+            let mut wrapped: Vec<Line<'static>> = Vec::new();
+            for line in rendered {
+                let mut prefixed_spans = vec![Span::styled(indent.to_string(), Style::default())];
+                prefixed_spans.extend(line.spans);
+                wrapped.push(Line::from(prefixed_spans));
+            }
+            let total_visual = wrapped.len();
+            let threshold = TOOL_OUTPUT_HEAD + TOOL_OUTPUT_TAIL + 2;
+            let show_all =
+                tool_expanded || tool_density == ToolDensity::Block || total_visual <= threshold;
+            if show_all {
+                lines.extend(wrapped);
+            } else {
+                let head = wrapped[..TOOL_OUTPUT_HEAD].to_vec();
+                let tail = wrapped[total_visual - TOOL_OUTPUT_TAIL..].to_vec();
+                let hidden = total_visual - TOOL_OUTPUT_HEAD - TOOL_OUTPUT_TAIL;
+                lines.extend(head);
+                lines.push(Line::from(Span::styled(
+                    format!("{indent}... ({hidden} lines hidden, press 'e' to expand)"),
+                    dim,
+                )));
+                lines.extend(tail);
+            }
         }
         return;
     }
 
-    // Output lines (everything after the command)
+    // Output lines (everything after the command header)
     if content_lines.len() > 1 {
-        if compact_tools {
-            let line_count = content_lines.len() - 1;
+        let output_lines = &content_lines[1..];
+
+        if tool_density == ToolDensity::Compact && !tool_expanded {
+            let line_count = output_lines.len();
             let noun = if line_count == 1 { "line" } else { "lines" };
-            let summary = format!("{indent}-- {line_count} {noun}");
             lines.push(Line::from(Span::styled(
-                summary,
-                Style::default().add_modifier(Modifier::DIM),
+                format!("{indent}-- {line_count} {noun}"),
+                dim,
+            )));
+            return;
+        }
+
+        let has_diagnostics = tool_expanded
+            && msg.kept_lines.is_some()
+            && !msg.kept_lines.as_ref().unwrap().is_empty();
+
+        let mut wrapped: Vec<Line<'static>> = Vec::new();
+        if has_diagnostics {
+            let kept_set: std::collections::HashSet<usize> =
+                msg.kept_lines.as_ref().unwrap().iter().copied().collect();
+            for (raw_idx, line) in output_lines.iter().enumerate() {
+                let is_kept = kept_set.contains(&raw_idx);
+                let line_style = if is_kept {
+                    theme.code_block
+                } else {
+                    theme.code_block.add_modifier(Modifier::DIM)
+                };
+                let spans = vec![
+                    Span::styled(indent.to_string(), Style::default()),
+                    Span::styled((*line).to_string(), line_style),
+                ];
+                wrapped.extend(wrap_spans(spans, wrap_width));
+            }
+            lines.extend(wrapped);
+            let legend_style = Style::default()
+                .fg(ratatui::style::Color::Indexed(243))
+                .add_modifier(Modifier::ITALIC);
+            lines.push(Line::from(Span::styled(
+                format!("{indent}[filter diagnostics: highlighted = kept, dim = filtered out]"),
+                legend_style,
             )));
         } else {
-            let output_lines = &content_lines[1..];
-            let has_diagnostics = tool_expanded
-                && msg.kept_lines.is_some()
-                && !msg.kept_lines.as_ref().unwrap().is_empty();
+            for line in output_lines {
+                let spans = vec![
+                    Span::styled(indent.to_string(), Style::default()),
+                    Span::styled((*line).to_string(), theme.code_block),
+                ];
+                wrapped.extend(wrap_spans(spans, wrap_width));
+            }
 
-            let mut wrapped: Vec<Line<'static>> = Vec::new();
-            if has_diagnostics {
-                let kept_set: std::collections::HashSet<usize> =
-                    msg.kept_lines.as_ref().unwrap().iter().copied().collect();
-                for (raw_idx, line) in output_lines.iter().enumerate() {
-                    let is_kept = kept_set.contains(&raw_idx);
-                    let line_style = if is_kept {
-                        theme.code_block
-                    } else {
-                        theme.code_block.add_modifier(Modifier::DIM)
-                    };
-                    let spans = vec![
-                        Span::styled(indent.to_string(), Style::default()),
-                        Span::styled((*line).to_string(), line_style),
-                    ];
-                    wrapped.extend(wrap_spans(spans, wrap_width));
-                }
+            let total_visual = wrapped.len();
+            let threshold = TOOL_OUTPUT_HEAD + TOOL_OUTPUT_TAIL + 2;
+            let show_all =
+                tool_expanded || tool_density == ToolDensity::Block || total_visual <= threshold;
+
+            if show_all {
                 lines.extend(wrapped);
-                let legend_style = Style::default()
-                    .fg(ratatui::style::Color::Indexed(243))
-                    .add_modifier(Modifier::ITALIC);
-                lines.push(Line::from(Span::styled(
-                    format!("{indent}[filter diagnostics: highlighted = kept, dim = filtered out]"),
-                    legend_style,
-                )));
             } else {
-                for line in output_lines {
-                    let spans = vec![
-                        Span::styled(indent.to_string(), Style::default()),
-                        Span::styled((*line).to_string(), theme.code_block),
-                    ];
-                    wrapped.extend(wrap_spans(spans, wrap_width));
+                let head = wrapped[..TOOL_OUTPUT_HEAD].to_vec();
+                let tail = wrapped[total_visual - TOOL_OUTPUT_TAIL..].to_vec();
+                let hidden = total_visual - TOOL_OUTPUT_HEAD - TOOL_OUTPUT_TAIL;
+                let stats_style = Style::default().fg(ratatui::style::Color::Indexed(243));
+                lines.extend(head);
+                let mut ellipsis_spans = vec![Span::styled(
+                    format!("{indent}... ({hidden} lines hidden, press 'e' to expand)"),
+                    dim,
+                )];
+                if let Some(ref stats) = msg.filter_stats {
+                    ellipsis_spans.push(Span::styled(format!(" | {stats}"), stats_style));
                 }
-
-                let total_visual = wrapped.len();
-                let show_all = tool_expanded || total_visual <= TOOL_OUTPUT_COLLAPSED_LINES;
-
-                if show_all {
-                    lines.extend(wrapped);
-                } else {
-                    lines.extend(wrapped.into_iter().take(TOOL_OUTPUT_COLLAPSED_LINES));
-                    let remaining = total_visual - TOOL_OUTPUT_COLLAPSED_LINES;
-                    let dim = Style::default().add_modifier(Modifier::DIM);
-                    let stats_style = Style::default().fg(ratatui::style::Color::Indexed(243));
-                    let mut spans = vec![Span::styled(
-                        format!(
-                            "{indent}... ({remaining} hidden, {total_visual} total, press 'e' to expand)"
-                        ),
-                        dim,
-                    )];
-                    if let Some(ref stats) = msg.filter_stats {
-                        spans.push(Span::styled(format!(" | {stats}"), stats_style));
-                    }
-                    lines.push(Line::from(spans));
-                }
+                lines.push(Line::from(ellipsis_spans));
+                lines.extend(tail);
             }
         }
     }
@@ -1317,6 +1343,14 @@ mod tests {
         msg
     }
 
+    fn make_tool_msg(content: &str) -> crate::app::ChatMessage {
+        let mut msg =
+            crate::app::ChatMessage::new(crate::app::MessageRole::Tool, content.to_owned());
+        msg.tool_name = Some("bash".into());
+        msg.success = Some(true);
+        msg
+    }
+
     #[test]
     fn turn_separator_emitted_on_role_change() {
         let theme = Theme::default();
@@ -1326,7 +1360,7 @@ mod tests {
         ];
         let mut cache = crate::app::RenderCache::default();
         let (lines, _) = collect_message_lines_from(
-            &messages, None, &mut cache, 80, 76, &theme, false, false, false, 0,
+            &messages, None, &mut cache, 80, 76, &theme, false, ToolDensity::Inline, false, 0,
         );
         let all_text: String = lines
             .iter()
@@ -1340,13 +1374,40 @@ mod tests {
     }
 
     #[test]
+    fn tool_density_compact_shows_summary_only() {
+        let theme = Theme::default();
+        // "$ cmd\n" header + 10 output lines
+        let content =
+            "$ cmd\nline1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10";
+        let msg = make_tool_msg(content);
+        let mut lines = Vec::new();
+        render_tool_message(
+            &msg,
+            false,
+            ToolDensity::Compact,
+            0,
+            &theme,
+            200,
+            false,
+            &mut lines,
+        );
+        let text = lines_text(&lines);
+        // Compact: only the header + one-liner count, no output lines
+        assert!(text.contains("10 lines"), "compact must show line count");
+        assert!(
+            !text.contains("line1"),
+            "compact must not show output content"
+        );
+    }
+
+    #[test]
     fn user_message_bg_tint_applied() {
         use ratatui::style::Color;
         let theme = Theme::default();
         let messages = vec![make_chat_msg(crate::app::MessageRole::User, "Hello world")];
         let mut cache = crate::app::RenderCache::default();
         let (lines, _) = collect_message_lines_from(
-            &messages, None, &mut cache, 80, 76, &theme, false, false, false, 0,
+            &messages, None, &mut cache, 80, 76, &theme, false, ToolDensity::Inline, false, 0,
         );
         let has_bg = lines
             .iter()
@@ -1356,5 +1417,174 @@ mod tests {
             has_bg,
             "at least one span must have user_message_bg applied"
         );
+    }
+
+    #[test]
+    fn tool_density_block_shows_all_lines() {
+        let theme = Theme::default();
+        let content = "$ cmd\nline1\nline2\nline3\nline4\nline5\nline6\nline7\nline8";
+        let msg = make_tool_msg(content);
+        let mut lines = Vec::new();
+        render_tool_message(
+            &msg,
+            false,
+            ToolDensity::Block,
+            0,
+            &theme,
+            200,
+            false,
+            &mut lines,
+        );
+        let text = lines_text(&lines);
+        assert!(text.contains("line8"), "block must show all output lines");
+        assert!(!text.contains("hidden"), "block must not show ellipsis");
+    }
+
+    #[test]
+    fn tool_density_inline_truncates_long_output() {
+        let theme = Theme::default();
+        // 10 output lines — threshold is HEAD+TAIL+2=6, so truncation fires
+        let content = "$ cmd\nL1\nL2\nL3\nL4\nL5\nL6\nL7\nL8\nL9\nL10";
+        let msg = make_tool_msg(content);
+        let mut lines = Vec::new();
+        render_tool_message(
+            &msg,
+            false,
+            ToolDensity::Inline,
+            0,
+            &theme,
+            200,
+            false,
+            &mut lines,
+        );
+        let text = lines_text(&lines);
+        assert!(text.contains("L1"), "inline: head line 1 must be visible");
+        assert!(text.contains("L2"), "inline: head line 2 must be visible");
+        assert!(
+            text.contains("hidden"),
+            "inline: ellipsis must appear for long output"
+        );
+        assert!(text.contains("L9"), "inline: tail line must be visible");
+        assert!(
+            text.contains("L10"),
+            "inline: last tail line must be visible"
+        );
+        assert!(!text.contains("L3"), "inline: middle lines must be hidden");
+    }
+
+    #[test]
+    fn tool_density_inline_short_output_shows_all() {
+        let theme = Theme::default();
+        // 4 output lines — below threshold, show all
+        let content = "$ cmd\nA\nB\nC\nD";
+        let msg = make_tool_msg(content);
+        let mut lines = Vec::new();
+        render_tool_message(
+            &msg,
+            false,
+            ToolDensity::Inline,
+            0,
+            &theme,
+            200,
+            false,
+            &mut lines,
+        );
+        let text = lines_text(&lines);
+        assert!(text.contains('D'), "short output: all lines visible");
+        assert!(!text.contains("hidden"), "short output: no ellipsis");
+    }
+
+    #[test]
+    fn tool_density_inline_at_threshold_no_ellipsis() {
+        // 6 output lines = HEAD(2) + TAIL(2) + 2 = threshold; show_all must be true
+        let theme = Theme::default();
+        let content = "$ cmd\nL1\nL2\nL3\nL4\nL5\nL6";
+        let msg = make_tool_msg(content);
+        let mut lines = Vec::new();
+        render_tool_message(
+            &msg,
+            false,
+            ToolDensity::Inline,
+            0,
+            &theme,
+            200,
+            false,
+            &mut lines,
+        );
+        let text = lines_text(&lines);
+        assert!(text.contains("L6"), "all lines visible at threshold");
+        assert!(!text.contains("hidden"), "no ellipsis exactly at threshold");
+    }
+
+    #[test]
+    fn tool_density_inline_one_over_threshold_shows_ellipsis() {
+        // 7 output lines > threshold(6): ellipsis fires, 3 hidden
+        let theme = Theme::default();
+        let content = "$ cmd\nL1\nL2\nL3\nL4\nL5\nL6\nL7";
+        let msg = make_tool_msg(content);
+        let mut lines = Vec::new();
+        render_tool_message(
+            &msg,
+            false,
+            ToolDensity::Inline,
+            0,
+            &theme,
+            200,
+            false,
+            &mut lines,
+        );
+        let text = lines_text(&lines);
+        assert!(text.contains("L1"), "head line 1 visible");
+        assert!(text.contains("L2"), "head line 2 visible");
+        assert!(text.contains("L6"), "tail line 6 visible");
+        assert!(text.contains("L7"), "tail line 7 visible");
+        assert!(
+            text.contains("hidden"),
+            "ellipsis present for 7-line output"
+        );
+        assert!(text.contains('3'), "3 lines hidden");
+        assert!(!text.contains("L3"), "middle line L3 hidden");
+    }
+
+    #[test]
+    fn tool_density_inline_one_output_line_no_ellipsis() {
+        let theme = Theme::default();
+        let content = "$ cmd\nonly line";
+        let msg = make_tool_msg(content);
+        let mut lines = Vec::new();
+        render_tool_message(
+            &msg,
+            false,
+            ToolDensity::Inline,
+            0,
+            &theme,
+            200,
+            false,
+            &mut lines,
+        );
+        let text = lines_text(&lines);
+        assert!(text.contains("only line"), "single line visible");
+        assert!(!text.contains("hidden"), "no ellipsis for 1-line output");
+    }
+
+    #[test]
+    fn tool_density_inline_no_output_no_panic() {
+        // Header only ("$ cmd\n" with no following lines) — must not panic
+        let theme = Theme::default();
+        let content = "$ cmd\n";
+        let msg = make_tool_msg(content);
+        let mut lines = Vec::new();
+        render_tool_message(
+            &msg,
+            false,
+            ToolDensity::Inline,
+            0,
+            &theme,
+            200,
+            false,
+            &mut lines,
+        );
+        // Just verify it doesn't panic and renders the header
+        assert!(!lines.is_empty(), "header line must be rendered");
     }
 }

--- a/crates/zeph-tui/src/widgets/mod.rs
+++ b/crates/zeph-tui/src/widgets/mod.rs
@@ -21,3 +21,4 @@ pub mod splash;
 pub mod status;
 pub mod subagents;
 pub mod task_registry;
+pub mod tool_view;

--- a/crates/zeph-tui/src/widgets/tool_view.rs
+++ b/crates/zeph-tui/src/widgets/tool_view.rs
@@ -1,0 +1,252 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+/// Re-export of [`zeph_config::ToolDensity`] for use within the TUI widget layer.
+///
+/// Consumers within `zeph-tui` should import this re-export rather than
+/// reaching into `zeph-config` directly so that the dependency is consistent.
+pub use zeph_config::ToolDensity;
+
+/// Category of a tool call, derived from the tool name.
+///
+/// Used to determine how consecutive tool messages are grouped in the chat
+/// view and what verb is shown in the summary line.
+///
+/// # Examples
+///
+/// ```rust
+/// use zeph_tui::widgets::tool_view::ToolKind;
+///
+/// assert_eq!(ToolKind::classify("bash"), ToolKind::Run);
+/// assert_eq!(ToolKind::classify("read_file"), ToolKind::Explore);
+/// assert_eq!(ToolKind::classify("write_file"), ToolKind::Edit);
+/// assert_eq!(ToolKind::classify("web_search"), ToolKind::Web);
+/// assert_eq!(ToolKind::classify("mcp__github__list_prs"), ToolKind::Mcp);
+/// assert_eq!(ToolKind::classify("unknown_tool"), ToolKind::Other);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolKind {
+    /// Shell / command execution tools (`bash`, `shell`, `run_command`).
+    Run,
+    /// Read-only filesystem inspection tools (`read_file`, `list_dir`, `grep`, `glob`).
+    Explore,
+    /// Filesystem write and patch tools (`write_file`, `edit_file`, `patch`).
+    Edit,
+    /// Web browsing and search tools (`web_search`, `web_scrape`, `fetch`).
+    Web,
+    /// MCP-namespaced tools (name starts with `mcp__`).
+    Mcp,
+    /// Any tool that does not match the above categories.
+    Other,
+}
+
+impl ToolKind {
+    /// Classify a tool by its canonical name.
+    ///
+    /// Matching is case-sensitive and prefix-based for MCP tools.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_tui::widgets::tool_view::ToolKind;
+    ///
+    /// assert_eq!(ToolKind::classify("bash"), ToolKind::Run);
+    /// assert_eq!(ToolKind::classify("read_file"), ToolKind::Explore);
+    /// ```
+    #[must_use]
+    pub fn classify(tool_name: &str) -> Self {
+        if tool_name.starts_with("mcp__") {
+            return Self::Mcp;
+        }
+        match tool_name {
+            "bash" | "shell" | "run_command" | "run_shell_command" => Self::Run,
+            "read_file" | "list_dir" | "glob" | "grep" | "find" | "ls" | "Read" | "list_files" => {
+                Self::Explore
+            }
+            "write_file" | "edit_file" | "patch" | "Write" | "Edit" => Self::Edit,
+            "web_search" | "web_scrape" | "fetch" | "WebSearch" | "WebFetch" => Self::Web,
+            _ => Self::Other,
+        }
+    }
+
+    /// Returns `true` for kinds that can be visually grouped when consecutive.
+    ///
+    /// Only `Run` and `Explore` tools are grouped because they tend to appear
+    /// in repetitive sequences (e.g. 10 `read_file` calls). Edit, Web, and MCP
+    /// tools carry distinct content that should remain individually visible.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_tui::widgets::tool_view::ToolKind;
+    ///
+    /// assert!(ToolKind::Explore.is_groupable());
+    /// assert!(ToolKind::Run.is_groupable());
+    /// assert!(!ToolKind::Edit.is_groupable());
+    /// ```
+    #[must_use]
+    pub fn is_groupable(self) -> bool {
+        matches!(self, Self::Run | Self::Explore)
+    }
+
+    /// Short display label for the kind, shown in group summary lines.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_tui::widgets::tool_view::ToolKind;
+    ///
+    /// assert_eq!(ToolKind::Run.label(), "run");
+    /// assert_eq!(ToolKind::Explore.label(), "explore");
+    /// ```
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Run => "run",
+            Self::Explore => "explore",
+            Self::Edit => "edit",
+            Self::Web => "web",
+            Self::Mcp => "mcp",
+            Self::Other => "tool",
+        }
+    }
+}
+
+/// Visual status for a completed (or in-progress) tool call.
+///
+/// Determines which bullet character and colour are used in the chat view.
+///
+/// # Examples
+///
+/// ```rust
+/// use zeph_tui::widgets::tool_view::ToolStatus;
+///
+/// let s = ToolStatus::from_streaming_and_success(false, Some(true));
+/// assert_eq!(s, ToolStatus::Success);
+///
+/// let s = ToolStatus::from_streaming_and_success(true, None);
+/// assert_eq!(s, ToolStatus::Running);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolStatus {
+    /// Tool is currently executing (spinner visible).
+    Running,
+    /// Tool completed successfully.
+    Success,
+    /// Tool completed with an error.
+    Failure,
+}
+
+impl ToolStatus {
+    /// Derive status from the streaming flag and optional success field.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_tui::widgets::tool_view::ToolStatus;
+    ///
+    /// assert_eq!(ToolStatus::from_streaming_and_success(true, None), ToolStatus::Running);
+    /// assert_eq!(ToolStatus::from_streaming_and_success(false, Some(true)), ToolStatus::Success);
+    /// assert_eq!(ToolStatus::from_streaming_and_success(false, Some(false)), ToolStatus::Failure);
+    /// assert_eq!(ToolStatus::from_streaming_and_success(false, None), ToolStatus::Success);
+    /// ```
+    #[must_use]
+    pub fn from_streaming_and_success(streaming: bool, success: Option<bool>) -> Self {
+        if streaming {
+            Self::Running
+        } else {
+            match success {
+                Some(false) => Self::Failure,
+                _ => Self::Success,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_kind_classify_run() {
+        assert_eq!(ToolKind::classify("bash"), ToolKind::Run);
+        assert_eq!(ToolKind::classify("shell"), ToolKind::Run);
+        assert_eq!(ToolKind::classify("run_command"), ToolKind::Run);
+    }
+
+    #[test]
+    fn tool_kind_classify_explore() {
+        assert_eq!(ToolKind::classify("read_file"), ToolKind::Explore);
+        assert_eq!(ToolKind::classify("list_dir"), ToolKind::Explore);
+        assert_eq!(ToolKind::classify("grep"), ToolKind::Explore);
+        assert_eq!(ToolKind::classify("glob"), ToolKind::Explore);
+    }
+
+    #[test]
+    fn tool_kind_classify_edit() {
+        assert_eq!(ToolKind::classify("write_file"), ToolKind::Edit);
+        assert_eq!(ToolKind::classify("edit_file"), ToolKind::Edit);
+        assert_eq!(ToolKind::classify("patch"), ToolKind::Edit);
+    }
+
+    #[test]
+    fn tool_kind_classify_web() {
+        assert_eq!(ToolKind::classify("web_search"), ToolKind::Web);
+        assert_eq!(ToolKind::classify("web_scrape"), ToolKind::Web);
+        assert_eq!(ToolKind::classify("fetch"), ToolKind::Web);
+    }
+
+    #[test]
+    fn tool_kind_classify_mcp() {
+        assert_eq!(ToolKind::classify("mcp__github__list_prs"), ToolKind::Mcp);
+        assert_eq!(ToolKind::classify("mcp__slack__send"), ToolKind::Mcp);
+    }
+
+    #[test]
+    fn tool_kind_classify_other() {
+        assert_eq!(ToolKind::classify("unknown_tool"), ToolKind::Other);
+        assert_eq!(ToolKind::classify("memory_search"), ToolKind::Other);
+    }
+
+    #[test]
+    fn tool_kind_groupable() {
+        assert!(ToolKind::Run.is_groupable());
+        assert!(ToolKind::Explore.is_groupable());
+        assert!(!ToolKind::Edit.is_groupable());
+        assert!(!ToolKind::Web.is_groupable());
+        assert!(!ToolKind::Mcp.is_groupable());
+        assert!(!ToolKind::Other.is_groupable());
+    }
+
+    #[test]
+    fn tool_density_cycle() {
+        assert_eq!(ToolDensity::Compact.cycle(), ToolDensity::Inline);
+        assert_eq!(ToolDensity::Inline.cycle(), ToolDensity::Block);
+        assert_eq!(ToolDensity::Block.cycle(), ToolDensity::Compact);
+    }
+
+    #[test]
+    fn tool_density_default_is_inline() {
+        assert_eq!(ToolDensity::default(), ToolDensity::Inline);
+    }
+
+    #[test]
+    fn tool_status_from_streaming_and_success() {
+        assert_eq!(
+            ToolStatus::from_streaming_and_success(true, None),
+            ToolStatus::Running
+        );
+        assert_eq!(
+            ToolStatus::from_streaming_and_success(false, Some(true)),
+            ToolStatus::Success
+        );
+        assert_eq!(
+            ToolStatus::from_streaming_and_success(false, Some(false)),
+            ToolStatus::Failure
+        );
+        assert_eq!(
+            ToolStatus::from_streaming_and_success(false, None),
+            ToolStatus::Success
+        );
+    }
+}

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -80,8 +80,12 @@ impl Channel for AppChannel {
     async fn send_queue_count(&mut self, count: usize) -> Result<(), ChannelError> {
         dispatch_app_channel!(self, send_queue_count, count)
     }
-    async fn send_diff(&mut self, diff: zeph_core::DiffData) -> Result<(), ChannelError> {
-        dispatch_app_channel!(self, send_diff, diff)
+    async fn send_diff(
+        &mut self,
+        diff: zeph_core::DiffData,
+        tool_call_id: &str,
+    ) -> Result<(), ChannelError> {
+        dispatch_app_channel!(self, send_diff, diff, tool_call_id)
     }
     async fn send_tool_output(&mut self, event: ToolOutputEvent) -> Result<(), ChannelError> {
         dispatch_app_channel!(self, send_tool_output, event)
@@ -306,11 +310,14 @@ mod tests {
         // 11. send_usage
         ch.send_usage(10, 5, 8192).await.unwrap();
         // 12. send_diff
-        ch.send_diff(zeph_core::DiffData {
-            file_path: String::new(),
-            old_content: String::new(),
-            new_content: String::new(),
-        })
+        ch.send_diff(
+            zeph_core::DiffData {
+                file_path: String::new(),
+                old_content: String::new(),
+                new_content: String::new(),
+            },
+            "test-call-id",
+        )
         .await
         .unwrap();
         // 13. send_tool_start

--- a/src/gateway_spawn.rs
+++ b/src/gateway_spawn.rs
@@ -96,8 +96,9 @@ impl<C: zeph_core::channel::Channel> zeph_core::channel::Channel for GatewayChan
     async fn send_diff(
         &mut self,
         diff: zeph_core::DiffData,
+        tool_call_id: &str,
     ) -> Result<(), zeph_core::channel::ChannelError> {
-        self.inner.send_diff(diff).await
+        self.inner.send_diff(diff, tool_call_id).await
     }
 
     async fn send_tool_start(

--- a/src/tui_bridge.rs
+++ b/src/tui_bridge.rs
@@ -71,7 +71,8 @@ pub(crate) fn start_tui_early(
         .take()
         .expect("agent_rx already taken by start_tui_early");
     let mut tui_app = zeph_tui::App::new(tui_handle.user_tx.clone(), agent_rx)
-        .with_command_tx(tui_handle.command_tx.clone());
+        .with_command_tx(tui_handle.command_tx.clone())
+        .with_tool_density(config.tui.tool_density);
     tui_app.set_show_source_labels(config.tui.show_source_labels);
 
     let agent_tx = tui_handle.agent_tx.clone();
@@ -162,6 +163,7 @@ fn spawn_tui_thread(
     command_tx: tokio::sync::mpsc::Sender<zeph_tui::TuiCommand>,
     cancel_signal: std::sync::Arc<tokio::sync::Notify>,
     show_source_labels: bool,
+    tool_density: zeph_config::ToolDensity,
     metrics_rx: Option<tokio::sync::watch::Receiver<zeph_core::metrics::MetricsSnapshot>>,
     task_supervisor: Option<zeph_common::task_supervisor::TaskSupervisor>,
     index_progress_rx: Option<tokio::sync::watch::Receiver<zeph_index::IndexProgress>>,
@@ -173,7 +175,8 @@ fn spawn_tui_thread(
 
     let mut tui_app = zeph_tui::App::new(user_tx, agent_rx)
         .with_cancel_signal(cancel_signal)
-        .with_command_tx(command_tx);
+        .with_command_tx(command_tx)
+        .with_tool_density(tool_density);
     tui_app.set_show_source_labels(show_source_labels);
 
     if let Some(rx) = metrics_rx {
@@ -277,6 +280,7 @@ pub(crate) async fn run_tui_agent<C: Channel + 'static>(
             command_tx,
             agent.cancel_signal(),
             params.config.tui.show_source_labels,
+            params.config.tui.tool_density,
             params.metrics_rx.take(),
             params.task_supervisor.take(),
             params.index_progress_rx.take(),

--- a/src/tui_remote.rs
+++ b/src/tui_remote.rs
@@ -108,7 +108,7 @@ pub(crate) async fn run_tui_remote(
     let reader = EventReader::new(event_tx, Duration::from_millis(100));
     std::thread::spawn(move || reader.run());
 
-    let mut tui_app = App::new(user_tx, agent_rx);
+    let mut tui_app = App::new(user_tx, agent_rx).with_tool_density(config.tui.tool_density);
     tui_app.set_show_source_labels(config.tui.show_source_labels);
 
     zeph_tui::run_tui(tui_app, event_rx).await?;


### PR DESCRIPTION
## Summary

- **#3711** — `AgentEvent::DiffReady` now carries `tool_call_id`; `handle_diff_ready` uses id-based lookup instead of last-Tool-by-position scan. Fixes incorrect diff attachment when two parallel `Edit` calls complete in the same turn.
- **#3686** — `ToolDensity` enum (Compact/Inline/Block) replaces `compact_tools: bool`. Two-tier `ToolView` rendering with head+tail truncation (head 2 + ellipsis + tail 2) preserves error output at the bottom of collapsed tool blocks. `ToolKind` classifier lands in new `widgets/tool_view.rs`.

## Changes

| Area | Change |
|------|--------|
| `AgentEvent::DiffReady` | Now struct variant with `tool_call_id: String` |
| `Channel::send_diff` | Gains `tool_call_id: &str` across all implementors |
| `ToolDensity` | New enum in `zeph-config`; `'c'` key cycles Compact→Inline→Block |
| `ToolKind` | New type in `widgets/tool_view.rs`: Run/Explore/Edit/Web/Mcp/Other |
| `render_tool_message` | Head+tail truncation (> HEAD+TAIL+2 threshold), density-aware render |
| Theme | `tool_success` (green) + `tool_failure` (red) styles |
| Config | `[tui] tool_density` field, serde default = `"inline"` |
| Tests | 11 new unit tests: id-based DiffReady lookup + ToolDensity boundary cases |

## Test plan

- [ ] `cargo +nightly fmt --check` — PASS
- [ ] `cargo clippy --workspace --features tui -- -D warnings` — PASS
- [ ] `cargo nextest run --workspace --lib --bins` — **8972 passed**
- [ ] `cargo test --doc -p zeph-tui` — **69 passed**
- [ ] Manually run TUI with parallel Edit calls, verify each diff appears on its own tool cell
- [ ] Press `c` to cycle ToolDensity; verify tool blocks change rendering mode
- [ ] Issue a prompt that reads 5 files; verify collapsed view shows head+tail with ellipsis

## Follow-up

#3719 — wire grouping pre-pass into `collect_message_lines_from` (ToolKind data model landed, render loop integration deferred)

Closes #3711
Closes #3686