### PR TITLE
feat(tui): editor-inline spinner, priority-collapse footer, user message tint (#3687)

### DIFF
--- a/crates/zeph-tui/src/app/draw.rs
+++ b/crates/zeph-tui/src/app/draw.rs
@@ -26,8 +26,19 @@ impl App {
                 self.sessions.current().scroll_offset.min(max_scroll);
         }
         self.draw_side_panel(frame, &layout);
-        widgets::chat::render_activity(self, frame, layout.activity);
-        widgets::input::render(self, frame, layout.input);
+        let spinner_idx = self.throbber_state().index().cast_unsigned();
+        let busy = self.is_agent_busy();
+        let activity_label = self.status_label().map(str::to_owned);
+        let supervisor_label = self.supervisor_activity_label();
+        let effective_label = activity_label.or(supervisor_label);
+        widgets::input::render(
+            self,
+            frame,
+            layout.input,
+            busy,
+            effective_label.as_deref(),
+            spinner_idx,
+        );
         widgets::status::render(self, &self.metrics, frame, layout.status);
 
         if let Some(state) = &self.file_picker_state {

--- a/crates/zeph-tui/src/app/mod.rs
+++ b/crates/zeph-tui/src/app/mod.rs
@@ -667,9 +667,8 @@ impl App {
 
     /// Return a truncated label for active `TaskSupervisor` tasks, or `None` when idle.
     ///
-    /// Used by [`crate::widgets::chat::render_activity`] to show a braille spinner with
-    /// the name of the first active (Running/Restarting) task when no other status
-    /// is being displayed.
+    /// Used by the input widget to show a braille spinner with the name of the first
+    /// active (Running/Restarting) task when no other status is being displayed.
     #[must_use]
     pub fn supervisor_activity_label(&self) -> Option<String> {
         self.task_supervisor.as_ref()?;

--- a/crates/zeph-tui/src/layout.rs
+++ b/crates/zeph-tui/src/layout.rs
@@ -58,8 +58,6 @@ pub struct AppLayout {
     pub resources: Rect,
     /// Sub-agents mini-panel within the side column.
     pub subagents: Rect,
-    /// Single-row activity / status-spinner bar.
-    pub activity: Rect,
     /// Multi-row text input box.
     pub input: Rect,
     /// Single-row bottom status bar (metrics, keybinding hints).
@@ -96,7 +94,6 @@ impl AppLayout {
             .constraints([
                 Constraint::Length(1),
                 Constraint::Min(10),
-                Constraint::Length(1),
                 Constraint::Length(input_height),
                 Constraint::Length(1),
             ])
@@ -111,9 +108,8 @@ impl AppLayout {
                 memory: Rect::default(),
                 resources: Rect::default(),
                 subagents: Rect::default(),
-                activity: outer[2],
-                input: outer[3],
-                status: outer[4],
+                input: outer[2],
+                status: outer[3],
             };
         }
 
@@ -140,9 +136,8 @@ impl AppLayout {
             memory: side_split[1],
             resources: side_split[2],
             subagents: side_split[3],
-            activity: outer[2],
-            input: outer[3],
-            status: outer[4],
+            input: outer[2],
+            status: outer[3],
         }
     }
 }
@@ -307,7 +302,6 @@ mod tests {
 
                 assert_within_bounds(layout.header, area);
                 assert_within_bounds(layout.chat, area);
-                assert_within_bounds(layout.activity, area);
                 assert_within_bounds(layout.input, area);
                 assert_within_bounds(layout.status, area);
 

--- a/crates/zeph-tui/src/theme.rs
+++ b/crates/zeph-tui/src/theme.rs
@@ -91,6 +91,10 @@ pub struct Theme {
     pub diff_header: Style,
     pub link: Style,
     pub table_border: Style,
+    /// Background tint applied to user message lines.
+    pub user_message_bg: Color,
+    /// Style for turn-separator lines between role changes.
+    pub turn_separator: Style,
 }
 
 impl Default for Theme {
@@ -137,6 +141,10 @@ impl Default for Theme {
                 .fg(Color::Cyan)
                 .add_modifier(Modifier::UNDERLINED),
             table_border: Style::default().fg(Color::DarkGray),
+            user_message_bg: Color::Rgb(20, 25, 35),
+            turn_separator: Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::DIM),
         }
     }
 }

--- a/crates/zeph-tui/src/widgets/chat.rs
+++ b/crates/zeph-tui/src/widgets/chat.rs
@@ -7,7 +7,7 @@ use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
-use throbber_widgets_tui::{BRAILLE_SIX, Throbber, WhichUse};
+use throbber_widgets_tui::BRAILLE_SIX;
 
 use crate::app::{App, MessageRole, RenderCache, RenderCacheKey, content_hash};
 use crate::highlight::SYNTAX_HIGHLIGHTER;
@@ -130,6 +130,8 @@ fn collect_message_lines_from(
         lines.push(Line::default());
     }
 
+    let mut prev_role: Option<MessageRole> = None;
+
     for (idx, msg) in messages.iter().enumerate() {
         let accent = match msg.role {
             MessageRole::User => theme.user_message,
@@ -138,9 +140,25 @@ fn collect_message_lines_from(
             MessageRole::System => theme.system_message,
         };
 
-        if idx > 0 {
+        // Emit a turn separator when the role changes (or at the very first message).
+        let role_changed = prev_role != Some(msg.role);
+        if role_changed {
+            if idx > 0 {
+                lines.push(Line::default());
+            }
+            let role_label = match msg.role {
+                MessageRole::User => "You",
+                MessageRole::Assistant => "Agent",
+                MessageRole::Tool => "Tool",
+                MessageRole::System => "System",
+            };
+            let sep_text = format!("── {} {} ──", msg.timestamp, role_label);
+            lines.push(Line::from(Span::styled(sep_text, theme.turn_separator)));
+        } else if idx > 0 {
             lines.push(Line::default());
         }
+
+        prev_role = Some(msg.role);
 
         let cache_key = RenderCacheKey {
             content_hash: content_hash(&msg.content),
@@ -177,62 +195,24 @@ fn collect_message_lines_from(
 
         all_md_links.extend(msg_md_links);
 
-        let time_str = &msg.timestamp;
-        for (i, mut line) in msg_lines.into_iter().enumerate() {
-            if msg.role == MessageRole::User {
+        let is_user = msg.role == MessageRole::User;
+        let user_bg = theme.user_message_bg;
+
+        for mut line in msg_lines {
+            if is_user {
                 line.spans.insert(0, Span::styled("\u{258e} ", accent));
+                // Apply background tint to all spans in user message lines.
+                for span in &mut line.spans {
+                    span.style = span.style.bg(user_bg);
+                }
             } else {
                 line.spans.insert(0, Span::raw("  "));
-            }
-            if i == 0 {
-                let content_width: usize =
-                    line.spans.iter().map(|s| s.content.chars().count()).sum();
-                let pad = wrap_width
-                    .saturating_sub(content_width)
-                    .saturating_sub(time_str.len());
-                if pad > 0 {
-                    line.spans.push(Span::raw(" ".repeat(pad)));
-                    line.spans
-                        .push(Span::styled(time_str.clone(), theme.system_message));
-                }
             }
             lines.push(line);
         }
     }
 
     (lines, all_md_links)
-}
-
-pub fn render_activity(app: &mut App, frame: &mut Frame, area: Rect) {
-    if area.height == 0 || area.width == 0 {
-        return;
-    }
-    let theme = Theme::default();
-
-    // Primary status label (tool running, status update, etc.).
-    if let Some(label) = app.status_label() {
-        let label = format!(" {label}");
-        let throbber = Throbber::default()
-            .label(label)
-            .style(theme.assistant_message)
-            .throbber_style(theme.highlight)
-            .throbber_set(BRAILLE_SIX)
-            .use_type(WhichUse::Spin);
-        frame.render_stateful_widget(throbber, area, app.throbber_state_mut());
-        return;
-    }
-
-    // Fallback: show active TaskSupervisor tasks with a braille spinner.
-    if let Some(task_label) = app.supervisor_activity_label() {
-        let label = format!(" {task_label}");
-        let throbber = Throbber::default()
-            .label(label)
-            .style(theme.assistant_message)
-            .throbber_style(theme.highlight)
-            .throbber_set(BRAILLE_SIX)
-            .use_type(WhichUse::Spin);
-        frame.render_stateful_widget(throbber, area, app.throbber_state_mut());
-    }
 }
 
 fn render_message_lines(
@@ -1328,6 +1308,53 @@ mod tests {
         assert!(
             !text.contains("more lines"),
             "no hint when expanded: {text}"
+        );
+    }
+
+    fn make_chat_msg(role: crate::app::MessageRole, content: &str) -> crate::app::ChatMessage {
+        let mut msg = crate::app::ChatMessage::new(role, content);
+        msg.timestamp = "14:30".to_owned();
+        msg
+    }
+
+    #[test]
+    fn turn_separator_emitted_on_role_change() {
+        let theme = Theme::default();
+        let messages = vec![
+            make_chat_msg(crate::app::MessageRole::User, "Hello"),
+            make_chat_msg(crate::app::MessageRole::Assistant, "Hi"),
+        ];
+        let mut cache = crate::app::RenderCache::default();
+        let (lines, _) = collect_message_lines_from(
+            &messages, None, &mut cache, 80, 76, &theme, false, false, false, 0,
+        );
+        let all_text: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert!(
+            all_text.contains("── "),
+            "turn separator must be present; got: {all_text:?}"
+        );
+    }
+
+    #[test]
+    fn user_message_bg_tint_applied() {
+        use ratatui::style::Color;
+        let theme = Theme::default();
+        let messages = vec![make_chat_msg(crate::app::MessageRole::User, "Hello world")];
+        let mut cache = crate::app::RenderCache::default();
+        let (lines, _) = collect_message_lines_from(
+            &messages, None, &mut cache, 80, 76, &theme, false, false, false, 0,
+        );
+        let has_bg = lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .any(|s| s.style.bg == Some(Color::Rgb(20, 25, 35)));
+        assert!(
+            has_bg,
+            "at least one span must have user_message_bg applied"
         );
     }
 }

--- a/crates/zeph-tui/src/widgets/input.rs
+++ b/crates/zeph-tui/src/widgets/input.rs
@@ -3,14 +3,22 @@
 
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::text::Span;
+use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+use throbber_widgets_tui::BRAILLE_SIX;
 use unicode_width::UnicodeWidthStr;
 
 use crate::app::{App, InputMode};
 use crate::theme::Theme;
 
-pub fn render(app: &App, frame: &mut Frame, area: Rect) {
+pub fn render(
+    app: &App,
+    frame: &mut Frame,
+    area: Rect,
+    busy: bool,
+    activity_label: Option<&str>,
+    spinner_idx: u8,
+) {
     let theme = Theme::default();
 
     let title = match app.input_mode() {
@@ -30,6 +38,18 @@ pub fn render(app: &App, frame: &mut Frame, area: Rect) {
 
     if app.editing_queued() {
         block = block.title_bottom(Span::styled(" [editing queued] ", theme.highlight));
+    }
+
+    if busy {
+        let sym_idx = usize::from(spinner_idx) % BRAILLE_SIX.symbols.len();
+        let symbol = BRAILLE_SIX.symbols[sym_idx];
+        let spinner_span = if let Some(label) = activity_label {
+            Span::styled(format!(" {symbol} {label} "), theme.highlight)
+        } else {
+            Span::styled(format!(" {symbol} "), theme.highlight)
+        };
+        let hint_span = Span::styled("Esc to interrupt ", theme.system_message);
+        block = block.title_bottom(Line::from(vec![spinner_span, hint_span]));
     }
 
     let visible_lines = area.height.saturating_sub(2);
@@ -110,7 +130,7 @@ mod tests {
     fn input_insert_mode() {
         let app = make_app();
         let output = render_to_string(40, 5, |frame, area| {
-            super::render(&app, frame, area);
+            super::render(&app, frame, area, false, None, 0);
         });
         assert_snapshot!(output);
     }
@@ -125,8 +145,53 @@ mod tests {
             ),
         ));
         let output = render_to_string(40, 5, |frame, area| {
-            super::render(&app, frame, area);
+            super::render(&app, frame, area, false, None, 0);
         });
         assert_snapshot!(output);
+    }
+
+    #[test]
+    fn input_busy_shows_spinner() {
+        let app = make_app();
+        let output = render_to_string(60, 5, |frame, area| {
+            super::render(&app, frame, area, true, Some("Thinking..."), 0);
+        });
+        assert!(
+            output.contains("Esc to interrupt"),
+            "spinner hint must appear when busy"
+        );
+    }
+
+    #[test]
+    fn input_idle_width_80() {
+        let app = make_app();
+        let output = render_to_string(80, 5, |frame, area| {
+            super::render(&app, frame, area, false, None, 0);
+        });
+        assert_snapshot!(output);
+    }
+
+    #[test]
+    fn input_busy_width_40() {
+        let app = make_app();
+        let output = render_to_string(40, 5, |frame, area| {
+            super::render(&app, frame, area, true, Some("Thinking..."), 0);
+        });
+        assert!(
+            output.contains("Esc to interrupt"),
+            "spinner hint must appear on narrow terminal"
+        );
+    }
+
+    #[test]
+    fn input_busy_width_80() {
+        let app = make_app();
+        let output = render_to_string(80, 5, |frame, area| {
+            super::render(&app, frame, area, true, Some("Thinking..."), 0);
+        });
+        assert!(
+            output.contains("Esc to interrupt"),
+            "spinner hint must appear on wide terminal"
+        );
     }
 }

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__input__tests__input_idle_width_80.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__input__tests__input_idle_width_80.snap
@@ -1,0 +1,10 @@
+---
+source: crates/zeph-tui/src/widgets/input.rs
+assertion_line: 171
+expression: output
+---
+┌ Input (Esc to cancel) ───────────────────────────────────────────────────────┐
+│Type a message, / for commands, @ to mention                                  │
+│                                                                              │
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__status__tests__status_bar_full_width_120.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__status__tests__status_bar_full_width_120.snap
@@ -1,0 +1,6 @@
+---
+source: crates/zeph-tui/src/widgets/status.rs
+assertion_line: 782
+expression: output
+---
+ [Insert] | claude-sonnet-4-6 | ctx:8% | ? for help | Skills: 1 active / 3 loaded | Tokens: 12.5k | API: 7 | 5m 00s

--- a/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__status__tests__status_bar_snapshot.snap
+++ b/crates/zeph-tui/src/widgets/snapshots/zeph_tui__widgets__status__tests__status_bar_snapshot.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/zeph-tui/src/widgets/status.rs
-assertion_line: 246
+assertion_line: 589
 expression: output
 ---
- [Insert] | Skills: 2 active / 5 loaded | Tokens: 4.2k | qdrant: OK | API: 12 | 2m 15s
+ [Insert] | ? for help | Skills: 2 active / 5 loaded | Tokens: 4.2k | API: 12 | 2m 15s

--- a/crates/zeph-tui/src/widgets/status.rs
+++ b/crates/zeph-tui/src/widgets/status.rs
@@ -13,91 +13,334 @@ use crate::app::{App, InputMode};
 use crate::metrics::MetricsSnapshot;
 use crate::theme::Theme;
 
+/// Priority level for a status bar segment.
+///
+/// Lower numeric value = higher importance. `Critical` segments are never dropped;
+/// lower-priority segments are dropped LIFO (last pushed = first dropped) within
+/// a priority level when the status bar width is exceeded.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum Priority {
+    Critical = 1,
+    High = 2,
+    Medium = 3,
+    Low = 4,
+}
+
+struct Segment {
+    spans: Vec<Span<'static>>,
+    priority: Priority,
+    width: u16,
+}
+
+struct SegmentList {
+    segments: Vec<Segment>,
+}
+
+impl SegmentList {
+    fn new() -> Self {
+        Self {
+            segments: Vec::new(),
+        }
+    }
+
+    fn push(&mut self, priority: Priority, spans: Vec<Span<'static>>) {
+        // TODO: use unicode_width for correct CJK/emoji column count
+        let width: u16 = spans.iter().fold(0u16, |acc, s| {
+            acc.saturating_add(u16::try_from(s.content.chars().count()).unwrap_or(u16::MAX))
+        });
+        self.segments.push(Segment {
+            spans,
+            priority,
+            width,
+        });
+    }
+
+    /// Iteratively drop the last-pushed segment among those with the highest (lowest importance)
+    /// priority level until total fits within `max_width`, never dropping Critical.
+    fn layout(mut self, max_width: u16) -> Vec<Span<'static>> {
+        loop {
+            let total: u16 = self
+                .segments
+                .iter()
+                .fold(0u16, |a, s| a.saturating_add(s.width));
+            if total <= max_width {
+                break;
+            }
+            // Find the worst (highest) priority among non-Critical segments.
+            let worst = self
+                .segments
+                .iter()
+                .filter(|s| s.priority != Priority::Critical)
+                .map(|s| s.priority)
+                .max();
+            let Some(worst_priority) = worst else {
+                // Only Critical segments remain — truncate the last one's spans if needed.
+                break;
+            };
+            // Drop the last-pushed segment at that priority level (LIFO).
+            let drop_idx = self
+                .segments
+                .iter()
+                .enumerate()
+                .rev()
+                .find(|(_, s)| s.priority == worst_priority)
+                .map(|(i, _)| i);
+            if let Some(idx) = drop_idx {
+                self.segments.remove(idx);
+            } else {
+                break;
+            }
+        }
+
+        // If Critical segments still overflow, truncate the last Critical span's content.
+        let total: u16 = self
+            .segments
+            .iter()
+            .fold(0u16, |a, s| a.saturating_add(s.width));
+        if total > max_width && !self.segments.is_empty() {
+            let overflow = total.saturating_sub(max_width) as usize;
+            if let Some(last_span) = self
+                .segments
+                .last_mut()
+                .and_then(|seg| seg.spans.last_mut())
+            {
+                let chars: Vec<char> = last_span.content.chars().collect();
+                let keep = chars.len().saturating_sub(overflow);
+                let truncated: String = chars[..keep].iter().collect();
+                last_span.content = truncated.into();
+            }
+        }
+
+        self.segments
+            .into_iter()
+            .flat_map(Segment::into_spans)
+            .collect()
+    }
+}
+
+impl Segment {
+    fn into_spans(self) -> Vec<Span<'static>> {
+        self.spans
+    }
+}
+
 pub fn render(app: &App, metrics: &MetricsSnapshot, frame: &mut Frame, area: Rect) {
     let theme = Theme::default();
-    let mode = match app.input_mode() {
-        InputMode::Normal => "Normal",
-        InputMode::Insert => "Insert",
-    };
-    let cancel_hint = if app.is_agent_busy() && app.input_mode() == InputMode::Normal {
-        " | [Esc to cancel]"
-    } else {
-        ""
-    };
-    let uptime = format_uptime(metrics.uptime_seconds);
-    let main_text = build_main_text(app, metrics, mode);
-    let mut spans: Vec<Span<'_>> = vec![Span::styled(main_text, theme.status_bar)];
-    append_security_spans(&mut spans, metrics, &theme);
-    append_compaction_segment(&mut spans, metrics, &theme);
-    append_goal_badge(&mut spans, metrics, &theme);
-    let suffix = build_suffix(metrics, cancel_hint, &uptime);
-    spans.push(Span::styled(suffix, theme.status_bar));
+    let list = build_segment_list(app, metrics, &theme);
+    let spans = list.layout(area.width);
     let line = Line::from(spans);
     let paragraph = Paragraph::new(line).style(theme.status_bar);
     frame.render_widget(paragraph, area);
 }
 
-fn build_main_text(app: &App, metrics: &MetricsSnapshot, mode: &str) -> String {
-    let plan_mode_seg = plan_mode_segment(app, metrics);
-    let subagent_view_seg = subagent_view_segment(app);
-    let qdrant_segment = if metrics.qdrant_available {
-        format!(" | {}: OK", metrics.vector_backend)
-    } else {
-        String::new()
+fn build_segment_list(app: &App, metrics: &MetricsSnapshot, theme: &Theme) -> SegmentList {
+    let mode = match app.input_mode() {
+        InputMode::Normal => "Normal",
+        InputMode::Insert => "Insert",
     };
-    let filter_segment = build_filter_segment(metrics);
-    let channel_segment = if metrics.active_channel.is_empty() {
-        String::new()
-    } else {
-        format!(" | ch:{}", metrics.active_channel)
-    };
-    let bg_segment = build_bg_segment(metrics);
-    let cocoon_segment = build_cocoon_segment(metrics);
-    format!(
-        " [{mode}]{model}{channel_segment}{plan_mode_seg}{subagent_view_seg} | Skills: {active} active / {total} loaded | Tokens: {tok}{qdrant_segment}{filter_segment}{bg_segment}{cocoon_segment}",
-        model = if metrics.model_name.is_empty() {
-            String::new()
-        } else {
-            format!(" | {}", metrics.model_name)
-        },
-        active = metrics.active_skills.len(),
-        total = metrics.total_skills,
-        tok = format_tokens(metrics.total_tokens),
-    )
+
+    let mut list = SegmentList::new();
+
+    push_critical_segments(&mut list, metrics, mode, theme);
+    list.push(
+        Priority::High,
+        vec![Span::styled(" | ? for help", theme.status_bar)],
+    );
+    push_medium_segments(&mut list, app, metrics, theme);
+    push_low_segments(&mut list, app, metrics, theme);
+
+    list
 }
 
-fn build_cocoon_segment(metrics: &MetricsSnapshot) -> String {
+fn push_critical_segments(
+    list: &mut SegmentList,
+    metrics: &MetricsSnapshot,
+    mode: &str,
+    theme: &Theme,
+) {
+    list.push(
+        Priority::Critical,
+        vec![Span::styled(format!(" [{mode}]"), theme.status_bar)],
+    );
+    if !metrics.model_name.is_empty() {
+        list.push(
+            Priority::Critical,
+            vec![Span::styled(
+                format!(" | {}", metrics.model_name),
+                theme.status_bar,
+            )],
+        );
+    }
+    if metrics.context_max_tokens > 0 {
+        let pct = context_pct(metrics.context_tokens, metrics.context_max_tokens);
+        list.push(
+            Priority::Critical,
+            vec![Span::styled(format!(" | ctx:{pct}%"), theme.status_bar)],
+        );
+    }
+}
+
+fn push_medium_segments(
+    list: &mut SegmentList,
+    app: &App,
+    metrics: &MetricsSnapshot,
+    theme: &Theme,
+) {
+    let plan_seg = plan_mode_segment(app, metrics);
+    if !plan_seg.is_empty() {
+        list.push(
+            Priority::Medium,
+            vec![Span::styled(plan_seg.to_owned(), theme.status_bar)],
+        );
+    }
+    let subagent_seg = subagent_view_segment(app);
+    if !subagent_seg.is_empty() {
+        list.push(
+            Priority::Medium,
+            vec![Span::styled(subagent_seg, theme.status_bar)],
+        );
+    }
+    if !metrics.active_channel.is_empty() {
+        list.push(
+            Priority::Medium,
+            vec![Span::styled(
+                format!(" | ch:{}", metrics.active_channel),
+                theme.status_bar,
+            )],
+        );
+    }
+    list.push(
+        Priority::Medium,
+        vec![Span::styled(
+            format!(
+                " | Skills: {} active / {} loaded",
+                metrics.active_skills.len(),
+                metrics.total_skills,
+            ),
+            theme.status_bar,
+        )],
+    );
+}
+
+#[allow(clippy::too_many_lines)]
+fn push_low_segments(list: &mut SegmentList, app: &App, metrics: &MetricsSnapshot, theme: &Theme) {
+    list.push(
+        Priority::Low,
+        vec![Span::styled(
+            format!(" | Tokens: {}", format_tokens(metrics.total_tokens)),
+            theme.status_bar,
+        )],
+    );
+    if metrics.cost_spent_cents > 0.0 {
+        list.push(
+            Priority::Low,
+            vec![Span::styled(
+                format!(" | ${:.4}", metrics.cost_spent_cents / 100.0),
+                theme.status_bar,
+            )],
+        );
+    }
+    list.push(
+        Priority::Low,
+        vec![Span::styled(
+            format!(" | API: {}", metrics.api_calls),
+            theme.status_bar,
+        )],
+    );
+    list.push(
+        Priority::Low,
+        vec![Span::styled(
+            format!(" | {}", format_uptime(metrics.uptime_seconds)),
+            theme.status_bar,
+        )],
+    );
+    if !metrics.shell_background_runs.is_empty() {
+        list.push(
+            Priority::Low,
+            vec![Span::styled(
+                format!(" | sh:{}", metrics.shell_background_runs.len()),
+                theme.status_bar,
+            )],
+        );
+    }
+    if let Some(cocoon_seg) = build_cocoon_spans(metrics, theme) {
+        list.push(Priority::Low, cocoon_seg);
+    }
+    if metrics.bg_enrichment_inflight > 0 || metrics.bg_telemetry_inflight > 0 {
+        list.push(
+            Priority::Low,
+            vec![Span::styled(
+                format!(
+                    " | bg: {} enrich, {} telem",
+                    metrics.bg_enrichment_inflight, metrics.bg_telemetry_inflight,
+                ),
+                theme.status_bar,
+            )],
+        );
+    }
+    if metrics.server_compaction_events > 0 {
+        list.push(
+            Priority::Low,
+            vec![
+                Span::styled(" | ", theme.status_bar),
+                Span::styled(
+                    format!("[SC: {}]", metrics.server_compaction_events),
+                    Style::default().fg(Color::Cyan),
+                ),
+            ],
+        );
+    }
+    if let Some(ref snap) = metrics.active_goal {
+        list.push(Priority::Low, build_goal_spans(snap, theme));
+    }
+    if metrics.filter_applications > 0 {
+        list.push(
+            Priority::Low,
+            vec![Span::styled(build_filter_text(metrics), theme.status_bar)],
+        );
+    }
+    let security_spans = build_security_spans(metrics, theme);
+    if !security_spans.is_empty() {
+        list.push(Priority::Low, security_spans);
+    }
+    if app.is_agent_busy() && app.input_mode() == InputMode::Normal {
+        list.push(
+            Priority::Low,
+            vec![Span::styled(" | [Esc to cancel]", theme.status_bar)],
+        );
+    }
+}
+
+fn context_pct(context_tokens: u64, context_max_tokens: u64) -> u64 {
+    #[allow(clippy::cast_precision_loss)]
+    let ratio = (context_tokens as f64 / context_max_tokens as f64 * 100.0).clamp(0.0, 100.0);
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let pct = ratio as u64;
+    pct
+}
+
+fn build_cocoon_spans(metrics: &MetricsSnapshot, theme: &Theme) -> Option<Vec<Span<'static>>> {
     match metrics.cocoon_connected {
-        None => String::new(),
+        None => None,
         Some(true) => {
-            let mut seg = format!(
+            let mut text = format!(
                 " | Cocoon: healthy ({} models, {} workers)",
-                metrics.cocoon_model_count, metrics.cocoon_worker_count
+                metrics.cocoon_model_count, metrics.cocoon_worker_count,
             );
             if let Some(balance) = metrics.cocoon_ton_balance {
-                let _ = write!(seg, ", {balance:.2} TON");
+                let _ = write!(text, ", {balance:.2} TON");
             }
-            seg
+            Some(vec![Span::styled(text, theme.status_bar)])
         }
-        Some(false) => " | Cocoon: sidecar unreachable".to_owned(),
+        Some(false) => Some(vec![Span::styled(
+            " | Cocoon: sidecar unreachable".to_owned(),
+            theme.status_bar,
+        )]),
     }
 }
 
-fn append_compaction_segment(spans: &mut Vec<Span<'_>>, metrics: &MetricsSnapshot, theme: &Theme) {
-    if metrics.server_compaction_events > 0 {
-        spans.push(Span::styled(" | ", theme.status_bar));
-        spans.push(Span::styled(
-            format!("[SC: {}]", metrics.server_compaction_events),
-            Style::default().fg(Color::Cyan),
-        ));
-    }
-}
-
-fn append_goal_badge(spans: &mut Vec<Span<'_>>, metrics: &MetricsSnapshot, theme: &Theme) {
-    use zeph_core::goal::GoalStatus;
-    let Some(ref snap) = metrics.active_goal else {
-        return;
-    };
+fn build_goal_spans(snap: &crate::metrics::GoalSnapshot, theme: &Theme) -> Vec<Span<'static>> {
+    use crate::metrics::GoalStatus;
     let (icon, color) = match snap.status {
         GoalStatus::Active => ("▶", Color::Green),
         GoalStatus::Paused => ("⏸", Color::Yellow),
@@ -115,79 +358,19 @@ fn append_goal_badge(spans: &mut Vec<Span<'_>>, metrics: &MetricsSnapshot, theme
         };
         format!(" {icon} {truncated}")
     };
-    spans.push(Span::styled(" | ", theme.status_bar));
-    spans.push(Span::styled(label, Style::default().fg(color)));
+    vec![
+        Span::styled(" | ", theme.status_bar),
+        Span::styled(label, Style::default().fg(color)),
+    ]
 }
 
-fn build_suffix(metrics: &MetricsSnapshot, cancel_hint: &str, uptime: &str) -> String {
-    let sh_seg = if metrics.shell_background_runs.is_empty() {
-        String::new()
-    } else {
-        format!(", sh:{}", metrics.shell_background_runs.len())
-    };
-    format!(
-        " | API: {api} | {uptime}{sh_seg}{cancel_hint}",
-        api = metrics.api_calls,
-    )
-}
-
-fn subagent_view_segment(app: &App) -> String {
-    if let Some(name) = app.view_target().subagent_name() {
-        format!(" | Viewing: {name}")
-    } else {
-        String::new()
-    }
-}
-
-fn plan_mode_segment<'a>(app: &App, metrics: &MetricsSnapshot) -> &'a str {
-    // MF3: show current side-panel mode when a plan graph is active.
-    if metrics
-        .orchestration_graph
-        .as_ref()
-        .is_some_and(|s| !s.is_stale())
-    {
-        if app.plan_view_active() {
-            " | [Agents]"
-        } else {
-            " | [Plan]"
-        }
-    } else {
-        ""
-    }
-}
-
-#[allow(clippy::cast_precision_loss)]
-fn build_filter_segment(metrics: &MetricsSnapshot) -> String {
-    if metrics.filter_applications > 0 {
-        let savings = if metrics.filter_raw_tokens > 0 {
-            metrics.filter_saved_tokens as f64 / metrics.filter_raw_tokens as f64 * 100.0
-        } else {
-            0.0
-        };
-        format!(
-            " | Filters: {}/{} ({savings:.0}% saved)",
-            metrics.filter_filtered_commands, metrics.filter_total_commands,
-        )
-    } else {
-        String::new()
-    }
-}
-
-fn build_bg_segment(metrics: &MetricsSnapshot) -> String {
-    let e = metrics.bg_enrichment_inflight;
-    let t = metrics.bg_telemetry_inflight;
-    if e > 0 || t > 0 {
-        format!(" | bg: {e} enrich, {t} telem")
-    } else {
-        String::new()
-    }
-}
-
-fn append_security_spans(spans: &mut Vec<Span<'_>>, metrics: &MetricsSnapshot, theme: &Theme) {
+fn build_security_spans(metrics: &MetricsSnapshot, theme: &Theme) -> Vec<Span<'static>> {
     let injection_flags = metrics.sanitizer_injection_flags;
     let exfil_total = metrics.exfiltration_images_blocked
         + metrics.exfiltration_tool_urls_flagged
         + metrics.exfiltration_memory_guards;
+
+    let mut spans: Vec<Span<'static>> = Vec::new();
 
     if injection_flags > 0 || exfil_total > 0 {
         spans.push(Span::styled(" | ", theme.status_bar));
@@ -216,6 +399,45 @@ fn append_security_spans(spans: &mut Vec<Span<'_>>, metrics: &MetricsSnapshot, t
         };
         spans.push(Span::styled(label, Style::default().fg(color)));
     }
+
+    spans
+}
+
+fn subagent_view_segment(app: &App) -> String {
+    if let Some(name) = app.view_target().subagent_name() {
+        format!(" | Viewing: {name}")
+    } else {
+        String::new()
+    }
+}
+
+fn plan_mode_segment<'a>(app: &App, metrics: &MetricsSnapshot) -> &'a str {
+    if metrics
+        .orchestration_graph
+        .as_ref()
+        .is_some_and(|s| !s.is_stale())
+    {
+        if app.plan_view_active() {
+            " | [Agents]"
+        } else {
+            " | [Plan]"
+        }
+    } else {
+        ""
+    }
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn build_filter_text(metrics: &MetricsSnapshot) -> String {
+    let savings = if metrics.filter_raw_tokens > 0 {
+        metrics.filter_saved_tokens as f64 / metrics.filter_raw_tokens as f64 * 100.0
+    } else {
+        0.0
+    };
+    format!(
+        " | Filters: {}/{} ({savings:.0}% saved)",
+        metrics.filter_filtered_commands, metrics.filter_total_commands,
+    )
 }
 
 #[allow(clippy::cast_precision_loss)]
@@ -269,6 +491,83 @@ mod tests {
     }
 
     #[test]
+    fn segment_list_drops_low_before_high() {
+        let theme = Theme::default();
+        let mut list = SegmentList::new();
+        // Critical: 10 chars
+        list.push(
+            Priority::Critical,
+            vec![Span::styled("0123456789", theme.status_bar)],
+        );
+        // High: 10 chars
+        list.push(
+            Priority::High,
+            vec![Span::styled("ABCDEFGHIJ", theme.status_bar)],
+        );
+        // Low: 10 chars — should be dropped first
+        list.push(
+            Priority::Low,
+            vec![Span::styled("xxxxxxxxxx", theme.status_bar)],
+        );
+        // max_width = 20: Critical + High fit (20 chars), Low is dropped
+        let spans = list.layout(20);
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("0123456789"), "Critical must survive");
+        assert!(text.contains("ABCDEFGHIJ"), "High must survive");
+        assert!(!text.contains("xxxxxxxxxx"), "Low must be dropped");
+    }
+
+    #[test]
+    fn segment_list_lifo_among_equal_priority() {
+        let theme = Theme::default();
+        let mut list = SegmentList::new();
+        // Critical: 10 chars
+        list.push(
+            Priority::Critical,
+            vec![Span::styled("0123456789", theme.status_bar)],
+        );
+        // Two Low segments: the last-pushed (B) should be dropped first
+        list.push(
+            Priority::Low,
+            vec![Span::styled("AAAAAAAAAA", theme.status_bar)],
+        );
+        list.push(
+            Priority::Low,
+            vec![Span::styled("BBBBBBBBBB", theme.status_bar)],
+        );
+        // max_width = 20: Critical + A fit, B is dropped (LIFO)
+        let spans = list.layout(20);
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("0123456789"), "Critical must survive");
+        assert!(text.contains("AAAAAAAAAA"), "First Low must survive");
+        assert!(
+            !text.contains("BBBBBBBBBB"),
+            "Second Low (LIFO) must be dropped"
+        );
+    }
+
+    #[test]
+    fn segment_list_critical_never_dropped() {
+        let theme = Theme::default();
+        let mut list = SegmentList::new();
+        list.push(
+            Priority::Critical,
+            vec![Span::styled("CRITICAL_SEGMENT_DATA", theme.status_bar)],
+        );
+        list.push(
+            Priority::Low,
+            vec![Span::styled("lowpri", theme.status_bar)],
+        );
+        // Extremely narrow — Low must be dropped, Critical survives (possibly truncated).
+        let spans = list.layout(5);
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(
+            !text.contains("lowpri"),
+            "Low must be dropped under pressure"
+        );
+    }
+
+    #[test]
     fn status_bar_snapshot() {
         use insta::assert_snapshot;
         use tokio::sync::mpsc;
@@ -313,7 +612,7 @@ mod tests {
             ..MetricsSnapshot::default()
         };
 
-        let output = render_to_string(120, 1, |frame, area| {
+        let output = render_to_string(180, 1, |frame, area| {
             super::render(&app, &metrics, frame, area);
         });
         assert!(
@@ -338,7 +637,7 @@ mod tests {
             ..MetricsSnapshot::default()
         };
 
-        let output = render_to_string(120, 1, |frame, area| {
+        let output = render_to_string(180, 1, |frame, area| {
             super::render(&app, &metrics, frame, area);
         });
         assert!(
@@ -363,7 +662,7 @@ mod tests {
             ..MetricsSnapshot::default()
         };
 
-        let output = render_to_string(120, 1, |frame, area| {
+        let output = render_to_string(180, 1, |frame, area| {
             super::render(&app, &metrics, frame, area);
         });
         assert!(
@@ -388,7 +687,7 @@ mod tests {
             ..MetricsSnapshot::default()
         };
 
-        let output = render_to_string(140, 1, |frame, area| {
+        let output = render_to_string(180, 1, |frame, area| {
             super::render(&app, &metrics, frame, area);
         });
         assert!(
@@ -400,11 +699,13 @@ mod tests {
     #[test]
     fn cocoon_segment_none_is_empty() {
         let metrics = MetricsSnapshot::default();
-        assert_eq!(build_cocoon_segment(&metrics), "");
+        let theme = Theme::default();
+        assert!(build_cocoon_spans(&metrics, &theme).is_none());
     }
 
     #[test]
     fn cocoon_segment_healthy() {
+        let theme = Theme::default();
         let metrics = MetricsSnapshot {
             cocoon_connected: Some(true),
             cocoon_worker_count: 12,
@@ -412,21 +713,25 @@ mod tests {
             cocoon_ton_balance: Some(42.5),
             ..MetricsSnapshot::default()
         };
-        let seg = build_cocoon_segment(&metrics);
-        assert!(seg.contains("healthy"), "got: {seg}");
-        assert!(seg.contains("3 models"), "got: {seg}");
-        assert!(seg.contains("12 workers"), "got: {seg}");
-        assert!(seg.contains("42.50 TON"), "got: {seg}");
+        let spans = build_cocoon_spans(&metrics, &theme).expect("should be Some");
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("healthy"), "got: {text}");
+        assert!(text.contains("3 models"), "got: {text}");
+        assert!(text.contains("12 workers"), "got: {text}");
+        assert!(text.contains("42.50 TON"), "got: {text}");
     }
 
     #[test]
     fn cocoon_segment_unreachable() {
+        let theme = Theme::default();
         let metrics = MetricsSnapshot {
             cocoon_connected: Some(false),
             ..MetricsSnapshot::default()
         };
+        let spans = build_cocoon_spans(&metrics, &theme).expect("should be Some");
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(
-            build_cocoon_segment(&metrics).contains("unreachable"),
+            text.contains("unreachable"),
             "expected 'unreachable' in segment"
         );
     }
@@ -444,12 +749,42 @@ mod tests {
         let app = App::new(user_tx, agent_rx);
         let metrics = MetricsSnapshot::default();
 
-        let output = render_to_string(120, 1, |frame, area| {
+        let output = render_to_string(180, 1, |frame, area| {
             super::render(&app, &metrics, frame, area);
         });
         assert!(
             !output.contains("SEC:"),
             "SEC indicator must be hidden when all counters are zero"
         );
+    }
+
+    #[test]
+    fn status_bar_full_width_120() {
+        use insta::assert_snapshot;
+        use tokio::sync::mpsc;
+
+        use crate::app::App;
+        use crate::metrics::MetricsSnapshot;
+        use crate::test_utils::render_to_string;
+
+        let (user_tx, _) = mpsc::channel(1);
+        let (_, agent_rx) = mpsc::channel(1);
+        let app = App::new(user_tx, agent_rx);
+        let metrics = MetricsSnapshot {
+            model_name: "claude-sonnet-4-6".into(),
+            context_tokens: 8_000,
+            context_max_tokens: 100_000,
+            total_tokens: 12_500,
+            uptime_seconds: 300,
+            api_calls: 7,
+            active_skills: vec!["code".into()],
+            total_skills: 3,
+            ..MetricsSnapshot::default()
+        };
+
+        let output = render_to_string(120, 1, |frame, area| {
+            super::render(&app, &metrics, frame, area);
+        });
+        assert_snapshot!(output);
     }
 }


### PR DESCRIPTION
## Summary

- Move activity spinner into input widget `title_bottom` with "Esc to interrupt" hint; remove dedicated activity row from layout (chat gains one row)
- Refactor status bar to `SegmentList` with `Priority` enum and LIFO drop algorithm — Critical segments always visible, lower-priority segments dropped gracefully at narrow widths; fix u16 wrapping with `saturating_add`
- Add `user_message_bg` tint and `turn_separator` style to `Theme`; replace per-message right-aligned timestamps with `── HH:MM Role ──` separator lines on role transitions

## Test plan

- [ ] `cargo nextest run -p zeph-tui --lib` — 486 tests pass (includes 6 new tests)
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean
- [ ] Snapshot: `input_idle_width_80`, `status_bar_full_width_120` (new)
- [ ] Snapshot: `status_bar_snapshot` (updated for segment reordering)
- [ ] Manual: dark terminal — verify spinner in input corner, tinted user messages, separator lines
- [ ] Manual: narrow terminal (width 60) — verify Critical segments remain, Low segments dropped

Closes #3687