### PR TITLE
feat(tui): native text selection + clipboard shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- feat(tui): native terminal text selection without Shift modifier. `EnableMouseCapture` replaced
+  with alternate-scroll mode (`\x1b[?1007h`/`\x1b[?1007l`) so the terminal translates scroll-wheel
+  events into arrow keys. Chat scrolling is preserved; `AppEvent::MouseScroll` removed from the
+  event model. Panic hook updated to emit `DisableAlternateScroll` on crash. Closes #3685. (#3685)
+
+- feat(tui): clipboard shortcuts for copying assistant replies. New `clipboard` module with
+  `ClipboardHandle` backed by arboard (local) with OSC 52 fallback (SSH/tmux). SSH detected via
+  `SSH_TTY`, `SSH_CONNECTION`, `SSH_CLIENT`. `Ctrl+O` and `/copy` slash command copy the last
+  assistant message to clipboard. `clipboard` feature flag (default-on) gates the arboard
+  dependency for headless builds. Closes #3685. (#3685)
+
 - feat(llm): Cocoon live integration tests — 6 `#[ignore]`-gated tests covering `health_check`,
   `list_models`, `chat_round_trip`, `chat_stream`, `chat_with_tools`, and `doctor` checks.
   Tests require `COCOON_TEST_URL` env var and skip gracefully without it; `#[ignore]` attributes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,6 +885,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1152,6 +1178,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
 
 [[package]]
 name = "cmake"
@@ -2201,6 +2236,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "esaxx-rs"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2311,6 +2352,21 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "ferroid"
@@ -2934,6 +2990,16 @@ dependencies = [
  "typenum",
  "version_check",
  "zeroize",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link",
 ]
 
 [[package]]
@@ -3578,6 +3644,20 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "tiff",
 ]
 
 [[package]]
@@ -4344,6 +4424,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4664,6 +4754,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4672,6 +4774,19 @@ dependencies = [
  "bitflags 2.11.1",
  "dispatch2",
  "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.11.1",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -4700,6 +4815,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
  "objc2-core-foundation",
 ]
 
@@ -5280,6 +5406,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "poly1305"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5662,6 +5801,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
 
 [[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
 name = "qdrant-client"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5701,6 +5846,12 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quinn"
@@ -6540,7 +6691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
 dependencies = [
  "fnv",
- "quick-error",
+ "quick-error 1.2.3",
  "tempfile",
  "wait-timeout",
 ]
@@ -8049,6 +8200,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1e6941f74491a80911cb8821cb1f55f7e13bca867b28a2b14e5a1daaf691eb3"
 dependencies = [
  "ratatui",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error 2.0.1",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -10038,6 +10203,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "x25519-dalek"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10926,6 +11108,8 @@ dependencies = [
 name = "zeph-tui"
 version = "0.20.2"
 dependencies = [
+ "arboard",
+ "base64 0.22.1",
  "chrono",
  "crossterm",
  "expectrl",
@@ -11088,3 +11272,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ age = { version = "0.11.3", default-features = false }
 agent-client-protocol = "0.11.1"
 agent-client-protocol-tokio = "0.11.1"
 anyhow = "1.0.102"
+arboard = "3.6.1"
 async-stream = "0.3.6"
 async-trait = "0.1.89"
 axum = "0.8.9"

--- a/crates/zeph-tui/Cargo.toml
+++ b/crates/zeph-tui/Cargo.toml
@@ -39,6 +39,8 @@ serde_json.workspace = true
 zeph-common.workspace = true
 zeph-core.workspace = true
 zeph-subagent.workspace = true
+base64.workspace = true
+arboard = { workspace = true, optional = true }
 
 [dev-dependencies]
 expectrl.workspace = true
@@ -49,7 +51,8 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tokio-util.workspace = true
 
 [features]
-default = []
+default = ["clipboard"]
+clipboard = ["dep:arboard"]
 cocoon = []
 
 [lints]

--- a/crates/zeph-tui/src/app/events.rs
+++ b/crates/zeph-tui/src/app/events.rs
@@ -20,17 +20,6 @@ impl App {
             AppEvent::Resize(_, _) => {
                 self.sessions.current_mut().render_cache.clear();
             }
-            AppEvent::MouseScroll(delta) => {
-                if self.confirm_state.is_none() {
-                    if delta > 0 {
-                        self.sessions.current_mut().scroll_offset =
-                            self.sessions.current().scroll_offset.saturating_add(1);
-                    } else {
-                        self.sessions.current_mut().scroll_offset =
-                            self.sessions.current().scroll_offset.saturating_sub(1);
-                    }
-                }
-            }
             AppEvent::Agent(agent_event) => self.handle_agent_event(agent_event),
             AppEvent::Paste(text) => self.handle_paste(&text),
         }

--- a/crates/zeph-tui/src/app/keys.rs
+++ b/crates/zeph-tui/src/app/keys.rs
@@ -154,6 +154,7 @@ impl App {
         }
     }
 
+    #[allow(clippy::too_many_lines)] // large match over all TuiCommand variants
     pub(super) fn execute_command(&mut self, cmd: TuiCommand) {
         match cmd {
             TuiCommand::SkillList => self.push_system_message(self.format_skill_list()),
@@ -240,6 +241,20 @@ impl App {
             TuiCommand::CocoonModels => {
                 self.push_system_message("Querying Cocoon models...".to_owned());
                 let _ = self.user_input_tx.try_send("/cocoon models".to_owned());
+            }
+            TuiCommand::CopyLastAssistant => {
+                if let Some(text) = self.last_assistant_content() {
+                    match self.clipboard.copy(&text) {
+                        Ok(()) => self.push_system_message(
+                            "Last assistant message copied to clipboard".to_owned(),
+                        ),
+                        Err(e) => {
+                            self.push_system_message(format!("Copy failed: {e}"));
+                        }
+                    }
+                } else {
+                    self.push_system_message("No assistant message to copy.".to_owned());
+                }
             }
             cmd => self.execute_plan_graph_command(cmd),
         }
@@ -463,6 +478,7 @@ impl App {
                     command: rest.join(" "),
                 })
             }
+            [cmd] if cmd.eq_ignore_ascii_case("/copy") => Some(TuiCommand::CopyLastAssistant),
             _ => None,
         }
     }
@@ -659,6 +675,18 @@ impl App {
         self.sessions.current_mut().scroll_offset = 0;
     }
 
+    /// Return the content of the last assistant message in the current session,
+    /// or `None` if no assistant message exists yet.
+    fn last_assistant_content(&self) -> Option<String> {
+        self.sessions
+            .current()
+            .messages
+            .iter()
+            .rev()
+            .find(|m| m.role == MessageRole::Assistant)
+            .map(|m| m.content.clone())
+    }
+
     /// Returns true if there are security events within the last 60 seconds.
     #[must_use]
     pub fn has_recent_security_events(&self) -> bool {
@@ -798,6 +826,9 @@ impl App {
                 {
                     self.subagent_sidebar.list_state.select(Some(0));
                 }
+            }
+            KeyCode::Char('o') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.execute_command(TuiCommand::CopyLastAssistant);
             }
             _ => {}
         }
@@ -1045,6 +1076,9 @@ impl App {
             }
             KeyCode::Char('k') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 let _ = self.user_input_tx.try_send("/clear-queue".to_owned());
+            }
+            KeyCode::Char('o') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.execute_command(TuiCommand::CopyLastAssistant);
             }
             KeyCode::Char('@') => {
                 self.open_file_picker();
@@ -1313,5 +1347,77 @@ impl App {
         // Non-blocking send; capacity 32 — silent drop if agent loop is saturated.
         // Message is visible in chat but not processed; acceptable for interactive TUI.
         let _ = self.user_input_tx.try_send(text);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::mpsc;
+
+    use super::*;
+    use crate::event::AgentEvent;
+    use crate::types::MessageRole;
+
+    fn make_app() -> (App, mpsc::Receiver<String>, mpsc::Sender<AgentEvent>) {
+        let (user_tx, user_rx) = mpsc::channel(16);
+        let (agent_tx, agent_rx) = mpsc::channel(16);
+        let mut app = App::new(user_tx, agent_rx);
+        app.sessions.current_mut().messages.clear();
+        (app, user_rx, agent_tx)
+    }
+
+    #[test]
+    fn last_assistant_content_returns_none_when_empty() {
+        let (app, _rx, _tx) = make_app();
+        assert_eq!(app.last_assistant_content(), None);
+    }
+
+    #[test]
+    fn last_assistant_content_returns_none_when_only_user_messages() {
+        let (mut app, _rx, _tx) = make_app();
+        app.sessions
+            .current_mut()
+            .messages
+            .push(ChatMessage::new(MessageRole::User, "hello"));
+        assert_eq!(app.last_assistant_content(), None);
+    }
+
+    #[test]
+    fn last_assistant_content_returns_latest() {
+        let (mut app, _rx, _tx) = make_app();
+        app.sessions
+            .current_mut()
+            .messages
+            .push(ChatMessage::new(MessageRole::Assistant, "first"));
+        app.sessions
+            .current_mut()
+            .messages
+            .push(ChatMessage::new(MessageRole::User, "follow-up"));
+        app.sessions
+            .current_mut()
+            .messages
+            .push(ChatMessage::new(MessageRole::Assistant, "second"));
+        assert_eq!(app.last_assistant_content(), Some("second".to_owned()));
+    }
+
+    #[test]
+    fn slash_copy_parses_to_copy_last_assistant() {
+        assert_eq!(
+            App::parse_session_slash("/copy"),
+            Some(TuiCommand::CopyLastAssistant)
+        );
+    }
+
+    #[test]
+    fn slash_copy_case_insensitive() {
+        assert_eq!(
+            App::parse_session_slash("/COPY"),
+            Some(TuiCommand::CopyLastAssistant)
+        );
+    }
+
+    #[test]
+    fn slash_unknown_returns_none() {
+        assert_eq!(App::parse_session_slash("/unknown"), None);
     }
 }

--- a/crates/zeph-tui/src/app/mod.rs
+++ b/crates/zeph-tui/src/app/mod.rs
@@ -402,6 +402,8 @@ pub struct App {
     /// Avoids acquiring `TaskSupervisor`'s inner mutex inside the draw closure, which
     /// can block the render loop when the reap driver holds the lock concurrently.
     cached_task_snapshots: Vec<zeph_common::task_supervisor::TaskSnapshot>,
+    /// Clipboard handle for `/copy` and `Ctrl+O` (#3685).
+    pub(crate) clipboard: crate::clipboard::ClipboardHandle,
 }
 
 impl App {
@@ -463,6 +465,7 @@ impl App {
             task_supervisor: None,
             show_task_panel: false,
             cached_task_snapshots: Vec::new(),
+            clipboard: crate::clipboard::ClipboardHandle::new(),
         }
     }
 
@@ -1787,47 +1790,76 @@ mod tests {
     }
 
     #[test]
-    fn mouse_scroll_up() {
+    fn scroll_up_via_key() {
         let (mut app, _rx, _tx) = make_app();
+        app.sessions.current_mut().input_mode = InputMode::Normal;
         assert_eq!(app.scroll_offset(), 0);
-        app.handle_event(AppEvent::MouseScroll(1));
+        app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Up,
+            KeyModifiers::NONE,
+        )));
         assert_eq!(app.scroll_offset(), 1);
-        app.handle_event(AppEvent::MouseScroll(1));
+        app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Up,
+            KeyModifiers::NONE,
+        )));
         assert_eq!(app.scroll_offset(), 2);
     }
 
     #[test]
-    fn mouse_scroll_down() {
+    fn scroll_down_via_key() {
         let (mut app, _rx, _tx) = make_app();
+        app.sessions.current_mut().input_mode = InputMode::Normal;
         app.sessions.current_mut().scroll_offset = 5;
-        app.handle_event(AppEvent::MouseScroll(-1));
+        app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Down,
+            KeyModifiers::NONE,
+        )));
         assert_eq!(app.scroll_offset(), 4);
-        app.handle_event(AppEvent::MouseScroll(-1));
+        app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Down,
+            KeyModifiers::NONE,
+        )));
         assert_eq!(app.scroll_offset(), 3);
     }
 
     #[test]
-    fn mouse_scroll_down_saturates_at_zero() {
+    fn scroll_down_saturates_at_zero() {
         let (mut app, _rx, _tx) = make_app();
+        app.sessions.current_mut().input_mode = InputMode::Normal;
         app.sessions.current_mut().scroll_offset = 1;
-        app.handle_event(AppEvent::MouseScroll(-1));
+        app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Down,
+            KeyModifiers::NONE,
+        )));
         assert_eq!(app.scroll_offset(), 0);
-        app.handle_event(AppEvent::MouseScroll(-1));
+        app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Down,
+            KeyModifiers::NONE,
+        )));
         assert_eq!(app.scroll_offset(), 0);
     }
 
     #[test]
-    fn mouse_scroll_during_confirm_blocked() {
+    fn scroll_during_confirm_blocked() {
         let (mut app, _rx, _tx) = make_app();
+        app.sessions.current_mut().input_mode = InputMode::Normal;
         let (tx, _oneshot_rx) = tokio::sync::oneshot::channel();
         app.confirm_state = Some(ConfirmState {
             prompt: "test?".into(),
             response_tx: Some(tx),
         });
         app.sessions.current_mut().scroll_offset = 5;
-        app.handle_event(AppEvent::MouseScroll(1));
+        // The confirm dialog intercepts all key events before the normal key handler.
+        app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Up,
+            KeyModifiers::NONE,
+        )));
         assert_eq!(app.scroll_offset(), 5);
-        app.handle_event(AppEvent::MouseScroll(-1));
+        app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Down,
+            KeyModifiers::NONE,
+        )));
         assert_eq!(app.scroll_offset(), 5);
     }
 

--- a/crates/zeph-tui/src/clipboard.rs
+++ b/crates/zeph-tui/src/clipboard.rs
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Clipboard integration for the TUI dashboard.
+//!
+//! Provides [`ClipboardHandle`] which writes text to the system clipboard via
+//! `arboard` when available, with an OSC 52 escape-sequence fallback for SSH
+//! sessions and environments where `arboard` is unavailable or fails.
+
+use crate::error::TuiError;
+
+/// Detect whether the process is running inside an SSH session.
+///
+/// Checks all three standard SSH environment variables: `SSH_TTY`,
+/// `SSH_CONNECTION`, and `SSH_CLIENT`. Some minimal SSH implementations (e.g.,
+/// dropbear) only set `SSH_CLIENT`, so all three must be checked.
+///
+/// Uses [`std::env::var_os`] to avoid `Err(NotUnicode)` on non-UTF-8 values.
+#[cfg(feature = "clipboard")]
+fn is_ssh() -> bool {
+    std::env::var_os("SSH_TTY").is_some()
+        || std::env::var_os("SSH_CONNECTION").is_some()
+        || std::env::var_os("SSH_CLIENT").is_some()
+}
+
+/// Write `text` to the terminal clipboard via the OSC 52 escape sequence.
+///
+/// The sequence is written to stderr to avoid interfering with ratatui's
+/// ownership of stdout in raw/alternate-screen mode. Flushes after writing
+/// to guarantee delivery before the next ratatui frame.
+#[cfg(feature = "clipboard")]
+fn write_osc52(text: &str) -> Result<(), TuiError> {
+    use base64::Engine as _;
+    use std::io::Write as _;
+    let encoded = base64::engine::general_purpose::STANDARD.encode(text.as_bytes());
+    let seq = format!("\x1b]52;c;{encoded}\x07");
+    let mut stderr = std::io::stderr();
+    stderr.write_all(seq.as_bytes()).map_err(TuiError::from)?;
+    stderr.flush().map_err(TuiError::from)?;
+    Ok(())
+}
+
+/// A handle to the system clipboard.
+///
+/// On local sessions, attempts to write via `arboard` and falls back to OSC 52
+/// on failure. On SSH sessions (detected via `SSH_TTY`, `SSH_CONNECTION`, or
+/// `SSH_CLIENT` at construction time), OSC 52 is used directly.
+///
+/// SSH status is detected once in [`new`](Self::new) and cached as a field;
+/// the detection is not repeated on each [`copy`](Self::copy) call.
+///
+/// When the `clipboard` feature is disabled, [`copy`](Self::copy) is a no-op.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use zeph_tui::clipboard::ClipboardHandle;
+///
+/// let mut handle = ClipboardHandle::new();
+/// handle.copy("hello").unwrap();
+/// ```
+pub struct ClipboardHandle {
+    #[cfg(feature = "clipboard")]
+    inner: Option<arboard::Clipboard>,
+    /// `true` when the process was launched inside an SSH session.
+    ///
+    /// Computed once at construction; SSH status cannot change during a session.
+    #[cfg(feature = "clipboard")]
+    is_ssh: bool,
+}
+
+impl ClipboardHandle {
+    /// Create a new clipboard handle.
+    ///
+    /// Detects SSH status once and caches it. On the `clipboard` feature path,
+    /// attempts to open `arboard::Clipboard` eagerly; stores `None` if
+    /// initialisation fails (graceful degradation to OSC 52).
+    #[must_use]
+    pub fn new() -> Self {
+        #[cfg(feature = "clipboard")]
+        {
+            let is_ssh = is_ssh();
+            let inner = arboard::Clipboard::new().ok();
+            Self { inner, is_ssh }
+        }
+        #[cfg(not(feature = "clipboard"))]
+        Self {}
+    }
+
+    /// Copy `text` to the clipboard.
+    ///
+    /// Uses OSC 52 when running over SSH. Otherwise tries the native clipboard
+    /// via `arboard` and falls back to OSC 52 on failure.
+    ///
+    /// When the `clipboard` feature is disabled, this is a no-op returning `Ok`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuiError::Io`] if writing the OSC 52 escape sequence to stderr
+    /// fails.
+    pub fn copy(&mut self, text: &str) -> Result<(), TuiError> {
+        #[cfg(feature = "clipboard")]
+        {
+            if self.is_ssh {
+                return write_osc52(text);
+            }
+            if let Some(ref mut cb) = self.inner
+                && cb.set_text(text).is_ok()
+            {
+                return Ok(());
+            }
+            // arboard unavailable or failed — fall back to OSC 52
+            write_osc52(text)
+        }
+        #[cfg(not(feature = "clipboard"))]
+        {
+            let _ = text;
+            Ok(())
+        }
+    }
+}
+
+impl Default for ClipboardHandle {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clipboard_handle_default_does_not_panic() {
+        let _ = ClipboardHandle::default();
+    }
+
+    #[test]
+    fn clipboard_handle_new_does_not_panic() {
+        let _ = ClipboardHandle::new();
+    }
+
+    #[cfg(feature = "clipboard")]
+    #[test]
+    fn is_ssh_false_when_env_absent() {
+        // Ensure none of the SSH env vars are set (they aren't in a cargo test environment).
+        // If running inside SSH, this test will correctly reflect that — skip the assertion.
+        if std::env::var_os("SSH_TTY").is_none()
+            && std::env::var_os("SSH_CONNECTION").is_none()
+            && std::env::var_os("SSH_CLIENT").is_none()
+        {
+            assert!(!is_ssh());
+        }
+    }
+
+    #[cfg(feature = "clipboard")]
+    #[test]
+    fn osc52_base64_encodes_payload() {
+        use base64::Engine as _;
+        let text = "hello clipboard";
+        let encoded = base64::engine::general_purpose::STANDARD.encode(text.as_bytes());
+        // Verify base64 output contains only safe characters (no control chars).
+        assert!(
+            encoded
+                .chars()
+                .all(|c| c.is_alphanumeric() || c == '+' || c == '/' || c == '=')
+        );
+    }
+}

--- a/crates/zeph-tui/src/command.rs
+++ b/crates/zeph-tui/src/command.rs
@@ -117,6 +117,8 @@ pub enum TuiCommand {
     // Cocoon sidecar inspection (#3673)
     CocoonStatus,
     CocoonModels,
+    // Clipboard (#3685)
+    CopyLastAssistant,
 }
 
 /// Metadata for a single entry in the command palette.
@@ -698,6 +700,16 @@ fn build_cocoon_commands() -> Vec<CommandEntry> {
     ]
 }
 
+fn build_clipboard_commands() -> Vec<CommandEntry> {
+    vec![CommandEntry {
+        id: "clipboard:copy",
+        label: "Copy last assistant reply to clipboard (/copy)",
+        category: "clipboard",
+        shortcut: Some("Ctrl+O"),
+        command: TuiCommand::CopyLastAssistant,
+    }]
+}
+
 fn build_extra_commands() -> Vec<CommandEntry> {
     let mut cmds = build_infra_commands();
     cmds.extend(build_agent_plan_commands());
@@ -741,6 +753,7 @@ fn build_extra_commands() -> Vec<CommandEntry> {
     });
     #[cfg(feature = "cocoon")]
     cmds.extend(build_cocoon_commands());
+    cmds.extend(build_clipboard_commands());
     cmds
 }
 
@@ -847,7 +860,8 @@ mod tests {
         // + 1 compaction:status + 1 guidelines:view + 1 tafc:status + 1 lsp:status
         // + 1 forgetting-sweep + 3 acp + 1 sandbox:status (#3294) = 43
         // + 2 cocoon (#3673) when feature = "cocoon"
-        let expected = 43 + if cfg!(feature = "cocoon") { 2 } else { 0 };
+        // + 1 clipboard:copy (#3685)
+        let expected = 44 + if cfg!(feature = "cocoon") { 2 } else { 0 };
         assert_eq!(extra_command_registry().len(), expected);
     }
 
@@ -984,5 +998,22 @@ mod tests {
         assert!(results.iter().any(|e| e.id == "experiment:status"));
         assert!(results.iter().any(|e| e.id == "experiment:report"));
         assert!(results.iter().any(|e| e.id == "experiment:best"));
+    }
+
+    #[test]
+    fn filter_clipboard_returns_copy_entry() {
+        let results = filter_commands("copy");
+        assert!(
+            results.iter().any(|e| e.id == "clipboard:copy"),
+            "clipboard:copy must appear when searching 'copy'"
+        );
+    }
+
+    #[test]
+    fn clipboard_copy_command_is_copy_last_assistant() {
+        let all = filter_commands("");
+        let entry = all.iter().find(|e| e.id == "clipboard:copy").unwrap();
+        assert_eq!(entry.command, TuiCommand::CopyLastAssistant);
+        assert_eq!(entry.shortcut, Some("Ctrl+O"));
     }
 }

--- a/crates/zeph-tui/src/event.rs
+++ b/crates/zeph-tui/src/event.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use crossterm::event::{self, Event as CrosstermEvent, KeyEvent, MouseEventKind};
+use crossterm::event::{self, Event as CrosstermEvent, KeyEvent};
 use tokio::sync::{Notify, mpsc, oneshot, watch};
 
 use zeph_core::metrics::MetricsSnapshot;
@@ -75,11 +75,6 @@ impl EventSource for CrosstermEventSource {
             match event::read() {
                 Ok(CrosstermEvent::Key(key)) => Some(AppEvent::Key(key)),
                 Ok(CrosstermEvent::Resize(w, h)) => Some(AppEvent::Resize(w, h)),
-                Ok(CrosstermEvent::Mouse(mouse)) => match mouse.kind {
-                    MouseEventKind::ScrollUp => Some(AppEvent::MouseScroll(1)),
-                    MouseEventKind::ScrollDown => Some(AppEvent::MouseScroll(-1)),
-                    _ => Some(AppEvent::Tick),
-                },
                 Ok(CrosstermEvent::Paste(text)) => Some(AppEvent::Paste(text)),
                 _ => Some(AppEvent::Tick),
             }
@@ -111,8 +106,6 @@ pub enum AppEvent {
     Tick,
     /// The terminal was resized to the given `(columns, rows)`.
     Resize(u16, u16),
-    /// Mouse wheel scroll: `+1` = up, `-1` = down.
-    MouseScroll(i8),
     /// An event forwarded from the agent event channel.
     Agent(AgentEvent),
     /// Text pasted via bracketed paste mode.
@@ -317,15 +310,6 @@ mod tests {
         let s = format!("{e:?}");
         assert!(s.contains("ConfirmRequest"));
         assert!(s.contains("delete?"));
-    }
-
-    #[test]
-    fn app_event_mouse_scroll_variant() {
-        let scroll_up = AppEvent::MouseScroll(1);
-        assert!(matches!(scroll_up, AppEvent::MouseScroll(1)));
-
-        let scroll_down = AppEvent::MouseScroll(-1);
-        assert!(matches!(scroll_down, AppEvent::MouseScroll(-1)));
     }
 
     #[test]

--- a/crates/zeph-tui/src/lib.rs
+++ b/crates/zeph-tui/src/lib.rs
@@ -39,6 +39,7 @@
 
 pub mod app;
 pub mod channel;
+pub mod clipboard;
 pub mod command;
 pub mod error;
 pub mod event;
@@ -106,9 +107,11 @@ pub async fn run_tui(mut app: App, mut event_rx: mpsc::Receiver<AppEvent>) -> Re
         let _ = crossterm::execute!(
             io::stdout(),
             crossterm::terminal::LeaveAlternateScreen,
-            crossterm::event::DisableMouseCapture,
             crossterm::event::DisableBracketedPaste,
         );
+        // Disable alternate-scroll mode; write directly to stderr to avoid
+        // interfering with the already-corrupted stdout alternate screen.
+        let _ = std::io::Write::write_all(&mut io::stderr(), b"\x1b[?1007l");
         original_hook(info);
     }));
 
@@ -204,13 +207,45 @@ async fn tui_loop(
     Ok(())
 }
 
+/// Enables alternate-scroll mode (`\x1b[?1007h`).
+///
+/// In this mode the terminal forwards scroll-wheel events as `Up`/`Down` arrow
+/// key sequences instead of mouse events, allowing native text selection without
+/// holding Shift.
+struct EnableAlternateScroll;
+
+impl crossterm::Command for EnableAlternateScroll {
+    fn write_ansi(&self, f: &mut impl std::fmt::Write) -> std::fmt::Result {
+        f.write_str("\x1b[?1007h")
+    }
+
+    #[cfg(windows)]
+    fn execute_winapi(&self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Disables alternate-scroll mode (`\x1b[?1007l`).
+struct DisableAlternateScroll;
+
+impl crossterm::Command for DisableAlternateScroll {
+    fn write_ansi(&self, f: &mut impl std::fmt::Write) -> std::fmt::Result {
+        f.write_str("\x1b[?1007l")
+    }
+
+    #[cfg(windows)]
+    fn execute_winapi(&self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
 fn init_terminal() -> Result<Terminal<CrosstermBackend<io::Stdout>>, TuiError> {
     crossterm::terminal::enable_raw_mode()?;
     let mut stdout = io::stdout();
     crossterm::execute!(
         stdout,
         crossterm::terminal::EnterAlternateScreen,
-        crossterm::event::EnableMouseCapture,
+        EnableAlternateScroll,
         crossterm::event::EnableBracketedPaste,
     )?;
     let backend = CrosstermBackend::new(stdout);
@@ -222,7 +257,7 @@ fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Re
     crossterm::execute!(
         terminal.backend_mut(),
         crossterm::terminal::LeaveAlternateScreen,
-        crossterm::event::DisableMouseCapture,
+        DisableAlternateScroll,
         crossterm::event::DisableBracketedPaste,
     )?;
     terminal.show_cursor()?;
@@ -259,5 +294,21 @@ mod tests {
         // If poll_metrics panics or the metrics watch channel is broken the test fails.
         // Verify the snapshot is accessible after polling.
         let _: &MetricsSnapshot = &app.metrics;
+    }
+
+    #[test]
+    fn alternate_scroll_enable_ansi() {
+        use crossterm::Command as _;
+        let mut buf = String::new();
+        super::EnableAlternateScroll.write_ansi(&mut buf).unwrap();
+        assert_eq!(buf, "\x1b[?1007h");
+    }
+
+    #[test]
+    fn alternate_scroll_disable_ansi() {
+        use crossterm::Command as _;
+        let mut buf = String::new();
+        super::DisableAlternateScroll.write_ansi(&mut buf).unwrap();
+        assert_eq!(buf, "\x1b[?1007l");
     }
 }


### PR DESCRIPTION
## Summary

- Replace `EnableMouseCapture` with alternate-scroll mode (`\x1b[?1007h`/`l`) so native terminal drag-select works without holding Shift; scroll-wheel preserved via synthesized `KeyCode::Up/Down` events
- New `clipboard` module: `ClipboardHandle` backed by arboard (local) + OSC 52 fallback for SSH/tmux; SSH detected via `SSH_TTY`, `SSH_CONNECTION`, `SSH_CLIENT`
- `Ctrl+O` and `/copy` slash command copy the last assistant reply to clipboard; `clipboard` feature (default-on) gates the arboard dependency for headless builds

Closes #3685. Part of epic #3684.

## Changed files

| File | Change |
|------|--------|
| `crates/zeph-tui/src/lib.rs` | `EnableAlternateScroll`/`DisableAlternateScroll` commands; panic hook updated |
| `crates/zeph-tui/src/event.rs` | Remove `AppEvent::MouseScroll`, `MouseEventKind` arm |
| `crates/zeph-tui/src/app/events.rs` | Remove `MouseScroll` handler |
| `crates/zeph-tui/src/app/mod.rs` | `ClipboardHandle` field; migrated scroll tests; `last_assistant_content()` |
| `crates/zeph-tui/src/app/keys.rs` | `Ctrl+O` binding (Normal + Insert); `CopyLastAssistant` handler |
| `crates/zeph-tui/src/command.rs` | `TuiCommand::CopyLastAssistant`; `/copy` palette entry |
| `crates/zeph-tui/src/clipboard.rs` | New: `ClipboardHandle`, SSH detection, arboard + OSC 52 |
| `crates/zeph-tui/Cargo.toml` | `arboard` optional dep (`clipboard` feature) |
| `Cargo.toml` | `arboard = "3.6.1"` in workspace deps |

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo clippy -p zeph-tui --no-default-features -- -D warnings` — clean (feature-off path)
- [x] `cargo nextest run --workspace --lib --bins` — 8967 passed
- [ ] Live manual: drag-select on iTerm2/Terminal.app/Ghostty (no Shift needed)
- [ ] Live manual: scroll-wheel chat navigation preserved
- [ ] Live manual: `Ctrl+O` copies last assistant reply to system clipboard
- [ ] Live manual: `/copy` slash command works identically
- [ ] Live SSH: OSC 52 clipboard copy path