### PR TITLE
fix(clippy): resolve --all-targets errors in tool_execution tests and cocoon.rs

### DIFF
--- a/crates/zeph-core/src/agent/tool_execution/tests/boundary_and_classifier_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/boundary_and_classifier_tests.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+#![allow(clippy::large_futures)]
+
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use zeph_tools::executor::{ToolCall, ToolError, ToolExecutor, ToolOutput};

--- a/crates/zeph-core/src/agent/tool_execution/tests/sanitize_and_native_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/sanitize_and_native_tests.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+#![allow(clippy::large_futures)]
+
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use zeph_tools::executor::{ToolCall, ToolError, ToolExecutor, ToolOutput};

--- a/crates/zeph-core/src/agent/tool_execution/tests/tafc_and_record_outcomes_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/tafc_and_record_outcomes_tests.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+#![allow(clippy::large_futures)]
+
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use zeph_tools::executor::{ToolCall, ToolError, ToolExecutor, ToolOutput};

--- a/src/commands/cocoon.rs
+++ b/src/commands/cocoon.rs
@@ -616,8 +616,10 @@ mod tests {
         check_proxy_connected(health_opt.as_ref(), &mut results);
         check_workers_available(health_opt.as_ref(), &mut results);
 
-        let mut entry = zeph_config::ProviderEntry::default();
-        entry.model = Some("Qwen/Qwen3-0.6B".into());
+        let entry = zeph_config::ProviderEntry {
+            model: Some("Qwen/Qwen3-0.6B".into()),
+            ..zeph_config::ProviderEntry::default()
+        };
         check_model_listed(&client, &entry, health_opt.as_ref(), &mut results).await;
 
         for check in &results {


### PR DESCRIPTION
## Summary

- Add `#![allow(clippy::large_futures)]` to three test files in `zeph-core/tool_execution/tests/` — the 17024-byte futures are inherent to the production `Agent` struct and cannot be reduced without invasive refactoring
- Rewrite `src/commands/cocoon.rs:619` to use struct literal with `..ProviderEntry::default()` instead of field-by-field assignment

## Test plan

- [x] `cargo clippy --workspace --all-targets --features full -- -D warnings` — 0 errors
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo nextest run --workspace --lib --bins --features full` — 9407 passed

Closes #3718