### PR TITLE
feat(hooks): add PreToolUse/PostToolUse hook context env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- feat(hooks): `PreToolUse` and `PostToolUse` hook events for the main agent and subagent paths.
+  New `[[hooks.pre_tool_use]]` and `[[hooks.post_tool_use]]` config sections accept
+  `HookMatcher` entries (pipe-separated tool name patterns). Hooks fire with env vars:
+  `ZEPH_TOOL_NAME`, `ZEPH_TOOL_ARGS_JSON` (truncated at 64 KiB via `floor_char_boundary` to
+  avoid `E2BIG` and UTF-8 panic), `ZEPH_SESSION_ID` (main agent only; omitted in subagent),
+  and `ZEPH_TOOL_DURATION_MS` (post hooks only). PreToolUse fires before the `RuntimeLayer`
+  permission check (observers see all attempted calls). Hook dispatch is fail-open at the agent
+  level; `fail_closed` in a `HookDef` aborts the hook-chain sequence only. Closes #3698.
+
 - feat(tui): native terminal text selection without Shift modifier. `EnableMouseCapture` replaced
   with alternate-scroll mode (`\x1b[?1007h`/`\x1b[?1007l`) so the terminal translates scroll-wheel
   events into arrow keys. Chat scrolling is preserved; `AppEvent::MouseScroll` removed from the

--- a/crates/zeph-config/src/hooks.rs
+++ b/crates/zeph-config/src/hooks.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
-use crate::subagent::HookDef;
+use crate::subagent::{HookDef, HookMatcher};
 
 fn default_debounce_ms() -> u64 {
     500
@@ -69,6 +69,36 @@ pub struct HooksConfig {
     /// - `ZEPH_TURN_LLM_REQUESTS`  — number of completed LLM round-trips this turn.
     #[serde(default)]
     pub turn_complete: Vec<HookDef>,
+    /// Hooks fired before each tool execution, matched by tool name pattern.
+    ///
+    /// Uses pipe-separated pattern matching (same as subagent hooks). Hooks fire
+    /// before the `RuntimeLayer::before_tool` permission check — they observe every
+    /// attempted tool call, including calls that will be subsequently blocked.
+    ///
+    /// Hook serialization within a tier: hooks for tools in the same dependency tier
+    /// are dispatched sequentially (one tool's hooks complete before the next tool's
+    /// hooks start). Hooks for tools in different tiers may overlap.
+    ///
+    /// Hooks are fail-open: errors are logged but do not block tool execution.
+    ///
+    /// Environment variables set for `Command` hooks:
+    /// - `ZEPH_TOOL_NAME`      — name of the tool being invoked.
+    /// - `ZEPH_TOOL_ARGS_JSON` — JSON-serialized tool arguments (truncated at 64 KiB).
+    /// - `ZEPH_SESSION_ID`     — current conversation identifier, omitted when unavailable.
+    #[serde(default)]
+    pub pre_tool_use: Vec<HookMatcher>,
+    /// Hooks fired after each tool execution completes, matched by tool name pattern.
+    ///
+    /// Fires after the tool result is available. Same pattern matching and
+    /// fail-open semantics as `pre_tool_use`.
+    ///
+    /// Environment variables set for `Command` hooks:
+    /// - `ZEPH_TOOL_NAME`        — name of the tool that was invoked.
+    /// - `ZEPH_TOOL_ARGS_JSON`   — JSON-serialized tool arguments (truncated at 64 KiB).
+    /// - `ZEPH_SESSION_ID`       — current conversation identifier, omitted when unavailable.
+    /// - `ZEPH_TOOL_DURATION_MS` — wall-clock execution time in milliseconds.
+    #[serde(default)]
+    pub post_tool_use: Vec<HookMatcher>,
 }
 
 impl HooksConfig {
@@ -87,6 +117,8 @@ impl HooksConfig {
             && self.file_changed.is_none()
             && self.permission_denied.is_empty()
             && self.turn_complete.is_empty()
+            && self.pre_tool_use.is_empty()
+            && self.post_tool_use.is_empty()
     }
 }
 
@@ -183,6 +215,8 @@ severity = "high"
             file_changed: None,
             permission_denied: Vec::new(),
             turn_complete: Vec::new(),
+            pre_tool_use: Vec::new(),
+            post_tool_use: Vec::new(),
         };
         assert!(!cfg.is_empty());
     }
@@ -194,6 +228,8 @@ severity = "high"
             file_changed: None,
             permission_denied: vec![cmd_hook("echo denied")],
             turn_complete: Vec::new(),
+            pre_tool_use: Vec::new(),
+            post_tool_use: Vec::new(),
         };
         assert!(!cfg.is_empty());
     }
@@ -205,6 +241,8 @@ severity = "high"
             file_changed: None,
             permission_denied: Vec::new(),
             turn_complete: vec![cmd_hook("notify-send Zeph done")],
+            pre_tool_use: Vec::new(),
+            post_tool_use: Vec::new(),
         };
         assert!(!cfg.is_empty());
     }
@@ -216,6 +254,8 @@ severity = "high"
             file_changed: None,
             permission_denied: Vec::new(),
             turn_complete: Vec::new(),
+            pre_tool_use: Vec::new(),
+            post_tool_use: Vec::new(),
         };
         assert!(cfg.is_empty());
     }
@@ -233,6 +273,51 @@ fail_closed = false
         assert_eq!(cfg.turn_complete.len(), 1);
         assert!(cfg.cwd_changed.is_empty());
         assert!(cfg.permission_denied.is_empty());
+    }
+
+    #[test]
+    fn hooks_config_not_empty_with_pre_tool_use() {
+        use crate::subagent::HookMatcher;
+        let cfg = HooksConfig {
+            cwd_changed: Vec::new(),
+            file_changed: None,
+            permission_denied: Vec::new(),
+            turn_complete: Vec::new(),
+            pre_tool_use: vec![HookMatcher {
+                matcher: "Edit|Write".to_owned(),
+                hooks: vec![cmd_hook("echo pre")],
+            }],
+            post_tool_use: Vec::new(),
+        };
+        assert!(!cfg.is_empty());
+    }
+
+    #[test]
+    fn hooks_config_parses_pre_and_post_tool_use_from_toml() {
+        let toml = r#"
+[[pre_tool_use]]
+matcher = "Edit|Write"
+[[pre_tool_use.hooks]]
+type = "command"
+command = "echo pre $ZEPH_TOOL_NAME"
+timeout_secs = 5
+fail_closed = false
+
+[[post_tool_use]]
+matcher = "Shell"
+[[post_tool_use.hooks]]
+type = "command"
+command = "echo post $ZEPH_TOOL_DURATION_MS"
+timeout_secs = 5
+fail_closed = false
+"#;
+        let cfg: HooksConfig = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.pre_tool_use.len(), 1);
+        assert_eq!(cfg.pre_tool_use[0].matcher, "Edit|Write");
+        assert_eq!(cfg.pre_tool_use[0].hooks.len(), 1);
+        assert_eq!(cfg.post_tool_use.len(), 1);
+        assert_eq!(cfg.post_tool_use[0].matcher, "Shell");
+        assert!(!cfg.is_empty());
     }
 
     /// Exercises the full testing.toml hooks pattern: `cwd_changed` + `file_changed` + `permission_denied`

--- a/crates/zeph-config/src/subagent.rs
+++ b/crates/zeph-config/src/subagent.rs
@@ -159,8 +159,13 @@ pub struct HookDef {
     /// Maximum seconds to wait for the hook before timing out. Default: 30.
     #[serde(default = "default_hook_timeout")]
     pub timeout_secs: u64,
-    /// When `true`, a non-zero exit code or timeout causes the calling operation to fail.
-    /// When `false` (default), errors are logged but execution continues.
+    /// When `true`, a non-zero exit code or timeout aborts the remaining hooks in the same
+    /// sequence (no further hooks in the list run). When `false` (default), errors are logged
+    /// and the next hook in the sequence continues.
+    ///
+    /// Note: in `pre_tool_use` and `post_tool_use` contexts this field controls hook-chain
+    /// execution only — it does **not** block the tool call itself. Hook dispatch is always
+    /// fail-open at the agent level; the tool executes regardless of hook outcomes.
     #[serde(default)]
     pub fail_closed: bool,
 }

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1407,6 +1407,18 @@ impl<C: Channel> Agent<C> {
             .turn_complete
             .clone_from(&config.turn_complete);
 
+        self.services
+            .session
+            .hooks_config
+            .pre_tool_use
+            .clone_from(&config.pre_tool_use);
+
+        self.services
+            .session
+            .hooks_config
+            .post_tool_use
+            .clone_from(&config.post_tool_use);
+
         if let Some(ref fc) = config.file_changed {
             self.services
                 .session

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -722,6 +722,10 @@ pub(crate) struct HooksConfigSnapshot {
     /// `Notifier::should_fire` gate when a notifier is configured; fires on every completion
     /// when no notifier is present.
     pub(crate) turn_complete: Vec<zeph_config::HookDef>,
+    /// Hooks fired before each tool execution, matched by tool name pattern.
+    pub(crate) pre_tool_use: Vec<zeph_config::HookMatcher>,
+    /// Hooks fired after each tool execution completes, matched by tool name pattern.
+    pub(crate) post_tool_use: Vec<zeph_config::HookMatcher>,
 }
 
 // Groups message buffering and image staging state.

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -16,6 +16,43 @@ use super::{
 use crate::agent::Agent;
 use crate::channel::{Channel, StopHint, ToolStartEvent};
 
+/// Maximum byte length of `ZEPH_TOOL_ARGS_JSON`. OS `ARG_MAX` is ~1 MB on macOS and ~2 MB on
+/// Linux; staying well below that avoids `E2BIG` when spawning hook processes.
+const TOOL_ARGS_JSON_LIMIT: usize = 64 * 1024;
+
+/// Build the base env map for `pre_tool_use` / `post_tool_use` hook dispatch.
+///
+/// `ZEPH_TOOL_ARGS_JSON` is truncated to [`TOOL_ARGS_JSON_LIMIT`] bytes when the serialized
+/// argument object would exceed the OS `ARG_MAX` limit.
+fn make_tool_hook_env(
+    tool_name: &str,
+    tool_input: &serde_json::Value,
+    session_id: Option<&str>,
+) -> std::collections::HashMap<String, String> {
+    let mut env = std::collections::HashMap::new();
+    env.insert("ZEPH_TOOL_NAME".to_owned(), tool_name.to_owned());
+
+    let raw = serde_json::to_string(tool_input).unwrap_or_default();
+    let args_json = if raw.len() > TOOL_ARGS_JSON_LIMIT {
+        tracing::warn!(
+            tool = tool_name,
+            len = raw.len(),
+            limit = TOOL_ARGS_JSON_LIMIT,
+            "ZEPH_TOOL_ARGS_JSON truncated for hook dispatch"
+        );
+        let limit = raw.floor_char_boundary(TOOL_ARGS_JSON_LIMIT);
+        format!("{}…", &raw[..limit])
+    } else {
+        raw
+    };
+    env.insert("ZEPH_TOOL_ARGS_JSON".to_owned(), args_json);
+
+    if let Some(sid) = session_id {
+        env.insert("ZEPH_SESSION_ID".to_owned(), sid.to_owned());
+    }
+    env
+}
+
 impl<C: Channel> Agent<C> {
     #[tracing::instrument(
         name = "core.tool.run_post_dispatch_phases",
@@ -927,6 +964,7 @@ impl<C: Channel> Agent<C> {
                 calls,
                 cache_hits,
                 args_hashes,
+                tool_started_ats,
                 &mut failed_ids,
                 &mut tool_results,
             )
@@ -1316,7 +1354,7 @@ impl<C: Channel> Agent<C> {
         fields(tier_size = tier_indices.len()),
         err
     )]
-    #[allow(clippy::too_many_arguments, clippy::ptr_arg)]
+    #[allow(clippy::too_many_arguments, clippy::ptr_arg, clippy::too_many_lines)]
     async fn build_tier_call_futures(
         &mut self,
         tool_calls: &[zeph_llm::provider::ToolUseRequest],
@@ -1410,6 +1448,37 @@ impl<C: Channel> Agent<C> {
                     skipped_output(tc.name.clone(), exceeded.to_error_message()),
                 ));
                 continue;
+            }
+
+            // Fire PreToolUse hooks before the RuntimeLayer permission check (fail-open).
+            let pre_hooks = self.services.session.hooks_config.pre_tool_use.clone();
+            if !pre_hooks.is_empty() {
+                let matched: Vec<&zeph_config::HookDef> =
+                    zeph_subagent::matching_hooks(&pre_hooks, tc.name.as_str());
+                if !matched.is_empty() {
+                    let _span =
+                        tracing::info_span!("core.hooks.pre_tool_use", tool = %tc.name).entered();
+                    let conv_id_str = self
+                        .services
+                        .memory
+                        .persistence
+                        .conversation_id
+                        .map(|id| id.0.to_string());
+                    let env =
+                        make_tool_hook_env(tc.name.as_str(), &tc.input, conv_id_str.as_deref());
+                    let owned: Vec<zeph_config::HookDef> = matched.into_iter().cloned().collect();
+                    let dispatch = self.mcp_dispatch();
+                    let mcp: Option<&dyn zeph_subagent::McpDispatch> = dispatch
+                        .as_ref()
+                        .map(|d| d as &dyn zeph_subagent::McpDispatch);
+                    if let Err(e) = zeph_subagent::hooks::fire_hooks(&owned, &env, mcp).await {
+                        tracing::warn!(
+                            error = %e,
+                            tool = %tc.name,
+                            "PreToolUse hook failed"
+                        );
+                    }
+                }
             }
 
             if let Some(fut) = self.run_before_tool_hooks(idx, tc, call).await {
@@ -1514,6 +1583,7 @@ impl<C: Channel> Agent<C> {
         calls: &[ToolCall],
         cache_hits: &[Option<zeph_tools::ToolOutput>],
         args_hashes: &[u64],
+        tool_started_ats: &[std::time::Instant],
         failed_ids: &mut std::collections::HashSet<String>,
         tool_results: &mut [Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>],
     ) {
@@ -1568,6 +1638,45 @@ impl<C: Channel> Agent<C> {
                             .await;
                     if hook_result.is_err() {
                         tracing::warn!("RuntimeLayer::after_tool panicked, continuing");
+                    }
+                }
+            }
+
+            // Fire PostToolUse hooks after the tool result is available (fail-open).
+            let post_hooks = self.services.session.hooks_config.post_tool_use.clone();
+            if !post_hooks.is_empty() {
+                let matched: Vec<&zeph_config::HookDef> =
+                    zeph_subagent::matching_hooks(&post_hooks, tool_calls[idx].name.as_str());
+                if !matched.is_empty() {
+                    let _span = tracing::info_span!(
+                        "core.hooks.post_tool_use",
+                        tool = %tool_calls[idx].name
+                    )
+                    .entered();
+                    let conv_id_str = self
+                        .services
+                        .memory
+                        .persistence
+                        .conversation_id
+                        .map(|id| id.0.to_string());
+                    let mut env = make_tool_hook_env(
+                        tool_calls[idx].name.as_str(),
+                        &tool_calls[idx].input,
+                        conv_id_str.as_deref(),
+                    );
+                    let duration_ms = tool_started_ats[idx].elapsed().as_millis();
+                    env.insert("ZEPH_TOOL_DURATION_MS".to_owned(), duration_ms.to_string());
+                    let owned: Vec<zeph_config::HookDef> = matched.into_iter().cloned().collect();
+                    let dispatch = self.mcp_dispatch();
+                    let mcp: Option<&dyn zeph_subagent::McpDispatch> = dispatch
+                        .as_ref()
+                        .map(|d| d as &dyn zeph_subagent::McpDispatch);
+                    if let Err(e) = zeph_subagent::hooks::fire_hooks(&owned, &env, mcp).await {
+                        tracing::warn!(
+                            error = %e,
+                            tool = %tool_calls[idx].name,
+                            "PostToolUse hook failed"
+                        );
                     }
                 }
             }
@@ -2144,4 +2253,75 @@ fn build_gated_defs_for_iteration(
         .filter(|d| allowed_set.contains(d.name.as_str()))
         .cloned()
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn json_val(s: &str) -> serde_json::Value {
+        serde_json::from_str(s).unwrap()
+    }
+
+    #[test]
+    fn make_tool_hook_env_sets_tool_name() {
+        let env = make_tool_hook_env("Edit", &serde_json::Value::Null, None);
+        assert_eq!(env.get("ZEPH_TOOL_NAME").map(String::as_str), Some("Edit"));
+    }
+
+    #[test]
+    fn make_tool_hook_env_sets_args_json_for_small_payload() {
+        let input = json_val(r#"{"path": "/tmp/foo.txt"}"#);
+        let env = make_tool_hook_env("Write", &input, None);
+        let args = env
+            .get("ZEPH_TOOL_ARGS_JSON")
+            .expect("ZEPH_TOOL_ARGS_JSON missing");
+        let parsed: serde_json::Value = serde_json::from_str(args).unwrap();
+        assert_eq!(parsed["path"], "/tmp/foo.txt");
+    }
+
+    #[test]
+    fn make_tool_hook_env_truncates_large_payload_safely() {
+        // Build a JSON string > 64 KiB with a multi-byte char near the boundary.
+        let mut big = String::from(r#"{"data":""#);
+        // Fill mostly with ASCII, then add a 3-byte char (€ = 0xE2 0x82 0xAC) right at boundary.
+        // We want the char boundary to fall inside the limit so truncation must round down.
+        while big.len() < TOOL_ARGS_JSON_LIMIT - 3 {
+            big.push('a');
+        }
+        big.push('€'); // 3 bytes — may straddle the limit
+        while big.len() < TOOL_ARGS_JSON_LIMIT + 100 {
+            big.push('b');
+        }
+        big.push_str(r#""}"#);
+        let input: serde_json::Value = serde_json::from_str(&big).unwrap_or_default();
+        // Must not panic and must end with the ellipsis character.
+        let env = make_tool_hook_env("Shell", &input, None);
+        let args = env
+            .get("ZEPH_TOOL_ARGS_JSON")
+            .expect("ZEPH_TOOL_ARGS_JSON missing");
+        assert!(
+            args.ends_with('…'),
+            "truncated value should end with ellipsis"
+        );
+        assert!(
+            args.is_char_boundary(args.len()),
+            "truncation must land on char boundary"
+        );
+    }
+
+    #[test]
+    fn make_tool_hook_env_sets_session_id_when_present() {
+        let env = make_tool_hook_env("Read", &serde_json::Value::Null, Some("sess-42"));
+        assert_eq!(
+            env.get("ZEPH_SESSION_ID").map(String::as_str),
+            Some("sess-42")
+        );
+    }
+
+    #[test]
+    fn make_tool_hook_env_omits_session_id_when_none() {
+        let env = make_tool_hook_env("Read", &serde_json::Value::Null, None);
+        assert!(!env.contains_key("ZEPH_SESSION_ID"));
+    }
 }

--- a/crates/zeph-subagent/src/agent_loop.rs
+++ b/crates/zeph-subagent/src/agent_loop.rs
@@ -26,15 +26,35 @@ enum SecretRequestOutcome {
     Cancelled,
 }
 
+/// Maximum byte length of `ZEPH_TOOL_ARGS_JSON` to avoid `E2BIG` when spawning hook processes.
+const TOOL_ARGS_JSON_LIMIT: usize = 64 * 1024;
+
 fn make_hook_env(
     task_id: &str,
     agent_name: &str,
     tool_name: &str,
+    tool_input: &serde_json::Value,
 ) -> std::collections::HashMap<String, String> {
     let mut env = std::collections::HashMap::new();
     env.insert("ZEPH_AGENT_ID".to_owned(), task_id.to_owned());
     env.insert("ZEPH_AGENT_NAME".to_owned(), agent_name.to_owned());
     env.insert("ZEPH_TOOL_NAME".to_owned(), tool_name.to_owned());
+
+    let raw = serde_json::to_string(tool_input).unwrap_or_default();
+    let args_json = if raw.len() > TOOL_ARGS_JSON_LIMIT {
+        tracing::warn!(
+            tool = tool_name,
+            len = raw.len(),
+            limit = TOOL_ARGS_JSON_LIMIT,
+            "ZEPH_TOOL_ARGS_JSON truncated for hook dispatch"
+        );
+        let limit = raw.floor_char_boundary(TOOL_ARGS_JSON_LIMIT);
+        format!("{}…", &raw[..limit])
+    } else {
+        raw
+    };
+    env.insert("ZEPH_TOOL_ARGS_JSON".to_owned(), args_json);
+
     env
 }
 
@@ -466,11 +486,10 @@ async fn handle_tool_step(
 
             let mut result_parts: Vec<MessagePart> = Vec::new();
             for tc in &tool_calls {
-                let mut hook_env = make_hook_env(task_id, agent_name, tc.name.as_str());
-
                 let pre_hooks: Vec<&HookDef> =
                     matching_hooks(&hooks.pre_tool_use, tc.name.as_str());
                 if !pre_hooks.is_empty() {
+                    let hook_env = make_hook_env(task_id, agent_name, tc.name.as_str(), &tc.input);
                     let pre_owned: Vec<HookDef> = pre_hooks.into_iter().cloned().collect();
                     // MCP dispatch is not available in the subagent execution path.
                     if let Err(e) = fire_hooks(&pre_owned, &hook_env, None).await {
@@ -514,12 +533,14 @@ async fn handle_tool_step(
                     is_error,
                 });
 
-                hook_env.insert("ZEPH_TOOL_DURATION_MS".to_owned(), duration_ms.to_string());
-
                 if !hooks.post_tool_use.is_empty() {
                     let post_hooks: Vec<&HookDef> =
                         matching_hooks(&hooks.post_tool_use, tc.name.as_str());
                     if !post_hooks.is_empty() {
+                        let mut hook_env =
+                            make_hook_env(task_id, agent_name, tc.name.as_str(), &tc.input);
+                        hook_env
+                            .insert("ZEPH_TOOL_DURATION_MS".to_owned(), duration_ms.to_string());
                         let post_owned: Vec<HookDef> = post_hooks.into_iter().cloned().collect();
                         // MCP dispatch is not available in the subagent execution path.
                         if let Err(e) = fire_hooks(&post_owned, &hook_env, None).await {
@@ -627,4 +648,39 @@ pub(super) async fn run_agent_loop(
     });
 
     Ok(last_result)
+}
+
+#[cfg(test)]
+mod make_hook_env_tests {
+    use super::*;
+
+    #[test]
+    fn sets_agent_id_and_name() {
+        let env = make_hook_env("task-1", "bot", "Edit", &serde_json::Value::Null);
+        assert_eq!(env.get("ZEPH_AGENT_ID").map(String::as_str), Some("task-1"));
+        assert_eq!(env.get("ZEPH_AGENT_NAME").map(String::as_str), Some("bot"));
+    }
+
+    #[test]
+    fn truncation_lands_on_char_boundary() {
+        let mut big = String::from(r#"{"d":""#);
+        while big.len() < TOOL_ARGS_JSON_LIMIT - 3 {
+            big.push('a');
+        }
+        big.push('€'); // 3-byte UTF-8 char that may straddle the boundary
+        while big.len() < TOOL_ARGS_JSON_LIMIT + 50 {
+            big.push('b');
+        }
+        big.push_str(r#""}"#);
+        let input: serde_json::Value = serde_json::from_str(&big).unwrap_or_default();
+        let env = make_hook_env("Shell", "bot", "Shell", &input);
+        let args = env
+            .get("ZEPH_TOOL_ARGS_JSON")
+            .expect("ZEPH_TOOL_ARGS_JSON missing");
+        assert!(
+            args.ends_with('…'),
+            "truncated value should end with ellipsis"
+        );
+        assert!(args.is_char_boundary(args.len()));
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `pre_tool_use` and `post_tool_use` fields to `HooksConfig` with `Vec<HookMatcher>` entries
- PreToolUse hooks fire before the RuntimeLayer permission check and receive `ZEPH_TOOL_NAME`, `ZEPH_TOOL_ARGS_JSON`, `ZEPH_SESSION_ID`
- PostToolUse hooks fire after tool completion and additionally receive `ZEPH_TOOL_DURATION_MS`
- Subagent path receives `ZEPH_TOOL_NAME` and `ZEPH_TOOL_ARGS_JSON` (no session ID by design)
- Args JSON is truncated at 64 KiB using `floor_char_boundary` to prevent UTF-8 panics on multibyte input
- Hook failures are fail-open at the agent level (documented on `HookDef.fail_closed`)
- JSON serialization in the subagent path is lazy — zero cost when no hooks are configured

## Files changed

- `crates/zeph-config/src/hooks.rs` — new `pre_tool_use`/`post_tool_use` fields on `HooksConfig`
- `crates/zeph-config/src/subagent.rs` — `fail_closed` doc clarification
- `crates/zeph-core/src/agent/builder.rs` — wire new config fields through builder
- `crates/zeph-core/src/agent/state/mod.rs` — `HooksConfigSnapshot` mirror
- `crates/zeph-core/src/agent/tool_execution/tier_loop.rs` — dispatch + 5 unit tests
- `crates/zeph-subagent/src/agent_loop.rs` — subagent hook dispatch + 2 unit tests
- `CHANGELOG.md` — `[Unreleased]` entry

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace --features "desktop,ide,server,chat,pdf,scheduler" -- -D warnings` — clean
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 9227 passed
- [ ] Unit tests for `make_tool_hook_env`: ZEPH_TOOL_NAME, small payload, 64KiB truncation with multibyte boundary, session ID, PostToolUse duration
- [ ] Unit tests for `make_hook_env` (subagent): truncation + ZEPH_AGENT_ID/NAME

Closes #3698