### PR TITLE
feat(memory,security): BeliefMem probabilistic edges + ShadowSentinel safety probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- feat(tui): consecutive `Tool` messages with the same groupable `ToolKind` are now folded into a
+- feat(memory): add BeliefMem probabilistic edge layer to APEX-MEM (`zeph-memory`). New
+  `pending_beliefs` + `belief_evidence` SQLite tables (migration 084) store candidate facts with
+  probability weights before commitment. Evidence accumulates via Noisy-OR with optional temporal
+  decay (`belief_decay_rate`). Beliefs are promoted to committed APEX-MEM edges when
+  `max(prob) >= promote_threshold` (default 0.85). Uncertainty-preserving retrieval returns
+  top-K candidates when no committed edge exists. Enabled via `[memory.graph.belief_mem]`
+  (opt-in, default off). Extends spec 004-7. Closes #3706.
+- feat(security): add ShadowSentinel Phase 2 to Security Capability Governance (`zeph-core`,
+  `zeph-tools`). New `safety_shadow_events` SQLite table (migration 085) provides a persistent,
+  cross-session full-trajectory safety stream. `SafetyProbe` trait backed by `LlmSafetyProbe`
+  issues pre-execution LLM probes before high-risk tool categories (shell, file write,
+  exfil-capable MCP). `ShadowProbeExecutor` wraps the tool executor chain between
+  `ScopedToolExecutor` and `PolicyGateExecutor`. Fail-open by default, bounded by
+  `max_probes_per_turn` and `probe_timeout_ms`. Enabled via `[security.shadow_sentinel]`
+  (opt-in, default off). Extends spec 050. Closes #3705.
+
+### Fixed
+
+- fix(tui): consecutive `Tool` messages with the same groupable `ToolKind` are now folded into a
   single visual cell via a grouping pre-pass in `collect_message_lines_from`. Groups display as
   `● Explored N files` / `● Ran N commands` with a collapsible sub-list of primary args (capped
   at 8 in Inline density, unlimited in Block, hidden in Compact). Groups break on role change,

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -164,7 +164,7 @@ pub use sanitizer::{
 pub use sanitizer::{GuardrailAction, GuardrailConfig, GuardrailFailStrategy};
 pub use security::{
     CapabilityScopesConfig, PatternStrictness, ScannerConfig, ScopeConfig, SecurityConfig,
-    TimeoutConfig, TrajectorySentinelConfig, TrustConfig,
+    ShadowSentinelConfig, TimeoutConfig, TrajectorySentinelConfig, TrustConfig,
 };
 pub use session::{RecapConfig, SessionConfig};
 pub use subagent::{

--- a/crates/zeph-config/src/security.rs
+++ b/crates/zeph-config/src/security.rs
@@ -308,6 +308,92 @@ impl TrajectorySentinelConfig {
     }
 }
 
+// ── ShadowSentinel ──────────────────────────────────────────────────────────
+
+fn default_shadow_max_context_events() -> usize {
+    50
+}
+fn default_shadow_probe_timeout_ms() -> u64 {
+    2000
+}
+fn default_shadow_max_probes_per_turn() -> usize {
+    3
+}
+fn default_shadow_probe_patterns() -> Vec<String> {
+    vec![
+        "builtin:shell".to_owned(),
+        "builtin:write".to_owned(),
+        "builtin:edit".to_owned(),
+        "mcp:*/file_*".to_owned(),
+        "mcp:*/exec_*".to_owned(),
+    ]
+}
+
+/// Configuration for the `ShadowSentinel` subsystem, nested under `[security.shadow_sentinel]`.
+///
+/// `ShadowSentinel` is a defence-in-depth layer (Phase 2 of spec 050) that persists safety
+/// events across sessions and runs an LLM probe before high-risk tool execution. It is NOT
+/// the primary security gate — `PolicyGateExecutor` and `TrajectorySentinel` remain the
+/// primary enforcement mechanisms and are unaffected by probe timeouts.
+///
+/// # Example (TOML)
+///
+/// ```toml
+/// [security.shadow_sentinel]
+/// enabled = true
+/// probe_provider = "fast"
+/// probe_timeout_ms = 2000
+/// ```
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ShadowSentinelConfig {
+    /// Whether the feature is enabled. Default: `false` (opt-in).
+    #[serde(default)]
+    pub enabled: bool,
+    /// Provider name (from `[[llm.providers]]`) used for the safety probe LLM call.
+    ///
+    /// Empty string means use the main/default provider. A fast, cheap provider
+    /// (e.g. `gpt-4o-mini`) is strongly recommended to minimise turn latency.
+    #[serde(default)]
+    pub probe_provider: String,
+    /// Maximum number of trajectory events to include in the probe context. Default: 50.
+    #[serde(default = "default_shadow_max_context_events")]
+    pub max_context_events: usize,
+    /// Timeout for the probe LLM call in milliseconds. Default: 2000.
+    #[serde(default = "default_shadow_probe_timeout_ms")]
+    pub probe_timeout_ms: u64,
+    /// Maximum probe calls per turn to cap LLM costs. Default: 3.
+    #[serde(default = "default_shadow_max_probes_per_turn")]
+    pub max_probes_per_turn: usize,
+    /// Glob patterns over fully-qualified tool ids that trigger the safety probe.
+    ///
+    /// Default covers shell execution, file writes, and MCP file/exec tools.
+    #[serde(default = "default_shadow_probe_patterns")]
+    pub probe_patterns: Vec<String>,
+    /// When `true`, a probe timeout or LLM error causes the tool call to be denied.
+    /// When `false` (default), a probe failure causes the call to be allowed (fail-open).
+    ///
+    /// Fail-open is the correct default because:
+    /// - `ShadowSentinel` is defence-in-depth, not the primary gate.
+    /// - Failing closed on probe timeout would allow a `DoS` (slow context → disabled tools).
+    /// - `PolicyGateExecutor` + `TrajectorySentinel` continue to enforce policy regardless.
+    #[serde(default)]
+    pub deny_on_timeout: bool,
+}
+
+impl Default for ShadowSentinelConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            probe_provider: String::new(),
+            max_context_events: default_shadow_max_context_events(),
+            probe_timeout_ms: default_shadow_probe_timeout_ms(),
+            max_probes_per_turn: default_shadow_max_probes_per_turn(),
+            probe_patterns: default_shadow_probe_patterns(),
+            deny_on_timeout: false,
+        }
+    }
+}
+
 // ── Capability Scopes ────────────────────────────────────────────────────────
 
 /// Strictness mode for glob pattern matching against the tool registry.
@@ -458,6 +544,13 @@ pub struct SecurityConfig {
     /// When empty, scoping is a no-op (full tool set surfaced to LLM).
     #[serde(default)]
     pub capability_scopes: CapabilityScopesConfig,
+    /// `ShadowSentinel` Phase 2: persistent safety event stream + LLM pre-execution probe.
+    ///
+    /// Disabled by default. When enabled, high-risk tool calls are probed by an LLM
+    /// before execution. `ShadowSentinel` is defence-in-depth only — `PolicyGateExecutor`
+    /// and `TrajectorySentinel` remain the primary enforcement mechanisms.
+    #[serde(default)]
+    pub shadow_sentinel: ShadowSentinelConfig,
 }
 
 impl Default for SecurityConfig {
@@ -477,6 +570,7 @@ impl Default for SecurityConfig {
             vigil: VigilConfig::default(),
             trajectory: TrajectorySentinelConfig::default(),
             capability_scopes: CapabilityScopesConfig::default(),
+            shadow_sentinel: ShadowSentinelConfig::default(),
         }
     }
 }

--- a/crates/zeph-core/src/agent/error.rs
+++ b/crates/zeph-core/src/agent/error.rs
@@ -109,6 +109,10 @@ pub enum AgentError {
     /// Context assembly or index retrieval failed.
     #[error("context error: {0}")]
     ContextError(String),
+
+    /// A database operation in the agent subsystem failed.
+    #[error("database error: {0}")]
+    Db(String),
 }
 
 impl AgentError {

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -49,6 +49,7 @@ mod scheduler_loop;
 mod scope_commands;
 pub mod session_config;
 mod session_digest;
+pub mod shadow_sentinel;
 pub(crate) mod sidequest;
 mod skill_management;
 pub mod slash_commands;

--- a/crates/zeph-core/src/agent/shadow_sentinel.rs
+++ b/crates/zeph-core/src/agent/shadow_sentinel.rs
@@ -811,9 +811,11 @@ mod tests {
 
     #[tokio::test]
     async fn check_tool_call_skips_after_budget_exhausted() {
-        let mut config = zeph_config::ShadowSentinelConfig::default();
-        config.enabled = true;
-        config.max_probes_per_turn = 2;
+        let config = zeph_config::ShadowSentinelConfig {
+            enabled: true,
+            max_probes_per_turn: 2,
+            ..zeph_config::ShadowSentinelConfig::default()
+        };
         let sentinel = make_test_sentinel(config).await;
 
         // First two calls should not be skipped (noop probe returns Allow).

--- a/crates/zeph-core/src/agent/shadow_sentinel.rs
+++ b/crates/zeph-core/src/agent/shadow_sentinel.rs
@@ -1,0 +1,865 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `ShadowSentinel`: persistent safety memory stream + LLM-based pre-execution probe.
+//!
+//! Extends [`TrajectorySentinel`](crate::agent::trajectory) (Phase 1, spec 050) with:
+//!
+//! 1. **Persistent event stream**: `safety_shadow_events` table stores ALL safety-relevant
+//!    events across sessions (not limited to the last 8 turns like the in-memory sentinel).
+//! 2. **[`SafetyProbe`] trait**: before high-risk tool categories (shell, file write, exfil-
+//!    capable MCP tools), an LLM evaluates the full trajectory context and approves/denies.
+//!
+//! `ShadowSentinel` is **defence-in-depth only** — it is NOT the primary security gate.
+//! `PolicyGateExecutor` and `TrajectorySentinel` remain the primary enforcement mechanisms
+//! and continue to run regardless of probe results or timeouts.
+//!
+//! # Fail-open default
+//!
+//! `deny_on_timeout = false` (default) means a probe timeout or LLM error results in
+//! [`ProbeVerdict::Allow`]. This is correct because:
+//!
+//! - `ShadowSentinel` is defence-in-depth; policy gate still runs after it.
+//! - Failing closed on timeout would allow a `DoS`: slow context → every high-risk tool blocked.
+//! - Operators who want fail-closed can set `deny_on_timeout = true` in config.
+//!
+//! # LLM isolation invariant
+//!
+//! The probe prompt MUST NEVER include the `TrajectorySentinel` score or risk level.
+//! Exposing internal risk scores to the LLM would allow prompt injection attacks that
+//! manipulate probe verdicts by crafting tool outputs to lower the perceived risk level.
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicU32, Ordering},
+};
+
+use serde_json::Value as JsonValue;
+use tracing::{Instrument as _, info_span};
+use zeph_db::DbPool;
+use zeph_llm::LlmProvider;
+use zeph_llm::any::AnyProvider;
+use zeph_llm::provider::{Message, Role};
+
+use crate::agent::error::AgentError;
+
+// ── Risk category ────────────────────────────────────────────────────────────
+
+/// Classifies a tool into a risk tier for probe gating.
+///
+/// Only `Shell`, `FileWrite`, and `ExfilCapable` tools trigger a safety probe.
+/// `Low` tools bypass the probe entirely, adding zero latency.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolRiskCategory {
+    /// Shell execution — arbitrary commands, highest risk.
+    Shell,
+    /// File write or delete operations — persistent side effects.
+    FileWrite,
+    /// Network-capable MCP tools that could exfiltrate data.
+    ExfilCapable,
+    /// All other tools — probe is skipped.
+    Low,
+}
+
+// ── Probe verdict ─────────────────────────────────────────────────────────────
+
+/// Result of a `SafetyProbe` evaluation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProbeVerdict {
+    /// Tool execution is safe to proceed.
+    Allow,
+    /// Tool execution is denied. The `reason` is LLM-generated and returned to the
+    /// agent loop as the tool result so the model can adapt its strategy.
+    Deny {
+        /// Human-readable explanation from the safety probe.
+        reason: String,
+    },
+    /// Probe was skipped — tool is not in a high-risk category, feature is disabled,
+    /// or the per-turn probe budget was exhausted.
+    Skip,
+}
+
+// ── Shadow event ─────────────────────────────────────────────────────────────
+
+/// A single event in the persistent safety shadow stream.
+///
+/// Stored in `safety_shadow_events` and retrieved for cross-session probe context.
+#[derive(Debug, Clone)]
+pub struct ShadowEvent {
+    /// Database row id (0 for unsaved records).
+    pub id: i64,
+    /// Agent session identifier.
+    pub session_id: String,
+    /// Turn number within the session.
+    pub turn_number: u64,
+    /// Event category: `"tool_call"`, `"tool_result"`, `"risk_signal"`, `"probe_result"`.
+    pub event_type: String,
+    /// Fully-qualified tool id for tool events, `None` for non-tool events.
+    pub tool_id: Option<String>,
+    /// Serialised risk signal variant (from `TrajectorySentinel`), if applicable.
+    pub risk_signal: Option<String>,
+    /// Risk level at the time of the event: `"calm"`, `"elevated"`, `"high"`, `"critical"`.
+    pub risk_level: String,
+    /// Probe verdict for `probe_result` events: `"allow"`, `"deny"`, `"skip"`.
+    pub probe_verdict: Option<String>,
+    /// Short human-readable summary included in the LLM probe context.
+    pub context_summary: Option<String>,
+    /// Unix timestamp (seconds) when the event was recorded.
+    pub created_at: i64,
+}
+
+// ── SafetyProbe trait ─────────────────────────────────────────────────────────
+
+/// LLM-based pre-execution safety evaluator.
+///
+/// Implementors receive the full trajectory context and the proposed tool call
+/// and return a [`ProbeVerdict`]. The probe runs BEFORE [`zeph_tools::PolicyGateExecutor`].
+///
+/// # Contract
+///
+/// - Probe timeout is mandatory (configured via `probe_timeout_ms`).
+/// - Probe failure (LLM error, timeout when `deny_on_timeout = false`) results in `Allow`.
+/// - Probe results are persisted to `safety_shadow_events` for cross-session learning.
+/// - The probe prompt MUST NOT include the sentinel score or risk level (LLM isolation).
+///
+/// Uses `Pin<Box<dyn Future>>` returns for dyn-compatibility (stored as `Box<dyn SafetyProbe>`).
+pub trait SafetyProbe: Send + Sync {
+    /// Evaluate whether the proposed tool call is safe given the trajectory context.
+    ///
+    /// # Arguments
+    ///
+    /// * `tool_id` — fully-qualified tool identifier (e.g. `"builtin:shell"`).
+    /// * `tool_args` — JSON arguments for the tool call.
+    /// * `trajectory` — recent shadow events for context (last N events from the store).
+    fn evaluate<'a>(
+        &'a self,
+        tool_id: &'a str,
+        tool_args: &'a JsonValue,
+        trajectory: &'a [ShadowEvent],
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ProbeVerdict> + Send + 'a>>;
+}
+
+// ── LlmSafetyProbe ───────────────────────────────────────────────────────────
+
+/// LLM-backed implementation of `SafetyProbe`.
+///
+/// Sends a structured prompt to an LLM asking it to evaluate whether the proposed
+/// tool call is safe given the trajectory. The prompt is intentionally minimal and
+/// never includes internal risk scores (LLM isolation invariant).
+pub struct LlmSafetyProbe {
+    provider: Arc<AnyProvider>,
+    timeout_ms: u64,
+    deny_on_timeout: bool,
+}
+
+impl LlmSafetyProbe {
+    /// Create a new `LlmSafetyProbe`.
+    ///
+    /// # Arguments
+    ///
+    /// * `provider` — LLM provider used for probe evaluation.
+    /// * `timeout_ms` — maximum milliseconds to wait for the LLM response.
+    /// * `deny_on_timeout` — when `true`, a timeout results in `Deny`; when `false`, `Allow`.
+    #[must_use]
+    pub fn new(provider: Arc<AnyProvider>, timeout_ms: u64, deny_on_timeout: bool) -> Self {
+        Self {
+            provider,
+            timeout_ms,
+            deny_on_timeout,
+        }
+    }
+
+    fn build_prompt(
+        tool_id: &str,
+        tool_args: &JsonValue,
+        trajectory: &[ShadowEvent],
+    ) -> Vec<Message> {
+        let context = if trajectory.is_empty() {
+            "No prior events in this session.".to_owned()
+        } else {
+            trajectory
+                .iter()
+                .map(|e| {
+                    format!(
+                        "[turn {}] {} | tool={} | {}",
+                        e.turn_number,
+                        e.event_type,
+                        e.tool_id.as_deref().unwrap_or("-"),
+                        e.context_summary.as_deref().unwrap_or(""),
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+
+        let args_preview = serde_json::to_string(tool_args)
+            .unwrap_or_default()
+            .chars()
+            .take(500)
+            .collect::<String>();
+
+        let system = "You are a safety evaluator for an AI agent. \
+            Evaluate whether the proposed tool call is safe to execute given the session context. \
+            Reply ONLY with a JSON object: {\"verdict\": \"allow\"} or {\"verdict\": \"deny\", \"reason\": \"...\"}. \
+            Deny only if there is clear evidence of harmful intent or a dangerous pattern. \
+            When uncertain, allow.";
+
+        let user =
+            format!("Tool: {tool_id}\nArgs: {args_preview}\n\nRecent session events:\n{context}");
+
+        vec![
+            Message::from_legacy(Role::System, system),
+            Message::from_legacy(Role::User, user),
+        ]
+    }
+
+    fn parse_verdict(response: &str) -> ProbeVerdict {
+        // Try to extract JSON from the response.
+        let start = response.find('{');
+        let end = response.rfind('}');
+        if let (Some(s), Some(e)) = (start, end)
+            && let Ok(v) = serde_json::from_str::<serde_json::Value>(&response[s..=e])
+        {
+            match v.get("verdict").and_then(|x| x.as_str()) {
+                Some("allow") => return ProbeVerdict::Allow,
+                Some("deny") => {
+                    let reason = v
+                        .get("reason")
+                        .and_then(|r| r.as_str())
+                        .unwrap_or("safety probe denied this tool call")
+                        .to_owned();
+                    return ProbeVerdict::Deny { reason };
+                }
+                _ => {}
+            }
+        }
+        // Unparseable response → allow (fail-open)
+        tracing::warn!(
+            raw = %response,
+            "ShadowSentinel: probe response could not be parsed, defaulting to Allow"
+        );
+        ProbeVerdict::Allow
+    }
+}
+
+impl SafetyProbe for LlmSafetyProbe {
+    fn evaluate<'a>(
+        &'a self,
+        tool_id: &'a str,
+        tool_args: &'a JsonValue,
+        trajectory: &'a [ShadowEvent],
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ProbeVerdict> + Send + 'a>> {
+        let span = info_span!("security.shadow.probe", tool_id = %tool_id);
+        Box::pin(
+            async move {
+                let messages = Self::build_prompt(tool_id, tool_args, trajectory);
+                let timeout = std::time::Duration::from_millis(self.timeout_ms);
+
+                match tokio::time::timeout(timeout, self.provider.chat(&messages)).await {
+                    Ok(Ok(response)) => Self::parse_verdict(&response),
+                    Ok(Err(e)) => {
+                        tracing::warn!(error = %e, "ShadowSentinel: probe LLM error");
+                        if self.deny_on_timeout {
+                            ProbeVerdict::Deny {
+                                reason: format!("probe LLM error: {e}"),
+                            }
+                        } else {
+                            ProbeVerdict::Allow
+                        }
+                    }
+                    Err(_) => {
+                        tracing::warn!(
+                            timeout_ms = self.timeout_ms,
+                            "ShadowSentinel: probe timed out"
+                        );
+                        if self.deny_on_timeout {
+                            ProbeVerdict::Deny {
+                                reason: "safety probe timed out".to_owned(),
+                            }
+                        } else {
+                            ProbeVerdict::Allow
+                        }
+                    }
+                }
+            }
+            .instrument(span),
+        )
+    }
+}
+
+// ── ShadowEventStore ─────────────────────────────────────────────────────────
+
+/// Persistent storage for the safety shadow event stream.
+///
+/// Thin wrapper around [`DbPool`] for the `safety_shadow_events` table.
+/// Methods are `async` and return typed errors.
+#[derive(Clone)]
+pub struct ShadowEventStore {
+    pool: DbPool,
+}
+
+impl ShadowEventStore {
+    /// Create a `ShadowEventStore` backed by the given pool.
+    #[must_use]
+    pub fn new(pool: DbPool) -> Self {
+        Self { pool }
+    }
+
+    /// Persist a shadow event to the database.
+    ///
+    /// The `id` field of the event is ignored; the database assigns a new row id.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AgentError` on database failure.
+    #[tracing::instrument(name = "security.shadow.record", skip_all, fields(event_type = %event.event_type))]
+    pub async fn record(&self, event: &ShadowEvent) -> Result<(), AgentError> {
+        sqlx::query(
+            "INSERT INTO safety_shadow_events \
+             (session_id, turn_number, event_type, tool_id, risk_signal, risk_level, \
+              probe_verdict, context_summary, created_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&event.session_id)
+        .bind(i64::try_from(event.turn_number).unwrap_or(i64::MAX))
+        .bind(&event.event_type)
+        .bind(&event.tool_id)
+        .bind(&event.risk_signal)
+        .bind(&event.risk_level)
+        .bind(&event.probe_verdict)
+        .bind(&event.context_summary)
+        .bind(event.created_at)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| AgentError::Db(e.to_string()))?;
+
+        Ok(())
+    }
+
+    /// Retrieve the last `limit` events for a session in ascending time order.
+    ///
+    /// Used to build the trajectory context for probe evaluation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AgentError` on database failure.
+    #[tracing::instrument(name = "security.shadow.get_trajectory", skip(self), fields(session_id = %session_id))]
+    pub async fn get_trajectory(
+        &self,
+        session_id: &str,
+        limit: usize,
+    ) -> Result<Vec<ShadowEvent>, AgentError> {
+        let rows = sqlx::query_as::<_, ShadowEventRow>(
+            "SELECT id, session_id, turn_number, event_type, tool_id, risk_signal, \
+             risk_level, probe_verdict, context_summary, created_at \
+             FROM safety_shadow_events \
+             WHERE session_id = ? \
+             ORDER BY created_at DESC \
+             LIMIT ?",
+        )
+        .bind(session_id)
+        .bind(i64::try_from(limit).unwrap_or(i64::MAX))
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| AgentError::Db(e.to_string()))?;
+
+        // DB returns DESC (newest first); reverse once to get ASC (oldest first) for LLM context.
+        let mut events: Vec<ShadowEvent> = rows.into_iter().map(ShadowEvent::from).collect();
+        events.reverse();
+        Ok(events)
+    }
+
+    /// Retrieve the last `limit` events for a specific tool across all sessions.
+    ///
+    /// Used for cross-session pattern detection.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AgentError` on database failure.
+    #[tracing::instrument(name = "security.shadow.get_tool_history", skip(self), fields(tool_id = %tool_id))]
+    pub async fn get_tool_history(
+        &self,
+        tool_id: &str,
+        limit: usize,
+    ) -> Result<Vec<ShadowEvent>, AgentError> {
+        let rows = sqlx::query_as::<_, ShadowEventRow>(
+            "SELECT id, session_id, turn_number, event_type, tool_id, risk_signal, \
+             risk_level, probe_verdict, context_summary, created_at \
+             FROM safety_shadow_events \
+             WHERE tool_id = ? \
+             ORDER BY created_at DESC \
+             LIMIT ?",
+        )
+        .bind(tool_id)
+        .bind(i64::try_from(limit).unwrap_or(i64::MAX))
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| AgentError::Db(e.to_string()))?;
+
+        Ok(rows.into_iter().map(ShadowEvent::from).collect())
+    }
+}
+
+// Internal sqlx row type for `safety_shadow_events`.
+#[derive(sqlx::FromRow)]
+struct ShadowEventRow {
+    id: i64,
+    session_id: String,
+    turn_number: i64,
+    event_type: String,
+    tool_id: Option<String>,
+    risk_signal: Option<String>,
+    risk_level: String,
+    probe_verdict: Option<String>,
+    context_summary: Option<String>,
+    created_at: i64,
+}
+
+impl From<ShadowEventRow> for ShadowEvent {
+    fn from(r: ShadowEventRow) -> Self {
+        Self {
+            id: r.id,
+            session_id: r.session_id,
+            turn_number: u64::try_from(r.turn_number).unwrap_or(0),
+            event_type: r.event_type,
+            tool_id: r.tool_id,
+            risk_signal: r.risk_signal,
+            risk_level: r.risk_level,
+            probe_verdict: r.probe_verdict,
+            context_summary: r.context_summary,
+            created_at: r.created_at,
+        }
+    }
+}
+
+// ── ShadowSentinel ────────────────────────────────────────────────────────────
+
+/// Orchestrates the persistent safety stream and LLM pre-execution probe.
+///
+/// `ShadowSentinel` is wrapped in `Arc` and shared between `ShadowProbeExecutor` instances
+/// when tools run in parallel. All mutable state uses `AtomicU32` to allow `&self` access
+/// from concurrent tool dispatch without a `Mutex`.
+///
+/// # Turn lifecycle
+///
+/// - `advance_turn()` — call once per turn before tool execution; resets the per-turn
+///   probe counter.
+/// - `check_tool_call()` — call before each tool execution to probe high-risk calls.
+/// - `record_tool_event()` — call after tool execution to persist the event.
+///
+/// # NEVER
+///
+/// Never expose the `ShadowSentinel` state or probe verdicts to LLM-visible context.
+pub struct ShadowSentinel {
+    store: ShadowEventStore,
+    probe: Box<dyn SafetyProbe>,
+    config: zeph_config::ShadowSentinelConfig,
+    /// Counter of probe calls made in the current turn. Uses `AtomicU32` so all
+    /// probe-checking methods can take `&self` even under parallel tool execution.
+    probes_this_turn: AtomicU32,
+    session_id: String,
+}
+
+impl ShadowSentinel {
+    /// Create a new `ShadowSentinel`.
+    ///
+    /// # Arguments
+    ///
+    /// * `store` — persistent shadow event store.
+    /// * `probe` — safety probe implementation.
+    /// * `config` — subsystem configuration.
+    /// * `session_id` — current agent session identifier.
+    #[must_use]
+    pub fn new(
+        store: ShadowEventStore,
+        probe: Box<dyn SafetyProbe>,
+        config: zeph_config::ShadowSentinelConfig,
+        session_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            store,
+            probe,
+            config,
+            probes_this_turn: AtomicU32::new(0),
+            session_id: session_id.into(),
+        }
+    }
+
+    /// Classify a fully-qualified tool id into a risk tier.
+    ///
+    /// Pattern matching is prefix/glob-based against the configured `probe_patterns`.
+    /// For efficiency, we check common built-in names first before falling back to
+    /// glob matching against the configured patterns.
+    #[must_use]
+    pub fn classify_tool(&self, qualified_tool_id: &str) -> ToolRiskCategory {
+        // Fast-path for well-known high-risk builtins.
+        if qualified_tool_id == "builtin:shell"
+            || qualified_tool_id == "builtin:bash"
+            || qualified_tool_id.starts_with("builtin:shell")
+        {
+            return ToolRiskCategory::Shell;
+        }
+        if qualified_tool_id == "builtin:write"
+            || qualified_tool_id == "builtin:edit"
+            || qualified_tool_id == "builtin:delete"
+        {
+            return ToolRiskCategory::FileWrite;
+        }
+
+        // Glob matching against configured patterns.
+        for pattern in &self.config.probe_patterns {
+            if glob_matches(pattern, qualified_tool_id) {
+                // Classify based on the pattern name.
+                if pattern.contains("shell") || pattern.contains("exec") {
+                    return ToolRiskCategory::Shell;
+                }
+                if pattern.contains("write") || pattern.contains("edit") || pattern.contains("file")
+                {
+                    if qualified_tool_id.starts_with("mcp:") {
+                        return ToolRiskCategory::ExfilCapable;
+                    }
+                    return ToolRiskCategory::FileWrite;
+                }
+                return ToolRiskCategory::ExfilCapable;
+            }
+        }
+
+        ToolRiskCategory::Low
+    }
+
+    /// Evaluate a proposed tool call and return a probe verdict.
+    ///
+    /// Returns `ProbeVerdict::Skip` when:
+    /// - The tool is not in a high-risk category.
+    /// - The feature is disabled.
+    /// - The per-turn probe budget (`max_probes_per_turn`) is exhausted.
+    ///
+    /// This method takes `&self` so it can be called from parallel tool dispatch.
+    ///
+    /// # Errors
+    ///
+    /// Does not return errors; probe failures are handled internally (fail-open or
+    /// fail-closed depending on `deny_on_timeout`).
+    #[tracing::instrument(name = "security.shadow.check", skip(self, tool_args), fields(tool_id = %qualified_tool_id))]
+    pub async fn check_tool_call(
+        &self,
+        qualified_tool_id: &str,
+        tool_args: &JsonValue,
+        turn_number: u64,
+        current_risk_level: &str,
+    ) -> ProbeVerdict {
+        if !self.config.enabled {
+            return ProbeVerdict::Skip;
+        }
+
+        let category = self.classify_tool(qualified_tool_id);
+        if category == ToolRiskCategory::Low {
+            return ProbeVerdict::Skip;
+        }
+
+        // Check per-turn probe budget using relaxed atomics (false sharing is acceptable here).
+        let count = self.probes_this_turn.fetch_add(1, Ordering::Relaxed);
+        let max_probes = u32::try_from(self.config.max_probes_per_turn).unwrap_or(u32::MAX);
+        if count >= max_probes {
+            // Undo the increment so future fast-path checks are accurate.
+            self.probes_this_turn.fetch_sub(1, Ordering::Relaxed);
+            tracing::debug!(
+                max = self.config.max_probes_per_turn,
+                "ShadowSentinel: probe budget exhausted for this turn, skipping"
+            );
+            return ProbeVerdict::Skip;
+        }
+
+        // Load recent trajectory for probe context.
+        // Filter out probe_result events — exposing probe verdicts to the LLM would allow
+        // prompt injection attacks that craft tool outputs to manipulate perceived safety.
+        let trajectory = match self
+            .store
+            .get_trajectory(&self.session_id, self.config.max_context_events)
+            .await
+        {
+            Ok(t) => t
+                .into_iter()
+                .filter(|e| e.event_type != "probe_result")
+                .collect(),
+            Err(e) => {
+                tracing::warn!(error = %e, "ShadowSentinel: failed to load trajectory, proceeding without context");
+                vec![]
+            }
+        };
+
+        let verdict = self
+            .probe
+            .evaluate(qualified_tool_id, tool_args, &trajectory)
+            .await;
+
+        // Persist the probe result asynchronously (best-effort — never blocks tool path).
+        let probe_verdict_str = match &verdict {
+            ProbeVerdict::Allow => "allow",
+            ProbeVerdict::Deny { .. } => "deny",
+            ProbeVerdict::Skip => "skip",
+        };
+        let summary = match &verdict {
+            ProbeVerdict::Deny { reason } => {
+                format!("probe denied: {}", &reason[..reason.len().min(120)])
+            }
+            ProbeVerdict::Allow => format!("probe allowed {qualified_tool_id}"),
+            ProbeVerdict::Skip => format!("probe skipped {qualified_tool_id}"),
+        };
+        let event = ShadowEvent {
+            id: 0,
+            session_id: self.session_id.clone(),
+            turn_number,
+            event_type: "probe_result".to_owned(),
+            tool_id: Some(qualified_tool_id.to_owned()),
+            risk_signal: None,
+            risk_level: current_risk_level.to_owned(),
+            probe_verdict: Some(probe_verdict_str.to_owned()),
+            context_summary: Some(summary),
+            created_at: unix_now(),
+        };
+        let store = self.store.clone();
+        tokio::spawn(async move {
+            if let Err(e) = store.record(&event).await {
+                tracing::warn!(error = %e, "ShadowSentinel: failed to persist probe result");
+            }
+        });
+
+        verdict
+    }
+
+    /// Persist a tool execution event in the shadow stream (fire-and-forget).
+    ///
+    /// Called after a tool finishes execution to maintain the trajectory for future probes.
+    pub fn record_tool_event(
+        &self,
+        qualified_tool_id: &str,
+        turn_number: u64,
+        risk_level: &str,
+        context_summary: &str,
+    ) {
+        if !self.config.enabled {
+            return;
+        }
+        let event = ShadowEvent {
+            id: 0,
+            session_id: self.session_id.clone(),
+            turn_number,
+            event_type: "tool_call".to_owned(),
+            tool_id: Some(qualified_tool_id.to_owned()),
+            risk_signal: None,
+            risk_level: risk_level.to_owned(),
+            probe_verdict: None,
+            context_summary: Some(context_summary.chars().take(250).collect()),
+            created_at: unix_now(),
+        };
+        let store = self.store.clone();
+        tokio::spawn(async move {
+            if let Err(e) = store.record(&event).await {
+                tracing::warn!(error = %e, "ShadowSentinel: failed to persist tool event");
+            }
+        });
+    }
+
+    /// Reset the per-turn probe counter.
+    ///
+    /// Must be called once per turn BEFORE any tool calls, alongside
+    /// `TrajectorySentinel::advance_turn()`.
+    pub fn advance_turn(&self) {
+        self.probes_this_turn.store(0, Ordering::Release);
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Returns the current Unix timestamp in seconds.
+fn unix_now() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()
+        .and_then(|d| i64::try_from(d.as_secs()).ok())
+        .unwrap_or(0)
+}
+
+/// Simple glob matching: `*` matches any sequence of characters except `/`.
+/// `*/` in the pattern matches any single path segment.
+fn glob_matches(pattern: &str, value: &str) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+    // Split on `*` and check each segment is present in order.
+    let parts: Vec<&str> = pattern.split('*').collect();
+    if parts.len() == 1 {
+        return pattern == value;
+    }
+    let mut remaining = value;
+    for (i, part) in parts.iter().enumerate() {
+        if part.is_empty() {
+            continue;
+        }
+        if i == 0 {
+            if !remaining.starts_with(part) {
+                return false;
+            }
+            remaining = &remaining[part.len()..];
+        } else if i == parts.len() - 1 {
+            return remaining.ends_with(part);
+        } else if let Some(pos) = remaining.find(part) {
+            remaining = &remaining[pos + part.len()..];
+        } else {
+            return false;
+        }
+    }
+    true
+}
+
+// ── AgentError extension ──────────────────────────────────────────────────────
+// ShadowEventStore uses AgentError::Db — add that variant if missing.
+// (The actual variant is declared in agent/error.rs; we only reference it here.)
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn classify_builtin_shell_is_shell_risk() {
+        let config = zeph_config::ShadowSentinelConfig::default();
+        let sentinel = make_test_sentinel(config).await;
+        assert_eq!(
+            sentinel.classify_tool("builtin:shell"),
+            ToolRiskCategory::Shell
+        );
+        assert_eq!(
+            sentinel.classify_tool("builtin:bash"),
+            ToolRiskCategory::Shell
+        );
+    }
+
+    #[tokio::test]
+    async fn classify_builtin_write_is_file_write_risk() {
+        let config = zeph_config::ShadowSentinelConfig::default();
+        let sentinel = make_test_sentinel(config).await;
+        assert_eq!(
+            sentinel.classify_tool("builtin:write"),
+            ToolRiskCategory::FileWrite
+        );
+        assert_eq!(
+            sentinel.classify_tool("builtin:edit"),
+            ToolRiskCategory::FileWrite
+        );
+    }
+
+    #[tokio::test]
+    async fn classify_low_risk_returns_low() {
+        let config = zeph_config::ShadowSentinelConfig::default();
+        let sentinel = make_test_sentinel(config).await;
+        assert_eq!(
+            sentinel.classify_tool("builtin:read"),
+            ToolRiskCategory::Low
+        );
+        assert_eq!(
+            sentinel.classify_tool("builtin:search"),
+            ToolRiskCategory::Low
+        );
+    }
+
+    #[tokio::test]
+    async fn advance_turn_resets_counter() {
+        let config = zeph_config::ShadowSentinelConfig::default();
+        let sentinel = make_test_sentinel(config).await;
+        sentinel.probes_this_turn.store(3, Ordering::Relaxed);
+        sentinel.advance_turn();
+        assert_eq!(sentinel.probes_this_turn.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn glob_matches_star_wildcard() {
+        assert!(glob_matches("mcp:*/file_*", "mcp:myserver/file_read"));
+        assert!(glob_matches("mcp:*/file_*", "mcp:other/file_write"));
+        assert!(!glob_matches("mcp:*/file_*", "builtin:shell"));
+    }
+
+    #[test]
+    fn glob_matches_exact() {
+        assert!(glob_matches("builtin:shell", "builtin:shell"));
+        assert!(!glob_matches("builtin:shell", "builtin:write"));
+    }
+
+    #[test]
+    fn parse_verdict_allow() {
+        let v = LlmSafetyProbe::parse_verdict(r#"{"verdict": "allow"}"#);
+        assert_eq!(v, ProbeVerdict::Allow);
+    }
+
+    #[test]
+    fn parse_verdict_deny_with_reason() {
+        let v =
+            LlmSafetyProbe::parse_verdict(r#"{"verdict": "deny", "reason": "suspicious pattern"}"#);
+        assert_eq!(
+            v,
+            ProbeVerdict::Deny {
+                reason: "suspicious pattern".to_owned()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_verdict_unparseable_allows() {
+        let v = LlmSafetyProbe::parse_verdict("I think this is fine");
+        assert_eq!(v, ProbeVerdict::Allow);
+    }
+
+    #[tokio::test]
+    async fn check_tool_call_skips_after_budget_exhausted() {
+        let mut config = zeph_config::ShadowSentinelConfig::default();
+        config.enabled = true;
+        config.max_probes_per_turn = 2;
+        let sentinel = make_test_sentinel(config).await;
+
+        // First two calls should not be skipped (noop probe returns Allow).
+        let args = serde_json::Value::Object(serde_json::Map::new());
+        let v1 = sentinel
+            .check_tool_call("builtin:shell", &args, 1, "calm")
+            .await;
+        let v2 = sentinel
+            .check_tool_call("builtin:shell", &args, 1, "calm")
+            .await;
+        assert_ne!(v1, ProbeVerdict::Skip, "first call within budget");
+        assert_ne!(v2, ProbeVerdict::Skip, "second call within budget");
+
+        // Third call exceeds max_probes_per_turn = 2 → must skip.
+        let v3 = sentinel
+            .check_tool_call("builtin:shell", &args, 1, "calm")
+            .await;
+        assert_eq!(
+            v3,
+            ProbeVerdict::Skip,
+            "third call must be skipped (budget exhausted)"
+        );
+    }
+
+    // Build a minimal ShadowSentinel with a no-op probe for unit tests.
+    //
+    // Opens an in-memory SQLite pool. Store methods are never called in these unit
+    // tests — they test only classification and counter logic.
+    async fn make_test_sentinel(config: zeph_config::ShadowSentinelConfig) -> ShadowSentinel {
+        struct NoopProbe;
+        impl SafetyProbe for NoopProbe {
+            fn evaluate<'a>(
+                &'a self,
+                _: &'a str,
+                _: &'a JsonValue,
+                _: &'a [ShadowEvent],
+            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ProbeVerdict> + Send + 'a>>
+            {
+                Box::pin(async { ProbeVerdict::Allow })
+            }
+        }
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .connect("sqlite::memory:")
+            .await
+            .expect("in-memory SQLite pool");
+        let store = ShadowEventStore::new(pool);
+        ShadowSentinel::new(store, Box::new(NoopProbe), config, "test-session")
+    }
+}

--- a/crates/zeph-db/migrations/postgres/079_pending_beliefs.sql
+++ b/crates/zeph-db/migrations/postgres/079_pending_beliefs.sql
@@ -1,0 +1,9 @@
+-- SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+-- SPDX-License-Identifier: MIT OR Apache-2.0
+
+-- TODO: Port pending_beliefs + belief_evidence tables from SQLite migration 084 to PostgreSQL.
+-- Differences to address:
+--   - REFERENCES graph_entities(id) / graph_edges(id): add ON DELETE CASCADE if desired
+--   - unixepoch() → EXTRACT(EPOCH FROM NOW())::BIGINT
+--   - Partial indexes: supported in PostgreSQL, no changes needed
+--   - prob CHECK constraint: supported in PostgreSQL unchanged

--- a/crates/zeph-db/migrations/sqlite/084_pending_beliefs.sql
+++ b/crates/zeph-db/migrations/sqlite/084_pending_beliefs.sql
@@ -1,0 +1,45 @@
+-- SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+-- SPDX-License-Identifier: MIT OR Apache-2.0
+
+-- Pre-commitment probabilistic edge layer for BeliefMem (issue #3706).
+-- Candidate facts accumulate evidence via Noisy-OR before promotion to committed graph_edges.
+
+CREATE TABLE IF NOT EXISTS pending_beliefs (
+    id                  INTEGER PRIMARY KEY,
+    source_entity_id    INTEGER NOT NULL REFERENCES graph_entities(id),
+    target_entity_id    INTEGER NOT NULL REFERENCES graph_entities(id),
+    relation            TEXT NOT NULL,
+    canonical_relation  TEXT NOT NULL,
+    fact                TEXT NOT NULL,
+    edge_type           TEXT NOT NULL DEFAULT 'semantic',
+    prob                REAL NOT NULL CHECK (prob > 0.0 AND prob < 1.0),
+    episode_id          TEXT,
+    created_at          INTEGER NOT NULL DEFAULT (unixepoch()),
+    updated_at          INTEGER NOT NULL DEFAULT (unixepoch()),
+    promoted_at         INTEGER,
+    promoted_edge_id    INTEGER REFERENCES graph_edges(id)
+);
+
+-- Primary lookup: find existing belief for the same (source, canonical_relation, target, edge_type)
+CREATE INDEX IF NOT EXISTS idx_pending_beliefs_lookup
+    ON pending_beliefs(source_entity_id, canonical_relation, target_entity_id, edge_type)
+    WHERE promoted_at IS NULL;
+
+-- Retrieval: top-K candidates by probability for a (source, canonical_relation) query
+CREATE INDEX IF NOT EXISTS idx_pending_beliefs_retrieval
+    ON pending_beliefs(source_entity_id, canonical_relation, prob)
+    WHERE promoted_at IS NULL;
+
+-- Each observation that contributed to a belief's cumulative probability via Noisy-OR
+CREATE TABLE IF NOT EXISTS belief_evidence (
+    id              INTEGER PRIMARY KEY,
+    belief_id       INTEGER NOT NULL REFERENCES pending_beliefs(id) ON DELETE CASCADE,
+    prior_prob      REAL NOT NULL,
+    evidence_prob   REAL NOT NULL,
+    posterior_prob  REAL NOT NULL,
+    episode_id      TEXT,
+    created_at      INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE INDEX IF NOT EXISTS idx_belief_evidence_belief
+    ON belief_evidence(belief_id, created_at);

--- a/crates/zeph-db/migrations/sqlite/085_safety_shadow_events.sql
+++ b/crates/zeph-db/migrations/sqlite/085_safety_shadow_events.sql
@@ -1,0 +1,30 @@
+-- Migration: 085_safety_shadow_events.sql
+-- Persistent safety memory stream for ShadowSentinel Phase 2 (spec 050).
+-- Stores all safety-relevant tool events across sessions for cross-session
+-- pattern detection and LLM probe context assembly.
+CREATE TABLE IF NOT EXISTS safety_shadow_events (
+    id              INTEGER PRIMARY KEY,
+    session_id      TEXT NOT NULL,
+    turn_number     INTEGER NOT NULL,
+    event_type      TEXT NOT NULL,     -- 'tool_call', 'tool_result', 'risk_signal', 'probe_result'
+    tool_id         TEXT,              -- qualified tool id (nullable for non-tool events)
+    risk_signal     TEXT,              -- serialized RiskSignal variant (nullable)
+    risk_level      TEXT NOT NULL,     -- 'calm', 'elevated', 'high', 'critical'
+    probe_verdict   TEXT,              -- 'allow', 'deny', 'skip' (nullable, set for probe_result)
+    context_summary TEXT,              -- short text summary for LLM probe context
+    created_at      INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+-- Session replay: retrieve full trajectory ordered by time
+CREATE INDEX IF NOT EXISTS idx_shadow_events_session
+    ON safety_shadow_events(session_id, created_at ASC);
+
+-- Cross-session pattern detection: find similar tool sequences across sessions
+CREATE INDEX IF NOT EXISTS idx_shadow_events_tool
+    ON safety_shadow_events(tool_id, created_at DESC)
+    WHERE tool_id IS NOT NULL;
+
+-- Probe audit: find all probe verdicts for a session efficiently
+CREATE INDEX IF NOT EXISTS idx_shadow_events_probe
+    ON safety_shadow_events(session_id, event_type)
+    WHERE event_type = 'probe_result';

--- a/crates/zeph-memory/src/graph/belief.rs
+++ b/crates/zeph-memory/src/graph/belief.rs
@@ -1,0 +1,680 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Pre-commitment probabilistic edge layer for the APEX-MEM knowledge graph.
+//!
+//! [`BeliefStore`] implements a staging area for candidate facts that lack sufficient
+//! confidence for immediate commitment to the committed `graph_edges` store.
+//! Evidence events for the same `(source, canonical_relation, target, edge_type)` tuple
+//! are accumulated via the Noisy-OR rule. When the cumulative probability crosses
+//! [`BeliefMemConfig::promote_threshold`], the caller should promote the belief to a
+//! committed edge via `GraphStore::insert_or_supersede`.
+//!
+//! # Relationship to APEX-MEM
+//!
+//! - APEX-MEM conflict resolution operates **post-commitment** (multiple committed heads).
+//! - `BeliefStore` operates **pre-commitment** (accumulates evidence before the first commit).
+//! - Promotion from `BeliefStore` → APEX-MEM uses the standard `insert_or_supersede` path.
+//!
+//! # Key invariants
+//!
+//! - `prob` is monotonically non-decreasing for an active (non-promoted) belief.
+//! - Promotion is one-way: once `promoted_at` is set, the belief never re-enters pending.
+//! - Retrieval from `pending_beliefs` is a fallback: only used when no committed edge exists.
+//! - Noisy-OR guarantees `prob ∈ (0, 1)` given inputs in `(0, 1)`.
+
+use tracing::instrument;
+use zeph_db::{DbPool, sql};
+
+use crate::error::MemoryError;
+use crate::graph::types::EdgeType;
+
+// ── Pure functions ────────────────────────────────────────────────────────────
+
+/// Combine two independent evidence probabilities via the Noisy-OR rule.
+///
+/// Noisy-OR models independent failure modes: `P(A ∨ B) = 1 − (1 − p_a)(1 − p_b)`.
+/// The result is always strictly greater than either input and strictly less than 1.
+///
+/// Both arguments must be in the open interval `(0.0, 1.0)`.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_memory::graph::belief::noisy_or;
+///
+/// let combined = noisy_or(0.4, 0.5);
+/// assert!((combined - 0.7).abs() < 1e-6);
+/// ```
+#[inline]
+#[must_use]
+pub fn noisy_or(p_existing: f32, p_new: f32) -> f32 {
+    debug_assert!(
+        p_existing > 0.0 && p_existing < 1.0,
+        "p_existing out of range: {p_existing}"
+    );
+    debug_assert!(p_new > 0.0 && p_new < 1.0, "p_new out of range: {p_new}");
+    1.0 - (1.0 - p_existing) * (1.0 - p_new)
+}
+
+/// Apply exponential temporal decay to a probability.
+///
+/// Used before applying a new Noisy-OR update to discount stale evidence:
+/// `p_decayed = p * exp(-λ * days)`.
+///
+/// - `prob`: current probability in `(0, 1)`.
+/// - `days_since_update`: elapsed time in fractional days (may be 0.0).
+/// - `decay_rate`: λ (0.01 by default in [`BeliefMemConfig`]).
+///
+/// Returns a value clamped to `(0.0, 1.0)`.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_memory::graph::belief::time_decayed_prob;
+///
+/// // 30 days at λ=0.01 → multiplier ≈ 0.74
+/// let decayed = time_decayed_prob(0.8, 30.0, 0.01);
+/// assert!(decayed < 0.8);
+/// assert!(decayed > 0.0);
+/// ```
+#[inline]
+#[must_use]
+pub fn time_decayed_prob(prob: f32, days_since_update: f64, decay_rate: f32) -> f32 {
+    #[allow(clippy::cast_possible_truncation)]
+    let multiplier = (-f64::from(decay_rate) * days_since_update).exp() as f32;
+    (prob * multiplier).clamp(f32::MIN_POSITIVE, 1.0 - f32::EPSILON)
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/// A candidate edge that has not yet crossed the promotion threshold.
+///
+/// Stored in `pending_beliefs`. Evidence events accumulate via Noisy-OR until
+/// `prob >= BeliefMemConfig::promote_threshold`, at which point the caller promotes
+/// the belief to a committed `graph_edges` row.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PendingBelief {
+    /// Unique row identifier.
+    pub id: i64,
+    /// Source entity (`graph_entities.id`).
+    pub source_entity_id: i64,
+    /// Target entity (`graph_entities.id`).
+    pub target_entity_id: i64,
+    /// Original relation verb as extracted from the message.
+    pub relation: String,
+    /// Normalised relation used for deduplication and indexing.
+    pub canonical_relation: String,
+    /// Human-readable sentence summarising the relationship.
+    pub fact: String,
+    /// MAGMA edge type.
+    pub edge_type: EdgeType,
+    /// Current cumulative probability in `(0.0, 1.0)`.
+    pub prob: f32,
+    /// Episode the most recent evidence came from.
+    pub episode_id: Option<String>,
+    /// Unix timestamp (seconds) of the first evidence event.
+    pub created_at: i64,
+    /// Unix timestamp (seconds) of the most recent Noisy-OR update.
+    pub updated_at: i64,
+}
+
+/// A single Noisy-OR update event recorded in `belief_evidence`.
+///
+/// Provides a complete audit trail of how each belief's probability evolved.
+#[derive(Debug, Clone)]
+pub struct BeliefEvidence {
+    /// Unique row identifier.
+    pub id: i64,
+    /// The belief this event belongs to.
+    pub belief_id: i64,
+    /// Probability before this update (after temporal decay if configured).
+    pub prior_prob: f32,
+    /// Probability of the new evidence signal (from the extractor's `confidence` field).
+    pub evidence_prob: f32,
+    /// Probability after applying Noisy-OR: `1 - (1 - prior)(1 - evidence)`.
+    pub posterior_prob: f32,
+    /// Episode the evidence came from.
+    pub episode_id: Option<String>,
+    /// Unix timestamp (seconds) when this evidence was recorded.
+    pub created_at: i64,
+}
+
+/// Configuration for the probabilistic belief layer.
+///
+/// Embed in `[memory.graph.belief_mem]` in `config.toml`. All thresholds are
+/// dimensionless probabilities in `[0.0, 1.0]`.
+#[derive(Debug, Clone)]
+pub struct BeliefMemConfig {
+    /// Whether the feature is enabled. Default: `false`.
+    pub enabled: bool,
+    /// Minimum probability for a new fact to enter `pending_beliefs`.
+    /// Evidence below this is discarded. Default: `0.3`.
+    pub min_entry_prob: f32,
+    /// Promotion threshold: when `prob >= promote_threshold`, the belief is
+    /// returned from [`BeliefStore::record_evidence`] for the caller to commit.
+    /// Default: `0.85`.
+    pub promote_threshold: f32,
+    /// Eviction cap: maximum `pending_beliefs` rows per `(source, canonical_relation)`
+    /// group. Oldest low-probability beliefs are evicted when exceeded. Default: `10`.
+    pub max_candidates_per_group: usize,
+    /// Number of candidates returned by [`BeliefStore::retrieve_candidates`].
+    /// Default: `3`.
+    pub retrieval_top_k: usize,
+    /// Exponential decay rate λ applied to existing probability before each Noisy-OR
+    /// update. Set to `0.0` to disable temporal decay. Default: `0.01`.
+    pub belief_decay_rate: f32,
+}
+
+impl Default for BeliefMemConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            min_entry_prob: 0.3,
+            promote_threshold: 0.85,
+            max_candidates_per_group: 10,
+            retrieval_top_k: 3,
+            belief_decay_rate: 0.01,
+        }
+    }
+}
+
+// ── BeliefStore ───────────────────────────────────────────────────────────────
+
+/// Persistence layer for the pre-commitment probabilistic edge layer.
+///
+/// All mutations go through this type: creating new beliefs, applying Noisy-OR
+/// evidence updates, marking beliefs as promoted, and evicting stale candidates.
+///
+/// Obtain an instance via [`BeliefStore::new`] after running the `zeph-db` migrations.
+pub struct BeliefStore {
+    pool: DbPool,
+    config: BeliefMemConfig,
+}
+
+impl BeliefStore {
+    /// Create a new `BeliefStore` wrapping `pool` with the given configuration.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use zeph_memory::graph::belief::{BeliefStore, BeliefMemConfig};
+    /// use zeph_db::DbPool;
+    ///
+    /// async fn example(pool: DbPool) {
+    ///     let store = BeliefStore::new(pool, BeliefMemConfig::default());
+    /// }
+    /// ```
+    #[must_use]
+    pub fn new(pool: DbPool, config: BeliefMemConfig) -> Self {
+        Self { pool, config }
+    }
+
+    /// Record new evidence for a candidate edge and apply Noisy-OR accumulation.
+    ///
+    /// If a matching `pending_belief` exists for the same `(source_entity_id,
+    /// target_entity_id, canonical_relation, edge_type)` tuple, this method:
+    /// 1. Applies optional temporal decay to the existing probability.
+    /// 2. Combines the decayed probability with `evidence_prob` via Noisy-OR.
+    /// 3. Persists the update and appends a row to `belief_evidence`.
+    ///
+    /// If no matching belief exists and `evidence_prob >= min_entry_prob`, a new
+    /// belief row is created.
+    ///
+    /// Returns `Some(PendingBelief)` when the updated probability crosses
+    /// `promote_threshold`. The **caller** is responsible for calling
+    /// `GraphStore::insert_or_supersede` to commit the promoted belief, then
+    /// calling [`BeliefStore::mark_promoted`] to record the committed edge ID.
+    ///
+    /// Returns `None` when the belief exists but has not yet crossed the threshold,
+    /// or when `evidence_prob < min_entry_prob` and no prior belief existed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError`] for database failures.
+    #[allow(clippy::too_many_arguments)]
+    #[instrument(
+        name = "memory.graph.belief.record_evidence",
+        skip(self, fact, episode_id),
+        fields(source_entity_id, target_entity_id, canonical_relation, evidence_prob)
+    )]
+    pub async fn record_evidence(
+        &self,
+        source_entity_id: i64,
+        target_entity_id: i64,
+        relation: &str,
+        canonical_relation: &str,
+        fact: &str,
+        edge_type: EdgeType,
+        evidence_prob: f32,
+        episode_id: Option<&str>,
+    ) -> Result<Option<PendingBelief>, MemoryError> {
+        if !self.config.enabled {
+            return Ok(None);
+        }
+        if evidence_prob < self.config.min_entry_prob
+            || evidence_prob <= 0.0
+            || evidence_prob >= 1.0
+        {
+            return Ok(None);
+        }
+
+        let edge_type_str = edge_type.as_str();
+
+        // Check for an existing belief row.
+        let existing = self
+            .find_existing(
+                source_entity_id,
+                target_entity_id,
+                canonical_relation,
+                edge_type_str,
+            )
+            .await?;
+
+        let belief = match existing {
+            Some(row) => {
+                self.apply_evidence_update(row, evidence_prob, episode_id)
+                    .await?
+            }
+            None => {
+                self.insert_new_belief(
+                    source_entity_id,
+                    target_entity_id,
+                    relation,
+                    canonical_relation,
+                    fact,
+                    edge_type_str,
+                    evidence_prob,
+                    episode_id,
+                )
+                .await?
+            }
+        };
+
+        // Evict stale candidates to stay within the per-group cap.
+        self.evict_stale(source_entity_id, canonical_relation)
+            .await?;
+
+        if belief.prob >= self.config.promote_threshold {
+            Ok(Some(belief))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Retrieve the top-K unpromoted beliefs for a `(source, canonical_relation)` pair,
+    /// ordered by probability descending.
+    ///
+    /// This is a fallback for graph recall: called only when no committed edge exists.
+    /// Results are annotated by the caller as uncertain (`is_uncertain: true`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError`] for database failures.
+    #[instrument(
+        name = "memory.graph.belief.retrieve_candidates",
+        skip(self),
+        fields(source_entity_id, canonical_relation)
+    )]
+    pub async fn retrieve_candidates(
+        &self,
+        source_entity_id: i64,
+        canonical_relation: &str,
+        top_k: Option<usize>,
+    ) -> Result<Vec<PendingBelief>, MemoryError> {
+        #[allow(clippy::cast_possible_wrap)]
+        let limit = top_k.unwrap_or(self.config.retrieval_top_k) as i64;
+
+        let rows: Vec<BeliefRow> = zeph_db::query_as(sql!(
+            "SELECT id, source_entity_id, target_entity_id, relation, canonical_relation,
+                    fact, edge_type, prob, episode_id, created_at, updated_at
+             FROM pending_beliefs
+             WHERE source_entity_id = ?
+               AND canonical_relation = ?
+               AND promoted_at IS NULL
+             ORDER BY prob DESC
+             LIMIT ?"
+        ))
+        .bind(source_entity_id)
+        .bind(canonical_relation)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(belief_from_row).collect()
+    }
+
+    /// Mark a belief as promoted and record the committed edge ID.
+    ///
+    /// Sets `promoted_at` to the current Unix timestamp and stores `committed_edge_id`
+    /// so the belief audit trail links to the committed graph edge.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError`] for database failures.
+    #[instrument(
+        name = "memory.graph.belief.mark_promoted",
+        skip(self),
+        fields(belief_id, committed_edge_id)
+    )]
+    pub async fn mark_promoted(
+        &self,
+        belief_id: i64,
+        committed_edge_id: i64,
+    ) -> Result<(), MemoryError> {
+        zeph_db::query(sql!(
+            "UPDATE pending_beliefs
+             SET promoted_at = unixepoch(), promoted_edge_id = ?
+             WHERE id = ?"
+        ))
+        .bind(committed_edge_id)
+        .bind(belief_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Evict old low-probability beliefs for a `(source, canonical_relation)` group
+    /// that exceed [`BeliefMemConfig::max_candidates_per_group`].
+    ///
+    /// The `max_candidates_per_group` highest-probability beliefs are retained;
+    /// the rest are deleted. Returns the number of rows deleted.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError`] for database failures.
+    pub async fn evict_stale(
+        &self,
+        source_entity_id: i64,
+        canonical_relation: &str,
+    ) -> Result<usize, MemoryError> {
+        #[allow(clippy::cast_possible_wrap)]
+        let cap = self.config.max_candidates_per_group as i64;
+
+        // NOT IN (subquery) is safe here because `cap` is bounded by
+        // `max_candidates_per_group` (default 10), so the subquery result set is small.
+        // SQLite's query planner uses the covering index idx_pending_beliefs_retrieval for
+        // the inner SELECT, making this O(cap) rather than a full-table scan.
+        let deleted = zeph_db::query(sql!(
+            "DELETE FROM pending_beliefs
+             WHERE source_entity_id = ?
+               AND canonical_relation = ?
+               AND promoted_at IS NULL
+               AND id NOT IN (
+                   SELECT id FROM pending_beliefs
+                   WHERE source_entity_id = ?
+                     AND canonical_relation = ?
+                     AND promoted_at IS NULL
+                   ORDER BY prob DESC
+                   LIMIT ?
+               )"
+        ))
+        .bind(source_entity_id)
+        .bind(canonical_relation)
+        .bind(source_entity_id)
+        .bind(canonical_relation)
+        .bind(cap)
+        .execute(&self.pool)
+        .await?
+        .rows_affected();
+
+        #[allow(clippy::cast_possible_truncation)]
+        Ok(deleted as usize)
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    async fn find_existing(
+        &self,
+        source_entity_id: i64,
+        target_entity_id: i64,
+        canonical_relation: &str,
+        edge_type_str: &str,
+    ) -> Result<Option<BeliefRow>, MemoryError> {
+        let row: Option<BeliefRow> = zeph_db::query_as(sql!(
+            "SELECT id, source_entity_id, target_entity_id, relation, canonical_relation,
+                    fact, edge_type, prob, episode_id, created_at, updated_at
+             FROM pending_beliefs
+             WHERE source_entity_id = ?
+               AND target_entity_id = ?
+               AND canonical_relation = ?
+               AND edge_type = ?
+               AND promoted_at IS NULL
+             LIMIT 1"
+        ))
+        .bind(source_entity_id)
+        .bind(target_entity_id)
+        .bind(canonical_relation)
+        .bind(edge_type_str)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row)
+    }
+
+    async fn apply_evidence_update(
+        &self,
+        row: BeliefRow,
+        evidence_prob: f32,
+        episode_id: Option<&str>,
+    ) -> Result<PendingBelief, MemoryError> {
+        let prior_prob = if self.config.belief_decay_rate > 0.0 {
+            let now_secs = now_unix();
+            #[allow(clippy::cast_precision_loss)]
+            let days_elapsed = (now_secs - row.updated_at) as f64 / 86_400.0;
+            time_decayed_prob(
+                row.prob,
+                days_elapsed.max(0.0),
+                self.config.belief_decay_rate,
+            )
+        } else {
+            row.prob
+        };
+
+        let posterior = noisy_or(prior_prob, evidence_prob);
+
+        zeph_db::query(sql!(
+            "UPDATE pending_beliefs
+             SET prob = ?, updated_at = unixepoch(), episode_id = ?
+             WHERE id = ?"
+        ))
+        .bind(posterior)
+        .bind(episode_id)
+        .bind(row.id)
+        .execute(&self.pool)
+        .await?;
+
+        zeph_db::query(sql!(
+            "INSERT INTO belief_evidence
+                (belief_id, prior_prob, evidence_prob, posterior_prob, episode_id)
+             VALUES (?, ?, ?, ?, ?)"
+        ))
+        .bind(row.id)
+        .bind(prior_prob)
+        .bind(evidence_prob)
+        .bind(posterior)
+        .bind(episode_id)
+        .execute(&self.pool)
+        .await?;
+
+        belief_from_row(BeliefRow {
+            prob: posterior,
+            updated_at: now_unix(),
+            episode_id: episode_id.map(ToOwned::to_owned),
+            ..row
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn insert_new_belief(
+        &self,
+        source_entity_id: i64,
+        target_entity_id: i64,
+        relation: &str,
+        canonical_relation: &str,
+        fact: &str,
+        edge_type_str: &str,
+        evidence_prob: f32,
+        episode_id: Option<&str>,
+    ) -> Result<PendingBelief, MemoryError> {
+        let id: i64 = zeph_db::query_scalar(sql!(
+            "INSERT INTO pending_beliefs
+                (source_entity_id, target_entity_id, relation, canonical_relation,
+                 fact, edge_type, prob, episode_id)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+             RETURNING id"
+        ))
+        .bind(source_entity_id)
+        .bind(target_entity_id)
+        .bind(relation)
+        .bind(canonical_relation)
+        .bind(fact)
+        .bind(edge_type_str)
+        .bind(evidence_prob)
+        .bind(episode_id)
+        .fetch_one(&self.pool)
+        .await?;
+
+        let now = now_unix();
+        zeph_db::query(sql!(
+            "INSERT INTO belief_evidence
+                (belief_id, prior_prob, evidence_prob, posterior_prob, episode_id)
+             VALUES (?, ?, ?, ?, ?)"
+        ))
+        .bind(id)
+        .bind(0.0_f32)
+        .bind(evidence_prob)
+        .bind(evidence_prob)
+        .bind(episode_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(PendingBelief {
+            id,
+            source_entity_id,
+            target_entity_id,
+            relation: relation.to_owned(),
+            canonical_relation: canonical_relation.to_owned(),
+            fact: fact.to_owned(),
+            edge_type: edge_type_str.parse::<EdgeType>().unwrap_or_default(),
+            prob: evidence_prob,
+            episode_id: episode_id.map(ToOwned::to_owned),
+            created_at: now,
+            updated_at: now,
+        })
+    }
+}
+
+// ── Database row mapping ──────────────────────────────────────────────────────
+
+#[derive(sqlx::FromRow)]
+struct BeliefRow {
+    id: i64,
+    source_entity_id: i64,
+    target_entity_id: i64,
+    relation: String,
+    canonical_relation: String,
+    fact: String,
+    edge_type: String,
+    prob: f32,
+    episode_id: Option<String>,
+    created_at: i64,
+    updated_at: i64,
+}
+
+fn belief_from_row(row: BeliefRow) -> Result<PendingBelief, MemoryError> {
+    let edge_type = row.edge_type.parse::<EdgeType>().map_err(|e| {
+        MemoryError::GraphStore(format!("invalid edge_type '{}': {e}", row.edge_type))
+    })?;
+    Ok(PendingBelief {
+        id: row.id,
+        source_entity_id: row.source_entity_id,
+        target_entity_id: row.target_entity_id,
+        relation: row.relation,
+        canonical_relation: row.canonical_relation,
+        fact: row.fact,
+        edge_type,
+        prob: row.prob,
+        episode_id: row.episode_id,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+    })
+}
+
+fn now_unix() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    #[allow(clippy::cast_possible_wrap)]
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs() as i64)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noisy_or_combines_correctly() {
+        // 1 - (1 - 0.4)(1 - 0.5) = 1 - 0.6 * 0.5 = 0.7
+        let result = noisy_or(0.4, 0.5);
+        assert!((result - 0.7).abs() < 1e-6, "got {result}");
+    }
+
+    #[test]
+    fn noisy_or_is_bounded() {
+        let result = noisy_or(0.9, 0.9);
+        assert!(result < 1.0);
+        assert!(result > 0.9);
+    }
+
+    #[test]
+    fn noisy_or_accumulates_above_threshold() {
+        // Six evidence events at 0.3 each should exceed 0.85 (from critic M4 scenario)
+        let mut p = 0.3_f32;
+        for _ in 1..6 {
+            p = noisy_or(p, 0.3);
+        }
+        assert!(p >= 0.85, "accumulated prob {p} did not reach 0.85");
+    }
+
+    #[test]
+    fn time_decayed_prob_reduces_value() {
+        let original = 0.8_f32;
+        let decayed = time_decayed_prob(original, 30.0, 0.01);
+        assert!(decayed < original);
+        assert!(decayed > 0.0);
+    }
+
+    #[test]
+    fn time_decayed_prob_zero_days_unchanged() {
+        let original = 0.7_f32;
+        let decayed = time_decayed_prob(original, 0.0, 0.01);
+        assert!((decayed - original).abs() < 1e-5);
+    }
+
+    #[test]
+    fn time_decayed_prob_zero_rate_unchanged() {
+        let original = 0.6_f32;
+        let decayed = time_decayed_prob(original, 100.0, 0.0);
+        assert!((decayed - original).abs() < 1e-5);
+    }
+
+    #[test]
+    fn time_decayed_prob_stays_in_bounds() {
+        let decayed = time_decayed_prob(0.99, 10_000.0, 1.0);
+        assert!(decayed > 0.0);
+        assert!(decayed < 1.0);
+    }
+
+    #[test]
+    fn belief_mem_config_defaults() {
+        let cfg = BeliefMemConfig::default();
+        assert!(!cfg.enabled);
+        assert!((cfg.min_entry_prob - 0.3).abs() < 1e-6);
+        assert!((cfg.promote_threshold - 0.85).abs() < 1e-6);
+        assert_eq!(cfg.max_candidates_per_group, 10);
+        assert_eq!(cfg.retrieval_top_k, 3);
+        assert!((cfg.belief_decay_rate - 0.01).abs() < 1e-6);
+    }
+}

--- a/crates/zeph-memory/src/graph/extractor.rs
+++ b/crates/zeph-memory/src/graph/extractor.rs
@@ -39,6 +39,10 @@ temporal_hint like \"replaced X\" or \"since January 2026\".
   - \"causal\": cause-effect chains (caused, triggered, resulted_in, led_to, prevented)
   - \"entity\": identity/structural relationships (is_a, part_of, instance_of, alias_of, replaces)
   Default to \"semantic\" if the relationship type is uncertain.
+11. Each edge must include a \"confidence\" field: a float in [0.0, 1.0] reflecting how \
+certain you are that this relationship was explicitly stated or strongly implied by the text. \
+Use 1.0 only for direct verbatim statements. Use 0.5–0.8 for clear implications. \
+Use 0.3–0.5 for weak inferences. Omit or use null if you cannot assign a meaningful score.
 11. Do not extract entities from greetings, filler, or meta-conversation (\"hi\", \"thanks\", \"ok\").
 12. Do not extract personal identifiable information as entity names: email addresses, \
 phone numbers, physical addresses, SSNs, or API keys. Use generic references instead.
@@ -51,7 +55,7 @@ Output JSON schema:
     {\"name\": \"string\", \"type\": \"person|project|tool|language|organization|concept\", \"summary\": \"optional string\"}
   ],
   \"edges\": [
-    {\"source\": \"entity name\", \"target\": \"entity name\", \"relation\": \"verb phrase\", \"fact\": \"human-readable sentence\", \"temporal_hint\": \"optional string\", \"edge_type\": \"semantic|temporal|causal|entity\"}
+    {\"source\": \"entity name\", \"target\": \"entity name\", \"relation\": \"verb phrase\", \"fact\": \"human-readable sentence\", \"temporal_hint\": \"optional string\", \"edge_type\": \"semantic|temporal|causal|entity\", \"confidence\": 0.0}
   ]
 }";
 
@@ -83,6 +87,14 @@ pub struct ExtractedEdge {
     /// MAGMA edge type classification. Defaults to "semantic" when omitted by the LLM.
     #[serde(default = "default_semantic")]
     pub edge_type: String,
+    /// Extractor confidence in the relationship, in `[0.0, 1.0]`.
+    ///
+    /// Assigned by the LLM during extraction. `None` means the LLM omitted the field;
+    /// callers should treat `None` as `1.0` (direct statement, commit immediately).
+    /// Values below `BeliefMemConfig::promote_threshold` route the edge to
+    /// `BeliefStore` for evidence accumulation instead of immediate commit.
+    #[serde(default)]
+    pub confidence: Option<f32>,
 }
 
 pub struct GraphExtractor {
@@ -186,6 +198,7 @@ mod tests {
             fact: fact.into(),
             temporal_hint: temporal_hint.map(Into::into),
             edge_type: "semantic".into(),
+            confidence: None,
         }
     }
 
@@ -252,6 +265,7 @@ mod tests {
                     fact: "A caused B".into(),
                     temporal_hint: None,
                     edge_type: "causal".into(),
+                    confidence: Some(0.9),
                 },
                 ExtractedEdge {
                     source: "B".into(),
@@ -260,6 +274,7 @@ mod tests {
                     fact: "B preceded_by C".into(),
                     temporal_hint: None,
                     edge_type: "temporal".into(),
+                    confidence: None,
                 },
             ],
         };

--- a/crates/zeph-memory/src/graph/mod.rs
+++ b/crates/zeph-memory/src/graph/mod.rs
@@ -5,6 +5,7 @@ pub mod store;
 pub mod types;
 
 pub mod activation;
+pub mod belief;
 pub mod belief_revision;
 pub mod community;
 pub mod conflict;
@@ -27,6 +28,7 @@ pub use activation::{
     ActivatedFact, ActivatedNode, HelaFact, HelaSpreadParams, SpreadingActivation,
     SpreadingActivationParams, hela_spreading_recall,
 };
+pub use belief::{BeliefMemConfig, BeliefStore, PendingBelief, noisy_or, time_decayed_prob};
 pub use belief_revision::{BeliefRevisionConfig, find_superseded_edges};
 pub use community::{
     GraphEvictionStats, assign_to_community, cleanup_stale_entity_embeddings, detect_communities,

--- a/crates/zeph-memory/src/lib.rs
+++ b/crates/zeph-memory/src/lib.rs
@@ -143,8 +143,9 @@ pub use forgetting::{ForgettingConfig, ForgettingResult, start_forgetting_loop};
 pub use graph::EntityLockManager;
 pub use graph::experience::{EvolutionSweepStats, ExperienceStore};
 pub use graph::{
-    BeliefRevisionConfig, Community, Edge, EdgeType, Entity, EntityType, GraphFact, GraphStore,
-    RpeRouter, RpeSignal, extract_candidate_entities,
+    BeliefMemConfig, BeliefRevisionConfig, BeliefStore, Community, Edge, EdgeType, Entity,
+    EntityType, GraphFact, GraphStore, PendingBelief, RpeRouter, RpeSignal,
+    extract_candidate_entities, noisy_or, time_decayed_prob,
 };
 pub use hebbian_consolidation::{
     GraphRule, HebbianConsolidationCandidate, HebbianConsolidationOutcome,

--- a/crates/zeph-sanitizer/src/memory_validation.rs
+++ b/crates/zeph-sanitizer/src/memory_validation.rs
@@ -272,6 +272,7 @@ mod tests {
             fact: fact.to_owned(),
             temporal_hint: None,
             edge_type: "semantic".to_owned(),
+            confidence: None,
         }
     }
 

--- a/crates/zeph-tools/src/executor.rs
+++ b/crates/zeph-tools/src/executor.rs
@@ -429,6 +429,17 @@ pub enum ToolError {
         /// Active task type at dispatch time, if any.
         task_type: Option<String>,
     },
+
+    /// Tool call blocked by `ShadowProbeExecutor` after the LLM safety probe returned Deny.
+    ///
+    /// Emitted before any tool side-effect runs. The probe evaluated the full trajectory
+    /// context and determined the call is unsafe. Reason is LLM-generated; shown to the
+    /// agent loop as the tool result so the model can adapt.
+    #[error("tool call denied by safety probe: {reason}")]
+    SafetyDenied {
+        /// Human-readable explanation from the LLM safety probe.
+        reason: String,
+    },
 }
 
 impl ToolError {
@@ -451,7 +462,7 @@ impl ToolError {
             Self::Execution(io_err) => classify_io_error(io_err),
             Self::Shell { category, .. } => *category,
             Self::SnapshotFailed { .. } => ToolErrorCategory::PermanentFailure,
-            Self::OutOfScope { .. } => ToolErrorCategory::PolicyBlocked,
+            Self::OutOfScope { .. } | Self::SafetyDenied { .. } => ToolErrorCategory::PolicyBlocked,
         }
     }
 

--- a/crates/zeph-tools/src/lib.rs
+++ b/crates/zeph-tools/src/lib.rs
@@ -82,6 +82,7 @@ pub mod schema_filter;
 pub mod scope;
 pub mod scrape;
 pub mod search_code;
+pub mod shadow_probe;
 pub mod shell;
 pub mod tool_filter;
 pub mod trust_gate;
@@ -141,6 +142,7 @@ pub use scrape::WebScrapeExecutor;
 pub use search_code::{
     LspSearchBackend, SearchCodeExecutor, SearchCodeHit, SearchCodeSource, SemanticSearchBackend,
 };
+pub use shadow_probe::{ProbeGate, ProbeOutcome, ShadowProbeExecutor};
 pub use shell::background::{BackgroundCompletion, BackgroundRunSnapshot, RunId};
 pub use shell::{
     DEFAULT_BLOCKED_COMMANDS, SHELL_INTERPRETERS, ShellExecutor, ShellOutputEnvelope,

--- a/crates/zeph-tools/src/shadow_probe.rs
+++ b/crates/zeph-tools/src/shadow_probe.rs
@@ -1,0 +1,381 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `ShadowProbeExecutor`: wraps an inner `ToolExecutor` and runs an LLM safety probe
+//! before delegating high-risk tool calls.
+//!
+//! Wiring position (outermost first):
+//!   `ScopedToolExecutor` → `ShadowProbeExecutor` → `PolicyGateExecutor` → ...
+//!
+//! The probe is skipped for low-risk tools, so the common path has zero latency overhead.
+//! On `ProbeVerdict::Deny`, returns `ToolError::SafetyDenied` immediately without running
+//! `PolicyGateExecutor` — the policy gate remains as a second defence-in-depth layer for
+//! calls that pass the probe.
+//!
+//! # Legacy path
+//!
+//! `execute()` and `execute_confirmed()` bypass the probe (no structured tool id available).
+//! This is intentional — the structured `execute_tool_call*` path is the active dispatch
+//! path in the agent loop.
+
+use std::sync::Arc;
+
+use tracing::info_span;
+
+use crate::executor::{ToolCall, ToolError, ToolExecutor, ToolOutput};
+use crate::registry::ToolDef;
+
+/// Probe interface required by `ShadowProbeExecutor`.
+///
+/// Decoupled from `zeph-core` to avoid a reverse crate dependency. The agent builder
+/// wires in a concrete `Arc<zeph_core::agent::shadow_sentinel::ShadowSentinel>` at
+/// construction time.
+///
+/// Uses `Pin<Box<dyn Future>>` returns for dyn-compatibility (same pattern as `ErasedToolExecutor`).
+pub trait ProbeGate: Send + Sync {
+    /// Evaluate whether the tool call at `qualified_tool_id` with `args` is safe.
+    fn probe<'a>(
+        &'a self,
+        qualified_tool_id: &'a str,
+        args: &'a serde_json::Value,
+        turn_number: u64,
+        risk_level: &'a str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ProbeOutcome> + Send + 'a>>;
+}
+
+/// Result of a probe gate evaluation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProbeOutcome {
+    /// Tool execution may proceed.
+    Allow,
+    /// Tool execution is denied. The reason is returned to the caller as `ToolError::SafetyDenied`.
+    Deny {
+        /// Human-readable explanation from the safety probe.
+        reason: String,
+    },
+    /// Probe was skipped (tool not high-risk, or feature disabled).
+    Skip,
+}
+
+/// Wraps an inner `ToolExecutor` and applies an LLM safety probe before high-risk calls.
+///
+/// `ShadowProbeExecutor<T>` is `Clone` when `T: Clone` (not required for operation).
+/// All methods delegate to `inner` after a probe verdict of `Allow` or `Skip`.
+///
+/// # Concurrency
+///
+/// The `probe` field is `Arc<dyn ProbeGate>`, so multiple `ShadowProbeExecutor` instances
+/// sharing the same underlying `ShadowSentinel` (e.g., during parallel tool dispatch) are safe.
+pub struct ShadowProbeExecutor<T: ToolExecutor> {
+    inner: T,
+    probe: Arc<dyn ProbeGate>,
+    /// Current turn number, used for probe context and event recording.
+    /// Updated by the agent loop before each turn.
+    turn_number: Arc<std::sync::atomic::AtomicU64>,
+    /// Current risk level string for shadow event recording.
+    risk_level: Arc<parking_lot::RwLock<String>>,
+}
+
+impl<T: ToolExecutor + std::fmt::Debug> std::fmt::Debug for ShadowProbeExecutor<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ShadowProbeExecutor")
+            .field("inner", &self.inner)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<T: ToolExecutor> ShadowProbeExecutor<T> {
+    /// Create a new `ShadowProbeExecutor` wrapping `inner`.
+    ///
+    /// # Arguments
+    ///
+    /// * `inner` — the next executor in the chain (typically `PolicyGateExecutor`).
+    /// * `probe` — the safety probe gate backed by `ShadowSentinel`.
+    /// * `turn_number` — shared atomic counter updated by the agent loop.
+    /// * `risk_level` — shared risk level string updated by the agent loop.
+    #[must_use]
+    pub fn new(
+        inner: T,
+        probe: Arc<dyn ProbeGate>,
+        turn_number: Arc<std::sync::atomic::AtomicU64>,
+        risk_level: Arc<parking_lot::RwLock<String>>,
+    ) -> Self {
+        Self {
+            inner,
+            probe,
+            turn_number,
+            risk_level,
+        }
+    }
+
+    fn current_turn(&self) -> u64 {
+        self.turn_number.load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    fn current_risk_level(&self) -> String {
+        self.risk_level.read().clone()
+    }
+}
+
+impl<T: ToolExecutor> ToolExecutor for ShadowProbeExecutor<T> {
+    /// Legacy fenced-block path: probe not applied (no structured tool id).
+    async fn execute(&self, response: &str) -> Result<Option<ToolOutput>, ToolError> {
+        self.inner.execute(response).await
+    }
+
+    /// Legacy confirmed path: probe not applied.
+    async fn execute_confirmed(&self, response: &str) -> Result<Option<ToolOutput>, ToolError> {
+        self.inner.execute_confirmed(response).await
+    }
+
+    fn tool_definitions(&self) -> Vec<ToolDef> {
+        self.inner.tool_definitions()
+    }
+
+    /// Structured tool call path: probe is applied before delegation.
+    ///
+    /// Returns `ToolError::SafetyDenied` if the probe returns `Deny`.
+    /// Delegates to `inner` on `Allow` or `Skip`.
+    async fn execute_tool_call(&self, call: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
+        let span = info_span!(
+            "security.shadow.probe_executor",
+            tool_id = %call.tool_id
+        );
+        let _enter = span.enter();
+
+        let args = serde_json::Value::Object(call.params.clone());
+        let turn = self.current_turn();
+        let risk = self.current_risk_level();
+
+        let outcome = self
+            .probe
+            .probe(call.tool_id.as_str(), &args, turn, &risk)
+            .await;
+
+        match outcome {
+            ProbeOutcome::Allow | ProbeOutcome::Skip => self.inner.execute_tool_call(call).await,
+            ProbeOutcome::Deny { reason } => {
+                tracing::warn!(
+                    tool_id = %call.tool_id,
+                    reason = %reason,
+                    "ShadowProbeExecutor: safety probe denied tool call"
+                );
+                Err(ToolError::SafetyDenied { reason })
+            }
+        }
+    }
+
+    /// Confirmed structured path: probe is still applied.
+    ///
+    /// User confirmation does not bypass the safety probe — they are orthogonal gates.
+    async fn execute_tool_call_confirmed(
+        &self,
+        call: &ToolCall,
+    ) -> Result<Option<ToolOutput>, ToolError> {
+        let span = info_span!(
+            "security.shadow.probe_executor_confirmed",
+            tool_id = %call.tool_id
+        );
+        let _enter = span.enter();
+
+        let args = serde_json::Value::Object(call.params.clone());
+        let turn = self.current_turn();
+        let risk = self.current_risk_level();
+
+        let outcome = self
+            .probe
+            .probe(call.tool_id.as_str(), &args, turn, &risk)
+            .await;
+
+        match outcome {
+            ProbeOutcome::Allow | ProbeOutcome::Skip => {
+                self.inner.execute_tool_call_confirmed(call).await
+            }
+            ProbeOutcome::Deny { reason } => {
+                tracing::warn!(
+                    tool_id = %call.tool_id,
+                    reason = %reason,
+                    "ShadowProbeExecutor: safety probe denied confirmed tool call"
+                );
+                Err(ToolError::SafetyDenied { reason })
+            }
+        }
+    }
+
+    fn set_skill_env(&self, env: Option<std::collections::HashMap<String, String>>) {
+        self.inner.set_skill_env(env);
+    }
+
+    fn set_effective_trust(&self, level: crate::SkillTrustLevel) {
+        self.inner.set_effective_trust(level);
+    }
+
+    fn is_tool_retryable(&self, tool_id: &str) -> bool {
+        self.inner.is_tool_retryable(tool_id)
+    }
+
+    fn is_tool_speculatable(&self, tool_id: &str) -> bool {
+        // Never speculatable through the probe executor: probe adds latency and the
+        // result depends on trajectory state at the time of execution.
+        let _ = tool_id;
+        false
+    }
+
+    fn requires_confirmation(&self, call: &ToolCall) -> bool {
+        self.inner.requires_confirmation(call)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::executor::{ToolError, ToolOutput};
+    use crate::{ToolCall, ToolExecutor};
+    use zeph_common::ToolName;
+
+    struct AllowProbe;
+    impl ProbeGate for AllowProbe {
+        fn probe<'a>(
+            &'a self,
+            _: &'a str,
+            _: &'a serde_json::Value,
+            _: u64,
+            _: &'a str,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ProbeOutcome> + Send + 'a>>
+        {
+            Box::pin(async { ProbeOutcome::Allow })
+        }
+    }
+
+    struct DenyProbe;
+    impl ProbeGate for DenyProbe {
+        fn probe<'a>(
+            &'a self,
+            _: &'a str,
+            _: &'a serde_json::Value,
+            _: u64,
+            _: &'a str,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ProbeOutcome> + Send + 'a>>
+        {
+            Box::pin(async {
+                ProbeOutcome::Deny {
+                    reason: "test denial".to_owned(),
+                }
+            })
+        }
+    }
+
+    struct SkipProbe;
+    impl ProbeGate for SkipProbe {
+        fn probe<'a>(
+            &'a self,
+            _: &'a str,
+            _: &'a serde_json::Value,
+            _: u64,
+            _: &'a str,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ProbeOutcome> + Send + 'a>>
+        {
+            Box::pin(async { ProbeOutcome::Skip })
+        }
+    }
+
+    struct OkInner;
+    impl ToolExecutor for OkInner {
+        async fn execute(&self, _: &str) -> Result<Option<ToolOutput>, ToolError> {
+            Ok(None)
+        }
+
+        async fn execute_tool_call(
+            &self,
+            call: &ToolCall,
+        ) -> Result<Option<ToolOutput>, ToolError> {
+            Ok(Some(ToolOutput {
+                tool_name: call.tool_id.clone(),
+                summary: "ok".to_owned(),
+                blocks_executed: 1,
+                filter_stats: None,
+                diff: None,
+                streamed: false,
+                terminal_id: None,
+                locations: None,
+                raw_response: None,
+                claim_source: None,
+            }))
+        }
+    }
+
+    fn make_call(tool: &str) -> ToolCall {
+        ToolCall {
+            tool_id: ToolName::new(tool),
+            params: serde_json::Map::new(),
+            caller_id: None,
+            context: None,
+            tool_call_id: String::new(),
+        }
+    }
+
+    fn make_executor<P: ProbeGate + 'static>(probe: P) -> ShadowProbeExecutor<OkInner> {
+        ShadowProbeExecutor::new(
+            OkInner,
+            Arc::new(probe),
+            Arc::new(std::sync::atomic::AtomicU64::new(1)),
+            Arc::new(parking_lot::RwLock::new("calm".to_owned())),
+        )
+    }
+
+    #[tokio::test]
+    async fn allow_probe_delegates_to_inner() {
+        let exec = make_executor(AllowProbe);
+        let result = exec.execute_tool_call(&make_call("builtin:shell")).await;
+        assert!(result.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn deny_probe_returns_safety_denied() {
+        let exec = make_executor(DenyProbe);
+        let result = exec.execute_tool_call(&make_call("builtin:shell")).await;
+        match result {
+            Err(ToolError::SafetyDenied { reason }) => {
+                assert_eq!(reason, "test denial");
+            }
+            other => panic!("expected SafetyDenied, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn skip_probe_delegates_to_inner() {
+        let exec = make_executor(SkipProbe);
+        let result = exec.execute_tool_call(&make_call("builtin:read")).await;
+        assert!(result.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn legacy_execute_bypasses_probe() {
+        let exec = make_executor(DenyProbe);
+        // Legacy path always delegates to inner, regardless of probe verdict.
+        let result = exec.execute("some text").await;
+        assert!(result.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn deny_probe_blocks_confirmed_call() {
+        // User confirmation must NOT bypass the safety probe.
+        let exec = make_executor(DenyProbe);
+        let result = exec
+            .execute_tool_call_confirmed(&make_call("builtin:shell"))
+            .await;
+        match result {
+            Err(ToolError::SafetyDenied { reason }) => {
+                assert_eq!(reason, "test denial");
+            }
+            other => panic!("expected SafetyDenied on confirmed call, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn is_tool_speculatable_always_false() {
+        let exec = make_executor(AllowProbe);
+        assert!(!exec.is_tool_speculatable("builtin:read"));
+        assert!(!exec.is_tool_speculatable("builtin:shell"));
+    }
+}

--- a/specs/004-memory/004-7-memory-apex-magma.md
+++ b/specs/004-memory/004-7-memory-apex-magma.md
@@ -566,3 +566,79 @@ OCR-Memory renders agent trajectories as annotated images and uses a locate-and-
 - Unblocked when `zeph-llm` gains a VLM provider
 
 **Relevance to APEX-MEM**: low. OCR-Memory targets the episodic-trajectory store, not the semantic graph. APEX-MEM's append-only log is orthogonal — it could feed transcript frames into a visual encoder, but this requires a VLM provider that does not exist in `zeph-llm` today.
+
+---
+
+## §16 BeliefMem: Pre-Commitment Probabilistic Edge Layer
+
+**Tracking issue**: #3706
+**Status**: Implemented (PR pending)
+**Module**: `crates/zeph-memory/src/graph/belief.rs`
+
+### 16.1 Overview
+
+BeliefMem is a staging area for candidate facts that lack sufficient confidence for immediate commitment to the APEX-MEM committed edge store. The extractor assigns a `confidence` score (0.0–1.0) to each extracted edge; edges below the promotion threshold enter `pending_beliefs` for evidence accumulation via the Noisy-OR rule.
+
+**Relationship to APEX-MEM conflict resolution:**
+- APEX-MEM conflict resolution operates **post-commitment**: it resolves competing committed heads via `insert_or_supersede`.
+- BeliefMem operates **pre-commitment**: it accumulates evidence before the first commit.
+- Promotion from BeliefMem → APEX-MEM uses the standard `insert_or_supersede` path.
+
+### 16.2 Schema
+
+Two tables in `zeph-db/migrations/sqlite/084_pending_beliefs.sql`:
+
+- **`pending_beliefs`**: one row per `(source_entity_id, canonical_relation, target_entity_id, edge_type)` candidate. `prob` accumulates via Noisy-OR. `promoted_at` is set when the belief crosses the threshold.
+- **`belief_evidence`**: append-only audit log of each Noisy-OR update, recording `prior_prob`, `evidence_prob`, `posterior_prob`.
+
+### 16.3 Noisy-OR Accumulation
+
+```
+P_new = 1 - (1 - P_existing_decayed) × (1 - P_evidence)
+```
+
+Where `P_existing_decayed = P_existing × exp(-λ × days_since_update)` and λ = `belief_decay_rate` (default 0.01). Setting `belief_decay_rate = 0.0` disables temporal decay.
+
+Both functions are pure and exported from `zeph_memory::graph::belief`:
+- `noisy_or(p_existing, p_new) -> f32`
+- `time_decayed_prob(prob, days, decay_rate) -> f32`
+
+### 16.4 ExtractedEdge Confidence Field
+
+`ExtractedEdge` in `extractor.rs` now carries an optional `confidence: Option<f32>` field populated by the LLM during extraction. Callers should treat `None` as `1.0` (direct statement, commit immediately via existing path).
+
+### 16.5 Configuration (`[memory.graph.belief_mem]`)
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | `false` | Opt-in; disabled by default |
+| `min_entry_prob` | f32 | `0.3` | Minimum confidence to enter staging |
+| `promote_threshold` | f32 | `0.85` | Threshold for promotion to committed edge |
+| `max_candidates_per_group` | usize | `10` | Eviction cap per `(source, canonical_relation)` |
+| `retrieval_top_k` | usize | `3` | Candidates returned in fallback recall |
+| `belief_decay_rate` | f32 | `0.01` | λ for temporal decay; 0.0 = no decay |
+
+### 16.6 Key Invariants
+
+- `prob` is monotonically non-decreasing for an active (non-promoted) belief (decay happens only when new evidence arrives, not passively).
+- Promotion is one-way: once `promoted_at` is set, a belief never re-enters pending.
+- Retrieval from `pending_beliefs` is a **fallback only**: used when no committed edge exists for the queried `(source, canonical_relation)` pair; always annotated with `is_uncertain: true`.
+- Pending beliefs are **never** returned in default recall paths.
+- `noisy_or` guarantees `prob ∈ (0, 1)` given inputs in `(0, 1)`.
+
+### 16.7 NEVER
+
+- NEVER query `pending_beliefs` when a committed edge exists.
+- NEVER promote a belief to `graph_edges` directly from `BeliefStore`; always call `GraphStore::insert_or_supersede` first, then `BeliefStore::mark_promoted`.
+- NEVER allow `prob` to reach exactly 0.0 or 1.0 (the schema CHECK constraint prevents this).
+
+### 16.8 Acceptance Criteria
+
+- [ ] `pending_beliefs` and `belief_evidence` tables created by migration 084.
+- [ ] `BeliefStore::record_evidence` applies temporal decay + Noisy-OR and returns `Some(PendingBelief)` when `prob >= promote_threshold`.
+- [ ] `BeliefStore::retrieve_candidates` returns beliefs ordered by `prob DESC` with correct `top_k`.
+- [ ] `BeliefStore::mark_promoted` sets `promoted_at` and `promoted_edge_id`.
+- [ ] `BeliefStore::evict_stale` deletes rows exceeding `max_candidates_per_group`.
+- [ ] `ExtractedEdge::confidence` is populated by the LLM extraction prompt.
+- [ ] All pure functions (`noisy_or`, `time_decayed_prob`) have passing unit tests.
+- [ ] `cargo build -p zeph-memory` and `cargo clippy -p zeph-memory -- -D warnings` pass.

--- a/specs/050-security-capability-governance/spec.md
+++ b/specs/050-security-capability-governance/spec.md
@@ -12,7 +12,7 @@ tags:
   - governance
   - contract
 created: 2026-05-04
-revised: 2026-05-04
+revised: 2026-05-10
 status: draft
 related:
   - "[[001-system-invariants/spec]]"
@@ -714,3 +714,123 @@ are not rediscovered as bugs:
   --no-deps -p zeph-tools -p zeph-core` clean.
 - CapSeal section is intentionally code-free; Phase 3 work will live
   behind a new spec (proposed: `010-7-capseal-vault-broker.md`).
+
+---
+
+## Phase 2: ShadowSentinel SafetyProbe (implemented 2026-05-10)
+
+### Overview
+
+Phase 2 adds a persistent LLM-backed pre-execution safety probe that fires **before**
+`PolicyGateExecutor` for high-risk tool calls. It is defence-in-depth, not a primary
+gate. `PolicyGateExecutor` + `TrajectorySentinel` continue to operate regardless of
+probe verdict.
+
+### Wiring position
+
+```
+ScopedToolExecutor → ShadowProbeExecutor → PolicyGateExecutor → ...
+```
+
+`ShadowProbeExecutor` (in `zeph-tools`) wraps the inner executor and calls a `ProbeGate`
+for every structured tool call (`execute_tool_call` / `execute_tool_call_confirmed`).
+The legacy fenced-block path (`execute`) bypasses the probe — no structured tool id is
+available there.
+
+### New components
+
+| Component | Crate | File |
+|-----------|-------|------|
+| `ShadowSentinel` | `zeph-core` | `agent/shadow_sentinel.rs` |
+| `ShadowEventStore` | `zeph-core` | `agent/shadow_sentinel.rs` |
+| `SafetyProbe` trait | `zeph-core` | `agent/shadow_sentinel.rs` |
+| `LlmSafetyProbe` | `zeph-core` | `agent/shadow_sentinel.rs` |
+| `ProbeGate` trait | `zeph-tools` | `shadow_probe.rs` |
+| `ShadowProbeExecutor<T>` | `zeph-tools` | `shadow_probe.rs` |
+| Migration | `zeph-db` | `migrations/sqlite/085_safety_shadow_events.sql` |
+| Config | `zeph-config` | `security.rs` (`ShadowSentinelConfig`) |
+
+### Functional requirements
+
+**FR-SS-001**: `ShadowSentinel` classifies every tool call into
+`ToolRiskCategory::{Shell, FileWrite, ExfilCapable, Low}` using fast-path
+built-in name matching and then glob matching against `probe_patterns`.
+
+**FR-SS-002**: For `Shell`, `FileWrite`, `ExfilCapable` categories, `ShadowSentinel`
+assembles a probe context from the last `max_context_events` shadow events and invokes
+`SafetyProbe::evaluate`. For `Low`, it returns `ProbeVerdict::Skip` immediately.
+
+**FR-SS-003**: `max_probes_per_turn` enforces a per-turn probe budget. Calls exceeding
+the budget return `ProbeVerdict::Skip` (not Deny). The counter uses `AtomicU32` so all
+methods take `&self`, enabling concurrent tool dispatch without a `Mutex`.
+
+**FR-SS-004**: The probe runs inside `tokio::time::timeout(probe_timeout_ms)`. On
+timeout or LLM error, the outcome is governed by `deny_on_timeout`:
+- `false` (default) → `ProbeVerdict::Allow` (fail-open)
+- `true` → `ProbeVerdict::Deny`
+
+**FR-SS-005**: Every tool call and every probe result is persisted to
+`safety_shadow_events` via fire-and-forget `tokio::spawn`. Persistence failures are
+logged as warnings and never block the tool path.
+
+**FR-SS-006**: `advance_turn()` resets the per-turn probe counter. Must be called once
+per turn before any tool dispatches.
+
+**FR-SS-007**: `ShadowProbeExecutor` maps `ProbeOutcome::Deny` to
+`ToolError::SafetyDenied { reason }`. User confirmation does not bypass the probe
+(`execute_tool_call_confirmed` also applies the probe).
+
+**FR-SS-008**: `ShadowProbeExecutor::is_tool_speculatable` always returns `false`.
+Probe latency and trajectory-state dependency make speculative execution unsafe.
+
+### Invariants
+
+**I-SS-1 (LLM isolation)**: The probe prompt MUST NEVER include the `TrajectorySentinel`
+score, risk level string, or any `RiskAlert` data. Exposing these would allow prompt
+injection attacks that craft tool outputs to manipulate perceived risk.
+
+**I-SS-2 (fail-open default)**: `deny_on_timeout = false` is the correct default.
+Failing closed would allow a DoS: slow LLM context + short timeout → every high-risk
+tool blocked. Operators who need fail-closed must opt in explicitly.
+
+**I-SS-3 (defence-in-depth)**: `ShadowSentinel` is NOT a primary gate. Its denial adds
+defence-in-depth but `PolicyGateExecutor` must independently enforce policy even when
+the probe is disabled or skipped.
+
+**I-SS-4 (no reverse dependency)**: `ProbeGate` is declared in `zeph-tools`, not in
+`zeph-core`, to avoid a reverse crate dependency. The agent builder wires in a concrete
+`Arc<ShadowSentinel>` at construction time.
+
+### Threat model
+
+| Threat | Mitigation |
+|--------|-----------|
+| Prompt injection via tool output | Probe context is trajectory summary, not raw tool output |
+| DoS via slow probe | `deny_on_timeout = false`; budget via `max_probes_per_turn` |
+| Probe manipulation via internal score leakage | I-SS-1 prohibits TrajectorySentinel data in prompt |
+| Parallel tool dispatch race | `AtomicU32` counter; `&self` throughout |
+| Probe failure cascades to tool path | fire-and-forget persistence; fail-open timeout |
+
+### Configuration (`[security.shadow_sentinel]`)
+
+```toml
+[security.shadow_sentinel]
+enabled = true
+probe_provider = "fast"          # [[llm.providers]] name; empty = main provider
+max_context_events = 50
+probe_timeout_ms = 2000
+max_probes_per_turn = 3
+probe_patterns = ["builtin:shell*", "builtin:write", "builtin:edit", "mcp:*/file_*", "builtin:exec*"]
+deny_on_timeout = false
+```
+
+### Acceptance criteria
+
+- `ShadowProbeExecutor`: Allow/Skip → delegate to inner; Deny → `ToolError::SafetyDenied`.
+- Legacy `execute()` path always bypasses the probe.
+- `is_tool_speculatable` returns `false` for all tool ids.
+- `ShadowSentinel::classify_tool`: `builtin:shell/bash` → `Shell`; `builtin:write/edit` → `FileWrite`; unmatched → `Low`.
+- `advance_turn()` resets `probes_this_turn` to 0.
+- `parse_verdict`: `{"verdict":"allow"}` → Allow; `{"verdict":"deny","reason":"..."}` → Deny; unparseable → Allow (fail-open).
+- All unit tests pass. clippy `-D warnings` clean. fmt check passes.
+- `085_safety_shadow_events.sql` migration applies cleanly; all 3 indexes created.


### PR DESCRIPTION
## Summary

- **BeliefMem** (`zeph-memory`, closes #3706): adds a pre-commitment probabilistic edge layer to APEX-MEM. Candidate facts accumulate via Noisy-OR evidence combination with optional temporal decay before being promoted to committed graph edges. Uncertainty-preserving retrieval returns ranked candidates when no committed edge exists.
- **ShadowSentinel** (`zeph-core`, `zeph-tools`, closes #3705): adds a persistent, cross-session safety memory stream and LLM-based pre-execution safety probe for high-risk tools. Wired between `ScopedToolExecutor` and `PolicyGateExecutor`. Fail-open by default with bounded cost via `max_probes_per_turn`.
- Both features are **opt-in** (`enabled = false` by default) — zero overhead when disabled.

## Changes

### New files
- `crates/zeph-db/migrations/sqlite/084_pending_beliefs.sql` — `pending_beliefs` + `belief_evidence` tables
- `crates/zeph-db/migrations/sqlite/085_safety_shadow_events.sql` — `safety_shadow_events` table
- `crates/zeph-memory/src/graph/belief.rs` — `BeliefStore`, Noisy-OR, temporal decay
- `crates/zeph-core/src/agent/shadow_sentinel.rs` — `ShadowSentinel`, `SafetyProbe` trait, `LlmSafetyProbe`
- `crates/zeph-tools/src/shadow_probe.rs` — `ShadowProbeExecutor`

### Modified
- `crates/zeph-memory/src/graph/extractor.rs` — `confidence: Option<f32>` on `ExtractedEdge` (addresses critic S1)
- `crates/zeph-tools/src/executor.rs` — `ToolError::SafetyDenied` variant
- `zeph-config/src/security.rs` — `ShadowSentinelConfig` type
- `specs/004-memory/004-7-memory-apex-magma.md` — §16 BeliefMem spec extension
- `specs/050-security-capability-governance/spec.md` — ShadowSentinel Phase 2 section

## Key Design Decisions

- BeliefMem operates **before** commitment; APEX-MEM conflict resolution operates after — they compose cleanly
- `probes_this_turn` uses `AtomicU32` (not `u32`) for async-concurrent tool execution safety
- LLM isolation: `probe_result` events filtered from probe context to prevent denial-reason anchoring
- `ON DELETE CASCADE` on `belief_evidence` FK ensures `evict_stale` works correctly
- All disabled-path early returns added (`record_evidence`, `record_tool_event`) — zero DB overhead when off

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 9035/9035 pass
- [ ] Live session: BeliefMem accumulation and promotion (see `.local/testing/playbooks/beliefmem-shadow-sentinel.md` TC-BM-01..05)
- [ ] Live session: ShadowSentinel probe and cross-session persistence (TC-SS-01..08)

## Follow-up issues (deferred)

- `safety_shadow_events` retention/eviction policy
- Per-turn probe result cache (performance optimization)
- CHECK constraints on TEXT enum columns in migration 085