### PR TITLE
feat(cocoon): add per-token pricing and STT Whisper endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `ScopedToolExecutor` and `PolicyGateExecutor`. Fail-open by default, bounded by
   `max_probes_per_turn` and `probe_timeout_ms`. Enabled via `[security.shadow_sentinel]`
   (opt-in, default off). Extends spec 050. Closes #3705.
-
-### Fixed
-
-- fix(tui): consecutive `Tool` messages with the same groupable `ToolKind` are now folded into a
+- feat(llm/cocoon): add `CocoonSttProvider` implementing `SpeechToText` via the sidecar's
+  `/v1/audio/transcriptions` endpoint (OpenAI Whisper wire format). Configure by setting
+  `stt_model` on a `[[llm.providers]]` entry with `type = "cocoon"`. Closes #3678.
+- feat(config): add `CocoonPricing` struct and `cocoon_pricing` field on `ProviderEntry` for
+  per-1K-token pricing (prompt + completion cents). Cocoon model names are not in the built-in
+  pricing table; this allows accurate cost tracking for any Cocoon model. Closes #3679.
+- feat(cost): `apply_cost_tracker` now accepts `&Config` and registers Cocoon provider pricing
+  with `CostTracker` at startup. Both runner and daemon code paths use the unified helper.
+- feat(llm/cocoon): add `CocoonClient::post_multipart` for multipart form POST (used by STT).
+- feat(tui): consecutive `Tool` messages with the same groupable `ToolKind` are now folded into a
   single visual cell via a grouping pre-pass in `collect_message_lines_from`. Groups display as
   `● Explored N files` / `● Ran N commands` with a collapsible sub-list of primary args (capped
   at 8 in Inline density, unlimited in Block, hidden in Compact). Groups break on role change,

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -148,7 +148,7 @@ pub use metrics::MetricsConfig;
 pub use notifications::NotificationsConfig;
 pub use providers::{
     BanditConfig, CacheTtl, CandleConfig, CandleInlineConfig, CascadeClassifierMode, CascadeConfig,
-    CoeConfig, ComplexityRoutingConfig, FAST_TIER_MODEL_HINTS, GeminiThinkingLevel,
+    CocoonPricing, CoeConfig, ComplexityRoutingConfig, FAST_TIER_MODEL_HINTS, GeminiThinkingLevel,
     GenerationParams, GonkaNode, LlmConfig, LlmRoutingStrategy, MAX_TOKENS_CAP, ProviderEntry,
     ProviderKind, ProviderName, RouterConfig, RouterStrategyConfig, SttConfig, ThinkingConfig,
     ThinkingEffort, TierMapping, validate_pool,

--- a/crates/zeph-config/src/providers.rs
+++ b/crates/zeph-config/src/providers.rs
@@ -1371,12 +1371,10 @@ impl Default for CandleInlineConfig {
 ///
 /// Cocoon model names (e.g. `Qwen/Qwen3-0.6B`) are not in the built-in pricing table.
 /// When this struct is present in a provider entry, its values are registered with
-/// [`CostTracker`] at startup so that token costs are tracked accurately.
+/// `CostTracker` at startup so that token costs are tracked accurately.
 ///
 /// Reasoning tokens (when the model uses chain-of-thought) are folded into
 /// `completion_tokens` by the Cocoon sidecar and counted at the completion price.
-///
-/// [`CostTracker`]: zeph_core::cost::CostTracker
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct CocoonPricing {
     /// Prompt (input) token price in cents per 1K tokens.

--- a/crates/zeph-config/src/providers.rs
+++ b/crates/zeph-config/src/providers.rs
@@ -1367,6 +1367,27 @@ impl Default for CandleInlineConfig {
     }
 }
 
+/// Per-1K-token pricing for a Cocoon provider, in cents.
+///
+/// Cocoon model names (e.g. `Qwen/Qwen3-0.6B`) are not in the built-in pricing table.
+/// When this struct is present in a provider entry, its values are registered with
+/// [`CostTracker`] at startup so that token costs are tracked accurately.
+///
+/// Reasoning tokens (when the model uses chain-of-thought) are folded into
+/// `completion_tokens` by the Cocoon sidecar and counted at the completion price.
+///
+/// [`CostTracker`]: zeph_core::cost::CostTracker
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct CocoonPricing {
+    /// Prompt (input) token price in cents per 1K tokens.
+    #[serde(default)]
+    pub prompt_cents_per_1k: f64,
+    /// Completion (output) token price in cents per 1K tokens.
+    /// Reasoning tokens are counted here since the sidecar folds them into completion tokens.
+    #[serde(default)]
+    pub completion_cents_per_1k: f64,
+}
+
 /// Unified provider entry: one struct replaces `CloudLlmConfig`, `OpenAiConfig`,
 /// `GeminiConfig`, `OllamaConfig`, `CompatibleConfig`, and `OrchestratorProviderConfig`.
 ///
@@ -1467,6 +1488,20 @@ pub struct ProviderEntry {
     /// Whether to perform a health check against `/stats` at provider construction time.
     #[serde(default = "default_true", skip_serializing_if = "is_true")]
     pub cocoon_health_check: bool,
+    /// Manual per-1K-token pricing for this Cocoon provider.
+    ///
+    /// Cocoon model names (e.g. `Qwen/Qwen3-0.6B`) are not in the built-in pricing table.
+    /// When this section is present, the values are registered with `CostTracker` at startup
+    /// so that token costs are tracked accurately.
+    ///
+    /// Example TOML:
+    /// ```toml
+    /// [llm.providers.cocoon_pricing]
+    /// prompt_cents_per_1k = 0.01
+    /// completion_cents_per_1k = 0.03
+    /// ```
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cocoon_pricing: Option<CocoonPricing>,
 
     /// Provider-specific instruction file.
     #[serde(default)]
@@ -1521,6 +1556,7 @@ impl Default for ProviderEntry {
             cocoon_client_url: None,
             cocoon_access_hash: None,
             cocoon_health_check: true,
+            cocoon_pricing: None,
             instruction_file: None,
             max_concurrent: None,
         }
@@ -1604,6 +1640,13 @@ impl ProviderEntry {
                              http://localhost:10000"
                         )));
                     }
+                    Ok(u) if !matches!(u.host_str(), Some("localhost" | "127.0.0.1" | "::1")) => {
+                        return Err(ConfigError::Validation(format!(
+                            "[[llm.providers]] entry '{name}': cocoon_client_url host must be \
+                             localhost or 127.0.0.1, got '{}'",
+                            u.host_str().unwrap_or("<none>")
+                        )));
+                    }
                     Ok(u) if u.scheme() != "http" && u.scheme() != "https" => {
                         return Err(ConfigError::Validation(format!(
                             "[[llm.providers]] entry '{name}': cocoon_client_url \
@@ -1619,6 +1662,21 @@ impl ProviderEntry {
                     "[[llm.providers]] entry '{name}': model must not be empty \
                      for cocoon provider"
                 )));
+            }
+            if let Some(ref p) = self.cocoon_pricing {
+                if !p.prompt_cents_per_1k.is_finite() || p.prompt_cents_per_1k < 0.0 {
+                    return Err(ConfigError::Validation(format!(
+                        "[[llm.providers]] entry '{name}': cocoon_pricing.prompt_cents_per_1k \
+                         must be a finite non-negative number"
+                    )));
+                }
+                if !p.completion_cents_per_1k.is_finite() || p.completion_cents_per_1k < 0.0 {
+                    return Err(ConfigError::Validation(format!(
+                        "[[llm.providers]] entry '{name}': \
+                         cocoon_pricing.completion_cents_per_1k \
+                         must be a finite non-negative number"
+                    )));
+                }
             }
         }
 
@@ -2694,17 +2752,28 @@ model = "claude-sonnet-4-6"
     }
 
     #[test]
-    fn test_cocoon_url_validation_accepts_https() {
+    fn test_cocoon_url_validation_accepts_https_localhost() {
         assert!(
-            cocoon_entry(Some("https://example.com:10000"), Some("Qwen/Qwen3-0.6B"))
+            cocoon_entry(Some("https://localhost:10000"), Some("Qwen/Qwen3-0.6B"))
                 .validate()
                 .is_ok()
         );
     }
 
     #[test]
+    fn test_cocoon_url_validation_rejects_non_localhost() {
+        let err = cocoon_entry(Some("http://192.168.1.10:10000"), Some("Qwen/Qwen3-0.6B"))
+            .validate()
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("localhost"),
+            "error should mention localhost restriction: {err}"
+        );
+    }
+
+    #[test]
     fn test_cocoon_url_validation_rejects_non_http_scheme() {
-        let err = cocoon_entry(Some("ftp://server"), Some("Qwen/Qwen3-0.6B"))
+        let err = cocoon_entry(Some("ftp://localhost"), Some("Qwen/Qwen3-0.6B"))
             .validate()
             .unwrap_err();
         assert!(
@@ -2751,5 +2820,35 @@ model = "claude-sonnet-4-6"
                 .validate()
                 .is_ok()
         );
+    }
+
+    #[test]
+    fn validate_cocoon_pricing_negative_prompt_errors() {
+        let mut e = cocoon_entry(Some("http://localhost:10000"), Some("Qwen/Qwen3-0.6B"));
+        e.cocoon_pricing = Some(CocoonPricing {
+            prompt_cents_per_1k: -1.0,
+            completion_cents_per_1k: 0.03,
+        });
+        assert!(e.validate().is_err());
+    }
+
+    #[test]
+    fn validate_cocoon_pricing_negative_completion_errors() {
+        let mut e = cocoon_entry(Some("http://localhost:10000"), Some("Qwen/Qwen3-0.6B"));
+        e.cocoon_pricing = Some(CocoonPricing {
+            prompt_cents_per_1k: 0.01,
+            completion_cents_per_1k: -0.5,
+        });
+        assert!(e.validate().is_err());
+    }
+
+    #[test]
+    fn validate_cocoon_pricing_valid_passes() {
+        let mut e = cocoon_entry(Some("http://localhost:10000"), Some("Qwen/Qwen3-0.6B"));
+        e.cocoon_pricing = Some(CocoonPricing {
+            prompt_cents_per_1k: 0.01,
+            completion_cents_per_1k: 0.03,
+        });
+        assert!(e.validate().is_ok());
     }
 }

--- a/crates/zeph-llm/src/cocoon/client.rs
+++ b/crates/zeph-llm/src/cocoon/client.rs
@@ -159,6 +159,36 @@ impl CocoonClient {
         .await
     }
 
+    /// POST a multipart form to `{base_url}{path}`.
+    ///
+    /// Used for audio transcription (`/v1/audio/transcriptions`). Attaches
+    /// `X-Access-Hash` header when `access_hash` is `Some`. The request is
+    /// bounded by the same LLM timeout configured at construction.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LlmError::Unavailable`] on connection failure or timeout.
+    pub async fn post_multipart(
+        &self,
+        path: &str,
+        form: reqwest::multipart::Form,
+    ) -> Result<reqwest::Response, LlmError> {
+        let span = tracing::info_span!("llm.cocoon.request", path);
+        async {
+            let url = format!("{}{path}", self.base_url);
+            let mut req = self.client.post(&url).multipart(form);
+            if let Some(ref hash) = self.access_hash {
+                req = req.header("X-Access-Hash", hash.as_str());
+            }
+            req.send().await.map_err(|e| {
+                tracing::warn!(error = %e, "cocoon multipart HTTP error");
+                LlmError::Unavailable
+            })
+        }
+        .instrument(span)
+        .await
+    }
+
     /// POST `body` to `{base_url}{path}`.
     ///
     /// Attaches `X-Access-Hash` header when `access_hash` is `Some`.

--- a/crates/zeph-llm/src/cocoon/mod.rs
+++ b/crates/zeph-llm/src/cocoon/mod.rs
@@ -28,8 +28,10 @@
 
 mod client;
 mod provider;
+mod stt;
 #[cfg(test)]
 mod tests;
 
 pub use client::{CocoonClient, CocoonHealth};
 pub use provider::CocoonProvider;
+pub use stt::CocoonSttProvider;

--- a/crates/zeph-llm/src/cocoon/mod.rs
+++ b/crates/zeph-llm/src/cocoon/mod.rs
@@ -4,8 +4,8 @@
 //! Cocoon confidential compute integration: sidecar HTTP client and LLM provider.
 //!
 //! [`CocoonClient`] communicates with the Cocoon C++ sidecar on `localhost`.
-//! [`CocoonProvider`] implements [`LlmProvider`] by delegating body construction
-//! to an inner [`OpenAiProvider`] and routing requests through [`CocoonClient`].
+//! [`CocoonProvider`] implements [`crate::provider::LlmProvider`] by delegating body construction
+//! to an inner [`crate::openai::OpenAiProvider`] and routing requests through [`CocoonClient`].
 //!
 //! All RA-TLS attestation, proxy selection, and TON payments are handled
 //! transparently by the sidecar. Zeph never connects to the proxy or TEE workers

--- a/crates/zeph-llm/src/cocoon/stt.rs
+++ b/crates/zeph-llm/src/cocoon/stt.rs
@@ -1,0 +1,189 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Speech-to-text provider for the Cocoon confidential compute sidecar.
+//!
+//! [`CocoonSttProvider`] implements [`SpeechToText`] by forwarding audio via
+//! multipart POST to the sidecar's `/v1/audio/transcriptions` endpoint.
+//! The sidecar accepts the standard OpenAI Whisper wire format.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use crate::cocoon::client::CocoonClient;
+use crate::error::LlmError;
+use crate::stt::{SpeechToText, Transcription};
+
+/// STT provider that routes audio through the Cocoon sidecar.
+///
+/// Uses the same `CocoonClient` transport as the LLM provider — the sidecar
+/// exposes `/v1/audio/transcriptions` in the OpenAI Whisper format.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::sync::Arc;
+/// use std::time::Duration;
+/// use zeph_llm::cocoon::{CocoonClient, CocoonSttProvider};
+///
+/// let client = Arc::new(CocoonClient::new(
+///     "http://localhost:10000",
+///     None,
+///     Duration::from_secs(30),
+/// ));
+/// let stt = CocoonSttProvider::new("whisper-1", client);
+/// ```
+pub struct CocoonSttProvider {
+    model: String,
+    client: Arc<CocoonClient>,
+    language: Option<String>,
+}
+
+impl std::fmt::Debug for CocoonSttProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CocoonSttProvider")
+            .field("model", &self.model)
+            .finish_non_exhaustive()
+    }
+}
+
+impl CocoonSttProvider {
+    /// Construct a new `CocoonSttProvider`.
+    ///
+    /// - `model` — Whisper model name forwarded in the `model` form field (e.g. `"whisper-1"`).
+    /// - `client` — shared transport; must point to the same sidecar as the LLM provider.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::sync::Arc;
+    /// use std::time::Duration;
+    /// use zeph_llm::cocoon::{CocoonClient, CocoonSttProvider};
+    ///
+    /// let client = Arc::new(CocoonClient::new(
+    ///     "http://localhost:10000", None, Duration::from_secs(30),
+    /// ));
+    /// let stt = CocoonSttProvider::new("whisper-1", client);
+    /// ```
+    #[must_use]
+    pub fn new(model: impl Into<String>, client: Arc<CocoonClient>) -> Self {
+        Self {
+            model: model.into(),
+            client,
+            language: None,
+        }
+    }
+
+    /// Set the transcription language hint.
+    ///
+    /// `"auto"` and empty strings are treated as no hint (the sidecar auto-detects).
+    #[must_use]
+    pub fn with_language(mut self, language: impl Into<String>) -> Self {
+        let lang = language.into();
+        if lang != "auto" && !lang.is_empty() {
+            self.language = Some(lang);
+        }
+        self
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct WhisperResponse {
+    text: String,
+}
+
+impl SpeechToText for CocoonSttProvider {
+    fn transcribe(
+        &self,
+        audio: &[u8],
+        filename: Option<&str>,
+    ) -> Pin<Box<dyn Future<Output = Result<Transcription, LlmError>> + Send + '_>> {
+        use tracing::Instrument as _;
+        let span = tracing::info_span!("llm.cocoon.stt.transcribe", model = %self.model);
+        let audio = audio.to_vec();
+        let fname = filename.unwrap_or("audio.wav").to_string();
+        Box::pin(
+            async move {
+                let part = reqwest::multipart::Part::bytes(audio)
+                    .file_name(fname)
+                    .mime_str("application/octet-stream")
+                    .map_err(|e| LlmError::TranscriptionFailed(e.to_string()))?;
+
+                let mut form = reqwest::multipart::Form::new()
+                    .text("model", self.model.clone())
+                    .text("response_format", "json")
+                    .part("file", part);
+                if let Some(ref lang) = self.language {
+                    form = form.text("language", lang.clone());
+                }
+
+                let resp = self
+                    .client
+                    .post_multipart("/v1/audio/transcriptions", form)
+                    .await?;
+
+                if !resp.status().is_success() {
+                    let status = resp.status();
+                    let mut body = resp.text().await.unwrap_or_default();
+                    body.truncate(500);
+                    return Err(LlmError::TranscriptionFailed(format!("{status}: {body}")));
+                }
+
+                let parsed: WhisperResponse = resp.json().await.map_err(LlmError::Http)?;
+                Ok(Transcription {
+                    text: parsed.text,
+                    language: None,
+                    duration_secs: None,
+                })
+            }
+            .instrument(span),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn make_client() -> Arc<CocoonClient> {
+        Arc::new(CocoonClient::new(
+            "http://localhost:10000",
+            None,
+            Duration::from_secs(30),
+        ))
+    }
+
+    #[test]
+    fn construction_stores_model() {
+        let stt = CocoonSttProvider::new("whisper-1", make_client());
+        assert_eq!(stt.model, "whisper-1");
+        assert!(stt.language.is_none());
+    }
+
+    #[test]
+    fn with_language_sets_non_auto() {
+        let stt = CocoonSttProvider::new("whisper-1", make_client()).with_language("en");
+        assert_eq!(stt.language.as_deref(), Some("en"));
+    }
+
+    #[test]
+    fn with_language_ignores_auto() {
+        let stt = CocoonSttProvider::new("whisper-1", make_client()).with_language("auto");
+        assert!(stt.language.is_none());
+    }
+
+    #[test]
+    fn with_language_ignores_empty() {
+        let stt = CocoonSttProvider::new("whisper-1", make_client()).with_language("");
+        assert!(stt.language.is_none());
+    }
+
+    #[test]
+    fn debug_does_not_expose_internals() {
+        let stt = CocoonSttProvider::new("whisper-1", make_client());
+        let debug = format!("{stt:?}");
+        assert!(debug.contains("whisper-1"));
+    }
+}

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -685,13 +685,29 @@ pub(crate) fn apply_response_cache<C: Channel>(
 
 pub(crate) fn apply_cost_tracker<C: Channel>(
     agent: Agent<C>,
-    enabled: bool,
-    max_daily_cents: u32,
+    config: &zeph_core::config::Config,
 ) -> Agent<C> {
-    if !enabled {
+    if !config.cost.enabled {
         return agent;
     }
-    agent.with_cost_tracker(CostTracker::new(true, f64::from(max_daily_cents)))
+    let mut tracker = CostTracker::new(true, f64::from(config.cost.max_daily_cents));
+    for entry in &config.llm.providers {
+        if entry.provider_type == zeph_config::ProviderKind::Cocoon
+            && let (Some(pricing), Some(model)) = (&entry.cocoon_pricing, &entry.model)
+        {
+            tracker = tracker.with_pricing(
+                model,
+                zeph_core::cost::ModelPricing {
+                    prompt_cents_per_1k: pricing.prompt_cents_per_1k,
+                    completion_cents_per_1k: pricing.completion_cents_per_1k,
+                    // Cocoon sidecar does not charge separately for cached tokens
+                    cache_read_cents_per_1k: 0.0,
+                    cache_write_cents_per_1k: 0.0,
+                },
+            );
+        }
+    }
+    agent.with_cost_tracker(tracker)
 }
 
 pub(crate) fn apply_summary_provider<C: Channel>(
@@ -1298,6 +1314,36 @@ pub(crate) fn apply_whisper_stt<C: Channel>(
     agent.with_stt(Box::new(whisper))
 }
 
+/// Apply Cocoon STT to the agent.
+///
+/// Constructs a [`CocoonClient`] from `entry`'s `cocoon_client_url` and `cocoon_access_hash`
+/// fields, then wires up a [`CocoonSttProvider`] using the LLM timeout so that large audio
+/// files are not cut off by a short health-check timeout.
+///
+/// [`CocoonClient`]: zeph_llm::cocoon::CocoonClient
+/// [`CocoonSttProvider`]: zeph_llm::cocoon::CocoonSttProvider
+#[cfg(feature = "cocoon")]
+pub(crate) fn apply_cocoon_stt<C: Channel>(
+    agent: zeph_core::agent::Agent<C>,
+    entry: &zeph_core::config::ProviderEntry,
+    language: &str,
+    llm_timeout_secs: u64,
+) -> zeph_core::agent::Agent<C> {
+    let model = entry.stt_model.as_deref().unwrap_or("whisper-1");
+    let base_url = entry
+        .cocoon_client_url
+        .as_deref()
+        .unwrap_or("http://localhost:10000");
+    let client = std::sync::Arc::new(zeph_llm::cocoon::CocoonClient::new(
+        base_url,
+        entry.cocoon_access_hash.clone(),
+        std::time::Duration::from_secs(llm_timeout_secs),
+    ));
+    let stt = zeph_llm::cocoon::CocoonSttProvider::new(model, client).with_language(language);
+    tracing::info!(model, base_url, "STT enabled via Cocoon sidecar");
+    agent.with_stt(Box::new(stt))
+}
+
 /// Apply MCP tool pruning (LLM-based) configuration to the agent.
 ///
 /// Converts `ToolPruningConfig` into `PruningParams` and optionally resolves a dedicated
@@ -1568,14 +1614,37 @@ mod tests {
     #[tokio::test]
     async fn apply_cost_tracker_disabled_returns_agent_unchanged() {
         let agent = make_agent();
-        let result = apply_cost_tracker(agent, false, 100);
+        let mut config = Config::load(Path::new("/nonexistent")).unwrap();
+        config.cost.enabled = false;
+        let result = apply_cost_tracker(agent, &config);
         drop(result);
     }
 
     #[tokio::test]
     async fn apply_cost_tracker_enabled_attaches_tracker() {
         let agent = make_agent();
-        let result = apply_cost_tracker(agent, true, 500);
+        let mut config = Config::load(Path::new("/nonexistent")).unwrap();
+        config.cost.enabled = true;
+        config.cost.max_daily_cents = 500;
+        let result = apply_cost_tracker(agent, &config);
+        drop(result);
+    }
+
+    #[tokio::test]
+    async fn apply_cost_tracker_registers_cocoon_pricing() {
+        let agent = make_agent();
+        let mut config = Config::load(Path::new("/nonexistent")).unwrap();
+        config.cost.enabled = true;
+        config.cost.max_daily_cents = 100;
+        let mut entry = zeph_config::ProviderEntry::default();
+        entry.provider_type = zeph_config::ProviderKind::Cocoon;
+        entry.model = Some("Qwen/Qwen3-0.6B".into());
+        entry.cocoon_pricing = Some(zeph_config::CocoonPricing {
+            prompt_cents_per_1k: 0.01,
+            completion_cents_per_1k: 0.03,
+        });
+        config.llm.providers = vec![entry];
+        let result = apply_cost_tracker(agent, &config);
         drop(result);
     }
 

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -1636,13 +1636,15 @@ mod tests {
         let mut config = Config::load(Path::new("/nonexistent")).unwrap();
         config.cost.enabled = true;
         config.cost.max_daily_cents = 100;
-        let mut entry = zeph_config::ProviderEntry::default();
-        entry.provider_type = zeph_config::ProviderKind::Cocoon;
-        entry.model = Some("Qwen/Qwen3-0.6B".into());
-        entry.cocoon_pricing = Some(zeph_config::CocoonPricing {
-            prompt_cents_per_1k: 0.01,
-            completion_cents_per_1k: 0.03,
-        });
+        let entry = zeph_config::ProviderEntry {
+            provider_type: zeph_config::ProviderKind::Cocoon,
+            model: Some("Qwen/Qwen3-0.6B".into()),
+            cocoon_pricing: Some(zeph_config::CocoonPricing {
+                prompt_cents_per_1k: 0.01,
+                completion_cents_per_1k: 0.03,
+            }),
+            ..zeph_config::ProviderEntry::default()
+        };
         config.llm.providers = vec![entry];
         let result = apply_cost_tracker(agent, &config);
         drop(result);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -660,13 +660,7 @@ pub(crate) async fn run_daemon(
         agent
     };
 
-    let agent = if config.cost.enabled {
-        let tracker =
-            zeph_core::cost::CostTracker::new(true, f64::from(config.cost.max_daily_cents));
-        agent.with_cost_tracker(tracker)
-    } else {
-        agent
-    };
+    let agent = agent_setup::apply_cost_tracker(agent, config);
 
     let agent = if config.tools.anomaly.enabled {
         agent.with_anomaly_detector(zeph_tools::AnomalyDetector::new(

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2117,8 +2117,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         config.llm.semantic_cache_enabled,
         crate::bootstrap::effective_embedding_model(config),
     );
-    let agent =
-        agent_setup::apply_cost_tracker(agent, config.cost.enabled, config.cost.max_daily_cents);
+    let agent = agent_setup::apply_cost_tracker(agent, config);
     let agent = agent_setup::apply_summary_provider(agent, summary_provider);
     let probe_provider = app.build_probe_provider();
     let agent = if let Some(pp) = probe_provider {
@@ -2543,6 +2542,22 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
                     tracing::error!(
                         provider = stt_entry.effective_name(),
                         "STT provider is type candle but the `candle` feature is not enabled; \
+                         STT disabled"
+                    );
+                    agent
+                }
+                #[cfg(feature = "cocoon")]
+                zeph_core::config::ProviderKind::Cocoon => agent_setup::apply_cocoon_stt(
+                    agent,
+                    stt_entry,
+                    language,
+                    config.timeouts.llm_request_timeout_secs,
+                ),
+                #[cfg(not(feature = "cocoon"))]
+                zeph_core::config::ProviderKind::Cocoon => {
+                    tracing::error!(
+                        provider = stt_entry.effective_name(),
+                        "STT provider is type cocoon but the `cocoon` feature is not enabled; \
                          STT disabled"
                     );
                     agent


### PR DESCRIPTION
## Summary

- Add `cocoon_pricing` config field (`prompt_cents_per_1k`, `completion_cents_per_1k`) to `ProviderEntry` so Cocoon model costs are tracked in `CostTracker` instead of silently recording zero (#3679)
- Add `CocoonSttProvider` implementing the `SpeechToText` trait, routing audio to the Cocoon sidecar's Whisper-compatible `/v1/audio/transcriptions` endpoint (#3678)
- Refactor `apply_cost_tracker` to accept `&Config` and register Cocoon pricing at bootstrap; fix `daemon.rs` which had an independent inline `CostTracker::new()` that bypassed shared initialization
- Security: validate `cocoon_pricing` fields against negative/NaN/Inf; restrict `cocoon_client_url` to loopback hosts to prevent SSRF

## Changes

- `crates/zeph-config/src/providers.rs` — `CocoonPricing` struct, `ProviderEntry.cocoon_pricing`, validation (loopback host, finite non-negative pricing)
- `crates/zeph-config/src/lib.rs` — re-export `CocoonPricing`
- `crates/zeph-llm/src/cocoon/client.rs` — `post_multipart()` with LLM timeout
- `crates/zeph-llm/src/cocoon/stt.rs` — new `CocoonSttProvider` (5 unit tests, tracing span)
- `crates/zeph-llm/src/cocoon/mod.rs` — expose `stt` module
- `src/agent_setup.rs` — refactored `apply_cost_tracker(&Config)`, new `apply_cocoon_stt()`
- `src/daemon.rs` — replace inline `CostTracker::new()` with shared `apply_cost_tracker()`
- `src/runner.rs` — STT dispatch `#[cfg(feature = "cocoon")]` branch

## Test plan

- [ ] 9025 unit tests pass (`cargo nextest run --workspace --lib --bins`)
- [ ] `cargo +nightly fmt --check` clean
- [ ] `cargo clippy --workspace -- -D warnings` clean
- [ ] Pricing: configure `cocoon_pricing` in a local config and verify `CostTracker` records non-zero cost after inference
- [ ] STT: send an audio file via `zeph stt --provider cocoon` and verify transcription round-trip
- [ ] Security: verify configs with negative pricing or non-loopback URL are rejected at startup

Closes #3679
Closes #3678