### PR TITLE
fix(llm): add missing backticks in stt.rs doc comments

### DIFF
--- a/crates/zeph-llm/src/cocoon/stt.rs
+++ b/crates/zeph-llm/src/cocoon/stt.rs
@@ -5,7 +5,7 @@
 //!
 //! [`CocoonSttProvider`] implements [`SpeechToText`] by forwarding audio via
 //! multipart POST to the sidecar's `/v1/audio/transcriptions` endpoint.
-//! The sidecar accepts the standard OpenAI Whisper wire format.
+//! The sidecar accepts the standard `OpenAI` Whisper wire format.
 
 use std::future::Future;
 use std::pin::Pin;
@@ -18,7 +18,7 @@ use crate::stt::{SpeechToText, Transcription};
 /// STT provider that routes audio through the Cocoon sidecar.
 ///
 /// Uses the same `CocoonClient` transport as the LLM provider — the sidecar
-/// exposes `/v1/audio/transcriptions` in the OpenAI Whisper format.
+/// exposes `/v1/audio/transcriptions` in the `OpenAI` Whisper format.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
## Summary

- Add backticks around `OpenAI` in two doc comments in `crates/zeph-llm/src/cocoon/stt.rs` (lines 8 and 21)
- Fixes `clippy::doc_markdown` / `missing_backtick_in_doc_comment` errors introduced in PR #3737

## Test plan

- [x] `cargo +nightly fmt --check` — passes
- [x] `cargo clippy --all-targets --workspace --features full -- -D warnings` — 0 warnings/errors

Closes #3741