### PR TITLE
fix(security): extend classify_tool to recognise bare shell and file-write tool ids

### DIFF
--- a/crates/zeph-core/src/agent/shadow_sentinel.rs
+++ b/crates/zeph-core/src/agent/shadow_sentinel.rs
@@ -496,12 +496,18 @@ impl ShadowSentinel {
         if qualified_tool_id == "builtin:shell"
             || qualified_tool_id == "builtin:bash"
             || qualified_tool_id.starts_with("builtin:shell")
+            || qualified_tool_id == "bash"
+            || qualified_tool_id == "shell"
+            || qualified_tool_id == "sh"
         {
             return ToolRiskCategory::Shell;
         }
         if qualified_tool_id == "builtin:write"
             || qualified_tool_id == "builtin:edit"
             || qualified_tool_id == "builtin:delete"
+            || qualified_tool_id == "write"
+            || qualified_tool_id == "edit"
+            || qualified_tool_id == "delete"
         {
             return ToolRiskCategory::FileWrite;
         }
@@ -760,6 +766,27 @@ mod tests {
         assert_eq!(
             sentinel.classify_tool("builtin:search"),
             ToolRiskCategory::Low
+        );
+    }
+
+    #[tokio::test]
+    async fn classify_bare_shell_names_are_shell_risk() {
+        let config = zeph_config::ShadowSentinelConfig::default();
+        let sentinel = make_test_sentinel(config).await;
+        assert_eq!(sentinel.classify_tool("bash"), ToolRiskCategory::Shell);
+        assert_eq!(sentinel.classify_tool("shell"), ToolRiskCategory::Shell);
+        assert_eq!(sentinel.classify_tool("sh"), ToolRiskCategory::Shell);
+    }
+
+    #[tokio::test]
+    async fn classify_bare_file_write_names_are_file_write_risk() {
+        let config = zeph_config::ShadowSentinelConfig::default();
+        let sentinel = make_test_sentinel(config).await;
+        assert_eq!(sentinel.classify_tool("write"), ToolRiskCategory::FileWrite);
+        assert_eq!(sentinel.classify_tool("edit"), ToolRiskCategory::FileWrite);
+        assert_eq!(
+            sentinel.classify_tool("delete"),
+            ToolRiskCategory::FileWrite
         );
     }
 


### PR DESCRIPTION
## Summary

- `ShadowSentinel.classify_tool()` fast-path only matched `"builtin:bash"` / `"builtin:shell"`, but `ShellExecutor` and `FileExecutor` register tools without the `builtin:` prefix (`"bash"`, `"write"`, `"edit"`, `"delete"`).
- As a result, every call to `classify_tool("bash")` returned `ToolRiskCategory::Low` → `ProbeVerdict::Skip`, so the LLM safety probe never fired and `safety_shadow_events` remained empty even during active shell sessions.
- Fix: add bare `"bash"`, `"shell"`, `"sh"` → `Shell` and `"write"`, `"edit"`, `"delete"` → `FileWrite` alongside existing qualified forms.
- Added 2 regression tests; all 9502 workspace tests pass.

## Test plan

- [ ] `cargo nextest run -p zeph-core -E 'test(classify)'` — 5/5 pass (including 2 new regression tests)
- [ ] `cargo nextest run --workspace --features full --lib --bins` — 9502/9502 pass
- [ ] `cargo clippy --workspace --features full -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean

Closes #3744