### PR TITLE
feat(channels): configurable Telegram streaming interval and Bot API 10.0 HTTP wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- feat(channels): add configurable Telegram streaming edit interval (`stream_interval_ms`,
+  default 3000ms, minimum 500ms). Replaces the hardcoded 3-second delay in
+  `TelegramChannel::should_send_update()` with the new `with_stream_interval(Duration)` builder.
+  Fixes a silent data-loss bug where short LLM responses fitting within one interval window were
+  discarded by `flush_chunks`. Closes #3727.
+- feat(channels): add `TelegramApiClient` raw HTTP wrapper for Telegram Bot API 10.0 methods
+  unavailable in teloxide 0.17: `answer_guest_query`, `get_managed_bot_access_settings`,
+  `set_managed_bot_access_settings`, `delete_message_reaction`, `delete_all_message_reactions`.
+  Bot token is redacted in `Debug` output and stripped from `reqwest` errors via `.without_url()`.
+  Unblocks Guest Mode (#3729), Bot-to-Bot communication (#3730), and reaction moderation (#3731).
+  Closes #3728.
+
 - feat(memory): add BeliefMem probabilistic edge layer to APEX-MEM (`zeph-memory`). New
   `pending_beliefs` + `belief_evidence` SQLite tables (migration 084) store candidate facts with
   probability weights before commitment. Evidence accumulates via Noisy-OR with optional temporal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10542,6 +10542,7 @@ dependencies = [
  "subtle",
  "teloxide",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
  "tokio-util",

--- a/crates/zeph-channels/Cargo.toml
+++ b/crates/zeph-channels/Cargo.toml
@@ -31,6 +31,7 @@ subtle = { workspace = true, optional = true }
 teloxide = { workspace = true, features = ["rustls", "ctrlc_handler", "macros"] }
 tokio = { workspace = true, features = ["sync", "rt"] }
 tokio-tungstenite = { workspace = true, optional = true, features = ["connect", "rustls-tls-native-roots"] }
+thiserror.workspace = true
 tracing.workspace = true
 unicode-width.workspace = true
 zeph-common.workspace = true

--- a/crates/zeph-channels/src/lib.rs
+++ b/crates/zeph-channels/src/lib.rs
@@ -41,6 +41,7 @@ pub mod markdown;
 #[cfg(feature = "slack")]
 pub mod slack;
 pub mod telegram;
+pub mod telegram_api_ext;
 
 pub use any::AnyChannel;
 pub use cli::CliChannel;

--- a/crates/zeph-channels/src/telegram.rs
+++ b/crates/zeph-channels/src/telegram.rs
@@ -24,6 +24,7 @@
 use std::time::{Duration, Instant};
 
 use crate::markdown::markdown_to_telegram;
+use crate::telegram_api_ext::TelegramApiClient;
 use teloxide::prelude::*;
 use teloxide::types::{BotCommand, ChatAction, MessageId, ParseMode};
 use tokio::sync::mpsc;
@@ -75,6 +76,7 @@ const MAX_IMAGE_BYTES: u32 = 20 * 1024 * 1024;
 /// let token = std::env::var("TELEGRAM_BOT_TOKEN").unwrap();
 /// let allowed = vec!["my_username".to_string()];
 /// let channel = TelegramChannel::new(token, allowed)
+///     .with_stream_interval(std::time::Duration::from_millis(2000))
 ///     .start()
 ///     .expect("failed to start telegram bot");
 /// ```
@@ -90,6 +92,10 @@ pub struct TelegramChannel {
     accumulated: String,
     last_edit: Option<Instant>,
     message_id: Option<MessageId>,
+    /// Minimum interval between streaming message edits. Defaults to 3 seconds.
+    stream_interval: Duration,
+    /// Raw Bot API 10.0 client for methods not yet covered by teloxide.
+    api_ext: TelegramApiClient,
     /// Optional supervisor used to register the Telegram listener task in the
     /// workspace-wide task registry with automatic restart on panic.
     supervisor: Option<TaskSupervisor>,
@@ -101,6 +107,7 @@ impl std::fmt::Debug for TelegramChannel {
             .field("chat_id", &self.chat_id)
             .field("allowed_users", &self.allowed_users)
             .field("accumulated_len", &self.accumulated.len())
+            .field("stream_interval_ms", &self.stream_interval.as_millis())
             .field("supervisor", &self.supervisor.is_some())
             .finish_non_exhaustive()
     }
@@ -125,10 +132,15 @@ impl TelegramChannel {
     /// * `allowed_users` — Telegram usernames (without `@`) that are permitted
     ///   to interact with the bot.  Must not be empty when [`start`] is called.
     ///
+    /// Use [`with_stream_interval`] to change the default 3-second streaming edit interval.
+    ///
     /// [`start`]: TelegramChannel::start
+    /// [`with_stream_interval`]: TelegramChannel::with_stream_interval
     #[must_use]
-    pub fn new(token: String, allowed_users: Vec<String>) -> Self {
-        let bot = Bot::new(token);
+    pub fn new(token: impl Into<String>, allowed_users: Vec<String>) -> Self {
+        let token = token.into();
+        let bot = Bot::new(&token);
+        let api_ext = TelegramApiClient::new(&token);
         let (_, rx) = mpsc::channel(64);
         Self {
             bot,
@@ -138,8 +150,38 @@ impl TelegramChannel {
             accumulated: String::new(),
             last_edit: None,
             message_id: None,
+            stream_interval: Duration::from_secs(3),
+            api_ext,
             supervisor: None,
         }
+    }
+
+    /// Set the minimum interval between streaming message edits.
+    ///
+    /// Values below 500 ms are clamped to 500 ms with a warning to prevent
+    /// triggering Telegram's rate limits (30 edits/second per chat).
+    ///
+    /// Default: 3000 ms.
+    #[must_use]
+    pub fn with_stream_interval(mut self, interval: Duration) -> Self {
+        const MIN_INTERVAL: Duration = Duration::from_millis(500);
+        if interval < MIN_INTERVAL {
+            tracing::warn!(
+                requested_ms = interval.as_millis(),
+                clamped_ms = MIN_INTERVAL.as_millis(),
+                "stream_interval_ms is below the minimum safe value; clamping to 500ms to avoid Telegram rate limits"
+            );
+            self.stream_interval = MIN_INTERVAL;
+        } else {
+            self.stream_interval = interval;
+        }
+        self
+    }
+
+    /// Access the raw Bot API 10.0 client for methods not covered by teloxide.
+    #[must_use]
+    pub fn api_ext(&self) -> &TelegramApiClient {
+        &self.api_ext
     }
 
     /// Attach a [`TaskSupervisor`] so the Telegram listener task is registered
@@ -247,6 +289,8 @@ impl TelegramChannel {
             accumulated: String::new(),
             last_edit: None,
             message_id: None,
+            stream_interval: Duration::from_secs(3),
+            api_ext: TelegramApiClient::new("test_token"),
             supervisor: None,
         };
         (channel, tx)
@@ -264,7 +308,7 @@ impl TelegramChannel {
     fn should_send_update(&self) -> bool {
         match self.last_edit {
             None => true,
-            Some(last) => last.elapsed() > Duration::from_secs(3),
+            Some(last) => last.elapsed() > self.stream_interval,
         }
     }
 
@@ -676,8 +720,10 @@ impl Channel for TelegramChannel {
             self.accumulated.len()
         );
 
-        // Final update with complete message
-        if self.message_id.is_some() {
+        // Send if there is unsent accumulated text OR an existing message to finalize.
+        // The `message_id.is_some()` guard alone would silently discard text that arrived
+        // before the first interval elapsed (so `send_or_edit` was never called).
+        if self.message_id.is_some() || !self.accumulated.is_empty() {
             self.send_or_edit().await?;
         }
 
@@ -960,6 +1006,8 @@ mod tests {
             accumulated: String::new(),
             last_edit: None,
             message_id: None,
+            stream_interval: Duration::from_secs(3),
+            api_ext: TelegramApiClient::with_base_url(server.uri()),
             supervisor: None,
         };
         (channel, tx)
@@ -1028,6 +1076,39 @@ mod tests {
                 .unwrap(),
         );
         assert!(!channel.should_send_update());
+    }
+
+    #[test]
+    fn with_stream_interval_custom_interval_respected() {
+        let mut channel = TelegramChannel::new("test_token".to_string(), Vec::new())
+            .with_stream_interval(Duration::from_millis(2000));
+        // 1500ms elapsed < 2000ms interval — should NOT send
+        channel.last_edit = Some(
+            Instant::now()
+                .checked_sub(Duration::from_millis(1500))
+                .unwrap(),
+        );
+        assert!(!channel.should_send_update());
+        // 2500ms elapsed > 2000ms interval — should send
+        channel.last_edit = Some(
+            Instant::now()
+                .checked_sub(Duration::from_millis(2500))
+                .unwrap(),
+        );
+        assert!(channel.should_send_update());
+    }
+
+    #[test]
+    fn with_stream_interval_clamps_below_500ms() {
+        let channel = TelegramChannel::new("test_token".to_string(), Vec::new())
+            .with_stream_interval(Duration::from_millis(100));
+        assert_eq!(channel.stream_interval, Duration::from_millis(500));
+    }
+
+    #[test]
+    fn with_stream_interval_default_is_3s() {
+        let channel = TelegramChannel::new("test_token", Vec::new());
+        assert_eq!(channel.stream_interval, Duration::from_secs(3));
     }
 
     #[test]
@@ -1111,17 +1192,40 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn flush_chunks_clears_state_when_no_message_id() {
+    async fn flush_chunks_clears_state_when_no_accumulated_and_no_message_id() {
         let (mut channel, _tx) = TelegramChannel::new_test(vec![]);
-        channel.accumulated = "some text".to_string();
+        // accumulated is empty and message_id is None — no API call expected.
         channel.last_edit = Some(Instant::now());
-        // message_id is None, so flush_chunks does not call send_or_edit.
 
         channel.flush_chunks().await.unwrap();
 
         assert!(channel.accumulated.is_empty());
         assert!(channel.last_edit.is_none());
         assert!(channel.message_id.is_none());
+    }
+
+    // flush_chunks() must send accumulated text even when message_id is None.
+    // Regression test for the data-loss bug where a short streaming response
+    // (entire reply arrives before stream_interval elapses) was silently discarded.
+    #[tokio::test]
+    async fn flush_chunks_sends_when_accumulated_but_message_id_is_none() {
+        let server = MockServer::start().await;
+        let (mut channel, _tx) = make_mocked_channel(&server, vec![]).await;
+
+        // Suppress the periodic send by setting last_edit to now (interval not elapsed).
+        channel.last_edit = Some(Instant::now());
+        channel.accumulated = "short reply".to_string();
+        // message_id is None — the periodic path never fired.
+
+        channel.flush_chunks().await.unwrap();
+
+        // The mock server must have received exactly one sendMessage call.
+        let requests = server.received_requests().await.unwrap();
+        assert!(
+            !requests.is_empty(),
+            "flush_chunks must send accumulated text even when message_id is None"
+        );
+        assert!(channel.accumulated.is_empty());
     }
 
     // ---------------------------------------------------------------------------

--- a/crates/zeph-channels/src/telegram.rs
+++ b/crates/zeph-channels/src/telegram.rs
@@ -1081,7 +1081,7 @@ mod tests {
     #[test]
     fn with_stream_interval_custom_interval_respected() {
         let mut channel = TelegramChannel::new("test_token".to_string(), Vec::new())
-            .with_stream_interval(Duration::from_millis(2000));
+            .with_stream_interval(Duration::from_secs(2));
         // 1500ms elapsed < 2000ms interval — should NOT send
         channel.last_edit = Some(
             Instant::now()

--- a/crates/zeph-channels/src/telegram_api_ext.rs
+++ b/crates/zeph-channels/src/telegram_api_ext.rs
@@ -420,7 +420,7 @@ mod tests {
     use wiremock::matchers::{method, path_regex};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    fn ok_body(result: serde_json::Value) -> serde_json::Value {
+    fn ok_body(result: &serde_json::Value) -> serde_json::Value {
         serde_json::json!({ "ok": true, "result": result })
     }
 
@@ -485,7 +485,7 @@ mod tests {
         Mock::given(method("POST"))
             .and(path_regex(".*/answerGuestQuery$"))
             .respond_with(
-                ResponseTemplate::new(200).set_body_json(ok_body(serde_json::json!({
+                ResponseTemplate::new(200).set_body_json(ok_body(&serde_json::json!({
                     "message_id": 123,
                     "chat_id": 456
                 }))),
@@ -508,7 +508,7 @@ mod tests {
         Mock::given(method("POST"))
             .and(path_regex(".*/answerGuestQuery$"))
             .respond_with(
-                ResponseTemplate::new(200).set_body_json(ok_body(serde_json::json!({
+                ResponseTemplate::new(200).set_body_json(ok_body(&serde_json::json!({
                     "message_id": 1,
                     "chat_id": 2
                 }))),
@@ -554,7 +554,7 @@ mod tests {
         Mock::given(method("POST"))
             .and(path_regex(".*/getManagedBotAccessSettings$"))
             .respond_with(
-                ResponseTemplate::new(200).set_body_json(ok_body(serde_json::json!({
+                ResponseTemplate::new(200).set_body_json(ok_body(&serde_json::json!({
                     "allow_private_chats": true,
                     "allow_group_chats": false,
                     "allow_channel_posts": true
@@ -595,7 +595,7 @@ mod tests {
         Mock::given(method("POST"))
             .and(path_regex(".*/setManagedBotAccessSettings$"))
             .respond_with(
-                ResponseTemplate::new(200).set_body_json(ok_body(serde_json::Value::Bool(true))),
+                ResponseTemplate::new(200).set_body_json(ok_body(&serde_json::Value::Bool(true))),
             )
             .mount(&server)
             .await;
@@ -643,7 +643,7 @@ mod tests {
         Mock::given(method("POST"))
             .and(path_regex(".*/deleteMessageReaction$"))
             .respond_with(
-                ResponseTemplate::new(200).set_body_json(ok_body(serde_json::Value::Bool(true))),
+                ResponseTemplate::new(200).set_body_json(ok_body(&serde_json::Value::Bool(true))),
             )
             .mount(&server)
             .await;
@@ -684,7 +684,7 @@ mod tests {
         Mock::given(method("POST"))
             .and(path_regex(".*/deleteAllMessageReactions$"))
             .respond_with(
-                ResponseTemplate::new(200).set_body_json(ok_body(serde_json::Value::Bool(true))),
+                ResponseTemplate::new(200).set_body_json(ok_body(&serde_json::Value::Bool(true))),
             )
             .mount(&server)
             .await;

--- a/crates/zeph-channels/src/telegram_api_ext.rs
+++ b/crates/zeph-channels/src/telegram_api_ext.rs
@@ -1,0 +1,740 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Raw HTTP client for Telegram Bot API 10.0 methods not yet exposed by teloxide.
+//!
+//! [`TelegramApiClient`] wraps `reqwest` and provides typed async methods for
+//! Bot API 10.0 features: Guest Mode query answering, managed-bot access
+//! settings, and reaction moderation.  It is embedded in [`TelegramChannel`]
+//! and accessible via [`TelegramChannel::api_ext`].
+//!
+//! Once teloxide gains native support for these methods, this module can be
+//! removed and call sites updated to use the teloxide API directly (tracked in
+//! issue #3732).
+//!
+//! [`TelegramChannel`]: crate::telegram::TelegramChannel
+//! [`TelegramChannel::api_ext`]: crate::telegram::TelegramChannel::api_ext
+
+use serde::{Deserialize, Serialize};
+
+/// Response payload from the `answerGuestQuery` Bot API method.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SentGuestMessage {
+    /// Telegram message identifier of the sent reply.
+    pub message_id: i64,
+    /// Identifier of the chat the message was sent to.
+    pub chat_id: i64,
+}
+
+/// Access settings for a managed bot in Guest Mode.
+///
+/// # Note
+///
+/// Field names are based on the Bot API 10.0 specification draft and will be
+/// verified against real API responses when `#3732` migrates to native teloxide.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BotAccessSettings {
+    /// Whether the managed bot may receive private-chat messages.
+    pub allow_private_chats: bool,
+    /// Whether the managed bot may participate in group chats.
+    pub allow_group_chats: bool,
+    /// Whether the managed bot may receive channel posts.
+    pub allow_channel_posts: bool,
+}
+
+/// A message received by a managed bot in Guest Mode.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct GuestMessage {
+    /// Telegram message identifier.
+    pub message_id: i64,
+    /// Identifier of the originating chat.
+    pub from_chat_id: i64,
+    /// Text content of the message, if any.
+    pub text: Option<String>,
+}
+
+/// Standard Telegram API JSON response envelope.
+#[derive(Deserialize)]
+struct TelegramResponse<T> {
+    ok: bool,
+    result: Option<T>,
+    description: Option<String>,
+}
+
+/// Errors returned by [`TelegramApiClient`] methods.
+#[derive(Debug, thiserror::Error)]
+pub enum TelegramApiError {
+    /// HTTP transport or status error.
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+    /// Telegram API returned `ok: false`.
+    #[error("Telegram API error: {0}")]
+    Api(String),
+}
+
+/// Raw HTTP client for Telegram Bot API 10.0 methods not covered by teloxide.
+///
+/// The bot token is embedded in the base URL and is never written to logs — the
+/// [`Debug`] implementation redacts it.
+///
+/// # Examples
+///
+/// ```no_run
+/// use zeph_channels::telegram_api_ext::TelegramApiClient;
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let client = TelegramApiClient::new("123456:ABC-DEF…");
+/// let result = client.answer_guest_query("query_id", "Hello!", None).await?;
+/// println!("sent message_id={}", result.message_id);
+/// # Ok(())
+/// # }
+/// ```
+pub struct TelegramApiClient {
+    client: reqwest::Client,
+    /// `https://api.telegram.org/bot<TOKEN>` — includes the token, never log.
+    base_url: String,
+}
+
+impl std::fmt::Debug for TelegramApiClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TelegramApiClient")
+            .field("base_url", &"[REDACTED]")
+            .finish_non_exhaustive()
+    }
+}
+
+impl TelegramApiClient {
+    /// Create a new client for the given bot `token`.
+    ///
+    /// The base URL is set to `https://api.telegram.org/bot<TOKEN>` so that each
+    /// `post()` call appends only the method name (e.g., `/answerGuestQuery`).
+    ///
+    /// Creates an independent `reqwest::Client` with its own connection pool.
+    /// To share a connection pool with an existing client, use
+    /// [`TelegramApiClient::with_client`].
+    #[must_use]
+    pub fn new(token: impl Into<String>) -> Self {
+        let token = token.into();
+        Self {
+            client: reqwest::Client::new(),
+            base_url: format!("https://api.telegram.org/bot{token}"),
+        }
+    }
+
+    /// Create a client that reuses an existing `reqwest::Client`.
+    ///
+    /// This allows sharing a connection pool with another HTTP client — for
+    /// example, the `reqwest::Client` backing teloxide's `Bot` — to avoid
+    /// opening duplicate TCP connections to `api.telegram.org`.
+    ///
+    /// The base URL is set to `https://api.telegram.org/bot<token>` using the
+    /// supplied `token`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use zeph_channels::telegram_api_ext::TelegramApiClient;
+    ///
+    /// let shared = reqwest::Client::new();
+    /// let client = TelegramApiClient::with_client(shared, "123456:ABC-DEF…");
+    /// ```
+    #[must_use]
+    pub fn with_client(client: reqwest::Client, token: &str) -> Self {
+        Self {
+            client,
+            base_url: format!("https://api.telegram.org/bot{token}"),
+        }
+    }
+
+    /// Create a client with a fully-qualified custom base URL.
+    ///
+    /// The `base_url` is stored as-is and each method name is appended with `/`.
+    /// The bot token is **not** automatically embedded — the caller is responsible
+    /// for including the full path prefix required by the target server.
+    ///
+    /// For the official Telegram Bot API protocol the expected format is:
+    /// `https://api.telegram.org/bot<TOKEN>` (same as what [`new`] builds).
+    /// For a local [Telegram Bot API server](https://core.telegram.org/bots/api#using-a-local-bot-api-server)
+    /// the format is typically `http://localhost:8081/bot<TOKEN>`.
+    ///
+    /// This method is primarily intended for testing (point at a wiremock server)
+    /// or for deployments that proxy through a local Bot API server.
+    ///
+    /// [`new`]: TelegramApiClient::new
+    #[must_use]
+    pub fn with_base_url(base_url: impl Into<String>) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            base_url: base_url.into(),
+        }
+    }
+
+    /// POST `body` to `{base_url}/{method}` and deserialize the result.
+    ///
+    /// Calls `.error_for_status()` before JSON parsing so that non-2xx HTTP
+    /// responses (e.g. 429 rate-limit, 502 gateway error) surface as
+    /// [`TelegramApiError::Http`] rather than serde deserialization errors.
+    /// URLs (which contain the bot token) are stripped from any `reqwest::Error`
+    /// before propagation to prevent token leakage into logs.
+    #[tracing::instrument(skip(self, body), fields(method = method))]
+    async fn post<T: serde::de::DeserializeOwned>(
+        &self,
+        method: &str,
+        body: &impl Serialize,
+    ) -> Result<T, TelegramApiError> {
+        let url = format!("{}/{method}", self.base_url);
+        let resp: TelegramResponse<T> = self
+            .client
+            .post(&url)
+            .json(body)
+            .send()
+            .await
+            .map_err(|e| TelegramApiError::Http(e.without_url()))?
+            .error_for_status()
+            .map_err(|e| TelegramApiError::Http(e.without_url()))?
+            .json()
+            .await
+            .map_err(|e| TelegramApiError::Http(e.without_url()))?;
+
+        if resp.ok {
+            resp.result
+                .ok_or_else(|| TelegramApiError::Api("ok=true but no result".into()))
+        } else {
+            Err(TelegramApiError::Api(
+                resp.description.unwrap_or_else(|| "unknown error".into()),
+            ))
+        }
+    }
+
+    /// Answer a Guest Mode query on behalf of a managed bot.
+    ///
+    /// # Arguments
+    ///
+    /// * `query_id` — identifier of the guest query to answer.
+    /// * `text` — reply text.
+    /// * `parse_mode` — optional parse mode (`"HTML"`, `"MarkdownV2"`, etc.).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TelegramApiError`] on HTTP failure or when `ok: false`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use zeph_channels::telegram_api_ext::TelegramApiClient;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = TelegramApiClient::new("TOKEN");
+    /// let sent = client.answer_guest_query("qid_123", "Hello!", Some("HTML")).await?;
+    /// println!("message_id={}", sent.message_id);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn answer_guest_query(
+        &self,
+        query_id: &str,
+        text: &str,
+        parse_mode: Option<&str>,
+    ) -> Result<SentGuestMessage, TelegramApiError> {
+        #[derive(Serialize)]
+        struct Req<'a> {
+            guest_query_id: &'a str,
+            text: &'a str,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            parse_mode: Option<&'a str>,
+        }
+        self.post(
+            "answerGuestQuery",
+            &Req {
+                guest_query_id: query_id,
+                text,
+                parse_mode,
+            },
+        )
+        .await
+    }
+
+    /// Retrieve access settings for a managed bot.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TelegramApiError`] on HTTP failure or when `ok: false`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use zeph_channels::telegram_api_ext::TelegramApiClient;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = TelegramApiClient::new("TOKEN");
+    /// let settings = client.get_managed_bot_access_settings().await?;
+    /// println!("private_chats={}", settings.allow_private_chats);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_managed_bot_access_settings(
+        &self,
+    ) -> Result<BotAccessSettings, TelegramApiError> {
+        self.post("getManagedBotAccessSettings", &serde_json::json!({}))
+            .await
+    }
+
+    /// Update access settings for a managed bot.
+    ///
+    /// Returns `true` when the settings were applied successfully.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TelegramApiError`] on HTTP failure or when `ok: false`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use zeph_channels::telegram_api_ext::{BotAccessSettings, TelegramApiClient};
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = TelegramApiClient::new("TOKEN");
+    /// let ok = client.set_managed_bot_access_settings(&BotAccessSettings {
+    ///     allow_private_chats: true,
+    ///     allow_group_chats: false,
+    ///     allow_channel_posts: false,
+    /// }).await?;
+    /// assert!(ok);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn set_managed_bot_access_settings(
+        &self,
+        settings: &BotAccessSettings,
+    ) -> Result<bool, TelegramApiError> {
+        self.post("setManagedBotAccessSettings", settings).await
+    }
+
+    /// Delete a specific reaction left by `user_id` on a message.
+    ///
+    /// Returns `true` on success.
+    ///
+    /// # Arguments
+    ///
+    /// * `chat_id` — identifier of the chat containing the message.
+    /// * `message_id` — identifier of the message.
+    /// * `user_id` — identifier of the user whose reaction to remove.
+    /// * `reaction` — emoji or custom reaction string to remove.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TelegramApiError`] on HTTP failure or when `ok: false`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use zeph_channels::telegram_api_ext::TelegramApiClient;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = TelegramApiClient::new("TOKEN");
+    /// let ok = client.delete_message_reaction(123, 456, 789, "👍").await?;
+    /// assert!(ok);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn delete_message_reaction(
+        &self,
+        chat_id: i64,
+        message_id: i64,
+        user_id: i64,
+        reaction: &str,
+    ) -> Result<bool, TelegramApiError> {
+        #[derive(Serialize)]
+        struct Req<'a> {
+            chat_id: i64,
+            message_id: i64,
+            user_id: i64,
+            reaction: &'a str,
+        }
+        self.post(
+            "deleteMessageReaction",
+            &Req {
+                chat_id,
+                message_id,
+                user_id,
+                reaction,
+            },
+        )
+        .await
+    }
+
+    /// Delete all reactions left by `user_id` on a message.
+    ///
+    /// Returns `true` on success.
+    ///
+    /// # Arguments
+    ///
+    /// * `chat_id` — identifier of the chat containing the message.
+    /// * `message_id` — identifier of the message.
+    /// * `user_id` — identifier of the user whose reactions to remove.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TelegramApiError`] on HTTP failure or when `ok: false`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use zeph_channels::telegram_api_ext::TelegramApiClient;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = TelegramApiClient::new("TOKEN");
+    /// let ok = client.delete_all_message_reactions(123, 456, 789).await?;
+    /// assert!(ok);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn delete_all_message_reactions(
+        &self,
+        chat_id: i64,
+        message_id: i64,
+        user_id: i64,
+    ) -> Result<bool, TelegramApiError> {
+        #[derive(Serialize)]
+        #[allow(clippy::struct_field_names)]
+        struct Req {
+            chat_id: i64,
+            message_id: i64,
+            user_id: i64,
+        }
+        self.post(
+            "deleteAllMessageReactions",
+            &Req {
+                chat_id,
+                message_id,
+                user_id,
+            },
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path_regex};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn ok_body(result: serde_json::Value) -> serde_json::Value {
+        serde_json::json!({ "ok": true, "result": result })
+    }
+
+    fn err_body(description: &str) -> serde_json::Value {
+        serde_json::json!({ "ok": false, "description": description })
+    }
+
+    // ── Serde round-trip tests ────────────────────────────────────────────────
+
+    #[test]
+    fn sent_guest_message_round_trip() {
+        let original = SentGuestMessage {
+            message_id: 42,
+            chat_id: 100,
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: SentGuestMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn bot_access_settings_round_trip() {
+        let original = BotAccessSettings {
+            allow_private_chats: true,
+            allow_group_chats: false,
+            allow_channel_posts: true,
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: BotAccessSettings = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn guest_message_round_trip() {
+        let original = GuestMessage {
+            message_id: 7,
+            from_chat_id: 999,
+            text: Some("hello".into()),
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: GuestMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn guest_message_round_trip_no_text() {
+        let original = GuestMessage {
+            message_id: 1,
+            from_chat_id: 2,
+            text: None,
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: GuestMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    // ── answer_guest_query ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn answer_guest_query_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/answerGuestQuery$"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(ok_body(serde_json::json!({
+                    "message_id": 123,
+                    "chat_id": 456
+                }))),
+            )
+            .mount(&server)
+            .await;
+
+        let client = TelegramApiClient::with_base_url(server.uri());
+        let result = client
+            .answer_guest_query("qid", "hello", None)
+            .await
+            .unwrap();
+        assert_eq!(result.message_id, 123);
+        assert_eq!(result.chat_id, 456);
+    }
+
+    #[tokio::test]
+    async fn answer_guest_query_with_parse_mode() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/answerGuestQuery$"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(ok_body(serde_json::json!({
+                    "message_id": 1,
+                    "chat_id": 2
+                }))),
+            )
+            .mount(&server)
+            .await;
+
+        let client = TelegramApiClient::with_base_url(server.uri());
+        let result = client
+            .answer_guest_query("qid", "<b>bold</b>", Some("HTML"))
+            .await
+            .unwrap();
+        assert_eq!(result.message_id, 1);
+    }
+
+    #[tokio::test]
+    async fn answer_guest_query_api_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/answerGuestQuery$"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(err_body("Bad Request: query not found")),
+            )
+            .mount(&server)
+            .await;
+
+        let client = TelegramApiClient::with_base_url(server.uri());
+        let err = client
+            .answer_guest_query("bad_id", "hi", None)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, TelegramApiError::Api(_)),
+            "expected Api error"
+        );
+    }
+
+    // ── get_managed_bot_access_settings ──────────────────────────────────────
+
+    #[tokio::test]
+    async fn get_managed_bot_access_settings_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/getManagedBotAccessSettings$"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(ok_body(serde_json::json!({
+                    "allow_private_chats": true,
+                    "allow_group_chats": false,
+                    "allow_channel_posts": true
+                }))),
+            )
+            .mount(&server)
+            .await;
+
+        let client = TelegramApiClient::with_base_url(server.uri());
+        let settings = client.get_managed_bot_access_settings().await.unwrap();
+        assert!(settings.allow_private_chats);
+        assert!(!settings.allow_group_chats);
+        assert!(settings.allow_channel_posts);
+    }
+
+    #[tokio::test]
+    async fn get_managed_bot_access_settings_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/getManagedBotAccessSettings$"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(err_body("Forbidden: bot is not a member")),
+            )
+            .mount(&server)
+            .await;
+
+        let client = TelegramApiClient::with_base_url(server.uri());
+        let err = client.get_managed_bot_access_settings().await.unwrap_err();
+        assert!(matches!(err, TelegramApiError::Api(_)));
+    }
+
+    // ── set_managed_bot_access_settings ──────────────────────────────────────
+
+    #[tokio::test]
+    async fn set_managed_bot_access_settings_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/setManagedBotAccessSettings$"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(ok_body(serde_json::Value::Bool(true))),
+            )
+            .mount(&server)
+            .await;
+
+        let client = TelegramApiClient::with_base_url(server.uri());
+        let ok = client
+            .set_managed_bot_access_settings(&BotAccessSettings {
+                allow_private_chats: true,
+                allow_group_chats: true,
+                allow_channel_posts: false,
+            })
+            .await
+            .unwrap();
+        assert!(ok);
+    }
+
+    #[tokio::test]
+    async fn set_managed_bot_access_settings_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/setManagedBotAccessSettings$"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(err_body("Bad Request: invalid settings")),
+            )
+            .mount(&server)
+            .await;
+
+        let client = TelegramApiClient::with_base_url(server.uri());
+        let err = client
+            .set_managed_bot_access_settings(&BotAccessSettings {
+                allow_private_chats: false,
+                allow_group_chats: false,
+                allow_channel_posts: false,
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(err, TelegramApiError::Api(_)));
+    }
+
+    // ── delete_message_reaction ───────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn delete_message_reaction_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/deleteMessageReaction$"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(ok_body(serde_json::Value::Bool(true))),
+            )
+            .mount(&server)
+            .await;
+
+        let client = TelegramApiClient::with_base_url(server.uri());
+        let ok = client
+            .delete_message_reaction(100, 200, 300, "👍")
+            .await
+            .unwrap();
+        assert!(ok);
+    }
+
+    #[tokio::test]
+    async fn delete_message_reaction_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/deleteMessageReaction$"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(err_body("Bad Request: message not found")),
+            )
+            .mount(&server)
+            .await;
+
+        let client = TelegramApiClient::with_base_url(server.uri());
+        let err = client
+            .delete_message_reaction(1, 2, 3, "👎")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, TelegramApiError::Api(_)));
+    }
+
+    // ── delete_all_message_reactions ─────────────────────────────────────────
+
+    #[tokio::test]
+    async fn delete_all_message_reactions_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/deleteAllMessageReactions$"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(ok_body(serde_json::Value::Bool(true))),
+            )
+            .mount(&server)
+            .await;
+
+        let client = TelegramApiClient::with_base_url(server.uri());
+        let ok = client
+            .delete_all_message_reactions(100, 200, 300)
+            .await
+            .unwrap();
+        assert!(ok);
+    }
+
+    #[tokio::test]
+    async fn delete_all_message_reactions_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/deleteAllMessageReactions$"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(err_body("Forbidden: not enough rights")),
+            )
+            .mount(&server)
+            .await;
+
+        let client = TelegramApiClient::with_base_url(server.uri());
+        let err = client
+            .delete_all_message_reactions(1, 2, 3)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, TelegramApiError::Api(_)));
+    }
+
+    // ── HTTP status error surfacing ───────────────────────────────────────────
+
+    #[tokio::test]
+    async fn http_429_surfaces_as_http_error_not_serde_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/answerGuestQuery$"))
+            .respond_with(ResponseTemplate::new(429).set_body_string("Too Many Requests"))
+            .mount(&server)
+            .await;
+
+        let client = TelegramApiClient::with_base_url(server.uri());
+        let err = client
+            .answer_guest_query("qid", "hi", None)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, TelegramApiError::Http(_)),
+            "expected Http error for 429, got {err:?}"
+        );
+    }
+}

--- a/crates/zeph-config/src/channels.rs
+++ b/crates/zeph-config/src/channels.rs
@@ -275,6 +275,10 @@ fn default_oauth_client_name() -> String {
     "Zeph".into()
 }
 
+fn default_stream_interval_ms() -> u64 {
+    3000
+}
+
 /// Telegram channel configuration, nested under `[telegram]` in TOML.
 ///
 /// When present, Zeph connects to Telegram as a bot using the provided token.
@@ -285,6 +289,7 @@ fn default_oauth_client_name() -> String {
 /// ```toml
 /// [telegram]
 /// allowed_users = ["myusername"]
+/// stream_interval_ms = 3000
 /// ```
 #[derive(Clone, Deserialize, Serialize)]
 pub struct TelegramConfig {
@@ -296,6 +301,13 @@ pub struct TelegramConfig {
     /// Skill allowlist for this channel.
     #[serde(default)]
     pub skills: ChannelSkillsConfig,
+    /// Minimum interval in milliseconds between streaming message edits.
+    ///
+    /// Defaults to 3000 ms (3 seconds) to stay within Telegram's rate limits.
+    /// Values below 500 ms are clamped to 500 ms with a warning; the Telegram
+    /// Bot API enforces a hard limit of ~30 edits/second per chat.
+    #[serde(default = "default_stream_interval_ms")]
+    pub stream_interval_ms: u64,
 }
 
 impl std::fmt::Debug for TelegramConfig {
@@ -304,6 +316,7 @@ impl std::fmt::Debug for TelegramConfig {
             .field("token", &self.token.as_ref().map(|_| "[REDACTED]"))
             .field("allowed_users", &self.allowed_users)
             .field("skills", &self.skills)
+            .field("stream_interval_ms", &self.stream_interval_ms)
             .finish()
     }
 }

--- a/crates/zeph-core/tests/vault_integration.rs
+++ b/crates/zeph-core/tests/vault_integration.rs
@@ -78,6 +78,7 @@ async fn age_vault_injects_token_into_existing_telegram_config() {
         token: None,
         allowed_users: vec!["test_user".to_owned()],
         skills: zeph_core::config::ChannelSkillsConfig::default(),
+        stream_interval_ms: 3000,
     });
     config.resolve_secrets(&vault).await.unwrap();
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -180,11 +180,12 @@ pub(crate) async fn create_channel_inner(
     }
 
     if let Some(token) = config.telegram.as_ref().and_then(|t| t.token.clone()) {
-        let allowed = config
-            .telegram
-            .as_ref()
-            .map_or_else(Vec::new, |t| t.allowed_users.clone());
-        let tg = TelegramChannel::new(token, allowed).start()?;
+        let tg_cfg = config.telegram.as_ref().unwrap();
+        let allowed = tg_cfg.allowed_users.clone();
+        let stream_interval = std::time::Duration::from_millis(tg_cfg.stream_interval_ms);
+        let tg = TelegramChannel::new(token, allowed)
+            .with_stream_interval(stream_interval)
+            .start()?;
         tracing::info!("running in Telegram mode");
         return Ok((AnyChannel::Telegram(tg), None));
     }

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -47,6 +47,7 @@ pub(crate) struct WizardState {
     pub(crate) channel: ChannelChoice,
     pub(crate) telegram_token: Option<String>,
     pub(crate) telegram_users: Vec<String>,
+    pub(crate) telegram_stream_interval_ms: u64,
     pub(crate) discord_token: Option<String>,
     pub(crate) discord_app_id: Option<String>,
     pub(crate) slack_bot_token: Option<String>,
@@ -269,6 +270,7 @@ impl Default for WizardState {
             channel: ChannelChoice::default(),
             telegram_token: None,
             telegram_users: Vec::new(),
+            telegram_stream_interval_ms: 3000,
             discord_token: None,
             discord_app_id: None,
             slack_bot_token: None,
@@ -525,6 +527,13 @@ fn step_channel(state: &mut WizardState) -> anyhow::Result<()> {
                 .map(|s| s.trim().to_owned())
                 .filter(|s| !s.is_empty())
                 .collect();
+            let interval_ms: u64 = Input::new()
+                .with_prompt(
+                    "Streaming edit interval in ms (rate-limit safe: >=2000, minimum enforced: 500)",
+                )
+                .default(3000u64)
+                .interact_text()?;
+            state.telegram_stream_interval_ms = interval_ms;
         }
         2 => {
             state.channel = ChannelChoice::Discord;
@@ -796,6 +805,7 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
                 token: None,
                 allowed_users: state.telegram_users.clone(),
                 skills: ChannelSkillsConfig::default(),
+                stream_interval_ms: state.telegram_stream_interval_ms,
             });
         }
         ChannelChoice::Discord => {

--- a/src/startup_checks.rs
+++ b/src/startup_checks.rs
@@ -85,6 +85,7 @@ mod tests {
                 token: Some("tok".into()),
                 allowed_users: vec![],
                 skills: ChannelSkillsConfig::default(),
+                stream_interval_ms: 3000,
             }),
             ..Default::default()
         };

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -95,6 +95,7 @@ async fn create_channel_telegram_without_token() {
         token: None,
         allowed_users: vec![],
         skills: zeph_core::config::ChannelSkillsConfig::default(),
+        stream_interval_ms: 3000,
     });
     let channel = create_channel(&config).await.unwrap();
     assert!(matches!(channel, AnyChannel::Cli(_)));
@@ -124,6 +125,7 @@ async fn create_channel_telegram_with_token() {
         token: Some("test_token".to_string()),
         allowed_users: vec!["testuser".to_string()],
         skills: zeph_core::config::ChannelSkillsConfig::default(),
+        stream_interval_ms: 3000,
     });
     let channel = create_channel(&config).await.unwrap();
     assert!(matches!(channel, AnyChannel::Telegram(_)));
@@ -171,6 +173,7 @@ async fn create_channel_telegram_with_empty_allowed_users_errors() {
         token: Some("test_token2".to_string()),
         allowed_users: vec![],
         skills: zeph_core::config::ChannelSkillsConfig::default(),
+        stream_interval_ms: 3000,
     });
     let result = create_channel(&config).await;
     assert!(result.is_err());


### PR DESCRIPTION
## Summary

- Add `stream_interval_ms` to `TelegramConfig` (default: 3000ms, clamped to 500ms minimum) applied via `TelegramChannel::with_stream_interval(Duration)` builder. Fixes a silent data-loss bug in `flush_chunks` where short LLM responses fitting within one interval window were silently discarded (Closes #3727).
- Add `TelegramApiClient` — a thin `reqwest`-based raw HTTP wrapper for Telegram Bot API 10.0 methods unavailable in teloxide 0.17: `answer_guest_query`, `get_managed_bot_access_settings`, `set_managed_bot_access_settings`, `delete_message_reaction`, `delete_all_message_reactions`. Bot token is redacted in `Debug` and stripped from reqwest error URLs via `.without_url()`. Unblocks #3729, #3730, #3731 (Closes #3728).

## Changes

- `crates/zeph-config/src/channels.rs` — `stream_interval_ms: u64` field with serde default
- `crates/zeph-channels/src/telegram_api_ext.rs` — **new**: `TelegramApiClient`, 5 async methods, 3 serde types (`SentGuestMessage`, `BotAccessSettings`, `GuestMessage`), `TelegramApiError` via `thiserror`
- `crates/zeph-channels/src/telegram.rs` — `with_stream_interval()` builder, `api_ext` field, `flush_chunks` data-loss fix
- `src/channel.rs` — wires `stream_interval_ms` from config
- `src/init/mod.rs` — `--init` wizard prompt for streaming interval

## Test Plan

- [ ] `cargo +nightly fmt --check` — CLEAN
- [ ] `cargo clippy --workspace -- -D warnings` — CLEAN
- [ ] `cargo nextest run --workspace --lib --bins` — 9075 passed
- [ ] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features full` — CLEAN
- [ ] 142 tests in `zeph-channels` (16 new wiremock + serde round-trip tests for `TelegramApiClient`, 4 new tests for streaming interval and flush_chunks fix)

## Notes

- `BotAccessSettings` field names are based on the Bot API 10.0 draft spec; will be verified when #3732 migrates to native teloxide.
- Two `reqwest::Client` instances exist (one in teloxide `Bot`, one in `TelegramApiClient`). Documented in `TelegramApiClient::new()` doc; consolidation deferred to #3732.