### PR TITLE
ci: add .cargo/config.toml for local build speedup, guard CI against it

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,8 @@
+[build]
+incremental = true
+rustflags = ["-C", "codegen-units=16"]
+rustc-wrapper = "sccache"
+
+[profile.dev]
+[profile.dev.build-override]
+opt-level = 3

--- a/.github/workflows/ci-non-linux.yml
+++ b/.github/workflows/ci-non-linux.yml
@@ -14,6 +14,8 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
+  RUSTC_WRAPPER: ""
+  CARGO_INCREMENTAL: "0"
 
 jobs:
   build-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
+  RUSTC_WRAPPER: ""
+  CARGO_INCREMENTAL: "0"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTC_WRAPPER: ""
+  CARGO_INCREMENTAL: "0"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Add `.cargo/config.toml` with `incremental = true`, `codegen-units=16`, and `rustc-wrapper = "sccache"` for faster local builds
- Set `RUSTC_WRAPPER: ""` and `CARGO_INCREMENTAL: "0"` in the global `env:` of `ci.yml`, `ci-non-linux.yml`, and `release.yml` to prevent the local config from affecting CI runners
- Jobs that use sccache (`build-tests`, `coverage`, release native build) override `RUSTC_WRAPPER` at the step level, so their behavior is unchanged

## Test plan

- [ ] Verify CI passes on all jobs (lint, clippy, msrv, bundle-check, rustdoc, build-tests, integration, release)
- [ ] Confirm `build-tests` and `coverage` still use sccache (step-level `RUSTC_WRAPPER: sccache` takes precedence over workflow global)
- [ ] Confirm cross-compile step in release is unaffected by `rustc-wrapper` from config (no sccache inside Docker)