### PR TITLE
fix(core): fix orphaned tool pairs and budget underestimation in subagent context slicing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(core): prevent orphaned ToolUse/ToolResult pairs in subagent parent context window. When
+  `extract_parent_messages` sliced the last N turns, pairs split across the slice boundary caused
+  `split_messages_structured` to silently downgrade ToolResult blocks to flat text. The new
+  `trim_parent_messages` helper performs two-pass orphan pruning after budget truncation: pass 1
+  removes ToolResult parts with no matching ToolUse in the slice; pass 2 removes dangling ToolUse
+  parts (excluding the trailing assistant message, which may have pending calls). Messages emptied
+  by pruning are removed. `rebuild_content` is only called when parts were actually changed,
+  preventing ThinkingBlock content corruption. Closes #3760.
+- fix(core): fix token budget underestimation in subagent parent context. `extract_parent_messages`
+  summed `m.content.len()` from `flatten_parts()`, which compresses ToolUse/ToolResult to short
+  placeholders. The actual Claude API JSON is larger. The new `estimate_parts_size` helper sums
+  per-part sizes accounting for ToolUse input JSON, ToolResult content, and image base64 overhead.
+  Budget truncation now iterates from newest to oldest, keeping the most-recent messages that fit.
+  Closes #3761.
+
 ## [0.21.0] - 2026-05-11
 
 ### Added

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -2572,7 +2572,8 @@ impl<C: Channel> Agent<C> {
     /// Extract recent parent messages for history propagation (Section 5.7 in spec).
     ///
     /// Filters system messages, takes last `context_window_turns * 2` messages,
-    /// and applies a 25% context window cap using a 4-chars-per-token heuristic.
+    /// applies a 25% context window cap using a 4-chars-per-token heuristic, and
+    /// prunes orphaned `ToolUse`/`ToolResult` pairs at the slice boundary.
     fn extract_parent_messages(
         &self,
         config: &zeph_config::SubAgentConfig,
@@ -2592,26 +2593,16 @@ impl<C: Channel> Agent<C> {
         let start = non_system.len().saturating_sub(take_count);
         let mut msgs = non_system[start..].to_vec();
 
-        // Cap at 25% of model context window (rough 4-chars-per-token heuristic).
-        let max_chars = 128_000usize / 4; // conservative default; 25% of 128K tokens
-        let mut total_chars: usize = 0;
-        let mut keep = msgs.len();
-        for (i, m) in msgs.iter().enumerate() {
-            total_chars += m.content.len();
-            if total_chars > max_chars {
-                keep = i;
-                break;
-            }
-        }
-        if keep < msgs.len() {
+        // Cap at 25% of model context window and prune orphaned tool pairs.
+        let max_chars = 128_000usize / 4;
+        let requested = msgs.len();
+        trim_parent_messages(&mut msgs, max_chars);
+        if msgs.len() < requested {
             tracing::info!(
-                kept = keep,
-                requested = config.context_window_turns * 2,
-                "[subagent] truncated parent history from {} to {} turns due to token budget",
-                config.context_window_turns * 2,
-                keep
+                kept = msgs.len(),
+                requested,
+                "[subagent] truncated parent history due to token budget or orphan pruning"
             );
-            msgs.truncate(keep);
         }
         msgs
     }
@@ -3466,6 +3457,185 @@ impl<C: Channel> Agent<C> {
         }
     }
 }
+/// Estimates the JSON payload size of a single [`zeph_llm::provider::Message`] for token-budget
+/// accounting.
+///
+/// When `parts` is empty the message is a legacy text-only message and `content.len()` is used
+/// directly. Otherwise each part is measured individually so that structured variants (images,
+/// tool invocations, thinking blocks) are accounted for rather than relying on the already-flat
+/// `content` string, which may not reflect the actual API payload size.
+pub(crate) fn estimate_parts_size(m: &zeph_llm::provider::Message) -> usize {
+    use zeph_llm::provider::MessagePart;
+    if m.parts.is_empty() {
+        return m.content.len();
+    }
+    m.parts
+        .iter()
+        .map(|p| match p {
+            MessagePart::Text { text }
+            | MessagePart::Recall { text }
+            | MessagePart::CodeContext { text }
+            | MessagePart::Summary { text }
+            | MessagePart::CrossSession { text } => text.len(),
+            MessagePart::ToolOutput { body, .. } => body.len(),
+            MessagePart::ToolUse { id, name, input } => {
+                50 + id.len() + name.len() + input.to_string().len()
+            }
+            MessagePart::ToolResult {
+                tool_use_id,
+                content,
+                ..
+            } => 50 + tool_use_id.len() + content.len(),
+            MessagePart::Image(img) => img.data.len() * 4 / 3,
+            MessagePart::ThinkingBlock {
+                thinking,
+                signature,
+            } => 50 + thinking.len() + signature.len(),
+            MessagePart::RedactedThinkingBlock { data } => data.len(),
+            MessagePart::Compaction { summary } => summary.len(),
+        })
+        .sum()
+}
+
+/// Applies token-budget truncation and orphaned-tool-pair pruning to a parent message slice.
+///
+/// Budget truncation keeps the **most recent** messages that fit within `max_chars`
+/// (a suffix), so the subagent always receives the freshest context.
+///
+/// Two passes are performed after budget truncation:
+///
+/// 1. Remove `ToolResult` parts from user messages whose matching `ToolUse` is no longer in the
+///    slice (truncated away).
+/// 2. Remove `ToolUse` parts from **interior** assistant messages whose matching `ToolResult`
+///    was removed in pass 1 or was already absent. The trailing assistant message is exempt —
+///    its unanswered `ToolUse` calls are not orphaned; the slice just ends before the result.
+///
+/// Messages that become fully empty after pruning are removed from `msgs`.
+///
+/// `rebuild_content` is called **only** when `retain` actually removed parts — preserving the
+/// existing `content` field (and any `ThinkingBlock` text embedded there) for unmodified
+/// messages.
+pub(crate) fn trim_parent_messages(msgs: &mut Vec<zeph_llm::provider::Message>, max_chars: usize) {
+    use zeph_llm::provider::{MessagePart, Role};
+
+    // Token-budget cap: keep the most recent messages that fit within max_chars.
+    // We iterate from the end (newest) and drain from the front once the budget is exceeded,
+    // so the subagent always receives the most recent context rather than stale early messages.
+    let mut total_chars = 0usize;
+    let mut drop_before = 0usize; // index of the first message to keep
+    for (i, m) in msgs.iter().enumerate().rev() {
+        total_chars += estimate_parts_size(m);
+        if total_chars > max_chars {
+            drop_before = i + 1;
+            break;
+        }
+    }
+    if drop_before > 0 {
+        msgs.drain(..drop_before);
+    }
+
+    // Pass 1: collect ToolUse IDs emitted by assistant messages; prune orphaned ToolResult
+    // parts from user messages that reference a ToolUse no longer present in the slice.
+    // Use owned Strings to avoid holding immutable borrows across the subsequent mutable loop.
+    let emitted_tool_ids: std::collections::HashSet<String> = msgs
+        .iter()
+        .filter(|m| m.role == Role::Assistant)
+        .flat_map(|m| m.parts.iter())
+        .filter_map(|p| {
+            if let MessagePart::ToolUse { id, .. } = p {
+                Some(id.clone())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let mut orphans_removed = 0usize;
+    for m in msgs.iter_mut() {
+        if m.role != Role::User || m.parts.is_empty() {
+            continue;
+        }
+        let before = m.parts.len();
+        m.parts.retain(|p| match p {
+            MessagePart::ToolResult { tool_use_id, .. } => {
+                emitted_tool_ids.contains(tool_use_id.as_str())
+            }
+            _ => true,
+        });
+        let dropped = before - m.parts.len();
+        if dropped > 0 {
+            orphans_removed += dropped;
+            if m.parts.is_empty() {
+                m.content.clear();
+            } else {
+                m.rebuild_content();
+            }
+        }
+    }
+
+    // Pass 2: collect ToolResult IDs present in user messages after pass 1; prune ToolUse
+    // parts from assistant messages whose result is confirmed absent.
+    //
+    // The trailing assistant message is exempt: it may legitimately contain unanswered
+    // ToolUse calls (the slice ends before the result arrives). Only interior assistant
+    // messages — those followed by at least one user message — can have provably orphaned
+    // ToolUse parts (the conversation moved on without answering them).
+    let consumed_tool_ids: std::collections::HashSet<String> = msgs
+        .iter()
+        .filter(|m| m.role == Role::User)
+        .flat_map(|m| m.parts.iter())
+        .filter_map(|p| {
+            if let MessagePart::ToolResult { tool_use_id, .. } = p {
+                Some(tool_use_id.clone())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // Index of the last assistant message — exempt from pass 2.
+    let last_assistant_idx = msgs
+        .iter()
+        .enumerate()
+        .rev()
+        .find(|(_, m)| m.role == Role::Assistant)
+        .map(|(i, _)| i);
+
+    for (idx, m) in msgs.iter_mut().enumerate() {
+        if m.role != Role::Assistant || m.parts.is_empty() {
+            continue;
+        }
+        // Skip the trailing assistant message — its unanswered ToolUse calls are not orphaned.
+        if Some(idx) == last_assistant_idx {
+            continue;
+        }
+        let before = m.parts.len();
+        m.parts.retain(|p| match p {
+            MessagePart::ToolUse { id, .. } => consumed_tool_ids.contains(id.as_str()),
+            _ => true,
+        });
+        let dropped = before - m.parts.len();
+        if dropped > 0 {
+            orphans_removed += dropped;
+            if m.parts.is_empty() {
+                m.content.clear();
+            } else {
+                m.rebuild_content();
+            }
+        }
+    }
+
+    // Remove messages that were emptied by orphan pruning.
+    msgs.retain(|m| !m.content.is_empty() || !m.parts.is_empty());
+
+    if orphans_removed > 0 {
+        tracing::debug!(
+            orphans = orphans_removed,
+            "[subagent] pruned orphaned ToolUse/ToolResult parts from parent context boundary"
+        );
+    }
+}
+
 /// Thin wrapper that implements [`zeph_subagent::McpDispatch`] over an [`Arc<zeph_mcp::McpManager>`].
 ///
 /// Used to pass MCP tool dispatch capability into `fire_hooks` without coupling

--- a/crates/zeph-core/src/agent/tests/mod.rs
+++ b/crates/zeph-core/src/agent/tests/mod.rs
@@ -19,3 +19,5 @@ mod secret_reason_truncation;
 mod shutdown_summary_tests;
 #[cfg(test)]
 mod small_misc_tests;
+#[cfg(test)]
+mod trim_parent_messages_tests;

--- a/crates/zeph-core/src/agent/tests/trim_parent_messages_tests.rs
+++ b/crates/zeph-core/src/agent/tests/trim_parent_messages_tests.rs
@@ -1,0 +1,266 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use serde_json::json;
+use zeph_llm::provider::{Message, MessagePart, Role};
+
+use crate::agent::{estimate_parts_size, trim_parent_messages};
+
+fn text_msg(role: Role, text: &str) -> Message {
+    Message::from_parts(
+        role,
+        vec![MessagePart::Text {
+            text: text.to_owned(),
+        }],
+    )
+}
+
+fn tool_use_msg(id: &str, name: &str) -> Message {
+    Message::from_parts(
+        Role::Assistant,
+        vec![MessagePart::ToolUse {
+            id: id.to_owned(),
+            name: name.to_owned(),
+            input: json!({}),
+        }],
+    )
+}
+
+fn tool_result_msg(tool_use_id: &str, content: &str) -> Message {
+    Message::from_parts(
+        Role::User,
+        vec![MessagePart::ToolResult {
+            tool_use_id: tool_use_id.to_owned(),
+            content: content.to_owned(),
+            is_error: false,
+        }],
+    )
+}
+
+#[test]
+fn trim_parent_messages_drops_orphaned_tool_results() {
+    // Slice starts with a user ToolResult for "tu_A", but the corresponding ToolUse is NOT
+    // in the slice (it was truncated away).  The orphan must be removed.
+    let mut msgs = vec![
+        tool_result_msg("tu_A", "result-a"),
+        text_msg(Role::Assistant, "ok"),
+    ];
+    trim_parent_messages(&mut msgs, usize::MAX);
+    // The orphaned ToolResult message must be gone; only the text assistant message remains.
+    assert_eq!(msgs.len(), 1, "orphaned ToolResult message must be removed");
+    assert!(
+        msgs[0]
+            .parts
+            .iter()
+            .all(|p| !matches!(p, MessagePart::ToolResult { .. })),
+        "no ToolResult parts must remain"
+    );
+}
+
+#[test]
+fn trim_parent_messages_keeps_matched_tool_pairs() {
+    // Both ToolUse and ToolResult for "tu_B" are in the slice — both must be kept.
+    let mut msgs = vec![
+        tool_use_msg("tu_B", "shell"),
+        tool_result_msg("tu_B", "output-b"),
+    ];
+    trim_parent_messages(&mut msgs, usize::MAX);
+    assert_eq!(msgs.len(), 2, "matched pair must not be removed");
+    let has_use = msgs[0]
+        .parts
+        .iter()
+        .any(|p| matches!(p, MessagePart::ToolUse { id, .. } if id == "tu_B"));
+    let has_result = msgs[1]
+        .parts
+        .iter()
+        .any(|p| matches!(p, MessagePart::ToolResult { tool_use_id, .. } if tool_use_id == "tu_B"));
+    assert!(has_use, "ToolUse must be preserved");
+    assert!(has_result, "ToolResult must be preserved");
+}
+
+#[test]
+fn trim_parent_messages_budget_uses_structured_size() {
+    // Build an assistant message where the ToolUse input is large enough that
+    // estimate_parts_size exceeds max_chars, but content.len() would not.
+    // max_chars = 10 — any real message will exceed it.
+    let large_input = json!({"cmd": "x".repeat(200)});
+    let assistant_msg = Message::from_parts(
+        Role::Assistant,
+        vec![MessagePart::ToolUse {
+            id: "tu_x".to_owned(),
+            name: "shell".to_owned(),
+            input: large_input,
+        }],
+    );
+    // Sanity: estimate_parts_size is larger than content.len() for the structured message.
+    let estimated = estimate_parts_size(&assistant_msg);
+    assert!(
+        estimated > assistant_msg.content.len(),
+        "structured size ({estimated}) must exceed flat content ({})",
+        assistant_msg.content.len()
+    );
+
+    let mut msgs = vec![assistant_msg, text_msg(Role::User, "hi")];
+    trim_parent_messages(&mut msgs, 10); // tiny budget — triggers truncation
+    assert!(
+        msgs.len() < 2,
+        "budget truncation must fire based on structured size"
+    );
+}
+
+#[test]
+fn trim_parent_messages_removes_empty_message_after_pruning() {
+    // A user message with only ToolResult parts that are all orphaned becomes empty
+    // and must be removed from the slice entirely.
+    let mut msgs = vec![
+        Message::from_parts(
+            Role::User,
+            vec![MessagePart::ToolResult {
+                tool_use_id: "tu_orphan".to_owned(),
+                content: "result".to_owned(),
+                is_error: false,
+            }],
+        ),
+        text_msg(Role::Assistant, "reply"),
+    ];
+    trim_parent_messages(&mut msgs, usize::MAX);
+    assert!(
+        msgs.iter()
+            .all(|m| m.role != Role::User || !m.parts.is_empty()),
+        "emptied user messages must be removed"
+    );
+    let has_orphan = msgs.iter().flat_map(|m| m.parts.iter()).any(
+        |p| matches!(p, MessagePart::ToolResult { tool_use_id, .. } if tool_use_id == "tu_orphan"),
+    );
+    assert!(!has_orphan, "orphaned ToolResult must not survive");
+}
+
+#[test]
+fn orphan_pruning_preserves_thinking_block() {
+    // Assistant message: [ThinkingBlock, Text, ToolUse(matched)]
+    // User message:      [ToolResult(matched)]
+    // After pruning: ToolUse is matched → nothing removed → rebuild_content NOT called →
+    //                ThinkingBlock text in content must be intact.
+    let thinking_text = "deep reasoning here";
+    let assistant_msg = Message::from_parts(
+        Role::Assistant,
+        vec![
+            MessagePart::ThinkingBlock {
+                thinking: thinking_text.to_owned(),
+                signature: "sig123".to_owned(),
+            },
+            MessagePart::Text {
+                text: "answer".to_owned(),
+            },
+            MessagePart::ToolUse {
+                id: "tu_matched".to_owned(),
+                name: "shell".to_owned(),
+                input: json!({}),
+            },
+        ],
+    );
+    // Capture content before pruning — it must not change.
+    let content_before = assistant_msg.content.clone();
+
+    let mut msgs = vec![
+        assistant_msg,
+        Message::from_parts(
+            Role::User,
+            vec![MessagePart::ToolResult {
+                tool_use_id: "tu_matched".to_owned(),
+                content: "ok".to_owned(),
+                is_error: false,
+            }],
+        ),
+    ];
+    trim_parent_messages(&mut msgs, usize::MAX);
+
+    assert_eq!(msgs.len(), 2, "no messages should be removed");
+    assert_eq!(msgs[0].parts.len(), 3, "all 3 assistant parts must survive");
+    assert_eq!(
+        msgs[0].content, content_before,
+        "content must not be modified (ThinkingBlock must not be erased)"
+    );
+}
+
+#[test]
+fn trailing_assistant_tool_use_preserved_without_result() {
+    // The slice ends with an assistant ToolUse that has no corresponding ToolResult —
+    // this is the trailing-edge case where the slice ends before the result arrives.
+    // Pass 2 must NOT remove this ToolUse.
+    let mut msgs = vec![
+        text_msg(Role::User, "do something"),
+        tool_use_msg("tu_trailing", "shell"),
+    ];
+    trim_parent_messages(&mut msgs, usize::MAX);
+    assert_eq!(msgs.len(), 2, "both messages must be preserved");
+    let has_trailing_use = msgs[1]
+        .parts
+        .iter()
+        .any(|p| matches!(p, MessagePart::ToolUse { id, .. } if id == "tu_trailing"));
+    assert!(
+        has_trailing_use,
+        "trailing unanswered ToolUse must not be pruned"
+    );
+}
+
+#[test]
+fn budget_keeps_suffix_not_prefix() {
+    // With a tight budget that fits only 1 message, the LAST (most recent) message must
+    // be kept, not the first (oldest).  This verifies the suffix-first truncation direction.
+    let small = text_msg(Role::User, "recent"); // ~6 bytes
+    let large = text_msg(Role::User, "x".repeat(500).as_str()); // ~500 bytes
+    let small_size = estimate_parts_size(&small);
+    let large_size = estimate_parts_size(&large);
+    let budget = small_size + large_size / 2; // fits small but not large
+    let mut msgs = vec![large, small]; // large first (older), small second (newer)
+    trim_parent_messages(&mut msgs, budget);
+    assert_eq!(msgs.len(), 1, "only one message must fit");
+    assert_eq!(
+        msgs[0].content, "recent",
+        "the most recent (suffix) message must be kept, not the older one"
+    );
+}
+
+#[test]
+fn trim_parent_messages_partial_prune_keeps_text() {
+    // A user message with both an orphaned ToolResult AND a Text part.
+    // After pruning, the ToolResult is removed but the Text part — and the message — must survive.
+    let mut msgs = vec![
+        text_msg(Role::Assistant, "thinking..."),
+        Message::from_parts(
+            Role::User,
+            vec![
+                MessagePart::ToolResult {
+                    tool_use_id: "tu_gone".to_owned(),
+                    content: "old result".to_owned(),
+                    is_error: false,
+                },
+                MessagePart::Text {
+                    text: "also some user text".to_owned(),
+                },
+            ],
+        ),
+        text_msg(Role::Assistant, "ok"),
+    ];
+    trim_parent_messages(&mut msgs, usize::MAX);
+    // Message must still exist (not emptied).
+    let user_msg = msgs.iter().find(|m| m.role == Role::User);
+    assert!(
+        user_msg.is_some(),
+        "user message must survive partial pruning"
+    );
+    let user_msg = user_msg.unwrap();
+    // The ToolResult must be gone.
+    let has_orphan = user_msg
+        .parts
+        .iter()
+        .any(|p| matches!(p, MessagePart::ToolResult { .. }));
+    assert!(!has_orphan, "orphaned ToolResult must be removed");
+    // The Text part must remain.
+    let has_text = user_msg
+        .parts
+        .iter()
+        .any(|p| matches!(p, MessagePart::Text { text } if text == "also some user text"));
+    assert!(has_text, "Text part must survive after orphan removal");
+}


### PR DESCRIPTION
## Summary

- Fixes silent data loss when subagent context slice boundary splits a ToolUse/ToolResult pair (#3760)
- Fixes token budget underestimation caused by flat `content.len()` instead of structured parts size (#3761)

## Changes

**`crates/zeph-core/src/agent/mod.rs`**

- `estimate_parts_size(m: &Message) -> usize` — computes Claude API payload size from structured parts (ToolUse input JSON, ToolResult content, image base64, etc.); falls back to `content.len()` for legacy messages
- `trim_parent_messages(msgs: &mut Vec<Message>, max_chars: usize)` — replaces the old inline truncation logic:
  - Budget truncation iterates newest→oldest, keeping the most-recent messages that fit (suffix, not prefix)
  - Pass 1: removes ToolResult parts whose paired ToolUse is not in the slice
  - Pass 2: removes dangling ToolUse parts, skipping the trailing assistant message (pending tool calls at boundary)
  - `rebuild_content` is guarded by `parts.len()` before/after to prevent ThinkingBlock content corruption
  - Messages emptied by pruning are removed
- `extract_parent_messages` delegates to `trim_parent_messages`

**`crates/zeph-core/src/agent/tests/trim_parent_messages_tests.rs`** — 8 unit tests:
- Orphaned ToolResult removed
- Matched pairs preserved
- Budget uses structured size
- Empty messages removed after pruning
- ThinkingBlock content preserved when ToolUse is matched
- Trailing ToolUse preserved without result
- Budget keeps suffix not prefix
- Partial prune keeps Text alongside orphaned ToolResult

## Test plan

- [ ] `cargo nextest run -p zeph-core --lib` — 1413 tests pass
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean
- [ ] Live subagent session with `context_window_turns = 3` and tool-heavy parent history — verify no orphaned ToolResult in debug dump

Closes #3760
Closes #3761