### PR TITLE
fix(tui): automatic view switch and real-time transcript for foreground subagents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- feat(tui): automatic view switch to foreground subagent transcript on spawn. When a foreground
+  subagent is started, the TUI switches to the subagent transcript view; when the subagent
+  completes or fails, the TUI returns to the Main view and shows a status bar notification with
+  the agent name and final state. Manual navigation is respected: if the user switches away while
+  the subagent is running, the automatic return-to-Main is suppressed. Closes #3762.
+
 ### Fixed
 
 - fix(core): prevent orphaned ToolUse/ToolResult pairs in subagent parent context window. When

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -2206,8 +2206,13 @@ impl<C: Channel> Agent<C> {
     }
 
     /// Poll a sub-agent until it reaches a terminal state, bridging secret requests to the
-    /// channel. Returns a human-readable status string suitable for sending to the user.
-    async fn poll_subagent_until_done(&mut self, task_id: &str, label: &str) -> Option<String> {
+    /// channel. Returns a human-readable status string and success flag suitable for
+    /// sending to the user and emitting lifecycle events.
+    async fn poll_subagent_until_done(
+        &mut self,
+        task_id: &str,
+        label: &str,
+    ) -> Option<(String, bool)> {
         use zeph_subagent::SubAgentState;
         let result = loop {
             tokio::time::sleep(std::time::Duration::from_millis(500)).await;
@@ -2246,22 +2251,22 @@ impl<C: Channel> Agent<C> {
             let mgr = self.services.orchestration.subagent_manager.as_ref()?;
             let statuses = mgr.statuses();
             let Some((_, status)) = statuses.iter().find(|(id, _)| id == task_id) else {
-                break format!("{label} completed (no status available).");
+                break (format!("{label} completed (no status available)."), true);
             };
             match status.state {
                 SubAgentState::Completed => {
                     let msg = status.last_message.clone().unwrap_or_else(|| "done".into());
-                    break format!("{label} completed: {msg}");
+                    break (format!("{label} completed: {msg}"), true);
                 }
                 SubAgentState::Failed => {
                     let msg = status
                         .last_message
                         .clone()
                         .unwrap_or_else(|| "unknown error".into());
-                    break format!("{label} failed: {msg}");
+                    break (format!("{label} failed: {msg}"), false);
                 }
                 SubAgentState::Canceled => {
-                    break format!("{label} was cancelled.");
+                    break (format!("{label} was cancelled."), false);
                 }
                 _ => {
                     let _ = self
@@ -2465,8 +2470,24 @@ impl<C: Channel> Agent<C> {
             .channel
             .send(&format!("Sub-agent '{name}' running... (id: {short})"))
             .await;
+        let _ = self
+            .channel
+            .notify_foreground_subagent_started(&task_id, name)
+            .await;
         let label = format!("Sub-agent '{name}'");
-        self.poll_subagent_until_done(&task_id, &label).await
+        let Some((result, success)) = self.poll_subagent_until_done(&task_id, &label).await else {
+            // Manager was dropped mid-poll; emit completed(false) so TUI does not stay stuck.
+            let _ = self
+                .channel
+                .notify_foreground_subagent_completed(&task_id, name, false)
+                .await;
+            return None;
+        };
+        let _ = self
+            .channel
+            .notify_foreground_subagent_completed(&task_id, name, success)
+            .await;
+        Some(result)
     }
 
     fn handle_agent_cancel(&mut self, id: &str) -> Option<String> {
@@ -2518,8 +2539,26 @@ impl<C: Channel> Agent<C> {
             .channel
             .send(&format!("Resuming sub-agent '{id}'... (new id: {short})"))
             .await;
-        self.poll_subagent_until_done(&task_id, "Resumed sub-agent")
+        let _ = self
+            .channel
+            .notify_foreground_subagent_started(&task_id, &def_name)
+            .await;
+        let Some((result, success)) = self
+            .poll_subagent_until_done(&task_id, "Resumed sub-agent")
             .await
+        else {
+            // Manager was dropped mid-poll; emit completed(false) so TUI does not stay stuck.
+            let _ = self
+                .channel
+                .notify_foreground_subagent_completed(&task_id, &def_name, false)
+                .await;
+            return None;
+        };
+        let _ = self
+            .channel
+            .notify_foreground_subagent_completed(&task_id, &def_name, success)
+            .await;
+        Some(result)
     }
 
     fn filtered_skills_for(&self, agent_name: &str) -> Option<Vec<String>> {

--- a/crates/zeph-core/src/channel.rs
+++ b/crates/zeph-core/src/channel.rs
@@ -410,6 +410,41 @@ pub trait Channel: Send {
     ) -> impl Future<Output = Result<(), ChannelError>> + Send {
         async { Ok(()) }
     }
+
+    /// Notify channel that a foreground subagent has started. No-op by default.
+    ///
+    /// Called after the subagent is spawned and before polling begins. Channels
+    /// that support subagent views (e.g. TUI) should switch to the subagent
+    /// transcript view on receipt.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the underlying I/O fails.
+    fn notify_foreground_subagent_started(
+        &mut self,
+        _id: &str,
+        _name: &str,
+    ) -> impl Future<Output = Result<(), ChannelError>> + Send {
+        async { Ok(()) }
+    }
+
+    /// Notify channel that a foreground subagent has completed. No-op by default.
+    ///
+    /// Called after `poll_subagent_until_done` returns. Channels that support
+    /// subagent views should switch back to the main view and show a status
+    /// notification.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the underlying I/O fails.
+    fn notify_foreground_subagent_completed(
+        &mut self,
+        _id: &str,
+        _name: &str,
+        _success: bool,
+    ) -> impl Future<Output = Result<(), ChannelError>> + Send {
+        async { Ok(()) }
+    }
 }
 
 /// Reason why the agent turn ended — carried by [`LoopbackEvent::Stop`].

--- a/crates/zeph-tui/src/app/events.rs
+++ b/crates/zeph-tui/src/app/events.rs
@@ -214,6 +214,30 @@ impl App {
             AgentEvent::SetMetricsRx(rx) => {
                 self.set_metrics_rx(rx);
             }
+            AgentEvent::ForegroundSubagentStarted { id, name } => {
+                self.sessions.current_mut().status_label =
+                    Some(format!("Sub-agent '{name}' running..."));
+                self.set_view_target(super::AgentViewTarget::SubAgent { id, name });
+            }
+            AgentEvent::ForegroundSubagentCompleted { id, name, success } => {
+                // Only switch back to Main if we are still viewing this subagent.
+                // If the user manually navigated away, respect that choice.
+                if self.sessions.current().view_target.subagent_id() == Some(id.as_str()) {
+                    self.set_view_target(super::AgentViewTarget::Main);
+                }
+                let label = if success {
+                    format!("Sub-agent '{name}' completed")
+                } else {
+                    format!("Sub-agent '{name}' failed")
+                };
+                self.sessions.current_mut().status_label = Some(label.clone());
+                self.sessions
+                    .current_mut()
+                    .messages
+                    .push(ChatMessage::new(MessageRole::System, label));
+                self.trim_messages();
+                self.auto_scroll();
+            }
         }
     }
 
@@ -343,7 +367,7 @@ impl App {
 mod tests {
     use tokio::sync::mpsc;
 
-    use crate::app::App;
+    use crate::app::{AgentViewTarget, App};
     use crate::event::AgentEvent;
     use crate::types::{ChatMessage, MessageRole};
     use zeph_core::DiffData;
@@ -542,5 +566,133 @@ mod tests {
             msgs[2].diff_data.is_none(),
             "call-C must remain without diff"
         );
+    }
+
+    #[test]
+    fn foreground_subagent_started_switches_view_to_subagent() {
+        let mut app = make_app();
+        assert!(app.sessions.current().view_target.is_main());
+
+        app.handle_agent_event(AgentEvent::ForegroundSubagentStarted {
+            id: "sa-001".into(),
+            name: "planner".into(),
+        });
+
+        assert_eq!(
+            app.sessions.current().view_target.subagent_id(),
+            Some("sa-001"),
+            "view must switch to the started subagent"
+        );
+        assert_eq!(
+            app.sessions.current().status_label.as_deref(),
+            Some("Sub-agent 'planner' running...")
+        );
+    }
+
+    #[test]
+    fn foreground_subagent_completed_switches_back_when_viewing_subagent() {
+        let mut app = make_app();
+
+        app.handle_agent_event(AgentEvent::ForegroundSubagentStarted {
+            id: "sa-002".into(),
+            name: "coder".into(),
+        });
+        assert_eq!(
+            app.sessions.current().view_target.subagent_id(),
+            Some("sa-002")
+        );
+
+        app.handle_agent_event(AgentEvent::ForegroundSubagentCompleted {
+            id: "sa-002".into(),
+            name: "coder".into(),
+            success: true,
+        });
+
+        assert!(
+            app.sessions.current().view_target.is_main(),
+            "view must return to Main after completion"
+        );
+        assert_eq!(
+            app.sessions.current().status_label.as_deref(),
+            Some("Sub-agent 'coder' completed")
+        );
+        let system_msg = app
+            .sessions
+            .current()
+            .messages
+            .iter()
+            .find(|m| m.role == MessageRole::System);
+        assert!(
+            system_msg.is_some(),
+            "completion system message must be pushed"
+        );
+    }
+
+    #[test]
+    fn foreground_subagent_completed_respects_manual_navigation() {
+        let mut app = make_app();
+
+        app.handle_agent_event(AgentEvent::ForegroundSubagentStarted {
+            id: "sa-003".into(),
+            name: "researcher".into(),
+        });
+
+        // Simulate user manually navigating away to a different subagent.
+        app.set_view_target(AgentViewTarget::SubAgent {
+            id: "sa-other".into(),
+            name: "other".into(),
+        });
+
+        app.handle_agent_event(AgentEvent::ForegroundSubagentCompleted {
+            id: "sa-003".into(),
+            name: "researcher".into(),
+            success: false,
+        });
+
+        // View must NOT switch to Main because user is viewing a different subagent.
+        assert_eq!(
+            app.sessions.current().view_target.subagent_id(),
+            Some("sa-other"),
+            "user's manual navigation must be preserved"
+        );
+    }
+
+    #[test]
+    fn foreground_subagent_failed_shows_failed_label() {
+        let mut app = make_app();
+
+        app.handle_agent_event(AgentEvent::ForegroundSubagentStarted {
+            id: "sa-004".into(),
+            name: "builder".into(),
+        });
+        app.handle_agent_event(AgentEvent::ForegroundSubagentCompleted {
+            id: "sa-004".into(),
+            name: "builder".into(),
+            success: false,
+        });
+
+        assert_eq!(
+            app.sessions.current().status_label.as_deref(),
+            Some("Sub-agent 'builder' failed")
+        );
+    }
+
+    // Fast-completing subagents cause a Started then immediately Completed event.
+    // This results in a brief flash before returning to Main, which is acceptable.
+    #[test]
+    fn foreground_subagent_fast_complete_ends_on_main() {
+        let mut app = make_app();
+
+        app.handle_agent_event(AgentEvent::ForegroundSubagentStarted {
+            id: "sa-fast".into(),
+            name: "quick".into(),
+        });
+        app.handle_agent_event(AgentEvent::ForegroundSubagentCompleted {
+            id: "sa-fast".into(),
+            name: "quick".into(),
+            success: true,
+        });
+
+        assert!(app.sessions.current().view_target.is_main());
     }
 }

--- a/crates/zeph-tui/src/channel.rs
+++ b/crates/zeph-tui/src/channel.rs
@@ -311,6 +311,38 @@ impl Channel for TuiChannel {
             .map_err(|_| ChannelError::ChannelClosed)?;
         rx.await.map_err(|_| ChannelError::ChannelClosed)
     }
+
+    async fn notify_foreground_subagent_started(
+        &mut self,
+        id: &str,
+        name: &str,
+    ) -> Result<(), ChannelError> {
+        // Non-critical: visual navigation only.
+        let _ = self
+            .agent_event_tx
+            .try_send(AgentEvent::ForegroundSubagentStarted {
+                id: id.to_owned(),
+                name: name.to_owned(),
+            });
+        Ok(())
+    }
+
+    async fn notify_foreground_subagent_completed(
+        &mut self,
+        id: &str,
+        name: &str,
+        success: bool,
+    ) -> Result<(), ChannelError> {
+        // Non-critical: visual navigation only.
+        let _ = self
+            .agent_event_tx
+            .try_send(AgentEvent::ForegroundSubagentCompleted {
+                id: id.to_owned(),
+                name: name.to_owned(),
+                success,
+            });
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -635,6 +667,47 @@ mod tests {
 
     /// Verify that non-critical send methods return `Ok(())` without blocking
     /// when the channel is full (backpressure test).
+    #[tokio::test]
+    async fn notify_foreground_subagent_started_sends_event() {
+        let (mut ch, _user_tx, mut agent_rx) = make_channel();
+        ch.notify_foreground_subagent_started("sa-1", "planner")
+            .await
+            .unwrap();
+        let evt = agent_rx.recv().await.unwrap();
+        assert!(
+            matches!(evt, AgentEvent::ForegroundSubagentStarted { ref id, ref name }
+                if id == "sa-1" && name == "planner"),
+            "expected ForegroundSubagentStarted"
+        );
+    }
+
+    #[tokio::test]
+    async fn notify_foreground_subagent_completed_sends_event_success() {
+        let (mut ch, _user_tx, mut agent_rx) = make_channel();
+        ch.notify_foreground_subagent_completed("sa-2", "coder", true)
+            .await
+            .unwrap();
+        let evt = agent_rx.recv().await.unwrap();
+        assert!(
+            matches!(evt, AgentEvent::ForegroundSubagentCompleted { ref id, ref name, success }
+                if id == "sa-2" && name == "coder" && success),
+            "expected ForegroundSubagentCompleted with success=true"
+        );
+    }
+
+    #[tokio::test]
+    async fn notify_foreground_subagent_completed_sends_event_failure() {
+        let (mut ch, _user_tx, mut agent_rx) = make_channel();
+        ch.notify_foreground_subagent_completed("sa-3", "builder", false)
+            .await
+            .unwrap();
+        let evt = agent_rx.recv().await.unwrap();
+        assert!(
+            matches!(evt, AgentEvent::ForegroundSubagentCompleted { success, .. } if !success),
+            "expected ForegroundSubagentCompleted with success=false"
+        );
+    }
+
     #[tokio::test]
     async fn non_critical_send_returns_ok_when_channel_full() {
         // Capacity 1 — fill it, then try to send non-critical events.

--- a/crates/zeph-tui/src/event.rs
+++ b/crates/zeph-tui/src/event.rs
@@ -214,6 +214,22 @@ pub enum AgentEvent {
     SetCancelSignal(Arc<Notify>),
     /// Wire a metrics receiver into the TUI App after early startup (Phase 2).
     SetMetricsRx(watch::Receiver<MetricsSnapshot>),
+    /// A foreground subagent has been spawned; the TUI should switch view to its transcript.
+    ForegroundSubagentStarted {
+        /// Stable sub-agent identifier (`task_id` from `SubAgentManager`).
+        id: String,
+        /// Human-readable agent definition name.
+        name: String,
+    },
+    /// A foreground subagent has reached a terminal state; the TUI should return to Main view.
+    ForegroundSubagentCompleted {
+        /// Stable sub-agent identifier.
+        id: String,
+        /// Human-readable agent definition name.
+        name: String,
+        /// `true` if Completed state, `false` if Failed/Canceled.
+        success: bool,
+    },
 }
 
 /// Blocking event pump that forwards terminal events to the async [`AppEvent`] channel.

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -117,6 +117,29 @@ impl Channel for AppChannel {
     async fn send_tool_start(&mut self, event: ToolStartEvent) -> Result<(), ChannelError> {
         dispatch_app_channel!(self, send_tool_start, event)
     }
+
+    async fn notify_foreground_subagent_started(
+        &mut self,
+        id: &str,
+        name: &str,
+    ) -> Result<(), ChannelError> {
+        dispatch_app_channel!(self, notify_foreground_subagent_started, id, name)
+    }
+
+    async fn notify_foreground_subagent_completed(
+        &mut self,
+        id: &str,
+        name: &str,
+        success: bool,
+    ) -> Result<(), ChannelError> {
+        dispatch_app_channel!(
+            self,
+            notify_foreground_subagent_completed,
+            id,
+            name,
+            success
+        )
+    }
 }
 
 #[cfg(feature = "tui")]
@@ -353,6 +376,14 @@ mod tests {
         // 15. send_stop_hint
         ch.send_stop_hint(StopHint::MaxTurnRequests).await.unwrap();
         // 16. confirm — skipped (reads from stdin; covered by separate test)
+        // 17. notify_foreground_subagent_started
+        ch.notify_foreground_subagent_started("sa-id", "planner")
+            .await
+            .unwrap();
+        // 18. notify_foreground_subagent_completed
+        ch.notify_foreground_subagent_completed("sa-id", "planner", true)
+            .await
+            .unwrap();
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `ForegroundSubagentStarted` and `ForegroundSubagentCompleted` `AgentEvent` variants
- TUI automatically switches to subagent transcript view on start; returns to Main on completion (respects manual navigation)
- `poll_subagent_until_done` now returns `(String, bool)` — success derived from state enum, not string matching
- `notify_foreground_subagent_completed` is guaranteed even when `subagent_manager` is dropped mid-poll (no orphaned view state)
- Real-time transcript via existing `maybe_reload_transcript` polling (~250ms latency)
- `AppChannel` forwards both new `Channel` trait methods via dispatch macro

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` — 9155 tests pass
- [ ] `ForegroundSubagentStarted` → view switches to subagent transcript
- [ ] `ForegroundSubagentCompleted` (success) → view returns to Main
- [ ] `ForegroundSubagentCompleted` (failure) → view returns to Main with failure notification
- [ ] Manual navigation away from subagent view before completion → no forced switch back
- [ ] Fast-completing subagent (Started + Completed in quick succession) → brief flash, then Main

Closes #3762