### PR TITLE
chore(deps): upgrade qdrant-client to 1.18

### DIFF
--- a/.github/deny.toml
+++ b/.github/deny.toml
@@ -11,7 +11,7 @@ features = ["candle", "tui"]
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 # rustls-pemfile unmaintained (RUSTSEC-2025-0134, via qdrant-client -> tonic 0.12)
-# Blocked on qdrant/rust-client#255 (tonic 0.14 upgrade removes rustls-pemfile)
+# Verified in qdrant-client 1.18 (tonic 0.12.3); remove once qdrant/rust-client#255 merges
 # number_prefix unmaintained (via indicatif -> hf-hub, candle transitive dep)
 ignore = ["RUSTSEC-2025-0134", "RUSTSEC-2024-0436"]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5798,9 +5798,9 @@ checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "qdrant-client"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d0a9b168ecf8f30a3eb7e8f4766e3050701242ffbe99838b58e6c4251e7211"
+checksum = "82cef4e669bcf9c07471463adab5ee080dd9bc9381f3652ea4981f6030b2c309"
 dependencies = [
  "anyhow",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ prometheus-client = "0.24.1"
 petgraph = "0.8.3"
 proptest = "1.11"
 pulldown-cmark = "0.13.3"
-qdrant-client = { version = "1.17", default-features = false }
+qdrant-client = { version = "1.18", default-features = false }
 rand = "0.10.1"
 rand_distr = "0.6"
 ratatui = "0.30"


### PR DESCRIPTION
## Summary

- Bumps `qdrant-client` from `1.17` to `1.18`, syncing the Rust client with the already-updated Docker image (`qdrant/qdrant:v1.18.0` in `docker-compose.yml`)
- Updates `.github/deny.toml` comment to reflect that RUSTSEC-2025-0134 was re-verified in 1.18

## Advisory status

`RUSTSEC-2025-0134` (`rustls-pemfile` unmaintained) is **not resolved** in this release — `qdrant-client 1.18` still depends on `tonic 0.12.3` which pulls in `rustls-pemfile`. The `deny.toml` ignore remains in place.

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 9155 tests passed
- [x] `cargo deny check --config .github/deny.toml advisories` — advisories ok

Closes #2347