### PR TITLE
fix(subagent): normalize tool IDs in FilteredToolExecutor to fix case/format mismatch

### DIFF
--- a/.zeph/agents/01-rust-architect.md
+++ b/.zeph/agents/01-rust-architect.md
@@ -8,8 +8,8 @@ skills:
     - rust-agent-handoff
 tools:
   allow:
-    - Read
-    - Write
+    - read
+    - write
     - Bash(cargo *)
     - Bash(rustc *)
     - Bash(git *)

--- a/.zeph/agents/02-rust-developer.md
+++ b/.zeph/agents/02-rust-developer.md
@@ -8,8 +8,8 @@ skills:
     - rust-agent-handoff
 tools:
   allow:
-    - Read
-    - Write
+    - read
+    - write
     - Bash(cargo *)
     - Bash(rustc *)
     - Bash(rustfmt *)

--- a/.zeph/agents/03-rust-testing-engineer.md
+++ b/.zeph/agents/03-rust-testing-engineer.md
@@ -8,8 +8,8 @@ skills:
     - rust-agent-handoff
 tools:
   allow:
-    - Read
-    - Write
+    - read
+    - write
     - Bash(cargo *)
     - Bash(cargo-nextest *)
     - Bash(cargo-llvm-cov *)

--- a/.zeph/agents/04-rust-performance-engineer.md
+++ b/.zeph/agents/04-rust-performance-engineer.md
@@ -8,8 +8,8 @@ skills:
     - rust-agent-handoff
 tools:
   allow:
-    - Read
-    - Write
+    - read
+    - write
     - Bash(cargo *)
     - Bash(flamegraph *)
     - Bash(sccache *)

--- a/.zeph/agents/05-rust-security-maintenance.md
+++ b/.zeph/agents/05-rust-security-maintenance.md
@@ -8,8 +8,8 @@ skills:
     - rust-agent-handoff
 tools:
   allow:
-    - Read
-    - Write
+    - read
+    - write
     - Bash(cargo *)
     - Bash(cargo-deny *)
     - Bash(cargo-outdated *)

--- a/.zeph/agents/06-rust-code-reviewer.md
+++ b/.zeph/agents/06-rust-code-reviewer.md
@@ -8,7 +8,7 @@ skills:
     - rust-agent-handoff
 tools:
   allow:
-    - Read
+    - read
     - Bash(cargo *)
     - Bash(cargo-expand *)
     - Bash(cargo-semver-checks *)

--- a/.zeph/agents/07-rust-cicd-devops.md
+++ b/.zeph/agents/07-rust-cicd-devops.md
@@ -8,8 +8,8 @@ skills:
     - rust-agent-handoff
 tools:
   allow:
-    - Read
-    - Write
+    - read
+    - write
     - Bash(cargo *)
     - Bash(git *)
     - Bash(docker *)

--- a/.zeph/agents/08-rust-debugger.md
+++ b/.zeph/agents/08-rust-debugger.md
@@ -8,8 +8,8 @@ skills:
     - rust-agent-handoff
 tools:
   allow:
-    - Read
-    - Write
+    - read
+    - write
     - Bash(cargo *)
     - Bash(rustc *)
     - Bash(cargo-expand *)

--- a/.zeph/agents/09-rust-critic.md
+++ b/.zeph/agents/09-rust-critic.md
@@ -8,8 +8,8 @@ skills:
     - rust-agent-handoff
 tools:
   allow:
-    - Read
-    - Write
+    - read
+    - write
     - Bash(cargo metadata *)
     - Bash(cargo tree *)
     - Bash(cargo audit *)

--- a/crates/zeph-subagent/src/filter.rs
+++ b/crates/zeph-subagent/src/filter.rs
@@ -38,6 +38,16 @@ fn collect_fenced_tags(executor: &dyn ErasedToolExecutor) -> Vec<&'static str> {
         .collect()
 }
 
+// ── Tool ID normalization ─────────────────────────────────────────────────────
+
+/// Normalize a tool ID for policy matching: lowercase, strip everything from the first `(` onward.
+///
+/// Examples: `"Read"` → `"read"`, `"Bash(cargo *)"` → `"bash"`, `"bash"` → `"bash"`.
+pub(crate) fn normalize_tool_id(s: &str) -> String {
+    let base = s.split('(').next().unwrap_or(s);
+    base.trim().to_lowercase()
+}
+
 // ── Tool filtering ────────────────────────────────────────────────────────────
 
 /// Wraps an [`ErasedToolExecutor`] and enforces a [`ToolPolicy`] plus an optional
@@ -100,16 +110,22 @@ impl FilteredToolExecutor {
 
     /// Check whether `tool_id` is allowed under the current policy and denylist.
     ///
-    /// Matching is exact string equality. MCP compound tool IDs (e.g. `mcp__server__tool`)
-    /// must be listed in full in `tools.except` — partial names or prefixes are not matched.
+    /// Matching is case-insensitive and strips argument suffixes (e.g. `"Bash(cargo *)"` matches
+    /// runtime ID `"bash"`). MCP compound tool IDs (`mcp__server__tool`) must still be listed in
+    /// full in `tools.except` — partial names or prefixes are not matched.
     fn is_allowed(&self, tool_id: &str) -> bool {
-        if self.disallowed.iter().any(|t| t == tool_id) {
+        let normalized = normalize_tool_id(tool_id);
+        if self
+            .disallowed
+            .iter()
+            .any(|t| normalize_tool_id(t) == normalized)
+        {
             return false;
         }
         match &self.policy {
             ToolPolicy::InheritAll => true,
-            ToolPolicy::AllowList(list) => list.iter().any(|t| t == tool_id),
-            ToolPolicy::DenyList(list) => !list.iter().any(|t| t == tool_id),
+            ToolPolicy::AllowList(list) => list.iter().any(|t| normalize_tool_id(t) == normalized),
+            ToolPolicy::DenyList(list) => !list.iter().any(|t| normalize_tool_id(t) == normalized),
         }
     }
 }
@@ -926,6 +942,42 @@ mod tests {
         assert_eq!(defs.len(), 2);
         assert!(defs.iter().any(|d| d.id == "shell"));
         assert!(defs.iter().any(|d| d.id == "web"));
+    }
+
+    // ── normalize_tool_id tests ────────────────────────────────────────────
+
+    #[test]
+    fn normalize_tool_id_lowercases() {
+        assert_eq!(normalize_tool_id("Read"), "read");
+        assert_eq!(normalize_tool_id("Write"), "write");
+        assert_eq!(normalize_tool_id("Edit"), "edit");
+    }
+
+    #[test]
+    fn normalize_tool_id_strips_args() {
+        assert_eq!(normalize_tool_id("Bash(cargo *)"), "bash");
+        assert_eq!(normalize_tool_id("Bash(git *)"), "bash");
+        assert_eq!(normalize_tool_id("bash"), "bash");
+    }
+
+    #[test]
+    fn allow_list_pascal_case_permits_lowercase_runtime_id() {
+        let exec = FilteredToolExecutor::new(
+            stub_box(&["read", "write", "bash"]),
+            ToolPolicy::AllowList(vec!["Read".into(), "Write".into(), "Bash(cargo *)".into()]),
+        );
+        // Runtime IDs are lowercase; policy entries use PascalCase / argument form.
+        assert!(exec.is_allowed("read"));
+        assert!(exec.is_allowed("write"));
+        assert!(exec.is_allowed("bash"));
+        assert!(!exec.is_allowed("web"));
+        // tool_definitions_erased must also filter correctly.
+        let defs = exec.tool_definitions_erased();
+        assert_eq!(
+            defs.len(),
+            3,
+            "read, write, bash must all appear in catalog"
+        );
     }
 
     // ── filter_skills tests ────────────────────────────────────────────────

--- a/crates/zeph-subagent/src/manager.rs
+++ b/crates/zeph-subagent/src/manager.rs
@@ -22,7 +22,7 @@ use crate::agent_loop::{AgentLoopArgs, run_agent_loop};
 
 use super::def::{MemoryScope, PermissionMode, SubAgentDef, ToolPolicy};
 use super::error::SubAgentError;
-use super::filter::{FilteredToolExecutor, PlanModeExecutor};
+use super::filter::{self, FilteredToolExecutor, PlanModeExecutor};
 use super::grants::{PermissionGrants, SecretRequest};
 use super::hooks::fire_hooks;
 use super::memory::{ensure_memory_dir, escape_memory_content, load_memory_content};
@@ -326,13 +326,15 @@ pub(crate) fn build_system_prompt_with_memory(
 
     // HIGH-04: if all three file tools are blocked (via disallowed_tools OR DenyList),
     // disable memory entirely — the agent cannot use file tools so memory would be useless.
-    let file_tools = ["Read", "Write", "Edit"];
-    let blocked_by_except = file_tools
-        .iter()
-        .all(|t| def.disallowed_tools.iter().any(|d| d == t));
+    let file_tools = ["read", "write", "edit"];
+    let blocked_by_except = file_tools.iter().all(|t| {
+        def.disallowed_tools
+            .iter()
+            .any(|d| filter::normalize_tool_id(d) == *t)
+    });
     // REV-HIGH-02: also check ToolPolicy::DenyList (tools.deny) for complete coverage.
     let blocked_by_deny = matches!(&def.tools, ToolPolicy::DenyList(list)
-        if file_tools.iter().all(|t| list.iter().any(|d| d == t)));
+        if file_tools.iter().all(|t| list.iter().any(|d| filter::normalize_tool_id(d) == *t)));
     if blocked_by_except || blocked_by_deny {
         tracing::warn!(
             agent = %def.name,
@@ -359,7 +361,10 @@ pub(crate) fn build_system_prompt_with_memory(
     if let ToolPolicy::AllowList(ref mut allowed) = def.tools {
         let mut added = Vec::new();
         for tool in &file_tools {
-            if !allowed.iter().any(|a| a == tool) {
+            if !allowed
+                .iter()
+                .any(|a| filter::normalize_tool_id(a) == *tool)
+            {
                 allowed.push((*tool).to_owned());
                 added.push(*tool);
             }
@@ -2981,13 +2986,13 @@ mod tests {
 
         build_system_prompt_with_memory(&mut def, Some(MemoryScope::Project));
 
-        // Read/Write/Edit must be auto-added to the AllowList.
+        // read/write/edit must be auto-added to the AllowList.
         assert!(
             matches!(&def.tools, ToolPolicy::AllowList(list)
-                if list.contains(&"Read".to_owned())
-                    && list.contains(&"Write".to_owned())
-                    && list.contains(&"Edit".to_owned())),
-            "Read/Write/Edit must be auto-enabled in AllowList when memory is set"
+                if list.contains(&"read".to_owned())
+                    && list.contains(&"write".to_owned())
+                    && list.contains(&"edit".to_owned())),
+            "read/write/edit must be auto-enabled in AllowList when memory is set"
         );
 
         std::env::set_current_dir(orig_dir).unwrap();


### PR DESCRIPTION
## Summary

- `crates/zeph-subagent/src/filter.rs`: added `normalize_tool_id` helper (lowercase + strip `(…)` suffix); applied to both sides in `is_allowed` across all policy branches
- `crates/zeph-subagent/src/manager.rs`: lowercased auto-added `file_tools` literals; comparisons use `filter::normalize_tool_id`
- `.zeph/agents/*.md` (9 files): updated `tools.allow` entries from PascalCase (`Read/Write/Edit`) to lowercase (`read/write/edit`)

## Root cause

`FilteredToolExecutor::is_allowed` performed an exact case-sensitive comparison between allow list entries (e.g. `"Read"`, `"Bash(cargo *)"`) and runtime tool IDs (e.g. `"read"`, `"bash"`). Every tool was blocked, leaving the LLM with an empty tool list and causing all bundled agents to produce text-only output.

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace --features full -- -D warnings` — clean
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 9158/9158 pass
- [ ] New unit tests in `filter.rs`: `normalize_tool_id_lowercases`, `normalize_tool_id_strips_args`, `allow_list_pascal_case_permits_lowercase_runtime_id`, and existing `inherit_all_permits_any_tool`, `deny_list_blocks_listed_tool`

Closes #3765