### PR TITLE
chore(deps): enforce workspace dep hygiene

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,10 @@ agent-client-protocol = "0.11.1"
 agent-client-protocol-tokio = "0.11.1"
 anyhow = "1.0.102"
 arboard = "3.6.1"
+arc-swap = "1.9.1"
 async-stream = "0.3.6"
 async-trait = "0.1.89"
+audioadapter-buffers = "3.0"
 axum = "0.8.9"
 base64 = "0.22.1"
 bech32 = "0.9.1"
@@ -45,16 +47,23 @@ expectrl = "0.8"
 futures = "0.3.32"
 futures-core = "0.3.32"
 glob = "0.3.3"
-hf-hub = { version = "0.5", default-features = false }
+globset = "0.4.18"
 hex = "0.4.3"
+hf-hub = { version = "0.5", default-features = false }
+hmac = "0.13"
 http = "1.4"
-k256 = { version = "0.13", default-features = false }
 http-body-util = "0.1.3"
 ignore = "0.4.25"
-include_dir = { version = "0.7.4", features = ["glob"] }
+include_dir = "0.7.4"
 indexmap = "2.14.0"
 indoc = "2.0.7"
 insta = "1.47.2"
+k256 = { version = "0.13", default-features = false }
+landlock = "0.4.4"
+libsqlite3-sys = "0.37.0"
+lru = "0.18.0"
+metrics = "0.24.5"
+metrics-util = "0.20.3"
 nix = { version = "0.31.2", default-features = false }
 notify = "8.2.0"
 notify-debouncer-mini = "0.7"
@@ -65,14 +74,11 @@ opentelemetry = "0.31"
 opentelemetry-otlp = { version = "0.31.1", default-features = false }
 opentelemetry_sdk = { version = "0.31", default-features = false }
 ordered-float = "5.3"
-pdf-extract = "0.10"
-metrics = "0.24.5"
-metrics-util = "0.20.3"
-arc-swap = "1.9.1"
-lru = "0.18.0"
 parking_lot = "0.12.5"
-prometheus-client = "0.24.1"
+pdf-extract = "0.10"
 petgraph = "0.8.3"
+pprof = { version = "0.15.0", default-features = false }
+prometheus-client = "0.24.1"
 proptest = "1.11"
 pulldown-cmark = "0.13.3"
 qdrant-client = { version = "1.18", default-features = false }
@@ -83,27 +89,23 @@ regex = "1.12.3"
 reqwest = { version = "0.13.3", default-features = false }
 ripemd = "0.2"
 rmcp = "1.6.0"
-rustix = { version = "1.1.4", default-features = false }
-audioadapter-buffers = "3.0"
 rubato = "2.0"
+rustix = { version = "1.1.4", default-features = false }
 schemars = "1.2.1"
-shell-words = "1.1.1"
-hmac = "0.13"
-sha2 = "0.11"
 scrape-core = "0.2.6"
+seccompiler = "0.5.0"
 semver = "1.0.28"
 serde = "1.0.228"
 serde_json = "1.0.149"
 serde_norway = "0.9.42"
 serial_test = "3.4"
-globset = "0.4.18"
+sha2 = "0.11"
+shell-words = "1.1.1"
 similar = "3.1"
 sqlx = { version = "0.8.6", default-features = false }
-libsqlite3-sys = { version = "0.37.0", features = ["bundled"] }
 subtle = "2.6"
-sysinfo = { version = "0.38.4", default-features = false, features = ["system"] }
-pprof = { version = "0.15.0", default-features = false }
 symphonia = { version = "0.5.5", default-features = false }
+sysinfo = { version = "0.38.4", default-features = false }
 teloxide = { version = "0.17", default-features = false }
 tempfile = "3.27"
 testcontainers = "0.27.3"
@@ -124,7 +126,7 @@ tracing = "0.1.44"
 tracing-appender = "0.2.5"
 tracing-chrome = "0.7.2"
 tracing-opentelemetry = "0.32.1"
-tracing-subscriber = { version = "0.3.23", default-features = false, features = ["parking_lot"] }
+tracing-subscriber = { version = "0.3.23", default-features = false }
 tracing-test = "0.2.6"
 tree-sitter = "0.26.8"
 tree-sitter-bash = "0.25.1"
@@ -143,36 +145,36 @@ url = "2.5.8"
 uuid = "1.23.1"
 walkdir = "2.5"
 wiremock = "0.6.5"
-zeroize = { version = "1.8.2", default-features = false }
 zeph-a2a = { path = "crates/zeph-a2a", version = "0.21.0" }
+zeph-acp = { path = "crates/zeph-acp", version = "0.21.0" }
 zeph-agent-context = { path = "crates/zeph-agent-context", version = "0.21.0" }
 zeph-agent-feedback = { path = "crates/zeph-agent-feedback", version = "0.21.0" }
 zeph-agent-persistence = { path = "crates/zeph-agent-persistence", version = "0.21.0" }
 zeph-agent-tools = { path = "crates/zeph-agent-tools", version = "0.21.0" }
 zeph-bench = { path = "crates/zeph-bench", version = "0.21.0" }
-zeph-acp = { path = "crates/zeph-acp", version = "0.21.0" }
-zeph-db = { path = "crates/zeph-db", default-features = false, version = "0.21.0" }
 zeph-channels = { path = "crates/zeph-channels", version = "0.21.0" }
+zeph-commands = { path = "crates/zeph-commands", version = "0.21.0" }
 zeph-common = { path = "crates/zeph-common", version = "0.21.0" }
 zeph-config = { path = "crates/zeph-config", version = "0.21.0" }
-zeph-commands = { path = "crates/zeph-commands", version = "0.21.0" }
 zeph-context = { path = "crates/zeph-context", version = "0.21.0" }
 zeph-core = { path = "crates/zeph-core", version = "0.21.0" }
+zeph-db = { path = "crates/zeph-db", default-features = false, version = "0.21.0" }
 zeph-experiments = { path = "crates/zeph-experiments", version = "0.21.0" }
 zeph-gateway = { path = "crates/zeph-gateway", version = "0.21.0" }
 zeph-index = { path = "crates/zeph-index", version = "0.21.0" }
 zeph-llm = { path = "crates/zeph-llm", version = "0.21.0" }
 zeph-mcp = { path = "crates/zeph-mcp", version = "0.21.0" }
 zeph-memory = { path = "crates/zeph-memory", default-features = false, version = "0.21.0" }
-zeph-scheduler = { path = "crates/zeph-scheduler", version = "0.21.0" }
-zeph-skills = { path = "crates/zeph-skills", version = "0.21.0" }
-zeph-tools = { path = "crates/zeph-tools", version = "0.21.0" }
-zeph-tui = { path = "crates/zeph-tui", version = "0.21.0" }
-zeph-vault = { path = "crates/zeph-vault", version = "0.21.0" }
 zeph-orchestration = { path = "crates/zeph-orchestration", version = "0.21.0" }
 zeph-plugins = { path = "crates/zeph-plugins", version = "0.21.0" }
 zeph-sanitizer = { path = "crates/zeph-sanitizer", version = "0.21.0" }
+zeph-scheduler = { path = "crates/zeph-scheduler", version = "0.21.0" }
+zeph-skills = { path = "crates/zeph-skills", version = "0.21.0" }
 zeph-subagent = { path = "crates/zeph-subagent", version = "0.21.0" }
+zeph-tools = { path = "crates/zeph-tools", version = "0.21.0" }
+zeph-tui = { path = "crates/zeph-tui", version = "0.21.0" }
+zeph-vault = { path = "crates/zeph-vault", version = "0.21.0" }
+zeroize = { version = "1.8.2", default-features = false }
 
 [workspace.lints.rust]
 unsafe_code = "deny"
@@ -268,6 +270,7 @@ opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true, features = ["grpc-tonic", "trace"] }
 opentelemetry_sdk = { workspace = true, optional = true, features = ["trace"] }
 parking_lot.workspace = true
+pprof = { workspace = true, optional = true, features = ["prost-codec"] }
 prometheus-client = { workspace = true, optional = true }
 reqwest.workspace = true
 rmcp.workspace = true
@@ -275,8 +278,8 @@ schemars = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 similar.workspace = true
+sysinfo = { workspace = true, optional = true }
 tempfile.workspace = true
-zeph-db.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-util.workspace = true
 toml.workspace = true
@@ -285,34 +288,33 @@ tracing.workspace = true
 tracing-appender.workspace = true
 tracing-chrome = { workspace = true, optional = true }
 tracing-opentelemetry = { workspace = true, optional = true }
-sysinfo = { workspace = true, optional = true }
-pprof = { workspace = true, optional = true, features = ["prost-codec"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 url.workspace = true
 uuid = { workspace = true, optional = true, features = ["v4"] }
-zeroize.workspace = true
 zeph-a2a = { workspace = true, optional = true }
 zeph-acp = { workspace = true, optional = true }
+zeph-bench = { workspace = true, optional = true }
 zeph-channels.workspace = true
 zeph-common.workspace = true
 zeph-config.workspace = true
 zeph-context.workspace = true
 zeph-core.workspace = true
+zeph-db.workspace = true
+zeph-experiments.workspace = true
 zeph-gateway = { workspace = true, optional = true }
 zeph-index.workspace = true
 zeph-llm.workspace = true
-zeph-memory.workspace = true
 zeph-mcp.workspace = true
-zeph-sanitizer.workspace = true
-zeph-scheduler = { workspace = true, optional = true }
-zeph-experiments.workspace = true
+zeph-memory.workspace = true
 zeph-orchestration.workspace = true
 zeph-plugins.workspace = true
+zeph-sanitizer.workspace = true
+zeph-scheduler = { workspace = true, optional = true }
 zeph-skills.workspace = true
 zeph-subagent.workspace = true
 zeph-tools.workspace = true
 zeph-tui = { workspace = true, optional = true }
-zeph-bench = { workspace = true, optional = true }
+zeroize.workspace = true
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/zeph-a2a/Cargo.toml
+++ b/crates/zeph-a2a/Cargo.toml
@@ -21,14 +21,14 @@ axum = { workspace = true, optional = true }
 base64.workspace = true
 blake3 = { workspace = true, optional = true }
 eventsource-stream.workspace = true
-hex.workspace = true
-hmac = { workspace = true, optional = true }
-sha2 = { workspace = true, optional = true }
 futures.workspace = true
 futures-core.workspace = true
+hex.workspace = true
+hmac = { workspace = true, optional = true }
 reqwest = { workspace = true, features = ["json", "stream"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+sha2 = { workspace = true, optional = true }
 subtle = { workspace = true, optional = true }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["net", "sync"] }

--- a/crates/zeph-acp/Cargo.toml
+++ b/crates/zeph-acp/Cargo.toml
@@ -51,9 +51,9 @@ parking_lot.workspace = true
 reqwest = { workspace = true, features = ["rustls", "stream"] }
 rmcp.workspace = true
 schemars.workspace = true
-shell-words.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+shell-words.workspace = true
 subtle = { workspace = true, optional = true }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["io-std", "sync", "macros", "rt", "test-util"] }
@@ -67,8 +67,8 @@ zeph-common.workspace = true
 zeph-config.workspace = true
 zeph-core.workspace = true
 zeph-llm.workspace = true
-zeph-memory.workspace = true
 zeph-mcp.workspace = true
+zeph-memory.workspace = true
 zeph-tools.workspace = true
 # See https://github.com/bug-ops/zeph (workspace dependencies only contain versions)
 

--- a/crates/zeph-channels/Cargo.toml
+++ b/crates/zeph-channels/Cargo.toml
@@ -29,9 +29,9 @@ serde_json.workspace = true
 sha2 = { workspace = true, optional = true }
 subtle = { workspace = true, optional = true }
 teloxide = { workspace = true, features = ["rustls", "ctrlc_handler", "macros"] }
+thiserror.workspace = true
 tokio = { workspace = true, features = ["sync", "rt"] }
 tokio-tungstenite = { workspace = true, optional = true, features = ["connect", "rustls-tls-native-roots"] }
-thiserror.workspace = true
 tracing.workspace = true
 unicode-width.workspace = true
 zeph-common.workspace = true

--- a/crates/zeph-common/Cargo.toml
+++ b/crates/zeph-common/Cargo.toml
@@ -35,14 +35,14 @@ thiserror.workspace = true
 tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }
 tokio-util.workspace = true
 tracing.workspace = true
-uuid = { workspace = true, features = ["v4"] }
-zeroize = { workspace = true, features = ["alloc", "derive", "serde"] }
 tree-sitter = { workspace = true, optional = true }
 tree-sitter-go = { workspace = true, optional = true }
 tree-sitter-javascript = { workspace = true, optional = true }
 tree-sitter-python = { workspace = true, optional = true }
 tree-sitter-rust = { workspace = true, optional = true }
 tree-sitter-typescript = { workspace = true, optional = true }
+uuid = { workspace = true, features = ["v4"] }
+zeroize = { workspace = true, features = ["alloc", "derive", "serde"] }
 
 [dev-dependencies]
 metrics-util = { workspace = true, features = ["debugging"] }

--- a/crates/zeph-core/Cargo.toml
+++ b/crates/zeph-core/Cargo.toml
@@ -33,8 +33,10 @@ sysinfo = ["dep:sysinfo"]
 base64.workspace = true
 blake3.workspace = true
 chrono.workspace = true
+cpu-time.workspace = true
 dirs.workspace = true
 futures.workspace = true
+metrics.workspace = true
 notify.workspace = true
 notify-debouncer-mini.workspace = true
 ordered-float = { workspace = true, features = ["serde"] }
@@ -47,9 +49,9 @@ schemars.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_norway.workspace = true
-tempfile.workspace = true
 sqlx.workspace = true
-zeph-db.workspace = true
+sysinfo = { workspace = true, features = ["system"], optional = true }
+tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["fs", "macros", "process", "rt-multi-thread", "sync", "time"] }
 tokio-stream.workspace = true
@@ -58,12 +60,8 @@ toml.workspace = true
 toml_edit.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["parking_lot", "registry"], optional = true }
-sysinfo = { workspace = true, optional = true }
-cpu-time.workspace = true
-metrics.workspace = true
 tree-sitter.workspace = true
 uuid = { workspace = true, features = ["v4", "serde"] }
-zeroize.workspace = true
 zeph-agent-context.workspace = true
 zeph-agent-feedback.workspace = true
 zeph-agent-persistence.workspace = true
@@ -72,18 +70,20 @@ zeph-commands.workspace = true
 zeph-common.workspace = true
 zeph-config.workspace = true
 zeph-context.workspace = true
-zeph-vault.workspace = true
-zeph-orchestration.workspace = true
-zeph-sanitizer.workspace = true
-zeph-subagent.workspace = true
+zeph-db.workspace = true
 zeph-experiments.workspace = true
 zeph-index.workspace = true
 zeph-llm.workspace = true
-zeph-memory.workspace = true
 zeph-mcp.workspace = true
+zeph-memory.workspace = true
+zeph-orchestration.workspace = true
 zeph-plugins.workspace = true
+zeph-sanitizer.workspace = true
 zeph-skills = { workspace = true, features = ["qdrant"] }
+zeph-subagent.workspace = true
 zeph-tools.workspace = true
+zeph-vault.workspace = true
+zeroize.workspace = true
 # See https://github.com/bug-ops/zeph (workspace dependencies only contain versions)
 
 [[bench]]
@@ -93,11 +93,11 @@ harness = false
 [dev-dependencies]
 age.workspace = true
 criterion.workspace = true
-metrics-util = { workspace = true, features = ["debugging"] }
-rmcp.workspace = true
 indoc.workspace = true
 insta.workspace = true
+metrics-util = { workspace = true, features = ["debugging"] }
 proptest.workspace = true
+rmcp.workspace = true
 schemars.workspace = true
 serial_test.workspace = true
 sqlx.workspace = true

--- a/crates/zeph-db/Cargo.toml
+++ b/crates/zeph-db/Cargo.toml
@@ -23,15 +23,15 @@ postgres = ["sqlx/postgres"]
 test-utils = ["dep:testcontainers", "dep:testcontainers-modules", "postgres"]
 
 [dependencies]
+regex = { workspace = true }
 # "macros" required for sqlx::migrate! in driver implementations.
 sqlx = { workspace = true, features = ["macros", "migrate", "runtime-tokio-rustls"] }
-regex = { workspace = true }
+testcontainers = { workspace = true, optional = true }
+testcontainers-modules = { workspace = true, features = ["postgres"], optional = true }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt"] }
 tracing.workspace = true
 zeph-common.workspace = true
-testcontainers = { workspace = true, optional = true }
-testcontainers-modules = { workspace = true, features = ["postgres"], optional = true }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/zeph-experiments/Cargo.toml
+++ b/crates/zeph-experiments/Cargo.toml
@@ -13,17 +13,17 @@ description = "Experiment engine for adaptive agent behavior testing and hyperpa
 readme = "README.md"
 
 [dependencies]
+futures.workspace = true
+ordered-float.workspace = true
+rand.workspace = true
+schemars.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
-rand.workspace = true
-tracing.workspace = true
-futures.workspace = true
-ordered-float.workspace = true
-schemars.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 toml.workspace = true
+tracing.workspace = true
 zeph-common.workspace = true
 zeph-config.workspace = true
 zeph-llm.workspace = true

--- a/crates/zeph-index/Cargo.toml
+++ b/crates/zeph-index/Cargo.toml
@@ -17,19 +17,13 @@ futures.workspace = true
 ignore.workspace = true
 notify.workspace = true
 notify-debouncer-mini.workspace = true
+schemars.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
-zeph-db = { workspace = true, features = ["sqlite"] }
 tokio = { workspace = true, features = ["fs", "rt"] }
 tracing.workspace = true
 tree-sitter.workspace = true
-uuid = { workspace = true, features = ["v4"] }
-zeph-common = { workspace = true, features = ["treesitter"] }
-zeph-llm.workspace = true
-zeph-memory = { workspace = true, features = ["sqlite"] }
-zeph-tools.workspace = true
-schemars.workspace = true
 # See https://github.com/bug-ops/zeph (workspace dependencies only contain versions)
 
 tree-sitter-bash.workspace = true
@@ -41,6 +35,12 @@ tree-sitter-python.workspace = true
 tree-sitter-rust.workspace = true
 tree-sitter-toml-ng.workspace = true
 tree-sitter-typescript.workspace = true
+uuid = { workspace = true, features = ["v4"] }
+zeph-common = { workspace = true, features = ["treesitter"] }
+zeph-db = { workspace = true, features = ["sqlite"] }
+zeph-llm.workspace = true
+zeph-memory = { workspace = true, features = ["sqlite"] }
+zeph-tools.workspace = true
 
 [dev-dependencies]
 sqlx = { workspace = true, features = ["runtime-tokio-rustls", "sqlite"] }

--- a/crates/zeph-llm/Cargo.toml
+++ b/crates/zeph-llm/Cargo.toml
@@ -25,29 +25,29 @@ testing = []
 [dependencies]
 async-stream.workspace = true
 audioadapter-buffers = { workspace = true, optional = true }
-bech32 = { workspace = true, optional = true }
 base64.workspace = true
+bech32 = { workspace = true, optional = true }
 candle-core = { workspace = true, optional = true }
 candle-nn = { workspace = true, optional = true }
 candle-transformers = { workspace = true, optional = true }
 dirs.workspace = true
 eventsource-stream.workspace = true
-hex = { workspace = true, optional = true }
-k256 = { workspace = true, optional = true, features = ["ecdsa", "std", "sha256"] }
 futures.workspace = true
 futures-core.workspace = true
+hex = { workspace = true, optional = true }
 hf-hub = { workspace = true, optional = true, features = ["tokio", "rustls-tls", "ureq"] }
+k256 = { workspace = true, optional = true, features = ["ecdsa", "std", "sha256"] }
 ollama-rs = { workspace = true, features = ["rustls", "stream"] }
 parking_lot.workspace = true
 rand.workspace = true
 rand_distr.workspace = true
-ripemd = { workspace = true, optional = true }
 reqwest = { workspace = true, features = ["json", "multipart", "rustls", "stream"] }
+ripemd = { workspace = true, optional = true }
 rubato = { workspace = true, optional = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-sha2 = { workspace = true, optional = true }
 serde_json.workspace = true
+sha2 = { workspace = true, optional = true }
 symphonia = { workspace = true, optional = true, features = ["mp3", "ogg", "wav", "flac", "pcm"] }
 thiserror.workspace = true
 tokenizers = { workspace = true, optional = true, features = ["fancy-regex"] }
@@ -56,9 +56,9 @@ tokio-stream.workspace = true
 tracing.workspace = true
 url.workspace = true
 uuid = { workspace = true, features = ["v4", "serde"] }
-zeroize = { workspace = true, optional = true }
 zeph-common.workspace = true
 zeph-config.workspace = true
+zeroize = { workspace = true, optional = true }
 # See https://github.com/bug-ops/zeph (workspace dependencies only contain versions)
 
 [dev-dependencies]
@@ -66,8 +66,8 @@ criterion.workspace = true
 insta.workspace = true
 proptest.workspace = true
 tempfile.workspace = true
-toml.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
+toml.workspace = true
 wiremock.workspace = true
 
 [[bench]]

--- a/crates/zeph-mcp/Cargo.toml
+++ b/crates/zeph-mcp/Cargo.toml
@@ -20,13 +20,13 @@ mock = []
 [dependencies]
 async-trait.workspace = true
 blake3.workspace = true
-futures.workspace = true
 dashmap.workspace = true
+futures.workspace = true
 glob.workspace = true
 http.workspace = true
-qdrant-client = { workspace = true, features = ["serde"] }
 open.workspace = true
 parking_lot.workspace = true
+qdrant-client = { workspace = true, features = ["serde"] }
 regex.workspace = true
 reqwest = { workspace = true, features = ["rustls", "json"] }
 rmcp = { workspace = true, features = ["client", "transport-child-process", "transport-streamable-http-client-reqwest", "auth"] }
@@ -34,7 +34,6 @@ schemars.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
-zeph-db = { workspace = true, features = ["sqlite"] }
 tokio = { workspace = true, features = ["process", "sync", "time", "rt", "net", "io-util"] }
 tokio-util.workspace = true
 tracing.workspace = true
@@ -42,6 +41,7 @@ url.workspace = true
 uuid = { workspace = true, features = ["v5"] }
 zeph-common.workspace = true
 zeph-config.workspace = true
+zeph-db = { workspace = true, features = ["sqlite"] }
 zeph-llm.workspace = true
 zeph-memory = { workspace = true, features = ["sqlite"] }
 zeph-tools.workspace = true

--- a/crates/zeph-memory/Cargo.toml
+++ b/crates/zeph-memory/Cargo.toml
@@ -15,10 +15,10 @@ readme = "README.md"
 [dependencies]
 arc-swap.workspace = true
 blake3.workspace = true
-lru.workspace = true
 chrono = { workspace = true, features = ["std", "clock"] }
 dashmap.workspace = true
 futures.workspace = true
+lru.workspace = true
 parking_lot.workspace = true
 pdf-extract = { workspace = true, optional = true }
 petgraph.workspace = true
@@ -26,19 +26,19 @@ qdrant-client = { workspace = true, features = ["serde"] }
 regex.workspace = true
 schemars.workspace = true
 serde = { workspace = true, features = ["derive"] }
-sha2.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 sqlx = { workspace = true, features = ["macros", "runtime-tokio-rustls", "sqlite", "migrate"] } # TODO(#2385-phase3): audit and remove direct sqlx dep once #[derive(sqlx::Type)] is resolved
 thiserror.workspace = true
-zeph-db.workspace = true
 tiktoken-rs.workspace = true
-toml.workspace = true
 tokio = { workspace = true, features = ["rt"] }
 tokio-util = { workspace = true, features = ["rt"] }
+toml.workspace = true
 tracing.workspace = true
 uuid = { workspace = true, features = ["v4", "v5"] }
 zeph-common.workspace = true
 zeph-config.workspace = true
+zeph-db.workspace = true
 zeph-llm.workspace = true
 # See https://github.com/bug-ops/zeph (workspace dependencies only contain versions)
 

--- a/crates/zeph-orchestration/Cargo.toml
+++ b/crates/zeph-orchestration/Cargo.toml
@@ -20,7 +20,6 @@ rand.workspace = true
 rand_distr.workspace = true
 schemars.workspace = true
 serde = { workspace = true, features = ["derive"] }
-zeph-db = { workspace = true, features = ["sqlite"] }
 serde_json.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["sync", "time"] }
@@ -29,6 +28,7 @@ uuid = { workspace = true, features = ["v4", "serde"] }
 
 zeph-common.workspace = true
 zeph-config.workspace = true
+zeph-db = { workspace = true, features = ["sqlite"] }
 zeph-llm.workspace = true
 zeph-memory = { workspace = true, features = ["sqlite"] }
 zeph-sanitizer.workspace = true

--- a/crates/zeph-sanitizer/Cargo.toml
+++ b/crates/zeph-sanitizer/Cargo.toml
@@ -13,14 +13,14 @@ description = "Content sanitization, exfiltration guard, PII filtering, and quar
 readme = "README.md"
 
 [dependencies]
+regex.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["time"] }
 tracing.workspace = true
-regex.workspace = true
-zeph-config.workspace = true
 zeph-common.workspace = true
+zeph-config.workspace = true
 zeph-llm.workspace = true
 zeph-memory.workspace = true
 zeph-tools.workspace = true
@@ -28,8 +28,8 @@ zeph-tools.workspace = true
 [dev-dependencies]
 proptest.workspace = true
 tempfile.workspace = true
-toml.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
+toml.workspace = true
 zeph-llm = { workspace = true, features = ["testing"] }
 
 [features]

--- a/crates/zeph-scheduler/Cargo.toml
+++ b/crates/zeph-scheduler/Cargo.toml
@@ -24,13 +24,13 @@ chrono = { workspace = true, features = ["std", "clock"] }
 cron.workspace = true
 reqwest = { workspace = true, features = ["json", "rustls"] }
 rustix = { workspace = true, features = ["fs", "process", "std"], optional = true }
+semver.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-semver.workspace = true
 thiserror.workspace = true
-zeph-db = { workspace = true, features = ["sqlite"] }
 tokio = { workspace = true, features = ["macros", "sync", "time"] }
 tracing.workspace = true
+zeph-db = { workspace = true, features = ["sqlite"] }
 # See https://github.com/bug-ops/zeph (workspace dependencies only contain versions)
 
 [dev-dependencies]

--- a/crates/zeph-skills/Cargo.toml
+++ b/crates/zeph-skills/Cargo.toml
@@ -23,8 +23,8 @@ anyhow = { workspace = true, optional = true }
 blake3.workspace = true
 clap = { workspace = true, features = ["derive", "env"], optional = true }
 dirs = { workspace = true, optional = true }
-include_dir.workspace = true
 futures.workspace = true
+include_dir = { workspace = true, features = ["glob"] }
 notify.workspace = true
 notify-debouncer-mini.workspace = true
 qdrant-client = { workspace = true, features = ["serde"], optional = true }

--- a/crates/zeph-subagent/Cargo.toml
+++ b/crates/zeph-subagent/Cargo.toml
@@ -15,14 +15,14 @@ readme = "README.md"
 [dependencies]
 dirs.workspace = true
 regex.workspace = true
-serde_norway.workspace = true
-toml.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+serde_norway.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["fs", "macros", "process", "rt-multi-thread", "sync", "time"] }
 tokio-util.workspace = true
+toml.workspace = true
 tracing.workspace = true
 uuid = { workspace = true, features = ["v4", "serde"] }
 zeph-common.workspace = true

--- a/crates/zeph-tools/Cargo.toml
+++ b/crates/zeph-tools/Cargo.toml
@@ -13,11 +13,11 @@ description = "Tool executor trait with shell, web scrape, and composite executo
 readme = "README.md"
 
 [dependencies]
+arc-swap.workspace = true
 dashmap.workspace = true
 dirs.workspace = true
 glob.workspace = true
 globset.workspace = true
-arc-swap.workspace = true
 parking_lot.workspace = true
 regex.workspace = true
 reqwest = { workspace = true, features = ["rustls"] }
@@ -25,11 +25,12 @@ schemars.workspace = true
 scrape-core.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+sqlx.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-toml.workspace = true
 tokio = { workspace = true, features = ["fs", "io-util", "macros", "process", "rt", "sync", "time"] }
 tokio-util.workspace = true
+toml.workspace = true
 tracing.workspace = true
 tree-sitter.workspace = true
 tree-sitter-bash.workspace = true
@@ -44,7 +45,6 @@ tree-sitter-typescript.workspace = true
 unicode-normalization.workspace = true
 url.workspace = true
 uuid = { workspace = true, features = ["v4", "serde"] }
-sqlx.workspace = true
 zeph-common = { workspace = true, features = ["treesitter"] }
 zeph-config.workspace = true
 zeph-db = { workspace = true, features = ["sqlite"] }
@@ -68,8 +68,8 @@ sandbox = ["dep:landlock", "dep:seccompiler"]
 nix = { workspace = true, features = ["signal", "process"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-landlock    = { version = "0.4.4", optional = true }
-seccompiler = { version = "0.5.0", optional = true }
+landlock    = { workspace = true, optional = true }
+seccompiler = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/crates/zeph-tui/Cargo.toml
+++ b/crates/zeph-tui/Cargo.toml
@@ -13,19 +13,22 @@ description = "Ratatui-based TUI dashboard with real-time metrics for Zeph"
 readme = "README.md"
 
 [dependencies]
+arboard = { workspace = true, optional = true }
+base64.workspace = true
+chrono = { workspace = true, features = ["clock"] }
+crossterm.workspace = true
 ignore.workspace = true
 indexmap.workspace = true
 nucleo-matcher.workspace = true
-chrono = { workspace = true, features = ["clock"] }
-crossterm.workspace = true
 pulldown-cmark.workspace = true
 ratatui.workspace = true
 regex.workspace = true
-thiserror.workspace = true
+serde_json.workspace = true
 similar.workspace = true
+thiserror.workspace = true
 throbber-widgets-tui.workspace = true
 tokio = { workspace = true, features = ["sync", "rt", "time"] }
-unicode-width.workspace = true
+tracing.workspace = true
 tree-sitter.workspace = true
 tree-sitter-bash.workspace = true
 tree-sitter-highlight.workspace = true
@@ -34,14 +37,11 @@ tree-sitter-json.workspace = true
 tree-sitter-python.workspace = true
 tree-sitter-rust.workspace = true
 tree-sitter-toml-ng.workspace = true
-tracing.workspace = true
-serde_json.workspace = true
+unicode-width.workspace = true
 zeph-common.workspace = true
 zeph-config.workspace = true
 zeph-core.workspace = true
 zeph-subagent.workspace = true
-base64.workspace = true
-arboard = { workspace = true, optional = true }
 
 [dev-dependencies]
 expectrl.workspace = true


### PR DESCRIPTION
## Summary

- Sort all `[dependencies]` sections alphabetically across 19 `Cargo.toml` files
- Remove `features` from `[workspace.dependencies]` — only versions (and `default-features`) remain there
- Move features to the crates that actually use them: `include_dir["glob"]` → `zeph-skills`, `sysinfo["system"]` → `zeph-core`
- Promote `landlock` and `seccompiler` from inline `version =` specs in `zeph-tools` to workspace entries; crate now references via `workspace = true`

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 9158 passed