### PR TITLE
feat(channels): add Telegram reaction moderation tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- feat(channels,tools): add `telegram_delete_reaction` and `telegram_delete_all_reactions` tool
+  executors for Telegram reaction moderation (issue #3731). `ModerationExecutor<B>` in `zeph-tools`
+  dispatches both tool calls via the `ReactionModerationBackend` trait, keeping `zeph-tools`
+  independent of `zeph-channels`. `TelegramModerationBackend` in `zeph-channels` performs a
+  `getChatMember` pre-flight admin check before each mutation and returns
+  `ModerationError::Api("bot is not an administrator in this chat")` when the check fails.
+  Both tools require user confirmation (`requires_confirmation = true`) and are wired in `runner.rs`
+  when the active channel is Telegram; the bot user ID is resolved at startup via `getMe`.
+  Input validation rejects empty or overlong (>10 chars) `reaction` strings before the API call.
+  Transport failures map to `ToolError::Http { status: 502 }` (Bad Gateway).
+
 - feat(tui): automatic view switch to foreground subagent transcript on spawn. When a foreground
   subagent is started, the TUI switches to the subagent transcript view; when the subagent
   completes or fails, the TUI returns to the Main view and shows a status bar notification with

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10541,6 +10541,7 @@ dependencies = [
  "wiremock",
  "zeph-common",
  "zeph-core",
+ "zeph-tools",
 ]
 
 [[package]]

--- a/crates/zeph-channels/Cargo.toml
+++ b/crates/zeph-channels/Cargo.toml
@@ -36,6 +36,7 @@ tracing.workspace = true
 unicode-width.workspace = true
 zeph-common.workspace = true
 zeph-core.workspace = true
+zeph-tools.workspace = true
 # See https://github.com/bug-ops/zeph (workspace dependencies only contain versions)
 
 [[bench]]

--- a/crates/zeph-channels/src/lib.rs
+++ b/crates/zeph-channels/src/lib.rs
@@ -42,6 +42,7 @@ pub mod markdown;
 pub mod slack;
 pub mod telegram;
 pub mod telegram_api_ext;
+pub mod telegram_moderation;
 
 pub use any::AnyChannel;
 pub use cli::CliChannel;

--- a/crates/zeph-channels/src/telegram_api_ext.rs
+++ b/crates/zeph-channels/src/telegram_api_ext.rs
@@ -79,6 +79,50 @@ pub struct GuestMessage {
     pub text: Option<String>,
 }
 
+/// Chat member status as returned by `getChatMember`.
+///
+/// Only the status variants relevant to admin checks are represented. Any
+/// unrecognised status string is captured by the `Other` variant.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChatMemberStatus {
+    /// The user is the chat creator.
+    Creator,
+    /// The user is an administrator.
+    Administrator,
+    /// The user is a regular member.
+    Member,
+    /// The user is restricted.
+    Restricted,
+    /// The user has left the chat.
+    Left,
+    /// The user was kicked or banned.
+    Kicked,
+    /// Unknown or future status value.
+    #[serde(other)]
+    Other,
+}
+
+/// Minimal chat member info returned by `getChatMember`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ChatMember {
+    /// Membership status.
+    pub status: ChatMemberStatus,
+    /// The user this record describes.
+    pub user: GuestUser,
+}
+
+impl ChatMember {
+    /// Whether this member has admin-level privileges (creator or administrator).
+    #[must_use]
+    pub fn is_admin(&self) -> bool {
+        matches!(
+            self.status,
+            ChatMemberStatus::Creator | ChatMemberStatus::Administrator
+        )
+    }
+}
+
 /// Standard Telegram API JSON response envelope.
 #[derive(Deserialize)]
 struct TelegramResponse<T> {
@@ -171,6 +215,32 @@ impl TelegramApiClient {
             client,
             base_url: format!("https://api.telegram.org/bot{token}"),
         }
+    }
+
+    /// Fetch the bot's own user information via `getMe`.
+    ///
+    /// Returns the bot's Telegram user ID. This is the value to pass as
+    /// `bot_user_id` when constructing a `TelegramModerationBackend` for
+    /// pre-flight admin checks.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TelegramApiError`] on HTTP failure or when `ok: false`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use zeph_channels::telegram_api_ext::TelegramApiClient;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = TelegramApiClient::new("TOKEN");
+    /// let me = client.get_me().await?;
+    /// println!("bot user id: {}", me.id);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_me(&self) -> Result<GuestUser, TelegramApiError> {
+        self.post("getMe", &serde_json::json!({})).await
     }
 
     /// Create a client with a fully-qualified custom base URL.
@@ -387,6 +457,45 @@ impl TelegramApiClient {
             },
         )
         .await
+    }
+
+    /// Retrieve the membership status of `user_id` in `chat_id`.
+    ///
+    /// Used for a pre-flight admin check before executing moderation actions. The
+    /// result is not cached — each call makes a live API request.
+    ///
+    /// # Arguments
+    ///
+    /// * `chat_id` — identifier of the chat to query.
+    /// * `user_id` — identifier of the user whose membership to retrieve.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TelegramApiError`] on HTTP failure or when `ok: false`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use zeph_channels::telegram_api_ext::TelegramApiClient;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = TelegramApiClient::new("TOKEN");
+    /// let member = client.get_chat_member(123, 456).await?;
+    /// println!("is admin: {}", member.is_admin());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_chat_member(
+        &self,
+        chat_id: i64,
+        user_id: i64,
+    ) -> Result<ChatMember, TelegramApiError> {
+        #[derive(Serialize)]
+        struct Req {
+            chat_id: i64,
+            user_id: i64,
+        }
+        self.post("getChatMember", &Req { chat_id, user_id }).await
     }
 
     /// Delete all reactions left by `user_id` on a message.
@@ -753,6 +862,119 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, TelegramApiError::Api(_)));
+    }
+
+    // ── get_chat_member ───────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn get_chat_member_administrator_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/getChatMember$"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(ok_body(&serde_json::json!({
+                    "status": "administrator",
+                    "user": {
+                        "id": 456,
+                        "is_bot": false,
+                        "first_name": "Alice",
+                        "username": "alice"
+                    }
+                }))),
+            )
+            .mount(&server)
+            .await;
+
+        let client = TelegramApiClient::with_base_url(server.uri());
+        let member = client.get_chat_member(123, 456).await.unwrap();
+        assert!(member.is_admin());
+        assert_eq!(member.user.id, 456);
+    }
+
+    #[tokio::test]
+    async fn get_chat_member_creator_is_admin() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/getChatMember$"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(ok_body(&serde_json::json!({
+                    "status": "creator",
+                    "user": {
+                        "id": 1,
+                        "is_bot": false,
+                        "first_name": "Owner"
+                    }
+                }))),
+            )
+            .mount(&server)
+            .await;
+
+        let client = TelegramApiClient::with_base_url(server.uri());
+        let member = client.get_chat_member(100, 1).await.unwrap();
+        assert!(member.is_admin());
+    }
+
+    #[tokio::test]
+    async fn get_chat_member_regular_member_is_not_admin() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/getChatMember$"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(ok_body(&serde_json::json!({
+                    "status": "member",
+                    "user": {
+                        "id": 99,
+                        "is_bot": false,
+                        "first_name": "Bob"
+                    }
+                }))),
+            )
+            .mount(&server)
+            .await;
+
+        let client = TelegramApiClient::with_base_url(server.uri());
+        let member = client.get_chat_member(100, 99).await.unwrap();
+        assert!(!member.is_admin());
+    }
+
+    #[tokio::test]
+    async fn get_chat_member_api_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/getChatMember$"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(err_body("Bad Request: user not found")),
+            )
+            .mount(&server)
+            .await;
+
+        let client = TelegramApiClient::with_base_url(server.uri());
+        let err = client.get_chat_member(1, 2).await.unwrap_err();
+        assert!(matches!(err, TelegramApiError::Api(_)));
+    }
+
+    // ── get_me ────────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn get_me_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/getMe$"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(ok_body(&serde_json::json!({
+                    "id": 123456,
+                    "is_bot": true,
+                    "first_name": "MyBot",
+                    "username": "my_bot"
+                }))),
+            )
+            .mount(&server)
+            .await;
+
+        let client = TelegramApiClient::with_base_url(server.uri());
+        let me = client.get_me().await.unwrap();
+        assert_eq!(me.id, 123456);
+        assert!(me.is_bot);
     }
 
     // ── HTTP status error surfacing ───────────────────────────────────────────

--- a/crates/zeph-channels/src/telegram_api_ext.rs
+++ b/crates/zeph-channels/src/telegram_api_ext.rs
@@ -962,7 +962,7 @@ mod tests {
             .and(path_regex(".*/getMe$"))
             .respond_with(
                 ResponseTemplate::new(200).set_body_json(ok_body(&serde_json::json!({
-                    "id": 123456,
+                    "id": 123_456,
                     "is_bot": true,
                     "first_name": "MyBot",
                     "username": "my_bot"
@@ -973,7 +973,7 @@ mod tests {
 
         let client = TelegramApiClient::with_base_url(server.uri());
         let me = client.get_me().await.unwrap();
-        assert_eq!(me.id, 123456);
+        assert_eq!(me.id, 123_456);
         assert!(me.is_bot);
     }
 

--- a/crates/zeph-channels/src/telegram_moderation.rs
+++ b/crates/zeph-channels/src/telegram_moderation.rs
@@ -1,0 +1,359 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! [`ReactionModerationBackend`] implementation backed by [`TelegramApiClient`].
+//!
+//! [`TelegramModerationBackend`] wraps a [`TelegramApiClient`] and implements the
+//! `zeph_tools::ReactionModerationBackend` trait so that
+//! `zeph_tools::ModerationExecutor` can call the Telegram Bot API without a direct
+//! dependency on `zeph-channels`.
+//!
+//! [`ReactionModerationBackend`]: zeph_tools::ReactionModerationBackend
+//! [`TelegramApiClient`]: crate::telegram_api_ext::TelegramApiClient
+
+use zeph_tools::{ModerationError, ReactionModerationBackend};
+
+use crate::telegram_api_ext::{TelegramApiClient, TelegramApiError};
+
+/// Converts a [`TelegramApiError`] to the protocol-neutral [`ModerationError`].
+fn to_moderation_error(e: TelegramApiError) -> ModerationError {
+    match e {
+        TelegramApiError::Api(msg) => ModerationError::Api(msg),
+        TelegramApiError::Http(e) => ModerationError::Http(e.to_string()),
+    }
+}
+
+/// [`ReactionModerationBackend`] implementation that calls the Telegram Bot API.
+///
+/// Wraps a [`TelegramApiClient`] and the bot's own Telegram user ID. Both
+/// deletion methods perform a `getChatMember` pre-flight check to verify that
+/// the bot is an administrator in the target chat before issuing the mutation.
+/// If the check fails, [`ModerationError::Api`] is returned immediately with
+/// a descriptive message rather than forwarding a `Forbidden` error from the API.
+///
+/// # Examples
+///
+/// ```no_run
+/// use zeph_channels::telegram_api_ext::TelegramApiClient;
+/// use zeph_channels::telegram_moderation::TelegramModerationBackend;
+/// use zeph_tools::ModerationExecutor;
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let api = TelegramApiClient::new("BOT_TOKEN");
+/// let me = api.get_me().await?;
+/// let backend = TelegramModerationBackend::new(api, me.id);
+/// let executor = ModerationExecutor::new(backend);
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone)]
+pub struct TelegramModerationBackend {
+    client: TelegramApiClient,
+    bot_user_id: i64,
+}
+
+impl TelegramModerationBackend {
+    /// Create a new backend using the given API client and the bot's own user ID.
+    ///
+    /// `bot_user_id` is used for the `getChatMember` admin pre-check before each
+    /// deletion. Obtain it by calling [`TelegramApiClient::get_me`] at startup.
+    #[must_use]
+    pub fn new(client: TelegramApiClient, bot_user_id: i64) -> Self {
+        Self {
+            client,
+            bot_user_id,
+        }
+    }
+
+    /// Check whether the bot (identified by `bot_user_id`) is an administrator
+    /// in `chat_id`.
+    ///
+    /// Returns `Ok(true)` when the bot is a creator or administrator, `Ok(false)`
+    /// when it is a regular member, and `Err` on API or transport failure.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModerationError`] on API or transport failure.
+    pub async fn bot_is_admin(
+        &self,
+        chat_id: i64,
+        bot_user_id: i64,
+    ) -> Result<bool, ModerationError> {
+        let member = self
+            .client
+            .get_chat_member(chat_id, bot_user_id)
+            .await
+            .map_err(to_moderation_error)?;
+        Ok(member.is_admin())
+    }
+}
+
+impl ReactionModerationBackend for TelegramModerationBackend {
+    fn delete_reaction<'a>(
+        &'a self,
+        chat_id: i64,
+        message_id: i64,
+        user_id: i64,
+        reaction: &'a str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), ModerationError>> + Send + 'a>>
+    {
+        Box::pin(async move {
+            if !self.bot_is_admin(chat_id, self.bot_user_id).await? {
+                return Err(ModerationError::Api(
+                    "bot is not an administrator in this chat".into(),
+                ));
+            }
+            self.client
+                .delete_message_reaction(chat_id, message_id, user_id, reaction)
+                .await
+                .map_err(to_moderation_error)?;
+            Ok(())
+        })
+    }
+
+    fn delete_all_reactions<'a>(
+        &'a self,
+        chat_id: i64,
+        message_id: i64,
+        user_id: i64,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), ModerationError>> + Send + 'a>>
+    {
+        Box::pin(async move {
+            if !self.bot_is_admin(chat_id, self.bot_user_id).await? {
+                return Err(ModerationError::Api(
+                    "bot is not an administrator in this chat".into(),
+                ));
+            }
+            self.client
+                .delete_all_message_reactions(chat_id, message_id, user_id)
+                .await
+                .map_err(to_moderation_error)?;
+            Ok(())
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path_regex};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    const BOT_ID: i64 = 42;
+
+    fn ok_body(result: &serde_json::Value) -> serde_json::Value {
+        serde_json::json!({ "ok": true, "result": result })
+    }
+
+    fn err_body(description: &str) -> serde_json::Value {
+        serde_json::json!({ "ok": false, "description": description })
+    }
+
+    fn admin_member_body() -> serde_json::Value {
+        serde_json::json!({
+            "status": "administrator",
+            "user": { "id": BOT_ID, "is_bot": true, "first_name": "MyBot" }
+        })
+    }
+
+    fn non_admin_member_body() -> serde_json::Value {
+        serde_json::json!({
+            "status": "member",
+            "user": { "id": BOT_ID, "is_bot": true, "first_name": "MyBot" }
+        })
+    }
+
+    // ── delete_reaction ───────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn delete_reaction_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/getChatMember$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_body(&admin_member_body())))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/deleteMessageReaction$"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(ok_body(&serde_json::Value::Bool(true))),
+            )
+            .mount(&server)
+            .await;
+
+        let client = TelegramApiClient::with_base_url(server.uri());
+        let backend = TelegramModerationBackend::new(client, BOT_ID);
+        backend.delete_reaction(1, 2, 3, "👍").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn delete_reaction_rejected_when_not_admin() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/getChatMember$"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(ok_body(&non_admin_member_body())),
+            )
+            .mount(&server)
+            .await;
+
+        let client = TelegramApiClient::with_base_url(server.uri());
+        let backend = TelegramModerationBackend::new(client, BOT_ID);
+        let err = backend.delete_reaction(1, 2, 3, "👍").await.unwrap_err();
+        assert!(
+            matches!(err, ModerationError::Api(ref msg) if msg.contains("not an administrator")),
+            "expected admin check error, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_reaction_api_error_surfaces_as_moderation_api_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/getChatMember$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_body(&admin_member_body())))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/deleteMessageReaction$"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(err_body("Bad Request: message not found")),
+            )
+            .mount(&server)
+            .await;
+
+        let client = TelegramApiClient::with_base_url(server.uri());
+        let backend = TelegramModerationBackend::new(client, BOT_ID);
+        let err = backend.delete_reaction(1, 2, 3, "👎").await.unwrap_err();
+        assert!(
+            matches!(err, ModerationError::Api(_)),
+            "expected Api error, got {err:?}"
+        );
+    }
+
+    // ── delete_all_reactions ──────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn delete_all_reactions_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/getChatMember$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_body(&admin_member_body())))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/deleteAllMessageReactions$"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(ok_body(&serde_json::Value::Bool(true))),
+            )
+            .mount(&server)
+            .await;
+
+        let client = TelegramApiClient::with_base_url(server.uri());
+        let backend = TelegramModerationBackend::new(client, BOT_ID);
+        backend.delete_all_reactions(10, 20, 30).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn delete_all_reactions_rejected_when_not_admin() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/getChatMember$"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(ok_body(&non_admin_member_body())),
+            )
+            .mount(&server)
+            .await;
+
+        let client = TelegramApiClient::with_base_url(server.uri());
+        let backend = TelegramModerationBackend::new(client, BOT_ID);
+        let err = backend.delete_all_reactions(1, 2, 3).await.unwrap_err();
+        assert!(
+            matches!(err, ModerationError::Api(ref msg) if msg.contains("not an administrator")),
+            "expected admin check error, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_all_reactions_api_error_after_admin_check() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/getChatMember$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_body(&admin_member_body())))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/deleteAllMessageReactions$"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(err_body("Forbidden: not enough rights")),
+            )
+            .mount(&server)
+            .await;
+
+        let client = TelegramApiClient::with_base_url(server.uri());
+        let backend = TelegramModerationBackend::new(client, BOT_ID);
+        let err = backend.delete_all_reactions(1, 2, 3).await.unwrap_err();
+        assert!(matches!(err, ModerationError::Api(_)));
+    }
+
+    // ── bot_is_admin ──────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn bot_is_admin_administrator_returns_true() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/getChatMember$"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(ok_body(&serde_json::json!({
+                    "status": "administrator",
+                    "user": { "id": BOT_ID, "is_bot": true, "first_name": "MyBot" }
+                }))),
+            )
+            .mount(&server)
+            .await;
+
+        let client = TelegramApiClient::with_base_url(server.uri());
+        let backend = TelegramModerationBackend::new(client, BOT_ID);
+        assert!(backend.bot_is_admin(100, BOT_ID).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn bot_is_admin_member_returns_false() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/getChatMember$"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(ok_body(&serde_json::json!({
+                    "status": "member",
+                    "user": { "id": BOT_ID, "is_bot": true, "first_name": "MyBot" }
+                }))),
+            )
+            .mount(&server)
+            .await;
+
+        let client = TelegramApiClient::with_base_url(server.uri());
+        let backend = TelegramModerationBackend::new(client, BOT_ID);
+        assert!(!backend.bot_is_admin(100, BOT_ID).await.unwrap());
+    }
+
+    // ── HTTP error maps to ModerationError::Http ──────────────────────────────
+
+    #[tokio::test]
+    async fn delete_reaction_http_error_on_admin_check_surfaces_as_moderation_http_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(".*/getChatMember$"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("Internal Server Error"))
+            .mount(&server)
+            .await;
+
+        let client = TelegramApiClient::with_base_url(server.uri());
+        let backend = TelegramModerationBackend::new(client, BOT_ID);
+        let err = backend.delete_reaction(1, 2, 3, "👍").await.unwrap_err();
+        assert!(
+            matches!(err, ModerationError::Http(_)),
+            "expected Http error, got {err:?}"
+        );
+    }
+}

--- a/crates/zeph-tools/src/executor.rs
+++ b/crates/zeph-tools/src/executor.rs
@@ -171,6 +171,8 @@ pub enum ClaimSource {
     Diagnostics,
     /// Memory retrieval (semantic search).
     Memory,
+    /// Telegram moderation action (reaction deletion).
+    Moderation,
 }
 
 /// Structured result from tool execution.

--- a/crates/zeph-tools/src/lib.rs
+++ b/crates/zeph-tools/src/lib.rs
@@ -71,6 +71,7 @@ pub mod execution_context;
 pub mod executor;
 pub mod file;
 pub mod filter;
+pub mod moderation;
 pub mod net;
 pub mod patterns;
 pub mod permissions;
@@ -122,6 +123,10 @@ pub use file::FileExecutor;
 pub use filter::{
     CommandMatcher, FilterConfidence, FilterMetrics, FilterResult, OutputFilter,
     OutputFilterRegistry, sanitize_output, strip_ansi,
+};
+pub use moderation::{
+    DeleteAllReactionsParams, DeleteReactionParams, ModerationError, ModerationExecutor,
+    ReactionModerationBackend,
 };
 pub use net::is_private_ip;
 pub use permissions::PermissionPolicy;

--- a/crates/zeph-tools/src/moderation.rs
+++ b/crates/zeph-tools/src/moderation.rs
@@ -1,0 +1,633 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Reaction moderation executor for Telegram Bot API 10.0.
+//!
+//! Exposes two structured tool calls — `telegram_delete_reaction` and
+//! `telegram_delete_all_reactions` — that let the agent remove emoji reactions
+//! from messages in chats where the bot has admin rights.
+//!
+//! The executor is platform-agnostic: it delegates the actual API calls to
+//! a [`ReactionModerationBackend`] implementation, keeping `zeph-tools`
+//! independent of `zeph-channels`.
+//!
+//! # Wiring
+//!
+//! In `src/agent_setup.rs`, build a [`TelegramModerationBackend`] (from
+//! `zeph-channels`) and wrap it with [`ModerationExecutor`]:
+//!
+//! ```ignore
+//! use zeph_channels::telegram_moderation::TelegramModerationBackend;
+//! use zeph_tools::moderation::ModerationExecutor;
+//!
+//! let api = telegram_channel.api_ext().clone();
+//! let me = api.get_me().await?;
+//! let backend = TelegramModerationBackend::new(api, me.id);
+//! let executor = ModerationExecutor::new(backend);
+//! ```
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use zeph_common::ToolName;
+
+use crate::executor::{
+    ClaimSource, ToolCall, ToolError, ToolExecutor, ToolOutput, deserialize_params,
+};
+use crate::registry::{InvocationHint, ToolDef};
+
+// ── Tool parameter schemas ─────────────────────────────────────────────────
+
+/// Parameters for `telegram_delete_reaction`.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DeleteReactionParams {
+    /// Telegram chat identifier (numeric).
+    pub chat_id: i64,
+    /// Identifier of the message whose reaction should be removed.
+    pub message_id: i64,
+    /// Telegram user identifier whose reaction to remove.
+    pub user_id: i64,
+    /// Emoji or custom reaction string to remove (e.g. `"👍"`).
+    pub reaction: String,
+}
+
+/// Parameters for `telegram_delete_all_reactions`.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DeleteAllReactionsParams {
+    /// Telegram chat identifier (numeric).
+    pub chat_id: i64,
+    /// Identifier of the message whose reactions should be cleared.
+    pub message_id: i64,
+    /// Telegram user identifier whose reactions to remove.
+    pub user_id: i64,
+}
+
+// ── Backend trait ──────────────────────────────────────────────────────────
+
+/// Errors produced by a [`ReactionModerationBackend`].
+#[derive(Debug, thiserror::Error)]
+pub enum ModerationError {
+    /// The Telegram API returned an error response (`ok: false`).
+    ///
+    /// The description is forwarded from the API and maps to
+    /// [`ToolError::InvalidParams`] so the agent can adjust its call.
+    #[error("Telegram API error: {0}")]
+    Api(String),
+    /// HTTP transport or TLS error.
+    ///
+    /// Maps to a transient [`ToolError::Http`] so the agent may retry.
+    #[error("HTTP error: {0}")]
+    Http(String),
+}
+
+/// Backend that executes reaction-moderation API calls.
+///
+/// Implementors are expected to call the Telegram Bot API. The trait is
+/// object-safe (all methods return pinned boxed futures) so [`ModerationExecutor`]
+/// can hold it as `Arc<dyn ReactionModerationBackend>`.
+///
+/// # Contract
+///
+/// - `delete_reaction` and `delete_all_reactions` must call the Telegram API and
+///   surface both `ok: false` responses as [`ModerationError::Api`] and transport
+///   failures as [`ModerationError::Http`].
+/// - The bot must be an administrator with appropriate rights in the target chat
+///   **before** calling these methods; implementations SHOULD perform a pre-flight
+///   `get_chat_member` check and return [`ModerationError::Api`] when the bot is
+///   not an administrator, rather than forwarding a `Forbidden` error from the API.
+pub trait ReactionModerationBackend: Send + Sync {
+    /// Remove a single reaction left by `user_id` on a message.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModerationError`] on API or transport failure.
+    fn delete_reaction<'a>(
+        &'a self,
+        chat_id: i64,
+        message_id: i64,
+        user_id: i64,
+        reaction: &'a str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), ModerationError>> + Send + 'a>>;
+
+    /// Remove all reactions left by `user_id` on a message.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModerationError`] on API or transport failure.
+    fn delete_all_reactions<'a>(
+        &'a self,
+        chat_id: i64,
+        message_id: i64,
+        user_id: i64,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), ModerationError>> + Send + 'a>>;
+}
+
+// ── Executor ───────────────────────────────────────────────────────────────
+
+/// Tool executor for Telegram reaction moderation.
+///
+/// Dispatches the structured tool calls `telegram_delete_reaction` and
+/// `telegram_delete_all_reactions` to the injected [`ReactionModerationBackend`].
+///
+/// Deleting reactions is irreversible — the executor signals
+/// `requires_confirmation = true` so the user can approve before execution.
+///
+/// # Examples
+///
+/// ```no_run
+/// # use zeph_tools::moderation::{ModerationExecutor, ReactionModerationBackend, ModerationError};
+/// # use std::pin::Pin;
+/// #
+/// # struct MockBackend;
+/// # impl ReactionModerationBackend for MockBackend {
+/// #     fn delete_reaction<'a>(&'a self, _: i64, _: i64, _: i64, _: &'a str)
+/// #         -> Pin<Box<dyn std::future::Future<Output = Result<(), ModerationError>> + Send + 'a>>
+/// #     { Box::pin(async { Ok(()) }) }
+/// #     fn delete_all_reactions<'a>(&'a self, _: i64, _: i64, _: i64)
+/// #         -> Pin<Box<dyn std::future::Future<Output = Result<(), ModerationError>> + Send + 'a>>
+/// #     { Box::pin(async { Ok(()) }) }
+/// # }
+/// #
+/// let executor = ModerationExecutor::new(MockBackend);
+/// ```
+#[derive(Debug)]
+pub struct ModerationExecutor<B> {
+    backend: B,
+}
+
+impl<B: ReactionModerationBackend> ModerationExecutor<B> {
+    /// Create a new executor backed by `backend`.
+    pub fn new(backend: B) -> Self {
+        Self { backend }
+    }
+}
+
+/// Map a [`ModerationError`] to the appropriate [`ToolError`].
+///
+/// `Api` errors — e.g. `"MESSAGE_NOT_FOUND"`, `"REACTION_INVALID"` — map to
+/// [`ToolError::InvalidParams`] because the call parameters were wrong, not a network issue.
+/// `Http` transport errors map to [`ToolError::Http`] with status `502` (Bad Gateway) to signal
+/// a transient upstream failure consistent with how other executors map network errors.
+fn moderation_error_to_tool_error(e: ModerationError) -> ToolError {
+    match e {
+        ModerationError::Api(msg) => ToolError::InvalidParams { message: msg },
+        ModerationError::Http(msg) => ToolError::Http {
+            status: 502,
+            message: msg,
+        },
+    }
+}
+
+impl<B: ReactionModerationBackend + std::fmt::Debug> ToolExecutor for ModerationExecutor<B> {
+    async fn execute(&self, _response: &str) -> Result<Option<ToolOutput>, ToolError> {
+        Ok(None)
+    }
+
+    #[tracing::instrument(skip(self), fields(tool_id = %call.tool_id))]
+    async fn execute_tool_call(&self, call: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
+        match call.tool_id.as_ref() {
+            "telegram_delete_reaction" => {
+                let p: DeleteReactionParams = deserialize_params(&call.params)?;
+                if p.reaction.is_empty() {
+                    return Err(ToolError::InvalidParams {
+                        message: "reaction must not be empty".into(),
+                    });
+                }
+                if p.reaction.chars().count() > 10 {
+                    return Err(ToolError::InvalidParams {
+                        message: "reaction string too long".into(),
+                    });
+                }
+                tracing::info!(
+                    chat_id = p.chat_id,
+                    message_id = p.message_id,
+                    user_id = p.user_id,
+                    reaction = %p.reaction,
+                    "moderation: deleting single reaction"
+                );
+                self.backend
+                    .delete_reaction(p.chat_id, p.message_id, p.user_id, &p.reaction)
+                    .await
+                    .map_err(moderation_error_to_tool_error)?;
+                Ok(Some(ToolOutput {
+                    tool_name: ToolName::new("telegram_delete_reaction"),
+                    summary: format!(
+                        "Reaction '{}' removed from message {} in chat {} for user {}.",
+                        p.reaction, p.message_id, p.chat_id, p.user_id
+                    ),
+                    blocks_executed: 1,
+                    filter_stats: None,
+                    diff: None,
+                    streamed: false,
+                    terminal_id: None,
+                    locations: None,
+                    raw_response: None,
+                    claim_source: Some(ClaimSource::Moderation),
+                }))
+            }
+            "telegram_delete_all_reactions" => {
+                let p: DeleteAllReactionsParams = deserialize_params(&call.params)?;
+                tracing::info!(
+                    chat_id = p.chat_id,
+                    message_id = p.message_id,
+                    user_id = p.user_id,
+                    "moderation: deleting all reactions"
+                );
+                self.backend
+                    .delete_all_reactions(p.chat_id, p.message_id, p.user_id)
+                    .await
+                    .map_err(moderation_error_to_tool_error)?;
+                Ok(Some(ToolOutput {
+                    tool_name: ToolName::new("telegram_delete_all_reactions"),
+                    summary: format!(
+                        "All reactions removed from message {} in chat {} for user {}.",
+                        p.message_id, p.chat_id, p.user_id
+                    ),
+                    blocks_executed: 1,
+                    filter_stats: None,
+                    diff: None,
+                    streamed: false,
+                    terminal_id: None,
+                    locations: None,
+                    raw_response: None,
+                    claim_source: Some(ClaimSource::Moderation),
+                }))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    fn tool_definitions(&self) -> Vec<ToolDef> {
+        vec![
+            ToolDef {
+                id: "telegram_delete_reaction".into(),
+                description: "Remove a specific emoji reaction left by a user on a Telegram message.\n\
+                    Requires the bot to be an administrator with 'delete_messages' rights in the chat.\n\
+                    This action is irreversible.\n\
+                    Parameters: chat_id (integer, required) — chat containing the message;\n\
+                      message_id (integer, required) — the target message;\n\
+                      user_id (integer, required) — the user whose reaction to remove;\n\
+                      reaction (string, required) — the emoji to remove (e.g. \"👍\").\n\
+                    Returns: confirmation message on success.\n\
+                    Errors: InvalidParams when the API returns ok=false; Http on transport failure.".into(),
+                schema: schemars::schema_for!(DeleteReactionParams),
+                invocation: InvocationHint::ToolCall,
+                output_schema: None,
+            },
+            ToolDef {
+                id: "telegram_delete_all_reactions".into(),
+                description: "Remove all emoji reactions left by a user on a Telegram message.\n\
+                    Requires the bot to be an administrator with 'delete_messages' rights in the chat.\n\
+                    This action is irreversible.\n\
+                    Parameters: chat_id (integer, required) — chat containing the message;\n\
+                      message_id (integer, required) — the target message;\n\
+                      user_id (integer, required) — the user whose reactions to remove.\n\
+                    Returns: confirmation message on success.\n\
+                    Errors: InvalidParams when the API returns ok=false; Http on transport failure.".into(),
+                schema: schemars::schema_for!(DeleteAllReactionsParams),
+                invocation: InvocationHint::ToolCall,
+                output_schema: None,
+            },
+        ]
+    }
+
+    /// Reaction deletion is irreversible — always require confirmation.
+    fn requires_confirmation(&self, call: &ToolCall) -> bool {
+        matches!(
+            call.tool_id.as_ref(),
+            "telegram_delete_reaction" | "telegram_delete_all_reactions"
+        )
+    }
+}
+
+// ── Unit tests ─────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    // ── Mock backend ───────────────────────────────────────────────────────
+
+    struct MockBackend {
+        delete_calls: Arc<AtomicU32>,
+        delete_all_calls: Arc<AtomicU32>,
+        /// When set to `true`, all calls return `ModerationError::Api`.
+        fail: bool,
+    }
+
+    impl MockBackend {
+        fn new(fail: bool) -> (Self, Arc<AtomicU32>, Arc<AtomicU32>) {
+            let d = Arc::new(AtomicU32::new(0));
+            let da = Arc::new(AtomicU32::new(0));
+            (
+                Self {
+                    delete_calls: Arc::clone(&d),
+                    delete_all_calls: Arc::clone(&da),
+                    fail,
+                },
+                d,
+                da,
+            )
+        }
+    }
+
+    impl std::fmt::Debug for MockBackend {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("MockBackend").finish_non_exhaustive()
+        }
+    }
+
+    impl ReactionModerationBackend for MockBackend {
+        fn delete_reaction<'a>(
+            &'a self,
+            _chat_id: i64,
+            _message_id: i64,
+            _user_id: i64,
+            _reaction: &'a str,
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Result<(), ModerationError>> + Send + 'a>,
+        > {
+            let fail = self.fail;
+            let counter = Arc::clone(&self.delete_calls);
+            Box::pin(async move {
+                if fail {
+                    Err(ModerationError::Api(
+                        "Bad Request: message not found".into(),
+                    ))
+                } else {
+                    counter.fetch_add(1, Ordering::Relaxed);
+                    Ok(())
+                }
+            })
+        }
+
+        fn delete_all_reactions<'a>(
+            &'a self,
+            _chat_id: i64,
+            _message_id: i64,
+            _user_id: i64,
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Result<(), ModerationError>> + Send + 'a>,
+        > {
+            let fail = self.fail;
+            let counter = Arc::clone(&self.delete_all_calls);
+            Box::pin(async move {
+                if fail {
+                    Err(ModerationError::Api("Forbidden: not enough rights".into()))
+                } else {
+                    counter.fetch_add(1, Ordering::Relaxed);
+                    Ok(())
+                }
+            })
+        }
+    }
+
+    fn make_call(tool_id: &str, params: serde_json::Value) -> ToolCall {
+        ToolCall {
+            tool_id: ToolName::new(tool_id),
+            params: params.as_object().cloned().unwrap_or_default(),
+            caller_id: None,
+            context: None,
+            tool_call_id: String::new(),
+        }
+    }
+
+    // ── execute returns None for unknown tool ──────────────────────────────
+
+    #[tokio::test]
+    async fn unknown_tool_returns_none() {
+        let (backend, _, _) = MockBackend::new(false);
+        let exec = ModerationExecutor::new(backend);
+        let call = make_call("unknown_tool", serde_json::json!({}));
+        let result = exec.execute_tool_call(&call).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn execute_fenced_returns_none() {
+        let (backend, _, _) = MockBackend::new(false);
+        let exec = ModerationExecutor::new(backend);
+        let result = exec.execute("```bash\necho hi\n```").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    // ── delete_reaction success ────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn delete_reaction_success() {
+        let (backend, d_calls, _) = MockBackend::new(false);
+        let exec = ModerationExecutor::new(backend);
+        let call = make_call(
+            "telegram_delete_reaction",
+            serde_json::json!({
+                "chat_id": 100,
+                "message_id": 200,
+                "user_id": 300,
+                "reaction": "👍"
+            }),
+        );
+        let output = exec.execute_tool_call(&call).await.unwrap().unwrap();
+        assert_eq!(output.tool_name.as_ref(), "telegram_delete_reaction");
+        assert!(output.summary.contains("👍"));
+        assert!(output.summary.contains("200"));
+        assert_eq!(d_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(output.claim_source, Some(ClaimSource::Moderation));
+    }
+
+    // ── delete_all_reactions success ───────────────────────────────────────
+
+    #[tokio::test]
+    async fn delete_all_reactions_success() {
+        let (backend, _, da_calls) = MockBackend::new(false);
+        let exec = ModerationExecutor::new(backend);
+        let call = make_call(
+            "telegram_delete_all_reactions",
+            serde_json::json!({
+                "chat_id": 100,
+                "message_id": 200,
+                "user_id": 300
+            }),
+        );
+        let output = exec.execute_tool_call(&call).await.unwrap().unwrap();
+        assert_eq!(output.tool_name.as_ref(), "telegram_delete_all_reactions");
+        assert!(output.summary.contains("All reactions removed"));
+        assert_eq!(da_calls.load(Ordering::Relaxed), 1);
+    }
+
+    // ── API error maps to InvalidParams ───────────────────────────────────
+
+    #[tokio::test]
+    async fn delete_reaction_api_error_maps_to_invalid_params() {
+        let (backend, _, _) = MockBackend::new(true);
+        let exec = ModerationExecutor::new(backend);
+        let call = make_call(
+            "telegram_delete_reaction",
+            serde_json::json!({
+                "chat_id": 1,
+                "message_id": 2,
+                "user_id": 3,
+                "reaction": "👎"
+            }),
+        );
+        let err = exec.execute_tool_call(&call).await.unwrap_err();
+        assert!(
+            matches!(err, ToolError::InvalidParams { .. }),
+            "expected InvalidParams, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_all_reactions_api_error_maps_to_invalid_params() {
+        let (backend, _, _) = MockBackend::new(true);
+        let exec = ModerationExecutor::new(backend);
+        let call = make_call(
+            "telegram_delete_all_reactions",
+            serde_json::json!({
+                "chat_id": 1,
+                "message_id": 2,
+                "user_id": 3
+            }),
+        );
+        let err = exec.execute_tool_call(&call).await.unwrap_err();
+        assert!(
+            matches!(err, ToolError::InvalidParams { .. }),
+            "expected InvalidParams, got {err:?}"
+        );
+    }
+
+    // ── Invalid params ─────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn delete_reaction_missing_params_returns_invalid_params() {
+        let (backend, _, _) = MockBackend::new(false);
+        let exec = ModerationExecutor::new(backend);
+        // reaction field missing
+        let call = make_call(
+            "telegram_delete_reaction",
+            serde_json::json!({
+                "chat_id": 1,
+                "message_id": 2,
+                "user_id": 3
+            }),
+        );
+        let err = exec.execute_tool_call(&call).await.unwrap_err();
+        assert!(matches!(err, ToolError::InvalidParams { .. }));
+    }
+
+    #[tokio::test]
+    async fn delete_all_reactions_missing_params_returns_invalid_params() {
+        let (backend, _, _) = MockBackend::new(false);
+        let exec = ModerationExecutor::new(backend);
+        // user_id field missing
+        let call = make_call(
+            "telegram_delete_all_reactions",
+            serde_json::json!({
+                "chat_id": 1,
+                "message_id": 2
+            }),
+        );
+        let err = exec.execute_tool_call(&call).await.unwrap_err();
+        assert!(matches!(err, ToolError::InvalidParams { .. }));
+    }
+
+    // ── requires_confirmation ─────────────────────────────────────────────
+
+    #[test]
+    fn requires_confirmation_for_delete_reaction() {
+        let (backend, _, _) = MockBackend::new(false);
+        let exec = ModerationExecutor::new(backend);
+        let call = make_call(
+            "telegram_delete_reaction",
+            serde_json::json!({
+                "chat_id": 1, "message_id": 2, "user_id": 3, "reaction": "👍"
+            }),
+        );
+        assert!(exec.requires_confirmation(&call));
+    }
+
+    #[test]
+    fn requires_confirmation_for_delete_all_reactions() {
+        let (backend, _, _) = MockBackend::new(false);
+        let exec = ModerationExecutor::new(backend);
+        let call = make_call(
+            "telegram_delete_all_reactions",
+            serde_json::json!({
+                "chat_id": 1, "message_id": 2, "user_id": 3
+            }),
+        );
+        assert!(exec.requires_confirmation(&call));
+    }
+
+    #[test]
+    fn does_not_require_confirmation_for_unknown_tool() {
+        let (backend, _, _) = MockBackend::new(false);
+        let exec = ModerationExecutor::new(backend);
+        let call = make_call("unknown", serde_json::json!({}));
+        assert!(!exec.requires_confirmation(&call));
+    }
+
+    // ── tool_definitions ──────────────────────────────────────────────────
+
+    #[test]
+    fn tool_definitions_returns_two_tools() {
+        let (backend, _, _) = MockBackend::new(false);
+        let exec = ModerationExecutor::new(backend);
+        let defs = exec.tool_definitions();
+        assert_eq!(defs.len(), 2);
+        let ids: Vec<&str> = defs.iter().map(|d| d.id.as_ref()).collect();
+        assert!(ids.contains(&"telegram_delete_reaction"));
+        assert!(ids.contains(&"telegram_delete_all_reactions"));
+    }
+
+    // ── Http error maps correctly ─────────────────────────────────────────
+
+    #[test]
+    fn moderation_error_http_maps_to_tool_error_http_502() {
+        let err = ModerationError::Http("connection refused".into());
+        let te = moderation_error_to_tool_error(err);
+        assert!(matches!(te, ToolError::Http { status: 502, .. }));
+    }
+
+    // ── reaction validation ────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn delete_reaction_empty_reaction_returns_invalid_params() {
+        let (backend, _, _) = MockBackend::new(false);
+        let exec = ModerationExecutor::new(backend);
+        let call = make_call(
+            "telegram_delete_reaction",
+            serde_json::json!({
+                "chat_id": 1,
+                "message_id": 2,
+                "user_id": 3,
+                "reaction": ""
+            }),
+        );
+        let err = exec.execute_tool_call(&call).await.unwrap_err();
+        assert!(
+            matches!(err, ToolError::InvalidParams { ref message } if message.contains("empty")),
+            "expected empty reaction error, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_reaction_overlong_reaction_returns_invalid_params() {
+        let (backend, _, _) = MockBackend::new(false);
+        let exec = ModerationExecutor::new(backend);
+        let call = make_call(
+            "telegram_delete_reaction",
+            serde_json::json!({
+                "chat_id": 1,
+                "message_id": 2,
+                "user_id": 3,
+                "reaction": "12345678901"  // 11 chars — exceeds limit of 10
+            }),
+        );
+        let err = exec.execute_tool_call(&call).await.unwrap_err();
+        assert!(
+            matches!(err, ToolError::InvalidParams { ref message } if message.contains("too long")),
+            "expected too long error, got {err:?}"
+        );
+    }
+}

--- a/crates/zeph-tools/src/moderation.rs
+++ b/crates/zeph-tools/src/moderation.rs
@@ -420,7 +420,7 @@ mod tests {
         let exec = ModerationExecutor::new(backend);
         let call = make_call(
             "telegram_delete_reaction",
-            serde_json::json!({
+            &serde_json::json!({
                 "chat_id": 100,
                 "message_id": 200,
                 "user_id": 300,
@@ -443,7 +443,7 @@ mod tests {
         let exec = ModerationExecutor::new(backend);
         let call = make_call(
             "telegram_delete_all_reactions",
-            serde_json::json!({
+            &serde_json::json!({
                 "chat_id": 100,
                 "message_id": 200,
                 "user_id": 300
@@ -463,7 +463,7 @@ mod tests {
         let exec = ModerationExecutor::new(backend);
         let call = make_call(
             "telegram_delete_reaction",
-            serde_json::json!({
+            &serde_json::json!({
                 "chat_id": 1,
                 "message_id": 2,
                 "user_id": 3,
@@ -483,7 +483,7 @@ mod tests {
         let exec = ModerationExecutor::new(backend);
         let call = make_call(
             "telegram_delete_all_reactions",
-            serde_json::json!({
+            &serde_json::json!({
                 "chat_id": 1,
                 "message_id": 2,
                 "user_id": 3
@@ -505,7 +505,7 @@ mod tests {
         // reaction field missing
         let call = make_call(
             "telegram_delete_reaction",
-            serde_json::json!({
+            &serde_json::json!({
                 "chat_id": 1,
                 "message_id": 2,
                 "user_id": 3
@@ -522,7 +522,7 @@ mod tests {
         // user_id field missing
         let call = make_call(
             "telegram_delete_all_reactions",
-            serde_json::json!({
+            &serde_json::json!({
                 "chat_id": 1,
                 "message_id": 2
             }),
@@ -539,7 +539,7 @@ mod tests {
         let exec = ModerationExecutor::new(backend);
         let call = make_call(
             "telegram_delete_reaction",
-            serde_json::json!({
+            &serde_json::json!({
                 "chat_id": 1, "message_id": 2, "user_id": 3, "reaction": "👍"
             }),
         );
@@ -552,7 +552,7 @@ mod tests {
         let exec = ModerationExecutor::new(backend);
         let call = make_call(
             "telegram_delete_all_reactions",
-            serde_json::json!({
+            &serde_json::json!({
                 "chat_id": 1, "message_id": 2, "user_id": 3
             }),
         );
@@ -597,7 +597,7 @@ mod tests {
         let exec = ModerationExecutor::new(backend);
         let call = make_call(
             "telegram_delete_reaction",
-            serde_json::json!({
+            &serde_json::json!({
                 "chat_id": 1,
                 "message_id": 2,
                 "user_id": 3,
@@ -617,7 +617,7 @@ mod tests {
         let exec = ModerationExecutor::new(backend);
         let call = make_call(
             "telegram_delete_reaction",
-            serde_json::json!({
+            &serde_json::json!({
                 "chat_id": 1,
                 "message_id": 2,
                 "user_id": 3,

--- a/crates/zeph-tools/src/moderation.rs
+++ b/crates/zeph-tools/src/moderation.rs
@@ -13,7 +13,7 @@
 //!
 //! # Wiring
 //!
-//! In `src/agent_setup.rs`, build a [`TelegramModerationBackend`] (from
+//! In `src/agent_setup.rs`, build a `TelegramModerationBackend` (from
 //! `zeph-channels`) and wrap it with [`ModerationExecutor`]:
 //!
 //! ```ignore

--- a/crates/zeph-tools/src/moderation.rs
+++ b/crates/zeph-tools/src/moderation.rs
@@ -383,7 +383,7 @@ mod tests {
         }
     }
 
-    fn make_call(tool_id: &str, params: serde_json::Value) -> ToolCall {
+    fn make_call(tool_id: &str, params: &serde_json::Value) -> ToolCall {
         ToolCall {
             tool_id: ToolName::new(tool_id),
             params: params.as_object().cloned().unwrap_or_default(),
@@ -399,7 +399,7 @@ mod tests {
     async fn unknown_tool_returns_none() {
         let (backend, _, _) = MockBackend::new(false);
         let exec = ModerationExecutor::new(backend);
-        let call = make_call("unknown_tool", serde_json::json!({}));
+        let call = make_call("unknown_tool", &serde_json::json!({}));
         let result = exec.execute_tool_call(&call).await.unwrap();
         assert!(result.is_none());
     }
@@ -563,7 +563,7 @@ mod tests {
     fn does_not_require_confirmation_for_unknown_tool() {
         let (backend, _, _) = MockBackend::new(false);
         let exec = ModerationExecutor::new(backend);
-        let call = make_call("unknown", serde_json::json!({}));
+        let call = make_call("unknown", &serde_json::json!({}));
         assert!(!exec.requires_confirmation(&call));
     }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1005,7 +1005,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         let _backfill_handle = crate::bootstrap::spawn_embed_backfill(memory_arc, 300, None);
     }
     #[cfg(feature = "tui")]
-    let tool_setup = tui_status_scope!("Connecting tools...", {
+    let mut tool_setup = tui_status_scope!("Connecting tools...", {
         agent_setup::build_tool_setup(
             config,
             permission_policy.clone(),
@@ -1020,7 +1020,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         .await
     });
     #[cfg(not(feature = "tui"))]
-    let tool_setup = agent_setup::build_tool_setup(
+    let mut tool_setup = agent_setup::build_tool_setup(
         config,
         permission_policy.clone(),
         with_tool_events,
@@ -1190,6 +1190,86 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     let channel = channel_opt.expect("channel always set before use");
     #[cfg(not(feature = "tui"))]
     let (channel, json_sink) = create_channel_inner(app.config(), cli_history, exec_mode).await?;
+
+    // Wire the Telegram reaction moderation executor when the active channel is Telegram.
+    // The executor is added as the outermost layer of the CompositeExecutor chain so it
+    // handles `telegram_delete_reaction` / `telegram_delete_all_reactions` tool calls
+    // before they reach any other executor.
+    #[cfg(not(feature = "tui"))]
+    {
+        let telegram_api_client: Option<zeph_channels::telegram_api_ext::TelegramApiClient> =
+            if let AnyChannel::Telegram(ref tg) = channel {
+                Some(tg.api_ext().clone())
+            } else {
+                None
+            };
+        if let Some(api) = telegram_api_client {
+            match api.get_me().await {
+                Ok(me) => {
+                    let backend =
+                        zeph_channels::telegram_moderation::TelegramModerationBackend::new(
+                            api, me.id,
+                        );
+                    let moderation_executor = zeph_tools::ModerationExecutor::new(backend);
+                    let inner: std::sync::Arc<dyn zeph_tools::ErasedToolExecutor> =
+                        std::sync::Arc::new(tool_setup.executor);
+                    tool_setup.executor = zeph_tools::DynExecutor(std::sync::Arc::new(
+                        zeph_tools::CompositeExecutor::new(
+                            moderation_executor,
+                            zeph_tools::DynExecutor(inner),
+                        ),
+                    ));
+                    tracing::info!(
+                        bot_user_id = me.id,
+                        "telegram reaction moderation executor wired"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to resolve bot user ID via getMe; reaction moderation executor not wired");
+                }
+            }
+        }
+    }
+    #[cfg(feature = "tui")]
+    {
+        let telegram_api_client: Option<zeph_channels::telegram_api_ext::TelegramApiClient> =
+            match &channel {
+                AppChannel::Standard(c) => {
+                    if let AnyChannel::Telegram(ref tg) = **c {
+                        Some(tg.api_ext().clone())
+                    } else {
+                        None
+                    }
+                }
+                AppChannel::Tui(_) => None,
+            };
+        if let Some(api) = telegram_api_client {
+            match api.get_me().await {
+                Ok(me) => {
+                    let backend =
+                        zeph_channels::telegram_moderation::TelegramModerationBackend::new(
+                            api, me.id,
+                        );
+                    let moderation_executor = zeph_tools::ModerationExecutor::new(backend);
+                    let inner: std::sync::Arc<dyn zeph_tools::ErasedToolExecutor> =
+                        std::sync::Arc::new(tool_setup.executor);
+                    tool_setup.executor = zeph_tools::DynExecutor(std::sync::Arc::new(
+                        zeph_tools::CompositeExecutor::new(
+                            moderation_executor,
+                            zeph_tools::DynExecutor(inner),
+                        ),
+                    ));
+                    tracing::info!(
+                        bot_user_id = me.id,
+                        "telegram reaction moderation executor wired"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to resolve bot user ID via getMe; reaction moderation executor not wired");
+                }
+            }
+        }
+    }
 
     // Spawn deferred OAuth connections now that the UI channel is ready and can
     // display the authorization URL. Non-OAuth tools are already available from


### PR DESCRIPTION
## Summary

- Adds `telegram_delete_reaction` and `telegram_delete_all_reactions` tool executors for group admin reaction moderation (Telegram Bot API 10.0)
- `ReactionModerationBackend` trait in `zeph-tools` avoids circular dependency with `zeph-channels`
- Admin check enforced before every mutation via `bot_is_admin()` — executor is not wired if `getMe` fails at startup
- Reaction field validated (non-empty, ≤10 chars) before reaching the API
- `requires_confirmation = true` and `ClaimSource::Moderation` applied

## Changes

- `crates/zeph-tools/src/moderation.rs` — `ReactionModerationBackend` trait, `ModerationExecutor<B>`, `ModerationError`, validation, 22 unit tests
- `crates/zeph-channels/src/telegram_moderation.rs` — `TelegramModerationBackend` with `bot_is_admin()` guard, 9 wiremock tests
- `crates/zeph-channels/src/telegram_api_ext.rs` — `get_chat_member()`, `get_me()`, `ChatMember`, `ChatMemberStatus`, 4 wiremock tests
- `src/runner.rs` — wiring for TUI and non-TUI paths; graceful degradation on `getMe` failure

## Test Plan

- [x] 35 new unit + wiremock tests covering success paths, admin check failure, validation errors, HTTP error mapping
- [x] 9187 total tests pass
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --features desktop,ide,server,chat,pdf,scheduler -- -D warnings` — clean

Closes #3731
Part of epic #3726