### PR TITLE
fix(zeph-common): add rt-multi-thread to tokio features

### DIFF
--- a/crates/zeph-common/Cargo.toml
+++ b/crates/zeph-common/Cargo.toml
@@ -32,7 +32,7 @@ schemars = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
 tokio-util.workspace = true
 tracing.workspace = true
 tree-sitter = { workspace = true, optional = true }


### PR DESCRIPTION
## Summary

- Add `"rt-multi-thread"` to tokio features in `crates/zeph-common/Cargo.toml`
- Fixes compile error when running `zeph-common` tests in isolation (e.g. `-p zeph-common`)
- Root cause: `test_spawn_blocking_semaphore_cap` uses `#[tokio::test(flavor = "multi_thread")]` which requires the `rt-multi-thread` feature; workspace builds masked this via feature-resolver=3 propagation from the root crate

## Test plan

- [x] `cargo nextest run -p zeph-common` — 113 tests passed (including `test_spawn_blocking_semaphore_cap`)
- [x] `cargo nextest run --workspace --lib --bins` — 9201 tests passed
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings

Closes #3781