### PR TITLE
fix(memory): gate cfg-dependent call sites in zeph-memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(memory): gate `checkpoint_wal` and `entity_community_ids` call sites with
+  `#[cfg(any(feature = "sqlite", feature = "postgres"))]` to fix compilation when
+  neither DB backend feature is enabled; add `HashMap::new()` fallback for
+  `community_ids` in `find_seed_entities` (issue #3784).
+
 ## [0.21.1] - 2026-05-12
 
 ### Added

--- a/crates/zeph-memory/src/graph/retrieval.rs
+++ b/crates/zeph-memory/src/graph/retrieval.rs
@@ -297,7 +297,10 @@ pub(crate) async fn find_seed_entities(
     let structural_scores = store.entity_structural_scores(&entity_ids).await?;
 
     // Step 4: community IDs.
+    #[cfg(any(feature = "sqlite", feature = "postgres"))]
     let community_ids = store.entity_community_ids(&entity_ids).await?;
+    #[cfg(not(any(feature = "sqlite", feature = "postgres")))]
+    let community_ids: HashMap<i64, i64> = HashMap::new();
 
     // Step 5: compute hybrid scores.
     let fts_weight = 1.0 - structural_weight;

--- a/crates/zeph-memory/src/graph/store/mod.rs
+++ b/crates/zeph-memory/src/graph/store/mod.rs
@@ -1207,6 +1207,7 @@ impl GraphStore {
     /// # Errors
     ///
     /// Returns an error if the database query fails.
+    #[cfg(any(feature = "sqlite", feature = "postgres"))]
     pub async fn entity_community_ids(
         &self,
         entity_ids: &[i64],

--- a/crates/zeph-memory/src/semantic/graph.rs
+++ b/crates/zeph-memory/src/semantic/graph.rs
@@ -390,6 +390,7 @@ pub async fn extract_and_store(
     let (entity_name_to_id, entities_upserted) = upsert_entities(&resolver, &result.entities).await;
     let edges_inserted = insert_edges(&resolver, &result.edges, &entity_name_to_id, &config).await;
 
+    #[cfg(any(feature = "sqlite", feature = "postgres"))]
     store.checkpoint_wal().await?;
 
     let new_entity_ids: Vec<i64> = entity_name_to_id.into_values().collect();


### PR DESCRIPTION
## Summary

- Add `#[cfg(any(feature = "sqlite", feature = "postgres"))]` to `entity_community_ids` fn declaration in `graph/store/mod.rs`
- Add `#[cfg(any(feature = "sqlite", feature = "postgres"))]` to `checkpoint_wal` call in `semantic/graph.rs`
- Add `#[cfg(any(feature = "sqlite", feature = "postgres"))]` guard and `HashMap::new()` fallback for `entity_community_ids` call in `graph/retrieval.rs`

Fixes compilation when neither DB backend feature is enabled (e.g., `cargo check -p zeph-sanitizer`). The definitions were already cfg-gated; this PR gates the call sites to match.

Closes #3784.

## Test plan

- [x] `cargo check -p zeph-sanitizer` — was the reproduction case, now passes
- [x] `cargo check -p zeph-memory` — passes
- [x] `cargo nextest run -p zeph-memory --lib` — 1280 passed
- [x] `cargo check --workspace --features full` — passes
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 9201 passed