### PR TITLE
refactor(config,experiments): strengthen provider field types and experiment lifecycle

### DIFF
--- a/crates/zeph-config/src/loader.rs
+++ b/crates/zeph-config/src/loader.rs
@@ -380,9 +380,17 @@ impl Config {
 
     /// Validate every required `*_provider` field references a declared provider.
     ///
-    /// The field table lists all 19 subsystem provider references. Each non-empty value must
+    /// The field table lists all subsystem provider references. Each non-empty value must
     /// match a name in `known`.
     fn validate_named_provider_refs(
+        &self,
+        known: &std::collections::HashSet<String>,
+    ) -> Result<(), ConfigError> {
+        self.validate_core_provider_refs(known)?;
+        self.validate_tool_and_quality_provider_refs(known)
+    }
+
+    fn validate_core_provider_refs(
         &self,
         known: &std::collections::HashSet<String>,
     ) -> Result<(), ConfigError> {
@@ -464,7 +472,44 @@ impl Config {
                 &self.memory.compression_spectrum.promotion_provider,
             ),
         ];
+        Self::check_provider_refs(fields, known)
+    }
 
+    fn validate_tool_and_quality_provider_refs(
+        &self,
+        known: &std::collections::HashSet<String>,
+    ) -> Result<(), ConfigError> {
+        let fields: &[(&str, &crate::providers::ProviderName)] = &[
+            (
+                "security.shadow_sentinel.probe_provider",
+                &self.security.shadow_sentinel.probe_provider,
+            ),
+            (
+                "tools.retry.parameter_reformat_provider",
+                &self.tools.retry.parameter_reformat_provider,
+            ),
+            (
+                "tools.adversarial_policy.policy_provider",
+                &self.tools.adversarial_policy.policy_provider,
+            ),
+            (
+                "tools.speculative.pattern.rerank_provider",
+                &self.tools.speculative.pattern.rerank_provider,
+            ),
+            (
+                "tools.compression.evolution_provider",
+                &self.tools.compression.evolution_provider,
+            ),
+            ("quality.proposer_provider", &self.quality.proposer_provider),
+            ("quality.checker_provider", &self.quality.checker_provider),
+        ];
+        Self::check_provider_refs(fields, known)
+    }
+
+    fn check_provider_refs(
+        fields: &[(&str, &crate::providers::ProviderName)],
+        known: &std::collections::HashSet<String>,
+    ) -> Result<(), ConfigError> {
         for (field, name) in fields {
             if !name.is_empty() && !known.contains(name.as_str()) {
                 return Err(ConfigError::Validation(format!(

--- a/crates/zeph-config/src/quality.rs
+++ b/crates/zeph-config/src/quality.rs
@@ -14,6 +14,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::providers::ProviderName;
+
 /// When to trigger the self-check pipeline.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
@@ -36,11 +38,11 @@ pub struct QualityConfig {
 
     /// Advisory: preferred provider for the Proposer role (MVP: no-op).
     #[serde(default)]
-    pub proposer_provider: String,
+    pub proposer_provider: ProviderName,
 
     /// Advisory: preferred provider for the Checker role (MVP: no-op).
     #[serde(default)]
-    pub checker_provider: String,
+    pub checker_provider: ProviderName,
 
     /// When to trigger the pipeline.
     #[serde(default)]
@@ -105,8 +107,8 @@ impl Default for QualityConfig {
     fn default() -> Self {
         Self {
             self_check: false,
-            proposer_provider: String::new(),
-            checker_provider: String::new(),
+            proposer_provider: ProviderName::default(),
+            checker_provider: ProviderName::default(),
             trigger: TriggerPolicy::default(),
             min_evidence: default_min_evidence(),
             async_run: false,

--- a/crates/zeph-config/src/security.rs
+++ b/crates/zeph-config/src/security.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use zeph_common::SkillTrustLevel;
 
+use crate::providers::ProviderName;
 use crate::tools::{AutonomyLevel, PreExecutionVerifierConfig};
 
 use crate::defaults::default_true;
@@ -354,7 +355,7 @@ pub struct ShadowSentinelConfig {
     /// Empty string means use the main/default provider. A fast, cheap provider
     /// (e.g. `gpt-4o-mini`) is strongly recommended to minimise turn latency.
     #[serde(default)]
-    pub probe_provider: String,
+    pub probe_provider: ProviderName,
     /// Maximum number of trajectory events to include in the probe context. Default: 50.
     #[serde(default = "default_shadow_max_context_events")]
     pub max_context_events: usize,
@@ -384,7 +385,7 @@ impl Default for ShadowSentinelConfig {
     fn default() -> Self {
         Self {
             enabled: false,
-            probe_provider: String::new(),
+            probe_provider: ProviderName::default(),
             max_context_events: default_shadow_max_context_events(),
             probe_timeout_ms: default_shadow_probe_timeout_ms(),
             max_probes_per_turn: default_shadow_max_probes_per_turn(),

--- a/crates/zeph-config/src/tools.rs
+++ b/crates/zeph-config/src/tools.rs
@@ -12,6 +12,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+use crate::providers::ProviderName;
 use zeph_common::SkillTrustLevel;
 
 // ── Permissions ──────────────────────────────────────────────────────────────
@@ -703,7 +704,7 @@ pub struct RetryConfig {
     /// Provider name for LLM-based parameter reformatting on `InvalidParameters`/`TypeMismatch`.
     /// Empty string = disabled.
     #[serde(default)]
-    pub parameter_reformat_provider: String,
+    pub parameter_reformat_provider: ProviderName,
 }
 
 impl Default for RetryConfig {
@@ -713,7 +714,7 @@ impl Default for RetryConfig {
             base_ms: default_retry_base_ms(),
             max_ms: default_retry_max_ms(),
             budget_secs: default_retry_budget_secs(),
-            parameter_reformat_provider: String::new(),
+            parameter_reformat_provider: ProviderName::default(),
         }
     }
 }
@@ -730,7 +731,7 @@ pub struct AdversarialPolicyConfig {
     pub enabled: bool,
     /// Provider name for the policy validation LLM.
     #[serde(default)]
-    pub policy_provider: String,
+    pub policy_provider: ProviderName,
     /// Path to a plain-text policy file.
     pub policy_file: Option<String>,
     /// Whether to allow tool calls when the policy LLM fails. Default: `false` (fail-closed).
@@ -748,7 +749,7 @@ impl Default for AdversarialPolicyConfig {
     fn default() -> Self {
         Self {
             enabled: false,
-            policy_provider: String::new(),
+            policy_provider: ProviderName::default(),
             policy_file: None,
             fail_open: false,
             timeout_ms: default_adversarial_timeout_ms(),
@@ -1009,7 +1010,7 @@ pub struct SpeculativePatternConfig {
     pub half_life_days: f64,
     /// LLM provider name for optional reranking. Empty = disabled.
     #[serde(default)]
-    pub rerank_provider: String,
+    pub rerank_provider: ProviderName,
 }
 
 fn default_min_observations() -> u32 {
@@ -1026,7 +1027,7 @@ impl Default for SpeculativePatternConfig {
             enabled: false,
             min_observations: default_min_observations(),
             half_life_days: default_half_life_days(),
-            rerank_provider: String::new(),
+            rerank_provider: ProviderName::default(),
         }
     }
 }
@@ -1167,7 +1168,7 @@ pub struct ToolCompressionConfig {
     pub min_lines_to_compress: usize,
     /// LLM provider name for self-evolution. Empty string = evolution disabled. Default: `""`.
     #[serde(default)]
-    pub evolution_provider: String,
+    pub evolution_provider: ProviderName,
     /// Minimum interval in seconds between self-evolution runs. Default: `3600`.
     #[serde(default = "default_evolution_min_interval_secs")]
     pub evolution_min_interval_secs: u64,
@@ -1184,7 +1185,7 @@ impl Default for ToolCompressionConfig {
         Self {
             enabled: false,
             min_lines_to_compress: default_compression_min_lines(),
-            evolution_provider: String::new(),
+            evolution_provider: ProviderName::default(),
             evolution_min_interval_secs: default_evolution_min_interval_secs(),
             max_rules: default_compression_max_rules(),
             regex_compile_timeout_ms: default_regex_compile_timeout_ms(),

--- a/crates/zeph-core/src/agent/experiment_cmd.rs
+++ b/crates/zeph-core/src/agent/experiment_cmd.rs
@@ -119,6 +119,10 @@ impl<C: Channel> Agent<C> {
         match &self.services.experiments.cancel {
             Some(token) if !token.is_cancelled() => {
                 token.cancel();
+                if let Some(h) = self.services.experiments.handle.take() {
+                    h.abort();
+                }
+                self.services.experiments.cancel = None;
                 "Experiment session cancelled. Results so far are saved.".to_owned()
             }
             _ => "No experiment is currently running.".to_owned(),
@@ -217,13 +221,14 @@ impl<C: Channel> Agent<C> {
         let cancel = engine.cancel_token();
         self.services.experiments.cancel = Some(cancel);
         let notify_tx = self.services.experiments.notify_tx.clone();
-        // intentionally untracked: long-running multi-minute LLM session with its own
-        // CancellationToken and single-instance invariant enforced by `experiments.cancel`.
+        // Not routed through BackgroundSupervisor: long-running multi-minute LLM session with its
+        // own CancellationToken and single-instance invariant enforced by `experiments.cancel`.
         // BackgroundSupervisor::spawn() returns bool (no JoinHandle), uses Drop-on-overflow
         // semantics, and has only small-fast task classes (Telemetry/Enrichment); routing an
         // experiment session through it would silently drop it when the Telemetry pool is full,
         // producing a misleading "starting" message with no experiment actually running.
-        drop(tokio::spawn(async move {
+        // The handle is stored in ExperimentState so shutdown() can abort it if needed.
+        let handle = tokio::spawn(async move {
             let mut engine = engine;
             let msg = match engine.run().await {
                 Ok(report) => {
@@ -245,7 +250,8 @@ impl<C: Channel> Agent<C> {
                 Err(e) => format!("Experiment session failed: {e}"),
             };
             let _ = notify_tx.send(msg).await;
-        }));
+        });
+        self.services.experiments.handle = Some(handle);
         format!(
             "Experiment session starting (max {max_n} experiments). \
              Use /experiment stop to cancel. Results will be shown when complete."

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -716,11 +716,16 @@ impl<C: Channel> Agent<C> {
         // startup strips the orphaned ToolUse and emits warnings.
         self.flush_orphaned_tool_use_on_shutdown().await;
 
-        // NOTE: forcibly aborts in-flight Enrichment and Telemetry tasks tracked by the
-        // supervisor. Before the sprint-1 refactor, experiment sessions were detached
-        // tokio::spawn calls that survived shutdown; they are now intentionally untracked
-        // (see experiment_cmd.rs) and will continue running until their own CancellationToken
-        // is triggered or the process exits.
+        // Signal the experiment CancellationToken first so the task can clean up gracefully,
+        // then abort the handle to guarantee it does not outlive the agent regardless.
+        if let Some(ref token) = self.services.experiments.cancel {
+            token.cancel();
+        }
+        if let Some(h) = self.services.experiments.handle.take() {
+            h.abort();
+        }
+
+        // Forcibly abort in-flight Enrichment and Telemetry tasks tracked by the supervisor.
         self.runtime.lifecycle.supervisor.abort_all();
 
         // Abort background task handles not tracked by BackgroundSupervisor.
@@ -881,6 +886,7 @@ impl<C: Channel> Agent<C> {
                     }
                     Some(LoopEvent::ExperimentCompleted(msg)) => {
                         self.services.experiments.cancel = None;
+                        self.services.experiments.handle = None;
                         if let Err(e) = self.channel.send(&msg).await {
                             tracing::warn!("failed to send experiment completion: {e}");
                         }

--- a/crates/zeph-core/src/agent/session_config.rs
+++ b/crates/zeph-core/src/agent/session_config.rs
@@ -134,7 +134,7 @@ impl AgentSessionConfig {
             max_retry_duration_secs: config.tools.retry.budget_secs,
             retry_base_ms: config.tools.retry.base_ms,
             retry_max_ms: config.tools.retry.max_ms,
-            parameter_reformat_provider: config.tools.retry.parameter_reformat_provider.clone(),
+            parameter_reformat_provider: config.tools.retry.parameter_reformat_provider.to_string(),
             tool_repeat_threshold: config.agent.tool_repeat_threshold,
             tool_summarization: config.tools.summarize_output,
             tool_call_cutoff: config.memory.tool_call_cutoff,
@@ -208,7 +208,7 @@ mod tests {
         assert_eq!(sc.retry_max_ms, config.tools.retry.max_ms);
         assert_eq!(
             sc.parameter_reformat_provider,
-            config.tools.retry.parameter_reformat_provider
+            config.tools.retry.parameter_reformat_provider.as_str()
         );
         assert_eq!(sc.tool_repeat_threshold, config.agent.tool_repeat_threshold);
         assert_eq!(sc.tool_summarization, config.tools.summarize_output);

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -615,6 +615,9 @@ pub(crate) struct ExperimentState {
     pub(crate) config: crate::config::ExperimentConfig,
     /// Cancellation token for a running experiment session. `Some` means an experiment is active.
     pub(crate) cancel: Option<tokio_util::sync::CancellationToken>,
+    /// `JoinHandle` for the background experiment task. Stored so shutdown can abort it if the
+    /// `CancellationToken` signal is not observed in time (e.g. the task is blocked on I/O).
+    pub(crate) handle: Option<tokio::task::JoinHandle<()>>,
     /// Pre-built config snapshot used as the experiment baseline (agent path).
     pub(crate) baseline: zeph_experiments::ConfigSnapshot,
     /// Dedicated judge provider for evaluation. When `Some`, the evaluator uses this provider
@@ -1170,6 +1173,7 @@ impl ExperimentState {
         Self {
             config: crate::config::ExperimentConfig::default(),
             cancel: None,
+            handle: None,
             baseline: zeph_experiments::ConfigSnapshot::default(),
             eval_provider: None,
             notify_rx: Some(notify_rx),

--- a/crates/zeph-core/src/agent/state/tests.rs
+++ b/crates/zeph-core/src/agent/state/tests.rs
@@ -33,6 +33,7 @@ fn make_experiment_state() -> ExperimentState {
     ExperimentState {
         config: crate::config::ExperimentConfig::default(),
         cancel: None,
+        handle: None,
         baseline: zeph_experiments::ConfigSnapshot::default(),
         eval_provider: None,
         notify_rx: Some(notify_rx),

--- a/crates/zeph-core/src/quality/config.rs
+++ b/crates/zeph-core/src/quality/config.rs
@@ -5,6 +5,7 @@
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use zeph_config::providers::ProviderName;
 
 /// When to run the self-check pipeline.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -40,14 +41,14 @@ pub struct QualityConfig {
     /// In MVP this field is parsed but not acted upon — the main provider is used.
     /// Tracked as a follow-up issue.
     #[serde(default)]
-    pub proposer_provider: String,
+    pub proposer_provider: ProviderName,
 
     /// Advisory: preferred provider for the Checker role.
     ///
     /// In MVP this field is parsed but not acted upon — the main provider is used.
     /// Tracked as a follow-up issue.
     #[serde(default)]
-    pub checker_provider: String,
+    pub checker_provider: ProviderName,
 
     /// When to trigger the self-check pipeline.
     #[serde(default)]
@@ -115,8 +116,8 @@ impl Default for QualityConfig {
     fn default() -> Self {
         Self {
             self_check: false,
-            proposer_provider: String::new(),
-            checker_provider: String::new(),
+            proposer_provider: ProviderName::default(),
+            checker_provider: ProviderName::default(),
             trigger: TriggerPolicy::default(),
             min_evidence: default_min_evidence(),
             async_run: false,

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -998,11 +998,8 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
     }
 
     config.tools.retry.max_attempts = state.retry_max_attempts;
-    config
-        .tools
-        .retry
-        .parameter_reformat_provider
-        .clone_from(&state.retry_parameter_reformat_provider);
+    config.tools.retry.parameter_reformat_provider =
+        zeph_config::ProviderName::new(&state.retry_parameter_reformat_provider);
 
     config.logging.file.clone_from(&state.log_file);
     config.logging.level.clone_from(&state.log_level);

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1750,7 +1750,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             }
 
             adv_policy_info = Some(zeph_core::AdversarialPolicyInfo {
-                provider: adv_cfg.policy_provider.clone(),
+                provider: adv_cfg.policy_provider.to_string(),
                 policy_count: policies.len(),
                 fail_open: adv_cfg.fail_open,
             });
@@ -1878,8 +1878,10 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             let probe_provider = if sentinel_cfg.probe_provider.is_empty() {
                 provider.clone()
             } else {
-                match crate::bootstrap::create_named_provider(&sentinel_cfg.probe_provider, config)
-                {
+                match crate::bootstrap::create_named_provider(
+                    sentinel_cfg.probe_provider.as_str(),
+                    config,
+                ) {
                     Ok(p) => p,
                     Err(e) => {
                         tracing::warn!(


### PR DESCRIPTION
## Summary

- Change 7 `*_provider` config fields from `String` to `ProviderName` across `zeph-config` and `zeph-core/quality`. Invalid provider names are now caught at startup validation instead of silently falling back to the default provider with incorrect cost/latency profile.
- Track the `JoinHandle` returned by `tokio::spawn` in `ExperimentState`. Both `shutdown()` and `experiment_stop()` now cancel the `CancellationToken` then hard-abort the handle, preventing orphaned experiment tasks on stop or restart.

## Changes

**Improvement A — Provider field type safety (`zeph-config`, `zeph-core`):**
- `probe_provider`, `parameter_reformat_provider`, `policy_provider`, `rerank_provider`, `evolution_provider`, `proposer_provider`, `checker_provider` changed from `String` → `ProviderName`
- All 7 fields registered in the startup validation table in `loader.rs`
- Quality no-op fields (`proposer_provider`, `checker_provider`) type-upgraded but not wired into pipeline (P2 for later)
- Call sites in `runner.rs`, `session_config.rs`, `init/mod.rs` updated accordingly

**Improvement B — Experiment task lifecycle (`zeph-core`):**
- `ExperimentState` gains `handle: Option<JoinHandle<()>>`
- `experiment_cmd.rs`: handle stored instead of dropped
- `shutdown()`: cancel token → abort handle (two-phase)
- `experiment_stop()`: same cancel → abort → clear pattern (fix for orphaned handle on stop+restart)
- `ExperimentCompleted` event: clears both `cancel` and `handle`

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo nextest run --workspace --lib --bins` — 9201 passed, 21 skipped
- [ ] Verify a config file with `probe_provider = "fast"` still loads correctly (serde transparent)
- [ ] Verify startup rejects `probe_provider = "nonexistent"` with a clear error