### PR TITLE
test(orchestration,memory): add unit tests for evaluate_abort and ExperienceStore

### DIFF
--- a/crates/zeph-memory/src/graph/experience.rs
+++ b/crates/zeph-memory/src/graph/experience.rs
@@ -180,3 +180,133 @@ impl ExperienceStore {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::store::GraphStore;
+    use crate::graph::types::EntityType;
+    use crate::store::SqliteStore;
+    use zeph_db::sql;
+
+    async fn setup() -> (ExperienceStore, GraphStore, DbPool) {
+        let store = SqliteStore::new(":memory:").await.unwrap();
+        let pool = store.pool().clone();
+        let exp = ExperienceStore::new(pool.clone());
+        let gs = GraphStore::new(pool.clone());
+        (exp, gs, pool)
+    }
+
+    #[tokio::test]
+    async fn record_tool_outcome_inserts_experience_node() {
+        let (exp, _gs, pool) = setup().await;
+        let id = exp
+            .record_tool_outcome("sess1", 1, "shell", "success", Some("exit 0"), None)
+            .await
+            .unwrap();
+        assert!(id > 0);
+
+        let (sid, turn, tool, outcome): (String, i64, String, String) = sqlx::query_as(sql!(
+            "SELECT session_id, turn, tool_name, outcome
+                 FROM experience_nodes WHERE id = ?1"
+        ))
+        .bind(id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(sid, "sess1");
+        assert_eq!(turn, 1);
+        assert_eq!(tool, "shell");
+        assert_eq!(outcome, "success");
+    }
+
+    #[tokio::test]
+    async fn link_sequential_creates_experience_edge() {
+        let (exp, _gs, pool) = setup().await;
+        let id1 = exp
+            .record_tool_outcome("sess1", 1, "shell", "success", None, None)
+            .await
+            .unwrap();
+        let id2 = exp
+            .record_tool_outcome("sess1", 2, "web_scrape", "success", None, None)
+            .await
+            .unwrap();
+
+        exp.link_sequential(id1, id2).await.unwrap();
+
+        let (src, tgt, rel): (i64, i64, String) = sqlx::query_as(sql!(
+            "SELECT source_exp_id, target_exp_id, relation
+             FROM experience_edges WHERE source_exp_id = ?1"
+        ))
+        .bind(id1)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(src, id1);
+        assert_eq!(tgt, id2);
+        assert_eq!(rel, "followed_by");
+    }
+
+    #[tokio::test]
+    async fn evolution_sweep_prunes_self_loops() {
+        let (exp, gs, pool) = setup().await;
+
+        let e1 = gs
+            .upsert_entity("Alice", "alice", EntityType::Person, Some("person"))
+            .await
+            .unwrap();
+        let e2 = gs
+            .upsert_entity("Bob", "bob", EntityType::Person, Some("person"))
+            .await
+            .unwrap();
+
+        // Drop the self-loop trigger so we can insert a test self-loop.
+        sqlx::query(sql!("DROP TRIGGER IF EXISTS graph_edges_no_self_loops"))
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        sqlx::query(sql!(
+            "INSERT INTO graph_edges
+             (source_entity_id, target_entity_id, relation, fact, confidence, edge_type)
+             VALUES (?1, ?1, 'knows', 'self', 0.5, 'semantic')"
+        ))
+        .bind(e1)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Restore the trigger with the original SQL from migration 044.
+        sqlx::query(sql!(
+            "CREATE TRIGGER IF NOT EXISTS graph_edges_no_self_loops
+             BEFORE INSERT ON graph_edges
+             BEGIN
+                 SELECT RAISE(ABORT, 'self-loop edge rejected: source and target entity must differ')
+                 WHERE NEW.source_entity_id = NEW.target_entity_id;
+             END"
+        ))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Insert a normal edge that must survive the sweep.
+        gs.insert_edge(e1, e2, "knows", "Alice knows Bob", 0.9, None)
+            .await
+            .unwrap();
+
+        let stats = exp.evolution_sweep(&gs, 0.3).await.unwrap();
+        assert_eq!(stats.pruned_self_loops, 1);
+        assert_eq!(stats.pruned_low_confidence, 0);
+
+        let count: i64 = sqlx::query_scalar(sql!(
+            "SELECT COUNT(*) FROM graph_edges
+             WHERE source_entity_id = ?1 AND target_entity_id = ?2"
+        ))
+        .bind(e1)
+        .bind(e2)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(count, 1);
+    }
+}

--- a/crates/zeph-orchestration/src/cascade.rs
+++ b/crates/zeph-orchestration/src/cascade.rs
@@ -592,4 +592,110 @@ mod tests {
         let root_warm = det.primary_root(TaskId(2), &g);
         assert_eq!(root_cold, root_warm);
     }
+
+    // --- evaluate_abort ---
+
+    #[test]
+    fn evaluate_abort_none_when_no_outcomes_recorded() {
+        // rate_threshold > 0 but region_health is empty — the `if let Some` arm returns None.
+        let g = graph_from(vec![make_node(0, &[]), make_node(1, &[0])]);
+        let mut det = CascadeDetector::new(cfg(0.5));
+        assert!(matches!(
+            det.evaluate_abort(&g, TaskId(1), 0.5),
+            AbortDecision::None
+        ));
+    }
+
+    #[test]
+    fn evaluate_abort_none_when_threshold_zero() {
+        let g = graph_from(vec![make_node(0, &[])]);
+        let mut det = CascadeDetector::new(cfg(0.5));
+        assert!(matches!(
+            det.evaluate_abort(&g, TaskId(0), 0.0),
+            AbortDecision::None
+        ));
+        // Negative threshold also short-circuits.
+        assert!(matches!(
+            det.evaluate_abort(&g, TaskId(0), -1.0),
+            AbortDecision::None
+        ));
+        // Exact EPSILON boundary — rate_threshold <= EPSILON is true.
+        assert!(matches!(
+            det.evaluate_abort(&g, TaskId(0), f32::EPSILON),
+            AbortDecision::None
+        ));
+    }
+
+    #[test]
+    fn evaluate_abort_fan_out_cascade_when_rate_exceeds_threshold() {
+        // 0 -> {1, 2, 3}: 3 children all fail — rate 1.0 >= 0.5, region_size = 3.
+        let g = graph_from(vec![
+            make_node(0, &[]),
+            make_node(1, &[0]),
+            make_node(2, &[0]),
+            make_node(3, &[0]),
+        ]);
+        let mut det = CascadeDetector::new(cfg(0.5));
+        det.record_outcome(TaskId(1), false, &g);
+        det.record_outcome(TaskId(2), false, &g);
+        det.record_outcome(TaskId(3), false, &g);
+        match det.evaluate_abort(&g, TaskId(1), 0.5) {
+            AbortDecision::FanOutCascade {
+                region_root,
+                failure_rate,
+                region_size,
+            } => {
+                assert_eq!(region_root, TaskId(0));
+                assert!((failure_rate - 1.0_f32).abs() < f32::EPSILON);
+                assert_eq!(region_size, 3);
+            }
+            AbortDecision::None => panic!("expected FanOutCascade, got None"),
+        }
+    }
+
+    #[test]
+    fn evaluate_abort_none_when_region_too_small() {
+        // 0 -> {1, 2}: 2 children, both fail — rate 1.0 >= 0.5 but region_size = 2 < 3.
+        let g = graph_from(vec![
+            make_node(0, &[]),
+            make_node(1, &[0]),
+            make_node(2, &[0]),
+        ]);
+        let mut det = CascadeDetector::new(cfg(0.5));
+        det.record_outcome(TaskId(1), false, &g);
+        det.record_outcome(TaskId(2), false, &g);
+        assert!(matches!(
+            det.evaluate_abort(&g, TaskId(1), 0.5),
+            AbortDecision::None
+        ));
+    }
+
+    #[test]
+    fn evaluate_abort_boundary_rate_equals_threshold() {
+        // 0 -> {1, 2, 3, 4}: 4 children, 2 fail, 2 succeed — rate exactly 0.5 = threshold.
+        let g = graph_from(vec![
+            make_node(0, &[]),
+            make_node(1, &[0]),
+            make_node(2, &[0]),
+            make_node(3, &[0]),
+            make_node(4, &[0]),
+        ]);
+        let mut det = CascadeDetector::new(cfg(0.5));
+        det.record_outcome(TaskId(1), false, &g);
+        det.record_outcome(TaskId(2), false, &g);
+        det.record_outcome(TaskId(3), true, &g);
+        det.record_outcome(TaskId(4), true, &g);
+        match det.evaluate_abort(&g, TaskId(1), 0.5) {
+            AbortDecision::FanOutCascade {
+                region_root,
+                failure_rate,
+                region_size,
+            } => {
+                assert_eq!(region_root, TaskId(0));
+                assert!((failure_rate - 0.5).abs() < f32::EPSILON);
+                assert_eq!(region_size, 4);
+            }
+            AbortDecision::None => panic!("expected FanOutCascade at exact boundary, got None"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Add 5 unit tests for `CascadeDetector::evaluate_abort` in `zeph-orchestration` (issue #3788): zero-threshold early-return, `FanOutCascade` when rate ≥ threshold and region ≥ 3, region-too-small guard, exact boundary case (rate == threshold), and fresh-detector path where `region_health` is empty
- Add 3 async unit tests for `ExperienceStore` in `zeph-memory` (issue #3787): `record_tool_outcome` (DB insertion + column assertions), `link_sequential` (edge creation), and `evolution_sweep` self-loop pruning via trigger bypass on in-memory SQLite

## Test plan

- [x] `cargo nextest run -p zeph-orchestration -E 'test(evaluate_abort)'` → 5 passed
- [x] `cargo nextest run -p zeph-memory -E 'test(experience)'` → 3 passed
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] Workspace regression: 9208 tests pass, 0 regressions (TUI SIGTERM in full parallel run is pre-existing flakiness unrelated to these changes; TUI tests pass in isolation)

Closes #3788
Closes #3787