### PR TITLE
fix(scheduler): add in_flight guard to tick() and surface invalid-cron errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   off by default; enabled via `[memory.optical_forgetting]` and `[memory.em_graph]`
   config sections.
 
+### Fixed
+
+- fix(scheduler): `tick()` now checks the `in_flight` set before dispatching periodic task
+  handlers (issue #3808). Previously only `catch_up_missed()` held the SIGNIFICANT-5 guard,
+  allowing concurrent executions of the same periodic task when a handler ran longer than
+  `tick_secs`. The slot is released after execution completes regardless of handler outcome.
+
+- fix(scheduler): `init()` now emits `tracing::error!` (not `warn!`) and marks the DB row
+  `status = 'error'` when a persisted job has a malformed cron expression (issue #3810). The
+  errored job remains visible in `zeph scheduler list` via the new `JobStore::mark_error()`
+  method. `ScheduledTaskInfo` and `TaskRunSummary` gain a `status` field.
+
 ### Changed
 
 - refactor(arch): propagate `sqlite`/`postgres` feature flags through the full crate DAG

--- a/crates/zeph-scheduler/src/daemon.rs
+++ b/crates/zeph-scheduler/src/daemon.rs
@@ -93,6 +93,8 @@ pub struct TaskRunSummary {
     pub last_run: String,
     /// Scheduled next run time (RFC 3339), or empty if not applicable.
     pub next_run: String,
+    /// Job status: `"pending"`, `"completed"`, `"done"`, or `"error"`.
+    pub status: String,
 }
 
 /// Run the scheduler in the current process (foreground / `--foreground` mode).
@@ -267,6 +269,7 @@ pub async fn daemon_status(
             mode: j.task_mode,
             last_run: String::new(), // store does not expose last_run yet; extend in follow-up
             next_run: j.next_run,
+            status: j.status,
         })
         .collect();
 

--- a/crates/zeph-scheduler/src/scheduler.rs
+++ b/crates/zeph-scheduler/src/scheduler.rs
@@ -172,6 +172,7 @@ impl Scheduler {
     /// # Errors
     ///
     /// Returns an error if DB init, upsert, `next_run` persistence, or job listing fails.
+    #[allow(clippy::too_many_lines)]
     pub async fn init(&mut self) -> Result<(), SchedulerError> {
         self.store.init().await?;
         let now = Utc::now();
@@ -266,11 +267,17 @@ impl Scheduler {
                     self.tasks.push(task);
                 }
                 Err(e) => {
-                    tracing::warn!(
+                    tracing::error!(
                         task = %job.name,
                         cron_expr = %job.cron_expr,
                         "skipping persisted job with invalid cron expression: {e}"
                     );
+                    if let Err(db_err) = self.store.mark_error(&job.name).await {
+                        tracing::warn!(
+                            task = %job.name,
+                            "failed to mark job as error in store: {db_err}"
+                        );
+                    }
                 }
             }
         }
@@ -560,6 +567,7 @@ impl Scheduler {
         });
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn tick(&mut self) {
         let now = Utc::now();
         let mut completed_oneshots: Vec<String> = Vec::new();
@@ -594,6 +602,22 @@ impl Scheduler {
             };
 
             if should_run {
+                let is_periodic = matches!(&task.mode, TaskMode::Periodic { .. });
+
+                // SIGNIFICANT-5: guard against concurrent executions of the same periodic task
+                // (e.g. overlap between catch_up_missed and tick). Drop the guard before any
+                // handler .await so the MutexGuard never crosses an await point.
+                if is_periodic {
+                    let mut guard = self.in_flight.lock().await;
+                    if guard.contains(task.name.as_str()) {
+                        tracing::debug!(task = %task.name, "tick: periodic task in-flight, skipping");
+                        drop(guard);
+                        continue;
+                    }
+                    guard.insert(task.name.clone());
+                    drop(guard);
+                }
+
                 if let Some(handler) = self.handlers.get(task.kind.as_str()) {
                     tracing::info!(task = %task.name, kind = task.kind.as_str(), "executing task");
                     match handler.execute(&task.config).await {
@@ -649,6 +673,11 @@ impl Scheduler {
                     }
                 } else {
                     tracing::debug!(task = %task.name, kind = task.kind.as_str(), "no handler registered");
+                }
+
+                // Release the in_flight slot after execution completes (success or error).
+                if is_periodic {
+                    self.in_flight.lock().await.remove(task.name.as_str());
                 }
             }
         }
@@ -1169,6 +1198,146 @@ mod tests {
             count.load(Ordering::Relaxed),
             1,
             "channel-registered task must fire"
+        );
+    }
+
+    /// `tick()` must skip a periodic task that is already present in `in_flight` (SIGNIFICANT-5).
+    ///
+    /// Simulates the overlap scenario: a slow handler is still running (name in `in_flight`)
+    /// when the next tick fires. The task must not execute a second time.
+    #[tokio::test]
+    async fn tick_skips_in_flight_periodic_task() {
+        let pool = test_pool().await;
+        let store = JobStore::new(pool.clone());
+        let (_tx, rx) = watch::channel(false);
+        let (mut scheduler, _msg_tx) = Scheduler::new(store, rx);
+
+        let task = ScheduledTask::new(
+            "slow_task",
+            "* * * * * *",
+            TaskKind::HealthCheck,
+            serde_json::Value::Null,
+        )
+        .unwrap();
+        scheduler.add_task(task);
+
+        let count = Arc::new(AtomicU32::new(0));
+        scheduler.register_handler(
+            &TaskKind::HealthCheck,
+            Box::new(CountingHandler {
+                count: count.clone(),
+            }),
+        );
+        scheduler.init().await.unwrap();
+
+        // Backdate next_run to make the task due.
+        zeph_db::query(sql!(
+            "UPDATE scheduled_jobs SET next_run = '2000-01-01T00:00:00+00:00' WHERE name = 'slow_task'"
+        ))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Pre-populate in_flight to simulate a concurrent execution already running.
+        scheduler
+            .in_flight
+            .lock()
+            .await
+            .insert("slow_task".to_owned());
+
+        scheduler.tick().await;
+
+        assert_eq!(
+            count.load(Ordering::Relaxed),
+            0,
+            "in-flight periodic task must not fire again on tick"
+        );
+
+        // Clean up so in_flight is empty for any subsequent assertions.
+        scheduler.in_flight.lock().await.remove("slow_task");
+    }
+
+    /// After `tick()` executes a periodic task, the task name is removed from `in_flight`.
+    #[tokio::test]
+    async fn tick_releases_in_flight_after_execution() {
+        let pool = test_pool().await;
+        let store = JobStore::new(pool.clone());
+        let (_tx, rx) = watch::channel(false);
+        let (mut scheduler, _msg_tx) = Scheduler::new(store, rx);
+
+        let task = ScheduledTask::new(
+            "release_task",
+            "* * * * * *",
+            TaskKind::HealthCheck,
+            serde_json::Value::Null,
+        )
+        .unwrap();
+        scheduler.add_task(task);
+        scheduler.register_handler(
+            &TaskKind::HealthCheck,
+            Box::new(CountingHandler {
+                count: Arc::new(AtomicU32::new(0)),
+            }),
+        );
+        scheduler.init().await.unwrap();
+
+        zeph_db::query(sql!(
+            "UPDATE scheduled_jobs SET next_run = '2000-01-01T00:00:00+00:00' WHERE name = 'release_task'"
+        ))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        scheduler.tick().await;
+
+        assert!(
+            !scheduler.in_flight.lock().await.contains("release_task"),
+            "in_flight must be empty after tick() completes for a periodic task"
+        );
+    }
+
+    /// `init()` marks a DB job with an invalid cron expression as `'error'` and emits error-level log.
+    ///
+    /// Covers issue #3810: an external tool writing a malformed cron directly to the `SQLite` table
+    /// must not silently disappear — it must be surfaced via `zeph scheduler list`.
+    #[tokio::test]
+    async fn init_marks_error_for_invalid_cron_job() {
+        let pool = test_pool().await;
+
+        // Write a job with an invalid cron expression directly, bypassing the Rust API.
+        let store_pre = JobStore::new(pool.clone());
+        store_pre.init().await.unwrap();
+        zeph_db::query(sql!(
+            "INSERT INTO scheduled_jobs (name, cron_expr, kind, task_mode, status) \
+             VALUES ('bad-cron', 'not-a-valid-cron', 'health_check', 'periodic', 'pending')"
+        ))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let store = JobStore::new(pool.clone());
+        let (_tx, rx) = watch::channel(false);
+        let (mut scheduler, _msg_tx) = Scheduler::new(store, rx);
+
+        scheduler.init().await.unwrap();
+
+        // The invalid job must not have been hydrated into self.tasks.
+        assert!(
+            scheduler.tasks.iter().all(|t| t.name != "bad-cron"),
+            "invalid cron job must not be added to self.tasks"
+        );
+
+        // The DB row must now carry status = 'error' so it is visible in the job list.
+        let status: String = zeph_db::query_scalar(sql!(
+            "SELECT status FROM scheduled_jobs WHERE name = 'bad-cron'"
+        ))
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            status, "error",
+            "invalid cron job must be marked as error in the DB (issue #3810)"
         );
     }
 }

--- a/crates/zeph-scheduler/src/store.rs
+++ b/crates/zeph-scheduler/src/store.rs
@@ -62,6 +62,8 @@ pub struct ScheduledTaskInfo {
     pub next_run: String,
     /// Stored task prompt for custom tasks; empty for config-driven built-in tasks.
     pub task_data: String,
+    /// Current job status: `"pending"`, `"completed"`, `"done"`, or `"error"`.
+    pub status: String,
 }
 
 /// Persistent storage layer for scheduled jobs.
@@ -259,6 +261,24 @@ impl JobStore {
         Ok(())
     }
 
+    /// Mark a job as permanently errored (e.g. invalid cron expression on hydration).
+    ///
+    /// The job remains visible in [`JobStore::list_jobs_full`] with `status = "error"` so
+    /// operators can identify it via `zeph scheduler list` without reading debug logs.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the SQL statement fails.
+    pub async fn mark_error(&self, name: &str) -> Result<(), SchedulerError> {
+        zeph_db::query(sql!(
+            "UPDATE scheduled_jobs SET status = 'error' WHERE name = ?"
+        ))
+        .bind(name)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
     /// Delete a job by name.
     ///
     /// # Errors
@@ -348,9 +368,10 @@ impl JobStore {
     ///
     /// Returns an error if the SQL query fails.
     pub async fn list_jobs_full(&self) -> Result<Vec<ScheduledTaskInfo>, SchedulerError> {
-        let rows: Vec<(String, String, String, String, Option<String>, String)> =
+        #[allow(clippy::type_complexity)]
+        let rows: Vec<(String, String, String, String, Option<String>, String, String)> =
             zeph_db::query_as(sql!(
-                "SELECT name, kind, task_mode, cron_expr, COALESCE(next_run, run_at), task_data \
+                "SELECT name, kind, task_mode, cron_expr, COALESCE(next_run, run_at), task_data, status \
                  FROM scheduled_jobs WHERE status != 'done' ORDER BY name"
             ))
             .fetch_all(&self.pool)
@@ -358,13 +379,16 @@ impl JobStore {
         Ok(rows
             .into_iter()
             .map(
-                |(name, kind, task_mode, cron_expr, next_run, task_data)| ScheduledTaskInfo {
-                    name,
-                    kind,
-                    task_mode,
-                    cron_expr,
-                    next_run: next_run.unwrap_or_default(),
-                    task_data,
+                |(name, kind, task_mode, cron_expr, next_run, task_data, status)| {
+                    ScheduledTaskInfo {
+                        name,
+                        kind,
+                        task_mode,
+                        cron_expr,
+                        next_run: next_run.unwrap_or_default(),
+                        task_data,
+                        status,
+                    }
                 },
             )
             .collect())


### PR DESCRIPTION
## Summary

- **#3808**: `tick()` now checks `in_flight` before dispatching periodic task handlers, consistent with the existing SIGNIFICANT-5 guard in `catch_up_missed()`. A periodic task already running is skipped; the `in_flight` slot is released after execution regardless of outcome.
- **#3810**: `init()` emits `tracing::error!` (not `warn!`) and marks the DB row `status = 'error'` via `JobStore::mark_error()` when a persisted job has an invalid cron expression. The errored job remains visible in `zeph scheduler list`. `ScheduledTaskInfo` and `TaskRunSummary` gain a `status` field.

## Changes

- `crates/zeph-scheduler/src/scheduler.rs`: `in_flight` guard in `tick()`, `mark_error` call in `init()`, 3 new unit tests
- `crates/zeph-scheduler/src/store.rs`: `JobStore::mark_error()`, `status` field in `ScheduledTaskInfo`, updated `list_jobs_full` query
- `crates/zeph-scheduler/src/daemon.rs`: `status` field in `TaskRunSummary`

## Test plan

- [ ] `tick_skips_in_flight_periodic_task` — verifies in_flight guard prevents double execution
- [ ] `tick_releases_in_flight_after_execution` — verifies slot is released after tick completes
- [ ] `init_marks_error_for_invalid_cron_job` — verifies DB row is marked 'error' for malformed cron
- [ ] All 68 `zeph-scheduler` unit tests pass
- [ ] Full workspace: 9261 tests pass, 0 failures

Closes #3808
Closes #3810