### PR TITLE
feat(memory): ExperienceId/EntityId newtypes + episodic consolidation daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `enabled`, `classifier_provider`, `validator_provider`, `token_budget`, `validation_enabled`,
   `validation_threshold`, `max_escalations`.
 
+- feat(memory): introduce `EntityId(i64)` and `ExperienceId(i64)` newtype wrappers (issue #3795).
+  `GraphStore::upsert_entity` now returns `(i64, EntityId)` — the raw `i64` is used at all call
+  sites requiring plain DB IDs; the `EntityId` newtype is stored on `Entity.id` to prevent silent
+  swaps between entity IDs and other integer types across the graph subsystem.
+
+- feat(memory): implement episodic-to-semantic consolidation daemon (issue #3799). New
+  `EpisodicConsolidationDaemon` background loop periodically sweeps unconsolidated
+  `episodic_events` rows, extracts durable facts via LLM, deduplicates with Jaccard token
+  overlap, persists to `consolidated_facts` / `consolidated_fact_sources` tables (migration 087),
+  optionally promotes high-confidence facts to the Qdrant `zeph_key_facts` semantic tier, and
+  marks processed events with `consolidated_at`. Controlled by `[memory.episodic_consolidation]`
+  config section: `enabled`, `consolidation_provider`, `interval_secs`, `batch_size`,
+  `min_age_secs`, `dedup_jaccard_threshold`.
+
 - feat(memory): implement ScrapMem optical forgetting and EM-Graph (issue #3713). New
   `optical_forgetting` module progressively compresses old messages through three fidelity
   levels — `Full` → `Compressed` → `SummaryOnly` — by scheduling background LLM sweeps.

--- a/crates/zeph-config/src/memory.rs
+++ b/crates/zeph-config/src/memory.rs
@@ -973,6 +973,13 @@ pub struct MemoryConfig {
     /// and linked via causal relationships, enabling causal-chain retrieval.
     #[serde(default)]
     pub em_graph: EmGraphConfig,
+    /// Episodic-to-semantic consolidation daemon (issue #3799).
+    ///
+    /// When `episodic_consolidation.enabled = true`, a background loop periodically sweeps
+    /// mature `episodic_events`, extracts durable facts via LLM, deduplicates against existing
+    /// key facts, and promotes them to the semantic tier in `zeph_key_facts`.
+    #[serde(default)]
+    pub episodic_consolidation: EpisodicConsolidationConfig,
 }
 
 // ── MemFlow tiered retrieval config (issue #3712) ──────────────────────────────
@@ -1116,6 +1123,79 @@ impl Default for EmGraphConfig {
             enabled: false,
             extract_provider: ProviderName::default(),
             max_chain_depth: 3,
+        }
+    }
+}
+
+// ── Episodic consolidation daemon config (issue #3799) ────────────────────────
+
+fn default_episodic_consolidation_interval_secs() -> u64 {
+    1800
+}
+
+fn default_episodic_consolidation_batch_size() -> usize {
+    30
+}
+
+fn default_episodic_consolidation_min_age_secs() -> u64 {
+    300
+}
+
+fn default_episodic_consolidation_dedup_jaccard_threshold() -> f32 {
+    0.6
+}
+
+/// Episodic-to-semantic consolidation daemon configuration (issue #3799).
+///
+/// When `enabled = true`, a background loop periodically sweeps mature `episodic_events`,
+/// extracts durable factual statements via LLM, deduplicates them against existing
+/// key facts using Jaccard similarity, and promotes accepted facts to the semantic tier
+/// in both `consolidated_facts` (`SQLite` persistence) and `zeph_key_facts` (Qdrant, if available).
+///
+/// # Example (TOML)
+///
+/// ```toml
+/// [memory.episodic_consolidation]
+/// enabled = false
+/// consolidation_provider = ""
+/// interval_secs = 1800
+/// batch_size = 30
+/// min_age_secs = 300
+/// dedup_jaccard_threshold = 0.6
+/// ```
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct EpisodicConsolidationConfig {
+    /// Enable the episodic consolidation daemon. Default: `false`.
+    pub enabled: bool,
+    /// Provider name from `[[llm.providers]]` for fact extraction LLM calls.
+    /// Falls back to the primary provider when empty.
+    pub consolidation_provider: ProviderName,
+    /// How often the consolidation sweep runs, in seconds. Default: `1800` (30 min).
+    #[serde(default = "default_episodic_consolidation_interval_secs")]
+    pub interval_secs: u64,
+    /// Maximum number of episodic events to process per sweep. Default: `30`.
+    #[serde(default = "default_episodic_consolidation_batch_size")]
+    pub batch_size: usize,
+    /// Minimum age in seconds before an episodic event is eligible. Default: `300` (5 min).
+    /// Prevents consolidating events from the active conversation.
+    #[serde(default = "default_episodic_consolidation_min_age_secs")]
+    pub min_age_secs: u64,
+    /// Jaccard similarity threshold for deduplication against existing key facts.
+    /// Facts with token-set Jaccard >= this value are considered duplicates. Default: `0.6`.
+    #[serde(default = "default_episodic_consolidation_dedup_jaccard_threshold")]
+    pub dedup_jaccard_threshold: f32,
+}
+
+impl Default for EpisodicConsolidationConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            consolidation_provider: ProviderName::default(),
+            interval_secs: default_episodic_consolidation_interval_secs(),
+            batch_size: default_episodic_consolidation_batch_size(),
+            min_age_secs: default_episodic_consolidation_min_age_secs(),
+            dedup_jaccard_threshold: default_episodic_consolidation_dedup_jaccard_threshold(),
         }
     }
 }

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -278,6 +278,7 @@ impl Default for Config {
                 tiered_retrieval: crate::memory::TieredRetrievalConfig::default(),
                 optical_forgetting: crate::memory::OpticalForgettingConfig::default(),
                 em_graph: crate::memory::EmGraphConfig::default(),
+                episodic_consolidation: crate::memory::EpisodicConsolidationConfig::default(),
             },
             telegram: None,
             discord: None,

--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -172,7 +172,7 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
 
             let entity = &matches[0];
             let edges = store
-                .edges_for_entity(entity.id)
+                .edges_for_entity(entity.id.0)
                 .await
                 .map_err(|e| CommandError::new(e.to_string()))?;
             if edges.is_empty() {
@@ -181,9 +181,9 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
 
             let mut entity_names: std::collections::HashMap<i64, String> =
                 std::collections::HashMap::new();
-            entity_names.insert(entity.id, entity.name.clone());
+            entity_names.insert(entity.id.0, entity.name.clone());
             for edge in &edges {
-                let other_id = if edge.source_entity_id == entity.id {
+                let other_id = if edge.source_entity_id == entity.id.0 {
                     edge.target_entity_id
                 } else {
                     edge.source_entity_id
@@ -247,7 +247,7 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
 
             let entity = &matches[0];
             let edges = store
-                .edge_history_for_entity(entity.id, 50)
+                .edge_history_for_entity(entity.id.0, 50)
                 .await
                 .map_err(|e| CommandError::new(e.to_string()))?;
             if edges.is_empty() {
@@ -256,7 +256,7 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
 
             let mut entity_names: std::collections::HashMap<i64, String> =
                 std::collections::HashMap::new();
-            entity_names.insert(entity.id, entity.name.clone());
+            entity_names.insert(entity.id.0, entity.name.clone());
             for edge in &edges {
                 for &id in &[edge.source_entity_id, edge.target_entity_id] {
                     entity_names.entry(id).or_default();

--- a/crates/zeph-core/src/agent/context/tests/prompt_tooling_summary_tests.rs
+++ b/crates/zeph-core/src/agent/context/tests/prompt_tooling_summary_tests.rs
@@ -1449,11 +1449,13 @@ async fn fetch_graph_facts_returns_some_with_entities_and_has_prefix() {
                 Some("systems language"),
             )
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let tokio_id = store
             .upsert_entity("tokio", "tokio", EntityType::Tool, Some("async runtime"))
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         store
             .insert_edge(rust_id, tokio_id, "uses", "Rust uses tokio", 0.9, None)
             .await

--- a/crates/zeph-db/migrations/sqlite/087_episodic_consolidation.sql
+++ b/crates/zeph-db/migrations/sqlite/087_episodic_consolidation.sql
@@ -1,0 +1,31 @@
+-- Migration: 087_episodic_consolidation.sql
+-- Episodic-to-semantic consolidation daemon tracking (issue #3799).
+
+-- Track which episodic events have been processed by the consolidation daemon.
+ALTER TABLE episodic_events ADD COLUMN consolidated_at INTEGER;
+
+-- Consolidated facts promoted from episodic events.
+-- Facts land in Qdrant `zeph_key_facts` collection AND in this SQLite table
+-- for provenance tracking and dedup queries.
+CREATE TABLE IF NOT EXISTS consolidated_facts (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    fact_text        TEXT NOT NULL,
+    source           TEXT NOT NULL DEFAULT 'episodic_consolidation',
+    cognitive_weight REAL NOT NULL DEFAULT 0.0,
+    created_at       INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+-- Link table: which episodic events contributed to which consolidated fact.
+CREATE TABLE IF NOT EXISTS consolidated_fact_sources (
+    id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    fact_id  INTEGER NOT NULL REFERENCES consolidated_facts(id),
+    event_id INTEGER NOT NULL REFERENCES episodic_events(id),
+    UNIQUE(fact_id, event_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_episodic_events_consolidated ON episodic_events(consolidated_at);
+CREATE INDEX IF NOT EXISTS idx_episodic_events_created ON episodic_events(created_at);
+CREATE INDEX IF NOT EXISTS idx_consolidated_facts_source ON consolidated_facts(source);
+CREATE INDEX IF NOT EXISTS idx_consolidated_fact_sources_fact ON consolidated_fact_sources(fact_id);
+CREATE INDEX IF NOT EXISTS idx_consolidated_fact_sources_event ON consolidated_fact_sources(event_id);
+CREATE INDEX IF NOT EXISTS idx_experience_nodes_session_time ON experience_nodes(session_id, created_at);

--- a/crates/zeph-memory/src/episodic_consolidation.rs
+++ b/crates/zeph-memory/src/episodic_consolidation.rs
@@ -619,7 +619,7 @@ mod tests {
         AnyProvider::Mock(p)
     }
 
-    /// Insert a message + episodic_event row; returns (message_id, event_id).
+    /// Insert a message + `episodic_event` row; returns (`message_id`, `event_id`).
     async fn insert_episodic_event(
         pool: &DbPool,
         conv_id: crate::ConversationId,

--- a/crates/zeph-memory/src/episodic_consolidation.rs
+++ b/crates/zeph-memory/src/episodic_consolidation.rs
@@ -1,0 +1,806 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Episodic-to-semantic consolidation daemon (issue #3799).
+//!
+//! A background loop sweeps mature `episodic_events` rows, batches them into a single
+//! LLM call to extract durable factual statements, deduplicates via Jaccard similarity,
+//! and promotes accepted facts to `consolidated_facts` (`SQLite`) and `zeph_key_facts`
+//! (Qdrant, when available).
+//!
+//! # Daemon pattern
+//!
+//! [`start_episodic_consolidation_loop`] follows the same pattern as
+//! [`crate::tiers::start_tier_promotion_loop`]: the loop exits immediately when
+//! `config.enabled = false` and fails open on every error (logs warning, skips sweep).
+//!
+//! # Invariants
+//!
+//! - Episodic events are **never deleted** — `consolidated_at` is set to mark processed rows.
+//! - LLM timeout or Qdrant unavailability skips the sweep; it does NOT crash the agent.
+//! - Re-running a sweep is idempotent: `WHERE consolidated_at IS NULL` prevents re-processing.
+//! - Each fact promotion is a single `SQLite` transaction for consistency.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio_util::sync::CancellationToken;
+use zeph_db::{DbPool, sql};
+use zeph_llm::any::AnyProvider;
+use zeph_llm::provider::{LlmProvider as _, Message, MessageMetadata, Role};
+
+use crate::embedding_store::EmbeddingStore;
+use crate::error::MemoryError;
+use crate::semantic::KEY_FACTS_COLLECTION;
+use crate::store::SqliteStore;
+
+/// Row fetched from `episodic_events`: `(id, session_id, event_type, summary, message_content, created_at)`.
+type CandidateRow = (i64, String, String, String, String, i64);
+
+/// Configuration for the episodic consolidation daemon.
+///
+/// Passed from `zeph-config::EpisodicConsolidationConfig` to avoid a direct
+/// dependency from `zeph-memory` on `zeph-config`.
+#[derive(Debug, Clone)]
+pub struct EpisodicConsolidationConfig {
+    /// Enable the episodic consolidation daemon.
+    pub enabled: bool,
+    /// Provider name for fact extraction LLM calls (resolved by the caller).
+    pub consolidation_provider: String,
+    /// How often the sweep runs, in seconds. Default: `1800`.
+    pub interval_secs: u64,
+    /// Maximum episodic events processed per sweep. Default: `30`.
+    pub batch_size: usize,
+    /// Minimum age in seconds before an event is eligible. Default: `300`.
+    pub min_age_secs: u64,
+    /// Jaccard token-set similarity threshold for dedup. Default: `0.6`.
+    pub dedup_jaccard_threshold: f32,
+}
+
+/// Result of one episodic consolidation sweep.
+#[derive(Debug, Default)]
+pub struct EpisodicConsolidationResult {
+    /// Number of episodic events processed in this sweep.
+    pub events_processed: usize,
+    /// Number of new facts promoted to semantic tier.
+    pub facts_promoted: usize,
+    /// Number of candidate facts dropped as near-duplicates.
+    pub duplicates_skipped: usize,
+    /// Number of events skipped due to negative cognitive weight.
+    pub negative_weight_skipped: usize,
+}
+
+/// A candidate episodic event fetched for consolidation.
+struct ConsolidationCandidate {
+    /// Row ID from `episodic_events.id` (NOT `ExperienceId` — these are different tables).
+    event_id: i64,
+    #[allow(dead_code)]
+    session_id: String,
+    event_type: String,
+    summary: String,
+    message_content: String,
+    cognitive_weight: f64,
+}
+
+/// An extracted fact from the LLM response.
+struct ExtractedFact {
+    fact: String,
+    source_event_ids: Vec<i64>,
+}
+
+/// Start the background episodic consolidation loop.
+///
+/// The loop ticks every `config.interval_secs` seconds, skipping the first tick to avoid
+/// running at startup. Each tick calls [`run_episodic_consolidation_sweep`]; errors are
+/// logged as warnings and do not stop the loop.
+///
+/// Returns immediately if `config.enabled = false`.
+pub async fn start_episodic_consolidation_loop(
+    store: Arc<SqliteStore>,
+    provider: AnyProvider,
+    config: EpisodicConsolidationConfig,
+    qdrant: Option<Arc<EmbeddingStore>>,
+    cancel: CancellationToken,
+) {
+    if !config.enabled {
+        tracing::debug!("episodic consolidation disabled (episodic_consolidation.enabled = false)");
+        return;
+    }
+
+    let mut ticker = tokio::time::interval(Duration::from_secs(config.interval_secs));
+    // Skip the first immediate tick so we don't run at startup.
+    ticker.tick().await;
+
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => {
+                tracing::debug!("episodic consolidation loop shutting down");
+                return;
+            }
+            _ = ticker.tick() => {}
+        }
+
+        match run_episodic_consolidation_sweep(
+            store.pool().clone(),
+            &provider,
+            &config,
+            qdrant.as_deref(),
+        )
+        .await
+        {
+            Ok(r) => {
+                tracing::info!(
+                    events = r.events_processed,
+                    promoted = r.facts_promoted,
+                    dupes = r.duplicates_skipped,
+                    skipped_neg = r.negative_weight_skipped,
+                    "episodic consolidation sweep complete"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "episodic consolidation sweep failed — skipping");
+            }
+        }
+    }
+}
+
+/// Run a single episodic consolidation sweep.
+///
+/// Steps:
+/// 1. Fetch mature, unprocessed candidates.
+/// 2. Compute cognitive weight from `experience_nodes`.
+/// 3. Call LLM to extract facts (single batch).
+/// 4. Jaccard dedup against last 200 existing facts.
+/// 5. Promote accepted facts; mark source events as consolidated.
+///
+/// # Errors
+///
+/// Returns [`MemoryError`] on database or LLM errors.
+#[allow(clippy::too_many_lines)] // complex sweep pipeline; decomposition deferred to future refactor
+#[tracing::instrument(skip_all, name = "memory.episodic_consolidation.sweep")]
+pub async fn run_episodic_consolidation_sweep(
+    pool: DbPool,
+    provider: &AnyProvider,
+    config: &EpisodicConsolidationConfig,
+    qdrant: Option<&EmbeddingStore>,
+) -> Result<EpisodicConsolidationResult, MemoryError> {
+    let mut result = EpisodicConsolidationResult::default();
+
+    // Step 1: fetch candidates.
+    let raw_candidates = fetch_candidates(&pool, config).await?;
+
+    if raw_candidates.is_empty() {
+        return Ok(result);
+    }
+
+    // Step 2: compute cognitive weight for each candidate.
+    let mut candidates: Vec<ConsolidationCandidate> = Vec::with_capacity(raw_candidates.len());
+    for (event_id, session_id, event_type, summary, message_content, created_at) in raw_candidates {
+        let weight = compute_cognitive_weight(&pool, &session_id, created_at).await?;
+        if weight < -0.5 {
+            result.negative_weight_skipped += 1;
+            // Still mark as consolidated so we don't retry endlessly.
+            mark_consolidated(&pool, event_id).await?;
+            continue;
+        }
+        candidates.push(ConsolidationCandidate {
+            event_id,
+            session_id,
+            event_type,
+            summary,
+            message_content,
+            cognitive_weight: weight,
+        });
+    }
+
+    if candidates.is_empty() {
+        return Ok(result);
+    }
+
+    result.events_processed = candidates.len();
+
+    // Step 3: extract facts via LLM.
+    let extracted = match extract_facts_via_llm(provider, &candidates).await {
+        Ok(facts) => facts,
+        Err(e) => {
+            tracing::warn!(error = %e, "episodic consolidation: LLM extraction failed, skipping sweep");
+            return Err(e);
+        }
+    };
+
+    // Empty array from LLM is valid — mark all events consolidated (nothing to extract).
+    if extracted.is_empty() {
+        tracing::debug!(
+            "episodic consolidation: LLM returned no facts, marking events consolidated"
+        );
+        for c in &candidates {
+            mark_consolidated(&pool, c.event_id).await?;
+        }
+        return Ok(result);
+    }
+
+    // Step 4: Jaccard dedup against last 200 existing facts.
+    let existing_facts = fetch_existing_facts(&pool, 200).await?;
+
+    // Step 5: promote accepted facts.
+    {
+        let mut all_source_event_ids: HashSet<i64> = HashSet::new();
+
+        for fact in extracted {
+            let is_dup = {
+                let _span = tracing::info_span!("memory.episodic_consolidation.dedup").entered();
+                is_jaccard_duplicate(&fact.fact, &existing_facts, config.dedup_jaccard_threshold)
+            };
+
+            if is_dup {
+                result.duplicates_skipped += 1;
+                // Still mark source events — duplicate detection is not an error.
+                // Only mark valid (non-hallucinated) source IDs.
+                for id in fact
+                    .source_event_ids
+                    .iter()
+                    .copied()
+                    .filter(|id| candidates.iter().any(|c| c.event_id == *id))
+                {
+                    all_source_event_ids.insert(id);
+                }
+                continue;
+            }
+
+            // Compute aggregate cognitive weight for the fact's source events.
+            let cog_weight = candidates
+                .iter()
+                .filter(|c| fact.source_event_ids.contains(&c.event_id))
+                .map(|c| c.cognitive_weight)
+                .sum::<f64>();
+            let cog_weight = if cog_weight.is_finite() {
+                cog_weight
+            } else {
+                0.0_f64
+            };
+
+            #[allow(clippy::cast_possible_truncation)]
+            let cog_weight_f32 = cog_weight as f32;
+
+            // S1: filter out LLM-hallucinated source IDs not in the candidate set.
+            let valid_source_ids: Vec<i64> = fact
+                .source_event_ids
+                .iter()
+                .copied()
+                .filter(|id| candidates.iter().any(|c| c.event_id == *id))
+                .collect();
+
+            promote_fact(
+                &pool,
+                &fact.fact,
+                cog_weight_f32,
+                &valid_source_ids,
+                qdrant,
+                provider,
+            )
+            .await?;
+
+            result.facts_promoted += 1;
+            for id in &fact.source_event_ids {
+                all_source_event_ids.insert(*id);
+            }
+        }
+
+        // Mark any candidates not covered by extracted facts as consolidated too.
+        for c in &candidates {
+            all_source_event_ids.insert(c.event_id);
+        }
+        for event_id in all_source_event_ids {
+            mark_consolidated(&pool, event_id).await?;
+        }
+    }
+
+    Ok(result)
+}
+
+/// Fetch unprocessed, mature episodic events with message content.
+///
+/// Excludes `SummaryOnly` messages (too degraded) and prefers `compressed_content`
+/// when available (`ScrapMem` fidelity levels: `Full`, `Compressed`, `SummaryOnly`).
+#[tracing::instrument(skip_all, name = "memory.episodic_consolidation.fetch_candidates")]
+async fn fetch_candidates(
+    pool: &DbPool,
+    config: &EpisodicConsolidationConfig,
+) -> Result<Vec<CandidateRow>, MemoryError> {
+    let min_age = i64::try_from(config.min_age_secs).unwrap_or(i64::MAX);
+    let batch = i64::try_from(config.batch_size).unwrap_or(i64::MAX);
+
+    let rows: Vec<CandidateRow> = zeph_db::query_as(sql!(
+        "SELECT e.id, e.session_id, e.event_type, e.summary,
+                COALESCE(m.compressed_content, m.content) AS message_content,
+                e.created_at
+         FROM episodic_events e
+         JOIN messages m ON m.id = e.message_id
+         WHERE e.consolidated_at IS NULL
+           AND e.created_at < unixepoch() - ?1
+           AND m.content_fidelity != 'SummaryOnly'
+         ORDER BY e.created_at ASC
+         LIMIT ?2"
+    ))
+    .bind(min_age)
+    .bind(batch)
+    .fetch_all(pool)
+    .await
+    .map_err(MemoryError::from)?;
+
+    Ok(rows)
+}
+
+/// Compute a cognitive weight signal for an episodic event.
+///
+/// Joins `experience_nodes` within a ±30 s window around the event's `created_at`.
+/// Returns 0.0 when no experience data is available.
+#[tracing::instrument(skip(pool), name = "memory.episodic_consolidation.cognitive_weight")]
+async fn compute_cognitive_weight(
+    pool: &DbPool,
+    session_id: &str,
+    created_at: i64,
+) -> Result<f64, MemoryError> {
+    let weight: f64 = zeph_db::query_scalar(sql!(
+        "SELECT COALESCE(SUM(CASE
+             WHEN outcome = 'success' THEN 1.0
+             WHEN outcome = 'error'   THEN -0.5
+             ELSE 0.0
+         END), 0.0)
+         FROM experience_nodes
+         WHERE session_id = ?1
+           AND created_at BETWEEN ?2 - 30 AND ?2 + 30"
+    ))
+    .bind(session_id)
+    .bind(created_at)
+    .fetch_one(pool)
+    .await
+    .map_err(MemoryError::from)?;
+
+    Ok(weight)
+}
+
+/// Call the LLM to extract durable facts from a batch of episodic events.
+///
+/// Returns an empty vec when the LLM signals no extractable facts.
+/// Returns `Err` on timeout or malformed JSON.
+#[tracing::instrument(skip_all, name = "memory.episodic_consolidation.extract_facts")]
+async fn extract_facts_via_llm(
+    provider: &AnyProvider,
+    candidates: &[ConsolidationCandidate],
+) -> Result<Vec<ExtractedFact>, MemoryError> {
+    let system_prompt = "You are a memory consolidation assistant. Given episodic events from an \
+        agent session, extract reusable factual statements. Each fact should be a single sentence \
+        that would be useful to recall in future conversations. Return a JSON array of objects: \
+        [{\"fact\": \"...\", \"source_event_ids\": [1, 2, ...]}]. \
+        Only extract facts that represent durable knowledge, not transient actions. \
+        Skip events that are purely procedural with no lasting insight.";
+
+    let user_content = candidates
+        .iter()
+        .enumerate()
+        .map(|(i, c)| {
+            let excerpt: String = c.message_content.chars().take(256).collect();
+            let summary_excerpt: String = c.summary.chars().take(256).collect();
+            format!(
+                "{}. [id={}] type={}, summary={}, message={}",
+                i + 1,
+                c.event_id,
+                c.event_type,
+                summary_excerpt,
+                excerpt
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let messages = vec![
+        Message {
+            role: Role::System,
+            content: system_prompt.to_owned(),
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        },
+        Message {
+            role: Role::User,
+            content: user_content,
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        },
+    ];
+
+    let text = tokio::time::timeout(Duration::from_secs(30), provider.chat(&messages))
+        .await
+        .map_err(|_| {
+            MemoryError::Other("episodic consolidation: LLM call timed out after 30s".to_owned())
+        })?
+        .map_err(|e| MemoryError::Other(format!("episodic consolidation: LLM error: {e}")))?;
+
+    let text = text.trim().to_owned();
+    if text.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Strip optional ```json … ``` fencing.
+    let json_str = if let Some(inner) = text
+        .strip_prefix("```json")
+        .or_else(|| text.strip_prefix("```"))
+    {
+        inner.trim_end_matches("```").trim()
+    } else {
+        text.as_str()
+    };
+
+    let parsed: serde_json::Value = serde_json::from_str(json_str).map_err(|e| {
+        MemoryError::Other(format!(
+            "episodic consolidation: malformed LLM JSON: {e} — raw: {json_str}"
+        ))
+    })?;
+
+    let arr = parsed.as_array().ok_or_else(|| {
+        MemoryError::Other("episodic consolidation: LLM returned non-array JSON".to_owned())
+    })?;
+
+    let mut facts = Vec::with_capacity(arr.len());
+    for item in arr {
+        let fact = item
+            .get("fact")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim()
+            .to_owned();
+        if fact.is_empty() {
+            continue;
+        }
+        let source_ids: Vec<i64> = item
+            .get("source_event_ids")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.iter().filter_map(serde_json::Value::as_i64).collect())
+            .unwrap_or_default();
+        facts.push(ExtractedFact {
+            fact,
+            source_event_ids: source_ids,
+        });
+    }
+
+    Ok(facts)
+}
+
+/// Fetch the last `limit` consolidated facts for Jaccard dedup.
+async fn fetch_existing_facts(pool: &DbPool, limit: i64) -> Result<Vec<String>, MemoryError> {
+    let rows: Vec<(String,)> = zeph_db::query_as(sql!(
+        "SELECT fact_text FROM consolidated_facts ORDER BY created_at DESC LIMIT ?1"
+    ))
+    .bind(limit)
+    .fetch_all(pool)
+    .await
+    .map_err(MemoryError::from)?;
+
+    Ok(rows.into_iter().map(|(s,)| s).collect())
+}
+
+/// Compute Jaccard similarity between two token sets.
+fn jaccard(a: &HashSet<&str>, b: &HashSet<&str>) -> f32 {
+    let intersection = a.intersection(b).count();
+    let union = a.union(b).count();
+    if union == 0 {
+        return 0.0;
+    }
+    #[allow(clippy::cast_precision_loss)]
+    (intersection as f32 / union as f32)
+}
+
+/// Return `true` if `fact` is a near-duplicate of any existing fact.
+fn is_jaccard_duplicate(fact: &str, existing: &[String], threshold: f32) -> bool {
+    let tokens: HashSet<&str> = fact.split_ascii_whitespace().collect();
+    for existing_fact in existing {
+        let existing_tokens: HashSet<&str> = existing_fact.split_ascii_whitespace().collect();
+        if jaccard(&tokens, &existing_tokens) >= threshold {
+            return true;
+        }
+    }
+    false
+}
+
+/// Promote a single accepted fact to `SQLite` and optionally Qdrant.
+///
+/// All `SQLite` writes for one fact happen in one transaction.
+/// Embeddings are generated via `provider.embed` using the provider's default model.
+#[tracing::instrument(skip_all, name = "memory.episodic_consolidation.promote")]
+async fn promote_fact(
+    pool: &DbPool,
+    fact_text: &str,
+    cognitive_weight: f32,
+    source_event_ids: &[i64],
+    qdrant: Option<&EmbeddingStore>,
+    provider: &AnyProvider,
+) -> Result<(), MemoryError> {
+    // Persist fact and provenance links in a single transaction.
+    let fact_id: i64 = {
+        let mut tx = pool.begin().await.map_err(MemoryError::from)?;
+
+        let fid: i64 = sqlx::query_scalar(sql!(
+            "INSERT INTO consolidated_facts (fact_text, source, cognitive_weight)
+             VALUES (?1, 'episodic_consolidation', ?2)
+             RETURNING id"
+        ))
+        .bind(fact_text)
+        .bind(cognitive_weight)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(MemoryError::from)?;
+
+        for &event_id in source_event_ids {
+            sqlx::query(sql!(
+                "INSERT OR IGNORE INTO consolidated_fact_sources (fact_id, event_id)
+                 VALUES (?1, ?2)"
+            ))
+            .bind(fid)
+            .bind(event_id)
+            .execute(&mut *tx)
+            .await
+            .map_err(MemoryError::from)?;
+        }
+
+        tx.commit().await.map_err(MemoryError::from)?;
+        fid
+    };
+
+    // Upsert into Qdrant `zeph_key_facts` when available.
+    if let Some(qdrant) = qdrant.filter(|_| provider.supports_embeddings()) {
+        match provider.embed(fact_text).await {
+            Ok(vector) => {
+                let vector_size = u64::try_from(vector.len()).unwrap_or(896);
+                if let Err(e) = qdrant
+                    .ensure_named_collection(KEY_FACTS_COLLECTION, vector_size)
+                    .await
+                {
+                    tracing::warn!(error = %e, "episodic consolidation: failed to ensure key_facts collection");
+                } else {
+                    let payload = serde_json::json!({
+                        "fact_text": fact_text,
+                        "source": "episodic_consolidation",
+                        "cognitive_weight": cognitive_weight,
+                        "consolidated_fact_id": fact_id,
+                    });
+                    if let Err(e) = qdrant
+                        .store_to_collection(KEY_FACTS_COLLECTION, payload, vector)
+                        .await
+                    {
+                        tracing::warn!(
+                            error = %e,
+                            "episodic consolidation: Qdrant upsert failed (SQLite fact was stored)"
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "episodic consolidation: embedding failed, fact stored in SQLite only"
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Mark an episodic event as consolidated.
+async fn mark_consolidated(pool: &DbPool, event_id: i64) -> Result<(), MemoryError> {
+    zeph_db::query(sql!(
+        "UPDATE episodic_events SET consolidated_at = unixepoch() WHERE id = ?1"
+    ))
+    .bind(event_id)
+    .execute(pool)
+    .await
+    .map_err(MemoryError::from)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::SqliteStore;
+    use zeph_db::sql;
+    use zeph_llm::any::AnyProvider;
+    use zeph_llm::mock::MockProvider;
+
+    async fn setup_db() -> (SqliteStore, DbPool) {
+        let store = SqliteStore::new(":memory:").await.unwrap();
+        let pool = store.pool().clone();
+        (store, pool)
+    }
+
+    fn mock_provider_with_response(response: &str) -> AnyProvider {
+        let mut p = MockProvider::default();
+        p.default_response = response.to_owned();
+        AnyProvider::Mock(p)
+    }
+
+    /// Insert a message + episodic_event row; returns (message_id, event_id).
+    async fn insert_episodic_event(
+        pool: &DbPool,
+        conv_id: crate::ConversationId,
+        content: &str,
+        summary: &str,
+        age_secs: i64,
+    ) -> (i64, i64) {
+        let msg_id: i64 = sqlx::query_scalar(sql!(
+            "INSERT INTO messages (conversation_id, role, content)
+             VALUES (?1, 'user', ?2)
+             RETURNING id"
+        ))
+        .bind(conv_id.0)
+        .bind(content)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+
+        let created_at = chrono::Utc::now().timestamp() - age_secs;
+        let event_id: i64 = sqlx::query_scalar(sql!(
+            "INSERT INTO episodic_events (session_id, message_id, event_type, summary, created_at)
+             VALUES ('test_session', ?1, 'tool_call', ?2, ?3)
+             RETURNING id"
+        ))
+        .bind(msg_id)
+        .bind(summary)
+        .bind(created_at)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+
+        (msg_id, event_id)
+    }
+
+    #[tokio::test]
+    async fn sweep_happy_path_promotes_fact() {
+        let (store, pool) = setup_db().await;
+        let conv_id = store.create_conversation().await.unwrap();
+
+        let (_, ev1) = insert_episodic_event(
+            &pool,
+            conv_id,
+            "Alice uses Rust for systems programming",
+            "Alice prefers Rust",
+            600,
+        )
+        .await;
+
+        let llm_response = format!(
+            r#"[{{"fact":"Alice uses Rust for systems programming","source_event_ids":[{ev1}]}}]"#
+        );
+        let provider = mock_provider_with_response(&llm_response);
+        let config = EpisodicConsolidationConfig {
+            enabled: true,
+            consolidation_provider: String::new(),
+            interval_secs: 1800,
+            batch_size: 30,
+            min_age_secs: 300,
+            dedup_jaccard_threshold: 0.6,
+        };
+
+        let result = run_episodic_consolidation_sweep(pool.clone(), &provider, &config, None)
+            .await
+            .unwrap();
+
+        assert_eq!(result.events_processed, 1);
+        assert_eq!(result.facts_promoted, 1);
+        assert_eq!(result.duplicates_skipped, 0);
+
+        let count: i64 = sqlx::query_scalar(sql!("SELECT COUNT(*) FROM consolidated_facts"))
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count, 1, "one fact must be persisted to consolidated_facts");
+
+        let consolidated_at: Option<i64> = sqlx::query_scalar(sql!(
+            "SELECT consolidated_at FROM episodic_events WHERE id = ?1"
+        ))
+        .bind(ev1)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(
+            consolidated_at.is_some(),
+            "event must be marked consolidated after sweep"
+        );
+    }
+
+    #[tokio::test]
+    async fn sweep_empty_llm_response_marks_events_consolidated() {
+        let (store, pool) = setup_db().await;
+        let conv_id = store.create_conversation().await.unwrap();
+
+        let (_, ev1) =
+            insert_episodic_event(&pool, conv_id, "routine operation", "no insight", 600).await;
+
+        let provider = mock_provider_with_response("[]");
+        let config = EpisodicConsolidationConfig {
+            enabled: true,
+            consolidation_provider: String::new(),
+            interval_secs: 1800,
+            batch_size: 30,
+            min_age_secs: 300,
+            dedup_jaccard_threshold: 0.6,
+        };
+
+        let result = run_episodic_consolidation_sweep(pool.clone(), &provider, &config, None)
+            .await
+            .unwrap();
+
+        assert_eq!(result.facts_promoted, 0, "no facts when LLM returns []");
+
+        let consolidated_at: Option<i64> = sqlx::query_scalar(sql!(
+            "SELECT consolidated_at FROM episodic_events WHERE id = ?1"
+        ))
+        .bind(ev1)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(
+            consolidated_at.is_some(),
+            "event must be marked consolidated even when LLM returns no facts"
+        );
+    }
+
+    #[test]
+    fn jaccard_identical_sets() {
+        let a: HashSet<&str> = ["foo", "bar", "baz"].iter().copied().collect();
+        let b = a.clone();
+        assert!((jaccard(&a, &b) - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn jaccard_disjoint_sets() {
+        let a: HashSet<&str> = ["foo", "bar"].iter().copied().collect();
+        let b: HashSet<&str> = ["baz", "qux"].iter().copied().collect();
+        assert!((jaccard(&a, &b) - 0.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn jaccard_partial_overlap() {
+        let a: HashSet<&str> = ["a", "b", "c"].iter().copied().collect();
+        let b: HashSet<&str> = ["b", "c", "d"].iter().copied().collect();
+        // intersection=2, union=4 → 0.5
+        assert!((jaccard(&a, &b) - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn is_duplicate_above_threshold() {
+        let existing = vec!["The sky is blue and clear".to_owned()];
+        assert!(is_jaccard_duplicate(
+            "The sky is blue and clear",
+            &existing,
+            0.6
+        ));
+    }
+
+    #[test]
+    fn is_not_duplicate_below_threshold() {
+        let existing = vec!["Rust is a systems programming language".to_owned()];
+        assert!(!is_jaccard_duplicate(
+            "Python is great for data science",
+            &existing,
+            0.6
+        ));
+    }
+
+    #[test]
+    fn episodic_consolidation_config_default() {
+        let cfg = EpisodicConsolidationConfig {
+            enabled: false,
+            consolidation_provider: String::new(),
+            interval_secs: 1800,
+            batch_size: 30,
+            min_age_secs: 300,
+            dedup_jaccard_threshold: 0.6,
+        };
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.interval_secs, 1800);
+        assert_eq!(cfg.batch_size, 30);
+        assert_eq!(cfg.min_age_secs, 300);
+        assert!((cfg.dedup_jaccard_threshold - 0.6).abs() < f32::EPSILON);
+    }
+}

--- a/crates/zeph-memory/src/graph/activation.rs
+++ b/crates/zeph-memory/src/graph/activation.rs
@@ -801,7 +801,8 @@ mod tests {
         let alice = store
             .upsert_entity("Alice", "Alice", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
 
         let sa = SpreadingActivation::new(default_params());
         let seeds = HashMap::from([(alice, 1.0_f32)]);
@@ -819,15 +820,18 @@ mod tests {
         let a = store
             .upsert_entity("A", "A", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let b = store
             .upsert_entity("B", "B", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let c = store
             .upsert_entity("C", "C", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         store
             .insert_edge(a, b, "knows", "A knows B", 1.0, None)
             .await
@@ -870,15 +874,18 @@ mod tests {
         let a = store
             .upsert_entity("A", "A", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let b = store
             .upsert_entity("B", "B", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let c = store
             .upsert_entity("C", "C", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         store
             .insert_edge(a, b, "knows", "A knows B", 1.0, None)
             .await
@@ -909,19 +916,23 @@ mod tests {
         let a = store
             .upsert_entity("A", "A", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let b = store
             .upsert_entity("B", "B", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let c = store
             .upsert_entity("C", "C", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let d = store
             .upsert_entity("D", "D", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         store
             .insert_edge(a, b, "rel", "A-B", 1.0, None)
             .await
@@ -963,7 +974,8 @@ mod tests {
         let hub = store
             .upsert_entity("Hub", "Hub", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
 
         for i in 0..5 {
             let leaf = store
@@ -974,7 +986,8 @@ mod tests {
                     None,
                 )
                 .await
-                .unwrap();
+                .unwrap()
+                .0;
             store
                 .insert_edge(hub, leaf, "has", &format!("Hub has Leaf{i}"), 1.0, None)
                 .await
@@ -1017,7 +1030,8 @@ mod tests {
         let root = store
             .upsert_entity("Root", "Root", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
 
         // Create 20 leaf nodes connected to root
         for i in 0..20 {
@@ -1029,7 +1043,8 @@ mod tests {
                     None,
                 )
                 .await
-                .unwrap();
+                .unwrap()
+                .0;
             store
                 .insert_edge(root, leaf, "has", &format!("Root has Node{i}"), 0.9, None)
                 .await
@@ -1060,15 +1075,18 @@ mod tests {
         let src = store
             .upsert_entity("Src", "Src", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let recent = store
             .upsert_entity("Recent", "Recent", EntityType::Tool, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let old = store
             .upsert_entity("Old", "Old", EntityType::Tool, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
 
         // Insert recent edge (default valid_from = now)
         store
@@ -1119,15 +1137,18 @@ mod tests {
         let a = store
             .upsert_entity("A", "A", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let b_semantic = store
             .upsert_entity("BSemantic", "BSemantic", EntityType::Tool, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let c_causal = store
             .upsert_entity("CCausal", "CCausal", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
 
         // Semantic edge from A
         store
@@ -1183,7 +1204,8 @@ mod tests {
                     None,
                 )
                 .await
-                .unwrap();
+                .unwrap()
+                .0;
             seeds.insert(id, 1.0_f32);
         }
 

--- a/crates/zeph-memory/src/graph/community.rs
+++ b/crates/zeph-memory/src/graph/community.rs
@@ -660,8 +660,7 @@ mod tests {
         store
             .upsert_entity("Solo", "Solo", EntityType::Concept, None)
             .await
-            .unwrap()
-            .0;
+            .unwrap();
         let count = detect_communities(&store, &provider, usize::MAX, 4, 0)
             .await
             .unwrap();
@@ -787,8 +786,7 @@ mod tests {
                     None,
                 )
                 .await
-                .unwrap()
-                .0;
+                .unwrap();
         }
 
         let count = detect_communities(&store, &provider, usize::MAX, 4, 0)
@@ -861,8 +859,7 @@ mod tests {
             store
                 .upsert_entity(&name, &name, EntityType::Concept, None)
                 .await
-                .unwrap()
-                .0;
+                .unwrap();
         }
 
         let stats = run_graph_eviction(&store, 90, 3).await.unwrap();

--- a/crates/zeph-memory/src/graph/community.rs
+++ b/crates/zeph-memory/src/graph/community.rs
@@ -114,8 +114,8 @@ async fn build_entity_graph_and_maps(
     let mut node_map: HashMap<i64, NodeIndex> = HashMap::new();
 
     for entity in entities {
-        let idx = graph.add_node(entity.id);
-        node_map.insert(entity.id, idx);
+        let idx = graph.add_node(entity.id.0);
+        node_map.insert(entity.id.0, idx);
     }
 
     let mut edge_facts_map: HashMap<(i64, i64), Vec<String>> = HashMap::new();
@@ -389,7 +389,7 @@ pub async fn detect_communities(
     let communities = run_label_propagation(&graph);
 
     let entity_name_map: HashMap<i64, &str> =
-        entities.iter().map(|e| (e.id, e.name.as_str())).collect();
+        entities.iter().map(|e| (e.id.0, e.name.as_str())).collect();
     let stored_fingerprints = store.community_fingerprints().await?;
 
     let mut sorted_labels: Vec<usize> = communities.keys().copied().collect();
@@ -488,10 +488,11 @@ pub async fn assign_to_community(
     };
 
     if let Some(mut target) = store.find_community_by_id(best_community_id).await? {
-        if !target.entity_ids.contains(&entity_id) {
-            target.entity_ids.push(entity_id);
+        if !target.entity_ids.iter().any(|eid| eid.0 == entity_id) {
+            target.entity_ids.push(crate::types::EntityId(entity_id));
+            let raw_ids: Vec<i64> = target.entity_ids.iter().map(|eid| eid.0).collect();
             store
-                .upsert_community(&target.name, &target.summary, &target.entity_ids, None)
+                .upsert_community(&target.name, &target.summary, &raw_ids, None)
                 .await?;
             // Clear fingerprint to invalidate cache — next detect_communities will re-summarize.
             store.clear_community_fingerprint(best_community_id).await?;
@@ -659,7 +660,8 @@ mod tests {
         store
             .upsert_entity("Solo", "Solo", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let count = detect_communities(&store, &provider, usize::MAX, 4, 0)
             .await
             .unwrap();
@@ -675,19 +677,23 @@ mod tests {
         let a = store
             .upsert_entity("A", "A", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let b = store
             .upsert_entity("B", "B", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let c = store
             .upsert_entity("C", "C", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let iso = store
             .upsert_entity("Isolated", "Isolated", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
 
         store
             .insert_edge(a, b, "r", "A relates B", 1.0, None)
@@ -707,7 +713,7 @@ mod tests {
         let communities = store.all_communities().await.unwrap();
         assert_eq!(communities.len(), 1);
         assert!(
-            !communities[0].entity_ids.contains(&iso),
+            !communities[0].entity_ids.iter().any(|eid| eid.0 == iso),
             "isolated entity must not be in any community"
         );
     }
@@ -726,7 +732,8 @@ mod tests {
                 let id = store
                     .upsert_entity(&name, &name, EntityType::Concept, None)
                     .await
-                    .unwrap();
+                    .unwrap()
+                    .0;
                 ids.push(id);
             }
             // Connect nodes within cluster (chain: 0-1-2).
@@ -753,7 +760,10 @@ mod tests {
         for ids in &cluster_ids {
             let found = communities
                 .iter()
-                .filter(|c| ids.iter().any(|id| c.entity_ids.contains(id)))
+                .filter(|c| {
+                    ids.iter()
+                        .any(|id| c.entity_ids.iter().any(|eid| eid.0 == *id))
+                })
                 .count();
             assert_eq!(
                 found, 1,
@@ -777,7 +787,8 @@ mod tests {
                     None,
                 )
                 .await
-                .unwrap();
+                .unwrap()
+                .0;
         }
 
         let count = detect_communities(&store, &provider, usize::MAX, 4, 0)
@@ -794,11 +805,13 @@ mod tests {
         let a = store
             .upsert_entity("EA", "EA", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let b = store
             .upsert_entity("EB", "EB", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let edge_id = store.insert_edge(a, b, "r", "f", 1.0, None).await.unwrap();
         store.invalidate_edge(edge_id).await.unwrap();
 
@@ -822,7 +835,8 @@ mod tests {
         let iso = store
             .upsert_entity("Orphan", "Orphan", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
 
         // Set last_seen_at to far in the past.
         zeph_db::query(sql!(
@@ -847,7 +861,8 @@ mod tests {
             store
                 .upsert_entity(&name, &name, EntityType::Concept, None)
                 .await
-                .unwrap();
+                .unwrap()
+                .0;
         }
 
         let stats = run_graph_eviction(&store, 90, 3).await.unwrap();
@@ -864,7 +879,8 @@ mod tests {
         let entity_id = store
             .upsert_entity("Loner", "Loner", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
 
         let result = assign_to_community(&store, entity_id).await.unwrap();
         assert!(result.is_none());
@@ -984,15 +1000,18 @@ mod tests {
         let a = store
             .upsert_entity("AA", "AA", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let b = store
             .upsert_entity("BB", "BB", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let d = store
             .upsert_entity("DD", "DD", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
 
         store
             .upsert_community("test_community", "summary", &[a, b], None)
@@ -1013,7 +1032,7 @@ mod tests {
             .unwrap()
             .expect("returned community_id must reference an existing row");
         assert!(
-            community.entity_ids.contains(&d),
+            community.entity_ids.iter().any(|eid| eid.0 == d),
             "D should be added to the community"
         );
         // Fingerprint must be NULL after assign (cache invalidated for next detect run).
@@ -1032,11 +1051,13 @@ mod tests {
         let a = store
             .upsert_entity("X", "X", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let b = store
             .upsert_entity("Y", "Y", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         store
             .insert_edge(a, b, "r", "X relates Y", 1.0, None)
             .await
@@ -1069,11 +1090,13 @@ mod tests {
         let a = store
             .upsert_entity("P", "P", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let b = store
             .upsert_entity("Q", "Q", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         store
             .insert_edge(a, b, "r", "P relates Q", 1.0, None)
             .await
@@ -1110,11 +1133,13 @@ mod tests {
         let a = store
             .upsert_entity("M1", "M1", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let b = store
             .upsert_entity("M2", "M2", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let edge_id = store
             .insert_edge(a, b, "r", "M1 relates M2", 1.0, None)
             .await
@@ -1147,11 +1172,13 @@ mod tests {
         let a = store
             .upsert_entity("C1A", "C1A", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let b = store
             .upsert_entity("C1B", "C1B", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         store.insert_edge(a, b, "r", "f", 1.0, None).await.unwrap();
 
         let count = detect_communities(&store, &provider, usize::MAX, 1, 0)
@@ -1208,23 +1235,28 @@ mod tests {
         let node_alpha = store
             .upsert_entity("CA", "CA", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let node_beta = store
             .upsert_entity("CB", "CB", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let node_gamma = store
             .upsert_entity("CC", "CC", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let node_delta = store
             .upsert_entity("CD", "CD", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let node_epsilon = store
             .upsert_entity("CE", "CE", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
 
         store
             .insert_edge(node_alpha, node_beta, "r", "A-B fact", 1.0, None)
@@ -1254,12 +1286,16 @@ mod tests {
 
         let abc_ids = [node_alpha, node_beta, node_gamma];
         let de_ids = [node_delta, node_epsilon];
-        let has_abc = communities
-            .iter()
-            .any(|comm| abc_ids.iter().all(|id| comm.entity_ids.contains(id)));
-        let has_de = communities
-            .iter()
-            .any(|comm| de_ids.iter().all(|id| comm.entity_ids.contains(id)));
+        let has_abc = communities.iter().any(|comm| {
+            abc_ids
+                .iter()
+                .all(|id| comm.entity_ids.iter().any(|eid| eid.0 == *id))
+        });
+        let has_de = communities.iter().any(|comm| {
+            de_ids
+                .iter()
+                .all(|id| comm.entity_ids.iter().any(|eid| eid.0 == *id))
+        });
         assert!(has_abc, "cluster A-B-C must form a community");
         assert!(has_de, "cluster D-E must form a community");
     }
@@ -1273,11 +1309,13 @@ mod tests {
         let x = store
             .upsert_entity("MX", "MX", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let y = store
             .upsert_entity("MY", "MY", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         store
             .insert_edge(x, y, "r", "X-Y fact", 1.0, None)
             .await
@@ -1298,11 +1336,13 @@ mod tests {
         let p = store
             .upsert_entity("ZP", "ZP", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let q = store
             .upsert_entity("ZQ", "ZQ", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         store
             .insert_edge(p, q, "r", "P-Q fact", 1.0, None)
             .await
@@ -1328,11 +1368,13 @@ mod tests {
         let a = store
             .upsert_entity("FA", "FA", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let b = store
             .upsert_entity("FB", "FB", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         store
             .insert_edge(a, b, "r", "edge1 fact", 1.0, None)
             .await
@@ -1401,11 +1443,13 @@ mod tests {
         let live_id = graph_store
             .upsert_entity("Live", "live", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let stale_id = graph_store
             .upsert_entity("Stale", "stale", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
 
         // Store embeddings with `entity_id_str` for both.
         let live_payload = serde_json::json!({

--- a/crates/zeph-memory/src/graph/experience.rs
+++ b/crates/zeph-memory/src/graph/experience.rs
@@ -13,6 +13,7 @@ use zeph_db::{DbPool, sql};
 
 use crate::error::MemoryError;
 use crate::graph::store::GraphStore;
+use crate::types::{EntityId, ExperienceId};
 
 /// Statistics from a single graph evolution sweep.
 #[derive(Debug, Default)]
@@ -40,7 +41,7 @@ impl ExperienceStore {
 
     /// Record a tool execution outcome as an experience node.
     ///
-    /// Returns the row ID of the newly inserted experience node.
+    /// Returns the strongly typed row ID of the newly inserted experience node.
     ///
     /// # Errors
     ///
@@ -70,7 +71,7 @@ impl ExperienceStore {
         outcome: &str,
         detail: Option<&str>,
         error_ctx: Option<&str>,
-    ) -> Result<i64, MemoryError> {
+    ) -> Result<ExperienceId, MemoryError> {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map_or(0, |d| d.as_secs().cast_signed());
@@ -90,7 +91,7 @@ impl ExperienceStore {
         .fetch_one(&self.pool)
         .await
         .map_err(MemoryError::from)?;
-        Ok(id)
+        Ok(ExperienceId(id))
     }
 
     /// Link an experience node to one or more knowledge graph entities.
@@ -102,17 +103,18 @@ impl ExperienceStore {
     /// Returns [`MemoryError`] if any database insert fails.
     pub async fn link_to_entities(
         &self,
-        experience_id: i64,
-        entity_ids: &[i64],
+        experience_id: ExperienceId,
+        entity_ids: &[EntityId],
     ) -> Result<(), MemoryError> {
-        let _span = tracing::info_span!("memory.experience.link_entities", experience_id).entered();
+        let _span =
+            tracing::info_span!("memory.experience.link_entities", exp = experience_id.0).entered();
         for &entity_id in entity_ids {
             zeph_db::query(sql!(
                 "INSERT OR IGNORE INTO experience_entity_links
                  (experience_id, entity_id) VALUES (?1, ?2)"
             ))
-            .bind(experience_id)
-            .bind(entity_id)
+            .bind(experience_id.0)
+            .bind(entity_id.0)
             .execute(&self.pool)
             .await
             .map_err(MemoryError::from)?;
@@ -125,14 +127,18 @@ impl ExperienceStore {
     /// # Errors
     ///
     /// Returns [`MemoryError`] if the database insert fails.
-    pub async fn link_sequential(&self, prev: i64, next: i64) -> Result<(), MemoryError> {
+    pub async fn link_sequential(
+        &self,
+        prev: ExperienceId,
+        next: ExperienceId,
+    ) -> Result<(), MemoryError> {
         zeph_db::query(sql!(
             "INSERT INTO experience_edges
              (source_exp_id, target_exp_id, relation)
              VALUES (?1, ?2, 'followed_by')"
         ))
-        .bind(prev)
-        .bind(next)
+        .bind(prev.0)
+        .bind(next.0)
         .execute(&self.pool)
         .await
         .map_err(MemoryError::from)?;
@@ -204,13 +210,13 @@ mod tests {
             .record_tool_outcome("sess1", 1, "shell", "success", Some("exit 0"), None)
             .await
             .unwrap();
-        assert!(id > 0);
+        assert!(id.0 > 0);
 
         let (sid, turn, tool, outcome): (String, i64, String, String) = sqlx::query_as(sql!(
             "SELECT session_id, turn, tool_name, outcome
                  FROM experience_nodes WHERE id = ?1"
         ))
-        .bind(id)
+        .bind(id.0)
         .fetch_one(&pool)
         .await
         .unwrap();
@@ -218,6 +224,45 @@ mod tests {
         assert_eq!(turn, 1);
         assert_eq!(tool, "shell");
         assert_eq!(outcome, "success");
+    }
+
+    #[tokio::test]
+    async fn link_to_entities_populates_link_table() {
+        let (exp, gs, pool) = setup().await;
+        let exp_id = exp
+            .record_tool_outcome("sess2", 1, "shell", "success", None, None)
+            .await
+            .unwrap();
+        let e1 = gs
+            .upsert_entity("Alice", "alice", EntityType::Person, None)
+            .await
+            .unwrap();
+        let e2 = gs
+            .upsert_entity("Bob", "bob", EntityType::Person, None)
+            .await
+            .unwrap();
+
+        exp.link_to_entities(exp_id, &[e1, e2]).await.unwrap();
+
+        let count: i64 = sqlx::query_scalar(sql!(
+            "SELECT COUNT(*) FROM experience_entity_links WHERE experience_id = ?1"
+        ))
+        .bind(exp_id.0)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(count, 2, "both entity links must be inserted");
+
+        // Idempotency: second call must not duplicate rows.
+        exp.link_to_entities(exp_id, &[e1]).await.unwrap();
+        let count2: i64 = sqlx::query_scalar(sql!(
+            "SELECT COUNT(*) FROM experience_entity_links WHERE experience_id = ?1"
+        ))
+        .bind(exp_id.0)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(count2, 2, "INSERT OR IGNORE must prevent duplicate links");
     }
 
     #[tokio::test]
@@ -238,12 +283,12 @@ mod tests {
             "SELECT source_exp_id, target_exp_id, relation
              FROM experience_edges WHERE source_exp_id = ?1"
         ))
-        .bind(id1)
+        .bind(id1.0)
         .fetch_one(&pool)
         .await
         .unwrap();
-        assert_eq!(src, id1);
-        assert_eq!(tgt, id2);
+        assert_eq!(src, id1.0);
+        assert_eq!(tgt, id2.0);
         assert_eq!(rel, "followed_by");
     }
 
@@ -271,7 +316,7 @@ mod tests {
              (source_entity_id, target_entity_id, relation, fact, confidence, edge_type)
              VALUES (?1, ?1, 'knows', 'self', 0.5, 'semantic')"
         ))
-        .bind(e1)
+        .bind(e1.0)
         .execute(&pool)
         .await
         .unwrap();
@@ -290,7 +335,7 @@ mod tests {
         .unwrap();
 
         // Insert a normal edge that must survive the sweep.
-        gs.insert_edge(e1, e2, "knows", "Alice knows Bob", 0.9, None)
+        gs.insert_edge(e1.0, e2.0, "knows", "Alice knows Bob", 0.9, None)
             .await
             .unwrap();
 
@@ -302,8 +347,8 @@ mod tests {
             "SELECT COUNT(*) FROM graph_edges
              WHERE source_entity_id = ?1 AND target_entity_id = ?2"
         ))
-        .bind(e1)
-        .bind(e2)
+        .bind(e1.0)
+        .bind(e2.0)
         .fetch_one(&pool)
         .await
         .unwrap();

--- a/crates/zeph-memory/src/graph/resolver/mod.rs
+++ b/crates/zeph-memory/src/graph/resolver/mod.rs
@@ -215,7 +215,7 @@ impl<'a> EntityResolver<'a> {
             self.store
                 .upsert_entity(&surface_name, &entity.canonical_name, et, summary)
                 .await?;
-            return Ok((entity.id, ResolutionOutcome::ExactMatch));
+            return Ok((entity.id.0, ResolutionOutcome::ExactMatch));
         }
 
         // Step 4: canonical name lookup.
@@ -223,7 +223,7 @@ impl<'a> EntityResolver<'a> {
             self.store
                 .upsert_entity(&surface_name, &entity.canonical_name, et, summary)
                 .await?;
-            return Ok((entity.id, ResolutionOutcome::ExactMatch));
+            return Ok((entity.id.0, ResolutionOutcome::ExactMatch));
         }
 
         // Step 5: Embedding-based resolution (when configured).
@@ -240,9 +240,10 @@ impl<'a> EntityResolver<'a> {
             .upsert_entity(&surface_name, &normalized, et, summary)
             .await?;
 
-        self.register_aliases(entity_id, &normalized, name).await?;
+        self.register_aliases(entity_id.0, &normalized, name)
+            .await?;
 
-        Ok((entity_id, ResolutionOutcome::Created))
+        Ok((entity_id.0, ResolutionOutcome::Created))
     }
 
     /// Compute embedding for an entity, incrementing `fallback_count` on failure/timeout.
@@ -488,11 +489,11 @@ impl<'a> EntityResolver<'a> {
             .store
             .upsert_entity(surface_name, normalized, et, summary)
             .await?;
-        self.register_aliases(entity_id, normalized, original_name)
+        self.register_aliases(entity_id.0, normalized, original_name)
             .await?;
         self.store_entity_embedding(
             emb_store,
-            entity_id,
+            entity_id.0,
             None,
             normalized,
             et,
@@ -500,7 +501,7 @@ impl<'a> EntityResolver<'a> {
             query_vec,
         )
         .await;
-        Ok((entity_id, ResolutionOutcome::Created))
+        Ok((entity_id.0, ResolutionOutcome::Created))
     }
 
     /// Register the normalized form and original trimmed form as aliases for an entity.

--- a/crates/zeph-memory/src/graph/resolver/tests.rs
+++ b/crates/zeph-memory/src/graph/resolver/tests.rs
@@ -149,11 +149,13 @@ async fn resolve_edge_inserts_new() {
     let src = gs
         .upsert_entity("src", "src", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt = gs
         .upsert_entity("tgt", "tgt", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let result = resolver
         .resolve_edge(src, tgt, "uses", "src uses tgt", 0.9, None)
@@ -171,11 +173,13 @@ async fn resolve_edge_deduplicates_identical() {
     let src = gs
         .upsert_entity("a", "a", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt = gs
         .upsert_entity("b", "b", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let first = resolver
         .resolve_edge(src, tgt, "uses", "a uses b", 0.9, None)
@@ -198,11 +202,13 @@ async fn resolve_edge_supersedes_contradictory() {
     let src = gs
         .upsert_entity("x", "x", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt = gs
         .upsert_entity("y", "y", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let first_id = resolver
         .resolve_edge(src, tgt, "prefers", "x prefers y (old)", 0.8, None)
@@ -232,11 +238,13 @@ async fn resolve_edge_direction_sensitive() {
     let a = gs
         .upsert_entity("node_a", "node_a", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("node_b", "node_b", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     // Insert A->B
     let id1 = resolver
@@ -265,11 +273,13 @@ async fn resolve_edge_normalizes_relation_case() {
     let src = gs
         .upsert_entity("p", "p", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt = gs
         .upsert_entity("q", "q", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     // Insert with uppercase relation
     let id1 = resolver
@@ -439,7 +449,8 @@ async fn resolve_with_embedding_store_score_above_threshold_merges() {
             Some("a programming language"),
         )
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let mock_vec = vec![1.0_f32, 0.0, 0.0, 0.0];
     emb.ensure_named_collection(ENTITY_COLLECTION, 4)
@@ -492,7 +503,8 @@ async fn resolve_with_embedding_store_score_below_ambiguous_creates_new() {
     let existing_id = gs
         .upsert_entity("java", "java", EntityType::Language, Some("java language"))
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     // Existing uses [1,0,0,0]; new entity will embed to [0,1,0,0] (orthogonal, score=0)
     emb.ensure_named_collection(ENTITY_COLLECTION, 4)
@@ -630,7 +642,8 @@ async fn merge_combines_summaries() {
             Some("first summary"),
         )
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let mock_vec = vec![1.0_f32, 0.0, 0.0, 0.0];
     emb.ensure_named_collection(ENTITY_COLLECTION, 4)
@@ -692,7 +705,8 @@ async fn merge_preserves_older_entity_id() {
             Some("old info"),
         )
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let mock_vec = vec![1.0_f32, 0.0, 0.0, 0.0];
     emb.ensure_named_collection(ENTITY_COLLECTION, 4)
@@ -740,7 +754,8 @@ async fn entity_type_filter_prevents_cross_type_merge() {
             Some("a person named python"),
         )
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let mock_vec = vec![1.0_f32, 0.0, 0.0, 0.0];
     emb.ensure_named_collection(ENTITY_COLLECTION, 4)
@@ -795,7 +810,8 @@ async fn custom_thresholds_respected() {
             Some("base"),
         )
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let existing_vec = vec![1.0_f32, 0.0, 0.0, 0.0];
     emb.ensure_named_collection(ENTITY_COLLECTION, 4)
@@ -876,7 +892,8 @@ async fn seed_entity_with_vector(
     let id = gs
         .upsert_entity(name, name, entity_type, Some(summary))
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     emb.ensure_named_collection(ENTITY_COLLECTION, u64::try_from(vector.len()).unwrap())
         .await
         .unwrap();
@@ -1125,7 +1142,8 @@ async fn resolve_entity_with_many_aliases() {
     let id = gs
         .upsert_entity("bigentity", "bigentity", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     for i in 0..100 {
         gs.add_alias(id, &format!("alias-{i}")).await.unwrap();
     }
@@ -1134,5 +1152,5 @@ async fn resolve_entity_with_many_aliases() {
 
     // Fuzzy search should still work via alias
     let results = gs.find_entities_fuzzy("alias-50", 10).await.unwrap();
-    assert!(results.iter().any(|e| e.id == id));
+    assert!(results.iter().any(|e| e.id.0 == id));
 }

--- a/crates/zeph-memory/src/graph/retrieval.rs
+++ b/crates/zeph-memory/src/graph/retrieval.rs
@@ -94,7 +94,7 @@ pub async fn graph_recall(
         // aliases have different display names but share canonical_name, preventing duplicates.
         let name_map: HashMap<i64, &str> = entities
             .iter()
-            .map(|e| (e.id, e.canonical_name.as_str()))
+            .map(|e| (e.id.0, e.canonical_name.as_str()))
             .collect();
 
         // Collect edge IDs before conversion to GraphFact (critic: issue 7 fix).
@@ -273,7 +273,7 @@ pub(crate) async fn find_seed_entities(
         let ranked = store.find_entities_ranked(word, limit * 2).await?;
         for (entity, fts_score) in ranked {
             fts_map
-                .entry(entity.id)
+                .entry(entity.id.0)
                 .and_modify(|(_, s)| *s = s.max(fts_score))
                 .or_insert((entity, fts_score));
         }
@@ -307,8 +307,8 @@ pub(crate) async fn find_seed_entities(
     let mut scored: Vec<ScoredEntity> = fts_map
         .into_values()
         .map(|(entity, fts_score)| {
-            let struct_score = structural_scores.get(&entity.id).copied().unwrap_or(0.0);
-            let community_id = community_ids.get(&entity.id).copied();
+            let struct_score = structural_scores.get(&entity.id.0).copied().unwrap_or(0.0);
+            let community_id = community_ids.get(&entity.id.0).copied();
             ScoredEntity {
                 entity,
                 fts_score,
@@ -361,7 +361,7 @@ pub(crate) async fn find_seed_entities(
         .map(|se| {
             let hybrid = se.fts_score * fts_weight + se.structural_score * structural_weight;
             // Clamp to [0.1, 1.0] to keep hybrid seeds above activation_threshold.
-            (se.entity.id, hybrid.clamp(0.1, 1.0))
+            (se.entity.id.0, hybrid.clamp(0.1, 1.0))
         })
         .collect();
 
@@ -528,11 +528,13 @@ mod tests {
         let user_id = store
             .upsert_entity("Alice", "Alice", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let tool_id = store
             .upsert_entity("neovim", "neovim", EntityType::Tool, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         store
             .insert_edge(user_id, tool_id, "uses", "Alice uses neovim", 0.9, None)
             .await
@@ -565,15 +567,18 @@ mod tests {
         let a = store
             .upsert_entity("Alpha", "Alpha", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let b = store
             .upsert_entity("Beta", "Beta", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let c = store
             .upsert_entity("Gamma", "Gamma", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         store
             .insert_edge(a, b, "knows", "Alpha knows Beta", 0.8, None)
             .await
@@ -610,11 +615,13 @@ mod tests {
         let alice = store
             .upsert_entity("Alice", "Alice", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let bob = store
             .upsert_entity("Bob", "Bob", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         store
             .insert_edge(alice, bob, "knows", "Alice knows Bob", 0.9, None)
             .await
@@ -652,15 +659,18 @@ mod tests {
         let a = store
             .upsert_entity("Alpha", "Alpha", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let b = store
             .upsert_entity("Beta", "Beta", EntityType::Tool, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let c = store
             .upsert_entity("AlphaGadget", "AlphaGadget", EntityType::Tool, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         // high-confidence direct edge
         store
             .insert_edge(a, b, "uses", "Alpha uses Beta", 1.0, None)
@@ -702,7 +712,8 @@ mod tests {
         let root = store
             .upsert_entity("Root", "Root", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         for i in 0..10 {
             let target = store
                 .upsert_entity(
@@ -712,7 +723,8 @@ mod tests {
                     None,
                 )
                 .await
-                .unwrap();
+                .unwrap()
+                .0;
             store
                 .insert_edge(
                     root,
@@ -751,11 +763,13 @@ mod tests {
         let alice = store
             .upsert_entity("Alice", "Alice", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let bob = store
             .upsert_entity("Bob", "Bob", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         // Insert an edge with valid_from = year 2100 (far future).
         zeph_db::query(
             sql!("INSERT INTO graph_edges (source_entity_id, target_entity_id, relation, fact, confidence, valid_from)
@@ -793,11 +807,13 @@ mod tests {
         let alice = store
             .upsert_entity("Alice", "Alice", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let carol = store
             .upsert_entity("Carol", "Carol", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         // Insert an edge valid 2020-01-01 → 2021-01-01 (already expired by 2026).
         zeph_db::query(
             sql!("INSERT INTO graph_edges
@@ -875,7 +891,8 @@ mod tests {
                     None,
                 )
                 .await
-                .unwrap();
+                .unwrap()
+                .0;
             entity_ids.push(id);
         }
 
@@ -890,7 +907,8 @@ mod tests {
         let hub = store
             .upsert_entity("Hub", "hub", crate::graph::types::EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         for &target in &entity_ids {
             store
                 .insert_edge(hub, target, "has", "Hub has entity", 0.9, None)
@@ -938,7 +956,8 @@ mod tests {
                 None,
             )
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let b = store
             .upsert_entity(
                 "Concept",
@@ -947,7 +966,8 @@ mod tests {
                 None,
             )
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         store
             .insert_edge(a, b, "rel", "Zephyr rel Concept", 0.9, None)
             .await
@@ -982,15 +1002,18 @@ mod tests {
         let a = store
             .upsert_entity("Alpha", "Alpha", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let b = store
             .upsert_entity("Beta", "Beta", EntityType::Tool, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let c = store
             .upsert_entity("AlphaGadget", "AlphaGadget", EntityType::Tool, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         store
             .insert_edge(a, b, "uses", "Alpha uses Beta", 1.0, None)
             .await
@@ -1033,11 +1056,13 @@ mod tests {
         let user = store
             .upsert_entity("Alice", "Alice", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let tool = store
             .upsert_entity("Vim", "Vim", EntityType::Tool, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let eid = store
             .insert_edge(user, tool, "uses", "Alice uses Vim", 0.9, None)
             .await
@@ -1087,11 +1112,13 @@ mod tests {
         let user = store
             .upsert_entity("Bob", "Bob", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let tool = store
             .upsert_entity("Emacs", "Emacs", EntityType::Tool, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let eid = store
             .insert_edge(user, tool, "uses", "Bob uses Emacs", 0.9, None)
             .await

--- a/crates/zeph-memory/src/graph/retrieval_astar.rs
+++ b/crates/zeph-memory/src/graph/retrieval_astar.rs
@@ -87,7 +87,7 @@ pub async fn graph_recall_astar(
         };
         for e in &entities {
             entity_name_map
-                .entry(e.id)
+                .entry(e.id.0)
                 .or_insert_with(|| e.canonical_name.clone());
         }
         all_db_edges.extend(edges);
@@ -300,11 +300,13 @@ mod tests {
         let a = store
             .upsert_entity("Alice", "alice", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let b = store
             .upsert_entity("Bob", "bob", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         store
             .insert_edge(a, b, "knows", "Alice knows Bob", 0.9, None)
             .await

--- a/crates/zeph-memory/src/graph/retrieval_beam.rs
+++ b/crates/zeph-memory/src/graph/retrieval_beam.rs
@@ -272,11 +272,13 @@ mod tests {
         let a = store
             .upsert_entity("Alice", "alice", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         let b = store
             .upsert_entity("Bob", "bob", EntityType::Person, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         store
             .insert_edge(a, b, "knows", "Alice knows Bob", 0.9, None)
             .await

--- a/crates/zeph-memory/src/graph/retrieval_watercircles.rs
+++ b/crates/zeph-memory/src/graph/retrieval_watercircles.rs
@@ -94,7 +94,7 @@ pub async fn graph_recall_watercircles(
 
             let name_map: HashMap<i64, &str> = entities
                 .iter()
-                .map(|e| (e.id, e.canonical_name.as_str()))
+                .map(|e| (e.id.0, e.canonical_name.as_str()))
                 .collect();
 
             let traversed_ids: Vec<i64> = edges.iter().map(|e| e.id).collect();
@@ -254,7 +254,8 @@ mod tests {
         let root = store
             .upsert_entity("Root", "root", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         for i in 0..10usize {
             let target = store
                 .upsert_entity(
@@ -264,7 +265,8 @@ mod tests {
                     None,
                 )
                 .await
-                .unwrap();
+                .unwrap()
+                .0;
             store
                 .insert_edge(root, target, "has", &format!("Root has T{i}"), 0.8, None)
                 .await

--- a/crates/zeph-memory/src/graph/store/mod.rs
+++ b/crates/zeph-memory/src/graph/store/mod.rs
@@ -17,7 +17,7 @@ use zeph_db::{ActiveDialect, DbPool, numbered_placeholder, placeholder_list};
 
 use crate::error::MemoryError;
 use crate::graph::conflict::{ApexMetrics, SUPERSEDE_DEPTH_CAP};
-use crate::types::MessageId;
+use crate::types::{EntityId, MessageId};
 
 use super::types::{Community, Edge, EdgeType, Entity, EntityAlias, EntityType};
 
@@ -64,7 +64,7 @@ impl GraphStore {
         canonical_name: &str,
         entity_type: EntityType,
         summary: Option<&str>,
-    ) -> Result<i64, MemoryError> {
+    ) -> Result<EntityId, MemoryError> {
         let type_str = entity_type.as_str();
         let id: i64 = zeph_db::query_scalar(sql!(
             "INSERT INTO graph_entities (name, canonical_name, entity_type, summary)
@@ -81,7 +81,7 @@ impl GraphStore {
         .bind(summary)
         .fetch_one(&self.pool)
         .await?;
-        Ok(id)
+        Ok(EntityId(id))
     }
 
     /// Find an entity by exact canonical name and type.
@@ -869,7 +869,8 @@ impl GraphStore {
         .await?;
         match row {
             Some(row) => {
-                let entity_ids: Vec<i64> = serde_json::from_str(&row.entity_ids)?;
+                let raw_ids: Vec<i64> = serde_json::from_str(&row.entity_ids)?;
+                let entity_ids = raw_ids.into_iter().map(EntityId).collect();
                 Ok(Some(Community {
                     id: row.id,
                     name: row.name,
@@ -900,7 +901,8 @@ impl GraphStore {
 
         rows.into_iter()
             .map(|row| {
-                let entity_ids: Vec<i64> = serde_json::from_str(&row.entity_ids)?;
+                let raw_ids: Vec<i64> = serde_json::from_str(&row.entity_ids)?;
+                let entity_ids = raw_ids.into_iter().map(EntityId).collect();
                 Ok(Community {
                     id: row.id,
                     name: row.name,
@@ -1039,7 +1041,8 @@ impl GraphStore {
         .await?;
         match row {
             Some(row) => {
-                let entity_ids: Vec<i64> = serde_json::from_str(&row.entity_ids)?;
+                let raw_ids: Vec<i64> = serde_json::from_str(&row.entity_ids)?;
+                let entity_ids = raw_ids.into_iter().map(EntityId).collect();
                 Ok(Some(Community {
                     id: row.id,
                     name: row.name,
@@ -2171,7 +2174,7 @@ fn entity_from_row(row: EntityRow) -> Result<Entity, MemoryError> {
         .parse::<EntityType>()
         .map_err(MemoryError::GraphStore)?;
     Ok(Entity {
-        id: row.id,
+        id: EntityId(row.id),
         name: row.name,
         canonical_name: row.canonical_name,
         entity_type,
@@ -2193,7 +2196,7 @@ struct AliasRow {
 fn alias_from_row(row: AliasRow) -> EntityAlias {
     EntityAlias {
         id: row.id,
-        entity_id: row.entity_id,
+        entity_id: EntityId(row.entity_id),
         alias_name: row.alias_name,
         created_at: row.created_at,
     }
@@ -2963,7 +2966,7 @@ fn normalize_and_dedup(rows: Vec<EntityFtsRow>) -> Vec<(Entity, f32)> {
             .parse()
             .unwrap_or(super::types::EntityType::Concept);
         let entity = Entity {
-            id,
+            id: EntityId(id),
             name,
             canonical_name,
             entity_type,

--- a/crates/zeph-memory/src/graph/store/tests.rs
+++ b/crates/zeph-memory/src/graph/store/tests.rs
@@ -52,8 +52,7 @@ async fn find_entity_found() {
     let gs = setup().await;
     gs.upsert_entity("Bob", "Bob", EntityType::Tool, Some("a tool"))
         .await
-        .unwrap()
-        .0;
+        .unwrap();
     let entity = gs
         .find_entity("Bob", EntityType::Tool)
         .await
@@ -75,8 +74,7 @@ async fn find_entities_fuzzy_partial_match() {
     let gs = setup().await;
     gs.upsert_entity("GraphQL", "GraphQL", EntityType::Concept, None)
         .await
-        .unwrap()
-        .0;
+        .unwrap();
     gs.upsert_entity("Graph", "Graph", EntityType::Concept, None)
         .await
         .unwrap();
@@ -101,8 +99,7 @@ async fn entity_count_non_empty() {
     let gs = setup().await;
     gs.upsert_entity("A", "A", EntityType::Concept, None)
         .await
-        .unwrap()
-        .0;
+        .unwrap();
     gs.upsert_entity("B", "B", EntityType::Concept, None)
         .await
         .unwrap();
@@ -116,8 +113,7 @@ async fn all_entities_and_stream() {
     let gs = setup().await;
     gs.upsert_entity("X", "X", EntityType::Project, None)
         .await
-        .unwrap()
-        .0;
+        .unwrap();
     gs.upsert_entity("Y", "Y", EntityType::Language, None)
         .await
         .unwrap();
@@ -656,8 +652,7 @@ async fn test_find_entities_fuzzy_no_results() {
     let gs = setup().await;
     gs.upsert_entity("Alpha", "Alpha", EntityType::Concept, None)
         .await
-        .unwrap()
-        .0;
+        .unwrap();
     let results = gs.find_entities_fuzzy("zzzznonexistent", 10).await.unwrap();
     assert!(
         results.is_empty(),
@@ -672,8 +667,7 @@ async fn upsert_entity_stores_canonical_name() {
     let gs = setup().await;
     gs.upsert_entity("rust", "rust", EntityType::Language, None)
         .await
-        .unwrap()
-        .0;
+        .unwrap();
     let entity = gs
         .find_entity("rust", EntityType::Language)
         .await
@@ -753,8 +747,7 @@ async fn find_entities_fuzzy_matches_summary() {
         Some("a systems programming language"),
     )
     .await
-    .unwrap()
-    .0;
+    .unwrap();
     gs.upsert_entity(
         "Go",
         "Go",
@@ -774,8 +767,7 @@ async fn find_entities_fuzzy_empty_query() {
     let gs = setup().await;
     gs.upsert_entity("Alpha", "Alpha", EntityType::Concept, None)
         .await
-        .unwrap()
-        .0;
+        .unwrap();
     // Empty query returns empty vec without hitting the database.
     let results = gs.find_entities_fuzzy("", 10).await.unwrap();
     assert!(results.is_empty(), "empty query should return no results");
@@ -1258,8 +1250,7 @@ async fn find_entities_fuzzy_special_chars() {
     let gs = setup().await;
     gs.upsert_entity("Graph", "Graph", EntityType::Concept, None)
         .await
-        .unwrap()
-        .0;
+        .unwrap();
     // FTS5 special characters in query must not cause an error.
     let results = gs.find_entities_fuzzy("graph\"()*:^", 10).await.unwrap();
     // "graph" survives sanitization and matches.
@@ -1271,8 +1262,7 @@ async fn find_entities_fuzzy_prefix_match() {
     let gs = setup().await;
     gs.upsert_entity("Graph", "Graph", EntityType::Concept, None)
         .await
-        .unwrap()
-        .0;
+        .unwrap();
     gs.upsert_entity("GraphQL", "GraphQL", EntityType::Concept, None)
         .await
         .unwrap();
@@ -1291,8 +1281,7 @@ async fn find_entities_fuzzy_fts5_operator_injection() {
     let gs = setup().await;
     gs.upsert_entity("Graph", "Graph", EntityType::Concept, None)
         .await
-        .unwrap()
-        .0;
+        .unwrap();
     gs.upsert_entity("Unrelated", "Unrelated", EntityType::Concept, None)
         .await
         .unwrap();
@@ -1321,8 +1310,7 @@ async fn find_entities_fuzzy_after_entity_update() {
         Some("initial summary bar"),
     )
     .await
-    .unwrap()
-    .0;
+    .unwrap();
     // Update summary via upsert — triggers the FTS UPDATE trigger.
     gs.upsert_entity(
         "Foo",
@@ -1349,8 +1337,7 @@ async fn find_entities_fuzzy_only_special_chars() {
     let gs = setup().await;
     gs.upsert_entity("Alpha", "Alpha", EntityType::Concept, None)
         .await
-        .unwrap()
-        .0;
+        .unwrap();
     // Queries consisting solely of FTS5 special characters produce no alphanumeric
     // tokens after sanitization, so the function returns early with an empty vec
     // rather than passing an empty or malformed MATCH expression to FTS5.
@@ -1379,8 +1366,7 @@ async fn find_entity_by_name_exact_wins_over_summary_mention() {
         Some("A person named Alice"),
     )
     .await
-    .unwrap()
-    .0;
+    .unwrap();
     // Google's summary mentions "Alice" — without the fix, FTS5 could rank this first.
     gs.upsert_entity(
         "Google",
@@ -1404,8 +1390,7 @@ async fn find_entity_by_name_case_insensitive_exact() {
     let gs = setup().await;
     gs.upsert_entity("Bob", "Bob", EntityType::Person, None)
         .await
-        .unwrap()
-        .0;
+        .unwrap();
 
     let results = gs.find_entity_by_name("bob").await.unwrap();
     assert!(!results.is_empty());
@@ -1417,8 +1402,7 @@ async fn find_entity_by_name_falls_back_to_fuzzy_when_no_exact_match() {
     let gs = setup().await;
     gs.upsert_entity("Charlie", "Charlie", EntityType::Person, None)
         .await
-        .unwrap()
-        .0;
+        .unwrap();
 
     // "Char" is not an exact match for "Charlie" → FTS5 prefix fallback should find it.
     let results = gs.find_entity_by_name("Char").await.unwrap();
@@ -1439,8 +1423,7 @@ async fn find_entity_by_name_matches_canonical_name() {
     // upsert_entity sets canonical_name = second arg
     gs.upsert_entity("Dave (Engineer)", "Dave", EntityType::Person, None)
         .await
-        .unwrap()
-        .0;
+        .unwrap();
 
     // Searching by canonical_name "Dave" must return the entity even though
     // the display name is "Dave (Engineer)".
@@ -3004,8 +2987,7 @@ async fn fts5_cross_session_visibility_after_checkpoint() {
         let gs_a = GraphStore::new(store_a.pool().clone());
         gs_a.upsert_entity("Rust", "rust", EntityType::Concept, None)
             .await
-            .unwrap()
-            .0;
+            .unwrap();
         gs_a.checkpoint_wal().await.unwrap();
     }
 
@@ -3350,8 +3332,7 @@ async fn find_entities_ranked_returns_scores_in_0_1() {
     store
         .upsert_entity("Rust", "rust", EntityType::Language, None)
         .await
-        .unwrap()
-        .0;
+        .unwrap();
     store
         .upsert_entity("RustLang", "rustlang", EntityType::Language, None)
         .await
@@ -3378,8 +3359,7 @@ async fn find_entities_ranked_empty_query_returns_empty() {
     store
         .upsert_entity("Rust", "rust", EntityType::Language, None)
         .await
-        .unwrap()
-        .0;
+        .unwrap();
 
     let results = store.find_entities_ranked("", 10).await.unwrap();
     assert!(results.is_empty(), "empty query must return no results");
@@ -3391,8 +3371,7 @@ async fn find_entities_ranked_top_match_has_highest_score() {
     store
         .upsert_entity("Rust", "rust", EntityType::Language, None)
         .await
-        .unwrap()
-        .0;
+        .unwrap();
     store
         .upsert_entity("Python", "python", EntityType::Language, None)
         .await

--- a/crates/zeph-memory/src/graph/store/tests.rs
+++ b/crates/zeph-memory/src/graph/store/tests.rs
@@ -18,7 +18,8 @@ async fn upsert_entity_insert_new() {
     let id = gs
         .upsert_entity("Alice", "Alice", EntityType::Person, Some("a person"))
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     assert!(id > 0);
 }
 
@@ -28,13 +29,15 @@ async fn upsert_entity_update_existing() {
     let id1 = gs
         .upsert_entity("Alice", "Alice", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     // Sleep 1ms to ensure datetime changes; SQLite datetime granularity is 1s,
     // so we verify idempotency instead of timestamp ordering.
     let id2 = gs
         .upsert_entity("Alice", "Alice", EntityType::Person, Some("updated"))
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     assert_eq!(id1, id2);
     let entity = gs
         .find_entity("Alice", EntityType::Person)
@@ -49,7 +52,8 @@ async fn find_entity_found() {
     let gs = setup().await;
     gs.upsert_entity("Bob", "Bob", EntityType::Tool, Some("a tool"))
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let entity = gs
         .find_entity("Bob", EntityType::Tool)
         .await
@@ -71,7 +75,8 @@ async fn find_entities_fuzzy_partial_match() {
     let gs = setup().await;
     gs.upsert_entity("GraphQL", "GraphQL", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     gs.upsert_entity("Graph", "Graph", EntityType::Concept, None)
         .await
         .unwrap();
@@ -96,7 +101,8 @@ async fn entity_count_non_empty() {
     let gs = setup().await;
     gs.upsert_entity("A", "A", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     gs.upsert_entity("B", "B", EntityType::Concept, None)
         .await
         .unwrap();
@@ -110,7 +116,8 @@ async fn all_entities_and_stream() {
     let gs = setup().await;
     gs.upsert_entity("X", "X", EntityType::Project, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     gs.upsert_entity("Y", "Y", EntityType::Language, None)
         .await
         .unwrap();
@@ -128,11 +135,13 @@ async fn insert_edge_without_episode() {
     let src = gs
         .upsert_entity("Src", "Src", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt = gs
         .upsert_entity("Tgt", "Tgt", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let eid = gs
         .insert_edge(src, tgt, "relates_to", "Src relates to Tgt", 0.9, None)
         .await
@@ -146,11 +155,13 @@ async fn insert_edge_deduplicates_active_edge() {
     let src = gs
         .upsert_entity("Alice", "Alice", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt = gs
         .upsert_entity("Google", "Google", EntityType::Organization, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let id1 = gs
         .insert_edge(src, tgt, "works_at", "Alice works at Google", 0.7, None)
@@ -191,11 +202,13 @@ async fn insert_edge_different_relations_are_distinct() {
     let src = gs
         .upsert_entity("Bob", "Bob", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt = gs
         .upsert_entity("Acme", "Acme", EntityType::Organization, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let id1 = gs
         .insert_edge(src, tgt, "founded", "Bob founded Acme", 0.8, None)
@@ -222,11 +235,13 @@ async fn insert_edge_with_episode() {
     let src = gs
         .upsert_entity("Src2", "Src2", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt = gs
         .upsert_entity("Tgt2", "Tgt2", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     // Verifies that passing an episode_id does not cause a panic or unexpected error on the
     // insertion path itself. The episode_id references the messages table; whether the FK
     // constraint fires depends on the SQLite FK enforcement mode at runtime. Both success
@@ -249,11 +264,13 @@ async fn invalidate_edge_sets_timestamps() {
     let src = gs
         .upsert_entity("E1", "E1", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt = gs
         .upsert_entity("E2", "E2", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let eid = gs
         .insert_edge(src, tgt, "r", "fact", 1.0, None)
         .await
@@ -277,15 +294,18 @@ async fn edges_for_entity_both_directions() {
     let a = gs
         .upsert_entity("A", "A", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("B", "B", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let c = gs
         .upsert_entity("C", "C", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     gs.insert_edge(a, b, "r", "f1", 1.0, None).await.unwrap();
     gs.insert_edge(c, a, "r", "f2", 1.0, None).await.unwrap();
 
@@ -299,11 +319,13 @@ async fn edges_between_both_directions() {
     let a = gs
         .upsert_entity("PA", "PA", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("PB", "PB", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     gs.insert_edge(a, b, "knows", "PA knows PB", 1.0, None)
         .await
         .unwrap();
@@ -320,11 +342,13 @@ async fn active_edge_count_excludes_invalidated() {
     let a = gs
         .upsert_entity("N1", "N1", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("N2", "N2", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let e1 = gs.insert_edge(a, b, "r1", "f1", 1.0, None).await.unwrap();
     gs.insert_edge(a, b, "r2", "f2", 1.0, None).await.unwrap();
     gs.invalidate_edge(e1).await.unwrap();
@@ -348,7 +372,14 @@ async fn upsert_community_insert_and_update() {
     let communities = gs.all_communities().await.unwrap();
     assert_eq!(communities.len(), 1);
     assert_eq!(communities[0].summary, "summary A updated");
-    assert_eq!(communities[0].entity_ids, vec![1, 2, 3, 4]);
+    assert_eq!(
+        communities[0]
+            .entity_ids
+            .iter()
+            .map(|e| e.0)
+            .collect::<Vec<_>>(),
+        vec![1_i64, 2, 3, 4]
+    );
 }
 
 #[tokio::test]
@@ -357,11 +388,13 @@ async fn community_for_entity_found() {
     let a = gs
         .upsert_entity("CA", "CA", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("CB", "CB", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     gs.upsert_community("cA", "summary", &[a, b], None)
         .await
         .unwrap();
@@ -402,16 +435,18 @@ async fn bfs_max_hops_0_returns_only_start() {
     let a = gs
         .upsert_entity("BfsA", "BfsA", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("BfsB", "BfsB", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     gs.insert_edge(a, b, "r", "f", 1.0, None).await.unwrap();
 
     let (entities, edges) = gs.bfs(a, 0).await.unwrap();
     assert_eq!(entities.len(), 1);
-    assert_eq!(entities[0].id, a);
+    assert_eq!(entities[0].id.0, a);
     assert!(edges.is_empty());
 }
 
@@ -421,20 +456,23 @@ async fn bfs_max_hops_2_chain() {
     let a = gs
         .upsert_entity("ChainA", "ChainA", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("ChainB", "ChainB", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let c = gs
         .upsert_entity("ChainC", "ChainC", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     gs.insert_edge(a, b, "r", "f1", 1.0, None).await.unwrap();
     gs.insert_edge(b, c, "r", "f2", 1.0, None).await.unwrap();
 
     let (entities, edges) = gs.bfs(a, 2).await.unwrap();
-    let ids: Vec<_> = entities.iter().map(|e| e.id).collect();
+    let ids: Vec<i64> = entities.iter().map(|e| e.id.0).collect();
     assert!(ids.contains(&a));
     assert!(ids.contains(&b));
     assert!(ids.contains(&c));
@@ -447,16 +485,18 @@ async fn bfs_cycle_no_infinite_loop() {
     let a = gs
         .upsert_entity("CycA", "CycA", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("CycB", "CycB", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     gs.insert_edge(a, b, "r", "f1", 1.0, None).await.unwrap();
     gs.insert_edge(b, a, "r", "f2", 1.0, None).await.unwrap();
 
     let (entities, _edges) = gs.bfs(a, 3).await.unwrap();
-    let ids: Vec<_> = entities.iter().map(|e| e.id).collect();
+    let ids: Vec<i64> = entities.iter().map(|e| e.id.0).collect();
     // Should have exactly A and B, no infinite loop
     assert!(ids.contains(&a));
     assert!(ids.contains(&b));
@@ -469,22 +509,25 @@ async fn test_invalidated_edges_excluded_from_bfs() {
     let a = gs
         .upsert_entity("InvA", "InvA", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("InvB", "InvB", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let c = gs
         .upsert_entity("InvC", "InvC", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let ab = gs.insert_edge(a, b, "r", "f1", 1.0, None).await.unwrap();
     gs.insert_edge(b, c, "r", "f2", 1.0, None).await.unwrap();
     // Invalidate A->B: BFS from A should not reach B or C.
     gs.invalidate_edge(ab).await.unwrap();
 
     let (entities, edges) = gs.bfs(a, 2).await.unwrap();
-    let ids: Vec<_> = entities.iter().map(|e| e.id).collect();
+    let ids: Vec<i64> = entities.iter().map(|e| e.id.0).collect();
     assert_eq!(ids, vec![a], "only start entity should be reachable");
     assert!(edges.is_empty(), "no active edges should be returned");
 }
@@ -495,10 +538,11 @@ async fn test_bfs_empty_graph() {
     let a = gs
         .upsert_entity("IsoA", "IsoA", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let (entities, edges) = gs.bfs(a, 2).await.unwrap();
-    let ids: Vec<_> = entities.iter().map(|e| e.id).collect();
+    let ids: Vec<i64> = entities.iter().map(|e| e.id.0).collect();
     assert_eq!(ids, vec![a], "isolated node: only start entity returned");
     assert!(edges.is_empty(), "no edges for isolated node");
 }
@@ -509,26 +553,30 @@ async fn test_bfs_diamond() {
     let a = gs
         .upsert_entity("DiamA", "DiamA", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("DiamB", "DiamB", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let c = gs
         .upsert_entity("DiamC", "DiamC", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let d = gs
         .upsert_entity("DiamD", "DiamD", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     gs.insert_edge(a, b, "r", "f1", 1.0, None).await.unwrap();
     gs.insert_edge(a, c, "r", "f2", 1.0, None).await.unwrap();
     gs.insert_edge(b, d, "r", "f3", 1.0, None).await.unwrap();
     gs.insert_edge(c, d, "r", "f4", 1.0, None).await.unwrap();
 
     let (entities, edges) = gs.bfs(a, 2).await.unwrap();
-    let mut ids: Vec<_> = entities.iter().map(|e| e.id).collect();
+    let mut ids: Vec<i64> = entities.iter().map(|e| e.id.0).collect();
     ids.sort_unstable();
     let mut expected = vec![a, b, c, d];
     expected.sort_unstable();
@@ -556,15 +604,18 @@ async fn all_active_edges_stream_excludes_invalidated() {
     let a = gs
         .upsert_entity("SA", "SA", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("SB", "SB", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let c = gs
         .upsert_entity("SC", "SC", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let e1 = gs.insert_edge(a, b, "r", "f1", 1.0, None).await.unwrap();
     gs.insert_edge(b, c, "r", "f2", 1.0, None).await.unwrap();
     gs.invalidate_edge(e1).await.unwrap();
@@ -605,7 +656,8 @@ async fn test_find_entities_fuzzy_no_results() {
     let gs = setup().await;
     gs.upsert_entity("Alpha", "Alpha", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let results = gs.find_entities_fuzzy("zzzznonexistent", 10).await.unwrap();
     assert!(
         results.is_empty(),
@@ -620,7 +672,8 @@ async fn upsert_entity_stores_canonical_name() {
     let gs = setup().await;
     gs.upsert_entity("rust", "rust", EntityType::Language, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let entity = gs
         .find_entity("rust", EntityType::Language)
         .await
@@ -636,7 +689,8 @@ async fn add_alias_idempotent() {
     let id = gs
         .upsert_entity("rust", "rust", EntityType::Language, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     gs.add_alias(id, "rust-lang").await.unwrap();
     // Second insert should succeed silently (INSERT OR IGNORE)
     gs.add_alias(id, "rust-lang").await.unwrap();
@@ -658,11 +712,12 @@ async fn find_entity_by_id_found() {
     let id = gs
         .upsert_entity("FindById", "finbyid", EntityType::Concept, Some("summary"))
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let entity = gs.find_entity_by_id(id).await.unwrap();
     assert!(entity.is_some());
     let entity = entity.unwrap();
-    assert_eq!(entity.id, id);
+    assert_eq!(entity.id.0, id);
     assert_eq!(entity.name, "FindById");
 }
 
@@ -679,7 +734,8 @@ async fn set_entity_qdrant_point_id_updates() {
     let id = gs
         .upsert_entity("QdrantPoint", "qdrantpoint", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let point_id = "550e8400-e29b-41d4-a716-446655440000";
     gs.set_entity_qdrant_point_id(id, point_id).await.unwrap();
 
@@ -697,7 +753,8 @@ async fn find_entities_fuzzy_matches_summary() {
         Some("a systems programming language"),
     )
     .await
-    .unwrap();
+    .unwrap()
+    .0;
     gs.upsert_entity(
         "Go",
         "Go",
@@ -717,7 +774,8 @@ async fn find_entities_fuzzy_empty_query() {
     let gs = setup().await;
     gs.upsert_entity("Alpha", "Alpha", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     // Empty query returns empty vec without hitting the database.
     let results = gs.find_entities_fuzzy("", 10).await.unwrap();
     assert!(results.is_empty(), "empty query should return no results");
@@ -735,7 +793,8 @@ async fn find_entity_by_alias_case_insensitive() {
     let id = gs
         .upsert_entity("rust", "rust", EntityType::Language, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     gs.add_alias(id, "rust").await.unwrap();
     gs.add_alias(id, "rust-lang").await.unwrap();
 
@@ -744,7 +803,7 @@ async fn find_entity_by_alias_case_insensitive() {
         .await
         .unwrap();
     assert!(found.is_some());
-    assert_eq!(found.unwrap().id, id);
+    assert_eq!(found.unwrap().id.0, id);
 }
 
 #[tokio::test]
@@ -753,7 +812,8 @@ async fn find_entity_by_alias_returns_none_for_unknown() {
     let id = gs
         .upsert_entity("rust", "rust", EntityType::Language, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     gs.add_alias(id, "rust").await.unwrap();
 
     let found = gs
@@ -770,7 +830,8 @@ async fn find_entity_by_alias_filters_by_entity_type() {
     let lang_id = gs
         .upsert_entity("python", "python", EntityType::Language, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     gs.add_alias(lang_id, "python").await.unwrap();
 
     let found_tool = gs
@@ -787,7 +848,7 @@ async fn find_entity_by_alias_filters_by_entity_type() {
         .await
         .unwrap();
     assert!(found_lang.is_some());
-    assert_eq!(found_lang.unwrap().id, lang_id);
+    assert_eq!(found_lang.unwrap().id.0, lang_id);
 }
 
 #[tokio::test]
@@ -796,7 +857,8 @@ async fn aliases_for_entity_returns_all() {
     let id = gs
         .upsert_entity("rust", "rust", EntityType::Language, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     gs.add_alias(id, "rust").await.unwrap();
     gs.add_alias(id, "rust-lang").await.unwrap();
     gs.add_alias(id, "rustlang").await.unwrap();
@@ -815,7 +877,8 @@ async fn find_entities_fuzzy_includes_aliases() {
     let id = gs
         .upsert_entity("rust", "rust", EntityType::Language, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     gs.add_alias(id, "rust-lang").await.unwrap();
     gs.upsert_entity("python", "python", EntityType::Language, None)
         .await
@@ -824,7 +887,7 @@ async fn find_entities_fuzzy_includes_aliases() {
     // "rust-lang" is an alias, not the entity name — fuzzy search should still find it
     let results = gs.find_entities_fuzzy("rust-lang", 10).await.unwrap();
     assert!(!results.is_empty());
-    assert!(results.iter().any(|e| e.id == id));
+    assert!(results.iter().any(|e| e.id.0 == id));
 }
 
 #[tokio::test]
@@ -833,7 +896,8 @@ async fn orphan_alias_cleanup_on_entity_delete() {
     let id = gs
         .upsert_entity("rust", "rust", EntityType::Language, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     gs.add_alias(id, "rust").await.unwrap();
     gs.add_alias(id, "rust-lang").await.unwrap();
 
@@ -1163,11 +1227,13 @@ async fn find_entity_by_alias_same_alias_two_entities_deterministic() {
     let id1 = gs
         .upsert_entity("python-v2", "python-v2", EntityType::Language, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let id2 = gs
         .upsert_entity("python-v3", "python-v3", EntityType::Language, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     gs.add_alias(id1, "python").await.unwrap();
     gs.add_alias(id2, "python").await.unwrap();
 
@@ -1179,7 +1245,7 @@ async fn find_entity_by_alias_same_alias_two_entities_deterministic() {
     assert!(found.is_some(), "should find an entity by shared alias");
     // ORDER BY e.id ASC guarantees deterministic result: first inserted wins
     assert_eq!(
-        found.unwrap().id,
+        found.unwrap().id.0,
         id1,
         "first-registered entity should win on shared alias"
     );
@@ -1192,7 +1258,8 @@ async fn find_entities_fuzzy_special_chars() {
     let gs = setup().await;
     gs.upsert_entity("Graph", "Graph", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     // FTS5 special characters in query must not cause an error.
     let results = gs.find_entities_fuzzy("graph\"()*:^", 10).await.unwrap();
     // "graph" survives sanitization and matches.
@@ -1204,7 +1271,8 @@ async fn find_entities_fuzzy_prefix_match() {
     let gs = setup().await;
     gs.upsert_entity("Graph", "Graph", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     gs.upsert_entity("GraphQL", "GraphQL", EntityType::Concept, None)
         .await
         .unwrap();
@@ -1223,7 +1291,8 @@ async fn find_entities_fuzzy_fts5_operator_injection() {
     let gs = setup().await;
     gs.upsert_entity("Graph", "Graph", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     gs.upsert_entity("Unrelated", "Unrelated", EntityType::Concept, None)
         .await
         .unwrap();
@@ -1252,7 +1321,8 @@ async fn find_entities_fuzzy_after_entity_update() {
         Some("initial summary bar"),
     )
     .await
-    .unwrap();
+    .unwrap()
+    .0;
     // Update summary via upsert — triggers the FTS UPDATE trigger.
     gs.upsert_entity(
         "Foo",
@@ -1279,7 +1349,8 @@ async fn find_entities_fuzzy_only_special_chars() {
     let gs = setup().await;
     gs.upsert_entity("Alpha", "Alpha", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     // Queries consisting solely of FTS5 special characters produce no alphanumeric
     // tokens after sanitization, so the function returns early with an empty vec
     // rather than passing an empty or malformed MATCH expression to FTS5.
@@ -1308,7 +1379,8 @@ async fn find_entity_by_name_exact_wins_over_summary_mention() {
         Some("A person named Alice"),
     )
     .await
-    .unwrap();
+    .unwrap()
+    .0;
     // Google's summary mentions "Alice" — without the fix, FTS5 could rank this first.
     gs.upsert_entity(
         "Google",
@@ -1332,7 +1404,8 @@ async fn find_entity_by_name_case_insensitive_exact() {
     let gs = setup().await;
     gs.upsert_entity("Bob", "Bob", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let results = gs.find_entity_by_name("bob").await.unwrap();
     assert!(!results.is_empty());
@@ -1344,7 +1417,8 @@ async fn find_entity_by_name_falls_back_to_fuzzy_when_no_exact_match() {
     let gs = setup().await;
     gs.upsert_entity("Charlie", "Charlie", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     // "Char" is not an exact match for "Charlie" → FTS5 prefix fallback should find it.
     let results = gs.find_entity_by_name("Char").await.unwrap();
@@ -1365,7 +1439,8 @@ async fn find_entity_by_name_matches_canonical_name() {
     // upsert_entity sets canonical_name = second arg
     gs.upsert_entity("Dave (Engineer)", "Dave", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     // Searching by canonical_name "Dave" must return the entity even though
     // the display name is "Dave (Engineer)".
@@ -1456,15 +1531,18 @@ async fn edges_after_id_first_page_returns_all_within_limit() {
     let a = gs
         .upsert_entity("PA", "PA", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("PB", "PB", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let c = gs
         .upsert_entity("PC", "PC", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let e1 = gs.insert_edge(a, b, "r", "f1", 1.0, None).await.unwrap();
     let e2 = gs.insert_edge(b, c, "r", "f2", 1.0, None).await.unwrap();
     let e3 = gs.insert_edge(a, c, "r", "f3", 1.0, None).await.unwrap();
@@ -1497,15 +1575,18 @@ async fn edges_after_id_skips_invalidated_edges() {
     let a = gs
         .upsert_entity("IA", "IA", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("IB", "IB", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let c = gs
         .upsert_entity("IC", "IC", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let e1 = gs.insert_edge(a, b, "r", "f1", 1.0, None).await.unwrap();
     let e2 = gs.insert_edge(b, c, "r", "f2", 1.0, None).await.unwrap();
 
@@ -1525,11 +1606,13 @@ async fn edges_at_timestamp_returns_active_edge() {
     let a = gs
         .upsert_entity("TA", "TA", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("TB", "TB", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     gs.insert_edge(a, b, "knows", "TA knows TB", 1.0, None)
         .await
         .unwrap();
@@ -1549,11 +1632,13 @@ async fn edges_at_timestamp_excludes_future_valid_from() {
     let a = gs
         .upsert_entity("FA", "FA", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("FB", "FB", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     // Insert edge with valid_from in the far future.
     sqlx::query(
         sql!("INSERT INTO graph_edges (source_entity_id, target_entity_id, relation, fact, confidence, valid_from)
@@ -1582,11 +1667,13 @@ async fn edges_at_timestamp_historical_window_visible() {
     let a = gs
         .upsert_entity("HA", "HA", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("HB", "HB", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     // Expired edge valid 2020-01-01 → 2021-01-01.
     sqlx::query(
         sql!("INSERT INTO graph_edges
@@ -1638,11 +1725,13 @@ async fn edges_at_timestamp_entity_as_target() {
     let src = gs
         .upsert_entity("SRC", "SRC", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt = gs
         .upsert_entity("TGT", "TGT", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     gs.insert_edge(src, tgt, "links", "SRC links TGT", 0.9, None)
         .await
         .unwrap();
@@ -1665,15 +1754,18 @@ async fn bfs_at_timestamp_excludes_expired_edges() {
     let a = gs
         .upsert_entity("BA", "BA", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("BB", "BB", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let c = gs
         .upsert_entity("BC", "BC", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     // A → B: active edge with explicit valid_from in 2019 so it predates all test timestamps.
     sqlx::query(sql!(
@@ -1704,7 +1796,7 @@ async fn bfs_at_timestamp_excludes_expired_edges() {
         .bfs_at_timestamp(a, 3, "2026-01-01 00:00:00")
         .await
         .unwrap();
-    let entity_ids: Vec<i64> = entities.iter().map(|e| e.id).collect();
+    let entity_ids: Vec<i64> = entities.iter().map(|e| e.id.0).collect();
     assert!(
         depth_map.contains_key(&a),
         "start entity must be in depth_map"
@@ -1735,11 +1827,13 @@ async fn edge_history_returns_all_versions_ordered() {
     let src = gs
         .upsert_entity("ESrc", "ESrc", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt = gs
         .upsert_entity("ETgt", "ETgt", EntityType::Organization, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     // Version 1: valid 2020→2022 (expired).
     sqlx::query(
@@ -1799,11 +1893,13 @@ async fn edge_history_like_escaping() {
     let src = gs
         .upsert_entity("EscSrc", "EscSrc", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt = gs
         .upsert_entity("EscTgt", "EscTgt", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     // Insert an edge with a fact that contains neither '%' nor '_'.
     gs.insert_edge(src, tgt, "ref", "plain text fact no wildcards", 1.0, None)
@@ -1833,11 +1929,13 @@ async fn invalidate_edge_sets_valid_to_and_expired_at() {
     let a = gs
         .upsert_entity("InvA", "InvA", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("InvB", "InvB", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let edge_id = gs
         .insert_edge(a, b, "rel", "InvA rel InvB", 1.0, None)
         .await
@@ -1890,11 +1988,13 @@ async fn edges_at_timestamp_valid_from_inclusive() {
     let a = gs
         .upsert_entity("VFI_A", "VFI_A", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("VFI_B", "VFI_B", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     sqlx::query(sql!(
         "INSERT INTO graph_edges
          (source_entity_id, target_entity_id, relation, fact, confidence, valid_from)
@@ -1924,11 +2024,13 @@ async fn edges_at_timestamp_valid_to_exclusive() {
     let a = gs
         .upsert_entity("VTO_A", "VTO_A", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("VTO_B", "VTO_B", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     sqlx::query(sql!(
         "INSERT INTO graph_edges
          (source_entity_id, target_entity_id, relation, fact, confidence,
@@ -1970,19 +2072,23 @@ async fn edges_at_timestamp_multiple_edges_same_entity() {
     let a = gs
         .upsert_entity("ME_A", "ME_A", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("ME_B", "ME_B", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let c = gs
         .upsert_entity("ME_C", "ME_C", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let d = gs
         .upsert_entity("ME_D", "ME_D", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     // A->B: active since 2020, no expiry — visible at 2025.
     sqlx::query(sql!(
@@ -2038,7 +2144,8 @@ async fn edges_at_timestamp_no_edges_returns_empty() {
     let a = gs
         .upsert_entity("NE_A", "NE_A", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let edges = gs
         .edges_at_timestamp(a, "2025-01-01 00:00:00")
@@ -2058,11 +2165,13 @@ async fn edge_history_basic_history() {
     let src = gs
         .upsert_entity("EH_Src", "EH_Src", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt = gs
         .upsert_entity("EH_Tgt", "EH_Tgt", EntityType::Organization, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     sqlx::query(sql!(
         "INSERT INTO graph_edges
@@ -2101,11 +2210,13 @@ async fn edge_history_for_entity_includes_expired() {
     let a = gs
         .upsert_entity("HistA", "HistA", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("HistB", "HistB", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     // Insert and immediately invalidate first edge
     let e1 = gs
@@ -2138,15 +2249,18 @@ async fn edge_history_for_entity_both_directions() {
     let a = gs
         .upsert_entity("DirA", "DirA", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("DirB", "DirB", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let c = gs
         .upsert_entity("DirC", "DirC", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     gs.insert_edge(a, b, "r1", "f1", 1.0, None).await.unwrap();
     gs.insert_edge(c, a, "r2", "f2", 1.0, None).await.unwrap();
@@ -2175,11 +2289,13 @@ async fn edge_history_for_entity_respects_limit() {
     let a = gs
         .upsert_entity("LimA", "LimA", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("LimB", "LimB", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     for i in 0..5u32 {
         gs.insert_edge(a, b, &format!("r{i}"), &format!("fact {i}"), 1.0, None)
@@ -2197,11 +2313,13 @@ async fn edge_history_limit_parameter() {
     let src = gs
         .upsert_entity("EHL_Src", "EHL_Src", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt = gs
         .upsert_entity("EHL_Tgt", "EHL_Tgt", EntityType::Organization, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     for (year, rel) in [
         (2018i32, "worked_at_v1"),
@@ -2247,11 +2365,13 @@ async fn edge_history_non_matching_relation_returns_empty() {
     let src = gs
         .upsert_entity("EHR_Src", "EHR_Src", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt = gs
         .upsert_entity("EHR_Tgt", "EHR_Tgt", EntityType::Organization, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     sqlx::query(sql!(
         "INSERT INTO graph_edges
@@ -2280,7 +2400,8 @@ async fn edge_history_empty_entity() {
     let src = gs
         .upsert_entity("EHE_Src", "EHE_Src", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let result = gs.edge_history(src, "anything", None, 100).await.unwrap();
     assert!(
@@ -2295,11 +2416,13 @@ async fn edge_history_fact_substring_filters_subset() {
     let src = gs
         .upsert_entity("EHP_Src", "EHP_Src", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt = gs
         .upsert_entity("EHP_Tgt", "EHP_Tgt", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     // Two facts containing "uses" and one containing "knows" (distinct relations to avoid
     // UNIQUE(source, target, relation) violation).
@@ -2347,11 +2470,13 @@ async fn bfs_at_timestamp_zero_hops() {
     let a = gs
         .upsert_entity("ZH_A", "ZH_A", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("ZH_B", "ZH_B", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     // Use an explicit valid_from so the query timestamp is within the data range.
     sqlx::query(sql!(
         "INSERT INTO graph_edges
@@ -2382,15 +2507,18 @@ async fn bfs_at_timestamp_expired_intermediate_blocks() {
     let a = gs
         .upsert_entity("EI_A", "EI_A", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("EI_B", "EI_B", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let c = gs
         .upsert_entity("EI_C", "EI_C", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     // A->B: expired in 2022.
     sqlx::query(sql!(
@@ -2421,7 +2549,7 @@ async fn bfs_at_timestamp_expired_intermediate_blocks() {
         .bfs_at_timestamp(a, 3, "2025-01-01 00:00:00")
         .await
         .unwrap();
-    let entity_ids: Vec<i64> = entities.iter().map(|e| e.id).collect();
+    let entity_ids: Vec<i64> = entities.iter().map(|e| e.id.0).collect();
     assert!(
         !depth_map.contains_key(&b),
         "B must not be reachable (A->B expired)"
@@ -2438,7 +2566,8 @@ async fn bfs_at_timestamp_disconnected_entity() {
     let a = gs
         .upsert_entity("DC_A", "DC_A", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let (_entities, edges, depth_map) = gs
         .bfs_at_timestamp(a, 3, "2025-01-01 00:00:00")
@@ -2455,11 +2584,13 @@ async fn bfs_at_timestamp_reverse_direction() {
     let a = gs
         .upsert_entity("RD_A", "RD_A", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("RD_B", "RD_B", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     // B -> A (B is source, A is target).
     sqlx::query(sql!(
@@ -2477,7 +2608,7 @@ async fn bfs_at_timestamp_reverse_direction() {
         .bfs_at_timestamp(a, 1, "2099-01-01 00:00:00")
         .await
         .unwrap();
-    let entity_ids: Vec<i64> = entities.iter().map(|e| e.id).collect();
+    let entity_ids: Vec<i64> = entities.iter().map(|e| e.id.0).collect();
     assert!(
         depth_map.contains_key(&b),
         "B must be reachable when BFS traverses reverse direction"
@@ -2497,11 +2628,13 @@ async fn bfs_at_timestamp_valid_to_boundary() {
     let a = gs
         .upsert_entity("VTB_A", "VTB_A", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("VTB_B", "VTB_B", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     // A->B: valid_to = "2025-06-01 00:00:00" (exactly).
     sqlx::query(sql!(
@@ -2546,11 +2679,13 @@ async fn insert_edge_typed_stores_edge_type() {
     let a = gs
         .upsert_entity("A", "A", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("B", "B", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let eid = gs
         .insert_edge_typed(a, b, "caused", "A caused B", 0.9, None, EdgeType::Causal)
         .await
@@ -2572,11 +2707,13 @@ async fn insert_edge_defaults_to_semantic() {
     let a = gs
         .upsert_entity("A2", "A2", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("B2", "B2", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let eid = gs
         .insert_edge(a, b, "uses", "A2 uses B2", 0.8, None)
         .await
@@ -2599,11 +2736,13 @@ async fn insert_edge_typed_dedup_key_includes_edge_type() {
     let a = gs
         .upsert_entity("X", "X", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("Y", "Y", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let id_semantic = gs
         .insert_edge_typed(
@@ -2652,11 +2791,13 @@ async fn insert_edge_typed_deduplicates_same_type() {
     let a = gs
         .upsert_entity("P", "P", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("Q", "Q", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let id1 = gs
         .insert_edge_typed(
@@ -2695,11 +2836,13 @@ async fn edges_for_entity_includes_edge_type() {
     let a = gs
         .upsert_entity("EA", "EA", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("EB", "EB", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     gs.insert_edge_typed(
         a,
         b,
@@ -2723,11 +2866,13 @@ async fn bfs_typed_empty_types_behaves_like_bfs_with_depth() {
     let a = gs
         .upsert_entity("T_A", "T_A", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("T_B", "T_B", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     gs.insert_edge_typed(
         a,
         b,
@@ -2755,15 +2900,18 @@ async fn bfs_typed_filters_by_edge_type() {
     let a = gs
         .upsert_entity("BT_A", "BT_A", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("BT_B", "BT_B", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let c = gs
         .upsert_entity("BT_C", "BT_C", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     // A->B: semantic edge
     gs.insert_edge_typed(a, b, "knows", "A knows B", 0.9, None, EdgeType::Semantic)
@@ -2812,11 +2960,13 @@ async fn bfs_typed_entity_type_filter() {
     let a = gs
         .upsert_entity("E_A", "E_A", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = gs
         .upsert_entity("E_B", "E_B", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     gs.insert_edge_typed(a, b, "is_a", "E_A is_a E_B", 1.0, None, EdgeType::Entity)
         .await
@@ -2854,7 +3004,8 @@ async fn fts5_cross_session_visibility_after_checkpoint() {
         let gs_a = GraphStore::new(store_a.pool().clone());
         gs_a.upsert_entity("Rust", "rust", EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         gs_a.checkpoint_wal().await.unwrap();
     }
 
@@ -2876,11 +3027,13 @@ async fn record_edge_retrieval_increments_count() {
     let a = store
         .upsert_entity("A", "a", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = store
         .upsert_entity("B", "b", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let edge_id: i64 = sqlx::query_scalar(
         sql!("INSERT INTO graph_edges (source_entity_id, target_entity_id, relation, fact, confidence, valid_from)
          VALUES (?1, ?2, 'knows', 'A knows B', 0.9, CURRENT_TIMESTAMP)
@@ -2934,11 +3087,13 @@ async fn record_edge_retrieval_sets_last_retrieved_at() {
     let a = store
         .upsert_entity("A", "a", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = store
         .upsert_entity("B", "b", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let edge_id: i64 = sqlx::query_scalar(
         sql!("INSERT INTO graph_edges (source_entity_id, target_entity_id, relation, fact, confidence, valid_from)
          VALUES (?1, ?2, 'knows', 'A knows B', 0.9, CURRENT_TIMESTAMP)
@@ -2992,11 +3147,13 @@ async fn decay_edge_retrieval_counts_reduces_count() {
     let a = store
         .upsert_entity("A", "a", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = store
         .upsert_entity("B", "b", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     // Insert edge with retrieval_count=10 and last_retrieved_at far in the past
     sqlx::query(sql!(
         "INSERT INTO graph_edges (source_entity_id, target_entity_id, relation, fact, confidence,
@@ -3033,11 +3190,13 @@ async fn decay_edge_retrieval_counts_skips_zero_count_edges() {
     let a = store
         .upsert_entity("A", "a", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = store
         .upsert_entity("B", "b", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     // Edge with retrieval_count=0 (default) — must not be updated
     store
         .insert_edge(a, b, "knows", "A knows B", 0.9, None)
@@ -3054,11 +3213,13 @@ async fn decay_edge_retrieval_counts_respects_interval() {
     let a = store
         .upsert_entity("A", "a", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = store
         .upsert_entity("B", "b", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     // Edge retrieved just now (last_retrieved_at = current time)
     let epoch_now = <zeph_db::ActiveDialect as zeph_db::dialect::Dialect>::EPOCH_NOW;
     let insert_raw = format!(
@@ -3090,11 +3251,13 @@ async fn entity_structural_scores_formula_hub_leaf() {
     let hub = store
         .upsert_entity("Hub", "hub", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let leaf = store
         .upsert_entity("Leaf", "leaf", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     // Hub has 1 edge; leaf has 1 edge (same edge, both as source/target)
     store
         .insert_edge(hub, leaf, "has", "Hub has Leaf", 0.9, None)
@@ -3123,7 +3286,8 @@ async fn entity_structural_scores_isolated_entity_gets_zero() {
     let isolated = store
         .upsert_entity("Isolated", "isolated", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let structural_scores = store.entity_structural_scores(&[isolated]).await.unwrap();
 
@@ -3140,7 +3304,8 @@ async fn entity_structural_scores_hub_higher_than_leaf() {
     let hub = store
         .upsert_entity("Hub2", "hub2", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     // Connect 5 leaves to hub — hub has degree 5, each leaf has degree 1
     for i in 0..5 {
         let leaf = store
@@ -3151,7 +3316,8 @@ async fn entity_structural_scores_hub_higher_than_leaf() {
                 None,
             )
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         store
             .insert_edge(hub, leaf, "has", &format!("Hub2 has SmLeaf{i}"), 0.9, None)
             .await
@@ -3184,7 +3350,8 @@ async fn find_entities_ranked_returns_scores_in_0_1() {
     store
         .upsert_entity("Rust", "rust", EntityType::Language, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     store
         .upsert_entity("RustLang", "rustlang", EntityType::Language, None)
         .await
@@ -3211,7 +3378,8 @@ async fn find_entities_ranked_empty_query_returns_empty() {
     store
         .upsert_entity("Rust", "rust", EntityType::Language, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let results = store.find_entities_ranked("", 10).await.unwrap();
     assert!(results.is_empty(), "empty query must return no results");
@@ -3223,7 +3391,8 @@ async fn find_entities_ranked_top_match_has_highest_score() {
     store
         .upsert_entity("Rust", "rust", EntityType::Language, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     store
         .upsert_entity("Python", "python", EntityType::Language, None)
         .await
@@ -3254,15 +3423,18 @@ async fn entity_community_ids_returns_correct_mapping() {
     let a = store
         .upsert_entity("A", "a", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b = store
         .upsert_entity("B", "b", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let c = store
         .upsert_entity("C", "c", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     // Insert community with a and b as members
     sqlx::query(sql!(
@@ -3309,7 +3481,8 @@ async fn insert_edge_typed_rejects_self_loop() {
     let id = gs
         .upsert_entity("Solo", "Solo", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let err = gs
         .insert_edge_typed(
@@ -3352,11 +3525,13 @@ async fn pool_isolation_independent_pools_do_not_starve() {
     let alice = gs_a
         .upsert_entity("Alice", "alice", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let bob = gs_a
         .upsert_entity("Bob", "bob", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     gs_a.insert_edge(alice, bob, "knows", "Alice knows Bob", 0.9, None)
         .await
         .unwrap();
@@ -3452,7 +3627,8 @@ async fn link_entity_to_episode_and_query() {
     let entity_id = gs
         .upsert_entity("Rust", "rust", EntityType::Language, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let ep_id = gs.ensure_episode(conv_id).await.unwrap();
     gs.link_entity_to_episode(ep_id, entity_id).await.unwrap();
 
@@ -3469,7 +3645,8 @@ async fn link_entity_to_episode_idempotent() {
     let entity_id = gs
         .upsert_entity("Tokio", "tokio", EntityType::Tool, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let ep_id = gs.ensure_episode(conv_id).await.unwrap();
     gs.link_entity_to_episode(ep_id, entity_id).await.unwrap();
     // Second call must not error (ON CONFLICT DO NOTHING).
@@ -3491,7 +3668,8 @@ async fn entity_in_multiple_episodes() {
     let entity_id = gs
         .upsert_entity("Cargo", "cargo", EntityType::Tool, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let ep1 = gs.ensure_episode(c1).await.unwrap();
     let ep2 = gs.ensure_episode(c2).await.unwrap();
     gs.link_entity_to_episode(ep1, entity_id).await.unwrap();
@@ -3510,7 +3688,8 @@ async fn episodes_for_entity_returns_empty_when_no_links() {
     let entity_id = gs
         .upsert_entity("Clippy", "clippy", EntityType::Tool, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let episodes = gs.episodes_for_entity(entity_id).await.unwrap();
     assert!(episodes.is_empty());
 }
@@ -3584,15 +3763,18 @@ async fn insert_or_supersede_sets_supersedes_pointer_and_invalidates_prior() {
     let src = gs
         .upsert_entity("Alice", "Alice", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt1 = gs
         .upsert_entity("Acme", "Acme", EntityType::Organization, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt2 = gs
         .upsert_entity("Globex", "Globex", EntityType::Organization, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let old_id = gs
         .insert_or_supersede(
@@ -3657,11 +3839,13 @@ async fn insert_or_supersede_reassertion_goes_to_reassertions_table() {
     let src = gs
         .upsert_entity("Bob", "Bob", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt = gs
         .upsert_entity("TechCorp", "TechCorp", EntityType::Organization, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let first_id = gs
         .insert_or_supersede(
@@ -3726,19 +3910,23 @@ async fn insert_or_supersede_only_one_active_head_after_supersession() {
     let src = gs
         .upsert_entity("Carol", "Carol", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt_a = gs
         .upsert_entity("OldCo", "OldCo", EntityType::Organization, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt_b = gs
         .upsert_entity("NewCo", "NewCo", EntityType::Organization, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt_c = gs
         .upsert_entity("FinalCo", "FinalCo", EntityType::Organization, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     gs.insert_or_supersede(
         src,
@@ -3807,11 +3995,13 @@ async fn check_supersede_depth_returns_zero_for_root_edge() {
     let src = gs
         .upsert_entity("Dave", "Dave", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt = gs
         .upsert_entity("Solo", "Solo", EntityType::Organization, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let edge_id = gs
         .insert_or_supersede(
@@ -3842,11 +4032,13 @@ async fn insert_or_supersede_same_tuple_no_unique_index_violation() {
     let src = gs
         .upsert_entity("Eve", "Eve", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt = gs
         .upsert_entity("SameCo", "SameCo", EntityType::Organization, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let first_id = gs
         .insert_or_supersede(
@@ -3935,11 +4127,13 @@ async fn test_insert_edge_default_weight_is_one() {
     let src = gs
         .upsert_entity("A", "A", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt = gs
         .upsert_entity("B", "B", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let eid = gs
         .insert_edge(src, tgt, "knows", "A knows B", 0.9, None)
         .await
@@ -3962,11 +4156,13 @@ async fn test_edge_weight_persists_after_update() {
     let src = gs
         .upsert_entity("C", "C", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt = gs
         .upsert_entity("D", "D", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let eid = gs
         .insert_edge(src, tgt, "likes", "C likes D", 0.8, None)
         .await
@@ -4001,11 +4197,13 @@ async fn test_apply_hebbian_increment_zero_delta_is_noop() {
     let src = gs
         .upsert_entity("E", "E", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt = gs
         .upsert_entity("F", "F", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let eid = gs
         .insert_edge(src, tgt, "rel", "fact", 0.5, None)
         .await
@@ -4030,11 +4228,13 @@ async fn test_apply_hebbian_increment_updates_weight() {
     let src = gs
         .upsert_entity("G", "G", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt = gs
         .upsert_entity("H", "H", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let eid = gs
         .insert_edge(src, tgt, "rel", "fact", 0.7, None)
         .await
@@ -4059,11 +4259,13 @@ async fn test_apply_hebbian_increment_skips_invalidated_edges() {
     let src = gs
         .upsert_entity("I", "I", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt = gs
         .upsert_entity("J", "J", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let eid = gs
         .insert_edge(src, tgt, "rel", "fact", 0.6, None)
         .await
@@ -4101,11 +4303,13 @@ async fn source_message_ids_for_edges_returns_rows_with_episode_id() {
     let src = gs
         .upsert_entity("A", "A", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt = gs
         .upsert_entity("B", "B", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     // Insert edge without episode_id, then backfill directly to avoid FK cascade through
     // conversations → messages tables in the in-memory test DB.
     let eid = gs
@@ -4141,11 +4345,13 @@ async fn source_message_ids_for_edges_skips_null_episode_id() {
     let src = gs
         .upsert_entity("X", "X", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt = gs
         .upsert_entity("Y", "Y", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     // Insert with no episode_id (None).
     let eid = gs
         .insert_edge(src, tgt, "uses", "X uses Y", 0.7, None)
@@ -4165,11 +4371,13 @@ async fn source_entity_id_for_edge_returns_correct_id() {
     let src = gs
         .upsert_entity("Src", "Src", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tgt = gs
         .upsert_entity("Tgt", "Tgt", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let eid = gs
         .insert_edge(src, tgt, "rel", "Src rel Tgt", 0.9, None)
         .await
@@ -4192,11 +4400,13 @@ async fn bfs_edges_at_depth_returns_neighbors() {
     let center = gs
         .upsert_entity("Center", "Center", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let neighbor = gs
         .upsert_entity("Neighbor", "Neighbor", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     gs.insert_edge(
         center,
         neighbor,
@@ -4228,7 +4438,8 @@ async fn bfs_edges_at_depth_empty_when_no_edges() {
     let entity = gs
         .upsert_entity("Isolated", "Isolated", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let facts = gs
         .bfs_edges_at_depth(entity, 1, &[EdgeType::Semantic])

--- a/crates/zeph-memory/src/graph/types.rs
+++ b/crates/zeph-memory/src/graph/types.rs
@@ -6,7 +6,7 @@
 use std::fmt;
 use std::str::FromStr;
 
-use crate::types::MessageId;
+use crate::types::{EntityId, MessageId};
 
 /// MAGMA edge type: the semantic category of a relationship between two entities.
 ///
@@ -84,7 +84,7 @@ impl FromStr for EntityType {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Entity {
     /// `SQLite` row ID.
-    pub id: i64,
+    pub id: EntityId,
     /// Raw extracted name as it appeared in the source text.
     pub name: String,
     /// Normalized canonical name (lowercase, de-aliased).
@@ -107,7 +107,7 @@ pub struct EntityAlias {
     /// `SQLite` row ID.
     pub id: i64,
     /// The entity this alias resolves to.
-    pub entity_id: i64,
+    pub entity_id: EntityId,
     /// The alternate name string.
     pub alias_name: String,
     /// ISO 8601 timestamp when the alias was recorded.
@@ -201,7 +201,7 @@ pub struct Community {
     /// LLM-generated summary of what the community's entities share.
     pub summary: String,
     /// IDs of all entities assigned to this community.
-    pub entity_ids: Vec<i64>,
+    pub entity_ids: Vec<EntityId>,
     /// Content fingerprint used to detect stale communities after membership changes.
     pub fingerprint: Option<String>,
     /// ISO 8601 timestamp when the community was detected.

--- a/crates/zeph-memory/src/lib.rs
+++ b/crates/zeph-memory/src/lib.rs
@@ -55,6 +55,7 @@
 //! - [`tiers::start_tier_promotion_loop`] — Episodic → Semantic promotion.
 //! - [`semantic::start_tree_consolidation_loop`] — hierarchical note consolidation.
 //! - [`hebbian_consolidation::spawn_consolidation_loop`] — HL-F3/F4 cluster distillation.
+//! - [`episodic_consolidation::start_episodic_consolidation_loop`] — episodic → semantic fact extraction.
 //!
 //! # Feature flags
 //!
@@ -71,6 +72,7 @@ pub mod compression;
 pub mod compression_guidelines;
 pub mod consolidation;
 pub mod document;
+pub mod episodic_consolidation;
 pub mod episodic_graph;
 pub mod facade;
 pub mod forgetting;
@@ -136,6 +138,10 @@ pub use embedding_registry::{
     EmbedFuture, Embeddable, EmbeddingRegistry, EmbeddingRegistryError, SyncStats,
 };
 pub use embedding_store::ensure_qdrant_collection;
+pub use episodic_consolidation::{
+    EpisodicConsolidationConfig, EpisodicConsolidationResult, run_episodic_consolidation_sweep,
+    start_episodic_consolidation_loop,
+};
 pub use episodic_graph::{
     CausalLink, EmGraphConfig, EpisodicEvent, extract_events, fetch_recent_events, link_events,
     recall_episodic_causal, store_events, store_links,
@@ -204,7 +210,7 @@ pub use tiered_retrieval::{
 pub use tiers::{TierPromotionConfig, start_tier_promotion_loop};
 pub use token_counter::TokenCounter;
 pub use tokio_util::sync::CancellationToken;
-pub use types::{ConversationId, MemSceneId, MemoryTier, MessageId};
+pub use types::{ConversationId, EntityId, ExperienceId, MemSceneId, MemoryTier, MessageId};
 pub use vector_store::{
     FieldCondition, FieldValue, ScoredVectorPoint, VectorFilter, VectorPoint, VectorStore,
     VectorStoreError,

--- a/crates/zeph-memory/src/quality_gate.rs
+++ b/crates/zeph-memory/src/quality_gate.rs
@@ -489,7 +489,7 @@ async fn compute_contradiction_risk(
     let canonical_predicate = extract_predicate_token(&content_lower);
 
     // Load all active edges where this entity is the source.
-    let Ok(edges) = store.edges_for_entity(subject_entity.id).await else {
+    let Ok(edges) = store.edges_for_entity(subject_entity.id.0).await else {
         return 0.0;
     };
 
@@ -497,7 +497,7 @@ async fn compute_contradiction_risk(
     let relevant_edges: Vec<_> = edges
         .iter()
         .filter(|e| {
-            e.source_entity_id == subject_entity.id
+            e.source_entity_id == subject_entity.id.0
                 && canonical_predicate
                     .as_ref()
                     .is_none_or(|p| e.relation == *p)

--- a/crates/zeph-memory/src/semantic/graph.rs
+++ b/crates/zeph-memory/src/semantic/graph.rs
@@ -1096,13 +1096,15 @@ mod tests {
             .await
             .unwrap()
             .expect("entity 'alice' must exist")
-            .id;
+            .id
+            .0;
         let bob_id = gs
             .find_entity("bob", crate::graph::EntityType::Person)
             .await
             .unwrap()
             .expect("entity 'bob' must exist")
-            .id;
+            .id
+            .0;
         let edges = gs.edges_exact(alice_id, bob_id).await.unwrap();
         assert_eq!(edges.len(), 1, "exactly one edge expected");
         // canonical_relation is lowercased; relation field preserves original casing post-strip

--- a/crates/zeph-memory/src/semantic/tests/graph.rs
+++ b/crates/zeph-memory/src/semantic/tests/graph.rs
@@ -35,11 +35,13 @@ async fn recall_graph_returns_facts_for_known_entity() {
     let rust_id = store
         .upsert_entity("rust", "rust", EntityType::Language, Some("a language"))
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let tokio_id = store
         .upsert_entity("tokio", "tokio", EntityType::Tool, Some("async runtime"))
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     store
         .insert_edge(
             rust_id,
@@ -69,15 +71,18 @@ async fn recall_graph_sorted_by_composite_score() {
     let a_id = store
         .upsert_entity("entity_a", "entity_a", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b_id = store
         .upsert_entity("entity_b", "entity_b", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let c_id = store
         .upsert_entity("entity_c", "entity_c", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     store
         .insert_edge(a_id, b_id, "relates", "a relates b", 0.9, None)
         .await
@@ -166,13 +171,15 @@ async fn recall_graph_truncates_to_limit() {
     let root_id = store
         .upsert_entity("root", "root", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     for i in 0..5 {
         let name = format!("target_{i}");
         let tid = store
             .upsert_entity(&name, &name, EntityType::Concept, None)
             .await
-            .unwrap();
+            .unwrap()
+            .0;
         store
             .insert_edge(
                 root_id,
@@ -201,15 +208,18 @@ async fn recall_graph_multi_hop_traverses_two_hops() {
     let a_id = store
         .upsert_entity("a_entity", "a_entity", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let b_id = store
         .upsert_entity("b_entity", "b_entity", EntityType::Person, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
     let c_id = store
         .upsert_entity("c_entity", "c_entity", EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     store
         .insert_edge(a_id, b_id, "knows", "a knows b", 0.9, None)
@@ -384,7 +394,8 @@ async fn seed_entity_with_zero_embedding(
     let id = store
         .upsert_entity(name, name, EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let point_id = uuid::Uuid::new_v4().to_string();
     let payload = json!({
@@ -434,7 +445,8 @@ async fn seed_entity_no_db_point_id(
     let id = store
         .upsert_entity(name, name, EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let point_id = uuid::Uuid::new_v4().to_string();
     let payload = json!({

--- a/crates/zeph-memory/src/types.rs
+++ b/crates/zeph-memory/src/types.rs
@@ -129,6 +129,76 @@ impl std::fmt::Display for MessageId {
     }
 }
 
+/// Strongly typed wrapper for `experience_nodes.id` row IDs.
+///
+/// Prevents accidental confusion with [`EntityId`], [`ConversationId`], or [`MessageId`]
+/// at experience-memory API boundaries.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_memory::ExperienceId;
+///
+/// let id = ExperienceId(10);
+/// assert_eq!(id.to_string(), "10");
+/// ```
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    sqlx::Type,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+#[sqlx(transparent)]
+pub struct ExperienceId(pub i64);
+
+impl std::fmt::Display for ExperienceId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Strongly typed wrapper for `graph_entities.id` row IDs.
+///
+/// Prevents confusion with [`ExperienceId`] or other integer IDs at graph-store
+/// API boundaries.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_memory::EntityId;
+///
+/// let id = EntityId(5);
+/// assert_eq!(id.to_string(), "5");
+/// ```
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    sqlx::Type,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+#[sqlx(transparent)]
+pub struct EntityId(pub i64);
+
+impl std::fmt::Display for EntityId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -184,5 +254,33 @@ mod tests {
         let id = MessageId(5);
         let copied = id;
         assert_eq!(id, copied);
+    }
+
+    #[test]
+    fn experience_id_display() {
+        let id = ExperienceId(10);
+        assert_eq!(format!("{id}"), "10");
+    }
+
+    #[test]
+    fn entity_id_display() {
+        let id = EntityId(5);
+        assert_eq!(format!("{id}"), "5");
+    }
+
+    #[test]
+    fn experience_id_ord() {
+        assert!(ExperienceId(1) < ExperienceId(2));
+        assert_eq!(ExperienceId(3), ExperienceId(3));
+    }
+
+    #[test]
+    fn entity_id_hash() {
+        use std::collections::HashSet;
+        let mut set = HashSet::new();
+        set.insert(EntityId(1));
+        set.insert(EntityId(2));
+        set.insert(EntityId(1));
+        assert_eq!(set.len(), 2);
     }
 }

--- a/crates/zeph-memory/tests/hela_spreading_activation.rs
+++ b/crates/zeph-memory/tests/hela_spreading_activation.rs
@@ -62,7 +62,8 @@ async fn seed_entity(
     let entity_id = graph
         .upsert_entity(name, name, EntityType::Concept, None)
         .await
-        .unwrap();
+        .unwrap()
+        .0;
 
     let point_id = uuid::Uuid::new_v4().to_string();
     let payload = json!({

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -1356,6 +1356,35 @@ impl AppBuilder {
         }
     }
 
+    /// Build a dedicated provider for episodic-to-semantic consolidation LLM calls (#3799).
+    ///
+    /// Returns `None` when `consolidation_provider` is empty or resolution fails; the caller
+    /// falls back to the primary provider.
+    pub fn build_episodic_consolidation_provider(&self) -> Option<AnyProvider> {
+        let name = &self
+            .config
+            .memory
+            .episodic_consolidation
+            .consolidation_provider;
+        if name.is_empty() {
+            return None;
+        }
+        match create_named_provider(name, &self.config) {
+            Ok(p) => {
+                tracing::info!(provider = %name, "episodic consolidation provider configured");
+                Some(p)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    provider = %name,
+                    error = %e,
+                    "episodic consolidation provider resolution failed — primary provider will be used"
+                );
+                None
+            }
+        }
+    }
+
     /// Build a dedicated provider for orchestration planner LLM calls.
     ///
     /// Returns `None` when `planner_provider` is empty (falls back to primary provider at call site).

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1642,6 +1642,40 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         });
     }
 
+    if config.memory.episodic_consolidation.enabled {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let ep_cfg = zeph_memory::EpisodicConsolidationConfig {
+            enabled: config.memory.episodic_consolidation.enabled,
+            consolidation_provider: config
+                .memory
+                .episodic_consolidation
+                .consolidation_provider
+                .to_string(),
+            interval_secs: config.memory.episodic_consolidation.interval_secs,
+            batch_size: config.memory.episodic_consolidation.batch_size,
+            min_age_secs: config.memory.episodic_consolidation.min_age_secs,
+            dedup_jaccard_threshold: config.memory.episodic_consolidation.dedup_jaccard_threshold,
+        };
+        let ep_provider = app
+            .build_episodic_consolidation_provider()
+            .unwrap_or_else(|| provider.clone());
+        let ep_qdrant = memory.embedding_store().cloned();
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(TaskDescriptor {
+            name: "mem-episodic-consolidation",
+            restart: RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_episodic_consolidation_loop(
+                    store.clone(),
+                    ep_provider.clone(),
+                    ep_cfg.clone(),
+                    ep_qdrant.clone(),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+
     let skill_paths = app.skill_paths_for_registry();
     // Cloned so the original can be moved into `with_skill_reload` while the copy is used
     // later for proactive exploration and promotion engine output directory resolution.


### PR DESCRIPTION
## Summary

- Introduces `ExperienceId(i64)` and `EntityId(i64)` newtypes in `zeph-memory` to eliminate argument-order bugs at `ExperienceStore` call sites (#3795). Zero-cost via `#[sqlx(transparent)]`; `Entity`, `EntityAlias`, `Community`, and `GraphStore::upsert_entity` migrated.
- Implements the MemTier §3.3 async episodic→semantic consolidation daemon (#3799): background tokio task sweeps `episodic_events`, derives cognitive weight from correlated `experience_nodes` outcomes, extracts durable facts via a single LLM batch call, deduplicates via Jaccard similarity, and promotes accepted facts to `consolidated_facts` (SQLite) + `zeph_key_facts` (Qdrant, optional).
- Migration 087 adds `consolidated_at` on `episodic_events`, new `consolidated_facts` + `consolidated_fact_sources` tables, and a `(session_id, created_at)` composite index on `experience_nodes` for the cognitive weight query.
- Daemon is disabled by default (`[memory.episodic_consolidation] enabled = false`); all six async I/O paths instrumented with `tracing::instrument` spans.

## Security / robustness fixes included

- LLM prompt `summary` and `message_content` both truncated to 256 chars (prompt injection mitigation)
- `cognitive_weight` guarded against NaN/Inf before Qdrant write
- LLM-returned `source_event_ids` validated against the candidate set before FK insert
- Empty LLM array marks source events consolidated immediately (prevents unbounded retry)

## Test plan

- [x] `cargo nextest run --workspace --lib --bins` — 9271 passed (+3 new DB-backed tests)
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --features "desktop,ide,server,chat,pdf,scheduler" -- -D warnings` — clean
- [x] `cargo doc --no-deps -p zeph-memory -p zeph-config` — no broken intra-doc links
- [x] `cargo test --doc -p zeph-memory -p zeph-config` — 32 doc-tests pass
- [ ] Live session test with `enabled = true` in `.local/config/testing.toml` — follow-up CI cycle (daemon runs on 30-minute interval; coverage-status row marked Untested)

Closes #3795
Closes #3799