### PR TITLE
fix(channels): move TcpListener::from_std before tokio::spawn in spawn_guest_proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- fix(channels): `spawn_guest_proxy` no longer panics inside a spawned task when
+  `tokio::net::TcpListener::from_std` fails (issue #3809). The conversion is now performed
+  synchronously before `tokio::spawn`, and failure propagates as `ChannelError::Other` via `?`
+  to the caller instead of silently killing the guest proxy listener task.
+
 - fix(scheduler): `tick()` now checks the `in_flight` set before dispatching periodic task
   handlers (issue #3808). Previously only `catch_up_missed()` held the SIGNIFICANT-5 guard,
   allowing concurrent executions of the same periodic task when a handler ran longer than

--- a/crates/zeph-channels/src/telegram.rs
+++ b/crates/zeph-channels/src/telegram.rs
@@ -672,9 +672,11 @@ fn spawn_guest_proxy(
         .route("/{*path}", any(proxy_handler))
         .with_state(state);
 
+    let listener = tokio::net::TcpListener::from_std(listener).map_err(|e| {
+        ChannelError::Other(format!("guest proxy: TcpListener conversion failed: {e}"))
+    })?;
+
     let handle = tokio::spawn(async move {
-        let listener = tokio::net::TcpListener::from_std(listener)
-            .expect("guest proxy: TcpListener conversion failed");
         if let Err(e) = axum::serve(listener, app).await {
             tracing::warn!("guest proxy axum serve error: {e}");
         }


### PR DESCRIPTION
## Summary

- Moves `tokio::net::TcpListener::from_std(listener)` before `tokio::spawn` in `spawn_guest_proxy()` (`crates/zeph-channels/src/telegram.rs`)
- Replaces `.expect("guest proxy: TcpListener conversion failed")` with `.map_err(|e| ChannelError::Other(...))?`
- Failure now propagates cleanly to the caller instead of silently panicking inside a spawned task

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --features desktop,ide,server,chat,pdf,scheduler -- -D warnings` — zero warnings
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 9274 tests pass
- [x] CHANGELOG.md updated in `[Unreleased]`

Closes #3809