### PR TITLE
docs(llm): document LlmProvider object-safety and dyn dispatch path via LlmProviderDyn

### DIFF
--- a/crates/zeph-llm/src/any.rs
+++ b/crates/zeph-llm/src/any.rs
@@ -1,29 +1,24 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-// TODO(arch-revised-2026-04-26): Full AnyProvider→Arc<dyn LlmProviderDyn> migration
-// spans 883 call sites and is deferred to epic/m49+/anyprovider-deprecation.
-// PR 7a (LlmProviderDyn adapter, no call-site changes) and PR 7b (router/cascade
-// only) land in m48; remaining ~880 sites are per-feature-area follow-ups requiring
-// /specs/<area>/llm-dyn-migration.md. See arch-assessment-revised-2026-04-26T02-04-23.md.
-
 //! Type-erased provider enum wrapping all concrete backends.
 //!
 //! [`AnyProvider`] lets callers hold and clone any backend without generics or
-//! `Box<dyn LlmProvider>`. The macro `delegate_provider!` generates the
+//! heap allocation. The macro `delegate_provider!` generates the
 //! match-over-variants boilerplate for every [`LlmProvider`] method delegation.
 //!
-//! # TODO (D1 — deferred: make `LlmProvider` object-safe, replace `AnyProvider` enum)
+//! # Dynamic dispatch
 //!
-//! `LlmProvider` is not object-safe today because of the `chat_typed<T: DeserializeOwned>` and
-//! `embed_batch` methods. The goal is to make it object-safe so the enum can be replaced by
-//! `Arc<dyn LlmProvider + Send + Sync>`, eliminating the need to patch this crate when adding a
-//! new provider backend.
+//! `LlmProvider` is not object-safe (RPIT returns + generic `chat_typed<T>`), so
+//! `Box<dyn LlmProvider>` / `Arc<dyn LlmProvider + Send + Sync>` do not compile.
+//! The object-safe shadow [`crate::provider_dyn::LlmProviderDyn`] is the current
+//! solution; use `Arc<dyn LlmProviderDyn>` wherever dynamic dispatch is required.
 //!
-//! **Blocked by:** full enumeration of `AnyProvider` match sites (router, cascade fallback,
-//! `chat_typed` callers), migration plan for structured-output extraction, and a streaming
-//! throughput benchmark gate. See critic review `.local/handoff/critic-review.md` §C3.
-//! Each step must be a separate PR; do NOT bundle with other refactors.
+//! # TODO (D1 — deferred: migrate call sites from `AnyProvider` to `Arc<dyn LlmProviderDyn>`)
+//!
+//! `LlmProviderDyn` already exists and works. The remaining work is call-site migration
+//! (~880 sites) across feature areas (epic/m49+/anyprovider-deprecation).
+//! Each area must be a separate PR; do NOT bundle.
 
 #[cfg(feature = "candle")]
 use crate::candle_provider::CandleProvider;
@@ -76,8 +71,9 @@ macro_rules! delegate_provider {
 ///
 /// All variants implement [`LlmProvider`] — `AnyProvider` delegates every trait method
 /// to its inner variant via the `delegate_provider!` macro. This avoids heap allocation
-/// (`Box<dyn LlmProvider>`) while retaining the ability to hold multiple provider types
-/// in a `Vec` or struct field.
+/// while retaining the ability to hold multiple provider types in a `Vec` or struct field.
+/// For dynamic dispatch across an unknown set of backends, prefer
+/// [`Arc<dyn LlmProviderDyn>`](crate::provider_dyn::LlmProviderDyn).
 ///
 /// The `Candle` variant is only available when the `candle` feature is enabled.
 #[derive(Debug, Clone)]

--- a/crates/zeph-llm/src/lib.rs
+++ b/crates/zeph-llm/src/lib.rs
@@ -19,6 +19,10 @@
 //! - [`LlmProvider::chat_with_tools`] — structured tool-call protocol
 //! - [`LlmProvider::chat_typed`] — schema-driven structured JSON extraction
 //!
+//! `LlmProvider` is not object-safe (RPIT returns + generic `chat_typed`).
+//! For dynamic dispatch use [`LlmProviderDyn`] via `Arc<dyn LlmProviderDyn>` —
+//! see the [`provider_dyn`] module.
+//!
 //! # Backends
 //!
 //! | Module | Backend | Feature flag |

--- a/crates/zeph-llm/src/provider.rs
+++ b/crates/zeph-llm/src/provider.rs
@@ -667,6 +667,18 @@ impl Message {
 /// hold any backend behind a single type, and [`crate::router::RouterProvider`]
 /// implements this trait to multiplex across multiple backends.
 ///
+/// # Object safety
+///
+/// This trait is **not** object-safe: 6 methods return `impl Future + Send` (RPIT),
+/// and [`chat_typed`](Self::chat_typed) carries a generic type parameter `T`.
+/// The `where Self: Sized` bound on `chat_typed` is a mitigation — it excludes that
+/// method from the vtable — but the RPIT methods remain and prevent `dyn LlmProvider`.
+/// Attempting `Box<dyn LlmProvider>` will produce a compile error.
+///
+/// For dynamic dispatch, use [`Arc<dyn LlmProviderDyn>`](crate::provider_dyn::LlmProviderDyn)
+/// instead — a blanket impl wires every `LlmProvider` implementor automatically.
+/// See the [`provider_dyn`](crate::provider_dyn) module for details.
+///
 /// # Required methods
 ///
 /// Implementors must provide: [`chat`](Self::chat), [`chat_stream`](Self::chat_stream),
@@ -680,6 +692,8 @@ impl Message {
 /// - [`embed_batch`](Self::embed_batch) — sequential fallback via [`embed`](Self::embed)
 /// - [`chat_with_tools`](Self::chat_with_tools) — falls back to [`chat`](Self::chat)
 /// - [`chat_typed`](Self::chat_typed) — schema-prompt injection + retry
+///   (requires `Self: Sized`; use [`chat_typed_dyn`](crate::provider_dyn::chat_typed_dyn)
+///   for trait objects)
 /// - [`supports_vision`](Self::supports_vision) — returns `false`
 /// - [`supports_tool_use`](Self::supports_tool_use) — returns `true`
 ///
@@ -878,6 +892,12 @@ pub trait LlmProvider: Send + Sync {
     ///
     /// Default implementation injects JSON schema into the system prompt and retries once
     /// on parse failure. Providers with native structured output should override this.
+    ///
+    /// # Object safety
+    ///
+    /// This method requires `Self: Sized` and is therefore unavailable on trait objects.
+    /// Use [`chat_typed_dyn`](crate::provider_dyn::chat_typed_dyn) when working with
+    /// `Arc<dyn LlmProviderDyn>`.
     #[allow(async_fn_in_trait)]
     async fn chat_typed<T>(&self, messages: &[Message]) -> Result<T, LlmError>
     where


### PR DESCRIPTION
## Summary

- Add `# Object safety` section to `LlmProvider` trait doc explaining the trait is not object-safe due to 6 RPIT-returning methods; `where Self: Sized` on `chat_typed` is a mitigation (vtable opt-out), not a cause
- Add per-method object-safety note to `chat_typed` pointing to `chat_typed_dyn` for trait objects
- Add crate-level note in `lib.rs` directing users to `LlmProviderDyn` / `Arc<dyn LlmProviderDyn>`
- Update `any.rs`: remove stale goal of making `LlmProvider` object-safe (replaced by `LlmProviderDyn`), remove broken handoff file reference, remove invisible duplicate TODO plain-comment block

## Test plan

- [ ] `cargo test --doc -p zeph-llm` — 12 doc-tests pass
- [ ] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-llm` — 0 warnings, 0 errors
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo nextest run --workspace --lib --bins` — 9274 tests pass

Closes #3805