### PR TITLE
fix(llm): add judge_timeout_ms to prevent cascade classifier blocking indefinitely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-llm`: add `judge_timeout_ms` field to `CascadeRouterConfig` (default 5 s) and wrap
+  `judge.chat()` in `tokio::time::timeout` inside `judge_score`; on timeout the call is
+  treated as a failure and heuristic scoring is used as fallback, preventing indefinite
+  blocking of the cascade routing loop (closes #3838).
+
 - fix(channels): `spawn_guest_proxy` no longer panics inside a spawned task when
   `tokio::net::TcpListener::from_std` fails (issue #3809). The conversion is now performed
   synchronously before `tokio::spawn`, and failure propagates as `ChannelError::Other` via `?`

--- a/config/default.toml
+++ b/config/default.toml
@@ -22,6 +22,18 @@ max_tool_iterations = 10
 # Routing strategy for multi-provider configs: "none" (default), "ema", "thompson", "cascade", "task", "bandit"
 # routing = "none"
 
+# ── Cascade routing ───────────────────────────────────────────────────────────
+# Set routing = "cascade" to enable escalating provider chain.
+# Cheap provider is tried first; escalates on degenerate output.
+#
+# [llm.router.cascade]
+# quality_threshold = 0.5      # minimum score [0.0, 1.0] to accept without escalating
+# max_escalations = 2          # max quality-based escalations per request
+# classifier_mode = "heuristic" # "heuristic" (default) or "judge"
+# judge_timeout_ms = 5000      # hard timeout for judge LLM call (ms); fallback on exceeded
+# window_size = 50             # rolling quality history window per provider
+# # cost_tiers = ["cheap", "mid", "expensive"]  # explicit cost ordering
+
 # ── PILOT bandit routing ──────────────────────────────────────────────────────
 # Set routing = "bandit" to enable LinUCB contextual bandit provider selection.
 # The bandit learns which provider performs best for each query context using

--- a/crates/zeph-config/src/providers.rs
+++ b/crates/zeph-config/src/providers.rs
@@ -274,6 +274,10 @@ fn default_cascade_window_size() -> usize {
     50
 }
 
+fn default_cascade_judge_timeout_ms() -> u64 {
+    5_000
+}
+
 fn default_reputation_decay_factor() -> f64 {
     0.95
 }
@@ -892,6 +896,12 @@ pub struct CascadeConfig {
     /// original chain order. When unset, chain order is used (default behavior).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cost_tiers: Option<Vec<String>>,
+
+    /// Hard timeout for the judge LLM call (milliseconds).
+    /// If the judge does not respond within this budget, the call is treated as a failure
+    /// and heuristic scoring is used instead. Default: 5000 (5 s).
+    #[serde(default = "default_cascade_judge_timeout_ms")]
+    pub judge_timeout_ms: u64,
 }
 
 impl Default for CascadeConfig {
@@ -903,6 +913,7 @@ impl Default for CascadeConfig {
             window_size: default_cascade_window_size(),
             max_cascade_tokens: None,
             cost_tiers: None,
+            judge_timeout_ms: default_cascade_judge_timeout_ms(),
         }
     }
 }

--- a/crates/zeph-llm/src/router/cascade.rs
+++ b/crates/zeph-llm/src/router/cascade.rs
@@ -282,15 +282,35 @@ fn build_judge_prompt(response: &str) -> String {
 /// Sends a single-turn prompt to `judge` asking it to rate `response` on a 0–10 scale.
 /// Normalises the result to [0.0, 1.0].
 ///
-/// Returns `None` on any error (network, parse, etc.); callers must fall back to heuristic.
+/// The call is bounded by `timeout`; if the judge does not respond in time, `None` is
+/// returned and the caller must fall back to heuristic scoring.
+///
+/// Returns `None` on any error (network, parse, timeout, etc.); callers must fall back to heuristic.
 ///
 /// # Errors
 ///
-/// Any `LlmError` from the judge call is swallowed and represented as `None`.
-pub async fn judge_score(judge: &dyn LlmProviderDyn, response: &str) -> Option<f64> {
+/// Any `LlmError` from the judge call or a timeout is swallowed and represented as `None`.
+pub async fn judge_score(
+    judge: &dyn LlmProviderDyn,
+    response: &str,
+    timeout: std::time::Duration,
+) -> Option<f64> {
     let prompt = build_judge_prompt(response);
     let messages = vec![Message::from_legacy(Role::User, prompt)];
-    let reply = judge.chat(&messages).await.ok()?;
+    let reply = match tokio::time::timeout(timeout, judge.chat(&messages)).await {
+        Ok(Ok(r)) => r,
+        Ok(Err(e)) => {
+            tracing::debug!(error = %e, "cascade: judge call failed");
+            return None;
+        }
+        Err(_) => {
+            tracing::warn!(
+                timeout_ms = timeout.as_millis(),
+                "cascade: judge call timed out, falling back to heuristic"
+            );
+            return None;
+        }
+    };
     parse_judge_score(&reply)
 }
 
@@ -578,5 +598,19 @@ mod tests {
             response_pos < end_pos,
             "response must appear before closing fence"
         );
+    }
+
+    #[tokio::test]
+    async fn judge_score_times_out_returns_none() {
+        use crate::mock::MockProvider;
+        use crate::provider_dyn::LlmProviderDyn;
+        use std::sync::Arc;
+
+        // Provider sleeps 2 s; timeout is 50 ms — must return None without blocking.
+        let provider: Arc<dyn LlmProviderDyn> =
+            Arc::new(MockProvider::with_responses(vec!["7".to_owned()]).with_delay(2_000));
+        let timeout = std::time::Duration::from_millis(50);
+        let result = judge_score(provider.as_ref(), "some response", timeout).await;
+        assert!(result.is_none(), "expected None on timeout, got {result:?}");
     }
 }

--- a/crates/zeph-llm/src/router/mod.rs
+++ b/crates/zeph-llm/src/router/mod.rs
@@ -243,6 +243,8 @@ pub struct CascadeRouterConfig {
     /// When set, providers are sorted by their position in this list at construction time.
     /// Providers not listed are appended after listed ones in original chain order.
     pub cost_tiers: Option<Vec<String>>,
+    /// Hard timeout for the judge LLM call (milliseconds). Default: 5000.
+    pub judge_timeout_ms: u64,
 }
 
 impl Default for CascadeRouterConfig {
@@ -255,6 +257,7 @@ impl Default for CascadeRouterConfig {
             max_cascade_tokens: None,
             summary_provider: None,
             cost_tiers: None,
+            judge_timeout_ms: 5_000,
         }
     }
 }
@@ -1286,16 +1289,23 @@ impl RouterProvider {
     /// Evaluate quality using the configured classifier mode.
     ///
     /// For `ClassifierMode::Judge`, calls the summary provider and falls back to heuristic
-    /// on any error. For `ClassifierMode::Heuristic`, evaluates synchronously.
+    /// on any error or timeout. For `ClassifierMode::Heuristic`, evaluates synchronously.
     async fn evaluate_quality(
         response: &str,
         threshold: f64,
         mode: ClassifierMode,
         summary_provider: Option<&dyn crate::provider_dyn::LlmProviderDyn>,
+        judge_timeout_ms: u64,
     ) -> cascade::QualityVerdict {
         if mode == ClassifierMode::Judge {
             if let Some(judge) = summary_provider {
-                match cascade::judge_score(judge, response).await {
+                match cascade::judge_score(
+                    judge,
+                    response,
+                    std::time::Duration::from_millis(judge_timeout_ms),
+                )
+                .await
+                {
                     Some(score) => {
                         let should_escalate = score < threshold;
                         tracing::debug!(
@@ -2082,6 +2092,7 @@ async fn cascade_evaluate_response(
         cfg.quality_threshold,
         cfg.classifier_mode,
         cfg.summary_provider.as_deref(),
+        cfg.judge_timeout_ms,
     )
     .await;
 

--- a/src/bootstrap/provider.rs
+++ b/src/bootstrap/provider.rs
@@ -94,6 +94,7 @@ fn build_cascade_router_config(
         max_cascade_tokens: cascade_cfg.max_cascade_tokens,
         summary_provider,
         cost_tiers: cascade_cfg.cost_tiers.clone(),
+        judge_timeout_ms: cascade_cfg.judge_timeout_ms,
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `judge_timeout_ms: u64` (default 5000 ms) to `CascadeConfig` and `CascadeRouterConfig`
- Wrap `judge.chat()` in `tokio::time::timeout` inside `judge_score`; emit `tracing::warn!` and return `None` on timeout so the caller falls back to the heuristic classifier
- Thread the timeout through `evaluate_quality` → `cascade_evaluate_response` → bootstrap config construction
- Add regression test `judge_score_times_out_returns_none` (2 s delay, 50 ms timeout, asserts `None`)
- Document `judge_timeout_ms` in `config/default.toml`

Pattern mirrors the existing `embedding_timeout_ms` on `BanditConfig`.

## Test plan

- [x] `cargo nextest run -p zeph-llm -E 'test(judge_score)'` — 7/7 pass including new timeout test
- [x] `cargo nextest run --workspace --lib --bins` — 9280 passed, 21 skipped
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean

Closes #3838