### PR TITLE
fix(a2a): add per-request timeouts to server handlers and client HTTP calls

### DIFF
--- a/crates/zeph-a2a/src/client.rs
+++ b/crates/zeph-a2a/src/client.rs
@@ -4,6 +4,7 @@
 //! A2A protocol HTTP client with optional TLS enforcement and SSRF protection.
 
 use std::pin::Pin;
+use std::time::Duration;
 
 use eventsource_stream::Eventsource;
 use futures_core::Stream;
@@ -74,6 +75,14 @@ pub struct A2aClient {
     client: reqwest::Client,
     require_tls: bool,
     ssrf_protection: bool,
+    /// Per-request timeout applied to `rpc_call` (send + JSON parse) and to the initial
+    /// `send()` in `stream_message`. The SSE body stream itself is not bounded — that
+    /// is the caller's responsibility.
+    ///
+    /// If the underlying `reqwest::Client` was also built with `.timeout()`, both limits
+    /// race: whichever fires first wins. `request_timeout` takes semantic priority because
+    /// it maps to `A2aError::Timeout`; the reqwest-level timeout maps to `A2aError::Http`.
+    request_timeout: Duration,
 }
 
 impl A2aClient {
@@ -87,6 +96,7 @@ impl A2aClient {
             client,
             require_tls: false,
             ssrf_protection: false,
+            request_timeout: Duration::from_secs(30),
         }
     }
 
@@ -113,8 +123,20 @@ impl A2aClient {
         self
     }
 
+    /// Set the per-request timeout for RPC and streaming connection calls (default: 30 seconds).
+    ///
+    /// Applied to the full send + JSON response parse in `rpc_call`, and to the initial
+    /// HTTP `send()` in `stream_message`. The SSE body stream after connection is intentionally
+    /// unbounded — streams can legitimately run for a long time.
+    #[must_use]
+    pub fn with_request_timeout(mut self, timeout: Duration) -> Self {
+        self.request_timeout = timeout;
+        self
+    }
+
     /// # Errors
-    /// Returns `A2aError` on network, JSON, or JSON-RPC errors.
+    /// Returns `A2aError` on network, JSON, or JSON-RPC errors, or `A2aError::Timeout`
+    /// if the request exceeds the configured `request_timeout`.
     pub async fn send_message(
         &self,
         endpoint: &str,
@@ -139,11 +161,17 @@ impl A2aClient {
         if let Some(t) = token {
             req = req.bearer_auth(t);
         }
-        let resp = req.send().await?;
+        let resp = tokio::time::timeout(self.request_timeout, req.send())
+            .await
+            .map_err(|_| A2aError::Timeout(self.request_timeout))?
+            .map_err(A2aError::Http)?;
 
         if !resp.status().is_success() {
             let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
+            let body = tokio::time::timeout(Duration::from_secs(5), resp.text())
+                .await
+                .unwrap_or(Ok(String::new()))
+                .unwrap_or_default();
             // Truncate body to avoid leaking large upstream error responses.
             let truncated = if body.len() > 256 {
                 format!("{}…", &body[..256])
@@ -176,7 +204,8 @@ impl A2aClient {
     }
 
     /// # Errors
-    /// Returns `A2aError` on network, JSON, or JSON-RPC errors.
+    /// Returns `A2aError` on network, JSON, or JSON-RPC errors, or `A2aError::Timeout`
+    /// if the request exceeds the configured `request_timeout`.
     pub async fn get_task(
         &self,
         endpoint: &str,
@@ -188,7 +217,8 @@ impl A2aClient {
     }
 
     /// # Errors
-    /// Returns `A2aError` on network, JSON, or JSON-RPC errors.
+    /// Returns `A2aError` on network, JSON, or JSON-RPC errors, or `A2aError::Timeout`
+    /// if the request exceeds the configured `request_timeout`.
     pub async fn cancel_task(
         &self,
         endpoint: &str,
@@ -247,8 +277,13 @@ impl A2aClient {
         if let Some(t) = token {
             req = req.bearer_auth(t);
         }
-        let resp = req.send().await?;
-        let rpc_response: JsonRpcResponse<R> = resp.json().await?;
+        let rpc_response: JsonRpcResponse<R> = tokio::time::timeout(self.request_timeout, async {
+            let resp = req.send().await?;
+            resp.json().await
+        })
+        .await
+        .map_err(|_| A2aError::Timeout(self.request_timeout))?
+        .map_err(A2aError::Http)?;
         rpc_response.into_result().map_err(A2aError::from)
     }
 }
@@ -869,5 +904,41 @@ mod wiremock_tests {
             .await;
         let err = result.err().expect("expected error");
         assert!(matches!(err, crate::error::A2aError::Stream(_)));
+    }
+
+    #[tokio::test]
+    async fn rpc_call_times_out() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/rpc"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_delay(std::time::Duration::from_secs(5))
+                    .set_body_json(serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": "req-1",
+                        "result": {
+                            "id": "t-1",
+                            "status": {"state": "completed", "timestamp": "2026-01-01T00:00:00Z"}
+                        }
+                    })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = A2aClient::new(reqwest::Client::new())
+            .with_request_timeout(std::time::Duration::from_millis(100));
+        let params = SendMessageParams {
+            message: Message::user_text("hello"),
+            configuration: None,
+        };
+        let result = client
+            .send_message(&format!("{}/rpc", server.uri()), params, None)
+            .await;
+        assert!(result.is_err());
+        assert!(
+            matches!(result.unwrap_err(), crate::error::A2aError::Timeout(_)),
+            "expected Timeout error"
+        );
     }
 }

--- a/crates/zeph-a2a/src/discovery.rs
+++ b/crates/zeph-a2a/src/discovery.rs
@@ -51,6 +51,8 @@ pub struct AgentRegistry {
     client: reqwest::Client,
     cache: RwLock<HashMap<String, CachedCard>>,
     ttl: Duration,
+    /// Timeout for each network request in [`discover`](Self::discover).
+    request_timeout: Duration,
 }
 
 impl AgentRegistry {
@@ -63,7 +65,17 @@ impl AgentRegistry {
             client,
             cache: RwLock::new(HashMap::new()),
             ttl,
+            request_timeout: Duration::from_secs(10),
         }
+    }
+
+    /// Set the per-request network timeout for [`discover`](Self::discover) calls (default: 10 seconds).
+    ///
+    /// Discovery is a lightweight GET request for the agent card; 10 seconds is generous.
+    #[must_use]
+    pub fn with_request_timeout(mut self, timeout: Duration) -> Self {
+        self.request_timeout = timeout;
+        self
     }
 
     /// Fetch the [`AgentCard`] from `{base_url}/.well-known/agent.json` and update the cache.
@@ -78,19 +90,23 @@ impl AgentRegistry {
     /// variant on non-2xx HTTP status or JSON parse failure.
     pub async fn discover(&self, base_url: &str) -> Result<AgentCard, A2aError> {
         let url = format!("{}{WELL_KNOWN_PATH}", base_url.trim_end_matches('/'));
-        let resp = self.client.get(&url).send().await?;
+        let card: AgentCard = tokio::time::timeout(self.request_timeout, async {
+            let resp = self.client.get(&url).send().await?;
 
-        if !resp.status().is_success() {
-            return Err(A2aError::Discovery {
-                url,
-                reason: format!("HTTP {}", resp.status()),
-            });
-        }
+            if !resp.status().is_success() {
+                return Err(A2aError::Discovery {
+                    url: url.clone(),
+                    reason: format!("HTTP {}", resp.status()),
+                });
+            }
 
-        let card: AgentCard = resp.json().await.map_err(|e| A2aError::Discovery {
-            url,
-            reason: e.to_string(),
-        })?;
+            resp.json().await.map_err(|e| A2aError::Discovery {
+                url: url.clone(),
+                reason: e.to_string(),
+            })
+        })
+        .await
+        .map_err(|_| A2aError::Timeout(self.request_timeout))??;
 
         let mut cache = self.cache.write().await;
         cache.insert(
@@ -336,5 +352,39 @@ mod wiremock_tests {
         // Should re-fetch from mock server
         let card = registry.get_or_discover(&base_url).await.unwrap();
         assert_eq!(card.name, "fresh-agent");
+    }
+
+    #[tokio::test]
+    async fn discover_times_out() {
+        let server = MockServer::start().await;
+        let base_url = server.uri();
+        Mock::given(method("GET"))
+            .and(path("/.well-known/agent.json"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_delay(Duration::from_secs(5))
+                    .set_body_json(serde_json::json!({
+                        "name": "slow-agent",
+                        "description": "test",
+                        "url": base_url,
+                        "version": "0.1.0",
+                        "protocolVersion": crate::A2A_PROTOCOL_VERSION,
+                        "capabilities": {"streaming": false, "pushNotifications": false, "stateTransitionHistory": false},
+                        "defaultInputModes": [],
+                        "defaultOutputModes": [],
+                        "skills": []
+                    })),
+            )
+            .mount(&server)
+            .await;
+
+        let registry = AgentRegistry::new(reqwest::Client::new(), Duration::from_mins(1))
+            .with_request_timeout(Duration::from_millis(100));
+        let result = registry.discover(&server.uri()).await;
+        assert!(result.is_err());
+        assert!(
+            matches!(result.unwrap_err(), A2aError::Timeout(_)),
+            "expected Timeout error from slow discovery"
+        );
     }
 }

--- a/crates/zeph-a2a/src/error.rs
+++ b/crates/zeph-a2a/src/error.rs
@@ -50,6 +50,10 @@ pub enum A2aError {
     /// `ssrf_protection = true` and DNS resolves to a private/loopback address.
     #[error("security policy violation: {0}")]
     Security(String),
+
+    /// A request or task processing operation exceeded its deadline.
+    #[error("operation timed out after {0:?}")]
+    Timeout(std::time::Duration),
 }
 
 impl From<JsonRpcError> for A2aError {

--- a/crates/zeph-a2a/src/server/handlers.rs
+++ b/crates/zeph-a2a/src/server/handlers.rs
@@ -129,26 +129,42 @@ async fn handle_send_message(
         .process(task.id.clone(), params.message, event_tx);
 
     let proc_handle = tokio::spawn(proc_future);
+    let abort_handle = proc_handle.abort_handle();
 
-    let mut accumulated = String::new();
-    while let Some(event) = event_rx.recv().await {
-        match event {
-            ProcessorEvent::ArtifactChunk { text, .. } => {
-                accumulated.push_str(&text);
+    let (accumulated, final_state) = match tokio::time::timeout(state.request_timeout, async {
+        let mut accumulated = String::new();
+        while let Some(event) = event_rx.recv().await {
+            match event {
+                ProcessorEvent::ArtifactChunk { text, .. } => {
+                    accumulated.push_str(&text);
+                }
+                ProcessorEvent::StatusUpdate { .. } => {}
             }
-            ProcessorEvent::StatusUpdate { .. } => {}
         }
-    }
-
-    let final_state = match proc_handle.await {
-        Ok(Ok(())) => TaskState::Completed,
-        Ok(Err(e)) => {
-            tracing::error!(task_id = %task.id, "task processing failed: {e}");
-            TaskState::Failed
-        }
-        Err(e) => {
-            tracing::error!(task_id = %task.id, "task processor panicked: {e}");
-            TaskState::Failed
+        let final_state = match proc_handle.await {
+            Ok(Ok(())) => TaskState::Completed,
+            Ok(Err(e)) => {
+                tracing::error!(task_id = %task.id, "task processing failed: {e}");
+                TaskState::Failed
+            }
+            Err(e) => {
+                tracing::error!(task_id = %task.id, "task processor panicked: {e}");
+                TaskState::Failed
+            }
+        };
+        (accumulated, final_state)
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(_elapsed) => {
+            tracing::warn!(
+                task_id = %task.id,
+                timeout = ?state.request_timeout,
+                "task processing timed out"
+            );
+            abort_handle.abort();
+            (String::new(), TaskState::Failed)
         }
     };
 
@@ -294,29 +310,14 @@ pub async fn stream_handler(
     Sse::new(stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(15)))
 }
 
-async fn stream_task(state: AppState, message: crate::types::Message, tx: mpsc::Sender<Event>) {
-    let task = state.task_manager.create_task(message.clone()).await;
-    let task_id = task.id.clone();
-    let context_id = task.context_id.clone();
-
-    state
-        .task_manager
-        .update_status(&task_id, TaskState::Working, None)
-        .await;
-    let _ = tx
-        .send(status_event(
-            &task_id,
-            context_id.as_ref(),
-            TaskState::Working,
-            false,
-        ))
-        .await;
-
-    let (event_tx, mut event_rx) = mpsc::channel::<ProcessorEvent>(32);
-    let proc_future = state.processor.process(task_id.clone(), message, event_tx);
-
-    let proc_handle = tokio::spawn(proc_future);
-
+async fn drain_processor_events(
+    state: &AppState,
+    task_id: &str,
+    context_id: Option<&String>,
+    event_rx: &mut tokio::sync::mpsc::Receiver<ProcessorEvent>,
+    proc_handle: tokio::task::JoinHandle<Result<(), crate::error::A2aError>>,
+    tx: &mpsc::Sender<Event>,
+) -> TaskState {
     let mut accumulated = String::new();
     while let Some(event) = event_rx.recv().await {
         match event {
@@ -330,8 +331,8 @@ async fn stream_task(state: AppState, message: crate::types::Message, tx: mpsc::
                 };
                 let evt = TaskArtifactUpdateEvent {
                     kind: "artifact-update".into(),
-                    task_id: task_id.clone(),
-                    context_id: context_id.clone(),
+                    task_id: task_id.to_owned(),
+                    context_id: context_id.cloned(),
                     artifact,
                     is_final,
                 };
@@ -343,15 +344,10 @@ async fn stream_task(state: AppState, message: crate::types::Message, tx: mpsc::
             } => {
                 state
                     .task_manager
-                    .update_status(&task_id, task_state, None)
+                    .update_status(task_id, task_state, None)
                     .await;
                 let _ = tx
-                    .send(status_event(
-                        &task_id,
-                        context_id.as_ref(),
-                        task_state,
-                        is_final,
-                    ))
+                    .send(status_event(task_id, context_id, task_state, is_final))
                     .await;
             }
         }
@@ -377,8 +373,63 @@ async fn stream_task(state: AppState, message: crate::types::Message, tx: mpsc::
             parts: vec![Part::text(accumulated)],
             metadata: None,
         };
-        state.task_manager.add_artifact(&task_id, artifact).await;
+        state.task_manager.add_artifact(task_id, artifact).await;
     }
+
+    final_state
+}
+
+async fn stream_task(state: AppState, message: crate::types::Message, tx: mpsc::Sender<Event>) {
+    let task = state.task_manager.create_task(message.clone()).await;
+    let task_id = task.id.clone();
+    let context_id = task.context_id.clone();
+
+    state
+        .task_manager
+        .update_status(&task_id, TaskState::Working, None)
+        .await;
+    let _ = tx
+        .send(status_event(
+            &task_id,
+            context_id.as_ref(),
+            TaskState::Working,
+            false,
+        ))
+        .await;
+
+    let (event_tx, mut event_rx) = mpsc::channel::<ProcessorEvent>(32);
+    let proc_future = state.processor.process(task_id.clone(), message, event_tx);
+
+    let proc_handle = tokio::spawn(proc_future);
+    // Processor abort on SSE client disconnect is not handled here — the spawned task
+    // continues until completion or this timeout fires. Aborting on client disconnect
+    // is a separate enhancement (requires select! on tx.closed()).
+    let abort_handle = proc_handle.abort_handle();
+
+    let final_state = match tokio::time::timeout(
+        state.request_timeout,
+        drain_processor_events(
+            &state,
+            &task_id,
+            context_id.as_ref(),
+            &mut event_rx,
+            proc_handle,
+            &tx,
+        ),
+    )
+    .await
+    {
+        Ok(s) => s,
+        Err(_elapsed) => {
+            tracing::warn!(
+                task_id = %task_id,
+                timeout = ?state.request_timeout,
+                "stream task processing timed out"
+            );
+            abort_handle.abort();
+            TaskState::Failed
+        }
+    };
 
     state
         .task_manager
@@ -531,6 +582,7 @@ mod tests {
             card: super::super::testing::test_card(),
             task_manager: super::super::state::TaskManager::new(),
             processor: Arc::new(MultiChunkProcessor),
+            request_timeout: std::time::Duration::from_secs(300),
         }
     }
 
@@ -559,5 +611,87 @@ mod tests {
         let artifacts = &body["result"]["artifacts"];
         let text = artifacts[0]["parts"][0]["text"].as_str().unwrap_or("");
         assert_eq!(text, "chunk1 chunk2 chunk3");
+    }
+
+    struct SlowProcessor;
+
+    impl super::super::state::TaskProcessor for SlowProcessor {
+        fn process(
+            &self,
+            _task_id: String,
+            _message: crate::types::Message,
+            _event_tx: tokio::sync::mpsc::Sender<super::super::state::ProcessorEvent>,
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Result<(), crate::error::A2aError>> + Send>,
+        > {
+            Box::pin(async {
+                tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+                Ok(())
+            })
+        }
+    }
+
+    fn slow_state_with_short_timeout() -> super::super::state::AppState {
+        use std::sync::Arc;
+        super::super::state::AppState {
+            card: super::super::testing::test_card(),
+            task_manager: super::super::state::TaskManager::new(),
+            processor: Arc::new(SlowProcessor),
+            request_timeout: std::time::Duration::from_millis(100),
+        }
+    }
+
+    #[tokio::test]
+    async fn timeout_returns_failed_state() {
+        let app = build_router_with_config(slow_state_with_short_timeout(), None, 0);
+        let msg = crate::types::Message {
+            role: crate::types::Role::User,
+            parts: vec![crate::types::Part::Text {
+                text: "hello".into(),
+                metadata: None,
+            }],
+            message_id: Some("m1".into()),
+            task_id: None,
+            context_id: None,
+            metadata: None,
+        };
+        let req = make_rpc_request(
+            "message/send",
+            &serde_json::json!({ "message": serde_json::to_value(&msg).unwrap() }),
+        );
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), 200);
+        let body = get_rpc_body(resp).await;
+        assert_eq!(
+            body["result"]["status"]["state"], "failed",
+            "timed-out task must be in failed state"
+        );
+    }
+
+    #[tokio::test]
+    async fn sse_stream_timeout_sends_failed_event() {
+        let app = build_router_with_config(slow_state_with_short_timeout(), None, 0);
+        let body = serde_json::json!({
+            "params": {
+                "message": {
+                    "role": "user",
+                    "parts": [{"kind": "text", "text": "slow"}]
+                }
+            }
+        });
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/a2a/stream")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), 200);
+        let body_bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let body_str = String::from_utf8_lossy(&body_bytes);
+        assert!(
+            body_str.contains("failed"),
+            "SSE stream must contain failed terminal event on timeout, got: {body_str}"
+        );
     }
 }

--- a/crates/zeph-a2a/src/server/handlers.rs
+++ b/crates/zeph-a2a/src/server/handlers.rs
@@ -582,7 +582,7 @@ mod tests {
             card: super::super::testing::test_card(),
             task_manager: super::super::state::TaskManager::new(),
             processor: Arc::new(MultiChunkProcessor),
-            request_timeout: std::time::Duration::from_secs(300),
+            request_timeout: std::time::Duration::from_mins(5),
         }
     }
 
@@ -625,7 +625,7 @@ mod tests {
             Box<dyn std::future::Future<Output = Result<(), crate::error::A2aError>> + Send>,
         > {
             Box::pin(async {
-                tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+                tokio::time::sleep(std::time::Duration::from_mins(1)).await;
                 Ok(())
             })
         }

--- a/crates/zeph-a2a/src/server/mod.rs
+++ b/crates/zeph-a2a/src/server/mod.rs
@@ -320,7 +320,7 @@ pub(crate) mod testing {
             card: test_card(),
             task_manager: TaskManager::new(),
             processor: Arc::new(EchoProcessor),
-            request_timeout: std::time::Duration::from_secs(300),
+            request_timeout: std::time::Duration::from_mins(5),
         }
     }
 
@@ -329,7 +329,7 @@ pub(crate) mod testing {
             card: test_card(),
             task_manager: TaskManager::new(),
             processor: Arc::new(FailingProcessor),
-            request_timeout: std::time::Duration::from_secs(300),
+            request_timeout: std::time::Duration::from_mins(5),
         }
     }
 }

--- a/crates/zeph-a2a/src/server/mod.rs
+++ b/crates/zeph-a2a/src/server/mod.rs
@@ -191,7 +191,7 @@ impl A2aServer {
     /// Set the per-request timeout for task processing (default: 300 seconds).
     ///
     /// If a [`TaskProcessor`] does not complete within this duration, the server
-    /// aborts the spawned future, marks the task as [`TaskState::Failed`], and returns
+    /// aborts the spawned future, marks the task as [`crate::TaskState::Failed`], and returns
     /// a JSON-RPC internal-error response to the caller.
     ///
     /// For streaming calls, a final SSE event with `failed` state is sent before the

--- a/crates/zeph-a2a/src/server/mod.rs
+++ b/crates/zeph-a2a/src/server/mod.rs
@@ -33,6 +33,7 @@ pub mod state;
 
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use tokio::sync::watch;
 
@@ -128,6 +129,7 @@ impl A2aServer {
             card,
             task_manager: TaskManager::new(),
             processor,
+            request_timeout: Duration::from_mins(5),
         };
 
         Self {
@@ -183,6 +185,20 @@ impl A2aServer {
     #[must_use]
     pub fn with_max_body_size(mut self, size: usize) -> Self {
         self.max_body_size = size;
+        self
+    }
+
+    /// Set the per-request timeout for task processing (default: 300 seconds).
+    ///
+    /// If a [`TaskProcessor`] does not complete within this duration, the server
+    /// aborts the spawned future, marks the task as [`TaskState::Failed`], and returns
+    /// a JSON-RPC internal-error response to the caller.
+    ///
+    /// For streaming calls, a final SSE event with `failed` state is sent before the
+    /// connection closes, so the client always receives a terminal event.
+    #[must_use]
+    pub fn with_request_timeout(mut self, timeout: Duration) -> Self {
+        self.state.request_timeout = timeout;
         self
     }
 
@@ -304,6 +320,7 @@ pub(crate) mod testing {
             card: test_card(),
             task_manager: TaskManager::new(),
             processor: Arc::new(EchoProcessor),
+            request_timeout: std::time::Duration::from_secs(300),
         }
     }
 
@@ -312,6 +329,7 @@ pub(crate) mod testing {
             card: test_card(),
             task_manager: TaskManager::new(),
             processor: Arc::new(FailingProcessor),
+            request_timeout: std::time::Duration::from_secs(300),
         }
     }
 }

--- a/crates/zeph-a2a/src/server/state.rs
+++ b/crates/zeph-a2a/src/server/state.rs
@@ -5,6 +5,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use tokio::sync::RwLock;
 
@@ -22,6 +23,9 @@ pub struct AppState {
     pub task_manager: TaskManager,
     /// The application-level logic that handles incoming task messages.
     pub processor: Arc<dyn TaskProcessor>,
+    /// Maximum time to wait for a [`TaskProcessor`] to complete before marking the task
+    /// as [`TaskState::Failed`] and aborting the spawned future.
+    pub request_timeout: Duration,
 }
 
 /// An event emitted by a [`TaskProcessor`] to drive the handler's response.

--- a/crates/zeph-config/src/channels.rs
+++ b/crates/zeph-config/src/channels.rs
@@ -462,6 +462,10 @@ fn default_ibct_ttl() -> u64 {
     300
 }
 
+fn default_a2a_request_timeout_ms() -> u64 {
+    300_000
+}
+
 /// A2A server configuration, nested under `[a2a]` in TOML.
 ///
 /// Controls the Agent-to-Agent HTTP server that exposes the agent via the A2A protocol.
@@ -526,6 +530,13 @@ pub struct A2aServerConfig {
     /// provider and STT configuration — no manual override is needed for those.
     #[serde(default)]
     pub advertise_files: bool,
+    /// Request processing timeout in milliseconds.
+    ///
+    /// Applies to both `message/send` and `tasks/stream` handlers.
+    /// On timeout the task is set to `Failed` and the HTTP connection is closed.
+    /// Defaults to 300 000 ms (5 minutes).
+    #[serde(default = "default_a2a_request_timeout_ms")]
+    pub request_timeout_ms: u64,
 }
 
 impl std::fmt::Debug for A2aServerConfig {
@@ -552,6 +563,7 @@ impl std::fmt::Debug for A2aServerConfig {
             )
             .field("ibct_ttl_secs", &self.ibct_ttl_secs)
             .field("advertise_files", &self.advertise_files)
+            .field("request_timeout_ms", &self.request_timeout_ms)
             .finish()
     }
 }
@@ -574,6 +586,7 @@ impl Default for A2aServerConfig {
             ibct_signing_key_vault_ref: None,
             ibct_ttl_secs: default_ibct_ttl(),
             advertise_files: false,
+            request_timeout_ms: default_a2a_request_timeout_ms(),
         }
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -77,7 +77,10 @@ fn spawn_a2a_server(
     .with_auth(config.a2a.auth_token.clone())
     .with_require_auth(config.a2a.require_auth)
     .with_rate_limit(config.a2a.rate_limit)
-    .with_max_body_size(config.a2a.max_body_size);
+    .with_max_body_size(config.a2a.max_body_size)
+    .with_request_timeout(std::time::Duration::from_millis(
+        config.a2a.request_timeout_ms,
+    ));
 
     tracing::info!(
         "A2A server spawned on {}:{}",


### PR DESCRIPTION
## Summary

- Wraps `proc_handle.await` in `handle_send_message` and `stream_task` with `tokio::time::timeout`; on timeout calls `abort_handle.abort()`, sets task state to `Failed`, and returns JSON-RPC error `-32603` (closes #3834)
- Wraps `req.send()` + `resp.json()` in `rpc_call` and `req.send()` in `stream_message` with `tokio::time::timeout`; wraps `AgentRegistry::discover` HTTP call with timeout (closes #3835)
- Adds `A2aServerConfig.request_timeout_ms` (serde default 300 000 ms) and wires it into `daemon.rs`

## New public API

| Item | Default |
|------|---------|
| `A2aError::Timeout(Duration)` | — |
| `A2aClient::with_request_timeout(Duration)` | 30 s |
| `AgentRegistry::with_request_timeout(Duration)` | 10 s |
| `A2aServer::with_request_timeout(Duration)` | 5 min |
| `A2aServerConfig.request_timeout_ms` | 300 000 ms |

## Test plan

- [ ] `cargo nextest run -p zeph-a2a --lib` — 97 tests pass including new `rpc_call_times_out`, `sse_stream_timeout_sends_failed_event`, `timeout_returns_failed_state`, `discover_times_out`
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean
- [ ] Full workspace: 9 281 tests pass