### PR TITLE
fix(orchestration): add LLM timeouts, config validation, and typed error variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `zeph-orchestration`: wrap all LLM `.await` calls in `LlmAggregator::aggregate`,
+  `LlmPlanner::plan`/`plan_with_hint`, `PlanVerifier::verify`/`replan`/`verify_plan`/`replan_from_plan`,
+  and `plan_cache::adapt_plan` with `tokio::time::timeout`. New `OrchestrationConfig` fields:
+  `aggregator_timeout_secs` (default 60), `planner_timeout_secs` (default 120),
+  `verifier_timeout_secs` (default 30). Validates `> 0` at startup. On timeout: aggregator falls
+  back to concatenation, planner returns `PlanningFailed`, verifier fails open (closes #3840).
+- `zeph-config`: `validate_orchestration()` now rejects `max_parallel = 0` and `max_tasks = 0`
+  with a `ConfigError::Validation` at startup, preventing the DAG scheduler from silently stalling
+  with all tasks stuck in `Pending` (closes #3841).
+- `zeph-orchestration`: add `Llm(#[from] zeph_llm::LlmError)` typed variant to `OrchestrationError`
+  so callers can pattern-match on root LLM error kinds without string comparison (closes #3842).
+
 ### Performance
 
 - `zeph-memory`: replace serial `embed()` calls with a single `embed_batch()` call in

--- a/crates/zeph-config/src/experiment.rs
+++ b/crates/zeph-config/src/experiment.rs
@@ -80,6 +80,18 @@ fn default_persistence_enabled() -> bool {
     true
 }
 
+fn default_aggregator_timeout_secs() -> u64 {
+    60
+}
+
+fn default_planner_timeout_secs() -> u64 {
+    120
+}
+
+fn default_verifier_timeout_secs() -> u64 {
+    30
+}
+
 fn default_plan_cache_similarity_threshold() -> f32 {
     0.90
 }
@@ -316,6 +328,29 @@ pub struct OrchestrationConfig {
     /// Default: `0.0` (unlimited).
     #[serde(default)]
     pub default_task_budget_cents: f64,
+
+    /// Timeout in seconds for aggregation LLM calls. Default: 60.
+    ///
+    /// On timeout the aggregator falls back to raw concatenation so that a graph
+    /// result is always returned. Set to `0` is rejected by `Config::validate()`.
+    #[serde(default = "default_aggregator_timeout_secs")]
+    pub aggregator_timeout_secs: u64,
+
+    /// Timeout in seconds for planner LLM calls. Default: 120.
+    ///
+    /// On timeout the planner returns `OrchestrationError::PlanningFailed`.
+    /// Planning has no fallback — without a graph no tasks can be dispatched.
+    /// Set to `0` is rejected by `Config::validate()`.
+    #[serde(default = "default_planner_timeout_secs")]
+    pub planner_timeout_secs: u64,
+
+    /// Timeout in seconds for verifier LLM calls (per-task and whole-plan). Default: 30.
+    ///
+    /// On timeout the verifier returns a fail-open result (`complete = true`, no gaps).
+    /// Matches the existing `predicate_timeout_secs` default.
+    /// Set to `0` is rejected by `Config::validate()`.
+    #[serde(default = "default_verifier_timeout_secs")]
+    pub verifier_timeout_secs: u64,
 }
 
 impl Default for OrchestrationConfig {
@@ -355,6 +390,9 @@ impl Default for OrchestrationConfig {
             persistence_enabled: default_persistence_enabled(),
             orchestrator_provider: ProviderName::default(),
             default_task_budget_cents: 0.0,
+            aggregator_timeout_secs: default_aggregator_timeout_secs(),
+            planner_timeout_secs: default_planner_timeout_secs(),
+            verifier_timeout_secs: default_verifier_timeout_secs(),
         }
     }
 }

--- a/crates/zeph-config/src/loader.rs
+++ b/crates/zeph-config/src/loader.rs
@@ -253,6 +253,16 @@ impl Config {
 
     /// Validate orchestration thresholds and cascade settings.
     fn validate_orchestration(&self) -> Result<(), ConfigError> {
+        if self.orchestration.max_parallel == 0 {
+            return Err(ConfigError::Validation(
+                "orchestration.max_parallel must be > 0".into(),
+            ));
+        }
+        if self.orchestration.max_tasks == 0 {
+            return Err(ConfigError::Validation(
+                "orchestration.max_tasks must be > 0".into(),
+            ));
+        }
         let ct = self.orchestration.completeness_threshold;
         if !ct.is_finite() || !(0.0..=1.0).contains(&ct) {
             return Err(ConfigError::Validation(format!(
@@ -278,6 +288,21 @@ impl Config {
                 "orchestration.lineage_ttl_secs must be > 0; \
                  set cascade_chain_threshold=0 to disable lineage tracking instead"
                     .into(),
+            ));
+        }
+        if self.orchestration.aggregator_timeout_secs == 0 {
+            return Err(ConfigError::Validation(
+                "orchestration.aggregator_timeout_secs must be > 0".into(),
+            ));
+        }
+        if self.orchestration.planner_timeout_secs == 0 {
+            return Err(ConfigError::Validation(
+                "orchestration.planner_timeout_secs must be > 0".into(),
+            ));
+        }
+        if self.orchestration.verifier_timeout_secs == 0 {
+            return Err(ConfigError::Validation(
+                "orchestration.verifier_timeout_secs must be > 0".into(),
             ));
         }
         Ok(())
@@ -893,6 +918,75 @@ weight = 0.3
         assert!((skills.disambiguation_threshold - 0.25_f32).abs() < f32::EPSILON);
 
         let _ = wrapped; // silence unused-variable lint
+    }
+
+    #[test]
+    fn validate_max_parallel_zero_rejected() {
+        let mut cfg = Config::default();
+        cfg.orchestration.max_parallel = 0;
+        let err = cfg.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("max_parallel"),
+            "expected max_parallel in error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_max_parallel_one_accepted() {
+        let mut cfg = Config::default();
+        cfg.orchestration.max_parallel = 1;
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_max_tasks_zero_rejected() {
+        let mut cfg = Config::default();
+        cfg.orchestration.max_tasks = 0;
+        let err = cfg.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("max_tasks"),
+            "expected max_tasks in error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_max_tasks_one_accepted() {
+        let mut cfg = Config::default();
+        cfg.orchestration.max_tasks = 1;
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_aggregator_timeout_zero_rejected() {
+        let mut cfg = Config::default();
+        cfg.orchestration.aggregator_timeout_secs = 0;
+        let err = cfg.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("aggregator_timeout_secs"),
+            "expected aggregator_timeout_secs in error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_planner_timeout_zero_rejected() {
+        let mut cfg = Config::default();
+        cfg.orchestration.planner_timeout_secs = 0;
+        let err = cfg.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("planner_timeout_secs"),
+            "expected planner_timeout_secs in error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_verifier_timeout_zero_rejected() {
+        let mut cfg = Config::default();
+        cfg.orchestration.verifier_timeout_secs = 0;
+        let err = cfg.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("verifier_timeout_secs"),
+            "expected verifier_timeout_secs in error, got: {err}"
+        );
     }
 
     #[test]

--- a/crates/zeph-core/src/agent/plan.rs
+++ b/crates/zeph-core/src/agent/plan.rs
@@ -388,8 +388,11 @@ impl<C: crate::channel::Channel> Agent<C> {
             .or(self.services.orchestration.orchestrator_provider.as_ref())
             .unwrap_or(&self.provider)
             .clone();
-        let mut verifier =
-            PlanVerifier::new(verify_provider, self.services.security.sanitizer.clone());
+        let mut verifier = PlanVerifier::new(
+            verify_provider,
+            self.services.security.sanitizer.clone(),
+            &self.services.orchestration.orchestration_config,
+        );
         let result = verifier
             .verify_plan(&goal, &truncated_output)
             .instrument(tracing::info_span!("core.plan.whole_plan_verify"))
@@ -821,6 +824,12 @@ impl<C: crate::channel::Channel> Agent<C> {
             let use_cache = topology_hint
                 .as_ref()
                 .is_none_or(|h| h.prompt_sentence().is_none());
+            let planner_timeout = std::time::Duration::from_secs(
+                self.services
+                    .orchestration
+                    .orchestration_config
+                    .planner_timeout_secs,
+            );
             let result = if use_cache {
                 plan_with_cache(
                     &planner,
@@ -831,6 +840,7 @@ impl<C: crate::channel::Channel> Agent<C> {
                     goal,
                     &available_agents,
                     max_tasks,
+                    planner_timeout,
                 )
                 .await
             } else {

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -428,8 +428,10 @@ impl<C: crate::channel::Channel> Agent<C> {
                             .completeness_threshold;
                         let sanitizer = self.services.security.sanitizer.clone();
 
-                        let verifier = plan_verifier
-                            .get_or_insert_with(|| PlanVerifier::new(verify_provider, sanitizer));
+                        let orch_config = self.services.orchestration.orchestration_config.clone();
+                        let verifier = plan_verifier.get_or_insert_with(|| {
+                            PlanVerifier::new(verify_provider, sanitizer, &orch_config)
+                        });
 
                         let task = scheduler.graph().tasks.get(task_id.index()).cloned();
 

--- a/crates/zeph-orchestration/src/aggregator.rs
+++ b/crates/zeph-orchestration/src/aggregator.rs
@@ -8,6 +8,7 @@
 //! implementation falls back to raw concatenation so that a graph result is always returned.
 
 use std::fmt::Write as _;
+use std::time::Duration;
 
 use zeph_llm::provider::{LlmProvider, Message, Role};
 
@@ -44,21 +45,23 @@ pub trait Aggregator: Send + Sync {
 ///
 /// Divides the total token budget (`config.aggregator_max_tokens × 4 chars/token`) equally
 /// across completed tasks and truncates each output before including it in the prompt.
-/// On LLM failure it falls back to raw concatenation via an internal `build_fallback` path;
-/// the fallback always succeeds if at least one task has a result.
+/// On LLM failure or timeout it falls back to raw concatenation via an internal `build_fallback`
+/// path; the fallback always succeeds if at least one task has a result.
 pub struct LlmAggregator<P: LlmProvider> {
     provider: P,
     /// Total character budget for all task outputs combined. Divided equally among
     /// completed tasks at aggregation time (S1).
     aggregation_char_budget: usize,
     sanitizer: ContentSanitizer,
+    /// Maximum time to wait for the aggregation LLM call before falling back.
+    timeout: Duration,
 }
 
 impl<P: LlmProvider> LlmAggregator<P> {
     /// Create a new `LlmAggregator` from a provider and orchestration config.
     ///
     /// The character budget is derived from `config.aggregator_max_tokens` using a
-    /// 4 chars-per-token estimate.
+    /// 4 chars-per-token estimate. The timeout is taken from `config.aggregator_timeout_secs`.
     #[must_use]
     pub fn new(provider: P, config: &OrchestrationConfig) -> Self {
         // Estimate 4 chars/token for the total budget.
@@ -67,6 +70,7 @@ impl<P: LlmProvider> LlmAggregator<P> {
             provider,
             aggregation_char_budget,
             sanitizer: ContentSanitizer::new(&ContentIsolationConfig::default()),
+            timeout: Duration::from_secs(config.aggregator_timeout_secs),
         }
     }
 }
@@ -143,19 +147,27 @@ impl<P: LlmProvider + Send + Sync> Aggregator for LlmAggregator<P> {
             Message::from_legacy(Role::User, user),
         ];
 
-        match self.provider.chat(&messages).await {
-            Ok(synthesis) => {
+        match tokio::time::timeout(self.timeout, self.provider.chat(&messages)).await {
+            Ok(Ok(synthesis)) => {
                 // Capture usage right after the successful API call.
                 let usage = self.provider.last_usage();
                 Ok((synthesis, usage))
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 // I3: on LLM failure, fall back to raw concatenation. Usage is not tracked
                 // for the fallback path because no tokens were successfully consumed.
                 tracing::error!(
                     graph_id = %graph.id,
                     error = %e,
                     "aggregation LLM call failed; falling back to raw concatenation"
+                );
+                Ok((build_fallback(graph, &self.sanitizer, per_task), None))
+            }
+            Err(_elapsed) => {
+                tracing::warn!(
+                    timeout_secs = self.timeout.as_secs(),
+                    graph_id = %graph.id,
+                    "aggregation LLM call timed out; falling back to raw concatenation"
                 );
                 Ok((build_fallback(graph, &self.sanitizer, per_task), None))
             }
@@ -351,6 +363,55 @@ mod tests {
                 result.contains("unique-skipped-description"),
                 "fallback must include skipped task description; got: {result}"
             );
+        }
+
+        #[tokio::test]
+        async fn test_aggregate_timeout_falls_back_to_concatenation() {
+            use futures::stream;
+            use zeph_llm::LlmError;
+            use zeph_llm::provider::{ChatStream, Message, StreamChunk};
+
+            struct SlowProvider;
+            impl zeph_llm::provider::LlmProvider for SlowProvider {
+                async fn chat(&self, _: &[Message]) -> Result<String, LlmError> {
+                    tokio::time::sleep(Duration::from_mins(1)).await;
+                    Ok("should not reach".to_string())
+                }
+                async fn chat_stream(&self, msgs: &[Message]) -> Result<ChatStream, LlmError> {
+                    let r = self.chat(msgs).await?;
+                    Ok(Box::pin(stream::once(async move {
+                        Ok(StreamChunk::Content(r))
+                    })))
+                }
+                fn supports_streaming(&self) -> bool {
+                    false
+                }
+                async fn embed(&self, _: &str) -> Result<Vec<f32>, LlmError> {
+                    Err(LlmError::Unavailable)
+                }
+                fn supports_embeddings(&self) -> bool {
+                    false
+                }
+                fn name(&self) -> &'static str {
+                    "slow-mock"
+                }
+            }
+
+            // Build manually with a 50ms timeout for test speed.
+            let agg = LlmAggregator {
+                provider: SlowProvider,
+                aggregation_char_budget: 1024 * 4,
+                sanitizer: ContentSanitizer::new(&ContentIsolationConfig::default()),
+                timeout: Duration::from_millis(50),
+            };
+
+            let graph = make_graph_with_tasks(&[(TaskStatus::Completed, Some("raw output"))]);
+            let (result, usage) = agg.aggregate(&graph).await.unwrap();
+            assert!(
+                result.contains("raw output"),
+                "timeout should fall back to raw concatenation; got: {result}"
+            );
+            assert!(usage.is_none(), "timeout fallback must not report usage");
         }
 
         #[tokio::test]

--- a/crates/zeph-orchestration/src/error.rs
+++ b/crates/zeph-orchestration/src/error.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use zeph_llm::LlmError;
 use zeph_subagent::SubAgentError;
 
 use super::lineage::LineageEntry;
@@ -100,6 +101,14 @@ pub enum OrchestrationError {
     /// Propagated error from a sub-agent execution.
     #[error(transparent)]
     SubAgent(#[from] SubAgentError),
+
+    /// An LLM provider call failed in a context with no more specific variant.
+    ///
+    /// Existing call sites that map `LlmError` to `PlanningFailed` or other semantic
+    /// variants are intentional and should not be changed. This variant is for new code
+    /// and for callers in `zeph-core` that propagate raw LLM errors.
+    #[error("orchestration LLM call failed: {0}")]
+    Llm(#[from] LlmError),
 
     /// A `VerifyPredicate::Expression` was encountered; only `Natural` is
     /// supported in v1.

--- a/crates/zeph-orchestration/src/plan_cache.rs
+++ b/crates/zeph-orchestration/src/plan_cache.rs
@@ -7,6 +7,8 @@
 //! On subsequent semantically similar goals, retrieves the closest template
 //! and uses a lightweight LLM adaptation call instead of full decomposition.
 
+use std::time::Duration;
+
 use blake3;
 use serde::{Deserialize, Serialize};
 use zeph_config::PlanCacheConfig;
@@ -470,6 +472,7 @@ pub async fn plan_with_cache<P>(
     goal: &str,
     available_agents: &[SubAgentDef],
     max_tasks: u32,
+    planner_timeout: Duration,
 ) -> Result<(TaskGraph, Option<(u64, u64)>), OrchestrationError>
 where
     P: super::planner::Planner,
@@ -484,7 +487,16 @@ where
                     tasks = template.tasks.len(),
                     "plan cache hit, adapting template"
                 );
-                match adapt_plan(provider, goal, &template, available_agents, max_tasks).await {
+                match adapt_plan(
+                    provider,
+                    goal,
+                    &template,
+                    available_agents,
+                    max_tasks,
+                    planner_timeout,
+                )
+                .await
+                {
                     Ok(result) => return Ok(result),
                     Err(e) => {
                         tracing::warn!(
@@ -514,7 +526,7 @@ where
 ///
 /// # Errors
 ///
-/// Returns `OrchestrationError::PlanningFailed` if the LLM call fails or the
+/// Returns `OrchestrationError::PlanningFailed` if the LLM call fails, times out, or the
 /// adapted graph fails DAG validation.
 async fn adapt_plan(
     provider: &impl LlmProvider,
@@ -522,6 +534,7 @@ async fn adapt_plan(
     template: &PlanTemplate,
     available_agents: &[SubAgentDef],
     max_tasks: u32,
+    timeout: Duration,
 ) -> Result<(TaskGraph, Option<(u64, u64)>), OrchestrationError> {
     use zeph_subagent::ToolPolicy;
 
@@ -569,9 +582,9 @@ async fn adapt_plan(
         Message::from_legacy(Role::User, user),
     ];
 
-    let response: PlannerResponse = provider
-        .chat_typed(&messages)
+    let response: PlannerResponse = tokio::time::timeout(timeout, provider.chat_typed(&messages))
         .await
+        .map_err(|_| OrchestrationError::PlanningFailed("plan cache adaptation timed out".into()))?
         .map_err(|e| OrchestrationError::PlanningFailed(e.to_string()))?;
 
     let usage = provider.last_usage();
@@ -957,6 +970,7 @@ mod tests {
             "do something",
             &[],
             20,
+            Duration::from_mins(2),
         )
         .await
         .unwrap();
@@ -1006,6 +1020,7 @@ mod tests {
             "deploy service",
             &[],
             20,
+            Duration::from_mins(2),
         )
         .await
         .unwrap();
@@ -1056,6 +1071,7 @@ mod tests {
             "deploy service",
             &[],
             20,
+            Duration::from_mins(2),
         )
         .await
         .unwrap();

--- a/crates/zeph-orchestration/src/planner.rs
+++ b/crates/zeph-orchestration/src/planner.rs
@@ -4,6 +4,7 @@
 //! LLM-based goal decomposition into a validated `TaskGraph`.
 
 use std::collections::{HashMap, HashSet};
+use std::time::Duration;
 
 use serde::Deserialize;
 use zeph_llm::provider::{LlmProvider, Message, Role}; // Role needed for plan_with_hint prompt augmentation
@@ -87,6 +88,8 @@ pub trait Planner: Send + Sync {
 pub struct LlmPlanner<P: LlmProvider> {
     provider: P,
     max_tasks: u32,
+    /// Maximum time to wait for a planner LLM call before returning `PlanningFailed`.
+    timeout: Duration,
 }
 
 impl<P: LlmProvider> LlmPlanner<P> {
@@ -94,12 +97,13 @@ impl<P: LlmProvider> LlmPlanner<P> {
     ///
     /// The caller resolves `config.planner_provider` to a concrete provider and passes
     /// it here. `LlmPlanner` uses whatever provider it receives without further
-    /// provider resolution.
+    /// provider resolution. The timeout is taken from `config.planner_timeout_secs`.
     #[must_use]
     pub fn new(provider: P, config: &OrchestrationConfig) -> Self {
         Self {
             provider,
             max_tasks: config.max_tasks,
+            timeout: Duration::from_secs(config.planner_timeout_secs),
         }
     }
 }
@@ -156,11 +160,11 @@ impl<P: LlmProvider + Send + Sync> Planner for LlmPlanner<P> {
                 *sys = Message::from_legacy(Role::System, augmented);
             }
         }
-        let response: PlannerResponse = self
-            .provider
-            .chat_typed(&messages)
-            .await
-            .map_err(|e| OrchestrationError::PlanningFailed(e.to_string()))?;
+        let response: PlannerResponse =
+            tokio::time::timeout(self.timeout, self.provider.chat_typed(&messages))
+                .await
+                .map_err(|_| OrchestrationError::PlanningFailed("planner timed out".into()))?
+                .map_err(|e| OrchestrationError::PlanningFailed(e.to_string()))?;
         let usage = self.provider.last_usage();
         let graph = convert_response(response, goal, available_agents, self.max_tasks)?;
         dag::validate(&graph.tasks, self.max_tasks as usize)?;
@@ -180,11 +184,11 @@ impl<P: LlmProvider + Send + Sync> Planner for LlmPlanner<P> {
 
         let messages = build_prompt(goal, available_agents, self.max_tasks);
 
-        let response: PlannerResponse = self
-            .provider
-            .chat_typed(&messages)
-            .await
-            .map_err(|e| OrchestrationError::PlanningFailed(e.to_string()))?;
+        let response: PlannerResponse =
+            tokio::time::timeout(self.timeout, self.provider.chat_typed(&messages))
+                .await
+                .map_err(|_| OrchestrationError::PlanningFailed("planner timed out".into()))?
+                .map_err(|e| OrchestrationError::PlanningFailed(e.to_string()))?;
 
         // Capture usage right after the API call, before any fallible post-processing.
         let usage = self.provider.last_usage();
@@ -866,6 +870,50 @@ mod tests {
             let planner = LlmPlanner::new(provider, &make_config());
             let (graph, _usage) = planner.plan("goal", &agents()).await.unwrap();
             assert_eq!(graph.tasks[0].execution_mode, ExecutionMode::Parallel);
+        }
+
+        #[tokio::test]
+        async fn test_plan_timeout_returns_planning_failed() {
+            use futures::stream;
+            use zeph_llm::LlmError;
+            use zeph_llm::provider::{ChatStream, Message, StreamChunk};
+
+            struct SlowProvider;
+            impl zeph_llm::provider::LlmProvider for SlowProvider {
+                async fn chat(&self, _: &[Message]) -> Result<String, LlmError> {
+                    tokio::time::sleep(Duration::from_mins(1)).await;
+                    Ok("never".to_string())
+                }
+                async fn chat_stream(&self, msgs: &[Message]) -> Result<ChatStream, LlmError> {
+                    let r = self.chat(msgs).await?;
+                    Ok(Box::pin(stream::once(async move {
+                        Ok(StreamChunk::Content(r))
+                    })))
+                }
+                fn supports_streaming(&self) -> bool {
+                    false
+                }
+                async fn embed(&self, _: &str) -> Result<Vec<f32>, LlmError> {
+                    Err(LlmError::Unavailable)
+                }
+                fn supports_embeddings(&self) -> bool {
+                    false
+                }
+                fn name(&self) -> &'static str {
+                    "slow-mock"
+                }
+            }
+
+            let planner = LlmPlanner {
+                provider: SlowProvider,
+                max_tasks: 20,
+                timeout: Duration::from_millis(50),
+            };
+            let err = planner.plan("some goal", &agents()).await.unwrap_err();
+            assert!(
+                matches!(err, OrchestrationError::PlanningFailed(_)),
+                "timeout must return PlanningFailed; got: {err:?}"
+            );
         }
     }
 }

--- a/crates/zeph-orchestration/src/scheduler/mod.rs
+++ b/crates/zeph-orchestration/src/scheduler/mod.rs
@@ -774,6 +774,9 @@ mod tests {
             persistence_enabled: true,
             orchestrator_provider: Default::default(),
             default_task_budget_cents: 0.0,
+            aggregator_timeout_secs: 60,
+            planner_timeout_secs: 120,
+            verifier_timeout_secs: 30,
         }
     }
 

--- a/crates/zeph-orchestration/src/verifier.rs
+++ b/crates/zeph-orchestration/src/verifier.rs
@@ -11,8 +11,11 @@
 //! All LLM call failures are fail-open: `verify()` returns `complete = true` on
 //! error; `replan()` returns an empty `Vec`. Verification never blocks execution.
 
+use std::time::Duration;
+
 use serde::{Deserialize, Serialize};
 use tracing::{error, warn};
+use zeph_config::OrchestrationConfig;
 use zeph_llm::provider::{LlmProvider, Message, Role};
 use zeph_sanitizer::{ContentSanitizer, ContentSource, ContentSourceKind};
 
@@ -120,16 +123,21 @@ pub struct PlanVerifier<P: LlmProvider> {
     /// Constructed with `spotlight_untrusted = false` so delimiters do not confuse
     /// the verification LLM (RISK-5): truncation and injection detection still apply.
     sanitizer: ContentSanitizer,
+    /// Maximum time to wait for each verifier LLM call before returning fail-open.
+    timeout: Duration,
 }
 
 impl<P: LlmProvider> PlanVerifier<P> {
-    /// Create a new `PlanVerifier`.
+    /// Create a new `PlanVerifier` from a provider, sanitizer, and orchestration config.
+    ///
+    /// The timeout is taken from `config.verifier_timeout_secs`.
     #[must_use]
-    pub fn new(provider: P, sanitizer: ContentSanitizer) -> Self {
+    pub fn new(provider: P, sanitizer: ContentSanitizer, config: &OrchestrationConfig) -> Self {
         Self {
             provider,
             consecutive_failures: 0,
             sanitizer,
+            timeout: Duration::from_secs(config.verifier_timeout_secs),
         }
     }
 
@@ -144,14 +152,14 @@ impl<P: LlmProvider> PlanVerifier<P> {
     pub async fn verify(&mut self, task: &TaskNode, output: &str) -> VerificationResult {
         let messages = build_verify_prompt(task, output, &self.sanitizer);
 
-        let result: Result<VerificationResult, _> = self.provider.chat_typed(&messages).await;
+        let result = tokio::time::timeout(self.timeout, self.provider.chat_typed(&messages)).await;
 
         match result {
-            Ok(vr) => {
+            Ok(Ok(vr)) => {
                 self.consecutive_failures = 0;
                 vr
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 self.consecutive_failures = self.consecutive_failures.saturating_add(1);
                 if self.consecutive_failures >= 3 {
                     error!(
@@ -168,6 +176,15 @@ impl<P: LlmProvider> PlanVerifier<P> {
                         "PlanVerifier: LLM call failed, treating task as complete (fail-open)"
                     );
                 }
+                VerificationResult::fail_open()
+            }
+            Err(_elapsed) => {
+                self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+                warn!(
+                    timeout_secs = self.timeout.as_secs(),
+                    task_id = %task.id,
+                    "PlanVerifier: LLM call timed out, treating task as complete (fail-open)"
+                );
                 VerificationResult::fail_open()
             }
         }
@@ -225,10 +242,14 @@ impl<P: LlmProvider> PlanVerifier<P> {
 
         let messages = build_replan_prompt(task, &actionable_gaps, &self.sanitizer);
 
-        let raw: Result<ReplanResponse, _> = self.provider.chat_typed(&messages).await;
+        let raw = tokio::time::timeout(
+            self.timeout,
+            self.provider.chat_typed::<ReplanResponse>(&messages),
+        )
+        .await;
 
         match raw {
-            Ok(resp) => {
+            Ok(Ok(resp)) => {
                 let mut new_tasks = Vec::new();
                 for (i, pt) in resp.tasks.into_iter().enumerate() {
                     let task_idx = next_id + u32::try_from(i).unwrap_or(0);
@@ -240,11 +261,19 @@ impl<P: LlmProvider> PlanVerifier<P> {
                 }
                 Ok(new_tasks)
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 warn!(
                     error = %e,
                     task_id = %task.id,
                     "PlanVerifier: replan LLM call failed, skipping replan (fail-open)"
+                );
+                Ok(Vec::new())
+            }
+            Err(_elapsed) => {
+                warn!(
+                    timeout_secs = self.timeout.as_secs(),
+                    task_id = %task.id,
+                    "PlanVerifier: replan LLM call timed out, skipping replan (fail-open)"
                 );
                 Ok(Vec::new())
             }
@@ -262,14 +291,14 @@ impl<P: LlmProvider> PlanVerifier<P> {
     pub async fn verify_plan(&mut self, goal: &str, aggregated_output: &str) -> VerificationResult {
         let messages = build_verify_plan_prompt(goal, aggregated_output, &self.sanitizer);
 
-        let result: Result<VerificationResult, _> = self.provider.chat_typed(&messages).await;
+        let result = tokio::time::timeout(self.timeout, self.provider.chat_typed(&messages)).await;
 
         match result {
-            Ok(vr) => {
+            Ok(Ok(vr)) => {
                 self.consecutive_failures = 0;
                 vr
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 self.consecutive_failures = self.consecutive_failures.saturating_add(1);
                 if self.consecutive_failures >= 3 {
                     error!(
@@ -285,6 +314,15 @@ impl<P: LlmProvider> PlanVerifier<P> {
                          (fail-open)"
                     );
                 }
+                VerificationResult::fail_open()
+            }
+            Err(_elapsed) => {
+                self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+                warn!(
+                    timeout_secs = self.timeout.as_secs(),
+                    "PlanVerifier: whole-plan LLM call timed out, treating plan as complete \
+                     (fail-open)"
+                );
                 VerificationResult::fail_open()
             }
         }
@@ -332,10 +370,14 @@ impl<P: LlmProvider> PlanVerifier<P> {
 
         let messages = build_replan_from_plan_prompt(goal, &actionable_gaps, &self.sanitizer);
 
-        let raw: Result<ReplanResponse, _> = self.provider.chat_typed(&messages).await;
+        let raw = tokio::time::timeout(
+            self.timeout,
+            self.provider.chat_typed::<ReplanResponse>(&messages),
+        )
+        .await;
 
         match raw {
-            Ok(resp) => {
+            Ok(Ok(resp)) => {
                 let mut new_tasks = Vec::new();
                 for (i, pt) in resp.tasks.into_iter().enumerate() {
                     let task_idx = next_id
@@ -351,10 +393,17 @@ impl<P: LlmProvider> PlanVerifier<P> {
                 }
                 Ok(new_tasks)
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 warn!(
                     error = %e,
                     "PlanVerifier: replan_from_plan LLM call failed, skipping replan (fail-open)"
+                );
+                Ok(Vec::new())
+            }
+            Err(_elapsed) => {
+                warn!(
+                    timeout_secs = self.timeout.as_secs(),
+                    "PlanVerifier: replan_from_plan LLM call timed out, skipping replan (fail-open)"
                 );
                 Ok(Vec::new())
             }
@@ -624,6 +673,7 @@ pub fn inject_tasks(
 mod tests {
     use super::*;
     use crate::graph::{TaskGraph, TaskId, TaskNode, TaskStatus};
+    use zeph_config::OrchestrationConfig;
 
     fn make_node(id: u32, deps: &[u32]) -> TaskNode {
         let mut n = TaskNode::new(id, format!("t{id}"), format!("desc {id}"));
@@ -772,7 +822,8 @@ mod tests {
         let provider = MockProvider {
             response: Ok(complete_result_json()),
         };
-        let mut verifier = PlanVerifier::new(provider, test_sanitizer());
+        let mut verifier =
+            PlanVerifier::new(provider, test_sanitizer(), &OrchestrationConfig::default());
         let task = TaskNode::new(0, "write code", "write the implementation");
         let result = verifier.verify(&task, "here is the code: ...").await;
         assert!(result.complete);
@@ -785,7 +836,8 @@ mod tests {
         let provider = MockProvider {
             response: Ok(incomplete_result_json()),
         };
-        let mut verifier = PlanVerifier::new(provider, test_sanitizer());
+        let mut verifier =
+            PlanVerifier::new(provider, test_sanitizer(), &OrchestrationConfig::default());
         let task = TaskNode::new(0, "write code", "write the implementation");
         let result = verifier.verify(&task, "partial output").await;
         assert!(!result.complete);
@@ -800,7 +852,8 @@ mod tests {
         let provider = MockProvider {
             response: Err(LlmError::Other("timeout".to_string())),
         };
-        let mut verifier = PlanVerifier::new(provider, test_sanitizer());
+        let mut verifier =
+            PlanVerifier::new(provider, test_sanitizer(), &OrchestrationConfig::default());
         let task = TaskNode::new(0, "write code", "write the implementation");
         let result = verifier.verify(&task, "output").await;
         // Fail-open: complete=true, no gaps, confidence=0.0
@@ -814,7 +867,8 @@ mod tests {
         let provider = MockProvider {
             response: Err(LlmError::Other("error".to_string())),
         };
-        let mut verifier = PlanVerifier::new(provider, test_sanitizer());
+        let mut verifier =
+            PlanVerifier::new(provider, test_sanitizer(), &OrchestrationConfig::default());
         let task = TaskNode::new(0, "t", "d");
         verifier.verify(&task, "out").await;
         assert_eq!(verifier.consecutive_failures(), 1);
@@ -828,7 +882,8 @@ mod tests {
         let provider = MockProvider {
             response: Ok(r#"{"tasks": []}"#.to_string()),
         };
-        let mut verifier = PlanVerifier::new(provider, test_sanitizer());
+        let mut verifier =
+            PlanVerifier::new(provider, test_sanitizer(), &OrchestrationConfig::default());
         let task = TaskNode::new(0, "t", "d");
         let gaps = vec![Gap {
             description: "minor issue".to_string(),
@@ -850,7 +905,8 @@ mod tests {
         let provider = MockProvider {
             response: Ok(replan_json),
         };
-        let mut verifier = PlanVerifier::new(provider, test_sanitizer());
+        let mut verifier =
+            PlanVerifier::new(provider, test_sanitizer(), &OrchestrationConfig::default());
         let task = TaskNode::new(0, "write code", "write implementation");
         let gaps = vec![Gap {
             description: "missing unit tests".to_string(),
@@ -869,7 +925,8 @@ mod tests {
         let provider = MockProvider {
             response: Err(LlmError::Other("replan error".to_string())),
         };
-        let mut verifier = PlanVerifier::new(provider, test_sanitizer());
+        let mut verifier =
+            PlanVerifier::new(provider, test_sanitizer(), &OrchestrationConfig::default());
         let task = TaskNode::new(0, "t", "d");
         let gaps = vec![Gap {
             description: "critical missing thing".to_string(),
@@ -889,7 +946,8 @@ mod tests {
         let provider = MockProvider {
             response: Ok(complete_result_json()),
         };
-        let mut verifier = PlanVerifier::new(provider, test_sanitizer());
+        let mut verifier =
+            PlanVerifier::new(provider, test_sanitizer(), &OrchestrationConfig::default());
         let task = TaskNode::new(0, "t", "d");
         // verify() must not panic and must call the LLM (fail-open if needed).
         let result = verifier
@@ -908,7 +966,8 @@ mod tests {
         let provider = MockProvider {
             response: Ok(replan_json),
         };
-        let mut verifier = PlanVerifier::new(provider, test_sanitizer());
+        let mut verifier =
+            PlanVerifier::new(provider, test_sanitizer(), &OrchestrationConfig::default());
         let task = TaskNode::new(0, "t", "d");
         let gaps = vec![Gap {
             description: long_desc,
@@ -945,7 +1004,8 @@ mod tests {
         let provider = MockProvider {
             response: Ok(complete_result_json()),
         };
-        let mut verifier = PlanVerifier::new(provider, test_sanitizer());
+        let mut verifier =
+            PlanVerifier::new(provider, test_sanitizer(), &OrchestrationConfig::default());
         let result = verifier
             .verify_plan("write a web server", "here is the server code")
             .await;
@@ -959,7 +1019,8 @@ mod tests {
         let provider = MockProvider {
             response: Ok(incomplete_result_json()),
         };
-        let mut verifier = PlanVerifier::new(provider, test_sanitizer());
+        let mut verifier =
+            PlanVerifier::new(provider, test_sanitizer(), &OrchestrationConfig::default());
         let result = verifier
             .verify_plan("write a web server", "partial output")
             .await;
@@ -973,7 +1034,8 @@ mod tests {
         let provider = MockProvider {
             response: Err(LlmError::Other("timeout".to_string())),
         };
-        let mut verifier = PlanVerifier::new(provider, test_sanitizer());
+        let mut verifier =
+            PlanVerifier::new(provider, test_sanitizer(), &OrchestrationConfig::default());
         let result = verifier.verify_plan("goal", "output").await;
         assert!(result.complete);
         assert!(result.gaps.is_empty());
@@ -994,7 +1056,8 @@ mod tests {
         let provider = MockProvider {
             response: Ok(replan_json),
         };
-        let mut verifier = PlanVerifier::new(provider, test_sanitizer());
+        let mut verifier =
+            PlanVerifier::new(provider, test_sanitizer(), &OrchestrationConfig::default());
         let gaps = vec![
             Gap {
                 description: "no auth".to_string(),
@@ -1023,7 +1086,8 @@ mod tests {
         let provider = MockProvider {
             response: Ok(r#"{"tasks": []}"#.to_string()),
         };
-        let mut verifier = PlanVerifier::new(provider, test_sanitizer());
+        let mut verifier =
+            PlanVerifier::new(provider, test_sanitizer(), &OrchestrationConfig::default());
         let gaps = vec![Gap {
             description: "minor issue".to_string(),
             severity: GapSeverity::Minor,
@@ -1040,7 +1104,8 @@ mod tests {
         let provider = MockProvider {
             response: Err(LlmError::Other("network error".to_string())),
         };
-        let mut verifier = PlanVerifier::new(provider, test_sanitizer());
+        let mut verifier =
+            PlanVerifier::new(provider, test_sanitizer(), &OrchestrationConfig::default());
         let gaps = vec![Gap {
             description: "critical gap".to_string(),
             severity: GapSeverity::Critical,
@@ -1061,7 +1126,8 @@ mod tests {
         let provider = MockProvider {
             response: Ok(json.to_string()),
         };
-        let mut verifier = PlanVerifier::new(provider, test_sanitizer());
+        let mut verifier =
+            PlanVerifier::new(provider, test_sanitizer(), &OrchestrationConfig::default());
         let result = verifier.verify_plan("goal", "output").await;
         assert!(!result.complete);
         assert!((result.confidence - 0.6).abs() < 0.01);
@@ -1082,7 +1148,8 @@ mod tests {
         let provider = MockProvider {
             response: Ok(json.to_string()),
         };
-        let mut verifier = PlanVerifier::new(provider, test_sanitizer());
+        let mut verifier =
+            PlanVerifier::new(provider, test_sanitizer(), &OrchestrationConfig::default());
         let result = verifier.verify_plan("goal", "output").await;
         let threshold = 0.7_f64;
         let should_replan =
@@ -1091,5 +1158,90 @@ mod tests {
             !should_replan,
             "should not trigger replan when confidence >= threshold"
         );
+    }
+
+    // --- timeout tests ---
+
+    fn slow_verifier() -> PlanVerifier<SlowMockProvider> {
+        let config = OrchestrationConfig::default();
+        let mut v = PlanVerifier::new(SlowMockProvider, test_sanitizer(), &config);
+        // Override timeout to 50ms so tests complete quickly.
+        v.timeout = Duration::from_millis(50);
+        v
+    }
+
+    struct SlowMockProvider;
+    impl LlmProvider for SlowMockProvider {
+        async fn chat(&self, _: &[Message]) -> Result<String, zeph_llm::LlmError> {
+            tokio::time::sleep(Duration::from_mins(1)).await;
+            Ok("never".to_string())
+        }
+        async fn chat_stream(
+            &self,
+            msgs: &[Message],
+        ) -> Result<zeph_llm::provider::ChatStream, zeph_llm::LlmError> {
+            use futures::stream;
+            use zeph_llm::provider::StreamChunk;
+            let r = self.chat(msgs).await?;
+            Ok(Box::pin(stream::once(async move {
+                Ok(StreamChunk::Content(r))
+            })))
+        }
+        fn supports_streaming(&self) -> bool {
+            false
+        }
+        async fn embed(&self, _: &str) -> Result<Vec<f32>, zeph_llm::LlmError> {
+            Err(zeph_llm::LlmError::Unavailable)
+        }
+        fn supports_embeddings(&self) -> bool {
+            false
+        }
+        fn name(&self) -> &'static str {
+            "slow-mock"
+        }
+    }
+
+    #[tokio::test]
+    async fn verify_timeout_is_fail_open() {
+        let mut verifier = slow_verifier();
+        let task = TaskNode::new(0, "t", "d");
+        let result = verifier.verify(&task, "output").await;
+        assert!(result.complete, "timeout must be fail-open (complete=true)");
+        assert!(result.gaps.is_empty());
+    }
+
+    #[tokio::test]
+    async fn replan_timeout_returns_empty() {
+        let mut verifier = slow_verifier();
+        let task = TaskNode::new(0, "t", "d");
+        let gaps = vec![Gap {
+            description: "critical".to_string(),
+            severity: GapSeverity::Critical,
+        }];
+        let graph = graph_from(vec![task.clone()]);
+        let result = verifier.replan(&task, &gaps, &graph, 20).await.unwrap();
+        assert!(result.is_empty(), "timeout must return empty vec");
+    }
+
+    #[tokio::test]
+    async fn verify_plan_timeout_is_fail_open() {
+        let mut verifier = slow_verifier();
+        let result = verifier.verify_plan("goal", "output").await;
+        assert!(result.complete, "timeout must be fail-open (complete=true)");
+        assert!(result.gaps.is_empty());
+    }
+
+    #[tokio::test]
+    async fn replan_from_plan_timeout_returns_empty() {
+        let mut verifier = slow_verifier();
+        let gaps = vec![Gap {
+            description: "critical".to_string(),
+            severity: GapSeverity::Critical,
+        }];
+        let result = verifier
+            .replan_from_plan("goal", &gaps, 0, 20)
+            .await
+            .unwrap();
+        assert!(result.is_empty(), "timeout must return empty vec");
     }
 }


### PR DESCRIPTION
## Summary

- **#3840**: Wrap all unguarded LLM `.await` calls in `LlmAggregator::aggregate`, `LlmPlanner::plan`/`plan_with_hint`, `PlanVerifier` (4 methods), and `plan_cache::adapt_plan` with `tokio::time::timeout`. Three new `OrchestrationConfig` fields (`aggregator_timeout_secs` = 60, `planner_timeout_secs` = 120, `verifier_timeout_secs` = 30) validated `> 0` at startup. Fail behavior matches existing patterns: aggregator falls back to concatenation, planner returns `PlanningFailed`, verifier fails open.
- **#3841**: `validate_orchestration()` now rejects `max_parallel = 0` and `max_tasks = 0` with `ConfigError::Validation` at startup, preventing silent DAG scheduler stall where all tasks remain `Pending`.
- **#3842**: Add `Llm(#[from] zeph_llm::LlmError)` typed variant to `OrchestrationError` so callers can pattern-match on root LLM error kinds without string comparison.

## Modified files

- `crates/zeph-config/src/experiment.rs` — new timeout config fields
- `crates/zeph-config/src/loader.rs` — validation for max_parallel, max_tasks, timeout fields
- `crates/zeph-orchestration/src/error.rs` — new `Llm(#[from] LlmError)` variant
- `crates/zeph-orchestration/src/aggregator.rs` — timeout wrapping
- `crates/zeph-orchestration/src/planner.rs` — timeout wrapping
- `crates/zeph-orchestration/src/verifier.rs` — timeout wrapping, `PlanVerifier::new` takes `&OrchestrationConfig`
- `crates/zeph-orchestration/src/plan_cache.rs` — timeout wrapping in `adapt_plan`
- `crates/zeph-orchestration/src/scheduler/mod.rs` — pass config to verifier constructor
- `crates/zeph-core/src/agent/plan.rs` — pass planner timeout from config
- `crates/zeph-core/src/agent/scheduler_loop.rs` — pass config to `PlanVerifier::new`

## Test plan

- [ ] `cargo nextest run -p zeph-orchestration --lib` — all timeout behavior tests pass (aggregator/planner/verifier × 4 verifier methods)
- [ ] `cargo nextest run -p zeph-config --lib` — max_parallel=0, max_tasks=0, and all three timeout_secs=0 rejection tests pass
- [ ] Full workspace: 9292 tests pass
- [ ] `cargo +nightly fmt --check` + `cargo clippy --workspace -- -D warnings` clean

Closes #3840
Closes #3841
Closes #3842