### PR TITLE
fix(skills): add configurable timeout to SkillGenerator and SkillMiner LLM calls

### DIFF
--- a/crates/zeph-config/src/features.rs
+++ b/crates/zeph-config/src/features.rs
@@ -284,6 +284,10 @@ pub struct SkillsConfig {
     /// Provider name for `/skill create` NL generation. Empty = primary provider.
     #[serde(default)]
     pub generation_provider: ProviderName,
+    /// Timeout in milliseconds for `/skill create` LLM generation (covers all internal retries).
+    /// Default: `60000` (60 s).
+    #[serde(default = "default_generation_timeout_ms")]
+    pub generation_timeout_ms: u64,
     /// Directory where generated skills are written. Defaults to first entry in `paths`.
     #[serde(default)]
     pub generation_output_dir: Option<String>,
@@ -296,6 +300,10 @@ pub struct SkillsConfig {
     /// Proactive world-knowledge exploration configuration (#3320).
     #[serde(default)]
     pub proactive_exploration: ProactiveExplorationConfig,
+}
+
+fn default_generation_timeout_ms() -> u64 {
+    60_000
 }
 
 // --- SkillEvaluationConfig defaults ---
@@ -463,7 +471,7 @@ fn default_rate_limit_rpm() -> u32 {
 }
 
 /// Configuration for the automated skill mining pipeline (`zeph-skills-miner` binary).
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct SkillMiningConfig {
     /// GitHub search queries for repo discovery (e.g. "topic:cli-tool language:rust stars:>100").
     #[serde(default)]
@@ -486,6 +494,28 @@ pub struct SkillMiningConfig {
     /// Maximum GitHub search requests per minute. Default: 25.
     #[serde(default = "default_rate_limit_rpm")]
     pub rate_limit_rpm: u32,
+    /// Timeout in milliseconds for each LLM skill generation call during mining. Default: `30000` (30 s).
+    #[serde(default = "default_mining_generation_timeout_ms")]
+    pub generation_timeout_ms: u64,
+}
+
+impl Default for SkillMiningConfig {
+    fn default() -> Self {
+        Self {
+            queries: Vec::new(),
+            max_repos_per_query: default_max_repos_per_query(),
+            dedup_threshold: default_dedup_threshold(),
+            output_dir: None,
+            generation_provider: ProviderName::default(),
+            embedding_provider: ProviderName::default(),
+            rate_limit_rpm: default_rate_limit_rpm(),
+            generation_timeout_ms: default_mining_generation_timeout_ms(),
+        }
+    }
+}
+
+fn default_mining_generation_timeout_ms() -> u64 {
+    30_000
 }
 
 /// Code indexing and repo-map configuration, nested under `[index]` in TOML.

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -213,6 +213,7 @@ impl Default for Config {
                 rl_warmup_updates: 50,
                 rl_embed_dim: None,
                 generation_provider: crate::providers::ProviderName::default(),
+                generation_timeout_ms: 60_000,
                 generation_output_dir: None,
                 mining: crate::features::SkillMiningConfig::default(),
                 evaluation: crate::features::SkillEvaluationConfig::default(),

--- a/crates/zeph-core/src/agent/learning/skill_commands.rs
+++ b/crates/zeph-core/src/agent/learning/skill_commands.rs
@@ -103,9 +103,22 @@ impl<C: Channel> Agent<C> {
             allowed_tools: Vec::new(),
         };
 
-        let mut generated = match generator.generate(request).await {
-            Ok(g) => g,
-            Err(e) => return Ok(format!("Skill generation failed: {e}")),
+        let timeout_ms = self.services.skill.generation_timeout_ms;
+        let mut generated = match tokio::time::timeout(
+            std::time::Duration::from_millis(timeout_ms),
+            generator.generate(request),
+        )
+        .await
+        {
+            Ok(Ok(g)) => g,
+            Ok(Err(e)) => return Ok(format!("Skill generation failed: {e}")),
+            Err(_) => {
+                tracing::warn!(timeout_ms, "skill generation timed out");
+                return Ok(format!(
+                    "Skill generation timed out after {}s.",
+                    timeout_ms / 1000
+                ));
+            }
         };
 
         // Dedup check: compare against existing registry embeddings.

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -2983,6 +2983,7 @@ impl<C: Channel> Agent<C> {
             .generation_provider
             .as_str()
             .clone_into(&mut self.services.skill.generation_provider_name);
+        self.services.skill.generation_timeout_ms = config.skills.generation_timeout_ms;
         self.services.skill.generation_output_dir =
             config.skills.generation_output_dir.as_deref().map(|p| {
                 if let Some(stripped) = p.strip_prefix("~/") {

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -122,6 +122,8 @@ pub(crate) struct SkillState {
     pub(crate) generation_output_dir: Option<std::path::PathBuf>,
     /// Provider name for `/skill create` generation. Empty = primary.
     pub(crate) generation_provider_name: String,
+    /// Timeout in milliseconds for `/skill create` LLM generation. Default: 60 000.
+    pub(crate) generation_timeout_ms: u64,
     /// Optional quality-gate evaluator for generated SKILL.md files (#3319).
     ///
     /// When `Some`, the evaluator is attached to every `SkillGenerator` instance so that
@@ -1090,6 +1092,7 @@ impl SkillState {
             rl_warmup_updates: 50,
             generation_output_dir: None,
             generation_provider_name: String::new(),
+            generation_timeout_ms: 60_000,
             skill_evaluator: None,
             eval_weights: zeph_skills::evaluator::EvaluationWeights::default(),
             eval_threshold: 0.60,

--- a/crates/zeph-skills/src/bin/miner.rs
+++ b/crates/zeph-skills/src/bin/miner.rs
@@ -126,6 +126,7 @@ async fn main() -> anyhow::Result<()> {
         output_dir: output_dir.clone(),
         rate_limit_rpm: config.skills.mining.rate_limit_rpm,
         dry_run: cli.dry_run,
+        generation_timeout_ms: config.skills.mining.generation_timeout_ms,
     };
 
     let miner = SkillMiner::new(

--- a/crates/zeph-skills/src/error.rs
+++ b/crates/zeph-skills/src/error.rs
@@ -63,6 +63,10 @@ pub enum SkillError {
     #[error("copy failed: {0}")]
     CopyFailed(String),
 
+    /// An LLM call exceeded its configured timeout.
+    #[error("skill generation timed out after {0}ms")]
+    Timeout(u64),
+
     /// Catch-all for errors that do not fit the above categories.
     #[error("{0}")]
     Other(String),

--- a/crates/zeph-skills/src/miner.rs
+++ b/crates/zeph-skills/src/miner.rs
@@ -75,6 +75,8 @@ pub struct MiningConfig {
     pub rate_limit_rpm: u32,
     /// When `true`, generate and report but do not write skills to disk.
     pub dry_run: bool,
+    /// Timeout in milliseconds for each LLM skill generation call. Default: 30 000.
+    pub generation_timeout_ms: u64,
 }
 
 /// Orchestrates the automated skill mining pipeline.
@@ -390,12 +392,17 @@ impl SkillMiner {
             Message::from_legacy(Role::User, &user_prompt),
         ];
 
-        let raw = self
-            .generator
-            .provider
-            .chat(&messages)
-            .await
-            .map_err(|e| SkillError::Other(format!("LLM generation failed: {e}")))?;
+        let timeout_ms = self.config.generation_timeout_ms;
+        let raw = tokio::time::timeout(
+            std::time::Duration::from_millis(timeout_ms),
+            self.generator.provider.chat(&messages),
+        )
+        .await
+        .map_err(|_| {
+            tracing::warn!(timeout_ms, "mining LLM generation timed out");
+            SkillError::Timeout(timeout_ms)
+        })?
+        .map_err(|e| SkillError::Other(format!("LLM generation failed: {e}")))?;
 
         crate::generator::parse_and_validate_pub(&crate::generator::extract_skill_md_pub(&raw))
     }
@@ -444,6 +451,7 @@ mod tests {
             output_dir: PathBuf::from("/tmp"),
             rate_limit_rpm: 25,
             dry_run: false,
+            generation_timeout_ms: 30_000,
         };
         let miner = SkillMiner {
             generator: SkillGenerator::new(
@@ -470,6 +478,7 @@ mod tests {
             output_dir: PathBuf::from("/tmp"),
             rate_limit_rpm: 25,
             dry_run: false,
+            generation_timeout_ms: 30_000,
         };
         assert!((config.dedup_threshold - 0.85_f32).abs() < f32::EPSILON);
         assert_eq!(config.max_repos_per_query, 20);
@@ -494,6 +503,7 @@ mod tests {
             output_dir: PathBuf::from(output_dir),
             rate_limit_rpm: 25,
             dry_run: false,
+            generation_timeout_ms: 30_000,
         };
         SkillMiner {
             generator: SkillGenerator::new(mock.clone(), PathBuf::from(output_dir)),
@@ -583,6 +593,7 @@ mod tests {
             output_dir: dir.path().to_path_buf(),
             rate_limit_rpm: 25,
             dry_run: true,
+            generation_timeout_ms: 30_000,
         };
         let miner = SkillMiner {
             generator: SkillGenerator::new(mock.clone(), dir.path().to_path_buf()),
@@ -641,6 +652,7 @@ mod tests {
             output_dir: PathBuf::from("/tmp"),
             rate_limit_rpm: 0,
             dry_run: false,
+            generation_timeout_ms: 30_000,
         };
         let miner = SkillMiner {
             generator: SkillGenerator::new(


### PR DESCRIPTION
## Summary

- Add `generation_timeout_ms` (default 60 s) to `SkillsConfig`; wire through `SkillState` to `skill_commands.rs` — wraps `generator.generate(request).await` with `tokio::time::timeout`
- Add `generation_timeout_ms` (default 30 s) to `SkillMiningConfig` and `MiningConfig`; wire to `miner.rs` — wraps `provider.chat(&messages).await` with `tokio::time::timeout`
- Add `SkillError::Timeout(u64)` variant for the miner path
- Replace `#[derive(Default)]` on `SkillMiningConfig` with manual `impl Default` to prevent zero-timeout trap

Both call sites now match the `ProactiveExplorer.explore` reference pattern in `zeph-agent-context/src/service.rs:416`.

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` — 9280 tests pass
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean
- [ ] Config defaults verified: `SkillsConfig::default().generation_timeout_ms == 60_000`, `SkillMiningConfig::default().generation_timeout_ms == 30_000`
- [ ] Follow-up issue to add unit tests for timeout branches via `MockProvider::with_delay()`

Closes #3843