### PR TITLE
fix(tools): preserve env overrides and cwd across macOS sandbox rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `bash` subprocess) and bypassing `TrustGateExecutor`'s quarantine enforcement for active
   skills. Added two regression tests using a nested composition and spy executors
   (closes #3869).
+- `zeph-tools` (macOS): `rewrite_command_with_sandbox_exec` now preserves env overrides
+  (`.env`/`.env_remove`) and `current_dir` across the Command rewrite that prepends
+  `sandbox-exec`. Previously, the wholesale `*std_cmd = Command::new(sandbox_exec)` reset
+  dropped every caller-configured env entry on the floor — so even with #3869 fixed, skill
+  secret env injection (`GITHUB_TOKEN` for the `github` skill) never reached the spawned
+  subprocess when `[tools.sandbox] enabled = true`. Added a regression test that asserts
+  env and cwd survive the rewrite (closes #3871).
 
 ### Changed
 

--- a/crates/zeph-tools/src/sandbox/macos.rs
+++ b/crates/zeph-tools/src/sandbox/macos.rs
@@ -358,12 +358,20 @@ fn rewrite_command_with_sandbox_exec(
     // Since tokio 1.x does not expose set_program, we rebuild via the `as_std_mut` method.
     let std_cmd = cmd.as_std_mut();
 
-    // Collect existing args before clearing.
+    // Collect existing program, args, env overrides, and cwd before clearing.
+    // The Command struct is fully replaced below to swap the program to sandbox-exec; without
+    // capturing these, caller-configured per-spawn state (skill secret env, cwd, etc.) is
+    // silently dropped on the floor — see #3871.
     let original_program = std_cmd.get_program().to_os_string();
     let original_args: Vec<std::ffi::OsString> = std_cmd
         .get_args()
         .map(std::ffi::OsStr::to_os_string)
         .collect();
+    let original_envs: Vec<(std::ffi::OsString, Option<std::ffi::OsString>)> = std_cmd
+        .get_envs()
+        .map(|(k, v)| (k.to_os_string(), v.map(std::ffi::OsStr::to_os_string)))
+        .collect();
+    let original_cwd: Option<PathBuf> = std_cmd.get_current_dir().map(Path::to_path_buf);
 
     // Replace program with sandbox-exec.
     *std_cmd = std::process::Command::new(sandbox_exec);
@@ -373,6 +381,21 @@ fn rewrite_command_with_sandbox_exec(
     std_cmd.arg(original_program);
     for arg in original_args {
         std_cmd.arg(arg);
+    }
+
+    // Restore env overrides and cwd captured above. `Some(v)` = explicit set, `None` = remove.
+    for (key, value) in original_envs {
+        match value {
+            Some(val) => {
+                std_cmd.env(key, val);
+            }
+            None => {
+                std_cmd.env_remove(key);
+            }
+        }
+    }
+    if let Some(cwd) = original_cwd {
+        std_cmd.current_dir(cwd);
     }
     // stdout/stderr piping must be re-applied by the caller (execute_bash already does this
     // before calling wrap, so the Stdio handles are set on the freshly-built std_cmd above).
@@ -753,6 +776,66 @@ mod tests {
         assert!(
             allow_pos > deny_pos,
             "allow must appear after deny (last-rule-wins)"
+        );
+    }
+
+    /// Regression for #3871: env overrides and cwd set on the original Command must survive
+    /// the sandbox-exec rewrite. Before the fix, the inner `*std_cmd = Command::new(...)`
+    /// reset replaced the entire struct, dropping `.env(...)` / `.env_remove(...)` / `.current_dir(...)`
+    /// entries — breaking skill secret env injection (`x-requires-secrets`) on macOS.
+    #[test]
+    fn rewrite_preserves_env_overrides_and_cwd() {
+        let mut cmd = tokio::process::Command::new("bash");
+        cmd.arg("-c").arg("echo hi");
+        cmd.env("GITHUB_TOKEN", "tok-xyz");
+        cmd.env("FOO", "bar");
+        cmd.env_remove("SECRET_TO_DROP");
+        cmd.current_dir("/tmp");
+
+        let sandbox_exec = PathBuf::from("/usr/bin/sandbox-exec");
+        let profile_path = PathBuf::from("/tmp/fake-profile.sb");
+        rewrite_command_with_sandbox_exec(&mut cmd, &sandbox_exec, &profile_path);
+
+        let std_cmd = cmd.as_std();
+        assert_eq!(std_cmd.get_program(), "/usr/bin/sandbox-exec");
+
+        let args: Vec<&std::ffi::OsStr> = std_cmd.get_args().collect();
+        assert_eq!(
+            args,
+            vec![
+                std::ffi::OsStr::new("-f"),
+                std::ffi::OsStr::new("/tmp/fake-profile.sb"),
+                std::ffi::OsStr::new("--"),
+                std::ffi::OsStr::new("bash"),
+                std::ffi::OsStr::new("-c"),
+                std::ffi::OsStr::new("echo hi"),
+            ]
+        );
+
+        let envs: std::collections::HashMap<std::ffi::OsString, Option<std::ffi::OsString>> =
+            std_cmd
+                .get_envs()
+                .map(|(k, v)| (k.to_os_string(), v.map(std::ffi::OsStr::to_os_string)))
+                .collect();
+        assert_eq!(
+            envs.get(std::ffi::OsStr::new("GITHUB_TOKEN")),
+            Some(&Some(std::ffi::OsString::from("tok-xyz"))),
+            "GITHUB_TOKEN must survive sandbox rewrite (#3871)"
+        );
+        assert_eq!(
+            envs.get(std::ffi::OsStr::new("FOO")),
+            Some(&Some(std::ffi::OsString::from("bar")))
+        );
+        assert_eq!(
+            envs.get(std::ffi::OsStr::new("SECRET_TO_DROP")),
+            Some(&None),
+            "env_remove entries must also be preserved as removals"
+        );
+
+        assert_eq!(
+            std_cmd.get_current_dir(),
+            Some(std::path::Path::new("/tmp")),
+            "current_dir must survive sandbox rewrite"
         );
     }
 }


### PR DESCRIPTION
## Summary

- `rewrite_command_with_sandbox_exec` on macOS replaced the entire `std::process::Command` with `Command::new(sandbox_exec)` to prepend the sandbox wrapper. Only program + args were carried over; `.env` / `.env_remove` overrides and `.current_dir` were dropped on the floor.
- Concrete impact, post-#3870:
  - **Skill secret env injection broken under sandbox**: with `[tools.sandbox] enabled = true` (the default in production configs), `cmd.envs(extra_env)` set by `build_bash_command` was wiped before spawn. `GITHUB_TOKEN` injected for the `github` skill never reached `gh`; tool reported `Token in default: invalid` because gh fell back to `hosts.yml` (which has no `oauth_token` field).
  - **Caller-configured `current_dir` discarded**: any future / present `.current_dir(...)` on bash invocations was reset to the parent process cwd.
- Capture program + args + envs + cwd before the in-place replacement, then replay envs and cwd onto the new Command. Added one regression test (`rewrite_preserves_env_overrides_and_cwd`) that sets `.env`, `.env_remove`, and `.current_dir` and asserts all three survive the rewrite.

Closes #3871. Restores the end-to-end flow originally targeted by #3870 (which fixed the propagation through `CompositeExecutor` but left the sandbox-side defect in place).

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo nextest run -p zeph-tools -E 'test(sandbox)'` → 58 passed (incl. new regression)
- [x] `cargo nextest run --workspace --lib --bins` → 9323 passed
- [ ] Manual macOS verification: with `[tools.sandbox] enabled = true`, `ZEPH_SECRET_GITHUB_TOKEN` in age vault, `github` skill `trusted` with `x-requires-secrets: github_token`, ask agent to run `gh auth status` and confirm source is `(GH_TOKEN)`/`(GITHUB_TOKEN)` (not `(default)`).

## Notes

- Linux Landlock backend does not use Command replacement (LSM ruleset attaches in-process), so this defect is macOS-specific. No change to `linux.rs`.
- The wider design issue — skill secret env should reach the subprocess regardless of sandbox state — is now resolved end-to-end. Trust-gate forwarding (#3870) and env preservation (this PR) together close the chain `vault → available_custom_secrets → set_skill_env → ShellExecutor::skill_env → cmd.envs → sandbox-exec → bash`.