### PR TITLE
fix(orchestration): apply >=3 escalation to PlanVerifier timeout arms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-orchestration`: `PlanVerifier::verify` and `PlanVerifier::verify_plan` now check the
+  `>= 3 consecutive_failures` escalation threshold on timeout-driven failures, not just LLM
+  error returns. Previously, an over-loaded or misconfigured `verify_provider` that always
+  timed out would silently fail-open forever — operators saw repeated `warn!` entries but
+  never the `error!` escalation. Both timeout arms now emit the same `error!` log as the
+  `Ok(Err(_))` path when `consecutive_failures >= 3`, advising the operator to inspect
+  `verify_provider` configuration (closes #3868).
+- `zeph-config`: document the orchestration timeout fields added in #3860 — added commented
+  `aggregator_timeout_secs = 60`, `planner_timeout_secs = 120`, and `verifier_timeout_secs = 30`
+  entries in the `[orchestration]` section of `config/default.toml` (closes #3867).
 - `zeph-orchestration`: wrap all LLM `.await` calls in `LlmAggregator::aggregate`,
   `LlmPlanner::plan`/`plan_with_hint`, `PlanVerifier::verify`/`replan`/`verify_plan`/`replan_from_plan`,
   and `plan_cache::adapt_plan` with `tokio::time::timeout`. New `OrchestrationConfig` fields:

--- a/config/default.toml
+++ b/config/default.toml
@@ -983,6 +983,12 @@ verify_max_tokens = 1024
 max_replans = 2
 # Enable post-task completeness verification (best-effort, does not gate dispatch)
 verify_completeness = false
+# Timeout in seconds for aggregation LLM calls (0 rejected by validation). Default: 60.
+# aggregator_timeout_secs = 60
+# Timeout in seconds for planner LLM calls (0 rejected by validation). Default: 120.
+# planner_timeout_secs = 120
+# Timeout in seconds for verifier LLM calls (0 rejected by validation). Default: 30.
+# verifier_timeout_secs = 30
 
 [classifiers]
 # Enable ML-backed classifiers (requires the `classifiers` feature at compile time).

--- a/crates/zeph-orchestration/src/verifier.rs
+++ b/crates/zeph-orchestration/src/verifier.rs
@@ -180,11 +180,21 @@ impl<P: LlmProvider> PlanVerifier<P> {
             }
             Err(_elapsed) => {
                 self.consecutive_failures = self.consecutive_failures.saturating_add(1);
-                warn!(
-                    timeout_secs = self.timeout.as_secs(),
-                    task_id = %task.id,
-                    "PlanVerifier: LLM call timed out, treating task as complete (fail-open)"
-                );
+                if self.consecutive_failures >= 3 {
+                    error!(
+                        consecutive_failures = self.consecutive_failures,
+                        timeout_secs = self.timeout.as_secs(),
+                        task_id = %task.id,
+                        "PlanVerifier: 3+ consecutive LLM failures — check verify_provider \
+                         configuration; all tasks will pass verification (fail-open)"
+                    );
+                } else {
+                    warn!(
+                        timeout_secs = self.timeout.as_secs(),
+                        task_id = %task.id,
+                        "PlanVerifier: LLM call timed out, treating task as complete (fail-open)"
+                    );
+                }
                 VerificationResult::fail_open()
             }
         }
@@ -318,11 +328,20 @@ impl<P: LlmProvider> PlanVerifier<P> {
             }
             Err(_elapsed) => {
                 self.consecutive_failures = self.consecutive_failures.saturating_add(1);
-                warn!(
-                    timeout_secs = self.timeout.as_secs(),
-                    "PlanVerifier: whole-plan LLM call timed out, treating plan as complete \
-                     (fail-open)"
-                );
+                if self.consecutive_failures >= 3 {
+                    error!(
+                        consecutive_failures = self.consecutive_failures,
+                        timeout_secs = self.timeout.as_secs(),
+                        "PlanVerifier: 3+ consecutive LLM failures in whole-plan verify — \
+                         check verify_provider configuration; plan treated as complete (fail-open)"
+                    );
+                } else {
+                    warn!(
+                        timeout_secs = self.timeout.as_secs(),
+                        "PlanVerifier: whole-plan LLM call timed out, treating plan as complete \
+                         (fail-open)"
+                    );
+                }
                 VerificationResult::fail_open()
             }
         }
@@ -1243,5 +1262,34 @@ mod tests {
             .await
             .unwrap();
         assert!(result.is_empty(), "timeout must return empty vec");
+    }
+
+    #[tokio::test]
+    async fn verify_timeout_increments_counter_and_crosses_threshold() {
+        let mut verifier = slow_verifier();
+        let task = TaskNode::new(0, "t", "d");
+        for _ in 0..3 {
+            let _ = verifier.verify(&task, "output").await;
+        }
+        assert_eq!(
+            verifier.consecutive_failures(),
+            3,
+            "three consecutive verify() timeouts must accumulate to 3 — the threshold the \
+             error! escalation arm checks"
+        );
+    }
+
+    #[tokio::test]
+    async fn verify_plan_timeout_increments_counter_and_crosses_threshold() {
+        let mut verifier = slow_verifier();
+        for _ in 0..3 {
+            let _ = verifier.verify_plan("goal", "output").await;
+        }
+        assert_eq!(
+            verifier.consecutive_failures(),
+            3,
+            "three consecutive verify_plan() timeouts must accumulate to 3 — the threshold \
+             the error! escalation arm checks"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- `PlanVerifier::verify` and `verify_plan` now emit `error!` once `consecutive_failures >= 3` on **timeout-driven** failures, mirroring the existing `Ok(Err(_))` path. Previously these arms only incremented the counter and warned, so a permanently slow `verify_provider` silently failed open forever (#3868).
- `replan` / `replan_from_plan` timeout arms left untouched — their `Ok(Err(_))` arms also do not track `consecutive_failures`; keeping symmetry.
- Documented the orchestration timeout fields added in #3860 by adding commented `aggregator_timeout_secs = 60`, `planner_timeout_secs = 120`, `verifier_timeout_secs = 30` entries in `[orchestration]` of `config/default.toml` (#3867). Defaults verified against the Serde `default_*` fns in `crates/zeph-config/src/experiment.rs`.

## Test plan

- [x] Added `verify_timeout_increments_counter_and_crosses_threshold` — drives `verify()` through 3 consecutive timeouts and asserts `consecutive_failures == 3` so the escalation arm fires.
- [x] Added `verify_plan_timeout_increments_counter_and_crosses_threshold` — same for `verify_plan()`.
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy -p zeph-orchestration --all-targets -- -D warnings`
- [x] `cargo nextest run -p zeph-orchestration -p zeph-config --lib` → **757 passed, 0 failed**
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-orchestration -p zeph-config`

Closes #3868
Closes #3867