### PR TITLE
fix(gateway): add timeout to webhook_tx.send() to prevent Axum worker stall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `zeph-config`: document the orchestration timeout fields added in #3860 — added commented
   `aggregator_timeout_secs = 60`, `planner_timeout_secs = 120`, and `verifier_timeout_secs = 30`
   entries in the `[orchestration]` section of `config/default.toml` (closes #3867).
+- `zeph-gateway`: `webhook_handler` now wraps `webhook_tx.send().await` in
+  `tokio::time::timeout`. When the agent cannot consume the message within the
+  configured window the handler returns `503 Service Unavailable` immediately
+  instead of blocking the Axum worker indefinitely. Timeout is configurable via
+  `gateway.webhook_send_timeout_secs` (default `5`). Builder method
+  `GatewayServer::with_webhook_timeout(Duration)` exposed for programmatic use
+  (closes #3844).
 - `zeph-orchestration`: wrap all LLM `.await` calls in `LlmAggregator::aggregate`,
   `LlmPlanner::plan`/`plan_with_hint`, `PlanVerifier::verify`/`replan`/`verify_plan`/`replan_from_plan`,
   and `plan_cache::adapt_plan` with `tokio::time::timeout`. New `OrchestrationConfig` fields:

--- a/config/default.toml
+++ b/config/default.toml
@@ -723,6 +723,8 @@ port = 8090
 rate_limit = 120
 # Maximum request body size in bytes (1MB)
 max_body_size = 1048576
+# Seconds to wait for the agent to consume a webhook message before returning 503
+webhook_send_timeout_secs = 5
 
 [metrics]
 # Enable Prometheus metrics export on the gateway /metrics endpoint.

--- a/crates/zeph-config/src/features.rs
+++ b/crates/zeph-config/src/features.rs
@@ -204,6 +204,10 @@ fn default_gateway_max_body() -> usize {
     1_048_576
 }
 
+fn default_gateway_webhook_send_timeout_secs() -> u64 {
+    5
+}
+
 /// Controls how skills are formatted in the system prompt.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -686,6 +690,7 @@ impl Default for CostConfig {
 /// auth_token = "secret"
 /// rate_limit = 60
 /// max_body_size = 1048576
+/// webhook_send_timeout_secs = 5
 /// ```
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GatewayConfig {
@@ -708,6 +713,10 @@ pub struct GatewayConfig {
     /// Maximum request body size in bytes. Must be `<= 10 MiB`. Default: `1048576` (1 MiB).
     #[serde(default = "default_gateway_max_body")]
     pub max_body_size: usize,
+    /// Maximum seconds to wait for the agent to consume a webhook message before
+    /// returning `503 Service Unavailable`. Default: `5`.
+    #[serde(default = "default_gateway_webhook_send_timeout_secs")]
+    pub webhook_send_timeout_secs: u64,
 }
 
 impl Default for GatewayConfig {
@@ -719,6 +728,7 @@ impl Default for GatewayConfig {
             auth_token: None,
             rate_limit: default_gateway_rate_limit(),
             max_body_size: default_gateway_max_body(),
+            webhook_send_timeout_secs: default_gateway_webhook_send_timeout_secs(),
         }
     }
 }

--- a/crates/zeph-gateway/src/handlers.rs
+++ b/crates/zeph-gateway/src/handlers.rs
@@ -77,13 +77,17 @@ struct HealthResponse {
 /// characters, then forwards the message as `"[sender@channel] body"` on the
 /// internal webhook channel.
 ///
+/// The send is wrapped in a timeout (`AppState::webhook_send_timeout`).  If the
+/// agent cannot consume the message within that window, the handler returns
+/// `503 Service Unavailable` rather than blocking the Axum worker indefinitely.
+///
 /// # Responses
 ///
 /// | Status | Condition |
 /// |---|---|
 /// | 200 | Message accepted and queued |
 /// | 422 | Payload failed field-length validation |
-/// | 503 | Internal channel is closed (agent shut down) |
+/// | 503 | Internal channel closed or send timed out due to backpressure |
 pub(crate) async fn webhook_handler(
     State(state): State<AppState>,
     payload: Result<Json<WebhookPayload>, JsonRejection>,
@@ -114,9 +118,9 @@ pub(crate) async fn webhook_handler(
     let sender = zeph_common::sanitize::strip_control_chars_preserve_whitespace(&payload.sender);
     let channel = zeph_common::sanitize::strip_control_chars_preserve_whitespace(&payload.channel);
     let msg = format!("[{}@{}] {}", sender, channel, payload.body);
-    match state.webhook_tx.send(msg).await {
-        Ok(()) => Json(WebhookResponse { status: "accepted" }).into_response(),
-        Err(_) => (
+    match tokio::time::timeout(state.webhook_send_timeout, state.webhook_tx.send(msg)).await {
+        Ok(Ok(())) => Json(WebhookResponse { status: "accepted" }).into_response(),
+        Ok(Err(_)) => (
             StatusCode::SERVICE_UNAVAILABLE,
             Json(ErrorResponse {
                 error: "agent unavailable".to_string(),
@@ -124,6 +128,20 @@ pub(crate) async fn webhook_handler(
             }),
         )
             .into_response(),
+        Err(_elapsed) => {
+            tracing::warn!(
+                timeout_secs = state.webhook_send_timeout.as_secs_f64(),
+                "webhook send timed out: agent backpressure"
+            );
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(ErrorResponse {
+                    error: "service unavailable: agent backpressure".to_string(),
+                    status: StatusCode::SERVICE_UNAVAILABLE.as_u16(),
+                }),
+            )
+                .into_response()
+        }
     }
 }
 
@@ -189,6 +207,7 @@ pub(crate) async fn metrics_handler(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{Duration, Instant};
 
     #[test]
     fn health_response_serializes() {
@@ -261,6 +280,35 @@ mod tests {
         let input = "he\x00llo";
         let result = zeph_common::sanitize::strip_control_chars_preserve_whitespace(input);
         assert_eq!(result, "hello");
+    }
+
+    /// When the webhook channel is full and the send times out, the handler must
+    /// return 503 rather than blocking the Axum worker indefinitely.
+    #[tokio::test]
+    async fn webhook_handler_returns_503_on_send_timeout() {
+        use axum::extract::State;
+        use axum::response::IntoResponse as _;
+
+        let (tx, _rx) = tokio::sync::mpsc::channel::<String>(1);
+        // Fill the channel so the next send() will block.
+        tx.send("fill".to_string()).await.unwrap();
+
+        let state = AppState {
+            webhook_tx: tx,
+            started_at: Instant::now(),
+            webhook_send_timeout: Duration::from_millis(5),
+        };
+
+        let payload = WebhookPayload {
+            channel: "ch".into(),
+            sender: "user".into(),
+            body: "hello".into(),
+        };
+
+        let response = webhook_handler(State(state), Ok(axum::Json(payload)))
+            .await
+            .into_response();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 
     #[test]

--- a/crates/zeph-gateway/src/router.rs
+++ b/crates/zeph-gateway/src/router.rs
@@ -189,6 +189,7 @@ mod tests {
         let state = AppState {
             webhook_tx: tx,
             started_at: Instant::now(),
+            webhook_send_timeout: std::time::Duration::from_secs(5),
         };
         (state, rx)
     }
@@ -221,6 +222,7 @@ mod tests {
         let state = AppState {
             webhook_tx: tx,
             started_at: Instant::now(),
+            webhook_send_timeout: std::time::Duration::from_secs(5),
         };
         let app = build_router(state, None, 0, 1_048_576);
 
@@ -404,6 +406,7 @@ mod tests {
         let state = AppState {
             webhook_tx: tx,
             started_at: Instant::now(),
+            webhook_send_timeout: std::time::Duration::from_secs(5),
         };
         let app = build_router(state, None, 0, 1_048_576);
 

--- a/crates/zeph-gateway/src/server.rs
+++ b/crates/zeph-gateway/src/server.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use std::net::SocketAddr;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use tokio::sync::{mpsc, watch};
 
@@ -19,6 +19,9 @@ pub(crate) struct AppState {
     pub webhook_tx: mpsc::Sender<String>,
     /// Monotonic timestamp recorded when the server started, used by `/health`.
     pub started_at: Instant,
+    /// Maximum time to wait for [`webhook_tx`] to accept a message before the
+    /// handler returns `503 Service Unavailable`.
+    pub webhook_send_timeout: Duration,
 }
 
 /// HTTP gateway server with bearer-auth, rate limiting, and body-size enforcement.
@@ -60,6 +63,7 @@ pub struct GatewayServer {
     auth_token: Option<String>,
     rate_limit: u32,
     max_body_size: usize,
+    webhook_send_timeout: Duration,
     webhook_tx: mpsc::Sender<String>,
     shutdown_rx: watch::Receiver<bool>,
     /// Prometheus metrics registry and endpoint path (feature-gated).
@@ -107,6 +111,7 @@ impl GatewayServer {
             auth_token: None,
             rate_limit: 120,
             max_body_size: 1_048_576,
+            webhook_send_timeout: Duration::from_secs(5),
             webhook_tx,
             shutdown_rx,
             #[cfg(feature = "prometheus")]
@@ -190,6 +195,31 @@ impl GatewayServer {
         self
     }
 
+    /// Set the maximum time the webhook handler will wait for the agent to
+    /// consume a message before returning `503 Service Unavailable`.
+    ///
+    /// The default is 5 seconds.  Set to a very large value to approximate
+    /// the previous unbounded behaviour (not recommended in production).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::time::Duration;
+    /// use tokio::sync::{mpsc, watch};
+    /// use zeph_gateway::GatewayServer;
+    ///
+    /// let (tx, _rx) = mpsc::channel::<String>(1);
+    /// let (_stx, srx) = watch::channel(false);
+    ///
+    /// let server = GatewayServer::new("127.0.0.1", 8080, tx, srx)
+    ///     .with_webhook_timeout(Duration::from_secs(10));
+    /// ```
+    #[must_use]
+    pub fn with_webhook_timeout(mut self, timeout: Duration) -> Self {
+        self.webhook_send_timeout = timeout;
+        self
+    }
+
     /// Attach a Prometheus metrics registry to the gateway.
     ///
     /// When set, the server mounts an additional route at `path` that returns the registry
@@ -244,6 +274,7 @@ impl GatewayServer {
         let state = AppState {
             webhook_tx: self.webhook_tx,
             started_at: Instant::now(),
+            webhook_send_timeout: self.webhook_send_timeout,
         };
 
         if self.auth_token.is_none() {
@@ -317,6 +348,7 @@ mod tests {
         let state = AppState {
             webhook_tx: server.webhook_tx,
             started_at: Instant::now(),
+            webhook_send_timeout: server.webhook_send_timeout,
         };
         let router = crate::router::build_router(
             state,

--- a/src/gateway_spawn.rs
+++ b/src/gateway_spawn.rs
@@ -155,7 +155,10 @@ pub(crate) fn spawn_gateway_server(
     )
     .with_auth(config.gateway.auth_token.clone())
     .with_rate_limit(config.gateway.rate_limit)
-    .with_max_body_size(config.gateway.max_body_size);
+    .with_max_body_size(config.gateway.max_body_size)
+    .with_webhook_timeout(std::time::Duration::from_secs(
+        config.gateway.webhook_send_timeout_secs,
+    ));
 
     #[cfg(feature = "prometheus")]
     let gw = if let Some((registry, path)) = metrics_registry {


### PR DESCRIPTION
## Summary

- Wraps `webhook_tx.send(msg).await` in `tokio::time::timeout` so a full or slow agent channel does not block the Axum HTTP worker indefinitely
- Returns `503 Service Unavailable` with a JSON error body on timeout; logs a warning with the configured window
- Adds `gateway.webhook_send_timeout_secs` (default `5`) to `GatewayConfig` and `config/default.toml`
- Exposes `GatewayServer::with_webhook_timeout(Duration)` builder method for programmatic control
- Adds unit test `webhook_handler_returns_503_on_send_timeout` covering the backpressure path

Closes #3844

## Test plan

- [x] `cargo nextest run -p zeph-gateway --lib` — 27 tests pass, including new `webhook_handler_returns_503_on_send_timeout`
- [x] `cargo nextest run --workspace --lib --bins` — 9324 tests pass
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --features "desktop,ide,server,chat,pdf,scheduler" -- -D warnings` — clean
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features -p zeph-gateway` — clean