### PR TITLE
fix(db): add 8 missing PostgreSQL migrations to reach SQLite parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-db`: add 8 missing PostgreSQL migration files to reach parity with SQLite schema
+  (migrations 069–071, 079–083): `trajectory_memory`, `message_category`, `memory_tree`,
+  `pending_beliefs` + `belief_evidence`, `safety_shadow_events`, `memflow_scrapmem`
+  (ScrapMem + EM-Graph), `episodic_consolidation`, and `experience_memory` — any deployment
+  using the `postgres` feature flag was missing these tables, causing silent empty results
+  (closes #3874).
 - `zeph-orchestration`: `PlanVerifier::verify` and `PlanVerifier::verify_plan` now check the
   `>= 3 consecutive_failures` escalation threshold on timeout-driven failures, not just LLM
   error returns. Previously, an over-loaded or misconfigured `verify_provider` that always

--- a/crates/zeph-db/migrations/postgres/069_trajectory_memory.sql
+++ b/crates/zeph-db/migrations/postgres/069_trajectory_memory.sql
@@ -1,0 +1,24 @@
+-- Trajectory-informed memory (#2498).
+-- Stores per-conversation procedural and episodic entries extracted from tool-call turns.
+CREATE TABLE IF NOT EXISTS trajectory_memory (
+    id              BIGSERIAL PRIMARY KEY,
+    conversation_id BIGINT REFERENCES conversations(id),
+    turn_index      BIGINT NOT NULL,
+    kind            TEXT NOT NULL CHECK(kind IN ('procedural', 'episodic')),
+    intent          TEXT NOT NULL,
+    outcome         TEXT NOT NULL,
+    tools_used      TEXT NOT NULL DEFAULT '[]',
+    confidence      REAL NOT NULL DEFAULT 0.8,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_trajectory_kind ON trajectory_memory(kind);
+CREATE INDEX IF NOT EXISTS idx_trajectory_conversation ON trajectory_memory(conversation_id);
+
+-- Per-conversation extraction watermark: tracks the last message id processed per conversation.
+CREATE TABLE IF NOT EXISTS trajectory_meta (
+    conversation_id BIGINT PRIMARY KEY REFERENCES conversations(id) ON DELETE CASCADE,
+    last_extracted_message_id BIGINT NOT NULL DEFAULT 0,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/crates/zeph-db/migrations/postgres/070_message_category.sql
+++ b/crates/zeph-db/migrations/postgres/070_message_category.sql
@@ -1,0 +1,6 @@
+-- Category-aware memory (#2428).
+-- Adds nullable category column to messages for skill/tool-based auto-tagging.
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS category TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_messages_category ON messages(category)
+    WHERE category IS NOT NULL;

--- a/crates/zeph-db/migrations/postgres/071_memory_tree.sql
+++ b/crates/zeph-db/migrations/postgres/071_memory_tree.sql
@@ -1,0 +1,29 @@
+-- TiMem temporal-hierarchical memory tree (#2262).
+-- Stores leaf memories and consolidated summaries in a hierarchy.
+CREATE TABLE IF NOT EXISTS memory_tree (
+    id              BIGSERIAL PRIMARY KEY,
+    level           BIGINT NOT NULL DEFAULT 0,
+    parent_id       BIGINT REFERENCES memory_tree(id),
+    content         TEXT NOT NULL,
+    source_ids      TEXT NOT NULL DEFAULT '[]',
+    token_count     BIGINT NOT NULL DEFAULT 0,
+    consolidated_at TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_tree_level ON memory_tree(level);
+CREATE INDEX IF NOT EXISTS idx_memory_tree_parent ON memory_tree(parent_id);
+-- Fast lookup of unconsolidated leaves (level=0, no parent yet).
+CREATE INDEX IF NOT EXISTS idx_memory_tree_unconsolidated
+    ON memory_tree(level, parent_id)
+    WHERE level = 0 AND parent_id IS NULL;
+
+-- Meta tracking for consolidation progress (tree-wide stats only, not per-conversation).
+CREATE TABLE IF NOT EXISTS memory_tree_meta (
+    id                      BIGINT PRIMARY KEY CHECK(id = 1),
+    last_consolidation_at   TIMESTAMPTZ,
+    total_consolidations    BIGINT NOT NULL DEFAULT 0,
+    updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO memory_tree_meta (id) VALUES (1) ON CONFLICT DO NOTHING;

--- a/crates/zeph-db/migrations/postgres/079_pending_beliefs.sql
+++ b/crates/zeph-db/migrations/postgres/079_pending_beliefs.sql
@@ -1,9 +1,45 @@
 -- SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 -- SPDX-License-Identifier: MIT OR Apache-2.0
 
--- TODO: Port pending_beliefs + belief_evidence tables from SQLite migration 084 to PostgreSQL.
--- Differences to address:
---   - REFERENCES graph_entities(id) / graph_edges(id): add ON DELETE CASCADE if desired
---   - unixepoch() → EXTRACT(EPOCH FROM NOW())::BIGINT
---   - Partial indexes: supported in PostgreSQL, no changes needed
---   - prob CHECK constraint: supported in PostgreSQL unchanged
+-- Pre-commitment probabilistic edge layer for BeliefMem (issue #3706).
+-- Candidate facts accumulate evidence via Noisy-OR before promotion to committed graph_edges.
+
+CREATE TABLE IF NOT EXISTS pending_beliefs (
+    id                  BIGSERIAL PRIMARY KEY,
+    source_entity_id    BIGINT NOT NULL REFERENCES graph_entities(id),
+    target_entity_id    BIGINT NOT NULL REFERENCES graph_entities(id),
+    relation            TEXT NOT NULL,
+    canonical_relation  TEXT NOT NULL,
+    fact                TEXT NOT NULL,
+    edge_type           TEXT NOT NULL DEFAULT 'semantic',
+    prob                REAL NOT NULL CHECK (prob > 0.0 AND prob < 1.0),
+    episode_id          TEXT,
+    created_at          BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT,
+    updated_at          BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT,
+    promoted_at         BIGINT,
+    promoted_edge_id    BIGINT REFERENCES graph_edges(id)
+);
+
+-- Primary lookup: find existing belief for the same (source, canonical_relation, target, edge_type)
+CREATE INDEX IF NOT EXISTS idx_pending_beliefs_lookup
+    ON pending_beliefs(source_entity_id, canonical_relation, target_entity_id, edge_type)
+    WHERE promoted_at IS NULL;
+
+-- Retrieval: top-K candidates by probability for a (source, canonical_relation) query
+CREATE INDEX IF NOT EXISTS idx_pending_beliefs_retrieval
+    ON pending_beliefs(source_entity_id, canonical_relation, prob)
+    WHERE promoted_at IS NULL;
+
+-- Each observation that contributed to a belief's cumulative probability via Noisy-OR
+CREATE TABLE IF NOT EXISTS belief_evidence (
+    id              BIGSERIAL PRIMARY KEY,
+    belief_id       BIGINT NOT NULL REFERENCES pending_beliefs(id) ON DELETE CASCADE,
+    prior_prob      REAL NOT NULL,
+    evidence_prob   REAL NOT NULL,
+    posterior_prob  REAL NOT NULL,
+    episode_id      TEXT,
+    created_at      BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT
+);
+
+CREATE INDEX IF NOT EXISTS idx_belief_evidence_belief
+    ON belief_evidence(belief_id, created_at);

--- a/crates/zeph-db/migrations/postgres/080_safety_shadow_events.sql
+++ b/crates/zeph-db/migrations/postgres/080_safety_shadow_events.sql
@@ -1,0 +1,30 @@
+-- Migration: 080_safety_shadow_events.sql
+-- Persistent safety memory stream for ShadowSentinel Phase 2 (spec 050).
+-- Stores all safety-relevant tool events across sessions for cross-session
+-- pattern detection and LLM probe context assembly.
+CREATE TABLE IF NOT EXISTS safety_shadow_events (
+    id              BIGSERIAL PRIMARY KEY,
+    session_id      TEXT NOT NULL,
+    turn_number     BIGINT NOT NULL,
+    event_type      TEXT NOT NULL,
+    tool_id         TEXT,
+    risk_signal     TEXT,
+    risk_level      TEXT NOT NULL,
+    probe_verdict   TEXT,
+    context_summary TEXT,
+    created_at      BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT
+);
+
+-- Session replay: retrieve full trajectory ordered by time
+CREATE INDEX IF NOT EXISTS idx_shadow_events_session
+    ON safety_shadow_events(session_id, created_at);
+
+-- Cross-session pattern detection: find similar tool sequences across sessions
+CREATE INDEX IF NOT EXISTS idx_shadow_events_tool
+    ON safety_shadow_events(tool_id, created_at DESC)
+    WHERE tool_id IS NOT NULL;
+
+-- Probe audit: find all probe verdicts for a session efficiently
+CREATE INDEX IF NOT EXISTS idx_shadow_events_probe
+    ON safety_shadow_events(session_id, event_type)
+    WHERE event_type = 'probe_result';

--- a/crates/zeph-db/migrations/postgres/081_memflow_scrapmem.sql
+++ b/crates/zeph-db/migrations/postgres/081_memflow_scrapmem.sql
@@ -1,0 +1,32 @@
+-- Migration: 081_memflow_scrapmem.sql
+-- MemFlow tiered retrieval (issue #3712) and ScrapMem optical forgetting + EM-Graph (issue #3713).
+
+-- ScrapMem optical forgetting: progressive content-fidelity decay on stored messages.
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS content_fidelity TEXT NOT NULL DEFAULT 'Full';
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS compressed_content TEXT;
+
+-- Episodic Memory Graph (EM-Graph): causal-temporal event extraction.
+-- No CASCADE: messages are never deleted (spec 001-6).
+CREATE TABLE IF NOT EXISTS episodic_events (
+    id          BIGSERIAL PRIMARY KEY,
+    session_id  TEXT NOT NULL,
+    message_id  BIGINT NOT NULL REFERENCES messages(id),
+    event_type  TEXT NOT NULL,
+    summary     TEXT NOT NULL,
+    embedding   BYTEA,
+    created_at  BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT
+);
+
+CREATE TABLE IF NOT EXISTS causal_links (
+    id              BIGSERIAL PRIMARY KEY,
+    cause_event_id  BIGINT NOT NULL REFERENCES episodic_events(id),
+    effect_event_id BIGINT NOT NULL REFERENCES episodic_events(id),
+    strength        REAL NOT NULL DEFAULT 1.0,
+    created_at      BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT,
+    UNIQUE(cause_event_id, effect_event_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_episodic_events_session ON episodic_events(session_id);
+CREATE INDEX IF NOT EXISTS idx_episodic_events_message ON episodic_events(message_id);
+CREATE INDEX IF NOT EXISTS idx_causal_links_cause ON causal_links(cause_event_id);
+CREATE INDEX IF NOT EXISTS idx_causal_links_effect ON causal_links(effect_event_id);

--- a/crates/zeph-db/migrations/postgres/082_episodic_consolidation.sql
+++ b/crates/zeph-db/migrations/postgres/082_episodic_consolidation.sql
@@ -1,0 +1,29 @@
+-- Migration: 082_episodic_consolidation.sql
+-- Episodic-to-semantic consolidation daemon tracking (issue #3799).
+
+-- Track which episodic events have been processed by the consolidation daemon.
+ALTER TABLE episodic_events ADD COLUMN IF NOT EXISTS consolidated_at BIGINT;
+
+-- Consolidated facts promoted from episodic events.
+CREATE TABLE IF NOT EXISTS consolidated_facts (
+    id               BIGSERIAL PRIMARY KEY,
+    fact_text        TEXT NOT NULL,
+    source           TEXT NOT NULL DEFAULT 'episodic_consolidation',
+    cognitive_weight REAL NOT NULL DEFAULT 0.0,
+    created_at       BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT
+);
+
+-- Link table: which episodic events contributed to which consolidated fact.
+CREATE TABLE IF NOT EXISTS consolidated_fact_sources (
+    id       BIGSERIAL PRIMARY KEY,
+    fact_id  BIGINT NOT NULL REFERENCES consolidated_facts(id),
+    event_id BIGINT NOT NULL REFERENCES episodic_events(id),
+    UNIQUE(fact_id, event_id)
+);
+
+-- Vector representations stored separately in Qdrant `zeph_key_facts` collection.
+CREATE INDEX IF NOT EXISTS idx_episodic_events_consolidated ON episodic_events(consolidated_at);
+CREATE INDEX IF NOT EXISTS idx_episodic_events_created ON episodic_events(created_at);
+CREATE INDEX IF NOT EXISTS idx_consolidated_facts_source ON consolidated_facts(source);
+CREATE INDEX IF NOT EXISTS idx_consolidated_fact_sources_fact ON consolidated_fact_sources(fact_id);
+CREATE INDEX IF NOT EXISTS idx_consolidated_fact_sources_event ON consolidated_fact_sources(event_id);

--- a/crates/zeph-db/migrations/postgres/083_experience_memory.sql
+++ b/crates/zeph-db/migrations/postgres/083_experience_memory.sql
@@ -1,0 +1,35 @@
+-- SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+-- SPDX-License-Identifier: MIT OR Apache-2.0
+
+-- Experience nodes: records of tool execution outcomes in the agent loop
+CREATE TABLE IF NOT EXISTS experience_nodes (
+    id          BIGSERIAL PRIMARY KEY,
+    session_id  TEXT    NOT NULL,
+    turn        BIGINT  NOT NULL,
+    tool_name   TEXT    NOT NULL,
+    outcome     TEXT    NOT NULL,
+    detail      TEXT,
+    error_ctx   TEXT,
+    created_at  BIGINT  NOT NULL
+);
+
+-- Experience edges: temporal sequence between consecutive experience nodes
+CREATE TABLE IF NOT EXISTS experience_edges (
+    id              BIGSERIAL PRIMARY KEY,
+    source_exp_id   BIGINT NOT NULL REFERENCES experience_nodes(id),
+    target_exp_id   BIGINT NOT NULL REFERENCES experience_nodes(id),
+    relation        TEXT   NOT NULL DEFAULT 'followed_by'
+);
+
+-- Links between experience nodes and knowledge graph entities
+CREATE TABLE IF NOT EXISTS experience_entity_links (
+    experience_id   BIGINT NOT NULL REFERENCES experience_nodes(id),
+    entity_id       BIGINT NOT NULL REFERENCES graph_entities(id),
+    PRIMARY KEY (experience_id, entity_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_experience_nodes_session      ON experience_nodes(session_id, turn);
+CREATE INDEX IF NOT EXISTS idx_experience_nodes_tool         ON experience_nodes(tool_name);
+CREATE INDEX IF NOT EXISTS idx_experience_entity_links       ON experience_entity_links(entity_id);
+-- Added by migration 082 (episodic_consolidation uses this for session-time lookups)
+CREATE INDEX IF NOT EXISTS idx_experience_nodes_session_time ON experience_nodes(session_id, created_at);


### PR DESCRIPTION
## Summary

- Add 7 new PostgreSQL migration files (069-071, 080-083) that had no postgres counterpart
- Replace `079_pending_beliefs.sql` TODO stub with full DDL including `belief_evidence` table
- PostgreSQL backend is now at parity with SQLite schema through migration 087

## Missing migrations addressed

| Postgres file | Content | SQLite source |
|---------------|---------|---------------|
| `069_trajectory_memory.sql` | `trajectory_memory`, `trajectory_meta` tables | SQLite 069 |
| `070_message_category.sql` | `category` column on `messages` | SQLite 070 |
| `071_memory_tree.sql` | `memory_tree`, `memory_tree_meta` tables | SQLite 071 |
| `079_pending_beliefs.sql` | `pending_beliefs`, `belief_evidence` tables (was TODO stub) | SQLite 084 |
| `080_safety_shadow_events.sql` | `safety_shadow_events` table | SQLite 085 |
| `081_memflow_scrapmem.sql` | ScrapMem columns + `episodic_events`, `causal_links` | SQLite 086 |
| `082_episodic_consolidation.sql` | `consolidated_facts`, `consolidated_fact_sources` | SQLite 087 |
| `083_experience_memory.sql` | `experience_nodes`, `experience_edges`, `experience_entity_links` | SQLite 076 |

Note: postgres migrations 075-078 already fully cover SQLite 080-083 — no duplicates added.

## Test plan

- [ ] Apply migrations against a fresh PostgreSQL instance: `cargo sqlx migrate run --source crates/zeph-db/migrations/postgres`
- [ ] Verify all new tables and indexes are created without error
- [ ] Confirm `SELECT * FROM trajectory_memory LIMIT 0` and equivalent queries succeed for all new tables
- [ ] Run `cargo nextest run --workspace --lib --bins` to confirm no regressions

Closes #3874