### PR TITLE
perf(channels,memory): add tracing instrumentation to Discord, Slack and GraphExtractor

### DIFF
--- a/crates/zeph-channels/src/discord/mod.rs
+++ b/crates/zeph-channels/src/discord/mod.rs
@@ -91,6 +91,10 @@ impl DiscordChannel {
             .is_none_or(|last| last.elapsed() > EDIT_THROTTLE)
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "channel.discord.send_or_edit", skip_all, level = "debug", fields(buf_len = %self.accumulated.len()))
+    )]
     async fn send_or_edit(&mut self) -> Result<(), ChannelError> {
         let channel_id = self
             .channel_id
@@ -168,6 +172,10 @@ impl Channel for DiscordChannel {
         }
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "channel.discord.recv", skip_all, fields(msg_len = tracing::field::Empty))
+    )]
     async fn recv(&mut self) -> Result<Option<ChannelMessage>, ChannelError> {
         loop {
             let Some(incoming) = self.rx.recv().await else {
@@ -196,6 +204,10 @@ impl Channel for DiscordChannel {
         }
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "channel.discord.send", skip_all, fields(msg_len = %text.len()))
+    )]
     async fn send(&mut self, text: &str) -> Result<(), ChannelError> {
         let channel_id = self
             .channel_id
@@ -219,6 +231,10 @@ impl Channel for DiscordChannel {
         Ok(())
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "channel.discord.send_chunk", skip_all, level = "debug", fields(chunk_len = %chunk.len()))
+    )]
     async fn send_chunk(&mut self, chunk: &str) -> Result<(), ChannelError> {
         self.accumulated.push_str(chunk);
         if self.should_send_update() {
@@ -227,6 +243,10 @@ impl Channel for DiscordChannel {
         Ok(())
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "channel.discord.flush_chunks", skip_all, level = "debug")
+    )]
     async fn flush_chunks(&mut self) -> Result<(), ChannelError> {
         if self.message_id.is_some() {
             self.send_or_edit().await?;
@@ -237,6 +257,10 @@ impl Channel for DiscordChannel {
         Ok(())
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "channel.discord.send_typing", skip_all, level = "debug")
+    )]
     async fn send_typing(&mut self) -> Result<(), ChannelError> {
         let Some(channel_id) = self.channel_id.as_deref() else {
             return Ok(());
@@ -245,6 +269,10 @@ impl Channel for DiscordChannel {
         Ok(())
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "channel.discord.confirm", skip_all, fields(prompt_len = %prompt.len()))
+    )]
     async fn confirm(&mut self, prompt: &str) -> Result<bool, ChannelError> {
         self.send(&format!(
             "{prompt}\nReply 'yes' to confirm (timeout: {}s).",

--- a/crates/zeph-channels/src/slack/mod.rs
+++ b/crates/zeph-channels/src/slack/mod.rs
@@ -88,6 +88,10 @@ impl SlackChannel {
             .is_none_or(|last| last.elapsed() > EDIT_THROTTLE)
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "channel.slack.send_or_edit", skip_all, level = "debug", fields(buf_len = %self.accumulated.len()))
+    )]
     async fn send_or_edit(&mut self) -> Result<(), ChannelError> {
         let channel_id = self
             .channel_id
@@ -144,6 +148,10 @@ impl Channel for SlackChannel {
         })
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "channel.slack.recv", skip_all, fields(msg_len = tracing::field::Empty))
+    )]
     async fn recv(&mut self) -> Result<Option<ChannelMessage>, ChannelError> {
         let Some(incoming) = self.rx.recv().await else {
             return Ok(None);
@@ -178,6 +186,10 @@ impl Channel for SlackChannel {
         }))
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "channel.slack.send", skip_all, fields(msg_len = %text.len()))
+    )]
     async fn send(&mut self, text: &str) -> Result<(), ChannelError> {
         let channel_id = self
             .channel_id
@@ -191,6 +203,10 @@ impl Channel for SlackChannel {
         Ok(())
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "channel.slack.send_chunk", skip_all, level = "debug", fields(chunk_len = %chunk.len()))
+    )]
     async fn send_chunk(&mut self, chunk: &str) -> Result<(), ChannelError> {
         self.accumulated.push_str(chunk);
         if self.should_send_update() {
@@ -199,6 +215,10 @@ impl Channel for SlackChannel {
         Ok(())
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "channel.slack.flush_chunks", skip_all, level = "debug")
+    )]
     async fn flush_chunks(&mut self) -> Result<(), ChannelError> {
         if self.message_ts.is_some() {
             self.send_or_edit().await?;
@@ -209,6 +229,10 @@ impl Channel for SlackChannel {
         Ok(())
     }
 
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "channel.slack.confirm", skip_all, fields(prompt_len = %prompt.len()))
+    )]
     async fn confirm(&mut self, prompt: &str) -> Result<bool, ChannelError> {
         self.send(&format!(
             "{prompt}\nReply 'yes' to confirm (timeout: {}s).",

--- a/crates/zeph-memory/src/graph/extractor.rs
+++ b/crates/zeph-memory/src/graph/extractor.rs
@@ -122,6 +122,7 @@ impl GraphExtractor {
     ///
     /// Returns an error only for transport-level failures (network, auth).
     /// JSON parse failures are logged and return `Ok(None)`.
+    #[tracing::instrument(name = "memory.graph.extract", skip_all, level = "debug", err)]
     pub async fn extract(
         &self,
         message: &str,


### PR DESCRIPTION
## Summary

- Add `#[cfg_attr(feature = "profiling", tracing::instrument(...))]` to all async `Channel` trait methods in `discord/mod.rs` (7 spans) and `slack/mod.rs` (6 spans) — matching the existing pattern from `telegram.rs` and `cli.rs`
- Add unconditional `#[tracing::instrument(name = "memory.graph.extract", skip_all, level = "debug", err)]` to `GraphExtractor::extract` in `zeph-memory` — an LLM-bound async fn previously invisible in Perfetto traces

Span names follow the `<crate_short>.<subsystem>.<op>` convention: `channel.discord.*`, `channel.slack.*`, `memory.graph.extract`. Pure instrumentation — zero logic changes.

Closes #3852
Closes #3831

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --features "desktop,ide,server,chat,pdf,scheduler" --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 9323 passed, 21 skipped