### PR TITLE
refactor(skills): introduce SkillEmbedding newtype for Vec<f32> embedding vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- `zeph-skills`: skill embedding vectors are now typed as `SkillEmbedding(Vec<f32>)` instead
+  of raw `Vec<f32>`. The newtype carries its dimension and requires explicit construction via
+  `SkillEmbedding::new(vec, expected_dim)` (validated) or `SkillEmbedding::from_raw(vec)`
+  (trusted provider boundary). All call sites in `SkillMatcher`, `CategoryMatcher`, and
+  `SkillMiner` — including test helpers — have been migrated. `EmbeddingDimMismatch` error
+  variant added to `SkillError` for future runtime validation (closes #3804).
+
 ### Fixed
 
 - `zeph-db`: add 8 missing PostgreSQL migration files to reach parity with SQLite schema

--- a/crates/zeph-skills/src/embedding.rs
+++ b/crates/zeph-skills/src/embedding.rs
@@ -1,0 +1,207 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Validated embedding vector newtype for skill matching.
+//!
+//! [`SkillEmbedding`] wraps a `Vec<f32>` and enforces dimension consistency at
+//! construction time, eliminating silent zero-similarity results from
+//! `cosine_similarity` when vectors of different lengths are compared.
+//!
+//! # Examples
+//!
+//! ```
+//! use zeph_skills::embedding::SkillEmbedding;
+//!
+//! // Validated construction — dimension is checked once at the boundary.
+//! let emb = SkillEmbedding::new(vec![1.0, 0.0, 0.0], 3).unwrap();
+//! assert_eq!(emb.dim(), 3);
+//!
+//! // AsRef<[f32]> keeps cosine_similarity call sites unchanged.
+//! let slice: &[f32] = emb.as_ref();
+//! assert_eq!(slice.len(), 3);
+//!
+//! // Mismatch is caught at construction.
+//! assert!(SkillEmbedding::new(vec![1.0, 0.0], 3).is_err());
+//! ```
+
+use crate::error::SkillError;
+
+/// Validated embedding vector for skill matching.
+///
+/// Wraps a `Vec<f32>` with a dimension guarantee: the length is checked at
+/// construction time and cannot change afterwards. This prevents silent
+/// cosine-similarity bugs where mismatched dimensions return `0.0`.
+///
+/// Use [`SkillEmbedding::new`] when an expected dimension is known (e.g. when
+/// storing a centroid alongside other embeddings). Use [`SkillEmbedding::from_raw`]
+/// at the embedding-provider boundary where the dimension is whatever the model
+/// returns and no cross-check is yet possible.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_skills::embedding::SkillEmbedding;
+///
+/// let emb = SkillEmbedding::new(vec![0.0, 1.0], 2).unwrap();
+/// assert_eq!(emb.dim(), 2);
+/// assert_eq!(emb.as_ref(), &[0.0_f32, 1.0]);
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct SkillEmbedding(Vec<f32>);
+
+impl SkillEmbedding {
+    /// Create a validated embedding vector.
+    ///
+    /// Checks that `vec.len() == expected_dim`. Use this when you know what
+    /// dimension all embeddings in a collection must share (e.g. centroid
+    /// construction, deduplication).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SkillError::EmbeddingDimMismatch`] if `vec.len() != expected_dim`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_skills::embedding::SkillEmbedding;
+    ///
+    /// let ok = SkillEmbedding::new(vec![1.0, 0.0], 2);
+    /// assert!(ok.is_ok());
+    ///
+    /// let err = SkillEmbedding::new(vec![1.0, 0.0], 3);
+    /// assert!(err.is_err());
+    /// ```
+    pub fn new(vec: Vec<f32>, expected_dim: usize) -> Result<Self, SkillError> {
+        if vec.len() != expected_dim {
+            return Err(SkillError::EmbeddingDimMismatch {
+                expected: expected_dim,
+                actual: vec.len(),
+            });
+        }
+        Ok(Self(vec))
+    }
+
+    /// Create a `SkillEmbedding` without dimension validation.
+    ///
+    /// Use only at the embedding-provider boundary — i.e., immediately after
+    /// receiving a vector from `embed_fn` or `embed_provider.embed()` within
+    /// a single call chain. The caller guarantees that all embeddings wrapped
+    /// with `from_raw` in the same matcher or miner session were produced by
+    /// the same model, ensuring dimensional consistency throughout the
+    /// collection.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_skills::embedding::SkillEmbedding;
+    ///
+    /// // At the provider boundary: dimension is whatever the model returns.
+    /// let raw = vec![0.1_f32, 0.2, 0.3];
+    /// let emb = SkillEmbedding::from_raw(raw);
+    /// assert_eq!(emb.dim(), 3);
+    /// ```
+    #[must_use]
+    pub fn from_raw(vec: Vec<f32>) -> Self {
+        Self(vec)
+    }
+
+    /// The number of dimensions in this embedding.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_skills::embedding::SkillEmbedding;
+    ///
+    /// let emb = SkillEmbedding::from_raw(vec![0.0; 768]);
+    /// assert_eq!(emb.dim(), 768);
+    /// ```
+    #[must_use]
+    pub fn dim(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Consume the wrapper and return the inner vector.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_skills::embedding::SkillEmbedding;
+    ///
+    /// let v = vec![1.0_f32, 2.0, 3.0];
+    /// let emb = SkillEmbedding::from_raw(v.clone());
+    /// assert_eq!(emb.into_inner(), v);
+    /// ```
+    #[must_use]
+    pub fn into_inner(self) -> Vec<f32> {
+        self.0
+    }
+}
+
+impl AsRef<[f32]> for SkillEmbedding {
+    fn as_ref(&self) -> &[f32] {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_valid_dimension() {
+        let emb = SkillEmbedding::new(vec![1.0, 0.0, 0.0], 3).unwrap();
+        assert_eq!(emb.dim(), 3);
+    }
+
+    #[test]
+    fn new_dimension_mismatch() {
+        let err = SkillEmbedding::new(vec![1.0, 0.0], 3).unwrap_err();
+        assert!(matches!(
+            err,
+            SkillError::EmbeddingDimMismatch {
+                expected: 3,
+                actual: 2
+            }
+        ));
+    }
+
+    #[test]
+    fn from_raw_any_dimension() {
+        let emb = SkillEmbedding::from_raw(vec![]);
+        assert_eq!(emb.dim(), 0);
+
+        let emb = SkillEmbedding::from_raw(vec![1.0; 1024]);
+        assert_eq!(emb.dim(), 1024);
+    }
+
+    #[test]
+    fn dim_accessor() {
+        assert_eq!(SkillEmbedding::from_raw(vec![0.0; 7]).dim(), 7);
+    }
+
+    #[test]
+    fn as_ref_returns_slice() {
+        let v = vec![1.0_f32, 2.0, 3.0];
+        let emb = SkillEmbedding::from_raw(v.clone());
+        assert_eq!(emb.as_ref(), v.as_slice());
+    }
+
+    #[test]
+    fn into_inner_returns_vec() {
+        let v = vec![0.5_f32, 1.0];
+        let emb = SkillEmbedding::from_raw(v.clone());
+        assert_eq!(emb.into_inner(), v);
+    }
+
+    #[test]
+    fn clone_preserves_data() {
+        let emb = SkillEmbedding::from_raw(vec![1.0, 2.0]);
+        assert_eq!(emb.clone(), emb);
+    }
+
+    #[test]
+    fn new_empty_dimension_zero() {
+        let emb = SkillEmbedding::new(vec![], 0).unwrap();
+        assert_eq!(emb.dim(), 0);
+    }
+}

--- a/crates/zeph-skills/src/error.rs
+++ b/crates/zeph-skills/src/error.rs
@@ -67,6 +67,19 @@ pub enum SkillError {
     #[error("skill generation timed out after {0}ms")]
     Timeout(u64),
 
+    /// Embedding vector length does not match the expected model dimension.
+    ///
+    /// Raised by [`crate::embedding::SkillEmbedding::new`] when the provided vector length
+    /// differs from `expected_dim`. Prevents silent zero-similarity results caused by
+    /// mismatched dimensions in `cosine_similarity`.
+    #[error("embedding dimension mismatch: expected {expected}, got {actual}")]
+    EmbeddingDimMismatch {
+        /// Dimension that was expected.
+        expected: usize,
+        /// Dimension of the provided vector.
+        actual: usize,
+    },
+
     /// Catch-all for errors that do not fit the above categories.
     #[error("{0}")]
     Other(String),

--- a/crates/zeph-skills/src/lib.rs
+++ b/crates/zeph-skills/src/lib.rs
@@ -53,6 +53,7 @@
 
 pub mod bm25;
 pub mod bundled;
+pub mod embedding;
 pub mod erl;
 pub mod error;
 pub mod evaluator;
@@ -76,6 +77,7 @@ pub mod trust_score;
 pub mod watcher;
 
 pub use bundled::bundled_skill_names;
+pub use embedding::SkillEmbedding;
 pub use error::SkillError;
 pub use evaluator::{
     EvaluationWeights, SkillEvaluationRequest, SkillEvaluator, SkillQualityScore, SkillVerdict,

--- a/crates/zeph-skills/src/matcher.rs
+++ b/crates/zeph-skills/src/matcher.rs
@@ -51,6 +51,7 @@ use std::time::Duration;
 use schemars::JsonSchema;
 use serde::Deserialize;
 
+use crate::embedding::SkillEmbedding;
 use crate::error::SkillError;
 use crate::loader::SkillMeta;
 use futures::stream::{self, StreamExt};
@@ -168,7 +169,7 @@ struct CategoryMatcher {
     /// Only categories with ≥ 2 embedded skills are stored here.
     categories: HashMap<String, Vec<usize>>,
     /// Centroid embedding per category.
-    centroids: HashMap<String, Vec<f32>>,
+    centroids: HashMap<String, SkillEmbedding>,
     /// Embedding positions for uncategorized skills or singleton-category skills.
     uncategorized: Vec<usize>,
 }
@@ -176,7 +177,7 @@ struct CategoryMatcher {
 impl CategoryMatcher {
     /// Build from completed embeddings. `skills` is the original skill slice passed to
     /// `SkillMatcher::new`; `embeddings` is the successful subset.
-    fn build(skills: &[&SkillMeta], embeddings: &[(usize, Vec<f32>)]) -> Self {
+    fn build(skills: &[&SkillMeta], embeddings: &[(usize, SkillEmbedding)]) -> Self {
         // Group embedding positions by category.
         let mut by_category: HashMap<String, Vec<usize>> = HashMap::new();
         let mut uncategorized: Vec<usize> = Vec::new();
@@ -199,12 +200,12 @@ impl CategoryMatcher {
         }
 
         // Compute centroids for multi-skill categories.
-        let mut centroids: HashMap<String, Vec<f32>> = HashMap::new();
+        let mut centroids: HashMap<String, SkillEmbedding> = HashMap::new();
         for (cat, positions) in &categories {
-            let dim = embeddings[positions[0]].1.len();
+            let dim = embeddings[positions[0]].1.dim();
             let mut centroid = vec![0.0f32; dim];
             for &pos in positions {
-                for (c, v) in centroid.iter_mut().zip(embeddings[pos].1.iter()) {
+                for (c, v) in centroid.iter_mut().zip(embeddings[pos].1.as_ref()) {
                     *c += v;
                 }
             }
@@ -213,7 +214,7 @@ impl CategoryMatcher {
             for c in &mut centroid {
                 *c /= n;
             }
-            centroids.insert(cat.clone(), centroid);
+            centroids.insert(cat.clone(), SkillEmbedding::from_raw(centroid));
         }
 
         Self {
@@ -235,7 +236,12 @@ impl CategoryMatcher {
         let mut cat_scores: Vec<(&str, f32)> = self
             .centroids
             .iter()
-            .map(|(cat, centroid)| (cat.as_str(), cosine_similarity(query_vec, centroid)))
+            .map(|(cat, centroid)| {
+                (
+                    cat.as_str(),
+                    cosine_similarity(query_vec, centroid.as_ref()),
+                )
+            })
             .collect();
         cat_scores
             .sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
@@ -252,7 +258,7 @@ impl CategoryMatcher {
 
 #[derive(Debug, Clone)]
 pub struct SkillMatcher {
-    embeddings: Vec<(usize, Vec<f32>)>,
+    embeddings: Vec<(usize, SkillEmbedding)>,
     /// Populated when at least 2 multi-skill categories exist.
     category_matcher: Option<CategoryMatcher>,
 }
@@ -293,7 +299,7 @@ impl SkillMatcher {
 
         for (i, name, result) in raw {
             match result {
-                Ok(vec) => embeddings.push((i, vec)),
+                Ok(vec) => embeddings.push((i, SkillEmbedding::from_raw(vec))),
                 Err(Some(zeph_llm::LlmError::EmbedUnsupported { provider })) => {
                     unsupported_provider = Some(provider);
                     unsupported_count += 1;
@@ -337,7 +343,7 @@ impl SkillMatcher {
         self.embeddings
             .iter()
             .find(|(idx, _)| *idx == skill_index)
-            .map(|(_, v)| v.as_slice())
+            .map(|(_, v)| v.as_ref())
     }
 
     /// Match a user query against stored skill embeddings, returning the top-K scored matches
@@ -389,7 +395,7 @@ impl SkillMatcher {
                 .iter()
                 .map(|&pos| ScoredMatch {
                     index: self.embeddings[pos].0,
-                    score: cosine_similarity(&query_vec, &self.embeddings[pos].1),
+                    score: cosine_similarity(&query_vec, self.embeddings[pos].1.as_ref()),
                 })
                 .collect(),
             None => self
@@ -397,7 +403,7 @@ impl SkillMatcher {
                 .iter()
                 .map(|(idx, emb)| ScoredMatch {
                     index: *idx,
-                    score: cosine_similarity(&query_vec, emb),
+                    score: cosine_similarity(&query_vec, emb.as_ref()),
                 })
                 .collect(),
         };
@@ -436,7 +442,8 @@ impl SkillMatcher {
         let mut pairs = Vec::new();
         for i in 0..self.embeddings.len() {
             for j in (i + 1)..self.embeddings.len() {
-                let sim = cosine_similarity(&self.embeddings[i].1, &self.embeddings[j].1);
+                let sim =
+                    cosine_similarity(self.embeddings[i].1.as_ref(), self.embeddings[j].1.as_ref());
                 if sim >= threshold {
                     pairs.push(ConfusabilityPair {
                         skill_a: skills[self.embeddings[i].0].name.clone(),
@@ -898,7 +905,7 @@ mod tests {
     #[test]
     fn matcher_backend_in_memory_is_not_qdrant() {
         let matcher = SkillMatcher {
-            embeddings: vec![(0, vec![1.0, 0.0])],
+            embeddings: vec![(0, SkillEmbedding::from_raw(vec![1.0, 0.0]))],
             category_matcher: None,
         };
         let backend = SkillMatcherBackend::InMemory(matcher);
@@ -935,7 +942,7 @@ mod tests {
     #[test]
     fn matcher_debug() {
         let matcher = SkillMatcher {
-            embeddings: vec![(0, vec![1.0])],
+            embeddings: vec![(0, SkillEmbedding::from_raw(vec![1.0]))],
             category_matcher: None,
         };
         let dbg = format!("{matcher:?}");
@@ -1142,7 +1149,10 @@ mod tests {
     #[test]
     fn confusability_report_empty_when_threshold_high() {
         let matcher = SkillMatcher {
-            embeddings: vec![(0, vec![1.0, 0.0]), (1, vec![0.0, 1.0])],
+            embeddings: vec![
+                (0, SkillEmbedding::from_raw(vec![1.0, 0.0])),
+                (1, SkillEmbedding::from_raw(vec![0.0, 1.0])),
+            ],
             category_matcher: None,
         };
         let metas = [make_meta("a", "alpha"), make_meta("b", "beta")];
@@ -1156,7 +1166,10 @@ mod tests {
     fn confusability_report_finds_similar_pair() {
         let v = vec![1.0_f32, 0.0, 0.0];
         let matcher = SkillMatcher {
-            embeddings: vec![(0, v.clone()), (1, v)],
+            embeddings: vec![
+                (0, SkillEmbedding::from_raw(v.clone())),
+                (1, SkillEmbedding::from_raw(v)),
+            ],
             category_matcher: None,
         };
         let metas = [make_meta("a", "alpha"), make_meta("b", "beta")];
@@ -1170,7 +1183,7 @@ mod tests {
     fn confusability_report_tracks_excluded_skills() {
         // embeddings only contains index 0; index 1 has no embedding.
         let matcher = SkillMatcher {
-            embeddings: vec![(0, vec![1.0, 0.0])],
+            embeddings: vec![(0, SkillEmbedding::from_raw(vec![1.0, 0.0]))],
             category_matcher: None,
         };
         let metas = [make_meta("a", "alpha"), make_meta("b", "beta")];

--- a/crates/zeph-skills/src/miner.rs
+++ b/crates/zeph-skills/src/miner.rs
@@ -19,6 +19,7 @@ use zeph_llm::provider::{LlmProvider, Message, Role};
 
 use zeph_common::secret::Secret;
 
+use crate::embedding::SkillEmbedding;
 use crate::error::SkillError;
 use crate::generator::{GeneratedSkill, SkillGenerator};
 use crate::loader::SkillMeta;
@@ -164,11 +165,11 @@ impl SkillMiner {
     }
 
     /// Pre-compute embeddings for existing skill descriptions.
-    async fn embed_existing(&self, skills: &[SkillMeta]) -> Vec<(String, Vec<f32>)> {
+    async fn embed_existing(&self, skills: &[SkillMeta]) -> Vec<(String, SkillEmbedding)> {
         let mut embeddings = Vec::with_capacity(skills.len());
         for skill in skills {
             match self.embed_provider.embed(&skill.description).await {
-                Ok(emb) => embeddings.push((skill.name.clone(), emb)),
+                Ok(emb) => embeddings.push((skill.name.clone(), SkillEmbedding::from_raw(emb))),
                 Err(e) => {
                     tracing::warn!(
                         skill = %skill.name,
@@ -185,7 +186,7 @@ impl SkillMiner {
     async fn process_repo(
         &self,
         repo: &RepoCandidate,
-        existing_embeddings: &[(String, Vec<f32>)],
+        existing_embeddings: &[(String, SkillEmbedding)],
         is_dry_run: bool,
     ) -> Result<Option<MinedSkill>, SkillError> {
         // Generate skill from repo.
@@ -417,21 +418,22 @@ impl SkillMiner {
     pub async fn is_novel(
         &self,
         candidate: &GeneratedSkill,
-        existing_embeddings: &[(String, Vec<f32>)],
+        existing_embeddings: &[(String, SkillEmbedding)],
     ) -> Result<(bool, f32), SkillError> {
         if existing_embeddings.is_empty() {
             return Ok((true, 0.0));
         }
 
-        let candidate_emb = self
-            .embed_provider
-            .embed(&candidate.meta.description)
-            .await
-            .map_err(|e| SkillError::Other(format!("embed failed: {e}")))?;
+        let candidate_emb = SkillEmbedding::from_raw(
+            self.embed_provider
+                .embed(&candidate.meta.description)
+                .await
+                .map_err(|e| SkillError::Other(format!("embed failed: {e}")))?,
+        );
 
         let max_sim = existing_embeddings
             .iter()
-            .map(|(_, emb)| cosine_similarity(&candidate_emb, emb))
+            .map(|(_, emb)| cosine_similarity(candidate_emb.as_ref(), emb.as_ref()))
             .fold(0.0_f32, f32::max);
 
         Ok((max_sim < self.config.dedup_threshold, max_sim))
@@ -539,15 +541,15 @@ mod tests {
         // Directly invoke the dedup logic that is_novel implements, bypassing LLM calls.
         fn is_novel_direct(
             &self,
-            candidate_emb: &[f32],
-            existing: &[(String, Vec<f32>)],
+            candidate_emb: &SkillEmbedding,
+            existing: &[(String, SkillEmbedding)],
         ) -> (bool, f32) {
             if existing.is_empty() {
                 return (true, 0.0);
             }
             let max_sim = existing
                 .iter()
-                .map(|(_, emb)| cosine_similarity(candidate_emb, emb))
+                .map(|(_, emb)| cosine_similarity(candidate_emb.as_ref(), emb.as_ref()))
                 .fold(0.0_f32, f32::max);
             (max_sim < self.threshold, max_sim)
         }
@@ -560,8 +562,12 @@ mod tests {
             embed_vec: vec![1.0, 0.0, 0.0],
             threshold: 0.85,
         };
-        let existing = vec![("existing".to_string(), vec![1.0, 0.0, 0.0])];
-        let (novel, sim) = helper.is_novel_direct(&helper.embed_vec, &existing);
+        let candidate = SkillEmbedding::from_raw(helper.embed_vec.clone());
+        let existing = vec![(
+            "existing".to_string(),
+            SkillEmbedding::from_raw(vec![1.0, 0.0, 0.0]),
+        )];
+        let (novel, sim) = helper.is_novel_direct(&candidate, &existing);
         assert!(!novel, "identical vectors should not be novel");
         assert!(
             (sim - 1.0_f32).abs() < 1e-5,
@@ -576,8 +582,12 @@ mod tests {
             embed_vec: vec![1.0, 0.0, 0.0],
             threshold: 0.85,
         };
-        let existing = vec![("other".to_string(), vec![0.0, 1.0, 0.0])];
-        let (novel, sim) = helper.is_novel_direct(&helper.embed_vec, &existing);
+        let candidate = SkillEmbedding::from_raw(helper.embed_vec.clone());
+        let existing = vec![(
+            "other".to_string(),
+            SkillEmbedding::from_raw(vec![0.0, 1.0, 0.0]),
+        )];
+        let (novel, sim) = helper.is_novel_direct(&candidate, &existing);
         assert!(novel, "orthogonal vectors should be novel, sim={sim}");
         assert!(sim < 0.85);
     }


### PR DESCRIPTION
## Summary

- Introduces `SkillEmbedding(Vec<f32>)` newtype in `crates/zeph-skills/src/embedding.rs` to replace raw `Vec<f32>` embedding vectors
- Adds validated constructor `new(vec, expected_dim)` and trusted-boundary constructor `from_raw(vec)`; `AsRef<[f32]>` keeps all `cosine_similarity` call sites unchanged
- Migrates all 4 call sites: `SkillMatcher::embeddings`, `CategoryMatcher::centroids`, `SkillMiner` pipeline, and `FixedEmbedMiner` test helper
- Adds `EmbeddingDimMismatch { expected, actual }` variant to `SkillError` for future runtime enforcement

## Motivation

Raw `Vec<f32>` carried no dimension information. Switching the embedding model (e.g. `nomic-embed-text` 768-dim → `all-minilm-l6` 384-dim) without reindexing silently produced incorrect cosine similarity scores — `cosine_similarity` returned `0.0` with no error or log. This was a recurring source of incorrect skill matching tracked in project memory.

## Test plan

- [ ] `cargo nextest run -p zeph-skills` — 417/417 pass
- [ ] `cargo test --doc -p zeph-skills` — 30/30 pass
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean
- [ ] Full workspace: 9334/9334 pass

Closes #3804