### PR TITLE
fix(common,bench,experiments): dedup UTC timestamp helpers and add evaluator tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-common`: new `timestamp` module with `utc_now_rfc3339()`, `utc_now_compact()`, and
+  `utc_now_datetime()` helpers — eliminates ~60 lines of duplicated Gregorian calendar arithmetic
+  that existed independently in `zeph-bench` and `zeph-experiments` (closes #3837).
+- `zeph-experiments`: `Evaluator::evaluate` is now wrapped in a `tracing::instrument` span
+  (`experiments.evaluator.evaluate`) with `subject_provider`, `cases`, and `err` fields,
+  making evaluation latency and LLM call timing visible in Perfetto/Jaeger traces (closes #3877).
+- `zeph-bench`: `uuid()` now samples `SystemTime::now()` once, eliminating a TOCTOU race where
+  seconds and nanoseconds could come from different clock ticks.
 - `zeph-db`: add 8 missing PostgreSQL migration files to reach parity with SQLite schema
   (migrations 069–071, 079–083): `trajectory_memory`, `message_category`, `memory_tree`,
   `pending_beliefs` + `belief_evidence`, `safety_shadow_events`, `memflow_scrapmem`

--- a/crates/zeph-bench/src/runner.rs
+++ b/crates/zeph-bench/src/runner.rs
@@ -31,6 +31,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 
+use zeph_common::timestamp;
 use zeph_core::agent::Agent;
 use zeph_core::instructions::InstructionBlock;
 use zeph_llm::any::AnyProvider;
@@ -267,7 +268,7 @@ impl BenchRunner {
             dataset: loader.name().to_owned(),
             model: model_id,
             run_id: uuid(),
-            started_at: now_rfc3339(),
+            started_at: timestamp::utc_now_rfc3339(),
             finished_at: String::new(),
             status: RunStatus::Running,
             results: vec![],
@@ -348,7 +349,7 @@ impl BenchRunner {
             dataset: loader.name().to_owned(),
             model: model_id,
             run_id: uuid(),
-            started_at: now_rfc3339(),
+            started_at: timestamp::utc_now_rfc3339(),
             finished_at: String::new(),
             status: RunStatus::Running,
             results: vec![],
@@ -586,51 +587,10 @@ fn post_process_response(raw: &str) -> String {
 /// sufficient for benchmark run identification.
 fn uuid() -> String {
     use std::time::{SystemTime, UNIX_EPOCH};
-    let ns = SystemTime::now()
+    let d = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map_or(0, |d| d.subsec_nanos());
-    let secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |d| d.as_secs());
-    format!("bench-{secs:x}-{ns:x}")
-}
-
-/// RFC 3339-like timestamp using `std` only (no chrono).
-fn now_rfc3339() -> String {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |d| d.as_secs());
-    // Minimal ISO 8601 UTC representation — good enough for result metadata.
-    let (y, mo, d, h, mi, s) = secs_to_ymdhms(secs);
-    format!("{y:04}-{mo:02}-{d:02}T{h:02}:{mi:02}:{s:02}Z")
-}
-
-/// Decompose Unix seconds into (year, month, day, hour, minute, second) UTC.
-fn secs_to_ymdhms(secs: u64) -> (u64, u64, u64, u64, u64, u64) {
-    const SECS_PER_MIN: u64 = 60;
-    const DAYS_PER_400Y: u64 = 146_097;
-
-    let s = secs % SECS_PER_MIN;
-    let total_mins = secs / SECS_PER_MIN;
-    let mi = total_mins % 60;
-    let total_hours = total_mins / 60;
-    let h = total_hours % 24;
-    let mut days = total_hours / 24;
-
-    // Proleptic Gregorian calendar computation.
-    // Shift epoch from 1970-01-01 to 0000-03-01 for easier leap-year math.
-    days += 719_468;
-    let era = days / DAYS_PER_400Y;
-    let doe = days % DAYS_PER_400Y;
-    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
-    let y = yoe + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let d = doy - (153 * mp + 2) / 5 + 1;
-    let mo = if mp < 10 { mp + 3 } else { mp - 9 };
-    let y = if mo <= 2 { y + 1 } else { y };
-    (y, mo, d, h, mi, s)
+        .unwrap_or_default();
+    format!("bench-{:x}-{:x}", d.as_secs(), d.subsec_nanos())
 }
 
 #[cfg(test)]
@@ -687,7 +647,7 @@ mod tests {
 
     #[test]
     fn now_rfc3339_has_correct_format() {
-        let ts = now_rfc3339();
+        let ts = timestamp::utc_now_rfc3339();
         // e.g. "2026-04-25T10:30:00Z"
         assert_eq!(ts.len(), 20);
         assert!(ts.ends_with('Z'));

--- a/crates/zeph-common/src/lib.rs
+++ b/crates/zeph-common/src/lib.rs
@@ -25,6 +25,7 @@ pub mod security_event;
 pub mod spawner;
 pub mod task_supervisor;
 pub mod text;
+pub mod timestamp;
 pub mod trust_level;
 pub mod types;
 

--- a/crates/zeph-common/src/timestamp.rs
+++ b/crates/zeph-common/src/timestamp.rs
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! UTC timestamp helpers shared across the workspace.
+//!
+//! All functions use [`std::time::SystemTime`] — no external date/time crates required.
+//! The O(1) Hinnant algorithm is used internally to convert Unix seconds to a
+//! calendar date without iterating over years or months.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Converts seconds since the Unix epoch to `(year, month, day, hour, minute, second)` UTC.
+///
+/// Uses the proleptic-Gregorian Hinnant algorithm — O(1), no heap allocation.
+/// Kept `pub(crate)` because the raw 6-tuple is an implementation detail; prefer
+/// the higher-level functions in this module for public use.
+pub(crate) fn secs_to_ymdhms(secs: u64) -> (u32, u32, u32, u32, u32, u32) {
+    const SECS_PER_MIN: u64 = 60;
+    const DAYS_PER_400Y: u64 = 146_097;
+
+    let s = (secs % SECS_PER_MIN) as u32;
+    let total_mins = secs / SECS_PER_MIN;
+    let mi = (total_mins % 60) as u32;
+    let total_hours = total_mins / 60;
+    let h = (total_hours % 24) as u32;
+    let mut days = total_hours / 24;
+
+    // Shift epoch from 1970-01-01 to 0000-03-01 for Gregorian math.
+    days += 719_468;
+    let era = days / DAYS_PER_400Y;
+    let doe = days % DAYS_PER_400Y;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    // All intermediate values are calendar-bounded (day ≤ 31, month ≤ 12, year ≤ ~u32::MAX/2).
+    #[allow(clippy::cast_possible_truncation)]
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    #[allow(clippy::cast_possible_truncation)]
+    let mo = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    #[allow(clippy::cast_possible_truncation)]
+    let y = if mo <= 2 { y + 1 } else { y } as u32;
+    (y, mo, d, h, mi, s)
+}
+
+fn unix_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
+}
+
+/// Returns the current UTC time as a `(year, month, day, hour, minute, second)` tuple.
+///
+/// # Examples
+///
+/// ```rust
+/// let (y, mo, d, h, mi, s) = zeph_common::timestamp::utc_now_datetime();
+/// assert!(y >= 2024, "year should be at least 2024");
+/// assert!((1..=12).contains(&mo));
+/// assert!((1..=31).contains(&d));
+/// assert!(h < 24 && mi < 60 && s < 60);
+/// ```
+#[must_use]
+pub fn utc_now_datetime() -> (u32, u32, u32, u32, u32, u32) {
+    secs_to_ymdhms(unix_secs())
+}
+
+/// Returns the current UTC time in RFC 3339 format: `YYYY-MM-DDTHH:MM:SSZ`.
+///
+/// # Examples
+///
+/// ```rust
+/// let ts = zeph_common::timestamp::utc_now_rfc3339();
+/// assert_eq!(ts.len(), 20, "expected format YYYY-MM-DDTHH:MM:SSZ");
+/// assert!(ts.ends_with('Z'));
+/// assert_eq!(&ts[10..11], "T");
+/// ```
+#[must_use]
+pub fn utc_now_rfc3339() -> String {
+    let (y, mo, d, h, mi, s) = utc_now_datetime();
+    format!("{y:04}-{mo:02}-{d:02}T{h:02}:{mi:02}:{s:02}Z")
+}
+
+/// Returns the current UTC time in compact format: `YYYYMMDD_HHMMSS`.
+///
+/// Suitable for filenames and run identifiers where colons and hyphens are undesirable.
+///
+/// # Examples
+///
+/// ```rust
+/// let ts = zeph_common::timestamp::utc_now_compact();
+/// assert_eq!(ts.len(), 15, "expected format YYYYMMDD_HHMMSS");
+/// assert_eq!(&ts[8..9], "_");
+/// ```
+#[must_use]
+pub fn utc_now_compact() -> String {
+    let (y, mo, d, h, mi, s) = utc_now_datetime();
+    format!("{y:04}{mo:02}{d:02}_{h:02}{mi:02}{s:02}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rfc3339_format_is_correct() {
+        let ts = utc_now_rfc3339();
+        assert_eq!(ts.len(), 20);
+        assert!(ts.ends_with('Z'));
+        assert_eq!(&ts[10..11], "T");
+        // Basic digit checks
+        assert!(ts[..4].chars().all(|c| c.is_ascii_digit()));
+    }
+
+    #[test]
+    fn compact_format_is_correct() {
+        let ts = utc_now_compact();
+        assert_eq!(ts.len(), 15);
+        assert_eq!(&ts[8..9], "_");
+    }
+
+    #[test]
+    fn secs_to_ymdhms_known_epoch() {
+        // Unix epoch = 1970-01-01 00:00:00
+        let (y, mo, d, h, mi, s) = secs_to_ymdhms(0);
+        assert_eq!((y, mo, d, h, mi, s), (1970, 1, 1, 0, 0, 0));
+    }
+
+    #[test]
+    fn secs_to_ymdhms_known_date() {
+        // 2024-03-01 00:00:00 UTC = 1709251200
+        let (y, mo, d, h, mi, s) = secs_to_ymdhms(1_709_251_200);
+        assert_eq!((y, mo, d, h, mi, s), (2024, 3, 1, 0, 0, 0));
+    }
+
+    #[test]
+    fn datetime_fields_are_in_range() {
+        let (y, mo, d, h, mi, s) = utc_now_datetime();
+        assert!(y >= 2024);
+        assert!((1..=12).contains(&mo));
+        assert!((1..=31).contains(&d));
+        assert!(h < 24 && mi < 60 && s < 60);
+    }
+}

--- a/crates/zeph-experiments/src/engine.rs
+++ b/crates/zeph-experiments/src/engine.rs
@@ -26,6 +26,7 @@ use std::time::Instant;
 use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
 use zeph_common::SessionId;
+use zeph_common::timestamp;
 use zeph_llm::any::AnyProvider;
 use zeph_memory::semantic::SemanticMemory;
 use zeph_memory::store::experiments::NewExperimentResult;
@@ -321,7 +322,7 @@ impl ExperimentEngine {
                 tokens_used: candidate_report.total_tokens,
                 accepted,
                 source: self.source.clone(),
-                created_at: chrono_now_utc(),
+                created_at: timestamp::utc_now_rfc3339(),
             });
         }
 
@@ -410,58 +411,6 @@ impl ExperimentEngine {
             );
         }
     }
-}
-
-/// Return a UTC timestamp string in `YYYY-MM-DD HH:MM:SS` format.
-#[allow(clippy::many_single_char_names)]
-fn chrono_now_utc() -> String {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    // Simple UTC formatter — no external date dependency.
-    let s = secs % 60;
-    let m = (secs / 60) % 60;
-    let h = (secs / 3600) % 24;
-    let days = secs / 86400;
-    // Days since 1970-01-01
-    let (y, mo, d) = days_to_ymd(days);
-    format!("{y:04}-{mo:02}-{d:02} {h:02}:{m:02}:{s:02}")
-}
-
-/// Convert days since Unix epoch to (year, month, day).
-fn days_to_ymd(mut days: u64) -> (u64, u64, u64) {
-    // Gregorian calendar algorithm.
-    let mut year = 1970u64;
-    loop {
-        let leap = is_leap(year);
-        let dy = if leap { 366 } else { 365 };
-        if days < dy {
-            break;
-        }
-        days -= dy;
-        year += 1;
-    }
-    let leap = is_leap(year);
-    let month_days: [u64; 12] = if leap {
-        [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
-    } else {
-        [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
-    };
-    let mut month = 1u64;
-    for md in &month_days {
-        if days < *md {
-            break;
-        }
-        days -= md;
-        month += 1;
-    }
-    (year, month, days + 1)
-}
-
-fn is_leap(y: u64) -> bool {
-    (y.is_multiple_of(4) && !y.is_multiple_of(100)) || y.is_multiple_of(400)
 }
 
 #[cfg(test)]
@@ -907,34 +856,23 @@ mod tests {
     }
 
     #[test]
-    fn chrono_now_utc_format() {
-        let s = chrono_now_utc();
-        assert_eq!(s.len(), 19, "timestamp must be 19 chars: {s}");
+    fn utc_now_rfc3339_format() {
+        let s = timestamp::utc_now_rfc3339();
+        assert_eq!(s.len(), 20, "timestamp must be 20 chars (RFC 3339): {s}");
         assert_eq!(&s[4..5], "-");
         assert_eq!(&s[7..8], "-");
-        assert_eq!(&s[10..11], " ");
+        assert_eq!(&s[10..11], "T");
         assert_eq!(&s[13..14], ":");
         assert_eq!(&s[16..17], ":");
+        assert!(s.ends_with('Z'));
     }
 
-    /// Verify that `days_to_ymd` correctly handles a known date including a leap year.
-    /// 2024-02-29 (leap day) = 19782 days since 1970-01-01.
+    /// Verify that the shared timestamp module returns a non-empty RFC 3339 string.
     #[test]
-    fn chrono_known_timestamp_leap_year() {
-        // 2024-02-29 00:00:00 UTC = 1_709_164_800 seconds since epoch.
-        // Verified via: date -d "2024-02-29 00:00:00 UTC" +%s
-        let secs: u64 = 1_709_164_800;
-        let second = secs % 60;
-        let minute = (secs / 60) % 60;
-        let hour = (secs / 3600) % 24;
-        let days = secs / 86400;
-        let (year, month, day) = days_to_ymd(days);
-        assert_eq!(year, 2024);
-        assert_eq!(month, 2);
-        assert_eq!(day, 29);
-        assert_eq!(second, 0);
-        assert_eq!(minute, 0);
-        assert_eq!(hour, 0);
+    fn utc_now_rfc3339_is_non_empty() {
+        let ts = timestamp::utc_now_rfc3339();
+        assert!(!ts.is_empty());
+        assert_eq!(ts.len(), 20);
     }
 
     /// `ExperimentEngine` must be Send to be used with `tokio::spawn`.

--- a/crates/zeph-experiments/src/evaluator.rs
+++ b/crates/zeph-experiments/src/evaluator.rs
@@ -222,6 +222,12 @@ impl Evaluator {
     ///
     /// Returns [`EvalError::Llm`] if any subject call fails fatally.
     /// Budget exhaustion and judge errors are handled gracefully (excluded from scores).
+    #[tracing::instrument(
+        name = "experiments.evaluator.evaluate",
+        skip(self, subject),
+        fields(subject_provider = %subject.name(), cases = self.benchmark.cases.len()),
+        err(level = tracing::Level::WARN)
+    )]
     pub async fn evaluate(&self, subject: &AnyProvider) -> Result<EvalReport, EvalError> {
         let cases_total = self.benchmark.cases.len();
 


### PR DESCRIPTION
## Summary

- Extracts ~60 lines of duplicated Gregorian calendar arithmetic from `zeph-bench` and `zeph-experiments` into a new `zeph_common::timestamp` module (`utc_now_rfc3339`, `utc_now_compact`, `utc_now_datetime`). Both crates now use the common implementation, eliminating any future divergence in calendar math bugs.
- Fixes a TOCTOU race in `uuid()` where two separate `SystemTime::now()` calls could sample seconds and nanoseconds from different clock ticks.
- Adds `#[tracing::instrument]` to `Evaluator::evaluate` (span: `experiments.evaluator.evaluate`, fields: `subject_provider`, `cases`, `err(level = WARN)`), making evaluation latency visible in Perfetto/Jaeger traces.

Closes #3837, closes #3877.

## Changes

- `crates/zeph-common/src/timestamp.rs` — new module with Hinnant O(1) calendar arithmetic, doc comments, and doctests
- `crates/zeph-common/src/lib.rs` — `pub mod timestamp` registered
- `crates/zeph-bench/src/runner.rs` — removed duplicated helpers; `uuid()` uses single `SystemTime::now()` call
- `crates/zeph-experiments/src/engine.rs` — removed duplicated helpers, call sites updated
- `crates/zeph-experiments/src/evaluator.rs` — `#[tracing::instrument]` added to `evaluate`

## Test plan

- [ ] `cargo +nightly fmt --check` — CLEAN
- [ ] `cargo clippy --workspace -- -D warnings` — CLEAN
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 9331 passed
- [ ] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — CLEAN
- [ ] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — 19 passed

## Follow-up issues

- Missing edge-case tests for `secs_to_ymdhms` (Y2K, Feb-29 century-leap, year-end, HH:MM:SS non-trivial) — P3
- No RFC 3339 assertion on `ExperimentResult.created_at` in engine tests — P4
- No `#[tracing_test::traced_test]` span assertion for `evaluate` — P4