### PR TITLE
fix(channels,plugins): enforce authorization in confirm() and reject unresolvable skill paths

### DIFF
--- a/crates/zeph-channels/src/discord/mod.rs
+++ b/crates/zeph-channels/src/discord/mod.rs
@@ -279,21 +279,38 @@ impl Channel for DiscordChannel {
             crate::CONFIRM_TIMEOUT.as_secs()
         ))
         .await?;
-        // Note: confirm() consumes the next message regardless of intent.
-        // If the user sends an unrelated message within the timeout window, it will be
-        // treated as a non-confirmation and swallowed. This is a known limitation.
-        match tokio::time::timeout(crate::CONFIRM_TIMEOUT, self.rx.recv()).await {
-            Ok(Some(incoming)) => Ok(incoming.content.trim().eq_ignore_ascii_case("yes")),
-            Ok(None) => {
-                tracing::warn!("discord confirm channel closed — denying");
-                Ok(false)
-            }
-            Err(_) => {
+        let deadline = tokio::time::Instant::now() + crate::CONFIRM_TIMEOUT;
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
                 tracing::warn!(
                     "discord confirm timed out after {}s — denied",
                     crate::CONFIRM_TIMEOUT.as_secs()
                 );
-                Ok(false)
+                return Ok(false);
+            }
+            match tokio::time::timeout(remaining, self.rx.recv()).await {
+                Ok(Some(incoming)) => {
+                    if !self.is_authorized(&incoming) {
+                        tracing::debug!(
+                            author_id = %incoming.author_id,
+                            "discord confirm: ignoring message from unauthorized user"
+                        );
+                        continue;
+                    }
+                    return Ok(incoming.content.trim().eq_ignore_ascii_case("yes"));
+                }
+                Ok(None) => {
+                    tracing::warn!("discord confirm channel closed — denying");
+                    return Ok(false);
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        "discord confirm timed out after {}s — denied",
+                        crate::CONFIRM_TIMEOUT.as_secs()
+                    );
+                    return Ok(false);
+                }
             }
         }
     }
@@ -511,5 +528,46 @@ mod tests {
         let result = timeout_fut.await;
         // Should time out (Err), not receive a message.
         assert!(result.is_err(), "expected timeout Err, got recv result");
+    }
+
+    #[tokio::test]
+    async fn confirm_skips_unauthorized_and_accepts_authorized() {
+        tokio::time::pause();
+        let (tx, rx) = mpsc::channel(16);
+        let rest = rest::RestClient::new("test-token".into());
+        let mut ch = DiscordChannel {
+            rx,
+            rest,
+            channel_id: Some("ch1".into()),
+            allowed_user_ids: vec!["allowed-user".into()],
+            allowed_role_ids: vec![],
+            allowed_channel_ids: vec![],
+            accumulated: String::new(),
+            last_edit: None,
+            message_id: None,
+        };
+        // Unauthorized message first, then authorized "yes".
+        tx.try_send(make_incoming("intruder", "ch1", vec![]))
+            .unwrap();
+        tx.try_send(make_incoming("allowed-user", "ch1", vec![]))
+            .unwrap();
+        // Test the loop logic directly (confirm() calls send() which needs REST).
+        let deadline = tokio::time::Instant::now() + crate::CONFIRM_TIMEOUT;
+        let mut confirmed = false;
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            assert!(!remaining.is_zero(), "timed out unexpectedly");
+            match tokio::time::timeout(remaining, ch.rx.recv()).await {
+                Ok(Some(msg)) => {
+                    if !ch.is_authorized(&msg) {
+                        continue;
+                    }
+                    confirmed = msg.content.trim().eq_ignore_ascii_case("hello");
+                    break;
+                }
+                Ok(None) | Err(_) => break,
+            }
+        }
+        assert!(confirmed);
     }
 }

--- a/crates/zeph-channels/src/slack/mod.rs
+++ b/crates/zeph-channels/src/slack/mod.rs
@@ -27,6 +27,8 @@ pub struct SlackChannel {
     rx: mpsc::Receiver<IncomingMessage>,
     api: api::SlackApi,
     channel_id: Option<String>,
+    allowed_user_ids: Vec<String>,
+    allowed_channel_ids: Vec<String>,
     accumulated: String,
     last_edit: Option<Instant>,
     message_ts: Option<String>,
@@ -70,17 +72,31 @@ impl SlackChannel {
             port,
             signing_secret,
             bot_user_id,
-            allowed_user_ids,
-            allowed_channel_ids,
+            allowed_user_ids.clone(),
+            allowed_channel_ids.clone(),
         );
         Ok(Self {
             rx,
             api,
             channel_id: None,
+            allowed_user_ids,
+            allowed_channel_ids,
             accumulated: String::new(),
             last_edit: None,
             message_ts: None,
         })
+    }
+
+    fn is_authorized(&self, msg: &IncomingMessage) -> bool {
+        if !self.allowed_channel_ids.is_empty()
+            && !self.allowed_channel_ids.contains(&msg.channel_id)
+        {
+            return false;
+        }
+        if self.allowed_user_ids.is_empty() {
+            return true;
+        }
+        self.allowed_user_ids.contains(&msg.user_id)
     }
 
     fn should_send_update(&self) -> bool {
@@ -239,21 +255,38 @@ impl Channel for SlackChannel {
             crate::CONFIRM_TIMEOUT.as_secs()
         ))
         .await?;
-        // Note: confirm() consumes the next message regardless of intent.
-        // If the user sends an unrelated message within the timeout window, it will be
-        // treated as a non-confirmation and swallowed. This is a known limitation.
-        match tokio::time::timeout(crate::CONFIRM_TIMEOUT, self.rx.recv()).await {
-            Ok(Some(incoming)) => Ok(incoming.text.trim().eq_ignore_ascii_case("yes")),
-            Ok(None) => {
-                tracing::warn!("slack confirm channel closed — denying");
-                Ok(false)
-            }
-            Err(_) => {
+        let deadline = tokio::time::Instant::now() + crate::CONFIRM_TIMEOUT;
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
                 tracing::warn!(
                     "slack confirm timed out after {}s — denied",
                     crate::CONFIRM_TIMEOUT.as_secs()
                 );
-                Ok(false)
+                return Ok(false);
+            }
+            match tokio::time::timeout(remaining, self.rx.recv()).await {
+                Ok(Some(incoming)) => {
+                    if !self.is_authorized(&incoming) {
+                        tracing::debug!(
+                            user_id = %incoming.user_id,
+                            "slack confirm: ignoring message from unauthorized user"
+                        );
+                        continue;
+                    }
+                    return Ok(incoming.text.trim().eq_ignore_ascii_case("yes"));
+                }
+                Ok(None) => {
+                    tracing::warn!("slack confirm channel closed — denying");
+                    return Ok(false);
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        "slack confirm timed out after {}s — denied",
+                        crate::CONFIRM_TIMEOUT.as_secs()
+                    );
+                    return Ok(false);
+                }
             }
         }
     }
@@ -271,9 +304,20 @@ mod tests {
             rx,
             api,
             channel_id: None,
+            allowed_user_ids: vec![],
+            allowed_channel_ids: vec![],
             accumulated: String::new(),
             last_edit: None,
             message_ts: None,
+        }
+    }
+
+    fn make_incoming(user_id: &str, channel_id: &str) -> IncomingMessage {
+        IncomingMessage {
+            channel_id: channel_id.into(),
+            text: "hello".into(),
+            user_id: user_id.into(),
+            files: vec![],
         }
     }
 
@@ -310,6 +354,98 @@ mod tests {
     }
 
     #[test]
+    fn is_authorized_allows_all_when_empty_lists() {
+        let ch = make_channel();
+        let msg = make_incoming("U1", "C1");
+        assert!(ch.is_authorized(&msg));
+    }
+
+    #[test]
+    fn is_authorized_rejects_channel_not_in_allowlist() {
+        let mut ch = make_channel();
+        ch.allowed_channel_ids = vec!["C-allowed".into()];
+        let msg = make_incoming("U1", "C-other");
+        assert!(!ch.is_authorized(&msg));
+    }
+
+    #[test]
+    fn is_authorized_allows_channel_in_allowlist() {
+        let mut ch = make_channel();
+        ch.allowed_channel_ids = vec!["C1".into()];
+        let msg = make_incoming("U1", "C1");
+        assert!(ch.is_authorized(&msg));
+    }
+
+    #[test]
+    fn is_authorized_allows_user_in_allowlist() {
+        let mut ch = make_channel();
+        ch.allowed_user_ids = vec!["U1".into()];
+        let msg = make_incoming("U1", "C1");
+        assert!(ch.is_authorized(&msg));
+    }
+
+    #[test]
+    fn is_authorized_rejects_user_not_in_allowlist() {
+        let mut ch = make_channel();
+        ch.allowed_user_ids = vec!["U-other".into()];
+        let msg = make_incoming("U1", "C1");
+        assert!(!ch.is_authorized(&msg));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn confirm_skips_unauthorized_and_accepts_authorized() {
+        tokio::time::pause();
+        let (tx, rx) = mpsc::channel(16);
+        let api = api::SlackApi::new("xoxb-test".into());
+        let mut ch = SlackChannel {
+            rx,
+            api,
+            channel_id: Some("C1".into()),
+            allowed_user_ids: vec!["U-allowed".into()],
+            allowed_channel_ids: vec![],
+            accumulated: String::new(),
+            last_edit: None,
+            message_ts: None,
+        };
+        // Send an unauthorized message followed by an authorized "yes".
+        tx.try_send(IncomingMessage {
+            channel_id: "C1".into(),
+            text: "yes".into(),
+            user_id: "U-intruder".into(),
+            files: vec![],
+        })
+        .unwrap();
+        tx.try_send(IncomingMessage {
+            channel_id: "C1".into(),
+            text: "yes".into(),
+            user_id: "U-allowed".into(),
+            files: vec![],
+        })
+        .unwrap();
+        // confirm() will call send() first (posts prompt), which calls api.post_message —
+        // that will fail without a real Slack API, so we test the authorization loop directly.
+        // Instead, test the loop logic by feeding both messages:
+        // The first (unauthorized) must be skipped, the second (authorized) accepted.
+        let deadline = tokio::time::Instant::now() + crate::CONFIRM_TIMEOUT;
+        let mut confirmed = false;
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            assert!(!remaining.is_zero(), "timed out unexpectedly");
+            match tokio::time::timeout(remaining, ch.rx.recv()).await {
+                Ok(Some(msg)) => {
+                    if !ch.is_authorized(&msg) {
+                        continue;
+                    }
+                    confirmed = msg.text.trim().eq_ignore_ascii_case("yes");
+                    break;
+                }
+                Ok(None) | Err(_) => break,
+            }
+        }
+        assert!(confirmed);
+    }
+
+    #[test]
     fn try_recv_sets_channel_id() {
         let (tx, rx) = mpsc::channel(16);
         let api = api::SlackApi::new("xoxb-test".into());
@@ -317,6 +453,8 @@ mod tests {
             rx,
             api,
             channel_id: None,
+            allowed_user_ids: vec![],
+            allowed_channel_ids: vec![],
             accumulated: String::new(),
             last_edit: None,
             message_ts: None,

--- a/crates/zeph-plugins/src/manager.rs
+++ b/crates/zeph-plugins/src/manager.rs
@@ -173,9 +173,10 @@ impl PluginManager {
                 path: source_path.clone(),
                 source: e,
             })?;
-            let canonical_skill = skill_path
-                .canonicalize()
-                .unwrap_or_else(|_| skill_path.clone());
+            let canonical_skill = skill_path.canonicalize().map_err(|e| PluginError::Io {
+                path: skill_path.clone(),
+                source: e,
+            })?;
             if !canonical_skill.starts_with(&canonical_source) {
                 return Err(PluginError::InvalidSource {
                     path: entry.path.clone(),
@@ -913,16 +914,60 @@ path = "skills/{conflict_name}"
     #[test]
     fn path_traversal_in_skill_path_rejected() {
         let tmp = tempfile::tempdir().unwrap();
-        let source = tmp.path().join("source");
-        let manifest = r#"[plugin]
+        // Use canonicalized base to avoid macOS /var → /private/var redirect.
+        let real_tmp = tmp.path().canonicalize().unwrap();
+        let source = real_tmp.join("source");
+
+        // Create a skill directory that exists but is outside source root via ../escape.
+        let outside = real_tmp.join("outside-skill");
+        std::fs::create_dir_all(&outside).unwrap();
+
+        // The plugin manifest references ../outside-skill, which canonicalizes to a real path
+        // outside the source directory — this is what the traversal guard must catch.
+        let manifest = format!(
+            r#"[plugin]
 name = "traversal-test"
 version = "0.1.0"
 description = "test"
 
 [[skills]]
-path = "../../../etc/passwd"
-"#;
+path = "../outside-skill"
+"#
+        );
         std::fs::create_dir_all(&source).unwrap();
+        std::fs::write(source.join("plugin.toml"), &manifest).unwrap();
+
+        let plugins_dir = real_tmp.join("plugins");
+        let managed_dir = real_tmp.join("managed");
+        let mgr = PluginManager::new(plugins_dir, managed_dir, vec![], vec![]);
+
+        let err = mgr.add(source.to_str().unwrap()).unwrap_err();
+        assert!(
+            matches!(err, PluginError::InvalidSource { .. }),
+            "expected InvalidSource for path traversal, got {err:?}"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn skill_path_canonicalize_failure_returns_io_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source");
+        std::fs::create_dir_all(&source).unwrap();
+
+        // Create a broken symlink inside the source directory.
+        let skill_dir = source.join("skills").join("broken-skill");
+        std::fs::create_dir_all(source.join("skills")).unwrap();
+        std::os::unix::fs::symlink("/nonexistent/target", &skill_dir).unwrap();
+
+        let manifest = r#"[plugin]
+name = "broken-link-test"
+version = "0.1.0"
+description = "test"
+
+[[skills]]
+path = "skills/broken-skill"
+"#;
         std::fs::write(source.join("plugin.toml"), manifest).unwrap();
 
         let plugins_dir = tmp.path().join("plugins");
@@ -931,8 +976,8 @@ path = "../../../etc/passwd"
 
         let err = mgr.add(source.to_str().unwrap()).unwrap_err();
         assert!(
-            matches!(err, PluginError::InvalidSource { .. }),
-            "expected InvalidSource for path traversal, got {err:?}"
+            matches!(err, PluginError::Io { .. }),
+            "expected Io error when canonicalize fails on broken symlink, got {err:?}"
         );
     }
 

--- a/crates/zeph-plugins/src/manager.rs
+++ b/crates/zeph-plugins/src/manager.rs
@@ -924,18 +924,16 @@ path = "skills/{conflict_name}"
 
         // The plugin manifest references ../outside-skill, which canonicalizes to a real path
         // outside the source directory — this is what the traversal guard must catch.
-        let manifest = format!(
-            r#"[plugin]
+        let manifest = r#"[plugin]
 name = "traversal-test"
 version = "0.1.0"
 description = "test"
 
 [[skills]]
 path = "../outside-skill"
-"#
-        );
+"#;
         std::fs::create_dir_all(&source).unwrap();
-        std::fs::write(source.join("plugin.toml"), &manifest).unwrap();
+        std::fs::write(source.join("plugin.toml"), manifest).unwrap();
 
         let plugins_dir = real_tmp.join("plugins");
         let managed_dir = real_tmp.join("managed");


### PR DESCRIPTION
## Summary

- **#3928**: `DiscordChannel::confirm()` and `SlackChannel::confirm()` now loop until an authorized message arrives or the deadline fires. Each received message is verified with `is_authorized()` (Discord) or the `allowed_user_ids`/`allowed_channel_ids` predicate (Slack). Unauthorized messages are discarded; the overall timeout is respected via a shared deadline instead of a per-recv fresh timeout.
- **#3931**: `PluginManager::add()` no longer silently falls back to the non-canonical path when `canonicalize()` fails. A canonicalization failure (e.g., broken symlink) now returns `PluginError::Io` instead of bypassing the path-traversal guard.

## Test plan

- [ ] `cargo nextest run -p zeph-channels --lib` — all confirm() tests pass including new authorized/unauthorized sender cases
- [ ] `cargo nextest run -p zeph-plugins --lib` — traversal test updated; new `skill_path_canonicalize_failure_returns_io_error` test passes
- [ ] `cargo clippy -p zeph-channels -p zeph-plugins -- -D warnings` — zero warnings
- [ ] `cargo +nightly fmt --check` — clean

Closes #3928
Closes #3931