### PR TITLE
fix(db): add PostgreSQL migrations 084-088 and fix SQLite-specific SQL syntax

### DIFF
--- a/crates/zeph-db/migrations/postgres/084_apex_mem.sql
+++ b/crates/zeph-db/migrations/postgres/084_apex_mem.sql
@@ -1,0 +1,37 @@
+-- Migration 084: APEX-MEM append-only MAGMA edge store (PostgreSQL).
+--
+-- Adapted from SQLite migration 075. Adds supersedes pointer and canonical_relation
+-- columns to graph_edges, partial unique index for active head-of-chain,
+-- and edge_reassertions table for byte-identical re-assertions (FR-015).
+
+ALTER TABLE graph_edges ADD COLUMN supersedes BIGINT REFERENCES graph_edges(id);
+ALTER TABLE graph_edges ADD COLUMN canonical_relation TEXT;
+
+-- Backfill: use raw relation as canonical for all existing rows (idempotent).
+UPDATE graph_edges SET canonical_relation = relation WHERE canonical_relation IS NULL;
+
+-- Partial unique index: at most one active head per (source, target, canonical_relation, edge_type).
+CREATE UNIQUE INDEX IF NOT EXISTS uq_graph_edges_active_head
+    ON graph_edges(source_entity_id, target_entity_id, canonical_relation, edge_type)
+    WHERE valid_to IS NULL AND expired_at IS NULL;
+
+-- Index for walking supersedes chains.
+CREATE INDEX IF NOT EXISTS idx_edges_supersedes ON graph_edges(supersedes);
+
+-- Index for head-of-chain queries ordered by recency.
+CREATE INDEX IF NOT EXISTS idx_edges_head_active
+    ON graph_edges(source_entity_id, canonical_relation, edge_type, created_at)
+    WHERE valid_to IS NULL AND expired_at IS NULL;
+
+-- Reassertion events: byte-identical re-assertions that do not insert a new edge (FR-015).
+-- episode_id is nullable: callers with no episode context store NULL.
+CREATE TABLE IF NOT EXISTS edge_reassertions (
+    id           BIGSERIAL PRIMARY KEY,
+    head_edge_id BIGINT NOT NULL REFERENCES graph_edges(id),
+    asserted_at  BIGINT NOT NULL,
+    episode_id   TEXT,
+    confidence   REAL   NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_reassertions_head
+    ON edge_reassertions(head_edge_id, asserted_at DESC);

--- a/crates/zeph-db/migrations/postgres/085_reasoning_strategies.sql
+++ b/crates/zeph-db/migrations/postgres/085_reasoning_strategies.sql
@@ -1,0 +1,22 @@
+-- SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+-- SPDX-License-Identifier: MIT OR Apache-2.0
+
+-- Migration 085: ReasoningBank distilled strategy memory (PostgreSQL).
+-- Adapted from SQLite migration 077.
+
+CREATE TABLE IF NOT EXISTS reasoning_strategies (
+    id           TEXT   PRIMARY KEY NOT NULL,
+    summary      TEXT   NOT NULL,
+    outcome      TEXT   NOT NULL,
+    task_hint    TEXT   NOT NULL,
+    created_at   BIGINT NOT NULL,
+    last_used_at BIGINT NOT NULL,
+    use_count    BIGINT NOT NULL DEFAULT 0,
+    embedded_at  BIGINT
+);
+
+CREATE INDEX IF NOT EXISTS idx_reasoning_strategies_last_used_at
+    ON reasoning_strategies (last_used_at);
+
+CREATE INDEX IF NOT EXISTS idx_reasoning_strategies_use_count
+    ON reasoning_strategies (use_count);

--- a/crates/zeph-db/migrations/postgres/086_hebbian_edge_weight.sql
+++ b/crates/zeph-db/migrations/postgres/086_hebbian_edge_weight.sql
@@ -1,0 +1,10 @@
+-- Migration 086: HL-F1 Hebbian edge weight + MM-F4 summaries range index (PostgreSQL).
+-- Adapted from SQLite migration 078.
+
+-- HL-F1: Hebbian reinforcement weight on graph edges.
+ALTER TABLE graph_edges ADD COLUMN weight REAL NOT NULL DEFAULT 1.0;
+
+-- MM-F4: Support index for filter_out_preserved_episode_ids range probes.
+CREATE INDEX IF NOT EXISTS idx_summaries_message_range
+    ON summaries(first_message_id, last_message_id)
+    WHERE first_message_id IS NOT NULL AND last_message_id IS NOT NULL;

--- a/crates/zeph-db/migrations/postgres/087_hebbian_consolidation.sql
+++ b/crates/zeph-db/migrations/postgres/087_hebbian_consolidation.sql
@@ -1,0 +1,21 @@
+-- Migration 087: HL-F3/F4 Hebbian background consolidation (PostgreSQL).
+-- Adapted from SQLite migration 079.
+
+-- HL-F3: cooldown marker — NULL means "never consolidated"; epoch seconds once set.
+ALTER TABLE graph_entities ADD COLUMN consolidated_at BIGINT;
+
+-- HL-F4: LLM-distilled rules anchored to a high-traffic entity cluster.
+CREATE TABLE IF NOT EXISTS graph_rules (
+    id               BIGSERIAL PRIMARY KEY,
+    anchor_entity_id BIGINT NOT NULL REFERENCES graph_entities(id),
+    summary          TEXT   NOT NULL,
+    trigger_hint     TEXT,
+    confidence       REAL   NOT NULL DEFAULT 0.0,
+    created_at       BIGINT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_graph_rules_anchor  ON graph_rules(anchor_entity_id);
+CREATE INDEX IF NOT EXISTS idx_graph_rules_created ON graph_rules(created_at);
+CREATE INDEX IF NOT EXISTS idx_graph_entities_consolidated
+    ON graph_entities(consolidated_at)
+    WHERE consolidated_at IS NOT NULL;

--- a/crates/zeph-db/migrations/postgres/088_trajectory_memory_cascade.sql
+++ b/crates/zeph-db/migrations/postgres/088_trajectory_memory_cascade.sql
@@ -1,0 +1,6 @@
+-- Migration 088: Add ON DELETE CASCADE to trajectory_memory.conversation_id FK.
+-- PostgreSQL cannot alter FK constraints in place; must drop and re-add.
+ALTER TABLE trajectory_memory
+    DROP CONSTRAINT IF EXISTS trajectory_memory_conversation_id_fkey,
+    ADD CONSTRAINT trajectory_memory_conversation_id_fkey
+        FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE;

--- a/crates/zeph-db/migrations/sqlite/069_trajectory_memory.sql
+++ b/crates/zeph-db/migrations/sqlite/069_trajectory_memory.sql
@@ -2,7 +2,7 @@
 -- Stores per-conversation procedural and episodic entries extracted from tool-call turns.
 CREATE TABLE IF NOT EXISTS trajectory_memory (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
-    conversation_id INTEGER REFERENCES conversations(id),
+    conversation_id INTEGER REFERENCES conversations(id) ON DELETE CASCADE,
     turn_index      INTEGER NOT NULL,
     kind            TEXT NOT NULL CHECK(kind IN ('procedural', 'episodic')),
     intent          TEXT NOT NULL,

--- a/crates/zeph-memory/src/episodic_consolidation.rs
+++ b/crates/zeph-memory/src/episodic_consolidation.rs
@@ -583,8 +583,9 @@ async fn promote_fact(
 
         for &event_id in source_event_ids {
             sqlx::query(sql!(
-                "INSERT OR IGNORE INTO consolidated_fact_sources (fact_id, event_id)
-                 VALUES (?1, ?2)"
+                "INSERT INTO consolidated_fact_sources (fact_id, event_id)
+                 VALUES (?1, ?2)
+                 ON CONFLICT (fact_id, event_id) DO NOTHING"
             ))
             .bind(fid)
             .bind(event_id)

--- a/crates/zeph-memory/src/episodic_graph.rs
+++ b/crates/zeph-memory/src/episodic_graph.rs
@@ -34,6 +34,8 @@ use zeph_llm::provider::{LlmProvider as _, Message, MessageMetadata, Role};
 
 pub use zeph_config::memory::EmGraphConfig;
 
+use zeph_db::ActiveDialect;
+
 use crate::error::MemoryError;
 use crate::store::SqliteStore;
 use crate::types::MessageId;
@@ -320,17 +322,20 @@ pub async fn store_events(
     }
     let mut tx = store.pool().begin().await?;
     for event in events.iter_mut() {
-        let id = sqlx::query_scalar::<_, i64>(
-            "INSERT INTO episodic_events (session_id, message_id, event_type, summary, created_at)
-             VALUES (?, ?, ?, ?, unixepoch())
-             RETURNING id",
-        )
-        .bind(&event.session_id)
-        .bind(event.message_id.0)
-        .bind(&event.event_type)
-        .bind(&event.summary)
-        .fetch_one(&mut *tx)
-        .await?;
+        let epoch_now = <ActiveDialect as zeph_db::dialect::Dialect>::EPOCH_NOW;
+        let raw = format!(
+            "INSERT INTO episodic_events (session_id, message_id, event_type, summary, created_at) \
+             VALUES (?, ?, ?, ?, {epoch_now}) \
+             RETURNING id"
+        );
+        let sql = zeph_db::rewrite_placeholders(&raw);
+        let id = sqlx::query_scalar::<_, i64>(&sql)
+            .bind(&event.session_id)
+            .bind(event.message_id.0)
+            .bind(&event.event_type)
+            .bind(&event.summary)
+            .fetch_one(&mut *tx)
+            .await?;
         event.id = id;
     }
     tx.commit().await?;
@@ -340,7 +345,8 @@ pub async fn store_events(
 /// Persist causal links to the `causal_links` table.
 ///
 /// All inserts are batched inside a single transaction. Duplicate
-/// `(cause_event_id, effect_event_id)` pairs are silently ignored via `INSERT OR IGNORE`
+/// `(cause_event_id, effect_event_id)` pairs are silently ignored via
+/// `ON CONFLICT (cause_event_id, effect_event_id) DO NOTHING`
 /// (requires the `UNIQUE` constraint added in migration 086).
 ///
 /// # Errors
@@ -352,16 +358,20 @@ pub async fn store_links(store: &SqliteStore, links: &[CausalLink]) -> Result<()
     }
     let mut tx = store.pool().begin().await?;
     for link in links {
-        sqlx::query(
-            "INSERT OR IGNORE INTO causal_links
-             (cause_event_id, effect_event_id, strength, created_at)
-             VALUES (?, ?, ?, unixepoch())",
-        )
-        .bind(link.cause_event_id)
-        .bind(link.effect_event_id)
-        .bind(link.strength)
-        .execute(&mut *tx)
-        .await?;
+        let epoch_now = <ActiveDialect as zeph_db::dialect::Dialect>::EPOCH_NOW;
+        let raw = format!(
+            "INSERT INTO causal_links \
+             (cause_event_id, effect_event_id, strength, created_at) \
+             VALUES (?, ?, ?, {epoch_now}) \
+             ON CONFLICT (cause_event_id, effect_event_id) DO NOTHING"
+        );
+        let sql = zeph_db::rewrite_placeholders(&raw);
+        sqlx::query(&sql)
+            .bind(link.cause_event_id)
+            .bind(link.effect_event_id)
+            .bind(link.strength)
+            .execute(&mut *tx)
+            .await?;
     }
     tx.commit().await?;
     Ok(())

--- a/crates/zeph-memory/src/graph/experience.rs
+++ b/crates/zeph-memory/src/graph/experience.rs
@@ -110,8 +110,9 @@ impl ExperienceStore {
             tracing::info_span!("memory.experience.link_entities", exp = experience_id.0).entered();
         for &entity_id in entity_ids {
             zeph_db::query(sql!(
-                "INSERT OR IGNORE INTO experience_entity_links
-                 (experience_id, entity_id) VALUES (?1, ?2)"
+                "INSERT INTO experience_entity_links
+                 (experience_id, entity_id) VALUES (?1, ?2)
+                 ON CONFLICT (experience_id, entity_id) DO NOTHING"
             ))
             .bind(experience_id.0)
             .bind(entity_id.0)

--- a/crates/zeph-memory/src/graph/store/mod.rs
+++ b/crates/zeph-memory/src/graph/store/mod.rs
@@ -2285,10 +2285,13 @@ impl GraphStore {
         // Ensure the conversation row exists before inserting into graph_episodes,
         // which has a FK referencing conversations(id). On a fresh database the agent
         // may run graph extraction before the conversation row is committed.
-        zeph_db::query(sql!("INSERT OR IGNORE INTO conversations (id) VALUES (?)"))
-            .bind(conversation_id)
-            .execute(&self.pool)
-            .await?;
+        zeph_db::query(sql!(
+            "INSERT INTO conversations (id) VALUES (?)
+             ON CONFLICT (id) DO NOTHING"
+        ))
+        .bind(conversation_id)
+        .execute(&self.pool)
+        .await?;
 
         let id: i64 = zeph_db::query_scalar(sql!(
             "INSERT INTO graph_episodes (conversation_id)
@@ -2315,8 +2318,9 @@ impl GraphStore {
         entity_id: i64,
     ) -> Result<(), MemoryError> {
         zeph_db::query(sql!(
-            "INSERT OR IGNORE INTO graph_episode_entities (episode_id, entity_id)
-             VALUES (?, ?)"
+            "INSERT INTO graph_episode_entities (episode_id, entity_id)
+             VALUES (?, ?)
+             ON CONFLICT (episode_id, entity_id) DO NOTHING"
         ))
         .bind(episode_id)
         .bind(entity_id)

--- a/crates/zeph-memory/src/reasoning.rs
+++ b/crates/zeph-memory/src/reasoning.rs
@@ -212,9 +212,15 @@ impl ReasoningMemory {
     ) -> Result<(), MemoryError> {
         let epoch_now = <ActiveDialect as zeph_db::dialect::Dialect>::EPOCH_NOW;
         let raw = format!(
-            "INSERT OR REPLACE INTO reasoning_strategies \
+            "INSERT INTO reasoning_strategies \
              (id, summary, outcome, task_hint, created_at, last_used_at, use_count, embedded_at) \
-             VALUES (?, ?, ?, ?, {epoch_now}, {epoch_now}, 0, NULL)"
+             VALUES (?, ?, ?, ?, {epoch_now}, {epoch_now}, 0, NULL) \
+             ON CONFLICT (id) DO UPDATE SET \
+               summary = EXCLUDED.summary, \
+               outcome = EXCLUDED.outcome, \
+               task_hint = EXCLUDED.task_hint, \
+               last_used_at = EXCLUDED.last_used_at, \
+               embedded_at = EXCLUDED.embedded_at"
         );
         let sql = zeph_db::rewrite_placeholders(&raw);
         zeph_db::query(&sql)

--- a/crates/zeph-memory/src/store/admission_training.rs
+++ b/crates/zeph-memory/src/store/admission_training.rs
@@ -238,8 +238,11 @@ impl SqliteStore {
         sample_count: i64,
     ) -> Result<(), MemoryError> {
         zeph_db::query(sql!(
-            "INSERT OR REPLACE INTO admission_rl_weights (id, weights_json, sample_count) \
-             VALUES (1, ?, ?)"
+            "INSERT INTO admission_rl_weights (id, weights_json, sample_count) \
+             VALUES (1, ?, ?) \
+             ON CONFLICT (id) DO UPDATE SET \
+               weights_json = EXCLUDED.weights_json, \
+               sample_count = EXCLUDED.sample_count"
         ))
         .bind(weights_json)
         .bind(sample_count)

--- a/crates/zeph-memory/src/store/skills.rs
+++ b/crates/zeph-memory/src/store/skills.rs
@@ -762,9 +762,10 @@ impl SqliteStore {
         hint: &str,
     ) -> Result<(), MemoryError> {
         zeph_db::query(sql!(
-            "INSERT OR IGNORE INTO step_corrections \
+            "INSERT INTO step_corrections \
              (skill_name, failure_kind, error_substring, tool_name, hint) \
-             VALUES (?, ?, ?, ?, ?)"
+             VALUES (?, ?, ?, ?, ?) \
+             ON CONFLICT (skill_name, failure_kind, error_substring, tool_name) DO NOTHING"
         ))
         .bind(skill_name)
         .bind(failure_kind)


### PR DESCRIPTION
## Summary

- Add four missing PostgreSQL migrations (084-087) at parity with SQLite for apex_mem, reasoning_strategies, hebbian edge weights, and hebbian consolidation tables (#3920)
- Add migration 088 to apply `ON DELETE CASCADE` to `trajectory_memory.conversation_id` FK, fixing conversation deletion failures in PostgreSQL (#3923)
- Replace eight `INSERT OR IGNORE` / `INSERT OR REPLACE` call sites in `zeph-memory` with portable `ON CONFLICT (...) DO NOTHING/UPDATE` syntax valid on both SQLite 3.24+ and PostgreSQL (#3925)
- Replace SQLite-only `unixepoch()` with dialect-portable `EPOCH_NOW` constant in `episodic_graph.rs`

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --lib --bins` — zero errors
- [x] `cargo nextest run --workspace --lib --bins` — 9326 passed, 0 failed
- [ ] PostgreSQL integration test (requires live PG instance) — not automated; migration SQL reviewed and verified against PG syntax rules

Closes #3920
Closes #3923
Closes #3925