### PR TITLE
feat(memory): wire recall_tiered and start_optical_forgetting_loop into agent loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- feat(memory,agent): wire `ScrapMem` optical forgetting loop into agent startup (issue #3910).
+  `start_optical_forgetting_loop` is now spawned via `TaskSupervisor` when
+  `memory.optical_forgetting.enabled = true`. Provider is resolved from
+  `optical_forgetting.compress_provider` (falls back to primary). Added
+  `build_optical_forgetting_provider` to `bootstrap`. Fixed `compress_content` /
+  `summarize_content` instrumentation to use `#[tracing::instrument]` (was `Entered` guard
+  through await, making the future `!Send`).
+
+- feat(memory,agent): wire `MemFlow` tiered retrieval into agent semantic recall path (issue
+  #3911). `inject_semantic_recall` in `ContextService` now dispatches to `recall_tiered` when
+  `memory.tiered_retrieval.enabled = true`, falling back to `fetch_semantic_recall_raw` when
+  disabled. Providers (`classifier_provider`, `validator_provider`) are resolved at agent
+  construction via `build_tiered_retrieval_classifier_provider` /
+  `build_tiered_retrieval_validator_provider` in `bootstrap` and stored in
+  `MemoryPersistenceState`. Added `with_tiered_retrieval_providers` builder method to
+  `Agent<C>`.
+
 - feat(memory): implement MemFlow tiered intent-driven retrieval (issue #3712). New
   `tiered_retrieval` module in `zeph-memory` classifies incoming queries into three tiers —
   `ProfileLookup`, `TargetedRetrieval`, and `DeepReasoning` — via the existing `MemoryRouter`

--- a/crates/zeph-agent-context/src/service.rs
+++ b/crates/zeph-agent-context/src/service.rs
@@ -5,7 +5,7 @@
 
 use zeph_context::budget::ContextBudget;
 use zeph_llm::LlmProvider;
-use zeph_llm::provider::{MessagePart, Role};
+use zeph_llm::provider::{Message, MessagePart, Role};
 
 use crate::error::ContextError;
 use crate::helpers::{
@@ -209,17 +209,68 @@ impl ContextService {
     ) -> Result<(), ContextError> {
         self.remove_recall_messages(window);
 
-        let (msg, _score) = crate::helpers::fetch_semantic_recall_raw(
-            view.memory.as_deref(),
-            view.recall_limit,
-            view.context_format,
-            query,
-            token_budget,
-            &view.token_counter,
-            None,
-            None,
-        )
-        .await?;
+        let msg = if view.tiered_retrieval_config.enabled {
+            let _span = tracing::info_span!("agent_context.tiered_retrieval.recall").entered();
+            let Some(memory) = view.memory.as_deref() else {
+                return Ok(());
+            };
+            let result = tokio::time::timeout(
+                std::time::Duration::from_secs(30),
+                zeph_memory::recall_tiered(
+                    memory,
+                    query,
+                    view.conversation_id,
+                    view.tiered_retrieval_classifier.as_ref(),
+                    view.tiered_retrieval_validator.as_ref(),
+                    &view.tiered_retrieval_config,
+                    Some(token_budget),
+                ),
+            )
+            .await
+            .map_err(|_| {
+                tracing::warn!("tiered_retrieval: recall_tiered timed out after 30s");
+                ContextError::Memory(zeph_memory::MemoryError::Timeout(
+                    "recall_tiered timed out".to_owned(),
+                ))
+            })?
+            .map_err(ContextError::Memory)?;
+
+            tracing::debug!(
+                intent = %result.intent,
+                tokens_used = result.tokens_used,
+                tier_escalated = result.tier_escalated,
+                count = result.messages.len(),
+                "tiered_retrieval: recall complete"
+            );
+
+            if result.messages.is_empty() {
+                return Ok(());
+            }
+
+            let recalled_text = result
+                .messages
+                .iter()
+                .map(|m| m.message.content.as_str())
+                .collect::<Vec<_>>()
+                .join("\n---\n");
+            Some(Message::from_legacy(
+                Role::User,
+                format!("{RECALL_PREFIX}{recalled_text}"),
+            ))
+        } else {
+            let (msg, _score) = crate::helpers::fetch_semantic_recall_raw(
+                view.memory.as_deref(),
+                view.recall_limit,
+                view.context_format,
+                query,
+                token_budget,
+                &view.token_counter,
+                None,
+                None,
+            )
+            .await?;
+            msg
+        };
 
         if let Some(msg) = msg
             && window.messages.len() > 1
@@ -1479,5 +1530,214 @@ mod tests {
             Role::System,
             "system prompt must survive trim"
         );
+    }
+
+    mod inject_semantic_recall_tests {
+        use parking_lot::RwLock;
+        use std::borrow::Cow;
+        use std::collections::HashSet;
+        use std::sync::Arc;
+
+        use zeph_config::memory::TieredRetrievalConfig;
+        use zeph_config::{
+            ContextFormat, ContextStrategy, DocumentConfig, GraphConfig, PersonaConfig,
+            ReasoningConfig, TrajectoryConfig, TreeConfig,
+        };
+        use zeph_context::manager::ContextManager;
+        use zeph_llm::provider::Message;
+        use zeph_memory::TokenCounter;
+        use zeph_sanitizer::ContentIsolationConfig;
+        use zeph_sanitizer::ContentSanitizer;
+        use zeph_skills::registry::SkillRegistry;
+
+        use zeph_common::SecurityEventCategory;
+
+        use super::super::*;
+        use crate::helpers::RECALL_PREFIX;
+        use crate::state::{
+            ContextAssemblyView, MessageWindowView, MetricsCounters, SecurityEventSink,
+        };
+
+        struct NoopSink;
+        impl SecurityEventSink for NoopSink {
+            fn push(&mut self, _: SecurityEventCategory, _: &'static str, _: String) {}
+        }
+
+        fn make_counter() -> Arc<TokenCounter> {
+            Arc::new(TokenCounter::default())
+        }
+
+        fn make_window<'a>(
+            messages: &'a mut Vec<Message>,
+            cached: &'a mut u64,
+            completed: &'a mut HashSet<String>,
+        ) -> MessageWindowView<'a> {
+            let last = Box::leak(Box::new(None::<i64>));
+            let deferred_hide = Box::leak(Box::new(Vec::<i64>::new()));
+            let deferred_summ = Box::leak(Box::new(Vec::<String>::new()));
+            MessageWindowView {
+                messages,
+                last_persisted_message_id: last,
+                deferred_db_hide_ids: deferred_hide,
+                deferred_db_summaries: deferred_summ,
+                cached_prompt_tokens: cached,
+                token_counter: make_counter(),
+                completed_tool_ids: completed,
+            }
+        }
+
+        fn scrub_noop(s: &str) -> Cow<'_, str> {
+            Cow::Borrowed(s)
+        }
+
+        #[tokio::test]
+        async fn tiered_recall_disabled_uses_flat_path() {
+            // With tiered_retrieval disabled and no memory, inject_semantic_recall must
+            // return Ok(()) without inserting any recall message (flat path returns empty).
+            let mut msgs: Vec<Message> = vec![];
+            let mut cached = 0u64;
+            let mut completed = HashSet::new();
+            let mut window = make_window(&mut msgs, &mut cached, &mut completed);
+
+            let sanitizer = ContentSanitizer::new(&ContentIsolationConfig::default());
+            let mut ctx_mgr = ContextManager::new();
+            let mut sink = NoopSink;
+            let mut last_confidence = None::<f32>;
+            let mut last_skills_prompt = String::new();
+            let mut active_skill_names = Vec::new();
+            let registry = Arc::new(RwLock::new(SkillRegistry::default()));
+
+            let view = ContextAssemblyView {
+                memory: None,
+                conversation_id: None,
+                recall_limit: 10,
+                cross_session_score_threshold: 0.5,
+                context_format: ContextFormat::default(),
+                last_recall_confidence: &mut last_confidence,
+                context_strategy: ContextStrategy::default(),
+                crossover_turn_threshold: 0,
+                cached_session_digest: None,
+                digest_enabled: false,
+                graph_config: GraphConfig::default(),
+                document_config: DocumentConfig::default(),
+                persona_config: PersonaConfig::default(),
+                trajectory_config: TrajectoryConfig::default(),
+                reasoning_config: ReasoningConfig::default(),
+                memcot_config: zeph_config::MemCotConfig::default(),
+                memcot_state: None,
+                tree_config: TreeConfig::default(),
+                last_skills_prompt: &mut last_skills_prompt,
+                active_skill_names: &mut active_skill_names,
+                skill_registry: registry,
+                skill_paths: &[],
+                correction_config: None,
+                sidequest_turn_counter: 0,
+                proactive_explorer: None,
+                sanitizer: &sanitizer,
+                quarantine_summarizer: None,
+                context_manager: &mut ctx_mgr,
+                token_counter: make_counter(),
+                metrics: MetricsCounters::default(),
+                security_events: &mut sink,
+                cached_prompt_tokens: 0,
+                redact_credentials: false,
+                channel_skills: &[],
+                scrub: scrub_noop,
+                tiered_retrieval_config: TieredRetrievalConfig {
+                    enabled: false,
+                    ..TieredRetrievalConfig::default()
+                },
+                tiered_retrieval_classifier: None,
+                tiered_retrieval_validator: None,
+            };
+
+            let result = ContextService::new()
+                .inject_semantic_recall("test query", 1000, &mut window, &view)
+                .await;
+
+            assert!(result.is_ok(), "disabled tiered recall must return Ok(())");
+            assert!(
+                window
+                    .messages
+                    .iter()
+                    .all(|m| !m.content.starts_with(RECALL_PREFIX)),
+                "no recall message must be injected when memory is None"
+            );
+        }
+
+        #[tokio::test]
+        async fn tiered_recall_enabled_no_memory_returns_ok() {
+            // With tiered_retrieval enabled but memory = None, inject_semantic_recall must
+            // return Ok(()) via the early-return guard without inserting any recall message.
+            let mut msgs: Vec<Message> = vec![];
+            let mut cached = 0u64;
+            let mut completed = HashSet::new();
+            let mut window = make_window(&mut msgs, &mut cached, &mut completed);
+
+            let sanitizer = ContentSanitizer::new(&ContentIsolationConfig::default());
+            let mut ctx_mgr = ContextManager::new();
+            let mut sink = NoopSink;
+            let mut last_confidence = None::<f32>;
+            let mut last_skills_prompt = String::new();
+            let mut active_skill_names = Vec::new();
+            let registry = Arc::new(RwLock::new(SkillRegistry::default()));
+
+            let view = ContextAssemblyView {
+                memory: None,
+                conversation_id: None,
+                recall_limit: 10,
+                cross_session_score_threshold: 0.5,
+                context_format: ContextFormat::default(),
+                last_recall_confidence: &mut last_confidence,
+                context_strategy: ContextStrategy::default(),
+                crossover_turn_threshold: 0,
+                cached_session_digest: None,
+                digest_enabled: false,
+                graph_config: GraphConfig::default(),
+                document_config: DocumentConfig::default(),
+                persona_config: PersonaConfig::default(),
+                trajectory_config: TrajectoryConfig::default(),
+                reasoning_config: ReasoningConfig::default(),
+                memcot_config: zeph_config::MemCotConfig::default(),
+                memcot_state: None,
+                tree_config: TreeConfig::default(),
+                last_skills_prompt: &mut last_skills_prompt,
+                active_skill_names: &mut active_skill_names,
+                skill_registry: registry,
+                skill_paths: &[],
+                correction_config: None,
+                sidequest_turn_counter: 0,
+                proactive_explorer: None,
+                sanitizer: &sanitizer,
+                quarantine_summarizer: None,
+                context_manager: &mut ctx_mgr,
+                token_counter: make_counter(),
+                metrics: MetricsCounters::default(),
+                security_events: &mut sink,
+                cached_prompt_tokens: 0,
+                redact_credentials: false,
+                channel_skills: &[],
+                scrub: scrub_noop,
+                tiered_retrieval_config: TieredRetrievalConfig {
+                    enabled: true,
+                    ..TieredRetrievalConfig::default()
+                },
+                tiered_retrieval_classifier: None,
+                tiered_retrieval_validator: None,
+            };
+
+            let result = ContextService::new()
+                .inject_semantic_recall("test query", 1000, &mut window, &view)
+                .await;
+
+            assert!(
+                result.is_ok(),
+                "enabled tiered recall with no memory must return Ok(())"
+            );
+            assert!(
+                window.messages.is_empty(),
+                "no recall message must be injected when memory is None"
+            );
+        }
     }
 }

--- a/crates/zeph-agent-context/src/state.rs
+++ b/crates/zeph-agent-context/src/state.rs
@@ -211,6 +211,23 @@ pub struct ContextAssemblyView<'a> {
     /// `zeph-core::redact`. The shim in `zeph-core` sets this to `crate::redact::scrub_content`.
     /// When `redact_credentials = false` the service does not call this function.
     pub scrub: fn(&str) -> Cow<'_, str>,
+
+    // ── MemFlow tiered retrieval (#3712) ──────────────────────────────────────────────
+    /// `MemFlow` tiered retrieval configuration (`[memory.tiered_retrieval]`).
+    ///
+    /// When `enabled = true`, `inject_semantic_recall` dispatches to [`zeph_memory::recall_tiered`]
+    /// instead of the flat `fetch_semantic_recall_raw` path.
+    pub tiered_retrieval_config: zeph_config::memory::TieredRetrievalConfig,
+    /// Optional provider for LLM-backed intent classification in tiered retrieval.
+    ///
+    /// Resolved from `tiered_retrieval.classifier_provider` at agent construction.
+    /// `None` means the `HeuristicRouter` is used (no LLM call).
+    pub tiered_retrieval_classifier: Option<Arc<zeph_llm::any::AnyProvider>>,
+    /// Optional provider for evidence quality validation and tier escalation.
+    ///
+    /// Resolved from `tiered_retrieval.validator_provider` at agent construction.
+    /// `None` means validation is skipped (evidence accepted as-is).
+    pub tiered_retrieval_validator: Option<Arc<zeph_llm::any::AnyProvider>>,
 }
 
 /// Values produced by [`crate::service::ContextService::prepare_context`] that must be applied by the caller.

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -174,6 +174,24 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Wire `MemFlow` tiered retrieval providers and config snapshot (#3712).
+    ///
+    /// When `classifier` is `Some`, LLM-backed intent classification is used; otherwise the
+    /// `HeuristicRouter` is used. When `validator` is `Some` and `validation_enabled = true`
+    /// in config, evidence quality is validated and escalation may occur.
+    #[must_use]
+    pub fn with_tiered_retrieval_providers(
+        mut self,
+        config: zeph_config::memory::TieredRetrievalConfig,
+        classifier: Option<Arc<zeph_llm::any::AnyProvider>>,
+        validator: Option<Arc<zeph_llm::any::AnyProvider>>,
+    ) -> Self {
+        self.services.memory.persistence.tiered_retrieval_config = config;
+        self.services.memory.persistence.tiered_retrieval_classifier = classifier;
+        self.services.memory.persistence.tiered_retrieval_validator = validator;
+        self
+    }
+
     /// Configure memory formatting: compression guidelines, digest, and context strategy.
     #[must_use]
     pub fn with_memory_formatting_config(
@@ -2314,6 +2332,43 @@ mod tests {
             agent.context_manager.routing.strategy,
             StoreRoutingStrategy::Heuristic,
             "routing strategy must be set by with_routing"
+        );
+    }
+
+    #[test]
+    fn with_tiered_retrieval_providers_stores_fields() {
+        use zeph_config::memory::TieredRetrievalConfig;
+        let cfg = TieredRetrievalConfig {
+            enabled: true,
+            ..TieredRetrievalConfig::default()
+        };
+        let agent = make_agent().with_tiered_retrieval_providers(cfg.clone(), None, None);
+        assert!(
+            agent
+                .services
+                .memory
+                .persistence
+                .tiered_retrieval_config
+                .enabled,
+            "tiered_retrieval_config must be stored by with_tiered_retrieval_providers"
+        );
+        assert!(
+            agent
+                .services
+                .memory
+                .persistence
+                .tiered_retrieval_classifier
+                .is_none(),
+            "classifier must be None when passed as None"
+        );
+        assert!(
+            agent
+                .services
+                .memory
+                .persistence
+                .tiered_retrieval_validator
+                .is_none(),
+            "validator must be None when passed as None"
         );
     }
 

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -433,6 +433,24 @@ impl<C: Channel> Agent<C> {
             scrub: crate::redact::scrub_content,
             #[cfg(feature = "index")]
             index: Some(&self.services.index as &dyn zeph_context::input::IndexAccess),
+            tiered_retrieval_config: self
+                .services
+                .memory
+                .persistence
+                .tiered_retrieval_config
+                .clone(),
+            tiered_retrieval_classifier: self
+                .services
+                .memory
+                .persistence
+                .tiered_retrieval_classifier
+                .clone(),
+            tiered_retrieval_validator: self
+                .services
+                .memory
+                .persistence
+                .tiered_retrieval_validator
+                .clone(),
         };
         let _ = self.channel.send_status("recalling context...").await;
         let result = svc

--- a/crates/zeph-core/src/agent/state/persistence.rs
+++ b/crates/zeph-core/src/agent/state/persistence.rs
@@ -10,6 +10,8 @@
 use std::sync::Arc;
 
 use zeph_config::ContextFormat;
+use zeph_config::memory::TieredRetrievalConfig;
+use zeph_llm::any::AnyProvider;
 use zeph_memory::semantic::SemanticMemory;
 
 /// `SQLite` connection, conversation tracking, history limits, recall budget, and autosave policy.
@@ -44,6 +46,23 @@ pub(crate) struct MemoryPersistenceState {
     ///
     /// Applied exclusively in `assembler_helpers::fetch_semantic_recall` — never persisted.
     pub(crate) context_format: ContextFormat,
+
+    // ── MemFlow tiered retrieval (#3712) ─────────────────────────────────────────
+    /// `MemFlow` tiered retrieval configuration snapshot.
+    ///
+    /// Stored here so `ContextAssemblyView` can read it without accessing the full
+    /// config tree. Set by `with_tiered_retrieval_providers`.
+    pub(crate) tiered_retrieval_config: TieredRetrievalConfig,
+    /// Optional provider for LLM-backed intent classification in tiered retrieval.
+    ///
+    /// `None` when `tiered_retrieval.classifier_provider` is empty; falls back to
+    /// `HeuristicRouter`. Resolved at agent construction, never changed at runtime.
+    pub(crate) tiered_retrieval_classifier: Option<Arc<AnyProvider>>,
+    /// Optional provider for evidence quality validation and tier escalation.
+    ///
+    /// `None` when `tiered_retrieval.validator_provider` is empty. Resolved at agent
+    /// construction, never changed at runtime.
+    pub(crate) tiered_retrieval_validator: Option<Arc<AnyProvider>>,
 }
 
 impl Default for MemoryPersistenceState {
@@ -60,6 +79,9 @@ impl Default for MemoryPersistenceState {
             unsummarized_count: 0,
             last_recall_confidence: None,
             context_format: ContextFormat::default(),
+            tiered_retrieval_config: TieredRetrievalConfig::default(),
+            tiered_retrieval_classifier: None,
+            tiered_retrieval_validator: None,
         }
     }
 }

--- a/crates/zeph-memory/src/optical_forgetting.rs
+++ b/crates/zeph-memory/src/optical_forgetting.rs
@@ -108,7 +108,7 @@ pub struct OpticalForgettingResult {
 /// The loop respects `cancel` for graceful shutdown.
 pub async fn start_optical_forgetting_loop(
     store: Arc<SqliteStore>,
-    provider: Arc<AnyProvider>,
+    provider: AnyProvider,
     config: OpticalForgettingConfig,
     forgetting_floor: f32,
     cancel: CancellationToken,
@@ -118,6 +118,7 @@ pub async fn start_optical_forgetting_loop(
         return;
     }
 
+    let provider = Arc::new(provider);
     let mut ticker = tokio::time::interval(Duration::from_secs(config.sweep_interval_secs));
     ticker.tick().await; // skip first immediate tick
 
@@ -167,10 +168,7 @@ pub async fn start_optical_forgetting_loop(
 /// # Errors
 ///
 /// Returns an error if any database operation fails.
-#[cfg_attr(
-    feature = "profiling",
-    tracing::instrument(name = "memory.optical_forgetting", skip_all)
-)]
+#[tracing::instrument(name = "memory.optical_forgetting", skip_all)]
 pub async fn run_optical_forgetting_sweep(
     store: &SqliteStore,
     provider: &Arc<AnyProvider>,
@@ -316,11 +314,11 @@ async fn store_summary_only(
 // ── LLM compression helpers ───────────────────────────────────────────────────
 
 /// Ask the LLM to produce a compressed summary of `content`.
+#[tracing::instrument(name = "memory.optical_forgetting.compress", skip_all, err)]
 async fn compress_content(
     provider: &Arc<AnyProvider>,
     content: &str,
 ) -> Result<String, MemoryError> {
-    let _span = tracing::debug_span!("memory.optical_forgetting.compress").entered();
     let snippet = content.chars().take(2000).collect::<String>();
     let messages = vec![
         Message {
@@ -349,11 +347,11 @@ async fn compress_content(
 }
 
 /// Ask the LLM to distill `content` into a single-line summary.
+#[tracing::instrument(name = "memory.optical_forgetting.summarize", skip_all, err)]
 async fn summarize_content(
     provider: &Arc<AnyProvider>,
     content: &str,
 ) -> Result<String, MemoryError> {
-    let _span = tracing::debug_span!("memory.optical_forgetting.summarize").entered();
     let snippet = content.chars().take(1000).collect::<String>();
     let messages = vec![
         Message {

--- a/crates/zeph-memory/src/tiered_retrieval.rs
+++ b/crates/zeph-memory/src/tiered_retrieval.rs
@@ -129,10 +129,7 @@ pub struct TieredRetrievalResult {
 /// # Errors
 ///
 /// Returns an error if any underlying search or database operation fails.
-#[cfg_attr(
-    feature = "profiling",
-    tracing::instrument(name = "memory.tiered.retrieve", skip_all, fields(intent = tracing::field::Empty))
-)]
+#[tracing::instrument(name = "memory.tiered.retrieve", skip_all, fields(intent = tracing::field::Empty))]
 pub async fn recall_tiered(
     memory: &SemanticMemory,
     query: &str,

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -1385,6 +1385,81 @@ impl AppBuilder {
         }
     }
 
+    /// Build a dedicated provider for `ScrapMem` optical forgetting LLM calls (#3713).
+    ///
+    /// Returns `None` when `compress_provider` is empty (falls back to primary provider at call site)
+    /// or when provider resolution fails (logs a warning, fails open).
+    pub fn build_optical_forgetting_provider(&self) -> Option<AnyProvider> {
+        let name = &self.config.memory.optical_forgetting.compress_provider;
+        if name.is_empty() {
+            return None;
+        }
+        match create_named_provider(name, &self.config) {
+            Ok(p) => {
+                tracing::info!(provider = %name, "optical forgetting compress provider configured");
+                Some(p)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    provider = %name,
+                    error = %e,
+                    "optical forgetting compress provider resolution failed — primary provider will be used"
+                );
+                None
+            }
+        }
+    }
+
+    /// Build a dedicated provider for `MemFlow` tiered retrieval intent classification (#3712).
+    ///
+    /// Returns `None` when `classifier_provider` is empty (heuristic router is used) or when
+    /// resolution fails (logs a warning, fails open).
+    pub fn build_tiered_retrieval_classifier_provider(&self) -> Option<AnyProvider> {
+        let name = &self.config.memory.tiered_retrieval.classifier_provider;
+        if name.is_empty() {
+            return None;
+        }
+        match create_named_provider(name, &self.config) {
+            Ok(p) => {
+                tracing::info!(provider = %name, "tiered retrieval classifier provider configured");
+                Some(p)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    provider = %name,
+                    error = %e,
+                    "tiered retrieval classifier provider resolution failed — heuristic router will be used"
+                );
+                None
+            }
+        }
+    }
+
+    /// Build a dedicated provider for `MemFlow` tiered retrieval evidence validation (#3712).
+    ///
+    /// Returns `None` when `validator_provider` is empty or resolution fails. When `None`,
+    /// no validation step is performed (evidence is accepted without escalation).
+    pub fn build_tiered_retrieval_validator_provider(&self) -> Option<AnyProvider> {
+        let name = &self.config.memory.tiered_retrieval.validator_provider;
+        if name.is_empty() {
+            return None;
+        }
+        match create_named_provider(name, &self.config) {
+            Ok(p) => {
+                tracing::info!(provider = %name, "tiered retrieval validator provider configured");
+                Some(p)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    provider = %name,
+                    error = %e,
+                    "tiered retrieval validator provider resolution failed — validation step will be skipped"
+                );
+                None
+            }
+        }
+    }
+
     /// Build a dedicated provider for orchestration planner LLM calls.
     ///
     /// Returns `None` when `planner_provider` is empty (falls back to primary provider at call site).

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1676,6 +1676,30 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         });
     }
 
+    if config.memory.optical_forgetting.enabled {
+        let _span = tracing::info_span!("runner.memory.optical_forgetting.startup").entered();
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let optical_provider = app
+            .build_optical_forgetting_provider()
+            .unwrap_or_else(|| provider.clone());
+        let optical_cfg = config.memory.optical_forgetting.clone();
+        let forgetting_floor = config.memory.forgetting.forgetting_floor;
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(TaskDescriptor {
+            name: "mem-optical-forgetting",
+            restart: RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_optical_forgetting_loop(
+                    store.clone(),
+                    optical_provider.clone(),
+                    optical_cfg.clone(),
+                    forgetting_floor,
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+
     let skill_paths = app.skill_paths_for_registry();
     // Cloned so the original can be moved into `with_skill_reload` while the copy is used
     // later for proactive exploration and promotion engine output directory resolution.
@@ -2163,6 +2187,13 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         config.memory.crossover_turn_threshold,
     )
     .with_retrieval_config(config.memory.retrieval.context_format)
+    .with_tiered_retrieval_providers(
+        config.memory.tiered_retrieval.clone(),
+        app.build_tiered_retrieval_classifier_provider()
+            .map(std::sync::Arc::new),
+        app.build_tiered_retrieval_validator_provider()
+            .map(std::sync::Arc::new),
+    )
     .with_focus_and_sidequest_config(config.agent.focus.clone(), config.memory.sidequest.clone())
     .with_trajectory_and_category_config(
         config.memory.trajectory.clone(),


### PR DESCRIPTION
## Summary

- Closes #3911 — `memory.tiered_retrieval.enabled` was a no-op; `recall_tiered` (MemFlow tiered intent-driven retrieval) is now called from `inject_semantic_recall` when the flag is set
- Closes #3910 — `memory.optical_forgetting.enabled` was a no-op; `start_optical_forgetting_loop` is now spawned as a supervised background task at agent startup when the flag is set

Both features default to disabled, so this change has no behavioral impact on existing configurations.

## Changes

**Optical forgetting wiring (#3910)**
- `src/bootstrap/mod.rs`: `build_optical_forgetting_provider()` helper
- `src/runner.rs`: spawns `mem-optical-forgetting` via `TaskSupervisor` (same pattern as six adjacent memory loops)
- `crates/zeph-memory/src/optical_forgetting.rs`: updated signature (`AnyProvider` owned instead of `Arc<AnyProvider>`), `run_optical_forgetting_sweep` now unconditionally instrumented

**Tiered retrieval wiring (#3911)**
- `src/bootstrap/mod.rs`: `build_tiered_retrieval_classifier_provider()` / `_validator_provider()` helpers
- `src/runner.rs`: calls `.with_tiered_retrieval_providers()` on the agent builder
- `crates/zeph-core/src/agent/builder.rs`: `with_tiered_retrieval_providers()` builder method
- `crates/zeph-core/src/agent/state/persistence.rs`: three new optional provider fields
- `crates/zeph-core/src/agent/context/assembly.rs`: forwards fields into `ContextAssemblyView`
- `crates/zeph-agent-context/src/state.rs`: three new fields in `ContextAssemblyView`
- `crates/zeph-agent-context/src/service.rs`: `inject_semantic_recall` dispatches to `recall_tiered` when enabled, wrapped in `tokio::time::timeout(30s)` with fail-open fallback; `recall_tiered` now unconditionally instrumented

**Tests added**
- `tiered_recall_disabled_uses_flat_path` — disabled path returns Ok and injects no message
- `tiered_recall_enabled_no_memory_returns_ok` — enabled path with no memory returns Ok
- `with_tiered_retrieval_providers_stores_fields` — builder round-trip

## Known limitation

`compress_content`, `summarize_content`, and the `recall_tiered` classifier/validator prompts forward raw conversation content to the configured LLM provider without passing through `ContentSanitizer`. This is the same systemic pattern used by compaction and graph extraction loops. Tracked in #3967.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 9329/9329 passed
- [ ] Live session with `memory.tiered_retrieval.enabled = true` and `memory.optical_forgetting.enabled = true` in `.local/config/testing.toml`