### PR TITLE
fix(db,memory): add DEFAULT to experience_nodes.created_at and sanitize LLM-bound content

### DIFF
--- a/crates/zeph-db/migrations/postgres/083_experience_memory.sql
+++ b/crates/zeph-db/migrations/postgres/083_experience_memory.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS experience_nodes (
     outcome     TEXT    NOT NULL,
     detail      TEXT,
     error_ctx   TEXT,
-    created_at  BIGINT  NOT NULL
+    created_at  BIGINT  NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT
 );
 
 -- Experience edges: temporal sequence between consecutive experience nodes

--- a/crates/zeph-db/migrations/sqlite/076_experience_memory.sql
+++ b/crates/zeph-db/migrations/sqlite/076_experience_memory.sql
@@ -2,7 +2,7 @@
 -- SPDX-License-Identifier: MIT OR Apache-2.0
 
 -- Experience nodes: records of tool execution outcomes in the agent loop
-CREATE TABLE experience_nodes (
+CREATE TABLE IF NOT EXISTS experience_nodes (
     id          INTEGER PRIMARY KEY AUTOINCREMENT,
     session_id  TEXT    NOT NULL,
     turn        INTEGER NOT NULL,
@@ -10,11 +10,11 @@ CREATE TABLE experience_nodes (
     outcome     TEXT    NOT NULL,
     detail      TEXT,
     error_ctx   TEXT,
-    created_at  INTEGER NOT NULL
+    created_at  INTEGER NOT NULL DEFAULT (unixepoch())
 );
 
 -- Experience edges: temporal sequence between consecutive experience nodes
-CREATE TABLE experience_edges (
+CREATE TABLE IF NOT EXISTS experience_edges (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
     source_exp_id   INTEGER NOT NULL REFERENCES experience_nodes(id),
     target_exp_id   INTEGER NOT NULL REFERENCES experience_nodes(id),
@@ -22,12 +22,12 @@ CREATE TABLE experience_edges (
 );
 
 -- Links between experience nodes and knowledge graph entities
-CREATE TABLE experience_entity_links (
+CREATE TABLE IF NOT EXISTS experience_entity_links (
     experience_id   INTEGER NOT NULL REFERENCES experience_nodes(id),
     entity_id       INTEGER NOT NULL REFERENCES graph_entities(id),
     PRIMARY KEY (experience_id, entity_id)
 );
 
-CREATE INDEX idx_experience_nodes_session ON experience_nodes(session_id, turn);
-CREATE INDEX idx_experience_nodes_tool    ON experience_nodes(tool_name);
-CREATE INDEX idx_experience_entity_links  ON experience_entity_links(entity_id);
+CREATE INDEX IF NOT EXISTS idx_experience_nodes_session ON experience_nodes(session_id, turn);
+CREATE INDEX IF NOT EXISTS idx_experience_nodes_tool    ON experience_nodes(tool_name);
+CREATE INDEX IF NOT EXISTS idx_experience_entity_links  ON experience_entity_links(entity_id);

--- a/crates/zeph-memory/src/optical_forgetting.rs
+++ b/crates/zeph-memory/src/optical_forgetting.rs
@@ -319,7 +319,8 @@ async fn compress_content(
     provider: &Arc<AnyProvider>,
     content: &str,
 ) -> Result<String, MemoryError> {
-    let snippet = content.chars().take(2000).collect::<String>();
+    let cleaned = zeph_common::sanitize::strip_control_chars_preserve_whitespace(content);
+    let snippet = cleaned.chars().take(2000).collect::<String>();
     let messages = vec![
         Message {
             role: Role::System,
@@ -352,7 +353,8 @@ async fn summarize_content(
     provider: &Arc<AnyProvider>,
     content: &str,
 ) -> Result<String, MemoryError> {
-    let snippet = content.chars().take(1000).collect::<String>();
+    let cleaned = zeph_common::sanitize::strip_control_chars_preserve_whitespace(content);
+    let snippet = cleaned.chars().take(1000).collect::<String>();
     let messages = vec![
         Message {
             role: Role::System,

--- a/crates/zeph-memory/src/tiered_retrieval.rs
+++ b/crates/zeph-memory/src/tiered_retrieval.rs
@@ -312,7 +312,12 @@ async fn validate_evidence(
     let evidence_snippet = messages
         .iter()
         .take(5)
-        .map(|m| m.message.content.chars().take(200).collect::<String>())
+        .map(|m| {
+            zeph_common::sanitize::strip_control_chars_preserve_whitespace(&m.message.content)
+                .chars()
+                .take(200)
+                .collect::<String>()
+        })
         .collect::<Vec<_>>()
         .join("\n---\n");
 
@@ -320,9 +325,10 @@ async fn validate_evidence(
         Given a query and evidence snippets, decide if the evidence is sufficient to answer the query. \
         Respond ONLY with a JSON object: {\"sufficient\": true|false, \"confidence\": 0.0-1.0}";
 
+    let sanitized_query = zeph_common::sanitize::strip_control_chars_preserve_whitespace(query);
     let user = format!(
         "<query>{}</query>\n<evidence>{}</evidence>",
-        query.chars().take(500).collect::<String>(),
+        sanitized_query.chars().take(500).collect::<String>(),
         evidence_snippet
     );
 


### PR DESCRIPTION
## Summary

- Add `DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT` to `created_at` in `postgres/083_experience_memory.sql` (closes #3921)
- Add `DEFAULT (unixepoch())` to `created_at` in `sqlite/076_experience_memory.sql`, plus `IF NOT EXISTS` on all `CREATE TABLE` / `CREATE INDEX` for idempotency
- Sanitize content before LLM send in `optical_forgetting.rs` (`compress_content`, `summarize_content`) and `tiered_retrieval.rs` (`validate_evidence`) via `zeph_common::sanitize::strip_control_chars_preserve_whitespace` (closes #3967)

Note: `ContentSanitizer` from `zeph-sanitizer` cannot be used directly — it depends on `zeph-memory`, creating a circular dependency. `zeph_common::sanitize` is the correct architectural choice and applies the same control-char stripping.

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace --features desktop,ide,server,chat,pdf,scheduler -- -D warnings` — clean
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 9427 tests pass
- [ ] PostgreSQL migration idempotency verified via integration tests (`--ignored`, requires live PG instance)

Closes #3921
Closes #3967