### PR TITLE
feat(hooks): add PostToolUse output replacement and duration_ms

### DIFF
--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -1817,7 +1817,8 @@ impl<C: Channel> Agent<C> {
                     let mcp: Option<&dyn zeph_subagent::McpDispatch> = dispatch
                         .as_ref()
                         .map(|d| d as &dyn zeph_subagent::McpDispatch);
-                    if let Err(e) = zeph_subagent::hooks::fire_hooks(&hooks, &env, mcp).await {
+                    if let Err(e) = zeph_subagent::hooks::fire_hooks(&hooks, &env, mcp, None).await
+                    {
                         tracing::warn!(error = %e, "turn_complete hook failed");
                     }
                 },
@@ -3389,7 +3390,7 @@ impl<C: Channel> Agent<C> {
             let mcp: Option<&dyn zeph_subagent::McpDispatch> = dispatch
                 .as_ref()
                 .map(|d| d as &dyn zeph_subagent::McpDispatch);
-            if let Err(e) = zeph_subagent::hooks::fire_hooks(&hooks, &env, mcp).await {
+            if let Err(e) = zeph_subagent::hooks::fire_hooks(&hooks, &env, mcp, None).await {
                 tracing::warn!(error = %e, "CwdChanged hook failed");
             } else {
                 tracing::info!(count = hooks.len(), "CwdChanged: hooks fired");
@@ -3430,7 +3431,7 @@ impl<C: Channel> Agent<C> {
             let mcp: Option<&dyn zeph_subagent::McpDispatch> = dispatch
                 .as_ref()
                 .map(|d| d as &dyn zeph_subagent::McpDispatch);
-            if let Err(e) = zeph_subagent::hooks::fire_hooks(&hooks, &env, mcp).await {
+            if let Err(e) = zeph_subagent::hooks::fire_hooks(&hooks, &env, mcp, None).await {
                 tracing::warn!(error = %e, "FileChanged hook failed");
             } else {
                 tracing::info!(count = hooks.len(), path = %event.path.display(), "FileChanged: hooks fired");

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -1376,7 +1376,7 @@ impl<C: Channel> Agent<C> {
         let mcp: Option<&dyn zeph_subagent::McpDispatch> = dispatch
             .as_ref()
             .map(|d| d as &dyn zeph_subagent::McpDispatch);
-        if let Err(e) = zeph_subagent::hooks::fire_hooks(&pd_hooks, &env, mcp).await {
+        if let Err(e) = zeph_subagent::hooks::fire_hooks(&pd_hooks, &env, mcp, None).await {
             tracing::warn!(error = %e, tool = %tc.name, "PermissionDenied hook failed");
         }
     }
@@ -1451,7 +1451,8 @@ impl<C: Channel> Agent<C> {
                     let mcp: Option<&dyn zeph_subagent::McpDispatch> = dispatch
                         .as_ref()
                         .map(|d| d as &dyn zeph_subagent::McpDispatch);
-                    if let Err(e) = zeph_subagent::hooks::fire_hooks(&owned, &env, mcp).await {
+                    if let Err(e) = zeph_subagent::hooks::fire_hooks(&owned, &env, mcp, None).await
+                    {
                         tracing::warn!(
                             error = %e,
                             tool = %tc.name,
@@ -1614,7 +1615,7 @@ impl<C: Channel> Agent<C> {
         Ok(Some(result))
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
     async fn apply_tier_results(
         &mut self,
         indices: Vec<usize>,
@@ -1627,7 +1628,7 @@ impl<C: Channel> Agent<C> {
         failed_ids: &mut std::collections::HashSet<String>,
         tool_results: &mut [Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>],
     ) {
-        for (idx, result) in indices.into_iter().zip(tier_results) {
+        for (idx, mut result) in indices.into_iter().zip(tier_results) {
             // IMP-02: Err(_) covers all error variants including ConfirmationRequired.
             // Ok(Some(out)) with "[error]" prefix covers synthetic/blocked results.
             let is_failed = match &result {
@@ -1704,19 +1705,63 @@ impl<C: Channel> Agent<C> {
                         &tool_calls[idx].input,
                         conv_id_str.as_deref(),
                     );
-                    let duration_ms = tool_started_ats[idx].elapsed().as_millis();
+                    let duration_ms = u64::try_from(tool_started_ats[idx].elapsed().as_millis())
+                        .unwrap_or(u64::MAX);
                     env.insert("ZEPH_TOOL_DURATION_MS".to_owned(), duration_ms.to_string());
                     let owned: Vec<zeph_config::HookDef> = matched.into_iter().cloned().collect();
                     let dispatch = self.mcp_dispatch();
                     let mcp: Option<&dyn zeph_subagent::McpDispatch> = dispatch
                         .as_ref()
                         .map(|d| d as &dyn zeph_subagent::McpDispatch);
-                    if let Err(e) = zeph_subagent::hooks::fire_hooks(&owned, &env, mcp).await {
-                        tracing::warn!(
-                            error = %e,
-                            tool = %tool_calls[idx].name,
-                            "PostToolUse hook failed"
-                        );
+
+                    // Build stdin JSON context for the hook process.
+                    let tool_output_text = match &result {
+                        Ok(Some(out)) => Some(out.summary.as_str()),
+                        _ => None,
+                    };
+                    let tool_error_text = match &result {
+                        Err(e) => Some(e.to_string()),
+                        _ => None,
+                    };
+                    let hook_input = zeph_subagent::PostToolUseHookInput {
+                        tool_name: tool_calls[idx].name.as_str(),
+                        tool_args: &tool_calls[idx].input,
+                        session_id: conv_id_str.as_deref(),
+                        duration_ms,
+                        tool_output: tool_output_text,
+                        tool_error: tool_error_text.as_deref(),
+                    };
+                    let stdin_bytes = serde_json::to_vec(&hook_input).ok();
+
+                    match zeph_subagent::hooks::fire_hooks(
+                        &owned,
+                        &env,
+                        mcp,
+                        stdin_bytes.as_deref(),
+                    )
+                    .await
+                    {
+                        Ok(run_result) => {
+                            if let Some(replacement) = run_result.output.updated_tool_output {
+                                // Apply hook-requested output substitution.
+                                if let Ok(Some(ref mut out)) = result {
+                                    tracing::debug!(
+                                        tool = %tool_calls[idx].name,
+                                        original_len = out.summary.len(),
+                                        replacement_len = replacement.len(),
+                                        "PostToolUse hook replaced tool output"
+                                    );
+                                    out.summary = replacement;
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                error = %e,
+                                tool = %tool_calls[idx].name,
+                                "PostToolUse hook failed"
+                            );
+                        }
                     }
                 }
             }

--- a/crates/zeph-subagent/src/agent_loop.rs
+++ b/crates/zeph-subagent/src/agent_loop.rs
@@ -452,6 +452,7 @@ async fn run_turn(
 }
 
 // Returns `true` if no tool was called (loop should break).
+#[allow(clippy::too_many_lines)]
 async fn handle_tool_step(
     executor: &FilteredToolExecutor,
     response: ChatResponse,
@@ -493,7 +494,7 @@ async fn handle_tool_step(
                     let hook_env = make_hook_env(task_id, agent_name, tc.name.as_str(), &tc.input);
                     let pre_owned: Vec<HookDef> = pre_hooks.into_iter().cloned().collect();
                     // MCP dispatch is not available in the subagent execution path.
-                    if let Err(e) = fire_hooks(&pre_owned, &hook_env, None).await {
+                    if let Err(e) = fire_hooks(&pre_owned, &hook_env, None, None).await {
                         tracing::warn!(error = %e, tool = %tc.name, "PreToolUse hook failed");
                     }
                 }
@@ -513,7 +514,11 @@ async fn handle_tool_step(
                     tool_call_id: String::new(),
                 };
                 let tool_start = Instant::now();
-                let (content, is_error) = match executor.execute_tool_call_erased(&call).await {
+                let exec_result = executor.execute_tool_call_erased(&call).await;
+                let duration_ms =
+                    u64::try_from(tool_start.elapsed().as_millis()).unwrap_or(u64::MAX);
+
+                let (mut content, is_error) = match &exec_result {
                     Ok(Some(output)) => (
                         format!(
                             "[tool output: {}]\n```\n{}\n```",
@@ -527,12 +532,6 @@ async fn handle_tool_step(
                         (format!("[tool error]: {e}"), true)
                     }
                 };
-                let duration_ms = tool_start.elapsed().as_millis();
-                result_parts.push(MessagePart::ToolResult {
-                    tool_use_id: tc.id.clone(),
-                    content,
-                    is_error,
-                });
 
                 if !hooks.post_tool_use.is_empty() {
                     let post_hooks: Vec<&HookDef> =
@@ -543,16 +542,52 @@ async fn handle_tool_step(
                         hook_env
                             .insert("ZEPH_TOOL_DURATION_MS".to_owned(), duration_ms.to_string());
                         let post_owned: Vec<HookDef> = post_hooks.into_iter().cloned().collect();
+                        let tool_output_text = exec_result
+                            .as_ref()
+                            .ok()
+                            .and_then(|r| r.as_ref())
+                            .map(|o| o.summary.as_str());
+                        let tool_error_text = exec_result
+                            .as_ref()
+                            .err()
+                            .map(std::string::ToString::to_string);
+                        let hook_input = super::hooks::PostToolUseHookInput {
+                            tool_name: tc.name.as_str(),
+                            tool_args: &tc.input,
+                            session_id: None,
+                            duration_ms,
+                            tool_output: tool_output_text,
+                            tool_error: tool_error_text.as_deref(),
+                        };
+                        let stdin_bytes = serde_json::to_vec(&hook_input).ok();
                         // MCP dispatch is not available in the subagent execution path.
-                        if let Err(e) = fire_hooks(&post_owned, &hook_env, None).await {
-                            tracing::warn!(
-                                error = %e,
-                                tool = %tc.name,
-                                "PostToolUse hook failed"
-                            );
+                        match fire_hooks(&post_owned, &hook_env, None, stdin_bytes.as_deref()).await
+                        {
+                            Ok(run_result) => {
+                                if let Some(replacement) = run_result.output.updated_tool_output {
+                                    tracing::debug!(
+                                        tool = %tc.name,
+                                        "PostToolUse hook replaced sub-agent tool output"
+                                    );
+                                    content = replacement;
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    error = %e,
+                                    tool = %tc.name,
+                                    "PostToolUse hook failed"
+                                );
+                            }
                         }
                     }
                 }
+
+                result_parts.push(MessagePart::ToolResult {
+                    tool_use_id: tc.id.clone(),
+                    content,
+                    is_error,
+                });
             }
 
             messages.push(Message::from_parts(Role::User, result_parts));

--- a/crates/zeph-subagent/src/hooks.rs
+++ b/crates/zeph-subagent/src/hooks.rs
@@ -24,6 +24,38 @@
 //! Hooks within a matcher are run sequentially. `fail_closed = true` hooks abort on the
 //! first error; `fail_closed = false` (default) log the error and continue.
 //!
+//! # `PostToolUse` stdout replacement
+//!
+//! Shell hooks for `PostToolUse` events may emit a JSON object to stdout to replace the
+//! tool output seen by the agent. The JSON must contain:
+//!
+//! ```json
+//! { "hookSpecificOutput": { "updatedToolOutput": "replacement text" } }
+//! ```
+//!
+//! If `updatedToolOutput` is `null` or absent, or stdout is empty / not valid JSON, the
+//! original tool output is preserved (backward compatible). Hook stdout is capped at 1 MiB
+//! to prevent memory exhaustion; output exceeding the cap is silently truncated and treated
+//! as if no substitution was requested.
+//!
+//! # Hook stdin (`PostToolUse`)
+//!
+//! For `PostToolUse` and `PostToolUseFailure` events, a JSON context object is written to
+//! the hook process's stdin:
+//!
+//! ```json
+//! {
+//!   "tool_name": "Shell",
+//!   "tool_args": { ... },
+//!   "session_id": "abc123",
+//!   "duration_ms": 142,
+//!   "tool_output": "command output here"
+//! }
+//! ```
+//!
+//! `tool_error` replaces `tool_output` for failure events. Hooks that do not read stdin
+//! are unaffected — the pipe is closed when the child ignores it.
+//!
 //! # Examples
 //!
 //! ```rust,no_run
@@ -36,7 +68,7 @@
 //!         timeout_secs: 5,
 //!         fail_closed: false,
 //!     }];
-//!     fire_hooks(&hooks, &HashMap::new(), None).await.unwrap();
+//!     fire_hooks(&hooks, &HashMap::new(), None, None).await.unwrap();
 //! }
 //! ```
 
@@ -44,11 +76,66 @@ use std::collections::HashMap;
 use std::hash::BuildHasher;
 use std::time::Duration;
 
+use serde::Serialize;
 use thiserror::Error;
+use tokio::io::AsyncWriteExt as _;
 use tokio::process::Command;
 use tokio::time::timeout;
 
 pub use zeph_config::{HookAction, HookDef, HookMatcher, SubagentHooks};
+
+// ── Hook output types ─────────────────────────────────────────────────────────
+
+/// Structured output captured from a hook's stdout.
+///
+/// Only populated for shell `PostToolUse` hooks; MCP hooks always produce
+/// `updated_tool_output: None`.
+#[derive(Debug, Default)]
+pub struct HookOutput {
+    /// Replacement text for the tool output, when the hook requests a substitution.
+    ///
+    /// `None` means the original tool output is preserved.
+    pub updated_tool_output: Option<String>,
+}
+
+/// Aggregate result of executing one or more hooks in sequence.
+///
+/// Callers that do not need the output can ignore this and check only for `Err`.
+#[derive(Debug, Default)]
+pub struct HookRunResult {
+    /// Merged output from the hook sequence. When multiple hooks emit
+    /// `updatedToolOutput`, the last non-`None` value wins.
+    pub output: HookOutput,
+}
+
+// ── Hook stdin payload ────────────────────────────────────────────────────────
+
+/// Context serialized to hook stdin for `PostToolUse` and `PostToolUseFailure` events.
+///
+/// The `tool_output` field is present for success events; `tool_error` is present
+/// for failure events. Both are `Option` with `skip_serializing_if` so only the
+/// relevant field appears in the JSON written to stdin.
+#[derive(Debug, Serialize)]
+pub struct PostToolUseHookInput<'a> {
+    /// Name of the tool that was invoked.
+    pub tool_name: &'a str,
+    /// Arguments passed to the tool (the parsed JSON value).
+    pub tool_args: &'a serde_json::Value,
+    /// Conversation / session identifier, if available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<&'a str>,
+    /// Wall-clock time the tool took to execute, in milliseconds.
+    pub duration_ms: u64,
+    /// Tool output text (success path). Absent for failure events.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_output: Option<&'a str>,
+    /// Tool error text (failure path). Absent for success events.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_error: Option<&'a str>,
+}
+
+/// Maximum number of bytes read from hook stdout before truncation.
+const HOOK_STDOUT_CAP: usize = 1024 * 1024; // 1 MiB
 
 // ── McpDispatch ───────────────────────────────────────────────────────────────
 
@@ -154,6 +241,16 @@ pub fn matching_hooks<'a>(matchers: &'a [HookMatcher], tool_name: &str) -> Vec<&
 /// execution stops immediately and `Err` is returned. Otherwise errors are logged
 /// and execution continues.
 ///
+/// The optional `stdin_json` bytes are written to the hook process's stdin before
+/// it runs (shell hooks only). Pass `None` for hooks that do not require context
+/// on stdin (e.g., `PreToolUse`). MCP hooks never receive stdin data.
+///
+/// When multiple shell hooks run in sequence and emit `updatedToolOutput`, the last
+/// non-`None` value wins. If a fail-closed hook aborts after a previous hook already
+/// produced a replacement, the prior replacement is preserved in the returned error
+/// path — callers should discard `HookRunResult` on `Err` if appropriate for their
+/// use-case, but the struct always reflects what was captured before the abort.
+///
 /// The `mcp` parameter provides MCP tool dispatch for `type = "mcp_tool"` hooks.
 /// Pass `None` when no MCP manager is available; `mcp_tool` hooks will fail with
 /// [`HookError::McpUnavailable`] (respecting `fail_closed`).
@@ -166,11 +263,25 @@ pub async fn fire_hooks<S: BuildHasher>(
     hooks: &[HookDef],
     env: &HashMap<String, String, S>,
     mcp: Option<&dyn McpDispatch>,
-) -> Result<(), HookError> {
+    stdin_json: Option<&[u8]>,
+) -> Result<HookRunResult, HookError> {
+    let mut run_result = HookRunResult::default();
     for hook in hooks {
-        let result = fire_single_hook(hook, env, mcp).await;
+        // For chaining: pass the already-replaced output as the new stdin so each
+        // subsequent hook sees the current (potentially substituted) output.
+        let effective_stdin = run_result
+            .output
+            .updated_tool_output
+            .as_deref()
+            .map(str::as_bytes)
+            .or(stdin_json);
+        let result = fire_single_hook(hook, env, mcp, effective_stdin).await;
         match result {
-            Ok(()) => {}
+            Ok(hook_output) => {
+                if hook_output.updated_tool_output.is_some() {
+                    run_result.output.updated_tool_output = hook_output.updated_tool_output;
+                }
+            }
             Err(e) if hook.fail_closed => {
                 tracing::error!(
                     error = %e,
@@ -186,16 +297,19 @@ pub async fn fire_hooks<S: BuildHasher>(
             }
         }
     }
-    Ok(())
+    Ok(run_result)
 }
 
 async fn fire_single_hook<S: BuildHasher>(
     hook: &HookDef,
     env: &HashMap<String, String, S>,
     mcp: Option<&dyn McpDispatch>,
-) -> Result<(), HookError> {
+    stdin_json: Option<&[u8]>,
+) -> Result<HookOutput, HookError> {
     match &hook.action {
-        HookAction::Command { command } => fire_shell_hook(command, hook.timeout_secs, env).await,
+        HookAction::Command { command } => {
+            fire_shell_hook(command, hook.timeout_secs, env, stdin_json).await
+        }
         HookAction::McpTool { server, tool, args } => {
             let dispatcher = mcp.ok_or_else(|| HookError::McpUnavailable {
                 server: server.clone(),
@@ -203,7 +317,10 @@ async fn fire_single_hook<S: BuildHasher>(
             })?;
             let call_fut = dispatcher.call_tool(server, tool, args.clone());
             match timeout(Duration::from_secs(hook.timeout_secs), call_fut).await {
-                Ok(Ok(_)) => Ok(()),
+                Ok(Ok(_)) => {
+                    // MCP hooks produce no stdout — output substitution is not supported.
+                    Ok(HookOutput::default())
+                }
                 Ok(Err(reason)) => Err(HookError::McpToolFailed {
                     server: server.clone(),
                     tool: tool.clone(),
@@ -222,7 +339,11 @@ async fn fire_shell_hook<S: BuildHasher>(
     command: &str,
     timeout_secs: u64,
     env: &HashMap<String, String, S>,
-) -> Result<(), HookError> {
+    stdin_json: Option<&[u8]>,
+) -> Result<HookOutput, HookError> {
+    use std::process::Stdio;
+    use tokio::io::AsyncReadExt as _;
+
     let mut cmd = Command::new("sh");
     cmd.arg("-c").arg(command);
     // SEC-H-002: clear inherited env to prevent secret leakage, then set only hook vars.
@@ -234,19 +355,55 @@ async fn fire_shell_hook<S: BuildHasher>(
     for (k, v) in env {
         cmd.env(k, v);
     }
-    // Suppress stdout/stderr to prevent hook output flooding the agent.
-    cmd.stdout(std::process::Stdio::null());
-    cmd.stderr(std::process::Stdio::null());
+    cmd.stdin(if stdin_json.is_some() {
+        Stdio::piped()
+    } else {
+        Stdio::null()
+    });
+    // Capture stdout to parse potential updatedToolOutput JSON.
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::null());
 
     let mut child = cmd.spawn().map_err(|e| HookError::Io {
         command: command.to_owned(),
         source: e,
     })?;
 
-    let result = timeout(Duration::from_secs(timeout_secs), child.wait()).await;
+    // Write stdin before awaiting child exit to avoid deadlock on full pipes.
+    // Drop the handle to close the pipe so the child gets EOF when it stops reading.
+    if let Some(bytes) = stdin_json
+        && let Some(mut stdin_handle) = child.stdin.take()
+        && let Err(e) = stdin_handle.write_all(bytes).await
+    {
+        tracing::warn!(
+            command,
+            error = %e,
+            "failed to write stdin to hook — continuing without stdin data"
+        );
+    }
 
-    match result {
-        Ok(Ok(status)) if status.success() => Ok(()),
+    // Read stdout up to HOOK_STDOUT_CAP bytes; truncated output will fail JSON parse
+    // and be treated as no substitution, logging a warning.
+    let stdout_handle = child.stdout.take();
+    let read_fut = async {
+        let mut buf = Vec::new();
+        if let Some(handle) = stdout_handle {
+            let mut limited = handle.take(HOOK_STDOUT_CAP as u64 + 1);
+            let _ = limited.read_to_end(&mut buf).await;
+        }
+        buf
+    };
+
+    let (wait_res, stdout_bytes) = tokio::join!(
+        timeout(Duration::from_secs(timeout_secs), child.wait()),
+        read_fut
+    );
+
+    match wait_res {
+        Ok(Ok(status)) if status.success() => {
+            let hook_output = parse_hook_stdout(command, &stdout_bytes);
+            Ok(hook_output)
+        }
         Ok(Ok(status)) => Err(HookError::NonZeroExit {
             command: command.to_owned(),
             code: status.code().unwrap_or(-1),
@@ -262,6 +419,57 @@ async fn fire_shell_hook<S: BuildHasher>(
                 command: command.to_owned(),
                 timeout_secs,
             })
+        }
+    }
+}
+
+/// Parse hook stdout bytes into a [`HookOutput`].
+///
+/// Returns a default (no substitution) value on any parse error to preserve
+/// backward compatibility with hooks that write non-JSON to stdout.
+fn parse_hook_stdout(command: &str, bytes: &[u8]) -> HookOutput {
+    if bytes.is_empty() {
+        return HookOutput::default();
+    }
+    if bytes.len() > HOOK_STDOUT_CAP {
+        tracing::warn!(
+            command,
+            bytes = bytes.len(),
+            cap = HOOK_STDOUT_CAP,
+            "hook stdout exceeds 1 MiB cap — treating as no substitution"
+        );
+        return HookOutput::default();
+    }
+    let Ok(text) = std::str::from_utf8(bytes) else {
+        tracing::warn!(command, "hook stdout is not valid UTF-8 — no substitution");
+        return HookOutput::default();
+    };
+    // Silent on JSON parse failure: backward compat — hooks may write human-readable output.
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(text) else {
+        return HookOutput::default();
+    };
+    let updated = json
+        .get("hookSpecificOutput")
+        .and_then(|h| h.get("updatedToolOutput"));
+
+    match updated {
+        None | Some(serde_json::Value::Null) => HookOutput::default(),
+        Some(serde_json::Value::String(s)) => HookOutput {
+            updated_tool_output: Some(s.clone()),
+        },
+        Some(other) => {
+            tracing::warn!(
+                command,
+                kind = other
+                    .is_object()
+                    .then_some("object")
+                    .or_else(|| other.is_array().then_some("array"))
+                    .or_else(|| other.is_number().then_some("number"))
+                    .or_else(|| other.is_boolean().then_some("boolean"))
+                    .unwrap_or("unknown"),
+                "hookSpecificOutput.updatedToolOutput has unexpected type — no substitution"
+            );
+            HookOutput::default()
         }
     }
 }
@@ -362,7 +570,7 @@ mod tests {
     async fn fire_hooks_success() {
         let hooks = vec![cmd_hook("true", false, 5)];
         let env = HashMap::new();
-        assert!(fire_hooks(&hooks, &env, None).await.is_ok());
+        assert!(fire_hooks(&hooks, &env, None, None).await.is_ok());
     }
 
     #[tokio::test]
@@ -372,14 +580,14 @@ mod tests {
             cmd_hook("true", false, 5),  // should still run
         ];
         let env = HashMap::new();
-        assert!(fire_hooks(&hooks, &env, None).await.is_ok());
+        assert!(fire_hooks(&hooks, &env, None, None).await.is_ok());
     }
 
     #[tokio::test]
     async fn fire_hooks_fail_closed_returns_err() {
         let hooks = vec![cmd_hook("false", true, 5)];
         let env = HashMap::new();
-        let result = fire_hooks(&hooks, &env, None).await;
+        let result = fire_hooks(&hooks, &env, None, None).await;
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(matches!(err, HookError::NonZeroExit { .. }));
@@ -389,7 +597,7 @@ mod tests {
     async fn fire_hooks_timeout() {
         let hooks = vec![cmd_hook("sleep 10", true, 1)];
         let env = HashMap::new();
-        let result = fire_hooks(&hooks, &env, None).await;
+        let result = fire_hooks(&hooks, &env, None, None).await;
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(matches!(err, HookError::Timeout { .. }));
@@ -400,13 +608,13 @@ mod tests {
         let hooks = vec![cmd_hook(r#"test "$ZEPH_TEST_VAR" = "hello""#, true, 5)];
         let mut env = HashMap::new();
         env.insert("ZEPH_TEST_VAR".to_owned(), "hello".to_owned());
-        assert!(fire_hooks(&hooks, &env, None).await.is_ok());
+        assert!(fire_hooks(&hooks, &env, None, None).await.is_ok());
     }
 
     #[tokio::test]
     async fn fire_hooks_empty_list_ok() {
         let env = HashMap::new();
-        assert!(fire_hooks(&[], &env, None).await.is_ok());
+        assert!(fire_hooks(&[], &env, None, None).await.is_ok());
     }
 
     #[tokio::test]
@@ -422,7 +630,7 @@ mod tests {
         }];
         let env = HashMap::new();
         // fail_open: should succeed even though MCP is unavailable
-        assert!(fire_hooks(&hooks, &env, None).await.is_ok());
+        assert!(fire_hooks(&hooks, &env, None, None).await.is_ok());
     }
 
     #[tokio::test]
@@ -437,7 +645,7 @@ mod tests {
             fail_closed: true,
         }];
         let env = HashMap::new();
-        let result = fire_hooks(&hooks, &env, None).await;
+        let result = fire_hooks(&hooks, &env, None, None).await;
         assert!(matches!(result, Err(HookError::McpUnavailable { .. })));
     }
 
@@ -475,7 +683,7 @@ mod tests {
             fail_closed: true,
         }];
         let env = HashMap::new();
-        let result = fire_hooks(&hooks, &env, Some(&dispatch)).await;
+        let result = fire_hooks(&hooks, &env, Some(&dispatch), None).await;
         assert!(
             result.is_ok(),
             "fire_hooks should succeed with mcp dispatch"
@@ -485,6 +693,78 @@ mod tests {
             1,
             "MCP dispatch should have been called exactly once"
         );
+    }
+
+    // ── stdout replacement tests ──────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn fire_hooks_stdout_replacement_json() {
+        let cmd = r#"printf '{"hookSpecificOutput":{"updatedToolOutput":"replaced"}}'"#;
+        let hooks = vec![cmd_hook(cmd, true, 5)];
+        let env = HashMap::new();
+        let result = fire_hooks(&hooks, &env, None, None).await.unwrap();
+        assert_eq!(
+            result.output.updated_tool_output.as_deref(),
+            Some("replaced")
+        );
+    }
+
+    #[tokio::test]
+    async fn fire_hooks_stdout_empty_no_replacement() {
+        let hooks = vec![cmd_hook("true", true, 5)];
+        let env = HashMap::new();
+        let result = fire_hooks(&hooks, &env, None, None).await.unwrap();
+        assert!(result.output.updated_tool_output.is_none());
+    }
+
+    #[tokio::test]
+    async fn fire_hooks_stdout_non_json_no_replacement() {
+        let hooks = vec![cmd_hook("echo hello", true, 5)];
+        let env = HashMap::new();
+        let result = fire_hooks(&hooks, &env, None, None).await.unwrap();
+        assert!(result.output.updated_tool_output.is_none());
+    }
+
+    #[tokio::test]
+    async fn fire_hooks_stdout_null_updatedtooloutput_no_replacement() {
+        let cmd = r#"printf '{"hookSpecificOutput":{"updatedToolOutput":null}}'"#;
+        let hooks = vec![cmd_hook(cmd, true, 5)];
+        let env = HashMap::new();
+        let result = fire_hooks(&hooks, &env, None, None).await.unwrap();
+        assert!(result.output.updated_tool_output.is_none());
+    }
+
+    #[tokio::test]
+    async fn fire_hooks_stdin_passed_to_hook() {
+        // Hook reads stdin and checks that "duration_ms" key is present in the JSON.
+        let cmd = r#"python3 -c "import sys,json; d=json.load(sys.stdin); exit(0 if 'duration_ms' in d else 1)""#;
+        let hooks = vec![cmd_hook(cmd, true, 10)];
+        let env = HashMap::new();
+        let stdin = br#"{"tool_name":"Shell","tool_args":{},"duration_ms":42}"#;
+        let result = fire_hooks(&hooks, &env, None, Some(stdin)).await;
+        assert!(
+            result.is_ok(),
+            "hook should succeed when stdin has duration_ms"
+        );
+    }
+
+    #[tokio::test]
+    async fn fire_hooks_chaining_last_replacement_wins() {
+        // First hook produces replacement "first", second produces "second" — second wins.
+        let h1 = cmd_hook(
+            r#"printf '{"hookSpecificOutput":{"updatedToolOutput":"first"}}'"#,
+            false,
+            5,
+        );
+        let h2 = cmd_hook(
+            r#"printf '{"hookSpecificOutput":{"updatedToolOutput":"second"}}'"#,
+            false,
+            5,
+        );
+        let hooks = vec![h1, h2];
+        let env = HashMap::new();
+        let result = fire_hooks(&hooks, &env, None, None).await.unwrap();
+        assert_eq!(result.output.updated_tool_output.as_deref(), Some("second"));
     }
 
     // ── YAML parsing ──────────────────────────────────────────────────────────

--- a/crates/zeph-subagent/src/lib.rs
+++ b/crates/zeph-subagent/src/lib.rs
@@ -60,8 +60,8 @@ pub use error::SubAgentError;
 pub use filter::{FilteredToolExecutor, PlanModeExecutor, filter_skills};
 pub use grants::{Grant, GrantKind, PermissionGrants, SecretRequest};
 pub use hooks::{
-    HookAction, HookDef, HookError, HookMatcher, McpDispatch, SubagentHooks, fire_hooks,
-    matching_hooks,
+    HookAction, HookDef, HookError, HookMatcher, HookOutput, HookRunResult, McpDispatch,
+    PostToolUseHookInput, SubagentHooks, fire_hooks, matching_hooks,
 };
 pub use manager::{SpawnContext, SubAgentHandle, SubAgentManager, SubAgentStatus};
 pub use memory::{ensure_memory_dir, load_memory_content};

--- a/crates/zeph-subagent/src/manager.rs
+++ b/crates/zeph-subagent/src/manager.rs
@@ -887,7 +887,7 @@ impl SubAgentManager {
             let start_hooks = config.hooks.start.clone();
             let start_env = make_hook_env(task_id, def_name, "");
             tokio::spawn(async move {
-                if let Err(e) = fire_hooks(&start_hooks, &start_env, None).await {
+                if let Err(e) = fire_hooks(&start_hooks, &start_env, None, None).await {
                     tracing::warn!(error = %e, "SubagentStart hook failed");
                 }
             });
@@ -968,7 +968,7 @@ impl SubAgentManager {
             let stop_hooks = self.stop_hooks.clone();
             let stop_env = make_hook_env(task_id, &handle.def.name, "");
             tokio::spawn(async move {
-                if let Err(e) = fire_hooks(&stop_hooks, &stop_env, None).await {
+                if let Err(e) = fire_hooks(&stop_hooks, &stop_env, None, None).await {
                     tracing::warn!(error = %e, "SubagentStop hook failed");
                 }
             });
@@ -1111,7 +1111,7 @@ impl SubAgentManager {
             let stop_hooks = self.stop_hooks.clone();
             let stop_env = make_hook_env(task_id, &handle.def.name, "");
             tokio::spawn(async move {
-                if let Err(e) = fire_hooks(&stop_hooks, &stop_env, None).await {
+                if let Err(e) = fire_hooks(&stop_hooks, &stop_env, None, None).await {
                     tracing::warn!(error = %e, "SubagentStop hook failed");
                 }
             });
@@ -1344,7 +1344,7 @@ impl SubAgentManager {
             let def_name = meta.def_name.clone();
             let start_env = make_hook_env(&new_task_id, &def_name, "");
             tokio::spawn(async move {
-                if let Err(e) = fire_hooks(&start_hooks, &start_env, None).await {
+                if let Err(e) = fire_hooks(&start_hooks, &start_env, None, None).await {
                     tracing::warn!(error = %e, "SubagentStart hook failed");
                 }
             });


### PR DESCRIPTION
## Summary

- PostToolUse hooks can now replace tool output by returning `hookSpecificOutput.updatedToolOutput` in stdout JSON; the replacement is injected into the LLM context before the tool result is processed
- Multiple chained hooks are supported: each hook receives the prior replacement as stdin, last non-null replacement wins
- Hook input JSON for PostToolUse and PostToolUseFailure events now includes `duration_ms` (wall-clock ms of tool execution, excluding permission prompts and PreToolUse hook time)
- Stdout captured up to 1 MiB; larger outputs trigger a warning and fall back to original result
- MCP hooks return empty `HookOutput` explicitly (no stdout capture)

## Changed files

- `crates/zeph-subagent/src/hooks.rs` — new types (`HookOutput`, `HookRunResult`, `PostToolUseHookInput`), stdout capture, JSON parsing, chaining logic
- `crates/zeph-core/src/agent/tool_execution/tier_loop.rs` — compute `duration_ms`, pass stdin to `fire_hooks`, apply output substitution
- `crates/zeph-subagent/src/agent_loop.rs` — subagent PostToolUse path updated with same duration_ms + substitution
- `crates/zeph-subagent/src/lib.rs` — re-exports for new public types
- `crates/zeph-subagent/src/manager.rs`, `crates/zeph-core/src/agent/mod.rs` — updated `fire_hooks` call sites

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 9436 passed, 21 skipped
- [x] Unit tests cover: happy path replacement, null/absent updatedToolOutput, empty stdout, invalid JSON stdout, duration_ms in input, hook chaining, MCP hooks

## Security

- In main agent path: hook replacement flows through `process_one_tool_result` → `sanitize_tool_output` (ContentSanitizer, Vigil gate, IPI analysis) — no change
- Pre-existing gap in subagent path filed as #3997 (P2, separate PR)

Closes #3798