### PR TITLE
fix(agent-context): replace sync span guard with .instrument() and remove unused _providers params

### DIFF
--- a/crates/zeph-agent-context/src/service.rs
+++ b/crates/zeph-agent-context/src/service.rs
@@ -210,7 +210,7 @@ impl ContextService {
         self.remove_recall_messages(window);
 
         let msg = if view.tiered_retrieval_config.enabled {
-            let _span = tracing::info_span!("agent_context.tiered_retrieval.recall").entered();
+            use tracing::Instrument as _;
             let Some(memory) = view.memory.as_deref() else {
                 return Ok(());
             };
@@ -224,7 +224,8 @@ impl ContextService {
                     view.tiered_retrieval_validator.as_ref(),
                     &view.tiered_retrieval_config,
                     Some(token_budget),
-                ),
+                )
+                .instrument(tracing::info_span!("agent_context.tiered_retrieval.recall")),
             )
             .await
             .map_err(|_| {
@@ -428,7 +429,6 @@ impl ContextService {
         query: &str,
         window: &mut MessageWindowView<'_>,
         view: &mut ContextAssemblyView<'_>,
-        _providers: &ProviderHandles,
     ) -> Result<ContextDelta, ContextError> {
         if view.context_manager.budget.is_none() {
             return Ok(ContextDelta::default());
@@ -880,7 +880,6 @@ impl ContextService {
     pub async fn maybe_compact(
         &self,
         summ: &mut ContextSummarizationView<'_>,
-        _providers: &ProviderHandles,
         status: &(impl StatusSink + ?Sized),
     ) -> Result<(), ContextError> {
         use zeph_context::manager::{CompactionState, CompactionTier};
@@ -1220,7 +1219,6 @@ impl ContextService {
     pub async fn maybe_proactive_compress(
         &self,
         summ: &mut ContextSummarizationView<'_>,
-        _providers: &ProviderHandles,
         status: &(impl StatusSink + ?Sized),
     ) {
         let Some((_threshold, max_summary_tokens)) = summ

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -354,7 +354,6 @@ impl<C: Channel> Agent<C> {
         // the mutable borrows in window/view — snapshot before establishing the long-lived
         // mutable borrows so the borrow checker accepts disjoint field access.
         let cached_prompt_tokens_snapshot = self.runtime.providers.cached_prompt_tokens;
-        let providers = self.providers();
 
         let correction_config = self.services.learning_engine.config.as_ref().map(|c| {
             zeph_context::input::CorrectionConfig {
@@ -453,9 +452,7 @@ impl<C: Channel> Agent<C> {
                 .clone(),
         };
         let _ = self.channel.send_status("recalling context...").await;
-        let result = svc
-            .prepare_context(query, &mut window, &mut view, &providers)
-            .await;
+        let result = svc.prepare_context(query, &mut window, &mut view).await;
         let _ = self.channel.send_status("").await;
 
         let delta =

--- a/crates/zeph-core/src/agent/context/summarization/scheduling.rs
+++ b/crates/zeph-core/src/agent/context/summarization/scheduling.rs
@@ -22,7 +22,6 @@ impl<C: Channel> Agent<C> {
         &mut self,
     ) -> Result<(), crate::agent::error::AgentError> {
         let svc = zeph_agent_context::ContextService::new();
-        let providers = self.providers();
 
         // Collect status messages from the service so they can be forwarded to the channel.
         // The service uses StatusSink (async trait) — CollectStatusSink gathers them synchronously.
@@ -33,7 +32,7 @@ impl<C: Channel> Agent<C> {
         let msg_count_before = self.msg.messages.len();
 
         let mut summ = self.summarization_view();
-        svc.maybe_compact(&mut summ, &providers, &status)
+        svc.maybe_compact(&mut summ, &status)
             .await
             .map_err(|e| crate::agent::error::AgentError::ContextError(format!("{e:#}")))?;
 
@@ -90,13 +89,11 @@ impl<C: Channel> Agent<C> {
     ) -> Result<(), crate::agent::error::AgentError> {
         let guidelines = self.load_compression_guidelines_for_compact().await;
         let svc = zeph_agent_context::ContextService::new();
-        let providers = self.providers();
         let status = TxStatusSink(self.services.session.status_tx.clone());
         let mut summ = self
             .summarization_view()
             .with_compression_guidelines(guidelines);
-        svc.maybe_proactive_compress(&mut summ, &providers, &status)
-            .await;
+        svc.maybe_proactive_compress(&mut summ, &status).await;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- **#3974**: Replace synchronous `EnteredSpan` guard held across `.await` in `inject_semantic_recall` with `.instrument()` on the `recall_tiered` future. `EnteredSpan` is `!Send` — on a multi-threaded tokio runtime the task can migrate threads at the await point, causing undefined behavior in the tracing subscriber. The span also closed prematurely before the async work completed.
- **#3977**: Remove the unused `_providers: &ProviderHandles` parameter from `prepare_context`, `maybe_compact`, and `maybe_proactive_compress`. Update all call sites in `assembly.rs` and `scheduling.rs`.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — 0 warnings
- [x] `cargo nextest run --workspace --lib --bins` — 9451 passed, 0 failed

Closes #3974
Closes #3977