### PR TITLE
refactor(context): enforce invariants and remove dead code (#3985, #3990, #3986)

### DIFF
--- a/crates/zeph-agent-context/src/service.rs
+++ b/crates/zeph-agent-context/src/service.rs
@@ -885,18 +885,19 @@ impl ContextService {
         use zeph_context::manager::{CompactionState, CompactionTier};
 
         // Increment turn counter unconditionally (tracks pressure regardless of guards).
-        if let Some(ref mut count) = summ.context_manager.turns_since_last_hard_compaction {
+        if let Some(count) = summ.context_manager.turns_since_last_hard_compaction_mut() {
             *count += 1;
         }
 
         // Guard: exhaustion — warn once, then no-op permanently.
-        if let CompactionState::Exhausted { ref mut warned } = summ.context_manager.compaction
-            && !*warned
+        if let CompactionState::Exhausted { warned } = summ.context_manager.compaction_state()
+            && !warned
         {
-            *warned = true;
+            summ.context_manager
+                .set_compaction_state(CompactionState::Exhausted { warned: true });
             tracing::warn!("compaction exhausted: context budget too tight for this session");
         }
-        if summ.context_manager.compaction.is_exhausted() {
+        if summ.context_manager.compaction_state().is_exhausted() {
             return Ok(());
         }
 
@@ -921,21 +922,28 @@ impl ContextService {
         }
 
         // Guard: already compacted this turn.
-        if summ.context_manager.compaction.is_compacted_this_turn() {
+        if summ
+            .context_manager
+            .compaction_state()
+            .is_compacted_this_turn()
+        {
             return Ok(());
         }
 
         // Decrement cooldown counter; record whether we are in cooldown.
-        let in_cooldown = summ.context_manager.compaction.cooldown_remaining() > 0;
+        let in_cooldown = summ.context_manager.compaction_state().cooldown_remaining() > 0;
         if in_cooldown
-            && let CompactionState::Cooling {
-                ref mut turns_remaining,
-            } = summ.context_manager.compaction
+            && let CompactionState::Cooling { turns_remaining } =
+                summ.context_manager.compaction_state()
         {
-            *turns_remaining -= 1;
-            if *turns_remaining == 0 {
-                summ.context_manager.compaction = CompactionState::Ready;
-            }
+            let next = turns_remaining - 1;
+            summ.context_manager.set_compaction_state(if next == 0 {
+                CompactionState::Ready
+            } else {
+                CompactionState::Cooling {
+                    turns_remaining: next,
+                }
+            });
         }
 
         match summ
@@ -1029,16 +1037,17 @@ impl ContextService {
         // Track hard compaction event for pressure metrics.
         let turns_since_last = summ
             .context_manager
-            .turns_since_last_hard_compaction
+            .turns_since_last_hard_compaction()
             .map(|t| u32::try_from(t).unwrap_or(u32::MAX));
-        summ.context_manager.turns_since_last_hard_compaction = Some(0);
+        summ.context_manager
+            .set_turns_since_last_hard_compaction(Some(0));
         if let Some(metrics) = summ.metrics {
             metrics.record_hard_compaction(turns_since_last);
         }
 
         if in_cooldown {
             tracing::debug!(
-                turns_remaining = summ.context_manager.compaction.cooldown_remaining(),
+                turns_remaining = summ.context_manager.compaction_state().cooldown_remaining(),
                 "hard compaction skipped: cooldown active"
             );
             return Ok(());
@@ -1063,9 +1072,10 @@ impl ContextService {
         let freed = crate::summarization::pruning::prune_tool_outputs(summ, min_to_free);
         if freed >= min_to_free {
             tracing::info!(freed, "hard compaction: pruning sufficient");
-            summ.context_manager.compaction = CompactionState::CompactedThisTurn {
-                cooldown: summ.context_manager.compaction_cooldown_turns,
-            };
+            summ.context_manager
+                .set_compaction_state(CompactionState::CompactedThisTurn {
+                    cooldown: summ.context_manager.compaction_cooldown_turns(),
+                });
             if let Err(e) = crate::summarization::deferred::flush_deferred_summaries(summ).await {
                 tracing::warn!(%e, "flush_deferred_summaries failed after hard compaction");
             }
@@ -1081,7 +1091,8 @@ impl ContextService {
                 compactable,
                 "hard compaction: too few messages, marking exhausted"
             );
-            summ.context_manager.compaction = CompactionState::Exhausted { warned: false };
+            summ.context_manager
+                .set_compaction_state(CompactionState::Exhausted { warned: false });
             status.send_status("").await;
             return Ok(());
         }
@@ -1098,7 +1109,8 @@ impl ContextService {
 
         if !outcome.is_compacted() || freed_tokens == 0 {
             tracing::warn!("hard compaction: no net reduction, marking exhausted");
-            summ.context_manager.compaction = CompactionState::Exhausted { warned: false };
+            summ.context_manager
+                .set_compaction_state(CompactionState::Exhausted { warned: false });
             status.send_status("").await;
             return Ok(());
         }
@@ -1112,14 +1124,16 @@ impl ContextService {
                 freed_tokens,
                 "hard compaction: still above hard threshold after compaction, marking exhausted"
             );
-            summ.context_manager.compaction = CompactionState::Exhausted { warned: false };
+            summ.context_manager
+                .set_compaction_state(CompactionState::Exhausted { warned: false });
             status.send_status("").await;
             return Ok(());
         }
 
-        summ.context_manager.compaction = CompactionState::CompactedThisTurn {
-            cooldown: summ.context_manager.compaction_cooldown_turns,
-        };
+        summ.context_manager
+            .set_compaction_state(CompactionState::CompactedThisTurn {
+                cooldown: summ.context_manager.compaction_cooldown_turns(),
+            });
 
         if tokens_before > *summ.cached_prompt_tokens {
             tracing::info!(
@@ -1260,8 +1274,9 @@ impl ContextService {
             .await
         {
             Ok(outcome) if outcome.is_compacted() => {
-                summ.context_manager.compaction =
-                    zeph_context::manager::CompactionState::CompactedThisTurn { cooldown: 0 };
+                summ.context_manager.set_compaction_state(
+                    zeph_context::manager::CompactionState::CompactedThisTurn { cooldown: 0 },
+                );
                 tracing::info!("proactive compression complete");
             }
             Ok(_) => {}

--- a/crates/zeph-agent-context/src/summarization/scheduling.rs
+++ b/crates/zeph-agent-context/src/summarization/scheduling.rs
@@ -35,7 +35,11 @@ use super::pruning::prune_tool_outputs;
     clippy::cast_sign_loss
 )]
 pub(crate) fn maybe_soft_compact_mid_iteration(summ: &mut ContextSummarizationView<'_>) {
-    if summ.context_manager.compaction.is_compacted_this_turn() {
+    if summ
+        .context_manager
+        .compaction_state()
+        .is_compacted_this_turn()
+    {
         return;
     }
     if !matches!(

--- a/crates/zeph-context/src/assembler.rs
+++ b/crates/zeph-context/src/assembler.rs
@@ -739,7 +739,7 @@ pub(crate) async fn fetch_corrections(
     let corrections = mem
         .retrieve_corrections(query, limit, min_score)
         .await
-        .unwrap_or_default();
+        .map_err(ContextError::Memory)?;
     if corrections.is_empty() {
         return Ok(None);
     }
@@ -1802,15 +1802,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fetch_corrections_swallows_error_returns_none() {
-        // fetch_corrections uses unwrap_or_default() so retrieve_corrections errors
-        // are swallowed: error → empty vec → None. This documents the production behavior.
+    async fn fetch_corrections_propagates_error() {
+        // fetch_corrections uses map_err(ContextError::Memory)? so retrieve_corrections
+        // errors are propagated instead of silently discarded.
         let mock = MockMemoryBackend::with_fail_on("retrieve_corrections");
         let view = mock_view(mock);
-        let result = fetch_corrections(&view, "query", 10, 0.5, |s| s.into())
-            .await
-            .unwrap();
-        assert!(result.is_none());
+        let result = fetch_corrections(&view, "query", 10, 0.5, |s| s.into()).await;
+        assert!(result.is_err(), "expected Err, got {result:?}");
     }
 
     // ── fetch_semantic_recall ─────────────────────────────────────────────────

--- a/crates/zeph-context/src/manager.rs
+++ b/crates/zeph-context/src/manager.rs
@@ -159,13 +159,13 @@ pub struct ContextManager {
     pub store_routing_provider: Option<Arc<zeph_llm::any::AnyProvider>>,
     /// Compaction lifecycle state. Replaces four independent boolean/u8 fields to make
     /// invalid states unrepresentable. See [`CompactionState`] for the full transition map.
-    pub compaction: CompactionState,
+    pub(crate) compaction: CompactionState,
     /// Number of cooling turns to enforce after a successful hard compaction.
-    pub compaction_cooldown_turns: u8,
+    pub(crate) compaction_cooldown_turns: u8,
     /// Counts user-message turns since the last hard compaction event.
     /// `None` = no hard compaction has occurred yet in this session.
     /// `Some(n)` = n turns have elapsed since the last hard compaction.
-    pub turns_since_last_hard_compaction: Option<u64>,
+    pub(crate) turns_since_last_hard_compaction: Option<u64>,
 }
 
 impl ContextManager {
@@ -275,6 +275,49 @@ impl ContextManager {
     /// `max_summary_tokens` element is unused on the Focus path — the auto-consolidation
     /// function uses `FocusConfig.max_knowledge_tokens / 2` instead.
     ///
+    /// Returns the current compaction lifecycle state.
+    #[must_use]
+    pub fn compaction_state(&self) -> CompactionState {
+        self.compaction
+    }
+
+    /// Returns a mutable reference to the compaction lifecycle state.
+    pub fn compaction_state_mut(&mut self) -> &mut CompactionState {
+        &mut self.compaction
+    }
+
+    /// Replaces the compaction lifecycle state.
+    pub fn set_compaction_state(&mut self, state: CompactionState) {
+        self.compaction = state;
+    }
+
+    /// Returns the number of cooling turns enforced after a hard compaction.
+    #[must_use]
+    pub fn compaction_cooldown_turns(&self) -> u8 {
+        self.compaction_cooldown_turns
+    }
+
+    /// Sets the number of cooling turns enforced after a hard compaction.
+    pub fn set_compaction_cooldown_turns(&mut self, turns: u8) {
+        self.compaction_cooldown_turns = turns;
+    }
+
+    /// Returns the number of user-message turns since the last hard compaction, if any.
+    #[must_use]
+    pub fn turns_since_last_hard_compaction(&self) -> Option<u64> {
+        self.turns_since_last_hard_compaction
+    }
+
+    /// Returns a mutable reference to the turns-since-last-hard-compaction counter.
+    pub fn turns_since_last_hard_compaction_mut(&mut self) -> &mut Option<u64> {
+        &mut self.turns_since_last_hard_compaction
+    }
+
+    /// Sets the turns-since-last-hard-compaction counter.
+    pub fn set_turns_since_last_hard_compaction(&mut self, value: Option<u64>) {
+        self.turns_since_last_hard_compaction = value;
+    }
+
     /// Will return `None` if compaction already happened this turn (CRIT-03 fix).
     #[must_use]
     pub fn should_proactively_compress(&self, current_tokens: u64) -> Option<(usize, usize)> {

--- a/crates/zeph-context/src/turn_context.rs
+++ b/crates/zeph-context/src/turn_context.rs
@@ -63,13 +63,6 @@ pub struct TurnContext {
     /// Snapshotting (rather than reading from a shared config) ensures the turn's
     /// timeout policy is stable even if the live config is reloaded mid-turn.
     pub timeouts: TimeoutConfig,
-    /// Optional channel-scoped tool allowlist for this turn.
-    ///
-    /// `None` means no channel-level restriction applies (other layers may still gate tool
-    /// access). Always `None` until Phase 2 wires channel config into the agent runtime.
-    ///
-    /// TODO(#3498): populate from active channel config during Phase 2 crate extraction.
-    pub tool_allowlist: Option<Vec<String>>,
 }
 
 impl TurnContext {
@@ -91,7 +84,6 @@ impl TurnContext {
             id,
             cancel_token,
             timeouts,
-            tool_allowlist: None,
         }
     }
 }
@@ -132,7 +124,6 @@ mod tests {
         let token = CancellationToken::new();
         let ctx = TurnContext::new(TurnId(1), token.clone(), TimeoutConfig::default());
         assert_eq!(ctx.id, TurnId(1));
-        assert!(ctx.tool_allowlist.is_none());
     }
 
     #[test]

--- a/crates/zeph-core/src/agent/compression_feedback.rs
+++ b/crates/zeph-core/src/agent/compression_feedback.rs
@@ -35,7 +35,7 @@ impl<C: Channel> Agent<C> {
             return;
         }
 
-        let Some(turns) = self.context_manager.turns_since_last_hard_compaction else {
+        let Some(turns) = self.context_manager.turns_since_last_hard_compaction() else {
             return;
         };
         if turns > config.detection_window_turns {

--- a/crates/zeph-core/src/agent/context/summarization/scheduling.rs
+++ b/crates/zeph-core/src/agent/context/summarization/scheduling.rs
@@ -28,7 +28,7 @@ impl<C: Channel> Agent<C> {
         let status = CollectStatusSink::default();
 
         // Capture pre-call state to detect what the service did.
-        let turns_before = self.context_manager.turns_since_last_hard_compaction;
+        let turns_before = self.context_manager.turns_since_last_hard_compaction();
         let msg_count_before = self.msg.messages.len();
 
         let mut summ = self.summarization_view();
@@ -50,7 +50,7 @@ impl<C: Channel> Agent<C> {
         // Update metrics that the service cannot track (no MetricsCallback in ContextSummarizationView).
         let msg_count_after = self.msg.messages.len();
         let compacted = msg_count_after < msg_count_before;
-        let hard_fired = self.context_manager.turns_since_last_hard_compaction == Some(0)
+        let hard_fired = self.context_manager.turns_since_last_hard_compaction() == Some(0)
             && turns_before != Some(0);
 
         if compacted {

--- a/crates/zeph-core/src/agent/context/tests/compaction_guards_and_consolidation_tests.rs
+++ b/crates/zeph-core/src/agent/context/tests/compaction_guards_and_consolidation_tests.rs
@@ -99,10 +99,12 @@ async fn cooldown_guard_decrements_and_skips_compaction() {
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
         .with_context_budget(100, 0.20, 0.75, 2, 0)
         .with_metrics(tx);
-    agent.context_manager.compaction_cooldown_turns = 2;
+    agent.context_manager.set_compaction_cooldown_turns(2);
 
     // Manually set cooling state as if compaction just fired and turn advanced.
-    agent.context_manager.compaction = CompactionState::Cooling { turns_remaining: 2 };
+    agent
+        .context_manager
+        .set_compaction_state(CompactionState::Cooling { turns_remaining: 2 });
 
     // Push enough tokens to trigger compaction threshold.
     for i in 0..10 {
@@ -116,12 +118,24 @@ async fn cooldown_guard_decrements_and_skips_compaction() {
 
     // First call: turns_remaining = 2 → skips, decrements to 1. No compaction fired.
     agent.maybe_compact().await.unwrap();
-    assert_eq!(agent.context_manager.compaction.cooldown_remaining(), 1);
+    assert_eq!(
+        agent
+            .context_manager
+            .compaction_state()
+            .cooldown_remaining(),
+        1
+    );
     assert_eq!(rx.borrow().context_compactions, 0);
 
     // Second call: turns_remaining = 1 → skips, decrements to 0 → transitions to Ready.
     agent.maybe_compact().await.unwrap();
-    assert_eq!(agent.context_manager.compaction.cooldown_remaining(), 0);
+    assert_eq!(
+        agent
+            .context_manager
+            .compaction_state()
+            .cooldown_remaining(),
+        0
+    );
     assert_eq!(rx.borrow().context_compactions, 0);
 }
 
@@ -137,10 +151,13 @@ async fn cooldown_guard_fires_after_expiry_and_resets_counter() {
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
         .with_context_budget(100, 0.20, 0.75, 2, 0)
         .with_metrics(tx);
-    agent.context_manager.compaction_cooldown_turns = 2;
+    agent.context_manager.set_compaction_cooldown_turns(2);
 
     // Ready state means cooldown has already expired.
-    assert_eq!(agent.context_manager.compaction, CompactionState::Ready);
+    assert_eq!(
+        agent.context_manager.compaction_state(),
+        CompactionState::Ready
+    );
 
     for i in 0..10 {
         agent.msg.messages.push(Message {
@@ -162,7 +179,7 @@ async fn cooldown_guard_fires_after_expiry_and_resets_counter() {
     assert_eq!(rx.borrow().context_compactions, 1);
     // After compaction the system prompt alone exceeds the tiny 100-token budget, so
     // Guard 3 marks exhaustion (still above threshold). Cooldown is not reset — correct.
-    assert!(agent.context_manager.compaction.is_exhausted());
+    assert!(agent.context_manager.compaction_state().is_exhausted());
 }
 
 // Exhaustion guard: when compaction_exhausted is set, maybe_compact returns early.
@@ -178,7 +195,9 @@ async fn exhaustion_guard_skips_compaction_when_exhausted() {
         .with_context_budget(100, 0.20, 0.75, 2, 0)
         .with_metrics(tx);
 
-    agent.context_manager.compaction = CompactionState::Exhausted { warned: false };
+    agent
+        .context_manager
+        .set_compaction_state(CompactionState::Exhausted { warned: false });
 
     for i in 0..10 {
         agent.msg.messages.push(Message {
@@ -206,7 +225,9 @@ async fn exhaustion_guard_warned_flag_set_once() {
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
         .with_context_budget(100, 0.20, 0.75, 2, 0);
 
-    agent.context_manager.compaction = CompactionState::Exhausted { warned: false };
+    agent
+        .context_manager
+        .set_compaction_state(CompactionState::Exhausted { warned: false });
 
     for i in 0..5 {
         agent.msg.messages.push(Message {
@@ -219,19 +240,19 @@ async fn exhaustion_guard_warned_flag_set_once() {
 
     // First call: warning not yet sent → warned flipped to true.
     assert!(matches!(
-        agent.context_manager.compaction,
+        agent.context_manager.compaction_state(),
         CompactionState::Exhausted { warned: false }
     ));
     agent.maybe_compact().await.unwrap();
     assert!(matches!(
-        agent.context_manager.compaction,
+        agent.context_manager.compaction_state(),
         CompactionState::Exhausted { warned: true }
     ));
 
     // Second call: warned already set, no state change.
     agent.maybe_compact().await.unwrap();
     assert!(matches!(
-        agent.context_manager.compaction,
+        agent.context_manager.compaction_state(),
         CompactionState::Exhausted { warned: true }
     ));
 }
@@ -249,11 +270,13 @@ async fn exhaustion_guard_takes_precedence_over_cooldown() {
 
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
         .with_context_budget(100, 0.20, 0.75, 2, 0);
-    agent.context_manager.compaction_cooldown_turns = 2;
+    agent.context_manager.set_compaction_cooldown_turns(2);
 
     // Exhausted state (the Cooling state would normally guard against exhaustion, but
     // we test the ordering guarantee that exhaustion check happens before cooldown decrement).
-    agent.context_manager.compaction = CompactionState::Exhausted { warned: false };
+    agent
+        .context_manager
+        .set_compaction_state(CompactionState::Exhausted { warned: false });
 
     for i in 0..10 {
         agent.msg.messages.push(Message {
@@ -267,7 +290,7 @@ async fn exhaustion_guard_takes_precedence_over_cooldown() {
     agent.maybe_compact().await.unwrap();
 
     // State must remain Exhausted — exhaustion guard returned before cooldown decrement.
-    assert!(agent.context_manager.compaction.is_exhausted());
+    assert!(agent.context_manager.compaction_state().is_exhausted());
     // No "compacting context..." status emitted.
     assert!(
         !statuses
@@ -310,15 +333,15 @@ async fn counterproductive_guard_sets_exhausted_when_too_few_messages() {
     agent.maybe_compact().await.unwrap();
 
     // Counterproductive guard: compactable ≤ 1 → exhausted set.
-    assert!(agent.context_manager.compaction.is_exhausted());
+    assert!(agent.context_manager.compaction_state().is_exhausted());
 }
 
 // Default value for compaction_cooldown_turns is 2.
 #[test]
 fn context_manager_defaults_have_compaction_guard_fields() {
     let cm = crate::agent::context_manager::ContextManager::new();
-    assert_eq!(cm.compaction_cooldown_turns, 2);
-    assert_eq!(cm.compaction, CompactionState::Ready);
+    assert_eq!(cm.compaction_cooldown_turns(), 2);
+    assert_eq!(cm.compaction_state(), CompactionState::Ready);
 }
 
 // with_compaction_cooldown builder sets the cooldown turns field.
@@ -330,9 +353,9 @@ fn builder_with_compaction_cooldown_sets_field() {
     let executor = MockToolExecutor::no_tools();
 
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
-    agent.context_manager.compaction_cooldown_turns = 5;
+    agent.context_manager.set_compaction_cooldown_turns(5);
 
-    assert_eq!(agent.context_manager.compaction_cooldown_turns, 5);
+    assert_eq!(agent.context_manager.compaction_cooldown_turns(), 5);
 }
 
 #[test]
@@ -373,7 +396,7 @@ async fn compaction_turns_after_hard_tracks_segments() {
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor)
         .with_context_budget(1000, 0.20, 0.75, 4, 0)
         .with_metrics(tx);
-    agent.context_manager.compaction_cooldown_turns = 0;
+    agent.context_manager.set_compaction_cooldown_turns(0);
 
     // Simulate first hard compaction by driving cached tokens above threshold.
     agent.runtime.providers.cached_prompt_tokens = 900;
@@ -385,7 +408,9 @@ async fn compaction_turns_after_hard_tracks_segments() {
     // Reset per-turn state (done by advance_turn at the start of each turn).
     agent.runtime.providers.cached_prompt_tokens = 0;
     for _ in 0..3 {
-        agent.context_manager.compaction = agent.context_manager.compaction.advance_turn();
+        agent
+            .context_manager
+            .set_compaction_state(agent.context_manager.compaction_state().advance_turn());
         agent.maybe_compact().await.unwrap();
     }
     // turns_since_last_hard_compaction is now Some(3).
@@ -393,12 +418,14 @@ async fn compaction_turns_after_hard_tracks_segments() {
     // Directly trigger the Hard tier accounting without a real LLM call
     // by simulating what maybe_compact does in the Hard branch.
     // This tests that the Vec accumulates the segment correctly.
-    if let Some(turns) = agent.context_manager.turns_since_last_hard_compaction {
+    if let Some(turns) = agent.context_manager.turns_since_last_hard_compaction() {
         agent.update_metrics(|m| {
             m.compaction_turns_after_hard.push(turns);
             m.compaction_hard_count += 1;
         });
-        agent.context_manager.turns_since_last_hard_compaction = Some(0);
+        agent
+            .context_manager
+            .set_turns_since_last_hard_compaction(Some(0));
     }
 
     assert_eq!(rx.borrow().compaction_hard_count, 2);
@@ -416,15 +443,19 @@ async fn compaction_turn_counter_increments_before_exhaustion_guard() {
         .with_context_budget(1000, 0.20, 0.75, 4, 0);
 
     // Manually set tracking active and exhaust compaction.
-    agent.context_manager.turns_since_last_hard_compaction = Some(0);
-    agent.context_manager.compaction = CompactionState::Exhausted { warned: false };
+    agent
+        .context_manager
+        .set_turns_since_last_hard_compaction(Some(0));
+    agent
+        .context_manager
+        .set_compaction_state(CompactionState::Exhausted { warned: false });
 
     // Call maybe_compact — early return via exhaustion guard.
     agent.maybe_compact().await.unwrap();
 
     // Turn counter must still have been incremented (S1/S2 fix).
     assert_eq!(
-        agent.context_manager.turns_since_last_hard_compaction,
+        agent.context_manager.turns_since_last_hard_compaction(),
         Some(1)
     );
 }
@@ -447,7 +478,9 @@ fn mid_iteration_skips_when_compacted_this_turn() {
     // Simulate token pressure above soft threshold
     agent.runtime.providers.cached_prompt_tokens = 75_000;
     // Mark hard compaction already ran this turn
-    agent.context_manager.compaction = CompactionState::CompactedThisTurn { cooldown: 2 };
+    agent
+        .context_manager
+        .set_compaction_state(CompactionState::CompactedThisTurn { cooldown: 2 });
 
     agent.maybe_soft_compact_mid_iteration();
 
@@ -533,10 +566,18 @@ fn mid_iteration_does_not_set_compacted_this_turn() {
     make_tool_pair_with_output(&mut agent, "a");
     agent.runtime.providers.cached_prompt_tokens = 75_000;
 
-    assert!(!agent.context_manager.compaction.is_compacted_this_turn());
+    assert!(
+        !agent
+            .context_manager
+            .compaction_state()
+            .is_compacted_this_turn()
+    );
     agent.maybe_soft_compact_mid_iteration();
     assert!(
-        !agent.context_manager.compaction.is_compacted_this_turn(),
+        !agent
+            .context_manager
+            .compaction_state()
+            .is_compacted_this_turn(),
         "maybe_soft_compact_mid_iteration must not set compacted_this_turn"
     );
 }
@@ -571,7 +612,10 @@ fn mid_iteration_fires_at_hard_tier() {
     );
     // compaction state must remain unchanged (no LLM call, no Hard compaction)
     assert!(
-        !agent.context_manager.compaction.is_compacted_this_turn(),
+        !agent
+            .context_manager
+            .compaction_state()
+            .is_compacted_this_turn(),
         "mid-iteration must not set compacted_this_turn even at Hard tier"
     );
 }
@@ -765,7 +809,7 @@ async fn probe_rejected_does_not_trigger_exhausted() {
     // Verify the state machine invariant: not Exhausted.
     assert!(
         !matches!(
-            agent.context_manager.compaction,
+            agent.context_manager.compaction_state(),
             CompactionState::Exhausted { .. }
         ),
         "ProbeRejected must not transition to Exhausted (H1 invariant)"
@@ -855,7 +899,10 @@ async fn maybe_proactive_compress_focus_strategy_routes_to_focus_pass() {
     );
     // Focus strategy must NOT set compacted_this_turn (reactive may still fire).
     assert!(
-        !agent.context_manager.compaction.is_compacted_this_turn(),
+        !agent
+            .context_manager
+            .compaction_state()
+            .is_compacted_this_turn(),
         "Focus must not set compacted_this_turn"
     );
 }

--- a/crates/zeph-core/src/agent/context/tests/prompt_tooling_summary_tests.rs
+++ b/crates/zeph-core/src/agent/context/tests/prompt_tooling_summary_tests.rs
@@ -776,7 +776,9 @@ async fn compacted_this_turn_reset_between_turns() {
     let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
 
     // Manually set state as if proactive compression fired
-    agent.context_manager.compaction = CompactionState::CompactedThisTurn { cooldown: 0 };
+    agent
+        .context_manager
+        .set_compaction_state(CompactionState::CompactedThisTurn { cooldown: 0 });
 
     // Process a message — advance_turn() resets state at turn start
     let _ = agent.process_user_message("first".to_owned(), vec![]).await;
@@ -785,7 +787,12 @@ async fn compacted_this_turn_reset_between_turns() {
     // have been set again only if proactive compression fired. Since threshold is
     // reactive by default, state should be Ready after turn (no proactive).
     // We can't inspect mid-turn, but we can check the default config doesn't trigger.
-    assert!(!agent.context_manager.compaction.is_compacted_this_turn());
+    assert!(
+        !agent
+            .context_manager
+            .compaction_state()
+            .is_compacted_this_turn()
+    );
 }
 
 #[tokio::test]
@@ -802,7 +809,12 @@ async fn maybe_proactive_compress_does_not_fire_with_reactive_strategy() {
     // should_proactively_compress returns None for Reactive → no compression
     let result = agent.maybe_proactive_compress().await;
     assert!(result.is_ok());
-    assert!(!agent.context_manager.compaction.is_compacted_this_turn());
+    assert!(
+        !agent
+            .context_manager
+            .compaction_state()
+            .is_compacted_this_turn()
+    );
 }
 
 // BudgetAllocation.graph_facts tests
@@ -1340,10 +1352,18 @@ fn tier0_does_not_set_compacted_this_turn() {
     // Simulate token usage above 70% soft threshold
     agent.runtime.providers.cached_prompt_tokens = 75_000;
 
-    assert!(!agent.context_manager.compaction.is_compacted_this_turn());
+    assert!(
+        !agent
+            .context_manager
+            .compaction_state()
+            .is_compacted_this_turn()
+    );
     agent.maybe_apply_deferred_summaries();
     assert!(
-        !agent.context_manager.compaction.is_compacted_this_turn(),
+        !agent
+            .context_manager
+            .compaction_state()
+            .is_compacted_this_turn(),
         "tier-0 must not set compacted_this_turn"
     );
 }

--- a/crates/zeph-core/src/agent/context_manager.rs
+++ b/crates/zeph-core/src/agent/context_manager.rs
@@ -19,7 +19,7 @@ mod tests {
         assert!((cm.hard_compaction_threshold - 0.90).abs() < f32::EPSILON);
         assert_eq!(cm.compaction_preserve_tail, 6);
         assert_eq!(cm.prune_protect_tokens, 40_000);
-        assert_eq!(cm.compaction, CompactionState::Ready);
+        assert_eq!(cm.compaction_state(), CompactionState::Ready);
     }
 
     #[test]
@@ -119,7 +119,7 @@ mod tests {
             threshold_tokens: 80_000,
             max_summary_tokens: 4_000,
         };
-        cm.compaction = CompactionState::CompactedThisTurn { cooldown: 0 };
+        cm.set_compaction_state(CompactionState::CompactedThisTurn { cooldown: 0 });
         assert!(cm.should_proactively_compress(100_000).is_none());
     }
 

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -678,11 +678,12 @@ impl<C: Channel> Agent<C> {
         // Finalize compaction trajectory: push the last open segment into the Vec.
         // This segment would otherwise only be pushed when the next hard compaction fires,
         // which never happens at session end.
-        if let Some(turns) = self.context_manager.turns_since_last_hard_compaction {
+        if let Some(turns) = self.context_manager.turns_since_last_hard_compaction() {
             self.update_metrics(|m| {
                 m.compaction_turns_after_hard.push(turns);
             });
-            self.context_manager.turns_since_last_hard_compaction = None;
+            self.context_manager
+                .set_turns_since_last_hard_compaction(None);
         }
 
         if let Some(ref tx) = self.runtime.metrics.metrics_tx {
@@ -2001,7 +2002,8 @@ impl<C: Channel> Agent<C> {
         // complete_focus and maybe_sidequest_eviction set this flag when they run (C1 fix).
         // advance_turn() transitions CompactedThisTurn → Cooling/Ready; all other states
         // pass through unchanged. See CompactionState::advance_turn for ordering guarantees.
-        self.context_manager.compaction = self.context_manager.compaction.advance_turn();
+        self.context_manager
+            .set_compaction_state(self.context_manager.compaction_state().advance_turn());
 
         // Tick Focus Agent and SideQuest turn counters (#1850, #1885).
         {
@@ -2010,7 +2012,12 @@ impl<C: Channel> Agent<C> {
             // SideQuest eviction: runs every N user turns when enabled.
             // Skipped when is_compacted_this_turn (focus truncation or prior eviction ran).
             let sidequest_should_fire = self.services.sidequest.tick();
-            if sidequest_should_fire && !self.context_manager.compaction.is_compacted_this_turn() {
+            if sidequest_should_fire
+                && !self
+                    .context_manager
+                    .compaction_state()
+                    .is_compacted_this_turn()
+            {
                 self.maybe_sidequest_eviction();
             }
         }
@@ -3018,7 +3025,8 @@ impl<C: Channel> Agent<C> {
         self.context_manager.soft_compaction_threshold = config.memory.soft_compaction_threshold;
         self.context_manager.hard_compaction_threshold = config.memory.hard_compaction_threshold;
         self.context_manager.compaction_preserve_tail = config.memory.compaction_preserve_tail;
-        self.context_manager.compaction_cooldown_turns = config.memory.compaction_cooldown_turns;
+        self.context_manager
+            .set_compaction_cooldown_turns(config.memory.compaction_cooldown_turns);
         self.context_manager.prune_protect_tokens = config.memory.prune_protect_tokens;
         self.context_manager.compression = config.memory.compression.clone();
         self.context_manager.routing = config.memory.store_routing.clone();
@@ -3226,10 +3234,11 @@ impl<C: Channel> Agent<C> {
                     self.recompute_prompt_tokens();
                     // C1 fix: prevent maybe_compact() from firing in the same turn.
                     // cooldown=0: eviction does not impose post-compaction cooldown.
-                    self.context_manager.compaction =
+                    self.context_manager.set_compaction_state(
                         crate::agent::context_manager::CompactionState::CompactedThisTurn {
                             cooldown: 0,
-                        };
+                        },
+                    );
                     tracing::info!(
                         freed_tokens = freed,
                         evicted_cursors = evicted_indices.len(),

--- a/crates/zeph-core/src/agent/tool_execution/focus.rs
+++ b/crates/zeph-core/src/agent/tool_execution/focus.rs
@@ -169,8 +169,9 @@ impl<C: Channel> Agent<C> {
         self.recompute_prompt_tokens();
         // C1 fix: mark compacted so maybe_compact() does not double-fire this turn.
         // cooldown=0: focus truncation does not impose post-compaction cooldown.
-        self.context_manager.compaction =
-            crate::agent::context_manager::CompactionState::CompactedThisTurn { cooldown: 0 };
+        self.context_manager.set_compaction_state(
+            crate::agent::context_manager::CompactionState::CompactedThisTurn { cooldown: 0 },
+        );
 
         self.rebuild_knowledge_block();
 
@@ -273,8 +274,9 @@ impl<C: Channel> Agent<C> {
             .append_llm_knowledge(summary.trim().to_owned());
         self.apply_compression_removals(to_remove_indices);
 
-        self.context_manager.compaction =
-            crate::agent::context_manager::CompactionState::CompactedThisTurn { cooldown: 0 };
+        self.context_manager.set_compaction_state(
+            crate::agent::context_manager::CompactionState::CompactedThisTurn { cooldown: 0 },
+        );
         self.services.focus.release_compression();
 
         format!(


### PR DESCRIPTION
## Summary

- **#3985** — `fetch_corrections` in `assembler.rs` now propagates `retrieve_corrections` errors via `map_err(ContextError::Memory)?` instead of silently swallowing them via `unwrap_or_default`. The fetcher is documented as safety-critical and never budget-gated, making silent failure especially risky.
- **#3990** — `ContextManager` compaction state-machine fields (`compaction`, `compaction_cooldown_turns`, `turns_since_last_hard_compaction`) changed from `pub` to `pub(crate)`; nine accessor/mutator methods added. All external callers in `zeph-agent-context`, `zeph-core`, and `zeph-subagent` updated to use the new API.
- **#3986** — `TurnContext.tool_allowlist: Option<Vec<String>>` and its `TODO(#3498)` removed. The field was always `None` and never wired to any channel config. Channel-scoped tool restriction remains tracked in #3879.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --features desktop,ide,server,chat,pdf,scheduler -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 9454/9454 passed

Closes #3985
Closes #3990
Closes #3986