### PR TITLE
fix(subagent): sanitize hook-replaced tool output and fix flaky bootstrap test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11043,6 +11043,7 @@ dependencies = [
  "zeph-common",
  "zeph-config",
  "zeph-llm",
+ "zeph-sanitizer",
  "zeph-skills",
  "zeph-tools",
 ]

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -2619,6 +2619,7 @@ impl<C: Channel> Agent<C> {
                 let score = child.score_now();
                 if score > 0.0 { Some(score) } else { None }
             },
+            content_isolation: self.runtime.config.security.content_isolation.clone(),
         }
     }
 

--- a/crates/zeph-subagent/Cargo.toml
+++ b/crates/zeph-subagent/Cargo.toml
@@ -28,6 +28,7 @@ uuid = { workspace = true, features = ["v4", "serde"] }
 zeph-common.workspace = true
 zeph-config.workspace = true
 zeph-llm.workspace = true
+zeph-sanitizer.workspace = true
 zeph-skills.workspace = true
 zeph-tools.workspace = true
 

--- a/crates/zeph-subagent/src/agent_loop.rs
+++ b/crates/zeph-subagent/src/agent_loop.rs
@@ -9,6 +9,7 @@ use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::{
     ChatResponse, LlmProvider, Message, MessageMetadata, MessagePart, Role, ToolDefinition,
 };
+use zeph_sanitizer::{ContentSanitizer, ContentSource, ContentSourceKind};
 use zeph_tools::executor::{ErasedToolExecutor, ToolCall};
 
 use super::filter::FilteredToolExecutor;
@@ -78,6 +79,7 @@ pub(super) struct AgentLoopArgs {
     pub(super) transcript_writer: Option<TranscriptWriter>,
     pub(super) spawn_depth: u32,
     pub(super) mcp_tool_names: Vec<String>,
+    pub(super) content_isolation: zeph_config::ContentIsolationConfig,
 }
 
 pub(super) fn make_message(role: Role, content: String) -> Message {
@@ -390,6 +392,7 @@ async fn run_turn(
     started_at: Instant,
     secret_request_tx: &mpsc::Sender<SecretRequest>,
     secret_rx: &mut mpsc::Receiver<Option<String>>,
+    sanitizer: &ContentSanitizer,
 ) -> Result<TurnOutcome, super::error::SubAgentError> {
     let response =
         call_provider_with_status(provider, messages, tool_defs, status_tx, *turns, started_at)
@@ -424,7 +427,10 @@ async fn run_turn(
     }
 
     let prev_len = messages.len();
-    let no_tool = handle_tool_step(executor, response, messages, hooks, task_id, agent_name).await;
+    let no_tool = handle_tool_step(
+        executor, response, messages, hooks, task_id, agent_name, sanitizer,
+    )
+    .await;
 
     if no_tool {
         let mut nudge_messages = Vec::new();
@@ -460,6 +466,7 @@ async fn handle_tool_step(
     hooks: &SubagentHooks,
     task_id: &str,
     agent_name: &str,
+    sanitizer: &ContentSanitizer,
 ) -> bool {
     match response {
         ChatResponse::Text(text) => {
@@ -569,7 +576,22 @@ async fn handle_tool_step(
                                         tool = %tc.name,
                                         "PostToolUse hook replaced sub-agent tool output"
                                     );
-                                    content = replacement;
+                                    let source = if tc.name.as_str().contains(':') {
+                                        ContentSource::new(ContentSourceKind::McpResponse)
+                                            .with_identifier(tc.name.as_str())
+                                    } else {
+                                        ContentSource::new(ContentSourceKind::ToolResult)
+                                            .with_identifier(tc.name.as_str())
+                                    };
+                                    let san_result = sanitizer.sanitize(&replacement, source);
+                                    if !san_result.injection_flags.is_empty() {
+                                        tracing::warn!(
+                                            tool = %tc.name,
+                                            flags = san_result.injection_flags.len(),
+                                            "injection patterns detected in hook-replaced sub-agent tool output"
+                                        );
+                                    }
+                                    content = san_result.body;
                                 }
                             }
                             Err(e) => {
@@ -620,7 +642,10 @@ pub(super) async fn run_agent_loop(
         mut transcript_writer,
         spawn_depth: _spawn_depth,
         mcp_tool_names,
+        content_isolation,
     } = args;
+
+    let sanitizer = ContentSanitizer::new(&content_isolation);
 
     let effective_system_prompt =
         build_effective_system_prompt(system_prompt, skills, &mcp_tool_names);
@@ -668,6 +693,7 @@ pub(super) async fn run_agent_loop(
             started_at,
             &secret_request_tx,
             &mut secret_rx,
+            &sanitizer,
         )
         .await?
         {

--- a/crates/zeph-subagent/src/manager.rs
+++ b/crates/zeph-subagent/src/manager.rs
@@ -18,7 +18,7 @@ use zeph_tools::FileExecutor;
 use zeph_tools::ToolCall;
 use zeph_tools::executor::{ErasedToolExecutor, ToolError, ToolOutput};
 
-use zeph_config::SubAgentConfig;
+use zeph_config::{ContentIsolationConfig, SubAgentConfig};
 
 use crate::agent_loop::{AgentLoopArgs, run_agent_loop};
 
@@ -66,6 +66,9 @@ pub struct SpawnContext {
     /// rather than `0.0`, preventing a subagent spawn from acting as a free risk reset.
     /// The subagent loop applies this via `TrajectorySentinel::seed_score` after build.
     pub seed_trajectory_score: Option<f32>,
+    /// Parent's content isolation config, propagated so the subagent loop can run the
+    /// same sanitizer settings on hook-replaced tool output.
+    pub content_isolation: ContentIsolationConfig,
 }
 
 /// Wraps an executor to allow file operations on the agent's memory directory.
@@ -827,6 +830,7 @@ impl SubAgentManager {
                 transcript_writer,
                 spawn_depth: spawn_depth + 1,
                 mcp_tool_names,
+                content_isolation: ctx.content_isolation,
             }));
 
         let handle_transcript_dir = if config.transcript_enabled {
@@ -1303,6 +1307,7 @@ impl SubAgentManager {
                 transcript_writer,
                 spawn_depth: 0,
                 mcp_tool_names: Vec::new(),
+                content_isolation: ContentIsolationConfig::default(),
             }));
 
         let resume_handle_transcript_dir = if config.transcript_enabled {
@@ -1538,7 +1543,7 @@ mod tests {
 
     use crate::agent_loop::{AgentLoopArgs, make_message, run_agent_loop};
     use crate::def::{MemoryScope, ModelSpec};
-    use zeph_config::SubAgentConfig;
+    use zeph_config::{ContentIsolationConfig, SubAgentConfig};
     use zeph_llm::provider::ChatResponse;
 
     use super::*;
@@ -3257,6 +3262,7 @@ mod tests {
             transcript_writer: None,
             spawn_depth: 0,
             mcp_tool_names: Vec::new(),
+            content_isolation: ContentIsolationConfig::default(),
         }
     }
 

--- a/src/bootstrap/tests.rs
+++ b/src/bootstrap/tests.rs
@@ -500,9 +500,12 @@ fn skill_paths_for_watcher_includes_plugins_root() {
 
 #[tokio::test]
 async fn create_skill_matcher_when_semantic_disabled() {
-    let tmp = std::env::temp_dir().join("zeph_test_skill_matcher_bootstrap.db");
-    let _ = std::fs::remove_file(&tmp);
-    let tmp_path = tmp.to_string_lossy().to_string();
+    let tmp_dir = tempfile::tempdir().expect("tempdir");
+    let tmp_path = tmp_dir
+        .path()
+        .join("skill_matcher_bootstrap.db")
+        .to_string_lossy()
+        .to_string();
 
     let mut config = Config::load(Path::new("/nonexistent")).unwrap();
     config.memory.semantic.enabled = false;
@@ -528,8 +531,6 @@ async fn create_skill_matcher_when_semantic_disabled() {
     let meta: Vec<&SkillMeta> = vec![];
     let result = create_skill_matcher(&config, &provider, &meta, &memory, "test-model", None).await;
     assert!(result.is_none());
-
-    let _ = std::fs::remove_file(&tmp);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Wire `ContentSanitizer` into the subagent agent loop so PostToolUse hook replacements pass through injection detection before reaching `MessagePart::ToolResult` (#3997)
- Replace the fixed `/tmp/zeph_test_skill_matcher_bootstrap.db` path in `create_skill_matcher_when_semantic_disabled` with `tempfile::tempdir()` to eliminate the race under parallel nextest (#4006)

## Details

**#3997 — subagent ContentSanitizer bypass**

The main agent path (`tier_loop.rs`) sanitizes tool results via `process_one_tool_result`. The subagent path had no equivalent, meaning hook-replaced output (introduced in #3798) bypassed injection detection, Vigil gate, and causal IPI analysis.

Changes:
- `ContentIsolationConfig` propagated from `SpawnContext` → `AgentLoopArgs`
- `ContentSanitizer` instantiated once at `run_agent_loop` entry, passed by reference to `handle_tool_step`
- Source type: `McpResponse` for names containing `:` (MCP convention), `ToolResult` otherwise
- Injection flags trigger `tracing::warn!`; sanitized body replaces raw hook output
- `zeph-sanitizer` added as workspace dep to `zeph-subagent`

**#4006 — flaky bootstrap test**

`TempDir` handle lives until end of test scope; manual `remove_file` calls removed.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 9460 passed, 21 skipped

## Follow-up

A unit test covering the `sanitizer.sanitize()` call at `agent_loop.rs:586` is missing. Tracked as P3 follow-up.

Closes #3997
Closes #4006