### PR TITLE
fix(agent-context): wire inject_semantic_recall into production path and fix recall accumulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `zeph-core`: `Agent::inject_semantic_recall` now delegates to
+  `ContextService::inject_semantic_recall_bare`, activating tiered retrieval on the
+  turn-loop hot path instead of bypassing it via `fetch_semantic_recall_raw` (closes #4022).
+- `zeph-agent-context`: `remove_by_part_or_prefix` now also removes `Role::User` messages
+  whose content starts with `RECALL_PREFIX`, preventing tiered-retrieval recall messages
+  from accumulating across turns (closes #4019).
+
 ### Added
 
 - `zeph-scheduler`: `Scheduler::with_handler_timeout(Duration)` builder method sets a

--- a/crates/zeph-agent-context/src/service.rs
+++ b/crates/zeph-agent-context/src/service.rs
@@ -282,6 +282,106 @@ impl ContextService {
         Ok(())
     }
 
+    /// Inject semantic recall without a full [`ContextAssemblyView`].
+    ///
+    /// This variant is called from `Agent::inject_semantic_recall` in `zeph-core`, where
+    /// constructing a full `ContextAssemblyView` would require duplicating all of
+    /// `prepare_context`'s setup. It carries only the fields that
+    /// [`inject_semantic_recall`] actually reads, enabling tiered retrieval on the
+    /// hot-path turn loop without the overhead of the full view.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ContextError::Memory`] if the recall backend returns an error.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn inject_semantic_recall_bare(
+        &self,
+        query: &str,
+        token_budget: usize,
+        window: &mut MessageWindowView<'_>,
+        memory: Option<&zeph_memory::semantic::SemanticMemory>,
+        recall_limit: usize,
+        context_format: zeph_config::ContextFormat,
+        conversation_id: Option<zeph_memory::ConversationId>,
+        tiered_classifier: Option<&std::sync::Arc<zeph_llm::any::AnyProvider>>,
+        tiered_validator: Option<&std::sync::Arc<zeph_llm::any::AnyProvider>>,
+        tiered_config: &zeph_config::memory::TieredRetrievalConfig,
+    ) -> Result<(), ContextError> {
+        self.remove_recall_messages(window);
+
+        let msg = if tiered_config.enabled {
+            use tracing::Instrument as _;
+            let Some(mem) = memory else {
+                return Ok(());
+            };
+            let result = tokio::time::timeout(
+                std::time::Duration::from_secs(30),
+                zeph_memory::recall_tiered(
+                    mem,
+                    query,
+                    conversation_id,
+                    tiered_classifier,
+                    tiered_validator,
+                    tiered_config,
+                    Some(token_budget),
+                )
+                .instrument(tracing::info_span!("agent_context.tiered_retrieval.recall")),
+            )
+            .await
+            .map_err(|_| {
+                tracing::warn!("tiered_retrieval: recall_tiered timed out after 30s");
+                ContextError::Memory(zeph_memory::MemoryError::Timeout(
+                    "recall_tiered timed out".to_owned(),
+                ))
+            })?
+            .map_err(ContextError::Memory)?;
+
+            tracing::debug!(
+                intent = %result.intent,
+                tokens_used = result.tokens_used,
+                tier_escalated = result.tier_escalated,
+                count = result.messages.len(),
+                "tiered_retrieval: recall complete"
+            );
+
+            if result.messages.is_empty() {
+                return Ok(());
+            }
+
+            let recalled_text = result
+                .messages
+                .iter()
+                .map(|m| m.message.content.as_str())
+                .collect::<Vec<_>>()
+                .join("\n---\n");
+            Some(Message::from_legacy(
+                Role::User,
+                format!("{RECALL_PREFIX}{recalled_text}"),
+            ))
+        } else {
+            let (msg, _score) = crate::helpers::fetch_semantic_recall_raw(
+                memory,
+                recall_limit,
+                context_format,
+                query,
+                token_budget,
+                &window.token_counter,
+                None,
+                None,
+            )
+            .await?;
+            msg
+        };
+
+        if let Some(msg) = msg
+            && window.messages.len() > 1
+        {
+            window.messages.insert(1, msg);
+        }
+
+        Ok(())
+    }
+
     /// Inject cross-session context messages into the window for the given query.
     ///
     /// Removes any existing cross-session messages first, fetches fresh cross-session
@@ -1361,17 +1461,25 @@ pub(crate) fn remove_by_prefix(
     messages.retain(|m| m.role != role || !m.content.starts_with(prefix));
 }
 
-/// Remove system messages that match either a typed `MessagePart` or a content prefix.
+/// Remove messages that match either a typed `MessagePart` or a content prefix.
 ///
-/// Typed-part matching takes priority — a message is removed if its **first** part
-/// satisfies `part_matches`. As a fallback, messages that start with `prefix` are also
-/// removed. Non-system messages are always retained.
+/// For `Role::System` messages: typed-part matching takes priority — a message is removed
+/// if its **first** part satisfies `part_matches`. As a fallback, messages that start with
+/// `prefix` are also removed.
+/// For `Role::User` messages: removed if their content starts with `prefix` (tiered-recall
+/// cleanup).
+/// All other roles are always retained.
 pub(crate) fn remove_by_part_or_prefix(
     messages: &mut Vec<zeph_llm::provider::Message>,
     prefix: &str,
     part_matches: impl Fn(&MessagePart) -> bool,
 ) {
     messages.retain(|m| {
+        // Role::User recall messages are produced by the tiered-retrieval path in
+        // inject_semantic_recall. They must be cleaned up the same way as Role::System ones.
+        if m.role == Role::User {
+            return !m.content.starts_with(prefix);
+        }
         if m.role != Role::System {
             return true;
         }
@@ -1478,6 +1586,42 @@ mod tests {
                 .messages
                 .iter()
                 .all(|m| !m.content.starts_with(RECALL_PREFIX))
+        );
+    }
+
+    // Regression test for #4019: Role::User recall messages must be removed by
+    // remove_recall_messages, not just Role::System ones.
+    #[test]
+    fn remove_recall_messages_removes_user_role_recall() {
+        let mut msgs = vec![
+            sys("system"),
+            user(&format!("{RECALL_PREFIX}recalled via tiered path")),
+            user("real user message"),
+        ];
+        let mut cached = 0u64;
+        let mut completed = HashSet::new();
+        let mut window = make_window(&mut msgs, &mut cached, &mut completed);
+
+        ContextService::new().remove_recall_messages(&mut window);
+
+        assert_eq!(
+            window.messages.len(),
+            2,
+            "Role::User recall message must be removed"
+        );
+        assert!(
+            window
+                .messages
+                .iter()
+                .all(|m| !m.content.starts_with(RECALL_PREFIX)),
+            "no message with RECALL_PREFIX must remain"
+        );
+        assert!(
+            window
+                .messages
+                .iter()
+                .any(|m| m.content == "real user message"),
+            "non-recall user message must survive"
         );
     }
 
@@ -1842,6 +1986,45 @@ mod tests {
             assert!(
                 result.is_ok(),
                 "prepare_context with tiered enabled and no budget must return Ok"
+            );
+        }
+
+        // Regression test for #4022: inject_semantic_recall_bare must be callable without a
+        // full ContextAssemblyView and must return Ok(()) when memory is None.
+        #[tokio::test]
+        async fn inject_semantic_recall_bare_no_memory_returns_ok() {
+            use zeph_config::memory::TieredRetrievalConfig;
+
+            let mut msgs: Vec<Message> = vec![];
+            let mut cached = 0u64;
+            let mut completed = HashSet::new();
+            let mut window = make_window(&mut msgs, &mut cached, &mut completed);
+
+            let result = ContextService::new()
+                .inject_semantic_recall_bare(
+                    "test query",
+                    1000,
+                    &mut window,
+                    None,
+                    10,
+                    zeph_config::ContextFormat::default(),
+                    None,
+                    None,
+                    None,
+                    &TieredRetrievalConfig {
+                        enabled: true,
+                        ..TieredRetrievalConfig::default()
+                    },
+                )
+                .await;
+
+            assert!(
+                result.is_ok(),
+                "inject_semantic_recall_bare with memory=None must return Ok(())"
+            );
+            assert!(
+                window.messages.is_empty(),
+                "no recall message must be injected when memory is None"
             );
         }
     }

--- a/crates/zeph-agent-context/src/service.rs
+++ b/crates/zeph-agent-context/src/service.rs
@@ -287,7 +287,7 @@ impl ContextService {
     /// This variant is called from `Agent::inject_semantic_recall` in `zeph-core`, where
     /// constructing a full `ContextAssemblyView` would require duplicating all of
     /// `prepare_context`'s setup. It carries only the fields that
-    /// [`inject_semantic_recall`] actually reads, enabling tiered retrieval on the
+    /// `inject_semantic_recall` actually reads, enabling tiered retrieval on the
     /// hot-path turn loop without the overhead of the full view.
     ///
     /// # Errors

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -1353,27 +1353,47 @@ impl<C: Channel> Agent<C> {
         query: &str,
         token_budget: usize,
     ) -> Result<(), super::super::error::AgentError> {
-        self.remove_recall_messages();
+        // Snapshot all read-only fields before the mutable borrow for the window view.
+        let tiered_config = self
+            .services
+            .memory
+            .persistence
+            .tiered_retrieval_config
+            .clone();
+        let tiered_classifier = self
+            .services
+            .memory
+            .persistence
+            .tiered_retrieval_classifier
+            .clone();
+        let tiered_validator = self
+            .services
+            .memory
+            .persistence
+            .tiered_retrieval_validator
+            .clone();
+        let memory = self.services.memory.persistence.memory.clone();
+        let recall_limit = self.services.memory.persistence.recall_limit;
+        let context_format = self.services.memory.persistence.context_format;
+        let conversation_id = self.services.memory.persistence.conversation_id;
 
-        let (msg, _score) = zeph_agent_context::helpers::fetch_semantic_recall_raw(
-            self.services.memory.persistence.memory.as_deref(),
-            self.services.memory.persistence.recall_limit,
-            self.services.memory.persistence.context_format,
+        let svc = zeph_agent_context::ContextService::new();
+        let mut window = self.message_window_view();
+
+        svc.inject_semantic_recall_bare(
             query,
             token_budget,
-            &self.runtime.metrics.token_counter,
-            None,
-            None,
+            &mut window,
+            memory.as_deref(),
+            recall_limit,
+            context_format,
+            conversation_id,
+            tiered_classifier.as_ref(),
+            tiered_validator.as_ref(),
+            &tiered_config,
         )
         .await
-        .map_err(|e| super::super::error::AgentError::ContextError(format!("{e:#}")))?;
-        if let Some(msg) = msg
-            && self.msg.messages.len() > 1
-        {
-            self.msg.messages.insert(1, msg);
-        }
-
-        Ok(())
+        .map_err(|e| super::super::error::AgentError::ContextError(format!("{e:#}")))
     }
 
     pub(in crate::agent) fn remove_summary_messages(&mut self) {


### PR DESCRIPTION
## Summary

- Wires `ContextService::inject_semantic_recall` into the agent turn loop via the new `inject_semantic_recall_bare` method in `zeph-agent-context`; the production assembly path in `zeph-core` now delegates to it, activating tiered retrieval for all production sessions.
- Extends `remove_by_part_or_prefix` to remove `Role::User` messages with `RECALL_PREFIX` (in addition to `Role::System`), preventing recall messages from accumulating across turns when tiered retrieval is enabled.
- Adds 2 regression tests covering both fixes.

## Test plan

- [x] `service::tests::remove_recall_messages_removes_user_role_recall` — verifies `Role::User` recall messages are cleaned up
- [x] `service::tests::inject_semantic_recall_tests::inject_semantic_recall_bare_no_memory_returns_ok` — verifies the new production API
- [x] 9465 workspace tests pass, clippy clean, fmt clean

Closes #4022
Closes #4019