### PR TITLE
refactor(config): VaultBackend enum, #[non_exhaustive] enums, metrics bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- `zeph-config`: `VaultConfig.backend` is now typed as `VaultBackend` enum instead of `String`,
+  with `serde(rename_all = "lowercase")` so existing TOML configs remain compatible (closes #3886).
+- `zeph-a2a`: `TaskState`, `Role`, `Part`, `TaskEvent` are now `#[non_exhaustive]` to allow
+  adding protocol variants without breaking downstream matches (closes #3893).
+- `zeph-config`: `ProviderKind`, `RouterStrategyConfig`, `LlmRoutingStrategy`, `CascadeClassifierMode`
+  are now `#[non_exhaustive]` for forward compatibility (closes #3893).
+
+### Dependencies
+
+- Updated `metrics` 0.24.5 → 0.24.6 and `metrics-util` 0.20.3 → 0.20.4 (closes #3895).
+
 ### Fixed
 
 - `zeph-core`: `Agent::inject_semantic_recall` now delegates to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4318,9 +4318,9 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.24.5"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff56c2e7dce6bd462e3b8919986a617027481b1dcc703175b58cf9dd98a2f071"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
 dependencies = [
  "portable-atomic",
  "rapidhash",
@@ -4328,9 +4328,9 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e56997f084e57b045edf17c3ed8ba7f9f779c670df8206dfd1c736f4c02dc4a"
+checksum = "96f8722f8562635f92f8ed992f26df0532266eb03d5202607c20c0d7e9745e13"
 dependencies = [
  "aho-corasick",
  "crossbeam-epoch",

--- a/crates/zeph-a2a/src/client.rs
+++ b/crates/zeph-a2a/src/client.rs
@@ -30,6 +30,7 @@ pub type TaskEventStream = Pin<Box<dyn Stream<Item = Result<TaskEvent, A2aError>
 /// The A2A spec multiplexes two event kinds over the same SSE channel. This enum
 /// uses `#[serde(untagged)]` so that the deserializer inspects the `kind` field
 /// inside the inner struct to determine the variant.
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum TaskEvent {

--- a/crates/zeph-a2a/src/types.rs
+++ b/crates/zeph-a2a/src/types.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 /// `Submitted` → `Working` → `Completed` (success) or `Failed` (error).
 /// `InputRequired` pauses processing until the caller sends more data.
 /// Terminal states (`Completed`, `Failed`, `Canceled`, `Rejected`) cannot be resumed.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TaskState {
     /// Task has been received and queued but processing has not started.
@@ -85,6 +86,7 @@ pub struct TaskStatus {
 }
 
 /// Participant role in a conversation message.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Role {
@@ -143,6 +145,7 @@ pub struct Message {
 /// let text_part = Part::text("Hello!");
 /// assert!(matches!(text_part, Part::Text { .. }));
 /// ```
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 pub enum Part {

--- a/crates/zeph-config/src/features.rs
+++ b/crates/zeph-config/src/features.rs
@@ -98,8 +98,31 @@ fn default_repo_map_ttl_secs() -> u64 {
     300
 }
 
-fn default_vault_backend() -> String {
-    "env".into()
+fn default_vault_backend() -> VaultBackend {
+    VaultBackend::Env
+}
+
+/// Selects the vault backend used to resolve secrets at startup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum VaultBackend {
+    /// Resolve secrets from environment variables (default, zero-config).
+    #[default]
+    Env,
+    /// Resolve secrets from an age-encrypted vault file.
+    Age,
+    /// Resolve secrets from the OS keyring.
+    Keyring,
+}
+
+impl std::fmt::Display for VaultBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Env => f.write_str("env"),
+            Self::Age => f.write_str("age"),
+            Self::Keyring => f.write_str("keyring"),
+        }
+    }
 }
 
 fn default_max_daily_cents() -> u32 {
@@ -634,9 +657,9 @@ impl Default for IndexConfig {
 /// ```
 #[derive(Debug, Deserialize, Serialize)]
 pub struct VaultConfig {
-    /// Vault backend identifier (`"age"`, `"env"`, or `"keyring"`). Default: `"env"`.
+    /// Which backend resolves secrets. Default: [`VaultBackend::Env`].
     #[serde(default = "default_vault_backend")]
-    pub backend: String,
+    pub backend: VaultBackend,
 }
 
 impl Default for VaultConfig {

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -128,7 +128,7 @@ pub use features::{
     CompressionSpectrumConfig, CostConfig, DaemonConfig, DebugConfig, GatewayConfig, IndexConfig,
     ProactiveExplorationConfig, ScheduledTaskConfig, ScheduledTaskKind, SchedulerConfig,
     SchedulerDaemonConfig, SkillEvaluationConfig, SkillMiningConfig, SkillPromptMode, SkillsConfig,
-    TraceConfig, VaultConfig,
+    TraceConfig, VaultBackend, VaultConfig,
 };
 pub use hooks::{FileChangedConfig, HooksConfig};
 pub use learning::{DetectorMode, LearningConfig};

--- a/crates/zeph-config/src/providers.rs
+++ b/crates/zeph-config/src/providers.rs
@@ -338,6 +338,7 @@ pub fn get_default_router_reorder_interval() -> u64 {
 /// model = "gpt-4o"
 /// name = "quality"
 /// ```
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ProviderKind {
@@ -699,6 +700,7 @@ pub struct SttConfig {
 }
 
 /// Routing strategy selection for multi-provider routing.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum RouterStrategyConfig {
@@ -919,6 +921,7 @@ impl Default for CascadeConfig {
 }
 
 /// Quality classifier mode for cascade routing.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum CascadeClassifierMode {
@@ -1162,6 +1165,7 @@ impl Default for GenerationParams {
 // ─── Unified config types ─────────────────────────────────────────────────────
 
 /// Routing strategy for the `[[llm.providers]]` pool.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum LlmRoutingStrategy {

--- a/crates/zeph-core/src/instructions.rs
+++ b/crates/zeph-core/src/instructions.rs
@@ -262,6 +262,7 @@ fn detection_paths(kind: ProviderKind, base: &Path) -> Vec<PathBuf> {
         | ProviderKind::Cocoon => {
             vec![base.join("AGENTS.md")]
         }
+        _ => vec![base.join("AGENTS.md")],
     }
 }
 

--- a/crates/zeph-core/src/provider_factory.rs
+++ b/crates/zeph-core/src/provider_factory.rs
@@ -130,6 +130,10 @@ pub fn build_provider_from_entry(
         ProviderKind::Cocoon => Err(BootstrapError::Provider(
             "cocoon feature is not enabled; rebuild with --features cocoon".into(),
         )),
+        _ => Err(BootstrapError::Provider(format!(
+            "unknown provider kind: {:?}",
+            entry.provider_type
+        ))),
     }
 }
 

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -4,6 +4,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::bootstrap::VaultArgs;
+use zeph_config::VaultBackend;
 use zeph_core::config::Config;
 
 pub fn resolve_config_path(cli_override: Option<&Path>) -> PathBuf {
@@ -48,6 +49,14 @@ fn resolve_config_path_impl(
     xdg
 }
 
+fn parse_backend_str(s: &str) -> VaultBackend {
+    match s {
+        "age" => VaultBackend::Age,
+        "keyring" => VaultBackend::Keyring,
+        _ => VaultBackend::Env,
+    }
+}
+
 /// Priority: CLI flag > `ZEPH_VAULT_*` env > config.vault.* > defaults
 pub fn parse_vault_args(
     config: &Config,
@@ -57,9 +66,9 @@ pub fn parse_vault_args(
 ) -> VaultArgs {
     let env_backend = std::env::var("ZEPH_VAULT_BACKEND").ok();
     let backend = cli_backend
-        .map(String::from)
-        .or(env_backend)
-        .unwrap_or_else(|| config.vault.backend.clone());
+        .map(parse_backend_str)
+        .or_else(|| env_backend.as_deref().map(parse_backend_str))
+        .unwrap_or(config.vault.backend);
 
     let env_key = std::env::var("ZEPH_VAULT_KEY").ok();
     let default_dir = zeph_core::vault::default_vault_dir();
@@ -67,7 +76,7 @@ pub fn parse_vault_args(
         .map(|p| p.to_string_lossy().into_owned())
         .or(env_key)
         .or_else(|| {
-            if backend == "age" {
+            if backend == VaultBackend::Age {
                 Some(
                     default_dir
                         .join("vault-key.txt")
@@ -84,7 +93,7 @@ pub fn parse_vault_args(
         .map(|p| p.to_string_lossy().into_owned())
         .or(env_vault)
         .or_else(|| {
-            if backend == "age" {
+            if backend == VaultBackend::Age {
                 Some(
                     default_dir
                         .join("secrets.age")

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -38,6 +38,7 @@ use zeph_skills::registry::SkillRegistry;
 use zeph_skills::watcher::{SkillEvent, SkillWatcher};
 
 use url::Url;
+use zeph_config::VaultBackend;
 use zeph_core::config::{Config, SecretResolver};
 use zeph_core::config_watcher::{ConfigEvent, ConfigWatcher};
 use zeph_core::vault::EnvVaultProvider;
@@ -73,7 +74,7 @@ pub struct AppBuilder {
 }
 
 pub struct VaultArgs {
-    pub backend: String,
+    pub backend: VaultBackend,
     pub key_path: Option<String>,
     pub vault_path: Option<String>,
 }
@@ -129,9 +130,9 @@ impl AppBuilder {
         let (vault, age_vault): (
             Box<dyn VaultProvider>,
             Option<Arc<RwLock<AgeVaultProvider>>>,
-        ) = match vault_args.backend.as_str() {
-            "env" => (Box::new(EnvVaultProvider), None),
-            "age" => {
+        ) = match vault_args.backend {
+            VaultBackend::Env => (Box::new(EnvVaultProvider), None),
+            VaultBackend::Age => {
                 let key = vault_args.key_path.ok_or_else(|| {
                     BootstrapError::Provider("--vault-key required for age backend".into())
                 })?;
@@ -145,10 +146,10 @@ impl AppBuilder {
                     Box::new(zeph_core::vault::ArcAgeVaultProvider(Arc::clone(&arc)));
                 (boxed, Some(arc))
             }
-            other => {
-                return Err(BootstrapError::Provider(format!(
-                    "unknown vault backend: {other}"
-                )));
+            VaultBackend::Keyring => {
+                return Err(BootstrapError::Provider(
+                    "keyring vault backend is not yet implemented".into(),
+                ));
             }
         };
 
@@ -1709,9 +1710,9 @@ impl AppBuilder {
 #[cfg(feature = "bench")]
 #[must_use]
 pub fn build_vault_provider(args: &VaultArgs) -> Option<Box<dyn VaultProvider>> {
-    match args.backend.as_str() {
-        "env" => Some(Box::new(EnvVaultProvider)),
-        "age" => {
+    match args.backend {
+        VaultBackend::Env => Some(Box::new(EnvVaultProvider)),
+        VaultBackend::Age => {
             let key = args.key_path.as_deref()?;
             let path = args.vault_path.as_deref()?;
             let provider =
@@ -1720,7 +1721,7 @@ pub fn build_vault_provider(args: &VaultArgs) -> Option<Box<dyn VaultProvider>> 
             let arc = Arc::new(RwLock::new(provider));
             Some(Box::new(zeph_core::vault::ArcAgeVaultProvider(arc)))
         }
-        _ => None,
+        VaultBackend::Keyring => None,
     }
 }
 

--- a/src/bootstrap/provider.rs
+++ b/src/bootstrap/provider.rs
@@ -33,8 +33,8 @@ fn build_cascade_router_config(
     config: &Config,
 ) -> CascadeRouterConfig {
     let classifier_mode = match cascade_cfg.classifier_mode {
-        zeph_core::config::CascadeClassifierMode::Heuristic => ClassifierMode::Heuristic,
         zeph_core::config::CascadeClassifierMode::Judge => ClassifierMode::Judge,
+        _ => ClassifierMode::Heuristic,
     };
     // SEC-CASCADE-01: clamp quality_threshold to [0.0, 1.0]; reject NaN/Inf.
     let raw_threshold = cascade_cfg.quality_threshold;
@@ -280,7 +280,6 @@ fn create_provider_from_pool(config: &Config) -> Result<AnyProvider, BootstrapEr
     }
 
     match config.llm.routing {
-        LlmRoutingStrategy::None => build_single_provider_from_pool(pool, config),
         LlmRoutingStrategy::Ema => {
             let providers = build_all_pool_providers(pool, config)?;
             let raw_alpha = config.llm.router_ema_alpha;
@@ -390,6 +389,7 @@ fn create_provider_from_pool(config: &Config) -> Result<AnyProvider, BootstrapEr
             )))
         }
         LlmRoutingStrategy::Triage => build_triage_provider(pool, config),
+        _ => build_single_provider_from_pool(pool, config),
     }
 }
 

--- a/src/bootstrap/tests.rs
+++ b/src/bootstrap/tests.rs
@@ -36,7 +36,7 @@ fn remote_url_not_localhost() {
 fn vault_args_defaults_in_test_context() {
     let config = Config::load(Path::new("/nonexistent")).unwrap();
     let args = parse_vault_args(&config, None, None, None);
-    assert_eq!(args.backend, "env");
+    assert_eq!(args.backend, zeph_config::VaultBackend::Env);
     assert!(args.key_path.is_none());
     assert!(args.vault_path.is_none());
 }
@@ -44,29 +44,29 @@ fn vault_args_defaults_in_test_context() {
 #[test]
 fn vault_args_uses_config_backend_as_fallback() {
     let mut config = Config::load(Path::new("/nonexistent")).unwrap();
-    config.vault.backend = "age".into();
+    config.vault.backend = zeph_config::VaultBackend::Age;
     let args = parse_vault_args(&config, None, None, None);
-    assert_eq!(args.backend, "age");
+    assert_eq!(args.backend, zeph_config::VaultBackend::Age);
 }
 
 #[test]
 fn vault_args_env_overrides_config() {
     let mut config = Config::load(Path::new("/nonexistent")).unwrap();
-    config.vault.backend = "age".into();
+    config.vault.backend = zeph_config::VaultBackend::Age;
     unsafe { std::env::set_var("ZEPH_VAULT_BACKEND", "env") };
     let args = parse_vault_args(&config, None, None, None);
     unsafe { std::env::remove_var("ZEPH_VAULT_BACKEND") };
-    assert_eq!(args.backend, "env");
+    assert_eq!(args.backend, zeph_config::VaultBackend::Env);
 }
 
 #[test]
 fn vault_args_struct_construction() {
     let args = VaultArgs {
-        backend: "age".into(),
+        backend: zeph_config::VaultBackend::Age,
         key_path: Some("/tmp/key".into()),
         vault_path: Some("/tmp/vault".into()),
     };
-    assert_eq!(args.backend, "age");
+    assert_eq!(args.backend, zeph_config::VaultBackend::Age);
     assert_eq!(args.key_path.as_deref(), Some("/tmp/key"));
     assert_eq!(args.vault_path.as_deref(), Some("/tmp/vault"));
 }
@@ -74,7 +74,7 @@ fn vault_args_struct_construction() {
 #[test]
 fn vault_args_cli_overrides_env_and_config() {
     let mut config = Config::load(Path::new("/nonexistent")).unwrap();
-    config.vault.backend = "env".into();
+    config.vault.backend = zeph_config::VaultBackend::Env;
     unsafe { std::env::set_var("ZEPH_VAULT_BACKEND", "env") };
     let args = parse_vault_args(
         &config,
@@ -83,7 +83,7 @@ fn vault_args_cli_overrides_env_and_config() {
         Some(Path::new("/cli/vault")),
     );
     unsafe { std::env::remove_var("ZEPH_VAULT_BACKEND") };
-    assert_eq!(args.backend, "age");
+    assert_eq!(args.backend, zeph_config::VaultBackend::Age);
     assert_eq!(args.key_path.as_deref(), Some("/cli/key"));
     assert_eq!(args.vault_path.as_deref(), Some("/cli/vault"));
 }
@@ -118,11 +118,11 @@ fn resolve_config_path_default() {
 #[test]
 fn vault_args_struct_env_backend() {
     let args = VaultArgs {
-        backend: "env".into(),
+        backend: zeph_config::VaultBackend::Env,
         key_path: None,
         vault_path: None,
     };
-    assert_eq!(args.backend, "env");
+    assert_eq!(args.backend, zeph_config::VaultBackend::Env);
     assert!(args.key_path.is_none());
     assert!(args.vault_path.is_none());
 }

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -456,12 +456,12 @@ async fn check_llm_provider(
             .as_deref()
             .unwrap_or("https://generativelanguage.googleapis.com")
             .to_owned(),
-        ProviderKind::Compatible => entry.base_url.clone().unwrap_or_default(),
         ProviderKind::Candle | ProviderKind::Gonka => unreachable!(),
         ProviderKind::Cocoon => entry
             .cocoon_client_url
             .clone()
             .unwrap_or_else(|| "http://localhost:10000".to_owned()),
+        _ => entry.base_url.clone().unwrap_or_default(),
     };
 
     if base_url.is_empty() {
@@ -767,7 +767,7 @@ pub(crate) async fn run_doctor(
     // 2 + 3 + 4. Vault checks
     {
         let vault_args = crate::bootstrap::parse_vault_args(&config, None, None, None);
-        if vault_args.backend == "age" {
+        if vault_args.backend == zeph_config::VaultBackend::Age {
             if let Some(ref vault_path) = vault_args.vault_path {
                 results.push(check_vault_file_exists(vault_path));
                 results.push(check_vault_file_mode(vault_path, "vault.file_mode"));

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -4,7 +4,7 @@
 use std::path::PathBuf;
 
 use dialoguer::{Confirm, Input, Password, Select};
-use zeph_config::{GeminiThinkingLevel, ThinkingConfig};
+use zeph_config::{GeminiThinkingLevel, ThinkingConfig, VaultBackend};
 use zeph_core::config::{
     AcpConfig, ChannelSkillsConfig, Config, DiscordConfig, LlmConfig, LlmRoutingStrategy,
     McpServerConfig, McpTrustLevel, MemoryConfig, OrchestrationConfig, ProviderEntry, ProviderKind,
@@ -836,7 +836,11 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
     }
 
     config.vault = VaultConfig {
-        backend: state.vault_backend.clone(),
+        backend: match state.vault_backend.as_str() {
+            "age" => VaultBackend::Age,
+            "keyring" => VaultBackend::Keyring,
+            _ => VaultBackend::Env,
+        },
     };
 
     apply_daemon_config(&mut config, state);

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2869,7 +2869,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             active_channel: active_channel_name.clone(),
             token_budget,
             compaction_threshold,
-            vault_backend: config.vault.backend.clone(),
+            vault_backend: config.vault.backend.to_string(),
             autosave_enabled: config.memory.autosave_assistant,
             model_name_override: Some(config.llm.effective_model().to_owned()),
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -365,7 +365,7 @@ fn build_config_vault_age() {
         ..WizardState::default()
     };
     let config = build_config(&state);
-    assert_eq!(config.vault.backend, "age");
+    assert_eq!(config.vault.backend, zeph_config::VaultBackend::Age);
 }
 
 #[test]

--- a/src/tui_remote.rs
+++ b/src/tui_remote.rs
@@ -82,6 +82,7 @@ pub(crate) async fn run_tui_remote(
                                     _ => {}
                                 }
                             }
+                            Ok(_) => {}
                             Err(e) => {
                                 let _ = agent_tx_pump
                                     .send(zeph_tui::AgentEvent::FullMessage(format!(


### PR DESCRIPTION
## Summary

- **#3886**: Replace `VaultConfig.backend: String` with a `VaultBackend` enum (`Env`/`Age`/`Keyring`). The field now uses `#[serde(rename_all = "lowercase")]` so existing TOML configs remain compatible. The bootstrap match is exhaustive at compile time — typos like `"Age"` or `"AGE"` are caught at deserialization instead of producing a runtime error.
- **#3893**: Add `#[non_exhaustive]` to eight public enums: `TaskState`, `Role`, `Part`, `TaskEvent` (zeph-a2a) and `ProviderKind`, `RouterStrategyConfig`, `LlmRoutingStrategy`, `CascadeClassifierMode` (zeph-config). New variants can now be added without breaking downstream exhaustive matches.
- **#3895**: Bump `metrics` 0.24.5 → 0.24.6 and `metrics-util` 0.20.3 → 0.20.4 to clear the yanked-crate advisory.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo nextest run --workspace --lib --bins` — 9464 passed (includes 2 new vault_backend tests)
- [x] `cargo deny check advisories` — only RUSTSEC-2025-0134 (pre-existing, tracked #3772)
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean

Closes #3886, #3893, #3895