### PR TITLE
refactor(agent-context): extract run_tiered_recall, SemanticRecallParams, and disambiguate_provider

### DIFF
--- a/crates/zeph-agent-context/src/lib.rs
+++ b/crates/zeph-agent-context/src/lib.rs
@@ -43,7 +43,7 @@ pub use compaction::{
 };
 pub use error::ContextError;
 pub use helpers::BudgetHint;
-pub use service::ContextService;
+pub use service::{ContextService, SemanticRecallParams};
 pub use state::{
     CompactionOutcome, CompactionPersistence, CompactionProbeCallback, ContextAssemblyView,
     ContextDelta, ContextSummarizationView, MessageWindowView, MetricsCallback, MetricsCounters,

--- a/crates/zeph-agent-context/src/service.rs
+++ b/crates/zeph-agent-context/src/service.rs
@@ -18,6 +18,32 @@ use crate::state::{
     ProviderHandles, StatusSink,
 };
 
+/// Configuration parameters for semantic recall injection.
+///
+/// Collects the 8 config-like arguments shared between the tiered and flat recall paths so
+/// callers do not need to pass them positionally to [`ContextService::inject_semantic_recall_bare`].
+///
+/// `window` and `memory` are kept as direct parameters on the method because they are
+/// mutable/output args rather than configuration.
+pub struct SemanticRecallParams<'a> {
+    /// Query string used for retrieval.
+    pub query: &'a str,
+    /// Maximum number of tokens the injected recall may consume.
+    pub token_budget: usize,
+    /// Maximum number of memories to retrieve (flat path only).
+    pub recall_limit: usize,
+    /// Format applied when serialising recalled memories.
+    pub context_format: zeph_config::ContextFormat,
+    /// Conversation scope used for tiered retrieval.
+    pub conversation_id: Option<zeph_memory::ConversationId>,
+    /// Optional LLM provider for intent classification (tiered path).
+    pub tiered_classifier: Option<&'a std::sync::Arc<zeph_llm::any::AnyProvider>>,
+    /// Optional LLM provider for result validation (tiered path).
+    pub tiered_validator: Option<&'a std::sync::Arc<zeph_llm::any::AnyProvider>>,
+    /// Tiered retrieval configuration controlling whether the tiered path is active.
+    pub tiered_config: &'a zeph_config::memory::TieredRetrievalConfig,
+}
+
 /// Stateless façade for agent context-assembly operations.
 ///
 /// This struct has no fields. All state flows through method parameters, which allows the
@@ -209,69 +235,19 @@ impl ContextService {
     ) -> Result<(), ContextError> {
         self.remove_recall_messages(window);
 
-        let msg = if view.tiered_retrieval_config.enabled {
-            use tracing::Instrument as _;
-            let Some(memory) = view.memory.as_deref() else {
-                return Ok(());
-            };
-            let result = tokio::time::timeout(
-                std::time::Duration::from_secs(30),
-                zeph_memory::recall_tiered(
-                    memory,
-                    query,
-                    view.conversation_id,
-                    view.tiered_retrieval_classifier.as_ref(),
-                    view.tiered_retrieval_validator.as_ref(),
-                    &view.tiered_retrieval_config,
-                    Some(token_budget),
-                )
-                .instrument(tracing::info_span!("agent_context.tiered_retrieval.recall")),
-            )
-            .await
-            .map_err(|_| {
-                tracing::warn!("tiered_retrieval: recall_tiered timed out after 30s");
-                ContextError::Memory(zeph_memory::MemoryError::Timeout(
-                    "recall_tiered timed out".to_owned(),
-                ))
-            })?
-            .map_err(ContextError::Memory)?;
-
-            tracing::debug!(
-                intent = %result.intent,
-                tokens_used = result.tokens_used,
-                tier_escalated = result.tier_escalated,
-                count = result.messages.len(),
-                "tiered_retrieval: recall complete"
-            );
-
-            if result.messages.is_empty() {
-                return Ok(());
-            }
-
-            let recalled_text = result
-                .messages
-                .iter()
-                .map(|m| m.message.content.as_str())
-                .collect::<Vec<_>>()
-                .join("\n---\n");
-            Some(Message::from_legacy(
-                Role::User,
-                format!("{RECALL_PREFIX}{recalled_text}"),
-            ))
-        } else {
-            let (msg, _score) = crate::helpers::fetch_semantic_recall_raw(
-                view.memory.as_deref(),
-                view.recall_limit,
-                view.context_format,
-                query,
-                token_budget,
-                &view.token_counter,
-                None,
-                None,
-            )
-            .await?;
-            msg
+        let params = SemanticRecallParams {
+            query,
+            token_budget,
+            recall_limit: view.recall_limit,
+            context_format: view.context_format,
+            conversation_id: view.conversation_id,
+            tiered_classifier: view.tiered_retrieval_classifier.as_ref(),
+            tiered_validator: view.tiered_retrieval_validator.as_ref(),
+            tiered_config: &view.tiered_retrieval_config,
         };
+        let msg = self
+            .run_tiered_recall(&params, window, view.memory.as_deref())
+            .await?;
 
         if let Some(msg) = msg
             && window.messages.len() > 1
@@ -293,37 +269,50 @@ impl ContextService {
     /// # Errors
     ///
     /// Returns [`ContextError::Memory`] if the recall backend returns an error.
-    #[allow(clippy::too_many_arguments)]
     pub async fn inject_semantic_recall_bare(
         &self,
-        query: &str,
-        token_budget: usize,
+        params: SemanticRecallParams<'_>,
         window: &mut MessageWindowView<'_>,
         memory: Option<&zeph_memory::semantic::SemanticMemory>,
-        recall_limit: usize,
-        context_format: zeph_config::ContextFormat,
-        conversation_id: Option<zeph_memory::ConversationId>,
-        tiered_classifier: Option<&std::sync::Arc<zeph_llm::any::AnyProvider>>,
-        tiered_validator: Option<&std::sync::Arc<zeph_llm::any::AnyProvider>>,
-        tiered_config: &zeph_config::memory::TieredRetrievalConfig,
     ) -> Result<(), ContextError> {
         self.remove_recall_messages(window);
 
-        let msg = if tiered_config.enabled {
+        let msg = self.run_tiered_recall(&params, window, memory).await?;
+
+        if let Some(msg) = msg
+            && window.messages.len() > 1
+        {
+            window.messages.insert(1, msg);
+        }
+
+        Ok(())
+    }
+
+    /// Execute tiered or flat semantic recall and return the message to inject, if any.
+    ///
+    /// Both `inject_semantic_recall` and `inject_semantic_recall_bare` share identical
+    /// retrieval logic; this method holds the single implementation.
+    async fn run_tiered_recall(
+        &self,
+        params: &SemanticRecallParams<'_>,
+        window: &MessageWindowView<'_>,
+        memory: Option<&zeph_memory::semantic::SemanticMemory>,
+    ) -> Result<Option<Message>, ContextError> {
+        if params.tiered_config.enabled {
             use tracing::Instrument as _;
             let Some(mem) = memory else {
-                return Ok(());
+                return Ok(None);
             };
             let result = tokio::time::timeout(
                 std::time::Duration::from_secs(30),
                 zeph_memory::recall_tiered(
                     mem,
-                    query,
-                    conversation_id,
-                    tiered_classifier,
-                    tiered_validator,
-                    tiered_config,
-                    Some(token_budget),
+                    params.query,
+                    params.conversation_id,
+                    params.tiered_classifier,
+                    params.tiered_validator,
+                    params.tiered_config,
+                    Some(params.token_budget),
                 )
                 .instrument(tracing::info_span!("agent_context.tiered_retrieval.recall")),
             )
@@ -345,7 +334,7 @@ impl ContextService {
             );
 
             if result.messages.is_empty() {
-                return Ok(());
+                return Ok(None);
             }
 
             let recalled_text = result
@@ -354,32 +343,24 @@ impl ContextService {
                 .map(|m| m.message.content.as_str())
                 .collect::<Vec<_>>()
                 .join("\n---\n");
-            Some(Message::from_legacy(
+            Ok(Some(Message::from_legacy(
                 Role::User,
                 format!("{RECALL_PREFIX}{recalled_text}"),
-            ))
+            )))
         } else {
             let (msg, _score) = crate::helpers::fetch_semantic_recall_raw(
                 memory,
-                recall_limit,
-                context_format,
-                query,
-                token_budget,
+                params.recall_limit,
+                params.context_format,
+                params.query,
+                params.token_budget,
                 &window.token_counter,
                 None,
                 None,
             )
             .await?;
-            msg
-        };
-
-        if let Some(msg) = msg
-            && window.messages.len() > 1
-        {
-            window.messages.insert(1, msg);
+            Ok(msg)
         }
-
-        Ok(())
     }
 
     /// Inject cross-session context messages into the window for the given query.
@@ -485,7 +466,7 @@ impl ContextService {
             prompt,
         )];
         match providers
-            .primary
+            .disambiguate
             .chat_typed::<zeph_skills::IntentClassification>(&messages)
             .await
         {
@@ -2000,22 +1981,22 @@ mod tests {
             let mut completed = HashSet::new();
             let mut window = make_window(&mut msgs, &mut cached, &mut completed);
 
+            let tiered_config = TieredRetrievalConfig {
+                enabled: true,
+                ..TieredRetrievalConfig::default()
+            };
+            let params = SemanticRecallParams {
+                query: "test query",
+                token_budget: 1000,
+                recall_limit: 10,
+                context_format: zeph_config::ContextFormat::default(),
+                conversation_id: None,
+                tiered_classifier: None,
+                tiered_validator: None,
+                tiered_config: &tiered_config,
+            };
             let result = ContextService::new()
-                .inject_semantic_recall_bare(
-                    "test query",
-                    1000,
-                    &mut window,
-                    None,
-                    10,
-                    zeph_config::ContextFormat::default(),
-                    None,
-                    None,
-                    None,
-                    &TieredRetrievalConfig {
-                        enabled: true,
-                        ..TieredRetrievalConfig::default()
-                    },
-                )
+                .inject_semantic_recall_bare(params, &mut window, None)
                 .await;
 
             assert!(

--- a/crates/zeph-agent-context/src/state.rs
+++ b/crates/zeph-agent-context/src/state.rs
@@ -374,6 +374,10 @@ pub struct ProviderHandles {
     pub primary: AnyProvider,
     /// Dedicated embedding provider.
     pub embedding: AnyProvider,
+    /// Provider for skill disambiguation classification calls.
+    ///
+    /// Falls back to `primary` when the `[skills] disambiguate_provider` config field is empty.
+    pub disambiguate: AnyProvider,
 }
 
 /// Abstract status sink for emitting short progress strings to the channel.

--- a/crates/zeph-config/src/features.rs
+++ b/crates/zeph-config/src/features.rs
@@ -331,6 +331,13 @@ pub struct SkillsConfig {
     /// Proactive world-knowledge exploration configuration (#3320).
     #[serde(default)]
     pub proactive_exploration: ProactiveExplorationConfig,
+    /// Provider name for skill disambiguation LLM classification calls.
+    ///
+    /// When set, the named provider is used instead of the primary provider for
+    /// [`ContextService::disambiguate_skills`]. Useful to route disambiguation to a
+    /// cheaper or faster model. When empty (the default), the primary provider is used.
+    #[serde(default)]
+    pub disambiguate_provider: ProviderName,
 }
 
 fn default_generation_timeout_ms() -> u64 {

--- a/crates/zeph-config/src/features.rs
+++ b/crates/zeph-config/src/features.rs
@@ -334,8 +334,8 @@ pub struct SkillsConfig {
     /// Provider name for skill disambiguation LLM classification calls.
     ///
     /// When set, the named provider is used instead of the primary provider for
-    /// [`ContextService::disambiguate_skills`]. Useful to route disambiguation to a
-    /// cheaper or faster model. When empty (the default), the primary provider is used.
+    /// skill disambiguation. Useful to route disambiguation to a cheaper or faster
+    /// model. When empty (the default), the primary provider is used.
     #[serde(default)]
     pub disambiguate_provider: ProviderName,
 }

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -218,6 +218,7 @@ impl Default for Config {
                 mining: crate::features::SkillMiningConfig::default(),
                 evaluation: crate::features::SkillEvaluationConfig::default(),
                 proactive_exploration: crate::features::ProactiveExplorationConfig::default(),
+                disambiguate_provider: crate::providers::ProviderName::default(),
             },
             memory: MemoryConfig {
                 sqlite_path: default_sqlite_path_field(),

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -45,9 +45,12 @@ impl zeph_agent_context::state::SecurityEventSink for SecuritySink<'_> {
 impl<C: Channel> Agent<C> {
     /// Construct a `ProviderHandles` bundle from the agent's primary and embedding providers.
     pub(in crate::agent) fn providers(&self) -> zeph_agent_context::state::ProviderHandles {
+        let disambiguate =
+            self.resolve_background_provider(&self.services.skill.disambiguate_provider_name);
         zeph_agent_context::state::ProviderHandles {
             primary: self.provider.clone(),
             embedding: self.embedding_provider.clone(),
+            disambiguate,
         }
     }
 
@@ -1379,21 +1382,20 @@ impl<C: Channel> Agent<C> {
 
         let svc = zeph_agent_context::ContextService::new();
         let mut window = self.message_window_view();
-
-        svc.inject_semantic_recall_bare(
+        let params = zeph_agent_context::service::SemanticRecallParams {
             query,
             token_budget,
-            &mut window,
-            memory.as_deref(),
             recall_limit,
             context_format,
             conversation_id,
-            tiered_classifier.as_ref(),
-            tiered_validator.as_ref(),
-            &tiered_config,
-        )
-        .await
-        .map_err(|e| super::super::error::AgentError::ContextError(format!("{e:#}")))
+            tiered_classifier: tiered_classifier.as_ref(),
+            tiered_validator: tiered_validator.as_ref(),
+            tiered_config: &tiered_config,
+        };
+
+        svc.inject_semantic_recall_bare(params, &mut window, memory.as_deref())
+            .await
+            .map_err(|e| super::super::error::AgentError::ContextError(format!("{e:#}")))
     }
 
     pub(in crate::agent) fn remove_summary_messages(&mut self) {

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -2966,6 +2966,7 @@ impl<C: Channel> Agent<C> {
         self.runtime.instructions.blocks = new_blocks;
     }
 
+    #[allow(clippy::too_many_lines)]
     fn reload_config(&mut self) {
         let Some(path) = self.runtime.lifecycle.config_path.clone() else {
             return;
@@ -2994,6 +2995,11 @@ impl<C: Channel> Agent<C> {
             .generation_provider
             .as_str()
             .clone_into(&mut self.services.skill.generation_provider_name);
+        config
+            .skills
+            .disambiguate_provider
+            .as_str()
+            .clone_into(&mut self.services.skill.disambiguate_provider_name);
         self.services.skill.generation_timeout_ms = config.skills.generation_timeout_ms;
         self.services.skill.generation_output_dir =
             config.skills.generation_output_dir.as_deref().map(|p| {

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -122,6 +122,8 @@ pub(crate) struct SkillState {
     pub(crate) generation_output_dir: Option<std::path::PathBuf>,
     /// Provider name for `/skill create` generation. Empty = primary.
     pub(crate) generation_provider_name: String,
+    /// Provider name for skill disambiguation LLM calls. Empty = primary.
+    pub(crate) disambiguate_provider_name: String,
     /// Timeout in milliseconds for `/skill create` LLM generation. Default: 60 000.
     pub(crate) generation_timeout_ms: u64,
     /// Optional quality-gate evaluator for generated SKILL.md files (#3319).
@@ -1092,6 +1094,7 @@ impl SkillState {
             rl_warmup_updates: 50,
             generation_output_dir: None,
             generation_provider_name: String::new(),
+            disambiguate_provider_name: String::new(),
             generation_timeout_ms: 60_000,
             skill_evaluator: None,
             eval_weights: zeph_skills::evaluator::EvaluationWeights::default(),


### PR DESCRIPTION
## Summary

- **#4052**: Extract private `run_tiered_recall` helper — eliminates ~70-line duplication between `inject_semantic_recall` and `inject_semantic_recall_bare`
- **#4053**: Replace 11 positional args of `inject_semantic_recall_bare` with `SemanticRecallParams<'a>`; remove `#[allow(clippy::too_many_arguments)]`
- **#4054**: Add `disambiguate_provider: ProviderName` to `SkillsConfig`; `disambiguate_skills` resolves the named provider at construction time, falls back to primary

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 9476 passed, 0 failed

Closes #4052, #4053, #4054