### PR TITLE
fix(config): replace VaultBackend.as_str() with enum match in cocoon and gonka

### DIFF
--- a/src/commands/cocoon.rs
+++ b/src/commands/cocoon.rs
@@ -247,8 +247,9 @@ async fn check_vault_key(
     let _span = tracing::info_span!("cli.cocoon.doctor.vault").entered();
     let vault_args = crate::bootstrap::parse_vault_args(config, None, None, None);
 
-    let vault: Box<dyn VaultProvider> = match vault_args.backend.as_str() {
-        "age" => {
+    use zeph_config::features::VaultBackend;
+    let vault: Box<dyn VaultProvider> = match vault_args.backend {
+        VaultBackend::Age => {
             let (Some(key), Some(path)) = (
                 vault_args.key_path.as_deref(),
                 vault_args.vault_path.as_deref(),
@@ -276,7 +277,7 @@ async fn check_vault_key(
                 }
             }
         }
-        "env" => Box::new(zeph_core::vault::EnvVaultProvider),
+        VaultBackend::Env => Box::new(zeph_core::vault::EnvVaultProvider),
         other => {
             results.push(CheckResult::warn(
                 "cocoon.vault",

--- a/src/commands/gonka.rs
+++ b/src/commands/gonka.rs
@@ -47,8 +47,9 @@ async fn resolve_vault_secrets(
     let _span = tracing::info_span!("cli.gonka.doctor.vault").entered();
     let vault_args = crate::bootstrap::parse_vault_args(config, None, None, None);
 
-    let vault: Box<dyn VaultProvider> = match vault_args.backend.as_str() {
-        "age" => {
+    use zeph_config::features::VaultBackend;
+    let vault: Box<dyn VaultProvider> = match vault_args.backend {
+        VaultBackend::Age => {
             let (Some(key), Some(path)) = (
                 vault_args.key_path.as_deref(),
                 vault_args.vault_path.as_deref(),
@@ -78,15 +79,12 @@ async fn resolve_vault_secrets(
                 }
             }
         }
-        "env" => Box::new(zeph_core::vault::EnvVaultProvider),
-        _ => {
+        VaultBackend::Env => Box::new(zeph_core::vault::EnvVaultProvider),
+        other => {
             let start = Instant::now();
             let r = CheckResult::warn(
                 "gonka.vault.private_key",
-                format!(
-                    "unknown vault backend '{}'; cannot resolve secrets",
-                    vault_args.backend
-                ),
+                format!("unknown vault backend '{other}'; cannot resolve secrets"),
                 elapsed_ms(start),
             );
             let addr_r = CheckResult::warn("gonka.vault.address", "skipped (unknown backend)", 0);

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -427,7 +427,7 @@ where
     (agent, Some(result.executor))
 }
 
-#[cfg(all(test, feature = "scheduler"))]
+#[cfg(all(test, feature = "scheduler", feature = "testing"))]
 mod tests {
     use tokio::sync::mpsc;
     use zeph_core::config::{ScheduledTaskConfig, ScheduledTaskKind};


### PR DESCRIPTION
## Summary

- Replace pre-refactor `match vault_args.backend.as_str()` string patterns in `cocoon.rs` and `gonka.rs` with direct `match vault_args.backend` using `VaultBackend::{Age,Env}` enum arms — fixes P0 compile error introduced by #4051
- Gate `bootstrap_returns_executor` test in `scheduler.rs` on `feature = "testing"` since `AnyProvider::Mock` requires that feature

## Test plan

- [x] `cargo build --features full` — compiles cleanly
- [x] `cargo nextest run --workspace --features full --lib --bins` — 9935 tests pass
- [x] `cargo clippy --workspace --features "desktop,ide,server,chat,pdf,scheduler" -- -D warnings` — clean
- [x] `cargo +nightly fmt --check` — clean

Closes #4068
Closes #4069