### PR TITLE
fix(config): add #[non_exhaustive] to VaultBackend and warn on unknown backend string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   adding protocol variants without breaking downstream matches (closes #3893).
 - `zeph-config`: `ProviderKind`, `RouterStrategyConfig`, `LlmRoutingStrategy`, `CascadeClassifierMode`
   are now `#[non_exhaustive]` for forward compatibility (closes #3893).
+- `zeph-config`: `VaultBackend` is now `#[non_exhaustive]` for consistency with other public
+  enums introduced in ec361936; external exhaustive matches updated with a wildcard arm (closes #4061).
+
+### Fixed
+
+- `parse_backend_str` now emits a `tracing::warn!` when the input string does not match any known
+  vault backend, preventing silent fallback to `VaultBackend::Env` on typos (closes #4062).
 
 ### Dependencies
 

--- a/crates/zeph-config/src/features.rs
+++ b/crates/zeph-config/src/features.rs
@@ -103,6 +103,7 @@ fn default_vault_backend() -> VaultBackend {
 }
 
 /// Selects the vault backend used to resolve secrets at startup.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum VaultBackend {

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -53,7 +53,14 @@ fn parse_backend_str(s: &str) -> VaultBackend {
     match s {
         "age" => VaultBackend::Age,
         "keyring" => VaultBackend::Keyring,
-        _ => VaultBackend::Env,
+        _ => {
+            tracing::warn!(
+                input = s,
+                "unknown vault backend '{}', falling back to env",
+                s
+            );
+            VaultBackend::Env
+        }
     }
 }
 

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -151,6 +151,9 @@ impl AppBuilder {
                     "keyring vault backend is not yet implemented".into(),
                 ));
             }
+            _ => {
+                return Err(BootstrapError::Provider("unsupported vault backend".into()));
+            }
         };
 
         config.resolve_secrets(vault.as_ref()).await?;
@@ -1722,6 +1725,7 @@ pub fn build_vault_provider(args: &VaultArgs) -> Option<Box<dyn VaultProvider>> 
             Some(Box::new(zeph_core::vault::ArcAgeVaultProvider(arc)))
         }
         VaultBackend::Keyring => None,
+        _ => None,
     }
 }
 

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -1724,7 +1724,6 @@ pub fn build_vault_provider(args: &VaultArgs) -> Option<Box<dyn VaultProvider>> 
             let arc = Arc::new(RwLock::new(provider));
             Some(Box::new(zeph_core::vault::ArcAgeVaultProvider(arc)))
         }
-        VaultBackend::Keyring => None,
         _ => None,
     }
 }


### PR DESCRIPTION
## Summary

- `VaultBackend` in `zeph-config` was missing `#[non_exhaustive]`, inconsistent with other public enums added in the same PR (ec361936). External exhaustive matches updated with a wildcard arm.
- `parse_backend_str` now emits `tracing::warn!` when the input string does not match any known vault backend variant, preventing silent fallback to `VaultBackend::Env` on operator typos (e.g. `ZEPH_VAULT_BACKEND=agee`).

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 9476 passed
- [x] Existing `parse_vault_args` tests in `src/bootstrap/tests.rs` exercise the backend resolution path

Closes #4061
Closes #4062