### PR TITLE
refactor: deduplicate hook env, fix visibility leak, add #[non_exhaustive]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `context.trajectory_hints`, `context.tree_memory`) to the three async context fetchers in the
   assembler (closes #3984).
 
+### Refactored
+
+- `zeph-subagent`: extracted `make_base_hook_env` and `TOOL_ARGS_JSON_LIMIT` into
+  `zeph-subagent::hooks`, eliminating duplicate env-building logic between subagent and
+  core tier-loop hook dispatch (closes #4015).
+- `zeph-agent-feedback`: `JudgeDetector::call_times` is now a private field; switched
+  `VecDeque<Instant>` from `std::time::Instant` to `tokio::time::Instant` to enable
+  deterministic time control in tests (closes #3988).
+- `zeph-sanitizer`: `ContentTrustLevel` and `ContentSourceKind` are now `#[non_exhaustive]`
+  to allow adding variants without breaking external exhaustive matches (closes #3932).
+
 ### Changed
 
 - `zeph-commands`: `GoalCommand::handle` now propagates errors via `?` instead of silently converting

--- a/crates/zeph-agent-feedback/src/lib.rs
+++ b/crates/zeph-agent-feedback/src/lib.rs
@@ -31,7 +31,9 @@
 
 use std::collections::VecDeque;
 use std::sync::LazyLock;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+
+use tokio::time::Instant;
 
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -593,7 +595,7 @@ pub struct JudgeDetector {
     /// Upper bound: at or above this, regex "is correction" is trusted without judge.
     adaptive_high: f32,
     /// Sliding-window timestamps for rate limiting (owned, not shared across spawns).
-    pub(crate) call_times: VecDeque<Instant>,
+    call_times: VecDeque<Instant>,
 }
 
 impl JudgeDetector {
@@ -1114,21 +1116,19 @@ mod tests {
         assert!(!jd.check_rate_limit(), "should block after limit exceeded");
     }
 
-    #[test]
-    fn rate_limiter_evicts_expired_entries() {
+    #[tokio::test]
+    async fn rate_limiter_evicts_expired_entries() {
+        tokio::time::pause();
         let mut jd = JudgeDetector::new(0.5, 0.8);
-        let expired = Instant::now()
-            .checked_sub(JUDGE_RATE_WINDOW)
-            .and_then(|t| t.checked_sub(Duration::from_secs(1)))
-            .unwrap();
         for _ in 0..JUDGE_RATE_LIMIT {
-            jd.call_times.push_back(expired);
+            assert!(jd.check_rate_limit());
         }
+        // Advance time past the rate-limit window so all entries expire.
+        tokio::time::advance(JUDGE_RATE_WINDOW + Duration::from_secs(1)).await;
         assert!(
             jd.check_rate_limit(),
             "expired entries should be evicted, new call must be allowed"
         );
-        assert_eq!(jd.call_times.len(), 1, "only the new entry remains");
     }
 
     // ── GAP-01: reasoning field defaults to empty string ──────────────────

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -16,37 +16,12 @@ use super::{
 use crate::agent::Agent;
 use crate::channel::{Channel, StopHint, ToolStartEvent};
 
-/// Maximum byte length of `ZEPH_TOOL_ARGS_JSON`. OS `ARG_MAX` is ~1 MB on macOS and ~2 MB on
-/// Linux; staying well below that avoids `E2BIG` when spawning hook processes.
-const TOOL_ARGS_JSON_LIMIT: usize = 64 * 1024;
-
-/// Build the base env map for `pre_tool_use` / `post_tool_use` hook dispatch.
-///
-/// `ZEPH_TOOL_ARGS_JSON` is truncated to [`TOOL_ARGS_JSON_LIMIT`] bytes when the serialized
-/// argument object would exceed the OS `ARG_MAX` limit.
 fn make_tool_hook_env(
     tool_name: &str,
     tool_input: &serde_json::Value,
     session_id: Option<&str>,
 ) -> std::collections::HashMap<String, String> {
-    let mut env = std::collections::HashMap::new();
-    env.insert("ZEPH_TOOL_NAME".to_owned(), tool_name.to_owned());
-
-    let raw = serde_json::to_string(tool_input).unwrap_or_default();
-    let args_json = if raw.len() > TOOL_ARGS_JSON_LIMIT {
-        tracing::warn!(
-            tool = tool_name,
-            len = raw.len(),
-            limit = TOOL_ARGS_JSON_LIMIT,
-            "ZEPH_TOOL_ARGS_JSON truncated for hook dispatch"
-        );
-        let limit = raw.floor_char_boundary(TOOL_ARGS_JSON_LIMIT);
-        format!("{}…", &raw[..limit])
-    } else {
-        raw
-    };
-    env.insert("ZEPH_TOOL_ARGS_JSON".to_owned(), args_json);
-
+    let mut env = zeph_subagent::make_base_hook_env(tool_name, tool_input);
     if let Some(sid) = session_id {
         env.insert("ZEPH_SESSION_ID".to_owned(), sid.to_owned());
     }
@@ -2350,6 +2325,7 @@ fn build_gated_defs_for_iteration(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use zeph_subagent::TOOL_ARGS_JSON_LIMIT;
 
     fn json_val(s: &str) -> serde_json::Value {
         serde_json::from_str(s).unwrap()

--- a/crates/zeph-sanitizer/src/types.rs
+++ b/crates/zeph-sanitizer/src/types.rs
@@ -34,6 +34,7 @@ use serde::{Deserialize, Serialize};
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum ContentTrustLevel {
     /// System prompt, hardcoded instructions, direct user input. No wrapping applied.
     Trusted,
@@ -64,6 +65,7 @@ pub enum ContentTrustLevel {
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum ContentSourceKind {
     /// Output from a locally-executed tool (shell, file I/O).
     ToolResult,

--- a/crates/zeph-subagent/src/agent_loop.rs
+++ b/crates/zeph-subagent/src/agent_loop.rs
@@ -14,7 +14,7 @@ use zeph_tools::executor::{ErasedToolExecutor, ToolCall};
 
 use super::filter::FilteredToolExecutor;
 use super::grants::SecretRequest;
-use super::hooks::{HookDef, SubagentHooks, fire_hooks, matching_hooks};
+use super::hooks::{HookDef, SubagentHooks, fire_hooks, make_base_hook_env, matching_hooks};
 use super::manager::SubAgentStatus;
 use super::state::SubAgentState;
 use super::transcript::TranscriptWriter;
@@ -27,35 +27,15 @@ enum SecretRequestOutcome {
     Cancelled,
 }
 
-/// Maximum byte length of `ZEPH_TOOL_ARGS_JSON` to avoid `E2BIG` when spawning hook processes.
-const TOOL_ARGS_JSON_LIMIT: usize = 64 * 1024;
-
 fn make_hook_env(
     task_id: &str,
     agent_name: &str,
     tool_name: &str,
     tool_input: &serde_json::Value,
 ) -> std::collections::HashMap<String, String> {
-    let mut env = std::collections::HashMap::new();
+    let mut env = make_base_hook_env(tool_name, tool_input);
     env.insert("ZEPH_AGENT_ID".to_owned(), task_id.to_owned());
     env.insert("ZEPH_AGENT_NAME".to_owned(), agent_name.to_owned());
-    env.insert("ZEPH_TOOL_NAME".to_owned(), tool_name.to_owned());
-
-    let raw = serde_json::to_string(tool_input).unwrap_or_default();
-    let args_json = if raw.len() > TOOL_ARGS_JSON_LIMIT {
-        tracing::warn!(
-            tool = tool_name,
-            len = raw.len(),
-            limit = TOOL_ARGS_JSON_LIMIT,
-            "ZEPH_TOOL_ARGS_JSON truncated for hook dispatch"
-        );
-        let limit = raw.floor_char_boundary(TOOL_ARGS_JSON_LIMIT);
-        format!("{}…", &raw[..limit])
-    } else {
-        raw
-    };
-    env.insert("ZEPH_TOOL_ARGS_JSON".to_owned(), args_json);
-
     env
 }
 
@@ -715,6 +695,7 @@ pub(super) async fn run_agent_loop(
 
 #[cfg(test)]
 mod make_hook_env_tests {
+    use super::super::hooks::TOOL_ARGS_JSON_LIMIT;
     use super::*;
 
     #[test]

--- a/crates/zeph-subagent/src/hooks.rs
+++ b/crates/zeph-subagent/src/hooks.rs
@@ -233,6 +233,57 @@ pub fn matching_hooks<'a>(matchers: &'a [HookMatcher], tool_name: &str) -> Vec<&
     result
 }
 
+// ── Hook env helpers ──────────────────────────────────────────────────────────
+
+/// Maximum byte length of `ZEPH_TOOL_ARGS_JSON` to avoid `E2BIG` when spawning hook processes.
+///
+/// OS `ARG_MAX` is ~1 MB on macOS and ~2 MB on Linux; staying well below that avoids `E2BIG`.
+pub const TOOL_ARGS_JSON_LIMIT: usize = 64 * 1024;
+
+/// Build the common hook environment variables shared by all hook dispatch sites.
+///
+/// Sets `ZEPH_TOOL_NAME` and `ZEPH_TOOL_ARGS_JSON`. The serialized `tool_input` is
+/// truncated to [`TOOL_ARGS_JSON_LIMIT`] bytes at a valid UTF-8 boundary when it
+/// would exceed the OS `ARG_MAX` limit.
+///
+/// Callers should extend the returned map with site-specific variables such as
+/// `ZEPH_AGENT_ID`, `ZEPH_AGENT_NAME`, or `ZEPH_SESSION_ID`.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_subagent::make_base_hook_env;
+///
+/// let env = make_base_hook_env("Edit", &serde_json::Value::Null);
+/// assert_eq!(env["ZEPH_TOOL_NAME"], "Edit");
+/// assert!(env.contains_key("ZEPH_TOOL_ARGS_JSON"));
+/// ```
+#[must_use]
+pub fn make_base_hook_env(
+    tool_name: &str,
+    tool_input: &serde_json::Value,
+) -> HashMap<String, String> {
+    let mut env = HashMap::new();
+    env.insert("ZEPH_TOOL_NAME".to_owned(), tool_name.to_owned());
+
+    let raw = serde_json::to_string(tool_input).unwrap_or_default();
+    let args_json = if raw.len() > TOOL_ARGS_JSON_LIMIT {
+        tracing::warn!(
+            tool = tool_name,
+            len = raw.len(),
+            limit = TOOL_ARGS_JSON_LIMIT,
+            "ZEPH_TOOL_ARGS_JSON truncated for hook dispatch"
+        );
+        let limit = raw.floor_char_boundary(TOOL_ARGS_JSON_LIMIT);
+        format!("{}…", &raw[..limit])
+    } else {
+        raw
+    };
+    env.insert("ZEPH_TOOL_ARGS_JSON".to_owned(), args_json);
+
+    env
+}
+
 // ── Execution ─────────────────────────────────────────────────────────────────
 
 /// Execute a list of hook definitions, setting the provided environment variables.

--- a/crates/zeph-subagent/src/lib.rs
+++ b/crates/zeph-subagent/src/lib.rs
@@ -61,7 +61,8 @@ pub use filter::{FilteredToolExecutor, PlanModeExecutor, filter_skills};
 pub use grants::{Grant, GrantKind, PermissionGrants, SecretRequest};
 pub use hooks::{
     HookAction, HookDef, HookError, HookMatcher, HookOutput, HookRunResult, McpDispatch,
-    PostToolUseHookInput, SubagentHooks, fire_hooks, matching_hooks,
+    PostToolUseHookInput, SubagentHooks, TOOL_ARGS_JSON_LIMIT, fire_hooks, make_base_hook_env,
+    matching_hooks,
 };
 pub use manager::{SpawnContext, SubAgentHandle, SubAgentManager, SubAgentStatus};
 pub use memory::{ensure_memory_dir, load_memory_content};


### PR DESCRIPTION
## Summary

- **#4015**: extract `make_base_hook_env` + `TOOL_ARGS_JSON_LIMIT` to `zeph-subagent/hooks.rs`; both `agent_loop.rs` and `tier_loop.rs` delegate to the shared function and only add site-specific keys (`ZEPH_AGENT_ID`/`ZEPH_AGENT_NAME` vs `ZEPH_SESSION_ID`)
- **#3988**: make `JudgeDetector.call_times` private; rewrite rate-limiter test to use `tokio::time::pause()` + `advance()` instead of direct field manipulation
- **#3932**: add `#[non_exhaustive]` to `ContentSourceKind` and `ContentTrustLevel` in `zeph-sanitizer` to allow future variants without breaking downstream exhaustive matches

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 9474/9474 passed
- [x] Rebased on origin/main

Closes #4015
Closes #3988
Closes #3932