### PR TITLE
refactor(commands): extract exit logic, fix error returns, fix LogCommand description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `zeph-commands`: `ExitCommand` and `QuitCommand` exit logic extracted into a shared `handle_exit`
+  helper, eliminating duplicate `handle()` bodies (closes #4094).
+- `zeph-commands`: `ImageCommand` and `SchedulerCommand` now return `Err(CommandError)` for invalid
+  arguments instead of `Ok(CommandOutput::Message)`, making error propagation consistent with other
+  handlers (closes #4095).
+- `zeph-commands`: `LogCommand::description()` corrected from `"Toggle verbose log output"` to
+  `"Show log tail and current log file path"` to match the handler's actual behavior (closes #4093).
 - `zeph-commands`: `GoalCommand::handle` now propagates errors via `?` instead of silently converting
   them to a display string with `unwrap_or_else` (closes #3933).
 - `zeph-commands`: shared test mock types (`MockDebug`, `MockMessages`, `MockSession`, `make_ctx`)

--- a/crates/zeph-commands/src/handlers/debug.rs
+++ b/crates/zeph-commands/src/handlers/debug.rs
@@ -19,7 +19,7 @@ impl CommandHandler<CommandContext<'_>> for LogCommand {
     }
 
     fn description(&self) -> &'static str {
-        "Toggle verbose log output"
+        "Show log tail and current log file path"
     }
 
     fn category(&self) -> SlashCategory {

--- a/crates/zeph-commands/src/handlers/misc.rs
+++ b/crates/zeph-commands/src/handlers/misc.rs
@@ -108,7 +108,7 @@ impl CommandHandler<CommandContext<'_>> for ImageCommand {
         Box::pin(
             async move {
                 if args.is_empty() {
-                    return Ok(CommandOutput::Message("Usage: /image <path>".to_owned()));
+                    return Err(CommandError::new("Usage: /image <path>"));
                 }
                 let result = ctx.agent.load_image(args).await?;
                 Ok(CommandOutput::Message(result))
@@ -167,18 +167,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn image_no_args_returns_usage_hint() {
+    async fn image_no_args_returns_error() {
         let mut sink = NullSink;
         let mut debug = MockDebug;
         let mut messages = MockMessages;
         let session = MockSession;
         let mut agent = crate::NullAgent;
         let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
-        let out = ImageCommand.handle(&mut ctx, "").await.unwrap();
-        let CommandOutput::Message(msg) = out else {
-            panic!("expected Message")
-        };
-        assert!(msg.contains("/image"));
+        let err = ImageCommand.handle(&mut ctx, "").await.unwrap_err();
+        assert!(err.to_string().contains("/image"));
     }
 
     #[tokio::test]

--- a/crates/zeph-commands/src/handlers/scheduler.rs
+++ b/crates/zeph-commands/src/handlers/scheduler.rs
@@ -45,8 +45,8 @@ impl CommandHandler<CommandContext<'_>> for SchedulerCommand {
         Box::pin(
             async move {
                 if !args.is_empty() && args != "list" {
-                    return Ok(CommandOutput::Message(
-                        "Unknown /scheduler subcommand. Available: /scheduler list".to_owned(),
+                    return Err(CommandError::new(
+                        "Unknown /scheduler subcommand. Available: /scheduler list",
                     ));
                 }
                 match ctx.agent.list_scheduled_tasks().await? {
@@ -91,17 +91,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn scheduler_unknown_subcommand_returns_error_message() {
+    async fn scheduler_unknown_subcommand_returns_error() {
         let mut sink = NullSink;
         let mut debug = MockDebug;
         let mut messages = MockMessages;
         let session = MockSession;
         let mut agent = crate::NullAgent;
         let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
-        let out = SchedulerCommand.handle(&mut ctx, "start").await.unwrap();
-        let CommandOutput::Message(msg) = out else {
-            panic!("expected Message")
-        };
-        assert!(msg.contains("Unknown") || msg.contains("Available"));
+        let err = SchedulerCommand
+            .handle(&mut ctx, "start")
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("Unknown") || err.to_string().contains("Available"));
     }
 }

--- a/crates/zeph-commands/src/handlers/session.rs
+++ b/crates/zeph-commands/src/handlers/session.rs
@@ -10,6 +10,17 @@ use crate::CommandHandler;
 use crate::context::CommandContext;
 use crate::{CommandError, CommandOutput, SlashCategory};
 
+async fn handle_exit(ctx: &mut CommandContext<'_>) -> Result<CommandOutput, CommandError> {
+    if ctx.session.supports_exit() {
+        Ok(CommandOutput::Exit)
+    } else {
+        ctx.sink
+            .send("/exit is not supported in this channel.")
+            .await?;
+        Ok(CommandOutput::Continue)
+    }
+}
+
 /// Exit the agent loop.
 ///
 /// `/exit` and `/quit` are treated as aliases; both map to this handler via the registry.
@@ -37,19 +48,7 @@ impl CommandHandler<CommandContext<'_>> for ExitCommand {
     ) -> Pin<Box<dyn Future<Output = Result<CommandOutput, CommandError>> + Send + 'a>> {
         use tracing::Instrument as _;
         let span = tracing::info_span!("commands.exit.handle");
-        Box::pin(
-            async move {
-                if ctx.session.supports_exit() {
-                    Ok(CommandOutput::Exit)
-                } else {
-                    ctx.sink
-                        .send("/exit is not supported in this channel.")
-                        .await?;
-                    Ok(CommandOutput::Continue)
-                }
-            }
-            .instrument(span),
-        )
+        Box::pin(async move { handle_exit(ctx).await }.instrument(span))
     }
 }
 
@@ -76,19 +75,7 @@ impl CommandHandler<CommandContext<'_>> for QuitCommand {
     ) -> Pin<Box<dyn Future<Output = Result<CommandOutput, CommandError>> + Send + 'a>> {
         use tracing::Instrument as _;
         let span = tracing::info_span!("commands.quit.handle");
-        Box::pin(
-            async move {
-                if ctx.session.supports_exit() {
-                    Ok(CommandOutput::Exit)
-                } else {
-                    ctx.sink
-                        .send("/exit is not supported in this channel.")
-                        .await?;
-                    Ok(CommandOutput::Continue)
-                }
-            }
-            .instrument(span),
-        )
+        Box::pin(async move { handle_exit(ctx).await }.instrument(span))
     }
 }
 


### PR DESCRIPTION
## Summary

- Extract shared `handle_exit()` helper in `session.rs`; `QuitCommand::handle()` now delegates to it instead of duplicating the body (closes #4094)
- `ImageCommand` and `SchedulerCommand` return `Err(CommandError)` for invalid arguments instead of `Ok(CommandOutput::Message)`, consistent with all other handlers (closes #4095)
- `LogCommand::description()` corrected from `"Toggle verbose log output"` to `"Show log tail and current log file path"` to match actual handler behavior (closes #4093)

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins` — 9474 passed, 0 failed
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `image_no_args_returns_error` and `scheduler_unknown_subcommand_returns_error` tests updated to use `unwrap_err()`