### PR TITLE
perf(orchestration): add tracing spans to adaptorch and DagScheduler

### DIFF
--- a/crates/zeph-orchestration/src/adaptorch.rs
+++ b/crates/zeph-orchestration/src/adaptorch.rs
@@ -229,6 +229,7 @@ impl TopologyAdvisor {
     /// Classify the goal and sample the best topology hint for this turn.
     ///
     /// Classification failures fall back to `TaskClass::Unknown` + `TopologyHint::Hybrid`.
+    #[tracing::instrument(name = "orchestration.adaptorch.recommend", skip(self), fields(goal_len = goal.len()))]
     pub async fn recommend(&self, goal: &str) -> AdvisorVerdict {
         self.metrics.classify_calls.fetch_add(1, Ordering::Relaxed);
 
@@ -320,6 +321,7 @@ impl TopologyAdvisor {
 
     // ─── private helpers ─────────────────────────────────────────────────────
 
+    #[tracing::instrument(name = "orchestration.adaptorch.classify", skip(self), fields(goal_len = goal.len()))]
     async fn classify(&self, goal: &str) -> TaskClass {
         let truncated: String = goal.chars().take(400).collect();
         let system = "\

--- a/crates/zeph-orchestration/src/scheduler/tick.rs
+++ b/crates/zeph-orchestration/src/scheduler/tick.rs
@@ -250,6 +250,7 @@ impl DagScheduler {
     /// Returns immediately — sleeping for the current deferral backoff — when no tasks
     /// are running. Uses a deadline derived from the nearest task timeout so that
     /// periodic timeout checking occurs even when no events arrive.
+    #[tracing::instrument(name = "orchestration.scheduler.wait_event", skip(self), fields(running = self.running.len()))]
     pub async fn wait_event(&mut self) {
         if self.running.is_empty() {
             tokio::time::sleep(self.current_deferral_backoff()).await;


### PR DESCRIPTION
## Summary

- Add `#[tracing::instrument]` to `TopologyAdvisor::recommend` and `TopologyAdvisor::classify` with span names `orchestration.adaptorch.recommend` / `orchestration.adaptorch.classify` and `goal_len` field — LLM classification latency is now visible in local Chrome JSON traces and Jaeger
- Add `#[tracing::instrument]` to `DagScheduler::wait_event` with span name `orchestration.scheduler.wait_event` and `running` field — scheduler blocking time is now distinguishable from task execution latency in traces

## Test plan

- [ ] `cargo clippy -p zeph-orchestration -- -D warnings` — clean
- [ ] `cargo nextest run -p zeph-orchestration --lib` — 363 passed
- [ ] `cargo +nightly fmt --check -p zeph-orchestration` — clean
- [ ] Run live session with `backend = "local"` telemetry, open trace in Perfetto — verify `orchestration.adaptorch.recommend`, `orchestration.adaptorch.classify`, and `orchestration.scheduler.wait_event` spans appear

Closes #4107
Closes #4108