### PR TITLE
perf(context): instrument remaining 7 assembler fetch_* functions with tracing spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   assembler (closes #3984).
 - `zeph-context`: `run_chunk_summaries` now converts the `guidelines` string to `Arc<str>` once
   before the chunk iterator, replacing a `String` clone per chunk with a cheap `Arc` clone (closes #3991).
+- `zeph-context`: added `tracing::instrument` spans to the remaining 7 uninstrumented `fetch_*`
+  functions in the assembler (`context.graph_facts`, `context.reasoning_strategies`,
+  `context.corrections`, `context.semantic_recall`, `context.document_rag`, `context.summaries`,
+  `context.cross_session`), completing full hot-path trace coverage (closes #4092).
 
 ### Refactored
 

--- a/crates/zeph-context/src/assembler.rs
+++ b/crates/zeph-context/src/assembler.rs
@@ -386,6 +386,7 @@ pub fn effective_recall_timeout_ms(configured: u64) -> u64 {
 
 use crate::input::ContextMemoryView;
 
+#[tracing::instrument(name = "context.graph_facts", skip_all)]
 #[allow(clippy::too_many_lines)] // single-pass view-aware enrichment pipeline
 pub(crate) async fn fetch_graph_facts(
     memory: &ContextMemoryView,
@@ -668,6 +669,7 @@ pub(crate) async fn fetch_tree_memory(
     Ok(Some(Message::from_legacy(Role::System, body)))
 }
 
+#[tracing::instrument(name = "context.reasoning_strategies", skip_all)]
 pub(crate) async fn fetch_reasoning_strategies(
     memory: &ContextMemoryView,
     query: &str,
@@ -729,6 +731,7 @@ pub(crate) async fn fetch_reasoning_strategies(
     Ok(Some(Message::from_legacy(Role::System, body)))
 }
 
+#[tracing::instrument(name = "context.corrections", skip_all)]
 pub(crate) async fn fetch_corrections(
     memory: &ContextMemoryView,
     query: &str,
@@ -755,6 +758,7 @@ pub(crate) async fn fetch_corrections(
     Ok(Some(Message::from_legacy(Role::System, text)))
 }
 
+#[tracing::instrument(name = "context.semantic_recall", skip_all)]
 pub(crate) async fn fetch_semantic_recall(
     memory: &ContextMemoryView,
     query: &str,
@@ -809,6 +813,7 @@ pub(crate) async fn fetch_semantic_recall(
     }
 }
 
+#[tracing::instrument(name = "context.document_rag", skip_all)]
 pub(crate) async fn fetch_document_rag(
     memory: &ContextMemoryView,
     query: &str,
@@ -860,6 +865,7 @@ pub(crate) async fn fetch_document_rag(
     }
 }
 
+#[tracing::instrument(name = "context.summaries", skip_all)]
 pub(crate) async fn fetch_summaries(
     memory: &ContextMemoryView,
     token_budget: usize,
@@ -905,6 +911,7 @@ pub(crate) async fn fetch_summaries(
     }
 }
 
+#[tracing::instrument(name = "context.cross_session", skip_all)]
 pub(crate) async fn fetch_cross_session(
     memory: &ContextMemoryView,
     query: &str,


### PR DESCRIPTION
## Summary

- Adds `#[tracing::instrument(name = "context.<fn_suffix>", skip_all)]` to the 7 previously uninstrumented `fetch_*` functions in `crates/zeph-context/src/assembler.rs`
- All 10 `fetch_*` functions in the context assembler now have tracing spans, completing full hot-path coverage for Perfetto/Chrome JSON trace analysis
- Verified that all listed `pub` items in `zeph-agent-context` (`state.rs`, `retrieved.rs`) already had complete `///` doc comments — no source changes needed for #4058

## Functions instrumented

| Function | Span name |
|---|---|
| `fetch_graph_facts` | `context.graph_facts` |
| `fetch_reasoning_strategies` | `context.reasoning_strategies` |
| `fetch_corrections` | `context.corrections` |
| `fetch_semantic_recall` | `context.semantic_recall` |
| `fetch_document_rag` | `context.document_rag` |
| `fetch_summaries` | `context.summaries` |
| `fetch_cross_session` | `context.cross_session` |

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 9474 passed, 0 failed

Closes #4092
Closes #4058