### PR TITLE
fix(memory,agent): fix postgres compile failure and skill provider startup init

### DIFF
--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -345,6 +345,21 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Set the LLM provider names for skill generation and disambiguation.
+    ///
+    /// Both names are resolved at runtime via the provider registry. An empty string falls back
+    /// to the primary provider.
+    #[must_use]
+    pub fn with_skill_provider_names(
+        mut self,
+        generation_provider_name: String,
+        disambiguate_provider_name: String,
+    ) -> Self {
+        self.services.skill.generation_provider_name = generation_provider_name;
+        self.services.skill.disambiguate_provider_name = disambiguate_provider_name;
+        self
+    }
+
     /// Override the embedding model name used for skill matching.
     #[must_use]
     pub fn with_embedding_model(mut self, model: String) -> Self {

--- a/crates/zeph-memory/src/graph/store/mod.rs
+++ b/crates/zeph-memory/src/graph/store/mod.rs
@@ -235,7 +235,7 @@ impl GraphStore {
     /// # Errors
     ///
     /// Returns an error if the PRAGMA execution fails.
-    #[cfg(feature = "sqlite")]
+    #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
     pub async fn checkpoint_wal(&self) -> Result<(), MemoryError> {
         zeph_db::query("PRAGMA wal_checkpoint(PASSIVE)")
             .execute(&self.pool)
@@ -249,6 +249,7 @@ impl GraphStore {
     ///
     /// Never returns an error.
     #[cfg(feature = "postgres")]
+    #[allow(clippy::unused_async)]
     pub async fn checkpoint_wal(&self) -> Result<(), MemoryError> {
         Ok(())
     }
@@ -2135,7 +2136,7 @@ impl GraphStore {
 
 // ── Dialect helpers ───────────────────────────────────────────────────────────
 
-#[cfg(feature = "sqlite")]
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
 fn community_ids_sql(placeholders: &str) -> String {
     format!(
         "SELECT CAST(j.value AS INTEGER) AS entity_id, c.id AS community_id

--- a/crates/zeph-memory/src/response_cache.rs
+++ b/crates/zeph-memory/src/response_cache.rs
@@ -111,7 +111,7 @@ impl ResponseCache {
         ))
         .bind(embedding_model)
         .bind(now)
-        .bind(max_candidates)
+        .bind(i64::from(max_candidates))
         .fetch_all(&self.pool)
         .await?;
 

--- a/crates/zeph-memory/src/store/corrections.rs
+++ b/crates/zeph-memory/src/store/corrections.rs
@@ -85,7 +85,7 @@ impl SqliteStore {
              ORDER BY id DESC LIMIT ?"
         ))
         .bind(skill_name)
-        .bind(limit)
+        .bind(i64::from(limit))
         .fetch_all(&self.pool)
         .await?;
         Ok(rows.into_iter().map(row_from_tuple).collect())
@@ -105,7 +105,7 @@ impl SqliteStore {
              skill_name, correction_kind, created_at \
              FROM user_corrections ORDER BY id DESC LIMIT ?"
         ))
-        .bind(limit)
+        .bind(i64::from(limit))
         .fetch_all(&self.pool)
         .await?;
         Ok(rows.into_iter().map(row_from_tuple).collect())

--- a/crates/zeph-memory/src/store/experiments.rs
+++ b/crates/zeph-memory/src/store/experiments.rs
@@ -169,7 +169,7 @@ impl SqliteStore {
                  FROM experiment_results WHERE session_id = ? ORDER BY id DESC LIMIT ?"
             ))
             .bind(sid)
-            .bind(limit)
+            .bind(i64::from(limit))
             .fetch_all(&self.pool)
             .await?
         } else {
@@ -178,7 +178,7 @@ impl SqliteStore {
                  delta, latency_ms, tokens_used, accepted, source, created_at \
                  FROM experiment_results ORDER BY id DESC LIMIT ?"
             ))
-            .bind(limit)
+            .bind(i64::from(limit))
             .fetch_all(&self.pool)
             .await?
         };

--- a/crates/zeph-memory/src/store/graph_store.rs
+++ b/crates/zeph-memory/src/store/graph_store.rs
@@ -119,6 +119,7 @@ impl RawGraphStore for TaskGraphStore {
         Ok(())
     }
 
+    #[cfg(not(feature = "postgres"))]
     async fn load_graph(&self, id: &str) -> Result<Option<String>, MemoryError> {
         let row: Option<(String,)> =
             zeph_db::query_as(sql!("SELECT graph_json FROM task_graphs WHERE id = ?"))
@@ -129,6 +130,7 @@ impl RawGraphStore for TaskGraphStore {
         Ok(row.map(|(json,)| json))
     }
 
+    #[cfg(not(feature = "postgres"))]
     async fn list_graphs(&self, limit: u32) -> Result<Vec<GraphSummary>, MemoryError> {
         let rows: Vec<(String, String, String, String, Option<String>)> = zeph_db::query_as(sql!(
             "SELECT id, goal, status, created_at, finished_at \
@@ -149,6 +151,45 @@ impl RawGraphStore for TaskGraphStore {
                 status,
                 created_at,
                 finished_at,
+            })
+            .collect())
+    }
+
+    #[cfg(feature = "postgres")]
+    async fn load_graph(&self, id: &str) -> Result<Option<String>, MemoryError> {
+        let row: Option<String> = sqlx::query_scalar::<sqlx::Postgres, String>(sql!(
+            "SELECT graph_json FROM task_graphs WHERE id = ?"
+        ))
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| MemoryError::GraphStore(e.to_string()))?;
+        Ok(row)
+    }
+
+    #[cfg(feature = "postgres")]
+    async fn list_graphs(&self, limit: u32) -> Result<Vec<GraphSummary>, MemoryError> {
+        use sqlx::Row as _;
+
+        let rows = sqlx::query::<sqlx::Postgres>(sql!(
+            "SELECT id, goal, status, created_at, finished_at \
+             FROM task_graphs \
+             ORDER BY created_at DESC \
+             LIMIT ?"
+        ))
+        .bind(i64::from(limit))
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| MemoryError::GraphStore(e.to_string()))?;
+
+        Ok(rows
+            .into_iter()
+            .map(|row| GraphSummary {
+                id: row.get("id"),
+                goal: row.get("goal"),
+                status: row.get("status"),
+                created_at: row.get("created_at"),
+                finished_at: row.get("finished_at"),
             })
             .collect())
     }

--- a/crates/zeph-memory/src/store/messages/mod.rs
+++ b/crates/zeph-memory/src/store/messages/mod.rs
@@ -272,7 +272,7 @@ impl SqliteStore {
              ) ORDER BY id ASC"
         ))
         .bind(conversation_id)
-        .bind(limit)
+        .bind(i64::from(limit))
         .fetch_all(&self.pool)
         .await?;
 
@@ -334,7 +334,7 @@ impl SqliteStore {
         .bind(conversation_id)
         .bind(exclude_user_only)
         .bind(exclude_agent_only)
-        .bind(limit)
+        .bind(i64::from(limit))
         .fetch_all(&self.pool)
         .await?;
 
@@ -491,7 +491,7 @@ impl SqliteStore {
             sql!("SELECT id FROM messages WHERE conversation_id = ? AND deleted_at IS NULL ORDER BY id ASC LIMIT ?"),
         )
         .bind(conversation_id)
-        .bind(n)
+        .bind(i64::from(n))
         .fetch_all(&self.pool)
         .await?;
         Ok(rows.into_iter().map(|r| r.0).collect())

--- a/crates/zeph-memory/src/store/preferences.rs
+++ b/crates/zeph-memory/src/store/preferences.rs
@@ -135,7 +135,7 @@ impl SqliteStore {
              ORDER BY id ASC LIMIT ?"
         ))
         .bind(after_id)
-        .bind(limit)
+        .bind(i64::from(limit))
         .fetch_all(&self.pool)
         .await?;
 

--- a/crates/zeph-memory/src/store/skills.rs
+++ b/crates/zeph-memory/src/store/skills.rs
@@ -461,6 +461,7 @@ impl SqliteStore {
     /// # Errors
     ///
     /// Returns an error if the delete fails.
+    #[cfg(not(feature = "postgres"))]
     pub async fn prune_skill_versions(
         &self,
         skill_name: &str,
@@ -478,6 +479,32 @@ impl SqliteStore {
         .bind(skill_name)
         .bind(skill_name)
         .bind(max_versions)
+        .execute(&self.pool)
+        .await?;
+        Ok(u32::try_from(result.rows_affected()).unwrap_or(0))
+    }
+
+    /// Prune old auto-generated skill versions, keeping only the most recent `max_versions`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database query fails.
+    #[cfg(feature = "postgres")]
+    pub async fn prune_skill_versions(
+        &self,
+        skill_name: &str,
+        max_versions: u32,
+    ) -> Result<u32, MemoryError> {
+        let result = zeph_db::query(sql!(
+            "DELETE FROM skill_versions WHERE id IN (\
+                SELECT id FROM skill_versions \
+                WHERE skill_name = ? AND source = 'auto' AND is_active = 0 \
+                ORDER BY id DESC \
+                OFFSET ?\
+            )"
+        ))
+        .bind(skill_name)
+        .bind(i64::from(max_versions))
         .execute(&self.pool)
         .await?;
         Ok(u32::try_from(result.rows_affected()).unwrap_or(0))
@@ -569,6 +596,7 @@ impl SqliteStore {
     ///
     /// # Errors
     /// Returns [`MemoryError`] on query failure.
+    #[cfg(not(feature = "postgres"))]
     pub async fn find_recurring_patterns(
         &self,
         min_count: u32,
@@ -603,16 +631,74 @@ impl SqliteStore {
             .collect())
     }
 
+    /// Find tool+skill combinations used at least `min_count` times within `window_days` days.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database query fails.
+    #[cfg(feature = "postgres")]
+    pub async fn find_recurring_patterns(
+        &self,
+        min_count: u32,
+        window_days: u32,
+    ) -> Result<Vec<(String, String, u32, u32)>, MemoryError> {
+        let rows: Vec<(String, String, i64, i64)> = zeph_db::query_as(sql!(
+            "SELECT tool_sequence, sequence_hash, \
+                    COUNT(*) as occurrence_count, \
+                    SUM(CASE WHEN outcome = 'success' THEN 1 ELSE 0 END) as success_count \
+             FROM skill_usage_log \
+             WHERE created_at > NOW() - INTERVAL '1 day' * ? \
+             GROUP BY sequence_hash, tool_sequence \
+             HAVING COUNT(*) >= ? \
+             ORDER BY occurrence_count DESC \
+             LIMIT 10"
+        ))
+        .bind(i64::from(window_days))
+        .bind(i64::from(min_count))
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|(seq, hash, occ, suc)| {
+                (
+                    seq,
+                    hash,
+                    u32::try_from(occ).unwrap_or(u32::MAX),
+                    u32::try_from(suc).unwrap_or(0),
+                )
+            })
+            .collect())
+    }
+
     /// Delete `skill_usage_log` rows older than `retention_days` days.
     ///
     /// # Errors
     /// Returns [`MemoryError`] on delete failure.
+    #[cfg(not(feature = "postgres"))]
     pub async fn prune_tool_usage_log(&self, retention_days: u32) -> Result<u64, MemoryError> {
         let result = zeph_db::query(sql!(
             "DELETE FROM skill_usage_log \
              WHERE created_at < datetime('now', '-' || ? || ' days')"
         ))
         .bind(retention_days)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected())
+    }
+
+    /// Delete tool usage log entries older than `retention_days` days.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database query fails.
+    #[cfg(feature = "postgres")]
+    pub async fn prune_tool_usage_log(&self, retention_days: u32) -> Result<u64, MemoryError> {
+        let result = zeph_db::query(sql!(
+            "DELETE FROM skill_usage_log \
+             WHERE created_at < NOW() - INTERVAL '1 day' * ?"
+        ))
+        .bind(i64::from(retention_days))
         .execute(&self.pool)
         .await?;
         Ok(result.rows_affected())
@@ -681,7 +767,7 @@ impl SqliteStore {
         ))
         .bind(skill_name)
         .bind(min_confidence)
-        .bind(limit)
+        .bind(i64::from(limit))
         .fetch_all(&self.pool)
         .await?;
         Ok(rows)
@@ -718,6 +804,7 @@ impl SqliteStore {
     /// # Errors
     ///
     /// Returns [`MemoryError`] on query failure.
+    #[cfg(not(feature = "postgres"))]
     pub async fn find_step_corrections(
         &self,
         skill_name: &str,
@@ -740,6 +827,39 @@ impl SqliteStore {
         .bind(error_context)
         .bind(tool_name)
         .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    /// Find corrections that match the given skill, failure kind, error context, and tool name.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database query fails.
+    #[cfg(feature = "postgres")]
+    pub async fn find_step_corrections(
+        &self,
+        skill_name: &str,
+        failure_kind: &str,
+        error_context: &str,
+        tool_name: &str,
+        limit: u32,
+    ) -> Result<Vec<(i64, String)>, MemoryError> {
+        let rows: Vec<(i64, String)> = zeph_db::query_as(sql!(
+            "SELECT id, hint FROM step_corrections \
+             WHERE skill_name = ? \
+               AND (failure_kind = '' OR failure_kind = ?) \
+               AND (error_substring = '' OR strpos(?, error_substring) > 0) \
+               AND (tool_name = '' OR tool_name = ?) \
+             ORDER BY success_count DESC, use_count DESC \
+             LIMIT ?"
+        ))
+        .bind(skill_name)
+        .bind(failure_kind)
+        .bind(error_context)
+        .bind(tool_name)
+        .bind(i64::from(limit))
         .fetch_all(&self.pool)
         .await?;
         Ok(rows)

--- a/crates/zeph-orchestration/src/plan_cache.rs
+++ b/crates/zeph-orchestration/src/plan_cache.rs
@@ -304,7 +304,7 @@ impl PlanCache {
              ORDER BY last_accessed_at DESC LIMIT ?"
         ))
         .bind(embedding_model)
-        .bind(self.config.max_templates)
+        .bind(i64::from(self.config.max_templates))
         .fetch_all(&self.pool)
         .await?;
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -528,6 +528,10 @@ pub(crate) async fn run_daemon(
             config.skills.two_stage_matching,
             config.skills.confusability_threshold,
         )
+        .with_skill_provider_names(
+            config.skills.generation_provider.as_str().to_owned(),
+            config.skills.disambiguate_provider.as_str().to_owned(),
+        )
         .with_skill_reload(skill_paths, reload_rx)
         .with_plugin_dirs_supplier(plugin_dirs_supplier)
         .with_managed_skills_dir(crate::bootstrap::managed_skills_dir())

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2138,6 +2138,10 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         config.skills.two_stage_matching,
         config.skills.confusability_threshold,
     )
+    .with_skill_provider_names(
+        config.skills.generation_provider.as_str().to_owned(),
+        config.skills.disambiguate_provider.as_str().to_owned(),
+    )
     .with_skill_reload(skill_paths, reload_rx)
     .with_plugin_dirs_supplier(plugin_dirs_supplier)
     .with_managed_skills_dir(crate::bootstrap::managed_skills_dir())


### PR DESCRIPTION
## Summary

- **#4078**: `cargo build -p zeph-memory --features postgres` failed with 47 errors due to duplicate fn definitions and executor type mismatches when both `sqlite` (default) and `postgres` features are active simultaneously
- **#4083**: `disambiguate_provider_name` and `generation_provider_name` in `SkillState` were never populated at agent startup — only on hot-reload via `reload_config()`

## Changes

### #4078 — zeph-memory postgres compile failure

- `graph/store/mod.rs`: guard `checkpoint_wal` and `community_ids_sql` with `#[cfg(all(feature = "sqlite", not(feature = "postgres")))]`; add postgres-gated `load_graph`/`list_graphs` using `sqlx::query::<Postgres>()` turbofish
- `store/skills.rs`: add postgres-gated equivalents for five SQLite-dialect methods (`datetime('now',...)` → `NOW() - INTERVAL`, `INSTR` → `strpos`, `max()` → `GREATEST`); `prune_skill_versions` uses `ORDER BY id DESC OFFSET ?` (PostgreSQL rejects expressions in LIMIT)
- `store/corrections.rs`, `experiments.rs`, `messages/mod.rs`, `preferences.rs`, `response_cache.rs`, `plan_cache.rs`: fix `u32` → `i64` bind params (sqlx has no `uint4` in postgres)
- `store/graph_store.rs`: postgres trait impls for `RawGraphStore`

### #4083 — skill provider names not set at startup

- `crates/zeph-core/src/agent/builder.rs`: add `with_skill_provider_names(generation, disambiguate)` builder method
- `src/runner.rs`, `src/daemon.rs`: wire `with_skill_provider_names` after `with_skill_matching_config`, reading from `config.skills.generation_provider` and `config.skills.disambiguate_provider`

## Test Plan

- [x] `cargo build -p zeph-memory --features postgres` — was 47 errors, now passes
- [x] `cargo build --workspace --features postgres` — passes
- [x] `cargo build --workspace` (default SQLite) — passes
- [x] `cargo +nightly fmt --check` — passes
- [x] `cargo clippy --workspace -- -D warnings` — passes
- [x] `cargo nextest run --workspace --lib --bins` — 9474 passed

Closes #4078
Closes #4083