### PR TITLE
fix(experiments): activate sqlite feature for isolated zeph-experiments builds

### DIFF
--- a/crates/zeph-experiments/Cargo.toml
+++ b/crates/zeph-experiments/Cargo.toml
@@ -27,7 +27,7 @@ tracing.workspace = true
 zeph-common.workspace = true
 zeph-config.workspace = true
 zeph-llm.workspace = true
-zeph-memory.workspace = true
+zeph-memory = { workspace = true, features = ["sqlite"] }
 
 [dev-dependencies]
 proptest.workspace = true


### PR DESCRIPTION
## Summary

- In `crates/zeph-experiments/Cargo.toml`, changed `zeph-memory.workspace = true` to `zeph-memory = { workspace = true, features = ["sqlite"] }` so the `sqlite` DB backend is activated in isolated `-p zeph-experiments` builds.

## Root Cause

The workspace-level `zeph-memory` dep used `default-features = false`, suppressing the `sqlite` feature when building `zeph-experiments` alone. Full `--workspace` builds worked by accident because other crates activated `zeph-memory/sqlite` as a side-effect.

## Test plan

- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-experiments` — 125/125 passed (was broken)
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 9476/9476 passed, 0 regressions
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean

Closes #4116