### PR TITLE
perf(tracing): add spans to LLM-calling functions in plan_cache, consolidation, admission

### DIFF
--- a/crates/zeph-memory/src/admission.rs
+++ b/crates/zeph-memory/src/admission.rs
@@ -375,6 +375,7 @@ async fn compute_semantic_novelty(
 /// LLM-based future utility estimate.
 ///
 /// On timeout or error, returns `0.5` (neutral — no bias toward admit or reject).
+#[tracing::instrument(name = "memory.admission.future_utility_llm", skip_all)]
 async fn compute_future_utility(content: &str, role: &str, provider: &AnyProvider) -> f32 {
     use zeph_llm::provider::{Message, MessageMetadata, Role};
 
@@ -487,6 +488,7 @@ async fn compute_goal_utility(
 /// LLM-based goal utility refinement for borderline cases.
 ///
 /// Returns the original `embedding_sim` on failure (safe fallback).
+#[tracing::instrument(name = "memory.admission.goal_utility_refine_llm", skip_all)]
 async fn refine_goal_utility_llm(
     content: &str,
     goal_text: &str,

--- a/crates/zeph-memory/src/consolidation.rs
+++ b/crates/zeph-memory/src/consolidation.rs
@@ -205,6 +205,7 @@ async fn process_conversation(
 ///
 /// Runs all embeds concurrently via `join_all`.  Candidates that fail to embed are logged
 /// and dropped; they will be retried in a future sweep cycle.
+#[tracing::instrument(name = "memory.consolidation.embed_batch", skip_all, fields(count = candidates.len()))]
 async fn embed_candidates(
     provider: &AnyProvider,
     candidates: &[(crate::types::MessageId, String)],
@@ -354,6 +355,7 @@ fn cluster_by_similarity(
 /// Ask the LLM to produce a `TopologyOp` for a cluster of similar messages.
 ///
 /// Returns `None` if the LLM response cannot be parsed or if the LLM declines.
+#[tracing::instrument(name = "memory.consolidation.propose_merge_llm", skip_all, fields(cluster_size = cluster.len()))]
 async fn propose_merge_op(provider: &AnyProvider, cluster: &[(i64, String)]) -> Option<TopologyOp> {
     use zeph_llm::provider::{Message, Role};
 

--- a/crates/zeph-orchestration/src/plan_cache.rs
+++ b/crates/zeph-orchestration/src/plan_cache.rs
@@ -462,7 +462,8 @@ impl PlanCache {
 /// # Errors
 ///
 /// Returns `OrchestrationError` from the planner on full-decomposition fallback.
-#[allow(clippy::too_many_arguments)] // function with many required inputs; a *Params struct would be more verbose without simplifying the call site
+#[allow(clippy::too_many_arguments)]
+#[tracing::instrument(name = "orchestration.plan_cache.plan", skip_all, fields(goal_len = goal.len()))]
 pub async fn plan_with_cache<P>(
     planner: &P,
     plan_cache: Option<&PlanCache>,
@@ -528,6 +529,7 @@ where
 ///
 /// Returns `OrchestrationError::PlanningFailed` if the LLM call fails, times out, or the
 /// adapted graph fails DAG validation.
+#[tracing::instrument(name = "orchestration.plan_cache.adapt", skip_all, fields(goal_len = goal.len()))]
 async fn adapt_plan(
     provider: &impl LlmProvider,
     goal: &str,


### PR DESCRIPTION
## Summary

- Add `#[tracing::instrument]` spans to 6 async LLM-calling functions across 3 files
- Enables trace-based latency profiling for plan cache adaptation and memory admission/consolidation paths
- No logic changes — instrumentation only

### Spans added

| Span name | File | Function |
|-----------|------|----------|
| `orchestration.plan_cache.plan` | `plan_cache.rs` | `plan_with_cache` |
| `orchestration.plan_cache.adapt` | `plan_cache.rs` | `adapt_plan` |
| `memory.consolidation.embed_batch` | `consolidation.rs` | `embed_candidates` (field: `count`) |
| `memory.consolidation.propose_merge_llm` | `consolidation.rs` | `propose_merge_op` (field: `cluster_size`) |
| `memory.admission.future_utility_llm` | `admission.rs` | `compute_future_utility` |
| `memory.admission.goal_utility_refine_llm` | `admission.rs` | `refine_goal_utility_llm` |

Closes #4118, #3889, #3888

## Test plan

- [x] `cargo build -p zeph-orchestration -p zeph-memory` passes
- [x] `cargo nextest run -p zeph-orchestration -p zeph-memory --lib` — 1692 tests passed, 0 failed
- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy -p zeph-orchestration -p zeph-memory -- -D warnings` passes