### PR TITLE
fix(memory): add postgres cfg guards, doc comments, tracing spans in skills store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,14 +42,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   functions in the assembler (`context.graph_facts`, `context.reasoning_strategies`,
   `context.corrections`, `context.semantic_recall`, `context.document_rag`, `context.summaries`,
   `context.cross_session`), completing full hot-path trace coverage (closes #4092).
+- `zeph-memory`: added `#[tracing::instrument(skip_all)]` to 6 hot-path async functions in
+  `skills.rs` (`record_skill_usage`, `record_skill_outcomes_batch`, `active_skill_version`,
+  `activate_skill_version`, `increment_heuristic_use_count`, `save_routing_head_weights`) and
+  2 functions in `graph_store.rs` (`save_graph`, `load_graph`) for trace visibility (closes #4129).
 
 ### Fixed
+
+- `zeph-memory`: `increment_heuristic_use_count` and `save_routing_head_weights` in
+  `skills.rs` now have `#[cfg(not(feature = "postgres"))]` / `#[cfg(feature = "postgres")]`
+  variants; the postgres variant uses `CURRENT_TIMESTAMP` instead of the SQLite-only
+  `datetime('now')` (closes #4126).
 
 - `zeph-core`: `/graph` command handlers now distinguish "graph enabled but vector store unavailable
   (Qdrant unreachable)" from "Graph memory is not enabled." when `memory.graph.enabled = true` but
   Qdrant is down, resolving the inconsistency with `/status` output (closes #4111).
 - `zeph-commands`: `ClearQueueCommand` now logs a `tracing::debug!` message when
   `send_queue_count` fails instead of silently discarding the error (closes #4115).
+
+### Documentation
+
+- `zeph-memory`: added `///` doc comments to `SkillUsageRow`, `SkillMetricsRow`, and
+  `SkillVersionRow` public structs and their fields in `skills.rs` (closes #4130).
 
 ### Refactored
 

--- a/crates/zeph-memory/src/store/graph_store.rs
+++ b/crates/zeph-memory/src/store/graph_store.rs
@@ -88,6 +88,7 @@ impl TaskGraphStore {
 }
 
 impl RawGraphStore for TaskGraphStore {
+    #[tracing::instrument(skip_all, name = "memory.graph.save_graph")]
     async fn save_graph(
         &self,
         id: &str,
@@ -120,6 +121,7 @@ impl RawGraphStore for TaskGraphStore {
     }
 
     #[cfg(not(feature = "postgres"))]
+    #[tracing::instrument(skip_all, name = "memory.graph.load_graph")]
     async fn load_graph(&self, id: &str) -> Result<Option<String>, MemoryError> {
         let row: Option<(String,)> =
             zeph_db::query_as(sql!("SELECT graph_json FROM task_graphs WHERE id = ?"))
@@ -156,6 +158,7 @@ impl RawGraphStore for TaskGraphStore {
     }
 
     #[cfg(feature = "postgres")]
+    #[tracing::instrument(skip_all, name = "memory.graph.load_graph")]
     async fn load_graph(&self, id: &str) -> Result<Option<String>, MemoryError> {
         let row: Option<String> = sqlx::query_scalar::<sqlx::Postgres, String>(sql!(
             "SELECT graph_json FROM task_graphs WHERE id = ?"

--- a/crates/zeph-memory/src/store/skills.rs
+++ b/crates/zeph-memory/src/store/skills.rs
@@ -6,33 +6,54 @@ use crate::error::MemoryError;
 #[allow(unused_imports)]
 use zeph_db::{begin_write, sql};
 
+/// Aggregated usage statistics for a single skill, returned by [`SqliteStore::load_skill_usage`].
 #[derive(Debug)]
 pub struct SkillUsageRow {
+    /// The skill's unique name.
     pub skill_name: String,
+    /// Total number of times this skill has been invoked.
     pub invocation_count: i64,
+    /// ISO-8601 timestamp of the most recent invocation.
     pub last_used_at: String,
 }
 
+/// Per-skill outcome metrics (success/failure counts) returned by [`SqliteStore::load_skill_outcome_stats`].
 #[derive(Debug)]
 pub struct SkillMetricsRow {
+    /// The skill's unique name.
     pub skill_name: String,
+    /// The version ID this row refers to, if tracked per-version.
     pub version_id: Option<i64>,
+    /// Total number of recorded outcomes.
     pub total: i64,
+    /// Number of successful outcomes.
     pub successes: i64,
+    /// Number of failed outcomes.
     pub failures: i64,
 }
 
+/// A single persisted skill version, returned by [`SqliteStore::load_skill_versions`] and related queries.
 #[derive(Debug)]
 pub struct SkillVersionRow {
+    /// Primary key assigned by the database.
     pub id: i64,
+    /// The skill's unique name.
     pub skill_name: String,
+    /// Monotonically increasing version number within the skill.
     pub version: i64,
+    /// Full SKILL.md body for this version.
     pub body: String,
+    /// Human-readable description extracted from the skill body.
     pub description: String,
+    /// Origin of the version: `"manual"`, `"auto"`, etc.
     pub source: String,
+    /// Whether this version is currently the active one for the skill.
     pub is_active: bool,
+    /// Number of successful tool invocations recorded against this version.
     pub success_count: i64,
+    /// Number of failed tool invocations recorded against this version.
     pub failure_count: i64,
+    /// ISO-8601 timestamp when this version was created.
     pub created_at: String,
 }
 
@@ -70,6 +91,7 @@ impl SqliteStore {
     /// # Errors
     ///
     /// Returns an error if the database operation fails.
+    #[tracing::instrument(skip_all, name = "memory.skills.record_skill_usage")]
     pub async fn record_skill_usage(&self, skill_names: &[&str]) -> Result<(), MemoryError> {
         for name in skill_names {
             zeph_db::query(sql!(
@@ -146,6 +168,7 @@ impl SqliteStore {
     /// # Errors
     ///
     /// Returns an error if any insert fails (whole batch is rolled back).
+    #[tracing::instrument(skip_all, name = "memory.skills.record_skill_outcomes_batch")]
     pub async fn record_skill_outcomes_batch(
         &self,
         skill_names: &[String],
@@ -313,6 +336,7 @@ impl SqliteStore {
     /// # Errors
     ///
     /// Returns an error if the query fails.
+    #[tracing::instrument(skip_all, name = "memory.skills.active_skill_version")]
     pub async fn active_skill_version(
         &self,
         skill_name: &str,
@@ -334,6 +358,7 @@ impl SqliteStore {
     /// # Errors
     ///
     /// Returns an error if the update fails.
+    #[tracing::instrument(skip_all, name = "memory.skills.activate_skill_version")]
     pub async fn activate_skill_version(
         &self,
         skill_name: &str,
@@ -732,11 +757,31 @@ impl SqliteStore {
     ///
     /// # Errors
     /// Returns [`MemoryError`] on update failure.
+    #[cfg(not(feature = "postgres"))]
+    #[tracing::instrument(skip_all, name = "memory.skills.increment_heuristic_use_count")]
     pub async fn increment_heuristic_use_count(&self, id: i64) -> Result<(), MemoryError> {
         zeph_db::query(sql!(
             "UPDATE skill_heuristics \
              SET use_count = use_count + 1, updated_at = datetime('now') \
              WHERE id = ?"
+        ))
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Increment `use_count` and update `updated_at` for an existing heuristic by ID.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] on update failure.
+    #[cfg(feature = "postgres")]
+    #[tracing::instrument(skip_all, name = "memory.skills.increment_heuristic_use_count")]
+    pub async fn increment_heuristic_use_count(&self, id: i64) -> Result<(), MemoryError> {
+        zeph_db::query(sql!(
+            "UPDATE skill_heuristics \
+             SET use_count = use_count + 1, updated_at = CURRENT_TIMESTAMP \
+             WHERE id = $1"
         ))
         .bind(id)
         .execute(&self.pool)
@@ -953,6 +998,8 @@ impl SqliteStore {
     /// # Errors
     ///
     /// Returns [`MemoryError`] on query failure.
+    #[cfg(not(feature = "postgres"))]
+    #[tracing::instrument(skip_all, name = "memory.skills.save_routing_head_weights")]
     pub async fn save_routing_head_weights(
         &self,
         embed_dim: i64,
@@ -969,6 +1016,39 @@ impl SqliteStore {
                baseline = excluded.baseline, \
                update_count = excluded.update_count, \
                updated_at = datetime('now')"
+        ))
+        .bind(embed_dim)
+        .bind(weights)
+        .bind(baseline)
+        .bind(update_count)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Persist routing head weights (upsert singleton row).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError`] on query failure.
+    #[cfg(feature = "postgres")]
+    #[tracing::instrument(skip_all, name = "memory.skills.save_routing_head_weights")]
+    pub async fn save_routing_head_weights(
+        &self,
+        embed_dim: i64,
+        weights: &[u8],
+        baseline: f64,
+        update_count: i64,
+    ) -> Result<(), MemoryError> {
+        zeph_db::query(sql!(
+            "INSERT INTO routing_head_weights (id, embed_dim, weights, baseline, update_count, updated_at) \
+             VALUES (1, $1, $2, $3, $4, CURRENT_TIMESTAMP) \
+             ON CONFLICT(id) DO UPDATE SET \
+               embed_dim = excluded.embed_dim, \
+               weights = excluded.weights, \
+               baseline = excluded.baseline, \
+               update_count = excluded.update_count, \
+               updated_at = CURRENT_TIMESTAMP"
         ))
         .bind(embed_dim)
         .bind(weights)


### PR DESCRIPTION
## Summary

- **#4126** (P2): `increment_heuristic_use_count` and `save_routing_head_weights` in `skills.rs` split into `#[cfg(not(feature = "postgres"))]` / `#[cfg(feature = "postgres")]` variants — postgres uses `CURRENT_TIMESTAMP` instead of SQLite-only `datetime('now')`
- **#4130** (P3): added `///` doc comments to `SkillUsageRow`, `SkillMetricsRow`, `SkillVersionRow` public structs and all their fields
- **#4129** (P3): added `#[tracing::instrument(skip_all)]` to 6 hot-path async functions in `skills.rs` and `save_graph`/`load_graph` in `graph_store.rs`

## Test plan

- [ ] `cargo +nightly fmt --check` — pass
- [ ] `cargo clippy -p zeph-memory --all-targets -- -D warnings` — pass, no warnings
- [ ] `cargo nextest run -p zeph-memory --lib` — 1329/1329 passed
- [ ] Postgres variant compiles with `--features postgres` without `datetime('now')` errors

Closes #4126
Closes #4130
Closes #4129