### PR TITLE
fix(memory): add tokio::time::timeout to LLM calls in zeph-memory

### DIFF
--- a/crates/zeph-memory/src/consolidation.rs
+++ b/crates/zeph-memory/src/consolidation.rs
@@ -379,13 +379,20 @@ async fn propose_merge_op(provider: &AnyProvider, cluster: &[(i64, String)]) -> 
         Message::from_legacy(Role::System, system_prompt),
         Message::from_legacy(Role::User, &user_prompt),
     ];
-    let text = match provider.chat(&messages).await {
-        Ok(t) => t,
-        Err(e) => {
-            tracing::warn!(error = %e, "consolidation: LLM call failed");
-            return None;
-        }
-    };
+    let text =
+        match tokio::time::timeout(std::time::Duration::from_secs(30), provider.chat(&messages))
+            .await
+        {
+            Err(_elapsed) => {
+                tracing::warn!("consolidation: propose_merge_op LLM call timed out after 30s");
+                return None;
+            }
+            Ok(Ok(t)) => t,
+            Ok(Err(e)) => {
+                tracing::warn!(error = %e, "consolidation: LLM call failed");
+                return None;
+            }
+        };
 
     // Try to parse from the first JSON object in the response.
     let start = text.find('{')?;

--- a/crates/zeph-memory/src/graph/extractor.rs
+++ b/crates/zeph-memory/src/graph/extractor.rs
@@ -138,25 +138,31 @@ impl GraphExtractor {
             Message::from_legacy(Role::User, user_prompt),
         ];
 
-        match self
-            .provider
-            .chat_typed_erased::<ExtractionResult>(&messages)
-            .await
+        match tokio::time::timeout(
+            std::time::Duration::from_secs(30),
+            self.provider
+                .chat_typed_erased::<ExtractionResult>(&messages),
+        )
+        .await
         {
-            Ok(mut result) => {
+            Err(_elapsed) => {
+                tracing::warn!("graph_extractor: extract LLM call timed out after 30s");
+                return Ok(None);
+            }
+            Ok(Ok(mut result)) => {
                 result.entities.truncate(self.max_entities);
                 result.edges.truncate(self.max_edges);
-                Ok(Some(result))
+                return Ok(Some(result));
             }
-            Err(LlmError::StructuredParse(msg)) => {
+            Ok(Err(LlmError::StructuredParse(msg))) => {
                 tracing::warn!(
                     "graph extraction: LLM returned unparseable output (len={}): {:.200}",
                     msg.len(),
                     msg
                 );
-                Ok(None)
+                return Ok(None);
             }
-            Err(other) => Err(MemoryError::Llm(other)),
+            Ok(Err(other)) => return Err(MemoryError::Llm(other)),
         }
     }
 }

--- a/crates/zeph-memory/src/semantic/summarization.rs
+++ b/crates/zeph-memory/src/semantic/summarization.rs
@@ -89,10 +89,7 @@ impl SemanticMemory {
     /// # Errors
     ///
     /// Returns an error if LLM call or database operation fails.
-    #[cfg_attr(
-        feature = "profiling",
-        tracing::instrument(name = "memory.summarize", skip_all, fields(input_msgs = %message_count, output_len = tracing::field::Empty))
-    )]
+    #[tracing::instrument(name = "memory.summarize", skip_all, fields(input_msgs = %message_count, output_len = tracing::field::Empty))]
     pub async fn summarize(
         &self,
         conversation_id: ConversationId,
@@ -127,24 +124,7 @@ impl SemanticMemory {
             metadata: MessageMetadata::default(),
         }];
 
-        let structured = match self
-            .provider
-            .chat_typed_erased::<StructuredSummary>(&chat_messages)
-            .await
-        {
-            Ok(s) => s,
-            Err(e) => {
-                tracing::warn!(
-                    "structured summarization failed, falling back to plain text: {e:#}"
-                );
-                let plain = self.provider.chat(&chat_messages).await?;
-                StructuredSummary {
-                    summary: plain,
-                    key_facts: vec![],
-                    entities: vec![],
-                }
-            }
-        };
+        let structured = self.call_summarization_llm(&chat_messages).await?;
         let summary_text = &structured.summary;
 
         let token_estimate = i64::try_from(self.token_counter.count_tokens(summary_text))?;
@@ -197,6 +177,57 @@ impl SemanticMemory {
         }
 
         Ok(Some(summary_id))
+    }
+
+    /// Call the LLM to produce a [`StructuredSummary`], falling back to plain text on parse error.
+    ///
+    /// Both the structured and fallback calls are bounded by a 60-second timeout.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError::Timeout`] if the LLM exceeds the deadline, or
+    /// [`MemoryError::Llm`] if the provider returns an error.
+    async fn call_summarization_llm(
+        &self,
+        chat_messages: &[Message],
+    ) -> Result<StructuredSummary, MemoryError> {
+        match tokio::time::timeout(
+            std::time::Duration::from_mins(1),
+            self.provider
+                .chat_typed_erased::<StructuredSummary>(chat_messages),
+        )
+        .await
+        {
+            Ok(Ok(s)) => Ok(s),
+            Ok(Err(e)) => {
+                tracing::warn!(
+                    "structured summarization failed, falling back to plain text: {e:#}"
+                );
+                match tokio::time::timeout(
+                    std::time::Duration::from_mins(1),
+                    self.provider.chat(chat_messages),
+                )
+                .await
+                {
+                    Ok(Ok(plain)) => Ok(StructuredSummary {
+                        summary: plain,
+                        key_facts: vec![],
+                        entities: vec![],
+                    }),
+                    Ok(Err(e)) => Err(MemoryError::Llm(e)),
+                    Err(_elapsed) => {
+                        tracing::warn!(
+                            "summarization: plain text fallback LLM call timed out after 60s"
+                        );
+                        Err(MemoryError::Timeout("LLM call timed out".into()))
+                    }
+                }
+            }
+            Err(_elapsed) => {
+                tracing::warn!("summarization: structured LLM call timed out after 60s");
+                Err(MemoryError::Timeout("LLM call timed out".into()))
+            }
+        }
     }
 
     pub(super) async fn store_key_facts(


### PR DESCRIPTION
## Summary

- `consolidation.rs` `propose_merge_op`: 30s timeout on `provider.chat`; returns `None` on elapsed (safe degradation, sweep loop skips cluster)
- `graph/extractor.rs` `GraphExtractor::extract`: 30s timeout on `chat_typed_erased`; returns `Ok(None)` on elapsed (consistent with parse-failure path)
- `semantic/summarization.rs`: LLM calls extracted to `call_summarization_llm` helper with 60s timeout on both structured and plain-text paths; `#[tracing::instrument]` promoted from `cfg_attr(profiling)` to unconditional so spans appear in default/production builds

All three sites violated the Await Discipline rule — a hung LLM provider could block the consolidation sweep loop or agent turn indefinitely.

## Test plan

- [x] `cargo nextest run -p zeph-memory --lib` — 1329 passed, 8 skipped
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo +nightly fmt --check` — clean

Closes #4146, #4148, #4149