### PR TITLE
fix(memory,plugins): atomicity and redundant I/O in skills store and plugin manager

### DIFF
--- a/crates/zeph-memory/src/store/skills.rs
+++ b/crates/zeph-memory/src/store/skills.rs
@@ -88,11 +88,15 @@ fn skill_version_from_tuple(t: SkillVersionTuple) -> SkillVersionRow {
 impl SqliteStore {
     /// Record usage of skills (UPSERT: increment count and update timestamp).
     ///
+    /// All UPSERTs are issued inside a single write transaction to avoid N
+    /// round-trips and WAL contention under concurrent callers.
+    ///
     /// # Errors
     ///
     /// Returns an error if the database operation fails.
     #[tracing::instrument(skip_all, name = "memory.skills.record_skill_usage")]
     pub async fn record_skill_usage(&self, skill_names: &[&str]) -> Result<(), MemoryError> {
+        let mut tx = begin_write(&self.pool).await?;
         for name in skill_names {
             zeph_db::query(sql!(
                 "INSERT INTO skill_usage (skill_name, invocation_count, last_used_at) \
@@ -102,9 +106,10 @@ impl SqliteStore {
                  last_used_at = CURRENT_TIMESTAMP"
             ))
             .bind(name)
-            .execute(&self.pool)
+            .execute(&mut *tx)
             .await?;
         }
+        tx.commit().await?;
         Ok(())
     }
 
@@ -428,6 +433,10 @@ impl SqliteStore {
 
     /// Ensure a base (v1 manual) version exists for a skill. Idempotent.
     ///
+    /// The check-then-insert-then-activate sequence runs inside a single write
+    /// transaction so that two concurrent callers cannot both observe
+    /// `existing.is_none()` and race to insert duplicate v1 rows.
+    ///
     /// # Errors
     ///
     /// Returns an error if the DB operation fails.
@@ -438,19 +447,42 @@ impl SqliteStore {
         body: &str,
         description: &str,
     ) -> Result<(), MemoryError> {
+        let mut tx = begin_write(&self.pool).await?;
+
         let existing: Option<(i64,)> = zeph_db::query_as(sql!(
             "SELECT id FROM skill_versions WHERE skill_name = ? LIMIT 1"
         ))
         .bind(skill_name)
-        .fetch_optional(&self.pool)
+        .fetch_optional(&mut *tx)
         .await?;
 
         if existing.is_none() {
-            let id = self
-                .save_skill_version(skill_name, 1, body, description, "manual", None, None)
+            let row: (i64,) = zeph_db::query_as(sql!(
+                "INSERT INTO skill_versions \
+                 (skill_name, version, body, description, source, error_context, predecessor_id) \
+                 VALUES (?, 1, ?, ?, 'manual', NULL, NULL) RETURNING id"
+            ))
+            .bind(skill_name)
+            .bind(body)
+            .bind(description)
+            .fetch_one(&mut *tx)
+            .await?;
+            let id = row.0;
+
+            zeph_db::query(sql!(
+                "UPDATE skill_versions SET is_active = 0 WHERE skill_name = ? AND is_active = 1"
+            ))
+            .bind(skill_name)
+            .execute(&mut *tx)
+            .await?;
+
+            zeph_db::query(sql!("UPDATE skill_versions SET is_active = 1 WHERE id = ?"))
+                .bind(id)
+                .execute(&mut *tx)
                 .await?;
-            self.activate_skill_version(skill_name, id).await?;
         }
+
+        tx.commit().await?;
         Ok(())
     }
 

--- a/crates/zeph-plugins/src/manager.rs
+++ b/crates/zeph-plugins/src/manager.rs
@@ -68,6 +68,8 @@ pub struct InstalledPlugin {
     pub description: String,
     /// Absolute path to the installed plugin root.
     pub path: PathBuf,
+    /// Skill names provided by this plugin (collected at list time to avoid re-reading manifests).
+    pub skill_names: Vec<String>,
 }
 
 /// Manages plugin lifecycle: install, remove, list.
@@ -351,11 +353,13 @@ impl PluginManager {
             let Ok(manifest): Result<PluginManifest, _> = toml::from_str(&text) else {
                 continue;
             };
+            let skill_names = collect_skill_names(&path, &manifest);
             plugins.push(InstalledPlugin {
                 name: manifest.plugin.name,
                 version: manifest.plugin.version,
                 description: manifest.plugin.description,
                 path,
+                skill_names,
             });
         }
 
@@ -424,7 +428,7 @@ impl PluginManager {
             .map(|m| m.name.clone())
             .collect();
 
-        // Other installed plugins' skill names.
+        // Other installed plugins' skill names — already collected by list_installed.
         let installed = self.list_installed().unwrap_or_default();
         let mut other_plugin_skills: std::collections::HashMap<String, String> =
             std::collections::HashMap::new();
@@ -432,15 +436,8 @@ impl PluginManager {
             if plugin.name == this_plugin {
                 continue;
             }
-            let manifest_path = plugin.path.join(".plugin.toml");
-            if let Ok(bytes) = std::fs::read(&manifest_path)
-                && let Ok(text) = String::from_utf8(bytes)
-                && let Ok(manifest) = toml::from_str::<PluginManifest>(&text)
-            {
-                let names = collect_skill_names(&plugin.path, &manifest);
-                for name in names {
-                    other_plugin_skills.insert(name, plugin.name.clone());
-                }
+            for name in &plugin.skill_names {
+                other_plugin_skills.insert(name.clone(), plugin.name.clone());
             }
         }
 


### PR DESCRIPTION
## Summary

- **#4159**: `ensure_skill_version_exists` — SELECT + INSERT + activate now runs inside a single `begin_write` transaction, eliminating the TOCTOU race that could produce duplicate v1 rows when concurrent sessions (Telegram/Slack) resolve the same new skill simultaneously
- **#4151**: `record_skill_usage` — UPSERT loop now wrapped in a single `begin_write` transaction, reducing N SQLite round-trips to 1 and preventing SQLITE_BUSY cascades under load (follows the pattern of `record_skill_outcomes_batch` in the same file)
- **#4158**: Added `skill_names: Vec<String>` to `InstalledPlugin`, populated once in `list_installed` via `collect_skill_names`; `check_skill_conflicts` now reads from `plugin.skill_names` instead of re-reading every manifest from disk in the inner loop

## Test plan

- [ ] `cargo nextest run -p zeph-memory -p zeph-plugins --lib` — 1397 tests pass
- [ ] `cargo nextest run --workspace --lib --bins` — 9488 tests pass, 21 skipped
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] Existing idempotency test for `ensure_skill_version_exists` passes
- [ ] Note: concurrency test for `ensure_skill_version_exists` is not yet present; recommend follow-up for Postgres `SELECT ... FOR UPDATE` guard (reviewer note: `begin_write` gives SQLite-level write exclusion but not Postgres-level row lock)

Closes #4159, #4151, #4158