### PR TITLE
perf(memory): add tracing span to compute_semantic_novelty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `zeph-memory`: added `#[tracing::instrument]` span to `compute_semantic_novelty` in
+  `admission.rs` so embedding latency during admission is visible in local Chrome JSON traces
+  (closes #4145).
+
 ### Added
 
 - `zeph-common`: added 8 exfiltration-channel patterns to `RAW_INJECTION_PATTERNS` (`exfil_curl`,

--- a/crates/zeph-memory/src/admission.rs
+++ b/crates/zeph-memory/src/admission.rs
@@ -336,6 +336,7 @@ pub fn compute_content_type_prior(role: &str) -> f32 {
 /// Compute semantic novelty as `1.0 - max_cosine_similarity_to_top3_neighbors`.
 ///
 /// Returns `1.0` when the memory is empty (everything is novel at cold start).
+#[tracing::instrument(name = "memory.admission.semantic_novelty", skip_all)]
 async fn compute_semantic_novelty(
     content: &str,
     provider: &AnyProvider,


### PR DESCRIPTION
## Summary

- Adds `#[tracing::instrument(name = \"memory.admission.semantic_novelty\", skip_all)]` to `compute_semantic_novelty` in `crates/zeph-memory/src/admission.rs`
- Embedding latency during admission gating is now visible in local Chrome JSON traces and Perfetto UI
- Consistent with sibling span names added in #4131 (`memory.admission.future_utility_llm`, `memory.admission.goal_utility_refine_llm`)

## Test plan

- [ ] `cargo clippy --workspace -- -D warnings` passes (zero warnings)
- [ ] `cargo nextest run -p zeph-memory --lib` — 1329 tests pass
- [ ] `cargo nextest run --workspace --lib --bins` — full workspace passes

Closes #4145