### PR TITLE
fix(agent-feedback,channels): add timeout guards to LLM and HTTP awaits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `zeph-memory`: added `#[tracing::instrument]` span to `compute_semantic_novelty` in
   `admission.rs` so embedding latency during admission is visible in local Chrome JSON traces
   (closes #4145).
+- `zeph-agent-feedback`: wrap `JudgeDetector::evaluate` LLM call in 30 s `tokio::time::timeout`; add `JudgeError::Timeout` variant (closes #4179).
+- `zeph-channels`: wrap Discord gateway `connect_async` (10 s), Hello receive (30 s), and interaction ACK (3 s) in `tokio::time::timeout` guards (closes #4180).
+- `zeph-channels`: wrap all Slack Web API HTTP calls (`auth_test`, `post_message`, `update_message`, `download_file`) in 15 s `tokio::time::timeout` guards (closes #4181).
 
 ### Added
 

--- a/crates/zeph-agent-feedback/Cargo.toml
+++ b/crates/zeph-agent-feedback/Cargo.toml
@@ -23,5 +23,9 @@ tracing.workspace = true
 zeph-common.workspace = true
 zeph-llm.workspace = true
 
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "sync", "time", "test-util", "macros"] }
+zeph-llm = { workspace = true, features = ["testing"] }
+
 [lints]
 workspace = true

--- a/crates/zeph-agent-feedback/src/lib.rs
+++ b/crates/zeph-agent-feedback/src/lib.rs
@@ -579,6 +579,8 @@ impl JudgeVerdict {
 pub enum JudgeError {
     #[error("LLM call failed: {0}")]
     Llm(#[from] zeph_llm::LlmError),
+    #[error("judge LLM call timed out")]
+    Timeout,
 }
 
 /// LLM-backed correction detector with a sliding-window rate limiter.
@@ -688,7 +690,9 @@ impl JudgeDetector {
     ///
     /// # Errors
     ///
-    /// Returns [`JudgeError::Llm`] if the provider call fails.
+    /// Returns [`JudgeError::Llm`] if the provider call fails, or [`JudgeError::Timeout`]
+    /// if the LLM does not respond within 30 seconds.
+    #[tracing::instrument(skip(provider, user_message, assistant_response), err)]
     pub async fn evaluate(
         provider: &AnyProvider,
         user_message: &str,
@@ -696,7 +700,12 @@ impl JudgeDetector {
         confidence_threshold: f32,
     ) -> Result<JudgeVerdict, JudgeError> {
         let messages = Self::build_messages(user_message, assistant_response);
-        let verdict: JudgeVerdict = provider.chat_typed_erased(&messages).await?;
+        let verdict: JudgeVerdict = tokio::time::timeout(
+            Duration::from_secs(30),
+            provider.chat_typed_erased(&messages),
+        )
+        .await
+        .map_err(|_| JudgeError::Timeout)??;
 
         tracing::debug!(
             is_correction = verdict.is_correction,
@@ -1919,6 +1928,25 @@ mod tests {
         let d = detector();
         let signal = d.detect("That's неправильно", &[]).unwrap();
         assert_eq!(signal.kind, CorrectionKind::ExplicitRejection);
+    }
+
+    // ── JudgeDetector::evaluate timeout regression (#4179) ───────────────
+
+    #[tokio::test]
+    async fn judge_evaluate_returns_timeout_error_when_provider_hangs() {
+        tokio::time::pause();
+        // Delay exceeds the 30s guard so the timeout fires before provider responds.
+        let mock = zeph_llm::mock::MockProvider::default().with_delay(60_000);
+        let provider = zeph_llm::any::AnyProvider::Mock(mock);
+        let handle = tokio::spawn(async move {
+            JudgeDetector::evaluate(&provider, "user msg", "assistant resp", 0.5).await
+        });
+        tokio::time::advance(Duration::from_secs(31)).await;
+        let result = handle.await.expect("task panicked");
+        assert!(
+            matches!(result, Err(JudgeError::Timeout)),
+            "expected JudgeError::Timeout, got {result:?}"
+        );
     }
 
     // ── JudgeVerdict / FeedbackVerdict sync test (#2250) ─────────────────

--- a/crates/zeph-channels/src/discord/gateway.rs
+++ b/crates/zeph-channels/src/discord/gateway.rs
@@ -84,11 +84,17 @@ async fn run_session(
     token: &str,
     tx: &mpsc::Sender<IncomingMessage>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let (ws_stream, _): (WsStream, _) = connect_async(GATEWAY_URL).await?;
+    let (ws_stream, _): (WsStream, _) =
+        tokio::time::timeout(Duration::from_secs(10), connect_async(GATEWAY_URL))
+            .await
+            .map_err(|_| "discord gateway connect timed out")?
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
     let (mut write, mut read) = ws_stream.split();
 
     // Wait for Hello (op 10)
-    let hello_text = read_next_text(&mut read).await?;
+    let hello_text = tokio::time::timeout(Duration::from_secs(30), read_next_text(&mut read))
+        .await
+        .map_err(|_| "discord gateway hello timed out")??;
     let hello: Value = serde_json::from_str(&hello_text)?;
     let op = hello.get("op").and_then(Value::as_u64).unwrap_or(0);
     if op != 10 {
@@ -234,12 +240,12 @@ async fn ack_interaction(
     );
     // type 5 = DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE
     let body = serde_json::json!({"type": 5});
-    client
-        .post(&url)
-        .json(&body)
-        .send()
-        .await?
-        .error_for_status()?;
+    tokio::time::timeout(Duration::from_secs(3), client.post(&url).json(&body).send())
+        .await
+        .map_err(|_| "discord interaction ack timed out")?
+        .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?
+        .error_for_status()
+        .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
     Ok(())
 }
 

--- a/crates/zeph-channels/src/slack/api.rs
+++ b/crates/zeph-channels/src/slack/api.rs
@@ -3,6 +3,8 @@
 
 //! Slack Web API client for message operations.
 
+use std::time::Duration;
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -59,14 +61,19 @@ impl SlackApi {
     ///
     /// Returns an error if the HTTP request or Slack API fails.
     pub async fn auth_test(&self) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
-        let resp: Value = self
-            .client
-            .post(format!("{SLACK_API}/auth.test"))
-            .bearer_auth(&self.token)
-            .send()
-            .await?
-            .json()
-            .await?;
+        let resp: Value = tokio::time::timeout(
+            Duration::from_secs(15),
+            self.client
+                .post(format!("{SLACK_API}/auth.test"))
+                .bearer_auth(&self.token)
+                .send(),
+        )
+        .await
+        .map_err(|_| "slack auth.test timed out")?
+        .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?
+        .json()
+        .await
+        .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
 
         if resp.get("ok").and_then(Value::as_bool) != Some(true) {
             let err = resp
@@ -91,15 +98,20 @@ impl SlackApi {
         channel: &str,
         text: &str,
     ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
-        let resp: SlackResponse = self
-            .client
-            .post(format!("{SLACK_API}/chat.postMessage"))
-            .bearer_auth(&self.token)
-            .json(&PostMessage { channel, text })
-            .send()
-            .await?
-            .json()
-            .await?;
+        let resp: SlackResponse = tokio::time::timeout(
+            Duration::from_secs(15),
+            self.client
+                .post(format!("{SLACK_API}/chat.postMessage"))
+                .bearer_auth(&self.token)
+                .json(&PostMessage { channel, text })
+                .send(),
+        )
+        .await
+        .map_err(|_| "slack chat.postMessage timed out")?
+        .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?
+        .json()
+        .await
+        .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
 
         if !resp.ok {
             return Err(
@@ -120,15 +132,20 @@ impl SlackApi {
         ts: &str,
         text: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let resp: SlackResponse = self
-            .client
-            .post(format!("{SLACK_API}/chat.update"))
-            .bearer_auth(&self.token)
-            .json(&UpdateMessage { channel, ts, text })
-            .send()
-            .await?
-            .json()
-            .await?;
+        let resp: SlackResponse = tokio::time::timeout(
+            Duration::from_secs(15),
+            self.client
+                .post(format!("{SLACK_API}/chat.update"))
+                .bearer_auth(&self.token)
+                .json(&UpdateMessage { channel, ts, text })
+                .send(),
+        )
+        .await
+        .map_err(|_| "slack chat.update timed out")?
+        .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?
+        .json()
+        .await
+        .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
 
         if !resp.ok {
             return Err(format!("slack chat.update: {}", resp.error.unwrap_or_default()).into());
@@ -152,11 +169,20 @@ impl SlackApi {
             return Err(format!("refusing to send token to non-slack host: {url}").into());
         }
 
-        let resp = self.client.get(url).bearer_auth(&self.token).send().await?;
+        let resp = tokio::time::timeout(
+            Duration::from_secs(15),
+            self.client.get(url).bearer_auth(&self.token).send(),
+        )
+        .await
+        .map_err(|_| "slack file download timed out")?
+        .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
         if !resp.status().is_success() {
             return Err(format!("slack file download failed: {}", resp.status()).into());
         }
-        let bytes = resp.bytes().await?;
+        let bytes = tokio::time::timeout(Duration::from_secs(15), resp.bytes())
+            .await
+            .map_err(|_| "slack file download body timed out")?
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
         if bytes.len() > MAX_AUDIO_BYTES {
             return Err(format!(
                 "slack file too large: {} bytes (max {MAX_AUDIO_BYTES})",


### PR DESCRIPTION
## Summary

- `zeph-agent-feedback`: wrap `JudgeDetector::evaluate` LLM call in 30 s `tokio::time::timeout`; add `JudgeError::Timeout` variant; add `#[tracing::instrument]` span (closes #4179)
- `zeph-channels`: wrap Discord gateway `connect_async` (10 s), Hello receive (30 s), and interaction ACK (3 s) in `tokio::time::timeout` guards (closes #4180)
- `zeph-channels`: wrap all Slack Web API HTTP calls (`auth_test`, `post_message`, `update_message`, `download_file`) in 15 s `tokio::time::timeout` guards (closes #4181)
- `zeph-agent-feedback`: fix pre-existing missing `tokio/test-util` + `zeph-llm/testing` dev-dependencies; add regression test for `JudgeError::Timeout`

## Test plan

- [x] `cargo +nightly fmt --check` — passes
- [x] `cargo clippy --workspace --features desktop,ide,server,chat,pdf,scheduler -- -D warnings` — passes
- [x] `cargo nextest run -p zeph-agent-feedback -p zeph-channels --lib` — 306/306 passed