### PR TITLE
fix(memory): make LLM timeouts configurable in consolidation, graph extractor, and summarization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `zeph-memory`: consolidation LLM timeout is now configurable via `ConsolidationConfig.llm_timeout_secs`
+  (default 30s); previously hardcoded to 30s (closes #4168).
+- `zeph-memory`: graph extractor LLM timeout is now configurable via `GraphExtractionConfig.llm_timeout_secs`
+  and `GraphConfig.llm_timeout_secs` (default 30s); previously hardcoded to 30s (closes #4169).
+- `zeph-memory`: summarization LLM timeout is now configurable via `MemoryConfig.summarization_llm_timeout_secs`
+  (default 60s); previously hardcoded to 60s in both the structured and plain-text fallback paths (closes #4170).
+
 ### Added
 
 - `zeph-common`: added 8 exfiltration-channel patterns to `RAW_INJECTION_PATTERNS` (`exfil_curl`,

--- a/crates/zeph-agent-persistence/src/graph.rs
+++ b/crates/zeph-agent-persistence/src/graph.rs
@@ -49,6 +49,7 @@ pub fn build_graph_extraction_config(
         belief_revision_similarity_threshold: cfg.belief_revision.similarity_threshold,
         conversation_id,
         apex_mem_enabled: cfg.apex_mem.enabled,
+        llm_timeout_secs: cfg.llm_timeout_secs,
     }
 }
 

--- a/crates/zeph-common/src/config/memory.rs
+++ b/crates/zeph-common/src/config/memory.rs
@@ -73,6 +73,8 @@ pub struct ConsolidationConfig {
     pub sweep_interval_secs: u64,
     pub sweep_batch_size: usize,
     pub similarity_threshold: f32,
+    /// LLM call timeout per `propose_merge_op` invocation, in seconds.
+    pub llm_timeout_secs: u64,
 }
 
 /// Runtime config for the forgetting sweep (#2397).

--- a/crates/zeph-config/src/memory.rs
+++ b/crates/zeph-config/src/memory.rs
@@ -62,6 +62,10 @@ fn default_summarization_threshold() -> usize {
     50
 }
 
+fn default_summarization_llm_timeout_secs() -> u64 {
+    60
+}
+
 fn default_context_budget_tokens() -> usize {
     0
 }
@@ -718,6 +722,9 @@ pub struct MemoryConfig {
     pub semantic: SemanticConfig,
     #[serde(default = "default_summarization_threshold")]
     pub summarization_threshold: usize,
+    /// LLM call timeout for summarization, in seconds. Default: `60`.
+    #[serde(default = "default_summarization_llm_timeout_secs")]
+    pub summarization_llm_timeout_secs: u64,
     #[serde(default = "default_context_budget_tokens")]
     pub context_budget_tokens: usize,
     #[serde(default = "default_soft_compaction_threshold")]
@@ -2132,10 +2139,17 @@ pub struct GraphConfig {
     /// supersession chains instead of the legacy destructive-update path.
     #[serde(default)]
     pub apex_mem: ApexMemConfig,
+    /// LLM call timeout per extraction request, in seconds. Default: `30`.
+    #[serde(default = "default_graph_llm_timeout_secs")]
+    pub llm_timeout_secs: u64,
 }
 
 fn default_graph_pool_size() -> u32 {
     3
+}
+
+fn default_graph_llm_timeout_secs() -> u64 {
+    30
 }
 
 /// APEX-MEM append-only write path configuration (`[memory.graph.apex_mem]`).
@@ -2293,6 +2307,7 @@ impl Default for GraphConfig {
             rpe: RpeConfig::default(),
             pool_size: default_graph_pool_size(),
             apex_mem: ApexMemConfig::default(),
+            llm_timeout_secs: default_graph_llm_timeout_secs(),
         }
     }
 }
@@ -2340,6 +2355,9 @@ pub struct ConsolidationConfig {
     /// Default: `0.85`.
     #[serde(default = "default_consolidation_similarity_threshold")]
     pub similarity_threshold: f32,
+    /// LLM call timeout per `propose_merge_op` invocation, in seconds. Default: `30`.
+    #[serde(default = "default_consolidation_llm_timeout_secs")]
+    pub llm_timeout_secs: u64,
 }
 
 impl Default for ConsolidationConfig {
@@ -2351,8 +2369,13 @@ impl Default for ConsolidationConfig {
             sweep_interval_secs: default_consolidation_sweep_interval_secs(),
             sweep_batch_size: default_consolidation_sweep_batch_size(),
             similarity_threshold: default_consolidation_similarity_threshold(),
+            llm_timeout_secs: default_consolidation_llm_timeout_secs(),
         }
     }
+}
+
+fn default_consolidation_llm_timeout_secs() -> u64 {
+    30
 }
 
 fn default_link_weight_decay_lambda() -> f64 {
@@ -2843,6 +2866,9 @@ pub struct AutoDreamConfig {
     pub consolidation_provider: ProviderName,
     /// Maximum agent loop iterations for the consolidation subagent. Default: `8`.
     pub max_iterations: u8,
+    /// LLM call timeout per `propose_merge_op` invocation, in seconds. Default: `30`.
+    #[serde(default = "default_autodream_llm_timeout_secs")]
+    pub llm_timeout_secs: u64,
 }
 
 impl Default for AutoDreamConfig {
@@ -2853,8 +2879,13 @@ impl Default for AutoDreamConfig {
             min_hours: 24,
             consolidation_provider: ProviderName::default(),
             max_iterations: 8,
+            llm_timeout_secs: default_autodream_llm_timeout_secs(),
         }
     }
+}
+
+fn default_autodream_llm_timeout_secs() -> u64 {
+    30
 }
 
 /// `MagicDocs` auto-maintained markdown configuration (#2702).

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -229,6 +229,7 @@ impl Default for Config {
                 qdrant_api_key: None,
                 semantic: SemanticConfig::default(),
                 summarization_threshold: 50,
+                summarization_llm_timeout_secs: 60,
                 context_budget_tokens: 0,
                 soft_compaction_threshold: 0.60,
                 hard_compaction_threshold: 0.90,

--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -517,6 +517,7 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
                                 .similarity_threshold,
                             conversation_id: None,
                             apex_mem_enabled: graph_cfg.apex_mem.enabled,
+                            llm_timeout_secs: graph_cfg.llm_timeout_secs,
                         };
                         let pool = store.pool().clone();
                         match extract_and_store(

--- a/crates/zeph-core/src/agent/autodream.rs
+++ b/crates/zeph-core/src/agent/autodream.rs
@@ -115,6 +115,7 @@ impl<C: Channel> super::Agent<C> {
             confidence_threshold: 0.7,
             similarity_threshold: 0.85,
             sweep_interval_secs: 0,
+            llm_timeout_secs: cfg.llm_timeout_secs,
         };
 
         // Run with a timeout bounded by max_iterations * ~30s per call as a rough limit.

--- a/crates/zeph-memory/src/consolidation.rs
+++ b/crates/zeph-memory/src/consolidation.rs
@@ -249,7 +249,7 @@ async fn apply_topology_op(
     config: &ConsolidationConfig,
     result: &mut ConsolidationResult,
 ) {
-    let ops = propose_merge_op(provider, &cluster).await;
+    let ops = propose_merge_op(provider, &cluster, config.llm_timeout_secs).await;
     match ops {
         None => {
             tracing::debug!(
@@ -356,7 +356,11 @@ fn cluster_by_similarity(
 ///
 /// Returns `None` if the LLM response cannot be parsed or if the LLM declines.
 #[tracing::instrument(name = "memory.consolidation.propose_merge_llm", skip_all, fields(cluster_size = cluster.len()))]
-async fn propose_merge_op(provider: &AnyProvider, cluster: &[(i64, String)]) -> Option<TopologyOp> {
+async fn propose_merge_op(
+    provider: &AnyProvider,
+    cluster: &[(i64, String)],
+    llm_timeout_secs: u64,
+) -> Option<TopologyOp> {
     use zeph_llm::provider::{Message, Role};
 
     let entries: String = cluster
@@ -379,20 +383,24 @@ async fn propose_merge_op(provider: &AnyProvider, cluster: &[(i64, String)]) -> 
         Message::from_legacy(Role::System, system_prompt),
         Message::from_legacy(Role::User, &user_prompt),
     ];
-    let text =
-        match tokio::time::timeout(std::time::Duration::from_secs(30), provider.chat(&messages))
-            .await
-        {
-            Err(_elapsed) => {
-                tracing::warn!("consolidation: propose_merge_op LLM call timed out after 30s");
-                return None;
-            }
-            Ok(Ok(t)) => t,
-            Ok(Err(e)) => {
-                tracing::warn!(error = %e, "consolidation: LLM call failed");
-                return None;
-            }
-        };
+    let text = match tokio::time::timeout(
+        std::time::Duration::from_secs(llm_timeout_secs),
+        provider.chat(&messages),
+    )
+    .await
+    {
+        Err(_elapsed) => {
+            tracing::warn!(
+                "consolidation: propose_merge_op LLM call timed out after {llm_timeout_secs}s"
+            );
+            return None;
+        }
+        Ok(Ok(t)) => t,
+        Ok(Err(e)) => {
+            tracing::warn!(error = %e, "consolidation: LLM call failed");
+            return None;
+        }
+    };
 
     // Try to parse from the first JSON object in the response.
     let start = text.find('{')?;
@@ -608,6 +616,19 @@ mod tests {
     }
 
     /// Sweep on an empty DB (no conversations) must return Ok with all-zero counters.
+    #[test]
+    fn consolidation_config_stores_custom_llm_timeout() {
+        let cfg = ConsolidationConfig {
+            enabled: true,
+            confidence_threshold: 0.75,
+            sweep_interval_secs: 300,
+            sweep_batch_size: 100,
+            similarity_threshold: 0.85,
+            llm_timeout_secs: 99,
+        };
+        assert_eq!(cfg.llm_timeout_secs, 99);
+    }
+
     #[tokio::test]
     async fn run_consolidation_sweep_empty_db_returns_ok() {
         use std::sync::Arc;
@@ -624,6 +645,7 @@ mod tests {
             sweep_interval_secs: 300,
             sweep_batch_size: 100,
             similarity_threshold: 0.85,
+            llm_timeout_secs: 30,
         };
 
         let result = run_consolidation_sweep(&store, &provider, &config).await;
@@ -662,6 +684,7 @@ mod tests {
             sweep_interval_secs: 300,
             sweep_batch_size: 100,
             similarity_threshold: 0.85,
+            llm_timeout_secs: 30,
         };
 
         let result = run_consolidation_sweep(&store, &provider, &config)
@@ -790,6 +813,7 @@ mod tests {
             sweep_interval_secs: 300,
             sweep_batch_size: 100,
             similarity_threshold: 0.85,
+            llm_timeout_secs: 30,
         };
 
         let r = run_consolidation_sweep(&store, &provider, &config)
@@ -832,6 +856,7 @@ mod tests {
             sweep_interval_secs: 300,
             sweep_batch_size: 100,
             similarity_threshold: 0.85,
+            llm_timeout_secs: 30,
         };
 
         let r = run_consolidation_sweep(&store, &provider, &config)
@@ -874,6 +899,7 @@ mod tests {
             sweep_interval_secs: 300,
             sweep_batch_size: 100,
             similarity_threshold: 0.85,
+            llm_timeout_secs: 30,
         };
 
         let r = run_consolidation_sweep(&store, &provider, &config)
@@ -917,6 +943,7 @@ mod tests {
             sweep_interval_secs: 300,
             sweep_batch_size: 100,
             similarity_threshold: 0.85,
+            llm_timeout_secs: 30,
         };
 
         let r = run_consolidation_sweep(&store, &provider, &config)
@@ -961,6 +988,7 @@ mod tests {
             sweep_interval_secs: 300,
             sweep_batch_size: 100,
             similarity_threshold: 0.85,
+            llm_timeout_secs: 30,
         };
 
         let r = run_consolidation_sweep(&store, &provider, &config)

--- a/crates/zeph-memory/src/graph/extractor.rs
+++ b/crates/zeph-memory/src/graph/extractor.rs
@@ -101,15 +101,22 @@ pub struct GraphExtractor {
     provider: AnyProvider,
     max_entities: usize,
     max_edges: usize,
+    llm_timeout_secs: u64,
 }
 
 impl GraphExtractor {
     #[must_use]
-    pub fn new(provider: AnyProvider, max_entities: usize, max_edges: usize) -> Self {
+    pub fn new(
+        provider: AnyProvider,
+        max_entities: usize,
+        max_edges: usize,
+        llm_timeout_secs: u64,
+    ) -> Self {
         Self {
             provider,
             max_entities,
             max_edges,
+            llm_timeout_secs,
         }
     }
 
@@ -139,14 +146,15 @@ impl GraphExtractor {
         ];
 
         match tokio::time::timeout(
-            std::time::Duration::from_secs(30),
+            std::time::Duration::from_secs(self.llm_timeout_secs),
             self.provider
                 .chat_typed_erased::<ExtractionResult>(&messages),
         )
         .await
         {
             Err(_elapsed) => {
-                tracing::warn!("graph_extractor: extract LLM call timed out after 30s");
+                let t = self.llm_timeout_secs;
+                tracing::warn!("graph_extractor: extract LLM call timed out after {t}s");
                 return Ok(None);
             }
             Ok(Ok(mut result)) => {
@@ -374,7 +382,7 @@ mod tests {
         async fn extract_truncates_to_max_entities() {
             let json = make_entities_json(20);
             let mock = MockProvider::with_responses(vec![json]);
-            let extractor = GraphExtractor::new(zeph_llm::any::AnyProvider::Mock(mock), 5, 100);
+            let extractor = GraphExtractor::new(zeph_llm::any::AnyProvider::Mock(mock), 5, 100, 30);
             let result = extractor.extract("test message", &[]).await.unwrap();
             let result = result.unwrap();
             assert_eq!(result.entities.len(), 5);
@@ -384,7 +392,7 @@ mod tests {
         async fn extract_truncates_to_max_edges() {
             let json = make_edges_json(15);
             let mock = MockProvider::with_responses(vec![json]);
-            let extractor = GraphExtractor::new(zeph_llm::any::AnyProvider::Mock(mock), 100, 3);
+            let extractor = GraphExtractor::new(zeph_llm::any::AnyProvider::Mock(mock), 100, 3, 30);
             let result = extractor.extract("test message", &[]).await.unwrap();
             let result = result.unwrap();
             assert_eq!(result.edges.len(), 3);
@@ -393,7 +401,7 @@ mod tests {
         #[tokio::test]
         async fn extract_returns_none_on_parse_failure() {
             let mock = MockProvider::with_responses(vec!["not valid json at all".into()]);
-            let extractor = GraphExtractor::new(zeph_llm::any::AnyProvider::Mock(mock), 10, 10);
+            let extractor = GraphExtractor::new(zeph_llm::any::AnyProvider::Mock(mock), 10, 10, 30);
             let result = extractor.extract("test message", &[]).await.unwrap();
             assert!(result.is_none());
         }
@@ -402,16 +410,27 @@ mod tests {
         async fn extract_returns_err_on_transport_failure() {
             let mock = MockProvider::default()
                 .with_errors(vec![zeph_llm::LlmError::Other("connection refused".into())]);
-            let extractor = GraphExtractor::new(zeph_llm::any::AnyProvider::Mock(mock), 10, 10);
+            let extractor = GraphExtractor::new(zeph_llm::any::AnyProvider::Mock(mock), 10, 10, 30);
             let result = extractor.extract("test message", &[]).await;
             assert!(result.is_err());
             assert!(matches!(result.unwrap_err(), MemoryError::Llm(_)));
         }
 
+        #[test]
+        fn graph_extractor_stores_custom_llm_timeout() {
+            let extractor = GraphExtractor::new(
+                zeph_llm::any::AnyProvider::Mock(MockProvider::default()),
+                10,
+                5,
+                42,
+            );
+            assert_eq!(extractor.llm_timeout_secs, 42);
+        }
+
         #[tokio::test]
         async fn extract_returns_none_on_empty_message() {
             let mock = MockProvider::with_responses(vec!["should not be called".into()]);
-            let extractor = GraphExtractor::new(zeph_llm::any::AnyProvider::Mock(mock), 10, 10);
+            let extractor = GraphExtractor::new(zeph_llm::any::AnyProvider::Mock(mock), 10, 10, 30);
 
             let result_empty = extractor.extract("", &[]).await.unwrap();
             assert!(result_empty.is_none());

--- a/crates/zeph-memory/src/semantic/graph.rs
+++ b/crates/zeph-memory/src/semantic/graph.rs
@@ -57,6 +57,8 @@ pub struct GraphExtractionConfig {
     pub conversation_id: Option<i64>,
     /// APEX-MEM: use `insert_or_supersede` instead of `resolve_edge_typed`. Default: `false`.
     pub apex_mem_enabled: bool,
+    /// LLM call timeout for extraction, in seconds. Default: `30`.
+    pub llm_timeout_secs: u64,
 }
 
 impl Default for GraphExtractionConfig {
@@ -78,6 +80,7 @@ impl Default for GraphExtractionConfig {
             belief_revision_similarity_threshold: 0.85,
             conversation_id: None,
             apex_mem_enabled: false,
+            llm_timeout_secs: 30,
         }
     }
 }
@@ -356,7 +359,12 @@ pub async fn extract_and_store(
 ) -> Result<ExtractionResult, MemoryError> {
     use crate::graph::{EntityResolver, GraphExtractor, GraphStore};
 
-    let extractor = GraphExtractor::new(provider.clone(), config.max_entities, config.max_edges);
+    let extractor = GraphExtractor::new(
+        provider.clone(),
+        config.max_entities,
+        config.max_edges,
+        config.llm_timeout_secs,
+    );
     let ctx_refs: Vec<&str> = context_messages.iter().map(String::as_str).collect();
 
     let store = GraphStore::new(pool);

--- a/crates/zeph-memory/src/semantic/mod.rs
+++ b/crates/zeph-memory/src/semantic/mod.rs
@@ -353,6 +353,8 @@ pub struct SemanticMemory {
     ///
     /// `Some` when `memory.retrieval_failures.enabled = true` at bootstrap.
     pub(crate) retrieval_failure_logger: Option<RetrievalFailureLogger>,
+    /// LLM call timeout for summarization, in seconds. Default: `60`.
+    pub(crate) summarization_llm_timeout_secs: u64,
 }
 
 impl SemanticMemory {
@@ -484,6 +486,7 @@ impl SemanticMemory {
             hebbian_lr: 0.1,
             hebbian_spread: HelaSpreadRuntime::default(),
             retrieval_failure_logger: None,
+            summarization_llm_timeout_secs: 60,
         })
     }
 
@@ -547,6 +550,7 @@ impl SemanticMemory {
             hebbian_lr: 0.1,
             hebbian_spread: HelaSpreadRuntime::default(),
             retrieval_failure_logger: None,
+            summarization_llm_timeout_secs: 60,
         })
     }
 
@@ -688,6 +692,15 @@ impl SemanticMemory {
     #[must_use]
     pub fn with_key_facts_dedup_threshold(mut self, threshold: f32) -> Self {
         self.key_facts_dedup_threshold = threshold;
+        self
+    }
+
+    /// Set the LLM call timeout for summarization, in seconds.
+    ///
+    /// Applies to both structured and plain-text fallback summarization calls.
+    #[must_use]
+    pub fn with_summarization_timeout(mut self, timeout_secs: u64) -> Self {
+        self.summarization_llm_timeout_secs = timeout_secs;
         self
     }
 
@@ -1038,6 +1051,7 @@ impl SemanticMemory {
             hebbian_lr: 0.1,
             hebbian_spread: HelaSpreadRuntime::default(),
             retrieval_failure_logger: None,
+            summarization_llm_timeout_secs: 60,
         }
     }
 
@@ -1120,6 +1134,7 @@ impl SemanticMemory {
             hebbian_lr: 0.1,
             hebbian_spread: HelaSpreadRuntime::default(),
             retrieval_failure_logger: None,
+            summarization_llm_timeout_secs: 60,
         })
     }
 

--- a/crates/zeph-memory/src/semantic/recall.rs
+++ b/crates/zeph-memory/src/semantic/recall.rs
@@ -1979,6 +1979,7 @@ mod tests {
             hebbian_lr: 0.1,
             hebbian_spread: crate::HelaSpreadRuntime::default(),
             retrieval_failure_logger: None,
+            summarization_llm_timeout_secs: 60,
         }
     }
 

--- a/crates/zeph-memory/src/semantic/summarization.rs
+++ b/crates/zeph-memory/src/semantic/summarization.rs
@@ -181,7 +181,7 @@ impl SemanticMemory {
 
     /// Call the LLM to produce a [`StructuredSummary`], falling back to plain text on parse error.
     ///
-    /// Both the structured and fallback calls are bounded by a 60-second timeout.
+    /// Both the structured and fallback calls are bounded by `summarization_llm_timeout_secs`.
     ///
     /// # Errors
     ///
@@ -191,8 +191,10 @@ impl SemanticMemory {
         &self,
         chat_messages: &[Message],
     ) -> Result<StructuredSummary, MemoryError> {
+        let timeout_secs = self.summarization_llm_timeout_secs;
+        let timeout = std::time::Duration::from_secs(timeout_secs);
         match tokio::time::timeout(
-            std::time::Duration::from_mins(1),
+            timeout,
             self.provider
                 .chat_typed_erased::<StructuredSummary>(chat_messages),
         )
@@ -203,12 +205,7 @@ impl SemanticMemory {
                 tracing::warn!(
                     "structured summarization failed, falling back to plain text: {e:#}"
                 );
-                match tokio::time::timeout(
-                    std::time::Duration::from_mins(1),
-                    self.provider.chat(chat_messages),
-                )
-                .await
-                {
+                match tokio::time::timeout(timeout, self.provider.chat(chat_messages)).await {
                     Ok(Ok(plain)) => Ok(StructuredSummary {
                         summary: plain,
                         key_facts: vec![],
@@ -217,14 +214,16 @@ impl SemanticMemory {
                     Ok(Err(e)) => Err(MemoryError::Llm(e)),
                     Err(_elapsed) => {
                         tracing::warn!(
-                            "summarization: plain text fallback LLM call timed out after 60s"
+                            "summarization: plain text fallback LLM call timed out after {timeout_secs}s"
                         );
                         Err(MemoryError::Timeout("LLM call timed out".into()))
                     }
                 }
             }
             Err(_elapsed) => {
-                tracing::warn!("summarization: structured LLM call timed out after 60s");
+                tracing::warn!(
+                    "summarization: structured LLM call timed out after {timeout_secs}s"
+                );
                 Err(MemoryError::Timeout("LLM call timed out".into()))
             }
         }

--- a/crates/zeph-memory/src/semantic/tests/graph.rs
+++ b/crates/zeph-memory/src/semantic/tests/graph.rs
@@ -377,6 +377,7 @@ async fn memory_with_in_memory_vector_store() -> (
         hebbian_lr: 0.1,
         hebbian_spread: crate::HelaSpreadRuntime::default(),
         retrieval_failure_logger: None,
+        summarization_llm_timeout_secs: 60,
     };
 
     (memory, embedding_store)

--- a/crates/zeph-memory/src/semantic/tests/mod.rs
+++ b/crates/zeph-memory/src/semantic/tests/mod.rs
@@ -68,6 +68,7 @@ pub(super) async fn test_semantic_memory(_supports_embeddings: bool) -> Semantic
         hebbian_lr: 0.1,
         hebbian_spread: crate::HelaSpreadRuntime::default(),
         retrieval_failure_logger: None,
+        summarization_llm_timeout_secs: 60,
     }
 }
 
@@ -168,6 +169,7 @@ async fn effective_embed_provider_routes_to_dedicated_embed_provider() {
         hebbian_lr: 0.1,
         hebbian_spread: crate::HelaSpreadRuntime::default(),
         retrieval_failure_logger: None,
+        summarization_llm_timeout_secs: 60,
     };
 
     assert!(
@@ -578,6 +580,7 @@ async fn store_correction_embedding_sqlite_clean_db_roundtrip() {
         hebbian_lr: 0.1,
         hebbian_spread: crate::HelaSpreadRuntime::default(),
         retrieval_failure_logger: None,
+        summarization_llm_timeout_secs: 60,
     };
 
     memory
@@ -698,6 +701,7 @@ async fn load_promotion_window_populates_embeddings_from_qdrant() {
         hebbian_lr: 0.1,
         hebbian_spread: crate::HelaSpreadRuntime::default(),
         retrieval_failure_logger: None,
+        summarization_llm_timeout_secs: 60,
     };
 
     let window = memory.load_promotion_window(10).await.unwrap();
@@ -724,6 +728,14 @@ async fn load_promotion_window_no_qdrant_all_none() {
     let window = memory.load_promotion_window(10).await.unwrap();
     assert_eq!(window.len(), 1);
     assert!(window[0].embedding.is_none());
+}
+
+#[tokio::test]
+async fn with_summarization_timeout_stores_custom_value() {
+    let memory = test_semantic_memory(false)
+        .await
+        .with_summarization_timeout(77);
+    assert_eq!(memory.summarization_llm_timeout_secs, 77);
 }
 
 use proptest::prelude::*;

--- a/crates/zeph-memory/src/semantic/tests/query_bias.rs
+++ b/crates/zeph-memory/src/semantic/tests/query_bias.rs
@@ -106,6 +106,7 @@ async fn test_apply_query_bias_dimension_mismatch_returns_unchanged() {
         hebbian_lr: 0.1,
         hebbian_spread: crate::HelaSpreadRuntime::default(),
         retrieval_failure_logger: None,
+        summarization_llm_timeout_secs: 60,
     };
 
     let embedding = vec![0.1_f32, 0.2, 0.3];

--- a/crates/zeph-memory/src/semantic/tests/recall.rs
+++ b/crates/zeph-memory/src/semantic/tests/recall.rs
@@ -85,6 +85,7 @@ async fn test_semantic_memory_sqlite_remember_recall_roundtrip() {
         hebbian_lr: 0.1,
         hebbian_spread: crate::HelaSpreadRuntime::default(),
         retrieval_failure_logger: None,
+        summarization_llm_timeout_secs: 60,
     };
 
     let cid = memory.sqlite().create_conversation().await.unwrap();

--- a/crates/zeph-memory/src/semantic/tests/summarization.rs
+++ b/crates/zeph-memory/src/semantic/tests/summarization.rs
@@ -362,6 +362,7 @@ async fn summarize_fails_when_provider_chat_fails() {
         hebbian_lr: 0.1,
         hebbian_spread: crate::HelaSpreadRuntime::default(),
         retrieval_failure_logger: None,
+        summarization_llm_timeout_secs: 60,
     };
     let cid = memory.sqlite().create_conversation().await.unwrap();
 
@@ -442,6 +443,7 @@ async fn summarize_fallback_to_plain_text_when_structured_fails() {
         hebbian_lr: 0.1,
         hebbian_spread: crate::HelaSpreadRuntime::default(),
         retrieval_failure_logger: None,
+        summarization_llm_timeout_secs: 60,
     };
 
     let cid = memory.sqlite().create_conversation().await.unwrap();
@@ -607,6 +609,7 @@ async fn make_embed_memory_with_threshold(threshold: f32) -> super::super::Seman
         hebbian_lr: 0.1,
         hebbian_spread: crate::HelaSpreadRuntime::default(),
         retrieval_failure_logger: None,
+        summarization_llm_timeout_secs: 60,
     }
 }
 
@@ -715,6 +718,7 @@ async fn store_key_facts_fail_open_on_search_error() {
         hebbian_lr: 0.1,
         hebbian_spread: crate::HelaSpreadRuntime::default(),
         retrieval_failure_logger: None,
+        summarization_llm_timeout_secs: 60,
     };
 
     let cid = memory.sqlite().create_conversation().await.unwrap();

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -426,6 +426,9 @@ impl AppBuilder {
             memory = memory.with_retrieval_failure_logger(logger);
         }
 
+        memory =
+            memory.with_summarization_timeout(self.config.memory.summarization_llm_timeout_secs);
+
         Ok(memory)
     }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1512,6 +1512,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
             sweep_interval_secs: config.memory.consolidation.sweep_interval_secs,
             sweep_batch_size: config.memory.consolidation.sweep_batch_size,
             similarity_threshold: config.memory.consolidation.similarity_threshold,
+            llm_timeout_secs: config.memory.consolidation.llm_timeout_secs,
         };
         let consolidation_provider = app
             .build_consolidation_provider()


### PR DESCRIPTION
## Summary

- Closes #4168 — `ConsolidationConfig.llm_timeout_secs` (default 30s) replaces hardcoded 30s in `propose_merge_op`
- Closes #4169 — `GraphExtractionConfig.llm_timeout_secs` / `GraphConfig.llm_timeout_secs` (default 30s) replace hardcoded 30s in `GraphExtractor::extract`
- Closes #4170 — `MemoryConfig.summarization_llm_timeout_secs` (default 60s) replaces hardcoded 60s in both LLM call paths in `call_summarization_llm`

All new serde fields use `#[serde(default = "...")]` so existing TOML configs work without modification. `warn!` messages include the actual runtime timeout value.

## Test plan

- [x] Full workspace test suite: 9494 tests passed, 21 skipped
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo +nightly fmt --check` clean
- [x] 3 regression tests added asserting non-default timeout values are stored and readable