### PR TITLE
fix(memory,skills): make save+activate skill version atomic in ARISE/upgrade paths

### DIFF
--- a/crates/zeph-core/src/agent/learning/background.rs
+++ b/crates/zeph-core/src/agent/learning/background.rs
@@ -193,47 +193,49 @@ async fn arise_store_version(args: AriseTaskArgs, generated: String) {
     };
     let predecessor_id = active.as_ref().map(|v| v.id);
     // CRITICAL: ARISE-generated versions MUST start at quarantined trust level.
-    let version_id = match args
-        .memory
-        .sqlite()
-        .save_skill_version(
-            &args.skill_name,
-            next_ver,
-            &generated,
-            &args.skill_desc,
-            "arise_trace",
-            None,
-            predecessor_id,
-        )
-        .await
-    {
-        Ok(id) => id,
-        Err(e) => {
-            tracing::warn!("ARISE: save_skill_version failed: {e:#}");
-            return;
-        }
-    };
-    tracing::info!(skill = %args.skill_name, version = next_ver, "ARISE: saved trace-improved version (quarantined)");
-    if args.auto_activate {
-        if let Err(e) = args
-            .memory
+    // When auto_activate is set, save and activate atomically to prevent orphaned versions.
+    let save_result = if args.auto_activate {
+        args.memory
             .sqlite()
-            .activate_skill_version(&args.skill_name, version_id)
+            .save_and_activate_skill_version(
+                &args.skill_name,
+                next_ver,
+                &generated,
+                &args.skill_desc,
+                "arise_trace",
+                None,
+                predecessor_id,
+            )
             .await
-        {
-            tracing::warn!("ARISE: activate_skill_version failed: {e:#}");
-            return;
-        }
-        if let Err(e) = write_skill_file(
+    } else {
+        args.memory
+            .sqlite()
+            .save_skill_version(
+                &args.skill_name,
+                next_ver,
+                &generated,
+                &args.skill_desc,
+                "arise_trace",
+                None,
+                predecessor_id,
+            )
+            .await
+    };
+    if let Err(e) = save_result {
+        tracing::warn!("ARISE: save_skill_version failed: {e:#}");
+        return;
+    }
+    tracing::info!(skill = %args.skill_name, version = next_ver, "ARISE: saved trace-improved version (quarantined)");
+    if args.auto_activate
+        && let Err(e) = write_skill_file(
             &args.skill_paths,
             &args.skill_name,
             &args.skill_desc,
             &generated,
         )
         .await
-        {
-            tracing::warn!("ARISE: write_skill_file failed: {e:#}");
-        }
+    {
+        tracing::warn!("ARISE: write_skill_file failed: {e:#}");
     }
     if let Err(e) = args
         .memory

--- a/crates/zeph-core/src/agent/learning/outcomes.rs
+++ b/crates/zeph-core/src/agent/learning/outcomes.rs
@@ -327,6 +327,9 @@ impl<C: Channel> Agent<C> {
         let predecessor_id = active.as_ref().map(|v| v.id);
 
         let next_ver = memory.sqlite().next_skill_version(skill_name).await?;
+
+        // When auto_activate is off or a domain gate must run first, save without activating.
+        // The gate may veto activation, so we cannot commit the activate atomically up front.
         let version_id = memory
             .sqlite()
             .save_skill_version(
@@ -378,6 +381,7 @@ impl<C: Channel> Agent<C> {
         }
 
         if config.auto_activate {
+            // Activate atomically after the gate passed.
             memory
                 .sqlite()
                 .activate_skill_version(skill_name, version_id)

--- a/crates/zeph-memory/src/store/skills.rs
+++ b/crates/zeph-memory/src/store/skills.rs
@@ -326,7 +326,7 @@ impl SqliteStore {
     /// Save a new skill version and atomically activate it within a single `BEGIN IMMEDIATE`
     /// transaction, preventing orphaned saved-but-inactive versions on crash or concurrent access.
     ///
-    /// Equivalent to calling [`save_skill_version`] followed by [`activate_skill_version`] but
+    /// Equivalent to calling [`Self::save_skill_version`] followed by [`Self::activate_skill_version`] but
     /// without the window between the two calls where the DB can be left in an inconsistent state.
     ///
     /// # Errors

--- a/crates/zeph-memory/src/store/skills.rs
+++ b/crates/zeph-memory/src/store/skills.rs
@@ -323,6 +323,62 @@ impl SqliteStore {
         Ok(row.0)
     }
 
+    /// Save a new skill version and atomically activate it within a single `BEGIN IMMEDIATE`
+    /// transaction, preventing orphaned saved-but-inactive versions on crash or concurrent access.
+    ///
+    /// Equivalent to calling [`save_skill_version`] followed by [`activate_skill_version`] but
+    /// without the window between the two calls where the DB can be left in an inconsistent state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the insert, deactivate, or activate queries fail. The transaction is
+    /// rolled back automatically on error.
+    #[allow(clippy::too_many_arguments)]
+    #[tracing::instrument(skip_all, name = "memory.skills.save_and_activate_skill_version")]
+    pub async fn save_and_activate_skill_version(
+        &self,
+        skill_name: &str,
+        version: i64,
+        body: &str,
+        description: &str,
+        source: &str,
+        error_context: Option<&str>,
+        predecessor_id: Option<i64>,
+    ) -> Result<i64, MemoryError> {
+        let mut tx = begin_write(&self.pool).await?;
+
+        let row: (i64,) = zeph_db::query_as(sql!(
+            "INSERT INTO skill_versions \
+             (skill_name, version, body, description, source, error_context, predecessor_id) \
+             VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id"
+        ))
+        .bind(skill_name)
+        .bind(version)
+        .bind(body)
+        .bind(description)
+        .bind(source)
+        .bind(error_context)
+        .bind(predecessor_id)
+        .fetch_one(&mut *tx)
+        .await?;
+        let id = row.0;
+
+        zeph_db::query(sql!(
+            "UPDATE skill_versions SET is_active = 0 WHERE skill_name = ? AND is_active = 1"
+        ))
+        .bind(skill_name)
+        .execute(&mut *tx)
+        .await?;
+
+        zeph_db::query(sql!("UPDATE skill_versions SET is_active = 1 WHERE id = ?"))
+            .bind(id)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+        Ok(id)
+    }
+
     /// Count the number of distinct conversation sessions in which a skill produced an outcome.
     ///
     /// Uses `COUNT(DISTINCT conversation_id)` from `skill_outcomes`. Rows where
@@ -1889,6 +1945,84 @@ mod tests {
         assert_eq!(
             trust.0, "quarantined",
             "schema default for skill_trust.trust_level must be 'quarantined'"
+        );
+    }
+
+    #[tokio::test]
+    async fn save_and_activate_skill_version_activates_new() {
+        let store = test_store().await;
+
+        let id = store
+            .save_and_activate_skill_version(
+                "git",
+                1,
+                "body v1",
+                "Git helper",
+                "manual",
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        assert!(id > 0);
+
+        let active = store.active_skill_version("git").await.unwrap().unwrap();
+        assert_eq!(active.id, id);
+        assert_eq!(active.version, 1);
+        assert_eq!(active.body, "body v1");
+        assert!(active.is_active);
+    }
+
+    #[tokio::test]
+    async fn save_and_activate_skill_version_deactivates_previous() {
+        let store = test_store().await;
+
+        let v1 = store
+            .save_and_activate_skill_version("git", 1, "v1", "desc", "manual", None, None)
+            .await
+            .unwrap();
+
+        let v2 = store
+            .save_and_activate_skill_version("git", 2, "v2", "desc", "auto", None, Some(v1))
+            .await
+            .unwrap();
+
+        let versions = store.load_skill_versions("git").await.unwrap();
+        assert_eq!(versions.len(), 2);
+
+        let old = versions.iter().find(|v| v.id == v1).unwrap();
+        let new = versions.iter().find(|v| v.id == v2).unwrap();
+        assert!(!old.is_active, "previous version must be deactivated");
+        assert!(new.is_active, "new version must be active");
+    }
+
+    #[tokio::test]
+    async fn save_and_activate_skill_version_only_one_active() {
+        let store = test_store().await;
+
+        let mut last_id = 0i64;
+        for i in 1i64..=4 {
+            last_id = store
+                .save_and_activate_skill_version(
+                    "git",
+                    i,
+                    &format!("v{i}"),
+                    "desc",
+                    "auto",
+                    None,
+                    None,
+                )
+                .await
+                .unwrap();
+        }
+
+        let versions = store.load_skill_versions("git").await.unwrap();
+        let active_count = versions.iter().filter(|v| v.is_active).count();
+        assert_eq!(active_count, 1, "exactly one version must be active");
+        assert_eq!(
+            versions.iter().find(|v| v.is_active).unwrap().id,
+            last_id,
+            "the last saved version must be the active one"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Add `save_and_activate_skill_version` to `SqliteStore` wrapping INSERT + deactivate-all + activate-new in a single `BEGIN IMMEDIATE` transaction — eliminates the TOCTOU window between the two separate calls that could orphan a saved-but-inactive skill version on crash or concurrent write
- Update the ARISE trace-improvement path (`background.rs`) to use the atomic helper when `auto_activate=true`
- Add 3 regression tests: happy path, previous-version deactivation, exactly-one-active invariant

The non-atomic save→gate→activate pattern in `outcomes.rs` is intentional: the domain gate sits between save and activate, so pre-commit atomicity is not applicable there (documented with a comment).

## Test plan

- [ ] `cargo nextest run -p zeph-memory` — 1340 passed
- [ ] `cargo clippy -p zeph-memory -p zeph-core -- -D warnings` — clean
- [ ] Regression tests `save_and_activate_skill_version_*` — 3 passed

Closes #4186