### PR TITLE
fix(memory,core): add timeout guards to embed calls and tracing spans

### DIFF
--- a/crates/zeph-core/src/agent/mcp.rs
+++ b/crates/zeph-core/src/agent/mcp.rs
@@ -11,6 +11,7 @@ impl<C: Channel> Agent<C> {
     /// All output is collected into the returned string; no channel sends are
     /// performed.  This makes the future `Send`-compatible for use in
     /// `AgentAccess::handle_mcp`.
+    #[tracing::instrument(skip_all, name = "core.agent.handle_mcp_command")]
     pub(super) async fn handle_mcp_command(
         &mut self,
         args: &str,

--- a/crates/zeph-core/src/agent/slash_commands.rs
+++ b/crates/zeph-core/src/agent/slash_commands.rs
@@ -452,6 +452,7 @@ impl<C: crate::channel::Channel> Agent<C> {
         }
     }
 
+    #[tracing::instrument(skip_all, name = "core.agent.handle_skills")]
     pub(super) async fn handle_skills_as_string(
         &mut self,
         subcommand: &str,

--- a/crates/zeph-memory/src/admission.rs
+++ b/crates/zeph-memory/src/admission.rs
@@ -348,10 +348,14 @@ async fn compute_semantic_novelty(
     if !provider.supports_embeddings() {
         return 1.0;
     }
-    let vector = match provider.embed(content).await {
-        Ok(v) => v,
-        Err(e) => {
+    let vector = match tokio::time::timeout(Duration::from_secs(5), provider.embed(content)).await {
+        Ok(Ok(v)) => v,
+        Ok(Err(e)) => {
             tracing::debug!(error = %e, "A-MAC: failed to embed for novelty, using 1.0");
+            return 1.0;
+        }
+        Err(_) => {
+            tracing::warn!("A-MAC: embed timed out in semantic_novelty, using 1.0");
             return 1.0;
         }
     };
@@ -443,20 +447,30 @@ async fn compute_goal_utility(
         return 0.0;
     }
 
-    let goal_emb = match provider.embed(goal_text).await {
-        Ok(v) => v,
-        Err(e) => {
-            tracing::debug!(error = %e, "goal_utility: failed to embed goal text, using 0.0");
-            return 0.0;
-        }
-    };
-    let content_emb = match provider.embed(content).await {
-        Ok(v) => v,
-        Err(e) => {
-            tracing::debug!(error = %e, "goal_utility: failed to embed content, using 0.0");
-            return 0.0;
-        }
-    };
+    let goal_emb =
+        match tokio::time::timeout(Duration::from_secs(5), provider.embed(goal_text)).await {
+            Ok(Ok(v)) => v,
+            Ok(Err(e)) => {
+                tracing::debug!(error = %e, "goal_utility: failed to embed goal text, using 0.0");
+                return 0.0;
+            }
+            Err(_) => {
+                tracing::warn!("A-MAC: embed timed out in goal_utility (goal text), using 0.0");
+                return 0.0;
+            }
+        };
+    let content_emb =
+        match tokio::time::timeout(Duration::from_secs(5), provider.embed(content)).await {
+            Ok(Ok(v)) => v,
+            Ok(Err(e)) => {
+                tracing::debug!(error = %e, "goal_utility: failed to embed content, using 0.0");
+                return 0.0;
+            }
+            Err(_) => {
+                tracing::warn!("A-MAC: embed timed out in goal_utility (content), using 0.0");
+                return 0.0;
+            }
+        };
 
     // Qdrant is used for novelty search, not for goal utility — we compute cosine directly.
     let _ = qdrant; // unused here; kept for API symmetry


### PR DESCRIPTION
## Summary

- Wrap `provider.embed()` calls in `compute_semantic_novelty` and `compute_goal_utility` with `tokio::time::timeout(Duration::from_secs(5), ...)` to prevent unbounded stalls on slow embedding backends; on timeout log a `warn!` and return the conservative default (`1.0` / `0.0`)
- Add `#[tracing::instrument(skip_all, name = "core.agent.handle_mcp_command")]` to `Agent::handle_mcp_command` so MCP dispatch appears in local traces
- Add `#[tracing::instrument(skip_all, name = "core.agent.handle_skills")]` to `Agent::handle_skills_as_string` so skills dispatch appears in local traces

## Test plan

- [ ] `cargo build -p zeph-memory -p zeph-core` passes
- [ ] `cargo check -p zeph-memory -p zeph-core` passes with zero warnings
- [ ] `cargo nextest run --config-file .github/nextest.toml -p zeph-memory -p zeph-core --lib` passes
- [ ] Local trace confirms `core.agent.handle_mcp_command` and `core.agent.handle_skills` spans visible

Closes #4199
Closes #4189