### PR TITLE
feat(agent-feedback): make JudgeDetector LLM timeout configurable

### DIFF
--- a/crates/zeph-agent-feedback/src/lib.rs
+++ b/crates/zeph-agent-feedback/src/lib.rs
@@ -691,21 +691,20 @@ impl JudgeDetector {
     /// # Errors
     ///
     /// Returns [`JudgeError::Llm`] if the provider call fails, or [`JudgeError::Timeout`]
-    /// if the LLM does not respond within 30 seconds.
+    /// if the LLM does not respond within `timeout`.
     #[tracing::instrument(skip(provider, user_message, assistant_response), err)]
     pub async fn evaluate(
         provider: &AnyProvider,
         user_message: &str,
         assistant_response: &str,
         confidence_threshold: f32,
+        timeout: Duration,
     ) -> Result<JudgeVerdict, JudgeError> {
         let messages = Self::build_messages(user_message, assistant_response);
-        let verdict: JudgeVerdict = tokio::time::timeout(
-            Duration::from_secs(30),
-            provider.chat_typed_erased(&messages),
-        )
-        .await
-        .map_err(|_| JudgeError::Timeout)??;
+        let verdict: JudgeVerdict =
+            tokio::time::timeout(timeout, provider.chat_typed_erased(&messages))
+                .await
+                .map_err(|_| JudgeError::Timeout)??;
 
         tracing::debug!(
             is_correction = verdict.is_correction,
@@ -1939,7 +1938,14 @@ mod tests {
         let mock = zeph_llm::mock::MockProvider::default().with_delay(60_000);
         let provider = zeph_llm::any::AnyProvider::Mock(mock);
         let handle = tokio::spawn(async move {
-            JudgeDetector::evaluate(&provider, "user msg", "assistant resp", 0.5).await
+            JudgeDetector::evaluate(
+                &provider,
+                "user msg",
+                "assistant resp",
+                0.5,
+                Duration::from_secs(30),
+            )
+            .await
         });
         tokio::time::advance(Duration::from_secs(31)).await;
         let result = handle.await.expect("task panicked");

--- a/crates/zeph-config/src/learning.rs
+++ b/crates/zeph-config/src/learning.rs
@@ -44,6 +44,10 @@ fn default_judge_adaptive_high() -> f32 {
     0.8
 }
 
+fn default_judge_llm_timeout_secs() -> u64 {
+    30
+}
+
 fn default_correction_recall_limit() -> u32 {
     3
 }
@@ -197,6 +201,10 @@ pub struct LearningConfig {
     /// Regex confidence at or above this value is accepted without judge confirmation.
     #[serde(default = "default_judge_adaptive_high")]
     pub judge_adaptive_high: f32,
+    /// Maximum seconds to wait for the judge LLM to respond before returning
+    /// [`JudgeError::Timeout`]. Applies to `detector_mode = "judge"` only.
+    #[serde(default = "default_judge_llm_timeout_secs")]
+    pub judge_llm_timeout_secs: u64,
     #[serde(default = "default_correction_recall_limit")]
     pub correction_recall_limit: u32,
     #[serde(default = "default_correction_min_similarity")]
@@ -324,6 +332,7 @@ impl Default for LearningConfig {
             feedback_provider: ProviderName::default(),
             judge_adaptive_low: default_judge_adaptive_low(),
             judge_adaptive_high: default_judge_adaptive_high(),
+            judge_llm_timeout_secs: default_judge_llm_timeout_secs(),
             correction_recall_limit: default_correction_recall_limit(),
             correction_min_similarity: default_correction_min_similarity(),
             auto_promote_min_uses: default_auto_promote_min_uses(),
@@ -418,6 +427,14 @@ feedback_provider = "fast""#;
         assert_eq!(cfg.min_failures, 3);
         assert_eq!(cfg.detector_mode, DetectorMode::Regex);
         assert!(cfg.feedback_provider.is_empty());
+    }
+
+    #[test]
+    fn judge_llm_timeout_secs_default_and_roundtrip() {
+        let cfg = LearningConfig::default();
+        assert_eq!(cfg.judge_llm_timeout_secs, 30);
+        let cfg: LearningConfig = toml::from_str("judge_llm_timeout_secs = 60").unwrap();
+        assert_eq!(cfg.judge_llm_timeout_secs, 60);
     }
 
     #[test]

--- a/crates/zeph-config/src/learning.rs
+++ b/crates/zeph-config/src/learning.rs
@@ -201,8 +201,8 @@ pub struct LearningConfig {
     /// Regex confidence at or above this value is accepted without judge confirmation.
     #[serde(default = "default_judge_adaptive_high")]
     pub judge_adaptive_high: f32,
-    /// Maximum seconds to wait for the judge LLM to respond before returning
-    /// [`JudgeError::Timeout`]. Applies to `detector_mode = "judge"` only.
+    /// Maximum seconds to wait for the judge LLM to respond before timing out.
+    /// Applies to `detector_mode = "judge"` only.
     #[serde(default = "default_judge_llm_timeout_secs")]
     pub judge_llm_timeout_secs: u64,
     #[serde(default = "default_correction_recall_limit")]

--- a/crates/zeph-core/src/agent/corrections.rs
+++ b/crates/zeph-core/src/agent/corrections.rs
@@ -112,6 +112,13 @@ impl<C: crate::channel::Channel> Agent<C> {
             .config
             .as_ref()
             .map_or(0.6_f32, |c| c.correction_confidence_threshold);
+        let judge_timeout = std::time::Duration::from_secs(
+            self.services
+                .learning_engine
+                .config
+                .as_ref()
+                .map_or(30, |c| c.judge_llm_timeout_secs),
+        );
 
         if let Some(llm_classifier) = self.services.feedback.llm_classifier.clone() {
             let classifier_metrics_bg = self.runtime.metrics.classifier_metrics.clone();
@@ -146,6 +153,7 @@ impl<C: crate::channel::Channel> Agent<C> {
                     user_msg_owned,
                     assistant_snippet,
                     confidence_threshold,
+                    judge_timeout,
                     memory_arc,
                     conv_id_bg,
                     skill_name,
@@ -448,11 +456,13 @@ async fn evaluate_with_llm_classifier(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn evaluate_with_judge(
     judge_provider: zeph_llm::any::AnyProvider,
     user_msg: String,
     assistant: String,
     confidence_threshold: f32,
+    timeout: std::time::Duration,
     memory_arc: Option<std::sync::Arc<zeph_memory::semantic::SemanticMemory>>,
     conv_id: Option<zeph_memory::ConversationId>,
     skill_name: String,
@@ -462,6 +472,7 @@ async fn evaluate_with_judge(
         &user_msg,
         &assistant,
         confidence_threshold,
+        timeout,
     )
     .await
     {


### PR DESCRIPTION
## Summary

- Adds `judge_llm_timeout_secs: u64` to `LearningConfig` (default: 30, fully TOML-configurable via `#[serde(default)]`)
- Threads it through `JudgeDetector::evaluate`, replacing the hardcoded `Duration::from_secs(30)`
- Adds a unit test for default value and TOML roundtrip

Follows the same pattern established in #4198 for other configurable LLM timeouts.

## Test plan

- [x] `cargo nextest run --workspace --lib --bins` — 9503 passed
- [x] `cargo clippy --workspace -- -D warnings` — 0 warnings
- [x] `cargo +nightly fmt --check` — clean
- [x] Unit test `judge_llm_timeout_secs_default_and_roundtrip` verifies default (30) and custom value (60) via TOML

Closes #4210