### PR TITLE
test(memory,subagent): add timeout regression and sanitize_identity_field tests

### DIFF
--- a/crates/zeph-memory/Cargo.toml
+++ b/crates/zeph-memory/Cargo.toml
@@ -61,7 +61,7 @@ insta.workspace = true
 proptest.workspace = true
 tempfile.workspace = true
 testcontainers.workspace = true
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 toml.workspace = true
 tracing-test.workspace = true
 zeph-llm = { workspace = true, features = ["testing"] }

--- a/crates/zeph-memory/src/admission.rs
+++ b/crates/zeph-memory/src/admission.rs
@@ -876,4 +876,46 @@ mod tests {
         let ctrl = ctrl.with_goal_gate(config);
         assert!(ctrl.weights.goal_utility.abs() < f32::EPSILON);
     }
+
+    // ── timeout regression tests (#4212) ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn compute_semantic_novelty_returns_one_on_embed_timeout() {
+        tokio::time::pause();
+        let mock = zeph_llm::mock::MockProvider::default()
+            .with_embed_delay(10_000)
+            .with_embedding(vec![0.0; 4]);
+        let provider = zeph_llm::any::AnyProvider::Mock(mock);
+        let handle =
+            tokio::spawn(async move { compute_semantic_novelty("hello", &provider, None).await });
+        tokio::time::advance(std::time::Duration::from_secs(6)).await;
+        let result = handle.await.expect("task panicked");
+        assert!(
+            (result - 1.0).abs() < f32::EPSILON,
+            "expected 1.0 on embed timeout, got {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn compute_goal_utility_returns_zero_on_embed_timeout() {
+        tokio::time::pause();
+        let mock = zeph_llm::mock::MockProvider::default()
+            .with_embed_delay(10_000)
+            .with_embedding(vec![0.0; 4]);
+        let provider = zeph_llm::any::AnyProvider::Mock(mock);
+        let gate = GoalGateConfig {
+            weight: 0.5,
+            threshold: 0.5,
+            provider: None,
+        };
+        let handle = tokio::spawn(async move {
+            compute_goal_utility("content", "goal", &gate, &provider, None).await
+        });
+        tokio::time::advance(std::time::Duration::from_secs(6)).await;
+        let result = handle.await.expect("task panicked");
+        assert!(
+            result.abs() < f32::EPSILON,
+            "expected 0.0 on embed timeout, got {result}"
+        );
+    }
 }

--- a/crates/zeph-subagent/src/manager.rs
+++ b/crates/zeph-subagent/src/manager.rs
@@ -4087,4 +4087,43 @@ mod tests {
              got: {prompt_empty}"
         );
     }
+
+    // ── sanitize_identity_field unit tests (#4183) ───────────────────────────
+
+    #[test]
+    fn sanitize_identity_field_passthrough_short_ascii() {
+        assert_eq!(sanitize_identity_field("planner"), "planner");
+    }
+
+    #[test]
+    fn sanitize_identity_field_newline_injection_returns_first_line() {
+        let input = "planner\nmalicious second line\nevil third";
+        assert_eq!(sanitize_identity_field(input), "planner");
+    }
+
+    #[test]
+    fn sanitize_identity_field_caps_at_128_chars() {
+        let long = "a".repeat(200);
+        let result = sanitize_identity_field(&long);
+        assert_eq!(result.len(), 128);
+    }
+
+    #[test]
+    fn sanitize_identity_field_empty_string_returns_empty() {
+        assert_eq!(sanitize_identity_field(""), "");
+    }
+
+    #[test]
+    fn sanitize_identity_field_unicode_char_safe_truncation() {
+        // Each '€' is 3 bytes in UTF-8. Build a string of 130 '€' chars (390 bytes).
+        // The function caps at 128 chars, so it must return exactly 128 '€' chars (384 bytes)
+        // without splitting a codepoint.
+        let input: String = "€".repeat(130);
+        let result = sanitize_identity_field(&input);
+        assert_eq!(result.chars().count(), 128);
+        assert!(
+            result.is_char_boundary(result.len()),
+            "result must be valid UTF-8"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Add mock-based timeout regression tests for `compute_semantic_novelty` and `compute_goal_utility` in `zeph-memory` using `MockProvider::with_embed_delay` + `tokio::time::pause/advance` to trigger the 5s internal timeout without real waiting; assert fallback sentinels (`1.0` for novelty, `0.0` for utility)
- Add `tokio` `test-util` dev-dependency to `zeph-memory`
- Add 5 direct unit tests for `sanitize_identity_field` in `zeph-subagent` covering: passthrough, newline injection truncation, 128-char cap, empty string, and Unicode-safe truncation

## Test plan

- [ ] `cargo nextest run -p zeph-memory -E 'test(timeout)'` — 2 new tests pass
- [ ] `cargo nextest run -p zeph-subagent -E 'test(sanitize)'` — 5 new tests pass
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy -p zeph-memory -p zeph-subagent -- -D warnings` — 0 warnings

Closes #4212
Closes #4183