### PR TITLE
refactor(commands): migrate debug.rs and session.rs to test_helpers; add docs

### DIFF
--- a/crates/zeph-commands/src/handlers/debug.rs
+++ b/crates/zeph-commands/src/handlers/debug.rs
@@ -157,49 +157,30 @@ mod tests {
     use super::*;
     use crate::CommandRegistry;
     use crate::context::CommandContext;
-    use crate::sink::ChannelSink;
+    use crate::handlers::test_helpers::{MockMessages, MockSession};
+    use crate::sink::NullSink;
     use crate::traits::debug::DebugAccess;
-    use crate::traits::messages::MessageAccess;
     use crate::traits::session::SessionAccess;
     use std::future::Future;
     use std::pin::Pin;
 
-    struct MockSession;
-
-    impl SessionAccess for MockSession {
-        fn supports_exit(&self) -> bool {
-            false
+    fn make_ctx<'a>(
+        sink: &'a mut NullSink,
+        debug: &'a mut MockDebug,
+        messages: &'a mut MockMessages,
+        session: &'a MockSession,
+        agent: &'a mut crate::NullAgent,
+    ) -> crate::context::CommandContext<'a> {
+        crate::context::CommandContext {
+            sink,
+            debug,
+            messages,
+            session: session as &dyn SessionAccess,
+            agent,
         }
     }
 
-    struct MockSink;
-
-    impl ChannelSink for MockSink {
-        fn send<'a>(
-            &'a mut self,
-            _msg: &'a str,
-        ) -> Pin<Box<dyn Future<Output = Result<(), CommandError>> + Send + 'a>> {
-            Box::pin(async { Ok(()) })
-        }
-
-        fn flush_chunks<'a>(
-            &'a mut self,
-        ) -> Pin<Box<dyn Future<Output = Result<(), CommandError>> + Send + 'a>> {
-            Box::pin(async { Ok(()) })
-        }
-
-        fn send_queue_count<'a>(
-            &'a mut self,
-            _count: usize,
-        ) -> Pin<Box<dyn Future<Output = Result<(), CommandError>> + Send + 'a>> {
-            Box::pin(async { Ok(()) })
-        }
-
-        fn supports_exit(&self) -> bool {
-            false
-        }
-    }
-
+    // Stateful mock required to assert dump enable/format behaviour.
     struct MockDebug {
         dump_active: bool,
         format: String,
@@ -255,46 +236,9 @@ mod tests {
         }
     }
 
-    struct MockMessages;
-
-    impl MessageAccess for MockMessages {
-        fn clear_history(&mut self) {}
-
-        fn queue_len(&self) -> usize {
-            0
-        }
-
-        fn drain_queue(&mut self) -> usize {
-            0
-        }
-
-        fn notify_queue_count<'a>(
-            &'a mut self,
-            _count: usize,
-        ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
-            Box::pin(async {})
-        }
-    }
-
-    fn make_ctx<'a>(
-        sink: &'a mut MockSink,
-        debug: &'a mut MockDebug,
-        messages: &'a mut MockMessages,
-        session: &'a MockSession,
-        agent: &'a mut crate::NullAgent,
-    ) -> CommandContext<'a> {
-        CommandContext {
-            sink,
-            debug,
-            messages,
-            session: session as &dyn SessionAccess,
-            agent,
-        }
-    }
-
     #[tokio::test]
     async fn log_command_formats_status() {
-        let mut sink = MockSink;
+        let mut sink = NullSink;
         let mut debug = MockDebug::ok();
         let mut messages = MockMessages;
         let session = MockSession;
@@ -309,7 +253,7 @@ mod tests {
 
     #[tokio::test]
     async fn debug_dump_no_args_reports_inactive() {
-        let mut sink = MockSink;
+        let mut sink = NullSink;
         let mut debug = MockDebug::ok();
         let mut messages = MockMessages;
         let session = MockSession;
@@ -324,7 +268,7 @@ mod tests {
 
     #[tokio::test]
     async fn debug_dump_with_path_enables_dump() {
-        let mut sink = MockSink;
+        let mut sink = NullSink;
         let mut debug = MockDebug::ok();
         let mut messages = MockMessages;
         let session = MockSession;
@@ -342,7 +286,7 @@ mod tests {
 
     #[tokio::test]
     async fn dump_format_no_args_shows_current() {
-        let mut sink = MockSink;
+        let mut sink = NullSink;
         let mut debug = MockDebug::ok();
         let mut messages = MockMessages;
         let session = MockSession;
@@ -357,7 +301,7 @@ mod tests {
 
     #[tokio::test]
     async fn dump_format_with_arg_switches_format() {
-        let mut sink = MockSink;
+        let mut sink = NullSink;
         let mut debug = MockDebug::ok();
         let mut messages = MockMessages;
         let session = MockSession;

--- a/crates/zeph-commands/src/handlers/session.rs
+++ b/crates/zeph-commands/src/handlers/session.rs
@@ -195,8 +195,8 @@ mod tests {
     use super::*;
     use crate::CommandRegistry;
     use crate::context::CommandContext;
+    use crate::handlers::test_helpers::MockDebug;
     use crate::sink::ChannelSink;
-    use crate::traits::debug::DebugAccess;
     use crate::traits::messages::MessageAccess;
     use crate::traits::session::SessionAccess;
     use std::future::Future;
@@ -232,41 +232,6 @@ mod tests {
 
         fn supports_exit(&self) -> bool {
             false
-        }
-    }
-
-    struct MockDebug;
-
-    impl DebugAccess for MockDebug {
-        fn log_status(&self) -> String {
-            String::new()
-        }
-
-        fn read_log_tail<'a>(
-            &'a self,
-            _n: usize,
-        ) -> Pin<Box<dyn Future<Output = Option<String>> + Send + 'a>> {
-            Box::pin(async { None })
-        }
-
-        fn scrub(&self, text: &str) -> String {
-            text.to_owned()
-        }
-
-        fn dump_status(&self) -> Option<String> {
-            None
-        }
-
-        fn dump_format_name(&self) -> String {
-            "raw".to_owned()
-        }
-
-        fn enable_dump(&mut self, _dir: &str) -> Result<String, CommandError> {
-            Ok("/tmp".to_owned())
-        }
-
-        fn set_dump_format(&mut self, _name: &str) -> Result<(), CommandError> {
-            Ok(())
         }
     }
 

--- a/crates/zeph-commands/src/handlers/test_helpers.rs
+++ b/crates/zeph-commands/src/handlers/test_helpers.rs
@@ -15,6 +15,10 @@ use crate::traits::debug::DebugAccess;
 use crate::traits::messages::MessageAccess;
 use crate::traits::session::SessionAccess;
 
+/// No-op stub for [`DebugAccess`] used in handler unit tests.
+///
+/// All methods return empty/default values; use a local override when a test
+/// needs to assert dump state or format changes.
 pub struct MockDebug;
 
 impl DebugAccess for MockDebug {
@@ -50,6 +54,10 @@ impl DebugAccess for MockDebug {
     }
 }
 
+/// No-op stub for [`MessageAccess`] used in handler unit tests.
+///
+/// History and queue operations are no-ops; use a local override when a test
+/// needs to assert that history was cleared or the queue was drained.
 pub struct MockMessages;
 
 impl MessageAccess for MockMessages {
@@ -71,6 +79,10 @@ impl MessageAccess for MockMessages {
     }
 }
 
+/// No-op stub for [`SessionAccess`] used in handler unit tests.
+///
+/// Always reports `supports_exit = false`; use a local override when exit
+/// behaviour needs to be asserted.
 pub struct MockSession;
 
 impl SessionAccess for MockSession {
@@ -79,6 +91,9 @@ impl SessionAccess for MockSession {
     }
 }
 
+/// Assemble a [`CommandContext`] from the provided mock components.
+///
+/// Convenience constructor so handler tests do not repeat the struct literal.
 pub fn make_ctx<'a>(
     sink: &'a mut NullSink,
     debug: &'a mut MockDebug,


### PR DESCRIPTION
## Summary

- Removes ~100 lines of duplicate mock definitions from `debug.rs` and `session.rs` test modules by importing the stateless mocks (`MockDebug`, `MockMessages`, `MockSession`) from `crate::handlers::test_helpers` where applicable.
- `debug.rs`: retains a local stateful `MockDebug` (needed to assert `enable_dump`/`set_dump_format` state transitions); replaces no-op `MockSink` with `NullSink`; imports `MockMessages` and `MockSession` from test_helpers.
- `session.rs`: imports `MockDebug` from test_helpers; retains local stateful `MockSink` (sent-buffer assertions), `MockMessages` (cleared/queue assertions), and `MockSession` (supports_exit assertions).
- Adds `///` doc comments to the four previously undocumented pub items in `test_helpers.rs` (`MockDebug`, `MockMessages`, `MockSession`, `make_ctx`).

## Test plan

- [x] `cargo nextest run -p zeph-commands` — 94 tests pass
- [x] `cargo nextest run --workspace --lib --bins` — 9509 tests pass, 0 failures
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo doc --no-deps -p zeph-commands` — no broken intra-doc links

Closes #4099
Closes #4097