### PR TITLE
feat(core,config): add stop hook block cap with configurable limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `exfil_wget_post`, `exfil_api_key_send`, `exfil_extract_all`, `exfil_leak`, `exfil_forward_to`,
   `exfil_exfiltrate`, `exfil_send_secret`) for detecting skills that attempt to exfiltrate data
   via shell network tools or social-engineering directives (closes #3959).
+- `zeph-config`: `hooks.hook_block_cap` config option (default: 8) — caps consecutive `PreToolUse`
+  hook blocks per turn; when the cap is reached the turn ends with a warning message. Counter
+  increments per blocked tool call (if a tier has N blocked tools, count jumps by N). Use 0 for no
+  cap. Parity with Claude Code v2.1.143 (closes #3995).
 - `zeph-plugins`: Stage-1 advisory SKILL.md injection scan on `plugin add` — each `SKILL.md` is
   scanned with `scan_skill_body` before files are copied; matches emit `WARN` tracing events but
   never block installation (advisory only, closes #3959).
@@ -35,6 +39,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `zeph-config`: `skills.semantic_scan` (bool, default `false`) and
   `skills.semantic_scan_provider` (provider name, default empty) config fields for opt-in
   LLM-backed SKILL.md compliance scan (closes #3959).
+
+### Changed (behavior fix)
+
+- `zeph-core`: `PreToolUse` hooks with `fail_closed = true` now correctly block tool execution when
+  the hook returns an error; previously hook errors were logged but the tool proceeded (fail-open
+  behavior despite `fail_closed` setting). This is a semantic behavior change — tools guarded by
+  `fail_closed` hooks that fail intermittently will no longer execute silently (closes #3995).
 
 ### Changed
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -1366,6 +1366,10 @@ provider_persistence = true
 #   [[hooks.permission_denied]] — a tool call was blocked by a RuntimeLayer check
 #   [hooks.file_changed]       — watched filesystem paths changed (see watch_paths)
 
+# Maximum number of PreToolUse hook blocks per turn before the turn is ended with a warning.
+# Counter increments once per blocked tool call. Use 0 for no cap.
+# hook_block_cap = 8
+
 # ── hooks.cwd_changed ─────────────────────────────────────────────────────────
 # Fired each time the agent changes its working directory.
 # Env vars set for command hooks: ZEPH_NEW_CWD (new path), ZEPH_OLD_CWD (previous path).

--- a/crates/zeph-config/src/hooks.rs
+++ b/crates/zeph-config/src/hooks.rs
@@ -11,6 +11,10 @@ fn default_debounce_ms() -> u64 {
     500
 }
 
+fn default_hook_block_cap() -> usize {
+    8
+}
+
 /// Configuration for hooks triggered when watched files change.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
@@ -39,7 +43,7 @@ impl Default for FileChangedConfig {
 ///
 /// Each sub-section corresponds to a lifecycle event. All sections default to
 /// empty (no hooks). Events fire in the order hooks are listed.
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
 pub struct HooksConfig {
     /// Hooks fired when the agent's working directory changes via `set_working_directory`.
@@ -69,6 +73,11 @@ pub struct HooksConfig {
     /// - `ZEPH_TURN_LLM_REQUESTS`  — number of completed LLM round-trips this turn.
     #[serde(default)]
     pub turn_complete: Vec<HookDef>,
+    /// Maximum number of `PreToolUse` hook blocks allowed per turn before the turn is ended
+    /// with a warning message. Counts individual tool blocks — if a tier has N blocked tools,
+    /// the counter increments by N. Default: 8. Use `0` for no cap (unlimited blocks).
+    #[serde(default = "default_hook_block_cap")]
+    pub hook_block_cap: usize,
     /// Hooks fired before each tool execution, matched by tool name pattern.
     ///
     /// Uses pipe-separated pattern matching (same as subagent hooks). Hooks fire
@@ -99,6 +108,20 @@ pub struct HooksConfig {
     /// - `ZEPH_TOOL_DURATION_MS` — wall-clock execution time in milliseconds.
     #[serde(default)]
     pub post_tool_use: Vec<HookMatcher>,
+}
+
+impl Default for HooksConfig {
+    fn default() -> Self {
+        Self {
+            cwd_changed: Vec::new(),
+            file_changed: None,
+            permission_denied: Vec::new(),
+            turn_complete: Vec::new(),
+            hook_block_cap: default_hook_block_cap(),
+            pre_tool_use: Vec::new(),
+            post_tool_use: Vec::new(),
+        }
+    }
 }
 
 impl HooksConfig {
@@ -215,6 +238,7 @@ severity = "high"
             file_changed: None,
             permission_denied: Vec::new(),
             turn_complete: Vec::new(),
+            hook_block_cap: 8,
             pre_tool_use: Vec::new(),
             post_tool_use: Vec::new(),
         };
@@ -228,6 +252,7 @@ severity = "high"
             file_changed: None,
             permission_denied: vec![cmd_hook("echo denied")],
             turn_complete: Vec::new(),
+            hook_block_cap: 8,
             pre_tool_use: Vec::new(),
             post_tool_use: Vec::new(),
         };
@@ -241,6 +266,7 @@ severity = "high"
             file_changed: None,
             permission_denied: Vec::new(),
             turn_complete: vec![cmd_hook("notify-send Zeph done")],
+            hook_block_cap: 8,
             pre_tool_use: Vec::new(),
             post_tool_use: Vec::new(),
         };
@@ -254,6 +280,7 @@ severity = "high"
             file_changed: None,
             permission_denied: Vec::new(),
             turn_complete: Vec::new(),
+            hook_block_cap: 8,
             pre_tool_use: Vec::new(),
             post_tool_use: Vec::new(),
         };
@@ -283,6 +310,7 @@ fail_closed = false
             file_changed: None,
             permission_denied: Vec::new(),
             turn_complete: Vec::new(),
+            hook_block_cap: 8,
             pre_tool_use: vec![HookMatcher {
                 matcher: "Edit|Write".to_owned(),
                 hooks: vec![cmd_hook("echo pre")],
@@ -364,5 +392,25 @@ fail_closed = false
             "expected 1 permission_denied hook"
         );
         assert!(!cfg.is_empty(), "hooks config must not be empty");
+    }
+
+    #[test]
+    fn hook_block_cap_default_is_8() {
+        let cfg = HooksConfig::default();
+        assert_eq!(cfg.hook_block_cap, 8);
+    }
+
+    #[test]
+    fn hook_block_cap_parses_from_toml() {
+        let toml = "hook_block_cap = 4\n";
+        let cfg: HooksConfig = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.hook_block_cap, 4);
+    }
+
+    #[test]
+    fn hook_block_cap_zero_from_toml() {
+        let toml = "hook_block_cap = 0\n";
+        let cfg: HooksConfig = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.hook_block_cap, 0);
     }
 }

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1466,6 +1466,8 @@ impl<C: Channel> Agent<C> {
             .post_tool_use
             .clone_from(&config.post_tool_use);
 
+        self.tool_orchestrator.hook_block_cap = config.hook_block_cap;
+
         if let Some(ref fc) = config.file_changed {
             self.services
                 .session

--- a/crates/zeph-core/src/agent/tool_execution/tests/hook_block_cap_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/hook_block_cap_tests.rs
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Tests for PreToolUse hook fail_closed blocking and hook_block_cap enforcement (#3995).
+//! Tests for `PreToolUse` hook `fail_closed` blocking and `hook_block_cap` enforcement (#3995).
 
 use zeph_config::{HookAction, HookDef, HookMatcher};
-use zeph_llm::provider::{Message, Role, ToolUseRequest};
+use zeph_llm::provider::{Message, MessagePart, Role, ToolUseRequest};
 
 use crate::agent::Agent;
 use crate::agent::agent_tests::{
@@ -60,8 +60,8 @@ fn make_agent_with_pre_hook(hook: HookDef, cap: usize) -> Agent<MockChannel> {
     agent
 }
 
-/// Fix 1: fail_closed PreToolUse hook that errors must block tool execution
-/// and increment hook_block_count.
+/// Fix 1: `fail_closed` `PreToolUse` hook that errors must block tool execution
+/// and increment `hook_block_count`.
 #[tokio::test]
 async fn fail_closed_hook_blocks_tool_and_increments_counter() {
     let mut agent = make_agent_with_pre_hook(fail_closed_hook(), 8);
@@ -79,7 +79,6 @@ async fn fail_closed_hook_blocks_tool_and_increments_counter() {
     );
 
     // The ToolResult must contain "[blocked]" indicating the tool was NOT executed.
-    use zeph_llm::provider::MessagePart;
     let blocked = agent.msg.messages.iter().any(|m| {
         m.parts.iter().any(|p| {
             if let MessagePart::ToolResult { content, .. } = p {
@@ -95,7 +94,7 @@ async fn fail_closed_hook_blocks_tool_and_increments_counter() {
     );
 }
 
-/// Regression guard: fail_open hook must NOT block the tool despite erroring.
+/// Regression guard: `fail_open` hook must NOT block the tool despite erroring.
 #[tokio::test]
 async fn fail_open_hook_does_not_block_tool() {
     let mut agent = make_agent_with_pre_hook(fail_open_hook(), 8);
@@ -113,7 +112,7 @@ async fn fail_open_hook_does_not_block_tool() {
     );
 }
 
-/// Fix 2: when hook_block_count reaches hook_block_cap, the turn must end
+/// Fix 2: when `hook_block_count` reaches `hook_block_cap`, the turn must end
 /// and a warning must be sent to the channel.
 #[tokio::test]
 async fn hook_block_cap_ends_turn_and_sends_warning() {
@@ -136,7 +135,7 @@ async fn hook_block_cap_ends_turn_and_sends_warning() {
     );
 }
 
-/// hook_block_cap = 0 means no cap — turn should NOT end due to hook blocks alone.
+/// `hook_block_cap = 0` means no cap — turn should NOT end due to hook blocks alone.
 #[tokio::test]
 async fn hook_block_cap_zero_means_no_cap() {
     let mut agent = make_agent_with_pre_hook(fail_closed_hook(), 0);

--- a/crates/zeph-core/src/agent/tool_execution/tests/hook_block_cap_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/hook_block_cap_tests.rs
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Tests for PreToolUse hook fail_closed blocking and hook_block_cap enforcement (#3995).
+
+use zeph_config::{HookAction, HookDef, HookMatcher};
+use zeph_llm::provider::{Message, Role, ToolUseRequest};
+
+use crate::agent::Agent;
+use crate::agent::agent_tests::{
+    MockChannel, MockToolExecutor, create_test_registry, mock_provider,
+};
+
+fn make_tool_use_request(id: &str, name: &str) -> ToolUseRequest {
+    ToolUseRequest {
+        id: id.into(),
+        name: name.into(),
+        input: serde_json::json!({}),
+    }
+}
+
+fn fail_closed_hook() -> HookDef {
+    HookDef {
+        action: HookAction::Command {
+            command: "exit 1".to_owned(),
+        },
+        timeout_secs: 5,
+        fail_closed: true,
+    }
+}
+
+fn fail_open_hook() -> HookDef {
+    HookDef {
+        action: HookAction::Command {
+            command: "exit 1".to_owned(),
+        },
+        timeout_secs: 5,
+        fail_closed: false,
+    }
+}
+
+fn make_agent_with_pre_hook(hook: HookDef, cap: usize) -> Agent<MockChannel> {
+    let mut agent = Agent::new(
+        mock_provider(vec![]),
+        MockChannel::new(vec![]),
+        create_test_registry(),
+        None,
+        5,
+        MockToolExecutor::no_tools(),
+    );
+    agent
+        .msg
+        .messages
+        .push(Message::from_legacy(Role::System, "system"));
+    agent.services.session.hooks_config.pre_tool_use = vec![HookMatcher {
+        matcher: "shell".to_owned(),
+        hooks: vec![hook],
+    }];
+    agent.tool_orchestrator.hook_block_cap = cap;
+    agent
+}
+
+/// Fix 1: fail_closed PreToolUse hook that errors must block tool execution
+/// and increment hook_block_count.
+#[tokio::test]
+async fn fail_closed_hook_blocks_tool_and_increments_counter() {
+    let mut agent = make_agent_with_pre_hook(fail_closed_hook(), 8);
+
+    let tool_calls = vec![make_tool_use_request("id-1", "shell")];
+    agent
+        .handle_native_tool_calls(None, &tool_calls)
+        .await
+        .unwrap();
+
+    // Counter must be incremented exactly once (one tool blocked).
+    assert_eq!(
+        agent.tool_orchestrator.hook_block_count, 1,
+        "hook_block_count must be 1 after one fail_closed block"
+    );
+
+    // The ToolResult must contain "[blocked]" indicating the tool was NOT executed.
+    use zeph_llm::provider::MessagePart;
+    let blocked = agent.msg.messages.iter().any(|m| {
+        m.parts.iter().any(|p| {
+            if let MessagePart::ToolResult { content, .. } = p {
+                content.contains("[blocked]")
+            } else {
+                false
+            }
+        })
+    });
+    assert!(
+        blocked,
+        "ToolResult must contain '[blocked]' when fail_closed hook errors"
+    );
+}
+
+/// Regression guard: fail_open hook must NOT block the tool despite erroring.
+#[tokio::test]
+async fn fail_open_hook_does_not_block_tool() {
+    let mut agent = make_agent_with_pre_hook(fail_open_hook(), 8);
+
+    let tool_calls = vec![make_tool_use_request("id-2", "shell")];
+    agent
+        .handle_native_tool_calls(None, &tool_calls)
+        .await
+        .unwrap();
+
+    // Counter must remain 0 (fail_open hook errors are logged but do not block).
+    assert_eq!(
+        agent.tool_orchestrator.hook_block_count, 0,
+        "hook_block_count must remain 0 for fail_open hook"
+    );
+}
+
+/// Fix 2: when hook_block_count reaches hook_block_cap, the turn must end
+/// and a warning must be sent to the channel.
+#[tokio::test]
+async fn hook_block_cap_ends_turn_and_sends_warning() {
+    // cap = 1 so that a single blocked tool triggers the cap.
+    let mut agent = make_agent_with_pre_hook(fail_closed_hook(), 1);
+
+    let tool_calls = vec![make_tool_use_request("id-3", "shell")];
+    agent
+        .handle_native_tool_calls(None, &tool_calls)
+        .await
+        .unwrap();
+
+    let sent = agent.channel.sent_messages();
+    let cap_warning = sent
+        .iter()
+        .any(|m| m.contains("Stopping:") && m.contains("hook"));
+    assert!(
+        cap_warning,
+        "channel must receive cap-reached warning; got: {sent:?}"
+    );
+}
+
+/// hook_block_cap = 0 means no cap — turn should NOT end due to hook blocks alone.
+#[tokio::test]
+async fn hook_block_cap_zero_means_no_cap() {
+    let mut agent = make_agent_with_pre_hook(fail_closed_hook(), 0);
+
+    let tool_calls = vec![make_tool_use_request("id-4", "shell")];
+    agent
+        .handle_native_tool_calls(None, &tool_calls)
+        .await
+        .unwrap();
+
+    let sent = agent.channel.sent_messages();
+    let cap_warning = sent
+        .iter()
+        .any(|m| m.contains("Stopping:") && m.contains("hook"));
+    assert!(
+        !cap_warning,
+        "cap=0 must not trigger cap-reached warning; got: {sent:?}"
+    );
+}

--- a/crates/zeph-core/src/agent/tool_execution/tests/mod.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 mod boundary_and_classifier_tests;
+mod hook_block_cap_tests;
 mod native_tests;
 mod parallel_and_handle_tests;
 mod pure_helpers_tests;

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -948,6 +948,25 @@ impl<C: Channel> Agent<C> {
             if tier_count > 1 {
                 let _ = self.channel.send_status("").await;
             }
+
+            // Check hook block cap after each tier (RF-1: counter is per-turn, not per-tier).
+            // hook_block_cap = 0 means no cap.
+            let cap = self.tool_orchestrator.hook_block_cap;
+            if cap > 0 && self.tool_orchestrator.hook_block_count >= cap {
+                tracing::warn!(
+                    hook_block_count = self.tool_orchestrator.hook_block_count,
+                    hook_block_cap = cap,
+                    "hook block cap reached — ending turn"
+                );
+                let _ = self
+                    .channel
+                    .send(&format!(
+                        "Stopping: PreToolUse hook blocked {}/{} tool calls this turn.",
+                        self.tool_orchestrator.hook_block_count, cap
+                    ))
+                    .await;
+                break;
+            }
         }
 
         // Pad with empty results if needed (defensive; should not happen).
@@ -1424,6 +1443,7 @@ impl<C: Channel> Agent<C> {
                         .map(|id| id.0.to_string());
                     let env =
                         make_tool_hook_env(tc.name.as_str(), &tc.input, conv_id_str.as_deref());
+                    let has_fail_closed = matched.iter().any(|h| h.fail_closed);
                     let owned: Vec<zeph_config::HookDef> = matched.into_iter().cloned().collect();
                     let dispatch = self.mcp_dispatch();
                     let mcp: Option<&dyn zeph_subagent::McpDispatch> = dispatch
@@ -1436,6 +1456,28 @@ impl<C: Channel> Agent<C> {
                         ))
                         .await
                     {
+                        if has_fail_closed {
+                            self.tool_orchestrator.hook_block_count += 1;
+                            tracing::warn!(
+                                error = %e,
+                                tool = %tc.name,
+                                hook_block_count = self.tool_orchestrator.hook_block_count,
+                                hook_block_cap = self.tool_orchestrator.hook_block_cap,
+                                "PreToolUse hook blocked tool (fail_closed)"
+                            );
+                            let msg = format!(
+                                "[blocked] PreToolUse hook blocked tool `{}`: {e}",
+                                tc.name
+                            );
+                            tier_futs.push((
+                                idx,
+                                Box::pin(std::future::ready(Ok(Some(skipped_output(
+                                    tc.name.clone(),
+                                    msg,
+                                ))))),
+                            ));
+                            continue;
+                        }
                         tracing::warn!(
                             error = %e,
                             tool = %tc.name,
@@ -2031,6 +2073,7 @@ impl<C: Channel> Agent<C> {
         self.tool_orchestrator.clear_doom_history();
         self.tool_orchestrator.clear_recent_tool_calls();
         self.tool_orchestrator.clear_utility_state();
+        self.tool_orchestrator.reset_hook_block_count();
 
         // `mut` required when context-compression is enabled to inject focus tool definitions.
         let tafc = &self.tool_orchestrator.tafc;

--- a/crates/zeph-core/src/agent/tool_orchestrator.rs
+++ b/crates/zeph-core/src/agent/tool_orchestrator.rs
@@ -57,6 +57,13 @@ pub(crate) struct ToolOrchestrator {
     pub(super) session_tool_call_count: u32,
     /// Maximum tool calls allowed per session. `None` = unlimited.
     pub(super) max_tool_calls_per_session: Option<u32>,
+    /// Number of `PreToolUse` hook blocks accumulated in the current turn.
+    /// Reset to 0 at the start of each `process_response_native_tools` call.
+    /// Incremented once per blocked tool call (not per iteration).
+    pub(super) hook_block_count: usize,
+    /// Maximum `PreToolUse` hook blocks per turn before the turn is ended with a warning.
+    /// Matches `HooksConfig::hook_block_cap`. 0 = no cap.
+    pub(super) hook_block_cap: usize,
 }
 
 /// Truncate a tool name to at most 256 bytes, respecting UTF-8 char boundaries.
@@ -98,6 +105,8 @@ impl ToolOrchestrator {
             utility_scorer: UtilityScorer::new(UtilityScoringConfig::default()),
             session_tool_call_count: 0,
             max_tool_calls_per_session: None,
+            hook_block_count: 0,
+            hook_block_cap: 8,
         }
     }
 
@@ -196,6 +205,12 @@ impl ToolOrchestrator {
 
     pub(super) fn clear_doom_history(&mut self) {
         self.doom_loop_history.clear();
+    }
+
+    /// Reset the per-turn `PreToolUse` hook block counter. Called at the start of each
+    /// `process_response_native_tools` call.
+    pub(super) fn reset_hook_block_count(&mut self) {
+        self.hook_block_count = 0;
     }
 
     /// Reset the repeat-detection sliding window between user turns.
@@ -586,6 +601,21 @@ mod tests {
         o.max_tool_calls_per_session = Some(10);
         o.session_tool_call_count = 10;
         assert_eq!(o.check_quota(), Some(10));
+    }
+
+    #[test]
+    fn hook_block_cap_defaults() {
+        let o = ToolOrchestrator::new();
+        assert_eq!(o.hook_block_cap, 8);
+        assert_eq!(o.hook_block_count, 0);
+    }
+
+    #[test]
+    fn reset_hook_block_count_clears_counter() {
+        let mut o = ToolOrchestrator::new();
+        o.hook_block_count = 5;
+        o.reset_hook_block_count();
+        assert_eq!(o.hook_block_count, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `hooks.hook_block_cap` config option (default: 8) that caps consecutive `PreToolUse` hook blocks per turn. When the cap is reached, the turn ends with a user-visible warning message. Set to `0` to disable the cap.
- Fix `PreToolUse` hooks with `fail_closed = true` to correctly block tool execution. Previously, hook errors were logged but the tool proceeded (fail-open behavior despite the `fail_closed` setting).
- Defer `/bg` fork command to a follow-up issue (requires subagent lifecycle infrastructure that does not exist yet).

Parity: Claude Code v2.1.143 (2026-05-15) stop hook block cap feature.

Closes #3995

## Changed files

- `crates/zeph-config/src/hooks.rs` — `hook_block_cap: usize` field (default 8)
- `crates/zeph-core/src/agent/tool_orchestrator.rs` — `hook_block_count`/`hook_block_cap` fields, `reset_hook_block_count()`
- `crates/zeph-core/src/agent/tool_execution/tier_loop.rs` — `fail_closed` enforcement fix, cap check post-tier
- `crates/zeph-core/src/agent/builder.rs` — config wiring
- `crates/zeph-core/src/agent/tool_execution/tests/hook_block_cap_tests.rs` — new tests
- `config/default.toml`, `CHANGELOG.md` — documented

## Test plan

- [ ] `hook_block_cap` default value is 8
- [ ] TOML config with custom value is parsed correctly
- [ ] `fail_closed` hook error produces `[blocked]` tool result and increments counter
- [ ] Counter resets at each turn start (no cross-turn bleed)
- [ ] Cap reached → warning sent to channel, turn ends
- [ ] `hook_block_cap = 0` → no cap enforced
- [ ] `fail_open` hook error (`fail_closed = false`) does not block or increment counter
- [ ] 9511 unit tests pass