### PR TITLE
refactor(context): rename ContextError to AssemblerError in zeph-context

### DIFF
--- a/crates/zeph-agent-context/src/error.rs
+++ b/crates/zeph-agent-context/src/error.rs
@@ -19,7 +19,7 @@ pub enum ContextError {
 
     /// Context assembler in `zeph-context` returned an error.
     #[error("context assembler error: {0}")]
-    Assembler(#[from] zeph_context::error::ContextError),
+    Assembler(#[from] zeph_context::error::AssemblerError),
 
     /// Serialization failed (e.g., building a JSON payload for the LLM).
     #[error("serialization error: {0}")]

--- a/crates/zeph-context/src/assembler.rs
+++ b/crates/zeph-context/src/assembler.rs
@@ -22,7 +22,7 @@ use futures::stream::FuturesUnordered;
 use zeph_common::memory::{AsyncMemoryRouter, CompressionLevel, GraphRecallParams, TokenCounting};
 use zeph_llm::provider::{Message, MessageMetadata, MessagePart, Role};
 
-use crate::error::ContextError;
+use crate::error::AssemblerError;
 use crate::input::ContextAssemblyInput;
 use crate::slot::ContextSlot;
 
@@ -96,7 +96,7 @@ pub struct PreparedContext {
 /// All logic is in [`ContextAssembler::gather`]. No state is stored on this type.
 pub struct ContextAssembler;
 
-type CtxFuture<'a> = Pin<Box<dyn Future<Output = Result<ContextSlot, ContextError>> + Send + 'a>>;
+type CtxFuture<'a> = Pin<Box<dyn Future<Output = Result<ContextSlot, AssemblerError>> + Send + 'a>>;
 
 fn empty_prepared_context() -> PreparedContext {
     PreparedContext {
@@ -213,7 +213,7 @@ fn schedule_context_fetchers<'r>(
         && let Some(idx) = index
     {
         fetchers.push(Box::pin(async move {
-            let result: Result<Option<String>, ContextError> =
+            let result: Result<Option<String>, AssemblerError> =
                 idx.fetch_code_rag(query, code_context_budget).await;
             result.map(ContextSlot::CodeContext)
         }));
@@ -268,7 +268,7 @@ fn schedule_context_fetchers<'r>(
 async fn drive_fetchers(
     mut fetchers: FuturesUnordered<CtxFuture<'_>>,
     prepared: &mut PreparedContext,
-) -> Result<(), ContextError> {
+) -> Result<(), AssemblerError> {
     while let Some(result) = fetchers.next().await {
         match result {
             Ok(slot) => match slot {
@@ -301,7 +301,9 @@ impl ContextAssembler {
     /// # Errors
     ///
     /// Propagates errors from any async fetch operation.
-    pub async fn gather(input: &ContextAssemblyInput<'_>) -> Result<PreparedContext, ContextError> {
+    pub async fn gather(
+        input: &ContextAssemblyInput<'_>,
+    ) -> Result<PreparedContext, AssemblerError> {
         let Some(ref budget) = input.context_manager.budget else {
             return Ok(empty_prepared_context());
         };
@@ -393,7 +395,7 @@ pub(crate) async fn fetch_graph_facts(
     query: &str,
     budget_tokens: usize,
     tc: &dyn TokenCounting,
-) -> Result<Option<Message>, ContextError> {
+) -> Result<Option<Message>, AssemblerError> {
     use zeph_common::memory::{RecallView, SpreadingActivationParams, classify_graph_subgraph};
 
     if budget_tokens == 0 || !memory.graph_config.enabled {
@@ -537,7 +539,7 @@ pub(crate) async fn fetch_persona_facts(
     memory: &ContextMemoryView,
     budget_tokens: usize,
     tc: &dyn TokenCounting,
-) -> Result<Option<Message>, ContextError> {
+) -> Result<Option<Message>, AssemblerError> {
     if budget_tokens == 0 || !memory.persona_config.enabled {
         return Ok(None);
     }
@@ -549,7 +551,7 @@ pub(crate) async fn fetch_persona_facts(
     let facts = mem
         .load_persona_facts(min_confidence)
         .await
-        .map_err(ContextError::Memory)?;
+        .map_err(AssemblerError::Memory)?;
 
     if facts.is_empty() {
         return Ok(None);
@@ -580,7 +582,7 @@ pub(crate) async fn fetch_trajectory_hints(
     memory: &ContextMemoryView,
     budget_tokens: usize,
     tc: &dyn TokenCounting,
-) -> Result<Option<Message>, ContextError> {
+) -> Result<Option<Message>, AssemblerError> {
     if budget_tokens == 0 || !memory.trajectory_config.enabled {
         return Ok(None);
     }
@@ -596,7 +598,7 @@ pub(crate) async fn fetch_trajectory_hints(
     let entries = mem
         .load_trajectory_entries(Some("procedural"), top_k)
         .await
-        .map_err(ContextError::Memory)?;
+        .map_err(AssemblerError::Memory)?;
 
     if entries.is_empty() {
         return Ok(None);
@@ -631,7 +633,7 @@ pub(crate) async fn fetch_tree_memory(
     memory: &ContextMemoryView,
     budget_tokens: usize,
     tc: &dyn TokenCounting,
-) -> Result<Option<Message>, ContextError> {
+) -> Result<Option<Message>, AssemblerError> {
     if budget_tokens == 0 || !memory.tree_config.enabled {
         return Ok(None);
     }
@@ -643,7 +645,7 @@ pub(crate) async fn fetch_tree_memory(
     let nodes = mem
         .load_tree_nodes(1, top_k)
         .await
-        .map_err(ContextError::Memory)?;
+        .map_err(AssemblerError::Memory)?;
 
     if nodes.is_empty() {
         return Ok(None);
@@ -676,7 +678,7 @@ pub(crate) async fn fetch_reasoning_strategies(
     budget_tokens: usize,
     top_k: usize,
     tc: &dyn TokenCounting,
-) -> Result<Option<Message>, ContextError> {
+) -> Result<Option<Message>, AssemblerError> {
     // S1: enforce the ≤500-token spec cap documented in ReasoningConfig.
     let budget_tokens = budget_tokens.min(500);
     if budget_tokens == 0 {
@@ -689,7 +691,7 @@ pub(crate) async fn fetch_reasoning_strategies(
     let strategies = mem
         .retrieve_reasoning_strategies(query, top_k)
         .await
-        .map_err(ContextError::Memory)?;
+        .map_err(AssemblerError::Memory)?;
 
     if strategies.is_empty() {
         return Ok(None);
@@ -738,14 +740,14 @@ pub(crate) async fn fetch_corrections(
     limit: usize,
     min_score: f32,
     scrub: fn(&str) -> std::borrow::Cow<'_, str>,
-) -> Result<Option<Message>, ContextError> {
+) -> Result<Option<Message>, AssemblerError> {
     let Some(ref mem) = memory.memory else {
         return Ok(None);
     };
     let corrections = mem
         .retrieve_corrections(query, limit, min_score)
         .await
-        .map_err(ContextError::Memory)?;
+        .map_err(AssemblerError::Memory)?;
     if corrections.is_empty() {
         return Ok(None);
     }
@@ -765,7 +767,7 @@ pub(crate) async fn fetch_semantic_recall(
     token_budget: usize,
     tc: &dyn TokenCounting,
     router: Option<&dyn AsyncMemoryRouter>,
-) -> Result<(Option<Message>, Option<f32>), ContextError> {
+) -> Result<(Option<Message>, Option<f32>), AssemblerError> {
     let Some(ref mem) = memory.memory else {
         return Ok((None, None));
     };
@@ -776,7 +778,7 @@ pub(crate) async fn fetch_semantic_recall(
     let recalled = mem
         .recall(query, memory.recall_limit, router)
         .await
-        .map_err(ContextError::Memory)?;
+        .map_err(AssemblerError::Memory)?;
     if recalled.is_empty() {
         return Ok((None, None));
     }
@@ -819,7 +821,7 @@ pub(crate) async fn fetch_document_rag(
     query: &str,
     token_budget: usize,
     tc: &dyn TokenCounting,
-) -> Result<Option<Message>, ContextError> {
+) -> Result<Option<Message>, AssemblerError> {
     if !memory.document_config.rag_enabled || token_budget == 0 {
         return Ok(None);
     }
@@ -832,7 +834,7 @@ pub(crate) async fn fetch_document_rag(
     let chunks = mem
         .search_document_collection(collection, query, top_k)
         .await
-        .map_err(ContextError::Memory)?;
+        .map_err(AssemblerError::Memory)?;
     if chunks.is_empty() {
         return Ok(None);
     }
@@ -870,7 +872,7 @@ pub(crate) async fn fetch_summaries(
     memory: &ContextMemoryView,
     token_budget: usize,
     tc: &dyn TokenCounting,
-) -> Result<Option<Message>, ContextError> {
+) -> Result<Option<Message>, AssemblerError> {
     let (Some(mem), Some(cid)) = (&memory.memory, memory.conversation_id) else {
         return Ok(None);
     };
@@ -881,7 +883,7 @@ pub(crate) async fn fetch_summaries(
     let summaries = mem
         .load_summaries(cid)
         .await
-        .map_err(ContextError::Memory)?;
+        .map_err(AssemblerError::Memory)?;
     if summaries.is_empty() {
         return Ok(None);
     }
@@ -917,7 +919,7 @@ pub(crate) async fn fetch_cross_session(
     query: &str,
     token_budget: usize,
     tc: &dyn TokenCounting,
-) -> Result<Option<Message>, ContextError> {
+) -> Result<Option<Message>, AssemblerError> {
     let (Some(mem), Some(cid)) = (&memory.memory, memory.conversation_id) else {
         return Ok(None);
     };
@@ -929,7 +931,7 @@ pub(crate) async fn fetch_cross_session(
     let results: Vec<_> = mem
         .search_session_summaries(query, 5, Some(cid))
         .await
-        .map_err(ContextError::Memory)?
+        .map_err(AssemblerError::Memory)?
         .into_iter()
         .filter(|r| r.score >= threshold)
         .collect();
@@ -1813,7 +1815,7 @@ mod tests {
 
     #[tokio::test]
     async fn fetch_corrections_propagates_error() {
-        // fetch_corrections uses map_err(ContextError::Memory)? so retrieve_corrections
+        // fetch_corrections uses map_err(AssemblerError::Memory)? so retrieve_corrections
         // errors are propagated instead of silently discarded.
         let mock = MockMemoryBackend::with_fail_on("retrieve_corrections");
         let view = mock_view(mock);

--- a/crates/zeph-context/src/error.rs
+++ b/crates/zeph-context/src/error.rs
@@ -9,9 +9,9 @@ use thiserror::Error;
 ///
 /// All async fetch operations in [`crate::assembler::ContextAssembler`] propagate
 /// errors through this type. Callers in `zeph-core` convert to `AgentError` at the
-/// boundary using `From<ContextError> for AgentError`.
+/// boundary using `From<AssemblerError> for AgentError`.
 #[derive(Debug, Error)]
-pub enum ContextError {
+pub enum AssemblerError {
     /// A memory subsystem operation failed.
     #[error("memory error: {0}")]
     Memory(Box<dyn std::error::Error + Send + Sync + 'static>),

--- a/crates/zeph-context/src/input.rs
+++ b/crates/zeph-context/src/input.rs
@@ -142,7 +142,7 @@ pub trait IndexAccess: Send + Sync {
         budget_tokens: usize,
     ) -> std::pin::Pin<
         Box<
-            dyn std::future::Future<Output = Result<Option<String>, crate::error::ContextError>>
+            dyn std::future::Future<Output = Result<Option<String>, crate::error::AssemblerError>>
                 + Send
                 + 'a,
         >,

--- a/crates/zeph-context/src/lib.rs
+++ b/crates/zeph-context/src/lib.rs
@@ -19,7 +19,7 @@
 //! - [`turn_context`] — [`turn_context::TurnId`], [`turn_context::TurnContext`] per-turn carrier
 //! - [`compression_feedback`] — context-loss detection and failure classification
 //! - [`microcompact`] — low-value tool detection helpers for time-based microcompact
-//! - [`error`] — [`error::ContextError`]
+//! - [`error`] — [`error::AssemblerError`]
 
 pub mod assembler;
 pub mod budget;

--- a/crates/zeph-core/src/agent/context_impls.rs
+++ b/crates/zeph-core/src/agent/context_impls.rs
@@ -20,7 +20,7 @@ impl IndexAccess for IndexState {
     ) -> Pin<
         Box<
             dyn std::future::Future<
-                    Output = Result<Option<String>, zeph_context::error::ContextError>,
+                    Output = Result<Option<String>, zeph_context::error::AssemblerError>,
                 > + Send
                 + 'a,
         >,
@@ -28,7 +28,7 @@ impl IndexAccess for IndexState {
         Box::pin(async move {
             self.fetch_code_rag(query, budget_tokens)
                 .await
-                .map_err(|e| zeph_context::error::ContextError::Assembly(format!("{e:#}")))
+                .map_err(|e| zeph_context::error::AssemblerError::Assembly(format!("{e:#}")))
         })
     }
 }


### PR DESCRIPTION
## Summary

- Renames `zeph_context::error::ContextError` → `AssemblerError` to match the `ContextAssembler` struct it originates from
- Eliminates naming collision with `zeph_agent_context::error::ContextError` — two independently maintained enums with overlapping semantics
- Updates all 6 affected files: `zeph-context/{error,assembler,input,lib}.rs`, `zeph-agent-context/error.rs`, `zeph-core/agent/context_impls.rs`
- Pure mechanical rename — no behavioral changes, no dependency graph changes

## Decision rationale

The two enums are at different abstraction layers and serve different purposes. Merging them would pull unnecessary deps (`MemoryError`, `serde_json`) into `zeph-context`. The `From`-based wrapping pattern (`Assembler(#[from] AssemblerError)`) is correct; only the naming was ambiguous. Renaming the low-level type to `AssemblerError` makes the relationship self-documenting.

## Test plan

- [x] `cargo +nightly fmt --check` — passes
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — zero warnings
- [x] `cargo nextest run --workspace --lib --bins` — 9536/9536 passed
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler` — clean

Closes #3796