### PR TITLE
fix(gateway,config,db): add GatewayConfig validation and fix stale docs

### DIFF
--- a/crates/zeph-config/src/features.rs
+++ b/crates/zeph-config/src/features.rs
@@ -803,6 +803,25 @@ impl Default for GatewayConfig {
     }
 }
 
+impl GatewayConfig {
+    /// Validate gateway configuration values.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error string when:
+    /// - `webhook_send_timeout_secs` is `0` or exceeds `300`
+    /// - `max_body_size` exceeds `10 MiB` (`10485760` bytes)
+    pub fn validate(&self) -> Result<(), String> {
+        if self.webhook_send_timeout_secs == 0 || self.webhook_send_timeout_secs > 300 {
+            return Err("webhook_send_timeout_secs must be between 1 and 300".to_owned());
+        }
+        if self.max_body_size > 10 * 1024 * 1024 {
+            return Err("max_body_size must be <= 10485760 (10 MiB)".to_owned());
+        }
+        Ok(())
+    }
+}
+
 /// Daemon / process supervisor configuration, nested under `[daemon]` in TOML.
 ///
 /// When `enabled = true`, Zeph runs as a background process with automatic restart
@@ -1050,6 +1069,38 @@ mod tests {
     fn index_config_workspace_root_none_by_default() {
         let cfg: IndexConfig = toml::from_str("enabled = false").unwrap();
         assert!(cfg.workspace_root.is_none());
+    }
+
+    #[test]
+    fn gateway_validate_timeout_zero_is_err() {
+        let cfg = GatewayConfig {
+            webhook_send_timeout_secs: 0,
+            ..GatewayConfig::default()
+        };
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn gateway_validate_timeout_over_limit_is_err() {
+        let cfg = GatewayConfig {
+            webhook_send_timeout_secs: 301,
+            ..GatewayConfig::default()
+        };
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn gateway_validate_max_body_over_limit_is_err() {
+        let cfg = GatewayConfig {
+            max_body_size: 10 * 1024 * 1024 + 1,
+            ..GatewayConfig::default()
+        };
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn gateway_validate_defaults_are_ok() {
+        assert!(GatewayConfig::default().validate().is_ok());
     }
 }
 

--- a/crates/zeph-db/migrations/postgres/083_experience_memory.sql
+++ b/crates/zeph-db/migrations/postgres/083_experience_memory.sql
@@ -31,5 +31,5 @@ CREATE TABLE IF NOT EXISTS experience_entity_links (
 CREATE INDEX IF NOT EXISTS idx_experience_nodes_session      ON experience_nodes(session_id, turn);
 CREATE INDEX IF NOT EXISTS idx_experience_nodes_tool         ON experience_nodes(tool_name);
 CREATE INDEX IF NOT EXISTS idx_experience_entity_links       ON experience_entity_links(entity_id);
--- Added by migration 082 (episodic_consolidation uses this for session-time lookups)
+-- Facilitates session-time lookups used by episodic_consolidation
 CREATE INDEX IF NOT EXISTS idx_experience_nodes_session_time ON experience_nodes(session_id, created_at);

--- a/crates/zeph-memory/src/graph/experience.rs
+++ b/crates/zeph-memory/src/graph/experience.rs
@@ -27,7 +27,8 @@ pub struct EvolutionSweepStats {
 /// Persistent store for experience memory nodes and edges.
 ///
 /// Wraps the `experience_nodes`, `experience_edges`, and `experience_entity_links`
-/// tables created by migration `076_experience_memory.sql`.
+/// tables created by migration `*_experience_memory.sql`
+/// (`SQLite`: `076_experience_memory.sql`, `PostgreSQL`: `083_experience_memory.sql`).
 pub struct ExperienceStore {
     pool: DbPool,
 }

--- a/src/gateway_spawn.rs
+++ b/src/gateway_spawn.rs
@@ -146,6 +146,10 @@ pub(crate) fn spawn_gateway_server(
 ) -> (tokio::task::JoinHandle<()>, tokio::task::JoinHandle<()>) {
     use zeph_gateway::GatewayServer;
 
+    if let Err(e) = config.gateway.validate() {
+        panic!("invalid gateway configuration: {e}");
+    }
+
     let (webhook_tx, mut webhook_rx) = tokio::sync::mpsc::channel::<String>(64);
     let gw = GatewayServer::new(
         &config.gateway.bind,


### PR DESCRIPTION
## Summary

- Add `GatewayConfig::validate()` that rejects `webhook_send_timeout_secs` outside `[1, 300]` and `max_body_size` above 10 MiB; call at startup in `spawn_gateway_server()` so misconfigured gateways abort early with a clear error instead of silently misbehaving
- Fix misleading SQL comment in `083_experience_memory.sql` that incorrectly attributed the session-time index to migration 082
- Make `ExperienceStore` doc comment backend-agnostic by listing both migration filenames (SQLite `076_experience_memory.sql` and PostgreSQL `083_experience_memory.sql`)

## Test plan

- [ ] `GatewayConfig::validate()` unit tests added: timeout=0 → Err, timeout=301 → Err, max_body > 10 MiB → Err, defaults → Ok
- [ ] `cargo nextest run --workspace --lib --bins` — 9549 passed
- [ ] `cargo clippy --workspace --features desktop,ide,server,chat,pdf,scheduler -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean

Closes #3908
Closes #3922
Closes #3924