### PR TITLE
refactor(config): migrate ProviderName to Arc<str> and tighten visibility

### DIFF
--- a/crates/zeph-common/src/types.rs
+++ b/crates/zeph-common/src/types.rs
@@ -241,6 +241,40 @@ impl ProviderName {
     pub fn as_str(&self) -> &str {
         &self.0
     }
+
+    /// Return `true` when this is the empty sentinel (use the primary provider).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_common::ProviderName;
+    ///
+    /// assert!(ProviderName::default().is_empty());
+    /// assert!(!ProviderName::new("fast").is_empty());
+    /// ```
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Return `Some(&str)` when non-empty, `None` for the empty sentinel.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_common::ProviderName;
+    ///
+    /// assert_eq!(ProviderName::default().as_non_empty(), None);
+    /// assert_eq!(ProviderName::new("fast").as_non_empty(), Some("fast"));
+    /// ```
+    #[must_use]
+    pub fn as_non_empty(&self) -> Option<&str> {
+        if self.0.is_empty() {
+            None
+        } else {
+            Some(&self.0)
+        }
+    }
 }
 
 impl Default for ProviderName {

--- a/crates/zeph-config/src/providers.rs
+++ b/crates/zeph-config/src/providers.rs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::fmt;
-
 use serde::{Deserialize, Serialize};
 
 // ── LLM provider config types (moved from zeph-llm) ─────────────────────────
@@ -86,125 +84,7 @@ pub enum GeminiThinkingLevel {
     High,
 }
 
-/// Newtype wrapper for a provider name referencing an entry in `[[llm.providers]]`.
-///
-/// Using a dedicated type instead of bare `String` makes provider cross-references
-/// explicit in the type system and enables validation at config load time.
-///
-/// # Note
-///
-/// `zeph-common` now defines a canonical `ProviderName(Arc<str>)` newtype. This
-/// config-local type uses `String` and exists for backward compat within `zeph-config`.
-///
-/// TODO(critic): migrate to `zeph_common::ProviderName` once `zeph-config` → `zeph-common`
-/// dependency inversion (A-1) lands.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct ProviderName(String);
-
-impl ProviderName {
-    /// Create a new `ProviderName` from any string-like value.
-    ///
-    /// An empty string is a sentinel meaning "use the primary provider" and is the
-    /// default value. Check [`is_empty`](Self::is_empty) before using in routing.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use zeph_config::providers::ProviderName;
-    ///
-    /// let name = ProviderName::new("fast");
-    /// assert_eq!(name.as_str(), "fast");
-    /// ```
-    #[must_use]
-    pub fn new(name: impl Into<String>) -> Self {
-        Self(name.into())
-    }
-
-    /// Return `true` when this is the empty sentinel (use primary provider).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use zeph_config::providers::ProviderName;
-    ///
-    /// assert!(ProviderName::default().is_empty());
-    /// assert!(!ProviderName::new("fast").is_empty());
-    /// ```
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    /// Return the inner string slice.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use zeph_config::providers::ProviderName;
-    ///
-    /// let name = ProviderName::new("quality");
-    /// assert_eq!(name.as_str(), "quality");
-    /// ```
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-
-    /// Return `Some(&str)` when non-empty, `None` for the empty sentinel.
-    ///
-    /// Bridges `Option<ProviderName>` fields and the legacy
-    /// `.as_deref().filter(|s| !s.is_empty())` pattern.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use zeph_config::providers::ProviderName;
-    ///
-    /// assert_eq!(ProviderName::default().as_non_empty(), None);
-    /// assert_eq!(ProviderName::new("fast").as_non_empty(), Some("fast"));
-    /// ```
-    #[must_use]
-    pub fn as_non_empty(&self) -> Option<&str> {
-        if self.0.is_empty() {
-            None
-        } else {
-            Some(&self.0)
-        }
-    }
-}
-
-impl fmt::Display for ProviderName {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl AsRef<str> for ProviderName {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for ProviderName {
-    type Target = str;
-
-    fn deref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl PartialEq<str> for ProviderName {
-    fn eq(&self, other: &str) -> bool {
-        self.0 == other
-    }
-}
-
-impl PartialEq<&str> for ProviderName {
-    fn eq(&self, other: &&str) -> bool {
-        self.0 == *other
-    }
-}
+pub use zeph_common::ProviderName;
 
 fn default_response_cache_ttl_secs() -> u64 {
     3600
@@ -304,25 +184,25 @@ pub fn default_stt_language() -> String {
 
 /// Returns the default embedding model name used by `[llm] embedding_model`.
 #[must_use]
-pub fn get_default_embedding_model() -> String {
+pub(crate) fn get_default_embedding_model() -> String {
     default_embedding_model()
 }
 
 /// Returns the default response cache TTL in seconds.
 #[must_use]
-pub fn get_default_response_cache_ttl_secs() -> u64 {
+pub(crate) fn get_default_response_cache_ttl_secs() -> u64 {
     default_response_cache_ttl_secs()
 }
 
 /// Returns the default EMA alpha for the router latency estimator.
 #[must_use]
-pub fn get_default_router_ema_alpha() -> f64 {
+pub(crate) fn get_default_router_ema_alpha() -> f64 {
     default_router_ema_alpha()
 }
 
 /// Returns the default router reorder interval (turns between provider re-ranking).
 #[must_use]
-pub fn get_default_router_reorder_interval() -> u64 {
+pub(crate) fn get_default_router_reorder_interval() -> u64 {
     default_router_reorder_interval()
 }
 
@@ -2207,7 +2087,10 @@ expert = "opus"
         let cr = cfg
             .complexity_routing
             .expect("complexity_routing must be present");
-        assert_eq!(cr.triage_provider.as_deref(), Some("fast"));
+        assert_eq!(
+            cr.triage_provider.as_ref().map(ProviderName::as_str),
+            Some("fast")
+        );
         assert!(!cr.bypass_single_provider);
         assert_eq!(cr.triage_timeout_secs, 10);
         assert_eq!(cr.max_triage_tokens, 100);
@@ -2538,13 +2421,6 @@ alpha = 1.5
         let n = ProviderName::default();
         assert!(n.is_empty());
         assert_eq!(n.as_str(), "");
-    }
-
-    #[test]
-    fn provider_name_deref_to_str() {
-        let n = ProviderName::new("quality");
-        let s: &str = &n;
-        assert_eq!(s, "quality");
     }
 
     #[test]

--- a/crates/zeph-core/src/agent/autodream.rs
+++ b/crates/zeph-core/src/agent/autodream.rs
@@ -106,7 +106,7 @@ impl<C: Channel> super::Agent<C> {
             .as_ref()
             .map(|tx| tx.send("Consolidating memories…".into()));
 
-        let provider = self.resolve_consolidation_provider(&cfg.consolidation_provider);
+        let provider = self.resolve_consolidation_provider(cfg.consolidation_provider.as_str());
 
         let store = memory.sqlite().clone();
         let consolidation_cfg = zeph_memory::ConsolidationConfig {

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -3049,7 +3049,11 @@ impl<C: Channel> Agent<C> {
             None
         } else {
             let resolved = self.resolve_background_provider(
-                &config.memory.store_routing.routing_classifier_provider,
+                config
+                    .memory
+                    .store_routing
+                    .routing_classifier_provider
+                    .as_str(),
             );
             Some(std::sync::Arc::new(resolved))
         };

--- a/crates/zeph-memory/src/compaction_probe.rs
+++ b/crates/zeph-memory/src/compaction_probe.rs
@@ -751,7 +751,10 @@ mod tests {
         let json = serde_json::to_string(&original).expect("serialize");
         let restored: CompactionProbeConfig = serde_json::from_str(&json).expect("deserialize");
         assert!(restored.enabled);
-        assert_eq!(restored.probe_provider.as_deref(), Some("fast"));
+        assert_eq!(
+            restored.probe_provider.as_ref().map(|p| p.as_str()),
+            Some("fast")
+        );
         assert!((restored.threshold - 0.65).abs() < 0.001);
     }
 

--- a/crates/zeph-memory/src/compaction_probe.rs
+++ b/crates/zeph-memory/src/compaction_probe.rs
@@ -752,7 +752,10 @@ mod tests {
         let restored: CompactionProbeConfig = serde_json::from_str(&json).expect("deserialize");
         assert!(restored.enabled);
         assert_eq!(
-            restored.probe_provider.as_ref().map(zeph_config::ProviderName::as_str),
+            restored
+                .probe_provider
+                .as_ref()
+                .map(zeph_config::ProviderName::as_str),
             Some("fast")
         );
         assert!((restored.threshold - 0.65).abs() < 0.001);

--- a/crates/zeph-memory/src/compaction_probe.rs
+++ b/crates/zeph-memory/src/compaction_probe.rs
@@ -752,7 +752,7 @@ mod tests {
         let restored: CompactionProbeConfig = serde_json::from_str(&json).expect("deserialize");
         assert!(restored.enabled);
         assert_eq!(
-            restored.probe_provider.as_ref().map(|p| p.as_str()),
+            restored.probe_provider.as_ref().map(zeph_config::ProviderName::as_str),
             Some("fast")
         );
         assert!((restored.threshold - 0.65).abs() < 0.001);

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -1571,7 +1571,7 @@ impl AppBuilder {
         }
         let classify_provider = if cfg.topology_provider.is_empty() {
             match create_named_provider(
-                &self.config.llm.providers.first()?.effective_name(),
+                self.config.llm.providers.first()?.effective_name(),
                 &self.config,
             ) {
                 Ok(p) => p,

--- a/src/bootstrap/provider.rs
+++ b/src/bootstrap/provider.rs
@@ -203,7 +203,11 @@ fn apply_routing_signals(router: RouterProvider, config: &Config) -> RouterProvi
 /// Look up a provider entry from the pool by name (exact match on `effective_name()`) or type.
 ///
 /// Used by quarantine, guardrail, judge, and experiment eval model resolution.
-pub fn create_named_provider(name: &str, config: &Config) -> Result<AnyProvider, BootstrapError> {
+pub fn create_named_provider(
+    name: impl AsRef<str>,
+    config: &Config,
+) -> Result<AnyProvider, BootstrapError> {
+    let name = name.as_ref();
     let entry = config
         .llm
         .providers
@@ -443,10 +447,10 @@ fn build_triage_provider(
         .first()
         .map(zeph_core::config::ProviderEntry::effective_name)
         .unwrap_or_default();
-    let triage_prov_name = cr
-        .triage_provider
-        .as_deref()
-        .unwrap_or(default_triage_name.as_str());
+    let triage_prov_name = cr.triage_provider.as_ref().map_or_else(
+        || default_triage_name.as_str(),
+        zeph_common::ProviderName::as_str,
+    );
     let triage_provider = create_named_provider(triage_prov_name, config).map_err(|e| {
         BootstrapError::Provider(format!(
             "triage_provider '{triage_prov_name}' not found in [[llm.providers]]: {e}"

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -876,7 +876,7 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
         Some("model") => {
             config.skills.learning.detector_mode = zeph_core::config::DetectorMode::Model;
             if let Some(ref provider) = state.feedback_provider {
-                config.skills.learning.feedback_provider = ProviderName::new(provider);
+                config.skills.learning.feedback_provider = ProviderName::new(provider.as_str());
             }
         }
         _ => {}
@@ -1003,7 +1003,7 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
 
     config.tools.retry.max_attempts = state.retry_max_attempts;
     config.tools.retry.parameter_reformat_provider =
-        zeph_config::ProviderName::new(&state.retry_parameter_reformat_provider);
+        zeph_config::ProviderName::new(state.retry_parameter_reformat_provider.as_str());
 
     config.logging.file.clone_from(&state.log_file);
     config.logging.level.clone_from(&state.log_level);
@@ -1052,7 +1052,7 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
     if state.mcp_discovery_strategy == "embedding" {
         config.mcp.tool_discovery.top_k = state.mcp_discovery_top_k;
         config.mcp.tool_discovery.embedding_provider =
-            ProviderName::new(&state.mcp_discovery_provider);
+            ProviderName::new(state.mcp_discovery_provider.as_str());
     }
 
     if state.experiments_enabled {
@@ -2272,7 +2272,13 @@ mod tests {
         };
         let config = build_config(&state);
         assert_eq!(
-            config.memory.compression.probe.probe_provider.as_deref(),
+            config
+                .memory
+                .compression
+                .probe
+                .probe_provider
+                .as_ref()
+                .map(|p| p.as_str()),
             Some("fast")
         );
     }

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -2278,7 +2278,7 @@ mod tests {
                 .probe
                 .probe_provider
                 .as_ref()
-                .map(|p| p.as_str()),
+                .map(ProviderName::as_str),
             Some("fast")
         );
     }


### PR DESCRIPTION
## Summary

- **#3890**: tighten four serde-default helpers from `pub` to `pub(crate)` in `zeph-config/src/providers.rs` (`get_default_embedding_model`, `get_default_response_cache_ttl_secs`, `get_default_router_ema_alpha`, `get_default_router_reorder_interval`). All callers are within the same crate.
- **#3864**: replace `zeph-config::ProviderName(String)` with a re-export of `zeph_common::ProviderName(Arc<str>)`. Config struct clones that previously copied heap-allocated strings are now O(1). Added `is_empty()` and `as_non_empty()` helpers to the canonical type. Updated ~10 call sites across the workspace; widened `create_named_provider` to `impl AsRef<str>`.

## Test plan

- [ ] `cargo +nightly fmt --check` — pass
- [ ] `cargo clippy --workspace -- -D warnings` — pass
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 9553 passed, 0 failed
- [ ] `cargo doc --no-deps -p zeph-common -p zeph-config` — clean

Closes #3864
Closes #3890