### PR TITLE
feat(context): wire TurnContext.tool_allowlist from channel config

### DIFF
--- a/crates/zeph-config/src/channels.rs
+++ b/crates/zeph-config/src/channels.rs
@@ -336,6 +336,10 @@ pub struct TelegramConfig {
     /// Skill allowlist for this channel.
     #[serde(default)]
     pub skills: ChannelSkillsConfig,
+    /// Tool allowlist for this channel. `None` means all tools are permitted.
+    /// `Some(vec![])` denies all tools. `Some(vec!["shell"])` allows only listed tools.
+    #[serde(default)]
+    pub allowed_tools: Option<Vec<String>>,
     /// Minimum interval in milliseconds between streaming message edits.
     ///
     /// Defaults to 3000 ms (3 seconds) to stay within Telegram's rate limits.
@@ -378,6 +382,7 @@ impl std::fmt::Debug for TelegramConfig {
             .field("token", &self.token.as_ref().map(|_| "[REDACTED]"))
             .field("allowed_users", &self.allowed_users)
             .field("skills", &self.skills)
+            .field("allowed_tools", &self.allowed_tools)
             .field("stream_interval_ms", &self.stream_interval_ms)
             .field("guest_mode", &self.guest_mode)
             .field("bot_to_bot", &self.bot_to_bot)
@@ -399,6 +404,9 @@ pub struct DiscordConfig {
     pub allowed_channel_ids: Vec<String>,
     #[serde(default)]
     pub skills: ChannelSkillsConfig,
+    /// Tool allowlist for this channel. `None` means all tools are permitted.
+    #[serde(default)]
+    pub allowed_tools: Option<Vec<String>>,
 }
 
 impl std::fmt::Debug for DiscordConfig {
@@ -410,6 +418,7 @@ impl std::fmt::Debug for DiscordConfig {
             .field("allowed_role_ids", &self.allowed_role_ids)
             .field("allowed_channel_ids", &self.allowed_channel_ids)
             .field("skills", &self.skills)
+            .field("allowed_tools", &self.allowed_tools)
             .finish()
     }
 }
@@ -428,6 +437,9 @@ pub struct SlackConfig {
     pub allowed_channel_ids: Vec<String>,
     #[serde(default)]
     pub skills: ChannelSkillsConfig,
+    /// Tool allowlist for this channel. `None` means all tools are permitted.
+    #[serde(default)]
+    pub allowed_tools: Option<Vec<String>>,
 }
 
 impl std::fmt::Debug for SlackConfig {
@@ -443,6 +455,7 @@ impl std::fmt::Debug for SlackConfig {
             .field("allowed_user_ids", &self.allowed_user_ids)
             .field("allowed_channel_ids", &self.allowed_channel_ids)
             .field("skills", &self.skills)
+            .field("allowed_tools", &self.allowed_tools)
             .finish()
     }
 }

--- a/crates/zeph-config/src/cli.rs
+++ b/crates/zeph-config/src/cli.rs
@@ -21,6 +21,9 @@ pub struct CliConfig {
     /// Loop command configuration.
     #[serde(rename = "loop")]
     pub loop_: LoopConfig,
+    /// Tool allowlist for CLI/TUI sessions. `None` means all tools are permitted.
+    #[serde(default)]
+    pub allowed_tools: Option<Vec<String>>,
 }
 
 /// Configuration for the `/loop` command.

--- a/crates/zeph-context/src/budget.rs
+++ b/crates/zeph-context/src/budget.rs
@@ -320,4 +320,23 @@ mod tests {
         assert!(alloc.summaries > 0);
         assert!(alloc.semantic_recall > 0);
     }
+
+    #[test]
+    fn budget_allocation_memory_first_and_graph_enabled() {
+        let tc = NaiveTc;
+        // 10_000 max, 20% reserve → 8_000 available (empty prompts = 0 tokens).
+        let budget = ContextBudget::new(10_000, 0.20).with_graph_enabled(true);
+        let alloc = budget.allocate_with_opts("", "", &tc, true, 0, true);
+        let available = 8_000_f32;
+        assert_eq!(
+            alloc.recent_history, 0,
+            "memory_first must zero recent_history"
+        );
+        assert_eq!(alloc.summaries, (available * 0.22) as usize);
+        assert_eq!(alloc.semantic_recall, (available * 0.22) as usize);
+        assert_eq!(alloc.cross_session, (available * 0.12) as usize);
+        assert_eq!(alloc.code_context, (available * 0.38) as usize);
+        assert_eq!(alloc.graph_facts, (available * 0.06) as usize);
+        assert_eq!(alloc.response_reserve, 2_000);
+    }
 }

--- a/crates/zeph-context/src/turn_context.rs
+++ b/crates/zeph-context/src/turn_context.rs
@@ -63,10 +63,21 @@ pub struct TurnContext {
     /// Snapshotting (rather than reading from a shared config) ensures the turn's
     /// timeout policy is stable even if the live config is reloaded mid-turn.
     pub timeouts: TimeoutConfig,
+    /// Optional channel-scoped tool allowlist for this turn.
+    ///
+    /// `None` means no channel-level restriction applies (other layers may still gate tool
+    /// access). When `Some`, only tools whose names appear in the list may be dispatched;
+    /// any call to a tool not in the list is rejected before execution.
+    ///
+    /// Populated from the active channel's `allowed_tools` config by the agent runtime
+    /// at turn start via [`TurnContext::with_tool_allowlist`].
+    pub tool_allowlist: Option<Vec<String>>,
 }
 
 impl TurnContext {
-    /// Create a new `TurnContext`.
+    /// Create a new `TurnContext` with no channel-level tool restriction.
+    ///
+    /// Use [`with_tool_allowlist`](Self::with_tool_allowlist) to set a channel-scoped allowlist.
     ///
     /// # Examples
     ///
@@ -77,6 +88,7 @@ impl TurnContext {
     ///
     /// let ctx = TurnContext::new(TurnId(1), CancellationToken::new(), TimeoutConfig::default());
     /// assert_eq!(ctx.id, TurnId(1));
+    /// assert!(ctx.tool_allowlist.is_none());
     /// ```
     #[must_use]
     pub fn new(id: TurnId, cancel_token: CancellationToken, timeouts: TimeoutConfig) -> Self {
@@ -84,6 +96,60 @@ impl TurnContext {
             id,
             cancel_token,
             timeouts,
+            tool_allowlist: None,
+        }
+    }
+
+    /// Set the channel-scoped tool allowlist for this turn.
+    ///
+    /// `None` clears any existing restriction. `Some(vec![])` denies all tools.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_context::turn_context::{TurnContext, TurnId};
+    /// use zeph_config::security::TimeoutConfig;
+    /// use tokio_util::sync::CancellationToken;
+    ///
+    /// let ctx = TurnContext::new(TurnId(0), CancellationToken::new(), TimeoutConfig::default())
+    ///     .with_tool_allowlist(Some(vec!["shell".to_owned(), "grep".to_owned()]));
+    /// assert!(ctx.is_tool_allowed("shell"));
+    /// assert!(!ctx.is_tool_allowed("web_scrape"));
+    /// ```
+    #[must_use]
+    pub fn with_tool_allowlist(mut self, allowlist: Option<Vec<String>>) -> Self {
+        self.tool_allowlist = allowlist;
+        self
+    }
+
+    /// Returns `true` if `tool_name` is permitted by the channel-level allowlist.
+    ///
+    /// When no allowlist is set (`None`), all tools are permitted.
+    /// When the allowlist is `Some`, only tools explicitly listed are permitted.
+    ///
+    /// Comparison is **case-sensitive**: `"Shell"` and `"shell"` are treated as different
+    /// names. Callers must normalize tool names to lowercase before populating the allowlist
+    /// if case-insensitive matching is required.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_context::turn_context::{TurnContext, TurnId};
+    /// use zeph_config::security::TimeoutConfig;
+    /// use tokio_util::sync::CancellationToken;
+    ///
+    /// let unrestricted = TurnContext::new(TurnId(0), CancellationToken::new(), TimeoutConfig::default());
+    /// assert!(unrestricted.is_tool_allowed("anything"));
+    ///
+    /// let restricted = unrestricted.with_tool_allowlist(Some(vec!["shell".to_owned()]));
+    /// assert!(restricted.is_tool_allowed("shell"));
+    /// assert!(!restricted.is_tool_allowed("web_scrape"));
+    /// ```
+    #[must_use]
+    pub fn is_tool_allowed(&self, tool_name: &str) -> bool {
+        match &self.tool_allowlist {
+            None => true,
+            Some(list) => list.iter().any(|t| t == tool_name),
         }
     }
 }
@@ -124,6 +190,54 @@ mod tests {
         let token = CancellationToken::new();
         let ctx = TurnContext::new(TurnId(1), token.clone(), TimeoutConfig::default());
         assert_eq!(ctx.id, TurnId(1));
+        assert!(ctx.tool_allowlist.is_none());
+    }
+
+    #[test]
+    fn turn_context_tool_allowlist_none_permits_all() {
+        let ctx = TurnContext::new(
+            TurnId(0),
+            CancellationToken::new(),
+            TimeoutConfig::default(),
+        );
+        assert!(ctx.is_tool_allowed("shell"));
+        assert!(ctx.is_tool_allowed("anything"));
+    }
+
+    #[test]
+    fn turn_context_tool_allowlist_some_filters() {
+        let ctx = TurnContext::new(
+            TurnId(0),
+            CancellationToken::new(),
+            TimeoutConfig::default(),
+        )
+        .with_tool_allowlist(Some(vec!["shell".to_owned(), "grep".to_owned()]));
+        assert!(ctx.is_tool_allowed("shell"));
+        assert!(ctx.is_tool_allowed("grep"));
+        assert!(!ctx.is_tool_allowed("web_scrape"));
+    }
+
+    #[test]
+    fn turn_context_tool_allowlist_empty_denies_all() {
+        let ctx = TurnContext::new(
+            TurnId(0),
+            CancellationToken::new(),
+            TimeoutConfig::default(),
+        )
+        .with_tool_allowlist(Some(vec![]));
+        assert!(!ctx.is_tool_allowed("shell"));
+    }
+
+    #[test]
+    fn turn_context_with_tool_allowlist_none_clears() {
+        let ctx = TurnContext::new(
+            TurnId(0),
+            CancellationToken::new(),
+            TimeoutConfig::default(),
+        )
+        .with_tool_allowlist(Some(vec!["shell".to_owned()]))
+        .with_tool_allowlist(None);
+        assert!(ctx.is_tool_allowed("anything"));
     }
 
     #[test]

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1925,6 +1925,16 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Set the channel-scoped tool allowlist for this session.
+    ///
+    /// `None` means no restriction (all tools permitted). `Some(vec![])` denies all tools.
+    /// The allowlist is snapshotted into each [`TurnContext`] at turn start.
+    #[must_use]
+    pub fn with_channel_tool_allowlist(mut self, allowlist: Option<Vec<String>>) -> Self {
+        self.runtime.config.channel_tool_allowlist = allowlist;
+        self
+    }
+
     // ---- Internal helpers (pub(super)) ----
 
     pub(super) fn summary_or_primary_provider(&self) -> &AnyProvider {

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1928,7 +1928,7 @@ impl<C: Channel> Agent<C> {
     /// Set the channel-scoped tool allowlist for this session.
     ///
     /// `None` means no restriction (all tools permitted). `Some(vec![])` denies all tools.
-    /// The allowlist is snapshotted into each [`TurnContext`] at turn start.
+    /// The allowlist is snapshotted into each `TurnContext` at turn start.
     #[must_use]
     pub fn with_channel_tool_allowlist(mut self, allowlist: Option<Vec<String>>) -> Self {
         self.runtime.config.channel_tool_allowlist = allowlist;

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -1442,7 +1442,8 @@ impl<C: Channel> Agent<C> {
             }
         }
 
-        let context = turn::TurnContext::new(id, cancel_token, self.runtime.config.timeouts);
+        let context = turn::TurnContext::new(id, cancel_token, self.runtime.config.timeouts)
+            .with_tool_allowlist(self.runtime.config.channel_tool_allowlist.clone());
         turn::Turn::new(context, input)
     }
 

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -244,6 +244,9 @@ pub(crate) struct RuntimeConfig {
     /// Per-channel skill allowlist. Skills not matching the allowlist are excluded from the
     /// prompt. An empty `allowed` list means all skills are permitted (default).
     pub(crate) channel_skills: zeph_config::ChannelSkillsConfig,
+    /// Per-channel tool allowlist. `None` = no restriction. `Some` = only listed tools permitted.
+    /// Populated from the active channel's `allowed_tools` config at agent build time.
+    pub(crate) channel_tool_allowlist: Option<Vec<String>>,
     /// Minimum allowed interval for `/loop` ticks (seconds). Sourced from `[cli.loop] min_interval_secs`.
     pub(crate) loop_min_interval_secs: u64,
     /// Runtime middleware layers for LLM calls and tool dispatch (#2286).
@@ -1028,6 +1031,7 @@ impl Default for RuntimeConfig {
             spawn_depth: 0,
             budget_hint_enabled: true,
             channel_skills: zeph_config::ChannelSkillsConfig::default(),
+            channel_tool_allowlist: None,
             loop_min_interval_secs: 5,
             layers: Vec::new(),
             supervisor_config: crate::config::TaskSupervisorConfig::default(),

--- a/crates/zeph-core/src/agent/state/tests.rs
+++ b/crates/zeph-core/src/agent/state/tests.rs
@@ -90,6 +90,7 @@ fn make_runtime_config() -> RuntimeConfig {
         spawn_depth: 0,
         budget_hint_enabled: true,
         channel_skills: zeph_config::ChannelSkillsConfig::default(),
+        channel_tool_allowlist: None,
         loop_min_interval_secs: 5,
         layers: Vec::new(),
         supervisor_config: crate::config::TaskSupervisorConfig::default(),

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -368,6 +368,34 @@ impl<C: Channel> Agent<C> {
         pre_exec_blocked
     }
 
+    /// Block tool calls whose names are absent from the channel-level allowlist (#3879).
+    ///
+    /// No-op when no allowlist is configured (`None`). Skips already-blocked indices.
+    /// Comparison is case-sensitive; channel configs must use canonical lowercase names.
+    fn apply_channel_tool_allowlist(&mut self, calls: &[ToolCall], pre_exec_blocked: &mut [bool]) {
+        let Some(ref allowlist) = self.runtime.config.channel_tool_allowlist else {
+            return;
+        };
+        for (idx, call) in calls.iter().enumerate() {
+            if pre_exec_blocked[idx] {
+                continue;
+            }
+            if !allowlist.iter().any(|t| t == call.tool_id.as_str()) {
+                tracing::warn!(tool = %call.tool_id, "tool blocked by channel allowlist");
+                self.update_metrics(|m| m.pre_execution_blocks += 1);
+                self.push_security_event(
+                    zeph_common::SecurityEventCategory::PreExecutionBlock,
+                    call.tool_id.as_str(),
+                    format!(
+                        "channel allowlist: '{}' is not permitted on this channel",
+                        call.tool_id
+                    ),
+                );
+                pre_exec_blocked[idx] = true;
+            }
+        }
+    }
+
     fn compute_utility_actions(
         &mut self,
         calls: &[ToolCall],
@@ -660,7 +688,9 @@ impl<C: Channel> Agent<C> {
         // Runs after exfiltration guard (flag-only) and before repeat-detection.
         // Block: return synthetic error result for this call without executing.
         // Warn: log + emit security event + continue execution.
-        let pre_exec_blocked = self.run_pre_execution_verifiers(&calls);
+        let mut pre_exec_blocked = self.run_pre_execution_verifiers(&calls);
+
+        self.apply_channel_tool_allowlist(&calls, &mut pre_exec_blocked);
 
         // Utility gate: score each call and recommend an action (#2477).
         // user_requested is detected from the last user message only — never from LLM content or

--- a/crates/zeph-core/tests/vault_integration.rs
+++ b/crates/zeph-core/tests/vault_integration.rs
@@ -78,6 +78,7 @@ async fn age_vault_injects_token_into_existing_telegram_config() {
         token: None,
         allowed_users: vec!["test_user".to_owned()],
         skills: zeph_core::config::ChannelSkillsConfig::default(),
+        allowed_tools: None,
         stream_interval_ms: 3000,
         guest_mode: false,
         bot_to_bot: false,

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -805,6 +805,7 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
                 token: None,
                 allowed_users: state.telegram_users.clone(),
                 skills: ChannelSkillsConfig::default(),
+                allowed_tools: None,
                 stream_interval_ms: state.telegram_stream_interval_ms,
                 guest_mode: false,
                 bot_to_bot: false,
@@ -820,6 +821,7 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
                 allowed_role_ids: vec![],
                 allowed_channel_ids: vec![],
                 skills: ChannelSkillsConfig::default(),
+                allowed_tools: None,
             });
         }
         ChannelChoice::Slack => {
@@ -831,6 +833,7 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
                 allowed_user_ids: vec![],
                 allowed_channel_ids: vec![],
                 skills: ChannelSkillsConfig::default(),
+                allowed_tools: None,
             });
         }
     }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1380,6 +1380,50 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         _ => zeph_core::config::ChannelSkillsConfig::default(),
     };
 
+    // Derive per-channel tool allowlist from the matching config section.
+    #[cfg(feature = "tui")]
+    let channel_tool_allowlist: Option<Vec<String>> = match &channel {
+        AppChannel::Standard(c) if matches!(c.as_ref(), AnyChannel::Telegram(_)) => app
+            .config()
+            .telegram
+            .as_ref()
+            .and_then(|c| c.allowed_tools.clone()),
+        #[cfg(feature = "discord")]
+        AppChannel::Standard(c) if matches!(c.as_ref(), AnyChannel::Discord(_)) => app
+            .config()
+            .discord
+            .as_ref()
+            .and_then(|c| c.allowed_tools.clone()),
+        #[cfg(feature = "slack")]
+        AppChannel::Standard(c) if matches!(c.as_ref(), AnyChannel::Slack(_)) => app
+            .config()
+            .slack
+            .as_ref()
+            .and_then(|c| c.allowed_tools.clone()),
+        _ => app.config().cli.allowed_tools.clone(),
+    };
+    #[cfg(not(feature = "tui"))]
+    let channel_tool_allowlist: Option<Vec<String>> = match &channel {
+        AnyChannel::Telegram(_) => app
+            .config()
+            .telegram
+            .as_ref()
+            .and_then(|c| c.allowed_tools.clone()),
+        #[cfg(feature = "discord")]
+        AnyChannel::Discord(_) => app
+            .config()
+            .discord
+            .as_ref()
+            .and_then(|c| c.allowed_tools.clone()),
+        #[cfg(feature = "slack")]
+        AnyChannel::Slack(_) => app
+            .config()
+            .slack
+            .as_ref()
+            .and_then(|c| c.allowed_tools.clone()),
+        _ => app.config().cli.allowed_tools.clone(),
+    };
+
     let conversation_id = match memory.sqlite().latest_conversation_id().await? {
         Some(id) => id,
         None => memory.sqlite().create_conversation().await?,
@@ -2507,6 +2551,7 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         agent.with_hooks_config(&config.hooks)
     };
     let agent = agent.with_channel_skills(channel_skills_config);
+    let agent = agent.with_channel_tool_allowlist(channel_tool_allowlist);
     let agent = agent.with_learning(config.skills.learning.clone());
 
     // Wire SkillEvaluator — enabled in both normal and bare mode (quality gate only).

--- a/src/startup_checks.rs
+++ b/src/startup_checks.rs
@@ -90,6 +90,7 @@ mod tests {
                 bot_to_bot: false,
                 allowed_bots: vec![],
                 max_bot_chain_depth: 3,
+                allowed_tools: None,
             }),
             ..Default::default()
         };

--- a/src/startup_checks.rs
+++ b/src/startup_checks.rs
@@ -129,6 +129,7 @@ mod tests {
                 allowed_role_ids: vec![],
                 allowed_channel_ids: vec![],
                 skills: ChannelSkillsConfig::default(),
+                allowed_tools: None,
             }),
             ..Default::default()
         };
@@ -149,6 +150,7 @@ mod tests {
                 allowed_user_ids: vec![],
                 allowed_channel_ids: vec![],
                 skills: ChannelSkillsConfig::default(),
+                allowed_tools: None,
             }),
             ..Default::default()
         };

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -152,6 +152,7 @@ async fn create_channel_discord_without_token_falls_through() {
         allowed_role_ids: vec![],
         allowed_channel_ids: vec![],
         skills: zeph_core::config::ChannelSkillsConfig::default(),
+        allowed_tools: None,
     });
     config.telegram = None;
     let channel = create_channel(&config).await.unwrap();
@@ -170,6 +171,7 @@ async fn create_channel_slack_without_token_falls_through() {
         allowed_user_ids: vec![],
         allowed_channel_ids: vec![],
         skills: zeph_core::config::ChannelSkillsConfig::default(),
+        allowed_tools: None,
     });
     config.telegram = None;
     let channel = create_channel(&config).await.unwrap();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -100,6 +100,7 @@ async fn create_channel_telegram_without_token() {
         bot_to_bot: false,
         allowed_bots: vec![],
         max_bot_chain_depth: 3,
+        allowed_tools: None,
     });
     let channel = create_channel(&config).await.unwrap();
     assert!(matches!(channel, AnyChannel::Cli(_)));
@@ -134,6 +135,7 @@ async fn create_channel_telegram_with_token() {
         bot_to_bot: false,
         allowed_bots: vec![],
         max_bot_chain_depth: 3,
+        allowed_tools: None,
     });
     let channel = create_channel(&config).await.unwrap();
     assert!(matches!(channel, AnyChannel::Telegram(_)));
@@ -181,6 +183,7 @@ async fn create_channel_telegram_with_empty_allowed_users_errors() {
         token: Some("test_token2".to_string()),
         allowed_users: vec![],
         skills: zeph_core::config::ChannelSkillsConfig::default(),
+        allowed_tools: None,
         stream_interval_ms: 3000,
         guest_mode: false,
         bot_to_bot: false,


### PR DESCRIPTION
## Summary

- Wire `TurnContext.tool_allowlist` from channel config — the field was always `None` since epic #3498 closed without completing this item (#3879)
- Add `allowed_tools: Option<Vec<String>>` to all four channel configs (`TelegramConfig`, `DiscordConfig`, `SlackConfig`, `CliConfig`) with `#[serde(default)]` for backward compatibility
- Enforce the allowlist in tool dispatch via `apply_channel_tool_allowlist` in `tier_loop.rs` — disallowed tools are blocked, logged at WARN, and emitted as a security event
- Add unit test for `ContextBudget` path 4 (`memory_first=true`, `graph_enabled=true`) covering all 7 slot allocations (#3828)

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 9555 passed
- [x] 6 unit tests in `turn_context.rs` cover: `None` allowlist (all allowed), non-empty allowlist (allowed/denied), empty allowlist (all denied)
- [x] Budget path-4 test asserts all 7 slot allocations

Closes #3879
Closes #3828