### PR TITLE
refactor(bench): replace unlinked TODOs with issue references in zeph-bench

### DIFF
--- a/crates/zeph-bench/src/channel.rs
+++ b/crates/zeph-bench/src/channel.rs
@@ -256,10 +256,8 @@ impl zeph_core::channel::Channel for BenchmarkChannel {
         Ok(())
     }
 
-    // TODO(bench-runner): tool output is intentionally dropped here.
-    // The default trait impl calls self.send(&formatted), which would push tool output
-    // into responses and corrupt benchmark metrics. Override to no-op until Phase 2
-    // when tool calls are captured separately.
+    // Tool output is intentionally dropped here — pushing it via the default impl would corrupt
+    // benchmark metrics. Phase 2 capture is tracked in #4237.
     async fn send_tool_output(&mut self, _event: ToolOutputEvent) -> Result<(), ChannelError> {
         Ok(())
     }

--- a/crates/zeph-bench/src/loaders/tau2_bench/eval.rs
+++ b/crates/zeph-bench/src/loaders/tau2_bench/eval.rs
@@ -14,9 +14,7 @@
 //! Only `requestor = "assistant"` gold actions are evaluated — user-simulator
 //! actions are out of scope for the single-turn MVP.
 //!
-//! # TODO
-//!
-//! TODO(#3417/D1): Phase 2 — implement upstream `EnvironmentEvaluator` (DB hash + `env_assertions`).
+//! Phase 2 `EnvironmentEvaluator` (DB hash + `env_assertions`) is tracked in #4234 (D1 of #3417).
 //! Current scoring is ACTION-only and matches upstream `evaluator_action.py`. To reproduce
 //! published numbers using `evaluation_type=ALL`, we additionally need:
 //!
@@ -120,8 +118,7 @@ impl Evaluator for TauBenchEvaluator {
         }
 
         let passed = matched == total;
-        // TODO(critic): append unmatched gold-action names to details for easier debugging.
-        // See critic-tau-bench-v2.md M4.
+        // Unmatched action names are already included via `unmatched={:?}` (#4235).
         let details = format!(
             "action_reward matched={}/{} recorded_calls={} unmatched={:?}",
             matched,

--- a/crates/zeph-bench/src/loaders/tau2_bench/loader.rs
+++ b/crates/zeph-bench/src/loaders/tau2_bench/loader.rs
@@ -134,9 +134,7 @@ impl DatasetLoader for Tau2BenchLoader {
 /// This is a deliberate MVP simplification — the full tau2-bench benchmark uses
 /// a multi-turn user simulator. Here we collapse it into one upfront prompt.
 ///
-/// # TODO
-///
-/// TODO(#3417/D4): implement multi-turn user simulator. The current approach
+/// Multi-turn user simulation is deferred to #4233 (D4 of #3417). The current approach
 /// works for ACTION-only scoring because the agent sees all information at once,
 /// but will under-score tasks where the user simulator drives information
 /// exchange across turns.

--- a/crates/zeph-bench/src/runner.rs
+++ b/crates/zeph-bench/src/runner.rs
@@ -424,8 +424,7 @@ impl BenchRunner {
         .entered();
         let prompt = scenario.primary_prompt()?.to_owned();
         let channel = BenchmarkChannel::new(vec![prompt]);
-        // TODO(multi-turn-history): when loaders emit multiple user turns, push each in
-        // order and seed assistant turns into the channel as captured-history.
+        // Multi-turn history seeding is deferred to #4236.
         let registry = SkillRegistry::empty();
 
         let system_content = match mode {


### PR DESCRIPTION
## Summary

- `loader.rs`: `TODO(#3417/D4)` → reference #4233 (multi-turn user simulator)
- `eval.rs` module doc: `TODO(#3417/D1)` → reference #4234 (EnvironmentEvaluator Phase 2)
- `eval.rs` inline: `TODO(critic)` removed — unmatched names already present in the `details` string via `unmatched={:?}`; tracked in #4235
- `runner.rs`: `TODO(multi-turn-history)` → reference #4236
- `channel.rs`: `TODO(bench-runner)` → reference #4237

Closes #3954

## Test plan

- [x] `cargo +nightly fmt --check -p zeph-bench` — clean
- [x] `cargo clippy -p zeph-bench --all-targets -- -D warnings` — no warnings
- [x] `cargo nextest run -p zeph-bench --lib --bins` — 139 passed, 1 skipped