### PR TITLE
refactor(llm,mcp): replace positional constructors with named-field config structs

### DIFF
--- a/crates/zeph-core/src/provider_factory.rs
+++ b/crates/zeph-core/src/provider_factory.rs
@@ -216,14 +216,14 @@ fn build_openai_provider(
         .unwrap_or_else(|| "gpt-4o-mini".to_owned());
     let max_tokens = entry.max_tokens.unwrap_or(4096);
     Ok(AnyProvider::OpenAi(
-        OpenAiProvider::new(
+        OpenAiProvider::new(zeph_llm::OpenAiConfig {
             api_key,
             base_url,
             model,
             max_tokens,
-            entry.embedding_model.clone(),
-            entry.reasoning_effort.clone(),
-        )
+            embedding_model: entry.embedding_model.clone(),
+            reasoning_effort: entry.reasoning_effort.clone(),
+        })
         .with_client(llm_client(config.timeouts.llm_request_timeout_secs))
         .with_output_schema_forwarding(
             config.mcp.forward_output_schema,
@@ -301,14 +301,14 @@ fn build_compatible_provider(
             .unwrap_or_default()
     });
     let max_tokens = entry.max_tokens.unwrap_or(4096);
-    let provider = CompatibleProvider::new(
-        name.to_owned(),
+    let provider = CompatibleProvider::new(zeph_llm::CompatibleConfig {
+        provider_name: name.to_owned(),
         api_key,
         base_url,
         model,
         max_tokens,
-        entry.embedding_model.clone(),
-    )
+        embedding_model: entry.embedding_model.clone(),
+    })
     .with_output_schema_forwarding(
         config.mcp.forward_output_schema,
         config.mcp.output_schema_hint_bytes,
@@ -386,14 +386,14 @@ fn build_gonka_provider(
     let max_tokens = entry.max_tokens.unwrap_or(4096);
     let timeout = std::time::Duration::from_secs(config.timeouts.llm_request_timeout_secs);
 
-    let provider = GonkaProvider::new(
-        std::sync::Arc::new(signer),
-        std::sync::Arc::new(pool),
+    let provider = GonkaProvider::new(zeph_llm::gonka::GonkaConfig {
+        signer: std::sync::Arc::new(signer),
+        pool: std::sync::Arc::new(pool),
         model,
         max_tokens,
-        entry.embedding_model.clone(),
+        embedding_model: entry.embedding_model.clone(),
         timeout,
-    );
+    });
 
     Ok(AnyProvider::Gonka(provider))
 }

--- a/crates/zeph-llm/src/any.rs
+++ b/crates/zeph-llm/src/any.rs
@@ -709,12 +709,14 @@ mod tests {
     #[test]
     fn any_openai_name() {
         let provider = AnyProvider::OpenAi(crate::openai::OpenAiProvider::new(
-            "key".into(),
-            "https://api.openai.com/v1".into(),
-            "gpt-4o".into(),
-            1024,
-            None,
-            None,
+            crate::openai::OpenAiConfig {
+                api_key: "key".into(),
+                base_url: "https://api.openai.com/v1".into(),
+                model: "gpt-4o".into(),
+                max_tokens: 1024,
+                embedding_model: None,
+                reasoning_effort: None,
+            },
         ));
         assert_eq!(provider.name(), "openai");
     }
@@ -722,12 +724,14 @@ mod tests {
     #[test]
     fn any_openai_supports_streaming() {
         let provider = AnyProvider::OpenAi(crate::openai::OpenAiProvider::new(
-            "key".into(),
-            "https://api.openai.com/v1".into(),
-            "gpt-4o".into(),
-            1024,
-            None,
-            None,
+            crate::openai::OpenAiConfig {
+                api_key: "key".into(),
+                base_url: "https://api.openai.com/v1".into(),
+                model: "gpt-4o".into(),
+                max_tokens: 1024,
+                embedding_model: None,
+                reasoning_effort: None,
+            },
         ));
         assert!(provider.supports_streaming());
     }
@@ -735,22 +739,26 @@ mod tests {
     #[test]
     fn any_openai_supports_embeddings() {
         let with_embed = AnyProvider::OpenAi(crate::openai::OpenAiProvider::new(
-            "key".into(),
-            "https://api.openai.com/v1".into(),
-            "gpt-4o".into(),
-            1024,
-            Some("text-embedding-3-small".into()),
-            None,
+            crate::openai::OpenAiConfig {
+                api_key: "key".into(),
+                base_url: "https://api.openai.com/v1".into(),
+                model: "gpt-4o".into(),
+                max_tokens: 1024,
+                embedding_model: Some("text-embedding-3-small".into()),
+                reasoning_effort: None,
+            },
         ));
         assert!(with_embed.supports_embeddings());
 
         let without_embed = AnyProvider::OpenAi(crate::openai::OpenAiProvider::new(
-            "key".into(),
-            "https://api.openai.com/v1".into(),
-            "gpt-4o".into(),
-            1024,
-            None,
-            None,
+            crate::openai::OpenAiConfig {
+                api_key: "key".into(),
+                base_url: "https://api.openai.com/v1".into(),
+                model: "gpt-4o".into(),
+                max_tokens: 1024,
+                embedding_model: None,
+                reasoning_effort: None,
+            },
         ));
         assert!(!without_embed.supports_embeddings());
     }
@@ -758,12 +766,14 @@ mod tests {
     #[test]
     fn any_openai_debug() {
         let provider = AnyProvider::OpenAi(crate::openai::OpenAiProvider::new(
-            "key".into(),
-            "https://api.openai.com/v1".into(),
-            "gpt-4o".into(),
-            1024,
-            None,
-            None,
+            crate::openai::OpenAiConfig {
+                api_key: "key".into(),
+                base_url: "https://api.openai.com/v1".into(),
+                model: "gpt-4o".into(),
+                max_tokens: 1024,
+                embedding_model: None,
+                reasoning_effort: None,
+            },
         ));
         let debug = format!("{provider:?}");
         assert!(debug.contains("OpenAi"));
@@ -792,12 +802,14 @@ mod tests {
     #[test]
     fn any_openai_supports_structured_output() {
         let provider = AnyProvider::OpenAi(crate::openai::OpenAiProvider::new(
-            "key".into(),
-            "https://api.openai.com/v1".into(),
-            "gpt-4o".into(),
-            1024,
-            None,
-            None,
+            crate::openai::OpenAiConfig {
+                api_key: "key".into(),
+                base_url: "https://api.openai.com/v1".into(),
+                model: "gpt-4o".into(),
+                max_tokens: 1024,
+                embedding_model: None,
+                reasoning_effort: None,
+            },
         ));
         assert!(provider.supports_structured_output());
     }
@@ -821,12 +833,14 @@ mod tests {
     #[test]
     fn any_openai_supports_vision() {
         let provider = AnyProvider::OpenAi(crate::openai::OpenAiProvider::new(
-            "key".into(),
-            "https://api.openai.com/v1".into(),
-            "gpt-4o".into(),
-            1024,
-            None,
-            None,
+            crate::openai::OpenAiConfig {
+                api_key: "key".into(),
+                base_url: "https://api.openai.com/v1".into(),
+                model: "gpt-4o".into(),
+                max_tokens: 1024,
+                embedding_model: None,
+                reasoning_effort: None,
+            },
         ));
         assert!(provider.supports_vision());
     }
@@ -860,14 +874,14 @@ mod tests {
             }])
             .unwrap(),
         );
-        AnyProvider::Gonka(GonkaProvider::new(
+        AnyProvider::Gonka(GonkaProvider::new(crate::gonka::GonkaConfig {
             signer,
             pool,
-            "gpt-4o",
-            4096,
-            None,
-            std::time::Duration::from_secs(30),
-        ))
+            model: "gpt-4o".into(),
+            max_tokens: 4096,
+            embedding_model: None,
+            timeout: std::time::Duration::from_secs(30),
+        }))
     }
 
     #[cfg(feature = "gonka")]

--- a/crates/zeph-llm/src/cocoon/provider.rs
+++ b/crates/zeph-llm/src/cocoon/provider.rs
@@ -165,14 +165,14 @@ impl CocoonProvider {
         client: Arc<CocoonClient>,
     ) -> Self {
         let model = model.into();
-        let inner = OpenAiProvider::new(
-            String::new(),
-            String::new(),
+        let inner = OpenAiProvider::new(crate::openai::OpenAiConfig {
+            api_key: String::new(),
+            base_url: String::new(),
             model,
             max_tokens,
-            embedding_model.clone(),
-            None,
-        );
+            embedding_model: embedding_model.clone(),
+            reasoning_effort: None,
+        });
         Self {
             inner,
             client,

--- a/crates/zeph-llm/src/compatible.rs
+++ b/crates/zeph-llm/src/compatible.rs
@@ -23,11 +23,47 @@
 use std::fmt;
 
 use crate::error::LlmError;
-use crate::openai::OpenAiProvider;
+use crate::openai::{OpenAiConfig, OpenAiProvider};
 use crate::provider::{
     ChatExtras, ChatResponse, ChatStream, GenerationOverrides, LlmProvider, Message, StatusTx,
     ToolDefinition,
 };
+
+/// Configuration for [`CompatibleProvider`].
+///
+/// Pass to [`CompatibleProvider::new`] instead of individual positional arguments to avoid
+/// silent parameter transposition.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_llm::compatible::{CompatibleConfig, CompatibleProvider};
+///
+/// let cfg = CompatibleConfig {
+///     provider_name: "together-ai".into(),
+///     api_key: "key".into(),
+///     base_url: "https://api.together.xyz/v1".into(),
+///     model: "meta-llama/Llama-3.3-70B-Instruct-Turbo".into(),
+///     max_tokens: 4096,
+///     embedding_model: None,
+/// };
+/// let provider = CompatibleProvider::new(cfg);
+/// ```
+#[derive(Debug, Clone)]
+pub struct CompatibleConfig {
+    /// Human-readable provider name used in logs and [`LlmProvider::name`].
+    pub provider_name: String,
+    /// Secret API key sent in the `Authorization: Bearer` header.
+    pub api_key: String,
+    /// Base URL of the endpoint, e.g. `"https://api.together.xyz/v1"`.
+    pub base_url: String,
+    /// Chat model identifier.
+    pub model: String,
+    /// Upper bound on completion tokens returned by the model.
+    pub max_tokens: u32,
+    /// Embedding model identifier. Set to `None` when the endpoint does not support embeddings.
+    pub embedding_model: Option<String>,
+}
 
 /// [`LlmProvider`] adapter for OpenAI-compatible REST endpoints.
 ///
@@ -40,17 +76,18 @@ pub struct CompatibleProvider {
 }
 
 impl CompatibleProvider {
+    /// Create a new provider from a [`CompatibleConfig`].
     #[must_use]
-    pub fn new(
-        provider_name: String,
-        api_key: String,
-        base_url: String,
-        model: String,
-        max_tokens: u32,
-        embedding_model: Option<String>,
-    ) -> Self {
-        let inner =
-            OpenAiProvider::new(api_key, base_url, model, max_tokens, embedding_model, None);
+    pub fn new(cfg: CompatibleConfig) -> Self {
+        let provider_name = cfg.provider_name;
+        let inner = OpenAiProvider::new(OpenAiConfig {
+            api_key: cfg.api_key,
+            base_url: cfg.base_url,
+            model: cfg.model,
+            max_tokens: cfg.max_tokens,
+            embedding_model: cfg.embedding_model,
+            reasoning_effort: None,
+        });
         Self {
             inner,
             provider_name,
@@ -234,14 +271,14 @@ mod tests {
     use super::*;
 
     fn test_provider() -> CompatibleProvider {
-        CompatibleProvider::new(
-            "groq".into(),
-            "key".into(),
-            "https://api.groq.com/openai/v1".into(),
-            "llama-3.3-70b".into(),
-            4096,
-            None,
-        )
+        CompatibleProvider::new(CompatibleConfig {
+            provider_name: "groq".into(),
+            api_key: "key".into(),
+            base_url: "https://api.groq.com/openai/v1".into(),
+            model: "llama-3.3-70b".into(),
+            max_tokens: 4096,
+            embedding_model: None,
+        })
     }
 
     #[test]
@@ -267,14 +304,14 @@ mod tests {
 
     #[test]
     fn supports_embeddings_with_model() {
-        let p = CompatibleProvider::new(
-            "test".into(),
-            "key".into(),
-            "http://localhost".into(),
-            "m".into(),
-            100,
-            Some("embed-model".into()),
-        );
+        let p = CompatibleProvider::new(CompatibleConfig {
+            provider_name: "test".into(),
+            api_key: "key".into(),
+            base_url: "http://localhost".into(),
+            model: "m".into(),
+            max_tokens: 100,
+            embedding_model: Some("embed-model".into()),
+        });
         assert!(p.supports_embeddings());
     }
 
@@ -294,14 +331,14 @@ mod tests {
 
     #[tokio::test]
     async fn chat_unreachable_errors() {
-        let p = CompatibleProvider::new(
-            "test".into(),
-            "key".into(),
-            "http://127.0.0.1:1".into(),
-            "m".into(),
-            100,
-            None,
-        );
+        let p = CompatibleProvider::new(CompatibleConfig {
+            provider_name: "test".into(),
+            api_key: "key".into(),
+            base_url: "http://127.0.0.1:1".into(),
+            model: "m".into(),
+            max_tokens: 100,
+            embedding_model: None,
+        });
         let msgs = vec![Message::from_legacy(crate::provider::Role::User, "hello")];
         assert!(p.chat(&msgs).await.is_err());
     }

--- a/crates/zeph-llm/src/gonka/mod.rs
+++ b/crates/zeph-llm/src/gonka/mod.rs
@@ -15,6 +15,6 @@ pub mod signer;
 mod tests;
 
 #[cfg(feature = "gonka")]
-pub use provider::GonkaProvider;
+pub use provider::{GonkaConfig, GonkaProvider};
 #[cfg(feature = "gonka")]
 pub use signer::RequestSigner;

--- a/crates/zeph-llm/src/gonka/provider.rs
+++ b/crates/zeph-llm/src/gonka/provider.rs
@@ -15,7 +15,7 @@ use crate::embed::truncate_for_embed;
 use crate::error::LlmError;
 use crate::gonka::endpoints::{EndpointPool, now_ns};
 use crate::gonka::signer::RequestSigner;
-use crate::openai::OpenAiProvider;
+use crate::openai::{OpenAiConfig, OpenAiProvider};
 use crate::provider::{ChatResponse, ChatStream, LlmProvider, Message, StatusTx, ToolDefinition};
 use crate::sse::openai_sse_to_stream;
 use crate::usage::UsageTracker;
@@ -85,6 +85,56 @@ struct EmbeddingBatchRequest<'a> {
 // GonkaProvider
 // ──────────────────────────────────────────────────────────────────────────────
 
+/// Configuration for [`GonkaProvider`].
+///
+/// Pass to [`GonkaProvider::new`] instead of individual positional arguments to avoid
+/// silent parameter transposition.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::sync::Arc;
+/// use std::time::Duration;
+/// use zeph_llm::gonka::endpoints::{EndpointPool, GonkaEndpoint};
+/// use zeph_llm::gonka::{GonkaConfig, GonkaProvider, RequestSigner};
+///
+/// # fn example() -> Result<(), zeph_llm::LlmError> {
+/// let signer = Arc::new(RequestSigner::from_hex(
+///     "0000000000000000000000000000000000000000000000000000000000000001",
+///     "gonka",
+/// )?);
+/// let pool = Arc::new(EndpointPool::new(vec![GonkaEndpoint {
+///     base_url: "https://node1.gonka.ai".into(),
+///     address: "gonka1w508d6qejxtdg4y5r3zarvary0c5xw7k2gsyg6".into(),
+/// }])?);
+/// let cfg = GonkaConfig {
+///     signer,
+///     pool,
+///     model: "gpt-4o".into(),
+///     max_tokens: 4096,
+///     embedding_model: Some("text-embedding-3-small".into()),
+///     timeout: Duration::from_secs(30),
+/// };
+/// let provider = GonkaProvider::new(cfg);
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Clone)]
+pub struct GonkaConfig {
+    /// ECDSA request signer used to authenticate all outbound HTTP calls.
+    pub signer: Arc<RequestSigner>,
+    /// Pool of Gonka network endpoints; failed nodes are skipped automatically.
+    pub pool: Arc<EndpointPool>,
+    /// Chat model identifier sent in the request body, e.g. `"gpt-4o"`.
+    pub model: String,
+    /// Upper bound on completion tokens returned by the model.
+    pub max_tokens: u32,
+    /// Embedding model identifier. Set to `None` to disable embedding support.
+    pub embedding_model: Option<String>,
+    /// Per-request deadline; wraps every outbound `.await`.
+    pub timeout: Duration,
+}
+
 /// LLM provider that routes requests through the Gonka network via ECDSA-signed transport.
 ///
 /// Request bodies are constructed by an inner [`OpenAiProvider`] (the Gonka gateway
@@ -130,69 +180,26 @@ impl Clone for GonkaProvider {
 }
 
 impl GonkaProvider {
-    /// Construct a new `GonkaProvider`.
-    ///
-    /// - `model` — chat model name sent in the request body (e.g. `"gpt-4o"`).
-    /// - `max_tokens` — upper bound on completion tokens.
-    /// - `embedding_model` — if `Some`, enables embedding support via `/embeddings`.
-    /// - `timeout` — per-request deadline; wraps every outbound `.await`.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use std::sync::Arc;
-    /// use std::time::Duration;
-    /// use zeph_llm::gonka::endpoints::{EndpointPool, GonkaEndpoint};
-    /// use zeph_llm::gonka::RequestSigner;
-    /// use zeph_llm::gonka::GonkaProvider;
-    ///
-    /// # fn example() -> Result<(), zeph_llm::LlmError> {
-    /// let signer = Arc::new(RequestSigner::from_hex(
-    ///     "0000000000000000000000000000000000000000000000000000000000000001",
-    ///     "gonka",
-    /// )?);
-    /// let pool = Arc::new(EndpointPool::new(vec![GonkaEndpoint {
-    ///     base_url: "https://node1.gonka.ai".into(),
-    ///     address: "gonka1w508d6qejxtdg4y5r3zarvary0c5xw7k2gsyg6".into(),
-    /// }])?);
-    /// let provider = GonkaProvider::new(
-    ///     signer,
-    ///     pool,
-    ///     "gpt-4o",
-    ///     4096,
-    ///     Some("text-embedding-3-small".into()),
-    ///     Duration::from_secs(30),
-    /// );
-    /// # Ok(())
-    /// # }
-    /// ```
+    /// Create a new provider from a [`GonkaConfig`].
     #[must_use]
-    pub fn new(
-        signer: Arc<RequestSigner>,
-        pool: Arc<EndpointPool>,
-        model: impl Into<String>,
-        max_tokens: u32,
-        embedding_model: Option<String>,
-        timeout: Duration,
-    ) -> Self {
-        let model = model.into();
-        let inner = OpenAiProvider::new(
-            String::new(),
-            String::new(),
-            model,
-            max_tokens,
-            embedding_model.clone(),
-            None,
-        );
+    pub fn new(cfg: GonkaConfig) -> Self {
+        let inner = OpenAiProvider::new(OpenAiConfig {
+            api_key: String::new(),
+            base_url: String::new(),
+            model: cfg.model,
+            max_tokens: cfg.max_tokens,
+            embedding_model: cfg.embedding_model.clone(),
+            reasoning_effort: None,
+        });
         // HTTP client timeout is generous to avoid double-timeout with tokio::time::timeout.
-        let client = crate::http::llm_client(timeout.as_secs().saturating_add(30));
+        let client = crate::http::llm_client(cfg.timeout.as_secs().saturating_add(30));
         Self {
             inner,
-            signer,
-            pool,
+            signer: cfg.signer,
+            pool: cfg.pool,
             client,
-            timeout,
-            embedding_model,
+            timeout: cfg.timeout,
+            embedding_model: cfg.embedding_model,
             usage: UsageTracker::default(),
             status_tx: None,
         }

--- a/crates/zeph-llm/src/gonka/tests.rs
+++ b/crates/zeph-llm/src/gonka/tests.rs
@@ -33,14 +33,14 @@ fn make_provider(base_url: &str) -> GonkaProvider {
         }])
         .unwrap(),
     );
-    GonkaProvider::new(
+    GonkaProvider::new(super::GonkaConfig {
         signer,
         pool,
-        "gpt-4o",
-        1024,
-        Some("text-embedding-3-small".to_owned()),
-        Duration::from_secs(10),
-    )
+        model: "gpt-4o".into(),
+        max_tokens: 1024,
+        embedding_model: Some("text-embedding-3-small".to_owned()),
+        timeout: Duration::from_secs(10),
+    })
 }
 
 fn user_message(text: &str) -> Vec<Message> {
@@ -234,7 +234,14 @@ async fn gonka_retry_on_endpoint_failure() {
         ])
         .unwrap(),
     );
-    let provider = GonkaProvider::new(signer, pool, "gpt-4o", 1024, None, Duration::from_secs(10));
+    let provider = GonkaProvider::new(super::GonkaConfig {
+        signer,
+        pool,
+        model: "gpt-4o".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        timeout: Duration::from_secs(10),
+    });
     let messages = user_message("retry test");
     let result = provider.chat(&messages).await.unwrap();
     assert_eq!(result, "hello");
@@ -317,7 +324,14 @@ async fn gonka_fresh_timestamp_on_retry() {
         ])
         .unwrap(),
     );
-    let provider = GonkaProvider::new(signer, pool, "gpt-4o", 1024, None, Duration::from_secs(10));
+    let provider = GonkaProvider::new(super::GonkaConfig {
+        signer,
+        pool,
+        model: "gpt-4o".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        timeout: Duration::from_secs(10),
+    });
     let messages = user_message("timestamp test");
     let result = provider.chat(&messages).await.unwrap();
     assert_eq!(result, "hello");
@@ -395,7 +409,14 @@ async fn gonka_embed_unsupported_without_model() {
         .unwrap(),
     );
     // No embedding model configured.
-    let provider = GonkaProvider::new(signer, pool, "gpt-4o", 1024, None, Duration::from_secs(5));
+    let provider = GonkaProvider::new(super::GonkaConfig {
+        signer,
+        pool,
+        model: "gpt-4o".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        timeout: Duration::from_secs(5),
+    });
     assert!(!provider.supports_embeddings());
 
     let result = provider.embed("test").await;

--- a/crates/zeph-llm/src/lib.rs
+++ b/crates/zeph-llm/src/lib.rs
@@ -109,8 +109,10 @@ pub(crate) mod usage;
 pub mod whisper;
 
 pub use classifier::metrics::{ClassifierMetrics, ClassifierMetricsSnapshot, TaskMetricsSnapshot};
+pub use compatible::CompatibleConfig;
 pub use error::LlmError;
 pub use extractor::Extractor;
+pub use openai::OpenAiConfig;
 pub use provider::{ChatExtras, ChatStream, LlmProvider, StreamChunk, ThinkingBlock};
 pub use provider_dyn::LlmProviderDyn;
 pub use router::aware::RouterAware;

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -34,6 +34,44 @@ use crate::error::LlmError;
 use base64::{Engine, engine::general_purpose::STANDARD};
 use serde::{Deserialize, Serialize};
 
+/// Configuration for [`OpenAiProvider`].
+///
+/// Pass to [`OpenAiProvider::new`] instead of individual positional arguments to avoid
+/// silent parameter transposition.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_llm::openai::{OpenAiConfig, OpenAiProvider};
+///
+/// let cfg = OpenAiConfig {
+///     api_key: "sk-...".into(),
+///     base_url: "https://api.openai.com/v1".into(),
+///     model: "gpt-4o".into(),
+///     max_tokens: 4096,
+///     embedding_model: Some("text-embedding-3-small".into()),
+///     reasoning_effort: None,
+/// };
+/// let provider = OpenAiProvider::new(cfg);
+/// ```
+#[derive(Debug, Clone)]
+pub struct OpenAiConfig {
+    /// Secret API key sent in the `Authorization: Bearer` header.
+    pub api_key: String,
+    /// Base URL of the endpoint, e.g. `"https://api.openai.com/v1"`.
+    /// Trailing slashes are stripped automatically.
+    pub base_url: String,
+    /// Chat model identifier, e.g. `"gpt-4o"`.
+    pub model: String,
+    /// Upper bound on completion tokens returned by the model.
+    pub max_tokens: u32,
+    /// Embedding model identifier. Set to `None` when the endpoint does not support embeddings.
+    pub embedding_model: Option<String>,
+    /// Reasoning effort level for `o*` models (`"low"`, `"medium"`, or `"high"`).
+    /// Leave `None` for standard chat models.
+    pub reasoning_effort: Option<String>,
+}
+
 use crate::provider::{
     ChatExtras, ChatResponse, ChatStream, GenerationOverrides, LlmProvider, Message, MessagePart,
     Role, StatusTx, ToolDefinition, ToolUseRequest,
@@ -116,32 +154,21 @@ impl Clone for OpenAiProvider {
 }
 
 impl OpenAiProvider {
-    /// Create a new provider.
-    ///
-    /// Trailing slashes are stripped from `base_url` automatically.
-    /// Set `embedding_model` to `None` when the endpoint does not support embeddings.
-    /// Set `reasoning_effort` to `Some("low" | "medium" | "high")` for `o*` reasoning models;
-    /// leave `None` for standard chat models.
+    /// Create a new provider from an [`OpenAiConfig`].
     #[must_use]
-    pub fn new(
-        api_key: String,
-        mut base_url: String,
-        model: String,
-        max_tokens: u32,
-        embedding_model: Option<String>,
-        reasoning_effort: Option<String>,
-    ) -> Self {
+    pub fn new(cfg: OpenAiConfig) -> Self {
+        let mut base_url = cfg.base_url;
         while base_url.ends_with('/') {
             base_url.pop();
         }
         Self {
             client: crate::http::llm_client(600),
-            api_key,
+            api_key: cfg.api_key,
             base_url,
-            model,
-            max_tokens,
-            embedding_model,
-            reasoning_effort,
+            model: cfg.model,
+            max_tokens: cfg.max_tokens,
+            embedding_model: cfg.embedding_model,
+            reasoning_effort: cfg.reasoning_effort,
             status_tx: None,
             usage: UsageTracker::default(),
             generation_overrides: None,

--- a/crates/zeph-llm/src/openai/tests.rs
+++ b/crates/zeph-llm/src/openai/tests.rs
@@ -7,26 +7,26 @@ use crate::provider::MessageMetadata;
 use tokio_stream::StreamExt;
 
 fn test_provider() -> OpenAiProvider {
-    OpenAiProvider::new(
-        "sk-test-key".into(),
-        "https://api.openai.com/v1".into(),
-        "gpt-5.2".into(),
-        4096,
-        Some("text-embedding-3-small".into()),
-        None,
-    )
+    OpenAiProvider::new(OpenAiConfig {
+        api_key: "sk-test-key".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "gpt-5.2".into(),
+        max_tokens: 4096,
+        embedding_model: Some("text-embedding-3-small".into()),
+        reasoning_effort: None,
+    })
 }
 
 #[test]
 fn context_window_gpt4o() {
-    let p = OpenAiProvider::new(
-        "k".into(),
-        "https://api.openai.com/v1".into(),
-        "gpt-4o".into(),
-        1024,
-        None,
-        None,
-    );
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "gpt-4o".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        reasoning_effort: None,
+    });
     assert_eq!(p.context_window(), Some(128_000));
 }
 
@@ -37,26 +37,26 @@ fn context_window_gpt5() {
 
 #[test]
 fn context_window_unknown() {
-    let p = OpenAiProvider::new(
-        "k".into(),
-        "https://api.openai.com/v1".into(),
-        "custom-model".into(),
-        1024,
-        None,
-        None,
-    );
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "custom-model".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        reasoning_effort: None,
+    });
     assert!(p.context_window().is_none());
 }
 
 fn test_provider_no_embed() -> OpenAiProvider {
-    OpenAiProvider::new(
-        "sk-test-key".into(),
-        "https://api.openai.com/v1".into(),
-        "gpt-5.2".into(),
-        4096,
-        None,
-        None,
-    )
+    OpenAiProvider::new(OpenAiConfig {
+        api_key: "sk-test-key".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "gpt-5.2".into(),
+        max_tokens: 4096,
+        embedding_model: None,
+        reasoning_effort: None,
+    })
 }
 
 #[test]
@@ -72,14 +72,14 @@ fn new_stores_fields() {
 
 #[test]
 fn new_with_reasoning_effort() {
-    let p = OpenAiProvider::new(
-        "key".into(),
-        "https://api.openai.com/v1".into(),
-        "gpt-5.2".into(),
-        4096,
-        None,
-        Some("high".into()),
-    );
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "key".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "gpt-5.2".into(),
+        max_tokens: 4096,
+        embedding_model: None,
+        reasoning_effort: Some("high".into()),
+    });
     assert_eq!(p.reasoning_effort.as_deref(), Some("high"));
 }
 
@@ -359,14 +359,14 @@ fn convert_messages_maps_roles() {
 
 #[tokio::test]
 async fn chat_unreachable_endpoint_errors() {
-    let p = OpenAiProvider::new(
-        "key".into(),
-        "http://127.0.0.1:1".into(),
-        "model".into(),
-        100,
-        None,
-        None,
-    );
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "key".into(),
+        base_url: "http://127.0.0.1:1".into(),
+        model: "model".into(),
+        max_tokens: 100,
+        embedding_model: None,
+        reasoning_effort: None,
+    });
     let messages = vec![Message {
         role: Role::User,
         content: "test".into(),
@@ -378,14 +378,14 @@ async fn chat_unreachable_endpoint_errors() {
 
 #[tokio::test]
 async fn stream_unreachable_endpoint_errors() {
-    let p = OpenAiProvider::new(
-        "key".into(),
-        "http://127.0.0.1:1".into(),
-        "model".into(),
-        100,
-        None,
-        None,
-    );
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "key".into(),
+        base_url: "http://127.0.0.1:1".into(),
+        model: "model".into(),
+        max_tokens: 100,
+        embedding_model: None,
+        reasoning_effort: None,
+    });
     let messages = vec![Message {
         role: Role::User,
         content: "test".into(),
@@ -397,14 +397,14 @@ async fn stream_unreachable_endpoint_errors() {
 
 #[tokio::test]
 async fn embed_unreachable_endpoint_errors() {
-    let p = OpenAiProvider::new(
-        "key".into(),
-        "http://127.0.0.1:1".into(),
-        "model".into(),
-        100,
-        Some("embed-model".into()),
-        None,
-    );
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "key".into(),
+        base_url: "http://127.0.0.1:1".into(),
+        model: "model".into(),
+        max_tokens: 100,
+        embedding_model: Some("embed-model".into()),
+        reasoning_effort: None,
+    });
     assert!(p.embed("test").await.is_err());
 }
 
@@ -423,14 +423,14 @@ async fn embed_without_model_returns_error() {
 
 #[test]
 fn base_url_strips_trailing_slash() {
-    let p = OpenAiProvider::new(
-        "key".into(),
-        "https://api.openai.com/v1/".into(),
-        "m".into(),
-        100,
-        None,
-        None,
-    );
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "key".into(),
+        base_url: "https://api.openai.com/v1/".into(),
+        model: "m".into(),
+        max_tokens: 100,
+        embedding_model: None,
+        reasoning_effort: None,
+    });
     assert_eq!(p.base_url, "https://api.openai.com/v1");
 }
 
@@ -469,14 +469,14 @@ fn embedding_response_empty_data() {
 #[ignore = "requires ZEPH_OPENAI_API_KEY env var"]
 async fn integration_openai_chat() {
     let api_key = std::env::var("ZEPH_OPENAI_API_KEY").expect("ZEPH_OPENAI_API_KEY must be set");
-    let provider = OpenAiProvider::new(
-        api_key,
-        "https://api.openai.com/v1".into(),
-        "gpt-5.2".into(),
-        256,
-        None,
-        None,
-    );
+    let provider = OpenAiProvider::new(OpenAiConfig {
+        api_key: api_key,
+        base_url: "https://api.openai.com/v1".into(),
+        model: "gpt-5.2".into(),
+        max_tokens: 256,
+        embedding_model: None,
+        reasoning_effort: None,
+    });
 
     let messages = vec![Message {
         role: Role::User,
@@ -493,14 +493,14 @@ async fn integration_openai_chat() {
 #[ignore = "requires ZEPH_OPENAI_API_KEY env var"]
 async fn integration_openai_chat_stream() {
     let api_key = std::env::var("ZEPH_OPENAI_API_KEY").expect("ZEPH_OPENAI_API_KEY must be set");
-    let provider = OpenAiProvider::new(
-        api_key,
-        "https://api.openai.com/v1".into(),
-        "gpt-5.2".into(),
-        256,
-        None,
-        None,
-    );
+    let provider = OpenAiProvider::new(OpenAiConfig {
+        api_key: api_key,
+        base_url: "https://api.openai.com/v1".into(),
+        model: "gpt-5.2".into(),
+        max_tokens: 256,
+        embedding_model: None,
+        reasoning_effort: None,
+    });
 
     let messages = vec![Message {
         role: Role::User,
@@ -524,27 +524,27 @@ async fn integration_openai_chat_stream() {
 
 #[test]
 fn context_window_gpt35() {
-    let p = OpenAiProvider::new(
-        "k".into(),
-        "https://api.openai.com/v1".into(),
-        "gpt-3.5-turbo".into(),
-        1024,
-        None,
-        None,
-    );
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "gpt-3.5-turbo".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        reasoning_effort: None,
+    });
     assert_eq!(p.context_window(), Some(16_385));
 }
 
 #[test]
 fn context_window_gpt4_turbo() {
-    let p = OpenAiProvider::new(
-        "k".into(),
-        "https://api.openai.com/v1".into(),
-        "gpt-4-turbo".into(),
-        1024,
-        None,
-        None,
-    );
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "gpt-4-turbo".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        reasoning_effort: None,
+    });
     assert_eq!(p.context_window(), Some(128_000));
 }
 
@@ -552,14 +552,14 @@ fn context_window_gpt4_turbo() {
 #[ignore = "requires ZEPH_OPENAI_API_KEY env var"]
 async fn integration_openai_embed() {
     let api_key = std::env::var("ZEPH_OPENAI_API_KEY").expect("ZEPH_OPENAI_API_KEY must be set");
-    let provider = OpenAiProvider::new(
-        api_key,
-        "https://api.openai.com/v1".into(),
-        "gpt-5.2".into(),
-        256,
-        Some("text-embedding-3-small".into()),
-        None,
-    );
+    let provider = OpenAiProvider::new(OpenAiConfig {
+        api_key: api_key,
+        base_url: "https://api.openai.com/v1".into(),
+        model: "gpt-5.2".into(),
+        max_tokens: 256,
+        embedding_model: Some("text-embedding-3-small".into()),
+        reasoning_effort: None,
+    });
 
     let embedding = provider.embed("Hello world").await.unwrap();
     assert!(!embedding.is_empty());
@@ -960,40 +960,40 @@ fn convert_messages_vision_image_only_no_text_part() {
 
 #[test]
 fn cache_slug_openai() {
-    let p = OpenAiProvider::new(
-        "k".into(),
-        "https://api.openai.com/v1".into(),
-        "gpt-4o".into(),
-        1024,
-        None,
-        None,
-    );
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "gpt-4o".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        reasoning_effort: None,
+    });
     assert_eq!(p.cache_slug(), "api_openai_com");
 }
 
 #[test]
 fn cache_slug_custom_host() {
-    let p = OpenAiProvider::new(
-        "k".into(),
-        "https://my-llm.example.com/v1".into(),
-        "model".into(),
-        1024,
-        None,
-        None,
-    );
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://my-llm.example.com/v1".into(),
+        model: "model".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        reasoning_effort: None,
+    });
     assert_eq!(p.cache_slug(), "my_llm_example_com");
 }
 
 #[test]
 fn cache_slug_localhost_with_port() {
-    let p = OpenAiProvider::new(
-        "k".into(),
-        "http://localhost:8080/v1".into(),
-        "model".into(),
-        1024,
-        None,
-        None,
-    );
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "http://localhost:8080/v1".into(),
+        model: "model".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        reasoning_effort: None,
+    });
     assert_eq!(p.cache_slug(), "localhost");
 }
 
@@ -1088,14 +1088,14 @@ async fn list_models_remote_http_error_propagates() {
         .mount(&server)
         .await;
 
-    let p = OpenAiProvider::new(
-        "key".into(),
-        server.uri(),
-        "gpt-4o".into(),
-        1024,
-        None,
-        None,
-    );
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "key".into(),
+        base_url: server.uri(),
+        model: "gpt-4o".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        reasoning_effort: None,
+    });
     let result = p.list_models_remote().await;
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("500"));
@@ -1119,14 +1119,14 @@ async fn chat_happy_path_wiremock() {
         .mount(&server)
         .await;
 
-    let p = OpenAiProvider::new(
-        "sk-test".into(),
-        server.uri(),
-        "gpt-4o".into(),
-        256,
-        None,
-        None,
-    );
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "sk-test".into(),
+        base_url: server.uri(),
+        model: "gpt-4o".into(),
+        max_tokens: 256,
+        embedding_model: None,
+        reasoning_effort: None,
+    });
     let messages = vec![Message {
         role: Role::User,
         content: "hi".into(),
@@ -1164,14 +1164,14 @@ async fn chat_with_tools_handles_null_assistant_content() {
         .mount(&server)
         .await;
 
-    let p = OpenAiProvider::new(
-        "sk-test".into(),
-        server.uri(),
-        "gpt-4o".into(),
-        256,
-        None,
-        None,
-    );
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "sk-test".into(),
+        base_url: server.uri(),
+        model: "gpt-4o".into(),
+        max_tokens: 256,
+        embedding_model: None,
+        reasoning_effort: None,
+    });
     let messages = vec![Message {
         role: Role::User,
         content: "hi".into(),
@@ -1218,14 +1218,14 @@ async fn chat_429_rate_limit_propagates() {
         .mount(&server)
         .await;
 
-    let p = OpenAiProvider::new(
-        "sk-test".into(),
-        server.uri(),
-        "gpt-4o".into(),
-        256,
-        None,
-        None,
-    );
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "sk-test".into(),
+        base_url: server.uri(),
+        model: "gpt-4o".into(),
+        max_tokens: 256,
+        embedding_model: None,
+        reasoning_effort: None,
+    });
     let messages = vec![Message {
         role: Role::User,
         content: "hi".into(),
@@ -1250,14 +1250,14 @@ async fn chat_401_auth_error_propagates() {
         .mount(&server)
         .await;
 
-    let p = OpenAiProvider::new(
-        "bad-key".into(),
-        server.uri(),
-        "gpt-4o".into(),
-        256,
-        None,
-        None,
-    );
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "bad-key".into(),
+        base_url: server.uri(),
+        model: "gpt-4o".into(),
+        max_tokens: 256,
+        embedding_model: None,
+        reasoning_effort: None,
+    });
     let messages = vec![Message {
         role: Role::User,
         content: "hi".into(),
@@ -1282,14 +1282,14 @@ async fn chat_500_server_error_propagates() {
         .mount(&server)
         .await;
 
-    let p = OpenAiProvider::new(
-        "sk-test".into(),
-        server.uri(),
-        "gpt-4o".into(),
-        256,
-        None,
-        None,
-    );
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "sk-test".into(),
+        base_url: server.uri(),
+        model: "gpt-4o".into(),
+        max_tokens: 256,
+        embedding_model: None,
+        reasoning_effort: None,
+    });
     let messages = vec![Message {
         role: Role::User,
         content: "hi".into(),
@@ -1302,14 +1302,14 @@ async fn chat_500_server_error_propagates() {
 
 #[test]
 fn with_generation_overrides_stores_overrides() {
-    let provider = OpenAiProvider::new(
-        "sk-test".into(),
-        "http://localhost".into(),
-        "gpt-4o".into(),
-        256,
-        None,
-        None,
-    );
+    let provider = OpenAiProvider::new(OpenAiConfig {
+        api_key: "sk-test".into(),
+        base_url: "http://localhost".into(),
+        model: "gpt-4o".into(),
+        max_tokens: 256,
+        embedding_model: None,
+        reasoning_effort: None,
+    });
     assert!(provider.generation_overrides.is_none());
     let overrides = GenerationOverrides {
         temperature: Some(0.7),
@@ -1466,14 +1466,14 @@ async fn embed_batch_no_embedding_model_returns_error() {
 #[tokio::test]
 async fn embed_batch_empty_returns_empty_without_network() {
     // Use provider with an unreachable endpoint — empty input must return immediately.
-    let p = OpenAiProvider::new(
-        "key".into(),
-        "http://127.0.0.1:1".into(),
-        "gpt-4o".into(),
-        4096,
-        Some("text-embedding-3-small".into()),
-        None,
-    );
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "key".into(),
+        base_url: "http://127.0.0.1:1".into(),
+        model: "gpt-4o".into(),
+        max_tokens: 4096,
+        embedding_model: Some("text-embedding-3-small".into()),
+        reasoning_effort: None,
+    });
     let result = p.embed_batch(&[]).await.unwrap();
     assert!(result.is_empty());
 }

--- a/crates/zeph-llm/src/openai/tests.rs
+++ b/crates/zeph-llm/src/openai/tests.rs
@@ -470,7 +470,7 @@ fn embedding_response_empty_data() {
 async fn integration_openai_chat() {
     let api_key = std::env::var("ZEPH_OPENAI_API_KEY").expect("ZEPH_OPENAI_API_KEY must be set");
     let provider = OpenAiProvider::new(OpenAiConfig {
-        api_key: api_key,
+        api_key,
         base_url: "https://api.openai.com/v1".into(),
         model: "gpt-5.2".into(),
         max_tokens: 256,
@@ -494,7 +494,7 @@ async fn integration_openai_chat() {
 async fn integration_openai_chat_stream() {
     let api_key = std::env::var("ZEPH_OPENAI_API_KEY").expect("ZEPH_OPENAI_API_KEY must be set");
     let provider = OpenAiProvider::new(OpenAiConfig {
-        api_key: api_key,
+        api_key,
         base_url: "https://api.openai.com/v1".into(),
         model: "gpt-5.2".into(),
         max_tokens: 256,
@@ -553,7 +553,7 @@ fn context_window_gpt4_turbo() {
 async fn integration_openai_embed() {
     let api_key = std::env::var("ZEPH_OPENAI_API_KEY").expect("ZEPH_OPENAI_API_KEY must be set");
     let provider = OpenAiProvider::new(OpenAiConfig {
-        api_key: api_key,
+        api_key,
         base_url: "https://api.openai.com/v1".into(),
         model: "gpt-5.2".into(),
         max_tokens: 256,

--- a/crates/zeph-llm/tests/gonka_live.rs
+++ b/crates/zeph-llm/tests/gonka_live.rs
@@ -44,8 +44,14 @@ mod live {
             .expect("non-empty pool"),
         );
 
-        let provider =
-            GonkaProvider::new(signer, pool, "gpt-4o", 16, None, Duration::from_secs(30));
+        let provider = GonkaProvider::new(zeph_llm::gonka::GonkaConfig {
+            signer,
+            pool,
+            model: "gpt-4o".into(),
+            max_tokens: 16,
+            embedding_model: None,
+            timeout: Duration::from_secs(30),
+        });
 
         let messages = vec![Message::from_legacy(
             Role::User,

--- a/crates/zeph-mcp/src/manager.rs
+++ b/crates/zeph-mcp/src/manager.rs
@@ -583,13 +583,15 @@ impl McpManager {
                         server_tool_metadata.get(&event.server_id).unwrap_or(&empty);
                     ingest_tools(
                         event.tools,
-                        &event.server_id,
-                        trust_level,
-                        allowlist.as_deref(),
-                        &expected_tools,
-                        status_tx.as_ref(),
-                        max_description_bytes,
-                        tool_metadata,
+                        &IngestConfig {
+                            server_id: &event.server_id,
+                            trust_level,
+                            allowlist: allowlist.as_deref(),
+                            expected_tools: &expected_tools,
+                            status_tx: status_tx.as_ref(),
+                            max_description_bytes,
+                            tool_metadata,
+                        },
                     )
                 };
                 apply_injection_penalties(
@@ -1036,13 +1038,15 @@ impl McpManager {
                     let tool_metadata = self.server_tool_metadata.get(&server_id).unwrap_or(&empty);
                     let (tools, sanitize_result) = ingest_tools(
                         raw_tools,
-                        &server_id,
-                        trust_level,
-                        allowlist.as_deref(),
-                        &expected_tools,
-                        self.status_tx.as_ref(),
-                        limits.description_bytes,
-                        tool_metadata,
+                        &IngestConfig {
+                            server_id: &server_id,
+                            trust_level,
+                            allowlist: allowlist.as_deref(),
+                            expected_tools: &expected_tools,
+                            status_tx: self.status_tx.as_ref(),
+                            max_description_bytes: limits.description_bytes,
+                            tool_metadata,
+                        },
                     );
                     apply_injection_penalties(
                         self.trust_store.as_ref(),
@@ -1183,13 +1187,15 @@ impl McpManager {
 
         let (tools, sanitize_result) = ingest_tools(
             raw_tools,
-            &entry.id,
-            entry.trust_level,
-            entry.tool_allowlist.as_deref(),
-            &entry.expected_tools,
-            self.status_tx.as_ref(),
-            self.max_description_bytes,
-            &entry.tool_metadata,
+            &IngestConfig {
+                server_id: &entry.id,
+                trust_level: entry.trust_level,
+                allowlist: entry.tool_allowlist.as_deref(),
+                expected_tools: &entry.expected_tools,
+                status_tx: self.status_tx.as_ref(),
+                max_description_bytes: self.max_description_bytes,
+                tool_metadata: &entry.tool_metadata,
+            },
         );
         apply_injection_penalties(
             self.trust_store.as_ref(),
@@ -1670,31 +1676,71 @@ async fn drain_oauth_results(
 // TODO(critic): ingest_tools has both too_many_arguments and too_many_lines
 // suppressed; not in scope for #3451. File a separate issue to decompose
 // with an IngestParams struct.
-#[allow(clippy::too_many_arguments, clippy::too_many_lines)] // complex algorithm function; both suppressions justified until the function is decomposed in a future refactor
-fn ingest_tools(
-    mut tools: Vec<McpTool>,
-    server_id: &str,
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+// complex algorithm function; both suppressions justified until the function is decomposed in a future refactor
+/// Configuration bundle passed to [`ingest_tools`].
+///
+/// Consolidates all per-server policy parameters so call sites pass a single
+/// reference instead of eight positional arguments.
+struct IngestConfig<'a> {
+    /// Stable identifier of the MCP server being ingested.
+    server_id: &'a str,
+    /// Trust classification that governs allowlist and attestation enforcement.
     trust_level: McpTrustLevel,
-    allowlist: Option<&[String]>,
-    expected_tools: &[String],
-    status_tx: Option<&StatusTx>,
+    /// Explicit tool allow-list from operator config (`None` = not configured).
+    allowlist: Option<&'a [String]>,
+    /// Operator-declared set of expected tool names used for attestation.
+    expected_tools: &'a [String],
+    /// Channel for surfacing warnings to the user-facing status bar.
+    status_tx: Option<&'a StatusTx>,
+    /// Maximum byte length for tool descriptions; longer descriptions are truncated.
     max_description_bytes: usize,
-    tool_metadata: &HashMap<String, ToolSecurityMeta>,
-) -> (Vec<McpTool>, SanitizeResult) {
-    use crate::attestation::{AttestationResult, attest_tools};
+    /// Per-tool security metadata overrides keyed by tool name.
+    tool_metadata: &'a HashMap<String, ToolSecurityMeta>,
+}
 
+/// Run the full tool-ingest pipeline: sanitize → assign security metadata →
+/// enforce data-flow policy → attest → apply allowlist filtering.
+///
+/// # Security invariant
+///
+/// Sanitization always runs first, before any filtering or storage, to prevent
+/// prompt-injection content from reaching the registry even for trusted servers.
+fn ingest_tools(mut tools: Vec<McpTool>, cfg: &IngestConfig<'_>) -> (Vec<McpTool>, SanitizeResult) {
     // SECURITY INVARIANT: sanitize BEFORE any filtering or storage.
-    let sanitize_result = sanitize_tools(&mut tools, server_id, max_description_bytes);
+    let sanitize_result = sanitize_tools(&mut tools, cfg.server_id, cfg.max_description_bytes);
+    assign_security_metadata(&mut tools, cfg.tool_metadata);
+    filter_data_flow_violations(&mut tools, cfg.server_id, cfg.trust_level);
+    tools = apply_attestation(tools, cfg.server_id, cfg.trust_level, cfg.expected_tools);
+    let filtered = apply_allowlist(
+        tools,
+        cfg.server_id,
+        cfg.trust_level,
+        cfg.allowlist,
+        cfg.status_tx,
+    );
+    (filtered, sanitize_result)
+}
 
-    // Assign per-tool security metadata from operator config or heuristic inference.
-    for tool in &mut tools {
+/// Assign per-tool security metadata from operator config or heuristic inference.
+fn assign_security_metadata(
+    tools: &mut [McpTool],
+    tool_metadata: &HashMap<String, ToolSecurityMeta>,
+) {
+    for tool in tools.iter_mut() {
         tool.security_meta = tool_metadata
             .get(&tool.name)
             .cloned()
             .unwrap_or_else(|| infer_security_meta(&tool.name));
     }
+}
 
-    // Data-flow policy: filter tools that violate sensitivity/trust constraints.
+/// Remove tools that violate data-flow sensitivity/trust constraints.
+fn filter_data_flow_violations(
+    tools: &mut Vec<McpTool>,
+    server_id: &str,
+    trust_level: McpTrustLevel,
+) {
     tools.retain(|tool| match check_data_flow(tool, trust_level) {
         Ok(()) => true,
         Err(e) => {
@@ -1707,11 +1753,21 @@ fn ingest_tools(
             false
         }
     });
+}
 
-    // Attestation: compare tools against operator-declared expectations.
+/// Compare tools against operator-declared expectations and filter unexpected
+/// tools from Untrusted/Sandboxed servers.
+fn apply_attestation(
+    tools: Vec<McpTool>,
+    server_id: &str,
+    trust_level: McpTrustLevel,
+    expected_tools: &[String],
+) -> Vec<McpTool> {
+    use crate::attestation::{AttestationResult, attest_tools};
+
     let attestation =
         attest_tools::<std::collections::hash_map::RandomState>(&tools, expected_tools, None);
-    tools = match attestation {
+    match attestation {
         AttestationResult::Unconfigured => tools,
         AttestationResult::Verified { .. } => {
             tracing::debug!(server_id, "attestation: all tools in expected set");
@@ -1744,9 +1800,18 @@ fn ingest_tools(
                 }
             }
         }
-    };
+    }
+}
 
-    let filtered = match trust_level {
+/// Enforce the trust-level allowlist policy and return the permitted tool set.
+fn apply_allowlist(
+    tools: Vec<McpTool>,
+    server_id: &str,
+    trust_level: McpTrustLevel,
+    allowlist: Option<&[String]>,
+    status_tx: Option<&StatusTx>,
+) -> Vec<McpTool> {
+    match trust_level {
         McpTrustLevel::Trusted => tools,
         McpTrustLevel::Untrusted => match allowlist {
             None => {
@@ -1805,8 +1870,7 @@ fn ingest_tools(
                 filtered
             }
         }
-    };
-    (filtered, sanitize_result)
+    }
 }
 
 /// Compute the sleep duration before retry attempt `attempt + 1`.
@@ -2650,13 +2714,15 @@ mod tests {
         let tools = vec![make_tool("srv", "tool_a"), make_tool("srv", "tool_b")];
         let (result, _) = ingest_tools(
             tools,
-            "srv",
-            McpTrustLevel::Trusted,
-            None,
-            &[],
-            None,
-            2048,
-            &HashMap::new(),
+            &IngestConfig {
+                server_id: "srv",
+                trust_level: McpTrustLevel::Trusted,
+                allowlist: None,
+                expected_tools: &[],
+                status_tx: None,
+                max_description_bytes: 2048,
+                tool_metadata: &HashMap::new(),
+            },
         );
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].name, "tool_a");
@@ -2668,13 +2734,15 @@ mod tests {
         let tools = vec![make_tool("srv", "tool_a"), make_tool("srv", "tool_b")];
         let (result, _) = ingest_tools(
             tools,
-            "srv",
-            McpTrustLevel::Untrusted,
-            None,
-            &[],
-            None,
-            2048,
-            &HashMap::new(),
+            &IngestConfig {
+                server_id: "srv",
+                trust_level: McpTrustLevel::Untrusted,
+                allowlist: None,
+                expected_tools: &[],
+                status_tx: None,
+                max_description_bytes: 2048,
+                tool_metadata: &HashMap::new(),
+            },
         );
         // None allowlist on Untrusted = no override → all tools pass through (warn-only)
         assert_eq!(result.len(), 2);
@@ -2685,13 +2753,15 @@ mod tests {
         let tools = vec![make_tool("srv", "tool_a"), make_tool("srv", "tool_b")];
         let (result, _) = ingest_tools(
             tools,
-            "srv",
-            McpTrustLevel::Untrusted,
-            Some(&[]),
-            &[],
-            None,
-            2048,
-            &HashMap::new(),
+            &IngestConfig {
+                server_id: "srv",
+                trust_level: McpTrustLevel::Untrusted,
+                allowlist: Some(&[]),
+                expected_tools: &[],
+                status_tx: None,
+                max_description_bytes: 2048,
+                tool_metadata: &HashMap::new(),
+            },
         );
         // Some(empty) on Untrusted = explicit deny-all (fail-closed)
         assert!(result.is_empty());
@@ -2707,13 +2777,15 @@ mod tests {
         let allowlist = vec!["tool_a".to_owned(), "tool_c".to_owned()];
         let (result, _) = ingest_tools(
             tools,
-            "srv",
-            McpTrustLevel::Untrusted,
-            Some(&allowlist),
-            &[],
-            None,
-            2048,
-            &HashMap::new(),
+            &IngestConfig {
+                server_id: "srv",
+                trust_level: McpTrustLevel::Untrusted,
+                allowlist: Some(&allowlist),
+                expected_tools: &[],
+                status_tx: None,
+                max_description_bytes: 2048,
+                tool_metadata: &HashMap::new(),
+            },
         );
         assert_eq!(result.len(), 2);
         let names: Vec<&str> = result.iter().map(|t| t.name.as_str()).collect();
@@ -2727,13 +2799,15 @@ mod tests {
         let tools = vec![make_tool("srv", "tool_a"), make_tool("srv", "tool_b")];
         let (result, _) = ingest_tools(
             tools,
-            "srv",
-            McpTrustLevel::Sandboxed,
-            Some(&[]),
-            &[],
-            None,
-            2048,
-            &HashMap::new(),
+            &IngestConfig {
+                server_id: "srv",
+                trust_level: McpTrustLevel::Sandboxed,
+                allowlist: Some(&[]),
+                expected_tools: &[],
+                status_tx: None,
+                max_description_bytes: 2048,
+                tool_metadata: &HashMap::new(),
+            },
         );
         // Sandboxed + empty allowlist = fail-closed: no tools exposed
         assert!(result.is_empty());
@@ -2745,13 +2819,15 @@ mod tests {
         let allowlist = vec!["tool_b".to_owned()];
         let (result, _) = ingest_tools(
             tools,
-            "srv",
-            McpTrustLevel::Sandboxed,
-            Some(&allowlist),
-            &[],
-            None,
-            2048,
-            &HashMap::new(),
+            &IngestConfig {
+                server_id: "srv",
+                trust_level: McpTrustLevel::Sandboxed,
+                allowlist: Some(&allowlist),
+                expected_tools: &[],
+                status_tx: None,
+                max_description_bytes: 2048,
+                tool_metadata: &HashMap::new(),
+            },
         );
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].name, "tool_b");
@@ -2767,13 +2843,15 @@ mod tests {
         let allowlist = vec!["legit_tool".to_owned()];
         let (result, sanitize_result) = ingest_tools(
             tools,
-            "srv",
-            McpTrustLevel::Untrusted,
-            Some(&allowlist),
-            &[],
-            None,
-            2048,
-            &HashMap::new(),
+            &IngestConfig {
+                server_id: "srv",
+                trust_level: McpTrustLevel::Untrusted,
+                allowlist: Some(&allowlist),
+                expected_tools: &[],
+                status_tx: None,
+                max_description_bytes: 2048,
+                tool_metadata: &HashMap::new(),
+            },
         );
         assert_eq!(result.len(), 1);
         // sanitize_tools replaces injected descriptions with a placeholder — not the original text
@@ -2789,13 +2867,15 @@ mod tests {
         let tools = vec![make_tool("srv", "exec_shell")];
         let (result, _) = ingest_tools(
             tools,
-            "srv",
-            McpTrustLevel::Trusted,
-            None,
-            &[],
-            None,
-            2048,
-            &HashMap::new(),
+            &IngestConfig {
+                server_id: "srv",
+                trust_level: McpTrustLevel::Trusted,
+                allowlist: None,
+                expected_tools: &[],
+                status_tx: None,
+                max_description_bytes: 2048,
+                tool_metadata: &HashMap::new(),
+            },
         );
         assert_eq!(
             result[0].security_meta.data_sensitivity,
@@ -2818,13 +2898,15 @@ mod tests {
         let tools = vec![make_tool("srv", "my_tool")];
         let (result, _) = ingest_tools(
             tools,
-            "srv",
-            McpTrustLevel::Trusted,
-            None,
-            &[],
-            None,
-            2048,
-            &meta_map,
+            &IngestConfig {
+                server_id: "srv",
+                trust_level: McpTrustLevel::Trusted,
+                allowlist: None,
+                expected_tools: &[],
+                status_tx: None,
+                max_description_bytes: 2048,
+                tool_metadata: &meta_map,
+            },
         );
         assert_eq!(
             result[0].security_meta.data_sensitivity,
@@ -2854,13 +2936,15 @@ mod tests {
         // Untrusted server + High sensitivity → tool must be filtered out
         let (result, _) = ingest_tools(
             tools,
-            "srv",
-            McpTrustLevel::Untrusted,
-            None,
-            &[],
-            None,
-            2048,
-            &meta_map,
+            &IngestConfig {
+                server_id: "srv",
+                trust_level: McpTrustLevel::Untrusted,
+                allowlist: None,
+                expected_tools: &[],
+                status_tx: None,
+                max_description_bytes: 2048,
+                tool_metadata: &meta_map,
+            },
         );
         assert!(
             result.is_empty(),

--- a/crates/zeph-skills/src/bin/miner.rs
+++ b/crates/zeph-skills/src/bin/miner.rs
@@ -217,14 +217,14 @@ fn build_provider(config: &zeph_config::Config, name: &str) -> anyhow::Result<An
                 .clone()
                 .unwrap_or_else(|| "https://api.openai.com/v1".into());
             let embedding_model = entry.embedding_model.clone();
-            AnyProvider::OpenAi(OpenAiProvider::new(
+            AnyProvider::OpenAi(OpenAiProvider::new(zeph_llm::OpenAiConfig {
                 api_key,
                 base_url,
                 model,
                 max_tokens,
                 embedding_model,
-                None, // reasoning_effort
-            ))
+                reasoning_effort: None,
+            }))
         }
         zeph_config::ProviderKind::Ollama => {
             let base_url = entry

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -1173,14 +1173,14 @@ fn build_acp_provider_factory(config: &zeph_core::config::Config) -> zeph_acp::P
                     reasoning_effort,
                 } if provider_name == "openai" => {
                     return Some(zeph_llm::any::AnyProvider::OpenAi(
-                        zeph_llm::openai::OpenAiProvider::new(
-                            api_key.clone(),
-                            base_url.clone(),
-                            model.clone(),
-                            *max_tokens,
-                            embed.clone(),
-                            reasoning_effort.clone(),
-                        ),
+                        zeph_llm::openai::OpenAiProvider::new(zeph_llm::openai::OpenAiConfig {
+                            api_key: api_key.clone(),
+                            base_url: base_url.clone(),
+                            model: model.clone(),
+                            max_tokens: *max_tokens,
+                            embedding_model: embed.clone(),
+                            reasoning_effort: reasoning_effort.clone(),
+                        }),
                     ));
                 }
                 ProviderSnapshot::Compatible {
@@ -1192,12 +1192,14 @@ fn build_acp_provider_factory(config: &zeph_core::config::Config) -> zeph_acp::P
                 } if provider_name == name => {
                     return Some(zeph_llm::any::AnyProvider::Compatible(
                         zeph_llm::compatible::CompatibleProvider::new(
-                            name.clone(),
-                            api_key.clone(),
-                            base_url.clone(),
-                            model.clone(),
-                            *max_tokens,
-                            embed.clone(),
+                            zeph_llm::compatible::CompatibleConfig {
+                                provider_name: name.clone(),
+                                api_key: api_key.clone(),
+                                base_url: base_url.clone(),
+                                model: model.clone(),
+                                max_tokens: *max_tokens,
+                                embedding_model: embed.clone(),
+                            },
                         ),
                     ));
                 }


### PR DESCRIPTION
## Summary

- Introduces `OpenAiConfig`, `CompatibleConfig`, and `GonkaConfig` structs in `zeph-llm` so constructors accept a single named-field struct instead of 6 positional arguments. Silent transposition of `String` args is now a compile error.
- Introduces `IngestConfig<'_>` in `zeph-mcp` and extracts `ingest_tools` (149 lines, 9 positional params) into four focused pipeline stages. The function body is now ~8 lines.

Closes #3861, Closes #3878.

## Changed files

- `crates/zeph-llm/src/openai/mod.rs` — `OpenAiConfig` struct + updated `OpenAiProvider::new`
- `crates/zeph-llm/src/compatible.rs` — `CompatibleConfig` struct + updated `CompatibleProvider::new`
- `crates/zeph-llm/src/gonka/provider.rs` — `GonkaConfig` struct + updated `GonkaProvider::new`
- `crates/zeph-llm/src/{any,lib,cocoon/provider}.rs`, `crates/zeph-core/src/provider_factory.rs`, `crates/zeph-skills/src/bin/miner.rs`, `src/acp.rs` — all call sites updated
- `crates/zeph-mcp/src/manager.rs` — `IngestConfig<'_>`, `assign_security_metadata`, `filter_data_flow_violations`, `apply_attestation`, `apply_allowlist`

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 9612 passed, 21 skipped
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — 19 passed
- [x] `cargo build -p zeph` with `--features desktop,ide,server,chat,pdf,scheduler` — clean

## LLM serialization gate

This PR touches `crates/zeph-llm/src/openai/mod.rs` and `compatible.rs` (constructor only — no request/response structs modified). A live API session test is required before merge per project rules: run `cargo run --features full -- --config .local/config/testing.toml` and verify at least one LLM round-trip completes without 400/422 errors.