### PR TITLE
docs(specs): add spec documents for zeph-agent-persistence and zeph-plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `specs/057-agent-persistence/spec.md` — comprehensive specification for `zeph-agent-persistence`
+  crate: stateless `PersistenceService`, borrow-lens views, history load with tool-pair sanitization,
+  message persistence, embedding decisions, exfiltration guard integration, and key durability invariants
+  (closes #3857).
+- `specs/058-plugins/spec.md` — comprehensive specification for `zeph-plugins` crate: plugin lifecycle
+  management (`add`, `remove`, `list`), manifest validation, tighten-only config overlays, skill
+  conflict detection, SHA-256 integrity verification, and path traversal prevention (closes #3855).
 - `zeph-skills`: `sanitize_skill_metadata()` — sanitizes untrusted SKILL.md description/trigger
   fields with UTF-8-safe truncation (`floor_char_boundary`), imperative-prefix stripping, and XML
   injection marker blocking before prompt injection (closes #4135).

--- a/specs/057-agent-persistence/spec.md
+++ b/specs/057-agent-persistence/spec.md
@@ -1,0 +1,417 @@
+---
+aliases:
+  - Agent Persistence Service
+  - Message Durability
+  - Conversation History
+tags:
+  - sdd
+  - spec
+  - persistence
+  - memory
+  - durability
+created: 2026-05-17
+status: approved
+related:
+  - "[[MOC-specs]]"
+  - "[[constitution]]"
+  - "[[001-system-invariants/spec]]"
+  - "[[002-agent-loop/spec]]"
+  - "[[004-memory/spec]]"
+  - "[[032-database-abstraction/spec]]"
+  - "[[010-security/spec]]"
+---
+
+# Spec: Agent Persistence Service (`zeph-agent-persistence`)
+
+> [!info]
+> Stateless façade for loading conversation history from and persisting agent messages to
+> the `SemanticMemory` backend (SQLite + Qdrant). Provides history sanitization, embedding
+> decisions, tool-pair validation, and message metadata tracking without depending on `zeph-core`.
+
+## 1. Overview
+
+### Problem Statement
+
+Agent message persistence — loading history, writing new messages, sanitizing orphaned tool pairs,
+deciding on embeddings — is complex logic that touches both SQLite (for durability) and Qdrant
+(for semantic retrieval). This logic was initially embedded in `zeph-core`, creating tight coupling
+and making testing difficult. The dependency on `zeph-core` forced memory, context, and tool subsystems
+to coordinate through a single shared type.
+
+### Goal
+
+Extract message persistence into a dedicated crate (`zeph-agent-persistence`) that:
+
+1. **Decouples memory, context, and tool-dispatch logic** — persistence becomes a pure async service
+   callable from tool dispatcher or agent loop without forming circular dependencies.
+2. **Enables borrow-lens patterns** — `MemoryPersistenceView`, `SecurityView`, `MetricsView` allow
+   the call site in `zeph-core` to prove disjoint borrows; the persistence service sees only what
+   it needs, avoiding opaque mut bundles.
+3. **Centralizes tool-pair sanitization** — orphaned `ToolUse`/`ToolResult` pairs are removed during
+   history load and marked for soft-delete in SQLite (M3 defense against tail latency bugs).
+4. **Provides clear contracts** — `LoadHistoryParams`, `LoadHistoryOutcome`, `PersistMessageRequest`,
+   `PersistMessageOutcome` make every step of persistence observable and testable.
+
+### Out of Scope
+
+- Configuration of memory backends (owned by `zeph-config`)
+- Semantic memory implementation (owned by `zeph-memory`)
+- Tool execution and feedback detection (owned by `zeph-agent-tools`)
+- LLM provider routing (owned by `zeph-llm`)
+- Database driver abstraction (owned by `zeph-db`)
+
+---
+
+## 2. User Stories
+
+### US-001: Load Conversation History
+
+AS A agent loop starting or resuming a session
+I WANT to restore the last N messages from SQLite with tool-pair sanitization
+SO THAT the conversation context is complete and orphaned tool calls do not cause subsequent errors.
+
+**Acceptance criteria:**
+
+```
+GIVEN a conversation ID and a SemanticMemory backend
+WHEN PersistenceService::load_history() is called
+THEN messages are fetched from SQLite (agent_visible=true)
+AND orphaned ToolUse/ToolResult pairs are removed
+AND removed message IDs are recorded for soft-delete
+AND LoadHistoryOutcome reports counts and DB totals
+```
+
+### US-002: Persist User and Assistant Messages
+
+AS A agent loop or tool dispatcher
+I WANT to write each message to SQLite with optional Qdrant embedding
+SO THAT conversation state is durable and retrievable for future sessions.
+
+**Acceptance criteria:**
+
+```
+GIVEN a message to persist with role, content, and parts
+WHEN PersistenceService::persist_message() is called
+THEN the message is saved to SQLite with auto-generated message_id
+AND embedding is performed if should_embed() returns true
+AND exfiltration guard prevents embedding when injection flags are set
+AND PersistMessageOutcome reports success, embedding status, and bytes written
+```
+
+### US-003: Sanitize Orphaned Tool Pairs
+
+AS A conversation history loader
+I WANT to detect and remove incomplete ToolUse/ToolResult sequences
+SO THAT missing tool results do not cause parsing errors or hanging tool-use messages.
+
+**Acceptance criteria:**
+
+```
+GIVEN a message buffer with potential orphans (trailing ToolUse, leading ToolResult, mid-history mismatches)
+WHEN sanitize_tool_pairs() is called
+THEN all four failure modes are handled
+AND removed message IDs are returned for soft-delete in SQLite
+AND logs record each orphan removal at WARN level
+```
+
+### US-004: Decide on Message Embedding
+
+AS A persistence service
+I WANT a decision function that evaluates whether a message should be embedded into Qdrant
+SO THAT sensitive content can skip embedding and short messages do not add noise to memory.
+
+**Acceptance criteria:**
+
+```
+GIVEN message role, content, parts, and security context
+WHEN should_embed_message() is called
+THEN embedding is skipped when:
+  - skip_embedding flag is true (exfiltration guard)
+  - parts contain [skipped] or [stopped] ToolResult markers
+  - role is Assistant, autosave is disabled, or content is too short
+AND all other messages embed by default
+```
+
+### US-005: Track Persistence Metrics
+
+AS A monitoring system
+I WANT per-message tracking of embedding status, bytes written, and security events
+SO THAT I can audit message flow and detect anomalies.
+
+**Acceptance criteria:**
+
+```
+GIVEN a persisted message with outcome details
+WHEN metrics are updated
+THEN sqlite_message_count, embeddings_generated, and exfiltration_memory_guards are incremented
+AND values are available to the metrics subsystem for Prometheus export
+```
+
+---
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN `LoadHistoryParams` is populated with memory, conversation ID, and mutable buffers THEN `load_history()` SHALL fetch up to 50 agent-visible messages (`agent_visible=true`) from SQLite | must |
+| FR-002 | WHEN loaded messages include empty or orphaned messages THEN they SHALL be skipped and counted in the outcome | must |
+| FR-003 | WHEN `sanitize_tool_pairs()` receives a message buffer THEN it SHALL remove: (1) trailing assistant ToolUse without matching ToolResult, (2) leading user ToolResult without preceding ToolUse, (3) mid-history orphaned ToolUse/ToolResult, and (4) unmatched ToolResult parts | must |
+| FR-004 | WHEN orphaned messages are removed THEN their SQLite `db_id` values SHALL be collected and returned for soft-delete | must |
+| FR-005 | WHEN `persist_message()` is called with memory disabled (None) THEN the operation SHALL return early with zero-filled outcome | must |
+| FR-006 | WHEN message parts cannot be serialized to JSON THEN persistence SHALL fail gracefully, log an error, and return `None` to avoid creating orphaned tool-pair records | must |
+| FR-007 | WHEN `exfiltration_guard` is active AND `has_injection_flags` is true AND `security.guard_memory_writes` is true THEN Qdrant embedding SHALL be skipped | must |
+| FR-008 | WHEN `should_embed_message()` evaluates a message THEN it SHALL respect: skip_embedding flag, [skipped]/[stopped] ToolResult markers, assistant autosave setting, and content length threshold | must |
+| FR-009 | WHEN message embedding is deferred to background THEN `memory.reap_embed_tasks()` SHALL be called to allow background task batching | must |
+| FR-010 | WHEN `last_persisted_message_id` is set THEN subsequent history loads SHALL fetch only newer messages (LIMIT-based pagination) | must |
+| FR-011 | WHEN a `PersistenceService` method encounters a database error THEN it SHALL log at ERROR level and return an error or `None`, never panic | must |
+| FR-012 | WHEN `serialize_parts_json()` is called THEN it SHALL serde-serialize parts to a flat JSON array; empty parts returns `"[]"` | must |
+| FR-013 | WHEN `has_meaningful_content()` evaluates a message THEN it SHALL identify legacy tool bracket markers and strip them; content with only markers is considered empty | must |
+| FR-014 | WHEN metrics are updated via `MetricsView` THEN `sqlite_message_count`, `embeddings_generated`, and `exfiltration_memory_guards` counters SHALL be incremented atomically | must |
+
+---
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Modularity | `zeph-agent-persistence` SHALL NOT depend on `zeph-core`; it is callable only through borrow-lens views constructed at the call site |
+| NFR-002 | Borrow checking | All three `*View` types use lifetime parameters to bind mutable references; the borrow checker at the call site can prove disjoint field borrows |
+| NFR-003 | Async runtime | All I/O operations are async; the crate depends on tokio but does not establish the runtime itself |
+| NFR-004 | Error handling | `PersistenceError` distinguishes between database errors and validation failures; all errors are loggable |
+| NFR-005 | Safety | No `unsafe` code |
+| NFR-006 | Observability | Key operations (load_history, persist_message, tool-pair sanitization) emit tracing spans with context (conversation ID, role, message count) |
+| NFR-007 | Minimal abstraction | The service is stateless (`&self` methods) and has no internal state; it is a pure interface to `SemanticMemory` and LLM providers |
+
+---
+
+## 5. Data Model
+
+### Core Structures
+
+| Entity | Module | Description |
+|--------|--------|-------------|
+| `PersistenceService` | `service.rs` | Stateless façade with async methods for history load and message persistence |
+| `LoadHistoryParams` | `service.rs` | Input bundle: message buffer, conversation ID, metadata buffers, memory view |
+| `LoadHistoryOutcome` | `request.rs` | Output: count of loaded/skipped messages, orphan removal count, total DB counts |
+| `PersistMessageRequest` | `request.rs` | Fully-owned input: role, content, parts, injection flags |
+| `PersistMessageOutcome` | `request.rs` | Output: message ID, embedding status, redaction flag, bytes written |
+| `MemoryPersistenceView` | `state.rs` | Borrow-lens over memory, conversation ID, autosave settings, goal text, unsummarized count |
+| `SecurityView` | `state.rs` | Borrow-lens over `guard_memory_writes` flag |
+| `MetricsView` | `state.rs` | Mutable borrow-lens over metrics counters |
+| `ProviderHandles` | `state.rs` | Arc-backed LLM and embedding provider handles for background tasks |
+
+### History Load Pipeline
+
+```
+load_history(LoadHistoryParams)
+  ↓
+fetch_history_filtered(cid, limit=50, agent_visible=true)  [SQLite]
+  ↓
+skip empty messages
+  ↓
+sanitize_tool_pairs(&mut messages)  [remove orphans, collect db_ids]
+  ↓
+soft_delete_messages(db_ids)  [SQLite, best-effort]
+  ↓
+count sqlite_total, semantic_total
+  ↓
+update last_persisted_message_id
+  ↓
+return LoadHistoryOutcome
+```
+
+### Message Persist Pipeline
+
+```
+persist_message(PersistMessageRequest, ...)
+  ↓
+serialize_parts_json(parts, role)  [JSON serialization]
+  ↓
+evaluate: guard_active = (security.guard_memory_writes && has_injection_flags)
+  ↓
+should_embed_message(skip_embedding=guard_active, parts, role, ...)
+  ↓
+if should_embed:
+    remember_with_parts(cid, role, content, parts_json, goal_text)  [A-MAC + Qdrant]
+  else:
+    save_only(cid, role, content, parts_json)  [SQLite only]
+  ↓
+update last_persisted_message_id, unsummarized_count
+  ↓
+update metrics (sqlite_message_count, embeddings_generated, exfiltration guards)
+  ↓
+reap_embed_tasks()  [allow background batching]
+  ↓
+return PersistMessageOutcome
+```
+
+### Tool-Pair Sanitization
+
+Orphaned `ToolUse`/`ToolResult` messages are detected and removed in four phases:
+
+1. **Trailing orphans**: Remove assistant messages at the end of the buffer with `ToolUse` parts
+   but no following user message with matching `ToolResult` parts.
+2. **Leading orphans**: Remove user messages at the start with `ToolResult` parts but no preceding
+   assistant message with matching `ToolUse` parts.
+3. **Mid-history orphaned ToolUse**: Strip `ToolUse` parts from assistant messages whose tool IDs
+   are not matched in the immediately following user message. Remove the message if no content remains.
+4. **Mid-history orphaned ToolResult**: Strip `ToolResult` parts from user messages whose IDs
+   are not matched in the preceding assistant message. Remove if no content remains.
+
+Each removal logs a WARN trace and records the message's `db_id` for soft-delete in SQLite.
+
+---
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| `memory` is `None` (memory disabled) | Return zero-filled outcome immediately; do not attempt DB access |
+| `conversation_id` is `None` | Return zero-filled outcome; waiting for first message sets the ID |
+| Empty message content and no parts | Skip the message and increment skip counter |
+| JSON serialization of parts fails | Log error, return `None`, skip persistence to avoid orphaned tool pairs |
+| SQLite soft-delete fails after orphan collection | Log WARN, continue; orphaned records will load again until manually cleaned |
+| Qdrant embedding timeout or error | Log error; the message is still in SQLite (save_only mode as fallback) |
+| Very large message (>100 KB) | Persist as-is (no size limit at service level; config controls embedding thresholds) |
+| Malformed legacy tool bracket syntax in content | `has_meaningful_content()` treats malformed tags as meaningful text |
+| Empty `last_persisted_message_id` at first call | Load from absolute history start (no OFFSET in query) |
+| Concurrent loads on same conversation | Both queries execute independently; last_persisted_message_id may race (handled by app-level session lock) |
+
+---
+
+## 7. Integration Points
+
+### Callers in `zeph-core`
+
+`zeph-core` holds the agent state and constructs borrow-lens views:
+
+```rust
+let memory_view = MemoryPersistenceView {
+    memory: self.memory.as_ref(),
+    conversation_id: self.conversation_id,
+    autosave_assistant: self.config.memory.autosave_assistant,
+    autosave_min_length: self.config.memory.autosave_min_length,
+    unsummarized_count: &mut self.unsummarized_count,
+    goal_text: self.current_goal.clone(),
+};
+
+let result = self.persistence_svc.load_history(LoadHistoryParams { ... })?;
+```
+
+### Dependency on `zeph-memory`
+
+- `SemanticMemory` — loads history, persists with embedding, soft-deletes messages
+- `ConversationId` — opaque type wrapping conversation identifiers
+- `MessageId` — opaque type for SQLite message IDs
+
+### Dependency on `zeph-llm`
+
+- `Message`, `MessagePart`, `Role` — message types from provider abstraction
+- `MessageMetadata` — includes `db_id`, `embedding_stored` flags
+
+### Dependency on `zeph-config`
+
+- `Config` — for autosave thresholds and memory settings (read via `MemoryPersistenceView`)
+
+---
+
+## 8. Key Invariants
+
+### Persistence Invariant
+
+Every message persisted to the agent conversation is written to SQLite and optionally to Qdrant.
+Once written, the message ID is recorded in `last_persisted_message_id` so subsequent history
+loads fetch only newer messages (LIMIT-based pagination).
+
+**Guarantee**: No message is loaded twice (except after manual compaction/recovery).
+
+### Tool-Pair Completeness Invariant
+
+For every `ToolUse` message part in a persisted assistant message, there MUST be a corresponding
+`ToolResult` message part in the immediately following user message, or the pair is sanitized
+at history-load time.
+
+**Guarantee**: Restored history never has dangling tool calls that await results.
+
+### Exfiltration Guard Invariant
+
+When `security.guard_memory_writes` is active AND a message has `has_injection_flags=true`,
+the message is persisted to SQLite but NOT embedded into Qdrant. This prevents injection
+patterns from contaminating semantic memory.
+
+**Guarantee**: Qdrant index does not reflect flagged injection content.
+
+### Unsummarized Count Invariant
+
+`unsummarized_count` is incremented once per message persisted via `persist_message()`.
+It is reset to zero when compaction runs. This tracks the age of the message buffer for
+compaction scheduling.
+
+**Guarantee**: Compaction triggers when unsummarized messages exceed a threshold.
+
+---
+
+## 9. NEVER Constraints
+
+- **NEVER** embed a message whose parts contain `[skipped]` or `[stopped]` ToolResult markers —
+  these are internal policy markers carrying no semantic value.
+- **NEVER** panic in `persist_message()` or `load_history()` — all errors must be loggable
+  and non-fatal (conversation continues).
+- **NEVER** double-persist a message — `last_persisted_message_id` monotonically increases;
+  no history reloads past that point unless it is explicitly reset.
+- **NEVER** create orphaned tool-pair records in SQLite — if parts cannot be serialized,
+  skip the entire message rather than storing partial state.
+- **NEVER** allow plugin or user code to bypass the borrow-lens views and directly construct
+  `*View` types — borrow-lens construction is reserved for `zeph-core` only.
+- **NEVER** mutate `MemoryPersistenceView::memory` or `MemoryPersistenceView::conversation_id`
+  after creation — the service treats them as read-only reference snapshots.
+- **NEVER** change the SQL limit (currently 50 messages per load) without updating tests
+  and compaction triggers — history load size is part of the performance contract.
+
+---
+
+## 10. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Dependency isolation | `cargo check -p zeph-agent-persistence` does not depend on `zeph-core` |
+| SC-002 | Tool-pair sanitization | Unit tests cover all four orphan removal modes; no orphaned pairs in integration tests |
+| SC-003 | Embedding decisions | Unit tests verify that guard_active, autosave, and content length threshold all work correctly |
+| SC-004 | Error handling | All database errors are caught and logged; no panics in happy or error paths |
+| SC-005 | Observation | All key operations emit `tracing::info_span!` spans with conversation ID and message count |
+
+---
+
+## 11. Agent Boundaries
+
+### Always (without asking)
+- Emit tracing spans with context (cid, role, content length) for all I/O operations
+- Log all orphan removals at WARN level with affected tool IDs
+- Keep the service stateless (no internal state, all I/O flows through method params)
+
+### Ask First
+- Adding new `*View` types or changing lifetime signatures
+- Changing the SQL LIMIT for history fetch (currently 50 messages)
+- Adding new embedding decision logic or overriding `should_embed_message()`
+
+### Never
+- Import from `zeph-core`
+- Use `unsafe` code
+- Panic in response to invalid input — always return an error
+- Directly mutate mutable borrows inside `MemoryPersistenceView` (borrow at call site only)
+
+---
+
+## 12. Open Questions
+
+None.
+
+---
+
+## 13. See Also
+
+- [[001-system-invariants/spec]] — system-wide invariants
+- [[002-agent-loop/spec]] — agent loop and context pressure
+- [[004-memory/spec]] — SemanticMemory backend
+- [[010-security/spec]] — exfiltration guard and security model
+- [[032-database-abstraction/spec]] — database abstraction layer for SQLite/PostgreSQL

--- a/specs/058-plugins/spec.md
+++ b/specs/058-plugins/spec.md
@@ -1,0 +1,465 @@
+---
+aliases:
+  - Plugin Management
+  - Plugin Installation
+  - Plugin Lifecycle
+  - Plugin Configuration Overlays
+tags:
+  - sdd
+  - spec
+  - plugins
+  - extensibility
+  - skills
+  - mcp
+created: 2026-05-17
+status: approved
+related:
+  - "[[MOC-specs]]"
+  - "[[constitution]]"
+  - "[[001-system-invariants/spec]]"
+  - "[[005-skills/spec]]"
+  - "[[008-mcp/spec]]"
+  - "[[010-security/spec]]"
+  - "[[028-runtime-layer/spec]]"
+---
+
+# Spec: Plugin Management System (`zeph-plugins`)
+
+> [!info]
+> Plugin discovery, installation, manifest parsing, config overlay application, and lifecycle
+> management for Zeph. Enables users to extend Zeph with third-party skills and MCP servers
+> while enforcing security invariants (tighten-only overlays, path traversal prevention,
+> skill name conflict detection).
+
+## 1. Overview
+
+### Problem Statement
+
+Zeph needs a way for users to extend the agent with third-party skills and MCP servers. Without
+a plugin system, users would need to fork the repository or manually copy files. A plugin system
+must:
+
+1. **Validate and install plugins** — with path traversal protection and manifest validation.
+2. **Manage skill registration** — prevent name conflicts with bundled and other plugin skills.
+3. **Apply tighten-only config overlays** — plugins cannot widen security constraints (e.g., add
+   commands to an allowlist); they can only narrow them.
+4. **Track plugin integrity** — record SHA-256 digests at install time and verify them at load time.
+5. **Provide discovery and listing** — users can inspect installed plugins and their skills.
+
+### Goal
+
+Provide `zeph-plugins` as the authoritative source for plugin lifecycle:
+- **Discovery**: scan `~/.local/share/zeph/plugins/` for installed plugins.
+- **Installation**: validate manifests, copy trees, register skills, apply overlays.
+- **Removal**: unregister skills and delete plugin directory.
+- **Listing**: enumerate installed plugins with metadata.
+- **Integrity**: verify plugins have not been tampered with since install.
+
+### Out of Scope
+
+- Skill registry and hot-reload (owned by `zeph-skills`)
+- MCP server lifecycle and communication (owned by `zeph-mcp`)
+- Agent bootstrap and config loading (owned by `zeph-config`)
+- TUI plugin management UI (owned by `zeph-tui`)
+
+---
+
+## 2. User Stories
+
+### US-001: Install a Local Plugin
+
+AS A user
+I WANT to install a plugin from a local directory
+SO THAT I can extend Zeph with third-party skills and MCP servers.
+
+**Acceptance criteria:**
+
+```
+GIVEN a local directory containing plugin.toml and skill directories
+WHEN plugin add /path/to/plugin is called
+THEN the plugin is validated, copied to ~/.local/share/zeph/plugins/<name>/
+AND all skills are registered with the skill registry
+AND MCP server declarations are recorded
+AND config overlay is applied at next startup
+AND warnings are emitted if the overlay will have no effect (empty base allowlist)
+```
+
+### US-002: Prevent Path Traversal Attacks
+
+AS A security administrator
+I WANT plugins to not escape their installation directory
+SO THAT a malicious plugin cannot read/modify files outside its scope.
+
+**Acceptance criteria:**
+
+```
+GIVEN a plugin manifest with skill path = "../../../etc/passwd"
+WHEN plugin add is called
+THEN the path is canonicalized
+AND if the resolved path escapes the source root, PluginError::InvalidSource is returned
+AND the plugin is not installed
+```
+
+### US-003: Enforce Tighten-Only Config Overlays
+
+AS A security system
+I WANT plugin config overlays to only narrow constraints, never loosen them
+SO THAT a malicious plugin cannot re-enable blocked commands or lower detection thresholds.
+
+**Acceptance criteria:**
+
+```
+GIVEN a plugin manifest with config overlay keys
+WHEN plugin add is called
+THEN only safelisted keys are allowed: [tools.blocked_commands, tools.allowed_commands, skills.disambiguation_threshold]
+AND tools.blocked_commands overlays grow (union across plugins)
+AND tools.allowed_commands overlays shrink (intersection, never wider than base)
+AND skills.disambiguation_threshold overlays rise (max across plugins)
+AND any non-safelisted key causes PluginError::UnsafeOverlay
+```
+
+### US-004: Detect Skill Name Conflicts
+
+AS A plugin manager
+I WANT to reject plugins with conflicting skill names
+SO THAT the skill registry remains unambiguous.
+
+**Acceptance criteria:**
+
+```
+GIVEN a plugin declaring skills with names already in {managed, bundled, other-plugin} sets
+WHEN plugin add is called
+THEN PluginError::SkillConflict is returned for each conflict
+AND the plugin is not installed
+```
+
+### US-005: Download and Verify Remote Plugins
+
+AS A user
+I WANT to install plugins from HTTP URLs with optional SHA-256 integrity checks
+SO THAT I can use plugins from trusted remote sources.
+
+**Acceptance criteria:**
+
+```
+GIVEN a plugin URL and optional expected SHA-256 digest
+WHEN plugin add_remote(url, Some(digest)) is called
+THEN the archive is downloaded
+AND the SHA-256 digest is computed and compared
+AND if digests mismatch, PluginError::IntegrityCheckFailed is returned
+AND if SHA-256 matches, the archive is extracted and installed locally
+```
+
+### US-006: Remove an Installed Plugin
+
+AS A user
+I WANT to uninstall a plugin and clean up its skills
+SO THAT the plugin no longer contributes to the agent.
+
+**Acceptance criteria:**
+
+```
+GIVEN an installed plugin name
+WHEN plugin remove <name> is called
+THEN the plugin directory is deleted from ~/.local/share/zeph/plugins/
+AND skills from that plugin are unregistered
+AND MCP server declarations are removed
+AND the integrity registry entry is cleared
+```
+
+### US-007: List Installed Plugins
+
+AS A user
+I WANT to see all installed plugins with metadata
+SO THAT I know what's available and what features each provides.
+
+**Acceptance criteria:**
+
+```
+GIVEN the plugins directory
+WHEN plugin list is called
+THEN each installed plugin is enumerated
+AND name, version, description, path, and skill list are returned
+AND plugins are sorted deterministically (by directory name)
+AND malformed or unverified plugins are logged but do not block listing
+```
+
+### US-008: Prevent .bundled Marker Carryover
+
+AS A security system
+I WANT all plugin skills to be treated as non-bundled
+SO THAT a plugin's SKILL.md files are not subject to bundled-skill trust hardening.
+
+**Acceptance criteria:**
+
+```
+GIVEN an installed plugin directory with residual .bundled markers
+WHEN the plugin is loaded
+THEN all .bundled markers are stripped recursively during installation
+AND the registry treats all plugin skills as hub-installed (non-bundled)
+```
+
+---
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN `plugin add /path` is called THEN `PluginManager::add()` SHALL read `plugin.toml`, parse it as TOML, and validate the manifest structure | must |
+| FR-002 | WHEN a plugin manifest is parsed THEN name, version, description, skills[], mcp.servers[], and config are extracted and validated | must |
+| FR-003 | WHEN a plugin name is validated THEN it SHALL match the regex `^[a-z0-9][a-z0-9-]*$` (lowercase alphanumeric and hyphens only) | must |
+| FR-004 | WHEN a skill path in the manifest is validated THEN its canonical resolved path SHALL be inside the source root (no escapes via ../) | must |
+| FR-005 | WHEN a skill path is validated THEN the skill directory SHALL contain a `SKILL.md` file or validation fails with `PluginError::SkillEntryMissing` | must |
+| FR-006 | WHEN a config overlay is validated THEN only keys in the safelist `[tools.blocked_commands, tools.allowed_commands, skills.disambiguation_threshold]` are allowed | must |
+| FR-007 | WHEN a skill name conflict is detected THEN the name must match against bundled skills (from `bundled_skill_names()`), managed skills, and other installed plugins | must |
+| FR-008 | WHEN `PluginManager::check_skill_conflicts()` runs THEN if any conflict exists, `PluginError::SkillConflict` is returned with all conflicting names | must |
+| FR-009 | WHEN a plugin is installed THEN its tree is copied to `~/.local/share/zeph/plugins/<name>/` atomically (copy source → copy dest → record registry entry) | must |
+| FR-010 | WHEN a plugin directory is copied THEN all `.bundled` markers are recursively stripped via `strip_bundled_markers()` | must |
+| FR-011 | WHEN `.plugin.toml` is written THEN it is a copy of the parsed and validated manifest; future overlay loads can read it without re-parsing the source | must |
+| FR-012 | WHEN a plugin is installed THEN its SHA-256 digest is computed and stored in the integrity registry as `.plugin-integrity.toml` under `default_runtime_data_root()` (e.g. `~/.local/share/zeph/` on Linux) | must |
+| FR-013 | WHEN a plugin config overlay is loaded at agent startup THEN `apply_plugin_config_overlays()` is called with the plugins directory | must |
+| FR-014 | WHEN overlays are applied THEN all plugins in deterministic order (sorted by dirname) contribute their safelisted keys to a `ResolvedOverlay` | must |
+| FR-015 | WHEN `tools.blocked_commands` overlays are applied THEN they form a union (monotonic growth); the agent's base blocked commands cannot shrink | must |
+| FR-016 | WHEN `tools.allowed_commands` overlays are applied THEN they form an intersection with the base; if the base is empty, no plugin can widen it | must |
+| FR-017 | WHEN `skills.disambiguation_threshold` overlays are applied THEN the maximum value across all plugins is used; thresholds never decrease | must |
+| FR-018 | WHEN plugin integrity is verified at load time THEN the SHA-256 digest stored at install is compared against the current manifest; if mismatch, `VerifyResult::Mismatch` is returned | must |
+| FR-019 | WHEN overlay resolution encounters a malformed `.plugin.toml` THEN the plugin is logged at WARN and skipped; the merge continues with remaining plugins | must |
+| FR-020 | WHEN `add_remote(url, expected_sha256)` is called THEN the archive is downloaded, SHA-256 is computed and compared, and if match the archive is extracted to a temp dir | must |
+| FR-021 | WHEN the archive SHA-256 does not match `expected_sha256` THEN `PluginError::IntegrityCheckFailed` is returned immediately; the archive is never extracted | must |
+| FR-022 | WHEN `allowed_commands` overlay will have no effect (base is empty) THEN a non-fatal warning is recorded in `AddResult::warnings` for the user to see | must |
+| FR-023 | WHEN skill regex scanning is performed THEN `scan_skill_body()` is called on each SKILL.md; warnings are advisory only and do not block installation | must |
+| FR-024 | WHEN `plugin remove <name>` is called THEN the plugin directory is deleted from disk and the integrity registry entry is cleared | must |
+| FR-025 | WHEN `plugin list` is called THEN all subdirectories under `plugins_dir` are enumerated; each `.plugin.toml` is parsed to collect metadata | must |
+| FR-026 | WHEN `plugin list` enumerates plugins THEN entries are sorted deterministically by directory name (not inode order) | must |
+
+---
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Security | Path traversal checks must canonicalize both source and destination paths and verify inclusion |
+| NFR-002 | Security | All plugin manifests are validated against a safelist before being applied to agent config |
+| NFR-003 | Security | `.bundled` markers are stripped from all plugin skill trees to prevent bypass of plugin trust model |
+| NFR-004 | Security | Skill name conflicts are detected and reported before installation; the operation fails cleanly |
+| NFR-005 | Integrity | Plugin archives are verified via SHA-256 before extraction; digests are stored at install time |
+| NFR-006 | Integrity | Installed manifests are copied to `.plugin.toml` for future integrity verification without re-reading source |
+| NFR-007 | Atomicity | Plugin install operations are atomic at the manifest/registry level: all-or-nothing copying and integrity recording |
+| NFR-008 | Observability | All install/remove/list operations emit tracing spans with plugin name and skill/MCP counts |
+| NFR-009 | Determinism | Plugin enumeration order is deterministic (sorted by filesystem entry name, not inode order) |
+| NFR-010 | Minimalism | The crate has no dependencies on `zeph-core`; it depends only on `zeph-config`, `zeph-skills`, `zeph-common`, and standard I/O libraries |
+
+---
+
+## 5. Data Model
+
+### Core Structures
+
+| Entity | Module | Description |
+|--------|--------|-------------|
+| `PluginManager` | `manager.rs` | Lifecycle manager: add, remove, list, conflict detection |
+| `PluginManifest` | `manifest.rs` | TOML schema: plugin metadata, skills, MCP servers, config overlay |
+| `PluginMeta` | `manifest.rs` | Plugin-level metadata: name, version, description |
+| `SkillEntry` | `manifest.rs` | Skill declaration: relative path to skill directory |
+| `McpSection` | `manifest.rs` | MCP server declarations: ID, command, args |
+| `PluginMcpServer` | `manifest.rs` | Single MCP server entry |
+| `AddResult` | `manager.rs` | Output of successful installation: name, root path, skills, MCP IDs, warnings |
+| `RemoveResult` | `manager.rs` | Output of successful removal: removed skills and MCP IDs |
+| `InstalledPlugin` | `manager.rs` | Plugin metadata as returned by `list`: name, version, description, path, skill_names |
+| `ResolvedOverlay` | `overlay.rs` | Aggregated config overlay from all plugins: blocked_add, allowed_intersect, threshold_max, source/skipped plugins |
+| `IntegrityRegistry` | `integrity.rs` | SHA-256 digest storage: maps plugin name → manifest SHA-256 hash |
+
+### Plugin Directory Layout
+
+```
+~/.local/share/zeph/plugins/
+├── plugin-a/
+│   ├── plugin.toml          (source manifest, user-provided)
+│   ├── .plugin.toml         (installed manifest copy, for integrity verification)
+│   ├── skills/
+│   │   └── skill-name/
+│   │       ├── SKILL.md
+│   │       └── ...
+│   └── ...
+├── plugin-b/
+│   └── ...
+```
+
+### Config Overlay Merge Rules
+
+| Field | Merge Strategy | Rationale |
+|-------|---|-----------|
+| `tools.blocked_commands` | Union (monotonic growth) | Only add restrictions; never remove existing blocks |
+| `tools.allowed_commands` | Intersection with base; base-gated | Narrowing only; if base is empty, remains empty |
+| `skills.disambiguation_threshold` | Max across plugins | Raise threshold to prevent ambiguity; never lower |
+
+---
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Plugin name contains uppercase letters | Rejected; `PluginError::InvalidName` |
+| Plugin manifest has syntax error (invalid TOML) | `PluginError::InvalidManifest` with parse error |
+| Skill directory does not contain SKILL.md | `PluginError::SkillEntryMissing` |
+| Skill path uses `../..` to escape source root | Canonicalization detects escape; `PluginError::InvalidSource` |
+| Config overlay key not in safelist | `PluginError::UnsafeOverlay` |
+| Skill name conflicts with bundled skill | `PluginError::SkillConflict` |
+| Plugin directory already installed | Overwrite with fresh copy (idempotent re-install) |
+| Remote download returns 404 | `PluginError::DownloadFailed` |
+| Archive SHA-256 mismatch | `PluginError::IntegrityCheckFailed`; archive not extracted |
+| `.plugin.toml` write fails after copy | Integrity registry not updated; plugin loads unverified next time (M4 fault tolerance) |
+| Overlay resolve encounters missing `.plugin.toml` | Plugin is silently skipped; overlay merge continues with others |
+| Overlay resolve encounters unreadable directory | Logged at DEBUG; plugin skipped |
+| List enumerates symlink to plugin directory | Symlink is ignored (only real directories from `PluginManager::add` are valid) |
+| User modifies `.plugin.toml` after install | Integrity verification fails; logged at WARN; overlay still applied (assume user intention) |
+| Empty `skills` or `mcp.servers` list | Valid; plugin may provide only config overlays |
+| Large plugin (>1 GB) | Copied as-is (no size limit at plugin level) |
+| Plugin removes itself during load | Graceful; next agent restart will not find it |
+
+---
+
+## 7. Integration Points
+
+### Agent Bootstrap (`zeph-core` startup)
+
+1. Config is loaded from `config.toml`.
+2. `apply_plugin_config_overlays()` is called with plugins directory.
+3. Resolved overlays are applied to the config in-memory.
+4. MCP servers and skills are registered based on plugin declarations.
+
+### Skill Registry (`zeph-skills`)
+
+- `bundled_skill_names()` is called to detect conflicts.
+- `SkillRegistry::register_hub_dir()` is called for each plugin skill directory.
+- Plugin skills are marked as non-bundled (full-trust model for user-installed extensions).
+
+### MCP Server Registration (`zeph-mcp`)
+
+- Plugin-declared MCP servers are validated against `mcp.allowed_commands` from config.
+- Server IDs are recorded for lifecycle management (restart required on plugin add/remove).
+
+### CLI Integration (`zeph` binary)
+
+- `/plugin add <source>` — installs a local plugin.
+- `/plugin add-remote <url> [sha256]` — installs a remote plugin.
+- `/plugin remove <name>` — uninstalls a plugin.
+- `/plugin list` — enumerates installed plugins.
+
+### TUI Integration (`zeph-tui`)
+
+- Plugin management commands in the command palette.
+- Plugin listing in a sidebar or status panel.
+- Inline warnings when overlay will have no effect.
+
+---
+
+## 8. Key Invariants
+
+### Tighten-Only Invariant
+
+Plugin config overlays can **never widen** security constraints. The safelisted keys enforce this:
+- `tools.blocked_commands` — only add to the blocked set.
+- `tools.allowed_commands` — only intersect with the base; if base is empty, union is empty.
+- `skills.disambiguation_threshold` — only raise, never lower.
+
+**Guarantee**: A plugin cannot re-enable blocked commands or lower security thresholds.
+
+### Skill Conflict Invariant
+
+No two plugins (including bundled skills and managed skills) may declare the same skill name.
+Conflicts are detected at install time and cause the installation to fail.
+
+**Guarantee**: The skill registry is unambiguous; each skill name maps to exactly one provider.
+
+### Path Traversal Invariant
+
+All plugin-relative paths (skill directories, file references) must stay within the plugin root.
+Canonicalization and inclusion checks prevent `../` escapes.
+
+**Guarantee**: A plugin cannot read or modify files outside its installation directory.
+
+### Integrity Invariant
+
+Every installed plugin has a SHA-256 digest recorded in the integrity registry. At load time,
+the manifest's digest is verified to detect tampering.
+
+**Guarantee**: Tampering with plugin manifests is detected (logged at WARN; overlay still applied).
+
+### Deterministic Enumeration Invariant
+
+Plugin directories are enumerated in a deterministic order (sorted by filesystem entry name),
+not by inode or creation order. This ensures reproducible overlay merge results across platforms.
+
+**Guarantee**: Config overlay results are identical regardless of filesystem mount order or recovery state.
+
+---
+
+## 9. NEVER Constraints
+
+- **NEVER** install a plugin whose manifest is not in the safelist — all config keys must match
+  `["tools.blocked_commands", "tools.allowed_commands", "skills.disambiguation_threshold"]`.
+- **NEVER** allow a plugin skill name to conflict with bundled or managed skills — conflicts must
+  be detected and reported before installation.
+- **NEVER** skip path traversal checks — canonicalize both paths and verify inclusion before copying.
+- **NEVER** widen `tools.allowed_commands` beyond the base allowlist — plugins can only narrow it.
+- **NEVER** lower `skills.disambiguation_threshold` — only raise it.
+- **NEVER** leave `.bundled` markers in installed plugin directories — strip them recursively
+  during installation.
+- **NEVER** panic on malformed plugin manifests — log and skip the plugin; continue with others.
+- **NEVER** write plugin files to disk before manifest validation — all checks happen before copying.
+- **NEVER** extract a remote plugin archive if SHA-256 verification fails — compare first, then extract.
+- **NEVER** allow symlinks in the plugins directory to contribute to overlay merge — only real
+  directories installed by `PluginManager::add` are valid sources.
+
+---
+
+## 10. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Path traversal protection | Unit tests verify that `../` escapes are rejected for all skill paths |
+| SC-002 | Conflict detection | Unit tests confirm that bundled, managed, and plugin skill conflicts are all detected |
+| SC-003 | Overlay tightening | Integration test verifies union, intersection, and max semantics for overlay merge |
+| SC-004 | Determinism | `plugin list` returns plugins in sorted order; overlay merge is reproducible across runs |
+| SC-005 | Integrity verification | Live test installs a plugin, modifies its manifest, and confirms detection at load time |
+| SC-006 | Error handling | All error types are handled; no panics on invalid manifests or missing directories |
+| SC-007 | .bundled stripping | Unit test confirms all `.bundled` markers are removed from installed plugin trees |
+
+---
+
+## 11. Agent Boundaries
+
+### Always (without asking)
+- Validate plugin names, skill paths, and config keys before copying any files
+- Emit tracing spans for install/remove/list with plugin names and counts
+- Deterministically sort plugin directories during enumeration
+- Strip all `.bundled` markers during installation
+
+### Ask First
+- Changing the safelist of allowed config overlay keys
+- Modifying overlay merge semantics (union/intersection/max rules)
+- Adding new plugin manifest fields or requirements
+
+### Never
+- Import from `zeph-core`
+- Allow symlinks in the plugins directory to contribute to merges
+- Panic on malformed manifests — log and skip
+- Copy files before manifest validation
+- Extract remote archives before SHA-256 verification
+
+---
+
+## 12. Open Questions
+
+None.
+
+---
+
+## 13. See Also
+
+- [[001-system-invariants/spec]] — system-wide invariants
+- [[005-skills/spec]] — skill registry and trust model
+- [[008-mcp/spec]] — MCP server lifecycle and server commands
+- [[010-security/spec]] — security model and authorization
+- [[028-runtime-layer/spec]] — config overlay merge timing


### PR DESCRIPTION
## Summary

- Add `specs/057-agent-persistence/spec.md`: comprehensive spec for `zeph-agent-persistence` covering persistence contract, durability guarantees, tool-pair orphan sanitization, embedding decision logic, failure modes, and integration with `zeph-memory` and `zeph-db`
- Add `specs/058-plugins/spec.md`: comprehensive spec for `zeph-plugins` covering `PluginManager` lifecycle, `PluginManifest` schema, tighten-only config overlay semantics, SHA-256 integrity verification, trust levels, and plugin discovery
- Register both specs in `specs/README.md`
- Update `CHANGELOG.md` under `[Unreleased]`

Closes #3857, #3855

## Test plan

- [ ] Verify `specs/057-agent-persistence/spec.md` covers all areas from #3857: persistence contract, durability, migration strategy, failure modes, zeph-memory/zeph-db relationship
- [ ] Verify `specs/058-plugins/spec.md` covers all areas from #3855: PluginManager lifecycle, PluginManifest schema, tighten-only overlay semantics, API contract, trust levels
- [ ] Check `specs/README.md` has entries for both new specs
- [ ] Check `CHANGELOG.md` has entries for both under `[Unreleased]`