### PR TITLE
fix(core,common,commands): async provider instruction reload, const fn, stale comment

### DIFF
--- a/crates/zeph-commands/src/handlers/mod.rs
+++ b/crates/zeph-commands/src/handlers/mod.rs
@@ -29,12 +29,8 @@ pub mod plugins;
 pub mod policy;
 pub mod scheduler;
 pub mod session;
-pub mod status;
-// Note: skill, skills, feedback handlers are kept as TODO — they hold non-Send DB references
-// across .await points which prevents implementing AgentAccess::handle_skill as Send future.
-// These commands continue to be dispatched via dispatch_slash_command in zeph-core until
-// SemanticMemory and AnyProvider implement Sync.
 pub mod skill;
+pub mod status;
 #[cfg(test)]
 pub mod test_helpers;
 pub mod trajectory;

--- a/crates/zeph-common/src/error_taxonomy.rs
+++ b/crates/zeph-common/src/error_taxonomy.rs
@@ -48,19 +48,19 @@ pub enum ErrorDomain {
 impl ErrorDomain {
     /// Whether errors in this domain should trigger automatic retry.
     #[must_use]
-    pub fn is_auto_retryable(self) -> bool {
+    pub const fn is_auto_retryable(self) -> bool {
         matches!(self, Self::System)
     }
 
     /// Whether the LLM should be asked to fix its output.
     #[must_use]
-    pub fn needs_llm_correction(self) -> bool {
+    pub const fn needs_llm_correction(self) -> bool {
         matches!(self, Self::Reflection | Self::Planning)
     }
 
     /// Human-readable label for audit logs.
     #[must_use]
-    pub fn label(self) -> &'static str {
+    pub const fn label(self) -> &'static str {
         match self {
             Self::Planning => "planning",
             Self::Reflection => "reflection",
@@ -91,7 +91,7 @@ pub enum ToolInvocationPhase {
 impl ToolInvocationPhase {
     /// Human-readable label for audit logs.
     #[must_use]
-    pub fn label(self) -> &'static str {
+    pub const fn label(self) -> &'static str {
         match self {
             Self::Setup => "setup",
             Self::ParamHandling => "param_handling",
@@ -152,7 +152,7 @@ pub enum ToolErrorCategory {
 impl ToolErrorCategory {
     /// Whether this error category is eligible for automatic retry with backoff.
     #[must_use]
-    pub fn is_retryable(self) -> bool {
+    pub const fn is_retryable(self) -> bool {
         matches!(
             self,
             Self::RateLimited | Self::ServerError | Self::NetworkError | Self::Timeout
@@ -163,7 +163,7 @@ impl ToolErrorCategory {
     ///
     /// Only `InvalidParameters` and `TypeMismatch` trigger the reformat path.
     #[must_use]
-    pub fn needs_parameter_reformat(self) -> bool {
+    pub const fn needs_parameter_reformat(self) -> bool {
         matches!(self, Self::InvalidParameters | Self::TypeMismatch)
     }
 
@@ -172,7 +172,7 @@ impl ToolErrorCategory {
     /// Infrastructure errors (network, timeout, server, rate limit) are NOT
     /// the model's fault and must never trigger self-reflection.
     #[must_use]
-    pub fn is_quality_failure(self) -> bool {
+    pub const fn is_quality_failure(self) -> bool {
         matches!(
             self,
             Self::InvalidParameters | Self::TypeMismatch | Self::ToolNotFound
@@ -181,7 +181,7 @@ impl ToolErrorCategory {
 
     /// Map to the high-level error domain for recovery dispatch.
     #[must_use]
-    pub fn domain(self) -> ErrorDomain {
+    pub const fn domain(self) -> ErrorDomain {
         match self {
             Self::ToolNotFound => ErrorDomain::Planning,
             Self::InvalidParameters | Self::TypeMismatch => ErrorDomain::Reflection,
@@ -197,7 +197,7 @@ impl ToolErrorCategory {
 
     /// Human-readable label for audit logs, TUI status indicators, and structured feedback.
     #[must_use]
-    pub fn label(self) -> &'static str {
+    pub const fn label(self) -> &'static str {
         match self {
             Self::ToolNotFound => "tool_not_found",
             Self::InvalidParameters => "invalid_parameters",
@@ -215,7 +215,7 @@ impl ToolErrorCategory {
 
     /// Map to the diagnostic invocation phase per arXiv:2601.16280.
     #[must_use]
-    pub fn phase(self) -> ToolInvocationPhase {
+    pub const fn phase(self) -> ToolInvocationPhase {
         match self {
             Self::ToolNotFound => ToolInvocationPhase::Setup,
             Self::InvalidParameters | Self::TypeMismatch => ToolInvocationPhase::ParamHandling,
@@ -232,7 +232,7 @@ impl ToolErrorCategory {
 
     /// Recovery suggestion for the LLM based on error category.
     #[must_use]
-    pub fn suggestion(self) -> &'static str {
+    pub const fn suggestion(self) -> &'static str {
         match self {
             Self::ToolNotFound => {
                 "Check the tool name. Use tool_definitions to see available tools."

--- a/crates/zeph-common/src/math.rs
+++ b/crates/zeph-common/src/math.rs
@@ -79,7 +79,7 @@ impl EmbeddingVector<Unnormalized> {
     /// assert_eq!(v.as_slice(), &[1.0_f32, 0.0]);
     /// ```
     #[must_use]
-    pub fn new(inner: Vec<f32>) -> Self {
+    pub const fn new(inner: Vec<f32>) -> Self {
         Self {
             inner,
             _state: PhantomData,
@@ -136,7 +136,7 @@ impl EmbeddingVector<Normalized> {
     /// assert_eq!(v.as_slice(), &[0.6_f32, 0.8]);
     /// ```
     #[must_use]
-    pub fn new_normalized(inner: Vec<f32>) -> Self {
+    pub const fn new_normalized(inner: Vec<f32>) -> Self {
         Self {
             inner,
             _state: PhantomData,
@@ -186,7 +186,7 @@ impl<State> EmbeddingVector<State> {
     /// assert_eq!(v.len(), 3);
     /// ```
     #[must_use]
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.inner.len()
     }
 
@@ -201,7 +201,7 @@ impl<State> EmbeddingVector<State> {
     /// assert!(v.is_empty());
     /// ```
     #[must_use]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
 }

--- a/crates/zeph-common/src/memory.rs
+++ b/crates/zeph-common/src/memory.rs
@@ -102,7 +102,7 @@ impl CompressionLevel {
     ///
     /// `Episodic = 1.0` (baseline), `Procedural = 0.6`, `Declarative = 0.3`.
     #[must_use]
-    pub fn cost_factor(self) -> f32 {
+    pub const fn cost_factor(self) -> f32 {
         match self {
             Self::Episodic => 1.0,
             Self::Procedural => 0.6,
@@ -284,7 +284,7 @@ impl EdgeType {
     /// assert_eq!(EdgeType::Causal.as_str(), "causal");
     /// ```
     #[must_use]
-    pub fn as_str(self) -> &'static str {
+    pub const fn as_str(self) -> &'static str {
         match self {
             Self::Semantic => "semantic",
             Self::Temporal => "temporal",

--- a/crates/zeph-common/src/security_event.rs
+++ b/crates/zeph-common/src/security_event.rs
@@ -46,7 +46,7 @@ impl SecurityEventCategory {
     ///
     /// Used as the `category` column in audit logs and TUI display.
     #[must_use]
-    pub fn as_str(self) -> &'static str {
+    pub const fn as_str(self) -> &'static str {
         match self {
             Self::InjectionFlag => "injection",
             Self::InjectionBlocked => "injection_blocked",

--- a/crates/zeph-common/src/task_supervisor.rs
+++ b/crates/zeph-common/src/task_supervisor.rs
@@ -132,7 +132,7 @@ impl TaskHandle {
 
     /// Return the task's name.
     #[must_use]
-    pub fn name(&self) -> &'static str {
+    pub const fn name(&self) -> &'static str {
         self.name
     }
 }
@@ -1030,7 +1030,7 @@ impl TaskSupervisor {
             }
         }
 
-        Self::wire_completion_reporter(name.clone(), jh, completion_tx);
+        Self::wire_completion_reporter(name, jh, completion_tx);
     }
 }
 

--- a/crates/zeph-common/src/timestamp.rs
+++ b/crates/zeph-common/src/timestamp.rs
@@ -14,7 +14,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// Uses the proleptic-Gregorian Hinnant algorithm — O(1), no heap allocation.
 /// Kept `pub(crate)` because the raw 6-tuple is an implementation detail; prefer
 /// the higher-level functions in this module for public use.
-pub(crate) fn secs_to_ymdhms(secs: u64) -> (u32, u32, u32, u32, u32, u32) {
+pub(crate) const fn secs_to_ymdhms(secs: u64) -> (u32, u32, u32, u32, u32, u32) {
     const SECS_PER_MIN: u64 = 60;
     const DAYS_PER_400Y: u64 = 146_097;
 

--- a/crates/zeph-common/src/trust_level.rs
+++ b/crates/zeph-common/src/trust_level.rs
@@ -52,7 +52,7 @@ impl SkillTrustLevel {
     /// assert!(SkillTrustLevel::Trusted.severity() < SkillTrustLevel::Blocked.severity());
     /// ```
     #[must_use]
-    pub fn severity(self) -> u8 {
+    pub const fn severity(self) -> u8 {
         match self {
             Self::Trusted => 0,
             Self::Verified => 1,
@@ -72,7 +72,7 @@ impl SkillTrustLevel {
     /// assert_eq!(result, SkillTrustLevel::Quarantined);
     /// ```
     #[must_use]
-    pub fn min_trust(self, other: Self) -> Self {
+    pub const fn min_trust(self, other: Self) -> Self {
         if self.severity() >= other.severity() {
             self
         } else {
@@ -91,7 +91,7 @@ impl SkillTrustLevel {
     /// assert!(!SkillTrustLevel::Blocked.is_active());
     /// ```
     #[must_use]
-    pub fn is_active(self) -> bool {
+    pub const fn is_active(self) -> bool {
         !matches!(self, Self::Blocked)
     }
 }

--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -630,7 +630,7 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
         &'a mut self,
         arg: &'a str,
     ) -> Pin<Box<dyn Future<Output = String> + Send + 'a>> {
-        Box::pin(async move { self.handle_provider_command_as_string(arg) })
+        Box::pin(async move { self.handle_provider_command_as_string(arg).await })
     }
 
     // ----- /policy -----

--- a/crates/zeph-core/src/agent/provider_cmd.rs
+++ b/crates/zeph-core/src/agent/provider_cmd.rs
@@ -62,7 +62,7 @@ impl<C: Channel> Agent<C> {
                     .iter()
                     .any(|e| e.effective_name().eq_ignore_ascii_case(&stored_name));
                 if found {
-                    let result = self.provider_switch_as_string(&stored_name);
+                    let result = self.provider_switch_as_string(&stored_name).await;
                     if result.contains("Switched") {
                         tracing::info!(
                             provider = stored_name,
@@ -126,7 +126,7 @@ impl<C: Channel> Agent<C> {
     }
 
     /// Update instruction files when the active provider changes (C5).
-    fn update_provider_instructions(&mut self, entry: &zeph_config::ProviderEntry) {
+    async fn update_provider_instructions(&mut self, entry: &zeph_config::ProviderEntry) {
         let Some(ref mut reload_state) = self.runtime.instructions.reload_state else {
             return;
         };
@@ -146,12 +146,13 @@ impl<C: Channel> Agent<C> {
         let provider_kinds = reload_state.provider_kinds.clone();
         let explicit_files = reload_state.explicit_files.clone();
         let auto_detect = reload_state.auto_detect;
-        let new_blocks = crate::instructions::load_instructions(
-            &base_dir,
-            &provider_kinds,
-            &explicit_files,
+        let new_blocks = crate::instructions::load_instructions_async(
+            base_dir,
+            provider_kinds,
+            explicit_files,
             auto_detect,
-        );
+        )
+        .await;
         tracing::info!(
             count = new_blocks.len(),
             provider = ?entry.provider_type,
@@ -189,11 +190,11 @@ impl<C: Channel> Agent<C> {
 
     /// Handle `/provider` command, returning a result string for use via
     /// [`zeph_commands::traits::agent::AgentAccess`].
-    pub(super) fn handle_provider_command_as_string(&mut self, arg: &str) -> String {
+    pub(super) async fn handle_provider_command_as_string(&mut self, arg: &str) -> String {
         match arg {
             "" => self.provider_list_as_string(),
             "status" => self.provider_status_as_string(),
-            name => self.provider_switch_as_string(name),
+            name => self.provider_switch_as_string(name).await,
         }
     }
 
@@ -252,7 +253,7 @@ impl<C: Channel> Agent<C> {
         out.trim_end().to_owned()
     }
 
-    fn provider_switch_as_string(&mut self, name: &str) -> String {
+    async fn provider_switch_as_string(&mut self, name: &str) -> String {
         let entry_clone = self
             .runtime
             .providers
@@ -314,7 +315,7 @@ impl<C: Channel> Agent<C> {
                     *override_slot.write() = None;
                 }
 
-                self.update_provider_instructions(&entry);
+                self.update_provider_instructions(&entry).await;
                 self.apply_provider_switch_metrics(&entry, &configured_name);
                 self.persist_channel_provider(configured_name.clone());
                 // Refresh the TUI context gauge with the new provider's window size.
@@ -382,15 +383,15 @@ mod tests {
         }
     }
 
-    #[test]
-    fn provider_list_empty_pool() {
+    #[tokio::test]
+    async fn provider_list_empty_pool() {
         let mut qa = QuickTestAgent::minimal("ok");
-        let out = qa.agent.handle_provider_command_as_string("");
+        let out = qa.agent.handle_provider_command_as_string("").await;
         assert!(out.contains("No providers configured"));
     }
 
-    #[test]
-    fn provider_list_shows_all_with_active_marker() {
+    #[tokio::test]
+    async fn provider_list_shows_all_with_active_marker() {
         let provider = mock_provider(vec![]);
         let channel = MockChannel::new(vec![]);
         let registry = create_test_registry();
@@ -405,15 +406,15 @@ mod tests {
         );
         agent.runtime.providers.provider_pool = vec![entry_a, entry_b];
 
-        let out = agent.handle_provider_command_as_string("");
+        let out = agent.handle_provider_command_as_string("").await;
         assert!(out.contains("ollama"), "should list ollama");
         assert!(out.contains("claude"), "should list claude");
         // Active provider is MockProvider; neither entry matches — no (active) marker expected.
         assert!(out.contains("Configured providers:"));
     }
 
-    #[test]
-    fn provider_list_marks_active_provider() {
+    #[tokio::test]
+    async fn provider_list_marks_active_provider() {
         let channel = MockChannel::new(vec![]);
         let registry = create_test_registry();
         let executor = MockToolExecutor::no_tools();
@@ -427,22 +428,25 @@ mod tests {
         agent.runtime.providers.provider_pool = vec![entry];
         agent.runtime.providers.provider_config_snapshot = Some(snapshot);
 
-        let out = agent.handle_provider_command_as_string("");
+        let out = agent.handle_provider_command_as_string("").await;
         assert!(out.contains("(active)"), "active entry must be marked");
     }
 
-    #[test]
-    fn provider_switch_unknown_name_returns_error() {
+    #[tokio::test]
+    async fn provider_switch_unknown_name_returns_error() {
         let mut qa = QuickTestAgent::minimal("ok");
         let entry = make_entry("ollama", ProviderKind::Ollama, Some("qwen3:8b"));
         qa.agent.runtime.providers.provider_pool = vec![entry];
-        let out = qa.agent.handle_provider_command_as_string("nonexistent");
+        let out = qa
+            .agent
+            .handle_provider_command_as_string("nonexistent")
+            .await;
         assert!(out.contains("Unknown provider 'nonexistent'"));
         assert!(out.contains("ollama"));
     }
 
-    #[test]
-    fn provider_switch_already_active_warns() {
+    #[tokio::test]
+    async fn provider_switch_already_active_warns() {
         let entry = make_entry("ollama", ProviderKind::Ollama, Some("qwen3:8b"));
         let snapshot = ollama_snapshot();
         let provider =
@@ -455,22 +459,22 @@ mod tests {
         agent.runtime.providers.provider_pool = vec![entry];
         agent.runtime.providers.provider_config_snapshot = Some(snapshot);
 
-        let out = agent.handle_provider_command_as_string("ollama");
+        let out = agent.handle_provider_command_as_string("ollama").await;
         assert!(out.contains("already active"));
     }
 
-    #[test]
-    fn provider_switch_missing_snapshot_returns_error() {
+    #[tokio::test]
+    async fn provider_switch_missing_snapshot_returns_error() {
         let mut qa = QuickTestAgent::minimal("ok");
         let entry = make_entry("ollama", ProviderKind::Ollama, Some("qwen3:8b"));
         qa.agent.runtime.providers.provider_pool = vec![entry];
         // provider_config_snapshot is None by default
-        let out = qa.agent.handle_provider_command_as_string("ollama");
+        let out = qa.agent.handle_provider_command_as_string("ollama").await;
         assert!(out.contains("config snapshot missing"));
     }
 
-    #[test]
-    fn provider_switch_success_resets_state() {
+    #[tokio::test]
+    async fn provider_switch_success_resets_state() {
         let entry_a = make_entry("ollama", ProviderKind::Ollama, Some("qwen3:8b"));
         let entry_b = make_entry("ollama2", ProviderKind::Ollama, Some("llama3.2"));
         let snapshot = ollama_snapshot();
@@ -485,7 +489,7 @@ mod tests {
         agent.runtime.providers.provider_config_snapshot = Some(snapshot);
         agent.runtime.providers.cached_prompt_tokens = 999;
 
-        let out = agent.handle_provider_command_as_string("ollama2");
+        let out = agent.handle_provider_command_as_string("ollama2").await;
         assert!(out.contains("Switched to provider:"), "unexpected: {out}");
         assert!(out.contains("llama3.2"));
         assert_eq!(
@@ -495,11 +499,11 @@ mod tests {
         assert_eq!(agent.runtime.config.model_name, "llama3.2");
     }
 
-    #[test]
-    fn provider_status_no_metrics() {
+    #[tokio::test]
+    async fn provider_status_no_metrics() {
         let mut qa = QuickTestAgent::minimal("ok");
         qa.agent.runtime.config.model_name = "test-model".to_owned();
-        let out = qa.agent.handle_provider_command_as_string("status");
+        let out = qa.agent.handle_provider_command_as_string("status").await;
         assert!(out.contains("Current provider:"));
         assert!(out.contains("test-model"));
     }
@@ -566,8 +570,8 @@ mod tests {
 
     // Verify that build_switch_message includes the embedding notice when embedding provider
     // name differs from the newly active chat provider name.
-    #[test]
-    fn build_switch_message_includes_notice_when_embedding_provider_differs() {
+    #[tokio::test]
+    async fn build_switch_message_includes_notice_when_embedding_provider_differs() {
         let entry_a = make_entry("ollama", ProviderKind::Ollama, Some("qwen3:8b"));
         let entry_b = make_entry("ollama2", ProviderKind::Ollama, Some("llama3.2"));
         let snapshot = ollama_snapshot();
@@ -587,7 +591,7 @@ mod tests {
         agent.runtime.providers.provider_pool = vec![entry_a, entry_b];
         agent.runtime.providers.provider_config_snapshot = Some(snapshot);
 
-        let out = agent.handle_provider_command_as_string("ollama2");
+        let out = agent.handle_provider_command_as_string("ollama2").await;
         // embedding_provider.name() == "mock" ≠ "ollama" (the new chat provider) → notice shown.
         assert!(
             out.contains("Embedding operations continue using"),
@@ -600,8 +604,8 @@ mod tests {
     }
 
     // Verify that /provider switch never replaces the embedding_provider field.
-    #[test]
-    fn provider_switch_does_not_change_embedding_provider() {
+    #[tokio::test]
+    async fn provider_switch_does_not_change_embedding_provider() {
         let entry_a = make_entry("ollama", ProviderKind::Ollama, Some("qwen3:8b"));
         let entry_b = make_entry("ollama2", ProviderKind::Ollama, Some("llama3.2"));
         let snapshot = ollama_snapshot();
@@ -622,7 +626,7 @@ mod tests {
 
         let embed_name_before = agent.embedding_provider.name().to_owned();
 
-        agent.handle_provider_command_as_string("ollama2");
+        agent.handle_provider_command_as_string("ollama2").await;
 
         // Chat provider must have changed.
         assert_eq!(agent.runtime.config.model_name, "llama3.2");


### PR DESCRIPTION
## Summary

- **#3866**: `update_provider_instructions` now uses `load_instructions_async`, offloading filesystem I/O to the blocking thread pool instead of running it synchronously on the Tokio worker thread inside `Box::pin(async move {...})`. Propagated `async` through `provider_switch_as_string` and `handle_provider_command_as_string`; updated all call sites and tests to `#[tokio::test]`.
- **#3863**: Annotated 21 eligible functions in `zeph-common` as `const fn` (`error_taxonomy`, `math`, `memory`, `trust_level`, `task_supervisor`).
- **#3881**: Removed stale comment in `handlers/mod.rs` that falsely claimed skill/feedback handlers were unimplemented due to non-Send constraints.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 9641 passed, 0 failed

Closes #3866, #3863, #3881