### PR TITLE
feat(config,acp,plugins): inline hooks in config.toml, ACP session CRUD, auto-update plugin policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `zeph-config`: `HooksConfig` — inline `[hooks]` section in `config.toml` for declaring hooks
+  without a separate `settings.json`. Supports all event types: `[[hooks.pre_tool_use]]`,
+  `[[hooks.post_tool_use]]`, `[[hooks.cwd_changed]]`, `[[hooks.permission_denied]]`,
+  `[[hooks.turn_complete]]`, `[hooks.file_changed]`. Both `command` and `mcp_tool` action
+  types are supported (closes #3885).
+- `zeph-acp`: REST CRUD endpoints for session lifecycle — `POST /sessions` (create),
+  `GET /sessions/{id}` (inspect), `PATCH /sessions/{id}` (rename title),
+  `DELETE /sessions/{id}` (remove session and event history). `POST /sessions` validates
+  `working_dir` against the `additional_directories` allowlist and returns `403` for
+  out-of-allowlist paths. `SessionStatus` enum (`running`/`idle`/`stopped`/`error`) reflects
+  live connection state (closes #3902).
+- `zeph-plugins`: `PluginMeta::auto_update` boolean field (default `false`) — opt-in advisory
+  flag for future automatic plugin updates on startup. Existing manifests without the field
+  default to `false` via `#[serde(default)]` (closes #3902).
+
 ### Fixed
 
 - `zeph-agent-feedback`: CJK rejection pattern `^違う` now requires a terminal punctuation

--- a/crates/zeph-acp/src/transport/crud.rs
+++ b/crates/zeph-acp/src/transport/crud.rs
@@ -1,0 +1,561 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! CRUD REST endpoints for ACP session management.
+//!
+//! These handlers complement the existing `GET /sessions` and
+//! `GET /sessions/{id}/messages` endpoints with full lifecycle control:
+//! create, inspect, update, and delete individual sessions.
+
+#![cfg(feature = "acp-http")]
+
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use zeph_memory::store::AcpSessionInfo;
+
+use crate::transport::http::AcpHttpState;
+
+// ── Request / response types ──────────────────────────────────────────────────
+
+/// Status of an ACP session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionStatus {
+    /// The session has an active HTTP/WebSocket connection.
+    Running,
+    /// The session exists but has no active connection (history-only).
+    Idle,
+    /// The session was explicitly stopped or reaped.
+    Stopped,
+    /// The session encountered an unrecoverable error.
+    Error,
+}
+
+/// Full session details returned by `POST /sessions` and `GET /sessions/{id}`.
+#[derive(Debug, Serialize)]
+pub struct SessionInfo {
+    /// ACP session UUID.
+    pub id: String,
+    /// Auto-generated session title, if available.
+    pub title: Option<String>,
+    /// ISO 8601 timestamp of session creation.
+    pub created_at: String,
+    /// ISO 8601 timestamp of the last session update.
+    pub updated_at: String,
+    /// Total number of persisted events in this session.
+    pub message_count: i64,
+    /// Current session lifecycle status.
+    pub status: SessionStatus,
+    /// Working directory reported for this session, if known.
+    pub working_dir: Option<PathBuf>,
+}
+
+impl SessionInfo {
+    fn from_store(
+        info: AcpSessionInfo,
+        status: SessionStatus,
+        working_dir: Option<PathBuf>,
+    ) -> Self {
+        Self {
+            id: info.id,
+            title: info.title,
+            created_at: info.created_at,
+            updated_at: info.updated_at,
+            message_count: info.message_count,
+            status,
+            working_dir,
+        }
+    }
+}
+
+/// Request body for `POST /sessions`.
+#[derive(Debug, Deserialize)]
+pub struct CreateSessionRequest {
+    /// Optional working directory for the new session.
+    ///
+    /// When provided, the path is validated against the `additional_directories`
+    /// allowlist configured for the ACP server. Requests with a path outside the
+    /// allowlist are rejected with `403 Forbidden`.
+    pub working_dir: Option<PathBuf>,
+    /// Optional model override (`"provider:model"` format).
+    pub model: Option<String>,
+    /// Optional session mode identifier.
+    pub mode: Option<String>,
+}
+
+/// Request body for `PATCH /sessions/{id}`.
+#[derive(Debug, Deserialize)]
+pub struct UpdateSessionRequest {
+    /// New title for the session.
+    pub title: Option<String>,
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Determine `SessionStatus` for a session ID by checking active connections.
+fn resolve_status(state: &AcpHttpState, id: &str) -> SessionStatus {
+    if state.connections.contains_key(id) {
+        SessionStatus::Running
+    } else {
+        SessionStatus::Idle
+    }
+}
+
+/// Validate `working_dir` against the `additional_directories` allowlist.
+///
+/// Returns `Ok(())` when the path is covered by the allowlist or when the
+/// allowlist is empty and `working_dir` is `None`.
+///
+/// # Errors
+///
+/// Returns `Err(StatusCode::FORBIDDEN)` when `working_dir` is present but
+/// not covered by the allowlist.
+async fn validate_working_dir(
+    state: &AcpHttpState,
+    working_dir: Option<&PathBuf>,
+) -> Result<(), StatusCode> {
+    let Some(dir) = working_dir else {
+        return Ok(());
+    };
+
+    let allowlist = &state.server_config.additional_directories;
+
+    if allowlist.is_empty() {
+        tracing::warn!(
+            path = %dir.display(),
+            "POST /sessions rejected: working_dir provided but additional_directories allowlist is empty"
+        );
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    // Canonicalize once; if it fails (path does not exist) reject immediately.
+    let canonical = tokio::fs::canonicalize(dir).await.map_err(|e| {
+        tracing::warn!(path = %dir.display(), error = %e, "cannot canonicalize working_dir");
+        StatusCode::FORBIDDEN
+    })?;
+
+    let allowed = allowlist
+        .iter()
+        .any(|entry| canonical.starts_with(entry.as_path()));
+
+    if !allowed {
+        tracing::warn!(
+            path = %canonical.display(),
+            "POST /sessions rejected: working_dir not in additional_directories allowlist"
+        );
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    Ok(())
+}
+
+// ── Handlers ──────────────────────────────────────────────────────────────────
+
+/// `POST /sessions` — create a new ACP session record.
+///
+/// Persists the session in the `SQLite` store and returns the full `SessionInfo`.
+/// `working_dir`, `model`, and `mode` are accepted but advisory for history
+/// callers (the actual agent loop is spawned lazily on the first prompt).
+///
+/// # Errors
+///
+/// Returns `403 Forbidden` when `working_dir` is outside the allowlist.
+/// Returns `503 Service Unavailable` when no `SQLite` store is configured.
+/// Returns `500 Internal Server Error` if the database write fails.
+pub async fn create_session_handler(
+    State(state): State<AcpHttpState>,
+    Json(req): Json<CreateSessionRequest>,
+) -> Result<impl IntoResponse, StatusCode> {
+    if !state.ready.load(std::sync::atomic::Ordering::Acquire) {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    validate_working_dir(&state, req.working_dir.as_ref()).await?;
+
+    let store = state
+        .store
+        .as_ref()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    let session_id = uuid::Uuid::new_v4().to_string();
+
+    store.create_acp_session(&session_id).await.map_err(|e| {
+        tracing::warn!(error = %e, "failed to create ACP session");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let info = store.get_acp_session_info(&session_id).await.map_err(|e| {
+        tracing::warn!(error = %e, "failed to retrieve created ACP session");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let Some(info) = info else {
+        tracing::warn!(session_id, "created ACP session not found immediately");
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    };
+
+    let body = SessionInfo::from_store(info, SessionStatus::Idle, req.working_dir);
+    Ok((StatusCode::CREATED, Json(body)))
+}
+
+/// `GET /sessions/{id}` — retrieve full details for a single ACP session.
+///
+/// # Errors
+///
+/// Returns `400 Bad Request` if `{id}` is not a valid UUID.
+/// Returns `404 Not Found` if the session does not exist.
+/// Returns `503 Service Unavailable` when no `SQLite` store is configured.
+/// Returns `500 Internal Server Error` if the database query fails.
+pub async fn get_session_handler(
+    State(state): State<AcpHttpState>,
+    Path(session_id): Path<String>,
+) -> Result<impl IntoResponse, StatusCode> {
+    if !state.ready.load(std::sync::atomic::Ordering::Acquire) {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
+    uuid::Uuid::parse_str(&session_id).map_err(|_| StatusCode::BAD_REQUEST)?;
+
+    let store = state
+        .store
+        .as_ref()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    let info = store
+        .get_acp_session_info(&session_id)
+        .await
+        .map_err(|e| {
+            tracing::warn!(error = %e, "failed to get ACP session info");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    let status = resolve_status(&state, &session_id);
+    Ok(Json(SessionInfo::from_store(info, status, None)))
+}
+
+/// `PATCH /sessions/{id}` — update mutable metadata for an existing session.
+///
+/// Currently supports renaming the session title.
+///
+/// # Errors
+///
+/// Returns `400 Bad Request` if `{id}` is not a valid UUID.
+/// Returns `404 Not Found` if the session does not exist.
+/// Returns `503 Service Unavailable` when no `SQLite` store is configured.
+/// Returns `500 Internal Server Error` if the database write or subsequent query fails.
+pub async fn update_session_handler(
+    State(state): State<AcpHttpState>,
+    Path(session_id): Path<String>,
+    Json(req): Json<UpdateSessionRequest>,
+) -> Result<impl IntoResponse, StatusCode> {
+    if !state.ready.load(std::sync::atomic::Ordering::Acquire) {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
+    uuid::Uuid::parse_str(&session_id).map_err(|_| StatusCode::BAD_REQUEST)?;
+
+    let store = state
+        .store
+        .as_ref()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    let exists = store.acp_session_exists(&session_id).await.map_err(|e| {
+        tracing::warn!(error = %e, "failed to check ACP session existence");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    if !exists {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    if let Some(title) = req.title {
+        store
+            .update_session_title(&session_id, &title)
+            .await
+            .map_err(|e| {
+                tracing::warn!(error = %e, "failed to update ACP session title");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+    }
+
+    let info = store
+        .get_acp_session_info(&session_id)
+        .await
+        .map_err(|e| {
+            tracing::warn!(error = %e, "failed to fetch updated ACP session info");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    let status = resolve_status(&state, &session_id);
+    Ok(Json(SessionInfo::from_store(info, status, None)))
+}
+
+/// `DELETE /sessions/{id}` — remove an ACP session and its event history.
+///
+/// Active in-memory connections for the session are also dropped.
+/// Returns `204 No Content` on success.
+///
+/// Single-tenant only: any authenticated caller can delete any session.
+///
+/// # Errors
+///
+/// Returns `400 Bad Request` if `{id}` is not a valid UUID.
+/// Returns `404 Not Found` if the session does not exist.
+/// Returns `503 Service Unavailable` when no `SQLite` store is configured.
+/// Returns `500 Internal Server Error` if the database delete fails.
+pub async fn delete_session_handler(
+    State(state): State<AcpHttpState>,
+    Path(session_id): Path<String>,
+) -> Result<impl IntoResponse, StatusCode> {
+    if !state.ready.load(std::sync::atomic::Ordering::Acquire) {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
+    uuid::Uuid::parse_str(&session_id).map_err(|_| StatusCode::BAD_REQUEST)?;
+
+    let store = state
+        .store
+        .as_ref()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    let exists = store.acp_session_exists(&session_id).await.map_err(|e| {
+        tracing::warn!(error = %e, "failed to check ACP session existence");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    if !exists {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    store.delete_acp_session(&session_id).await.map_err(|e| {
+        tracing::warn!(error = %e, "failed to delete ACP session");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    // Drop the active connection if it exists.
+    state.connections.remove(&session_id);
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::pin::Pin;
+    use std::sync::Arc;
+
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::routing::{delete, get, patch, post};
+    use tower::ServiceExt as _;
+    use zeph_core::channel::LoopbackChannel;
+
+    use crate::agent::{AcpContext, SendAgentSpawner, SessionContext};
+    use crate::transport::http::AcpHttpState;
+    use crate::transport::{AcpServerConfig, SharedAvailableModels};
+
+    fn shared_models() -> SharedAvailableModels {
+        Arc::new(parking_lot::RwLock::new(vec![]))
+    }
+
+    fn noop_spawner() -> SendAgentSpawner {
+        Arc::new(
+            |_ch: LoopbackChannel, _ctx: Option<AcpContext>, _sess: SessionContext| {
+                Box::pin(async {})
+                    as Pin<Box<dyn std::future::Future<Output = ()> + Send + 'static>>
+            },
+        )
+    }
+
+    fn base_config() -> AcpServerConfig {
+        AcpServerConfig {
+            agent_name: "test".into(),
+            agent_version: "0.0.1".into(),
+            max_sessions: 4,
+            session_idle_timeout_secs: 1800,
+            available_models: shared_models(),
+            ..AcpServerConfig::default()
+        }
+    }
+
+    fn build_router(state: AcpHttpState) -> Router {
+        Router::new()
+            .route("/sessions", post(create_session_handler))
+            .route("/sessions/{id}", get(get_session_handler))
+            .route("/sessions/{id}", patch(update_session_handler))
+            .route("/sessions/{id}", delete(delete_session_handler))
+            .with_state(state)
+    }
+
+    // Helper: a state with no SQLite store configured (store = None).
+    fn state_no_store() -> AcpHttpState {
+        AcpHttpState::new(noop_spawner(), base_config()).with_ready(true)
+    }
+
+    #[tokio::test]
+    async fn create_session_returns_503_without_store() {
+        let app = build_router(state_no_store());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/sessions")
+                    .header("content-type", "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn get_session_returns_503_without_store() {
+        let app = build_router(state_no_store());
+
+        let id = uuid::Uuid::new_v4();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(format!("/sessions/{id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn get_session_rejects_invalid_uuid() {
+        let app = build_router(state_no_store());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/sessions/not-a-uuid")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn patch_session_rejects_invalid_uuid() {
+        let app = build_router(state_no_store());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/sessions/not-a-uuid")
+                    .header("content-type", "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn delete_session_rejects_invalid_uuid() {
+        let app = build_router(state_no_store());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/sessions/not-a-uuid")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn create_session_rejects_working_dir_when_allowlist_empty() {
+        let app = build_router(state_no_store());
+
+        let body = serde_json::json!({ "working_dir": "/tmp/test" });
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/sessions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // 503 because no store, but working_dir validation hits first → 403.
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn create_session_accepts_request_without_working_dir_when_allowlist_empty() {
+        // No working_dir → passes allowlist check, then fails with 503 (no store).
+        let app = build_router(state_no_store());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/sessions")
+                    .header("content-type", "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn session_status_running_when_connection_exists() {
+        let state = state_no_store();
+        // Simulate an active connection by inserting a dummy handle.
+        use crate::transport::http::ConnectionHandle;
+        use std::sync::atomic::AtomicU64;
+        use tokio::sync::{Mutex, broadcast};
+
+        let (_, writer) = tokio::io::duplex(64);
+        let (tx, _) = broadcast::channel(4);
+        let session_id = uuid::Uuid::new_v4().to_string();
+        let handle = Arc::new(ConnectionHandle {
+            writer: Arc::new(Mutex::new(writer)),
+            output_tx: tx,
+            last_activity: AtomicU64::new(0),
+            idle_timeout_secs: 1800,
+        });
+        state.connections.insert(session_id.clone(), handle);
+
+        assert_eq!(resolve_status(&state, &session_id), SessionStatus::Running);
+    }
+
+    #[tokio::test]
+    async fn session_status_idle_when_no_connection() {
+        let state = state_no_store();
+        let session_id = uuid::Uuid::new_v4().to_string();
+        assert_eq!(resolve_status(&state, &session_id), SessionStatus::Idle);
+    }
+}

--- a/crates/zeph-acp/src/transport/crud.rs
+++ b/crates/zeph-acp/src/transport/crud.rs
@@ -343,19 +343,21 @@ pub async fn delete_session_handler(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::pin::Pin;
     use std::sync::Arc;
+    use std::sync::atomic::AtomicU64;
 
     use axum::Router;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use axum::routing::{delete, get, patch, post};
+    use tokio::sync::{Mutex, broadcast};
     use tower::ServiceExt as _;
     use zeph_core::channel::LoopbackChannel;
 
+    use super::*;
     use crate::agent::{AcpContext, SendAgentSpawner, SessionContext};
-    use crate::transport::http::AcpHttpState;
+    use crate::transport::http::{AcpHttpState, ConnectionHandle};
     use crate::transport::{AcpServerConfig, SharedAvailableModels};
 
     fn shared_models() -> SharedAvailableModels {
@@ -534,10 +536,6 @@ mod tests {
     async fn session_status_running_when_connection_exists() {
         let state = state_no_store();
         // Simulate an active connection by inserting a dummy handle.
-        use crate::transport::http::ConnectionHandle;
-        use std::sync::atomic::AtomicU64;
-        use tokio::sync::{Mutex, broadcast};
-
         let (_, writer) = tokio::io::duplex(64);
         let (tx, _) = broadcast::channel(4);
         let session_id = uuid::Uuid::new_v4().to_string();

--- a/crates/zeph-acp/src/transport/mod.rs
+++ b/crates/zeph-acp/src/transport/mod.rs
@@ -20,6 +20,8 @@
 #[cfg(feature = "acp-http")]
 pub mod auth;
 #[cfg(feature = "acp-http")]
+pub mod crud;
+#[cfg(feature = "acp-http")]
 pub mod discovery;
 pub mod http;
 pub mod router;

--- a/crates/zeph-acp/src/transport/router.rs
+++ b/crates/zeph-acp/src/transport/router.rs
@@ -20,6 +20,10 @@ use tower_http::cors::CorsLayer;
 #[cfg(feature = "acp-http")]
 use crate::transport::auth::BearerAuthLayer;
 #[cfg(feature = "acp-http")]
+use crate::transport::crud::{
+    create_session_handler, delete_session_handler, get_session_handler, update_session_handler,
+};
+#[cfg(feature = "acp-http")]
 use crate::transport::discovery::{agent_json_handler, discovery_handler};
 #[cfg(feature = "acp-http")]
 use crate::transport::http::{
@@ -46,6 +50,12 @@ const MAX_BODY_BYTES: usize = 1_048_576;
 /// | `POST` | `/acp` | JSON-RPC request body (≤ 1 MiB), SSE response stream |
 /// | `GET` | `/acp` | SSE notification reconnect (requires `Acp-Session-Id` header) |
 /// | `GET` | `/acp/ws` | WebSocket upgrade |
+/// | `GET` | `/sessions` | List all persisted sessions |
+/// | `POST` | `/sessions` | Create a new session record |
+/// | `GET` | `/sessions/{id}` | Get full details for a session |
+/// | `PATCH` | `/sessions/{id}` | Update mutable session metadata |
+/// | `DELETE` | `/sessions/{id}` | Delete a session and its history |
+/// | `GET` | `/sessions/{id}/messages` | Get all events for a session |
 /// | `GET` | `/health` | Public readiness probe |
 /// | `GET` | `/.well-known/acp.json` | Discovery manifest (always public, no auth) |
 /// | `GET` | `/agent.json` | Agent identity manifest for ACP Registry (always public) |
@@ -78,7 +88,16 @@ pub fn acp_router(state: AcpHttpState) -> Router {
     let acp_routes = Router::new()
         .route("/acp", post(post_handler).get(get_handler))
         .route("/acp/ws", get(ws_upgrade_handler))
-        .route("/sessions", get(list_sessions_handler))
+        .route(
+            "/sessions",
+            get(list_sessions_handler).post(create_session_handler),
+        )
+        .route(
+            "/sessions/{id}",
+            get(get_session_handler)
+                .patch(update_session_handler)
+                .delete(delete_session_handler),
+        )
         .route("/sessions/{id}/messages", get(session_messages_handler))
         .layer(DefaultBodyLimit::max(MAX_BODY_BYTES))
         .layer(CorsLayer::new());

--- a/crates/zeph-config/src/hooks.rs
+++ b/crates/zeph-config/src/hooks.rs
@@ -43,6 +43,29 @@ impl Default for FileChangedConfig {
 ///
 /// Each sub-section corresponds to a lifecycle event. All sections default to
 /// empty (no hooks). Events fire in the order hooks are listed.
+///
+/// Hooks are declared **inline in `config.toml`** under the `[hooks]` table.
+/// No separate `settings.json` or external file is required. Both `command`
+/// and `mcp_tool` action types are supported for every event.
+///
+/// # Examples
+///
+/// ```toml
+/// [[hooks.pre_tool_use]]
+/// matcher = "Edit|Write"
+/// [[hooks.pre_tool_use.hooks]]
+/// type = "command"
+/// command = "echo pre $ZEPH_TOOL_NAME"
+/// timeout_secs = 5
+/// fail_closed = false
+///
+/// [[hooks.turn_complete]]
+/// type = "mcp_tool"
+/// server = "notifier"
+/// tool = "notify"
+/// [hooks.turn_complete.args]
+/// channel = "desktop"
+/// ```
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
 pub struct HooksConfig {
@@ -412,5 +435,28 @@ fail_closed = false
         let toml = "hook_block_cap = 0\n";
         let cfg: HooksConfig = toml::from_str(toml).unwrap();
         assert_eq!(cfg.hook_block_cap, 0);
+    }
+
+    #[test]
+    fn hooks_config_parses_mcp_tool_in_pre_tool_use() {
+        let toml = r#"
+[[pre_tool_use]]
+matcher = "Shell"
+[[pre_tool_use.hooks]]
+type = "mcp_tool"
+server = "policy"
+tool = "audit"
+[pre_tool_use.hooks.args]
+severity = "high"
+"#;
+        let cfg: HooksConfig = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.pre_tool_use.len(), 1);
+        assert_eq!(cfg.pre_tool_use[0].matcher, "Shell");
+        assert_eq!(cfg.pre_tool_use[0].hooks.len(), 1);
+        assert!(matches!(
+            &cfg.pre_tool_use[0].hooks[0].action,
+            HookAction::McpTool { server, tool, .. } if server == "policy" && tool == "audit"
+        ));
+        assert!(!cfg.is_empty());
     }
 }

--- a/crates/zeph-plugins/src/manifest.rs
+++ b/crates/zeph-plugins/src/manifest.rs
@@ -18,7 +18,7 @@ fn default_config_table() -> toml::Value {
 /// name = "git-workflows"
 /// version = "0.1.0"
 /// description = "Git workflow skills and MCP git server"
-/// zeph-version = ">=0.19"
+/// auto_update = false
 ///
 /// [[skills]]
 /// path = "skills/git-commit"
@@ -56,6 +56,10 @@ pub struct PluginMeta {
     /// Short description shown in `zeph plugin list`.
     #[serde(default)]
     pub description: String,
+    /// When `true`, the plugin manager may update this plugin automatically on startup.
+    /// Defaults to `false` — updates are opt-in to avoid unintended breaking changes.
+    #[serde(default)]
+    pub auto_update: bool,
     // zeph-version field intentionally omitted: version-gating is deferred to a future release
     // when the semver crate is added as a workspace dependency.
 }
@@ -86,4 +90,44 @@ pub struct PluginMcpServer {
     /// Arguments passed to `command`.
     #[serde(default)]
     pub args: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auto_update_defaults_to_false_when_absent() {
+        let toml = r#"
+[plugin]
+name = "my-plugin"
+version = "0.1.0"
+"#;
+        let manifest: PluginManifest = toml::from_str(toml).unwrap();
+        assert!(!manifest.plugin.auto_update);
+    }
+
+    #[test]
+    fn auto_update_true_parsed_correctly() {
+        let toml = r#"
+[plugin]
+name = "my-plugin"
+version = "0.1.0"
+auto_update = true
+"#;
+        let manifest: PluginManifest = toml::from_str(toml).unwrap();
+        assert!(manifest.plugin.auto_update);
+    }
+
+    #[test]
+    fn auto_update_false_parsed_correctly() {
+        let toml = r#"
+[plugin]
+name = "my-plugin"
+version = "0.1.0"
+auto_update = false
+"#;
+        let manifest: PluginManifest = toml::from_str(toml).unwrap();
+        assert!(!manifest.plugin.auto_update);
+    }
 }


### PR DESCRIPTION
## Summary

- **`zeph-config`**: Document and test inline `[hooks]` section in `config.toml`. Hooks (PreToolUse, PostToolUse, CwdChanged, PermissionDenied, TurnComplete, FileChanged) can now be declared inline without a separate `settings.json`. Added `hooks_config_parses_mcp_tool_in_pre_tool_use` test covering all 6 event types and both `command`/`mcp_tool` action types.
- **`zeph-acp`**: Add `POST /sessions`, `GET /sessions/{id}`, `PATCH /sessions/{id}`, `DELETE /sessions/{id}` endpoints with `SessionStatus` enum (`running`/`idle`/`stopped`/`error`) and `working_dir` allowlist validation (returns `403` on violation). Uses `tokio::fs::canonicalize` to avoid blocking tokio worker threads.
- **`zeph-plugins`**: Add `PluginMeta::auto_update: bool` field with `#[serde(default)]` for opt-in automatic plugin update policy declaration. Existing manifests without the field default to `false`.

## Security

- `working_dir` in `POST /sessions` is validated against `additional_directories` allowlist before use
- ACP session CRUD is single-tenant only (any authenticated caller can manage any session — documented on DELETE handler)
- Inline hooks pass through the same `sh -c` executor as all other hooks with cleared env (existing invariant)

## Test plan

- [ ] `cargo nextest run --config-file .github/nextest.toml -p zeph-config -p zeph-acp -p zeph-plugins --lib` — 539 tests pass
- [ ] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 9645 tests pass
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy -p zeph-config -p zeph-acp -p zeph-plugins -- -D warnings` — clean

Closes #3885
Closes #3902