### PR TITLE
fix(plugins,memory): enforce await-discipline timeout guards

### DIFF
--- a/crates/zeph-config/src/memory.rs
+++ b/crates/zeph-config/src/memory.rs
@@ -1008,6 +1008,8 @@ pub struct MemoryConfig {
 /// validation_enabled = false
 /// validation_threshold = 0.6
 /// max_escalations = 1
+/// classifier_timeout_secs = 5
+/// validator_timeout_secs = 5
 /// ```
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
@@ -1031,6 +1033,14 @@ pub struct TieredRetrievalConfig {
     pub validation_threshold: f32,
     /// Maximum tier escalations per query. Default: `1`.
     pub max_escalations: u8,
+    /// Timeout in seconds for the classifier LLM call. Default: `5`.
+    ///
+    /// On timeout the pipeline falls back to the `HeuristicRouter` (fail-open).
+    pub classifier_timeout_secs: u64,
+    /// Timeout in seconds for the validator LLM call. Default: `5`.
+    ///
+    /// On timeout the validator is treated as sufficient (fail-open).
+    pub validator_timeout_secs: u64,
 }
 
 impl Default for TieredRetrievalConfig {
@@ -1043,6 +1053,8 @@ impl Default for TieredRetrievalConfig {
             validation_enabled: false,
             validation_threshold: 0.6,
             max_escalations: 1,
+            classifier_timeout_secs: 5,
+            validator_timeout_secs: 5,
         }
     }
 }

--- a/crates/zeph-memory/src/tiered_retrieval.rs
+++ b/crates/zeph-memory/src/tiered_retrieval.rs
@@ -151,7 +151,7 @@ pub async fn recall_tiered(
             0.7,
         );
         let decision = if let Ok(d) = tokio::time::timeout(
-            std::time::Duration::from_secs(5),
+            std::time::Duration::from_secs(config.classifier_timeout_secs),
             hybrid.classify_async(query),
         )
         .await
@@ -220,6 +220,7 @@ async fn escalation_loop(
                 query,
                 &messages,
                 config.validation_threshold,
+                config.validator_timeout_secs,
             )
             .instrument(tracing::debug_span!("memory.tiered.validate"))
             .await;
@@ -299,6 +300,7 @@ async fn validate_evidence(
     query: &str,
     messages: &[RecalledMessage],
     threshold: f32,
+    timeout_secs: u64,
 ) -> bool {
     use zeph_llm::provider::{LlmProvider as _, Message, MessageMetadata, Role};
 
@@ -344,7 +346,12 @@ async fn validate_evidence(
         },
     ];
 
-    match tokio::time::timeout(std::time::Duration::from_secs(5), provider.chat(&msgs)).await {
+    match tokio::time::timeout(
+        std::time::Duration::from_secs(timeout_secs),
+        provider.chat(&msgs),
+    )
+    .await
+    {
         Ok(Ok(raw)) => parse_validation_response(&raw, threshold),
         Ok(Err(e)) => {
             tracing::warn!(error = %e, "tiered: validator LLM call failed, treating as sufficient");
@@ -493,6 +500,26 @@ mod tests {
         assert_eq!(cfg.token_budget, 4096);
         assert!(!cfg.validation_enabled);
         assert_eq!(cfg.max_escalations, 1);
+        // Verify config-driven timeout defaults (fix #4250).
+        assert_eq!(cfg.classifier_timeout_secs, 5);
+        assert_eq!(cfg.validator_timeout_secs, 5);
+    }
+
+    #[test]
+    fn tiered_retrieval_config_timeout_fields_propagate() {
+        // Verify that custom timeout values survive a round-trip through the struct.
+        let cfg = TieredRetrievalConfig {
+            classifier_timeout_secs: 10,
+            validator_timeout_secs: 15,
+            ..TieredRetrievalConfig::default()
+        };
+        assert_eq!(cfg.classifier_timeout_secs, 10);
+        assert_eq!(cfg.validator_timeout_secs, 15);
+        // Confirm the durations would be built correctly from the fields.
+        let classifier_dur = std::time::Duration::from_secs(cfg.classifier_timeout_secs);
+        let validator_dur = std::time::Duration::from_secs(cfg.validator_timeout_secs);
+        assert_eq!(classifier_dur.as_secs(), 10);
+        assert_eq!(validator_dur.as_secs(), 15);
     }
 
     #[test]
@@ -649,7 +676,7 @@ mod tests {
 
     /// Test 4a: `validate_evidence` returns `true` (fail-open) when the validator LLM times out.
     ///
-    /// Uses `with_delay` to force the validator past the 5-second timeout threshold.
+    /// Uses `with_delay` to force the validator past the configured timeout threshold.
     /// The pipeline must treat a timed-out validator as sufficient (fail-open) and not escalate.
     #[tokio::test]
     async fn validate_evidence_timeout_is_fail_open() {
@@ -670,7 +697,7 @@ mod tests {
             .await
             .expect("remember");
 
-        // Delay > 5 s causes the internal tokio::time::timeout in validate_evidence to fire.
+        // Delay > validator_timeout_secs causes the internal tokio::time::timeout to fire.
         let slow_mock = MockProvider::default().with_delay(6_000);
         let validator = Arc::new(AnyProvider::Mock(slow_mock));
 
@@ -679,6 +706,7 @@ mod tests {
             validation_enabled: true,
             validation_threshold: 0.6,
             max_escalations: 1,
+            validator_timeout_secs: 5,
             ..TieredRetrievalConfig::default()
         };
 

--- a/crates/zeph-plugins/Cargo.toml
+++ b/crates/zeph-plugins/Cargo.toml
@@ -23,6 +23,7 @@ sha2.workspace = true
 tar.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
+tokio = { workspace = true, features = ["time"] }
 toml.workspace = true
 tracing.workspace = true
 walkdir = { workspace = true }

--- a/crates/zeph-plugins/src/manager.rs
+++ b/crates/zeph-plugins/src/manager.rs
@@ -89,6 +89,8 @@ pub struct PluginManager {
     base_allowed_commands: Vec<String>,
     /// Path to the integrity registry file. Injected so tests can use isolated paths.
     integrity_registry_path: PathBuf,
+    /// Timeout in seconds for each HTTP phase of [`Self::add_remote`] (connect + body read).
+    download_timeout_secs: u64,
 }
 
 impl PluginManager {
@@ -127,7 +129,18 @@ impl PluginManager {
             mcp_allowed_commands,
             base_allowed_commands,
             integrity_registry_path,
+            download_timeout_secs: 30,
         }
+    }
+
+    /// Override the HTTP download timeout used by [`Self::add_remote`].
+    ///
+    /// Each phase (connect and body read) is independently bounded by this value.
+    /// The default is 30 seconds.
+    #[must_use]
+    pub fn with_download_timeout_secs(mut self, secs: u64) -> Self {
+        self.download_timeout_secs = secs;
+        self
     }
 
     /// Override the integrity registry path. Intended for tests only.
@@ -316,8 +329,14 @@ impl PluginManager {
         let span = tracing::info_span!("plugins.manager.add_remote", %url);
         let _guard = span.enter();
 
-        let response = reqwest::get(url)
+        let timeout = std::time::Duration::from_secs(self.download_timeout_secs);
+
+        let response = tokio::time::timeout(timeout, reqwest::get(url))
             .await
+            .map_err(|_| PluginError::DownloadFailed {
+                url: url.to_owned(),
+                reason: format!("download timed out after {}s", self.download_timeout_secs),
+            })?
             .map_err(|e| PluginError::DownloadFailed {
                 url: url.to_owned(),
                 reason: e.to_string(),
@@ -330,9 +349,12 @@ impl PluginManager {
             });
         }
 
-        let bytes = response
-            .bytes()
+        let bytes = tokio::time::timeout(timeout, response.bytes())
             .await
+            .map_err(|_| PluginError::DownloadFailed {
+                url: url.to_owned(),
+                reason: format!("download timed out after {}s", self.download_timeout_secs),
+            })?
             .map_err(|e| PluginError::DownloadFailed {
                 url: url.to_owned(),
                 reason: format!("failed to read response body: {e}"),
@@ -1694,6 +1716,48 @@ path = "skills/no-skill-md"
         let result = mgr.add_remote(&url, Some(&expected_hash)).await.unwrap();
         assert_eq!(result.name, "remote-plugin");
         assert!(result.installed_skills.contains(&"my-skill".to_owned()));
+    }
+
+    #[tokio::test]
+    async fn add_remote_connect_timeout_returns_download_failed() {
+        use std::time::Duration;
+
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source");
+        write_plugin(
+            &source,
+            "timeout-plugin",
+            &simple_manifest("timeout-plugin", "t-skill"),
+            &[("t-skill", "body")],
+        );
+
+        let archive = build_tar_gz(&source);
+
+        let mock_server = MockServer::start().await;
+        // Delay > download_timeout_secs (1s) triggers the tokio::time::timeout guard.
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(archive)
+                    .set_delay(Duration::from_secs(3)),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let plugins_dir = tmp.path().join("plugins");
+        let managed_dir = tmp.path().join("managed");
+        let mgr = PluginManager::new(plugins_dir, managed_dir, vec![], vec![])
+            .with_download_timeout_secs(1);
+
+        let url = format!("{}/timeout-plugin.tar.gz", mock_server.uri());
+        let err = mgr.add_remote(&url, None).await.unwrap_err();
+        assert!(
+            matches!(err, PluginError::DownloadFailed { ref reason, .. } if reason.contains("timed out")),
+            "slow response must produce DownloadFailed with timeout message, got {err:?}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **#4249**: both `reqwest::get` and `response.bytes()` in `PluginManager::add_remote` are now wrapped with `tokio::time::timeout`. Added `download_timeout_secs` field (default 30s) to `PluginManager`; timeout returns `PluginError::DownloadFailed("download timed out after {N}s")`.
- **#4250**: replaced hardcoded `Duration::from_secs(5)` literals in `recall_tiered` with `TieredRetrievalConfig` fields `classifier_timeout_secs` and `validator_timeout_secs` (both default 5, `#[serde(default)]` for backward compatibility).
- Added regression tests: wiremock-based timeout test for `PluginManager`; config-propagation tests for `TieredRetrievalConfig`.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --features "desktop,ide,server,chat,pdf,scheduler" -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 9643 passed, 0 failures
- [x] New wiremock test verifies `DownloadFailed` when HTTP stalls past timeout
- [x] New config test verifies custom `classifier_timeout_secs` / `validator_timeout_secs` propagate to `Duration` used in `recall_tiered`

Closes #4249
Closes #4250