### PR TITLE
feat(context,memory): add compaction_provider and shutdown_summary_provider config fields

### DIFF
--- a/crates/zeph-agent-context/src/state.rs
+++ b/crates/zeph-agent-context/src/state.rs
@@ -370,7 +370,7 @@ impl ContextSummarizationView<'_> {
 /// Each handle is an `Arc`-backed clone, suitable for moving into spawned tasks
 /// or passing across async boundaries.
 pub struct ProviderHandles {
-    /// Primary LLM provider used for completions and compaction.
+    /// Primary LLM provider used for completions.
     pub primary: AnyProvider,
     /// Dedicated embedding provider.
     pub embedding: AnyProvider,
@@ -378,6 +378,10 @@ pub struct ProviderHandles {
     ///
     /// Falls back to `primary` when the `[skills] disambiguate_provider` config field is empty.
     pub disambiguate: AnyProvider,
+    /// Provider used for deferred tool-pair summarization (context compaction).
+    ///
+    /// Falls back to `primary` when the `[memory] compaction_provider` config field is empty.
+    pub compaction: AnyProvider,
 }
 
 /// Abstract status sink for emitting short progress strings to the channel.

--- a/crates/zeph-agent-context/src/summarization/deferred.rs
+++ b/crates/zeph-agent-context/src/summarization/deferred.rs
@@ -152,7 +152,7 @@ pub(crate) async fn maybe_summarize_tool_pair(
             metadata: MessageMetadata::default(),
         }];
         status.send_status("summarizing output...").await;
-        let chat_fut = providers.primary.chat(&msgs);
+        let chat_fut = providers.compaction.chat(&msgs);
         let summary = match tokio::time::timeout(llm_timeout, chat_fut).await {
             Ok(Ok(s)) => s,
             Ok(Err(e)) => {

--- a/crates/zeph-config/src/memory.rs
+++ b/crates/zeph-config/src/memory.rs
@@ -789,6 +789,30 @@ pub struct MemoryConfig {
     /// Default: `10`.
     #[serde(default = "default_shutdown_summary_timeout_secs")]
     pub shutdown_summary_timeout_secs: u64,
+    /// LLM provider used for shutdown summarization calls.
+    ///
+    /// Accepts a provider name from `[[llm.providers]]`. When empty, falls back to the primary
+    /// provider. Use a fast, cost-efficient model (e.g. `"fast"`) to minimise shutdown latency.
+    ///
+    /// Example:
+    /// ```toml
+    /// [memory]
+    /// shutdown_summary_provider = "fast"
+    /// ```
+    #[serde(default)]
+    pub shutdown_summary_provider: ProviderName,
+    /// LLM provider used for deferred tool-pair summarization (context compaction).
+    ///
+    /// Accepts a provider name from `[[llm.providers]]`. When empty, falls back to the primary
+    /// provider. A mid-tier model is usually sufficient for compaction summaries.
+    ///
+    /// Example:
+    /// ```toml
+    /// [memory]
+    /// compaction_provider = "fast"
+    /// ```
+    #[serde(default)]
+    pub compaction_provider: ProviderName,
     /// Use structured anchored summaries for context compaction.
     ///
     /// When enabled, hard compaction requests a JSON schema from the LLM
@@ -3669,5 +3693,53 @@ mod apex_mem_quality_gate_config_tests {
         let cfg: WriteQualityGateConfig = toml::from_str("").unwrap();
         assert!(!cfg.enabled, "empty TOML must produce default (disabled)");
         assert_eq!(cfg.recent_window, 32);
+    }
+
+    #[test]
+    fn memory_config_shutdown_summary_provider_toml_roundtrip() {
+        let toml = r#"
+            history_limit = 50
+            shutdown_summary_provider = "fast"
+        "#;
+        let cfg: MemoryConfig = toml::from_str(toml).expect("must deserialize");
+        assert_eq!(
+            cfg.shutdown_summary_provider.as_str(),
+            "fast",
+            "shutdown_summary_provider must deserialize from TOML"
+        );
+    }
+
+    #[test]
+    fn memory_config_shutdown_summary_provider_default_is_empty() {
+        let cfg: MemoryConfig = toml::from_str("history_limit = 50").expect("must deserialize");
+        assert_eq!(
+            cfg.shutdown_summary_provider.as_str(),
+            "",
+            "shutdown_summary_provider must default to empty string"
+        );
+    }
+
+    #[test]
+    fn memory_config_compaction_provider_toml_roundtrip() {
+        let toml = r#"
+            history_limit = 50
+            compaction_provider = "mid"
+        "#;
+        let cfg: MemoryConfig = toml::from_str(toml).expect("must deserialize");
+        assert_eq!(
+            cfg.compaction_provider.as_str(),
+            "mid",
+            "compaction_provider must deserialize from TOML"
+        );
+    }
+
+    #[test]
+    fn memory_config_compaction_provider_default_is_empty() {
+        let cfg: MemoryConfig = toml::from_str("history_limit = 50").expect("must deserialize");
+        assert_eq!(
+            cfg.compaction_provider.as_str(),
+            "",
+            "compaction_provider must default to empty string"
+        );
     }
 }

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -256,6 +256,8 @@ impl Default for Config {
                 shutdown_summary_min_messages: 4,
                 shutdown_summary_max_messages: 20,
                 shutdown_summary_timeout_secs: 30,
+                shutdown_summary_provider: crate::providers::ProviderName::default(),
+                compaction_provider: crate::providers::ProviderName::default(),
                 structured_summaries: false,
                 tiers: TierConfig::default(),
                 admission: crate::memory::AdmissionConfig::default(),

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -161,6 +161,15 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Set the provider name used for deferred tool-pair summarization (context compaction).
+    ///
+    /// Accepts a name from `[[llm.providers]]`. Empty string → fall back to the primary provider.
+    #[must_use]
+    pub fn with_compaction_provider(mut self, provider_name: impl Into<String>) -> Self {
+        self.services.memory.compaction.compaction_provider_name = provider_name.into();
+        self
+    }
+
     // ---- Memory Formatting ----
 
     /// Configure the memory snippet rendering format for context assembly (MM-F5, #3340).
@@ -269,6 +278,15 @@ impl<C: Channel> Agent<C> {
             .memory
             .compaction
             .shutdown_summary_timeout_secs = timeout_secs;
+        self
+    }
+
+    /// Set the provider name used for shutdown summarization LLM calls.
+    ///
+    /// Accepts a name from `[[llm.providers]]`. Empty string → fall back to the primary provider.
+    #[must_use]
+    pub fn with_shutdown_summary_provider(mut self, provider_name: impl Into<String>) -> Self {
+        self.services.memory.compaction.shutdown_summary_provider = provider_name.into();
         self
     }
 

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -47,10 +47,13 @@ impl<C: Channel> Agent<C> {
     pub(in crate::agent) fn providers(&self) -> zeph_agent_context::state::ProviderHandles {
         let disambiguate =
             self.resolve_background_provider(&self.services.skill.disambiguate_provider_name);
+        let compaction = self
+            .resolve_background_provider(&self.services.memory.compaction.compaction_provider_name);
         zeph_agent_context::state::ProviderHandles {
             primary: self.provider.clone(),
             embedding: self.embedding_provider.clone(),
             disambiguate,
+            compaction,
         }
     }
 

--- a/crates/zeph-core/src/agent/context/summarization/mod.rs
+++ b/crates/zeph-core/src/agent/context/summarization/mod.rs
@@ -32,8 +32,21 @@ impl<C: Channel> Agent<C> {
         > = std::sync::Arc::new(
             zeph_agent_context::memory_backend::TokenCounterAdapter::new(token_counter),
         );
+        let compaction_provider = {
+            let name = self
+                .services
+                .memory
+                .compaction
+                .compaction_provider_name
+                .clone();
+            if name.is_empty() {
+                self.summary_or_primary_provider().clone()
+            } else {
+                self.resolve_background_provider(&name)
+            }
+        };
         SummarizationDeps {
-            provider: self.summary_or_primary_provider().clone(),
+            provider: compaction_provider,
             llm_timeout: std::time::Duration::from_secs(self.runtime.config.timeouts.llm_seconds),
             token_counter: token_counter_adapter,
             structured_summaries: self.services.memory.compaction.structured_summaries,

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -392,6 +392,9 @@ impl<C: Channel> Agent<C> {
         &self,
         chat_messages: &[Message],
     ) -> Option<zeph_memory::StructuredSummary> {
+        let provider = self.resolve_background_provider(
+            &self.services.memory.compaction.shutdown_summary_provider,
+        );
         let timeout_dur = std::time::Duration::from_secs(
             self.services
                 .memory
@@ -400,8 +403,7 @@ impl<C: Channel> Agent<C> {
         );
         match tokio::time::timeout(
             timeout_dur,
-            self.provider
-                .chat_typed_erased::<zeph_memory::StructuredSummary>(chat_messages),
+            provider.chat_typed_erased::<zeph_memory::StructuredSummary>(chat_messages),
         )
         .await
         {
@@ -410,7 +412,7 @@ impl<C: Channel> Agent<C> {
                 tracing::warn!(
                     "shutdown summary: structured LLM call failed, falling back to plain: {e:#}"
                 );
-                self.plain_text_summary_fallback(chat_messages, timeout_dur)
+                self.plain_text_summary_fallback(&provider, chat_messages, timeout_dur)
                     .await
             }
             Err(_) => {
@@ -421,7 +423,7 @@ impl<C: Channel> Agent<C> {
                         .compaction
                         .shutdown_summary_timeout_secs
                 );
-                self.plain_text_summary_fallback(chat_messages, timeout_dur)
+                self.plain_text_summary_fallback(&provider, chat_messages, timeout_dur)
                     .await
             }
         }
@@ -429,10 +431,11 @@ impl<C: Channel> Agent<C> {
 
     async fn plain_text_summary_fallback(
         &self,
+        provider: &zeph_llm::any::AnyProvider,
         chat_messages: &[Message],
         timeout_dur: std::time::Duration,
     ) -> Option<zeph_memory::StructuredSummary> {
-        match tokio::time::timeout(timeout_dur, self.provider.chat(chat_messages)).await {
+        match tokio::time::timeout(timeout_dur, provider.chat(chat_messages)).await {
             Ok(Ok(plain)) => Some(zeph_memory::StructuredSummary {
                 summary: plain,
                 key_facts: vec![],

--- a/crates/zeph-core/src/agent/state/compaction.rs
+++ b/crates/zeph-core/src/agent/state/compaction.rs
@@ -24,6 +24,14 @@ pub(crate) struct MemoryCompactionState {
     pub(crate) shutdown_summary_max_messages: usize,
     /// Timeout (in seconds) for the shutdown summary LLM call.
     pub(crate) shutdown_summary_timeout_secs: u64,
+    /// Provider name for shutdown summarization LLM calls.
+    ///
+    /// Empty string → fall back to the primary provider via `resolve_background_provider`.
+    pub(crate) shutdown_summary_provider: String,
+    /// Provider name for deferred tool-pair summarization (context compaction).
+    ///
+    /// Empty string → fall back to the primary provider via `resolve_background_provider`.
+    pub(crate) compaction_provider_name: String,
     /// When `true`, hard compaction uses `AnchoredSummary` (structured JSON) instead of
     /// free-form prose. Falls back to prose on any LLM or validation failure.
     pub(crate) structured_summaries: bool,
@@ -47,6 +55,8 @@ impl Default for MemoryCompactionState {
             shutdown_summary_min_messages: 4,
             shutdown_summary_max_messages: 20,
             shutdown_summary_timeout_secs: 30,
+            shutdown_summary_provider: String::new(),
+            compaction_provider_name: String::new(),
             structured_summaries: false,
             digest_config: crate::config::DigestConfig::default(),
             cached_session_digest: None,

--- a/crates/zeph-core/src/agent/tests/shutdown_summary_tests.rs
+++ b/crates/zeph-core/src/agent/tests/shutdown_summary_tests.rs
@@ -588,3 +588,104 @@ fn test_scheduled_task_injection_format() {
     assert!(text.starts_with(crate::agent::SCHEDULED_TASK_PREFIX));
     assert!(text.contains(prompt));
 }
+
+#[test]
+fn with_compaction_provider_builder_sets_field() {
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+
+    let agent =
+        Agent::new(provider, channel, registry, None, 5, executor).with_compaction_provider("fast");
+
+    assert_eq!(
+        agent.services.memory.compaction.compaction_provider_name, "fast",
+        "with_compaction_provider must store the provider name"
+    );
+}
+
+#[test]
+fn with_compaction_provider_empty_string_stores_empty() {
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+
+    let agent =
+        Agent::new(provider, channel, registry, None, 5, executor).with_compaction_provider("");
+
+    assert_eq!(
+        agent.services.memory.compaction.compaction_provider_name, "",
+        "empty compaction_provider_name must be stored as-is (triggers primary fallback)"
+    );
+}
+
+#[test]
+fn compaction_provider_name_default_is_empty() {
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+
+    let agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+    assert_eq!(
+        agent.services.memory.compaction.compaction_provider_name, "",
+        "compaction_provider_name must default to empty string"
+    );
+}
+
+#[test]
+fn with_shutdown_summary_provider_builder_sets_field() {
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+
+    let agent = Agent::new(provider, channel, registry, None, 5, executor)
+        .with_shutdown_summary_provider("quality");
+
+    assert_eq!(
+        agent.services.memory.compaction.shutdown_summary_provider, "quality",
+        "with_shutdown_summary_provider must store the provider name"
+    );
+}
+
+#[test]
+fn shutdown_summary_provider_default_is_empty() {
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+
+    let agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+    assert_eq!(
+        agent.services.memory.compaction.shutdown_summary_provider, "",
+        "shutdown_summary_provider must default to empty string"
+    );
+}
+
+#[test]
+fn providers_compaction_falls_back_to_primary_when_name_empty() {
+    use zeph_llm::LlmProvider as _;
+    use zeph_llm::mock::MockProvider;
+
+    let mut mock = MockProvider::default();
+    mock.name_override = Some("primary-mock".into());
+    let primary = AnyProvider::Mock(mock);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+
+    // No with_compaction_provider call → name stays empty → falls back to primary.
+    let agent = Agent::new(primary, channel, registry, None, 5, executor);
+    let handles = agent.providers();
+
+    assert_eq!(
+        handles.compaction.name(),
+        "primary-mock",
+        "compaction must fall back to primary when compaction_provider_name is empty"
+    );
+}

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2219,6 +2219,8 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         config.memory.shutdown_summary_max_messages,
         config.memory.shutdown_summary_timeout_secs,
     )
+    .with_shutdown_summary_provider(config.memory.shutdown_summary_provider.as_str().to_owned())
+    .with_compaction_provider(config.memory.compaction_provider.as_str().to_owned())
     .with_structured_summaries(config.memory.structured_summaries)
     .with_tool_call_cutoff(config.memory.tool_call_cutoff)
     .with_hybrid_search(config.skills.hybrid_search)


### PR DESCRIPTION
## Summary

- Adds `compaction_provider` field to `MemoryCompactionState` and `ProviderHandles` — wired into both the deferred summarization path (`deferred.rs`) and the main compaction path (`build_summarization_deps()`), resolving at startup via `resolve_background_provider`
- Adds `shutdown_summary_provider` to `MemoryConfig` — wired through `AgentBuilder.with_shutdown_summary_provider()` into `call_llm_for_session_summary()`
- Both fields default to empty string, falling back to primary when unset (backward-compatible)
- 10 unit tests: TOML roundtrip, builder setters, defaults, fallback-to-primary

Closes #3858, Closes #3859

## Test plan

- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 9651 passed
- [x] `cargo clippy --workspace --features desktop,ide,server,chat,pdf,scheduler -- -D warnings` — 0 warnings
- [x] `cargo +nightly fmt --check` — clean
- [x] New fields covered by 10 unit tests (TOML roundtrip, defaults, fallback, builder setters)