### PR TITLE
fix(core,config,skills): add timeout guards and fix scheduler default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-core`: `update_provider_instructions` now wraps `load_instructions_async` in a 5 s
+  timeout; on expiry logs a warning and keeps the previous instruction blocks, preventing an
+  indefinite hang on the provider-switch hot path (closes #4257).
+- `zeph-config`: `SchedulerConfig::default().enabled` changed from `true` to `false`, matching
+  all other subsystem config defaults so the scheduler no longer activates on a freshly created
+  config with no `[scheduler]` section (closes #4255).
+- `zeph-skills`: `SkillMiner::embed_existing` now wraps each `embed_provider.embed()` call in
+  `tokio::time::timeout(generation_timeout_ms)`; on timeout logs a warning and skips the skill
+  instead of blocking the entire mining run (closes #4254).
+
 - `zeph-agent-feedback`: CJK rejection pattern `^違う` now requires a terminal punctuation
   character, whitespace, or end-of-message so that neutral phrases like "違う質問があります"
   ("I have a different question") are no longer classified as ExplicitRejection (closes #3826).

--- a/crates/zeph-config/src/features.rs
+++ b/crates/zeph-config/src/features.rs
@@ -971,7 +971,7 @@ pub struct SchedulerConfig {
 impl Default for SchedulerConfig {
     fn default() -> Self {
         Self {
-            enabled: true,
+            enabled: false,
             tick_interval_secs: default_scheduler_tick_interval(),
             max_tasks: default_scheduler_max_tasks(),
             tasks: Vec::new(),
@@ -1114,6 +1114,15 @@ mod tests {
             ..GatewayConfig::default()
         };
         assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn scheduler_config_default_is_disabled() {
+        let cfg = SchedulerConfig::default();
+        assert!(
+            !cfg.enabled,
+            "scheduler must be opt-in (enabled = false by default)"
+        );
     }
 }
 

--- a/crates/zeph-core/src/agent/provider_cmd.rs
+++ b/crates/zeph-core/src/agent/provider_cmd.rs
@@ -12,6 +12,8 @@ use super::agent_supervisor::TaskClass;
 use crate::channel::Channel;
 use zeph_llm::provider::LlmProvider as _;
 
+const INSTRUCTIONS_RELOAD_TIMEOUT: Duration = Duration::from_secs(5);
+
 impl<C: Channel> Agent<C> {
     /// Restore the last-used provider for the active channel from `SQLite` (#3308).
     ///
@@ -146,13 +148,17 @@ impl<C: Channel> Agent<C> {
         let provider_kinds = reload_state.provider_kinds.clone();
         let explicit_files = reload_state.explicit_files.clone();
         let auto_detect = reload_state.auto_detect;
-        let new_blocks = crate::instructions::load_instructions_async(
+        let load_fut = crate::instructions::load_instructions_async(
             base_dir,
             provider_kinds,
             explicit_files,
             auto_detect,
-        )
-        .await;
+        );
+        let Ok(new_blocks) = tokio::time::timeout(INSTRUCTIONS_RELOAD_TIMEOUT, load_fut).await
+        else {
+            tracing::warn!("instructions reload timed out, keeping previous instructions");
+            return;
+        };
         tracing::info!(
             count = new_blocks.len(),
             provider = ?entry.provider_type,

--- a/crates/zeph-skills/src/miner.rs
+++ b/crates/zeph-skills/src/miner.rs
@@ -716,6 +716,8 @@ mod tests {
 
     #[tokio::test]
     async fn embed_existing_skips_skills_on_timeout() {
+        use crate::loader::load_skill_meta_from_str;
+
         // MockProvider delays embed by 200ms; generation_timeout_ms=1ms forces a timeout.
         // embed_existing must return an empty vec (all skills skipped) without panicking.
         let slow_mock = zeph_llm::any::AnyProvider::Mock(
@@ -740,7 +742,6 @@ mod tests {
             config,
             http: reqwest::Client::new(),
         };
-        use crate::loader::load_skill_meta_from_str;
         let content = "---\nname: slow-skill\ndescription: Slow skill.\n---\n\n## Usage\n\nSlow.\n";
         let (meta, _) = load_skill_meta_from_str(content).unwrap();
         let result = miner.embed_existing(&[meta]).await;

--- a/crates/zeph-skills/src/miner.rs
+++ b/crates/zeph-skills/src/miner.rs
@@ -176,14 +176,23 @@ impl SkillMiner {
     /// Pre-compute embeddings for existing skill descriptions.
     async fn embed_existing(&self, skills: &[SkillMeta]) -> Vec<(String, SkillEmbedding)> {
         let mut embeddings = Vec::with_capacity(skills.len());
+        let timeout = Duration::from_millis(self.config.generation_timeout_ms);
         for skill in skills {
-            match self.embed_provider.embed(&skill.description).await {
-                Ok(emb) => embeddings.push((skill.name.clone(), SkillEmbedding::from_raw(emb))),
-                Err(e) => {
+            let embed_fut = self.embed_provider.embed(&skill.description);
+            match tokio::time::timeout(timeout, embed_fut).await {
+                Ok(Ok(emb)) => embeddings.push((skill.name.clone(), SkillEmbedding::from_raw(emb))),
+                Ok(Err(e)) => {
                     tracing::warn!(
                         skill = %skill.name,
                         error = %e,
                         "failed to embed existing skill for dedup"
+                    );
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        skill = %skill.name,
+                        timeout_ms = self.config.generation_timeout_ms,
+                        "embed timed out, skipping skill for dedup"
                     );
                 }
             }
@@ -703,5 +712,41 @@ mod tests {
         };
         // rpm=0 → max(1) → delay = 60_000ms (1 per minute)
         assert_eq!(miner.request_delay(), Duration::from_mins(1));
+    }
+
+    #[tokio::test]
+    async fn embed_existing_skips_skills_on_timeout() {
+        // MockProvider delays embed by 200ms; generation_timeout_ms=1ms forces a timeout.
+        // embed_existing must return an empty vec (all skills skipped) without panicking.
+        let slow_mock = zeph_llm::any::AnyProvider::Mock(
+            zeph_llm::mock::MockProvider::default().with_embed_delay(200),
+        );
+        let config = MiningConfig {
+            queries: vec![],
+            max_repos_per_query: 20,
+            dedup_threshold: 0.85,
+            output_dir: PathBuf::from("/tmp"),
+            rate_limit_rpm: 25,
+            dry_run: false,
+            generation_timeout_ms: 1,
+        };
+        let miner = SkillMiner {
+            generator: SkillGenerator::new(
+                zeph_llm::any::AnyProvider::Mock(zeph_llm::mock::MockProvider::default()),
+                PathBuf::from("/tmp"),
+            ),
+            embed_provider: slow_mock,
+            github_token: Secret::new(String::new()),
+            config,
+            http: reqwest::Client::new(),
+        };
+        use crate::loader::load_skill_meta_from_str;
+        let content = "---\nname: slow-skill\ndescription: Slow skill.\n---\n\n## Usage\n\nSlow.\n";
+        let (meta, _) = load_skill_meta_from_str(content).unwrap();
+        let result = miner.embed_existing(&[meta]).await;
+        assert!(
+            result.is_empty(),
+            "timed-out embeds must be skipped; got {result:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **#4257** (`zeph-core`): `update_provider_instructions` now wraps `load_instructions_async` in a 5 s `tokio::time::timeout` (constant `INSTRUCTIONS_RELOAD_TIMEOUT`). On expiry, logs a warning and returns early, keeping previous instructions unchanged.
- **#4255** (`zeph-config`): `SchedulerConfig::default().enabled` changed from `true` to `false`, matching every other subsystem config default.
- **#4254** (`zeph-skills`): `embed_existing` now wraps each `embed_provider.embed()` call in `tokio::time::timeout(generation_timeout_ms)`. On timeout, logs a warning and skips the skill — the mining run continues.

## Test plan

- [ ] 9647 unit tests pass (`cargo nextest run --workspace --lib --bins`)
- [ ] New test `scheduler_config_default_is_disabled` in `zeph-config` asserts `enabled = false`
- [ ] New test `embed_existing_skips_skills_on_timeout` in `zeph-skills` verifies timeout-skip path using a mock provider with artificial delay
- [ ] `cargo +nightly fmt --check` clean
- [ ] `cargo clippy --workspace -- -D warnings` clean
- [ ] `cargo doc --no-deps --workspace --features desktop,ide,server,chat,pdf,scheduler` no broken intra-doc links

Closes #4257
Closes #4255
Closes #4254