### PR TITLE
feat(common,skills,tui): event-driven shutdown and error taxonomy improvements

### DIFF
--- a/crates/zeph-common/src/error_taxonomy.rs
+++ b/crates/zeph-common/src/error_taxonomy.rs
@@ -114,7 +114,8 @@ impl ToolInvocationPhase {
 /// assert!(ToolErrorCategory::RateLimited.is_retryable());
 /// assert!(!ToolErrorCategory::InvalidParameters.is_retryable());
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum ToolErrorCategory {
     // ── Initialization failures ──────────────────────────────────────────
     /// Tool name not found in the registry (LLM requested a non-existent tool).

--- a/crates/zeph-common/src/security_event.rs
+++ b/crates/zeph-common/src/security_event.rs
@@ -9,6 +9,7 @@
 /// Category of a security event used for TUI display and audit logging.
 ///
 /// Each variant maps to a short string key via [`SecurityEventCategory::as_str`].
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SecurityEventCategory {
     /// Prompt-injection flag raised by the sanitizer.

--- a/crates/zeph-common/src/task_supervisor.rs
+++ b/crates/zeph-common/src/task_supervisor.rs
@@ -314,6 +314,8 @@ struct Inner {
     /// Limits the number of concurrently running `spawn_blocking` tasks to prevent
     /// runaway thread-pool growth under burst load.
     blocking_semaphore: Arc<tokio::sync::Semaphore>,
+    /// Notified when `active_count()` reaches zero so `shutdown_all` wakes immediately.
+    shutdown_notify: Arc<tokio::sync::Notify>,
 }
 
 // ── Main type ────────────────────────────────────────────────────────────────
@@ -381,6 +383,7 @@ impl TaskSupervisor {
             completion_tx,
             cancel: cancel.clone(),
             blocking_semaphore: Arc::new(tokio::sync::Semaphore::new(8)),
+            shutdown_notify: Arc::new(tokio::sync::Notify::new()),
         });
 
         // Only start the reap driver when a Tokio runtime is available. In synchronous
@@ -697,35 +700,44 @@ impl TaskSupervisor {
     /// unrelated components.
     pub async fn shutdown_all(&self, timeout: Duration) {
         self.inner.cancel.cancel();
-        let deadline = tokio::time::Instant::now() + timeout;
+        let sleep = tokio::time::sleep(timeout);
+        tokio::pin!(sleep);
         loop {
             let active = self.active_count();
             if active == 0 {
                 break;
             }
-            if tokio::time::Instant::now() >= deadline {
-                let mut remaining_names: Vec<Arc<str>> = Vec::new();
-                {
-                    let mut state = self.inner.state.lock();
-                    for entry in state.tasks.values_mut() {
-                        if matches!(
-                            entry.status,
-                            TaskStatus::Running | TaskStatus::Restarting { .. }
-                        ) {
-                            remaining_names.push(Arc::clone(&entry.name));
-                            entry.abort_handle.abort();
-                            entry.status = TaskStatus::Aborted;
+            // Subscribe before re-checking so we cannot miss a notification that
+            // fires between the active_count() call above and the select below.
+            let notified = self.inner.shutdown_notify.notified();
+            tokio::select! {
+                biased;
+                () = notified => {
+                    // reap driver decremented active count — re-check at top of loop
+                }
+                () = &mut sleep => {
+                    let mut remaining_names: Vec<Arc<str>> = Vec::new();
+                    {
+                        let mut state = self.inner.state.lock();
+                        for entry in state.tasks.values_mut() {
+                            if matches!(
+                                entry.status,
+                                TaskStatus::Running | TaskStatus::Restarting { .. }
+                            ) {
+                                remaining_names.push(Arc::clone(&entry.name));
+                                entry.abort_handle.abort();
+                                entry.status = TaskStatus::Aborted;
+                            }
                         }
                     }
+                    tracing::warn!(
+                        remaining = active,
+                        tasks = ?remaining_names,
+                        "shutdown timeout — aborting remaining tasks"
+                    );
+                    break;
                 }
-                tracing::warn!(
-                    remaining = active,
-                    tasks = ?remaining_names,
-                    "shutdown timeout — aborting remaining tasks"
-                );
-                break;
             }
-            tokio::time::sleep(Duration::from_millis(50)).await;
         }
     }
 
@@ -886,12 +898,18 @@ impl TaskSupervisor {
         // Without this, Restart-policy tasks re-register as Running, causing
         // has_active_tasks() to stay true and the drain loop to spin until timeout.
         if inner.cancel.is_cancelled() {
-            let mut state = inner.state.lock();
-            state.tasks.remove(&completion.name);
+            {
+                let mut state = inner.state.lock();
+                state.tasks.remove(&completion.name);
+            }
+            inner.shutdown_notify.notify_waiters();
             return;
         }
 
         let Some((attempt, max, delay)) = Self::classify_completion(inner, &completion) else {
+            // Task removed from registry (RunOnce completed or Restart exhausted) —
+            // wake shutdown_all so it can re-check active_count immediately.
+            inner.shutdown_notify.notify_waiters();
             return;
         };
 

--- a/crates/zeph-skills/src/evolution.rs
+++ b/crates/zeph-skills/src/evolution.rs
@@ -95,12 +95,9 @@ impl From<zeph_common::error_taxonomy::ToolErrorCategory> for FailureKind {
             C::PolicyBlocked | C::ConfirmationRequired | C::ToolNotFound => Self::WrongApproach,
             // LLM-supplied parameters were invalid or mistyped.
             C::InvalidParameters | C::TypeMismatch => Self::SyntaxError,
-            // Infrastructure failures and non-quality outcomes are not attributable to the skill.
-            C::RateLimited
-            | C::ServerError
-            | C::NetworkError
-            | C::PermanentFailure
-            | C::Cancelled => Self::Unknown,
+            // Infrastructure failures, non-quality outcomes, and unknown future variants
+            // are not attributable to the skill.
+            _ => Self::Unknown,
         }
     }
 }

--- a/crates/zeph-tui/src/app/mod.rs
+++ b/crates/zeph-tui/src/app/mod.rs
@@ -1275,6 +1275,7 @@ fn format_security_report(metrics: &MetricsSnapshot) -> String {
             SecurityEventCategory::CrossBoundaryMcpToAcp => "CROSS_BOUNDARY ",
             SecurityEventCategory::VigilFlag => "VIGIL_FLAG     ",
             SecurityEventCategory::GoalDrift => "GOAL_DRIFT     ",
+            _ => "UNKNOWN        ",
         };
         lines.push(format!("  [{ts}] {cat}  {:<20}  {}", ev.source, ev.detail));
     }

--- a/crates/zeph-tui/src/widgets/security.rs
+++ b/crates/zeph-tui/src/widgets/security.rs
@@ -229,6 +229,7 @@ fn append_event_items<'a>(
             }
             SecurityEventCategory::VigilFlag => ("[vigi] ", block_style),
             SecurityEventCategory::GoalDrift => ("[gdft] ", flag_style),
+            _ => ("[unkn] ", Style::default().fg(Color::DarkGray)),
         };
         let hm = format_hm(ev.timestamp);
         items.push(ListItem::new(Line::from(vec![


### PR DESCRIPTION
## Summary

- **#4253**: Replace 50 ms busy-poll in `TaskSupervisor::shutdown_all` with a `tokio::sync::Notify` field. `handle_completion` calls `notify_waiters()` on every active-count decrement; `shutdown_all` uses `tokio::select!` on `notified()` vs a pinned timeout future. Graceful and timeout paths preserved.
- **#4256**: Add `serde::Deserialize` and `#[non_exhaustive]` to `ToolErrorCategory`; add `#[non_exhaustive]` to `SecurityEventCategory`. Update downstream match sites in `zeph-skills` and `zeph-tui` with wildcard arms.

## Changes

- `crates/zeph-common/src/task_supervisor.rs` — event-driven shutdown via `Arc<Notify>`
- `crates/zeph-common/src/error_taxonomy.rs` — `Deserialize` + `#[non_exhaustive]` on `ToolErrorCategory`
- `crates/zeph-common/src/security_event.rs` — `#[non_exhaustive]` on `SecurityEventCategory`
- `crates/zeph-skills/src/evolution.rs` — wildcard arm for non-exhaustive match
- `crates/zeph-tui/src/app/mod.rs` — wildcard arm
- `crates/zeph-tui/src/widgets/security.rs` — wildcard arm

## Test plan

- [x] `cargo nextest run -p zeph-common` — 131/131 pass (covers `test_graceful_shutdown`, `test_shutdown_timeout_expiry`, `test_shutdown_drains_post_cancel_completions`)
- [x] `cargo nextest run --workspace --lib --bins` — 9647/9647 pass
- [x] `cargo clippy --workspace --features desktop,ide,server,chat,pdf,scheduler -- -D warnings` — clean
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [x] `cargo +nightly fmt --check` — clean

Closes #4253
Closes #4256