### PR TITLE
feat(acp,sanitizer): non_exhaustive SessionStatus, AtomicUsize counter, rename circuit check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- `zeph-acp`: `SessionStatus` enum marked `#[non_exhaustive]` — downstream match arms must
+  include a `_ =>` wildcard to remain compatible with future variants (closes #4264).
+- `zeph-sanitizer`: `NliSanitizer::circuit_is_open` renamed to
+  `check_and_maybe_reset_circuit` to make the cooldown-reset side effect explicit (closes #4251).
+
+### Performance
+
+- `zeph-sanitizer`: `SecretMaskRegistry` counter replaced with `AtomicUsize` (lock-free
+  increment); `mask()` now uses a pre-sorted `Vec` cache updated on `register()`, reducing
+  per-call complexity from O(n log n) to O(n). Concurrent `register()` correctness preserved
+  by holding `forward.write()` across the full check-and-insert path (closes #4248).
+
 ### Added
 
 - `zeph-config`: `HooksConfig` — inline `[hooks]` section in `config.toml` for declaring hooks

--- a/crates/zeph-acp/src/transport/crud.rs
+++ b/crates/zeph-acp/src/transport/crud.rs
@@ -22,6 +22,7 @@ use crate::transport::http::AcpHttpState;
 // ── Request / response types ──────────────────────────────────────────────────
 
 /// Status of an ACP session.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SessionStatus {

--- a/crates/zeph-sanitizer/src/nli.rs
+++ b/crates/zeph-sanitizer/src/nli.rs
@@ -155,7 +155,7 @@ impl NliSanitizer {
             return None;
         }
         let provider = self.provider.as_ref()?;
-        if self.circuit_is_open() {
+        if self.check_and_maybe_reset_circuit() {
             warn!("NLI stage: circuit breaker open, skipping check");
             return None;
         }
@@ -214,7 +214,9 @@ impl NliSanitizer {
         }
     }
 
-    fn circuit_is_open(&self) -> bool {
+    // Returns true if the circuit is open (inhibit the NLI call). As a side effect,
+    // resets the circuit when the cooldown has elapsed.
+    fn check_and_maybe_reset_circuit(&self) -> bool {
         let open_at = self.circuit_open_at.load(Ordering::Relaxed);
         if open_at == 0 {
             return false;
@@ -378,13 +380,13 @@ mod tests {
         s.consecutive_timeouts
             .store(CIRCUIT_BREAKER_THRESHOLD, Ordering::Relaxed);
         // Before any open_at is set, circuit is not open.
-        assert!(!s.circuit_is_open());
+        assert!(!s.check_and_maybe_reset_circuit());
         // Set open_at to now — circuit should be open.
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map_or(0, |d| d.as_secs());
         s.circuit_open_at.store(now, Ordering::Relaxed);
-        assert!(s.circuit_is_open());
+        assert!(s.check_and_maybe_reset_circuit());
     }
 
     #[test]
@@ -396,7 +398,7 @@ mod tests {
         s.consecutive_timeouts
             .store(CIRCUIT_BREAKER_THRESHOLD, Ordering::Relaxed);
         // After cooldown check, circuit should be reset.
-        assert!(!s.circuit_is_open());
+        assert!(!s.check_and_maybe_reset_circuit());
         assert_eq!(s.consecutive_timeouts.load(Ordering::Relaxed), 0);
     }
 

--- a/crates/zeph-sanitizer/src/secret_mask.rs
+++ b/crates/zeph-sanitizer/src/secret_mask.rs
@@ -32,8 +32,8 @@
 //! assert!(unmasked.contains("sk-supersecretvalue12345678"));
 //! ```
 
-use std::cmp::Reverse;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use parking_lot::RwLock;
 
@@ -127,10 +127,12 @@ pub struct SecretMaskRegistry {
     forward: RwLock<HashMap<String, String>>,
     /// `placeholder` → `secret_value`  (reverse mapping for unmask)
     reverse: RwLock<HashMap<String, String>>,
+    /// Pre-sorted pairs `(secret, placeholder)` by secret length descending, cached for `mask()`.
+    sorted_pairs: RwLock<Vec<(String, String)>>,
     /// Per-session random nonce (16 hex chars, generated at construction).
     nonce: String,
-    /// Monotonic counter for unique placeholder indexes.
-    counter: RwLock<usize>,
+    /// Monotonic counter for unique placeholder indexes (lock-free).
+    counter: AtomicUsize,
 }
 
 impl std::fmt::Debug for SecretMaskRegistry {
@@ -161,8 +163,9 @@ impl SecretMaskRegistry {
         Self {
             forward: RwLock::new(HashMap::new()),
             reverse: RwLock::new(HashMap::new()),
+            sorted_pairs: RwLock::new(Vec::new()),
             nonce,
-            counter: RwLock::new(0),
+            counter: AtomicUsize::new(0),
         }
     }
 
@@ -186,23 +189,25 @@ impl SecretMaskRegistry {
         if secret_value.len() < MIN_SECRET_LEN {
             return;
         }
-        // Avoid creating duplicate entries for the same secret value.
-        if self.forward.read().contains_key(secret_value) {
+        // Hold the write lock for the entire check-then-insert sequence to prevent a
+        // TOCTOU race where two concurrent callers both pass the contains_key check and
+        // produce duplicate placeholders for the same secret.
+        let mut forward = self.forward.write();
+        if forward.contains_key(secret_value) {
             return;
         }
-        let index = {
-            let mut c = self.counter.write();
-            let idx = *c;
-            *c += 1;
-            idx
-        };
+        let index = self.counter.fetch_add(1, Ordering::Relaxed);
         let placeholder = format!("<SECRET:{}:{}:{}>", category.as_str(), self.nonce, index);
-        self.forward
-            .write()
-            .insert(secret_value.to_owned(), placeholder.clone());
+        forward.insert(secret_value.to_owned(), placeholder.clone());
+        drop(forward);
         self.reverse
             .write()
-            .insert(placeholder, secret_value.to_owned());
+            .insert(placeholder.clone(), secret_value.to_owned());
+
+        // Rebuild the sorted cache: longest secret first to prevent substring collision.
+        let mut pairs = self.sorted_pairs.write();
+        pairs.push((secret_value.to_owned(), placeholder));
+        pairs.sort_unstable_by_key(|(s, _)| std::cmp::Reverse(s.len()));
     }
 
     /// Replace all registered secret values in `text` with their placeholder tokens.
@@ -226,20 +231,13 @@ impl SecretMaskRegistry {
     /// ```
     #[must_use]
     pub fn mask(&self, text: &str) -> String {
-        let forward = self.forward.read();
-        if forward.is_empty() {
+        let pairs = self.sorted_pairs.read();
+        if pairs.is_empty() {
             return text.to_owned();
         }
-        // Sort by value length descending to prevent substring collision.
-        let mut pairs: Vec<(&str, &str)> = forward
-            .iter()
-            .map(|(secret, placeholder)| (secret.as_str(), placeholder.as_str()))
-            .collect();
-        pairs.sort_unstable_by_key(|(secret, _)| Reverse(secret.len()));
-
         let mut result = text.to_owned();
-        for (secret, placeholder) in pairs {
-            result = result.replace(secret, placeholder);
+        for (secret, placeholder) in pairs.iter() {
+            result = result.replace(secret.as_str(), placeholder.as_str());
         }
         result
     }


### PR DESCRIPTION
## Summary

- **#4264** — Add `#[non_exhaustive]` to `SessionStatus` enum in `zeph-acp` so downstream match arms must include a wildcard, making future variant additions backward-compatible.
- **#4248** — Replace `RwLock<usize>` counter in `SecretMaskRegistry` with `AtomicUsize`; cache a pre-sorted `Vec<(String, String)>` updated on `register()` so `mask()` is O(n) per call instead of O(n log n). TOCTOU race eliminated by holding `forward.write()` across the full check-and-insert path.
- **#4251** — Rename `NliSanitizer::circuit_is_open` to `check_and_maybe_reset_circuit` to make the cooldown-reset side effect explicit; all call sites updated.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --lib --bins` — 9695 passed

Closes #4264
Closes #4248
Closes #4251