### PR TITLE
fix(sanitizer): add filter_async() to avoid blocking tokio executor

### DIFF
--- a/crates/zeph-sanitizer/Cargo.toml
+++ b/crates/zeph-sanitizer/Cargo.toml
@@ -19,7 +19,7 @@ regex.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["time"] }
+tokio = { workspace = true, features = ["rt", "time"] }
 tracing.workspace = true
 zeph-common.workspace = true
 zeph-config.workspace = true

--- a/crates/zeph-sanitizer/src/ipi_filter.rs
+++ b/crates/zeph-sanitizer/src/ipi_filter.rs
@@ -138,6 +138,10 @@ static SHARED_PATTERNS: LazyLock<Vec<WeightedPattern>> = LazyLock::new(|| {
 /// Compiled regex patterns are initialised via `LazyLock` — first call compiles,
 /// subsequent calls reuse. Thread-safe by construction.
 ///
+/// Use [`IpiFilter::filter`] in synchronous or blocking contexts.
+/// Use [`IpiFilter::filter_async`] when calling from an async context to avoid
+/// blocking the tokio executor thread on CPU-bound regex work.
+///
 /// # Examples
 ///
 /// ```rust
@@ -149,7 +153,7 @@ static SHARED_PATTERNS: LazyLock<Vec<WeightedPattern>> = LazyLock::new(|| {
 /// assert!(verdict.patterns_found.is_empty());
 /// assert_eq!(verdict.sanitized, "Hello, world!");
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct IpiFilter {
     threshold: f32,
 }
@@ -235,6 +239,33 @@ impl IpiFilter {
             patterns_found,
             sanitized,
         }
+    }
+
+    /// Async-safe variant of [`IpiFilter::filter`] for use in async contexts.
+    ///
+    /// Runs the CPU-bound regex scan on a blocking thread via
+    /// [`tokio::task::spawn_blocking`] so the tokio executor is not stalled.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the blocking task panics (propagated as a
+    /// [`tokio::task::JoinError`]).
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use zeph_sanitizer::IpiFilter;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let filter = IpiFilter::new(0.6);
+    /// let verdict = filter.filter_async("Hello, world!".to_owned()).await.unwrap();
+    /// assert_eq!(verdict.score, 0.0);
+    /// # }
+    /// ```
+    pub async fn filter_async(&self, text: String) -> Result<IpiVerdict, tokio::task::JoinError> {
+        let this = self.clone();
+        tokio::task::spawn_blocking(move || this.filter(&text)).await
     }
 }
 

--- a/crates/zeph-tools/src/scrape.rs
+++ b/crates/zeph-tools/src/scrape.rs
@@ -589,7 +589,7 @@ impl WebScrapeExecutor {
                 caller_id,
             )
             .await?;
-        Ok(self.apply_ipi_filter(&body, &params.url))
+        self.apply_ipi_filter(&body, &params.url).await
     }
 
     async fn scrape_instruction(
@@ -676,7 +676,7 @@ impl WebScrapeExecutor {
         .await
         .map_err(|e| ToolError::Execution(std::io::Error::other(e.to_string())))??;
         // apply_ipi_filter runs on plain extracted text, not raw HTML
-        Ok(self.apply_ipi_filter(&extracted, &instruction.url))
+        self.apply_ipi_filter(&extracted, &instruction.url).await
     }
 
     fn make_blocked_event(
@@ -961,13 +961,21 @@ impl WebScrapeExecutor {
 
     /// Apply IPI filter to a fetched response body.
     ///
-    /// Always returns the sanitized text. When score >= threshold, prepends a warning
-    /// header and emits a `tracing::warn!` log with the detected pattern names.
-    fn apply_ipi_filter(&self, body: &str, url: &str) -> String {
-        let _span =
-            tracing::info_span!("tools.scrape.apply_ipi_filter", url, body_len = body.len())
-                .entered();
-        let verdict = self.ipi_filter.filter(body);
+    /// Runs regex scanning on a blocking thread via `spawn_blocking` to avoid
+    /// stalling the tokio executor on large inputs. When score >= threshold,
+    /// prepends a warning header and emits a `tracing::warn!` log.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ToolError`] if the blocking scan task panics.
+    async fn apply_ipi_filter(&self, body: &str, url: &str) -> Result<String, ToolError> {
+        let span = tracing::info_span!("tools.scrape.apply_ipi_filter", url, body_len = body.len());
+        let verdict = self
+            .ipi_filter
+            .filter_async(body.to_owned())
+            .await
+            .map_err(|e| ToolError::Execution(std::io::Error::other(e.to_string())))?;
+        let _enter = span.enter();
         if !verdict.patterns_found.is_empty() {
             tracing::warn!(
                 url = url,
@@ -978,14 +986,14 @@ impl WebScrapeExecutor {
         }
         // verdict.sanitized == body only when score < threshold (no redaction)
         if verdict.sanitized == body {
-            verdict.sanitized
+            Ok(verdict.sanitized)
         } else {
-            format!(
+            Ok(format!(
                 "[IPI WARNING: score={:.2}, patterns={}] {}",
                 verdict.score,
                 verdict.patterns_found.join(", "),
                 verdict.sanitized,
-            )
+            ))
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add `pub async fn filter_async()` to `IpiFilter` that offloads CPU-bound regex scanning to a blocking thread via `tokio::task::spawn_blocking`, preventing tokio executor stalls on large web-scraped inputs
- Keep synchronous `filter()` intact for use in blocking contexts
- Derive `Clone` on `IpiFilter` (required for `spawn_blocking` closure); add `tokio rt` feature to `zeph-sanitizer`
- Convert `WebScrapeExecutor::apply_ipi_filter` to `async fn` and update both call sites

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 9711 passed, 21 skipped

Closes #4282