### PR TITLE
fix(memory): add embed timeout to hela_spreading_recall

### DIFF
--- a/crates/zeph-config/src/memory.rs
+++ b/crates/zeph-config/src/memory.rs
@@ -1612,6 +1612,10 @@ pub struct HebbianConfig {
     /// Any internal step (anchor ANN, edges batch, vectors batch) that exceeds this
     /// duration triggers an `Ok(Vec::new())` fallback with a `WARN`. Default: `8`.
     pub step_budget_ms: u64,
+    /// Timeout for the initial query embedding call in HL-F5, in seconds.
+    ///
+    /// `0` disables the timeout. Default: `5`.
+    pub embed_timeout_secs: u64,
 }
 
 impl Default for HebbianConfig {
@@ -1630,6 +1634,7 @@ impl Default for HebbianConfig {
             spread_depth: 2,
             spread_edge_types: Vec::new(),
             step_budget_ms: 8,
+            embed_timeout_secs: 5,
         }
     }
 }

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -2868,8 +2868,11 @@ pub fn migrate_memory_hebbian_spread_config(
     let has_budget = toml_src
         .lines()
         .any(|l| l.trim().starts_with("step_budget_ms"));
+    let has_embed_timeout = toml_src
+        .lines()
+        .any(|l| l.trim().starts_with("embed_timeout_secs"));
 
-    if has_spreading && has_depth && has_budget {
+    if has_spreading && has_depth && has_budget && has_embed_timeout {
         return Ok(MigrationResult {
             output: toml_src.to_owned(),
             changed_count: 0,
@@ -2881,7 +2884,8 @@ pub fn migrate_memory_hebbian_spread_config(
         # spreading_activation = false   # opt-in BFS from top-1 ANN anchor; requires enabled=true\n\
         # spread_depth = 2               # BFS hops, clamped [1,6]\n\
         # spread_edge_types = []         # MAGMA edge types to traverse; empty = all\n\
-        # step_budget_ms = 8             # per-step circuit-breaker timeout (anchor ANN / edges / vectors)\n";
+        # step_budget_ms = 8             # per-step circuit-breaker timeout (anchor ANN / edges / vectors)\n\
+        # embed_timeout_secs = 5         # timeout for the initial query embedding call (0 = disabled)\n";
 
     let output = format!("{toml_src}{extra}");
     Ok(MigrationResult {

--- a/crates/zeph-memory/src/graph/activation.rs
+++ b/crates/zeph-memory/src/graph/activation.rs
@@ -93,6 +93,9 @@ pub struct HelaSpreadParams {
     /// vectors batch) that exceeds this duration triggers an `Ok(Vec::new())`
     /// fallback with a `WARN`. Default: `Some(8 ms)`.
     pub step_budget: Option<std::time::Duration>,
+    /// Timeout for the initial query embedding call. `None` = no timeout.
+    /// Default: `Some(5 s)`.
+    pub embed_timeout: Option<std::time::Duration>,
 }
 
 impl Default for HelaSpreadParams {
@@ -102,6 +105,7 @@ impl Default for HelaSpreadParams {
             edge_types: Vec::new(),
             max_visited: 200,
             step_budget: Some(std::time::Duration::from_millis(8)),
+            embed_timeout: Some(std::time::Duration::from_secs(5)),
         }
     }
 }
@@ -192,7 +196,16 @@ pub async fn hela_spreading_recall(
     }
 
     // ── Step 1: embed query ───────────────────────────────────────────────────
-    let q_vec = provider.embed(query).await?;
+    let q_vec = if let Some(timeout) = params.embed_timeout {
+        tokio::time::timeout(timeout, provider.embed(query))
+            .await
+            .map_err(|_| {
+                tracing::warn!(timeout_ms = timeout.as_millis(), "hela: embed timed out");
+                MemoryError::Timeout("hela embed".into())
+            })??
+    } else {
+        provider.embed(query).await?
+    };
 
     // Dim probe: search with k=1 to catch dimension mismatch at the Qdrant layer.
     let t_anchor = Instant::now();
@@ -1270,6 +1283,112 @@ mod tests {
         assert!(p.step_budget.is_some());
         assert!(p.edge_types.is_empty());
         assert_eq!(p.max_visited, 200);
+    }
+
+    #[test]
+    fn hela_spread_params_default_embed_timeout_is_some() {
+        let p = HelaSpreadParams::default();
+        assert!(
+            p.embed_timeout.is_some(),
+            "default embed_timeout must be Some (5 s)"
+        );
+    }
+
+    // Regression test for #4285: hela_spreading_recall must return
+    // MemoryError::Timeout when the embed provider stalls beyond embed_timeout.
+    #[tokio::test]
+    async fn hela_spreading_recall_embed_timeout_returns_error() {
+        use std::time::Duration;
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+
+        use crate::embedding_store::EmbeddingStore;
+        use crate::error::MemoryError;
+        use crate::in_memory_store::InMemoryVectorStore;
+
+        let store = setup_store().await;
+
+        // Provider sleeps 500 ms; timeout is set to 50 ms → must fire.
+        let mock = MockProvider::default().with_embed_delay(500);
+        let provider = AnyProvider::Mock(mock);
+
+        let sqlite = crate::store::SqliteStore::with_pool_size(":memory:", 1)
+            .await
+            .unwrap();
+        let embeddings =
+            EmbeddingStore::with_store(Box::new(InMemoryVectorStore::new()), sqlite.pool().clone());
+
+        let params = HelaSpreadParams {
+            embed_timeout: Some(Duration::from_millis(50)),
+            ..Default::default()
+        };
+
+        let result = hela_spreading_recall(
+            &store,
+            &embeddings,
+            &provider,
+            "test query",
+            5,
+            &params,
+            false,
+            0.0,
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(MemoryError::Timeout(_))),
+            "expected Err(MemoryError::Timeout), got {:?}",
+            result
+        );
+    }
+
+    // When embed_timeout is None the embed call is not wrapped; the (fast) mock
+    // returns immediately and the function must succeed.
+    #[tokio::test]
+    async fn hela_spreading_recall_no_timeout_does_not_wrap() {
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+
+        use crate::embedding_store::EmbeddingStore;
+        use crate::in_memory_store::InMemoryVectorStore;
+
+        let store = setup_store().await;
+
+        let mock = MockProvider::default().with_embed_delay(0);
+        let provider = AnyProvider::Mock(mock);
+
+        let sqlite = crate::store::SqliteStore::with_pool_size(":memory:", 1)
+            .await
+            .unwrap();
+        let embeddings =
+            EmbeddingStore::with_store(Box::new(InMemoryVectorStore::new()), sqlite.pool().clone());
+
+        let params = HelaSpreadParams {
+            embed_timeout: None,
+            ..Default::default()
+        };
+
+        // embed returns a zero-dimension vector (embed not configured for 384-dim),
+        // so Qdrant search finds nothing — the function returns Ok(Vec::new()).
+        let result = hela_spreading_recall(
+            &store,
+            &embeddings,
+            &provider,
+            "test query",
+            5,
+            &params,
+            false,
+            0.0,
+        )
+        .await;
+
+        // The mock embed returns an empty vec by default; the ANN search will
+        // find no results — the expected outcome is Ok(empty) or a non-Timeout error.
+        assert!(
+            !matches!(result, Err(crate::error::MemoryError::Timeout(_))),
+            "embed_timeout: None must not produce a Timeout error, got {:?}",
+            result
+        );
     }
 
     #[test]

--- a/crates/zeph-memory/src/graph/activation.rs
+++ b/crates/zeph-memory/src/graph/activation.rs
@@ -1337,8 +1337,7 @@ mod tests {
 
         assert!(
             matches!(result, Err(MemoryError::Timeout(_))),
-            "expected Err(MemoryError::Timeout), got {:?}",
-            result
+            "expected Err(MemoryError::Timeout), got {result:?}"
         );
     }
 
@@ -1386,8 +1385,7 @@ mod tests {
         // find no results — the expected outcome is Ok(empty) or a non-Timeout error.
         assert!(
             !matches!(result, Err(crate::error::MemoryError::Timeout(_))),
-            "embed_timeout: None must not produce a Timeout error, got {:?}",
-            result
+            "embed_timeout: None must not produce a Timeout error, got {result:?}"
         );
     }
 

--- a/crates/zeph-memory/src/semantic/mod.rs
+++ b/crates/zeph-memory/src/semantic/mod.rs
@@ -250,7 +250,7 @@ pub(crate) enum QueryIntent {
 /// HL-F5 runtime wiring for spreading activation (mirror of `[memory.hebbian]` spread fields).
 ///
 /// Built from config at bootstrap and attached via [`SemanticMemory::with_hebbian_spread`].
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct HelaSpreadRuntime {
     /// `true` when `[memory.hebbian] enabled = true` AND `spreading_activation = true`.
     pub enabled: bool,
@@ -262,6 +262,21 @@ pub struct HelaSpreadRuntime {
     pub edge_types: Vec<crate::graph::EdgeType>,
     /// Per-step circuit-breaker duration.
     pub step_budget: Option<std::time::Duration>,
+    /// Timeout for the initial query embedding call. `None` = no timeout.
+    pub embed_timeout: Option<std::time::Duration>,
+}
+
+impl Default for HelaSpreadRuntime {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            depth: 2,
+            max_visited: 200,
+            edge_types: Vec::new(),
+            step_budget: Some(std::time::Duration::from_millis(8)),
+            embed_timeout: Some(std::time::Duration::from_secs(5)),
+        }
+    }
 }
 
 /// High-level semantic memory orchestrator combining `SQLite` and Qdrant.

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -1756,6 +1756,13 @@ impl AppBuilder {
             step_budget: Some(std::time::Duration::from_millis(
                 self.config.memory.hebbian.step_budget_ms,
             )),
+            embed_timeout: if self.config.memory.hebbian.embed_timeout_secs == 0 {
+                None
+            } else {
+                Some(std::time::Duration::from_secs(
+                    self.config.memory.hebbian.embed_timeout_secs,
+                ))
+            },
         }
     }
 }


### PR DESCRIPTION
## Summary

- Wraps `provider.embed(query).await?` in `hela_spreading_recall()` with `tokio::time::timeout`, returning `MemoryError::Timeout` on expiry
- Adds `embed_timeout: Option<Duration>` to `HelaSpreadParams` and `HelaSpreadRuntime` (default `Some(5s)`)
- Adds `embed_timeout_secs: u64` to `HebbianConfig` (default `5`) with config migration
- Populates `embed_timeout` from config in `build_hela_runtime()` in bootstrap
- 3 regression tests: timeout returns error, no-timeout passes, default is `Some(5s)`

Fixes the Await Discipline violation: every external `.await` on the agent path must have a timeout.

Closes #4285

## Test plan

- [x] `cargo nextest run -p zeph-memory` — 1355 passed
- [x] Workspace: 9716 tests passed
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo +nightly fmt --check` — clean