### PR TITLE
refactor(config): replace stringly-typed fields with enums

### DIFF
--- a/crates/zeph-config/src/memory.rs
+++ b/crates/zeph-config/src/memory.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use zeph_common::memory::EdgeType;
 use zeph_common::secret::Secret;
 
 use crate::defaults::{default_sqlite_path_field, default_true};
@@ -1605,7 +1606,7 @@ pub struct HebbianConfig {
     ///
     /// Accepted values: `"semantic"`, `"temporal"`, `"causal"`, `"entity"`.
     /// Empty = traverse all edge types. Default: `[]`.
-    pub spread_edge_types: Vec<String>,
+    pub spread_edge_types: Vec<EdgeType>,
     /// Per-step circuit-breaker timeout for HL-F5 in milliseconds.
     ///
     /// Any internal step (anchor ANN, edges batch, vectors batch) that exceeds this
@@ -3306,14 +3307,25 @@ impl Default for ReasoningConfig {
 
 // ── Eviction config (moved from zeph-memory) ─────────────────────────────────
 
+/// Eviction policy variant.
+///
+/// Serialises as `"ebbinghaus"` in TOML/JSON so existing configs remain valid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EvictionPolicy {
+    /// Ebbinghaus forgetting-curve eviction.
+    #[default]
+    Ebbinghaus,
+}
+
 /// Configuration for the memory eviction policy.
 ///
 /// Controls which policy runs during the periodic sweep and how many entries
 /// are retained. `zeph-memory` re-exports this type from here.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct EvictionConfig {
-    /// Policy name. Currently only `"ebbinghaus"` is supported.
-    pub policy: String,
+    /// Eviction policy. Currently only [`EvictionPolicy::Ebbinghaus`] is supported.
+    pub policy: EvictionPolicy,
     /// Maximum number of entries to retain. `0` means unlimited (eviction disabled).
     pub max_entries: usize,
     /// How often to run the eviction sweep, in seconds.
@@ -3323,7 +3335,7 @@ pub struct EvictionConfig {
 impl Default for EvictionConfig {
     fn default() -> Self {
         Self {
-            policy: "ebbinghaus".to_owned(),
+            policy: EvictionPolicy::Ebbinghaus,
             max_entries: 0,
             sweep_interval_secs: 3600,
         }

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -1746,23 +1746,7 @@ impl AppBuilder {
 
     /// Build the HeLa-Mem spread runtime from config.
     fn build_hela_runtime(&self) -> zeph_memory::HelaSpreadRuntime {
-        let edge_types = self
-            .config
-            .memory
-            .hebbian
-            .spread_edge_types
-            .iter()
-            .filter_map(|raw| {
-                raw.parse::<zeph_memory::graph::EdgeType>()
-                    .map_err(|_| {
-                        tracing::warn!(
-                            value = %raw,
-                            "memory.hebbian.spread_edge_types: unrecognised edge type, ignored"
-                        );
-                    })
-                    .ok()
-            })
-            .collect();
+        let edge_types = self.config.memory.hebbian.spread_edge_types.clone();
         zeph_memory::HelaSpreadRuntime {
             enabled: self.config.memory.hebbian.enabled
                 && self.config.memory.hebbian.spreading_activation,


### PR DESCRIPTION
## Summary

- Add `EvictionPolicy` enum replacing `policy: String` in `EvictionConfig` — invalid values are now rejected at config parse time instead of silently falling back at runtime
- Change `HebbianConfig.spread_edge_types` from `Vec<String>` to `Vec<EdgeType>` — removes runtime string parsing in `build_hela_runtime`, parse errors surface at config load

Existing TOML configs remain valid: `policy = "ebbinghaus"` and `spread_edge_types = ["semantic", "temporal"]` deserialize correctly via `#[serde(rename_all = "lowercase")]` / `#[serde(rename_all = "snake_case")]`.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --features desktop,ide,server,chat,pdf,scheduler -- -D warnings` — clean
- [x] `cargo nextest run --workspace --lib --bins` — 9730/9730 passed

Closes #3832
Closes #3833