### PR TITLE
fix(llm,memory): remove doc duplicate, dead field, normalize span prefixes

### DIFF
--- a/crates/zeph-llm/src/router/mod.rs
+++ b/crates/zeph-llm/src/router/mod.rs
@@ -38,12 +38,6 @@
 //! Thompson and Bandit state files are loaded from user-controlled paths at startup.
 //! Files are validated (finite floats, clamped range) and written with `0o600` permissions
 //! on Unix. Do not store state files in world-writable directories.
-//!
-//! # Security
-//!
-//! Thompson and Bandit state are loaded from user-controlled paths at startup. Files are
-//! validated (finite floats, clamped range) and written with `0o600` permissions
-//! on Unix. Do not store state files in world-writable directories.
 
 pub mod asi;
 pub mod aware;

--- a/crates/zeph-memory/src/episodic_consolidation.rs
+++ b/crates/zeph-memory/src/episodic_consolidation.rs
@@ -47,8 +47,6 @@ type CandidateRow = (i64, String, String, String, String, i64);
 pub struct EpisodicConsolidationConfig {
     /// Enable the episodic consolidation daemon.
     pub enabled: bool,
-    /// Provider name for fact extraction LLM calls (resolved by the caller).
-    pub consolidation_provider: String,
     /// How often the sweep runs, in seconds. Default: `1800`.
     pub interval_secs: u64,
     /// Maximum episodic events processed per sweep. Default: `30`.
@@ -166,7 +164,7 @@ pub async fn start_episodic_consolidation_loop(
 ///
 /// Returns [`MemoryError`] on database or LLM errors.
 #[allow(clippy::too_many_lines)] // complex sweep pipeline; decomposition deferred to future refactor
-#[tracing::instrument(skip_all, name = "memory.episodic_consolidation.sweep")]
+#[tracing::instrument(skip_all, name = "memory.episodic.sweep")]
 pub async fn run_episodic_consolidation_sweep(
     pool: DbPool,
     provider: &AnyProvider,
@@ -240,7 +238,7 @@ pub async fn run_episodic_consolidation_sweep(
 
         for fact in extracted {
             let is_dup = {
-                let _span = tracing::info_span!("memory.episodic_consolidation.dedup").entered();
+                let _span = tracing::info_span!("memory.episodic.dedup").entered();
                 is_jaccard_duplicate(&fact.fact, &existing_facts, config.dedup_jaccard_threshold)
             };
 
@@ -351,7 +349,7 @@ pub async fn run_episodic_consolidation_sweep(
 ///
 /// Excludes `SummaryOnly` messages (too degraded) and prefers `compressed_content`
 /// when available (`ScrapMem` fidelity levels: `Full`, `Compressed`, `SummaryOnly`).
-#[tracing::instrument(skip_all, name = "memory.episodic_consolidation.fetch_candidates")]
+#[tracing::instrument(skip_all, name = "memory.episodic.fetch_candidates")]
 async fn fetch_candidates(
     pool: &DbPool,
     config: &EpisodicConsolidationConfig,
@@ -384,7 +382,7 @@ async fn fetch_candidates(
 ///
 /// Joins `experience_nodes` within a ±30 s window around the event's `created_at`.
 /// Returns 0.0 when no experience data is available.
-#[tracing::instrument(skip(pool), name = "memory.episodic_consolidation.cognitive_weight")]
+#[tracing::instrument(skip(pool), name = "memory.episodic.cognitive_weight")]
 async fn compute_cognitive_weight(
     pool: &DbPool,
     session_id: &str,
@@ -413,7 +411,7 @@ async fn compute_cognitive_weight(
 ///
 /// Returns an empty vec when the LLM signals no extractable facts.
 /// Returns `Err` on timeout or malformed JSON.
-#[tracing::instrument(skip_all, name = "memory.episodic_consolidation.extract_facts")]
+#[tracing::instrument(skip_all, name = "memory.episodic.extract_facts")]
 async fn extract_facts_via_llm(
     provider: &AnyProvider,
     candidates: &[ConsolidationCandidate],
@@ -716,7 +714,6 @@ mod tests {
         let provider = mock_provider_with_response(&llm_response);
         let config = EpisodicConsolidationConfig {
             enabled: true,
-            consolidation_provider: String::new(),
             interval_secs: 1800,
             batch_size: 30,
             min_age_secs: 300,
@@ -761,7 +758,6 @@ mod tests {
         let provider = mock_provider_with_response("[]");
         let config = EpisodicConsolidationConfig {
             enabled: true,
-            consolidation_provider: String::new(),
             interval_secs: 1800,
             batch_size: 30,
             min_age_secs: 300,
@@ -833,7 +829,6 @@ mod tests {
     fn episodic_consolidation_config_default() {
         let cfg = EpisodicConsolidationConfig {
             enabled: false,
-            consolidation_provider: String::new(),
             interval_secs: 1800,
             batch_size: 30,
             min_age_secs: 300,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1691,11 +1691,6 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         let store = std::sync::Arc::new(memory.sqlite().clone());
         let ep_cfg = zeph_memory::EpisodicConsolidationConfig {
             enabled: config.memory.episodic_consolidation.enabled,
-            consolidation_provider: config
-                .memory
-                .episodic_consolidation
-                .consolidation_provider
-                .to_string(),
             interval_secs: config.memory.episodic_consolidation.interval_secs,
             batch_size: config.memory.episodic_consolidation.batch_size,
             min_age_secs: config.memory.episodic_consolidation.min_age_secs,


### PR DESCRIPTION
## Summary

- **#3827**: Remove duplicate `# Security` section from `RouterProvider` module doc — `cargo doc` output now renders a single, clean Security section
- **#3822**: Remove dead `consolidation_provider: String` field from `zeph_memory::EpisodicConsolidationConfig` — the provider is resolved by the caller (`runner.rs`) via `build_episodic_consolidation_provider()` and passed directly as `AnyProvider`; the field was always set to empty string and never read inside the crate
- **#3846**: Rename all `memory.episodic_consolidation.*` span names to `memory.episodic.*` in `episodic_consolidation.rs` — consistent with the convention established in PR #3839 and with `memory.tiers.*` / `memory.scenes.*`; enables single-pattern trace filtering in Perfetto/Jaeger

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy -p zeph-llm -p zeph-memory -- -D warnings` — clean
- [x] `cargo nextest run -p zeph-llm -p zeph-memory --lib` — 2213 passed, 0 failed
- [x] `cargo clippy --workspace --lib --bins -- -D warnings` — clean

Closes #3827, #3822, #3846