### PR TITLE
fix(llm,memory): guard async executor from blocking I/O and stalled embed calls (#4296, #4297)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-llm`: `BanditState::load`, `ReputationTracker::load`, and `ThompsonState::load` in
+  `RouterProvider` builder methods were calling `std::fs::read` directly on the Tokio executor
+  thread; wrapped in a `blocking_load()` helper using `tokio::task::block_in_place` to avoid
+  stalling the thread pool during startup (closes #4296).
+- `zeph-memory`: Added `tokio::time::timeout` guards (5 s, fail-open) to all remaining
+  `embed()` call sites in `semantic/recall.rs`, `semantic/mod.rs`, `semantic/summarization.rs`,
+  `semantic/cross_session.rs`, and `reasoning.rs`; the batch `join_all` in `semantic/graph.rs`
+  received a 30 s global timeout — prevents a stalled embedding provider from blocking agent
+  turns indefinitely (closes #4297).
 - `zeph-tools`: `RiskChainAccumulator` is now instantiated at agent startup and wired to
   `ShellExecutor` via `with_risk_chain` and to the agent builder via
   `with_risk_chain_accumulator`. Multi-step shell attack chain detection is active at runtime

--- a/crates/zeph-llm/src/router/mod.rs
+++ b/crates/zeph-llm/src/router/mod.rs
@@ -76,6 +76,21 @@ use thompson::ThompsonState;
 static ASI_WARN_LAST_SECS: AtomicU64 = AtomicU64::new(0);
 use zeph_common::math::cosine_similarity;
 
+/// Runs `f` without blocking the Tokio executor.
+///
+/// On a multi-thread runtime uses `block_in_place`; on a `current_thread` runtime (unit
+/// tests, single-threaded entry points) falls back to a direct call since there is no
+/// executor thread pool to offload to.
+fn blocking_load<T>(f: impl FnOnce() -> T) -> T {
+    if tokio::runtime::Handle::try_current()
+        .is_ok_and(|h| h.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread)
+    {
+        tokio::task::block_in_place(f)
+    } else {
+        f()
+    }
+}
+
 /// Simple bounded embedding cache for bandit feature vectors.
 ///
 /// Keyed by `u64` hash of query text (using `std::hash`). Eviction is FIFO on insertion
@@ -451,7 +466,7 @@ impl RouterProvider {
     pub fn with_thompson(mut self, state_path: Option<&Path>) -> Self {
         self.strategy = RouterStrategy::Thompson;
         let path = state_path.map_or_else(ThompsonState::default_path, Path::to_path_buf);
-        let mut state = ThompsonState::load(&path);
+        let mut state = blocking_load(|| ThompsonState::load(&path));
         // CRIT-3: prune orphan entries from previous configs.
         let known: std::collections::HashSet<String> = self
             .state
@@ -467,8 +482,10 @@ impl RouterProvider {
 
     /// Enable PILOT bandit routing strategy (`LinUCB` contextual bandit).
     ///
-    /// Loads existing state from `state_path` (or the default path). Applies session-level
-    /// decay if `config.decay_factor < 1.0`, and prunes arms for removed providers.
+    /// Loads existing state from `state_path` (or the default path) using
+    /// [`tokio::task::block_in_place`] to avoid blocking the async executor.
+    /// Applies session-level decay if `config.decay_factor < 1.0`, and prunes arms for
+    /// removed providers.
     ///
     /// `embedding_provider` is used to obtain feature vectors for each query.
     /// When `None`, the bandit falls back to Thompson/uniform selection whenever an
@@ -490,7 +507,7 @@ impl RouterProvider {
         }
         let cache_size = config.cache_size;
         let path = state_path.map_or_else(BanditState::default_path, Path::to_path_buf);
-        let mut state = BanditState::load(&path);
+        let mut state = blocking_load(|| BanditState::load(&path));
         if state.dim == 0 {
             state = BanditState::new(config.dim);
         } else if state.dim != config.dim {
@@ -576,8 +593,9 @@ impl RouterProvider {
 
     /// Enable Bayesian reputation scoring (RAPS).
     ///
-    /// Loads existing state from `state_path` (or the default path), applies session-level
-    /// decay, and prunes stale provider entries.
+    /// Loads existing state from `state_path` (or the default path) using
+    /// [`tokio::task::block_in_place`] to avoid blocking the async executor.
+    /// Applies session-level decay and prunes stale provider entries.
     ///
     /// No-op for Cascade routing (reputation is not used for cost-tier ordering).
     #[must_use]
@@ -590,7 +608,7 @@ impl RouterProvider {
     ) -> Self {
         let path = state_path.map_or_else(ReputationTracker::default_path, Path::to_path_buf);
         // Load persisted state, apply decay, and prune orphaned providers.
-        let mut tracker = ReputationTracker::load(&path);
+        let mut tracker = blocking_load(|| ReputationTracker::load(&path));
         let known: std::collections::HashSet<String> = self
             .state
             .providers
@@ -3815,5 +3833,13 @@ mod tests {
         // coherence_score returns None when the window has < 2 entries; after one push it's None.
         // We only verify the ASI has the provider in its window (score will be None with 1 entry).
         let _ = coherence; // just verifying no panic
+    }
+
+    /// Regression for #4296: `blocking_load` must not panic on a `current_thread` runtime
+    /// and must actually call the closure, returning its result.
+    #[tokio::test]
+    async fn blocking_load_runs_closure_on_current_thread_runtime() {
+        let result = super::blocking_load(|| 42_u32);
+        assert_eq!(result, 42, "blocking_load must return the closure result");
     }
 }

--- a/crates/zeph-memory/src/reasoning.rs
+++ b/crates/zeph-memory/src/reasoning.rs
@@ -705,10 +705,19 @@ pub async fn process_turn(
 
     // Embed task_hint + summary for Qdrant retrieval (S2 from architect plan).
     let embed_input = format!("{}\n{}", outcome.task_hint, summary);
-    let embedding = match embed_provider.embed(&embed_input).await {
-        Ok(v) => v,
-        Err(e) => {
+    let embedding = match tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        embed_provider.embed(&embed_input),
+    )
+    .await
+    {
+        Ok(Ok(v)) => v,
+        Ok(Err(e)) => {
             tracing::warn!(error = %e, "reasoning: embedding failed — strategy not stored");
+            return Ok(());
+        }
+        Err(_) => {
+            tracing::warn!("reasoning: embed timed out — strategy not stored");
             return Ok(());
         }
     };

--- a/crates/zeph-memory/src/semantic/cross_session.rs
+++ b/crates/zeph-memory/src/semantic/cross_session.rs
@@ -98,7 +98,19 @@ impl SemanticMemory {
             return Ok(());
         }
 
-        let vector = self.effective_embed_provider().embed(summary_text).await?;
+        let vector = match tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            self.effective_embed_provider().embed(summary_text),
+        )
+        .await
+        {
+            Ok(Ok(v)) => v,
+            Ok(Err(e)) => return Err(e.into()),
+            Err(_) => {
+                tracing::warn!("store_session_summary: embed timed out — skipping store");
+                return Ok(());
+            }
+        };
         let vector_size = u64::try_from(vector.len()).unwrap_or(896);
         qdrant
             .ensure_named_collection(SESSION_SUMMARIES_COLLECTION, vector_size)
@@ -148,7 +160,21 @@ impl SemanticMemory {
             return Ok(Vec::new());
         }
 
-        let vector = self.effective_embed_provider().embed(query).await?;
+        let vector = match tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            self.effective_embed_provider().embed(query),
+        )
+        .await
+        {
+            Ok(Ok(v)) => v,
+            Ok(Err(e)) => return Err(e.into()),
+            Err(_) => {
+                tracing::warn!(
+                    "search_session_summaries: embed timed out, returning empty results"
+                );
+                return Ok(Vec::new());
+            }
+        };
         let vector_size = u64::try_from(vector.len()).unwrap_or(896);
         qdrant
             .ensure_named_collection(SESSION_SUMMARIES_COLLECTION, vector_size)

--- a/crates/zeph-memory/src/semantic/graph.rs
+++ b/crates/zeph-memory/src/semantic/graph.rs
@@ -217,9 +217,18 @@ async fn embed_work_items(
 ) -> Vec<(usize, Vec<f32>)> {
     use futures::future;
 
-    let embed_results: Vec<_> =
-        future::join_all(work_items.iter().map(|w| provider.embed(&w.embed_text))).await;
-
+    let Ok(embed_results) = tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        future::join_all(work_items.iter().map(|w| provider.embed(&w.embed_text))),
+    )
+    .await
+    else {
+        tracing::warn!(
+            count = work_items.len(),
+            "note_linking: batch embed timed out — skipping all entities"
+        );
+        return Vec::new();
+    };
     embed_results
         .into_iter()
         .enumerate()
@@ -1119,6 +1128,36 @@ mod tests {
         assert_eq!(
             edges[0].relation, "KNOWS",
             "display relation must preserve original casing"
+        );
+    }
+
+    /// Regression for #4297: `embed_work_items` must return an empty Vec (fail-open) when the
+    /// batch `join_all` embed call exceeds the 30 s global timeout.
+    #[tokio::test]
+    async fn embed_work_items_timeout_returns_empty() {
+        use zeph_llm::mock::MockProvider;
+
+        // embed_delay_ms > 30_000 ms would make the test too slow; we rely on tokio::time::pause
+        // to advance virtual time instantly, so the timeout fires without real delay.
+        tokio::time::pause();
+
+        // Delay longer than the 30 s timeout (in virtual time).
+        let mut mock = MockProvider::default();
+        mock.supports_embeddings = true;
+        mock.embed_delay_ms = 31_000;
+        let provider = AnyProvider::Mock(mock);
+
+        let work_items = vec![super::EntityWorkItem {
+            entity_id: 1,
+            canonical_name: "Alice".to_owned(),
+            embed_text: "Alice".to_owned(),
+            self_point_id: None,
+        }];
+
+        let result = super::embed_work_items(&work_items, &provider).await;
+        assert!(
+            result.is_empty(),
+            "embed_work_items must return empty Vec on 30 s timeout (fail-open)"
         );
     }
 }

--- a/crates/zeph-memory/src/semantic/mod.rs
+++ b/crates/zeph-memory/src/semantic/mod.rs
@@ -878,10 +878,15 @@ impl SemanticMemory {
         let texts: Vec<String> = facts.iter().map(|f| f.content.clone()).collect();
         let mut embeddings: Vec<Vec<f32>> = Vec::with_capacity(texts.len());
         for text in &texts {
-            match provider.embed(text).await {
-                Ok(v) => embeddings.push(v),
-                Err(e) => {
+            match tokio::time::timeout(std::time::Duration::from_secs(5), provider.embed(text))
+                .await
+            {
+                Ok(Ok(v)) => embeddings.push(v),
+                Ok(Err(e)) => {
                     tracing::warn!(error = %e, "query-bias: failed to embed persona fact — skipping");
+                }
+                Err(_) => {
+                    tracing::warn!("query-bias: embed timed out for persona fact — skipping");
                 }
             }
         }
@@ -1324,7 +1329,19 @@ impl SemanticMemory {
         if !self.effective_embed_provider().supports_embeddings() {
             return Ok(Vec::new());
         }
-        let embedding = self.effective_embed_provider().embed(query).await?;
+        let embedding = match tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            self.effective_embed_provider().embed(query),
+        )
+        .await
+        {
+            Ok(Ok(v)) => v,
+            Ok(Err(e)) => return Err(e.into()),
+            Err(_) => {
+                tracing::warn!("retrieve_reasoning_strategies: embed timed out, returning empty");
+                return Ok(Vec::new());
+            }
+        };
         reasoning
             .retrieve_by_embedding(&embedding, limit as u64)
             .await

--- a/crates/zeph-memory/src/semantic/recall.rs
+++ b/crates/zeph-memory/src/semantic/recall.rs
@@ -760,7 +760,19 @@ impl SemanticMemory {
             && self.effective_embed_provider().supports_embeddings()
         {
             let embed_input = self.apply_search_prompt(query);
-            let query_vector = self.effective_embed_provider().embed(&embed_input).await?;
+            let query_vector = match tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                self.effective_embed_provider().embed(&embed_input),
+            )
+            .await
+            {
+                Ok(Ok(v)) => v,
+                Ok(Err(e)) => return Err(e.into()),
+                Err(_) => {
+                    tracing::warn!("recall_semantic: embed timed out, returning empty results");
+                    return Ok(Vec::new());
+                }
+            };
             let query_vector = self.apply_query_bias(query, query_vector).await;
             let vector_size = u64::try_from(query_vector.len()).unwrap_or(896);
             qdrant.ensure_collection(vector_size).await?;
@@ -809,7 +821,19 @@ impl SemanticMemory {
             return Ok(Vec::new());
         }
         let embed_input = self.apply_search_prompt(query);
-        let query_vector = self.effective_embed_provider().embed(&embed_input).await?;
+        let query_vector = match tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            self.effective_embed_provider().embed(&embed_input),
+        )
+        .await
+        {
+            Ok(Ok(v)) => v,
+            Ok(Err(e)) => return Err(e.into()),
+            Err(_) => {
+                tracing::warn!("recall_vectors_raw: embed timed out, returning empty results");
+                return Ok(Vec::new());
+            }
+        };
         let query_vector = self.apply_query_bias(query, query_vector).await;
         let vector_size = u64::try_from(query_vector.len()).unwrap_or(896);
         qdrant.ensure_collection(vector_size).await?;

--- a/crates/zeph-memory/src/semantic/summarization.rs
+++ b/crates/zeph-memory/src/semantic/summarization.rs
@@ -145,8 +145,13 @@ impl SemanticMemory {
         if let Some(qdrant) = &self.qdrant
             && self.effective_embed_provider().supports_embeddings()
         {
-            match self.effective_embed_provider().embed(summary_text).await {
-                Ok(vector) => {
+            match tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                self.effective_embed_provider().embed(summary_text),
+            )
+            .await
+            {
+                Ok(Ok(vector)) => {
                     let vector_size = u64::try_from(vector.len()).unwrap_or(896);
                     if let Err(e) = qdrant.ensure_collection(vector_size).await {
                         tracing::warn!("Failed to ensure Qdrant collection: {e:#}");
@@ -165,8 +170,11 @@ impl SemanticMemory {
                         tracing::warn!("Failed to embed summary: {e:#}");
                     }
                 }
-                Err(e) => {
+                Ok(Err(e)) => {
                     tracing::warn!("Failed to generate summary embedding: {e:#}");
+                }
+                Err(_) => {
+                    tracing::warn!("summarize: embed timed out for summary text — skipping store");
                 }
             }
         }
@@ -254,10 +262,19 @@ impl SemanticMemory {
         let Some(first_fact) = filtered.first().copied() else {
             return;
         };
-        let first_vector = match self.effective_embed_provider().embed(first_fact).await {
-            Ok(v) => v,
-            Err(e) => {
+        let first_vector = match tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            self.effective_embed_provider().embed(first_fact),
+        )
+        .await
+        {
+            Ok(Ok(v)) => v,
+            Ok(Err(e)) => {
                 tracing::warn!("Failed to embed key fact: {e:#}");
+                return;
+            }
+            Err(_) => {
+                tracing::warn!("store_key_facts: embed timed out for first fact — skipping");
                 return;
             }
         };
@@ -282,8 +299,13 @@ impl SemanticMemory {
         .await;
 
         for fact in filtered[1..].iter().copied() {
-            match self.effective_embed_provider().embed(fact).await {
-                Ok(vector) => {
+            match tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                self.effective_embed_provider().embed(fact),
+            )
+            .await
+            {
+                Ok(Ok(vector)) => {
                     self.store_key_fact_if_unique(
                         qdrant,
                         conversation_id,
@@ -294,8 +316,11 @@ impl SemanticMemory {
                     )
                     .await;
                 }
-                Err(e) => {
+                Ok(Err(e)) => {
                     tracing::warn!("Failed to embed key fact: {e:#}");
+                }
+                Err(_) => {
+                    tracing::warn!("store_key_facts: embed timed out for fact — skipping");
                 }
             }
         }
@@ -360,7 +385,19 @@ impl SemanticMemory {
             return Ok(Vec::new());
         }
 
-        let vector = self.effective_embed_provider().embed(query).await?;
+        let vector = match tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            self.effective_embed_provider().embed(query),
+        )
+        .await
+        {
+            Ok(Ok(v)) => v,
+            Ok(Err(e)) => return Err(e.into()),
+            Err(_) => {
+                tracing::warn!("search_key_facts: embed timed out, returning empty results");
+                return Ok(Vec::new());
+            }
+        };
         let vector_size = u64::try_from(vector.len()).unwrap_or(896);
         qdrant
             .ensure_named_collection(KEY_FACTS_COLLECTION, vector_size)
@@ -404,7 +441,21 @@ impl SemanticMemory {
         if !qdrant.collection_exists(collection).await? {
             return Ok(Vec::new());
         }
-        let vector = self.effective_embed_provider().embed(query).await?;
+        let vector = match tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            self.effective_embed_provider().embed(query),
+        )
+        .await
+        {
+            Ok(Ok(v)) => v,
+            Ok(Err(e)) => return Err(e.into()),
+            Err(_) => {
+                tracing::warn!(
+                    "search_document_collection: embed timed out, returning empty results"
+                );
+                return Ok(Vec::new());
+            }
+        };
         let results = qdrant
             .search_collection(collection, &vector, limit, None)
             .await?;


### PR DESCRIPTION
## Summary

- **#4296 (zeph-llm)**: `BanditState::load`, `ReputationTracker::load`, and `ThompsonState::load` called `std::fs::read` directly on the Tokio executor thread inside `RouterProvider` builder methods. Added a `blocking_load()` helper using `tokio::task::block_in_place` (falls back to a direct call on `current_thread` runtime used in tests). Pattern follows the existing `save_bandit_state` reference implementation.

- **#4297 (zeph-memory)**: 10 `embed()` call sites in `semantic/recall.rs`, `semantic/mod.rs`, `semantic/summarization.rs`, `semantic/cross_session.rs`, `reasoning.rs`, and `semantic/graph.rs` were missing `tokio::time::timeout` guards. Added 5 s fail-open timeouts to all individual call sites; the `join_all` batch in `graph.rs` received a 30 s global timeout.

## Test plan

- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy -p zeph-llm -p zeph-memory -- -D warnings` — clean
- [ ] `cargo nextest run --workspace --lib --bins` — 9740 passed, 0 failed
- [ ] Regression test `blocking_load_runs_closure_on_current_thread_runtime` added (zeph-llm)
- [ ] Regression test `embed_work_items_timeout_returns_empty` added (zeph-memory)

Closes #4296
Closes #4297