### PR TITLE
refactor(config): replace stringly-typed fields with enums (#4298, #4299)

### DIFF
--- a/crates/zeph-agent-context/src/memory_backend.rs
+++ b/crates/zeph-agent-context/src/memory_backend.rs
@@ -367,16 +367,12 @@ impl zeph_context::summarization::MessageTokenCounter for TokenCounterAdapter {
 pub fn build_memory_router(
     manager: &zeph_context::manager::ContextManager,
 ) -> Box<dyn zeph_common::memory::AsyncMemoryRouter + Send + Sync> {
-    use zeph_common::memory::parse_route_str;
     use zeph_config::StoreRoutingStrategy;
 
     if !manager.routing.enabled {
         return Box::new(zeph_memory::HeuristicRouter);
     }
-    let fallback = parse_route_str(
-        &manager.routing.fallback_route,
-        zeph_common::memory::MemoryRoute::Hybrid,
-    );
+    let fallback = manager.routing.fallback_route;
     match manager.routing.strategy {
         StoreRoutingStrategy::Heuristic => Box::new(zeph_memory::HeuristicRouter),
         StoreRoutingStrategy::Llm => {

--- a/crates/zeph-common/src/memory.rs
+++ b/crates/zeph-common/src/memory.rs
@@ -15,13 +15,18 @@ use serde::{Deserialize, Serialize};
 // ── MemoryRoute ───────────────────────────────────────────────────────────────
 
 /// Classification of which memory backend(s) to query.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// Used in routing configuration and at runtime to dispatch memory operations.
+/// Serialises with `snake_case` names (`keyword`, `semantic`, `hybrid`, `graph`, `episodic`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum MemoryRoute {
     /// Full-text search only (`SQLite` FTS5). Fast, good for keyword/exact queries.
     Keyword,
     /// Vector search only (Qdrant). Good for semantic/conceptual queries.
     Semantic,
     /// Both backends, results merged by reciprocal rank fusion.
+    #[default]
     Hybrid,
     /// Graph-based retrieval via BFS traversal.
     Graph,

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -172,7 +172,7 @@ pub use subagent::{
     ToolPolicy,
 };
 pub use telemetry::{TelemetryBackend, TelemetryConfig};
-pub use tools::ToolCompressionConfig;
+pub use tools::{SandboxBackend, ToolCompressionConfig};
 pub use ui::{
     AcpAuthMethod, AcpConfig, AcpLspConfig, AcpSubagentsConfig, AcpTransport, AdditionalDir,
     AdditionalDirError, SubagentPresetConfig, ToolDensity, TuiConfig,

--- a/crates/zeph-config/src/memory.rs
+++ b/crates/zeph-config/src/memory.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use zeph_common::memory::EdgeType;
+use zeph_common::memory::{EdgeType, MemoryRoute};
 use zeph_common::secret::Secret;
 
 use crate::defaults::{default_sqlite_path_field, default_true};
@@ -2700,8 +2700,9 @@ pub struct StoreRoutingConfig {
     /// Falls back to the primary provider when empty. Default: `""`.
     pub routing_classifier_provider: ProviderName,
     /// Route to use when the classifier is uncertain (confidence < threshold).
-    /// Default: `"hybrid"`.
-    pub fallback_route: String,
+    ///
+    /// Defaults to [`MemoryRoute::Hybrid`].
+    pub fallback_route: MemoryRoute,
     /// Confidence threshold below which `HybridRouter` escalates to LLM.
     /// Range: `[0.0, 1.0]`. Default: `0.7`.
     pub confidence_threshold: f32,
@@ -2713,7 +2714,7 @@ impl Default for StoreRoutingConfig {
             enabled: false,
             strategy: StoreRoutingStrategy::Heuristic,
             routing_classifier_provider: ProviderName::default(),
-            fallback_route: "hybrid".into(),
+            fallback_route: MemoryRoute::Hybrid,
             confidence_threshold: 0.7,
         }
     }

--- a/crates/zeph-config/src/sanitizer.rs
+++ b/crates/zeph-config/src/sanitizer.rs
@@ -173,9 +173,9 @@ pub struct NliConfig {
 
     /// Provider name from `[[llm.providers]]` to use for NLI inference.
     ///
-    /// Empty string means fall back to the default provider. Prefer a fast, cheap model.
+    /// An empty [`ProviderName`] falls back to the default provider. Prefer a fast, cheap model.
     #[serde(default)]
-    pub provider: String,
+    pub provider: ProviderName,
 
     /// Entailment score threshold above which content is flagged (default: 0.75).
     #[serde(default = "default_nli_threshold")]
@@ -206,7 +206,7 @@ impl Default for NliConfig {
     fn default() -> Self {
         Self {
             enabled: false,
-            provider: String::new(),
+            provider: ProviderName::default(),
             threshold: default_nli_threshold(),
             timeout_ms: default_nli_timeout_ms(),
             max_content_len: default_nli_max_content_len(),

--- a/crates/zeph-config/src/session.rs
+++ b/crates/zeph-config/src/session.rs
@@ -8,6 +8,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::providers::ProviderName;
+
 /// Top-level `[session]` config block.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
@@ -64,8 +66,8 @@ pub struct RecapConfig {
 
     /// Provider name from `[[llm.providers]]` for recap LLM calls.
     ///
-    /// An empty string falls back to the primary provider. Default: `""`.
-    pub provider: String,
+    /// An empty [`ProviderName`] falls back to the primary provider. Default: `""`.
+    pub provider: ProviderName,
 
     /// Maximum recent messages included when generating a fresh recap.
     ///
@@ -79,7 +81,7 @@ impl Default for RecapConfig {
         Self {
             on_resume: true,
             max_tokens: 200,
-            provider: String::new(),
+            provider: ProviderName::default(),
             max_input_messages: 20,
         }
     }

--- a/crates/zeph-config/src/tools.rs
+++ b/crates/zeph-config/src/tools.rs
@@ -296,8 +296,22 @@ fn default_sandbox_profile() -> SandboxProfile {
     SandboxProfile::Workspace
 }
 
-fn default_sandbox_backend() -> String {
-    "auto".into()
+/// Backend used to enforce OS-level sandboxing.
+///
+/// Serialises with `kebab-case` names so TOML values match the original string convention
+/// (`"auto"`, `"seatbelt"`, `"landlock-bwrap"`, `"noop"`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum SandboxBackend {
+    /// Automatically select the best available backend for the current OS.
+    #[default]
+    Auto,
+    /// macOS `sandbox-exec` (Seatbelt) profile.
+    Seatbelt,
+    /// Linux Landlock + bubblewrap combination.
+    LandlockBwrap,
+    /// Disable sandboxing (testing / unsupported platforms).
+    Noop,
 }
 
 /// OS-level subprocess sandbox configuration (`[tools.sandbox]` TOML section).
@@ -318,9 +332,11 @@ pub struct SandboxConfig {
     /// When `true`, sandbox initialization failure aborts startup (fail-closed). Default: `true`.
     #[serde(default = "default_true")]
     pub strict: bool,
-    /// OS backend hint: `"auto"` / `"seatbelt"` / `"landlock-bwrap"` / `"noop"`.
-    #[serde(default = "default_sandbox_backend")]
-    pub backend: String,
+    /// OS backend used to enforce sandboxing.
+    ///
+    /// Accepts `"auto"`, `"seatbelt"`, `"landlock-bwrap"`, or `"noop"` in TOML.
+    #[serde(default)]
+    pub backend: SandboxBackend,
     /// Hostnames denied network egress from sandboxed subprocesses.
     #[serde(default)]
     pub denied_domains: Vec<String>,
@@ -337,7 +353,7 @@ impl Default for SandboxConfig {
             allow_read: Vec::new(),
             allow_write: Vec::new(),
             strict: true,
-            backend: default_sandbox_backend(),
+            backend: SandboxBackend::Auto,
             denied_domains: Vec::new(),
             fail_if_unavailable: false,
         }

--- a/crates/zeph-core/src/agent/session_digest.rs
+++ b/crates/zeph-core/src/agent/session_digest.rs
@@ -455,7 +455,7 @@ impl<C: Channel> Agent<C> {
         }];
 
         let provider =
-            self.resolve_background_provider(&self.runtime.config.recap_config.provider.clone());
+            self.resolve_background_provider(self.runtime.config.recap_config.provider.as_str());
 
         let _ = self.channel.send_status("Generating recap...").await;
 

--- a/crates/zeph-memory/src/episodic_consolidation.rs
+++ b/crates/zeph-memory/src/episodic_consolidation.rs
@@ -27,6 +27,7 @@ use std::time::Duration;
 
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument as _;
+use zeph_common::types::ProviderName;
 use zeph_db::{DbPool, sql};
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::{LlmProvider as _, Message, MessageMetadata, Role};
@@ -47,6 +48,8 @@ type CandidateRow = (i64, String, String, String, String, i64);
 pub struct EpisodicConsolidationConfig {
     /// Enable the episodic consolidation daemon.
     pub enabled: bool,
+    /// Provider name for fact extraction LLM calls (resolved by the caller).
+    pub consolidation_provider: ProviderName,
     /// How often the sweep runs, in seconds. Default: `1800`.
     pub interval_secs: u64,
     /// Maximum episodic events processed per sweep. Default: `30`.
@@ -714,6 +717,7 @@ mod tests {
         let provider = mock_provider_with_response(&llm_response);
         let config = EpisodicConsolidationConfig {
             enabled: true,
+            consolidation_provider: ProviderName::default(),
             interval_secs: 1800,
             batch_size: 30,
             min_age_secs: 300,
@@ -758,6 +762,7 @@ mod tests {
         let provider = mock_provider_with_response("[]");
         let config = EpisodicConsolidationConfig {
             enabled: true,
+            consolidation_provider: ProviderName::default(),
             interval_secs: 1800,
             batch_size: 30,
             min_age_secs: 300,
@@ -829,6 +834,7 @@ mod tests {
     fn episodic_consolidation_config_default() {
         let cfg = EpisodicConsolidationConfig {
             enabled: false,
+            consolidation_provider: ProviderName::default(),
             interval_secs: 1800,
             batch_size: 30,
             min_age_secs: 300,

--- a/crates/zeph-orchestration/src/plan_cache.rs
+++ b/crates/zeph-orchestration/src/plan_cache.rs
@@ -19,14 +19,13 @@ use zeph_llm::provider::{LlmProvider, Message, Role};
 
 use super::dag;
 use super::error::OrchestrationError;
-use super::graph::TaskGraph;
+use super::graph::{FailureStrategy, TaskGraph};
 use super::planner::{PlannerResponse, convert_response_pub};
 use zeph_subagent::SubAgentDef;
 
 /// Structural skeleton of a single task, stripped of all runtime state.
 ///
-/// Used inside a [`PlanTemplate`]. All fields use owned `String` types so the
-/// template can be serialised independently of the live `TaskGraph`.
+/// Used inside a [`PlanTemplate`]. Serialised as JSON in the `plan_cache` table.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TemplateTask {
     /// Human-readable task title.
@@ -39,11 +38,9 @@ pub struct TemplateTask {
     /// Kebab-case `task_id` strings of tasks this task depends on.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub depends_on: Vec<String>,
-    /// Serialised [`FailureStrategy`] name, if overridden per task.
-    ///
-    /// [`FailureStrategy`]: crate::graph::FailureStrategy
+    /// Failure strategy override for this task, if set by the original planner.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub failure_strategy: Option<String>,
+    pub failure_strategy: Option<FailureStrategy>,
     /// Stable kebab-case `task_id` assigned during template extraction.
     pub task_id: String,
 }
@@ -106,7 +103,7 @@ impl PlanTemplate {
                     .iter()
                     .map(|dep| id_to_slug[dep.index()].clone())
                     .collect(),
-                failure_strategy: node.failure_strategy.map(|fs| fs.to_string()),
+                failure_strategy: node.failure_strategy,
                 task_id: id_to_slug[i].clone(),
             })
             .collect();

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -211,7 +211,7 @@ pub(crate) struct WizardState {
     // OS subprocess sandbox (#3070, #3077)
     pub(crate) sandbox_enabled: bool,
     pub(crate) sandbox_profile: String,
-    pub(crate) sandbox_backend: String,
+    pub(crate) sandbox_backend: zeph_config::SandboxBackend,
     pub(crate) sandbox_strict: bool,
     pub(crate) sandbox_allow_read: Vec<String>,
     pub(crate) sandbox_allow_write: Vec<String>,
@@ -398,7 +398,7 @@ impl Default for WizardState {
             file_allow_read: Vec::new(),
             sandbox_enabled: false,
             sandbox_profile: "workspace".to_owned(),
-            sandbox_backend: "auto".to_owned(),
+            sandbox_backend: zeph_config::SandboxBackend::Auto,
             sandbox_strict: true,
             sandbox_allow_read: Vec::new(),
             sandbox_allow_write: Vec::new(),
@@ -944,11 +944,7 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
             zeph_config::tools::SandboxProfile::Workspace
         }
     };
-    config
-        .tools
-        .sandbox
-        .backend
-        .clone_from(&state.sandbox_backend);
+    config.tools.sandbox.backend = state.sandbox_backend.clone();
     config.tools.sandbox.strict = state.sandbox_strict;
     config.tools.sandbox.allow_read = state
         .sandbox_allow_read
@@ -2408,7 +2404,7 @@ mod tests {
         let state = WizardState {
             sandbox_enabled: true,
             sandbox_profile: "workspace".into(),
-            sandbox_backend: "auto".into(),
+            sandbox_backend: zeph_config::SandboxBackend::Auto,
             sandbox_strict: true,
             sandbox_allow_read: vec!["/tmp/read".into()],
             sandbox_allow_write: vec!["/tmp/write".into()],
@@ -2420,7 +2416,10 @@ mod tests {
             config.tools.sandbox.profile,
             zeph_config::tools::SandboxProfile::Workspace
         );
-        assert_eq!(config.tools.sandbox.backend, "auto");
+        assert_eq!(
+            config.tools.sandbox.backend,
+            zeph_config::SandboxBackend::Auto
+        );
         assert_eq!(config.tools.sandbox.allow_read.len(), 1);
         assert_eq!(config.tools.sandbox.allow_write.len(), 1);
     }

--- a/src/init/security.rs
+++ b/src/init/security.rs
@@ -107,7 +107,12 @@ pub(super) fn step_sandbox(state: &mut WizardState) -> anyhow::Result<()> {
         .items(backends)
         .default(0)
         .interact()?;
-    state.sandbox_backend = backend_values[bidx].into();
+    state.sandbox_backend = match backend_values[bidx] {
+        "seatbelt" => zeph_config::SandboxBackend::Seatbelt,
+        "landlock-bwrap" => zeph_config::SandboxBackend::LandlockBwrap,
+        "noop" => zeph_config::SandboxBackend::Noop,
+        _ => zeph_config::SandboxBackend::Auto,
+    };
 
     state.sandbox_strict = Confirm::new()
         .with_prompt(

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1691,6 +1691,11 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
         let store = std::sync::Arc::new(memory.sqlite().clone());
         let ep_cfg = zeph_memory::EpisodicConsolidationConfig {
             enabled: config.memory.episodic_consolidation.enabled,
+            consolidation_provider: config
+                .memory
+                .episodic_consolidation
+                .consolidation_provider
+                .clone(),
             interval_secs: config.memory.episodic_consolidation.interval_secs,
             batch_size: config.memory.episodic_consolidation.batch_size,
             min_age_secs: config.memory.episodic_consolidation.min_age_secs,


### PR DESCRIPTION
## Summary

Replaces `String` config fields that accept a finite set of values with typed enums, so invalid values are rejected at TOML/JSON deserialization instead of causing runtime panics or silent fallbacks.

- `RecapConfig.provider: String` → `ProviderName`
- `NliConfig.provider: String` → `ProviderName`
- `RoutingConfig.fallback_route: String` → `MemoryRoute` (default `Hybrid`)
- `TemplateTask.failure_strategy: Option<String>` → `Option<FailureStrategy>`
- `SandboxConfig.backend: String` → `SandboxBackend` (new enum: `auto` / `seatbelt` / `landlock-bwrap` / `noop`)
- `EpisodicConsolidationConfig.consolidation_provider: String` → `ProviderName`
- Wizard state `sandbox_backend: String` → `SandboxBackend` in `init/mod.rs` and `init/security.rs`
- `MemoryRoute` in `zeph-common` gains `Serialize`/`Deserialize`/`Default` derives
- `parse_route_str()` in `zeph-agent-context` now uses `MemoryRoute` directly (no string matching)
- Removed duplicate `# Security` doc section from `zeph-llm/src/router/mod.rs`

Existing serialized configs remain forward-compatible: serde attributes (`rename_all = "kebab-case"`) match the previous string values exactly.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --all-targets --features desktop,ide,server,chat,pdf,scheduler --workspace -- -D warnings` — zero warnings
- [x] `cargo nextest run --workspace --lib --bins` — 9738 passed, 0 failed

Closes #4298
Closes #4299