### PR TITLE
feat(skills): wire requires_trust_check into per-invocation blake3 re-hash

### DIFF
--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -342,7 +342,9 @@ impl<C: Channel> Agent<C> {
     pub fn with_trust_snapshot(
         mut self,
         snapshot: std::sync::Arc<
-            parking_lot::RwLock<std::collections::HashMap<String, zeph_common::SkillTrustLevel>>,
+            parking_lot::RwLock<
+                std::collections::HashMap<String, crate::skill_invoker::SkillTrustSnapshot>,
+            >,
         >,
     ) -> Self {
         self.services.skill.trust_snapshot = snapshot;

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -801,7 +801,7 @@ impl<C: Channel> Agent<C> {
                     .contains(&s.name().to_string())
             })
             .filter(|s| match trust_map.get(s.name()) {
-                Some(zeph_common::SkillTrustLevel::Blocked) => {
+                Some(snap) if snap.trust_level == zeph_common::SkillTrustLevel::Blocked => {
                     tracing::debug!(skill = s.name(), "excluded from catalog: trust=blocked");
                     false
                 }
@@ -818,7 +818,7 @@ impl<C: Channel> Agent<C> {
                 .skill
                 .active_skill_names
                 .iter()
-                .filter_map(|name| trust_map.get(name).copied())
+                .filter_map(|name| trust_map.get(name).map(|s| s.trust_level))
                 .fold(zeph_common::SkillTrustLevel::Trusted, |acc, lvl| {
                     acc.min_trust(lvl)
                 })
@@ -869,7 +869,12 @@ impl<C: Channel> Agent<C> {
         let mut skills_prompt = if effective_mode == crate::config::SkillPromptMode::Compact {
             format_skills_prompt_compact(&active_skills)
         } else {
-            format_skills_prompt(&active_skills, &trust_map, &health_map)
+            let trust_levels: std::collections::HashMap<String, zeph_common::SkillTrustLevel> =
+                trust_map
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.trust_level))
+                    .collect();
+            format_skills_prompt(&active_skills, &trust_levels, &health_map)
         };
         // ERL: append learned heuristics for active skills (no-op when erl_enabled = false).
         let erl_suffix = self.build_erl_heuristics_prompt().await;
@@ -1256,7 +1261,7 @@ impl<C: Channel> Agent<C> {
     async fn run_paste_skill_activation(
         &mut self,
         active_skills: &[zeph_skills::loader::Skill],
-        trust_map: &std::collections::HashMap<String, zeph_common::SkillTrustLevel>,
+        trust_map: &std::collections::HashMap<String, crate::skill_invoker::SkillTrustSnapshot>,
     ) {
         use zeph_config::tools::SpeculationMode;
 
@@ -1300,8 +1305,7 @@ impl<C: Channel> Agent<C> {
             let skill_hash = skill.meta.skill_dir.to_string_lossy();
             let skill_trust = trust_map
                 .get(skill_name.as_str())
-                .copied()
-                .unwrap_or(zeph_common::SkillTrustLevel::Trusted);
+                .map_or(zeph_common::SkillTrustLevel::Trusted, |s| s.trust_level);
 
             let predictions = match tokio::time::timeout(
                 std::time::Duration::from_millis(500),

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -84,7 +84,10 @@ pub(crate) struct SkillState {
     /// Per-turn trust snapshot written by `prepare_context` after `build_skill_trust_map`.
     /// Shared with `SkillInvokeExecutor` so it can resolve trust without hitting `SQLite`
     /// on every tool call. Refreshed once per turn — stale by at most one turn.
-    pub(crate) trust_snapshot: Arc<RwLock<HashMap<String, zeph_common::SkillTrustLevel>>>,
+    /// Carries full `SkillTrustSnapshot` (level + `requires_trust_check` + `blake3_hash`) so
+    /// `SkillInvokeExecutor` can perform per-invocation re-hash when the flag is set.
+    pub(crate) trust_snapshot:
+        Arc<RwLock<HashMap<String, crate::skill_invoker::SkillTrustSnapshot>>>,
     pub(crate) skill_paths: Vec<PathBuf>,
     pub(crate) managed_dir: Option<PathBuf>,
     pub(crate) trust_config: crate::config::TrustConfig,

--- a/crates/zeph-core/src/agent/state/skill.rs
+++ b/crates/zeph-core/src/agent/state/skill.rs
@@ -12,6 +12,8 @@ use std::collections::HashMap;
 use zeph_skills::loader::Skill;
 use zeph_skills::trust::SkillTrustLevel;
 
+use crate::skill_invoker::SkillTrustSnapshot;
+
 use super::SkillState;
 
 impl SkillState {
@@ -21,10 +23,14 @@ impl SkillState {
     /// the caller is responsible for storing the result.
     pub(crate) fn rebuild_prompt(
         all_skills: &[Skill],
-        trust_map: &HashMap<String, SkillTrustLevel>,
+        trust_map: &HashMap<String, SkillTrustSnapshot>,
         health_map: &HashMap<String, (f64, u32)>,
     ) -> String {
-        zeph_skills::prompt::format_skills_prompt(all_skills, trust_map, health_map)
+        let trust_levels: HashMap<String, SkillTrustLevel> = trust_map
+            .iter()
+            .map(|(k, v)| (k.clone(), v.trust_level))
+            .collect();
+        zeph_skills::prompt::format_skills_prompt(all_skills, &trust_levels, health_map)
     }
 
     /// Rebuild the BM25 index from current registry metadata, if hybrid search is enabled.

--- a/crates/zeph-core/src/agent/trust_commands.rs
+++ b/crates/zeph-core/src/agent/trust_commands.rs
@@ -6,6 +6,8 @@ use std::fmt::Write;
 
 use zeph_skills::SkillTrustLevel;
 
+use crate::skill_invoker::SkillTrustSnapshot;
+
 use super::{Agent, Channel};
 
 impl<C: Channel> Agent<C> {
@@ -150,7 +152,7 @@ impl<C: Channel> Agent<C> {
         }
     }
 
-    pub(super) async fn build_skill_trust_map(&mut self) -> HashMap<String, SkillTrustLevel> {
+    pub(super) async fn build_skill_trust_map(&mut self) -> HashMap<String, SkillTrustSnapshot> {
         // Clone Arc before .await so no &self fields are held across suspension points.
         let memory = self.services.memory.persistence.memory.clone();
         let Some(memory) = memory else {
@@ -161,14 +163,21 @@ impl<C: Channel> Agent<C> {
         };
         rows.into_iter()
             .filter_map(|r| {
-                let level = match r.trust_level.as_str() {
+                let trust_level = match r.trust_level.as_str() {
                     "trusted" => SkillTrustLevel::Trusted,
                     "verified" => SkillTrustLevel::Verified,
                     "quarantined" => SkillTrustLevel::Quarantined,
                     "blocked" => SkillTrustLevel::Blocked,
                     _ => return None,
                 };
-                Some((r.skill_name, level))
+                Some((
+                    r.skill_name,
+                    SkillTrustSnapshot {
+                        trust_level,
+                        requires_trust_check: r.requires_trust_check,
+                        blake3_hash: r.blake3_hash,
+                    },
+                ))
             })
             .collect()
     }

--- a/crates/zeph-core/src/lib.rs
+++ b/crates/zeph-core/src/lib.rs
@@ -117,7 +117,7 @@ pub use channel::{
 };
 pub use config::{Config, ConfigError};
 pub use runtime_context::RuntimeContext;
-pub use skill_invoker::{InvokeSkillParams, SkillInvokeExecutor};
+pub use skill_invoker::{InvokeSkillParams, SkillInvokeExecutor, SkillTrustSnapshot};
 pub use skill_loader::SkillLoaderExecutor;
 pub use zeph_common::hash::blake3_hex as content_hash;
 pub use zeph_sanitizer::exfiltration::{

--- a/crates/zeph-core/src/skill_invoker.rs
+++ b/crates/zeph-core/src/skill_invoker.rs
@@ -26,10 +26,27 @@ use serde::Deserialize;
 use zeph_common::SkillTrustLevel;
 use zeph_skills::prompt::{sanitize_skill_text, wrap_quarantined};
 use zeph_skills::registry::SkillRegistry;
+use zeph_skills::trust::compute_skill_hash;
 use zeph_tools::executor::{
     ToolCall, ToolError, ToolExecutor, ToolOutput, deserialize_params, truncate_tool_output,
 };
 use zeph_tools::registry::{InvocationHint, ToolDef};
+
+/// Per-invocation trust metadata snapshot for a single skill.
+///
+/// Populated once per turn from the trust DB by `build_skill_trust_map` and shared
+/// with `SkillInvokeExecutor` so it can resolve trust without hitting `SQLite` on each
+/// tool call. When `requires_trust_check` is `true`, `execute_tool_call` re-hashes
+/// the skill's `SKILL.md` before dispatch (tamper detection per #4293).
+#[derive(Clone, Debug)]
+pub struct SkillTrustSnapshot {
+    /// Access level governing which tools the skill may invoke.
+    pub trust_level: SkillTrustLevel,
+    /// Whether to re-hash `SKILL.md` on every invocation and abort if the digest changed.
+    pub requires_trust_check: bool,
+    /// blake3 hex hash of `SKILL.md` recorded at trust-grant time.
+    pub blake3_hash: String,
+}
 
 /// Parameters for the `invoke_skill` tool call.
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -52,7 +69,7 @@ pub struct SkillInvokeExecutor {
     /// Per-skill trust snapshot refreshed once per turn by the agent.
     /// Absence of an entry means no trust row exists — treat as Quarantined
     /// (see `SkillTrustLevel::default`).
-    trust_snapshot: Arc<RwLock<HashMap<String, SkillTrustLevel>>>,
+    trust_snapshot: Arc<RwLock<HashMap<String, SkillTrustSnapshot>>>,
 }
 
 impl SkillInvokeExecutor {
@@ -63,7 +80,7 @@ impl SkillInvokeExecutor {
     #[must_use]
     pub fn new(
         registry: Arc<RwLock<SkillRegistry>>,
-        trust_snapshot: Arc<RwLock<HashMap<String, SkillTrustLevel>>>,
+        trust_snapshot: Arc<RwLock<HashMap<String, SkillTrustSnapshot>>>,
     ) -> Self {
         Self {
             registry,
@@ -71,15 +88,80 @@ impl SkillInvokeExecutor {
         }
     }
 
-    /// Resolve the trust level for a skill from the snapshot.
+    /// Resolve the trust snapshot entry for a skill.
     ///
-    /// Returns `SkillTrustLevel::default()` (Quarantined) when no row exists — fail-closed.
-    fn resolve_trust(&self, skill_name: &str) -> SkillTrustLevel {
-        self.trust_snapshot
-            .read()
-            .get(skill_name)
-            .copied()
-            .unwrap_or_default()
+    /// Returns `None` when no row exists — callers treat absence as Quarantined (fail-closed).
+    fn resolve_snapshot(&self, skill_name: &str) -> Option<SkillTrustSnapshot> {
+        self.trust_snapshot.read().get(skill_name).cloned()
+    }
+
+    /// Run the per-invocation blake3 integrity check.
+    ///
+    /// Returns `Some(output)` when the invocation must be aborted (hash mismatch, empty stored
+    /// hash, missing skill dir, or IO error). Returns `None` when the check passes and dispatch
+    /// should proceed.
+    async fn check_integrity(
+        &self,
+        skill_name: &str,
+        skill_name_safe: &str,
+        entry: &SkillTrustSnapshot,
+    ) -> Result<Option<ToolOutput>, ToolError> {
+        if entry.blake3_hash.is_empty() {
+            tracing::warn!(
+                skill = %skill_name,
+                "requires_trust_check is set but no stored hash found, aborting invocation"
+            );
+            return Ok(Some(make_output(format!(
+                "skill integrity check failed: {skill_name_safe} \
+                 — requires_trust_check is set but no stored hash found"
+            ))));
+        }
+        let stored_hash = entry.blake3_hash.clone();
+        let skill_dir = {
+            let guard = self.registry.read();
+            guard.skill_dir(skill_name)
+        };
+        let Some(dir) = skill_dir else {
+            tracing::warn!(
+                skill = %skill_name,
+                "requires_trust_check: skill_dir not found, aborting invocation"
+            );
+            return Ok(Some(make_output(format!(
+                "skill integrity check failed: {skill_name_safe} — skill directory not found"
+            ))));
+        };
+        let current_hash = tokio::task::spawn_blocking(move || compute_skill_hash(&dir))
+            .await
+            .map_err(|e| ToolError::InvalidParams {
+                message: format!("spawn_blocking join error: {e}"),
+            })?;
+        match current_hash {
+            Ok(hash) if hash != stored_hash => {
+                tracing::warn!(
+                    skill = %skill_name,
+                    "hash mismatch on per-invocation check, demoting to Quarantined"
+                );
+                self.trust_snapshot
+                    .write()
+                    .entry(skill_name.to_owned())
+                    .and_modify(|e| e.trust_level = SkillTrustLevel::Quarantined);
+                // TODO: persist demotion to trust store (#4293 follow-up)
+                Ok(Some(make_output(format!(
+                    "skill integrity check failed: {skill_name_safe} — demoted to Quarantined"
+                ))))
+            }
+            Err(e) => {
+                tracing::warn!(
+                    skill = %skill_name,
+                    err = %e,
+                    "failed to re-hash skill, aborting invocation"
+                );
+                Ok(Some(make_output(format!(
+                    "skill integrity check failed: {skill_name_safe} — cannot read SKILL.md"
+                ))))
+            }
+            Ok(_) => Ok(None), // hash matches, proceed
+        }
     }
 }
 
@@ -111,7 +193,8 @@ impl ToolExecutor for SkillInvokeExecutor {
         let params: InvokeSkillParams = deserialize_params(&call.params)?;
         let skill_name: String = params.skill_name.chars().take(128).collect();
 
-        let trust = self.resolve_trust(&skill_name);
+        let snapshot = self.resolve_snapshot(&skill_name);
+        let trust = snapshot.as_ref().map(|s| s.trust_level).unwrap_or_default();
         // Sanitize skill_name before it appears in any tool output: it originates from the LLM
         // and could carry injection markers (e.g. `<|im_start|>`).
         let skill_name_safe = sanitize_skill_text(&skill_name);
@@ -121,6 +204,16 @@ impl ToolExecutor for SkillInvokeExecutor {
             return Ok(Some(make_output(format!(
                 "skill is blocked by policy: {skill_name_safe}"
             ))));
+        }
+
+        // Per-invocation integrity check: re-hash SKILL.md when requires_trust_check is set.
+        if let Some(entry) = snapshot.as_ref().filter(|s| s.requires_trust_check) {
+            let abort = self
+                .check_integrity(&skill_name, &skill_name_safe, entry)
+                .await?;
+            if let Some(output) = abort {
+                return Ok(Some(output));
+            }
         }
 
         // Clone body out of the read guard before any .await — never hold lock across await.
@@ -192,13 +285,35 @@ mod tests {
         SkillRegistry::load(&[dir.to_path_buf()])
     }
 
+    fn make_snapshot(level: SkillTrustLevel) -> SkillTrustSnapshot {
+        SkillTrustSnapshot {
+            trust_level: level,
+            requires_trust_check: false,
+            blake3_hash: String::new(),
+        }
+    }
+
     fn make_executor(
         registry: SkillRegistry,
         trust_map: HashMap<String, SkillTrustLevel>,
     ) -> SkillInvokeExecutor {
+        let snapshot_map: HashMap<String, SkillTrustSnapshot> = trust_map
+            .into_iter()
+            .map(|(k, v)| (k, make_snapshot(v)))
+            .collect();
         SkillInvokeExecutor::new(
             Arc::new(RwLock::new(registry)),
-            Arc::new(RwLock::new(trust_map)),
+            Arc::new(RwLock::new(snapshot_map)),
+        )
+    }
+
+    fn make_executor_with_snapshots(
+        registry: SkillRegistry,
+        snapshots: HashMap<String, SkillTrustSnapshot>,
+    ) -> SkillInvokeExecutor {
+        SkillInvokeExecutor::new(
+            Arc::new(RwLock::new(registry)),
+            Arc::new(RwLock::new(snapshots)),
         )
     }
 
@@ -401,5 +516,165 @@ mod tests {
         let defs = executor.tool_definitions();
         assert_eq!(defs.len(), 1);
         assert_eq!(defs[0].id.as_ref(), "invoke_skill");
+    }
+
+    // ── Per-invocation trust check tests ────────────────────────────────────
+
+    #[tokio::test]
+    async fn hash_match_passes_normally() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = "## Trusted body";
+        let registry = make_registry_with_skill(dir.path(), "checked-skill", body);
+        let skill_dir = dir.path().join("checked-skill");
+        let stored_hash = zeph_skills::trust::compute_skill_hash(&skill_dir).unwrap();
+        let snapshots = HashMap::from([(
+            "checked-skill".to_owned(),
+            SkillTrustSnapshot {
+                trust_level: SkillTrustLevel::Trusted,
+                requires_trust_check: true,
+                blake3_hash: stored_hash,
+            },
+        )]);
+        let executor = make_executor_with_snapshots(registry, snapshots);
+        let result = executor
+            .execute_tool_call(&make_call("checked-skill"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            result.summary.contains("Trusted body"),
+            "body returned on hash match"
+        );
+    }
+
+    #[tokio::test]
+    async fn hash_mismatch_demotes_to_quarantined_and_aborts() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = "## Original body";
+        let registry = make_registry_with_skill(dir.path(), "tampered-skill", body);
+        let snapshots = HashMap::from([(
+            "tampered-skill".to_owned(),
+            SkillTrustSnapshot {
+                trust_level: SkillTrustLevel::Trusted,
+                requires_trust_check: true,
+                blake3_hash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                    .to_owned(),
+            },
+        )]);
+        let snapshot_arc = Arc::new(RwLock::new(snapshots));
+        let executor =
+            SkillInvokeExecutor::new(Arc::new(RwLock::new(registry)), Arc::clone(&snapshot_arc));
+        let result = executor
+            .execute_tool_call(&make_call("tampered-skill"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            result.summary.contains("demoted to Quarantined"),
+            "output must mention demotion: {}",
+            result.summary
+        );
+        assert!(
+            !result.summary.contains("Original body"),
+            "body must not be returned on hash mismatch"
+        );
+        // Snapshot entry must be demoted in memory.
+        let level = snapshot_arc
+            .read()
+            .get("tampered-skill")
+            .map(|s| s.trust_level);
+        assert_eq!(level, Some(SkillTrustLevel::Quarantined));
+    }
+
+    #[tokio::test]
+    async fn requires_trust_check_false_skips_hash() {
+        // When requires_trust_check=false, even a deliberately wrong hash must NOT block.
+        let dir = tempfile::tempdir().unwrap();
+        let body = "## Body without check";
+        let registry = make_registry_with_skill(dir.path(), "no-check-skill", body);
+        let snapshots = HashMap::from([(
+            "no-check-skill".to_owned(),
+            SkillTrustSnapshot {
+                trust_level: SkillTrustLevel::Trusted,
+                requires_trust_check: false,
+                blake3_hash: "wrong_hash_that_would_fail_if_checked".to_owned(),
+            },
+        )]);
+        let executor = make_executor_with_snapshots(registry, snapshots);
+        let result = executor
+            .execute_tool_call(&make_call("no-check-skill"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            result.summary.contains("Body without check"),
+            "body must be returned when check disabled"
+        );
+    }
+
+    #[tokio::test]
+    async fn requires_trust_check_true_empty_hash_aborts_with_distinct_error() {
+        // Legacy DB row or misconfiguration: requires_trust_check=true but blake3_hash is empty.
+        // Must abort with a distinct diagnostic, not "hash mismatch".
+        let dir = tempfile::tempdir().unwrap();
+        let body = "## Some body";
+        let registry = make_registry_with_skill(dir.path(), "legacy-skill", body);
+        let snapshots = HashMap::from([(
+            "legacy-skill".to_owned(),
+            SkillTrustSnapshot {
+                trust_level: SkillTrustLevel::Trusted,
+                requires_trust_check: true,
+                blake3_hash: String::new(), // empty — legacy row
+            },
+        )]);
+        let executor = make_executor_with_snapshots(registry, snapshots);
+        let result = executor
+            .execute_tool_call(&make_call("legacy-skill"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            result.summary.contains("no stored hash found"),
+            "must emit distinct error for missing hash: {}",
+            result.summary
+        );
+        assert!(
+            !result.summary.contains("demoted to Quarantined"),
+            "must not emit mismatch message for missing hash: {}",
+            result.summary
+        );
+        assert!(
+            !result.summary.contains("Some body"),
+            "body must not be returned: {}",
+            result.summary
+        );
+    }
+
+    #[tokio::test]
+    async fn skill_dir_none_aborts_invocation() {
+        // Skill is in the snapshot with requires_trust_check=true but not in registry.
+        let dir = tempfile::tempdir().unwrap();
+        let registry = SkillRegistry::load(&[dir.path().to_path_buf()]);
+        let snapshots = HashMap::from([(
+            "ghost-skill".to_owned(),
+            SkillTrustSnapshot {
+                trust_level: SkillTrustLevel::Trusted,
+                requires_trust_check: true,
+                blake3_hash: "deadbeef".to_owned(),
+            },
+        )]);
+        let executor = make_executor_with_snapshots(registry, snapshots);
+        let result = executor
+            .execute_tool_call(&make_call("ghost-skill"))
+            .await
+            .unwrap()
+            .unwrap();
+        // Fail-closed: skill_dir not found → abort.
+        assert!(
+            result.summary.contains("skill directory not found")
+                || result.summary.contains("skill not found"),
+            "must abort when skill_dir is missing: {}",
+            result.summary
+        );
     }
 }

--- a/crates/zeph-db/migrations/postgres/089_skill_trust_requires_check.sql
+++ b/crates/zeph-db/migrations/postgres/089_skill_trust_requires_check.sql
@@ -1,0 +1,4 @@
+-- Migration 089: Add requires_trust_check flag to skill_trust table.
+-- Controls per-invocation blake3 re-hash before skill dispatch (#4293).
+ALTER TABLE skill_trust
+    ADD COLUMN IF NOT EXISTS requires_trust_check INTEGER NOT NULL DEFAULT 0;

--- a/crates/zeph-db/migrations/sqlite/088_skill_trust_requires_check.sql
+++ b/crates/zeph-db/migrations/sqlite/088_skill_trust_requires_check.sql
@@ -1,0 +1,4 @@
+-- Migration 088: Add requires_trust_check flag to skill_trust table.
+-- Controls per-invocation blake3 re-hash before skill dispatch (#4293).
+ALTER TABLE skill_trust
+    ADD COLUMN requires_trust_check INTEGER NOT NULL DEFAULT 0;

--- a/crates/zeph-memory/src/store/trust.rs
+++ b/crates/zeph-memory/src/store/trust.rs
@@ -61,6 +61,10 @@ pub struct SkillTrustRow {
     pub updated_at: String,
     /// Upstream git commit hash at install time (from `x-git-hash` frontmatter field).
     pub git_hash: Option<String>,
+    /// Whether to re-hash `SKILL.md` on every invocation and abort if the digest changed.
+    ///
+    /// Set via `skill trust --require-check <name>` or the trust management CLI.
+    pub requires_trust_check: bool,
 }
 
 type TrustTuple = (
@@ -72,6 +76,7 @@ type TrustTuple = (
     String,
     String,
     Option<String>,
+    i64,
 );
 
 fn row_from_tuple(t: TrustTuple) -> SkillTrustRow {
@@ -85,6 +90,7 @@ fn row_from_tuple(t: TrustTuple) -> SkillTrustRow {
         blake3_hash: t.5,
         updated_at: t.6,
         git_hash: t.7,
+        requires_trust_check: t.8 != 0,
     }
 }
 
@@ -171,7 +177,7 @@ impl SqliteStore {
     ) -> Result<Option<SkillTrustRow>, MemoryError> {
         let row: Option<TrustTuple> = zeph_db::query_as(sql!(
             "SELECT skill_name, trust_level, source_kind, source_url, source_path, \
-             blake3_hash, updated_at, git_hash \
+             blake3_hash, updated_at, git_hash, requires_trust_check \
              FROM skill_trust WHERE skill_name = ?"
         ))
         .bind(skill_name)
@@ -188,7 +194,7 @@ impl SqliteStore {
     pub async fn load_all_skill_trust(&self) -> Result<Vec<SkillTrustRow>, MemoryError> {
         let rows: Vec<TrustTuple> = zeph_db::query_as(sql!(
             "SELECT skill_name, trust_level, source_kind, source_url, source_path, \
-             blake3_hash, updated_at, git_hash \
+             blake3_hash, updated_at, git_hash, requires_trust_check \
              FROM skill_trust ORDER BY skill_name"
         ))
         .fetch_all(&self.pool)
@@ -226,6 +232,30 @@ impl SqliteStore {
             .bind(skill_name)
             .execute(&self.pool)
             .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Set the `requires_trust_check` flag for a skill.
+    ///
+    /// When `true`, the agent re-hashes `SKILL.md` before each invocation and aborts
+    /// if the blake3 digest changed (tamper detection per #4293).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the update fails.
+    pub async fn set_requires_trust_check(
+        &self,
+        skill_name: &str,
+        enabled: bool,
+    ) -> Result<bool, MemoryError> {
+        let flag = i64::from(enabled);
+        let result = zeph_db::query(
+            sql!("UPDATE skill_trust SET requires_trust_check = ?, updated_at = CURRENT_TIMESTAMP WHERE skill_name = ?"),
+        )
+        .bind(flag)
+        .bind(skill_name)
+        .execute(&self.pool)
+        .await?;
         Ok(result.rows_affected() > 0)
     }
 

--- a/crates/zeph-skills/src/registry.rs
+++ b/crates/zeph-skills/src/registry.rs
@@ -220,6 +220,19 @@ impl SkillRegistry {
         self.entries.iter().map(|e| &e.meta).collect()
     }
 
+    /// Return the directory path for a skill by name.
+    ///
+    /// Returns `None` if no skill with that name is registered. Used by
+    /// `SkillInvokeExecutor` to locate `SKILL.md` for per-invocation blake3 re-hash
+    /// when `requires_trust_check` is `true`.
+    #[must_use]
+    pub fn skill_dir(&self, name: &str) -> Option<std::path::PathBuf> {
+        self.entries
+            .iter()
+            .find(|e| e.meta.name == name)
+            .map(|e| e.meta.skill_dir.clone())
+    }
+
     /// Get the body for a skill by name, loading from disk on first access.
     ///
     /// # Errors

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1762,7 +1762,9 @@ pub(crate) async fn run(cli: Cli) -> anyhow::Result<()> {
     // Pre-allocate trust snapshot Arc shared between the agent's SkillState and
     // SkillInvokeExecutor — written once per turn by prepare_context, read by the executor.
     let trust_snapshot: std::sync::Arc<
-        parking_lot::RwLock<std::collections::HashMap<String, zeph_common::SkillTrustLevel>>,
+        parking_lot::RwLock<
+            std::collections::HashMap<String, zeph_core::skill_invoker::SkillTrustSnapshot>,
+        >,
     > = std::sync::Arc::new(parking_lot::RwLock::new(std::collections::HashMap::new()));
     let skill_invoke_executor = zeph_core::SkillInvokeExecutor::new(
         std::sync::Arc::clone(&registry),


### PR DESCRIPTION
## Summary

- `SkillTrust::requires_trust_check` was a documented data model stub with zero production call sites. This PR implements the feature end-to-end.
- Per-invocation blake3 re-hash is opt-in (`requires_trust_check = true`, default `false`) — zero overhead for the majority of skills.
- Adds DB migrations for SQLite (088) and Postgres (089) with `DEFAULT 0` — safe for existing rows.
- `check_integrity()` is wrapped in `spawn_blocking` (sync fs::read); registry lock is not held across any `.await`.
- Fail-closed on missing `skill_dir` or empty `blake3_hash` (distinct error messages for operability).
- On hash mismatch: WARN log + in-memory demotion to Quarantined + invocation aborted.

## Test plan

- [x] `hash_match_passes_normally` — re-hash matches, invocation proceeds
- [x] `hash_mismatch_demotes_to_quarantined_and_aborts` — mismatch → demotion + abort
- [x] `requires_trust_check_false_skips_hash` — opt-out path untouched
- [x] `requires_trust_check_true_empty_hash_aborts_with_distinct_error` — empty stored hash → distinct error, not "demoted to Quarantined"
- [x] `skill_dir_none_aborts_invocation` — None skill_dir → fail-closed

9743 tests pass. `cargo +nightly fmt --check` and `cargo clippy --workspace --features "desktop,ide,server,chat,pdf,scheduler" -- -D warnings` clean.

## Follow-up (non-blocking)
- P3: constant-time hash comparison (`subtle::ConstantTimeEq`)
- P3: TOCTOU documentation note
- P4: mtime guard to skip re-hash when SKILL.md is unmodified between invocations